### PR TITLE
fix(huawei): route ghcr/quay/gcr/k8s through bastion NAT-bypass, not external harbor.openova.io

### DIFF
--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -641,17 +641,29 @@ locals {
   # registry:2 caches on direct EIP 212.72.24.20 (kom4dc NAT blocklist bypass,
   # Wave 5.106 #2462). harbor + docker.io mirror via :5000 / :5002 (#2842).
   #
-  # #3913: PREVIOUSLY quay.io / gcr.io / registry.k8s.io / ghcr.io / xpkg.upbound.io
-  # / public.ecr.aws all pulled DIRECT from upstream on kom4dc — the #1 fresh-prov
-  # pull-stall class this ticket closes. The bastion registry:2 caches are anon-only
-  # (can't auth private ghcr) and only front harbor + docker.io, so they can't carry
-  # those registries. But Huawei worker egress is wide-open via the NAT Gateway
-  # (see the secgroup comment above: "unconstrained egress to ... harbor.openova.io"),
-  # and harbor.openova.io's proxy-cache projects are anonymous-pullable. So route
-  # the remaining upstream registries through harbor.openova.io directly — mirroring
-  # the proven post-cutover set in self-sovereign-cutover/04-registry-pivot-
-  # daemonset.yaml. docker.io stays on the bastion :5002 cache (the documented
-  # NAT-blocklist bypass — #2842 — leave it as-is).
+  # #3913 (revert of regression 4049d61f4): the bastion :5000 cache is NOT a
+  # harbor-only/docker-only front — it is the SAME Harbor proxy-cache as
+  # harbor.openova.io, reachable over the LOCAL EIP 212.72.24.20 with NO NAT
+  # egress. It already serves the proxy-ghcr / proxy-quay / proxy-gcr / proxy-k8s
+  # projects (anon-pullable; verified live 2026-06-21: flux source-controller,
+  # cnpg, external-secrets, openbao, oauth2-proxy, kube-apiserver, gcr distroless
+  # all return manifest HTTP 200 via http://212.72.24.20:5000/v2/proxy-*/...).
+  #
+  # 4049d61f4 wrongly re-routed ghcr/quay/gcr/registry.k8s.io to the EXTERNAL
+  # https://harbor.openova.io. On kom4dc, reaching harbor.openova.io needs NAT
+  # egress → draws a reputation-blocklisted ("poisoned") EIP → cloud-init's
+  # Flux/cilium/k8s image pulls stall → region-a never bootstraps → prov FAILS.
+  # The bastion is the NAT-bypass local registry built exactly to avoid this.
+  # Route ghcr/quay/gcr/registry.k8s.io through the bastion :5000 with the SAME
+  # proxy-* rewrites — zero NAT egress, exactly like harbor + docker.io already do.
+  #
+  # xpkg.upbound.io / public.ecr.aws stay on https://harbor.openova.io: the
+  # bastion :5000 has NO proxy-xpkg / proxy-ecr projects (verified live: real
+  # manifest pull -> HTTP 404, vs proxy-gcr -> 200), so routing them to the
+  # bastion would 404. They are Crossplane-provider / ecr images that are NOT in
+  # the Phase-1 bootstrap critical path (Crossplane is idle on kom4dc — infra is
+  # 100% OpenTofu), so the external-harbor route for these two is harmless and
+  # strictly better than a 404. docker.io stays on the bastion :5002 cache.
   registry_mirror_yaml_huawei = <<-EOT
     mirrors:
       "harbor.openova.io":
@@ -665,22 +677,22 @@ locals {
           - "http://212.72.24.20:5002"
       "quay.io":
         endpoint:
-          - "https://harbor.openova.io"
+          - "http://212.72.24.20:5000"
         rewrite:
           "(.*)": "proxy-quay/$1"
       "gcr.io":
         endpoint:
-          - "https://harbor.openova.io"
+          - "http://212.72.24.20:5000"
         rewrite:
           "(.*)": "proxy-gcr/$1"
       "registry.k8s.io":
         endpoint:
-          - "https://harbor.openova.io"
+          - "http://212.72.24.20:5000"
         rewrite:
           "(.*)": "proxy-k8s/$1"
       "ghcr.io":
         endpoint:
-          - "https://harbor.openova.io"
+          - "http://212.72.24.20:5000"
         rewrite:
           "(.*)": "proxy-ghcr/$1"
       "xpkg.upbound.io":


### PR DESCRIPTION
Refs #3913

## Problem (regression revert)

Commit `4049d61f4` (`Refs #3913`, Jun 20) re-routed `ghcr.io / quay.io / gcr.io / registry.k8s.io / xpkg.upbound.io / public.ecr.aws` in the **Huawei (kom4dc)** containerd registry-mirror from the **bastion** to the **EXTERNAL `https://harbor.openova.io`**.

On kom4dc, reaching `harbor.openova.io` requires **NAT egress** → draws a reputation-blocklisted ("poisoned") EIP → cloud-init's Flux/cilium/k8s image pulls stall → region-a never bootstraps → **every fresh prov FAILS**. The bastion (`212.72.24.20`) is the NAT-bypass local registry built exactly to avoid this — and it IS the same Harbor proxy-cache, reached over the local EIP with zero NAT egress.

## Fix

In `registry_mirror_yaml_huawei` (`infra/providers/huawei/main.tf`), route `ghcr.io / quay.io / gcr.io / registry.k8s.io` through the bastion `http://212.72.24.20:5000` with the **same** `proxy-*` rewrites — exactly like `harbor.openova.io` + `docker.io` already do. Hetzner mirror untouched (clean-egress cloud, no bastion).

## Validation — live test-pull through bastion `:5000` (2026-06-21, read-only)

The operator's hard requirement: no additional handicaps. Every critical registry was test-pulled for a REAL manifest before the change:

| Registry | Bastion path | Real image probed | Result |
|---|---|---|---|
| ghcr.io | `proxy-ghcr` | flux source-controller v1.3.0, cnpg 1.23.0, external-secrets v0.9.0 | **200** |
| quay.io | `proxy-quay` | openbao 2.0.0, oauth2-proxy v6.1.1 | **200** |
| registry.k8s.io | `proxy-k8s` | kube-apiserver | **200** |
| gcr.io | `proxy-gcr` | distroless/static-debian12 | **200** |

All four critical registries serve `200` via `http://212.72.24.20:5000/v2/proxy-*/...` (anonymous; bastion `:5000` is registry/2.0, `/v2/` → `200 {}`).

### Why xpkg/ecr stay on harbor.openova.io
The bastion has **no** `proxy-xpkg` / `proxy-ecr` projects (real-manifest pull → **404**, vs `proxy-gcr` → **200**). Those are Crossplane-provider / ECR images **not** in the Phase-1 bootstrap critical path (Crossplane is idle on kom4dc — infra is 100% OpenTofu), so leaving them on the external-harbor route is harmless and strictly better than routing to a 404.

## Gates
- `tofu fmt` — clean (no diff)
- `tofu validate` — **Success! The configuration is valid.**
- `scripts/lint-cloudinit.sh huawei` — **PASS** (rendered OK, 36 runcmd items dash -n clean)
- `scripts/lint-cloudinit.sh both` — **PASS** (Hetzner unaffected)

## Deployment note — catalyst-api rebuild REQUIRED
This IaC is **baked into the catalyst-api image** (`products/catalyst/bootstrap/api/Containerfile:163` → `COPY infra/providers/ /infra/providers/`; provisioner reads from in-image `/infra/providers/huawei`). CI fires on the `infra/providers/**` path filter. The next prov picks up this fix **only after** the catalyst-api image rebuilds + the mothership rolls to the new SHA. No prov was fired by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)