### PR TITLE
fix(bootstrap): FORBID k3s local-path — --disable=local-storage + Kyverno ENFORCE deny + CSI-default StorageClass (#3971)

### DIFF
--- a/clusters/_template/bootstrap-kit-crs/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit-crs/10-gitea.yaml
@@ -143,7 +143,7 @@ spec:
       log_min_duration_statement: '1000'
   storage:
     size: 5Gi
-    storageClass: local-path
+    storageClass: ''
   enableSuperuserAccess: true
   monitoring:
     enablePodMonitor: false

--- a/clusters/_template/bootstrap-kit-crs/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit-crs/19-harbor.yaml
@@ -99,7 +99,7 @@ spec:
       log_min_duration_statement: '1000'
   storage:
     size: 5Gi
-    storageClass: local-path
+    storageClass: ''
   enableSuperuserAccess: true
   monitoring:
     enablePodMonitor: false

--- a/clusters/_template/bootstrap-kit-crs/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit-crs/52-bp-guacamole.yaml
@@ -87,7 +87,7 @@ spec:
       memory: 512Mi
   storage:
     size: 5Gi
-    storageClass: local-path
+    storageClass: ''
   enableSuperuserAccess: true
   monitoring:
     enablePodMonitor: false

--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -167,7 +167,7 @@ spec:
       # the chart ExternalSecret is suppressed via sso.externalSecret.enabled,
       # not sso.enabled), so the login_source row gets seeded in the mgmt
       # vCluster placement (caught live hw171). Refs #3374 #3642.
-      version: 1.2.39
+      version: 1.2.40
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/clusters/_template/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/_template/bootstrap-kit/11-powerdns.yaml
@@ -150,7 +150,7 @@ spec:
       # chart renders the canonical apps.openova.io/v1 Application CR for
       # this slot's HelmRelease so the console /apps list, per-app Topology
       # tab + showback resolve powerdns (no more "no Application CR").
-      version: 1.2.16
+      version: 1.2.17
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns

--- a/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
+++ b/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
@@ -148,7 +148,7 @@ spec:
       # pda-sso-oidc-credentials is populated, so `envFrom` is never empty at
       # first serve and /oidc/login deterministically 302s to KC from t=0.
       # 0.1.17: #3852 — SQLALCHEMY_ENGINE_OPTIONS pool_pre_ping survives CNPG SSL recycling.
-      version: 0.1.17
+      version: 0.1.18
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns-admin

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1052,7 +1052,7 @@ spec:
       #   Jobs so the Kyverno flux-managed (Enforce) policy admits them in
       #   catalyst-system. Pre-1.4.722 the pre-install hook was DENIED →
       #   console install failed pre-install on every Enforce Sovereign (hw172).
-      version: 1.4.744
+      version: 1.4.745
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/16-cnpg.yaml
+++ b/clusters/_template/bootstrap-kit/16-cnpg.yaml
@@ -52,8 +52,18 @@ spec:
   targetNamespace: cnpg-system
   # CNPG only needs Flux Ready (its own CRDs ship in the same chart;
   # consumers of postgresql.cnpg.io/v1.Cluster gate themselves on bp-cnpg).
+  #
+  # #3971 — also gate on bp-hcloud-csi. bp-cnpg is the root of the stateful-
+  # Postgres dependency tree (bp-postgres-shared{,-b,-c}, bp-cnpg-pair, and
+  # transitively harbor/keycloak/gitea via the shared-pg roles), all of which
+  # bind PVCs. k3s now runs `--disable=local-storage` so local-path is
+  # FORBIDDEN and the ONLY default StorageClass is the cloud CSI. Gating here
+  # guarantees the durable default class EXISTS before any cnpg PVC binds, so
+  # nothing hangs Pending. bp-hcloud-csi is Ready on BOTH providers (it
+  # renders empty on Huawei) so this dependsOn never deadlocks.
   dependsOn:
     - name: bp-flux
+    - name: bp-hcloud-csi
   chart:
     spec:
       chart: bp-cnpg

--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -143,7 +143,7 @@ spec:
       # (no fromHost mirror of a pod-mounted Secret → no vcluster-0.23.0
       # from-host/to-host deadlock, and no missing credential). Lockstep with
       # 16c/16d. Refs #3876 #3374 #3737.
-      version: 0.2.4
+      version: 0.2.5
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
+++ b/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
@@ -87,7 +87,7 @@ spec:
       # vc-mgmt as the syncer-mangled host object (no fromHost mirror → no
       # vcluster-0.23.0 deadlock, no missing GF_DATABASE_* env). Lockstep with
       # 16a/16d. Refs #3876 #3374 #3737.
-      version: 0.2.4
+      version: 0.2.5
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
+++ b/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
@@ -75,7 +75,7 @@ spec:
       # the 4 vc-mgmt-homed deadlock apps; newapi keeps its `newapi/*` fromHost
       # wildcard per #3876), so this slot renders byte-identical to 0.2.2 on the
       # additive chart. Lockstep with 16a/16c. Refs #3876 #3374 #3737.
-      version: 0.2.4
+      version: 0.2.5
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/18-seaweedfs.yaml
+++ b/clusters/_template/bootstrap-kit/18-seaweedfs.yaml
@@ -98,7 +98,7 @@ spec:
       # ("violates PodSecurity baseline: hostPath volumes"). 1.2.0 shipped
       # the `seaweedfs-storage` StorageClass (qa-loop Wave 5 Fix #79 Gap B)
       # so PVCs that default to it bind day-1 on bare-k3s Sovereigns.
-      version: 1.2.2
+      version: 1.2.3
       sourceRef:
         kind: HelmRepository
         name: bp-seaweedfs

--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -221,7 +221,7 @@ spec:
       # ExternalSecret is suppressed via sso.externalSecret.enabled), so
       # auth_mode=oidc_auth is PUT in the mgmt vCluster placement (caught live
       # hw171: systeminfo auth_mode=db_auth). Refs #3374 #3642.
-      version: 1.2.34
+      version: 1.2.35
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
+++ b/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
@@ -111,7 +111,7 @@ spec:
       # 1.0.37 (#3859): add org-services to harbor-proxy-pull exclude (sme→
       # org-services rename orphaned the mixed-image carve-out → provisioning
       # CR-minter Enforce-denied → #3376 funnel could not reach ACTIVE).
-      version: 1.0.37
+      version: 1.0.38
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno

--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -194,7 +194,7 @@ spec:
       # chart renders the canonical apps.openova.io/v1 Application CR for
       # this slot's HelmRelease so the console /apps list, per-app Topology
       # tab + showback resolve guacamole (no more "no Application CR").
-      version: 0.2.25
+      version: 0.2.26
       sourceRef:
         kind: HelmRepository
         name: bp-guacamole

--- a/clusters/_template/bootstrap-kit/54-bp-dmz-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/54-bp-dmz-vcluster.yaml
@@ -72,7 +72,7 @@ spec:
       # bp-mgmt-vcluster + bp-rtz-vcluster (sibling tag parity). The active
       # fromHost.secrets mappings live in bp-mgmt-vcluster; DMZ takes the
       # version bump only.
-      version: 0.2.8
+      version: 0.2.9
       sourceRef:
         kind: HelmRepository
         name: bp-dmz-vcluster

--- a/clusters/_template/bootstrap-kit/55a-bp-hcloud-csi.yaml
+++ b/clusters/_template/bootstrap-kit/55a-bp-hcloud-csi.yaml
@@ -82,10 +82,22 @@ metadata:
   labels:
     catalyst.openova.io/slot: "55a"
 spec:
-  # Suspend on non-Hetzner providers. Huawei cloud-init substitutes "true";
-  # Hetzner cloud-init substitutes "false" (or omits → default kicks in).
-  # Same provider-keyed gate shape as bp-hcloud-ccm (slot 55).
-  suspend: ${HCLOUD_HR_SUSPEND:=false}
+  # #3971 — ACTIVE on BOTH providers (NOT suspended). The chart `enabled`
+  # toggle below (HCLOUD_CSI_ENABLED) decides whether this installs the real
+  # Hetzner CSI (Hetzner substitutes "true") or an EMPTY release that reports
+  # Ready immediately (Huawei substitutes "false"). This MUST stay active on
+  # Huawei: the stateful root slots (bp-cnpg slot 16 + bp-mgmt-vcluster slot
+  # 58) now `dependsOn: bp-hcloud-csi` to guarantee the durable default
+  # StorageClass exists BEFORE any PVC binds (k3s now runs
+  # `--disable=local-storage` so local-path is FORBIDDEN — see the cloud-init
+  # k3s install block). A `dependsOn` on a SUSPENDED HelmRelease blocks
+  # forever — Flux never marks a suspended HR Ready — so the old
+  # `suspend: ${HCLOUD_HR_SUSPEND}` shape would deadlock EVERY Huawei prov.
+  # Rendering empty (enabled=false) keeps the HR Ready so the dependsOn is
+  # satisfied on both clouds. Huawei's own durable CSI (everest/EVS) is slot
+  # 55b (#3971 follow-up); until it lands a Huawei prov has no default class
+  # and the Phase-1 storage-durability gate honestly FAILS it (never silent
+  # ephemeral storage).
   interval: 15m
   releaseName: hcloud-csi
   targetNamespace: hcloud-csi
@@ -101,28 +113,42 @@ spec:
   chart:
     spec:
       chart: bp-hcloud-csi
-      version: 1.2.0
+      version: 1.2.1
       sourceRef:
         kind: HelmRepository
         name: bp-hcloud-csi
         namespace: flux-system
-  # ── Activation on Hetzner ────────────────────────────────────────────
-  # enabled + defaultStorageClass flip the chart from its default-off
-  # no-op (the EPIC-6 opt-in shape) to: install the driver, render the
-  # hcloud-volumes SC, and run the default-class flip hook. This is the
-  # whole point of the slot — every fresh Hetzner Sovereign comes up with
-  # the cloud-block CSI as the ONE default class, never ephemeral local-path.
+  # ── Provider-keyed activation ────────────────────────────────────────
+  # HCLOUD_CSI_ENABLED is "true" on Hetzner, "false" on Huawei (cloud-init
+  # substitute map, alongside HCLOUD_HR_SUSPEND). On Hetzner this flips the
+  # chart from its default-off no-op to: install the driver, render the
+  # hcloud-volumes SC, and run the default-class flip hook — the cluster's
+  # ONE default class is now a durable cloud volume, never ephemeral
+  # local-path (which `--disable=local-storage` forbids outright). On Huawei
+  # enabled=false renders ZERO resources → the HR installs empty and reports
+  # Ready immediately so the bp-cnpg / bp-mgmt-vcluster dependsOn is satisfied
+  # without the suspended-HR deadlock. defaultStorageClass tracks enabled so
+  # the flip hook only runs where the SC actually exists.
   values:
-    enabled: true
-    defaultStorageClass: true
+    enabled: ${HCLOUD_CSI_ENABLED:=true}
+    defaultStorageClass: ${HCLOUD_CSI_ENABLED:=true}
   # ── Hetzner-token wiring ─────────────────────────────────────────────
   # Pulls `hcloud-token` from the canonical flux-system/cloud-credentials
   # Secret (cloud-init Phase 0) into .Values.hetznerToken; the chart
   # renders the namespace-local hcloud-csi-token Secret from it. Flux
   # dereferences valuesFrom at apply time so the plaintext never lands in
   # this committed manifest. Mirrors slot 55 (bp-hcloud-ccm).
+  #
+  # `optional: true` (#3971) — on Huawei the cloud-credentials Secret has NO
+  # `hcloud-token` key (it carries huawei-ak/sk/region instead). Since the HR
+  # is now ACTIVE on Huawei (enabled=false, empty render), Flux would FAIL to
+  # apply if it tried to dereference a missing valuesKey. optional:true makes
+  # Flux SKIP the entry when the key is absent (same idiom as slot 50
+  # cluster-autoscaler's hcloud-token wiring) — the empty Huawei render needs
+  # no token anyway.
   valuesFrom:
     - kind: Secret
       name: cloud-credentials
       valuesKey: hcloud-token
       targetPath: hetznerToken
+      optional: true

--- a/clusters/_template/bootstrap-kit/55a-bp-hcloud-csi.yaml
+++ b/clusters/_template/bootstrap-kit/55a-bp-hcloud-csi.yaml
@@ -1,0 +1,128 @@
+# bp-hcloud-csi — Catalyst bootstrap-kit Blueprint #55a (#3971).
+# (Tier 5 — Cloud Integration). The storage sibling of bp-hcloud-ccm
+# (slot 55) + bp-cluster-autoscaler-hcloud (slot 50) — the full
+# Hetzner-cloud-direct trio (CCM + CSI + autoscaler).
+#
+# WHY THIS SLOT EXISTS (the P0 blocker #3971)
+# ===========================================
+# k3s ships `local-path-provisioner` as the cluster-default StorageClass.
+# With NO cloud block-storage CSI installed, EVERY PVC on EVERY Sovereign
+# landed on local-path — a directory on the node's LOCAL disk with no cloud
+# volume behind it. A node replacement (autoscaler, failed node, re-prov,
+# disk loss) DESTROYS that PV's data — including cnpg-pair-primary 3×100Gi
+# (prod Postgres), openbao 10Gi (secrets), the customer-Org DB, keycloak,
+# gitea, harbor, loki/mimir/tempo. That invalidates the BCP/DR model.
+#
+# bp-hcloud-csi was formerly bootstrap-kit slot 17a but was REMOVED on
+# 2026-05-17 (Wave 7) because its Flux chart pull went through the
+# harbor.<sov> OCI endpoint BEFORE harbor was reachable (the cutover URL
+# rewrite raced harbor's own install — see the kustomization.yaml slot-17a
+# comment block). This re-add lands the slot at 55a (AFTER bp-harbor 19),
+# pulling from `oci://ghcr.io/openova-io` exactly like slot 55 (bp-hcloud-
+# ccm), so the pre-cutover chart pull hits ghcr — never the not-yet-ready
+# harbor. Post-cutover the slot-06a URL rewrite points it at the local
+# harbor, by which time harbor is long-Ready.
+#
+# INTENTIONALLY SUSPENDED on non-Hetzner providers (e.g. HCS / Huawei) —
+# same `${HCLOUD_HR_SUSPEND:=false}` gate as bp-hcloud-ccm. The Huawei
+# cloud-init substitutes HCLOUD_HR_SUSPEND="true"; the Hetzner cloud-init
+# leaves the default (false). Huawei's equivalent cloud block storage CSI
+# (everest / EVS) is tracked separately — see the #3971 follow-up. An empty
+# READY/STATUS column for this HR on an HCS Sovereign is BY DESIGN.
+#
+# WHAT IT INSTALLS
+# ================
+#   - The Hetzner Cloud CSI driver (csi.hetzner.cloud) controller +
+#     node DaemonSet (upstream hcloud-csi 2.13.0 subchart).
+#   - The `hcloud-volumes` StorageClass — reclaimPolicy Retain (production-
+#     data durability: the backing Hetzner Volume survives PVC/PV deletion),
+#     volumeBindingMode WaitForFirstConsumer (pins the volume to the Pod's
+#     node), allowVolumeExpansion true.
+#   - VolumeSnapshotClass `hcloud-volumes-snapshots` (storage-level DR).
+#   - A post-install hook Job that promotes hcloud-volumes to cluster-default
+#     and DEMOTES the k3s local-path default (templates/default-class-hook).
+#     local-path stays installed but non-default for ephemeral caches.
+#
+# Hetzner-token wiring (mirrors bp-hcloud-ccm slot 55 / bp-cluster-
+# autoscaler-hcloud slot 50):
+#   - cloud-init writes `flux-system/cloud-credentials` Secret with the
+#     `hcloud-token` key.
+#   - This HelmRelease lifts `hcloud-token` into `hcloudToken` via Flux
+#     `valuesFrom`. The chart's templates/hcloud-token-secret.yaml then
+#     renders the namespace-local `hcloud-csi/hcloud-csi-token` Secret the
+#     upstream controller binds for Hetzner-API auth. Without it the SC
+#     exists but every PVC fails to provision with a 401.
+#
+# dependsOn: (none) — like bp-hcloud-ccm, the CSI is a foundational cloud
+# seam that must be Ready BEFORE the stateful apps (openbao/keycloak/gitea/
+# cnpg) create their PVCs. The cloud-credentials Secret is provisioned by
+# cloud-init BEFORE Flux installs anything, and the chart pulls from ghcr,
+# so it has no Flux dependency. The stateful slots install LATE (their own
+# dependsOn chains on bp-mgmt-vcluster / bp-cert-manager), by which time the
+# CSI default-class flip has already run.
+
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-hcloud-csi
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-hcloud-csi
+  namespace: flux-system
+  labels:
+    catalyst.openova.io/slot: "55a"
+spec:
+  # Suspend on non-Hetzner providers. Huawei cloud-init substitutes "true";
+  # Hetzner cloud-init substitutes "false" (or omits → default kicks in).
+  # Same provider-keyed gate shape as bp-hcloud-ccm (slot 55).
+  suspend: ${HCLOUD_HR_SUSPEND:=false}
+  interval: 15m
+  releaseName: hcloud-csi
+  targetNamespace: hcloud-csi
+  install:
+    createNamespace: true
+    timeout: 15m
+    remediation:
+      retries: -1
+  upgrade:
+    timeout: 15m
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: bp-hcloud-csi
+      version: 1.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-hcloud-csi
+        namespace: flux-system
+  # ── Activation on Hetzner ────────────────────────────────────────────
+  # enabled + defaultStorageClass flip the chart from its default-off
+  # no-op (the EPIC-6 opt-in shape) to: install the driver, render the
+  # hcloud-volumes SC, and run the default-class flip hook. This is the
+  # whole point of the slot — every fresh Hetzner Sovereign comes up with
+  # the cloud-block CSI as the ONE default class, never ephemeral local-path.
+  values:
+    enabled: true
+    defaultStorageClass: true
+  # ── Hetzner-token wiring ─────────────────────────────────────────────
+  # Pulls `hcloud-token` from the canonical flux-system/cloud-credentials
+  # Secret (cloud-init Phase 0) into .Values.hetznerToken; the chart
+  # renders the namespace-local hcloud-csi-token Secret from it. Flux
+  # dereferences valuesFrom at apply time so the plaintext never lands in
+  # this committed manifest. Mirrors slot 55 (bp-hcloud-ccm).
+  valuesFrom:
+    - kind: Secret
+      name: cloud-credentials
+      valuesKey: hcloud-token
+      targetPath: hetznerToken

--- a/clusters/_template/bootstrap-kit/56-bp-openova-flow-server.yaml
+++ b/clusters/_template/bootstrap-kit/56-bp-openova-flow-server.yaml
@@ -71,7 +71,7 @@ spec:
   chart:
     spec:
       chart: bp-openova-flow-server
-      version: 0.2.3
+      version: 0.2.4
       sourceRef:
         kind: HelmRepository
         name: bp-openova-flow-server

--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -64,9 +64,19 @@ spec:
   # so we point Flux to install INTO that namespace. The vCluster
   # subchart's StatefulSet + Service + RBAC land here.
   targetNamespace: mgmt
+  # #3971 — also gate on bp-hcloud-csi. bp-mgmt-vcluster is the root of the
+  # other stateful dependency tree (openbao slot 08, keycloak 09, gitea 10,
+  # harbor 19 all `dependsOn: bp-mgmt-vcluster`) and the vCluster StatefulSet
+  # itself binds a PVC. k3s now runs `--disable=local-storage` so local-path
+  # is FORBIDDEN and the ONLY default StorageClass is the cloud CSI. Gating
+  # here guarantees the durable default class EXISTS before the vCluster (and
+  # everything downstream of it) binds a PVC — nothing hangs Pending.
+  # bp-hcloud-csi is Ready on BOTH providers (empty render on Huawei) so this
+  # dependsOn never deadlocks.
   dependsOn:
     - name: bp-cilium
     - name: bp-cert-manager
+    - name: bp-hcloud-csi
   chart:
     spec:
       chart: bp-mgmt-vcluster

--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -192,7 +192,7 @@ spec:
       # `harbor-core.harbor.svc` — resolves Harbor again post-#3642 (it now runs
       # INSIDE vc-mgmt; the host name NXDOMAIN'd → cutover wedged at step-02 on
       # hw171). Same proven host-service-aliases mechanism as gitea/keycloak/openbao.
-      version: 0.2.28
+      version: 0.2.29
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/clusters/_template/bootstrap-kit/59-bp-rtz-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/59-bp-rtz-vcluster.yaml
@@ -80,7 +80,7 @@ spec:
       # 0.2.13 (#3859): add `org-services` to the valkey isolation allow-list
       # (was only `sme`; the BSS tier was renamed to org-services) — unblocks
       # auth/billing/domain/notification → valkey, the #3376 funnel.
-      version: 0.2.13
+      version: 0.2.14
       sourceRef:
         kind: HelmRepository
         name: bp-rtz-vcluster

--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -252,6 +252,21 @@ resources:
   # clustermesh-apiserver could not migrate from NodePort to LB on
   # omantel multi-region (qa-loop iter-12 Fix #53D).
   - 55-bp-hcloud-ccm.yaml
+  # bp-hcloud-csi (slot 55a, #3971) — Hetzner Cloud CSI driver. The
+  # STORAGE sibling of slot 55 (CCM). Installs the csi.hetzner.cloud
+  # driver + the hcloud-volumes StorageClass (reclaimPolicy Retain) and
+  # runs a post-install hook that flips the cluster-default from the
+  # ephemeral k3s local-path to hcloud-volumes. WITHOUT this slot every
+  # Sovereign's PVCs (cnpg 3×100Gi prod-pg, openbao secrets, customer-Org
+  # DB, keycloak/gitea/harbor/loki/mimir/tempo) land on node-local disk →
+  # a node replacement destroys the data → the BCP/DR model is invalid
+  # (the P0 blocker). MUST be registered here or Flux never creates the
+  # HR (the #3191 forgotten-slot wedge class). Formerly slot 17a (REMOVED
+  # 2026-05-17 for a harbor-pull chicken-and-egg — see the slot-17a
+  # comment above); re-added here AFTER bp-harbor (19) so the pre-cutover
+  # ghcr pull never races harbor. Suspended on Huawei via HCLOUD_HR_SUSPEND
+  # (same gate as slot 55); Huawei EVS/everest CSI is a #3971 follow-up.
+  - 55a-bp-hcloud-csi.yaml
   # OpenovaFlow observability cohort — slots 56/57. Three-agent split
   # (Agent #1: TS @openova/flow-core + @openova/flow-canvas, Agent #2:
   # Go server + flux adapter, Agent #3: bootstrap-kit + catalyst-api

--- a/clusters/_template/bootstrap-kit/placement.yaml
+++ b/clusters/_template/bootstrap-kit/placement.yaml
@@ -143,6 +143,8 @@ spec:
        namespace: dmz, justification: "HOST-MINIMUM §4 — the DMZ vCluster runtime itself"}
     - {file: 55-bp-hcloud-ccm.yaml, hr: bp-hcloud-ccm, vcluster: host, target: host,
        namespace: kube-system, justification: "HOST-MINIMUM §4 — cloud controller manager"}
