### PR TITLE
fix(console): purge rendered Tenant/SME banned terms → Organization (#3383)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/app/layouts/WizardLayout.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/layouts/WizardLayout.tsx
@@ -60,7 +60,7 @@ export const WIZARD_STEPS = [
   { id: 2, label: 'Topology',     desc: 'Regions, HA, air-gap'             },
   { id: 3, label: 'Provider',     desc: 'Cloud + region + sizing per slot' },
   { id: 4, label: 'Components',   desc: 'Platform building blocks'         },
-  { id: 5, label: 'Marketplace',  desc: 'Multi-tenant SaaS storefront'     },
+  { id: 5, label: 'Marketplace',  desc: 'Multi-Organization SaaS storefront' },
   { id: 6, label: 'Domain',       desc: 'Pool subdomain or BYO domain'     },
   { id: 7, label: 'Credentials',  desc: 'API tokens + SSH key'             },
   { id: 8, label: 'Review',       desc: 'Confirm and provision'            },

--- a/products/catalyst/bootstrap/ui/src/components/CrudModals/AddVClusterModal.tsx
+++ b/products/catalyst/bootstrap/ui/src/components/CrudModals/AddVClusterModal.tsx
@@ -73,7 +73,7 @@ export function AddVClusterModal({
         <TextInput
           value={name}
           onChange={setName}
-          placeholder="e.g. tenant-a-rtz"
+          placeholder="e.g. acme-rtz"
           testId="add-vcluster-modal-name"
         />
       </FormRow>

--- a/products/catalyst/bootstrap/ui/src/components/CrudModals/formFields/VClusterFormFields.tsx
+++ b/products/catalyst/bootstrap/ui/src/components/CrudModals/formFields/VClusterFormFields.tsx
@@ -29,7 +29,7 @@ export function VClusterFormFields({ values, onChange }: VClusterFormFieldsProps
         <TextInput
           value={values.name}
           onChange={(v) => onChange({ ...values, name: v })}
-          placeholder="e.g. tenant-a-rtz"
+          placeholder="e.g. acme-rtz"
           testId="vcluster-form-name"
         />
       </FormRow>

--- a/products/catalyst/bootstrap/ui/src/pages/admin/parent-domains/ParentDomainsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/admin/parent-domains/ParentDomainsPage.tsx
@@ -109,7 +109,7 @@ export function ParentDomainsPage({
       <div className="mb-4 flex items-center justify-between">
         <div>
           <p className="text-sm text-[var(--color-text-dim)]">
-            Domains served by this Sovereign's PowerDNS. The primary hosts your console + API; sme-pool domains are offered to SME tenants for free subdomain allocation.
+            Domains served by this Sovereign's PowerDNS. The primary hosts your console + API; pool domains are offered to Organizations for free subdomain allocation.
           </p>
         </div>
         <button
@@ -381,7 +381,7 @@ function AddDomainModal({ onClose, onCreated }: AddDomainModalProps) {
             onChange={(e) => setRole(e.target.value as ParentDomainRole)}
             className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-3 py-2 text-sm text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
           >
-            <option value="sme-pool">sme-pool — offered to SME tenants</option>
+            <option value="sme-pool">pool — offered to Organizations</option>
             <option value="primary">primary — operator's own domain</option>
           </select>
         </label>

--- a/products/catalyst/bootstrap/ui/src/pages/marketplace/marketplaceCopy.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/marketplace/marketplaceCopy.ts
@@ -34,10 +34,10 @@ export const FAMILY_COPY: Record<string, FamilyCopy> = {
     overview: [
       'PILOT is the delivery plane of every Sovereign. It turns a Git repository ' +
         'into the only mutable system of record — every change to platform configuration, ' +
-        'every Blueprint upgrade, every tenant onboarding flows through a pull request, ' +
+        'every Blueprint upgrade, every Organization onboarding flows through a pull request, ' +
         'is reconciled by Flux, and is observable as code.',
       'OpenTofu and Crossplane provision the underlying cloud and Kubernetes ' +
-        'primitives, while vCluster carves the cluster into isolated tenant spaces. ' +
+        'primitives, while vCluster carves the cluster into isolated Organization spaces. ' +
         'Gitea hosts the operator-controlled repositories so the Sovereign keeps ' +
         'delivering even when the public internet is unavailable.',
     ],
@@ -45,7 +45,7 @@ export const FAMILY_COPY: Record<string, FamilyCopy> = {
       'GitOps reconciliation from operator-controlled repositories',
       'Crossplane Compositions for cloud and Kubernetes day-2 operations',
       'OpenTofu modules for Phase 0 infrastructure provisioning',
-      'vCluster tenant isolation without per-tenant control planes',
+      'vCluster Organization isolation without per-Organization control planes',
       'Self-hosted Gitea for sovereign source-of-truth',
     ],
     chip: { bg: 'rgba(56,189,248,0.16)', fg: '#38BDF8', border: 'rgba(56,189,248,0.35)' },
@@ -171,14 +171,14 @@ export const FAMILY_COPY: Record<string, FamilyCopy> = {
         'BGE produces embeddings.',
       'LangFuse traces every prompt, completion, tool call, and cost across the ' +
         'stack. Axon brokers gateway access to upstream LLM providers, and ' +
-        'LibreChat ships an end-user interface ready for tenant onboarding.',
+        'LibreChat ships an end-user interface ready for Organization onboarding.',
     ],
     capabilities: [
       'Inference serving with KServe and vLLM',
       'Vector search at petabyte scale on the Sovereign’s own storage',
       'Embedding generation and retrieval-augmented generation pipelines',
       'End-to-end LLM observability with cost, latency, and lineage',
-      'Tenant-facing chat interface with role-based access control',
+      'Organization-facing chat interface with role-based access control',
     ],
     chip: { bg: 'rgba(244,114,182,0.16)', fg: '#F472B6', border: 'rgba(244,114,182,0.35)' },
   },
@@ -242,7 +242,7 @@ export const COMPONENT_COPY: Record<string, ComponentCopy> = {
       'one-minute reconciliation cadence.',
     integration:
       'Flux is the only path through which platform manifests reach the cluster. Crossplane ' +
-      'Compositions, Blueprint OCI artifacts, and tenant overlays are all delivered through Flux ' +
+      'Compositions, Blueprint OCI artifacts, and Organization overlays are all delivered through Flux ' +
       'GitRepository and OCIRepository sources.',
     highlights: [
       'GitRepository and OCIRepository sources reconciled every minute',
@@ -272,7 +272,7 @@ export const COMPONENT_COPY: Record<string, ComponentCopy> = {
   gitea: {
     positioning:
       'Gitea is the Sovereign-local Git server that holds the operator-controlled source of truth. ' +
-      'Catalyst pre-creates five organisation tenants per Sovereign, each with its own visibility ' +
+      'Catalyst pre-creates five Organizations per Sovereign, each with its own visibility ' +
       'and policy boundary.',
     integration:
       'Gitea backs onto CloudNative PG for metadata and SeaweedFS for LFS objects. Flux pulls ' +
@@ -304,15 +304,15 @@ export const COMPONENT_COPY: Record<string, ComponentCopy> = {
   },
   vcluster: {
     positioning:
-      'vCluster carves a host Kubernetes cluster into isolated virtual clusters. Each tenant gets ' +
+      'vCluster carves a host Kubernetes cluster into isolated virtual clusters. Each Organization gets ' +
       'its own kube-apiserver, controller-manager, and scheduler, while sharing the host’s ' +
       'compute and network underlay.',
     integration:
-      'Catalyst exposes vCluster instances as a tenant-onboarding primitive. Tenants get a real ' +
+      'Catalyst exposes vCluster instances as an Organization-onboarding primitive. Organizations get a real ' +
       'kubeconfig, namespace-scoped policy, and storage carved from SeaweedFS pools, all without ' +
       'standing up a separate physical cluster.',
     highlights: [
-      'Per-tenant control planes on shared host nodes',
+      'Per-Organization control planes on shared host nodes',
       'Bidirectional service exposure to host workloads',
       'Resource quotas and storage carved from the host’s pools',
     ],
@@ -642,13 +642,13 @@ export const COMPONENT_COPY: Record<string, ComponentCopy> = {
   keycloak: {
     positioning:
       'Keycloak is the identity provider for every Sovereign. It federates external IdPs over ' +
-      'OIDC and SAML and issues tokens to operators, tenants, and workloads.',
+      'OIDC and SAML and issues tokens to operators, Organizations, and workloads.',
     integration:
       'Keycloak backs onto CloudNative PG and exposes itself behind Envoy. Catalyst pre-configures ' +
-      'realms for the platform, the operator console, and tenant onboarding.',
+      'realms for the platform, the operator console, and Organization onboarding.',
     highlights: [
       'OIDC and SAML identity federation',
-      'Realms isolated per tenant or business unit',
+      'Realms isolated per Organization or business unit',
       'Token customisation for downstream authorization',
     ],
     upstreamUrl: 'https://www.keycloak.org',
@@ -714,7 +714,7 @@ export const COMPONENT_COPY: Record<string, ComponentCopy> = {
     highlights: [
       'Curated dashboards for every Catalyst component',
       'Unified query across metrics, logs, and traces',
-      'Keycloak SSO and per-tenant org isolation',
+      'Keycloak SSO and per-Organization isolation',
     ],
     upstreamUrl: 'https://grafana.com/oss/grafana/',
     upstreamLabel: 'grafana.com',
@@ -729,7 +729,7 @@ export const COMPONENT_COPY: Record<string, ComponentCopy> = {
     highlights: [
       'Vendor-neutral SDKs for every supported language',
       'Gateway and agent topology with multi-pipeline routing',
-      'Per-tenant tail-sampling for noisy services',
+      'Per-Organization tail-sampling for noisy services',
     ],
     upstreamUrl: 'https://opentelemetry.io',
     upstreamLabel: 'opentelemetry.io',
@@ -759,7 +759,7 @@ export const COMPONENT_COPY: Record<string, ComponentCopy> = {
     highlights: [
       'Label-indexed log store with object-storage backend',
       'LogQL query language',
-      'Multi-tenant isolation for shared deployments',
+      'Multi-Organization isolation for shared deployments',
     ],
     upstreamUrl: 'https://grafana.com/oss/loki/',
     upstreamLabel: 'grafana.com/loki',
@@ -796,7 +796,7 @@ export const COMPONENT_COPY: Record<string, ComponentCopy> = {
   },
   opensearch: {
     positioning:
-      'OpenSearch is the search and analytics engine. It backs full-text search for tenant-facing ' +
+      'OpenSearch is the search and analytics engine. It backs full-text search for Organization-facing ' +
       'workloads and ad-hoc operational analytics.',
     integration:
       'OpenSearch runs as a stateful workload with its own storage class. Operators consume it ' +
@@ -1043,13 +1043,13 @@ export const COMPONENT_COPY: Record<string, ComponentCopy> = {
   axon: {
     positioning:
       'Axon is the LLM gateway. It brokers access to upstream providers, normalises pricing, and ' +
-      'ships tenant-scoped quota controls so platform owners can ration tokens.',
+      'ships Organization-scoped quota controls so platform owners can ration tokens.',
     integration:
       'Axon runs in front of every CORTEX endpoint that consumes upstream APIs. Telemetry feeds ' +
       'LangFuse for cost and latency tracking.',
     highlights: [
       'Provider-agnostic LLM API',
-      'Per-tenant quota and rate limiting',
+      'Per-Organization quota and rate limiting',
       'Cost-attribution telemetry into LangFuse',
     ],
     upstreamUrl: 'https://openova.io/products/axon',
@@ -1124,7 +1124,7 @@ export const COMPONENT_COPY: Record<string, ComponentCopy> = {
       'gateway telemetry through.',
     highlights: [
       'Prompt and completion tracing',
-      'Cost attribution per model and tenant',
+      'Cost attribution per model and Organization',
       'Session viewer for end-to-end RAG debugging',
     ],
     upstreamUrl: 'https://langfuse.com',
@@ -1132,7 +1132,7 @@ export const COMPONENT_COPY: Record<string, ComponentCopy> = {
   },
   librechat: {
     positioning:
-      'LibreChat is the AI chat interface. It ships with multi-model support, tenant onboarding, ' +
+      'LibreChat is the AI chat interface. It ships with multi-model support, Organization onboarding, ' +
       'and RBAC out of the box, so operators can replace third-party chat services with a ' +
       'self-hosted equivalent.',
     integration:
@@ -1140,7 +1140,7 @@ export const COMPONENT_COPY: Record<string, ComponentCopy> = {
       'SSO is wired through Keycloak.',
     highlights: [
       'Multi-model chat with conversation history',
-      'Tenant onboarding and RBAC',
+      'Organization onboarding and RBAC',
       'Plugin and agent integration',
     ],
     upstreamUrl: 'https://librechat.ai',
@@ -1165,7 +1165,7 @@ export const COMPONENT_COPY: Record<string, ComponentCopy> = {
   },
   livekit: {
     positioning:
-      'LiveKit is the WebRTC SFU for real-time video and audio. It powers tenant conferencing ' +
+      'LiveKit is the WebRTC SFU for real-time video and audio. It powers Organization conferencing ' +
       'workloads with end-to-end encryption and recording.',
     integration:
       'LiveKit pairs with STUNner for NAT traversal. Recording lands on the Sovereign’s ' +

--- a/products/catalyst/bootstrap/ui/src/pages/sme/CreateTenantPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sme/CreateTenantPage.test.tsx
@@ -139,6 +139,6 @@ describe('CreateTenantPage', () => {
       'sme-create-tenant-parent-select',
     ) as HTMLSelectElement
     expect(select.disabled).toBe(true)
-    expect(select.textContent).toContain('No sme-pool parents available')
+    expect(select.textContent).toContain('No pool parents available')
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sme/CreateTenantPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sme/CreateTenantPage.tsx
@@ -435,7 +435,7 @@ export function CreateTenantPage({
               {poolLoading && <option value="">Loading…</option>}
               {!poolLoading && pool.length === 0 && (
                 <option value="">
-                  No sme-pool parents available — contact the Sovereign
+                  No pool parents available — contact the Sovereign
                   operator
                 </option>
               )}
@@ -470,7 +470,7 @@ export function CreateTenantPage({
               className="rounded-md border border-[var(--color-border)] bg-[var(--color-input)] px-3 py-2 text-sm"
             />
             <span className="text-xs text-[var(--color-text-dim)]">
-              Ask the SME to add a CNAME from
+              Ask the Organization to add a CNAME from
               <code className="mx-1 rounded bg-[var(--color-input)] px-1">
                 console.{byoDomain || '<their-domain>'}
               </code>

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
@@ -982,7 +982,7 @@ function PublishToggleChip({ slug, isBootstrap = false }: PublishToggleChipProps
           : state === 'unpublished'
             ? 'Click to publish — shows in marketplace storefront'
             : state === 'bootstrap'
-              ? 'This is a bootstrap-kit install (HelmRelease without a catalog entry). It ships with the platform and is not surfaced in the tenant marketplace.'
+              ? 'This is a bootstrap-kit install (HelmRelease without a catalog entry). It ships with the platform and is not surfaced in the Organization marketplace.'
               : ''
       }
       className={`chip ${
@@ -1509,9 +1509,9 @@ function OverviewPanel({
         </section>
       ) : null}
 
-      {/* Tenant */}
+      {/* Organization */}
       <section className="section" data-testid="sov-section-tenant">
-        <h2>Tenant</h2>
+        <h2>Organization</h2>
         <p className="desc">
           {sovereignFQDN
             ? `Installing into ${sovereignFQDN} — currently ${applicationsCount} components targeted.`

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
@@ -407,7 +407,7 @@ export function CatalogDetail() {
               <span
                 className="chip chip-free"
                 data-testid="badge-platform-component"
-                title="Installed at bootstrap as a platform HelmRelease (no per-tenant Application CR)"
+                title="Installed at bootstrap as a platform HelmRelease (no per-Organization Application CR)"
               >
                 platform component
               </span>

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/SettingsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/SettingsPage.tsx
@@ -98,7 +98,7 @@ const SECTIONS: readonly SectionDef[] = [
   // is just a toggle etting under setting it dosnt need tohave a
   // sdicated page ... it shoudl be somewher e here ... similar to
   // other setting"*.
-  { id: 'marketplace', label: 'Marketplace', description: 'Public storefront, branding, tenant wildcard ingress. Changes are committed to your GitOps repo and reconciled by Flux within ~1 minute.' },
+  { id: 'marketplace', label: 'Marketplace', description: 'Public storefront, branding, Organization wildcard ingress. Changes are committed to your GitOps repo and reconciled by Flux within ~1 minute.' },
   { id: 'notifications', label: 'Notifications', description: 'Email + Slack hooks for provisioning events.' },
   { id: 'members', label: 'Members', description: 'Operators with admin / dev / viewer roles.' },
   { id: 'danger-zone', label: 'Danger zone', description: 'Wipe Sovereign, decommission, transfer ownership.' },

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/BillingPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/BillingPage.tsx
@@ -150,8 +150,8 @@ export function BillingPage({
                 Subscriptions
               </h2>
               <p className="mt-0.5 text-xs text-[var(--color-text-dim)]">
-                Active tenant subscriptions, plan tier, monthly recurring revenue,
-                and current payment status.
+                Active organization subscriptions, plan tier, monthly recurring
+                revenue, and current payment status.
               </p>
             </div>
             {pendingApi ? (
@@ -265,7 +265,7 @@ export function BillingPage({
               className="px-4 py-12 text-center text-sm text-[var(--color-text-dim)]"
             >
               {subscriptions.length === 0
-                ? 'No tenant subscriptions yet. New tenants appear here once they purchase a plan from the marketplace.'
+                ? 'No organization subscriptions yet. New organizations appear here once they purchase a plan from the marketplace.'
                 : 'No subscriptions match the current filters.'}
             </div>
           ) : (

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/BssLandingPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/BssLandingPage.tsx
@@ -10,12 +10,12 @@
  *
  * Layout (PortalShell body):
  *   • KPI strip — 4 cards (Billing MRR / Orders pending / Vouchers
- *     active / Tenants active) using the SettingsPage SectionCard
+ *     active / Organizations active) using the SettingsPage SectionCard
  *     chrome (var(--color-bg-2) on rounded border, h2 + tagline).
  *   • Revenue card — 30-day revenue + inline SVG sparkline, full
  *     width below the KPI strip.
  *   • Section nav grid — 5 cards (Billing / Orders / Revenue /
- *     Vouchers / Tenants) linking to /bss/<section>, mirroring the
+ *     Vouchers / Organizations) linking to /bss/<section>, mirroring the
  *     AppsPage `.apps-grid` minmax(360px, 1fr) auto-fit pattern.
  *
  * Per docs/INVIOLABLE-PRINCIPLES.md #1 (waterfall — first paint is the
@@ -58,7 +58,7 @@ export const BSS_SECTIONS: readonly BssSection[] = [
   {
     id: 'orders',
     label: 'Orders',
-    description: 'New tenant orders, provisioning queue, fulfilment.',
+    description: 'New organization orders, provisioning queue, fulfilment.',
     to: '/bss/orders',
   },
   {
@@ -75,8 +75,8 @@ export const BSS_SECTIONS: readonly BssSection[] = [
   },
   {
     id: 'tenants',
-    label: 'Tenants',
-    description: 'Active tenant organizations and lifecycle controls.',
+    label: 'Organizations',
+    description: 'Active organizations and lifecycle controls.',
     to: '/bss/tenants',
   },
 ] as const
@@ -161,7 +161,7 @@ export function BssLandingPage({
           />
           <KpiCard
             id="tenants"
-            title="Tenants active"
+            title="Organizations active"
             value={loaded ? String(overview!.tenants.active) : '—'}
             footer={
               loaded

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/OrdersPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/OrdersPage.tsx
@@ -166,7 +166,7 @@ export function OrdersPage({
             </svg>
             <input
               type="search"
-              placeholder="Search orders by id, tenant, or product…"
+              placeholder="Search orders by id, organization, or product…"
               className="orders-search-input"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
@@ -227,7 +227,7 @@ export function OrdersPage({
             <thead>
               <tr>
                 <th data-col="id">Order ID</th>
-                <th data-col="tenant">Tenant org</th>
+                <th data-col="tenant">Organization</th>
                 <th data-col="product">Product</th>
                 <th data-col="status">Status</th>
                 <th data-col="created">Created</th>
@@ -254,7 +254,7 @@ export function OrdersPage({
                     data-testid="bss-orders-table-empty"
                   >
                     {orders.length === 0
-                      ? 'No orders yet. Tenant orders from the marketplace will appear here.'
+                      ? 'No orders yet. Organization orders from the marketplace will appear here.'
                       : 'No orders match the current filters.'}
                   </td>
                 </tr>

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/RevenuePage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/RevenuePage.tsx
@@ -10,13 +10,13 @@
  *
  * Layout (PortalShell body):
  *   • Back-to-overview crumb (headerSlotLeft, matches BssSectionShell).
- *   • KPI strip — 4 cards (Last 30d revenue / MoM delta / Top tenant /
+ *   • KPI strip — 4 cards (Last 30d revenue / MoM delta / Top organization /
  *     Top plan) using the same KpiCard chrome as BssLandingPage.
  *   • Revenue trend — full-width line chart of daily revenue for the
  *     trailing 30 days. Uses Recharts (already a top-level dep, see
  *     widgets/cloud-list/MetricsPanel.tsx + widgets/compliance/
  *     ComplianceTreemap.tsx) so we don't introduce a new chart lib.
- *   • Breakdown table — Plan | Tenants | MRR | YoY %, sortable by any
+ *   • Breakdown table — Plan | Organizations | MRR | YoY %, sortable by any
  *     column. Mirrors the ParentDomainsPage table chrome (border-
  *     collapse, var(--color-border) row dividers, uppercase dimmed
  *     header cells).
@@ -129,9 +129,9 @@ export function RevenuePage({
           />
           <KpiCard
             id="top-tenant"
-            title="Top tenant"
+            title="Top organization"
             value={loaded && revenue!.kpi.topTenant ? revenue!.kpi.topTenant : '—'}
-            footer={loaded && !revenue!.kpi.topTenant ? 'No tenants yet' : undefined}
+            footer={loaded && !revenue!.kpi.topTenant ? 'No organizations yet' : undefined}
             pendingApi={pendingApi}
           />
           <KpiCard
@@ -186,9 +186,9 @@ export function RevenuePage({
                 Breakdown by plan
               </h2>
               <p className="mt-0.5 text-xs text-[var(--color-text-dim)]">
-                MRR contribution, active tenant count, and year-over-year
-                delta per subscription plan. Click any column header to
-                sort.
+                MRR contribution, active organization count, and
+                year-over-year delta per subscription plan. Click any
+                column header to sort.
               </p>
             </div>
             {pendingApi ? (
@@ -477,7 +477,7 @@ function BreakdownTable({ rows, loaded }: BreakdownTableProps) {
         data-testid="bss-revenue-breakdown-empty"
         className="rounded-md border border-[var(--color-border)] px-4 py-8 text-center text-sm text-[var(--color-text-dim)]"
       >
-        No plan revenue yet. Once tenants subscribe to a plan, MRR
+        No plan revenue yet. Once organizations subscribe to a plan, MRR
         contribution per plan will appear here.
       </div>
     )
@@ -499,7 +499,7 @@ function BreakdownTable({ rows, loaded }: BreakdownTableProps) {
             className="py-2 pr-3"
           />
           <SortableTh
-            label="Tenants"
+            label="Organizations"
             col="tenants"
             activeKey={sortKey}
             activeDir={sortDir}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/TenantsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/TenantsPage.tsx
@@ -117,7 +117,7 @@ export function TenantsPage({
     <PortalShell
       deploymentId={deploymentId}
       sovereignFQDN={sovereignFQDN}
-      pageTitle="Tenants"
+      pageTitle="Organizations"
       headerSlotLeft={
         <Link
           to={'/bss' as never}
@@ -130,8 +130,8 @@ export function TenantsPage({
     >
       <div data-testid="bss-tenants-page">
         <p className="mb-4 text-sm text-[var(--color-text-dim)]">
-          Tenant organisations provisioned via marketplace signup. Each row is
-          one Organization CR + per-tenant vCluster on this Sovereign.
+          Organizations provisioned via marketplace signup. Each row is
+          one Organization CR + per-Organization vCluster on this Sovereign.
         </p>
 
         {/* Filter row — mirrors JobsTable.toolbar shape but uses the
@@ -152,7 +152,7 @@ export function TenantsPage({
               onChange={(e) => setSearch(e.target.value)}
               placeholder="Search by org, subdomain, owner email, or status…"
               data-testid="bss-tenants-search"
-              aria-label="Search tenants"
+              aria-label="Search organizations"
               className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
             />
           </label>
@@ -247,16 +247,16 @@ export function TenantsPage({
             data-testid="bss-tenants-empty"
             className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-4 py-8 text-center text-sm text-[var(--color-text-dim)]"
           >
-            No tenants provisioned yet. Marketplace signups land here once the
-            tenant-provisioning pipeline (vCluster + Keycloak + DNS + certs)
-            reaches the registered state.
+            No organizations provisioned yet. Marketplace signups land here once
+            the organization-provisioning pipeline (vCluster + Keycloak + DNS +
+            certs) reaches the registered state.
           </div>
         ) : visibleTenants.length === 0 ? (
           <div
             data-testid="bss-tenants-no-matches"
             className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-4 py-8 text-center text-sm text-[var(--color-text-dim)]"
           >
-            No tenants match the current filters.
+            No organizations match the current filters.
           </div>
         ) : (
           <div className="overflow-x-auto rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)]">

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/VouchersPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/VouchersPage.tsx
@@ -569,7 +569,7 @@ function IssueVoucherModal({ onClose, onIssued }: IssueVoucherModalProps) {
             type="text"
             value={description}
             onChange={(e) => setDescription(e.target.value)}
-            placeholder="Launch promotion — first 100 tenants"
+            placeholder="Launch promotion — first 100 organizations"
             className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-3 py-2 text-sm text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
           />
         </label>

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-compute/CloudComputePage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-compute/CloudComputePage.tsx
@@ -27,7 +27,7 @@ const COMPUTE_TILES: readonly ComputeTile[] = [
   {
     id: 'vclusters',
     label: 'vClusters',
-    tagline: 'Logical isolation per Sovereign tenant',
+    tagline: 'Logical isolation per Organization',
   },
   {
     id: 'node-pools',

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kinds.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kinds.ts
@@ -173,7 +173,7 @@ const ICON_POLICY_REPORT =
 export const KINDS: readonly CloudKindEntry[] = [
   // Primary chips — the 6 most-used surfaces stay inline.
   { id: 'clusters', label: 'Clusters', tagline: 'k3s / k8s control planes', hasData: true, Component: ClustersPage, icon: ICON_CLUSTER, category: 'compute', primary: true },
-  { id: 'vclusters', label: 'vClusters', tagline: 'Logical isolation per Sovereign tenant', hasData: true, Component: VClustersPage, icon: ICON_VCLUSTER, category: 'compute', primary: true },
+  { id: 'vclusters', label: 'vClusters', tagline: 'Logical isolation per Organization', hasData: true, Component: VClustersPage, icon: ICON_VCLUSTER, category: 'compute', primary: true },
   { id: 'node-pools', label: 'Node Pools', tagline: 'Worker pools grouped by SKU + role', hasData: true, Component: NodePoolsPage, icon: ICON_NODE_POOL, category: 'compute', primary: true },
   { id: 'pvcs', label: 'PVCs', tagline: 'Persistent volume claims', hasData: true, Component: PvcsPage, icon: ICON_PVC, category: 'storage', primary: true },
   { id: 'load-balancers', label: 'Load Balancers', tagline: 'Cloud-provisioned LBs fronting clusters', hasData: true, Component: LoadBalancersPage, icon: ICON_LB, category: 'network', primary: true },

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/settings/MarketplaceSection.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/settings/MarketplaceSection.tsx
@@ -173,8 +173,8 @@ export function MarketplaceSection() {
         <div className="min-w-0 flex-1">
           <p className="text-sm text-[var(--color-text)]">
             {enabled
-              ? 'Public storefront, *.{sovereignFQDN} tenant wildcard, and back-office routes are exposed.'
-              : 'Only console + admin routes are exposed; SME services run in the cluster but have no public ingress.'}
+              ? 'Public storefront, *.{sovereignFQDN} Organization wildcard, and back-office routes are exposed.'
+              : 'Only console + admin routes are exposed; Organization services run in the cluster but have no public ingress.'}
           </p>
         </div>
         <button

--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepMarketplace.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepMarketplace.tsx
@@ -81,10 +81,10 @@ export function StepMarketplace() {
     <StepShell
       title="Marketplace mode"
       description={
-        'Marketplace mode turns this Sovereign into a multi-tenant SaaS platform. ' +
+        'Marketplace mode turns this Sovereign into a multi-Organization SaaS platform. ' +
         'You publish apps from your unified catalog, customers sign up at the storefront, ' +
-        'and each tenant runs in an isolated subdomain shell. Leave it off to provision a ' +
-        'single-tenant private Sovereign — you can flip the toggle later from Settings.'
+        'and each Organization runs in an isolated subdomain shell. Leave it off to provision a ' +
+        'single-Organization private Sovereign — you can flip the toggle later from Settings.'
       }
       onNext={next}
       onBack={back}
@@ -138,7 +138,7 @@ export function StepMarketplace() {
               >
                 {marketplaceURL}
               </code>
-              , get isolated per-tenant subdomains, and consume apps you publish from your
+              , get isolated per-Organization subdomains, and consume apps you publish from your
               unified catalog.
             </p>
           </div>

--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepReview.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepReview.tsx
@@ -1266,7 +1266,7 @@ export function StepReview() {
                 lineHeight: 1.5,
               }}
             >
-              Single-tenant private Sovereign. No storefront, no per-tenant subdomains. You can
+              Single-Organization private Sovereign. No storefront, no per-Organization subdomains. You can
               flip Marketplace mode on later from the post-launch Settings page without
               re-provisioning.
             </p>

--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/componentGroups.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/componentGroups.ts
@@ -173,9 +173,9 @@ export const GROUPS: GroupDef[] = [
     components: [
       { id: 'flux',       name: 'Flux CD',    desc: 'GitOps reconciler driving every Sovereign cluster from Git', tier: 'mandatory', dependencies: [] },
       { id: 'crossplane', name: 'Crossplane', desc: 'Cloud and Kubernetes APIs as native CRDs',                   tier: 'mandatory', dependencies: [] },
-      { id: 'gitea',      name: 'Gitea',      desc: 'Sovereign-local Git server with five tenant organisations',  tier: 'mandatory', dependencies: ['cnpg'] },
+      { id: 'gitea',      name: 'Gitea',      desc: 'Sovereign-local Git server with five organizations',         tier: 'mandatory', dependencies: ['cnpg'] },
       { id: 'opentofu',   name: 'OpenTofu',   desc: 'Phase-zero IaC for cloud machines, networks, DNS',           tier: 'mandatory', dependencies: [] },
-      { id: 'vcluster',   name: 'vCluster',   desc: 'Virtual control planes for tenant isolation on shared nodes', tier: 'mandatory', dependencies: [] },
+      { id: 'vcluster',   name: 'vCluster',   desc: 'Virtual control planes for Organization isolation on shared nodes', tier: 'mandatory', dependencies: [] },
     ],
   },
   {
@@ -339,7 +339,7 @@ export const GROUPS: GroupDef[] = [
       { id: 'knative',   name: 'Knative',   desc: 'Scale-to-zero runtime for HTTP and event-driven workloads',     tier: 'optional',  dependencies: [] },
       // Axon is an OpenOva-internal component without a finalized
       // upstream brand mark — render the letter-mark fallback (#173).
-      { id: 'axon',      name: 'Axon',      desc: 'Provider-agnostic LLM gateway with per-tenant quota and cost', tier: 'recommended', dependencies: [], logoUrl: null },
+      { id: 'axon',      name: 'Axon',      desc: 'Provider-agnostic LLM gateway with per-Organization quota and cost', tier: 'recommended', dependencies: [], logoUrl: null },
       { id: 'neo4j',     name: 'Neo4j',     desc: 'Graph database for fraud, identity, and knowledge graphs',     tier: 'optional',  dependencies: [] },
       { id: 'vllm',      name: 'vLLM',      desc: 'High-throughput LLM inference with PagedAttention and batching', tier: 'optional', dependencies: [], logoUrl: basePath('component-logos/vllm.png') },
       { id: 'milvus',    name: 'Milvus',    desc: 'Vector database for billion-scale similarity search',          tier: 'optional',  dependencies: ['seaweedfs'] },
@@ -353,7 +353,7 @@ export const GROUPS: GroupDef[] = [
       // earlier dep `['cnpg']` was wrong: LibreChat does not speak
       // PostgreSQL and would not start with cnpg alone. (audit 2026-04 —
       // confirmed against https://www.librechat.ai/docs/user_guides/mongodb)
-      { id: 'librechat', name: 'LibreChat', desc: 'Multi-model self-hosted chat with tenant onboarding and RBAC', tier: 'optional', dependencies: ['ferretdb'] },
+      { id: 'librechat', name: 'LibreChat', desc: 'Multi-model self-hosted chat with Organization onboarding and RBAC', tier: 'optional', dependencies: ['ferretdb'] },
     ],
   },
   {
@@ -362,7 +362,7 @@ export const GROUPS: GroupDef[] = [
     required: false,
     components: [
       { id: 'stalwart', name: 'Stalwart', desc: 'All-in-one SMTP, IMAP, and JMAP mail server',                tier: 'recommended', dependencies: [] },
-      { id: 'livekit',  name: 'LiveKit',  desc: 'WebRTC SFU for tenant video and audio with encryption',     tier: 'recommended', dependencies: [] },
+      { id: 'livekit',  name: 'LiveKit',  desc: 'WebRTC SFU for Organization video and audio with encryption', tier: 'recommended', dependencies: [] },
       { id: 'stunner',  name: 'STUNner',  desc: 'Kubernetes-native TURN and STUN gateway for WebRTC media',  tier: 'recommended', dependencies: [] },
       { id: 'matrix',   name: 'Matrix',   desc: 'Federated end-to-end encrypted messaging with protocol bridges', tier: 'optional', dependencies: ['cnpg'] },
       { id: 'ntfy',     name: 'Ntfy',     desc: 'Topic-based push notifications over HTTP with mobile subscribers', tier: 'optional', dependencies: [] },


### PR DESCRIPTION
Removes user-rendered 'Tenants'/'SME tenants'/'OpenOva SME' strings from BSS Plans column, parent-domains copy, marketplace storefront copy, wizard, AppDetail, etc. → Organization per GLOSSARY. Internal type names / wire fields / cache keys untouched. tsc -b + npm run build + vitest(38) green. Two generated-artifact slugs (bp-wordpress-tenant) routed to blueprint-source rename (noted). Refs #3383