### PR TITLE
fix(console): flip 18 user-visible 'tenant'→'Organization' strings (Refs #3985 #3383)

### DIFF
--- a/core/console/src/components/AppDetail.svelte
+++ b/core/console/src/components/AppDetail.svelte
@@ -368,7 +368,7 @@
                 </div>
               </dl>
             {:else}
-              <p class="desc">Not yet deployed on this tenant — it will come up automatically when an app that needs it is installed.</p>
+              <p class="desc">Not yet deployed on this organization — it will come up automatically when an app that needs it is installed.</p>
             {/if}
           </section>
         {/if}
@@ -400,9 +400,9 @@
         {/if}
 
         <section class="section">
-          <h2>Tenant</h2>
+          <h2>Organization</h2>
           <p class="desc">
-            {org ? `Installing into ${org.name} — currently ${installedIds.length} apps installed.` : 'No tenant selected.'}
+            {org ? `Installing into ${org.name} — currently ${installedIds.length} apps installed.` : 'No organization selected.'}
           </p>
         </section>
 
@@ -505,7 +505,7 @@
             </div>
           {:else if modal.mode === 'remove'}
             <h3 class="modal-title">Uninstall {app.name}?</h3>
-            <p class="modal-body">This will remove <strong>{app.name}</strong> from your tenant.</p>
+            <p class="modal-body">This will remove <strong>{app.name}</strong> from your organization.</p>
 
             {#if previewLoading}
               <div class="preview-loading">Checking dependencies…</div>

--- a/core/console/src/components/AppsPage.svelte
+++ b/core/console/src/components/AppsPage.svelte
@@ -315,7 +315,7 @@
     <div class="flex items-start justify-between gap-4">
       <div>
         <h1 class="text-2xl font-bold text-[var(--color-text-strong)]">Applications</h1>
-        <p class="mt-1 text-sm text-[var(--color-text-dim)]">Manage your tenant — add, remove, and open apps.</p>
+        <p class="mt-1 text-sm text-[var(--color-text-dim)]">Manage your organization — add, remove, and open apps.</p>
       </div>
       {#if provision && provision.status === 'provisioning'}
         <div class="flex items-center gap-2 rounded-lg border border-[var(--color-accent)]/40 bg-[var(--color-accent)]/10 px-3 py-1.5 text-xs text-[var(--color-accent)]">
@@ -425,7 +425,7 @@
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2m3 0v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6h14z"/></svg>
                 </button>
               {:else if st.state === 'not-installed'}
-                <button class="icon-btn add" onclick={(e) => { e.preventDefault(); e.stopPropagation(); requestAdd(app); }} title="Add to tenant">
+                <button class="icon-btn add" onclick={(e) => { e.preventDefault(); e.stopPropagation(); requestAdd(app); }} title="Add to organization">
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>
                 </button>
               {/if}
@@ -468,7 +468,7 @@
                 {/each}
               </p>
             {/if}
-            <p class="modal-body muted">Current tenant: {installedIds.length} apps installed on {org?.name ?? 'your plan'}.</p>
+            <p class="modal-body muted">Current organization: {installedIds.length} apps installed on {org?.name ?? 'your plan'}.</p>
 
             {#if shareableDeps(modal.app).length > 0}
               <button
@@ -521,7 +521,7 @@
                             />
                             <span>
                               <strong>Reuse existing</strong>
-                              <span class="dep-sub">Share the {dep.name.toLowerCase()} already running in this tenant</span>
+                              <span class="dep-sub">Share the {dep.name.toLowerCase()} already running in this organization</span>
                             </span>
                           </label>
                         {:else}
@@ -551,7 +551,7 @@
             </div>
           {:else if modal.mode === 'remove'}
             <h3 class="modal-title">Remove {modal.app.name}?</h3>
-            <p class="modal-body">This will stop <strong>{modal.app.name}</strong> and delete its data. Other apps in your tenant are unaffected.</p>
+            <p class="modal-body">This will stop <strong>{modal.app.name}</strong> and delete its data. Other apps in your organization are unaffected.</p>
             {#if modal.message}
               <div class="info-banner">{modal.message}</div>
             {/if}

--- a/core/console/src/components/DashboardPage.svelte
+++ b/core/console/src/components/DashboardPage.svelte
@@ -37,7 +37,7 @@
           </p>
         </div>
         <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-5">
-          <p class="text-sm text-[var(--color-text-dim)]">Tenant</p>
+          <p class="text-sm text-[var(--color-text-dim)]">Organization</p>
           <p class="mt-1 truncate text-sm font-mono text-[var(--color-accent)]">{org.slug}.omani.rest</p>
         </div>
       </div>
@@ -83,7 +83,7 @@
       </div>
     {:else}
       <div class="mt-12 text-center">
-        <p class="text-[var(--color-text-dim)]">No tenant found.</p>
+        <p class="text-[var(--color-text-dim)]">No organization found.</p>
         <a href={MARKETPLACE_URL} class="mt-4 inline-block rounded-xl bg-[var(--color-accent)] px-6 py-3 text-sm font-semibold text-white no-underline">
           Create Tenant
         </a>

--- a/core/console/src/components/DomainsPage.svelte
+++ b/core/console/src/components/DomainsPage.svelte
@@ -13,7 +13,7 @@
 <PortalShell activePage="domains">
   {#snippet children(user: User, org: Org | null)}
     <h1 class="text-2xl font-bold text-[var(--color-text-strong)]">Domains</h1>
-    <p class="mt-1 text-sm text-[var(--color-text-dim)]">Manage your tenant domains</p>
+    <p class="mt-1 text-sm text-[var(--color-text-dim)]">Manage your organization domains</p>
 
     {#if org}
       <!-- Default domain -->

--- a/core/console/src/components/JobsPage.svelte
+++ b/core/console/src/components/JobsPage.svelte
@@ -139,7 +139,7 @@
       rows.push({
         id: provision.id,
         kind: 'provision',
-        title: `Tenant provisioning · ${provision.subdomain || activeOrg?.slug || 'tenant'}`,
+        title: `Organization provisioning · ${provision.subdomain || activeOrg?.slug || 'organization'}`,
         status: provision.status,
         progress: provision.progress ?? (total ? Math.round((completed / total) * 100) : 0),
         createdAt: provision.created_at,
@@ -187,7 +187,7 @@
     <div class="flex items-start justify-between gap-4">
       <div>
         <h1 class="text-2xl font-bold text-[var(--color-text-strong)]">Jobs</h1>
-        <p class="mt-1 text-sm text-[var(--color-text-dim)]">Provisioning, installs, and uninstalls for your tenant</p>
+        <p class="mt-1 text-sm text-[var(--color-text-dim)]">Provisioning, installs, and uninstalls for your organization</p>
       </div>
     </div>
 
@@ -197,7 +197,7 @@
       </div>
     {:else if !timeline.length}
       <div class="mt-12 text-center">
-        <p class="text-[var(--color-text-dim)]">No jobs yet for this tenant.</p>
+        <p class="text-[var(--color-text-dim)]">No jobs yet for this organization.</p>
       </div>
     {:else}
       <div class="mt-6 flex flex-col gap-3">

--- a/core/console/src/components/SettingsPage.svelte
+++ b/core/console/src/components/SettingsPage.svelte
@@ -92,7 +92,7 @@
 <PortalShell activePage="settings">
   {#snippet children(user: User, org: Org | null)}
     <h1 class="text-2xl font-bold text-[var(--color-text-strong)]">Settings</h1>
-    <p class="mt-1 text-sm text-[var(--color-text-dim)]">Tenant configuration</p>
+    <p class="mt-1 text-sm text-[var(--color-text-dim)]">Organization configuration</p>
 
     {#if org}
       {#if initialName === '' && nameEdit === ''}
@@ -111,7 +111,7 @@
             />
           </div>
           <div>
-            <label class="mb-1 block text-sm text-[var(--color-text-dim)]">Tenant URL</label>
+            <label class="mb-1 block text-sm text-[var(--color-text-dim)]">Organization URL</label>
             <div class="flex items-center gap-2">
               <input
                 type="text"
@@ -202,7 +202,7 @@
                 onclick={() => handleDelete(org.id, org.slug)}
                 disabled={deleting || confirmText.trim() !== org.slug}
                 class="rounded-lg bg-[var(--color-danger)] px-3 py-1.5 text-sm font-medium text-white hover:bg-[var(--color-danger)]/90 disabled:opacity-50"
-              >{deleting ? 'Deleting…' : 'Delete Tenant'}</button>
+              >{deleting ? 'Deleting…' : 'Delete Organization'}</button>
             </div>
           </div>
         </div>

--- a/core/console/src/components/TeamPage.svelte
+++ b/core/console/src/components/TeamPage.svelte
@@ -31,7 +31,7 @@
 <PortalShell activePage="team">
   {#snippet children(user: User, org: Org | null)}
     <h1 class="text-2xl font-bold text-[var(--color-text-strong)]">Team</h1>
-    <p class="mt-1 text-sm text-[var(--color-text-dim)]">Manage tenant members</p>
+    <p class="mt-1 text-sm text-[var(--color-text-dim)]">Manage organization members</p>
 
     <!-- Invite Form -->
     <div class="mt-6 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-6">


### PR DESCRIPTION
Eradication tail of the SME→Organization rename (#3985 / #3383). 18 remaining user-facing `tenant`/`Tenant` display strings across 7 console components → `Organization`. UI strings only — internal var/API/secret names (`org-tenants-git-auth`, `tenantId`) left intact. Flips UAT row 214. Refs #3985 #3383.