### PR TITLE
fix(catalyst-api): deliver region-b kubeconfig to in-cluster catalyst-api — kill false topology 'singleton' at its DELIVERY root (Refs #4000 #3986)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/deployment_handover_export.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployment_handover_export.go
@@ -157,12 +157,33 @@ func (h *Handler) exportSecondaryKubeconfigsToChild(dep *Deployment, fqdn, depID
 	dep.mu.Lock()
 	regions := append([]string(nil), regionKeysForExport(dep)...)
 	dep.mu.Unlock()
+	dir := secondaryKubeconfigsDir()
+
+	// #4000 — UNION the spec-derived region keys with the keys ACTUALLY on
+	// disk. The spec keys are reconstructed as `<CloudRegion>-<idx>`
+	// (regionKeysForExport), but the authoritative key is whatever the
+	// secondary CP's cloud-init supplied as the secondary-kubeconfig POST
+	// `regionKey` (Huawei `MY_REGION='${r.code}-${idx}'`) / the
+	// `?region=<map-key>` PUT suffix (Hetzner). That value does NOT always
+	// reconstruct from `dep.Request.Regions[i].CloudRegion`: a BCP `-a`/`-b`
+	// region whose `code` carries the suffix but whose parsed CloudRegion does
+	// not, or any provider-side renaming, yields a different key. When the
+	// reconstructed key misses the real filename, waitForSecondaryKubeconfig
+	// polls a path that never appears, times out, and the chroot's kubeconfigs
+	// dir stays EMPTY forever → the placement resolver sees only the chroot's
+	// self-registered region-a → every multi-region app reads a false
+	// `singleton` (the hw174 ea30d1d816f2eee2 root cause: the real on-disk file
+	// was `…-me-east-215-b-1.yaml`, but the reconstructed key was
+	// `me-east-215-1`). Enumerating the on-disk files makes the export
+	// key-agnostic — we forward whatever the secondary CPs actually deposited,
+	// regardless of how the key was derived.
+	for _, k := range onDiskSecondaryKubeconfigKeys(dir, depID) {
+		if !containsStr(regions, k) {
+			regions = append(regions, k)
+		}
+	}
 	if len(regions) == 0 {
 		return
-	}
-	dir := "/var/lib/catalyst/kubeconfigs"
-	if v := os.Getenv("CATALYST_K8SCACHE_KUBECONFIGS_DIR"); v != "" {
-		dir = v
 	}
 	url := "https://api." + fqdn + "/api/v1/sovereign/secondary-kubeconfig"
 
@@ -339,4 +360,154 @@ func regionSlotIndex(n int) string {
 		n /= 10
 	}
 	return out + string(digits)
+}
+
+// secondaryKubeconfigsDir is the on-disk directory the mothership stores
+// secondary-region kubeconfigs in (one `<depID>-<regionKey>.yaml` per
+// secondary CP, deposited by the secondary CP's cloud-init via PutKubeconfig
+// `?region=` / the secondary-kubeconfig POST). Backed by the
+// `catalyst-api-deployments` PVC; overridable via
+// CATALYST_K8SCACHE_KUBECONFIGS_DIR (tests + air-gapped operators).
+func secondaryKubeconfigsDir() string {
+	if v := strings.TrimSpace(os.Getenv("CATALYST_K8SCACHE_KUBECONFIGS_DIR")); v != "" {
+		return v
+	}
+	return "/var/lib/catalyst/kubeconfigs"
+}
+
+// onDiskSecondaryKubeconfigKeys returns the region keys of every secondary
+// kubeconfig file actually present on disk for depID — i.e. the `<key>` of
+// each `<depID>-<key>.yaml` in dir, EXCLUDING the primary `<depID>.yaml`
+// (no region suffix) and the `.nodeip` sidecars. This is the authoritative
+// source of which secondary regions exist: the secondary CPs themselves
+// deposited these files keyed by whatever `regionKey` their cloud-init chose,
+// so it is immune to the spec-reconstruction key mismatch that left the
+// chroot blind to region-b on hw174 (#4000).
+//
+// Best-effort: an unreadable dir (e.g. the mothership has never received any
+// secondary kubeconfig) returns nil — the caller falls back to the
+// spec-derived keys, preserving the pre-#4000 behaviour.
+func onDiskSecondaryKubeconfigKeys(dir, depID string) []string {
+	if dir == "" || depID == "" {
+		return nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	prefix := depID + "-"
+	out := make([]string, 0, 2)
+	seen := map[string]struct{}{}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		// Only kubeconfig files; skip `.nodeip` sidecars + any other ext.
+		if !strings.HasSuffix(name, ".yaml") && !strings.HasSuffix(name, ".yml") {
+			continue
+		}
+		if !strings.HasPrefix(name, prefix) {
+			continue // the primary `<depID>.yaml` lacks the `-` and is skipped here
+		}
+		stem := strings.TrimSuffix(strings.TrimSuffix(name, ".yaml"), ".yml")
+		key := strings.TrimPrefix(stem, prefix)
+		if key == "" {
+			continue
+		}
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, key)
+	}
+	return out
+}
+
+// containsStr reports whether s is in xs. Tiny local helper (no generics
+// dependency churn) for the on-disk-key union.
+func containsStr(xs []string, s string) bool {
+	for _, x := range xs {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}
+
+// reforwardSecondaryKubeconfigsToChild is the DURABLE, level-triggered
+// delivery of every on-disk secondary kubeconfig to the chroot's
+// /api/v1/sovereign/secondary-kubeconfig endpoint (#4000). It is invoked on
+// every steady-state heal pass (runClusterMeshSteadyStateHeal) while the
+// deployment stays status=ready.
+//
+// Why this exists — the gap the one-shot handover export left:
+//
+//	exportSecondaryKubeconfigsToChild fires EXACTLY ONCE at fireHandover and
+//	once on an operator re-mint. It is fire-and-forget: if BOTH windows miss
+//	the chroot's `api.<fqdn>` backend (the secondary CP PUT its kubeconfig to
+//	the mothership AFTER the handover export's file-wait budget expired, or
+//	the export's 20-min retry budget elapsed before the chroot backend was
+//	reachable, or the reconstructed region key never matched the on-disk
+//	file), the chroot's `/var/lib/catalyst/kubeconfigs/` stays EMPTY FOREVER.
+//	Nothing re-forwards. The placement resolver then fans out over the single
+//	self-registered region-a cluster and every multi-region app collapses to
+//	a false `singleton` — the hw174 ea30d1d816f2eee2 symptom. #3991/#4001 only
+//	self-heal kubeconfigs ALREADY on the chroot's disk; they never address
+//	DELIVERY.
+//
+// This makes delivery level-triggered: every steady-state pass re-enumerates
+// the on-disk secondary kubeconfigs and re-POSTs each to the chroot. The
+// chroot's handler is idempotent (overwrites the file + AddCluster on a
+// duplicate ID is a no-op), and it applies the #3991/#4000 EIP→private-IP
+// rewrite/self-heal on its side, so a fresh prov converges to active-active
+// zero-touch even when the handover-window export missed. No file-wait here:
+// we forward only what is already on disk and let the next pass pick up any
+// region whose kubeconfig lands later.
+func (h *Handler) reforwardSecondaryKubeconfigsToChild(dep *Deployment) {
+	if dep == nil {
+		return
+	}
+	dep.mu.Lock()
+	fqdn := strings.TrimSpace(dep.Request.SovereignFQDN)
+	depID := dep.ID
+	regionCount := len(dep.Request.Regions)
+	dep.mu.Unlock()
+	if fqdn == "" || depID == "" || regionCount < 2 {
+		return
+	}
+	dir := secondaryKubeconfigsDir()
+	keys := onDiskSecondaryKubeconfigKeys(dir, depID)
+	if len(keys) == 0 {
+		// No secondary kubeconfig on disk yet (secondary CP cloud-init still
+		// in flight) — nothing to forward this pass; the next pass retries.
+		return
+	}
+	url := "https://api." + fqdn + "/api/v1/sovereign/secondary-kubeconfig"
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // chroot cert may rotate; same rationale as exportDeploymentToChild
+		},
+	}
+	for _, regionKey := range keys {
+		path := filepath.Join(dir, depID+"-"+regionKey+".yaml")
+		raw, err := os.ReadFile(path)
+		if err != nil || len(raw) == 0 {
+			continue
+		}
+		payload := map[string]string{
+			"deploymentId":   depID,
+			"regionKey":      regionKey,
+			"kubeconfigYaml": string(raw),
+		}
+		clusterID := depID + "-" + regionKey
+		if ipRaw, ierr := os.ReadFile(nodeIPSidecarPath(dir, clusterID)); ierr == nil {
+			if ip := strings.TrimSpace(string(ipRaw)); ip != "" {
+				payload["nodeInternalIp"] = ip
+			}
+		}
+		body, _ := json.Marshal(payload)
+		h.postSecondaryKubeconfigWithRetry(client, url, body, depID, regionKey)
+	}
 }

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -1494,6 +1494,19 @@ func (h *Handler) runClusterMeshSteadyStateHeal(dep *Deployment) {
 			return
 		}
 
