### PR TITLE
fix(bootstrap-kit): gate stateful root slots on BOTH per-provider CSIs — kill the Huawei storage-ordering race (hw182)

### DIFF
--- a/clusters/_template/bootstrap-kit/16-cnpg.yaml
+++ b/clusters/_template/bootstrap-kit/16-cnpg.yaml
@@ -53,17 +53,28 @@ spec:
   # CNPG only needs Flux Ready (its own CRDs ship in the same chart;
   # consumers of postgresql.cnpg.io/v1.Cluster gate themselves on bp-cnpg).
   #
-  # #3971 — also gate on bp-hcloud-csi. bp-cnpg is the root of the stateful-
-  # Postgres dependency tree (bp-postgres-shared{,-b,-c}, bp-cnpg-pair, and
-  # transitively harbor/keycloak/gitea via the shared-pg roles), all of which
-  # bind PVCs. k3s now runs `--disable=local-storage` so local-path is
-  # FORBIDDEN and the ONLY default StorageClass is the cloud CSI. Gating here
-  # guarantees the durable default class EXISTS before any cnpg PVC binds, so
-  # nothing hangs Pending. bp-hcloud-csi is Ready on BOTH providers (it
-  # renders empty on Huawei) so this dependsOn never deadlocks.
+  # #3971 / #892 — gate on BOTH per-provider cloud-CSI slots. bp-cnpg is the
+  # root of the stateful-Postgres dependency tree (bp-postgres-shared{,-b,-c},
+  # bp-cnpg-pair, and transitively harbor/keycloak/gitea via the shared-pg
+  # roles), all of which bind PVCs. k3s now runs `--disable=local-storage` so
+  # local-path is FORBIDDEN and the ONLY default StorageClass is the cloud CSI.
+  # Gating here guarantees the durable default class EXISTS before any cnpg PVC
+  # binds, so nothing hangs Pending.
+  #
+  # #892 (root-caused live on hw182): on Hetzner the default class comes from
+  # bp-hcloud-csi (slot 55a); on Huawei it comes from bp-huawei-evs-csi (slot
+  # 55b, the evs-ssd class). bp-hcloud-csi renders EMPTY on Huawei and goes Ready
+  # WITHOUT any default class — so gating on bp-hcloud-csi ALONE did NOT
+  # guarantee a default class on Huawei → cnpg PVCs were minted classless before
+  # evs-ssd landed, "" frozen permanently, Pending 84m+ (gitea/harbor/guacamole-
+  # pg) → console never installed. Listing BOTH CSIs makes the provider-correct
+  # one gate the PVCs while the other is an always-Ready empty no-op (both slots
+  # are active-but-empty on the OTHER provider, so neither dependsOn deadlocks —
+  # see slots 55a + 55b). No per-provider dependsOn templating needed.
   dependsOn:
     - name: bp-flux
     - name: bp-hcloud-csi
+    - name: bp-huawei-evs-csi
   chart:
     spec:
       chart: bp-cnpg

--- a/clusters/_template/bootstrap-kit/55b-bp-huawei-evs-csi.yaml
+++ b/clusters/_template/bootstrap-kit/55b-bp-huawei-evs-csi.yaml
@@ -33,17 +33,35 @@
 # 169.254.169.254/openstack/latest/meta_data.json → uuid + AZ me-east-215a,
 # and evs.me-east-215.kom4dc.nationalcloud.om answers (IAM-token gated).
 #
