### PR TITLE
fix(#3991): in-cluster catalyst-api reaches region-b apiserver via VPC-peered private IP (EIP was region-a-unroutable)

### DIFF
--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -988,9 +988,18 @@ locals {
           PRIMARY_HOST='${local.name_prefix}-${local.region_keys[0]}-cp1-${substr(sha256("${var.deployment_id}-${local.region_keys[0]}-cp0-${var.retry_attempt}"), 0, 6)}'
           MY_REGION='${idx == 0 ? r.code : "${r.code}-${idx}"}'
           MY_EIP='${huaweicloud_vpc_eip.cp[r.code].publicip.0.ip_address}'
+          # #3991 — this CP's PRIVATE eth0 IP (same detection as --node-ip).
+          # The kubeconfig keeps MY_EIP as `server:` so the EXTERNAL mothership
+          # can reach this region. We ALSO ship the private IP so the IN-CLUSTER
+          # catalyst-api (chroot), which sits inside region-a's VPC and cannot
+          # route to this region's DNAT'd EIP, can rewrite the server host to
+          # this VPC-peered private IP it CAN reach (over the cross-VPC peering
+          # routes provisioned above). The k3s apiserver lists NODE_IP as a TLS
+          # SAN, so the pinned-CA handshake still validates after the swap.
+          export MY_NODE_IP=$(ip -4 -o addr show dev eth0 | awk '{print $4}' | cut -d/ -f1)
           if [ -n "${var.deployment_id}" ] && [ -n "${var.kubeconfig_bearer_token}" ] && [ "$${HOSTNAME}" != "$${PRIMARY_HOST}" ] && [ -n "$${MY_REGION}" ] && [ -n "$${MY_EIP}" ]; then
             sed "s|server: https://127.0.0.1:6443|server: https://$${MY_EIP}:6443|" /etc/rancher/k3s/k3s.yaml > /tmp/kubeconfig-secondary.yaml
-            python3 -c "import json; print(json.dumps({'deploymentId':'${var.deployment_id}','regionKey':'$${MY_REGION}','kubeconfigYaml':open('/tmp/kubeconfig-secondary.yaml').read()}))" > /tmp/secondary-kubeconfig-body.json
+            python3 -c "import json,os; print(json.dumps({'deploymentId':'${var.deployment_id}','regionKey':'$${MY_REGION}','kubeconfigYaml':open('/tmp/kubeconfig-secondary.yaml').read(),'nodeInternalIp':os.environ.get('MY_NODE_IP','')}))" > /tmp/secondary-kubeconfig-body.json
             for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
               HTTP_CODE=$(curl -sk -o /dev/null -w '%%{http_code}' -X POST \
                 -H "Authorization: Bearer ${var.kubeconfig_bearer_token}" \

--- a/products/catalyst/bootstrap/api/internal/handler/deployment_handover_export.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployment_handover_export.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 )
@@ -208,6 +209,18 @@ func (h *Handler) exportSecondaryKubeconfigsToChild(dep *Deployment, fqdn, depID
 				"deploymentId":   depID,
 				"regionKey":      regionKey,
 				"kubeconfigYaml": string(raw),
+			}
+			// #3991 — replay the secondary CP's private node IP (if the
+			// CP supplied one and we stashed it as a sidecar) so the
+			// chroot can rewrite the kubeconfig's server host from the
+			// VPC-external EIP to the VPC-peered private IP it can route
+			// to. Best-effort: a missing sidecar means the chroot keeps
+			// the EIP (pre-#3991 behaviour).
+			clusterID := depID + "-" + regionKey
+			if ipRaw, ierr := os.ReadFile(nodeIPSidecarPath(dir, clusterID)); ierr == nil {
+				if ip := strings.TrimSpace(string(ipRaw)); ip != "" {
+					payload["nodeInternalIp"] = ip
+				}
 			}
 			body, _ := json.Marshal(payload)
 			h.postSecondaryKubeconfigWithRetry(client, url, body, depID, regionKey)

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_secondary_kubeconfig.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_secondary_kubeconfig.go
@@ -34,7 +34,9 @@ package handler
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -57,10 +59,81 @@ func kubeconfigsDir() string {
 // match the on-disk filename suffix convention `<depID>-<region>.yaml`
 // (e.g. depID="abc123", region="nbg1-1" → /var/lib/catalyst/kubeconfigs/
 // abc123-nbg1-1.yaml). KubeconfigYAML is the raw kubeconfig bytes.
+//
+// NodeInternalIP (#3991) — the secondary CP's PRIVATE node IP, detected
+// at cloud-init time by the same `ip -4 -o addr show dev eth0` the k3s
+// `--node-ip` uses. The IaC writes the kubeconfig's server URL to the
+// region's PUBLIC EIP (`MY_EIP`) because the EXTERNAL mothership — which
+// loads this same kubeconfig into its own k8sCache — sits outside both
+// per-region VPCs and can only reach the DNAT'd EIP. But the IN-CLUSTER
+// catalyst-api (the chroot) runs INSIDE region-a's VPC, where that EIP
+// is unroutable (HCS DNAT is external-only; verified live on hw173:
+// region-a pod → EIP:6443 times out, region-a pod → peer private-IP:6443
+// is OPEN over the existing cross-VPC peering). So the chroot rewrites
+// the server host to this private IP, which IS region-a-routable via the
+// VPC-peering routes provisioned by the huawei/hetzner IaC. The k3s
+// apiserver cert already carries `--tls-san=$NODE_IP`, so the pinned-CA
+// TLS handshake still validates after the host swap. Optional + only
+// honoured on a chroot (SOVEREIGN_FQDN set); empty/absent → no rewrite
+// (mothership keeps the EIP).
 type secondaryKubeconfigRequest struct {
 	DeploymentID   string `json:"deploymentId"`
 	RegionKey      string `json:"regionKey"`
 	KubeconfigYAML string `json:"kubeconfigYaml"`
+	NodeInternalIP string `json:"nodeInternalIp,omitempty"`
+}
+
+// rewriteKubeconfigServerHost replaces the host:port host portion of the
+// `server:` URL(s) in a kubeconfig with newHost, preserving the scheme,
+// port, and path. Returns the rewritten bytes and the number of server
+// lines changed. A kubeconfig with multiple clusters has its every
+// server line rewritten (a secondary k3s kubeconfig has exactly one).
+//
+// Only the HOST is swapped — scheme (https), port (6443), and any path
+// stay intact, so the pinned `certificate-authority-data` continues to
+// validate against the apiserver cert (which lists the node IP as a SAN).
+func rewriteKubeconfigServerHost(raw, newHost string) (string, int) {
+	newHost = strings.TrimSpace(newHost)
+	if newHost == "" {
+		return raw, 0
+	}
+	lines := strings.Split(raw, "\n")
+	changed := 0
+	for i, line := range lines {
+		trimmed := strings.TrimLeft(line, " \t")
+		if !strings.HasPrefix(trimmed, "server:") {
+			continue
+		}
+		indent := line[:len(line)-len(trimmed)]
+		rawURL := strings.TrimSpace(strings.TrimPrefix(trimmed, "server:"))
+		u, err := url.Parse(rawURL)
+		if err != nil || u.Host == "" {
+			continue
+		}
+		port := u.Port()
+		if port != "" {
+			u.Host = net.JoinHostPort(newHost, port)
+		} else {
+			u.Host = newHost
+		}
+		lines[i] = indent + "server: " + u.String()
+		changed++
+	}
+	if changed == 0 {
+		return raw, 0
+	}
+	return strings.Join(lines, "\n"), changed
+}
+
+// isChroot reports whether this catalyst-api runs as an in-cluster
+// Sovereign (chroot) rather than the external mothership. The canonical
+// discriminator used throughout the handler package is the SOVEREIGN_FQDN
+// env: set on every Sovereign by the bp-catalyst-platform chart, unset on
+// the mothership. Only the chroot rewrites the secondary kubeconfig to the
+// VPC-peered private IP (#3991); the mothership keeps the public EIP it
+// needs to reach the region from outside the VPC.
+func isChroot() bool {
+	return strings.TrimSpace(os.Getenv("SOVEREIGN_FQDN")) != ""
 }
 
 // safeIDPattern rejects path-traversal + shell-meta in deploymentId
@@ -68,6 +141,15 @@ type secondaryKubeconfigRequest struct {
 // depth — the filename is composed from these and written to a
 // shared-PVC directory.
 var safeIDPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,62}$`)
+
+// nodeIPSidecarPath is the on-disk path of the private-node-IP sidecar
+// for a secondary cluster (#3991). It sits next to `<clusterID>.yaml` as
+// `<clusterID>.nodeip` so the mothership's handover forward can replay
+// the IP to the chroot. The `.nodeip` extension keeps it out of
+// LoadClustersFromDir's `*.yaml` glob.
+func nodeIPSidecarPath(dir, clusterID string) string {
+	return filepath.Join(dir, clusterID+".nodeip")
+}
 
 // HandleSovereignSecondaryKubeconfig handles POST
 // /api/v1/sovereign/secondary-kubeconfig.
@@ -115,6 +197,37 @@ func (h *Handler) HandleSovereignSecondaryKubeconfig(w http.ResponseWriter, r *h
 		})
 		return
 	}
+
+	// #3991 — cross-region datapath fix. The IaC stamps the secondary
+	// region's `server:` URL to its PUBLIC EIP so the external mothership
+	// (outside the per-region VPCs) can reach it. But the IN-CLUSTER
+	// catalyst-api (chroot) runs inside region-a's VPC, where the peer
+	// region's EIP is unroutable (HCS DNAT is external-only). When a
+	// nodeInternalIp is supplied AND we are the chroot, rewrite the server
+	// host to that VPC-peered private IP — region-a-routable via the
+	// IaC's cross-VPC peering routes, and still cert-valid because the k3s
+	// apiserver lists the node IP as a TLS SAN. The mothership (no
+	// SOVEREIGN_FQDN) leaves the kubeconfig untouched: it keeps the EIP.
+	nodeIP := strings.TrimSpace(body.NodeInternalIP)
+	if nodeIP != "" && net.ParseIP(nodeIP) == nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":  "invalid-nodeInternalIp",
+			"detail": "nodeInternalIp must be a valid IP address",
+		})
+		return
+	}
+	if nodeIP != "" && isChroot() {
+		rewritten, n := rewriteKubeconfigServerHost(raw, nodeIP)
+		if n > 0 {
+			raw = rewritten
+			h.log.Info("secondary-kubeconfig: rewrote server host to VPC-peered private IP (#3991)",
+				"depId", body.DeploymentID,
+				"region", body.RegionKey,
+				"serversRewritten", n,
+			)
+		}
+	}
+
 	dir := kubeconfigsDir()
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		h.log.Warn("secondary-kubeconfig: mkdir failed", "dir", dir, "err", err)
@@ -133,6 +246,19 @@ func (h *Handler) HandleSovereignSecondaryKubeconfig(w http.ResponseWriter, r *h
 			"detail": err.Error(),
 		})
 		return
+	}
+
+	// #3991 — persist the private node IP as a sidecar so the mothership's
+	// handover forward (exportSecondaryKubeconfigsToChild) can replay it to
+	// the chroot, which is the consumer that must rewrite EIP→private-IP.
+	// Best-effort: a missing sidecar simply means the chroot keeps the EIP
+	// (the pre-#3991 behaviour), so a write failure must not fail the POST.
+	if nodeIP != "" {
+		sidecar := nodeIPSidecarPath(dir, clusterID)
+		if werr := os.WriteFile(sidecar, []byte(nodeIP), 0o600); werr != nil {
+			h.log.Warn("secondary-kubeconfig: node-ip sidecar write failed (non-fatal)",
+				"path", sidecar, "err", werr)
+		}
 	}
 	if err := h.k8sCache.AddCluster(k8scache.ClusterRef{
 		ID:             clusterID,

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_secondary_kubeconfig_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_secondary_kubeconfig_test.go
@@ -1,0 +1,254 @@
+// sovereign_secondary_kubeconfig_test.go — #3991 cross-region datapath fix.
+//
+// Proves the chroot rewrites a secondary region's kubeconfig `server:`
+// host from the VPC-external EIP to the VPC-peered private node IP it can
+// route to, while the mothership leaves the EIP untouched. Root-caused
+// live on hw173: the in-cluster catalyst-api (region-a) times out on
+// region-b's DNAT'd EIP (212.72.24.35:6443) but reaches region-b's
+// private cp1 IP (10.179.1.131:6443) over the existing cross-VPC peering.
+
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// secondaryKubeconfigFixture is a minimal but valid kubeconfig whose
+// server points at the VPC-external EIP, mirroring what the IaC stamps.
+const secondaryKubeconfigFixture = `apiVersion: v1
+kind: Config
+clusters:
+- name: default
+  cluster:
+    certificate-authority-data: ` + fakeCAData + `
+    server: https://212.72.24.35:6443
+contexts:
+- name: default
+  context:
+    cluster: default
+    user: default
+current-context: default
+users:
+- name: default
+  user:
+    token: fake-token
+`
+
+// fakeCAData is a syntactically valid base64 CA blob so clientcmd parses
+// the kubeconfig without reaching the network.
+const fakeCAData = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJoRENDQVN1Z0F3SUJBZ0lRREMtLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+
+func TestRewriteKubeconfigServerHost(t *testing.T) {
+	tests := []struct {
+		name       string
+		raw        string
+		newHost    string
+		wantHost   string
+		wantChange int
+	}{
+		{
+			name:       "eip swapped for private ip, port + scheme preserved",
+			raw:        "    server: https://212.72.24.35:6443\n",
+			newHost:    "10.179.1.131",
+			wantHost:   "    server: https://10.179.1.131:6443\n",
+			wantChange: 1,
+		},
+		{
+			name:       "empty newHost is a no-op",
+			raw:        "    server: https://212.72.24.35:6443\n",
+			newHost:    "",
+			wantHost:   "    server: https://212.72.24.35:6443\n",
+			wantChange: 0,
+		},
+		{
+			name:       "no server line is a no-op",
+			raw:        "apiVersion: v1\nkind: Config\n",
+			newHost:    "10.179.1.131",
+			wantHost:   "apiVersion: v1\nkind: Config\n",
+			wantChange: 0,
+		},
+		{
+			name:       "indentation preserved",
+			raw:        "        server: https://1.2.3.4:6443",
+			newHost:    "10.0.0.9",
+			wantHost:   "        server: https://10.0.0.9:6443",
+			wantChange: 1,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, n := rewriteKubeconfigServerHost(tc.raw, tc.newHost)
+			if got != tc.wantHost {
+				t.Errorf("rewrite host = %q, want %q", got, tc.wantHost)
+			}
+			if n != tc.wantChange {
+				t.Errorf("changed count = %d, want %d", n, tc.wantChange)
+			}
+		})
+	}
+}
+
+func TestIsChroot(t *testing.T) {
+	t.Run("set => chroot", func(t *testing.T) {
+		t.Setenv("SOVEREIGN_FQDN", "t99.omani.works")
+		if !isChroot() {
+			t.Fatal("isChroot()=false with SOVEREIGN_FQDN set")
+		}
+	})
+	t.Run("unset => mothership", func(t *testing.T) {
+		t.Setenv("SOVEREIGN_FQDN", "")
+		if isChroot() {
+			t.Fatal("isChroot()=true with SOVEREIGN_FQDN unset")
+		}
+	})
+}
+
+// postSecondaryKubeconfig drives the handler and returns the recorder.
+func postSecondaryKubeconfig(t *testing.T, h *Handler, body map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sovereign/secondary-kubeconfig", bytes.NewReader(raw))
+	rec := httptest.NewRecorder()
+	h.HandleSovereignSecondaryKubeconfig(rec, req)
+	return rec
+}
+
+// TestSecondaryKubeconfig_ChrootRewritesServerToPrivateIP is the #3991
+// acceptance unit: on a chroot, a POST carrying nodeInternalIp persists a
+// kubeconfig whose server host is the PRIVATE IP (region-a-routable), not
+// the EIP.
+func TestSecondaryKubeconfig_ChrootRewritesServerToPrivateIP(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CATALYST_K8SCACHE_KUBECONFIGS_DIR", dir)
+	t.Setenv("SOVEREIGN_FQDN", "t99.omani.works") // chroot
+
+	cache := newK8sCacheWithClusters(t, nil)
+	h := &Handler{
+		log:      slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		k8sCache: cache,
+	}
+
+	rec := postSecondaryKubeconfig(t, h, map[string]string{
+		"deploymentId":   "dep3991",
+		"regionKey":      "me-east-215-b-1",
+		"kubeconfigYaml": secondaryKubeconfigFixture,
+		"nodeInternalIp": "10.179.1.131",
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	onDisk, err := os.ReadFile(filepath.Join(dir, "dep3991-me-east-215-b-1.yaml"))
+	if err != nil {
+		t.Fatalf("read persisted kubeconfig: %v", err)
+	}
+	got := string(onDisk)
+	if !strings.Contains(got, "server: https://10.179.1.131:6443") {
+		t.Errorf("persisted kubeconfig did not get private-IP server; got:\n%s", got)
+	}
+	if strings.Contains(got, "212.72.24.35") {
+		t.Errorf("persisted kubeconfig still carries the EIP; got:\n%s", got)
+	}
+}
+
+// TestSecondaryKubeconfig_MothershipKeepsEIP proves the no-regression
+// guarantee: with SOVEREIGN_FQDN unset (mothership) the server host is
+// left as the EIP — the external mothership needs it.
+func TestSecondaryKubeconfig_MothershipKeepsEIP(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CATALYST_K8SCACHE_KUBECONFIGS_DIR", dir)
+	t.Setenv("SOVEREIGN_FQDN", "") // mothership
+
+	cache := newK8sCacheWithClusters(t, nil)
+	h := &Handler{
+		log:      slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		k8sCache: cache,
+	}
+
+	rec := postSecondaryKubeconfig(t, h, map[string]string{
+		"deploymentId":   "dep3991",
+		"regionKey":      "me-east-215-b-1",
+		"kubeconfigYaml": secondaryKubeconfigFixture,
+		"nodeInternalIp": "10.179.1.131",
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	onDisk, err := os.ReadFile(filepath.Join(dir, "dep3991-me-east-215-b-1.yaml"))
+	if err != nil {
+		t.Fatalf("read persisted kubeconfig: %v", err)
+	}
+	got := string(onDisk)
+	if !strings.Contains(got, "server: https://212.72.24.35:6443") {
+		t.Errorf("mothership rewrote the EIP; expected it preserved. got:\n%s", got)
+	}
+
+	// The mothership stashes the private IP as a sidecar for handover replay.
+	sidecar, err := os.ReadFile(filepath.Join(dir, "dep3991-me-east-215-b-1.nodeip"))
+	if err != nil {
+		t.Fatalf("expected node-ip sidecar on mothership: %v", err)
+	}
+	if strings.TrimSpace(string(sidecar)) != "10.179.1.131" {
+		t.Errorf("sidecar = %q, want 10.179.1.131", string(sidecar))
+	}
+}
+
+// TestSecondaryKubeconfig_InvalidNodeIPRejected guards the IP validation.
+func TestSecondaryKubeconfig_InvalidNodeIPRejected(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CATALYST_K8SCACHE_KUBECONFIGS_DIR", dir)
+	t.Setenv("SOVEREIGN_FQDN", "t99.omani.works")
+
+	cache := newK8sCacheWithClusters(t, nil)
+	h := &Handler{
+		log:      slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		k8sCache: cache,
+	}
+	rec := postSecondaryKubeconfig(t, h, map[string]string{
+		"deploymentId":   "dep3991",
+		"regionKey":      "me-east-215-b-1",
+		"kubeconfigYaml": secondaryKubeconfigFixture,
+		"nodeInternalIp": "not-an-ip; rm -rf /",
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d (want 400), body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestSecondaryKubeconfig_NoNodeIPLeavesServerUnchanged proves the
+// backward-compat path: a pre-#3991 IaC that omits nodeInternalIp yields
+// the legacy behaviour (EIP server, no rewrite) even on a chroot.
+func TestSecondaryKubeconfig_NoNodeIPLeavesServerUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CATALYST_K8SCACHE_KUBECONFIGS_DIR", dir)
+	t.Setenv("SOVEREIGN_FQDN", "t99.omani.works")
+
+	cache := newK8sCacheWithClusters(t, nil)
+	h := &Handler{
+		log:      slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		k8sCache: cache,
+	}
+	rec := postSecondaryKubeconfig(t, h, map[string]string{
+		"deploymentId":   "dep3991",
+		"regionKey":      "me-east-215-b-1",
+		"kubeconfigYaml": secondaryKubeconfigFixture,
+		// no nodeInternalIp
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	onDisk, _ := os.ReadFile(filepath.Join(dir, "dep3991-me-east-215-b-1.yaml"))
+	if !strings.Contains(string(onDisk), "server: https://212.72.24.35:6443") {
+		t.Errorf("expected unchanged EIP server without nodeInternalIp; got:\n%s", string(onDisk))
+	}
+}


### PR DESCRIPTION
## Problem (proven LIVE on hw173, a 2-region kom4dc prov)

The in-cluster catalyst-api runs in **region-a**. It lists region-a pods fine but **times out** on region-b's apiserver, so the topology placement fan-out sees only region-a — grafana / keycloak / the ~47 mgmt/rtz/dmz-vCluster components render as **1 region instead of 2**.

Region-b's registered secondary-kubeconfig points at the **externally-DNAT'd EIP `https://212.72.24.35:6443`**. That EIP is reachable from the *external* mothership but **NOT routable from inside region-a's VPC** (HCS DNAT is external-only).

## Root cause = ENDPOINT, not peering

The cross-VPC **peering + routes already exist** (`infra/providers/huawei/main.tf` `huaweicloud_vpc_peering_connection.mesh` + `mesh_a_to_b`/`mesh_b_to_a`, region-a `10.169.0.0/16` ↔ region-b `10.179.0.0/16`). Live reachability test **from the region-a node hosting the in-cluster catalyst-api**:

| target | result |
|---|---|
| region-b EIP `212.72.24.35:6443` (registered) | **Operation timed out** ❌ |
| region-b private cp1 `10.179.1.131:6443` (VPC-peered) | **OPEN** ✅ |
| via private-IP kubeconfig: `get pods -A` region-b | **listed grafana + keycloak + keycloak-postgresql** ✅ |

So the datapath is fine; only the *registered server URL* is wrong for the in-cluster consumer.

## Fix (no region-a regression)

The same kubeconfig file is consumed by **two** clients with opposite reachability needs:
- **external mothership** (outside both VPCs) → needs the **EIP**.
- **in-cluster catalyst-api / chroot** (inside region-a's VPC) → needs the **private IP**.

So the rewrite is gated on the consumer:
1. **IaC** (`huawei/main.tf`): the secondary CP detects its private eth0 IP at runtime (same detection as k3s `--node-ip`) and ships it as `nodeInternalIp` in the secondary-kubeconfig POST. The kubeconfig keeps the EIP for the mothership.
2. **Chroot handler** (`HandleSovereignSecondaryKubeconfig`): when `SOVEREIGN_FQDN` is set (chroot) **and** a `nodeInternalIp` is provided, rewrite the kubeconfig server **host** to that VPC-peered private IP before write + `AddCluster`. Host-only swap preserves scheme/port/path, so the pinned-CA TLS handshake still validates (k3s lists the node IP as a `--tls-san`; live probe returned 401 auth-error, not a TLS error). The mothership (`SOVEREIGN_FQDN` unset) leaves the EIP untouched.
3. **Handover forward** (`exportSecondaryKubeconfigsToChild`): the mothership stashes the private IP as a `.nodeip` sidecar and replays it to the chroot.

## No-regression

- Mothership keeps the EIP (test asserts it) — region-a/external access unchanged.
- Absent `nodeInternalIp` (pre-#3991 IaC) → legacy EIP behaviour (test asserts it).
- Hetzner path untouched (different endpoint + shared cross-location private network).
- Live hw173 not disrupted: debug pods only; cleaned up.

## Validation

- `go build ./...` ✅, `go vet ./...` ✅, full `internal/handler` test package ✅
- New tests: chroot rewrite, mothership-keeps-EIP + sidecar, invalid-IP→400, no-IP backward-compat, pure rewrite helper.
- `scripts/lint-cloudinit.sh huawei` ✅ (render + `dash -n` on all 39 runcmd items); `tofu fmt` ✅.

## Acceptance (live)

After this fix rolls, the in-cluster catalyst-api can LIST region-b pods → the placement endpoint returns 2 targets and the treemap shows both regions. The endpoint-level proof above already demonstrates the private-IP datapath lists region-b workloads from region-a.

Refs #3982
Refs #3991

🤖 Generated with [Claude Code](https://claude.com/claude-code)