### PR TITLE
feat(openova-mcp): first slice — RBAC-scoped thin-facade MCP server + real read-only Org-scoped tools (Refs #3988)

### DIFF
--- a/products/openova-mcp/README.md
+++ b/products/openova-mcp/README.md
@@ -1,0 +1,92 @@
+# openova-mcp — OpenOva MCP server (#3988, first vertical slice)
+
+The **OpenOva MCP server** exposes the OpenOva product surface as MCP tools
+whose surface is **RBAC-scoped per user**, so the tool set an agent sees is
+**identical to what that user can do in the Catalyst console UI**. It is a
+**thin facade**: it reimplements nothing — every data tool forwards the
+caller's bearer to the **live catalyst-api**, so the endpoint's own authz
+is the final word. Identity is the **single source-of-truth claim
+contract** (`core/services/shared/auth.Claims`) — NOT a parallel auth
+system.
+
+This module is the **first concrete, live-testable slice** of the EPIC. It
+ships:
+
+1. **The MCP server core** (`cmd/openova-mcp`) — JSON-RPC 2.0 over stdio,
+   the same proven transport the sandbox MCP uses.
+2. **Per-relevant-Keycloak identity resolution** (`internal/identity`) —
+   parses the bearer into `auth.Claims`, derives the realm **context**
+   (Organization vs Sovereign), the **tier** (viewer<developer<operator<
+   admin<owner<sovereign-admin), and the pinned **Org scope**.
+3. **Two-layer RBAC** (`internal/tools`):
+   - **Layer 1** — `tools/list` is filtered by `(context, tier)` so the
+     agent's surface == the user's UI surface.
+   - **Layer 2** — `tools/call` re-authorizes against the **same** identity,
+     so a hand-crafted call to a filtered-out tool is still denied.
+4. **Real, read-only, Org-scoped tools** backed by the live catalyst-api
+   (`internal/catalystapi`):
+   - `whoami` — the resolved identity the server sees (mirrors `/auth/me`).
+   - `list_organizations` — `GET /api/v1/organizations`, Org-scoped.
+   - `list_applications` — `GET /api/v1/sovereigns/{id}/applications`,
+     Org-scoped (a user with rights only to Org X sees only Org X's apps).
+   - `get_application` — `GET /api/v1/sovereigns/{id}/applications/{name}`,
+     with a cross-Org defense-in-depth scope check.
+   - `list_environments` — derived from the caller's Applications (Catalyst
+     has no standalone list-environments REST endpoint; the console derives
+     env partitions the same way, so the facade does too).
+
+## How the thin-facade + RBAC parity holds
+
+- The server holds **no privileged token**. Every backing call forwards the
+  caller's compact JWT verbatim as `Authorization: Bearer …` (and as the
+  `catalyst_session` cookie), so the catalyst-api `RequireSession` +
+  per-handler tier check is the final word. When the endpoint returns 403,
+  the MCP surfaces the **same** upstream status (parity).
+- Org scoping is enforced twice: the endpoint scopes by the caller's
+  session, and the facade additionally filters Application items to the
+  caller's Org namespace (`<org>` / `<org>-<env_type>`), so a cross-Org
+  leak cannot pass through even if the endpoint widened.
+
+## Env contract (`cmd/openova-mcp`)
+
+| Env var | Purpose |
+|---|---|
+| `OPENOVA_MCP_CATALYST_API_URL` | base URL of the catalyst-api / gateway (required for data tools; `whoami` works without it) |
+| `OPENOVA_MCP_CONTEXT` | `organization` \| `sovereign` — pins the instance context per the topology table (empty = derive per-token) |
+| `OPENOVA_MCP_VERIFY` | `rs256` (default) \| `hs256` \| `insecure` — bearer verification mode |
+| `OPENOVA_MCP_RS256_PUBKEY_PEM` | PEM of the RS256 public key (Sovereign handover-jwt pubkey) when verify=rs256 |
+| `OPENOVA_MCP_HS256_SECRET` | HS256 shared secret when verify=hs256 |
+| `OPENOVA_MCP_BEARER` | fallback bearer when a `tools/call` omits the `_auth.token` argument |
+
+## Live-acceptance (hw173)
+
+Proven on `hw173.omani.works` (dep `7bb723da8da06047`) by running this
+server **inside hw173's catalyst-api pod** pointed at the real
+`localhost:8080`, with bearers signed by hw173's own handover key:
+
+- A sovereign-admin `list_applications` returns the **real** Application CRs
+  unfiltered.
+- An Org token (`org_id=acme`) sees **only** that Org's Applications.
+- An out-of-scope `get_application` for another Org returns **forbidden**.
+
+See the walk evidence on issue #3988.
+
+## Deferred to follow-ups (NOT built in this slice)
+
+Per #3988 §5, the following are explicitly out of this slice and tracked as
+follow-ups:
+
+- **chepherd integration** — the `bp-openova-mcp dependsOn bp-chepherd`
+  Blueprint chart, the `openovaMCP.*` repoint, the `.mcp.json` injection.
+- **HTTP/SSE transport** — this slice uses stdio; the long-lived
+  per-Org/per-Sovereign Service needs streamable-HTTP/SSE + stable DNS.
+- **Per-realm JWKS validation** — this slice verifies against a single
+  RS256/HS256 key; the full per-realm JWKS cache (Org realm vs Sovereign
+  realm) is the production identity path.
+- **Write / mutating tools** — `org.apps.install`, `deployments.*`,
+  `vouchers.*`, `cutover.*`, `placement.*`, `k8s.write.*`, etc.
+- **Sovereign-scoped admin tools** + the full ~26 (Org) / ~70 (Sovereign)
+  tool catalog.
+- **The registry-coverage parity test** — generate the registry from the
+  route table + a CI test that fails when a mutating endpoint has neither a
+  tool nor an explicit `// not-exposed:` annotation.

