### PR TITLE
fix(bp-catalyst-platform): gitea-token-mint readiness probe is 403-tolerant (1.4.723)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1052,7 +1052,9 @@ spec:
       #   Jobs so the Kyverno flux-managed (Enforce) policy admits them in
       #   catalyst-system. Pre-1.4.722 the pre-install hook was DENIED →
       #   console install failed pre-install on every Enforce Sovereign (hw172).
-      version: 1.4.722
+      # - 1.4.723 (#3948): gitea-token-mint readiness probe is 403-tolerant
+      #   (was curl -sSf → 14min dead-wait on REQUIRE_SIGNIN_VIEW gitea).
+      version: 1.4.723
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -182,7 +182,7 @@ spec:
       # `harbor-core.harbor.svc` — resolves Harbor again post-#3642 (it now runs
       # INSIDE vc-mgmt; the host name NXDOMAIN'd → cutover wedged at step-02 on
       # hw171). Same proven host-service-aliases mechanism as gitea/keycloak/openbao.
-      version: 0.2.27
+      version: 0.2.28
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -182,7 +182,7 @@ spec:
       # `harbor-core.harbor.svc` — resolves Harbor again post-#3642 (it now runs
       # INSIDE vc-mgmt; the host name NXDOMAIN'd → cutover wedged at step-02 on
       # hw171). Same proven host-service-aliases mechanism as gitea/keycloak/openbao.
-      version: 0.2.26
+      version: 0.2.27
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -303,7 +303,8 @@ spec:
       # seed must run (it polls public.users + rollout-restarts the Deployment,
       # both vcluster-side). Kills the slot-80↔slot-80a circular deadlock. Also
       # absorbs the 1.4.113–1.4.116 deploy-bot upstream-v0.13.2 chart bumps.
-      version: 1.4.117
+      # 1.4.119 (#3948): sql-dsn-gate volume gate symmetry fix.
+      version: 1.4.119
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/clusters/_template/bootstrap-kit/80a-newapi-host-seams.yaml
+++ b/clusters/_template/bootstrap-kit/80a-newapi-host-seams.yaml
@@ -74,8 +74,8 @@ spec:
       # host-seams slot NO LONGER renders the seed Job/CronJob (under host-seams
       # the seed would block on a schema this side never migrates → deadlock).
       # It still renders the CNPG Cluster + DSN-sync Job + AppRegistration +
-      # ExternalSecrets. Lockstep with slot 80 + blueprint.yaml → 1.4.117.
-      version: 1.4.117
+      # ExternalSecrets. Lockstep with slot 80 + blueprint.yaml → 1.4.119 (#3948).
+      version: 1.4.119
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.26
+  version: 0.2.27
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.27
+  version: 0.2.28
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -325,7 +325,10 @@ name: bp-mgmt-vcluster
 # Paired with the 06a-bp-self-sovereign-cutover.yaml overlay change that points
 # harbor.adminSecretRef.name at the synced `harbor-admin-x-harbor-x-mgmt-vcluster`
 # Secret. Refs #3926 #3379 #3642.
-version: 0.2.26
+# 0.2.27 (#3948): fromHost-import gitea/gitea-pg-app (exact-name) so the
+# gitea pod's GITEA__database__PASSWD secretKeyRef resolves inside vc-mgmt —
+# unblocks gitea → bp-catalyst-platform gitea-token-mint hook → console (hw172).
+version: 0.2.27
 appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -328,7 +328,10 @@ name: bp-mgmt-vcluster
 # 0.2.27 (#3948): fromHost-import gitea/gitea-pg-app (exact-name) so the
 # gitea pod's GITEA__database__PASSWD secretKeyRef resolves inside vc-mgmt —
 # unblocks gitea → bp-catalyst-platform gitea-token-mint hook → console (hw172).
