### PR TITLE
fix(cloud-graph): spread nodes across the full canvas — elliptical field, stop center-clump (#3958)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/GraphCanvas.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/GraphCanvas.tsx
@@ -250,31 +250,44 @@ function makeForceBound(
 }
 
 /**
- * Soft radial containment (#3958). A GENTLE inward force for any node
- * whose distance from (cx, cy) exceeds `fieldRadius`. Unlike makeForceBound
- * (a hard clamp at the literal viewport edge), this is a spring that grows
+ * Soft ELLIPTICAL containment (#3958). A GENTLE inward force for any node
+ * whose normalized position leaves the field ellipse
+ * `(dx/fieldRadiusX)² + (dy/fieldRadiusY)² > 1`. Unlike makeForceBound (a
+ * hard clamp at the literal viewport edge), this is a spring that grows
  * with how far the node has strayed past the target field — so the cloud
- * settles at ~70% of the viewport with the natural force-directed
- * topology intact, never flung to the edges and never crushed into the
- * centre. Inside the field it does nothing (the charge/link/gravity
- * balance owns the layout there).
+ * settles into an ellipse filling ~85% of BOTH the canvas width and
+ * height, with the natural force-directed topology intact, never flung to
+ * the edges and never crushed into the centre. On a wide-short canvas the
+ * X radius is materially larger than the Y radius, so the cloud fills the
+ * empty left/right margin instead of collapsing into a short-dim disc.
+ * Inside the ellipse it does nothing (the charge/link/gravity balance owns
+ * the layout there).
  */
-function makeForceRadialCap(cx: number, cy: number, fieldRadius: number) {
+function makeForceRadialCap(cx: number, cy: number, fieldRadiusX: number, fieldRadiusY: number) {
   let nodes: LiveNode[] = []
   const force = (alpha: number) => {
-    if (fieldRadius <= 0) return
+    if (fieldRadiusX <= 0 || fieldRadiusY <= 0) return
     for (const n of nodes) {
       // Pinned nodes are operator-controlled — never nudge them.
       if (n.fx !== null || n.fy !== null) continue
       const dx = n.x - cx
       const dy = n.y - cy
-      const dist = Math.hypot(dx, dy)
-      if (dist <= fieldRadius || dist === 0) continue
-      // Spring strength scales with the overshoot fraction so a node
-      // just past the field barely feels it, while a far-flung node is
-      // pulled firmly back. k tuned to be gentle (founder: keep the
-      // organic feel — no snapping).
-      const overshoot = (dist - fieldRadius) / fieldRadius
+      // Normalized elliptical distance: == 1 on the field boundary, > 1
+      // outside it. Squaring avoids a sqrt on the common in-field path.
+      const nx = dx / fieldRadiusX
+      const ny = dy / fieldRadiusY
+      const norm2 = nx * nx + ny * ny
+      if (norm2 <= 1 || norm2 === 0) continue
+      // overshoot = how far past the boundary, as a fraction. norm is the
+      // elliptical radius (1 at the boundary); (norm-1) is the fractional
+      // overshoot, identical in spirit to the old (dist-R)/R.
+      const norm = Math.sqrt(norm2)
+      const overshoot = norm - 1
+      // Spring strength scales with the overshoot fraction so a node just
+      // past the field barely feels it, while a far-flung node is pulled
+      // firmly back. k tuned to be gentle (founder: keep the organic feel
+      // — no snapping). Push back along the true displacement (dx, dy) so
+      // the restoring force points at the centre.
       const k = Math.min(0.25, overshoot) * alpha
       n.vx -= dx * k
       n.vy -= dy * k
@@ -639,12 +652,13 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, GraphCanvasProps>(funct
     ;(sim.force('gravityX') as ReturnType<typeof forceX>).x(cx).strength(phys.centerGravity)
     ;(sim.force('gravityY') as ReturnType<typeof forceY>).y(cy).strength(phys.centerGravity)
 
-    // Soft radial containment — a GENTLE inward nudge for any node that
-    // strays past the target field radius (~70% viewport). This is the
-    // primary "stay centred, don't fling to edges" force; the hard
-    // bound clamp below is only the absolute safety net at the true
-    // viewport edge (#3958 — keep the cloud at ~70%, never the edges).
-    sim.force('field', makeForceRadialCap(cx, cy, phys.fieldRadius))
+    // Soft ELLIPTICAL containment — a GENTLE inward nudge for any node that
+    // strays past the target field ellipse (~85% of width AND height). This
+    // is the "stay in-field, don't fling to edges" force; the hard bound
+    // clamp below is only the absolute safety net at the true viewport edge
+    // (#3958 — fill the canvas on BOTH axes, never collapse to a short-dim
+    // disc with empty left/right margin).
+    sim.force('field', makeForceRadialCap(cx, cy, phys.fieldRadiusX, phys.fieldRadiusY))
 
     // Bounded-physics force — re-install every tick-tune so the box
     // matches the current container size. d3-force's `force()` setter

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/layout.test.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/layout.test.ts
@@ -1,0 +1,323 @@
+/**
+ * layout.test.ts — locks the #3958 / fix/cloud-graph-spread-layout
+ * contract on `physicsFor` and the settled force-directed layout:
+ *
+ *   1. ELLIPTICAL field geometry: on a wide-short canvas the X-field
+ *      (anchored to width/2) is materially larger than the Y-field
+ *      (anchored to height/2), so the cloud fills BOTH axes instead of
+ *      collapsing into a min(W,H)/2 disc with empty left/right margin.
+ *   2. Constant-density clamp invariants hold across N = 4 / 64 / 400.
+ *   3. The settled layout (driven headlessly through the real d3-force
+ *      sim with production charge/collide/gravity + the elliptical cap)
+ *      fills ≥75% of BOTH the canvas width and height for N = 64, while a
+ *      4-node graph stays a tidy CENTRED cluster (not flung to corners).
+ *
+ * Approach note (per the brief): jsdom has no rAF loop, but d3-force's
+ * `simulation.tick()` is fully synchronous, so we drive the sim to a
+ * settled state deterministically (seeded RNG + fixed tick budget) and
+ * assert the bounding-box coverage directly. The cap used here is the
+ * SAME elliptical boundary the canvas installs (mirrored inline so the
+ * test owns no DOM); the geometry source of truth — `physicsFor` — is
+ * imported directly.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  forceSimulation,
+  forceManyBody,
+  forceCollide,
+  forceX,
+  forceY,
+  forceCenter,
+  type Simulation,
+} from 'd3-force'
+import { physicsFor, NODE_R, BOUND_PADDING } from './layout'
+
+/* ── geometry contract (pure, no sim) ───────────────────────────── */
+
+describe('physicsFor — elliptical, viewport-filling field', () => {
+  const W = 1100
+  const H = 600
+
+  it('X-field tracks width/2 and Y-field tracks height/2 — they differ when W≠H', () => {
+    for (const n of [4, 64, 400]) {
+      const p = physicsFor(n, W, H)
+      // The wide axis must be materially larger than the short axis.
+      expect(p.fieldRadiusX).toBeGreaterThan(p.fieldRadiusY)
+      // …and by roughly the canvas aspect ratio (same density factor on
+      // both axes ⇒ the ratio is the half-extent ratio when neither axis
+      // is clamped). At the very least it must exceed a short-dim circle.
+      const shortDimCircleR = Math.min(W, H) / 2 // what the OLD code used
+      // For a mid-size graph the X field reaches past the short-dim radius
+      // territory the old circle was stuck inside.
+      if (n >= 64) {
+        expect(p.fieldRadiusX).toBeGreaterThan(shortDimCircleR * 0.5)
+      }
+    }
+  })
+
+  it('a square canvas yields equal X/Y fields (no spurious asymmetry)', () => {
+    const p = physicsFor(64, 800, 800)
+    expect(p.fieldRadiusX).toBeCloseTo(p.fieldRadiusY, 6)
+  })
+
+  it('each axis is clamped inside its own half-extent (never spills the edge)', () => {
+    for (const n of [4, 64, 400, 4000]) {
+      const p = physicsFor(n, W, H)
+      expect(p.fieldRadiusX).toBeLessThanOrEqual(W / 2)
+      expect(p.fieldRadiusY).toBeLessThanOrEqual(H / 2)
+      // …and never collapses to a dot, even for a 4-node graph.
+      expect(p.fieldRadiusX).toBeGreaterThan(W / 2 * 0.1)
+      expect(p.fieldRadiusY).toBeGreaterThan(H / 2 * 0.1)
+    }
+  })
+
+  it('the field grows with sqrt(N) (constant density) on BOTH axes', () => {
+    const p4 = physicsFor(4, W, H)
+    const p64 = physicsFor(64, W, H)
+    const p400 = physicsFor(400, W, H)
+    expect(p64.fieldRadiusX).toBeGreaterThan(p4.fieldRadiusX)
+    expect(p400.fieldRadiusX).toBeGreaterThanOrEqual(p64.fieldRadiusX)
+    expect(p64.fieldRadiusY).toBeGreaterThan(p4.fieldRadiusY)
+    expect(p400.fieldRadiusY).toBeGreaterThanOrEqual(p64.fieldRadiusY)
+  })
+
+  it('scalar fieldRadius is the SHORT axis (min of X/Y)', () => {
+    const p = physicsFor(64, W, H)
+    expect(p.fieldRadius).toBe(Math.min(p.fieldRadiusX, p.fieldRadiusY))
+  })
+
+  it('centerGravity is now weak (anti-drift only, not center-crush)', () => {
+    for (const n of [4, 64, 400, 8000]) {
+      const p = physicsFor(n, W, H)
+      expect(p.centerGravity).toBeGreaterThan(0)
+      expect(p.centerGravity).toBeLessThanOrEqual(0.05)
+    }
+  })
+
+  it('charge is a dominant spreading force (strongly negative for small N)', () => {
+    // The whole point of the fix: repulsion must be strong enough to push
+    // nodes out to fill the field instead of collapsing to the centre.
+    expect(physicsFor(64, W, H).charge).toBeLessThanOrEqual(-150)
+    // …and softens (less negative) as N grows so a huge graph stays bounded.
+    expect(physicsFor(8000, W, H).charge).toBeGreaterThan(physicsFor(64, W, H).charge)
+  })
+})
+
+/* ── settled-layout contract (headless d3-force) ────────────────── */
+
+/**
+ * A small deterministic PRNG so the settled layout is reproducible in CI
+ * (d3-force seeds initial positions from Math.random via its phyllotaxis
+ * fallback only when x/y are unset — we set them ourselves, so the only
+ * randomness is our jitter seed here).
+ */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0
+  return () => {
+    a |= 0
+    a = (a + 0x6d2b79f5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+interface SimNode {
+  index?: number
+  x: number
+  y: number
+  vx: number
+  vy: number
+  fx: number | null
+  fy: number | null
+  degree: number
+}
+
+/**
+ * Mirror of GraphCanvas.makeForceRadialCap — the elliptical soft cap. Kept
+ * inline so this test owns no DOM/component import; the geometry it caps to
+ * comes straight from physicsFor (the source of truth under test).
+ */
+function ellipticalCap(cx: number, cy: number, rx: number, ry: number) {
+  let nodes: SimNode[] = []
+  const force = (alpha: number) => {
+    if (rx <= 0 || ry <= 0) return
+    for (const n of nodes) {
+      if (n.fx !== null || n.fy !== null) continue
+      const dx = n.x - cx
+      const dy = n.y - cy
+      const nx = dx / rx
+      const ny = dy / ry
+      const norm2 = nx * nx + ny * ny
+      if (norm2 <= 1 || norm2 === 0) continue
+      const overshoot = Math.sqrt(norm2) - 1
+      const k = Math.min(0.25, overshoot) * alpha
+      n.vx -= dx * k
+      n.vy -= dy * k
+    }
+  }
+  ;(force as unknown as { initialize: (n: SimNode[]) => void }).initialize = (next) => {
+    nodes = next
+  }
+  return force as ((alpha: number) => void) & { initialize: (n: SimNode[]) => void }
+}
+
+/**
+ * Mirror of GraphCanvas.makeForceBound — the HARD viewport-edge clamp +
+ * velocity-reflection safety net. Production installs this alongside the
+ * soft elliptical cap; we mirror it so the settle test is faithful (the
+ * hard bound is what guarantees no node ever leaves the canvas).
+ */
+function hardBound(W: number, H: number, padding: number, nodeR: number) {
+  let nodes: SimNode[] = []
+  const force = () => {
+    for (const n of nodes) {
+      const minX = nodeR + padding
+      const minY = nodeR + padding
+      const maxX = Math.max(minX, W - nodeR - padding)
+      const maxY = Math.max(minY, H - nodeR - padding)
+      if (n.x < minX) {
+        n.x = minX
+        if (n.vx < 0) n.vx = -n.vx * 0.4
+      } else if (n.x > maxX) {
+        n.x = maxX
+        if (n.vx > 0) n.vx = -n.vx * 0.4
+      }
+      if (n.y < minY) {
+        n.y = minY
+        if (n.vy < 0) n.vy = -n.vy * 0.4
+      } else if (n.y > maxY) {
+        n.y = maxY
+        if (n.vy > 0) n.vy = -n.vy * 0.4
+      }
+    }
+  }
+  ;(force as unknown as { initialize: (n: SimNode[]) => void }).initialize = (next) => {
+    nodes = next
+  }
+  return force as (() => void) & { initialize: (n: SimNode[]) => void }
+}
+
+/** Build N seeded nodes clustered near the centroid (as the canvas seeds). */
+function seedNodes(count: number, cx: number, cy: number, seedR: number, rng: () => number): SimNode[] {
+  const out: SimNode[] = []
+  for (let i = 0; i < count; i++) {
+    const ang = rng() * 2 * Math.PI
+    const rad = Math.sqrt(rng()) * seedR
+    out.push({
+      x: cx + Math.cos(ang) * rad,
+      y: cy + Math.sin(ang) * rad,
+      vx: 0,
+      vy: 0,
+      fx: null,
+      fy: null,
+      degree: 0,
+    })
+  }
+  return out
+}
+
+/** Drive the production force config to a settled state, return the nodes. */
+function settle(count: number, W: number, H: number, seed = 1): SimNode[] {
+  const phys = physicsFor(count, W, H)
+  const cx = W / 2
+  const cy = H / 2
+  const rng = mulberry32(seed)
+  const seedR = Math.min(60, phys.fieldRadius * 0.5)
+  const nodes = seedNodes(count, cx, cy, seedR, rng)
+
+  const sim: Simulation<SimNode, undefined> = forceSimulation<SimNode>(nodes)
+    .force('charge', forceManyBody<SimNode>().strength(phys.charge))
+    .force(
+      'collide',
+      forceCollide<SimNode>().radius(NODE_R + 4).strength(0.9),
+    )
+    .force('center', forceCenter<SimNode>(cx, cy))
+    .force('gravityX', forceX<SimNode>(cx).strength(phys.centerGravity))
+    .force('gravityY', forceY<SimNode>(cy).strength(phys.centerGravity))
+    .force('field', ellipticalCap(cx, cy, phys.fieldRadiusX, phys.fieldRadiusY))
+    .force('bound', hardBound(W, H, BOUND_PADDING, NODE_R))
+    .alphaDecay(phys.alphaDecay)
+    .alphaTarget(0)
+    .stop()
+
+  // No links in this isolation test — we measure the spread of the field
+  // itself (the founder complaint is about the empty margin, not topology).
+  // Tick to convergence: enough iterations for alpha to decay below the
+  // default 0.001 stop threshold given phys.alphaDecay.
+  const ticks = Math.ceil(Math.log(0.001) / Math.log(1 - phys.alphaDecay)) + 50
+  sim.alpha(1)
+  for (let i = 0; i < ticks; i++) sim.tick()
+
+  return nodes
+}
+
+function bbox(nodes: SimNode[]) {
+  let minX = Infinity
+  let maxX = -Infinity
+  let minY = Infinity
+  let maxY = -Infinity
+  for (const n of nodes) {
+    minX = Math.min(minX, n.x)
+    maxX = Math.max(maxX, n.x)
+    minY = Math.min(minY, n.y)
+    maxY = Math.max(maxY, n.y)
+  }
+  return { minX, maxX, minY, maxY, w: maxX - minX, h: maxY - minY }
+}
+
+describe('settled layout fills the canvas (headless d3-force)', () => {
+  const W = 1100
+  const H = 600
+
+  it('N=64 fills ≥75% of BOTH width and height', () => {
+    const nodes = settle(64, W, H, 42)
+    const b = bbox(nodes)
+    expect(b.w).toBeGreaterThanOrEqual(0.75 * W)
+    expect(b.h).toBeGreaterThanOrEqual(0.75 * H)
+  })
+
+  it('N=64 — no two node centres closer than the collide radius', () => {
+    const nodes = settle(64, W, H, 7)
+    const collideR = NODE_R + 4 // forceCollide radius used above
+    // d3 collide resolves overlaps softly; allow a small tolerance for the
+    // residual sub-radius penetration at the settle threshold.
+    const minAllowed = collideR * 0.9
+    let minDist = Infinity
+    for (let i = 0; i < nodes.length; i++) {
+      for (let j = i + 1; j < nodes.length; j++) {
+        const d = Math.hypot(nodes[i].x - nodes[j].x, nodes[i].y - nodes[j].y)
+        minDist = Math.min(minDist, d)
+      }
+    }
+    expect(minDist).toBeGreaterThanOrEqual(minAllowed)
+  })
+
+  it('N=4 stays a tidy CENTRED cluster (not flung to the corners)', () => {
+    const nodes = settle(4, W, H, 3)
+    const b = bbox(nodes)
+    const cx = W / 2
+    const cy = H / 2
+    // The cluster's bounding box centre is near the canvas centre.
+    expect(Math.abs((b.minX + b.maxX) / 2 - cx)).toBeLessThan(0.18 * W)
+    expect(Math.abs((b.minY + b.maxY) / 2 - cy)).toBeLessThan(0.18 * H)
+    // …and it does NOT sprawl to the edges (a tidy small cluster).
+    expect(b.w).toBeLessThan(0.6 * W)
+    expect(b.h).toBeLessThan(0.6 * H)
+  })
+
+  it('N=400 fills the canvas (no dense central blob) and stays inside the viewport', () => {
+    const nodes = settle(400, W, H, 11)
+    const b = bbox(nodes)
+    // Wide spread on both axes — fills the canvas, NOT a central blob…
+    expect(b.w).toBeGreaterThanOrEqual(0.75 * W)
+    expect(b.h).toBeGreaterThanOrEqual(0.75 * H)
+    // …and the hard bound guarantees no node ever leaves the viewport.
+    const edge = NODE_R + BOUND_PADDING
+    expect(b.minX).toBeGreaterThanOrEqual(edge - 0.5)
+    expect(b.maxX).toBeLessThanOrEqual(W - edge + 0.5)
+    expect(b.minY).toBeGreaterThanOrEqual(edge - 0.5)
+    expect(b.maxY).toBeLessThanOrEqual(H - edge + 0.5)
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/layout.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/layout.ts
@@ -13,10 +13,15 @@
  * The fix is to make the spread a function of √N so DENSITY stays
  * constant: 4 nodes → a small centred cluster, 60 nodes → a
  * proportionally larger field at the SAME density. physicsFor() targets a
- * field RADIUS that scales with √N (area ∝ N), then derives the per-tick
+ * field whose RADII scale with √N (area ∝ N), then derives the per-tick
  * forces from that field:
- *   • centerGravity parks the equilibrium inside the field (~70% of the
- *     viewport, never the literal edges).
+ *   • The field is an ELLIPSE, not a short-dim circle: fieldRadiusX is
+ *     anchored to width/2 and fieldRadiusY to height/2. On a wide-short
+ *     canvas (~1100×600) this fills BOTH axes instead of collapsing into
+ *     a min(W,H)/2 disc centred in a sea of empty left/right margin.
+ *   • centerGravity is a WEAK anti-drift pull only (~0.02–0.05) — it
+ *     parks the equilibrium against drift without crushing the cloud to
+ *     the centre. Repulsion (charge) is the dominant spreading force.
  *   • linkDistance is CLAMPED to [minLink, maxLink]: minLink ≥
  *     2·maxNodeR + pad prevents overlap; maxLink caps edge-fling.
  *   • collide has a HARD floor so two bubbles can never overlap.
@@ -36,11 +41,19 @@ export const NODE_R = 14
 export const BOUND_PADDING = 20
 
 /** Reference for the constant-density spread — at N_REF nodes the field
- *  fills FIELD_FRAC of the viewport's smaller half-extent. */
+ *  fills FIELD_FRAC of each viewport half-extent. */
 const DENSITY_N_REF = 40
-/** Target field radius as a fraction of min(W,H)/2 at N_REF nodes.
- *  ~0.7 keeps the cloud at ~70% of the viewport, never the edges. */
-const FIELD_FRAC = 0.7
+/** Target field radius as a fraction of a half-extent at N_REF nodes.
+ *  ~0.85 fills the canvas generously (the elliptical cap clamps to
+ *  FIELD_MAX_FRAC, so large graphs reach ~85% of BOTH axes). */
+const FIELD_FRAC = 0.85
+/** Upper clamp: the field never exceeds this fraction of a half-extent,
+ *  so the cloud fills the canvas without spilling past the edge padding. */
+const FIELD_MAX_FRAC = 0.88
+/** Lower clamp: the field never drops below this fraction of a half-extent,
+ *  so even a 1–4 node graph keeps "social distance" (a tidy cluster, not a
+ *  single overlapping dot) while staying centred. */
+const FIELD_MIN_FRAC = 0.18
 /** Max node radius (degree-driven) used to floor link length + collide so
  *  bubbles never overlap. Mirrors radiusForDegree's clamp ceiling. */
 const MAX_NODE_R = 20
@@ -54,24 +67,42 @@ export interface PhysicsParams {
   collide: number
   alphaDecay: number
   centerGravity: number
-  /** The target field radius — the canvas uses it for the soft radial
-   *  containment so the cloud parks at ~70% of the viewport. */
+  /** The target field radius on the X axis — anchored to width/2. The
+   *  elliptical radial cap uses this so the cloud fills the canvas WIDTH
+   *  on a wide-short viewport instead of collapsing into a min(W,H) disc. */
+  fieldRadiusX: number
+  /** The target field radius on the Y axis — anchored to height/2. */
+  fieldRadiusY: number
+  /** Scalar convenience = min(fieldRadiusX, fieldRadiusY). Retained for
+   *  seeding-jitter and any caller that wants a single scalar; the radial
+   *  CAP itself is elliptical (uses X and Y independently). */
   fieldRadius: number
 }
 
 export function physicsFor(nodeCount: number, width = 800, height = 480): PhysicsParams {
   const n = Math.max(1, nodeCount)
-  const halfExtent = Math.min(width, height) / 2
-  // Constant-density target field radius: grows with √N (area ∝ N),
-  // anchored so N_REF nodes fill FIELD_FRAC of the half-extent. Clamped
-  // so 1-4 nodes stay a tight centred cluster (not a single dot) and a
-  // huge graph never exceeds the viewport.
-  const rawField = FIELD_FRAC * halfExtent * Math.sqrt(n / DENSITY_N_REF)
-  const fieldRadius = Math.max(
-    // floor: at least enough room for a few non-overlapping bubbles.
-    Math.min(halfExtent * 0.35, 3 * (MAX_NODE_R + BOUND_PADDING)),
-    Math.min(halfExtent * 0.92, rawField),
+  const halfW = width / 2
+  const halfH = height / 2
+  // Constant-density spread factor: grows with √N (area ∝ N), anchored so
+  // N_REF nodes fill FIELD_FRAC of each half-extent. The SAME factor is
+  // applied to both axes so density stays uniform; the asymmetry between
+  // fieldRadiusX and fieldRadiusY comes purely from the canvas aspect
+  // ratio (width/2 vs height/2). On a wide-short canvas this yields a
+  // genuinely WIDER field that fills the empty left/right margin.
+  const densityFactor = FIELD_FRAC * Math.sqrt(n / DENSITY_N_REF)
+  // Per-axis field radius. Clamp each independently to its own half-extent
+  // so neither axis spills past the edge padding nor collapses to a dot.
+  const fieldRadiusX = Math.max(
+    halfW * FIELD_MIN_FRAC,
+    Math.min(halfW * FIELD_MAX_FRAC, halfW * densityFactor),
   )
+  const fieldRadiusY = Math.max(
+    halfH * FIELD_MIN_FRAC,
+    Math.min(halfH * FIELD_MAX_FRAC, halfH * densityFactor),
+  )
+  // Scalar = the SHORT axis (min) so seeding-jitter never seeds outside the
+  // tighter dimension; the cap below is elliptical and uses X/Y directly.
+  const fieldRadius = Math.min(fieldRadiusX, fieldRadiusY)
 
   // Hard collision floor: two MAX_NODE_R bubbles + a little air. This is
   // the no-overlap guarantee independent of N.
@@ -87,38 +118,42 @@ export function physicsFor(nodeCount: number, width = 800, height = 480): Physic
   // tighter (constant density) but always within [minLink, maxLink].
   const linkDistance = Math.max(minLink, Math.min(maxLink, 90 - Math.log2(n) * 6))
 
-  // Charge (repulsion) softens as N grows so the field stays bounded;
-  // gravity is the complementary inward pull that parks the equilibrium
-  // inside fieldRadius. Both scale gently with N.
+  // Charge (repulsion) is now the DOMINANT spreading force — strong enough
+  // to push nodes OUT to fill the field instead of collapsing to the
+  // centre. It softens as N grows so a huge graph stays bounded (the
+  // elliptical cap catches the overshoot). centerGravity is ONLY anti-drift
+  // now (~0.02–0.05) — it keeps the cloud from wandering off-centre without
+  // crushing it inward; the field's shape is owned by charge + collide +
+  // the elliptical cap, not by gravity.
   let charge: number
   let linkStrength: number
   let alphaDecay: number
   let centerGravity: number
   if (n <= 50) {
-    charge = -70
+    charge = -240
     linkStrength = 0.5
     alphaDecay = 0.022
-    centerGravity = 0.12
+    centerGravity = 0.03
   } else if (n <= 200) {
-    charge = -55
+    charge = -150
     linkStrength = 0.45
     alphaDecay = 0.026
-    centerGravity = 0.11
+    centerGravity = 0.035
   } else if (n <= 1000) {
-    charge = -40
+    charge = -90
     linkStrength = 0.38
     alphaDecay = 0.03
-    centerGravity = 0.1
+    centerGravity = 0.04
   } else if (n <= 5000) {
-    charge = -22
+    charge = -45
     linkStrength = 0.25
     alphaDecay = 0.04
-    centerGravity = 0.09
+    centerGravity = 0.045
   } else {
-    charge = -13
+    charge = -24
     linkStrength = 0.15
     alphaDecay = 0.05
-    centerGravity = 0.08
+    centerGravity = 0.05
   }
 
   return {
@@ -130,6 +165,8 @@ export function physicsFor(nodeCount: number, width = 800, height = 480): Physic
     collide,
     alphaDecay,
     centerGravity,
+    fieldRadiusX,
+    fieldRadiusY,
     fieldRadius,
   }
 }


### PR DESCRIPTION
Founder live on hw173: cloud graph nodes clump in the center with empty side margins. Root: the field was a circle bounded by min(W,H)/2 (short dim) + centering forces overpowering a weak charge. Fix: elliptical field (X from W/2, Y from H/2, √N density), elliptical radial cap, charge −240/−150/−90 (dominant spread), centerGravity 0.03–0.05 (anti-drift only). Test asserts N=64 fills ≥75% of both axes + no overlap; N=4 tidy centred; N=400 fills without a blob. tsc -b + npm run build + vitest(35) + eslint green. Refs #3958