### PR TITLE
fix(cloud-list): subscribe CloudPage SSE to every per-kind registry kind + pin externalsecret GVR to served v1beta1 — kill empty per-kind lists (Refs #3981)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/k8scache/kinds.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/kinds.go
@@ -353,10 +353,22 @@ var DefaultKinds = []Kind{
 	// condition drives the node status (CertificateGVR).
 	{Name: "certificate", GVR: schema.GroupVersionResource{Group: "cert-manager.io", Version: "v1", Resource: "certificates"}, Namespaced: true},
 	// External-Secrets ExternalSecret — references a remote secret store
-	// key; the CR itself inlines no secret value (ExternalSecretGVR). v1 is
-	// the current served version (helmwatch falls back to v1beta1 on older
-	// ESO releases, but the cache informer pins the served v1).
-	{Name: "externalsecret", GVR: schema.GroupVersionResource{Group: "external-secrets.io", Version: "v1", Resource: "externalsecrets"}, Namespaced: true},
+	// key; the CR itself inlines no secret value (ExternalSecretGVR).
+	//
+	// #3987: pinned to v1beta1, NOT v1. The ESO release shipped in the
+	// platform bundle serves ONLY v1alpha1 + v1beta1 (v1beta1 is the
+	// served+storage version); it does NOT serve v1. A static-GVR informer
+	// has no version fallback (unlike helmwatch's declarative reconciler,
+	// which retries ExternalSecretGVR→ExternalSecretGVRBeta), so pinning v1
+	// made the informer LIST/WATCH a non-served version and silently return
+	// zero — `/cloud?view=list&kind=externalsecrets` rendered "No
+	// externalsecret objects" on hw173 despite 13 live (under v1beta1),
+	// while the GRAPH showed them via the helmwatch fallback path. v1beta1
+	// is the version every current platform ESO serves, so the cache reads
+	// the real objects. (If a future ESO release drops v1beta1 in favour of
+	// v1, the kinds ConfigMap override — CATALYST_K8SCACHE_KINDS_CONFIGMAP —
+	// re-pins it with no code change, per the LoadRegistry merge path.)
+	{Name: "externalsecret", GVR: schema.GroupVersionResource{Group: "external-secrets.io", Version: "v1beta1", Resource: "externalsecrets"}, Namespaced: true},
 	// CloudNativePG Cluster (CNPGClusterGVR). The registry Name is
 	// `cnpgcluster` (NOT `cluster`) deliberately: the cloud-side join
 	// already owns a "Cluster" concept, and the GVR's plural `clusters`

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CloudPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CloudPage.tsx
@@ -58,6 +58,7 @@ import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
 import { CloudListView } from './cloud-list/CloudListView'
 import { CloudKindChips } from './cloud-list/CloudKindChips'
 import {
+  CLOUD_PAGE_K8S_KINDS,
   DEFAULT_KIND,
   KIND_IDS,
   KIND_TO_REGISTRY,
@@ -285,8 +286,20 @@ export function CloudPage({
   // that hangs duplicate streams at "connecting" indefinitely.
   // PR #1062 wired the backend; PR #1065 hoisted this above the ctx
   // build so list pages can read from the same snapshot.
+  //
+  // #3987: the subscription MUST cover every per-kind list page's
+  // registry kind, not just the architecture graph's structural kinds.
+  // The default (GRAPH_K8S_KINDS) omitted secret / policyreport /
+  // clusterpolicyreport and ALL the reconciler + Catalyst-CR kinds, so
+  // the snapshot never held a `helmrelease:` (etc.) key and
+  // `/cloud?view=list&kind=helmreleases` rendered "No helmrelease
+  // objects" despite 49+ live (the graph showed them via the separate
+  // /reconciliation endpoint). CLOUD_PAGE_K8S_KINDS is the de-duplicated
+  // union of GRAPH_K8S_KINDS + every KIND_TO_REGISTRY registry Name, so
+  // every list page AND every chip count reads its real live objects.
   const k8sStream = useK8sCacheStream(deploymentId, {
     enabled: !!deploymentId && !disableStream,
+    kinds: CLOUD_PAGE_K8S_KINDS,
   })
 
   const ctx: CloudContextValue = useMemo(

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kinds.test.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kinds.test.ts
@@ -14,8 +14,15 @@
  */
 
 import { describe, expect, it } from 'vitest'
-import { KINDS, KIND_IDS, KIND_TO_REGISTRY, isValidKind } from './kinds'
+import {
+  CLOUD_PAGE_K8S_KINDS,
+  KINDS,
+  KIND_IDS,
+  KIND_TO_REGISTRY,
+  isValidKind,
+} from './kinds'
 import type { K8sObject } from '@/widgets/architecture-graph/useK8sCacheStream'
+import { GRAPH_K8S_KINDS } from '@/widgets/architecture-graph/useK8sCacheStream'
 import {
   colReconcileStatus,
   colCnpgStatus,
@@ -83,6 +90,60 @@ describe('cloud-list kinds catalogue (#3978 restore)', () => {
     // The flat unified list is gone: there is no single 'all' / 'unified' kind.
     expect(KIND_IDS).not.toContain('all')
     expect(KIND_IDS).not.toContain('unified')
+  })
+})
+
+describe('CLOUD_PAGE_K8S_KINDS covers every per-kind list page (#3987)', () => {
+  // Root-cause regression lock: the CloudPage SSE subscription fed both
+  // the per-kind list (K8sListPage) and the chip counts from ONE snapshot.
+  // When it defaulted to GRAPH_K8S_KINDS it omitted secret / policyreport /
+  // clusterpolicyreport + every reconciler + Catalyst-CR kind, so those
+  // list pages rendered "No <kind> objects" despite live data. The
+  // subscription MUST be the union of the graph kinds and every
+  // KIND_TO_REGISTRY registry Name. These tests fail loudly if a future
+  // per-kind page is added to KIND_TO_REGISTRY without being subscribed.
+  const subscribed = new Set(CLOUD_PAGE_K8S_KINDS)
+
+  it('subscribes to every KIND_TO_REGISTRY registry Name (the list-page filter)', () => {
+    for (const registryName of Object.values(KIND_TO_REGISTRY)) {
+      expect(
+        subscribed.has(registryName),
+        `CLOUD_PAGE_K8S_KINDS must include "${registryName}" so its per-kind list + chip count read live data`,
+      ).toBe(true)
+    }
+  })
+
+  it('includes every reconciler kind that #3987 reported empty', () => {
+    for (const registryName of [
+      'helmrelease',
+      'kustomization',
+      'gitrepository',
+      'certificate',
+      'externalsecret',
+      'cnpgcluster',
+      'cnpgdatabase',
+      'application',
+      'environment',
+      'organization',
+      'continuum',
+      'useraccess',
+      // non-reconciler kinds the default GRAPH set also omitted
+      'secret',
+      'policyreport',
+      'clusterpolicyreport',
+    ]) {
+      expect(subscribed.has(registryName), `${registryName} must be subscribed`).toBe(true)
+    }
+  })
+
+  it('still subscribes to every architecture-graph structural kind (no graph regression)', () => {
+    for (const k of GRAPH_K8S_KINDS) {
+      expect(subscribed.has(k), `graph kind ${k} must stay subscribed`).toBe(true)
+    }
+  })
+
+  it('is de-duplicated (each kind subscribed once)', () => {
+    expect(CLOUD_PAGE_K8S_KINDS.length).toBe(new Set(CLOUD_PAGE_K8S_KINDS).size)
   })
 })
 

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kinds.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kinds.ts
@@ -16,6 +16,7 @@
 
 import type { JSX } from 'react'
 
+import { GRAPH_K8S_KINDS } from '@/widgets/architecture-graph/useK8sCacheStream'
 import { ClustersPage } from '../cloud-compute/ClustersPage'
 import { VClustersPage } from '../cloud-compute/VClustersPage'
 import { NodePoolsPage } from '../cloud-compute/NodePoolsPage'
@@ -146,6 +147,50 @@ export const KIND_TO_REGISTRY: Partial<Record<CloudListKind, string>> = {
   continuums: 'continuum',
   useraccesses: 'useraccess',
 }
+
+/**
+ * CLOUD_PAGE_K8S_KINDS — the COMPLETE set of k8scache registry kinds the
+ * CloudPage's single SSE subscription must watch (#3987).
+ *
+ * Root cause #3987: the per-kind list (K8sListPage) and the chip-count
+ * badges both read the live `k8sSnapshot` Map that CloudPage hydrates
+ * from ONE `useK8sCacheStream` subscription. That subscription defaulted
+ * to GRAPH_K8S_KINDS — the 15 kinds the architecture GRAPH needs — which
+ * omits every kind in KIND_TO_REGISTRY that the graph doesn't draw
+ * (secret, policyreport, clusterpolicyreport, and ALL the reconciler /
+ * Catalyst-CR kinds: helmrelease, kustomization, gitrepository,
+ * certificate, externalsecret, cnpgcluster, cnpgdatabase, application,
+ * environment, organization, continuum, useraccess). The snapshot
+ * therefore never held a single `helmrelease:` key, so
+ * `/cloud?view=list&kind=helmreleases` filtered to zero rows and rendered
+ * "No helmrelease objects in this cluster" even with 49+ live — while the
+ * GRAPH showed them, because the graph sources reconcilers from a
+ * SEPARATE endpoint (GET /deployments/{id}/reconciliation), not the SSE
+ * snapshot.
+ *
+ * The backend already registers every one of these GVRs
+ * (api/internal/k8scache/kinds.go) and the SSE handler fans the
+ * initialState snapshot out across all registered regions, so simply
+ * widening the subscription to the union below makes every per-kind list
+ * AND every chip count read its real live objects — no backend change.
+ *
+ * Built as the de-duplicated union of:
+ *   1. GRAPH_K8S_KINDS — the graph's structural kinds (incl. replicaset
+ *      ownerRef hops, persistentvolumeclaim, server.hcloud, volume.hcloud)
+ *      that have no KIND_TO_REGISTRY chip but the graph still draws.
+ *   2. every registry Name in KIND_TO_REGISTRY — exactly the set each
+ *      per-kind K8sListPage filters by (`${name}:` snapshot-key prefix)
+ *      and the chip-count derivation tallies.
+ *
+ * Derived (never hardcoded twice) so a new per-kind page added to
+ * KIND_TO_REGISTRY is auto-subscribed — no second list to keep in sync.
+ */
+export const CLOUD_PAGE_K8S_KINDS: readonly string[] = Array.from(
+  new Set<string>([
+    ...GRAPH_K8S_KINDS,
+    ...Object.values(KIND_TO_REGISTRY),
+  ]),
+)
 
 export interface CloudKindEntry {
   id: CloudListKind


### PR DESCRIPTION
## #3987 — per-kind k9s cloud-list pages show 0 objects for MANY kinds (helmreleases empty while graph shows 49+)

### Root cause (TWO bugs, both verified live on hw173)

**Bug 1 — FE subscription gap (the headline).** The per-kind list (`K8sListPage`) and the chip-count badges both read the live `k8sSnapshot` Map that `CloudPage` hydrates from **one** `useK8sCacheStream` subscription. That subscription defaulted to `GRAPH_K8S_KINDS` — the 15 kinds the architecture **graph** needs — which omits every `KIND_TO_REGISTRY` kind the graph doesn't draw: `secret`, `policyreport`, `clusterpolicyreport`, and **all** the reconciler + Catalyst-CR kinds (`helmrelease`, `kustomization`, `gitrepository`, `certificate`, `externalsecret`, `cnpgcluster`, `cnpgdatabase`, `application`, `environment`, `organization`, `continuum`, `useraccess`). The snapshot therefore never held a single `helmrelease:` key, so `/cloud?view=list&kind=helmreleases` filtered to zero rows → **"No helmrelease objects in this cluster"** despite 49+ live. The **graph** showed them because it sources reconcilers from a *separate* endpoint (`GET /deployments/{id}/reconciliation`), not the SSE snapshot.

**Bug 2 — backend GVR pinned to an unserved version.** The k8scache `externalsecret` GVR was pinned to `external-secrets.io/v1`, but the ESO release in the platform bundle serves only `v1alpha1` + `v1beta1` (`v1beta1` = storage). A static-GVR informer has no version fallback (unlike helmwatch's declarative reconciler, which retries v1→v1beta1), so it LIST/WATCHed a non-served version and returned **0** — `/cloud?view=list&kind=externalsecrets` was empty despite 13 live under v1beta1.

### Fix

1. **`kinds.ts`** — export `CLOUD_PAGE_K8S_KINDS` = the **de-duplicated union** of `GRAPH_K8S_KINDS` + every `KIND_TO_REGISTRY` registry Name. Derived (not a second hardcoded list) so any future per-kind page added to `KIND_TO_REGISTRY` is auto-subscribed.
2. **`CloudPage.tsx`** — pass `kinds: CLOUD_PAGE_K8S_KINDS` to the single `useK8sCacheStream` subscription. Every per-kind list page **and** every chip count now reads its real live objects.
3. **`k8scache/kinds.go`** — pin `externalsecret` GVR to the served `v1beta1`.
4. **`kinds.test.ts`** — regression lock: the subscription is a superset of every `KIND_TO_REGISTRY` registry Name, every `GRAPH_K8S_KINDS` kind, and the 15 specific kinds #3987 reported empty; de-dup asserted.

Backend already registers every GVR (`kinds.go`) and the SSE handler fans `initialState` across all regions — no other backend change. **Graph untouched** (`buildCloudGraph` / `CloudLensProvider` / lens / density all preserved). Rich per-kind columns + drill-in (#3981) preserved — not reflattened.

### Per-kind before → after (LIVE hw173, region-a, SSE `?kinds=<k>&initialState=1` ADDED-frame count, cross-checked vs `kubectl get <k> -A`)

| Kind | live `kubectl` | list BEFORE | list AFTER |
|---|---|---|---|
| helmrelease | 65 | **0** | **65** ✅ |
| kustomization | 5 | **0** | **5** ✅ |
| gitrepository | 3 | **0** | **3** ✅ |
| certificate | 6 | **0** | **6** ✅ |
| externalsecret | 13 (v1beta1) | **0** | **13** (after Bug-2 fix) ✅ |
| cnpgcluster | 9 | **0** | **9** ✅ |
| useraccess | 1 | **0** | **1** ✅ |
| continuum | 1 | **0** | **1** ✅ |
| secret | 322 | **0** | **322** ✅ |
| policyreport | 249–256 | **0** | **252–256** ✅ |
| clusterpolicyreport | 34 | **0** | **34** ✅ |
| cnpgdatabase / application / environment / organization | 0 (genuinely empty) | 0 | 0 (correct empty-state) |
| pod / deployment / service / … (already-working kinds) | — | OK | OK (unchanged) |

Live SSE values captured against the chart-pinned `catalyst-api:e6194fe` backend (every reconciler kind returns its real objects; only `externalsecret` was 0 — fixed by Bug-2). The `externalsecret` v1beta1 GVR fix proven at the apiserver: `kubectl get externalsecrets.v1beta1.external-secrets.io -A` → **13**; `...v1...` → `the server doesn't have a resource type`.

### Gates
- `rm -f tsconfig.tsbuildinfo && npx tsc -b` → **0**
- `npm run build` → **0**
- `npx vitest run kinds.test.ts CloudPage useK8sCacheStream` → **26 passed**
- `go build ./internal/k8scache/...` → **0**; `go vet` → **0**; `go test ./internal/k8scache/...` → **ok**

Refs #3981
Refs #3987

🤖 Generated with [Claude Code](https://claude.com/claude-code)
