### PR TITLE
fix(bp-mgmt-vcluster): #3642 spine — replicate gitea-pg-rw/-ro Services host→vc-mgmt (0.2.28)

### DIFF
--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -182,7 +182,7 @@ spec:
       # `harbor-core.harbor.svc` — resolves Harbor again post-#3642 (it now runs
       # INSIDE vc-mgmt; the host name NXDOMAIN'd → cutover wedged at step-02 on
       # hw171). Same proven host-service-aliases mechanism as gitea/keycloak/openbao.
-      version: 0.2.27
+      version: 0.2.28
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -182,7 +182,7 @@ spec:
       # `harbor-core.harbor.svc` — resolves Harbor again post-#3642 (it now runs
       # INSIDE vc-mgmt; the host name NXDOMAIN'd → cutover wedged at step-02 on
       # hw171). Same proven host-service-aliases mechanism as gitea/keycloak/openbao.
-      version: 0.2.26
+      version: 0.2.27
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -303,7 +303,8 @@ spec:
       # seed must run (it polls public.users + rollout-restarts the Deployment,
       # both vcluster-side). Kills the slot-80↔slot-80a circular deadlock. Also
       # absorbs the 1.4.113–1.4.116 deploy-bot upstream-v0.13.2 chart bumps.
-      version: 1.4.117
+      # 1.4.119 (#3948): sql-dsn-gate volume gate symmetry fix.
+      version: 1.4.119
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/clusters/_template/bootstrap-kit/80a-newapi-host-seams.yaml
+++ b/clusters/_template/bootstrap-kit/80a-newapi-host-seams.yaml
@@ -74,8 +74,8 @@ spec:
       # host-seams slot NO LONGER renders the seed Job/CronJob (under host-seams
       # the seed would block on a schema this side never migrates → deadlock).
       # It still renders the CNPG Cluster + DSN-sync Job + AppRegistration +
-      # ExternalSecrets. Lockstep with slot 80 + blueprint.yaml → 1.4.117.
-      version: 1.4.117
+      # ExternalSecrets. Lockstep with slot 80 + blueprint.yaml → 1.4.119 (#3948).
+      version: 1.4.119
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.26
+  version: 0.2.27
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.27
+  version: 0.2.28
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -325,7 +325,10 @@ name: bp-mgmt-vcluster
 # Paired with the 06a-bp-self-sovereign-cutover.yaml overlay change that points
 # harbor.adminSecretRef.name at the synced `harbor-admin-x-harbor-x-mgmt-vcluster`
 # Secret. Refs #3926 #3379 #3642.
-version: 0.2.26
+# 0.2.27 (#3948): fromHost-import gitea/gitea-pg-app (exact-name) so the
+# gitea pod's GITEA__database__PASSWD secretKeyRef resolves inside vc-mgmt —
+# unblocks gitea → bp-catalyst-platform gitea-token-mint hook → console (hw172).
+version: 0.2.27
 appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -328,7 +328,10 @@ name: bp-mgmt-vcluster
 # 0.2.27 (#3948): fromHost-import gitea/gitea-pg-app (exact-name) so the
 # gitea pod's GITEA__database__PASSWD secretKeyRef resolves inside vc-mgmt —
 # unblocks gitea → bp-catalyst-platform gitea-token-mint hook → console (hw172).
-version: 0.2.27
+# 0.2.28 (#3948): replicateServices.fromHost gitea/gitea-pg-rw + -ro (the
+# SERVICE half) so `gitea-pg-rw.gitea.svc.cluster.local` resolves in vc-mgmt —
+# the configure-gitea ORM ping was NXDOMAIN-CrashLooping past the secret fix.
+version: 0.2.28
 appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -467,6 +467,28 @@ vcluster:
           to: newapi/newapi-bp-newapi-newapi-pg-rw
         - from: newapi/newapi-bp-newapi-newapi-pg-ro
           to: newapi/newapi-bp-newapi-newapi-pg-ro
