### PR TITLE
fix(bp-mgmt-vcluster): #3642 secret+service cross-boundary cascade on hw172 — harbor/seaweedfs/valkey/gitea-pg delivery + 403-tolerant gitea-mint (0.2.28 / 1.4.724)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1052,7 +1052,7 @@ spec:
       #   Jobs so the Kyverno flux-managed (Enforce) policy admits them in
       #   catalyst-system. Pre-1.4.722 the pre-install hook was DENIED →
       #   console install failed pre-install on every Enforce Sovereign (hw172).
-      version: 1.4.723
+      version: 1.4.724
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -182,7 +182,7 @@ spec:
       # `harbor-core.harbor.svc` — resolves Harbor again post-#3642 (it now runs
       # INSIDE vc-mgmt; the host name NXDOMAIN'd → cutover wedged at step-02 on
       # hw171). Same proven host-service-aliases mechanism as gitea/keycloak/openbao.
-      version: 0.2.27
+      version: 0.2.28
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.27
+  version: 0.2.28
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -328,7 +328,28 @@ name: bp-mgmt-vcluster
 # 0.2.27 (#3948): fromHost-import gitea/gitea-pg-app (exact-name) so the
 # gitea pod's GITEA__database__PASSWD secretKeyRef resolves inside vc-mgmt —
 # unblocks gitea → bp-catalyst-platform gitea-token-mint hook → console (hw172).
-version: 0.2.27
+# 0.2.28 (#3952, Refs #3642 #3737 #3948 — SUPERSEDES #3950/#3951): comprehensive
+# fix for the #3642 secret+service cross-boundary cascade root-caused live on
+# hw172 (dep b50ba61d9cb9e157, BOTH regions). Two delivery mechanisms:
+#   sync.fromHost.secrets.mappings.byName:
+#     + harbor/harbor-pg-app (host→mgmt, exact-name analog of 0.2.27 gitea-pg-app):
+#       harbor's in-vc database-secret-sync Job copies this raw CNPG-app Secret →
+#       harbor-database-secret; without it harbor-core CreateContainerConfigError.
+#     + rtz/seaweedfs-s3-secret-x-seaweedfs-x-rtz-vcluster (CROSS-vc rtz→mgmt):
+#       openbao snapshot-replication's S3-creds seeder reads it from ns rtz;
+#       invisible inside vc-mgmt after #3642 → openbao-snapshot-save stuck.
+#   networking.replicateServices.fromHost:
+#     + gitea-pg-rw/-ro + harbor-pg-rw/-ro (host→mgmt): the dedicated embedded
+#       CNPG -rw/-ro Services don't reliably resolve inside vc-mgmt — PROVEN by
+#       region-B gitea Init:CrashLoop `lookup gitea-pg-rw.gitea.svc: no such host`.
+#       Folds #3950 (the SERVICE half).
+#     + valkey-primary + seaweedfs-s3 rtz-mangled (CROSS-vc rtz→mgmt): newapi
+#       Redis URL + openbao S3 endpoint point at vc-rtz Services that NXDOMAIN
+#       inside vc-mgmt → newapi `[FATAL] Redis ping test failed` CrashLoop.
+# All additions are additive / no-op-until-the-source-renders (the established
+# replicateServices + fromHost-secrets semantics). #3951 (gitea-token-mint
+# 403-tolerant probe) is folded into bp-catalyst-platform, NOT here.
+version: 0.2.28
 appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -467,6 +467,57 @@ vcluster:
           to: newapi/newapi-bp-newapi-newapi-pg-rw
         - from: newapi/newapi-bp-newapi-newapi-pg-ro
           to: newapi/newapi-bp-newapi-newapi-pg-ro