-# PROVIDER GATING — the inverse of slot 55a
-# =========================================
-# Suspended by DEFAULT (`suspend: ${HUAWEI_HR_SUSPEND:=true}`): a Hetzner
-# Sovereign (HUAWEI_HR_SUSPEND=true) NEVER installs it — the Hetzner Cloud CSI
-# (slot 55a) is its durable default class. The Huawei cloud-init sets
-# HUAWEI_HR_SUSPEND=false, so a Huawei Sovereign installs it for real. This is
-# the SAME gate that drives bp-velero-hcs (slot 34a) + every other HCS-only HR.
-# (Slot 55a uses the OPPOSITE convention — active-but-empty on Huawei — because
-# bp-cnpg/bp-mgmt-vcluster `dependsOn` it; nothing dependsOn THIS slot, so a
-# plain provider-suspend is correct and avoids installing the Hetzner-irrelevant
-# EVS driver on Hetzner.)
+# PROVIDER GATING — active-but-empty on Hetzner (the slot-55a pattern)
+# ====================================================================
+# #892 (Refs #3992 #3971) — this slot is now ACTIVE on BOTH providers (NOT
+# suspended), exactly like slot 55a. The chart `enabled` toggle (EVS_CSI_ENABLED)
+# decides whether it installs the real EVS driver (Huawei substitutes "true") or
+# an EMPTY release that reports Ready immediately (Hetzner substitutes "false" —
+# the chart default). Why this changed from the old `suspend:
+# ${HUAWEI_HR_SUSPEND:=true}`:
+#
+#   The stateful root slots bp-cnpg (16) + bp-mgmt-vcluster (58) now ALSO
+#   `dependsOn: bp-huawei-evs-csi` — on Huawei this is the slot that actually
+#   creates the durable default StorageClass (`evs-ssd`); slot 55a's
+#   bp-hcloud-csi renders EMPTY there and goes Ready WITHOUT any default class,
+#   so depending on slot 55a alone did NOT guarantee a default class exists
+#   before the first CNPG/vCluster PVC binds (the hw182 ordering race — PVCs
+#   minted classless before evs-ssd landed, frozen "" forever → gitea/harbor/
+#   guacamole-pg Pending 84m+ → console never installs).
+#
+#   A `dependsOn` on a SUSPENDED HelmRelease blocks FOREVER — Flux never marks a
+#   suspended HR Ready. So the old `suspend:` shape would deadlock EVERY Hetzner
+#   prov the moment slots 16/58 gate on this HR. Rendering empty (enabled=false)
+#   keeps the HR Ready so the dependsOn is satisfied on Hetzner without the
+#   suspended-HR deadlock — the SAME proven idiom slot 55a uses on Huawei.
+#
+# Both CSI slots are now active-but-empty on the OTHER provider, so the stateful
+# roots can `dependsOn: [bp-hcloud-csi, bp-huawei-evs-csi]` (list BOTH) and the
+# correct one (whichever installs a real default class for this provider) gates
+# the PVCs while the empty one is a Ready no-op. No per-provider dependsOn
+# templating is needed — see slots 16 + 58.
 #
 # WHAT IT INSTALLS (Huawei only)
 # ==============================
@@ -105,9 +123,18 @@ metadata:
   labels:
     catalyst.openova.io/slot: "55b"
 spec:
-  # Default-suspended (Hetzner). The Huawei cloud-init sets
-  # HUAWEI_HR_SUSPEND=false so a Huawei Sovereign installs the EVS CSI for real.
-  suspend: ${HUAWEI_HR_SUSPEND:=true}
+  # #892 — ACTIVE on BOTH providers (NOT suspended). The chart `enabled` toggle
+  # below (EVS_CSI_ENABLED) decides whether this installs the real Huawei EVS CSI
+  # + the evs-ssd default StorageClass (Huawei substitutes "true") or an EMPTY
+  # release that reports Ready immediately (Hetzner substitutes "false" — the
+  # chart default). This MUST stay active on Hetzner now that the stateful root
+  # slots bp-cnpg (16) + bp-mgmt-vcluster (58) `dependsOn: bp-huawei-evs-csi`: a
+  # `dependsOn` on a SUSPENDED HR blocks forever — Flux never marks a suspended
+  # HR Ready — so the old `suspend: ${HUAWEI_HR_SUSPEND}` shape would deadlock
+  # EVERY Hetzner prov. Rendering empty (enabled=false) keeps the HR Ready so the
+  # dependsOn is satisfied on both clouds (mirrors slot 55a's empty render on
+  # Huawei). See the PROVIDER GATING header block.
+  #
   # #4038-followup — gate on bp-reflector so the `ghcr-pull` imagePullSecret has
   # been mirrored into `huawei-evs-csi` BEFORE the private-image CSI pods are
   # created (otherwise they ImagePullBackOff 401 and never self-heal; see the
@@ -162,11 +189,14 @@ spec:
   # StatefulSet pods scheduled → vc-mgmt/rtz/dmz kubeconfig secrets were
   # created → the spine resumed (HR ready 36 → climbing).
   #
