### PR TITLE
fix(bp-self-sovereign-cutover): step-03 harbor-prewarm — bound skopeo copies with --command-timeout (0.1.77)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -559,7 +559,12 @@ spec:
       # every cutover Job's dial timed out and the cutover wedged at step-01 (gitea-mirror)
       # on hw165. Purely additive (Cilium unions policies) — opens the path without editing
       # bp-mgmt-vcluster. mgmtIsolationCarveOut.{enabled,mgmtNamespace} (default enabled,mgmt).
-      version: 0.1.76
+      # 0.1.77 (#3944, Refs #3379 #3642 #3927): step-03 harbor-prewarm's skopeo
+      # copies (Phase A images + Phase A2 charts) gain `--command-timeout`
+      # (prewarm.skopeoCommandTimeout, default 1200s) so a silently-stalled
+      # connection FAILS FAST instead of hanging the Job "active" for hours —
+      # the symptom seen live on hw171 right after #3927 unstuck step-02.
+      version: 0.1.77
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.76
+  version: 0.1.77
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -938,7 +938,26 @@ name: bp-self-sovereign-cutover
 # cutoverComplete while the customer journey was dead, PRINCIPLES A1/A2);
 # step-09 mint stamps the token-source annotation on the no-op path too.
 # Refs #3689 #3379.
-version: 0.1.76
+# 0.1.77 (#3944, Refs #3379 #3642 #3927): step-03 harbor-prewarm stalled
+# "active" for HOURS post-#3642 right after #3927 unstuck step-02. Root cause:
+# every `skopeo copy` in Phase A (openova-io container images) + Phase A2
+# (openova-io helm chart OCI artifacts) ran with NO `--command-timeout`. A copy
+# whose TCP connection is ESTABLISHED but then silently STALLS mid-blob (no
+# bytes, no reset — common on a freshly-bootstrapped/throttled Sovereign network
+# or against the registry.<fqdn> front door that accepts the connect but stops
+# responding) hangs INDEFINITELY: `--retry-times` only fires on an ERROR, never
+# on a stuck-but-alive connection. With no command timeout the worker never
+# drains, the parent `wait` blocks forever, the Job sits "active" until the
+# 5400s activeDeadlineSeconds kills it, and catalyst-api auto-re-runs the
+# DeadlineExceeded step (cutover.go) → back-to-back 90-min hangs = "active for
+# hours". Fix: add `skopeo --command-timeout ${PREWARM_SKOPEO_TIMEOUT}` (GLOBAL
+# flag, before `copy`) to BOTH copy loops, new tunable
+# prewarm.skopeoCommandTimeout (default 1200s/20m). A stalled connection now
+# FAILS FAST → the per-image outer retry loop (PREWARM_COPY_ATTEMPTS) self-heals,
+# the exact path that was unreachable while the copy hung. Validated:
+# `helm template` + `sh -n`/`dash -n` clean. Live confirmation deferred to the
+# hw172 cutover walk reaching step-03. Lockstep: 06a pin + blueprint.yaml.
+version: 0.1.77
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -108,6 +108,28 @@ data:
             value: {{ .Values.helmRepositories.namespace | quote }}
           - name: UPSTREAM_PREFIX
             value: {{ .Values.helmRepositories.upstreamPrefix | quote }}