--- a/products/openova-mcp/cmd/openova-mcp/main.go
+++ b/products/openova-mcp/cmd/openova-mcp/main.go
@@ -1,0 +1,378 @@
+// openova-mcp is the OpenOva MCP server (#3988) — first vertical slice.
+//
+// It exposes the OpenOva product surface (Applications, Environments,
+// Organizations) as MCP tools whose surface is RBAC-scoped per user so the
+// agent's tool set is IDENTICAL to what that user can do in the console
+// UI. It is a THIN facade: every data tool forwards the caller's bearer to
+// the LIVE catalyst-api, so the endpoint's own authz is the final word.
+//
+// Wire model (this slice): JSON-RPC 2.0 over stdio (Content-Length-framed),
+// the same proven transport the sandbox MCP uses. The bearer is supplied
+// per `tools/call` (and `tools/list`) via the `_auth.token` argument OR the
+// OPENOVA_MCP_BEARER env fallback, validated into the shared
+// auth.Claims, and resolved into the (context, tier, scope) identity that
+// drives both RBAC layers. The streamable-HTTP/SSE transport + chepherd
+// injection are DEFERRED to follow-ups (#3988 §4.3, §5).
+//
+// Env contract:
+//
+//	OPENOVA_MCP_CATALYST_API_URL  base URL of the catalyst-api / gateway
+//	                              (e.g. https://console.openova.io). Required
+//	                              for the data tools; whoami works without it.
+//	OPENOVA_MCP_CONTEXT           "organization" | "sovereign" — pins the
+//	                              instance context per the topology table.
+//	                              Empty = derive per-token.
+//	OPENOVA_MCP_VERIFY            "rs256" | "hs256" | "insecure" (default
+//	                              rs256). Selects bearer verification.
+//	OPENOVA_MCP_RS256_PUBKEY_PEM  PEM of the RS256 public key (the
+//	                              Sovereign handover-jwt public key) when
+//	                              verify=rs256.
+//	OPENOVA_MCP_HS256_SECRET      HS256 shared secret when verify=hs256.
+//	OPENOVA_MCP_BEARER            fallback bearer when a call omits _auth.
+package main
+
+import (
+	"bufio"
+	"context"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/textproto"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/openova-io/openova/products/openova-mcp/internal/catalystapi"
+	"github.com/openova-io/openova/products/openova-mcp/internal/identity"
+	"github.com/openova-io/openova/products/openova-mcp/internal/tools"
+)
+
+const (
+	protocolVersion = "2024-11-05"
+	serverName      = "openova-mcp"
+	serverVersion   = "0.1.0-slice1"
+)
+
+// JSON-RPC 2.0 envelopes.
+
+type rpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  any             `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
+}
+
+func main() {
+	log.SetOutput(os.Stderr)
+	log.SetFlags(log.LstdFlags | log.Lmicroseconds | log.LUTC)
+	log.Printf("%s %s starting (protocol %s)", serverName, serverVersion, protocolVersion)
+
+	resolver, err := buildResolver()
+	if err != nil {
+		log.Fatalf("resolver: %v", err)
+	}
+	apiURL := os.Getenv("OPENOVA_MCP_CATALYST_API_URL")
+	var api *catalystapi.Client
+	if apiURL != "" {
+		api = catalystapi.New(apiURL)
+	}
+	reg := tools.NewRegistry(api)
+	srv := &server{reg: reg, resolver: resolver, fallbackBearer: os.Getenv("OPENOVA_MCP_BEARER"), out: os.Stdout}
+	log.Printf("env: catalyst_api=%q context_pin=%q verify=%q bearer_fallback=%v",
+		apiURL, os.Getenv("OPENOVA_MCP_CONTEXT"), verifyMode(), os.Getenv("OPENOVA_MCP_BEARER") != "")
+
+	in := bufio.NewReader(os.Stdin)
+	for {
+		msg, err := readFrame(in)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				log.Printf("stdin EOF — exiting")
+				return
+			}
+			log.Printf("read frame: %v", err)
+			return
+		}
+		if err := srv.dispatch(msg); err != nil {
+			log.Printf("dispatch: %v", err)
+		}
+	}
+}
+
+// server handles a single MCP peer over stdio.
+type server struct {
+	reg            *tools.Registry
+	resolver       *identity.Resolver
+	fallbackBearer string
+	out            io.Writer
+}
+
+func (s *server) dispatch(raw []byte) error {
+	var req rpcRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		return s.writeError(nil, -32700, "parse error", err.Error())
+	}
+	switch req.Method {
+	case "initialize":
+		return s.handleInitialize(req)
+	case "tools/list":
+		return s.handleToolsList(req)
+	case "tools/call":
+		return s.handleToolsCall(req)
+	case "ping":
+		return s.writeResult(req.ID, map[string]any{"pong": true})
+	case "notifications/initialized", "notifications/cancelled":
+		return nil
+	default:
+		return s.writeError(req.ID, -32601, "method not found", req.Method)
+	}
+}
+
+func (s *server) handleInitialize(req rpcRequest) error {
+	return s.writeResult(req.ID, map[string]any{
+		"protocolVersion": protocolVersion,
+		"serverInfo":      map[string]any{"name": serverName, "version": serverVersion},
+		"capabilities":    map[string]any{"tools": map[string]any{"listChanged": false}},
+	})
+}
+
+// handleToolsList resolves the caller and returns ONLY the tools visible
+// to their (context, tier) — layer-1 RBAC. The bearer is read from the
+// `_meta._auth.token` param OR the env fallback. An unauthenticated
+// tools/list returns an empty surface (a caller with no identity sees
+// nothing).
+func (s *server) handleToolsList(req rpcRequest) error {
+	id, _ := s.resolveFromParams(req.Params)
+	return s.writeResult(req.ID, map[string]any{"tools": s.reg.List(id)})
+}
+
+func (s *server) handleToolsCall(req rpcRequest) error {
+	var params struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return s.writeError(req.ID, -32602, "invalid params", err.Error())
+	}
+
+	id, err := s.resolveBearer(extractBearer(s.fallbackBearer, params.Arguments))
+	if err != nil {
+		return s.writeError(req.ID, -32001, "unauthenticated", err.Error())
+	}
+	args := stripAuthEnvelope(params.Arguments)
+
+	result, callErr := s.reg.Call(context.Background(), id, params.Name, args)
+	if callErr != nil {
+		return s.toolError(req.ID, callErr)
+	}
+	body, _ := json.Marshal(result)
+	return s.writeResult(req.ID, map[string]any{
+		"content": []map[string]any{{"type": "text", "text": string(body)}},
+		"isError": false,
+	})
+}
+
+// toolError maps a Call error to the right MCP error code so the parity
+// semantics hold: a forbidden tool returns a distinct code carrying the
+// 403-equivalent, an upstream catalyst-api status is surfaced verbatim.
+func (s *server) toolError(id json.RawMessage, err error) error {
+	switch {
+	case errors.Is(err, tools.ErrForbidden):
+		return s.writeError(id, -32003, "forbidden", map[string]any{"status": 403, "detail": err.Error()})
+	case errors.Is(err, tools.ErrUnknownTool):
+		return s.writeError(id, -32601, "unknown tool", err.Error())
+	default:
+		var apiErr *catalystapi.APIError
+		if errors.As(err, &apiErr) {
+			return s.writeError(id, -32010, "upstream error",
+				map[string]any{"status": apiErr.Status, "body": apiErr.Body})
+		}
+		return s.writeError(id, -32000, "tool error", err.Error())
+	}
+}
+
+// resolveFromParams pulls a bearer out of a generic params blob (the
+// `_meta._auth.token` or `_auth.token` side-channel) for tools/list.
+func (s *server) resolveFromParams(params json.RawMessage) (*identity.Identity, error) {
+	return s.resolveBearer(extractBearer(s.fallbackBearer, params))
+}
+
+func (s *server) resolveBearer(bearer string) (*identity.Identity, error) {
+	if bearer == "" {
+		return nil, errors.New("no bearer (set _auth.token in arguments or OPENOVA_MCP_BEARER)")
+	}
+	return s.resolver.Resolve(bearer)
+}
+
+// ── bearer plumbing (mirrors the sandbox MCP _auth envelope) ─────────────
+
+func extractBearer(fallback string, rawArgs json.RawMessage) string {
+	if len(rawArgs) > 0 {
+		// Accept both top-level `_auth.token` and `_meta._auth.token`.
+		var env struct {
+			Auth struct {
+				Token string `json:"token"`
+			} `json:"_auth"`
+			Meta struct {
+				Auth struct {
+					Token string `json:"token"`
+				} `json:"_auth"`
+			} `json:"_meta"`
+		}
+		if err := json.Unmarshal(rawArgs, &env); err == nil {
+			if env.Auth.Token != "" {
+				return env.Auth.Token
+			}
+			if env.Meta.Auth.Token != "" {
+				return env.Meta.Auth.Token
+			}
+		}
+	}
+	return fallback
+}
+
+func stripAuthEnvelope(rawArgs json.RawMessage) json.RawMessage {
+	if len(rawArgs) == 0 {
+		return rawArgs
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(rawArgs, &m); err != nil {
+		return rawArgs
+	}
+	if _, ok := m["_auth"]; !ok {
+		return rawArgs
+	}
+	delete(m, "_auth")
+	out, err := json.Marshal(m)
+	if err != nil {
+		return rawArgs
+	}
+	return out
+}
+
+// ── resolver construction ────────────────────────────────────────────────
+
+func verifyMode() string {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv("OPENOVA_MCP_VERIFY")))
+	if v == "" {
+		return "rs256"
+	}
+	return v
+}
+
+func contextPin() identity.Context {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("OPENOVA_MCP_CONTEXT"))) {
+	case "organization", "org":
+		return identity.ContextOrganization
+	case "sovereign":
+		return identity.ContextSovereign
+	default:
+		return ""
+	}
+}
+
+func buildResolver() (*identity.Resolver, error) {
+	pin := contextPin()
+	switch verifyMode() {
+	case "rs256":
+		pemStr := os.Getenv("OPENOVA_MCP_RS256_PUBKEY_PEM")
+		if pemStr == "" {
+			return nil, errors.New("verify=rs256 requires OPENOVA_MCP_RS256_PUBKEY_PEM")
+		}
+		pub, err := parseRSAPublicKeyPEM(pemStr)
+		if err != nil {
+			return nil, err
+		}
+		return identity.NewRS256Resolver(pub, pin), nil
+	case "hs256":
+		secret := os.Getenv("OPENOVA_MCP_HS256_SECRET")
+		if secret == "" {
+			return nil, errors.New("verify=hs256 requires OPENOVA_MCP_HS256_SECRET")
+		}
+		return identity.NewHS256Resolver([]byte(secret), pin), nil
+	case "insecure":
+		log.Printf("WARNING: verify=insecure — signatures NOT verified (test/trusted-transport only)")
+		return identity.NewInsecureResolver(pin), nil
+	default:
+		return nil, fmt.Errorf("unknown OPENOVA_MCP_VERIFY=%q", verifyMode())
+	}
+}
+
+func parseRSAPublicKeyPEM(pemStr string) (*rsa.PublicKey, error) {
+	block, _ := pem.Decode([]byte(pemStr))
+	if block == nil {
+		return nil, errors.New("RS256 pubkey: no PEM block found")
+	}
+	if key, err := x509.ParsePKIXPublicKey(block.Bytes); err == nil {
+		if rk, ok := key.(*rsa.PublicKey); ok {
+			return rk, nil
+		}
+		return nil, errors.New("RS256 pubkey: PKIX key is not RSA")
+	}
+	// Fall back to PKCS1.
+	rk, err := x509.ParsePKCS1PublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("RS256 pubkey: parse: %w", err)
+	}
+	return rk, nil
+}
+
+// ── framing (identical to the proven sandbox MCP transport) ──────────────
+
+func (s *server) writeResult(id json.RawMessage, result any) error {
+	return s.writeFrame(rpcResponse{JSONRPC: "2.0", ID: id, Result: result})
+}
+
+func (s *server) writeError(id json.RawMessage, code int, msg string, data any) error {
+	return s.writeFrame(rpcResponse{JSONRPC: "2.0", ID: id, Error: &rpcError{Code: code, Message: msg, Data: data}})
+}
+
+func (s *server) writeFrame(resp rpcResponse) error {
+	body, err := json.Marshal(resp)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(s.out, "Content-Length: %d\r\n\r\n", len(body)); err != nil {
+		return err
+	}
+	_, err = s.out.Write(body)
+	return err
+}
+
+func readFrame(r *bufio.Reader) ([]byte, error) {
+	tp := textproto.NewReader(r)
+	header, err := tp.ReadMIMEHeader()
+	if err != nil {
+		return nil, err
+	}
+	clStr := header.Get("Content-Length")
+	if clStr == "" {
+		return nil, errors.New("missing Content-Length")
+	}
+	cl, err := strconv.Atoi(clStr)
+	if err != nil {
+		return nil, fmt.Errorf("bad Content-Length: %w", err)
+	}
+	body := make([]byte, cl)
+	if _, err := io.ReadFull(r, body); err != nil {
+		return nil, err
+	}
+	return body, nil
+}

--- a/products/openova-mcp/go.mod
+++ b/products/openova-mcp/go.mod
@@ -1,0 +1,39 @@
+// openova-mcp is the OpenOva MCP server (#3988) — an RBAC-scoped-per-user
+// thin facade that exposes the OpenOva product surface (Applications,
+// Environments, Organizations, …) as MCP tools whose surface is IDENTICAL
+// to what the same user can do in the Catalyst console UI.
+//
+// First vertical slice (this module): the MCP server core + a handful of
+// REAL read-only Org-scoped tools backed by the LIVE catalyst-api. The
+// server is a THIN facade — it reimplements NOTHING. It:
+//
+//   - parses the caller's bearer into the SINGLE source-of-truth claim
+//     contract core/services/shared/auth.Claims (the SAME shape the
+//     console + catalyst-api already use — NOT a parallel auth type),
+//   - derives the caller's realm context (Org realm vs Sovereign realm),
+//     tier, and Org scope from those claims,
+//   - filters tools/list by (tier, scope) so the agent's surface == the
+//     user's UI surface (defense-in-depth layer 1),
+//   - re-authorizes every tools/call against the same claims (layer 2),
+//   - forwards the caller's IDENTITY to the real catalyst-api REST
+//     endpoint for the actual data — holding no god-token of its own.
+//
+// Deferred to follow-ups (NOT in this slice): chepherd injection, the
+// HTTP/SSE transport, write/mutating tools, Sovereign-scoped admin tools,
+// the full ~26/~70 tool catalog, the registry-coverage parity test.
+//
+// We depend on the in-tree shared-auth module via the same `replace`
+// pattern catalyst-bootstrap + the sandbox MCP already use, so the claim
+// contract has exactly one definition repo-wide.
+module github.com/openova-io/openova/products/openova-mcp
+
+go 1.23.0
+
+toolchain go1.23.4
+
+require (
+	github.com/golang-jwt/jwt/v5 v5.2.1
+	github.com/openova-io/openova/core/services/shared v0.0.0
+)
+
+replace github.com/openova-io/openova/core/services/shared => ../../core/services/shared

--- a/products/openova-mcp/go.sum
+++ b/products/openova-mcp/go.sum
@@ -1,0 +1,2 @@
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=

--- a/products/openova-mcp/internal/catalystapi/client.go
+++ b/products/openova-mcp/internal/catalystapi/client.go
@@ -1,0 +1,160 @@
+// Package catalystapi is the thin HTTP client the MCP tool handlers use
+// to reach the LIVE catalyst-api. It is the facade boundary mandated by
+// #3988 §3: the MCP reimplements NOTHING — every tool forwards the
+// caller's bearer to the SAME REST endpoint the console UI calls, so the
+// endpoint's own authz (RequireSession + the per-handler tier check) is
+// the final word. The MCP holds no privileged token of its own.
+//
+// Endpoints used by the first slice (all read-only, from the real
+// catalyst-api route table in
+// products/catalyst/bootstrap/api/cmd/api/main.go):
+//
+//   - GET /api/v1/sovereigns/{id}/applications              (HandleApplicationList)
+//   - GET /api/v1/sovereigns/{id}/applications/{name}       (HandleApplicationGet)
+//   - GET /api/v1/organizations                             (HandleListOrganizations)
+package catalystapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Client wraps an HTTP client + the catalyst-api base URL. The caller's
+// bearer is supplied per-request (forwarded identity), never stored.
+type Client struct {
+	baseURL string
+	http    *http.Client
+}
+
+// New returns a Client targeting baseURL (e.g.
+// `https://console.openova.io` for the mothership route table, or the
+// in-cluster catalyst-api Service URL on a Sovereign). The default 30s
+// timeout bounds a wedged upstream.
+func New(baseURL string) *Client {
+	return &Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		http:    &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// WithHTTPClient overrides the underlying http.Client (used by tests to
+// inject a RoundTripper that serves canned catalyst-api responses).
+func (c *Client) WithHTTPClient(h *http.Client) *Client { c.http = h; return c }
+
+// APIError carries the upstream status + body so the MCP can return the
+// SAME status the UI endpoint returned (the parity requirement — #3988
+// DoD §4). isError-mapping happens in the dispatch layer.
+type APIError struct {
+	Status int
+	Body   string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("catalyst-api: upstream status %d: %s", e.Status, truncate(e.Body, 512))
+}
+
+// get issues an authenticated GET and decodes a 2xx JSON body into out.
+// Non-2xx → *APIError carrying the upstream status (so 403→403 parity
+// holds). bearer is forwarded verbatim as the Authorization header AND as
+// the session cookie, covering both the gateway (Authorization) and the
+// catalyst-api RequireSession (cookie) read paths.
+func (c *Client) get(ctx context.Context, path, bearer string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return fmt.Errorf("catalyst-api: build request: %w", err)
+	}
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+		// catalyst-api RequireSession reads the session cookie; forward
+		// the same bearer there too so the facade works against both the
+		// gateway and the catalyst-api directly.
+		req.Header.Set("Cookie", "catalyst_session="+bearer)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("catalyst-api: %s: %w", path, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return &APIError{Status: resp.StatusCode, Body: string(body)}
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("catalyst-api: decode %s: %w", path, err)
+	}
+	return nil
+}
+
+// ── Wire shapes (mirror the catalyst-api handler responses exactly) ──────
+
+// ApplicationListResponse mirrors applicationListResponse in
+// products/catalyst/bootstrap/api/internal/handler/applications.go.
+type ApplicationListResponse struct {
+	Kind  string            `json:"kind"`
+	Items []ApplicationItem `json:"items"`
+	Total int               `json:"total"`
+}
+
+// ApplicationItem mirrors applicationListItem.
+type ApplicationItem struct {
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Blueprint string `json:"blueprint,omitempty"`
+	Version   string `json:"version,omitempty"`
+	Phase     string `json:"phase,omitempty"`
+}
+
+// OrganizationListResponse mirrors the {items:[…]} envelope from
+// HandleListOrganizations.
+type OrganizationListResponse struct {
+	Items []map[string]any `json:"items"`
+}
+
+// ListApplications calls GET /api/v1/sovereigns/{depID}/applications.
+func (c *Client) ListApplications(ctx context.Context, depID, bearer string) (*ApplicationListResponse, error) {
+	var out ApplicationListResponse
+	if err := c.get(ctx, fmt.Sprintf("/api/v1/sovereigns/%s/applications", depID), bearer, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// GetApplication calls GET /api/v1/sovereigns/{depID}/applications/{name}.
+// The body shape is the full Application object; we return it as a generic
+// map so the MCP surfaces exactly what the UI would render without forcing
+// a brittle struct on a still-evolving CR shape.
+func (c *Client) GetApplication(ctx context.Context, depID, name, bearer string) (map[string]any, error) {
+	var out map[string]any
+	if err := c.get(ctx, fmt.Sprintf("/api/v1/sovereigns/%s/applications/%s", depID, name), bearer, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// ListOrganizations calls GET /api/v1/organizations.
+func (c *Client) ListOrganizations(ctx context.Context, bearer string) (*OrganizationListResponse, error) {
+	var out OrganizationListResponse
+	if err := c.get(ctx, "/api/v1/organizations", bearer, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/products/openova-mcp/internal/identity/identity.go
+++ b/products/openova-mcp/internal/identity/identity.go
@@ -1,0 +1,353 @@
+// Package identity resolves an MCP caller's identity from their bearer
+// token into the SINGLE source-of-truth claim contract
+// (core/services/shared/auth.Claims) and derives the (context, tier,
+// scope) triple every RBAC decision in the MCP server consults.
+//
+// This is the "per-relevant-Keycloak identity resolution" of #3988 §4.2,
+// reduced to the first-slice essentials:
+//
+//   - parse the compact JWT into auth.Claims (the SAME type the console
+//   - catalyst-api parse — asserted by importing it, never redefining),
+//   - choose the realm CONTEXT from the token issuer: an issuer ending in
+//     `/realms/sovereign` (or carrying a sovereign-admin role) is the
+//     Sovereign context; an issuer ending in `/realms/<org-slug>` (or any
+//     token carrying an org_id) is that Organization's context,
+//   - derive the TIER from the highest catalyst-<tier> realm role (or the
+//     precomputed `tier`/legacy `role` claim),
+//   - pin the SCOPE: Org context → the token's OrgID; Sovereign context →
+//     the whole Sovereign.
+//
+// Signature verification (JWKS per realm) is deliberately OUT of this
+// first slice — see VerifyMode. The slice's live-acceptance signs the
+// test bearer with the Sovereign's own handover RS256 key and the caller
+// supplies the matching public key, so the server verifies the signature
+// it can verify and resolves identity from the verified claims. The full
+// per-realm JWKS cache is a documented follow-up (#3988 §4.2).
+package identity
+
+import (
+	"crypto/rsa"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	sharedauth "github.com/openova-io/openova/core/services/shared/auth"
+)
+
+// Context is the realm context an MCP connection runs in. It selects the
+// trusted realm, the pinned scope, and the filtered tool set (#3988 §4.3
+// topology table).
+type Context string
+
+const (
+	// ContextOrganization — the caller authenticated against an
+	// Organization's Keycloak realm. Their data scope is pinned to that
+	// Org's vCluster; the tool surface is the Org subset.
+	ContextOrganization Context = "organization"
+
+	// ContextSovereign — the caller authenticated against the Sovereign
+	// realm as a sovereign-admin. Full Sovereign scope; full tool surface.
+	ContextSovereign Context = "sovereign"
+)
+
+// Tier is the catalog tier the caller holds, lowest→highest. Mirrors the
+// 5-tier ladder the console + catalyst-api use
+// (viewer < developer < operator < admin < owner) plus the distinguished
+// sovereign-admin which sits above owner for cross-Org reach.
+type Tier int
+
+const (
+	TierNone Tier = iota
+	TierViewer
+	TierDeveloper
+	TierOperator
+	TierAdmin
+	TierOwner
+	TierSovereignAdmin
+)
+
+// String renders the canonical tier label.
+func (t Tier) String() string {
+	switch t {
+	case TierViewer:
+		return "viewer"
+	case TierDeveloper:
+		return "developer"
+	case TierOperator:
+		return "operator"
+	case TierAdmin:
+		return "admin"
+	case TierOwner:
+		return "owner"
+	case TierSovereignAdmin:
+		return "sovereign-admin"
+	default:
+		return "none"
+	}
+}
+
+// AtLeast reports whether t is at or above the floor tier.
+func (t Tier) AtLeast(floor Tier) bool { return t >= floor }
+
+// Identity is the resolved caller. Every RBAC decision (tools/list filter
+// + tools/call re-auth) consults this — derived ONCE per call from the
+// validated claims so handlers never re-derive "is this user allowed?".
+type Identity struct {
+	// Claims is the verified, shared-contract claim set. Carried so
+	// handlers + the facade can forward the caller's identity downstream
+	// and so whoami can echo exactly what the server saw.
+	Claims *sharedauth.Claims
+
+	// Context is the realm context (organization | sovereign).
+	Context Context
+
+	// Tier is the highest catalog tier the caller holds.
+	Tier Tier
+
+	// OrgID is the pinned Organization scope in Org context (the slug used
+	// on the Organization CR + as the vCluster scope). Empty in Sovereign
+	// context.
+	OrgID string
+
+	// DeploymentID is the Sovereign deployment the caller's session is
+	// bound to (handover JWT `deployment_id`). Used to address the
+	// catalyst-api `/api/v1/sovereigns/{id}/…` route table.
+	DeploymentID string
+
+	// SovereignFQDN is the Sovereign primary FQDN (handover JWT
+	// `sovereign_fqdn`). Surfaced via whoami.
+	SovereignFQDN string
+
+	// Email is the caller's primary email (echoed by whoami).
+	Email string
+
+	// RawBearer is the compact JWT the caller presented, retained so the
+	// thin-facade tool handlers can forward the caller's IDENTITY verbatim
+	// to the real catalyst-api endpoint (the endpoint's own authz is the
+	// final word). Set by Resolve; never logged.
+	RawBearer string
+}
+
+// VerifyMode selects how the bearer signature is verified for this slice.
+type VerifyMode int
+
+const (
+	// VerifyRS256PublicKey verifies the bearer against a single RS256
+	// public key (the Sovereign's handover-jwt public key). This is the
+	// mode the first-slice live-acceptance uses.
+	VerifyRS256PublicKey VerifyMode = iota
+
+	// VerifyHS256Secret verifies the bearer against a single HS256 shared
+	// secret (the catalyst-api service-token signing key). Mirrors the
+	// sandbox MCP's call-gate so an in-cluster service token is accepted.
+	VerifyHS256Secret
+
+	// VerifyInsecureNoSignature SKIPS signature verification and resolves
+	// identity from the unverified claims. ONLY for unit tests + a
+	// trusted in-cluster transport that already terminated auth upstream.
+	// Production binaries MUST NOT select this.
+	VerifyInsecureNoSignature
+)
+
+// Resolver turns a raw bearer into a resolved Identity. Constructed once
+// at server start with the trusted key/secret + verify mode.
+type Resolver struct {
+	mode      VerifyMode
+	rsaPub    *rsa.PublicKey
+	hmacKey   []byte
+	pinnedCtx Context // when non-empty, forces the connection context (per-Org-MCP vs Sovereign-MCP topology).
+}
+
+// NewRS256Resolver builds a resolver that verifies bearers against the
+// supplied RS256 public key. pinnedCtx (optional) forces the connection
+// context per the #3988 §4.3 topology table — a per-Org MCP instance pins
+// ContextOrganization so even a Sovereign token cannot widen the surface.
+func NewRS256Resolver(pub *rsa.PublicKey, pinnedCtx Context) *Resolver {
+	return &Resolver{mode: VerifyRS256PublicKey, rsaPub: pub, pinnedCtx: pinnedCtx}
+}
+
+// NewHS256Resolver builds a resolver that verifies bearers against the
+// supplied HS256 secret.
+func NewHS256Resolver(secret []byte, pinnedCtx Context) *Resolver {
+	return &Resolver{mode: VerifyHS256Secret, hmacKey: secret, pinnedCtx: pinnedCtx}
+}
+
+// NewInsecureResolver builds a resolver that does NOT verify signatures.
+// Tests + trusted-transport only.
+func NewInsecureResolver(pinnedCtx Context) *Resolver {
+	return &Resolver{mode: VerifyInsecureNoSignature, pinnedCtx: pinnedCtx}
+}
+
+// Resolve parses + verifies the bearer and derives the Identity. Returns
+// an error (→ MCP 401) when the bearer is missing, malformed, or its
+// signature/expiry fails.
+func (r *Resolver) Resolve(rawBearer string) (*Identity, error) {
+	raw := strings.TrimSpace(strings.TrimPrefix(rawBearer, "Bearer "))
+	if raw == "" {
+		return nil, errors.New("identity: empty bearer")
+	}
+
+	claims := &sharedauth.Claims{}
+	parser := jwt.NewParser()
+
+	var err error
+	switch r.mode {
+	case VerifyRS256PublicKey:
+		_, err = parser.ParseWithClaims(raw, claims, func(t *jwt.Token) (any, error) {
+			if _, ok := t.Method.(*jwt.SigningMethodRSA); !ok {
+				return nil, fmt.Errorf("identity: unexpected signing method %v (want RS256)", t.Header["alg"])
+			}
+			return r.rsaPub, nil
+		})
+	case VerifyHS256Secret:
+		_, err = parser.ParseWithClaims(raw, claims, func(t *jwt.Token) (any, error) {
+			if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+				return nil, fmt.Errorf("identity: unexpected signing method %v (want HS256)", t.Header["alg"])
+			}
+			return r.hmacKey, nil
+		})
+	case VerifyInsecureNoSignature:
+		_, _, err = parser.ParseUnverified(raw, claims)
+	default:
+		return nil, errors.New("identity: unknown verify mode")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("identity: bearer rejected: %w", err)
+	}
+
+	id, err := r.fromClaims(claims)
+	if err != nil {
+		return nil, err
+	}
+	id.RawBearer = raw
+	return id, nil
+}
+
+// fromClaims derives the (context, tier, scope) triple from already-parsed
+// claims. Exported-via-Resolve only; split out so unit tests can exercise
+// the derivation without minting a signed token.
+func (r *Resolver) fromClaims(claims *sharedauth.Claims) (*Identity, error) {
+	id := &Identity{
+		Claims:        claims,
+		OrgID:         claims.OrgID,
+		DeploymentID:  claims.DeploymentID,
+		SovereignFQDN: claims.SovereignFQDN,
+		Email:         claims.Email,
+		Tier:          deriveTier(claims),
+	}
+
+	// Realm context: an explicit sovereign-admin role / tier wins; else a
+	// token carrying an org_id is an Org context; else (issuer ends
+	// /realms/sovereign) Sovereign.
+	id.Context = deriveContext(claims, id.Tier)
+
+	// A per-instance pin (per-Org MCP vs Sovereign MCP) is the final word
+	// on context so a Sovereign token presented to a per-Org instance
+	// cannot widen the surface beyond that Org. When the pin forces Org
+	// context the token MUST carry the matching org_id.
+	if r.pinnedCtx != "" {
+		if r.pinnedCtx == ContextOrganization && id.OrgID == "" {
+			return nil, errors.New("identity: per-Org MCP requires an org-scoped token (no org_id claim)")
+		}
+		id.Context = r.pinnedCtx
+	}
+
+	if id.Context == ContextOrganization && id.OrgID == "" {
+		return nil, errors.New("identity: organization context requires an org_id claim")
+	}
+	return id, nil
+}
+
+// deriveTier picks the highest catalog tier the claims express. Order of
+// precedence: an explicit sovereign-admin signal (role/realm-role) →
+// TierSovereignAdmin; else the highest catalyst-<tier> realm role; else
+// the precomputed `tier`/legacy `role` string.
+func deriveTier(claims *sharedauth.Claims) Tier {
+	if isSovereignAdmin(claims) {
+		return TierSovereignAdmin
+	}
+	best := TierNone
+	for _, role := range claims.Groups { // groups can also carry tier hints; harmless if absent
+		if t := tierFromLabel(role); t > best {
+			best = t
+		}
+	}
+	// The shared Claims type does not carry realm_access directly; the
+	// Keycloak realm roles are projected into Capabilities + the `role`
+	// claim by the mint path. We accept both the catalyst-<tier> role
+	// strings (when present in Capabilities) and the flattened `role`.
+	for _, cap := range claims.Capabilities {
+		if t := tierFromLabel(cap); t > best {
+			best = t
+		}
+	}
+	if t := tierFromLabel(claims.Role); t > best {
+		best = t
+	}
+	return best
+}
+
+// tierFromLabel maps a single role/label string to a Tier. Accepts both
+// the bare tier name (`owner`) and the catalyst-prefixed realm role
+// (`catalyst-owner`).
+func tierFromLabel(s string) Tier {
+	s = strings.ToLower(strings.TrimSpace(s))
+	s = strings.TrimPrefix(s, "catalyst-")
+	switch s {
+	case "owner":
+		return TierOwner
+	case "admin":
+		return TierAdmin
+	case "operator":
+		return TierOperator
+	case "developer":
+		return TierDeveloper
+	case "viewer":
+		return TierViewer
+	default:
+		return TierNone
+	}
+}
+
+// isSovereignAdmin reports whether the claims express the distinguished
+// sovereign-admin authority (the handover JWT `role: sovereign-admin`, the
+// `sovereign-admins` realm role/group, or the legacy `superadmin`).
+func isSovereignAdmin(claims *sharedauth.Claims) bool {
+	role := strings.ToLower(strings.TrimSpace(claims.Role))
+	if role == "sovereign-admin" || role == "superadmin" {
+		return true
+	}
+	for _, g := range claims.Groups {
+		gg := strings.ToLower(strings.TrimPrefix(strings.TrimSpace(g), "/"))
+		if gg == "sovereign-admins" || gg == "sovereign-admin" {
+			return true
+		}
+	}
+	for _, c := range claims.Capabilities {
+		if strings.EqualFold(strings.TrimSpace(c), "sovereign-admins") {
+			return true
+		}
+	}
+	return false
+}
+
+// deriveContext picks the realm context. A sovereign-admin tier always
+// resolves Sovereign; a token carrying an org_id resolves that Org;
+// otherwise an issuer ending in /realms/sovereign resolves Sovereign.
+func deriveContext(claims *sharedauth.Claims, tier Tier) Context {
+	if tier == TierSovereignAdmin {
+		return ContextSovereign
+	}
+	if claims.OrgID != "" {
+		return ContextOrganization
+	}
+	iss, _ := claims.GetIssuer()
+	if strings.HasSuffix(strings.ToLower(strings.TrimSpace(iss)), "/realms/sovereign") {
+		return ContextSovereign
+	}
+	// Default: organization context (a non-admin token without an org_id
+	// is under-scoped — fromClaims rejects it with a clear error).
+	return ContextOrganization
+}

--- a/products/openova-mcp/internal/identity/identity_test.go
+++ b/products/openova-mcp/internal/identity/identity_test.go
@@ -1,0 +1,143 @@
+package identity
+
+import (
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	sharedauth "github.com/openova-io/openova/core/services/shared/auth"
+)
+
+// resolverFromClaims exercises the (context, tier, scope) derivation
+// without minting a signed token — the insecure resolver + fromClaims.
+func TestDeriveContextAndTier(t *testing.T) {
+	cases := []struct {
+		name      string
+		claims    *sharedauth.Claims
+		pin       Context
+		wantCtx   Context
+		wantTier  Tier
+		wantOrg   string
+		expectErr bool
+	}{
+		{
+			name: "sovereign-admin role → sovereign context, top tier",
+			claims: &sharedauth.Claims{
+				Email: "emrah.baysal@openova.io", Role: "sovereign-admin",
+				DeploymentID: "7bb723da8da06047",
+			},
+			wantCtx: ContextSovereign, wantTier: TierSovereignAdmin,
+		},
+		{
+			name: "org owner → organization context, owner tier",
+			claims: &sharedauth.Claims{
+				Email: "owner@acme.test", OrgID: "acme", Role: "owner",
+			},
+			wantCtx: ContextOrganization, wantTier: TierOwner, wantOrg: "acme",
+		},
+		{
+			name: "org viewer via catalyst-viewer capability",
+			claims: &sharedauth.Claims{
+				Email: "v@acme.test", OrgID: "acme",
+				Capabilities: []string{"catalyst-viewer"},
+			},
+			wantCtx: ContextOrganization, wantTier: TierViewer, wantOrg: "acme",
+		},
+		{
+			name: "highest of multiple roles wins",
+			claims: &sharedauth.Claims{
+				OrgID: "acme", Capabilities: []string{"catalyst-viewer", "catalyst-admin", "catalyst-developer"},
+			},
+			wantCtx: ContextOrganization, wantTier: TierAdmin, wantOrg: "acme",
+		},
+		{
+			name: "pin organization but no org_id → error",
+			claims: &sharedauth.Claims{
+				Email: "x@y.test", Role: "owner",
+			},
+			pin: ContextOrganization, expectErr: true,
+		},
+		{
+			name: "non-admin without org_id → under-scoped error",
+			claims: &sharedauth.Claims{
+				Email: "x@y.test", Role: "viewer",
+			},
+			expectErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewInsecureResolver(tc.pin)
+			id, err := r.fromClaims(tc.claims)
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (id=%+v)", id)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if id.Context != tc.wantCtx {
+				t.Errorf("context = %q, want %q", id.Context, tc.wantCtx)
+			}
+			if id.Tier != tc.wantTier {
+				t.Errorf("tier = %s, want %s", id.Tier, tc.wantTier)
+			}
+			if id.OrgID != tc.wantOrg {
+				t.Errorf("orgID = %q, want %q", id.OrgID, tc.wantOrg)
+			}
+		})
+	}
+}
+
+// TestResolveInsecureFromSignedToken confirms the JWT parse path populates
+// the shared claim fields the handover JWT carries.
+func TestResolveInsecureFromSignedToken(t *testing.T) {
+	claims := &sharedauth.Claims{
+		Email:         "emrah.baysal@openova.io",
+		Role:          "sovereign-admin",
+		DeploymentID:  "7bb723da8da06047",
+		SovereignFQDN: "hw173.omani.works",
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodNone, claims)
+	signed, err := tok.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	// Insecure resolver uses ParseUnverified so an alg=none token resolves.
+	id, err := NewInsecureResolver("").Resolve(signed)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if id.Context != ContextSovereign || id.Tier != TierSovereignAdmin {
+		t.Fatalf("got context=%s tier=%s", id.Context, id.Tier)
+	}
+	if id.DeploymentID != "7bb723da8da06047" {
+		t.Errorf("deployment_id = %q", id.DeploymentID)
+	}
+	if id.RawBearer != signed {
+		t.Errorf("raw bearer not retained for facade forwarding")
+	}
+}
+
+func TestPinForcesContext(t *testing.T) {
+	// A sovereign-admin token presented to a per-Org-pinned MCP must NOT
+	// widen the surface: the pin forces Org context, and (lacking org_id)
+	// it is rejected — a per-Org instance only accepts org-scoped tokens.
+	claims := &sharedauth.Claims{Email: "a@b.test", Role: "sovereign-admin"}
+	_, err := NewInsecureResolver(ContextOrganization).fromClaims(claims)
+	if err == nil {
+		t.Fatal("expected per-Org pin to reject a non-org-scoped token")
+	}
+
+	// With an org_id the pin holds the caller to that Org even though the
+	// token also carries sovereign-admin.
+	claims2 := &sharedauth.Claims{Email: "a@b.test", Role: "sovereign-admin", OrgID: "acme"}
+	id, err := NewInsecureResolver(ContextOrganization).fromClaims(claims2)
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if id.Context != ContextOrganization {
+		t.Fatalf("pin failed to force org context: %s", id.Context)
+	}
+}

--- a/products/openova-mcp/internal/tools/catalogue.go
+++ b/products/openova-mcp/internal/tools/catalogue.go
@@ -147,10 +147,17 @@ func handleGetApplication(ctx context.Context, id *identity.Identity, api *catal
 		return nil, err
 	}
 	// Org scoping: reject an app whose namespace is not the caller's Org
-	// (defense in depth — the endpoint already scopes, but the facade
-	// double-checks so a cross-Org name leak cannot pass through).
+	// (defense in depth — the get-by-name endpoint resolves across
+	// namespaces and does NOT scope, so the facade MUST: a cross-Org name
+	// must not leak another Org's data). The catalyst-api get response
+	// carries `namespace` at the top level (HandleApplicationGet wire
+	// shape); fall back to metadata.namespace for the raw-CR shape.
 	if id.Context == identity.ContextOrganization {
-		if ns := nestedString(obj, "metadata", "namespace"); ns != "" && !namespaceBelongsToOrg(ns, id.OrgID) {
+		ns := nestedString(obj, "namespace")
+		if ns == "" {
+			ns = nestedString(obj, "metadata", "namespace")
+		}
+		if ns != "" && !namespaceBelongsToOrg(ns, id.OrgID) {
 			return nil, fmt.Errorf("%w: application %q is not in organization %q", ErrForbidden, in.Name, id.OrgID)
 		}
 	}

--- a/products/openova-mcp/internal/tools/catalogue.go
+++ b/products/openova-mcp/internal/tools/catalogue.go
@@ -1,0 +1,284 @@
+// catalogue.go — the first-slice OpenOva MCP tool catalogue.
+//
+// All tools here are READ-ONLY and Org-scoped (RequiredContext is empty so
+// they are offered in both Org + Sovereign contexts, since a sovereign-
+// admin can read any Org). The write/mutating + Sovereign-only tools
+// (deployments.*, vouchers.*, cutover.*, placement.*) are DEFERRED to
+// follow-ups per #3988 §5; this slice ships the read facade only.
+//
+// Org scoping is enforced at the handler boundary: an Org-context caller
+// only ever sees data for their own OrgID (the catalyst-api endpoint is
+// addressed by the caller's bound deployment, and Application items are
+// filtered to the caller's Org namespace). A sovereign-admin sees the full
+// set unfiltered.
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/openova-io/openova/products/openova-mcp/internal/catalystapi"
+	"github.com/openova-io/openova/products/openova-mcp/internal/identity"
+)
+
+// catalogue enumerates every tool the first slice advertises.
+func catalogue() []Tool {
+	emptyObj := map[string]any{"type": "object", "additionalProperties": false}
+
+	return []Tool{
+		{
+			Name:        "whoami",
+			Description: "Return the resolved caller identity the MCP server sees: realm context (organization|sovereign), tier, Org scope, deployment, email. Mirrors the console's /auth/me.",
+			InputSchema: emptyObj,
+			MinTier:     identity.TierViewer,
+			Handler:     handleWhoami,
+		},
+		{
+			Name:        "list_organizations",
+			Description: "List the Organizations the caller can see. In Org context this is the caller's own Organization only; a sovereign-admin sees every Organization on the Sovereign. Thin facade over GET /api/v1/organizations.",
+			InputSchema: emptyObj,
+			MinTier:     identity.TierViewer,
+			Handler:     handleListOrganizations,
+		},
+		{
+			Name:        "list_environments",
+			Description: "List the Environments (env-type partitions: dev/staging/prod) visible to the caller, derived from the Applications running in the caller's Organization. Scoped to the caller's Org in Org context.",
+			InputSchema: emptyObj,
+			MinTier:     identity.TierViewer,
+			Handler:     handleListEnvironments,
+		},
+		{
+			Name:        "list_applications",
+			Description: "List the Applications in the caller's Organization, with blueprint, version, namespace, and phase — exactly what the console Applications page shows for that user. Thin facade over GET /api/v1/sovereigns/{id}/applications, Org-scoped.",
+			InputSchema: emptyObj,
+			MinTier:     identity.TierViewer,
+			Handler:     handleListApplications,
+		},
+		{
+			Name:        "get_application",
+			Description: "Get a single Application by name in the caller's Organization (full status + spec the console detail view renders). Org-scoped: a name outside the caller's Org is not returned.",
+			InputSchema: map[string]any{
+				"type":                 "object",
+				"additionalProperties": false,
+				"required":             []string{"name"},
+				"properties": map[string]any{
+					"name": map[string]any{"type": "string", "description": "Application name (metadata.name)."},
+				},
+			},
+			MinTier: identity.TierViewer,
+			Handler: handleGetApplication,
+		},
+	}
+}
+
+// ── handlers ─────────────────────────────────────────────────────────────
+
+func handleWhoami(_ context.Context, id *identity.Identity, _ *catalystapi.Client, _ json.RawMessage) (any, error) {
+	return map[string]any{
+		"email":           id.Email,
+		"context":         string(id.Context),
+		"tier":            id.Tier.String(),
+		"org_id":          id.OrgID,
+		"deployment_id":   id.DeploymentID,
+		"sovereign_fqdn":  id.SovereignFQDN,
+		"sovereign_admin": id.Tier == identity.TierSovereignAdmin,
+	}, nil
+}
+
+func handleListOrganizations(ctx context.Context, id *identity.Identity, api *catalystapi.Client, _ json.RawMessage) (any, error) {
+	if api == nil {
+		return nil, fmt.Errorf("catalyst-api client not configured")
+	}
+	resp, err := api.ListOrganizations(ctx, bearerOf(id))
+	if err != nil {
+		return nil, err
+	}
+	items := resp.Items
+	// Org scoping: an Org-context caller sees only their own Organization.
+	// A sovereign-admin sees the full list.
+	if id.Context == identity.ContextOrganization {
+		items = filterOrgs(items, id.OrgID)
+	}
+	return map[string]any{"items": items, "total": len(items)}, nil
+}
+
+func handleListApplications(ctx context.Context, id *identity.Identity, api *catalystapi.Client, _ json.RawMessage) (any, error) {
+	if api == nil {
+		return nil, fmt.Errorf("catalyst-api client not configured")
+	}
+	depID, err := requireDeployment(id)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := api.ListApplications(ctx, depID, bearerOf(id))
+	if err != nil {
+		return nil, err
+	}
+	items := resp.Items
+	if id.Context == identity.ContextOrganization {
+		items = filterAppsToOrg(items, id.OrgID)
+	}
+	return map[string]any{"kind": resp.Kind, "items": items, "total": len(items)}, nil
+}
+
+func handleGetApplication(ctx context.Context, id *identity.Identity, api *catalystapi.Client, args json.RawMessage) (any, error) {
+	if api == nil {
+		return nil, fmt.Errorf("catalyst-api client not configured")
+	}
+	var in struct {
+		Name string `json:"name"`
+	}
+	if len(args) > 0 {
+		if err := json.Unmarshal(args, &in); err != nil {
+			return nil, fmt.Errorf("invalid arguments: %w", err)
+		}
+	}
+	if strings.TrimSpace(in.Name) == "" {
+		return nil, fmt.Errorf("missing required argument: name")
+	}
+	depID, err := requireDeployment(id)
+	if err != nil {
+		return nil, err
+	}
+	obj, err := api.GetApplication(ctx, depID, in.Name, bearerOf(id))
+	if err != nil {
+		return nil, err
+	}
+	// Org scoping: reject an app whose namespace is not the caller's Org
+	// (defense in depth — the endpoint already scopes, but the facade
+	// double-checks so a cross-Org name leak cannot pass through).
+	if id.Context == identity.ContextOrganization {
+		if ns := nestedString(obj, "metadata", "namespace"); ns != "" && !namespaceBelongsToOrg(ns, id.OrgID) {
+			return nil, fmt.Errorf("%w: application %q is not in organization %q", ErrForbidden, in.Name, id.OrgID)
+		}
+	}
+	return obj, nil
+}
+
+// handleListEnvironments derives the distinct Environments from the
+// Applications visible to the caller. Catalyst has no standalone
+// list-environments REST endpoint today; the console derives the env-type
+// partitions from the running Applications, so the MCP does the same —
+// staying a faithful facade rather than inventing a new surface.
+func handleListEnvironments(ctx context.Context, id *identity.Identity, api *catalystapi.Client, _ json.RawMessage) (any, error) {
+	if api == nil {
+		return nil, fmt.Errorf("catalyst-api client not configured")
+	}
+	depID, err := requireDeployment(id)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := api.ListApplications(ctx, depID, bearerOf(id))
+	if err != nil {
+		return nil, err
+	}
+	items := resp.Items
+	if id.Context == identity.ContextOrganization {
+		items = filterAppsToOrg(items, id.OrgID)
+	}
+	// Group apps by their Environment (the namespace = `<org>-<env_type>`
+	// per the naming convention in CLAUDE.md §Naming).
+	envs := map[string]int{}
+	for _, it := range items {
+		env := it.Namespace
+		if env == "" {
+			env = "(unknown)"
+		}
+		envs[env]++
+	}
+	out := make([]map[string]any, 0, len(envs))
+	for env, n := range envs {
+		out = append(out, map[string]any{"name": env, "applications": n})
+	}
+	return map[string]any{"items": out, "total": len(out)}, nil
+}
+
+// ── scoping helpers ──────────────────────────────────────────────────────
+
+// bearerOf returns the raw compact JWT the caller presented, forwarded
+// verbatim to the catalyst-api so the endpoint's own authz is the final
+// word (thin-facade rule).
+func bearerOf(id *identity.Identity) string {
+	if id == nil || id.Claims == nil {
+		return ""
+	}
+	// The shared Claims type does not retain the raw token; the dispatch
+	// layer stashes it on the identity via SetRawBearer. Fall back to "".
+	return id.RawBearer
+}
+
+// requireDeployment returns the deployment ID the caller's session is
+// bound to (handover JWT deployment_id). The catalyst-api route table is
+// addressed by `/api/v1/sovereigns/{id}/…`; without a deployment binding
+// the facade cannot resolve which Sovereign to query.
+func requireDeployment(id *identity.Identity) (string, error) {
+	if id.DeploymentID == "" {
+		return "", fmt.Errorf("no deployment binding on the caller's token (deployment_id claim required)")
+	}
+	return id.DeploymentID, nil
+}
+
+// filterOrgs keeps only the Organization whose slug/id matches orgID.
+func filterOrgs(items []map[string]any, orgID string) []map[string]any {
+	out := make([]map[string]any, 0, 1)
+	for _, it := range items {
+		if orgMatches(it, orgID) {
+			out = append(out, it)
+		}
+	}
+	return out
+}
+
+// orgMatches reports whether an org record's slug/id/name matches orgID.
+func orgMatches(rec map[string]any, orgID string) bool {
+	for _, k := range []string{"slug", "id", "name", "org_id", "organization"} {
+		if v, ok := rec[k].(string); ok && strings.EqualFold(strings.TrimSpace(v), orgID) {
+			return true
+		}
+	}
+	return false
+}
+
+// filterAppsToOrg keeps only Applications whose namespace belongs to the
+// caller's Org. The namespace convention is `<org>-<env_type>` (or the
+// per-Org vcluster namespace `<org>`), so a prefix match on the slug is
+// the scoping rule the console uses.
+func filterAppsToOrg(items []catalystapi.ApplicationItem, orgID string) []catalystapi.ApplicationItem {
+	out := make([]catalystapi.ApplicationItem, 0, len(items))
+	for _, it := range items {
+		if namespaceBelongsToOrg(it.Namespace, orgID) {
+			out = append(out, it)
+		}
+	}
+	return out
+}
+
+// namespaceBelongsToOrg reports whether a namespace belongs to orgID. The
+// Organization owns namespaces named `<org>` and `<org>-<env_type>`
+// (CLAUDE.md §Naming), so an exact match or a `<org>-` prefix qualifies.
+func namespaceBelongsToOrg(ns, orgID string) bool {
+	ns = strings.ToLower(strings.TrimSpace(ns))
+	org := strings.ToLower(strings.TrimSpace(orgID))
+	if org == "" || ns == "" {
+		return false
+	}
+	return ns == org || strings.HasPrefix(ns, org+"-")
+}
+
+// nestedString safely reads a string at a nested path in a generic map.
+func nestedString(obj map[string]any, path ...string) string {
+	cur := any(obj)
+	for _, p := range path {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return ""
+		}
+		cur = m[p]
+	}
+	if s, ok := cur.(string); ok {
+		return s
+	}
+	return ""
+}

--- a/products/openova-mcp/internal/tools/registry.go
+++ b/products/openova-mcp/internal/tools/registry.go
@@ -1,0 +1,145 @@
+// Package tools is the OpenOva MCP tool catalogue + the two-layer RBAC
+// gate (#3988 §4.1).
+//
+//	Layer 1 — tools/list filtering: List(id) returns ONLY the tools the
+//	          caller's resolved (context, tier) authorizes, so the agent's
+//	          surface == the user's UI surface. An Org owner never even
+//	          SEES the Sovereign-scoped tools.
+//	Layer 2 — tools/call re-auth: Call(id, …) independently re-checks the
+//	          tool's required (context, tier) + Org pin against the SAME
+//	          identity, so a hand-crafted call to a filtered-out tool is
+//	          still denied with a forbidden error.
+//
+// First slice = read-only Org-scoped tools only. Every data tool is a
+// THIN facade that forwards the caller's bearer to the real catalyst-api
+// (see internal/catalystapi). The registry holds no privileged token.
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/openova-io/openova/products/openova-mcp/internal/catalystapi"
+	"github.com/openova-io/openova/products/openova-mcp/internal/identity"
+)
+
+// ErrForbidden is returned by Call when the caller's identity does not
+// satisfy a tool's required (context, tier). The dispatch layer maps it to
+// the parity-403 the UI endpoint would return.
+var ErrForbidden = errors.New("forbidden")
+
+// ErrUnknownTool is returned by Call for a name not in the catalogue.
+var ErrUnknownTool = errors.New("unknown tool")
+
+// HandlerFunc is the shape every tool implementation conforms to. It
+// receives the resolved caller Identity, the backend client, and the raw
+// arguments JSON; returns any JSON-marshalable value or an error.
+type HandlerFunc func(ctx context.Context, id *identity.Identity, api *catalystapi.Client, args json.RawMessage) (any, error)
+
+// Tool is one MCP tool the server advertises.
+type Tool struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	InputSchema map[string]any `json:"inputSchema"`
+
+	// RequiredContext — when non-empty, the tool is only visible/callable
+	// in that realm context. Empty = visible in BOTH contexts. The
+	// Sovereign context is a superset, so a tool requiring
+	// ContextOrganization is ALSO offered to a sovereign-admin (who can
+	// act on any Org); a tool requiring ContextSovereign is NEVER offered
+	// in an Org context.
+	RequiredContext identity.Context `json:"-"`
+
+	// MinTier — the lowest tier that may see/call the tool. Read tools
+	// default to TierViewer.
+	MinTier identity.Tier `json:"-"`
+
+	// Handler runs the tool.
+	Handler HandlerFunc `json:"-"`
+}
+
+// Registry is the in-process catalogue + backend client.
+type Registry struct {
+	tools map[string]Tool
+	api   *catalystapi.Client
+}
+
+// NewRegistry builds the catalogue wired to the supplied catalyst-api
+// client. Pass nil api only in unit tests that exercise the gate shape
+// without a backend.
+func NewRegistry(api *catalystapi.Client) *Registry {
+	r := &Registry{tools: map[string]Tool{}, api: api}
+	for _, t := range catalogue() {
+		r.tools[t.Name] = t
+	}
+	return r
+}
+
+// visible reports whether the tool is visible to the given identity under
+// layer-1 (and gate-checked identically under layer-2). A nil identity
+// sees nothing.
+func (r *Registry) visible(t Tool, id *identity.Identity) bool {
+	if id == nil {
+		return false
+	}
+	if !id.Tier.AtLeast(t.MinTier) {
+		return false
+	}
+	if t.RequiredContext == "" {
+		return true // visible in both contexts
+	}
+	switch t.RequiredContext {
+	case identity.ContextSovereign:
+		// Sovereign-scoped tools are ONLY visible in the Sovereign
+		// context. An Org-context caller never sees them.
+		return id.Context == identity.ContextSovereign
+	case identity.ContextOrganization:
+		// Org-scoped tools are visible to an Org caller AND to a
+		// sovereign-admin (Sovereign context is a superset).
+		return id.Context == identity.ContextOrganization || id.Context == identity.ContextSovereign
+	default:
+		return false
+	}
+}
+
+// List returns the tools visible to id, sorted by name (layer 1).
+func (r *Registry) List(id *identity.Identity) []Tool {
+	out := make([]Tool, 0, len(r.tools))
+	for _, t := range r.tools {
+		if r.visible(t, id) {
+			out = append(out, t)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// Call re-authorizes (layer 2) then invokes the named tool. Returns
+// ErrUnknownTool for an unknown name and ErrForbidden when id fails the
+// gate — even if the name is real, a caller who cannot see it cannot call
+// it.
+func (r *Registry) Call(ctx context.Context, id *identity.Identity, name string, args json.RawMessage) (any, error) {
+	t, ok := r.tools[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrUnknownTool, name)
+	}
+	if id == nil {
+		return nil, fmt.Errorf("%w: unauthenticated", ErrForbidden)
+	}
+	if !r.visible(t, id) {
+		// Identical gate to layer 1 → identical forbidden semantics the
+		// UI endpoint would return for an out-of-scope user.
+		return nil, fmt.Errorf("%w: tool %q not authorized for context=%s tier=%s",
+			ErrForbidden, name, id.Context, id.Tier)
+	}
+	if t.Handler == nil {
+		return map[string]any{"status": "not_implemented", "tool": name}, nil
+	}
+	return t.Handler(ctx, id, r.api, args)
+}
+
+// Has reports whether the catalogue contains a tool by name (test helper).
+func (r *Registry) Has(name string) bool { _, ok := r.tools[name]; return ok }

--- a/products/openova-mcp/internal/tools/tools_test.go
+++ b/products/openova-mcp/internal/tools/tools_test.go
@@ -1,0 +1,209 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	sharedauth "github.com/openova-io/openova/core/services/shared/auth"
+	"github.com/openova-io/openova/products/openova-mcp/internal/catalystapi"
+	"github.com/openova-io/openova/products/openova-mcp/internal/identity"
+)
+
+// roundTripFunc lets a test stand in for the live catalyst-api.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func jsonResp(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+}
+
+func orgIdentity(org, dep string, tier identity.Tier) *identity.Identity {
+	return &identity.Identity{
+		Claims:       &sharedauth.Claims{OrgID: org, DeploymentID: dep},
+		Context:      identity.ContextOrganization,
+		Tier:         tier,
+		OrgID:        org,
+		DeploymentID: dep,
+		RawBearer:    "org-bearer",
+	}
+}
+
+func sovereignIdentity(dep string) *identity.Identity {
+	return &identity.Identity{
+		Claims:       &sharedauth.Claims{Role: "sovereign-admin", DeploymentID: dep},
+		Context:      identity.ContextSovereign,
+		Tier:         identity.TierSovereignAdmin,
+		DeploymentID: dep,
+		RawBearer:    "sov-bearer",
+	}
+}
+
+// TestListFilterIsContextScoped — layer-1 RBAC: both contexts see the
+// read tools (a sovereign-admin can read any Org), and an unauthenticated
+// caller sees nothing. (Sovereign-only write tools are deferred, so the
+// surface is identical here — the gate plumbing is what's under test.)
+func TestListVisibility(t *testing.T) {
+	reg := NewRegistry(nil)
+
+	if got := reg.List(nil); len(got) != 0 {
+		t.Fatalf("unauthenticated caller should see 0 tools, got %d", len(got))
+	}
+
+	orgTools := reg.List(orgIdentity("acme", "dep1", identity.TierViewer))
+	if len(orgTools) == 0 {
+		t.Fatal("org viewer should see the read tools")
+	}
+	for _, want := range []string{"whoami", "list_applications", "get_application", "list_environments", "list_organizations"} {
+		if !containsTool(orgTools, want) {
+			t.Errorf("org viewer missing expected tool %q", want)
+		}
+	}
+}
+
+// TestCallUnknownAndForbidden — layer-2 re-auth.
+func TestCallGate(t *testing.T) {
+	reg := NewRegistry(nil)
+
+	// Unknown tool.
+	_, err := reg.Call(context.Background(), orgIdentity("acme", "d", identity.TierOwner), "nope.nope", nil)
+	if !errors.Is(err, ErrUnknownTool) {
+		t.Fatalf("want ErrUnknownTool, got %v", err)
+	}
+
+	// Nil identity → forbidden.
+	_, err = reg.Call(context.Background(), nil, "whoami", nil)
+	if !errors.Is(err, ErrForbidden) {
+		t.Fatalf("want ErrForbidden for nil identity, got %v", err)
+	}
+}
+
+// TestListApplicationsOrgScoped — the facade forwards the caller's bearer
+// and filters items to the caller's Org namespace.
+func TestListApplicationsOrgScoped(t *testing.T) {
+	var sawAuth, sawCookie, sawPath string
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		sawAuth = r.Header.Get("Authorization")
+		sawCookie = r.Header.Get("Cookie")
+		sawPath = r.URL.Path
+		return jsonResp(200, `{"kind":"ApplicationList","items":[
+			{"kind":"Application","name":"shop","namespace":"acme-prod","blueprint":"bp-wordpress","phase":"Ready"},
+			{"kind":"Application","name":"blog","namespace":"acme","blueprint":"bp-ghost","phase":"Ready"},
+			{"kind":"Application","name":"other","namespace":"globex-prod","blueprint":"bp-gitea","phase":"Ready"}
+		],"total":3}`), nil
+	})
+	api := catalystapi.New("https://console.test").WithHTTPClient(&http.Client{Transport: rt})
+	reg := NewRegistry(api)
+
+	out, err := reg.Call(context.Background(), orgIdentity("acme", "7bb723da8da06047", identity.TierViewer), "list_applications", nil)
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	// Forwarded identity assertions (thin facade).
+	if sawAuth != "Bearer org-bearer" {
+		t.Errorf("Authorization not forwarded: %q", sawAuth)
+	}
+	if !strings.Contains(sawCookie, "catalyst_session=org-bearer") {
+		t.Errorf("session cookie not forwarded: %q", sawCookie)
+	}
+	if sawPath != "/api/v1/sovereigns/7bb723da8da06047/applications" {
+		t.Errorf("wrong path: %q", sawPath)
+	}
+	// Org scoping: only acme-* namespaces remain.
+	m := out.(map[string]any)
+	items := m["items"].([]catalystapi.ApplicationItem)
+	if len(items) != 2 {
+		t.Fatalf("org scoping failed: want 2 acme apps, got %d: %+v", len(items), items)
+	}
+	for _, it := range items {
+		if !strings.HasPrefix(it.Namespace, "acme") {
+			t.Errorf("leaked cross-org app: %+v", it)
+		}
+	}
+}
+
+// TestListApplicationsSovereignUnfiltered — a sovereign-admin sees all.
+func TestListApplicationsSovereignUnfiltered(t *testing.T) {
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return jsonResp(200, `{"kind":"ApplicationList","items":[
+			{"kind":"Application","name":"a","namespace":"acme-prod"},
+			{"kind":"Application","name":"b","namespace":"globex-prod"}
+		],"total":2}`), nil
+	})
+	api := catalystapi.New("https://console.test").WithHTTPClient(&http.Client{Transport: rt})
+	reg := NewRegistry(api)
+	out, err := reg.Call(context.Background(), sovereignIdentity("7bb723da8da06047"), "list_applications", nil)
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	items := out.(map[string]any)["items"].([]catalystapi.ApplicationItem)
+	if len(items) != 2 {
+		t.Fatalf("sovereign-admin should see all apps unfiltered, got %d", len(items))
+	}
+}
+
+// TestParity403 — when the catalyst-api endpoint returns 403, the MCP
+// surfaces the SAME upstream status (thin-facade parity, #3988 DoD §4).
+func TestParity403(t *testing.T) {
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return jsonResp(403, `{"error":"forbidden","detail":"requires tier-admin or higher"}`), nil
+	})
+	api := catalystapi.New("https://console.test").WithHTTPClient(&http.Client{Transport: rt})
+	reg := NewRegistry(api)
+
+	_, err := reg.Call(context.Background(), orgIdentity("acme", "dep1", identity.TierViewer), "list_applications", nil)
+	var apiErr *catalystapi.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("want *catalystapi.APIError, got %v", err)
+	}
+	if apiErr.Status != 403 {
+		t.Fatalf("parity broken: upstream 403 not preserved, got %d", apiErr.Status)
+	}
+}
+
+// TestGetApplicationCrossOrgDenied — a name resolving to another Org's
+// namespace is denied by the facade's defense-in-depth scope check.
+func TestGetApplicationCrossOrgDenied(t *testing.T) {
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return jsonResp(200, `{"metadata":{"name":"leak","namespace":"globex-prod"},"spec":{}}`), nil
+	})
+	api := catalystapi.New("https://console.test").WithHTTPClient(&http.Client{Transport: rt})
+	reg := NewRegistry(api)
+
+	args, _ := json.Marshal(map[string]string{"name": "leak"})
+	_, err := reg.Call(context.Background(), orgIdentity("acme", "dep1", identity.TierViewer), "get_application", args)
+	if !errors.Is(err, ErrForbidden) {
+		t.Fatalf("cross-org get should be ErrForbidden, got %v", err)
+	}
+}
+
+// TestWhoamiNeedsNoBackend — whoami echoes the resolved identity.
+func TestWhoami(t *testing.T) {
+	reg := NewRegistry(nil)
+	out, err := reg.Call(context.Background(), sovereignIdentity("7bb723da8da06047"), "whoami", nil)
+	if err != nil {
+		t.Fatalf("whoami: %v", err)
+	}
+	m := out.(map[string]any)
+	if m["context"] != "sovereign" || m["sovereign_admin"] != true {
+		t.Fatalf("whoami wrong: %+v", m)
+	}
+}
+
+func containsTool(ts []Tool, name string) bool {
+	for _, t := range ts {
+		if t.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/products/openova-mcp/internal/tools/tools_test.go
+++ b/products/openova-mcp/internal/tools/tools_test.go
@@ -171,18 +171,43 @@ func TestParity403(t *testing.T) {
 }
 
 // TestGetApplicationCrossOrgDenied — a name resolving to another Org's
-// namespace is denied by the facade's defense-in-depth scope check.
+// namespace is denied by the facade's defense-in-depth scope check. The
+// catalyst-api get-by-name response carries `namespace` at the top level
+// (the real HandleApplicationGet wire shape, confirmed on hw173); the
+// metadata.namespace fallback covers the raw-CR shape.
 func TestGetApplicationCrossOrgDenied(t *testing.T) {
+	for _, body := range []string{
+		`{"name":"leak","namespace":"globex-prod","blueprint":"bp-gitea"}`, // top-level (real endpoint shape)
+		`{"metadata":{"name":"leak","namespace":"globex-prod"},"spec":{}}`, // raw-CR shape
+	} {
+		rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return jsonResp(200, body), nil
+		})
+		api := catalystapi.New("https://console.test").WithHTTPClient(&http.Client{Transport: rt})
+		reg := NewRegistry(api)
+
+		args, _ := json.Marshal(map[string]string{"name": "leak"})
+		_, err := reg.Call(context.Background(), orgIdentity("acme", "dep1", identity.TierViewer), "get_application", args)
+		if !errors.Is(err, ErrForbidden) {
+			t.Fatalf("cross-org get should be ErrForbidden for body %q, got %v", body, err)
+		}
+	}
+}
+
+// TestGetApplicationOwnOrgAllowed — the caller's own Org app is returned.
+func TestGetApplicationOwnOrgAllowed(t *testing.T) {
 	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
-		return jsonResp(200, `{"metadata":{"name":"leak","namespace":"globex-prod"},"spec":{}}`), nil
+		return jsonResp(200, `{"name":"shop","namespace":"acme-prod","blueprint":"bp-wordpress"}`), nil
 	})
 	api := catalystapi.New("https://console.test").WithHTTPClient(&http.Client{Transport: rt})
 	reg := NewRegistry(api)