-  # Hetzner is unaffected (this slot is HUAWEI_HR_SUSPEND-suspended there).
+  # Hetzner is unaffected: the slot is now ACTIVE there too (#892) but
+  # EVS_CSI_ENABLED=false renders an EMPTY release (Ready immediately, zero EVS
+  # resources) so it only satisfies the slot-16/58 dependsOn — the durable
+  # default class on Hetzner is hcloud-volumes from slot 55a.
   # Override EVS_CSI_ENABLED="false" only for a deliberate no-storage Huawei
   # smoke prov; a real Huawei prov MUST have it true or the Phase-1
   # storage-durability gate fails it (local-path is FORBIDDEN, never a silent
-  # fallback). See #3971.
+  # fallback). See #3971 #892.
   values:
     enabled: ${EVS_CSI_ENABLED:=true}
     defaultStorageClass: ${EVS_CSI_ENABLED:=true}
@@ -191,20 +221,33 @@ spec:
   # Pull the four Huawei creds from the canonical flux-system/cloud-credentials
   # Secret (cloud-init Phase 0) into the chart values. Flux dereferences
   # valuesFrom at apply time so the plaintext never lands in this manifest.
+  #
+  # `optional: true` (#892) — now that this HR is ACTIVE on Hetzner too
+  # (enabled=false empty render, no longer suspended), Flux applies it on
+  # Hetzner — where the cloud-credentials Secret carries `hcloud-token`, NOT the
+  # four `huawei-*` keys. Without optional:true Flux would FAIL to apply the HR
+  # (cannot dereference a missing valuesKey) → the dependsOn from slots 16/58
+  # would never be satisfied → deadlock. optional:true makes Flux SKIP each
+  # absent key on the empty Hetzner render (the same idiom slot 55a uses for the
+  # absent hcloud-token on Huawei); on Huawei all four keys are present.
   valuesFrom:
     - kind: Secret
       name: cloud-credentials
       valuesKey: huawei-ak
       targetPath: huaweiAccessKey
+      optional: true
     - kind: Secret
       name: cloud-credentials
       valuesKey: huawei-sk
       targetPath: huaweiSecretKey
+      optional: true
     - kind: Secret
       name: cloud-credentials
       valuesKey: huawei-project-id
       targetPath: huaweiProjectId
+      optional: true
     - kind: Secret
       name: cloud-credentials
       valuesKey: huawei-region
       targetPath: huaweiRegion
+      optional: true

--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -64,19 +64,28 @@ spec:
   # so we point Flux to install INTO that namespace. The vCluster
   # subchart's StatefulSet + Service + RBAC land here.
   targetNamespace: mgmt
-  # #3971 — also gate on bp-hcloud-csi. bp-mgmt-vcluster is the root of the
-  # other stateful dependency tree (openbao slot 08, keycloak 09, gitea 10,
-  # harbor 19 all `dependsOn: bp-mgmt-vcluster`) and the vCluster StatefulSet
-  # itself binds a PVC. k3s now runs `--disable=local-storage` so local-path
-  # is FORBIDDEN and the ONLY default StorageClass is the cloud CSI. Gating
-  # here guarantees the durable default class EXISTS before the vCluster (and
-  # everything downstream of it) binds a PVC — nothing hangs Pending.
-  # bp-hcloud-csi is Ready on BOTH providers (empty render on Huawei) so this
-  # dependsOn never deadlocks.
+  # #3971 / #892 — gate on BOTH per-provider cloud-CSI slots. bp-mgmt-vcluster
+  # is the root of the other stateful dependency tree (openbao slot 08, keycloak
+  # 09, gitea 10, harbor 19 all `dependsOn: bp-mgmt-vcluster`) and the vCluster
+  # StatefulSet itself binds a PVC. k3s now runs `--disable=local-storage` so
+  # local-path is FORBIDDEN and the ONLY default StorageClass is the cloud CSI.
+  # Gating here guarantees the durable default class EXISTS before the vCluster
+  # (and everything downstream of it) binds a PVC — nothing hangs Pending.
+  #
+  # #892 (root-caused live on hw182): on Hetzner the default class is
+  # bp-hcloud-csi's hcloud-volumes (slot 55a); on Huawei it is bp-huawei-evs-csi's
+  # evs-ssd (slot 55b). bp-hcloud-csi renders EMPTY on Huawei and goes Ready
+  # WITHOUT any default class, so gating on bp-hcloud-csi ALONE did NOT guarantee
+  # a default class on Huawei → the vCluster PVC (and the host-shared CNPG PVCs
+  # downstream) raced ahead of evs-ssd. Listing BOTH CSIs makes the provider-
+  # correct one gate the PVCs while the other is an always-Ready empty no-op
+  # (both slots are active-but-empty on the OTHER provider, so neither dependsOn
+  # deadlocks — see slots 55a + 55b). No per-provider dependsOn templating needed.
   dependsOn:
     - name: bp-cilium
     - name: bp-cert-manager
     - name: bp-hcloud-csi
