### PR TITLE
feat(catalyst): convergence-monitor surface B — Reconciliation page + bounded Flux DAG endpoint

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -1295,6 +1295,13 @@ func main() {
 		// than only on state transitions.
 		rg.Post("/api/v1/deployments/{depId}/refresh-watch", h.RefreshWatch)
 		rg.Get("/api/v1/deployments/{depId}/components/state", h.GetComponentsState)
+		// #3925 surface B — the bounded Flux dependency DAG for the
+		// Convergence-Monitor Reconciliation page. Nodes = HelmReleases +
+		// Kustomizations (the declared desired set), edges = real
+		// dependsOn, coloured by live reconcile state (Reconciled /
+		// Reconciling / Drifted / Degraded). Read-only. Scanner/Job nodes
+		// are EXCLUDED by construction (it's built from reconcilers only).
+		rg.Get("/api/v1/deployments/{depId}/reconciliation", h.GetReconciliationDAG)
 		// OpenovaFlow proxy (Agent #3 integration — PR #1389/#1390
 		// follow-up). Proxies the FlowPage canvas's snapshot/stream/
 		// ingest path to the bp-openova-flow-server inside the

--- a/products/catalyst/bootstrap/api/internal/handler/reconciliation_dag.go
+++ b/products/catalyst/bootstrap/api/internal/handler/reconciliation_dag.go
@@ -1,0 +1,369 @@
+// reconciliation_dag.go — the bounded Flux dependency DAG that backs the
+// Convergence-Monitor Reconciliation page (#3925 surface B).
+//
+// # Why this is NOT the Jobs/Flow snapshot
+//
+// The Flow snapshot (flow_snapshot_local.go) ingests EVERY Job — install
+// leaves, Phase-0 tofu chain, cutover steps, Day-2 scanners — into one flat
+// graph. That's the Jobs view's job. The Reconciliation view answers a
+// different question: "is the declared Flux/GitOps DESIRED state converged,
+// and if not, where is it stuck?". Its node-set is therefore the BOUNDED,
+// declared set of continuous reconcilers:
+//
+//   - HelmRelease nodes — one per bp-* HelmRelease (the layer with an
+//     explicit spec.dependsOn DAG). Sourced from the helmwatch informer's
+//     ComponentSnapshot (AppID, Status, DependsOn, Stalled).
+//   - Kustomization nodes — one per Flux Kustomization reconcile leaf
+//     (jobs.KindReconcile, "reconcile-<name>"), the bootstrap-kit tiers.
+//
+// Scanners / one-shot Jobs / CronJobs are NEVER in this set — they are
+// finite jobs, not reconcilers, so they live on the Jobs page. The DAG is
+// bounded by construction: node count == (#HelmReleases + #Kustomizations),
+// edges == real declared dependsOn, ZERO scanner/Job nodes.
+//
+// # Vocabulary — never Success/Failed (those imply a finite end)
+//
+//   Reconciled  ← helmwatch `installed`            (in-sync, not a finite win)
+//   Reconciling ← `pending` / `installing`, OR a transient `failed`/`degraded`
+//                 that is NOT Stalled (Flux is still retrying)
+//   Drifted     ← `degraded` that is NOT Stalled    (out of sync, self-healing)
+//   Degraded    ← `failed` AND Stalled              (Flux exhausted retries)
+//   Suspended   ← Flux-suspended reconciler          (reserved; not emitted yet)
+//
+// The STICKY rule (kills the flapping #3916 / ticket symptom 2): only a
+// Flux `Stalled` HelmRelease maps to a terminal `Degraded`; every other
+// `Ready=False` is `Reconciling`, which holds a spinner and never flips to a
+// red terminal.
+package handler
+
+import (
+	"context"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
+)
+
+// Reconciliation node-state vocabulary (wire contract — the FE renders
+// these verbatim; NEVER Success/Succeeded/Failed).
+const (
+	ReconStateReconciled  = "Reconciled"
+	ReconStateReconciling = "Reconciling"
+	ReconStateDrifted     = "Drifted"
+	ReconStateDegraded    = "Degraded"
+	ReconStateSuspended   = "Suspended"
+)
+
+// Reconciliation node-kinds.
+const (
+	ReconKindHelmRelease   = "HelmRelease"
+	ReconKindKustomization = "Kustomization"
+)
+
+// ReconciliationNode is one node in the bounded Flux DAG.
+type ReconciliationNode struct {
+	// ID — stable, unique within the DAG. For HelmReleases it's the
+	// bp-prefixed AppID ("bp-keycloak"); for Kustomizations the tier slug
+	// ("bootstrap-kit").
+	ID string `json:"id"`
+	// Label — the human-readable name shown on the node.
+	Label string `json:"label"`
+	// Kind — HelmRelease | Kustomization.
+	Kind string `json:"kind"`
+	// State — the Reconciliation vocabulary (Reconciled/Reconciling/…).
+	State string `json:"state"`
+	// DependsOn — node IDs this node declares a Flux dependsOn against.
+	// Edges are derived from these by exact-ID match (dangling deps are
+	// dropped so the DAG never renders an edge to a non-existent node).
+	DependsOn []string `json:"dependsOn,omitempty"`
+	// Message — the Flux Ready-condition message, when available.
+	Message string `json:"message,omitempty"`
+}
+
+// ReconciliationDAG is the GET /reconciliation response envelope.
+type ReconciliationDAG struct {
+	// Nodes — the bounded declared set (HelmReleases + Kustomizations).
+	Nodes []ReconciliationNode `json:"nodes"`
+	// Reconciled / Total — the N/M-Reconciled header counts.
+	Reconciled int `json:"reconciled"`
+	Total      int `json:"total"`
+	// Watching — true while a live helmwatch informer is attached (the
+	// counts track convergence live); false once Phase-1 ended (counts
+	// come from the frozen / live-re-read snapshot).
+	Watching bool `json:"watching"`
+	// NotYetTracked — the deferred continuous-reconciler classes this view
+	// does NOT yet include (Crossplane, cert-manager, CNPG, External-Secrets,
+	// the CRD controllers). Surfaced so the operator knows the scope —
+	// ticket §2 surface-A footnote.
+	NotYetTracked []string `json:"notYetTracked"`
+}
+
+// notYetTrackedReconcilers — the deferred continuous-reconciler classes
+// (ticket §2 surface-A: "list them explicitly in the UI's 'not yet tracked'
+// footnote"). Flux-only to start; these absorb later as node-kinds.
+var notYetTrackedReconcilers = []string{
+	"Crossplane",
+	"cert-manager",
+	"CNPG",
+	"External-Secrets",
+	"CRD controllers",
+}
+
+// reconStateForComponent maps a helmwatch ComponentSnapshot to the
+// Reconciliation vocabulary. This is the STICKY state machine: only a
+// Stalled HelmRelease is terminal-Degraded; every other not-installed
+// state is in-progress (Reconciling/Drifted), so the view never flaps a
+// transient Ready=False into a red Failed.
+func reconStateForComponent(cs helmwatch.ComponentSnapshot) string {
+	switch strings.ToLower(strings.TrimSpace(cs.Status)) {
+	case helmwatch.StateInstalled:
+		return ReconStateReconciled
+	case helmwatch.StatePending, helmwatch.StateInstalling:
+		return ReconStateReconciling
+	case helmwatch.StateDegraded:
+		// Degraded-but-not-stalled = drifted/out-of-sync, self-healing on
+		// the next reconcile. A stalled degraded escalates to Degraded.
+		if cs.Stalled {
+			return ReconStateDegraded
+		}
+		return ReconStateDrifted
+	case helmwatch.StateFailed:
+		// Only a STABLY-failed (Stalled) HR is terminal-Degraded; a
+		// still-retrying failure is Reconciling (kills the flapping).
+		if cs.Stalled {
+			return ReconStateDegraded
+		}
+		return ReconStateReconciling
+	default:
+		return ReconStateReconciling
+	}
+}
+
+// reconStateForReconcileJob maps a Flux Kustomization reconcile leaf
+// (jobs.KindReconcile) status to the Reconciliation vocabulary. The jobs
+// store status enum is pending/running/succeeded/failed; a Kustomization
+// is continuous so we never render Success/Failed:
+//
+//	succeeded → Reconciled · running/pending → Reconciling · failed → Degraded
+func reconStateForReconcileJob(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case jobs.StatusSucceeded:
+		return ReconStateReconciled
+	case jobs.StatusFailed:
+		return ReconStateDegraded
+	default:
+		return ReconStateReconciling
+	}
+}
+
+// GetReconciliationDAG handles GET
+// /api/v1/deployments/{depId}/reconciliation.
+//
+// Builds the bounded Flux DAG (HelmReleases + Kustomizations) coloured by
+// live reconcile state. Read-only, stateless: it reuses the same
+// component-snapshot read path GetComponentsState uses (live watcher →
+// one-shot live re-read → frozen persisted fallback) plus the jobs store's
+// Kustomization reconcile leaves.
+func (h *Handler) GetReconciliationDAG(w http.ResponseWriter, r *http.Request) {
+	depID := strings.TrimSpace(chi.URLParam(r, "depId"))
+	if depID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "missing-depId"})
+		return
+	}
+	val, ok := h.deployments.Load(depID)
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "deployment-not-found"})
+		return
+	}
+	dep := val.(*Deployment)
+
+	components, watching := h.reconciliationComponents(r.Context(), dep)
+	kustomizations := h.reconciliationKustomizations(depID)
+
+	dag := buildReconciliationDAG(components, kustomizations, watching)
+	writeJSON(w, http.StatusOK, dag)
+}
+
+// reconciliationComponents reads the deployment's bp-* HelmReleases through
+// the same three-tier path GetComponentsState uses, returning the snapshot
+// + a `watching` flag. Live watcher first (counts track convergence), then
+// a one-shot live re-read, then the frozen persisted fallback.
+func (h *Handler) reconciliationComponents(ctx context.Context, dep *Deployment) ([]helmwatch.ComponentSnapshot, bool) {
+	dep.mu.Lock()
+	watcher := dep.liveWatcher
+	var fallbackStates map[string]string
+	if dep.Result != nil {
+		fallbackStates = dep.Result.ComponentStates
+	}
+	dep.mu.Unlock()
+
+	if watcher != nil {
+		return watcher.SnapshotComponents(), true
+	}
+	if live, ok := h.liveComponentsSnapshot(ctx, dep); ok {
+		return live, false
+	}
+	out := make([]helmwatch.ComponentSnapshot, 0, len(fallbackStates))
+	for appID, state := range fallbackStates {
+		out = append(out, helmwatch.ComponentSnapshot{
+			AppID:           appID,
+			Status:          state,
+			HelmReleaseName: "bp-" + appID,
+			Namespace:       helmwatch.FluxNamespace,
+		})
+	}
+	return out, false
+}
+
+// reconciliationKustomizations pulls the Flux Kustomization reconcile leaves
+// (jobs.KindReconcile, "reconcile-<name>") from the jobs store. These are the
+// bootstrap-kit dependency tiers — the OTHER half of the bounded declared
+// set. Returns nil when the store is unconfigured / empty (the DAG then
+// carries HelmReleases only, still bounded).
+//
+// IMPORTANT: ONLY reconcile-kind leaves are returned — install leaves,
+// cron/task/scanner leaves, step leaves, group jobs are all filtered out, so
+// no scanner or Job ever leaks into the Reconciliation DAG.
+func (h *Handler) reconciliationKustomizations(depID string) []jobs.Job {
+	st := h.jobsStore()
+	if st == nil {
+		return nil
+	}
+	js, err := st.ListJobs(depID)
+	if err != nil || len(js) == 0 {
+		return nil
+	}
+	out := make([]jobs.Job, 0)
+	for _, j := range js {
+		if isReconcileKustomization(j) {
+			out = append(out, j)
+		}
+	}
+	return out
+}
+
+// isReconcileKustomization reports whether a Job is a Flux Kustomization
+// reconcile leaf — the ONLY job kind that belongs in the Reconciliation DAG.
+// Matches the persisted Kind OR the "reconcile-" name prefix (back-compat
+// with rows persisted before Kind existed). A group job is never a leaf.
+func isReconcileKustomization(j jobs.Job) bool {
+	if j.Type == jobs.JobTypeGroup {
+		return false
+	}
+	if j.Kind == jobs.KindReconcile {
+		return true
+	}
+	if j.Kind == "" && strings.HasPrefix(j.JobName, jobs.ReconcileJobPrefix) {
+		return true
+	}
+	return false
+}
+
+// buildReconciliationDAG assembles the bounded DAG from the HelmRelease
+// component snapshots + the Kustomization reconcile leaves. Edges are
+// derived from declared dependsOn by exact-ID match; dangling deps (to a
+// node not in the set) are dropped. Nodes are sorted by (kind, id) for a
+// stable render. Exported-shape so the FE + tests share one contract.
+func buildReconciliationDAG(
+	components []helmwatch.ComponentSnapshot,
+	kustomizations []jobs.Job,
+	watching bool,
+) ReconciliationDAG {
+	nodes := make([]ReconciliationNode, 0, len(components)+len(kustomizations))
+	idSet := make(map[string]struct{})
+
+	// Kustomization nodes first (the tier spine sits above HRs).
+	for _, j := range kustomizations {
+		id := strings.TrimPrefix(j.JobName, jobs.ReconcileJobPrefix)
+		if id == "" {
+			id = j.JobName
+		}
+		label := j.DisplayName
+		if label == "" {
+			label = id
+		}
+		nodes = append(nodes, ReconciliationNode{
+			ID:    "kustomization/" + id,
+			Label: label,
+			Kind:  ReconKindKustomization,
+			State: reconStateForReconcileJob(j.Status),
+			// Kustomization dependsOn is not threaded through the jobs store
+			// today; the tier ordering is implicit. Edges left empty.
+		})
+		idSet["kustomization/"+id] = struct{}{}
+	}
+
+	// HelmRelease nodes — bp-prefixed id so dependsOn (also bp-prefixed on
+	// the wire? no — ComponentSnapshot.DependsOn is bp-STRIPPED) resolves.
+	for _, cs := range components {
+		appID := strings.TrimSpace(cs.AppID)
+		if appID == "" {
+			continue
+		}
+		id := "bp-" + strings.TrimPrefix(appID, "bp-")
+		deps := make([]string, 0, len(cs.DependsOn))
+		for _, d := range cs.DependsOn {
+			d = strings.TrimSpace(d)
+			if d == "" {
+				continue
+			}
+			deps = append(deps, "bp-"+strings.TrimPrefix(d, "bp-"))
+		}
+		nodes = append(nodes, ReconciliationNode{
+			ID:        id,
+			Label:     id,
+			Kind:      ReconKindHelmRelease,
+			State:     reconStateForComponent(cs),
+			DependsOn: deps,
+			Message:   cs.Message,
+		})
+		idSet[id] = struct{}{}
+	}
+
+	// Prune dangling dependsOn edges (a dep whose target isn't in the set —
+	// e.g. a dep on a host-side component the watch never observed). Keeps
+	// the DAG honest: every rendered edge connects two real nodes.
+	for i := range nodes {
+		if len(nodes[i].DependsOn) == 0 {
+			continue
+		}
+		kept := nodes[i].DependsOn[:0]
+		for _, d := range nodes[i].DependsOn {
+			if _, ok := idSet[d]; ok {
+				kept = append(kept, d)
+			}
+		}
+		if len(kept) == 0 {
+			nodes[i].DependsOn = nil
+		} else {
+			nodes[i].DependsOn = kept
+		}
+	}
+
+	sort.SliceStable(nodes, func(i, j int) bool {
+		if nodes[i].Kind != nodes[j].Kind {
+			// Kustomizations render above HelmReleases.
+			return nodes[i].Kind == ReconKindKustomization
+		}
+		return nodes[i].ID < nodes[j].ID
+	})
+
+	reconciled := 0
+	for _, n := range nodes {
+		if n.State == ReconStateReconciled {
+			reconciled++
+		}
+	}
+
+	return ReconciliationDAG{
+		Nodes:         nodes,
+		Reconciled:    reconciled,
+		Total:         len(nodes),
+		Watching:      watching,
+		NotYetTracked: notYetTrackedReconcilers,
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/reconciliation_dag_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/reconciliation_dag_test.go
@@ -1,0 +1,200 @@
+// reconciliation_dag_test.go — unit tests for the #3925 surface-B bounded
+// Flux DAG assembly. Asserts the success criteria from the ticket §4:
+//   - bounded node-set: node count == #HelmReleases + #Kustomizations
+//   - ZERO scanner/Job nodes (scanners never enter the reconciler set)
+//   - edges == real declared dependsOn (dangling deps pruned)
+//   - vocabulary: Reconciled/Reconciling/Drifted/Degraded — never
+//     Success/Succeeded/Failed; only a Stalled HR → terminal Degraded
+package handler
+
+import (
+	"testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
+)
+
+// The state machine: only a Stalled HR is terminal-Degraded; every other
+// not-installed state is in-progress (Reconciling/Drifted). This is the
+// anti-flapping guarantee (symptom 2).
+func TestReconStateForComponent_StickyVocabulary(t *testing.T) {
+	cases := []struct {
+		name    string
+		status  string
+		stalled bool
+		want    string
+	}{
+		{"installed → Reconciled", helmwatch.StateInstalled, false, ReconStateReconciled},
+		{"pending → Reconciling", helmwatch.StatePending, false, ReconStateReconciling},
+		{"installing → Reconciling", helmwatch.StateInstalling, false, ReconStateReconciling},
+		{"degraded-not-stalled → Drifted", helmwatch.StateDegraded, false, ReconStateDrifted},
+		{"degraded-stalled → Degraded", helmwatch.StateDegraded, true, ReconStateDegraded},
+		// The load-bearing anti-flap case: a transient failed (still
+		// retrying) must be Reconciling, NOT a terminal Degraded.
+		{"failed-not-stalled → Reconciling (no flap)", helmwatch.StateFailed, false, ReconStateReconciling},
+		{"failed-stalled → Degraded", helmwatch.StateFailed, true, ReconStateDegraded},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := reconStateForComponent(helmwatch.ComponentSnapshot{Status: c.status, Stalled: c.stalled})
+			if got != c.want {
+				t.Fatalf("reconStateForComponent(%q,stalled=%v) = %q, want %q", c.status, c.stalled, got, c.want)
+			}
+		})
+	}
+}
+
+// A continuous Kustomization is never rendered Success/Failed.
+func TestReconStateForReconcileJob_Vocabulary(t *testing.T) {
+	cases := map[string]string{
+		jobs.StatusSucceeded: ReconStateReconciled,
+		jobs.StatusRunning:   ReconStateReconciling,
+		jobs.StatusPending:   ReconStateReconciling,
+		jobs.StatusFailed:    ReconStateDegraded,
+	}
+	for status, want := range cases {
+		if got := reconStateForReconcileJob(status); got != want {
+			t.Fatalf("reconStateForReconcileJob(%q) = %q, want %q", status, got, want)
+		}
+	}
+}
+
+// The DAG is bounded: node count == #HelmReleases + #Kustomizations, edges
+// follow declared dependsOn, and the N/M-Reconciled header is correct.
+func TestBuildReconciliationDAG_BoundedAndEdges(t *testing.T) {
+	components := []helmwatch.ComponentSnapshot{
+		{AppID: "cilium", Status: helmwatch.StateInstalled},
+		{AppID: "keycloak", Status: helmwatch.StateInstalled, DependsOn: []string{"cilium"}},
+		{AppID: "newapi", Status: helmwatch.StateFailed, Stalled: true, DependsOn: []string{"keycloak"}},
+		{AppID: "loki", Status: helmwatch.StateInstalling},
+	}
+	kustomizations := []jobs.Job{
+		{JobName: "reconcile-bootstrap-kit", DisplayName: "Bootstrap", Kind: jobs.KindReconcile, Status: jobs.StatusSucceeded},
+	}
+	dag := buildReconciliationDAG(components, kustomizations, true)
+
+	// Bounded: 4 HRs + 1 Kustomization = 5.
+	if dag.Total != 5 || len(dag.Nodes) != 5 {
+		t.Fatalf("expected 5 bounded nodes, got total=%d len=%d", dag.Total, len(dag.Nodes))
+	}
+	// Reconciled count: cilium + keycloak + bootstrap-kit = 3.
+	if dag.Reconciled != 3 {
+		t.Fatalf("expected 3 Reconciled, got %d", dag.Reconciled)
+	}
+	if !dag.Watching {
+		t.Fatal("watching flag must propagate")
+	}
+
+	byID := map[string]ReconciliationNode{}
+	for _, n := range dag.Nodes {
+		byID[n.ID] = n
+	}
+	// HR ids are bp-prefixed; dependsOn resolved to bp-prefixed ids.
+	kc, ok := byID["bp-keycloak"]
+	if !ok {
+		t.Fatal("bp-keycloak node missing")
+	}
+	if len(kc.DependsOn) != 1 || kc.DependsOn[0] != "bp-cilium" {
+		t.Fatalf("keycloak dependsOn = %v, want [bp-cilium]", kc.DependsOn)
+	}
+	// Stalled HR → terminal Degraded.
+	if byID["bp-newapi"].State != ReconStateDegraded {
+		t.Fatalf("stalled newapi state = %q, want Degraded", byID["bp-newapi"].State)
+	}
+	// Kustomization node present + Reconciled.
+	k, ok := byID["kustomization/bootstrap-kit"]
+	if !ok {
+		t.Fatal("kustomization/bootstrap-kit node missing")
+	}
+	if k.Kind != ReconKindKustomization || k.State != ReconStateReconciled {
+		t.Fatalf("kustomization node = %+v", k)
+	}
+}
+
+// Dangling dependsOn (to a node not in the bounded set) is pruned so the
+// DAG never renders an edge to a non-existent node.
+func TestBuildReconciliationDAG_PrunesDanglingEdges(t *testing.T) {
+	components := []helmwatch.ComponentSnapshot{
+		// depends on a host-side component the watch never observed.
+		{AppID: "harbor", Status: helmwatch.StateInstalled, DependsOn: []string{"shared-postgres-not-in-set"}},
+	}
+	dag := buildReconciliationDAG(components, nil, true)
+	if len(dag.Nodes) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(dag.Nodes))
+	}
+	if dag.Nodes[0].DependsOn != nil {
+		t.Fatalf("dangling dep must be pruned, got %v", dag.Nodes[0].DependsOn)
+	}
+}
+
+// The CRITICAL bound: scanners / cron / task / install / step / group jobs
+// must NEVER enter the Reconciliation DAG. Only reconcile-kind leaves do.
+func TestReconciliationKustomizations_ExcludesScannersAndNonReconcileJobs(t *testing.T) {
+	h, st := newOpStateHandler(t)
+	depID := "dep-recon-scope"
+	seed := []jobs.Job{
+		// reconcile-kind — the ONLY kind that should appear.
+		{DeploymentID: depID, JobName: "reconcile-bootstrap-kit", Kind: jobs.KindReconcile, Status: jobs.StatusSucceeded},
+		{DeploymentID: depID, JobName: "reconcile-flux-system", Kind: jobs.KindReconcile, Status: jobs.StatusRunning},
+		// scanners — must be EXCLUDED.
+		{DeploymentID: depID, JobName: "cron-trivy-scan", Kind: jobs.KindCron, Status: jobs.StatusSucceeded},
+		{DeploymentID: depID, JobName: "task-syft-sbom", Kind: jobs.KindTask, Status: jobs.StatusSucceeded},
+		// install leaf — must be EXCLUDED (HRs come from the watcher, not here).
+		{DeploymentID: depID, JobName: "install-cilium", Kind: jobs.KindInstall, Status: jobs.StatusSucceeded},
+		// cutover step — must be EXCLUDED.
+		{DeploymentID: depID, JobName: "cutover-step-05", Kind: jobs.KindStep, Status: jobs.StatusRunning},
+		// group — must be EXCLUDED.
+		{DeploymentID: depID, JobName: jobs.GroupBootstrapKit, Type: jobs.JobTypeGroup, Status: jobs.StatusRunning},
+	}
+	for _, j := range seed {
+		if err := st.UpsertJob(j); err != nil {
+			t.Fatalf("UpsertJob: %v", err)
+		}
+	}
+	k := h.reconciliationKustomizations(depID)
+	if len(k) != 2 {
+		names := make([]string, 0, len(k))
+		for _, j := range k {
+			names = append(names, j.JobName)
+		}
+		t.Fatalf("expected exactly 2 reconcile leaves, got %d: %v", len(k), names)
+	}
+	for _, j := range k {
+		if !isReconcileKustomization(j) {
+			t.Fatalf("non-reconcile job leaked into the DAG scope: %s", j.JobName)
+		}
+	}
+
+	// And the assembled DAG carries ZERO scanner nodes.
+	dag := buildReconciliationDAG(nil, k, false)
+	for _, n := range dag.Nodes {
+		if n.Kind != ReconKindKustomization {
+			t.Fatalf("unexpected non-Kustomization node in scanner-scope DAG: %+v", n)
+		}
+	}
+	if dag.Total != 2 {
+		t.Fatalf("expected 2 Kustomization nodes, got %d", dag.Total)
+	}
+}
+
+// The "not yet tracked" footnote names the deferred reconciler classes.
+func TestBuildReconciliationDAG_NotYetTrackedFootnote(t *testing.T) {
+	dag := buildReconciliationDAG(nil, nil, false)
+	if len(dag.NotYetTracked) == 0 {
+		t.Fatal("notYetTracked footnote must be populated")
+	}
+	for _, want := range []string{"Crossplane", "cert-manager", "CNPG", "External-Secrets"} {
+		if !sliceHas(dag.NotYetTracked, want) {
+			t.Fatalf("notYetTracked missing %q (got %v)", want, dag.NotYetTracked)
+		}
+	}
+}
+
+func sliceHas(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -70,6 +70,8 @@ import { JobsPage } from '@/pages/sovereign/JobsPage'
 import { JobDetail } from '@/pages/sovereign/JobDetail'
 import { JobsTimeline } from '@/pages/sovereign/JobsTimeline'
 import { Dashboard } from '@/pages/sovereign/Dashboard'
+// #3925 surface B — Reconciliation page (bounded Flux dependency DAG).
+import { ReconciliationPage } from '@/pages/sovereign/ReconciliationPage'
 import { CloudPage } from '@/pages/sovereign/CloudPage'
 import { ResourceDetailRoute } from '@/pages/sovereign/cloud-list/ResourceDetailRoute'
 import { SessionsRoute } from '@/pages/sovereign/sessions/SessionsRoute'
@@ -844,6 +846,15 @@ const provisionDashboardRoute = createRoute({
   beforeLoad: provisionAuthGuard,
 })
 
+// #3925 surface B — Reconciliation page (bounded Flux dependency DAG).
+// Sibling of the Jobs route; lives under Cloud in the left-nav.
+const provisionReconciliationRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/provision/$deploymentId/reconciliation',
+  component: ReconciliationPage,
+  beforeLoad: provisionAuthGuard,
+})
+
 // Sovereign self-decommission (issue #319). Reachable from the Sovereign
 // Admin Dashboard's Decommission link AND directly via deep-link from
 // the customer's own console.<sovereign-fqdn> after handover. POSTs to
