### PR TITLE
fix(console): flip 8 remaining user-visible 'tenant'→'Organization' leaks (row 214)

### DIFF
--- a/core/console/src/components/AppDetail.svelte
+++ b/core/console/src/components/AppDetail.svelte
@@ -327,7 +327,7 @@
           <section class="section">
             <h2>Connection</h2>
             <p class="section-hint">
-              Your apps reach this service inside the tenant vCluster. Credentials are
+              Your apps reach this service inside the Organization vCluster. Credentials are
               injected at deploy time — no manual wiring needed.
             </p>
             {#if backing}

--- a/core/console/src/components/BackingServices.svelte
+++ b/core/console/src/components/BackingServices.svelte
@@ -80,7 +80,7 @@
     <h2>Backing services</h2>
     <p class="sub">
       Databases, caches, and queues that run behind your apps. Status mirrors the
-      live pods in your tenant. Connection details live on each app's detail page.
+      live pods in your Organization. Connection details live on each app's detail page.
     </p>
   </header>
 

--- a/core/console/src/components/DashboardPage.svelte
+++ b/core/console/src/components/DashboardPage.svelte
@@ -85,7 +85,7 @@
       <div class="mt-12 text-center">
         <p class="text-[var(--color-text-dim)]">No organization found.</p>
         <a href={MARKETPLACE_URL} class="mt-4 inline-block rounded-xl bg-[var(--color-accent)] px-6 py-3 text-sm font-semibold text-white no-underline">
-          Create Tenant
+          Create Organization
         </a>
       </div>
     {/if}

--- a/core/console/src/components/SettingsPage.svelte
+++ b/core/console/src/components/SettingsPage.svelte
@@ -165,13 +165,13 @@
       <div class="mt-6 rounded-xl border border-[var(--color-danger)]/30 bg-[var(--color-danger)]/5 p-6">
         <h2 class="mb-2 text-base font-semibold text-[var(--color-danger)]">Danger Zone</h2>
         <p class="mb-4 text-sm text-[var(--color-text-dim)]">
-          Deleting your tenant will permanently remove all data, apps, and domains. This action cannot be undone.
+          Deleting your Organization will permanently remove all data, apps, and domains. This action cannot be undone.
         </p>
         <button
           onclick={() => { confirmOpen = true; confirmText = ''; deleteError = ''; }}
           class="rounded-lg border border-[var(--color-danger)] px-5 py-2 text-sm font-semibold text-[var(--color-danger)] hover:bg-[var(--color-danger)] hover:text-white transition-colors"
         >
-          Delete Tenant
+          Delete Organization
         </button>
       </div>
 
@@ -180,7 +180,7 @@
           <div class="w-full max-w-md rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-6">
             <h3 class="text-lg font-semibold text-[var(--color-danger)]">Delete {org.name}?</h3>
             <p class="mt-2 text-sm text-[var(--color-text-dim)]">
-              This cannot be undone. All apps, databases, and domains tied to this tenant will be torn down.
+              This cannot be undone. All apps, databases, and domains tied to this Organization will be torn down.
               Type <strong class="font-mono text-[var(--color-text)]">{org.slug}</strong> below to confirm.
             </p>
             <input

--- a/core/console/src/components/Sidebar.svelte
+++ b/core/console/src/components/Sidebar.svelte
@@ -73,7 +73,7 @@
               </button>
             {/each}
             {#if orgs.length === 0}
-              <p class="px-3 py-2 text-xs text-[var(--color-text-dim)]">No tenants.</p>
+              <p class="px-3 py-2 text-xs text-[var(--color-text-dim)]">No Organizations.</p>
             {/if}
           </div>
         {/if}

--- a/products/catalyst/bootstrap/ui/src/pages/org/UsersPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/org/UsersPage.tsx
@@ -105,7 +105,7 @@ export function UsersPage({
         <div>
           <h1 className="text-xl font-semibold text-[var(--color-text-strong)]">Users</h1>
           <p className="text-sm text-[var(--color-text-dim)]">
-            Tenant-scoped user CRUD. Create fires the unified-rbac hook to materialise the user across Keycloak, NewAPI, and the K8s Secret store.
+            Organization-scoped user CRUD. Create fires the unified-rbac hook to materialise the user across Keycloak, NewAPI, and the K8s Secret store.
           </p>
         </div>
         <button

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/VouchersPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/VouchersPage.tsx
@@ -147,7 +147,7 @@ export function VouchersPage({
       <div className="mx-auto max-w-7xl" data-testid="bss-vouchers-page">
         <header className="mb-4">
           <p className="text-sm text-[var(--color-text-dim)]">
-            Issue prepaid codes for tenant signup or upgrades. Past
+            Issue prepaid codes for Organization signup or upgrades. Past
             redemptions are preserved on revoke; only new redemptions are
             blocked.
           </p>

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/VouchersPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/VouchersPage.tsx
@@ -603,7 +603,7 @@ function IssueVoucherModal({ onClose, onIssued }: IssueVoucherModalProps) {
             type="email"
             value={recipient}
             onChange={(e) => setRecipient(e.target.value)}
-            placeholder="founder@tenant.example"
+            placeholder="founder@acme.example"
             className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-3 py-2 text-sm text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
             autoComplete="off"
           />


### PR DESCRIPTION
Closes the tail of UAT row 214 — *"No SME/tenant banned-term leak in the console bundle."*

PR #4017 flipped 18 banned-term strings but missed rendered `tenant`/`Tenant`/`tenants` leaks that still ship to users. This flips the remaining **9** rendered occurrences (the 8 the triage named + 1 sibling caught by the residual grep).

### Customer console — `core/console/src/components/`
- **SettingsPage.svelte** — Danger-Zone body ×2 + `Delete Tenant` button → `Delete Organization`
- **DashboardPage.svelte** — `Create Tenant` empty-state CTA → `Create Organization`
- **Sidebar.svelte** — `No tenants.` org-switcher empty state → `No Organizations.`
- **BackingServices.svelte** — panel sub-copy `…live pods in your tenant.` → `…in your Organization.`
- **AppDetail.svelte** — Connection section-hint `…inside the tenant vCluster.` → `…the Organization vCluster.` (not in the triage list; caught by the mandated residual grep, same rendered-leak class, fixed in scope)

### Operator console — `products/catalyst/bootstrap/ui/src/pages/`
- **org/UsersPage.tsx** — `Tenant-scoped user CRUD.` → `Organization-scoped user CRUD.`
- **sovereign/bss/VouchersPage.tsx** — `…for tenant signup or upgrades.` → `…for Organization signup or upgrades.`

### Scope discipline
Only **user-visible rendered strings** changed. No code identifiers, API fields (`X-Tenant-Host`, `tenant.*`), CSS classes (`.orders-cell-tenant`), `data-testid`/`data-col` attributes, route paths (`/bss/tenants`), TS type literals (`'tenants'` union members, `Tenant` type, sort `case 'tenants'`), or test fixtures were touched — those keep `tenant` by contract.

**Residual-grep proof** (`git grep -n -iE "\btenants?\b"` over both console dirs): every remaining hit is a non-rendered identifier / comment / `data-*` attribute / route path / type literal / test fixture. Zero rendered `tenant` text remains. Notably `bss/TenantsPage.tsx` already renders `pageTitle="Organizations"`, header `Org`, and "organizations" empty-states (PR #4017 work) — its residual hits are all identifiers.

### Gates
- `core/console` — `npm run build` (astro) ✅ green, 8 pages built
- operator UI — `npm run typecheck` (`tsc -b`) ✅ EXIT=0 + `npm run build` (vite) ✅ green

Refs #3985

🤖 Generated with [Claude Code](https://claude.com/claude-code)