+    - name: bp-huawei-evs-csi
   chart:
     spec:
       chart: bp-mgmt-vcluster

--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -271,11 +271,16 @@ resources:
   # storage sibling of 55a. Installs the open-source huaweicloud-csi-driver EVS
   # plugin (evs.csi.huaweicloud.com) + the durable `evs-ssd` default
   # StorageClass so Huawei PVCs land on real EVS block volumes, never the
-  # FORBIDDEN k3s local-path. Default-SUSPENDED (HUAWEI_HR_SUSPEND defaults
-  # true) so Hetzner never installs the Hetzner-irrelevant EVS driver; the
-  # Huawei cloud-init flips HUAWEI_HR_SUSPEND=false. Closes the Huawei half of
-  # the #3971 P0 blocker (Huawei provs wedged at ~40/50 HRs with no
-  # StorageClass + every stateful PVC Pending). MUST be registered here or Flux
+  # FORBIDDEN k3s local-path. #892 — ACTIVE on BOTH providers (no longer
+  # HUAWEI_HR_SUSPEND-suspended): the chart `enabled` toggle (EVS_CSI_ENABLED)
+  # installs the real EVS driver on Huawei (true) or an EMPTY/Ready no-op on
+  # Hetzner (false). It MUST stay active on Hetzner because the stateful root
+  # slots bp-cnpg (16) + bp-mgmt-vcluster (58) now `dependsOn` it — a dependsOn
+  # on a SUSPENDED HR deadlocks (mirrors slot 55a's empty render on Huawei).
+  # Closes the Huawei half of the #3971 P0 blocker (Huawei provs wedged at
+  # ~40/50 HRs with no StorageClass + every stateful PVC Pending; #892 closes
+  # the ordering race where the stateful roots gated only on bp-hcloud-csi,
+  # which is Ready-with-no-class on Huawei). MUST be registered here or Flux
   # never creates the HR (the #3191 forgotten-slot wedge class).
   - 55b-bp-huawei-evs-csi.yaml
   # OpenovaFlow observability cohort — slots 56/57. Three-agent split

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -620,6 +620,18 @@ write_files:
             # BOTH providers so the stateful root slots (bp-cnpg / bp-mgmt-
             # vcluster) can `dependsOn` it without deadlocking — see slot 55a.
             HCLOUD_CSI_ENABLED: "true"
+            # #892 — drive bp-huawei-evs-csi's chart `enabled` toggle (slot 55b).
+            # Slot 55b is now ACTIVE on Hetzner too (no longer HUAWEI_HR_SUSPEND-
+            # suspended) because the stateful root slots bp-cnpg/bp-mgmt-vcluster
+            # now `dependsOn` it (a dependsOn on a SUSPENDED HR deadlocks). On
+            # Hetzner EVS_CSI_ENABLED=false renders an EMPTY release (Ready
+            # immediately, zero EVS resources) — the durable default class on
+            # Hetzner is hcloud-volumes from slot 55a; the Hetzner-irrelevant EVS
+            # driver never installs. WITHOUT this explicit "false" the chart
+            # default (${EVS_CSI_ENABLED:=true}) would try to install the EVS
+            # driver on Hetzner. Mirrors HCLOUD_CSI_ENABLED:false on the Huawei
+            # side below.
+            EVS_CSI_ENABLED: "false"
             # #3971 (Refs #3992) — explicit per-provider durable StorageClass
             # name for the host-shared CNPG clusters (gitea-pg / harbor-pg /
             # guacamole-pg, slots 10/19/52). NAMING (not omitting) the class on
@@ -648,8 +660,8 @@ write_files:
             # reports Ready immediately (the dependsOn from the stateful root
             # slots is satisfied without the suspended-HR deadlock). The Hetzner
             # Cloud CSI obviously does NOT run on HCS; Huawei's durable default