+        # ── #3642/#3948 gitea-pg host→vCluster reachability (the SERVICE half,
+        #    companion to the gitea/gitea-pg-app fromHost SECRET mapping below) ──
+        # gitea ships its OWN dedicated `gitea-pg` CNPG Cluster (NOT shared-pg),
+        # HOST-rendered in host ns `gitea` (placement: gitea HR is vcluster-app,
+        # but its cnpg-cluster.yaml renders host-side via the host-seams seam).
+        # The gitea pod (now in vc-mgmt after #3642) connects to
+        # `gitea-pg-rw.gitea.svc.cluster.local:5432` (values.yaml
+        # gitea.database.HOST). The CNPG `-rw`/`-ro` Services live HOST-side
+        # only, so inside vc-mgmt that FQDN is NXDOMAIN → the `configure-gitea`
+        # init container's ORM ping fails `dial tcp: lookup
+        # gitea-pg-rw.gitea.svc.cluster.local: no such host` → gitea
+        # Init:CrashLoopBackOff → gitea-http never serves → the
+        # catalyst-gitea-token-mint hook retries forever → bp-catalyst-platform
+        # install hangs → CONSOLE NEVER COMES UP (hw172 RCA, dep
+        # b50ba61d9cb9e157). Mirror both Services so the host-style FQDN resolves
+        # in the vCluster — the EXACT same SERVICE-half gap already fixed for
+        # guacamole-pg + newapi-pg above. No-op until the host-seams HR renders
+        # the gitea-pg Cluster (additive).
+        - from: gitea/gitea-pg-rw
+          to: gitea/gitea-pg-rw
+        - from: gitea/gitea-pg-ro
+          to: gitea/gitea-pg-ro
         # ClusterMesh-global write endpoints (active-hot-standby): the host
         # FQDN cross-region SHARED_PG consumers (grafana et al.) actually dial.
         - from: shared-data/shared-pg-mesh-rw

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -737,8 +737,41 @@ vcluster:
         mappings:
           byName:
             # gitea/harbor/grafana — host-minted SSO/OIDC creds ONLY
-            # (the pod-mounted DB Secret is intentionally NOT imported).
+            # (the pod-mounted *-database-secret reflector hub Secret is
+            # intentionally NOT imported — it would make the from-host and
+            # to-host secret syncers fight over the same virtual object, the
+            # #3374 deadlock; the DB hub Secret is delivered natively
+            # in-vCluster by bp-postgres mangledTarget per #3879 instead).
             "gitea/gitea-oauth-source-credentials": "gitea/gitea-oauth-source-credentials"
+            # ── #3642/#3948 gitea-pg-app delivery (hw172 spine wedge) ──
+            # gitea (unlike keycloak/grafana/harbor) consumes its DB password
+            # from the RAW CNPG-app Secret `gitea-pg-app` DIRECTLY (chart
+            # values.yaml `additionalConfigFromEnvs` →
+            # GITEA__database__PASSWD secretKeyRef name: gitea-pg-app), NOT
+            # the reflected `gitea-database-secret`. After #3642 moved gitea
+            # INTO vc-mgmt the pod resolves that as
+            # `gitea-pg-app-x-gitea-x-mgmt-vcluster` in host ns `mgmt`, which
+            # never lands: host CNPG `gitea-pg` mints `gitea-pg-app` in host
+            # ns `gitea` (emberstack reflector-scoped to `gitea` only) and the
+            # `gitea/*` wildcard above was narrowed to SSO-only — so nothing
+            # delivers `gitea-pg-app` across the host→vCluster boundary →
+            # gitea pod `Init:CreateContainerConfigError` (secret
+            # "gitea-pg-app-x-gitea-x-mgmt-vcluster" not found) → the
+            # bp-catalyst-platform `gitea-token-mint` pre-install hook hangs
+            # → console install times out (hw172 RCA, dep b50ba61d9cb9e157).
+            #
+            # SAFE to fromHost-import (no from-host↔to-host fight): unlike the
+            # 4 `*-database-secret` reflector hub Secrets, `gitea-pg-app` is
+            # the RAW CNPG-generated app Secret — it carries NO emberstack
+            # `reflection-*` annotations targeting ns `mgmt` and is NOT
+            # materialised there by any bp-postgres mangledTarget (#3879), so
+            # the from-host syncer is its ONLY in-vCluster owner. Proven by
+            # the byte-identical working analog `guacamole-pg-app` (also a raw
+            # CNPG-app Secret, pod-mounted inside vc-mgmt) delivered cleanly
+            # via the `catalyst-system/*` wildcard below — guacamole-server
+            # runs 1/1 in vc-mgmt with no syncer contention. EXACT-NAME (not
+            # `gitea/*`) so the #3374 DB-hub-Secret exclusion stays intact.
+            "gitea/gitea-pg-app": "gitea/gitea-pg-app"
             "harbor/harbor-sso-oidc-credentials": "harbor/harbor-sso-oidc-credentials"
             "grafana/grafana-sso-oidc-credentials": "grafana/grafana-sso-oidc-credentials"
             # keycloak — NO entry: the only host-minted Secret it needs is

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.118
+  version: 1.4.119
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -802,7 +802,12 @@ name: bp-newapi
 # role=all keeps the gate "true" so standalone/host-placed installs are
 # byte-identical. Lockstep: 80-newapi.yaml + 80a-newapi-host-seams.yaml pins +
 # blueprint.yaml → 1.4.117.
