### PR TITLE
fix(convmon-ui): import SortDir to unblock catalyst-ui build (#3958)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/ReconciliationTable.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/ReconciliationTable.tsx
@@ -30,6 +30,7 @@ import {
   matchReconNode,
   compareReconNodes,
   type ReconSortKey,
+  type SortDir,
 } from './reconciliation.shared'
 
 /* ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Hotfix: the #3959 merge (5133ec0) broke the deploy-bot `build-ui` step — `ReconciliationTable.tsx` referenced `SortDir` without importing it (only `ReconSortKey` was imported after the types moved to `reconciliation.shared.ts`). PR CI's vitest job passed but `tsc -b && vite build` (the deploy build) failed with TS2304.

Verified with the EXACT build command this time: `tsc -b` clean + full `npm run build` exit 0.

Refs #3958 #3925