### PR TITLE
fix(catalyst-api): AppDetail Resources/Logs tabs resolve mgmt-vCluster synced resources post-#3642

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications.go
@@ -1810,6 +1810,102 @@ func routeNamespaceMatchesApp(routeNS, targetNS string) bool {
 	return false
 }
 
+// loft-sh / vCluster syncer annotation keys. When the per-tier vCluster
+// (#3642) syncs an in-vCluster resource down to its HOST namespace
+// (mgmt/dmz/rtz), it MANGLES the host name (`<name>-x-<vcns>-x-<vcluster>`,
+// truncated + hash-suffixed when too long) and stamps the authoritative
+// in-vCluster identity onto these annotations. We read them rather than
+// reverse-parsing the mangled name because the syncer truncates long names
+// and replaces the suffix with a hash (e.g.
+// `mimir-overrides-exporter-…-x-mimir-x--2baf76f56f`,
+// `guacamole-server-…-x-catalyst-system-x-533a6f8601`), so a pure
+// string-suffix parse is unreliable. The annotations are exact.
+const (
+	loftObjectNamespaceAnno = "vcluster.loft.sh/object-namespace"
+	loftObjectNameAnno      = "vcluster.loft.sh/object-name"
+	loftHostNamespaceAnno   = "vcluster.loft.sh/object-host-namespace"
+)
+
+// vClusterSyncedObjectNamespace returns the in-vCluster namespace a host
+// object was synced from (via the loft annotation), but ONLY when the
+// object actually lives in a known vCluster HOST sync namespace
+// (mgmt/dmz/rtz). For any object NOT in a sync namespace it returns "" —
+// so a non-vCluster object can never be reattributed to a different
+// namespace. This is the namespace-scoping guard that mirrors
+// routeNamespaceMatchesApp: we widen the lookup ONLY across the
+// deterministic sync namespaces, never arbitrarily.
+//
+// Returns "" when the object is nil, not in a sync namespace, or carries
+// no object-namespace annotation (a host-native object in mgmt/dmz/rtz,
+// e.g. the vcluster statefulset itself, has no such annotation).
+func vClusterSyncedObjectNamespace(obj *unstructured.Unstructured) string {
+	if obj == nil {
+		return ""
+	}
+	hostNS := obj.GetNamespace()
+	inSyncNS := false
+	for _, syncNS := range vClusterHostSyncNamespaces {
+		if hostNS == syncNS {
+			inSyncNS = true
+			break
+		}
+	}
+	if !inSyncNS {
+		return ""
+	}
+	anns := obj.GetAnnotations()
+	// Prefer the explicit object-host-namespace cross-check: only trust
+	// the object-namespace mapping when the syncer agrees the host
+	// namespace is this object's host landing zone. When the host-ns
+	// annotation is absent (older syncer) fall back to object-namespace
+	// alone — still gated by inSyncNS above.
+	if hn := anns[loftHostNamespaceAnno]; hn != "" && hn != hostNS {
+		return ""
+	}
+	return anns[loftObjectNamespaceAnno]
+}
+
+// vClusterSyncedDisplayName returns the de-mangled, in-vCluster object name
+// for a host-synced object (from the loft annotation), or "" when the
+// object is nil / not a synced object / carries no name annotation. Used to
+// surface the real name the operator knows (`gitea-75d9f486fb-g8hsr`)
+// instead of the mangled host name
+// (`gitea-75d9f486fb-g8hsr-x-gitea-x-mgmt-vcluster`).
+func vClusterSyncedDisplayName(obj *unstructured.Unstructured) string {
+	if obj == nil {
+		return ""
+	}
+	return obj.GetAnnotations()[loftObjectNameAnno]
+}
+
+// objectInAppNamespace decides whether a host object belongs to the app
+// installed in `targetNS`, accounting for the #3642 host→mgmt-vCluster
+// migration. It matches when EITHER:
+//
+//	(a) the object's own host namespace equals targetNS (pre-#3642
+//	    invariant — the app and its resources share a host namespace), OR
+//	(b) the object is synced from a per-tier vCluster (mgmt/dmz/rtz) and
+//	    its authoritative in-vCluster namespace (loft annotation) equals
+//	    targetNS — the post-#3642 case where the app's
+//	    `spec.targetNamespace` is the IN-vCluster namespace (gitea/grafana/
+//	    openbao/…) but the host-synced pods/services/etc. land in `mgmt`.
+//
+// The widening is strictly scoped: (b) only fires for objects already
+// living in a known sync namespace whose loft annotation matches targetNS,
+// so an unrelated object in another namespace can never false-positive
+// onto this app. This is the AppDetail Resources/Logs sibling of #3933's
+// routeNamespaceMatchesApp fix — same #3642 family, applied to the generic
+// resource-list namespace filter.
+func objectInAppNamespace(obj *unstructured.Unstructured, targetNS string) bool {
+	if obj == nil || targetNS == "" {
+		return false
+	}
+	if obj.GetNamespace() == targetNS {
+		return true
+	}
+	return vClusterSyncedObjectNamespace(obj) == targetNS
+}
+
 // lookupExternalURL — G90 2026-06-01.
 //
 // Resolve the operator-visible front-door URL for an installed Application