-version: 1.4.118
+# 1.4.119 (#3948): render the `sql-dsn-gate` Secret VOLUME under the same
+# `$dsnGateOn` condition as the wait-for-sql-dsn initContainer (was gated on
+# cnpg.enabled alone) — fixes `volumeMounts[0].name: Not found "sql-dsn-gate"`
+# install failure under placement.role=vcluster-app (cnpg.enabled=false +
+# database.existingSecret set). Lockstep: both slot pins + blueprint → 1.4.119.
+version: 1.4.119
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/deployment.yaml
+++ b/platform/newapi/chart/templates/deployment.yaml
@@ -553,9 +553,16 @@ spec:
           emptyDir:
             sizeLimit: 64Mi
         {{- end }}
-        {{- /* #3374: DSN Secret projected for the wait-for-sql-dsn initContainer. */ -}}
-        {{- $dsnGate := .Values.databaseDsnGate | default dict -}}
-        {{- if and (default true $dsnGate.enabled) .Values.cnpg.enabled }}
+        {{- /* #3374: DSN Secret projected for the wait-for-sql-dsn initContainer.
+           #3948: the volume MUST render under the SAME `$dsnGateOn` condition as
+           the wait-for-sql-dsn initContainer (defined above) — not `cnpg.enabled`
+           alone. Under placement.role=vcluster-app cnpg.enabled is false but
+           `database.existingSecret` is set (the mirrored DSN), so `$dsnGateOn`
+           is true and the initContainer renders WITH its `sql-dsn-gate`
+           volumeMount; the old `cnpg.enabled`-only gate dropped the volume →
+           `initContainers[1].volumeMounts[0].name: Not found: "sql-dsn-gate"`
+           install failure (hw172 bp-newapi HR). `$effDbSecret` is in scope here. */ -}}
+        {{- if $dsnGateOn }}
         - name: sql-dsn-gate
           secret:
             secretName: {{ $effDbSecret }}


### PR DESCRIPTION
Refs #3948 #3642 #3737 — follow-up to #3949 (the SERVICE half of the same gitea spine wedge).

#3949 fixed the gitea-pg-app SECRET so the gitea pod could mount its DB password — but the pod then CrashLooped one layer deeper:

```
configure-gitea: dial tcp: lookup gitea-pg-rw.gitea.svc.cluster.local: no such host
```

gitea ships its OWN dedicated `gitea-pg` CNPG Cluster (host ns `gitea`). After #3642 the gitea pod runs in vc-mgmt and dials `gitea-pg-rw.gitea.svc.cluster.local:5432` (`values.yaml gitea.database.HOST`), but the CNPG `-rw`/`-ro` Services live host-side only → NXDOMAIN inside vc-mgmt → gitea `Init:CrashLoopBackOff` → gitea-http never serves → `catalyst-gitea-token-mint` hook retries forever → bp-catalyst-platform install hangs → **console never comes up** (hw172, dep `b50ba61d9cb9e157`).

**Fix:** add `gitea/gitea-pg-rw` + `gitea/gitea-pg-ro` to `replicateServices.fromHost` — the exact SERVICE-half gap already covered for guacamole-pg + newapi-pg. Additive (no-op until the host-seams HR renders the gitea-pg Cluster).

Lockstep: chart + blueprint + slot pin (`58-bp-mgmt-vcluster`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)