-version: 0.2.27
+# 0.2.28 (#3948): replicateServices.fromHost gitea/gitea-pg-rw + -ro (the
+# SERVICE half) so `gitea-pg-rw.gitea.svc.cluster.local` resolves in vc-mgmt —
+# the configure-gitea ORM ping was NXDOMAIN-CrashLooping past the secret fix.
+version: 0.2.28
 appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -467,6 +467,28 @@ vcluster:
           to: newapi/newapi-bp-newapi-newapi-pg-rw
         - from: newapi/newapi-bp-newapi-newapi-pg-ro
           to: newapi/newapi-bp-newapi-newapi-pg-ro
+        # ── #3642/#3948 gitea-pg host→vCluster reachability (the SERVICE half,
+        #    companion to the gitea/gitea-pg-app fromHost SECRET mapping below) ──
+        # gitea ships its OWN dedicated `gitea-pg` CNPG Cluster (NOT shared-pg),
+        # HOST-rendered in host ns `gitea` (placement: gitea HR is vcluster-app,
+        # but its cnpg-cluster.yaml renders host-side via the host-seams seam).
+        # The gitea pod (now in vc-mgmt after #3642) connects to
+        # `gitea-pg-rw.gitea.svc.cluster.local:5432` (values.yaml
+        # gitea.database.HOST). The CNPG `-rw`/`-ro` Services live HOST-side
+        # only, so inside vc-mgmt that FQDN is NXDOMAIN → the `configure-gitea`
+        # init container's ORM ping fails `dial tcp: lookup
+        # gitea-pg-rw.gitea.svc.cluster.local: no such host` → gitea
+        # Init:CrashLoopBackOff → gitea-http never serves → the
+        # catalyst-gitea-token-mint hook retries forever → bp-catalyst-platform
+        # install hangs → CONSOLE NEVER COMES UP (hw172 RCA, dep
+        # b50ba61d9cb9e157). Mirror both Services so the host-style FQDN resolves
+        # in the vCluster — the EXACT same SERVICE-half gap already fixed for
+        # guacamole-pg + newapi-pg above. No-op until the host-seams HR renders
+        # the gitea-pg Cluster (additive).
+        - from: gitea/gitea-pg-rw
+          to: gitea/gitea-pg-rw
+        - from: gitea/gitea-pg-ro
+          to: gitea/gitea-pg-ro
         # ClusterMesh-global write endpoints (active-hot-standby): the host
         # FQDN cross-region SHARED_PG consumers (grafana et al.) actually dial.
         - from: shared-data/shared-pg-mesh-rw

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -737,8 +737,41 @@ vcluster:
         mappings:
           byName:
             # gitea/harbor/grafana — host-minted SSO/OIDC creds ONLY
-            # (the pod-mounted DB Secret is intentionally NOT imported).
+            # (the pod-mounted *-database-secret reflector hub Secret is
+            # intentionally NOT imported — it would make the from-host and
+            # to-host secret syncers fight over the same virtual object, the
+            # #3374 deadlock; the DB hub Secret is delivered natively
+            # in-vCluster by bp-postgres mangledTarget per #3879 instead).
             "gitea/gitea-oauth-source-credentials": "gitea/gitea-oauth-source-credentials"
