### PR TITLE
feat(catalyst-api,ui): convergence-monitor surface D — top-bar readiness chip + operationInProgress API field

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/deployment_operation_state.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployment_operation_state.go
@@ -1,0 +1,111 @@
+// deployment_operation_state.go — the `operationInProgress` projection
+// that backs the Convergence-Monitor top-bar readiness chip (#3925
+// surface D).
+//
+// # Why a separate boolean from `status`
+//
+// The deployment `status` enum (deployments.go:80) answers "where is the
+// INITIAL provision?" — pending → tofu-applying → flux-bootstrapping →
+// phase1-watching → ready. Once a Sovereign reaches `ready` an operator
+// can still kick off a FINITE multi-step operation — the classic case is
+// `bp-self-sovereign-cutover`'s 8 sequential Jobs, or a DR-switchover.
+// While that operation runs the env is NOT "still provisioning" (status
+// stays `ready`) and it is NOT idle either. The chip needs to render
+// `OPERATION-IN-PROGRESS` distinctly so a stuck cutover is never misread
+// as ongoing initial provisioning (ticket §5(c) — "a 2-hour-stuck
+// cutover was read as still provisioning").
+//
+// `operationInProgress` is true while a cutover / DR-switchover Job group
+// is non-terminal. It is surface-only — it NEVER gates `status` and never
+// changes the convergence machinery. The Reconciliation DAG stays green
+// throughout (the Flux spine is reconciled; the operation is a finite job
+// that's running, not a broken convergence).
+package handler
+
+import (
+	"strings"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
+)
+
+// operationGroupSlugs are the group slugs whose non-terminal presence
+// flips operationInProgress true. These are the FINITE multi-step
+// operations an operator runs on an already-provisioned Sovereign —
+// distinct from the initial provision (provisioner / bootstrap-kit / apps
+// groups, which `status` already tracks). Kept as a set so the detection
+// is an O(1) membership test, not a brittle prefix string-match.
+var operationGroupSlugs = map[string]struct{}{
+	jobs.GroupCutover: {}, // bp-self-sovereign-cutover's 8 sequential steps
+	// DR-switchover is modelled as a cutover-class step group; if a
+	// dedicated group slug is introduced it is added here verbatim.
+}
+
+// operationInProgress reports whether a finite, post-provision operation
+// (cutover / DR-switchover) is currently running for the given deployment.
+//
+// True iff the jobs store holds at least one Job that BOTH:
+//   - belongs to an operation group (cutover/DR-switchover) — matched on
+//     either the group Job's own slug OR a "<group>-step-…" leaf, AND
+//   - is NOT in a terminal state (succeeded / failed) — i.e. it is
+//     pending or running.
+//
+// Returns false (never errors) when the jobs store is unconfigured or the
+// deployment has no jobs — the chip degrades to reading `status` alone.
+func (h *Handler) operationInProgress(deploymentID string) bool {
+	st := h.jobsStore()
+	if st == nil {
+		return false
+	}
+	js, err := st.ListJobs(deploymentID)
+	if err != nil || len(js) == 0 {
+		return false
+	}
+	for _, j := range js {
+		if !isOperationJob(j) {
+			continue
+		}
+		if isNonTerminalJobStatus(j.Status) {
+			return true
+		}
+	}
+	return false
+}
+
+// isOperationJob reports whether a Job belongs to one of the post-provision
+// operation groups (cutover / DR-switchover). It matches:
+//   - a group Job whose JobName is an operation slug, OR
+//   - a step leaf named "<operationSlug>-step-<…>" (KindStep under an
+//     operation group), OR
+//   - a leaf whose ParentID resolves to "<deploymentId>:<operationSlug>".
+//
+// The "<slug>-step-" infix check mirrors jobs.kindForLeaf's ordering so a
+// "cutover-step-05-egress-block" leaf is recognised as an operation step.
+func isOperationJob(j jobs.Job) bool {
+	if _, ok := operationGroupSlugs[j.JobName]; ok {
+		return true
+	}
+	for slug := range operationGroupSlugs {
+		// "<slug>-step-" leaf (e.g. "cutover-step-05-…").
+		if strings.HasPrefix(j.JobName, slug+"-step-") {
+			return true
+		}
+		// Leaf hanging off the operation group's synthesised parent.
+		if j.ParentID != "" && strings.HasSuffix(j.ParentID, ":"+slug) {
+			return true
+		}
+	}
+	return false
+}
+
+// isNonTerminalJobStatus reports whether a Job status string represents an
+// in-flight (pending/running) — anything other than succeeded/failed.
+// An empty/unknown status is treated as non-terminal (conservative: a
+// freshly-seeded step with no status yet is "in progress", not done).
+func isNonTerminalJobStatus(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case jobs.StatusSucceeded, jobs.StatusFailed:
+		return false
+	default:
+		return true
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/deployment_operation_state_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployment_operation_state_test.go
@@ -1,0 +1,148 @@
+// deployment_operation_state_test.go — unit tests for the
+// `operationInProgress` projection that backs the #3925 surface-D
+// readiness chip. Asserts the cutover-detection truth table:
+//   - no jobs / nil store           → false
+//   - only provision/install jobs   → false  (initial provision is `status`, not an operation)
+//   - cutover group running         → true
+//   - cutover step running          → true
+//   - cutover group all-terminal    → false (operation finished)
+package handler
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
+)
+
+func newOpStateHandler(t *testing.T) (*Handler, *jobs.Store) {
+	t.Helper()
+	js, err := jobs.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	h := NewWithJobsStore(slog.New(slog.NewJSONHandler(io.Discard, nil)), js)
+	return h, js
+}
+
+func TestOperationInProgress_NilStore(t *testing.T) {
+	h := New(slog.New(slog.NewJSONHandler(io.Discard, nil)))
+	if h.operationInProgress("dep-x") {
+		t.Fatal("nil jobs store must yield operationInProgress=false")
+	}
+}
+
+func TestOperationInProgress_NoJobs(t *testing.T) {
+	h, _ := newOpStateHandler(t)
+	if h.operationInProgress("dep-empty") {
+		t.Fatal("no jobs must yield operationInProgress=false")
+	}
+}
+
+// Only initial-provision jobs (install-* under bootstrap-kit) — even
+// while RUNNING — must NOT flip operationInProgress. The provision is
+// tracked by `status`, not by this boolean.
+func TestOperationInProgress_ProvisionJobsOnly(t *testing.T) {
+	h, st := newOpStateHandler(t)
+	depID := "dep-prov"
+	t0 := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	parentID := jobs.JobID(depID, jobs.GroupBootstrapKit)
+	seed := []jobs.Job{
+		{DeploymentID: depID, JobName: jobs.GroupBootstrapKit, Type: jobs.JobTypeGroup, Status: jobs.StatusRunning},
+		{DeploymentID: depID, JobName: "install-cilium", AppID: "cilium", Type: jobs.JobTypeInstall, ParentID: parentID, Status: jobs.StatusRunning, StartedAt: &t0},
+		{DeploymentID: depID, JobName: "install-flux", AppID: "flux", Type: jobs.JobTypeInstall, ParentID: parentID, Status: jobs.StatusPending},
+	}
+	for _, j := range seed {
+		if err := st.UpsertJob(j); err != nil {
+			t.Fatalf("UpsertJob: %v", err)
+		}
+	}
+	if h.operationInProgress(depID) {
+		t.Fatal("install/provision jobs must NOT count as an operation")
+	}
+}
+
+// A running cutover GROUP job flips operationInProgress true.
+func TestOperationInProgress_CutoverGroupRunning(t *testing.T) {
+	h, st := newOpStateHandler(t)
+	depID := "dep-cutover-grp"
+	if err := st.UpsertJob(jobs.Job{
+		DeploymentID: depID, JobName: jobs.GroupCutover, DisplayName: jobs.GroupCutoverDisplay,
+		Type: jobs.JobTypeGroup, Status: jobs.StatusRunning,
+	}); err != nil {
+		t.Fatalf("UpsertJob: %v", err)
+	}
+	if !h.operationInProgress(depID) {
+		t.Fatal("a running cutover group must yield operationInProgress=true")
+	}
+}
+
+// A running cutover STEP leaf (cutover-step-NN-…) flips it true even when
+// the parent group row isn't separately present.
+func TestOperationInProgress_CutoverStepRunning(t *testing.T) {
+	h, st := newOpStateHandler(t)
+	depID := "dep-cutover-step"
+	t0 := time.Now().UTC()
+	parentID := jobs.JobID(depID, jobs.GroupCutover)
+	seed := []jobs.Job{
+		{DeploymentID: depID, JobName: jobs.GroupCutover, Type: jobs.JobTypeGroup, Status: jobs.StatusRunning},
+		{DeploymentID: depID, JobName: "cutover-step-01-mirror", Kind: jobs.KindStep, ParentID: parentID, Status: jobs.StatusSucceeded, StartedAt: &t0, FinishedAt: &t0},
+		{DeploymentID: depID, JobName: "cutover-step-05-egress-block", Kind: jobs.KindStep, ParentID: parentID, Status: jobs.StatusRunning, StartedAt: &t0},
+	}
+	for _, j := range seed {
+		if err := st.UpsertJob(j); err != nil {
+			t.Fatalf("UpsertJob: %v", err)
+		}
+	}
+	if !h.operationInProgress(depID) {
+		t.Fatal("a running cutover step must yield operationInProgress=true")
+	}
+}
+
+// Once every cutover step + the group are terminal (succeeded/failed),
+// the operation is over — operationInProgress must be false again so the
+// chip flips back to READY.
+func TestOperationInProgress_CutoverAllTerminal(t *testing.T) {
+	h, st := newOpStateHandler(t)
+	depID := "dep-cutover-done"
+	t0 := time.Now().UTC()
+	parentID := jobs.JobID(depID, jobs.GroupCutover)
+	seed := []jobs.Job{
+		{DeploymentID: depID, JobName: jobs.GroupCutover, Type: jobs.JobTypeGroup, Status: jobs.StatusSucceeded, StartedAt: &t0, FinishedAt: &t0},
+		{DeploymentID: depID, JobName: "cutover-step-01-mirror", Kind: jobs.KindStep, ParentID: parentID, Status: jobs.StatusSucceeded, StartedAt: &t0, FinishedAt: &t0},
+		{DeploymentID: depID, JobName: "cutover-step-08-verify", Kind: jobs.KindStep, ParentID: parentID, Status: jobs.StatusSucceeded, StartedAt: &t0, FinishedAt: &t0},
+	}
+	for _, j := range seed {
+		if err := st.UpsertJob(j); err != nil {
+			t.Fatalf("UpsertJob: %v", err)
+		}
+	}
+	if h.operationInProgress(depID) {
+		t.Fatal("a fully-terminal cutover must yield operationInProgress=false")
+	}
+}
+
+// A FAILED cutover step is terminal — operationInProgress is false (the
+// operation stopped; the chip reflects READY/DEGRADED, and the Jobs page
+// shows the failed step). This guards against treating `failed` as
+// in-flight.
+func TestOperationInProgress_CutoverStepFailedIsTerminal(t *testing.T) {
+	h, st := newOpStateHandler(t)
+	depID := "dep-cutover-failed"
+	t0 := time.Now().UTC()
+	parentID := jobs.JobID(depID, jobs.GroupCutover)
+	seed := []jobs.Job{
+		{DeploymentID: depID, JobName: jobs.GroupCutover, Type: jobs.JobTypeGroup, Status: jobs.StatusFailed, StartedAt: &t0, FinishedAt: &t0},
+		{DeploymentID: depID, JobName: "cutover-step-05-egress-block", Kind: jobs.KindStep, ParentID: parentID, Status: jobs.StatusFailed, StartedAt: &t0, FinishedAt: &t0},
+	}
+	for _, j := range seed {
+		if err := st.UpsertJob(j); err != nil {
+			t.Fatalf("UpsertJob: %v", err)
+		}
+	}
+	if h.operationInProgress(depID) {
+		t.Fatal("a failed (terminal) cutover step must yield operationInProgress=false")
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -1601,7 +1601,14 @@ func (h *Handler) GetDeployment(w http.ResponseWriter, r *http.Request) {
 	// freshly-signed. Best-effort: on mint failure, leave the existing
 	// URL in place so a transient signer error doesn't break polling.
 	h.remintHandoverURLForReadyDeployment(dep)
-	writeJSON(w, http.StatusOK, dep.State())
+	state := dep.State()
+	// #3925 surface D — enrich with `operationInProgress` so the
+	// Convergence-Monitor top-bar chip can render OPERATION-IN-PROGRESS
+	// distinctly from initial CONVERGING. Computed off the jobs store
+	// (cutover / DR-switchover group non-terminal), which lives on the
+	// Handler — so it's injected here rather than inside Deployment.State().
+	state["operationInProgress"] = h.operationInProgress(dep.ID)
+	writeJSON(w, http.StatusOK, state)
 }
 
 // remintHandoverURLForReadyDeployment re-signs the handover JWT on a

--- a/products/catalyst/bootstrap/ui/src/components/ReadinessChip.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/components/ReadinessChip.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * ReadinessChip.test.tsx — wiring lock-in for the #3925 surface-D
+ * readiness chip + operation banner.
+ *
+ * Coverage:
+ *   • deriveChipState truth table (pure) — the four states + precedence:
+ *       converging > operation > degraded > ready
+ *   • chip renders the right label/data-state for each status projection
+ *   • chip links to /dashboard (click target)
+ *   • operationInProgress flips the chip to OPERATION-IN-PROGRESS AND
+ *     surfaces the OperationBanner with a "view progress" link
+ *   • the banner is absent in every non-operation state
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  ReadinessChip,
+  OperationBanner,
+  deriveChipState,
+  type ReadinessSnapshot,
+} from './ReadinessChip'
+
+afterEach(cleanup)
+
+function renderInShell(node: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <>{node}</>,
+  })
+  const dashboardRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/dashboard',
+    component: () => <div>dashboard</div>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute, dashboardRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router as never} />
+    </QueryClientProvider>,
+  )
+}
+
+describe('deriveChipState', () => {
+  const cases: Array<[string, ReadinessSnapshot | null, ReturnType<typeof deriveChipState>]> = [
+    ['null snapshot → converging (never falsely READY)', null, 'converging'],
+    ['ready + idle → ready', { status: 'ready' }, 'ready'],
+    ['ready + secondaryDegraded → degraded', { status: 'ready', secondaryDegraded: true }, 'degraded'],
+    ['ready + operationInProgress → operation', { status: 'ready', operationInProgress: true }, 'operation'],
+    ['phase1-watching → converging', { status: 'phase1-watching' }, 'converging'],
+    ['tofu-applying → converging', { status: 'tofu-applying' }, 'converging'],
+    ['failed → degraded', { status: 'failed' }, 'degraded'],
+    // Precedence: an in-flight provision wins even if operationInProgress
+    // somehow also set (it never should, but the provision dominates).
+    [
+      'converging beats operation',
+      { status: 'phase1-watching', operationInProgress: true },
+      'converging',
+    ],
+    // Precedence: operation beats degraded on a ready env.
+    [
+      'operation beats degraded',
+      { status: 'ready', operationInProgress: true, secondaryDegraded: true },
+      'operation',
+    ],
+  ]
+  for (const [name, snap, expected] of cases) {
+    it(name, () => {
+      expect(deriveChipState(snap)).toBe(expected)
+    })
+  }
+})
+
+describe('ReadinessChip render', () => {
+  it('renders READY for a ready, idle env and links to /dashboard', async () => {
+    renderInShell(
+      <ReadinessChip deploymentId="d-1" snapshotOverride={{ status: 'ready' }} disablePoll />,
+    )
+    const chip = await screen.findByTestId('readiness-chip')
+    expect(chip.getAttribute('data-state')).toBe('ready')
+    expect(screen.getByTestId('readiness-chip-label').textContent).toBe('Ready')
+    // Click target is the Dashboard.
+    expect(chip.getAttribute('href')).toContain('/dashboard')
+  })
+
+  it('renders CONVERGING (pulse) while provisioning', async () => {
+    renderInShell(
+      <ReadinessChip
+        deploymentId="d-2"
+        snapshotOverride={{ status: 'phase1-watching' }}
+        disablePoll
+      />,
+    )
+    const chip = await screen.findByTestId('readiness-chip')
+    expect(chip.getAttribute('data-state')).toBe('converging')
+  })
+
+  it('renders DEGRADED when a secondary region lags', async () => {
+    renderInShell(
+      <ReadinessChip
+        deploymentId="d-3"
+        snapshotOverride={{ status: 'ready', secondaryDegraded: true }}
+        disablePoll
+      />,
+    )
+    const chip = await screen.findByTestId('readiness-chip')
+    expect(chip.getAttribute('data-state')).toBe('degraded')
+  })
+
+  it('renders OPERATION-IN-PROGRESS when operationInProgress is true', async () => {
+    renderInShell(
+      <ReadinessChip
+        deploymentId="d-4"
+        snapshotOverride={{ status: 'ready', operationInProgress: true }}
+        disablePoll
+      />,
+    )
+    const chip = await screen.findByTestId('readiness-chip')
+    expect(chip.getAttribute('data-state')).toBe('operation')
+    expect(screen.getByTestId('readiness-chip-label').textContent).toMatch(/operation/i)
+  })
+})
+
+describe('OperationBanner', () => {
+  it('renders with a view-progress link ONLY while an operation runs', async () => {
+    renderInShell(
+      <OperationBanner
+        deploymentId="d-5"
+        snapshotOverride={{ status: 'ready', operationInProgress: true }}
+        disablePoll
+      />,
+    )
+    expect(await screen.findByTestId('operation-banner')).toBeTruthy()
+    const link = screen.getByTestId('operation-banner-link')
+    expect(link.getAttribute('href')).toContain('/dashboard')
+  })
+
+  it('renders null when no operation is in progress (ready)', async () => {
+    renderInShell(
+      <OperationBanner deploymentId="d-6" snapshotOverride={{ status: 'ready' }} disablePoll />,
+    )
+    // Let the router settle, then assert the banner never mounts.
+    await new Promise((r) => setTimeout(r, 0))
+    expect(screen.queryByTestId('operation-banner')).toBeNull()
+  })
+
+  it('renders null while merely converging', async () => {
+    renderInShell(
+      <OperationBanner
+        deploymentId="d-7"
+        snapshotOverride={{ status: 'phase1-watching' }}
+        disablePoll
+      />,
+    )
+    await new Promise((r) => setTimeout(r, 0))
+    expect(screen.queryByTestId('operation-banner')).toBeNull()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/components/ReadinessChip.tsx
+++ b/products/catalyst/bootstrap/ui/src/components/ReadinessChip.tsx
@@ -1,0 +1,261 @@
+/**
+ * ReadinessChip — the Convergence-Monitor top-bar readiness chip (#3925
+ * surface D). Rendered in the PortalShell header on EVERY operator page.
+ *
+ * A single status pill that answers the operator's "is my Sovereign
+ * ready, converging, degraded, or running an operation?" question at a
+ * glance, backed by the deployment-status API:
+ *
+ *   READY                 ⇔ status=="ready" AND no in-flight operation
+ *   CONVERGING            ⇔ status in the in-flight provision enum
+ *   DEGRADED              ⇔ secondaryDegraded==true on a ready env
+ *   OPERATION-IN-PROGRESS ⇔ operationInProgress==true (a finite cutover /
+ *                           DR-switchover Job group is non-terminal —
+ *                           distinct from initial provisioning)
+ *
+ * Precedence (ticket §2 surface-D + §5): an in-flight OPERATION wins over
+ * READY/DEGRADED because a stuck cutover must never read as "still
+ * provisioning" nor as a plain "ready". CONVERGING (initial provision)
+ * wins over everything because the env isn't usable yet.
+ *
+ * Click → Dashboard (the wizard/treemap surface). When an operation is in
+ * progress the chip also renders a thin banner under the header with a
+ * "view progress" link to the Dashboard, so the operator is unmistakably
+ * told an operation is running (DECISION: banner + toggle, never an
+ * auto-flip-back — founder-agreed).
+ *
+ * Self-contained data: the chip polls GET /api/v1/deployments/{id} on a
+ * short interval (independent of the SSE machinery in useDeploymentEvents,
+ * which closes once status flips ready) so it stays fresh THROUGH a
+ * post-ready cutover. Per docs/INVIOLABLE-PRINCIPLES.md #4 the poll URL is
+ * built from API_BASE, never inlined.
+ */
+
+import { useQuery } from '@tanstack/react-query'
+import { Link } from '@tanstack/react-router'
+import { API_BASE } from '@/shared/config/urls'
+
+/** The four chip states, in render-precedence order (see deriveChipState). */
+export type ChipState = 'converging' | 'operation' | 'degraded' | 'ready'
+
+/** In-flight provision statuses — mirror of useDeploymentEvents.ts
+ *  IN_FLIGHT_STATUSES + api/internal/handler/deployments.go isInFlightStatus(). */
+const IN_FLIGHT_STATUSES: ReadonlySet<string> = new Set([
+  'pending',
+  'provisioning',
+  'tofu-applying',
+  'flux-bootstrapping',
+  'phase1-watching',
+])
+
+/** Minimal projection of GET /deployments/{id} the chip consumes. */
+export interface ReadinessSnapshot {
+  status?: string
+  secondaryDegraded?: boolean
+  operationInProgress?: boolean
+}
+
+/**
+ * deriveChipState resolves the single chip state from the deployment
+ * status projection. Precedence (highest first):
+ *   1. CONVERGING  — the initial provision is still running; the env is
+ *      not usable yet, so this dominates everything.
+ *   2. OPERATION   — a finite cutover/DR operation is in flight on an
+ *      already-provisioned env; must read distinctly from both READY and
+ *      "still provisioning".
+ *   3. DEGRADED    — a secondary region lags on a ready env.
+ *   4. READY       — converged, idle, no operation.
+ */
+export function deriveChipState(snap: ReadinessSnapshot | null | undefined): ChipState {
+  const status = (snap?.status ?? '').trim().toLowerCase()
+  if (IN_FLIGHT_STATUSES.has(status)) return 'converging'
+  if (snap?.operationInProgress === true) return 'operation'
+  if (snap?.secondaryDegraded === true) return 'degraded'
+  if (status === 'ready') return 'ready'
+  // Unknown / failed / partial — treat a non-ready, non-in-flight status
+  // as converging so the chip never falsely claims READY. (A terminal
+  // `failed` env still wants attention, not a green chip.)
+  if (status === 'failed' || status === 'partial-failure') return 'degraded'
+  return 'converging'
+}
+
+interface ChipTone {
+  label: string
+  dot: string
+  bg: string
+  border: string
+  fg: string
+  pulse: boolean
+}
+
+const CHIP_TONE: Record<ChipState, ChipTone> = {
+  ready: {
+    label: 'Ready',
+    dot: '#4ADE80',
+    bg: 'rgba(74,222,128,0.10)',
+    border: 'rgba(74,222,128,0.35)',
+    fg: '#4ADE80',
+    pulse: false,
+  },
+  converging: {
+    label: 'Converging',
+    dot: '#38BDF8',
+    bg: 'rgba(56,189,248,0.10)',
+    border: 'rgba(56,189,248,0.35)',
+    fg: '#38BDF8',
+    pulse: true,
+  },
+  degraded: {
+    label: 'Degraded',
+    dot: '#FBBF24',
+    bg: 'rgba(251,191,36,0.10)',
+    border: 'rgba(251,191,36,0.35)',
+    fg: '#FBBF24',
+    pulse: false,
+  },
+  operation: {
+    label: 'Operation in progress',
+    dot: '#818CF8',
+    bg: 'rgba(129,140,248,0.10)',
+    border: 'rgba(129,140,248,0.35)',
+    fg: '#818CF8',
+    pulse: true,
+  },
+}
+
+/** Poll cadence for the chip's own status query (ms). Short enough that a
+ *  cutover start/finish is reflected promptly, long enough not to hammer
+ *  the API. */
+const CHIP_POLL_MS = 5_000
+
+export interface ReadinessChipProps {
+  /** Resolved deployment id — drives both the poll and the Dashboard link. */
+  deploymentId: string
+  /** Test seam — synthetic snapshot bypassing the live poll. */
+  snapshotOverride?: ReadinessSnapshot | null
+  /** Test seam — disable the network poll (jsdom). */
+  disablePoll?: boolean
+}
+
+/**
+ * useReadinessSnapshot polls GET /deployments/{id} and returns the
+ * status projection the chip reads. Kept tiny + independent of
+ * useDeploymentEvents so the chip stays live after the SSE stream closes.
+ */
+function useReadinessSnapshot(
+  deploymentId: string,
+  enabled: boolean,
+): ReadinessSnapshot | null {
+  const q = useQuery<ReadinessSnapshot | null>({
+    queryKey: ['readiness-chip', deploymentId],
+    queryFn: async () => {
+      const res = await fetch(
+        `${API_BASE}/v1/deployments/${encodeURIComponent(deploymentId)}`,
+        { headers: { Accept: 'application/json' }, credentials: 'include' },
+      )
+      if (!res.ok) return null
+      return (await res.json()) as ReadinessSnapshot
+    },
+    enabled: enabled && !!deploymentId,
+    refetchInterval: CHIP_POLL_MS,
+    staleTime: CHIP_POLL_MS,
+    placeholderData: (prev) => prev,
+  })
+  return q.data ?? null
+}
+
+export function ReadinessChip({
+  deploymentId,
+  snapshotOverride,
+  disablePoll = false,
+}: ReadinessChipProps) {
+  const polled = useReadinessSnapshot(deploymentId, !disablePoll && snapshotOverride === undefined)
+  const snapshot = snapshotOverride !== undefined ? snapshotOverride : polled
+  const state = deriveChipState(snapshot)
+  const tone = CHIP_TONE[state]
+
+  // The Dashboard link target differs by surface: on the mothership the
+  // wizard tracks /provision/$id/dashboard; on the chroot Sovereign
+  // Console the clean /dashboard route renders the same component. We
+  // always link to `/dashboard` — TanStack resolves it against the active
+  // basepath, and the chroot redirect map handles the prefix — mirroring
+  // StatusStrip's breadcrumb which links to `/dashboard` too.
+  return (
+    <Link
+      to={'/dashboard' as never}
+      data-testid="readiness-chip"
+      data-state={state}
+      className="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-bold uppercase tracking-wide no-underline transition-colors"
+      style={{ background: tone.bg, borderColor: tone.border, color: tone.fg }}
+      title={`Sovereign status: ${tone.label}`}
+      aria-label={`Sovereign status: ${tone.label}. Open the Dashboard.`}
+    >
+      <span
+        data-testid="readiness-chip-dot"
+        className={tone.pulse ? 'readiness-chip-dot-pulse' : undefined}
+        style={{
+          width: 7,
+          height: 7,
+          borderRadius: '50%',
+          flexShrink: 0,
+          background: tone.dot,
+        }}
+        aria-hidden
+      />
+      <span data-testid="readiness-chip-label">{tone.label}</span>
+      <style>{READINESS_CHIP_CSS}</style>
+    </Link>
+  )
+}
+
+/**
+ * OperationBanner — the thin under-header banner shown ONLY while an
+ * operation is in progress (#3925 surface D, DECISION: banner + toggle,
+ * not auto-flip-back). Carries a "view progress" link to the Dashboard.
+ * Renders null in every other state so the header band stays clean.
+ */
+export function OperationBanner({
+  deploymentId,
+  snapshotOverride,
+  disablePoll = false,
+}: ReadinessChipProps) {
+  const polled = useReadinessSnapshot(deploymentId, !disablePoll && snapshotOverride === undefined)
+  const snapshot = snapshotOverride !== undefined ? snapshotOverride : polled
+  const state = deriveChipState(snapshot)
+  if (state !== 'operation') return null
+  return (
+    <div
+      data-testid="operation-banner"
+      role="status"
+      className="flex items-center gap-3 border-b border-[color:rgba(129,140,248,0.30)] bg-[color:rgba(129,140,248,0.08)] px-4 py-2 text-xs text-[var(--color-text)]"
+    >
+      <span
+        className="readiness-chip-dot-pulse"
+        style={{ width: 7, height: 7, borderRadius: '50%', background: '#818CF8', flexShrink: 0 }}
+        aria-hidden
+      />
+      <span className="font-medium">
+        An operation is in progress — the Sovereign is running a finite
+        cutover / switchover. Convergence is unaffected.
+      </span>
+      <Link
+        to={'/dashboard' as never}
+        data-testid="operation-banner-link"
+        className="ml-auto rounded-md border border-[color:rgba(129,140,248,0.40)] px-2 py-0.5 font-semibold text-[#818CF8] no-underline hover:bg-[color:rgba(129,140,248,0.15)]"
+      >
+        View progress →
+      </Link>
+      <style>{READINESS_CHIP_CSS}</style>
+    </div>
+  )
+}
+
+const READINESS_CHIP_CSS = `
+.readiness-chip-dot-pulse {
+  animation: readiness-chip-pulse 2s ease-in-out infinite;
+}
+@keyframes readiness-chip-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: 0.4; transform: scale(0.65); }
+}
+`

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/PortalShell.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/PortalShell.tsx
@@ -49,6 +49,7 @@ import { ThemeToggle } from '@/components/ThemeToggle'
 import { NotificationBell } from '@/shared/ui/notifications'
 import { ProfileMenu } from '@/widgets/auth/ProfileMenu'
 import { DETECTED_MODE } from '@/shared/lib/detectMode'
+import { ReadinessChip, OperationBanner } from '@/components/ReadinessChip'
 
 interface PortalShellProps {
   /** Stable deploymentId from the URL parameter. */
@@ -118,6 +119,11 @@ export function PortalShell({
             className="flex shrink-0 items-center gap-3"
           >
             {headerSlotRight}
+            {/* #3925 surface D — readiness chip on every page. Click →
+                Dashboard. Only rendered once a deploymentId is resolved
+                (on the chroot it's empty for one render while
+                /sovereign/self resolves; the chip then mounts). */}
+            {deploymentId ? <ReadinessChip deploymentId={deploymentId} /> : null}
             <NotificationBell />
             <ThemeToggle />
             {/* Issue #750 — signed-in user identity in the top-right
@@ -126,6 +132,10 @@ export function PortalShell({
             <ProfileMenu />
           </div>
         </header>
+        {/* #3925 surface D — operation-in-progress banner. Renders null
+            in every state except `operation` (DECISION: banner + toggle,
+            not auto-flip-back). */}
+        {deploymentId ? <OperationBanner deploymentId={deploymentId} /> : null}
         <main className="flex-1 p-8">{children}</main>
       </div>
     </div>


### PR DESCRIPTION
## Convergence-Monitor surface D (#3925) — top-bar readiness chip

Refs #3925 #3646. Independently mergeable off `main`. One of three stacked PRs (D / B / A); recommended merge order D → B → A (A deep-links B's `/reconciliation` route, B is the chip's sibling — but each builds + tests standalone).

### What it delivers
- A status chip in the **PortalShell header on every operator page**: `READY` / `CONVERGING` / `DEGRADED` / `OPERATION-IN-PROGRESS`, backed by the deployment-status API. Click → Dashboard.
- A thin **operation banner** (with a "view progress" link) that surfaces **only** while an operation runs. DECISION (founder-agreed): banner + toggle, never auto-flip-back.
- Backend: a **NEW `operationInProgress` boolean** on `GET /api/v1/deployments/{id}` — true while a finite cutover / DR-switchover Job group is non-terminal. Surface-only: it NEVER gates `status`. So a 2-hour-stuck cutover reads `OPERATION-IN-PROGRESS`, not "still provisioning" (ticket §5(c)).

Chip-state precedence: `converging > operation > degraded > ready` (an unfinished provision dominates; an in-flight operation wins over a plain ready/degraded).

### Key test assertions
- **Go** (`deployment_operation_state_test.go`): nil store / no jobs → false; install/provision jobs (even running) → false; running cutover group/step → true; all-terminal & failed-terminal cutover → false.
- **TS** (`ReadinessChip.test.tsx`): `deriveChipState` precedence truth table; chip renders the right state per status projection + links to `/dashboard`; `OperationBanner` present **only** while an operation runs.

### Needs a live deploy to confirm
The chip's `OPERATION-IN-PROGRESS` state + the new API field are exercised end-to-end only during an actual `bp-self-sovereign-cutover` run on a fresh prov (SC-5). Unit coverage proves the logic; the live wire-up (chip turns purple while the cutover Job group is non-terminal) lands in the #3925 UAT walk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)