+          # #3944 (Refs #3379 #3642 #3927): per-`skopeo copy` command timeout.
+          # A `skopeo copy` whose TCP connection is ESTABLISHED but then
+          # silently STALLS mid-blob (no bytes, no reset — common on a
+          # freshly-bootstrapped/throttled Sovereign network, or against the
+          # registry.<fqdn> front door that accepts the connect but stops
+          # responding) hangs INDEFINITELY: `--retry-times` only fires on an
+          # ERROR, never on a stuck-but-alive connection. With no command
+          # timeout the copy never returns, the worker never drains, the parent
+          # `wait` blocks forever, and the whole Job sits "active" until the
+          # 5400s activeDeadlineSeconds kills it — then catalyst-api auto-re-runs
+          # the DeadlineExceeded step (cutover.go) and the next 90-min hang
+          # begins. Back-to-back deadline cycles = the "step-03 active for hours,
+          # never completing" symptom seen live on hw171 (dep 3963e9267c10a90d)
+          # right after #3927 unstuck step-02. `--command-timeout` bounds each
+          # individual copy so a stalled connection FAILS FAST → the per-image
+          # outer retry loop (PREWARM_COPY_ATTEMPTS) re-attempts with backoff,
+          # which is exactly the self-heal path that was unreachable while the
+          # copy hung. 1200s (20m) is generous for the largest multi-layer
+          # PRIVATE openova-io image over throttled egress yet collapses an
+          # infinite hang into a bounded, retryable failure.
+          - name: PREWARM_SKOPEO_TIMEOUT
+            value: {{ .Values.prewarm.skopeoCommandTimeout | default "1200s" | quote }}
         volumeMounts:
           - name: prewarm
             mountPath: /work
@@ -308,7 +330,10 @@ data:
               : >"${cpdir}/${slug}.log"
               while [ "${attempt}" -le "${PREWARM_COPY_ATTEMPTS}" ]; do
                 echo "[harbor-prewarm] copy ${up} attempt ${attempt}/${PREWARM_COPY_ATTEMPTS}" >>"${cpdir}/${slug}.log"
-                if skopeo copy \
+                # #3944: `--command-timeout` is a skopeo GLOBAL flag (must
+                # precede the `copy` subcommand) — it bounds the whole copy so a
+                # silently-stalled connection can't hang the worker forever.
+                if skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT}" copy \
                   --insecure-policy \
                   --retry-times 5 \
                   --src-creds="${ghcr_user}:${ghcr_pat}" \
@@ -485,7 +510,9 @@ data:
               csrc="docker://${up_chart_prefix}/${cchart}:${cver}"
               cdst="docker://${HARBOR_HOST}/openova-io/${cchart}:${cver}"
               cslug=$(printf '%s_%s' "${cchart}" "${cver}" | tr -c 'A-Za-z0-9._-' '_')
-              if skopeo copy \
+              # #3944: bound the chart-OCI copy too (skopeo GLOBAL flag before
+              # the `copy` subcommand) so a stalled connection fails fast.
+              if skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT}" copy \
                 --insecure-policy \
                 --retry-times 3 \
                 --src-creds="${ghcr_user}:${ghcr_pat}" \

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -846,4 +846,33 @@ if ! grep -q 'chart-mirror-names.txt' "$TMP/render.yaml"; then
 fi
 echo "  PASS (Step-03 Phase A2 mirrors openova-io helm charts into local Harbor before egress is cut)"
 
