### PR TITLE
feat(jobs+cloud): recon-mgmt surface + /jobs finite-only + reconciliation deep-link selects the recon LENS (#3996)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -1302,6 +1302,20 @@ func main() {
 		// Reconciling / Drifted / Degraded). Read-only. Scanner/Job nodes
 		// are EXCLUDED by construction (it's built from reconcilers only).
 		rg.Get("/api/v1/deployments/{depId}/reconciliation", h.GetReconciliationDAG)
+		// #3996 — lightweight ArgoCD/Flux MANAGEMENT surface on the recon
+		// lens. LIST every manageable Flux reconciler (HelmRelease /
+		// Kustomization / GitRepository / OCIRepository / HelmRepository /
+		// HelmChart) with live status + last-reconcile + revision + suspended
+		// flag; DRILL into one object's owning-controller LOGS filtered to
+		// that object; and TRIGGER reconcile/suspend/resume via the
+		// in-cluster dynamic client (annotation / spec.suspend patch — NEVER
+		// a shell-out). The action route is owner-checked (404 cross-tenant)
+		// + operator-RBAC-gated (403 otherwise), the SAME gate the jobs-retry
+		// endpoint uses. Read routes are inside RequireSession so claims are
+		// populated; the action route reads them for the RBAC gate + audit.
+		rg.Get("/api/v1/deployments/{depId}/reconcilers", h.ListReconcilers)
+		rg.Get("/api/v1/deployments/{depId}/reconcilers/{kind}/{ns}/{name}/logs", h.GetReconcilerLogs)
+		rg.Post("/api/v1/deployments/{depId}/reconcilers/{kind}/{ns}/{name}/{action}", h.ReconcilerAction)
 		// OpenovaFlow proxy (Agent #3 integration — PR #1389/#1390
 		// follow-up). Proxies the FlowPage canvas's snapshot/stream/
 		// ingest path to the bp-openova-flow-server inside the

--- a/products/catalyst/bootstrap/api/internal/handler/jobs.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs.go
@@ -741,6 +741,17 @@ func (h *Handler) ListJobs(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
+	// /jobs is the FINITE-work view (#3996 follow-up): drop the continuous
+	// reconcilers (Flux HelmRelease installs, Kustomization reconciles, and
+	// long-running reconciler Deployments) so the founder sees jobs that
+	// start/run/end — provision + cutover steps, batch Jobs, CronJob runs,
+	// one-shot Day-2 mutations — instead of an ever-growing wall of
+	// always-on reconcilers. Those reconcilers now live ONLY on the Cloud
+	// Reconciliation lens + reconciler-management surface (#3996), which
+	// reads them LIVE from the cluster; the store keeps the full set, only
+	// this view is narrowed. GetJob stays unfiltered so a deep-link to a
+	// reconciler row still resolves.
+	out = jobs.FilterFiniteJobs(out)
 	if out == nil {
 		out = []jobs.Job{}
 	}

--- a/products/catalyst/bootstrap/api/internal/handler/jobs_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_test.go
@@ -72,19 +72,34 @@ func TestHandler_ListJobs_Empty(t *testing.T) {
 	}
 }
 
+// TestHandler_ListJobs_Populated asserts the FINITE-work view (#3996
+// follow-up): the continuous-reconciler install leaves (KindInstall) are
+// dropped from /jobs and surface only on the Cloud Reconciliation lens,
+// while genuinely finite work (provision steps, batch Jobs, CronJob runs,
+// Day-2 mutations) still renders. A finite-work group with surviving
+// children keeps its rolled-up status + ChildIDs; the bootstrap-kit group,
+// left with only install leaves, is pruned entirely.
 func TestHandler_ListJobs_Populated(t *testing.T) {
 	r, st, _ := newJobsAPIRouter(t)
 	depID := "dep-populated"
 
 	t0 := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
-	parentID := jobs.JobID(depID, jobs.GroupBootstrapKit)
+	// bootstrap-kit group holds ONLY install leaves (continuous Flux
+	// HelmReleases) — it must be pruned from /jobs after filtering.
+	bkParent := jobs.JobID(depID, jobs.GroupBootstrapKit)
+	// reconcilers group holds finite work (provisioner steps, a batch
+	// task) that MUST still render on /jobs.
+	finiteParent := jobs.JobID(depID, jobs.GroupProvisioner)
 	jobsToSeed := []jobs.Job{
-		// Parent group materialised explicitly — exactly what the
-		// helmwatch bridge does on first seed.
+		// bootstrap-kit group + its continuous install leaves → all dropped.
 		{DeploymentID: depID, JobName: jobs.GroupBootstrapKit, DisplayName: jobs.GroupBootstrapKitDisplay, Type: jobs.JobTypeGroup, Status: jobs.StatusPending},
-		{DeploymentID: depID, JobName: "install-cilium", AppID: "cilium", Type: jobs.JobTypeInstall, ParentID: parentID, Status: jobs.StatusSucceeded, StartedAt: &t0, FinishedAt: ptrTime(t0.Add(20 * time.Second))},
-		{DeploymentID: depID, JobName: "install-flux", AppID: "flux", Type: jobs.JobTypeInstall, ParentID: parentID, Status: jobs.StatusRunning, StartedAt: ptrTime(t0.Add(time.Minute))},
-		{DeploymentID: depID, JobName: "install-keycloak", AppID: "keycloak", Type: jobs.JobTypeInstall, ParentID: parentID, Status: jobs.StatusPending},
+		{DeploymentID: depID, JobName: "install-cilium", AppID: "cilium", Kind: jobs.KindInstall, Type: jobs.JobTypeInstall, ParentID: bkParent, Status: jobs.StatusSucceeded, StartedAt: &t0, FinishedAt: ptrTime(t0.Add(20 * time.Second))},
+		{DeploymentID: depID, JobName: "install-flux", AppID: "flux", Kind: jobs.KindInstall, Type: jobs.JobTypeInstall, ParentID: bkParent, Status: jobs.StatusRunning, StartedAt: ptrTime(t0.Add(time.Minute))},
+		// Finite-work group + surviving children (a provision step + a
+		// batch task) → kept on /jobs.
+		{DeploymentID: depID, JobName: jobs.GroupProvisioner, Type: jobs.JobTypeGroup, Status: jobs.StatusPending},
+		{DeploymentID: depID, JobName: "provisioner-step-tofu-init", Kind: jobs.KindStep, Type: jobs.JobTypeInstall, ParentID: finiteParent, Status: jobs.StatusSucceeded, StartedAt: &t0, FinishedAt: ptrTime(t0.Add(10 * time.Second))},
+		{DeploymentID: depID, JobName: "task-snapshot-once", Kind: jobs.KindTask, Type: jobs.JobTypeInstall, ParentID: finiteParent, Status: jobs.StatusRunning, StartedAt: ptrTime(t0.Add(time.Minute))},
 	}
 	for _, j := range jobsToSeed {
 		if err := st.UpsertJob(j); err != nil {
@@ -101,10 +116,21 @@ func TestHandler_ListJobs_Populated(t *testing.T) {
 		Jobs []jobs.Job `json:"jobs"`
 	}
 	decodeJSON(t, rec.Body, &resp)
-	if len(resp.Jobs) != 4 {
-		t.Fatalf("expected 4 jobs (group + 3 leaves), got %d", len(resp.Jobs))
+
+	// Expect the finite group + its 2 finite leaves; bootstrap-kit + the 2
+	// install leaves are gone.
+	if len(resp.Jobs) != 3 {
+		t.Fatalf("expected 3 jobs (finite group + 2 finite leaves), got %d: %+v", len(resp.Jobs), resp.Jobs)
 	}
-	// Find the group job and assert its rolled-up status.
+	for _, j := range resp.Jobs {
+		if jobs.IsContinuousReconciler(j.Kind) {
+			t.Errorf("continuous reconciler leaked into /jobs: %q (kind=%q)", j.JobName, j.Kind)
+		}
+		if j.JobName == jobs.GroupBootstrapKit {
+			t.Errorf("empty bootstrap-kit group should have been pruned, still present")
+		}
+	}
+	// The finite group survives with both finite children + a running rollup.
 	var group *jobs.Job
 	for i := range resp.Jobs {
 		if resp.Jobs[i].Type == jobs.JobTypeGroup {
@@ -113,21 +139,17 @@ func TestHandler_ListJobs_Populated(t *testing.T) {
 		}
 	}
 	if group == nil {
-		t.Fatalf("group job missing in response: %+v", resp.Jobs)
+		t.Fatalf("finite group job missing in response: %+v", resp.Jobs)
 	}
-	// Mixed children (succeeded + running + pending) → rolled-up
-	// status must be running (failed > running > pending > succeeded).
+	if group.JobName != jobs.GroupProvisioner {
+		t.Errorf("surviving group: want %q, got %q", jobs.GroupProvisioner, group.JobName)
+	}
+	// Children: succeeded step + running task → rolled-up running.
 	if group.Status != jobs.StatusRunning {
 		t.Errorf("group rolled-up Status: want running, got %q", group.Status)
 	}
-	if len(group.ChildIDs) != 3 {
-		t.Errorf("group ChildIDs: want 3, got %d (%v)", len(group.ChildIDs), group.ChildIDs)
-	}
-	// Verify all leaf jobs carry parentId.
-	for _, j := range resp.Jobs {
-		if j.Type == jobs.JobTypeInstall && j.ParentID != parentID {
-			t.Errorf("leaf %q parentId: want %q, got %q", j.JobName, parentID, j.ParentID)
-		}
+	if len(group.ChildIDs) != 2 {
+		t.Errorf("group ChildIDs: want 2, got %d (%v)", len(group.ChildIDs), group.ChildIDs)
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/reconcilers.go
+++ b/products/catalyst/bootstrap/api/internal/handler/reconcilers.go
@@ -1,0 +1,463 @@
+// reconcilers.go — the lightweight ArgoCD/Flux MANAGEMENT surface for the
+// Cloud view's Reconciliation lens (issue #3996).
+//
+// Where reconciliation_dag.go renders the BOUNDED Flux DAG (read-only, for
+// the convergence graph) and jobs_retry.go re-drives a FAILED activity from
+// the Jobs canvas, this file gives the operator an ArgoCD-like management
+// surface over the FULL continuous-reconciler set — every Flux reconciler
+// object (HelmRelease, Kustomization, GitRepository, OCIRepository,
+// HelmRepository, HelmChart) — with three capabilities:
+//
+//   GET  /api/v1/deployments/{depId}/reconcilers
+//        → list with live status + last-reconcile + message + revision +
+//          suspended flag + the controller that owns each kind.
+//
+//   GET  /api/v1/deployments/{depId}/reconcilers/{kind}/{ns}/{name}/logs
+//        → page the owning controller's logs (helm-controller /
+//          kustomize-controller / source-controller) FILTERED to this
+//          object, mirroring the GET /actions/executions/{id}/logs shape.
+//
+//   POST /api/v1/deployments/{depId}/reconcilers/{kind}/{ns}/{name}/{action}
+//        action ∈ {reconcile, suspend, resume}:
+//          reconcile → annotate reconcile.fluxcd.io/requestedAt=<RFC3339>
+//          suspend   → merge-patch spec.suspend=true
+//          resume    → merge-patch spec.suspend=false
+//        via the IN-CLUSTER DYNAMIC CLIENT only — NEVER a shell-out
+//        (PRINCIPLES #61). Owner-checked (404 cross-tenant) + RBAC-gated to
+//        operator tier (403 otherwise), the SAME gate jobs_retry.go uses.
+package handler
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
+)
+
+// Reconciler-log paging defaults — mirror the jobs execution-log contract
+// (jobs.DefaultLogPageSize / MaxLogPageSize) so the FE reuses one viewer.
+const (
+	defaultReconcilerLogTail = 200
+	maxReconcilerLogTail     = 5000
+)
+
+// resolveReconcilerDeployment loads + ownership-gates the deployment for a
+// reconciler-management request. Returns the Deployment, or nil after
+// having already written the 404/403 response. Mirrors the RetryJob lookup
+// (chrootEnsureDeployment first so the Sovereign-side catalyst-api serves
+// its imported deployment by id).
+func (h *Handler) resolveReconcilerDeployment(w http.ResponseWriter, r *http.Request, depID string) *Deployment {
+	dep := h.chrootEnsureDeployment(depID)
+	if dep == nil {
+		if val, ok := h.deployments.Load(depID); ok {
+			dep = val.(*Deployment)
+		}
+	}
+	if dep == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "deployment not found"})
+		return nil
+	}
+	if !h.checkOwnership(w, r, dep) {
+		return nil // 404 already written
+	}
+	return dep
+}
+
+// ListReconcilers handles GET /api/v1/deployments/{depId}/reconcilers.
+//
+// Returns `{ "reconcilers": [...], "reconciled": N, "total": M }` — every
+// manageable Flux reconciler with its live status, last-reconcile ts,
+// message, applied revision, suspended flag, and owning controller. The
+// counts let the convergence %/ratio drill into the non-Reconciled rows.
+func (h *Handler) ListReconcilers(w http.ResponseWriter, r *http.Request) {
+	depID := strings.TrimSpace(chi.URLParam(r, "depId"))
+	if depID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "missing-depId"})
+		return
+	}
+	dep := h.resolveReconcilerDeployment(w, r, depID)
+	if dep == nil {
+		return
+	}
+	dyn, err := h.sovereignDynamicClient(dep)
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]string{
+			"error":  "cluster-client-unavailable",
+			"detail": err.Error(),
+		})
+		return
+	}
+	listCtx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+	rows, err := helmwatch.ListManagedReconcilers(listCtx, dyn)
+	if err != nil {
+		h.log.Warn("ListReconcilers: list failed", "depId", depID, "err", err)
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "list-failed"})
+		return
+	}
+	if rows == nil {
+		rows = []helmwatch.ManagedReconciler{}
+	}
+	reconciled := 0
+	for _, rc := range rows {
+		if rc.State == helmwatch.ManageStateReconciled {
+			reconciled++
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"reconcilers": rows,
+		"reconciled":  reconciled,
+		"total":       len(rows),
+	})
+}
+
+// ReconcilerAction handles POST
+// /api/v1/deployments/{depId}/reconcilers/{kind}/{ns}/{name}/{action}.
+//
+//	200 — action applied; body echoes the kind/name/action + requestedBy.
+//	400 — missing path params / unknown kind / unsupported action.
+//	403 — caller lacks operator RBAC.
+//	404 — unknown deployment / cross-tenant.
+//	502 — the in-cluster client/patch write failed.
+func (h *Handler) ReconcilerAction(w http.ResponseWriter, r *http.Request) {
+	depID := strings.TrimSpace(chi.URLParam(r, "depId"))
+	kind := strings.TrimSpace(chi.URLParam(r, "kind"))
+	ns := strings.TrimSpace(chi.URLParam(r, "ns"))
+	name := strings.TrimSpace(chi.URLParam(r, "name"))
+	action := strings.ToLower(strings.TrimSpace(chi.URLParam(r, "action")))
+	if depID == "" || kind == "" || ns == "" || name == "" || action == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "missing-path-params"})
+		return
+	}
+	gvr, ok := helmwatch.ManagedGVRForKind(kind)
+	if !ok {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":  "unknown-kind",
+			"detail": fmt.Sprintf("kind %q is not a manageable Flux reconciler", kind),
+		})
+		return
+	}
+	switch action {
+	case "reconcile", "suspend", "resume":
+	default:
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":  "unsupported-action",
+			"detail": fmt.Sprintf("action %q must be one of reconcile / suspend / resume", action),
+		})
+		return
+	}
+
+	dep := h.resolveReconcilerDeployment(w, r, depID)
+	if dep == nil {
+		return
+	}
+	// RBAC: mutating a reconciler is an operator action — reuse the SAME
+	// operator-tier gate the jobs-retry endpoint uses (403 for viewers; nil
+	// claims pass for CI/tests).
+	claims := auth.ClaimsFromContext(r.Context())
+	if !jobRetryCallerAuthorized(claims, dep) {
+		writeJSON(w, http.StatusForbidden, map[string]string{
+			"error":  "forbidden",
+			"detail": "managing a reconciler requires operator tier or higher",
+		})
+		return
+	}
+
+	dyn, err := h.sovereignDynamicClient(dep)
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]string{
+			"error":  "cluster-client-unavailable",
+			"detail": err.Error(),
+		})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+
+	now := time.Now().UTC()
+	var patch []byte
+	switch action {
+	case "reconcile":
+		// The Flux-native "reconcile now" primitive (the same annotation
+		// `flux reconcile` writes). Reuse the exact constant + shape
+		// jobs_retry.go's triggerReconcileAnnotation uses.
+		patch = []byte(fmt.Sprintf(
+			`{"metadata":{"annotations":{%q:%q}}}`,
+			reconcileRequestedAtAnnotation, now.Format(time.RFC3339Nano),
+		))
+	case "suspend":
+		patch = []byte(`{"spec":{"suspend":true}}`)
+	case "resume":
+		patch = []byte(`{"spec":{"suspend":false}}`)
+	}
+
+	if _, err := dyn.Resource(gvr).Namespace(ns).Patch(ctx, name, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+		h.log.Warn("ReconcilerAction: patch failed",
+			"depId", depID, "kind", kind, "ns", ns, "name", name, "action", action, "err", err)
+		writeJSON(w, http.StatusBadGateway, map[string]string{
+			"error":  "action-failed",
+			"detail": err.Error(),
+		})
+		return
+	}
+
+	operator := retryOperatorIdentity(claims, r)
+	h.log.Info("ReconcilerAction applied",
+		"depId", depID, "kind", kind, "ns", ns, "name", name,
+		"action", action, "by", operator)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"kind":        kind,
+		"namespace":   ns,
+		"name":        name,
+		"action":      action,
+		"requestedAt": now.Format(time.RFC3339),
+		"requestedBy": operator,
+	})
+}
+
+// GetReconcilerLogs handles GET
+// /api/v1/deployments/{depId}/reconcilers/{kind}/{ns}/{name}/logs?tailLines=N.
+//
+// Tails the OWNING controller's pod logs (helm-controller /
+// kustomize-controller / source-controller) and FILTERS to lines mentioning
+// this object's "<ns>/<name>" coordinate — Flux controllers log every
+// reconcile line with the object's namespaced name, so a substring match
+// yields exactly this object's reconcile output. Returns the same paginated
+// shape the execution-log viewer reads: `{ "lines": [...], "total": N }`.
+//
+// 404 when the controller pod can't be found (Flux not installed / RBAC).
+func (h *Handler) GetReconcilerLogs(w http.ResponseWriter, r *http.Request) {
+	depID := strings.TrimSpace(chi.URLParam(r, "depId"))
+	kind := strings.TrimSpace(chi.URLParam(r, "kind"))
+	ns := strings.TrimSpace(chi.URLParam(r, "ns"))
+	name := strings.TrimSpace(chi.URLParam(r, "name"))
+	if depID == "" || kind == "" || ns == "" || name == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "missing-path-params"})
+		return
+	}
+	if _, ok := helmwatch.ManagedGVRForKind(kind); !ok {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unknown-kind"})
+		return
+	}
+	controller := helmwatch.ControllerForKind(kind)
+	if controller == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "no-controller-for-kind"})
+		return
+	}
+
+	dep := h.resolveReconcilerDeployment(w, r, depID)
+	if dep == nil {
+		return
+	}
+
+	core, err := h.sovereignCoreClient(dep)
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]string{
+			"error":  "cluster-client-unavailable",
+			"detail": err.Error(),
+		})
+		return
+	}
+
+	tail := defaultReconcilerLogTail
+	if v := strings.TrimSpace(r.URL.Query().Get("tailLines")); v != "" {
+		if n, perr := strconv.Atoi(v); perr == nil && n > 0 {
+			tail = n
+		}
+	}
+	if tail > maxReconcilerLogTail {
+		tail = maxReconcilerLogTail
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 20*time.Second)
+	defer cancel()
+
+	lines, err := tailControllerLogsForObject(ctx, core, controller, ns, name, tail)
+	if err != nil {
+		h.log.Warn("GetReconcilerLogs: tail failed",
+			"depId", depID, "kind", kind, "controller", controller, "err", err)
+		writeJSON(w, http.StatusBadGateway, map[string]string{
+			"error":  "logs-unavailable",
+			"detail": err.Error(),
+		})
+		return
+	}
+	if lines == nil {
+		lines = []reconcilerLogLine{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"controller": controller,
+		"object":     ns + "/" + name,
+		"lines":      lines,
+		"total":      len(lines),
+	})
+}
+
+// reconcilerLogLine is one rendered controller-log line for the FE viewer.
+type reconcilerLogLine struct {
+	LineNumber int    `json:"lineNumber"`
+	Message    string `json:"message"`
+}
+
+// fluxControllerNamespace — Flux controllers live in flux-system on every
+// Catalyst Sovereign (bootstrap-kit installs them there). The pod selector
+// is `app=<controller>` (the canonical Flux label, matching
+// helmwatch.HelmControllerSelector's pattern).
+const fluxControllerNamespace = helmwatch.FluxNamespace
+
+// tailControllerLogsForObject finds the named Flux controller pod in
+// flux-system, pulls its last `tail`×4 lines (oversample so post-filter we
+// still return a useful window), and keeps only lines mentioning the
+// object's "<ns>/<name>" coordinate or its bare name. Returns at most `tail`
+// matched lines (newest-biased: the controller writes chronologically so the
+// returned slice is the matched tail).
+func tailControllerLogsForObject(ctx context.Context, core kubernetes.Interface, controller, ns, name string, tail int) ([]reconcilerLogLine, error) {
+	podName, err := firstReadyControllerPod(ctx, core, controller)
+	if err != nil {
+		return nil, err
+	}
+	// Oversample raw lines so the post-filter still yields a useful window
+	// (a busy controller interleaves many objects' lines).
+	rawTail := int64(tail * 8)
+	if rawTail > int64(maxReconcilerLogTail*8) {
+		rawTail = int64(maxReconcilerLogTail * 8)
+	}
+	opts := &corev1.PodLogOptions{
+		Follow:    false,
+		TailLines: &rawTail,
+	}
+	stream, err := core.CoreV1().Pods(fluxControllerNamespace).GetLogs(podName, opts).Stream(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("open %s/%s log stream: %w", fluxControllerNamespace, podName, err)
+	}
+	defer stream.Close()
+
+	nsName := ns + "/" + name
+	out := make([]reconcilerLogLine, 0, tail)
+	sc := bufio.NewScanner(stream)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	n := 0
+	for sc.Scan() {
+		line := sc.Text()
+		// Flux controllers log the object as "<ns>/<name>" in a
+		// name=/namespace= or path field; match either the namespaced form
+		// or the bare name (some lines log just name= with a separate
+		// namespace=). The namespaced form is the precise match; the bare
+		// name is a fallback that still scopes to this object on a normal
+		// Sovereign (object names are unique within flux-system).
+		if !strings.Contains(line, nsName) && !logLineMentionsName(line, name) {
+			continue
+		}
+		n++
+		out = append(out, reconcilerLogLine{LineNumber: n, Message: line})
+	}
+	if err := sc.Err(); err != nil {
+		// Return what we matched so far rather than failing the whole pull.
+		if len(out) > 0 {
+			return clampLogTail(out, tail), nil
+		}
+		return nil, fmt.Errorf("scan %s logs: %w", controller, err)
+	}
+	return clampLogTail(out, tail), nil
+}
+
+// logLineMentionsName reports whether a controller log line references the
+// object by bare name in a name= / "name": field (avoids matching a random
+// substring). Conservative: requires a delimiter before the name so
+// "foo" doesn't match "foobar".
+func logLineMentionsName(line, name string) bool {
+	for _, marker := range []string{
+		`name="` + name + `"`,
+		`name=` + name,
+		`"name":"` + name + `"`,
+		`/` + name,
+	} {
+		if strings.Contains(line, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// clampLogTail keeps the LAST `tail` lines (the newest window) and
+// renumbers them 1..len so the FE viewer's line gutter is contiguous.
+func clampLogTail(in []reconcilerLogLine, tail int) []reconcilerLogLine {
+	if tail > 0 && len(in) > tail {
+		in = in[len(in)-tail:]
+	}
+	for i := range in {
+		in[i].LineNumber = i + 1
+	}
+	return in
+}
+
+// firstReadyControllerPod returns the name of a Running Flux controller pod
+// matching `app=<controller>` in flux-system. Prefers a Running pod; falls
+// back to the first listed when none report Running (so logs from a
+// CrashLooping controller — the most useful diagnostic — still surface).
+func firstReadyControllerPod(ctx context.Context, core kubernetes.Interface, controller string) (string, error) {
+	pods, err := core.CoreV1().Pods(fluxControllerNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app=" + controller,
+	})
+	if err != nil {
+		return "", fmt.Errorf("list %s pods: %w", controller, err)
+	}
+	if len(pods.Items) == 0 {
+		return "", fmt.Errorf("no %s pod found in %s", controller, fluxControllerNamespace)
+	}
+	for i := range pods.Items {
+		if pods.Items[i].Status.Phase == corev1.PodRunning {
+			return pods.Items[i].Name, nil
+		}
+	}
+	return pods.Items[0].Name, nil
+}
+
+// sovereignCoreClient builds a typed kubernetes.Interface against the
+// target cluster — the in-cluster ServiceAccount on a Sovereign chroot
+// (SOVEREIGN_FQDN matches), else the posted-back kubeconfig on the mother.
+// Mirrors sovereignDynamicClient (infrastructure.go) exactly, but returns a
+// core clientset for Pod log tailing.
+func (h *Handler) sovereignCoreClient(dep *Deployment) (kubernetes.Interface, error) {
+	dep.mu.Lock()
+	kubeconfigPath := ""
+	if dep.Result != nil {
+		kubeconfigPath = dep.Result.KubeconfigPath
+	}
+	depFQDN := strings.TrimSpace(dep.Request.SovereignFQDN)
+	dep.mu.Unlock()
+
+	if selfFQDN := strings.TrimSpace(os.Getenv("SOVEREIGN_FQDN")); selfFQDN != "" && selfFQDN == depFQDN {
+		cfg, err := rest.InClusterConfig()
+		if err != nil {
+			return nil, fmt.Errorf("chroot in-cluster config: %w", err)
+		}
+		return kubernetes.NewForConfig(cfg)
+	}
+	if kubeconfigPath == "" {
+		return nil, fmt.Errorf("sovereign cluster kubeconfig not yet posted back — retry once Phase-1 ready")
+	}
+	raw, err := os.ReadFile(kubeconfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("read kubeconfig: %w", err)
+	}
+	if h.coreFactory != nil {
+		return h.coreFactory(string(raw))
+	}
+	return helmwatch.NewKubernetesClientFromKubeconfig(string(raw))
+}

--- a/products/catalyst/bootstrap/api/internal/handler/reconcilers_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/reconcilers_test.go
@@ -1,0 +1,250 @@
+// reconcilers_test.go — coverage for the #3996 lightweight ArgoCD/Flux
+// management surface: LIST (status + revision + suspended), the
+// reconcile/suspend/resume action patches via the dynamic client (no
+// shell-out), and the RBAC 403 / unknown-kind 400 gates.
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes"
+	kfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// fakeManageDynamicFactory registers the manageable Flux GVRs (the six the
+// management surface lists + patches) with the dynamic-fake client so the
+// List + Patch calls resolve.
+func fakeManageDynamicFactory(seed ...runtime.Object) (func(string) (dynamic.Interface, error), *dynamicfake.FakeDynamicClient) {
+	scheme := runtime.NewScheme()
+	listKinds := map[schema.GroupVersionResource]string{
+		helmwatch.HelmReleaseGVR:    "HelmReleaseList",
+		helmwatch.KustomizationGVR:  "KustomizationList",
+		helmwatch.GitRepositoryGVR:  "GitRepositoryList",
+		helmwatch.OCIRepositoryGVR:  "OCIRepositoryList",
+		helmwatch.HelmRepositoryGVR: "HelmRepositoryList",
+		helmwatch.HelmChartGVR:      "HelmChartList",
+	}
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, seed...)
+	return func(_ string) (dynamic.Interface, error) { return client, nil }, client
+}
+
+// helmReleaseObj builds an unstructured HelmRelease with the given Ready
+// status + suspend + applied revision.
+func helmReleaseObj(name string, ready bool, suspend bool, revision string) *unstructured.Unstructured {
+	readyStatus := "True"
+	if !ready {
+		readyStatus = "False"
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "helm.toolkit.fluxcd.io/v2",
+		"kind":       "HelmRelease",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": helmwatch.FluxNamespace,
+		},
+		"spec": map[string]any{"suspend": suspend},
+		"status": map[string]any{
+			"lastAppliedRevision": revision,
+			"conditions": []any{map[string]any{
+				"type":               "Ready",
+				"status":             readyStatus,
+				"reason":             "ReconciliationSucceeded",
+				"message":            "Release reconciliation succeeded",
+				"lastTransitionTime": "2026-06-20T10:00:00Z",
+			}},
+		},
+	}}
+}
+
+// manageHarness wires a Handler with a deployment owned by ownerEmail (with
+// a kubeconfig so sovereignDynamicClient/CoreClient use the injected fakes),
+// the three management routes, and the seeded dynamic objects.
+func manageHarness(t *testing.T, ownerEmail string, dynSeed ...runtime.Object) (*chi.Mux, *Handler, string) {
+	t.Helper()
+	h := New(silentLogger())
+	factory, _ := fakeManageDynamicFactory(dynSeed...)
+	h.dynamicFactory = factory
+	h.coreFactory = func(_ string) (kubernetes.Interface, error) {
+		return kfake.NewSimpleClientset(), nil
+	}
+
+	depID := "dep-manage"
+	kubePath := filepath.Join(t.TempDir(), "kubeconfig")
+	if err := os.WriteFile(kubePath, []byte("apiVersion: v1\nkind: Config\n"), 0o600); err != nil {
+		t.Fatalf("write kubeconfig: %v", err)
+	}
+	dep := &Deployment{
+		ID:         depID,
+		OwnerEmail: ownerEmail,
+		Request:    provisioner.Request{SovereignFQDN: "t99.omani.works"},
+		Result:     &provisioner.Result{KubeconfigPath: kubePath},
+	}
+	h.deployments.Store(depID, dep)
+
+	r := chi.NewRouter()
+	r.Get("/api/v1/deployments/{depId}/reconcilers", h.ListReconcilers)
+	r.Get("/api/v1/deployments/{depId}/reconcilers/{kind}/{ns}/{name}/logs", h.GetReconcilerLogs)
+	r.Post("/api/v1/deployments/{depId}/reconcilers/{kind}/{ns}/{name}/{action}", h.ReconcilerAction)
+	return r, h, depID
+}
+
+func manageActionReq(depID, kind, ns, name, action string, claims *auth.Claims) *http.Request {
+	url := "/api/v1/deployments/" + depID + "/reconcilers/" + kind + "/" + ns + "/" + name + "/" + action
+	req := httptest.NewRequest(http.MethodPost, url, nil)
+	if claims != nil {
+		req = req.WithContext(context.WithValue(req.Context(), auth.ClaimsKey, claims))
+		if claims.Email != "" {
+			req.Header.Set("X-User-Email", claims.Email)
+		}
+	}
+	return req
+}
+
+// List returns the seeded reconcilers with live status + revision +
+// suspended flag, and the reconciled/total counts.
+func TestListReconcilers_StatusRevisionSuspended(t *testing.T) {
+	r, _, depID := manageHarness(t, "",
+		helmReleaseObj("bp-keycloak", true /*ready*/, false /*suspend*/, "0.4.1"),
+		helmReleaseObj("bp-grafana", true, true /*suspended*/, "8.0.0"),
+	)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+		"/api/v1/deployments/"+depID+"/reconcilers", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d; body=%s", rec.Code, rec.Body.String())
+	}
+	var out struct {
+		Reconcilers []helmwatch.ManagedReconciler `json:"reconcilers"`
+		Reconciled  int                           `json:"reconciled"`
+		Total       int                           `json:"total"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Total != 2 {
+		t.Fatalf("want total=2, got %d", out.Total)
+	}
+	// Reconciled count = only the non-suspended Ready=True one (the suspended
+	// row maps to Suspended, NOT Reconciled).
+	if out.Reconciled != 1 {
+		t.Fatalf("want reconciled=1 (suspended excluded), got %d", out.Reconciled)
+	}
+	byName := map[string]helmwatch.ManagedReconciler{}
+	for _, rc := range out.Reconcilers {
+		byName[rc.Name] = rc
+	}
+	kc := byName["bp-keycloak"]
+	if kc.State != helmwatch.ManageStateReconciled || kc.Revision != "0.4.1" || kc.Suspended {
+		t.Fatalf("keycloak row wrong: %+v", kc)
+	}
+	if kc.Controller != "helm-controller" {
+		t.Fatalf("keycloak controller want helm-controller, got %q", kc.Controller)
+	}
+	gf := byName["bp-grafana"]
+	if gf.State != helmwatch.ManageStateSuspended || !gf.Suspended {
+		t.Fatalf("grafana row should be Suspended: %+v", gf)
+	}
+}
+
+// Reconcile annotates reconcile.fluxcd.io/requestedAt on the live object via
+// the dynamic client (no shell-out).
+func TestReconcilerAction_Reconcile_AnnotatesRequestedAt(t *testing.T) {
+	r, h, depID := manageHarness(t, "",
+		helmReleaseObj("bp-keycloak", true, false, "0.4.1"))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, manageActionReq(depID, "HelmRelease", helmwatch.FluxNamespace, "bp-keycloak", "reconcile", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d; body=%s", rec.Code, rec.Body.String())
+	}
+	dyn, _ := h.dynamicFactory("")
+	got, err := dyn.Resource(helmwatch.HelmReleaseGVR).Namespace(helmwatch.FluxNamespace).
+		Get(context.Background(), "bp-keycloak", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get after reconcile: %v", err)
+	}
+	ann := got.GetAnnotations()
+	if ann[reconcileRequestedAtAnnotation] == "" {
+		t.Fatalf("want %s annotation set, annotations=%v", reconcileRequestedAtAnnotation, ann)
+	}
+}
+
+// Suspend then Resume flip spec.suspend on the live object.
+func TestReconcilerAction_SuspendResume(t *testing.T) {
+	r, h, depID := manageHarness(t, "",
+		helmReleaseObj("bp-keycloak", true, false, "0.4.1"))
+	dyn, _ := h.dynamicFactory("")
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, manageActionReq(depID, "HelmRelease", helmwatch.FluxNamespace, "bp-keycloak", "suspend", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("suspend want 200, got %d; body=%s", rec.Code, rec.Body.String())
+	}
+	got, _ := dyn.Resource(helmwatch.HelmReleaseGVR).Namespace(helmwatch.FluxNamespace).
+		Get(context.Background(), "bp-keycloak", metav1.GetOptions{})
+	if s, _, _ := unstructured.NestedBool(got.Object, "spec", "suspend"); !s {
+		t.Fatalf("after suspend want spec.suspend=true, got %v", got.Object["spec"])
+	}
+
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, manageActionReq(depID, "HelmRelease", helmwatch.FluxNamespace, "bp-keycloak", "resume", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("resume want 200, got %d; body=%s", rec.Code, rec.Body.String())
+	}
+	got, _ = dyn.Resource(helmwatch.HelmReleaseGVR).Namespace(helmwatch.FluxNamespace).
+		Get(context.Background(), "bp-keycloak", metav1.GetOptions{})
+	if s, _, _ := unstructured.NestedBool(got.Object, "spec", "suspend"); s {
+		t.Fatalf("after resume want spec.suspend=false, got %v", got.Object["spec"])
+	}
+}
+
+// A non-operator (viewer) session is denied 403. OwnerEmail empty +
+// OPERATOR_EMAIL cleared isolates the RBAC gate as the decision point.
+func TestReconcilerAction_Forbidden_Viewer(t *testing.T) {
+	t.Setenv("OPERATOR_EMAIL", "")
+	r, _, depID := manageHarness(t, "",
+		helmReleaseObj("bp-keycloak", true, false, "0.4.1"))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, manageActionReq(depID, "HelmRelease", helmwatch.FluxNamespace, "bp-keycloak", "suspend",
+		&auth.Claims{Email: "viewer@t99.omani.works", Tier: "viewer"}))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("want 403 for viewer, got %d; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// An unknown kind is rejected 400 before touching the cluster.
+func TestReconcilerAction_UnknownKind(t *testing.T) {
+	r, _, depID := manageHarness(t, "")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, manageActionReq(depID, "Banana", "ns", "x", "reconcile", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("want 400 for unknown kind, got %d; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// An unsupported action is rejected 400.
+func TestReconcilerAction_UnsupportedAction(t *testing.T) {
+	r, _, depID := manageHarness(t, "",
+		helmReleaseObj("bp-keycloak", true, false, "0.4.1"))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, manageActionReq(depID, "HelmRelease", helmwatch.FluxNamespace, "bp-keycloak", "delete", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("want 400 for unsupported action, got %d; body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/helmwatch/manage.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/manage.go
@@ -1,0 +1,266 @@
+// manage.go — the reader half of the lightweight ArgoCD-like reconciler
+// MANAGEMENT surface (issue #3996). Where reconcilers.go observes the
+// non-install reconciler activities for the Jobs canvas, this file lists
+// the FULL continuous-reconciler set the operator manages from the Cloud
+// view's Reconciliation lens — every Flux reconciler object (HelmRelease,
+// Kustomization, and the four Flux *source* kinds) plus the declarative
+// Catalyst CRs — with the rich per-object status the management UI needs:
+// the live reconcile state, the last-reconcile timestamp, the Ready
+// condition message, the applied source revision, and the suspended flag.
+//
+// It is deliberately GENERIC + read-only: it lists a fixed set of
+// reconciler GVRs via the SAME dynamic.Interface the rest of helmwatch
+// uses and emits one typed ManagedReconciler per object. The handler
+// (internal/handler/reconcilers.go) maps each onto the wire shape and
+// gates the mutating actions (reconcile / suspend / resume) behind the
+// same owner-check + operator RBAC the jobs-retry endpoint uses.
+package helmwatch
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+// Flux *source* GVRs (source-controller). These carry no spec.dependsOn
+// DAG but ARE first-class Flux reconcilers the operator manages — a stuck
+// GitRepository / OCIRepository / HelmRepository / HelmChart is the most
+// common reason a downstream HelmRelease never reconciles, so the
+// management surface must list + drive them too (issue #3996).
+var (
+	// GitRepositoryGVR — Flux GitRepository (source-controller).
+	GitRepositoryGVR = schema.GroupVersionResource{
+		Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "gitrepositories",
+	}
+	// OCIRepositoryGVR — Flux OCIRepository (source-controller).
+	OCIRepositoryGVR = schema.GroupVersionResource{
+		Group: "source.toolkit.fluxcd.io", Version: "v1beta2", Resource: "ocirepositories",
+	}
+	// HelmRepositoryGVR — Flux HelmRepository (source-controller).
+	HelmRepositoryGVR = schema.GroupVersionResource{
+		Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "helmrepositories",
+	}
+	// HelmChartGVR — Flux HelmChart (source-controller).
+	HelmChartGVR = schema.GroupVersionResource{
+		Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "helmcharts",
+	}
+)
+
+// FluxReconcilerKind — the wire `kind` the management surface uses to
+// address an object in the action/log routes. These match the K8s Kind
+// 1:1 (PascalCase) so the FE renders them verbatim and the handler maps
+// kind→GVR + kind→controller deterministically.
+const (
+	ManageKindHelmRelease    = "HelmRelease"
+	ManageKindKustomization  = "Kustomization"
+	ManageKindGitRepository  = "GitRepository"
+	ManageKindOCIRepository  = "OCIRepository"
+	ManageKindHelmRepository = "HelmRepository"
+	ManageKindHelmChart      = "HelmChart"
+)
+
+// managedGVRByKind maps each manageable Flux kind onto its GVR. The
+// handler reuses this for the reconcile/suspend/resume action routes so
+// there is ONE source of truth for kind→GVR. The declarative Catalyst CRs
+// (Application/Environment/Organization/Continuum) are intentionally NOT
+// here — they are reconciled by the Catalyst controllers, not Flux, and
+// carry no spec.suspend, so they are list-only on this surface.
+var managedGVRByKind = map[string]schema.GroupVersionResource{
+	ManageKindHelmRelease:    HelmReleaseGVR,
+	ManageKindKustomization:  KustomizationGVR,
+	ManageKindGitRepository:  GitRepositoryGVR,
+	ManageKindOCIRepository:  OCIRepositoryGVR,
+	ManageKindHelmRepository: HelmRepositoryGVR,
+	ManageKindHelmChart:      HelmChartGVR,
+}
+
+// ManagedGVRForKind returns the GVR for a manageable Flux kind + whether
+// the kind is recognised. The handler uses it to reject an unknown kind
+// with 400 before touching the cluster.
+func ManagedGVRForKind(kind string) (schema.GroupVersionResource, bool) {
+	gvr, ok := managedGVRByKind[strings.TrimSpace(kind)]
+	return gvr, ok
+}
+
+// ManagedReconciler is one row in the reconciler-management list — the
+// rich per-object status the lightweight ArgoCD-like UI renders.
+type ManagedReconciler struct {
+	// Kind — the K8s Kind (HelmRelease / Kustomization / GitRepository /
+	// OCIRepository / HelmRepository / HelmChart). Addresses the object in
+	// the action + log routes.
+	Kind string `json:"kind"`
+	// Name / Namespace — the object's coordinates.
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	// State — the Reconciliation vocabulary (Reconciled / Reconciling /
+	// Degraded / Suspended). NEVER Success/Failed (these are continuous
+	// reconcilers). Suspended wins over every other state.
+	State string `json:"state"`
+	// Message — the Flux Ready condition message (the "why" one-liner).
+	Message string `json:"message,omitempty"`
+	// Revision — the applied/attempted source revision (chart version,
+	// git SHA, OCI digest), when the object reports one.
+	Revision string `json:"revision,omitempty"`
+	// Suspended — true when spec.suspend is set. The FE renders Resume in
+	// place of Suspend + a muted row.
+	Suspended bool `json:"suspended"`
+	// LastReconcile — the Ready condition lastTransitionTime (RFC3339), or
+	// empty when the object has never reported Ready.
+	LastReconcile string `json:"lastReconcile,omitempty"`
+	// Controller — the Flux controller that owns this kind
+	// (helm-controller / kustomize-controller / source-controller). The FE
+	// shows it; the log route filters that controller's logs to this object.
+	Controller string `json:"controller"`
+}
+
+// Management state vocabulary (wire contract — matches reconciliation_dag.go
+// so the FE renders one set of labels). Exported so the handler counts the
+// Reconciled rows against the same constant the reader emits.
+const (
+	ManageStateReconciled  = "Reconciled"
+	ManageStateReconciling = "Reconciling"
+	ManageStateDegraded    = "Degraded"
+	ManageStateSuspended   = "Suspended"
+)
+
+// controllerForKind maps a Flux kind onto the controller whose logs carry
+// that object's reconcile output. helm-controller for HelmReleases,
+// kustomize-controller for Kustomizations, source-controller for the four
+// source kinds. The log route tails this controller filtered to the object.
+func controllerForKind(kind string) string {
+	switch kind {
+	case ManageKindHelmRelease:
+		return "helm-controller"
+	case ManageKindKustomization:
+		return "kustomize-controller"
+	case ManageKindGitRepository, ManageKindOCIRepository,
+		ManageKindHelmRepository, ManageKindHelmChart:
+		return "source-controller"
+	default:
+		return ""
+	}
+}
+
+// ControllerForKind is the exported form the handler uses to resolve the
+// controller (and its pod selector) for the log route.
+func ControllerForKind(kind string) string { return controllerForKind(kind) }
+
+// manageStateForReady maps a Flux object's Ready condition + suspended flag
+// onto the management vocabulary. Suspended always wins. Otherwise it
+// reuses the same anti-flap rule the DAG uses: Ready=True → Reconciled,
+// Ready=False+Stalled → Degraded, everything else → Reconciling.
+func manageStateForReady(conds []metav1.Condition, suspended bool) string {
+	if suspended {
+		return ManageStateSuspended
+	}
+	switch statusFromReadyCondition(conds) {
+	case ObsStatusSucceeded:
+		return ManageStateReconciled
+	case ObsStatusFailed:
+		return ManageStateDegraded
+	default:
+		return ManageStateReconciling
+	}
+}
+
+// revisionFromObject extracts the most meaningful applied/attempted source
+// revision a Flux object reports, trying the per-kind status fields in
+// priority order. Empty when none is present (e.g. an object that has never
+// reconciled). The order is: lastAppliedRevision (HelmRelease/Kustomization)
+// → lastAttemptedRevision (HelmRelease in-flight) → status.artifact.revision
+// (the source kinds).
+func revisionFromObject(u *unstructured.Unstructured) string {
+	for _, path := range [][]string{
+		{"status", "lastAppliedRevision"},
+		{"status", "lastAttemptedRevision"},
+		{"status", "artifact", "revision"},
+		{"status", "history", "0", "chartVersion"}, // best-effort HR chart version
+	} {
+		if v, ok, _ := unstructured.NestedString(u.Object, path...); ok {
+			if s := strings.TrimSpace(v); s != "" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// suspendedFromObject reads spec.suspend (default false). All the manageable
+// Flux kinds carry this field.
+func suspendedFromObject(u *unstructured.Unstructured) bool {
+	v, _, _ := unstructured.NestedBool(u.Object, "spec", "suspend")
+	return v
+}
+
+// ListManagedReconcilers performs a ONE-SHOT list of every manageable Flux
+// reconciler kind via the supplied dynamic client and returns the rich
+// management rows. Best-effort per GVR: a List error on one kind (e.g. the
+// OCIRepository CRD absent on a cluster that uses none) is swallowed so the
+// other kinds still surface. Returns an empty slice (never nil). The result
+// is sorted by (kind, namespace, name) for a stable render + test.
+func ListManagedReconcilers(ctx context.Context, dyn dynamic.Interface) ([]ManagedReconciler, error) {
+	if dyn == nil {
+		return []ManagedReconciler{}, nil
+	}
+	out := make([]ManagedReconciler, 0, 64)
+
+	// Stable kind order so the list reads + tests deterministically.
+	kinds := []string{
+		ManageKindHelmRelease,
+		ManageKindKustomization,
+		ManageKindGitRepository,
+		ManageKindOCIRepository,
+		ManageKindHelmRepository,
+		ManageKindHelmChart,
+	}
+	for _, kind := range kinds {
+		gvr := managedGVRByKind[kind]
+		list, err := dyn.Resource(gvr).Namespace("").List(ctx, metav1.ListOptions{})
+		if err != nil {
+			// CRD absent / RBAC-denied for this kind — skip, keep the rest.
+			continue
+		}
+		for i := range list.Items {
+			u := &list.Items[i]
+			conds, _ := extractConditions(u)
+			suspended := suspendedFromObject(u)
+			out = append(out, ManagedReconciler{
+				Kind:          kind,
+				Name:          u.GetName(),
+				Namespace:     u.GetNamespace(),
+				State:         manageStateForReady(conds, suspended),
+				Message:       messageFromReadyCondition(conds),
+				Revision:      revisionFromObject(u),
+				Suspended:     suspended,
+				LastReconcile: formatReconcileTime(readyTransitionTime(conds)),
+				Controller:    controllerForKind(kind),
+			})
+		}
+	}
+
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Kind != out[j].Kind {
+			return out[i].Kind < out[j].Kind
+		}
+		if out[i].Namespace != out[j].Namespace {
+			return out[i].Namespace < out[j].Namespace
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out, nil
+}
+
+// formatReconcileTime renders a reconcile timestamp as RFC3339, or "" when
+// zero (never reconciled).
+func formatReconcileTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}

--- a/products/catalyst/bootstrap/api/internal/helmwatch/manage_test.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/manage_test.go
@@ -1,0 +1,105 @@
+// manage_test.go — coverage for the #3996 reconciler-management reader:
+// kind→GVR mapping, kind→controller mapping, and the rich status/revision/
+// suspended projection from live objects.
+package helmwatch
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func TestManagedGVRForKind(t *testing.T) {
+	for _, kind := range []string{
+		ManageKindHelmRelease, ManageKindKustomization, ManageKindGitRepository,
+		ManageKindOCIRepository, ManageKindHelmRepository, ManageKindHelmChart,
+	} {
+		if _, ok := ManagedGVRForKind(kind); !ok {
+			t.Fatalf("kind %q should be manageable", kind)
+		}
+	}
+	if _, ok := ManagedGVRForKind("Banana"); ok {
+		t.Fatalf("unknown kind should not be manageable")
+	}
+}
+
+func TestControllerForKind(t *testing.T) {
+	cases := map[string]string{
+		ManageKindHelmRelease:    "helm-controller",
+		ManageKindKustomization:  "kustomize-controller",
+		ManageKindGitRepository:  "source-controller",
+		ManageKindOCIRepository:  "source-controller",
+		ManageKindHelmRepository: "source-controller",
+		ManageKindHelmChart:      "source-controller",
+	}
+	for kind, want := range cases {
+		if got := ControllerForKind(kind); got != want {
+			t.Fatalf("ControllerForKind(%q)=%q want %q", kind, got, want)
+		}
+	}
+}
+
+func mkHR(name string, readyStatus string, suspend bool, rev string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "helm.toolkit.fluxcd.io/v2",
+		"kind":       "HelmRelease",
+		"metadata":   map[string]any{"name": name, "namespace": "flux-system"},
+		"spec":       map[string]any{"suspend": suspend},
+		"status": map[string]any{
+			"lastAppliedRevision": rev,
+			"conditions": []any{map[string]any{
+				"type": "Ready", "status": readyStatus, "reason": "x",
+				"message": "m", "lastTransitionTime": "2026-06-20T10:00:00Z",
+			}},
+		},
+	}}
+}
+
+func TestListManagedReconcilers_Projection(t *testing.T) {
+	scheme := runtime.NewScheme()
+	listKinds := map[schema.GroupVersionResource]string{
+		HelmReleaseGVR:    "HelmReleaseList",
+		KustomizationGVR:  "KustomizationList",
+		GitRepositoryGVR:  "GitRepositoryList",
+		OCIRepositoryGVR:  "OCIRepositoryList",
+		HelmRepositoryGVR: "HelmRepositoryList",
+		HelmChartGVR:      "HelmChartList",
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds,
+		mkHR("bp-ready", "True", false, "1.0.0"),
+		mkHR("bp-suspended", "True", true, "2.0.0"),
+		mkHR("bp-progressing", "False", false, "3.0.0"),
+	)
+	rows, err := ListManagedReconcilers(context.Background(), dyn)
+	if err != nil {
+		t.Fatalf("ListManagedReconcilers: %v", err)
+	}
+	got := map[string]ManagedReconciler{}
+	for _, r := range rows {
+		got[r.Name] = r
+	}
+	if got["bp-ready"].State != ManageStateReconciled || got["bp-ready"].Revision != "1.0.0" {
+		t.Fatalf("bp-ready wrong: %+v", got["bp-ready"])
+	}
+	if got["bp-suspended"].State != ManageStateSuspended || !got["bp-suspended"].Suspended {
+		t.Fatalf("bp-suspended wrong: %+v", got["bp-suspended"])
+	}
+	// Ready=False but NOT Stalled → Reconciling (anti-flap), never Degraded.
+	if got["bp-progressing"].State != ManageStateReconciling {
+		t.Fatalf("bp-progressing should be Reconciling, got %q", got["bp-progressing"].State)
+	}
+	if got["bp-ready"].LastReconcile == "" {
+		t.Fatalf("bp-ready should carry a lastReconcile timestamp")
+	}
+}
+
+func TestListManagedReconcilers_NilClient(t *testing.T) {
+	rows, err := ListManagedReconcilers(context.Background(), nil)
+	if err != nil || len(rows) != 0 {
+		t.Fatalf("nil client should return empty,nil; got %v, %v", rows, err)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/jobs/filter.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/filter.go
@@ -1,0 +1,148 @@
+package jobs
+
+// filter.go — the `/jobs` view selector (issue #3996 follow-up).
+//
+// # Why /jobs is FINITE-only
+//
+// The Jobs page is a list of FINITE work — things that start, run, and
+// end: provision steps, cutover steps, batch Jobs, CronJob runs, and the
+// one-shot Day-2 mutations. The CONTINUOUS reconcilers — the Flux
+// HelmRelease installs that never stop reconciling, the Flux
+// Kustomization reconcile leaves, and the long-running reconciler
+// Deployments — are NOT finite work. They run forever by design, so
+// listing them on /jobs drowns the finite rows in an ever-growing wall of
+// "running" reconcilers (the exact symptom the founder sees on
+// console.<sov>/jobs).
+//
+// Those continuous reconcilers now have their OWN home: the Cloud surface
+// Reconciliation lens + the lightweight ArgoCD-like reconciler-management
+// surface (#3996), which reads them LIVE from the cluster (independent of
+// this jobs store). So removing them from /jobs loses nothing — it moves
+// them to the surface that's actually built for "always-on" objects.
+//
+// # What stays
+//
+//   - KindStep      — provision / cutover / DR-switchover steps (finite).
+//   - KindTask      — standalone / owned batch Jobs (finite).
+//   - KindCron      — recurring CronJob runs (each run is a finite
+//                     Execution; the row is the job-history).
+//   - KindMutation  — one-shot Day-2 Crossplane XRC submissions (finite).
+//   - KindLifecycle — Phase-0 / lifecycle leaves (tofu-init etc., finite).
+//
+// # What's removed
+//
+//   - KindInstall    — a Flux HelmRelease install leaf. Flux reconciles it
+//                      forever; it never "finishes". CONTINUOUS.
+//   - KindReconcile  — a Flux Kustomization reconcile leaf. CONTINUOUS.
+//   - KindReconciler — a long-running reconciler Deployment. CONTINUOUS.
+//
+// # Group pruning
+//
+// Removing the continuous leaves can leave a synthesised group Job with no
+// remaining children (e.g. the `reconcilers` group when every member was a
+// Kustomization/reconciler, or `bootstrap-kit` when it only ever held
+// install leaves). An empty group is noise, so we drop any group that has
+// no surviving descendant after the leaf filter and re-derive the tree
+// view so ChildIDs / rollups stay honest.
+
+// continuousReconcilerKinds is the set of Job kinds that represent
+// always-on reconcilers rather than finite work. They are surfaced on the
+// Cloud Reconciliation lens / reconciler-management surface (#3996), never
+// on /jobs.
+var continuousReconcilerKinds = map[string]bool{
+	KindInstall:    true,
+	KindReconcile:  true,
+	KindReconciler: true,
+}
+
+// IsContinuousReconciler reports whether a Job's kind is one of the
+// always-on reconciler kinds excluded from the finite /jobs list. Group
+// jobs (KindGroup) are never themselves continuous — they're pruned only
+// when empty, by FilterFiniteJobs.
+func IsContinuousReconciler(kind string) bool {
+	return continuousReconcilerKinds[kind]
+}
+
+// FilterFiniteJobs returns the subset of `in` that represents FINITE work
+// for the /jobs list: continuous-reconciler leaves (HelmRelease installs,
+// Flux Kustomization reconciles, reconciler Deployments) are dropped, and
+// any group Job left with no surviving descendant is pruned. The returned
+// slice is re-run through deriveTreeView so ChildIDs and group rollups
+// reflect only the surviving rows.
+//
+// The input is expected to be a deriveTreeView-shaped slice (the output of
+// Store.ListJobs): leaf rows + synthesised group rows, ParentID linking
+// children to groups. RunCount and other read-derived fields on the
+// survivors are preserved (deriveTreeView leaves leaf fields untouched and
+// only recomputes ChildIDs + group rollups).
+func FilterFiniteJobs(in []Job) []Job {
+	if len(in) == 0 {
+		return in
+	}
+
+	// Pass 1 — keep every non-group leaf that is NOT a continuous
+	// reconciler; defer the group keep/drop decision to pass 3 (a group
+	// survives only if at least one descendant survives).
+	type node struct {
+		job      Job
+		isGroup  bool
+		survives bool
+	}
+	nodes := make([]node, 0, len(in))
+	byID := make(map[string]int, len(in))
+	for _, j := range in {
+		isGroup := j.Type == JobTypeGroup || j.Kind == KindGroup
+		survives := false
+		if !isGroup {
+			// A leaf survives iff it is finite (not a continuous
+			// reconciler). Back-fill the kind from the name for legacy
+			// rows so a row persisted before the Kind field existed is
+			// classified honestly.
+			kind := j.Kind
+			if kind == "" {
+				kind = kindForLeaf(j.JobName)
+			}
+			survives = !IsContinuousReconciler(kind)
+		}
+		byID[j.ID] = len(nodes)
+		nodes = append(nodes, node{job: j, isGroup: isGroup, survives: survives})
+	}
+
+	// Pass 2 — propagate leaf survival up the parent chain so a group with
+	// at least one surviving descendant is itself kept. Walk leaves and
+	// mark every ancestor.
+	for i := range nodes {
+		if nodes[i].isGroup || !nodes[i].survives {
+			continue
+		}
+		parentID := nodes[i].job.ParentID
+		for parentID != "" {
+			pi, ok := byID[parentID]
+			if !ok {
+				break
+			}
+			if nodes[pi].survives {
+				break // ancestor already marked; chain above it too
+			}
+			nodes[pi].survives = true
+			parentID = nodes[pi].job.ParentID
+		}
+	}
+
+	// Pass 3 — collect survivors in input order, stripping derived fields
+	// so deriveTreeView recomputes ChildIDs / rollups against only the
+	// surviving set.
+	out := make([]Job, 0, len(nodes))
+	for i := range nodes {
+		if !nodes[i].survives {
+			continue
+		}
+		j := nodes[i].job
+		j.ChildIDs = nil
+		out = append(out, j)
+	}
+	if len(out) == 0 {
+		return []Job{}
+	}
+	return deriveTreeView(out)
+}

--- a/products/catalyst/bootstrap/api/internal/jobs/filter_test.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/filter_test.go
@@ -1,0 +1,115 @@
+package jobs
+
+import (
+	"testing"
+	"time"
+)
+
+// TestFilterFiniteJobs_DropsContinuousKeepsFinite asserts the /jobs
+// FINITE-work view (#3996 follow-up): the continuous reconcilers (install /
+// reconcile / reconciler leaves) are dropped, finite kinds (step / task /
+// cron / mutation / lifecycle) are kept, and a group left with no surviving
+// descendant is pruned while a group with a surviving finite child stays
+// with a correct rollup.
+func TestFilterFiniteJobs_DropsContinuousKeepsFinite(t *testing.T) {
+	dep := "dep-x"
+	t0 := time.Date(2026, 6, 21, 0, 0, 0, 0, time.UTC)
+	bk := JobID(dep, GroupBootstrapKit)
+	rec := JobID(dep, GroupReconcilers)
+	prov := JobID(dep, GroupProvisioner)
+
+	in := []Job{
+		// bootstrap-kit holds only continuous install leaves → group pruned.
+		{ID: bk, DeploymentID: dep, JobName: GroupBootstrapKit, Type: JobTypeGroup, Kind: KindGroup},
+		{ID: JobID(dep, "install-cilium"), DeploymentID: dep, JobName: "install-cilium", Kind: KindInstall, Type: JobTypeInstall, ParentID: bk, Status: StatusSucceeded},
+		{ID: JobID(dep, "install-flux"), DeploymentID: dep, JobName: "install-flux", Kind: KindInstall, Type: JobTypeInstall, ParentID: bk, Status: StatusRunning},
+
+		// reconcilers group holds only Kustomization reconciles + a
+		// reconciler Deployment → group pruned.
+		{ID: rec, DeploymentID: dep, JobName: GroupReconcilers, Type: JobTypeGroup, Kind: KindGroup},
+		{ID: JobID(dep, "reconcile-apps"), DeploymentID: dep, JobName: "reconcile-apps", Kind: KindReconcile, Type: JobTypeInstall, ParentID: rec, Status: StatusRunning},
+		{ID: JobID(dep, "reconciler-sso-bridge"), DeploymentID: dep, JobName: "reconciler-sso-bridge", Kind: KindReconciler, Type: JobTypeInstall, ParentID: rec, Status: StatusHealthy},
+
+		// provisioner group holds finite work → group + children kept.
+		{ID: prov, DeploymentID: dep, JobName: GroupProvisioner, Type: JobTypeGroup, Kind: KindGroup},
+		{ID: JobID(dep, "provisioner-step-tofu-init"), DeploymentID: dep, JobName: "provisioner-step-tofu-init", Kind: KindStep, Type: JobTypeInstall, ParentID: prov, Status: StatusSucceeded, StartedAt: &t0, FinishedAt: ptrT(t0.Add(time.Second))},
+		{ID: JobID(dep, "task-backup-once"), DeploymentID: dep, JobName: "task-backup-once", Kind: KindTask, Type: JobTypeInstall, ParentID: prov, Status: StatusRunning, StartedAt: ptrT(t0.Add(2 * time.Second))},
+		{ID: JobID(dep, "cron-snapshot"), DeploymentID: dep, JobName: "cron-snapshot", Kind: KindCron, Type: JobTypeInstall, ParentID: prov, Status: StatusSucceeded, StartedAt: &t0},
+		{ID: JobID(dep, "mutation-create-bucket"), DeploymentID: dep, JobName: "mutation-create-bucket", Kind: KindMutation, Type: JobTypeInstall, ParentID: prov, Status: StatusSucceeded, StartedAt: &t0},
+	}
+
+	out := FilterFiniteJobs(in)
+
+	// Survivors: provisioner group + 4 finite leaves = 5.
+	if len(out) != 5 {
+		t.Fatalf("want 5 survivors (group + 4 finite leaves), got %d: %+v", len(out), names(out))
+	}
+	for _, j := range out {
+		if IsContinuousReconciler(j.Kind) {
+			t.Errorf("continuous reconciler survived: %q (kind=%q)", j.JobName, j.Kind)
+		}
+		if j.JobName == GroupBootstrapKit || j.JobName == GroupReconcilers {
+			t.Errorf("empty group %q should be pruned", j.JobName)
+		}
+	}
+	var g *Job
+	for i := range out {
+		if out[i].Type == JobTypeGroup {
+			g = &out[i]
+		}
+	}
+	if g == nil || g.JobName != GroupProvisioner {
+		t.Fatalf("provisioner group missing/wrong: %+v", out)
+	}
+	if len(g.ChildIDs) != 4 {
+		t.Errorf("provisioner ChildIDs: want 4, got %d (%v)", len(g.ChildIDs), g.ChildIDs)
+	}
+	// succeeded + running + succeeded + succeeded → running rollup.
+	if g.Status != StatusRunning {
+		t.Errorf("provisioner rollup status: want running, got %q", g.Status)
+	}
+}
+
+// TestFilterFiniteJobs_LegacyKindBackfill asserts a row persisted before
+// the Kind field existed (Kind == "") is classified by JobName so an
+// "install-*" legacy leaf is still recognised as continuous and dropped,
+// while a "task-*" legacy leaf survives.
+func TestFilterFiniteJobs_LegacyKindBackfill(t *testing.T) {
+	dep := "dep-legacy"
+	in := []Job{
+		{ID: JobID(dep, "install-legacy"), DeploymentID: dep, JobName: "install-legacy", Type: JobTypeInstall, Status: StatusSucceeded},
+		{ID: JobID(dep, "task-legacy"), DeploymentID: dep, JobName: "task-legacy", Type: JobTypeInstall, Status: StatusSucceeded},
+	}
+	out := FilterFiniteJobs(in)
+	if len(out) != 1 || out[0].JobName != "task-legacy" {
+		t.Fatalf("legacy backfill: want only task-legacy, got %v", names(out))
+	}
+}
+
+// TestFilterFiniteJobs_AllContinuousYieldsEmpty asserts a deployment whose
+// /jobs store is nothing but continuous reconcilers returns an empty list
+// (never nil — the handler marshals []).
+func TestFilterFiniteJobs_AllContinuousYieldsEmpty(t *testing.T) {
+	dep := "dep-all-recon"
+	in := []Job{
+		{ID: JobID(dep, "install-a"), DeploymentID: dep, JobName: "install-a", Kind: KindInstall, Type: JobTypeInstall},
+		{ID: JobID(dep, "reconcile-b"), DeploymentID: dep, JobName: "reconcile-b", Kind: KindReconcile, Type: JobTypeInstall},
+	}
+	out := FilterFiniteJobs(in)
+	if len(out) != 0 {
+		t.Fatalf("want empty, got %v", names(out))
+	}
+	if out == nil {
+		t.Fatalf("want non-nil empty slice")
+	}
+}
+
+func names(js []Job) []string {
+	out := make([]string, len(js))
+	for i := range js {
+		out[i] = js[i].JobName
+	}
+	return out
+}
+
+func ptrT(t time.Time) *time.Time { return &t }

--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -189,6 +189,17 @@ import {
   probeWhoamiAndCacheMarker,
   sanitizeNextParam,
 } from './auth-gate'
+import { LENSES, type LensId } from '@/widgets/architecture-graph/presets'
+
+// isValidLensId — closed-set guard for the cloud route's `lens` query
+// param (#3996 follow-up: the reconciliation deep-link carries
+// `?view=graph&lens=reconciliation`). LENSES is the single source of truth
+// for valid lens ids; an unknown value is dropped at validateSearch so the
+// CloudLensProvider falls back to the default Cloud lens rather than
+// crashing on a missing table entry.
+function isValidLensId(raw: unknown): raw is LensId {
+  return typeof raw === 'string' && Object.prototype.hasOwnProperty.call(LENSES, raw)
+}
 
 /**
  * rootBeforeLoad — universal auth gate (#1090 cluster A2,
@@ -876,6 +887,12 @@ const provisionDecommissionRoute = createRoute({
 interface CloudSearch {
   view?: 'graph' | 'list'
   kind?: string
+  // lens — the active Cloud lens (chip-set) to open on. #3996 follow-up:
+  // the ConvergenceWizard reconciliation deep-link sends
+  // `?view=graph&lens=reconciliation` so the operator lands on the
+  // Reconciliation lens, not the default Cloud lens. Carried through both
+  // cloud routes' validateSearch so CloudPage can seed CloudLensProvider.
+  lens?: LensId
 }
 
 /**
@@ -990,6 +1007,7 @@ const provisionCloudRoute = createRoute({
     if (typeof raw.kind === 'string' && raw.kind.length > 0) {
       out.kind = normaliseCloudKind(raw.kind)
     }
+    if (isValidLensId(raw.lens)) out.lens = raw.lens
     return out
   },
 })
@@ -1457,6 +1475,7 @@ const consoleCloudRoute = createRoute({
     if (typeof raw.kind === 'string' && raw.kind.length > 0) {
       out.kind = normaliseCloudKind(raw.kind)
     }
+    if (isValidLensId(raw.lens)) out.lens = raw.lens
     return out
   },
 })

--- a/products/catalyst/bootstrap/ui/src/lib/reconciler-manage.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/reconciler-manage.api.ts
@@ -1,0 +1,133 @@
+/**
+ * lib/reconciler-manage.api.ts — client for the #3996 lightweight
+ * ArgoCD/Flux MANAGEMENT surface on the Reconciliation lens.
+ *
+ * Matches the Go handlers in
+ * products/catalyst/bootstrap/api/internal/handler/reconcilers.go:
+ *
+ *   GET  /api/v1/deployments/{id}/reconcilers
+ *   GET  /api/v1/deployments/{id}/reconcilers/{kind}/{ns}/{name}/logs
+ *   POST /api/v1/deployments/{id}/reconcilers/{kind}/{ns}/{name}/{action}
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md #4 the URL is built from API_BASE.
+ * Mutating calls go through authedFetch so the operator's session/Bearer
+ * is attached (the backend gates them behind the operator-tier RBAC).
+ */
+
+import { API_BASE } from '@/shared/config/urls'
+import { authedFetch } from '@/shared/lib/authedFetch'
+
+/** The reconcile state vocabulary the management list emits (never Success/Failed). */
+export type ManageState = 'Reconciled' | 'Reconciling' | 'Degraded' | 'Suspended'
+
+/** A manageable Flux reconciler row (mirror of helmwatch.ManagedReconciler). */
+export interface ManagedReconciler {
+  kind: string
+  name: string
+  namespace: string
+  state: ManageState
+  message?: string
+  revision?: string
+  suspended: boolean
+  lastReconcile?: string
+  controller: string
+}
+
+export interface ReconcilerList {
+  reconcilers: ManagedReconciler[]
+  reconciled: number
+  total: number
+}
+
+/** One controller-log line for the drill-in viewer. */
+export interface ReconcilerLogLine {
+  lineNumber: number
+  message: string
+}
+
+export interface ReconcilerLogs {
+  controller: string
+  object: string
+  lines: ReconcilerLogLine[]
+  total: number
+}
+
+/** The three Flux-native actions the surface can trigger. */
+export type ReconcilerActionKind = 'reconcile' | 'suspend' | 'resume'
+
+/** The Flux kinds that are MANAGEABLE (have reconcile/suspend/resume + logs).
+ *  The declarative Catalyst CRs are list-only, so the FE only shows the
+ *  management affordances for these. */
+export const MANAGEABLE_KINDS: ReadonlySet<string> = new Set([
+  'HelmRelease',
+  'Kustomization',
+  'GitRepository',
+  'OCIRepository',
+  'HelmRepository',
+  'HelmChart',
+])
+
+/** isManageableKind — true when a kind supports the Flux management actions. */
+export function isManageableKind(kind: string): boolean {
+  return MANAGEABLE_KINDS.has(kind)
+}
+
+/** fetchReconcilers lists every manageable Flux reconciler with live status. */
+export async function fetchReconcilers(deploymentId: string): Promise<ReconcilerList> {
+  const res = await authedFetch(
+    `${API_BASE}/v1/deployments/${encodeURIComponent(deploymentId)}/reconcilers`,
+    { headers: { Accept: 'application/json' } },
+  )
+  if (!res.ok) {
+    throw new Error(`reconcilers list failed: HTTP ${res.status}`)
+  }
+  return (await res.json()) as ReconcilerList
+}
+
+/** fetchReconcilerLogs pages the owning controller's logs filtered to one object. */
+export async function fetchReconcilerLogs(
+  deploymentId: string,
+  kind: string,
+  namespace: string,
+  name: string,
+  tailLines = 200,
+): Promise<ReconcilerLogs> {
+  const base = `${API_BASE}/v1/deployments/${encodeURIComponent(deploymentId)}/reconcilers`
+  const path = `${base}/${encodeURIComponent(kind)}/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/logs`
+  const res = await authedFetch(`${path}?tailLines=${tailLines}`, {
+    headers: { Accept: 'application/json' },
+  })
+  if (!res.ok) {
+    throw new Error(`reconciler logs failed: HTTP ${res.status}`)
+  }
+  return (await res.json()) as ReconcilerLogs
+}
+
+export interface ReconcilerActionResult {
+  kind: string
+  namespace: string
+  name: string
+  action: ReconcilerActionKind
+  requestedAt: string
+  requestedBy: string
+}
+
+/** triggerReconcilerAction fires reconcile / suspend / resume on one object. */
+export async function triggerReconcilerAction(
+  deploymentId: string,
+  kind: string,
+  namespace: string,
+  name: string,
+  action: ReconcilerActionKind,
+): Promise<ReconcilerActionResult> {
+  const base = `${API_BASE}/v1/deployments/${encodeURIComponent(deploymentId)}/reconcilers`
+  const path = `${base}/${encodeURIComponent(kind)}/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/${action}`
+  const res = await authedFetch(path, { method: 'POST' })
+  if (res.status === 403) {
+    throw new Error('Not permitted — managing a reconciler requires operator tier or higher.')
+  }
+  if (!res.ok) {
+    throw new Error(`reconciler ${action} failed: HTTP ${res.status}`)
+  }
+  return (await res.json()) as ReconcilerActionResult
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CloudPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CloudPage.tsx
@@ -68,6 +68,7 @@ import {
 } from './cloud-list/kinds'
 import { useK8sCacheStream } from '@/widgets/architecture-graph/useK8sCacheStream'
 import { CloudLensProvider } from '@/widgets/architecture-graph/useCloudLens'
+import type { LensId } from '@/widgets/architecture-graph/presets'
 import {
   getHierarchicalInfrastructure,
   listDeployments,
@@ -206,7 +207,15 @@ export function CloudPage({
   const navigate = useNavigate()
 
   const pathname = useRouterState({ select: (s) => s.location.pathname })
-  const search = useSearch({ strict: false }) as { view?: string; kind?: string }
+  const search = useSearch({ strict: false }) as {
+    view?: string
+    kind?: string
+    // #3996 follow-up — the reconciliation deep-link opens the surface on
+    // the Reconciliation lens; the route's validateSearch already
+    // closed-set-validated this against LENSES, so we thread it straight
+    // into CloudLensProvider as the initial chip-set.
+    lens?: LensId
+  }
 
   const { snapshot } = useDeploymentEvents({
     deploymentId,
@@ -689,7 +698,7 @@ export function CloudPage({
         </div>
 
         <CloudContext.Provider value={ctx}>
-          <CloudLensProvider>
+          <CloudLensProvider initialLensId={search.lens}>
           <div
             id="cloud-page-content"
             ref={contentRef}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/ConvergenceWizard.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/ConvergenceWizard.test.tsx
@@ -111,10 +111,17 @@ describe('ConvergenceWizard render', () => {
     expect(screen.getByTestId('wizard-reconcile-ratio').textContent).toContain('52/65')
   })
 
-  it('deep-links phase ③ to the unified Cloud graph and ② to Jobs', async () => {
+  it('deep-links phase ③ to the unified Cloud graph reconciliation LENS and ② to Jobs', async () => {
     renderWizard({ status: 'phase1-watching' } as DeploymentSnapshot)
     const reconLink = await screen.findByTestId('wizard-link-reconciliation')
-    expect(reconLink.getAttribute('href')).toContain('/cloud')
+    const href = reconLink.getAttribute('href') ?? ''
+    expect(href).toContain('/cloud')
+    // #3996 follow-up — the link must select the Reconciliation lens, not
+    // the default Cloud lens. The cloud route's validateSearch carries the
+    // `lens` param through, so the rendered href must include it (a dropped
+    // param would mean the deep-link lands on the default lens).
+    expect(href).toContain('view=graph')
+    expect(href).toContain('lens=reconciliation')
     const jobsLink = screen.getByTestId('wizard-link-jobs')
     expect(jobsLink.getAttribute('href')).toContain('/jobs')
   })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/ConvergenceWizard.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/ConvergenceWizard.tsx
@@ -169,11 +169,15 @@ export function ConvergenceWizard({ snapshot, deploymentId }: ConvergenceWizardP
                   {' · '}
                   {/* #3958 — the standalone /reconciliation DAG page is
                       gone; reconcilers now live on the unified Cloud
-                      graph. Deep-link there. */}
+                      graph. #3996 follow-up: deep-link must select the
+                      Reconciliation LENS (not the default Cloud lens) so
+                      the operator lands on the reconciler chip-set —
+                      `lens=reconciliation` is carried through the cloud
+                      route's validateSearch and seeds CloudLensProvider. */}
                   <Link
                     to={'/provision/$deploymentId/cloud' as never}
                     params={{ deploymentId } as never}
-                    search={{ view: 'graph' } as never}
+                    search={{ view: 'graph', lens: 'reconciliation' } as never}
                     data-testid="wizard-link-reconciliation"
                     className="text-[var(--color-accent)] no-underline hover:underline"
                   >

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.tsx
@@ -5,14 +5,26 @@
  *   • Header: <h1>Jobs</h1> + tagline + back-to-apps link.
  *   • <JobsTable /> — table view with search/sort/filter + per-row Retry.
  *
+ * # FINITE work only (#3996 follow-up)
+ *
+ * /jobs is the list of FINITE work — things that start, run, and END:
+ * provision steps, cutover steps, batch Jobs, CronJob runs, and one-shot
+ * Day-2 mutations. The CONTINUOUS reconcilers — Flux HelmRelease installs,
+ * Flux Kustomization reconciles, and long-running reconciler Deployments —
+ * are NOT finite work; they run forever by design. They are now EXCLUDED
+ * from `/jobs` by the catalyst-api `ListJobs` handler
+ * (`jobs.FilterFiniteJobs`) and surface ONLY on the Cloud surface's
+ * Reconciliation lens + the ArgoCD-like reconciler-management surface
+ * (#3996), which reads them LIVE from the cluster. So this page no longer
+ * drowns its finite rows in an ever-growing wall of "running" reconcilers.
+ *
  * # One honest list — no client-side mashup (issue #3646)
  *
  * This page renders ONE backend list: the catalyst-api `/jobs` REST
- * payload (`liveJobs`), which — after the §5a generic ingestion — already
- * carries EVERY reconciler activity (HelmRelease installs, Flux
- * Kustomizations, recurring CronJobs, batch Jobs, reconciler Deployments,
- * the cutover steps) with a backend-derived, honest status. The previous
- * four-feed mashup is GONE:
+ * payload (`liveJobs`), now narrowed to the finite-work set described
+ * above (recurring CronJobs + batch Jobs + the provision/cutover steps),
+ * each with a backend-derived, honest status. The previous four-feed
+ * mashup is GONE:
  *
  *   ✗ `flowJobs` (`synthesizeJobFromFlowNode` as a list source) — the
  *     openova-flow rows are now written into the jobs Store by the

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ReconcileTab.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ReconcileTab.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * ReconcileTab.test.tsx — wiring lock-in for the #3996 management tab:
+ * reads status/revision/suspended off the live object, renders controller
+ * LOGS, and fires reconcile / suspend / resume through the action client.
+ */
+
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { K8sObject } from '@/widgets/architecture-graph/useK8sCacheStream'
+
+const fetchReconcilerLogs = vi.fn()
+const triggerReconcilerAction = vi.fn()
+
+vi.mock('@/lib/reconciler-manage.api', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/reconciler-manage.api')>(
+    '@/lib/reconciler-manage.api',
+  )
+  return {
+    ...actual,
+    fetchReconcilerLogs: (...a: unknown[]) => fetchReconcilerLogs(...a),
+    triggerReconcilerAction: (...a: unknown[]) => triggerReconcilerAction(...a),
+  }
+})
+
+import { ReconcileTab, wireKindFor, isReconcilerManageable } from './ReconcileTab'
+
+afterEach(cleanup)
+
+function renderTab(obj: K8sObject | null, apiKind = 'helmrelease') {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <ReconcileTab deploymentId="dep-1" apiKind={apiKind} ns="flux-system" name="bp-keycloak" obj={obj} />
+    </QueryClientProvider>,
+  )
+}
+
+const READY_HR: K8sObject = {
+  apiVersion: 'helm.toolkit.fluxcd.io/v2',
+  kind: 'HelmRelease',
+  metadata: { name: 'bp-keycloak', namespace: 'flux-system' },
+  spec: { suspend: false },
+  status: {
+    lastAppliedRevision: '0.4.1',
+    conditions: [{ type: 'Ready', status: 'True', reason: 'ReconciliationSucceeded', message: 'ok' }],
+  },
+} as unknown as K8sObject
+
+beforeEach(() => {
+  fetchReconcilerLogs.mockReset()
+  triggerReconcilerAction.mockReset()
+  fetchReconcilerLogs.mockResolvedValue({
+    controller: 'helm-controller',
+    object: 'flux-system/bp-keycloak',
+    lines: [{ lineNumber: 1, message: 'reconciling HelmRelease flux-system/bp-keycloak' }],
+    total: 1,
+  })
+  triggerReconcilerAction.mockResolvedValue({
+    kind: 'HelmRelease',
+    namespace: 'flux-system',
+    name: 'bp-keycloak',
+    action: 'reconcile',
+    requestedAt: '2026-06-20T10:01:00Z',
+    requestedBy: 'emrah.baysal@openova.io',
+  })
+})
+
+describe('wireKindFor / isReconcilerManageable', () => {
+  it('maps the six manageable kinds and rejects others', () => {
+    expect(wireKindFor('helmrelease')).toBe('HelmRelease')
+    expect(wireKindFor('gitrepository')).toBe('GitRepository')
+    expect(isReconcilerManageable('kustomization')).toBe(true)
+    expect(isReconcilerManageable('pod')).toBe(false)
+    expect(wireKindFor('configmap')).toBe('')
+  })
+})
+
+describe('ReconcileTab', () => {
+  it('shows state/revision/suspended off the live object and renders logs', async () => {
+    renderTab(READY_HR)
+    expect(screen.getByTestId('reconcile-kv-state').textContent).toContain('Reconciled')
+    expect(screen.getByTestId('reconcile-kv-revision').textContent).toContain('0.4.1')
+    expect(screen.getByTestId('reconcile-kv-suspended').textContent).toContain('no')
+    await waitFor(() =>
+      expect(screen.getByTestId('reconcile-tab-logs').textContent).toContain(
+        'flux-system/bp-keycloak',
+      ),
+    )
+  })
+
+  it('fires Reconcile now with the PascalCase wire kind', async () => {
+    renderTab(READY_HR)
+    fireEvent.click(screen.getByTestId('reconcile-action-reconcile'))
+    await waitFor(() =>
+      expect(triggerReconcilerAction).toHaveBeenCalledWith(
+        'dep-1',
+        'HelmRelease',
+        'flux-system',
+        'bp-keycloak',
+        'reconcile',
+      ),
+    )
+  })
+
+  it('shows Suspend for a running reconciler and triggers it', async () => {
+    renderTab(READY_HR)
+    fireEvent.click(screen.getByTestId('reconcile-action-suspend'))
+    await waitFor(() =>
+      expect(triggerReconcilerAction).toHaveBeenCalledWith(
+        'dep-1',
+        'HelmRelease',
+        'flux-system',
+        'bp-keycloak',
+        'suspend',
+      ),
+    )
+  })
+
+  it('shows Resume (not Suspend) when the object is suspended', () => {
+    const suspended = {
+      ...READY_HR,
+      spec: { suspend: true },
+    } as unknown as K8sObject
+    renderTab(suspended)
+    expect(screen.getByTestId('reconcile-kv-suspended').textContent).toContain('yes')
+    expect(screen.getByTestId('reconcile-kv-state').textContent).toContain('Suspended')
+    expect(screen.getByTestId('reconcile-action-resume')).toBeTruthy()
+    expect(screen.queryByTestId('reconcile-action-suspend')).toBeNull()
+  })
+
+  it('renders the not-flux note for a non-manageable kind', () => {
+    renderTab(READY_HR, 'configmap')
+    expect(screen.getByTestId('reconcile-tab-not-flux')).toBeTruthy()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ReconcileTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ReconcileTab.tsx
@@ -1,0 +1,251 @@
+/**
+ * ReconcileTab — the lightweight ArgoCD/Flux MANAGEMENT tab on the recon
+ * lens drill-in (issue #3996). Rendered inside ResourceDetailPage for the
+ * manageable Flux reconciler kinds only (HelmRelease / Kustomization /
+ * GitRepository / OCIRepository / HelmRepository / HelmChart).
+ *
+ * It is purely ADDITIVE — the existing Overview / YAML / Logs / Exec /
+ * Events / Metrics / Tree tabs and the rest of the k9s-style explorer are
+ * untouched. This tab adds, in one place:
+ *   • the live reconcile status + applied source revision + suspended flag
+ *     (read off the already-loaded resource object),
+ *   • the OWNING controller's LOGS filtered to this object (new endpoint),
+ *   • the Flux-native triggers: Reconcile now / Suspend / Resume.
+ *
+ * The cloud-list registry uses lowercase-singular kind ids (e.g.
+ * "helmrelease"); the management endpoints address objects by their
+ * PascalCase K8s Kind. wireKindFor() maps between them.
+ */
+
+import { useMemo, useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import type { K8sObject } from '@/widgets/architecture-graph/useK8sCacheStream'
+import {
+  fetchReconcilerLogs,
+  triggerReconcilerAction,
+  type ReconcilerActionKind,
+} from '@/lib/reconciler-manage.api'
+
+const LOG_POLL_MS = 5_000
+
+/** Map the cloud-list lowercase-singular kind id → the PascalCase K8s Kind
+ *  the management endpoints address. Returns '' for a non-manageable kind. */
+export function wireKindFor(apiKind: string): string {
+  switch (apiKind.toLowerCase()) {
+    case 'helmrelease':
+      return 'HelmRelease'
+    case 'kustomization':
+      return 'Kustomization'
+    case 'gitrepository':
+      return 'GitRepository'
+    case 'ocirepository':
+      return 'OCIRepository'
+    case 'helmrepository':
+      return 'HelmRepository'
+    case 'helmchart':
+      return 'HelmChart'
+    default:
+      return ''
+  }
+}
+
+/** isReconcilerManageable — true when the kind supports this tab. */
+export function isReconcilerManageable(apiKind: string): boolean {
+  return wireKindFor(apiKind) !== ''
+}
+
+/** Read the Ready condition off a Flux object → a display state string. */
+function readyStateOf(obj: K8sObject | null, suspended: boolean): string {
+  if (suspended) return 'Suspended'
+  const conds = ((obj?.status as { conditions?: unknown } | undefined)?.conditions ?? []) as {
+    type?: string
+    status?: string
+    reason?: string
+  }[]
+  const ready = conds.find((c) => c.type === 'Ready')
+  if (!ready) return 'Reconciling'
+  if (ready.status === 'True') return 'Reconciled'
+  if (ready.status === 'False' && (ready.reason ?? '').toLowerCase() === 'stalled') return 'Degraded'
+  return 'Reconciling'
+}
+
+function readyMessageOf(obj: K8sObject | null): string {
+  const conds = ((obj?.status as { conditions?: unknown } | undefined)?.conditions ?? []) as {
+    type?: string
+    message?: string
+  }[]
+  return conds.find((c) => c.type === 'Ready')?.message ?? ''
+}
+
+function revisionOf(obj: K8sObject | null): string {
+  const status = (obj?.status ?? {}) as Record<string, unknown>
+  const artifact = (status.artifact ?? {}) as Record<string, unknown>
+  return (
+    (status.lastAppliedRevision as string) ||
+    (status.lastAttemptedRevision as string) ||
+    (artifact.revision as string) ||
+    ''
+  )
+}
+
+export interface ReconcileTabProps {
+  deploymentId: string
+  /** lowercase-singular kind id from the cloud-list registry. */
+  apiKind: string
+  ns: string
+  name: string
+  /** The already-loaded live object (status/spec for the status block). */
+  obj: K8sObject | null
+  /** Mirrors the page's RBAC hint; the server is the authoritative gate. */
+  isTierAdmin?: boolean
+}
+
+export function ReconcileTab({ deploymentId, apiKind, ns, name, obj, isTierAdmin = true }: ReconcileTabProps) {
+  const qc = useQueryClient()
+  const [actionMsg, setActionMsg] = useState<string>('')
+  const wireKind = useMemo(() => wireKindFor(apiKind), [apiKind])
+
+  const suspended = useMemo(
+    () => Boolean((obj?.spec as { suspend?: boolean } | undefined)?.suspend),
+    [obj],
+  )
+  const state = readyStateOf(obj, suspended)
+  const revision = revisionOf(obj)
+  const message = readyMessageOf(obj)
+
+  const logsQuery = useQuery({
+    queryKey: ['reconciler-logs', deploymentId, wireKind, ns, name],
+    queryFn: () => fetchReconcilerLogs(deploymentId, wireKind, ns || '', name),
+    enabled: !!deploymentId && !!wireKind && !!name,
+    refetchInterval: LOG_POLL_MS,
+    staleTime: LOG_POLL_MS,
+    placeholderData: (prev) => prev,
+  })
+
+  const action = useMutation({
+    mutationFn: (a: ReconcilerActionKind) =>
+      triggerReconcilerAction(deploymentId, wireKind, ns || '', name, a),
+    onSuccess: (res) => {
+      setActionMsg(`${res.action} requested by ${res.requestedBy}`)
+      void qc.invalidateQueries({ queryKey: ['reconciler-logs', deploymentId, wireKind, ns, name] })
+      void qc.invalidateQueries({ queryKey: ['reconciliation-dag', deploymentId] })
+    },
+    onError: (e: unknown) => setActionMsg(e instanceof Error ? e.message : 'action failed'),
+  })
+
+  if (!wireKind) {
+    return (
+      <div
+        data-testid="reconcile-tab-not-flux"
+        className="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-2)] p-6 text-sm text-[var(--color-text-dim)]"
+      >
+        This kind is not a Flux-managed reconciler — reconcile / suspend / resume are unavailable.
+      </div>
+    )
+  }
+
+  return (
+    <div data-testid="reconcile-tab" className="space-y-4">
+      {/* Status block — read off the live object. */}
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-3" data-testid="reconcile-tab-status">
+        <KV label="State" value={state} testId="reconcile-kv-state" />
+        <KV label="Revision" value={revision || '—'} testId="reconcile-kv-revision" />
+        <KV label="Suspended" value={suspended ? 'yes' : 'no'} testId="reconcile-kv-suspended" />
+      </div>
+      {message ? (
+        <p className="text-sm text-[var(--color-text-dim)]" data-testid="reconcile-tab-message">
+          {message}
+        </p>
+      ) : null}
+
+      {/* Triggers — RBAC-gated server-side; the UI hides them for viewers. */}
+      <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-2)] p-4">
+        <div className="mb-2 text-xs uppercase tracking-wide text-[var(--color-text-dim)]">Flux actions</div>
+        <div className="flex flex-wrap items-center gap-2" data-testid="reconcile-tab-actions">
+          <button
+            type="button"
+            disabled={!isTierAdmin || action.isPending}
+            onClick={() => action.mutate('reconcile')}
+            data-testid="reconcile-action-reconcile"
+            className="rounded-md border border-[var(--color-accent)] bg-[var(--color-bg)] px-3 py-1.5 text-sm font-semibold text-[var(--color-accent)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50"
+          >
+            Reconcile now
+          </button>
+          {suspended ? (
+            <button
+              type="button"
+              disabled={!isTierAdmin || action.isPending}
+              onClick={() => action.mutate('resume')}
+              data-testid="reconcile-action-resume"
+              className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-1.5 text-sm font-semibold text-[var(--color-text)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50"
+            >
+              Resume
+            </button>
+          ) : (
+            <button
+              type="button"
+              disabled={!isTierAdmin || action.isPending}
+              onClick={() => action.mutate('suspend')}
+              data-testid="reconcile-action-suspend"
+              className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-1.5 text-sm font-semibold text-[var(--color-text)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50"
+            >
+              Suspend
+            </button>
+          )}
+          {actionMsg ? (
+            <span className="text-xs text-[var(--color-text-dim)]" data-testid="reconcile-action-msg">
+              {actionMsg}
+            </span>
+          ) : null}
+        </div>
+      </div>
+
+      {/* Logs — the owning controller's output filtered to this object. */}
+      <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-2)] p-4">
+        <div className="mb-2 flex items-center justify-between">
+          <span className="text-xs uppercase tracking-wide text-[var(--color-text-dim)]">
+            Controller logs
+            {logsQuery.data ? (
+              <span className="ml-1 normal-case text-[var(--color-accent)]"> · {logsQuery.data.controller}</span>
+            ) : null}
+          </span>
+          {logsQuery.isFetching ? (
+            <span className="text-[10px] uppercase tracking-wide text-emerald-400">live</span>
+          ) : null}
+        </div>
+        <pre
+          data-testid="reconcile-tab-logs"
+          className="max-h-[48vh] min-h-[200px] overflow-auto rounded-md border border-[var(--color-border)] bg-[var(--log-viewer-bg,#0D1117)] p-3 font-mono text-xs text-[#c9d1d9]"
+        >
+          {logsQuery.isLoading ? (
+            <span className="text-[#6e7681]">Loading controller logs…</span>
+          ) : logsQuery.isError ? (
+            <span className="text-[#6e7681]">
+              Could not load logs: {(logsQuery.error as Error)?.message}
+            </span>
+          ) : (logsQuery.data?.lines.length ?? 0) === 0 ? (
+            <span className="text-[#6e7681]">
+              No recent controller lines mention this object.
+            </span>
+          ) : (
+            logsQuery.data!.lines.map((l) => (
+              <div key={l.lineNumber} className="flex gap-3">
+                <span className="w-9 flex-shrink-0 select-none text-right text-[#6e7681]">{l.lineNumber}</span>
+                <span className="whitespace-pre-wrap break-words">{l.message}</span>
+              </div>
+            ))
+          )}
+        </pre>
+      </div>
+    </div>
+  )
+}
+
+function KV({ label, value, testId }: { label: string; value: string; testId: string }) {
+  return (
+    <div className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] p-3" data-testid={testId}>
+      <div className="text-xs uppercase tracking-wide text-[var(--color-text-dim)]">{label}</div>
+      <div className="mt-1 break-words font-mono text-sm text-[var(--color-text)]">{value || '—'}</div>
+    </div>
+  )
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceDetailPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceDetailPage.test.tsx
@@ -151,10 +151,15 @@ describe('ResourceDetailPage', () => {
     )
     // URL-kind shape preserved on the wrapper for deep-link asserts.
     expect(screen.getByTestId('resource-detail-services-kube-dns')).toBeTruthy()
-    // Tab strip still uses the canonical 7 testids.
-    for (const t of ['overview', 'yaml', 'logs', 'exec', 'events', 'metrics', 'tree']) {
+    // Tab strip for a non-Pod, non-reconcilable kind (Service): the
+    // Pod-only 'exec' tab (#2626) and the Flux-only 'reconcile' tab (#3996)
+    // are hidden; every other tab renders.
+    for (const t of ['overview', 'yaml', 'logs', 'events', 'metrics', 'sbom', 'compliance', 'tree']) {
       expect(screen.getByTestId(`resource-detail-tab-${t}`)).toBeTruthy()
     }
+    // exec is Pod-only and reconcile is Flux-only — neither shows on a Service.
+    expect(screen.queryByTestId('resource-detail-tab-exec')).toBeNull()
+    expect(screen.queryByTestId('resource-detail-tab-reconcile')).toBeNull()
   })
 
   it('renders YamlEditor with singular kind for plural URL kind', () => {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceDetailPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceDetailPage.tsx
@@ -60,6 +60,8 @@ import { LogViewer } from '@/widgets/cloud-list/LogViewer'
 import { ExecPanel } from '@/widgets/cloud-list/ExecPanel'
 // Wave-2 Family-E (#1583, C11-010): per-Pod SBOM + CVE drill-down.
 import { SBOMTab } from './SBOMTab'
+// #3996 — the lightweight ArgoCD/Flux management tab (Flux reconciler kinds).
+import { ReconcileTab, isReconcilerManageable } from './ReconcileTab'
 import type { K8sObject } from '@/widgets/architecture-graph/useK8sCacheStream'
 import {
   RESOURCE_DETAIL_TABS,
@@ -245,7 +247,13 @@ export function ResourceDetailPage(props: ResourceDetailPageProps) {
         {/* G79 #2626: 'exec' tab is only meaningful for Pods. Hide it on
             non-Pod kinds rather than rendering a tab whose content is
             "Drill into the Tree tab and pick a child Pod." */}
-        {RESOURCE_DETAIL_TABS.filter((t) => t !== 'exec' || apiKind === 'pod').map((t) => {
+        {RESOURCE_DETAIL_TABS.filter(
+          (t) =>
+            (t !== 'exec' || apiKind === 'pod') &&
+            // #3996 — the 'reconcile' management tab is only meaningful for
+            // the Flux reconciler kinds; hide it everywhere else.
+            (t !== 'reconcile' || isReconcilerManageable(apiKind)),
+        ).map((t) => {
           const active = t === tab
           return (
             <button
@@ -364,6 +372,23 @@ export function ResourceDetailPage(props: ResourceDetailPageProps) {
                 Open in Compliance Dashboard →
               </a>
             </div>
+          )}
+          {tab === 'reconcile' && (
+            isReconcilerManageable(apiKind) ? (
+              <ReconcileTab
+                deploymentId={deploymentId}
+                apiKind={apiKind}
+                ns={ns}
+                name={name}
+                obj={obj}
+                isTierAdmin={isTierAdmin}
+              />
+            ) : (
+              <PlaceholderTab
+                testId="resource-detail-reconcile-not-flux"
+                note="Reconcile / suspend / resume are available only for Flux reconciler kinds (HelmRelease, Kustomization, GitRepository, OCIRepository, HelmRepository, HelmChart)."
+              />
+            )
           )}
           {tab === 'tree' && (
             <ResourceTree basePath={basePath} tree={tree} isError={!!treeErr} isLoading={!tree && !treeErr} />
@@ -926,6 +951,8 @@ function tabLabel(tab: ResourceDetailTab): string {
       return 'Metrics'
     case 'sbom':
       return 'SBOM'
+    case 'reconcile':
+      return 'Reconcile'
     case 'tree':
       return 'Tree'
     default:

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/resource.api.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/resource.api.ts
@@ -88,6 +88,11 @@ export const RESOURCE_DETAIL_TABS = [
   'metrics',
   'sbom',
   'compliance',
+  // #3996 — the lightweight ArgoCD/Flux management tab. Rendered only for
+  // the manageable Flux reconciler kinds (HelmRelease / Kustomization /
+  // GitRepository / OCIRepository / HelmRepository / HelmChart); hidden on
+  // every other kind, exactly like the Pod-only 'exec' tab.
+  'reconcile',
   'tree',
 ] as const
 export type ResourceDetailTab = (typeof RESOURCE_DETAIL_TABS)[number]

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/useCloudLens.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/useCloudLens.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * useCloudLens.test.tsx — the lens-seeding contract (#3996 follow-up).
+ *
+ * The ConvergenceWizard reconciliation deep-link arrives at the Cloud
+ * surface with `?lens=reconciliation`; CloudPage threads it into
+ * CloudLensProvider as `initialLensId`. These tests pin that the initial
+ * lens is honoured, that an absent/unknown seed falls back to the default
+ * Cloud lens, and that operator interaction (selectLens) still wins
+ * thereafter.
+ */
+import { describe, it, expect } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { useCloudLensState } from './useCloudLens'
+import { DEFAULT_LENS_ID, LENSES, lensChips, setsEqual } from './presets'
+
+describe('useCloudLensState — initial lens seeding (#3996)', () => {
+  it('opens on the reconciliation lens when seeded with it', () => {
+    const { result } = renderHook(() => useCloudLensState('reconciliation'))
+    expect(result.current.lensId).toBe('reconciliation')
+    expect(
+      setsEqual(result.current.activeTypes, lensChips(LENSES.reconciliation)),
+    ).toBe(true)
+    expect(result.current.isCustom).toBe(false)
+  })
+
+  it('falls back to the default Cloud lens when seed is undefined', () => {
+    const { result } = renderHook(() => useCloudLensState(undefined))
+    expect(result.current.lensId).toBe(DEFAULT_LENS_ID)
+  })
+
+  it('falls back to the default Cloud lens when seed is an unknown id', () => {
+    // Cast through unknown — validateSearch already closed-set-guards the
+    // wire value, but the hook must be defensive if a stray id arrives.
+    const { result } = renderHook(() =>
+      useCloudLensState('not-a-lens' as never),
+    )
+    expect(result.current.lensId).toBe(DEFAULT_LENS_ID)
+  })
+
+  it('lets operator selectLens override the seeded lens', () => {
+    const { result } = renderHook(() => useCloudLensState('reconciliation'))
+    act(() => result.current.selectLens('networking'))
+    expect(result.current.lensId).toBe('networking')
+    expect(
+      setsEqual(result.current.activeTypes, lensChips(LENSES.networking)),
+    ).toBe(true)
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/useCloudLens.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/useCloudLens.tsx
@@ -51,11 +51,21 @@ export interface CloudLensState {
  * useCloudLensState — the state implementation. Used directly by the
  * provider; exposed so the graph widget can also fall back to a private
  * instance when it's rendered standalone (no provider).
+ *
+ * `initialLensId` seeds the opening lens (#3996 follow-up: the
+ * ConvergenceWizard reconciliation deep-link arrives with
+ * `?lens=reconciliation`, which CloudPage threads down here so the surface
+ * opens on the Reconciliation chip-set instead of the default Cloud lens).
+ * It is honoured ONLY for the initial state — once the operator selects a
+ * lens or edits chips, that interaction owns the state (we never re-seed on
+ * a re-render, so navigating chips never snaps back to the URL lens).
  */
-export function useCloudLensState(): CloudLensState {
-  const [lensId, setLensId] = useState<LensId>(DEFAULT_LENS_ID)
+export function useCloudLensState(initialLensId?: LensId): CloudLensState {
+  const seedId: LensId =
+    initialLensId && LENSES[initialLensId] ? initialLensId : DEFAULT_LENS_ID
+  const [lensId, setLensId] = useState<LensId>(seedId)
   const [activeTypes, setActiveTypes] = useState<Set<ArchNodeType>>(
-    () => lensChips(LENSES[DEFAULT_LENS_ID]),
+    () => lensChips(LENSES[seedId]),
   )
 
   const api = useMemo<CloudLensState>(() => {
@@ -90,8 +100,20 @@ export function useCloudLensState(): CloudLensState {
 
 const CloudLensContext = createContext<CloudLensState | null>(null)
 
-export function CloudLensProvider({ children }: { children: ReactNode }) {
-  const value = useCloudLensState()
+export function CloudLensProvider({
+  children,
+  initialLensId,
+}: {
+  children: ReactNode
+  /**
+   * Seed the opening lens from the URL (`?lens=<id>`). #3996 follow-up:
+   * the reconciliation deep-link opens the surface on the Reconciliation
+   * lens. Honoured only for the initial mount — operator chip/lens
+   * interactions own the state thereafter.
+   */
+  initialLensId?: LensId
+}) {
+  const value = useCloudLensState(initialLensId)
   return <CloudLensContext.Provider value={value}>{children}</CloudLensContext.Provider>
 }
 


### PR DESCRIPTION
Ships the recon train the founder is staring at on the live hw173 console — three things together so the console shows all of them at once.

## What lands

1. **Reconciler-management recon surface (#3996)** — the lightweight ArgoCD/Flux-style drill on the Cloud Reconciliation lens: per-reconciler list with live status + last-reconcile + revision, a drill-in detail tab with logs and reconcile / suspend / resume actions. Reads reconcilers LIVE from the cluster (independent of the jobs store).

2. **/jobs = FINITE work only.** `catalyst-api` `ListJobs` now passes its store output through `jobs.FilterFiniteJobs`, which drops the CONTINUOUS reconcilers (Flux HelmRelease installs `KindInstall`, Flux Kustomization reconciles `KindReconcile`, long-running reconciler Deployments `KindReconciler`) and prunes any group left empty. Genuinely finite work still renders: provision/cutover steps `KindStep`, batch Jobs `KindTask`, CronJob runs `KindCron`, one-shot Day-2 mutations `KindMutation`, lifecycle leaves. The continuous reconcilers now live ONLY on the recon lens / surface above (the store keeps the full set — only the `/jobs` view is narrowed; `GetJob` stays unfiltered so deep-links resolve).

3. **Reconciliation deep-link → recon LENS.** `ConvergenceWizard` reconciliation link now targets `/provision/$id/cloud?view=graph&lens=reconciliation`. The cloud route's `CloudSearch` type + both `validateSearch` fns carry a closed-set-validated `lens` param (guarded against `LENSES`); `CloudPage` threads it into `CloudLensProvider` as `initialLensId`; `useCloudLensState` seeds the opening chip-set from it so the surface opens on the **Reconciliation** lens, not the default Cloud lens. Operator chip/lens interaction still wins after.

Also corrects a stale `ResourceDetailPage` tab-strip assertion left by #3996 (`exec` is Pod-only #2626, `reconcile` is Flux-only #3996 — neither shows on a Service).

## Gates

- BE: `go build` / `go vet` / `go test` green — new `internal/jobs/filter_test.go` + updated handler `TestHandler_ListJobs_Populated`.
- FE: `tsc -b` + `npm run build` green; new `useCloudLens.test.tsx` (lens seeding) + strengthened `ConvergenceWizard` link test (asserts `lens=reconciliation` survives the route validator) pass.
- Net FE test delta vs the #3996 base: **-1 failing file** (fixed the stale ResourceDetailPage tab test), **zero new failures**. Remaining pre-existing failures are unrelated environmental suites.

Refs #3996 #3999

🤖 Generated with [Claude Code](https://claude.com/claude-code)