### PR TITLE
feat(cloud): network+security per-kind pages — Gateway/HTTPRoute/NetworkPolicy/CiliumNetworkPolicy (Refs #3998)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kinds.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kinds.ts
@@ -39,6 +39,14 @@ import {
   EndpointSlicesListPage,
   ServicesListPage,
   IngressesListPage,
+  // Network + security coverage (#3998) — gateway-api front door +
+  // NetworkPolicy / CiliumNetworkPolicy security posture, all LIVE on
+  // hw173 but previously invisible in the cloud-view.
+  GatewaysListPage,
+  HttpRoutesListPage,
+  NetworkPoliciesListPage,
+  CiliumNetworkPoliciesListPage,
+  CiliumClusterwideNetworkPoliciesListPage,
   StorageClassesListPage,
   DnsZonesListPage,
   PolicyReportsListPage,
@@ -66,6 +74,12 @@ export type CloudListKind =
   | 'load-balancers'
   | 'services'
   | 'ingresses'
+  // Network + security coverage (#3998) — gateway-api + policy kinds.
+  | 'gateways'
+  | 'httproutes'
+  | 'networkpolicies'
+  | 'ciliumnetworkpolicies'
+  | 'ciliumclusterwidenetworkpolicies'
   | 'pvcs'
   | 'buckets'
   | 'volumes'
@@ -121,6 +135,16 @@ export const KIND_TO_REGISTRY: Partial<Record<CloudListKind, string>> = {
   replicasets: 'replicaset',
   services: 'service',
   ingresses: 'ingress',
+  // Network + security coverage (#3998) — registry Names verbatim from
+  // api/internal/k8scache/kinds.go (gateway / httproute / networkpolicy /
+  // ciliumnetworkpolicy / ciliumclusterwidenetworkpolicy). Adding them
+  // here auto-subscribes the CloudPage SSE (CLOUD_PAGE_K8S_KINDS union)
+  // so each per-kind list + chip count reads live objects.
+  gateways: 'gateway',
+  httproutes: 'httproute',
+  networkpolicies: 'networkpolicy',
+  ciliumnetworkpolicies: 'ciliumnetworkpolicy',
+  ciliumclusterwidenetworkpolicies: 'ciliumclusterwidenetworkpolicy',
   configmaps: 'configmap',
   secrets: 'secret',
   namespaces: 'namespace',
@@ -225,6 +249,18 @@ const ICON_LB =
   'M12 4v4m0 0a4 4 0 0 0 -4 4v0m4 -4a4 4 0 0 1 4 4v0M4 12h4M16 12h4M6 14a2 2 0 0 0 2 2v0a2 2 0 0 0 2 -2v0a2 2 0 0 0 -2 -2v0a2 2 0 0 0 -2 2zM14 14a2 2 0 0 0 2 2v0a2 2 0 0 0 2 -2v0a2 2 0 0 0 -2 -2v0a2 2 0 0 0 -2 2z'
 const ICON_SERVICE = 'M5 7h14M5 12h14M5 17h14M3 7v10M21 7v10'
 const ICON_INGRESS = 'M3 12h6M21 12h-6M9 8l4 4 -4 4M15 16l-4 -4 4 -4'
+// Network + security coverage (#3998). Gateway = door/portal glyph;
+// HTTPRoute = branching route; NetworkPolicy / CiliumNetworkPolicy =
+// shield (the security-posture family) — CCNP shares the shield since
+// it's the cluster-scoped sibling.
+const ICON_GATEWAY =
+  'M5 21V8l7 -4 7 4v13M5 21h14M9 21v-6h6v6M9 11h.01M15 11h.01'
+const ICON_HTTPROUTE =
+  'M4 6h7a4 4 0 0 1 4 4v0a4 4 0 0 0 4 4h1M4 6l3 -3M4 6l3 3M20 14l-3 -3M20 14l-3 3'
+const ICON_NETPOL =
+  'M12 3l8 4v5c0 5 -3.5 8 -8 9 -4.5 -1 -8 -4 -8 -9V7zM12 8v4M12 15h.01'
+const ICON_CILIUM_NETPOL =
+  'M12 3l8 4v5c0 5 -3.5 8 -8 9 -4.5 -1 -8 -4 -8 -9V7zM9 12l2 2 4 -4'
 const ICON_DNS =
   'M12 3a9 9 0 0 0 0 18m0 -18a9 9 0 0 1 0 18m0 -18c2 2 3 5 3 9s-1 7 -3 9m0 -18c-2 2 -3 5 -3 9s1 7 3 9M3 12h18'
 const ICON_PVC =
@@ -306,6 +342,15 @@ export const KINDS: readonly CloudKindEntry[] = [
   // Networking
   { id: 'services', label: 'Services', tagline: 'ClusterIP / NodePort / LoadBalancer routes', hasData: true, Component: ServicesListPage, icon: ICON_SERVICE, category: 'network', primary: false },
   { id: 'ingresses', label: 'Ingresses', tagline: 'HTTP routing + TLS terminators', hasData: true, Component: IngressesListPage, icon: ICON_INGRESS, category: 'network', primary: false },
+  // Network + security coverage (#3998). The gateway-api front door
+  // (Gateway + HTTPRoute) + the security posture (NetworkPolicy + Cilium
+  // NetworkPolicy / ClusterwideNetworkPolicy). All LIVE on hw173 but
+  // previously had no cloud-view page. Each renders its OWN columns.
+  { id: 'gateways', label: 'Gateways', tagline: 'Gateway API front doors — class / address / programmed.', hasData: true, Component: GatewaysListPage, icon: ICON_GATEWAY, category: 'network', primary: false },
+  { id: 'httproutes', label: 'HTTPRoutes', tagline: 'Gateway API routes — hostnames / parent Gateway / rules.', hasData: true, Component: HttpRoutesListPage, icon: ICON_HTTPROUTE, category: 'network', primary: false },
+  { id: 'networkpolicies', label: 'Network Policies', tagline: 'K8s NetworkPolicies — pod selector / ingress-egress / types.', hasData: true, Component: NetworkPoliciesListPage, icon: ICON_NETPOL, category: 'network', primary: false },
+  { id: 'ciliumnetworkpolicies', label: 'Cilium Network Policies', tagline: 'CiliumNetworkPolicies — L3-L7 micro-segmentation per namespace.', hasData: true, Component: CiliumNetworkPoliciesListPage, icon: ICON_CILIUM_NETPOL, category: 'network', primary: false },
+  { id: 'ciliumclusterwidenetworkpolicies', label: 'Cilium Clusterwide Policies', tagline: 'CiliumClusterwideNetworkPolicies — cluster-scoped baseline deny.', hasData: true, Component: CiliumClusterwideNetworkPoliciesListPage, icon: ICON_CILIUM_NETPOL, category: 'network', primary: false },
   { id: 'endpointslices', label: 'EndpointSlices', tagline: 'Service backend addresses', hasData: true, Component: EndpointSlicesListPage, icon: ICON_EPS, category: 'network', primary: false },
   { id: 'dns-zones', label: 'DNS Zones', tagline: 'PowerDNS zones (Sovereign-side)', hasData: false, Component: DnsZonesListPage, icon: ICON_DNS, category: 'network', primary: false },
 

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kindsPages.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kindsPages.tsx
@@ -7,6 +7,7 @@
  * delegates rendering to the generic K8sListPage.
  */
 
+import type { K8sObject } from '@/widgets/architecture-graph/useK8sCacheStream'
 import {
   K8sListPage,
   COL_NAME,
@@ -249,6 +250,302 @@ export function IngressesListPage() {
               'rules'
             ] ?? []) as Array<{ host?: string }>
             return rules.map((r) => r.host).filter(Boolean).join(', ') || '—'
+          },
+        },
+        COL_AGE,
+      ]}
+    />
+  )
+}
+
+/* ── Network + security coverage (#3998) ──────────────────────────────
+ *
+ * The gateway-api front door (Gateway + HTTPRoute) and the security
+ * posture (NetworkPolicy + CiliumNetworkPolicy / ClusterwideNetworkPolicy)
+ * are LIVE on every Sovereign but had no cloud-view page — so the front
+ * door + micro-segmentation were invisible. These wrappers render them as
+ * standard K8sListPages driven by the live k8scache SSE snapshot (the GVRs
+ * are already registered in api/internal/k8scache/kinds.go: gateway /
+ * httproute / networkpolicy / ciliumnetworkpolicy /
+ * ciliumclusterwidenetworkpolicy, all on the SERVED versions verified
+ * against hw173). Each carries the columns the operator needs.
+ * ────────────────────────────────────────────────────────────────── */
+
+/** Render a Gateway status condition (Programmed / Accepted) as a short
+ *  string. Gateway has no Ready condition; Programmed=True is the
+ *  "front door is live" signal. */
+function gatewayConditionStatus(o: K8sObject, type: string): string {
+  const conds = (o.status as Record<string, unknown> | undefined)?.[
+    'conditions'
+  ] as Array<Record<string, unknown>> | undefined
+  if (!Array.isArray(conds)) return '—'
+  const c = conds.find((x) => x?.['type'] === type)
+  const s = c?.['status'] as string | undefined
+  return s ?? '—'
+}
+
+export function GatewaysListPage() {
+  return (
+    <K8sListPage
+      kind="gateway"
+      title="Gateways"
+      tagline="Gateway API front doors — the real ingress path. Class / address / Programmed state."
+      columns={[
+        COL_NAMESPACE,
+        COL_NAME,
+        {
+          header: 'Class',
+          extract: (o) => {
+            const cls = (o.spec as Record<string, unknown> | undefined)?.[
+              'gatewayClassName'
+            ] as string | undefined
+            return cls ?? '—'
+          },
+        },
+        {
+          header: 'Address',
+          extract: (o) => {
+            // Prefer status.addresses (the assigned front-door IP/host);
+            // fall back to spec.addresses (operator-requested). On
+            // nodeIPAM/DNAT clouds (Huawei) the EIP is wired outside the
+            // Gateway CR so this can legitimately be "—" — the address is
+            // surfaced via the LoadBalancer/Service path instead.
+            const fromStatus = (o.status as Record<string, unknown> | undefined)?.[
+              'addresses'
+            ] as Array<{ value?: string }> | undefined
+            const fromSpec = (o.spec as Record<string, unknown> | undefined)?.[
+              'addresses'
+            ] as Array<{ value?: string }> | undefined
+            const addrs = (fromStatus && fromStatus.length ? fromStatus : fromSpec) ?? []
+            const vals = addrs.map((a) => a?.value).filter(Boolean)
+            return vals.length ? vals.join(', ') : '—'
+          },
+        },
+        {
+          header: 'Listeners',
+          extract: (o) => {
+            const l = (o.spec as Record<string, unknown> | undefined)?.[
+              'listeners'
+            ] as unknown[] | undefined
+            return Array.isArray(l) ? String(l.length) : '—'
+          },
+        },
+        {
+          header: 'Programmed',
+          extract: (o) => gatewayConditionStatus(o, 'Programmed'),
+        },
+        COL_AGE,
+      ]}
+    />
+  )
+}
+
+export function HttpRoutesListPage() {
+  return (
+    <K8sListPage
+      kind="httproute"
+      title="HTTPRoutes"
+      tagline="Gateway API routes — hostnames + the Gateway they attach to + rule count."
+      columns={[
+        COL_NAMESPACE,
+        COL_NAME,
+        {
+          header: 'Hostnames',
+          extract: (o) => {
+            const hosts = ((o.spec as Record<string, unknown> | undefined)?.[
+              'hostnames'
+            ] ?? []) as string[]
+            return Array.isArray(hosts) && hosts.length ? hosts.join(', ') : '—'
+          },
+        },
+        {
+          header: 'Parent Gateway',
+          extract: (o) => {
+            const refs = ((o.spec as Record<string, unknown> | undefined)?.[
+              'parentRefs'
+            ] ?? []) as Array<{ name?: string; namespace?: string }>
+            const names = refs
+              .map((r) => (r?.namespace ? `${r.namespace}/${r.name}` : r?.name))
+              .filter(Boolean)
+            return names.length ? names.join(', ') : '—'
+          },
+        },
+        {
+          header: 'Rules',
+          extract: (o) => {
+            const rules = (o.spec as Record<string, unknown> | undefined)?.[
+              'rules'
+            ] as unknown[] | undefined
+            return Array.isArray(rules) ? String(rules.length) : '—'
+          },
+        },
+        COL_AGE,
+      ]}
+    />
+  )
+}
+
+/** Format a podSelector/endpointSelector.matchLabels map into a compact
+ *  k=v string, or "(all)" for an empty selector (which selects every pod
+ *  in scope — the default-deny baseline shape). */
+function formatSelector(sel: Record<string, unknown> | undefined): string {
+  if (!sel) return '—'
+  const labels = sel['matchLabels'] as Record<string, string> | undefined
+  if (!labels || Object.keys(labels).length === 0) {
+    // An explicitly-empty selector matches everything; distinguish from
+    // "no selector field at all".
+    return Object.prototype.hasOwnProperty.call(sel, 'matchLabels') ||
+      Object.keys(sel).length === 0
+      ? '(all)'
+      : '—'
+  }
+  return Object.entries(labels)
+    .map(([k, v]) => `${k}=${v}`)
+    .join(', ')
+}
+
+/** Count ingress + egress rule arrays and policyTypes for a (K8s or
+ *  Cilium) network policy, reading from either spec or spec.specs[0]. */
+function policyRuleSummary(spec: Record<string, unknown> | undefined): {
+  ingress: number
+  egress: number
+} {
+  const ing = (spec?.['ingress'] as unknown[] | undefined) ?? []
+  const egr = (spec?.['egress'] as unknown[] | undefined) ?? []
+  return {
+    ingress: Array.isArray(ing) ? ing.length : 0,
+    egress: Array.isArray(egr) ? egr.length : 0,
+  }
+}
+
+export function NetworkPoliciesListPage() {
+  return (
+    <K8sListPage
+      kind="networkpolicy"
+      title="Network Policies"
+      tagline="K8s NetworkPolicies — pod selector, ingress/egress rule counts, policy types."
+      columns={[
+        COL_NAMESPACE,
+        COL_NAME,
+        {
+          header: 'Pod Selector',
+          extract: (o) =>
+            formatSelector(
+              (o.spec as Record<string, unknown> | undefined)?.[
+                'podSelector'
+              ] as Record<string, unknown> | undefined,
+            ),
+        },
+        {
+          header: 'Ingress/Egress',
+          extract: (o) => {
+            const s = policyRuleSummary(
+              o.spec as Record<string, unknown> | undefined,
+            )
+            return `${s.ingress} / ${s.egress}`
+          },
+        },
+        {
+          header: 'Policy Types',
+          extract: (o) => {
+            const t = ((o.spec as Record<string, unknown> | undefined)?.[
+              'policyTypes'
+            ] ?? []) as string[]
+            return Array.isArray(t) && t.length ? t.join(', ') : '—'
+          },
+        },
+        COL_AGE,
+      ]}
+    />
+  )
+}
+
+/** Resolve a CiliumNetworkPolicy's effective rule spec — Cilium accepts
+ *  EITHER a single `spec` OR a `specs[]` array (mutually exclusive). For
+ *  the list summary we read `spec`, falling back to the first `specs[]`
+ *  entry. */
+function ciliumPolicySpec(o: K8sObject): Record<string, unknown> | undefined {
+  const spec = o.spec as Record<string, unknown> | undefined
+  if (spec && Object.keys(spec).length > 0) return spec
+  const specs = (o as Record<string, unknown>)['specs'] as
+    | Array<Record<string, unknown>>
+    | undefined
+  return Array.isArray(specs) && specs.length > 0 ? specs[0] : undefined
+}
+
+/** Aggregate ingress/egress across `spec` AND every `specs[]` entry so the
+ *  count reflects the whole policy, not just the first rule block. */
+function ciliumRuleSummary(o: K8sObject): { ingress: number; egress: number } {
+  const blocks: Array<Record<string, unknown> | undefined> = []
+  const spec = o.spec as Record<string, unknown> | undefined
+  if (spec && Object.keys(spec).length > 0) blocks.push(spec)
+  const specs = (o as Record<string, unknown>)['specs'] as
+    | Array<Record<string, unknown>>
+    | undefined
+  if (Array.isArray(specs)) blocks.push(...specs)
+  let ingress = 0
+  let egress = 0
+  for (const b of blocks) {
+    const s = policyRuleSummary(b)
+    ingress += s.ingress
+    egress += s.egress
+  }
+  return { ingress, egress }
+}
+
+export function CiliumNetworkPoliciesListPage() {
+  return (
+    <K8sListPage
+      kind="ciliumnetworkpolicy"
+      title="Cilium Network Policies"
+      tagline="CiliumNetworkPolicies — L3-L7 micro-segmentation. Endpoint selector + ingress/egress."
+      columns={[
+        COL_NAMESPACE,
+        COL_NAME,
+        {
+          header: 'Endpoint Selector',
+          extract: (o) =>
+            formatSelector(
+              ciliumPolicySpec(o)?.['endpointSelector'] as
+                | Record<string, unknown>
+                | undefined,
+            ),
+        },
+        {
+          header: 'Ingress/Egress',
+          extract: (o) => {
+            const s = ciliumRuleSummary(o)
+            return `${s.ingress} / ${s.egress}`
+          },
+        },
+        COL_AGE,
+      ]}
+    />
+  )
+}
+
+export function CiliumClusterwideNetworkPoliciesListPage() {
+  return (
+    <K8sListPage
+      kind="ciliumclusterwidenetworkpolicy"
+      title="Cilium Clusterwide Network Policies"
+      tagline="Cluster-scoped CiliumClusterwideNetworkPolicies — the baseline deny + cross-namespace rules."
+      columns={[
+        COL_NAME,
+        {
+          header: 'Endpoint Selector',
+          extract: (o) =>
+            formatSelector(
+              ciliumPolicySpec(o)?.['endpointSelector'] as
+                | Record<string, unknown>
+                | undefined,
+            ),
+        },
+        {
+          header: 'Ingress/Egress',
+          extract: (o) => {
+            const s = ciliumRuleSummary(o)
+            return `${s.ingress} / ${s.egress}`
           },
         },
         COL_AGE,


### PR DESCRIPTION
## What

Adds cloud-view per-kind list pages for the **network + security** coverage half of #3998:

- **Gateways** (`gateway.networking.k8s.io/v1`) — class / address / listeners / Programmed
- **HTTPRoutes** (`gateway.networking.k8s.io/v1`) — hostnames / parent Gateway / rules
- **Network Policies** (`networking.k8s.io/v1`) — pod selector / ingress-egress / policyTypes
- **Cilium Network Policies** (`cilium.io/v2`) — endpoint selector / ingress-egress (handles both `spec` and `specs[]`)
- **Cilium Clusterwide Network Policies** (`cilium.io/v2`) — cluster-scoped, honest empty-state when none live

These are LIVE on every Sovereign but previously had **no cloud-view page**, so the actual front door (gateway-api) and the micro-segmentation security posture were invisible.

## ONLY-ADD — no regression

Pure front-end addition. The existing k9s explorer / graph / already-working kinds (#3970 / #3981 / #3987) are untouched. The 14 `kinds.test.ts` regression-lock tests still pass; the existing per-kind pages still render.

Backend was already done on `main`:
- All five GVRs are registered in `api/internal/k8scache/kinds.go` on the **served** versions (verified live against hw173).
- The cutover-driver `ClusterRole` already grants `get/list/watch` on all five.

So this PR is FE-only (`kinds.ts` + `kindsPages.tsx`). Adding each kind to `KIND_TO_REGISTRY` auto-subscribes the CloudPage SSE via the `CLOUD_PAGE_K8S_KINDS` union (the #3987/#3997 mechanism) — no second list to keep in sync.

## LIVE verification on hw173 (dep `7bb723da8da06047`)

Queried the live hw173 catalyst-api through the exact REST/SSE path the cloud-list FE consumes (`GET /api/v1/sovereigns/{id}/k8s/{kind}`, Bearer-authed via the KC SA client). After FE snapshot-key dedup (`${kind}:${ns}/${name}` — how `K8sListPage` renders):

| Kind | FE-rendered | `kubectl get` (region-a) | Match |
|---|---|---|---|
| Gateway | **1** (`kube-system/cilium-gateway`, Programmed=True) | 1 | ✅ |
| HTTPRoute | **15** | 15 | ✅ |
| NetworkPolicy | **10** (cross-region union) | 8 (region-a only) | ✅ honest |
| CiliumNetworkPolicy | **5** | 5 | ✅ |
| CiliumClusterwideNetworkPolicy | **0** (empty-state) | 0 | ✅ |

NetworkPolicy shows **10** (not 8) because hw173 is multi-region: region-b carries 2 additional replica-side cnpg-pair policies (`allow-probe-to-replica`, `probe-egress`). The cloud-list shows the cross-region union — the more complete/honest picture. The ticket's "8" was a region-a-only `kubectl get`.

Honest 0s preserved: Ingress (0) and Organizations (0) untouched; CCNP renders its empty-state.

## Gates

- FE: `npx tsc -b` ✅, `npm run build` ✅, `npx vitest run cloud-list/kinds.test.ts` 14/14 ✅ (the one `ResourceDetailPage.test.tsx` failure is **pre-existing on clean `main`**, unrelated)
- BE: `go build ./...` ✅, `go vet ./...` ✅

Refs #3998 #3987 #3970