### PR TITLE
fix(catalyst-rbac): cutover-driver SA can patch Flux reconcilers — recon reconcile/suspend/resume no longer 502 (Refs #3996 #3999)

### DIFF
--- a/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
+++ b/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
@@ -545,3 +545,59 @@ rules:
   - apiGroups: ["source.toolkit.fluxcd.io"]
     resources: ["gitrepositories"]
     verbs: ["get", "list", "watch"]
+
+  # ───────────────────────────────────────────────────────────────
+  # Issue #3996 / #3999 — RECONCILER-MANAGEMENT ACTIONS (reconcile /
+  # suspend / resume) on the Cloud view's Reconciliation lens. The
+  # handler (internal/handler/reconcilers.go ReconcilerAction) drives
+  # the FULL Flux reconciler set via the in-cluster dynamic client:
+  #   reconcile → MergePatch metadata.annotations
+  #               reconcile.fluxcd.io/requestedAt=<RFC3339>
+  #   suspend   → MergePatch spec.suspend=true
+  #   resume    → MergePatch spec.suspend=false
+  # All three are a single apiserver Patch (types.MergePatchType), so
+  # the ONLY mutating verb the surface needs is `patch` (no `update`,
+  # no `create`, no `delete` — those actions never run here).
+  #
+  # The six manageable kinds are the source of truth in
+  # internal/helmwatch/manage.go managedGVRByKind:
+  #   helm.toolkit.fluxcd.io/helmreleases
+  #   kustomize.toolkit.fluxcd.io/kustomizations
+  #   source.toolkit.fluxcd.io/{gitrepositories,ocirepositories,
+  #                             helmrepositories,helmcharts}
+  #
+  # Caught live on hw174 (UAT rows 196/197): every action 502'd with
+  #   helmreleases.helm.toolkit.fluxcd.io is forbidden: ServiceAccount
+  #   "catalyst-api-cutover-driver" cannot patch resource "helmreleases"
+  # because the SA had only get/list/watch on the Flux kinds above and
+  # NO patch anywhere — the requestedAt annotation + spec.suspend never
+  # landed. This rule adds the missing patch verb (least-privilege:
+  # only `patch`, only the six kinds the recon surface manages).
+  #
+  # The three source kinds ocirepositories/helmrepositories/helmcharts
+  # also had NO read rule at all, so the management LIST (GET
+  # /reconcilers, helmwatch.ListManagedReconcilers) never surfaced them
+  # — granted get/list/watch here too so they render and are drivable.
+  # helmreleases/kustomizations/gitrepositories already carry
+  # get/list/watch above; RBAC rules merge additively so only the
+  # missing verbs/kinds are added here.
+  # ───────────────────────────────────────────────────────────────
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: ["helmreleases"]
+    verbs: ["patch"]
+  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+    resources: ["kustomizations"]
+    verbs: ["patch"]
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources:
+      - gitrepositories
+      - ocirepositories
+      - helmrepositories
+      - helmcharts
+    verbs: ["patch"]
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources:
+      - ocirepositories
+      - helmrepositories
+      - helmcharts
+    verbs: ["get", "list", "watch"]


### PR DESCRIPTION
## The defect (live on hw174, UAT rows 196/197)

The Cloud-view **Reconciliation lens** management actions return **HTTP 502**:

```
POST /api/v1/deployments/ea30d1d816f2eee2/reconcilers/HelmRelease/flux-system/bp-falco/reconcile
→ 502: helmreleases.helm.toolkit.fluxcd.io is forbidden: ServiceAccount
       "catalyst-api-cutover-driver" cannot patch resource "helmreleases"
```

Same for suspend. The `reconcile.fluxcd.io/requestedAt` annotation + `spec.suspend` never land. The API surface (`internal/handler/reconcilers.go` `ReconcilerAction`) is correct — only the RBAC grant was missing.

## Root cause

`ReconcilerAction` drives the six manageable Flux kinds (source of truth: `internal/helmwatch/manage.go` `managedGVRByKind`) via a single in-cluster `Patch` (`types.MergePatchType`):
- reconcile → `metadata.annotations[reconcile.fluxcd.io/requestedAt]`
- suspend → `spec.suspend=true`
- resume → `spec.suspend=false`

The `catalyst-api-cutover-driver` ClusterRole granted only `get/list/watch` on `helmreleases`/`kustomizations`/`gitrepositories` and **no `patch` anywhere**, and had **no rule at all** for `ocirepositories`/`helmrepositories`/`helmcharts`.

## Fix

`products/catalyst/chart/templates/clusterrole-cutover-driver.yaml` (appended block):
- `patch` verb on all six manageable Flux kinds (least-privilege — only `patch`; the handler never uses update/create/delete here).
- `get/list/watch` on `ocirepositories`/`helmrepositories`/`helmcharts` so the management LIST (`helmwatch.ListManagedReconcilers`) surfaces them.
- The existing get/list/watch on helmreleases/kustomizations/gitrepositories stays; RBAC rules merge additively.

## Gate

- `helm template … --show-only templates/clusterrole-cutover-driver.yaml` renders the ClusterRole with the new patch verbs.
- `kubectl apply --dry-run=client` validates it as a well-formed K8s object (60 rules).

## Acceptance (live verify on hw174 — pending orchestrator sequencing)

Apply the updated ClusterRole to the live cluster, then re-run via the authed API:
- `POST .../reconcilers/HelmRelease/flux-system/bp-falco/reconcile` → expect **200**
- `kubectl get hr bp-falco -n flux-system -o yaml | grep requestedAt` → annotation **landed**
- suspend → `spec.suspend:true` → resume → `false`

This flips **UAT rows 196/197 ❌→✅**.

Refs #3996 #3999

🤖 Generated with [Claude Code](https://claude.com/claude-code)