### PR TITLE
feat(console): wire live Continuum DR status into the reachable ContinuumPage (Pillar-3 visible)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/lib/continuum.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/continuum.api.ts
@@ -123,6 +123,31 @@ export interface ContinuumAuditListResponse {
   total: number
 }
 
+/**
+ * ContinuumFleetItem — one row of GET /api/v1/fleet/continuum. Mirrors
+ * the catalyst-api `continuumFleetItem` shape (continuum_extras.go) — a
+ * roll-up of every live Continuum CR across the Sovereigns this
+ * catalyst-api can see. Drives the ContinuumPage `list` (fleet) mode.
+ */
+export interface ContinuumFleetItem {
+  sovereign: string
+  name: string
+  namespace: string
+  primaryRegion: string
+  currentPrimary: string
+  phase: string
+  walLagSeconds: number
+  leaseHolder?: string
+  lastSwitchover?: string
+  healthy: boolean
+}
+
+/** ContinuumFleetResponse — items envelope of GET /fleet/continuum. */
+export interface ContinuumFleetResponse {
+  items: ContinuumFleetItem[]
+  total: number
+}
+
 /* ── Endpoint helpers ────────────────────────────────────────────── */
 
 function continuumsBase(sovereignId: string): string {
@@ -230,6 +255,26 @@ export async function listContinuumAudit(
   const res = await authedFetch(url, { headers: { Accept: 'application/json' } })
   if (!res.ok) {
     throw new Error(`continuum audit list: HTTP ${res.status}`)
+  }
+  return res.json()
+}
+
+/**
+ * listFleetContinuums — fleet-wide roll-up of every live Continuum CR
+ * (GET /api/v1/fleet/continuum). The endpoint is NOT scoped to a single
+ * Sovereign — catalyst-api aggregates across every Sovereign it can
+ * reach. The ContinuumPage `list` mode renders one row per item, linking
+ * to the per-continuum overview.
+ *
+ * Wire path:
+ *
+ *   browser ──/api/v1/fleet/continuum──▶ catalyst-api (continuum_extras.go)
+ */
+export async function listFleetContinuums(): Promise<ContinuumFleetResponse> {
+  const url = `${API_BASE}/v1/fleet/continuum`
+  const res = await authedFetch(url, { headers: { Accept: 'application/json' } })
+  if (!res.ok) {
+    throw new Error(`continuum fleet list: HTTP ${res.status}`)
   }
   return res.json()
 }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/stubs/ContinuumPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/stubs/ContinuumPage.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * ContinuumPage.test.tsx — lock-in for the live DR wiring (#3375 / #1101).
+ *
+ * The page was an explicit STUB; #3969 moved DR onto it but it was never
+ * data-wired. These tests assert the REAL widgets now render from a
+ * mocked continuum.api response, AND that the honest empty-state shows
+ * when no Continuum CR exists (the backend 404 path) — NOT a crash, NOT
+ * a fabricated green.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import { ContinuumPage } from './ContinuumPage'
+import * as continuumApi from '@/lib/continuum.api'
+
+// useSession + useResolvedDeploymentId hit the network — stub them so the
+// page renders deterministically with a known tier + deployment id.
+vi.mock('@/shared/lib/useSession', () => ({
+  useSession: () => ({
+    signedIn: true,
+    email: 'owner@acme.io',
+    sub: 'u-1',
+    tier: 'owner',
+    roles: ['catalyst-owner'],
+    loading: false,
+    refetch: vi.fn(),
+    signOut: vi.fn(),
+  }),
+}))
+vi.mock('@/shared/lib/useResolvedDeploymentId', () => ({
+  useResolvedDeploymentId: () => ({ deploymentId: 'dep-1', isLoading: false }),
+}))
+
+function renderPage(mode: 'list' | 'overview' | 'audit' | 'settings', path: string) {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const route = createRoute({
+    getParentRoute: () => rootRoute,
+    path:
+      mode === 'list'
+        ? '/app/$deploymentId/continuum'
+        : mode === 'overview'
+          ? '/app/$deploymentId/continuum/$continuumId'
+          : mode === 'audit'
+            ? '/app/$deploymentId/continuum/$continuumId/audit'
+            : '/app/$deploymentId/continuum/$continuumId/settings',
+    component: () => <ContinuumPage mode={mode} />,
+  })
+  const tree = rootRoute.addChildren([route])
+  const router = createRouter({
+    routeTree: tree,
+    history: createMemoryHistory({ initialEntries: [path] }),
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('ContinuumPage — overview mode (live CR)', () => {
+  beforeEach(() => {
+    vi.spyOn(continuumApi, 'getContinuum').mockResolvedValue({
+      name: 'dr-wp',
+      namespace: 'acme',
+      uid: 'u-cr-1',
+      spec: {
+        primaryRegion: 'hz-fsn-rtz-prod',
+        hotStandbyRegions: ['hz-hel-rtz-prod'],
+      },
+      status: {
+        phase: 'Healthy',
+        leaseHolder: 'hz-fsn-rtz-prod',
+        replicationLagSeconds: 8,
+        primaryRegion: 'hz-fsn-rtz-prod',
+        replicaRegion: 'hz-hel-rtz-prod',
+      },
+    })
+  })
+
+  it('renders StatusPanel from a mocked continuum.api response', async () => {
+    renderPage('overview', '/app/dep-1/continuum/dr-wp')
+    // The StatusPanel renders the live phase pill + green lag bucket.
+    expect(await screen.findByTestId('continuum-status-panel')).toBeTruthy()
+    expect(screen.getByTestId('continuum-status-phase-Healthy')).toBeTruthy()
+    expect(screen.getByTestId('continuum-status-lag-bucket-green')).toBeTruthy()
+    // Hot-standby region badge derived from spec.hotStandbyRegions.
+    expect(screen.getByTestId('continuum-status-hotstandby-hz-hel-rtz-prod')).toBeTruthy()
+  })
+})
+
+describe('ContinuumPage — overview mode (no CR → calm empty-state)', () => {
+  beforeEach(() => {
+    // The backend 404s when there is no live 2-region pair; getContinuum
+    // throws "continuum get: HTTP 404".
+    vi.spyOn(continuumApi, 'getContinuum').mockRejectedValue(
+      new Error('continuum get: HTTP 404'),
+    )
+  })
+
+  it('renders the calm "no DR pair yet" placeholder, not a crash or fake-green', async () => {
+    renderPage('overview', '/app/dep-1/continuum/dr-wp')
+    expect(await screen.findByTestId('continuum-overview-no-cr')).toBeTruthy()
+    // The StatusPanel must NOT render a fabricated green status.
+    expect(screen.queryByTestId('continuum-status-panel')).toBeNull()
+  })
+})
+
+describe('ContinuumPage — overview mode (genuine error)', () => {
+  beforeEach(() => {
+    vi.spyOn(continuumApi, 'getContinuum').mockRejectedValue(
+      new Error('continuum get: HTTP 500'),
+    )
+  })
+
+  it('surfaces a non-404 error honestly (not as the empty-state)', async () => {
+    renderPage('overview', '/app/dep-1/continuum/dr-wp')
+    expect(await screen.findByTestId('continuum-overview-error')).toBeTruthy()
+    expect(screen.queryByTestId('continuum-overview-no-cr')).toBeNull()
+  })
+})
+
+describe('ContinuumPage — list (fleet) mode', () => {
+  it('renders a row per fleet item linking to the overview', async () => {
+    vi.spyOn(continuumApi, 'listFleetContinuums').mockResolvedValue({
+      items: [
+        {
+          sovereign: 'dep-1',
+          name: 'cont-omantel',
+          namespace: 'qa-omantel',
+          primaryRegion: 'fsn1',
+          currentPrimary: 'fsn1',
+          phase: 'Healthy',
+          walLagSeconds: 2,
+          healthy: true,
+        },
+      ],
+      total: 1,
+    })
+    renderPage('list', '/app/dep-1/continuum')
+    expect(await screen.findByTestId('continuum-list-row-0')).toBeTruthy()
+    expect(screen.getByTestId('continuum-list-row-0').textContent).toContain('cont-omantel')
+  })
+
+  it('renders a calm empty-state when the fleet is empty', async () => {
+    vi.spyOn(continuumApi, 'listFleetContinuums').mockResolvedValue({ items: [], total: 0 })
+    renderPage('list', '/app/dep-1/continuum')
+    expect(await screen.findByTestId('continuum-list-empty')).toBeTruthy()
+  })
+})
+
+describe('ContinuumPage — audit mode', () => {
+  it('renders SwitchoverHistory from the audit api', async () => {
+    vi.spyOn(continuumApi, 'listContinuumAudit').mockResolvedValue({
+      items: [
+        {
+          auditType: 'continuum-switchover',
+          ts: '2026-05-08T14:23:11Z',
+          actor: 'owner@acme.io',
+          detail: 'switchover requested: hz-fsn-rtz-prod → hz-hel-rtz-prod',
+          result: 'ok',
+        },
+      ],
+      total: 1,
+    })
+    renderPage('audit', '/app/dep-1/continuum/dr-wp/audit')
+    // SwitchoverHistory renders its table (not the empty placeholder).
+    expect(await screen.findByTestId('continuum-history')).toBeTruthy()
+  })
+})
+
+describe('ContinuumPage — settings mode (read-only RPO/RTO)', () => {
+  it('renders the read-only policy summary from spec', async () => {
+    vi.spyOn(continuumApi, 'getContinuum').mockResolvedValue({
+      name: 'dr-wp',
+      namespace: 'acme',
+      uid: 'u-cr-1',
+      spec: { rpoSeconds: 30, rtoSeconds: 60, autoFailover: true },
+      status: {},
+    })
+    renderPage('settings', '/app/dep-1/continuum/dr-wp/settings')
+    expect(await screen.findByTestId('continuum-settings-rpo')).toBeTruthy()
+    expect(screen.getByTestId('continuum-settings-rpo').textContent).toBe('30')
+    expect(screen.getByTestId('continuum-settings-rto').textContent).toBe('60')
+    expect(screen.getByTestId('continuum-settings-autofailover').textContent).toBe('enabled')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/stubs/ContinuumPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/stubs/ContinuumPage.tsx
@@ -1,31 +1,66 @@
 /**
- * ContinuumPage — minimal target-state route surface (qa-loop iter-6
- * Cluster-A `spa-target-state-routes-missing`).
+ * ContinuumPage — the live Continuum DR surface (#3375 / #1101).
  *
- * The Continuum DR feature (PostgreSQL HA across regions, switchover,
- * audit trail, RPO/RTO knobs) is owned by other Fix Authors. This stub
- * mounts the target-state routes so URLs resolve to a 200 with the
- * canonical "Continuum"/"DR" page-title token + the continuumId from
- * the URL — enough for the test matrix to confirm the SPA route is
- * wired. Real data wiring lands in subsequent slices.
+ * #3969 moved DR OUT of the per-app Topology tab into this dedicated
+ * page. This file replaces the original target-state STUB (which only
+ * resolved the routes to a 200 + page-title token) with REAL data
+ * wiring: it fetches the live Continuum CR / fleet roll-up off
+ * catalyst-api and renders the COMPLETE continuum widgets the K-Cont-2
+ * reconciler patches (StatusPanel, FailbackPanel, SwitchoverHistory).
  *
- * URL shapes mounted:
- *   /app/$deploymentId/continuum                          — fleet list
- *   /app/$deploymentId/continuum/$continuumId             — overview
- *   /app/$deploymentId/continuum/$continuumId/audit       — switchover audit
- *   /app/$deploymentId/continuum/$continuumId/settings    — RPO/RTO knobs
+ * URL shapes mounted (UNCHANGED from the stub — the route-matrix test
+ * asserts these resolve with the "Continuum" page-title token + the
+ * continuumId derived from the URL, never hardcoded — INVIOLABLE
+ * PRINCIPLES #4):
+ *   /app/$deploymentId/continuum                        — fleet list
+ *   /app/$deploymentId/continuum/$continuumId           — overview (DR status)
+ *   /app/$deploymentId/continuum/$continuumId/audit     — switchover audit
+ *   /app/$deploymentId/continuum/$continuumId/settings  — RPO/RTO summary
  *
- * Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), the label/sub
- * routes are derived from URL params, not static.
+ * Honest empty/loading/error states: a Continuum CR may not exist yet on
+ * a single-region or pre-converged Sovereign. The backend returns 404
+ * (getContinuum throws) — we render a calm "no DR pair yet" placeholder,
+ * NEVER a crash or a fabricated green status.
  */
 
-import { useParams } from '@tanstack/react-router'
+import { useMemo } from 'react'
+import { useParams, useNavigate } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
+
 import { PortalShell } from '../PortalShell'
 import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
+import { useSession } from '@/shared/lib/useSession'
+import { StatusPanel } from '@/widgets/continuum/StatusPanel'
+import { FailbackPanel } from '@/widgets/continuum/FailbackPanel'
+import { SwitchoverHistory } from '@/widgets/continuum/SwitchoverHistory'
+import {
+  getContinuum,
+  listContinuumAudit,
+  listFleetContinuums,
+  type ContinuumGetResponse,
+} from '@/lib/continuum.api'
 
 export interface ContinuumPageProps {
   /** Sub-page mode: list / overview / audit / settings. */
   mode?: 'list' | 'overview' | 'audit' | 'settings'
+}
+
+/**
+ * deriveTier — collapse the session's explicit tier claim (or the
+ * catalyst-<tier> realm roles) into a single tier string. Mirrors the
+ * AppDetail derivation so the FailbackPanel's owner/admin affordances
+ * gate identically. The server remains the single source of truth for
+ * authorization — this only shows/hides the convenience controls.
+ */
+function deriveTier(tier: string, roles: string[]): string {
+  if (tier) return tier
+  const lower = roles.map((r) => r.toLowerCase())
+  if (lower.includes('catalyst-owner')) return 'owner'
+  if (lower.includes('catalyst-admin')) return 'admin'
+  if (lower.includes('catalyst-operator')) return 'operator'
+  if (lower.includes('catalyst-developer')) return 'developer'
+  if (lower.includes('catalyst-viewer')) return 'viewer'
+  return ''
 }
 
 export function ContinuumPage({ mode = 'list' }: ContinuumPageProps = {}) {
@@ -41,50 +76,346 @@ export function ContinuumPage({ mode = 'list' }: ContinuumPageProps = {}) {
     <PortalShell deploymentId={deploymentId} pageTitle="Continuum">
       <div className="p-6 space-y-4" data-testid="continuum-page">
         <h2 className="text-xl font-semibold text-[var(--color-text)]">DR — Continuum</h2>
-        {mode === 'list' && (
-          <div data-testid="continuum-list">
-            <p className="text-sm text-[oklch(55%_0.01_250)]">Continuum DR list (pending live data).</p>
-            <ul className="mt-2 text-sm">
-              <li><code>cont-omantel</code></li>
-            </ul>
-          </div>
-        )}
+        {mode === 'list' && <FleetList deploymentId={deploymentId} />}
         {mode === 'overview' && (
-          <div data-testid="continuum-overview">
-            <p className="text-sm text-[oklch(55%_0.01_250)]">
-              Topology + WAL replication + Switchover for <code>{continuumId}</code> (pending live data).
-            </p>
-            <ul className="mt-2 text-sm">
-              <li>Topology</li>
-              <li>WAL</li>
-              <li>Switchover (last status: <code>completed</code>)</li>
-            </ul>
-          </div>
+          <ContinuumOverview deploymentId={deploymentId} continuumId={continuumId} />
         )}
         {mode === 'audit' && (
-          <div data-testid="continuum-audit">
-            <p className="text-sm text-[oklch(55%_0.01_250)]">
-              Switchover audit trail for <code>{continuumId}</code> (pending live data).
-            </p>
-            <table className="mt-2 text-sm">
-              <thead><tr><th>Event</th><th>Duration</th></tr></thead>
-              <tbody><tr><td>Switchover</td><td>—</td></tr></tbody>
-            </table>
-          </div>
+          <ContinuumAudit deploymentId={deploymentId} continuumId={continuumId} />
         )}
         {mode === 'settings' && (
-          <div data-testid="continuum-settings">
-            <p className="text-sm text-[oklch(55%_0.01_250)]">
-              RPO / RTO knobs for <code>{continuumId}</code> (pending live data).
-            </p>
-            <form className="mt-2 space-y-2 text-sm">
-              <label className="block">RPO (seconds)<input className="ml-2 w-24 rounded border px-1" defaultValue="30" /></label>
-              <label className="block">RTO (seconds)<input className="ml-2 w-24 rounded border px-1" defaultValue="60" /></label>
-              <button type="button" className="rounded bg-[--color-brand-500] px-3 py-1 text-white">Save</button>
-            </form>
-          </div>
+          <ContinuumSettings deploymentId={deploymentId} continuumId={continuumId} />
         )}
       </div>
     </PortalShell>
+  )
+}
+
+/* ── list mode ─────────────────────────────────────────────────────── */
+
+function FleetList({ deploymentId }: { deploymentId: string }) {
+  const navigate = useNavigate()
+  const q = useQuery({
+    queryKey: ['continuum-fleet'],
+    queryFn: () => listFleetContinuums(),
+    retry: false,
+    refetchInterval: 30_000,
+  })
+
+  if (q.isLoading) {
+    return (
+      <div data-testid="continuum-list" className="text-sm text-[var(--color-text-dim)]">
+        <p data-testid="continuum-list-loading">Loading DR pairs…</p>
+      </div>
+    )
+  }
+  if (q.isError) {
+    return (
+      <div data-testid="continuum-list" className="text-sm">
+        <p data-testid="continuum-list-error" className="text-[var(--color-text-dim)]">
+          Could not load the Continuum fleet. {(q.error as Error).message}
+        </p>
+      </div>
+    )
+  }
+
+  const items = q.data?.items ?? []
+  if (items.length === 0) {
+    return (
+      <div data-testid="continuum-list" className="text-sm">
+        <p data-testid="continuum-list-empty" className="text-[var(--color-text-dim)]">
+          No Continuum DR pairs yet. A pair appears once an Application is placed
+          active-hot-standby across two regions.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div data-testid="continuum-list">
+      <table className="mt-2 w-full text-sm">
+        <thead className="text-left text-[var(--color-text-dim)]">
+          <tr>
+            <th className="pb-1.5">Name</th>
+            <th className="pb-1.5">Phase</th>
+            <th className="pb-1.5">Primary region</th>
+            <th className="pb-1.5">Lag</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((it, i) => (
+            <tr
+              key={`${it.namespace}-${it.name}-${i}`}
+              data-testid={`continuum-list-row-${i}`}
+              className="cursor-pointer border-t border-[var(--color-border)] hover:bg-[var(--color-bg-2)]"
+              onClick={() =>
+                void navigate({
+                  to: `/app/${deploymentId}/continuum/${it.name}` as never,
+                })
+              }
+            >
+              <td className="py-1.5 font-mono text-[var(--color-text)]">{it.name}</td>
+              <td className="py-1.5">
+                <span
+                  className={`inline-flex rounded-md px-1.5 py-0.5 text-[10px] font-semibold uppercase ${
+                    it.healthy ? 'bg-green-500/10 text-green-400' : 'bg-yellow-500/10 text-yellow-400'
+                  }`}
+                >
+                  {it.phase || (it.healthy ? 'Healthy' : 'Degraded')}
+                </span>
+              </td>
+              <td className="py-1.5 font-mono text-[var(--color-text-dim)]">
+                {it.primaryRegion || '—'}
+              </td>
+              <td className="py-1.5 font-mono text-[var(--color-text-dim)]">
+                {Number.isFinite(it.walLagSeconds) ? `${it.walLagSeconds}s` : '—'}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+/* ── overview mode ─────────────────────────────────────────────────── */
+
+/** useContinuum — shared GET /continuums/{name} hook used by every per-CR mode. */
+function useContinuum(deploymentId: string, continuumId: string) {
+  return useQuery<ContinuumGetResponse>({
+    queryKey: ['continuum', deploymentId, continuumId],
+    queryFn: () => getContinuum(deploymentId, continuumId),
+    enabled: !!deploymentId && !!continuumId,
+    retry: false,
+    refetchInterval: 15_000,
+  })
+}
+
+/**
+ * isNoCRError — the backend 404s (getContinuum throws "HTTP 404") when
+ * there is genuinely no 2-region cnpg-pair / Continuum CR for this app.
+ * That is an HONEST empty-state, not a failure — render the calm "no DR
+ * pair yet" placeholder rather than an error banner.
+ */
+function isNoCRError(err: unknown): boolean {
+  return err instanceof Error && /HTTP 404/.test(err.message)
+}
+
+function ContinuumOverview({
+  deploymentId,
+  continuumId,
+}: {
+  deploymentId: string
+  continuumId: string
+}) {
+  const session = useSession()
+  const tier = deriveTier(session.tier, session.roles)
+  const isOwner = ['owner', 'admin'].includes(tier)
+  const isSovereignAdmin = ['owner', 'admin'].includes(tier)
+
+  const q = useContinuum(deploymentId, continuumId)
+
+  const spec = (q.data?.spec ?? {}) as Record<string, unknown>
+  const status = (q.data?.status ?? {}) as Record<string, unknown>
+  const primaryRegion =
+    (status['primaryRegion'] as string | undefined) ??
+    (spec['primaryRegion'] as string | undefined) ??
+    undefined
+  const hotStandbyRegions = useMemo(() => {
+    const fromSpec = spec['hotStandbyRegions']
+    if (Array.isArray(fromSpec)) return fromSpec.map((r) => String(r))
+    const replica = status['replicaRegion'] as string | undefined
+    return replica ? [replica] : []
+  }, [spec, status])
+
+  const failback = (spec['failback'] as Record<string, unknown> | undefined) ?? {}
+  const last = (status['lastSwitchover'] as Record<string, unknown> | undefined) ?? undefined
+  const switchoverSucceeded =
+    (last?.['result'] as string | undefined) === 'Success' ||
+    (status['phase'] as string | undefined) === 'FailedOver'
+
+  if (q.isLoading) {
+    return (
+      <div data-testid="continuum-overview">
+        <p data-testid="continuum-overview-loading" className="text-sm text-[var(--color-text-dim)]">
+          Loading DR status for <code>{continuumId}</code>…
+        </p>
+      </div>
+    )
+  }
+
+  // Honest empty-state: no Continuum CR / no 2-region pair yet.
+  if (q.isError && isNoCRError(q.error)) {
+    return (
+      <div data-testid="continuum-overview">
+        <div
+          data-testid="continuum-overview-no-cr"
+          className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] p-4 text-sm text-[var(--color-text-dim)]"
+        >
+          <p className="font-semibold text-[var(--color-text)]">No DR pair yet</p>
+          <p className="mt-1">
+            <code>{continuumId}</code> has no live Continuum record. A DR pair
+            (primary + hot standby) appears once this Application is placed
+            active-hot-standby across two regions.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  // Genuine fetch error (not a 404) — surface it honestly.
+  if (q.isError) {
+    return (
+      <div data-testid="continuum-overview">
+        <p data-testid="continuum-overview-error" className="text-sm text-red-400">
+          Could not load DR status for <code>{continuumId}</code>:{' '}
+          {(q.error as Error).message}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div data-testid="continuum-overview" className="space-y-4">
+      <StatusPanel
+        status={status}
+        primaryRegion={primaryRegion}
+        hotStandbyRegions={hotStandbyRegions}
+      />
+      {switchoverSucceeded ? (
+        <FailbackPanel
+          sovereignId={deploymentId}
+          continuumName={continuumId}
+          namespace={q.data?.namespace}
+          isOwner={isOwner}
+          isSovereignAdmin={isSovereignAdmin}
+          approvalRequired={Boolean(failback['approvalRequired'] ?? false)}
+          failbackRequested={Boolean(failback['requested'] ?? false)}
+          failbackApproved={Boolean(failback['approved'] ?? false)}
+          onChanged={() => void q.refetch()}
+        />
+      ) : null}
+    </div>
+  )
+}
+
+/* ── audit mode ────────────────────────────────────────────────────── */
+
+function ContinuumAudit({
+  deploymentId,
+  continuumId,
+}: {
+  deploymentId: string
+  continuumId: string
+}) {
+  const q = useQuery({
+    queryKey: ['continuum-audit', deploymentId, continuumId],
+    queryFn: () => listContinuumAudit(deploymentId, { limit: 200 }),
+    enabled: !!deploymentId,
+    retry: false,
+    refetchInterval: 30_000,
+  })
+
+  if (q.isLoading) {
+    return (
+      <div data-testid="continuum-audit">
+        <p data-testid="continuum-audit-loading" className="text-sm text-[var(--color-text-dim)]">
+          Loading switchover audit for <code>{continuumId}</code>…
+        </p>
+      </div>
+    )
+  }
+  if (q.isError) {
+    return (
+      <div data-testid="continuum-audit">
+        <p data-testid="continuum-audit-error" className="text-sm text-[var(--color-text-dim)]">
+          Could not load the switchover audit. {(q.error as Error).message}
+        </p>
+      </div>
+    )
+  }
+
+  const events = q.data?.items ?? []
+  return (
+    <div data-testid="continuum-audit" className="space-y-2">
+      <p className="text-sm text-[var(--color-text-dim)]">
+        Switchover audit trail for <code>{continuumId}</code>.
+      </p>
+      <SwitchoverHistory events={events} />
+    </div>
+  )
+}
+
+/* ── settings mode ─────────────────────────────────────────────────── */
+
+/**
+ * ContinuumSettings — read-only RPO/RTO summary off the live CR spec.
+ *
+ * The catalyst-api DOES expose a PUT /continuum/{name} for rpo/rto, but
+ * this slice ships the READ-ONLY summary only (per the brief: do NOT
+ * fabricate write controls). Wiring the live editor is a follow-up.
+ */
+function ContinuumSettings({
+  deploymentId,
+  continuumId,
+}: {
+  deploymentId: string
+  continuumId: string
+}) {
+  const q = useContinuum(deploymentId, continuumId)
+  const spec = (q.data?.spec ?? {}) as Record<string, unknown>
+
+  if (q.isLoading) {
+    return (
+      <div data-testid="continuum-settings">
+        <p data-testid="continuum-settings-loading" className="text-sm text-[var(--color-text-dim)]">
+          Loading DR policy for <code>{continuumId}</code>…
+        </p>
+      </div>
+    )
+  }
+  if (q.isError && isNoCRError(q.error)) {
+    return (
+      <div data-testid="continuum-settings">
+        <p data-testid="continuum-settings-no-cr" className="text-sm text-[var(--color-text-dim)]">
+          No DR policy yet — <code>{continuumId}</code> has no live Continuum record.
+        </p>
+      </div>
+    )
+  }
+  if (q.isError) {
+    return (
+      <div data-testid="continuum-settings">
+        <p data-testid="continuum-settings-error" className="text-sm text-red-400">
+          Could not load DR policy: {(q.error as Error).message}
+        </p>
+      </div>
+    )
+  }
+
+  const rpo = spec['rpoSeconds'] ?? spec['rpo'] ?? '—'
+  const rto = spec['rtoSeconds'] ?? spec['rto'] ?? '—'
+  const autoFailover = Boolean(spec['autoFailover'] ?? false)
+
+  return (
+    <div data-testid="continuum-settings" className="space-y-2">
+      <p className="text-sm text-[var(--color-text-dim)]">
+        DR policy for <code>{continuumId}</code> (read-only).
+      </p>
+      <dl className="grid max-w-md grid-cols-2 gap-2 text-sm">
+        <dt className="text-[var(--color-text-dim)]">RPO (seconds)</dt>
+        <dd className="font-mono text-[var(--color-text)]" data-testid="continuum-settings-rpo">
+          {String(rpo)}
+        </dd>
+        <dt className="text-[var(--color-text-dim)]">RTO (seconds)</dt>
+        <dd className="font-mono text-[var(--color-text)]" data-testid="continuum-settings-rto">
+          {String(rto)}
+        </dd>
+        <dt className="text-[var(--color-text-dim)]">Auto-failover</dt>
+        <dd className="font-mono text-[var(--color-text)]" data-testid="continuum-settings-autofailover">
+          {autoFailover ? 'enabled' : 'disabled'}
+        </dd>
+      </dl>
+    </div>
   )
 }


### PR DESCRIPTION
## What

Wires the live Continuum DR status into the reachable `ContinuumPage` so the region-kill / DR posture (Pillar-3) is actually visible in the console.

The backend (`continuum_live.go` — phase / `leaseHolder` / `replicationLagSeconds` / switchover step / `lastSwitchover`) and the pure-presentation widgets (`StatusPanel`, `FailbackPanel`, `SwitchoverHistory`) were **complete but orphaned**: `src/pages/sovereign/stubs/ContinuumPage.tsx` was an explicit STUB that only resolved the routes to a 200 + page-title token. #3969 moved DR off the per-app Topology tab onto this dedicated page but never data-wired it, so the status the K-Cont-2 reconciler patches was invisible.

## The wiring (per route mode)

| Route | Mode | Now renders |
|---|---|---|
| `/continuum` | list | `GET /fleet/continuum` fleet roll-up — one row per Continuum CR (name · phase · primary region · lag), linking to each overview |
| `/continuum/$id` | overview | `GET /continuums/{name}` → `StatusPanel` (phase pill, primary region, lease holder+expiry, lag bar green<30/yellow30-60/red>60, switchover Step N/7, last-switchover) + `FailbackPanel` (only after a successful switchover) |
| `/continuum/$id/audit` | audit | `listContinuumAudit` → `SwitchoverHistory` table |
| `/continuum/$id/settings` | settings | READ-ONLY RPO / RTO / auto-failover summary off the live spec (no fabricated write controls — live PUT editor is a follow-up) |

## Honest states (no fake-green)

A Continuum CR may not exist on a single-region or pre-converged Sovereign — the backend 404s. The overview/settings render a calm **"no DR pair yet"** placeholder; a non-404 fetch error is surfaced honestly; loading shows a spinner line. The `StatusPanel` is never mounted with a fabricated status.

## MUST-PRESERVE held

Route shapes, the `mode` prop, the `pageTitle="Continuum"` token, and the URL-param-derived labels (INVIOLABLE-PRINCIPLES #4) are all unchanged — only the data wiring + widget rendering were added. Adds a `listFleetContinuums` helper + fleet types to `continuum.api.ts`.

## Tests / gates

- `tsc -b --force` — clean (exit 0).
- New `ContinuumPage.test.tsx` (overview renders `StatusPanel` from a mocked CR; calm empty-state on 404; honest non-404 error; fleet list + empty; audit history; read-only settings) + the existing `StatusPanel` / `FailbackPanel` / `SwitchoverHistory` / `SwitchoverDialog` widget tests: **32/32 green**.
- The 69 pre-existing failures elsewhere in the suite (PinInput6, StepComponents catalog cascade, SettingsPage, ExecPanel, ...) are unrelated to this change — this PR touches only 3 files in the continuum area.

## Verification note

Full live proof needs a 2-region cnpg-pair (a live Continuum CR); the live render is confirmed on the orchestrator's cycle-2b fresh prov. Acceptance here = the page renders the widgets from a mocked CR response + the calm empty-state with no CR.

Refs #3375 #1101

🤖 Generated with [Claude Code](https://claude.com/claude-code)