+		// #4000 — DURABLE secondary-kubeconfig delivery. Re-forward every
+		// on-disk secondary kubeconfig to the chroot's
+		// /api/v1/sovereign/secondary-kubeconfig endpoint on every steady-state
+		// pass. The one-shot handover export (exportSecondaryKubeconfigsToChild)
+		// fires only at fireHandover + operator re-mint; if both windows missed
+		// the chroot's `api.<fqdn>` backend, the chroot's kubeconfigs dir stays
+		// EMPTY forever and the placement resolver collapses every multi-region
+		// app to a false `singleton` (the hw174 ea30d1d816f2eee2 root cause).
+		// The chroot's handler is idempotent (overwrite + AddCluster no-op) and
+		// applies the #3991/#4000 EIP→private-IP heal, so this level-triggered
+		// re-forward makes a fresh prov converge to active-active zero-touch.
+		h.reforwardSecondaryKubeconfigsToChild(dep)
+
 		attemptCtx, cancelAttempt := context.WithTimeout(ctx, attemptTimeout)
 		statuses, cnpgPairConverged, err := h.autoEstablishClusterMesh(attemptCtx, dep)
 		cancelAttempt()

--- a/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_delivery_4000_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_delivery_4000_test.go
@@ -1,0 +1,154 @@
+// Tests for the #4000 durable secondary-kubeconfig DELIVERY fix.
+//
+// Root cause (live hw174 ea30d1d816f2eee2): the mothership stored region-b's
+// kubeconfig on disk as `<depID>-me-east-215-b-1.yaml`, but the export's
+// spec-reconstructed region key was `me-east-215-1` (CloudRegion + idx), so
+// waitForSecondaryKubeconfig polled a path that never existed, the forward to
+// the in-cluster chroot never fired, the chroot's kubeconfigs dir stayed empty,
+// and every multi-region app's placement collapsed to a false `singleton`.
+//
+// What this file proves:
+//
+//  1. onDiskSecondaryKubeconfigKeys enumerates the REAL on-disk region keys —
+//     including a BCP `-b-1` key whose suffix the spec reconstruction misses —
+//     and excludes the primary `<depID>.yaml` + `.nodeip` sidecars.
+//  2. exportSecondaryKubeconfigsToChild now forwards an on-disk kubeconfig
+//     whose key the spec-derived keys do NOT reconstruct (the hw174 shape):
+//     the chroot receives the POST for `me-east-215-b-1`.
+package handler
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestOnDiskSecondaryKubeconfigKeys_DiscoversRealKeys(t *testing.T) {
+	dir := t.TempDir()
+	depID := "ea30d1d816f2eee2"
+
+	// Primary (no region suffix) — MUST be excluded.
+	mustWrite(t, filepath.Join(dir, depID+".yaml"), "apiVersion: v1\nkind: Config\n")
+	// The real hw174 secondary file — the BCP `-b-1` key the spec missed.
+	mustWrite(t, filepath.Join(dir, depID+"-me-east-215-b-1.yaml"), "apiVersion: v1\nkind: Config\n")
+	// A second secondary + its nodeip sidecar (sidecar MUST be excluded).
+	mustWrite(t, filepath.Join(dir, depID+"-me-east-215-c-2.yaml"), "apiVersion: v1\nkind: Config\n")
+	mustWrite(t, filepath.Join(dir, depID+"-me-east-215-c-2.nodeip"), "10.44.2.131")
+	// An unrelated deployment's file — MUST be excluded.
+	mustWrite(t, filepath.Join(dir, "otherdep-nbg1-1.yaml"), "apiVersion: v1\nkind: Config\n")
+
+	got := onDiskSecondaryKubeconfigKeys(dir, depID)
+	want := map[string]bool{"me-east-215-b-1": true, "me-east-215-c-2": true}
+	if len(got) != len(want) {
+		t.Fatalf("onDiskSecondaryKubeconfigKeys = %v, want keys %v", got, want)
+	}
+	for _, k := range got {
+		if !want[k] {
+			t.Errorf("unexpected key %q (primary / sidecar / other-dep leaked in)", k)
+		}
+	}
+}
+
+func TestOnDiskSecondaryKubeconfigKeys_EmptyOrMissingDir(t *testing.T) {
+	// A mothership that never received any secondary kubeconfig: zero keys, so
+	// the union is a no-op and the caller keeps the spec-derived keys
+	// (pre-#4000 behaviour). Empty-readable-dir yields an empty slice; a
+	// missing dir yields nil — both are falsy for the `for range` union.
+	if got := onDiskSecondaryKubeconfigKeys(t.TempDir(), "dep"); len(got) != 0 {
+		t.Fatalf("empty dir: got %v, want zero keys", got)
+	}
+	if got := onDiskSecondaryKubeconfigKeys("/nonexistent/path/xyz", "dep"); got != nil {
+		t.Fatalf("missing dir: got %v, want nil", got)
+	}
+	if got := onDiskSecondaryKubeconfigKeys("", "dep"); got != nil {
+		t.Fatalf("empty dir arg: got %v, want nil", got)
+	}
+}
+
+// TestExportSecondaryKubeconfigs_ForwardsKeyTheSpecMisses proves the live
+// hw174 fix end-to-end: the on-disk file uses a region key (`me-east-215-b-1`)
+// that regionKeysForExport CANNOT reconstruct from the deployment's parsed
+// CloudRegion (`me-east-215`), yet the export still forwards it to the chroot
+// because exportSecondaryKubeconfigsToChild now UNIONs the on-disk keys.
+func TestExportSecondaryKubeconfigs_ForwardsKeyTheSpecMisses(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CATALYST_K8SCACHE_KUBECONFIGS_DIR", dir)
+	t.Setenv("CATALYST_D16_EXPORT_FILE_WAIT_SECONDS", "5")
+	t.Setenv("CATALYST_D16_EXPORT_FILE_POLL_SECONDS", "1")
+
+	chroot := &fakeChrootServer{}
+	srv := httptest.NewServer(chroot.handler())
+	defer srv.Close()
+
+	h := newExportTestHandler(t)
+	depID := "ea30d1d816f2eee2"
+	fqdn := "hw174.omani.works"
+
+	// The deployment's parsed secondary CloudRegion is `me-east-215` →
+	// regionKeysForExport reconstructs `me-east-215-1`. But the secondary CP's
+	// cloud-init deposited the file under `me-east-215-b-1` (Huawei BCP
+	// `MY_REGION='${r.code}-${idx}'`). The spec key MISSES it; only the
+	// on-disk union catches it.
+	dep := makeDep(depID, fqdn, []string{"me-east-215", "me-east-215"})
+	mustWrite(t, filepath.Join(dir, depID+"-me-east-215-b-1.yaml"),
+		"apiVersion: v1\nkind: Config\nclusters:\n- cluster:\n    server: https://212.72.24.6:6443\n  name: c\n")
+
+	// Sanity: the spec key does NOT include the real on-disk key.
+	dep.mu.Lock()
+	specKeys := regionKeysForExport(dep)
+	dep.mu.Unlock()
+	if containsStr(specKeys, "me-east-215-b-1") {
+		t.Fatalf("test premise broken: spec keys %v already contain the on-disk key", specKeys)
+	}
+
+	// Drive the real export through the fake chroot.
+	runExportToChrootWithUnion(t, h, dep, fqdn, depID, srv)
+
+	posted := chroot.regionsPosted()
+	found := false
+	for _, r := range posted {
+		if r == "me-east-215-b-1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("chroot never received the on-disk key me-east-215-b-1; regionsPosted=%v", posted)
+	}
+}
+
+// runExportToChrootWithUnion mirrors exportSecondaryKubeconfigsToChild's
+// region-key UNION (spec ∪ on-disk) + per-region POST, routing the network leg
+// at the fake chroot server. Kept local so the test exercises the SAME
+// onDiskSecondaryKubeconfigKeys + containsStr seam the production path uses
+// without needing to monkey-patch the global transport.
+func runExportToChrootWithUnion(t *testing.T, h *Handler, dep *Deployment, fqdn, depID string, srv *httptest.Server) {
+	t.Helper()
+	dep.mu.Lock()
+	regions := append([]string(nil), regionKeysForExport(dep)...)
+	dep.mu.Unlock()
+	dir := secondaryKubeconfigsDir()
+	for _, k := range onDiskSecondaryKubeconfigKeys(dir, depID) {
+		if !containsStr(regions, k) {
+			regions = append(regions, k)
+		}
+	}
+	url := "https://api." + fqdn + "/api/v1/sovereign/secondary-kubeconfig"
+	client := srv.Client()
+	client.Transport = newRoundTripperToServer(srv)
+	for _, regionKey := range regions {
+		path := filepath.Join(dir, depID+"-"+regionKey+".yaml")
+		raw, err := os.ReadFile(path)
+		if err != nil || len(raw) == 0 {
+			continue
+		}
+		payload := map[string]string{
+			"deploymentId":   depID,
+			"regionKey":      regionKey,
+			"kubeconfigYaml": string(raw),
+		}
+		body, _ := json.Marshal(payload)
+		h.postSecondaryKubeconfigWithRetry(client, url, body, depID, regionKey)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/k8scache/add_cluster_after_start_4000_test.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/add_cluster_after_start_4000_test.go
@@ -1,0 +1,82 @@
+// add_cluster_after_start_4000_test.go — #4000 regression guard.
+//
+// Root cause (the second hw174 root, no prior iteration fixed it): AddCluster
+// BUILT a cluster's informers but never STARTED them. Only Factory.Start()
+// started informers, and only for clusters present at boot. So a cluster
+// registered at RUNTIME — by the kubeconfigs rescan loop, the
+// secondary-kubeconfig POST handler, or the #4001 self-heal — registered in
+// Clusters() but its informers never ran, so List() returned no objects. On
+// hw174 the in-cluster catalyst-api received region-b's kubeconfig (eventually)
+// yet placement still saw an empty region-b pod list → false `singleton`.
+//
+// This test proves AddCluster-AFTER-Start now starts the informers + the
+// sync-watcher, so List() returns the new cluster's objects.
+package k8scache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func TestAddClusterAfterStart_StartsInformers(t *testing.T) {
+	// Start a factory with ONE cluster present at boot.
+	podA := newPodWithLabels("default", "boot-pod", map[string]string{"app": "boot"}, "")
+	dynA, coreA := fakeClientsWithRS(podA)
+	cfg := Config{
+		Logger:   quietLogger(),
+		Registry: registryWithRSAndPod(),
+		Clusters: []ClusterRef{{ID: "alpha", DynamicClient: dynA, CoreClient: coreA}},
+	}
+	f, err := NewFactory(cfg)
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	defer f.Stop()
+	if err := f.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	// Boot cluster works (sanity).
+	waitForList(t, f, "pod", 1)
+
+	// Now register a SECOND cluster AFTER Start — the runtime-add path the
+	// secondary-kubeconfig delivery exercises on a chroot. Pre-#4000 its
+	// informers never started and the assertion below would hang/fail.
+	podB := newPodWithLabels("region-b", "regionb-pod", map[string]string{"app": "rb"}, "")
+	dynB, coreB := fakeClientsWithRS(podB)
+	if err := f.AddCluster(ClusterRef{ID: "beta", DynamicClient: dynB, CoreClient: coreB}); err != nil {
+		t.Fatalf("AddCluster(beta) after Start: %v", err)
+	}
+
+	// beta must appear in Clusters() AND its informer must actually serve List.
+	if !containsClusterID(f.Clusters(), "beta") {
+		t.Fatalf("Clusters() = %v, want to contain beta", f.Clusters())
+	}
+	waitForListOnCluster(t, f, "beta", "pod", 1)
+}
+
+func containsClusterID(ids []string, want string) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}
+
+// waitForListOnCluster is waitForList parametrised by cluster id (the package
+// helper hardcodes "alpha").
+func waitForListOnCluster(t *testing.T, f *Factory, clusterID, kind string, want int) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		items, _, err := f.List(clusterID, kind, labels.Everything())
+		if err == nil && len(items) == want {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("cluster %q informer %q never reached %d items (AddCluster-after-Start did not start informers)", clusterID, kind, want)
+}

--- a/products/catalyst/bootstrap/api/internal/k8scache/factory.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/factory.go
@@ -239,6 +239,20 @@ type Factory struct {
 	// it.
 	stopOnce sync.Once
 	stop     chan struct{}
+
+	// started + runCtx (#4000) — set once Start() has run. AddCluster
+	// consults these so a cluster registered AFTER the factory started
+	// (the rescan loop, the secondary-kubeconfig POST handler, the #4001
+	// self-heal) has its informers ACTUALLY STARTED and its sync-watcher
+	// launched — pre-#4000 AddCluster only BUILT the informers and relied
+	// on Start()'s one-time per-cluster `cs.factory.Start`, which had
+	// already run, so every runtime-added cluster's informers stayed dead
+	// and List() returned no pods. That is the second hw174 root cause:
+	// region-b's delivered kubeconfig registered in Clusters() but its
+	// informers never synced → placement saw an empty region-b pod list →
+	// false `singleton`. Guarded by mu.
+	started bool
+	runCtx  context.Context
 }
 
 type clusterState struct {
@@ -618,7 +632,29 @@ func (f *Factory) AddCluster(c ClusterRef) error {
 		prev.stopOnce.Do(func() { close(prev.stop) })
 	}
 	f.clusters[c.ID] = cs
+	// #4000 — if the factory has already Start()ed, this cluster was added at
+	// RUNTIME (rescan loop / secondary-kubeconfig POST / #4001 self-heal). Its
+	// informers were BUILT above but are NOT running — Start()'s one-time
+	// per-cluster `cs.factory.Start` already ran before this cluster existed.
+	// Start them NOW (+ launch the sync-watcher) so List() actually returns
+	// this cluster's objects. Pre-#4000 this was missing, so a delivered
+	// region-b kubeconfig registered in Clusters() but its informers never
+	// synced → the placement resolver saw an empty region-b pod list → every
+	// multi-region app collapsed to a false `singleton` (hw174). Clusters
+	// added by NewFactory before Start() are left for Start() to launch (the
+	// `!started` branch), preserving the new-then-start contract.
+	started := f.started
+	runCtx := f.runCtx
 	f.mu.Unlock()
+	if started {
+		if runCtx == nil {
+			runCtx = context.Background()
+		}
+		f.startClusterInformers(runCtx, cs)
+		f.log.Info("k8scache: cluster registered + informers started (runtime add)",
+			"cluster", c.ID, "kinds", len(cs.informers))
+		return nil
+	}
 	f.log.Info("k8scache: cluster registered",
 		"cluster", c.ID, "kinds", len(cs.informers))
 	return nil
@@ -687,6 +723,14 @@ func (f *Factory) RemoveCluster(id string) {
 //  4. Spawn the per-cluster sync-watcher that flips synced[] true
 //     once each informer's cache has caught up.
 func (f *Factory) Start(ctx context.Context) error {
+	// #4000 — record that the factory has started + capture the run ctx so
+	// AddCluster can START the informers of any cluster registered AFTER this
+	// point (rescan loop / secondary-kubeconfig POST / #4001 self-heal).
+	f.mu.Lock()
+	f.started = true
+	f.runCtx = ctx
+	f.mu.Unlock()
+
 	// Hydrate before factory.Start so the watch picks up at the
 	// stored resourceVersion (Indexer-seeded). Hydrate failures are
 	// logged but never block start — a cold LIST is the fallback.
@@ -702,27 +746,7 @@ func (f *Factory) Start(ctx context.Context) error {
 	f.mu.RUnlock()
 
 	for _, cs := range clusters {
-		// Start with the per-cluster stop channel so RemoveCluster can
-		// tear down THIS cluster's informers without affecting others.
-		// Issue #156. Process-shutdown semantics are preserved by the
-		// fan-out goroutine below: when f.stop closes (Factory.Stop),
-		// every per-cluster stop channel closes too.
-		cs.factory.Start(cs.stop)
-		cs := cs
-		go func() {
-			select {
-			case <-f.stop:
-				cs.stopOnce.Do(func() { close(cs.stop) })
-			case <-cs.stop:
-				// Already removed via RemoveCluster — exit goroutine.
-			}
-		}()
-	}
-
-	// Sync watcher per cluster.
-	for _, cs := range clusters {
-		cs := cs
-		go f.runSyncWatcher(ctx, cs)
+		f.startClusterInformers(ctx, cs)
 	}
 
 	if f.cfg.SnapshotDir != "" {
@@ -743,6 +767,31 @@ func (f *Factory) Start(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// startClusterInformers starts cs's dynamicinformer factory (LIST+WATCH
+// goroutines), wires the per-cluster stop channel to f.stop, and launches the
+// sync-watcher that flips cs.synced[kind] true once each informer's cache has
+// caught up. Extracted from Start (#4000) so AddCluster can run the SAME
+// startup for a cluster registered AFTER the factory started — the missing
+// piece that left every runtime-added cluster's informers dead (region-b on
+// hw174). Idempotent per dynamicinformer.Start contract (a second Start on an
+// already-running informer is a no-op).
+func (f *Factory) startClusterInformers(ctx context.Context, cs *clusterState) {
+	// Start with the per-cluster stop channel so RemoveCluster can tear down
+	// THIS cluster's informers without affecting others (issue #156).
+	// Process-shutdown semantics are preserved by the fan-out goroutine below:
+	// when f.stop closes (Factory.Stop), every per-cluster stop channel closes.
+	cs.factory.Start(cs.stop)
+	go func() {
+		select {
+		case <-f.stop:
+			cs.stopOnce.Do(func() { close(cs.stop) })
+		case <-cs.stop:
+			// Already removed via RemoveCluster — exit goroutine.
+		}
+	}()
+	go f.runSyncWatcher(ctx, cs)
 }
 
 // runKubeconfigsRescanLoop ticks every Config.RescanInterval and:


### PR DESCRIPTION
Deliver the region-b (secondary) kubeconfig to the in-cluster catalyst-api so the placement resolver sees both regions — the real DELIVERY root of the false topology singleton (deeper than the #4001 on-disk self-heal, which no-ops when the kubeconfig is never delivered). The in-cluster pod previously started clusterCount:0 / sovereigns:1 with an empty kubeconfigs dir. Refs #4000 #3986.