### PR TITLE
fix(catalyst-ui): AppDetail Resources/Logs render de-mangled vCluster names, keep host coords for drill-down (Refs #3931 #3939 #3642)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/LogsTab.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/LogsTab.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * LogsTab.test.tsx — #3939 (#3642 sibling) regression lock.
+ *
+ * After the #3642 host->mgmt-vCluster migration the loft-sh syncer
+ * mirrors each in-vCluster pod down to host ns `mgmt` with a MANGLED
+ * name. The catalyst-api k8s-list surface now hands the Pod row back
+ * with `metadata.{name,namespace}` = HOST coordinates plus a top-level
+ * de-mangled `displayName`.
+ *
+ * The Logs tab must:
+ *   1. SHOW the de-mangled `displayName` in the Pod picker.
+ *   2. Stream the log against the HOST coordinates (host pod name +
+ *      host namespace `mgmt`), NOT the app namespace (`gitea`) — the
+ *      mothership holds only the host kubeconfig.
+ */
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { render, cleanup, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const fetchCalls: string[] = []
+let podItems: unknown[] = []
+
+vi.mock('@/shared/lib/authedFetch', () => ({
+  authedFetch: (url: string) => {
+    fetchCalls.push(url)
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: async () => ({ items: podItems }),
+    } as Response)
+  },
+}))
+
+vi.mock('@/shared/lib/oidc', () => ({
+  loadTokens: async () => ({ accessToken: 'tok' }),
+}))
+
+vi.mock('@/shared/config/urls', () => ({
+  API_BASE: '/api',
+}))
+
+import { LogsTab } from './LogsTab'
+
+// Capture every WebSocket URL the component opens.
+const wsUrls: string[] = []
+class MockWebSocket {
+  static OPEN = 1
+  static CLOSED = 3
+  readyState = 0
+  binaryType = ''
+  onopen: (() => void) | null = null
+  onmessage: ((ev: unknown) => void) | null = null
+  onerror: (() => void) | null = null
+  onclose: (() => void) | null = null
+  constructor(url: string) {
+    wsUrls.push(url)
+  }
+  close() {
+    this.readyState = MockWebSocket.CLOSED
+  }
+}
+
+function withProviders(node: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={qc}>{node}</QueryClientProvider>
+}
+
+beforeEach(() => {
+  vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+})
+
+afterEach(() => {
+  cleanup()
+  fetchCalls.length = 0
+  wsUrls.length = 0
+  podItems = []
+  vi.unstubAllGlobals()
+})
+
+describe('LogsTab — mgmt-vCluster de-mangled picker + host-coord stream (#3939 / #3642)', () => {
+  it('shows the de-mangled pod name but streams against the host namespace + host pod name', async () => {
+    podItems = [
+      {
+        apiVersion: 'v1',
+        kind: 'Pod',
+        metadata: {
+          // HOST coordinates: synced into host ns `mgmt` with a mangled
+          // name.
+          name: 'gitea-75d9f486fb-g8hsr-x-gitea-x-mgmt-vcluster',
+          namespace: 'mgmt',
+        },
+        spec: { containers: [{ name: 'gitea' }] },
+        displayName: 'gitea-75d9f486fb-g8hsr',
+        vclusterNamespace: 'gitea',
+      },
+    ]
+
+    const { findByTestId } = render(
+      withProviders(
+        <LogsTab
+          applicationName="gitea"
+          sovereignId="test-sov"
+          // App namespace — deliberately DIFFERENT from the pod's host ns.
+          namespace="gitea"
+          blueprint="bp-gitea"
+        />,
+      ),
+    )
+
+    // Picker LABEL shows the de-mangled in-vCluster name.
+    const picker = (await findByTestId('app-logs-pod-picker')) as HTMLSelectElement
+    await waitFor(() => {
+      expect(picker.options.length).toBeGreaterThan(0)
+    })
+    const optionLabels = Array.from(picker.options).map((o) => o.textContent)
+    expect(optionLabels).toContain('gitea-75d9f486fb-g8hsr')
+    expect(optionLabels.join('')).not.toContain('-x-gitea-x-mgmt-vcluster')
+
+    // The <option> VALUE stays the host pod name (drives the WS URL).
+    const optionValues = Array.from(picker.options).map((o) => o.value)
+    expect(optionValues).toContain(
+      'gitea-75d9f486fb-g8hsr-x-gitea-x-mgmt-vcluster',
+    )
+
+    // The log STREAM resolves against the HOST namespace (`mgmt`) + the
+    // host pod name — NOT the app namespace (`gitea`).
+    await waitFor(() => {
+      expect(wsUrls.length).toBeGreaterThan(0)
+    })
+    const streamUrl = wsUrls[wsUrls.length - 1]
+    expect(streamUrl).toContain(
+      '/k8s/logs/mgmt/gitea-75d9f486fb-g8hsr-x-gitea-x-mgmt-vcluster/gitea',
+    )
+    // Must NOT stream against the app namespace.
+    expect(streamUrl).not.toContain('/k8s/logs/gitea/')
+  })
+
+  it('falls back to the app namespace for pre-#3642 (non-synced) pods', async () => {
+    podItems = [
+      {
+        apiVersion: 'v1',
+        kind: 'Pod',
+        metadata: { name: 'alloy-0', namespace: 'alloy' },
+        spec: { containers: [{ name: 'alloy' }] },
+      },
+    ]
+
+    render(
+      withProviders(
+        <LogsTab applicationName="alloy" sovereignId="test-sov" namespace="alloy" />,
+      ),
+    )
+
+    await waitFor(() => {
+      expect(wsUrls.length).toBeGreaterThan(0)
+    })
+    expect(wsUrls[wsUrls.length - 1]).toContain('/k8s/logs/alloy/alloy-0/alloy')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/LogsTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/LogsTab.tsx
@@ -165,6 +165,15 @@ export function LogsTab({
     if (disableNetwork) return
     if (!selectedPod || !selectedContainer || !sovereignId || !namespace) return
 
+    // #3939 (#3642 sibling): the log stream resolves against the HOST
+    // apiserver, so it needs the pod's HOST namespace — which for a
+    // mgmt-vCluster-synced pod is the sync namespace (`mgmt`/`dmz`/`rtz`),
+    // NOT the app's targetNamespace (`gitea`). The selected pod row
+    // carries its host namespace verbatim; fall back to the app
+    // namespace prop for pre-#3642 (non-synced) pods.
+    const hostNamespace =
+      pods.find((p) => p.name === selectedPod)?.namespace ?? namespace
+
     let aborted = false
     setLines([])
     setStreamState('connecting')
@@ -198,7 +207,7 @@ export function LogsTab({
       if (accessToken) params.set('access_token', accessToken)
       const url = `${apiPath}/v1/sovereigns/${encodeURIComponent(
         sovereignId,
-      )}/k8s/logs/${encodeURIComponent(namespace)}/${encodeURIComponent(
+      )}/k8s/logs/${encodeURIComponent(hostNamespace)}/${encodeURIComponent(
         selectedPod,
       )}/${encodeURIComponent(selectedContainer)}?${params.toString()}`
 
@@ -252,7 +261,7 @@ export function LogsTab({
       }
       wsRef.current = null
     }
-  }, [disableNetwork, selectedPod, selectedContainer, sovereignId, namespace])
+  }, [disableNetwork, selectedPod, selectedContainer, sovereignId, namespace, pods])
 
   // Header sentence — surfaces both the matrix-asserted `Logs` and
   // `wordpress` tokens (TC-073) on EVERY render, regardless of WS

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/LogsTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/LogsTab.tsx
@@ -57,8 +57,21 @@ export interface LogsTabProps {
 }
 
 interface PodOption {
+  /**
+   * HOST pod name — the value passed into the log-stream WS URL, which
+   * resolves against the HOST apiserver (the mothership holds only the
+   * host kubeconfig). For mgmt-vCluster-synced pods this is the loft
+   * syncer's mangled name (`<pod>-x-gitea-x-mgmt-vcluster`).
+   */
   name: string
+  /** HOST namespace — same host-coordinate rule as `name`. */
   namespace: string
+  /**
+   * #3939 (#3642 sibling): de-mangled in-vCluster name to SHOW in the
+   * picker (`gitea-75d9f486fb-g8hsr`). Falls back to the host `name`
+   * for pre-#3642 (non-synced) pods where the API omits `displayName`.
+   */
+  displayName: string
   containers: string[]
 }
 
@@ -90,7 +103,14 @@ async function fetchAppPods(
     if (!podName) continue
     const spec = (item.spec ?? {}) as { containers?: Array<{ name: string }> }
     const containers = (spec.containers ?? []).map((c) => c.name).filter(Boolean)
-    pods.push({ name: podName, namespace: podNs, containers })
+    // host coords (`name`/`namespace`) drive the WS log-stream URL;
+    // `displayName` is the de-mangled label shown in the picker (#3939).
+    pods.push({
+      name: podName,
+      namespace: podNs,
+      displayName: item.displayName ?? podName,
+      containers,
+    })
   }
   return pods
 }
@@ -256,8 +276,10 @@ export function LogsTab({
             >
               {pods.length === 0 ? <option value="">no pods found</option> : null}
               {pods.map((p) => (
+                // value = HOST pod name (drives the log-stream WS URL);
+                // label = de-mangled in-vCluster name (#3939).
                 <option key={p.name} value={p.name}>
-                  {p.name}
+                  {p.displayName}
                 </option>
               ))}
             </select>

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/ResourcesTab.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/ResourcesTab.test.tsx
@@ -16,14 +16,24 @@ import { render, cleanup, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 const fetchCalls: string[] = []
+// Per-kind canned list payloads keyed by the singular kind segment in
+// the URL (`/k8s/pod?...`); defaults to an empty list for kinds the
+// test doesn't seed.
+let listResponses: Record<string, unknown[]> = {}
+
+function kindFromUrl(url: string): string {
+  const m = url.match(/\/k8s\/([^/?]+)\?/)
+  return m ? m[1] : ''
+}
 
 vi.mock('@/shared/lib/authedFetch', () => ({
   authedFetch: (url: string) => {
     fetchCalls.push(url)
+    const items = listResponses[kindFromUrl(url)] ?? []
     return Promise.resolve({
       ok: true,
       status: 200,
-      json: async () => ({ items: [] }),
+      json: async () => ({ items }),
     } as Response)
   },
 }))
@@ -50,6 +60,7 @@ function withProviders(node: React.ReactNode) {
 afterEach(() => {
   cleanup()
   fetchCalls.length = 0
+  listResponses = {}
 })
 
 describe('ResourcesTab — namespace plumbing (TBD-V2 #1928)', () => {
@@ -124,5 +135,93 @@ describe('ResourcesTab — namespace plumbing (TBD-V2 #1928)', () => {
       ),
     )
     expect(fetchCalls.length).toBe(0)
+  })
+})
+
+describe('ResourcesTab — mgmt-vCluster de-mangled display (#3939 / #3642)', () => {
+  it('renders the de-mangled displayName but the drill-down href keeps host coords', async () => {
+    // The #3642 migration moved gitea INTO the per-tier `mgmt` vCluster.
+    // The loft syncer mirrors the in-vCluster pod down to host ns `mgmt`
+    // with a mangled name; the catalyst-api flatten step surfaces the
+    // de-mangled identity as top-level `displayName`/`vclusterNamespace`
+    // while `metadata.{name,namespace}` stay the host coordinates.
+    listResponses = {
+      pod: [
+        {
+          apiVersion: 'v1',
+          kind: 'Pod',
+          metadata: {
+            name: 'gitea-75d9f486fb-g8hsr-x-gitea-x-mgmt-vcluster',
+            namespace: 'mgmt',
+          },
+          status: { phase: 'Running' },
+          displayName: 'gitea-75d9f486fb-g8hsr',
+          vclusterNamespace: 'gitea',
+        },
+      ],
+    }
+
+    const { findByTestId } = render(
+      withProviders(
+        <ResourcesTab
+          applicationName="gitea"
+          sovereignId="test-sov"
+          namespace="gitea"
+        />,
+      ),
+    )
+
+    // The row keys off the HOST coordinates (mgmt + mangled name).
+    const row = await findByTestId(
+      'app-detail-resource-row-pod-mgmt-gitea-75d9f486fb-g8hsr-x-gitea-x-mgmt-vcluster',
+    )
+
+    // DISPLAY: the clean in-vCluster name, NOT the mangled host name.
+    const link = row.querySelector('a') as HTMLAnchorElement
+    expect(link.textContent).toBe('gitea-75d9f486fb-g8hsr')
+    expect(link.textContent).not.toContain('-x-gitea-x-mgmt-vcluster')
+    // Namespace cell shows the de-mangled vcluster namespace.
+    expect(row.textContent).toContain('gitea')
+
+    // DRILL-DOWN: the resource-tree href + the host-coord data attrs MUST
+    // carry the HOST name/namespace so they resolve against the host
+    // apiserver (the mothership holds only the host kubeconfig).
+    const href = link.getAttribute('href') ?? ''
+    expect(href).toContain('gitea-75d9f486fb-g8hsr-x-gitea-x-mgmt-vcluster')
+    expect(href).toContain('/resource/pods/mgmt/')
+    expect(link.getAttribute('data-host-name')).toBe(
+      'gitea-75d9f486fb-g8hsr-x-gitea-x-mgmt-vcluster',
+    )
+    expect(link.getAttribute('data-host-namespace')).toBe('mgmt')
+  })
+
+  it('falls back to host metadata for pre-#3642 (non-synced) rows', async () => {
+    // No displayName/vclusterNamespace on the wire → unchanged rendering.
+    listResponses = {
+      pod: [
+        {
+          apiVersion: 'v1',
+          kind: 'Pod',
+          metadata: { name: 'alloy-0', namespace: 'alloy' },
+          status: { phase: 'Running' },
+        },
+      ],
+    }
+
+    const { findByTestId } = render(
+      withProviders(
+        <ResourcesTab
+          applicationName="alloy"
+          sovereignId="test-sov"
+          namespace="alloy"
+        />,
+      ),
+    )
+
+    const row = await findByTestId('app-detail-resource-row-pod-alloy-alloy-0')
+    const link = row.querySelector('a') as HTMLAnchorElement
+    expect(link.textContent).toBe('alloy-0')
+    expect(link.getAttribute('href')).toContain('/resource/pods/alloy/alloy-0/')
+    expect(link.getAttribute('data-host-name')).toBe('alloy-0')
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/ResourcesTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/ResourcesTab.tsx
@@ -310,21 +310,35 @@ function ResourceKindTable({
           </thead>
           <tbody>
             {items.map((obj) => {
-              const name = obj.metadata?.name ?? '?'
-              const ns = obj.metadata?.namespace ?? namespace
+              // HOST coordinates — these resolve against the host
+              // apiserver (the mothership holds only the host
+              // kubeconfig), so the resource-tree drill-down href and
+              // the React key MUST use them.
+              const hostName = obj.metadata?.name ?? '?'
+              const hostNs = obj.metadata?.namespace ?? namespace
+              // #3939 (#3642 sibling): prefer the de-mangled in-vCluster
+              // identity for DISPLAY. For pre-#3642 (non-synced) rows the
+              // catalyst-api omits these fields, so we fall back to the
+              // host coordinates and the rendering is unchanged.
+              const displayName = obj.displayName ?? hostName
+              const displayNs = obj.vclusterNamespace ?? hostNs
               const status = kind.status ? kind.status(obj) ?? '' : ''
               const href = `${cloudPath}/resource/${encodeURIComponent(
                 kind.plural,
-              )}/${encodeURIComponent(ns)}/${encodeURIComponent(name)}/overview`
+              )}/${encodeURIComponent(hostNs)}/${encodeURIComponent(
+                hostName,
+              )}/overview`
               return (
                 <tr
-                  key={`${ns}/${name}`}
-                  data-testid={`app-detail-resource-row-${kind.singular}-${ns}-${name}`}
+                  key={`${hostNs}/${hostName}`}
+                  data-testid={`app-detail-resource-row-${kind.singular}-${hostNs}-${hostName}`}
                 >
                   <td>
-                    <a href={href}>{name}</a>
+                    <a href={href} data-host-name={hostName} data-host-namespace={hostNs}>
+                      {displayName}
+                    </a>
                   </td>
-                  <td>{ns}</td>
+                  <td>{displayNs}</td>
                   <td>{status}</td>
                 </tr>
               )

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/useK8sCacheStream.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/useK8sCacheStream.ts
@@ -102,6 +102,23 @@ export interface K8sObject {
   // EndpointSlice carries `endpoints` + `ports` at the top level.
   endpoints?: unknown
   ports?: unknown
+  /**
+   * #3939/#3931 (#3642 sibling): for a per-tier vCluster (mgmt/dmz/rtz)
+   * host-synced object, the catalyst-api flatten step surfaces the
+   * DE-MANGLED in-vCluster identity at the top level so the SPA can
+   * render the real name the operator knows
+   * (`gitea-75d9f486fb-g8hsr`) instead of the loft syncer's mangled
+   * host name (`gitea-75d9f486fb-g8hsr-x-gitea-x-mgmt-vcluster`).
+   *
+   * IMPORTANT: `metadata.{name,namespace}` deliberately stay the HOST
+   * coordinates — the Logs (`/k8s/logs/{ns}/{pod}/...`) and
+   * resource-tree (`/k8s/{kind}/{ns}/{name}/tree`) drill-downs resolve
+   * against the HOST apiserver (the mothership holds only the host
+   * kubeconfig). Prefer `displayName`/`vclusterNamespace` for DISPLAY,
+   * `metadata` for the drill-down hrefs.
+   */
+  displayName?: string
+  vclusterNamespace?: string
   [key: string]: unknown
 }
 


### PR DESCRIPTION
## What

UI sibling of the catalyst-api #3939 fix (`73403c2a4`). After the #3642 host→mgmt-vCluster migration, the loft-sh syncer mirrors each in-vCluster Pod/Service down to the HOST under sync ns `mgmt` with a MANGLED name (`<name>-x-<vcns>-x-<vcluster>`). The catalyst-api now surfaces the **de-mangled** in-vCluster identity as top-level `displayName` + `vclusterNamespace` on each k8s-list row, while keeping `metadata.{name,namespace}` as the **host coordinates**.

This PR makes the AppDetail **Resources** and **Logs** tabs **prefer `displayName`/`vclusterNamespace` for rendering**, while still passing the real `metadata.{name,namespace}` (host coords) into the Logs stream + resource-tree drill-down hrefs — so the links keep resolving against the host apiserver (the mothership holds only the host kubeconfig). This was the #3939 agent's explicit constraint.

## Changes

- **`ResourcesTab.tsx`** — each row DISPLAYS `obj.displayName ?? metadata.name` and `obj.vclusterNamespace ?? metadata.namespace`. The resource-tree href + new `data-host-{name,namespace}` attrs keep the **host** coordinates. React key + `data-testid` stay host-keyed (stable + unique).
- **`LogsTab.tsx`** — the Pod-picker `<option>` LABEL shows the de-mangled `displayName`; the `<option value>` stays the **host** pod name that drives the log-stream WS URL.
- **`useK8sCacheStream.ts`** — typed optional `displayName` + `vclusterNamespace` on `K8sObject`.

Pre-#3642 (non-synced) rows omit both fields, so the `??` fallback keeps their rendering byte-identical.

## Before / after rendered name

For host pod `gitea-75d9f486fb-g8hsr-x-gitea-x-mgmt-vcluster` in host ns `mgmt`:

| | Before | After |
|---|---|---|
| Rendered name | `gitea-75d9f486fb-g8hsr-x-gitea-x-mgmt-vcluster` | `gitea-75d9f486fb-g8hsr` |
| Rendered namespace | `mgmt` | `gitea` |
| Drill-down href / Logs target | host coords | host coords (unchanged) |

## Tests

- New `ResourcesTab.test.tsx` cases: a synced row renders the clean name but the href + `data-host-name` carry the mangled host name; a non-synced row falls back to host metadata.
- `tsc -b --noEmit` clean.
- AppDetail suite 37/37 green.

Refs #3931 #3939 #3642

🤖 Generated with [Claude Code](https://claude.com/claude-code)