+        # ── #3952 gitea-pg + harbor-pg host→vCluster reachability (SERVICE half) ──
+        # gitea + harbor each own a DEDICATED embedded CNPG `Cluster` HOST-rendered
+        # in host ns `gitea`/`harbor` (NOT shared-pg). After #3642 both apps run
+        # INSIDE vc-mgmt and dial the CNPG primary at
+        # `<app>-pg-rw.<ns>.svc.cluster.local:5432` (gitea values.yaml
+        # `gitea.database.HOST`; harbor values.yaml `database.host`
+        # `harbor-pg-rw.harbor.svc.cluster.local`). The CNPG `-rw`/`-ro` Services
+        # live HOST-side only and DON'T reliably resolve inside vc-mgmt:
+        # PROVEN on hw172 — region-B `gitea` `Init:CrashLoopBackOff`
+        # `Failed to initialize ORM engine: dial tcp: lookup
+        # gitea-pg-rw.gitea.svc.cluster.local: no such host` while the host CNPG
+        # `gitea-pg` is 1/1 healthy. (Region-A gitea resolved transiently — the
+        # vCluster CoreDNS host-service fallthrough is timing-dependent; the
+        # replicateServices mirror is the deterministic fix.) harbor-core hits the
+        # identical NXDOMAIN on `harbor-pg-rw.harbor.svc` the moment its
+        # `harbor-database-secret` lands (the secret fix above). Same 4th-layer
+        # DNS gap already fixed for guacamole-pg/newapi-pg above — mirror the
+        # gitea-pg + harbor-pg `-rw`/`-ro` Services so both apps' host-style
+        # FQDNs resolve natively inside vc-mgmt. Additive / no-op until each
+        # host-bridged CNPG Cluster renders. Folds #3950 (SERVICE half). Refs
+        # #3952 #3948 #3642.
+        - from: gitea/gitea-pg-rw
+          to: gitea/gitea-pg-rw
+        - from: gitea/gitea-pg-ro
+          to: gitea/gitea-pg-ro
+        - from: harbor/harbor-pg-rw
+          to: harbor/harbor-pg-rw
+        - from: harbor/harbor-pg-ro
+          to: harbor/harbor-pg-ro
+        # ── #3952 CROSS-vCLUSTER (rtz→mgmt) SERVICE reachability ──
+        # Two vc-mgmt apps depend on Services that live in the RTZ vCluster
+        # (#3373 Batch A re-homed valkey + seaweedfs INTO vc-rtz), so their host
+        # projections are the rtz-syncer-mangled names in HOST ns `rtz`. Pre-#3642
+        # these apps ran HOST-side and resolved the host ns-`rtz` Service; after
+        # #3642 they run inside vc-mgmt, whose CoreDNS has NO ns `rtz` → NXDOMAIN.
+        # Mirror each host `rtz/<svc>` into vc-mgmt ns `rtz` (same name) so the
+        # baked FQDN resolves natively:
+        #   • valkey-primary — newapi's `REDIS_CONN_STRING` (chart 1.4.81/#3482)
+        #     is `redis://valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc:6379`;
+        #     without this newapi `[FATAL] Redis ping test failed: lookup … no
+        #     such host` CrashLoops (hw172, BOTH regions).
+        #   • seaweedfs-s3 — openbao snapshot-replication's `S3_ENDPOINT` is
+        #     `http://seaweedfs-s3-x-seaweedfs-x-rtz-vcluster.rtz.svc:8333`; the
+        #     companion creds Secret is delivered by the fromHost.secrets entry
+        #     above. Both are needed for the raft-snapshot S3 backup to work.
+        # No-op until bp-valkey/bp-seaweedfs render in vc-rtz (additive). Refs
+        # #3952 #3482 #3629 #3373.
+        - from: rtz/valkey-primary-x-valkey-x-rtz-vcluster
+          to: rtz/valkey-primary-x-valkey-x-rtz-vcluster
+        - from: rtz/seaweedfs-s3-x-seaweedfs-x-rtz-vcluster
+          to: rtz/seaweedfs-s3-x-seaweedfs-x-rtz-vcluster
         # ClusterMesh-global write endpoints (active-hot-standby): the host
         # FQDN cross-region SHARED_PG consumers (grafana et al.) actually dial.
         - from: shared-data/shared-pg-mesh-rw
@@ -773,6 +824,33 @@ vcluster:
             # `gitea/*`) so the #3374 DB-hub-Secret exclusion stays intact.
             "gitea/gitea-pg-app": "gitea/gitea-pg-app"
             "harbor/harbor-sso-oidc-credentials": "harbor/harbor-sso-oidc-credentials"
