### PR TITLE
fix(kyverno): exclude CNPG-managed PVCs from pvc-must-be-velero-backed (unblocks DB tier)

### DIFF
--- a/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
+++ b/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
@@ -111,7 +111,14 @@ spec:
       # 1.0.37 (#3859): add org-services to harbor-proxy-pull exclude (sme→
       # org-services rename orphaned the mixed-image carve-out → provisioning
       # CR-minter Enforce-denied → #3376 funnel could not reach ACTIVE).
-      version: 1.0.38
+      # 1.0.38 (#3971): K23 forbid-local-path-storage ClusterPolicy (Enforce-
+      # always deny of local-path / rancher.io/local-path PVC/SC/PV).
+      # 1.0.39 (#3971, hw178): EXCLUDE CNPG-managed PVCs (label `cnpg.io/cluster`)
+      # from the pvc-must-be-velero-backed rule — CNPG backs up via its own
+      # barman/object-store WAL-streaming, not Velero, so the over-broad rule
+      # stranded the entire DB tier (harbor-pg/gitea-pg/guacamole-pg/pdns-pg).
+      # Mirrors the by-label CNPG carve-out on flux-managed (#3374).
+      version: 1.0.39
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno

--- a/platform/kyverno-policies/blueprint.yaml
+++ b/platform/kyverno-policies/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.38
+  version: 1.0.39
   card:
     title: Kyverno Policy Library
     family: guardian

--- a/platform/kyverno-policies/chart/Chart.yaml
+++ b/platform/kyverno-policies/chart/Chart.yaml
@@ -220,7 +220,20 @@ type: application
 # local-path / rancher.io/local-path. The admission layer of the 3-layer
 # local-path-FORBIDDEN defence (k3s --disable=local-storage + cloud CSI default
 # + this policy). Founder: "local path never ever ALLOWED".
-version: 1.0.38
+# 1.0.39 (#3971, hw178 dep 02bc518fcb1b4cb3, 2026-06-21): EXCLUDE CNPG-managed
+# PVCs from the `pvc-must-be-velero-backed` rule (K2 backup-configured). The
+# DB tier (harbor-pg / gitea-pg / guacamole-pg / pdns-pg / keycloak) runs on
+# CloudNativePG, which creates each instance PVC WITHOUT Velero labels because
+# it backs up via its OWN continuous barman / object-store WAL-streaming, not
+# Velero. The over-broad rule flagged the entire DB tier as a backup-configured
+# `fail` ("PVC harbor-pg-1 is not declared as part of a Velero backup"),
+# stranding the database PVCs the moment the policy is Enforce. Added an
+# `exclude.any[].resources.selector.matchExpressions` on `cnpg.io/cluster`
+# Exists — exempts ONLY operator-backed CNPG PVCs in ANY namespace; genuinely-
+# unprotected user PVCs stay subject to the velero-backed requirement. Mirrors
+# the by-label CNPG carve-out on the flux-managed policy (#3374). Template-only
+# behavior change + new test fixtures. Refs #3971.
+version: 1.0.39
 appVersion: "1.0.2"
 keywords: [catalyst, blueprint, kyverno, policy, compliance, audit]
 maintainers:

--- a/platform/kyverno-policies/chart/templates/baseline/20-backup-configured.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/20-backup-configured.yaml
@@ -56,6 +56,30 @@ spec:
                 {{- range $ns := .Values.compliancePolicies.backupConfigured.excludeNamespaces }}
                 - {{ $ns }}
                 {{- end }}