+echo "[cutover-contract] Case 27: Step-03 harbor-prewarm bounds every skopeo copy with --command-timeout (#3944, Refs #3379 #3642 #3927)"
+# hw171: right after #3927 unstuck step-02, step-03 stalled "active" for HOURS.
+# Root cause: a `skopeo copy` whose connection is ESTABLISHED but then silently
+# STALLS mid-blob hangs INDEFINITELY — `--retry-times` only fires on an ERROR,
+# never on a stuck-but-alive connection — so the worker never drains, the parent
+# `wait` blocks forever, and the Job sits "active" until the 5400s deadline kills
+# it, after which catalyst-api auto-re-runs the DeadlineExceeded step → endless
+# 90-min hangs. The bound `skopeo --command-timeout ${PREWARM_SKOPEO_TIMEOUT}`
+# (a GLOBAL flag, before the `copy` subcommand) collapses the infinite hang into
+# a bounded, retryable failure that the per-image outer loop can self-heal.
+# Both copy loops (Phase A images + Phase A2 charts) MUST carry it.
+if ! grep -q 'PREWARM_SKOPEO_TIMEOUT' "$TMP/render.yaml"; then
+  echo "FAIL: Step-03 missing PREWARM_SKOPEO_TIMEOUT env — skopeo copies are unbounded and can hang the Job 'active' for hours (#3944)" >&2
+  exit 1
+fi
+# Count the actual bound invocations: every `skopeo ... copy` must be preceded by
+# --command-timeout. There are exactly two copy loops (Phase A + Phase A2).
+bound_copies=$(grep -c 'skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT}" copy' "$TMP/render.yaml" || true)
+if [ "${bound_copies}" -lt 2 ]; then
+  echo "FAIL: Step-03 has < 2 --command-timeout-bound skopeo copy invocations (found ${bound_copies}); a Phase A or A2 copy is still unbounded and can hang forever (#3944)" >&2
+  exit 1
+fi
+# And NO bare `skopeo copy` (without the timeout) may remain in the prewarm step.
+if grep -Eq '^\s*(if\s+)?skopeo copy ' "$TMP/render.yaml"; then
+  echo "FAIL: Step-03 still has a bare 'skopeo copy' without --command-timeout — bound it so a stalled connection fails fast (#3944)" >&2
+  exit 1
+fi
+echo "  PASS (Step-03 bounds both Phase A + Phase A2 skopeo copies with --command-timeout; no bare unbounded copy remains)"
+
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -310,6 +310,24 @@ harbor:
 # hit a warm cache. The list is intentionally narrow (the heaviest
 # charts). Operators can extend via overlay; an empty list is also valid.
 prewarm:
+  # #3944 (Refs #3379 #3642 #3927): per-`skopeo copy` command timeout for
+  # step-03 Phase A (openova-io container images) + Phase A2 (openova-io helm
+  # chart OCI artifacts). A `skopeo copy` whose connection is ESTABLISHED but
+  # silently STALLS mid-blob hangs forever — `--retry-times` only fires on an
+  # ERROR, never on a stuck-but-alive connection. With no command timeout the
+  # whole Job sits "active" until the 5400s activeDeadlineSeconds kills it,
+  # catalyst-api auto-re-runs the DeadlineExceeded step, and the next 90-min
+  # hang begins → "step-03 active for hours, never completing" (live hw171, dep
+  # 3963e9267c10a90d, right after #3927 unstuck step-02). This bounds each
+  # individual copy so a stalled connection FAILS FAST → the per-image outer
+  # retry loop (PREWARM_COPY_ATTEMPTS) self-heals. Go duration string (skopeo
+  # `--command-timeout`). 1200s (20m) is generous for the largest multi-layer
+  # PRIVATE openova-io image over throttled egress yet collapses an infinite
+  # hang into a bounded, retryable failure. Operators on extremely slow links
+  # may raise it via overlay; it must stay comfortably below
+  # stepTimeouts.harborPrewarmSeconds (5400s) so at least 2-3 copies can run
+  # serially within one Job's deadline even in the worst case.
+  skopeoCommandTimeout: "1200s"
   images:
     - "proxy-docker/library/redis:7"
     - "proxy-docker/library/postgres:16"


### PR DESCRIPTION
## Problem (live hw171, dep 3963e9267c10a90d)

After #3927 unstuck the Pillar-5 cutover from **step-02** (harbor-projects — `harbor-core.harbor.svc` NXDOMAIN post-#3642), the cutover advanced to **step-03 (harbor-prewarm)** and then **stalled 'active' for hours, never completing** — cutoverComplete stayed false. This is the next defect in the per-attempt 'cutover reveals the earlier-stage bug each time' chain. RCA done from the chart definition (hw171 is wiped).

## Mechanism