-
-	args, _ := json.Marshal(map[string]string{"name": "leak"})
-	_, err := reg.Call(context.Background(), orgIdentity("acme", "dep1", identity.TierViewer), "get_application", args)
-	if !errors.Is(err, ErrForbidden) {
-		t.Fatalf("cross-org get should be ErrForbidden, got %v", err)
+	args, _ := json.Marshal(map[string]string{"name": "shop"})
+	out, err := reg.Call(context.Background(), orgIdentity("acme", "dep1", identity.TierViewer), "get_application", args)
+	if err != nil {
+		t.Fatalf("own-org get should succeed, got %v", err)
+	}
+	if out.(map[string]any)["namespace"] != "acme-prod" {
+		t.Fatalf("wrong app returned: %+v", out)
 	}
 }
 


### PR DESCRIPTION
## What this is

The **first concrete, live-testable vertical slice** of the OpenOva MCP server (#3988) — now unblocked (SME→Organization #3995/#3985 merged).

The OpenOva MCP server exposes the OpenOva product surface as MCP tools whose surface is **RBAC-scoped per user**, so an agent's tool set is **identical to what that user can do in the Catalyst console UI**. It is a **thin facade** — it reimplements nothing, forwards the caller's bearer to the **live catalyst-api** (the endpoint's own authz is the final word), and resolves identity from the **single source-of-truth claim contract** `core/services/shared/auth.Claims` (NOT a parallel auth system).

`Refs #3988`. Base `main`. NOT auto-close — the issue closes after the operator walk lands.

## The slice (`products/openova-mcp/`)

- **`cmd/openova-mcp`** — MCP server core, JSON-RPC 2.0 over stdio (the proven sandbox-MCP transport).
- **`internal/identity`** — per-relevant-Keycloak identity resolution: parses the bearer into `auth.Claims`, derives realm **context** (organization | sovereign), **tier** (viewer<developer<operator<admin<owner<sovereign-admin), pinned **Org scope**. RS256/HS256/insecure verify modes; a per-Org pin holds a token to its Org.
- **`internal/tools`** — **two-layer RBAC**: `tools/list` filtered by `(context, tier)` [layer 1]; `tools/call` re-authorized against the same identity [layer 2].
- **`internal/catalystapi`** — the facade boundary: forwards the caller's bearer to the real endpoints; preserves the upstream status so a **403 maps to a 403 (parity)**.
- **Real, read-only, Org-scoped tools**: `whoami`, `list_organizations`, `list_applications`, `get_application`, `list_environments` — each Org-scoped so a user with rights only to Org X sees only Org X's data; a sovereign-admin sees the full set.

## hw173 LIVE-PROOF (real data, not a mock)

Run **inside hw173's catalyst-api pod** (dep `7bb723da8da06047`) pointed at the real `localhost:8080`, bearers signed by hw173's own handover key. Three real `Application` CRs were seeded on hw173 for the walk (2 in `acme-prod`, 1 in `globex-prod`) and removed after.

**PROOF 1 — sovereign-admin `list_applications` → all 3 REAL apps:**
```json
{"items":[{"name":"blog","namespace":"acme-prod","blueprint":"bp-ghost","version":"0.2.0","phase":"Pending"},
{"name":"shop","namespace":"acme-prod","blueprint":"bp-wordpress","version":"0.4.1","phase":"Pending"},
{"name":"portal","namespace":"globex-prod","blueprint":"bp-gitea","version":"0.3.0","phase":"Pending"}],"kind":"ApplicationList","total":3}
```

**PROOF 2 — Org token (`org_id=acme`) `list_applications` → ONLY the 2 acme apps (RBAC Org-scope):**
```json
{"items":[{"name":"blog","namespace":"acme-prod",...},{"name":"shop","namespace":"acme-prod",...}],"kind":"ApplicationList","total":2}
```
(globex `portal` correctly filtered out.)

**PROOF 3 — Org token (acme) `get_application portal` (globex app) → SAME 403 the UI would return:**
```json
{"id":3,"error":{"code":-32003,"message":"forbidden","data":{"detail":"forbidden: application \"portal\" is not in organization \"acme\"","status":403}}}
```
**PROOF 3b — Org token (acme) `get_application shop` (own app) → returns the REAL app** (blueprint bp-wordpress, ns acme-prod, real uid + conditions).

**PROOF 4 — Org token `whoami`:** `{"context":"organization","tier":"owner","org_id":"acme","sovereign_admin":false,...}`
**PROOF 5 — sovereign-admin `whoami`:** `{"context":"sovereign","tier":"sovereign-admin","sovereign_admin":true,...}`

**PROOF 6 — Org token `list_environments` → only `acme-prod` (2 apps).**
**PROOF 7 — sovereign-admin `list_environments` → `acme-prod` (2) + `globex-prod` (1).**
**PROOF 8 — Org `tools/list` (layer-1 RBAC)** shows the 5 read tools: `get_application`, `list_applications`, `list_environments`, `list_organizations`, `whoami`.

> The walk **found a real bug** unit tests missed: the get-by-name response carries `namespace` at the top level (not under `metadata`), so the facade's cross-Org scope check read the wrong path and leaked another Org's app. Fixed in 613e63c and live re-verified (PROOF 3). This is exactly why a live user-acceptance walk is the only acceptance.

## Gates

`go build ./...`, `go vet ./...`, `go test ./...` green; `gofmt` clean.

## Deferred to follow-ups (per #3988 §5 — NOT built here, noted in the module README)

- chepherd integration + `bp-openova-mcp dependsOn bp-chepherd` chart + `openovaMCP.*` repoint + `.mcp.json` injection.
- HTTP/SSE transport (this slice = stdio).
- Per-realm JWKS validation (this slice = single RS256/HS256 key).
- Write / mutating tools (`org.apps.install`, `deployments.*`, `vouchers.*`, `cutover.*`, `placement.*`, `k8s.write.*`).
- Sovereign-scoped admin tools + the full ~26 (Org) / ~70 (Sovereign) catalog.
- The registry-coverage parity test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
