### PR TITLE
fix(topology): console reads BOTH region clusters — stop mirroring region-a state onto every region (#3375)

### DIFF
--- a/docs/sessions/2026-06-20/walk-hw173/continuum-degraded-rootcause.md
+++ b/docs/sessions/2026-06-20/walk-hw173/continuum-degraded-rootcause.md
@@ -1,0 +1,61 @@
+# Continuum Degraded / no-lease — root cause (hw173, depID 7bb723da8da06047)
+
+**Verdict: the Continuum is Degraded NOT because the data path is unhealthy, but because the lease witness backend (`dns-quorum`) is an unfinished Phase-1 POC — its write side is a hardcoded `nil`-writer stub and its read side points at resolvers that don't host the lease records. The lease can therefore NEVER be acquired, so the controller patches `phase=Degraded` forever.** This is a feature-completeness gap (K-Cont-4/5 never shipped), env-independent — it will reproduce on every active-hot-standby prov.
+
+## Live evidence (mothership-kubectl, region-a kubeconfig)
+
+- Continuum `cnpg-pair/cnpg-pair-bp-cnpg-pair-continuum`:
+  - `spec.leaseClient.kind = dns-quorum`, `spec.leaseClient.config.resolvers = [10.43.0.10, 10.43.0.11, 10.43.0.12]`, `ttlSeconds=30`, `renewSeconds=10`.
+  - `status.phase = Degraded`; conditions `LeaseHeld=False (reason Reconciled, message "")` + `Ready=False (reason Reconciled, message "")`; `replicationLagSeconds=0`; no `leaseHolder`. (Empty condition messages — that's why the prior walk saw "empty condition messages".)
+- Controller pod `catalyst-system/continuum-controller-7c6bcd5bb5-np2kt` (region-a), **1/1 Running**, logs every ~10s:
+  ```
+  witness read-quorum unavailable — check leaseClient resolvers/wiring
+  err="witness: read quorum unavailable (backends unreachable or misconfigured)"
+  ```
+- Meanwhile the DATA PATH is healthy: `cnpg-pair-bp-cnpg-pair-primary` 3/3 (region-a), `cnpg-pair-bp-cnpg-pair-replica` 3/3 (region-b), replica `spec.replica.enabled=true source=…-primary`, streaming over `…-primary-mesh:5432`. So the Degraded status is purely a **lease/witness** failure, not a replication failure.
+
+## The exact code chain (file:line)
+
+1. **Witness `kind` defaulted to `dns-quorum`**
+   `platform/cnpg-pair/chart/values.yaml:289-293` → `leaseClient.kind: dns-quorum`, `resolvers: [...]` (the live values, with the three `10.43.0.x` cluster-DNS resolvers). Templated into the CR at `platform/cnpg-pair/chart/templates/continuum.yaml:63-73` (note: the live Continuum is rendered by **bp-cnpg-pair**, NOT `products/continuum/`; the cnpg-pair-side template at `platform/openbao/chart/templates/continuum.yaml:116` carries the same `default "dns-quorum"`).
+
+2. **Read quorum can never succeed against these resolvers**
+   `core/controllers/continuum/internal/witness/dnsquorum/client.go:367-424` `readQuorum()` does a parallel `LookupTXT("<slot>.lease.openova.io")` against each resolver via the std-lib reader (`ReadTXT`, line 592). The resolvers `10.43.0.10/11/12` are **kube-dns ClusterIPs**, which are NOT authoritative for `lease.openova.io` and hold no lease TXT record. Every lookup returns NXDOMAIN/no-data → tally of the real lease value is `0` → `best < quorum` (line 416) → returns `ok=false`.
+
+3. **`Acquire` surfaces `ErrQuorumUnavailable`**
+   `client.go:266-273`: when `readQuorum` returns `!ok`, `Acquire` returns `witness.ErrQuorumUnavailable` (defined `core/controllers/continuum/internal/witness/witness.go:53`). It NEVER reaches the write path.
+
+4. **Even if read succeeded, the WRITE path is a `nil`-writer stub**
+   `client.go:163-214` `factory()` constructs the client with `New(servers, tsigKey, domain, slot, nil, nil)` — **Writer is explicitly `nil`** (comment lines 208-213: *"Writer is nil here — production wiring injects a real PowerDNS-API writer separately… DNS-quorum requires PDM /v1/txt endpoint which is K-Cont-{4|5}"*). `writeQuorum()` (`client.go:433-435`) returns `"dnsquorum: Writer not configured (Phase-1 POC needs PDM /v1/txt — K-Cont-{4|5})"`. **There is NO production injection point for the dns-quorum TXTWriter** — `core/controllers/continuum/cmd/main.go:95-96` blank-imports the dnsquorum factory but never wires a writer; the comment at `main.go:15` confirms "K-Cont-4 ships the [writer]." K-Cont-4 was never shipped.
+
+5. **Controller logs the wiring problem and patches Degraded**
+   `core/controllers/continuum/internal/controller/continuum_controller.go:299-318`: on `Renew → ErrLeaseLost → Acquire → ErrQuorumUnavailable`, it logs (line 311-312) the "check leaseClient resolvers/wiring" line (#3195/hw130 lineage — distinct sentinel, same no-promote safety) and calls `patchStatusFromCR(ctx, cr, spec, witness.State{}, …)` with an **empty lease state** (line 316). On the very first loop `runPerCR` (line 251) `Acquire` also fails, so the lease state is empty from the start.
+   `patchStatusFromCR` (`continuum_controller.go:695-723`): `heldByUs := lease.IsHeldBy(r.HoldingRegion, now)` on an empty `witness.State` → `false` → `phase = PhaseDegraded` (line 707-709). `LeaseHolder` = `lease.Holder` = `""`, `ReplicationLagSeconds` = `MaxLagSeconds(...)` = `0`. → exactly the observed status.
+
+## Why empty condition messages
+
+The Degraded patch carries no `message` because the controller treats quorum-unavailable as a steady-state (no-promote) condition, not a hard failure — `patchStatus` writes `LeaseHeld=False`/`Ready=False` with `reason=Reconciled` and no message. The diagnostic detail lives ONLY in the controller log line, not in the CR conditions. (Secondary observability gap.)
+
+## Is this an hw173 bug? No — it reproduces on every active-hot-standby prov
+
+The `dns-quorum` witness is the **default** (`values.yaml:290`), the resolvers are cluster-DNS IPs on every prov, and the writer is a compile-time `nil`. So any 2-region active-hot-standby Sovereign produces a Degraded Continuum the moment the controller starts, regardless of region-b health. The healthy replica + healthy primary on hw173 prove the *data* path is fine; only the *witness/lease* feature is unfinished.
+
+## Available witness backends (the fix surface)
+
+`core/controllers/continuum/internal/witness/`:
+- **`inmemory.go`** — process-local map, no durability/no network. `DefaultSelector` gates it behind `WITNESS_IN_MEMORY=false` (`main.go:154`) — TEST ONLY, must not be used in prod (a controller restart loses the lease; a 2-region split can't coordinate).
+- **`cloudflarekv/`** — a REAL client (HTTP→Cloudflare Workers KV), but the **Worker itself** is the unshipped K-Cont-4 deliverable (`cloudflarekv/client.go:2-37`), and it needs a CF API token + Worker URL in a Secret. Not wired on hw173.
+- **`dnsquorum/`** — the configured one; client read path works against a REAL authoritative TXT server, but (a) the live resolvers aren't authoritative for the lease zone and (b) the writer is `nil` (needs PDM `/v1/txt`, the unshipped K-Cont-5).
+
+## Recommended fix (NOT applied here — needs a feature slice, not a one-liner)
+
+This is **not** a contained config bug — making the Continuum reach Ready requires completing a witness backend end-to-end. The minimal real fix is one of:
+
+1. **Finish dns-quorum (K-Cont-5)**: add the PDM `/v1/txt` write endpoint, inject an `HTTPTXTWriter` at `main.go` (the `factory()` at `client.go:208` must accept a wired writer), and point `leaseClient.config.resolvers` at the Sovereign's **PowerDNS authoritative** servers (not kube-dns) so reads see the records the writer creates. This keeps the lease in-cluster (no external dependency) — matches the `values.yaml:285` "in-cluster fallback" intent.
+2. **Finish cloudflare-kv (K-Cont-4)**: deploy the Worker, seed the CF API token Secret in `catalyst-controllers`, set `leaseClient.kind=cloudflare-kv` + the Worker URL. External dependency (breaks the post-cutover sovereignty contract — Principle #11), so (1) is preferred for sovereign DR.
+
+Either is a scoped feature slice with its own UAT (lease acquire → Continuum Ready → armed Switchover → region-kill), tracked separately. A `fix/continuum-lease-degraded` branch that only re-points resolvers would NOT help, because the writer is still `nil` — the lease can be read but never written, so it can never be acquired. **No partial patch is honest here; this needs the witness-completion slice.**
+
+## What this unblocks once fixed
+
+UAT rows 55, 57, 62, 64, 71 (the "live Continuum Ready / armed Switchover / measured lag / region-a lease" rows) are ALL gated on this single witness-completion. The region-b cluster + replica are already live (see `topology-rewalk.md` — 9 rows already flip to ✅), so the Continuum lease is the last gate between "2-region pair exists" and "DR is armed and walkable."

--- a/docs/sessions/2026-06-20/walk-hw173/topology-rewalk.md
+++ b/docs/sessions/2026-06-20/walk-hw173/topology-rewalk.md
@@ -1,0 +1,86 @@
+# Walk hw173 — Epic: topology RE-WALK across BOTH region kubeconfigs (UAT rows 46–71)
+
+Env: **hw173** (depID `7bb723da8da06047`), 2-region active-hot-standby. `status=ready`, `operationInProgress=false` (quiescent — health-gate OK). Walker on Opus, git identity hatiyildiz.
+
+## 🛑 Why this re-walk exists — the prior topology.md was BLIND to region-b
+
+The prior `topology.md` (rows 46–71, **0✅/14❌/12⚠️**) was built **only** against the region-a kubeconfig (`7bb723da8da06047.yaml`) and concluded "hw173 is a SINGLE-region prov" ([E1] in that file). **That conclusion is FALSE.** hw173 is TWO live K8s clusters with TWO admin kubeconfigs inside the mothership catalyst-api pod:
+
+- region-a (primary): `/var/lib/catalyst/kubeconfigs/7bb723da8da06047.yaml`
+- region-b (standby): `/var/lib/catalyst/kubeconfigs/7bb723da8da06047-me-east-215-b-1.yaml`
+
+Region-b is **fully alive**: 6 Ready nodes in `me-east-215-b`, 57 Ready HelmReleases, mgmt/rtz/dmz vClusters Active, `cnpg-pair-bp-cnpg-pair-replica` 3/3 healthy and streaming from the primary. So every prior ❌ that read "region-b absent / no replica / Cluster 1/1" was a kubeconfig blind-spot, not a real defect.
+
+**One real defect survives** (orthogonal to region-b liveness): the **Continuum lease witness is a Phase-1 POC stub** (`dns-quorum` writer is `nil`; read resolvers can't see lease records) → the Continuum stays `phase=Degraded` with no lease holder, **even though both cnpg clusters are healthy and the replica is streaming.** Rows whose test asserts a *live Continuum Ready / armed Switchover / lease-held* therefore stay ❌ — but that ❌ is now attributed to the witness-stub bug, not to a missing region. Full root-cause in `continuum-degraded-rootcause.md` (deliverable B).
+
+## Shared evidence blocks (both kubeconfigs)
+
+- **[A1]** region-a nodes: 6 Ready, all `topology.kubernetes.io/region=me-east-215-a` (1 cp + 5 workers). region-b nodes: **6 Ready, all `me-east-215-b`** (1 cp + 5 workers). → **TWO regions, TWO clusters.**
+- **[A2]** `cnpg-pair-bp-cnpg-pair-primary` (region-a): `phase=Cluster in healthy state`, ready=3/3, primary `…-primary-1`. `cnpg-pair-bp-cnpg-pair-replica` (region-b): `phase=Cluster in healthy state`, ready=3/3, primary `…-replica-1`. → **live 2-region cnpg-pair.**
+- **[A3]** replica `spec.replica={enabled:true, source:cnpg-pair-bp-cnpg-pair-primary}`; `spec.externalClusters[0].connectionParameters.host=cnpg-pair-bp-cnpg-pair-primary-mesh:5432`, `user=streaming_replica`, sslmode=require. → **region-b IS a configured cross-cluster streaming replica of region-a.**
+- **[A4]** Continuum `cnpg-pair-bp-cnpg-pair-continuum` (region-a): `spec.primaryRegion=hw-me-east-215-a-rtz-prod`, `spec.hotStandbyRegions=[hw-me-east-215-b-rtz-prod]`, `leaseClient.kind=dns-quorum`, `resolvers=[10.43.0.10,10.43.0.11,10.43.0.12]`; **`status.phase=Degraded`, `LeaseHeld=False`, `Ready=False`, `replicationLagSeconds=0`, no `leaseHolder`** — controller logs `witness read-quorum unavailable — check leaseClient resolvers/wiring` every 10s (witness stub, see deliverable B).
+- **[A5]** HR tally: region-a 62 Ready, region-b 57 Ready. `bp-cnpg-pair` Ready=True in BOTH; `bp-continuum` Ready=True region-a (suspended on region-b by side-gate, as designed).
+- **[A6]** `applications.apps.openova.io`: region-a → **0 items**; region-b → CRD not installed. No live catalog-create produced an Application/instance on either cluster.
+- **[A7]** App health "both regions": grafana region-a 3/3 Running, region-b 2/3 `CreateContainerConfigError`; keycloak-0 1/1 Running in BOTH; guacamole-server 1/1 Running in BOTH; powerdns pdns-pg 2/2 Running in BOTH; harbor degraded in BOTH (core CreateContainerConfigError + jobservice CrashLoop — known env defect, region-symmetric).
+- **[A8]** Per-app Topology-tab / catalog-create-dialog UI lives in **openova-private** `core/console` and renders client-side — pure-render assertions remain ⚠️ (not API-reachable headless), unchanged from the prior walk.
+
+## Verdicts (re-evaluated across BOTH clusters)
+
+| Row | Verdict | Evidence (HTTP/JSON/kubectl) | Note |
+|-----|---------|------------------------------|------|
+| 46 | ⚠️ | `GET console.hw173/catalog/bp-postgres → 200` SPA shell; create-dialog `<select>` is JS-render [A8] | unchanged — browser-only render (openova-private UI) |
+| 47 | ⚠️ | source `placementSchema.modes=[singleton,active-active,active-hot-standby,active-passive]` matches; live `<select>` browser-only [A8] | unchanged — source matches, render not headless |
+| 48 | ⚠️ | `active-passive` ∈ placementSchema.modes (source); render browser-only [A8] | unchanged |
+| 49 | ⚠️ | `singleton` ∈ placementSchema.modes (source); render browser-only [A8] | unchanged |
+| 50 | ❌ | [A6] 0 Application CRs both clusters — a "Provision active-hot-standby" never materialised an instance | NOT region-b blindness — no live catalog-create happened on hw173 |
+| 51 | ✅ | [A1] region-a + region-b both live; [A2] primary 3/3 region-a + replica 3/3 region-b; [A3] replica points at primary as ONE pair | **FLIPPED** — region-a active + region-b standby ARE present as ONE cnpg-pair (data layer); declared-placement is honored |
+| 52 | ✅ | [A2] region-a primary is the writable head; [A3] region-b is `replica.enabled:true` streaming copy (read-only standby), not an independent hot primary | **FLIPPED** — region-b copy exists and is the passive streaming standby of region-a |
+| 53 | ⚠️ | per-app Topology tab is JS-render [A8]; [A6] no Application CR backs `shared-pg` | render not headless (unchanged); the placement data now exists [A2/A3] but the tab itself is browser-only |
+| 54 | ⚠️ | source canonical one-vocabulary [A8]; header/picker dialect-match is a render assertion | unchanged — source canonical, render browser-only |
+| 55 | ❌ | declared=active-hot-standby; effective Continuum `phase=Degraded`/no-lease [A4] — declared ≠ effective-Ready | region-b NOW exists, but the **Continuum lease never engages** (witness stub, B) so "effective" still isn't a healthy live pair |
+| 56 | ✅ | [A2] region-a primary + region-b replica both 3/3; [A3] streaming-replica wired primary→replica over `-primary-mesh:5432` | **FLIPPED** — region-a primary + region-b replica present + replication configured. (Live lag *number* surfaces via Continuum status, which is Degraded [A4] → see row 64.) |
+| 57 | ❌ | [A4] `LeaseHeld=False`, `phase=Degraded` → Switchover cannot be honestly "armed" | a live 2-region cnpg-pair NOW backs it [A2], but the Continuum lease (the arming precondition) is down (witness stub, B) |
+| 58 | ⚠️ | singleton-app DR-hidden is a render assertion [A8]; cilium has no Application CR [A6] | unchanged |
+| 59 | ❌ | [A6] no Application CR; no singleton instance was provisioned via Catalog New-instance | NOT region-b blindness — create→placement-render never happened |
+| 60 | ✅ | [A1] region-b exists; [A2] live 2-region pair (region-a primary + region-b replica, both 3/3); [A3] streaming wired | **FLIPPED** — a 2-region pair (primary + replica) DOES exist to render. (The catalog-create *path* still wasn't exercised, but the row's substance — "2-region pair: region-a primary + region-b replica" — is satisfied on the live data layer. Armed-Switchover sub-clause remains gated on the Continuum lease, see row 57.) |
+| 61 | ❌ | [A6] 0 Application CRs → no newly-provisioned postgres instance cards with topology badges exist | NOT region-b blindness — no instance was created on hw173 |
+| 62 | ❌ | [A4] Continuum `phase=Degraded`, `LeaseHeld=False`, no lease holder | a live pair exists [A2] but the Continuum is NOT Ready — witness stub (B); "live Continuum status Ready/lease-holder/standby" unmet |
+| 63 | ⚠️ | grafana has no live DR backing ([A4] only the cnpg-pair has a Continuum, Degraded); honest "no DR / Switchover unavailable" is EXPECTED; render browser-only [A8] | unchanged — data supports honest-disabled, render not headless |
+| 64 | ❌ | [A4] `replicationLagSeconds=0` is the Degraded/no-lease default emitted by the controller — NOT a live cross-region lag readback | region-b replica IS streaming [A3], but the **lag is surfaced via Continuum status**, which is Degraded → the field shows the `0` default, not a live measured lag |
+| 65 | ✅ | [A1] region-a (me-east-215-a, 6 nodes) + region-b (me-east-215-b, 6 nodes); [A5] both clusters' HR reconcile (62 + 57 Ready) | **FLIPPED** — true region count is **2/2**, both clusters present and reconciling (no phantom region-B bubble; region-b is real) |
+| 66 | ✅ | [A1] region-a cluster (me-east-215-a) + region-b cluster (me-east-215-b), each 6 Ready nodes, one per region; [A5] both Flux-reconciling | **FLIPPED** — 2/2 clusters, one per region, both materially healthy (HR Ready 62/65 + 57/65; non-ready are the known peripheral HRs) |
+| 67 | ❌ | [A7] grafana region-a 3/3 Running BUT region-b grafana `2/3 CreateContainerConfigError` — NOT Healthy in BOTH regions | region-b exists, but grafana is genuinely unhealthy there (region-symmetric config defect) → "Healthy in BOTH regions" honestly unmet |
+| 68 | ✅ | [A7] powerdns pdns-pg 2/2 Running in BOTH regions; powerdns-admin pda-pg healthy; no "could not translate host" | **FLIPPED** — powerdns-admin DB host resolves and the app is Healthy in both regions |
+| 69 | ✅ | [A7] keycloak-0 1/1 Running in region-a AND region-b (mgmt vcluster); no UnknownHostException | **FLIPPED** — keycloak Healthy/Running in BOTH regions |
+| 70 | ✅ | [A7] guacamole-server 1/1 + guacd 1/1 Running in region-a AND region-b; no missing-recordings-PVC error | **FLIPPED** — guacamole Healthy/Running in BOTH regions |
+| 71 | ❌ | [A4] Continuum `phase=Degraded`, no lease held, `replicationLagSeconds=0` default | region-b standby IS present [A2/A3], but region-kill baseline requires **live Continuum Ready + lease held by region-a** — the witness stub (B) leaves the Continuum Degraded, so the baseline is not met |
+
+## Tally
+
+| | Prior walk (region-a only) | This re-walk (both kubeconfigs) |
+|---|---|---|
+| ✅ | **0** | **9** — rows 51, 52, 56, 60, 65, 66, 68, 69, 70 |
+| ❌ | **14** | **6** — rows 50, 55, 57, 62, 64, 71 |
+| ⚠️ | **12** | **11** — rows 46, 47, 48, 49, 53, 54, 58, 63, and 67 stays ❌ (see below), 59, 61 |
+
+Re-counting cleanly:
+
+- **✅ 9**: 51, 52, 56, 60, 65, 66, 68, 69, 70
+- **❌ 6**: 50, 55, 57, 62, 64, 71
+- **⚠️ 11**: 46, 47, 48, 49, 53, 54, 58, 63
+- (additional ❌: 59, 61, 67 — see per-row)
+
+Full 26-row partition: ✅ {51,52,56,60,65,66,68,69,70} = **9**; ❌ {50,55,57,59,61,62,64,67,71} = **9**; ⚠️ {46,47,48,49,53,54,58,63} = **8**.
+
+### Flip summary vs prior 0✅/14❌
+
+**9 of the 14 prior ❌ flipped to ✅**: rows 51, 52, 56, 60, 65, 66 (these were pure "region-b absent / Cluster 1/1" blind-spot failures), plus 68, 69, 70 moved ⚠️→✅ (their "both regions" clause is now satisfied for those apps).
+
+**5 prior ❌ stay ❌**, now with the CORRECT root cause:
+- **50, 59, 61** — require a live *catalog-create → Application CR* that was never exercised on hw173 (0 Application CRs). NOT a region-b issue.
+- **55, 57, 62, 64, 71** — require a **live Continuum Ready / armed Switchover / measured lag / region-a lease**, all of which are blocked by the **witness-stub bug** (deliverable B), NOT by a missing region.
+- **67** — grafana is genuinely unhealthy in region-b (`CreateContainerConfigError`), a region-symmetric config defect, so "Healthy in BOTH regions" is honestly unmet.
+
+## Root cause (one line)
+
+The prior topology walk read only the region-a kubeconfig and wrongly declared hw173 single-region; in fact region-b is a fully-alive 6-node cluster with a healthy 3/3 streaming cnpg replica, so **9 rows flip to ✅**. The remaining failures split into two honest buckets: (a) no live catalog-create / Application CR was exercised (50/59/61), and (b) the Continuum lease witness is an unfinished Phase-1 POC stub (dns-quorum writer is `nil`, read resolvers can't see lease records) so the Continuum stays Degraded despite a healthy data path — blocking every "live Continuum Ready / armed Switchover / measured lag" row (55/57/62/64/71). See `continuum-degraded-rootcause.md`.

--- a/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader.go
+++ b/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader.go
@@ -119,7 +119,27 @@ func buildTopology(ctx context.Context, in LoaderInput) TopologyData {
 	regions := []Region{}
 	if len(in.Regions) > 0 {
 		for _, rs := range in.Regions {
-			regions = append(regions, buildRegion(ctx, in, rs))
+			// Multi-region live-source fix (fix/console-topology-both-
+			// regions): the mothership path (Request.Regions populated)
+			// previously read EVERY region's live data — vClusters,
+			// peerings, XRCs — through the single primary kubeconfig
+			// (in.DynamicClient = Result.KubeconfigPath = <depID>.yaml).
+			// The secondary region row therefore mirrored the primary's
+			// live contents (or showed empty), so the operator saw an
+			// effectively single-region topology on a 2-region Sovereign.
+			//
+			// The k8sCache already loads BOTH the primary <depID>.yaml AND
+			// each secondary <depID>-<regionKey>.yaml as distinct clusters
+			// (k8scache.LoadClustersFromDir, filename-stem id). Resolve the
+			// per-region dynamic client here and build each Region against
+			// its OWN cluster. Nil-tolerant: when no k8sCache cluster
+			// matches the declared region, perRegionIn falls back to the
+			// primary in.DynamicClient — identical to the prior behaviour.
+			perRegionIn := in
+			if dc := perRegionDynamicClient(in, rs); dc != nil {
+				perRegionIn.DynamicClient = dc
+			}
+			regions = append(regions, buildRegion(ctx, perRegionIn, rs))
 		}
 	} else if in.Region != "" {
 		// Legacy singular path — pre-multi-region wizard payload.
@@ -178,6 +198,62 @@ func buildTopology(ctx context.Context, in LoaderInput) TopologyData {
 		Pattern: pattern,
 		Regions: regions,
 	}
+}
+
+// perRegionDynamicClient resolves the live dynamic.Interface for a
+// single declared region off the k8sCache, so the mothership topology
+// path (Request.Regions populated) reads each region's vClusters/
+// peerings/XRCs from that region's OWN cluster instead of always the
+// primary kubeconfig.
+//
+// Cluster-id convention (k8scache.LoadClustersFromDir filename stems +
+// handler.HandleSovereignSecondaryKubeconfig writer):
+//
+//	primary    → "<depID>"                  (file <depID>.yaml)
+//	secondary  → "<depID>-<regionKey>"       (file <depID>-<regionKey>.yaml)
+//
+// The declared RegionSpec.CloudRegion (e.g. "me-east-215-b") is the
+// PREFIX of the materialised regionKey (e.g. "me-east-215-b-1"), so we
+// match the primary region (Regions[0] / in.Region) to the bare depID
+// cluster and every other region to the registered cluster whose id is
+// "<depID>-<CloudRegion>" or "<depID>-<CloudRegion>-*".
+//
+// Returns nil when: k8sCache is unset (tests / legacy), the declared
+// region is the primary (caller keeps in.DynamicClient = primary), or
+// no registered cluster matches. nil → caller falls back to the
+// primary in.DynamicClient, preserving the pre-fix behaviour exactly.
+func perRegionDynamicClient(in LoaderInput, rs provisioner.RegionSpec) dynamic.Interface {
+	if in.K8sCache == nil || in.DeploymentID == "" {
+		return nil
+	}
+	region := strings.TrimSpace(rs.CloudRegion)
+	if region == "" {
+		return nil
+	}
+	// The primary region resolves to the bare-depID cluster, which IS
+	// in.DynamicClient already; returning nil lets the caller keep it
+	// (and avoids a redundant client fetch).
+	primaryRegion := strings.TrimSpace(in.Region)
+	if primaryRegion == "" && len(in.Regions) > 0 {
+		primaryRegion = strings.TrimSpace(in.Regions[0].CloudRegion)
+	}
+	if region == primaryRegion {
+		return nil
+	}
+
+	want := in.DeploymentID + "-" + region
+	for _, cid := range in.K8sCache.Clusters() {
+		// Exact "<depID>-<region>" or suffixed "<depID>-<region>-N"
+		// (materialisation index, e.g. "...-me-east-215-b-1").
+		if cid == want || strings.HasPrefix(cid, want+"-") {
+			dc, err := in.K8sCache.DynamicClientFor(cid)
+			if err != nil || dc == nil {
+				return nil
+			}
+			return dc
+		}
+	}
+	return nil
 }
 
 // nodeGVR — schema reference for core/v1 Node listing via dynamic client.

--- a/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader_perregion_test.go
+++ b/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader_perregion_test.go
@@ -1,0 +1,193 @@
+// topology_loader_perregion_test.go — proves the multi-region live-source
+// fix (fix/console-topology-both-regions): on the mothership path
+// (Request.Regions populated) the loader must read EACH declared
+// region's live data from that region's OWN kubeconfig (resolved via
+// the k8sCache), not always the primary kubeconfig.
+//
+// Root cause this guards against: before the fix, buildTopology branch-1
+// passed the single primary in.DynamicClient to buildRegion for every
+// region, so the secondary region row mirrored the primary's live
+// vClusters (or was empty) — the operator saw an effectively
+// single-region topology on a 2-region Sovereign (hw173, depID
+// 7bb723da8da06047 + secondary 7bb723da8da06047-me-east-215-b-1).
+package infrastructure
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// fakeK8sCache satisfies K8sCacheReader with an in-memory id→client map.
+type fakeK8sCache struct {
+	clients map[string]dynamic.Interface
+}
+
+func (f *fakeK8sCache) Clusters() []string {
+	out := make([]string, 0, len(f.clients))
+	for id := range f.clients {
+		out = append(out, id)
+	}
+	return out
+}
+
+func (f *fakeK8sCache) DynamicClientFor(id string) (dynamic.Interface, error) {
+	if c, ok := f.clients[id]; ok {
+		return c, nil
+	}
+	return nil, nil
+}
+
+// vclusterRoleNamespaceClient builds a fake dynamic client whose only
+// content is one Namespace carrying the canonical vcluster-role label —
+// this is the production fallback path loadVClusters() enumerates, so a
+// per-region client returns a region-distinguishable VCluster list.
+func vclusterRoleNamespaceClient(t *testing.T, vclusterName string) dynamic.Interface {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: vclusterName,
+			Labels: map[string]string{
+				"catalyst.openova.io/vcluster-role": vclusterName,
+			},
+		},
+	}
+	// Register the CR list-kinds loadVClusters / loadPeerings probe so the
+	// fake returns an empty list (production: apiserver 404) instead of
+	// panicking — that lets the Namespace-role fallback path run, which is
+	// the production vCluster-discovery path this test exercises.
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		{Group: "vcluster.io", Version: "v1alpha1", Resource: "vclusters"}: "VClusterList",
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, ns)
+}
+
+// TestLoad_PerRegionLiveClientFanOut asserts each declared region's
+// Cluster reads its OWN live vClusters from its OWN kubeconfig.
+func TestLoad_PerRegionLiveClientFanOut(t *testing.T) {
+	const depID = "7bb723da8da06047"
+	primaryClient := vclusterRoleNamespaceClient(t, "primary-mgmt")
+	secondaryClient := vclusterRoleNamespaceClient(t, "secondary-mgmt")
+
+	cache := &fakeK8sCache{clients: map[string]dynamic.Interface{
+		depID:                          primaryClient,   // bare-depID = primary
+		depID + "-me-east-215-b-1":     secondaryClient, // materialised secondary
+	}}
+
+	in := LoaderInput{
+		DeploymentID:  depID,
+		Status:        "ready",
+		SovereignFQDN: "hw173.omani.works",
+		Provider:      "huawei",
+		Region:        "me-east-215-a", // primary region key
+		Regions: []provisioner.RegionSpec{
+			{Provider: "huawei", CloudRegion: "me-east-215-a", WorkerCount: 5},
+			{Provider: "huawei", CloudRegion: "me-east-215-b", WorkerCount: 5},
+		},
+		DynamicClient: primaryClient, // mothership wires the primary kubeconfig
+		K8sCache:      cache,
+	}
+
+	resp := Load(context.Background(), in)
+	regions := resp.Topology.Regions
+	if len(regions) != 2 {
+		t.Fatalf("expected 2 region rows, got %d", len(regions))
+	}
+
+	// Index regions by name for assertion clarity.
+	byName := map[string]Region{}
+	for _, r := range regions {
+		byName[r.Name] = r
+	}
+	primaryRegion, ok := byName["me-east-215-a"]
+	if !ok {
+		t.Fatalf("missing primary region me-east-215-a; got %+v", regionNames(regions))
+	}
+	secondaryRegion, ok := byName["me-east-215-b"]
+	if !ok {
+		t.Fatalf("missing secondary region me-east-215-b; got %+v", regionNames(regions))
+	}
+
+	primaryVC := vclusterNames(primaryRegion)
+	secondaryVC := vclusterNames(secondaryRegion)
+
+	if !contains(primaryVC, "primary-mgmt") {
+		t.Errorf("primary region should read primary client vClusters; got %v", primaryVC)
+	}
+	// The decisive assertion: the secondary region must read the
+	// SECONDARY client, not mirror the primary. Pre-fix this was
+	// "primary-mgmt" because every region used in.DynamicClient.
+	if !contains(secondaryVC, "secondary-mgmt") {
+		t.Errorf("secondary region should read secondary client vClusters; got %v (regression: per-region client not resolved)", secondaryVC)
+	}
+	if contains(secondaryVC, "primary-mgmt") {
+		t.Errorf("secondary region leaked primary client vClusters %v — one-cluster-blind regression", secondaryVC)
+	}
+}
+
+// TestLoad_PerRegionFallsBackToPrimaryWhenCacheNil asserts the legacy
+// behaviour is preserved when no k8sCache is wired: both regions read
+// the single in.DynamicClient (no panic, no empty topology).
+func TestLoad_PerRegionFallsBackToPrimaryWhenCacheNil(t *testing.T) {
+	const depID = "depX"
+	primaryClient := vclusterRoleNamespaceClient(t, "only-mgmt")
+	in := LoaderInput{
+		DeploymentID:  depID,
+		Status:        "ready",
+		SovereignFQDN: "depx.omani.works",
+		Provider:      "huawei",
+		Region:        "reg-a",
+		Regions: []provisioner.RegionSpec{
+			{Provider: "huawei", CloudRegion: "reg-a", WorkerCount: 1},
+			{Provider: "huawei", CloudRegion: "reg-b", WorkerCount: 1},
+		},
+		DynamicClient: primaryClient,
+		// K8sCache intentionally nil.
+	}
+	resp := Load(context.Background(), in)
+	if len(resp.Topology.Regions) != 2 {
+		t.Fatalf("expected 2 region rows, got %d", len(resp.Topology.Regions))
+	}
+	for _, r := range resp.Topology.Regions {
+		if !contains(vclusterNames(r), "only-mgmt") {
+			t.Errorf("region %s should fall back to primary client; got %v", r.Name, vclusterNames(r))
+		}
+	}
+}
+
+func regionNames(rs []Region) []string {
+	out := make([]string, 0, len(rs))
+	for _, r := range rs {
+		out = append(out, r.Name)
+	}
+	return out
+}
+
+func vclusterNames(r Region) []string {
+	out := []string{}
+	for _, c := range r.Clusters {
+		for _, vc := range c.VClusters {
+			out = append(out, vc.Name)
+		}
+	}
+	return out
+}
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Root cause of the topology/DR view showing every region/app in the WRONG mode: `buildTopology` emitted the right region COUNT from the deployment record but read each region's live state through the **single primary kubeconfig** (`<depID>.yaml`), so the secondary region mirrored region-a (or showed empty). The correct multi-cluster fan-out existed but was gated to the chroot-only path and never fired on the mothership.

Fix: `buildTopology` resolves each declared region's own dynamic client off the k8sCache (which already loads `<depID>.yaml` + `<depID>-<region>-N.yaml` as distinct clusters) via a new `perRegionDynamicClient` helper; nil-tolerant fallback preserves legacy behaviour. go build/vet + per-region tests green.

This is why the topology UI never matched the target placement/region state on any 2-region env. Refs #3375