-            # StorageClass is the EVS CSI at slot 55b (below), which DOES install
-            # on Huawei (HUAWEI_HR_SUSPEND=false).
+            # StorageClass is the EVS CSI at slot 55b (below), which installs for
+            # real on Huawei (EVS_CSI_ENABLED=true).
             HCLOUD_CSI_ENABLED: "false"
             # #3971 follow-up — bp-huawei-evs-csi (slot 55b) installs the
             # open-source huaweicloud-csi-driver EVS plugin + the evs-ssd default
@@ -992,13 +1004,18 @@ runcmd:
   # node-local disk (no cloud block volume behind it) — any node replacement
   # destroys the PV's data (prod Postgres 3×100Gi, openbao secrets, customer
   # DB), invalidating BCP/DR. With the provisioner gone, the ONLY default
-  # StorageClass is the per-provider cloud CSI (Hetzner: bp-hcloud-csi slot
-  # 55a → csi.hetzner.cloud + hcloud-volumes). The stateful root slots
-  # (bp-cnpg / bp-mgmt-vcluster) `dependsOn: bp-hcloud-csi` so the CSI default
-  # class exists BEFORE any PVC binds — nothing hangs Pending. A belt-and-
-  # braces Kyverno ENFORCE policy (bp-kyverno-policies K23 forbid-local-path-
-  # storage) additionally DENIES any PVC/StorageClass/PV that references
-  # local-path. (founder: "local path never ever ALLOWED".)
+  # StorageClass is the per-provider cloud CSI: Hetzner → bp-hcloud-csi slot
+  # 55a (csi.hetzner.cloud + hcloud-volumes); Huawei → bp-huawei-evs-csi slot
+  # 55b (evs.csi.huaweicloud.com + evs-ssd). The stateful root slots (bp-cnpg /
+  # bp-mgmt-vcluster) `dependsOn: [bp-hcloud-csi, bp-huawei-evs-csi]` — BOTH
+  # CSI slots, so the PROVIDER-CORRECT default class exists BEFORE any PVC
+  # binds and nothing hangs Pending (#892: gating on bp-hcloud-csi alone froze
+  # Huawei PVCs classless because bp-hcloud-csi renders EMPTY/Ready-with-no-class
+  # on Huawei — the durable class there is evs-ssd from slot 55b). Both CSI
+  # slots are active-but-empty on the OTHER provider, so neither dependsOn
+  # deadlocks. A belt-and-braces Kyverno ENFORCE policy (bp-kyverno-policies
+  # K23 forbid-local-path-storage) additionally DENIES any PVC/StorageClass/PV
+  # that references local-path. (founder: "local path never ever ALLOWED".)
   - |
     NODE_EXTERNAL_IP=$(${node_external_ip_cmd})
     [ -n "$${NODE_EXTERNAL_IP}" ] || { echo "[k3s] FATAL: could not determine node external IP" >&2; exit 87; }
@@ -1021,11 +1038,14 @@ runcmd:
   # #3971 — NO StorageClass is provisioned here. k3s ran with
   # `--disable=local-storage` (above) so the ephemeral local-path provisioner
   # is FORBIDDEN — it is never installed. The cluster comes up with ZERO
-  # StorageClasses; the per-provider cloud block-storage CSI (Hetzner:
-  # bp-hcloud-csi slot 55a) installs the durable default `hcloud-volumes` SC
-  # via Flux. The stateful root slots (bp-cnpg / bp-mgmt-vcluster) gate on
-  # `dependsOn: bp-hcloud-csi`, so the default class exists before the first
-  # PVC binds (no Pending-PVC regression). The former `kubectl patch sc
+  # StorageClasses; the per-provider cloud block-storage CSI installs the
+  # durable default SC via Flux (Hetzner: bp-hcloud-csi slot 55a → hcloud-
+  # volumes; Huawei: bp-huawei-evs-csi slot 55b → evs-ssd). The stateful root
+  # slots (bp-cnpg / bp-mgmt-vcluster) gate on
+  # `dependsOn: [bp-hcloud-csi, bp-huawei-evs-csi]` — BOTH CSI slots — so the
+  # PROVIDER-CORRECT default class exists before the first PVC binds (#892: the
+  # earlier single-CSI gate let Huawei PVCs race ahead of evs-ssd and freeze
+  # classless; no Pending-PVC regression now). The former `kubectl patch sc
   # local-path is-default-class=true` block that lived here is DELETED —
   # asserting/defaulting local-path is exactly the anti-pattern #3971 forbids.
 

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -628,7 +628,7 @@ write_files:
             # immediately, zero EVS resources) — the durable default class on
             # Hetzner is hcloud-volumes from slot 55a; the Hetzner-irrelevant EVS
             # driver never installs. WITHOUT this explicit "false" the chart
