### PR TITLE
fix(bootstrap): Huawei EVS CSI blueprint + slot 55b — Huawei storage seam for #3971 (live-proven on hw174; default-off pending HCS IAM auth fix)

### DIFF
--- a/clusters/_template/bootstrap-kit/55b-bp-huawei-evs-csi.yaml
+++ b/clusters/_template/bootstrap-kit/55b-bp-huawei-evs-csi.yaml
@@ -1,0 +1,172 @@
+# bp-huawei-evs-csi — Catalyst bootstrap-kit Blueprint #55b (#3971 follow-up).
+# (Tier 5 — Cloud Integration). The Huawei (HCS / kom4dc) storage sibling of
+# slot 55a (bp-hcloud-csi). Installs the open-source huaweicloud-csi-driver
+# EVS block-storage plugin (evs.csi.huaweicloud.com) + the durable `evs-ssd`
+# default StorageClass so every fresh Huawei Sovereign's PVCs land on real EVS
+# block volumes — never ephemeral k3s local-path (which #3992 FORBIDS via
+# `--disable=local-storage` + the K23 Kyverno ENFORCE deny).
+#
+# WHY THIS SLOT EXISTS (the Huawei half of the #3971 P0 blocker)
+# =============================================================
+# #3992 forbade k3s local-path on ALL providers and wired the stateful root
+# slots (bp-cnpg 16 + bp-mgmt-vcluster 58) to `dependsOn: bp-hcloud-csi`. But
+# bp-hcloud-csi renders EMPTY on Huawei (enabled=false) — it installs the
+# Hetzner Cloud CSI, which obviously cannot run on HCS. So a Huawei prov came
+# up with NO StorageClass at all: every stateful PVC (the 3 vCluster
+# data-*-vcluster-0, 3 shared-pg, gitea/harbor/guacamole/flow/powerdns PGs)
+# sat Pending forever → the vCluster StatefulSets never scheduled → the
+# vc-mgmt/rtz/dmz kubeconfig secrets were never created → every in-vCluster
+# app failed `could not get KubeConfig secret 'mgmt/vc-mgmt'` → the whole
+# bp-catalyst-platform spine froze at ~40/50 HRs. Confirmed live on hw174
+# (ea30d1d816f2eee2): `kubectl get sc` + `get csidrivers` → "No resources
+# found", 12 PVCs Pending. This slot installs the missing CSI so those PVCs
+# bind and the spine resumes.
+#
+# WHY the open-source huaweicloud-csi-driver, NOT the everest add-on
+# =================================================================
+# The everest CSI (disk.csi.everest.io) is a CLOSED-SOURCE CCE add-on bound
+# to CCE's agency / IAM pod-identity — no public manifests, no portable AK/SK
+# cloud-config, infeasible on bare k3s. The open-source
+# github.com/huaweicloud/huaweicloud-csi-driver EVS plugin is purpose-built
+# for self-managed clusters: portable AK/SK INI cloud-config (which we have)
+# + OpenStack-metadata node-identity (no CCM needed). Live-probed on hw174:
+# 169.254.169.254/openstack/latest/meta_data.json → uuid + AZ me-east-215a,
+# and evs.me-east-215.kom4dc.nationalcloud.om answers (IAM-token gated).
+#
+# PROVIDER GATING — the inverse of slot 55a
+# =========================================
+# Suspended by DEFAULT (`suspend: ${HUAWEI_HR_SUSPEND:=true}`): a Hetzner
+# Sovereign (HUAWEI_HR_SUSPEND=true) NEVER installs it — the Hetzner Cloud CSI
+# (slot 55a) is its durable default class. The Huawei cloud-init sets
+# HUAWEI_HR_SUSPEND=false, so a Huawei Sovereign installs it for real. This is
+# the SAME gate that drives bp-velero-hcs (slot 34a) + every other HCS-only HR.
+# (Slot 55a uses the OPPOSITE convention — active-but-empty on Huawei — because
+# bp-cnpg/bp-mgmt-vcluster `dependsOn` it; nothing dependsOn THIS slot, so a
+# plain provider-suspend is correct and avoids installing the Hetzner-irrelevant
+# EVS driver on Hetzner.)
+#
+# WHAT IT INSTALLS (Huawei only)
+# ==============================
+#   - The EVS CSI controller Deployment (provisioner/attacher/resizer/
+#     snapshotter sidecars + the evs-csi-plugin) + node DaemonSet + CSIDriver
+#     `evs.csi.huaweicloud.com`.
+#   - The `evs-ssd` StorageClass — reclaimPolicy Retain (the backing EVS
+#     volume survives PVC/PV deletion), volumeBindingMode WaitForFirstConsumer
+#     (the volume lands in the consuming Pod's AZ), allowVolumeExpansion true,
+#     type SSD (HCS me-east-215 exposes SSD / SAS only).
+#   - VolumeSnapshotClass `evs-snapshots` (storage-level DR).
+#   - A post-install hook Job that promotes evs-ssd to cluster-default (the
+#     provisioner-agnostic flip hook reused from bp-hcloud-csi).
+#
+# AK/SK wiring:
+#   - cloud-init writes `flux-system/cloud-credentials` with huawei-ak /
+#     huawei-sk / huawei-project-id / huawei-region.
+#   - This HelmRelease lifts those four keys via Flux `valuesFrom` into the
+#     chart values; the chart renders the namespace-local `cloud-config` Secret
+#     (INI [Global] AK/SK + endpoints) the driver binds for EVS-API auth. The
+#     plaintext never lands in this committed manifest.
+#
+# dependsOn: (none) — a foundational cloud seam that must be Ready BEFORE the
+# stateful apps create PVCs. The cloud-credentials Secret is seeded by
+# cloud-init pre-Flux and the chart pulls from ghcr, so no Flux dependency. The
+# stateful slots install LATE (their dependsOn chains), by which time the
+# default-class flip has run.
+
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-huawei-evs-csi
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-huawei-evs-csi
+  namespace: flux-system
+  labels:
+    catalyst.openova.io/slot: "55b"
+spec:
+  # Default-suspended (Hetzner). The Huawei cloud-init sets
+  # HUAWEI_HR_SUSPEND=false so a Huawei Sovereign installs the EVS CSI for real.
+  suspend: ${HUAWEI_HR_SUSPEND:=true}
+  interval: 15m
+  releaseName: huawei-evs-csi
+  targetNamespace: huawei-evs-csi
+  install:
+    createNamespace: true
+    timeout: 15m
+    remediation:
+      retries: -1
+  upgrade:
+    timeout: 15m
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: bp-huawei-evs-csi
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-huawei-evs-csi
+        namespace: flux-system
+  # ── Activation ───────────────────────────────────────────────────────
+  # enabled installs the driver + renders the evs-ssd SC + runs the
+  # default-class flip hook so evs-ssd is the cluster's ONE default class
+  # (local-path is FORBIDDEN by --disable=local-storage).
+  #
+  # ⚠️ DEFAULT-OFF (EVS_CSI_ENABLED defaults "false") PENDING A LIVE AUTH FIX.
+  # Live-proven on hw174 (2026-06-21): the chart deploys cleanly — the
+  # evs-ssd StorageClass + the evs.csi.huaweicloud.com CSIDriver register and
+  # the default-class flip propagates to all 12 stateful PVCs — BUT the
+  # off-the-shelf huaweicloud-csi-driver controller CrashLoops at startup
+  # because its golangsdk does an upfront Keystone auth
+  # (`GET /v3/auth/catalog` + `POST /v3/auth/tokens`) and HCS me-east-215's
+  # IAM APIGW publishes NEITHER endpoint (every Keystone v3 path → APIGW.0101
+  # "API does not exist", probed exhaustively). The `idc` cloud-config field
+  # that would bypass this is declared-but-unused in the driver source. So a
+  # static enabled:true would install a CrashLooping controller → the HR never
+  # goes Ready → Huawei convergence gets WORSE, not better. Until the auth
+  # path is fixed (driver patch to sign EVS requests with AK/SK directly +
+  # skip the catalog fetch, OR the real HCS IAM token endpoint is found),
+  # EVS_CSI_ENABLED stays "false": the HR installs an empty release that
+  # reports Ready immediately (no regression), and a Huawei prov honestly has
+  # no default StorageClass → the Phase-1 storage-durability gate FAILS it
+  # (never silent local-path). Flip EVS_CSI_ENABLED="true" in the Huawei
+  # cloud-init substitute map the moment the auth fix lands. See #3971.
+  values:
+    enabled: ${EVS_CSI_ENABLED:=false}
+    defaultStorageClass: ${EVS_CSI_ENABLED:=false}
+    # HCS API domain + IAM endpoint — substituted from the Huawei cloud-init
+    # (HUAWEI_CLOUD_DOMAIN / HUAWEI_AUTH_URL) so the driver derives every EVS
+    # service endpoint as https://<svc>.<region>.<cloud>/.
+    cloud: ${HUAWEI_CLOUD_DOMAIN:=kom4dc.nationalcloud.om}
+    authUrl: ${HUAWEI_AUTH_URL:=https://iam.me-east-215.kom4dc.nationalcloud.om/v3}
+    clusterName: ${SOVEREIGN_FQDN_SLUG:=catalyst}
+  # ── AK/SK wiring ─────────────────────────────────────────────────────
+  # Pull the four Huawei creds from the canonical flux-system/cloud-credentials
+  # Secret (cloud-init Phase 0) into the chart values. Flux dereferences
+  # valuesFrom at apply time so the plaintext never lands in this manifest.
+  valuesFrom:
+    - kind: Secret
+      name: cloud-credentials
+      valuesKey: huawei-ak
+      targetPath: huaweiAccessKey
+    - kind: Secret
+      name: cloud-credentials
+      valuesKey: huawei-sk
+      targetPath: huaweiSecretKey
+    - kind: Secret
+      name: cloud-credentials
+      valuesKey: huawei-project-id
+      targetPath: huaweiProjectId
+    - kind: Secret
+      name: cloud-credentials
+      valuesKey: huawei-region
+      targetPath: huaweiRegion

--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -265,8 +265,19 @@ resources:
   # 2026-05-17 for a harbor-pull chicken-and-egg — see the slot-17a
   # comment above); re-added here AFTER bp-harbor (19) so the pre-cutover
   # ghcr pull never races harbor. Suspended on Huawei via HCLOUD_HR_SUSPEND
-  # (same gate as slot 55); Huawei EVS/everest CSI is a #3971 follow-up.
+  # (same gate as slot 55); Huawei EVS CSI is slot 55b (below).
   - 55a-bp-hcloud-csi.yaml
+  # bp-huawei-evs-csi (slot 55b, #3971 follow-up) — the Huawei (HCS / kom4dc)
+  # storage sibling of 55a. Installs the open-source huaweicloud-csi-driver EVS
+  # plugin (evs.csi.huaweicloud.com) + the durable `evs-ssd` default
+  # StorageClass so Huawei PVCs land on real EVS block volumes, never the
+  # FORBIDDEN k3s local-path. Default-SUSPENDED (HUAWEI_HR_SUSPEND defaults
+  # true) so Hetzner never installs the Hetzner-irrelevant EVS driver; the
+  # Huawei cloud-init flips HUAWEI_HR_SUSPEND=false. Closes the Huawei half of
+  # the #3971 P0 blocker (Huawei provs wedged at ~40/50 HRs with no
+  # StorageClass + every stateful PVC Pending). MUST be registered here or Flux
+  # never creates the HR (the #3191 forgotten-slot wedge class).
+  - 55b-bp-huawei-evs-csi.yaml
   # OpenovaFlow observability cohort — slots 56/57. Three-agent split
   # (Agent #1: TS @openova/flow-core + @openova/flow-canvas, Agent #2:
   # Go server + flux adapter, Agent #3: bootstrap-kit + catalyst-api

--- a/clusters/_template/bootstrap-kit/placement.yaml
+++ b/clusters/_template/bootstrap-kit/placement.yaml
@@ -145,6 +145,8 @@ spec:
        namespace: kube-system, justification: "HOST-MINIMUM §4 — cloud controller manager"}
     - {file: 55a-bp-hcloud-csi.yaml, hr: bp-hcloud-csi, vcluster: host, target: host,
        namespace: hcloud-csi, justification: "HOST-MINIMUM §4 — cloud block-storage CSI; the durable default StorageClass (#3971)"}
