### PR TITLE
fix(sso): #3642 mgmt-vCluster pivot broke gitea/harbor/guacamole SSO-landing — split-gate sso-configure + open guacamole DB ingress

### DIFF
--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -162,7 +162,12 @@ spec:
       # (openbao pattern) that re-asserts the `openova-sso` login source every
       # 60s, so a CNPG DB re-init no longer silently strands gitea's SSO at
       # `oauth2 source not found` 500 (caught live hw167). Refs #3374.
-      version: 1.2.38
+      # 1.2.39 (#3934 / Refs #3642, 2026-06-20): split-gate — the in-vCluster
+      # sso-configure Deployment now survives the host-bridge suppress (only
+      # the chart ExternalSecret is suppressed via sso.externalSecret.enabled,
+      # not sso.enabled), so the login_source row gets seeded in the mgmt
+      # vCluster placement (caught live hw171). Refs #3374 #3642.
+      version: 1.2.39
       sourceRef:
         kind: HelmRepository
         name: bp-gitea
@@ -213,7 +218,14 @@ spec:
     # chart values short-circuits the configure-oauth Job; the envsubst
     # below makes SSO work zero-touch on every fresh Sovereign.
     sso:
-      enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      externalSecret:
+        enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      # #3934 (Refs #3642): sso.enabled STAYS true so the in-vCluster
+      # sso-configure Deployment renders (it seeds the `openova-sso`
+      # login_source DB row via kubectl-exec into the live gitea Pod). Only
+      # the chart's ExternalSecret is suppressed above (host-rendered). NOT
+      # placement-generated — placement.yaml no longer declares sso.enabled.
+      enabled: true
       sovereignFqdn: ${SOVEREIGN_FQDN}
     # G87 #2634 (2026-06-01): multi-region Sovereigns default CNPG
     # instances to 2 so the operator spreads across regions via

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1041,7 +1041,13 @@ spec:
             # 1.4.699 — #3856 (Refs #3375 #3581): ONE canonical DR vocabulary — catalog-seed (bp-cnpg-pair + bp-continuum) + cnpgpair.yaml CRD enum drop the banned un-hyphenated `active-hotstandby` for the canonical `active-hot-standby`; catalyst-ui Instances table canonicalizes for display so the bp-postgres chip renders clean. Catalyst-Zero render byte-unchanged. NOTE re-pin: the catalyst-build auto-bump may publish a higher patch (it increments from Chart.yaml at merge) — verify the ghcr tag before a fresh prov pins this.
       # 1.4.702 — #3819 #3854 #3859 (Refs #3383 #3376): sme→org-services rename TAIL — funnel/BSS
       #   control-plane namespace defaults + reflector/policy allow-lists re-pointed at org-services.
-      version: 1.4.716
+      # 1.4.717 — #3934 (Refs #3642): baseline-default-deny CNP adds `mgmt` to the
+      #   catalyst-system ingress allow-list so the mgmt-vCluster-resident guacamole
+      #   webapp can reach its host-rendered guacamole-pg DB (hw171 403 fix) + split-
+      #   gates the gitea/harbor sso-configure Deployment (sso.externalSecret.enabled).
+      #   Renumbered past the deploy-bot auto-bump to 1.4.717 (one above main's
+      #   1.4.716) to clear the pin collision.
+      version: 1.4.717
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -216,7 +216,12 @@ spec:
       # this slot's HelmRelease so the console /apps list, per-app Topology
       # tab + showback resolve harbor (no more "no Application CR").
       # 1.2.33: #3855 — durable zero-click SSO (continuous OIDC reconciler + bare-URL redirect).
-      version: 1.2.33
+      # 1.2.34 (#3934 / Refs #3642, 2026-06-20): split-gate — the in-vCluster
+      # sso-configure Deployment survives the host-bridge suppress (only the
+      # ExternalSecret is suppressed via sso.externalSecret.enabled), so
+      # auth_mode=oidc_auth is PUT in the mgmt vCluster placement (caught live
+      # hw171: systeminfo auth_mode=db_auth). Refs #3374 #3642.
+      version: 1.2.34
       sourceRef:
         kind: HelmRepository
         name: bp-harbor
