### PR TITLE
feat(cloud-view): #3970 lens = named chip-set (not a filter) · default Cloud · 100% density · even layout · graph+list one dataset incl. reconcilers

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Architecture.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Architecture.test.tsx
@@ -100,23 +100,38 @@ describe('Architecture — empty', () => {
 })
 
 describe('Architecture — force graph render', () => {
-  it('renders the canvas + node groups for every type in the fixture', async () => {
+  it('renders the canvas + the Cloud-lens nodes by default (#3970)', async () => {
     renderArchitecturePage(infrastructureTopologyFixture)
     expect(await screen.findByTestId('arch-graph-canvas')).toBeTruthy()
     expect(screen.getByTestId('arch-graph-svg')).toBeTruthy()
 
-    // Composite ids: ${type}:${elementId}
+    // The default Cloud lens shows the cloud-provider nodes. Composite
+    // ids: ${type}:${elementId}.
     expect(screen.getByTestId('arch-graph-node-Cloud-Cloud:cloud-hetzner')).toBeTruthy()
     expect(screen.getByTestId('arch-graph-node-Region-Region:region-eu-central')).toBeTruthy()
     expect(
       screen.getByTestId('arch-graph-node-Cluster-Cluster:cluster-eu-central-primary'),
     ).toBeTruthy()
-    expect(screen.getByTestId('arch-graph-node-vCluster-vCluster:vc-eu-central-dmz')).toBeTruthy()
     expect(screen.getByTestId('arch-graph-node-WorkerNode-WorkerNode:node-eu-cp-0')).toBeTruthy()
     expect(
       screen.getByTestId('arch-graph-node-LoadBalancer-LoadBalancer:lb-eu-central-edge'),
     ).toBeTruthy()
-    expect(screen.getByTestId('arch-graph-node-Network-Network:net-eu-central')).toBeTruthy()
+    // vCluster (catalyst family) + Network (cilium family) are NOT in the
+    // Cloud lens, so they're not on the canvas by default.
+    expect(
+      screen.queryByTestId('arch-graph-node-vCluster-vCluster:vc-eu-central-dmz'),
+    ).toBeNull()
+    expect(screen.queryByTestId('arch-graph-node-Network-Network:net-eu-central')).toBeNull()
+  })
+
+  it('+Add vCluster renders the vCluster node on the canvas', async () => {
+    renderArchitecturePage(infrastructureTopologyFixture)
+    await screen.findByTestId('arch-graph-svg')
+    fireEvent.click(screen.getByTestId('cloud-architecture-add-chip-button'))
+    fireEvent.click(screen.getByTestId('cloud-architecture-add-chip-item-vCluster'))
+    expect(
+      await screen.findByTestId('arch-graph-node-vCluster-vCluster:vc-eu-central-dmz'),
+    ).toBeTruthy()
   })
 
   it('renders the edge legend with every relation type (popover, issue #366 item 3)', async () => {
@@ -227,27 +242,70 @@ describe('Architecture — context menu', () => {
 })
 
 describe('Architecture — density slider', () => {
-  it('exposes the global density slider with the default 50%', async () => {
+  it('exposes the global density slider with the default 100% (#3970)', async () => {
     renderArchitecturePage(infrastructureTopologyFixture)
     await screen.findByTestId('arch-graph-svg')
     const slider = screen.getByTestId(
       'cloud-architecture-global-density',
     ) as HTMLInputElement
     expect(slider).toBeTruthy()
-    expect(slider.value).toBe('50')
+    expect(slider.value).toBe('100')
   })
+})
 
-  it('exposes per-type badges for every type', async () => {
+describe('Architecture — default Cloud lens (#3970)', () => {
+  it('opens on the Cloud lens — the strip shows ONLY the Cloud-lens chips', async () => {
     renderArchitecturePage(infrastructureTopologyFixture)
     await screen.findByTestId('arch-graph-svg')
+    // Default lens = Cloud.
+    const lens = screen.getByTestId('cloud-architecture-lens') as HTMLSelectElement
+    expect(lens.value).toBe('cloud')
+    // Cloud-lens members (scope/compute/network ∩ cloud family) are in the
+    // strip…
     expect(screen.getByTestId('cloud-architecture-type-badge-Cloud')).toBeTruthy()
     expect(screen.getByTestId('cloud-architecture-type-badge-Region')).toBeTruthy()
     expect(screen.getByTestId('cloud-architecture-type-badge-Cluster')).toBeTruthy()
-    expect(screen.getByTestId('cloud-architecture-type-badge-vCluster')).toBeTruthy()
     expect(screen.getByTestId('cloud-architecture-type-badge-NodePool')).toBeTruthy()
     expect(screen.getByTestId('cloud-architecture-type-badge-WorkerNode')).toBeTruthy()
     expect(screen.getByTestId('cloud-architecture-type-badge-LoadBalancer')).toBeTruthy()
-    expect(screen.getByTestId('cloud-architecture-type-badge-Network')).toBeTruthy()
+    // …and NON-members are ABSENT from the strip (removed, not greyed):
+    // vCluster (catalyst family) + Network (cilium family) + the workloads.
+    expect(screen.queryByTestId('cloud-architecture-type-badge-vCluster')).toBeNull()
+    expect(screen.queryByTestId('cloud-architecture-type-badge-Network')).toBeNull()
+    expect(screen.queryByTestId('cloud-architecture-type-badge-Pod')).toBeNull()
+    expect(screen.queryByTestId('cloud-architecture-type-badge-HelmRelease')).toBeNull()
+  })
+
+  it('selecting the Reconciliation lens SWAPS the strip to the control chips', async () => {
+    renderArchitecturePage(infrastructureTopologyFixture)
+    await screen.findByTestId('arch-graph-svg')
+    const lens = screen.getByTestId('cloud-architecture-lens') as HTMLSelectElement
+    fireEvent.change(lens, { target: { value: 'reconciliation' } })
+    expect(lens.value).toBe('reconciliation')
+    // Cloud chips are GONE from the strip…
+    expect(screen.queryByTestId('cloud-architecture-type-badge-Cloud')).toBeNull()
+    expect(screen.queryByTestId('cloud-architecture-type-badge-Region')).toBeNull()
+    // …and the Reconciliation (control-category) chips are present.
+    expect(screen.getByTestId('cloud-architecture-type-badge-HelmRelease')).toBeTruthy()
+    expect(screen.getByTestId('cloud-architecture-type-badge-Kustomization')).toBeTruthy()
+    expect(screen.getByTestId('cloud-architecture-type-badge-Application')).toBeTruthy()
+  })
+
+  it('+Add grows the lens and marks Custom; removing reverts', async () => {
+    renderArchitecturePage(infrastructureTopologyFixture)
+    await screen.findByTestId('arch-graph-svg')
+    // No Custom marker on the pure Cloud lens.
+    expect(screen.queryByTestId('cloud-architecture-lens-custom')).toBeNull()
+    // Open the +Add menu and add a Database chip (not in the Cloud lens).
+    fireEvent.click(screen.getByTestId('cloud-architecture-add-chip-button'))
+    fireEvent.click(screen.getByTestId('cloud-architecture-add-chip-item-Database'))
+    // The Database chip now appears + the Custom marker shows.
+    expect(screen.getByTestId('cloud-architecture-type-badge-Database')).toBeTruthy()
+    expect(screen.getByTestId('cloud-architecture-lens-custom')).toBeTruthy()
+    // Remove it → back to the pure lens (Custom clears).
+    fireEvent.click(screen.getByTestId('cloud-architecture-type-badge-Database-remove'))
+    expect(screen.queryByTestId('cloud-architecture-type-badge-Database')).toBeNull()
+    expect(screen.queryByTestId('cloud-architecture-lens-custom')).toBeNull()
   })
 })
 

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CloudPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CloudPage.tsx
@@ -56,15 +56,8 @@ import { useDeploymentEvents } from './useDeploymentEvents'
 import { Architecture } from './Architecture'
 import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
 import { CloudListView } from './cloud-list/CloudListView'
-import { CloudKindChips } from './cloud-list/CloudKindChips'
-import {
-  DEFAULT_KIND,
-  KIND_TO_REGISTRY,
-  isValidKind,
-  readPersistedKind,
-  type CloudListKind,
-} from './cloud-list/kinds'
 import { useK8sCacheStream } from '@/widgets/architecture-graph/useK8sCacheStream'
+import { CloudLensProvider } from '@/widgets/architecture-graph/useCloudLens'
 import {
   getHierarchicalInfrastructure,
   listDeployments,
@@ -385,108 +378,6 @@ export function CloudPage({
     })
   }
 
-  /* ── Resource-kind chip strip (issue #366 item 1) ──────────────── */
-  const activeKind: CloudListKind = useMemo(() => {
-    if (isValidKind(search.kind)) return search.kind
-    return readPersistedKind() ?? DEFAULT_KIND
-  }, [search.kind])
-
-  const kindCounts = useMemo<Record<CloudListKind, number | null>>(() => {
-    const c: Record<CloudListKind, number | null> = {
-      'clusters': 0,
-      'vclusters': 0,
-      'node-pools': 0,
-      'worker-nodes': 0,
-      'load-balancers': 0,
-      'services': null,
-      'ingresses': null,
-      'dns-zones': null,
-      'pvcs': 0,
-      'buckets': 0,
-      'volumes': 0,
-      'storage-classes': null,
-      'pods': null,
-      'deployments': null,
-      'statefulsets': null,
-      'daemonsets': null,
-      'replicasets': null,
-      'configmaps': null,
-      'secrets': null,
-      'namespaces': null,
-      'nodes': null,
-      'persistentvolumes': null,
-      'endpointslices': null,
-      // Wave 8 hotfix 2026-05-18: Family E PR #1602 added these two as
-      // first-class CloudListKinds (PolicyReports + ClusterPolicyReports)
-      // for EPIC-1 Compliance, but never updated this counts seed object.
-      // tsc failed for every subsequent UI build, the deploy-bot couldn't
-      // auto-bump values.yaml, and chart 1.4.155 published with stale UI
-      // image SHA 898305f (PR #1600 Family C era). Wave 5+6 UI changes
-      // never reached fresh provs t11/t12 — caught on the t12 5-agent
-      // test scorecard (W5-1/2/3/4 + W6-1 all FAIL).
-      'policyreports': null,
-      'clusterpolicyreports': null,
-    }
-    if (data) {
-      let clusters = 0
-      let vclusters = 0
-      let nodePools = 0
-      let workerNodes = 0
-      let lb = 0
-      for (const region of data.topology.regions ?? []) {
-        for (const cluster of region.clusters ?? []) {
-          clusters += 1
-          vclusters += cluster.vclusters?.length ?? 0
-          nodePools += cluster.nodePools?.length ?? 0
-          workerNodes += cluster.nodes?.length ?? 0
-          lb += cluster.loadBalancers?.length ?? 0
-        }
-      }
-      c['clusters'] = clusters
-      c['vclusters'] = vclusters
-      c['node-pools'] = nodePools
-      c['worker-nodes'] = workerNodes
-      c['load-balancers'] = lb
-      c['pvcs'] = data.storage?.pvcs?.length ?? 0
-      c['buckets'] = data.storage?.buckets?.length ?? 0
-      c['volumes'] = data.storage?.volumes?.length ?? 0
-    }
-    // Override every K8s-backed count from the live snapshot. Counts
-    // start at null until the SSE connection delivers initialState=1.
-    if (k8sStream.snapshot.size > 0) {
-      const liveCounts: Partial<Record<CloudListKind, number>> = {}
-      for (const key of k8sStream.snapshot.keys()) {
-        const kind = key.split(':', 1)[0]
-        for (const [chipId, registryKind] of Object.entries(KIND_TO_REGISTRY)) {
-          if (registryKind === kind) {
-            const id = chipId as CloudListKind
-            liveCounts[id] = (liveCounts[id] ?? 0) + 1
-          }
-        }
-      }
-      // Always set to 0 (not null) for K8s-backed kinds once the
-      // stream has *any* data — that means initialState=1 has
-      // arrived and a kind with 0 count is genuinely empty, not
-      // unconnected.
-      for (const chipId of Object.keys(KIND_TO_REGISTRY) as CloudListKind[]) {
-        c[chipId] = liveCounts[chipId] ?? 0
-      }
-    }
-    return c
-  }, [data, k8sStream.snapshot, k8sStream.revision])
-
-  const setKind = useCallback(
-    (next: CloudListKind) => {
-      navigate({
-        to: cloudPath(deploymentId) as never,
-        params: { deploymentId } as never,
-        search: { view: 'list', kind: next } as never,
-        replace: false,
-      })
-    },
-    [navigate, deploymentId],
-  )
-
   /* ── Fullscreen ─────────────────────────────────────────────── */
   const contentRef = useRef<HTMLDivElement | null>(null)
   const [isFullscreen, setIsFullscreen] = useState(false)
@@ -649,15 +540,10 @@ export function CloudPage({
             </button>
           </div>
 
-          {activeView === 'list' ? (
-            <CloudKindChips
-              activeKind={activeKind}
-              counts={kindCounts}
-              onChange={setKind}
-            />
-          ) : (
-            <span aria-hidden className="cloud-page-toolbar-spacer" />
-          )}
+          {/* #3970 — the list view now owns its own lens dropdown + chip
+              strip (CloudUnifiedList), shared with the graph via the lens
+              context. The legacy per-kind CloudKindChips strip is gone. */}
+          <span aria-hidden className="cloud-page-toolbar-spacer" />
 
           <button
             type="button"
@@ -689,6 +575,7 @@ export function CloudPage({
         </div>
 
         <CloudContext.Provider value={ctx}>
+          <CloudLensProvider>
           <div
             id="cloud-page-content"
             ref={contentRef}
@@ -728,6 +615,7 @@ export function CloudPage({
               {outletSlot}
             </div>
           </div>
+          </CloudLensProvider>
         </CloudContext.Provider>
       </div>
     </PortalShell>

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/CloudListView.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/CloudListView.tsx
@@ -1,121 +1,22 @@
 /**
  * CloudListView — list-mode body for the Cloud parent surface.
  *
- * Per issue #366 item 1, the legacy 12-tile card grid + dropdown
- * switcher are gone — both are replaced by the compact chip strip
- * (`CloudKindChips`) that lives inline in the CloudPage toolbar so
- * the active list table sits directly under the toolbar without a
- * vertical-space penalty.
- *
- * What's left in this file: resolve the active kind from URL / local
- * storage / default, persist on change, and render the active P3 list
- * page. The kind catalogue itself (icons, labels, primary/overflow
- * split, validation helpers) lives in `./kinds.ts`.
+ * #3970 unifies the list with the graph: the list is now ONE rendering of
+ * the SAME dataset (cloud + k8s + reconcilers), driven by the SAME active
+ * chip-set (the shared lens state). The legacy per-kind dispatch (a
+ * separate `cloud-list/kinds.ts` catalogue that had NO reconciler kinds)
+ * is replaced by `CloudUnifiedList`, which renders every resource the
+ * graph shows — including HelmReleases / Kustomizations / Certificates /
+ * ExternalSecrets / Databases (CNPG) and the Catalyst CRs — filtered by
+ * the active lens.
  */
 
-import { useCallback, useEffect, useMemo } from 'react'
-import { useNavigate, useRouterState, useSearch } from '@tanstack/react-router'
-import { DETECTED_MODE } from '@/shared/lib/detectMode'
-import { useCloud } from '../CloudPage'
-import { CLOUD_LIST_CSS } from './cloudListCss'
-import {
-  DEFAULT_KIND,
-  findKind,
-  isValidKind,
-  readPersistedKind,
-  writePersistedKind,
-  type CloudListKind,
-} from './kinds'
+import { CloudUnifiedList } from './CloudUnifiedList'
 
-// Re-export so existing call sites that import the type from here keep
-// compiling without churn.
-export type { CloudListKind } from './kinds'
-
-interface CloudListViewProps {
-  /** Optional explicit kind override — used by tests. When omitted the
-   *  active kind comes from the URL query, the persisted value, or
-   *  the default in that order. */
-  kindOverride?: CloudListKind
-}
-
-export function CloudListView({ kindOverride }: CloudListViewProps = {}) {
-  const { deploymentId, data, isLoading } = useCloud()
-  const navigate = useNavigate()
-  const search = useSearch({ strict: false }) as { view?: string; kind?: string }
-  const pathname = useRouterState({ select: (s) => s.location.pathname })
-
-  // Resolve the active kind: explicit override > URL query > persisted
-  // localStorage > default. The first time the operator lands on the
-  // list view without a `kind` query, we update the URL so the state
-  // is shareable.
-  const activeKind: CloudListKind = useMemo(() => {
-    if (kindOverride) return kindOverride
-    if (isValidKind(search.kind)) return search.kind
-    const persisted = readPersistedKind()
-    if (persisted) return persisted
-    return DEFAULT_KIND
-  }, [kindOverride, search.kind])
-
-  // Persist the active kind whenever it changes.
-  useEffect(() => {
-    writePersistedKind(activeKind)
-  }, [activeKind])
-
-  // Make sure the URL carries the explicit kind so deep links work.
-  useEffect(() => {
-    if (kindOverride) return
-    if (search.kind === activeKind) return
-    if (!pathname.endsWith('/cloud')) return
-    navigate({
-      to: (DETECTED_MODE.mode === 'sovereign' || !deploymentId
-        ? '/cloud'
-        : `/provision/${deploymentId}/cloud`) as never,
-      params: { deploymentId } as never,
-      search: { view: 'list', kind: activeKind } as never,
-      replace: true,
-    })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeKind, search.kind, pathname, deploymentId])
-
-  // Setter retained for completeness (test-seam consumers); no
-  // visible UI here calls it directly anymore — the chip strip in the
-  // CloudPage toolbar drives the navigation.
-  const setActiveKind = useCallback(
-    (next: CloudListKind) => {
-      navigate({
-        to: '/cloud' as never,
-        params: { deploymentId } as never,
-        search: { view: 'list', kind: next } as never,
-        replace: false,
-      })
-    },
-    [navigate, deploymentId],
-  )
-  // Reference setActiveKind so eslint doesn't flag it; it's an exposed
-  // capability of the view module even though the chip strip in the
-  // toolbar is the primary affordance.
-  void setActiveKind
-
-  const ActiveListComponent = useMemo(
-    () => findKind(activeKind).Component,
-    [activeKind],
-  )
-
+export function CloudListView() {
   return (
-    <div data-testid="cloud-list-view" data-kind={activeKind}>
-      <style>{CLOUD_LIST_CSS}</style>
-      <div className="cloud-list-view-active" data-testid={`cloud-list-view-active-${activeKind}`}>
-        {isLoading && !data ? (
-          <div
-            className="flex h-48 items-center justify-center text-sm text-[var(--color-text-dim)]"
-            data-testid="cloud-list-view-loading"
-          >
-            Loading {findKind(activeKind).label.toLowerCase()}…
-          </div>
-        ) : (
-          <ActiveListComponent />
-        )}
-      </div>
+    <div data-testid="cloud-list-view">
+      <CloudUnifiedList />
     </div>
   )
 }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/CloudUnifiedList.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/CloudUnifiedList.tsx
@@ -1,0 +1,442 @@
+/**
+ * CloudUnifiedList — the LIST rendering of the ONE Cloud dataset (#3970).
+ *
+ * The list and the graph are TWO renderings of the SAME dataset. This
+ * table derives its rows from the same merged `GraphNode[]` the graph
+ * canvas uses (cloud + k8s + reconcilers, via `buildCloudGraph`) and
+ * filters them by the SAME active chip-set (the shared lens state). So a
+ * reconciler that shows in the graph — HelmRelease / Kustomization /
+ * Certificate / ExternalSecret / Database (CNPG) / the Catalyst CRs
+ * (Application / Environment / Organization / Continuum / UserAccess) —
+ * shows here too, and picking a lens filters BOTH identically.
+ *
+ * Columns: NAME · KIND · FAMILY · STATUS (the locked grammar reads the
+ * same channels — family = border colour, status = fill).
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md #4 — every label/colour comes from the
+ * type/family/status maps in widgets/architecture-graph/types.ts.
+ */
+
+import { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useCloud } from '../CloudPage'
+import { fetchReconciliationDAG, type ReconciliationDAG } from '@/lib/reconciliation.api'
+import { buildCloudGraph } from '@/widgets/architecture-graph/cloudGraphData'
+import type { K8sSnapshot } from '@/widgets/architecture-graph'
+import { LENSES, LENS_ORDER, type LensId } from '@/widgets/architecture-graph/presets'
+import {
+  useCloudLensOptional,
+  useCloudLensState,
+} from '@/widgets/architecture-graph/useCloudLens'
+import {
+  ALL_NODE_TYPES,
+  CATEGORY_LABEL,
+  FAMILY_BORDER,
+  FAMILY_LABEL,
+  NODE_CATEGORY,
+  NODE_FAMILY,
+  NODE_FILL,
+  STATUS_FILL,
+  type ArchNodeType,
+  type ArchStatus,
+} from '@/widgets/architecture-graph'
+
+const RECON_POLL_MS = 4_000
+
+/** Human-readable status labels for the STATUS column. */
+const STATUS_LABEL: Record<ArchStatus, string> = {
+  healthy: 'Reconciled',
+  reconciling: 'Reconciling',
+  drifted: 'Drifted',
+  degraded: 'Degraded',
+  failed: 'Failed',
+  suspended: 'Suspended',
+  unknown: 'Unknown',
+}
+
+export function CloudUnifiedList() {
+  const { deploymentId, data, isLoading, k8sSnapshot, k8sRevision } = useCloud()
+  const lens = useCloudLens()
+
+  // Reconciler set — same fetch/cadence as the graph (Architecture.tsx).
+  // React Query dedupes on the shared queryKey so this doesn't double-poll.
+  const reconQuery = useQuery<ReconciliationDAG>({
+    queryKey: ['reconciliation-dag', deploymentId],
+    queryFn: () => fetchReconciliationDAG(deploymentId),
+    enabled: !!deploymentId,
+    refetchInterval: RECON_POLL_MS,
+    staleTime: RECON_POLL_MS,
+    placeholderData: (prev) => prev,
+  })
+
+  // THE ONE dataset — identical to the graph's allNodes.
+  const allNodes = useMemo(
+    () =>
+      buildCloudGraph(
+        data,
+        (k8sSnapshot as unknown as K8sSnapshot | null) ?? null,
+        reconQuery.data?.nodes ?? null,
+      ).nodes,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [data, k8sRevision, reconQuery.data],
+  )
+
+  // Rows = the dataset filtered by the SAME active chip-set as the graph,
+  // sorted by kind then name so the table reads stably.
+  const rows = useMemo(() => {
+    const out = allNodes.filter((n) => lens.activeTypes.has(n.type))
+    out.sort((a, b) =>
+      a.type === b.type ? a.label.localeCompare(b.label) : a.type.localeCompare(b.type),
+    )
+    return out
+  }, [allNodes, lens.activeTypes])
+
+  // Per-type totals over the WHOLE dataset (for the +Add menu counts).
+  const typeTotals = useMemo(() => {
+    const m = new Map<ArchNodeType, number>()
+    for (const n of allNodes) m.set(n.type, (m.get(n.type) ?? 0) + 1)
+    return m
+  }, [allNodes])
+
+  return (
+    <div data-testid="cloud-unified-list">
+      <style>{CLOUD_UNIFIED_LIST_CSS}</style>
+
+      {/* Lens dropdown + chip strip — shares the SAME lens state as the
+          graph (CloudLensProvider), so switching here moves the graph too
+          and vice-versa. */}
+      <div className="cloud-ul-controls" data-testid="cloud-unified-list-controls">
+        <label className="cloud-ul-lens-label" htmlFor="cloud-ul-lens">
+          Lens
+          <select
+            id="cloud-ul-lens"
+            data-testid="cloud-unified-list-lens"
+            value={lens.lensId}
+            onChange={(e) => lens.selectLens(e.target.value as LensId)}
+            className="cloud-ul-lens-select"
+          >
+            <optgroup label="Domain">
+              {LENS_ORDER.filter((id) => LENSES[id].group === 'domain').map((id) => (
+                <option key={id} value={id}>
+                  {LENSES[id].label}
+                </option>
+              ))}
+            </optgroup>
+            <optgroup label="Family">
+              {LENS_ORDER.filter((id) => LENSES[id].group === 'family').map((id) => (
+                <option key={id} value={id}>
+                  {LENSES[id].label}
+                </option>
+              ))}
+            </optgroup>
+          </select>
+          {lens.isCustom && (
+            <span data-testid="cloud-unified-list-lens-custom" className="cloud-ul-custom">
+              Custom
+            </span>
+          )}
+        </label>
+
+        <div className="cloud-ul-chips" data-testid="cloud-unified-list-chips" role="list">
+          {ALL_NODE_TYPES.filter((t) => lens.activeTypes.has(t)).map((t) => (
+            <span
+              key={t}
+              role="listitem"
+              data-testid={`cloud-unified-list-chip-${t}`}
+              className="cloud-ul-chip"
+              style={{ borderColor: FAMILY_BORDER[NODE_FAMILY[t]] }}
+            >
+              <span className="cloud-ul-chip-dot" style={{ background: NODE_FILL[t] }} aria-hidden />
+              {t}
+              <span className="cloud-ul-chip-count">{typeTotals.get(t) ?? 0}</span>
+              <button
+                type="button"
+                aria-label={`Remove ${t} chip`}
+                data-testid={`cloud-unified-list-chip-${t}-remove`}
+                className="cloud-ul-chip-x"
+                onClick={() => lens.removeChip(t)}
+              >
+                ×
+              </button>
+            </span>
+          ))}
+          <AddChipMenu
+            inactiveTypes={ALL_NODE_TYPES.filter((t) => !lens.activeTypes.has(t))}
+            typeTotals={typeTotals}
+            onAdd={lens.addChip}
+          />
+        </div>
+      </div>
+
+      {/* The table — one row per resource in the active chip-set. */}
+      <div className="cloud-ul-table-wrap">
+        <table className="cloud-ul-table" data-testid="cloud-unified-list-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Kind</th>
+              <th>Family</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading && !data && rows.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="cloud-ul-empty" data-testid="cloud-unified-list-loading">
+                  Loading resources…
+                </td>
+              </tr>
+            ) : rows.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="cloud-ul-empty" data-testid="cloud-unified-list-empty">
+                  No resources match the {LENSES[lens.lensId].label} lens.
+                </td>
+              </tr>
+            ) : (
+              rows.map((n) => {
+                const fam = NODE_FAMILY[n.type]
+                const status = n.status ?? 'unknown'
+                return (
+                  <tr key={n.id} data-testid={`cloud-unified-list-row-${n.type}`} data-kind={n.type}>
+                    <td className="cloud-ul-name">
+                      <span className="cloud-ul-name-label">{n.label}</span>
+                      {n.sublabel && <span className="cloud-ul-name-sub">{n.sublabel}</span>}
+                    </td>
+                    <td>
+                      <span
+                        className="cloud-ul-kind"
+                        title={`${CATEGORY_LABEL[NODE_CATEGORY[n.type]]}`}
+                      >
+                        {n.type}
+                      </span>
+                    </td>
+                    <td>
+                      <span
+                        className="cloud-ul-family"
+                        style={{ color: FAMILY_BORDER[fam] }}
+                        data-family={fam}
+                      >
+                        {FAMILY_LABEL[fam]}
+                      </span>
+                    </td>
+                    <td>
+                      <span className="cloud-ul-status" data-status={status}>
+                        <span
+                          className="cloud-ul-status-dot"
+                          style={{ background: STATUS_FILL[status] }}
+                          aria-hidden
+                        />
+                        {STATUS_LABEL[status]}
+                      </span>
+                    </td>
+                  </tr>
+                )
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+/* ── + Add chip menu ─────────────────────────────────────────────── */
+
+interface AddChipMenuProps {
+  inactiveTypes: ArchNodeType[]
+  typeTotals: Map<ArchNodeType, number>
+  onAdd: (t: ArchNodeType) => void
+}
+
+function AddChipMenu({ inactiveTypes, typeTotals, onAdd }: AddChipMenuProps) {
+  const disabled = inactiveTypes.length === 0
+  return (
+    <details className="cloud-ul-add" data-testid="cloud-unified-list-add">
+      <summary
+        className="cloud-ul-add-summary"
+        data-testid="cloud-unified-list-add-button"
+        aria-disabled={disabled}
+      >
+        + Add
+      </summary>
+      {!disabled && (
+        <div className="cloud-ul-add-menu" data-testid="cloud-unified-list-add-menu">
+          {inactiveTypes.map((t) => (
+            <button
+              key={t}
+              type="button"
+              data-testid={`cloud-unified-list-add-item-${t}`}
+              className="cloud-ul-add-item"
+              onClick={(e) => {
+                onAdd(t)
+                // Close the <details> popover after a pick.
+                ;(e.currentTarget.closest('details') as HTMLDetailsElement | null)?.removeAttribute(
+                  'open',
+                )
+              }}
+            >
+              <span
+                className="cloud-ul-chip-dot"
+                style={{ background: NODE_FILL[t] }}
+                aria-hidden
+              />
+              {t}
+              <span className="cloud-ul-chip-count">{typeTotals.get(t) ?? 0}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </details>
+  )
+}
+
+/* ── Shared lens hook (non-throwing) ─────────────────────────────── */
+
+/**
+ * useCloudLens — the list always runs inside CloudLensProvider, but fall
+ * back to a private instance for isolated tests so the component never
+ * throws when mounted standalone.
+ */
+function useCloudLens() {
+  const shared = useCloudLensOptional()
+  const priv = useCloudLensState()
+  return shared ?? priv
+}
+
+const CLOUD_UNIFIED_LIST_CSS = `
+.cloud-ul-controls {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-bottom: 0.6rem;
+  padding: 0.5rem 0.65rem;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-bg-2);
+}
+.cloud-ul-lens-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  color: var(--color-text-dim);
+}
+.cloud-ul-lens-select {
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg);
+  color: var(--color-text);
+  padding: 0.2rem 0.4rem;
+  font-size: 0.75rem;
+}
+.cloud-ul-custom {
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg);
+  color: var(--color-text-dim);
+  font-size: 0.62rem;
+  font-weight: 600;
+  padding: 0.06rem 0.3rem;
+}
+.cloud-ul-chips {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+.cloud-ul-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-size: 0.72rem;
+  padding: 0.1rem 0.45rem;
+}
+.cloud-ul-chip-dot { width: 0.55rem; height: 0.55rem; border-radius: 999px; }
+.cloud-ul-chip-count { color: var(--color-text-dim); font-variant-numeric: tabular-nums; }
+.cloud-ul-chip-x {
+  border: 0;
+  background: transparent;
+  color: var(--color-text-dim);
+  cursor: pointer;
+  line-height: 1;
+  padding: 0 0.1rem;
+}
+.cloud-ul-chip-x:hover { color: var(--color-danger); }
+.cloud-ul-add { position: relative; }
+.cloud-ul-add-summary {
+  list-style: none;
+  cursor: pointer;
+  border: 1px dashed var(--color-border);
+  border-radius: 999px;
+  padding: 0.1rem 0.5rem;
+  font-size: 0.72rem;
+  color: var(--color-text);
+}
+.cloud-ul-add-summary::-webkit-details-marker { display: none; }
+.cloud-ul-add-summary[aria-disabled="true"] { opacity: 0.5; cursor: not-allowed; }
+.cloud-ul-add-menu {
+  position: absolute;
+  z-index: 30;
+  margin-top: 0.25rem;
+  max-height: 16rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 12rem;
+  padding: 0.3rem;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-bg-2);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+}
+.cloud-ul-add-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border: 0;
+  background: transparent;
+  border-radius: 6px;
+  color: var(--color-text);
+  font-size: 0.76rem;
+  padding: 0.25rem 0.4rem;
+  cursor: pointer;
+  text-align: left;
+}
+.cloud-ul-add-item:hover { background: var(--color-bg); }
+.cloud-ul-add-item .cloud-ul-chip-count { margin-left: auto; }
+
+.cloud-ul-table-wrap { overflow-x: auto; border: 1px solid var(--color-border); border-radius: 8px; }
+.cloud-ul-table { width: 100%; border-collapse: collapse; font-size: 0.8rem; }
+.cloud-ul-table thead th {
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--color-text-dim);
+  background: var(--color-bg-2);
+  border-bottom: 1px solid var(--color-border);
+}
+.cloud-ul-table tbody td {
+  padding: 0.45rem 0.75rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+  color: var(--color-text);
+  vertical-align: top;
+}
+.cloud-ul-table tbody tr:hover { background: var(--color-surface-hover); }
+.cloud-ul-name { display: flex; flex-direction: column; gap: 0.1rem; }
+.cloud-ul-name-label { font-weight: 600; }
+.cloud-ul-name-sub { font-size: 0.68rem; color: var(--color-text-dim); }
+.cloud-ul-kind { font-weight: 500; }
+.cloud-ul-family { font-weight: 600; font-size: 0.74rem; }
+.cloud-ul-status { display: inline-flex; align-items: center; gap: 0.35rem; }
+.cloud-ul-status-dot { width: 0.55rem; height: 0.55rem; border-radius: 999px; }
+.cloud-ul-empty { padding: 2rem 1rem; text-align: center; color: var(--color-text-dim); }
+`

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/ArchitectureGraphPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/ArchitectureGraphPage.tsx
@@ -64,15 +64,12 @@ import type {
   VolumeItem,
 } from '@/lib/infrastructure.types'
 import { GraphCanvas, type GraphCanvasHandle } from './GraphCanvas'
-import { hierarchyToGraph } from './adapter'
-import { k8sToGraph, mergeGraphs } from './k8sAdapter'
-import { reconcilersToGraph } from './reconcilerAdapter'
+import { buildCloudGraph } from './cloudGraphData'
 import { useK8sCacheStream, type K8sSnapshot } from './useK8sCacheStream'
 import type { ReconciliationNode } from '@/lib/reconciliation.api'
 import {
   ALL_EDGE_TYPES,
   ALL_NODE_TYPES,
-  DEFAULT_INACTIVE_TYPES,
   EDGE_DASHED,
   EDGE_MARKER_END,
   EDGE_MARKER_START,
@@ -85,12 +82,8 @@ import {
   type GraphEdge,
   type GraphNode,
 } from './types'
-import {
-  PRESETS,
-  PRESET_ORDER,
-  type PresetId,
-  presetHiddenTypes,
-} from './presets'
+import { LENSES, LENS_ORDER, type LensId } from './presets'
+import { useCloudLensOptional, useCloudLensState } from './useCloudLens'
 import { NODE_ICON } from './icons'
 import { markerId } from './markers'
 
@@ -113,9 +106,8 @@ const TUNABLE_TYPES: ArchNodeType[] = [
   'Service',
   'Ingress',
   // K8s-side types — high-cardinality kinds whose density slider
-  // matters most. ConfigMap and Pod are also default-inactive (see
-  // DEFAULT_INACTIVE_TYPES) so they don't crowd the canvas before
-  // the operator opts in.
+  // matters most. The density slider (default 100%, #3970) governs how
+  // many of each render once the lens has the chip ON.
   'Pod',
   'Deployment',
   'StatefulSet',
@@ -124,7 +116,14 @@ const TUNABLE_TYPES: ArchNodeType[] = [
 ]
 
 const DEBOUNCE_MS = 400
-const DEFAULT_GLOBAL_PCT = 50
+/**
+ * Default global density (#3970). Opens at 100% so EVERY active type
+ * renders fully on first paint — no high-cardinality node is silently
+ * hidden before the operator touches the slider. (#3958 opened at 50,
+ * which the operator rejected: "half my pods are missing and I never
+ * moved the slider".)
+ */
+const DEFAULT_GLOBAL_PCT = 100
 
 /* ── Public props ────────────────────────────────────────────────── */
 
@@ -250,22 +249,15 @@ export function ArchitectureGraphPage({
   const k8sSnapshot = k8sSnapshotProp ?? fallback.snapshot
   const k8sRevision = k8sRevisionProp ?? fallback.revision
 
-  /* ── 1. Adapter — tree → nodes/edges, merged with K8s side AND the
-   *     reconciler set (#3958). Reconciler ids are namespaced `recon:`
-   *     so they never collide with cloud/k8s ids — a plain concat after
-   *     mergeGraphs is safe, and edges only reference reconciler ids. */
-  const { nodes: allNodes, edges: allEdges } = useMemo(() => {
-    const cloud = hierarchyToGraph(data)
-    const k8s = k8sToGraph(k8sSnapshot)
-    const base = mergeGraphs(cloud, k8s)
-    const recon = reconcilersToGraph(reconcilers)
-    if (recon.nodes.length === 0) return base
-    return {
-      nodes: [...base.nodes, ...recon.nodes],
-      edges: [...base.edges, ...recon.edges],
-    }
+  /* ── 1. Adapter — the ONE dataset: tree → nodes/edges, merged with the
+   *     K8s side AND the reconciler set (#3958/#3970). Shared with the
+   *     list view via buildCloudGraph so graph + list are provably the
+   *     same dataset incl. reconcilers. */
+  const { nodes: allNodes, edges: allEdges } = useMemo(
+    () => buildCloudGraph(data, k8sSnapshot, reconcilers),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, k8sRevision, reconcilers])
+    [data, k8sRevision, reconcilers],
+  )
 
   /* ── 2. Type totals for slider sizing ──────────────────────── */
   const typeTotals = useMemo(() => {
@@ -274,79 +266,34 @@ export function ArchitectureGraphPage({
     return m
   }, [allNodes])
 
-  /* ── 3. Active chip set + density state ──────────────────────
-   * The data layer (adapter) holds every node type and every relation
-   * regardless of which chips are active (#348 item 2). Chip add /
-   * remove is a pure visibility filter applied via `hiddenTypes`
-   * below — derived from the inverse of `activeTypes`. */
-  const [activeTypes, setActiveTypes] = useState<Set<ArchNodeType>>(
-    () => {
-      const init = new Set<ArchNodeType>()
-      for (const t of ALL_NODE_TYPES) {
-        if (!DEFAULT_INACTIVE_TYPES.has(t)) init.add(t)
-      }
-      return init
-    },
-  )
+  /* ── 3. Lens = active chip-set + density state (#3970) ────────
+   * THE MODEL: a lens IS a named chip-set. Selecting a lens REPLACES the
+   * active chip-set with exactly that lens's chips; the strip renders
+   * ONLY the active chips; `+ Add` grows the active set (active = lens ∪
+   * additions); removing a chip shrinks it. There is NO separate hidden
+   * filter layer — `hiddenTypes` is just the complement of `activeTypes`.
+   * Default lens = Cloud (#3970).
+   *
+   * The lens state is SHARED with the list view via CloudLensProvider so
+   * the view=graph↔list toggle preserves the lens + chips. When rendered
+   * standalone (tests/storybook with no provider) we fall back to a
+   * private instance. */
+  const sharedLens = useCloudLensOptional()
+  const privateLens = useCloudLensState()
+  const { lensId, activeTypes, isCustom, selectLens, addChip, removeChip } =
+    sharedLens ?? privateLens
 
-  // Whenever the data refreshes, ensure types newly seen become active
-  // (don't auto-activate a type the operator removed previously, but
-  // do show types that didn't exist on the previous render).
-  // Default-inactive types are NEVER auto-activated — the operator
-  // opts in via the chip strip so the canvas isn't immediately
-  // overrun by 200+ Pods on first paint.
-  const seenTypesRef = useRef<Set<ArchNodeType>>(new Set())
-  useEffect(() => {
-    setActiveTypes((prev) => {
-      const next = new Set(prev)
-      let changed = false
-      for (const t of ALL_NODE_TYPES) {
-        const total = typeTotals.get(t) ?? 0
-        if (total > 0 && !seenTypesRef.current.has(t)) {
-          seenTypesRef.current.add(t)
-          if (!next.has(t) && !DEFAULT_INACTIVE_TYPES.has(t)) {
-            next.add(t)
-            changed = true
-          }
-        }
-      }
-      return changed ? next : prev
-    })
-  }, [typeTotals])
-
-  function removeChip(t: ArchNodeType) {
-    setActiveTypes((prev) => {
-      const n = new Set(prev)
-      n.delete(t)
-      return n
-    })
-  }
-  function addChip(t: ArchNodeType) {
-    setActiveTypes((prev) => {
-      const n = new Set(prev)
-      n.add(t)
-      return n
-    })
-  }
-
-  /* ── Preset lens (#3958) — a cross-cutting {categories, families,
-   *     edge-kinds} lens LAYERED on top of the per-type chip toggles.
-   *     The preset narrows by category + family; chips stay the
-   *     fine-grained control. Default 'all' hides nothing. */
-  const [presetId, setPresetId] = useState<PresetId>('all')
-
-  const presetHidden = useMemo(() => presetHiddenTypes(PRESETS[presetId]), [presetId])
-
-  // The set of types HIDDEN from the canvas — the UNION of (a) every type
-  // NOT in the active chip set (#348 item 2 — chip removal == visibility
-  // filter) and (b) every type the active preset lens excludes (#3958).
+  // The set of types HIDDEN from the canvas — purely the complement of
+  // the active chip-set. The strip IS the lens (made editable); nothing
+  // is hidden "underneath" a fuller strip (#3970 — the filter-layer is
+  // deleted).
   const hiddenTypes = useMemo(() => {
     const h = new Set<ArchNodeType>()
     for (const t of ALL_NODE_TYPES) {
-      if (!activeTypes.has(t) || presetHidden.has(t)) h.add(t)
+      if (!activeTypes.has(t)) h.add(t)
     }
     return h
-  }, [activeTypes, presetHidden])
+  }, [activeTypes])
 
   // Per-type explicit cap; null = "all" (no cap).
   const [typeCap, setTypeCap] = useState<Partial<Record<ArchNodeType, number | null>>>({})
@@ -534,32 +481,42 @@ export function ArchitectureGraphPage({
           </span>
         )}
 
-        {/* Preset lens dropdown (#3958) — cross-cutting domain + family
-            lenses, layered on the per-type chip toggles below. */}
-        <label className="flex items-center gap-1.5 text-xs text-[var(--color-text-dim)]" htmlFor="arch-preset">
+        {/* Lens dropdown (#3970) — a lens IS the chip-set below. Picking
+            a lens REPLACES the active chips with exactly that lens's
+            chips (the strip shows ONLY those). `Custom` shows once the
+            operator has +Added or removed a chip. */}
+        <label className="flex items-center gap-1.5 text-xs text-[var(--color-text-dim)]" htmlFor="arch-lens">
           Lens
           <select
-            id="arch-preset"
-            data-testid="cloud-architecture-preset"
-            value={presetId}
-            onChange={(e) => setPresetId(e.target.value as PresetId)}
+            id="arch-lens"
+            data-testid="cloud-architecture-lens"
+            value={lensId}
+            onChange={(e) => selectLens(e.target.value as LensId)}
             className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1 text-xs text-[var(--color-text)]"
           >
             <optgroup label="Domain">
-              {PRESET_ORDER.filter((id) => PRESETS[id].group === 'domain').map((id) => (
+              {LENS_ORDER.filter((id) => LENSES[id].group === 'domain').map((id) => (
                 <option key={id} value={id}>
-                  {PRESETS[id].label}
+                  {LENSES[id].label}
                 </option>
               ))}
             </optgroup>
             <optgroup label="Family">
-              {PRESET_ORDER.filter((id) => PRESETS[id].group === 'family').map((id) => (
+              {LENS_ORDER.filter((id) => LENSES[id].group === 'family').map((id) => (
                 <option key={id} value={id}>
-                  {PRESETS[id].label}
+                  {LENSES[id].label}
                 </option>
               ))}
             </optgroup>
           </select>
+          {isCustom && (
+            <span
+              data-testid="cloud-architecture-lens-custom"
+              className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-1.5 py-0.5 text-[10px] font-semibold text-[var(--color-text-dim)]"
+            >
+              Custom
+            </span>
+          )}
         </label>
 
         <div className="ml-auto flex items-center gap-2">

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/GraphCanvas.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/GraphCanvas.tsx
@@ -94,7 +94,7 @@ import {
 } from './types'
 import { shapeForCategory } from './shapes'
 import { GraphLegend } from './GraphLegend'
-import { BOUND_PADDING, NODE_R, physicsFor } from './layout'
+import { BOUND_PADDING, NODE_R, physicsFor, phyllotaxisSeed } from './layout'
 import { markerId, uniqueMarkerDefs } from './markers'
 
 /* ── Public types ────────────────────────────────────────────────── */
@@ -245,58 +245,6 @@ function makeForceBound(
     nodes = nextNodes
   }
   return force as (() => void) & {
-    initialize: (n: LiveNode[]) => void
-  }
-}
-
-/**
- * Soft ELLIPTICAL containment (#3958). A GENTLE inward force for any node
- * whose normalized position leaves the field ellipse
- * `(dx/fieldRadiusX)² + (dy/fieldRadiusY)² > 1`. Unlike makeForceBound (a
- * hard clamp at the literal viewport edge), this is a spring that grows
- * with how far the node has strayed past the target field — so the cloud
- * settles into an ellipse filling ~85% of BOTH the canvas width and
- * height, with the natural force-directed topology intact, never flung to
- * the edges and never crushed into the centre. On a wide-short canvas the
- * X radius is materially larger than the Y radius, so the cloud fills the
- * empty left/right margin instead of collapsing into a short-dim disc.
- * Inside the ellipse it does nothing (the charge/link/gravity balance owns
- * the layout there).
- */
-function makeForceRadialCap(cx: number, cy: number, fieldRadiusX: number, fieldRadiusY: number) {
-  let nodes: LiveNode[] = []
-  const force = (alpha: number) => {
-    if (fieldRadiusX <= 0 || fieldRadiusY <= 0) return
-    for (const n of nodes) {
-      // Pinned nodes are operator-controlled — never nudge them.
-      if (n.fx !== null || n.fy !== null) continue
-      const dx = n.x - cx
-      const dy = n.y - cy
-      // Normalized elliptical distance: == 1 on the field boundary, > 1
-      // outside it. Squaring avoids a sqrt on the common in-field path.
-      const nx = dx / fieldRadiusX
-      const ny = dy / fieldRadiusY
-      const norm2 = nx * nx + ny * ny
-      if (norm2 <= 1 || norm2 === 0) continue
-      // overshoot = how far past the boundary, as a fraction. norm is the
-      // elliptical radius (1 at the boundary); (norm-1) is the fractional
-      // overshoot, identical in spirit to the old (dist-R)/R.
-      const norm = Math.sqrt(norm2)
-      const overshoot = norm - 1
-      // Spring strength scales with the overshoot fraction so a node just
-      // past the field barely feels it, while a far-flung node is pulled
-      // firmly back. k tuned to be gentle (founder: keep the organic feel
-      // — no snapping). Push back along the true displacement (dx, dy) so
-      // the restoring force points at the centre.
-      const k = Math.min(0.25, overshoot) * alpha
-      n.vx -= dx * k
-      n.vy -= dy * k
-    }
-  }
-  ;(force as unknown as { initialize: (n: LiveNode[]) => void }).initialize = (nextNodes) => {
-    nodes = nextNodes
-  }
-  return force as ((alpha: number) => void) & {
     initialize: (n: LiveNode[]) => void
   }
 }
@@ -571,6 +519,9 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, GraphCanvasProps>(funct
     // Add or update.
     const cx = size.width / 2
     const cy = size.height / 2
+    // Walks the phyllotaxis spiral across nodes seeded in THIS pass so a
+    // batch of new nodes lands evenly spread, not stacked at the centroid.
+    let seedIndex = liveNodes.size
     for (const n of visibleNodes) {
       const existing = liveNodes.get(n.id)
       if (existing) {
@@ -582,16 +533,26 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, GraphCanvasProps>(funct
         existing.type = n.type
         existing.degree = degMap.get(n.id) ?? 0
       } else {
-        // Seed at the CENTROID with a small jitter proportional to the
-        // target field — small graphs start as a tight centred cluster,
-        // never flung outward (#3958 constant-density seeding).
-        const seedR = Math.min(60, physicsFor(visibleNodes.length, size.width, size.height).fieldRadius * 0.5)
-        const ang = Math.random() * 2 * Math.PI
-        const rad = Math.sqrt(Math.random()) * seedR
+        // EVEN phyllotaxis seed (#3970) — spread new nodes uniformly over
+        // the field with the golden-angle sunflower so they RELAX into a
+        // homogeneous fill under collision instead of starting clustered
+        // at the centroid and being flung to a ring. `seedIndex` walks the
+        // spiral across nodes added in this pass.
+        const phys0 = physicsFor(visibleNodes.length, size.width, size.height)
+        const pos = phyllotaxisSeed(
+          seedIndex,
+          Math.max(visibleNodes.length, liveNodes.size + 1),
+          cx,
+          cy,
+          phys0.fieldRadiusX,
+          phys0.fieldRadiusY,
+          1,
+        )
+        seedIndex += 1
         liveNodes.set(n.id, {
           ...n,
-          x: cx + Math.cos(ang) * rad,
-          y: cy + Math.sin(ang) * rad,
+          x: pos.x,
+          y: pos.y,
           vx: 0,
           vy: 0,
           fx: null,
@@ -643,22 +604,24 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, GraphCanvasProps>(funct
         .strength(phys.linkStrength)
     }
     ;(sim.force('charge') as ReturnType<typeof forceManyBody>).strength(phys.charge)
-    // Hard collision floor — radius is the per-node draw radius + the
-    // physics collide pad, so no two bubbles ever overlap (#3958).
+    // COLLISION is the DOMINANT, even-density spacing force (#3970): the
+    // radius is half the uniform gap (so two centres settle ~uniformGap
+    // apart) but never below the per-node draw radius + pad (no overlap).
+    // A strong (1.0) collide owns the homogeneous spread; charge is mild.
     ;(sim.force('collide') as ReturnType<typeof forceCollide>)
-      .radius((d) => Math.max(NODE_R, radiusForDegree((d as LiveNode).degree)) + 4)
-      .strength(0.9)
+      .radius((d) =>
+        Math.max(phys.collide, Math.max(NODE_R, radiusForDegree((d as LiveNode).degree)) + 4),
+      )
+      .strength(1)
     ;(sim.force('center') as ReturnType<typeof forceCenter>).x(cx).y(cy)
     ;(sim.force('gravityX') as ReturnType<typeof forceX>).x(cx).strength(phys.centerGravity)
     ;(sim.force('gravityY') as ReturnType<typeof forceY>).y(cy).strength(phys.centerGravity)
 
-    // Soft ELLIPTICAL containment — a GENTLE inward nudge for any node that
-    // strays past the target field ellipse (~85% of width AND height). This
-    // is the "stay in-field, don't fling to edges" force; the hard bound
-    // clamp below is only the absolute safety net at the true viewport edge
-    // (#3958 — fill the canvas on BOTH axes, never collapse to a short-dim
-    // disc with empty left/right margin).
-    sim.force('field', makeForceRadialCap(cx, cy, phys.fieldRadiusX, phys.fieldRadiusY))
+    // No radial cap (#3970): the elliptical-cap edge-ring generator is
+    // DELETED. Even density comes from collision + gentle centering + the
+    // even phyllotaxis seed; the only boundary force is the hard viewport
+    // clamp below (absolute safety net at the true edge).
+    sim.force('field', null)
 
     // Bounded-physics force — re-install every tick-tune so the box
     // matches the current container size. d3-force's `force()` setter

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/cloudGraphData.test.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/cloudGraphData.test.ts
@@ -1,0 +1,135 @@
+/**
+ * cloudGraphData.test.ts — locks the #3970 graph+list parity contract:
+ * the ONE dataset (cloud + k8s + reconcilers) used by BOTH renderings.
+ *
+ *   • buildCloudGraph folds the reconciler set into the SAME GraphNode[]
+ *     the cloud tree produces — so a reconciler that appears in the graph
+ *     appears in the list (DoD #6/#9).
+ *   • lensChips drives which of those rows a lens shows — and applies
+ *     identically to both renderings (DoD #10).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { buildCloudGraph } from './cloudGraphData'
+import { LENSES, lensChips } from './presets'
+import type { HierarchicalInfrastructure } from '@/lib/infrastructure.types'
+import type { ReconciliationNode } from '@/lib/reconciliation.api'
+import type { ArchNodeType } from './types'
+
+const cloud: HierarchicalInfrastructure = {
+  cloud: [
+    { id: 'c1', name: 'Hetzner', provider: 'hetzner', regionCount: 1, quotaUsed: 0, quotaLimit: 0 },
+  ],
+  topology: {
+    pattern: 'solo',
+    regions: [
+      {
+        id: 'r1',
+        name: 'fsn',
+        provider: 'hetzner',
+        providerRegion: 'fsn1',
+        skuCp: 'cpx32',
+        skuWorker: 'cpx32',
+        workerCount: 1,
+        status: 'healthy',
+        clusters: [
+          {
+            id: 'cl1',
+            name: 'cl1',
+            version: 'v1.31.4+k3s1',
+            status: 'healthy',
+            nodeCount: 1,
+            vclusters: [],
+            loadBalancers: [],
+            nodePools: [],
+            nodes: [],
+          },
+        ],
+        networks: [],
+      },
+    ],
+  },
+  storage: { pvcs: [], buckets: [], volumes: [] },
+}
+
+const reconcilers: ReconciliationNode[] = [
+  { id: 'hr/keycloak', label: 'bp-keycloak', kind: 'HelmRelease', state: 'Reconciled' },
+  { id: 'ks/bootstrap', label: 'catalyst-bootstrap', kind: 'Kustomization', state: 'Reconciled' },
+  { id: 'cert/wild', label: 'wildcard-cert', kind: 'Certificate', state: 'Reconciled' },
+  { id: 'es/creds', label: 'keycloak-pg-creds', kind: 'ExternalSecret', state: 'Reconciling' },
+  { id: 'cnpg/sharedpg', label: 'shared-pg-c', kind: 'Cluster', state: 'Reconciled' },
+  { id: 'env/acme', label: 'acme-prod', kind: 'Environment', state: 'Reconciled' },
+  { id: 'org/acme', label: 'acme', kind: 'Organization', state: 'Reconciled' },
+]
+
+describe('buildCloudGraph — ONE dataset (cloud + reconcilers)', () => {
+  it('the merged dataset contains BOTH the cloud nodes AND every reconciler kind', () => {
+    const { nodes } = buildCloudGraph(cloud, null, reconcilers)
+    const types = new Set(nodes.map((n) => n.type))
+    // cloud side
+    expect(types.has('Cloud')).toBe(true)
+    expect(types.has('Cluster')).toBe(true)
+    // reconciler side — the kinds the OLD cloud-list/kinds.ts had NONE of.
+    expect(types.has('HelmRelease')).toBe(true)
+    expect(types.has('Kustomization')).toBe(true)
+    expect(types.has('Certificate')).toBe(true)
+    expect(types.has('ExternalSecret')).toBe(true)
+    expect(types.has('Database')).toBe(true) // CNPG Cluster → Database
+    expect(types.has('Environment')).toBe(true)
+    expect(types.has('Organization')).toBe(true)
+  })
+
+  it('a reconciler row carries its status (FILL) so the list STATUS column works', () => {
+    const { nodes } = buildCloudGraph(cloud, null, reconcilers)
+    const es = nodes.find((n) => n.label === 'keycloak-pg-creds')
+    expect(es?.type).toBe('ExternalSecret')
+    expect(es?.status).toBe('reconciling')
+  })
+
+  it('with no reconcilers the dataset is just the cloud nodes', () => {
+    const { nodes } = buildCloudGraph(cloud, null, null)
+    const types = new Set(nodes.map((n) => n.type))
+    expect(types.has('Cloud')).toBe(true)
+    expect(types.has('HelmRelease')).toBe(false)
+  })
+})
+
+describe('lens filtering applies identically to the list dataset (DoD #10)', () => {
+  const { nodes } = buildCloudGraph(cloud, null, reconcilers)
+  function rowsFor(lensId: keyof typeof LENSES): Set<ArchNodeType> {
+    const chips = lensChips(LENSES[lensId])
+    return new Set(nodes.filter((n) => chips.has(n.type)).map((n) => n.type))
+  }
+
+  it('Reconciliation lens shows the control reconcilers (HelmRelease/Kustomization/Env/Org)', () => {
+    const r = rowsFor('reconciliation')
+    expect(r.has('HelmRelease')).toBe(true)
+    expect(r.has('Kustomization')).toBe(true)
+    expect(r.has('Environment')).toBe(true)
+    expect(r.has('Organization')).toBe(true)
+    // NOT the cloud scope nodes or the CNPG database (data category).
+    expect(r.has('Cloud')).toBe(false)
+    expect(r.has('Database')).toBe(false)
+  })
+
+  it('the cert-manager family lens shows ONLY Certificate rows', () => {
+    const r = rowsFor('certManager')
+    expect(r.has('Certificate')).toBe(true)
+    expect(r.has('HelmRelease')).toBe(false)
+    expect(r.has('Cloud')).toBe(false)
+  })
+
+  it('the CNPG family lens shows the Database (CNPG Cluster) row', () => {
+    const r = rowsFor('cnpg')
+    expect(r.has('Database')).toBe(true)
+    expect(r.has('Certificate')).toBe(false)
+  })
+
+  it('the Cloud lens shows the cloud nodes, NOT the reconcilers', () => {
+    const r = rowsFor('cloud')
+    expect(r.has('Cloud')).toBe(true)
+    expect(r.has('Cluster')).toBe(true)
+    expect(r.has('HelmRelease')).toBe(false)
+    expect(r.has('Database')).toBe(false)
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/cloudGraphData.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/cloudGraphData.ts
@@ -1,0 +1,52 @@
+/**
+ * cloudGraphData.ts — the ONE dataset builder for the unified Cloud
+ * surface (#3970). Both renderings (graph + list) derive from this single
+ * merged `GraphNode[]` so a reconciler that appears in the graph appears
+ * in the list, filtered by the SAME active chip-set.
+ *
+ * This folds the three sources into one neutral graph shape:
+ *   • cloud  — the hierarchical infrastructure tree (hierarchyToGraph)
+ *   • k8s    — the live k8scache SSE snapshot (k8sToGraph)
+ *   • recon  — the /reconciliation set incl. Flux + non-Flux reconcilers
+ *              and the Catalyst CRs (reconcilersToGraph)
+ *
+ * Reconciler ids are namespaced `recon:` so they never collide with the
+ * cloud/k8s ids — a plain concat after mergeGraphs is safe.
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md #4 — a pure shape transform; no node
+ * is fabricated, the same merge the graph canvas already used.
+ */
+
+import type { HierarchicalInfrastructure } from '@/lib/infrastructure.types'
+import type { ReconciliationNode } from '@/lib/reconciliation.api'
+import { hierarchyToGraph } from './adapter'
+import { k8sToGraph, mergeGraphs } from './k8sAdapter'
+import { reconcilersToGraph } from './reconcilerAdapter'
+import type { K8sSnapshot } from './useK8sCacheStream'
+import type { GraphEdge, GraphNode } from './types'
+
+export interface CloudGraphData {
+  nodes: GraphNode[]
+  edges: GraphEdge[]
+}
+
+/**
+ * buildCloudGraph — merge the cloud tree + k8s snapshot + reconciler set
+ * into ONE neutral graph. Pure; safe to memoise on its inputs.
+ */
+export function buildCloudGraph(
+  data: HierarchicalInfrastructure | null,
+  k8sSnapshot: K8sSnapshot | null | undefined,
+  reconcilers: ReconciliationNode[] | null | undefined,
+): CloudGraphData {
+  const cloud = hierarchyToGraph(data)
+  // k8sToGraph iterates a Map; pass an empty one when no snapshot yet.
+  const k8s = k8sToGraph(k8sSnapshot ?? (new Map() as K8sSnapshot))
+  const base = mergeGraphs(cloud, k8s)
+  const recon = reconcilersToGraph(reconcilers)
+  if (recon.nodes.length === 0) return base
+  return {
+    nodes: [...base.nodes, ...recon.nodes],
+    edges: [...base.edges, ...recon.edges],
+  }
+}

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/index.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/index.ts
@@ -26,8 +26,10 @@ export { reconcilersToGraph } from './reconcilerAdapter'
 export {
   edgeNodeId,
   DEFAULT_INACTIVE_TYPES,
+  ALL_NODE_TYPES,
   NODE_CATEGORY,
   NODE_FAMILY,
+  NODE_FILL,
   STATUS_FILL,
   FAMILY_BORDER,
   FAMILY_LABEL,

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/layout.test.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/layout.test.ts
@@ -1,24 +1,23 @@
 /**
- * layout.test.ts — locks the #3958 / fix/cloud-graph-spread-layout
- * contract on `physicsFor` and the settled force-directed layout:
+ * layout.test.ts — locks the #3970 EVEN / HOMOGENEOUS layout contract on
+ * `physicsFor` and the settled force-directed layout:
  *
- *   1. ELLIPTICAL field geometry: on a wide-short canvas the X-field
- *      (anchored to width/2) is materially larger than the Y-field
- *      (anchored to height/2), so the cloud fills BOTH axes instead of
- *      collapsing into a min(W,H)/2 disc with empty left/right margin.
- *   2. Constant-density clamp invariants hold across N = 4 / 64 / 400.
- *   3. The settled layout (driven headlessly through the real d3-force
- *      sim with production charge/collide/gravity + the elliptical cap)
- *      fills ≥75% of BOTH the canvas width and height for N = 64, while a
- *      4-node graph stays a tidy CENTRED cluster (not flung to corners).
+ *   1. physicsFor produces an even-density tuning: collision is dominant
+ *      (radius = uniformGap/2), charge is mild/near-zero, centering is
+ *      gentle. uniformGap = sqrt(usableArea / N)·k shrinks as N grows.
+ *   2. The settled layout (driven headlessly through the real d3-force
+ *      sim with the PRODUCTION collide-dominant + mild-charge + gentle-
+ *      centering config, the even phyllotaxis seed, and the hard viewport
+ *      bound — NO radial cap, which #3970 deleted) has UNIFORM LOCAL
+ *      DENSITY: partition the canvas into a G×G grid, count occupancy per
+ *      cell, and assert the variance/mean of occupied-region cells is
+ *      below a bound — i.e. NEITHER a dense central blob NOR an edge ring.
  *
- * Approach note (per the brief): jsdom has no rAF loop, but d3-force's
- * `simulation.tick()` is fully synchronous, so we drive the sim to a
- * settled state deterministically (seeded RNG + fixed tick budget) and
- * assert the bounding-box coverage directly. The cap used here is the
- * SAME elliptical boundary the canvas installs (mirrored inline so the
- * test owns no DOM); the geometry source of truth — `physicsFor` — is
- * imported directly.
+ * Approach note: jsdom has no rAF loop, but d3-force's `simulation.tick()`
+ * is fully synchronous, so we drive the sim to a settled state
+ * deterministically (seeded RNG + fixed tick budget) and assert the
+ * grid-cell occupancy variance directly. The geometry source of truth —
+ * `physicsFor` + `phyllotaxisSeed` — is imported directly.
  */
 
 import { describe, it, expect } from 'vitest'
@@ -31,87 +30,83 @@ import {
   forceCenter,
   type Simulation,
 } from 'd3-force'
-import { physicsFor, NODE_R, BOUND_PADDING } from './layout'
+import { physicsFor, phyllotaxisSeed, NODE_R, BOUND_PADDING } from './layout'
 
 /* ── geometry contract (pure, no sim) ───────────────────────────── */
 
-describe('physicsFor — elliptical, viewport-filling field', () => {
+describe('physicsFor — even/homogeneous tuning (#3970)', () => {
   const W = 1100
   const H = 600
 
-  it('X-field tracks width/2 and Y-field tracks height/2 — they differ when W≠H', () => {
-    for (const n of [4, 64, 400]) {
+  it('collision is the dominant spacing force: collide = uniformGap/2', () => {
+    for (const n of [25, 64, 400]) {
       const p = physicsFor(n, W, H)
-      // The wide axis must be materially larger than the short axis.
-      expect(p.fieldRadiusX).toBeGreaterThan(p.fieldRadiusY)
-      // …and by roughly the canvas aspect ratio (same density factor on
-      // both axes ⇒ the ratio is the half-extent ratio when neither axis
-      // is clamped). At the very least it must exceed a short-dim circle.
-      const shortDimCircleR = Math.min(W, H) / 2 // what the OLD code used
-      // For a mid-size graph the X field reaches past the short-dim radius
-      // territory the old circle was stuck inside.
-      if (n >= 64) {
-        expect(p.fieldRadiusX).toBeGreaterThan(shortDimCircleR * 0.5)
-      }
+      expect(p.collide).toBeCloseTo(p.uniformGap / 2, 6)
+      // a hard floor so two bubbles never overlap
+      expect(p.collide).toBeGreaterThanOrEqual(NODE_R)
     }
   })
 
-  it('a square canvas yields equal X/Y fields (no spurious asymmetry)', () => {
-    const p = physicsFor(64, 800, 800)
-    expect(p.fieldRadiusX).toBeCloseTo(p.fieldRadiusY, 6)
-  })
-
-  it('each axis is clamped inside its own half-extent (never spills the edge)', () => {
-    for (const n of [4, 64, 400, 4000]) {
+  it('charge is mild / near-zero (no edge-fling)', () => {
+    for (const n of [25, 64, 400, 4000]) {
       const p = physicsFor(n, W, H)
-      expect(p.fieldRadiusX).toBeLessThanOrEqual(W / 2)
-      expect(p.fieldRadiusY).toBeLessThanOrEqual(H / 2)
-      // …and never collapses to a dot, even for a 4-node graph.
-      expect(p.fieldRadiusX).toBeGreaterThan(W / 2 * 0.1)
-      expect(p.fieldRadiusY).toBeGreaterThan(H / 2 * 0.1)
+      expect(p.charge).toBeGreaterThan(-30)
+      expect(p.charge).toBeLessThanOrEqual(0)
     }
   })
 
-  it('the field grows with sqrt(N) (constant density) on BOTH axes', () => {
-    const p4 = physicsFor(4, W, H)
+  it('the uniform gap shrinks with N (constant density)', () => {
+    const p25 = physicsFor(25, W, H)
     const p64 = physicsFor(64, W, H)
     const p400 = physicsFor(400, W, H)
-    expect(p64.fieldRadiusX).toBeGreaterThan(p4.fieldRadiusX)
-    expect(p400.fieldRadiusX).toBeGreaterThanOrEqual(p64.fieldRadiusX)
-    expect(p64.fieldRadiusY).toBeGreaterThan(p4.fieldRadiusY)
-    expect(p400.fieldRadiusY).toBeGreaterThanOrEqual(p64.fieldRadiusY)
+    expect(p64.uniformGap).toBeLessThanOrEqual(p25.uniformGap)
+    expect(p400.uniformGap).toBeLessThanOrEqual(p64.uniformGap)
   })
 
-  it('scalar fieldRadius is the SHORT axis (min of X/Y)', () => {
-    const p = physicsFor(64, W, H)
-    expect(p.fieldRadius).toBe(Math.min(p.fieldRadiusX, p.fieldRadiusY))
-  })
-
-  it('centerGravity is now weak (anti-drift only, not center-crush)', () => {
+  it('centerGravity is weak (anti-drift only, never center-crush)', () => {
     for (const n of [4, 64, 400, 8000]) {
       const p = physicsFor(n, W, H)
       expect(p.centerGravity).toBeGreaterThan(0)
-      expect(p.centerGravity).toBeLessThanOrEqual(0.05)
+      expect(p.centerGravity).toBeLessThanOrEqual(0.07)
     }
   })
 
-  it('charge is a dominant spreading force (strongly negative for small N)', () => {
-    // The whole point of the fix: repulsion must be strong enough to push
-    // nodes out to fill the field instead of collapsing to the centre.
-    expect(physicsFor(64, W, H).charge).toBeLessThanOrEqual(-150)
-    // …and softens (less negative) as N grows so a huge graph stays bounded.
-    expect(physicsFor(8000, W, H).charge).toBeGreaterThan(physicsFor(64, W, H).charge)
+  it('the field anchor tracks width/2 and height/2 (fills both axes)', () => {
+    const p = physicsFor(64, W, H)
+    expect(p.fieldRadiusX).toBeGreaterThan(p.fieldRadiusY) // wide canvas
+    expect(p.fieldRadiusX).toBeLessThanOrEqual(W / 2)
+    expect(p.fieldRadiusY).toBeLessThanOrEqual(H / 2)
+  })
+})
+
+/* ── phyllotaxis seed is even ───────────────────────────────────── */
+
+describe('phyllotaxisSeed — even sunflower seeding', () => {
+  it('places points across the field with no central pile-up', () => {
+    const cx = 550
+    const cy = 300
+    const rx = 500
+    const ry = 270
+    const N = 200
+    const pts = Array.from({ length: N }, (_, i) =>
+      phyllotaxisSeed(i, N, cx, cy, rx, ry, 0),
+    )
+    // radii are spread roughly uniformly by area (sqrt distribution): the
+    // mean normalized radius is around 2/3, not clustered at 0.
+    const meanNormR =
+      pts.reduce((s, p) => s + Math.hypot((p.x - cx) / rx, (p.y - cy) / ry), 0) / N
+    expect(meanNormR).toBeGreaterThan(0.55)
+    expect(meanNormR).toBeLessThan(0.78)
+    // every point stays inside the field ellipse.
+    for (const p of pts) {
+      const nd = Math.hypot((p.x - cx) / rx, (p.y - cy) / ry)
+      expect(nd).toBeLessThanOrEqual(1.0001)
+    }
   })
 })
 
 /* ── settled-layout contract (headless d3-force) ────────────────── */
 
-/**
- * A small deterministic PRNG so the settled layout is reproducible in CI
- * (d3-force seeds initial positions from Math.random via its phyllotaxis
- * fallback only when x/y are unset — we set them ourselves, so the only
- * randomness is our jitter seed here).
- */
 function mulberry32(seed: number): () => number {
   let a = seed >>> 0
   return () => {
@@ -135,39 +130,9 @@ interface SimNode {
 }
 
 /**
- * Mirror of GraphCanvas.makeForceRadialCap — the elliptical soft cap. Kept
- * inline so this test owns no DOM/component import; the geometry it caps to
- * comes straight from physicsFor (the source of truth under test).
- */
-function ellipticalCap(cx: number, cy: number, rx: number, ry: number) {
-  let nodes: SimNode[] = []
-  const force = (alpha: number) => {
-    if (rx <= 0 || ry <= 0) return
-    for (const n of nodes) {
-      if (n.fx !== null || n.fy !== null) continue
-      const dx = n.x - cx
-      const dy = n.y - cy
-      const nx = dx / rx
-      const ny = dy / ry
-      const norm2 = nx * nx + ny * ny
-      if (norm2 <= 1 || norm2 === 0) continue
-      const overshoot = Math.sqrt(norm2) - 1
-      const k = Math.min(0.25, overshoot) * alpha
-      n.vx -= dx * k
-      n.vy -= dy * k
-    }
-  }
-  ;(force as unknown as { initialize: (n: SimNode[]) => void }).initialize = (next) => {
-    nodes = next
-  }
-  return force as ((alpha: number) => void) & { initialize: (n: SimNode[]) => void }
-}
-
-/**
  * Mirror of GraphCanvas.makeForceBound — the HARD viewport-edge clamp +
- * velocity-reflection safety net. Production installs this alongside the
- * soft elliptical cap; we mirror it so the settle test is faithful (the
- * hard bound is what guarantees no node ever leaves the canvas).
+ * velocity-reflection safety net. This is the ONLY boundary force in the
+ * #3970 model (the radial cap is deleted).
  */
 function hardBound(W: number, H: number, padding: number, nodeR: number) {
   let nodes: SimNode[] = []
@@ -199,21 +164,19 @@ function hardBound(W: number, H: number, padding: number, nodeR: number) {
   return force as (() => void) & { initialize: (n: SimNode[]) => void }
 }
 
-/** Build N seeded nodes clustered near the centroid (as the canvas seeds). */
-function seedNodes(count: number, cx: number, cy: number, seedR: number, rng: () => number): SimNode[] {
+/** Seed N nodes on the EVEN phyllotaxis pattern (as the canvas now does). */
+function seedNodes(
+  count: number,
+  cx: number,
+  cy: number,
+  rx: number,
+  ry: number,
+  rng: () => number,
+): SimNode[] {
   const out: SimNode[] = []
   for (let i = 0; i < count; i++) {
-    const ang = rng() * 2 * Math.PI
-    const rad = Math.sqrt(rng()) * seedR
-    out.push({
-      x: cx + Math.cos(ang) * rad,
-      y: cy + Math.sin(ang) * rad,
-      vx: 0,
-      vy: 0,
-      fx: null,
-      fy: null,
-      degree: 0,
-    })
+    const p = phyllotaxisSeed(i, count, cx, cy, rx, ry, 1, rng)
+    out.push({ x: p.x, y: p.y, vx: 0, vy: 0, fx: null, fy: null, degree: 0 })
   }
   return out
 }
@@ -224,29 +187,26 @@ function settle(count: number, W: number, H: number, seed = 1): SimNode[] {
   const cx = W / 2
   const cy = H / 2
   const rng = mulberry32(seed)
-  const seedR = Math.min(60, phys.fieldRadius * 0.5)
-  const nodes = seedNodes(count, cx, cy, seedR, rng)
+  const nodes = seedNodes(count, cx, cy, phys.fieldRadiusX, phys.fieldRadiusY, rng)
 
   const sim: Simulation<SimNode, undefined> = forceSimulation<SimNode>(nodes)
     .force('charge', forceManyBody<SimNode>().strength(phys.charge))
     .force(
       'collide',
-      forceCollide<SimNode>().radius(NODE_R + 4).strength(0.9),
+      // PRODUCTION collide: radius = uniformGap/2 (floored at NODE_R+4),
+      // strength 1 — the dominant even-density force.
+      forceCollide<SimNode>().radius(Math.max(phys.collide, NODE_R + 4)).strength(1),
     )
     .force('center', forceCenter<SimNode>(cx, cy))
     .force('gravityX', forceX<SimNode>(cx).strength(phys.centerGravity))
     .force('gravityY', forceY<SimNode>(cy).strength(phys.centerGravity))
-    .force('field', ellipticalCap(cx, cy, phys.fieldRadiusX, phys.fieldRadiusY))
+    // NO radial cap (#3970). Only the hard viewport bound.
     .force('bound', hardBound(W, H, BOUND_PADDING, NODE_R))
     .alphaDecay(phys.alphaDecay)
     .alphaTarget(0)
     .stop()
 
-  // No links in this isolation test — we measure the spread of the field
-  // itself (the founder complaint is about the empty margin, not topology).
-  // Tick to convergence: enough iterations for alpha to decay below the
-  // default 0.001 stop threshold given phys.alphaDecay.
-  const ticks = Math.ceil(Math.log(0.001) / Math.log(1 - phys.alphaDecay)) + 50
+  const ticks = Math.ceil(Math.log(0.001) / Math.log(1 - phys.alphaDecay)) + 80
   sim.alpha(1)
   for (let i = 0; i < ticks; i++) sim.tick()
 
@@ -267,23 +227,84 @@ function bbox(nodes: SimNode[]) {
   return { minX, maxX, minY, maxY, w: maxX - minX, h: maxY - minY }
 }
 
-describe('settled layout fills the canvas (headless d3-force)', () => {
+/**
+ * Grid-cell occupancy variance / mean over the OCCUPIED region (the
+ * bounding box of the settled cloud). A perfectly uniform fill has all
+ * cells equally populated (variance/mean → ~0); a central blob leaves the
+ * outer cells empty and stacks the centre (high variance); an edge ring
+ * leaves the centre cells empty (also high variance). The bound asserts
+ * the fill is even in BOTH the no-blob and no-ring senses.
+ */
+function occupancyVarianceOverMean(nodes: SimNode[], G: number) {
+  const b = bbox(nodes)
+  const w = Math.max(1, b.w)
+  const h = Math.max(1, b.h)
+  const cells = new Array(G * G).fill(0)
+  for (const n of nodes) {
+    let gx = Math.floor(((n.x - b.minX) / w) * G)
+    let gy = Math.floor(((n.y - b.minY) / h) * G)
+    gx = Math.min(G - 1, Math.max(0, gx))
+    gy = Math.min(G - 1, Math.max(0, gy))
+    cells[gy * G + gx] += 1
+  }
+  const mean = nodes.length / (G * G)
+  const variance =
+    cells.reduce((s, c) => s + (c - mean) * (c - mean), 0) / cells.length
+  return { ratio: variance / mean, cells, G, mean }
+}
+
+/** Count how many of the CENTRE cells are occupied — guards against an
+ *  edge-ring (empty middle). */
+function centreCellsOccupied(cells: number[], G: number): number {
+  // The central 2×2 (even G) or 1×1 (odd G) block.
+  const lo = Math.floor((G - 1) / 2)
+  const hi = Math.ceil((G - 1) / 2)
+  let occupied = 0
+  let total = 0
+  for (let gy = lo; gy <= hi; gy++) {
+    for (let gx = lo; gx <= hi; gx++) {
+      total += 1
+      if (cells[gy * G + gx] > 0) occupied += 1
+    }
+  }
+  return occupied / total
+}
+
+describe('settled layout has UNIFORM LOCAL DENSITY (#3970)', () => {
   const W = 1100
   const H = 600
 
-  it('N=64 fills ≥75% of BOTH width and height', () => {
-    const nodes = settle(64, W, H, 42)
+  for (const N of [25, 64, 200]) {
+    it(`N=${N}: grid-cell occupancy variance/mean is below the even-density bound`, () => {
+      const nodes = settle(N, W, H, 42 + N)
+      // 5×5 grid over the occupied region. A uniform fill keeps the
+      // variance/mean low; a blob or ring blows it up. Empirically the
+      // collide-dominant even-seed layout settles well under 2.0.
+      const { ratio } = occupancyVarianceOverMean(nodes, 5)
+      expect(ratio).toBeLessThan(2.0)
+    })
+  }
+
+  it('N=400 fills the canvas (≥70% of BOTH axes) — no center-crush', () => {
+    const nodes = settle(400, W, H, 11)
     const b = bbox(nodes)
-    expect(b.w).toBeGreaterThanOrEqual(0.75 * W)
-    expect(b.h).toBeGreaterThanOrEqual(0.75 * H)
+    expect(b.w).toBeGreaterThanOrEqual(0.7 * W)
+    expect(b.h).toBeGreaterThanOrEqual(0.7 * H)
   })
 
-  it('N=64 — no two node centres closer than the collide radius', () => {
+  it('N=64 — the CENTRE is occupied (no edge-ring / empty middle)', () => {
     const nodes = settle(64, W, H, 7)
-    const collideR = NODE_R + 4 // forceCollide radius used above
-    // d3 collide resolves overlaps softly; allow a small tolerance for the
-    // residual sub-radius penetration at the settle threshold.
-    const minAllowed = collideR * 0.9
+    const { cells, G } = occupancyVarianceOverMean(nodes, 5)
+    // The central block must be populated — an edge ring would leave it 0.
+    expect(centreCellsOccupied(cells, G)).toBeGreaterThan(0)
+  })
+
+  it('N=64 — no two node centres closer than the collide radius (no overlap)', () => {
+    const nodes = settle(64, W, H, 9)
+    const phys = physicsFor(64, W, H)
+    const collideR = Math.max(phys.collide, NODE_R + 4)
+    // d3 collide resolves overlaps softly; allow a small residual.
+    const minAllowed = collideR * 0.85
     let minDist = Infinity
     for (let i = 0; i < nodes.length; i++) {
       for (let j = i + 1; j < nodes.length; j++) {
@@ -294,27 +315,10 @@ describe('settled layout fills the canvas (headless d3-force)', () => {
     expect(minDist).toBeGreaterThanOrEqual(minAllowed)
   })
 
-  it('N=4 stays a tidy CENTRED cluster (not flung to the corners)', () => {
-    const nodes = settle(4, W, H, 3)
-    const b = bbox(nodes)
-    const cx = W / 2
-    const cy = H / 2
-    // The cluster's bounding box centre is near the canvas centre.
-    expect(Math.abs((b.minX + b.maxX) / 2 - cx)).toBeLessThan(0.18 * W)
-    expect(Math.abs((b.minY + b.maxY) / 2 - cy)).toBeLessThan(0.18 * H)
-    // …and it does NOT sprawl to the edges (a tidy small cluster).
-    expect(b.w).toBeLessThan(0.6 * W)
-    expect(b.h).toBeLessThan(0.6 * H)
-  })
-
-  it('N=400 fills the canvas (no dense central blob) and stays inside the viewport', () => {
-    const nodes = settle(400, W, H, 11)
-    const b = bbox(nodes)
-    // Wide spread on both axes — fills the canvas, NOT a central blob…
-    expect(b.w).toBeGreaterThanOrEqual(0.75 * W)
-    expect(b.h).toBeGreaterThanOrEqual(0.75 * H)
-    // …and the hard bound guarantees no node ever leaves the viewport.
+  it('every node stays inside the viewport (hard bound holds)', () => {
+    const nodes = settle(200, W, H, 3)
     const edge = NODE_R + BOUND_PADDING
+    const b = bbox(nodes)
     expect(b.minX).toBeGreaterThanOrEqual(edge - 0.5)
     expect(b.maxX).toBeLessThanOrEqual(W - edge + 0.5)
     expect(b.minY).toBeGreaterThanOrEqual(edge - 0.5)

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/layout.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/layout.ts
@@ -1,30 +1,33 @@
 /**
- * layout.ts — the constant-density, viewport-aware force tuning for the
- * unified Cloud-graph (#3958). Pure math, no DOM — lives in its own
- * module so GraphCanvas.tsx stays a component-only file
+ * layout.ts — even / homogeneous force tuning for the unified Cloud-graph
+ * (#3958 / #3970). Pure math, no DOM — lives in its own module so
+ * GraphCanvas.tsx stays a component-only file
  * (react-refresh/only-export-components) and so the tuning is unit-test
  * lockable.
  *
- * The founder repeatedly rejected two failure modes:
+ * #3970 corrects the layout. The founder rejected BOTH failure modes:
  *   • center-crush  — small graphs collapse into an overlapping blob.
- *   • edge-fling    — charge repulsion blows nodes to the canvas edge,
- *                     centre empty.
+ *   • edge-fling    — charge repulsion (with the old elliptical radial
+ *                     cap) parks nodes on a boundary RING with an empty
+ *                     middle.
  *
- * The fix is to make the spread a function of √N so DENSITY stays
- * constant: 4 nodes → a small centred cluster, 60 nodes → a
- * proportionally larger field at the SAME density. physicsFor() targets a
- * field whose RADII scale with √N (area ∝ N), then derives the per-tick
- * forces from that field:
- *   • The field is an ELLIPSE, not a short-dim circle: fieldRadiusX is
- *     anchored to width/2 and fieldRadiusY to height/2. On a wide-short
- *     canvas (~1100×600) this fills BOTH axes instead of collapsing into
- *     a min(W,H)/2 disc centred in a sea of empty left/right margin.
- *   • centerGravity is a WEAK anti-drift pull only (~0.02–0.05) — it
- *     parks the equilibrium against drift without crushing the cloud to
- *     the centre. Repulsion (charge) is the dominant spreading force.
- *   • linkDistance is CLAMPED to [minLink, maxLink]: minLink ≥
- *     2·maxNodeR + pad prevents overlap; maxLink caps edge-fling.
- *   • collide has a HARD floor so two bubbles can never overlap.
+ * The target is EVEN node density across the WHOLE canvas — no dense
+ * centre, no edge ring. The recipe:
+ *   • COLLISION is the dominant force. `forceCollide(uniformGap)` with a
+ *     hard strength spaces every node at least `uniformGap` apart, where
+ *     uniformGap ≈ sqrt(canvasArea / N) · GAP_K — exactly the spacing a
+ *     uniform packing of N nodes over the canvas needs. This is what
+ *     makes the density homogeneous.
+ *   • CHARGE is mild / near-zero (a tiny anti-overlap nudge only), so it
+ *     never flings nodes outward to a ring.
+ *   • GENTLE centering (forceX/forceY at a low strength) only keeps the
+ *     cloud from drifting off-canvas — never strong enough to crush the
+ *     middle.
+ *   • EVEN SEEDING (phyllotaxis sunflower over the canvas) so nodes RELAX
+ *     into a uniform fill instead of starting clustered and being pushed.
+ *   • No radial cap — the elliptical-cap edge-ring generator is DELETED
+ *     (#3970). The hard viewport-bound clamp remains as the absolute
+ *     safety net only.
  */
 
 /**
@@ -40,120 +43,121 @@ export const NODE_R = 14
  */
 export const BOUND_PADDING = 20
 
-/** Reference for the constant-density spread — at N_REF nodes the field
- *  fills FIELD_FRAC of each viewport half-extent. */
-const DENSITY_N_REF = 40
-/** Target field radius as a fraction of a half-extent at N_REF nodes.
- *  ~0.85 fills the canvas generously (the elliptical cap clamps to
- *  FIELD_MAX_FRAC, so large graphs reach ~85% of BOTH axes). */
-const FIELD_FRAC = 0.85
-/** Upper clamp: the field never exceeds this fraction of a half-extent,
- *  so the cloud fills the canvas without spilling past the edge padding. */
-const FIELD_MAX_FRAC = 0.88
-/** Lower clamp: the field never drops below this fraction of a half-extent,
- *  so even a 1–4 node graph keeps "social distance" (a tidy cluster, not a
- *  single overlapping dot) while staying centred. */
-const FIELD_MIN_FRAC = 0.18
-/** Max node radius (degree-driven) used to floor link length + collide so
- *  bubbles never overlap. Mirrors radiusForDegree's clamp ceiling. */
+/** Max node radius (degree-driven) used to floor the collide radius so
+ *  even high-degree bubbles never overlap. Mirrors radiusForDegree's
+ *  clamp ceiling. */
 const MAX_NODE_R = 20
 
+/**
+ * Uniform-gap tuning. The even-density gap is the side of the square each
+ * node would own in a uniform packing of N nodes over the usable canvas:
+ *   gap = sqrt(usableArea / N) · GAP_K
+ * GAP_K < 1 packs a little tighter than a perfect square lattice so the
+ * cloud reads as a filled field, not a sparse grid; the gap is then
+ * clamped to [GAP_MIN, GAP_MAX] so two nodes never overlap (floor) and a
+ * tiny graph doesn't sprawl edge-to-edge (ceiling).
+ */
+const GAP_K = 0.92
+/** Floor: two MAX_NODE_R bubbles + a little air — the no-overlap guarantee. */
+const GAP_MIN = 2 * MAX_NODE_R + 6
+/** Ceiling: a small graph keeps tidy social distance without spanning the
+ *  whole canvas. */
+const GAP_MAX = 120
+
 export interface PhysicsParams {
+  /** Charge (repulsion). Mild / near-zero in the even-density model so it
+   *  no longer flings nodes outward — collision owns the spacing. */
   charge: number
   linkDistance: number
   minLink: number
   maxLink: number
   linkStrength: number
+  /** The collide radius — the DOMINANT spacing force. Equal to half the
+   *  uniformGap so two node CENTRES settle ~uniformGap apart. */
   collide: number
+  /** The even-density target gap between adjacent node centres. */
+  uniformGap: number
   alphaDecay: number
+  /** Gentle anti-drift centering strength (forceX/forceY). Low enough to
+   *  never crush the middle. */
   centerGravity: number
-  /** The target field radius on the X axis — anchored to width/2. The
-   *  elliptical radial cap uses this so the cloud fills the canvas WIDTH
-   *  on a wide-short viewport instead of collapsing into a min(W,H) disc. */
+  /** Retained for the centering anchor + seeding extent. Anchored to
+   *  width/2 (X) and height/2 (Y) so the cloud fills BOTH axes. */
   fieldRadiusX: number
-  /** The target field radius on the Y axis — anchored to height/2. */
   fieldRadiusY: number
-  /** Scalar convenience = min(fieldRadiusX, fieldRadiusY). Retained for
-   *  seeding-jitter and any caller that wants a single scalar; the radial
-   *  CAP itself is elliptical (uses X and Y independently). */
+  /** Scalar convenience = min(fieldRadiusX, fieldRadiusY). */
   fieldRadius: number
 }
+
+/** Field as a fraction of each half-extent — used only as the seeding
+ *  extent + the gentle-centering anchor (no hard cap). */
+const FIELD_FRAC = 0.86
 
 export function physicsFor(nodeCount: number, width = 800, height = 480): PhysicsParams {
   const n = Math.max(1, nodeCount)
   const halfW = width / 2
   const halfH = height / 2
-  // Constant-density spread factor: grows with √N (area ∝ N), anchored so
-  // N_REF nodes fill FIELD_FRAC of each half-extent. The SAME factor is
-  // applied to both axes so density stays uniform; the asymmetry between
-  // fieldRadiusX and fieldRadiusY comes purely from the canvas aspect
-  // ratio (width/2 vs height/2). On a wide-short canvas this yields a
-  // genuinely WIDER field that fills the empty left/right margin.
-  const densityFactor = FIELD_FRAC * Math.sqrt(n / DENSITY_N_REF)
-  // Per-axis field radius. Clamp each independently to its own half-extent
-  // so neither axis spills past the edge padding nor collapses to a dot.
-  const fieldRadiusX = Math.max(
-    halfW * FIELD_MIN_FRAC,
-    Math.min(halfW * FIELD_MAX_FRAC, halfW * densityFactor),
-  )
-  const fieldRadiusY = Math.max(
-    halfH * FIELD_MIN_FRAC,
-    Math.min(halfH * FIELD_MAX_FRAC, halfH * densityFactor),
-  )
-  // Scalar = the SHORT axis (min) so seeding-jitter never seeds outside the
-  // tighter dimension; the cap below is elliptical and uses X/Y directly.
+
+  // Per-axis seeding/centering field — just the usable extent on each
+  // axis. No radial cap clamps to it; it only bounds the seed pattern and
+  // anchors the gentle centering pull.
+  const fieldRadiusX = halfW * FIELD_FRAC
+  const fieldRadiusY = halfH * FIELD_FRAC
   const fieldRadius = Math.min(fieldRadiusX, fieldRadiusY)
 
-  // Hard collision floor: two MAX_NODE_R bubbles + a little air. This is
-  // the no-overlap guarantee independent of N.
-  const collide = MAX_NODE_R + 6
+  // EVEN-DENSITY gap. Usable canvas area (inside the bound padding) divided
+  // by N gives the area each node owns; its square-root is the side. GAP_K
+  // packs a touch tighter so the field reads as filled.
+  const usableW = Math.max(1, width - 2 * (NODE_R + BOUND_PADDING))
+  const usableH = Math.max(1, height - 2 * (NODE_R + BOUND_PADDING))
+  const rawGap = Math.sqrt((usableW * usableH) / n) * GAP_K
+  const uniformGap = Math.max(GAP_MIN, Math.min(GAP_MAX, rawGap))
+
+  // Collision is the DOMINANT force: radius = half the gap so two node
+  // centres can't come closer than ~uniformGap. This is what makes the
+  // density homogeneous across the canvas.
+  const collide = uniformGap / 2
 
   // Link length clamp. minLink keeps connected bubbles from overlapping;
-  // maxLink prevents a long chain from flinging an endpoint to the edge.
+  // maxLink prevents a long chain from flinging an endpoint away. Both
+  // track the uniform gap so a connected pair sits roughly one cell apart.
   const minLink = 2 * MAX_NODE_R + 10 // ≥ sum-of-radii + pad
-  // maxLink scales with the field but never lets one edge span the whole
-  // cloud — keeps the natural topology readable without edge-fling.
-  const maxLink = Math.max(minLink + 8, Math.min(fieldRadius * 0.9, 160))
-  // Nominal link distance scales mildly down with N so dense graphs pack
-  // tighter (constant density) but always within [minLink, maxLink].
-  const linkDistance = Math.max(minLink, Math.min(maxLink, 90 - Math.log2(n) * 6))
+  const maxLink = Math.max(minLink + 8, Math.min(uniformGap * 1.6, 200))
+  const linkDistance = Math.max(minLink, Math.min(maxLink, uniformGap))
 
-  // Charge (repulsion) is now the DOMINANT spreading force — strong enough
-  // to push nodes OUT to fill the field instead of collapsing to the
-  // centre. It softens as N grows so a huge graph stays bounded (the
-  // elliptical cap catches the overshoot). centerGravity is ONLY anti-drift
-  // now (~0.02–0.05) — it keeps the cloud from wandering off-centre without
-  // crushing it inward; the field's shape is owned by charge + collide +
-  // the elliptical cap, not by gravity.
+  // Charge is MILD / near-zero now (#3970) — collision owns spacing, so a
+  // strong negative charge would only re-introduce the edge-fling. A tiny
+  // negative value just helps disconnected components ease apart. It
+  // softens further as N grows so a huge graph never blows up.
   let charge: number
   let linkStrength: number
   let alphaDecay: number
   let centerGravity: number
   if (n <= 50) {
-    charge = -240
-    linkStrength = 0.5
+    charge = -18
+    linkStrength = 0.4
     alphaDecay = 0.022
-    centerGravity = 0.03
-  } else if (n <= 200) {
-    charge = -150
-    linkStrength = 0.45
-    alphaDecay = 0.026
-    centerGravity = 0.035
-  } else if (n <= 1000) {
-    charge = -90
-    linkStrength = 0.38
-    alphaDecay = 0.03
-    centerGravity = 0.04
-  } else if (n <= 5000) {
-    charge = -45
-    linkStrength = 0.25
-    alphaDecay = 0.04
     centerGravity = 0.045
-  } else {
-    charge = -24
-    linkStrength = 0.15
-    alphaDecay = 0.05
+  } else if (n <= 200) {
+    charge = -12
+    linkStrength = 0.35
+    alphaDecay = 0.026
     centerGravity = 0.05
+  } else if (n <= 1000) {
+    charge = -8
+    linkStrength = 0.3
+    alphaDecay = 0.03
+    centerGravity = 0.055
+  } else if (n <= 5000) {
+    charge = -4
+    linkStrength = 0.2
+    alphaDecay = 0.04
+    centerGravity = 0.06
+  } else {
+    charge = -2
+    linkStrength = 0.12
+    alphaDecay = 0.05
+    centerGravity = 0.065
   }
 
   return {
@@ -163,10 +167,50 @@ export function physicsFor(nodeCount: number, width = 800, height = 480): Physic
     maxLink,
     linkStrength,
     collide,
+    uniformGap,
     alphaDecay,
     centerGravity,
     fieldRadiusX,
     fieldRadiusY,
     fieldRadius,
   }
+}
+
+/**
+ * phyllotaxisSeed — an EVEN sunflower/phyllotaxis seed position for node
+ * `i` of `count`, spread over the elliptical field (fieldRadiusX ×
+ * fieldRadiusY) centred at (cx, cy). The golden-angle spiral places points
+ * at uniform local density across the disc, so nodes START evenly spread
+ * and merely RELAX under collision — no central jitter to be flung outward
+ * (#3970 replaces the old tight-central-jitter seeding).
+ *
+ * `jitter` (0..1) breaks the perfect lattice slightly via the supplied RNG
+ * so the relaxed layout looks organic rather than a visible spiral; pass a
+ * deterministic RNG in tests for reproducibility.
+ */
+const GOLDEN_ANGLE = Math.PI * (3 - Math.sqrt(5))
+
+export function phyllotaxisSeed(
+  i: number,
+  count: number,
+  cx: number,
+  cy: number,
+  fieldRadiusX: number,
+  fieldRadiusY: number,
+  jitter = 0,
+  rng: () => number = Math.random,
+): { x: number; y: number } {
+  const n = Math.max(1, count)
+  // Normalized radius 0..1 — sqrt keeps the areal density uniform across
+  // the disc (equal-area rings). +0.5 offset avoids stacking the first few
+  // points at the exact centre.
+  const t = Math.sqrt((i + 0.5) / n)
+  const ang = i * GOLDEN_ANGLE
+  let rx = t * fieldRadiusX
+  let ry = t * fieldRadiusY
+  if (jitter > 0) {
+    rx += (rng() - 0.5) * jitter * fieldRadiusX * 0.12
+    ry += (rng() - 0.5) * jitter * fieldRadiusY * 0.12
+  }
+  return { x: cx + Math.cos(ang) * rx, y: cy + Math.sin(ang) * ry }
 }

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/presets.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/presets.ts
@@ -1,41 +1,41 @@
 /**
- * presets.ts — cross-cutting LENSES for the unified Cloud-graph (#3958).
+ * presets.ts — the LENSES for the unified Cloud surface (#3958 / #3970).
  *
- * A preset is a saved triple of {categories (shapes), families (borders),
- * edgeKinds}. Selecting one narrows the canvas to nodes whose CATEGORY is
- * in the preset's category set AND whose FAMILY is in the preset's family
- * set — layered ON TOP of the per-type chip toggles (the chip toggles
- * stay the fine-grained control; the preset is the coarse lens).
+ * #3970 corrects the lens model. A lens is NOT a filter layer that hides
+ * node types underneath a still-full chip strip. **A lens IS a named,
+ * predefined chip-set, nothing more.** Selecting a lens sets the active
+ * chip-set to *exactly* that lens's chips; the chip strip then renders
+ * ONLY those chips (non-member chips are removed from the strip, not
+ * greyed). `+ Add` grows the active set (active = lensChips ∪ additions);
+ * removing a chip shrinks it. There is no separate hidden layer.
  *
  * Two flavours, per the founder-signed design:
- *   • Domain lenses  — All / Runtime / Cloud / Reconciliation /
- *                      Networking / Data / Security. Cut by CATEGORY
- *                      (every family allowed).
+ *   • Domain lenses  — Cloud (default) / Runtime / Reconciliation /
+ *                      Networking / Data / Security. Membership cut by
+ *                      CATEGORY (and, for Cloud, ALSO by family).
  *   • Family lenses  — Flux / Crossplane / cert-manager / CNPG /
- *                      External-Secrets / Cilium / Catalyst CRs. Cut by
- *                      FAMILY (every category allowed).
+ *                      External-Secrets / Cilium / Catalyst. Membership
+ *                      cut by FAMILY.
  *
- * Per docs/INVIOLABLE-PRINCIPLES.md #4 — the preset table is data; the
- * page reads it, no hardcoded lens logic at the call site.
+ * Per docs/INVIOLABLE-PRINCIPLES.md #4 — the lens membership is DERIVED
+ * from NODE_CATEGORY / NODE_FAMILY at runtime, never hand-listed at a
+ * call site. `lensChips(lens)` is the single resolver the page and the
+ * list both consume.
  */
 
 import {
-  ALL_CATEGORIES,
-  ALL_FAMILIES,
   ALL_NODE_TYPES,
   NODE_CATEGORY,
   NODE_FAMILY,
-  type ArchEdgeType,
   type ArchNodeType,
   type NodeCategory,
   type NodeFamily,
 } from './types'
 
-export type PresetId =
+export type LensId =
   // Domain lenses
-  | 'all'
-  | 'runtime'
   | 'cloud'
+  | 'runtime'
   | 'reconciliation'
   | 'networking'
   | 'data'
@@ -49,35 +49,51 @@ export type PresetId =
   | 'cilium'
   | 'catalyst'
 
-export interface Preset {
-  id: PresetId
+/**
+ * Back-compat alias — some call sites historically imported `PresetId`.
+ * A lens IS the preset; keep the alias so the rename is non-breaking.
+ */
+export type PresetId = LensId
+
+export interface Lens {
+  id: LensId
   label: string
   /** 'domain' lenses cut by category; 'family' lenses cut by family. */
   group: 'domain' | 'family'
-  /** Active categories (shapes). Empty/omitted = all categories. */
+  /** Membership categories. A type is a member when its category is in
+   *  this set (AND, when `families` is also set, its family is in that
+   *  set too). Omitted = category is not a constraint. */
   categories?: NodeCategory[]
-  /** Active families (borders). Empty/omitted = all families. */
+  /** Membership families. A type is a member when its family is in this
+   *  set (AND any `categories` constraint). Omitted = family is not a
+   *  constraint. */
   families?: NodeFamily[]
-  /** Active edge kinds. Omitted = all edge kinds. */
-  edgeKinds?: ArchEdgeType[]
 }
 
-/** The preset table — single source of truth for the dropdown. */
-export const PRESETS: Record<PresetId, Preset> = {
-  // ── Domain lenses (cut by category) ──────────────────────────────
-  all: { id: 'all', label: 'All', group: 'domain' },
-  runtime: {
-    id: 'runtime',
-    label: 'Runtime',
-    group: 'domain',
-    categories: ['compute', 'scope'],
-  },
+/** Back-compat alias — a lens IS a preset. */
+export type Preset = Lens
+
+/**
+ * The lens table — single source of truth for the dropdown. Membership
+ * is DERIVED from these category/family rules via `lensChips` below; the
+ * chips are never hand-listed.
+ */
+export const LENSES: Record<LensId, Lens> = {
+  // ── Domain lenses ────────────────────────────────────────────────
+  // Cloud is the DEFAULT lens (#3970): the cloud-provider infrastructure
+  // picture — scope/compute/network nodes of the cloud family.
   cloud: {
     id: 'cloud',
     label: 'Cloud',
     group: 'domain',
     categories: ['scope', 'compute', 'network'],
     families: ['cloud'],
+  },
+  runtime: {
+    id: 'runtime',
+    label: 'Runtime',
+    group: 'domain',
+    categories: ['compute', 'scope'],
   },
   reconciliation: {
     id: 'reconciliation',
@@ -127,17 +143,22 @@ export const PRESETS: Record<PresetId, Preset> = {
   cilium: { id: 'cilium', label: 'Cilium', group: 'family', families: ['cilium'] },
   catalyst: {
     id: 'catalyst',
-    label: 'Catalyst CRs',
+    label: 'Catalyst',
     group: 'family',
     families: ['catalyst'],
   },
 }
 
+/** Back-compat alias — `LENSES` is the lens/preset table. */
+export const PRESETS = LENSES
+
+/** The default lens the surface opens on (#3970). */
+export const DEFAULT_LENS_ID: LensId = 'cloud'
+
 /** Ordered list for the dropdown — domain lenses first, then family. */
-export const PRESET_ORDER: PresetId[] = [
-  'all',
-  'runtime',
+export const LENS_ORDER: LensId[] = [
   'cloud',
+  'runtime',
   'reconciliation',
   'networking',
   'data',
@@ -151,24 +172,39 @@ export const PRESET_ORDER: PresetId[] = [
   'catalyst',
 ]
 
+/** Back-compat alias. */
+export const PRESET_ORDER = LENS_ORDER
+
 /**
- * presetHiddenTypes — the set of ArchNodeTypes a preset HIDES. A type is
- * hidden when its category isn't in the preset's category allow-list OR
- * its family isn't in the preset's family allow-list. The 'all' preset
- * (and any preset with neither constraint) hides nothing. This composes
- * with the per-type chip `hiddenTypes` via set-union downstream.
+ * lensChips — the explicit set of ArchNodeTypes a lens SHOWS. A type is
+ * a member when its category passes the lens's category constraint AND
+ * its family passes the lens's family constraint. Constraints that are
+ * omitted are not applied. This is the chip-set the strip renders and
+ * the dataset both the graph and the list filter by (#3970).
+ *
+ * Derived purely from NODE_CATEGORY / NODE_FAMILY — never hand-listed
+ * (Principle #4). A lens with neither constraint would match every type;
+ * no such lens exists in the table (the old unconstrained 'all' lens is
+ * deleted — the default is now Cloud).
  */
-export function presetHiddenTypes(preset: Preset): Set<ArchNodeType> {
-  const hidden = new Set<ArchNodeType>()
-  const catAllow = new Set<NodeCategory>(preset.categories ?? ALL_CATEGORIES)
-  const famAllow = new Set<NodeFamily>(preset.families ?? ALL_FAMILIES)
-  const allCats = !preset.categories || preset.categories.length === 0
-  const allFams = !preset.families || preset.families.length === 0
-  if (allCats && allFams) return hidden // 'all' / unconstrained → hide nothing
+export function lensChips(lens: Lens): Set<ArchNodeType> {
+  const catAllow = lens.categories ? new Set<NodeCategory>(lens.categories) : null
+  const famAllow = lens.families ? new Set<NodeFamily>(lens.families) : null
+  const out = new Set<ArchNodeType>()
   for (const t of ALL_NODE_TYPES) {
-    const cat = NODE_CATEGORY[t]
-    const fam = NODE_FAMILY[t]
-    if (!catAllow.has(cat) || !famAllow.has(fam)) hidden.add(t)
+    if (catAllow && !catAllow.has(NODE_CATEGORY[t])) continue
+    if (famAllow && !famAllow.has(NODE_FAMILY[t])) continue
+    out.add(t)
   }
-  return hidden
+  return out
+}
+
+/**
+ * setsEqual — small helper used by the page to decide whether the active
+ * chip-set is still the pure lens (no `Custom` marker) or has diverged.
+ */
+export function setsEqual<T>(a: ReadonlySet<T>, b: ReadonlySet<T>): boolean {
+  if (a.size !== b.size) return false
+  for (const v of a) if (!b.has(v)) return false
+  return true
 }

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/unifiedGraph.test.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/unifiedGraph.test.ts
@@ -22,7 +22,7 @@ import {
   type ArchStatus,
 } from './types'
 import { reconcilersToGraph } from './reconcilerAdapter'
-import { PRESETS, presetHiddenTypes } from './presets'
+import { LENSES, DEFAULT_LENS_ID, lensChips } from './presets'
 import { shapeForCategory } from './shapes'
 import { physicsFor } from './layout'
 import type { ReconciliationNode } from '@/lib/reconciliation.api'
@@ -114,30 +114,55 @@ describe('reconcilersToGraph', () => {
   })
 })
 
-describe('preset lenses', () => {
-  it('the All preset hides nothing', () => {
-    expect(presetHiddenTypes(PRESETS.all).size).toBe(0)
+describe('lens chip-sets (#3970 — a lens IS a named chip-set)', () => {
+  it('the default lens is Cloud — the cloud-provider scope/compute/network nodes', () => {
+    expect(DEFAULT_LENS_ID).toBe('cloud')
+    const chips = lensChips(LENSES.cloud)
+    // Cloud-family scope/compute/network nodes are members…
+    expect(chips.has('Cloud')).toBe(true)
+    expect(chips.has('Region')).toBe(true)
+    expect(chips.has('Cluster')).toBe(true)
+    expect(chips.has('NodePool')).toBe(true)
+    expect(chips.has('LoadBalancer')).toBe(true)
+    // …and non-cloud-family / non-domain types are NOT in the strip.
+    expect(chips.has('Pod')).toBe(false) // coreK8s family
+    expect(chips.has('HelmRelease')).toBe(false) // flux family
+    expect(chips.has('Database')).toBe(false) // cnpg family
   })
-  it('Reconciliation keeps only Control/Reconciler shapes', () => {
-    const hidden = presetHiddenTypes(PRESETS.reconciliation)
-    // HelmRelease (control) survives; Pod (compute) is hidden.
-    expect(hidden.has('HelmRelease')).toBe(false)
-    expect(hidden.has('Kustomization')).toBe(false)
-    expect(hidden.has('Pod')).toBe(true)
-    expect(hidden.has('Service')).toBe(true)
+  it('Reconciliation = exactly the Control/Reconciler chips', () => {
+    const chips = lensChips(LENSES.reconciliation)
+    // HelmRelease (control) is a member; Pod / Service are NOT in the strip.
+    expect(chips.has('HelmRelease')).toBe(true)
+    expect(chips.has('Kustomization')).toBe(true)
+    expect(chips.has('Application')).toBe(true)
+    expect(chips.has('Environment')).toBe(true)
+    expect(chips.has('Pod')).toBe(false)
+    expect(chips.has('Service')).toBe(false)
   })
-  it('the Flux family lens keeps only Flux-family types', () => {
-    const hidden = presetHiddenTypes(PRESETS.flux)
-    expect(hidden.has('HelmRelease')).toBe(false)
-    expect(hidden.has('Kustomization')).toBe(false)
-    expect(hidden.has('Certificate')).toBe(true) // cert-manager family
-    expect(hidden.has('Pod')).toBe(true)
+  it('the Flux family lens = exactly the Flux-family chips', () => {
+    const chips = lensChips(LENSES.flux)
+    expect(chips.has('HelmRelease')).toBe(true)
+    expect(chips.has('Kustomization')).toBe(true)
+    expect(chips.has('Certificate')).toBe(false) // cert-manager family
+    expect(chips.has('Pod')).toBe(false)
   })
-  it('Networking keeps the network category', () => {
-    const hidden = presetHiddenTypes(PRESETS.networking)
-    expect(hidden.has('Service')).toBe(false)
-    expect(hidden.has('Gateway')).toBe(false)
-    expect(hidden.has('Pod')).toBe(true)
+  it('Networking = exactly the network-category chips', () => {
+    const chips = lensChips(LENSES.networking)
+    expect(chips.has('Service')).toBe(true)
+    expect(chips.has('Gateway')).toBe(true)
+    expect(chips.has('Pod')).toBe(false)
+  })
+  it('every lens membership is non-empty except the runtime-only Crossplane family', () => {
+    for (const id of Object.keys(LENSES) as (keyof typeof LENSES)[]) {
+      const size = lensChips(LENSES[id]).size
+      if (id === 'crossplane') {
+        // Crossplane is a runtime-only family — statically empty in
+        // NODE_FAMILY; populated from live apiVersion at runtime.
+        expect(size).toBe(0)
+      } else {
+        expect(size).toBeGreaterThan(0)
+      }
+    }
   })
 })
 
@@ -152,25 +177,30 @@ describe('shapeForCategory', () => {
   })
 })
 
-describe('physicsFor — constant-density centered field', () => {
+describe('physicsFor — even / homogeneous density (#3970)', () => {
   const W = 1000
   const H = 600
 
-  it('field radius grows with sqrt(N) (constant density)', () => {
+  it('the uniform gap SHRINKS as N grows (constant density: more nodes ⇒ tighter packing)', () => {
     const p4 = physicsFor(4, W, H)
     const p40 = physicsFor(40, W, H)
     const p160 = physicsFor(160, W, H)
-    // monotonic increase
-    expect(p40.fieldRadius).toBeGreaterThan(p4.fieldRadius)
-    expect(p160.fieldRadius).toBeGreaterThan(p40.fieldRadius)
-    // never exceeds the viewport half-extent (no edge overflow)
-    expect(p160.fieldRadius).toBeLessThanOrEqual(Math.min(W, H) / 2)
+    // gap = sqrt(area / N): monotonically smaller as N grows (clamped).
+    expect(p40.uniformGap).toBeLessThanOrEqual(p4.uniformGap)
+    expect(p160.uniformGap).toBeLessThanOrEqual(p40.uniformGap)
+    // collide radius is half the gap — the dominant spacing force.
+    expect(p40.collide).toBeCloseTo(p40.uniformGap / 2, 6)
   })
 
-  it('a tiny graph stays a centred cluster, not flung to edges', () => {
-    const p = physicsFor(4, W, H)
-    // 4-node field is a small fraction of the viewport.
-    expect(p.fieldRadius).toBeLessThan(Math.min(W, H) / 2 * 0.5)
+  it('collision (not charge) is the dominant force — charge is mild/near-zero', () => {
+    for (const n of [4, 64, 400]) {
+      const p = physicsFor(n, W, H)
+      // mild charge — never the strong negative that flings to a ring.
+      expect(p.charge).toBeGreaterThan(-30)
+      expect(p.charge).toBeLessThanOrEqual(0)
+      // collide floor keeps nodes apart (no overlap).
+      expect(p.collide).toBeGreaterThanOrEqual(20)
+    }
   })
 
   it('link distance is clamped to [minLink, maxLink] with no overlap', () => {
@@ -179,17 +209,15 @@ describe('physicsFor — constant-density centered field', () => {
       expect(p.minLink).toBeGreaterThanOrEqual(2 * 20 + 10) // sum-of-radii + pad
       expect(p.linkDistance).toBeGreaterThanOrEqual(p.minLink)
       expect(p.linkDistance).toBeLessThanOrEqual(p.maxLink)
-      expect(p.maxLink).toBeLessThanOrEqual(160)
-      // hard collision floor present
-      expect(p.collide).toBeGreaterThanOrEqual(20)
+      expect(p.maxLink).toBeLessThanOrEqual(200)
     }
   })
 
-  it('keeps a gentle inward gravity at every scale', () => {
+  it('keeps a gentle inward gravity at every scale (anti-drift, never center-crush)', () => {
     for (const n of [4, 40, 1000, 8000]) {
       const p = physicsFor(n, W, H)
       expect(p.centerGravity).toBeGreaterThan(0)
-      expect(p.centerGravity).toBeLessThan(0.3)
+      expect(p.centerGravity).toBeLessThanOrEqual(0.07)
     }
   })
 })

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/useCloudLens.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/useCloudLens.tsx
@@ -1,0 +1,106 @@
+/**
+ * useCloudLens.tsx — the SHARED lens / active-chip-set state for the
+ * unified Cloud surface (#3970).
+ *
+ * THE MODEL: a lens IS a named chip-set. The active chip-set is the single
+ * source of what renders in BOTH the graph and the list. Lifting it into a
+ * context (provided once at the CloudPage level) means toggling between
+ * `view=graph` and `view=list` preserves the lens + chips, and `+ Add` in
+ * either rendering grows the same set.
+ *
+ *   • selectLens(id)  → active chip-set := exactly that lens's chips
+ *                       (clean reset; prior +Add additions are dropped).
+ *   • addChip(t)      → active := active ∪ {t}
+ *   • removeChip(t)   → active := active − {t}
+ *   • isCustom        → active chip-set has diverged from the pure lens.
+ *
+ * Default lens = Cloud (#3970).
+ */
+/* eslint-disable react-refresh/only-export-components */
+// This module intentionally co-locates the lens-state hooks
+// (useCloudLensState / useCloudLensOptional) with the CloudLensProvider —
+// they are one cohesive unit. Fast-refresh of the (trivial) provider is a
+// non-concern; the lens state is shared, not hot-swapped.
+
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react'
+import {
+  LENSES,
+  DEFAULT_LENS_ID,
+  lensChips,
+  setsEqual,
+  type LensId,
+} from './presets'
+import type { ArchNodeType } from './types'
+
+export interface CloudLensState {
+  lensId: LensId
+  activeTypes: Set<ArchNodeType>
+  isCustom: boolean
+  selectLens: (id: LensId) => void
+  addChip: (t: ArchNodeType) => void
+  removeChip: (t: ArchNodeType) => void
+}
+
+/**
+ * useCloudLensState — the state implementation. Used directly by the
+ * provider; exposed so the graph widget can also fall back to a private
+ * instance when it's rendered standalone (no provider).
+ */
+export function useCloudLensState(): CloudLensState {
+  const [lensId, setLensId] = useState<LensId>(DEFAULT_LENS_ID)
+  const [activeTypes, setActiveTypes] = useState<Set<ArchNodeType>>(
+    () => lensChips(LENSES[DEFAULT_LENS_ID]),
+  )
+
+  const api = useMemo<CloudLensState>(() => {
+    const selectLens = (id: LensId) => {
+      setLensId(id)
+      setActiveTypes(lensChips(LENSES[id]))
+    }
+    const addChip = (t: ArchNodeType) =>
+      setActiveTypes((prev) => {
+        const n = new Set(prev)
+        n.add(t)
+        return n
+      })
+    const removeChip = (t: ArchNodeType) =>
+      setActiveTypes((prev) => {
+        const n = new Set(prev)
+        n.delete(t)
+        return n
+      })
+    return {
+      lensId,
+      activeTypes,
+      isCustom: !setsEqual(activeTypes, lensChips(LENSES[lensId])),
+      selectLens,
+      addChip,
+      removeChip,
+    }
+  }, [lensId, activeTypes])
+
+  return api
+}
+
+const CloudLensContext = createContext<CloudLensState | null>(null)
+
+export function CloudLensProvider({ children }: { children: ReactNode }) {
+  const value = useCloudLensState()
+  return <CloudLensContext.Provider value={value}>{children}</CloudLensContext.Provider>
+}
+
+/**
+ * useCloudLens — read the shared lens state. When no provider is mounted
+ * (standalone graph in tests/storybook) the caller should fall back to a
+ * private `useCloudLensState()` instance instead; this hook returns null
+ * in that case so the caller can branch.
+ */
+export function useCloudLensOptional(): CloudLensState | null {
+  return useContext(CloudLensContext)
+}


### PR DESCRIPTION
Lens IS a named predefined chip-set: selecting a lens replaces the active chips and the strip shows ONLY those; +Add grows the lens. Default lens=Cloud, density=100%. Even/homogeneous layout (makeForceRadialCap + presetHiddenTypes deleted; collision-dominant + phyllotaxis seeding). Graph + list render ONE dataset incl. reconcilers (HelmRelease/Kustomization/Certificate/ExternalSecret/Database/Catalyst CRs). Gates green: tsc -b 0, npm run build 0, eslint 0, vitest 69+ green; grep confirms makeForceRadialCap/presetHiddenTypes gone. Live operator-walk pending roll onto hw173.

Refs #3970