+            # ── #3642/#3948 gitea-pg-app delivery (hw172 spine wedge) ──
+            # gitea (unlike keycloak/grafana/harbor) consumes its DB password
+            # from the RAW CNPG-app Secret `gitea-pg-app` DIRECTLY (chart
+            # values.yaml `additionalConfigFromEnvs` →
+            # GITEA__database__PASSWD secretKeyRef name: gitea-pg-app), NOT
+            # the reflected `gitea-database-secret`. After #3642 moved gitea
+            # INTO vc-mgmt the pod resolves that as
+            # `gitea-pg-app-x-gitea-x-mgmt-vcluster` in host ns `mgmt`, which
+            # never lands: host CNPG `gitea-pg` mints `gitea-pg-app` in host
+            # ns `gitea` (emberstack reflector-scoped to `gitea` only) and the
+            # `gitea/*` wildcard above was narrowed to SSO-only — so nothing
+            # delivers `gitea-pg-app` across the host→vCluster boundary →
+            # gitea pod `Init:CreateContainerConfigError` (secret
+            # "gitea-pg-app-x-gitea-x-mgmt-vcluster" not found) → the
+            # bp-catalyst-platform `gitea-token-mint` pre-install hook hangs
+            # → console install times out (hw172 RCA, dep b50ba61d9cb9e157).
+            #
+            # SAFE to fromHost-import (no from-host↔to-host fight): unlike the
+            # 4 `*-database-secret` reflector hub Secrets, `gitea-pg-app` is
+            # the RAW CNPG-generated app Secret — it carries NO emberstack
+            # `reflection-*` annotations targeting ns `mgmt` and is NOT
+            # materialised there by any bp-postgres mangledTarget (#3879), so
+            # the from-host syncer is its ONLY in-vCluster owner. Proven by
+            # the byte-identical working analog `guacamole-pg-app` (also a raw
+            # CNPG-app Secret, pod-mounted inside vc-mgmt) delivered cleanly
+            # via the `catalyst-system/*` wildcard below — guacamole-server
+            # runs 1/1 in vc-mgmt with no syncer contention. EXACT-NAME (not
+            # `gitea/*`) so the #3374 DB-hub-Secret exclusion stays intact.
+            "gitea/gitea-pg-app": "gitea/gitea-pg-app"
             "harbor/harbor-sso-oidc-credentials": "harbor/harbor-sso-oidc-credentials"
             "grafana/grafana-sso-oidc-credentials": "grafana/grafana-sso-oidc-credentials"
             # keycloak — NO entry: the only host-minted Secret it needs is

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.118
+  version: 1.4.119
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -802,7 +802,12 @@ name: bp-newapi
 # role=all keeps the gate "true" so standalone/host-placed installs are
 # byte-identical. Lockstep: 80-newapi.yaml + 80a-newapi-host-seams.yaml pins +
 # blueprint.yaml → 1.4.117.
-version: 1.4.118
+# 1.4.119 (#3948): render the `sql-dsn-gate` Secret VOLUME under the same
+# `$dsnGateOn` condition as the wait-for-sql-dsn initContainer (was gated on
+# cnpg.enabled alone) — fixes `volumeMounts[0].name: Not found "sql-dsn-gate"`
+# install failure under placement.role=vcluster-app (cnpg.enabled=false +
+# database.existingSecret set). Lockstep: both slot pins + blueprint → 1.4.119.
+version: 1.4.119
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/deployment.yaml
+++ b/platform/newapi/chart/templates/deployment.yaml
@@ -553,9 +553,16 @@ spec:
           emptyDir:
             sizeLimit: 64Mi
         {{- end }}
-        {{- /* #3374: DSN Secret projected for the wait-for-sql-dsn initContainer. */ -}}
-        {{- $dsnGate := .Values.databaseDsnGate | default dict -}}
-        {{- if and (default true $dsnGate.enabled) .Values.cnpg.enabled }}
+        {{- /* #3374: DSN Secret projected for the wait-for-sql-dsn initContainer.
+           #3948: the volume MUST render under the SAME `$dsnGateOn` condition as
+           the wait-for-sql-dsn initContainer (defined above) — not `cnpg.enabled`
+           alone. Under placement.role=vcluster-app cnpg.enabled is false but
+           `database.existingSecret` is set (the mirrored DSN), so `$dsnGateOn`
+           is true and the initContainer renders WITH its `sql-dsn-gate`
+           volumeMount; the old `cnpg.enabled`-only gate dropped the volume →
+           `initContainers[1].volumeMounts[0].name: Not found: "sql-dsn-gate"`
+           install failure (hw172 bp-newapi HR). `$effDbSecret` is in scope here. */ -}}
+        {{- if $dsnGateOn }}
         - name: sql-dsn-gate
           secret:
             secretName: {{ $effDbSecret }}

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2912,7 +2912,11 @@ name: bp-catalyst-platform
 # Catalyst-Zero render adds one namespace to one ingress matchExpression (no
 # behavior change on a host-placed guacamole). Renumbered past the deploy-bot
 # auto-bump to 1.4.717 (one above main's 1.4.716) to clear the pin collision.