@@ -308,7 +313,14 @@ spec:
     # post-install Job PUTs /api/v2.0/configurations with
     # auth_mode=oidc_auth + oidc_endpoint computed from sovereignFqdn.
     sso:
-      enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      externalSecret:
+        enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      # #3934 (Refs #3642): sso.enabled STAYS true so the in-vCluster
+      # sso-configure Deployment renders (it PUTs auth_mode=oidc_auth to
+      # harbor-core /api/v2.0/configurations). Only the chart's ExternalSecret
+      # is suppressed above (host-rendered). NOT placement-generated —
+      # placement.yaml no longer declares sso.enabled.
+      enabled: true
       sovereignFqdn: ${SOVEREIGN_FQDN}
     # G87 #2634: multi-region CNPG instances default (1 single-region, 2 multi).
     postgres:

--- a/clusters/_template/bootstrap-kit/placement.yaml
+++ b/clusters/_template/bootstrap-kit/placement.yaml
@@ -254,7 +254,15 @@ spec:
       hostBridge:
         suppress:
           gateway.enabled: false
-          sso.enabled: false
+          # #3934 (Refs #3642): suppress ONLY the chart's in-vCluster
+          # ExternalSecret (the host renders gitea-oauth-source-credentials
+          # below) — NOT sso.enabled. The chart's sso-configure Deployment
+          # MUST render in-vCluster: it kubectl-exec's the live gitea Pod to
+          # seed the `openova-sso` login_source DB row (without it
+          # /user/oauth2/openova-sso 500s `oauth2 source not found`). Its creds
+          # arrive via bp-mgmt-vcluster sync.fromHost
+          # `gitea/gitea-oauth-source-credentials`.
+          sso.externalSecret.enabled: false
           postgres.cluster.enabled: false
         hostDocuments:
           # HTTPRoute in the `mgmt` host ns (same ns as the mangled backend
@@ -942,7 +950,14 @@ spec:
       hostBridge:
         suppress:
           gateway.enabled: false
-          sso.enabled: false
+          # #3934 (Refs #3642): suppress ONLY the chart's in-vCluster
+          # ExternalSecret (the host renders harbor-sso-oidc-credentials
+          # below) — NOT sso.enabled. The sso-configure Deployment MUST render
+          # in-vCluster: it PUTs auth_mode=oidc_auth to harbor-core
+          # /api/v2.0/configurations (without it harbor stays db_auth → login
+          # form, no SSO auto-land). Its creds arrive via bp-mgmt-vcluster
+          # sync.fromHost `harbor/harbor-sso-oidc-credentials`.
+          sso.externalSecret.enabled: false
           postgres.cluster.enabled: false
         hostDocuments:
           - apiVersion: gateway.networking.k8s.io/v1

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.38
+  version: 1.2.39
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -139,7 +139,20 @@ name: bp-gitea
 # a Pod roll. New value sso.reconcileIntervalSeconds (default 60). Every
 # hard-won fix from the hook (pod-selector #2818, TAB-stripping AUTH_ID #2816,
 # public-first discovery URL #3150) carried verbatim. Refs #3374.
-version: 1.2.38
+# 1.2.39 (#3934 / Refs #3642, 2026-06-20): SPLIT-GATE for the mgmt-vCluster
+# host-bridge. When #3642 promotes gitea into the mgmt vCluster, the host
+# renders gitea-oauth-source-credentials (ESO + the OpenBao ClusterSecretStore
+# are host resources) and placement.yaml's hostBridge.suppress set
+# `sso.enabled: false` — which ALSO killed the 1.2.38 sso-configure Deployment,
+# so the `openova-sso` login_source row was NEVER seeded and
+# `GET /user/oauth2/openova-sso` 500'd `oauth2 source not found` (caught live
+# hw171 2026-06-19). New value sso.externalSecret.enabled (default true) now
+# gates the chart's ExternalSecret independently; the Deployment stays gated on
+# sso.enabled. Host-bridge sets externalSecret.enabled:false (skip the duplicate
+# in-vCluster Secret) while sso.enabled stays true so the Deployment renders
+# IN the vCluster and seeds the row (its creds cross in via bp-mgmt-vcluster
+# sync.fromHost). Non-host-bridged render is byte-identical. Refs #3374 #3642.
+version: 1.2.39
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/templates/sso-oauth-source-externalsecret.yaml
+++ b/platform/gitea/chart/templates/sso-oauth-source-externalsecret.yaml
@@ -32,7 +32,22 @@ no ESO). With the guard, the resource is simply omitted until the next
 Flux reconcile re-renders once the CRD exists (Capabilities re-evaluated
 every reconcile), so SSO wiring self-heals with zero manual touch.
 */}}
