### PR TITLE
fix(topology): derive REAL placement from live runtime — kill the uniform false 'singleton' (#3982)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -1489,6 +1489,12 @@ func main() {
 		rg.Post("/api/v1/sovereigns/{id}/applications/preview", h.HandleApplicationPreview)
 		rg.Get("/api/v1/sovereigns/{id}/applications/{name}/status", h.HandleApplicationStatus)
 		rg.Get("/api/v1/sovereigns/{id}/applications/{name}/stream", h.HandleApplicationStream)
+		// #3982 — REAL placement targets derived from the live runtime
+		// (where the component's Pods actually run, across BOTH region
+		// clusters in k8scache). Wires the #3969 placement MODEL to reality
+		// so the Topology tab stops showing a uniform false `singleton`.
+		// Works for bootstrap HelmReleases (no Application CR) AND CR apps.
+		rg.Get("/api/v1/sovereigns/{id}/applications/{name}/placement", h.HandleApplicationPlacement)
 		// qa-loop iter-11 Fix #45 Cluster-C: full Application detail
 		// (identity + spec + status) so the Sovereign Console SPA's
 		// AppDetail page can synthesise an ApplicationDescriptor on the

--- a/products/catalyst/bootstrap/api/internal/handler/applications_placement_runtime.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_placement_runtime.go
@@ -1,0 +1,390 @@
+// Package handler — applications_placement_runtime.go (#3982).
+//
+// #3969 shipped the application-centric Placement MODEL (PlacementTarget,
+// DerivePattern, the {Placement, Status} FE shape) but NOTHING populated
+// the placement targets from the live runtime — so every component's
+// placement was empty and `DerivePattern([])` returned `singleton`
+// uniformly, even for grafana / keycloak that demonstrably run in BOTH
+// regions of a 2-region prov.
+//
+// This file is the OTHER half: it DERIVES each component's REAL placement
+// from where its workloads actually run, across BOTH region clusters the
+// catalyst-api already holds in k8scache. It is purely additive — it does
+// NOT touch the #3969 model files (placement_target.go / recon_status.go),
+// the FE {Placement, Status} shape, or the contradiction-removal. It ADDS
+// runtime-derivation.
+//
+//	GET /api/v1/sovereigns/{id}/applications/{name}/placement
+//	  → { "targets": [ {region, cluster, vcluster, role, standbyType}, … ],
+//	      "derivedFromRuntime": true }
+//
+// The derivation is GENERIC across every component the Topology tab renders
+// — bootstrap-kit HelmReleases with NO Application CR (grafana/keycloak/
+// harbor/gitea/…), CNPG pairs, components in mgmt/dmz/rtz vClusters,
+// host-placed components, single-region AND multi-region — because it keys
+// on the LIVE Pods (matched by the same identity the Resources tab uses),
+// never on an Application CR that may not exist.
+//
+// Role inference (honest, never fabricated):
+//   - CNPG Pods carrying the openova.io/cnpg-role label → the `primary`
+//     region's target is Primary; `replica` regions are Standby·Hot (the
+//     pair streams). This mirrors continuum_live.go's cnpg contract.
+//   - Stateless workloads replicated across N>1 regions (grafana, keycloak)
+//     → EACH region is a Primary (multi-primary / active-active) — that is
+//     the truthful reading of "the same app serves traffic in both
+//     regions".
+//   - A genuinely single-region component → ONE target → DerivePattern
+//     yields `singleton` (correct, honest — NOT the old false uniform
+//     singleton).
+//
+// Ref #3982, #3969.
+package handler
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+
+	bpv1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// runtimePlacementResponse is the body of GET
+// /applications/{name}/placement. `Targets` is the #3969 PlacementTarget
+// list derived from the live runtime; the FE feeds it straight into
+// derivePattern. `DerivedFromRuntime` is always true here — it lets the FE
+// distinguish "real, observed placement" from the legacy spec/status
+// projection it falls back to when this endpoint is unavailable.
+type runtimePlacementResponse struct {
+	Targets            []bpv1.PlacementTarget `json:"targets"`
+	DerivedFromRuntime bool                   `json:"derivedFromRuntime"`
+}
+
+// HandleApplicationPlacement — GET
+// /api/v1/sovereigns/{id}/applications/{name}/placement
+//
+// Derives the component's REAL placement targets from the live runtime.
+// Works for bootstrap HelmReleases (no Application CR) and Application-CR
+// installs alike because it keys on the component's live Pods, not a CR.
+func (h *Handler) HandleApplicationPlacement(w http.ResponseWriter, r *http.Request) {
+	urlID := chi.URLParam(r, "id")
+	name := strings.TrimSpace(chi.URLParam(r, "name"))
+	if name == "" {
+		writeBadRequest(w, "missing-name", "application name is required")
+		return
+	}
+	if h.k8sCache == nil {
+		// No data plane (pre-handover mothership / CI) — honest empty
+		// placement; the FE keeps its legacy spec/status fallback.
+		writeJSON(w, http.StatusOK, runtimePlacementResponse{Targets: []bpv1.PlacementTarget{}, DerivedFromRuntime: true})
+		return
+	}
+
+	primaryID := h.resolveChrootClusterID(urlID)
+
+	// Optional namespace scoping. When provided the match is restricted
+	// to the component's install namespace (the FE passes the app's
+	// targetNamespace), which de-noises multi-tenant clusters. Empty =
+	// match across every namespace (the safe default for bootstrap
+	// components whose namespace the FE may not know).
+	ns := strings.TrimSpace(r.URL.Query().Get("namespace"))
+
+	clusterRegion := h.clusterRegionMap(urlID)
+
+	targets := h.derivePlacementTargets(name, ns, primaryID, clusterRegion)
+	writeJSON(w, http.StatusOK, runtimePlacementResponse{Targets: targets, DerivedFromRuntime: true})
+}
+
+// clusterRegionMap builds the clusterID→cloudRegion map from the
+// deployment's declared Regions[], mirroring HandleTreemap's G77 #2624
+// fallback. The primary cluster id (the deployment id, or the
+// `sovereign-<fqdn>` self-registered chroot id) maps to the first declared
+// region; each secondary `<depID>-<cloudRegion>` maps to its own region.
+// Used so a region label can be attached to every cluster even when the
+// Pod/Node `topology.kubernetes.io/region` label is absent (common on HCS,
+// where Huawei CCM doesn't stamp it).
+func (h *Handler) clusterRegionMap(urlID string) map[string]string {
+	out := map[string]string{}
+	var dep *Deployment
+	if val, ok := h.deployments.Load(urlID); ok {
+		dep = val.(*Deployment)
+	} else {
+		dep = h.chrootEnsureDeployment(urlID)
+	}
+	if dep == nil {
+		return out
+	}
+	dep.mu.Lock()
+	regs := append([]provisioner.RegionSpec(nil), dep.Request.Regions...)
+	fqdn := dep.Request.SovereignFQDN
+	depID := dep.ID
+	dep.mu.Unlock()
+
+	if len(regs) > 0 && regs[0].CloudRegion != "" {
+		out[depID] = regs[0].CloudRegion
+		out[urlID] = regs[0].CloudRegion
+		if fqdn != "" {
+			out["sovereign-"+fqdn] = regs[0].CloudRegion
+		}
+	}
+	for _, rs := range regs {
+		if rs.CloudRegion == "" {
+			continue
+		}
+		out[depID+"-"+rs.CloudRegion] = rs.CloudRegion
+	}
+	return out
+}
+
+// placementOccupancy is the per-(region × cluster × vcluster) live presence
+// of a component's workloads, accumulated across the fan-out. Role is
+// inferred at the end from the cnpg signals; `anyCNPG`/`anyPrimary`/
+// `anyReplica` capture the CNPG instance-role labels we observed for this
+// occupancy.
+type placementOccupancy struct {
+	region   string
+	cluster  string
+	vcluster string
+
+	anyCNPG    bool
+	anyPrimary bool // observed a cnpg primary instance here
+	anyReplica bool // observed a cnpg replica instance here
+}
+
+// derivePlacementTargets is the core: fan out across every registered
+// cluster, list its Pods + Namespaces + Nodes, keep the Pods that belong to
+// `name`, and collapse them into one PlacementTarget per (region × cluster
+// × vcluster) the component actually occupies, with an HONEST role.
+func (h *Handler) derivePlacementTargets(name, ns, primaryID string, clusterRegion map[string]string) []bpv1.PlacementTarget {
+	// Fan out across primary + every secondary region cluster.
+	clusterIDs := []string{primaryID}
+	seen := map[string]struct{}{primaryID: {}}
+	for _, cid := range h.k8sCache.Clusters() {
+		if _, ok := seen[cid]; ok {
+			continue
+		}
+		seen[cid] = struct{}{}
+		clusterIDs = append(clusterIDs, cid)
+	}
+
+	// key = region|cluster|vcluster → occupancy.
+	occ := map[string]*placementOccupancy{}
+	for _, cid := range clusterIDs {
+		pods, _, err := h.k8sCache.List(cid, "pod", labels.Everything())
+		if err != nil {
+			// A secondary that can't be listed degrades silently — render
+			// N-1 regions rather than nothing. The primary's pods are the
+			// floor; a missing primary just yields no targets (honest).
+			continue
+		}
+		nsList, _, _ := h.k8sCache.List(cid, "namespace", labels.Everything())
+		nodes, _, _ := h.k8sCache.List(cid, "node", labels.Everything())
+		nsByName := indexByName(nsList)
+		nodeByName := indexByName(nodes)
+
+		for _, p := range pods {
+			if !podBelongsToComponent(p, name, ns) {
+				continue
+			}
+			region := podRegion(p, nsByName, nodeByName, clusterRegion[cid])
+			vcluster := podVCluster(p, nsByName)
+			key := region + "|" + cid + "|" + vcluster
+			o := occ[key]
+			if o == nil {
+				o = &placementOccupancy{region: region, cluster: cid, vcluster: vcluster}
+				occ[key] = o
+			}
+			if role := cnpgInstanceRole(p); role != "" {
+				o.anyCNPG = true
+				switch role {
+				case cnpgRolePrimary:
+					o.anyPrimary = true
+				case cnpgRoleReplica:
+					o.anyReplica = true
+				}
+			}
+		}
+	}
+
+	if len(occ) == 0 {
+		return []bpv1.PlacementTarget{}
+	}
+
+	// Collapse occupancies → targets with honest roles.
+	//
+	// CNPG path: if ANY occupancy carried a cnpg-role label, the component
+	// is a stateful pair — the occupancy(ies) that hold the primary
+	// instance are Primary; the rest are Standby·Hot (the pair streams).
+	// Stateless path: every region the component runs in is a Primary
+	// (multi-region stateless = active-active; single region = singleton).
+	anyCNPG := false
+	for _, o := range occ {
+		if o.anyCNPG {
+			anyCNPG = true
+			break
+		}
+	}
+
+	targets := make([]bpv1.PlacementTarget, 0, len(occ))
+	for _, o := range occ {
+		t := bpv1.PlacementTarget{
+			Region:   o.region,
+			Cluster:  o.cluster,
+			VCluster: o.vcluster,
+		}
+		switch {
+		case anyCNPG && o.anyPrimary:
+			t.Role = bpv1.DataRolePrimary
+		case anyCNPG && o.anyReplica:
+			t.Role = bpv1.DataRoleStandby
+			t.StandbyType = bpv1.StandbyHot
+		case anyCNPG:
+			// A CNPG occupancy whose instance-role we couldn't read (label
+			// absent on these pods) — treat as a Hot standby follower so it
+			// never masquerades as a second writer. Honest + conservative.
+			t.Role = bpv1.DataRoleStandby
+			t.StandbyType = bpv1.StandbyHot
+		default:
+			// Stateless: every occupied region serves traffic → Primary.
+			t.Role = bpv1.DataRolePrimary
+		}
+		targets = append(targets, t)
+	}
+
+	// Stable, deterministic order: Primaries first, then by region/cluster/
+	// vcluster — keeps the FE card order + DerivePattern repeatable.
+	sort.SliceStable(targets, func(i, j int) bool {
+		a, b := targets[i], targets[j]
+		if (a.Role == bpv1.DataRolePrimary) != (b.Role == bpv1.DataRolePrimary) {
+			return a.Role == bpv1.DataRolePrimary
+		}
+		if a.Region != b.Region {
+			return a.Region < b.Region
+		}
+		if a.Cluster != b.Cluster {
+			return a.Cluster < b.Cluster
+		}
+		return a.VCluster < b.VCluster
+	})
+	return targets
+}
+
+// podBelongsToComponent reports whether Pod p is part of the component
+// `name`. It mirrors the Resources tab's identity join: the
+// app.kubernetes.io/instance|name label (preserved verbatim by the loft
+// syncer even when the host Pod NAME is mangled), the de-mangled
+// in-vCluster object name, or the top-level ownerRef name. When `ns` is
+// non-empty the Pod must also belong to that app namespace (host ns OR the
+// loft-synced in-vCluster ns), reusing objectInAppNamespace.
+func podBelongsToComponent(p *unstructured.Unstructured, name, ns string) bool {
+	if p == nil || name == "" {
+		return false
+	}
+	if ns != "" && !objectInAppNamespace(p, ns) {
+		return false
+	}
+	if applicationKey(p) == name {
+		return true
+	}
+	if v := p.GetLabels()["app.kubernetes.io/name"]; v == name {
+		return true
+	}
+	// De-mangled in-vCluster object name (loft annotation), e.g. a host Pod
+	// `grafana-…-x-grafana-x-mgmt-vcluster` carries object-name
+	// `grafana-…`; its instance label already matched above in the common
+	// case, but charts that omit the instance label still resolve here via
+	// the synced Deployment/StatefulSet owner name prefix.
+	if dn := vClusterSyncedDisplayName(p); dn != "" && strings.HasPrefix(dn, name) {
+		return true
+	}
+	return false
+}
+
+// podRegion derives the region a Pod runs in: pod label → namespace label →
+// host Node's region labels → the cluster's declared cloudRegion fallback.
+// Mirrors buildPodRows' region join (the dashboard's proven path) so the
+// Topology tab and the treemap agree on region naming.
+func podRegion(p *unstructured.Unstructured, nsByName, nodeByName map[string]*unstructured.Unstructured, clusterCloudRegion string) string {
+	if v := p.GetLabels()["openova.io/region"]; v != "" {
+		return v
+	}
+	if ns, ok := nsByName[p.GetNamespace()]; ok {
+		if v := ns.GetLabels()["openova.io/region"]; v != "" {
+			return v
+		}
+	}
+	if nodeName, _, _ := unstructured.NestedString(p.Object, "spec", "nodeName"); nodeName != "" {
+		if n, ok := nodeByName[nodeName]; ok {
+			nl := n.GetLabels()
+			if v := nl["openova.io/region"]; v != "" {
+				return v
+			}
+			if v := nl["topology.kubernetes.io/region"]; v != "" {
+				return v
+			}
+			if v := nl["failure-domain.beta.kubernetes.io/region"]; v != "" {
+				return v
+			}
+		}
+	}
+	return clusterCloudRegion
+}
+
+// podVCluster derives the vCluster tier a Pod sits in (mgmt|dmz|rtz, or ""
+// for host-placed). For a loft-synced Pod the host namespace IS the tier
+// (mgmt/dmz/rtz) and the loft annotation confirms it; otherwise the host
+// namespace's catalyst.openova.io/vcluster-role label carries it (same join
+// buildPodRows uses). Empty = host-placed (no vCluster).
+func podVCluster(p *unstructured.Unstructured, nsByName map[string]*unstructured.Unstructured) string {
+	hostNS := p.GetNamespace()
+	for _, tier := range vClusterHostSyncNamespaces {
+		if hostNS == tier {
+			return tier
+		}
+	}
+	if ns, ok := nsByName[hostNS]; ok {
+		if v := ns.GetLabels()["catalyst.openova.io/vcluster-role"]; v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// cnpgInstanceRole returns the CNPG instance role of a Pod (primary|replica)
+// from the openova.io/cnpg-role label the bp-cnpg-pair / bp-postgres-shared
+// charts stamp on each half. Empty for non-CNPG Pods. Mirrors the
+// continuum_live.go cnpg contract.
+func cnpgInstanceRole(p *unstructured.Unstructured) string {
+	lbls := p.GetLabels()
+	if v := lbls[cnpgRoleLabel]; v == cnpgRolePrimary || v == cnpgRoleReplica {
+		return v
+	}
+	// CNPG's own operator label (upstream) — a secondary signal when the
+	// OpenOva pair-role label is absent on a shared/standalone Cluster.
+	if v := lbls["cnpg.io/instanceRole"]; v == "primary" || v == "replica" {
+		return v
+	}
+	if v := lbls["role"]; v == "primary" || v == "replica" {
+		// Legacy CNPG label; only trust it when paired with a cnpg cluster
+		// label so a generic `role` label on an unrelated pod can't leak in.
+		if lbls["cnpg.io/cluster"] != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// indexByName builds a name→object map for the namespace/node join lists.
+func indexByName(objs []*unstructured.Unstructured) map[string]*unstructured.Unstructured {
+	m := make(map[string]*unstructured.Unstructured, len(objs))
+	for _, o := range objs {
+		if o != nil {
+			m[o.GetName()] = o
+		}
+	}
+	return m
+}

--- a/products/catalyst/bootstrap/api/internal/handler/applications_placement_runtime_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_placement_runtime_test.go
@@ -1,0 +1,254 @@
+package handler
+
+// applications_placement_runtime_test.go (#3982) — locks the runtime
+// placement derivation: a component that runs in BOTH regions must surface
+// 2 targets (Pattern ≠ singleton), a CNPG pair must surface Primary +
+// Standby, and a genuinely single-region component must surface ONE target
+// (Pattern singleton — honest). These reproduce the hw173 failure: grafana
+// + keycloak ran in both regions yet the Topology tab showed singleton
+// because nothing populated placement from the live runtime.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	bpv1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/k8scache"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// placementFixturePod builds a Pod with the labels the derivation reads.
+func placementFixturePod(ns, name, instance, region, cnpgRole string) *unstructured.Unstructured {
+	lbls := map[string]any{
+		"app.kubernetes.io/instance": instance,
+	}
+	if region != "" {
+		lbls["openova.io/region"] = region
+	}
+	if cnpgRole != "" {
+		lbls["openova.io/cnpg-role"] = cnpgRole
+		lbls["cnpg.io/cluster"] = instance
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"namespace":         ns,
+			"name":              name,
+			"creationTimestamp": time.Now().Add(-time.Hour).UTC().Format(time.RFC3339),
+			"resourceVersion":   "1",
+			"labels":            lbls,
+		},
+		"spec": map[string]any{
+			"containers": []any{map[string]any{"name": "main", "image": "ghcr.io/x:1"}},
+		},
+		"status": map[string]any{
+			"phase":      "Running",
+			"conditions": []any{map[string]any{"type": "Ready", "status": "True"}},
+		},
+	}}
+}
+
+// newPlacementHandler stands up a Handler whose k8scache holds TWO region
+// clusters, each seeded with the supplied pods, plus a deployment record
+// declaring the two cloud regions (so the cluster→region fallback resolves).
+func newPlacementHandler(t *testing.T, depID, regionA, regionB string, podsA, podsB []*unstructured.Unstructured) *Handler {
+	t.Helper()
+
+	clusterA := depID
+	clusterB := depID + "-" + regionB
+
+	r := k8scache.NewRegistry()
+	_ = r.Add(k8scache.Kind{Name: "pod", GVR: schema.GroupVersionResource{Version: "v1", Resource: "pods"}, Namespaced: true})
+	_ = r.Add(k8scache.Kind{Name: "namespace", GVR: schema.GroupVersionResource{Version: "v1", Resource: "namespaces"}, Namespaced: false})
+	_ = r.Add(k8scache.Kind{Name: "node", GVR: schema.GroupVersionResource{Version: "v1", Resource: "nodes"}, Namespaced: false})
+
+	dynA, coreA := dashFixtureClients(toRuntimeObjs(podsA)...)
+	dynB, coreB := dashFixtureClients(toRuntimeObjs(podsB)...)
+
+	cfg := k8scache.Config{
+		Logger:   quietHandlerLogger(),
+		Registry: r,
+		Clusters: []k8scache.ClusterRef{
+			{ID: clusterA, DynamicClient: dynA, CoreClient: coreA},
+			{ID: clusterB, DynamicClient: dynB, CoreClient: coreB},
+		},
+	}
+	f, err := k8scache.NewFactory(cfg)
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	if err := f.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(f.Stop)
+
+	// Wait for both clusters' pod informers to sync.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		a, _, _ := f.List(clusterA, "pod", labels.Everything())
+		b, _, _ := f.List(clusterB, "pod", labels.Everything())
+		if len(a) >= len(podsA) && len(b) >= len(podsB) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	h := NewWithPDM(quietHandlerLogger(), &fakePDM{})
+	h.SetK8sCache(f, k8scache.NewSARCache(), "")
+	// Seed the deployment record so clusterRegionMap resolves both regions.
+	h.deployments.Store(depID, &Deployment{
+		ID: depID,
+		Request: provisioner.Request{
+			SovereignFQDN: "t99.omani.works",
+			Regions: []provisioner.RegionSpec{
+				{CloudRegion: regionA},
+				{CloudRegion: regionB},
+			},
+		},
+	})
+	return h
+}
+
+func toRuntimeObjs(pods []*unstructured.Unstructured) []runtime.Object {
+	out := make([]runtime.Object, 0, len(pods))
+	for _, p := range pods {
+		out = append(out, p)
+	}
+	return out
+}
+
+// callPlacement invokes HandleApplicationPlacement via a chi router so the
+// {id}/{name} URL params resolve.
+func callPlacement(t *testing.T, h *Handler, depID, name string) runtimePlacementResponse {
+	t.Helper()
+	router := chi.NewRouter()
+	router.Get("/api/v1/sovereigns/{id}/applications/{name}/placement", h.HandleApplicationPlacement)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+depID+"/applications/"+name+"/placement", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("placement: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp runtimePlacementResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, rec.Body.String())
+	}
+	return resp
+}
+
+// A stateless component running in BOTH regions must surface 2 targets,
+// both Primary → Pattern active-active (NOT singleton). This is the hw173
+// grafana/keycloak case.
+func TestPlacementRuntime_StatelessTwoRegions_NotSingleton(t *testing.T) {
+	depID := "dep-grafana-2region"
+	regionA, regionB := "me-east-215-a", "me-east-215-b"
+	h := newPlacementHandler(t, depID, regionA, regionB,
+		[]*unstructured.Unstructured{placementFixturePod("mgmt", "grafana-aaa", "grafana", regionA, "")},
+		[]*unstructured.Unstructured{placementFixturePod("mgmt", "grafana-bbb", "grafana", regionB, "")},
+	)
+
+	resp := callPlacement(t, h, depID, "grafana")
+	if len(resp.Targets) != 2 {
+		t.Fatalf("grafana targets: got %d want 2 (%+v)", len(resp.Targets), resp.Targets)
+	}
+	for _, tgt := range resp.Targets {
+		if tgt.Role != bpv1.DataRolePrimary {
+			t.Fatalf("grafana target %+v: role %q want Primary (stateless multi-region = multi-primary)", tgt, tgt.Role)
+		}
+	}
+	if got := bpv1.DerivePattern(resp.Targets, bpv1.CapabilityMultiPrimary); got == bpv1.PatternSingleton {
+		t.Fatalf("grafana pattern is singleton — the exact hw173 bug; targets=%+v", resp.Targets)
+	}
+	// Both regions represented.
+	regions := map[string]bool{}
+	for _, tgt := range resp.Targets {
+		regions[tgt.Region] = true
+	}
+	if !regions[regionA] || !regions[regionB] {
+		t.Fatalf("grafana regions: got %v want both %s + %s", regions, regionA, regionB)
+	}
+}
+
+// A CNPG pair (primary in region-a, replica in region-b) must surface a
+// Primary target + a Standby·Hot target → Pattern active-hot-standby.
+func TestPlacementRuntime_CNPGPair_PrimaryPlusStandby(t *testing.T) {
+	depID := "dep-cnpg-pair"
+	regionA, regionB := "me-east-215-a", "me-east-215-b"
+	h := newPlacementHandler(t, depID, regionA, regionB,
+		[]*unstructured.Unstructured{placementFixturePod("shared-data", "shared-pg-1", "shared-pg", regionA, "primary")},
+		[]*unstructured.Unstructured{placementFixturePod("shared-data", "shared-pg-2", "shared-pg", regionB, "replica")},
+	)
+
+	resp := callPlacement(t, h, depID, "shared-pg")
+	if len(resp.Targets) != 2 {
+		t.Fatalf("cnpg targets: got %d want 2 (%+v)", len(resp.Targets), resp.Targets)
+	}
+	var primaries, hotStandbys int
+	for _, tgt := range resp.Targets {
+		switch tgt.Role {
+		case bpv1.DataRolePrimary:
+			primaries++
+		case bpv1.DataRoleStandby:
+			if tgt.StandbyType == bpv1.StandbyHot {
+				hotStandbys++
+			}
+		}
+	}
+	if primaries != 1 || hotStandbys != 1 {
+		t.Fatalf("cnpg roles: primaries=%d hotStandbys=%d want 1+1 (%+v)", primaries, hotStandbys, resp.Targets)
+	}
+	if got := bpv1.DerivePattern(resp.Targets, bpv1.CapabilityPrimaryStandby); got != bpv1.PatternActiveHotStandby {
+		t.Fatalf("cnpg pattern: got %q want active-hot-standby (%+v)", got, resp.Targets)
+	}
+}
+
+// A genuinely single-region component surfaces ONE target → singleton.
+// This is the HONEST singleton (not the uniform false one).
+func TestPlacementRuntime_SingleRegion_HonestSingleton(t *testing.T) {
+	depID := "dep-single"
+	regionA, regionB := "me-east-215-a", "me-east-215-b"
+	h := newPlacementHandler(t, depID, regionA, regionB,
+		[]*unstructured.Unstructured{placementFixturePod("apps", "solo-xyz", "solo", regionA, "")},
+		[]*unstructured.Unstructured{}, // nothing in region-b
+	)
+
+	resp := callPlacement(t, h, depID, "solo")
+	if len(resp.Targets) != 1 {
+		t.Fatalf("single-region targets: got %d want 1 (%+v)", len(resp.Targets), resp.Targets)
+	}
+	if resp.Targets[0].Region != regionA {
+		t.Fatalf("single-region: region %q want %q", resp.Targets[0].Region, regionA)
+	}
+	if got := bpv1.DerivePattern(resp.Targets, bpv1.CapabilityPrimaryStandby); got != bpv1.PatternSingleton {
+		t.Fatalf("single-region pattern: got %q want singleton (%+v)", got, resp.Targets)
+	}
+}
+
+// A component that doesn't exist anywhere surfaces zero targets (empty, not
+// an error) — the FE then keeps its legacy fallback.
+func TestPlacementRuntime_Unknown_EmptyTargets(t *testing.T) {
+	depID := "dep-empty"
+	h := newPlacementHandler(t, depID, "me-east-215-a", "me-east-215-b",
+		[]*unstructured.Unstructured{placementFixturePod("mgmt", "grafana-aaa", "grafana", "me-east-215-a", "")},
+		[]*unstructured.Unstructured{},
+	)
+	resp := callPlacement(t, h, depID, "does-not-exist")
+	if len(resp.Targets) != 0 {
+		t.Fatalf("unknown component: got %d targets want 0 (%+v)", len(resp.Targets), resp.Targets)
+	}
+	if !resp.DerivedFromRuntime {
+		t.Fatalf("derivedFromRuntime must be true even when empty")
+	}
+}

--- a/products/catalyst/bootstrap/ui/src/lib/catalog.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/catalog.api.ts
@@ -508,6 +508,53 @@ export async function getApplicationStatus(
   return res.json()
 }
 
+/**
+ * RuntimePlacementResponse — #3982: the REAL placement targets derived
+ * from where the component's workloads actually run, across BOTH region
+ * clusters the catalyst-api holds in k8scache. Body of GET
+ * /sovereigns/{id}/applications/{name}/placement.
+ *
+ * `targets[]` is the #3969 PlacementTarget shape (region × cluster ×
+ * vCluster × role Primary|Standby, standby type Hot|Cold). The FE feeds it
+ * straight into `derivePattern` so the Topology tab renders the TRUE
+ * pattern (active-active for grafana/keycloak across 2 regions,
+ * active-hot-standby for a CNPG pair, singleton ONLY for a genuinely
+ * single-region component). Works for bootstrap HelmReleases (no
+ * Application CR) AND Application-CR installs because it keys on live Pods.
+ */
+export interface RuntimePlacementResponse {
+  targets: Array<{
+    region: string
+    cluster: string
+    vcluster?: string
+    role: 'Primary' | 'Standby'
+    standbyType?: 'Hot' | 'Cold'
+  }>
+  derivedFromRuntime: boolean
+}
+
+/**
+ * getApplicationPlacement — #3982. Fetch the runtime-derived placement
+ * targets for a component. Generic across every component the Topology tab
+ * renders. Returns null on any non-OK status so the caller can fall back to
+ * the legacy spec/status projection without throwing (the endpoint 200s
+ * with empty targets when the data plane is unavailable, so a thrown error
+ * here means a genuine transport failure).
+ */
+export async function getApplicationPlacement(
+  sovereignId: string,
+  name: string,
+  namespace?: string,
+): Promise<RuntimePlacementResponse | null> {
+  const params = new URLSearchParams()
+  if (namespace) params.set('namespace', namespace)
+  const qs = params.toString()
+  const url = `${applicationsBase(sovereignId)}/${encodeURIComponent(name)}/placement${qs ? '?' + qs : ''}`
+  const res = await authedFetch(url, { headers: { Accept: 'application/json' } })
+  if (!res.ok) return null
+  return res.json()
+}
+
 export function applicationStreamURL(
   sovereignId: string,
   name: string,

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.test.tsx
@@ -9,7 +9,7 @@
  * the status endpoint (the 404 loop). Keys on `isBootstrap`, never a
  * blueprint name.
  */
-import { describe, it, expect, afterEach, vi } from 'vitest'
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
 import { render, screen, cleanup, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
@@ -17,11 +17,13 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 const getApplicationStatus = vi.fn()
 const getCatalogItem = vi.fn()
+const getApplicationPlacement = vi.fn()
 const getHierarchicalInfrastructure = vi.fn()
 
 vi.mock('@/lib/catalog.api', () => ({
   getApplicationStatus: (...a: unknown[]) => getApplicationStatus(...a),
   getCatalogItem: (...a: unknown[]) => getCatalogItem(...a),
+  getApplicationPlacement: (...a: unknown[]) => getApplicationPlacement(...a),
 }))
 
 vi.mock('@/lib/infrastructure.types', () => ({
@@ -40,6 +42,13 @@ function withProviders(node: React.ReactNode) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return <QueryClientProvider client={qc}>{node}</QueryClientProvider>
 }
+
+beforeEach(() => {
+  // #3982 — default the runtime-placement endpoint to "no runtime targets"
+  // so the legacy spec/status projection still drives the existing asserts.
+  // Tests that exercise the runtime path override this per-case.
+  getApplicationPlacement.mockResolvedValue({ targets: [], derivedFromRuntime: true })
+})
 
 afterEach(() => {
   cleanup()
@@ -155,5 +164,66 @@ describe('TopologyTab — bootstrap HelmRelease status poll (#3656)', () => {
       expect(getApplicationStatus).toHaveBeenCalled()
     })
     expect(screen.queryByTestId('topology-tab-status-bootstrap')).toBeNull()
+  })
+})
+
+describe('TopologyTab — #3982 runtime-derived placement', () => {
+  it('a bootstrap component running in BOTH regions shows 2 targets, pattern ≠ singleton (the hw173 grafana bug)', async () => {
+    getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
+    // grafana: a bootstrap HelmRelease (no Application CR) whose pods run in
+    // BOTH regions. Before #3982 this fell to derivePattern([]) = singleton.
+    getApplicationPlacement.mockResolvedValue({
+      targets: [
+        { region: 'me-east-215-a', cluster: 'dep-x', vcluster: 'mgmt', role: 'Primary' },
+        { region: 'me-east-215-b', cluster: 'dep-x-b', vcluster: 'mgmt', role: 'Primary' },
+      ],
+      derivedFromRuntime: true,
+    })
+
+    render(
+      withProviders(
+        <TopologyTab sovereignId="dep-x" applicationName="grafana" namespace="mgmt" isBootstrap />,
+      ),
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-target-card-0')).toBeTruthy()
+    })
+    // TWO targets, both regions present.
+    expect(screen.getByTestId('topology-tab-target-card-1')).toBeTruthy()
+    expect(screen.queryByTestId('topology-tab-target-card-2')).toBeNull()
+    // Pattern is active-active (2 primaries), NOT the false singleton.
+    expect(screen.getByTestId('topology-tab-pattern').textContent).toBe('active-active')
+    expect(screen.getByTestId('topology-tab-pattern').textContent).not.toBe('singleton')
+    // The empty "No placement targets reported yet" state is gone.
+    expect(screen.queryByTestId('topology-tab-placement-empty')).toBeNull()
+  })
+
+  it('runtime targets override the legacy spec projection (reality wins)', async () => {
+    getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
+    // CR app whose spec says single-region, but the workloads actually run
+    // as a CNPG pair across 2 regions → runtime wins → active-hot-standby.
+    getApplicationStatus.mockResolvedValue({
+      name: 'shared-pg',
+      namespace: 'shared-data',
+      spec: { placement: { targets: [{ region: 'region-a', cluster: 'c', vcluster: 'host', role: 'Primary' }] } },
+      status: { placement: 'Reconciled' },
+    })
+    getApplicationPlacement.mockResolvedValue({
+      targets: [
+        { region: 'region-a', cluster: 'c', vcluster: 'host', role: 'Primary' },
+        { region: 'region-b', cluster: 'c-b', vcluster: 'host', role: 'Standby', standbyType: 'Hot' },
+      ],
+      derivedFromRuntime: true,
+    })
+
+    render(
+      withProviders(<TopologyTab sovereignId="dep-y" applicationName="shared-pg" namespace="shared-data" />),
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-target-card-1')).toBeTruthy()
+    })
+    expect(screen.getByTestId('topology-tab-pattern').textContent).toBe('active-hot-standby')
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
@@ -23,7 +23,12 @@
 import { useMemo, useState } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 
-import { getApplicationStatus, getCatalogItem, type CatalogItem } from '@/lib/catalog.api'
+import {
+  getApplicationPlacement,
+  getApplicationStatus,
+  getCatalogItem,
+  type CatalogItem,
+} from '@/lib/catalog.api'
 import { getHierarchicalInfrastructure } from '@/lib/infrastructure.types'
 import { PlacementEditor, type OwnedDependencyInfo } from '@/widgets/topology/PlacementEditor'
 import {
@@ -105,6 +110,26 @@ export function TopologyTab({
 
   const app: ApplicationStatus | undefined = initialApp ?? statusQ.data
 
+  // #3982 — the REAL placement, derived from where the component's
+  // workloads actually run across BOTH region clusters. This is the
+  // authoritative source for the target cards + the derived Pattern; it is
+  // what makes grafana/keycloak (running in 2 regions) render 2 targets
+  // instead of the old uniform false `singleton`. Generic: works for
+  // bootstrap HelmReleases (no Application CR) AND wizard installs, because
+  // the backend keys on live Pods. Falls back silently (null) to the legacy
+  // spec/status projection below when the data plane is unavailable.
+  const placementQ = useQuery({
+    queryKey: ['application-placement', sovereignId, applicationName, namespace, refreshTick],
+    queryFn: () => getApplicationPlacement(sovereignId, applicationName, namespace),
+    enabled: !disableNetwork && !!sovereignId && !!applicationName,
+    refetchInterval: 30_000,
+    retry: false,
+  })
+  const runtimeTargets: PlacementTarget[] = useMemo(() => {
+    const t = placementQ.data?.targets
+    return Array.isArray(t) ? (t as PlacementTarget[]) : []
+  }, [placementQ.data])
+
   // Pull the Blueprint card for placementCapability (gates >1 Primary).
   const blueprintRef = app?.spec?.blueprintRef
   const blueprintQ = useQuery({
@@ -128,9 +153,17 @@ export function TopologyTab({
     staleTime: 60_000,
   })
 
-  // The desired-state targets: prefer spec.placement.targets[] (#3969
-  // canonical); else project the legacy mode/regions or status rollup.
+  // The target list rendered by the Placement panel + fed to derivePattern.
+  // Priority (#3982):
+  //   1. RUNTIME-derived targets — where the component's workloads ACTUALLY
+  //      run, across both region clusters. Authoritative; this is what makes
+  //      grafana/keycloak show 2 targets instead of a false `singleton`.
+  //   2. spec.placement.targets[] — the #3969 desired-state the operator
+  //      explicitly chose in the editor (used pre-rollout / when the data
+  //      plane is unavailable).
+  //   3. legacy status.targets / mode+regions projection.
   const targets: PlacementTarget[] = useMemo(() => {
+    if (runtimeTargets.length > 0) return runtimeTargets
     const specPlacement = app?.spec?.placement
     if (specPlacement && typeof specPlacement === 'object') {
       const t = (specPlacement as Record<string, unknown>).targets
@@ -147,7 +180,7 @@ export function TopologyTab({
     const mode = typeof specPlacement === 'string' ? specPlacement : ((status.placement as string) ?? '')
     const regions = Array.isArray(app?.spec?.regions) ? app!.spec!.regions! : statusRegions.map((r) => r.name)
     return targetsFromLegacy({ mode, regions, statusRegions })
-  }, [app])
+  }, [app, runtimeTargets])
 
   const pattern = useMemo(() => derivePattern(targets), [targets])
 


### PR DESCRIPTION
## What

Wires the #3969 placement MODEL to **reality**. #3969 shipped the model
(`PlacementTarget` / `DerivePattern` / the FE `{Placement, Status}` shape) but
NOTHING populated the targets from the live runtime — so every component's
placement was empty and `DerivePattern([])` returned **`singleton`** uniformly,
even for grafana / keycloak that demonstrably run in BOTH regions of a 2-region
prov (proven live on hw173). This PR adds the runtime-derivation half.

## Data-flow trace (FE → API → runtime)

FE `TopologyTab.tsx` → `getApplicationPlacement()` (`catalog.api.ts`) →
`GET /api/v1/sovereigns/{id}/applications/{name}/placement` →
`HandleApplicationPlacement` (new `applications_placement_runtime.go`) →
`h.k8sCache` fan-out across **both** region clusters (`List("pod"|"namespace"|"node")`)
→ per-(region × cluster × vCluster) occupancy → honest roles → `PlacementTarget[]`.

The derivation reuses the **proven dashboard/treemap path**: the
`clusterID→cloudRegion` map from `Deployment.Request.Regions[]`, the
`applicationKey` identity join (the same label the Resources tab filters on —
loft preserves label VALUES even when it mangles the host Pod NAME), the
`openova.io/region` / Node-label region join, and the `openova.io/cnpg-role`
contract from `continuum_live.go`.

## Generic across every component (not special-cased)

Keys on **live Pods**, never an Application CR — so it covers bootstrap-kit
HelmReleases with NO Application CR (grafana/keycloak/harbor/gitea/…), CNPG
pairs, mgmt/dmz/rtz vCluster components, host-placed, single- AND multi-region.

## Honest role inference

- CNPG `primary` region → **Primary**; `replica` regions → **Standby·Hot** (the pair streams).
- Stateless replicated across N>1 regions (grafana/keycloak) → each region a **Primary** (active-active).
- Genuinely single-region → ONE target → `DerivePattern` yields **singleton** (correct, honest).

## Per-component rendered before → after

| Component | runs in | BEFORE | AFTER |
|---|---|---|---|
| grafana (bootstrap HR) | region-a + region-b | 0 targets, **singleton** | 2 targets, **active-active** |
| keycloak | region-a + region-b | 0 targets, **singleton** | 2 targets, **active-active** |
| cnpg pair (shared-pg) | primary-a + replica-b | 0 targets, **singleton** | Primary + Standby·Hot, **active-hot-standby** |
| true single-region | one region | **singleton** | 1 target, **singleton** (honest) |

## MUST-PRESERVE — zero regression

- #3969 model files (`placement_target.go`, `recon_status.go`) **untouched** — their tests still green.
- FE `TopologyTab` single-panel `{Placement, Status}` shape preserved; **no** declared/observed/effective/mode/DR/"Disaster Recovery"/DEGRADED-mandate machinery reintroduced (the only matches for those words are the pre-existing #3969 header comment documenting the deletion + the ordinary-English "declared Regions[]").
- Purely additive — runtime-derivation is layered above the legacy spec/status fallback (which still drives when the data plane is unavailable).

## Gates

- `go build ./...` + `go vet ./...` (api module) = 0
- `go test ./internal/handler/` = pass (incl. 4 new runtime-placement tests); #3969 model package = pass
- FE `tsc -b` = 0, `npm run build` = 0, eslint changed = 0, vitest TopologyTab + placement = 21 pass

Refs #3982 + Refs #3969
