### PR TITLE
feat(ui): convergence-monitor surface A — state-aware Dashboard (5-phase wizard ⇄ treemap + auto-flip)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/ConvergenceWizard.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/ConvergenceWizard.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * ConvergenceWizard.test.tsx — #3925 surface-A state-aware Dashboard.
+ *
+ * Coverage:
+ *   • deriveWizardPhase — status → phase mapping (the 5 phases)
+ *   • hrRatio — multi-region HR census + componentStates fallback
+ *   • wizard render — highlights the live phase + shows the Reconcile ratio
+ *   • deep-links — phase ③ → /reconciliation, phase ② → /jobs
+ *   • Dashboard view toggle — auto-flip to treemap on ready; wizard while
+ *     converging; the manual Progress ⇄ Treemap toggle flips both ways
+ */
+
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+import {
+  ConvergenceWizard,
+  deriveWizardPhase,
+  hrRatio,
+} from './ConvergenceWizard'
+import { Dashboard } from './Dashboard'
+import type { DeploymentSnapshot } from './useDeploymentEvents'
+import type { TreemapData } from '@/lib/treemap.types'
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('deriveWizardPhase', () => {
+  const cases: Array<[string | undefined, ReturnType<typeof deriveWizardPhase>]> = [
+    ['pending', 'infrastructure'],
+    ['tofu-applying', 'infrastructure'],
+    ['flux-bootstrapping', 'bootstrap'],
+    ['phase1-watching', 'reconciliation'],
+    ['ready', 'ready'],
+    ['failed', 'health'],
+    ['partial-failure', 'health'],
+    [undefined, 'infrastructure'],
+  ]
+  for (const [status, expected] of cases) {
+    it(`${status ?? '(none)'} → ${expected}`, () => {
+      expect(deriveWizardPhase(status ? ({ status } as DeploymentSnapshot) : null)).toBe(expected)
+    })
+  }
+})
+
+describe('hrRatio', () => {
+  it('sums the multi-region HR census', () => {
+    const snap = {
+      regions: [
+        { region: 'a', primary: true, hrReady: 60, hrTotal: 63, degraded: false },
+        { region: 'b', primary: false, hrReady: 48, hrTotal: 63, degraded: true },
+      ],
+    } as DeploymentSnapshot
+    expect(hrRatio(snap)).toEqual({ ready: 108, total: 126 })
+  })
+  it('falls back to componentStates when no region census', () => {
+    const snap = {
+      componentStates: { cilium: 'installed', flux: 'installed', keycloak: 'installing' },
+    } as unknown as DeploymentSnapshot
+    expect(hrRatio(snap)).toEqual({ ready: 2, total: 3 })
+  })
+  it('returns 0/0 when nothing is known', () => {
+    expect(hrRatio(null)).toEqual({ ready: 0, total: 0 })
+  })
+})
+
+function renderWizard(snapshot: DeploymentSnapshot | null) {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const route = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/dashboard',
+    component: () => <ConvergenceWizard snapshot={snapshot} deploymentId="d-1" />,
+  })
+  const reconRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/reconciliation',
+    component: () => <div data-testid="recon-target" />,
+  })
+  const jobsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/jobs',
+    component: () => <div data-testid="jobs-target" />,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([route, reconRoute, jobsRoute]),
+    history: createMemoryHistory({ initialEntries: ['/provision/d-1/dashboard'] }),
+  })
+  return render(<RouterProvider router={router as never} />)
+}
+
+describe('ConvergenceWizard render', () => {
+  it('highlights the live phase + shows the Reconcile ratio', async () => {
+    renderWizard({
+      status: 'phase1-watching',
+      regions: [{ region: 'a', primary: true, hrReady: 52, hrTotal: 65, degraded: false }],
+    } as DeploymentSnapshot)
+    const recon = await screen.findByTestId('wizard-phase-reconciliation')
+    expect(recon.getAttribute('data-active')).toBe('true')
+    expect(screen.getByTestId('wizard-reconcile-ratio').textContent).toContain('52/65')
+  })
+
+  it('deep-links phase ③ to the Reconciliation page and ② to Jobs', async () => {
+    renderWizard({ status: 'phase1-watching' } as DeploymentSnapshot)
+    const reconLink = await screen.findByTestId('wizard-link-reconciliation')
+    expect(reconLink.getAttribute('href')).toContain('/reconciliation')
+    const jobsLink = screen.getByTestId('wizard-link-jobs')
+    expect(jobsLink.getAttribute('href')).toContain('/jobs')
+  })
+})
+
+// ── Dashboard view toggle + auto-flip ─────────────────────────────────────
+//
+// The Dashboard derives its view from the deployment snapshot (fetched via
+// useDeploymentEvents → GET /events). We stub fetch to return a chosen
+// status so we can assert the auto-flip.
+
+function stubEventsFetch(state: DeploymentSnapshot | undefined) {
+  globalThis.fetch = ((url: string) => {
+    const u = String(url)
+    if (u.includes('/events')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ events: [], state, done: state !== undefined }),
+      } as unknown as Response)
+    }
+    // deployment poll / anything else
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(state ?? {}),
+    } as unknown as Response)
+  }) as typeof fetch
+  if (typeof globalThis.ResizeObserver === 'undefined') {
+    class FakeRO {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    ;(globalThis as unknown as { ResizeObserver: typeof FakeRO }).ResizeObserver = FakeRO
+  }
+}
+
+const EMPTY_TREEMAP: TreemapData = { total_count: 0, items: [] } as unknown as TreemapData
+
+function renderDashboard() {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const dashRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/dashboard',
+    // disableStream skips the EventSource (jsdom has none); the snapshot is
+    // resolved via the GET /events replay path ({state, done:true}) — the
+    // same seam the existing Dashboard suite uses.
+    component: () => <Dashboard initialDataOverride={EMPTY_TREEMAP} disableStream />,
+  })
+  const reconRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/reconciliation',
+    component: () => <div data-testid="recon-target" />,
+  })
+  const jobsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/jobs',
+    component: () => <div data-testid="jobs-target" />,
+  })
+  const decomRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/decommission/$deploymentId',
+    component: () => <div data-testid="decom-target" />,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([dashRoute, reconRoute, jobsRoute, decomRoute]),
+    history: createMemoryHistory({ initialEntries: ['/provision/d-1/dashboard'] }),
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router as never} />
+    </QueryClientProvider>,
+  )
+}
+
+describe('Dashboard state-aware view', () => {
+  beforeEach(() => {
+    // default: not-ready (still converging)
+    stubEventsFetch({ status: 'phase1-watching' } as DeploymentSnapshot)
+  })
+
+  it('renders the wizard (Progress) while converging', async () => {
+    renderDashboard()
+    expect(await screen.findByTestId('convergence-wizard')).toBeTruthy()
+    // Treemap controller is hidden in progress view.
+    expect(screen.queryByTestId('dashboard-treemap-frame')).toBeNull()
+  })
+
+  it('AUTO-FLIPS to the treemap when status is ready', async () => {
+    stubEventsFetch({ status: 'ready' } as DeploymentSnapshot)
+    renderDashboard()
+    // The treemap frame appears once the ready snapshot resolves.
+    await waitFor(() => {
+      expect(screen.queryByTestId('dashboard-treemap-frame')).toBeTruthy()
+    })
+    expect(screen.queryByTestId('convergence-wizard')).toBeNull()
+  })
+
+  it('manual toggle flips Progress ⇄ Treemap both ways', async () => {
+    renderDashboard()
+    // Starts on Progress (converging).
+    expect(await screen.findByTestId('convergence-wizard')).toBeTruthy()
+    // Flip to Treemap.
+    fireEvent.click(screen.getByTestId('dashboard-view-treemap'))
+    await waitFor(() => {
+      expect(screen.queryByTestId('dashboard-treemap-frame')).toBeTruthy()
+    })
+    expect(screen.queryByTestId('convergence-wizard')).toBeNull()
+    // Flip back to Progress.
+    fireEvent.click(screen.getByTestId('dashboard-view-progress'))
+    await waitFor(() => {
+      expect(screen.queryByTestId('convergence-wizard')).toBeTruthy()
+    })
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/ConvergenceWizard.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/ConvergenceWizard.tsx
@@ -1,0 +1,214 @@
+/**
+ * ConvergenceWizard — the state-aware 5-phase wizard half of the
+ * Convergence-Monitor Dashboard (#3925 surface A).
+ *
+ * While a Sovereign is converging (or running an operation) the Dashboard
+ * renders THIS instead of the treemap: a 5-phase progress wizard
+ *
+ *   Infrastructure → Bootstrap → Reconciliation → Health → Ready
+ *
+ * with the live phase highlighted and, in the Reconciliation phase, the
+ * live HelmRelease ratio ("Reconcile 52/65"). The moment status flips
+ * `ready` the Dashboard AUTO-FLIPS to the treemap; a persistent toggle
+ * flips back to this wizard (DECISION: banner+toggle, not auto-flip-back —
+ * the user keeps control once they toggle).
+ *
+ * Deep-links (ticket §2 surface-C / §5):
+ *   • Phase ③ Reconciliation → the Reconciliation page (the Flux DAG).
+ *   • Phase ② Bootstrap + any operation → the Jobs page (the finite jobs).
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md #4 the phase set + ratio come from the
+ * deployment status + the region HR census, never hardcoded.
+ */
+
+import { Link } from '@tanstack/react-router'
+import type { DeploymentSnapshot, RegionHealth } from './useDeploymentEvents'
+
+/** The five wizard phases, in order. */
+export type WizardPhase =
+  | 'infrastructure'
+  | 'bootstrap'
+  | 'reconciliation'
+  | 'health'
+  | 'ready'
+
+export const WIZARD_PHASES: ReadonlyArray<{ id: WizardPhase; label: string }> = [
+  { id: 'infrastructure', label: 'Infrastructure' },
+  { id: 'bootstrap', label: 'Bootstrap' },
+  { id: 'reconciliation', label: 'Reconciliation' },
+  { id: 'health', label: 'Health' },
+  { id: 'ready', label: 'Ready' },
+]
+
+const PHASE_INDEX: Record<WizardPhase, number> = {
+  infrastructure: 0,
+  bootstrap: 1,
+  reconciliation: 2,
+  health: 3,
+  ready: 4,
+}
+
+/**
+ * deriveWizardPhase maps the deployment status (+ HR census) to the live
+ * wizard phase. The mapping mirrors the provision lifecycle:
+ *
+ *   pending / tofu-applying      → Infrastructure (OpenTofu applies infra)
+ *   flux-bootstrapping           → Bootstrap       (k3s→cilium→flux land)
+ *   phase1-watching              → Reconciliation   (HRs reconcile; show ratio)
+ *   (HRs all installed, settling) → Health
+ *   ready                        → Ready
+ *
+ * A non-ready, non-in-flight status (failed/partial) pins Health so the
+ * operator sees "stuck just short of ready" rather than a false Ready.
+ */
+export function deriveWizardPhase(snap: DeploymentSnapshot | null | undefined): WizardPhase {
+  const status = (snap?.status ?? '').trim().toLowerCase()
+  switch (status) {
+    case 'pending':
+    case 'provisioning':
+    case 'tofu-applying':
+      return 'infrastructure'
+    case 'flux-bootstrapping':
+      return 'bootstrap'
+    case 'phase1-watching':
+      return 'reconciliation'
+    case 'ready':
+      return 'ready'
+    case 'failed':
+    case 'partial-failure':
+      // Stuck just short — Health is the "almost there / needs attention"
+      // phase; the chip + banner carry the degraded signal.
+      return 'health'
+    default:
+      // Unknown/empty (first paint before snapshot resolves) — start at
+      // Infrastructure rather than falsely claim Ready.
+      return 'infrastructure'
+  }
+}
+
+/** hrRatio sums the HelmRelease census across regions → {ready, total}. */
+export function hrRatio(snap: DeploymentSnapshot | null | undefined): { ready: number; total: number } {
+  const regions: RegionHealth[] = snap?.regions ?? []
+  if (regions.length > 0) {
+    let ready = 0
+    let total = 0
+    for (const r of regions) {
+      ready += r.hrReady ?? 0
+      total += r.hrTotal ?? 0
+    }
+    return { ready, total }
+  }
+  // Single-region / pre-census: fall back to componentStates if present.
+  const cs = snap?.componentStates ?? snap?.result?.componentStates ?? null
+  if (cs) {
+    const entries = Object.values(cs)
+    const ready = entries.filter((s) => s === 'installed').length
+    return { ready, total: entries.length }
+  }
+  return { ready: 0, total: 0 }
+}
+
+export interface ConvergenceWizardProps {
+  snapshot: DeploymentSnapshot | null
+  deploymentId: string
+}
+
+export function ConvergenceWizard({ snapshot, deploymentId }: ConvergenceWizardProps) {
+  const phase = deriveWizardPhase(snapshot)
+  const activeIdx = PHASE_INDEX[phase]
+  const ratio = hrRatio(snapshot)
+
+  return (
+    <div
+      data-testid="convergence-wizard"
+      data-phase={phase}
+      className="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-2)] p-6"
+    >
+      <style>{WIZARD_CSS}</style>
+      <h2 className="mb-1 text-lg font-semibold text-[var(--color-text-strong)]">
+        Converging to desired state
+      </h2>
+      <p className="mb-5 text-xs text-[var(--color-text-dim)]">
+        The Sovereign is provisioning. This wizard auto-flips to the resource
+        treemap the moment it reaches Ready.
+      </p>
+
+      <ol className="flex flex-col gap-2 sm:flex-row sm:items-stretch sm:gap-0">
+        {WIZARD_PHASES.map((p, i) => {
+          const isActive = i === activeIdx
+          const isDone = i < activeIdx
+          const stateCls = isDone
+            ? 'wizard-phase-done'
+            : isActive
+              ? 'wizard-phase-active'
+              : 'wizard-phase-pending'
+          return (
+            <li
+              key={p.id}
+              data-testid={`wizard-phase-${p.id}`}
+              data-active={isActive ? 'true' : 'false'}
+              data-done={isDone ? 'true' : 'false'}
+              className={`wizard-phase ${stateCls} flex flex-1 flex-col gap-1 rounded-lg border px-3 py-3 sm:mx-1`}
+            >
+              <span className="flex items-center gap-2 text-sm font-semibold">
+                <span className="wizard-phase-dot" aria-hidden>
+                  {isDone ? '✓' : isActive ? '●' : i + 1}
+                </span>
+                {p.label}
+              </span>
+              {/* Reconciliation phase shows the live HR ratio + a deep-link. */}
+              {p.id === 'reconciliation' ? (
+                <span className="text-[11px] text-[var(--color-text-dim)]">
+                  {ratio.total > 0 ? (
+                    <span data-testid="wizard-reconcile-ratio" className="font-mono">
+                      Reconcile {ratio.ready}/{ratio.total}
+                    </span>
+                  ) : (
+                    'Reconcile'
+                  )}
+                  {' · '}
+                  <Link
+                    to={'/reconciliation' as never}
+                    params={{ deploymentId } as never}
+                    data-testid="wizard-link-reconciliation"
+                    className="text-[var(--color-accent)] no-underline hover:underline"
+                  >
+                    view DAG →
+                  </Link>
+                </span>
+              ) : null}
+              {/* Bootstrap phase deep-links the Jobs page (finite jobs). */}
+              {p.id === 'bootstrap' ? (
+                <span className="text-[11px] text-[var(--color-text-dim)]">
+                  <Link
+                    to={'/jobs' as never}
+                    params={{ deploymentId } as never}
+                    data-testid="wizard-link-jobs"
+                    className="text-[var(--color-accent)] no-underline hover:underline"
+                  >
+                    view jobs →
+                  </Link>
+                </span>
+              ) : null}
+            </li>
+          )
+        })}
+      </ol>
+    </div>
+  )
+}
+
+const WIZARD_CSS = `
+.wizard-phase { border-color: var(--color-border); background: var(--color-bg); transition: all 0.2s ease; }
+.wizard-phase-dot {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 20px; height: 20px; border-radius: 50%; font-size: 11px; font-weight: 700;
+  background: var(--color-border); color: var(--color-text-dim);
+}
+.wizard-phase-pending { opacity: 0.6; }
+.wizard-phase-active { border-color: #38BDF8; background: rgba(56,189,248,0.08); }
+.wizard-phase-active .wizard-phase-dot { background: #38BDF8; color: #06121c; animation: wizard-pulse 2s ease-in-out infinite; }
+.wizard-phase-done { border-color: rgba(74,222,128,0.35); }
+.wizard-phase-done .wizard-phase-dot { background: #4ADE80; color: #052e13; }
+@keyframes wizard-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.5; } }
+`

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.test.tsx
@@ -53,6 +53,11 @@ function renderDashboard(
         disableStream
         initialDataOverride={dataOverride}
         initialLayers={opts.initialLayers}
+        // #3925 surface A — these tests assert the treemap surface; pin the
+        // view to treemap so the new Progress ⇄ Treemap toggle (which
+        // defaults to Progress while the test-stubbed status is non-ready)
+        // doesn't hide it. The wizard/auto-flip behaviour has its own suite.
+        initialView="treemap"
       />
     ),
   })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.tsx
@@ -52,6 +52,9 @@ import { useQuery } from '@tanstack/react-query'
 
 import { PortalShell } from './PortalShell'
 import { useDeploymentEvents } from './useDeploymentEvents'
+// #3925 surface A — state-aware Dashboard: the 5-phase convergence wizard
+// that ⇄ toggles with the treemap and auto-flips to it on `status==ready`.
+import { ConvergenceWizard } from './ConvergenceWizard'
 import {
   TreemapLayerController,
 } from '@/components/TreemapLayerController'
@@ -131,6 +134,11 @@ export interface DashboardProps {
   initialLayers?: readonly TreemapDimension[]
   initialColorBy?: TreemapColorBy
   initialSizeBy?: TreemapSizeBy
+  /** #3925 surface A — test seam: pin the Progress ⇄ Treemap view. When
+   *  set, the wizard/treemap toggle starts on this side regardless of the
+   *  (test-stubbed) deployment status. Production leaves this unset so the
+   *  view derives from status (auto-flip to treemap on ready). */
+  initialView?: 'progress' | 'treemap'
 }
 
 export function Dashboard({
@@ -139,6 +147,7 @@ export function Dashboard({
   initialLayers,
   initialColorBy,
   initialSizeBy,
+  initialView,
 }: DashboardProps = {}) {
   const { deploymentId: resolved } = useResolvedDeploymentId()
   const deploymentId = resolved ?? ''
@@ -150,6 +159,22 @@ export function Dashboard({
     disableStream,
   })
   const sovereignFQDN = snapshot?.sovereignFQDN ?? snapshot?.result?.sovereignFQDN ?? null
+
+  // #3925 surface A — state-aware view toggle. While the Sovereign is
+  // converging we render the 5-phase wizard; the moment status flips
+  // `ready` we AUTO-FLIP to the treemap. A persistent Progress ⇄ Treemap
+  // toggle lets the operator flip back/forth AFTER the auto-flip (DECISION:
+  // the user keeps control once they toggle — no auto-flip-back).
+  //
+  // Implementation: `userView` is null until the operator clicks the
+  // toggle. The effective view is the user's choice if set, else derived
+  // from status (treemap when ready, wizard otherwise). This auto-flips on
+  // ready WITHOUT a setState-in-effect storm and respects a manual override.
+  const isReady = (snapshot?.status ?? '').trim().toLowerCase() === 'ready'
+  const [userView, setUserView] = useState<'progress' | 'treemap' | null>(
+    initialView ?? null,
+  )
+  const view: 'progress' | 'treemap' = userView ?? (isReady ? 'treemap' : 'progress')
 
   // #3687 fold #3692 (2026-06-18): default Layer-1 = `organization` on the
   // Sovereign Console so the operator's landing treemap groups by the
@@ -396,6 +421,53 @@ export function Dashboard({
           Dashboard
         </span>
 
+        {/* #3925 surface A — persistent Progress ⇄ Treemap toggle. Always
+            present so the operator can flip either way; the active side is
+            driven by `view` (auto-flips to treemap on ready). */}
+        <div
+          className="mb-3 inline-flex rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-2)] p-0.5"
+          role="tablist"
+          aria-label="Dashboard view"
+          data-testid="dashboard-view-toggle"
+        >
+          <button
+            type="button"
+            role="tab"
+            aria-selected={view === 'progress'}
+            onClick={() => setUserView('progress')}
+            data-testid="dashboard-view-progress"
+            className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
+              view === 'progress'
+                ? 'bg-[var(--color-accent)]/15 text-[var(--color-accent)]'
+                : 'text-[var(--color-text-dim)] hover:text-[var(--color-text)]'
+            }`}
+          >
+            Progress
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={view === 'treemap'}
+            onClick={() => setUserView('treemap')}
+            data-testid="dashboard-view-treemap"
+            className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
+              view === 'treemap'
+                ? 'bg-[var(--color-accent)]/15 text-[var(--color-accent)]'
+                : 'text-[var(--color-text-dim)] hover:text-[var(--color-text)]'
+            }`}
+          >
+            Treemap
+          </button>
+        </div>
+
+        {/* Progress view — the 5-phase convergence wizard. */}
+        {view === 'progress' ? (
+          <ConvergenceWizard snapshot={snapshot} deploymentId={deploymentId} />
+        ) : null}
+
+        {/* Treemap view — the existing resource-utilisation surface. */}
+        {view === 'treemap' ? (
+        <>
         <TreemapLayerController
           layers={layers}
           setLayers={setLayers}
@@ -516,6 +588,8 @@ export function Dashboard({
 
         {/* Legend */}
         <Legend colorBy={colorBy} />
+        </>
+        ) : null}
       </div>
     </PortalShell>
   )


### PR DESCRIPTION
## Convergence-Monitor surface A (#3925) — state-aware Dashboard

Refs #3925 #3646. Independently mergeable off `main`. One of three stacked PRs (D / B / A); merge after B so the wizard's "view DAG" deep-link resolves to a registered route (the Link is a soft dependency — A builds + tests standalone).

### What it delivers
- The Dashboard is now **phase-aware**. While the Sovereign is converging it renders a **5-phase wizard** — Infrastructure → Bootstrap → Reconciliation → Health → Ready — with the live phase highlighted and the live **HelmRelease ratio** ("Reconcile 52/65") in the Reconciliation phase.
- **AUTO-FLIP to the existing squarified treemap** the moment `status == "ready"`.
- A **persistent Progress ⇄ Treemap toggle** that flips both ways after the auto-flip (the operator keeps control once they toggle — no auto-flip-back).
- **Deep-links** (ticket §5): wizard phase ③ Reconciliation → the Reconciliation page (surface B); phase ② Bootstrap → the Jobs page.

The treemap surface itself is unchanged — it's gated behind the toggle. A new `initialView` test seam pins the view for the existing treemap suite.

### Key test assertions (`ConvergenceWizard.test.tsx`)
- `deriveWizardPhase` status→phase mapping for all 5 phases (+ failed/partial → Health, unknown → Infrastructure, never a false Ready).
- `hrRatio` sums the multi-region HR census + falls back to `componentStates`.
- Wizard highlights the live phase + shows the `Reconcile 52/65` ratio; deep-links resolve to `/reconciliation` + `/jobs`.
- Dashboard **AUTO-FLIPS** to the treemap on `ready`, shows the wizard while converging, and the **manual toggle flips both ways**.

### Needs a live deploy to confirm
The auto-flip on a *real* `status` transition (`phase1-watching → ready`) over SSE is exercised end-to-end only on a fresh prov (SC-6); unit coverage drives it via the GET-replay snapshot seam. Lands in the #3925 UAT walk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)