### PR TITLE
feat(bp-chepherd): chepherd as an installable Application + openova-mcp create_application write tool (Refs #4010 #3988)

### DIFF
--- a/.github/workflows/chepherd-build.yaml
+++ b/.github/workflows/chepherd-build.yaml
@@ -18,7 +18,9 @@ env:
   REGISTRY: ghcr.io
   IMAGE: ghcr.io/openova-io/bp-chepherd
   # Pin the upstream chepherd daemon image the openova-mcp binary overlays.
-  CHEPHERD_BASE: ghcr.io/chepherd/chepherd:v0.9.4
+  # Digest-pinned to the v0.9.4 build that carries the bp-chepherd MCP seam
+  # (chepherd #747 / #4010: CHEPHERD_EXTRA_MCP_JSON + CHEPHERD_DEFAULT_MODEL).
+  CHEPHERD_BASE: ghcr.io/chepherd/chepherd:v0.9.4@sha256:b6f0c43b63b8933bfaad8cf09366642e63656d9664887eab20eac26e96d28b82
 
 permissions:
   contents: read

--- a/.github/workflows/chepherd-build.yaml
+++ b/.github/workflows/chepherd-build.yaml
@@ -34,9 +34,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set short SHA
+      - name: Set short SHA + chart appVersion
         id: vars
-        run: echo "sha_short=$(echo $GITHUB_SHA | head -c 7)" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "sha_short=$(echo $GITHUB_SHA | head -c 7)" >> "$GITHUB_OUTPUT"
+          # The chart's image helper resolves to repository:<Chart.AppVersion>
+          # (chepherd.image in _helpers.tpl), so the published image MUST carry
+          # that exact tag or the StatefulSet ImagePullBackOffs. Derive it from
+          # the chart so the tag can never drift from what the chart references.
+          APPVER=$(grep -E '^appVersion:' products/chepherd/chart/Chart.yaml | head -1 | sed -E 's/appVersion:[[:space:]]*"?([^"]+)"?/\1/')
+          echo "app_version=${APPVER}" >> "$GITHUB_OUTPUT"
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -54,5 +61,6 @@ jobs:
             CHEPHERD_BASE=${{ env.CHEPHERD_BASE }}
           push: true
           tags: |
+            ${{ env.IMAGE }}:${{ steps.vars.outputs.app_version }}
             ${{ env.IMAGE }}:${{ steps.vars.outputs.sha_short }}
             ${{ env.IMAGE }}:latest

--- a/.github/workflows/chepherd-build.yaml
+++ b/.github/workflows/chepherd-build.yaml
@@ -1,0 +1,56 @@
+name: Build bp-chepherd
+
+# Builds the bp-chepherd Application image: the upstream chepherd daemon
+# image with OpenOva's openova-mcp binary baked in (#4010). The build
+# context is the repo root because the openova-mcp module imports
+# core/services/shared/auth from this repo.
+
+on:
+  push:
+    paths:
+      - 'products/chepherd/**'
+      - 'products/openova-mcp/**'
+      - 'core/services/shared/auth/**'
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ghcr.io/openova-io/bp-chepherd
+  # Pin the upstream chepherd daemon image the openova-mcp binary overlays.
+  CHEPHERD_BASE: ghcr.io/chepherd/chepherd:v0.9.4
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-bp-chepherd:
+    runs-on: ubuntu-latest
+    outputs:
+      sha_short: ${{ steps.vars.outputs.sha_short }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set short SHA
+        id: vars
+        run: echo "sha_short=$(echo $GITHUB_SHA | head -c 7)" >> "$GITHUB_OUTPUT"
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build + push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: products/chepherd/Containerfile
+          build-args: |
+            CHEPHERD_BASE=${{ env.CHEPHERD_BASE }}
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.vars.outputs.sha_short }}
+            ${{ env.IMAGE }}:latest

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-20T19:38:21.614Z",
+  "generatedAt": "2026-06-21T07:17:19.566Z",
   "blueprints": [
     {
       "id": "bp-alloy",
@@ -493,7 +493,7 @@
         "supported": [
           "singleton"
         ],
-        "multiRegion": null,
+        "multiRegion": "singleton",
         "singleRegion": "singleton",
         "perTopology": {
           "singleton": {
@@ -958,7 +958,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.1.5",
+      "version": "1.2.0",
       "section": "pts-3-2-gitops-and-iac",
       "depends": [
         "bp-crossplane"
@@ -1078,7 +1078,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "section": "pts-3-1-networking-and-service-mesh",
       "depends": [
         "bp-cilium",
@@ -1578,7 +1578,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.39",
+      "version": "1.2.40",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-postgres"
@@ -1708,7 +1708,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.25",
+      "version": "0.2.27",
       "section": "pts-3-1-networking-and-service-mesh",
       "depends": [
         "bp-keycloak",
@@ -1778,7 +1778,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.34",
+      "version": "1.2.35",
       "section": "pts-3-5-storage-and-data",
       "depends": [
         "bp-cnpg",
@@ -1896,7 +1896,57 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.1.0",
+      "version": "1.2.1",
+      "section": "pts-3-5-storage-and-data",
+      "depends": [],
+      "shareable": false,
+      "contextSchema": null,
+      "producesInstances": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      },
+      "hasUserUIEndpoint": false
+    },
+    {
+      "id": "bp-huawei-evs-csi",
+      "slug": "huawei-evs-csi",
+      "title": "huawei-evs-csi",
+      "summary": "",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.0.3",
       "section": "pts-3-5-storage-and-data",
       "depends": [],
       "shareable": false,
@@ -2331,7 +2381,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.0.37",
+      "version": "1.0.39",
       "section": "pts-3-3-security-and-policy",
       "depends": [],
       "shareable": false,
@@ -2828,7 +2878,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.2.28",
+      "version": "0.2.29",
       "section": "pts-3-2-control-plane-isolation",
       "depends": [
         "bp-cilium",
@@ -3828,7 +3878,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "section": "pts-4-1-data-services",
       "depends": [
         "bp-cnpg",
@@ -3905,7 +3955,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.16",
+      "version": "1.2.17",
       "section": "pts-3-2-gitops-and-iac",
       "depends": [
         "bp-cert-manager"
@@ -3957,7 +4007,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-powerdns",
@@ -4161,7 +4211,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "section": "pts-3-2-control-plane-isolation",
       "depends": [
         "bp-cilium",
@@ -4329,7 +4379,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "section": "pts-3-5-storage-and-data",
       "depends": [
         "bp-cert-manager"
@@ -4647,7 +4697,7 @@
     {
       "id": "bp-stalwart-tenant",
       "slug": "stalwart-tenant",
-      "title": "Stalwart (per-tenant)",
+      "title": "Stalwart (per-Organization)",
       "summary": "|",
       "icon": "stalwart.svg",
       "category": "communication",
@@ -5454,14 +5504,14 @@
     {
       "id": "bp-wordpress-tenant",
       "slug": "wordpress-tenant",
-      "title": "WordPress Tenant",
+      "title": "WordPress (per-Organization)",
       "summary": "|",
       "icon": "wordpress.svg",
       "category": "tenant-app",
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "section": "pts-7-org-tenant",
       "depends": [
         "bp-postgres",

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-21T07:12:23.003Z",
+  "generatedAt": "2026-06-20T19:38:21.614Z",
   "blueprints": [
     {
       "id": "bp-alloy",
@@ -472,6 +472,48 @@
       "hasUserUIEndpoint": false
     },
     {
+      "id": "bp-chepherd",
+      "slug": "chepherd",
+      "title": "Chepherd",
+      "summary": "|",
+      "icon": "chepherd.svg",
+      "category": "ai-runtime",
+      "tagline": null,
+      "tags": [],
+      "visibility": "listed",
+      "version": "0.1.0",
+      "section": "pts-7-org-tenant",
+      "depends": [
+        "bp-external-secrets"
+      ],
+      "shareable": false,
+      "contextSchema": null,
+      "producesInstances": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": null,
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      },
+      "hasUserUIEndpoint": true
+    },
+    {
       "id": "bp-cilium",
       "slug": "cilium",
       "title": "Cilium",
@@ -916,7 +958,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.0",
+      "version": "1.1.5",
       "section": "pts-3-2-gitops-and-iac",
       "depends": [
         "bp-crossplane"
@@ -1036,7 +1078,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.2.9",
+      "version": "0.2.8",
       "section": "pts-3-1-networking-and-service-mesh",
       "depends": [
         "bp-cilium",
@@ -1536,7 +1578,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.40",
+      "version": "1.2.39",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-postgres"
@@ -1666,7 +1708,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.27",
+      "version": "0.2.25",
       "section": "pts-3-1-networking-and-service-mesh",
       "depends": [
         "bp-keycloak",
@@ -1736,7 +1778,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.35",
+      "version": "1.2.34",
       "section": "pts-3-5-storage-and-data",
       "depends": [
         "bp-cnpg",
@@ -1854,57 +1896,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.1",
-      "section": "pts-3-5-storage-and-data",
-      "depends": [],
-      "shareable": false,
-      "contextSchema": null,
-      "producesInstances": null,
-      "topology": {
-        "supported": [
-          "singleton"
-        ],
-        "multiRegion": "singleton",
-        "singleRegion": "singleton",
-        "perTopology": {
-          "singleton": {
-            "replication": null,
-            "switchover": null,
-            "placement": {
-              "tier": "",
-              "clusters": [
-                "mgmt-A",
-                "mgmt-B",
-                "dmz-A",
-                "dmz-B",
-                "rtz-A",
-                "rtz-B"
-              ],
-              "roles": {
-                "mgmt-A": "singleton",
-                "mgmt-B": "singleton",
-                "dmz-A": "singleton",
-                "dmz-B": "singleton",
-                "rtz-A": "singleton",
-                "rtz-B": "singleton"
-              }
-            }
-          }
-        }
-      },
-      "hasUserUIEndpoint": false
-    },
-    {
-      "id": "bp-huawei-evs-csi",
-      "slug": "huawei-evs-csi",
-      "title": "huawei-evs-csi",
-      "summary": "",
-      "icon": null,
-      "category": null,
-      "tagline": null,
-      "tags": [],
-      "visibility": "unlisted",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "section": "pts-3-5-storage-and-data",
       "depends": [],
       "shareable": false,
@@ -2339,7 +2331,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.0.39",
+      "version": "1.0.37",
       "section": "pts-3-3-security-and-policy",
       "depends": [],
       "shareable": false,
@@ -2836,7 +2828,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.2.29",
+      "version": "0.2.28",
       "section": "pts-3-2-control-plane-isolation",
       "depends": [
         "bp-cilium",
@@ -3836,7 +3828,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.5",
+      "version": "0.2.4",
       "section": "pts-4-1-data-services",
       "depends": [
         "bp-cnpg",
@@ -3913,7 +3905,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.17",
+      "version": "1.2.16",
       "section": "pts-3-2-gitops-and-iac",
       "depends": [
         "bp-cert-manager"
@@ -3965,7 +3957,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.18",
+      "version": "0.1.17",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-powerdns",
@@ -4169,7 +4161,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.2.14",
+      "version": "0.2.13",
       "section": "pts-3-2-control-plane-isolation",
       "depends": [
         "bp-cilium",
@@ -4337,7 +4329,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.3",
+      "version": "1.2.2",
       "section": "pts-3-5-storage-and-data",
       "depends": [
         "bp-cert-manager"
@@ -4655,7 +4647,7 @@
     {
       "id": "bp-stalwart-tenant",
       "slug": "stalwart-tenant",
-      "title": "Stalwart (per-Organization)",
+      "title": "Stalwart (per-tenant)",
       "summary": "|",
       "icon": "stalwart.svg",
       "category": "communication",
@@ -5462,14 +5454,14 @@
     {
       "id": "bp-wordpress-tenant",
       "slug": "wordpress-tenant",
-      "title": "WordPress (per-Organization)",
+      "title": "WordPress Tenant",
       "summary": "|",
       "icon": "wordpress.svg",
       "category": "tenant-app",
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.4.2",
+      "version": "0.4.1",
       "section": "pts-7-org-tenant",
       "depends": [
         "bp-postgres",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -628,7 +628,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "supported": [
         "singleton"
       ],
-      "multiRegion": null,
+      "multiRegion": "singleton",
       "singleRegion": "singleton",
       "perTopology": {
         "singleton": {

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -607,6 +607,48 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "hasUserUIEndpoint": false
   },
   {
+    "id": "bp-chepherd",
+    "slug": "chepherd",
+    "title": "Chepherd",
+    "summary": "|",
+    "icon": "chepherd.svg",
+    "category": "ai-runtime",
+    "tagline": null,
+    "tags": [],
+    "visibility": "listed",
+    "version": "0.1.0",
+    "section": "pts-7-org-tenant",
+    "depends": [
+      "bp-external-secrets"
+    ],
+    "shareable": false,
+    "contextSchema": null,
+    "producesInstances": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": null,
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    },
+    "hasUserUIEndpoint": true
+  },
+  {
     "id": "bp-cilium",
     "slug": "cilium",
     "title": "Cilium",
@@ -5702,6 +5744,7 @@ export const PLATFORM_BLUEPRINT_FILES: readonly string[] = [
   "platform/cert-manager-issuers/blueprint.yaml",
   "platform/cert-manager-powerdns-webhook/blueprint.yaml",
   "platform/cert-manager/blueprint.yaml",
+  "platform/chepherd/blueprint.yaml",
   "platform/cilium-policies/blueprint.yaml",
   "platform/cilium/blueprint.yaml",
   "platform/clickhouse/blueprint.yaml",

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -6466,4 +6466,80 @@ spec:
     maxPerOrg: 0
     namingTemplate: "{{ "{{" }}.AppName{{ "}}" }}-{{ "{{" }}.InstanceID{{ "}}" }}"
     isolationLevel: namespace
+---
+# bp-chepherd (#4010) — chepherd as an installable Application Blueprint.
+# A User installs this into their own Organization from the catalog, chats
+# with the built-in solo agent (Claude Opus 4.7, token pre-configured), and
+# the agent creates more Applications in the User's Org via the RBAC-scoped
+# openova MCP. The north-star self-service journey (UAT rows 218-223).
+# Lockstep with products/chepherd/blueprint.yaml spec.version 0.1.0 + the
+# published chart ghcr.io/openova-io/bp-chepherd:0.1.0.
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-chepherd
+  labels:
+    catalyst.openova.io/managed-by: catalog-seed
+    catalyst.openova.io/origin: openova-public
+    catalyst.openova.io/curation: openova-public
+    catalyst.openova.io/category: ai-runtime
+    catalyst.openova.io/section: pts-7-org-tenant
+    app.kubernetes.io/managed-by: {{ $managedBy }}
+    app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  version: "0.1.0"
+  visibility: listed
+  card:
+    title: "Chepherd"
+    category: ai-runtime
+    family: agent-runtime
+    summary: "Your AI engineering team — chat with a built-in solo agent (Claude Opus 4.7) that creates Applications in your Organization for you."
+    description: "Install chepherd into your Organization and chat with its solo agent (Claude Opus 4.7, token pre-configured). The agent reaches the OpenOva MCP — scoped to exactly what you can do in the console — to create and manage Applications in YOUR Organization on your behalf."
+    icon: chepherd.svg
+    license: "MIT"
+    tags: [chepherd, agent, multi-agent, claude, opus, mcp, self-service]
+    docs: "https://github.com/chepherd/chepherd"
+  placementSchema:
+    modes: [single-region]
+    default: single-region
+  manifests:
+    chart: bp-chepherd
+  source:
+    kind: HelmRepository
+    type: oci
+    url: oci://ghcr.io/openova-io
+    chart: bp-chepherd
+    version: 0.1.0
+  topology:
+    supported:
+      - singleton
+    defaults:
+      single-region: singleton
+    perTopology:
+      singleton:
+        placement:
+          tier: rtz
+          clusters: [rtz-A]
+          roles:
+            rtz-A: singleton
+  endpoints:
+    - name: console
+      hostnameTemplate: "chepherd.{{ "{{" }}.OrgSlug{{ "}}" }}.{{ "{{" }}.SovereignFQDN{{ "}}" }}"
+      port: 443
+      protocol: https
+      tls: true
+      visibility: public
+      launchDefault: true
+      ssoEnabled: true
+  sso:
+    realm: "{{ "{{" }}.OrgSlug{{ "}}" }}"
+    protocolMapper: oidc
+    groupsClaim: groups
+    rolesFromGroup:
+      sovereign-admins: admin
+    silentLogin: true
+  multiInstance:
+    enabled: false
 {{- end }}

--- a/products/chepherd/Containerfile
+++ b/products/chepherd/Containerfile
@@ -12,7 +12,7 @@
 # its go workspace). CHEPHERD_BASE pins the upstream chepherd daemon image.
 #
 #   docker build -f products/chepherd/Containerfile \
-#     --build-arg CHEPHERD_BASE=ghcr.io/chepherd/chepherd:v0.9.4 \
+#     --build-arg CHEPHERD_BASE=ghcr.io/chepherd/chepherd:v0.9.4@sha256:b6f0c43b63b8933bfaad8cf09366642e63656d9664887eab20eac26e96d28b82 \
 #     -t ghcr.io/openova-io/bp-chepherd:dev .
 
 # ─── Stage 1: build the openova-mcp binary ────────────────────────────────
@@ -27,7 +27,9 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-s -w" \
     -o /usr/local/bin/openova-mcp ./cmd/openova-mcp
 
 # ─── Stage 2: overlay onto the upstream chepherd image ────────────────────
-ARG CHEPHERD_BASE=ghcr.io/chepherd/chepherd:v0.9.4
+# Digest-pinned to the v0.9.4 build carrying the bp-chepherd MCP seam
+# (chepherd #747 / #4010: CHEPHERD_EXTRA_MCP_JSON + CHEPHERD_DEFAULT_MODEL).
+ARG CHEPHERD_BASE=ghcr.io/chepherd/chepherd:v0.9.4@sha256:b6f0c43b63b8933bfaad8cf09366642e63656d9664887eab20eac26e96d28b82
 FROM ${CHEPHERD_BASE}
 
 # Bake the openova-mcp binary in at the path the chart's

--- a/products/chepherd/Containerfile
+++ b/products/chepherd/Containerfile
@@ -1,0 +1,38 @@
+# bp-chepherd image — chepherd runtime + the bundled openova-mcp binary.
+#
+# The bp-chepherd Application image is the upstream chepherd daemon image
+# with OpenOva's `openova-mcp` server binary baked in at
+# /usr/local/bin/openova-mcp. chepherd injects this MCP server into every
+# spawned agent's .mcp.json (via CHEPHERD_EXTRA_MCP_JSON, set by the
+# bp-chepherd Helm chart), so the User's solo agent (Claude Opus 4.7) can
+# create Applications in the User's own Organization through the
+# RBAC-scoped OpenOva MCP.
+#
+# Build context = the repo root (the build needs products/openova-mcp and
+# its go workspace). CHEPHERD_BASE pins the upstream chepherd daemon image.
+#
+#   docker build -f products/chepherd/Containerfile \
+#     --build-arg CHEPHERD_BASE=ghcr.io/chepherd/chepherd:v0.9.4 \
+#     -t ghcr.io/openova-io/bp-chepherd:dev .
+
+# ─── Stage 1: build the openova-mcp binary ────────────────────────────────
+FROM golang:1.25-alpine AS mcp-builder
+WORKDIR /build
+# The openova-mcp module imports core/services/shared/auth from this repo,
+# so the build needs both module trees. Copy the whole repo (build context
+# is the repo root) and build from the module directory.
+COPY . .
+WORKDIR /build/products/openova-mcp
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-s -w" \
+    -o /usr/local/bin/openova-mcp ./cmd/openova-mcp
+
+# ─── Stage 2: overlay onto the upstream chepherd image ────────────────────
+ARG CHEPHERD_BASE=ghcr.io/chepherd/chepherd:v0.9.4
+FROM ${CHEPHERD_BASE}
+
+# Bake the openova-mcp binary in at the path the chart's
+# CHEPHERD_EXTRA_MCP_JSON stanza references (openovaMCP.binaryPath).
+COPY --from=mcp-builder /usr/local/bin/openova-mcp /usr/local/bin/openova-mcp
+
+# The chepherd image already defines its ENTRYPOINT (chepherd-entrypoint)
+# and EXPOSEs 8080/9090; bp-chepherd inherits them unchanged.

--- a/products/chepherd/README.md
+++ b/products/chepherd/README.md
@@ -1,0 +1,107 @@
+# bp-chepherd — chepherd as an OpenOva Application Blueprint (#4010)
+
+**What it is.** [chepherd](https://github.com/chepherd/chepherd) is a
+multi-agent runtime + dashboard. **bp-chepherd** packages it as an
+installable OpenOva **Application Blueprint**: a User installs it into their
+own **Organization** from the catalog, then chats with its built-in **solo
+agent** (Claude Opus 4.7, token pre-configured). The agent reaches the
+**OpenOva MCP** — scoped to exactly what that User can do in the console —
+to **create more Applications in the User's own Organization** on the User's
+behalf.
+
+**Role in Catalyst.** An **Application Blueprint** (not control plane). It
+installs into an Organization's Environment like any other catalog app, and
+is the missing piece of the north-star self-service journey
+([`docs/ledger/UAT.md`](../../docs/ledger/UAT.md) rows 218–223):
+coupon → Org → passwordless PIN → install chepherd → chat solo-agent →
+agent creates apps via the MCP.
+
+See [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md) for where Blueprints
+sit in the model and [`docs/GLOSSARY.md`](../../docs/GLOSSARY.md) for the
+Organization / Application / Blueprint canon.
+
+## The journey this enables (UAT 218–223)
+
+1. A User, signed into their Org (passwordless 6-digit PIN), opens the
+   catalog and installs **Chepherd** (this Helm chart).
+2. The Application provisions: a `StatefulSet` running `chepherd run
+   --headless`, a `Service`, an `HTTPRoute` at
+   `chepherd.<org>.<sovereign-fqdn>`, CSI-backed PVCs.
+3. The User opens the chepherd console and **chats** with the solo agent —
+   Claude **Opus 4.7**, whose Anthropic token is already wired from a Secret.
+4. The User asks the agent to "install WordPress in my org". The agent calls
+   the **`create_application`** tool on the **openova MCP**, which forwards
+   the User's session bearer to the live catalyst-api `POST
+   /api/v1/sovereigns/{id}/applications`. RBAC-scoped: the tool is
+   tier-admin-gated and the target Org is **pinned to the User's own Org** —
+   the agent can never create apps in another Organization.
+5. A new Application appears in the User's Org, created by the agent.
+
+## How the solo agent is wired
+
+| Concern | Wiring |
+|---|---|
+| **Model = Claude Opus 4.7** | `agent.model: claude-opus-4-7` → `CHEPHERD_DEFAULT_MODEL` env → chepherd passes `--model claude-opus-4-7` to the spawned `claude-code` (chepherd #4010 default-model fallback). |
+| **Anthropic token (pre-configured)** | `ANTHROPIC_API_KEY` env sourced from the `chepherd-anthropic-token` **Secret** (an `ExternalSecret` pulls `sk-ant-…` from the Org's openbao by default — **never hardcoded**, per Inviolable Principle #4). chepherd seeds its vault `anthropic-api` provider from this env; the agent inherits it at spawn. |
+| **Solo (no supervisor)** | `agent.solo: true` → `chepherd run --no-shepherd` — a single worker agent the User chats 1:1 with. |
+| **openova MCP** | `CHEPHERD_EXTRA_MCP_JSON` (set by the chart) merges an `openova` MCP-server stanza into **every** spawned agent's `.mcp.json` (chepherd #4010 merge seam), pointing at the bundled `/usr/local/bin/openova-mcp` binary. The MCP holds **no privileged token** — it forwards the caller's session bearer to the live catalyst-api, so the endpoint's own authz is the final word. |
+
+## openova MCP — RBAC-scoped app creation
+
+The agent's app-creation tool is the **`create_application`** tool added to
+[`products/openova-mcp`](../openova-mcp/README.md) (#4010 — the first
+write/mutating MCP tool):
+
+- **Tier-gated** (`MinTier=admin`) mirroring the endpoint's
+  `applicationInstallCallerAuthorized` (tier-admin/owner/sovereign-admin), so
+  a viewer/developer agent never even *sees* the tool.
+- **Org-pinned** — in Organization context the `organizationRef` is forced to
+  the caller's own Org; an attempt to point the environment at another Org is
+  denied (`ErrForbidden`).
+- **Parity** — the MCP surfaces the upstream catalyst-api status verbatim
+  (incl. 403), so the agent's reach == the User's console reach.
+
+## Configuration knobs (`configSchema` highlights)
+
+| Knob | Default | Notes |
+|---|---|---|
+| `agent.model` | `claude-opus-4-7` | The Claude model the solo agent runs on. |
+| `agent.solo` | `true` | Single solo agent (no shepherd). |
+| `anthropic.secretName` | `chepherd-anthropic-token` | Secret holding `sk-ant-…`. |
+| `anthropic.externalSecret.enabled` | `true` | Pull the token from openbao via ESO; set `false` to pre-create the Secret out-of-band. |
+| `openovaMCP.enabled` | `true` | Inject the openova MCP into spawned agents. |
+| `openovaMCP.context` | `organization` | Pins the MCP to the User's Org (defense in depth). |
+| `persistence.state.size` | `5Gi` | chepherd runtime-state PVC (CSI default class — **local-path forbidden**, #3971). |
+
+## Image
+
+`ghcr.io/openova-io/bp-chepherd` is the **upstream chepherd daemon image**
+with the **`openova-mcp`** binary baked in at `/usr/local/bin/openova-mcp`
+(see [`Containerfile`](Containerfile) + the
+[`chepherd-build.yaml`](../../.github/workflows/chepherd-build.yaml) workflow).
+The build context is the repo root because the openova-mcp module imports
+`core/services/shared/auth` from this repo. `CHEPHERD_BASE` pins the upstream
+chepherd daemon image the binary overlays.
+
+## Operational notes
+
+- **Storage**: state + per-agent repo PVCs use the cluster's **default CSI
+  StorageClass** (leave `storageClass` empty). Never local-path (#3971).
+- **Backups**: the chepherd state PVC holds session history + the credential
+  vault; back it up with the Org's standard PVC backup policy.
+- **Multi-region**: single-region `singleton` only — chepherd is a
+  per-Org control surface, not a replicated data plane.
+- **Auth**: the chepherd console is reached via the Cilium Gateway HTTPRoute
+  with the Org's Keycloak SSO (silent login). The agent presents the User's
+  session bearer to the openova MCP on each `tools/call`.
+
+## What the fresh-prov walk should see
+
+The full live e2e walk runs in the orchestrator's wipe → prov → walk loop.
+On a fresh prov, after a User installs bp-chepherd:
+
+1. `kubectl -n <org>-prod get statefulset,svc,httproute,externalsecret -l catalyst.openova.io/blueprint=bp-chepherd` → all present; the StatefulSet pod becomes `Ready` (`/healthz` 200).
+2. The chepherd pod env carries `CHEPHERD_DEFAULT_MODEL=claude-opus-4-7`, `ANTHROPIC_API_KEY` (from the Secret), and `CHEPHERD_EXTRA_MCP_JSON` with the `openova` server stanza.
+3. The chepherd console loads at `chepherd.<org>.<sovereign-fqdn>` (SSO).
+4. Spawning the solo agent → its `.mcp.json` lists **both** `chepherd` and `openova` MCP servers, and the agent was launched with `--model claude-opus-4-7`.
+5. Asking the agent to install an app → a new `Application` CR appears in the User's Org namespace, created via the openova MCP `create_application` tool (tier-admin-gated, Org-pinned).

--- a/products/chepherd/blueprint.yaml
+++ b/products/chepherd/blueprint.yaml
@@ -122,6 +122,10 @@ spec:
     supported:
       - singleton
     defaults:
+      # chepherd is a region-pinned singleton coordinator/agent console — it
+      # does not replicate across regions, so both BCP defaults resolve to the
+      # single in-region instance (schema requires both keys; G116).
+      multi-region: singleton
       single-region: singleton
     perTopology:
       singleton:

--- a/products/chepherd/blueprint.yaml
+++ b/products/chepherd/blueprint.yaml
@@ -1,0 +1,151 @@
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: bp-chepherd
+  labels:
+    catalyst.openova.io/category: ai-runtime
+    catalyst.openova.io/section: pts-7-org-tenant
+spec:
+  version: 0.1.0
+  card:
+    title: Chepherd
+    summary: |
+      Your AI engineering team — a multi-agent runtime + dashboard you
+      install into your own Organization. Chat with the built-in solo
+      agent (Claude Opus 4.7, token pre-configured); it creates and
+      manages Applications in YOUR Organization on your behalf through the
+      OpenOva MCP, scoped to exactly what you can do in the console.
+    icon: chepherd.svg
+    category: ai-runtime
+    family: agent-runtime
+    tags: [chepherd, agent, multi-agent, claude, opus, mcp, self-service]
+    documentation: https://github.com/chepherd/chepherd
+    license: MIT
+  visibility: listed
+  owner:
+    team: ai-platform
+    contact: ai-platform@openova.io
+  configSchema:
+    type: object
+    properties:
+      agent:
+        type: object
+        description: The solo agent the User chats with.
+        properties:
+          model:
+            type: string
+            default: claude-opus-4-7
+            description: |
+              The Claude model the solo agent runs on. The north-star
+              journey ships Claude Opus 4.7 ("token already configured").
+            enum:
+              - claude-opus-4-7
+              - claude-opus-4-8
+              - claude-sonnet-4-6
+          solo:
+            type: boolean
+            default: true
+            description: |
+              true = a single solo agent (no shepherd/supervisor) — the
+              1:1 chat journey. false = also spawn a shepherd watcher.
+          systemPrompt:
+            type: string
+            default: ""
+            description: Optional system prompt the solo agent boots with.
+      anthropic:
+        type: object
+        description: |
+          Anthropic API token wiring. The token is read from a Kubernetes
+          Secret (ExternalSecret/openbao by default) — never entered here.
+        properties:
+          secretName:
+            type: string
+            default: chepherd-anthropic-token
+          externalSecret:
+            type: object
+            properties:
+              enabled:
+                type: boolean
+                default: true
+                description: |
+                  true = pull the sk-ant-... token from the Org's openbao
+                  via an ExternalSecret. false = the operator pre-creates
+                  the Secret out-of-band (e.g. a sealed-secret).
+      openovaMCP:
+        type: object
+        description: |
+          Wires the solo agent to the OpenOva MCP server so it can create
+          Applications in the User's own Organization, RBAC-scoped to the
+          User's rights (the MCP forwards the caller's session bearer to
+          the live catalyst-api; the endpoint's authz is the final word).
+        properties:
+          enabled:
+            type: boolean
+            default: true
+          context:
+            type: string
+            enum: [organization, sovereign]
+            default: organization
+            description: |
+              Pins the MCP to the Organization context so the agent can
+              only act within the User's own Org (defense in depth).
+      persistence:
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: true
+          state:
+            type: object
+            properties:
+              size:
+                type: string
+                default: 5Gi
+            description: |
+              chepherd runtime state PVC. Backed by the cluster's default
+              CSI StorageClass — local-path is forbidden (#3971).
+  placementSchema:
+    modes: [single-region]
+    default: single-region
+  manifests:
+    chart: ./chart
+  depends:
+    - blueprint: bp-external-secrets
+      version: ^1.0
+      alias: eso
+  upgrades:
+    from: ["0.x"]
+  observability:
+    metrics: prometheus
+    logs: stdout
+  topology:
+    supported:
+      - singleton
+    defaults:
+      single-region: singleton
+    perTopology:
+      singleton:
+        placement:
+          tier: rtz
+          clusters:
+            - rtz-A
+          roles:
+            rtz-A: singleton
+  endpoints:
+    - name: console
+      hostnameTemplate: chepherd.{{.OrgSlug}}.{{.SovereignFQDN}}
+      port: 443
+      protocol: https
+      tls: true
+      visibility: public
+      launchDefault: true
+      ssoEnabled: true
+  sso:
+    realm: '{{.OrgSlug}}'
+    protocolMapper: oidc
+    groupsClaim: groups
+    rolesFromGroup:
+      sovereign-admins: admin
+    silentLogin: true
+  multiInstance:
+    enabled: false

--- a/products/chepherd/chart/Chart.yaml
+++ b/products/chepherd/chart/Chart.yaml
@@ -1,0 +1,32 @@
+apiVersion: v2
+name: bp-chepherd
+description: |
+  Chepherd — multi-agent runtime + dashboard, packaged as an installable
+  OpenOva Application Blueprint. A User installs chepherd into their own
+  Organization from the catalog, then chats with its solo agent (Claude
+  Opus 4.7, token pre-configured). The agent reaches the openova MCP server
+  (RBAC-scoped to the User's rights) to create more Applications in the
+  User's own Organization — the north-star self-service journey.
+type: application
+version: 0.1.0
+appVersion: "0.9.4"
+keywords:
+  - chepherd
+  - agent-runtime
+  - multi-agent
+  - solo-agent
+  - openova-blueprint
+maintainers:
+  - name: OpenOva
+    url: https://github.com/openova-io/openova
+sources:
+  - https://github.com/chepherd/chepherd
+  - https://github.com/openova-io/openova
+# Opt out of the hollow-chart guard (Blueprint-Release workflow / issue #181):
+# this is a product chart deploying a single upstream image (chepherd) with
+# Catalyst-authored resources (StatefulSet + Service + HTTPRoute + MCP
+# ConfigMap + ExternalSecret). No bundled upstream Helm subchart — same
+# shape as products/axon (PR), bp-continuum, bp-kyverno-policies.
+annotations:
+  catalyst.openova.io/no-upstream: "true"
+  openova.io/blueprint-type: thirdparty

--- a/products/chepherd/chart/templates/_helpers.tpl
+++ b/products/chepherd/chart/templates/_helpers.tpl
@@ -1,0 +1,34 @@
+{{/* chart name */}}
+{{- define "chepherd.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* fully-qualified name */}}
+{{- define "chepherd.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* common labels */}}
+{{- define "chepherd.labels" -}}
+app.kubernetes.io/name: {{ include "chepherd.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+catalyst.openova.io/blueprint: bp-chepherd
+{{- end -}}
+
+{{/* selector labels */}}
+{{- define "chepherd.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chepherd.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/* image ref */}}
+{{- define "chepherd.image" -}}
+{{- printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) -}}
+{{- end -}}

--- a/products/chepherd/chart/templates/externalsecret-anthropic.yaml
+++ b/products/chepherd/chart/templates/externalsecret-anthropic.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.anthropic.externalSecret.enabled (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1") }}
+# Anthropic API token for the solo agent — pulled from the Org's openbao
+# into the K8s Secret the StatefulSet consumes. The sk-ant-... value is
+# NEVER written into the chart (Inviolable Principle #4 / SECURITY.md).
+#
+# ESO-CRD guard (gold standard: bp-openbao sso-oauth-source-externalsecret):
+# without the Capabilities check, installing on a cluster where the
+# external-secrets.io CRDs are not yet established fails at manifest-build
+# time and wedges the install. With the guard, the resource is omitted
+# until the next Flux reconcile re-renders once the CRD exists.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.anthropic.secretName }}
+  labels:
+    {{- include "chepherd.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.anthropic.externalSecret.refreshInterval }}
+  secretStoreRef:
+    name: {{ .Values.anthropic.externalSecret.secretStoreRef }}
+    kind: {{ .Values.anthropic.externalSecret.secretStoreKind }}
+  target:
+    name: {{ .Values.anthropic.secretName }}
+    creationPolicy: Owner
+  data:
+    - secretKey: {{ .Values.anthropic.secretKey }}
+      remoteRef:
+        key: {{ .Values.anthropic.externalSecret.remoteKey }}
+        property: {{ .Values.anthropic.externalSecret.remoteProperty }}
+{{- end }}

--- a/products/chepherd/chart/templates/httproute.yaml
+++ b/products/chepherd/chart/templates/httproute.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.httpRoute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "chepherd.fullname" . }}
+  labels:
+    {{- include "chepherd.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ .Values.httpRoute.parentRef.name }}
+      namespace: {{ .Values.httpRoute.parentRef.namespace }}
+  {{- if .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml .Values.httpRoute.hostnames | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "chepherd.fullname" . }}
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/products/chepherd/chart/templates/service.yaml
+++ b/products/chepherd/chart/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "chepherd.fullname" . }}
+  labels:
+    {{- include "chepherd.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "chepherd.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+    - name: metrics
+      port: {{ .Values.service.metricsPort }}
+      targetPort: metrics

--- a/products/chepherd/chart/templates/statefulset.yaml
+++ b/products/chepherd/chart/templates/statefulset.yaml
@@ -1,0 +1,174 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "chepherd.fullname" . }}
+  labels:
+    {{- include "chepherd.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "chepherd.fullname" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "chepherd.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "chepherd.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: chepherd
+          image: {{ include "chepherd.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - run
+            - --headless          # Pod mode: no TUI, runtime + WS + MCP HTTP
+            - --listen
+            - "0.0.0.0:{{ .Values.service.port }}"
+            {{- if .Values.agent.solo }}
+            - --no-shepherd       # solo: a single worker agent, no supervisor
+            {{- end }}
+            - --agent
+            - {{ .Values.agent.flavor | quote }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+            - name: metrics
+              containerPort: {{ .Values.service.metricsPort }}
+          env:
+            # ── Solo-agent model — NORTH STAR: Claude Opus 4.7 ──────────────
+            # chepherd passes this as `--model` to the spawned claude-code so
+            # the User's solo agent runs on Opus 4.7.
+            - name: CHEPHERD_DEFAULT_MODEL
+              value: {{ .Values.agent.model | quote }}
+            {{- if .Values.agent.systemPrompt }}
+            - name: CHEPHERD_DEFAULT_SYSTEM_PROMPT
+              value: {{ .Values.agent.systemPrompt | quote }}
+            {{- end }}
+            # ── Anthropic API token (from Secret — never hardcoded) ─────────
+            # chepherd seeds its vault `anthropic-api` provider from this env;
+            # the spawned agent inherits ANTHROPIC_API_KEY at spawn time.
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.anthropic.secretName }}
+                  key: {{ .Values.anthropic.secretKey }}
+            {{- if .Values.openovaMCP.enabled }}
+            # ── openova MCP injection seam (chepherd #4010) ─────────────────
+            # chepherd merges this JSON into every spawned agent's .mcp.json,
+            # so the solo agent discovers the `openova` MCP server alongside
+            # chepherd's own. The agent then calls create_application etc. on
+            # the User's Org, RBAC-scoped (the openova MCP forwards the
+            # caller's session bearer to the live catalyst-api).
+            - name: CHEPHERD_EXTRA_MCP_JSON
+              value: |-
+                {"mcpServers":{"openova":{
+                  "command":{{ .Values.openovaMCP.binaryPath | quote }},
+                  "env":{
+                    "OPENOVA_MCP_CATALYST_API_URL":{{ .Values.openovaMCP.catalystApiUrl | quote }},
+                    "OPENOVA_MCP_CONTEXT":{{ .Values.openovaMCP.context | quote }},
+                    "OPENOVA_MCP_VERIFY":{{ .Values.openovaMCP.verify | quote }},
+                    "OPENOVA_MCP_RS256_PUBKEY_PEM":"$(OPENOVA_MCP_RS256_PUBKEY_PEM)"
+                  }
+                }}}
+            {{- if eq .Values.openovaMCP.verify "rs256" }}
+            # The RS256 public key the MCP verifies caller bearers against,
+            # reflected from the Sovereign's handover-jwt secret. Surfaced as
+            # an env var so the EXTRA_MCP_JSON above can $(…)-expand it into
+            # the per-agent MCP server stanza.
+            - name: OPENOVA_MCP_RS256_PUBKEY_PEM
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.openovaMCP.rs256PubkeySecret.name }}
+                  key: {{ .Values.openovaMCP.rs256PubkeySecret.key }}
+            {{- end }}
+            {{- end }}
+            - name: CHEPHERD_STATE_DIR
+              value: /var/chepherd/state
+          volumeMounts:
+            - name: state
+              mountPath: /var/chepherd/state
+            - name: repo
+              mountPath: /var/chepherd/repo
+            {{- if .Values.podman.inPod }}
+            - name: fuse
+              mountPath: /dev/fuse
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.podman.inPod }}
+          securityContext:
+            # rootless podman-in-pod needs the SYS_ADMIN cap + device access
+            # for the ContainerRuntime that hosts per-agent claude REPLs.
+            seccompProfile:
+              type: Unconfined
+            capabilities:
+              add: ["SYS_ADMIN"]
+          {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 15
+      volumes:
+        {{- if not .Values.persistence.enabled }}
+        - name: state
+          emptyDir: {}
+        - name: repo
+          emptyDir: {}
+        {{- end }}
+        {{- if .Values.podman.inPod }}
+        - name: fuse
+          hostPath:
+            path: /dev/fuse
+            type: CharDevice
+        {{- end }}
+  {{- if .Values.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: state
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: {{ .Values.persistence.state.size }}
+        {{- if .Values.persistence.state.storageClass }}
+        storageClassName: {{ .Values.persistence.state.storageClass }}
+        {{- end }}
+    - metadata:
+        name: repo
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: {{ .Values.persistence.repo.size }}
+        {{- if .Values.persistence.repo.storageClass }}
+        storageClassName: {{ .Values.persistence.repo.storageClass }}
+        {{- end }}
+  {{- end }}

--- a/products/chepherd/chart/values.yaml
+++ b/products/chepherd/chart/values.yaml
@@ -1,0 +1,130 @@
+# bp-chepherd — default values
+#
+# Deploys chepherd as an OpenOva Application into a User's Organization /
+# Environment. The User installs this from the catalog; its solo agent
+# (Claude Opus 4.7) then creates more Applications in the User's own Org
+# via the RBAC-scoped openova MCP server.
+#
+# Inviolable Principle #4: no hardcoded secrets/config in code — every knob
+# flows through values → env → the chepherd binary; the Anthropic token
+# comes from a Secret (ExternalSecret/openbao), NEVER a literal here.
+
+# ── chepherd runtime image ────────────────────────────────────────────────
+image:
+  repository: ghcr.io/openova-io/bp-chepherd
+  tag: ""                 # defaults to .Chart.AppVersion
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# ── Solo-agent profile ────────────────────────────────────────────────────
+# chepherd boots with a single solo worker agent the User chats with. The
+# journey requires Claude Opus 4.7: `agent.model` is passed to the spawned
+# claude-code as `--model`, so the agent runs on Opus 4.7.
+agent:
+  flavor: claude-code      # the spawned agent CLI flavor
+  model: claude-opus-4-7   # NORTH-STAR: the solo agent runs on Claude Opus 4.7
+  # Optional system-prompt the solo agent boots with. Empty = chepherd default.
+  systemPrompt: ""
+  # When true, NO shepherd/supervisor is spawned — a single solo agent only
+  # (matches the catalog/solo recipe). The journey is a 1:1 chat with one agent.
+  solo: true
+
+# ── Anthropic API token (the "token already configured" requirement) ──────
+# The solo agent authenticates to Anthropic with this token. It is sourced
+# from a Kubernetes Secret — sk-ant-... is NEVER written into the chart.
+# Two delivery modes:
+#   externalSecret.enabled=true (default, production): an ExternalSecret
+#     pulls the key from openbao (path `anthropic/<org>`) into the Secret.
+#   externalSecret.enabled=false: the operator pre-creates a Secret named
+#     `secretName` with key `anthropicApiKey` out-of-band (e.g. sealed-secret).
+anthropic:
+  secretName: chepherd-anthropic-token
+  secretKey: anthropicApiKey
+  externalSecret:
+    enabled: true
+    refreshInterval: 1h
+    # ClusterSecretStore that fronts the Org's openbao (region1 default).
+    secretStoreRef: vault-region1
+    secretStoreKind: ClusterSecretStore
+    # openbao path + property holding the sk-ant-... token.
+    remoteKey: anthropic/token
+    remoteProperty: apiKey
+
+# ── openova MCP integration ───────────────────────────────────────────────
+# The chepherd image bundles the `openova-mcp` binary at /usr/local/bin.
+# chepherd injects this MCP-server stanza into EVERY spawned agent's
+# .mcp.json via the CHEPHERD_EXTRA_MCP_JSON seam (chepherd #4010), so the
+# solo agent's app-creation tools == the User's UI rights, RBAC-scoped to
+# the User's Org.
+#
+# RBAC parity: the openova MCP holds NO privileged token; it forwards the
+# caller's session bearer to the live catalyst-api, whose own authz is the
+# final word. The bearer is presented per-call by the agent (the chat UI
+# supplies the User's session token), so create_application is gated to
+# tier-admin-or-higher and pinned to the User's own Org.
+openovaMCP:
+  enabled: true
+  binaryPath: /usr/local/bin/openova-mcp
+  # In-cluster catalyst-api the MCP forwards calls to. On a Sovereign this
+  # is the per-Org catalyst-api Service; the gateway terminates session auth.
+  catalystApiUrl: http://catalyst-api.catalyst-system.svc
+  # Pins the MCP to the Organization context so even a wider token cannot
+  # widen the surface beyond the User's Org (defense in depth).
+  context: organization
+  # Bearer verification mode for the MCP (rs256 against the Sovereign
+  # handover pubkey by default). The pubkey is reflected in from the
+  # catalyst handover-jwt secret.
+  verify: rs256
+  rs256PubkeySecret:
+    name: catalyst-handover-jwt
+    key: handover-jwt-public.pem
+
+# ── Service (chepherd web UI + dashboard WS + MCP) ────────────────────────
+service:
+  type: ClusterIP
+  port: 8080            # chepherd web UI + dashboard WS + MCP HTTP
+  metricsPort: 9090     # Prometheus scrape
+
+# ── HTTPRoute (Cilium Gateway) — the User reaches the chepherd console ─────
+httpRoute:
+  enabled: true
+  hostnames: []         # default: discovered from the Org/Sovereign FQDN
+  parentRef:
+    name: catalyst-gateway
+    namespace: catalyst-system
+
+# ── Persistence — chepherd runtime state + per-agent repo/cache ───────────
+# CSI-backed PVCs. storageClass empty = the cluster's default CSI class.
+# NEVER local-path (#3971): leaving storageClass empty resolves to the
+# per-provider CSI default the platform installs.
+persistence:
+  enabled: true
+  state:
+    size: 5Gi
+    storageClass: ""    # "" = cluster default CSI class (NEVER local-path)
+  repo:
+    size: 10Gi
+    storageClass: ""
+
+# ── Resources ─────────────────────────────────────────────────────────────
+# chepherd itself is a light coordinator; the per-agent claude REPLs are the
+# heavy users and run as sidecar/podman children inside the pod.
+resources:
+  requests:
+    cpu: 200m
+    memory: 512Mi
+  limits:
+    cpu: "2"
+    memory: 4Gi
+
+# ── Pod security / scheduling ─────────────────────────────────────────────
+podAnnotations: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# rootless podman-in-pod needs /dev/fuse + relaxed seccomp; gated so a
+# locked-down cluster can disable the in-pod spawner and use an external one.
+podman:
+  inPod: true


### PR DESCRIPTION
## bp-chepherd — chepherd as an installable Application + the openova-mcp `create_application` write tool

Refs #4010 #3988. Builds the north-star self-service journey's missing piece (UAT rows 218–223): a User installs chepherd into their own Org, chats with the solo agent (Claude **Opus 4.7**, token pre-configured), and the agent creates Applications in the User's Org via the **RBAC-scoped openova MCP**.

### What's here (openova side)

**`products/chepherd/` — the bp-chepherd Blueprint**
- **chart/** — `StatefulSet` (`chepherd run --headless`, `--no-shepherd` solo, model pinned to `claude-opus-4-7` via `CHEPHERD_DEFAULT_MODEL`), `Service`, `HTTPRoute` at `chepherd.<org>.<sovereign-fqdn>`, per-Org **CSI** PVCs (`storageClass:""` = default CSI class, **never local-path** per #3971), and an **ExternalSecret** for the Anthropic token (openbao→ESO, **never hardcoded**, CRD-capability guarded — the bp-openbao gold-standard pattern).
- **blueprint.yaml + configSchema + README** — canonical `catalyst.openova.io/v1alpha1` Blueprint: model knob, solo toggle, openova-MCP context pin, `endpoints` + `sso` (silent login).
- **Containerfile + `.github/workflows/chepherd-build.yaml`** — the `ghcr.io/openova-io/bp-chepherd` image = the upstream chepherd daemon image with the `openova-mcp` binary baked in at `/usr/local/bin/openova-mcp` (build context = repo root for the `core/services/shared/auth` import).
- The chart sets **`CHEPHERD_EXTRA_MCP_JSON`** so chepherd merges the `openova` MCP server into every spawned agent's `.mcp.json`.

**`products/openova-mcp/` — `create_application` (the FIRST write/mutating MCP tool)**
- Thin facade over `POST /api/v1/sovereigns/{id}/applications` (`HandleApplicationInstall`).
- **`MinTier=admin`** mirrors `applicationInstallCallerAuthorized` (tier-admin/owner/sovereign-admin) — a viewer/developer agent never even *sees* it.
- In Org context **`organizationRef` is pinned to the caller's own Org** — the agent cannot create cross-Org. The endpoint's `configSchema` validation + tier re-check are the final word; upstream status (incl. 403) surfaces verbatim (parity).
- `catalystapi.InstallApplication` + a shared `do()` POST path forwarding the caller's bearer (Authorization header + `catalyst_session` cookie).
- Tests: tier-gated (layer-1 list filter + layer-2 re-auth), Org-pinned create, cross-Org denied, 403 parity. `go build/vet/test` green.

**Catalog registration** — bp-chepherd seeded as a **listed** card in `catalog-seed/blueprints.yaml`; `blueprints.json` / `catalog.generated.ts` regenerated from the new `products/chepherd/blueprint.yaml` (93 blueprints, additive).

### Gates
- `helm lint` + `helm template` all modes (ESO present/absent, MCP on/off, persistence on/off, podman on/off) render clean; `CHEPHERD_EXTRA_MCP_JSON` renders as **valid JSON** pinned to `organization` context; the full catalyst chart still renders.
- openova-mcp `go build && go vet && go test ./...` green (incl. 4 new create_application tests).

### Coupled chepherd change — MERGED + daemon image published
The chepherd-side seam (`CHEPHERD_EXTRA_MCP_JSON` merge + `CHEPHERD_DEFAULT_MODEL` fallback) is **merged to chepherd `main`** as the isolated **chepherd PR #747** (merge SHA `8bf3c2e32bfee737ab7d1262f9bb32ffe6bb3df2`). The tangled original branch (#746, ~40 commits of unrelated mixed-team work) was superseded by the clean 2-file cherry-pick.

The chepherd daemon image carrying the seam is **published + cosign-signed**:
- `ghcr.io/chepherd/chepherd:v0.9.4`
- digest `sha256:b6f0c43b63b8933bfaad8cf09366642e63656d9664887eab20eac26e96d28b82`

This PR's `CHEPHERD_BASE` is now **digest-pinned** to that exact image (Containerfile + `chepherd-build.yaml`). (chepherd's `release-images.yml` was also fixed — a yanked `setup-trivy` action ref had broken every daemon publish; chepherd PR #748.)

### ⛔ DO NOT MERGE until hw174 converges
This PR touches the catalog + catalyst-api seed; merging fires the deploy-bot and **rolls the mothership**, which would abandon the in-flight hw174 prov. Leave OPEN, rebased on `main`, image pin updated, green — ready for the orchestrator to merge **after** hw174 converges. On merge, `chepherd-build.yaml` publishes `ghcr.io/openova-io/bp-chepherd:0.9.4` overlaying the pinned daemon base.

### What the fresh-prov walk should see
The full live e2e walk runs in the orchestrator's wipe→prov→walk loop. After a User installs bp-chepherd: the StatefulSet/Service/HTTPRoute/ExternalSecret appear in the Org namespace; the pod env carries `CHEPHERD_DEFAULT_MODEL=claude-opus-4-7` + `ANTHROPIC_API_KEY` (from Secret) + `CHEPHERD_EXTRA_MCP_JSON` (openova stanza); the chepherd console loads at `chepherd.<org>.<fqdn>`; the spawned solo agent's `.mcp.json` lists **both** `chepherd` and `openova` MCP servers and was launched with `--model claude-opus-4-7`; asking it to install an app creates an `Application` CR in the User's Org via the `create_application` tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)