--- a/products/catalyst/bootstrap/api/internal/handler/applications_vcluster_resources_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_vcluster_resources_test.go
@@ -1,0 +1,223 @@
+// applications_vcluster_resources_test.go — #3931 (#3642 sibling).
+//
+// Coverage for the AppDetail Resources/Logs tab fix: after #3642 the
+// front-door apps (gitea/grafana/harbor/keycloak/openbao/newapi/guacamole)
+// moved INTO the per-tier `mgmt` vCluster. The loft-sh syncer mirrors each
+// in-vCluster Pod/Service/etc. down to the HOST under sync namespace `mgmt`
+// with a MANGLED name (`<name>-x-<vcns>-x-<vcluster>`, truncated +
+// hash-suffixed when long) and stamps the authoritative in-vCluster
+// identity onto `vcluster.loft.sh/object-*` annotations.
+//
+// The AppDetail Resources tab queries `GET /k8s/{kind}?namespace=<app
+// targetNamespace>` (e.g. `gitea`); pre-#3931 the host namespace filter
+// required `metadata.namespace == gitea`, so every mgmt-synced row was
+// stripped → the tab came back empty for EVERY mgmt-vCluster app even
+// though their pods are Running. objectInAppNamespace widens the match to
+// the deterministic sync namespaces (mgmt/dmz/rtz) via the loft
+// annotation, and the flatten step surfaces the de-mangled display name.
+package handler
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// mgmtSyncedGiteaPod mirrors the real hw171 host object: a gitea Pod synced
+// from the in-vCluster `gitea` namespace into host ns `mgmt` with the loft
+// mangled name + authoritative object-* annotations.
+func mgmtSyncedGiteaPod() *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name":      "gitea-75d9f486fb-g8hsr-x-gitea-x-mgmt-vcluster",
+			"namespace": "mgmt",
+			"annotations": map[string]any{
+				"vcluster.loft.sh/object-namespace":      "gitea",
+				"vcluster.loft.sh/object-name":           "gitea-75d9f486fb-g8hsr",
+				"vcluster.loft.sh/object-host-namespace": "mgmt",
+			},
+			"labels": map[string]any{
+				"app.kubernetes.io/instance": "gitea",
+			},
+		},
+		"status": map[string]any{"phase": "Running"},
+	}}
+}
+
+func TestVClusterSyncedObjectNamespace(t *testing.T) {
+	cases := []struct {
+		name string
+		obj  *unstructured.Unstructured
+		want string
+	}{
+		{
+			name: "mgmt-synced gitea pod resolves to in-vcluster namespace",
+			obj:  mgmtSyncedGiteaPod(),
+			want: "gitea",
+		},
+		{
+			name: "nil object yields empty",
+			obj:  nil,
+			want: "",
+		},
+		{
+			// A host-native object in a NON-sync namespace must never be
+			// reattributed, even if it somehow carries the annotation.
+			name: "object in non-sync namespace is never reattributed",
+			obj: &unstructured.Unstructured{Object: map[string]any{
+				"metadata": map[string]any{
+					"name":      "some-pod",
+					"namespace": "default",
+					"annotations": map[string]any{
+						"vcluster.loft.sh/object-namespace": "gitea",
+					},
+				},
+			}},
+			want: "",
+		},
+		{
+			// A host-native object that genuinely lives in the sync
+			// namespace (e.g. the vcluster statefulset itself) carries no
+			// object-namespace annotation → no reattribution.
+			name: "host-native object in mgmt with no annotation yields empty",
+			obj: &unstructured.Unstructured{Object: map[string]any{
+				"metadata": map[string]any{
+					"name":      "mgmt-vcluster-0",
+					"namespace": "mgmt",
+				},
+			}},
+			want: "",
+		},
+		{
+			// Defensive: the host-namespace cross-check must reject a
+			// mismatched/forged object-host-namespace.
+			name: "mismatched object-host-namespace rejected",
+			obj: &unstructured.Unstructured{Object: map[string]any{
+				"metadata": map[string]any{
+					"name":      "x-x-y-x-mgmt-vcluster",
+					"namespace": "mgmt",
+					"annotations": map[string]any{
+						"vcluster.loft.sh/object-namespace":      "gitea",
+						"vcluster.loft.sh/object-host-namespace": "dmz",
+					},
+				},
+			}},
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := vClusterSyncedObjectNamespace(tc.obj); got != tc.want {
+				t.Fatalf("vClusterSyncedObjectNamespace() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestVClusterSyncedDisplayName(t *testing.T) {
+	if got := vClusterSyncedDisplayName(mgmtSyncedGiteaPod()); got != "gitea-75d9f486fb-g8hsr" {
+		t.Fatalf("display name de-mangle = %q, want %q", got, "gitea-75d9f486fb-g8hsr")
+	}
+	if got := vClusterSyncedDisplayName(nil); got != "" {
+		t.Fatalf("nil object display name = %q, want empty", got)
+	}
+	// An object with no loft name annotation has no de-mangled name.
+	plain := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{"name": "gitea-pg-1", "namespace": "gitea"},
+	}}
+	if got := vClusterSyncedDisplayName(plain); got != "" {
+		t.Fatalf("non-synced object display name = %q, want empty", got)
+	}
+}
+
+// TestObjectInAppNamespace is the core of the #3931 fix: the namespace
+// filter the AppDetail Resources/Logs tabs depend on must match BOTH the
+// pre-#3642 same-namespace case AND the post-#3642 mgmt-synced case,
+// scoped strictly to the sync namespaces.
+func TestObjectInAppNamespace(t *testing.T) {
+	// In-vCluster CNPG pod that genuinely lives in host ns `gitea`
+	// (database pods are NOT synced through the vCluster — they run on the
+	// host under the app's targetNamespace). Pre-#3642 invariant path.
+	giteaPGHost := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{"name": "gitea-pg-1", "namespace": "gitea"},
+	}}
+	// A grafana pod synced into mgmt — belongs to the grafana app, NOT gitea.
+	grafanaSynced := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{
+			"name":      "grafana-54cbc744cf-96nhh-x-grafana-x-mgmt-vcluster",
+			"namespace": "mgmt",
+			"annotations": map[string]any{
+				"vcluster.loft.sh/object-namespace":      "grafana",
+				"vcluster.loft.sh/object-host-namespace": "mgmt",
+			},
+		},
+	}}
+
+	cases := []struct {
+		name     string
+		obj      *unstructured.Unstructured
+		targetNS string
+		want     bool
+	}{
+		{"mgmt-synced gitea pod matches gitea app", mgmtSyncedGiteaPod(), "gitea", true},
+		{"host-native gitea-pg matches gitea app (pre-#3642 path)", giteaPGHost, "gitea", true},
+		{"mgmt-synced grafana pod does NOT match gitea app", grafanaSynced, "gitea", false},
+		{"mgmt-synced gitea pod does NOT match grafana app", mgmtSyncedGiteaPod(), "grafana", false},
+		{"empty targetNS matches nothing", mgmtSyncedGiteaPod(), "", false},
+		{"nil object matches nothing", nil, "gitea", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := objectInAppNamespace(tc.obj, tc.targetNS); got != tc.want {
+				t.Fatalf("objectInAppNamespace(_, %q) = %v, want %v", tc.targetNS, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFlattenK8sListItems_VClusterDisplayName verifies the list-row
+// projection: a mgmt-synced row keeps its HOST metadata coordinates (so
+// the Logs/tree drill-down resolves against the host apiserver) AND
+// surfaces the de-mangled in-vCluster identity for rendering.
+func TestFlattenK8sListItems_VClusterDisplayName(t *testing.T) {
+	items := []*unstructured.Unstructured{mgmtSyncedGiteaPod()}
+	out := flattenK8sListItems("pod", items)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(out))
+	}
+	row := out[0].Object
+
+	// Host coordinates preserved for drill-down.
+	gotName, _, _ := unstructured.NestedString(row, "metadata", "name")
+	if gotName != "gitea-75d9f486fb-g8hsr-x-gitea-x-mgmt-vcluster" {
+		t.Fatalf("metadata.name = %q, want host mangled name", gotName)
+	}
+	gotNS, _, _ := unstructured.NestedString(row, "metadata", "namespace")
+	if gotNS != "mgmt" {
+		t.Fatalf("metadata.namespace = %q, want host ns mgmt", gotNS)
+	}
+
+	// De-mangled identity surfaced for the UI.
+	if dn, _ := row["displayName"].(string); dn != "gitea-75d9f486fb-g8hsr" {
+		t.Fatalf("row displayName = %q, want de-mangled in-vcluster name", dn)
+	}
+	if vcNS, _ := row["vclusterNamespace"].(string); vcNS != "gitea" {
+		t.Fatalf("row vclusterNamespace = %q, want gitea", vcNS)
+	}
+
+	// A non-synced host row must NOT carry the display fields.
+	plain := []*unstructured.Unstructured{{Object: map[string]any{
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": map[string]any{"name": "gitea-pg-1", "namespace": "gitea"},
+		"status":   map[string]any{"phase": "Running"},
+	}}}
+	pout := flattenK8sListItems("pod", plain)[0].Object
+	if _, ok := pout["displayName"]; ok {
+		t.Fatalf("non-synced row must not carry displayName")
+	}
+	if _, ok := pout["vclusterNamespace"]; ok {
+		t.Fatalf("non-synced row must not carry vclusterNamespace")
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/k8s.go
+++ b/products/catalyst/bootstrap/api/internal/handler/k8s.go
@@ -217,11 +217,25 @@ func (h *Handler) HandleK8sList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Namespace pre-filter (cheap; before SAR loop).
+	//
+	// #3931 (#3642 sibling): a request for ns=<app targetNamespace> must
+	// ALSO surface the app's resources that the per-tier vCluster syncer
+	// mirrored onto the HOST under a sync namespace (mgmt/dmz/rtz). Those
+	// rows have `metadata.namespace=mgmt` but the authoritative
+	// `vcluster.loft.sh/object-namespace` annotation equals the requested
+	// in-vCluster namespace (e.g. `gitea`). objectInAppNamespace matches
+	// both the pre-#3642 same-namespace case AND the post-#3642 synced
+	// case, strictly scoped to the known sync namespaces — so the
+	// AppDetail Resources/Logs tabs stop coming back empty for every
+	// mgmt-vCluster app. We KEEP the host coordinates on each row
+	// (metadata.{name,namespace}) so the Logs/tree drill-down still
+	// resolves against the host apiserver; the de-mangled display name is
+	// surfaced separately in the flatten step.
 	if ns != "" {
 		fItems := items[:0]
 		fClusters := itemClusters[:0]
 		for i, it := range items {
-			if it.GetNamespace() == ns {
+			if objectInAppNamespace(it, ns) {
 				fItems = append(fItems, it)
 				fClusters = append(fClusters, itemClusters[i])
 			}
@@ -385,7 +399,7 @@ func flattenK8sListItemsWithClusters(kind string, items []*unstructured.Unstruct
 		// Shallow-copy the source map so we can decorate without
 		// mutating the cached Unstructured (the Indexer hands out the
 		// same pointer to every reader).
-		base := make(map[string]interface{}, len(it.Object)+6)
+		base := make(map[string]interface{}, len(it.Object)+8)
 		for k, v := range it.Object {
 			base[k] = v
 		}
@@ -399,6 +413,25 @@ func flattenK8sListItemsWithClusters(kind string, items []*unstructured.Unstruct
 			base["region"] = region
 		} else if region := it.GetLabels()["topology.kubernetes.io/region"]; region != "" {
 			base["region"] = region
+		}
+		// #3931 (#3642 sibling): for a per-tier vCluster (mgmt/dmz/rtz)
+		// host-synced object, surface the DE-MANGLED in-vCluster identity
+		// so the AppDetail Resources tab renders the real name the
+		// operator knows (`gitea-75d9f486fb-g8hsr`) instead of the loft
+		// syncer's mangled host name
+		// (`gitea-75d9f486fb-g8hsr-x-gitea-x-mgmt-vcluster`). The embedded
+		// `metadata.{name,namespace}` deliberately STAY the host
+		// coordinates — the Logs (`/k8s/logs/{ns}/{pod}/...`) and
+		// resource-tree (`/k8s/{kind}/{ns}/{name}/tree`) drill-downs
+		// resolve against the HOST apiserver (the mothership holds only
+		// the host kubeconfig), so they need `mgmt` + the mangled name.
+		// The SPA prefers `displayName`/`vclusterNamespace` for rendering
+		// and uses `metadata` for the drill-down hrefs.
+		if vcNS := vClusterSyncedObjectNamespace(it); vcNS != "" {
+			base["vclusterNamespace"] = vcNS
+			if dn := vClusterSyncedDisplayName(it); dn != "" {
+				base["displayName"] = dn
+			}
 		}
 		switch k8scache.CanonicalKindName(kind) {
 		case "pod":


### PR DESCRIPTION
## Problem (sibling of #3933, same #3642 family)

#3933 fixed the AppDetail **Open button + Topology placement** for mgmt-vCluster apps. This PR fixes the **sibling regression** the #3931 body explicitly flagged ("Audit for sibling host-side lookups the #3642 move breaks the same way"): the AppDetail **Resources** and **Logs** tabs are **EMPTY** for every mgmt-vCluster app.

### Live root cause (confirmed on hw171, dep `3963e9267c10a90d`, via mothership catalyst-api)

Post-#3642 the 7 front-door apps (gitea/grafana/harbor/keycloak/openbao/newapi/guacamole) moved INTO the `mgmt` vCluster. The loft-sh syncer mirrors each in-vCluster Pod/Service/etc. down to the **HOST** under sync namespace `mgmt` with a **mangled name** and stamps the authoritative in-vCluster identity onto `vcluster.loft.sh/object-*` annotations:

```
# host ns mgmt — the actual gitea workload pod (mangled)
gitea-75d9f486fb-g8hsr-x-gitea-x-mgmt-vcluster   1/1 Running
  vcluster.loft.sh/object-namespace      = gitea
  vcluster.loft.sh/object-name           = gitea-75d9f486fb-g8hsr
  vcluster.loft.sh/object-host-namespace = mgmt

# host ns gitea (= app spec.targetNamespace) — only the CNPG pod, NOT the workload
gitea-pg-1   1/1 Running
```

The Resources tab queries `GET /k8s/{kind}?namespace=gitea`. `HandleK8sList`'s namespace pre-filter required `metadata.namespace == gitea`, so **every mgmt-synced row was stripped → empty tab**. The Logs tab couldn't resolve either (handed `targetNamespace=gitea`, but the pod only exists in `mgmt` under the mangled name).

Key constraint: the mothership holds **only the HOST kubeconfig** (`server: https://212.72.24.6:6443`). Logs/tree resolve ONLY via host coords (`mgmt` + mangled name); the de-mangled name does **not** resolve on the host.

## Fix (mirrors #3933 `routeNamespaceMatchesApp`, scoped to mgmt/dmz/rtz)

- **`objectInAppNamespace`** (`applications.go`) — namespace filter matches BOTH the pre-#3642 same-namespace case AND the post-#3642 synced case, keyed off the authoritative `vcluster.loft.sh/object-namespace` annotation (read, not reverse-parsed — the syncer truncates+hashes long names, e.g. `…-x-mimir-x--2baf76f56f`). Strictly scoped: only fires for objects already in a known sync namespace, with a host-namespace cross-check, so unrelated/cross-app objects can never false-positive.
- **`HandleK8sList`** (`k8s.go`) — pre-filter uses `objectInAppNamespace`. Each row's `metadata.{name,namespace}` is **preserved as the HOST coords** so the Logs (`/k8s/logs/{ns}/{pod}`) + resource-tree (`/k8s/{kind}/{ns}/{name}/tree`) drill-downs keep working against the host apiserver.
- **flatten step** surfaces de-mangled `displayName` + `vclusterNamespace` so the UI renders the real in-vCluster name (`gitea-75d9f486fb-g8hsr`) instead of the mangled host name.

Generalizes across all front-door apps — every synced pod/service carries the annotations (verified live: gitea/grafana/harbor/keycloak/openbao + guacamole's `catalyst-system` targetNS).

## Tests
- New `applications_vcluster_resources_test.go`: mgmt-mirrored pod resolves to its app + display-name de-mangled; unrelated-ns / cross-app / host-native / mismatched-host-ns objects excluded; list-row keeps host coords while surfacing display fields.
- `go build ./...` + `go vet ./...` + full handler suite green.

## Verification path (post-roll on a fresh mgmt-vCluster prov)
Open AppDetail for any mgmt-vCluster app (e.g. bp-gitea) → Resources tab lists the Running pods/services with clean names; click a pod → Logs tab streams. Empty tabs = FAIL.

Refs #3642 #3646 #3687 #3931

🤖 Generated with [Claude Code](https://claude.com/claude-code)