Step-03 (`platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml`):
- **Phase A** — `skopeo copy docker://ghcr.io/openova-io/... docker://registry.<fqdn>/...` for the ~29 PRIVATE openova-io container images, in parallel (PREWARM_PARALLELISM=6, PREWARM_COPY_ATTEMPTS=3 outer × `--retry-times 5` inner).
- **Phase A2** — same for the openova-io helm chart OCI artifacts.
- **Phase B** — curl HEAD against the in-cluster `harbor-core.harbor` path (the one #3927 fixed at port 80).

## Root cause

Every `skopeo copy` ran with **NO `--command-timeout`**. `--retry-times` only fires on an **error** (reset/EOF) — it does **nothing** for a connection that is **established but silently stalled** mid-blob (no bytes, no reset). That is exactly the failure mode on a freshly-bootstrapped/throttled Sovereign network, or against the `registry.<fqdn>` front door that accepts the TCP connect but stops responding. The copy hangs **indefinitely** → the worker never drains → the parent `wait` blocks forever → the Job sits 'active' until the 5400s `activeDeadlineSeconds` kills it → catalyst-api auto-re-runs the DeadlineExceeded step (cutover.go) → **back-to-back 90-min hangs = 'active for hours'.**

`#3927` does NOT cover this: it fixed the in-cluster plain-name `harbor-core.harbor` (used by step-02 + step-03 Phase B). Phase A/A2 push to the **public** `registry.<fqdn>` gateway path, which #3927 never touched.

## Fix

Add `skopeo --command-timeout ${PREWARM_SKOPEO_TIMEOUT}` (a **global** skopeo flag, before the `copy` subcommand) to **both** copy loops. New tunable `prewarm.skopeoCommandTimeout` (default **1200s/20m** — generous for the largest multi-layer private image over throttled egress yet bounded). A stalled connection now **fails fast** → the per-image outer retry loop self-heals (the recovery path that was unreachable while the copy hung). Must stay well below `stepTimeouts.harborPrewarmSeconds` (5400s) so multiple copies still fit one deadline even worst-case.

### Files
- `03-harbor-prewarm-job.yaml` — `PREWARM_SKOPEO_TIMEOUT` env + `--command-timeout` on `copy_one` (Phase A) and `copy_chart` (Phase A2).
- `values.yaml` — `prewarm.skopeoCommandTimeout: "1200s"`.
- `tests/cutover-contract.sh` — new **Case 27** gates both bound copies + no bare `skopeo copy` remains (this is the blueprint-release publish gate).
- Lockstep: `Chart.yaml` 0.1.76→**0.1.77** + `blueprint.yaml` + `06a-bp-self-sovereign-cutover.yaml` pin.

## Validation
- `helm template` renders clean; rendered step-03 script passes `sh -n` / `dash -n` / `bash -n`.
- All **27** `cutover-contract.sh` gates green (incl. the new Case 27).
- **Live confirmation deferred** to the hw172 cutover walk reaching step-03 (no live env yet).

## Diagnostic plan for hw172 (confirm root + watch for the secondary gap)
When hw172's cutover reaches step-03, capture the harbor-prewarm Pod log:
1. **Confirm the timeout engages** if a copy stalls: look for skopeo erroring with a timeout rather than the Pod sitting active past ~20m on a single `copy <image> attempt N` line. The step should now either complete or FATAL with `push_fail>0` (a clean, re-runnable failure) rather than hang.
2. **Secondary gap to watch (correctness, NOT this PR):** Phase A enumerates openova-io images via host-side `kubectl get pods -A` (L229). Post-#3642 the openova-io front-door apps run INSIDE the vClusters, so a host `get pods -A` may NOT see them → an **incomplete** prewarm list → post-cutover ImagePullBackOff. If step-03 logs `found <small N> unique openova-io images` (expected ~29), that's the #3642 host-vs-vCluster visibility gap (same family as #3927/#3934) — file/extend a follow-up to enumerate across the vClusters or fall back to the declared bp-* image set. Tracked in #3944.

Refs #3944 #3379 #3642 #3927

🤖 Generated with [Claude Code](https://claude.com/claude-code)