### PR TITLE
fix(bp-catalyst-platform): managed-by:flux on catalyst-gitea-token-mint pre-install hook so Kyverno admits it in catalyst-system — unblock console install (1.4.722)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1047,7 +1047,12 @@ spec:
       #   gates the gitea/harbor sso-configure Deployment (sso.externalSecret.enabled).
       #   Renumbered past the deploy-bot auto-bump to 1.4.717 (one above main's
       #   1.4.716) to clear the pin collision.
-      version: 1.4.721
+      # 1.4.722 — #3946: add app.kubernetes.io/managed-by:flux to the
+      #   catalyst-gitea-token-mint (+ qa-finalizer-strip + migrate) Helm-hook
+      #   Jobs so the Kyverno flux-managed (Enforce) policy admits them in
+      #   catalyst-system. Pre-1.4.722 the pre-install hook was DENIED →
+      #   console install failed pre-install on every Enforce Sovereign (hw172).
+      version: 1.4.722
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,25 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.722 — #3946 (Refs #3296 #3297 #3201, 2026-06-20): unblock console install
+# on every Sovereign where the Kyverno `flux-managed` ClusterPolicy is Enforce.
+# The `catalyst-gitea-token-mint` pre-install hook Job is created directly by
+# Helm (helm.sh/hook: pre-install), so it carries NONE of Flux's HR-applied
+# labels. It lands in .Release.Namespace = `catalyst-system`, which is NOT in
+# the policy's excludeNamespaces list (only `catalyst` is). flux-managed
+# (Enforce) therefore DENIES the hook at admission → bp-catalyst-platform
+# install fails pre-install → Flux uninstalls + retries → console never serves
+# (root-caused live hw172, dep b50ba61d9cb9e157, 1.4.721). FIX: add
+# `app.kubernetes.io/managed-by: flux` (the policy's own documented remediation)
+# to metadata.labels of every Helm-hook Job in templates/ that lands in
+# catalyst-system — catalyst-gitea-token-mint (pre-install),
+# qa-fixtures/qa-finalizer-strip (pre-install), and
+# migrate-applications-instance-id (post-install; its previous
+# `{{ .Release.Service }}` value rendered to `Helm`, also rejected). Mirrors the
+# sibling hooks catalyst-gitea-admin-secret-bridge.yaml +
+# catalog-sovereign-repo-bootstrap-job.yaml that already carry it. NOT a chart
+# regression: the missing-label state is unchanged since 2026-06-09 (a7fb48245);
+# the token-secret template did not change in the 1.4.711→1.4.721 window — the
+# denial is environmental (catalyst-system gated by the Enforce policy).
 # 1.4.707 — #3906 (Refs #3642, #3848, #3813, 2026-06-19): FIX the passwordless
 # PIN-login secret catalyst-openova-kc-credentials hitting the SAME intra-release
 # lookup-ordering trap #3848 already fixed for the org-controller secret. Post-#3642
@@ -2892,7 +2912,7 @@ name: bp-catalyst-platform
 # Catalyst-Zero render adds one namespace to one ingress matchExpression (no
 # behavior change on a host-placed guacamole). Renumbered past the deploy-bot
 # auto-bump to 1.4.717 (one above main's 1.4.716) to clear the pin collision.
-version: 1.4.721
+version: 1.4.722
 # 1.4.702 — #3819 #3854 #3859 (Refs #3383 #3376): sme→org-services rename TAIL — the
 #   funnel/BSS control-plane templates + values default the namespace to `org-services`
 #   instead of the dead `sme` ns: provisioning-github-token / valkey-cross-ns-secret +

--- a/products/catalyst/chart/templates/catalyst-gitea-token-secret.yaml
+++ b/products/catalyst/chart/templates/catalyst-gitea-token-secret.yaml
@@ -308,6 +308,16 @@ metadata:
   name: catalyst-gitea-token-mint
   namespace: {{ $namespace }}
   labels:
+    # #3946: Helm creates this pre-install hook Job directly, so it carries
+    # none of Flux's HR-applied labels. The flux-managed ClusterPolicy
+    # (Enforce) gates Job/catalyst-system/* (catalyst-system is NOT in the
+    # excludeNamespaces list — only `catalyst` is), so without this label
+    # admission DENIES the hook and bp-catalyst-platform install fails
+    # pre-install. The label is the policy's own documented remediation
+    # (platform/kyverno-policies/.../baseline/10-flux-managed.yaml) and
+    # mirrors the sibling hooks catalyst-gitea-admin-secret-bridge.yaml +
+    # catalog-sovereign-repo-bootstrap-job.yaml that already carry it.
+    app.kubernetes.io/managed-by: flux
     catalyst.openova.io/blueprint: bp-catalyst-platform
     catalyst.openova.io/component: catalyst-gitea-token-mint
   annotations:

--- a/products/catalyst/chart/templates/migrate-applications-instanceId-job.yaml
+++ b/products/catalyst/chart/templates/migrate-applications-instanceId-job.yaml
@@ -19,7 +19,14 @@ metadata:
   name: {{ printf "%s-migrate-applications-instance-id" .Release.Name | trunc 63 | trimSuffix "-" }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    # #3946: this hook Job is created directly by Helm and lands in
+    # .Release.Namespace (catalyst-system), which is NOT in the Kyverno
+    # flux-managed (Enforce) excludeNamespaces list. The previous value
+    # `{{ "{{" }} .Release.Service {{ "}}" }}` rendered to `Helm`, which the
+    # policy rejects — it requires the literal value `flux`. Hardcode `flux`
+    # so the post-install migration hook is admitted (same gate that blocks
+    # the catalyst-gitea-token-mint pre-install hook).
+    app.kubernetes.io/managed-by: flux
     app.kubernetes.io/name: catalyst
     app.kubernetes.io/component: migration
     catalyst.openova.io/migration: applications-instance-id

--- a/products/catalyst/chart/templates/qa-fixtures/pre-install-finalizer-strip.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/pre-install-finalizer-strip.yaml
@@ -128,6 +128,12 @@ metadata:
   name: qa-finalizer-strip
   namespace: {{ .Release.Namespace | quote }}
   labels:
+    # #3946: same Kyverno flux-managed (Enforce) gate as the sibling
+    # catalyst-gitea-token-mint pre-install hook — this Job lands in
+    # .Release.Namespace (catalyst-system) which is NOT in the policy
+    # excludeNamespaces list, so the Helm-created (Flux-label-less) hook
+    # is DENIED at admission unless it carries this label.
+    app.kubernetes.io/managed-by: flux
     catalyst.openova.io/managed-by: qa-fixtures
   annotations:
     helm.sh/hook: pre-install,pre-upgrade


### PR DESCRIPTION
## Gate failure (live hw172, dep `b50ba61d9cb9e157`, bp-catalyst-platform 1.4.721)

`bp-catalyst-platform` HR `READY=False`:
```
Helm install failed for release catalyst-system/catalyst-platform with chart bp-catalyst-platform@1.4.721:
failed pre-install: admission webhook "validate.kyverno.svc-fail" denied the request:
resource Job/catalyst-system/catalyst-gitea-token-mint was blocked due to the following policies
flux-managed:
  workload-must-be-flux-managed: 'Job/catalyst-gitea-token-mint is not Flux-managed.
    Add label `app.kubernetes.io/managed-by: flux` on metadata.labels OR attach an
    ownerReference to a HelmRelease / Kustomization.'
```
Flux uninstalls + retries -> same denial -> console never serves -> the 186-row UAT walk is gated.

## Root cause
The `catalyst-gitea-token-mint` pre-install hook Job is created **directly by Helm** (`helm.sh/hook: pre-install,pre-upgrade`), so it carries **none** of Flux's HR-applied labels. It lands in `.Release.Namespace = catalyst-system`, which is **NOT** in the live `flux-managed` ClusterPolicy `excludeNamespaces` list (only `catalyst` is). The policy is **Enforce**, so admission DENIES the Job.

## Regression verdict -- NOT a chart regression
The Job's missing-`managed-by:flux` state is **unchanged since commit `a7fb48245` (2026-06-09)** -- well before 1.4.711. The token-secret template did **not** change in the 1.4.711->1.4.721 window (only image bumps + a network-policy edit). The denial is **environmental**: `catalyst-system` is gated by the Enforce `flux-managed` policy on hw172 (hw171 escaped for some env-state reason -- different policy mode at install / grandfathered Job / different install path).

## Fix
Add `app.kubernetes.io/managed-by: flux` (the policy's own documented remediation message) to `metadata.labels` of **every Helm-hook Job in `products/catalyst/chart/templates/` that lands in catalyst-system**:
- `catalyst-gitea-token-mint` -- `catalyst-gitea-token-secret.yaml` (pre-install) -- the live failure point
- `qa-finalizer-strip` -- `qa-fixtures/pre-install-finalizer-strip.yaml` (pre-install)
- `catalyst-platform-migrate-applications-instance-id` -- `migrate-applications-instanceId-job.yaml` (post-install; its prior `{{ .Release.Service }}` value rendered to `Helm`, also rejected)

Mirrors the sibling hooks `catalyst-gitea-admin-secret-bridge.yaml` + `catalog-sovereign-repo-bootstrap-job.yaml` that already carry the label.

Lockstep bump: `Chart.yaml` 1.4.721->**1.4.722** + `_template` slot pin `13-bp-catalyst-platform.yaml`.

## Validation
- `helm template` renders clean (exit 0); all three Jobs render with `app.kubernetes.io/managed-by: flux` in metadata.
- The pre-existing `helm lint` error (`catalyst-keycloak-credentials-host-bridge.yaml`) is unrelated -- confirmed present on clean origin/main.
- Live-unblock applied to hw172 via a narrow Kyverno PolicyException (not Audit/disable) -- see issue #3946.

Refs #3946 #3296 #3297 #3201

Generated with [Claude Code](https://claude.com/claude-code)
