### PR TITLE
fix(bp-huawei-evs-csi): slot 55b dependsOn bp-reflector — close ghcr-pull race (EVS-CSI ImagePullBackOff no self-heal) (#4038 follow-up)

### DIFF
--- a/clusters/_template/bootstrap-kit/55b-bp-huawei-evs-csi.yaml
+++ b/clusters/_template/bootstrap-kit/55b-bp-huawei-evs-csi.yaml
@@ -66,11 +66,23 @@
 #     (INI [Global] AK/SK + endpoints) the driver binds for EVS-API auth. The
 #     plaintext never lands in this committed manifest.
 #
-# dependsOn: (none) — a foundational cloud seam that must be Ready BEFORE the
-# stateful apps create PVCs. The cloud-credentials Secret is seeded by
-# cloud-init pre-Flux and the chart pulls from ghcr, so no Flux dependency. The
-# stateful slots install LATE (their dependsOn chains), by which time the
-# default-class flip has run.
+# dependsOn: bp-reflector — the driver image
+# (ghcr.io/openova-io/openova/evs-csi-plugin) is a PRIVATE ghcr package whose
+# pod spec carries `imagePullSecrets: [ghcr-pull]` (#4037/#4038). That secret is
+# NOT created in `huawei-evs-csi` by this slot; it is MIRRORED there by the
+# emberstack reflector (slot 05a) from `flux-system/ghcr-pull`. Without a
+# dependsOn on bp-reflector this slot raced ahead: the CSI HR installed and
+# created its controller/node pods BEFORE the reflector had mirrored the secret,
+# so the kubelet pulled `evs-csi-plugin` anonymously → 401 Unauthorized →
+# ImagePullBackOff that does NOT self-heal once the secret later lands (a pod in
+# pull-backoff is never re-resolved against newly-arrived imagePullSecrets; it
+# needs a recreate). Live evidence hw179 (f06e6dd2e8e6dc52, region B,
+# 2026-06-21): ghcr-pull reflected into huawei-evs-csi at T+~9m but all three
+# CSI pods stayed ImagePullBackOff 11m+ with the last pull attempt 10m stale.
+# Gating on bp-reflector guarantees the secret exists before the pods are
+# created. (cloud-credentials for AK/SK is still seeded by cloud-init pre-Flux,
+# so no Flux dependency there; only the private-image pull secret needs the
+# reflector ordering.)
 
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
@@ -96,6 +108,15 @@ spec:
   # Default-suspended (Hetzner). The Huawei cloud-init sets
   # HUAWEI_HR_SUSPEND=false so a Huawei Sovereign installs the EVS CSI for real.
   suspend: ${HUAWEI_HR_SUSPEND:=true}
+  # #4038-followup — gate on bp-reflector so the `ghcr-pull` imagePullSecret has
+  # been mirrored into `huawei-evs-csi` BEFORE the private-image CSI pods are
+  # created (otherwise they ImagePullBackOff 401 and never self-heal; see the
+  # dependsOn note in the header). bp-reflector (slot 05a) is Ready early — it
+  # only dependsOn bp-cert-manager — so this gate adds no meaningful latency to a
+  # slot that already installs after the early foundational tier.
+  dependsOn:
+    - name: bp-reflector
+      namespace: flux-system
   interval: 15m
   releaseName: huawei-evs-csi
   targetNamespace: huawei-evs-csi

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -693,14 +693,20 @@ slots:
   # The Huawei (HCS / kom4dc) STORAGE sibling of slot 55a. Installs the
   # open-source huaweicloud-csi-driver EVS plugin (evs.csi.huaweicloud.com) +
   # the durable evs-ssd default StorageClass so Huawei PVCs land on real EVS
-  # block volumes (local-path FORBIDDEN by --disable=local-storage). No
-  # dependsOn: foundational cloud seam, Ready before the stateful apps create
-  # PVCs (cloud-credentials seeded by cloud-init pre-Flux, chart pulls from
-  # ghcr). Default-suspended on Hetzner (HUAWEI_HR_SUSPEND); the Huawei
-  # cloud-init flips it active. Closes the Huawei half of the #3971 P0 blocker.
+  # block volumes (local-path FORBIDDEN by --disable=local-storage).
+  # bp-reflector dep (#4044, #4038 follow-up): the driver image
+  # ghcr.io/openova-io/openova/evs-csi-plugin is a PRIVATE ghcr package whose
+  # pod spec carries imagePullSecrets:[ghcr-pull]; that secret is MIRRORED into
+  # huawei-evs-csi by the emberstack reflector (slot 5a), so the reflector must
+  # be Ready before the CSI pods are created — otherwise they pull anonymously,
+  # 401, ImagePullBackOff, and never self-heal once the secret lands (live hw179
+  # 2026-06-21). Same rationale as bp-external-dns above. cloud-credentials for
+  # AK/SK is still seeded by cloud-init pre-Flux (no Flux dep there).
+  # Default-suspended on Hetzner (HUAWEI_HR_SUSPEND); the Huawei cloud-init flips
+  # it active. Closes the Huawei half of the #3971 P0 blocker.
   - slot: 55b
     name: bp-huawei-evs-csi
-    depends_on: []
+    depends_on: [bp-reflector]
     wave: present
 
   # ---- Slots 56/57 — OpenovaFlow observability cohort.


### PR DESCRIPTION
## What

Add `dependsOn: bp-reflector` to the slot-55b `bp-huawei-evs-csi` HelmRelease.

## Why (live evidence hw179 / f06e6dd2e8e6dc52, region B, 2026-06-21)

`#4038` added `imagePullSecrets: [ghcr-pull]` for the private driver image — correct, but slot 55b had `dependsOn: (none)` and **raced the reflector** (slot 05a) that mirrors `ghcr-pull` into the `huawei-evs-csi` namespace:

1. CSI HR creates its private-image pods.
2. `ghcr-pull` not yet mirrored → kubelet pulls anonymously → `401` → ImagePullBackOff.
3. Secret later reflected in-ns (verified), but pods **never self-heal** (kubelet doesn't re-resolve imagePullSecrets for a pod already in backoff).

Observed: ghcr-pull reflected at ~T+9m, all 3 CSI pods stayed ImagePullBackOff 11m+.

## Fix shape

Matches the **existing precedent** of 5 slots that already `dependsOn: bp-reflector` (external-dns, powerdns-admin, the 3 shared-postgres slots). bp-reflector is Ready early (only `dependsOn: bp-cert-manager`) → no meaningful added latency.

Refs #4044 #4038 #4037

🤖 Generated with [Claude Code](https://claude.com/claude-code)