### PR TITLE
fix(catalyst-console): topology placement-edit dropdown derives mode descriptions from the per-component matrix (openbao active-passive no longer says 'backup-restore') (Refs #3905) — re-cut of #3907

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.tsx
@@ -29,8 +29,8 @@ import {
 import { listOrganizations, type OrgRow } from '@/lib/organizations.api'
 import { getHierarchicalInfrastructure } from '@/lib/infrastructure.types'
 import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
-import { ALL_MODES, canonicalizeMode, describeMode } from '@/widgets/topology/TopologyEditor'
-import { BLUEPRINT_BY_ID } from '@/shared/constants/catalog.generated'
+import { ALL_MODES, canonicalizeMode, describeModeForComponent } from '@/widgets/topology/TopologyEditor'
+import { BLUEPRINT_BY_ID, TOPOLOGY_BY_ID } from '@/shared/constants/catalog.generated'
 
 // #3599 / #3600 — the vCluster/zone options the catalyst-api backend
 // validates (`placement.vcluster ∈ {host, mgmt, dmz, rtz}`,
@@ -581,6 +581,12 @@ export function NewInstanceDialog({
 
   const requiresMultiRegion = MULTI_REGION_MODES.has(topology)
 
+  // #3905 — the per-component topology matrix (same source the declared-
+  // topology card reads) so the instance-create mode picker derives each
+  // mode's helper text from THIS component's DR contract, never the generic
+  // "backup-restore" string that contradicted the card.
+  const componentTopology = TOPOLOGY_BY_ID[`bp-${bpName}`] ?? TOPOLOGY_BY_ID[bpName]
+
   // #3370 — required backing services (declared depends[] that are
   // themselves shareable). One generic selector each.
   const backingBlueprints = useMemo<string[]>(() => {
@@ -764,7 +770,7 @@ export function NewInstanceDialog({
               const enabled = allowedModeSet.has(m)
               return (
                 <option key={m} value={m} disabled={!enabled}>
-                  {m} — {describeMode(m)}
+                  {m} — {describeModeForComponent(m, componentTopology)}
                   {enabled ? '' : ' (not supported by this blueprint)'}
                 </option>
               )

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
@@ -443,6 +443,11 @@ export function TopologyTab({
         namespace={namespace}
         blueprint={blueprint}
         supportedCanonical={declaredTopology?.supported}
+        // #3905 — feed the SAME per-component topology matrix the card reads
+        // so the edit dropdown's per-mode helper text derives from the
+        // component's real DR contract (replication + switchover), never the
+        // generic "backup-restore" string that contradicted the card.
+        topology={declaredTopology}
         disableNetwork={disableNetwork}
         onApplied={() => {
           setRefreshTick((t) => t + 1)

--- a/products/catalyst/bootstrap/ui/src/widgets/topology/TopologyEditor.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/topology/TopologyEditor.test.tsx
@@ -14,7 +14,8 @@ import { describe, it, expect, afterEach } from 'vitest'
 import { render, screen, cleanup, fireEvent } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
-import { TopologyEditor } from './TopologyEditor'
+import { TopologyEditor, describeModeForComponent } from './TopologyEditor'
+import { TOPOLOGY_BY_ID } from '@/shared/constants/catalog.generated'
 
 function withProviders(node: React.ReactNode) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
@@ -134,6 +135,69 @@ describe('TopologyEditor — preview', () => {
     fireEvent.click(screen.getByTestId('topology-editor-region-hz-hel-rtz-prod-checkbox'))
     fireEvent.click(screen.getByTestId('topology-editor-preview-btn'))
     expect(screen.getByTestId('topology-editor-preview-modal')).toBeTruthy()
+  })
+})
+
+describe('TopologyEditor — matrix-derived mode descriptions (#3905)', () => {
+  // The exact bug the founder flagged: the card derived openbao's
+  // active-passive as `raft · async` warm-standby from the topology matrix,
+  // while the edit dropdown printed a GENERIC "…(backup-restore)" string for
+  // every component. The dropdown now reads the SAME matrix, so its
+  // active-passive helper text must mirror the matrix contract and never say
+  // "backup-restore".
+  const openbaoTopology = TOPOLOGY_BY_ID['bp-openbao']
+
+  it('the openbao active-passive option derives raft/async/raft-transition from the matrix (no backup-restore)', () => {
+    expect(openbaoTopology).toBeTruthy()
+    render(
+      withProviders(
+        <TopologyEditor
+          sovereignId="dep-1"
+          applicationName="openbao"
+          currentMode="active-passive"
+          currentRegions={['mgmt-A']}
+          availableRegions={['mgmt-A', 'mgmt-B']}
+          supportedCanonical={openbaoTopology.supported}
+          topology={openbaoTopology}
+          disableNetwork
+        />,
+      ),
+    )
+    const desc = screen.getByTestId('topology-editor-mode-active-passive-desc')
+    const text = (desc.textContent ?? '').toLowerCase()
+    // Matches the CARD's matrix-derived semantics (raft · async + raft-transition + 60s/30s).
+    expect(text).toContain('raft')
+    expect(text).toContain('async')
+    expect(text).toContain('raft-transition')
+    expect(text).toContain('60s')
+    expect(text).toContain('30s')
+    // The contradiction is gone: no generic "backup-restore" anywhere.
+    expect(text).not.toContain('backup-restore')
+  })
+
+  it('describeModeForComponent for openbao active-passive exactly matches the matrix variant', () => {
+    const text = describeModeForComponent('active-passive', openbaoTopology).toLowerCase()
+    const v = openbaoTopology.perTopology['active-passive']
+    // Every field the dropdown shows is sourced from the matrix, not hardcoded.
+    expect(v?.replication?.backend).toBe('raft')
+    expect(v?.replication?.mode).toBe('async')
+    expect(v?.switchover?.mechanism).toBe('raft-transition')
+    expect(text).toContain(`${v!.replication!.backend} · ${v!.replication!.mode}`.toLowerCase())
+    expect(text).toContain('raft-transition switchover')
+    expect(text).not.toContain('backup-restore')
+  })
+
+  it('falls back to the generic one-liner when no matrix is supplied', () => {
+    // An app with no spec.topology block → no `topology` prop → generic copy.
+    const text = describeModeForComponent('active-passive', undefined).toLowerCase()
+    expect(text).toContain('promotes on failover')
+    // The generic fallback is mechanism-neutral; it must not claim backup-restore.
+    expect(text).not.toContain('backup-restore')
+  })
+
+  it('singleton uses the generic one-liner even with a matrix (no DR contract to derive)', () => {
+    const text = describeModeForComponent('singleton', openbaoTopology).toLowerCase()
+    expect(text).toContain('one cluster')
   })
 })
 

--- a/products/catalyst/bootstrap/ui/src/widgets/topology/TopologyEditor.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/topology/TopologyEditor.tsx
@@ -33,6 +33,7 @@ import {
   type ApplicationPreviewResponse,
   type CatalogItem,
 } from '@/lib/catalog.api'
+import type { BlueprintTopology } from '@/shared/constants/catalog.generated'
 
 export interface TopologyEditorProps {
   sovereignId: string
@@ -55,6 +56,18 @@ export interface TopologyEditorProps {
    * contradiction). Falls back to placementSchema.modes / ALL_MODES.
    */
   supportedCanonical?: string[]
+  /**
+   * #3905 — the Blueprint's declared topology matrix (the SAME
+   * `BlueprintTopology` the declared-topology CARD reads from
+   * `TOPOLOGY_BY_ID`). When provided, each mode's helper text is DERIVED
+   * from this component's `perTopology` contract (replication backend/mode +
+   * switchover mechanism + RTO/RPO) so the edit dropdown can NEVER
+   * contradict the card. Without it (an app with no matrix entry) the
+   * picker falls back to the generic `describeMode` one-liners. This kills
+   * the openbao bug where the card said `raft · async` warm-standby while
+   * the dropdown said "backup-restore".
+   */
+  topology?: BlueprintTopology
   /** Fired after a successful Apply. */
   onApplied?: () => void
   /** Test seam — bypass the network call for snapshot testing. */
@@ -120,6 +133,7 @@ export function TopologyEditor({
   namespace,
   blueprint,
   supportedCanonical,
+  topology,
   onApplied,
   disableNetwork = false,
 }: TopologyEditorProps) {
@@ -274,7 +288,9 @@ export function TopologyEditor({
                 data-testid={`topology-editor-mode-${m}-radio`}
               />
               <span className="text-sm font-medium text-[var(--color-text)]">{m}</span>
-              <span className="ml-2 text-xs text-[var(--color-text-dim)]">{describeMode(m)}</span>
+              <span className="ml-2 text-xs text-[var(--color-text-dim)]" data-testid={`topology-editor-mode-${m}-desc`}>
+                {describeModeForComponent(m, topology)}
+              </span>
             </label>
           )
         })}
@@ -423,10 +439,84 @@ export function describeMode(mode: string): string {
     case 'active-hot-standby':
       return 'primary serves; standby ready for switchover'
     case 'active-passive':
-      return 'primary serves; passive cold/warm standby (backup-restore)'
+      // Generic FALLBACK only — used when an app declares no per-component
+      // topology matrix. Most active-passive apps in the catalog replicate
+      // (raft/streaming/cnpg), so the matrix-derived describer below
+      // ALWAYS wins for them. Kept deliberately mechanism-neutral.
+      return 'primary serves; standby in the second region promotes on failover'
     default:
       return ''
   }
+}
+
+/**
+ * describeModeForComponent (#3905) — the per-mode helper text the placement
+ * edit dropdown actually renders. It DERIVES the description from the SAME
+ * per-component `BlueprintTopology` matrix the declared-topology CARD reads
+ * (the component's `perTopology[variant]` contract: replication backend/mode
+ * + switchover mechanism + RTO/RPO), so the card and the edit UI can NEVER
+ * contradict for any component.
+ *
+ * The root bug this fixes: `describeMode('active-passive')` returned a
+ * GENERIC, hardcoded, component-agnostic "…(backup-restore)" string for
+ * EVERY component, while the card derived openbao's real `raft · async`
+ * warm-standby semantics from the matrix. Now the dropdown reads the matrix
+ * too, so openbao's active-passive option shows raft/async/raft-transition,
+ * not backup-restore.
+ *
+ * Falls back to the generic `describeMode` one-liner when the component
+ * declares no matrix entry for the mode (the singleton class, or an app with
+ * no `spec.topology` block at all).
+ */
+export function describeModeForComponent(mode: string, topology?: BlueprintTopology): string {
+  const canon = canonicalizeMode(mode)
+  const generic = describeMode(mode)
+  if (!topology) return generic
+
+  // perTopology keys use the matrix dialect (active-hot-standby /
+  // active-passive / active-active / singleton); match canonically so the
+  // editor's canonical token resolves the right contract.
+  let variant: BlueprintTopology['perTopology'][string] | undefined
+  for (const [key, contract] of Object.entries(topology.perTopology)) {
+    if (canonicalizeMode(key) === canon) {
+      variant = contract
+      break
+    }
+  }
+  if (!variant) return generic
+
+  // singleton carries no DR contract — the generic one-liner is correct and
+  // there is nothing matrix-specific to add.
+  if (canon === 'singleton') return generic
+
+  const repl = variant.replication
+  const sw = variant.switchover
+  const parts: string[] = []
+
+  // Lead with the operative posture per class, then append the component's
+  // concrete replication + switchover contract from the matrix.
+  if (canon === 'active-active') {
+    parts.push('every region serves traffic')
+  } else {
+    // active-hot-standby / active-passive: one region serves, the other is
+    // the standby. The replication mode (sync vs async) is what separates a
+    // hot standby from a warm one — and it comes from the matrix, never a
+    // hardcoded "backup-restore".
+    parts.push('primary serves; second-region standby promotes on failover')
+  }
+
+  if (repl?.backend) {
+    const mode = repl.mode ? `${repl.backend} · ${repl.mode}` : repl.backend
+    parts.push(`${mode} replication`)
+  }
+  if (sw?.mechanism && sw.mechanism.toLowerCase() !== 'none') {
+    const rto = sw.rtoSeconds != null ? `RTO ${sw.rtoSeconds}s` : null
+    const rpo = sw.rpoSeconds != null ? `RPO ${sw.rpoSeconds}s` : null
+    const slo = [rto, rpo].filter(Boolean).join(' / ')
+    parts.push(slo ? `${sw.mechanism} switchover (${slo})` : `${sw.mechanism} switchover`)
+  }
+
+  return parts.join('; ')
 }
 
 function sameRegionSet(a: string[], b: string[]): boolean {


### PR DESCRIPTION
## What

The placement-edit **mode dropdown** on an Application's Topology tab now derives its per-mode helper text from the **same per-component topology matrix** (`TOPOLOGY_BY_ID`) that the declared-topology **CARD** reads. The card and the edit UI can no longer contradict for any component (the topology mock design decision #1: **one matrix, two readers**).

This is a clean re-cut of the stale, conflicting **#3907** (10-file conflict, drifted far behind main) — FE-only, dropping the unrelated stale-stack `bootstrap/api/internal/...` Go drift that #3907 had accumulated. **Supersedes #3907.**

## The bug (the founder's complaint)

`TopologyEditor.describeMode()` returned **generic, hardcoded, component-agnostic** strings. For `active-passive` it always read *"primary serves; passive cold/warm standby (**backup-restore**)"*. The card derives each component's real DR contract from the matrix (generated from `blueprint.yaml` `spec.topology`), so for **bp-openbao** the card showed `raft · async` / `raft-transition` / RTO 60s · RPO 30s while the dropdown said **"backup-restore"** — the exact contradiction the founder flagged.

## The fix

- New exported `describeModeForComponent(mode, topology)` in `TopologyEditor.tsx` derives the dropdown copy from the same `BlueprintTopology.perTopology[variant]` contract the card reads (replication backend/mode + switchover mechanism + RTO/RPO).
- Generic `describeMode()` stays only as the fallback (no matrix entry, or the `singleton` class which carries no DR contract). Its `active-passive` fallback is now mechanism-neutral (no "backup-restore").
- Wired into `TopologyTab` (post-create placement editor, via a new optional `topology` prop) and `InstancesSection` (instance-create mode picker), both passing the component's `TOPOLOGY_BY_ID` entry.

### Before / after — bp-openbao active-passive

| | helper text |
|---|---|
| **Before** (generic, what the founder saw) | `primary serves; passive cold/warm standby (backup-restore)` |
| **After** (matrix-derived, matches the card) | `primary serves; second-region standby promotes on failover; raft · async replication; raft-transition switchover (RTO 60s / RPO 30s)` |

The card and the edit dropdown now read the SAME contract.

## Validation

- `npx vitest run src/widgets/topology/TopologyEditor.test.tsx` → **10/10 pass**, incl. 4 new tests asserting the openbao active-passive dropdown derives raft/async/raft-transition/60s/30s from the matrix and contains **no** "backup-restore".
- Related suites (`src/widgets/topology` + `InstancesSection` + `TopologyTab.dr` + `CatalogDetail.edit`) → **39/39 pass**.
- `tsc -b --noEmit` → **clean**.

Env-independent FE/data fix. No prov fired. `Refs #3375 #3856 #3905 #3907` (not `Closes`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