+            # ── #3952 harbor-pg-app delivery (hw172 spine wedge) ──
+            # EXACT analog of the gitea-pg-app fix above (#3948/#3949). Harbor
+            # runs its OWN embedded CNPG `harbor-pg` (host ns `harbor`) — it is
+            # NOT a shared-pg consumer, so bp-postgres `mangledTarget` (#3879)
+            # does NOT mint a `harbor-database-secret` for it. Instead the harbor
+            # chart's in-vc-mgmt `harbor-database-secret-sync` post-install Job
+            # (templates/database-secret-sync-job.yaml) copies the raw CNPG-app
+            # Secret `harbor-pg-app` → `harbor-database-secret`, which harbor-core
+            # then mounts (values.yaml `database.password` secretKeyRef). After
+            # #3642 moved Harbor INTO vc-mgmt, `harbor-pg-app` is minted by CNPG
+            # in the HOST ns `harbor` (emberstack reflector scoped to `harbor`
+            # only) and is NOT visible inside vc-mgmt → the sync-Job's source
+            # poll never resolves → `harbor-database-secret` is never created →
+            # harbor-core `CreateContainerConfigError` (secret
+            # "harbor-database-secret-x-harbor-x-mgmt-vcluster" not found) →
+            # harbor-jobservice CrashLoops on it (hw172 RCA, dep
+            # b50ba61d9cb9e157, BOTH regions). SAFE to fromHost-import (single
+            # in-vCluster owner, no from-host↔to-host fight): like gitea-pg-app
+            # it is the RAW CNPG-generated app Secret — NO emberstack
+            # `reflection-*` annotation targeting ns `mgmt`, NOT materialised
+            # there by any bp-postgres mangledTarget — so the from-host syncer is
+            # its only in-vc owner. Proven by the byte-identical working analogs
+            # `gitea-pg-app` (above) + `guacamole-pg-app` (catalyst-system/*).
+            # EXACT-NAME (not `harbor/*`) so the #3374 `harbor-database-secret`
+            # DB-hub exclusion stays intact (that hub Secret must NEVER be
+            # fromHost-imported — it is reflector-owned). Refs #3952 #3642.
+            "harbor/harbor-pg-app": "harbor/harbor-pg-app"
             "grafana/grafana-sso-oidc-credentials": "grafana/grafana-sso-oidc-credentials"
             # keycloak — NO entry: the only host-minted Secret it needs is
             # `keycloak-database-secret` (excluded above); it has no host SSO
@@ -781,6 +859,32 @@ vcluster:
             "openbao/openbao-sso-oidc-credentials": "openbao/openbao-sso-oidc-credentials"
             "openbao/openbao-host-token-reviewer-static": "openbao/openbao-host-token-reviewer-static"
             "catalyst-system/*": "catalyst-system/*"
+            # ── #3952 CROSS-vCLUSTER (rtz→mgmt): seaweedfs-s3-secret ──
+            # openbao's snapshot-replication CronJob (templates/snapshot-
+            # replication.yaml) backs its raft snapshots to the SeaweedFS S3
+            # endpoint. SeaweedFS lives in the RTZ vCluster (#3373 Batch A), so
+            # its S3 admin Secret is the rtz-syncer-mangled host object
+            # `seaweedfs-s3-secret-x-seaweedfs-x-rtz-vcluster` in HOST ns `rtz`.
+            # The openbao chart ships an `openbao-snapshot-s3-seed` Job that does
+            # a cross-namespace `get secret -n rtz
+            # seaweedfs-s3-secret-x-seaweedfs-x-rtz-vcluster` and copies the
+            # admin keys into the openbao ns as `seaweedfs-s3-secret` (the
+            # CronJob reads creds via secretKeyRef, which K8s resolves only in
+            # the Pod's own namespace). Pre-#3642 openbao ran HOST-side so that
+            # ns-`rtz` read resolved against the host apiserver. After #3642
+            # openbao runs INSIDE vc-mgmt, whose apiserver has NO ns `rtz` and
+            # cannot see that host Secret → the seeder Job loops its 30-min wait
+            # forever (`secrets "seaweedfs-s3-secret-x-seaweedfs-x-rtz-vcluster"
+            # not found`) → `seaweedfs-s3-secret` never lands →
+            # `openbao-snapshot-save`/`-fetch` `CreateContainerConfigError`
+            # (hw172 RCA, BOTH regions). Mirroring the host `rtz/<src>` Secret
+            # into vc-mgmt ns `rtz` (same name) makes the seeder's cross-ns read
+            # resolve natively inside vc-mgmt with ZERO openbao-chart change
+            # ($seederSrcNs=`rtz`, $seederSrcName=`seaweedfs-s3-secret-x-...`).
+            # No-op until bp-seaweedfs (a later rtz-vCluster slot) renders the
+            # source — additive. The companion S3-ENDPOINT Service is mirrored
+            # via replicateServices.fromHost below. Refs #3952 #3629 #3373.
+            "rtz/seaweedfs-s3-secret-x-seaweedfs-x-rtz-vcluster": "rtz/seaweedfs-s3-secret-x-seaweedfs-x-rtz-vcluster"
 
   # ── In-vCluster CRD registration (#3373, OSS-native) ────────────────────
   # The init-manifests deployer (`loft-sh/vcluster` controllers

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2912,7 +2912,15 @@ name: bp-catalyst-platform
 # Catalyst-Zero render adds one namespace to one ingress matchExpression (no
 # behavior change on a host-placed guacamole). Renumbered past the deploy-bot
 # auto-bump to 1.4.717 (one above main's 1.4.716) to clear the pin collision.
