### PR TITLE
fix(cloud-view): surface the REAL front-door LB from the deployment record, not the empty XRC layer (Refs #3998 #3987)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader.go
+++ b/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader.go
@@ -398,17 +398,6 @@ func buildRegionFromLiveNodes(ctx context.Context, in LoaderInput) (Region, bool
 	if in.Region != "" {
 		clusterID = "cluster-" + in.DeploymentID + "-" + in.Region
 	}
-	cluster := Cluster{
-		ID:            clusterID,
-		Name:          clusterName,
-		Version:       "v1.31",
-		Status:        in.Status,
-		NodeCount:     len(allNodes),
-		VClusters:     loadVClusters(ctx, in),
-		LoadBalancers: []LoadBalancer{},
-		NodePools:     pools,
-		Nodes:         allNodes,
-	}
 	// Provider selection: prefer the wizard-declared provider; if the
 	// chroot's synthesised deployment has no Provider (G14, Refs
 	// #2551), sniff the first Node's provider hints before defaulting.
@@ -416,6 +405,9 @@ func buildRegionFromLiveNodes(ctx context.Context, in LoaderInput) (Region, bool
 	// "huawei://..." / "hcloud://...") + sometimes a label like
 	// "topology.kubernetes.io/cloud-provider". Default "hetzner" is
 	// kept only as the absolute last resort.
+	//
+	// Resolved BEFORE the cluster is built so frontDoorLBs can pick the
+	// correct FrontDoorKind (gateway-eip on Huawei vs cloud-lb elsewhere).
 	provider := in.Provider
 	if provider == "" {
 		for _, n := range list.Items {
@@ -441,6 +433,26 @@ func buildRegionFromLiveNodes(ctx context.Context, in LoaderInput) (Region, bool
 	}
 	if provider == "" {
 		provider = "hetzner"
+	}
+	// Carry the resolved provider so frontDoorLBs reads the real value
+	// even when the synthesised deployment had no declared Provider.
+	lbIn := in
+	lbIn.Provider = provider
+	cluster := Cluster{
+		ID:        clusterID,
+		Name:      clusterName,
+		Version:   "v1.31",
+		Status:    in.Status,
+		NodeCount: len(allNodes),
+		VClusters: loadVClusters(ctx, in),
+		// Refs #3998: source the front-door LB from the deployment record
+		// (Result.LoadBalancerIP), NOT the empty XRC layer — so the live
+		// chroot path (the one every real Sovereign hits, since catalyst-api
+		// runs in-cluster) shows the real EIP/Gateway or cloud LB instead
+		// of 0/0.
+		LoadBalancers: frontDoorLBs(lbIn, regionName),
+		NodePools:     pools,
+		Nodes:         allNodes,
 	}
 	region := Region{
 		ID:             "region-" + regionName,
@@ -638,6 +650,21 @@ func buildNodePools(in LoaderInput, rs provisioner.RegionSpec) []NodePool {
 }
 
 func buildLBs(in LoaderInput, rs provisioner.RegionSpec) []LoadBalancer {
+	return frontDoorLBs(in, rs.CloudRegion)
+}
+
+// frontDoorLBs composes the cloud front-door LoadBalancer row from the
+// DEPLOYMENT RECORD (Result.LoadBalancerIP) — the source of truth that is
+// always populated post-Phase-0 — rather than the empty Crossplane XRC
+// layer (Refs #3998). On Hetzner the IP is a real `hcloud_load_balancer`;
+// on Huawei kom4dc it is the EIP DNAT'd to the Cilium Gateway NodePort
+// (FrontDoorKind distinguishes them so the UI can explain the datapath).
+//
+// Both the declared (mothership) path and the live chroot path call this,
+// so the LB page renders the real front door on EVERY Sovereign instead
+// of 0/0. Returns an empty slice (never a synthesised row) when the
+// record has no LoadBalancerIP yet, per the no-placeholder principle.
+func frontDoorLBs(in LoaderInput, region string) []LoadBalancer {
 	if in.Result == nil || in.Result.LoadBalancerIP == "" {
 		return []LoadBalancer{}
 	}
@@ -645,14 +672,33 @@ func buildLBs(in LoaderInput, rs provisioner.RegionSpec) []LoadBalancer {
 	if name == "" {
 		name = "ingress-lb"
 	}
+	// The platform's standard front door terminates HTTPS (443) + HTTP
+	// (80) at the Cilium Gateway and exposes the k3s/k8s apiserver on
+	// 6443. These are the listeners every Sovereign provisions; sourced
+	// from the deploy topology, not fabricated per-cluster runtime state.
+	listeners := []LoadBalancerListener{
+		{Port: 80, Protocol: "tcp"},
+		{Port: 443, Protocol: "tcp"},
+		{Port: 6443, Protocol: "tcp"},
+	}
+	// FrontDoorKind: Huawei has no day-2 ELB instantiated (the EIP DNATs
+	// straight to the Gateway NodePort), so model it as gateway-eip;
+	// every other provider provisions a real cloud LB.
+	frontDoor := "cloud-lb"
+	if strings.EqualFold(in.Provider, "huawei") {
+		frontDoor = "gateway-eip"
+	}
 	return []LoadBalancer{{
-		ID:           "lb-" + in.DeploymentID,
-		Name:         name,
-		PublicIP:     in.Result.LoadBalancerIP,
-		Ports:        "80,443,6443",
-		TargetHealth: "—",
-		Region:       rs.CloudRegion,
-		Status:       in.Status,
+		ID:            "lb-" + in.DeploymentID,
+		Name:          name,
+		PublicIP:      in.Result.LoadBalancerIP,
+		Listeners:     listeners,
+		Targets:       []LoadBalancerTarget{},
+		Ports:         "80,443,6443",
+		TargetHealth:  "—",
+		Region:        region,
+		Status:        in.Status,
+		FrontDoorKind: frontDoor,
 	}}
 }
 

--- a/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader_frontdoor_test.go
+++ b/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader_frontdoor_test.go
@@ -1,0 +1,171 @@
+// topology_loader_frontdoor_test.go — proves the front-door LoadBalancer
+// fix (Refs #3998): the cloud-view LB page must surface the REAL front
+// door on EVERY Sovereign, sourced from the deployment record
+// (Result.LoadBalancerIP), NOT the empty Crossplane XRC layer.
+//
+// Root cause this guards against: the live chroot path
+// (buildRegionFromLiveNodes — the branch every real Sovereign hits, since
+// catalyst-api runs in-cluster) previously hardcoded
+// `LoadBalancers: []LoadBalancer{}`, so the LB page rendered 0/0 even
+// though Result.LoadBalancerIP held the live EIP/cloud-LB. On hw174
+// (Huawei, EIP DNAT'd to the Cilium Gateway NodePort) that meant the
+// operator could not answer "how is the platform fronted".
+package infrastructure
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// liveNodeClient builds a fake dynamic client carrying real Nodes so the
+// loader's live chroot path (buildRegionFromLiveNodes) fires. The vcluster
+// + node list-kinds are registered so the discovery probes return empty
+// (production: apiserver 404) instead of panicking.
+func liveNodeClient(t *testing.T, providerID string) dynamic.Interface {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	cp := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cp-0",
+			Labels: map[string]string{
+				"node-role.kubernetes.io/control-plane": "",
+				"node.kubernetes.io/instance-type":      "s7.large.2",
+			},
+		},
+		Spec:   corev1.NodeSpec{ProviderID: providerID},
+		Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}}},
+	}
+	worker := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "worker-0",
+			Labels: map[string]string{"node.kubernetes.io/instance-type": "s7.xlarge.2"},
+		},
+		Spec:   corev1.NodeSpec{ProviderID: providerID},
+		Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}}},
+	}
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		{Group: "vcluster.io", Version: "v1alpha1", Resource: "vclusters"}: "VClusterList",
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, cp, worker)
+}
+
+func lbsOf(r Region) []LoadBalancer {
+	out := []LoadBalancer{}
+	for _, c := range r.Clusters {
+		out = append(out, c.LoadBalancers...)
+	}
+	return out
+}
+
+// TestFrontDoor_LiveChrootPath_SurfacesLBFromRecord is the decisive
+// regression guard: the live chroot path now emits a non-empty LB sourced
+// from Result.LoadBalancerIP, with FrontDoorKind=gateway-eip on Huawei.
+func TestFrontDoor_LiveChrootPath_SurfacesLBFromRecord(t *testing.T) {
+	const depID = "ea30d1d816f2eee2"
+	in := LoaderInput{
+		DeploymentID:  depID,
+		Status:        "ready",
+		SovereignFQDN: "hw174.omani.works",
+		// No declared Provider + no Regions → forces the live chroot path
+		// (buildRegionFromLiveNodes), exactly like the in-cluster catalyst-api
+		// on a real Sovereign. Provider is sniffed from the node providerID.
+		Result:        &provisioner.Result{LoadBalancerIP: "212.72.24.33"},
+		DynamicClient: liveNodeClient(t, "huawei:///me-east-215-a/abc-123"),
+	}
+
+	resp := Load(context.Background(), in)
+	if len(resp.Topology.Regions) != 1 {
+		t.Fatalf("expected 1 region from live nodes, got %d", len(resp.Topology.Regions))
+	}
+	lbs := lbsOf(resp.Topology.Regions[0])
+	if len(lbs) != 1 {
+		t.Fatalf("REGRESSION: live chroot path emitted %d LBs, want 1 (the front door sourced from Result.LoadBalancerIP)", len(lbs))
+	}
+	lb := lbs[0]
+	if lb.PublicIP != "212.72.24.33" {
+		t.Errorf("LB PublicIP = %q, want the record's LoadBalancerIP 212.72.24.33", lb.PublicIP)
+	}
+	if lb.FrontDoorKind != "gateway-eip" {
+		t.Errorf("FrontDoorKind = %q, want gateway-eip (Huawei EIP→Gateway NodePort)", lb.FrontDoorKind)
+	}
+	if len(lb.Listeners) == 0 {
+		t.Errorf("LB.Listeners empty — the UI's listeners column would render '—'")
+	}
+	// Worker nodes must still be real (sourced from live K8s, not XRCs).
+	var nodeCount int
+	for _, c := range resp.Topology.Regions[0].Clusters {
+		nodeCount += len(c.Nodes)
+	}
+	if nodeCount != 2 {
+		t.Errorf("expected 2 live nodes surfaced, got %d", nodeCount)
+	}
+}
+
+// TestFrontDoor_DeclaredPath_CloudLBForHetzner asserts the mothership /
+// declared path also emits the structured listeners + a cloud-lb
+// FrontDoorKind for a provider that provisions a real cloud LB.
+func TestFrontDoor_DeclaredPath_CloudLBForHetzner(t *testing.T) {
+	in := LoaderInput{
+		DeploymentID:  "depHZ",
+		Status:        "ready",
+		SovereignFQDN: "t99.omani.works",
+		Provider:      "hetzner",
+		Region:        "fsn1",
+		Regions: []provisioner.RegionSpec{
+			{Provider: "hetzner", CloudRegion: "fsn1", WorkerCount: 2},
+		},
+		Result: &provisioner.Result{LoadBalancerIP: "5.6.7.8"},
+	}
+	resp := Load(context.Background(), in)
+	if len(resp.Topology.Regions) != 1 {
+		t.Fatalf("expected 1 region, got %d", len(resp.Topology.Regions))
+	}
+	lbs := lbsOf(resp.Topology.Regions[0])
+	if len(lbs) != 1 {
+		t.Fatalf("expected 1 LB on the declared path, got %d", len(lbs))
+	}
+	lb := lbs[0]
+	if lb.PublicIP != "5.6.7.8" {
+		t.Errorf("LB PublicIP = %q, want 5.6.7.8", lb.PublicIP)
+	}
+	if lb.FrontDoorKind != "cloud-lb" {
+		t.Errorf("FrontDoorKind = %q, want cloud-lb (Hetzner provisions a real hcloud LB)", lb.FrontDoorKind)
+	}
+	if len(lb.Listeners) == 0 {
+		t.Errorf("LB.Listeners empty on the declared path")
+	}
+}
+
+// TestFrontDoor_NoIPYields_EmptyNotFabricated guards the no-placeholder
+// principle: when the record has no LoadBalancerIP yet, the LB slice is
+// empty — never a synthesised row.
+func TestFrontDoor_NoIPYields_EmptyNotFabricated(t *testing.T) {
+	in := LoaderInput{
+		DeploymentID:  "depPending",
+		Status:        "unknown",
+		SovereignFQDN: "pending.omani.works",
+		Provider:      "hetzner",
+		Region:        "fsn1",
+		Regions: []provisioner.RegionSpec{
+			{Provider: "hetzner", CloudRegion: "fsn1", WorkerCount: 1},
+		},
+		// Result nil → no LoadBalancerIP known yet.
+	}
+	resp := Load(context.Background(), in)
+	if len(resp.Topology.Regions) != 1 {
+		t.Fatalf("expected 1 region, got %d", len(resp.Topology.Regions))
+	}
+	if got := len(lbsOf(resp.Topology.Regions[0])); got != 0 {
+		t.Errorf("expected 0 LBs when no LoadBalancerIP is known, got %d (fabricated placeholder)", got)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/infrastructure/types.go
+++ b/products/catalyst/bootstrap/api/internal/infrastructure/types.go
@@ -139,18 +139,52 @@ type VCluster struct {
 	Status    string `json:"status"`
 }
 
-// LoadBalancer — Hetzner cloud LB (or future multi-cloud equivalent)
-// attached to the cluster. Today a Sovereign has exactly one LB
-// fronting the ingress controller; future multi-LB topologies surface
-// here.
+// LoadBalancer — the cloud front door fronting the cluster's ingress.
+// Provider-agnostic (Refs #3998): on Hetzner this is a real
+// `hcloud_load_balancer`; on Huawei kom4dc (no day-2 ELB instantiated)
+// it is the EIP DNAT'd to the Cilium-Gateway NodePort. Either way the
+// PublicIP + listeners are sourced from the deployment record
+// (`Result.LoadBalancerIP`) — NOT the empty Crossplane XRC layer — so
+// the page answers "how is the platform fronted" on every Sovereign.
 type LoadBalancer struct {
-	ID           string `json:"id"`
-	Name         string `json:"name"`
-	PublicIP     string `json:"publicIP"`
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	PublicIP string `json:"publicIP"`
+
+	// Listeners + Targets are the structured wire contract the cloud-view
+	// LoadBalancersPage renders (lib/infrastructure.types.ts → LBListener /
+	// LBTarget). Ports + TargetHealth are the flat legacy strings kept for
+	// the deprecated flatten-network projection — populated from the same
+	// data so both consumers stay coherent.
+	Listeners []LoadBalancerListener `json:"listeners"`
+	Targets   []LoadBalancerTarget   `json:"targets"`
+
 	Ports        string `json:"ports"`
 	TargetHealth string `json:"targetHealth"`
 	Region       string `json:"region"`
 	Status       string `json:"status"`
+
+	// FrontDoorKind — provider-agnostic descriptor of HOW the cluster is
+	// fronted: "cloud-lb" (a real provider LB, e.g. Hetzner hcloud LB) or
+	// "gateway-eip" (Huawei EIP DNAT'd to the Cilium Gateway NodePort).
+	// Lets the UI explain the EIP+Gateway datapath when no cloud LB exists
+	// (Refs #3998). Empty when unknown.
+	FrontDoorKind string `json:"frontDoorKind,omitempty"`
+}
+
+// LoadBalancerListener — one listener port/protocol pair on the front
+// door. Mirrors lib/infrastructure.types.ts → LBListener verbatim.
+type LoadBalancerListener struct {
+	Port     int    `json:"port"`
+	Protocol string `json:"protocol"`
+}
+
+// LoadBalancerTarget — one backend target behind the front door.
+// Mirrors lib/infrastructure.types.ts → LBTarget verbatim.
+type LoadBalancerTarget struct {
+	ID     string `json:"id"`
+	IP     string `json:"ip"`
+	Status string `json:"status"`
 }
 
 // NodePool — a logical group of identically-sized worker nodes the

--- a/products/catalyst/bootstrap/ui/src/lib/infrastructure.types.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/infrastructure.types.ts
@@ -134,6 +134,15 @@ export interface LoadBalancerSpec {
   targets: LBTarget[]
   region: string
   status: TopologyStatus
+  /**
+   * Provider-agnostic descriptor of HOW the cluster is fronted (Refs #3998):
+   * - 'cloud-lb'    — a real provider load balancer (e.g. Hetzner hcloud LB).
+   * - 'gateway-eip' — a cloud EIP DNAT'd to the Cilium Gateway NodePort
+   *                   (Huawei kom4dc, where no day-2 ELB is instantiated).
+   * Lets the LB view explain the EIP+Gateway datapath. Optional —
+   * absent on older API builds.
+   */
+  frontDoorKind?: 'cloud-lb' | 'gateway-eip'
 }
 
 export interface FirewallRule {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-network/LoadBalancersPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-network/LoadBalancersPage.tsx
@@ -80,6 +80,19 @@ function formatListeners(lb: LoadBalancerSpec): string {
   return lb.listeners.map((l) => `${l.protocol}:${l.port}`).join(', ')
 }
 
+// formatFrontDoor explains the real ingress datapath (Refs #3998): a real
+// cloud LB vs an EIP DNAT'd to the Cilium Gateway NodePort (Huawei).
+function formatFrontDoor(lb: LoadBalancerSpec): string {
+  switch (lb.frontDoorKind) {
+    case 'cloud-lb':
+      return 'Cloud load balancer'
+    case 'gateway-eip':
+      return 'EIP → Cilium Gateway (NodePort)'
+    default:
+      return '—'
+  }
+}
+
 export function LoadBalancersPage() {
   const { deploymentId, data, isLoading } = useCloud()
   const rows = useMemo(() => flatten(data), [data])
@@ -232,6 +245,7 @@ export function LoadBalancersPage() {
             />
             <DetailRow label="Name" value={openRow.lb.name} />
             <DetailRow label="ID" value={openRow.lb.id} mono />
+            <DetailRow label="Front door" value={formatFrontDoor(openRow.lb)} />
             <DetailRow label="Public IP" value={openRow.lb.publicIP} mono />
             <DetailRow label="Listeners" value={formatListeners(openRow.lb)} mono />
             <DetailRow


### PR DESCRIPTION
## What

The Catalyst console cloud-view Load Balancers page rendered **0/0** on a real Sovereign even though the front door is live — because the live chroot path (`buildRegionFromLiveNodes`, the branch every running Sovereign hits since catalyst-api runs in-cluster) hardcoded `LoadBalancers: []LoadBalancer{}`, ignoring the deployment record's `Result.LoadBalancerIP`. The empty Crossplane XRC layer (`LoadBalancerClaim`) was never the right source — on a real Sovereign that whole OpenOva day-2 XRC layer is 0 instances; infra is 100% OpenTofu-provisioned.

## Fix (Path A — the approved lighter path)

- **Source `loadBalancers[]` from where the data actually lives** — the deployment record (`Result.LoadBalancerIP`) — in BOTH the declared (mothership) path and the live chroot path, via a shared `frontDoorLBs()` helper. Never the empty XRC layer.
- **Structured contract**: add `Listeners[]` / `Targets[]` to the Go `LoadBalancer` type so it matches the UI `LoadBalancerSpec` (`LBListener` / `LBTarget`) — the listeners column now renders the real `tcp:80/443/6443` instead of `—`.
- **Front-door descriptor**: add `FrontDoorKind` (`cloud-lb` | `gateway-eip`) so the view explains the real ingress datapath provider-agnostically — a real cloud LB (Hetzner) vs an EIP DNAT'd to the Cilium Gateway NodePort (Huawei kom4dc). Surfaced as a "Front door" row in the LB detail drawer.
- **Worker nodes** are already sourced from live K8s (not XRCs) — left exactly as-is.
- Network/security kinds (Gateway / HTTPRoute / NetworkPolicy / CNP / CCNP) for #3998 scope item 1 were already wired on the base branch.

## MUST-PRESERVE (no regression)

- The populated `regions` / `clusters` / `networks` tree (sourced from the deployment record) is untouched.
- The k9s-style per-kind cloud-list explorer + every existing column is untouched — this is ONLY-ADD on the LB seam.
- Honest 0s stay 0: the LB slice is empty (no fabricated row) when `LoadBalancerIP` isn't known yet.

## Before / After (cloud-view diff)

| Surface | Before | After |
|---|---|---|
| regions / clusters / networks | populated | **unchanged** |
| Worker Nodes | live K8s nodes | **unchanged** (still live K8s) |
| Load Balancers (live chroot path) | **0 rows** | **1 row** — real EIP/LB from the record, with listeners + front-door kind |
| Load Balancers listeners column | `—` (no `listeners[]` in JSON) | `tcp:80, tcp:443, tcp:6443` |
| LB detail "Front door" | absent | `EIP → Cilium Gateway (NodePort)` (Huawei) / `Cloud load balancer` (Hetzner) |

## Tests

- 3 new Go loader tests: live-chroot regression guard (non-empty LB from record + `gateway-eip` for Huawei + 2 live nodes), declared `cloud-lb` path, and no-placeholder guard.
- `go build ./...` + `go vet ./...` green; full `internal/infrastructure` + `internal/handler` packages green.
- UI `tsc -b` typecheck green; `cloud-network` + `cloud-list` vitest 60/60 green. (Unrelated pre-existing UI test failures in PinInput6 / ProvisionPage / Settings / wizard are untouched by this PR.)

## Backlog

Path B (provisioning instantiates the Crossplane XRCs so the XRC layer truly mirrors the OpenTofu infra — the heavier object-model-live decision) is filed as **#4018** for founder A-vs-B steer; not built here.

## Live verify

Best-effort on hw174 (`ea30d1d816f2eee2`); the durable proof is the orchestrator's cycle-2 fresh prov. hw174's chroot catalyst-api image may currently be ImagePullBackOff (ghcr-blob DNS flake on the IPv4-only kom4dc VPC) — if the live console is env-blocked, that is not this fix failing.

Refs #3998 #3987
