### PR TITLE
feat(catalyst-ui): Reconciliation DAG view — real node-edge graph + DAG/List tabs (Refs #3925)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/ReconciliationPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/ReconciliationPage.test.tsx
@@ -1,19 +1,21 @@
 /**
  * ReconciliationPage.test.tsx — wiring lock-in for the #3925 surface-B
- * Reconciliation page.
+ * Reconciliation page (two-tab design, operator 2026-06-20).
  *
  * Coverage:
  *   • renders the N/M-Reconciled header
- *   • renders one node per declared component (bounded: HRs + Kustomizations)
- *   • renders the Reconciliation vocabulary — Reconciled/Reconciling/
- *     Drifted/Degraded — and NEVER Success/Succeeded/Failed
- *   • ZERO scanner/Job nodes (the page is fed the bounded DAG only)
- *   • dependsOn edges surface on the node row
+ *   • DAG tab (default): one GRAPH node per declared component + dependsOn
+ *     rendered as graph EDGES (not inline text) — the real dependency view
+ *   • Reconciliation vocabulary — Reconciled/Reconciling/Degraded — and
+ *     NEVER Success/Succeeded/Failed
+ *   • ZERO scanner/Job nodes (bounded DAG only)
+ *   • List tab: switching surfaces the scannable status rows + dependsOn
  *   • the not-yet-tracked footnote renders
+ *   • empty state
  */
 
 import { describe, it, expect, afterEach } from 'vitest'
-import { render, screen, cleanup, within } from '@testing-library/react'
+import { render, screen, cleanup, within, fireEvent } from '@testing-library/react'
 import {
   RouterProvider,
   createRouter,
@@ -69,46 +71,44 @@ describe('ReconciliationPage', () => {
     expect(count.textContent).toMatch(/reconciled/i)
   })
 
-  it('renders one node per declared component (bounded set)', async () => {
+  it('defaults to the DAG tab and renders one graph node per declared component', async () => {
     renderPage()
-    await screen.findByTestId('reconciliation-dag')
-    const nodes = screen.getAllByTestId('reconciliation-node')
+    await screen.findByTestId('reconciliation-dag-svg')
+    const nodes = screen.getAllByTestId(/^reconciliation-dag-node-/)
     expect(nodes).toHaveLength(5)
+    // ZERO scanner/Job nodes — only HelmRelease + Kustomization kinds.
+    for (const n of nodes) {
+      expect(['HelmRelease', 'Kustomization']).toContain(n.getAttribute('data-kind'))
+    }
+  })
+
+  it('renders dependsOn as graph EDGES (the real dependency view)', async () => {
+    renderPage()
+    const edges = await screen.findByTestId('reconciliation-dag-edges')
+    // Two declared deps: bp-keycloak→bp-cilium, bp-newapi→bp-keycloak.
+    expect(edges.querySelectorAll('polyline')).toHaveLength(2)
   })
 
   it('renders the Reconciliation vocabulary and NEVER Success/Failed', async () => {
     renderPage()
     const dag = await screen.findByTestId('reconciliation-dag')
     const text = dag.textContent ?? ''
-    // Vocabulary present.
     expect(text).toMatch(/Reconciled/)
     expect(text).toMatch(/Reconciling/)
     expect(text).toMatch(/Degraded/)
-    // Forbidden finite-end words ABSENT.
     expect(text).not.toMatch(/Success/i)
     expect(text).not.toMatch(/Succeeded/i)
     expect(text).not.toMatch(/\bFailed\b/i)
   })
 
-  it('renders ZERO scanner/Job nodes (only HelmRelease + Kustomization kinds)', async () => {
+  it('switches to the List tab and surfaces status rows + dependsOn', async () => {
     renderPage()
-    await screen.findByTestId('reconciliation-dag')
-    const nodes = screen.getAllByTestId('reconciliation-node')
-    for (const n of nodes) {
-      const kind = n.getAttribute('data-kind')
-      expect(['HelmRelease', 'Kustomization']).toContain(kind)
-    }
-  })
-
-  it('surfaces dependsOn edges on the node row', async () => {
-    renderPage()
-    await screen.findByTestId('reconciliation-dag')
-    const keycloak = screen
-      .getAllByTestId('reconciliation-node')
-      .find((n) => n.getAttribute('data-node-id') === 'bp-keycloak')
+    fireEvent.click(await screen.findByTestId('reconciliation-tab-list'))
+    const nodes = await screen.findAllByTestId('reconciliation-node')
+    expect(nodes).toHaveLength(5)
+    const keycloak = nodes.find((n) => n.getAttribute('data-node-id') === 'bp-keycloak')
     expect(keycloak).toBeTruthy()
-    const deps = within(keycloak!).getByTestId('reconciliation-node-deps')
-    expect(deps.textContent).toContain('bp-cilium')
+    expect(within(keycloak!).getByTestId('reconciliation-node-deps').textContent).toContain('bp-cilium')
   })
 
   it('renders the not-yet-tracked footnote', async () => {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/ReconciliationPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/ReconciliationPage.tsx
@@ -4,28 +4,31 @@
  *   • /sovereign/provision/$deploymentId/reconciliation   (mothership)
  *   • /reconciliation                                      (chroot console)
  *
- * The permanent, LIVING Flux/GitOps dependency DAG — the convergence
- * spine. Nodes = the declared desired components (a bounded set:
- * HelmReleases + Kustomizations); edges = real Flux dependsOn; each
- * coloured by live reconcile state. It NEVER "finishes" — it holds desired
- * state. "Done provisioning" = the bounded set is all-Reconciled.
+ * The permanent, LIVING reconciler view — the convergence spine. Two tabs
+ * over ONE dataset (operator design 2026-06-20):
+ *   • DAG  — a real node-edge dependency GRAPH (force-free topological
+ *            layout via the shared depsLayout, the same engine the Job
+ *            dependencies graph uses), coloured by live reconcile state.
+ *            Filtered to **Flux by default** because Flux Kustomizations/
+ *            HelmReleases are the layer with real spec.dependsOn edges; the
+ *            edgeless controller classes only render as standalone nodes
+ *            when you explicitly widen the filter.
+ *   • List — the SAME reconcilers as a scannable status table (all classes).
  *
  * Vocabulary (NOT Success/Failed — those imply a finite end):
  *   Reconciled · Reconciling · Drifted · Degraded · Suspended
  * A node goes Degraded ONLY when Flux reports Stalled; every other
  * Ready=False is Reconciling, which holds a spinner — never a red Failed.
  *
- * Scope — Flux-only to start (HelmReleases + Kustomizations). The deferred
- * continuous-reconciler classes are surfaced in the "not yet tracked"
- * footnote so the operator knows the scope.
- *
  * Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), the data URL is
  * built from API_BASE inside reconciliation.api.ts, and every colour is a
  * named state token, not an inline hex literal scattered through JSX.
  */
 
+import { useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
+import { depsLayout, type LayoutInput } from '@/shared/lib/depsLayout'
 import { PortalShell } from './PortalShell'
 import {
   fetchReconciliationDAG,
@@ -49,6 +52,19 @@ const STATE_TONE: Record<ReconState, { glyph: string; fg: string; bg: string; bo
   Suspended: { glyph: '⏸', fg: 'var(--color-text-dim)', bg: 'rgba(148,163,184,0.10)', border: 'rgba(148,163,184,0.30)', pulse: false },
 }
 
+/** The default DAG filter — Flux is the only layer with real dependsOn
+ *  edges, so it's the graph that actually reads as a chain. */
+const FLUX_CLASS = 'Flux'
+const ALL_CLASS = 'All'
+
+/** A node's filter CLASS. Flux = HelmRelease|Kustomization (the edge-bearing
+ *  layer); every other kind is its own class (Crossplane, cert-manager, …). */
+function nodeClass(kind: string): string {
+  return kind === 'HelmRelease' || kind === 'Kustomization' ? FLUX_CLASS : kind
+}
+
+type ReconView = 'dag' | 'list'
+
 export interface ReconciliationPageProps {
   /** Test seam — synthetic DAG bypassing the live fetch. */
   dataOverride?: ReconciliationDAG
@@ -71,16 +87,37 @@ export function ReconciliationPage({ dataOverride, disablePoll = false }: Reconc
 
   const dag = dataOverride ?? query.data ?? null
 
+  const [view, setView] = useState<ReconView>('dag')
+  const [filter, setFilter] = useState<string>(FLUX_CLASS)
+
+  // The filter options present in the data: All + Flux + any other classes.
+  const filterClasses = useMemo(() => {
+    const present = new Set<string>()
+    for (const n of dag?.nodes ?? []) present.add(nodeClass(n.kind))
+    const ordered = [ALL_CLASS, FLUX_CLASS, ...[...present].filter((c) => c !== FLUX_CLASS).sort()]
+    // de-dup while preserving order
+    return [...new Set(ordered)]
+  }, [dag])
+
+  // DAG nodes after the class filter (default Flux). List shows ALL.
+  const dagNodes = useMemo(() => {
+    const all = dag?.nodes ?? []
+    if (filter === ALL_CLASS) return all
+    return all.filter((n) => nodeClass(n.kind) === filter)
+  }, [dag, filter])
+
+  const hasNodes = !!dag && dag.nodes.length > 0
+
   return (
     <PortalShell deploymentId={deploymentId} pageTitle="Reconciliation">
       <div className="mx-auto max-w-5xl" data-testid="reconciliation-page">
         <style>{RECON_CSS}</style>
 
         {/* N/M-Reconciled header */}
-        <header className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <header className="mb-3 flex flex-wrap items-center justify-between gap-3">
           <div>
             <h2 className="text-lg font-semibold text-[var(--color-text-strong)]">
-              Flux convergence spine
+              Reconciliation spine
             </h2>
             <p className="mt-0.5 text-xs text-[var(--color-text-dim)]">
               The bounded declared set of continuous reconcilers. This view
@@ -101,6 +138,48 @@ export function ReconciliationPage({ dataOverride, disablePoll = false }: Reconc
             </div>
           ) : null}
         </header>
+
+        {/* Tabs + (DAG-only) class filter */}
+        {hasNodes ? (
+          <div className="mb-3 flex flex-wrap items-center gap-2" data-testid="reconciliation-tabs">
+            <div className="inline-flex overflow-hidden rounded-lg border border-[var(--color-border)]">
+              {(['dag', 'list'] as ReconView[]).map((v) => (
+                <button
+                  key={v}
+                  type="button"
+                  data-testid={`reconciliation-tab-${v}`}
+                  aria-pressed={view === v}
+                  onClick={() => setView(v)}
+                  className={
+                    'px-3 py-1.5 text-xs font-semibold capitalize transition ' +
+                    (view === v
+                      ? 'bg-[var(--color-bg-3)] text-[var(--color-text-strong)]'
+                      : 'bg-transparent text-[var(--color-text-dim)] hover:text-[var(--color-text)]')
+                  }
+                >
+                  {v === 'dag' ? 'DAG' : 'List'}
+                </button>
+              ))}
+            </div>
+            {view === 'dag' ? (
+              <label className="ml-1 flex items-center gap-1.5 text-[11px] text-[var(--color-text-dim)]">
+                Filter
+                <select
+                  data-testid="reconciliation-dag-filter"
+                  value={filter}
+                  onChange={(e) => setFilter(e.target.value)}
+                  className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-2 py-1 text-xs text-[var(--color-text)]"
+                >
+                  {filterClasses.map((c) => (
+                    <option key={c} value={c}>
+                      {c}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            ) : null}
+          </div>
+        ) : null}
 
         {query.isLoading && !dag ? (
           <div
@@ -130,8 +209,12 @@ export function ReconciliationPage({ dataOverride, disablePoll = false }: Reconc
           </div>
         ) : null}
 
-        {dag && dag.nodes.length > 0 ? (
-          <ReconciliationDAGView dag={dag} />
+        {hasNodes ? (
+          view === 'dag' ? (
+            <ReconciliationGraph nodes={dagNodes} filter={filter} />
+          ) : (
+            <ReconciliationList nodes={dag!.nodes} />
+          )
         ) : null}
 
         {/* Not-yet-tracked footnote (ticket §2 surface-A). */}
@@ -149,25 +232,177 @@ export function ReconciliationPage({ dataOverride, disablePoll = false }: Reconc
   )
 }
 
+/* ── DAG tab — the real node-edge graph ──────────────────────────────── */
+
+const NODE_W = 184
+const NODE_H = 52
+
 /**
- * ReconciliationDAGView renders the bounded DAG. Nodes are grouped by kind
- * (Kustomization tier spine first, then HelmReleases); each row shows its
- * state badge + declared dependencies. The dependency arrows are rendered
- * as inline "depends on →" chips (a full force-directed layout is overkill
- * for the bounded set; the dependency text is the load-bearing signal the
- * operator reads — "where is it stuck and what's blocking it").
+ * ReconciliationGraph renders the dependency DAG as a topological-layered
+ * SVG graph — nodes coloured by reconcile state, edges = real Flux
+ * dependsOn drawn as orthogonal step polylines with an arrow head. The
+ * layout comes from the shared depsLayout engine (the same one the Job
+ * dependencies graph uses) — deterministic, no graph library, SSR-safe.
  */
-function ReconciliationDAGView({ dag }: { dag: ReconciliationDAG }) {
-  const kustomizations = dag.nodes.filter((n) => n.kind === 'Kustomization')
-  const helmReleases = dag.nodes.filter((n) => n.kind === 'HelmRelease')
+function ReconciliationGraph({ nodes, filter }: { nodes: ReconciliationNode[]; filter: string }) {
+  const visibleIds = useMemo(() => new Set(nodes.map((n) => n.id)), [nodes])
+  const layout = useMemo(() => {
+    const inputs: LayoutInput[] = nodes.map((n) => ({
+      id: n.id,
+      // Drop dangling deps (to a node filtered out) so we never draw an
+      // edge to a node that isn't on screen.
+      dependsOn: (n.dependsOn ?? []).filter((d) => visibleIds.has(d)),
+    }))
+    return depsLayout(inputs, { nodeWidth: NODE_W, nodeHeight: NODE_H })
+  }, [nodes, visibleIds])
+
+  const byId = useMemo(() => {
+    const m = new Map<string, ReconciliationNode>()
+    for (const n of nodes) m.set(n.id, n)
+    return m
+  }, [nodes])
+
+  if (nodes.length === 0) {
+    return (
+      <div
+        data-testid="reconciliation-dag-empty"
+        className="flex h-64 flex-col items-center justify-center gap-1 rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-2)] text-center text-sm text-[var(--color-text-dim)]"
+      >
+        <p className="font-medium text-[var(--color-text)]">
+          No reconcilers match the “{filter}” filter.
+        </p>
+        <p>Widen the filter to All to see the other reconciler classes.</p>
+      </div>
+    )
+  }
+
   return (
-    <div data-testid="reconciliation-dag" className="flex flex-col gap-5">
-      {kustomizations.length > 0 ? (
-        <NodeGroup title="Kustomization tiers" nodes={kustomizations} />
-      ) : null}
-      {helmReleases.length > 0 ? (
-        <NodeGroup title="HelmReleases" nodes={helmReleases} />
-      ) : null}
+    <div
+      data-testid="reconciliation-dag"
+      className="relative w-full overflow-auto rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-2)]"
+      style={{ maxHeight: 560 }}
+    >
+      <svg
+        data-testid="reconciliation-dag-svg"
+        width={layout.width}
+        height={layout.height}
+        viewBox={`0 0 ${layout.width} ${layout.height}`}
+        role="img"
+        aria-label="Reconciler dependency graph"
+        style={{ display: 'block', minWidth: '100%' }}
+      >
+        <defs>
+          <marker
+            id="recon-dag-arrow"
+            viewBox="0 0 10 10"
+            refX="9"
+            refY="5"
+            markerWidth="6"
+            markerHeight="6"
+            orient="auto-start-reverse"
+          >
+            <path d="M0,0 L10,5 L0,10 Z" fill="var(--color-border-strong)" />
+          </marker>
+        </defs>
+
+        {/* Edges first so they sit beneath the nodes. */}
+        <g data-testid="reconciliation-dag-edges">
+          {layout.edges.map((e) => (
+            <polyline
+              key={`${e.from}->${e.to}`}
+              data-testid={`reconciliation-dag-edge-${e.from}-${e.to}`}
+              points={e.points.map((p) => `${p.x},${p.y}`).join(' ')}
+              fill="none"
+              stroke="var(--color-border-strong)"
+              strokeWidth={1.5}
+              markerEnd="url(#recon-dag-arrow)"
+            />
+          ))}
+        </g>
+
+        {/* Nodes. */}
+        <g data-testid="reconciliation-dag-nodes">
+          {layout.nodes.map((ln) => {
+            const node = byId.get(ln.id)
+            if (!node) return null
+            const tone = STATE_TONE[node.state]
+            return (
+              <g
+                key={ln.id}
+                data-testid={`reconciliation-dag-node-${ln.id}`}
+                data-node-id={ln.id}
+                data-state={node.state}
+                data-kind={node.kind}
+                transform={`translate(${ln.x}, ${ln.y})`}
+              >
+                <rect
+                  width={NODE_W}
+                  height={NODE_H}
+                  rx={10}
+                  ry={10}
+                  fill="var(--color-bg)"
+                  stroke={tone.border}
+                  strokeWidth={1.5}
+                />
+                {/* State pip. */}
+                <circle cx={15} cy={NODE_H / 2} r={6} fill={tone.fg} className={tone.pulse ? 'recon-pulse' : undefined} />
+                {/* Label. */}
+                <text
+                  x={30}
+                  y={NODE_H / 2 - 5}
+                  fill="var(--color-text-strong)"
+                  fontSize={12}
+                  fontWeight={600}
+                  dominantBaseline="middle"
+                  style={{ pointerEvents: 'none' }}
+                >
+                  {truncate(node.label, 22)}
+                </text>
+                {/* kind · state. */}
+                <text
+                  x={30}
+                  y={NODE_H / 2 + 11}
+                  fill="var(--color-text-dim)"
+                  fontSize={10}
+                  fontWeight={400}
+                  dominantBaseline="middle"
+                  style={{ pointerEvents: 'none' }}
+                >
+                  {node.kind} · {node.state}
+                </text>
+              </g>
+            )
+          })}
+        </g>
+      </svg>
+
+      {/* Stats overlay. */}
+      <div
+        data-testid="reconciliation-dag-stats"
+        className="pointer-events-none absolute bottom-2 left-2 flex gap-2"
+      >
+        <span className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg)]/80 px-2 py-0.5 text-[11px] text-[var(--color-text-dim)]">
+          {layout.nodes.length} nodes
+        </span>
+        <span className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg)]/80 px-2 py-0.5 text-[11px] text-[var(--color-text-dim)]">
+          {layout.edges.length} edges
+        </span>
+      </div>
+    </div>
+  )
+}
+
+/* ── List tab — the scannable status table (all classes) ─────────────── */
+
+function ReconciliationList({ nodes }: { nodes: ReconciliationNode[] }) {
+  const kustomizations = nodes.filter((n) => n.kind === 'Kustomization')
+  const helmReleases = nodes.filter((n) => n.kind === 'HelmRelease')
+  const others = nodes.filter((n) => n.kind !== 'Kustomization' && n.kind !== 'HelmRelease')
+  return (
+    <div data-testid="reconciliation-list" className="flex flex-col gap-5">
+      {kustomizations.length > 0 ? <NodeGroup title="Kustomization tiers" nodes={kustomizations} /> : null}
+      {helmReleases.length > 0 ? <NodeGroup title="HelmReleases" nodes={helmReleases} /> : null}
+      {others.length > 0 ? <NodeGroup title="Other reconcilers" nodes={others} /> : null}
     </div>
   )
 }
@@ -208,6 +443,7 @@ function ReconciliationNodeRow({ node }: { node: ReconciliationNode }) {
         {node.state}
       </span>
       <span className="font-mono text-sm text-[var(--color-text-strong)]">{node.label}</span>
+      <span className="text-[11px] uppercase tracking-wide text-[var(--color-text-dimmer)]">{node.kind}</span>
       {node.dependsOn && node.dependsOn.length > 0 ? (
         <span
           data-testid="reconciliation-node-deps"
@@ -223,8 +459,13 @@ function ReconciliationNodeRow({ node }: { node: ReconciliationNode }) {
   )
 }
 
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s
+  return s.slice(0, Math.max(0, max - 1)) + '…'
+}
+
 const RECON_CSS = `
-.recon-pulse { animation: recon-pulse 2s ease-in-out infinite; display: inline-block; }
+.recon-pulse { animation: recon-pulse 2s ease-in-out infinite; transform-box: fill-box; transform-origin: center; }
 @keyframes recon-pulse {
   0%, 100% { opacity: 1; transform: scale(1); }
   50%      { opacity: 0.4; transform: scale(0.7); }


### PR DESCRIPTION
**Founder-found:** the Reconciliation page was a flat LIST (`nodes.map` rows), not a DAG *view* — even with 54 nodes + 69 edges in the data.

**This delivers the actual graph**, per the operator's two-tab design (all recon objects in both tabs, DAG default-filtered to Flux):
- **DAG tab (default):** a real node-edge dependency **graph** — topological layout via the shared `depsLayout` engine (the same one `JobDependenciesGraph` uses; **no new library, no ad-hoc SVG**), nodes colored by reconcile state, edges = real Flux `spec.dependsOn`.
- **Flux-default filter:** Flux (HelmReleases + Kustomizations) is the only layer with real `dependsOn` edges, so it's the default graph; widen to All / a class for the edgeless controller classes.
- **List tab:** the same reconcilers as a scannable status table (all classes).

7/7 page tests pass. Backend already emits the Flux nodes+edges (#3956); the non-Flux reconciler nodes (Crossplane/cert-manager/CNPG/ESO/controllers) are a follow-up so the filter has more classes.

Refs #3925

🤖 Generated with [Claude Code](https://claude.com/claude-code)