-            # default (${EVS_CSI_ENABLED:=true}) would try to install the EVS
+            # default ($${EVS_CSI_ENABLED:=true}) would try to install the EVS
             # driver on Hetzner. Mirrors HCLOUD_CSI_ENABLED:false on the Huawei
             # side below.
             EVS_CSI_ENABLED: "false"

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -254,11 +254,16 @@ slots:
     wave: W2.K1
   - slot: 16
     name: bp-cnpg
-    # #3971 — bp-hcloud-csi gates the durable default StorageClass that EVERY
-    # cnpg PVC (and its shared-pg / cnpg-pair / harbor / keycloak / gitea
-    # downstream) needs now that k3s runs --disable=local-storage (local-path
-    # FORBIDDEN). bp-hcloud-csi is Ready on both providers (empty on Huawei).
-    depends_on: [bp-flux, bp-hcloud-csi]
+    # #3971 / #892 — gate on BOTH per-provider cloud-CSI slots so the durable
+    # default StorageClass EVERY cnpg PVC (shared-pg / cnpg-pair / harbor /
+    # keycloak / gitea downstream) needs EXISTS before any PVC binds now that
+    # k3s runs --disable=local-storage (local-path FORBIDDEN). On Hetzner the
+    # default class is bp-hcloud-csi's hcloud-volumes; on Huawei it is
+    # bp-huawei-evs-csi's evs-ssd. bp-hcloud-csi renders EMPTY on Huawei (Ready
+    # with NO class), so gating on it ALONE froze Huawei PVCs classless before
+    # evs-ssd landed (hw182). Both CSI slots are active-but-empty on the OTHER
+    # provider so neither dependsOn deadlocks.
+    depends_on: [bp-flux, bp-hcloud-csi, bp-huawei-evs-csi]
     wave: W2.K1
   - slot: 16a
     name: bp-postgres-shared
@@ -742,11 +747,17 @@ slots:
     depends_on:
       - bp-cilium
       - bp-cert-manager
-      # #3971 — bp-hcloud-csi gates the durable default StorageClass the
-      # vCluster StatefulSet PVC (and openbao/keycloak/gitea/harbor downstream
-      # of bp-mgmt-vcluster) need now that local-path is FORBIDDEN
-      # (--disable=local-storage). Ready on both providers (empty on Huawei).
+      # #3971 / #892 — gate on BOTH per-provider cloud-CSI slots so the durable
+      # default StorageClass the vCluster StatefulSet PVC (and openbao/keycloak/
+      # gitea/harbor downstream of bp-mgmt-vcluster) needs EXISTS before any PVC
+      # binds now that local-path is FORBIDDEN (--disable=local-storage). On
+      # Hetzner the class is bp-hcloud-csi's hcloud-volumes; on Huawei it is
+      # bp-huawei-evs-csi's evs-ssd. bp-hcloud-csi renders EMPTY on Huawei (Ready
+      # with NO class), so gating on it ALONE raced the vCluster PVC ahead of
+      # evs-ssd (hw182). Both CSI slots are active-but-empty on the OTHER
+      # provider so neither dependsOn deadlocks.
       - bp-hcloud-csi
+      - bp-huawei-evs-csi
     wave: present
 
   # ---- Slot 59 — bp-rtz-vcluster (DoD A4 — secondary-only RTZ vCluster).


### PR DESCRIPTION
## The bug (confirmed live on hw182, a Huawei/kom4dc Sovereign)

Host-shared CNPG clusters `gitea-pg` (ns gitea), `harbor-pg` (ns harbor), `guacamole-pg` (ns catalyst-system) wedged 84m+: their PVCs froze `Pending` with `pod has unbound immediate PersistentVolumeClaims`. A PVC created **before any default StorageClass exists** gets `storageClassName: ""` frozen in permanently (immutable) → gitea/harbor never start → the `catalyst-catalog-sovereign-repo-bootstrap` hook hangs → **the console never installs.**

## Precise root cause — the dependsOn named the wrong CSI on Huawei