-version: 1.4.723
+# 1.4.724 — #3952 (folds #3951, Refs #3642 #3948): the catalyst-gitea-token-mint
+# pre-install hook's gitea-API readiness probe is now 403-tolerant. With gitea's
+# REQUIRE_SIGNIN_VIEW the unauthenticated /api/v1/version returns HTTP 403, and
+# the old `curl -sSf` (fail on >=400) NEVER broke the wait loop → it burned the
+# full 168x5s=14min budget on every prov before falling through to the
+# authenticated mint (verified live hw172, dep b50ba61d9cb9e157). Now any HTTP
+# answer (non-000 code) = reachable; only a connect failure keeps waiting —
+# removing a 14min dead-wait from the console-up critical path.
+version: 1.4.724
 # 1.4.702 — #3819 #3854 #3859 (Refs #3383 #3376): sme→org-services rename TAIL — the
 #   funnel/BSS control-plane templates + values default the namespace to `org-services`
 #   instead of the dead `sme` ns: provisioning-github-token / valkey-cross-ns-secret +

--- a/products/catalyst/chart/templates/catalyst-gitea-token-secret.yaml
+++ b/products/catalyst/chart/templates/catalyst-gitea-token-secret.yaml
@@ -372,13 +372,27 @@ spec:
               # *chart-internal* layer of that same family.
               ITERATIONS={{ .Values.giteaWait.iterations | default 168 }}
               INTERVAL={{ .Values.giteaWait.intervalSeconds | default 5 }}
+              # #3952 (folds #3951): treat ANY HTTP answer (incl. 403) as
+              # 'API reachable'; only a connect failure keeps waiting. With
+              # gitea's REQUIRE_SIGNIN_VIEW enabled the unauthenticated
+              # /api/v1/version probe returns HTTP 403 ("Only signed in user is
+              # allowed to call APIs") — and `curl -f` (fail on >=400) means the
+              # loop NEVER breaks, burning the full 168x5s=14min budget on every
+              # prov before falling through to the (authenticated) mint at step 4
+              # (verified live on hw172, dep b50ba61d9cb9e157). `curl -o /dev/null
+              # -w '%{http_code}'` (no `-f`) prints the status code on any HTTP
+              # response and `000` on a connect failure (NXDOMAIN/refused), so a
+              # non-000 code = the API is serving (gitea is up), regardless of the
+              # auth verdict.
               for i in $(seq 1 "$ITERATIONS"); do
-                if curl -sSf -o /dev/null --max-time 3 \
-                     http://gitea-http.gitea.svc.cluster.local:3000/api/v1/version; then
-                  echo "gitea api reachable"
+                CODE=$(curl -sS -o /dev/null --max-time 3 -w '%{http_code}' \
+                     http://gitea-http.gitea.svc.cluster.local:3000/api/v1/version \
+                     2>/dev/null || echo 000)
+                if [ -n "$CODE" ] && [ "$CODE" != "000" ]; then
+                  echo "gitea api reachable (HTTP $CODE)"
                   break
                 fi
-                echo "waiting for gitea api ($i/$ITERATIONS)"
+                echo "waiting for gitea api ($i/$ITERATIONS, code=$CODE)"
                 sleep "$INTERVAL"
               done
               # Step 2: Re-check existing token in catalyst-gitea-token —


### PR DESCRIPTION
Refs #3952 #3642 #3737 #3948 #3949 — **SUPERSEDES #3950 #3951** (intent folded; close them as superseded).