@@ -1384,6 +1395,12 @@ const consoleDashboardRoute = createRoute({
   getParentRoute: () => consoleLayoutRoute,
   path: '/dashboard',
   component: Dashboard,
+})
+// #3925 surface B — Reconciliation page (chroot Sovereign Console twin).
+const consoleReconciliationRoute = createRoute({
+  getParentRoute: () => consoleLayoutRoute,
+  path: '/reconciliation',
+  component: ReconciliationPage,
 })
 const consoleAppsRoute = createRoute({
   getParentRoute: () => consoleLayoutRoute,
@@ -2314,6 +2331,8 @@ const routeTree = rootRoute.addChildren([
   provisionJobsTimelineRoute,
   provisionJobDetailRoute,
   provisionDashboardRoute,
+  // #3925 surface B — Reconciliation page (mothership).
+  provisionReconciliationRoute,
   provisionDecommissionRoute,
   provisionCloudRoute.addChildren(legacyCloudRedirectRoutes),
   provisionResourceDetailRoute,
@@ -2354,6 +2373,8 @@ const routeTree = rootRoute.addChildren([
   marketplaceProductRoute,
   consoleLayoutRoute.addChildren([
     consoleDashboardRoute,
+    // #3925 surface B — Reconciliation page (chroot Sovereign Console).
+    consoleReconciliationRoute,
     consoleAppsRoute,
     consoleAppDetailRoute,
     consoleAppDetailTabRoute,

--- a/products/catalyst/bootstrap/ui/src/lib/reconciliation.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/reconciliation.api.ts
@@ -1,0 +1,54 @@
+/**
+ * lib/reconciliation.api.ts — client for the #3925 surface-B bounded Flux
+ * dependency DAG (GET /api/v1/deployments/{id}/reconciliation).
+ *
+ * Matches the Go ReconciliationDAG / ReconciliationNode structs in
+ * products/catalyst/bootstrap/api/internal/handler/reconciliation_dag.go.
+ * The wire vocabulary is the Reconciliation set — NEVER Success/Failed.
+ */
+
+import { API_BASE } from '@/shared/config/urls'
+
+/** The node-state vocabulary the FE renders verbatim. */
+export type ReconState =
+  | 'Reconciled'
+  | 'Reconciling'
+  | 'Drifted'
+  | 'Degraded'
+  | 'Suspended'
+
+export type ReconKind = 'HelmRelease' | 'Kustomization'
+
+export interface ReconciliationNode {
+  id: string
+  label: string
+  kind: ReconKind
+  state: ReconState
+  dependsOn?: string[]
+  message?: string
+}
+
+export interface ReconciliationDAG {
+  nodes: ReconciliationNode[]
+  reconciled: number
+  total: number
+  watching: boolean
+  notYetTracked: string[]
+}
+
+/**
+ * fetchReconciliationDAG retrieves the bounded Flux DAG for a deployment.
+ * Per docs/INVIOLABLE-PRINCIPLES.md #4 the URL is built from API_BASE.
+ */
+export async function fetchReconciliationDAG(
+  deploymentId: string,
+): Promise<ReconciliationDAG> {
+  const res = await fetch(
+    `${API_BASE}/v1/deployments/${encodeURIComponent(deploymentId)}/reconciliation`,
+    { headers: { Accept: 'application/json' }, credentials: 'include' },
+  )
+  if (!res.ok) {
+    throw new Error(`reconciliation DAG fetch failed: HTTP ${res.status}`)
+  }
+  return (await res.json()) as ReconciliationDAG
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/ReconciliationPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/ReconciliationPage.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * ReconciliationPage.test.tsx — wiring lock-in for the #3925 surface-B
+ * Reconciliation page.
+ *
+ * Coverage:
+ *   • renders the N/M-Reconciled header
+ *   • renders one node per declared component (bounded: HRs + Kustomizations)
+ *   • renders the Reconciliation vocabulary — Reconciled/Reconciling/
+ *     Drifted/Degraded — and NEVER Success/Succeeded/Failed
+ *   • ZERO scanner/Job nodes (the page is fed the bounded DAG only)
+ *   • dependsOn edges surface on the node row
+ *   • the not-yet-tracked footnote renders
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup, within } from '@testing-library/react'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ReconciliationPage } from './ReconciliationPage'
+import type { ReconciliationDAG } from '@/lib/reconciliation.api'
+
+afterEach(cleanup)
+
+const SAMPLE_DAG: ReconciliationDAG = {
+  nodes: [
+    { id: 'kustomization/bootstrap-kit', label: 'Bootstrap', kind: 'Kustomization', state: 'Reconciled' },
+    { id: 'bp-cilium', label: 'bp-cilium', kind: 'HelmRelease', state: 'Reconciled' },
+    { id: 'bp-keycloak', label: 'bp-keycloak', kind: 'HelmRelease', state: 'Reconciled', dependsOn: ['bp-cilium'] },
+    { id: 'bp-newapi', label: 'bp-newapi', kind: 'HelmRelease', state: 'Degraded', dependsOn: ['bp-keycloak'] },
+    { id: 'bp-loki', label: 'bp-loki', kind: 'HelmRelease', state: 'Reconciling' },
+  ],
+  reconciled: 3,
+  total: 5,
+  watching: true,
+  notYetTracked: ['Crossplane', 'cert-manager', 'CNPG', 'External-Secrets', 'CRD controllers'],
+}
+
+function renderPage(dag: ReconciliationDAG = SAMPLE_DAG) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const route = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/reconciliation',
+    component: () => <ReconciliationPage dataOverride={dag} disablePoll />,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([route]),
+    history: createMemoryHistory({ initialEntries: ['/provision/d-1/reconciliation'] }),
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router as never} />
+    </QueryClientProvider>,
+  )
+}
+
+describe('ReconciliationPage', () => {
+  it('renders the N/M-Reconciled header', async () => {
+    renderPage()
+    const count = await screen.findByTestId('reconciliation-header-count')
+    expect(count.textContent).toContain('3/5')
+    expect(count.textContent).toMatch(/reconciled/i)
+  })
+
+  it('renders one node per declared component (bounded set)', async () => {
+    renderPage()
+    await screen.findByTestId('reconciliation-dag')
+    const nodes = screen.getAllByTestId('reconciliation-node')
+    expect(nodes).toHaveLength(5)
+  })
+
+  it('renders the Reconciliation vocabulary and NEVER Success/Failed', async () => {
+    renderPage()
+    const dag = await screen.findByTestId('reconciliation-dag')
+    const text = dag.textContent ?? ''
+    // Vocabulary present.
+    expect(text).toMatch(/Reconciled/)
+    expect(text).toMatch(/Reconciling/)
+    expect(text).toMatch(/Degraded/)
+    // Forbidden finite-end words ABSENT.
+    expect(text).not.toMatch(/Success/i)
+    expect(text).not.toMatch(/Succeeded/i)
+    expect(text).not.toMatch(/\bFailed\b/i)
+  })
+
+  it('renders ZERO scanner/Job nodes (only HelmRelease + Kustomization kinds)', async () => {
+    renderPage()
+    await screen.findByTestId('reconciliation-dag')
+    const nodes = screen.getAllByTestId('reconciliation-node')
+    for (const n of nodes) {
+      const kind = n.getAttribute('data-kind')
+      expect(['HelmRelease', 'Kustomization']).toContain(kind)
+    }
+  })
+
+  it('surfaces dependsOn edges on the node row', async () => {
+    renderPage()
+    await screen.findByTestId('reconciliation-dag')
+    const keycloak = screen
+      .getAllByTestId('reconciliation-node')
+      .find((n) => n.getAttribute('data-node-id') === 'bp-keycloak')
+    expect(keycloak).toBeTruthy()
+    const deps = within(keycloak!).getByTestId('reconciliation-node-deps')
+    expect(deps.textContent).toContain('bp-cilium')
+  })
+
+  it('renders the not-yet-tracked footnote', async () => {
+    renderPage()
+    const note = await screen.findByTestId('reconciliation-not-tracked')
+    expect(note.textContent).toMatch(/Crossplane/)
+    expect(note.textContent).toMatch(/cert-manager/)
+  })
+
+  it('renders the empty state when no reconcilers are observed', async () => {
+    renderPage({ nodes: [], reconciled: 0, total: 0, watching: false, notYetTracked: [] })
+    expect(await screen.findByTestId('reconciliation-empty')).toBeTruthy()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/ReconciliationPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/ReconciliationPage.tsx
@@ -1,0 +1,232 @@
+/**
+ * ReconciliationPage — the Convergence-Monitor Reconciliation surface
+ * (#3925 surface B), served at:
+ *   • /sovereign/provision/$deploymentId/reconciliation   (mothership)
+ *   • /reconciliation                                      (chroot console)
+ *
+ * The permanent, LIVING Flux/GitOps dependency DAG — the convergence
+ * spine. Nodes = the declared desired components (a bounded set:
+ * HelmReleases + Kustomizations); edges = real Flux dependsOn; each
+ * coloured by live reconcile state. It NEVER "finishes" — it holds desired
+ * state. "Done provisioning" = the bounded set is all-Reconciled.
+ *
+ * Vocabulary (NOT Success/Failed — those imply a finite end):
+ *   Reconciled · Reconciling · Drifted · Degraded · Suspended
+ * A node goes Degraded ONLY when Flux reports Stalled; every other
+ * Ready=False is Reconciling, which holds a spinner — never a red Failed.
+ *
+ * Scope — Flux-only to start (HelmReleases + Kustomizations). The deferred
+ * continuous-reconciler classes are surfaced in the "not yet tracked"
+ * footnote so the operator knows the scope.
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), the data URL is
+ * built from API_BASE inside reconciliation.api.ts, and every colour is a
+ * named state token, not an inline hex literal scattered through JSX.
+ */
+
+import { useQuery } from '@tanstack/react-query'
+import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
+import { PortalShell } from './PortalShell'
+import {
+  fetchReconciliationDAG,
+  type ReconState,
+  type ReconciliationDAG,
+  type ReconciliationNode,
+} from '@/lib/reconciliation.api'
+
+/** Live poll cadence — a reconcile loop is continuous; a few seconds keeps
+ *  the DAG fresh through convergence without hammering the API. */
+const RECON_POLL_MS = 4_000
+
+/** Per-state visual tokens. The glyph + colour are the only state signal;
+ *  the STRING is the vocabulary word verbatim (the FE never renders
+ *  Success/Failed). */
+const STATE_TONE: Record<ReconState, { glyph: string; fg: string; bg: string; border: string; pulse: boolean }> = {
+  Reconciled: { glyph: '◇', fg: '#4ADE80', bg: 'rgba(74,222,128,0.10)', border: 'rgba(74,222,128,0.30)', pulse: false },
+  Reconciling: { glyph: '↻', fg: '#38BDF8', bg: 'rgba(56,189,248,0.10)', border: 'rgba(56,189,248,0.30)', pulse: true },
+  Drifted: { glyph: '⤳', fg: '#FBBF24', bg: 'rgba(251,191,36,0.10)', border: 'rgba(251,191,36,0.30)', pulse: false },
+  Degraded: { glyph: '⚠', fg: '#F87171', bg: 'rgba(248,113,113,0.10)', border: 'rgba(248,113,113,0.30)', pulse: false },
+  Suspended: { glyph: '⏸', fg: 'var(--color-text-dim)', bg: 'rgba(148,163,184,0.10)', border: 'rgba(148,163,184,0.30)', pulse: false },
+}
+
+export interface ReconciliationPageProps {
+  /** Test seam — synthetic DAG bypassing the live fetch. */
+  dataOverride?: ReconciliationDAG
+  /** Test seam — disable the network poll (jsdom). */
+  disablePoll?: boolean
+}
+
+export function ReconciliationPage({ dataOverride, disablePoll = false }: ReconciliationPageProps = {}) {
+  const { deploymentId: resolved } = useResolvedDeploymentId()
+  const deploymentId = resolved ?? ''
+
+  const query = useQuery<ReconciliationDAG>({
+    queryKey: ['reconciliation-dag', deploymentId],
+    queryFn: () => fetchReconciliationDAG(deploymentId),
+    enabled: !dataOverride && !disablePoll && !!deploymentId,
+    refetchInterval: RECON_POLL_MS,
+    staleTime: RECON_POLL_MS,
+    placeholderData: (prev) => prev,
+  })
+
+  const dag = dataOverride ?? query.data ?? null
+
+  return (
+    <PortalShell deploymentId={deploymentId} pageTitle="Reconciliation">
+      <div className="mx-auto max-w-5xl" data-testid="reconciliation-page">
+        <style>{RECON_CSS}</style>
+
+        {/* N/M-Reconciled header */}
+        <header className="mb-4 flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold text-[var(--color-text-strong)]">
+              Flux convergence spine
+            </h2>
+            <p className="mt-0.5 text-xs text-[var(--color-text-dim)]">
+              The bounded declared set of continuous reconcilers. This view
+              never finishes — it holds desired state.
+            </p>
+          </div>
+          {dag ? (
+            <div
+              data-testid="reconciliation-header-count"
+              className="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-2)] px-4 py-2 text-right"
+            >
+              <div className="font-mono text-xl font-semibold text-[var(--color-text-strong)]">
+                {dag.reconciled}/{dag.total}
+              </div>
+              <div className="text-[11px] uppercase tracking-wide text-[var(--color-text-dim)]">
+                Reconciled
+              </div>
+            </div>
+          ) : null}
+        </header>
+
+        {query.isLoading && !dag ? (
+          <div
+            className="flex h-64 items-center justify-center text-sm text-[var(--color-text-dim)]"
+            data-testid="reconciliation-loading"
+          >
+            Loading the reconciliation spine…
+          </div>
+        ) : null}
+
+        {query.isError && !dag ? (
+          <div
+            className="rounded-md border border-[color:rgba(239,68,68,0.4)] bg-[color:rgba(239,68,68,0.08)] p-3 text-sm text-[#fca5a5]"
+            data-testid="reconciliation-error"
+          >
+            Could not load the reconciliation spine. Retrying…
+          </div>
+        ) : null}
+
+        {dag && dag.nodes.length === 0 && !query.isLoading ? (
+          <div
+            className="flex h-64 flex-col items-center justify-center gap-1 text-center text-sm text-[var(--color-text-dim)]"
+            data-testid="reconciliation-empty"
+          >
+            <p className="font-medium text-[var(--color-text)]">No reconcilers observed yet.</p>
+            <p>Once Flux begins reconciling the desired graph, the spine renders here.</p>
+          </div>
+        ) : null}
+
+        {dag && dag.nodes.length > 0 ? (
+          <ReconciliationDAGView dag={dag} />
+        ) : null}
+
+        {/* Not-yet-tracked footnote (ticket §2 surface-A). */}
+        {dag && dag.notYetTracked && dag.notYetTracked.length > 0 ? (
+          <p
+            className="mt-6 text-[11px] text-[var(--color-text-dimmer)]"
+            data-testid="reconciliation-not-tracked"
+          >
+            Not yet tracked here (deferred continuous reconcilers):{' '}
+            {dag.notYetTracked.join(' · ')}.
+          </p>
+        ) : null}
+      </div>
+    </PortalShell>
+  )
+}
+
+/**
+ * ReconciliationDAGView renders the bounded DAG. Nodes are grouped by kind
+ * (Kustomization tier spine first, then HelmReleases); each row shows its
+ * state badge + declared dependencies. The dependency arrows are rendered
+ * as inline "depends on →" chips (a full force-directed layout is overkill
+ * for the bounded set; the dependency text is the load-bearing signal the
+ * operator reads — "where is it stuck and what's blocking it").
+ */
+function ReconciliationDAGView({ dag }: { dag: ReconciliationDAG }) {
+  const kustomizations = dag.nodes.filter((n) => n.kind === 'Kustomization')
+  const helmReleases = dag.nodes.filter((n) => n.kind === 'HelmRelease')
+  return (
+    <div data-testid="reconciliation-dag" className="flex flex-col gap-5">
+      {kustomizations.length > 0 ? (
+        <NodeGroup title="Kustomization tiers" nodes={kustomizations} />
+      ) : null}
+      {helmReleases.length > 0 ? (
+        <NodeGroup title="HelmReleases" nodes={helmReleases} />
+      ) : null}
+    </div>
+  )
+}
+
+function NodeGroup({ title, nodes }: { title: string; nodes: ReconciliationNode[] }) {
+  return (
+    <section data-testid={`reconciliation-group-${title.split(' ')[0]?.toLowerCase()}`}>
+      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[var(--color-text-dim)]">
+        {title}
+      </h3>
+      <ul className="flex flex-col gap-1.5">
+        {nodes.map((n) => (
+          <ReconciliationNodeRow key={n.id} node={n} />
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+function ReconciliationNodeRow({ node }: { node: ReconciliationNode }) {
+  const tone = STATE_TONE[node.state]
+  return (
+    <li
+      data-testid="reconciliation-node"
+      data-node-id={node.id}
+      data-state={node.state}
+      data-kind={node.kind}
+      className="flex flex-wrap items-center gap-3 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-2)] px-3 py-2"
+    >
+      <span
+        data-testid="reconciliation-node-badge"
+        className="inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] font-bold uppercase tracking-wide"
+        style={{ background: tone.bg, borderColor: tone.border, color: tone.fg }}
+      >
+        <span className={tone.pulse ? 'recon-pulse' : undefined} aria-hidden>
+          {tone.glyph}
+        </span>
+        {node.state}
+      </span>
+      <span className="font-mono text-sm text-[var(--color-text-strong)]">{node.label}</span>
+      {node.dependsOn && node.dependsOn.length > 0 ? (
+        <span
+          data-testid="reconciliation-node-deps"
+          className="ml-auto text-[11px] text-[var(--color-text-dim)]"
+        >
+          depends on{' '}
+          <span className="font-mono text-[var(--color-text)]">
+            {node.dependsOn.join(', ')}
+          </span>
+        </span>
+      ) : null}
+    </li>
+  )
+}
+
+const RECON_CSS = `
+.recon-pulse { animation: recon-pulse 2s ease-in-out infinite; display: inline-block; }
+@keyframes recon-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: 0.4; transform: scale(0.7); }
+}
+`

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Sidebar.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Sidebar.tsx
@@ -48,12 +48,13 @@ interface SidebarProps {
 /* ── Top-level (flat) nav items ─────────────────────────────────── */
 
 interface FlatNavItem {
-  id: 'apps' | 'catalog' | 'jobs' | 'dashboard' | 'cloud' | 'users' | 'settings'
+  id: 'apps' | 'catalog' | 'jobs' | 'reconciliation' | 'dashboard' | 'cloud' | 'users' | 'settings'
   label: string
   to:
     | '/provision/$deploymentId'
     | '/provision/$deploymentId/catalog'
     | '/provision/$deploymentId/jobs'
+    | '/provision/$deploymentId/reconciliation'
     | '/provision/$deploymentId/dashboard'
     | '/provision/$deploymentId/cloud'
     | '/provision/$deploymentId/users'
@@ -105,6 +106,17 @@ const FLAT_NAV: FlatNavItem[] = [
     to: '/provision/$deploymentId/cloud',
     icon: CLOUD_ICON,
   },
+  // #3925 surface B — Reconciliation (the Flux convergence spine). Sits
+  // under Cloud: Cloud is the infra estate, Reconciliation is the GitOps
+  // desired-state DAG that converges onto it.
+  {
+    id: 'reconciliation',
+    label: 'Reconciliation',
+    to: '/provision/$deploymentId/reconciliation',
+    // Tabler IconRefresh — verbatim path data, viewBox 24x24. A circular
+    // refresh glyph reads as "continuous reconcile".
+    icon: 'M20 11A8.1 8.1 0 004.5 9M4 5v4h4M4 13a8.1 8.1 0 0015.5 2M20 19v-4h-4',
+  },
   {
     id: 'users',
     label: 'Users',
@@ -123,7 +135,7 @@ const SETTINGS_ITEM: FlatNavItem = {
 
 /* ── Active-state derivation ────────────────────────────────────── */
 
-type ActiveSection = 'apps' | 'catalog' | 'jobs' | 'dashboard' | 'cloud' | 'users' | 'settings'
+type ActiveSection = 'apps' | 'catalog' | 'jobs' | 'reconciliation' | 'dashboard' | 'cloud' | 'users' | 'settings'
 
 // Cloud section is active when the path matches any of the
 // `/cloud[/...]` or legacy `/infrastructure[/...]` segments. We use a
@@ -135,6 +147,8 @@ const CLOUD_PATH_RE = /\/(cloud|infrastructure)(\/|$)/
 function deriveActiveSection(pathname: string): ActiveSection {
   if (CLOUD_PATH_RE.test(pathname)) return 'cloud'
   if (pathname.endsWith('/dashboard')) return 'dashboard'
+  // #3925 surface B — /reconciliation highlights the Reconciliation entry.
+  if (/\/reconciliation(\/|$)/.test(pathname)) return 'reconciliation'
   // Catalog (#3601) — /catalog and /catalog/<blueprint> both count.
   if (/\/catalog(\/|$)/.test(pathname)) return 'catalog'
   if (pathname.endsWith('/jobs')) return 'jobs'

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
@@ -38,7 +38,7 @@ const CLOUD_ICON =
   'M6.657 18c-2.572 0 -4.657 -2.007 -4.657 -4.483c0 -2.475 2.085 -4.482 4.657 -4.482c.393 -1.762 1.794 -3.2 3.675 -3.773c1.88 -.572 3.956 -.193 5.444 1c1.488 1.19 2.162 3.007 1.77 4.769h.99c1.913 0 3.464 1.56 3.464 3.486c0 1.927 -1.551 3.487 -3.465 3.487h-11.878'
 
 interface FlatNavItem {
-  id: 'apps' | 'catalog' | 'sandbox' | 'jobs' | 'compliance' | 'dashboard' | 'cloud' | 'users' | 'organizations' | 'settings'
+  id: 'apps' | 'catalog' | 'sandbox' | 'jobs' | 'reconciliation' | 'compliance' | 'dashboard' | 'cloud' | 'users' | 'organizations' | 'settings'
   label: string
   to: string
   icon: string
@@ -102,6 +102,16 @@ const FLAT_NAV: FlatNavItem[] = [
     label: 'Jobs',
     to: '/jobs',
     icon: 'M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4',
+  },
+  // #3925 surface B — Reconciliation (the Flux convergence spine). The
+  // bounded GitOps desired-state DAG; sits with Jobs in the operations
+  // band. Icon: Tabler IconRefresh (circular refresh = continuous
+  // reconcile).
+  {
+    id: 'reconciliation',
+    label: 'Reconciliation',
+    to: '/reconciliation',
+    icon: 'M20 11A8.1 8.1 0 004.5 9M4 5v4h4M4 13a8.1 8.1 0 0015.5 2M20 19v-4h-4',
   },
   // Compliance (Wave 5.62a, Refs #2318 / #1096): expose the existing
   // SRE / SecLead compliance dashboards (mounted at /sre/compliance +
@@ -185,7 +195,7 @@ const SETTINGS_SUB_NAV: SubNavItem[] = [
 
 // ── Active-state derivation ───────────────────────────────────────────────────
 
-type ActiveSection = 'apps' | 'catalog' | 'sandbox' | 'jobs' | 'compliance' | 'dashboard' | 'cloud' | 'users' | 'organizations' | 'settings'
+type ActiveSection = 'apps' | 'catalog' | 'sandbox' | 'jobs' | 'reconciliation' | 'compliance' | 'dashboard' | 'cloud' | 'users' | 'organizations' | 'settings'
 
 const CLOUD_PATH_RE = /^\/(cloud|infrastructure)(\/|$)/
 
@@ -200,6 +210,8 @@ function deriveActiveSection(pathname: string): ActiveSection {
   // /sandbox/$id, and /sandbox/settings (Wave 3).
   if (/^\/sandbox(\/|$)/.test(pathname)) return 'sandbox'
   if (/^\/jobs(\/|$)/.test(pathname)) return 'jobs'
+  // #3925 surface B — /reconciliation highlights the Reconciliation entry.
+  if (/^\/reconciliation(\/|$)/.test(pathname)) return 'reconciliation'
   // /sre/compliance + /sec/compliance + /compliance/* all highlight
   // the Compliance nav entry (Wave 5.62a, Refs #2318 / #1096). The
   // entry's to: '/sre/compliance' is the SRE dashboard landing; the


### PR DESCRIPTION
## Convergence-Monitor surface B (#3925) — Reconciliation page + bounded Flux DAG

Refs #3925 #3646. Independently mergeable off `main`. One of three stacked PRs (D / B / A). Two commits: backend endpoint + frontend page/nav.

### What it delivers
- **NEW endpoint** `GET /api/v1/deployments/{id}/reconciliation` — the bounded Flux dependency DAG. Nodes = **HelmReleases** (from the helmwatch `ComponentSnapshot`, the layer with the explicit `spec.dependsOn` DAG) **+ Kustomizations** (`jobs.KindReconcile` leaves, the bootstrap-kit tiers); edges = real declared `dependsOn`; each coloured by live reconcile state.
- **NEW Reconciliation page** + a **"Reconciliation" left-nav entry in BOTH sidebars** (mothership `Sidebar` + chroot `SovereignSidebar`), with active-section highlighting. Routes: `/provision/$id/reconciliation` + `/reconciliation`. Renders the DAG (Kustomization tiers above HelmReleases) + an **N/M-Reconciled header**.

### Vocabulary — never Success/Failed
`Reconciled · Reconciling · Drifted · Degraded · Suspended`. **STICKY** state machine: only a Flux-**Stalled** HelmRelease maps to terminal `Degraded`; every other `Ready=False` is `Reconciling` (holds a spinner, never a red Failed) — this kills the flapping (#3916 / ticket symptom 2).

### Bounded by construction (ticket SC-3)
The DAG is built from reconcilers ONLY — scanner / cron / task / install / step / group jobs **NEVER** enter it. Node count == `#HelmReleases + #Kustomizations`. Dangling `dependsOn` edges are pruned. The deferred reconciler classes (Crossplane / cert-manager / CNPG / External-Secrets / CRD controllers) surface in a "not yet tracked" footnote.

### Key test assertions
- **Go** (`reconciliation_dag_test.go`): sticky vocabulary truth table incl. the load-bearing `failed-not-stalled → Reconciling` anti-flap; bounded node-set == #HRs + #Kustomizations; **ZERO scanner/Job nodes** (the disposition test seeds trivy/syft/install/step/group and asserts only the 2 reconcile leaves survive); edges == declared dependsOn; dangling-edge prune.
- **TS** (`ReconciliationPage.test.tsx`): N/M header; one node per declared component; vocabulary present + `Success`/`Succeeded`/`Failed` **ABSENT**; ZERO scanner/Job nodes (only HelmRelease + Kustomization kinds); dependsOn on the row; not-yet-tracked footnote; empty state.

### Needs a live deploy to confirm
SC-3's exact node-count parity (`== kubectl get hr -A + kubectl get kustomization -A`) is a live-cluster assertion; lands in the #3925 UAT walk. The endpoint reuses the proven 3-tier component read (live watcher → one-shot live re-read → frozen fallback) `GetComponentsState` already ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)