### PR TITLE
fix(catalog): render operator /catalog grid FROM the live catalog so bp-wordpress is discoverable, not deep-link-only (Refs #3942 #3668)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogPage.test.tsx
@@ -10,7 +10,7 @@
  *   • Mounts inside PortalShell (sidebar present)
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, cleanup, fireEvent, within } from '@testing-library/react'
 import {
   RouterProvider,
@@ -98,5 +98,67 @@ describe('CatalogPage (#3601)', () => {
     const after = within(await screen.findByTestId('sov-catalog-grid')).getAllByTestId(/^sov-app-card-bp-/)
     expect(after.length).toBeLessThan(before.length)
     expect(after.some((c) => c.getAttribute('data-testid') === 'sov-app-card-bp-cilium')).toBe(true)
+  })
+})
+
+/**
+ * #3668 (hw171 catalog walk) — the grid must render every Blueprint the
+ * LIVE catalog serves, not only the build-time component graph. A
+ * seeded-but-uncatalogued Blueprint such as `bp-wordpress` (the
+ * marketplace-funnel CMS — present in catalog-seed/blueprints.yaml but NOT
+ * in componentGroups.ts) was invisible in the grid even though its detail
+ * page `/catalog/bp-wordpress` rendered fully. This test locks in that the
+ * grid now unions the `/api/v1/catalog` items (via `useCatalog`) as extra
+ * cards. `useCatalog` is mocked so the merge runs deterministically
+ * regardless of the test harness's detected mode.
+ */
+vi.mock('@/lib/useCatalog', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/useCatalog')>()
+  return {
+    ...actual,
+    useCatalog: () => ({
+      data: [
+        {
+          name: 'bp-wordpress',
+          version: '0.4.1',
+          card: { title: 'WordPress', summary: 'Turnkey SSO CMS' },
+          origin: 2,
+          source: 'sovereign',
+        },
+      ],
+      isSuccess: true,
+      isError: false,
+      isLoading: false,
+    }),
+  }
+})
+
+describe('CatalogPage — live catalog union (#3668)', () => {
+  beforeEach(() => {
+    useWizardStore.setState({ ...INITIAL_WIZARD_STATE })
+    globalThis.fetch = (() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ apps: [] }),
+      } as unknown as Response)) as typeof fetch
+  })
+
+  afterEach(() => cleanup())
+
+  it('renders a grid card for a catalog blueprint absent from the static graph (bp-wordpress)', async () => {
+    renderCatalog('d-1')
+    const grid = await screen.findByTestId('sov-catalog-grid')
+    // The wordpress card appears (it is NOT a bootstrap-kit or wizard
+    // component, so it can only come from the live-catalog union).
+    const wp = await within(grid).findByTestId('sov-app-card-bp-wordpress')
+    expect(wp).toBeTruthy()
+    expect(wp.getAttribute('href')).toBe('/provision/d-1/catalog/bp-wordpress')
+  })
+
+  it('still renders the static bootstrap-kit cards alongside the catalog union', async () => {
+    renderCatalog('d-1')
+    const grid = await screen.findByTestId('sov-catalog-grid')
+    expect(within(grid).getByTestId('sov-app-card-bp-cilium')).toBeTruthy()
+    expect(within(grid).getByTestId('sov-app-card-bp-wordpress')).toBeTruthy()
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogPage.tsx
@@ -33,8 +33,45 @@ import { resolveApplications, type ApplicationDescriptor } from './applicationCa
 import type { ApplicationStatus } from './eventReducer'
 import { useCatalogAdmin } from '@/shared/lib/useCatalogAdmin'
 import { listApps, type CommerceApp } from '@/lib/commerce.api'
+import { useCatalog } from '@/lib/useCatalog'
+import type { CatalogItem } from '@/lib/catalog.api'
 
 const DEFAULT_APP_ENVIRONMENT = 'dev'
+
+/** Stable empty list so the merge memo doesn't re-run on every render. */
+const EMPTY_ITEMS: readonly CatalogItem[] = []
+
+/**
+ * #3668 (hw171 catalog walk) — project a live catalog API item into the same
+ * `ApplicationDescriptor` shape the grid's `AppCard` consumes. Used ONLY for
+ * blueprints the build-time component graph (`componentGroups.ts`) doesn't
+ * already cover (e.g. `bp-wordpress`), so a seeded-but-uncatalogued Blueprint
+ * still gets a grid card instead of being reachable only by deep-link.
+ *
+ * Generic over every blueprint (founder rule #4): pure field projection off
+ * `spec.card`, no per-blueprint branch. The descriptor's `id` is the canonical
+ * `bp-<slug>` so the card links to the CLASS page `/catalog/bp-<slug>` exactly
+ * like the static descriptors do.
+ */
+function catalogItemToDescriptor(it: CatalogItem): ApplicationDescriptor | null {
+  const id = it.name?.startsWith('bp-') ? it.name : it.name ? `bp-${it.name}` : ''
+  if (!id) return null
+  const bareId = id.replace(/^bp-/, '')
+  const card = it.card ?? { title: bareId }
+  const category = card.category ?? card.family ?? 'application'
+  return {
+    id,
+    bareId,
+    title: card.title || bareId,
+    description: card.summary ?? card.description ?? card.tagline ?? '',
+    familyId: category,
+    familyName: category,
+    tier: 'optional',
+    logoUrl: null,
+    dependencies: [],
+    bootstrapKit: false,
+  }
+}
 
 /**
  * #3603 (EPIC #3597) — the admin-editable overlay for one catalog entry,
@@ -64,11 +101,51 @@ export function CatalogPage() {
   const isSovereignMode = DETECTED_MODE.mode === 'sovereign'
 
   // Catalog = every Application this Sovereign knows about (the same
-  // `resolveApplications` union AppsPage's Catalog tab rendered).
-  const catalogApps = useMemo(
+  // `resolveApplications` union AppsPage's Catalog tab rendered) — the
+  // bootstrap-kit + selected components + their transitive deps, resolved
+  // from the build-time component graph.
+  const staticApps = useMemo(
     () => resolveApplications(store.selectedComponents),
     [store.selectedComponents],
   )
+
+  // #3668 (hw171 catalog walk) — the grid must ALSO render every Blueprint
+  // the live catalog serves, not only the build-time component graph. Some
+  // seeded Blueprints (e.g. `bp-wordpress` / `bp-wordpress-tenant`, the
+  // marketplace-funnel CMS) are NOT in `componentGroups.ts` — they ship as
+  // catalog-seed CRs (products/catalyst/chart/templates/catalog-seed/
+  // blueprints.yaml) but have no wizard-component entry, so they were
+  // INVISIBLE in the grid even though their detail page (`/catalog/bp-<x>`,
+  // which fetches the CR by name) rendered fully. Per founder rule #4 the
+  // catalog renders FROM the catalog (the in-cluster Blueprint CRs), not a
+  // hand-curated list — so union the live `/api/v1/catalog` items as extra
+  // descriptors for any blueprint the static graph doesn't already cover.
+  const catalogQuery = useCatalog({ enabled: isSovereignMode })
+  const catalogItems = catalogQuery.data ?? EMPTY_ITEMS
+  const catalogIconBySlug = useMemo(() => {
+    const m: Record<string, { iconLight: string; iconDark: string }> = {}
+    for (const it of catalogItems) {
+      const slug = (it.name ?? '').replace(/^bp-/, '')
+      if (!slug) continue
+      m[slug] = {
+        iconLight: it.card?.iconLight ?? '',
+        iconDark: it.card?.iconDark ?? '',
+      }
+    }
+    return m
+  }, [catalogItems])
+
+  const catalogApps = useMemo<ApplicationDescriptor[]>(() => {
+    const seen = new Set(staticApps.map((a) => a.id))
+    const extra: ApplicationDescriptor[] = []
+    for (const it of catalogItems) {
+      const bp = catalogItemToDescriptor(it)
+      if (!bp || seen.has(bp.id)) continue
+      seen.add(bp.id)
+      extra.push(bp)
+    }
+    return [...staticApps, ...extra]
+  }, [staticApps, catalogItems])
 
   // Live publish/status overlay — identical projection to AppsPage's
   // `sovereign-apps-live` query so a card's INSTALLED / AVAILABLE pill and
@@ -239,6 +316,13 @@ export function CatalogPage() {
                     description: edit.summary || app.description,
                   }
                 : app
+            // #3668 — IaC-first icon: the admin commerce-store edit wins
+            // (manual override), else the live catalog item's `card.iconLight`/
+            // `iconDark` (the seed/Gitea IaC value). Falls through to the
+            // descriptor's build-time logo / letter-mark inside AppCard.
+            const catalogIcon = catalogIconBySlug[slug]
+            const iconLight = edit?.iconLight || catalogIcon?.iconLight
+            const iconDark = edit?.iconDark || catalogIcon?.iconDark
             return (
               <AppCard
                 key={app.id}
@@ -255,8 +339,8 @@ export function CatalogPage() {
                 isService={false}
                 marketplacePublished={published}
                 slug={slug}
-                iconLight={edit?.iconLight}
-                iconDark={edit?.iconDark}
+                iconLight={iconLight}
+                iconDark={iconDark}
                 onEdit={
                   isAdmin
                     ? () => {


### PR DESCRIPTION
## Determination: REAL discoverability gap (NOT by-design)

The operator `/catalog` grid did **not** render from the catalog. `CatalogPage.tsx` built its card list purely from `resolveApplications()` (`applicationCatalog.ts`), unioning only `BOOTSTRAP_KIT` + `componentGroups.ts` mandatory/selected/transitive entries. `bp-wordpress` / `bp-wordpress-tenant` ship **only** as catalog-seed Blueprint CRs (`templates/catalog-seed/blueprints.yaml`, #3870), are **not** in `componentGroups.ts` and **not** in the bootstrap-kit — so they never entered the grid and had **no card**, while `/catalog/bp-wordpress` rendered fully because `CatalogDetail` fetches the CR by name via `GET /api/v1/catalog/{name}`.

**Differentiating field:** presence in `componentGroups.ts` (the build-time grid source). The catalog-seed CR carries `visibility: listed` + a full `card` and IS served by `GET /api/v1/catalog` — the grid simply never read that list. Same class as #3159 (catalog only showed the 14-CR baseline).

This is **not by-design**: #3668's spec is explicit (founder rule #4) — the catalog renders FROM the catalog, generic over every blueprint, with `bp-wordpress` named as a must-be-discoverable blueprint and *"no blueprint left ... just because it isn't in a build-time map."*

## Fix
`products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogPage.tsx`:
- Union the live `GET /api/v1/catalog` items (via `useCatalog()`) into the grid as extra `ApplicationDescriptor`s for any blueprint the static component graph doesn't already cover. Pure projection off `spec.card`, no per-blueprint code (founder rule #4). Descriptor id is the canonical `bp-<slug>` so the card links to the CLASS page exactly like static cards.
- IaC-first icon for union cards: admin commerce-store edit → catalog item `card.iconLight/iconDark` → build-time logo → letter-mark.
- Gated on `isSovereignMode` (mirrors the existing live-apps overlay query — the grid's live overlays already only apply on the Sovereign's own console, which is where the hw171 walk found the gap).

## Test
`CatalogPage.test.tsx` adds a lock-in: a catalog blueprint absent from the static graph (`bp-wordpress`) renders a grid card linking to `/catalog/bp-wordpress`, alongside the static bootstrap-kit cards.

## Validation
- `tsc -b --noEmit` clean
- `eslint` clean
- CatalogPage / CatalogDetail / AppsPage / applicationCatalog suites green (43 tests)
- The 10 unrelated failing suites (PinInput6, StepComponents, SettingsPage, etc.) are **pre-existing on the base branch** (verified via `git stash` run) — untouched by this change.

Refs #3942 #3668 #3870

🤖 Generated with [Claude Code](https://claude.com/claude-code)