## What broke (hw172, dep `b50ba61d9cb9e157`, BOTH regions)
The #3642 host→mgmt-vCluster move stranded several apps' cross-boundary dependencies. Root-caused live via the mothership catalyst-api pod (`kubectl --kubeconfig /var/lib/catalyst/kubeconfigs/b50ba61d9cb9e157.yaml`):

| App (vc-mgmt) | Symptom | Root cause |
|---|---|---|
| `harbor-core` | `CreateContainerConfigError`: `harbor-database-secret-x-harbor-x-mgmt-vcluster` not found | Harbor runs its OWN embedded CNPG (not shared-pg) → bp-postgres `mangledTarget` does NOT mint `harbor-database-secret`. The in-vc `database-secret-sync` Job copies `harbor-pg-app`→`harbor-database-secret`, but `harbor-pg-app` (host ns `harbor`) was not fromHost-imported → never minted. Exact analog of #3949's gitea-pg-app fix. |
| `harbor-jobservice` | CrashLoop | cascade of harbor-core |
| `gitea` (region B) | `Init:CrashLoopBackOff`: `lookup gitea-pg-rw.gitea.svc.cluster.local: no such host` | host CNPG `-rw`/`-ro` Services don't reliably resolve inside vc-mgmt (region A resolved transiently — proves it's a real gap). |
| `openbao-snapshot-save`/`-seed` | seeder loops forever; `seaweedfs-s3-secret-x-seaweedfs-x-rtz-vcluster` not found | CROSS-vCluster (rtz→mgmt): the seaweedfs S3 secret + endpoint live in host ns `rtz` (vc-rtz's namespace) → invisible inside vc-mgmt. |
| `newapi` | `[FATAL] Redis ping test failed: lookup valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc: no such host` | CROSS-vCluster (rtz→mgmt): valkey lives in vc-rtz; the host-mangled name NXDOMAINs inside vc-mgmt. |

Transient (already self-healed on primary as openbao/keycloak/ESO converged): grafana, oidc-gate ×2, hubble-ui, provisioning. Not structural.

## The fix — ONE comprehensive PR
**bp-mgmt-vcluster 0.2.27 → 0.2.28**
- `sync.fromHost.secrets.mappings.byName`: `+ harbor/harbor-pg-app` (host→mgmt) `+ rtz/seaweedfs-s3-secret-x-seaweedfs-x-rtz-vcluster` (cross-vc).
- `networking.replicateServices.fromHost`: `+ gitea-pg-rw/-ro` `+ harbor-pg-rw/-ro` (host→mgmt, folds #3950) `+ valkey-primary` `+ seaweedfs-s3` (cross-vc rtz→mgmt).
- All additive / no-op-until-source-renders (established replicateServices + fromHost-secrets semantics; same safety proof as the `gitea-pg-app`/`guacamole-pg-app` analogs).

**bp-catalyst-platform 1.4.723 → 1.4.724** (folds #3951)
- gitea-token-mint readiness probe is now 403-tolerant: `curl -sSf` never broke the loop on gitea's `REQUIRE_SIGNIN_VIEW` 403 → 14min dead-wait every prov. Now any non-`000` HTTP code = reachable.

Lockstep pins: `58-bp-mgmt-vcluster` → 0.2.28; `13-bp-catalyst-platform` → 1.4.724.

## Validation
- `helm template` + `tests/render.sh` PASS; decoded `vc-config` secret carries all 6 new `replicateServices.fromHost` entries + both new `fromHost.secrets` mappings.
- gitea-mint probe shell block `dash -n` clean. (The pre-existing `helm lint` error in `catalyst-keycloak-credentials-host-bridge.yaml` is unrelated — `lookup`-template `---` quirk, last touched by #3908.)

## Capacity (reported, NOT changed here)
hw172 is **CPU-saturated** (~98.8% of 14 cores: CP 97%, workers 99/99/97%; memory ~30%). `Insufficient cpu` FailedScheduling hits catalyst-api, all 4 catalyst controllers, marketplace-api, billing, provisioning, sme-pg, AND mgmt-vcluster-0. Post-#3642 the mgmt vCluster carries more apps and the fixed 3×4-CPU worker layout can't fit it; no Huawei autoscaler. GENUINE over-commit — recommend bumping worker flavor or count in the fire body (reported to the operator; node sizing NOT changed blindly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)