+    - {file: 55a-bp-hcloud-csi.yaml, hr: bp-hcloud-csi, vcluster: host, target: host,
+       namespace: hcloud-csi, justification: "HOST-MINIMUM §4 — cloud block-storage CSI; the durable default StorageClass (#3971)"}
     - {file: 58-bp-mgmt-vcluster.yaml, hr: bp-mgmt-vcluster, vcluster: host, target: host,
        namespace: mgmt, justification: "HOST-MINIMUM §4 — the MGMT vCluster runtime itself"}
     - {file: 59-bp-rtz-vcluster.yaml, hr: bp-rtz-vcluster, vcluster: host, target: host,
@@ -410,7 +412,7 @@ spec:
                   log_min_duration_statement: "1000"
               storage:
                 size: 5Gi
-                storageClass: local-path
+                storageClass: ""  # #3971 — empty ⇒ CNPG cluster-default durable cloud CSI; local-path FORBIDDEN
               enableSuperuserAccess: true
               monitoring:
                 enablePodMonitor: false
@@ -1054,7 +1056,7 @@ spec:
                   log_min_duration_statement: "1000"
               storage:
                 size: 5Gi
-                storageClass: local-path
+                storageClass: ""  # #3971 — empty ⇒ CNPG cluster-default durable cloud CSI; local-path FORBIDDEN
               enableSuperuserAccess: true
               monitoring:
                 enablePodMonitor: false
@@ -1274,7 +1276,7 @@ spec:
                   memory: 512Mi
               storage:
                 size: 5Gi
-                storageClass: local-path
+                storageClass: ""  # #3971 — empty ⇒ CNPG cluster-default durable cloud CSI; local-path FORBIDDEN
               enableSuperuserAccess: true
               monitoring:
                 enablePodMonitor: false

--- a/docs/sessions/2026-06-20/3971-huawei-everest-evs-csi-plan.md
+++ b/docs/sessions/2026-06-20/3971-huawei-everest-evs-csi-plan.md
@@ -1,0 +1,115 @@
+# #3971 — Huawei HCS (kom4dc) EVS / everest CSI: grounded follow-up plan
+
+**Status:** Hetzner path SHIPPED in this PR (bp-hcloud-csi bootstrap-kit slot
+55a + default-class flip + the provider-agnostic Phase-1 DoD gate). The Huawei
+EVS CSI path is **deliberately deferred** — the exact manifests/version/
+provisioner string for a **bare k3s** cluster on **HCS** (Huawei Cloud Stack,
+NOT public CCE) are not in-repo and not verifiable from here without a live
+kom4dc cluster to probe. This doc is the precise, grounded plan so the next
+session lands it without guessing.
+
+Per the #3971 instruction: *"If the Huawei everest CSI install is genuinely
+uncertain (manifests/version), implement the Hetzner hcloud-csi path fully +
+the default-SC flip + the DoD gate, and write a precise, grounded plan for the
+Huawei everest CSI (exact manifests/creds/slot) rather than guessing."*
+
+## Why the Hetzner gate already protects Huawei
+
+The Phase-1 DoD gate (`catalyst-api markPhase1Done`, #3971) is
+**provider-agnostic**: it probes the new Sovereign's default StorageClass and
+FAILS the prov if it is `rancher.io/local-path`. So a Huawei Sovereign that
+comes up before its EVS CSI lands will be honestly marked `failed` (not
+silently `ready` on ephemeral disk). The gate does NOT need a Huawei-specific
+change — it already catches the Huawei case. What's missing is the Huawei CSI
+itself so the gate goes GREEN there.
+
+## What's available (grounded in the repo today)
+
+- **Creds** — `flux-system/cloud-credentials` Secret already carries the
+  Huawei AK/SK on every HCS Sovereign (`infra/providers/huawei/main.tf`
+  `cloud_credentials_secret_yaml_huawei`, lines ~669-681):
+  - `huawei-ak` = `var.huawei_access_key`
+  - `huawei-sk` = `var.huawei_secret_key`
+  - `huawei-region` = `var.huawei_region`
+  - `huawei-project-id` — **NOTE a pre-existing bug**: line 679 sets it to
+    `${var.huawei_region}`, not `${var.huawei_project_id}`. The EVS CSI needs
+    the real project-id, so fix this line as part of the Huawei CSI PR (out of
+    scope for THIS #3971 Hetzner PR; flagged here so it isn't missed).
+- **Provider-keyed suspend gate** — the same `HUAWEI_HR_SUSPEND` /
+  `HCLOUD_HR_SUSPEND` envsubst pair that gates bp-velero-hcs (slot 34a) and
+  bp-hcloud-ccm (slot 55). The Huawei cloud-init sets `HUAWEI_HR_SUSPEND=false`
+  + `HCLOUD_HR_SUSPEND=true`; the Hetzner cloud-init the inverse. So a Huawei
+  CSI slot uses `suspend: ${HUAWEI_HR_SUSPEND:=true}` (default-suspended → a
+  Hetzner Sovereign never installs it).
+- **Object storage endpoint** — HCS OBS is reachable at
+  `https://obs.<region>.kom4dc.nationalcloud.om` (main.tf line 887), proving
+  the HCS API surface naming pattern for this private cloud.
+
+## The plan (next session, separate PR — Refs #3971)
+
+### 1. Vendor the everest EVS CSI as a Catalyst Blueprint chart
+
+Create `platform/huawei-evs-csi/` mirroring `platform/hcloud-csi/`:
+- `chart/Chart.yaml` — umbrella `bp-huawei-evs-csi`. The upstream is Huawei's
+  **everest-csi-driver** (EVS block storage). On HCS/CCE this is normally
+  delivered as the `everest` add-on; for a **bare k3s** cluster it must be
+  installed as raw manifests (the CCE add-on assumes CCE's metadata service).
+  The driver image + sidecars (`external-provisioner`, `external-attacher`,
+  `external-resizer`, `node-driver-registrar`, `livenessprobe`) come from
+  Huawei SWR (`swr.<region>.myhuaweicloud.com/everest/...` or the kom4dc SWR
+  mirror). **VERIFY the exact image tags against a live kom4dc node's
+  containerd / a Huawei HCS everest release before pinning** — do not guess the
+  tag.
+- `chart/templates/storageclass.yaml` — StorageClass `evs-ssd`:
+  - `provisioner: disk.csi.everest.io` (the everest EVS provisioner string —
+    **CONFIRM** against the live driver's CSIDriver object; some HCS builds use
+    `everest-csi-provisioner`).
+  - `parameters.type: SSD` (or `SAS`/`GPSSD` per the kom4dc EVS catalogue).
+  - `reclaimPolicy: Retain`, `volumeBindingMode: WaitForFirstConsumer`,
+    `allowVolumeExpansion: true` — same durability posture as hcloud-volumes.
+  - The default-class flip hook is REUSABLE verbatim from bp-hcloud-csi
+    (`default-class-hook.yaml` is provisioner-agnostic — it only needs the
+    target SC name); copy it and set `DEFAULT_SC=evs-ssd`.
+- `chart/templates/cloud-credentials.yaml` — render the everest cloud-config
+  Secret (`cloud-config` in kube-system) from `.Values.huaweiAK/SK/projectId/
+  region` populated via Flux `valuesFrom` against `cloud-credentials` (keys
+  `huawei-ak`/`huawei-sk`/`huawei-project-id`/`huawei-region`). everest reads
+  AK/SK + project + region to call the EVS OpenAPI.
+- `chart/templates/volumesnapshotclass.yaml` — `evs-snapshots`
+  (`driver: disk.csi.everest.io`) — EVS supports snapshots.
+
+### 2. Bootstrap-kit slot `55b-bp-huawei-evs-csi.yaml`
+
+Mirror `55a-bp-hcloud-csi.yaml` exactly, but:
+- `suspend: ${HUAWEI_HR_SUSPEND:=true}` (default-suspended; Huawei cloud-init
+  flips it false; Hetzner never installs it).
+- `values: { enabled: true, defaultStorageClass: true }`.
+- `valuesFrom` four entries pulling `huawei-ak`/`huawei-sk`/`huawei-project-id`/
+  `huawei-region` from `cloud-credentials` into the chart's value paths.
+- Register it in `kustomization.yaml` resources[] **and**
+  `scripts/expected-bootstrap-deps.yaml` (slot 55b, name `bp-huawei-evs-csi`,
+  `depends_on: []`, `wave: present`) — the drift guard requires both.
+
+### 3. Validate
+
+- `helm lint` + `helm template` the new chart (default-off renders zero;
+  enabled renders SC + driver + hook).
+- `kubectl kustomize clusters/_template/bootstrap-kit` green; `bash
+  scripts/check-bootstrap-deps.sh` 0 drift.
+- `scripts/lint-cloudinit.sh both` (no cloud-init change needed — the
+  HUAWEI_HR_SUSPEND substitute already exists).
+- The real proof is a **fresh zero-touch kom4dc prov**: `kubectl get sc` shows
+  `evs-ssd` default + local-path non-default, every stateful PVC Bound to an
+  EVS volume (verify the backing volume exists via the Huawei EVS OpenAPI), and
+  the Phase-1 DoD gate goes GREEN (no `default-storageclass-ephemeral` fail).
+
+## Open verification items (must confirm on a live kom4dc before pinning)
+
+1. Exact everest driver + sidecar **image tags** (SWR registry path + version).
+2. The CSIDriver **provisioner string** (`disk.csi.everest.io` vs
+   `everest-csi-provisioner`).
+3. The EVS **volume type** parameter values the kom4dc EVS catalogue exposes
+   (`SSD`/`SAS`/`GPSSD`/`ESSD`).
+4. Whether HCS everest on **bare k3s** needs the CCE metadata shim or runs with
+   AK/SK cloud-config alone (the CCE add-on path assumes CCE).
+5. Fix the `huawei-project-id` cloud-credentials bug (main.tf line 679).

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -942,8 +942,21 @@ runcmd:
   # wait specifically for the apiserver /healthz endpoint, not node-Ready).
   - 'until kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml get --raw /healthz; do sleep 5; done'
 
-  # local-path StorageClass is shipped by k3s; assert it + mark default
-  # before anything that PVCs.
+  # local-path StorageClass is shipped by k3s; assert it + mark default as a
+  # TRANSIENT bootstrap default so the very-early PVCs (created before any
+  # cloud CSI exists) have somewhere to bind.
+  #
+  # #3971 — local-path is EPHEMERAL (a directory on the node's local disk, no
+  # cloud block volume behind it). It is the default ONLY for the bootstrap
+  # window. The bootstrap-kit installs the per-provider cloud block-storage
+  # CSI (Hetzner: bp-hcloud-csi slot 55a → csi.hetzner.cloud + hcloud-volumes
+  # SC; Huawei: everest/EVS, #3971 follow-up) whose post-install hook PROMOTES
+  # the CSI class to cluster-default and DEMOTES this local-path default — so
+  # every STATEFUL PVC (which installs LATE, after bp-mgmt-vcluster /
+  # bp-cert-manager) lands on a DURABLE cloud volume. The Phase-1 DoD gate
+  # (catalyst-api markPhase1Done, #3971) FAILS the prov if the FINAL default
+  # is still local-path, so this transient default can never silently persist.
+  # local-path is LEFT installed (non-default) for genuinely-ephemeral caches.
   - 'until kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml get sc local-path >/dev/null 2>&1; do sleep 2; done'
   - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml patch storageclass local-path -p ''{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'''
   - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml get sc -o name | grep -q "^storageclass.storage.k8s.io/local-path$" || { echo "FATAL: local-path StorageClass missing after k3s install" >&2; exit 1; }'

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -614,6 +614,12 @@ write_files:
             SOVEREIGN_FQDN_SLUG: "${sovereign_fqdn_slug}"
             HUAWEI_HR_SUSPEND: "true"
             HCLOUD_HR_SUSPEND: "false"
+            # #3971 — drive bp-hcloud-csi's chart `enabled` toggle (slot 55a).
+            # Hetzner installs the real Hetzner Cloud CSI + the hcloud-volumes
+            # default StorageClass. The HR stays ACTIVE (never suspended) on
+            # BOTH providers so the stateful root slots (bp-cnpg / bp-mgmt-
+            # vcluster) can `dependsOn` it without deadlocking — see slot 55a.
+            HCLOUD_CSI_ENABLED: "true"
 %{ endif ~}
 %{ if provider == "huawei" ~}
             # Huawei: no cloud CCM. Cilium LB-IPAM assigns the clustermesh
@@ -623,6 +629,15 @@ write_files:
             # PDNS-host overrides + per-region HR suspension also flow here.
             HCLOUD_HR_SUSPEND: "true"
             HUAWEI_HR_SUSPEND: "false"
+            # #3971 — bp-hcloud-csi (slot 55a) stays ACTIVE on Huawei but with
+            # the chart `enabled=false`, so it installs an EMPTY release that
+            # reports Ready immediately (the dependsOn from the stateful root
+            # slots is satisfied without the suspended-HR deadlock). The Hetzner
+            # Cloud CSI obviously does NOT run on HCS; Huawei's durable default
+            # StorageClass (everest/EVS, slot 55b) is the #3971 follow-up. Until
+            # it lands, a Huawei prov has NO default class → the Phase-1
+            # storage-durability gate honestly FAILS it (never silent local-path).
+            HCLOUD_CSI_ENABLED: "false"
             SECONDARY_HR_SUSPEND: "${sovereign_region_role == "primary" ? "false" : "true"}"
             CILIUM_LB_IPAM_ENABLED: "true"
             CILIUM_LB_IPAM_CIDRS: "${node_external_ip_value}/32"
@@ -923,6 +938,19 @@ runcmd:
   # k3s_extra_args carries provider-specific server flags (OIDC, taints,
   # watch-cache tuning, topology labels). The CNI is disabled (Cilium owns
   # the network from first pod); flannel/servicelb/traefik all off.
+  #
+  # #3971 — `--disable=local-storage` FORBIDS the k3s local-path provisioner
+  # entirely: it is NEVER installed on a fresh prov. local-path is ephemeral
+  # node-local disk (no cloud block volume behind it) — any node replacement
+  # destroys the PV's data (prod Postgres 3×100Gi, openbao secrets, customer
+  # DB), invalidating BCP/DR. With the provisioner gone, the ONLY default
+  # StorageClass is the per-provider cloud CSI (Hetzner: bp-hcloud-csi slot
+  # 55a → csi.hetzner.cloud + hcloud-volumes). The stateful root slots
+  # (bp-cnpg / bp-mgmt-vcluster) `dependsOn: bp-hcloud-csi` so the CSI default
+  # class exists BEFORE any PVC binds — nothing hangs Pending. A belt-and-
+  # braces Kyverno ENFORCE policy (bp-kyverno-policies K23 forbid-local-path-
+  # storage) additionally DENIES any PVC/StorageClass/PV that references
+  # local-path. (founder: "local path never ever ALLOWED".)
   - |
     NODE_EXTERNAL_IP=$(${node_external_ip_cmd})
     [ -n "$${NODE_EXTERNAL_IP}" ] || { echo "[k3s] FATAL: could not determine node external IP" >&2; exit 87; }
@@ -935,31 +963,23 @@ runcmd:
     curl -sfL https://get.k3s.io | \
       INSTALL_K3S_VERSION=${k3s_version} \
       K3S_TOKEN=${k3s_token} \
-      INSTALL_K3S_EXEC="server --cluster-init --flannel-backend=none --disable-network-policy --disable=traefik --disable=servicelb --cluster-cidr=${cluster_cidr} --service-cidr=${service_cidr} --node-ip=$${NODE_IP} --node-external-ip=$${NODE_EXTERNAL_IP} --advertise-address=$${NODE_IP} --kubelet-arg=max-pods=220 --tls-san=${sovereign_fqdn} --tls-san=$${NODE_IP} --tls-san=$${NODE_EXTERNAL_IP} --node-label catalyst.openova.io/role=control-plane --node-label openova.io/region=${region_canonical_label} ${k3s_extra_args} --write-kubeconfig-mode=0644" \
+      INSTALL_K3S_EXEC="server --cluster-init --flannel-backend=none --disable-network-policy --disable=traefik --disable=servicelb --disable=local-storage --cluster-cidr=${cluster_cidr} --service-cidr=${service_cidr} --node-ip=$${NODE_IP} --node-external-ip=$${NODE_EXTERNAL_IP} --advertise-address=$${NODE_IP} --kubelet-arg=max-pods=220 --tls-san=${sovereign_fqdn} --tls-san=$${NODE_IP} --tls-san=$${NODE_EXTERNAL_IP} --node-label catalyst.openova.io/role=control-plane --node-label openova.io/region=${region_canonical_label} ${k3s_extra_args} --write-kubeconfig-mode=0644" \
       sh -
 
   # Wait for the API server to be reachable (Cilium comes up later, so we
   # wait specifically for the apiserver /healthz endpoint, not node-Ready).
   - 'until kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml get --raw /healthz; do sleep 5; done'
 
-  # local-path StorageClass is shipped by k3s; assert it + mark default as a
-  # TRANSIENT bootstrap default so the very-early PVCs (created before any
-  # cloud CSI exists) have somewhere to bind.
-  #
-  # #3971 — local-path is EPHEMERAL (a directory on the node's local disk, no
-  # cloud block volume behind it). It is the default ONLY for the bootstrap
-  # window. The bootstrap-kit installs the per-provider cloud block-storage
-  # CSI (Hetzner: bp-hcloud-csi slot 55a → csi.hetzner.cloud + hcloud-volumes
-  # SC; Huawei: everest/EVS, #3971 follow-up) whose post-install hook PROMOTES
-  # the CSI class to cluster-default and DEMOTES this local-path default — so
-  # every STATEFUL PVC (which installs LATE, after bp-mgmt-vcluster /
-  # bp-cert-manager) lands on a DURABLE cloud volume. The Phase-1 DoD gate
-  # (catalyst-api markPhase1Done, #3971) FAILS the prov if the FINAL default
-  # is still local-path, so this transient default can never silently persist.
-  # local-path is LEFT installed (non-default) for genuinely-ephemeral caches.
-  - 'until kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml get sc local-path >/dev/null 2>&1; do sleep 2; done'
-  - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml patch storageclass local-path -p ''{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'''
-  - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml get sc -o name | grep -q "^storageclass.storage.k8s.io/local-path$" || { echo "FATAL: local-path StorageClass missing after k3s install" >&2; exit 1; }'
+  # #3971 — NO StorageClass is provisioned here. k3s ran with
+  # `--disable=local-storage` (above) so the ephemeral local-path provisioner
+  # is FORBIDDEN — it is never installed. The cluster comes up with ZERO
+  # StorageClasses; the per-provider cloud block-storage CSI (Hetzner:
+  # bp-hcloud-csi slot 55a) installs the durable default `hcloud-volumes` SC
+  # via Flux. The stateful root slots (bp-cnpg / bp-mgmt-vcluster) gate on
+  # `dependsOn: bp-hcloud-csi`, so the default class exists before the first
+  # PVC binds (no Pending-PVC regression). The former `kubectl patch sc
+  # local-path is-default-class=true` block that lived here is DELETED —
+  # asserting/defaulting local-path is exactly the anti-pattern #3971 forbids.
 
 %{ if deployment_id != "" && kubeconfig_bearer_token != "" && catalyst_api_url != "" ~}
   # ══════════════════════════════════════════════════════════════════════

--- a/platform/bp-dmz-vcluster/blueprint.yaml
+++ b/platform/bp-dmz-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.8
+  version: 0.2.9
   card:
     title: DMZ vCluster
     summary: |

--- a/platform/bp-dmz-vcluster/chart/Chart.yaml
+++ b/platform/bp-dmz-vcluster/chart/Chart.yaml
@@ -51,7 +51,8 @@ name: bp-dmz-vcluster
 # mints no host-side DB/SSO Secret, so no fromHost.secrets mapping is needed
 # here. Syncer image tag bumped to 0.23.0 to match. Default render unchanged
 # in shape (still default-OFF; subchart version only).
-version: 0.2.8
+# 0.2.9 (#3971): vCluster etcd storageClass empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN.
+version: 0.2.9
 appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign DMZ

--- a/platform/bp-dmz-vcluster/chart/values.yaml
+++ b/platform/bp-dmz-vcluster/chart/values.yaml
@@ -147,7 +147,7 @@ vcluster:
         volumeClaim:
           enabled: true
           size: "5Gi"
-          storageClass: "local-path"
+          storageClass: ""  # #3971 — empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN
     service:
       enabled: true
       spec:

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.28
+  version: 0.2.29
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -349,7 +349,8 @@ name: bp-mgmt-vcluster
 # All additions are additive / no-op-until-the-source-renders (the established
 # replicateServices + fromHost-secrets semantics). #3951 (gitea-token-mint
 # 403-tolerant probe) is folded into bp-catalyst-platform, NOT here.
-version: 0.2.28
+# 0.2.29 (#3971): vCluster etcd storageClass empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN.
+version: 0.2.29
 appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -362,7 +362,7 @@ vcluster:
         volumeClaim:
           enabled: true
           size: "5Gi"
-          storageClass: "local-path"
+          storageClass: ""  # #3971 — empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN
     service:
       enabled: true
       spec:

--- a/platform/bp-rtz-vcluster/blueprint.yaml
+++ b/platform/bp-rtz-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.13
+  version: 0.2.14
   card:
     title: RTZ vCluster
     summary: |

--- a/platform/bp-rtz-vcluster/chart/Chart.yaml
+++ b/platform/bp-rtz-vcluster/chart/Chart.yaml
@@ -67,7 +67,8 @@ name: bp-rtz-vcluster
 # (valkey/seaweedfs/vllm) mint no host-side DB/SSO Secret, so no
 # fromHost.secrets mapping is needed here. Syncer image tag bumped to 0.23.0
 # to match. Default render unchanged in shape (subchart version only).
-version: 0.2.13
+# 0.2.14 (#3971): vCluster etcd storageClass empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN.
+version: 0.2.14
 appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign RTZ

--- a/platform/bp-rtz-vcluster/chart/values.yaml
+++ b/platform/bp-rtz-vcluster/chart/values.yaml
@@ -177,7 +177,7 @@ vcluster:
         volumeClaim:
           enabled: true
           size: "5Gi"
-          storageClass: "local-path"
+          storageClass: ""  # #3971 — empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN
     service:
       enabled: true
       spec:

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.39
+  version: 1.2.40
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -152,7 +152,8 @@ name: bp-gitea
 # in-vCluster Secret) while sso.enabled stays true so the Deployment renders
 # IN the vCluster and seeds the row (its creds cross in via bp-mgmt-vcluster
 # sync.fromHost). Non-host-bridged render is byte-identical. Refs #3374 #3642.
-version: 1.2.39
+# 1.2.40 (#3971): CNPG storageClass empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN.
+version: 1.2.40
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/templates/cnpg-cluster.yaml
+++ b/platform/gitea/chart/templates/cnpg-cluster.yaml
@@ -120,7 +120,10 @@ spec:
 
   storage:
     size: {{ .Values.postgres.cluster.storageSize | default "5Gi" }}
-    storageClass: {{ .Values.postgres.cluster.storageClass | default "local-path" | quote }}
+    # #3971 — empty ⇒ omit ⇒ CNPG uses the cluster-default durable cloud CSI; local-path FORBIDDEN.
+    {{- with .Values.postgres.cluster.storageClass }}
+    storageClass: {{ . | quote }}
+    {{- end }}
 
   enableSuperuserAccess: true
 

--- a/platform/gitea/chart/values.yaml
+++ b/platform/gitea/chart/values.yaml
@@ -263,7 +263,7 @@ postgres:
     database: gitea
     owner: gitea
     storageSize: 5Gi
-    storageClass: local-path
+    storageClass: ""  # #3971 — empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN
     resources:
       requests:
         cpu: 100m

--- a/platform/guacamole/blueprint.yaml
+++ b/platform/guacamole/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/category: platform
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.25
+  version: 0.2.26
   card:
     title: Apache Guacamole
     summary: Clientless HTML5 remote-desktop gateway. Browser-based RDP / VNC / SSH and kubectl-exec into Pods, with Keycloak SSO and full session recording to SeaweedFS. One Guacamole per Sovereign per ADR-0001 §11.

--- a/platform/guacamole/chart/Chart.yaml
+++ b/platform/guacamole/chart/Chart.yaml
@@ -197,7 +197,8 @@ name: bp-guacamole
 # readTopology serves spec.placement VERBATIM to the Topology tab + the
 # Instances-table chip, so the legacy spelling leaked the banned word to the
 # operator (hw159 #3375).
-version: 0.2.25
+# 0.2.26 (#3971): CNPG storageClass empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN.
+version: 0.2.26
 appVersion: "1.5.5"
 description: |
   Catalyst-authored Blueprint chart for Apache Guacamole — a clientless

--- a/platform/guacamole/chart/templates/cnpg-cluster.yaml
+++ b/platform/guacamole/chart/templates/cnpg-cluster.yaml
@@ -72,7 +72,10 @@ spec:
     {{- toYaml ($cl.resources | default (dict "requests" (dict "cpu" "50m" "memory" "128Mi") "limits" (dict "memory" "512Mi"))) | nindent 4 }}
   storage:
     size: {{ $cl.storageSize | default "5Gi" }}
-    storageClass: {{ $cl.storageClass | default "local-path" | quote }}
+    # #3971 — empty ⇒ omit ⇒ CNPG uses the cluster-default durable cloud CSI; local-path FORBIDDEN.
+    {{- with $cl.storageClass }}
+    storageClass: {{ . | quote }}
+    {{- end }}
   enableSuperuserAccess: true
   monitoring:
     enablePodMonitor: false

--- a/platform/guacamole/chart/values.yaml
+++ b/platform/guacamole/chart/values.yaml
@@ -196,7 +196,7 @@ guacamole:
       imageName: harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql
       pgVersion: "16"
       storageSize: 5Gi
-      storageClass: local-path
+      storageClass: ""  # #3971 — empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN
       resources:
         requests:
           cpu: 50m

--- a/platform/harbor/blueprint.yaml
+++ b/platform/harbor/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-5-storage-and-data
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.34
+  version: 1.2.35
   card:
     title: Harbor
     family: foundation

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -122,7 +122,8 @@ type: application
 # externalSecret.enabled:false (host renders harbor-sso-oidc-credentials) while
 # sso.enabled stays true so the configurator runs IN the vCluster against
 # harbor-core. Non-host-bridged render byte-identical. Refs #3374 #3642.
-version: 1.2.34
+# 1.2.35 (#3971): CNPG storageClass empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN.
+version: 1.2.35
 appVersion: "2.14.3"
 # 1.2.23 (G117.5 #2744, 2026-06-02): SSO defense-in-depth via Harbor's
 # `oidc_extra_redirect_parms` config field. The configure-oauth Job now

--- a/platform/harbor/chart/templates/cnpg-cluster.yaml
+++ b/platform/harbor/chart/templates/cnpg-cluster.yaml
@@ -100,7 +100,10 @@ spec:
 
   storage:
     size: {{ .Values.postgres.cluster.storageSize | default "5Gi" }}
-    storageClass: {{ .Values.postgres.cluster.storageClass | default "local-path" | quote }}
+    # #3971 — empty ⇒ omit ⇒ CNPG uses the cluster-default durable cloud CSI; local-path FORBIDDEN.
+    {{- with .Values.postgres.cluster.storageClass }}
+    storageClass: {{ . | quote }}
+    {{- end }}
 
   enableSuperuserAccess: true
 

--- a/platform/harbor/chart/values.yaml
+++ b/platform/harbor/chart/values.yaml
@@ -570,7 +570,7 @@ postgres:
     namespace: harbor
     instances: 1                  # bump to 3 alongside HA overlay once beyond Phase-0
     storageSize: 5Gi
-    storageClass: local-path      # Contabo k3s default; Hetzner Sovereign overlays → hcloud-volumes
+    storageClass: ""  # #3971 — empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN
     # CNPG postgres image. Defaults to the mothership Harbor proxy cache
     # (harbor.openova.io/proxy-ghcr) so fresh-prov bootstrap pulls the
     # ~300MB image through Harbor instead of throttling on anonymous ghcr

--- a/platform/hcloud-csi/README.md
+++ b/platform/hcloud-csi/README.md
@@ -1,27 +1,41 @@
 # bp-hcloud-csi
 
-**Status**: Phase-0 scaffold (#1095 slice H6). Activated by EPIC-6 (#1101).
-**Updated**: 2026-05-08
+**Status**: Bootstrap-kit slot 55a (#3971) — installed on every fresh Hetzner
+Sovereign as the cluster-default StorageClass. (Was Phase-0 scaffold #1095
+slice H6 / EPIC-6 #1101.)
+**Updated**: 2026-06-20
 
 Upstream Hetzner Cloud CSI driver (`hetznercloud/csi-driver`) wrapped as a
 Catalyst Blueprint. Provides the `hcloud-volumes` StorageClass that backs
-multi-node stateful workloads on Hetzner Sovereigns — required for CNPG
-primary/replica pairs across nodes (and across regions, once Cilium
-ClusterMesh + Continuum land in #1101).
+ALL stateful workloads on Hetzner Sovereigns (CNPG primary/replica pairs,
+openbao, keycloak, gitea, harbor, loki/mimir/tempo) — durable cloud block
+volumes instead of ephemeral node-local disk.
 
-This Blueprint is **not** in the bootstrap-kit. The default StorageClass on
-existing Sovereigns is `local-path` (single-node-bound) — installing this
-chart with `defaultStorageClass: true` flips the default to `hcloud-volumes`,
-which would migrate every new PVC. Operators activate deliberately per
-Sovereign once the upgrade path for existing PVCs is sized.
+**In the bootstrap-kit (#3971).** The HelmRelease at
+`clusters/_template/bootstrap-kit/55a-bp-hcloud-csi.yaml` installs this chart
+on every fresh **Hetzner** Sovereign with `enabled: true` +
+`defaultStorageClass: true` (suspended on Huawei via `HCLOUD_HR_SUSPEND`). A
+post-install hook promotes `hcloud-volumes` to cluster-default and DEMOTES the
+k3s `local-path` default — so production PVCs never land on ephemeral disk.
+The Phase-1 DoD gate in catalyst-api (`markPhase1Done`) FAILS a prov whose
+final default StorageClass is still `local-path`, so this can never silently
+regress. local-path stays installed (non-default) for genuinely-ephemeral
+caches.
+
+> **The P0 blocker it closes (#3971):** before this slot, k3s `local-path` was
+> the default and ONLY StorageClass on every Sovereign — a directory on the
+> node's local disk with no cloud volume behind it. A node replacement
+> (autoscaler, failed node, re-prov, disk loss) destroyed that PV's data,
+> including prod Postgres (3×100Gi), openbao secrets, and the customer-Org DB.
 
 ## What it ships
 
 | Template | Effect |
 |---|---|
-| `storageclass.yaml` | StorageClass `hcloud-volumes` with `WaitForFirstConsumer` binding (Pod scheduling pins the volume to the right node) and `allowVolumeExpansion: true`. Optional `volumeBindingMode: Immediate` override for use cases that need pre-provisioning. |
-| `storageclass-default.yaml` | Annotates `hcloud-volumes` as the cluster default when `.Values.defaultStorageClass: true`. |
-| `volumesnapshotclass.yaml` | VolumeSnapshotClass for backup workflows. Default off. |
+| `storageclass.yaml` | StorageClass `hcloud-volumes` — `reclaimPolicy: Retain` (production-data durability: the backing Hetzner Volume survives PVC/PV deletion), `WaitForFirstConsumer` binding (pins the volume to the Pod's node), `allowVolumeExpansion: true`. |
+| `default-class-hook.yaml` + `default-class-hook-rbac.yaml` | Post-install hook Job (+ scoped ClusterRole) that promotes `hcloud-volumes` to cluster-default and demotes the k3s `local-path` default so there is exactly ONE durable default class. |
+| `volumesnapshotclass.yaml` | VolumeSnapshotClass `hcloud-volumes-snapshots` for storage-level DR / backup workflows. Default ON (#3971). |
+| `hcloud-token-secret.yaml` | Renders the `hcloud-csi-token` Secret from the Hetzner API token (Flux `valuesFrom` cloud-credentials) so the controller authenticates. |
 
 Upstream `hcloud-csi-driver` itself is pulled in as a Helm subchart from
 `hetznercloud/csi-driver` (referenced in `Chart.yaml`). The catalyst overlay
@@ -29,22 +43,25 @@ templates above sit alongside it.
 
 ## Activation contract
 
+The bootstrap-kit slot (55a) already sets these on every Hetzner Sovereign;
+this is the values shape if you hand-override per Sovereign:
+
 ```yaml
 # values.yaml override (or per-Sovereign overlay)
 enabled: true
 defaultStorageClass: true              # flip the cluster default
-hcloudCsi:
-  controller:
-    replicas: 2                        # HA for multi-node Sovereigns
-  storageClasses:
-    - name: hcloud-volumes
-      reclaimPolicy: Delete
-      volumeBindingMode: WaitForFirstConsumer
-      allowVolumeExpansion: true
+hetznerToken: "<from cloud-credentials via Flux valuesFrom>"
+catalystStorageClasses:
+  - name: hcloud-volumes
+    reclaimPolicy: Retain                # production-data durability (#3971)
+    volumeBindingMode: WaitForFirstConsumer
+    allowVolumeExpansion: true
+volumeSnapshotClass:
+  enabled: true                         # storage-level DR (#3971)
 ```
 
-When `enabled: false` (the default), no resources render — installing the
-chart is a no-op until the operator opts in.
+When `enabled: false` (the chart default), no resources render — the chart is
+a no-op. The bootstrap-kit slot is what flips `enabled: true` on Hetzner.
 
 ## Why a separate Blueprint, not a values toggle on bp-cilium
 
@@ -52,13 +69,26 @@ CSI drivers are independent of CNI. Mixing them risks coupling the network
 plane upgrade cycle to the storage plane upgrade cycle. Separate Blueprint
 keeps the surfaces independent.
 
-## Why default-OFF on `defaultStorageClass`
+## Default-class flip + local-path demotion (#3971)
 
-Flipping the cluster's default StorageClass is a destructive change for
-Pods relying on the previous default's volume-binding semantics. Existing
-Sovereigns ship with `local-path` as default; an in-place migration plan
-(drain, repvc, copy-data) is its own slice. Keeping `defaultStorageClass:
-false` here ensures installing the chart is reversible.
+The **chart's** `defaultStorageClass` value defaults to `false` (so a bare
+`helm install` is reversible), but the **bootstrap-kit slot 55a** sets it
+`true` on every Hetzner Sovereign. When true:
+
+- The `hcloud-volumes` StorageClass renders with the
+  `storageclass.kubernetes.io/is-default-class: "true"` annotation.
+- A post-install hook Job (`default-class-hook.yaml`) waits for the SC to
+  exist, then promotes it to default and **demotes** the k3s `local-path`
+  default (strips its default annotation) so there is exactly ONE default.
+- `local-path` is left INSTALLED but non-default — genuinely-ephemeral caches
+  can still opt in with `storageClassName: local-path`.
+
+On a FRESH prov this is non-destructive: the stateful slots (openbao,
+keycloak, gitea, cnpg) install LATE (after their `dependsOn` chains on
+bp-mgmt-vcluster / bp-cert-manager), by which time the CSI default-class flip
+has already run, so their PVCs bind to the durable `hcloud-volumes` class.
+Migrating an EXISTING Sovereign's local-path data is out of scope (destructive,
+separate) — the durable fix is the bootstrap so every fresh prov is correct.
 
 ## References
 

--- a/platform/hcloud-csi/blueprint.yaml
+++ b/platform/hcloud-csi/blueprint.yaml
@@ -7,13 +7,15 @@ metadata:
   annotations:
     catalyst.openova.io/provider: hetzner
 spec:
-  version: 1.1.0
+  version: 1.2.0
   card:
     title: Hetzner Cloud CSI
     summary: |
       Hetzner Cloud CSI driver providing the hcloud-volumes StorageClass.
       Required for multi-node stateful workloads (CNPG primary/replica
-      pairs) on Hetzner Sovereigns. Activated by EPIC-6 (#1101).
+      pairs) on Hetzner Sovereigns. Bootstrap-kit slot 55a (#3971) installs
+      it on every fresh Hetzner Sovereign as the cluster-default SC so
+      production PVCs never land on ephemeral k3s local-path.
     family: storage
     documentation: ./README.md
   visibility: unlisted

--- a/platform/hcloud-csi/blueprint.yaml
+++ b/platform/hcloud-csi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     catalyst.openova.io/provider: hetzner
 spec:
-  version: 1.2.0
+  version: 1.2.1
   card:
     title: Hetzner Cloud CSI
     summary: |

--- a/platform/hcloud-csi/chart/Chart.yaml
+++ b/platform/hcloud-csi/chart/Chart.yaml
@@ -12,7 +12,11 @@ name: bp-hcloud-csi
 # StorageClass to hcloud-volumes. The default SC now uses reclaimPolicy
 # Retain (production-data durability) and ships the VolumeSnapshotClass ON.
 # Closes the P0 blocker where every PVC landed on ephemeral k3s local-path.
-version: 1.2.0
+# 1.2.1 (2026-06-20 #3971): default-class-hook comment updated for the
+# local-path-FORBIDDEN model (k3s --disable=local-storage + Kyverno deny):
+# on a fresh prov the hook's demote step is a no-op (local-path never exists);
+# it only heals an UPGRADE from a pre-#3971 cluster with a stale default.
+version: 1.2.1
 description: |
   Catalyst-curated Blueprint umbrella chart for the Hetzner Cloud CSI
   driver. Provides the hcloud-volumes StorageClass for multi-node stateful

--- a/platform/hcloud-csi/chart/Chart.yaml
+++ b/platform/hcloud-csi/chart/Chart.yaml
@@ -7,7 +7,12 @@ name: bp-hcloud-csi
 # pods cannot authenticate to the Hetzner API; the StorageClass exists
 # but every PVC fails to provision with a 401 from the CSI driver.
 # Mirrors bp-hcloud-ccm 1.0.0 wiring.
-version: 1.1.0
+# 1.2.0 (2026-06-20 #3971): wire into the bootstrap-kit (slot 55a) so EVERY
+# fresh Hetzner Sovereign installs the CSI + flips the cluster-default
+# StorageClass to hcloud-volumes. The default SC now uses reclaimPolicy
+# Retain (production-data durability) and ships the VolumeSnapshotClass ON.
+# Closes the P0 blocker where every PVC landed on ephemeral k3s local-path.
+version: 1.2.0
 description: |
   Catalyst-curated Blueprint umbrella chart for the Hetzner Cloud CSI
   driver. Provides the hcloud-volumes StorageClass for multi-node stateful

--- a/platform/hcloud-csi/chart/templates/default-class-hook-rbac.yaml
+++ b/platform/hcloud-csi/chart/templates/default-class-hook-rbac.yaml
@@ -1,0 +1,68 @@
+{{- /*
+RBAC for the default-StorageClass flip hook (#3971).
+
+A post-install/post-upgrade Job (templates/default-class-hook.yaml) demotes
+k3s `local-path` from cluster-default and promotes `hcloud-volumes` so EVERY
+Sovereign ends with the cloud-block-storage CSI as the one default class.
+Patching a cluster-scoped StorageClass needs a ClusterRole + binding.
+
+Gated on the SAME .Values.enabled + .Values.defaultStorageClass pair as the
+hook itself so a default-off render emits ZERO resources (smoke-render guard).
+
+hook-weight -5 (lower/earlier than the Job's 0) so the SA + ClusterRole +
+Binding land BEFORE the Job that consumes them. hook-delete-policy keeps the
+namespace tidy across re-installs.
+*/}}
+{{- if and .Values.enabled .Values.defaultStorageClass }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-default-class
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: bp-hcloud-csi
+    app.kubernetes.io/component: default-class-hook
+    catalyst.openova.io/blueprint: bp-hcloud-csi
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-default-class
+  labels:
+    app.kubernetes.io/name: bp-hcloud-csi
+    app.kubernetes.io/component: default-class-hook
+    catalyst.openova.io/blueprint: bp-hcloud-csi
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-default-class
+  labels:
+    app.kubernetes.io/name: bp-hcloud-csi
+    app.kubernetes.io/component: default-class-hook
+    catalyst.openova.io/blueprint: bp-hcloud-csi
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-default-class
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-default-class
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/platform/hcloud-csi/chart/templates/default-class-hook.yaml
+++ b/platform/hcloud-csi/chart/templates/default-class-hook.yaml
@@ -1,0 +1,133 @@
+{{- /*
+Default-StorageClass flip hook — bp-hcloud-csi (#3971).
+
+THE FIX
+=======
+k3s ships `local-path` (rancher.io/local-path) and cloud-init marks it the
+cluster-default during the bootstrap window so the very-early PVCs (before any
+CSI exists) have SOMEWHERE to bind. local-path is a directory on the node's
+local disk — NO cloud block volume behind it — so any node replacement
+destroys that data. The P0 blocker (#3971) is that EVERY Sovereign's PVCs
+landed on local-path because no CSI was ever installed.
+
+This post-install/post-upgrade Job runs AFTER the hcloud-volumes StorageClass
+(templates/storageclass.yaml) and the CSI controller have landed. It:
+  1. Waits (bounded) for the `hcloud-volumes` SC to exist.
+  2. Promotes `hcloud-volumes` to cluster-default (idempotent — the SC may
+     already carry the annotation when .Values.defaultStorageClass renders it
+     directly; this guarantees it even if a prior local-path default lingers).
+  3. DEMOTES every OTHER StorageClass that still carries the default-class
+     annotation (i.e. `local-path`) so there is EXACTLY ONE default. Two
+     defaults is an error state Kubernetes resolves non-deterministically.
+
+local-path is LEFT INSTALLED (non-default) so genuinely-ephemeral caches can
+still opt in via `storageClassName: local-path`. Stateful PVCs (which omit
+storageClassName) now bind to the durable cloud-block default.
+
+Why a hook (not a static manifest): a Helm chart cannot annotate a foreign
+StorageClass (`local-path`) it does not own without adopting it. A short Job
+with a scoped ClusterRole patches both classes idempotently and self-deletes.
+
+Gated on .Values.enabled + .Values.defaultStorageClass so a default-off render
+emits ZERO resources. Fails FAST (300s) so a broken CSI surfaces in Flux
+conditions, not a 15-minute spin. backoffLimit 0 + hook-delete-policy keeps it
+clean across re-installs.
+*/}}
+{{- if and .Values.enabled .Values.defaultStorageClass }}
+{{- $defaultSC := "hcloud-volumes" -}}
+{{- if .Values.catalystStorageClasses }}
+{{-   $defaultSC = (index .Values.catalystStorageClasses 0).name -}}
+{{- end -}}
+{{- $timeout := 300 -}}
+{{- $interval := 3 -}}
+{{- $image := "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7" -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-default-class
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: bp-hcloud-csi
+    app.kubernetes.io/component: default-class-hook
+    catalyst.openova.io/blueprint: bp-hcloud-csi
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bp-hcloud-csi
+        app.kubernetes.io/component: default-class-hook
+    spec:
+      serviceAccountName: {{ .Release.Name }}-default-class
+      restartPolicy: Never
+      containers:
+        - name: flip
+          image: {{ $image | quote }}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests: { cpu: 25m, memory: 32Mi }
+            limits: { memory: 96Mi }
+          env:
+            - name: DEFAULT_SC
+              value: {{ $defaultSC | quote }}
+            - name: TIMEOUT_SECONDS
+              value: {{ $timeout | quote }}
+            - name: INTERVAL_SECONDS
+              value: {{ $interval | quote }}
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              set -euo pipefail
+              DEFAULT_ANN='storageclass.kubernetes.io/is-default-class'
+              echo "bp-hcloud-csi default-class flip: target default = ${DEFAULT_SC} (budget=${TIMEOUT_SECONDS}s)"
+
+              # 1. Wait (bounded) for the CSI StorageClass to exist.
+              deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+              until kubectl get storageclass "${DEFAULT_SC}" >/dev/null 2>&1; do
+                if [ "$(date +%s)" -ge "${deadline}" ]; then
+                  echo "FATAL: StorageClass ${DEFAULT_SC} never appeared within ${TIMEOUT_SECONDS}s." >&2
+                  echo "The hcloud-csi controller / StorageClass did not install — inspect the bp-hcloud-csi HelmRelease." >&2
+                  exit 1
+                fi
+                echo "waiting for StorageClass ${DEFAULT_SC} ..."
+                sleep "${INTERVAL_SECONDS}"
+              done
+
+              # 2. Promote the CSI class to cluster-default (idempotent).
+              kubectl annotate storageclass "${DEFAULT_SC}" \
+                "${DEFAULT_ANN}=true" --overwrite
+              echo "promoted ${DEFAULT_SC} to cluster-default."
+
+              # 3. Demote every OTHER class still flagged default (e.g. local-path)
+              #    so there is EXACTLY ONE default class. Non-fatal if none exist
+              #    (operator may have run k3s with --disable local-storage).
+              others="$(kubectl get storageclass \
+                -o jsonpath="{range .items[?(@.metadata.annotations.${DEFAULT_ANN}=='true')]}{.metadata.name}{'\n'}{end}" \
+                2>/dev/null || true)"
+              for sc in ${others}; do
+                [ "${sc}" = "${DEFAULT_SC}" ] && continue
+                echo "demoting stale default StorageClass: ${sc}"
+                kubectl annotate storageclass "${sc}" \
+                  "${DEFAULT_ANN}=false" --overwrite || true
+              done
+
+              echo "default-class flip complete. Final defaults:"
+              kubectl get storageclass \
+                -o custom-columns='NAME:.metadata.name,DEFAULT:.metadata.annotations.storageclass\.kubernetes\.io/is-default-class' \
+                2>/dev/null || true
+{{- end }}

--- a/platform/hcloud-csi/chart/templates/default-class-hook.yaml
+++ b/platform/hcloud-csi/chart/templates/default-class-hook.yaml
@@ -3,30 +3,35 @@ Default-StorageClass flip hook — bp-hcloud-csi (#3971).
 
 THE FIX
 =======
-k3s ships `local-path` (rancher.io/local-path) and cloud-init marks it the
-cluster-default during the bootstrap window so the very-early PVCs (before any
-CSI exists) have SOMEWHERE to bind. local-path is a directory on the node's
-local disk — NO cloud block volume behind it — so any node replacement
-destroys that data. The P0 blocker (#3971) is that EVERY Sovereign's PVCs
-landed on local-path because no CSI was ever installed.
+local-path is a directory on the node's local disk — NO cloud block volume
+behind it — so any node replacement destroys that data. The P0 blocker (#3971)
+is that EVERY Sovereign's PVCs landed on local-path because no CSI was ever
+installed. The durable fix FORBIDS local-path entirely: k3s now runs
+`--disable=local-storage` (cloud-init) so the local-path provisioner is NEVER
+installed, and the only default StorageClass is the cloud CSI's hcloud-volumes.
 
 This post-install/post-upgrade Job runs AFTER the hcloud-volumes StorageClass
 (templates/storageclass.yaml) and the CSI controller have landed. It:
   1. Waits (bounded) for the `hcloud-volumes` SC to exist.
   2. Promotes `hcloud-volumes` to cluster-default (idempotent — the SC may
      already carry the annotation when .Values.defaultStorageClass renders it
-     directly; this guarantees it even if a prior local-path default lingers).
+     directly; this guarantees it even on an UPGRADE of a pre-#3971 cluster
+     where a stale local-path default may still linger).
   3. DEMOTES every OTHER StorageClass that still carries the default-class
-     annotation (i.e. `local-path`) so there is EXACTLY ONE default. Two
-     defaults is an error state Kubernetes resolves non-deterministically.
+     annotation so there is EXACTLY ONE default. On a FRESH prov this is a
+     harmless no-op (local-path was never installed). On an UPGRADE of an
+     older cluster it strips a lingering local-path default. Two defaults is
+     an error state Kubernetes resolves non-deterministically.
 
-local-path is LEFT INSTALLED (non-default) so genuinely-ephemeral caches can
-still opt in via `storageClassName: local-path`. Stateful PVCs (which omit
-storageClassName) now bind to the durable cloud-block default.
+Note: on a fresh prov local-path does not exist at all (k3s
+--disable=local-storage), and a Kyverno ENFORCE policy
+(bp-kyverno-policies K23) DENIES any attempt to (re)create it. This hook's
+demote step exists only to heal an UPGRADE from a pre-#3971 cluster that
+already had a local-path default annotated.
 
 Why a hook (not a static manifest): a Helm chart cannot annotate a foreign
-StorageClass (`local-path`) it does not own without adopting it. A short Job
-with a scoped ClusterRole patches both classes idempotently and self-deletes.
+StorageClass it does not own without adopting it. A short Job with a scoped
+ClusterRole patches the classes idempotently and self-deletes.
 
 Gated on .Values.enabled + .Values.defaultStorageClass so a default-off render
 emits ZERO resources. Fails FAST (300s) so a broken CSI surfaces in Flux

--- a/platform/hcloud-csi/chart/values.yaml
+++ b/platform/hcloud-csi/chart/values.yaml
@@ -38,20 +38,30 @@ hetznerToken: ""
 # Sovereign without editing this chart. Named `catalystStorageClasses`
 # to avoid collision with the upstream `hcloud-csi.storageClasses` key
 # (different shape — upstream has its own list under that name).
+#
+# #3971 — reclaimPolicy is `Retain` (NOT `Delete`): the FIRST entry is the
+# cluster-default SC for EVERY stateful PVC on the Sovereign (cnpg 3×100Gi,
+# openbao secrets, customer-Org DB, …). `Retain` keeps the backing Hetzner
+# Cloud Volume alive when a PVC/PV is deleted (node replacement, autoscaler
+# churn, accidental PVC delete) so production data survives — the durable
+# fix for the P0 "PVCs land on ephemeral local-path" blocker. Operators
+# reclaim a `Released` PV's volume deliberately (it is never auto-deleted).
 catalystStorageClasses:
   - name: hcloud-volumes
-    reclaimPolicy: Delete
+    reclaimPolicy: Retain
     volumeBindingMode: WaitForFirstConsumer
     allowVolumeExpansion: true
     parameters: {}
 
-# VolumeSnapshotClass for backup workflows (Velero etc.). Default off —
-# requires snapshot.storage.k8s.io/v1 CRDs which are part of the upstream
-# CSI subchart.
+# VolumeSnapshotClass for backup workflows (Velero etc.). #3971 — default ON
+# so every Sovereign has storage-level snapshots out of the box (the
+# upstream hcloud-csi subchart ships the snapshot.storage.k8s.io/v1 CRDs +
+# external-snapshotter sidecar). deletionPolicy Retain mirrors the SC so a
+# deleted VolumeSnapshot never silently drops the cloud snapshot.
 volumeSnapshotClass:
-  enabled: false
+  enabled: true
   name: hcloud-volumes-snapshots
-  deletionPolicy: Delete
+  deletionPolicy: Retain
 
 # ─── Upstream subchart values (subchart key: hcloud-csi) ──────────────
 hcloud-csi:

--- a/platform/kyverno-policies/blueprint.yaml
+++ b/platform/kyverno-policies/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.37
+  version: 1.0.38
   card:
     title: Kyverno Policy Library
     family: guardian

--- a/platform/kyverno-policies/chart/Chart.yaml
+++ b/platform/kyverno-policies/chart/Chart.yaml
@@ -215,7 +215,12 @@ type: application
 # 1.0.37 (#3859): add `org-services` to harbor-proxy-pull extraExcludeNamespaces
 # (sme→org-services rename #3383 orphaned the mixed-image-Pod carve-out → the
 # provisioning CR-minter was Enforce-denied → #3376 funnel could not go ACTIVE).
-version: 1.0.37
+# 1.0.38 (#3971): K23 forbid-local-path-storage ClusterPolicy — ENFORCE-always
+# (NOT bootstrapMode-gated) deny of any PVC/StorageClass/PV referencing
+# local-path / rancher.io/local-path. The admission layer of the 3-layer
+# local-path-FORBIDDEN defence (k3s --disable=local-storage + cloud CSI default
+# + this policy). Founder: "local path never ever ALLOWED".
+version: 1.0.38
 appVersion: "1.0.2"
 keywords: [catalyst, blueprint, kyverno, policy, compliance, audit]
 maintainers:

--- a/platform/kyverno-policies/chart/templates/baseline/23-forbid-local-path.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/23-forbid-local-path.yaml
@@ -1,0 +1,156 @@
+{{/*
+K23 — FORBID the ephemeral k3s local-path provisioner (#3971).
+
+THE MANDATE
+===========
+Founder, verbatim (#3971): "make the local paths not default even FORBIDDEN.
+local path never ever ALLOWED!!"
+
+k3s ships a `local-path` StorageClass backed by `rancher.io/local-path` — a
+directory on the node's LOCAL disk with NO cloud block volume behind it. Any
+node replacement (autoscaler, failed node, re-prov, disk loss) DESTROYS that
+PV's data — prod Postgres 3×100Gi, openbao secrets, the customer-Org DB,
+keycloak/gitea/harbor. That invalidates the BCP/DR model.
+
+DEFENCE IN DEPTH
+================
+This is the THIRD of three layers that make local-path impossible:
+  1. k3s `--disable=local-storage` (cloud-init) — the provisioner is NEVER
+     installed on a fresh prov.
+  2. The per-provider cloud CSI (bp-hcloud-csi slot 55a) installs the durable
+     `hcloud-volumes` default StorageClass, and is a `dependsOn` of the
+     stateful root slots so it is Ready before any PVC binds.
+  3. THIS Kyverno ENFORCE policy — the admission guard that DENIES any
+     PersistentVolumeClaim / StorageClass / PersistentVolume that references
+     `local-path` or `rancher.io/local-path`, so no future chart, overlay, or
+     operator can ever silently reintroduce non-durable node-local storage.
+  + the Phase-1 provisioning DoD gate (catalyst-api) FAILS a prov whose
+    resolved default StorageClass is still local-path.
+
+WHY action IS HARDCODED Enforce (NOT the bootstrapMode helper)
+==============================================================
+Every OTHER policy in this chart resolves its action through
+`bp-kyverno-policies.action`, which downgrades to Audit while
+`compliancePolicies.bootstrapMode` is true (the Phase-1 window) so
+not-yet-ready workloads aren't fail-closed-blocked. This policy is the
+EXCEPTION: it is a structural data-durability safety invariant, and the
+local-path PVCs it forbids are created DURING that very bootstrap window. An
+Audit-during-bootstrap downgrade would let every stateful PVC land on
+ephemeral disk before the post-handover flip to Enforce — exactly the failure
+#3971 exists to prevent. It is therefore hardcoded `Enforce`. This is safe
+because the cloud CSI default class is guaranteed Ready before any PVC binds
+(layer 2), so NO legitimate bootstrap PVC needs local-path — the policy never
+blocks a well-formed prov.
+
+Operator override: `--set compliancePolicies.forbidLocalPath.enabled=false`
+disables it entirely (e.g. an air-gapped single-node Sovereign deliberately
+running on node-local disk with no cloud volumes). Per-namespace escape via
+`.excludeNamespaces`.
+*/}}
+{{- if .Values.compliancePolicies.forbidLocalPath.enabled -}}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: forbid-local-path-storage
+  labels:
+    app.kubernetes.io/name: bp-kyverno
+    app.kubernetes.io/component: compliance-policy
+    catalyst.openova.io/policy-tier: compliance
+    catalyst.openova.io/policy-domain: storage-durability
+  annotations:
+    policies.kyverno.io/title: Forbid the ephemeral k3s local-path provisioner
+    policies.kyverno.io/category: catalyst-storage-durability
+    policies.kyverno.io/severity: critical
+    policies.kyverno.io/subject: PersistentVolumeClaim,StorageClass,PersistentVolume
+    policies.kyverno.io/description: >-
+      local-path (rancher.io/local-path) is ephemeral node-local disk with no
+      cloud block volume behind it — a node replacement destroys the data,
+      invalidating BCP/DR. #3971 forbids it entirely: k3s runs
+      --disable=local-storage and the durable per-provider cloud CSI is the
+      only default StorageClass. This policy fail-closes any PVC / StorageClass
+      / PV that references local-path.
+spec:
+  # HARDCODED Enforce — NOT the bootstrapMode helper. See the header comment:
+  # the local-path PVCs this forbids are created during the Phase-1 bootstrap
+  # window, so an Audit-during-bootstrap downgrade would defeat the guard.
+  validationFailureAction: Enforce
+  background: true
+  rules:
+    # ── Rule 1: PVCs may not request the local-path StorageClass ──────────
+    - name: pvc-no-local-path-storageclass
+      match:
+        any:
+          - resources:
+              kinds:
+                - PersistentVolumeClaim
+      {{- with .Values.compliancePolicies.forbidLocalPath.excludeNamespaces }}
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range . }}
+                - {{ . }}
+                {{- end }}
+      {{- end }}
+      validate:
+        message: >-
+          PersistentVolumeClaim
+          {{ `{{request.object.metadata.namespace}}/{{request.object.metadata.name}}` }}
+          requests the FORBIDDEN local-path StorageClass. local-path is
+          ephemeral node-local disk (no cloud block volume) — #3971 forbids it.
+          Omit storageClassName to bind to the durable cluster-default cloud
+          CSI (hcloud-volumes on Hetzner), or name an explicit durable class.
+        deny:
+          conditions:
+            any:
+              - key: {{ `"{{ request.object.spec.storageClassName || '' }}"` }}
+                operator: AnyIn
+                value:
+                  - local-path
+                  - rancher.io/local-path
+    # ── Rule 2: no StorageClass may use the local-path provisioner ────────
+    #    (also catches a StorageClass literally named `local-path`).
+    - name: storageclass-no-local-path-provisioner
+      match:
+        any:
+          - resources:
+              kinds:
+                - StorageClass
+      validate:
+        message: >-
+          StorageClass {{ `{{request.object.metadata.name}}` }} uses the
+          FORBIDDEN local-path provisioner (rancher.io/local-path) or is named
+          `local-path`. #3971: local-path is ephemeral node-local disk — use a
+          durable cloud CSI provisioner (csi.hetzner.cloud) instead.
+        deny:
+          conditions:
+            any:
+              - key: {{ `"{{ request.object.provisioner || '' }}"` }}
+                operator: AnyIn
+                value:
+                  - rancher.io/local-path
+                  - local-path
+              - key: {{ `"{{ request.object.metadata.name }}"` }}
+                operator: Equals
+                value: local-path
+    # ── Rule 3: no PV may declare the local-path StorageClass ─────────────
+    - name: pv-no-local-path-storageclass
+      match:
+        any:
+          - resources:
+              kinds:
+                - PersistentVolume
+      validate:
+        message: >-
+          PersistentVolume {{ `{{request.object.metadata.name}}` }} declares the
+          FORBIDDEN local-path StorageClass. #3971: local-path is ephemeral
+          node-local disk — back PVs with a durable cloud CSI instead.
+        deny:
+          conditions:
+            any:
+              - key: {{ `"{{ request.object.spec.storageClassName || '' }}"` }}
+                operator: AnyIn
+                value:
+                  - local-path
+                  - rancher.io/local-path
+{{- end }}

--- a/platform/kyverno-policies/chart/tests/fixtures/README.md
+++ b/platform/kyverno-policies/chart/tests/fixtures/README.md
@@ -35,8 +35,9 @@ exactly one (per workload).
 | probes-present | `probes-present/pass-deployment.yaml` | `probes-present/fail-deployment.yaml` |
 | resource-requests | `resource-requests/pass-deployment.yaml` | `resource-requests/fail-deployment.yaml` |
 | image-tag-pinned | `image-tag-pinned/pass-deployment.yaml` | `image-tag-pinned/fail-deployment.yaml` |
+| forbid-local-path-storage (#3971) | `forbid-local-path/pass-pvc.yaml` | `forbid-local-path/fail-pvc.yaml` |
 
-The remaining 15 policies' fixtures are deferred — slice S1 ships the
+The remaining policies' fixtures are deferred — slice S1 ships the
 authoritative matrix.
 
 ## MUTATE policy fixtures (Refs #3268)

--- a/platform/kyverno-policies/chart/tests/fixtures/forbid-local-path/fail-pvc.yaml
+++ b/platform/kyverno-policies/chart/tests/fixtures/forbid-local-path/fail-pvc.yaml
@@ -1,0 +1,33 @@
+# Failing case (#3971): a PVC requesting the FORBIDDEN local-path StorageClass.
+# The forbid-local-path-storage policy (Enforce) DENIES this on admission —
+# local-path is ephemeral node-local disk with no cloud volume behind it.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: fail-pvc
+  namespace: example
+spec:
+  storageClassName: local-path
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+# Also failing: a StorageClass using the rancher.io/local-path provisioner.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: example-local-path
+provisioner: rancher.io/local-path
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+---
+# Also failing: a StorageClass literally named `local-path`.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-path
+provisioner: csi.hetzner.cloud
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer

--- a/platform/kyverno-policies/chart/tests/fixtures/forbid-local-path/pass-pvc.yaml
+++ b/platform/kyverno-policies/chart/tests/fixtures/forbid-local-path/pass-pvc.yaml
@@ -1,0 +1,28 @@
+# Passing case (#3971): a PVC that OMITS storageClassName binds to the
+# cluster-default durable cloud CSI (hcloud-volumes) — no local-path reference,
+# so the forbid-local-path-storage policy allows it.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pass-pvc
+  namespace: example
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+# Also passing: an explicit DURABLE class is fine (only local-path is forbidden).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pass-pvc-explicit-durable
+  namespace: example
+spec:
+  storageClassName: hcloud-volumes
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/platform/kyverno-policies/chart/values.yaml
+++ b/platform/kyverno-policies/chart/values.yaml
@@ -399,6 +399,28 @@ compliancePolicies:
       - mgmt
       - rtz
 
+  # #3971 — FORBID the ephemeral k3s local-path provisioner cluster-wide.
+  # The founder mandate (verbatim): "make the local paths not default even
+  # FORBIDDEN. local path never ever ALLOWED". k3s now runs
+  # --disable=local-storage so the local-path provisioner is never installed;
+  # this policy is the belt-and-braces admission guard that DENIES any
+  # PersistentVolumeClaim / StorageClass / PersistentVolume that references
+  # `local-path` or `rancher.io/local-path`, so a future chart/overlay/operator
+  # can never silently reintroduce non-durable node-local storage.
+  #
+  # action is HARDCODED Enforce in the template (NOT gated by bootstrapMode):
+  # this is a structural data-durability safety invariant, not a soft
+  # compliance recommendation — it must fail-closed during the Phase-1
+  # bootstrap window too (that's exactly when the stateful PVCs bind). The
+  # cloud CSI (bp-hcloud-csi slot 55a) gates the stateful root slots so the
+  # durable default class exists before any PVC binds — no legitimate
+  # bootstrap PVC needs local-path, so Enforce-always cannot wedge the prov.
+  forbidLocalPath:
+    enabled: true
+    # Genuinely-special namespaces that may need an escape hatch (none by
+    # default — local-path is forbidden EVERYWHERE, including kube-system).
+    excludeNamespaces: []
+
   # G98 (Refs #2644, 2026-06-01) — MUTATE policy that auto-stamps
   # `catalyst.openova.io/application` label on Pods cluster-wide.
   # Without this label, the Compliance scorecard's per-Application

--- a/platform/openova-flow-server/chart/Chart.yaml
+++ b/platform/openova-flow-server/chart/Chart.yaml
@@ -5,7 +5,8 @@ name: bp-openova-flow-server
 # Opt out of the hollow-chart guard per docs/BLUEPRINT-AUTHORING.md §11.1.
 annotations:
   catalyst.openova.io/no-upstream: "true"
-version: 0.2.3
+# 0.2.4 (#3971): CNPG storageClass empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN.
+version: 0.2.4
 appVersion: "0.2.0"
 description: |
   Catalyst Blueprint chart for the openova-flow-server — the

--- a/platform/openova-flow-server/chart/templates/cnpg-cluster.yaml
+++ b/platform/openova-flow-server/chart/templates/cnpg-cluster.yaml
@@ -66,7 +66,10 @@ spec:
 
   storage:
     size: {{ .Values.postgres.cluster.storageSize | default "5Gi" }}
-    storageClass: {{ .Values.postgres.cluster.storageClass | default "local-path" | quote }}
+    # #3971 — empty ⇒ omit ⇒ CNPG uses the cluster-default durable cloud CSI; local-path FORBIDDEN.
+    {{- with .Values.postgres.cluster.storageClass }}
+    storageClass: {{ . | quote }}
+    {{- end }}
 
   enableSuperuserAccess: true
 

--- a/platform/openova-flow-server/chart/values.yaml
+++ b/platform/openova-flow-server/chart/values.yaml
@@ -120,7 +120,7 @@ postgres:
     database: openova_flow
     owner: openova_flow
     storageSize: "5Gi"
-    storageClass: local-path
+    storageClass: ""  # #3971 — empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN
     resources:
       requests:
         cpu: 50m

--- a/platform/postgres/blueprint.yaml
+++ b/platform/postgres/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-4-1-data-services
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.2.4
+  version: 0.2.5
   card:
     title: PostgreSQL
     summary: |

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -112,7 +112,8 @@ name: bp-postgres
 #   regions so it admits under BOTH the pre-#3370 CRD (hard-required) and the
 #   #3370 CRD (CEL-waived) — breaks the live upgrade-rollback deadlock that
 #   blocked keycloak->gitea->catalyst-platform on hw130.
-version: 0.2.4
+# 0.2.5 (#3971): CNPG storageClass empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN.
+version: 0.2.5
 appVersion: "0.1.2"
 description: |
   Catalyst-authored data-instance Blueprint for a shareable, reusable

--- a/platform/postgres/chart/templates/cluster.yaml
+++ b/platform/postgres/chart/templates/cluster.yaml
@@ -232,7 +232,14 @@ spec:
 
   storage:
     size: {{ .Values.instance.storageSize | default "5Gi" }}
-    storageClass: {{ .Values.instance.storageClass | default "local-path" | quote }}
+    # #3971 — when storageClass is empty, OMIT the field so CNPG binds to the
+    # cluster DEFAULT StorageClass (the durable cloud CSI — hcloud-volumes on
+    # Hetzner). Never default to "local-path": k3s now runs
+    # --disable=local-storage so the ephemeral local-path provisioner does not
+    # exist, and a Kyverno ENFORCE policy DENIES any local-path reference.
+    {{- with .Values.instance.storageClass }}
+    storageClass: {{ . | quote }}
+    {{- end }}
 
   enableSuperuserAccess: {{ .Values.instance.enableSuperuserAccess | default false }}
 

--- a/platform/postgres/chart/templates/replica-cluster.yaml
+++ b/platform/postgres/chart/templates/replica-cluster.yaml
@@ -52,7 +52,11 @@ spec:
 
   storage:
     size: {{ .Values.instance.storageSize | default "5Gi" }}
-    storageClass: {{ .Values.instance.storageClass | default "local-path" | quote }}
+    # #3971 — empty ⇒ omit ⇒ CNPG uses the cluster-default durable cloud CSI.
+    # local-path is FORBIDDEN (k3s --disable=local-storage + Kyverno deny).
+    {{- with .Values.instance.storageClass }}
+    storageClass: {{ . | quote }}
+    {{- end }}
 
   resources:
     {{- toYaml .Values.instance.resources | nindent 4 }}

--- a/platform/postgres/chart/values.yaml
+++ b/platform/postgres/chart/values.yaml
@@ -45,7 +45,13 @@ instance:
 
   # Storage for the engine's PVCs.
   storageSize: 5Gi
-  storageClass: local-path
+  # #3971 — empty ⇒ CNPG binds to the cluster-DEFAULT StorageClass (the
+  # durable cloud CSI: hcloud-volumes on Hetzner). NEVER "local-path": k3s
+  # runs --disable=local-storage so the ephemeral provisioner is FORBIDDEN
+  # (and a Kyverno ENFORCE policy DENIES any local-path reference). Per-
+  # Sovereign overlay MAY pin an explicit durable class; it must not be
+  # local-path.
+  storageClass: ""
 
   resources:
     requests:

--- a/platform/powerdns-admin/blueprint.yaml
+++ b/platform/powerdns-admin/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 0.1.17
+  version: 0.1.18
   card:
     title: powerdns-admin
     summary: |

--- a/platform/powerdns-admin/chart/Chart.yaml
+++ b/platform/powerdns-admin/chart/Chart.yaml
@@ -161,7 +161,8 @@ name: bp-powerdns-admin
 # reconnect before handing out any pooled connection — the canonical fix for
 # server-side connection recycling. NO DB-host/topology change (PDA stays on
 # shared-pg-b). Configurable via config.sqlAlchemyEngineOptions; set {} to omit.
-version: 0.1.17
+# 0.1.18 (#3971): CNPG storageClass empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN.
+version: 0.1.18
 description: |
   PowerDNS-Admin (ngoduykhanh/powerdns-admin) web UI Blueprint for
   per-Sovereign PowerDNS zone + record management. Drives the

--- a/platform/powerdns-admin/chart/templates/cnpg-cluster.yaml
+++ b/platform/powerdns-admin/chart/templates/cnpg-cluster.yaml
@@ -49,7 +49,10 @@ spec:
       owner: {{ .Values.postgres.cluster.owner | default "pda" }}
   storage:
     size: {{ .Values.postgres.cluster.storageSize | default "5Gi" }}
-    storageClass: {{ .Values.postgres.cluster.storageClass | default "local-path" }}
+    # #3971 — empty ⇒ omit ⇒ CNPG uses the cluster-default durable cloud CSI; local-path FORBIDDEN.
+    {{- with .Values.postgres.cluster.storageClass }}
+    storageClass: {{ . | quote }}
+    {{- end }}
   resources:
     {{- toYaml .Values.postgres.cluster.resources | nindent 4 }}
 

--- a/platform/powerdns-admin/chart/values.yaml
+++ b/platform/powerdns-admin/chart/values.yaml
@@ -112,7 +112,7 @@ postgres:
     database: pda
     owner: pda
     storageSize: 5Gi
-    storageClass: local-path
+    storageClass: ""  # #3971 — empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN
     resources:
       requests:
         cpu: 100m

--- a/platform/powerdns/blueprint.yaml
+++ b/platform/powerdns/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-2-gitops-and-iac
 spec:
-  version: 1.2.16
+  version: 1.2.17
   card:
     title: PowerDNS
     summary: |

--- a/platform/powerdns/chart/Chart.yaml
+++ b/platform/powerdns/chart/Chart.yaml
@@ -47,7 +47,8 @@ name: bp-powerdns
 # readTopology serves spec.placement VERBATIM to the Topology tab + the
 # Instances-table chip, so the legacy spelling leaked the banned word to the
 # operator (hw159 #3375).
-version: 1.2.16
+# 1.2.17 (#3971): CNPG storageClass empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN.
+version: 1.2.17
 description: |
   Catalyst-curated Blueprint wrapper for PowerDNS Authoritative.
   Carries Catalyst-specific values.yaml + templates (CNPG cluster, dnsdist

--- a/platform/powerdns/chart/templates/cnpg-cluster.yaml
+++ b/platform/powerdns/chart/templates/cnpg-cluster.yaml
@@ -192,7 +192,10 @@ spec:
 
   storage:
     size: {{ .Values.postgres.cluster.storageSize | default "5Gi" }}
-    storageClass: {{ .Values.postgres.cluster.storageClass | default "local-path" | quote }}
+    # #3971 — empty ⇒ omit ⇒ CNPG uses the cluster-default durable cloud CSI; local-path FORBIDDEN.
+    {{- with .Values.postgres.cluster.storageClass }}
+    storageClass: {{ . | quote }}
+    {{- end }}
 
   enableSuperuserAccess: true
 

--- a/platform/powerdns/chart/values.yaml
+++ b/platform/powerdns/chart/values.yaml
@@ -308,7 +308,7 @@ postgres:
     namespace: powerdns
     instances: 1                 # bump to 3 alongside replicaCount=3 once we move beyond Phase-0 single-region
     storageSize: 5Gi
-    storageClass: local-path     # Contabo k3s default; Sovereign Hetzner clusters override to hcloud-volumes
+    storageClass: ""  # #3971 — empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN
     # CNPG postgres image. Defaults to the mothership Harbor proxy cache
     # (harbor.openova.io/proxy-ghcr) so fresh-prov bootstrap pulls the
     # ~300MB image through Harbor instead of throttling on anonymous ghcr

--- a/platform/seaweedfs/blueprint.yaml
+++ b/platform/seaweedfs/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-5-storage-and-data
 spec:
-  version: 1.2.2
+  version: 1.2.3
   card:
     title: SeaweedFS
     family: foundation

--- a/platform/seaweedfs/chart/Chart.yaml
+++ b/platform/seaweedfs/chart/Chart.yaml
@@ -31,7 +31,11 @@ description: |
     IAM credentials sourced from External Secrets, not via the upstream
     chart's TLS/JWT machinery).
 type: application
-version: 1.2.2
+# 1.2.3 (#3971): seaweedfs-storage SC default provisioner local-path ->
+# csi.hetzner.cloud (durable). local-path is FORBIDDEN (k3s
+# --disable=local-storage + Kyverno ENFORCE deny). bp-hcloud-csi gates the
+# stateful root slots so the cloud CSI is Ready before any seaweedfs PVC binds.
+version: 1.2.3
 appVersion: "4.22"
 keywords: [catalyst, blueprint, seaweedfs, s3, object-storage, storage]
 maintainers:

--- a/platform/seaweedfs/chart/templates/storageclass.yaml
+++ b/platform/seaweedfs/chart/templates/storageclass.yaml
@@ -18,20 +18,23 @@ Why bp-seaweedfs ships this StorageClass (not bp-guacamole / overlay):
     is operator-tunable through `seaweedfsOverlay.storageClasses[]`.
   - Per BLUEPRINT-AUTHORING.md §11 (umbrella ownership), per-Sovereign
     overlays select the underlying provisioner via Flux `valuesFrom` so
-    Sovereigns with hcloud-csi installed map `seaweedfs-storage` →
-    `csi.hetzner.cloud` while bare-k3s Sovereigns map onto
-    `rancher.io/local-path` (always present on k3s).
+    Sovereigns map `seaweedfs-storage` → their cloud CSI provisioner
+    (`csi.hetzner.cloud` on Hetzner; everest/EVS on Huawei).
 
-Default provisioner is `rancher.io/local-path` because:
-  - Every Sovereign provisioned by the OpenTofu Phase 0 module runs k3s
-    which ships the local-path provisioner pre-installed.
-  - bp-hcloud-csi installs LATER in the bootstrap-kit ordering and is
-    optional (single-node Sovereigns or non-Hetzner clouds skip it).
-  - Defaulting to local-path means PVCs requesting `seaweedfs-storage`
-    bind successfully on day-1 without operator intervention. Operators
-    flip to `csi.hetzner.cloud` (or the dedicated `seaweedfs-csi-driver`
-    once installed) by overriding `seaweedfsOverlay.storageClasses[].provisioner`
-    in the per-Sovereign HelmRelease.
+#3971 — Default provisioner is `csi.hetzner.cloud` (the durable Hetzner
+Cloud CSI), NOT the ephemeral k3s local-path:
+  - k3s now runs `--disable=local-storage` (cloud-init), so the local-path
+    provisioner is FORBIDDEN — it is NEVER installed. A StorageClass with
+    `provisioner: rancher.io/local-path` would be non-functional (no
+    provisioner to bind) AND would be DENIED by the bp-kyverno-policies
+    local-path ENFORCE policy.
+  - bp-hcloud-csi (bootstrap-kit slot 55a) is now a `dependsOn` of the
+    stateful root slots (bp-cnpg / bp-mgmt-vcluster), so the cloud CSI +
+    its `hcloud-volumes` default class are guaranteed Ready before any
+    seaweedfs PVC binds.
+  - Non-Hetzner clouds override `seaweedfsOverlay.storageClasses[].provisioner`
+    to their own durable CSI (Huawei: everest/EVS — #3971 follow-up). NEVER
+    map this back to local-path.
 
 Disabled by default (`seaweedfsOverlay.storageClasses[].enabled` per entry)
 so this template is a no-op until the operator explicitly opts in. The
@@ -59,7 +62,7 @@ metadata:
     {{- with $sc.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-provisioner: {{ $sc.provisioner | default "rancher.io/local-path" | quote }}
+provisioner: {{ $sc.provisioner | default "csi.hetzner.cloud" | quote }}
 reclaimPolicy: {{ $sc.reclaimPolicy | default "Delete" | quote }}
 volumeBindingMode: {{ $sc.volumeBindingMode | default "WaitForFirstConsumer" | quote }}
 allowVolumeExpansion: {{ $sc.allowVolumeExpansion | default true }}

--- a/platform/seaweedfs/chart/values.yaml
+++ b/platform/seaweedfs/chart/values.yaml
@@ -364,13 +364,14 @@ seaweedfsOverlay:
   # (bp-guacamole recordings PVC, future bp-loki/mimir/tempo cache PVCs)
   # binds against the class registered here.
   #
-  # Default `provisioner: rancher.io/local-path` — k3s ships the
-  # local-path-provisioner pre-installed on every Sovereign, so PVCs bind
-  # day-1 without waiting for bp-hcloud-csi or the SeaweedFS CSI driver to
-  # install. Per-Sovereign overlay flips `provisioner:` to
-  # `csi.hetzner.cloud` (Hetzner Sovereigns with bp-hcloud-csi installed)
-  # or `seaweedfs-csi-driver.csi.k8s.io` (when the dedicated SeaweedFS CSI
-  # is rolled out at slot 18.1) without modifying the chart.
+  # #3971 — Default `provisioner: csi.hetzner.cloud` (the durable Hetzner
+  # Cloud CSI), NOT the ephemeral k3s local-path. k3s runs
+  # --disable=local-storage so local-path is FORBIDDEN (never installed; a
+  # Kyverno ENFORCE policy DENIES any local-path reference). bp-hcloud-csi
+  # (slot 55a) is a dependsOn of the stateful root slots, so the cloud CSI is
+  # Ready before any seaweedfs PVC binds. Per-Sovereign overlay flips
+  # `provisioner:` to the cloud's durable CSI on non-Hetzner clouds (Huawei:
+  # everest/EVS — #3971 follow-up). NEVER set this to local-path.
   #
   # Per docs/INVIOLABLE-PRINCIPLES.md #4 every field below is operator-
   # tunable through `seaweedfsOverlay.storageClasses[]` — list semantics
@@ -379,9 +380,9 @@ seaweedfsOverlay:
   storageClasses:
     - name: seaweedfs-storage
       enabled: true
-      # Single-Sovereign safe default — k3s ships local-path. Overlay
-      # MAY override to csi.hetzner.cloud / seaweedfs-csi-driver.csi.k8s.io.
-      provisioner: rancher.io/local-path
+      # #3971 — durable cloud CSI (NOT local-path, which is FORBIDDEN).
+      # Overlay MAY override to the cloud's own durable CSI on non-Hetzner.
+      provisioner: csi.hetzner.cloud
       reclaimPolicy: Delete
       # WaitForFirstConsumer keeps PV creation lazy so overlay can re-tier
       # the underlying provisioner without re-binding existing PVCs.

--- a/platform/wordpress-tenant/blueprint.yaml
+++ b/platform/wordpress-tenant/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: tenant-app
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.4.1
+  version: 0.4.2
   card:
     title: WordPress Tenant
     summary: |

--- a/platform/wordpress-tenant/chart/Chart.yaml
+++ b/platform/wordpress-tenant/chart/Chart.yaml
@@ -94,7 +94,8 @@ name: bp-wordpress-tenant
 #   - Operator-facing trade-off (documented in values.yaml + DESIGN
 #     of bp-cnpg-pair §7): primary BLOCKS new writes when replica is
 #     unreachable; every COMMIT pays the inter-region RTT.
-version: 0.4.1
+# 0.4.2 (#3971): CNPG storageClass empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN.
+version: 0.4.2
 appVersion: "6"
 description: |
   Catalyst Blueprint scratch chart for in-vcluster WordPress, one

--- a/platform/wordpress-tenant/chart/templates/cnpg-cluster.yaml
+++ b/platform/wordpress-tenant/chart/templates/cnpg-cluster.yaml
@@ -151,7 +151,10 @@ spec:
 
   storage:
     size: {{ .Values.database.cluster.storageSize }}
-    storageClass: {{ .Values.database.cluster.storageClass | quote }}
+    # #3971 — empty ⇒ omit ⇒ CNPG uses the cluster-default durable cloud CSI; local-path FORBIDDEN.
+    {{- with .Values.database.cluster.storageClass }}
+    storageClass: {{ . | quote }}
+    {{- end }}
 
   {{- if $haEnabled }}
   # Region pinning — node-affinity is the operator's idiomatic seam for
@@ -256,7 +259,10 @@ spec:
 
   storage:
     size: {{ .Values.database.cluster.storageSize }}
-    storageClass: {{ .Values.database.cluster.storageClass | quote }}
+    # #3971 — empty ⇒ omit ⇒ CNPG uses the cluster-default durable cloud CSI; local-path FORBIDDEN.
+    {{- with .Values.database.cluster.storageClass }}
+    storageClass: {{ . | quote }}
+    {{- end }}
 
   resources:
     {{- toYaml .Values.database.cluster.resources | nindent 4 }}

--- a/platform/wordpress-tenant/chart/values.yaml
+++ b/platform/wordpress-tenant/chart/values.yaml
@@ -166,7 +166,7 @@ database:
     database: "wordpress"
     owner: "wordpress"
     storageSize: "10Gi"
-    storageClass: "local-path"
+    storageClass: ""  # #3971 — empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN
     resources:
       requests:
         cpu: 100m
@@ -394,7 +394,7 @@ persistence:
   wpContent:
     enabled: true
     size: "10Gi"
-    storageClass: "local-path"
+    storageClass: ""  # #3971 — empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN
     accessModes:
       - ReadWriteOnce
 

--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/flowemit"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handoverjwt"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/k8scache"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/openbao"
@@ -162,6 +163,18 @@ type Handler struct {
 	// can be exercised in milliseconds. Issue #538.
 	kubeconfigArrivalTimeout      time.Duration
 	kubeconfigArrivalPollInterval time.Duration
+
+	// phase1StorageGate — test-only override for the #3971 default-
+	// StorageClass durability gate run at the end of markPhase1Done.
+	// Production uses helmwatch.DefaultStorageClassFromKubeconfig
+	// (typed client against the new Sovereign's kubeconfig, rest.Config
+	// 30s timeout, read-only StorageClass List). Tests inject a closure
+	// returning a canned helmwatch.DefaultStorageClassInfo so the gate's
+	// ready→failed flip can be exercised without a real cluster. Nil =
+	// "use production default". When the kubeconfig is unreadable the
+	// gate is SKIPPED (never downgrades a ready deployment on probe
+	// error) — the gate only fires on a POSITIVE local-path observation.
+	phase1StorageGate func(ctx context.Context, kubeconfigPath string) (helmwatch.DefaultStorageClassInfo, error)
 
 	// ClusterMesh level-triggered reconcile knobs (#3241). The
 	// runAutoEstablishClusterMesh wrapper re-runs the idempotent

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_storage_gate_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_storage_gate_test.go
@@ -1,0 +1,169 @@
+// phase1_storage_gate_test.go — #3971 wiring coverage. Proves the
+// storage-durability gate in markPhase1Done downgrades an otherwise-ready
+// deployment to `failed` (default-storageclass-ephemeral) when the new
+// Sovereign's default StorageClass is still k3s local-path, leaves a
+// durable-default prov untouched, and SKIPS (never downgrades) when the
+// probe cannot run.
+
+package handler
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+func newStorageGateDeployment(id string) *Deployment {
+	return &Deployment{
+		ID:        id,
+		Status:    "phase1-watching",
+		StartedAt: time.Now(),
+		eventsCh:  make(chan provisioner.Event, 256),
+		done:      make(chan struct{}),
+		Request: provisioner.Request{
+			SovereignFQDN: "otech-storage.example.com",
+			OrgEmail:      "operator@storage.example.com",
+			BcpTopology:   provisioner.BcpTopologySingleRegion,
+			Regions: []provisioner.RegionSpec{
+				{Provider: "hetzner", CloudRegion: "fsn1"},
+			},
+		},
+		Result: &provisioner.Result{
+			SovereignFQDN: "otech-storage.example.com",
+			// Non-empty so the gate actually runs (it SKIPS on empty path).
+			KubeconfigPath: "/var/lib/catalyst/kubeconfigs/" + id + ".yaml",
+		},
+		OwnerEmail: "operator@storage.example.com",
+	}
+}
+
+// Default StorageClass is the ephemeral local-path → ready must flip to
+// failed with the canonical default-storageclass-ephemeral reason, and NO
+// handover token is minted.
+func TestMarkPhase1Done_EphemeralDefaultStorageClass_NotReady(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.SetHandoverSigner(loadTestSigner(t))
+	h.phase1StorageGate = func(ctx context.Context, path string) (helmwatch.DefaultStorageClassInfo, error) {
+		return helmwatch.DefaultStorageClassInfo{
+			Name:        "local-path",
+			Provisioner: helmwatch.LocalPathProvisioner,
+			Found:       true,
+			Ephemeral:   true,
+		}, nil
+	}
+
+	dep := newStorageGateDeployment("phase1-storage-ephemeral")
+	h.deployments.Store(dep.ID, dep)
+
+	finalStates := map[string]string{
+		"cilium":            helmwatch.StateInstalled,
+		"catalyst-platform": helmwatch.StateInstalled,
+		"hcloud-csi":        helmwatch.StateInstalled,
+	}
+	h.markPhase1Done(dep, finalStates, helmwatch.OutcomeReady)
+
+	dep.mu.Lock()
+	defer dep.mu.Unlock()
+
+	if dep.Status != "failed" {
+		t.Fatalf("Status = %q, want failed (ephemeral local-path default)", dep.Status)
+	}
+	if !strings.Contains(strings.ToLower(dep.Error), "local-path") {
+		t.Errorf("Error must name local-path; got %q", dep.Error)
+	}
+	if dep.Result.Phase1Outcome != provisioner.ReasonDefaultStorageClassEphemeral {
+		t.Errorf("Phase1Outcome = %q, want %q", dep.Result.Phase1Outcome, provisioner.ReasonDefaultStorageClassEphemeral)
+	}
+	if dep.Result.HandoverFiredAt != nil {
+		t.Errorf("HandoverFiredAt unexpectedly set on ephemeral-storage failure")
+	}
+}
+
+// Durable cloud CSI default → the gate leaves the ready deployment alone.
+func TestMarkPhase1Done_DurableDefaultStorageClass_Ready(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.SetHandoverSigner(loadTestSigner(t))
+	h.phase1StorageGate = func(ctx context.Context, path string) (helmwatch.DefaultStorageClassInfo, error) {
+		return helmwatch.DefaultStorageClassInfo{
+			Name:        "hcloud-volumes",
+			Provisioner: "csi.hetzner.cloud",
+			Found:       true,
+			Ephemeral:   false,
+		}, nil
+	}
+
+	dep := newStorageGateDeployment("phase1-storage-durable")
+	h.deployments.Store(dep.ID, dep)
+
+	finalStates := map[string]string{
+		"cilium":     helmwatch.StateInstalled,
+		"hcloud-csi": helmwatch.StateInstalled,
+	}
+	h.markPhase1Done(dep, finalStates, helmwatch.OutcomeReady)
+
+	dep.mu.Lock()
+	defer dep.mu.Unlock()
+
+	if dep.Status != "ready" {
+		t.Fatalf("Status = %q, want ready (durable cloud CSI default)", dep.Status)
+	}
+	if dep.Result.Phase1Outcome == provisioner.ReasonDefaultStorageClassEphemeral {
+		t.Errorf("durable-default prov must not be stamped %q", provisioner.ReasonDefaultStorageClassEphemeral)
+	}
+}
+
+// A probe error (e.g. unreadable kubeconfig, apiserver blip) must SKIP the
+// gate — a transient failure can never downgrade a ready Sovereign.
+func TestMarkPhase1Done_StorageGateProbeError_SkipsNotDowngrade(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.SetHandoverSigner(loadTestSigner(t))
+	h.phase1StorageGate = func(ctx context.Context, path string) (helmwatch.DefaultStorageClassInfo, error) {
+		return helmwatch.DefaultStorageClassInfo{}, context.DeadlineExceeded
+	}
+
+	dep := newStorageGateDeployment("phase1-storage-probe-error")
+	h.deployments.Store(dep.ID, dep)
+
+	finalStates := map[string]string{"cilium": helmwatch.StateInstalled}
+	h.markPhase1Done(dep, finalStates, helmwatch.OutcomeReady)
+
+	dep.mu.Lock()
+	defer dep.mu.Unlock()
+
+	if dep.Status != "ready" {
+		t.Fatalf("Status = %q, want ready (probe error must SKIP, not downgrade)", dep.Status)
+	}
+	if dep.Result.Phase1Outcome == provisioner.ReasonDefaultStorageClassEphemeral {
+		t.Errorf("probe error must not stamp the ephemeral-storage reason")
+	}
+}
+
+// No default StorageClass at all → also a hard failure (every default-less
+// PVC hangs Pending), distinct from the local-path case.
+func TestMarkPhase1Done_NoDefaultStorageClass_NotReady(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.SetHandoverSigner(loadTestSigner(t))
+	h.phase1StorageGate = func(ctx context.Context, path string) (helmwatch.DefaultStorageClassInfo, error) {
+		return helmwatch.DefaultStorageClassInfo{Found: false}, nil
+	}
+
+	dep := newStorageGateDeployment("phase1-storage-no-default")
+	h.deployments.Store(dep.ID, dep)
+
+	finalStates := map[string]string{"cilium": helmwatch.StateInstalled}
+	h.markPhase1Done(dep, finalStates, helmwatch.OutcomeReady)
+
+	dep.mu.Lock()
+	defer dep.mu.Unlock()
+
+	if dep.Status != "failed" {
+		t.Fatalf("Status = %q, want failed (no default StorageClass)", dep.Status)
+	}
+	if dep.Result.Phase1Outcome != provisioner.ReasonDefaultStorageClassEphemeral {
+		t.Errorf("Phase1Outcome = %q, want %q", dep.Result.Phase1Outcome, provisioner.ReasonDefaultStorageClassEphemeral)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -765,7 +765,40 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 	// terminal log line + the secondary-degraded warn below.
 	regionHealth := dep.Result.Regions
 	secondaryDegraded := dep.Result.SecondaryDegraded
+	// #3971 — capture the kubeconfig path + ready-ness under the lock so
+	// the storage-durability gate (run AFTER the unlock, off the lock, so
+	// its bounded apiserver List never blocks a concurrent State() snapshot)
+	// can probe the primary cluster's default StorageClass.
+	storageGateKubeconfig := dep.Result.KubeconfigPath
+	storageGateEligible := dep.Status == "ready"
 	dep.mu.Unlock()
+
+	// #3971 STORAGE DURABILITY GATE — sibling of the #3375 DR gate above,
+	// run off-lock because it issues a bounded apiserver call. An otherwise-
+	// ready Sovereign whose resolved DEFAULT StorageClass is still the k3s
+	// ephemeral local-path (rancher.io/local-path) must NOT be claimed
+	// ready: every PVC (prod Postgres 3×100Gi, openbao secrets, customer-Org
+	// DB, …) would land on node-local disk and be destroyed by a node
+	// replacement. The bootstrap-kit installs the per-provider cloud CSI
+	// (bp-hcloud-csi slot 55a on Hetzner) which flips the default to a
+	// durable cloud volume; this gate verifies the flip actually took. It is
+	// CONSERVATIVE: it only DOWNGRADES ready→failed on a POSITIVE local-path
+	// observation. A probe error (unreadable kubeconfig, apiserver blip,
+	// missing path) SKIPS the gate — it never invents a failure, mirroring
+	// the surface-not-gate discipline for slow/transient conditions.
+	if storageGateEligible {
+		if reason := h.evaluateStorageDurabilityGate(dep, storageGateKubeconfig); reason != "" {
+			dep.mu.Lock()
+			// Re-check the deployment hasn't been adopted in the gap.
+			if dep.Status == "ready" {
+				dep.Status = "failed"
+				dep.Error = reason
+				dep.Result.Phase1Outcome = provisioner.ReasonDefaultStorageClassEphemeral
+				finalStatus = "failed"
+			}
+			dep.mu.Unlock()
+		}
+	}
 
 	// Persist the deployment record after the status flip so a
 	// concurrent State() snapshot picked up by the wizard's poll
@@ -926,6 +959,84 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 		// markPhase1Done returns.
 		h.runSecondaryBridgeBackfill(dep)
 	}
+}
+
+// evaluateStorageDurabilityGate probes the primary Sovereign cluster's
+// default StorageClass (#3971) and returns a non-empty failure reason ONLY
+// when the default is the k3s ephemeral local-path provisioner — the
+// non-durable condition the bootstrap-kit's per-provider cloud CSI is
+// supposed to flip away from. Empty return = PASS (durable default) or SKIP
+// (probe could not run; we never invent a failure from a probe error).
+//
+// Read-only per docs/PRINCIPLES.md #3 — it lists StorageClasses, patches
+// nothing. The probe is bounded by the helmwatch rest.Config timeout (30s).
+//
+// The actual probe is injectable via h.phase1StorageGate so unit tests can
+// drive the ready→failed flip with a canned result; production binds the
+// kubeconfig-reading helmwatch.DefaultStorageClassFromKubeconfig.
+func (h *Handler) evaluateStorageDurabilityGate(dep *Deployment, kubeconfigPath string) string {
+	if kubeconfigPath == "" {
+		// No kubeconfig path captured (older record / short-circuit) —
+		// cannot probe; SKIP rather than fail a ready deployment.
+		return ""
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	probe := h.phase1StorageGate
+	if probe == nil {
+		// Production default: read the kubeconfig file off the PVC and
+		// query the live cluster's StorageClasses with a typed client.
+		probe = func(ctx context.Context, path string) (helmwatch.DefaultStorageClassInfo, error) {
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				return helmwatch.DefaultStorageClassInfo{}, fmt.Errorf("read kubeconfig %s: %w", path, err)
+			}
+			return helmwatch.DefaultStorageClassFromKubeconfig(ctx, string(raw))
+		}
+	}
+
+	info, err := probe(ctx, kubeconfigPath)
+	if err != nil {
+		// Probe failed (apiserver blip, unreadable kubeconfig) — SKIP.
+		// A transient probe error must never downgrade a ready Sovereign;
+		// the gate fires only on a POSITIVE local-path observation.
+		h.log.Warn("phase 1 default-StorageClass durability gate could not probe the new Sovereign — skipping (will not downgrade ready); inspect `kubectl get sc` manually (#3971)",
+			"id", dep.ID,
+			"err", err,
+		)
+		return ""
+	}
+
+	if !info.Found {
+		// No default StorageClass at all — distinct from local-path, but
+		// still a misconfiguration (every PVC without an explicit
+		// storageClassName stays Pending forever). Fail the prov honestly.
+		h.log.Error("phase 1 storage gate: NO default StorageClass on the new Sovereign — every PVC without an explicit storageClassName will hang Pending (#3971)",
+			"id", dep.ID,
+		)
+		return "Phase 1 storage durability gate failed: the new Sovereign has NO default StorageClass. Every PVC that omits storageClassName (cnpg, openbao, keycloak, gitea, harbor) will stay Pending forever. The bootstrap-kit's cloud block-storage CSI (bp-hcloud-csi on Hetzner) did not install or did not flip the cluster default. Operator: inspect `kubectl get sc` and `flux get helmrelease bp-hcloud-csi -n flux-system` on the new cluster (#3971)."
+	}
+
+	if info.Ephemeral {
+		h.log.Error("phase 1 storage gate: default StorageClass is the EPHEMERAL k3s local-path — production data is non-durable (#3971)",
+			"id", dep.ID,
+			"defaultStorageClass", info.Name,
+			"provisioner", info.Provisioner,
+		)
+		return fmt.Sprintf("Phase 1 storage durability gate failed: the new Sovereign's default StorageClass is %q (%s) — ephemeral node-local disk with NO cloud block volume behind it. Every PVC (prod Postgres 3×100Gi, openbao secrets, customer-Org DB, keycloak/gitea/harbor) would be destroyed by a node replacement, invalidating the BCP/DR model. The bootstrap-kit's cloud block-storage CSI (bp-hcloud-csi slot 55a on Hetzner) did not install or did not flip the cluster default to a durable cloud volume. Operator: inspect `kubectl get sc` and `flux get helmrelease bp-hcloud-csi -n flux-system` on the new cluster (#3971).", info.Name, info.Provisioner)
+	}
+
+	// Durable default (cloud CSI). PASS. Log the success so the condition
+	// is greppable in the catalyst-api logs alongside the other gates.
+	h.log.Info("phase 1 storage durability gate passed: default StorageClass is a durable cloud volume (#3971)",
+		"id", dep.ID,
+		"defaultStorageClass", info.Name,
+		"provisioner", info.Provisioner,
+		"multipleDefaults", info.MultipleDefaults,
+	)
+	return ""
 }
 
 // primaryRegionKey returns the declared primary region's key for the

--- a/products/catalyst/bootstrap/api/internal/helmwatch/storageclass.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/storageclass.go
@@ -1,0 +1,102 @@
+// Default-StorageClass durability probe (#3971).
+//
+// The P0 blocker #3971: k3s ships local-path (rancher.io/local-path) as the
+// cluster-default StorageClass, and with no cloud block-storage CSI installed
+// EVERY PVC on a Sovereign landed on ephemeral node-local disk — a node
+// replacement destroys the data (prod Postgres, openbao secrets, customer DB).
+// The bootstrap-kit now installs a per-provider cloud CSI (bp-hcloud-csi on
+// Hetzner) and flips the default class to the durable cloud volume.
+//
+// DefaultStorageClassFromKubeconfig is the read-only probe the Phase-1 DoD
+// gate (handler.markPhase1Done) uses to FAIL a prov whose resolved default
+// StorageClass is still local-path — so a Sovereign can never silently come
+// up on ephemeral storage again. Per docs/PRINCIPLES.md the probe is
+// strictly read-only: it lists StorageClasses and reports the default's
+// name + provisioner. It never patches anything.
+package helmwatch
+
+import (
+	"context"
+	"fmt"
+
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// defaultStorageClassAnnotation is the canonical Kubernetes annotation that
+// marks a StorageClass as the cluster default.
+const defaultStorageClassAnnotation = "storageclass.kubernetes.io/is-default-class"
+
+// LocalPathProvisioner is the k3s-shipped ephemeral provisioner. A default
+// StorageClass backed by this provisioner is the #3971 failure condition.
+const LocalPathProvisioner = "rancher.io/local-path"
+
+// DefaultStorageClassInfo is the result of the default-class probe: the name
+// + provisioner of the cluster's default StorageClass, and whether exactly
+// one default was found. Ephemeral is true when the default's provisioner is
+// the k3s local-path provisioner (the #3971 non-durable condition).
+type DefaultStorageClassInfo struct {
+	// Name of the default StorageClass ("" when none is marked default).
+	Name string
+	// Provisioner of the default StorageClass (its .provisioner field).
+	Provisioner string
+	// Found is true when exactly one StorageClass is marked default.
+	Found bool
+	// MultipleDefaults is true when >1 StorageClass carries the default
+	// annotation — an error state Kubernetes resolves non-deterministically.
+	MultipleDefaults bool
+	// Ephemeral is true when the default's provisioner is local-path (the
+	// non-durable, node-bound k3s provisioner) — the #3971 failure.
+	Ephemeral bool
+}
+
+// storageClassLister is the minimal surface DefaultStorageClassInfoFromList
+// needs — a typed kubernetes.Interface satisfies it via
+// StorageV1().StorageClasses().List. Tests inject a fake.NewSimpleClientset.
+type storageClassLister interface {
+	List(ctx context.Context, opts metav1.ListOptions) (*storagev1.StorageClassList, error)
+}
+
+// DefaultStorageClassInfoFromList computes the default-class info from a live
+// StorageClass list. Pulled out of the kubeconfig path so unit tests can
+// drive it with a fake clientset without a real cluster.
+func DefaultStorageClassInfoFromList(ctx context.Context, lister storageClassLister) (DefaultStorageClassInfo, error) {
+	list, err := lister.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return DefaultStorageClassInfo{}, fmt.Errorf("list storageclasses: %w", err)
+	}
+
+	info := DefaultStorageClassInfo{}
+	defaults := 0
+	for i := range list.Items {
+		sc := &list.Items[i]
+		if sc.Annotations[defaultStorageClassAnnotation] != "true" {
+			continue
+		}
+		defaults++
+		// First default wins for the reported Name/Provisioner; the
+		// MultipleDefaults flag captures the >1 error state separately.
+		if !info.Found {
+			info.Name = sc.Name
+			info.Provisioner = sc.Provisioner
+			info.Found = true
+			info.Ephemeral = sc.Provisioner == LocalPathProvisioner
+		}
+	}
+	info.MultipleDefaults = defaults > 1
+	return info, nil
+}
+
+// DefaultStorageClassFromKubeconfig builds a typed client from the new
+// Sovereign's kubeconfig and reports its default StorageClass. The same
+// rest.Config.Timeout treatment as the rest of the helmwatch path (issue
+// #923) so a hung apiserver fails fast rather than blocking the gate.
+//
+// Read-only (docs/PRINCIPLES.md #3) — lists StorageClasses, patches nothing.
+func DefaultStorageClassFromKubeconfig(ctx context.Context, kubeconfigYAML string) (DefaultStorageClassInfo, error) {
+	clientset, err := NewKubernetesClientFromKubeconfig(kubeconfigYAML)
+	if err != nil {
+		return DefaultStorageClassInfo{}, err
+	}
+	return DefaultStorageClassInfoFromList(ctx, clientset.StorageV1().StorageClasses())
+}

--- a/products/catalyst/bootstrap/api/internal/helmwatch/storageclass_test.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/storageclass_test.go
@@ -1,0 +1,96 @@
+// storageclass_test.go — #3971 default-StorageClass durability probe.
+// Proves DefaultStorageClassInfoFromList correctly classifies the cluster
+// default: ephemeral local-path (the P0 failure), durable cloud CSI (pass),
+// no default, and the multiple-defaults error state.
+
+package helmwatch
+
+import (
+	"context"
+	"testing"
+
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func sc(name, provisioner string, isDefault bool) *storagev1.StorageClass {
+	ann := map[string]string{}
+	if isDefault {
+		ann[defaultStorageClassAnnotation] = "true"
+	}
+	return &storagev1.StorageClass{
+		ObjectMeta:  metav1.ObjectMeta{Name: name, Annotations: ann},
+		Provisioner: provisioner,
+	}
+}
+
+func TestDefaultStorageClassInfoFromList(t *testing.T) {
+	tests := []struct {
+		name         string
+		objs         []*storagev1.StorageClass
+		wantFound    bool
+		wantName     string
+		wantEphem    bool
+		wantMultiple bool
+	}{
+		{
+			name:      "ephemeral local-path default — the #3971 failure",
+			objs:      []*storagev1.StorageClass{sc("local-path", LocalPathProvisioner, true)},
+			wantFound: true,
+			wantName:  "local-path",
+			wantEphem: true,
+		},
+		{
+			name: "durable hcloud-volumes default — pass",
+			objs: []*storagev1.StorageClass{
+				sc("local-path", LocalPathProvisioner, false),
+				sc("hcloud-volumes", "csi.hetzner.cloud", true),
+			},
+			wantFound: true,
+			wantName:  "hcloud-volumes",
+			wantEphem: false,
+		},
+		{
+			name:      "no default at all",
+			objs:      []*storagev1.StorageClass{sc("local-path", LocalPathProvisioner, false)},
+			wantFound: false,
+		},
+		{
+			name: "multiple defaults flagged",
+			objs: []*storagev1.StorageClass{
+				sc("local-path", LocalPathProvisioner, true),
+				sc("hcloud-volumes", "csi.hetzner.cloud", true),
+			},
+			wantFound:    true,
+			wantMultiple: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			objs := make([]runtime.Object, 0, len(tc.objs))
+			for _, o := range tc.objs {
+				objs = append(objs, o)
+			}
+			cs := kfake.NewSimpleClientset(objs...)
+			info, err := DefaultStorageClassInfoFromList(context.Background(), cs.StorageV1().StorageClasses())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if info.Found != tc.wantFound {
+				t.Errorf("Found = %v, want %v", info.Found, tc.wantFound)
+			}
+			if tc.wantName != "" && info.Name != tc.wantName {
+				t.Errorf("Name = %q, want %q", info.Name, tc.wantName)
+			}
+			if info.Ephemeral != tc.wantEphem {
+				t.Errorf("Ephemeral = %v, want %v", info.Ephemeral, tc.wantEphem)
+			}
+			if info.MultipleDefaults != tc.wantMultiple {
+				t.Errorf("MultipleDefaults = %v, want %v", info.MultipleDefaults, tc.wantMultiple)
+			}
+		})
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -1357,6 +1357,18 @@ func detectPartialRegionMaterialisation(declaredRegions []RegionSpec, perRegion 
 // Sovereign cannot honour must NOT be stamped `ready`.
 const ReasonStandbyRegionAbsent = "standby-region-absent"
 
+// ReasonDefaultStorageClassEphemeral is the canonical Phase-1 failure
+// reason stamped when an otherwise-ready Sovereign's resolved DEFAULT
+// StorageClass is still the k3s ephemeral local-path provisioner
+// (rancher.io/local-path) — meaning no cloud block-storage CSI flipped
+// the default to a durable volume (#3971). Every PVC (prod Postgres
+// 3×100Gi, openbao secrets, customer-Org DB, …) would land on node-local
+// disk and be destroyed by any node replacement, invalidating the BCP/DR
+// model. It is the storage sibling of ReasonStandbyRegionAbsent: a
+// durability guarantee the Sovereign cannot honour must NOT be stamped
+// `ready`.
+const ReasonDefaultStorageClassEphemeral = "default-storageclass-ephemeral"
+
 // DeclaredDRStandbyIntegrity reports whether a multi-region DR topology's
 // standby half is structurally PRESENT, given:
 //

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2920,7 +2920,8 @@ name: bp-catalyst-platform
 # authenticated mint (verified live hw172, dep b50ba61d9cb9e157). Now any HTTP
 # answer (non-000 code) = reachable; only a connect failure keeps waiting —
 # removing a 14min dead-wait from the console-up critical path.
-version: 1.4.744
+# 1.4.745 (#3971): CNPG storageClass empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN.
+version: 1.4.745
 # 1.4.702 — #3819 #3854 #3859 (Refs #3383 #3376): sme→org-services rename TAIL — the
 #   funnel/BSS control-plane templates + values default the namespace to `org-services`
 #   instead of the dead `sme` ns: provisioning-github-token / valkey-cross-ns-secret +

--- a/products/catalyst/chart/templates/org-services/cnpg-cluster.yaml
+++ b/products/catalyst/chart/templates/org-services/cnpg-cluster.yaml
@@ -127,7 +127,10 @@ spec:
 
   storage:
     size: {{ .Values.orgPostgres.cluster.storageSize | default "10Gi" }}
-    storageClass: {{ .Values.orgPostgres.cluster.storageClass | default "local-path" | quote }}
+    # #3971 — empty ⇒ omit ⇒ CNPG uses the cluster-default durable cloud CSI; local-path FORBIDDEN.
+    {{- with .Values.orgPostgres.cluster.storageClass }}
+    storageClass: {{ . | quote }}
+    {{- end }}
 
   # Organization init-databases Job (when enabled — see init-databases.yaml below)
   # connects as superuser to CREATE DATABASE / GRANT. Disabling this

--- a/products/catalyst/chart/templates/qa-fixtures/cnpg-clusters-qa.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/cnpg-clusters-qa.yaml
@@ -227,7 +227,10 @@ spec:
   primaryUpdateStrategy: unsupervised
   storage:
     size: {{ .Values.qaFixtures.cnpgStorageSize | default "1Gi" }}
-    storageClass: {{ .Values.qaFixtures.cnpgStorageClass | default "local-path" }}
+    # #3971 — empty ⇒ omit ⇒ CNPG uses the cluster-default durable cloud CSI; local-path FORBIDDEN.
+    {{- with .Values.qaFixtures.cnpgStorageClass }}
+    storageClass: {{ . | quote }}
+    {{- end }}
   resources:
     requests:
       cpu: 100m
@@ -304,7 +307,10 @@ spec:
   primaryUpdateStrategy: unsupervised
   storage:
     size: {{ .Values.qaFixtures.cnpgStorageSize | default "1Gi" }}
-    storageClass: {{ .Values.qaFixtures.cnpgStorageClass | default "local-path" }}
+    # #3971 — empty ⇒ omit ⇒ CNPG uses the cluster-default durable cloud CSI; local-path FORBIDDEN.
+    {{- with .Values.qaFixtures.cnpgStorageClass }}
+    storageClass: {{ . | quote }}
+    {{- end }}
   resources:
     requests:
       cpu: 100m

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -1455,7 +1455,7 @@ orgPostgres:
       - org_billing                 # billing service primary DB
       - org_documents               # FerretDB (MongoDB-wire) backing DB — issue #861
     storageSize: 10Gi
-    storageClass: local-path        # k3s default; per-Sovereign overlays may override
+    storageClass: ""  # #3971 — empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN
     resources:
       requests:
         cpu: 100m
@@ -2057,7 +2057,7 @@ qaFixtures:
   cnpgInstances: 1
   cnpgImage: ghcr.io/cloudnative-pg/postgresql:16.4-1
   cnpgStorageSize: 1Gi
-  cnpgStorageClass: local-path
+  cnpgStorageClass: ""  # #3971 — empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN
   cnpgDatabase: app
   # qa-loop iter-1 prefetch Fix #110: terminal phase string seeded onto
   # cluster-primary + cluster-replica `status.phase`. The CNPG operator

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -254,7 +254,11 @@ slots:
     wave: W2.K1
   - slot: 16
     name: bp-cnpg
-    depends_on: [bp-flux]
+    # #3971 — bp-hcloud-csi gates the durable default StorageClass that EVERY
+    # cnpg PVC (and its shared-pg / cnpg-pair / harbor / keycloak / gitea
+    # downstream) needs now that k3s runs --disable=local-storage (local-path
+    # FORBIDDEN). bp-hcloud-csi is Ready on both providers (empty on Huawei).
+    depends_on: [bp-flux, bp-hcloud-csi]
     wave: W2.K1
   - slot: 16a
     name: bp-postgres-shared
@@ -718,6 +722,11 @@ slots:
     depends_on:
       - bp-cilium
       - bp-cert-manager
+      # #3971 — bp-hcloud-csi gates the durable default StorageClass the
+      # vCluster StatefulSet PVC (and openbao/keycloak/gitea/harbor downstream
+      # of bp-mgmt-vcluster) need now that local-path is FORBIDDEN
+      # (--disable=local-storage). Ready on both providers (empty on Huawei).
+      - bp-hcloud-csi
     wave: present
 
   # ---- Slot 59 — bp-rtz-vcluster (DoD A4 — secondary-only RTZ vCluster).

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -672,6 +672,19 @@ slots:
     depends_on: []
     wave: present
 
+  # ---- Slot 55a — bp-hcloud-csi (Hetzner Cloud CSI driver, #3971).
+  # STORAGE sibling of slot 55. Installs csi.hetzner.cloud + the
+  # hcloud-volumes StorageClass (reclaimPolicy Retain) and flips the
+  # cluster-default OFF the ephemeral k3s local-path. No dependsOn: a
+  # foundational cloud seam that must be Ready before the stateful apps
+  # create PVCs (its cloud-credentials Secret is seeded by cloud-init
+  # pre-Flux, and the chart pulls from ghcr — no Flux dependency). The
+  # P0 fix for "every PVC lands on local-path". Suspended on Huawei.
+  - slot: 55a
+    name: bp-hcloud-csi
+    depends_on: []
+    wave: present
+
   # ---- Slots 56/57 — OpenovaFlow observability cohort.
   # Stateless HTTP+SSE event router (slot 56, primary cluster only) +
   # region-aware Flux adapter DaemonSet (slot 57, every cluster).


### PR DESCRIPTION
## #3971 — local-path FORBIDDEN: cloud CSI is the only durable default StorageClass

**P0 fix.** Every Sovereign's PVCs were landing on k3s `local-path` (ephemeral node-local disk, no cloud block volume) — a node replacement destroyed prod Postgres (3×100Gi), openbao secrets, the customer-Org DB, invalidating BCP/DR. The prior (recovered) commit installed the Hetzner CSI as default + a Phase-1 gate but **left local-path installed**. This PR closes the founder's gap: *"make the local paths not default even FORBIDDEN. local path never ever ALLOWED!!"*

### Three-layer local-path-FORBIDDEN defence
1. **k3s `--disable=local-storage`** (cloud-init) — the local-path provisioner is NEVER installed on a fresh prov. The old cloud-init block that asserted + patched local-path as cluster-default (FATAL if missing) is deleted.
2. **Cloud CSI is the only default, Ready before any PVC binds** — `bp-hcloud-csi` (slot 55a) is now a `dependsOn` of the two stateful ROOT gates (`bp-cnpg` 16 + `bp-mgmt-vcluster` 58), so every PVC-binding slot transitively waits for the durable default class → **no Pending-PVC regression**. To keep that dependsOn safe on **both** clouds (a dependsOn on a *suspended* HR deadlocks Flux), slot 55a is no longer `suspend`-ed on Huawei: it stays ACTIVE with `enabled=${HCLOUD_CSI_ENABLED}` — `true` on Hetzner (full CSI) / `false` on Huawei (empty render → Ready immediately). hcloud-token valuesFrom is now `optional: true`. expected-bootstrap-deps + placement.yaml + bootstrap-kit-crs all updated (0 drift, 0 cycle).
3. **Kyverno ENFORCE-always policy** (`bp-kyverno-policies` K23 `forbid-local-path-storage`) — DENIES any PVC / StorageClass / PV referencing `local-path` / `rancher.io/local-path`. Hardcoded `Enforce` (NOT bootstrapMode-gated) because the PVCs it guards are created *during* the bootstrap window. + pass/fail fixtures.

Plus the prior commit's **provider-agnostic Phase-1 storage-durability gate** (catalyst-api `markPhase1Done`): fails a prov whose resolved default SC is still local-path (or has none) — verified green.

### Blast-radius cleanup
Every chart that defaulted a CNPG/PVC `storageClass` to `local-path` now defaults to empty (⇒ CNPG binds the cluster-default durable cloud CSI): postgres, gitea, harbor, powerdns, powerdns-admin, openova-flow-server, guacamole, wordpress-tenant, products/catalyst (org-services + qa-fixtures), and 3 vcluster etcd-persistence values. `seaweedfs-storage` SC default provisioner `local-path` → `csi.hetzner.cloud`. All affected charts patch-bumped, render clean (no local-path emitted; override still works).

### Huawei CSI — remaining step (deliberate, documented)
The Huawei everest/EVS CSI (slot 55b) is **deferred** — its bare-k3s HCS manifests/version/provisioner are not verifiable without a live kom4dc cluster. The provider-agnostic Phase-1 gate already **FAILS** a Huawei prov that comes up on local-path (no silent ephemeral storage). The precise grounded plan (slot 55b, creds, chart, the `huawei-project-id` cloud-credentials bug) is in `docs/sessions/2026-06-20/3971-huawei-everest-evs-csi-plan.md`.

### Verification
CSI is a fresh-prov/cloud-init change — it **cannot** be live-walked on hw173; the honest acceptance is the **next fresh prov**: `kubectl get sc` shows the cloud CSI default, local-path is absent (k3s `--disable=local-storage`), the Kyverno policy + Phase-1 gate block any local-path, and zero PVCs on local-path.

Gates run green:
- `scripts/lint-cloudinit.sh both` — PASS (hetzner 61903B / huawei 70558B, dash -n clean).
- `tofu test` — **hetzner 10/0**, **huawei 5/0** (incl. user_data size guardrails).
- `kubectl kustomize` bootstrap-kit + bootstrap-kit-crs — clean.
- `scripts/check-bootstrap-deps.sh` — 0 drift, 0 cycle (CSI dependsOn introduces no cycle).
- `scripts/render-slot-placement.py check` — PASS.
- `helm template` all touched charts + per-chart render tests (postgres/gitea/harbor/guacamole/vcluster/seaweedfs/…) — green.
- `go build/vet/test` (handler + helmwatch storage gate) — green.

### Deliberately excluded (flagged, not silently broken)
The `omantel.omani.works` live overlay deliberately pins `storageClass: local-path` (single-CSI chroot, no SeaweedFS-CSI) with its own rationale comment. Left as-is — when this lands on omantel it will need an overlay update or a per-namespace Kyverno exclusion. Not a fresh-prov #3971 concern.

Refs #3971

🤖 Generated with [Claude Code](https://claude.com/claude-code)