### PR TITLE
fix(topology): placement matcher resolves bp-prefixed id against bare loft-synced pods (#3986)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications_placement_runtime.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_placement_runtime.go
@@ -273,6 +273,38 @@ func (h *Handler) derivePlacementTargets(name, ns, primaryID string, clusterRegi
 	return targets
 }
 
+// componentNameCandidates returns the identity strings a Pod may carry for
+// the component the FE asked about. The Topology tab passes the AppDetail
+// ROUTE id, which for bootstrap-kit components is the Blueprint name
+// `bp-<chart>` (e.g. `bp-grafana`) — the route + Dashboard lookup both key
+// on the `bp-`-prefixed id (see Dashboard.test.tsx "route param is
+// `bp-harbor`, NOT bare `harbor`"). But the live Pods — including the
+// loft-synced ones in mgmt/dmz/rtz host namespaces — carry the BARE upstream
+// chart identity (`app.kubernetes.io/instance=grafana`,
+// `app.kubernetes.io/name=grafana`, in-vCluster object name `grafana-…`).
+//
+// #3986: the pre-#3986 matcher compared the raw `bp-grafana` against the
+// bare `grafana` label/key and matched NOTHING → empty targets → false
+// singleton (proven live on hw173: `…/applications/bp-grafana/placement`
+// returned `{"targets":[]}` while `…/applications/grafana/placement`
+// returned a target). We normalise the same way every other handler does
+// (`strings.TrimPrefix(name, "bp-")`, mirroring LogsTab's
+// `blueprint.replace(/^bp-/, '')` and the resource-list path) and accept
+// EITHER form, so a wizard-installed app named without the prefix AND a
+// bootstrap-kit `bp-`-routed app both resolve to the same pods the Resources
+// tab shows. Deduped, non-empty entries only.
+func componentNameCandidates(name string) []string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil
+	}
+	out := []string{name}
+	if bare := strings.TrimPrefix(name, "bp-"); bare != "" && bare != name {
+		out = append(out, bare)
+	}
+	return out
+}
+
 // podBelongsToComponent reports whether Pod p is part of the component
 // `name`. It mirrors the Resources tab's identity join: the
 // app.kubernetes.io/instance|name label (preserved verbatim by the loft
@@ -280,6 +312,14 @@ func (h *Handler) derivePlacementTargets(name, ns, primaryID string, clusterRegi
 // in-vCluster object name, or the top-level ownerRef name. When `ns` is
 // non-empty the Pod must also belong to that app namespace (host ns OR the
 // loft-synced in-vCluster ns), reusing objectInAppNamespace.
+//
+// #3986: the FE passes the AppDetail route id, which for bootstrap-kit
+// components is `bp-<chart>` while the live (incl. loft-synced) Pods carry
+// the BARE chart identity. We therefore match against BOTH the raw and the
+// `bp-`-stripped form (componentNameCandidates) so grafana et al. — synced
+// as `grafana-…-x-grafana-x-mgmt-vcluster` in host ns `mgmt` but still
+// labelled `app.kubernetes.io/{instance,name}=grafana` — resolve instead of
+// yielding a false singleton.
 func podBelongsToComponent(p *unstructured.Unstructured, name, ns string) bool {
 	if p == nil || name == "" {
 		return false
@@ -287,19 +327,24 @@ func podBelongsToComponent(p *unstructured.Unstructured, name, ns string) bool {
 	if ns != "" && !objectInAppNamespace(p, ns) {
 		return false
 	}
-	if applicationKey(p) == name {
-		return true
-	}
-	if v := p.GetLabels()["app.kubernetes.io/name"]; v == name {
-		return true
-	}
-	// De-mangled in-vCluster object name (loft annotation), e.g. a host Pod
-	// `grafana-…-x-grafana-x-mgmt-vcluster` carries object-name
-	// `grafana-…`; its instance label already matched above in the common
-	// case, but charts that omit the instance label still resolve here via
-	// the synced Deployment/StatefulSet owner name prefix.
-	if dn := vClusterSyncedDisplayName(p); dn != "" && strings.HasPrefix(dn, name) {
-		return true
+	appKey := applicationKey(p)
+	chartName := p.GetLabels()["app.kubernetes.io/name"]
+	// The de-mangled in-vCluster object name (loft annotation), e.g. a host
+	// Pod `grafana-…-x-grafana-x-mgmt-vcluster` carries object-name
+	// `grafana-…`. The instance/name labels match in the common case; this
+	// resolves charts that omit the instance label via the synced
+	// Deployment/StatefulSet owner name prefix.
+	displayName := vClusterSyncedDisplayName(p)
+	for _, cand := range componentNameCandidates(name) {
+		if appKey == cand {
+			return true
+		}
+		if chartName == cand {
+			return true
+		}
+		if displayName != "" && strings.HasPrefix(displayName, cand) {
+			return true
+		}
 	}
 	return false
 }

--- a/products/catalyst/bootstrap/api/internal/handler/applications_placement_runtime_livedata_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_placement_runtime_livedata_test.go
@@ -1,0 +1,233 @@
+package handler
+
+// applications_placement_runtime_livedata_test.go (#3986) — the LIVE-DATA
+// proof. These tests load the ACTUAL grafana / keycloak Pod objects (plus
+// the real host Nodes + the `mgmt` Namespace) captured from BOTH regions of
+// hw173 (a 2-region prov) on 2026-06-20, seed them into a 2-cluster
+// k8scache, and run them through the REAL derivePlacementTargets matcher.
+//
+// They reproduce the exact #3986 live symptom — `…/applications/bp-grafana/
+// placement?namespace=mgmt` returned `{"targets":[]}` (false singleton) on
+// image 3a1bb63 — and lock the fix: the bp-prefixed AppDetail route id must
+// resolve the bare-labelled, loft-synced pods so grafana/keycloak surface 2
+// targets. Unlike the synthetic fixtures, these are byte-for-byte the live
+// host Pods: mangled name `grafana-…-x-grafana-x-mgmt-vcluster`, host ns
+// `mgmt`, labels app.kubernetes.io/{instance,name}=grafana, the full loft
+// annotation set, and region resolved off the REAL host Node label
+// (the pods carry no openova.io/region label — the Node fallback is what
+// makes region-a vs region-b distinct).
+//
+// testdata/hw173_3986/ holds the captured JSON (grafana-{a,b}.json,
+// keycloak-{a,b}.json, nodes-{a,b}.json, ns-mgmt-{a,b}.json).
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	bpv1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/k8scache"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// loadLiveList reads a captured `kubectl get -o json` file and returns its
+// items as runtime.Objects (or the single object when the file is not a
+// List). Fatal on any read/parse error — these are checked-in fixtures.
+func loadLiveList(t *testing.T, rel string) []runtime.Object {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("testdata", "hw173_3986", rel))
+	if err != nil {
+		t.Fatalf("read %s: %v", rel, err)
+	}
+	var top map[string]any
+	if err := json.Unmarshal(b, &top); err != nil {
+		t.Fatalf("parse %s: %v", rel, err)
+	}
+	if items, ok := top["items"].([]any); ok {
+		out := make([]runtime.Object, 0, len(items))
+		for _, it := range items {
+			m, ok := it.(map[string]any)
+			if !ok {
+				continue
+			}
+			out = append(out, &unstructured.Unstructured{Object: m})
+		}
+		return out
+	}
+	return []runtime.Object{&unstructured.Unstructured{Object: top}}
+}
+
+// newLivePlacementHandler seeds a 2-cluster k8scache with the captured
+// pods/nodes/namespace for each region and a deployment record declaring the
+// two real cloud regions, then returns a Handler wired to it.
+func newLivePlacementHandler(t *testing.T, depID, regionA, regionB string, objsA, objsB []runtime.Object) *Handler {
+	t.Helper()
+
+	clusterA := depID
+	clusterB := depID + "-" + regionB
+
+	r := k8scache.NewRegistry()
+	_ = r.Add(k8scache.Kind{Name: "pod", GVR: schema.GroupVersionResource{Version: "v1", Resource: "pods"}, Namespaced: true})
+	_ = r.Add(k8scache.Kind{Name: "namespace", GVR: schema.GroupVersionResource{Version: "v1", Resource: "namespaces"}, Namespaced: false})
+	_ = r.Add(k8scache.Kind{Name: "node", GVR: schema.GroupVersionResource{Version: "v1", Resource: "nodes"}, Namespaced: false})
+
+	dynA, coreA := dashFixtureClients(objsA...)
+	dynB, coreB := dashFixtureClients(objsB...)
+
+	cfg := k8scache.Config{
+		Logger:   quietHandlerLogger(),
+		Registry: r,
+		Clusters: []k8scache.ClusterRef{
+			{ID: clusterA, DynamicClient: dynA, CoreClient: coreA},
+			{ID: clusterB, DynamicClient: dynB, CoreClient: coreB},
+		},
+	}
+	f, err := k8scache.NewFactory(cfg)
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	if err := f.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(f.Stop)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		a, _, _ := f.List(clusterA, "pod", labels.Everything())
+		b, _, _ := f.List(clusterB, "pod", labels.Everything())
+		if len(a) >= 1 && len(b) >= 1 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	h := NewWithPDM(quietHandlerLogger(), &fakePDM{})
+	h.SetK8sCache(f, k8scache.NewSARCache(), "")
+	h.deployments.Store(depID, &Deployment{
+		ID: depID,
+		Request: provisioner.Request{
+			SovereignFQDN: "hw173.omani.works",
+			Regions: []provisioner.RegionSpec{
+				{CloudRegion: regionA},
+				{CloudRegion: regionB},
+			},
+		},
+	})
+	return h
+}
+
+// componentLiveTargets builds the per-region object sets (pods + node + ns)
+// for `component` and resolves placement targets through the REAL handler.
+func componentLiveTargets(t *testing.T, component, queryName string) runtimePlacementResponse {
+	t.Helper()
+	depID := "7bb723da8da06047"
+	// The REAL hw173 node labels: region-a nodes carry
+	// topology.kubernetes.io/region=me-east-215-a, region-b =…-b. The
+	// deployment record's CloudRegion only feeds the cluster fallback; the
+	// authoritative per-pod region join is the host Node label below.
+	regionA, regionB := "me-east-215-a", "me-east-215-b"
+
+	objsA := loadLiveList(t, component+"-a.json")
+	objsA = append(objsA, loadLiveList(t, "nodes-a.json")...)
+	objsA = append(objsA, loadLiveList(t, "ns-mgmt-a.json")...)
+
+	objsB := loadLiveList(t, component+"-b.json")
+	objsB = append(objsB, loadLiveList(t, "nodes-b.json")...)
+	objsB = append(objsB, loadLiveList(t, "ns-mgmt-b.json")...)
+
+	h := newLivePlacementHandler(t, depID, regionA, regionB, objsA, objsB)
+	return callPlacement(t, h, depID, queryName)
+}
+
+// TestPlacementRuntime_LiveHw173Grafana_BpPrefixed_2Targets is the canonical
+// #3986 live-data proof: the REAL grafana pods from both hw173 regions,
+// queried with the REAL bp-prefixed route id, must surface 2 targets.
+func TestPlacementRuntime_LiveHw173Grafana_BpPrefixed_2Targets(t *testing.T) {
+	resp := componentLiveTargets(t, "grafana", "bp-grafana")
+	if len(resp.Targets) != 2 {
+		t.Fatalf("LIVE bp-grafana targets: got %d want 2 — the #3986 false-singleton bug; targets=%+v",
+			len(resp.Targets), resp.Targets)
+	}
+	regions := map[string]bool{}
+	for _, tgt := range resp.Targets {
+		if tgt.Role != bpv1.DataRolePrimary {
+			t.Fatalf("LIVE bp-grafana target %+v: role %q want Primary", tgt, tgt.Role)
+		}
+		regions[tgt.Region] = true
+	}
+	if len(regions) != 2 {
+		t.Fatalf("LIVE bp-grafana: got regions %v want 2 distinct (region-a + region-b); targets=%+v", regions, resp.Targets)
+	}
+	if got := bpv1.DerivePattern(resp.Targets, bpv1.CapabilityMultiPrimary); got == bpv1.PatternSingleton {
+		t.Fatalf("LIVE bp-grafana pattern is singleton — the #3986 bug; targets=%+v", resp.Targets)
+	}
+	t.Logf("LIVE bp-grafana -> %d targets, regions=%v (PASS)", len(resp.Targets), regions)
+}
+
+// Bare `grafana` (the wizard-install form / what the pre-fix endpoint already
+// half-resolved) must ALSO surface both regions — proving the fix is additive
+// and the bare path still works.
+func TestPlacementRuntime_LiveHw173Grafana_Bare_2Targets(t *testing.T) {
+	resp := componentLiveTargets(t, "grafana", "grafana")
+	if len(resp.Targets) != 2 {
+		t.Fatalf("LIVE grafana (bare) targets: got %d want 2; targets=%+v", len(resp.Targets), resp.Targets)
+	}
+}
+
+// The REAL keycloak StatefulSet pods (keycloak-0-x-keycloak-x-mgmt-vcluster)
+// from both regions, queried bp-prefixed, must surface 2 targets.
+func TestPlacementRuntime_LiveHw173Keycloak_BpPrefixed_2Targets(t *testing.T) {
+	resp := componentLiveTargets(t, "keycloak", "bp-keycloak")
+	if len(resp.Targets) != 2 {
+		t.Fatalf("LIVE bp-keycloak targets: got %d want 2 — #3986; targets=%+v", len(resp.Targets), resp.Targets)
+	}
+	regions := map[string]bool{}
+	for _, tgt := range resp.Targets {
+		regions[tgt.Region] = true
+	}
+	if len(regions) != 2 {
+		t.Fatalf("LIVE bp-keycloak: got regions %v want 2 distinct; targets=%+v", regions, resp.Targets)
+	}
+}
+
+// NO-REGRESSION cross-check: a genuine control-plane single-region component
+// must STAY a singleton. catalyst-api runs in region-a ONLY (oracle: "A-only
+// (control plane)", 1 target, singleton). The #3986 bp- strip must NOT
+// fabricate a second target — the bp-stripped form `catalyst-api` matches the
+// SAME single A-only pod, never an extra region. Uses the REAL hw173
+// catalyst-api pod (region-a) + an empty region-b set.
+func TestPlacementRuntime_LiveHw173CatalystApi_StaysSingleton(t *testing.T) {
+	depID := "7bb723da8da06047"
+	regionA, regionB := "me-east-215-a", "me-east-215-b"
+
+	objsA := loadLiveList(t, "capi-a.json")
+	objsA = append(objsA, loadLiveList(t, "nodes-a.json")...)
+	objsA = append(objsA, loadLiveList(t, "ns-catalyst-system-a.json")...)
+
+	// region-b: catalyst-api absent (capi-b.json is an empty List) — only the
+	// nodes + ns are present, mirroring the live "0 pods in B" ground truth.
+	objsB := loadLiveList(t, "capi-b.json")
+	objsB = append(objsB, loadLiveList(t, "nodes-b.json")...)
+	objsB = append(objsB, loadLiveList(t, "ns-catalyst-system-b.json")...)
+
+	h := newLivePlacementHandler(t, depID, regionA, regionB, objsA, objsB)
+
+	for _, q := range []string{"bp-catalyst-api", "catalyst-api"} {
+		resp := callPlacement(t, h, depID, q)
+		if len(resp.Targets) != 1 {
+			t.Fatalf("LIVE %s targets: got %d want 1 (must STAY singleton, A-only control plane); targets=%+v",
+				q, len(resp.Targets), resp.Targets)
+		}
+		if got := bpv1.DerivePattern(resp.Targets, bpv1.CapabilityPrimaryStandby); got != bpv1.PatternSingleton {
+			t.Fatalf("LIVE %s pattern: got %q want singleton (honest single-region); targets=%+v", q, got, resp.Targets)
+		}
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/applications_placement_runtime_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_placement_runtime_test.go
@@ -181,6 +181,135 @@ func TestPlacementRuntime_StatelessTwoRegions_NotSingleton(t *testing.T) {
 	}
 }
 
+// loftSyncedFixturePod builds a Pod with the EXACT shape a per-tier
+// vCluster (#3642) syncs down into its HOST namespace: the mangled host name
+// (`<name>-x-<chart>-x-<vcluster>`), the host namespace `mgmt`, the upstream
+// chart labels preserved verbatim by the loft syncer
+// (app.kubernetes.io/{instance,name}=<chart>), and the loft object-* /
+// host-* annotations. This reproduces the REAL hw173 grafana pod
+// (`grafana-6f94dbbd8f-zs8fr-x-grafana-x-mgmt-vcluster`, host ns `mgmt`,
+// labels instance=grafana name=grafana) — NOT a clean non-synced mock, which
+// is exactly the gap the #3984 tests missed.
+func loftSyncedFixturePod(hostNS, chart, mangledName, inVClusterNS, inVClusterName, vcluster, region string) *unstructured.Unstructured {
+	lbls := map[string]any{
+		"app.kubernetes.io/instance":  chart,
+		"app.kubernetes.io/name":      chart,
+		"vcluster.loft.sh/managed-by": vcluster,
+		"vcluster.loft.sh/namespace":  inVClusterNS,
+	}
+	if region != "" {
+		// On hw173 the synced Pod itself does NOT carry openova.io/region;
+		// the region resolves off the host Node. We seed it here only so the
+		// unit test's region join is deterministic without a Node fixture —
+		// the live path exercises the Node fallback (verified separately).
+		lbls["openova.io/region"] = region
+	}
+	anns := map[string]any{
+		"vcluster.loft.sh/object-name":           inVClusterName,
+		"vcluster.loft.sh/object-namespace":      inVClusterNS,
+		"vcluster.loft.sh/object-host-namespace": hostNS,
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"namespace":         hostNS,
+			"name":              mangledName,
+			"creationTimestamp": time.Now().Add(-time.Hour).UTC().Format(time.RFC3339),
+			"resourceVersion":   "1",
+			"labels":            lbls,
+			"annotations":       anns,
+		},
+		"spec": map[string]any{
+			"containers": []any{map[string]any{"name": "grafana", "image": "ghcr.io/x:1"}},
+		},
+		"status": map[string]any{
+			"phase":      "Running",
+			"conditions": []any{map[string]any{"type": "Ready", "status": "True"}},
+		},
+	}}
+}
+
+// TestPlacementRuntime_LoftSyncedGrafana_BpPrefixed_TwoRegions is the #3986
+// reproduction: the FE asks for the `bp-`-prefixed AppDetail route id
+// (`bp-grafana`) but the live, loft-synced grafana pods in BOTH regions are
+// labelled bare `grafana`. The pre-#3986 matcher compared `bp-grafana`
+// against `grafana` and matched NOTHING → `{"targets":[]}` → false singleton
+// (the live hw173 symptom). After the fix it must surface 2 targets,
+// Pattern ≠ singleton. Uses the REAL loft pod shape, queried with the REAL
+// `bp-grafana` id — the two facts the #3984 tests both omitted.
+func TestPlacementRuntime_LoftSyncedGrafana_BpPrefixed_TwoRegions(t *testing.T) {
+	depID := "dep-grafana-loft"
+	regionA, regionB := "me-east-215-a", "me-east-215-b"
+	h := newPlacementHandler(t, depID, regionA, regionB,
+		[]*unstructured.Unstructured{loftSyncedFixturePod(
+			"mgmt", "grafana",
+			"grafana-6f94dbbd8f-zs8fr-x-grafana-x-mgmt-vcluster",
+			"grafana", "grafana-6f94dbbd8f-zs8fr", "mgmt-vcluster", regionA)},
+		[]*unstructured.Unstructured{loftSyncedFixturePod(
+			"mgmt", "grafana",
+			"grafana-5b9f9b5d4b-xp844-x-grafana-x-mgmt-vcluster",
+			"grafana", "grafana-5b9f9b5d4b-xp844", "mgmt-vcluster", regionB)},
+	)
+
+	// Query with the BP-PREFIXED id the FE actually sends (the route id),
+	// scoped to host ns `mgmt` exactly as the live capture did.
+	router := chi.NewRouter()
+	router.Get("/api/v1/sovereigns/{id}/applications/{name}/placement", h.HandleApplicationPlacement)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+depID+"/applications/bp-grafana/placement?namespace=mgmt", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("placement: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp runtimePlacementResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, rec.Body.String())
+	}
+
+	if len(resp.Targets) != 2 {
+		t.Fatalf("bp-grafana (loft-synced) targets: got %d want 2 — the exact #3986 bug; targets=%+v",
+			len(resp.Targets), resp.Targets)
+	}
+	regions := map[string]bool{}
+	for _, tgt := range resp.Targets {
+		if tgt.Role != bpv1.DataRolePrimary {
+			t.Fatalf("bp-grafana target %+v: role %q want Primary (stateless multi-region)", tgt, tgt.Role)
+		}
+		if tgt.VCluster != "mgmt" {
+			t.Fatalf("bp-grafana target %+v: vcluster %q want mgmt (loft host ns)", tgt, tgt.VCluster)
+		}
+		regions[tgt.Region] = true
+	}
+	if !regions[regionA] || !regions[regionB] {
+		t.Fatalf("bp-grafana regions: got %v want both %s + %s", regions, regionA, regionB)
+	}
+	if got := bpv1.DerivePattern(resp.Targets, bpv1.CapabilityMultiPrimary); got == bpv1.PatternSingleton {
+		t.Fatalf("bp-grafana pattern is singleton — the #3986 live bug; targets=%+v", resp.Targets)
+	}
+}
+
+// TestPlacementRuntime_LoftSyncedKeycloak_BpPrefixed mirrors the grafana case
+// for the keycloak StatefulSet pod (`keycloak-0-x-keycloak-x-mgmt-vcluster`),
+// the other component the issue calls out as falsely singleton.
+func TestPlacementRuntime_LoftSyncedKeycloak_BpPrefixed(t *testing.T) {
+	depID := "dep-keycloak-loft"
+	regionA, regionB := "me-east-215-a", "me-east-215-b"
+	h := newPlacementHandler(t, depID, regionA, regionB,
+		[]*unstructured.Unstructured{loftSyncedFixturePod(
+			"mgmt", "keycloak", "keycloak-0-x-keycloak-x-mgmt-vcluster",
+			"keycloak", "keycloak-0", "mgmt-vcluster", regionA)},
+		[]*unstructured.Unstructured{loftSyncedFixturePod(
+			"mgmt", "keycloak", "keycloak-0-x-keycloak-x-mgmt-vcluster",
+			"keycloak", "keycloak-0", "mgmt-vcluster", regionB)},
+	)
+	resp := callPlacement(t, h, depID, "bp-keycloak")
+	if len(resp.Targets) != 2 {
+		t.Fatalf("bp-keycloak (loft-synced) targets: got %d want 2; targets=%+v", len(resp.Targets), resp.Targets)
+	}
+}
+
 // A CNPG pair (primary in region-a, replica in region-b) must surface a
 // Primary target + a Standby·Hot target → Pattern active-hot-standby.
 func TestPlacementRuntime_CNPGPair_PrimaryPlusStandby(t *testing.T) {

--- a/products/catalyst/bootstrap/api/internal/handler/testdata/hw173_3986/capi-a.json
+++ b/products/catalyst/bootstrap/api/internal/handler/testdata/hw173_3986/capi-a.json
@@ -1,0 +1,992 @@
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "creationTimestamp": "2026-06-20T14:38:29Z",
+                "generateName": "catalyst-api-7db77c9859-",
+                "labels": {
+                    "app.kubernetes.io/name": "catalyst-api",
+                    "catalyst.openova.io/application": "catalyst-api",
+                    "pod-template-hash": "7db77c9859",
+                    "policy.cilium.io/enforced": "true"
+                },
+                "name": "catalyst-api-7db77c9859-x46ng",
+                "namespace": "catalyst-system",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "blockOwnerDeletion": true,
+                        "controller": true,
+                        "kind": "ReplicaSet",
+                        "name": "catalyst-api-7db77c9859",
+                        "uid": "0bff99ee-332b-4332-8353-16f1ab9d39b3"
+                    }
+                ],
+                "resourceVersion": "860884",
+                "uid": "83e0c0c2-d107-4c7f-8f44-fabf655ec657"
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "env": [
+                            {
+                                "name": "PORT",
+                                "value": "8080"
+                            },
+                            {
+                                "name": "OPENOVA_FLOW_SERVER_URL",
+                                "value": "http://openova-flow-server.catalyst-system.svc.cluster.local"
+                            },
+                            {
+                                "name": "CATALYST_BUILD_SHA",
+                                "value": "3a1bb63"
+                            },
+                            {
+                                "name": "CATALYST_CHART_VERSION",
+                                "value": "1.4.95"
+                            },
+                            {
+                                "name": "CORS_ORIGIN",
+                                "valueFrom": {
+                                    "configMapKeyRef": {
+                                        "key": "sovereign-console-url",
+                                        "name": "catalyst-runtime-config",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "DYNADOT_API_KEY",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "api-key",
+                                        "name": "dynadot-api-credentials",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "DYNADOT_API_SECRET",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "api-secret",
+                                        "name": "dynadot-api-credentials",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "DYNADOT_MANAGED_DOMAINS",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "domains",
+                                        "name": "dynadot-api-credentials",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "DYNADOT_DOMAIN",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "domain",
+                                        "name": "dynadot-api-credentials",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_TOFU_WORKDIR",
+                                "value": "/var/lib/catalyst/tofu"
+                            },
+                            {
+                                "name": "CATALYST_HUAWEI_NAT_EIP_STATE",
+                                "value": "/var/lib/catalyst/tofu/nat-eip-blocklist.json"
+                            },
+                            {
+                                "name": "CATALYST_TF_PLUGIN_CACHE_DIR",
+                                "value": "/var/lib/catalyst/tofu-plugin-cache"
+                            },
+                            {
+                                "name": "CATALYST_DEPLOYMENTS_DIR",
+                                "value": "/var/lib/catalyst/deployments"
+                            },
+                            {
+                                "name": "CATALYST_PHASE1_MIN_BOOTSTRAP_KIT_HRS",
+                                "value": "1"
+                            },
+                            {
+                                "name": "CATALYST_PHASE1_WATCH_TIMEOUT",
+                                "value": "120m"
+                            },
+                            {
+                                "name": "CATALYST_KUBECONFIGS_DIR",
+                                "value": "/var/lib/catalyst/kubeconfigs"
+                            },
+                            {
+                                "name": "CATALYST_API_PUBLIC_URL",
+                                "valueFrom": {
+                                    "configMapKeyRef": {
+                                        "key": "sovereign-api-public-url",
+                                        "name": "catalyst-runtime-config"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_NATS_URL",
+                                "value": "nats://nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc.cluster.local:4222"
+                            },
+                            {
+                                "name": "CATALYST_K8SCACHE_KUBECONFIGS_DIR",
+                                "value": "/var/lib/catalyst/kubeconfigs"
+                            },
+                            {
+                                "name": "CATALYST_K8SCACHE_SNAPSHOT_DIR",
+                                "value": "/var/cache/sov-cache"
+                            },
+                            {
+                                "name": "CATALYST_K8SCACHE_KINDS_CONFIGMAP",
+                                "value": "catalyst-k8scache-kinds"
+                            },
+                            {
+                                "name": "CATALYST_K8SCACHE_KINDS_CONFIGMAP_NAMESPACE",
+                                "value": "catalyst"
+                            },
+                            {
+                                "name": "CATALYST_GHCR_PULL_TOKEN",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "token",
+                                        "name": "catalyst-ghcr-pull-token",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_HARBOR_ROBOT_TOKEN",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "token",
+                                        "name": "harbor-robot-token"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_HUAWEI_ACCESS_KEY",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "access_key",
+                                        "name": "huawei-operator-creds",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_HUAWEI_SECRET_KEY",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "secret_key",
+                                        "name": "huawei-operator-creds",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_HUAWEI_PROJECT_ID",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "project_id",
+                                        "name": "huawei-operator-creds",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_HUAWEI_REGION",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "region",
+                                        "name": "huawei-operator-creds",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_POWERDNS_API_KEY",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "api-key",
+                                        "name": "powerdns-api-credentials",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_POWERDNS_API_URL",
+                                "value": "http://powerdns.powerdns.svc.cluster.local:8081"
+                            },
+                            {
+                                "name": "CATALYST_POWERDNS_SERVER_ID",
+                                "value": "localhost"
+                            },
+                            {
+                                "name": "CATALYST_KC_ADDR",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "addr",
+                                        "name": "catalyst-kc-sa-credentials",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_KC_REALM",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "realm",
+                                        "name": "catalyst-kc-sa-credentials",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_KC_SA_CLIENT_ID",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "client-id",
+                                        "name": "catalyst-kc-sa-credentials",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_KC_SA_CLIENT_SECRET",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "client-secret",
+                                        "name": "catalyst-kc-sa-credentials",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_OIDC_PROVIDER_ENABLED",
+                                "value": "true"
+                            },
+                            {
+                                "name": "CATALYST_PIN_BROKER_CLIENT_ID",
+                                "value": "catalyst-pin"
+                            },
+                            {
+                                "name": "CATALYST_PIN_BROKER_CLIENT_SECRET",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "client-secret",
+                                        "name": "catalyst-pin-broker-credentials",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_GITEA_URL",
+                                "value": "http://gitea-http.gitea.svc.cluster.local:3000"
+                            },
+                            {
+                                "name": "CATALYST_GITEA_TOKEN",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "token",
+                                        "name": "catalyst-gitea-token",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_SME_JWT_SECRET",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "JWT_SECRET",
+                                        "name": "org-services-secrets",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_NEWAPI_ADDR",
+                                "value": "http://newapi-bp-newapi.newapi.svc.cluster.local:3000"
+                            },
+                            {
+                                "name": "CATALYST_NEWAPI_ADMIN_TOKEN",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "ADMIN_API_TOKEN",
+                                        "name": "catalyst-newapi-admin-token",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "KC_BOOTSTRAP_TIER_ROLES",
+                                "value": "false"
+                            },
+                            {
+                                "name": "CATALYST_HANDOVER_JWT_PUBLIC_PATH",
+                                "value": "/etc/catalyst/handover-jwt-public/public.jwk"
+                            },
+                            {
+                                "name": "CATALYST_OPENBAO_ADDR",
+                                "value": "http://openbao.openbao.svc.cluster.local:8200"
+                            },
+                            {
+                                "name": "CATALYST_OPENBAO_K8S_AUTH_ROLE",
+                                "value": "catalyst-api"
+                            },
+                            {
+                                "name": "SOVEREIGN_FQDN",
+                                "valueFrom": {
+                                    "configMapKeyRef": {
+                                        "key": "fqdn",
+                                        "name": "sovereign-fqdn",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "SOVEREIGN_REGIONS_JSON",
+                                "valueFrom": {
+                                    "configMapKeyRef": {
+                                        "key": "regionsJson",
+                                        "name": "sovereign-fqdn",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "OPERATOR_EMAIL",
+                                "valueFrom": {
+                                    "configMapKeyRef": {
+                                        "key": "orgEmail",
+                                        "name": "sovereign-fqdn",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "SOVEREIGN_CONTROL_PLANE_IP",
+                                "valueFrom": {
+                                    "configMapKeyRef": {
+                                        "key": "controlPlaneIP",
+                                        "name": "sovereign-fqdn",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "GITOPS_REPO_URL",
+                                "valueFrom": {
+                                    "configMapKeyRef": {
+                                        "key": "gitopsRepoURL",
+                                        "name": "sovereign-fqdn",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "ORG_NAME",
+                                "valueFrom": {
+                                    "configMapKeyRef": {
+                                        "key": "orgName",
+                                        "name": "sovereign-fqdn",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_OTECH_FQDN",
+                                "valueFrom": {
+                                    "configMapKeyRef": {
+                                        "key": "fqdn",
+                                        "name": "sovereign-fqdn",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_SELF_DEPLOYMENT_ID",
+                                "valueFrom": {
+                                    "configMapKeyRef": {
+                                        "key": "selfDeploymentId",
+                                        "name": "sovereign-fqdn",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "SOVEREIGN_LB_IP",
+                                "valueFrom": {
+                                    "configMapKeyRef": {
+                                        "key": "lbIP",
+                                        "name": "sovereign-fqdn",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_OTECH_INGRESS_IPV4",
+                                "valueFrom": {
+                                    "configMapKeyRef": {
+                                        "key": "lbIP",
+                                        "name": "sovereign-fqdn",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_CONFIGURED_REGIONS",
+                                "valueFrom": {
+                                    "configMapKeyRef": {
+                                        "key": "configuredRegions",
+                                        "name": "sovereign-fqdn",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "SOVEREIGN_ENABLE_HOT_STANDBY",
+                                "valueFrom": {
+                                    "configMapKeyRef": {
+                                        "key": "enableHotStandby",
+                                        "name": "sovereign-fqdn",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "SOVEREIGN_PRIMARY_REGION",
+                                "valueFrom": {
+                                    "configMapKeyRef": {
+                                        "key": "primaryRegion",
+                                        "name": "sovereign-fqdn",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "SOVEREIGN_REPLICA_REGION",
+                                "valueFrom": {
+                                    "configMapKeyRef": {
+                                        "key": "replicaRegion",
+                                        "name": "sovereign-fqdn",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_QA_APPLICATIONS",
+                                "valueFrom": {
+                                    "configMapKeyRef": {
+                                        "key": "qaApplications",
+                                        "name": "sovereign-fqdn",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_GITOPS_USER",
+                                "value": "gitea_admin"
+                            },
+                            {
+                                "name": "CATALYST_GITOPS_REPO_URL",
+                                "value": "http://gitea-http.gitea.svc.cluster.local:3000/openova/openova"
+                            },
+                            {
+                                "name": "CATALYST_GITOPS_BRANCH",
+                                "value": "sme-tenants"
+                            },
+                            {
+                                "name": "CATALYST_GITOPS_TOKEN",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "GITHUB_TOKEN",
+                                        "name": "provisioning-github-token",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "POOL_DOMAIN_MANAGER_URL",
+                                "value": "https://pool.openova.io"
+                            },
+                            {
+                                "name": "CATALYST_PDM_BASIC_AUTH_USER",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "username",
+                                        "name": "pdm-basicauth",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_PDM_BASIC_AUTH_PASS",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "password",
+                                        "name": "pdm-basicauth",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_HANDOVER_SIGNER_PATH",
+                                "value": "/var/lib/catalyst/handover-jwt-private.pem"
+                            },
+                            {
+                                "name": "CATALYST_KC_CLIENT_ID",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "kc-client-id",
+                                        "name": "catalyst-magic-link-credentials",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_KC_REDIRECT_URI",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "kc-redirect-uri",
+                                        "name": "catalyst-magic-link-credentials",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_SESSION_COOKIE_SECRET",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "session-cookie-secret",
+                                        "name": "catalyst-magic-link-credentials",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_POST_AUTH_REDIRECT",
+                                "value": "/sovereign/components"
+                            },
+                            {
+                                "name": "CATALYST_OPENOVA_KC_ADDR",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "kc-addr",
+                                        "name": "catalyst-openova-kc-credentials",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_OPENOVA_KC_REALM",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "kc-realm",
+                                        "name": "catalyst-openova-kc-credentials",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_OPENOVA_KC_SA_CLIENT_ID",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "kc-sa-client-id",
+                                        "name": "catalyst-openova-kc-credentials",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_OPENOVA_KC_SA_CLIENT_SECRET",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "kc-sa-client-secret",
+                                        "name": "catalyst-openova-kc-credentials",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_OPENOVA_KC_AUDIENCE",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "kc-audience",
+                                        "name": "catalyst-openova-kc-credentials",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_SMTP_HOST",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "smtp-host",
+                                        "name": "catalyst-openova-kc-credentials",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_SMTP_PORT",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "smtp-port",
+                                        "name": "catalyst-openova-kc-credentials",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_SMTP_USER",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "smtp-user",
+                                        "name": "catalyst-openova-kc-credentials",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_SMTP_PASS",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "smtp-pass",
+                                        "name": "catalyst-openova-kc-credentials",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_SMTP_FROM",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "smtp-from",
+                                        "name": "catalyst-openova-kc-credentials",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CATALYST_SESSION_COOKIE_DOMAIN"
+                            },
+                            {
+                                "name": "CATALYST_CATALOG_URL",
+                                "value": "http://catalyst-catalog.catalyst-system.svc.cluster.local:8080"
+                            },
+                            {
+                                "name": "CATALYST_MIMIR_URL",
+                                "value": "http://mimir-query-frontend-x-mimir-x-mgmt-vcluster.mgmt.svc.cluster.local:8080"
+                            },
+                            {
+                                "name": "CATALYST_TEST_SESSION_ENABLED",
+                                "value": "false"
+                            }
+                        ],
+                        "image": "ghcr.io/openova-io/openova/catalyst-api:3a1bb63",
+                        "imagePullPolicy": "IfNotPresent",
+                        "livenessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 8080,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 3,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 1
+                        },
+                        "name": "catalyst-api",
+                        "ports": [
+                            {
+                                "containerPort": 8080,
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "path": "/readyz",
+                                "port": 8080,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 2,
+                            "periodSeconds": 5,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 1
+                        },
+                        "resources": {
+                            "limits": {
+                                "cpu": "2",
+                                "memory": "4Gi"
+                            },
+                            "requests": {
+                                "cpu": "100m",
+                                "memory": "96Mi"
+                            }
+                        },
+                        "securityContext": {
+                            "allowPrivilegeEscalation": false,
+                            "readOnlyRootFilesystem": false,
+                            "runAsNonRoot": true,
+                            "runAsUser": 65534
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/tmp",
+                                "name": "tmp"
+                            },
+                            {
+                                "mountPath": "/home/nonroot",
+                                "name": "home"
+                            },
+                            {
+                                "mountPath": "/var/lib/catalyst",
+                                "name": "catalyst"
+                            },
+                            {
+                                "mountPath": "/var/cache/sov-cache",
+                                "name": "sov-cache"
+                            },
+                            {
+                                "mountPath": "/etc/catalyst/handover-jwt-public",
+                                "name": "handover-jwt-public",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-cqzs9",
+                                "readOnly": true
+                            }
+                        ]
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "enableServiceLinks": true,
+                "imagePullSecrets": [
+                    {
+                        "name": "ghcr-pull"
+                    }
+                ],
+                "nodeName": "catalyst-hw173-omani-works-7bb723da-me-east-215-a-wfce2ae",
+                "preemptionPolicy": "PreemptLowerPriority",
+                "priority": 0,
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {
+                    "fsGroup": 65534,
+                    "fsGroupChangePolicy": "OnRootMismatch"
+                },
+                "serviceAccount": "catalyst-api-cutover-driver",
+                "serviceAccountName": "catalyst-api-cutover-driver",
+                "terminationGracePeriodSeconds": 30,
+                "tolerations": [
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "tolerationSeconds": 300
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "tolerationSeconds": 300
+                    }
+                ],
+                "volumes": [
+                    {
+                        "emptyDir": {
+                            "sizeLimit": "2Gi"
+                        },
+                        "name": "tmp"
+                    },
+                    {
+                        "emptyDir": {
+                            "sizeLimit": "256Mi"
+                        },
+                        "name": "home"
+                    },
+                    {
+                        "name": "catalyst",
+                        "persistentVolumeClaim": {
+                            "claimName": "catalyst-api-deployments"
+                        }
+                    },
+                    {
+                        "name": "sov-cache",
+                        "persistentVolumeClaim": {
+                            "claimName": "catalyst-api-cache"
+                        }
+                    },
+                    {
+                        "name": "handover-jwt-public",
+                        "secret": {
+                            "defaultMode": 420,
+                            "items": [
+                                {
+                                    "key": "public.jwk",
+                                    "path": "public.jwk"
+                                }
+                            ],
+                            "optional": true,
+                            "secretName": "catalyst-handover-jwt-public"
+                        }
+                    },
+                    {
+                        "name": "kube-api-access-cqzs9",
+                        "projected": {
+                            "defaultMode": 420,
+                            "sources": [
+                                {
+                                    "serviceAccountToken": {
+                                        "expirationSeconds": 3607,
+                                        "path": "token"
+                                    }
+                                },
+                                {
+                                    "configMap": {
+                                        "items": [
+                                            {
+                                                "key": "ca.crt",
+                                                "path": "ca.crt"
+                                            }
+                                        ],
+                                        "name": "kube-root-ca.crt"
+                                    }
+                                },
+                                {
+                                    "downwardAPI": {
+                                        "items": [
+                                            {
+                                                "fieldRef": {
+                                                    "apiVersion": "v1",
+                                                    "fieldPath": "metadata.namespace"
+                                                },
+                                                "path": "namespace"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-06-20T14:38:31Z",
+                        "status": "True",
+                        "type": "PodReadyToStartContainers"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-06-20T14:38:30Z",
+                        "status": "True",
+                        "type": "Initialized"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-06-20T14:38:35Z",
+                        "status": "True",
+                        "type": "Ready"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-06-20T14:38:35Z",
+                        "status": "True",
+                        "type": "ContainersReady"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-06-20T14:38:29Z",
+                        "status": "True",
+                        "type": "PodScheduled"
+                    }
+                ],
+                "containerStatuses": [
+                    {
+                        "containerID": "containerd://85a27822b6d534dda3b2de2f98e5d122261e372af69b562a10e95242842e53fe",
+                        "image": "ghcr.io/openova-io/openova/catalyst-api:3a1bb63",
+                        "imageID": "ghcr.io/openova-io/openova/catalyst-api@sha256:f43db4565f6a93ce78fe7ebb0044d16b8e4bcc69713941ed7e3bf7a84a3b1bf3",
+                        "lastState": {},
+                        "name": "catalyst-api",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": true,
+                        "state": {
+                            "running": {
+                                "startedAt": "2026-06-20T14:38:31Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/tmp",
+                                "name": "tmp"
+                            },
+                            {
+                                "mountPath": "/home/nonroot",
+                                "name": "home"
+                            },
+                            {
+                                "mountPath": "/var/lib/catalyst",
+                                "name": "catalyst"
+                            },
+                            {
+                                "mountPath": "/var/cache/sov-cache",
+                                "name": "sov-cache"
+                            },
+                            {
+                                "mountPath": "/etc/catalyst/handover-jwt-public",
+                                "name": "handover-jwt-public",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-cqzs9",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    }
+                ],
+                "hostIP": "10.169.1.83",
+                "hostIPs": [
+                    {
+                        "ip": "10.169.1.83"
+                    }
+                ],
+                "phase": "Running",
+                "podIP": "10.42.4.88",
+                "podIPs": [
+                    {
+                        "ip": "10.42.4.88"
+                    }
+                ],
+                "qosClass": "Burstable",
+                "startTime": "2026-06-20T14:38:30Z"
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": ""
+    }
+}

--- a/products/catalyst/bootstrap/api/internal/handler/testdata/hw173_3986/capi-b.json
+++ b/products/catalyst/bootstrap/api/internal/handler/testdata/hw173_3986/capi-b.json
@@ -1,0 +1,8 @@
+{
+    "apiVersion": "v1",
+    "items": [],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": ""
+    }
+}

--- a/products/catalyst/bootstrap/api/internal/handler/testdata/hw173_3986/grafana-a.json
+++ b/products/catalyst/bootstrap/api/internal/handler/testdata/hw173_3986/grafana-a.json
@@ -1,0 +1,909 @@
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "annotations": {
+                    "checksum/config": "358aeebcab338232a319c93fe77308cb2aa495043534a0b95d0c2d55bc344b58",
+                    "checksum/sc-dashboard-provider-config": "64ec80d6198b5a55edbce4049575aea3408f244d5163717308f1af05fd4d1c44",
+                    "checksum/secret": "d612a3698e7ae8b09040674c9cfb45c8a550e18f99385bfe4db311523d672ea9",
+                    "cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
+                    "kubectl.kubernetes.io/default-container": "grafana",
+                    "vcluster.loft.sh/labels": "app.kubernetes.io/instance=\"grafana\"\napp.kubernetes.io/name=\"grafana\"\napp.kubernetes.io/version=\"12.3.1\"\nhelm.sh/chart=\"grafana-10.5.15\"\npod-template-hash=\"6f94dbbd8f\"",
+                    "vcluster.loft.sh/managed-annotations": "checksum/config\nchecksum/sc-dashboard-provider-config\nchecksum/secret\nkubectl.kubernetes.io/default-container",
+                    "vcluster.loft.sh/name": "grafana-6f94dbbd8f-zs8fr",
+                    "vcluster.loft.sh/namespace": "grafana",
+                    "vcluster.loft.sh/object-host-name": "grafana-6f94dbbd8f-zs8fr-x-grafana-x-mgmt-vcluster",
+                    "vcluster.loft.sh/object-host-namespace": "mgmt",
+                    "vcluster.loft.sh/object-kind": "/v1, Kind=Pod",
+                    "vcluster.loft.sh/object-name": "grafana-6f94dbbd8f-zs8fr",
+                    "vcluster.loft.sh/object-namespace": "grafana",
+                    "vcluster.loft.sh/object-uid": "f852e641-cfc2-4281-ba2f-dd3074304915",
+                    "vcluster.loft.sh/owner-references": "[{\"apiVersion\":\"apps/v1\",\"kind\":\"ReplicaSet\",\"name\":\"grafana-6f94dbbd8f\",\"uid\":\"8a630071-56b2-4fa4-b801-94c489869c8c\",\"controller\":true,\"blockOwnerDeletion\":true}]",
+                    "vcluster.loft.sh/owner-set-kind": "ReplicaSet",
+                    "vcluster.loft.sh/service-account-name": "grafana",
+                    "vcluster.loft.sh/token-rvgduwzd": "eyJhbGciOiJSUzI1NiIsImtpZCI6IkNwYXBBaDZQaEZXWmp4cmlNNWcwMlR4ZnM1RFFrUmt0T2QwSWJfSXdwU1kifQ.eyJhdWQiOlsiaHR0cHM6Ly9rdWJlcm5ldGVzLmRlZmF1bHQuc3ZjLmNsdXN0ZXIubG9jYWwiLCJodHRwczovL2t1YmVybmV0ZXMuZGVmYXVsdC5zdmMiLCJodHRwczovL2t1YmVybmV0ZXMuZGVmYXVsdCJdLCJleHAiOjIwOTcyODYzNTAsImlhdCI6MTc4MTkyNjM1MCwiaXNzIjoiaHR0cHM6Ly9rdWJlcm5ldGVzLmRlZmF1bHQuc3ZjLmNsdXN0ZXIubG9jYWwiLCJqdGkiOiI1NjM3YzQ2NC0xOWI4LTRkNTQtODY0Ny1lNzAzYzBmNDk2MTIiLCJrdWJlcm5ldGVzLmlvIjp7Im5hbWVzcGFjZSI6ImdyYWZhbmEiLCJwb2QiOnsibmFtZSI6ImdyYWZhbmEtNmY5NGRiYmQ4Zi16czhmciIsInVpZCI6ImY4NTJlNjQxLWNmYzItNDI4MS1iYTJmLWRkMzA3NDMwNDkxNSJ9LCJzZXJ2aWNlYWNjb3VudCI6eyJuYW1lIjoiZ3JhZmFuYSIsInVpZCI6ImVmNGU5MTZlLTVkOGItNGE2Mi1iYjM4LTM2NTZhZmYxNjAxMSJ9fSwibmJmIjoxNzgxOTI2MzUwLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6Z3JhZmFuYTpncmFmYW5hIn0.YK1QGYqU5NQY4-LNi-eet2l43sbMhAB8XLz7qB3lYeVuGzOujrzGqbRltEzM1v-_Lt4BCdbbrrOO3Au0kDgVFvtcMb0L4JAlmufXnNjxmav4h5LcnBkaQYt2N5NaKuAQVsWdAz4KN6-wMFAADOBIBT_zyfi4tEcP_jAQBfVP2V04WL5KE56xvygTNQHoriv94qeYxzEek3r9GHvBZ5kDVGGFOBONUj5iRUe4VH9p6uMrbwZvo82r_o5zOxe6wOvt92vj2YePz9dwITSmy8c-Frt-K7fI8WZBV9iT3Ojo-EhwyYnIDXjtaYFXo7Rji3geR_9sIJw9WA2Z1ZY6cIiJAA",
+                    "vcluster.loft.sh/uid": "f852e641-cfc2-4281-ba2f-dd3074304915"
+                },
+                "creationTimestamp": "2026-06-20T03:32:31Z",
+                "labels": {
+                    "app.kubernetes.io/instance": "grafana",
+                    "app.kubernetes.io/name": "grafana",
+                    "app.kubernetes.io/version": "12.3.1",
+                    "helm.sh/chart": "grafana-10.5.15",
+                    "pod-template-hash": "6f94dbbd8f",
+                    "vcluster.loft.sh/managed-by": "mgmt-vcluster",
+                    "vcluster.loft.sh/namespace": "grafana",
+                    "vcluster.loft.sh/ns-label-mgmt-vcluster-x-82a3537ff0": "grafana",
+                    "vcluster.loft.sh/ns-label-mgmt-vcluster-x-cf1227b7b2": "grafana"
+                },
+                "name": "grafana-6f94dbbd8f-zs8fr-x-grafana-x-mgmt-vcluster",
+                "namespace": "mgmt",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "v1",
+                        "controller": true,
+                        "kind": "Service",
+                        "name": "mgmt-vcluster",
+                        "uid": "1e8c3e36-fdf1-482f-9725-45d1f2b5fbea"
+                    }
+                ],
+                "resourceVersion": "48371",
+                "uid": "df9f4f1c-1a57-443b-a27a-612c4eb5e9b0"
+            },
+            "spec": {
+                "automountServiceAccountToken": false,
+                "containers": [
+                    {
+                        "env": [
+                            {
+                                "name": "GRAFANA_PORT",
+                                "value": "tcp://10.96.133.20:80"
+                            },
+                            {
+                                "name": "GRAFANA_PORT_80_TCP",
+                                "value": "tcp://10.96.133.20:80"
+                            },
+                            {
+                                "name": "GRAFANA_PORT_80_TCP_ADDR",
+                                "value": "10.96.133.20"
+                            },
+                            {
+                                "name": "GRAFANA_PORT_80_TCP_PORT",
+                                "value": "80"
+                            },
+                            {
+                                "name": "GRAFANA_PORT_80_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "GRAFANA_SERVICE_HOST",
+                                "value": "10.96.133.20"
+                            },
+                            {
+                                "name": "GRAFANA_SERVICE_PORT",
+                                "value": "80"
+                            },
+                            {
+                                "name": "GRAFANA_SERVICE_PORT_SERVICE",
+                                "value": "80"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT",
+                                "value": "tcp://10.96.117.155:443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP",
+                                "value": "tcp://10.96.117.155:443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_ADDR",
+                                "value": "10.96.117.155"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_PORT",
+                                "value": "443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_HOST",
+                                "value": "10.96.117.155"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_PORT",
+                                "value": "443"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_PORT_HTTPS",
+                                "value": "443"
+                            },
+                            {
+                                "name": "METHOD",
+                                "value": "WATCH"
+                            },
+                            {
+                                "name": "LABEL",
+                                "value": "grafana_dashboard"
+                            },
+                            {
+                                "name": "LABEL_VALUE",
+                                "value": "1"
+                            },
+                            {
+                                "name": "FOLDER",
+                                "value": "/tmp/dashboards"
+                            },
+                            {
+                                "name": "RESOURCE",
+                                "value": "both"
+                            },
+                            {
+                                "name": "NAMESPACE",
+                                "value": "ALL"
+                            },
+                            {
+                                "name": "REQ_USERNAME",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "admin-user",
+                                        "name": "grafana-x-grafana-x-mgmt-vcluster"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "REQ_PASSWORD",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "admin-password",
+                                        "name": "grafana-x-grafana-x-mgmt-vcluster"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "REQ_URL",
+                                "value": "http://localhost:3000/api/admin/provisioning/dashboards/reload"
+                            },
+                            {
+                                "name": "REQ_METHOD",
+                                "value": "POST"
+                            }
+                        ],
+                        "image": "harbor.openova.io/proxy-quay/kiwigrid/k8s-sidecar:2.5.0",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "grafana-sc-dashboard",
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m",
+                                "memory": "192Mi"
+                            },
+                            "requests": {
+                                "cpu": "10m",
+                                "memory": "64Mi"
+                            }
+                        },
+                        "securityContext": {
+                            "allowPrivilegeEscalation": false,
+                            "capabilities": {
+                                "drop": [
+                                    "ALL"
+                                ]
+                            },
+                            "seccompProfile": {
+                                "type": "RuntimeDefault"
+                            }
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/tmp/dashboards",
+                                "name": "sc-dashboard-volume"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-x2p9m",
+                                "readOnly": true
+                            }
+                        ]
+                    },
+                    {
+                        "env": [
+                            {
+                                "name": "GRAFANA_PORT",
+                                "value": "tcp://10.96.133.20:80"
+                            },
+                            {
+                                "name": "GRAFANA_PORT_80_TCP",
+                                "value": "tcp://10.96.133.20:80"
+                            },
+                            {
+                                "name": "GRAFANA_PORT_80_TCP_ADDR",
+                                "value": "10.96.133.20"
+                            },
+                            {
+                                "name": "GRAFANA_PORT_80_TCP_PORT",
+                                "value": "80"
+                            },
+                            {
+                                "name": "GRAFANA_PORT_80_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "GRAFANA_SERVICE_HOST",
+                                "value": "10.96.133.20"
+                            },
+                            {
+                                "name": "GRAFANA_SERVICE_PORT",
+                                "value": "80"
+                            },
+                            {
+                                "name": "GRAFANA_SERVICE_PORT_SERVICE",
+                                "value": "80"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT",
+                                "value": "tcp://10.96.117.155:443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP",
+                                "value": "tcp://10.96.117.155:443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_ADDR",
+                                "value": "10.96.117.155"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_PORT",
+                                "value": "443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_HOST",
+                                "value": "10.96.117.155"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_PORT",
+                                "value": "443"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_PORT_HTTPS",
+                                "value": "443"
+                            },
+                            {
+                                "name": "METHOD",
+                                "value": "WATCH"
+                            },
+                            {
+                                "name": "LABEL",
+                                "value": "grafana_datasource"
+                            },
+                            {
+                                "name": "LABEL_VALUE",
+                                "value": "1"
+                            },
+                            {
+                                "name": "FOLDER",
+                                "value": "/etc/grafana/provisioning/datasources"
+                            },
+                            {
+                                "name": "RESOURCE",
+                                "value": "both"
+                            },
+                            {
+                                "name": "NAMESPACE",
+                                "value": "ALL"
+                            },
+                            {
+                                "name": "REQ_USERNAME",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "admin-user",
+                                        "name": "grafana-x-grafana-x-mgmt-vcluster"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "REQ_PASSWORD",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "admin-password",
+                                        "name": "grafana-x-grafana-x-mgmt-vcluster"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "REQ_URL",
+                                "value": "http://localhost:3000/api/admin/provisioning/datasources/reload"
+                            },
+                            {
+                                "name": "REQ_METHOD",
+                                "value": "POST"
+                            }
+                        ],
+                        "image": "harbor.openova.io/proxy-quay/kiwigrid/k8s-sidecar:2.5.0",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "grafana-sc-datasources",
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m",
+                                "memory": "192Mi"
+                            },
+                            "requests": {
+                                "cpu": "10m",
+                                "memory": "64Mi"
+                            }
+                        },
+                        "securityContext": {
+                            "allowPrivilegeEscalation": false,
+                            "capabilities": {
+                                "drop": [
+                                    "ALL"
+                                ]
+                            },
+                            "seccompProfile": {
+                                "type": "RuntimeDefault"
+                            }
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/etc/grafana/provisioning/datasources",
+                                "name": "sc-datasources-volume"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-x2p9m",
+                                "readOnly": true
+                            }
+                        ]
+                    },
+                    {
+                        "env": [
+                            {
+                                "name": "GRAFANA_PORT",
+                                "value": "tcp://10.96.133.20:80"
+                            },
+                            {
+                                "name": "GRAFANA_PORT_80_TCP",
+                                "value": "tcp://10.96.133.20:80"
+                            },
+                            {
+                                "name": "GRAFANA_PORT_80_TCP_ADDR",
+                                "value": "10.96.133.20"
+                            },
+                            {
+                                "name": "GRAFANA_PORT_80_TCP_PORT",
+                                "value": "80"
+                            },
+                            {
+                                "name": "GRAFANA_PORT_80_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "GRAFANA_SERVICE_HOST",
+                                "value": "10.96.133.20"
+                            },
+                            {
+                                "name": "GRAFANA_SERVICE_PORT",
+                                "value": "80"
+                            },
+                            {
+                                "name": "GRAFANA_SERVICE_PORT_SERVICE",
+                                "value": "80"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT",
+                                "value": "tcp://10.96.117.155:443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP",
+                                "value": "tcp://10.96.117.155:443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_ADDR",
+                                "value": "10.96.117.155"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_PORT",
+                                "value": "443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_HOST",
+                                "value": "10.96.117.155"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_PORT",
+                                "value": "443"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_PORT_HTTPS",
+                                "value": "443"
+                            },
+                            {
+                                "name": "POD_IP",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "status.podIP"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "GF_SECURITY_ADMIN_USER",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "admin-user",
+                                        "name": "grafana-x-grafana-x-mgmt-vcluster"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "GF_SECURITY_ADMIN_PASSWORD",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "admin-password",
+                                        "name": "grafana-x-grafana-x-mgmt-vcluster"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "GF_PATHS_DATA",
+                                "value": "/var/lib/grafana/"
+                            },
+                            {
+                                "name": "GF_PATHS_LOGS",
+                                "value": "/var/log/grafana"
+                            },
+                            {
+                                "name": "GF_PATHS_PLUGINS",
+                                "value": "/var/lib/grafana/plugins"
+                            },
+                            {
+                                "name": "GF_PATHS_PROVISIONING",
+                                "value": "/etc/grafana/provisioning"
+                            },
+                            {
+                                "name": "GF_UNIFIED_STORAGE_INDEX_PATH",
+                                "value": "/var/lib/grafana-search/bleve"
+                            },
+                            {
+                                "name": "GOMEMLIMIT",
+                                "valueFrom": {
+                                    "resourceFieldRef": {
+                                        "divisor": "1",
+                                        "resource": "limits.memory"
+                                    }
+                                }
+                            }
+                        ],
+                        "envFrom": [
+                            {
+                                "secretRef": {
+                                    "name": "grafana-sso-oidc-credentials-x-grafana-x-mgmt-vcluster"
+                                }
+                            },
+                            {
+                                "secretRef": {
+                                    "name": "grafana-database-env-x-grafana-x-mgmt-vcluster",
+                                    "optional": true
+                                }
+                            }
+                        ],
+                        "image": "harbor.openova.io/proxy-dockerhub/grafana/grafana:12.3.1",
+                        "imagePullPolicy": "IfNotPresent",
+                        "livenessProbe": {
+                            "failureThreshold": 10,
+                            "httpGet": {
+                                "path": "/api/health",
+                                "port": "grafana",
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 60,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 30
+                        },
+                        "name": "grafana",
+                        "ports": [
+                            {
+                                "containerPort": 3000,
+                                "name": "grafana",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 9094,
+                                "name": "gossip-tcp",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 9094,
+                                "name": "gossip-udp",
+                                "protocol": "UDP"
+                            },
+                            {
+                                "containerPort": 6060,
+                                "name": "profiling",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "path": "/api/health",
+                                "port": "grafana",
+                                "scheme": "HTTP"
+                            },
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 1
+                        },
+                        "resources": {
+                            "limits": {
+                                "cpu": "500m",
+                                "memory": "512Mi"
+                            },
+                            "requests": {
+                                "cpu": "100m",
+                                "memory": "256Mi"
+                            }
+                        },
+                        "securityContext": {
+                            "allowPrivilegeEscalation": false,
+                            "capabilities": {
+                                "drop": [
+                                    "ALL"
+                                ]
+                            },
+                            "privileged": false,
+                            "seccompProfile": {
+                                "type": "RuntimeDefault"
+                            }
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/etc/grafana/grafana.ini",
+                                "name": "config",
+                                "subPath": "grafana.ini"
+                            },
+                            {
+                                "mountPath": "/var/lib/grafana",
+                                "name": "storage"
+                            },
+                            {
+                                "mountPath": "/var/lib/grafana-search",
+                                "name": "search"
+                            },
+                            {
+                                "mountPath": "/tmp/dashboards",
+                                "name": "sc-dashboard-volume"
+                            },
+                            {
+                                "mountPath": "/etc/grafana/provisioning/dashboards/sc-dashboardproviders.yaml",
+                                "name": "sc-dashboard-provider",
+                                "subPath": "provider.yaml"
+                            },
+                            {
+                                "mountPath": "/etc/grafana/provisioning/datasources",
+                                "name": "sc-datasources-volume"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-x2p9m",
+                                "readOnly": true
+                            }
+                        ]
+                    }
+                ],
+                "dnsConfig": {
+                    "nameservers": [
+                        "10.96.212.31"
+                    ],
+                    "options": [
+                        {
+                            "name": "ndots",
+                            "value": "5"
+                        }
+                    ],
+                    "searches": [
+                        "grafana.svc.cluster.local",
+                        "svc.cluster.local",
+                        "cluster.local"
+                    ]
+                },
+                "dnsPolicy": "None",
+                "enableServiceLinks": false,
+                "hostAliases": [
+                    {
+                        "hostnames": [
+                            "kubernetes",
+                            "kubernetes.default",
+                            "kubernetes.default.svc"
+                        ],
+                        "ip": "10.96.117.155"
+                    }
+                ],
+                "hostname": "grafana-6f94dbbd8f-zs8fr",
+                "nodeName": "catalyst-hw173-omani-works-7bb723da-me-east-215-a-w21d1c8",
+                "preemptionPolicy": "PreemptLowerPriority",
+                "priority": 0,
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {
+                    "fsGroup": 472,
+                    "runAsGroup": 472,
+                    "runAsNonRoot": true,
+                    "runAsUser": 472
+                },
+                "serviceAccount": "vc-workload-mgmt-vcluster",
+                "serviceAccountName": "vc-workload-mgmt-vcluster",
+                "shareProcessNamespace": false,
+                "terminationGracePeriodSeconds": 30,
+                "tolerations": [
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "tolerationSeconds": 300
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "tolerationSeconds": 300
+                    }
+                ],
+                "volumes": [
+                    {
+                        "configMap": {
+                            "defaultMode": 420,
+                            "name": "grafana-x-grafana-x-mgmt-vcluster"
+                        },
+                        "name": "config"
+                    },
+                    {
+                        "name": "storage",
+                        "persistentVolumeClaim": {
+                            "claimName": "grafana-x-grafana-x-mgmt-vcluster"
+                        }
+                    },
+                    {
+                        "emptyDir": {},
+                        "name": "search"
+                    },
+                    {
+                        "emptyDir": {},
+                        "name": "sc-dashboard-volume"
+                    },
+                    {
+                        "configMap": {
+                            "defaultMode": 420,
+                            "name": "grafana-config-dashboards-x-grafana-x-mgmt-vcluster"
+                        },
+                        "name": "sc-dashboard-provider"
+                    },
+                    {
+                        "emptyDir": {},
+                        "name": "sc-datasources-volume"
+                    },
+                    {
+                        "name": "kube-api-access-x2p9m",
+                        "projected": {
+                            "defaultMode": 420,
+                            "sources": [
+                                {
+                                    "downwardAPI": {
+                                        "items": [
+                                            {
+                                                "fieldRef": {
+                                                    "apiVersion": "v1",
+                                                    "fieldPath": "metadata.annotations['vcluster.loft.sh/token-rvgduwzd']"
+                                                },
+                                                "mode": 420,
+                                                "path": "token"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "configMap": {
+                                        "items": [
+                                            {
+                                                "key": "ca.crt",
+                                                "path": "ca.crt"
+                                            }
+                                        ],
+                                        "name": "kube-root-ca.crt-x-grafana-x-mgmt-vcluster"
+                                    }
+                                },
+                                {
+                                    "downwardAPI": {
+                                        "items": [
+                                            {
+                                                "fieldRef": {
+                                                    "apiVersion": "v1",
+                                                    "fieldPath": "metadata.annotations['vcluster.loft.sh/namespace']"
+                                                },
+                                                "path": "namespace"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-06-20T03:35:32Z",
+                        "status": "True",
+                        "type": "PodReadyToStartContainers"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-06-20T03:32:37Z",
+                        "status": "True",
+                        "type": "Initialized"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-06-20T03:41:47Z",
+                        "status": "True",
+                        "type": "Ready"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-06-20T03:41:47Z",
+                        "status": "True",
+                        "type": "ContainersReady"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-06-20T03:32:37Z",
+                        "status": "True",
+                        "type": "PodScheduled"
+                    }
+                ],
+                "containerStatuses": [
+                    {
+                        "containerID": "containerd://31acf41a4749f7572fac7dee42779484922e2e5c4a20ed1beaaee478bcb5188a",
+                        "image": "harbor.openova.io/proxy-dockerhub/grafana/grafana:12.3.1",
+                        "imageID": "harbor.openova.io/proxy-dockerhub/grafana/grafana@sha256:2175aaa91c96733d86d31cf270d5310b278654b03f5718c59de12a865380a31f",
+                        "lastState": {},
+                        "name": "grafana",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": true,
+                        "state": {
+                            "running": {
+                                "startedAt": "2026-06-20T03:41:33Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/etc/grafana/grafana.ini",
+                                "name": "config"
+                            },
+                            {
+                                "mountPath": "/var/lib/grafana",
+                                "name": "storage"
+                            },
+                            {
+                                "mountPath": "/var/lib/grafana-search",
+                                "name": "search"
+                            },
+                            {
+                                "mountPath": "/tmp/dashboards",
+                                "name": "sc-dashboard-volume"
+                            },
+                            {
+                                "mountPath": "/etc/grafana/provisioning/dashboards/sc-dashboardproviders.yaml",
+                                "name": "sc-dashboard-provider"
+                            },
+                            {
+                                "mountPath": "/etc/grafana/provisioning/datasources",
+                                "name": "sc-datasources-volume"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-x2p9m",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "containerID": "containerd://85299f648eb6e909c71a973f403323ff0eed4b930bf5dcbb7be0af41ff40c31c",
+                        "image": "harbor.openova.io/proxy-quay/kiwigrid/k8s-sidecar:2.5.0",
+                        "imageID": "harbor.openova.io/proxy-quay/kiwigrid/k8s-sidecar@sha256:a6b3f707f883108376514489a94d6629109a327b2978e1d826cd104c4ca436df",
+                        "lastState": {},
+                        "name": "grafana-sc-dashboard",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": true,
+                        "state": {
+                            "running": {
+                                "startedAt": "2026-06-20T03:32:59Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/tmp/dashboards",
+                                "name": "sc-dashboard-volume"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-x2p9m",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "containerID": "containerd://6c60ab686aa018d06b140a2c3d57dc46401157bcf703b9604da674450d184af2",
+                        "image": "harbor.openova.io/proxy-quay/kiwigrid/k8s-sidecar:2.5.0",
+                        "imageID": "harbor.openova.io/proxy-quay/kiwigrid/k8s-sidecar@sha256:a6b3f707f883108376514489a94d6629109a327b2978e1d826cd104c4ca436df",
+                        "lastState": {},
+                        "name": "grafana-sc-datasources",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": true,
+                        "state": {
+                            "running": {
+                                "startedAt": "2026-06-20T03:32:59Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/etc/grafana/provisioning/datasources",
+                                "name": "sc-datasources-volume"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-x2p9m",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    }
+                ],
+                "hostIP": "10.169.1.2",
+                "hostIPs": [
+                    {
+                        "ip": "10.169.1.2"
+                    }
+                ],
+                "phase": "Running",
+                "podIP": "10.42.1.252",
+                "podIPs": [
+                    {
+                        "ip": "10.42.1.252"
+                    }
+                ],
+                "qosClass": "Burstable",
+                "startTime": "2026-06-20T03:32:37Z"
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": ""
+    }
+}

--- a/products/catalyst/bootstrap/api/internal/handler/testdata/hw173_3986/grafana-b.json
+++ b/products/catalyst/bootstrap/api/internal/handler/testdata/hw173_3986/grafana-b.json
@@ -1,0 +1,913 @@
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "annotations": {
+                    "checksum/config": "358aeebcab338232a319c93fe77308cb2aa495043534a0b95d0c2d55bc344b58",
+                    "checksum/sc-dashboard-provider-config": "64ec80d6198b5a55edbce4049575aea3408f244d5163717308f1af05fd4d1c44",
+                    "checksum/secret": "cd3bfcb7048baa5eba7a613d87c2718f42511f817c8dd8176ee7858d9c231242",
+                    "cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
+                    "kubectl.kubernetes.io/default-container": "grafana",
+                    "vcluster.loft.sh/labels": "app.kubernetes.io/instance=\"grafana\"\napp.kubernetes.io/name=\"grafana\"\napp.kubernetes.io/version=\"12.3.1\"\nhelm.sh/chart=\"grafana-10.5.15\"\npod-template-hash=\"5b9f9b5d4b\"",
+                    "vcluster.loft.sh/managed-annotations": "checksum/config\nchecksum/sc-dashboard-provider-config\nchecksum/secret\nkubectl.kubernetes.io/default-container",
+                    "vcluster.loft.sh/name": "grafana-5b9f9b5d4b-xp844",
+                    "vcluster.loft.sh/namespace": "grafana",
+                    "vcluster.loft.sh/object-host-name": "grafana-5b9f9b5d4b-xp844-x-grafana-x-mgmt-vcluster",
+                    "vcluster.loft.sh/object-host-namespace": "mgmt",
+                    "vcluster.loft.sh/object-kind": "/v1, Kind=Pod",
+                    "vcluster.loft.sh/object-name": "grafana-5b9f9b5d4b-xp844",
+                    "vcluster.loft.sh/object-namespace": "grafana",
+                    "vcluster.loft.sh/object-uid": "9788d973-84b7-4ba8-955f-c70a0b6bf414",
+                    "vcluster.loft.sh/owner-references": "[{\"apiVersion\":\"apps/v1\",\"kind\":\"ReplicaSet\",\"name\":\"grafana-5b9f9b5d4b\",\"uid\":\"3077a8a2-37c0-4c17-a992-bd5dc7282f1d\",\"controller\":true,\"blockOwnerDeletion\":true}]",
+                    "vcluster.loft.sh/owner-set-kind": "ReplicaSet",
+                    "vcluster.loft.sh/service-account-name": "grafana",
+                    "vcluster.loft.sh/token-wyzdazbj": "eyJhbGciOiJSUzI1NiIsImtpZCI6ImRhbG5uLTRBMHZBdHhRUEVqY2FlUElISk16ZDZERlF6ZjBsYTByYW9rUTAifQ.eyJhdWQiOlsiaHR0cHM6Ly9rdWJlcm5ldGVzLmRlZmF1bHQuc3ZjLmNsdXN0ZXIubG9jYWwiLCJodHRwczovL2t1YmVybmV0ZXMuZGVmYXVsdC5zdmMiLCJodHRwczovL2t1YmVybmV0ZXMuZGVmYXVsdCJdLCJleHAiOjIwOTcyODY1MzEsImlhdCI6MTc4MTkyNjUzMSwiaXNzIjoiaHR0cHM6Ly9rdWJlcm5ldGVzLmRlZmF1bHQuc3ZjLmNsdXN0ZXIubG9jYWwiLCJqdGkiOiIyMDY5OGFiNy00OWMyLTQ2ZWMtOGZiOS1jMWUwOWFhMWY2MjYiLCJrdWJlcm5ldGVzLmlvIjp7Im5hbWVzcGFjZSI6ImdyYWZhbmEiLCJwb2QiOnsibmFtZSI6ImdyYWZhbmEtNWI5ZjliNWQ0Yi14cDg0NCIsInVpZCI6Ijk3ODhkOTczLTg0YjctNGJhOC05NTVmLWM3MGEwYjZiZjQxNCJ9LCJzZXJ2aWNlYWNjb3VudCI6eyJuYW1lIjoiZ3JhZmFuYSIsInVpZCI6IjMzMmEyMWVmLWUyYzItNDk3Ny1hY2Q5LWYxM2VmOTQ5ZmRiMCJ9fSwibmJmIjoxNzgxOTI2NTMxLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6Z3JhZmFuYTpncmFmYW5hIn0.rr8W_ynoNwRJlRGfI5kxDMdSEjplJY1v51noWqxEcsJtoXJ9Ai5VwvUl35rf9FeJtOwgJVC7Yuc3WsxMJ0Mu9ffvj25Uquz445lJLc8ThazN1UNIkq8R0OXNLlBld6v8sHXwFvmcYhggTAH4EiRY1IBQ9r0sXXYkqdaWWZoHxG_tfRlvmtYfwnLVx2CKFwW72coe-0tTWk7jJCIvfKhm9uuWfoNq4dCBPShUgTC18Ik3trtKVGGZVdW_kfURalb7HGgFJXZc6jHJOP2mKO8rVuyfy3yvgzAFg1gZWln3VIZLyNfseHIzCdtsHgq5PLb4gFRPYfS8jf6BpGOZppRiUA",
+                    "vcluster.loft.sh/uid": "9788d973-84b7-4ba8-955f-c70a0b6bf414"
+                },
+                "creationTimestamp": "2026-06-20T03:35:31Z",
+                "labels": {
+                    "app.kubernetes.io/instance": "grafana",
+                    "app.kubernetes.io/name": "grafana",
+                    "app.kubernetes.io/version": "12.3.1",
+                    "helm.sh/chart": "grafana-10.5.15",
+                    "pod-template-hash": "5b9f9b5d4b",
+                    "vcluster.loft.sh/managed-by": "mgmt-vcluster",
+                    "vcluster.loft.sh/namespace": "grafana",
+                    "vcluster.loft.sh/ns-label-mgmt-vcluster-x-82a3537ff0": "grafana",
+                    "vcluster.loft.sh/ns-label-mgmt-vcluster-x-cf1227b7b2": "grafana"
+                },
+                "name": "grafana-5b9f9b5d4b-xp844-x-grafana-x-mgmt-vcluster",
+                "namespace": "mgmt",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "v1",
+                        "controller": true,
+                        "kind": "Service",
+                        "name": "mgmt-vcluster",
+                        "uid": "37149640-d492-4758-93d3-f157d152d649"
+                    }
+                ],
+                "resourceVersion": "32744",
+                "uid": "6a56df8e-7b66-4612-a2da-ba5d9fa68eb9"
+            },
+            "spec": {
+                "automountServiceAccountToken": false,
+                "containers": [
+                    {
+                        "env": [
+                            {
+                                "name": "GRAFANA_PORT",
+                                "value": "tcp://10.97.139.132:80"
+                            },
+                            {
+                                "name": "GRAFANA_PORT_80_TCP",
+                                "value": "tcp://10.97.139.132:80"
+                            },
+                            {
+                                "name": "GRAFANA_PORT_80_TCP_ADDR",
+                                "value": "10.97.139.132"
+                            },
+                            {
+                                "name": "GRAFANA_PORT_80_TCP_PORT",
+                                "value": "80"
+                            },
+                            {
+                                "name": "GRAFANA_PORT_80_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "GRAFANA_SERVICE_HOST",
+                                "value": "10.97.139.132"
+                            },
+                            {
+                                "name": "GRAFANA_SERVICE_PORT",
+                                "value": "80"
+                            },
+                            {
+                                "name": "GRAFANA_SERVICE_PORT_SERVICE",
+                                "value": "80"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT",
+                                "value": "tcp://10.97.83.45:443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP",
+                                "value": "tcp://10.97.83.45:443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_ADDR",
+                                "value": "10.97.83.45"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_PORT",
+                                "value": "443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_HOST",
+                                "value": "10.97.83.45"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_PORT",
+                                "value": "443"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_PORT_HTTPS",
+                                "value": "443"
+                            },
+                            {
+                                "name": "METHOD",
+                                "value": "WATCH"
+                            },
+                            {
+                                "name": "LABEL",
+                                "value": "grafana_dashboard"
+                            },
+                            {
+                                "name": "LABEL_VALUE",
+                                "value": "1"
+                            },
+                            {
+                                "name": "FOLDER",
+                                "value": "/tmp/dashboards"
+                            },
+                            {
+                                "name": "RESOURCE",
+                                "value": "both"
+                            },
+                            {
+                                "name": "NAMESPACE",
+                                "value": "ALL"
+                            },
+                            {
+                                "name": "REQ_USERNAME",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "admin-user",
+                                        "name": "grafana-x-grafana-x-mgmt-vcluster"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "REQ_PASSWORD",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "admin-password",
+                                        "name": "grafana-x-grafana-x-mgmt-vcluster"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "REQ_URL",
+                                "value": "http://localhost:3000/api/admin/provisioning/dashboards/reload"
+                            },
+                            {
+                                "name": "REQ_METHOD",
+                                "value": "POST"
+                            }
+                        ],
+                        "image": "harbor.openova.io/proxy-quay/kiwigrid/k8s-sidecar:2.5.0",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "grafana-sc-dashboard",
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m",
+                                "memory": "192Mi"
+                            },
+                            "requests": {
+                                "cpu": "10m",
+                                "memory": "64Mi"
+                            }
+                        },
+                        "securityContext": {
+                            "allowPrivilegeEscalation": false,
+                            "capabilities": {
+                                "drop": [
+                                    "ALL"
+                                ]
+                            },
+                            "seccompProfile": {
+                                "type": "RuntimeDefault"
+                            }
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/tmp/dashboards",
+                                "name": "sc-dashboard-volume"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-d9npg",
+                                "readOnly": true
+                            }
+                        ]
+                    },
+                    {
+                        "env": [
+                            {
+                                "name": "GRAFANA_PORT",
+                                "value": "tcp://10.97.139.132:80"
+                            },
+                            {
+                                "name": "GRAFANA_PORT_80_TCP",
+                                "value": "tcp://10.97.139.132:80"
+                            },
+                            {
+                                "name": "GRAFANA_PORT_80_TCP_ADDR",
+                                "value": "10.97.139.132"
+                            },
+                            {
+                                "name": "GRAFANA_PORT_80_TCP_PORT",
+                                "value": "80"
+                            },
+                            {
+                                "name": "GRAFANA_PORT_80_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "GRAFANA_SERVICE_HOST",
+                                "value": "10.97.139.132"
+                            },
+                            {
+                                "name": "GRAFANA_SERVICE_PORT",
+                                "value": "80"
+                            },
+                            {
+                                "name": "GRAFANA_SERVICE_PORT_SERVICE",
+                                "value": "80"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT",
+                                "value": "tcp://10.97.83.45:443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP",
+                                "value": "tcp://10.97.83.45:443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_ADDR",
+                                "value": "10.97.83.45"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_PORT",
+                                "value": "443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_HOST",
+                                "value": "10.97.83.45"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_PORT",
+                                "value": "443"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_PORT_HTTPS",
+                                "value": "443"
+                            },
+                            {
+                                "name": "METHOD",
+                                "value": "WATCH"
+                            },
+                            {
+                                "name": "LABEL",
+                                "value": "grafana_datasource"
+                            },
+                            {
+                                "name": "LABEL_VALUE",
+                                "value": "1"
+                            },
+                            {
+                                "name": "FOLDER",
+                                "value": "/etc/grafana/provisioning/datasources"
+                            },
+                            {
+                                "name": "RESOURCE",
+                                "value": "both"
+                            },
+                            {
+                                "name": "NAMESPACE",
+                                "value": "ALL"
+                            },
+                            {
+                                "name": "REQ_USERNAME",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "admin-user",
+                                        "name": "grafana-x-grafana-x-mgmt-vcluster"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "REQ_PASSWORD",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "admin-password",
+                                        "name": "grafana-x-grafana-x-mgmt-vcluster"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "REQ_URL",
+                                "value": "http://localhost:3000/api/admin/provisioning/datasources/reload"
+                            },
+                            {
+                                "name": "REQ_METHOD",
+                                "value": "POST"
+                            }
+                        ],
+                        "image": "harbor.openova.io/proxy-quay/kiwigrid/k8s-sidecar:2.5.0",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "grafana-sc-datasources",
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m",
+                                "memory": "192Mi"
+                            },
+                            "requests": {
+                                "cpu": "10m",
+                                "memory": "64Mi"
+                            }
+                        },
+                        "securityContext": {
+                            "allowPrivilegeEscalation": false,
+                            "capabilities": {
+                                "drop": [
+                                    "ALL"
+                                ]
+                            },
+                            "seccompProfile": {
+                                "type": "RuntimeDefault"
+                            }
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/etc/grafana/provisioning/datasources",
+                                "name": "sc-datasources-volume"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-d9npg",
+                                "readOnly": true
+                            }
+                        ]
+                    },
+                    {
+                        "env": [
+                            {
+                                "name": "GRAFANA_PORT",
+                                "value": "tcp://10.97.139.132:80"
+                            },
+                            {
+                                "name": "GRAFANA_PORT_80_TCP",
+                                "value": "tcp://10.97.139.132:80"
+                            },
+                            {
+                                "name": "GRAFANA_PORT_80_TCP_ADDR",
+                                "value": "10.97.139.132"
+                            },
+                            {
+                                "name": "GRAFANA_PORT_80_TCP_PORT",
+                                "value": "80"
+                            },
+                            {
+                                "name": "GRAFANA_PORT_80_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "GRAFANA_SERVICE_HOST",
+                                "value": "10.97.139.132"
+                            },
+                            {
+                                "name": "GRAFANA_SERVICE_PORT",
+                                "value": "80"
+                            },
+                            {
+                                "name": "GRAFANA_SERVICE_PORT_SERVICE",
+                                "value": "80"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT",
+                                "value": "tcp://10.97.83.45:443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP",
+                                "value": "tcp://10.97.83.45:443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_ADDR",
+                                "value": "10.97.83.45"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_PORT",
+                                "value": "443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_HOST",
+                                "value": "10.97.83.45"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_PORT",
+                                "value": "443"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_PORT_HTTPS",
+                                "value": "443"
+                            },
+                            {
+                                "name": "POD_IP",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "status.podIP"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "GF_SECURITY_ADMIN_USER",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "admin-user",
+                                        "name": "grafana-x-grafana-x-mgmt-vcluster"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "GF_SECURITY_ADMIN_PASSWORD",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "admin-password",
+                                        "name": "grafana-x-grafana-x-mgmt-vcluster"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "GF_PATHS_DATA",
+                                "value": "/var/lib/grafana/"
+                            },
+                            {
+                                "name": "GF_PATHS_LOGS",
+                                "value": "/var/log/grafana"
+                            },
+                            {
+                                "name": "GF_PATHS_PLUGINS",
+                                "value": "/var/lib/grafana/plugins"
+                            },
+                            {
+                                "name": "GF_PATHS_PROVISIONING",
+                                "value": "/etc/grafana/provisioning"
+                            },
+                            {
+                                "name": "GF_UNIFIED_STORAGE_INDEX_PATH",
+                                "value": "/var/lib/grafana-search/bleve"
+                            },
+                            {
+                                "name": "GOMEMLIMIT",
+                                "valueFrom": {
+                                    "resourceFieldRef": {
+                                        "divisor": "1",
+                                        "resource": "limits.memory"
+                                    }
+                                }
+                            }
+                        ],
+                        "envFrom": [
+                            {
+                                "secretRef": {
+                                    "name": "grafana-sso-oidc-credentials-x-grafana-x-mgmt-vcluster"
+                                }
+                            },
+                            {
+                                "secretRef": {
+                                    "name": "grafana-database-env-x-grafana-x-mgmt-vcluster",
+                                    "optional": true
+                                }
+                            }
+                        ],
+                        "image": "harbor.openova.io/proxy-dockerhub/grafana/grafana:12.3.1",
+                        "imagePullPolicy": "IfNotPresent",
+                        "livenessProbe": {
+                            "failureThreshold": 10,
+                            "httpGet": {
+                                "path": "/api/health",
+                                "port": "grafana",
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 60,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 30
+                        },
+                        "name": "grafana",
+                        "ports": [
+                            {
+                                "containerPort": 3000,
+                                "name": "grafana",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 9094,
+                                "name": "gossip-tcp",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 9094,
+                                "name": "gossip-udp",
+                                "protocol": "UDP"
+                            },
+                            {
+                                "containerPort": 6060,
+                                "name": "profiling",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "path": "/api/health",
+                                "port": "grafana",
+                                "scheme": "HTTP"
+                            },
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 1
+                        },
+                        "resources": {
+                            "limits": {
+                                "cpu": "500m",
+                                "memory": "512Mi"
+                            },
+                            "requests": {
+                                "cpu": "100m",
+                                "memory": "256Mi"
+                            }
+                        },
+                        "securityContext": {
+                            "allowPrivilegeEscalation": false,
+                            "capabilities": {
+                                "drop": [
+                                    "ALL"
+                                ]
+                            },
+                            "privileged": false,
+                            "seccompProfile": {
+                                "type": "RuntimeDefault"
+                            }
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/etc/grafana/grafana.ini",
+                                "name": "config",
+                                "subPath": "grafana.ini"
+                            },
+                            {
+                                "mountPath": "/var/lib/grafana",
+                                "name": "storage"
+                            },
+                            {
+                                "mountPath": "/var/lib/grafana-search",
+                                "name": "search"
+                            },
+                            {
+                                "mountPath": "/tmp/dashboards",
+                                "name": "sc-dashboard-volume"
+                            },
+                            {
+                                "mountPath": "/etc/grafana/provisioning/dashboards/sc-dashboardproviders.yaml",
+                                "name": "sc-dashboard-provider",
+                                "subPath": "provider.yaml"
+                            },
+                            {
+                                "mountPath": "/etc/grafana/provisioning/datasources",
+                                "name": "sc-datasources-volume"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-d9npg",
+                                "readOnly": true
+                            }
+                        ]
+                    }
+                ],
+                "dnsConfig": {
+                    "nameservers": [
+                        "10.97.56.246"
+                    ],
+                    "options": [
+                        {
+                            "name": "ndots",
+                            "value": "5"
+                        }
+                    ],
+                    "searches": [
+                        "grafana.svc.cluster.local",
+                        "svc.cluster.local",
+                        "cluster.local"
+                    ]
+                },
+                "dnsPolicy": "None",
+                "enableServiceLinks": false,
+                "hostAliases": [
+                    {
+                        "hostnames": [
+                            "kubernetes",
+                            "kubernetes.default",
+                            "kubernetes.default.svc"
+                        ],
+                        "ip": "10.97.83.45"
+                    }
+                ],
+                "hostname": "grafana-5b9f9b5d4b-xp844",
+                "nodeName": "catalyst-hw173-omani-works-7bb723da-me-east-215-b-w468e0e",
+                "preemptionPolicy": "PreemptLowerPriority",
+                "priority": 0,
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {
+                    "fsGroup": 472,
+                    "runAsGroup": 472,
+                    "runAsNonRoot": true,
+                    "runAsUser": 472
+                },
+                "serviceAccount": "vc-workload-mgmt-vcluster",
+                "serviceAccountName": "vc-workload-mgmt-vcluster",
+                "shareProcessNamespace": false,
+                "terminationGracePeriodSeconds": 30,
+                "tolerations": [
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "tolerationSeconds": 300
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "tolerationSeconds": 300
+                    }
+                ],
+                "volumes": [
+                    {
+                        "configMap": {
+                            "defaultMode": 420,
+                            "name": "grafana-x-grafana-x-mgmt-vcluster"
+                        },
+                        "name": "config"
+                    },
+                    {
+                        "name": "storage",
+                        "persistentVolumeClaim": {
+                            "claimName": "grafana-x-grafana-x-mgmt-vcluster"
+                        }
+                    },
+                    {
+                        "emptyDir": {},
+                        "name": "search"
+                    },
+                    {
+                        "emptyDir": {},
+                        "name": "sc-dashboard-volume"
+                    },
+                    {
+                        "configMap": {
+                            "defaultMode": 420,
+                            "name": "grafana-config-dashboards-x-grafana-x-mgmt-vcluster"
+                        },
+                        "name": "sc-dashboard-provider"
+                    },
+                    {
+                        "emptyDir": {},
+                        "name": "sc-datasources-volume"
+                    },
+                    {
+                        "name": "kube-api-access-d9npg",
+                        "projected": {
+                            "defaultMode": 420,
+                            "sources": [
+                                {
+                                    "downwardAPI": {
+                                        "items": [
+                                            {
+                                                "fieldRef": {
+                                                    "apiVersion": "v1",
+                                                    "fieldPath": "metadata.annotations['vcluster.loft.sh/token-wyzdazbj']"
+                                                },
+                                                "mode": 420,
+                                                "path": "token"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "configMap": {
+                                        "items": [
+                                            {
+                                                "key": "ca.crt",
+                                                "path": "ca.crt"
+                                            }
+                                        ],
+                                        "name": "kube-root-ca.crt-x-grafana-x-mgmt-vcluster"
+                                    }
+                                },
+                                {
+                                    "downwardAPI": {
+                                        "items": [
+                                            {
+                                                "fieldRef": {
+                                                    "apiVersion": "v1",
+                                                    "fieldPath": "metadata.annotations['vcluster.loft.sh/namespace']"
+                                                },
+                                                "path": "namespace"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-06-20T03:36:40Z",
+                        "status": "True",
+                        "type": "PodReadyToStartContainers"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-06-20T03:35:36Z",
+                        "status": "True",
+                        "type": "Initialized"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-06-20T03:35:36Z",
+                        "message": "containers with unready status: [grafana]",
+                        "reason": "ContainersNotReady",
+                        "status": "False",
+                        "type": "Ready"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-06-20T03:35:36Z",
+                        "message": "containers with unready status: [grafana]",
+                        "reason": "ContainersNotReady",
+                        "status": "False",
+                        "type": "ContainersReady"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-06-20T03:35:36Z",
+                        "status": "True",
+                        "type": "PodScheduled"
+                    }
+                ],
+                "containerStatuses": [
+                    {
+                        "image": "harbor.openova.io/proxy-dockerhub/grafana/grafana:12.3.1",
+                        "imageID": "",
+                        "lastState": {},
+                        "name": "grafana",
+                        "ready": false,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "waiting": {
+                                "message": "secret \"grafana-sso-oidc-credentials-x-grafana-x-mgmt-vcluster\" not found",
+                                "reason": "CreateContainerConfigError"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/etc/grafana/grafana.ini",
+                                "name": "config"
+                            },
+                            {
+                                "mountPath": "/var/lib/grafana",
+                                "name": "storage"
+                            },
+                            {
+                                "mountPath": "/var/lib/grafana-search",
+                                "name": "search"
+                            },
+                            {
+                                "mountPath": "/tmp/dashboards",
+                                "name": "sc-dashboard-volume"
+                            },
+                            {
+                                "mountPath": "/etc/grafana/provisioning/dashboards/sc-dashboardproviders.yaml",
+                                "name": "sc-dashboard-provider"
+                            },
+                            {
+                                "mountPath": "/etc/grafana/provisioning/datasources",
+                                "name": "sc-datasources-volume"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-d9npg",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "containerID": "containerd://d0ad2a05a72a552c2288a4cbd405bb19c72177742efc9ed9e7a02d2fb45b4360",
+                        "image": "docker.io/kiwigrid/k8s-sidecar:2.5.0",
+                        "imageID": "docker.io/kiwigrid/k8s-sidecar@sha256:a6b3f707f883108376514489a94d6629109a327b2978e1d826cd104c4ca436df",
+                        "lastState": {},
+                        "name": "grafana-sc-dashboard",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": true,
+                        "state": {
+                            "running": {
+                                "startedAt": "2026-06-20T03:35:50Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/tmp/dashboards",
+                                "name": "sc-dashboard-volume"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-d9npg",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "containerID": "containerd://8b489deda2d8e5314193cddeea6256f2170ac14830db6fe970999af34ff19feb",
+                        "image": "docker.io/kiwigrid/k8s-sidecar:2.5.0",
+                        "imageID": "docker.io/kiwigrid/k8s-sidecar@sha256:a6b3f707f883108376514489a94d6629109a327b2978e1d826cd104c4ca436df",
+                        "lastState": {},
+                        "name": "grafana-sc-datasources",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": true,
+                        "state": {
+                            "running": {
+                                "startedAt": "2026-06-20T03:35:50Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/etc/grafana/provisioning/datasources",
+                                "name": "sc-datasources-volume"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-d9npg",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    }
+                ],
+                "hostIP": "10.179.1.124",
+                "hostIPs": [
+                    {
+                        "ip": "10.179.1.124"
+                    }
+                ],
+                "phase": "Pending",
+                "podIP": "10.43.4.141",
+                "podIPs": [
+                    {
+                        "ip": "10.43.4.141"
+                    }
+                ],
+                "qosClass": "Burstable",
+                "startTime": "2026-06-20T03:35:36Z"
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": ""
+    }
+}

--- a/products/catalyst/bootstrap/api/internal/handler/testdata/hw173_3986/keycloak-a.json
+++ b/products/catalyst/bootstrap/api/internal/handler/testdata/hw173_3986/keycloak-a.json
@@ -1,0 +1,951 @@
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "annotations": {
+                    "checksum/configmap-env-vars": "e3dbf4e351779bb99f7609221644a89a198ecd144a89a3b68b65d97d389f71c2",
+                    "checksum/secrets": "e0061a139854a5b3272a0287d2a9b28c76288efadabfea76da680f4a75efdd64",
+                    "cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
+                    "vcluster.loft.sh/hosts-rewritten": "true",
+                    "vcluster.loft.sh/labels": "app.kubernetes.io/component=\"keycloak\"\napp.kubernetes.io/instance=\"keycloak\"\napp.kubernetes.io/managed-by=\"flux\"\napp.kubernetes.io/name=\"keycloak\"\napp.kubernetes.io/part-of=\"keycloak\"\napp.kubernetes.io/version=\"26.3.3\"\napps.kubernetes.io/pod-index=\"0\"\ncontroller-revision-hash=\"keycloak-5d5c456544\"\nhelm.sh/chart=\"keycloak-25.2.0\"\npolicy.cilium.io/enforced=\"true\"\nstatefulset.kubernetes.io/pod-name=\"keycloak-0\"",
+                    "vcluster.loft.sh/managed-annotations": "checksum/configmap-env-vars\nchecksum/secrets",
+                    "vcluster.loft.sh/name": "keycloak-0",
+                    "vcluster.loft.sh/namespace": "keycloak",
+                    "vcluster.loft.sh/object-host-name": "keycloak-0-x-keycloak-x-mgmt-vcluster",
+                    "vcluster.loft.sh/object-host-namespace": "mgmt",
+                    "vcluster.loft.sh/object-kind": "/v1, Kind=Pod",
+                    "vcluster.loft.sh/object-name": "keycloak-0",
+                    "vcluster.loft.sh/object-namespace": "keycloak",
+                    "vcluster.loft.sh/object-uid": "dbff9ca4-9486-42d7-9506-a245f8adb72e",
+                    "vcluster.loft.sh/owner-references": "[{\"apiVersion\":\"apps/v1\",\"kind\":\"StatefulSet\",\"name\":\"keycloak\",\"uid\":\"2022126b-d916-44ec-b9d7-1170e73644e5\",\"controller\":true,\"blockOwnerDeletion\":true}]",
+                    "vcluster.loft.sh/owner-set-kind": "StatefulSet",
+                    "vcluster.loft.sh/service-account-name": "keycloak",
+                    "vcluster.loft.sh/token-pdderfpn": "eyJhbGciOiJSUzI1NiIsImtpZCI6IkNwYXBBaDZQaEZXWmp4cmlNNWcwMlR4ZnM1RFFrUmt0T2QwSWJfSXdwU1kifQ.eyJhdWQiOlsiaHR0cHM6Ly9rdWJlcm5ldGVzLmRlZmF1bHQuc3ZjLmNsdXN0ZXIubG9jYWwiLCJodHRwczovL2t1YmVybmV0ZXMuZGVmYXVsdC5zdmMiLCJodHRwczovL2t1YmVybmV0ZXMuZGVmYXVsdCJdLCJleHAiOjIwOTcyODU1ODIsImlhdCI6MTc4MTkyNTU4MiwiaXNzIjoiaHR0cHM6Ly9rdWJlcm5ldGVzLmRlZmF1bHQuc3ZjLmNsdXN0ZXIubG9jYWwiLCJqdGkiOiI2ZjZiMjY3Yy0wZGJlLTQ2ZjItOTljZC0wYTU4MWM2MDZmOGQiLCJrdWJlcm5ldGVzLmlvIjp7Im5hbWVzcGFjZSI6ImtleWNsb2FrIiwicG9kIjp7Im5hbWUiOiJrZXljbG9hay0wIiwidWlkIjoiZGJmZjljYTQtOTQ4Ni00MmQ3LTk1MDYtYTI0NWY4YWRiNzJlIn0sInNlcnZpY2VhY2NvdW50Ijp7Im5hbWUiOiJrZXljbG9hayIsInVpZCI6ImQxNjJhYzFkLTMxODgtNDliMi05ZTMxLTY4Y2JiZDZmMTViYyJ9fSwibmJmIjoxNzgxOTI1NTgyLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6a2V5Y2xvYWs6a2V5Y2xvYWsifQ.ZsWr3wSd9E9PaLcexJB-OERCzI3Cke_gZ5nAl-UlkpQxHdzVVFiuyf_JuNYuNih8KSW0-x4UG0hA5KfQvLhL9PADA2mNsKVRcNcNkWIyZD-jJp3zbUPb06kNv2zFp0Ip4V78FBV6WtjupGGEANHgUrHcQ2ncoWv866lu2RtKfyXpjVOM_9f-HHflFwxziEB5DtrDhmc7TRlzuTcvZlGuGjCbaukYWOUIFTuDujII6OatwiyAN_gQthCkQ6uOFivz6ctwrZyMLQrxQMjRRCuGp5UzAH6ZJV7k3C7yiE5K7njxJfuyBzDOLMO3M6vB4ZBjbJCsVpeC_Gr3Keoo9szp1A",
+                    "vcluster.loft.sh/uid": "dbff9ca4-9486-42d7-9506-a245f8adb72e"
+                },
+                "creationTimestamp": "2026-06-20T03:19:42Z",
+                "labels": {
+                    "app.kubernetes.io/component": "keycloak",
+                    "app.kubernetes.io/instance": "keycloak",
+                    "app.kubernetes.io/managed-by": "flux",
+                    "app.kubernetes.io/name": "keycloak",
+                    "app.kubernetes.io/part-of": "keycloak",
+                    "app.kubernetes.io/version": "26.3.3",
+                    "apps.kubernetes.io/pod-index": "0",
+                    "controller-revision-hash": "keycloak-5d5c456544",
+                    "helm.sh/chart": "keycloak-25.2.0",
+                    "policy.cilium.io/enforced": "true",
+                    "statefulset.kubernetes.io/pod-name": "keycloak-0",
+                    "vcluster.loft.sh/managed-by": "mgmt-vcluster",
+                    "vcluster.loft.sh/namespace": "keycloak",
+                    "vcluster.loft.sh/ns-label-mgmt-vcluster-x-82a3537ff0": "keycloak",
+                    "vcluster.loft.sh/ns-label-mgmt-vcluster-x-cf1227b7b2": "keycloak"
+                },
+                "name": "keycloak-0-x-keycloak-x-mgmt-vcluster",
+                "namespace": "mgmt",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "v1",
+                        "controller": true,
+                        "kind": "Service",
+                        "name": "mgmt-vcluster",
+                        "uid": "1e8c3e36-fdf1-482f-9725-45d1f2b5fbea"
+                    }
+                ],
+                "resourceVersion": "31497",
+                "uid": "3e27b282-4afd-4aea-9b42-a6064746795b"
+            },
+            "spec": {
+                "affinity": {
+                    "podAntiAffinity": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": [
+                            {
+                                "podAffinityTerm": {
+                                    "labelSelector": {
+                                        "matchLabels": {
+                                            "app.kubernetes.io/component": "keycloak",
+                                            "app.kubernetes.io/instance": "keycloak",
+                                            "app.kubernetes.io/name": "keycloak",
+                                            "vcluster.loft.sh/managed-by": "mgmt-vcluster",
+                                            "vcluster.loft.sh/namespace": "keycloak"
+                                        }
+                                    },
+                                    "topologyKey": "kubernetes.io/hostname"
+                                },
+                                "weight": 1
+                            }
+                        ]
+                    }
+                },
+                "automountServiceAccountToken": false,
+                "containers": [
+                    {
+                        "env": [
+                            {
+                                "name": "KEYCLOAK_PORT",
+                                "value": "tcp://10.96.182.157:80"
+                            },
+                            {
+                                "name": "KEYCLOAK_PORT_80_TCP",
+                                "value": "tcp://10.96.182.157:80"
+                            },
+                            {
+                                "name": "KEYCLOAK_PORT_80_TCP_ADDR",
+                                "value": "10.96.182.157"
+                            },
+                            {
+                                "name": "KEYCLOAK_PORT_80_TCP_PORT",
+                                "value": "80"
+                            },
+                            {
+                                "name": "KEYCLOAK_PORT_80_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT",
+                                "value": "tcp://10.96.139.25:5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT_5432_TCP",
+                                "value": "tcp://10.96.139.25:5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT_5432_TCP_ADDR",
+                                "value": "10.96.139.25"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT_5432_TCP_PORT",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT_5432_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_SERVICE_HOST",
+                                "value": "10.96.139.25"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_SERVICE_PORT",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_SERVICE_PORT_TCP_POSTGRESQL",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_SERVICE_HOST",
+                                "value": "10.96.182.157"
+                            },
+                            {
+                                "name": "KEYCLOAK_SERVICE_PORT",
+                                "value": "80"
+                            },
+                            {
+                                "name": "KEYCLOAK_SERVICE_PORT_HTTP",
+                                "value": "80"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT",
+                                "value": "tcp://10.96.117.155:443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP",
+                                "value": "tcp://10.96.117.155:443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_ADDR",
+                                "value": "10.96.117.155"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_PORT",
+                                "value": "443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_HOST",
+                                "value": "10.96.117.155"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_PORT",
+                                "value": "443"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_PORT_HTTPS",
+                                "value": "443"
+                            },
+                            {
+                                "name": "KUBERNETES_NAMESPACE",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "metadata.annotations['vcluster.loft.sh/namespace']"
+                                    }
+                                }
+                            }
+                        ],
+                        "envFrom": [
+                            {
+                                "configMapRef": {
+                                    "name": "keycloak-env-vars-x-keycloak-x-mgmt-vcluster"
+                                }
+                            },
+                            {
+                                "configMapRef": {
+                                    "name": "keycloak-kc-frontend-env-x-keycloak-x-mgmt-vcluster"
+                                }
+                            }
+                        ],
+                        "image": "harbor.openova.io/proxy-dockerhub/bitnamilegacy/keycloak:26.3.3-debian-12-r0",
+                        "imagePullPolicy": "IfNotPresent",
+                        "livenessProbe": {
+                            "failureThreshold": 3,
+                            "initialDelaySeconds": 60,
+                            "periodSeconds": 1,
+                            "successThreshold": 1,
+                            "tcpSocket": {
+                                "port": "http"
+                            },
+                            "timeoutSeconds": 5
+                        },
+                        "name": "keycloak",
+                        "ports": [
+                            {
+                                "containerPort": 8080,
+                                "name": "http",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 7800,
+                                "name": "discovery",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "path": "/realms/master",
+                                "port": "http",
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 30,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 1
+                        },
+                        "resources": {
+                            "limits": {
+                                "cpu": "2",
+                                "memory": "2Gi"
+                            },
+                            "requests": {
+                                "cpu": "250m",
+                                "memory": "512Mi"
+                            }
+                        },
+                        "securityContext": {
+                            "allowPrivilegeEscalation": false,
+                            "capabilities": {
+                                "drop": [
+                                    "ALL"
+                                ]
+                            },
+                            "privileged": false,
+                            "readOnlyRootFilesystem": true,
+                            "runAsGroup": 1001,
+                            "runAsNonRoot": true,
+                            "runAsUser": 1001,
+                            "seLinuxOptions": {},
+                            "seccompProfile": {
+                                "type": "RuntimeDefault"
+                            }
+                        },
+                        "startupProbe": {
+                            "failureThreshold": 360,
+                            "httpGet": {
+                                "path": "/",
+                                "port": "http",
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 30,
+                            "periodSeconds": 5,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 5
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/tmp",
+                                "name": "empty-dir",
+                                "subPath": "tmp-dir"
+                            },
+                            {
+                                "mountPath": "/bitnami/keycloak",
+                                "name": "empty-dir",
+                                "subPath": "app-volume-dir"
+                            },
+                            {
+                                "mountPath": "/opt/bitnami/keycloak/conf",
+                                "name": "empty-dir",
+                                "subPath": "app-conf-dir"
+                            },
+                            {
+                                "mountPath": "/opt/bitnami/keycloak/lib/quarkus",
+                                "name": "empty-dir",
+                                "subPath": "app-quarkus-dir"
+                            },
+                            {
+                                "mountPath": "/opt/bitnami/keycloak/data",
+                                "name": "empty-dir",
+                                "subPath": "app-data-dir"
+                            },
+                            {
+                                "mountPath": "/opt/bitnami/keycloak/providers",
+                                "name": "empty-dir",
+                                "subPath": "app-providers-dir"
+                            },
+                            {
+                                "mountPath": "/opt/bitnami/keycloak/themes",
+                                "name": "empty-dir",
+                                "subPath": "app-themes-dir"
+                            },
+                            {
+                                "mountPath": "/opt/bitnami/keycloak/secrets",
+                                "name": "keycloak-secrets"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-cfw4b",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/etc/hosts",
+                                "name": "vcluster-rewrite-hosts",
+                                "subPath": "hosts"
+                            }
+                        ]
+                    }
+                ],
+                "dnsConfig": {
+                    "nameservers": [
+                        "10.96.212.31"
+                    ],
+                    "options": [
+                        {
+                            "name": "ndots",
+                            "value": "5"
+                        }
+                    ],
+                    "searches": [
+                        "keycloak.svc.cluster.local",
+                        "svc.cluster.local",
+                        "cluster.local"
+                    ]
+                },
+                "dnsPolicy": "None",
+                "enableServiceLinks": false,
+                "hostAliases": [
+                    {
+                        "hostnames": [
+                            "kubernetes",
+                            "kubernetes.default",
+                            "kubernetes.default.svc"
+                        ],
+                        "ip": "10.96.117.155"
+                    }
+                ],
+                "hostname": "keycloak-0",
+                "initContainers": [
+                    {
+                        "args": [
+                            "-c",
+                            "sed -E -e 's/^(\\d+.\\d+.\\d+.\\d+\\s+)keycloak-0$/\\1 keycloak-0.keycloak-headless.keycloak.svc.cluster.local keycloak-0/' /etc/hosts \u003e /hosts/hosts"
+                        ],
+                        "command": [
+                            "sh"
+                        ],
+                        "env": [
+                            {
+                                "name": "KEYCLOAK_PORT",
+                                "value": "tcp://10.96.182.157:80"
+                            },
+                            {
+                                "name": "KEYCLOAK_PORT_80_TCP",
+                                "value": "tcp://10.96.182.157:80"
+                            },
+                            {
+                                "name": "KEYCLOAK_PORT_80_TCP_ADDR",
+                                "value": "10.96.182.157"
+                            },
+                            {
+                                "name": "KEYCLOAK_PORT_80_TCP_PORT",
+                                "value": "80"
+                            },
+                            {
+                                "name": "KEYCLOAK_PORT_80_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT",
+                                "value": "tcp://10.96.139.25:5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT_5432_TCP",
+                                "value": "tcp://10.96.139.25:5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT_5432_TCP_ADDR",
+                                "value": "10.96.139.25"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT_5432_TCP_PORT",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT_5432_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_SERVICE_HOST",
+                                "value": "10.96.139.25"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_SERVICE_PORT",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_SERVICE_PORT_TCP_POSTGRESQL",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_SERVICE_HOST",
+                                "value": "10.96.182.157"
+                            },
+                            {
+                                "name": "KEYCLOAK_SERVICE_PORT",
+                                "value": "80"
+                            },
+                            {
+                                "name": "KEYCLOAK_SERVICE_PORT_HTTP",
+                                "value": "80"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT",
+                                "value": "tcp://10.96.117.155:443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP",
+                                "value": "tcp://10.96.117.155:443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_ADDR",
+                                "value": "10.96.117.155"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_PORT",
+                                "value": "443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_HOST",
+                                "value": "10.96.117.155"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_PORT",
+                                "value": "443"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_PORT_HTTPS",
+                                "value": "443"
+                            }
+                        ],
+                        "image": "library/alpine:3.20",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "vcluster-rewrite-hosts",
+                        "resources": {
+                            "limits": {
+                                "cpu": "30m",
+                                "memory": "64Mi"
+                            },
+                            "requests": {
+                                "cpu": "30m",
+                                "memory": "64Mi"
+                            }
+                        },
+                        "securityContext": {
+                            "allowPrivilegeEscalation": false,
+                            "capabilities": {
+                                "drop": [
+                                    "ALL"
+                                ]
+                            },
+                            "runAsGroup": 1001,
+                            "runAsNonRoot": true,
+                            "runAsUser": 1001,
+                            "seccompProfile": {
+                                "type": "RuntimeDefault"
+                            }
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/hosts",
+                                "name": "vcluster-rewrite-hosts"
+                            }
+                        ]
+                    },
+                    {
+                        "args": [
+                            "-ec",
+                            ". /opt/bitnami/scripts/liblog.sh\n\ninfo \"Copying writable dirs to empty dir\"\n# In order to not break the application functionality we need to make some\n# directories writable, so we need to copy it to an empty dir volume\ncp -r --preserve=mode,timestamps /opt/bitnami/keycloak/lib/quarkus /emptydir/app-quarkus-dir\ncp -r --preserve=mode,timestamps /opt/bitnami/keycloak/data /emptydir/app-data-dir\ncp -r --preserve=mode,timestamps /opt/bitnami/keycloak/providers /emptydir/app-providers-dir\ncp -r --preserve=mode,timestamps /opt/bitnami/keycloak/themes /emptydir/app-themes-dir\ninfo \"Copy operation completed\"\n"
+                        ],
+                        "command": [
+                            "/bin/bash"
+                        ],
+                        "env": [
+                            {
+                                "name": "KEYCLOAK_PORT",
+                                "value": "tcp://10.96.182.157:80"
+                            },
+                            {
+                                "name": "KEYCLOAK_PORT_80_TCP",
+                                "value": "tcp://10.96.182.157:80"
+                            },
+                            {
+                                "name": "KEYCLOAK_PORT_80_TCP_ADDR",
+                                "value": "10.96.182.157"
+                            },
+                            {
+                                "name": "KEYCLOAK_PORT_80_TCP_PORT",
+                                "value": "80"
+                            },
+                            {
+                                "name": "KEYCLOAK_PORT_80_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT",
+                                "value": "tcp://10.96.139.25:5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT_5432_TCP",
+                                "value": "tcp://10.96.139.25:5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT_5432_TCP_ADDR",
+                                "value": "10.96.139.25"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT_5432_TCP_PORT",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT_5432_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_SERVICE_HOST",
+                                "value": "10.96.139.25"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_SERVICE_PORT",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_SERVICE_PORT_TCP_POSTGRESQL",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_SERVICE_HOST",
+                                "value": "10.96.182.157"
+                            },
+                            {
+                                "name": "KEYCLOAK_SERVICE_PORT",
+                                "value": "80"
+                            },
+                            {
+                                "name": "KEYCLOAK_SERVICE_PORT_HTTP",
+                                "value": "80"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT",
+                                "value": "tcp://10.96.117.155:443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP",
+                                "value": "tcp://10.96.117.155:443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_ADDR",
+                                "value": "10.96.117.155"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_PORT",
+                                "value": "443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_HOST",
+                                "value": "10.96.117.155"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_PORT",
+                                "value": "443"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_PORT_HTTPS",
+                                "value": "443"
+                            }
+                        ],
+                        "image": "harbor.openova.io/proxy-dockerhub/bitnamilegacy/keycloak:26.3.3-debian-12-r0",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "prepare-write-dirs",
+                        "resources": {
+                            "limits": {
+                                "cpu": "150m",
+                                "ephemeral-storage": "2Gi",
+                                "memory": "192Mi"
+                            },
+                            "requests": {
+                                "cpu": "100m",
+                                "ephemeral-storage": "50Mi",
+                                "memory": "128Mi"
+                            }
+                        },
+                        "securityContext": {
+                            "allowPrivilegeEscalation": false,
+                            "capabilities": {
+                                "drop": [
+                                    "ALL"
+                                ]
+                            },
+                            "privileged": false,
+                            "readOnlyRootFilesystem": true,
+                            "runAsGroup": 1001,
+                            "runAsNonRoot": true,
+                            "runAsUser": 1001,
+                            "seLinuxOptions": {},
+                            "seccompProfile": {
+                                "type": "RuntimeDefault"
+                            }
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/emptydir",
+                                "name": "empty-dir"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-cfw4b",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/etc/hosts",
+                                "name": "vcluster-rewrite-hosts",
+                                "subPath": "hosts"
+                            }
+                        ]
+                    }
+                ],
+                "nodeName": "catalyst-hw173-omani-works-7bb723da-me-east-215-a-wc5b620",
+                "preemptionPolicy": "PreemptLowerPriority",
+                "priority": 0,
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {
+                    "fsGroup": 1001,
+                    "fsGroupChangePolicy": "Always"
+                },
+                "serviceAccount": "vc-workload-mgmt-vcluster",
+                "serviceAccountName": "vc-workload-mgmt-vcluster",
+                "terminationGracePeriodSeconds": 30,
+                "tolerations": [
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "tolerationSeconds": 300
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "tolerationSeconds": 300
+                    }
+                ],
+                "volumes": [
+                    {
+                        "emptyDir": {},
+                        "name": "empty-dir"
+                    },
+                    {
+                        "name": "keycloak-secrets",
+                        "projected": {
+                            "defaultMode": 420,
+                            "sources": [
+                                {
+                                    "secret": {
+                                        "name": "keycloak-x-keycloak-x-mgmt-vcluster"
+                                    }
+                                },
+                                {
+                                    "secret": {
+                                        "items": [
+                                            {
+                                                "key": "password",
+                                                "path": "db-password"
+                                            }
+                                        ],
+                                        "name": "keycloak-postgresql-x-keycloak-x-mgmt-vcluster"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "name": "kube-api-access-cfw4b",
+                        "projected": {
+                            "defaultMode": 420,
+                            "sources": [
+                                {
+                                    "downwardAPI": {
+                                        "items": [
+                                            {
+                                                "fieldRef": {
+                                                    "apiVersion": "v1",
+                                                    "fieldPath": "metadata.annotations['vcluster.loft.sh/token-pdderfpn']"
+                                                },
+                                                "mode": 420,
+                                                "path": "token"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "configMap": {
+                                        "items": [
+                                            {
+                                                "key": "ca.crt",
+                                                "path": "ca.crt"
+                                            }
+                                        ],
+                                        "name": "kube-root-ca.crt-x-keycloak-x-mgmt-vcluster"
+                                    }
+                                },
+                                {
+                                    "downwardAPI": {
+                                        "items": [
+                                            {
+                                                "fieldRef": {
+                                                    "apiVersion": "v1",
+                                                    "fieldPath": "metadata.annotations['vcluster.loft.sh/namespace']"
+                                                },
+                                                "path": "namespace"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "emptyDir": {},
+                        "name": "vcluster-rewrite-hosts"
+                    }
+                ]
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-06-20T03:19:46Z",
+                        "status": "True",
+                        "type": "PodReadyToStartContainers"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-06-20T03:30:28Z",
+                        "status": "True",
+                        "type": "Initialized"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-06-20T03:31:05Z",
+                        "status": "True",
+                        "type": "Ready"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-06-20T03:31:05Z",
+                        "status": "True",
+                        "type": "ContainersReady"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-06-20T03:19:42Z",
+                        "status": "True",
+                        "type": "PodScheduled"
+                    }
+                ],
+                "containerStatuses": [
+                    {
+                        "containerID": "containerd://51159e2bca2c86e75c194145a599e35e2c3bf0ef4f7b457dabd5ad9e34f86296",
+                        "image": "harbor.openova.io/proxy-dockerhub/bitnamilegacy/keycloak:26.3.3-debian-12-r0",
+                        "imageID": "harbor.openova.io/proxy-dockerhub/bitnamilegacy/keycloak@sha256:da3df0976a9f9a664bdbde6cb5308b78f03ac94d0abf33b2df355bbb06cbc5b9",
+                        "lastState": {},
+                        "name": "keycloak",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": true,
+                        "state": {
+                            "running": {
+                                "startedAt": "2026-06-20T03:30:28Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/tmp",
+                                "name": "empty-dir"
+                            },
+                            {
+                                "mountPath": "/bitnami/keycloak",
+                                "name": "empty-dir"
+                            },
+                            {
+                                "mountPath": "/opt/bitnami/keycloak/conf",
+                                "name": "empty-dir"
+                            },
+                            {
+                                "mountPath": "/opt/bitnami/keycloak/lib/quarkus",
+                                "name": "empty-dir"
+                            },
+                            {
+                                "mountPath": "/opt/bitnami/keycloak/data",
+                                "name": "empty-dir"
+                            },
+                            {
+                                "mountPath": "/opt/bitnami/keycloak/providers",
+                                "name": "empty-dir"
+                            },
+                            {
+                                "mountPath": "/opt/bitnami/keycloak/themes",
+                                "name": "empty-dir"
+                            },
+                            {
+                                "mountPath": "/opt/bitnami/keycloak/secrets",
+                                "name": "keycloak-secrets"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-cfw4b",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            },
+                            {
+                                "mountPath": "/etc/hosts",
+                                "name": "vcluster-rewrite-hosts"
+                            }
+                        ]
+                    }
+                ],
+                "hostIP": "10.169.1.28",
+                "hostIPs": [
+                    {
+                        "ip": "10.169.1.28"
+                    }
+                ],
+                "initContainerStatuses": [
+                    {
+                        "containerID": "containerd://b222ef1c5a2d444638d0ba199be5ffb3e05e4e68e0138d77fcbf11419fc0a86f",
+                        "image": "docker.io/library/alpine:3.20",
+                        "imageID": "docker.io/library/alpine@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc",
+                        "lastState": {},
+                        "name": "vcluster-rewrite-hosts",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "terminated": {
+                                "containerID": "containerd://b222ef1c5a2d444638d0ba199be5ffb3e05e4e68e0138d77fcbf11419fc0a86f",
+                                "exitCode": 0,
+                                "finishedAt": "2026-06-20T03:19:45Z",
+                                "reason": "Completed",
+                                "startedAt": "2026-06-20T03:19:45Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/hosts",
+                                "name": "vcluster-rewrite-hosts"
+                            }
+                        ]
+                    },
+                    {
+                        "containerID": "containerd://80bc06ddb89b4a9dc44e13da9bf48b83fdc9b6bc8c8ceb4dd05329fbc975719f",
+                        "image": "harbor.openova.io/proxy-dockerhub/bitnamilegacy/keycloak:26.3.3-debian-12-r0",
+                        "imageID": "harbor.openova.io/proxy-dockerhub/bitnamilegacy/keycloak@sha256:da3df0976a9f9a664bdbde6cb5308b78f03ac94d0abf33b2df355bbb06cbc5b9",
+                        "lastState": {},
+                        "name": "prepare-write-dirs",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "terminated": {
+                                "containerID": "containerd://80bc06ddb89b4a9dc44e13da9bf48b83fdc9b6bc8c8ceb4dd05329fbc975719f",
+                                "exitCode": 0,
+                                "finishedAt": "2026-06-20T03:30:25Z",
+                                "reason": "Completed",
+                                "startedAt": "2026-06-20T03:30:25Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/emptydir",
+                                "name": "empty-dir"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-cfw4b",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            },
+                            {
+                                "mountPath": "/etc/hosts",
+                                "name": "vcluster-rewrite-hosts"
+                            }
+                        ]
+                    }
+                ],
+                "phase": "Running",
+                "podIP": "10.42.2.117",
+                "podIPs": [
+                    {
+                        "ip": "10.42.2.117"
+                    }
+                ],
+                "qosClass": "Burstable",
+                "startTime": "2026-06-20T03:19:42Z"
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": ""
+    }
+}

--- a/products/catalyst/bootstrap/api/internal/handler/testdata/hw173_3986/keycloak-b.json
+++ b/products/catalyst/bootstrap/api/internal/handler/testdata/hw173_3986/keycloak-b.json
@@ -1,0 +1,951 @@
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "annotations": {
+                    "checksum/configmap-env-vars": "e3dbf4e351779bb99f7609221644a89a198ecd144a89a3b68b65d97d389f71c2",
+                    "checksum/secrets": "e1a16f42bdd74ec9e2461249298e5c832eb1c68664c4534bda645720cf837cf8",
+                    "cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
+                    "vcluster.loft.sh/hosts-rewritten": "true",
+                    "vcluster.loft.sh/labels": "app.kubernetes.io/component=\"keycloak\"\napp.kubernetes.io/instance=\"keycloak\"\napp.kubernetes.io/managed-by=\"flux\"\napp.kubernetes.io/name=\"keycloak\"\napp.kubernetes.io/part-of=\"keycloak\"\napp.kubernetes.io/version=\"26.3.3\"\napps.kubernetes.io/pod-index=\"0\"\ncontroller-revision-hash=\"keycloak-5f568999bc\"\nhelm.sh/chart=\"keycloak-25.2.0\"\npolicy.cilium.io/enforced=\"true\"\nstatefulset.kubernetes.io/pod-name=\"keycloak-0\"",
+                    "vcluster.loft.sh/managed-annotations": "checksum/configmap-env-vars\nchecksum/secrets",
+                    "vcluster.loft.sh/name": "keycloak-0",
+                    "vcluster.loft.sh/namespace": "keycloak",
+                    "vcluster.loft.sh/object-host-name": "keycloak-0-x-keycloak-x-mgmt-vcluster",
+                    "vcluster.loft.sh/object-host-namespace": "mgmt",
+                    "vcluster.loft.sh/object-kind": "/v1, Kind=Pod",
+                    "vcluster.loft.sh/object-name": "keycloak-0",
+                    "vcluster.loft.sh/object-namespace": "keycloak",
+                    "vcluster.loft.sh/object-uid": "c4d64583-a355-4373-919e-cc7c83e3e521",
+                    "vcluster.loft.sh/owner-references": "[{\"apiVersion\":\"apps/v1\",\"kind\":\"StatefulSet\",\"name\":\"keycloak\",\"uid\":\"34460a36-0855-45a6-8c8d-6a3f88208697\",\"controller\":true,\"blockOwnerDeletion\":true}]",
+                    "vcluster.loft.sh/owner-set-kind": "StatefulSet",
+                    "vcluster.loft.sh/service-account-name": "keycloak",
+                    "vcluster.loft.sh/token-jbjqmkxw": "eyJhbGciOiJSUzI1NiIsImtpZCI6ImRhbG5uLTRBMHZBdHhRUEVqY2FlUElISk16ZDZERlF6ZjBsYTByYW9rUTAifQ.eyJhdWQiOlsiaHR0cHM6Ly9rdWJlcm5ldGVzLmRlZmF1bHQuc3ZjLmNsdXN0ZXIubG9jYWwiLCJodHRwczovL2t1YmVybmV0ZXMuZGVmYXVsdC5zdmMiLCJodHRwczovL2t1YmVybmV0ZXMuZGVmYXVsdCJdLCJleHAiOjIwOTcyODYxMzUsImlhdCI6MTc4MTkyNjEzNSwiaXNzIjoiaHR0cHM6Ly9rdWJlcm5ldGVzLmRlZmF1bHQuc3ZjLmNsdXN0ZXIubG9jYWwiLCJqdGkiOiJkMDViMDZkNi1hMTJlLTRjNjgtYWMwMi1iMGEwMDU1YTQ4MjIiLCJrdWJlcm5ldGVzLmlvIjp7Im5hbWVzcGFjZSI6ImtleWNsb2FrIiwicG9kIjp7Im5hbWUiOiJrZXljbG9hay0wIiwidWlkIjoiYzRkNjQ1ODMtYTM1NS00MzczLTkxOWUtY2M3YzgzZTNlNTIxIn0sInNlcnZpY2VhY2NvdW50Ijp7Im5hbWUiOiJrZXljbG9hayIsInVpZCI6IjNkNTkyNzkzLTY2ZDktNDEyMy1hZGQwLTQ5ZWMxZDBhYmM1OSJ9fSwibmJmIjoxNzgxOTI2MTM1LCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6a2V5Y2xvYWs6a2V5Y2xvYWsifQ.dvvqdCwch45PZlE6ZDCUG0hbYT0Rd4A5l3u1BSa9tMkgpnV9MSHbweO6RQ5WkTmbMjbuRVpilLtgO3cLzBzKhhZgQTHd5rBwCMmL5psiTG5h-Z88_EVXDnO6juvuAcZxyWpP4_zpYqPptemkdwQ51aTevs-lJqnSQzyKgqzRBtJhKwVfqwTz0rL9-d8wykxwL3ypd5N82DOoPUwdXyVKvhnvLHZczeP84N9aYHpZj9cHQtUJFcBuh5TNoHDhyT-L1KbP483OTlYE7Q2MMiDvMrcrh4FsjAvCqEfhVqpzvr6F09cl5ITRVDUojweN1hVJ720Vx6zWC-yW2U-G3jtpeg",
+                    "vcluster.loft.sh/uid": "c4d64583-a355-4373-919e-cc7c83e3e521"
+                },
+                "creationTimestamp": "2026-06-20T03:28:55Z",
+                "labels": {
+                    "app.kubernetes.io/component": "keycloak",
+                    "app.kubernetes.io/instance": "keycloak",
+                    "app.kubernetes.io/managed-by": "flux",
+                    "app.kubernetes.io/name": "keycloak",
+                    "app.kubernetes.io/part-of": "keycloak",
+                    "app.kubernetes.io/version": "26.3.3",
+                    "apps.kubernetes.io/pod-index": "0",
+                    "controller-revision-hash": "keycloak-5f568999bc",
+                    "helm.sh/chart": "keycloak-25.2.0",
+                    "policy.cilium.io/enforced": "true",
+                    "statefulset.kubernetes.io/pod-name": "keycloak-0",
+                    "vcluster.loft.sh/managed-by": "mgmt-vcluster",
+                    "vcluster.loft.sh/namespace": "keycloak",
+                    "vcluster.loft.sh/ns-label-mgmt-vcluster-x-82a3537ff0": "keycloak",
+                    "vcluster.loft.sh/ns-label-mgmt-vcluster-x-cf1227b7b2": "keycloak"
+                },
+                "name": "keycloak-0-x-keycloak-x-mgmt-vcluster",
+                "namespace": "mgmt",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "v1",
+                        "controller": true,
+                        "kind": "Service",
+                        "name": "mgmt-vcluster",
+                        "uid": "37149640-d492-4758-93d3-f157d152d649"
+                    }
+                ],
+                "resourceVersion": "30405",
+                "uid": "9b4769c3-8fa9-4909-afc6-abb2494f6254"
+            },
+            "spec": {
+                "affinity": {
+                    "podAntiAffinity": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": [
+                            {
+                                "podAffinityTerm": {
+                                    "labelSelector": {
+                                        "matchLabels": {
+                                            "app.kubernetes.io/component": "keycloak",
+                                            "app.kubernetes.io/instance": "keycloak",
+                                            "app.kubernetes.io/name": "keycloak",
+                                            "vcluster.loft.sh/managed-by": "mgmt-vcluster",
+                                            "vcluster.loft.sh/namespace": "keycloak"
+                                        }
+                                    },
+                                    "topologyKey": "kubernetes.io/hostname"
+                                },
+                                "weight": 1
+                            }
+                        ]
+                    }
+                },
+                "automountServiceAccountToken": false,
+                "containers": [
+                    {
+                        "env": [
+                            {
+                                "name": "KEYCLOAK_PORT",
+                                "value": "tcp://10.97.76.107:80"
+                            },
+                            {
+                                "name": "KEYCLOAK_PORT_80_TCP",
+                                "value": "tcp://10.97.76.107:80"
+                            },
+                            {
+                                "name": "KEYCLOAK_PORT_80_TCP_ADDR",
+                                "value": "10.97.76.107"
+                            },
+                            {
+                                "name": "KEYCLOAK_PORT_80_TCP_PORT",
+                                "value": "80"
+                            },
+                            {
+                                "name": "KEYCLOAK_PORT_80_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT",
+                                "value": "tcp://10.97.41.225:5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT_5432_TCP",
+                                "value": "tcp://10.97.41.225:5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT_5432_TCP_ADDR",
+                                "value": "10.97.41.225"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT_5432_TCP_PORT",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT_5432_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_SERVICE_HOST",
+                                "value": "10.97.41.225"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_SERVICE_PORT",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_SERVICE_PORT_TCP_POSTGRESQL",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_SERVICE_HOST",
+                                "value": "10.97.76.107"
+                            },
+                            {
+                                "name": "KEYCLOAK_SERVICE_PORT",
+                                "value": "80"
+                            },
+                            {
+                                "name": "KEYCLOAK_SERVICE_PORT_HTTP",
+                                "value": "80"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT",
+                                "value": "tcp://10.97.83.45:443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP",
+                                "value": "tcp://10.97.83.45:443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_ADDR",
+                                "value": "10.97.83.45"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_PORT",
+                                "value": "443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_HOST",
+                                "value": "10.97.83.45"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_PORT",
+                                "value": "443"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_PORT_HTTPS",
+                                "value": "443"
+                            },
+                            {
+                                "name": "KUBERNETES_NAMESPACE",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "metadata.annotations['vcluster.loft.sh/namespace']"
+                                    }
+                                }
+                            }
+                        ],
+                        "envFrom": [
+                            {
+                                "configMapRef": {
+                                    "name": "keycloak-env-vars-x-keycloak-x-mgmt-vcluster"
+                                }
+                            },
+                            {
+                                "configMapRef": {
+                                    "name": "keycloak-kc-frontend-env-x-keycloak-x-mgmt-vcluster"
+                                }
+                            }
+                        ],
+                        "image": "harbor.openova.io/proxy-dockerhub/bitnamilegacy/keycloak:26.3.3-debian-12-r0",
+                        "imagePullPolicy": "IfNotPresent",
+                        "livenessProbe": {
+                            "failureThreshold": 3,
+                            "initialDelaySeconds": 60,
+                            "periodSeconds": 1,
+                            "successThreshold": 1,
+                            "tcpSocket": {
+                                "port": "http"
+                            },
+                            "timeoutSeconds": 5
+                        },
+                        "name": "keycloak",
+                        "ports": [
+                            {
+                                "containerPort": 8080,
+                                "name": "http",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 7800,
+                                "name": "discovery",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "path": "/realms/master",
+                                "port": "http",
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 30,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 1
+                        },
+                        "resources": {
+                            "limits": {
+                                "cpu": "2",
+                                "memory": "2Gi"
+                            },
+                            "requests": {
+                                "cpu": "250m",
+                                "memory": "512Mi"
+                            }
+                        },
+                        "securityContext": {
+                            "allowPrivilegeEscalation": false,
+                            "capabilities": {
+                                "drop": [
+                                    "ALL"
+                                ]
+                            },
+                            "privileged": false,
+                            "readOnlyRootFilesystem": true,
+                            "runAsGroup": 1001,
+                            "runAsNonRoot": true,
+                            "runAsUser": 1001,
+                            "seLinuxOptions": {},
+                            "seccompProfile": {
+                                "type": "RuntimeDefault"
+                            }
+                        },
+                        "startupProbe": {
+                            "failureThreshold": 360,
+                            "httpGet": {
+                                "path": "/",
+                                "port": "http",
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 30,
+                            "periodSeconds": 5,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 5
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/tmp",
+                                "name": "empty-dir",
+                                "subPath": "tmp-dir"
+                            },
+                            {
+                                "mountPath": "/bitnami/keycloak",
+                                "name": "empty-dir",
+                                "subPath": "app-volume-dir"
+                            },
+                            {
+                                "mountPath": "/opt/bitnami/keycloak/conf",
+                                "name": "empty-dir",
+                                "subPath": "app-conf-dir"
+                            },
+                            {
+                                "mountPath": "/opt/bitnami/keycloak/lib/quarkus",
+                                "name": "empty-dir",
+                                "subPath": "app-quarkus-dir"
+                            },
+                            {
+                                "mountPath": "/opt/bitnami/keycloak/data",
+                                "name": "empty-dir",
+                                "subPath": "app-data-dir"
+                            },
+                            {
+                                "mountPath": "/opt/bitnami/keycloak/providers",
+                                "name": "empty-dir",
+                                "subPath": "app-providers-dir"
+                            },
+                            {
+                                "mountPath": "/opt/bitnami/keycloak/themes",
+                                "name": "empty-dir",
+                                "subPath": "app-themes-dir"
+                            },
+                            {
+                                "mountPath": "/opt/bitnami/keycloak/secrets",
+                                "name": "keycloak-secrets"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-cm76x",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/etc/hosts",
+                                "name": "vcluster-rewrite-hosts",
+                                "subPath": "hosts"
+                            }
+                        ]
+                    }
+                ],
+                "dnsConfig": {
+                    "nameservers": [
+                        "10.97.56.246"
+                    ],
+                    "options": [
+                        {
+                            "name": "ndots",
+                            "value": "5"
+                        }
+                    ],
+                    "searches": [
+                        "keycloak.svc.cluster.local",
+                        "svc.cluster.local",
+                        "cluster.local"
+                    ]
+                },
+                "dnsPolicy": "None",
+                "enableServiceLinks": false,
+                "hostAliases": [
+                    {
+                        "hostnames": [
+                            "kubernetes",
+                            "kubernetes.default",
+                            "kubernetes.default.svc"
+                        ],
+                        "ip": "10.97.83.45"
+                    }
+                ],
+                "hostname": "keycloak-0",
+                "initContainers": [
+                    {
+                        "args": [
+                            "-c",
+                            "sed -E -e 's/^(\\d+.\\d+.\\d+.\\d+\\s+)keycloak-0$/\\1 keycloak-0.keycloak-headless.keycloak.svc.cluster.local keycloak-0/' /etc/hosts \u003e /hosts/hosts"
+                        ],
+                        "command": [
+                            "sh"
+                        ],
+                        "env": [
+                            {
+                                "name": "KEYCLOAK_PORT",
+                                "value": "tcp://10.97.76.107:80"
+                            },
+                            {
+                                "name": "KEYCLOAK_PORT_80_TCP",
+                                "value": "tcp://10.97.76.107:80"
+                            },
+                            {
+                                "name": "KEYCLOAK_PORT_80_TCP_ADDR",
+                                "value": "10.97.76.107"
+                            },
+                            {
+                                "name": "KEYCLOAK_PORT_80_TCP_PORT",
+                                "value": "80"
+                            },
+                            {
+                                "name": "KEYCLOAK_PORT_80_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT",
+                                "value": "tcp://10.97.41.225:5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT_5432_TCP",
+                                "value": "tcp://10.97.41.225:5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT_5432_TCP_ADDR",
+                                "value": "10.97.41.225"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT_5432_TCP_PORT",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT_5432_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_SERVICE_HOST",
+                                "value": "10.97.41.225"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_SERVICE_PORT",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_SERVICE_PORT_TCP_POSTGRESQL",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_SERVICE_HOST",
+                                "value": "10.97.76.107"
+                            },
+                            {
+                                "name": "KEYCLOAK_SERVICE_PORT",
+                                "value": "80"
+                            },
+                            {
+                                "name": "KEYCLOAK_SERVICE_PORT_HTTP",
+                                "value": "80"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT",
+                                "value": "tcp://10.97.83.45:443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP",
+                                "value": "tcp://10.97.83.45:443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_ADDR",
+                                "value": "10.97.83.45"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_PORT",
+                                "value": "443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_HOST",
+                                "value": "10.97.83.45"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_PORT",
+                                "value": "443"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_PORT_HTTPS",
+                                "value": "443"
+                            }
+                        ],
+                        "image": "library/alpine:3.20",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "vcluster-rewrite-hosts",
+                        "resources": {
+                            "limits": {
+                                "cpu": "30m",
+                                "memory": "64Mi"
+                            },
+                            "requests": {
+                                "cpu": "30m",
+                                "memory": "64Mi"
+                            }
+                        },
+                        "securityContext": {
+                            "allowPrivilegeEscalation": false,
+                            "capabilities": {
+                                "drop": [
+                                    "ALL"
+                                ]
+                            },
+                            "runAsGroup": 1001,
+                            "runAsNonRoot": true,
+                            "runAsUser": 1001,
+                            "seccompProfile": {
+                                "type": "RuntimeDefault"
+                            }
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/hosts",
+                                "name": "vcluster-rewrite-hosts"
+                            }
+                        ]
+                    },
+                    {
+                        "args": [
+                            "-ec",
+                            ". /opt/bitnami/scripts/liblog.sh\n\ninfo \"Copying writable dirs to empty dir\"\n# In order to not break the application functionality we need to make some\n# directories writable, so we need to copy it to an empty dir volume\ncp -r --preserve=mode,timestamps /opt/bitnami/keycloak/lib/quarkus /emptydir/app-quarkus-dir\ncp -r --preserve=mode,timestamps /opt/bitnami/keycloak/data /emptydir/app-data-dir\ncp -r --preserve=mode,timestamps /opt/bitnami/keycloak/providers /emptydir/app-providers-dir\ncp -r --preserve=mode,timestamps /opt/bitnami/keycloak/themes /emptydir/app-themes-dir\ninfo \"Copy operation completed\"\n"
+                        ],
+                        "command": [
+                            "/bin/bash"
+                        ],
+                        "env": [
+                            {
+                                "name": "KEYCLOAK_PORT",
+                                "value": "tcp://10.97.76.107:80"
+                            },
+                            {
+                                "name": "KEYCLOAK_PORT_80_TCP",
+                                "value": "tcp://10.97.76.107:80"
+                            },
+                            {
+                                "name": "KEYCLOAK_PORT_80_TCP_ADDR",
+                                "value": "10.97.76.107"
+                            },
+                            {
+                                "name": "KEYCLOAK_PORT_80_TCP_PORT",
+                                "value": "80"
+                            },
+                            {
+                                "name": "KEYCLOAK_PORT_80_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT",
+                                "value": "tcp://10.97.41.225:5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT_5432_TCP",
+                                "value": "tcp://10.97.41.225:5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT_5432_TCP_ADDR",
+                                "value": "10.97.41.225"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT_5432_TCP_PORT",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_PORT_5432_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_SERVICE_HOST",
+                                "value": "10.97.41.225"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_SERVICE_PORT",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_POSTGRESQL_SERVICE_PORT_TCP_POSTGRESQL",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "KEYCLOAK_SERVICE_HOST",
+                                "value": "10.97.76.107"
+                            },
+                            {
+                                "name": "KEYCLOAK_SERVICE_PORT",
+                                "value": "80"
+                            },
+                            {
+                                "name": "KEYCLOAK_SERVICE_PORT_HTTP",
+                                "value": "80"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT",
+                                "value": "tcp://10.97.83.45:443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP",
+                                "value": "tcp://10.97.83.45:443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_ADDR",
+                                "value": "10.97.83.45"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_PORT",
+                                "value": "443"
+                            },
+                            {
+                                "name": "KUBERNETES_PORT_443_TCP_PROTO",
+                                "value": "tcp"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_HOST",
+                                "value": "10.97.83.45"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_PORT",
+                                "value": "443"
+                            },
+                            {
+                                "name": "KUBERNETES_SERVICE_PORT_HTTPS",
+                                "value": "443"
+                            }
+                        ],
+                        "image": "harbor.openova.io/proxy-dockerhub/bitnamilegacy/keycloak:26.3.3-debian-12-r0",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "prepare-write-dirs",
+                        "resources": {
+                            "limits": {
+                                "cpu": "150m",
+                                "ephemeral-storage": "2Gi",
+                                "memory": "192Mi"
+                            },
+                            "requests": {
+                                "cpu": "100m",
+                                "ephemeral-storage": "50Mi",
+                                "memory": "128Mi"
+                            }
+                        },
+                        "securityContext": {
+                            "allowPrivilegeEscalation": false,
+                            "capabilities": {
+                                "drop": [
+                                    "ALL"
+                                ]
+                            },
+                            "privileged": false,
+                            "readOnlyRootFilesystem": true,
+                            "runAsGroup": 1001,
+                            "runAsNonRoot": true,
+                            "runAsUser": 1001,
+                            "seLinuxOptions": {},
+                            "seccompProfile": {
+                                "type": "RuntimeDefault"
+                            }
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/emptydir",
+                                "name": "empty-dir"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-cm76x",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/etc/hosts",
+                                "name": "vcluster-rewrite-hosts",
+                                "subPath": "hosts"
+                            }
+                        ]
+                    }
+                ],
+                "nodeName": "catalyst-hw173-omani-works-7bb723da-me-east-215-b-wd65403",
+                "preemptionPolicy": "PreemptLowerPriority",
+                "priority": 0,
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {
+                    "fsGroup": 1001,
+                    "fsGroupChangePolicy": "Always"
+                },
+                "serviceAccount": "vc-workload-mgmt-vcluster",
+                "serviceAccountName": "vc-workload-mgmt-vcluster",
+                "terminationGracePeriodSeconds": 30,
+                "tolerations": [
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "tolerationSeconds": 300
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "tolerationSeconds": 300
+                    }
+                ],
+                "volumes": [
+                    {
+                        "emptyDir": {},
+                        "name": "empty-dir"
+                    },
+                    {
+                        "name": "keycloak-secrets",
+                        "projected": {
+                            "defaultMode": 420,
+                            "sources": [
+                                {
+                                    "secret": {
+                                        "name": "keycloak-x-keycloak-x-mgmt-vcluster"
+                                    }
+                                },
+                                {
+                                    "secret": {
+                                        "items": [
+                                            {
+                                                "key": "password",
+                                                "path": "db-password"
+                                            }
+                                        ],
+                                        "name": "keycloak-postgresql-x-keycloak-x-mgmt-vcluster"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "name": "kube-api-access-cm76x",
+                        "projected": {
+                            "defaultMode": 420,
+                            "sources": [
+                                {
+                                    "downwardAPI": {
+                                        "items": [
+                                            {
+                                                "fieldRef": {
+                                                    "apiVersion": "v1",
+                                                    "fieldPath": "metadata.annotations['vcluster.loft.sh/token-jbjqmkxw']"
+                                                },
+                                                "mode": 420,
+                                                "path": "token"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "configMap": {
+                                        "items": [
+                                            {
+                                                "key": "ca.crt",
+                                                "path": "ca.crt"
+                                            }
+                                        ],
+                                        "name": "kube-root-ca.crt-x-keycloak-x-mgmt-vcluster"
+                                    }
+                                },
+                                {
+                                    "downwardAPI": {
+                                        "items": [
+                                            {
+                                                "fieldRef": {
+                                                    "apiVersion": "v1",
+                                                    "fieldPath": "metadata.annotations['vcluster.loft.sh/namespace']"
+                                                },
+                                                "path": "namespace"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "emptyDir": {},
+                        "name": "vcluster-rewrite-hosts"
+                    }
+                ]
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-06-20T03:28:57Z",
+                        "status": "True",
+                        "type": "PodReadyToStartContainers"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-06-20T03:34:32Z",
+                        "status": "True",
+                        "type": "Initialized"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-06-20T03:35:10Z",
+                        "status": "True",
+                        "type": "Ready"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-06-20T03:35:10Z",
+                        "status": "True",
+                        "type": "ContainersReady"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-06-20T03:28:55Z",
+                        "status": "True",
+                        "type": "PodScheduled"
+                    }
+                ],
+                "containerStatuses": [
+                    {
+                        "containerID": "containerd://481577d386e33edf4d4b8c622cf348d88bed329195ede16e2d03678a99c531b5",
+                        "image": "harbor.openova.io/proxy-dockerhub/bitnamilegacy/keycloak:26.3.3-debian-12-r0",
+                        "imageID": "harbor.openova.io/proxy-dockerhub/bitnamilegacy/keycloak@sha256:da3df0976a9f9a664bdbde6cb5308b78f03ac94d0abf33b2df355bbb06cbc5b9",
+                        "lastState": {},
+                        "name": "keycloak",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": true,
+                        "state": {
+                            "running": {
+                                "startedAt": "2026-06-20T03:34:33Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/tmp",
+                                "name": "empty-dir"
+                            },
+                            {
+                                "mountPath": "/bitnami/keycloak",
+                                "name": "empty-dir"
+                            },
+                            {
+                                "mountPath": "/opt/bitnami/keycloak/conf",
+                                "name": "empty-dir"
+                            },
+                            {
+                                "mountPath": "/opt/bitnami/keycloak/lib/quarkus",
+                                "name": "empty-dir"
+                            },
+                            {
+                                "mountPath": "/opt/bitnami/keycloak/data",
+                                "name": "empty-dir"
+                            },
+                            {
+                                "mountPath": "/opt/bitnami/keycloak/providers",
+                                "name": "empty-dir"
+                            },
+                            {
+                                "mountPath": "/opt/bitnami/keycloak/themes",
+                                "name": "empty-dir"
+                            },
+                            {
+                                "mountPath": "/opt/bitnami/keycloak/secrets",
+                                "name": "keycloak-secrets"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-cm76x",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            },
+                            {
+                                "mountPath": "/etc/hosts",
+                                "name": "vcluster-rewrite-hosts"
+                            }
+                        ]
+                    }
+                ],
+                "hostIP": "10.179.1.91",
+                "hostIPs": [
+                    {
+                        "ip": "10.179.1.91"
+                    }
+                ],
+                "initContainerStatuses": [
+                    {
+                        "containerID": "containerd://d8294de5b788d6a95215061c7c5d4c29efeaab55d205f9508ff3470819c9a0f5",
+                        "image": "docker.io/library/alpine:3.20",
+                        "imageID": "docker.io/library/alpine@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc",
+                        "lastState": {},
+                        "name": "vcluster-rewrite-hosts",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "terminated": {
+                                "containerID": "containerd://d8294de5b788d6a95215061c7c5d4c29efeaab55d205f9508ff3470819c9a0f5",
+                                "exitCode": 0,
+                                "finishedAt": "2026-06-20T03:28:56Z",
+                                "reason": "Completed",
+                                "startedAt": "2026-06-20T03:28:56Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/hosts",
+                                "name": "vcluster-rewrite-hosts"
+                            }
+                        ]
+                    },
+                    {
+                        "containerID": "containerd://f23e98512502278293b0c93d75dd3ded60ca8743c3c06703ad313acc96535cbb",
+                        "image": "harbor.openova.io/proxy-dockerhub/bitnamilegacy/keycloak:26.3.3-debian-12-r0",
+                        "imageID": "harbor.openova.io/proxy-dockerhub/bitnamilegacy/keycloak@sha256:da3df0976a9f9a664bdbde6cb5308b78f03ac94d0abf33b2df355bbb06cbc5b9",
+                        "lastState": {},
+                        "name": "prepare-write-dirs",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "terminated": {
+                                "containerID": "containerd://f23e98512502278293b0c93d75dd3ded60ca8743c3c06703ad313acc96535cbb",
+                                "exitCode": 0,
+                                "finishedAt": "2026-06-20T03:34:27Z",
+                                "reason": "Completed",
+                                "startedAt": "2026-06-20T03:34:27Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/emptydir",
+                                "name": "empty-dir"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-cm76x",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            },
+                            {
+                                "mountPath": "/etc/hosts",
+                                "name": "vcluster-rewrite-hosts"
+                            }
+                        ]
+                    }
+                ],
+                "phase": "Running",
+                "podIP": "10.43.1.100",
+                "podIPs": [
+                    {
+                        "ip": "10.43.1.100"
+                    }
+                ],
+                "qosClass": "Burstable",
+                "startTime": "2026-06-20T03:28:55Z"
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": ""
+    }
+}

--- a/products/catalyst/bootstrap/api/internal/handler/testdata/hw173_3986/nodes-a.json
+++ b/products/catalyst/bootstrap/api/internal/handler/testdata/hw173_3986/nodes-a.json
@@ -1,0 +1,2911 @@
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "alpha.kubernetes.io/provided-node-ip": "10.169.1.43",
+                    "etcd.k3s.cattle.io/local-snapshots-timestamp": "2026-06-20T12:00:03+08:00",
+                    "etcd.k3s.cattle.io/node-address": "10.169.1.43",
+                    "etcd.k3s.cattle.io/node-name": "catalyst-hw173-omani-works-7bb723da-me-east-215-a-cp1-dea611-3890e578",
+                    "k3s.io/external-ip": "212.72.24.30",
+                    "k3s.io/hostname": "catalyst-hw173-omani-works-7bb723da-me-east-215-a-cp1-dea611",
+                    "k3s.io/internal-ip": "10.169.1.43",
+                    "k3s.io/node-args": "[\"server\",\"--cluster-init\",\"--flannel-backend\",\"none\",\"--disable-network-policy\",\"--disable\",\"traefik\",\"--disable\",\"servicelb\",\"--cluster-cidr\",\"10.42.0.0/16\",\"--service-cidr\",\"10.96.0.0/16\",\"--node-ip\",\"10.169.1.43\",\"--node-external-ip\",\"212.72.24.30\",\"--advertise-address\",\"10.169.1.43\",\"--kubelet-arg\",\"max-pods=220\",\"--tls-san\",\"hw173.omani.works\",\"--tls-san\",\"10.169.1.43\",\"--tls-san\",\"212.72.24.30\",\"--node-label\",\"catalyst.openova.io/role=control-plane\",\"--node-label\",\"openova.io/region=hw-me-east-215-a-rtz-prod\",\"--node-label\",\"topology.kubernetes.io/region=me-east-215-a\",\"--node-label\",\"topology.kubernetes.io/zone=me-east-215-a\",\"--node-label\",\"catalyst.openova.io/provider=huawei\",\"--kube-apiserver-arg\",\"default-watch-cache-size=200\",\"--kube-apiserver-arg\",\"watch-cache-sizes=secrets#500,configmaps#500\",\"--etcd-snapshot-retention\",\"5\",\"--write-kubeconfig-mode\",\"0644\"]",
+                    "k3s.io/node-config-hash": "5N7TF3OKGAT35UTHJND6WTCCZQKFZ46QA3IPV3H3QZKEZYRNVZHA====",
+                    "k3s.io/node-env": "{\"K3S_TOKEN\":\"********\"}",
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2026-06-20T02:58:07Z",
+                "finalizers": [
+                    "wrangler.cattle.io/node",
+                    "wrangler.cattle.io/managed-etcd-controller"
+                ],
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "k3s",
+                    "beta.kubernetes.io/os": "linux",
+                    "catalyst.openova.io/provider": "huawei",
+                    "catalyst.openova.io/role": "control-plane",
+                    "failure-domain.beta.kubernetes.io/region": "me-east-215-a",
+                    "failure-domain.beta.kubernetes.io/zone": "me-east-215-a",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "catalyst-hw173-omani-works-7bb723da-me-east-215-a-cp1-dea611",
+                    "kubernetes.io/os": "linux",
+                    "node-role.kubernetes.io/control-plane": "true",
+                    "node-role.kubernetes.io/etcd": "true",
+                    "node-role.kubernetes.io/master": "true",
+                    "node.kubernetes.io/instance-type": "k3s",
+                    "openova.io/region": "hw-me-east-215-a-rtz-prod",
+                    "topology.kubernetes.io/region": "me-east-215-a",
+                    "topology.kubernetes.io/zone": "me-east-215-a"
+                },
+                "name": "catalyst-hw173-omani-works-7bb723da-me-east-215-a-cp1-dea611",
+                "resourceVersion": "898690",
+                "uid": "cc508104-23b6-4250-ab16-6be23033ce6a"
+            },
+            "spec": {
+                "podCIDR": "10.42.0.0/24",
+                "podCIDRs": [
+                    "10.42.0.0/24"
+                ],
+                "providerID": "k3s://catalyst-hw173-omani-works-7bb723da-me-east-215-a-cp1-dea611"
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "10.169.1.43",
+                        "type": "InternalIP"
+                    },
+                    {
+                        "address": "212.72.24.30",
+                        "type": "ExternalIP"
+                    },
+                    {
+                        "address": "catalyst-hw173-omani-works-7bb723da-me-east-215-a-cp1-dea611",
+                        "type": "Hostname"
+                    }
+                ],
+                "allocatable": {
+                    "cpu": "2",
+                    "ephemeral-storage": "39857063496",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "16176736Ki",
+                    "pods": "220"
+                },
+                "capacity": {
+                    "cpu": "2",
+                    "ephemeral-storage": "40971488Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "16176736Ki",
+                    "pods": "220"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2026-06-20T02:59:49Z",
+                        "lastTransitionTime": "2026-06-20T02:59:49Z",
+                        "message": "Cilium is running on this node",
+                        "reason": "CiliumIsUp",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:09:21Z",
+                        "lastTransitionTime": "2026-06-20T02:58:21Z",
+                        "message": "Node is a voting member of the etcd cluster",
+                        "reason": "MemberNotLearner",
+                        "status": "True",
+                        "type": "EtcdIsVoter"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:10:03Z",
+                        "lastTransitionTime": "2026-06-20T02:58:07Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:10:03Z",
+                        "lastTransitionTime": "2026-06-20T02:58:07Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:10:03Z",
+                        "lastTransitionTime": "2026-06-20T02:58:07Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:10:03Z",
+                        "lastTransitionTime": "2026-06-20T02:59:45Z",
+                        "message": "kubelet is posting ready status",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10250
+                    }
+                },
+                "images": [
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/catalyst-api@sha256:3e233095b657e7c84da1e200c45d483e6c7ab509b23cf8bfe1bf0b8dfd01dfad",
+                            "ghcr.io/openova-io/openova/catalyst-api:c7d040a"
+                        ],
+                        "sizeBytes": 456618827
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/alpine/k8s@sha256:dfe8c7a06c41d0b6e8757da99531f8f302e9a2687fa0155af4c4087df585c9c8",
+                            "harbor.openova.io/proxy-dockerhub/alpine/k8s:1.31.1"
+                        ],
+                        "sizeBytes": 306265288
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql@sha256:027303cd89644acdeba67d2b37f70eff6a7f345220f127721ff92504e1e4eae6",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16"
+                        ],
+                        "sizeBytes": 258220911
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/cilium@sha256:758ca0793f5995bb938a2fa219dcce63dc0b3fa7fc4ce5cc851125281fb7361d"
+                        ],
+                        "sizeBytes": 224306600
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql@sha256:99be063781d171d3971089b49c992706bdab9ccbd2b57cdf126c7542773aedfe",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16.4"
+                        ],
+                        "sizeBytes": 217672880
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/grafana/alloy@sha256:6e00cf7c5a692ff5f24844529416ed017d76fce922f8199004e73d5eca46b6b8",
+                            "harbor.openova.io/proxy-dockerhub/grafana/alloy:v1.16.0"
+                        ],
+                        "sizeBytes": 151457664
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/amazon/aws-cli@sha256:643507c10ada7964ca6157b3d799f030b90577643da9955d319a77399ed80d73",
+                            "harbor.openova.io/proxy-dockerhub/amazon/aws-cli:2.17.0"
+                        ],
+                        "sizeBytes": 125732170
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl@sha256:64614ef8290f3fb27fed5164b338debeeb79a1e5e26c93eb920770b71abd7c48",
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.31.4"
+                        ],
+                        "sizeBytes": 111911970
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl@sha256:1249fc292e84a38575ee0cadc3e28dcd7ddf5a3a4e5da401b1a8599e8ac52a1b",
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7"
+                        ],
+                        "sizeBytes": 110946736
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/kyverno/kyverno-cli@sha256:1e99a199adb36cedddf5c3e2fc24a150e26cf2e18b9e8dfe505a3c862647a4eb",
+                            "harbor.openova.io/proxy-ghcr/kyverno/kyverno-cli:v1.18.0"
+                        ],
+                        "sizeBytes": 103609401
+                    },
+                    {
+                        "names": [
+                            "docker.io/powerdns/pdns-auth-50@sha256:1f136c4fa4f995279b43c6a8413dde05147cc9b74a437e188f92b0088c523a8d",
+                            "docker.io/powerdns/pdns-auth-50:5.0.3"
+                        ],
+                        "sizeBytes": 102061459
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/cilium-envoy@sha256:709c08ade3d17d52da4ca2af33f431360ec26268d288d9a6cd1d98acc9a1dced"
+                        ],
+                        "sizeBytes": 62862122
+                    },
+                    {
+                        "names": [
+                            "mirror.gcr.io/aquasec/trivy@sha256:be1190afcb28352bfddc4ddeb71470835d16462af68d310f9f4bca710961a41e",
+                            "mirror.gcr.io/aquasec/trivy:0.70.0"
+                        ],
+                        "sizeBytes": 58469315
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/fluxcd/kustomize-controller@sha256:e3b0cf847e9cdf47b19af0fbcfe22786b80b598e0caeea8b6d2a5f9c26a48a24",
+                            "ghcr.io/fluxcd/kustomize-controller:v1.4.0"
+                        ],
+                        "sizeBytes": 54969920
+                    },
+                    {
+                        "names": [
+                            "docker.io/falcosecurity/falco@sha256:b4166a61f41e2fa638c041cac881d8bb32c284e3aaf282fdfed80f15f6eb55e3",
+                            "docker.io/falcosecurity/falco:0.43.1"
+                        ],
+                        "sizeBytes": 50563340
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/fluxcd/notification-controller@sha256:425309a159b15e07f7d97622effc79bc432a37ed55289dd465d37fa217a92a7d",
+                            "ghcr.io/fluxcd/notification-controller:v1.4.0"
+                        ],
+                        "sizeBytes": 43654595
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/fluxcd/helm-controller@sha256:4c75ca6c24ceb1f1bd7e935d9287a93e4f925c512f206763ec5a47de3ef3ff48",
+                            "ghcr.io/fluxcd/helm-controller:v1.1.0"
+                        ],
+                        "sizeBytes": 40818921
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/fluxcd/image-reflector-controller@sha256:c6864684f96cfbb3a91c816084032bb019b302af8b63b0e06b12b4018a9a8242",
+                            "ghcr.io/fluxcd/image-reflector-controller:v0.33.0"
+                        ],
+                        "sizeBytes": 38586158
+                    },
+                    {
+                        "names": [
+                            "docker.io/grafana/tempo@sha256:65a5789759435f1ef696f1953258b9bbdb18eb571d5ce711ff812d2e128288a4",
+                            "docker.io/grafana/tempo:2.9.0"
+                        ],
+                        "sizeBytes": 36423494
+                    },
+                    {
+                        "names": [
+                            "registry.k8s.io/external-dns/external-dns@sha256:4f3ba4c2bd28030caad05bb7b47fbf47549a46d5e8443b74f0be463550b4fc2b",
+                            "registry.k8s.io/external-dns/external-dns:v0.15.1"
+                        ],
+                        "sizeBytes": 33661299
+                    },
+                    {
+                        "names": [
+                            "docker.io/falcosecurity/falcoctl@sha256:0d3bddce03a26365b86e6ff1aa5c51965d2e16569e8cf8b3e37a3d3ef186dc9b",
+                            "docker.io/falcosecurity/falcoctl:0.12.2"
+                        ],
+                        "sizeBytes": 33185258
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/fluxcd/source-controller@sha256:3c5f0f022f990ffc0daf00e5b199548fc0fa6e7119e972318f0267081a332963",
+                            "ghcr.io/fluxcd/source-controller:v1.4.1"
+                        ],
+                        "sizeBytes": 32386205
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/catalyst-ui@sha256:450056eef6ba1980235f03c2ec2331a363075e94b687fe4cdbd09abebff4b829",
+                            "ghcr.io/openova-io/openova/catalyst-ui:d52f76e"
+                        ],
+                        "sizeBytes": 31804289
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/catalyst-ui@sha256:93bc0cd1fdea1db23225bbd3ee634ebaa0f574bf0240417581be1b4c5911d398",
+                            "ghcr.io/openova-io/openova/catalyst-ui:c7d040a"
+                        ],
+                        "sizeBytes": 31794686
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/catalyst-ui@sha256:f47e82ea05fc26f3183aa05341880b17f0753aca0dfd5fdaeb727fe8c42f4784",
+                            "ghcr.io/openova-io/openova/catalyst-ui:24e4f22"
+                        ],
+                        "sizeBytes": 31794668
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/catalyst-ui@sha256:4d451633940a290e1925584b8bdfd645ee6e5dbfdd3c364b0558e958495e5d34",
+                            "ghcr.io/openova-io/openova/catalyst-ui:25b7727"
+                        ],
+                        "sizeBytes": 31790738
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/catalyst-ui@sha256:ffa43e74696da2b69514d1d7e2c494f03808147a6dbcbd7668d40db2cf8fa9b6",
+                            "ghcr.io/openova-io/openova/catalyst-ui:3a1bb63"
+                        ],
+                        "sizeBytes": 31789597
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/operator-generic@sha256:f7884848483bbcd7b1e0ccfd34ba4546f258b460cb4b7e2f06a1bcc96ef88039"
+                        ],
+                        "sizeBytes": 31216191
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/marketplace@sha256:a5eccce2d44f344dd3f984fbf7742fc21fa67077ebdd3f2522a2e6ec88cff162",
+                            "ghcr.io/openova-io/openova/marketplace:ac8e023"
+                        ],
+                        "sizeBytes": 26213737
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/console@sha256:f220f466b119562bfcdcba9da60220f7e10ae8c71788e987826d27b6a3ad527e",
+                            "ghcr.io/openova-io/openova/console:3c2f7e4"
+                        ],
+                        "sizeBytes": 26126565
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/admin@sha256:836defa5c46ad5e21a212fcb707ab067ea60264edb4446efb70a74a96affd424",
+                            "ghcr.io/openova-io/openova/admin:3c2f7e4"
+                        ],
+                        "sizeBytes": 26103885
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/fluxcd/image-automation-controller@sha256:5b6c2e97055cfe69fe8996f48b53db039c136210dbc98c5631864a9e573d0e20",
+                            "ghcr.io/fluxcd/image-automation-controller:v0.39.0"
+                        ],
+                        "sizeBytes": 22354899
+                    },
+                    {
+                        "names": [
+                            "docker.io/rancher/mirrored-coredns-coredns@sha256:82979ddf442c593027a57239ad90616deb874e90c365d1a96ad508c2104bdea5",
+                            "docker.io/rancher/mirrored-coredns-coredns:1.12.0"
+                        ],
+                        "sizeBytes": 20938299
+                    },
+                    {
+                        "names": [
+                            "docker.io/natsio/jetstream-controller@sha256:5f38a5fe3ad179ffaca897edd6742f5fd26d3d5cf22de069c8fe024c52adab39",
+                            "docker.io/natsio/jetstream-controller:0.18.2"
+                        ],
+                        "sizeBytes": 20349008
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/aquasecurity/node-collector@sha256:f4702ce4667388f0219d6248d623a7e816231c2d4561d6af01c3ae053e524025",
+                            "ghcr.io/aquasecurity/node-collector:0.3.1"
+                        ],
+                        "sizeBytes": 20174022
+                    },
+                    {
+                        "names": [
+                            "docker.io/rancher/mirrored-metrics-server@sha256:dccf8474fb910fef261d31d9483d7e4c1df7b86cf4d638fb6a7d7c88bd51600a",
+                            "docker.io/rancher/mirrored-metrics-server:v0.7.2"
+                        ],
+                        "sizeBytes": 19494186
+                    },
+                    {
+                        "names": [
+                            "docker.io/rancher/local-path-provisioner@sha256:9b914881170048f80ae9302f36e5b99b4a6b18af73a38adc1c66d12f65d360be",
+                            "docker.io/rancher/local-path-provisioner:v0.0.30"
+                        ],
+                        "sizeBytes": 18584855
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/organization-controller@sha256:5db285364a423be98a81185fbe09ef05fe23d628744f7e86f479b52f0358506a",
+                            "ghcr.io/openova-io/openova/organization-controller:300d853"
+                        ],
+                        "sizeBytes": 17698913
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/environment-controller@sha256:2a2dd00e93f0aef618f86bf46b45bc8342775686fff508f136e2a19f725c40f0",
+                            "ghcr.io/openova-io/openova/environment-controller:01db043"
+                        ],
+                        "sizeBytes": 16808753
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/useraccess-controller@sha256:8d865fc5241e520b3a9fd16f2597e32e5c9eb08aa41b83b7b9e4fd40ce599974",
+                            "ghcr.io/openova-io/openova/useraccess-controller:01db043"
+                        ],
+                        "sizeBytes": 16674249
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-quay/prometheus-operator/prometheus-config-reloader@sha256:959d47672fbff2776a04ec62b8afcec89e8c036af84dc5fade50019dab212746",
+                            "harbor.openova.io/proxy-quay/prometheus-operator/prometheus-config-reloader:v0.81.0"
+                        ],
+                        "sizeBytes": 14433657
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/corazawaf/coraza-spoa@sha256:e8e9e21f494fa334de5ad469fbdb3d595b2651d1db88105f5971cb2eada27cb1",
+                            "ghcr.io/corazawaf/coraza-spoa:0.7.0"
+                        ],
+                        "sizeBytes": 11937882
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/k8s-ws-proxy@sha256:0e3c679c9f78b302575cf9d6e2ae0e5d82d861e4d6de19876df0ca496677825b",
+                            "ghcr.io/openova-io/openova/k8s-ws-proxy:b32eb9b"
+                        ],
+                        "sizeBytes": 11403264
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/openova-flow-adapter-flux@sha256:ffc60bb400d3b8e8e7d19ced0b8714d038ee6c9b9012cc9019e2341d57c1989f",
+                            "ghcr.io/openova-io/openova/openova-flow-adapter-flux:b32eb9b"
+                        ],
+                        "sizeBytes": 10917169
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/application-controller@sha256:4f93ec89305c6c2df2044022e3e4027be122326d79b1ecd201948b4e1eb2bfe3",
+                            "ghcr.io/openova-io/openova/application-controller:01db043"
+                        ],
+                        "sizeBytes": 9783902
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/curlimages/curl@sha256:d9b4541e214bcd85196d6e92e2753ac6d0ea699f0af5741f8c6cccbfcf00ef4b",
+                            "harbor.openova.io/proxy-dockerhub/curlimages/curl:8.10.1"
+                        ],
+                        "sizeBytes": 9414401
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/services-tenant@sha256:b10165940cb83d6bc73462fca172aaf5f09093d0edd4d55893e768903e9b6445",
+                            "ghcr.io/openova-io/openova/services-tenant:c068e6a"
+                        ],
+                        "sizeBytes": 9198708
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/services-provisioning@sha256:c63cd2e345206404083210f83d9d454ae9b50338dc98fb183ed27cbefe551061",
+                            "ghcr.io/openova-io/openova/services-provisioning:c068e6a"
+                        ],
+                        "sizeBytes": 5662896
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/services-domain@sha256:4c8b60ed4282d8d58f67a078ac762aac551de29abfcb8c33ae0bc29f78167f71",
+                            "ghcr.io/openova-io/openova/services-domain:c068e6a"
+                        ],
+                        "sizeBytes": 5535697
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/services-catalog@sha256:cb7211549ce610067b492f4c823c01c50fbe0523f8a53713abadc6e0aa2d48b0",
+                            "ghcr.io/openova-io/openova/services-catalog:c068e6a"
+                        ],
+                        "sizeBytes": 5333143
+                    }
+                ],
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "b274f7c1-d401-49e0-8546-3a4dbc39e410",
+                    "containerRuntimeVersion": "containerd://1.7.23-k3s2",
+                    "kernelVersion": "5.15.0-76-generic",
+                    "kubeProxyVersion": "v1.31.4+k3s1",
+                    "kubeletVersion": "v1.31.4+k3s1",
+                    "machineID": "41895bd1876a403788902e232a28f6c9",
+                    "operatingSystem": "linux",
+                    "osImage": "Ubuntu 22.04.2 LTS",
+                    "systemUUID": "b3313987-d9aa-4ade-be60-d044c6cf1b4c"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "alpha.kubernetes.io/provided-node-ip": "10.169.1.2",
+                    "k3s.io/hostname": "catalyst-hw173-omani-works-7bb723da-me-east-215-a-w21d1c8",
+                    "k3s.io/internal-ip": "10.169.1.2",
+                    "k3s.io/node-args": "[\"agent\",\"--node-label\",\"catalyst.openova.io/provider=huawei\",\"--node-label\",\"openova.io/region=hw-me-east-215-a-rtz-prod\",\"--node-label\",\"topology.kubernetes.io/region=me-east-215-a\",\"--node-label\",\"topology.kubernetes.io/zone=me-east-215-a\"]",
+                    "k3s.io/node-config-hash": "IGBSO4FMC7NARQHWC2L6GVMICVTYKLUIOWX7FPNTZJHOZOLQ7FCQ====",
+                    "k3s.io/node-env": "{\"K3S_TOKEN\":\"********\",\"K3S_URL\":\"https://10.169.1.43:6443\"}",
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2026-06-20T02:59:54Z",
+                "finalizers": [
+                    "wrangler.cattle.io/node",
+                    "wrangler.cattle.io/managed-etcd-controller"
+                ],
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "k3s",
+                    "beta.kubernetes.io/os": "linux",
+                    "catalyst.openova.io/provider": "huawei",
+                    "failure-domain.beta.kubernetes.io/region": "me-east-215-a",
+                    "failure-domain.beta.kubernetes.io/zone": "me-east-215-a",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "catalyst-hw173-omani-works-7bb723da-me-east-215-a-w21d1c8",
+                    "kubernetes.io/os": "linux",
+                    "node.kubernetes.io/instance-type": "k3s",
+                    "openova.io/region": "hw-me-east-215-a-rtz-prod",
+                    "topology.kubernetes.io/region": "me-east-215-a",
+                    "topology.kubernetes.io/zone": "me-east-215-a"
+                },
+                "name": "catalyst-hw173-omani-works-7bb723da-me-east-215-a-w21d1c8",
+                "resourceVersion": "897893",
+                "uid": "ed04c269-fac2-4092-9a26-a962798e4c98"
+            },
+            "spec": {
+                "podCIDR": "10.42.1.0/24",
+                "podCIDRs": [
+                    "10.42.1.0/24"
+                ],
+                "providerID": "k3s://catalyst-hw173-omani-works-7bb723da-me-east-215-a-w21d1c8"
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "10.169.1.2",
+                        "type": "InternalIP"
+                    },
+                    {
+                        "address": "catalyst-hw173-omani-works-7bb723da-me-east-215-a-w21d1c8",
+                        "type": "Hostname"
+                    }
+                ],
+                "allocatable": {
+                    "cpu": "4",
+                    "ephemeral-storage": "39857063496",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "32666744Ki",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "cpu": "4",
+                    "ephemeral-storage": "40971488Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "32666744Ki",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2026-06-20T03:01:07Z",
+                        "lastTransitionTime": "2026-06-20T03:01:07Z",
+                        "message": "Cilium is running on this node",
+                        "reason": "CiliumIsUp",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:09:19Z",
+                        "lastTransitionTime": "2026-06-20T02:59:54Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:09:19Z",
+                        "lastTransitionTime": "2026-06-20T02:59:54Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:09:19Z",
+                        "lastTransitionTime": "2026-06-20T02:59:54Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:09:19Z",
+                        "lastTransitionTime": "2026-06-20T03:01:03Z",
+                        "message": "kubelet is posting ready status",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10250
+                    }
+                },
+                "images": [
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql@sha256:027303cd89644acdeba67d2b37f70eff6a7f345220f127721ff92504e1e4eae6",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16"
+                        ],
+                        "sizeBytes": 258220911
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/cilium@sha256:758ca0793f5995bb938a2fa219dcce63dc0b3fa7fc4ce5cc851125281fb7361d"
+                        ],
+                        "sizeBytes": 224306600
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql@sha256:99be063781d171d3971089b49c992706bdab9ccbd2b57cdf126c7542773aedfe",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16.4"
+                        ],
+                        "sizeBytes": 217672880
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/grafana/grafana@sha256:2175aaa91c96733d86d31cf270d5310b278654b03f5718c59de12a865380a31f",
+                            "harbor.openova.io/proxy-dockerhub/grafana/grafana:12.3.1"
+                        ],
+                        "sizeBytes": 210410945
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/grafana/alloy@sha256:6e00cf7c5a692ff5f24844529416ed017d76fce922f8199004e73d5eca46b6b8",
+                            "harbor.openova.io/proxy-dockerhub/grafana/alloy:v1.16.0"
+                        ],
+                        "sizeBytes": 151457664
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/amazon/aws-cli@sha256:643507c10ada7964ca6157b3d799f030b90577643da9955d319a77399ed80d73",
+                            "harbor.openova.io/proxy-dockerhub/amazon/aws-cli:2.17.0"
+                        ],
+                        "sizeBytes": 125732170
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl@sha256:64614ef8290f3fb27fed5164b338debeeb79a1e5e26c93eb920770b71abd7c48",
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.31.4"
+                        ],
+                        "sizeBytes": 111911970
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl@sha256:1249fc292e84a38575ee0cadc3e28dcd7ddf5a3a4e5da401b1a8599e8ac52a1b",
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7"
+                        ],
+                        "sizeBytes": 110946736
+                    },
+                    {
+                        "names": [
+                            "docker.io/chrislusf/seaweedfs@sha256:84429e5f21fad82246f5cfae7b39e9a17da18afb62f2b79c25ccd364ab02793b",
+                            "docker.io/chrislusf/seaweedfs:4.22"
+                        ],
+                        "sizeBytes": 100503219
+                    },
+                    {
+                        "names": [
+                            "docker.io/otel/opentelemetry-collector-contrib@sha256:a516c26968aa1feb5e5fc0562e3338ea13755cb4f373603226bcc4e276374ad0",
+                            "docker.io/otel/opentelemetry-collector-contrib:0.150.1"
+                        ],
+                        "sizeBytes": 98571324
+                    },
+                    {
+                        "names": [
+                            "docker.io/velero/velero@sha256:e4d1e79be2ee1d51056734ada5e51c78a29b924e4d055cd28e0b4103ae2268ad",
+                            "docker.io/velero/velero:v1.18.0"
+                        ],
+                        "sizeBytes": 78724238
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/gitea/gitea@sha256:6b068c75b3454016b0304d0bb158b027cae6393fc668ce6a3727d4f4016261ed",
+                            "harbor.openova.io/proxy-dockerhub/gitea/gitea:1.22.3-rootless"
+                        ],
+                        "sizeBytes": 67735375
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-quay/openbao/openbao@sha256:7de07aa6df3937d44c96c2d65c188b2d4a70546f2a764ad4510301305af6a223",
+                            "harbor.openova.io/proxy-quay/openbao/openbao:2.1.0"
+                        ],
+                        "sizeBytes": 62890555
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/cilium-envoy@sha256:709c08ade3d17d52da4ca2af33f431360ec26268d288d9a6cd1d98acc9a1dced"
+                        ],
+                        "sizeBytes": 62862122
+                    },
+                    {
+                        "names": [
+                            "quay.io/minio/minio@sha256:1dce27c494a16bae114774f1cec295493f3613142713130c2d22dd5696be6ad3",
+                            "quay.io/minio/minio:RELEASE.2024-12-18T13-15-44Z"
+                        ],
+                        "sizeBytes": 62642371
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/loft-sh/vcluster@sha256:521b2fc8c8d0c2f1254d7fb956fbf274d3328f1e555270b57a886f9ae10d2109",
+                            "harbor.openova.io/proxy-ghcr/loft-sh/vcluster:0.23.0"
+                        ],
+                        "sizeBytes": 60761070
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/newapi-mirror@sha256:e596cb4aa2c234d88c3e05f41d430f405e6ccfdfa7acc8972c97793e9add4c36",
+                            "ghcr.io/openova-io/openova/newapi-mirror:v0.13.2"
+                        ],
+                        "sizeBytes": 58999657
+                    },
+                    {
+                        "names": [
+                            "mirror.gcr.io/aquasec/trivy@sha256:be1190afcb28352bfddc4ddeb71470835d16462af68d310f9f4bca710961a41e",
+                            "mirror.gcr.io/aquasec/trivy:0.70.0"
+                        ],
+                        "sizeBytes": 58469315
+                    },
+                    {
+                        "names": [
+                            "docker.io/falcosecurity/falco@sha256:b4166a61f41e2fa638c041cac881d8bb32c284e3aaf282fdfed80f15f6eb55e3",
+                            "docker.io/falcosecurity/falco:0.43.1"
+                        ],
+                        "sizeBytes": 50563340
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/kyverno/background-controller@sha256:fd6d30964297f1c94c2d741a1c44d055994cd4354e6f7e718cad59e6b5aa6c66",
+                            "harbor.openova.io/proxy-ghcr/kyverno/background-controller:v1.18.0"
+                        ],
+                        "sizeBytes": 45603201
+                    },
+                    {
+                        "names": [
+                            "docker.io/velero/velero-plugin-for-aws@sha256:7e82f717f44e89671212e0dfce7e061321c386ea84a33bca64a671670ca6c278",
+                            "docker.io/velero/velero-plugin-for-aws:v1.14.0"
+                        ],
+                        "sizeBytes": 39572667
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/cloudnative-pg@sha256:68074486205a33ed41928761e22ad48278c690feebe8316727a1c6b3380f9e5e",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/cloudnative-pg:1.29.0"
+                        ],
+                        "sizeBytes": 36402270
+                    },
+                    {
+                        "names": [
+                            "docker.io/grafana/mimir@sha256:686138d9f941508c99c931cc9e69bf9f6100dd4d2d623bf57b38d5c25ee645c1",
+                            "docker.io/grafana/mimir:3.0.4"
+                        ],
+                        "sizeBytes": 33769654
+                    },
+                    {
+                        "names": [
+                            "docker.io/falcosecurity/falcoctl@sha256:0d3bddce03a26365b86e6ff1aa5c51965d2e16569e8cf8b3e37a3d3ef186dc9b",
+                            "docker.io/falcosecurity/falcoctl:0.12.2"
+                        ],
+                        "sizeBytes": 33185258
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/fluxcd/source-controller@sha256:3c5f0f022f990ffc0daf00e5b199548fc0fa6e7119e972318f0267081a332963",
+                            "harbor.openova.io/proxy-ghcr/fluxcd/source-controller:v1.4.1"
+                        ],
+                        "sizeBytes": 32386205
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/catalyst-ui@sha256:3c7379154ced83418849277a7ebdf02189a471127c203b2742dacc6e232f1579",
+                            "ghcr.io/openova-io/openova/catalyst-ui:ba69881"
+                        ],
+                        "sizeBytes": 31804137
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/catalyst-ui@sha256:77803d8ce20edcfc684c467867d0ec2425f9eae301055c8a3a424c23450bed06",
+                            "ghcr.io/openova-io/openova/catalyst-ui:5a8f964"
+                        ],
+                        "sizeBytes": 31789275
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/catalyst-ui@sha256:c8ccc438c838a12c46311e730f23c7c54e8d8e15bba62ca826af47afbc5d1b40",
+                            "ghcr.io/openova-io/openova/catalyst-ui:2876e02"
+                        ],
+                        "sizeBytes": 31761897
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/operator-generic@sha256:f7884848483bbcd7b1e0ccfd34ba4546f258b460cb4b7e2f06a1bcc96ef88039"
+                        ],
+                        "sizeBytes": 31216191
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-k8s/kube-apiserver@sha256:ace6a943b058439bd6daeb74f152e7c36e6fc0b5e481cdff9364cd6ca0473e5e",
+                            "harbor.openova.io/proxy-k8s/kube-apiserver:v1.31.4"
+                        ],
+                        "sizeBytes": 27972283
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-k8s/kube-controller-manager@sha256:4bd1d4a449e7a1a4f375bd7c71abf48a95f8949b38f725ded255077329f21f7b",
+                            "harbor.openova.io/proxy-k8s/kube-controller-manager:v1.31.4"
+                        ],
+                        "sizeBytes": 26147269
+                    },
+                    {
+                        "names": [
+                            "quay.io/brancz/kube-rbac-proxy@sha256:2c7b120590cbe9f634f5099f2cbb91d0b668569023a81505ca124a5c437e7663",
+                            "quay.io/brancz/kube-rbac-proxy:v0.15.0"
+                        ],
+                        "sizeBytes": 25017413
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator@sha256:ac26ee0a25a3513f0743c45b214c57a789fd64570b72c78d844686eda81e2b3e",
+                            "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.101.0"
+                        ],
+                        "sizeBytes": 24090204
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-quay/kiwigrid/k8s-sidecar@sha256:a6b3f707f883108376514489a94d6629109a327b2978e1d826cd104c4ca436df",
+                            "harbor.openova.io/proxy-quay/kiwigrid/k8s-sidecar:2.5.0"
+                        ],
+                        "sizeBytes": 23422974
+                    },
+                    {
+                        "names": [
+                            "quay.io/jetstack/cert-manager-controller@sha256:ac105277e06e134a3d474d1535f1dc46f2606ebecf69b458e096d5f428e34fcb",
+                            "quay.io/jetstack/cert-manager-controller:v1.16.5"
+                        ],
+                        "sizeBytes": 21207976
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/aquasecurity/node-collector@sha256:f4702ce4667388f0219d6248d623a7e816231c2d4561d6af01c3ae053e524025",
+                            "ghcr.io/aquasecurity/node-collector:0.3.1"
+                        ],
+                        "sizeBytes": 20174022
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-quay/oauth2-proxy/oauth2-proxy@sha256:dcb6ff8dd21bf3058f6a22c6fa385fa5b897a9cd3914c88a2cc2bb0a85f8065d",
+                            "harbor.openova.io/proxy-quay/oauth2-proxy/oauth2-proxy:v7.6.0"
+                        ],
+                        "sizeBytes": 16521978
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-quay/prometheus-operator/prometheus-config-reloader@sha256:959d47672fbff2776a04ec62b8afcec89e8c036af84dc5fade50019dab212746",
+                            "harbor.openova.io/proxy-quay/prometheus-operator/prometheus-config-reloader:v0.81.0"
+                        ],
+                        "sizeBytes": 14433657
+                    },
+                    {
+                        "names": [
+                            "quay.io/jetstack/cert-manager-startupapicheck@sha256:8c122cb4ed0d3e42b528b2b868a10522222ceeef8e91f80f16f1d0e2206aefda",
+                            "quay.io/jetstack/cert-manager-startupapicheck:v1.16.5"
+                        ],
+                        "sizeBytes": 14113488
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/k8s-ws-proxy@sha256:0e3c679c9f78b302575cf9d6e2ae0e5d82d861e4d6de19876df0ca496677825b",
+                            "ghcr.io/openova-io/openova/k8s-ws-proxy:b32eb9b"
+                        ],
+                        "sizeBytes": 11403264
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/openova-flow-adapter-flux@sha256:ffc60bb400d3b8e8e7d19ced0b8714d038ee6c9b9012cc9019e2341d57c1989f",
+                            "ghcr.io/openova-io/openova/openova-flow-adapter-flux:b32eb9b"
+                        ],
+                        "sizeBytes": 10917169
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/curlimages/curl@sha256:d9b4541e214bcd85196d6e92e2753ac6d0ea699f0af5741f8c6cccbfcf00ef4b",
+                            "harbor.openova.io/proxy-dockerhub/curlimages/curl:8.10.1"
+                        ],
+                        "sizeBytes": 9414401
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/services-auth@sha256:626c863bddfaba576294164e0d29d9594f6a38e65b577b0b95fd5adf4fae5baa",
+                            "ghcr.io/openova-io/openova/services-auth:2529da1"
+                        ],
+                        "sizeBytes": 4781044
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/newapi-sandbox-bridge@sha256:170363bf9b313db7844a566df72aa07ab483d31c1eb2af59694da65169483c02",
+                            "ghcr.io/openova-io/openova/newapi-sandbox-bridge:5d818d4"
+                        ],
+                        "sizeBytes": 4477093
+                    },
+                    {
+                        "names": [
+                            "docker.io/library/alpine@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc",
+                            "harbor.openova.io/proxy-dockerhub/library/alpine@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc",
+                            "docker.io/library/alpine:3.20",
+                            "harbor.openova.io/proxy-dockerhub/library/alpine:3.20"
+                        ],
+                        "sizeBytes": 3641182
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/services-metering-sidecar@sha256:259420d49d42b44d8ce36ab062e1fb88d033571c98362008951f195636b086ff",
+                            "ghcr.io/openova-io/openova/services-metering-sidecar:41e02c8"
+                        ],
+                        "sizeBytes": 3548511
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/library/busybox@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662",
+                            "harbor.openova.io/proxy-dockerhub/library/busybox:1.36"
+                        ],
+                        "sizeBytes": 2217006
+                    },
+                    {
+                        "names": [
+                            "docker.io/rancher/mirrored-library-busybox@sha256:8a45424ddf949bbe9bb3231b05f9032a45da5cd036eb4867b511b00734756d6f",
+                            "docker.io/rancher/mirrored-library-busybox:1.36.1"
+                        ],
+                        "sizeBytes": 2147340
+                    },
+                    {
+                        "names": [
+                            "docker.io/rancher/mirrored-pause@sha256:74c4244427b7312c5b901fe0f67cbc53683d06f4f24c6faee65d4182bf0fa893",
+                            "docker.io/rancher/mirrored-pause:3.6"
+                        ],
+                        "sizeBytes": 301463
+                    }
+                ],
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "be38faa3-dc45-4169-810b-3ea3bde86293",
+                    "containerRuntimeVersion": "containerd://1.7.23-k3s2",
+                    "kernelVersion": "5.15.0-76-generic",
+                    "kubeProxyVersion": "v1.31.4+k3s1",
+                    "kubeletVersion": "v1.31.4+k3s1",
+                    "machineID": "41895bd1876a403788902e232a28f6c9",
+                    "operatingSystem": "linux",
+                    "osImage": "Ubuntu 22.04.2 LTS",
+                    "systemUUID": "9ff483b6-3814-4c65-8718-25a404114e1e"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "alpha.kubernetes.io/provided-node-ip": "10.169.1.51",
+                    "k3s.io/hostname": "catalyst-hw173-omani-works-7bb723da-me-east-215-a-wa0b878",
+                    "k3s.io/internal-ip": "10.169.1.51",
+                    "k3s.io/node-args": "[\"agent\",\"--node-label\",\"catalyst.openova.io/provider=huawei\",\"--node-label\",\"openova.io/region=hw-me-east-215-a-rtz-prod\",\"--node-label\",\"topology.kubernetes.io/region=me-east-215-a\",\"--node-label\",\"topology.kubernetes.io/zone=me-east-215-a\"]",
+                    "k3s.io/node-config-hash": "IGBSO4FMC7NARQHWC2L6GVMICVTYKLUIOWX7FPNTZJHOZOLQ7FCQ====",
+                    "k3s.io/node-env": "{\"K3S_TOKEN\":\"********\",\"K3S_URL\":\"https://10.169.1.43:6443\"}",
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2026-06-20T03:01:57Z",
+                "finalizers": [
+                    "wrangler.cattle.io/node",
+                    "wrangler.cattle.io/managed-etcd-controller"
+                ],
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "k3s",
+                    "beta.kubernetes.io/os": "linux",
+                    "catalyst.openova.io/provider": "huawei",
+                    "failure-domain.beta.kubernetes.io/region": "me-east-215-a",
+                    "failure-domain.beta.kubernetes.io/zone": "me-east-215-a",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "catalyst-hw173-omani-works-7bb723da-me-east-215-a-wa0b878",
+                    "kubernetes.io/os": "linux",
+                    "node.kubernetes.io/instance-type": "k3s",
+                    "openova.io/region": "hw-me-east-215-a-rtz-prod",
+                    "topology.kubernetes.io/region": "me-east-215-a",
+                    "topology.kubernetes.io/zone": "me-east-215-a"
+                },
+                "name": "catalyst-hw173-omani-works-7bb723da-me-east-215-a-wa0b878",
+                "resourceVersion": "900495",
+                "uid": "562a0785-168a-421c-a800-a32a3822e616"
+            },
+            "spec": {
+                "podCIDR": "10.42.3.0/24",
+                "podCIDRs": [
+                    "10.42.3.0/24"
+                ],
+                "providerID": "k3s://catalyst-hw173-omani-works-7bb723da-me-east-215-a-wa0b878"
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "10.169.1.51",
+                        "type": "InternalIP"
+                    },
+                    {
+                        "address": "catalyst-hw173-omani-works-7bb723da-me-east-215-a-wa0b878",
+                        "type": "Hostname"
+                    }
+                ],
+                "allocatable": {
+                    "cpu": "4",
+                    "ephemeral-storage": "39857063496",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "32666744Ki",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "cpu": "4",
+                    "ephemeral-storage": "40971488Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "32666744Ki",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2026-06-20T03:03:20Z",
+                        "lastTransitionTime": "2026-06-20T03:03:20Z",
+                        "message": "Cilium is running on this node",
+                        "reason": "CiliumIsUp",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:11:41Z",
+                        "lastTransitionTime": "2026-06-20T03:01:56Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:11:41Z",
+                        "lastTransitionTime": "2026-06-20T03:01:56Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:11:41Z",
+                        "lastTransitionTime": "2026-06-20T03:01:56Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:11:41Z",
+                        "lastTransitionTime": "2026-06-20T03:03:14Z",
+                        "message": "kubelet is posting ready status",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10250
+                    }
+                },
+                "images": [
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/alpine/k8s@sha256:9c4976d47656d78cf53a92b0203fc54ac45eae18a2b45001ac221c27da4c8036",
+                            "harbor.openova.io/proxy-dockerhub/alpine/k8s:1.31.4"
+                        ],
+                        "sizeBytes": 315720891
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql@sha256:027303cd89644acdeba67d2b37f70eff6a7f345220f127721ff92504e1e4eae6",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16"
+                        ],
+                        "sizeBytes": 258220911
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/cilium@sha256:758ca0793f5995bb938a2fa219dcce63dc0b3fa7fc4ce5cc851125281fb7361d"
+                        ],
+                        "sizeBytes": 224306600
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/grafana/alloy@sha256:6e00cf7c5a692ff5f24844529416ed017d76fce922f8199004e73d5eca46b6b8",
+                            "harbor.openova.io/proxy-dockerhub/grafana/alloy:v1.16.0"
+                        ],
+                        "sizeBytes": 151457664
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/amazon/aws-cli@sha256:643507c10ada7964ca6157b3d799f030b90577643da9955d319a77399ed80d73",
+                            "harbor.openova.io/proxy-dockerhub/amazon/aws-cli:2.17.0"
+                        ],
+                        "sizeBytes": 125732170
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl@sha256:64614ef8290f3fb27fed5164b338debeeb79a1e5e26c93eb920770b71abd7c48",
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.31.4"
+                        ],
+                        "sizeBytes": 111911970
+                    },
+                    {
+                        "names": [
+                            "docker.io/bitnamilegacy/kubectl@sha256:1249fc292e84a38575ee0cadc3e28dcd7ddf5a3a4e5da401b1a8599e8ac52a1b",
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl@sha256:1249fc292e84a38575ee0cadc3e28dcd7ddf5a3a4e5da401b1a8599e8ac52a1b",
+                            "docker.io/bitnamilegacy/kubectl:1.30.7",
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7"
+                        ],
+                        "sizeBytes": 110946736
+                    },
+                    {
+                        "names": [
+                            "docker.io/powerdns/pdns-auth-50@sha256:1f136c4fa4f995279b43c6a8413dde05147cc9b74a437e188f92b0088c523a8d",
+                            "docker.io/powerdns/pdns-auth-50:5.0.3"
+                        ],
+                        "sizeBytes": 102061459
+                    },
+                    {
+                        "names": [
+                            "docker.io/chrislusf/seaweedfs@sha256:84429e5f21fad82246f5cfae7b39e9a17da18afb62f2b79c25ccd364ab02793b",
+                            "docker.io/chrislusf/seaweedfs:4.22"
+                        ],
+                        "sizeBytes": 100503219
+                    },
+                    {
+                        "names": [
+                            "docker.io/powerdns/dnsdist-19@sha256:c2f859bb67865987878ff93c9c75758236fe659b4117b296da29da6b572affd0",
+                            "docker.io/powerdns/dnsdist-19:1.9.14"
+                        ],
+                        "sizeBytes": 84956522
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-quay/openbao/openbao@sha256:41dc3e47da01575e1ffea70aa635180b57ff999264398313334c259a697bf7a2",
+                            "harbor.openova.io/proxy-quay/openbao/openbao:2.3.1"
+                        ],
+                        "sizeBytes": 77189230
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/powerdnsadmin/pda-legacy@sha256:0fc92c8ef63a6704083ca1989c83d2b747f7abc0e5045d56d9c69a76e08a9a5e",
+                            "harbor.openova.io/proxy-dockerhub/powerdnsadmin/pda-legacy:0.4.2"
+                        ],
+                        "sizeBytes": 73000672
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/external-secrets/external-secrets@sha256:937c550ff84dded588324be89df42b2fa7d2cb2981271343c956b5348ae64011",
+                            "harbor.openova.io/proxy-ghcr/external-secrets/external-secrets:v0.10.7"
+                        ],
+                        "sizeBytes": 66393246
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/cilium-envoy@sha256:709c08ade3d17d52da4ca2af33f431360ec26268d288d9a6cd1d98acc9a1dced"
+                        ],
+                        "sizeBytes": 62862122
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/newapi-mirror@sha256:e596cb4aa2c234d88c3e05f41d430f405e6ccfdfa7acc8972c97793e9add4c36",
+                            "ghcr.io/openova-io/openova/newapi-mirror:v0.13.2"
+                        ],
+                        "sizeBytes": 58999657
+                    },
+                    {
+                        "names": [
+                            "mirror.gcr.io/aquasec/trivy@sha256:be1190afcb28352bfddc4ddeb71470835d16462af68d310f9f4bca710961a41e",
+                            "mirror.gcr.io/aquasec/trivy:0.70.0"
+                        ],
+                        "sizeBytes": 58469315
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/fluxcd/kustomize-controller@sha256:e3b0cf847e9cdf47b19af0fbcfe22786b80b598e0caeea8b6d2a5f9c26a48a24",
+                            "harbor.openova.io/proxy-ghcr/fluxcd/kustomize-controller:v1.4.0"
+                        ],
+                        "sizeBytes": 54969920
+                    },
+                    {
+                        "names": [
+                            "docker.io/falcosecurity/falco@sha256:b4166a61f41e2fa638c041cac881d8bb32c284e3aaf282fdfed80f15f6eb55e3",
+                            "docker.io/falcosecurity/falco:0.43.1"
+                        ],
+                        "sizeBytes": 50563340
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/kyverno/kyverno@sha256:cb033c200dc85be0a4d38e1a72894038a0c067d73f1ce6aedd569f9769a3d262",
+                            "harbor.openova.io/proxy-ghcr/kyverno/kyverno:v1.18.0"
+                        ],
+                        "sizeBytes": 46511461
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/fluxcd/notification-controller@sha256:425309a159b15e07f7d97622effc79bc432a37ed55289dd465d37fa217a92a7d",
+                            "harbor.openova.io/proxy-ghcr/fluxcd/notification-controller:v1.4.0"
+                        ],
+                        "sizeBytes": 43654595
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/kyverno/kyvernopre@sha256:60b53ebf646f788e6e5d312f9cbf267d7537ec14afec68bde2e1dad55c552cc7",
+                            "harbor.openova.io/proxy-ghcr/kyverno/kyvernopre:v1.18.0"
+                        ],
+                        "sizeBytes": 41450999
+                    },
+                    {
+                        "names": [
+                            "docker.io/grafana/loki@sha256:3c8fd3570dd9219951a60d3f919c7f31923d10baee578b77bc26c4a0b32d092d",
+                            "docker.io/grafana/loki:3.6.7"
+                        ],
+                        "sizeBytes": 41373791
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/cloudnative-pg@sha256:68074486205a33ed41928761e22ad48278c690feebe8316727a1c6b3380f9e5e",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/cloudnative-pg:1.29.0"
+                        ],
+                        "sizeBytes": 36402270
+                    },
+                    {
+                        "names": [
+                            "docker.io/grafana/rollout-operator@sha256:cdb420c0af2cc5b32a33267cdd4aac8cd7867d539975a75dc856b0cfebbadff4",
+                            "docker.io/grafana/rollout-operator:v0.32.0"
+                        ],
+                        "sizeBytes": 34785847
+                    },
+                    {
+                        "names": [
+                            "docker.io/grafana/mimir@sha256:686138d9f941508c99c931cc9e69bf9f6100dd4d2d623bf57b38d5c25ee645c1",
+                            "docker.io/grafana/mimir:3.0.4"
+                        ],
+                        "sizeBytes": 33769654
+                    },
+                    {
+                        "names": [
+                            "docker.io/falcosecurity/falcoctl@sha256:0d3bddce03a26365b86e6ff1aa5c51965d2e16569e8cf8b3e37a3d3ef186dc9b",
+                            "docker.io/falcosecurity/falcoctl:0.12.2"
+                        ],
+                        "sizeBytes": 33185258
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/catalyst-ui@sha256:d8f00ba6f935e3f318043ba89a53aad380821b532dcabe920abcdd7dbfc7e7d8",
+                            "ghcr.io/openova-io/openova/catalyst-ui:01c150e"
+                        ],
+                        "sizeBytes": 31804250
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/catalyst-ui@sha256:01e0e6f9fcf5fd8f48923b4b875e3581b90db2015ac97bdd94d1ab68fc3a5e9a",
+                            "ghcr.io/openova-io/openova/catalyst-ui:22b94e9"
+                        ],
+                        "sizeBytes": 31798259
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/catalyst-ui@sha256:231e6f10ca08a69cf7c0cf57d9422f4d768f981231281974fde432942f94a8c4",
+                            "ghcr.io/openova-io/openova/catalyst-ui:3b91660"
+                        ],
+                        "sizeBytes": 31764576
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/operator-generic@sha256:f7884848483bbcd7b1e0ccfd34ba4546f258b460cb4b7e2f06a1bcc96ef88039"
+                        ],
+                        "sizeBytes": 31216191
+                    },
+                    {
+                        "names": [
+                            "docker.io/kiwigrid/k8s-sidecar@sha256:a6b3f707f883108376514489a94d6629109a327b2978e1d826cd104c4ca436df",
+                            "docker.io/kiwigrid/k8s-sidecar:2.5.0"
+                        ],
+                        "sizeBytes": 23422974
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/aquasecurity/node-collector@sha256:f4702ce4667388f0219d6248d623a7e816231c2d4561d6af01c3ae053e524025",
+                            "ghcr.io/aquasecurity/node-collector:0.3.1"
+                        ],
+                        "sizeBytes": 20174022
+                    },
+                    {
+                        "names": [
+                            "docker.io/coredns/coredns@sha256:9caabbf6238b189a65d0d6e6ac138de60d6a1c419e5a341fbbb7c78382559c6e",
+                            "docker.io/coredns/coredns:1.11.3"
+                        ],
+                        "sizeBytes": 18562039
+                    },
+                    {
+                        "names": [
+                            "quay.io/jetstack/cert-manager-webhook@sha256:2b10bf39d0e1e056f2bd0743c7e743f28285085e76cf860ddd1dc23abe3a74ad",
+                            "quay.io/jetstack/cert-manager-webhook:v1.16.5"
+                        ],
+                        "sizeBytes": 18212681
+                    },
+                    {
+                        "names": [
+                            "quay.io/oauth2-proxy/oauth2-proxy@sha256:dcb6ff8dd21bf3058f6a22c6fa385fa5b897a9cd3914c88a2cc2bb0a85f8065d",
+                            "quay.io/oauth2-proxy/oauth2-proxy:v7.6.0"
+                        ],
+                        "sizeBytes": 16521978
+                    },
+                    {
+                        "names": [
+                            "quay.io/jetstack/cert-manager-cainjector@sha256:b3b12f6a140f55697130c4c23453eb24200205e1341095c0f3e9e9d471e5fba6",
+                            "quay.io/jetstack/cert-manager-cainjector:v1.16.5"
+                        ],
+                        "sizeBytes": 15446237
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-quay/prometheus-operator/prometheus-config-reloader@sha256:959d47672fbff2776a04ec62b8afcec89e8c036af84dc5fade50019dab212746",
+                            "harbor.openova.io/proxy-quay/prometheus-operator/prometheus-config-reloader:v0.81.0"
+                        ],
+                        "sizeBytes": 14433657
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/k8s-ws-proxy@sha256:0e3c679c9f78b302575cf9d6e2ae0e5d82d861e4d6de19876df0ca496677825b",
+                            "ghcr.io/openova-io/openova/k8s-ws-proxy:b32eb9b"
+                        ],
+                        "sizeBytes": 11403264
+                    },
+                    {
+                        "names": [
+                            "registry.k8s.io/autoscaling/vpa-updater@sha256:b60e102cefe4760b2ee4d04bc7f21fff5882ed7f5641b0dd4efbef452749baeb",
+                            "registry.k8s.io/autoscaling/vpa-updater:1.5.0"
+                        ],
+                        "sizeBytes": 11330068
+                    },
+                    {
+                        "names": [
+                            "registry.k8s.io/autoscaling/vpa-admission-controller@sha256:080854aebf844e29ec21538196f8d2fe606281189e1f1a9168a4f553b43e3251",
+                            "registry.k8s.io/autoscaling/vpa-admission-controller:1.5.0"
+                        ],
+                        "sizeBytes": 11292005
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/openova-flow-adapter-flux@sha256:ffc60bb400d3b8e8e7d19ced0b8714d038ee6c9b9012cc9019e2341d57c1989f",
+                            "ghcr.io/openova-io/openova/openova-flow-adapter-flux:b32eb9b"
+                        ],
+                        "sizeBytes": 10917169
+                    },
+                    {
+                        "names": [
+                            "docker.io/library/nats@sha256:c82559e4476289481a8a5196e675ebfe67eea81d95e5161e3e78eccfe766608e",
+                            "docker.io/library/nats:2.10.16-alpine"
+                        ],
+                        "sizeBytes": 9725619
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/curlimages/curl@sha256:d9b4541e214bcd85196d6e92e2753ac6d0ea699f0af5741f8c6cccbfcf00ef4b",
+                            "harbor.openova.io/proxy-dockerhub/curlimages/curl:8.10.1"
+                        ],
+                        "sizeBytes": 9414401
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/services-provisioning@sha256:44582feaa2b9f49949601e6930f0b99d3949024635bd7f597ce10d6a38dfe707",
+                            "ghcr.io/openova-io/openova/services-provisioning:2529da1"
+                        ],
+                        "sizeBytes": 5663101
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/services-provisioning@sha256:c63cd2e345206404083210f83d9d454ae9b50338dc98fb183ed27cbefe551061",
+                            "ghcr.io/openova-io/openova/services-provisioning:c068e6a"
+                        ],
+                        "sizeBytes": 5662896
+                    },
+                    {
+                        "names": [
+                            "docker.io/natsio/nats-server-config-reloader@sha256:98d592981444fac82f79950b42f439f16918e9788fe5080eb32ac8cc7f357df1",
+                            "docker.io/natsio/nats-server-config-reloader:0.14.3"
+                        ],
+                        "sizeBytes": 4628347
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/newapi-sandbox-bridge@sha256:170363bf9b313db7844a566df72aa07ab483d31c1eb2af59694da65169483c02",
+                            "ghcr.io/openova-io/openova/newapi-sandbox-bridge:5d818d4"
+                        ],
+                        "sizeBytes": 4477093
+                    },
+                    {
+                        "names": [
+                            "docker.io/library/alpine@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc",
+                            "harbor.openova.io/proxy-dockerhub/library/alpine@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc",
+                            "docker.io/library/alpine:3.20",
+                            "harbor.openova.io/proxy-dockerhub/library/alpine:3.20"
+                        ],
+                        "sizeBytes": 3641182
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/services-metering-sidecar@sha256:259420d49d42b44d8ce36ab062e1fb88d033571c98362008951f195636b086ff",
+                            "ghcr.io/openova-io/openova/services-metering-sidecar:41e02c8"
+                        ],
+                        "sizeBytes": 3548511
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/library/busybox@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662",
+                            "harbor.openova.io/proxy-dockerhub/library/busybox:1.36"
+                        ],
+                        "sizeBytes": 2217006
+                    }
+                ],
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "094e9e64-d86c-468e-abaa-501c460684a2",
+                    "containerRuntimeVersion": "containerd://1.7.23-k3s2",
+                    "kernelVersion": "5.15.0-76-generic",
+                    "kubeProxyVersion": "v1.31.4+k3s1",
+                    "kubeletVersion": "v1.31.4+k3s1",
+                    "machineID": "41895bd1876a403788902e232a28f6c9",
+                    "operatingSystem": "linux",
+                    "osImage": "Ubuntu 22.04.2 LTS",
+                    "systemUUID": "4f019e51-b6d2-4d6c-ab6d-595ca5af53d2"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "alpha.kubernetes.io/provided-node-ip": "10.169.1.28",
+                    "k3s.io/hostname": "catalyst-hw173-omani-works-7bb723da-me-east-215-a-wc5b620",
+                    "k3s.io/internal-ip": "10.169.1.28",
+                    "k3s.io/node-args": "[\"agent\",\"--node-label\",\"catalyst.openova.io/provider=huawei\",\"--node-label\",\"openova.io/region=hw-me-east-215-a-rtz-prod\",\"--node-label\",\"topology.kubernetes.io/region=me-east-215-a\",\"--node-label\",\"topology.kubernetes.io/zone=me-east-215-a\"]",
+                    "k3s.io/node-config-hash": "IGBSO4FMC7NARQHWC2L6GVMICVTYKLUIOWX7FPNTZJHOZOLQ7FCQ====",
+                    "k3s.io/node-env": "{\"K3S_TOKEN\":\"********\",\"K3S_URL\":\"https://10.169.1.43:6443\"}",
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2026-06-20T03:01:06Z",
+                "finalizers": [
+                    "wrangler.cattle.io/node",
+                    "wrangler.cattle.io/managed-etcd-controller"
+                ],
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "k3s",
+                    "beta.kubernetes.io/os": "linux",
+                    "catalyst.openova.io/provider": "huawei",
+                    "failure-domain.beta.kubernetes.io/region": "me-east-215-a",
+                    "failure-domain.beta.kubernetes.io/zone": "me-east-215-a",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "catalyst-hw173-omani-works-7bb723da-me-east-215-a-wc5b620",
+                    "kubernetes.io/os": "linux",
+                    "node.kubernetes.io/instance-type": "k3s",
+                    "openova.io/region": "hw-me-east-215-a-rtz-prod",
+                    "topology.kubernetes.io/region": "me-east-215-a",
+                    "topology.kubernetes.io/zone": "me-east-215-a"
+                },
+                "name": "catalyst-hw173-omani-works-7bb723da-me-east-215-a-wc5b620",
+                "resourceVersion": "900085",
+                "uid": "1213f7f8-f644-4863-82b4-21107838fef4"
+            },
+            "spec": {
+                "podCIDR": "10.42.2.0/24",
+                "podCIDRs": [
+                    "10.42.2.0/24"
+                ],
+                "providerID": "k3s://catalyst-hw173-omani-works-7bb723da-me-east-215-a-wc5b620"
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "10.169.1.28",
+                        "type": "InternalIP"
+                    },
+                    {
+                        "address": "catalyst-hw173-omani-works-7bb723da-me-east-215-a-wc5b620",
+                        "type": "Hostname"
+                    }
+                ],
+                "allocatable": {
+                    "cpu": "4",
+                    "ephemeral-storage": "39857063496",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "32666744Ki",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "cpu": "4",
+                    "ephemeral-storage": "40971488Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "32666744Ki",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2026-06-20T03:01:56Z",
+                        "lastTransitionTime": "2026-06-20T03:01:56Z",
+                        "message": "Cilium is running on this node",
+                        "reason": "CiliumIsUp",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:11:21Z",
+                        "lastTransitionTime": "2026-06-20T03:01:06Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:11:21Z",
+                        "lastTransitionTime": "2026-06-20T03:01:06Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:11:21Z",
+                        "lastTransitionTime": "2026-06-20T03:01:06Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:11:21Z",
+                        "lastTransitionTime": "2026-06-20T03:01:51Z",
+                        "message": "kubelet is posting ready status",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10250
+                    }
+                },
+                "images": [
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/guacamole-server@sha256:0f62f6d17ab379e46aa66874b2ff564dab856a6ef5e754a69cbb34c32d3e588a",
+                            "ghcr.io/openova-io/openova/guacamole-server:1.5.5"
+                        ],
+                        "sizeBytes": 307550497
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/alpine/k8s@sha256:dfe8c7a06c41d0b6e8757da99531f8f302e9a2687fa0155af4c4087df585c9c8",
+                            "harbor.openova.io/proxy-dockerhub/alpine/k8s:1.31.1"
+                        ],
+                        "sizeBytes": 306265288
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/keycloak@sha256:da3df0976a9f9a664bdbde6cb5308b78f03ac94d0abf33b2df355bbb06cbc5b9",
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/keycloak:26.3.3-debian-12-r0"
+                        ],
+                        "sizeBytes": 271527858
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql@sha256:027303cd89644acdeba67d2b37f70eff6a7f345220f127721ff92504e1e4eae6",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16"
+                        ],
+                        "sizeBytes": 258220911
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/cilium@sha256:758ca0793f5995bb938a2fa219dcce63dc0b3fa7fc4ce5cc851125281fb7361d"
+                        ],
+                        "sizeBytes": 224306600
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql@sha256:99be063781d171d3971089b49c992706bdab9ccbd2b57cdf126c7542773aedfe",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16.4"
+                        ],
+                        "sizeBytes": 217672880
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql@sha256:cd2f88c75f4465ed14ff2006147e06405cca646c00f252a2dfb73910728d289f",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16.4-1"
+                        ],
+                        "sizeBytes": 211733506
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/grafana/alloy@sha256:6e00cf7c5a692ff5f24844529416ed017d76fce922f8199004e73d5eca46b6b8",
+                            "harbor.openova.io/proxy-dockerhub/grafana/alloy:v1.16.0"
+                        ],
+                        "sizeBytes": 151457664
+                    },
+                    {
+                        "names": [
+                            "docker.io/bitnamilegacy/kubectl@sha256:1249fc292e84a38575ee0cadc3e28dcd7ddf5a3a4e5da401b1a8599e8ac52a1b",
+                            "docker.io/bitnamilegacy/kubectl:1.30.7"
+                        ],
+                        "sizeBytes": 110946736
+                    },
+                    {
+                        "names": [
+                            "docker.io/chrislusf/seaweedfs@sha256:84429e5f21fad82246f5cfae7b39e9a17da18afb62f2b79c25ccd364ab02793b",
+                            "docker.io/chrislusf/seaweedfs:4.22"
+                        ],
+                        "sizeBytes": 100503219
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-quay/openbao/openbao@sha256:7de07aa6df3937d44c96c2d65c188b2d4a70546f2a764ad4510301305af6a223",
+                            "harbor.openova.io/proxy-quay/openbao/openbao:2.1.0"
+                        ],
+                        "sizeBytes": 62890555
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/cilium-envoy@sha256:709c08ade3d17d52da4ca2af33f431360ec26268d288d9a6cd1d98acc9a1dced"
+                        ],
+                        "sizeBytes": 62862122
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/loft-sh/vcluster@sha256:521b2fc8c8d0c2f1254d7fb956fbf274d3328f1e555270b57a886f9ae10d2109",
+                            "harbor.openova.io/proxy-ghcr/loft-sh/vcluster:0.23.0"
+                        ],
+                        "sizeBytes": 60761070
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/newapi-mirror@sha256:e596cb4aa2c234d88c3e05f41d430f405e6ccfdfa7acc8972c97793e9add4c36",
+                            "ghcr.io/openova-io/openova/newapi-mirror:v0.13.2"
+                        ],
+                        "sizeBytes": 58999657
+                    },
+                    {
+                        "names": [
+                            "mirror.gcr.io/aquasec/trivy@sha256:be1190afcb28352bfddc4ddeb71470835d16462af68d310f9f4bca710961a41e",
+                            "mirror.gcr.io/aquasec/trivy:0.70.0"
+                        ],
+                        "sizeBytes": 58469315
+                    },
+                    {
+                        "names": [
+                            "docker.io/falcosecurity/falco@sha256:b4166a61f41e2fa638c041cac881d8bb32c284e3aaf282fdfed80f15f6eb55e3",
+                            "docker.io/falcosecurity/falco:0.43.1"
+                        ],
+                        "sizeBytes": 50563340
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/kyverno/kyverno@sha256:cb033c200dc85be0a4d38e1a72894038a0c067d73f1ce6aedd569f9769a3d262",
+                            "harbor.openova.io/proxy-ghcr/kyverno/kyverno:v1.18.0"
+                        ],
+                        "sizeBytes": 46511461
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/kyverno/cleanup-controller@sha256:a2a060b731f1ea54de2295b886c600d65af032fec18096a816424acfe8dec7d2",
+                            "harbor.openova.io/proxy-ghcr/kyverno/cleanup-controller:v1.18.0"
+                        ],
+                        "sizeBytes": 42285963
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/kyverno/kyvernopre@sha256:60b53ebf646f788e6e5d312f9cbf267d7537ec14afec68bde2e1dad55c552cc7",
+                            "harbor.openova.io/proxy-ghcr/kyverno/kyvernopre:v1.18.0"
+                        ],
+                        "sizeBytes": 41450999
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/cloudnative-pg@sha256:68074486205a33ed41928761e22ad48278c690feebe8316727a1c6b3380f9e5e",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/cloudnative-pg:1.29.0"
+                        ],
+                        "sizeBytes": 36402270
+                    },
+                    {
+                        "names": [
+                            "docker.io/grafana/mimir@sha256:686138d9f941508c99c931cc9e69bf9f6100dd4d2d623bf57b38d5c25ee645c1",
+                            "docker.io/grafana/mimir:3.0.4"
+                        ],
+                        "sizeBytes": 33769654
+                    },
+                    {
+                        "names": [
+                            "docker.io/falcosecurity/falcoctl@sha256:0d3bddce03a26365b86e6ff1aa5c51965d2e16569e8cf8b3e37a3d3ef186dc9b",
+                            "docker.io/falcosecurity/falcoctl:0.12.2"
+                        ],
+                        "sizeBytes": 33185258
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/operator-generic@sha256:f7884848483bbcd7b1e0ccfd34ba4546f258b460cb4b7e2f06a1bcc96ef88039"
+                        ],
+                        "sizeBytes": 31216191
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/hubble-relay@sha256:6cfae1d1afa566ba941f03d4d7e141feddd05260e5cd0a1509aba1890a45ef00"
+                        ],
+                        "sizeBytes": 28577506
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-k8s/kube-apiserver@sha256:ace6a943b058439bd6daeb74f152e7c36e6fc0b5e481cdff9364cd6ca0473e5e",
+                            "harbor.openova.io/proxy-k8s/kube-apiserver:v1.31.4"
+                        ],
+                        "sizeBytes": 27972283
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-k8s/kube-controller-manager@sha256:4bd1d4a449e7a1a4f375bd7c71abf48a95f8949b38f725ded255077329f21f7b",
+                            "harbor.openova.io/proxy-k8s/kube-controller-manager:v1.31.4"
+                        ],
+                        "sizeBytes": 26147269
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/console@sha256:f220f466b119562bfcdcba9da60220f7e10ae8c71788e987826d27b6a3ad527e",
+                            "ghcr.io/openova-io/openova/console:3c2f7e4"
+                        ],
+                        "sizeBytes": 26126565
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/admin@sha256:836defa5c46ad5e21a212fcb707ab067ea60264edb4446efb70a74a96affd424",
+                            "ghcr.io/openova-io/openova/admin:3c2f7e4"
+                        ],
+                        "sizeBytes": 26103885
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/ferretdb/ferretdb@sha256:78497e6209865382781ff4d113ae61353f34c5cf2b49359dbd960748437c9c46",
+                            "harbor.openova.io/proxy-ghcr/ferretdb/ferretdb:1.24"
+                        ],
+                        "sizeBytes": 23217925
+                    },
+                    {
+                        "names": [
+                            "docker.io/nginxinc/nginx-unprivileged@sha256:0c79d56aee561a1d81c63f00eee5fb5fe29279560cdc55e91425133104c7fbe6",
+                            "docker.io/nginxinc/nginx-unprivileged:1.29-alpine"
+                        ],
+                        "sizeBytes": 23098099
+                    },
+                    {
+                        "names": [
+                            "xpkg.upbound.io/crossplane/crossplane@sha256:c98f027ffade306fc9a5132aec74a1430357f1028c0da024b95c25a19b3148fc",
+                            "xpkg.upbound.io/crossplane/crossplane:v1.18.0"
+                        ],
+                        "sizeBytes": 20944049
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/aquasecurity/node-collector@sha256:f4702ce4667388f0219d6248d623a7e816231c2d4561d6af01c3ae053e524025",
+                            "ghcr.io/aquasecurity/node-collector:0.3.1"
+                        ],
+                        "sizeBytes": 20174022
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/continuum-controller@sha256:0ebfb774b75d163d55899bc4100e9aab2546b2941e6b707d7de79f89f54671e4",
+                            "ghcr.io/openova-io/openova/continuum-controller:01db043"
+                        ],
+                        "sizeBytes": 18699284
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/organization-controller@sha256:5db285364a423be98a81185fbe09ef05fe23d628744f7e86f479b52f0358506a",
+                            "ghcr.io/openova-io/openova/organization-controller:300d853"
+                        ],
+                        "sizeBytes": 17698913
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/useraccess-controller@sha256:8d865fc5241e520b3a9fd16f2597e32e5c9eb08aa41b83b7b9e4fd40ce599974",
+                            "ghcr.io/openova-io/openova/useraccess-controller:01db043"
+                        ],
+                        "sizeBytes": 16674249
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/stakater/reloader@sha256:4e0db5b629ad5b50ccadae6f31f5916adab300dc3801482503f4984da4727e30",
+                            "ghcr.io/stakater/reloader:v1.4.16"
+                        ],
+                        "sizeBytes": 15679304
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-quay/prometheus-operator/prometheus-config-reloader@sha256:959d47672fbff2776a04ec62b8afcec89e8c036af84dc5fade50019dab212746",
+                            "harbor.openova.io/proxy-quay/prometheus-operator/prometheus-config-reloader:v0.81.0"
+                        ],
+                        "sizeBytes": 14433657
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/k8s-ws-proxy@sha256:0e3c679c9f78b302575cf9d6e2ae0e5d82d861e4d6de19876df0ca496677825b",
+                            "ghcr.io/openova-io/openova/k8s-ws-proxy:b32eb9b"
+                        ],
+                        "sizeBytes": 11403264
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/openova-flow-adapter-flux@sha256:ffc60bb400d3b8e8e7d19ced0b8714d038ee6c9b9012cc9019e2341d57c1989f",
+                            "ghcr.io/openova-io/openova/openova-flow-adapter-flux:b32eb9b"
+                        ],
+                        "sizeBytes": 10917169
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/curlimages/curl@sha256:d9b4541e214bcd85196d6e92e2753ac6d0ea699f0af5741f8c6cccbfcf00ef4b",
+                            "harbor.openova.io/proxy-dockerhub/curlimages/curl:8.10.1"
+                        ],
+                        "sizeBytes": 9414401
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/services-tenant@sha256:b10165940cb83d6bc73462fca172aaf5f09093d0edd4d55893e768903e9b6445",
+                            "ghcr.io/openova-io/openova/services-tenant:c068e6a"
+                        ],
+                        "sizeBytes": 9198708
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/services-domain@sha256:4c8b60ed4282d8d58f67a078ac762aac551de29abfcb8c33ae0bc29f78167f71",
+                            "ghcr.io/openova-io/openova/services-domain:c068e6a"
+                        ],
+                        "sizeBytes": 5535697
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/services-catalog@sha256:cb7211549ce610067b492f4c823c01c50fbe0523f8a53713abadc6e0aa2d48b0",
+                            "ghcr.io/openova-io/openova/services-catalog:c068e6a"
+                        ],
+                        "sizeBytes": 5333143
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/services-notification@sha256:d939887e5f8155a5c645b6059b37d68e8a9a9cbd6aefd28413b6de35b4ace656",
+                            "ghcr.io/openova-io/openova/services-notification:c068e6a"
+                        ],
+                        "sizeBytes": 4661995
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/newapi-sandbox-bridge@sha256:170363bf9b313db7844a566df72aa07ab483d31c1eb2af59694da65169483c02",
+                            "ghcr.io/openova-io/openova/newapi-sandbox-bridge:5d818d4"
+                        ],
+                        "sizeBytes": 4477093
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/catalyst-catalog@sha256:a8f2294713976d3a67d4f31392e685eab6abfbb53ec1b0315f149fa116b67054",
+                            "ghcr.io/openova-io/openova/catalyst-catalog:973094b"
+                        ],
+                        "sizeBytes": 3835292
+                    },
+                    {
+                        "names": [
+                            "docker.io/library/alpine@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc",
+                            "harbor.openova.io/proxy-dockerhub/library/alpine@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc",
+                            "docker.io/library/alpine:3.20",
+                            "harbor.openova.io/proxy-dockerhub/library/alpine:3.20"
+                        ],
+                        "sizeBytes": 3641182
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/marketplace-api@sha256:ca5bce57ae23c8aae3fc81614782134dffaca4c9cceebf8177ab9cf4e8247c0e",
+                            "ghcr.io/openova-io/openova/marketplace-api:3c2f7e4"
+                        ],
+                        "sizeBytes": 2260290
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/library/busybox@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662",
+                            "harbor.openova.io/proxy-dockerhub/library/busybox:1.36"
+                        ],
+                        "sizeBytes": 2217006
+                    },
+                    {
+                        "names": [
+                            "docker.io/rancher/mirrored-library-busybox@sha256:8a45424ddf949bbe9bb3231b05f9032a45da5cd036eb4867b511b00734756d6f",
+                            "docker.io/rancher/mirrored-library-busybox:1.36.1"
+                        ],
+                        "sizeBytes": 2147340
+                    }
+                ],
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "cb897c74-1a60-4c3a-a855-232800545ef2",
+                    "containerRuntimeVersion": "containerd://1.7.23-k3s2",
+                    "kernelVersion": "5.15.0-76-generic",
+                    "kubeProxyVersion": "v1.31.4+k3s1",
+                    "kubeletVersion": "v1.31.4+k3s1",
+                    "machineID": "41895bd1876a403788902e232a28f6c9",
+                    "operatingSystem": "linux",
+                    "osImage": "Ubuntu 22.04.2 LTS",
+                    "systemUUID": "7fa4cbc0-64c7-4b4f-bb5d-3e51917f0196"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "alpha.kubernetes.io/provided-node-ip": "10.169.1.134",
+                    "k3s.io/hostname": "catalyst-hw173-omani-works-7bb723da-me-east-215-a-wed93d5",
+                    "k3s.io/internal-ip": "10.169.1.134",
+                    "k3s.io/node-args": "[\"agent\",\"--node-label\",\"catalyst.openova.io/provider=huawei\",\"--node-label\",\"openova.io/region=hw-me-east-215-a-rtz-prod\",\"--node-label\",\"topology.kubernetes.io/region=me-east-215-a\",\"--node-label\",\"topology.kubernetes.io/zone=me-east-215-a\"]",
+                    "k3s.io/node-config-hash": "IGBSO4FMC7NARQHWC2L6GVMICVTYKLUIOWX7FPNTZJHOZOLQ7FCQ====",
+                    "k3s.io/node-env": "{\"K3S_TOKEN\":\"********\",\"K3S_URL\":\"https://10.169.1.43:6443\"}",
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2026-06-20T03:03:49Z",
+                "finalizers": [
+                    "wrangler.cattle.io/node",
+                    "wrangler.cattle.io/managed-etcd-controller"
+                ],
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "k3s",
+                    "beta.kubernetes.io/os": "linux",
+                    "catalyst.openova.io/provider": "huawei",
+                    "failure-domain.beta.kubernetes.io/region": "me-east-215-a",
+                    "failure-domain.beta.kubernetes.io/zone": "me-east-215-a",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "catalyst-hw173-omani-works-7bb723da-me-east-215-a-wed93d5",
+                    "kubernetes.io/os": "linux",
+                    "node.kubernetes.io/instance-type": "k3s",
+                    "openova.io/region": "hw-me-east-215-a-rtz-prod",
+                    "topology.kubernetes.io/region": "me-east-215-a",
+                    "topology.kubernetes.io/zone": "me-east-215-a"
+                },
+                "name": "catalyst-hw173-omani-works-7bb723da-me-east-215-a-wed93d5",
+                "resourceVersion": "902401",
+                "uid": "19b660e2-5e1f-4bb6-90f3-98c822e1e1fd"
+            },
+            "spec": {
+                "podCIDR": "10.42.5.0/24",
+                "podCIDRs": [
+                    "10.42.5.0/24"
+                ],
+                "providerID": "k3s://catalyst-hw173-omani-works-7bb723da-me-east-215-a-wed93d5"
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "10.169.1.134",
+                        "type": "InternalIP"
+                    },
+                    {
+                        "address": "catalyst-hw173-omani-works-7bb723da-me-east-215-a-wed93d5",
+                        "type": "Hostname"
+                    }
+                ],
+                "allocatable": {
+                    "cpu": "4",
+                    "ephemeral-storage": "39857063496",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "32666736Ki",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "cpu": "4",
+                    "ephemeral-storage": "40971488Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "32666736Ki",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2026-06-20T03:04:38Z",
+                        "lastTransitionTime": "2026-06-20T03:04:38Z",
+                        "message": "Cilium is running on this node",
+                        "reason": "CiliumIsUp",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:13:15Z",
+                        "lastTransitionTime": "2026-06-20T03:03:49Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:13:15Z",
+                        "lastTransitionTime": "2026-06-20T03:03:49Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:13:15Z",
+                        "lastTransitionTime": "2026-06-20T03:03:49Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:13:15Z",
+                        "lastTransitionTime": "2026-06-20T03:04:34Z",
+                        "message": "kubelet is posting ready status",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10250
+                    }
+                },
+                "images": [
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql@sha256:027303cd89644acdeba67d2b37f70eff6a7f345220f127721ff92504e1e4eae6",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16"
+                        ],
+                        "sizeBytes": 258220911
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/cilium@sha256:758ca0793f5995bb938a2fa219dcce63dc0b3fa7fc4ce5cc851125281fb7361d"
+                        ],
+                        "sizeBytes": 224306600
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql@sha256:cd2f88c75f4465ed14ff2006147e06405cca646c00f252a2dfb73910728d289f",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16.4-1"
+                        ],
+                        "sizeBytes": 211733506
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/grafana/alloy@sha256:6e00cf7c5a692ff5f24844529416ed017d76fce922f8199004e73d5eca46b6b8",
+                            "harbor.openova.io/proxy-dockerhub/grafana/alloy:v1.16.0"
+                        ],
+                        "sizeBytes": 151457664
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/amazon/aws-cli@sha256:643507c10ada7964ca6157b3d799f030b90577643da9955d319a77399ed80d73",
+                            "harbor.openova.io/proxy-dockerhub/amazon/aws-cli:2.17.0"
+                        ],
+                        "sizeBytes": 125732170
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/postgresql@sha256:de520acd66fc954d538faa997771ca791f9fcba8b837419a8bc4d08a08df3762",
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/postgresql:17.6.0-debian-12-r0"
+                        ],
+                        "sizeBytes": 111456870
+                    },
+                    {
+                        "names": [
+                            "docker.io/bitnamilegacy/kubectl@sha256:1249fc292e84a38575ee0cadc3e28dcd7ddf5a3a4e5da401b1a8599e8ac52a1b",
+                            "docker.io/bitnamilegacy/kubectl:1.30.7"
+                        ],
+                        "sizeBytes": 110946736
+                    },
+                    {
+                        "names": [
+                            "docker.io/chrislusf/seaweedfs@sha256:84429e5f21fad82246f5cfae7b39e9a17da18afb62f2b79c25ccd364ab02793b",
+                            "docker.io/chrislusf/seaweedfs:4.22"
+                        ],
+                        "sizeBytes": 100503219
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/goharbor/harbor-jobservice@sha256:e2b0298e894d725d68954b786c61c5dd607114f6129534756c8f7985124c07a6",
+                            "harbor.openova.io/proxy-dockerhub/goharbor/harbor-jobservice:v2.14.3"
+                        ],
+                        "sizeBytes": 74802491
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/external-secrets/external-secrets@sha256:937c550ff84dded588324be89df42b2fa7d2cb2981271343c956b5348ae64011",
+                            "harbor.openova.io/proxy-ghcr/external-secrets/external-secrets:v0.10.7"
+                        ],
+                        "sizeBytes": 66393246
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/goharbor/harbor-core@sha256:a30e5a8be3d94b6485e7fdd4ed7fdf9e9724ee0a6d103b3804aacf6784ee358e",
+                            "harbor.openova.io/proxy-dockerhub/goharbor/harbor-core:v2.14.3"
+                        ],
+                        "sizeBytes": 65498736
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/goharbor/redis-photon@sha256:f0e08db4909c21535667bd89676ac28c27003ca967830e259e3bd3aeb8e22f9c",
+                            "harbor.openova.io/proxy-dockerhub/goharbor/redis-photon:v2.14.3"
+                        ],
+                        "sizeBytes": 64079006
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/cilium-envoy@sha256:709c08ade3d17d52da4ca2af33f431360ec26268d288d9a6cd1d98acc9a1dced"
+                        ],
+                        "sizeBytes": 62862122
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/sigstore/policy-controller/policy-controller@sha256:0bcd60beb93f4427c29cf3a669743caf58490e98ded4380c33c09f092734a6ab"
+                        ],
+                        "sizeBytes": 61402611
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/newapi-mirror@sha256:e596cb4aa2c234d88c3e05f41d430f405e6ccfdfa7acc8972c97793e9add4c36",
+                            "ghcr.io/openova-io/openova/newapi-mirror:v0.13.2"
+                        ],
+                        "sizeBytes": 58999657
+                    },
+                    {
+                        "names": [
+                            "mirror.gcr.io/aquasec/trivy@sha256:be1190afcb28352bfddc4ddeb71470835d16462af68d310f9f4bca710961a41e",
+                            "mirror.gcr.io/aquasec/trivy:0.70.0"
+                        ],
+                        "sizeBytes": 58469315
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/goharbor/harbor-portal@sha256:2556b6c7dd832bf22ed8b177245fa5fbcd70255959e69c5d0fbe2153f4bd2243",
+                            "harbor.openova.io/proxy-dockerhub/goharbor/harbor-portal:v2.14.3"
+                        ],
+                        "sizeBytes": 56696973
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/goharbor/nginx-photon@sha256:e31b5290e31938fde76590e4f5d7b8eb3d8038ad1485879bdad7a480538dc858",
+                            "harbor.openova.io/proxy-dockerhub/goharbor/nginx-photon:v2.14.3"
+                        ],
+                        "sizeBytes": 54477190
+                    },
+                    {
+                        "names": [
+                            "docker.io/falcosecurity/falco@sha256:b4166a61f41e2fa638c041cac881d8bb32c284e3aaf282fdfed80f15f6eb55e3",
+                            "docker.io/falcosecurity/falco:0.43.1"
+                        ],
+                        "sizeBytes": 50563340
+                    },
+                    {
+                        "names": [
+                            "registry-1.docker.io/bitnami/valkey@sha256:bcb8664d48fc0449050e1524e4041504bb774cc4ecc00bd0cc52daaad12beea4",
+                            "registry-1.docker.io/bitnami/valkey:latest"
+                        ],
+                        "sizeBytes": 49194903
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/kyverno/reports-controller@sha256:0090bf10eabae091ceb48c38fb894580b63c4e76e40137b7972f5895f0402110",
+                            "harbor.openova.io/proxy-ghcr/kyverno/reports-controller:v1.18.0"
+                        ],
+                        "sizeBytes": 45253065
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/fluxcd/flux-cli@sha256:a9cb966cddc1a0c56dc0d57dda485d9477dd397f8b45f222717b24663471fd1f",
+                            "harbor.openova.io/proxy-ghcr/fluxcd/flux-cli:v2.4.0"
+                        ],
+                        "sizeBytes": 41877267
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/fluxcd/helm-controller@sha256:4c75ca6c24ceb1f1bd7e935d9287a93e4f925c512f206763ec5a47de3ef3ff48",
+                            "harbor.openova.io/proxy-ghcr/fluxcd/helm-controller:v1.1.0"
+                        ],
+                        "sizeBytes": 40818921
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/fluxcd/image-reflector-controller@sha256:c6864684f96cfbb3a91c816084032bb019b302af8b63b0e06b12b4018a9a8242",
+                            "harbor.openova.io/proxy-ghcr/fluxcd/image-reflector-controller:v0.33.0"
+                        ],
+                        "sizeBytes": 38586158
+                    },
+                    {
+                        "names": [
+                            "docker.io/natsio/nats-box@sha256:1cc4201866645d6501ed370d2300852711468886565b0e1a3dc69e9739909a0e",
+                            "docker.io/natsio/nats-box:0.14.3"
+                        ],
+                        "sizeBytes": 38475647
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/cloudnative-pg@sha256:68074486205a33ed41928761e22ad48278c690feebe8316727a1c6b3380f9e5e",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/cloudnative-pg:1.29.0"
+                        ],
+                        "sizeBytes": 36402270
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/clustermesh-apiserver@sha256:37a7fdbef806b78ef63df9f1a9828fdddbf548d1f0e43b8eb10a6bdc8fa03958"
+                        ],
+                        "sizeBytes": 35425816
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/hashicorp/vault-k8s@sha256:690647d935f9bb17b4e9d1eb75d10b1b23cfd63d98ca1c456e88ae1429d6c656",
+                            "harbor.openova.io/proxy-dockerhub/hashicorp/vault-k8s:1.4.2"
+                        ],
+                        "sizeBytes": 35244498
+                    },
+                    {
+                        "names": [
+                            "docker.io/grafana/mimir@sha256:686138d9f941508c99c931cc9e69bf9f6100dd4d2d623bf57b38d5c25ee645c1",
+                            "docker.io/grafana/mimir:3.0.4"
+                        ],
+                        "sizeBytes": 33769654
+                    },
+                    {
+                        "names": [
+                            "docker.io/falcosecurity/falcoctl@sha256:0d3bddce03a26365b86e6ff1aa5c51965d2e16569e8cf8b3e37a3d3ef186dc9b",
+                            "docker.io/falcosecurity/falcoctl:0.12.2"
+                        ],
+                        "sizeBytes": 33185258
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/operator-generic@sha256:f7884848483bbcd7b1e0ccfd34ba4546f258b460cb4b7e2f06a1bcc96ef88039"
+                        ],
+                        "sizeBytes": 31216191
+                    },
+                    {
+                        "names": [
+                            "quay.io/minio/mc@sha256:993e8c454a7ec632923f7e3e61adf1d473261da6354cefd641aedd33a2cfe112",
+                            "quay.io/minio/mc:RELEASE.2024-11-21T17-21-54Z"
+                        ],
+                        "sizeBytes": 28122288
+                    },
+                    {
+                        "names": [
+                            "docker.io/zachomedia/cert-manager-webhook-pdns@sha256:4940e227a39ba04fcbdc99d55918946183f08722480953537b28c33304f96d82",
+                            "docker.io/zachomedia/cert-manager-webhook-pdns:v2.5.5"
+                        ],
+                        "sizeBytes": 28019091
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/aquasecurity/node-collector@sha256:f4702ce4667388f0219d6248d623a7e816231c2d4561d6af01c3ae053e524025",
+                            "ghcr.io/aquasecurity/node-collector:0.3.1"
+                        ],
+                        "sizeBytes": 20174022
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/hubble-ui-backend@sha256:0e0eed917653441fded4e7cdb096b7be6a3bddded5a2dd10812a27b1fc6ed95b"
+                        ],
+                        "sizeBytes": 20027102
+                    },
+                    {
+                        "names": [
+                            "docker.io/coredns/coredns@sha256:9caabbf6238b189a65d0d6e6ac138de60d6a1c419e5a341fbbb7c78382559c6e",
+                            "docker.io/coredns/coredns:1.11.3"
+                        ],
+                        "sizeBytes": 18562039
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-quay/prometheus-operator/prometheus-config-reloader@sha256:959d47672fbff2776a04ec62b8afcec89e8c036af84dc5fade50019dab212746",
+                            "harbor.openova.io/proxy-quay/prometheus-operator/prometheus-config-reloader:v0.81.0"
+                        ],
+                        "sizeBytes": 14433657
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/k8s-ws-proxy@sha256:0e3c679c9f78b302575cf9d6e2ae0e5d82d861e4d6de19876df0ca496677825b",
+                            "ghcr.io/openova-io/openova/k8s-ws-proxy:b32eb9b"
+                        ],
+                        "sizeBytes": 11403264
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/hubble-ui@sha256:e2e9313eb7caf64b0061d9da0efbdad59c6c461f6ca1752768942bfeda0796c6"
+                        ],
+                        "sizeBytes": 11081180
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/openova-flow-adapter-flux@sha256:ffc60bb400d3b8e8e7d19ced0b8714d038ee6c9b9012cc9019e2341d57c1989f",
+                            "ghcr.io/openova-io/openova/openova-flow-adapter-flux:b32eb9b"
+                        ],
+                        "sizeBytes": 10917169
+                    },
+                    {
+                        "names": [
+                            "docker.io/library/nats@sha256:c82559e4476289481a8a5196e675ebfe67eea81d95e5161e3e78eccfe766608e",
+                            "docker.io/library/nats:2.10.16-alpine"
+                        ],
+                        "sizeBytes": 9725619
+                    },
+                    {
+                        "names": [
+                            "docker.io/curlimages/curl@sha256:d9b4541e214bcd85196d6e92e2753ac6d0ea699f0af5741f8c6cccbfcf00ef4b",
+                            "harbor.openova.io/proxy-dockerhub/curlimages/curl@sha256:d9b4541e214bcd85196d6e92e2753ac6d0ea699f0af5741f8c6cccbfcf00ef4b",
+                            "docker.io/curlimages/curl:8.10.1",
+                            "harbor.openova.io/proxy-dockerhub/curlimages/curl:8.10.1"
+                        ],
+                        "sizeBytes": 9414401
+                    },
+                    {
+                        "names": [
+                            "docker.io/natsio/nats-server-config-reloader@sha256:98d592981444fac82f79950b42f439f16918e9788fe5080eb32ac8cc7f357df1",
+                            "docker.io/natsio/nats-server-config-reloader:0.14.3"
+                        ],
+                        "sizeBytes": 4628347
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/newapi-sandbox-bridge@sha256:170363bf9b313db7844a566df72aa07ab483d31c1eb2af59694da65169483c02",
+                            "ghcr.io/openova-io/openova/newapi-sandbox-bridge:5d818d4"
+                        ],
+                        "sizeBytes": 4477093
+                    },
+                    {
+                        "names": [
+                            "docker.io/library/alpine@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc",
+                            "harbor.openova.io/proxy-dockerhub/alpine@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc",
+                            "harbor.openova.io/proxy-dockerhub/library/alpine@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc",
+                            "docker.io/library/alpine:3.20",
+                            "harbor.openova.io/proxy-dockerhub/alpine:3.20"
+                        ],
+                        "sizeBytes": 3641182
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/library/busybox@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662",
+                            "harbor.openova.io/proxy-dockerhub/library/busybox:1.36"
+                        ],
+                        "sizeBytes": 2217006
+                    },
+                    {
+                        "names": [
+                            "docker.io/rancher/mirrored-library-busybox@sha256:8a45424ddf949bbe9bb3231b05f9032a45da5cd036eb4867b511b00734756d6f",
+                            "docker.io/rancher/mirrored-library-busybox:1.36.1"
+                        ],
+                        "sizeBytes": 2147340
+                    },
+                    {
+                        "names": [
+                            "docker.io/rancher/mirrored-pause@sha256:74c4244427b7312c5b901fe0f67cbc53683d06f4f24c6faee65d4182bf0fa893",
+                            "docker.io/rancher/mirrored-pause:3.6"
+                        ],
+                        "sizeBytes": 301463
+                    }
+                ],
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "9f78daf8-4063-4e33-bf9c-2f8b6c7e7027",
+                    "containerRuntimeVersion": "containerd://1.7.23-k3s2",
+                    "kernelVersion": "5.15.0-76-generic",
+                    "kubeProxyVersion": "v1.31.4+k3s1",
+                    "kubeletVersion": "v1.31.4+k3s1",
+                    "machineID": "41895bd1876a403788902e232a28f6c9",
+                    "operatingSystem": "linux",
+                    "osImage": "Ubuntu 22.04.2 LTS",
+                    "systemUUID": "876f4015-e2be-4a52-bbd5-fce58f5cbbfc"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "alpha.kubernetes.io/provided-node-ip": "10.169.1.83",
+                    "k3s.io/hostname": "catalyst-hw173-omani-works-7bb723da-me-east-215-a-wfce2ae",
+                    "k3s.io/internal-ip": "10.169.1.83",
+                    "k3s.io/node-args": "[\"agent\",\"--node-label\",\"catalyst.openova.io/provider=huawei\",\"--node-label\",\"openova.io/region=hw-me-east-215-a-rtz-prod\",\"--node-label\",\"topology.kubernetes.io/region=me-east-215-a\",\"--node-label\",\"topology.kubernetes.io/zone=me-east-215-a\"]",
+                    "k3s.io/node-config-hash": "IGBSO4FMC7NARQHWC2L6GVMICVTYKLUIOWX7FPNTZJHOZOLQ7FCQ====",
+                    "k3s.io/node-env": "{\"K3S_TOKEN\":\"********\",\"K3S_URL\":\"https://10.169.1.43:6443\"}",
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2026-06-20T03:02:02Z",
+                "finalizers": [
+                    "wrangler.cattle.io/node",
+                    "wrangler.cattle.io/managed-etcd-controller"
+                ],
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "k3s",
+                    "beta.kubernetes.io/os": "linux",
+                    "catalyst.openova.io/provider": "huawei",
+                    "failure-domain.beta.kubernetes.io/region": "me-east-215-a",
+                    "failure-domain.beta.kubernetes.io/zone": "me-east-215-a",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "catalyst-hw173-omani-works-7bb723da-me-east-215-a-wfce2ae",
+                    "kubernetes.io/os": "linux",
+                    "node.kubernetes.io/instance-type": "k3s",
+                    "openova.io/region": "hw-me-east-215-a-rtz-prod",
+                    "topology.kubernetes.io/region": "me-east-215-a",
+                    "topology.kubernetes.io/zone": "me-east-215-a"
+                },
+                "name": "catalyst-hw173-omani-works-7bb723da-me-east-215-a-wfce2ae",
+                "resourceVersion": "897067",
+                "uid": "ac48c3d8-bcfd-4577-8ff0-58d08ee829db"
+            },
+            "spec": {
+                "podCIDR": "10.42.4.0/24",
+                "podCIDRs": [
+                    "10.42.4.0/24"
+                ],
+                "providerID": "k3s://catalyst-hw173-omani-works-7bb723da-me-east-215-a-wfce2ae"
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "10.169.1.83",
+                        "type": "InternalIP"
+                    },
+                    {
+                        "address": "catalyst-hw173-omani-works-7bb723da-me-east-215-a-wfce2ae",
+                        "type": "Hostname"
+                    }
+                ],
+                "allocatable": {
+                    "cpu": "4",
+                    "ephemeral-storage": "39857063496",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "32666744Ki",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "cpu": "4",
+                    "ephemeral-storage": "40971488Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "32666744Ki",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2026-06-20T03:03:03Z",
+                        "lastTransitionTime": "2026-06-20T03:03:03Z",
+                        "message": "Cilium is running on this node",
+                        "reason": "CiliumIsUp",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:08:40Z",
+                        "lastTransitionTime": "2026-06-20T03:02:01Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:08:40Z",
+                        "lastTransitionTime": "2026-06-20T03:02:01Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:08:40Z",
+                        "lastTransitionTime": "2026-06-20T03:02:01Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:08:40Z",
+                        "lastTransitionTime": "2026-06-20T03:02:59Z",
+                        "message": "kubelet is posting ready status",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10250
+                    }
+                },
+                "images": [
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/catalyst-api@sha256:25e35caa74ae8354f87481c1a91b8c1d173ee1828774867e987b7bdb367d9437",
+                            "ghcr.io/openova-io/openova/catalyst-api:01c150e"
+                        ],
+                        "sizeBytes": 456624059
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/catalyst-api@sha256:382319d07e5b68431446d95bbe2aad8cd283567614e9d704b443ef80f24ed806",
+                            "ghcr.io/openova-io/openova/catalyst-api:3b91660"
+                        ],
+                        "sizeBytes": 456623985
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/catalyst-api@sha256:62b56958c09fb52c3cc615302a0e45d9b5d9fba8c220e1df5814b3138ed1d153",
+                            "ghcr.io/openova-io/openova/catalyst-api:2876e02"
+                        ],
+                        "sizeBytes": 456623940
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/catalyst-api@sha256:b9defedc846492b815008558d1d9c539dfeacccb44c2f90cf76559a38b8ae720",
+                            "ghcr.io/openova-io/openova/catalyst-api:ba69881"
+                        ],
+                        "sizeBytes": 456622194
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/alpine/k8s@sha256:9c4976d47656d78cf53a92b0203fc54ac45eae18a2b45001ac221c27da4c8036",
+                            "harbor.openova.io/proxy-dockerhub/alpine/k8s:1.31.4"
+                        ],
+                        "sizeBytes": 315720891
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/alpine/k8s@sha256:bd01dae02676ce4cab62fc744e43443eee5bf660054e94d3496d23bfc35d384e",
+                            "harbor.openova.io/proxy-dockerhub/alpine/k8s:1.30.0"
+                        ],
+                        "sizeBytes": 292136583
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql@sha256:027303cd89644acdeba67d2b37f70eff6a7f345220f127721ff92504e1e4eae6",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16"
+                        ],
+                        "sizeBytes": 258220911
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/cilium@sha256:758ca0793f5995bb938a2fa219dcce63dc0b3fa7fc4ce5cc851125281fb7361d"
+                        ],
+                        "sizeBytes": 224306600
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql@sha256:99be063781d171d3971089b49c992706bdab9ccbd2b57cdf126c7542773aedfe",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16.4"
+                        ],
+                        "sizeBytes": 217672880
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql@sha256:cd2f88c75f4465ed14ff2006147e06405cca646c00f252a2dfb73910728d289f",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16.4-1"
+                        ],
+                        "sizeBytes": 211733506
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/grafana/alloy@sha256:6e00cf7c5a692ff5f24844529416ed017d76fce922f8199004e73d5eca46b6b8",
+                            "harbor.openova.io/proxy-dockerhub/grafana/alloy:v1.16.0"
+                        ],
+                        "sizeBytes": 151457664
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/guacd@sha256:38232cae271361ef53db46faf5c49fe64049a1320a05b82c597425b69d6ce77e",
+                            "ghcr.io/openova-io/openova/guacd:1.5.5"
+                        ],
+                        "sizeBytes": 129509469
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl@sha256:64614ef8290f3fb27fed5164b338debeeb79a1e5e26c93eb920770b71abd7c48",
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.31.4"
+                        ],
+                        "sizeBytes": 111911970
+                    },
+                    {
+                        "names": [
+                            "docker.io/powerdns/pdns-auth-50@sha256:1f136c4fa4f995279b43c6a8413dde05147cc9b74a437e188f92b0088c523a8d",
+                            "docker.io/powerdns/pdns-auth-50:5.0.3"
+                        ],
+                        "sizeBytes": 102061459
+                    },
+                    {
+                        "names": [
+                            "docker.io/chrislusf/seaweedfs@sha256:84429e5f21fad82246f5cfae7b39e9a17da18afb62f2b79c25ccd364ab02793b",
+                            "docker.io/chrislusf/seaweedfs:4.22"
+                        ],
+                        "sizeBytes": 100503219
+                    },
+                    {
+                        "names": [
+                            "docker.io/emberstack/kubernetes-reflector@sha256:84a83d1c28e78a3b7614e85b0dad872e88c549e05a7838754c4a340be601a4ae",
+                            "docker.io/emberstack/kubernetes-reflector:7.1.288"
+                        ],
+                        "sizeBytes": 93834221
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/goharbor/harbor-registryctl@sha256:ddf6bb429eb6b5a3db3e98bfe6ab3dd2567ebb35547836d87fc54ddacebfac8d",
+                            "harbor.openova.io/proxy-dockerhub/goharbor/harbor-registryctl:v2.14.3"
+                        ],
+                        "sizeBytes": 69351406
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/catalyst-api@sha256:f43db4565f6a93ce78fe7ebb0044d16b8e4bcc69713941ed7e3bf7a84a3b1bf3",
+                            "ghcr.io/openova-io/openova/catalyst-api:3a1bb63"
+                        ],
+                        "sizeBytes": 68285932
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/catalyst-api@sha256:aa2a27e506c5ecd9058a949dd71e5717fd0996efcec8e1918b6c20cceedc76e7",
+                            "ghcr.io/openova-io/openova/catalyst-api:25b7727"
+                        ],
+                        "sizeBytes": 68279434
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/catalyst-api@sha256:6d24e1c21f0efcdf50788e215840f910aa7d76877504cebe609714497559f0da",
+                            "ghcr.io/openova-io/openova/catalyst-api:5a8f964"
+                        ],
+                        "sizeBytes": 68279434
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/catalyst-api@sha256:f615456341b180feef1e538fdf1689cfc1048b5492434657cd3f78b975a458b9",
+                            "ghcr.io/openova-io/openova/catalyst-api:0d78ff5"
+                        ],
+                        "sizeBytes": 68277295
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/external-secrets/external-secrets@sha256:937c550ff84dded588324be89df42b2fa7d2cb2981271343c956b5348ae64011",
+                            "harbor.openova.io/proxy-ghcr/external-secrets/external-secrets:v0.10.7"
+                        ],
+                        "sizeBytes": 66393246
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/cilium-envoy@sha256:709c08ade3d17d52da4ca2af33f431360ec26268d288d9a6cd1d98acc9a1dced"
+                        ],
+                        "sizeBytes": 62862122
+                    },
+                    {
+                        "names": [
+                            "mirror.gcr.io/aquasec/trivy@sha256:be1190afcb28352bfddc4ddeb71470835d16462af68d310f9f4bca710961a41e",
+                            "mirror.gcr.io/aquasec/trivy:0.70.0"
+                        ],
+                        "sizeBytes": 58469315
+                    },
+                    {
+                        "names": [
+                            "docker.io/falcosecurity/falco@sha256:b4166a61f41e2fa638c041cac881d8bb32c284e3aaf282fdfed80f15f6eb55e3",
+                            "docker.io/falcosecurity/falco:0.43.1"
+                        ],
+                        "sizeBytes": 50563340
+                    },
+                    {
+                        "names": [
+                            "mirror.gcr.io/aquasec/trivy-operator@sha256:448484ece65e26f1c7237c8d20dab997f5a8319968286a09e188140b863cf1f9",
+                            "mirror.gcr.io/aquasec/trivy-operator:0.30.1"
+                        ],
+                        "sizeBytes": 49226533
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/cloudnative-pg@sha256:68074486205a33ed41928761e22ad48278c690feebe8316727a1c6b3380f9e5e",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/cloudnative-pg:1.29.0"
+                        ],
+                        "sizeBytes": 36402270
+                    },
+                    {
+                        "names": [
+                            "docker.io/grafana/mimir@sha256:686138d9f941508c99c931cc9e69bf9f6100dd4d2d623bf57b38d5c25ee645c1",
+                            "docker.io/grafana/mimir:3.0.4"
+                        ],
+                        "sizeBytes": 33769654
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/goharbor/registry-photon@sha256:6533fc396cbce57131053faec55e1bd1da8b92aed318410c203ff1c7a9b910ab",
+                            "harbor.openova.io/proxy-dockerhub/goharbor/registry-photon:v2.14.3"
+                        ],
+                        "sizeBytes": 33528071
+                    },
+                    {
+                        "names": [
+                            "docker.io/falcosecurity/falcoctl@sha256:0d3bddce03a26365b86e6ff1aa5c51965d2e16569e8cf8b3e37a3d3ef186dc9b",
+                            "docker.io/falcosecurity/falcoctl:0.12.2"
+                        ],
+                        "sizeBytes": 33185258
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/catalyst-ui@sha256:70dfadc103e85c3d9e408f184cae65dc8983ef6363c3c0a097f78f49d190db7e",
+                            "ghcr.io/openova-io/openova/catalyst-ui:0d78ff5"
+                        ],
+                        "sizeBytes": 31761894
+                    },
+                    {
+                        "names": [
+                            "quay.io/minio/mc@sha256:993e8c454a7ec632923f7e3e61adf1d473261da6354cefd641aedd33a2cfe112",
+                            "quay.io/minio/mc:RELEASE.2024-11-21T17-21-54Z"
+                        ],
+                        "sizeBytes": 28122288
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/marketplace@sha256:a5eccce2d44f344dd3f984fbf7742fc21fa67077ebdd3f2522a2e6ec88cff162",
+                            "ghcr.io/openova-io/openova/marketplace:ac8e023"
+                        ],
+                        "sizeBytes": 26213737
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/fluxcd/image-automation-controller@sha256:5b6c2e97055cfe69fe8996f48b53db039c136210dbc98c5631864a9e573d0e20",
+                            "harbor.openova.io/proxy-ghcr/fluxcd/image-automation-controller:v0.39.0"
+                        ],
+                        "sizeBytes": 22354899
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/library/nginx@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10",
+                            "harbor.openova.io/proxy-dockerhub/library/nginx:1.27-alpine"
+                        ],
+                        "sizeBytes": 20984244
+                    },
+                    {
+                        "names": [
+                            "xpkg.upbound.io/crossplane/crossplane@sha256:c98f027ffade306fc9a5132aec74a1430357f1028c0da024b95c25a19b3148fc",
+                            "xpkg.upbound.io/crossplane/crossplane:v1.18.0"
+                        ],
+                        "sizeBytes": 20944049
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/environment-controller@sha256:2a2dd00e93f0aef618f86bf46b45bc8342775686fff508f136e2a19f725c40f0",
+                            "ghcr.io/openova-io/openova/environment-controller:01db043"
+                        ],
+                        "sizeBytes": 16808753
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-quay/prometheus-operator/prometheus-config-reloader@sha256:959d47672fbff2776a04ec62b8afcec89e8c036af84dc5fade50019dab212746",
+                            "harbor.openova.io/proxy-quay/prometheus-operator/prometheus-config-reloader:v0.81.0"
+                        ],
+                        "sizeBytes": 14433657
+                    },
+                    {
+                        "names": [
+                            "docker.io/bitnami/sealed-secrets-controller@sha256:29148c5750290f8a3022541712d0984775a0553a949c48e9285f5862532cc362",
+                            "docker.io/bitnami/sealed-secrets-controller:0.27.1"
+                        ],
+                        "sizeBytes": 12615435
+                    },
+                    {
+                        "names": [
+                            "registry.k8s.io/autoscaling/vpa-recommender@sha256:0e26495e23c72aad6840fea22cb49865de703348c4e2bd56d173d718e849233a",
+                            "registry.k8s.io/autoscaling/vpa-recommender:1.5.0"
+                        ],
+                        "sizeBytes": 11411407
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/k8s-ws-proxy@sha256:0e3c679c9f78b302575cf9d6e2ae0e5d82d861e4d6de19876df0ca496677825b",
+                            "ghcr.io/openova-io/openova/k8s-ws-proxy:b32eb9b"
+                        ],
+                        "sizeBytes": 11403264
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/openova-flow-adapter-flux@sha256:ffc60bb400d3b8e8e7d19ced0b8714d038ee6c9b9012cc9019e2341d57c1989f",
+                            "ghcr.io/openova-io/openova/openova-flow-adapter-flux:b32eb9b"
+                        ],
+                        "sizeBytes": 10917169
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/application-controller@sha256:4f93ec89305c6c2df2044022e3e4027be122326d79b1ecd201948b4e1eb2bfe3",
+                            "ghcr.io/openova-io/openova/application-controller:01db043"
+                        ],
+                        "sizeBytes": 9783902
+                    },
+                    {
+                        "names": [
+                            "docker.io/library/nats@sha256:c82559e4476289481a8a5196e675ebfe67eea81d95e5161e3e78eccfe766608e",
+                            "docker.io/library/nats:2.10.16-alpine"
+                        ],
+                        "sizeBytes": 9725619
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/curlimages/curl@sha256:d9b4541e214bcd85196d6e92e2753ac6d0ea699f0af5741f8c6cccbfcf00ef4b",
+                            "harbor.openova.io/proxy-dockerhub/curlimages/curl:8.10.1"
+                        ],
+                        "sizeBytes": 9414401
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/services-provisioning@sha256:c63cd2e345206404083210f83d9d454ae9b50338dc98fb183ed27cbefe551061",
+                            "ghcr.io/openova-io/openova/services-provisioning:c068e6a"
+                        ],
+                        "sizeBytes": 5662896
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/services-billing@sha256:4e4da149cd5668c13f7f4da934c72f8e96b933ae0d929eda0ea1f3e72544b48e",
+                            "ghcr.io/openova-io/openova/services-billing:c068e6a"
+                        ],
+                        "sizeBytes": 5224926
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/services-auth@sha256:6fd3cf80296a13cdcdcc8bd9877b48ab3232b399900ab3b43b0e7efc264b34d4",
+                            "ghcr.io/openova-io/openova/services-auth:c068e6a"
+                        ],
+                        "sizeBytes": 4781044
+                    },
+                    {
+                        "names": [
+                            "docker.io/natsio/nats-server-config-reloader@sha256:98d592981444fac82f79950b42f439f16918e9788fe5080eb32ac8cc7f357df1",
+                            "docker.io/natsio/nats-server-config-reloader:0.14.3"
+                        ],
+                        "sizeBytes": 4628347
+                    },
+                    {
+                        "names": [
+                            "docker.io/library/alpine@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc",
+                            "harbor.openova.io/proxy-dockerhub/library/alpine@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc",
+                            "docker.io/library/alpine:3.20",
+                            "harbor.openova.io/proxy-dockerhub/library/alpine:3.20"
+                        ],
+                        "sizeBytes": 3641182
+                    }
+                ],
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "1e1b9e2a-5445-4d1c-9132-1defe356565d",
+                    "containerRuntimeVersion": "containerd://1.7.23-k3s2",
+                    "kernelVersion": "5.15.0-76-generic",
+                    "kubeProxyVersion": "v1.31.4+k3s1",
+                    "kubeletVersion": "v1.31.4+k3s1",
+                    "machineID": "41895bd1876a403788902e232a28f6c9",
+                    "operatingSystem": "linux",
+                    "osImage": "Ubuntu 22.04.2 LTS",
+                    "systemUUID": "cf7f1254-9795-4763-b1a5-906f26b8c7a4"
+                }
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": ""
+    }
+}

--- a/products/catalyst/bootstrap/api/internal/handler/testdata/hw173_3986/nodes-b.json
+++ b/products/catalyst/bootstrap/api/internal/handler/testdata/hw173_3986/nodes-b.json
@@ -1,0 +1,2712 @@
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "alpha.kubernetes.io/provided-node-ip": "10.179.1.131",
+                    "etcd.k3s.cattle.io/local-snapshots-timestamp": "2026-06-20T12:00:02+08:00",
+                    "etcd.k3s.cattle.io/node-address": "10.179.1.131",
+                    "etcd.k3s.cattle.io/node-name": "catalyst-hw173-omani-works-7bb723da-me-east-215-b-cp1-174a7a-274d2802",
+                    "k3s.io/external-ip": "212.72.24.35",
+                    "k3s.io/hostname": "catalyst-hw173-omani-works-7bb723da-me-east-215-b-cp1-174a7a",
+                    "k3s.io/internal-ip": "10.179.1.131",
+                    "k3s.io/node-args": "[\"server\",\"--cluster-init\",\"--flannel-backend\",\"none\",\"--disable-network-policy\",\"--disable\",\"traefik\",\"--disable\",\"servicelb\",\"--cluster-cidr\",\"10.43.0.0/16\",\"--service-cidr\",\"10.97.0.0/16\",\"--node-ip\",\"10.179.1.131\",\"--node-external-ip\",\"212.72.24.35\",\"--advertise-address\",\"10.179.1.131\",\"--kubelet-arg\",\"max-pods=220\",\"--tls-san\",\"hw173.omani.works\",\"--tls-san\",\"10.179.1.131\",\"--tls-san\",\"212.72.24.35\",\"--node-label\",\"catalyst.openova.io/role=control-plane\",\"--node-label\",\"openova.io/region=hw-me-east-215-b-rtz-prod\",\"--node-label\",\"topology.kubernetes.io/region=me-east-215-b\",\"--node-label\",\"topology.kubernetes.io/zone=me-east-215-b\",\"--node-label\",\"catalyst.openova.io/provider=huawei\",\"--kube-apiserver-arg\",\"default-watch-cache-size=200\",\"--kube-apiserver-arg\",\"watch-cache-sizes=secrets#500,configmaps#500\",\"--etcd-snapshot-retention\",\"5\",\"--write-kubeconfig-mode\",\"0644\"]",
+                    "k3s.io/node-config-hash": "FBFKQN7E73JXZWSPBYZSHJRBHGFD4HCTB5BUNCTTTR6N4XH545IA====",
+                    "k3s.io/node-env": "{\"K3S_TOKEN\":\"********\"}",
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2026-06-20T02:58:19Z",
+                "finalizers": [
+                    "wrangler.cattle.io/node",
+                    "wrangler.cattle.io/managed-etcd-controller"
+                ],
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "k3s",
+                    "beta.kubernetes.io/os": "linux",
+                    "catalyst.openova.io/provider": "huawei",
+                    "catalyst.openova.io/role": "control-plane",
+                    "failure-domain.beta.kubernetes.io/region": "me-east-215-b",
+                    "failure-domain.beta.kubernetes.io/zone": "me-east-215-b",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "catalyst-hw173-omani-works-7bb723da-me-east-215-b-cp1-174a7a",
+                    "kubernetes.io/os": "linux",
+                    "node-role.kubernetes.io/control-plane": "true",
+                    "node-role.kubernetes.io/etcd": "true",
+                    "node-role.kubernetes.io/master": "true",
+                    "node.kubernetes.io/instance-type": "k3s",
+                    "openova.io/region": "hw-me-east-215-b-rtz-prod",
+                    "topology.kubernetes.io/region": "me-east-215-b",
+                    "topology.kubernetes.io/zone": "me-east-215-b"
+                },
+                "name": "catalyst-hw173-omani-works-7bb723da-me-east-215-b-cp1-174a7a",
+                "resourceVersion": "717361",
+                "uid": "5ad06609-1788-41ae-8774-885f7c2a0f68"
+            },
+            "spec": {
+                "podCIDR": "10.43.0.0/24",
+                "podCIDRs": [
+                    "10.43.0.0/24"
+                ],
+                "providerID": "k3s://catalyst-hw173-omani-works-7bb723da-me-east-215-b-cp1-174a7a"
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "10.179.1.131",
+                        "type": "InternalIP"
+                    },
+                    {
+                        "address": "212.72.24.35",
+                        "type": "ExternalIP"
+                    },
+                    {
+                        "address": "catalyst-hw173-omani-works-7bb723da-me-east-215-b-cp1-174a7a",
+                        "type": "Hostname"
+                    }
+                ],
+                "allocatable": {
+                    "cpu": "2",
+                    "ephemeral-storage": "39857063496",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "16176736Ki",
+                    "pods": "220"
+                },
+                "capacity": {
+                    "cpu": "2",
+                    "ephemeral-storage": "40971488Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "16176736Ki",
+                    "pods": "220"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2026-06-20T03:06:46Z",
+                        "lastTransitionTime": "2026-06-20T03:06:46Z",
+                        "message": "Cilium is running on this node",
+                        "reason": "CiliumIsUp",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:08:34Z",
+                        "lastTransitionTime": "2026-06-20T02:58:34Z",
+                        "message": "Node is a voting member of the etcd cluster",
+                        "reason": "MemberNotLearner",
+                        "status": "True",
+                        "type": "EtcdIsVoter"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:09:50Z",
+                        "lastTransitionTime": "2026-06-20T02:58:19Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:09:50Z",
+                        "lastTransitionTime": "2026-06-20T02:58:19Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:09:50Z",
+                        "lastTransitionTime": "2026-06-20T02:58:19Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:09:50Z",
+                        "lastTransitionTime": "2026-06-20T03:06:43Z",
+                        "message": "kubelet is posting ready status",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10250
+                    }
+                },
+                "images": [
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/catalyst-api@sha256:3e233095b657e7c84da1e200c45d483e6c7ab509b23cf8bfe1bf0b8dfd01dfad",
+                            "ghcr.io/openova-io/openova/catalyst-api:c7d040a"
+                        ],
+                        "sizeBytes": 456618827
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql@sha256:027303cd89644acdeba67d2b37f70eff6a7f345220f127721ff92504e1e4eae6",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16"
+                        ],
+                        "sizeBytes": 258220911
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/cilium@sha256:758ca0793f5995bb938a2fa219dcce63dc0b3fa7fc4ce5cc851125281fb7361d"
+                        ],
+                        "sizeBytes": 224306600
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql@sha256:99be063781d171d3971089b49c992706bdab9ccbd2b57cdf126c7542773aedfe",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16.4"
+                        ],
+                        "sizeBytes": 217672880
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/grafana/alloy@sha256:6e00cf7c5a692ff5f24844529416ed017d76fce922f8199004e73d5eca46b6b8",
+                            "harbor.openova.io/proxy-dockerhub/grafana/alloy:v1.16.0"
+                        ],
+                        "sizeBytes": 151457664
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/amazon/aws-cli@sha256:643507c10ada7964ca6157b3d799f030b90577643da9955d319a77399ed80d73",
+                            "harbor.openova.io/proxy-dockerhub/amazon/aws-cli:2.17.0"
+                        ],
+                        "sizeBytes": 125732170
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl@sha256:64614ef8290f3fb27fed5164b338debeeb79a1e5e26c93eb920770b71abd7c48",
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.31.4"
+                        ],
+                        "sizeBytes": 111911970
+                    },
+                    {
+                        "names": [
+                            "docker.io/bitnamilegacy/kubectl@sha256:1249fc292e84a38575ee0cadc3e28dcd7ddf5a3a4e5da401b1a8599e8ac52a1b",
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl@sha256:1249fc292e84a38575ee0cadc3e28dcd7ddf5a3a4e5da401b1a8599e8ac52a1b",
+                            "docker.io/bitnamilegacy/kubectl:1.30.7",
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7"
+                        ],
+                        "sizeBytes": 110946736
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/kyverno/kyverno-cli@sha256:1e99a199adb36cedddf5c3e2fc24a150e26cf2e18b9e8dfe505a3c862647a4eb",
+                            "harbor.openova.io/proxy-ghcr/kyverno/kyverno-cli:v1.18.0"
+                        ],
+                        "sizeBytes": 103609401
+                    },
+                    {
+                        "names": [
+                            "docker.io/chrislusf/seaweedfs@sha256:84429e5f21fad82246f5cfae7b39e9a17da18afb62f2b79c25ccd364ab02793b",
+                            "docker.io/chrislusf/seaweedfs:4.22"
+                        ],
+                        "sizeBytes": 100503219
+                    },
+                    {
+                        "names": [
+                            "docker.io/powerdns/dnsdist-19@sha256:c2f859bb67865987878ff93c9c75758236fe659b4117b296da29da6b572affd0",
+                            "docker.io/powerdns/dnsdist-19:1.9.14"
+                        ],
+                        "sizeBytes": 84956522
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/powerdnsadmin/pda-legacy@sha256:0fc92c8ef63a6704083ca1989c83d2b747f7abc0e5045d56d9c69a76e08a9a5e",
+                            "harbor.openova.io/proxy-dockerhub/powerdnsadmin/pda-legacy:0.4.2"
+                        ],
+                        "sizeBytes": 73000672
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/cilium-envoy@sha256:709c08ade3d17d52da4ca2af33f431360ec26268d288d9a6cd1d98acc9a1dced"
+                        ],
+                        "sizeBytes": 62862122
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/fluxcd/kustomize-controller@sha256:e3b0cf847e9cdf47b19af0fbcfe22786b80b598e0caeea8b6d2a5f9c26a48a24",
+                            "ghcr.io/fluxcd/kustomize-controller:v1.4.0"
+                        ],
+                        "sizeBytes": 54969920
+                    },
+                    {
+                        "names": [
+                            "docker.io/falcosecurity/falco@sha256:b4166a61f41e2fa638c041cac881d8bb32c284e3aaf282fdfed80f15f6eb55e3",
+                            "docker.io/falcosecurity/falco:0.43.1"
+                        ],
+                        "sizeBytes": 50563340
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/fluxcd/notification-controller@sha256:425309a159b15e07f7d97622effc79bc432a37ed55289dd465d37fa217a92a7d",
+                            "ghcr.io/fluxcd/notification-controller:v1.4.0"
+                        ],
+                        "sizeBytes": 43654595
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/fluxcd/helm-controller@sha256:4c75ca6c24ceb1f1bd7e935d9287a93e4f925c512f206763ec5a47de3ef3ff48",
+                            "ghcr.io/fluxcd/helm-controller:v1.1.0"
+                        ],
+                        "sizeBytes": 40818921
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/fluxcd/image-reflector-controller@sha256:c6864684f96cfbb3a91c816084032bb019b302af8b63b0e06b12b4018a9a8242",
+                            "ghcr.io/fluxcd/image-reflector-controller:v0.33.0"
+                        ],
+                        "sizeBytes": 38586158
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/cloudnative-pg@sha256:68074486205a33ed41928761e22ad48278c690feebe8316727a1c6b3380f9e5e",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/cloudnative-pg:1.29.0"
+                        ],
+                        "sizeBytes": 36402270
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/hashicorp/vault-k8s@sha256:690647d935f9bb17b4e9d1eb75d10b1b23cfd63d98ca1c456e88ae1429d6c656",
+                            "harbor.openova.io/proxy-dockerhub/hashicorp/vault-k8s:1.4.2"
+                        ],
+                        "sizeBytes": 35244498
+                    },
+                    {
+                        "names": [
+                            "registry.k8s.io/external-dns/external-dns@sha256:4f3ba4c2bd28030caad05bb7b47fbf47549a46d5e8443b74f0be463550b4fc2b",
+                            "registry.k8s.io/external-dns/external-dns:v0.15.1"
+                        ],
+                        "sizeBytes": 33661299
+                    },
+                    {
+                        "names": [
+                            "docker.io/falcosecurity/falcoctl@sha256:0d3bddce03a26365b86e6ff1aa5c51965d2e16569e8cf8b3e37a3d3ef186dc9b",
+                            "docker.io/falcosecurity/falcoctl:0.12.2"
+                        ],
+                        "sizeBytes": 33185258
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/fluxcd/source-controller@sha256:3c5f0f022f990ffc0daf00e5b199548fc0fa6e7119e972318f0267081a332963",
+                            "ghcr.io/fluxcd/source-controller:v1.4.1"
+                        ],
+                        "sizeBytes": 32386205
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/catalyst-ui@sha256:93bc0cd1fdea1db23225bbd3ee634ebaa0f574bf0240417581be1b4c5911d398",
+                            "ghcr.io/openova-io/openova/catalyst-ui:c7d040a"
+                        ],
+                        "sizeBytes": 31794686
+                    },
+                    {
+                        "names": [
+                            "quay.io/minio/mc@sha256:993e8c454a7ec632923f7e3e61adf1d473261da6354cefd641aedd33a2cfe112",
+                            "quay.io/minio/mc:RELEASE.2024-11-21T17-21-54Z"
+                        ],
+                        "sizeBytes": 28122288
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/marketplace@sha256:a5eccce2d44f344dd3f984fbf7742fc21fa67077ebdd3f2522a2e6ec88cff162",
+                            "ghcr.io/openova-io/openova/marketplace:ac8e023"
+                        ],
+                        "sizeBytes": 26213737
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/console@sha256:f220f466b119562bfcdcba9da60220f7e10ae8c71788e987826d27b6a3ad527e",
+                            "ghcr.io/openova-io/openova/console:3c2f7e4"
+                        ],
+                        "sizeBytes": 26126565
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/admin@sha256:836defa5c46ad5e21a212fcb707ab067ea60264edb4446efb70a74a96affd424",
+                            "ghcr.io/openova-io/openova/admin:3c2f7e4"
+                        ],
+                        "sizeBytes": 26103885
+                    },
+                    {
+                        "names": [
+                            "docker.io/nginxinc/nginx-unprivileged@sha256:0c79d56aee561a1d81c63f00eee5fb5fe29279560cdc55e91425133104c7fbe6",
+                            "docker.io/nginxinc/nginx-unprivileged:1.29-alpine"
+                        ],
+                        "sizeBytes": 23098099
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/fluxcd/image-automation-controller@sha256:5b6c2e97055cfe69fe8996f48b53db039c136210dbc98c5631864a9e573d0e20",
+                            "ghcr.io/fluxcd/image-automation-controller:v0.39.0"
+                        ],
+                        "sizeBytes": 22354899
+                    },
+                    {
+                        "names": [
+                            "docker.io/natsio/jetstream-controller@sha256:5f38a5fe3ad179ffaca897edd6742f5fd26d3d5cf22de069c8fe024c52adab39",
+                            "docker.io/natsio/jetstream-controller:0.18.2"
+                        ],
+                        "sizeBytes": 20349008
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/aquasecurity/node-collector@sha256:f4702ce4667388f0219d6248d623a7e816231c2d4561d6af01c3ae053e524025",
+                            "ghcr.io/aquasecurity/node-collector:0.3.1"
+                        ],
+                        "sizeBytes": 20174022
+                    },
+                    {
+                        "names": [
+                            "docker.io/coredns/coredns@sha256:9caabbf6238b189a65d0d6e6ac138de60d6a1c419e5a341fbbb7c78382559c6e",
+                            "docker.io/coredns/coredns:1.11.3"
+                        ],
+                        "sizeBytes": 18562039
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/organization-controller@sha256:5db285364a423be98a81185fbe09ef05fe23d628744f7e86f479b52f0358506a",
+                            "ghcr.io/openova-io/openova/organization-controller:300d853"
+                        ],
+                        "sizeBytes": 17698913
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/environment-controller@sha256:2a2dd00e93f0aef618f86bf46b45bc8342775686fff508f136e2a19f725c40f0",
+                            "ghcr.io/openova-io/openova/environment-controller:01db043"
+                        ],
+                        "sizeBytes": 16808753
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/useraccess-controller@sha256:8d865fc5241e520b3a9fd16f2597e32e5c9eb08aa41b83b7b9e4fd40ce599974",
+                            "ghcr.io/openova-io/openova/useraccess-controller:01db043"
+                        ],
+                        "sizeBytes": 16674249
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-quay/prometheus-operator/prometheus-config-reloader@sha256:959d47672fbff2776a04ec62b8afcec89e8c036af84dc5fade50019dab212746",
+                            "harbor.openova.io/proxy-quay/prometheus-operator/prometheus-config-reloader:v0.81.0"
+                        ],
+                        "sizeBytes": 14433657
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/corazawaf/coraza-spoa@sha256:e8e9e21f494fa334de5ad469fbdb3d595b2651d1db88105f5971cb2eada27cb1",
+                            "ghcr.io/corazawaf/coraza-spoa:0.7.0"
+                        ],
+                        "sizeBytes": 11937882
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/k8s-ws-proxy@sha256:0e3c679c9f78b302575cf9d6e2ae0e5d82d861e4d6de19876df0ca496677825b",
+                            "ghcr.io/openova-io/openova/k8s-ws-proxy:b32eb9b"
+                        ],
+                        "sizeBytes": 11403264
+                    },
+                    {
+                        "names": [
+                            "registry.k8s.io/autoscaling/vpa-updater@sha256:b60e102cefe4760b2ee4d04bc7f21fff5882ed7f5641b0dd4efbef452749baeb",
+                            "registry.k8s.io/autoscaling/vpa-updater:1.5.0"
+                        ],
+                        "sizeBytes": 11330068
+                    },
+                    {
+                        "names": [
+                            "registry.k8s.io/autoscaling/vpa-admission-controller@sha256:080854aebf844e29ec21538196f8d2fe606281189e1f1a9168a4f553b43e3251",
+                            "registry.k8s.io/autoscaling/vpa-admission-controller:1.5.0"
+                        ],
+                        "sizeBytes": 11292005
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/openova-flow-adapter-flux@sha256:ffc60bb400d3b8e8e7d19ced0b8714d038ee6c9b9012cc9019e2341d57c1989f",
+                            "ghcr.io/openova-io/openova/openova-flow-adapter-flux:b32eb9b"
+                        ],
+                        "sizeBytes": 10917169
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/application-controller@sha256:4f93ec89305c6c2df2044022e3e4027be122326d79b1ecd201948b4e1eb2bfe3",
+                            "ghcr.io/openova-io/openova/application-controller:01db043"
+                        ],
+                        "sizeBytes": 9783902
+                    },
+                    {
+                        "names": [
+                            "docker.io/curlimages/curl@sha256:d9b4541e214bcd85196d6e92e2753ac6d0ea699f0af5741f8c6cccbfcf00ef4b",
+                            "harbor.openova.io/proxy-dockerhub/curlimages/curl@sha256:d9b4541e214bcd85196d6e92e2753ac6d0ea699f0af5741f8c6cccbfcf00ef4b",
+                            "docker.io/curlimages/curl:8.10.1",
+                            "harbor.openova.io/proxy-dockerhub/curlimages/curl:8.10.1"
+                        ],
+                        "sizeBytes": 9414401
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/services-tenant@sha256:b10165940cb83d6bc73462fca172aaf5f09093d0edd4d55893e768903e9b6445",
+                            "ghcr.io/openova-io/openova/services-tenant:c068e6a"
+                        ],
+                        "sizeBytes": 9198708
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/services-provisioning@sha256:c63cd2e345206404083210f83d9d454ae9b50338dc98fb183ed27cbefe551061",
+                            "ghcr.io/openova-io/openova/services-provisioning:c068e6a"
+                        ],
+                        "sizeBytes": 5662896
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/services-domain@sha256:4c8b60ed4282d8d58f67a078ac762aac551de29abfcb8c33ae0bc29f78167f71",
+                            "ghcr.io/openova-io/openova/services-domain:c068e6a"
+                        ],
+                        "sizeBytes": 5535697
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/services-catalog@sha256:cb7211549ce610067b492f4c823c01c50fbe0523f8a53713abadc6e0aa2d48b0",
+                            "ghcr.io/openova-io/openova/services-catalog:c068e6a"
+                        ],
+                        "sizeBytes": 5333143
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/services-billing@sha256:4e4da149cd5668c13f7f4da934c72f8e96b933ae0d929eda0ea1f3e72544b48e",
+                            "ghcr.io/openova-io/openova/services-billing:c068e6a"
+                        ],
+                        "sizeBytes": 5224926
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/services-auth@sha256:6fd3cf80296a13cdcdcc8bd9877b48ab3232b399900ab3b43b0e7efc264b34d4",
+                            "ghcr.io/openova-io/openova/services-auth:c068e6a"
+                        ],
+                        "sizeBytes": 4781044
+                    }
+                ],
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "be3b96e3-9e91-41d7-8422-9048318b8abc",
+                    "containerRuntimeVersion": "containerd://1.7.23-k3s2",
+                    "kernelVersion": "5.15.0-76-generic",
+                    "kubeProxyVersion": "v1.31.4+k3s1",
+                    "kubeletVersion": "v1.31.4+k3s1",
+                    "machineID": "41895bd1876a403788902e232a28f6c9",
+                    "operatingSystem": "linux",
+                    "osImage": "Ubuntu 22.04.2 LTS",
+                    "systemUUID": "f47b474d-f77a-4813-9452-a5fb2007dded"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "alpha.kubernetes.io/provided-node-ip": "10.179.1.124",
+                    "k3s.io/hostname": "catalyst-hw173-omani-works-7bb723da-me-east-215-b-w468e0e",
+                    "k3s.io/internal-ip": "10.179.1.124",
+                    "k3s.io/node-args": "[\"agent\",\"--node-label\",\"catalyst.openova.io/provider=huawei\",\"--node-label\",\"openova.io/region=hw-me-east-215-b-rtz-prod\",\"--node-label\",\"topology.kubernetes.io/region=me-east-215-b\",\"--node-label\",\"topology.kubernetes.io/zone=me-east-215-b\"]",
+                    "k3s.io/node-config-hash": "ZAZ32NBDFHNHP7KSGYPV2T64JKCNXS5UYCTPHLTVNJNJTCWZ3AUQ====",
+                    "k3s.io/node-env": "{\"K3S_TOKEN\":\"********\",\"K3S_URL\":\"https://10.179.1.131:6443\"}",
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2026-06-20T03:02:09Z",
+                "finalizers": [
+                    "wrangler.cattle.io/node",
+                    "wrangler.cattle.io/managed-etcd-controller"
+                ],
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "k3s",
+                    "beta.kubernetes.io/os": "linux",
+                    "catalyst.openova.io/provider": "huawei",
+                    "failure-domain.beta.kubernetes.io/region": "me-east-215-b",
+                    "failure-domain.beta.kubernetes.io/zone": "me-east-215-b",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "catalyst-hw173-omani-works-7bb723da-me-east-215-b-w468e0e",
+                    "kubernetes.io/os": "linux",
+                    "node.kubernetes.io/instance-type": "k3s",
+                    "openova.io/region": "hw-me-east-215-b-rtz-prod",
+                    "topology.kubernetes.io/region": "me-east-215-b",
+                    "topology.kubernetes.io/zone": "me-east-215-b"
+                },
+                "name": "catalyst-hw173-omani-works-7bb723da-me-east-215-b-w468e0e",
+                "resourceVersion": "718090",
+                "uid": "e1d8c1b0-1093-451f-ae58-32094d685330"
+            },
+            "spec": {
+                "podCIDR": "10.43.4.0/24",
+                "podCIDRs": [
+                    "10.43.4.0/24"
+                ],
+                "providerID": "k3s://catalyst-hw173-omani-works-7bb723da-me-east-215-b-w468e0e"
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "10.179.1.124",
+                        "type": "InternalIP"
+                    },
+                    {
+                        "address": "catalyst-hw173-omani-works-7bb723da-me-east-215-b-w468e0e",
+                        "type": "Hostname"
+                    }
+                ],
+                "allocatable": {
+                    "cpu": "4",
+                    "ephemeral-storage": "39857063496",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "32666744Ki",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "cpu": "4",
+                    "ephemeral-storage": "40971488Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "32666744Ki",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2026-06-20T03:07:17Z",
+                        "lastTransitionTime": "2026-06-20T03:07:17Z",
+                        "message": "Cilium is running on this node",
+                        "reason": "CiliumIsUp",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:10:30Z",
+                        "lastTransitionTime": "2026-06-20T03:02:09Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:10:30Z",
+                        "lastTransitionTime": "2026-06-20T03:02:09Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:10:30Z",
+                        "lastTransitionTime": "2026-06-20T03:02:09Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:10:30Z",
+                        "lastTransitionTime": "2026-06-20T03:07:16Z",
+                        "message": "kubelet is posting ready status",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10250
+                    }
+                },
+                "images": [
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/guacamole-server@sha256:0f62f6d17ab379e46aa66874b2ff564dab856a6ef5e754a69cbb34c32d3e588a",
+                            "ghcr.io/openova-io/openova/guacamole-server:1.5.5"
+                        ],
+                        "sizeBytes": 307550497
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql@sha256:027303cd89644acdeba67d2b37f70eff6a7f345220f127721ff92504e1e4eae6",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16"
+                        ],
+                        "sizeBytes": 258220911
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/cilium@sha256:758ca0793f5995bb938a2fa219dcce63dc0b3fa7fc4ce5cc851125281fb7361d"
+                        ],
+                        "sizeBytes": 224306600
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql@sha256:cd2f88c75f4465ed14ff2006147e06405cca646c00f252a2dfb73910728d289f",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16.4-1"
+                        ],
+                        "sizeBytes": 211733506
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/grafana/grafana@sha256:2175aaa91c96733d86d31cf270d5310b278654b03f5718c59de12a865380a31f",
+                            "harbor.openova.io/proxy-dockerhub/grafana/grafana:12.3.1"
+                        ],
+                        "sizeBytes": 210410945
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/grafana/alloy@sha256:6e00cf7c5a692ff5f24844529416ed017d76fce922f8199004e73d5eca46b6b8",
+                            "harbor.openova.io/proxy-dockerhub/grafana/alloy:v1.16.0"
+                        ],
+                        "sizeBytes": 151457664
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl@sha256:f5fc0d561d9ef931f9ecb2e8b65d93eb92767c57f64897c56a100bfe28102c74",
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.29.3"
+                        ],
+                        "sizeBytes": 106148689
+                    },
+                    {
+                        "names": [
+                            "docker.io/powerdns/pdns-auth-50@sha256:1f136c4fa4f995279b43c6a8413dde05147cc9b74a437e188f92b0088c523a8d",
+                            "docker.io/powerdns/pdns-auth-50:5.0.3"
+                        ],
+                        "sizeBytes": 102061459
+                    },
+                    {
+                        "names": [
+                            "docker.io/chrislusf/seaweedfs@sha256:84429e5f21fad82246f5cfae7b39e9a17da18afb62f2b79c25ccd364ab02793b",
+                            "docker.io/chrislusf/seaweedfs:4.22"
+                        ],
+                        "sizeBytes": 100503219
+                    },
+                    {
+                        "names": [
+                            "docker.io/otel/opentelemetry-collector-contrib@sha256:a516c26968aa1feb5e5fc0562e3338ea13755cb4f373603226bcc4e276374ad0",
+                            "docker.io/otel/opentelemetry-collector-contrib:0.150.1"
+                        ],
+                        "sizeBytes": 98571324
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/powerdnsadmin/pda-legacy@sha256:0fc92c8ef63a6704083ca1989c83d2b747f7abc0e5045d56d9c69a76e08a9a5e",
+                            "harbor.openova.io/proxy-dockerhub/powerdnsadmin/pda-legacy:0.4.2"
+                        ],
+                        "sizeBytes": 73000672
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-quay/openbao/openbao@sha256:7de07aa6df3937d44c96c2d65c188b2d4a70546f2a764ad4510301305af6a223",
+                            "harbor.openova.io/proxy-quay/openbao/openbao:2.1.0"
+                        ],
+                        "sizeBytes": 62890555
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/cilium-envoy@sha256:709c08ade3d17d52da4ca2af33f431360ec26268d288d9a6cd1d98acc9a1dced"
+                        ],
+                        "sizeBytes": 62862122
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/loft-sh/vcluster@sha256:521b2fc8c8d0c2f1254d7fb956fbf274d3328f1e555270b57a886f9ae10d2109",
+                            "harbor.openova.io/proxy-ghcr/loft-sh/vcluster:0.23.0"
+                        ],
+                        "sizeBytes": 60761070
+                    },
+                    {
+                        "names": [
+                            "mirror.gcr.io/aquasec/trivy@sha256:be1190afcb28352bfddc4ddeb71470835d16462af68d310f9f4bca710961a41e",
+                            "mirror.gcr.io/aquasec/trivy:0.70.0"
+                        ],
+                        "sizeBytes": 58469315
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/goharbor/harbor-portal@sha256:2556b6c7dd832bf22ed8b177245fa5fbcd70255959e69c5d0fbe2153f4bd2243",
+                            "harbor.openova.io/proxy-dockerhub/goharbor/harbor-portal:v2.14.3"
+                        ],
+                        "sizeBytes": 56696973
+                    },
+                    {
+                        "names": [
+                            "docker.io/falcosecurity/falco@sha256:b4166a61f41e2fa638c041cac881d8bb32c284e3aaf282fdfed80f15f6eb55e3",
+                            "docker.io/falcosecurity/falco:0.43.1"
+                        ],
+                        "sizeBytes": 50563340
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/kyverno/reports-controller@sha256:0090bf10eabae091ceb48c38fb894580b63c4e76e40137b7972f5895f0402110",
+                            "harbor.openova.io/proxy-ghcr/kyverno/reports-controller:v1.18.0"
+                        ],
+                        "sizeBytes": 45253065
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/fluxcd/notification-controller@sha256:425309a159b15e07f7d97622effc79bc432a37ed55289dd465d37fa217a92a7d",
+                            "ghcr.io/fluxcd/notification-controller:v1.4.0"
+                        ],
+                        "sizeBytes": 43654595
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/fluxcd/flux-cli@sha256:a9cb966cddc1a0c56dc0d57dda485d9477dd397f8b45f222717b24663471fd1f",
+                            "harbor.openova.io/proxy-ghcr/fluxcd/flux-cli:v2.4.0"
+                        ],
+                        "sizeBytes": 41877267
+                    },
+                    {
+                        "names": [
+                            "docker.io/grafana/loki@sha256:3c8fd3570dd9219951a60d3f919c7f31923d10baee578b77bc26c4a0b32d092d",
+                            "docker.io/grafana/loki:3.6.7"
+                        ],
+                        "sizeBytes": 41373791
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/fluxcd/helm-controller@sha256:4c75ca6c24ceb1f1bd7e935d9287a93e4f925c512f206763ec5a47de3ef3ff48",
+                            "harbor.openova.io/proxy-ghcr/fluxcd/helm-controller:v1.1.0"
+                        ],
+                        "sizeBytes": 40818921
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/cloudnative-pg@sha256:68074486205a33ed41928761e22ad48278c690feebe8316727a1c6b3380f9e5e",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/cloudnative-pg:1.29.0"
+                        ],
+                        "sizeBytes": 36402270
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/clustermesh-apiserver@sha256:37a7fdbef806b78ef63df9f1a9828fdddbf548d1f0e43b8eb10a6bdc8fa03958"
+                        ],
+                        "sizeBytes": 35425816
+                    },
+                    {
+                        "names": [
+                            "docker.io/grafana/mimir@sha256:686138d9f941508c99c931cc9e69bf9f6100dd4d2d623bf57b38d5c25ee645c1",
+                            "docker.io/grafana/mimir:3.0.4"
+                        ],
+                        "sizeBytes": 33769654
+                    },
+                    {
+                        "names": [
+                            "docker.io/falcosecurity/falcoctl@sha256:0d3bddce03a26365b86e6ff1aa5c51965d2e16569e8cf8b3e37a3d3ef186dc9b",
+                            "docker.io/falcosecurity/falcoctl:0.12.2"
+                        ],
+                        "sizeBytes": 33185258
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-k8s/kube-apiserver@sha256:ace6a943b058439bd6daeb74f152e7c36e6fc0b5e481cdff9364cd6ca0473e5e",
+                            "harbor.openova.io/proxy-k8s/kube-apiserver:v1.31.4"
+                        ],
+                        "sizeBytes": 27972283
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-k8s/kube-controller-manager@sha256:4bd1d4a449e7a1a4f375bd7c71abf48a95f8949b38f725ded255077329f21f7b",
+                            "harbor.openova.io/proxy-k8s/kube-controller-manager:v1.31.4"
+                        ],
+                        "sizeBytes": 26147269
+                    },
+                    {
+                        "names": [
+                            "docker.io/kiwigrid/k8s-sidecar@sha256:a6b3f707f883108376514489a94d6629109a327b2978e1d826cd104c4ca436df",
+                            "harbor.openova.io/proxy-quay/kiwigrid/k8s-sidecar@sha256:a6b3f707f883108376514489a94d6629109a327b2978e1d826cd104c4ca436df",
+                            "docker.io/kiwigrid/k8s-sidecar:2.5.0",
+                            "harbor.openova.io/proxy-quay/kiwigrid/k8s-sidecar:2.5.0"
+                        ],
+                        "sizeBytes": 23422974
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/fluxcd/image-automation-controller@sha256:5b6c2e97055cfe69fe8996f48b53db039c136210dbc98c5631864a9e573d0e20",
+                            "harbor.openova.io/proxy-ghcr/fluxcd/image-automation-controller:v0.39.0"
+                        ],
+                        "sizeBytes": 22354899
+                    },
+                    {
+                        "names": [
+                            "xpkg.upbound.io/crossplane/crossplane@sha256:c98f027ffade306fc9a5132aec74a1430357f1028c0da024b95c25a19b3148fc",
+                            "xpkg.upbound.io/crossplane/crossplane:v1.18.0"
+                        ],
+                        "sizeBytes": 20944049
+                    },
+                    {
+                        "names": [
+                            "docker.io/rancher/mirrored-coredns-coredns@sha256:82979ddf442c593027a57239ad90616deb874e90c365d1a96ad508c2104bdea5",
+                            "docker.io/rancher/mirrored-coredns-coredns:1.12.0"
+                        ],
+                        "sizeBytes": 20938299
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/aquasecurity/node-collector@sha256:f4702ce4667388f0219d6248d623a7e816231c2d4561d6af01c3ae053e524025",
+                            "ghcr.io/aquasecurity/node-collector:0.3.1"
+                        ],
+                        "sizeBytes": 20174022
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/hubble-ui-backend@sha256:0e0eed917653441fded4e7cdb096b7be6a3bddded5a2dd10812a27b1fc6ed95b"
+                        ],
+                        "sizeBytes": 20027102
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-quay/oauth2-proxy/oauth2-proxy@sha256:dcb6ff8dd21bf3058f6a22c6fa385fa5b897a9cd3914c88a2cc2bb0a85f8065d",
+                            "harbor.openova.io/proxy-quay/oauth2-proxy/oauth2-proxy:v7.6.0"
+                        ],
+                        "sizeBytes": 16521978
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-quay/prometheus-operator/prometheus-config-reloader@sha256:959d47672fbff2776a04ec62b8afcec89e8c036af84dc5fade50019dab212746",
+                            "harbor.openova.io/proxy-quay/prometheus-operator/prometheus-config-reloader:v0.81.0"
+                        ],
+                        "sizeBytes": 14433657
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/k8s-ws-proxy@sha256:0e3c679c9f78b302575cf9d6e2ae0e5d82d861e4d6de19876df0ca496677825b",
+                            "ghcr.io/openova-io/openova/k8s-ws-proxy:b32eb9b"
+                        ],
+                        "sizeBytes": 11403264
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/hubble-ui@sha256:e2e9313eb7caf64b0061d9da0efbdad59c6c461f6ca1752768942bfeda0796c6"
+                        ],
+                        "sizeBytes": 11081180
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/openova-flow-adapter-flux@sha256:ffc60bb400d3b8e8e7d19ced0b8714d038ee6c9b9012cc9019e2341d57c1989f",
+                            "ghcr.io/openova-io/openova/openova-flow-adapter-flux:b32eb9b"
+                        ],
+                        "sizeBytes": 10917169
+                    },
+                    {
+                        "names": [
+                            "docker.io/library/alpine@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc",
+                            "docker.io/library/alpine:3.20"
+                        ],
+                        "sizeBytes": 3641182
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/library/busybox@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662",
+                            "harbor.openova.io/proxy-dockerhub/library/busybox:1.36"
+                        ],
+                        "sizeBytes": 2217006
+                    },
+                    {
+                        "names": [
+                            "docker.io/rancher/mirrored-library-busybox@sha256:8a45424ddf949bbe9bb3231b05f9032a45da5cd036eb4867b511b00734756d6f",
+                            "docker.io/rancher/mirrored-library-busybox:1.36.1"
+                        ],
+                        "sizeBytes": 2147340
+                    },
+                    {
+                        "names": [
+                            "docker.io/rancher/mirrored-pause@sha256:74c4244427b7312c5b901fe0f67cbc53683d06f4f24c6faee65d4182bf0fa893",
+                            "docker.io/rancher/mirrored-pause:3.6"
+                        ],
+                        "sizeBytes": 301463
+                    }
+                ],
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "8047410f-e375-4d62-8502-125e50053d1a",
+                    "containerRuntimeVersion": "containerd://1.7.23-k3s2",
+                    "kernelVersion": "5.15.0-76-generic",
+                    "kubeProxyVersion": "v1.31.4+k3s1",
+                    "kubeletVersion": "v1.31.4+k3s1",
+                    "machineID": "41895bd1876a403788902e232a28f6c9",
+                    "operatingSystem": "linux",
+                    "osImage": "Ubuntu 22.04.2 LTS",
+                    "systemUUID": "9f72ef07-efbc-4c7b-af48-f1ead642154d"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "alpha.kubernetes.io/provided-node-ip": "10.179.1.32",
+                    "k3s.io/hostname": "catalyst-hw173-omani-works-7bb723da-me-east-215-b-w4b871f",
+                    "k3s.io/internal-ip": "10.179.1.32",
+                    "k3s.io/node-args": "[\"agent\",\"--node-label\",\"catalyst.openova.io/provider=huawei\",\"--node-label\",\"openova.io/region=hw-me-east-215-b-rtz-prod\",\"--node-label\",\"topology.kubernetes.io/region=me-east-215-b\",\"--node-label\",\"topology.kubernetes.io/zone=me-east-215-b\"]",
+                    "k3s.io/node-config-hash": "ZAZ32NBDFHNHP7KSGYPV2T64JKCNXS5UYCTPHLTVNJNJTCWZ3AUQ====",
+                    "k3s.io/node-env": "{\"K3S_TOKEN\":\"********\",\"K3S_URL\":\"https://10.179.1.131:6443\"}",
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2026-06-20T03:00:45Z",
+                "finalizers": [
+                    "wrangler.cattle.io/node",
+                    "wrangler.cattle.io/managed-etcd-controller"
+                ],
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "k3s",
+                    "beta.kubernetes.io/os": "linux",
+                    "catalyst.openova.io/provider": "huawei",
+                    "failure-domain.beta.kubernetes.io/region": "me-east-215-b",
+                    "failure-domain.beta.kubernetes.io/zone": "me-east-215-b",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "catalyst-hw173-omani-works-7bb723da-me-east-215-b-w4b871f",
+                    "kubernetes.io/os": "linux",
+                    "node.kubernetes.io/instance-type": "k3s",
+                    "openova.io/region": "hw-me-east-215-b-rtz-prod",
+                    "topology.kubernetes.io/region": "me-east-215-b",
+                    "topology.kubernetes.io/zone": "me-east-215-b"
+                },
+                "name": "catalyst-hw173-omani-works-7bb723da-me-east-215-b-w4b871f",
+                "resourceVersion": "717106",
+                "uid": "9eb7d3aa-d8a2-42b9-9b38-acd9e9784e79"
+            },
+            "spec": {
+                "podCIDR": "10.43.2.0/24",
+                "podCIDRs": [
+                    "10.43.2.0/24"
+                ],
+                "providerID": "k3s://catalyst-hw173-omani-works-7bb723da-me-east-215-b-w4b871f"
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "10.179.1.32",
+                        "type": "InternalIP"
+                    },
+                    {
+                        "address": "catalyst-hw173-omani-works-7bb723da-me-east-215-b-w4b871f",
+                        "type": "Hostname"
+                    }
+                ],
+                "allocatable": {
+                    "cpu": "4",
+                    "ephemeral-storage": "39857063496",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "32666744Ki",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "cpu": "4",
+                    "ephemeral-storage": "40971488Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "32666744Ki",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2026-06-20T03:06:44Z",
+                        "lastTransitionTime": "2026-06-20T03:06:44Z",
+                        "message": "Cilium is running on this node",
+                        "reason": "CiliumIsUp",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:09:31Z",
+                        "lastTransitionTime": "2026-06-20T03:00:46Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:09:31Z",
+                        "lastTransitionTime": "2026-06-20T03:00:46Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:09:31Z",
+                        "lastTransitionTime": "2026-06-20T03:00:46Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:09:31Z",
+                        "lastTransitionTime": "2026-06-20T03:06:44Z",
+                        "message": "kubelet is posting ready status",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10250
+                    }
+                },
+                "images": [
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/alpine/k8s@sha256:bd01dae02676ce4cab62fc744e43443eee5bf660054e94d3496d23bfc35d384e",
+                            "harbor.openova.io/proxy-dockerhub/alpine/k8s:1.30.0"
+                        ],
+                        "sizeBytes": 292136583
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql@sha256:027303cd89644acdeba67d2b37f70eff6a7f345220f127721ff92504e1e4eae6",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16"
+                        ],
+                        "sizeBytes": 258220911
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/cilium@sha256:758ca0793f5995bb938a2fa219dcce63dc0b3fa7fc4ce5cc851125281fb7361d"
+                        ],
+                        "sizeBytes": 224306600
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql@sha256:cd2f88c75f4465ed14ff2006147e06405cca646c00f252a2dfb73910728d289f",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16.4-1"
+                        ],
+                        "sizeBytes": 211733506
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/grafana/alloy@sha256:6e00cf7c5a692ff5f24844529416ed017d76fce922f8199004e73d5eca46b6b8",
+                            "harbor.openova.io/proxy-dockerhub/grafana/alloy:v1.16.0"
+                        ],
+                        "sizeBytes": 151457664
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/guacd@sha256:38232cae271361ef53db46faf5c49fe64049a1320a05b82c597425b69d6ce77e",
+                            "ghcr.io/openova-io/openova/guacd:1.5.5"
+                        ],
+                        "sizeBytes": 129509469
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl@sha256:64614ef8290f3fb27fed5164b338debeeb79a1e5e26c93eb920770b71abd7c48",
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.31.4"
+                        ],
+                        "sizeBytes": 111911970
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl@sha256:1249fc292e84a38575ee0cadc3e28dcd7ddf5a3a4e5da401b1a8599e8ac52a1b",
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7"
+                        ],
+                        "sizeBytes": 110946736
+                    },
+                    {
+                        "names": [
+                            "docker.io/chrislusf/seaweedfs@sha256:84429e5f21fad82246f5cfae7b39e9a17da18afb62f2b79c25ccd364ab02793b",
+                            "docker.io/chrislusf/seaweedfs:4.22"
+                        ],
+                        "sizeBytes": 100503219
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/goharbor/harbor-registryctl@sha256:ddf6bb429eb6b5a3db3e98bfe6ab3dd2567ebb35547836d87fc54ddacebfac8d",
+                            "harbor.openova.io/proxy-dockerhub/goharbor/harbor-registryctl:v2.14.3"
+                        ],
+                        "sizeBytes": 69351406
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/external-secrets/external-secrets@sha256:937c550ff84dded588324be89df42b2fa7d2cb2981271343c956b5348ae64011",
+                            "harbor.openova.io/proxy-ghcr/external-secrets/external-secrets:v0.10.7"
+                        ],
+                        "sizeBytes": 66393246
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-quay/openbao/openbao@sha256:7de07aa6df3937d44c96c2d65c188b2d4a70546f2a764ad4510301305af6a223",
+                            "harbor.openova.io/proxy-quay/openbao/openbao:2.1.0"
+                        ],
+                        "sizeBytes": 62890555
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/cilium-envoy@sha256:709c08ade3d17d52da4ca2af33f431360ec26268d288d9a6cd1d98acc9a1dced"
+                        ],
+                        "sizeBytes": 62862122
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/loft-sh/vcluster@sha256:521b2fc8c8d0c2f1254d7fb956fbf274d3328f1e555270b57a886f9ae10d2109",
+                            "harbor.openova.io/proxy-ghcr/loft-sh/vcluster:0.23.0"
+                        ],
+                        "sizeBytes": 60761070
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/newapi-mirror@sha256:e596cb4aa2c234d88c3e05f41d430f405e6ccfdfa7acc8972c97793e9add4c36",
+                            "ghcr.io/openova-io/openova/newapi-mirror:v0.13.2"
+                        ],
+                        "sizeBytes": 58999657
+                    },
+                    {
+                        "names": [
+                            "mirror.gcr.io/aquasec/trivy@sha256:be1190afcb28352bfddc4ddeb71470835d16462af68d310f9f4bca710961a41e",
+                            "mirror.gcr.io/aquasec/trivy:0.70.0"
+                        ],
+                        "sizeBytes": 58469315
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/fluxcd/kustomize-controller@sha256:e3b0cf847e9cdf47b19af0fbcfe22786b80b598e0caeea8b6d2a5f9c26a48a24",
+                            "harbor.openova.io/proxy-ghcr/fluxcd/kustomize-controller:v1.4.0"
+                        ],
+                        "sizeBytes": 54969920
+                    },
+                    {
+                        "names": [
+                            "docker.io/falcosecurity/falco@sha256:b4166a61f41e2fa638c041cac881d8bb32c284e3aaf282fdfed80f15f6eb55e3",
+                            "docker.io/falcosecurity/falco:0.43.1"
+                        ],
+                        "sizeBytes": 50563340
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/kyverno/cleanup-controller@sha256:a2a060b731f1ea54de2295b886c600d65af032fec18096a816424acfe8dec7d2",
+                            "harbor.openova.io/proxy-ghcr/kyverno/cleanup-controller:v1.18.0"
+                        ],
+                        "sizeBytes": 42285963
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/cloudnative-pg@sha256:68074486205a33ed41928761e22ad48278c690feebe8316727a1c6b3380f9e5e",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/cloudnative-pg:1.29.0"
+                        ],
+                        "sizeBytes": 36402270
+                    },
+                    {
+                        "names": [
+                            "docker.io/grafana/mimir@sha256:686138d9f941508c99c931cc9e69bf9f6100dd4d2d623bf57b38d5c25ee645c1",
+                            "docker.io/grafana/mimir:3.0.4"
+                        ],
+                        "sizeBytes": 33769654
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/goharbor/registry-photon@sha256:6533fc396cbce57131053faec55e1bd1da8b92aed318410c203ff1c7a9b910ab",
+                            "harbor.openova.io/proxy-dockerhub/goharbor/registry-photon:v2.14.3"
+                        ],
+                        "sizeBytes": 33528071
+                    },
+                    {
+                        "names": [
+                            "docker.io/falcosecurity/falcoctl@sha256:0d3bddce03a26365b86e6ff1aa5c51965d2e16569e8cf8b3e37a3d3ef186dc9b",
+                            "docker.io/falcosecurity/falcoctl:0.12.2"
+                        ],
+                        "sizeBytes": 33185258
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/fluxcd/source-controller@sha256:3c5f0f022f990ffc0daf00e5b199548fc0fa6e7119e972318f0267081a332963",
+                            "harbor.openova.io/proxy-ghcr/fluxcd/source-controller:v1.4.1"
+                        ],
+                        "sizeBytes": 32386205
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/operator-generic@sha256:f7884848483bbcd7b1e0ccfd34ba4546f258b460cb4b7e2f06a1bcc96ef88039"
+                        ],
+                        "sizeBytes": 31216191
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-k8s/kube-apiserver@sha256:ace6a943b058439bd6daeb74f152e7c36e6fc0b5e481cdff9364cd6ca0473e5e",
+                            "harbor.openova.io/proxy-k8s/kube-apiserver:v1.31.4"
+                        ],
+                        "sizeBytes": 27972283
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-k8s/kube-controller-manager@sha256:4bd1d4a449e7a1a4f375bd7c71abf48a95f8949b38f725ded255077329f21f7b",
+                            "harbor.openova.io/proxy-k8s/kube-controller-manager:v1.31.4"
+                        ],
+                        "sizeBytes": 26147269
+                    },
+                    {
+                        "names": [
+                            "quay.io/brancz/kube-rbac-proxy@sha256:2c7b120590cbe9f634f5099f2cbb91d0b668569023a81505ca124a5c437e7663",
+                            "quay.io/brancz/kube-rbac-proxy:v0.15.0"
+                        ],
+                        "sizeBytes": 25017413
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator@sha256:ac26ee0a25a3513f0743c45b214c57a789fd64570b72c78d844686eda81e2b3e",
+                            "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.101.0"
+                        ],
+                        "sizeBytes": 24090204
+                    },
+                    {
+                        "names": [
+                            "docker.io/rancher/mirrored-coredns-coredns@sha256:82979ddf442c593027a57239ad90616deb874e90c365d1a96ad508c2104bdea5",
+                            "docker.io/rancher/mirrored-coredns-coredns:1.12.0"
+                        ],
+                        "sizeBytes": 20938299
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/aquasecurity/node-collector@sha256:f4702ce4667388f0219d6248d623a7e816231c2d4561d6af01c3ae053e524025",
+                            "ghcr.io/aquasecurity/node-collector:0.3.1"
+                        ],
+                        "sizeBytes": 20174022
+                    },
+                    {
+                        "names": [
+                            "docker.io/rancher/mirrored-metrics-server@sha256:dccf8474fb910fef261d31d9483d7e4c1df7b86cf4d638fb6a7d7c88bd51600a",
+                            "docker.io/rancher/mirrored-metrics-server:v0.7.2"
+                        ],
+                        "sizeBytes": 19494186
+                    },
+                    {
+                        "names": [
+                            "docker.io/rancher/local-path-provisioner@sha256:9b914881170048f80ae9302f36e5b99b4a6b18af73a38adc1c66d12f65d360be",
+                            "docker.io/rancher/local-path-provisioner:v0.0.30"
+                        ],
+                        "sizeBytes": 18584855
+                    },
+                    {
+                        "names": [
+                            "docker.io/coredns/coredns@sha256:9caabbf6238b189a65d0d6e6ac138de60d6a1c419e5a341fbbb7c78382559c6e",
+                            "docker.io/coredns/coredns:1.11.3"
+                        ],
+                        "sizeBytes": 18562039
+                    },
+                    {
+                        "names": [
+                            "quay.io/jetstack/cert-manager-webhook@sha256:2b10bf39d0e1e056f2bd0743c7e743f28285085e76cf860ddd1dc23abe3a74ad",
+                            "quay.io/jetstack/cert-manager-webhook:v1.16.5"
+                        ],
+                        "sizeBytes": 18212681
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-quay/oauth2-proxy/oauth2-proxy@sha256:dcb6ff8dd21bf3058f6a22c6fa385fa5b897a9cd3914c88a2cc2bb0a85f8065d",
+                            "harbor.openova.io/proxy-quay/oauth2-proxy/oauth2-proxy:v7.6.0"
+                        ],
+                        "sizeBytes": 16521978
+                    },
+                    {
+                        "names": [
+                            "quay.io/jetstack/cert-manager-cainjector@sha256:b3b12f6a140f55697130c4c23453eb24200205e1341095c0f3e9e9d471e5fba6",
+                            "quay.io/jetstack/cert-manager-cainjector:v1.16.5"
+                        ],
+                        "sizeBytes": 15446237
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-quay/prometheus-operator/prometheus-config-reloader@sha256:959d47672fbff2776a04ec62b8afcec89e8c036af84dc5fade50019dab212746",
+                            "harbor.openova.io/proxy-quay/prometheus-operator/prometheus-config-reloader:v0.81.0"
+                        ],
+                        "sizeBytes": 14433657
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/k8s-ws-proxy@sha256:0e3c679c9f78b302575cf9d6e2ae0e5d82d861e4d6de19876df0ca496677825b",
+                            "ghcr.io/openova-io/openova/k8s-ws-proxy:b32eb9b"
+                        ],
+                        "sizeBytes": 11403264
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/openova-flow-adapter-flux@sha256:ffc60bb400d3b8e8e7d19ced0b8714d038ee6c9b9012cc9019e2341d57c1989f",
+                            "ghcr.io/openova-io/openova/openova-flow-adapter-flux:b32eb9b"
+                        ],
+                        "sizeBytes": 10917169
+                    },
+                    {
+                        "names": [
+                            "docker.io/library/nats@sha256:c82559e4476289481a8a5196e675ebfe67eea81d95e5161e3e78eccfe766608e",
+                            "docker.io/library/nats:2.10.16-alpine"
+                        ],
+                        "sizeBytes": 9725619
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/curlimages/curl@sha256:d9b4541e214bcd85196d6e92e2753ac6d0ea699f0af5741f8c6cccbfcf00ef4b",
+                            "harbor.openova.io/proxy-dockerhub/curlimages/curl:8.10.1"
+                        ],
+                        "sizeBytes": 9414401
+                    },
+                    {
+                        "names": [
+                            "docker.io/natsio/nats-server-config-reloader@sha256:98d592981444fac82f79950b42f439f16918e9788fe5080eb32ac8cc7f357df1",
+                            "docker.io/natsio/nats-server-config-reloader:0.14.3"
+                        ],
+                        "sizeBytes": 4628347
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/newapi-sandbox-bridge@sha256:170363bf9b313db7844a566df72aa07ab483d31c1eb2af59694da65169483c02",
+                            "ghcr.io/openova-io/openova/newapi-sandbox-bridge:5d818d4"
+                        ],
+                        "sizeBytes": 4477093
+                    },
+                    {
+                        "names": [
+                            "docker.io/library/alpine@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc",
+                            "docker.io/library/alpine:3.20"
+                        ],
+                        "sizeBytes": 3641182
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/services-metering-sidecar@sha256:259420d49d42b44d8ce36ab062e1fb88d033571c98362008951f195636b086ff",
+                            "ghcr.io/openova-io/openova/services-metering-sidecar:41e02c8"
+                        ],
+                        "sizeBytes": 3548511
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/library/busybox@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662",
+                            "harbor.openova.io/proxy-dockerhub/library/busybox:1.36"
+                        ],
+                        "sizeBytes": 2217006
+                    },
+                    {
+                        "names": [
+                            "docker.io/rancher/mirrored-library-busybox@sha256:8a45424ddf949bbe9bb3231b05f9032a45da5cd036eb4867b511b00734756d6f",
+                            "docker.io/rancher/mirrored-library-busybox:1.36.1"
+                        ],
+                        "sizeBytes": 2147340
+                    },
+                    {
+                        "names": [
+                            "docker.io/rancher/mirrored-pause@sha256:74c4244427b7312c5b901fe0f67cbc53683d06f4f24c6faee65d4182bf0fa893",
+                            "docker.io/rancher/mirrored-pause:3.6"
+                        ],
+                        "sizeBytes": 301463
+                    }
+                ],
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "689fdac8-3517-42fe-9519-62fd08496bf2",
+                    "containerRuntimeVersion": "containerd://1.7.23-k3s2",
+                    "kernelVersion": "5.15.0-76-generic",
+                    "kubeProxyVersion": "v1.31.4+k3s1",
+                    "kubeletVersion": "v1.31.4+k3s1",
+                    "machineID": "41895bd1876a403788902e232a28f6c9",
+                    "operatingSystem": "linux",
+                    "osImage": "Ubuntu 22.04.2 LTS",
+                    "systemUUID": "2e03ae22-e40b-42de-b1a0-b36ef4871a74"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "alpha.kubernetes.io/provided-node-ip": "10.179.1.152",
+                    "k3s.io/hostname": "catalyst-hw173-omani-works-7bb723da-me-east-215-b-w71c873",
+                    "k3s.io/internal-ip": "10.179.1.152",
+                    "k3s.io/node-args": "[\"agent\",\"--node-label\",\"catalyst.openova.io/provider=huawei\",\"--node-label\",\"openova.io/region=hw-me-east-215-b-rtz-prod\",\"--node-label\",\"topology.kubernetes.io/region=me-east-215-b\",\"--node-label\",\"topology.kubernetes.io/zone=me-east-215-b\"]",
+                    "k3s.io/node-config-hash": "ZAZ32NBDFHNHP7KSGYPV2T64JKCNXS5UYCTPHLTVNJNJTCWZ3AUQ====",
+                    "k3s.io/node-env": "{\"K3S_TOKEN\":\"********\",\"K3S_URL\":\"https://10.179.1.131:6443\"}",
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2026-06-20T03:01:49Z",
+                "finalizers": [
+                    "wrangler.cattle.io/node",
+                    "wrangler.cattle.io/managed-etcd-controller"
+                ],
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "k3s",
+                    "beta.kubernetes.io/os": "linux",
+                    "catalyst.openova.io/provider": "huawei",
+                    "failure-domain.beta.kubernetes.io/region": "me-east-215-b",
+                    "failure-domain.beta.kubernetes.io/zone": "me-east-215-b",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "catalyst-hw173-omani-works-7bb723da-me-east-215-b-w71c873",
+                    "kubernetes.io/os": "linux",
+                    "node.kubernetes.io/instance-type": "k3s",
+                    "openova.io/region": "hw-me-east-215-b-rtz-prod",
+                    "topology.kubernetes.io/region": "me-east-215-b",
+                    "topology.kubernetes.io/zone": "me-east-215-b"
+                },
+                "name": "catalyst-hw173-omani-works-7bb723da-me-east-215-b-w71c873",
+                "resourceVersion": "718452",
+                "uid": "40393367-783c-4533-b8d6-6b5549555ea7"
+            },
+            "spec": {
+                "podCIDR": "10.43.3.0/24",
+                "podCIDRs": [
+                    "10.43.3.0/24"
+                ],
+                "providerID": "k3s://catalyst-hw173-omani-works-7bb723da-me-east-215-b-w71c873"
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "10.179.1.152",
+                        "type": "InternalIP"
+                    },
+                    {
+                        "address": "catalyst-hw173-omani-works-7bb723da-me-east-215-b-w71c873",
+                        "type": "Hostname"
+                    }
+                ],
+                "allocatable": {
+                    "cpu": "4",
+                    "ephemeral-storage": "39857063496",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "32666744Ki",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "cpu": "4",
+                    "ephemeral-storage": "40971488Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "32666744Ki",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2026-06-20T03:07:17Z",
+                        "lastTransitionTime": "2026-06-20T03:07:17Z",
+                        "message": "Cilium is running on this node",
+                        "reason": "CiliumIsUp",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:10:56Z",
+                        "lastTransitionTime": "2026-06-20T03:01:48Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:10:56Z",
+                        "lastTransitionTime": "2026-06-20T03:01:48Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:10:56Z",
+                        "lastTransitionTime": "2026-06-20T03:01:48Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:10:56Z",
+                        "lastTransitionTime": "2026-06-20T03:07:14Z",
+                        "message": "kubelet is posting ready status",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10250
+                    }
+                },
+                "images": [
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql@sha256:027303cd89644acdeba67d2b37f70eff6a7f345220f127721ff92504e1e4eae6",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16"
+                        ],
+                        "sizeBytes": 258220911
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/cilium@sha256:758ca0793f5995bb938a2fa219dcce63dc0b3fa7fc4ce5cc851125281fb7361d"
+                        ],
+                        "sizeBytes": 224306600
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql@sha256:99be063781d171d3971089b49c992706bdab9ccbd2b57cdf126c7542773aedfe",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16.4"
+                        ],
+                        "sizeBytes": 217672880
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/keycloak-config-cli@sha256:31d496f6b77dce3ef315be74b05e61ed62ac427ea373bfecb6e3b5b4755071d4",
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/keycloak-config-cli:6.4.0-debian-12-r11"
+                        ],
+                        "sizeBytes": 212166537
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/grafana/alloy@sha256:6e00cf7c5a692ff5f24844529416ed017d76fce922f8199004e73d5eca46b6b8",
+                            "harbor.openova.io/proxy-dockerhub/grafana/alloy:v1.16.0"
+                        ],
+                        "sizeBytes": 151457664
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl@sha256:64614ef8290f3fb27fed5164b338debeeb79a1e5e26c93eb920770b71abd7c48",
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.31.4"
+                        ],
+                        "sizeBytes": 111911970
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/postgresql@sha256:de520acd66fc954d538faa997771ca791f9fcba8b837419a8bc4d08a08df3762",
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/postgresql:17.6.0-debian-12-r0"
+                        ],
+                        "sizeBytes": 111456870
+                    },
+                    {
+                        "names": [
+                            "docker.io/bitnamilegacy/kubectl@sha256:1249fc292e84a38575ee0cadc3e28dcd7ddf5a3a4e5da401b1a8599e8ac52a1b",
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl@sha256:1249fc292e84a38575ee0cadc3e28dcd7ddf5a3a4e5da401b1a8599e8ac52a1b",
+                            "docker.io/bitnamilegacy/kubectl:1.30.7",
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7"
+                        ],
+                        "sizeBytes": 110946736
+                    },
+                    {
+                        "names": [
+                            "docker.io/powerdns/pdns-auth-50@sha256:1f136c4fa4f995279b43c6a8413dde05147cc9b74a437e188f92b0088c523a8d",
+                            "docker.io/powerdns/pdns-auth-50:5.0.3"
+                        ],
+                        "sizeBytes": 102061459
+                    },
+                    {
+                        "names": [
+                            "docker.io/velero/velero@sha256:e4d1e79be2ee1d51056734ada5e51c78a29b924e4d055cd28e0b4103ae2268ad",
+                            "docker.io/velero/velero:v1.18.0"
+                        ],
+                        "sizeBytes": 78724238
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/goharbor/harbor-jobservice@sha256:e2b0298e894d725d68954b786c61c5dd607114f6129534756c8f7985124c07a6",
+                            "harbor.openova.io/proxy-dockerhub/goharbor/harbor-jobservice:v2.14.3"
+                        ],
+                        "sizeBytes": 74802491
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/powerdnsadmin/pda-legacy@sha256:0fc92c8ef63a6704083ca1989c83d2b747f7abc0e5045d56d9c69a76e08a9a5e",
+                            "harbor.openova.io/proxy-dockerhub/powerdnsadmin/pda-legacy:0.4.2"
+                        ],
+                        "sizeBytes": 73000672
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/gitea/gitea@sha256:6b068c75b3454016b0304d0bb158b027cae6393fc668ce6a3727d4f4016261ed",
+                            "harbor.openova.io/proxy-dockerhub/gitea/gitea:1.22.3-rootless"
+                        ],
+                        "sizeBytes": 67735375
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/cilium-envoy@sha256:709c08ade3d17d52da4ca2af33f431360ec26268d288d9a6cd1d98acc9a1dced"
+                        ],
+                        "sizeBytes": 62862122
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/sigstore/policy-controller/policy-controller@sha256:0bcd60beb93f4427c29cf3a669743caf58490e98ded4380c33c09f092734a6ab"
+                        ],
+                        "sizeBytes": 61402611
+                    },
+                    {
+                        "names": [
+                            "mirror.gcr.io/aquasec/trivy@sha256:be1190afcb28352bfddc4ddeb71470835d16462af68d310f9f4bca710961a41e",
+                            "mirror.gcr.io/aquasec/trivy:0.70.0"
+                        ],
+                        "sizeBytes": 58469315
+                    },
+                    {
+                        "names": [
+                            "docker.io/falcosecurity/falco@sha256:b4166a61f41e2fa638c041cac881d8bb32c284e3aaf282fdfed80f15f6eb55e3",
+                            "docker.io/falcosecurity/falco:0.43.1"
+                        ],
+                        "sizeBytes": 50563340
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/kyverno/background-controller@sha256:fd6d30964297f1c94c2d741a1c44d055994cd4354e6f7e718cad59e6b5aa6c66",
+                            "harbor.openova.io/proxy-ghcr/kyverno/background-controller:v1.18.0"
+                        ],
+                        "sizeBytes": 45603201
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/fluxcd/helm-controller@sha256:4c75ca6c24ceb1f1bd7e935d9287a93e4f925c512f206763ec5a47de3ef3ff48",
+                            "ghcr.io/fluxcd/helm-controller:v1.1.0"
+                        ],
+                        "sizeBytes": 40818921
+                    },
+                    {
+                        "names": [
+                            "docker.io/velero/velero-plugin-for-aws@sha256:7e82f717f44e89671212e0dfce7e061321c386ea84a33bca64a671670ca6c278",
+                            "docker.io/velero/velero-plugin-for-aws:v1.14.0"
+                        ],
+                        "sizeBytes": 39572667
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/fluxcd/image-reflector-controller@sha256:c6864684f96cfbb3a91c816084032bb019b302af8b63b0e06b12b4018a9a8242",
+                            "harbor.openova.io/proxy-ghcr/fluxcd/image-reflector-controller:v0.33.0"
+                        ],
+                        "sizeBytes": 38586158
+                    },
+                    {
+                        "names": [
+                            "docker.io/natsio/nats-box@sha256:1cc4201866645d6501ed370d2300852711468886565b0e1a3dc69e9739909a0e",
+                            "docker.io/natsio/nats-box:0.14.3"
+                        ],
+                        "sizeBytes": 38475647
+                    },
+                    {
+                        "names": [
+                            "docker.io/grafana/tempo@sha256:65a5789759435f1ef696f1953258b9bbdb18eb571d5ce711ff812d2e128288a4",
+                            "docker.io/grafana/tempo:2.9.0"
+                        ],
+                        "sizeBytes": 36423494
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/cloudnative-pg@sha256:68074486205a33ed41928761e22ad48278c690feebe8316727a1c6b3380f9e5e",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/cloudnative-pg:1.29.0"
+                        ],
+                        "sizeBytes": 36402270
+                    },
+                    {
+                        "names": [
+                            "docker.io/grafana/rollout-operator@sha256:cdb420c0af2cc5b32a33267cdd4aac8cd7867d539975a75dc856b0cfebbadff4",
+                            "docker.io/grafana/rollout-operator:v0.32.0"
+                        ],
+                        "sizeBytes": 34785847
+                    },
+                    {
+                        "names": [
+                            "docker.io/grafana/mimir@sha256:686138d9f941508c99c931cc9e69bf9f6100dd4d2d623bf57b38d5c25ee645c1",
+                            "docker.io/grafana/mimir:3.0.4"
+                        ],
+                        "sizeBytes": 33769654
+                    },
+                    {
+                        "names": [
+                            "docker.io/falcosecurity/falcoctl@sha256:0d3bddce03a26365b86e6ff1aa5c51965d2e16569e8cf8b3e37a3d3ef186dc9b",
+                            "docker.io/falcosecurity/falcoctl:0.12.2"
+                        ],
+                        "sizeBytes": 33185258
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/hubble-relay@sha256:6cfae1d1afa566ba941f03d4d7e141feddd05260e5cd0a1509aba1890a45ef00"
+                        ],
+                        "sizeBytes": 28577506
+                    },
+                    {
+                        "names": [
+                            "docker.io/zachomedia/cert-manager-webhook-pdns@sha256:4940e227a39ba04fcbdc99d55918946183f08722480953537b28c33304f96d82",
+                            "docker.io/zachomedia/cert-manager-webhook-pdns:v2.5.5"
+                        ],
+                        "sizeBytes": 28019091
+                    },
+                    {
+                        "names": [
+                            "xpkg.upbound.io/crossplane/crossplane@sha256:c98f027ffade306fc9a5132aec74a1430357f1028c0da024b95c25a19b3148fc",
+                            "xpkg.upbound.io/crossplane/crossplane:v1.18.0"
+                        ],
+                        "sizeBytes": 20944049
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/aquasecurity/node-collector@sha256:f4702ce4667388f0219d6248d623a7e816231c2d4561d6af01c3ae053e524025",
+                            "ghcr.io/aquasecurity/node-collector:0.3.1"
+                        ],
+                        "sizeBytes": 20174022
+                    },
+                    {
+                        "names": [
+                            "quay.io/oauth2-proxy/oauth2-proxy@sha256:dcb6ff8dd21bf3058f6a22c6fa385fa5b897a9cd3914c88a2cc2bb0a85f8065d",
+                            "quay.io/oauth2-proxy/oauth2-proxy:v7.6.0"
+                        ],
+                        "sizeBytes": 16521978
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/stakater/reloader@sha256:4e0db5b629ad5b50ccadae6f31f5916adab300dc3801482503f4984da4727e30",
+                            "ghcr.io/stakater/reloader:v1.4.16"
+                        ],
+                        "sizeBytes": 15679304
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-quay/prometheus-operator/prometheus-config-reloader@sha256:959d47672fbff2776a04ec62b8afcec89e8c036af84dc5fade50019dab212746",
+                            "harbor.openova.io/proxy-quay/prometheus-operator/prometheus-config-reloader:v0.81.0"
+                        ],
+                        "sizeBytes": 14433657
+                    },
+                    {
+                        "names": [
+                            "registry.k8s.io/autoscaling/vpa-recommender@sha256:0e26495e23c72aad6840fea22cb49865de703348c4e2bd56d173d718e849233a",
+                            "registry.k8s.io/autoscaling/vpa-recommender:1.5.0"
+                        ],
+                        "sizeBytes": 11411407
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/k8s-ws-proxy@sha256:0e3c679c9f78b302575cf9d6e2ae0e5d82d861e4d6de19876df0ca496677825b",
+                            "ghcr.io/openova-io/openova/k8s-ws-proxy:b32eb9b"
+                        ],
+                        "sizeBytes": 11403264
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/openova-flow-adapter-flux@sha256:ffc60bb400d3b8e8e7d19ced0b8714d038ee6c9b9012cc9019e2341d57c1989f",
+                            "ghcr.io/openova-io/openova/openova-flow-adapter-flux:b32eb9b"
+                        ],
+                        "sizeBytes": 10917169
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/curlimages/curl@sha256:d9b4541e214bcd85196d6e92e2753ac6d0ea699f0af5741f8c6cccbfcf00ef4b",
+                            "harbor.openova.io/proxy-dockerhub/curlimages/curl:8.10.1"
+                        ],
+                        "sizeBytes": 9414401
+                    },
+                    {
+                        "names": [
+                            "docker.io/library/alpine@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc",
+                            "docker.io/library/alpine:3.20"
+                        ],
+                        "sizeBytes": 3641182
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/library/busybox@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662",
+                            "harbor.openova.io/proxy-dockerhub/library/busybox:1.36"
+                        ],
+                        "sizeBytes": 2217006
+                    },
+                    {
+                        "names": [
+                            "docker.io/rancher/mirrored-library-busybox@sha256:8a45424ddf949bbe9bb3231b05f9032a45da5cd036eb4867b511b00734756d6f",
+                            "docker.io/rancher/mirrored-library-busybox:1.36.1"
+                        ],
+                        "sizeBytes": 2147340
+                    },
+                    {
+                        "names": [
+                            "docker.io/rancher/mirrored-pause@sha256:74c4244427b7312c5b901fe0f67cbc53683d06f4f24c6faee65d4182bf0fa893",
+                            "docker.io/rancher/mirrored-pause:3.6"
+                        ],
+                        "sizeBytes": 301463
+                    }
+                ],
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "05e0258d-a265-4595-94f7-e1258bd35119",
+                    "containerRuntimeVersion": "containerd://1.7.23-k3s2",
+                    "kernelVersion": "5.15.0-76-generic",
+                    "kubeProxyVersion": "v1.31.4+k3s1",
+                    "kubeletVersion": "v1.31.4+k3s1",
+                    "machineID": "41895bd1876a403788902e232a28f6c9",
+                    "operatingSystem": "linux",
+                    "osImage": "Ubuntu 22.04.2 LTS",
+                    "systemUUID": "1404cc2e-0316-4ba9-b605-71f89b0c466f"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "alpha.kubernetes.io/provided-node-ip": "10.179.1.155",
+                    "k3s.io/hostname": "catalyst-hw173-omani-works-7bb723da-me-east-215-b-w8a0eb8",
+                    "k3s.io/internal-ip": "10.179.1.155",
+                    "k3s.io/node-args": "[\"agent\",\"--node-label\",\"catalyst.openova.io/provider=huawei\",\"--node-label\",\"openova.io/region=hw-me-east-215-b-rtz-prod\",\"--node-label\",\"topology.kubernetes.io/region=me-east-215-b\",\"--node-label\",\"topology.kubernetes.io/zone=me-east-215-b\"]",
+                    "k3s.io/node-config-hash": "ZAZ32NBDFHNHP7KSGYPV2T64JKCNXS5UYCTPHLTVNJNJTCWZ3AUQ====",
+                    "k3s.io/node-env": "{\"K3S_TOKEN\":\"********\",\"K3S_URL\":\"https://10.179.1.131:6443\"}",
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2026-06-20T03:07:20Z",
+                "finalizers": [
+                    "wrangler.cattle.io/node",
+                    "wrangler.cattle.io/managed-etcd-controller"
+                ],
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "k3s",
+                    "beta.kubernetes.io/os": "linux",
+                    "catalyst.openova.io/provider": "huawei",
+                    "failure-domain.beta.kubernetes.io/region": "me-east-215-b",
+                    "failure-domain.beta.kubernetes.io/zone": "me-east-215-b",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "catalyst-hw173-omani-works-7bb723da-me-east-215-b-w8a0eb8",
+                    "kubernetes.io/os": "linux",
+                    "node.kubernetes.io/instance-type": "k3s",
+                    "openova.io/region": "hw-me-east-215-b-rtz-prod",
+                    "topology.kubernetes.io/region": "me-east-215-b",
+                    "topology.kubernetes.io/zone": "me-east-215-b"
+                },
+                "name": "catalyst-hw173-omani-works-7bb723da-me-east-215-b-w8a0eb8",
+                "resourceVersion": "717715",
+                "uid": "42fc65de-922c-4c68-9e74-08a8b5b0f9c9"
+            },
+            "spec": {
+                "podCIDR": "10.43.5.0/24",
+                "podCIDRs": [
+                    "10.43.5.0/24"
+                ],
+                "providerID": "k3s://catalyst-hw173-omani-works-7bb723da-me-east-215-b-w8a0eb8"
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "10.179.1.155",
+                        "type": "InternalIP"
+                    },
+                    {
+                        "address": "catalyst-hw173-omani-works-7bb723da-me-east-215-b-w8a0eb8",
+                        "type": "Hostname"
+                    }
+                ],
+                "allocatable": {
+                    "cpu": "4",
+                    "ephemeral-storage": "39857063496",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "32666744Ki",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "cpu": "4",
+                    "ephemeral-storage": "40971488Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "32666744Ki",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2026-06-20T03:08:50Z",
+                        "lastTransitionTime": "2026-06-20T03:08:50Z",
+                        "message": "Cilium is running on this node",
+                        "reason": "CiliumIsUp",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:10:05Z",
+                        "lastTransitionTime": "2026-06-20T03:07:20Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:10:05Z",
+                        "lastTransitionTime": "2026-06-20T03:07:20Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:10:05Z",
+                        "lastTransitionTime": "2026-06-20T03:07:20Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:10:05Z",
+                        "lastTransitionTime": "2026-06-20T03:08:46Z",
+                        "message": "kubelet is posting ready status",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10250
+                    }
+                },
+                "images": [
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql@sha256:027303cd89644acdeba67d2b37f70eff6a7f345220f127721ff92504e1e4eae6",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16"
+                        ],
+                        "sizeBytes": 258220911
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/cilium@sha256:758ca0793f5995bb938a2fa219dcce63dc0b3fa7fc4ce5cc851125281fb7361d"
+                        ],
+                        "sizeBytes": 224306600
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/grafana/alloy@sha256:6e00cf7c5a692ff5f24844529416ed017d76fce922f8199004e73d5eca46b6b8",
+                            "harbor.openova.io/proxy-dockerhub/grafana/alloy:v1.16.0"
+                        ],
+                        "sizeBytes": 151457664
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl@sha256:64614ef8290f3fb27fed5164b338debeeb79a1e5e26c93eb920770b71abd7c48",
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.31.4"
+                        ],
+                        "sizeBytes": 111911970
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl@sha256:1249fc292e84a38575ee0cadc3e28dcd7ddf5a3a4e5da401b1a8599e8ac52a1b",
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7"
+                        ],
+                        "sizeBytes": 110946736
+                    },
+                    {
+                        "names": [
+                            "docker.io/bitnamilegacy/kubectl@sha256:f5fc0d561d9ef931f9ecb2e8b65d93eb92767c57f64897c56a100bfe28102c74",
+                            "docker.io/bitnamilegacy/kubectl:1.29.3"
+                        ],
+                        "sizeBytes": 106148689
+                    },
+                    {
+                        "names": [
+                            "docker.io/chrislusf/seaweedfs@sha256:84429e5f21fad82246f5cfae7b39e9a17da18afb62f2b79c25ccd364ab02793b",
+                            "docker.io/chrislusf/seaweedfs:4.22"
+                        ],
+                        "sizeBytes": 100503219
+                    },
+                    {
+                        "names": [
+                            "docker.io/emberstack/kubernetes-reflector@sha256:84a83d1c28e78a3b7614e85b0dad872e88c549e05a7838754c4a340be601a4ae",
+                            "docker.io/emberstack/kubernetes-reflector:7.1.288"
+                        ],
+                        "sizeBytes": 93834221
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-quay/openbao/openbao@sha256:41dc3e47da01575e1ffea70aa635180b57ff999264398313334c259a697bf7a2",
+                            "harbor.openova.io/proxy-quay/openbao/openbao:2.3.1"
+                        ],
+                        "sizeBytes": 77189230
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/powerdnsadmin/pda-legacy@sha256:0fc92c8ef63a6704083ca1989c83d2b747f7abc0e5045d56d9c69a76e08a9a5e",
+                            "harbor.openova.io/proxy-dockerhub/powerdnsadmin/pda-legacy:0.4.2"
+                        ],
+                        "sizeBytes": 73000672
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/external-secrets/external-secrets@sha256:937c550ff84dded588324be89df42b2fa7d2cb2981271343c956b5348ae64011",
+                            "harbor.openova.io/proxy-ghcr/external-secrets/external-secrets:v0.10.7"
+                        ],
+                        "sizeBytes": 66393246
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/goharbor/redis-photon@sha256:f0e08db4909c21535667bd89676ac28c27003ca967830e259e3bd3aeb8e22f9c",
+                            "harbor.openova.io/proxy-dockerhub/goharbor/redis-photon:v2.14.3"
+                        ],
+                        "sizeBytes": 64079006
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/cilium-envoy@sha256:709c08ade3d17d52da4ca2af33f431360ec26268d288d9a6cd1d98acc9a1dced"
+                        ],
+                        "sizeBytes": 62862122
+                    },
+                    {
+                        "names": [
+                            "quay.io/minio/minio@sha256:1dce27c494a16bae114774f1cec295493f3613142713130c2d22dd5696be6ad3",
+                            "quay.io/minio/minio:RELEASE.2024-12-18T13-15-44Z"
+                        ],
+                        "sizeBytes": 62642371
+                    },
+                    {
+                        "names": [
+                            "mirror.gcr.io/aquasec/trivy@sha256:be1190afcb28352bfddc4ddeb71470835d16462af68d310f9f4bca710961a41e",
+                            "mirror.gcr.io/aquasec/trivy:0.70.0"
+                        ],
+                        "sizeBytes": 58469315
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/fluxcd/kustomize-controller@sha256:e3b0cf847e9cdf47b19af0fbcfe22786b80b598e0caeea8b6d2a5f9c26a48a24",
+                            "ghcr.io/fluxcd/kustomize-controller:v1.4.0"
+                        ],
+                        "sizeBytes": 54969920
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/goharbor/nginx-photon@sha256:e31b5290e31938fde76590e4f5d7b8eb3d8038ad1485879bdad7a480538dc858",
+                            "harbor.openova.io/proxy-dockerhub/goharbor/nginx-photon:v2.14.3"
+                        ],
+                        "sizeBytes": 54477190
+                    },
+                    {
+                        "names": [
+                            "docker.io/falcosecurity/falco@sha256:b4166a61f41e2fa638c041cac881d8bb32c284e3aaf282fdfed80f15f6eb55e3",
+                            "docker.io/falcosecurity/falco:0.43.1"
+                        ],
+                        "sizeBytes": 50563340
+                    },
+                    {
+                        "names": [
+                            "mirror.gcr.io/aquasec/trivy-operator@sha256:448484ece65e26f1c7237c8d20dab997f5a8319968286a09e188140b863cf1f9",
+                            "mirror.gcr.io/aquasec/trivy-operator:0.30.1"
+                        ],
+                        "sizeBytes": 49226533
+                    },
+                    {
+                        "names": [
+                            "registry-1.docker.io/bitnami/valkey@sha256:bcb8664d48fc0449050e1524e4041504bb774cc4ecc00bd0cc52daaad12beea4",
+                            "registry-1.docker.io/bitnami/valkey:latest"
+                        ],
+                        "sizeBytes": 49194903
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/kyverno/kyverno@sha256:cb033c200dc85be0a4d38e1a72894038a0c067d73f1ce6aedd569f9769a3d262",
+                            "harbor.openova.io/proxy-ghcr/kyverno/kyverno:v1.18.0"
+                        ],
+                        "sizeBytes": 46511461
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/fluxcd/notification-controller@sha256:425309a159b15e07f7d97622effc79bc432a37ed55289dd465d37fa217a92a7d",
+                            "harbor.openova.io/proxy-ghcr/fluxcd/notification-controller:v1.4.0"
+                        ],
+                        "sizeBytes": 43654595
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/kyverno/kyvernopre@sha256:60b53ebf646f788e6e5d312f9cbf267d7537ec14afec68bde2e1dad55c552cc7",
+                            "harbor.openova.io/proxy-ghcr/kyverno/kyvernopre:v1.18.0"
+                        ],
+                        "sizeBytes": 41450999
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/fluxcd/image-reflector-controller@sha256:c6864684f96cfbb3a91c816084032bb019b302af8b63b0e06b12b4018a9a8242",
+                            "ghcr.io/fluxcd/image-reflector-controller:v0.33.0"
+                        ],
+                        "sizeBytes": 38586158
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/cloudnative-pg@sha256:68074486205a33ed41928761e22ad48278c690feebe8316727a1c6b3380f9e5e",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/cloudnative-pg:1.29.0"
+                        ],
+                        "sizeBytes": 36402270
+                    },
+                    {
+                        "names": [
+                            "docker.io/grafana/mimir@sha256:686138d9f941508c99c931cc9e69bf9f6100dd4d2d623bf57b38d5c25ee645c1",
+                            "docker.io/grafana/mimir:3.0.4"
+                        ],
+                        "sizeBytes": 33769654
+                    },
+                    {
+                        "names": [
+                            "docker.io/falcosecurity/falcoctl@sha256:0d3bddce03a26365b86e6ff1aa5c51965d2e16569e8cf8b3e37a3d3ef186dc9b",
+                            "docker.io/falcosecurity/falcoctl:0.12.2"
+                        ],
+                        "sizeBytes": 33185258
+                    },
+                    {
+                        "names": [
+                            "quay.io/jetstack/cert-manager-controller@sha256:ac105277e06e134a3d474d1535f1dc46f2606ebecf69b458e096d5f428e34fcb",
+                            "quay.io/jetstack/cert-manager-controller:v1.16.5"
+                        ],
+                        "sizeBytes": 21207976
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/library/nginx@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10",
+                            "harbor.openova.io/proxy-dockerhub/library/nginx:1.27-alpine"
+                        ],
+                        "sizeBytes": 20984244
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/aquasecurity/node-collector@sha256:f4702ce4667388f0219d6248d623a7e816231c2d4561d6af01c3ae053e524025",
+                            "ghcr.io/aquasecurity/node-collector:0.3.1"
+                        ],
+                        "sizeBytes": 20174022
+                    },
+                    {
+                        "names": [
+                            "docker.io/coredns/coredns@sha256:9caabbf6238b189a65d0d6e6ac138de60d6a1c419e5a341fbbb7c78382559c6e",
+                            "docker.io/coredns/coredns:1.11.3"
+                        ],
+                        "sizeBytes": 18562039
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-quay/prometheus-operator/prometheus-config-reloader@sha256:959d47672fbff2776a04ec62b8afcec89e8c036af84dc5fade50019dab212746",
+                            "harbor.openova.io/proxy-quay/prometheus-operator/prometheus-config-reloader:v0.81.0"
+                        ],
+                        "sizeBytes": 14433657
+                    },
+                    {
+                        "names": [
+                            "quay.io/jetstack/cert-manager-startupapicheck@sha256:8c122cb4ed0d3e42b528b2b868a10522222ceeef8e91f80f16f1d0e2206aefda",
+                            "quay.io/jetstack/cert-manager-startupapicheck:v1.16.5"
+                        ],
+                        "sizeBytes": 14113488
+                    },
+                    {
+                        "names": [
+                            "docker.io/bitnami/sealed-secrets-controller@sha256:29148c5750290f8a3022541712d0984775a0553a949c48e9285f5862532cc362",
+                            "docker.io/bitnami/sealed-secrets-controller:0.27.1"
+                        ],
+                        "sizeBytes": 12615435
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/k8s-ws-proxy@sha256:0e3c679c9f78b302575cf9d6e2ae0e5d82d861e4d6de19876df0ca496677825b",
+                            "ghcr.io/openova-io/openova/k8s-ws-proxy:b32eb9b"
+                        ],
+                        "sizeBytes": 11403264
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/openova-flow-adapter-flux@sha256:ffc60bb400d3b8e8e7d19ced0b8714d038ee6c9b9012cc9019e2341d57c1989f",
+                            "ghcr.io/openova-io/openova/openova-flow-adapter-flux:b32eb9b"
+                        ],
+                        "sizeBytes": 10917169
+                    },
+                    {
+                        "names": [
+                            "docker.io/library/nats@sha256:c82559e4476289481a8a5196e675ebfe67eea81d95e5161e3e78eccfe766608e",
+                            "docker.io/library/nats:2.10.16-alpine"
+                        ],
+                        "sizeBytes": 9725619
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/curlimages/curl@sha256:d9b4541e214bcd85196d6e92e2753ac6d0ea699f0af5741f8c6cccbfcf00ef4b",
+                            "harbor.openova.io/proxy-dockerhub/curlimages/curl:8.10.1"
+                        ],
+                        "sizeBytes": 9414401
+                    },
+                    {
+                        "names": [
+                            "docker.io/natsio/nats-server-config-reloader@sha256:98d592981444fac82f79950b42f439f16918e9788fe5080eb32ac8cc7f357df1",
+                            "docker.io/natsio/nats-server-config-reloader:0.14.3"
+                        ],
+                        "sizeBytes": 4628347
+                    },
+                    {
+                        "names": [
+                            "docker.io/library/alpine@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc",
+                            "docker.io/library/alpine:3.20"
+                        ],
+                        "sizeBytes": 3641182
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/library/busybox@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662",
+                            "harbor.openova.io/proxy-dockerhub/library/busybox:1.36"
+                        ],
+                        "sizeBytes": 2217006
+                    },
+                    {
+                        "names": [
+                            "docker.io/rancher/mirrored-library-busybox@sha256:8a45424ddf949bbe9bb3231b05f9032a45da5cd036eb4867b511b00734756d6f",
+                            "docker.io/rancher/mirrored-library-busybox:1.36.1"
+                        ],
+                        "sizeBytes": 2147340
+                    },
+                    {
+                        "names": [
+                            "docker.io/rancher/mirrored-pause@sha256:74c4244427b7312c5b901fe0f67cbc53683d06f4f24c6faee65d4182bf0fa893",
+                            "docker.io/rancher/mirrored-pause:3.6"
+                        ],
+                        "sizeBytes": 301463
+                    }
+                ],
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "6a7fc3d4-672b-4f6b-b61a-983f9a497fc1",
+                    "containerRuntimeVersion": "containerd://1.7.23-k3s2",
+                    "kernelVersion": "5.15.0-76-generic",
+                    "kubeProxyVersion": "v1.31.4+k3s1",
+                    "kubeletVersion": "v1.31.4+k3s1",
+                    "machineID": "41895bd1876a403788902e232a28f6c9",
+                    "operatingSystem": "linux",
+                    "osImage": "Ubuntu 22.04.2 LTS",
+                    "systemUUID": "877a81ae-d125-43b0-84e6-bf3946b5f53a"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "alpha.kubernetes.io/provided-node-ip": "10.179.1.91",
+                    "k3s.io/hostname": "catalyst-hw173-omani-works-7bb723da-me-east-215-b-wd65403",
+                    "k3s.io/internal-ip": "10.179.1.91",
+                    "k3s.io/node-args": "[\"agent\",\"--node-label\",\"catalyst.openova.io/provider=huawei\",\"--node-label\",\"openova.io/region=hw-me-east-215-b-rtz-prod\",\"--node-label\",\"topology.kubernetes.io/region=me-east-215-b\",\"--node-label\",\"topology.kubernetes.io/zone=me-east-215-b\"]",
+                    "k3s.io/node-config-hash": "ZAZ32NBDFHNHP7KSGYPV2T64JKCNXS5UYCTPHLTVNJNJTCWZ3AUQ====",
+                    "k3s.io/node-env": "{\"K3S_TOKEN\":\"********\",\"K3S_URL\":\"https://10.179.1.131:6443\"}",
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2026-06-20T03:00:37Z",
+                "finalizers": [
+                    "wrangler.cattle.io/node",
+                    "wrangler.cattle.io/managed-etcd-controller"
+                ],
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "k3s",
+                    "beta.kubernetes.io/os": "linux",
+                    "catalyst.openova.io/provider": "huawei",
+                    "failure-domain.beta.kubernetes.io/region": "me-east-215-b",
+                    "failure-domain.beta.kubernetes.io/zone": "me-east-215-b",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "catalyst-hw173-omani-works-7bb723da-me-east-215-b-wd65403",
+                    "kubernetes.io/os": "linux",
+                    "node.kubernetes.io/instance-type": "k3s",
+                    "openova.io/region": "hw-me-east-215-b-rtz-prod",
+                    "topology.kubernetes.io/region": "me-east-215-b",
+                    "topology.kubernetes.io/zone": "me-east-215-b"
+                },
+                "name": "catalyst-hw173-omani-works-7bb723da-me-east-215-b-wd65403",
+                "resourceVersion": "716215",
+                "uid": "ac7f15ae-e2d0-48d0-b2a4-c2424b3202e7"
+            },
+            "spec": {
+                "podCIDR": "10.43.1.0/24",
+                "podCIDRs": [
+                    "10.43.1.0/24"
+                ],
+                "providerID": "k3s://catalyst-hw173-omani-works-7bb723da-me-east-215-b-wd65403"
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "10.179.1.91",
+                        "type": "InternalIP"
+                    },
+                    {
+                        "address": "catalyst-hw173-omani-works-7bb723da-me-east-215-b-wd65403",
+                        "type": "Hostname"
+                    }
+                ],
+                "allocatable": {
+                    "cpu": "4",
+                    "ephemeral-storage": "39857063496",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "32666744Ki",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "cpu": "4",
+                    "ephemeral-storage": "40971488Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "32666744Ki",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2026-06-20T03:08:22Z",
+                        "lastTransitionTime": "2026-06-20T03:08:22Z",
+                        "message": "Cilium is running on this node",
+                        "reason": "CiliumIsUp",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:08:31Z",
+                        "lastTransitionTime": "2026-06-20T03:00:37Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:08:31Z",
+                        "lastTransitionTime": "2026-06-20T03:00:37Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:08:31Z",
+                        "lastTransitionTime": "2026-06-20T03:00:37Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-06-20T15:08:31Z",
+                        "lastTransitionTime": "2026-06-20T03:08:17Z",
+                        "message": "kubelet is posting ready status",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10250
+                    }
+                },
+                "images": [
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/keycloak@sha256:da3df0976a9f9a664bdbde6cb5308b78f03ac94d0abf33b2df355bbb06cbc5b9",
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/keycloak:26.3.3-debian-12-r0"
+                        ],
+                        "sizeBytes": 271527858
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql@sha256:027303cd89644acdeba67d2b37f70eff6a7f345220f127721ff92504e1e4eae6",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16"
+                        ],
+                        "sizeBytes": 258220911
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/cilium@sha256:758ca0793f5995bb938a2fa219dcce63dc0b3fa7fc4ce5cc851125281fb7361d"
+                        ],
+                        "sizeBytes": 224306600
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql@sha256:99be063781d171d3971089b49c992706bdab9ccbd2b57cdf126c7542773aedfe",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16.4"
+                        ],
+                        "sizeBytes": 217672880
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql@sha256:cd2f88c75f4465ed14ff2006147e06405cca646c00f252a2dfb73910728d289f",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16.4-1"
+                        ],
+                        "sizeBytes": 211733506
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/grafana/alloy@sha256:6e00cf7c5a692ff5f24844529416ed017d76fce922f8199004e73d5eca46b6b8",
+                            "harbor.openova.io/proxy-dockerhub/grafana/alloy:v1.16.0"
+                        ],
+                        "sizeBytes": 151457664
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl@sha256:64614ef8290f3fb27fed5164b338debeeb79a1e5e26c93eb920770b71abd7c48",
+                            "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.31.4"
+                        ],
+                        "sizeBytes": 111911970
+                    },
+                    {
+                        "names": [
+                            "docker.io/bitnamilegacy/kubectl@sha256:1249fc292e84a38575ee0cadc3e28dcd7ddf5a3a4e5da401b1a8599e8ac52a1b",
+                            "docker.io/bitnamilegacy/kubectl:1.30.7"
+                        ],
+                        "sizeBytes": 110946736
+                    },
+                    {
+                        "names": [
+                            "docker.io/powerdns/pdns-auth-50@sha256:1f136c4fa4f995279b43c6a8413dde05147cc9b74a437e188f92b0088c523a8d",
+                            "docker.io/powerdns/pdns-auth-50:5.0.3"
+                        ],
+                        "sizeBytes": 102061459
+                    },
+                    {
+                        "names": [
+                            "docker.io/chrislusf/seaweedfs@sha256:84429e5f21fad82246f5cfae7b39e9a17da18afb62f2b79c25ccd364ab02793b",
+                            "docker.io/chrislusf/seaweedfs:4.22"
+                        ],
+                        "sizeBytes": 100503219
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/powerdnsadmin/pda-legacy@sha256:0fc92c8ef63a6704083ca1989c83d2b747f7abc0e5045d56d9c69a76e08a9a5e",
+                            "harbor.openova.io/proxy-dockerhub/powerdnsadmin/pda-legacy:0.4.2"
+                        ],
+                        "sizeBytes": 73000672
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/goharbor/harbor-core@sha256:a30e5a8be3d94b6485e7fdd4ed7fdf9e9724ee0a6d103b3804aacf6784ee358e",
+                            "harbor.openova.io/proxy-dockerhub/goharbor/harbor-core:v2.14.3"
+                        ],
+                        "sizeBytes": 65498736
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/cilium-envoy@sha256:709c08ade3d17d52da4ca2af33f431360ec26268d288d9a6cd1d98acc9a1dced"
+                        ],
+                        "sizeBytes": 62862122
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/loft-sh/vcluster@sha256:521b2fc8c8d0c2f1254d7fb956fbf274d3328f1e555270b57a886f9ae10d2109",
+                            "harbor.openova.io/proxy-ghcr/loft-sh/vcluster:0.23.0"
+                        ],
+                        "sizeBytes": 60761070
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/newapi-mirror@sha256:e596cb4aa2c234d88c3e05f41d430f405e6ccfdfa7acc8972c97793e9add4c36",
+                            "ghcr.io/openova-io/openova/newapi-mirror:v0.13.2"
+                        ],
+                        "sizeBytes": 58999657
+                    },
+                    {
+                        "names": [
+                            "mirror.gcr.io/aquasec/trivy@sha256:be1190afcb28352bfddc4ddeb71470835d16462af68d310f9f4bca710961a41e",
+                            "mirror.gcr.io/aquasec/trivy:0.70.0"
+                        ],
+                        "sizeBytes": 58469315
+                    },
+                    {
+                        "names": [
+                            "docker.io/falcosecurity/falco@sha256:b4166a61f41e2fa638c041cac881d8bb32c284e3aaf282fdfed80f15f6eb55e3",
+                            "docker.io/falcosecurity/falco:0.43.1"
+                        ],
+                        "sizeBytes": 50563340
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/kyverno/kyverno@sha256:cb033c200dc85be0a4d38e1a72894038a0c067d73f1ce6aedd569f9769a3d262",
+                            "harbor.openova.io/proxy-ghcr/kyverno/kyverno:v1.18.0"
+                        ],
+                        "sizeBytes": 46511461
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/kyverno/kyvernopre@sha256:60b53ebf646f788e6e5d312f9cbf267d7537ec14afec68bde2e1dad55c552cc7",
+                            "harbor.openova.io/proxy-ghcr/kyverno/kyvernopre:v1.18.0"
+                        ],
+                        "sizeBytes": 41450999
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/cloudnative-pg@sha256:68074486205a33ed41928761e22ad48278c690feebe8316727a1c6b3380f9e5e",
+                            "harbor.openova.io/proxy-ghcr/cloudnative-pg/cloudnative-pg:1.29.0"
+                        ],
+                        "sizeBytes": 36402270
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/clustermesh-apiserver@sha256:37a7fdbef806b78ef63df9f1a9828fdddbf548d1f0e43b8eb10a6bdc8fa03958"
+                        ],
+                        "sizeBytes": 35425816
+                    },
+                    {
+                        "names": [
+                            "docker.io/grafana/mimir@sha256:686138d9f941508c99c931cc9e69bf9f6100dd4d2d623bf57b38d5c25ee645c1",
+                            "docker.io/grafana/mimir:3.0.4"
+                        ],
+                        "sizeBytes": 33769654
+                    },
+                    {
+                        "names": [
+                            "docker.io/falcosecurity/falcoctl@sha256:0d3bddce03a26365b86e6ff1aa5c51965d2e16569e8cf8b3e37a3d3ef186dc9b",
+                            "docker.io/falcosecurity/falcoctl:0.12.2"
+                        ],
+                        "sizeBytes": 33185258
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/fluxcd/source-controller@sha256:3c5f0f022f990ffc0daf00e5b199548fc0fa6e7119e972318f0267081a332963",
+                            "ghcr.io/fluxcd/source-controller:v1.4.1"
+                        ],
+                        "sizeBytes": 32386205
+                    },
+                    {
+                        "names": [
+                            "quay.io/cilium/operator-generic@sha256:f7884848483bbcd7b1e0ccfd34ba4546f258b460cb4b7e2f06a1bcc96ef88039"
+                        ],
+                        "sizeBytes": 31216191
+                    },
+                    {
+                        "names": [
+                            "quay.io/minio/mc@sha256:993e8c454a7ec632923f7e3e61adf1d473261da6354cefd641aedd33a2cfe112",
+                            "quay.io/minio/mc:RELEASE.2024-11-21T17-21-54Z"
+                        ],
+                        "sizeBytes": 28122288
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-k8s/kube-apiserver@sha256:ace6a943b058439bd6daeb74f152e7c36e6fc0b5e481cdff9364cd6ca0473e5e",
+                            "harbor.openova.io/proxy-k8s/kube-apiserver:v1.31.4"
+                        ],
+                        "sizeBytes": 27972283
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-k8s/kube-controller-manager@sha256:4bd1d4a449e7a1a4f375bd7c71abf48a95f8949b38f725ded255077329f21f7b",
+                            "harbor.openova.io/proxy-k8s/kube-controller-manager:v1.31.4"
+                        ],
+                        "sizeBytes": 26147269
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/fluxcd/image-automation-controller@sha256:5b6c2e97055cfe69fe8996f48b53db039c136210dbc98c5631864a9e573d0e20",
+                            "ghcr.io/fluxcd/image-automation-controller:v0.39.0"
+                        ],
+                        "sizeBytes": 22354899
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/aquasecurity/node-collector@sha256:f4702ce4667388f0219d6248d623a7e816231c2d4561d6af01c3ae053e524025",
+                            "ghcr.io/aquasecurity/node-collector:0.3.1"
+                        ],
+                        "sizeBytes": 20174022
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-quay/prometheus-operator/prometheus-config-reloader@sha256:959d47672fbff2776a04ec62b8afcec89e8c036af84dc5fade50019dab212746",
+                            "harbor.openova.io/proxy-quay/prometheus-operator/prometheus-config-reloader:v0.81.0"
+                        ],
+                        "sizeBytes": 14433657
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/k8s-ws-proxy@sha256:0e3c679c9f78b302575cf9d6e2ae0e5d82d861e4d6de19876df0ca496677825b",
+                            "ghcr.io/openova-io/openova/k8s-ws-proxy:b32eb9b"
+                        ],
+                        "sizeBytes": 11403264
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/openova-flow-adapter-flux@sha256:ffc60bb400d3b8e8e7d19ced0b8714d038ee6c9b9012cc9019e2341d57c1989f",
+                            "ghcr.io/openova-io/openova/openova-flow-adapter-flux:b32eb9b"
+                        ],
+                        "sizeBytes": 10917169
+                    },
+                    {
+                        "names": [
+                            "docker.io/library/nats@sha256:c82559e4476289481a8a5196e675ebfe67eea81d95e5161e3e78eccfe766608e",
+                            "docker.io/library/nats:2.10.16-alpine"
+                        ],
+                        "sizeBytes": 9725619
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/curlimages/curl@sha256:d9b4541e214bcd85196d6e92e2753ac6d0ea699f0af5741f8c6cccbfcf00ef4b",
+                            "harbor.openova.io/proxy-dockerhub/curlimages/curl:8.10.1"
+                        ],
+                        "sizeBytes": 9414401
+                    },
+                    {
+                        "names": [
+                            "docker.io/natsio/nats-server-config-reloader@sha256:98d592981444fac82f79950b42f439f16918e9788fe5080eb32ac8cc7f357df1",
+                            "docker.io/natsio/nats-server-config-reloader:0.14.3"
+                        ],
+                        "sizeBytes": 4628347
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/newapi-sandbox-bridge@sha256:170363bf9b313db7844a566df72aa07ab483d31c1eb2af59694da65169483c02",
+                            "ghcr.io/openova-io/openova/newapi-sandbox-bridge:5d818d4"
+                        ],
+                        "sizeBytes": 4477093
+                    },
+                    {
+                        "names": [
+                            "docker.io/library/alpine@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc",
+                            "harbor.openova.io/proxy-dockerhub/alpine@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc",
+                            "docker.io/library/alpine:3.20",
+                            "harbor.openova.io/proxy-dockerhub/alpine:3.20"
+                        ],
+                        "sizeBytes": 3641182
+                    },
+                    {
+                        "names": [
+                            "ghcr.io/openova-io/openova/services-metering-sidecar@sha256:259420d49d42b44d8ce36ab062e1fb88d033571c98362008951f195636b086ff",
+                            "ghcr.io/openova-io/openova/services-metering-sidecar:41e02c8"
+                        ],
+                        "sizeBytes": 3548511
+                    },
+                    {
+                        "names": [
+                            "harbor.openova.io/proxy-dockerhub/library/busybox@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662",
+                            "harbor.openova.io/proxy-dockerhub/library/busybox:1.36"
+                        ],
+                        "sizeBytes": 2217006
+                    },
+                    {
+                        "names": [
+                            "docker.io/rancher/mirrored-library-busybox@sha256:8a45424ddf949bbe9bb3231b05f9032a45da5cd036eb4867b511b00734756d6f",
+                            "docker.io/rancher/mirrored-library-busybox:1.36.1"
+                        ],
+                        "sizeBytes": 2147340
+                    },
+                    {
+                        "names": [
+                            "docker.io/rancher/mirrored-pause@sha256:74c4244427b7312c5b901fe0f67cbc53683d06f4f24c6faee65d4182bf0fa893",
+                            "docker.io/rancher/mirrored-pause:3.6"
+                        ],
+                        "sizeBytes": 301463
+                    }
+                ],
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "c634aeea-c12e-421f-b358-10fe1c0e78e6",
+                    "containerRuntimeVersion": "containerd://1.7.23-k3s2",
+                    "kernelVersion": "5.15.0-76-generic",
+                    "kubeProxyVersion": "v1.31.4+k3s1",
+                    "kubeletVersion": "v1.31.4+k3s1",
+                    "machineID": "41895bd1876a403788902e232a28f6c9",
+                    "operatingSystem": "linux",
+                    "osImage": "Ubuntu 22.04.2 LTS",
+                    "systemUUID": "9bfb8389-2732-459b-a35d-15b4a96f8b47"
+                }
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": ""
+    }
+}

--- a/products/catalyst/bootstrap/api/internal/handler/testdata/hw173_3986/ns-catalyst-system-a.json
+++ b/products/catalyst/bootstrap/api/internal/handler/testdata/hw173_3986/ns-catalyst-system-a.json
@@ -1,0 +1,24 @@
+{
+    "apiVersion": "v1",
+    "kind": "Namespace",
+    "metadata": {
+        "creationTimestamp": "2026-06-20T02:58:14Z",
+        "labels": {
+            "catalyst.openova.io/sovereign": "hw173.omani.works",
+            "kubernetes.io/metadata.name": "catalyst-system",
+            "kustomize.toolkit.fluxcd.io/name": "bootstrap-kit",
+            "kustomize.toolkit.fluxcd.io/namespace": "flux-system"
+        },
+        "name": "catalyst-system",
+        "resourceVersion": "3496",
+        "uid": "c807fe2f-3a09-41e9-bd75-cb0cf4e4e95f"
+    },
+    "spec": {
+        "finalizers": [
+            "kubernetes"
+        ]
+    },
+    "status": {
+        "phase": "Active"
+    }
+}

--- a/products/catalyst/bootstrap/api/internal/handler/testdata/hw173_3986/ns-catalyst-system-b.json
+++ b/products/catalyst/bootstrap/api/internal/handler/testdata/hw173_3986/ns-catalyst-system-b.json
@@ -1,0 +1,24 @@
+{
+    "apiVersion": "v1",
+    "kind": "Namespace",
+    "metadata": {
+        "creationTimestamp": "2026-06-20T03:17:52Z",
+        "labels": {
+            "catalyst.openova.io/sovereign": "hw173.omani.works",
+            "kubernetes.io/metadata.name": "catalyst-system",
+            "kustomize.toolkit.fluxcd.io/name": "bootstrap-kit",
+            "kustomize.toolkit.fluxcd.io/namespace": "flux-system"
+        },
+        "name": "catalyst-system",
+        "resourceVersion": "5935",
+        "uid": "e2d2a2c3-595f-40c2-8fb0-ff827c40ca49"
+    },
+    "spec": {
+        "finalizers": [
+            "kubernetes"
+        ]
+    },
+    "status": {
+        "phase": "Active"
+    }
+}

--- a/products/catalyst/bootstrap/api/internal/handler/testdata/hw173_3986/ns-mgmt-a.json
+++ b/products/catalyst/bootstrap/api/internal/handler/testdata/hw173_3986/ns-mgmt-a.json
@@ -1,0 +1,43 @@
+{
+    "apiVersion": "v1",
+    "kind": "Namespace",
+    "metadata": {
+        "annotations": {
+            "meta.helm.sh/release-name": "mgmt-vcluster",
+            "meta.helm.sh/release-namespace": "mgmt"
+        },
+        "creationTimestamp": "2026-06-20T03:06:22Z",
+        "labels": {
+            "app.kubernetes.io/instance": "mgmt-vcluster",
+            "app.kubernetes.io/managed-by": "Helm",
+            "app.kubernetes.io/name": "bp-mgmt-vcluster",
+            "app.kubernetes.io/version": "0.23.0",
+            "catalyst.openova.io/blueprint": "bp-mgmt-vcluster",
+            "catalyst.openova.io/sovereign": "hw173.omani.works",
+            "catalyst.openova.io/topology": "dod-a4",
+            "catalyst.openova.io/topology-role": "primary",
+            "catalyst.openova.io/vcluster": "mgmt",
+            "catalyst.openova.io/vcluster-role": "mgmt",
+            "helm.sh/chart": "bp-mgmt-vcluster-0.2.28",
+            "helm.toolkit.fluxcd.io/name": "bp-mgmt-vcluster",
+            "helm.toolkit.fluxcd.io/namespace": "flux-system",
+            "kubernetes.io/metadata.name": "mgmt",
+            "kustomize.toolkit.fluxcd.io/name": "bootstrap-kit",
+            "kustomize.toolkit.fluxcd.io/namespace": "flux-system",
+            "pod-security.kubernetes.io/audit": "baseline",
+            "pod-security.kubernetes.io/enforce": "baseline",
+            "pod-security.kubernetes.io/warn": "baseline"
+        },
+        "name": "mgmt",
+        "resourceVersion": "10257",
+        "uid": "f7af9f42-0e18-44f2-8015-672fc9a54112"
+    },
+    "spec": {
+        "finalizers": [
+            "kubernetes"
+        ]
+    },
+    "status": {
+        "phase": "Active"
+    }
+}

--- a/products/catalyst/bootstrap/api/internal/handler/testdata/hw173_3986/ns-mgmt-b.json
+++ b/products/catalyst/bootstrap/api/internal/handler/testdata/hw173_3986/ns-mgmt-b.json
@@ -1,0 +1,43 @@
+{
+    "apiVersion": "v1",
+    "kind": "Namespace",
+    "metadata": {
+        "annotations": {
+            "meta.helm.sh/release-name": "mgmt-vcluster",
+            "meta.helm.sh/release-namespace": "mgmt"
+        },
+        "creationTimestamp": "2026-06-20T03:17:52Z",
+        "labels": {
+            "app.kubernetes.io/instance": "mgmt-vcluster",
+            "app.kubernetes.io/managed-by": "Helm",
+            "app.kubernetes.io/name": "bp-mgmt-vcluster",
+            "app.kubernetes.io/version": "0.23.0",
+            "catalyst.openova.io/blueprint": "bp-mgmt-vcluster",
+            "catalyst.openova.io/sovereign": "hw173.omani.works",
+            "catalyst.openova.io/topology": "dod-a4",
+            "catalyst.openova.io/topology-role": "primary",
+            "catalyst.openova.io/vcluster": "mgmt",
+            "catalyst.openova.io/vcluster-role": "mgmt",
+            "helm.sh/chart": "bp-mgmt-vcluster-0.2.28",
+            "helm.toolkit.fluxcd.io/name": "bp-mgmt-vcluster",
+            "helm.toolkit.fluxcd.io/namespace": "flux-system",
+            "kubernetes.io/metadata.name": "mgmt",
+            "kustomize.toolkit.fluxcd.io/name": "bootstrap-kit",
+            "kustomize.toolkit.fluxcd.io/namespace": "flux-system",
+            "pod-security.kubernetes.io/audit": "baseline",
+            "pod-security.kubernetes.io/enforce": "baseline",
+            "pod-security.kubernetes.io/warn": "baseline"
+        },
+        "name": "mgmt",
+        "resourceVersion": "10690",
+        "uid": "819608d0-709c-40f5-ada3-773e92ff5d3e"
+    },
+    "spec": {
+        "finalizers": [
+            "kubernetes"
+        ]
+    },
+    "status": {
+        "phase": "Active"
+    }
+}


### PR DESCRIPTION
## What

#3984 wired the placement MODEL to the live runtime, but its pod-matcher
(`applications_placement_runtime.go`) missed the **bp-prefix** mismatch: the
AppDetail Topology tab passes the route id `bp-<chart>` (the Dashboard route +
lookup both key on the `bp-`-prefixed id), while the live, **loft-synced** pods
in host ns `mgmt`/`dmz`/`rtz` carry the **bare** upstream chart identity
(`app.kubernetes.io/{instance,name}=grafana`). So `bp-grafana` matched nothing
→ `{"targets":[]}` → false **singleton**, even though grafana runs in both
regions.

## Root cause — proven LIVE on hw173 (image `3a1bb63` = #3984 merged)

```
GET …/applications/bp-grafana/placement?namespace=mgmt → {"targets":[]}        # the bug
GET …/applications/grafana/placement?namespace=mgmt    → {"targets":[{region-a…}]} # bare resolves
```

The real grafana host pod: `grafana-6f94dbbd8f-zs8fr-x-grafana-x-mgmt-vcluster`,
host ns `mgmt`, labels `app.kubernetes.io/{instance,name}=grafana`, full loft
`object-*` annotation set. Same for keycloak (`keycloak-0-x-keycloak-x-mgmt-vcluster`).

## Fix

`componentNameCandidates(name)` strips the `bp-` prefix (mirroring LogsTab's
`blueprint.replace(/^bp-/, '')` and the resource-list path) and
`podBelongsToComponent` matches against BOTH the raw and the bare form. Purely
additive — the bare wizard-install path is unchanged; the #3969 model files,
the FE `{Placement, Status}` shape, and the #3984 endpoint contract are
untouched.

## Tests — REAL loft pod shape + REAL captured hw173 objects (no mocks)

- `applications_placement_runtime_test.go`: synthetic but real-shape loft pods
  (mangled name + loft annotations + bare labels) queried `bp-grafana` /
  `bp-keycloak` → 2 targets. RED without the fix (got 0), GREEN with it.
- `applications_placement_runtime_livedata_test.go` + `testdata/hw173_3986/`:
  the ACTUAL grafana + keycloak + control-plane catalyst-api pods (both regions)
  + real host Nodes + Namespaces, captured from hw173 on 2026-06-20, run through
  the REAL `derivePlacementTargets`:
  - `bp-grafana` → **2 targets** (region-a + region-b, both Primary, pattern ≠ singleton)
  - `bp-keycloak` → **2 targets**, 2 distinct regions
  - `catalyst-api` (A-only control plane) → **stays singleton** (no regression)

## Live-env note for the coordinator (region-b reachability gap)

I could NOT build+push the image (no ghcr-push credential in this env — the gh
token + ghcr_pull_token are pull-only). The image **builds clean** from the
Containerfile with this change (`catalyst-api:fix3986-local`). The branch is
ready for the coordinator to roll.

Separately: on hw173 the **in-cluster** catalyst-api (which serves the live
endpoint) has region-b's apiserver (`212.72.24.35:6443`) **unreachable** from
its pod network — `List(region-b, pod)` times out and is silently skipped, so
even bare `grafana` returns only region-a today (the treemap-by-region also
shows only region-a). I registered region-b's kubeconfig via
`POST /sovereign/secondary-kubeconfig` (status 201, `cluster registered, kinds:48`)
but LISTs still time out → this is an **env cross-region apiserver reachability
gap, independent of this matcher fix**. After the coordinator rolls this image
AND region-b pods are listable, `bp-grafana` will return 2 targets exactly as
the live-data test proves.

## Gates

- `go build ./...` = 0, `go vet ./internal/handler/` = 0
- `go test ./internal/handler/` = pass (full package, incl. #3969 model + 4 new live-data tests)
- Containerfile image build = success

Refs #3982