The stateful root slots **bp-cnpg (16)** + **bp-mgmt-vcluster (58)** gated on `dependsOn: bp-hcloud-csi` to guarantee a durable default class exists before their PVCs bind. But `bp-hcloud-csi` is the **Hetzner** CSI. On Huawei it renders **EMPTY** and goes `Ready` **without creating any default StorageClass**. The real Huawei default class (`evs-ssd`) comes from **bp-huawei-evs-csi (slot 55b)**, which was **not** in the dependsOn — so on Huawei the stateful PVCs raced ahead of `evs-ssd`, were minted classless, and froze. The Hetzner path worked because there it correctly waits for the class-producing CSI.

## The fix (provider-symmetric — list BOTH, no per-provider templating)

Flux does **not** tolerate a dependsOn on a **suspended** HR (it never goes Ready → deadlock). Slot 55b was `suspend: ${HUAWEI_HR_SUSPEND:=true}` (suspended on Hetzner), so naively listing it would have deadlocked every Hetzner prov. So slot 55b is now **active-but-empty on Hetzner**, exactly mirroring how slot 55a is active-but-empty on Huawei:

- **slots 16 + 58** → `dependsOn: [bp-hcloud-csi, bp-huawei-evs-csi]`. The provider-correct CSI gates the PVCs; the other is an always-Ready empty no-op. No per-provider dependsOn templating needed.
- **slot 55b** → drop `suspend`; gate purely on the chart `enabled` toggle (`EVS_CSI_ENABLED`, already wired). On Hetzner `EVS_CSI_ENABLED=false` → 0 resources → Ready immediately. `valuesFrom` gains `optional: true` ×4 so the absent `huawei-*` keys in the Hetzner `cloud-credentials` Secret don't fail apply (same idiom as slot 55a's optional `hcloud-token` on Huawei).
- **cloud-init** → add explicit `EVS_CSI_ENABLED="false"` to the Hetzner substitute block (chart default is `true`), so the EVS driver never installs on Hetzner. Fixed the misleading comments (near line 1026) that claimed the stateful slots gate on `bp-hcloud-csi`.
- **scripts/expected-bootstrap-deps.yaml** → declare the new `bp-huawei-evs-csi` edge on slots 16 + 58 (the `check-bootstrap-deps` drift gate).

## Why slot 55b correctly creates the default class (task item 3)

`helm template ... --set enabled=true --set defaultStorageClass=true` renders the `evs-ssd` StorageClass with `storageclass.kubernetes.io/is-default-class: "true"`, the `evs.csi.huaweicloud.com` CSIDriver, the controller Deployment + node DaemonSet, **and** the post-install default-class flip Job — so `evs-ssd` is the cluster's one default class. Slot 55b already gates on `bp-reflector` so its private driver image's `ghcr-pull` secret is mirrored before the pods are created (#4037/#4038).

## No chart touched → no version/pin bump

This is entirely bootstrap-kit slot files + cloud-init + the audit data. No `Chart.yaml` changed, so the pin-sync / GHCR-tag gates are clean no-ops (the `bp-huawei-evs-csi` chart's `enabled: false` master gate already renders the empty path).

## Validation

- `scripts/check-bootstrap-deps.sh` → **PASS** (drift 0, cycles 0); the rendered DAG shows slots 16 + 58 gated on `bp-hcloud-csi bp-huawei-evs-csi`.
- `scripts/check-bootstrap-kit-pin-sync.sh --changed-only --base origin/main` → no Chart.yaml changed, no-op.
- `scripts/check-cloudinit-kustomization-deps.sh` → **PASS**.
- `helm template` bp-huawei-evs-csi both paths: `enabled=false` → **0 resources** (clean Hetzner empty render); `enabled=true` → `evs-ssd` default SC + CSIDriver + flip Job, no `VolumeSnapshotClass` leak (#4030 trap respected).
- G36 `tofu test` (cloud-init `templatefile()` render gate) — re-run on this branch; the `%{ if provider }`/`endif` blocks stay balanced and the new substitute key sits inside the existing Hetzner block.

## Remaining ordering risk

None at the dependsOn level. Comment-only references to "bp-hcloud-csi" as the example CSI remain in `platform/seaweedfs` + `platform/kyverno-policies` chart prose; they are descriptive (not runtime dependsOn) and were intentionally **not** edited to avoid forcing chart version bumps + pin churn. They remain accurate for Hetzner and merely incomplete for Huawei.

Refs #892 Refs #895

🤖 Generated with [Claude Code](https://claude.com/claude-code)