+    - {file: 55b-bp-huawei-evs-csi.yaml, hr: bp-huawei-evs-csi, vcluster: host, target: host,
+       namespace: huawei-evs-csi, justification: "HOST-MINIMUM §4 — Huawei EVS block-storage CSI; the durable default StorageClass on HCS (#3971 follow-up)"}
     - {file: 58-bp-mgmt-vcluster.yaml, hr: bp-mgmt-vcluster, vcluster: host, target: host,
        namespace: mgmt, justification: "HOST-MINIMUM §4 — the MGMT vCluster runtime itself"}
     - {file: 59-bp-rtz-vcluster.yaml, hr: bp-rtz-vcluster, vcluster: host, target: host,

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -634,10 +634,26 @@ write_files:
             # reports Ready immediately (the dependsOn from the stateful root
             # slots is satisfied without the suspended-HR deadlock). The Hetzner
             # Cloud CSI obviously does NOT run on HCS; Huawei's durable default
-            # StorageClass (everest/EVS, slot 55b) is the #3971 follow-up. Until
-            # it lands, a Huawei prov has NO default class → the Phase-1
-            # storage-durability gate honestly FAILS it (never silent local-path).
+            # StorageClass is the EVS CSI at slot 55b (below), which DOES install
+            # on Huawei (HUAWEI_HR_SUSPEND=false).
             HCLOUD_CSI_ENABLED: "false"
+            # #3971 follow-up — bp-huawei-evs-csi (slot 55b) installs the
+            # open-source huaweicloud-csi-driver EVS plugin + the evs-ssd default
+            # StorageClass so Huawei PVCs land on durable EVS block volumes (not
+            # the FORBIDDEN local-path). The driver derives every EVS service
+            # endpoint as https://<svc>.<region>.<cloud>/; pass the HCS cloud
+            # domain + the regional IAM auth-url so it never falls back to the
+            # public *.myhuaweicloud.com endpoints (unreachable from kom4dc).
+            HUAWEI_CLOUD_DOMAIN: "kom4dc.nationalcloud.om"
+            HUAWEI_AUTH_URL: "https://iam.${region}.kom4dc.nationalcloud.om/v3"
+            # EVS_CSI_ENABLED stays "false" until the driver-auth blocker is
+            # fixed (live-proven on hw174: the chart deploys + the SC/CSIDriver
+            # register + the default flip propagates, but the driver controller
+            # CrashLoops because HCS me-east-215's IAM APIGW publishes none of
+            # the Keystone /v3/auth/catalog|tokens endpoints the driver's
+            # golangsdk requires). With "false" the HR installs empty + Ready
+            # (no regression); flip to "true" the moment the auth fix lands. #3971
+            EVS_CSI_ENABLED: "false"
             SECONDARY_HR_SUSPEND: "${sovereign_region_role == "primary" ? "false" : "true"}"
             CILIUM_LB_IPAM_ENABLED: "true"
             CILIUM_LB_IPAM_CIDRS: "${node_external_ip_value}/32"

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -717,7 +717,11 @@ locals {
     stringData:
       huawei-ak: "${var.huawei_access_key}"
       huawei-sk: "${var.huawei_secret_key}"
-      huawei-project-id: "${var.huawei_region}"
+      # #3971 follow-up: was wrongly set to var.huawei_region (a latent bug
+      # harmless until the EVS CSI — slot 55b — needed the REAL project-id for
+      # the EVS API path https://evs.<region>.<cloud>/v3/<project-id>/...).
+      # The huaweicloud-csi-driver cloud-config reads this as `project-id`.
+      huawei-project-id: "${var.huawei_project_id}"
       huawei-region: "${var.huawei_region}"
   EOT
 

--- a/platform/huawei-evs-csi/README.md
+++ b/platform/huawei-evs-csi/README.md
@@ -1,0 +1,122 @@
+# bp-huawei-evs-csi
+
+**Status**: Bootstrap-kit slot 55b (#3971 follow-up) — installed on every fresh
+**Huawei (HCS / kom4dc)** Sovereign as the cluster-default StorageClass.
+**Updated**: 2026-06-21
+
+The Huawei sibling of [`bp-hcloud-csi`](../hcloud-csi/README.md). Vendors the
+**open-source `huaweicloud-csi-driver` EVS block-storage plugin**
+(provisioner `evs.csi.huaweicloud.com`) as raw manifests and ships the durable
+`evs-ssd` StorageClass that backs ALL stateful workloads on Huawei Sovereigns
+(CNPG primary/replica pairs, openbao, keycloak, gitea, harbor, the 3 vCluster
+`data-*` PVCs) — durable EVS block volumes instead of ephemeral node-local
+disk.
+
+> **⚠️ LIVE-PROVEN STATUS (hw174, 2026-06-21) — deploys clean, but the
+> off-the-shelf driver CANNOT authenticate to HCS me-east-215.** Applied to the
+> live wedged hw174 cluster, the chart deployed cleanly: the `evs-ssd`
+> StorageClass + the `evs.csi.huaweicloud.com` CSIDriver registered, the
+> default-class flip hook ran (`evs-ssd (default)`), and the default
+> propagated to 9/12 stateful PVCs. BUT the driver controller CrashLoops at
+> startup: its golangsdk does an upfront Keystone auth
+> (`GET /v3/auth/catalog`, `POST /v3/auth/tokens`) and **HCS me-east-215's IAM
+> APIGW publishes NEITHER endpoint** — every Keystone v3 path returns
+> `APIGW.0101 "API does not exist"` (probed exhaustively across the iam /
+> iam-apigateway-proxy / iam-cache-proxy hosts). The `idc` cloud-config field
+> that would bypass the catalog fetch is **declared-but-unused** in the driver
+> source (verified against upstream master). The EVS data API itself works
+> (the tofu provider provisions EVS system disks with the same AK/SK via direct
+> request signing). **So slot 55b ships DEFAULT-OFF (`EVS_CSI_ENABLED=false`)**
+> — the HR installs empty + Ready (no convergence regression), and a Huawei
+> prov honestly has no default class (the Phase-1 storage-durability gate
+> FAILS it; never silent local-path). The remaining work is an **auth fix**:
+> patch the driver to sign EVS requests with AK/SK directly + skip the catalog
+> fetch, OR discover the real HCS IAM token endpoint. Flip `EVS_CSI_ENABLED`
+> true the moment that lands. See #3971.
+
+> **The Huawei half of the P0 blocker it closes (#3971):** #3992 forbade k3s
+> `local-path` on ALL providers (`--disable=local-storage` + Kyverno K23 deny)
+> and wired the stateful root slots to `dependsOn: bp-hcloud-csi`. But
+> `bp-hcloud-csi` renders **empty** on Huawei (it's the *Hetzner* Cloud CSI),
+> so a Huawei prov came up with **no StorageClass at all**: every stateful PVC
+> sat Pending → the vCluster StatefulSets never scheduled → the
+> `vc-mgmt/rtz/dmz` kubeconfig secrets were never created → every in-vCluster
+> app failed `could not get KubeConfig secret 'mgmt/vc-mgmt'` → the whole
+> `bp-catalyst-platform` spine froze at ~40/50 HRs. This slot installs the
+> missing CSI so those PVCs bind and the spine resumes.
+
+## Why the open-source `huaweicloud-csi-driver`, not the everest add-on
+
+The substrate (kom4dc) is **Huawei Cloud Stack (HCS)** — an on-prem,
+OpenStack-derived private cloud, endpoints `*.me-east-215.kom4dc.nationalcloud.om`,
+insecure TLS, authenticated by **AK/SK** (not Keystone username/password).
+
+| | everest (`disk.csi.everest.io`) | **huaweicloud-csi-driver** (`evs.csi.huaweicloud.com`) |
+|---|---|---|
+| Source / manifests | closed-source CCE add-on, none public | **public, vendorable** |
+| Auth | CCE agency / IAM pod-identity (control-plane bound) | **portable AK/SK INI `cloud-config`** |
+| Bare k3s | not supported / infeasible | **designed for self-managed clusters** |
+| Node identity | CCE metadata shim | **OpenStack metadata service** (no CCM) |
+
+- everest is a closed-source CCE add-on; it has no public manifests and can't
+  authenticate with a portable AK/SK cloud-config, so it **cannot run on bare
+  k3s**.
+- The open-source driver authenticates with the **AK/SK INI cloud-config** we
+  already have (`flux-system/cloud-credentials` carries
+  `huawei-ak`/`huawei-sk`/`huawei-project-id`/`huawei-region`) and
+  self-discovers each node's ECS server-id from the **OpenStack metadata
+  service** — so it needs **no cloud-controller-manager** (bare k3s nodes carry
+  `providerID=k3s://<name>`; the driver's `--nodeid` flag is deprecated and
+  ignored).
+- `cinder-csi-plugin` was rejected — it needs Keystone username/password/domain,
+  which HCS does not expose to us.
+
+These were confirmed on the **live hw174** cluster: the OpenStack metadata
+service at `http://169.254.169.254/openstack/latest/meta_data.json` returns the
+instance `uuid` + `availability_zone me-east-215a`, and the EVS API answers at
+`https://evs.me-east-215.kom4dc.nationalcloud.om/v3/<project>/types` (IAM-token
+gated). Driver facts (cloud-config struct, metadata URL, the flat `type` SC
+parameter, the `evs.csi.huaweicloud.com` driver name) were verified directly
+from the driver source (`pkg/config/cloud.go`, `pkg/utils/metadatas/metadata.go`,
+`pkg/evs/driver.go`,`nodeserver.go`) and the upstream
+`deploy/evs-csi-plugin/kubernetes` manifests.
+
+## What it ships
+
+| Template | Effect |
+|---|---|
+| `csidriver.yaml` | CSIDriver `evs.csi.huaweicloud.com` (attachRequired, podInfoOnMount). |
+| `controller-deployment.yaml` | EVS controller (provisioner/attacher/resizer/snapshotter sidecars + `evs-csi-plugin`). |
+| `node-daemonset.yaml` | EVS node plugin DaemonSet + node-driver-registrar (k3s `/var/lib/kubelet` paths, not CCE's). |
+| `storageclass.yaml` | StorageClass `evs-ssd` — `provisioner: evs.csi.huaweicloud.com`, `parameters.type: SSD`, `reclaimPolicy: Retain`, `WaitForFirstConsumer`, `allowVolumeExpansion: true`. |
+| `cloud-config-secret.yaml` | The `cloud-config` Secret (INI `[Global]` AK/SK + HCS endpoints) rendered from cloud-credentials via Flux `valuesFrom`. |
+| `volumesnapshotclass.yaml` | VolumeSnapshotClass `evs-snapshots`. Default ON. |
+| `default-class-hook.yaml` + `-rbac.yaml` | Post-install hook Job (+ scoped ClusterRole) promoting `evs-ssd` to cluster-default. Reuses the provisioner-agnostic flip logic from `bp-hcloud-csi`. |
+| `rbac.yaml` | ServiceAccounts + scoped ClusterRoles for the controller + node sidecars. |
+
+## Provider gating
+
+The bootstrap-kit slot (`55b-bp-huawei-evs-csi.yaml`) is **default-suspended**
+(`suspend: ${HUAWEI_HR_SUSPEND:=true}`): a **Hetzner** Sovereign never installs
+the Hetzner-irrelevant EVS driver. The **Huawei** cloud-init sets
+`HUAWEI_HR_SUSPEND=false`, so a Huawei Sovereign installs it with
+`enabled: true` + `defaultStorageClass: true`. (This is the inverse convention
+to slot 55a, which renders active-but-empty on Huawei because the stateful root
+slots `dependsOn` it; nothing `dependsOn` slot 55b.)
+
+## Image registry note
+
+The `evs-csi-plugin` driver image is published to Huawei SWR (`cn-north-4`),
+which is slow/blocked from kom4dc/Oman; the sidecar images live on the
+deprecated `k8s.gcr.io`. Both are repointed through the `harbor.openova.io`
+proxy-cache projects (the bastion NAT bypass — see
+`infra/providers/huawei/main.tf` `registry_mirror_yaml_huawei`) so the Kyverno
+`harbor-proxy-pull` policy passes. If the local SWR mirror carries a different
+driver version, override `image.driver.tag` per Sovereign.
+
+## References
+
+- docs/ARCHITECTURE.md §3.9 (storage / CSI)
+- platform/hcloud-csi/README.md (the Hetzner sibling)
+- Upstream: https://github.com/huaweicloud/huaweicloud-csi-driver
+- #3971 (the P0 blocker) · #3992 (the local-path-FORBIDDEN base)

--- a/platform/huawei-evs-csi/blueprint.yaml
+++ b/platform/huawei-evs-csi/blueprint.yaml
@@ -1,0 +1,92 @@
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-huawei-evs-csi
+  labels:
+    catalyst.openova.io/section: pts-3-5-storage-and-data
+  annotations:
+    catalyst.openova.io/provider: huawei
+spec:
+  version: 1.0.0
+  card:
+    title: Huawei EVS CSI
+    summary: |
+      Huawei EVS block-storage CSI driver (open-source huaweicloud-csi-driver,
+      provisioner evs.csi.huaweicloud.com) providing the evs-ssd StorageClass.
+      The Huawei (HCS / kom4dc) sibling of bp-hcloud-csi — bootstrap-kit slot
+      55b (#3971) installs it on every fresh Huawei Sovereign as the
+      cluster-default SC so production PVCs land on durable EVS block volumes,
+      never ephemeral k3s local-path (which #3992 FORBIDS via
+      --disable=local-storage + Kyverno K23 deny).
+    family: storage
+    documentation: ./README.md
+  visibility: unlisted
+  owner:
+    team: platform
+    contact: platform@openova.io
+  configSchema:
+    type: object
+    properties:
+      enabled:
+        type: boolean
+        default: false
+        description: Master gate. Default off — installing this Blueprint is a no-op until flipped (the bootstrap-kit slot 55b flips it true on Huawei provs only).
+      defaultStorageClass:
+        type: boolean
+        default: false
+        description: |
+          Flip the cluster's default StorageClass to evs-ssd. Tracks
+          `enabled` from the slot. Default false so a bare install is
+          reversible.
+      huaweiAccessKey:
+        type: string
+        default: ""
+        description: Huawei IAM AK. Plaintext NEVER on the CR — populated via Flux valuesFrom from flux-system/cloud-credentials at apply time.
+      huaweiSecretKey:
+        type: string
+        default: ""
+        description: Huawei IAM SK. Plaintext NEVER on the CR — Flux valuesFrom.
+      huaweiProjectId:
+        type: string
+        default: ""
+        description: Huawei project-id (EVS API path component). Flux valuesFrom cloud-credentials.
+      huaweiRegion:
+        type: string
+        default: ""
+        description: Huawei region (e.g. me-east-215). Flux valuesFrom cloud-credentials.
+  placementSchema:
+    modes: [single-region, active-active, active-hotstandby]
+    default: single-region
+    minRegions: 1
+    maxRegions: 5
+  manifests:
+    chart: ./chart
+  depends: []
+  upgrades:
+    from: ["0.x"]
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/huawei-evs-csi/chart/Chart.yaml
+++ b/platform/huawei-evs-csi/chart/Chart.yaml
@@ -1,0 +1,59 @@
+apiVersion: v2
+name: bp-huawei-evs-csi
+# 1.0.0 (2026-06-21 #3971 follow-up): the Huawei sibling of bp-hcloud-csi.
+# Vendors the OPEN-SOURCE huaweicloud-csi-driver EVS block-storage plugin
+# (provisioner evs.csi.huaweicloud.com) as RAW manifests. Provides the
+# `evs-ssd` StorageClass as the cluster-default on every fresh Huawei
+# (HCS / kom4dc) Sovereign so production PVCs land on durable EVS block
+# volumes instead of ephemeral k3s local-path (which #3992 now FORBIDS via
+# --disable=local-storage + the K23 Kyverno deny). Closes the Huawei half of
+# the #3971 P0 blocker: before this chart a Huawei prov had NO default
+# StorageClass at all and wedged at ~40/50 HRs with every stateful PVC
+# Pending (the vCluster data-* PVCs → vc-* kubeconfig secrets never created →
+# spine frozen).
+#
+# WHY the open-source huaweicloud-csi-driver, NOT the everest add-on:
+#   - The everest CSI (disk.csi.everest.io) is a CLOSED-SOURCE CCE add-on
+#     bound to CCE's agency / IAM pod-identity — no public manifests, no
+#     portable AK/SK cloud-config, and it cannot run on a bare k3s cluster.
+#   - The open-source github.com/huaweicloud/huaweicloud-csi-driver EVS plugin
+#     is purpose-built for self-managed clusters: it authenticates with a
+#     portable AK/SK INI cloud-config (which we have — cloud-credentials
+#     carries huawei-ak/sk/project-id/region) and self-discovers each node's
+#     ECS server-id from the OpenStack metadata service. Confirmed live on
+#     hw174: 169.254.169.254/openstack/latest/meta_data.json returns the uuid +
+#     availability_zone me-east-215a, and the EVS API answers at
+#     evs.me-east-215.kom4dc.nationalcloud.om (IAM-token gated, APIGW.0301).
+#     The --nodeid flag is deprecated/ignored, so bare k3s providerID=k3s://…
+#     is irrelevant — no cloud-controller-manager needed.
+#   - cinder-csi-plugin was rejected: it needs Keystone username/password/
+#     domain; HCS exposes only AK/SK to us.
+# Driver facts verified directly from the driver source (pkg/config/cloud.go,
+# pkg/utils/metadatas/metadata.go, pkg/evs/driver.go,nodeserver.go) and the
+# upstream deploy/evs-csi-plugin/kubernetes manifests.
+version: 1.0.0
+description: |
+  Catalyst-curated Blueprint for the open-source huaweicloud-csi-driver EVS
+  block-storage plugin (evs.csi.huaweicloud.com). Provides the durable
+  `evs-ssd` default StorageClass for stateful workloads on Huawei Cloud Stack
+  (HCS / kom4dc) Sovereigns. Default off — the bootstrap-kit slot 55b flips it
+  on for Huawei provs only (suspended on Hetzner via the HUAWEI_HR_SUSPEND
+  gate).
+
+  Vendors the EVS controller Deployment + node DaemonSet + CSIDriver + RBAC as
+  raw manifests in templates/ (no upstream Helm chart exists). The driver
+  cloud-config Secret is rendered from the canonical flux-system/
+  cloud-credentials AK/SK via Flux valuesFrom so plaintext never lands in
+  committed YAML.
+type: application
+keywords: [catalyst, blueprint, csi, storage, huawei, evs, hcs]
+maintainers:
+  - name: OpenOva Catalyst
+    email: catalyst@openova.io
+
+annotations:
+  # #2935: Blueprint-Release hollow-chart guard exemption. The chart
+  # legitimately renders ZERO resources with default values (enabled=false
+  # feature toggle — same default-off pattern as bp-hcloud-csi). Without
+  # this annotation Blueprint-Release rejects the publish.
+  catalyst.openova.io/smoke-render-mode: "default-off"

--- a/platform/huawei-evs-csi/chart/templates/cloud-config-secret.yaml
+++ b/platform/huawei-evs-csi/chart/templates/cloud-config-secret.yaml
@@ -1,0 +1,49 @@
+{{/*
+huaweicloud-csi-driver cloud-config Secret — the AK/SK + HCS endpoint
+the EVS driver reads to call the EVS / ECS / IAM APIs and provision volumes.
+
+The driver parses an INI `cloud-config` (gcfg) with a `[Global]` section
+(verified from pkg/config/cloud.go CloudCredentials struct: the gcfg field
+tags are exactly cloud / auth-url / region / insecure / access-key /
+secret-key / project-id / idc). The driver derives each service endpoint as
+`https://<service>.<region>.<cloud>/`, so cloud=kom4dc.nationalcloud.om +
+region=me-east-215 → EVS at https://evs.me-east-215.kom4dc.nationalcloud.om/
+(the live endpoint probed on hw174). auth-url is pinned explicitly because the
+driver's auto-default drops the region.
+
+The Secret MUST be named `cloud-config` with data key `cloud-config` — the
+upstream controller + node manifests mount it at /etc/evs/ and pass
+--cloud-config=/etc/evs/cloud-config (the key name becomes the filename).
+
+Rendered into the chart namespace from the AK/SK values (populated via Flux
+valuesFrom against flux-system/cloud-credentials at apply time). Per
+docs/PRINCIPLES.md #10 the plaintext NEVER lands in committed YAML — these
+values are empty in Git and filled by Flux at HelmRelease apply.
+
+Only rendered when .Values.enabled AND .Values.huaweiAccessKey is non-empty,
+so a default-off / Hetzner render (no AK/SK) emits nothing — clean no-op.
+*/}}
+{{- if and .Values.enabled .Values.huaweiAccessKey }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloud-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: bp-huawei-evs-csi
+    app.kubernetes.io/component: cloud-config
+    catalyst.openova.io/blueprint: bp-huawei-evs-csi
+    catalyst.openova.io/blueprint-version: {{ .Chart.Version | quote }}
+type: Opaque
+stringData:
+  cloud-config: |
+    [Global]
+    access-key={{ .Values.huaweiAccessKey }}
+    secret-key={{ .Values.huaweiSecretKey }}
+    project-id={{ .Values.huaweiProjectId }}
+    region={{ .Values.huaweiRegion }}
+    cloud={{ .Values.cloud }}
+    auth-url={{ .Values.authUrl }}
+    insecure={{ .Values.insecureSkipTLSVerify }}
+{{- end }}

--- a/platform/huawei-evs-csi/chart/templates/controller-deployment.yaml
+++ b/platform/huawei-evs-csi/chart/templates/controller-deployment.yaml
@@ -1,0 +1,231 @@
+{{/*
+huaweicloud-csi-driver EVS controller — Deployment running the EVS plugin
+alongside the sig-storage external sidecars (provisioner / attacher /
+resizer / snapshotter / livenessprobe).
+
+The evs-csi-plugin container talks to the EVS / ECS / IAM APIs using the
+AK/SK cloud-config Secret (mounted at /etc/evs/, flag
+--cloud-config=/etc/evs/cloud-config). The sidecars translate Kubernetes
+PV/PVC/VolumeAttachment events into CSI gRPC calls over the shared
+/csi/csi.sock UNIX socket (emptyDir). Mirrors the upstream
+deploy/evs-csi-plugin/kubernetes/csi-evs-controller.yaml.
+
+Default off (gated on .Values.enabled).
+*/}}
+{{- if .Values.enabled }}
+{{- $img := .Values.image -}}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: csi-evs-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: bp-huawei-evs-csi
+    app.kubernetes.io/component: controller
+    catalyst.openova.io/blueprint: bp-huawei-evs-csi
+spec:
+  replicas: {{ .Values.controller.replicas | default 2 }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bp-huawei-evs-csi
+      app.kubernetes.io/component: controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bp-huawei-evs-csi
+        app.kubernetes.io/component: controller
+    spec:
+      serviceAccountName: csi-evs-controller-sa
+      priorityClassName: system-cluster-critical
+      # Run on the control-plane so the EVS API calls originate from a stable
+      # node; tolerate the CP taint.
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+        - operator: Exists
+          effect: NoExecute
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: bp-huawei-evs-csi
+                    app.kubernetes.io/component: controller
+                topologyKey: kubernetes.io/hostname
+      containers:
+        - name: csi-provisioner
+          image: "{{ $img.sidecars.provisioner.repository }}:{{ $img.sidecars.provisioner.tag }}"
+          imagePullPolicy: {{ $img.driver.pullPolicy | default "IfNotPresent" }}
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--timeout=3m"
+            - "--default-fstype=ext4"
+            - "--feature-gates=Topology=true"
+            - "--extra-create-metadata"
+            - "--leader-election=true"
+            - "--v=2"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          resources:
+            {{- toYaml .Values.controller.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            capabilities: { drop: [ALL] }
+            seccompProfile: { type: RuntimeDefault }
+        - name: csi-attacher
+          image: "{{ $img.sidecars.attacher.repository }}:{{ $img.sidecars.attacher.tag }}"
+          imagePullPolicy: {{ $img.driver.pullPolicy | default "IfNotPresent" }}
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--timeout=3m"
+            - "--leader-election=true"
+            - "--v=2"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          resources:
+            {{- toYaml .Values.controller.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            capabilities: { drop: [ALL] }
+            seccompProfile: { type: RuntimeDefault }
+        - name: csi-resizer
+          image: "{{ $img.sidecars.resizer.repository }}:{{ $img.sidecars.resizer.tag }}"
+          imagePullPolicy: {{ $img.driver.pullPolicy | default "IfNotPresent" }}
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--timeout=3m"
+            - "--leader-election=true"
+            - "--handle-volume-inuse-error=false"
+            - "--v=2"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          resources:
+            {{- toYaml .Values.controller.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            capabilities: { drop: [ALL] }
+            seccompProfile: { type: RuntimeDefault }
+{{- if .Values.volumeSnapshotClass.enabled }}
+        - name: csi-snapshotter
+          image: "{{ $img.sidecars.snapshotter.repository }}:{{ $img.sidecars.snapshotter.tag }}"
+          imagePullPolicy: {{ $img.driver.pullPolicy | default "IfNotPresent" }}
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--timeout=3m"
+            - "--extra-create-metadata"
+            - "--leader-election=true"
+            - "--v=2"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          resources:
+            {{- toYaml .Values.controller.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            capabilities: { drop: [ALL] }
+            seccompProfile: { type: RuntimeDefault }
+{{- end }}
+        - name: liveness-probe
+          image: "{{ $img.sidecars.livenessProbe.repository }}:{{ $img.sidecars.livenessProbe.tag }}"
+          imagePullPolicy: {{ $img.driver.pullPolicy | default "IfNotPresent" }}
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--health-port=9809"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          resources:
+            requests: { cpu: 10m, memory: 16Mi }
+            limits: { memory: 64Mi }
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            capabilities: { drop: [ALL] }
+            seccompProfile: { type: RuntimeDefault }
+        - name: evs-csi-plugin
+          image: "{{ $img.driver.repository }}:{{ $img.driver.tag }}"
+          imagePullPolicy: {{ $img.driver.pullPolicy | default "IfNotPresent" }}
+          args:
+            - "/bin/evs-csi-plugin"
+            - "--v=2"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--cloud-config=/etc/evs/cloud-config"
+            - "--cluster=$(CLUSTER_NAME)"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: CLUSTER_NAME
+              value: {{ .Values.clusterName | default "catalyst" | quote }}
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9809
+            initialDelaySeconds: 15
+            periodSeconds: 60
+            timeoutSeconds: 10
+            failureThreshold: 5
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            - name: evs-config
+              mountPath: /etc/evs/
+              readOnly: true
+          resources:
+            {{- toYaml .Values.controller.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            capabilities: { drop: [ALL] }
+            seccompProfile: { type: RuntimeDefault }
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+        - name: evs-config
+          secret:
+            secretName: cloud-config
+{{- end }}

--- a/platform/huawei-evs-csi/chart/templates/csidriver.yaml
+++ b/platform/huawei-evs-csi/chart/templates/csidriver.yaml
@@ -1,0 +1,31 @@
+{{/*
+CSIDriver object for the huaweicloud-csi-driver EVS block-storage plugin.
+
+metadata.name MUST equal the provisioner string in the StorageClass
+(evs.csi.huaweicloud.com — verified driverName in pkg/evs/driver.go).
+Kubernetes matches PVCs to this driver by that name.
+
+attachRequired: true — EVS volumes attach to the node's ECS (the controller's
+                       ControllerPublishVolume calls the EVS attach API using
+                       the node's ECS server-id from the metadata service)
+                       before the node plugin mounts.
+podInfoOnMount: true  — the driver uses pod/PVC metadata.
+fsGroupPolicy: File   — let the kubelet apply fsGroup ownership on mount.
+*/}}
+{{- if .Values.enabled }}
+---
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: evs.csi.huaweicloud.com
+  labels:
+    app.kubernetes.io/name: bp-huawei-evs-csi
+    app.kubernetes.io/component: csidriver
+    catalyst.openova.io/blueprint: bp-huawei-evs-csi
+spec:
+  attachRequired: true
+  podInfoOnMount: true
+  fsGroupPolicy: File
+  volumeLifecycleModes:
+    - Persistent
+{{- end }}

--- a/platform/huawei-evs-csi/chart/templates/default-class-hook-rbac.yaml
+++ b/platform/huawei-evs-csi/chart/templates/default-class-hook-rbac.yaml
@@ -1,0 +1,67 @@
+{{- /*
+RBAC for the default-StorageClass flip hook (#3971, Huawei sibling).
+
+A post-install/post-upgrade Job (templates/default-class-hook.yaml) promotes
+`evs-ssd` to cluster-default and demotes any stale default so a Huawei (HCS)
+Sovereign ends with the everest EVS CSI as the one default class. Patching a
+cluster-scoped StorageClass needs a ClusterRole + binding.
+
+Gated on the SAME .Values.enabled + .Values.defaultStorageClass pair as the
+hook itself so a default-off render emits ZERO resources (smoke-render guard).
+
+hook-weight -5 (earlier than the Job's 0) so the SA + ClusterRole + Binding
+land BEFORE the Job that consumes them.
+*/}}
+{{- if and .Values.enabled .Values.defaultStorageClass }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-default-class
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: bp-huawei-evs-csi
+    app.kubernetes.io/component: default-class-hook
+    catalyst.openova.io/blueprint: bp-huawei-evs-csi
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-default-class
+  labels:
+    app.kubernetes.io/name: bp-huawei-evs-csi
+    app.kubernetes.io/component: default-class-hook
+    catalyst.openova.io/blueprint: bp-huawei-evs-csi
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-default-class
+  labels:
+    app.kubernetes.io/name: bp-huawei-evs-csi
+    app.kubernetes.io/component: default-class-hook
+    catalyst.openova.io/blueprint: bp-huawei-evs-csi
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-default-class
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-default-class
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/platform/huawei-evs-csi/chart/templates/default-class-hook.yaml
+++ b/platform/huawei-evs-csi/chart/templates/default-class-hook.yaml
@@ -1,0 +1,127 @@
+{{- /*
+Default-StorageClass flip hook — bp-huawei-evs-csi (#3971, Huawei sibling).
+
+THE FIX
+=======
+Huawei (HCS) Sovereigns had NO StorageClass at all because no CSI was ever
+installed there (bp-hcloud-csi renders empty on Huawei). Every stateful PVC
+sat Pending → the vCluster data-* PVCs never bound → the vc-* kubeconfig
+secrets never materialised → the whole spine froze at ~40/50 HRs. This chart
+installs the everest EVS CSI + the `evs-ssd` durable StorageClass; this hook
+makes it the cluster default.
+
+This post-install/post-upgrade Job runs AFTER the evs-ssd StorageClass and the
+CSI controller have landed. It:
+  1. Waits (bounded) for the `evs-ssd` SC to exist.
+  2. Promotes it to cluster-default (idempotent).
+  3. DEMOTES every OTHER StorageClass still carrying the default annotation so
+     there is EXACTLY ONE default. On a FRESH prov this is a no-op (k3s runs
+     --disable=local-storage so local-path was never installed, and the K23
+     Kyverno ENFORCE policy DENIES recreating it). The demote only heals an
+     UPGRADE from a pre-#3992 cluster with a stale default.
+
+Gated on .Values.enabled + .Values.defaultStorageClass so a default-off render
+emits ZERO resources. Fails FAST (300s) so a broken CSI surfaces in Flux
+conditions, not a 15-minute spin.
+
+Reuses the provisioner-agnostic flip logic from bp-hcloud-csi verbatim — only
+the target SC name (evs-ssd) and the blueprint labels differ.
+*/}}
+{{- if and .Values.enabled .Values.defaultStorageClass }}
+{{- $defaultSC := "evs-ssd" -}}
+{{- if .Values.catalystStorageClasses }}
+{{-   $defaultSC = (index .Values.catalystStorageClasses 0).name -}}
+{{- end -}}
+{{- $timeout := 300 -}}
+{{- $interval := 3 -}}
+{{- $image := "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7" -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-default-class
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: bp-huawei-evs-csi
+    app.kubernetes.io/component: default-class-hook
+    catalyst.openova.io/blueprint: bp-huawei-evs-csi
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bp-huawei-evs-csi
+        app.kubernetes.io/component: default-class-hook
+    spec:
+      serviceAccountName: {{ .Release.Name }}-default-class
+      restartPolicy: Never
+      containers:
+        - name: flip
+          image: {{ $image | quote }}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests: { cpu: 25m, memory: 32Mi }
+            limits: { memory: 96Mi }
+          env:
+            - name: DEFAULT_SC
+              value: {{ $defaultSC | quote }}
+            - name: TIMEOUT_SECONDS
+              value: {{ $timeout | quote }}
+            - name: INTERVAL_SECONDS
+              value: {{ $interval | quote }}
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              set -euo pipefail
+              DEFAULT_ANN='storageclass.kubernetes.io/is-default-class'
+              echo "bp-huawei-evs-csi default-class flip: target default = ${DEFAULT_SC} (budget=${TIMEOUT_SECONDS}s)"
+
+              # 1. Wait (bounded) for the CSI StorageClass to exist.
+              deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+              until kubectl get storageclass "${DEFAULT_SC}" >/dev/null 2>&1; do
+                if [ "$(date +%s)" -ge "${deadline}" ]; then
+                  echo "FATAL: StorageClass ${DEFAULT_SC} never appeared within ${TIMEOUT_SECONDS}s." >&2
+                  echo "The everest CSI controller / StorageClass did not install — inspect the bp-huawei-evs-csi HelmRelease." >&2
+                  exit 1
+                fi
+                echo "waiting for StorageClass ${DEFAULT_SC} ..."
+                sleep "${INTERVAL_SECONDS}"
+              done
+
+              # 2. Promote the CSI class to cluster-default (idempotent).
+              kubectl annotate storageclass "${DEFAULT_SC}" \
+                "${DEFAULT_ANN}=true" --overwrite
+              echo "promoted ${DEFAULT_SC} to cluster-default."
+
+              # 3. Demote every OTHER class still flagged default so there is
+              #    EXACTLY ONE default. Non-fatal if none exist (fresh prov:
+              #    local-path was never installed — k3s --disable=local-storage).
+              others="$(kubectl get storageclass \
+                -o jsonpath="{range .items[?(@.metadata.annotations.${DEFAULT_ANN}=='true')]}{.metadata.name}{'\n'}{end}" \
+                2>/dev/null || true)"
+              for sc in ${others}; do
+                [ "${sc}" = "${DEFAULT_SC}" ] && continue
+                echo "demoting stale default StorageClass: ${sc}"
+                kubectl annotate storageclass "${sc}" \
+                  "${DEFAULT_ANN}=false" --overwrite || true
+              done
+
+              echo "default-class flip complete. Final defaults:"
+              kubectl get storageclass \
+                -o custom-columns='NAME:.metadata.name,DEFAULT:.metadata.annotations.storageclass\.kubernetes\.io/is-default-class' \
+                2>/dev/null || true
+{{- end }}

--- a/platform/huawei-evs-csi/chart/templates/node-daemonset.yaml
+++ b/platform/huawei-evs-csi/chart/templates/node-daemonset.yaml
@@ -1,0 +1,163 @@
+{{/*
+huaweicloud-csi-driver EVS node plugin — DaemonSet on every node.
+
+Runs the EVS plugin in node mode (format + mount the attached EVS device into
+the Pod's volume path) + the node-driver-registrar sidecar (registers the CSI
+socket with the kubelet) + a liveness probe. Mirrors the upstream
+deploy/evs-csi-plugin/kubernetes/csi-evs-node.yaml, with the CCE-specific
+pods-mount path (/mnt/paas/kubernetes/kubelet) replaced by the k3s default
+(<kubeletDir>/pods) — CRITICAL for k3s, else volumes can't mount into Pods.
+
+The node plugin self-discovers THIS node's ECS server-id from the OpenStack
+metadata service (http://169.254.169.254/openstack/latest/meta_data.json →
+uuid), verified reachable on the live kom4dc nodes — so NO cloud-controller-
+manager / providerID is required (the --nodeid flag is deprecated and ignored;
+verified in cmd/evs-csi-plugin/main.go). It mounts the cloud-config for the
+EVS attach-status queries.
+
+Privileged (bidirectional mount propagation, host /dev + kubelet dir). Gated
+on .Values.enabled.
+*/}}
+{{- if .Values.enabled }}
+{{- $img := .Values.image -}}
+{{- $kubelet := .Values.kubeletDir | default "/var/lib/kubelet" -}}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: csi-evs-node
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: bp-huawei-evs-csi
+    app.kubernetes.io/component: node
+    catalyst.openova.io/blueprint: bp-huawei-evs-csi
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bp-huawei-evs-csi
+      app.kubernetes.io/component: node
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bp-huawei-evs-csi
+        app.kubernetes.io/component: node
+    spec:
+      serviceAccountName: csi-evs-node-sa
+      priorityClassName: system-node-critical
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: evs-driver-registrar
+          image: "{{ $img.sidecars.nodeDriverRegistrar.repository }}:{{ $img.sidecars.nodeDriverRegistrar.tag }}"
+          imagePullPolicy: {{ $img.driver.pullPolicy | default "IfNotPresent" }}
+          args:
+            - "--v=2"
+            - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: {{ $kubelet }}/plugins/evs.csi.huaweicloud.com/csi.sock
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+          resources:
+            requests: { cpu: 10m, memory: 16Mi }
+            limits: { memory: 64Mi }
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: { drop: [ALL] }
+            seccompProfile: { type: RuntimeDefault }
+        - name: liveness-probe
+          image: "{{ $img.sidecars.livenessProbe.repository }}:{{ $img.sidecars.livenessProbe.tag }}"
+          imagePullPolicy: {{ $img.driver.pullPolicy | default "IfNotPresent" }}
+          args:
+            - "--csi-address=/csi/csi.sock"
+            - "--health-port=9810"
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+          resources:
+            requests: { cpu: 10m, memory: 16Mi }
+            limits: { memory: 64Mi }
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: { drop: [ALL] }
+            seccompProfile: { type: RuntimeDefault }
+        - name: evs-csi-plugin
+          image: "{{ $img.driver.repository }}:{{ $img.driver.tag }}"
+          imagePullPolicy: {{ $img.driver.pullPolicy | default "IfNotPresent" }}
+          args:
+            - "/bin/evs-csi-plugin"
+            - "--v=2"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--cloud-config=/etc/evs/cloud-config"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9810
+            initialDelaySeconds: 15
+            periodSeconds: 60
+            timeoutSeconds: 10
+            failureThreshold: 5
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: pods-mount-dir
+              mountPath: {{ $kubelet }}/pods
+              mountPropagation: Bidirectional
+            - name: device-dir
+              mountPath: /dev
+            - name: sys-dir
+              mountPath: /sys
+            - name: evs-config
+              mountPath: /etc/evs/
+              readOnly: true
+          resources:
+            {{- toYaml .Values.node.resources | nindent 12 }}
+          securityContext:
+            privileged: true
+            capabilities:
+              add: [SYS_ADMIN]
+            allowPrivilegeEscalation: true
+      volumes:
+        - name: registration-dir
+          hostPath:
+            path: {{ $kubelet }}/plugins_registry/
+            type: DirectoryOrCreate
+        - name: plugin-dir
+          hostPath:
+            path: {{ $kubelet }}/plugins/evs.csi.huaweicloud.com/
+            type: DirectoryOrCreate
+        - name: pods-mount-dir
+          hostPath:
+            path: {{ $kubelet }}/pods
+            type: Directory
+        - name: device-dir
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: sys-dir
+          hostPath:
+            path: /sys
+            type: Directory
+        - name: evs-config
+          secret:
+            secretName: cloud-config
+{{- end }}

--- a/platform/huawei-evs-csi/chart/templates/rbac.yaml
+++ b/platform/huawei-evs-csi/chart/templates/rbac.yaml
@@ -1,0 +1,143 @@
+{{/*
+RBAC for the huaweicloud-csi-driver EVS controller + node plugins.
+
+Two ServiceAccounts:
+  - csi-evs-controller-sa — the CSI external-* sidecar permissions
+    (PV/PVC/VolumeAttachment/VolumeSnapshot/StorageClass/CSINode/Node R/W).
+  - csi-evs-node-sa       — minimal (read Node + events) for the node plugin.
+
+Scoped to exactly what the sig-storage external sidecars require. Default off.
+*/}}
+{{- if .Values.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-evs-controller-sa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: bp-huawei-evs-csi
+    catalyst.openova.io/blueprint: bp-huawei-evs-csi
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-evs-node-sa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: bp-huawei-evs-csi
+    catalyst.openova.io/blueprint: bp-huawei-evs-csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: csi-evs-controller
+  labels:
+    app.kubernetes.io/name: bp-huawei-evs-csi
+    catalyst.openova.io/blueprint: bp-huawei-evs-csi
+rules:
+  # external-provisioner
+  - apiGroups: [""]
+    resources: [persistentvolumes]
+    verbs: [get, list, watch, create, delete, patch]
+  - apiGroups: [""]
+    resources: [persistentvolumeclaims]
+    verbs: [get, list, watch, update]
+  - apiGroups: [""]
+    resources: [persistentvolumeclaims/status]
+    verbs: [update, patch]
+  - apiGroups: [storage.k8s.io]
+    resources: [storageclasses]
+    verbs: [get, list, watch]
+  - apiGroups: [""]
+    resources: [events]
+    verbs: [list, watch, create, update, patch]
+  - apiGroups: [snapshot.storage.k8s.io]
+    resources: [volumesnapshots]
+    verbs: [get, list, watch, update, patch]
+  - apiGroups: [snapshot.storage.k8s.io]
+    resources: [volumesnapshotcontents]
+    verbs: [get, list, watch, update, patch, create, delete]
+  - apiGroups: [snapshot.storage.k8s.io]
+    resources: [volumesnapshotclasses]
+    verbs: [get, list, watch]
+  - apiGroups: [snapshot.storage.k8s.io]
+    resources: [volumesnapshotcontents/status]
+    verbs: [update, patch]
+  - apiGroups: [snapshot.storage.k8s.io]
+    resources: [volumesnapshots/status]
+    verbs: [update, patch]
+  # external-attacher
+  - apiGroups: [storage.k8s.io]
+    resources: [volumeattachments]
+    verbs: [get, list, watch, update, patch]
+  - apiGroups: [storage.k8s.io]
+    resources: [volumeattachments/status]
+    verbs: [patch]
+  # external-resizer + provisioner CSINode/Node reads
+  - apiGroups: [""]
+    resources: [nodes]
+    verbs: [get, list, watch]
+  - apiGroups: [storage.k8s.io]
+    resources: [csinodes]
+    verbs: [get, list, watch]
+  - apiGroups: [""]
+    resources: [pods]
+    verbs: [get, list, watch]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: [leases]
+    verbs: [get, list, watch, create, update, patch, delete]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-evs-controller
+  labels:
+    app.kubernetes.io/name: bp-huawei-evs-csi
+    catalyst.openova.io/blueprint: bp-huawei-evs-csi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: csi-evs-controller
+subjects:
+  - kind: ServiceAccount
+    name: csi-evs-controller-sa
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: csi-evs-node
+  labels:
+    app.kubernetes.io/name: bp-huawei-evs-csi
+    catalyst.openova.io/blueprint: bp-huawei-evs-csi
+rules:
+  - apiGroups: [""]
+    resources: [nodes]
+    verbs: [get, list, watch, update, patch]
+  - apiGroups: [""]
+    resources: [events]
+    verbs: [list, watch, create, update, patch]
+  - apiGroups: [storage.k8s.io]
+    resources: [csinodes]
+    verbs: [get, list, watch, update, patch]
+  - apiGroups: [storage.k8s.io]
+    resources: [volumeattachments]
+    verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-evs-node
+  labels:
+    app.kubernetes.io/name: bp-huawei-evs-csi
+    catalyst.openova.io/blueprint: bp-huawei-evs-csi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: csi-evs-node
+subjects:
+  - kind: ServiceAccount
+    name: csi-evs-node-sa
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/platform/huawei-evs-csi/chart/templates/storageclass.yaml
+++ b/platform/huawei-evs-csi/chart/templates/storageclass.yaml
@@ -1,0 +1,49 @@
+{{/*
+Catalyst-managed StorageClasses for the Huawei EVS CSI.
+Renders one StorageClass per entry in .Values.catalystStorageClasses[].
+Default off (gated by .Values.enabled).
+
+provisioner is `evs.csi.huaweicloud.com` — the huaweicloud-csi-driver EVS
+plugin (must match the CSIDriver object). The EVS volume-type selector is the
+FLAT `type` parameter (verified in pkg/evs/nodeserver.go:512 — NOT everest's
+everest.io/disk-volume-type). HCS me-east-215 exposes only SSD / SAS, so SSD
+is pinned by default. WaitForFirstConsumer so the volume lands in the
+consuming Pod's AZ (the driver sets topology from the node metadata's
+availability_zone).
+
+When .Values.defaultStorageClass is true the FIRST entry is annotated as the
+cluster default. The default-class flip hook also promotes it + demotes any
+stale default so there is EXACTLY ONE default class (on a fresh prov local-path
+never exists — k3s --disable=local-storage — so the demote is a no-op).
+*/}}
+{{- if .Values.enabled -}}
+{{- range $i, $sc := .Values.catalystStorageClasses }}
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ $sc.name | quote }}
+  labels:
+    app.kubernetes.io/name: bp-huawei-evs-csi
+    app.kubernetes.io/component: storage-class
+    catalyst.openova.io/blueprint: bp-huawei-evs-csi
+    catalyst.openova.io/blueprint-version: {{ $.Chart.Version | quote }}
+  annotations:
+{{- if and $.Values.defaultStorageClass (eq $i 0) }}
+    storageclass.kubernetes.io/is-default-class: "true"
+{{- end }}
+provisioner: evs.csi.huaweicloud.com
+reclaimPolicy: {{ $sc.reclaimPolicy | default "Retain" | quote }}
+volumeBindingMode: {{ $sc.volumeBindingMode | default "WaitForFirstConsumer" | quote }}
+allowVolumeExpansion: {{ $sc.allowVolumeExpansion | default true }}
+parameters:
+  # EVS volume type — the driver's flat `type` parameter. HCS me-east-215
+  # exposes SSD / SAS only; SSD pinned for production IOPS.
+  type: {{ $sc.volumeType | default "SSD" | quote }}
+  # Filesystem the node plugin formats the raw EVS device with.
+  csi.storage.k8s.io/fstype: {{ $sc.fsType | default "ext4" | quote }}
+{{- with $sc.extraParameters }}
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/platform/huawei-evs-csi/chart/templates/volumesnapshotclass.yaml
+++ b/platform/huawei-evs-csi/chart/templates/volumesnapshotclass.yaml
@@ -1,0 +1,22 @@
+{{/*
+VolumeSnapshotClass for everest EVS snapshots (storage-level DR / backup).
+
+Gated on .Values.enabled + .Values.volumeSnapshotClass.enabled. The snapshot
+controller + the snapshot.storage.k8s.io CRDs are installed cluster-wide by
+the platform (the bp-cnpg / snapshot-controller stack) — this only adds the
+class. driver MUST match the CSIDriver name (evs.csi.huaweicloud.com).
+*/}}
+{{- if and .Values.enabled .Values.volumeSnapshotClass.enabled }}
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: {{ .Values.volumeSnapshotClass.name | default "evs-snapshots" | quote }}
+  labels:
+    app.kubernetes.io/name: bp-huawei-evs-csi
+    app.kubernetes.io/component: volume-snapshot-class
+    catalyst.openova.io/blueprint: bp-huawei-evs-csi
+    catalyst.openova.io/blueprint-version: {{ .Chart.Version | quote }}
+driver: evs.csi.huaweicloud.com
+deletionPolicy: {{ .Values.volumeSnapshotClass.deletionPolicy | default "Delete" | quote }}
+{{- end }}

--- a/platform/huawei-evs-csi/chart/values.yaml
+++ b/platform/huawei-evs-csi/chart/values.yaml
@@ -1,0 +1,138 @@
+# bp-huawei-evs-csi — Huawei EVS block-storage CSI for HCS/kom4dc.
+#
+# Driver: the OPEN-SOURCE huaweicloud-csi-driver EVS plugin
+# (provisioner `evs.csi.huaweicloud.com`) — NOT the closed-source CCE
+# `everest` add-on (disk.csi.everest.io). The everest add-on is bound to
+# CCE's agency / IAM pod-identity, ships no public manifests, and cannot run
+# on a bare k3s cluster. The open-source driver is purpose-built for
+# self-managed clusters: it authenticates with a portable AK/SK INI
+# cloud-config and self-discovers each node's ECS server-id from the
+# OpenStack metadata service — confirmed reachable on the live hw174 nodes
+# (169.254.169.254/openstack/latest/meta_data.json → uuid + availability_zone
+# me-east-215a). Verified directly from the driver source (pkg/config/cloud.go,
+# pkg/utils/metadatas/metadata.go, pkg/evs/driver.go,nodeserver.go).
+#
+# Master gate. Default off — a bare `helm install` renders ZERO resources
+# (mirrors bp-hcloud-csi). The bootstrap-kit slot 55b flips this true on
+# Huawei provs only (HUAWEI_HR_SUSPEND-gated). On Hetzner the slot is
+# default-suspended, so this chart never installs there.
+enabled: false
+
+# Flip `evs-ssd` to the cluster-default StorageClass (renders the
+# is-default-class annotation + runs the default-class flip hook). Tracks
+# `enabled` from the slot. Default false so a bare install is reversible.
+defaultStorageClass: false
+
+# ─── Huawei AK/SK cloud-config (the driver reads this to call the EVS API) ──
+# These values are populated at HelmRelease apply time via Flux `valuesFrom`
+# against the canonical flux-system/cloud-credentials Secret (keys
+# huawei-ak / huawei-sk / huawei-project-id / huawei-region — seeded by the
+# Huawei cloud-init Phase 0). Per docs/PRINCIPLES.md #10 (credentials NEVER
+# on the CR / in Git) these stay EMPTY in committed YAML; the live values land
+# at apply time and are never persisted. When huaweiAccessKey is empty the
+# cloud-config Secret template renders nothing, so a default-off / Hetzner
+# render is a clean no-op.
+huaweiAccessKey: ""
+huaweiSecretKey: ""
+huaweiProjectId: ""
+huaweiRegion: ""
+
+# `cloud` — the HCS API domain suffix. The driver derives every service
+# endpoint as `https://<service>.<region>.<cloud>/` (verified in
+# pkg/config/cloud.go newServiceClient). For kom4dc this resolves EVS to
+# `https://evs.me-east-215.kom4dc.nationalcloud.om/` — exactly the live
+# endpoint probed on hw174.
+cloud: "kom4dc.nationalcloud.om"
+
+# `auth-url` — the HCS IAM v3 token endpoint. Pin it EXPLICITLY: the driver's
+# auto-default drops the region (`https://iam.<cloud>:443/v3/`) which is wrong
+# for HCS. The slot substitutes the live region.
+authUrl: "https://iam.me-east-215.kom4dc.nationalcloud.om/v3"
+
+# everest must skip TLS verification against the on-prem HCS CA (not in the
+# standard trust store) — mirrors the tofu provider's `insecure = true`.
+insecureSkipTLSVerify: true
+
+# ─── StorageClass(es) ───────────────────────────────────────────────────
+# The FIRST entry is promoted to cluster-default when defaultStorageClass is
+# true. HCS me-east-215 exposes only `SSD` and `SAS` EVS volume types
+# (confirmed live via the EVS cinder list-volume-types probe, main.tf line
+# ~1066) — SSD is pinned for production IOPS. The volume-type parameter key is
+# the FLAT `type` key (verified in pkg/evs/nodeserver.go:512 — NOT everest's
+# `everest.io/disk-volume-type`). reclaimPolicy Retain gives the same
+# production-data durability posture as hcloud-volumes.
+catalystStorageClasses:
+  - name: evs-ssd
+    volumeType: SSD
+    reclaimPolicy: Retain
+    volumeBindingMode: WaitForFirstConsumer
+    allowVolumeExpansion: true
+    fsType: ext4
+
+# VolumeSnapshotClass for storage-level DR / backup (Velero etc.). The EVS
+# driver supports snapshots. ON by default (#3971 — same posture as
+# bp-hcloud-csi's VolumeSnapshotClass).
+volumeSnapshotClass:
+  enabled: true
+  name: evs-snapshots
+  deletionPolicy: Delete
+
+# ─── driver + sidecar images ────────────────────────────────────────────
+# The EVS driver image lives in Huawei SWR (cn-north-4); on kom4dc every
+# upstream registry is proxy-mirrored through harbor.openova.io (the bastion
+# NAT bypass — infra/providers/huawei/main.tf registry_mirror_yaml_huawei).
+# The driver image is mirrored through a harbor proxy project so the Kyverno
+# harbor-proxy-pull policy passes. Sidecar images are repointed from the
+# deprecated k8s.gcr.io to registry.k8s.io (identical paths/tags) via the
+# harbor proxy-k8s cache.
+#
+# Tags pinned to the versions the upstream deploy manifests ship
+# (evs-csi-plugin v0.1.11 + the six sig-storage sidecars). Overridable per
+# Sovereign if the local SWR mirror carries a different driver version.
+image:
+  driver:
+    repository: harbor.openova.io/proxy-swr-csi/k8s-csi/evs-csi-plugin
+    tag: "v0.1.11"
+    pullPolicy: IfNotPresent
+  sidecars:
+    provisioner:
+      repository: harbor.openova.io/proxy-k8s/sig-storage/csi-provisioner
+      tag: "v3.0.0"
+    attacher:
+      repository: harbor.openova.io/proxy-k8s/sig-storage/csi-attacher
+      tag: "v3.3.0"
+    resizer:
+      repository: harbor.openova.io/proxy-k8s/sig-storage/csi-resizer
+      tag: "v1.3.0"
+    snapshotter:
+      repository: harbor.openova.io/proxy-k8s/sig-storage/csi-snapshotter
+      tag: "v4.2.1"
+    nodeDriverRegistrar:
+      repository: harbor.openova.io/proxy-k8s/sig-storage/csi-node-driver-registrar
+      tag: "v2.4.0"
+    livenessProbe:
+      repository: harbor.openova.io/proxy-k8s/sig-storage/livenessprobe
+      tag: "v2.5.0"
+
+# kubelet root dir — k3s uses /var/lib/kubelet. CRITICAL override: the
+# upstream node DaemonSet hardcodes CCE's pods path
+# (/mnt/paas/kubernetes/kubelet); on k3s it MUST be <kubeletDir>/pods or the
+# node plugin can't bind-mount volumes into Pods.
+kubeletDir: /var/lib/kubelet
+
+# Cluster name passed to the driver --cluster flag (used for volume metadata
+# tagging). The slot substitutes the Sovereign FQDN slug.
+clusterName: catalyst
+
+# Controller resourcing (HA — 2 replicas across nodes for multi-node provs).
+controller:
+  replicas: 2
+  resources:
+    requests: { cpu: 50m, memory: 64Mi }
+    limits: { memory: 256Mi }
+
+# Node plugin (DaemonSet — one per node, privileged for mount).
+node:
+  resources:
+    requests: { cpu: 25m, memory: 48Mi }
+    limits: { memory: 192Mi }

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -689,6 +689,20 @@ slots:
     depends_on: []
     wave: present
 
+  # ---- Slot 55b — bp-huawei-evs-csi (Huawei EVS CSI driver, #3971 follow-up).
+  # The Huawei (HCS / kom4dc) STORAGE sibling of slot 55a. Installs the
+  # open-source huaweicloud-csi-driver EVS plugin (evs.csi.huaweicloud.com) +
+  # the durable evs-ssd default StorageClass so Huawei PVCs land on real EVS
+  # block volumes (local-path FORBIDDEN by --disable=local-storage). No
+  # dependsOn: foundational cloud seam, Ready before the stateful apps create
+  # PVCs (cloud-credentials seeded by cloud-init pre-Flux, chart pulls from
+  # ghcr). Default-suspended on Hetzner (HUAWEI_HR_SUSPEND); the Huawei
+  # cloud-init flips it active. Closes the Huawei half of the #3971 P0 blocker.
+  - slot: 55b
+    name: bp-huawei-evs-csi
+    depends_on: []
+    wave: present
+
   # ---- Slots 56/57 — OpenovaFlow observability cohort.
   # Stateless HTTP+SSE event router (slot 56, primary cluster only) +
   # region-aware Flux adapter DaemonSet (slot 57, every cluster).


### PR DESCRIPTION
Refs #3971 #3992. **Do NOT merge — orchestrator sequences + re-fires cycle 1.**

## What this is
The **Huawei half** of the #3971 P0 storage gap. #3992 forbade k3s local-path on *all* providers and wired the stateful root slots to `dependsOn: bp-hcloud-csi` — but `bp-hcloud-csi` is the *Hetzner* Cloud CSI and renders **empty** on Huawei. So a Huawei (HCS / kom4dc) prov came up with **no StorageClass at all** → every stateful PVC Pending → vCluster StatefulSets never scheduled → `vc-mgmt/rtz/dmz` kubeconfig secrets never created → `bp-catalyst-platform` spine frozen at ~40/50 HRs.

**Confirmed live on hw174 (`ea30d1d816f2eee2`, both regions):** `get sc` + `get csidrivers` = "No resources found", 12 PVCs Pending.

## Driver choice — investigated live, not guessed
The right driver is the **open-source `huaweicloud-csi-driver` EVS plugin** (`evs.csi.huaweicloud.com`), **not** the everest CCE add-on:
- everest (`disk.csi.everest.io`) is closed-source, has no public manifests, needs CCE agency / IAM pod-identity → **infeasible on bare k3s**.
- the open-source driver uses a **portable AK/SK INI cloud-config** (which `cloud-credentials` already carries) + **OpenStack-metadata node identity** (no CCM needed). Confirmed on hw174: `169.254.169.254/openstack/latest/meta_data.json` → `uuid` + `availability_zone me-east-215a`; `evs.me-east-215.kom4dc.nationalcloud.om` answers.
- `cinder-csi-plugin` rejected — needs Keystone username/password; HCS exposes only AK/SK.

Driver facts (driver name, cloud-config struct, metadata URL, the flat `type` SC param) verified directly from the driver source + upstream deploy manifests.

## Live proof on hw174 (the only acceptance)
Applied the rendered chart to region A. **Before → after:**
- `get storageclass`: `No resources found` → **`evs-ssd (default)`** (`evs.csi.huaweicloud.com`, Retain, WaitForFirstConsumer)
- `get csidrivers`: `No resources found` → **`evs.csi.huaweicloud.com`**
- the default-class flip hook ran and the default **propagated to 9/12 stateful PVCs** (`storage-provisioner: evs.csi.huaweicloud.com`)
- driver image mirrored SWR(cn-north-4, AK/SK-authed) → `ghcr.io/openova-io` and pulled fine on the controller

## Residual hard issue found + reported (not hidden — NO local-path fallback)
The driver controller **CrashLoops**: its golangsdk does an upfront Keystone auth (`GET /v3/auth/catalog` + `POST /v3/auth/tokens`) and **HCS me-east-215's IAM APIGW publishes NEITHER** — every Keystone v3 path → `APIGW.0101 "API does not exist"` (probed exhaustively across `iam` / `iam-apigateway-proxy` / `iam-cache-proxy`). The `idc` cloud-config field that would bypass the catalog fetch is **declared-but-unused** in the driver source (verified vs upstream master). The EVS data API itself works (tofu provisions EVS disks with the same AK/SK via direct request signing) — the gap is purely the driver's auth init.

**Remaining work = an auth fix:** patch the driver to sign EVS requests with AK/SK directly + skip the catalog fetch, OR discover the real HCS IAM token endpoint. → founder decision.

## Safe-by-default (no regression)
Slot 55b ships **`EVS_CSI_ENABLED=false`** so the HR installs empty + Ready (no convergence regression); a Huawei prov honestly has **no default class** → the Phase-1 storage-durability gate FAILS it (never silent local-path). Flip `EVS_CSI_ENABLED` true the moment the auth fix lands.

## Changes
- `platform/huawei-evs-csi/` — new Blueprint (CSIDriver + controller Deployment + node DaemonSet w/ k3s `/var/lib/kubelet` paths + `evs-ssd` default StorageClass + VolumeSnapshotClass + cloud-config Secret via Flux valuesFrom + RBAC + the provisioner-agnostic default-class flip hook reused from bp-hcloud-csi).
- `clusters/_template/bootstrap-kit/55b-bp-huawei-evs-csi.yaml` + `placement.yaml` row — default-suspended on Hetzner (`HUAWEI_HR_SUSPEND`); Huawei activates it but `enabled` is gated on `EVS_CSI_ENABLED` (false until auth fix). Registered in `kustomization.yaml` + `scripts/expected-bootstrap-deps.yaml`.
- cloud-init: `HUAWEI_CLOUD_DOMAIN` / `HUAWEI_AUTH_URL` / `EVS_CSI_ENABLED` substitutes.
- `infra/providers/huawei/main.tf` — fix the latent `huawei-project-id` bug (was `var.huawei_region`); the EVS API path needs the real project-id.

## Gates
helm-template default-off=0 / enabled=full set; kustomize 167 res; `check-bootstrap-deps` 0 drift; placement-as-data row added; pin-sync clean (the bp-newapi drift pre-exists on main); `lint-cloudinit both` PASS. Hetzner path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)