### PR TITLE
fix(topology-ui): bootstrap placement queries empty namespace so active-active targets resolve (Refs #4000 #3986)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.test.tsx
@@ -149,6 +149,35 @@ describe('TopologyTab — bootstrap HelmRelease status poll (#3656)', () => {
     expect(getApplicationStatus).not.toHaveBeenCalled()
   })
 
+  it('#4000: queries placement with EMPTY namespace for a bootstrap component (workload Pods run in their own ns, not the flux-system HR ns)', async () => {
+    getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
+
+    render(
+      withProviders(
+        <TopologyTab sovereignId="test-sov" applicationName="bp-alloy" namespace="flux-system" isBootstrap />,
+      ),
+    )
+
+    await waitFor(() => {
+      expect(getApplicationPlacement).toHaveBeenCalled()
+    })
+    // bp-alloy's HelmRelease is in flux-system but its DaemonSet Pods run in ns
+    // `alloy` (21-alloy.yaml targetNamespace). Passing flux-system would filter
+    // them ALL out → false singleton; empty namespace matches across all ns.
+    expect(getApplicationPlacement).toHaveBeenCalledWith('test-sov', 'bp-alloy', undefined)
+  })
+
+  it('#4000: queries placement WITH the app namespace for a non-bootstrap app (no regression)', async () => {
+    getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
+    getApplicationStatus.mockResolvedValue({ name: 'wordpress', namespace: 'qa-omantel', spec: {}, status: {} })
+
+    render(withProviders(<TopologyTab sovereignId="test-sov" applicationName="wordpress" namespace="qa-omantel" />))
+
+    await waitFor(() => {
+      expect(getApplicationPlacement).toHaveBeenCalledWith('test-sov', 'wordpress', 'qa-omantel')
+    })
+  })
+
   it('DOES poll the status endpoint for a non-bootstrap app (Application CR exists)', async () => {
     getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
     getApplicationStatus.mockResolvedValue({

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
@@ -118,9 +118,22 @@ export function TopologyTab({
   // bootstrap HelmReleases (no Application CR) AND wizard installs, because
   // the backend keys on live Pods. Falls back silently (null) to the legacy
   // spec/status projection below when the data plane is unavailable.
+  // #4000: a bootstrap-kit HelmRelease lives in flux-system, but its WORKLOAD
+  // Pods run in their own targetNamespace (e.g. bp-alloy → ns `alloy`, see
+  // 21-alloy.yaml `targetNamespace: alloy`). AppDetail passes the HR namespace
+  // (flux-system) as `namespace`, and the placement endpoint filters Pods by a
+  // NON-EMPTY namespace — so the HR namespace excludes EVERY workload Pod → 0
+  // targets → a false "No placement targets reported yet" even on a converged
+  // multi-region prov (caught live on hw174, where bp-alloy showed singleton/
+  // no-targets while the data plane held its region-a+region-b DaemonSet pods).
+  // The endpoint documents EMPTY namespace as the safe default for bootstrap
+  // components (match across all namespaces); honour that so bp-alloy et al.
+  // resolve their real active-active targets. Wizard installs (non-bootstrap)
+  // keep their namespace — no regression.
+  const placementNamespace = isBootstrap ? undefined : namespace
   const placementQ = useQuery({
-    queryKey: ['application-placement', sovereignId, applicationName, namespace, refreshTick],
-    queryFn: () => getApplicationPlacement(sovereignId, applicationName, namespace),
+    queryKey: ['application-placement', sovereignId, applicationName, placementNamespace, refreshTick],
+    queryFn: () => getApplicationPlacement(sovereignId, applicationName, placementNamespace),
     enabled: !disableNetwork && !!sovereignId && !!applicationName,
     refetchInterval: 30_000,
     retry: false,


### PR DESCRIPTION
Live-caught on hw174: a bootstrap component's per-app Topology tab shows a false `singleton` / 'No placement targets reported yet' even when its workloads run in 2 regions. Root: AppDetail passes the HelmRelease namespace (e.g. `flux-system`) to the placement endpoint, but the workload Pods run in their own `targetNamespace` (bp-alloy → `alloy`, per 21-alloy.yaml) — the endpoint's non-empty-ns filter then excludes every pod → 0 targets. Fix: pass empty namespace for `isBootstrap` (the endpoint's documented match-all default); non-bootstrap apps keep their ns. +2 regression tests (all 8 green locally). Refs #4000 #3986.

HELD for merge until cycle-2 reaches `ready` (UI merge rolls the mothership mid-prov).