+          {{- /*
+            #3971 (2026-06-21, first proven hw178 dep 02bc518fcb1b4cb3): the
+            database tier's PVCs are CNPG (CloudNativePG) operator-managed.
+            CNPG creates each instance PVC (`<cluster>-N`, e.g. `harbor-pg-1`,
+            `gitea-pg-1`, `guacamole-pg-1`, `pdns-pg-1`) WITHOUT any Velero
+            label/annotation because it backs up via its OWN continuous
+            barman / object-store WAL-streaming mechanism, not Velero — the two
+            backup stories are mutually exclusive by design. The over-broad
+            `pvc-must-be-velero-backed` rule flagged the ENTIRE DB tier (harbor,
+            gitea, keycloak, powerdns, guacamole all run on CNPG): on hw178
+            every CNPG instance PVC sat Pending with the event `policy
+            backup-configured/pvc-must-be-velero-backed fail: PVC harbor-pg-1 is
+            not declared as part of a Velero backup`. Every CNPG-created PVC
+            carries the `cnpg.io/cluster: <cluster-name>` label; excluding on
+            its presence exempts ONLY operator-backed database PVCs in ANY
+            namespace (current or future), while every genuinely-unprotected
+            user PVC stays subject to the velero-backed requirement. Mirrors the
+            by-label CNPG carve-out on the flux-managed policy (#3374). Refs #3971.
+          */}}
+          - resources:
+              selector:
+                matchExpressions:
+                  - key: cnpg.io/cluster
+                    operator: Exists
       validate:
         message: >-
           PVC {{ `{{request.object.metadata.name}}` }} is not declared

