### PR TITLE
fix(bp-catalyst-platform): bp-chepherd missing required topology.defaults.multi-region (console 404)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1052,7 +1052,9 @@ spec:
       #   Jobs so the Kyverno flux-managed (Enforce) policy admits them in
       #   catalyst-system. Pre-1.4.722 the pre-install hook was DENIED →
       #   console install failed pre-install on every Enforce Sovereign (hw172).
-      version: 1.4.756
+      # 1.4.757 — bp-chepherd Blueprint missing required topology.defaults.multi-region
+      #   aborted the whole catalyst-platform install (console 404, hw182). Fixed.
+      version: 1.4.757
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2931,7 +2931,9 @@ name: bp-catalyst-platform
 #   clusters name an explicit per-provider storageClass so their PVCs never freeze
 #   "" before the default StorageClass lands (hw174: 3 PVCs stuck Pending<empty>).
 #   (renumbered 1.4.747→1.4.749, one above main's deploy-bot 1.4.748, to clear the pin collision.)
-version: 1.4.756
+# 1.4.757 — bp-chepherd Blueprint missing required topology.defaults.multi-region → whole
+#   catalyst-platform install aborted (console 404 on every fresh prov). Add multi-region: singleton.
+version: 1.4.757
 # 1.4.702 — #3819 #3854 #3859 (Refs #3383 #3376): sme→org-services rename TAIL — the
 #   funnel/BSS control-plane templates + values default the namespace to `org-services`
 #   instead of the dead `sme` ns: provisioning-github-token / valkey-cross-ns-secret +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -6516,6 +6516,7 @@ spec:
     supported:
       - singleton
     defaults:
+      multi-region: singleton
       single-region: singleton
     perTopology:
       singleton:


### PR DESCRIPTION
## Bug
`bp-catalyst-platform@1.4.756` ships the `bp-chepherd` seed Blueprint with `topology.defaults` missing the **required** `multi-region` key. The Blueprint CRD requires `[multi-region, single-region]`, so the whole helm install aborts:
```
Blueprint.catalyst.openova.io "bp-chepherd" is invalid: spec.topology.defaults.multi-region: Required value
```
→ catalyst-platform never installs → **console 404 on every fresh prov**. Found live on hw182 (region-a 58/67 HRs, only bp-catalyst-platform False).

## Fix
Add `multi-region: singleton` to bp-chepherd's `topology.defaults` (matches bp-prometheus/bp-cnpg singleton pattern). Chart bumped 1.4.756→1.4.757.

## Follow-up (separate)
chepherd was renamed to **agenity** (github.com/agenity-org/agenity). Renaming the Blueprint `bp-chepherd`→`bp-agenity` + repinning to the agenity chart is a separate PR pending the agenity chart publish.

Refs #4049