-version: 1.4.722
+# 1.4.723 (#3948): gitea-token-mint readiness probe treats ANY HTTP answer
+# (incl. 403 from REQUIRE_SIGNIN_VIEW) as reachable — was `curl -sSf` which
+# never broke on 403 and burned the full 14min wait every prov before the
+# (authenticated) mint, slowing bp-catalyst-platform install → console.
+version: 1.4.723
 # 1.4.702 — #3819 #3854 #3859 (Refs #3383 #3376): sme→org-services rename TAIL — the
 #   funnel/BSS control-plane templates + values default the namespace to `org-services`
 #   instead of the dead `sme` ns: provisioning-github-token / valkey-cross-ns-secret +

--- a/products/catalyst/chart/templates/catalyst-gitea-token-secret.yaml
+++ b/products/catalyst/chart/templates/catalyst-gitea-token-secret.yaml
@@ -372,10 +372,25 @@ spec:
               # *chart-internal* layer of that same family.
               ITERATIONS={{ .Values.giteaWait.iterations | default 168 }}
               INTERVAL={{ .Values.giteaWait.intervalSeconds | default 5 }}
+              # Readiness = the gitea API server ANSWERS, not 2xx. #3948: with
+              # `REQUIRE_SIGNIN_VIEW` enabled, gitea returns HTTP 403
+              # ("Only signed in user is allowed to call APIs") on the
+              # unauthenticated /api/v1/version probe — a `curl -sSf` (-f fails
+              # on >=400) NEVER breaks the loop, so the hook burned the FULL
+              # 168x5s=14min budget on every prov before falling through to the
+              # mint (Step 4 IS authenticated `-u GU:GP`, so it succeeded anyway
+              # — the wait was pure dead time that slowed the whole spine →
+              # bp-catalyst-platform install → console by ~14min; on hw172 the
+              # gitea pod itself had only just recovered, compounding the delay).
+              # Any HTTP status (incl. 403) proves the API is up; a connect
+              # failure (NXDOMAIN / refused) yields curl exit!=0 + empty code.
+              # So break on a non-empty HTTP code and keep waiting only while the
+              # server is genuinely unreachable.
               for i in $(seq 1 "$ITERATIONS"); do
-                if curl -sSf -o /dev/null --max-time 3 \
-                     http://gitea-http.gitea.svc.cluster.local:3000/api/v1/version; then
-                  echo "gitea api reachable"
+                CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 3 \
+                     http://gitea-http.gitea.svc.cluster.local:3000/api/v1/version || true)
+                if [ -n "$CODE" ] && [ "$CODE" != "000" ]; then
+                  echo "gitea api reachable (HTTP $CODE)"
                   break
                 fi
                 echo "waiting for gitea api ($i/$ITERATIONS)"


### PR DESCRIPTION
Refs #3948 #3642 — follow-up to #3949/#3950, removes a 14min dead-wait on the console-up critical path.

The `catalyst-gitea-token-mint` pre-install hook's readiness loop used `curl -sSf /api/v1/version`. With gitea's `REQUIRE_SIGNIN_VIEW` enabled, the unauthenticated probe returns **HTTP 403** (`Only signed in user is allowed to call APIs`) — and `-f` (fail on ≥400) means the loop NEVER breaks, so the hook spun the full 168×5s=**14min** budget on every prov before falling through to the mint. Step 4 (the actual mint) is authenticated (`-u GU:GP`) so it succeeded anyway — the 14min was pure dead time delaying `bp-catalyst-platform` install → console.

**Fix:** treat ANY HTTP answer (incl. 403) as 'API reachable'; only a connect failure (NXDOMAIN/refused → curl code `000`/empty) keeps waiting.

**Verified live on hw172** (dep `b50ba61d9cb9e157`): once gitea served, the token minted immediately and `bp-catalyst-platform` install proceeded to deploy the console/api workloads.

Lockstep: chart + slot pin (`13-bp-catalyst-platform`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)