--- a/platform/kyverno-policies/chart/tests/fixtures/README.md
+++ b/platform/kyverno-policies/chart/tests/fixtures/README.md
@@ -36,9 +36,17 @@ exactly one (per workload).
 | resource-requests | `resource-requests/pass-deployment.yaml` | `resource-requests/fail-deployment.yaml` |
 | image-tag-pinned | `image-tag-pinned/pass-deployment.yaml` | `image-tag-pinned/fail-deployment.yaml` |
 | forbid-local-path-storage (#3971) | `forbid-local-path/pass-pvc.yaml` | `forbid-local-path/fail-pvc.yaml` |
+| backup-configured / pvc-must-be-velero-backed (#3971) | `backup-configured/pass-pvc.yaml` | `backup-configured/fail-pvc.yaml` |
 
 The remaining policies' fixtures are deferred — slice S1 ships the
 authoritative matrix.
+
+`backup-configured` pass fixture proves BOTH legitimate exemptions: a
+CNPG-managed PVC (label `cnpg.io/cluster` → exempt via the 1.0.39 carve-out,
+backed by barman not Velero) AND a Velero-bound user PVC (label
+`velero.io/managed-by-schedule`). The fail fixture is a stateful user PVC with
+neither marker — still correctly DENIED, proving the carve-out did not weaken
+the policy for genuinely-unprotected PVCs.
 
 ## MUTATE policy fixtures (Refs #3268)
 

--- a/platform/kyverno-policies/chart/tests/fixtures/backup-configured/fail-pvc.yaml
+++ b/platform/kyverno-policies/chart/tests/fixtures/backup-configured/fail-pvc.yaml
@@ -1,0 +1,19 @@
+# Failing case (#3971): a genuinely-unprotected user PVC.
+#
+# This PVC carries NEITHER the `cnpg.io/cluster` label (so the 1.0.39 CNPG
+# carve-out does NOT exempt it) NOR any Velero binding (`velero.io/managed-by-
+# schedule` label / `velero.io/backup-volumes` annotation). It is a stateful
+# user workload with no backup story at all — the backup-configured policy's
+# `pvc-must-be-velero-backed` rule correctly FLAGS it (DENY under Enforce).
+# This proves the CNPG carve-out did NOT weaken the policy for unprotected PVCs.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: unprotected-user-data
+  namespace: example
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/platform/kyverno-policies/chart/tests/fixtures/backup-configured/pass-pvc.yaml
+++ b/platform/kyverno-policies/chart/tests/fixtures/backup-configured/pass-pvc.yaml
@@ -1,0 +1,39 @@
+# Passing case (#3971): a CNPG-managed database PVC.
+#
+# CloudNativePG stamps every instance PVC it creates with the label
+# `cnpg.io/cluster: <cluster-name>` (here `harbor-pg`). CNPG backs these up
+# via its OWN continuous barman / object-store WAL-streaming, NOT Velero, so it
+# never adds a `velero.io/managed-by-schedule` label or a `velero.io/backup-
+# volumes` annotation. The backup-configured policy's `pvc-must-be-velero-backed`
+# rule EXCLUDES PVCs carrying `cnpg.io/cluster` (the 1.0.39 carve-out), so this
+# PVC is ALLOWED even though it has no Velero binding.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: harbor-pg-1
+  namespace: harbor
+  labels:
+    cnpg.io/cluster: harbor-pg
+    cnpg.io/pvcRole: PG_DATA
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+---
+# Also passing: a plain user PVC that DOES declare its Velero backup via the
+# `velero.io/managed-by-schedule` label — the original, intended pass path.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: app-data-velero-backed
+  namespace: example
+  labels:
+    velero.io/managed-by-schedule: daily-app-backup
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi


### PR DESCRIPTION
Refs #3971

## Problem (live on hw178, dep `02bc518fcb1b4cb3`)

Database-tier PVCs `harbor-pg-1`, `gitea-pg-1`, `guacamole-pg-1`, `pdns-pg-1` were stuck **Pending** — NOT a CSI failure (the `evs-ssd` default StorageClass + driver work; 7 other PVCs Bound). They were flagged/denied by the Kyverno **K2 `backup-configured`** ClusterPolicy:

```
policy backup-configured/pvc-must-be-velero-backed fail: validation error:
PVC harbor-pg-1 is not declared as part of a Velero backup. Add label
velero.io/managed-by-schedule or annotate the owning Pod template with
velero.io/backup-volumes
```

## Root cause

CNPG (CloudNativePG) creates its database instance PVCs **without** Velero labels because it backs up via its **own continuous barman / object-store WAL-streaming**, not Velero — the two backup stories are mutually exclusive by design. The `pvc-must-be-velero-backed` rule was over-broad and flagged the entire CNPG database tier (harbor, gitea, keycloak, powerdns, guacamole all run on CNPG). Under Enforce it strands the whole DB tier.

## Fix

`platform/kyverno-policies/chart/templates/baseline/20-backup-configured.yaml` — add a second `exclude.any[]` entry scoping out CNPG-managed PVCs by label:

```yaml
- resources:
    selector:
      matchExpressions:
        - key: cnpg.io/cluster
          operator: Exists
```

Every CNPG-created PVC carries `cnpg.io/cluster: <cluster-name>`, so this exempts **only** operator-backed database PVCs in any namespace (current or future). Genuinely-unprotected user PVCs (no `cnpg.io/cluster`, no Velero binding) **stay** subject to the velero-backed requirement — the policy is NOT weakened, NOT flipped to Audit. This mirrors the proven by-label CNPG carve-out already shipped on the `flux-managed` policy (#3374, `app.kubernetes.io/managed-by: cloudnative-pg`).

## Lockstep version bump (1.0.38 → 1.0.39)

Chart.yaml == blueprint.yaml == bootstrap-kit slot-27a pin, all `1.0.39`. `scripts/check-bootstrap-kit-pin-sync.sh` reports `OK bp-kyverno-policies: chart=1.0.39 pin=1.0.39` (the 3 other DRIFT lines — bp-newapi, bp-catalyst-platform — are pre-existing on main, handled by the auto-bump hook, unrelated to this PR).

## Test proof

New fixtures `tests/fixtures/backup-configured/{pass,fail}-pvc.yaml` + README coverage row. `kyverno` CLI egress is blocked in the sandbox, so the two-directional proof was run as a deterministic trace of the rendered policy's exclude/validate logic against the fixtures:

```
[PASS] harbor-pg-1            -> ALLOW (excluded)      (label cnpg.io/cluster present — CNPG carve-out)
[PASS] app-data-velero-backed -> ALLOW (velero-backed) (has velero.io/managed-by-schedule label)
[PASS] unprotected-user-data  -> DENY                  (no velero binding -> Enforce blocks)
OVERALL: ALL EXPECTED
```

`helm template` renders the full chart cleanly (22 ClusterPolicies).

## Do not merge yet

Held for batch-merge after hw178 reaches ready (per the dispatch brief).

🤖 Generated with [Claude Code](https://claude.com/claude-code)