-{{- if and .Values.sso.enabled (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1") }}
+{{- /*
+#3934 (Refs #3642): split-gate. When gitea is host-bridged into the mgmt
+vCluster (the #3642 placement), the HOST renders this ExternalSecret (the
+external-secrets-operator lives on the host, and the OpenBao
+ClusterSecretStore is a host resource the vCluster apiserver can't expose
+to). placement.yaml's hostBridge.suppress sets `sso.externalSecret.enabled:
+false` so the chart does NOT also render an in-vCluster copy (double-owner) —
+WITHOUT disabling `sso.enabled`, which still renders the sso-configure
+Deployment IN the vCluster (it kubectl-exec's the live gitea Pod, so it
+belongs alongside it; its creds arrive via the bp-mgmt-vcluster fromHost
+secret-crossing of `gitea-oauth-source-credentials`). On a non-host-bridged
+prov `sso.externalSecret.enabled` defaults true → byte-identical render.
+*/}}
+{{- $esEnabled := true }}
+{{- if .Values.sso.externalSecret }}{{- if hasKey .Values.sso.externalSecret "enabled" }}{{- $esEnabled = .Values.sso.externalSecret.enabled }}{{- end }}{{- end }}
+{{- if and .Values.sso.enabled $esEnabled (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1") }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:

--- a/platform/gitea/chart/values.yaml
+++ b/platform/gitea/chart/values.yaml
@@ -305,6 +305,19 @@ gateway:
 # (`gitea_admin`) still exists as a break-glass account for cutover step 1.
 sso:
   enabled: true
+  # #3934 (Refs #3642): split-gate for the host-bridge (mgmt-vCluster)
+  # placement. When gitea is host-bridged, the HOST renders the
+  # gitea-oauth-source-credentials ExternalSecret (external-secrets-operator
+  # + the OpenBao ClusterSecretStore are host resources) and placement.yaml's
+  # hostBridge.suppress sets `externalSecret.enabled: false` so the chart does
+  # NOT also render an in-vCluster copy (avoids two owners of one Secret name).
+  # `sso.enabled` STAYS true so the sso-configure Deployment still renders IN
+  # the vCluster — it kubectl-exec's the live gitea Pod (belongs alongside it)
+  # and mounts the host-bridged creds crossed in by bp-mgmt-vcluster's
+  # sync.fromHost mapping `gitea/gitea-oauth-source-credentials`. Default true
+  # → on a non-host-bridged prov the render is byte-identical to before.
+  externalSecret:
+    enabled: true
   # Keycloak realm. Defaults to the shared-sovereign realm shipped by
   # platform/keycloak/chart/templates/configmap-sovereign-realm.yaml.
   realm: sovereign

--- a/platform/harbor/blueprint.yaml
+++ b/platform/harbor/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-5-storage-and-data
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.33
+  version: 1.2.34
   card:
     title: Harbor
     family: foundation

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -111,7 +111,18 @@ type: application
 #       `/service/token` untouched (401 auth-challenge, not redirected).
 #       PROVEN GREEN: probe landed registry.<fqdn>/harbor/projects
 #       signed-in on hw167.
-version: 1.2.33
+# 1.2.34 (#3934 / Refs #3642, 2026-06-20): SPLIT-GATE for the mgmt-vCluster
+# host-bridge. The #3642 promotion of harbor into the mgmt vCluster set
+# placement.yaml hostBridge.suppress `sso.enabled: false`, which ALSO killed
+# the 1.2.33 sso-configure Deployment — so auth_mode was never PUT to oidc_auth
+# and the bare registry URL showed the local-DB sign-in form (caught live
+# hw171 2026-06-19, /api/v2.0/systeminfo auth_mode=db_auth). New value
+# sso.externalSecret.enabled (default true) gates the chart's ExternalSecret
+# independently; the Deployment stays gated on sso.enabled. Host-bridge sets
+# externalSecret.enabled:false (host renders harbor-sso-oidc-credentials) while
+# sso.enabled stays true so the configurator runs IN the vCluster against
+# harbor-core. Non-host-bridged render byte-identical. Refs #3374 #3642.
+version: 1.2.34
 appVersion: "2.14.3"
 # 1.2.23 (G117.5 #2744, 2026-06-02): SSO defense-in-depth via Harbor's
 # `oidc_extra_redirect_parms` config field. The configure-oauth Job now

--- a/platform/harbor/chart/templates/sso-oauth-source-externalsecret.yaml
+++ b/platform/harbor/chart/templates/sso-oauth-source-externalsecret.yaml
@@ -33,7 +33,20 @@ resource is simply omitted until the CRD exists, then re-rendered on the next
 Flux reconcile (Capabilities re-evaluated every reconcile) so SSO wiring
 self-heals with zero manual touch.
 */}}
-{{- if and .Values.sso.enabled (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1") }}
+{{- /*
+#3934 (Refs #3642): split-gate. When harbor is host-bridged into the mgmt
+vCluster, the HOST renders this ExternalSecret (ESO + the OpenBao
+ClusterSecretStore are host resources). placement.yaml's hostBridge.suppress
+sets `sso.externalSecret.enabled: false` so the chart does NOT render an
+in-vCluster duplicate — WITHOUT disabling `sso.enabled`, which still renders
+the sso-configure Deployment IN the vCluster (it PUTs auth_mode=oidc_auth to
+harbor-core's /api/v2.0/configurations; its creds arrive via the
+bp-mgmt-vcluster fromHost crossing of `harbor-sso-oidc-credentials`).
+Default true → non-host-bridged render is byte-identical.
+*/}}
+{{- $esEnabled := true }}
+{{- if .Values.sso.externalSecret }}{{- if hasKey .Values.sso.externalSecret "enabled" }}{{- $esEnabled = .Values.sso.externalSecret.enabled }}{{- end }}{{- end }}
+{{- if and .Values.sso.enabled $esEnabled (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1") }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:

--- a/platform/harbor/chart/values.yaml
+++ b/platform/harbor/chart/values.yaml
@@ -447,6 +447,15 @@ harborOverlay:
 # remains as the break-glass account for Sovereign-recovery scenarios.
 sso:
   enabled: true
+  # #3934 (Refs #3642): split-gate for the host-bridge (mgmt-vCluster)
+  # placement. Host-bridged → the HOST renders the harbor-sso-oidc-credentials
+  # ExternalSecret; placement.yaml's hostBridge.suppress sets
+  # `externalSecret.enabled: false` so the chart skips the in-vCluster copy,
+  # while `sso.enabled` stays true so the sso-configure Deployment (which PUTs
+  # auth_mode=oidc_auth) still renders in the vCluster alongside harbor-core.
+  # Default true → non-host-bridged render byte-identical.
+  externalSecret:
+    enabled: true
   realm: sovereign
   # Per-Sovereign cluster overlay sets this (e.g. `hw86.omani.works`).
   # When empty the configure-oauth Job is suppressed so a half-configured

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2881,7 +2881,18 @@ name: bp-catalyst-platform
 # 1.4.695 — #3849 (Refs #3848): org-controller reads the keycloak SA secret from
 # the host-bridge (catalyst-openova-kc-credentials) instead of an intra-release
 # helm lookup that lost the ordering race on a cold install.
-version: 1.4.716
+# 1.4.717 — #3934 (Refs #3642): baseline-default-deny CNP for catalyst-system
+# adds `mgmt` to allowedIngressNamespaces. The #3642 host-bridge promotes
+# guacamole into the mgmt vCluster (webapp Pod re-homes to host ns `mgmt`)
+# while its CNPG DB guacamole-pg stays in catalyst-system — the baseline
+# dropped webapp→guacamole-pg:5432, the postgresql auth provider halted, and
+# /guacamole/api/session 403'd (blank page, caught live hw171). Also split-gates
+# the gitea/harbor sso-configure Deployment on .Values.sso.externalSecret.enabled
+# so the #3642 mgmt-vCluster pivot stops breaking gitea/harbor SSO-landing.
+# Catalyst-Zero render adds one namespace to one ingress matchExpression (no
+# behavior change on a host-placed guacamole). Renumbered past the deploy-bot
+# auto-bump to 1.4.717 (one above main's 1.4.716) to clear the pin collision.
+version: 1.4.717
 # 1.4.702 — #3819 #3854 #3859 (Refs #3383 #3376): sme→org-services rename TAIL — the
 #   funnel/BSS control-plane templates + values default the namespace to `org-services`
 #   instead of the dead `sme` ns: provisioning-github-token / valkey-cross-ns-secret +

--- a/products/catalyst/chart/templates/network-policies/baseline-catalyst-system.yaml
+++ b/products/catalyst/chart/templates/network-policies/baseline-catalyst-system.yaml
@@ -82,7 +82,17 @@ when qaFixtures is disabled.
      BSS/funnel control-plane Deployments; the legacy `sme` entry stays one
      release for back-compat / any not-yet-migrated Sovereign. */}}
 {{- $allowedPlatform := .Values.security.baselineCnp.allowedPlatformNamespaces | default (list "keycloak" "gitea" "powerdns" "cnpg-system" "openbao" "harbor" "nats-system" "loki" "mimir" "tempo" "alloy" "opentelemetry" "external-secrets-system" "cert-manager" "org-services" "sme" "newapi" "mgmt") }}
-{{- $allowedIngressNs := .Values.security.baselineCnp.allowedIngressNamespaces | default (list "catalyst" "flux-system" "kube-system" "oidc-gate") }}
+{{- /* #3934 (Refs #3642): "mgmt" added to the INGRESS allow-list. The #3642
+     host-bridge promotes guacamole INTO the mgmt vCluster — its webapp Pod
+     now runs in host ns `mgmt` (synced `guacamole-server-x-catalyst-system-x-
+     mgmt-vcluster`) while its CNPG DB `guacamole-pg` stays host-rendered in
+     `catalyst-system`. With `mgmt` absent here this baseline default-deny
+     dropped the webapp→guacamole-pg:5432 connection → the postgresql auth
+     provider halted → /guacamole/api/session 403, blank page (caught live
+     hw171 2026-06-19). gitea-pg / harbor-pg sit in their OWN host namespaces
+     (gitea/harbor), already in $allowedPlatform's EGRESS list, so this single
+     INGRESS add covers the only DB that re-homed to catalyst-system. */}}
+{{- $allowedIngressNs := .Values.security.baselineCnp.allowedIngressNamespaces | default (list "catalyst" "flux-system" "kube-system" "oidc-gate" "mgmt") }}
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -2190,11 +2190,22 @@ security:
     #     proxied request — oidc-gate authenticates the User but the
     #     app 502s on upstream timeout (hw133 #813, fresh prov
     #     2026-06-14; same isolation class as the sme→NATS #3423 block).
+    #   - mgmt (#3934 / Refs #3642) — the #3642 host-bridge promotes
+    #     guacamole INTO the mgmt vCluster: its webapp Pod runs in host ns
+    #     `mgmt` (synced `guacamole-server-x-catalyst-system-x-mgmt-vcluster`)
+    #     while its CNPG DB `guacamole-pg` stays host-rendered in
+    #     catalyst-system. Without `mgmt` here the baseline default-deny
+    #     dropped webapp→guacamole-pg:5432 → the postgresql auth provider
+    #     halted → /guacamole/api/session 403, blank page (caught live hw171
+    #     2026-06-19). The other re-homed apps' DBs (gitea-pg, harbor-pg)
+    #     live in their own host namespaces, not catalyst-system, so this
+    #     single ingress entry is the complete fix for the catalyst-system DB.
     allowedIngressNamespaces:
       - catalyst
       - flux-system
       - kube-system
       - oidc-gate
+      - mgmt
 
 # ── Migrations (post-install / post-upgrade Helm-hook Jobs) ──────────────
 # Per PR #2795 (G117.2 multi-instance Application CRD): backfill spec.instanceId


### PR DESCRIPTION
## Summary
The #3642 host→mgmt-vCluster promotion regressed 4 SSO-landing surfaces (north-star #3: open any app URL → land signed-in as admin). Root-caused **live on hw171** (dep `3963e9267c10a90d`). grafana + openbao still land fine; these 4 are real regressions. Refs #3374 #3642 #3150. Closes-tracker #3934.

## Grounded root causes (each with the failing log/config line)

| App | Live symptom | Root cause |
|---|---|---|
| **gitea** | bare URL → `/user/oauth2/openova-sso` → **HTTP 500** | gitea log `auth/oauth.go:872` `SignIn: oauth2 source not found, name: openova-sso`; `gitea admin auth list` **empty**. placement.yaml `hostBridge.suppress: {sso.enabled: false}` killed the chart's sso-configure Deployment — the ONLY actor that runs `gitea admin auth add-oauth` to seed the `login_source` DB row. The host-bridge delivered the cred Secret (`gitea-oauth-source-credentials`, present) but nothing seeded the row. |
| **harbor** | `registry.<fqdn>/harbor/projects` shows a **login form** | `/api/v2.0/systeminfo` → `auth_mode: db_auth`. Same `sso.enabled: false` suppress killed the harbor-sso-configure Deployment that PUTs `auth_mode=oidc_auth` to `/api/v2.0/configurations`. |
| **guacamole** | SPA loads, `/guacamole/api/session` → **403**, blank | guacamole-server log `PSQLException: connection attempt failed`. The re-homed pod (host ns `mgmt`) TCP-times-out to `guacamole-pg-rw.catalyst-system.svc:5432` → postgresql auth provider halts → 403. The catalyst-system `baseline-default-deny` CNP ingress allow-list omits `mgmt`. |
| **keycloak account-console** | `auth.<fqdn>/realms/sovereign/account` → **'Something went wrong'** | browser-flow `catalyst-pin-redirector` has `defaultProvider: catalyst-pin` → account-console (no kc_idp_hint / no session cookie) bounces to the catalyst-pin IdP → HTTP **400 `cookie_not_found`**. |

## Fix
- **bp-gitea 1.2.38→1.2.39 / bp-harbor 1.2.33→1.2.34**: new `sso.externalSecret.enabled` value (default **true**) gates the chart's ExternalSecret independently of `sso.enabled`. Host-bridge sets `externalSecret.enabled:false` (host owns the Secret) while `sso.enabled` stays true → the sso-configure Deployment renders **inside the vCluster** alongside the app pod (where its kubectl-exec / API-PUT belongs; its creds already cross in via bp-mgmt-vcluster `sync.fromHost`). Non-host-bridged render is **byte-identical**.
- **placement.yaml** (slots 10-gitea, 19-harbor): suppress flips `sso.enabled:false` → `sso.externalSecret.enabled:false`; `sso.enabled` reverted to chart-default true in the rendered slots. `render-slot-placement.py check` PASSES.
- **bp-catalyst-platform 1.4.713→1.4.714**: `security.baselineCnp.allowedIngressNamespaces` += `mgmt` so the mgmt-vCluster-resident guacamole webapp can reach its host-rendered `guacamole-pg` DB. (gitea-pg/harbor-pg live in their own host namespaces, already egress-allowed — only guacamole's DB re-homed to catalyst-system.)
- **account-console**: intentionally NOT changed — `defaultProvider: catalyst-pin` is load-bearing for the app zero-click SSO that IS north-star #3. The account-console 'Something went wrong' only manifests on a cold nav without a KC session; it lands fine once a session exists. Documented as a secondary-surface limitation in #3934.

## Validation (env-independent)
- helm template gitea+harbor in **host-bridge mode** → sso-configure Deployment renders, ExternalSecret suppressed; **default mode** → both render (byte-identical).
- All chart-publish-gate tests PASS: gitea 6/6, harbor 5/5 (incl. `g117-5-sso-tier1`).
- `render-slot-placement.py check` PASSES (65 slots).
- baseline CNP renders `mgmt` in the catalyst-system ingress matchExpression.

## Needs a live deploy to fully verify
The fixes are config/chart; a fresh prov (or a chart roll on hw171) is needed to confirm the gitea login_source row seeds, harbor flips to oidc_auth, and guacamole reaches its DB. Per CLAUDE.md the merged PR is the permanent artifact; the live walk re-verifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)