### PR TITLE
fix(cloud-view): scope Nodes to the deployment + evict wiped clusters from k8scache

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/k8s.go
+++ b/products/catalyst/bootstrap/api/internal/handler/k8s.go
@@ -160,17 +160,13 @@ func (h *Handler) HandleK8sList(w http.ResponseWriter, r *http.Request) {
 	// only — preserves the original semantics for legacy callers and
 	// keeps wire-shape backward-compatible (Cluster=primary,
 	// Clusters=[] omitted).
-	fanOutIDs := []string{clusterID}
-	if h.k8sCache != nil {
-		seen := map[string]struct{}{clusterID: {}}
-		for _, cid := range h.k8sCache.Clusters() {
-			if _, ok := seen[cid]; ok {
-				continue
-			}
-			seen[cid] = struct{}{}
-			fanOutIDs = append(fanOutIDs, cid)
-		}
-	}
+	//
+	// #3987 — scope the fan-out to THIS deployment's clusters (primary +
+	// its "<primary>-<region>" secondaries), NOT the whole process cache.
+	// On the mothership the process cache holds every managed Sovereign's
+	// clusters; a blind Clusters() fan-out leaked sibling deployments'
+	// (and stale wiped-deployment) Nodes into the page being viewed.
+	fanOutIDs := h.deploymentScopedClusterIDs(clusterID)
 
 	// Carry the source cluster id alongside each item positionally
 	// — the parallel slice survives sort + paginate + SAR-gate so
@@ -711,8 +707,13 @@ func (h *Handler) HandleK8sStream(w http.ResponseWriter, r *http.Request) {
 	// registered cluster so /cloud?view=list&kind=nodes renders all
 	// 3 region nodes on a 3-region Sovereign (not just the primary's
 	// 1). Single-cluster Sovereigns keep the primary-only filter.
-	allowedClusters := map[string]struct{}{clusterID: {}}
-	for _, cid := range h.k8sCache.Clusters() {
+	//
+	// #3987 — scope to THIS deployment's clusters (primary + its
+	// "<primary>-<region>" secondaries), NOT the whole process cache, so
+	// the mothership SSE stream for one deployment never delivers a
+	// sibling (or stale wiped) deployment's events.
+	allowedClusters := map[string]struct{}{}
+	for _, cid := range h.deploymentScopedClusterIDs(clusterID) {
 		allowedClusters[cid] = struct{}{}
 	}
 
@@ -927,6 +928,45 @@ func (h *Handler) k8sCacheHasCluster(id string) bool {
 		}
 	}
 	return false
+}
+
+// deploymentScopedClusterIDs returns ONLY the k8scache cluster IDs that
+// belong to the deployment whose (already chroot-resolved) primary
+// cluster id is `resolvedID` — the primary itself plus any
+// "<resolvedID>-<region>" secondaries registered by the
+// secondary-kubeconfig fan-out.
+//
+// #3987 — the per-deployment Cloud Nodes/k8s-list pages must show ONLY
+// the requested deployment's clusters. The mothership process cache
+// holds EVERY managed Sovereign's clusters at once (one .yaml per
+// deployment in /var/lib/catalyst/kubeconfigs), so a blind
+// `h.k8sCache.Clusters()` fan-out merged a sibling deployment's Nodes
+// into the page being viewed — the hw178 page rendered 39 nodes spanning
+// hw136 + two already-wiped deployments whose stale cluster IDs had not
+// been evicted. Scoping the fan-out to the requested deployment's own
+// cluster-id prefix fixes the cross-deployment leak at the read tier
+// (the eviction half is fixed in k8scache's rescan-prune loop). The
+// chroot post-cutover case is unaffected: there every registered cluster
+// IS this Sovereign's (one primary + its secondaries, all sharing the
+// resolved id prefix), so the same prefix scope keeps the full set.
+func (h *Handler) deploymentScopedClusterIDs(resolvedID string) []string {
+	out := []string{resolvedID}
+	if h.k8sCache == nil {
+		return out
+	}
+	prefix := resolvedID + "-"
+	seen := map[string]struct{}{resolvedID: {}}
+	for _, cid := range h.k8sCache.Clusters() {
+		if _, ok := seen[cid]; ok {
+			continue
+		}
+		// Only this deployment's secondaries — "<primary>-<region>".
+		if strings.HasPrefix(cid, prefix) {
+			seen[cid] = struct{}{}
+			out = append(out, cid)
+		}
+	}
+	return out
 }
 
 // resolveChrootClusterID rewrites an incoming URL cluster ID onto the

--- a/products/catalyst/bootstrap/api/internal/handler/k8s_scope_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/k8s_scope_test.go
@@ -1,0 +1,86 @@
+// k8s_scope_test.go — #3987: the per-deployment Cloud Nodes / k8s-list
+// pages must show ONLY the requested deployment's clusters. The
+// mothership process cache holds EVERY managed Sovereign's clusters at
+// once (one kubeconfig per deployment), so a blind fan-out across the
+// whole cache leaked sibling — and stale wiped — deployments' Nodes into
+// the page being viewed (the hw178 page rendering 39 nodes spanning
+// hw136 + two wiped deployments). deploymentScopedClusterIDs is the
+// read-tier scope that fixes it.
+
+package handler
+
+import (
+	"io"
+	"log/slog"
+	"sort"
+	"testing"
+
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func TestDeploymentScopedClusterIDs_ExcludesSiblingAndWipedDeployments(t *testing.T) {
+	const (
+		depA       = "02bc518fcb1b4cb3" // the deployment whose page we view (hw178)
+		depASecond = depA + "-me-east-215-b-1"
+		depB       = "3a2ee904b1d0366a" // a live SIBLING deployment (hw136)
+		depBSecond = depB + "-me-east-215-b-1"
+		wiped      = "068f217746ca7779" // a wiped deployment whose stale id lingered
+	)
+
+	// Register all five clusters in ONE process cache, exactly as the
+	// mothership does (every managed Sovereign's kubeconfigs loaded into
+	// the same Factory).
+	cache := newK8sCacheWithClusters(t, map[string]*dynamicfake.FakeDynamicClient{
+		depA:       fakeHRDynamicClient(t),
+		depASecond: fakeHRDynamicClient(t),
+		depB:       fakeHRDynamicClient(t),
+		depBSecond: fakeHRDynamicClient(t),
+		wiped:      fakeHRDynamicClient(t),
+	})
+
+	h := &Handler{
+		log:      slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		k8sCache: cache,
+	}
+
+	// Scope to depA. We must get depA + its OWN secondary, and NOTHING
+	// from depB or the wiped deployment.
+	got := h.deploymentScopedClusterIDs(depA)
+	sort.Strings(got)
+
+	want := []string{depA, depASecond}
+	sort.Strings(want)
+
+	if len(got) != len(want) {
+		t.Fatalf("scoped fan-out leaked sibling/wiped clusters: got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("scoped fan-out mismatch at %d: got %v, want %v", i, got, want)
+		}
+	}
+
+	// Explicit cross-deployment assertions — the exact #3987 leak.
+	for _, leaked := range []string{depB, depBSecond, wiped} {
+		for _, id := range got {
+			if id == leaked {
+				t.Fatalf("deployment %s leaked cluster %q from a different deployment", depA, leaked)
+			}
+		}
+	}
+
+	// And the symmetric case: scoping to depB returns only depB's set,
+	// never depA's — so neither deployment's page bleeds into the other.
+	gotB := h.deploymentScopedClusterIDs(depB)
+	sort.Strings(gotB)
+	wantB := []string{depB, depBSecond}
+	sort.Strings(wantB)
+	if len(gotB) != len(wantB) {
+		t.Fatalf("depB scope wrong: got %v, want %v", gotB, wantB)
+	}
+	for i := range wantB {
+		if gotB[i] != wantB[i] {
+			t.Fatalf("depB scope mismatch: got %v, want %v", gotB, wantB)
+		}
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/k8s_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/k8s_test.go
@@ -375,15 +375,25 @@ func TestHandleK8sList_NamespaceAliasFiltering(t *testing.T) {
 //
 // Multi-region Sovereigns register N kubeconfigs in the k8sCache
 // (primary + N-1 secondaries via the handover hook, PRs #1579 + #1581).
-// /cloud?view=list&kind=nodes must enumerate items from every
-// registered cluster and stamp each row with its source cluster id.
+// /cloud?view=list&kind=nodes must enumerate items from every cluster
+// THAT BELONGS TO THE REQUESTED DEPLOYMENT and stamp each row with its
+// source cluster id.
 //
 // Pre-fix: HandleK8sList queried only the resolveChrootClusterID
 // result (primary), returning 1 row on a 3-region Sovereign while the
 // aggregate /dashboard chips correctly counted 3.
+//
+// #3987: the secondary's cluster id MUST follow the canonical
+// "<primary>-<region>" convention (k8scache.LoadClustersFromDir stems +
+// HandleSovereignSecondaryKubeconfig writer) so the deployment-scoped
+// fan-out includes it. A bare unrelated id (a SIBLING deployment) must
+// NOT be merged — that was the hw178-page-shows-hw136-nodes leak.
 func TestHandleK8sList_FanOutAcrossClusters(t *testing.T) {
 	podA := newPod("default", "primary-pod")
 	podB := newPod("default", "secondary-pod")
+	// A THIRD pod in a SIBLING deployment's cluster — must NOT leak into
+	// the requested deployment's page (#3987).
+	podSibling := newPod("default", "sibling-pod")
 
 	scheme := runtime.NewScheme()
 	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Version: "v1", Kind: "PodList"}, &unstructured.UnstructuredList{})
@@ -393,12 +403,19 @@ func TestHandleK8sList_FanOutAcrossClusters(t *testing.T) {
 	}
 	dynA := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrList, podA)
 	dynB := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrList, podB)
+	dynSibling := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrList, podSibling)
+	const (
+		primaryID   = "02bc518fcb1b4cb3"             // the requested deployment
+		secondaryID = primaryID + "-me-east-215-b-1" // its OWN secondary region
+		siblingID   = "3a2ee904b1d0366a"             // a DIFFERENT live deployment
+	)
 	cfg := k8scache.Config{
 		Logger:   quietLog(),
 		Registry: minimalRegistry(),
 		Clusters: []k8scache.ClusterRef{
-			{ID: "primary", DynamicClient: dynA, CoreClient: kfake.NewSimpleClientset()},
-			{ID: "sin-2", DynamicClient: dynB, CoreClient: kfake.NewSimpleClientset()},
+			{ID: primaryID, DynamicClient: dynA, CoreClient: kfake.NewSimpleClientset()},
+			{ID: secondaryID, DynamicClient: dynB, CoreClient: kfake.NewSimpleClientset()},
+			{ID: siblingID, DynamicClient: dynSibling, CoreClient: kfake.NewSimpleClientset()},
 		},
 	}
 	f, err := k8scache.NewFactory(cfg)
@@ -409,12 +426,13 @@ func TestHandleK8sList_FanOutAcrossClusters(t *testing.T) {
 		t.Fatalf("Start: %v", err)
 	}
 	t.Cleanup(f.Stop)
-	// Wait for both clusters' pod informers to sync.
+	// Wait for all clusters' pod informers to sync.
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		ia, _, _ := f.List("primary", "pod", nil)
-		ib, _, _ := f.List("sin-2", "pod", nil)
-		if len(ia) == 1 && len(ib) == 1 {
+		ia, _, _ := f.List(primaryID, "pod", nil)
+		ib, _, _ := f.List(secondaryID, "pod", nil)
+		is, _, _ := f.List(siblingID, "pod", nil)
+		if len(ia) == 1 && len(ib) == 1 && len(is) == 1 {
 			break
 		}
 		time.Sleep(20 * time.Millisecond)
@@ -424,7 +442,7 @@ func TestHandleK8sList_FanOutAcrossClusters(t *testing.T) {
 	h.SetK8sCache(f, k8scache.NewSARCache(), "X-Forwarded-User")
 	r := newRouter(h)
 
-	req := httptest.NewRequest("GET", "/api/v1/sovereigns/primary/k8s/pod", nil)
+	req := httptest.NewRequest("GET", "/api/v1/sovereigns/"+primaryID+"/k8s/pod", nil)
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 	if rec.Code != 200 {
@@ -434,16 +452,22 @@ func TestHandleK8sList_FanOutAcrossClusters(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
+	// Exactly 2 items: the deployment's primary + its own secondary. The
+	// sibling deployment's pod MUST NOT appear (#3987 cross-deployment
+	// leak guard).
 	if len(resp.Items) != 2 {
-		t.Fatalf("fan-out expected 2 items (primary+sin-2); got %d", len(resp.Items))
+		t.Fatalf("scoped fan-out expected 2 items (primary+own-secondary); got %d (%v)", len(resp.Items), resp.Items)
 	}
-	// Both source clusters MUST appear in the Clusters header.
+	// Both this deployment's clusters MUST appear; the sibling MUST NOT.
 	gotClusters := map[string]bool{}
 	for _, c := range resp.Clusters {
 		gotClusters[c] = true
 	}
-	if !gotClusters["primary"] || !gotClusters["sin-2"] {
-		t.Fatalf("expected Clusters=[primary,sin-2]; got %v", resp.Clusters)
+	if !gotClusters[primaryID] || !gotClusters[secondaryID] {
+		t.Fatalf("expected Clusters=[%s,%s]; got %v", primaryID, secondaryID, resp.Clusters)
+	}
+	if gotClusters[siblingID] {
+		t.Fatalf("#3987 LEAK: sibling deployment cluster %s appeared in %s's page: %v", siblingID, primaryID, resp.Clusters)
 	}
 	// Each row carries its source cluster stamp under top-level "cluster".
 	stamps := map[string]bool{}
@@ -452,8 +476,11 @@ func TestHandleK8sList_FanOutAcrossClusters(t *testing.T) {
 			stamps[cid] = true
 		}
 	}
-	if !stamps["primary"] || !stamps["sin-2"] {
+	if !stamps[primaryID] || !stamps[secondaryID] {
 		t.Fatalf("expected each row to carry source cluster id; got %v", stamps)
+	}
+	if stamps[siblingID] {
+		t.Fatalf("#3987 LEAK: a row was stamped with sibling cluster %s", siblingID)
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/k8scache/factory.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/factory.go
@@ -257,6 +257,17 @@ type Factory struct {
 
 type clusterState struct {
 	id string
+	// kubeconfigPath — the on-disk kubeconfig this cluster was loaded
+	// from (empty for chroot self-registered + test-injected clusters
+	// that carry a pre-built DynamicClient). #3987: the rescan-prune
+	// loop evicts a file-backed cluster once its kubeconfig disappears
+	// from KubeconfigsDir — the eviction half of the cross-deployment
+	// Nodes leak (a wiped deployment whose .yaml lingered, or whose
+	// RemoveCluster ran in-process but the Pod then restarted and the
+	// hydrate/rescan path could otherwise resurrect it). Clusters with
+	// an empty path are NEVER pruned (the chroot's own in-cluster
+	// cluster has no backing file and must survive every rescan).
+	kubeconfigPath string
 	// factory — the dynamicinformer factory for this cluster. Watches
 	// every registered Kind with no per-Kind LIST bound.
 	//
@@ -561,10 +572,11 @@ func (f *Factory) AddCluster(c ClusterRef) error {
 	// the architectural rationale. Every Kind in DefaultKinds now has a
 	// naturally-bounded population, so one unbounded factory is correct.
 	cs := &clusterState{
-		id:          c.ID,
-		dyn:         dyn,
-		core:        core,
-		restCfg:     restCfg, // G95.1 (Refs #2642) — nil on pre-built-client test path; production kubeconfig path populates it for exec-stream SPDY dials.
+		id:             c.ID,
+		kubeconfigPath: c.KubeconfigPath, // #3987 — empty for pre-built-client (chroot/test) clusters; rescan-prune only evicts file-backed clusters whose file disappeared.
+		dyn:            dyn,
+		core:           core,
+		restCfg:        restCfg, // G95.1 (Refs #2642) — nil on pre-built-client test path; production kubeconfig path populates it for exec-stream SPDY dials.
 		factory:     dynamicinformer.NewDynamicSharedInformerFactory(dyn, f.cfg.Resync),
 		informers:   map[string]cache.SharedIndexInformer{},
 		indexers:    map[string]cache.Indexer{},
@@ -856,6 +868,23 @@ func (f *Factory) rescanOnce(ctx context.Context) {
 			f.log.Info("k8scache: rescan — registered new cluster",
 				"id", ref.ID, "kubeconfig", ref.KubeconfigPath)
 		}
+
+		// #3987 — prune file-backed clusters whose kubeconfig vanished from
+		// the dir. A wiped deployment's RemoveCluster runs in-process, but a
+		// lingering or re-loaded .yaml (or a Pod restart that re-scanned a
+		// stale file) could otherwise keep a dead cluster registered — its
+		// Nodes then leak into a sibling deployment's Cloud page through the
+		// process cache. Computing the prune set here (rescan tier) is the
+		// eviction half of the cross-deployment Nodes leak; the read tier's
+		// per-deployment scoping is the other half (handler.deploymentScoped
+		// ClusterIDs). Clusters with an empty kubeconfigPath (chroot's own
+		// in-cluster cluster, test-injected pre-built clients) are NEVER
+		// pruned. RemoveCluster is idempotent + tears down the reflectors.
+		for _, id := range f.clustersToPrune() {
+			f.log.Info("k8scache: rescan — pruning cluster whose kubeconfig disappeared",
+				"id", id)
+			f.RemoveCluster(id)
+		}
 	}
 
 	// Chroot self-register recovery: when the Pod started before the
@@ -888,6 +917,36 @@ func (f *Factory) rescanOnce(ctx context.Context) {
 	}
 	f.log.Info("k8scache: rescan — chroot self-registered from ConfigMap",
 		"id", ref.ID, "sovereignFQDN", fqdn)
+}
+
+// clustersToPrune returns the ids of file-backed clusters whose
+// kubeconfig file no longer exists on disk. Clusters registered with a
+// pre-built DynamicClient (empty kubeconfigPath — the chroot's own
+// in-cluster cluster + test-injected clients) are never returned, so
+// the prune can never evict a cluster that has no backing file to
+// disappear. Pure read of f.clusters under the lock + an os.Stat per
+// candidate; the caller (rescanOnce) does the actual RemoveCluster
+// outside the lock. #3987.
+func (f *Factory) clustersToPrune() []string {
+	f.mu.RLock()
+	type cand struct{ id, path string }
+	cands := make([]cand, 0, len(f.clusters))
+	for id, cs := range f.clusters {
+		if cs == nil || cs.kubeconfigPath == "" {
+			continue
+		}
+		cands = append(cands, cand{id: id, path: cs.kubeconfigPath})
+	}
+	f.mu.RUnlock()
+
+	var stale []string
+	for _, c := range cands {
+		if _, err := os.Stat(c.path); err != nil && os.IsNotExist(err) {
+			stale = append(stale, c.id)
+		}
+	}
+	sort.Strings(stale)
+	return stale
 }
 
 // readSovereignFQDNFromConfigMap returns the non-empty fqdn from the

--- a/products/catalyst/bootstrap/api/internal/k8scache/k8scache_test.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/k8scache_test.go
@@ -1246,3 +1246,99 @@ users: [{name: u, user: {token: t}}]
 	}
 }
 
+// TestFactory_RescanPrunesVanishedKubeconfig is the #3987 eviction half:
+// a file-backed cluster whose kubeconfig disappears from KubeconfigsDir
+// must be pruned by the next rescan, while (a) a sibling whose file
+// still exists and (b) a pre-built-client cluster with NO backing file
+// (the chroot's own in-cluster cluster) both survive. This is the
+// k8scache-tier guard against a wiped deployment's cluster id leaking
+// its Nodes into a sibling deployment's Cloud page through the process
+// cache.
+func TestFactory_RescanPrunesVanishedKubeconfig(t *testing.T) {
+	tmp := t.TempDir()
+	kubeconfig := func() string {
+		return `apiVersion: v1
+kind: Config
+clusters:
+- name: c
+  cluster:
+    server: https://127.0.0.1:6443
+    insecure-skip-tls-verify: true
+contexts:
+- name: c
+  context:
+    cluster: c
+    user: u
+current-context: c
+users:
+- name: u
+  user:
+    token: t
+`
+	}
+	// depA = the deployment whose page we view (file survives).
+	// depB = the wiped deployment (file gets deleted).
+	pathA := tmp + "/depA.yaml"
+	pathB := tmp + "/depB.yaml"
+	if err := os.WriteFile(pathA, []byte(kubeconfig()), 0o600); err != nil {
+		t.Fatalf("write depA: %v", err)
+	}
+	if err := os.WriteFile(pathB, []byte(kubeconfig()), 0o600); err != nil {
+		t.Fatalf("write depB: %v", err)
+	}
+
+	refs, err := LoadClustersFromDir(quietLogger(), tmp)
+	if err != nil {
+		t.Fatalf("LoadClustersFromDir: %v", err)
+	}
+
+	// Also inject a pre-built-client cluster (no kubeconfig file) — the
+	// chroot's own in-cluster cluster. It must NEVER be pruned.
+	pod := newPod("default", "x")
+	dyn, core := fakeClients(pod)
+
+	cfg := Config{
+		Logger:         quietLogger(),
+		Registry:       minimalRegistry(),
+		KubeconfigsDir: tmp,
+		Clusters:       append(refs, ClusterRef{ID: "chroot-self", DynamicClient: dyn, CoreClient: core}),
+	}
+	f, err := NewFactory(cfg)
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	defer f.Stop()
+	if got := len(f.Clusters()); got != 3 {
+		t.Fatalf("expected 3 clusters (depA, depB, chroot-self), got %d (%v)", got, f.Clusters())
+	}
+
+	// Wipe depB: delete its kubeconfig file (what the wipe handler's
+	// snapshot cleanup + a stale-file purge would leave behind).
+	if err := os.Remove(pathB); err != nil {
+		t.Fatalf("remove depB kubeconfig: %v", err)
+	}
+
+	// One rescan pass must prune depB and keep depA + chroot-self.
+	f.rescanOnce(context.Background())
+
+	got := map[string]bool{}
+	for _, id := range f.Clusters() {
+		got[id] = true
+	}
+	if got["depB"] {
+		t.Fatalf("depB still registered after its kubeconfig disappeared: %v", f.Clusters())
+	}
+	if !got["depA"] {
+		t.Fatalf("depA wrongly pruned — its kubeconfig still exists: %v", f.Clusters())
+	}
+	if !got["chroot-self"] {
+		t.Fatalf("chroot-self (no backing file) wrongly pruned: %v", f.Clusters())
+	}
+
+	// depB's List must now error (cluster gone), proving the Nodes no
+	// longer surface from the process cache.
+	if _, _, err := f.List("depB", "pod", labels.Everything()); err == nil {
+		t.Fatalf("List(depB) expected error after prune, got nil")
+	}
+}
+


### PR DESCRIPTION
## Problem

The per-deployment Cloud **Nodes** page for the current prov **hw178** (dep `02bc518fcb1b4cb3`) showed **39 nodes spanning FOUR deployments** — hw136 (adopted, alive), hw176 + hw177 (wiped — records + kubeconfigs purged), and hw178 itself. hw178's own kubeconfig correctly returns only 6 nodes (12 across its 2 regions on the live env), so the leak is in the catalyst-api `k8scache` / topology read path, not the real cluster.

### Orphan check (read-only, no deletes)

Confirmed via the Huawei provider's own signed ECS list (reusing `sigv3.go`, no hand-rolled SDK-HMAC-SHA256) against the kom4dc project: **`catalyst-hw176-*` = 0 servers, `catalyst-hw177-*` = 0 servers**. Their VMs are genuinely **tofu-destroyed** — no orphaned/billing infra. So this is purely a stale/cross-deployment **cache display bug**, which this PR fixes.

## Two root causes, both fixed

1. **Read-tier cross-deployment leak.** `HandleK8sList` + `HandleK8sStream` fanned out across `h.k8sCache.Clusters()` — the **entire process cache** — instead of the requested deployment's clusters. On the mothership that cache holds every managed Sovereign's kubeconfigs at once, so a sibling deployment's (and any stale wiped-deployment's) Nodes merged into the page being viewed. New `deploymentScopedClusterIDs(resolvedID)` returns only the primary `<depID>` plus its `<depID>-<region>` secondaries. The chroot single-Sovereign post-cutover case is unchanged (every registered cluster shares the resolved id prefix).

2. **Eviction gap.** The k8scache rescan loop only ever **added** clusters. A wiped deployment whose `.yaml` lingered — or whose in-process `RemoveCluster` ran but a Pod restart then re-scanned a stale file — stayed registered and kept leaking its Nodes. `rescanOnce` now **prunes** file-backed clusters whose kubeconfig disappeared (`clustersToPrune`), tracked via a new `clusterState.kubeconfigPath`. Pre-built-client clusters (the chroot's own in-cluster cluster, test-injected clients) carry an empty path and are **never** pruned.

## Tests

- `TestFactory_RescanPrunesVanishedKubeconfig` — a wiped deployment's cluster is evicted once its kubeconfig vanishes; a sibling whose file still exists, and a no-file chroot cluster, both survive; `List` on the pruned id errors.
- `TestDeploymentScopedClusterIDs_ExcludesSiblingAndWipedDeployments` — scoping to dep-A returns only dep-A's clusters, never dep-B's or a wiped dep's (and symmetrically for dep-B).
- `TestHandleK8sList_FanOutAcrossClusters` updated to the canonical `<primary>-<region>` secondary convention + an explicit sibling-deployment leak guard.

## Gates

`go build ./...`, `go vet ./...`, and `go test ./...` green on the touched packages (`internal/k8scache`, `internal/handler`).

**Held for batch-merge after hw178 reaches ready — do not merge yet.**

Refs #3987

🤖 Generated with [Claude Code](https://claude.com/claude-code)