### PR TITLE
fix(bp-cilium): poison-proof console gateway isolation — dedicated cilium-gateway-console (Refs #4053)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1054,7 +1054,10 @@ spec:
       #   console install failed pre-install on every Enforce Sovereign (hw172).
       # 1.4.757 — bp-chepherd Blueprint missing required topology.defaults.multi-region
       #   aborted the whole catalyst-platform install (console 404, hw182). Fixed.
-      version: 1.4.759
+      # 1.4.760 (#4053) — poison-proof console gateway isolation: the console re-parents
+      #   onto a dedicated cilium-gateway-console (own CEC, stable backends only) so an
+      #   app-backend poison on the shared cilium-gateway can never 404 the console.
+      version: 1.4.760
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/sovereign-tls/cilium-gateway-console.yaml
+++ b/clusters/_template/sovereign-tls/cilium-gateway-console.yaml
@@ -1,0 +1,84 @@
+# #4053 — Dedicated CONSOLE Cilium Gateway (poison-proof blast-radius isolation)
+# ─────────────────────────────────────────────────────────────────────────────
+# Cilium Gateway API compiles ALL of a Gateway's HTTPRoutes + backends into ONE
+# CiliumEnvoyConfig (`cilium-gateway-<name>`), committed ATOMICALLY by
+# cilium-agent. If ANY single backend Service referenced by ANY HTTPRoute on the
+# gateway is unresolvable (a half-converged app, a vanished vcluster-bridge
+# Service, an empty EndpointSlice), getK8sService returns "retrieved nil
+# details" → the ENTIRE CEC upsert fails → cilium-envoy gets 0 listeners → the
+# whole gateway 404s. This is the unfixed upstream bug cilium#35728 /
+# cilium#34982 — no config flag and no fix on the pinned Cilium 1.16.5
+# (platform/cilium/chart/Chart.lock). Confirmed live on hw182 (newapi install
+# #3831's bridge Service poisoned the shared gateway and took down the console).
+#
+# Fix: because the CEC is ONE-PER-GATEWAY, this dedicated console Gateway
+# carries ONLY the catalyst-ui + catalyst-api HTTPRoutes (re-parented here by
+# bp-catalyst-platform's templates/httproute.yaml via
+# ingress.gateway.parentRef.name=cilium-gateway-console). Those backends are
+# stable ClusterIP Services that ALWAYS resolve, so this gateway's CEC is
+# structurally immune to the app-backend poisoning that can zero the shared
+# `cilium-gateway`. A broken volatile app can now only 404 ITS gateway — the
+# console stays up.
+#
+# Why moved out of the chart / into the Kustomize sovereign-tls tier: identical
+# rationale to clusters/_template/sovereign-tls/cilium-gateway.yaml — the
+# gateway.networking.k8s.io CRDs are installed by the Cilium HelmRelease, so
+# Flux dry-runs the whole Kustomization before any HR applies; placing the
+# Gateway in the chart would invert ordering and open a transient
+# "no Gateway → no envoy listener → console unreachable" window on every Helm
+# upgrade. The sovereign-tls Kustomization dependsOn bootstrap-kit Ready.
+#
+# Host ports 31443 / 31080 (NOT 30443 / 30080): the shared gateway already binds
+# 30443 / 30080 in hostNetwork mode. Each Gateway's listeners bind distinct host
+# ports so both coexist on the same node set without a bind() collision. A
+# DEDICATED cloud LoadBalancer (infra/providers/{hetzner,huawei}/main.tf —
+# `console` LB) forwards public 443 → node:31443 and 80 → node:31080. The
+# console A-records (console./api.<fqdn>) point at THAT LB IP, while the wildcard
+# `*.<fqdn>` keeps pointing at the shared gateway's LB (DNS split owned by
+# core/pool-domain-manager — see its consoleLoadBalancerIP plumbing).
+#
+# Listeners: rendered by bp-catalyst-platform's templates/sovereign-tls-vars-cm.
+# yaml into ConfigMap flux-system/sovereign-tls-vars key CONSOLE_LISTENERS_YAML
+# and inlined here by Flux postBuild.substituteFrom — same scalar-placeholder
+# pattern as the shared gateway (see cilium-gateway.yaml header for why a scalar
+# `listeners: ${VAR}` parses cleanly through kustomize-build before envsubst).
+# The console listener pair is hostnamed `*.${SOVEREIGN_FQDN}` and binds the
+# per-prov wildcard Secret `sovereign-wildcard-tls-${SOVEREIGN_FQDN_DASHED}` —
+# the SAME cert the shared gateway uses for the apex wildcard, so no extra
+# Let's-Encrypt issuance and no extra cert resource is required.
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: cilium-gateway-console
+  namespace: kube-system
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+    catalyst.openova.io/component: cilium-gateway-console
+spec:
+  gatewayClassName: cilium
+  # Hetzner LB annotations for the console gateway's auto-created Service.
+  # Cilium 1.16+ forwards spec.infrastructure.annotations onto the
+  # `cilium-gateway-cilium-gateway-console` Service, where hcloud-CCM
+  # (bp-hcloud-ccm) provisions a Hetzner LB. health-check pinned to the console
+  # gateway's HTTPS host port (31443). Capped at 8 entries (CRD maxProperties) —
+  # same set as the shared gateway minus the timing knobs (TBD-A36 #1896). The
+  # tofu-provisioned console LB (infra/providers/hetzner/main.tf) is the primary
+  # public path; this Service-level LB is the cluster-side mirror so operators
+  # inspecting `kubectl get svc -n kube-system` see a LoadBalancer, not a
+  # bare ClusterIP (the t28 A98 confusion — see cilium-gateway.yaml header).
+  infrastructure:
+    annotations:
+      load-balancer.hetzner.cloud/name: "${SOVEREIGN_FQDN_SLUG:=catalyst}-${SOVEREIGN_REGION_KEY:=primary}-console-gateway"
+      load-balancer.hetzner.cloud/location: "${HCLOUD_LB_LOCATION}"
+      load-balancer.hetzner.cloud/type: "lb11"
+      load-balancer.hetzner.cloud/use-private-ip: "false"
+      load-balancer.hetzner.cloud/disable-private-ingress: "true"
+      load-balancer.hetzner.cloud/health-check-protocol: "tcp"
+      load-balancer.hetzner.cloud/health-check-port: "31443"
+      load-balancer.hetzner.cloud/health-check-retries: "3"
+  # ports 31443/31080 (not 443/80, not 30443/30080) — see header. cilium-envoy
+  # binds high host ports because cilium-agent's BPF socket-LB blocks privileged
+  # binds; the console LB does the public 443→31443 / 80→31080 translation, so
+  # browsers still hit `https://console.<fqdn>/`.
+  listeners: ${CONSOLE_LISTENERS_YAML}

--- a/clusters/_template/sovereign-tls/kustomization.yaml
+++ b/clusters/_template/sovereign-tls/kustomization.yaml
@@ -3,6 +3,13 @@ kind: Kustomization
 resources:
   - cilium-gateway-cert.yaml
   - cilium-gateway.yaml
+  # #4053 — dedicated CONSOLE gateway (poison-proof blast-radius isolation).
+  # Reuses the same per-prov wildcard Secret as cilium-gateway-cert.yaml above
+  # (no extra Certificate). Carries ONLY the catalyst-ui + catalyst-api routes
+  # so a broken app-backend on the SHARED cilium-gateway can never 404 the
+  # console. Listeners inlined from ConfigMap key CONSOLE_LISTENERS_YAML via the
+  # same Flux postBuild.substituteFrom that feeds the shared gateway.
+  - cilium-gateway-console.yaml
   # powerdns-api-credentials Secret (#3888 / Refs #3847) — the DNS-01 API key
   # the bp-cert-manager-powerdns-webhook solver reads to issue the wildcard
   # cert above. Evicted OUT of cloud-init into this Flux-reconciled tier so it

--- a/core/pool-domain-manager/api/openapi.yaml
+++ b/core/pool-domain-manager/api/openapi.yaml
@@ -127,6 +127,12 @@ paths:
                 reservationToken: { type: string, format: uuid }
                 sovereignFQDN: { type: string }
                 loadBalancerIP: { type: string, format: ipv4 }
+                # #4053 — optional. When set, the console + api A-records point
+                # at the dedicated console LB (the isolated cilium-gateway-console)
+                # instead of loadBalancerIP, so a poisoned shared-gateway CEC can
+                # never 404 the console. Omitted = every record points at
+                # loadBalancerIP (legacy single-LB behaviour).
+                consoleLoadBalancerIP: { type: string, format: ipv4 }
       responses:
         '200': { description: Committed }
         '202': { description: Committed in DB; Dynadot retry needed }

--- a/core/pool-domain-manager/internal/allocator/allocator.go
+++ b/core/pool-domain-manager/internal/allocator/allocator.go
@@ -289,6 +289,14 @@ type CommitInput struct {
 	ReservationToken string
 	SovereignFQDN    string
 	LoadBalancerIP   string
+	// ConsoleLoadBalancerIP — #4053. When non-empty, the `console` and `api`
+	// A-records point HERE (the dedicated console LB → cilium-gateway-console)
+	// instead of at LoadBalancerIP. This isolates the Sovereign console onto
+	// its own Cilium Gateway / CiliumEnvoyConfig so a poisoned shared-gateway
+	// CEC (one unresolvable app backend, cilium#35728) can never 404 the
+	// console. Empty = pre-#4053 behaviour: every record points at
+	// LoadBalancerIP (byte-identical to the legacy single-LB record set).
+	ConsoleLoadBalancerIP string
 }
 
 // Commit flips a reservation to ACTIVE and writes the canonical 6-record set
@@ -319,7 +327,7 @@ func (a *Allocator) Commit(ctx context.Context, poolDomain, subdomain string, in
 	}
 
 	childZone := childZoneName(poolDomain, subdomain)
-	rrsets := canonicalRecordSet(childZone, in.LoadBalancerIP)
+	rrsets := canonicalRecordSet(childZone, in.LoadBalancerIP, in.ConsoleLoadBalancerIP)
 
 	if err := a.dns.PatchRRSets(ctx, childZone, rrsets); err != nil {
 		a.log.Error("PowerDNS write canonical record set failed",
@@ -515,34 +523,59 @@ func childZoneName(poolDomain, subdomain string) string {
 	return strings.ToLower(strings.TrimSpace(subdomain)) + "." + strings.ToLower(strings.TrimSpace(poolDomain))
 }
 
-// canonicalRecordSet returns the 6-RRset payload PowerDNS PATCH expects to
+// canonicalRecordSet returns the 7-RRset payload PowerDNS PATCH expects to
 // publish a fresh Sovereign:
 //
-//	@        A   <lb>   (apex of the child zone)
-//	*        A   <lb>   (wildcard for ad-hoc subdomains)
-//	console  A   <lb>
-//	api      A   <lb>
-//	gitea    A   <lb>
-//	harbor   A   <lb>
+//	@            A   <lb>          (apex of the child zone)
+//	*            A   <lb>          (wildcard for ad-hoc subdomains)
+//	console      A   <consoleLB>   (#4053 — isolated console gateway)
+//	api          A   <consoleLB>   (#4053 — isolated console gateway)
+//	gitea        A   <lb>
+//	harbor       A   <lb>
+//	marketplace  A   <lb>
+//
+// #4053 — the `console` and `api` names point at consoleLBIP (the dedicated
+// console LB → cilium-gateway-console) so a poisoned SHARED-gateway CEC can
+// never 404 the console. When consoleLBIP is empty (a provisioner or a
+// deployment record that pre-dates #4053), it falls back to lbIP for those two
+// names too — making the record set byte-identical to the legacy single-LB
+// payload. Every other name (apex, wildcard, gitea, harbor, marketplace) always
+// points at lbIP (the shared gateway) regardless.
 //
 // Per docs/PLATFORM-POWERDNS.md these names mirror the canonical-record
 // contract and use TTL 300 for fast failover.
-func canonicalRecordSet(childZone, lbIP string) []pdns.RRSet {
-	prefixes := []string{"", "*", "console", "api", "gitea", "harbor", "marketplace"}
+func canonicalRecordSet(childZone, lbIP, consoleLBIP string) []pdns.RRSet {
+	if consoleLBIP == "" {
+		consoleLBIP = lbIP
+	}
+	// Per-prefix target: the two console-control-plane names ride the console
+	// LB; everything else rides the shared LB.
+	prefixes := []struct {
+		name string
+		ip   string
+	}{
+		{"", lbIP},
+		{"*", lbIP},
+		{"console", consoleLBIP},
+		{"api", consoleLBIP},
+		{"gitea", lbIP},
+		{"harbor", lbIP},
+		{"marketplace", lbIP},
+	}
 	rrsets := make([]pdns.RRSet, 0, len(prefixes))
 	for _, p := range prefixes {
 		var name string
-		if p == "" {
+		if p.name == "" {
 			name = childZone
 		} else {
-			name = p + "." + childZone
+			name = p.name + "." + childZone
 		}
 		rrsets = append(rrsets, pdns.RRSet{
 			Name:       name,
 			Type:       "A",
 			TTL:        pdns.DefaultChildRecordTTL,
 			ChangeType: "REPLACE",
-			Records:    []pdns.Record{{Content: lbIP}},
+			Records:    []pdns.Record{{Content: p.ip}},
 		})
 	}
 	return rrsets

--- a/core/pool-domain-manager/internal/allocator/allocator_test.go
+++ b/core/pool-domain-manager/internal/allocator/allocator_test.go
@@ -155,7 +155,9 @@ func TestChildZoneName(t *testing.T) {
 }
 
 func TestCanonicalRecordSet(t *testing.T) {
-	rrsets := canonicalRecordSet("acme.openova.io", "1.2.3.4")
+	// #4053 — empty consoleLBIP = legacy single-LB behaviour: EVERY record
+	// (incl. console/api) points at lbIP, byte-identical to pre-#4053.
+	rrsets := canonicalRecordSet("acme.openova.io", "1.2.3.4", "")
 	if len(rrsets) != 7 {
 		t.Fatalf("expected 7 RRsets, got %d", len(rrsets))
 	}
@@ -190,6 +192,39 @@ func TestCanonicalRecordSet(t *testing.T) {
 	for name, seen := range wantNames {
 		if !seen {
 			t.Errorf("missing RRset for %q", name)
+		}
+	}
+}
+
+// TestCanonicalRecordSetConsoleSplit — #4053. When a console LB IP is supplied,
+// ONLY console + api ride it; every other name keeps the shared LB IP. This is
+// the DNS half of the poison-proof gateway isolation: console./api.<fqdn> reach
+// the dedicated cilium-gateway-console while *.<fqdn> (every volatile app) keeps
+// reaching the shared cilium-gateway.
+func TestCanonicalRecordSetConsoleSplit(t *testing.T) {
+	const sharedIP = "1.2.3.4"
+	const consoleIP = "9.9.9.9"
+	rrsets := canonicalRecordSet("acme.openova.io", sharedIP, consoleIP)
+	if len(rrsets) != 7 {
+		t.Fatalf("expected 7 RRsets, got %d", len(rrsets))
+	}
+	wantIP := map[string]string{
+		"acme.openova.io":             sharedIP,
+		"*.acme.openova.io":           sharedIP,
+		"console.acme.openova.io":     consoleIP,
+		"api.acme.openova.io":         consoleIP,
+		"gitea.acme.openova.io":       sharedIP,
+		"harbor.acme.openova.io":      sharedIP,
+		"marketplace.acme.openova.io": sharedIP,
+	}
+	for _, r := range rrsets {
+		want, ok := wantIP[r.Name]
+		if !ok {
+			t.Errorf("unexpected RRset name %q", r.Name)
+			continue
+		}
+		if len(r.Records) != 1 || r.Records[0].Content != want {
+			t.Errorf("%s → %v, want %s", r.Name, r.Records, want)
 		}
 	}
 }
@@ -246,7 +281,7 @@ func TestCommitDNSShape(t *testing.T) {
 	dns := newFakeDNS()
 	dns.zones["omantel.omani.works"] = []string{"ns1.openova.io.", "ns2.openova.io."}
 
-	rrsets := canonicalRecordSet("omantel.omani.works", "10.20.30.40")
+	rrsets := canonicalRecordSet("omantel.omani.works", "10.20.30.40", "")
 	if err := dns.PatchRRSets(context.Background(), "omantel.omani.works", rrsets); err != nil {
 		t.Fatal(err)
 	}

--- a/core/pool-domain-manager/internal/handler/handler.go
+++ b/core/pool-domain-manager/internal/handler/handler.go
@@ -220,6 +220,12 @@ type CommitRequest struct {
 	ReservationToken string `json:"reservationToken"`
 	SovereignFQDN    string `json:"sovereignFQDN"`
 	LoadBalancerIP   string `json:"loadBalancerIP"`
+	// ConsoleLoadBalancerIP — #4053. Optional. When supplied, the `console`
+	// and `api` A-records point at this dedicated console-LB IP (the isolated
+	// cilium-gateway-console front door) instead of LoadBalancerIP, so a
+	// poisoned shared-gateway CEC can never 404 the console. Omitted = every
+	// record points at LoadBalancerIP (legacy single-LB behaviour).
+	ConsoleLoadBalancerIP string `json:"consoleLoadBalancerIP,omitempty"`
 }
 
 // Commit promotes a reservation to active and writes Dynadot records.
@@ -258,9 +264,10 @@ func (h *Handler) Commit(w http.ResponseWriter, r *http.Request) {
 	}
 
 	alloc, err := h.Alloc.Commit(r.Context(), domain, sub, allocator.CommitInput{
-		ReservationToken: req.ReservationToken,
-		SovereignFQDN:    req.SovereignFQDN,
-		LoadBalancerIP:   req.LoadBalancerIP,
+		ReservationToken:      req.ReservationToken,
+		SovereignFQDN:         req.SovereignFQDN,
+		LoadBalancerIP:        req.LoadBalancerIP,
+		ConsoleLoadBalancerIP: req.ConsoleLoadBalancerIP, // #4053 — empty-safe (falls back to LoadBalancerIP)
 	})
 	if err != nil {
 		// Allocator returns a wrapped "powerdns write" error AFTER the row

--- a/infra/providers/hetzner/main.tf
+++ b/infra/providers/hetzner/main.tf
@@ -1135,6 +1135,99 @@ resource "hcloud_load_balancer_service" "dns" {
   }
 }
 
+# ── #4053 — Dedicated CONSOLE load balancer (poison-proof gateway isolation) ──
+#
+# Cilium Gateway API compiles every HTTPRoute + backend of a Gateway into ONE
+# CiliumEnvoyConfig committed atomically; a single unresolvable app backend
+# fails the whole CEC and 404s the entire gateway (cilium#35728, unfixed on the
+# pinned 1.16.5). The console is therefore isolated onto its OWN Cilium Gateway
+# (`cilium-gateway-console`, host ports 31443/31080 — see
+# clusters/_template/sovereign-tls/cilium-gateway-console.yaml), carrying ONLY
+# the stable catalyst-ui + catalyst-api backends.
+#
+# Both `hcloud_load_balancer` (lb11) and the Huawei ELB do TCP PASSTHROUGH on
+# 443 (TLS terminates at cilium-envoy, NOT the LB), so neither can route by SNI
+# / Host header — a single LB IP + single public 443 can reach exactly ONE host
+# port, hence ONE gateway. Isolating the console onto a second gateway on a
+# second host port therefore requires a SECOND public LB IP. The console
+# A-records (console./api.<fqdn>) point at THIS LB → node:31443; the wildcard
+# `*.<fqdn>` (every volatile app/tenant host) keeps pointing at the shared
+# `hcloud_load_balancer.main` → node:30443. DNS split is owned by
+# core/pool-domain-manager (consoleLoadBalancerIP) + the catalyst-api handover.
+#
+# This is the only design that (a) keeps the console always reachable on the
+# canonical https://console.<fqdn>/ :443 URL, (b) is byte-identical across
+# Hetzner + Huawei (both just do dumb TCP 443→port), and (c) needs no Cilium
+# upgrade — the pinned 1.16.5 does NOT reconcile a TLSRoute-passthrough SNI
+# front gateway (TLSRoute is a startup CRD presence-check only on 1.16.x), which
+# rules out the single-IP front-gateway alternative.
+resource "hcloud_load_balancer" "console" {
+  name               = "catalyst-${replace(var.sovereign_fqdn, ".", "-")}-console-lb"
+  load_balancer_type = "lb11"
+  location           = var.region
+  algorithm {
+    type = "round_robin"
+  }
+  labels = {
+    "catalyst.openova.io/sovereign" = var.sovereign_fqdn
+    "catalyst.openova.io/role"      = "console"
+  }
+}
+
+resource "hcloud_load_balancer_network" "console" {
+  load_balancer_id = hcloud_load_balancer.console.id
+  network_id       = hcloud_network.region["primary"].id
+  # .253 — one below the shared LB's .254 anchor (see hcloud_load_balancer_
+  # network.main). Pins the console LB's private IP so it cannot race the CP /
+  # shared-LB allocations during parallel apply.
+  ip = "10.0.1.253"
+
+  depends_on = [hcloud_network_subnet.region]
+}
+
+# Console LB targets — same node set as the shared LB. cilium-envoy runs as a
+# DaemonSet on every node and binds BOTH 30443 (shared) and 31443 (console), so
+# every node is a valid target for the console LB too.
+resource "hcloud_load_balancer_target" "console_control_plane" {
+  count            = local.control_plane_count
+  type             = "server"
+  load_balancer_id = hcloud_load_balancer.console.id
+  server_id        = hcloud_server.control_plane[count.index].id
+  use_private_ip   = true
+
+  depends_on = [hcloud_load_balancer_network.console]
+}
+
+resource "hcloud_load_balancer_target" "console_workers" {
+  count            = var.worker_count
+  type             = "server"
+  load_balancer_id = hcloud_load_balancer.console.id
+  server_id        = hcloud_server.worker[count.index].id
+  use_private_ip   = true
+
+  depends_on = [
+    hcloud_load_balancer_network.console,
+    hcloud_server.worker,
+  ]
+}
+
+resource "hcloud_load_balancer_service" "console_http" {
+  load_balancer_id = hcloud_load_balancer.console.id
+  protocol         = "tcp"
+  listen_port      = 80
+  # 31080 — the console gateway's HTTP host-port (cilium-gateway-console.yaml).
+  destination_port = 31080
+}
+
+resource "hcloud_load_balancer_service" "console_https" {
+  load_balancer_id = hcloud_load_balancer.console.id
+  protocol         = "tcp"
+  listen_port      = 443
+  # 31443 — the console gateway's HTTPS host-port. TLS terminates at the
+  # console gateway's cilium-envoy (per-prov wildcard cert), NOT here.
+  destination_port = 31443
+}
+
 # ── DNS: deliberately NOT a tofu concern ──────────────────────────────────
 #
 # Per the PDM (pool-domain-manager) ownership boundary set at #168, ALL

--- a/infra/providers/hetzner/outputs.tf
+++ b/infra/providers/hetzner/outputs.tf
@@ -7,8 +7,21 @@ output "control_plane_ip" {
 }
 
 output "load_balancer_ip" {
-  description = "Public IPv4 of the Hetzner load balancer (the address DNS A records point at)"
+  description = "Public IPv4 of the Hetzner load balancer (the address the wildcard + app DNS A records point at)"
   value       = hcloud_load_balancer.main.ipv4
+}
+
+# #4053 — public IPv4 of the dedicated CONSOLE load balancer. The
+# console./api.<fqdn> A-records point HERE (forwards 443→node:31443 to the
+# isolated cilium-gateway-console), while the wildcard *.<fqdn> keeps pointing
+# at load_balancer_ip above (the shared cilium-gateway). catalyst-api reads this
+# and threads it to pool-domain-manager /commit as consoleLoadBalancerIP so a
+# poisoned shared-gateway CEC can never 404 the console. Empty-safe: a consumer
+# that pre-dates #4053 ignores this output and PDM falls back to
+# load_balancer_ip for every record (byte-identical to pre-#4053 behaviour).
+output "console_load_balancer_ip" {
+  description = "Public IPv4 of the dedicated console load balancer (console./api.<fqdn> point here; #4053 gateway isolation)"
+  value       = hcloud_load_balancer.console.ipv4
 }
 
 output "sovereign_fqdn" {

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -1352,3 +1352,128 @@ resource "huaweicloud_elb_monitor" "http" {
   timeout     = 5
   max_retries = 3
 }
+
+# ── #4053 — Dedicated CONSOLE ELB (poison-proof gateway isolation) ───────────
+#
+# Cilium Gateway API compiles every HTTPRoute + backend of a Gateway into ONE
+# CiliumEnvoyConfig committed atomically; one unresolvable app backend fails the
+# whole CEC and 404s the entire gateway (cilium#35728, unfixed on pinned 1.16.5;
+# hit live on hw182). The console is isolated onto its OWN Cilium Gateway
+# (`cilium-gateway-console`, host ports 31443/31080 —
+# clusters/_template/sovereign-tls/cilium-gateway-console.yaml) with stable
+# backends only.
+#
+# This ELB does the SAME TCP-passthrough trick as the primary ELB above but
+# targets the console gateway's host ports (31443/31080). Because the ELB TCP
+# listener is dumb L4 passthrough (no SNI — Huawei SNI requires terminating TLS
+# at the ELB, which would break the in-cluster per-prov cert model), the console
+# needs its OWN public EIP: console./api.<fqdn> A-records point at THIS ELB's
+# EIP, the wildcard *.<fqdn> keeps pointing at elb_primary. DNS split is owned by
+# core/pool-domain-manager (consoleLoadBalancerIP) + the catalyst-api handover.
+# Byte-identical design to the Hetzner console LB (infra/providers/hetzner).
+
+resource "huaweicloud_vpc_eip" "elb_console" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    share_type  = "PER"
+    name        = "${local.name_prefix}-elb-console-bw"
+    size        = 300
+    charge_mode = "traffic"
+  }
+}
+
+resource "huaweicloud_elb_loadbalancer" "console" {
+  name              = "${local.name_prefix}-elb-console"
+  vpc_id            = huaweicloud_vpc.region[local.region_keys[0]].id
+  ipv4_subnet_id    = huaweicloud_vpc_subnet.region[local.region_keys[0]].ipv4_subnet_id
+  ipv4_eip_id       = huaweicloud_vpc_eip.elb_console.id
+  availability_zone = [var.huawei_az]
+  description       = "Catalyst Sovereign ${var.sovereign_fqdn} — #4053 dedicated CONSOLE gateway 443→31443 + 80→31080 routing"
+
+  # Same immutable-field churn guards as elb_primary (see its lifecycle block):
+  # the provider sends null/empty for these on subsequent plans and HCS rejects
+  # the PUT. They are auto-pinned at create; ignore them.
+  lifecycle {
+    ignore_changes = [
+      l4_flavor_id,
+      l7_flavor_id,
+      vpc_id,
+      ipv4_eip_id,
+    ]
+  }
+}
+
+resource "huaweicloud_elb_pool" "console_https" {
+  name            = "${local.name_prefix}-elb-pool-console-https"
+  protocol        = "TCP"
+  lb_method       = "ROUND_ROBIN"
+  loadbalancer_id = huaweicloud_elb_loadbalancer.console.id
+  description     = "cilium-gateway-console targets on port 31443"
+}
+
+resource "huaweicloud_elb_pool" "console_http" {
+  name            = "${local.name_prefix}-elb-pool-console-http"
+  protocol        = "TCP"
+  lb_method       = "ROUND_ROBIN"
+  loadbalancer_id = huaweicloud_elb_loadbalancer.console.id
+  description     = "cilium-gateway-console targets on port 31080"
+}
+
+resource "huaweicloud_elb_listener" "console_https" {
+  loadbalancer_id = huaweicloud_elb_loadbalancer.console.id
+  name            = "${local.name_prefix}-elb-listener-console-https"
+  protocol        = "TCP"
+  protocol_port   = 443
+  default_pool_id = huaweicloud_elb_pool.console_https.id
+  idle_timeout    = 60
+  description     = "TCP passthrough — cilium-gateway-console terminates TLS at 31443"
+}
+
+resource "huaweicloud_elb_listener" "console_http" {
+  loadbalancer_id = huaweicloud_elb_loadbalancer.console.id
+  name            = "${local.name_prefix}-elb-listener-console-http"
+  protocol        = "TCP"
+  protocol_port   = 80
+  default_pool_id = huaweicloud_elb_pool.console_http.id
+  idle_timeout    = 60
+  description     = "TCP passthrough — console HTTP→HTTPS redirect"
+}
+
+# Console ELB members: the SAME primary-region nodes as the primary ELB.
+# cilium-envoy runs on every node and binds BOTH 30443 (shared) and 31443
+# (console), so every node is a valid console-ELB target on 31443/31080.
+resource "huaweicloud_elb_member" "console_https" {
+  count         = length(local.primary_lb_node_ips)
+  pool_id       = huaweicloud_elb_pool.console_https.id
+  address       = local.primary_lb_node_ips[count.index]
+  protocol_port = 31443
+  subnet_id     = huaweicloud_vpc_subnet.region[local.region_keys[0]].ipv4_subnet_id
+}
+
+resource "huaweicloud_elb_member" "console_http" {
+  count         = length(local.primary_lb_node_ips)
+  pool_id       = huaweicloud_elb_pool.console_http.id
+  address       = local.primary_lb_node_ips[count.index]
+  protocol_port = 31080
+  subnet_id     = huaweicloud_vpc_subnet.region[local.region_keys[0]].ipv4_subnet_id
+}
+
+resource "huaweicloud_elb_monitor" "console_https" {
+  pool_id     = huaweicloud_elb_pool.console_https.id
+  protocol    = "TCP"
+  port        = 31443
+  interval    = 10
+  timeout     = 5
+  max_retries = 3
+}
+
+resource "huaweicloud_elb_monitor" "console_http" {
+  pool_id     = huaweicloud_elb_pool.console_http.id
+  protocol    = "TCP"
+  port        = 31080
+  interval    = 10
+  timeout     = 5
+  max_retries = 3
+}

--- a/infra/providers/huawei/outputs.tf
+++ b/infra/providers/huawei/outputs.tf
@@ -9,8 +9,19 @@ output "control_plane_ip" {
 }
 
 output "load_balancer_ip" {
-  description = "Public EIP of the Wave 5.98 (#2447) Huawei ELB. Sovereign FQDN A-record points HERE. ELB does 443→30443 + 80→30080 TCP passthrough to cilium-envoy on the primary-region nodes (cilium-agent BPF socket-LB blocks privileged-port bind on envoy DS — verified otech45-47)."
+  description = "Public EIP of the Wave 5.98 (#2447) Huawei ELB. The wildcard + app DNS A-records point HERE. ELB does 443→30443 + 80→30080 TCP passthrough to cilium-envoy on the primary-region nodes (cilium-agent BPF socket-LB blocks privileged-port bind on envoy DS — verified otech45-47)."
   value       = huaweicloud_vpc_eip.elb_primary.publicip.0.ip_address
+}
+
+# #4053 — public EIP of the dedicated CONSOLE ELB. console./api.<fqdn> point
+# HERE (443→31443 to the isolated cilium-gateway-console); the wildcard *.<fqdn>
+# keeps pointing at load_balancer_ip above (the shared cilium-gateway).
+# catalyst-api threads this to pool-domain-manager /commit as
+# consoleLoadBalancerIP. Empty-safe: a pre-#4053 consumer ignores it and PDM
+# falls back to load_balancer_ip for every record.
+output "console_load_balancer_ip" {
+  description = "Public EIP of the dedicated console ELB (console./api.<fqdn> point here; #4053 gateway isolation)."
+  value       = huaweicloud_vpc_eip.elb_console.publicip.0.ip_address
 }
 
 output "sovereign_fqdn" {

--- a/products/catalyst/bootstrap/api/internal/dynadot/dynadot.go
+++ b/products/catalyst/bootstrap/api/internal/dynadot/dynadot.go
@@ -136,36 +136,55 @@ func (c *Client) AddRecord(ctx context.Context, domain string, rec Record) error
 // wildcard A + per-component A records (console, gitea, harbor, admin, api)
 // pointing at the load balancer IP.
 //
+// #4053 — POISON-PROOF console gateway isolation. An OPTIONAL trailing
+// consoleLBIP (variadic so every existing caller compiles unchanged) routes the
+// `console` and `api` records at the dedicated console LB (the isolated
+// cilium-gateway-console front door) instead of lbIP, so a poisoned
+// shared-gateway CiliumEnvoyConfig (one unresolvable app backend, cilium#35728)
+// can never 404 the console. When consoleLBIP is omitted or empty, console + api
+// fall back to lbIP — byte-identical to the pre-#4053 record set.
+//
 // This is idempotent — re-running it with the same domain + IP is safe.
 // Re-running with a different IP appends additional records (Dynadot's
 // add_dns_to_current_setting semantics) so the caller is responsible for
 // cleaning up stale records via DeleteRecords if the IP changes.
-func (c *Client) AddSovereignRecords(ctx context.Context, domain, subdomain, lbIP string) error {
+func (c *Client) AddSovereignRecords(ctx context.Context, domain, subdomain, lbIP string, consoleLBIP ...string) error {
 	// For pool domains the records go on the pool domain (e.g. omani.works)
 	// with subdomains like "omantel", "console.omantel", "gitea.omantel", etc.
 	// For BYO domains the customer is expected to manage their own DNS — we
 	// only attempt Dynadot writes when the domain is one we own.
 
-	prefixes := []string{
-		"",         // wildcard apex of the subdomain — *.omantel.omani.works
-		"console",  // console.omantel.omani.works
-		"gitea",    // gitea.omantel.omani.works
-		"harbor",   // harbor.omantel.omani.works
-		"admin",    // admin.omantel.omani.works
-		"api",      // api.omantel.omani.works
+	// #4053 — resolve the console-facing IP (defaults to lbIP when not split).
+	consoleIP := lbIP
+	if len(consoleLBIP) > 0 && consoleLBIP[0] != "" {
+		consoleIP = consoleLBIP[0]
 	}
 
-	for _, p := range prefixes {
+	// prefix → target IP. console + api ride the console LB; everything else
+	// rides the shared LB.
+	records := []struct {
+		prefix string
+		ip     string
+	}{
+		{"", lbIP},             // wildcard apex of the subdomain — *.omantel.omani.works
+		{"console", consoleIP}, // console.omantel.omani.works (#4053)
+		{"gitea", lbIP},        // gitea.omantel.omani.works
+		{"harbor", lbIP},       // harbor.omantel.omani.works
+		{"admin", lbIP},        // admin.omantel.omani.works
+		{"api", consoleIP},     // api.omantel.omani.works (#4053)
+	}
+
+	for _, rec := range records {
 		var sub string
-		if p == "" {
+		if rec.prefix == "" {
 			sub = "*." + subdomain
 		} else {
-			sub = p + "." + subdomain
+			sub = rec.prefix + "." + subdomain
 		}
 		err := c.AddRecord(ctx, domain, Record{
 			Subdomain: sub,
 			Type:      "A",
-			Value:     lbIP,
+			Value:     rec.ip,
 			TTL:       300,
 		})
 		if err != nil {
@@ -313,21 +332,21 @@ func truncate(s string, max int) string {
 // truth in the wizard state):
 //
 //   - parentZone:    the registered domain held in the Dynadot account,
-//                    e.g. "omani.works". MUST be one of the managed
-//                    domains (IsManagedDomain returns true) — otherwise
-//                    we refuse to call the API.
+//     e.g. "omani.works". MUST be one of the managed
+//     domains (IsManagedDomain returns true) — otherwise
+//     we refuse to call the API.
 //   - sovereignFQDN: the child zone, e.g. "omantel.omani.works". MUST end
-//                    with "." + parentZone.
+//     with "." + parentZone.
 //   - lbIP:          the new Sovereign's public load-balancer IP, used as
-//                    the glue A-record value for ns1.<sovereignFQDN>. The
-//                    Sovereign's PowerDNS chart materialises ns1/ns2/ns3
-//                    behind that single IP via the anycast-endpoint
-//                    Service (see platform/powerdns/chart/values.yaml).
+//     the glue A-record value for ns1.<sovereignFQDN>. The
+//     Sovereign's PowerDNS chart materialises ns1/ns2/ns3
+//     behind that single IP via the anycast-endpoint
+//     Service (see platform/powerdns/chart/values.yaml).
 //   - extraNS:       optional additional NS hostnames to bundle into the
-//                    delegation. Empty/nil means the canonical 3-record
-//                    set (ns1.<fqdn>, ns2.<fqdn>, ns3.<fqdn>). Callers
-//                    pass non-default values when a Sovereign is fronted
-//                    by a CDN that mints its own NS hostnames.
+//     delegation. Empty/nil means the canonical 3-record
+//     set (ns1.<fqdn>, ns2.<fqdn>, ns3.<fqdn>). Callers
+//     pass non-default values when a Sovereign is fronted
+//     by a CDN that mints its own NS hostnames.
 //
 // Like AddSovereignRecords this method uses the package's
 // add_dns_to_current_setting=yes contract — it never replaces the parent

--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -1405,30 +1405,30 @@ func (h *Handler) CreateDeployment(w http.ResponseWriter, r *http.Request) {
 //
 // Why a list endpoint:
 //
-//   The wizard's index route (/sovereign/wizard, /sovereign/) needs to
-//   know whether the signed-in operator already has an in-flight
-//   deployment so it can auto-redirect to /sovereign/provision/<id>
-//   instead of presenting Step 1 of an empty wizard. Without this
-//   redirect, an operator who refreshes the tab during a 15-minute
-//   provisioning run loses the progress page and lands on the org
-//   form — which is the exact bug the founder hit live with otech90
-//   on 2026-05-04.
+//	The wizard's index route (/sovereign/wizard, /sovereign/) needs to
+//	know whether the signed-in operator already has an in-flight
+//	deployment so it can auto-redirect to /sovereign/provision/<id>
+//	instead of presenting Step 1 of an empty wizard. Without this
+//	redirect, an operator who refreshes the tab during a 15-minute
+//	provisioning run loses the progress page and lands on the org
+//	form — which is the exact bug the founder hit live with otech90
+//	on 2026-05-04.
 //
 // Filtering rules:
 //
-//   1. ?owner=<email> — restrict to deployments whose OwnerEmail
-//      matches (case-insensitive).
-//   2. When auth.RequireSession is wired, X-User-Email is always set
-//      and we ALSO restrict to that session's email regardless of
-//      the ?owner= value, so an operator can't list someone else's
-//      deployments by passing a different ?owner=. The server-side
-//      check is the security boundary; ?owner= is effectively a
-//      hint that mirrors the session.
-//   3. When the middleware is bypassed (CI / tests / catalyst-api
-//      running without CATALYST_KC_ADDR), the ?owner= filter is the
-//      only filter and an empty ?owner= returns every deployment —
-//      same passthrough policy as checkOwnership() to keep existing
-//      tests working unchanged.
+//  1. ?owner=<email> — restrict to deployments whose OwnerEmail
+//     matches (case-insensitive).
+//  2. When auth.RequireSession is wired, X-User-Email is always set
+//     and we ALSO restrict to that session's email regardless of
+//     the ?owner= value, so an operator can't list someone else's
+//     deployments by passing a different ?owner=. The server-side
+//     check is the security boundary; ?owner= is effectively a
+//     hint that mirrors the session.
+//  3. When the middleware is bypassed (CI / tests / catalyst-api
+//     running without CATALYST_KC_ADDR), the ?owner= filter is the
+//     only filter and an empty ?owner= returns every deployment —
+//     same passthrough policy as checkOwnership() to keep existing
+//     tests working unchanged.
 //
 // Adopted deployments (AdoptedAt != nil) are EXCLUDED from the list —
 // post-handover the customer's Sovereign is operationally self-
@@ -2126,10 +2126,11 @@ func (h *Handler) commitPDMWithRetry(dep *Deployment, result *provisioner.Result
 		pdmCtx,
 		dep.pdmPoolDomain,
 		pdm.CommitInput{
-			Subdomain:        dep.pdmSubdomain,
-			ReservationToken: dep.pdmReservationToken,
-			SovereignFQDN:    result.SovereignFQDN,
-			LoadBalancerIP:   result.LoadBalancerIP,
+			Subdomain:             dep.pdmSubdomain,
+			ReservationToken:      dep.pdmReservationToken,
+			SovereignFQDN:         result.SovereignFQDN,
+			LoadBalancerIP:        result.LoadBalancerIP,
+			ConsoleLoadBalancerIP: result.ConsoleLoadBalancerIP, // #4053 — isolated console LB (empty-safe)
 		},
 		func(ctx context.Context) (*pdm.Reservation, error) {
 			emitInfo(fmt.Sprintf("PDM reservation expired during Phase 0 — re-Reserving %s.%s",

--- a/products/catalyst/bootstrap/api/internal/pdm/client.go
+++ b/products/catalyst/bootstrap/api/internal/pdm/client.go
@@ -175,6 +175,12 @@ type CommitInput struct {
 	ReservationToken string
 	SovereignFQDN    string
 	LoadBalancerIP   string
+	// ConsoleLoadBalancerIP — #4053. Optional. When set, the console + api
+	// A-records point at the dedicated console LB (the isolated
+	// cilium-gateway-console) instead of LoadBalancerIP, so a poisoned
+	// shared-gateway CEC (cilium#35728) can never 404 the console. Empty =
+	// every record points at LoadBalancerIP (legacy single-LB behaviour).
+	ConsoleLoadBalancerIP string
 }
 
 // Commit calls POST /api/v1/pool/{domain}/commit.
@@ -201,6 +207,13 @@ func (c *Client) Commit(ctx context.Context, poolDomain string, in CommitInput) 
 		"reservationToken": in.ReservationToken,
 		"sovereignFQDN":    in.SovereignFQDN,
 		"loadBalancerIP":   in.LoadBalancerIP,
+	}
+	// #4053 — only send consoleLoadBalancerIP when the console gateway is
+	// isolated (a dedicated console LB exists). Omitting the key when empty
+	// keeps the wire body byte-identical to the pre-#4053 request, and PDM
+	// falls back to loadBalancerIP for the console records.
+	if in.ConsoleLoadBalancerIP != "" {
+		body["consoleLoadBalancerIP"] = in.ConsoleLoadBalancerIP
 	}
 	raw, err := json.Marshal(body)
 	if err != nil {

--- a/products/catalyst/bootstrap/api/internal/providers/hetzner/provider.go
+++ b/products/catalyst/bootstrap/api/internal/providers/hetzner/provider.go
@@ -102,12 +102,13 @@ func (p *Provider) Provision(ctx context.Context, spec providers.ProvisionSpec, 
 		return nil, err
 	}
 	return &providers.ProvisionResult{
-		SovereignFQDN:  res.SovereignFQDN,
-		ControlPlaneIP: res.ControlPlaneIP,
-		LoadBalancerIP: res.LoadBalancerIP,
-		ConsoleURL:     res.ConsoleURL,
-		GitOpsRepoURL:  res.GitOpsRepoURL,
-		KubeconfigPath: res.KubeconfigPath,
+		SovereignFQDN:         res.SovereignFQDN,
+		ControlPlaneIP:        res.ControlPlaneIP,
+		LoadBalancerIP:        res.LoadBalancerIP,
+		ConsoleLoadBalancerIP: res.ConsoleLoadBalancerIP, // #4053 — dedicated console LB
+		ConsoleURL:            res.ConsoleURL,
+		GitOpsRepoURL:         res.GitOpsRepoURL,
+		KubeconfigPath:        res.KubeconfigPath,
 	}, nil
 }
 

--- a/products/catalyst/bootstrap/api/internal/providers/huawei/provider.go
+++ b/products/catalyst/bootstrap/api/internal/providers/huawei/provider.go
@@ -225,12 +225,13 @@ func (p *Provider) Provision(ctx context.Context, spec providers.ProvisionSpec, 
 		return nil, err
 	}
 	return &providers.ProvisionResult{
-		SovereignFQDN:  res.SovereignFQDN,
-		ControlPlaneIP: res.ControlPlaneIP,
-		LoadBalancerIP: res.LoadBalancerIP,
-		ConsoleURL:     res.ConsoleURL,
-		GitOpsRepoURL:  res.GitOpsRepoURL,
-		KubeconfigPath: res.KubeconfigPath,
+		SovereignFQDN:         res.SovereignFQDN,
+		ControlPlaneIP:        res.ControlPlaneIP,
+		LoadBalancerIP:        res.LoadBalancerIP,
+		ConsoleLoadBalancerIP: res.ConsoleLoadBalancerIP, // #4053 — dedicated console ELB
+		ConsoleURL:            res.ConsoleURL,
+		GitOpsRepoURL:         res.GitOpsRepoURL,
+		KubeconfigPath:        res.KubeconfigPath,
 	}, nil
 }
 

--- a/products/catalyst/bootstrap/api/internal/providers/provider.go
+++ b/products/catalyst/bootstrap/api/internal/providers/provider.go
@@ -177,9 +177,9 @@ type RegionSpec struct {
 // providers package doesn't need to import the provisioner package
 // (and create an import cycle).
 type ParentDomain struct {
-	Name       string `json:"name"`
-	Role       string `json:"role,omitempty"`
-	Registrar  string `json:"registrar,omitempty"`
+	Name          string `json:"name"`
+	Role          string `json:"role,omitempty"`
+	Registrar     string `json:"registrar,omitempty"`
 	ProvisionedAt string `json:"provisionedAt,omitempty"`
 }
 
@@ -188,7 +188,9 @@ type ParentDomain struct {
 // so adding a new provider does not require an interface bump.
 //
 // Hetzner uses: hcloud_token, hcloud_project_id, object_storage_access_key,
-//               object_storage_secret_key, object_storage_region
+//
+//	object_storage_secret_key, object_storage_region
+//
 // Huawei (planned) will use: ak, sk, project_id, region
 type ProviderCreds struct {
 	Raw map[string]string
@@ -222,9 +224,16 @@ type ProvisionResult struct {
 	SovereignFQDN  string
 	ControlPlaneIP string
 	LoadBalancerIP string
-	ConsoleURL     string
-	GitOpsRepoURL  string
-	KubeconfigPath string
+	// ConsoleLoadBalancerIP — #4053. Public IP of the dedicated console LB
+	// (tofu output console_load_balancer_ip). console./api.<fqdn> point here
+	// (the isolated cilium-gateway-console); the wildcard *.<fqdn> keeps
+	// pointing at LoadBalancerIP (the shared cilium-gateway). Empty when the
+	// provider/tofu module pre-dates #4053 — DNS then falls back to
+	// LoadBalancerIP for the console records (legacy single-LB behaviour).
+	ConsoleLoadBalancerIP string
+	ConsoleURL            string
+	GitOpsRepoURL         string
+	KubeconfigPath        string
 }
 
 // WipeSpec — input to CloudProvider.Wipe. Carries everything the

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -1069,8 +1069,13 @@ type Result struct {
 	SovereignFQDN  string `json:"sovereignFQDN"`
 	ControlPlaneIP string `json:"controlPlaneIP"`
 	LoadBalancerIP string `json:"loadBalancerIP"`
-	ConsoleURL     string `json:"consoleURL"`
-	GitOpsRepoURL  string `json:"gitopsRepoURL"`
+	// ConsoleLoadBalancerIP — #4053. tofu output console_load_balancer_ip:
+	// the dedicated console LB that fronts the isolated cilium-gateway-console.
+	// console./api.<fqdn> DNS point here; the wildcard keeps pointing at
+	// LoadBalancerIP. Empty when the tofu module pre-dates #4053.
+	ConsoleLoadBalancerIP string `json:"consoleLoadBalancerIP,omitempty"`
+	ConsoleURL            string `json:"consoleURL"`
+	GitOpsRepoURL         string `json:"gitopsRepoURL"`
 
 	// KubeconfigPath — absolute path to the kubeconfig YAML on the
 	// catalyst-api PVC. Empty until cloud-init PUTs the bytes back
@@ -1982,12 +1987,13 @@ func (p *Provisioner) Provision(ctx context.Context, req Request, events chan<- 
 	}
 
 	result := &Result{
-		SovereignFQDN:       req.SovereignFQDN,
-		ControlPlaneIP:      out.ControlPlaneIP,
-		LoadBalancerIP:      out.LoadBalancerIP,
-		ConsoleURL:          fmt.Sprintf("https://console.%s", req.SovereignFQDN),
-		GitOpsRepoURL:       fmt.Sprintf("https://gitea.%s", req.SovereignFQDN),
-		MaterializedRegions: materialised,
+		SovereignFQDN:         req.SovereignFQDN,
+		ControlPlaneIP:        out.ControlPlaneIP,
+		LoadBalancerIP:        out.LoadBalancerIP,
+		ConsoleLoadBalancerIP: out.ConsoleLoadBalancerIP, // #4053 — "" when module pre-dates #4053
+		ConsoleURL:            fmt.Sprintf("https://console.%s", req.SovereignFQDN),
+		GitOpsRepoURL:         fmt.Sprintf("https://gitea.%s", req.SovereignFQDN),
+		MaterializedRegions:   materialised,
 	}
 
 	// Only enforce when the operator declared >=2 regions AND the
@@ -2335,6 +2341,12 @@ func streamLines(r io.Reader, phase, level string, emit func(string, string, str
 type tofuOutputs struct {
 	ControlPlaneIP string `json:"control_plane_ip"`
 	LoadBalancerIP string `json:"load_balancer_ip"`
+	// ConsoleLoadBalancerIP — #4053. Both providers emit
+	// `console_load_balancer_ip` (the dedicated console LB for the isolated
+	// cilium-gateway-console). asString() returns "" when the key is absent
+	// (a tofu module that pre-dates #4053), and the DNS layer falls back to
+	// LoadBalancerIP for the console records — byte-identical legacy behaviour.
+	ConsoleLoadBalancerIP string `json:"console_load_balancer_ip"`
 	// ControlPlaneIPsPerRegion — map<region-code, primary-CP-EIP>.
 	// Populated by BOTH the Huawei module's `control_plane_ips_per_region`
 	// output AND (as of 2026-06-03 / #2840 follow-up) the Hetzner module's
@@ -2404,6 +2416,7 @@ func (p *Provisioner) readOutputs(ctx context.Context, deployDir string) (*tofuO
 	return &tofuOutputs{
 		ControlPlaneIP:           asString("control_plane_ip"),
 		LoadBalancerIP:           asString("load_balancer_ip"),
+		ConsoleLoadBalancerIP:    asString("console_load_balancer_ip"), // #4053 — "" when module pre-dates #4053
 		ControlPlaneIPsPerRegion: asStringMap("control_plane_ips_per_region"),
 	}, nil
 }

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2933,7 +2933,21 @@ name: bp-catalyst-platform
 #   (renumbered 1.4.747→1.4.749, one above main's deploy-bot 1.4.748, to clear the pin collision.)
 # 1.4.757 — bp-chepherd Blueprint missing required topology.defaults.multi-region → whole
 #   catalyst-platform install aborted (console 404 on every fresh prov). Add multi-region: singleton.
-version: 1.4.759
+# 1.4.760 (#4053) — POISON-PROOF console gateway isolation. Cilium compiles ALL of a
+#   Gateway's HTTPRoutes+backends into ONE CiliumEnvoyConfig committed atomically; one
+#   unresolvable app backend (a half-converged app, a vanished vcluster-bridge Service)
+#   fails the whole CEC → cilium-envoy serves 0 listeners → the entire gateway 404s,
+#   console included (cilium#35728, unfixed on pinned 1.16.5; hit live hw182). Fix:
+#   (1) sovereign-tls-vars-cm.yaml emits a NEW ConfigMap key CONSOLE_LISTENERS_YAML for a
+#   dedicated console gateway (host ports 31443/31080, `*.<fqdn>` listener, same per-prov
+#   wildcard cert); (2) the catalyst-ui + catalyst-api HTTPRoutes re-parent onto
+#   `cilium-gateway-console` (ingress.gateway.parentRef.name default flip) so their CEC
+#   carries ONLY stable ClusterIP backends and can never be poisoned by an app on the
+#   SHARED cilium-gateway. New consoleGateway.{httpsPort,httpPort} values. Pairs with
+#   clusters/_template/sovereign-tls/cilium-gateway-console.yaml (the Gateway resource),
+#   infra/providers/{hetzner,huawei} (dedicated console LB → 31443) + core/pool-domain-
+#   manager + catalyst-api (console./api.<fqdn> DNS split to the console LB).
+version: 1.4.760
 # 1.4.702 — #3819 #3854 #3859 (Refs #3383 #3376): sme→org-services rename TAIL — the
 #   funnel/BSS control-plane templates + values default the namespace to `org-services`
 #   instead of the dead `sme` ns: provisioning-github-token / valkey-cross-ns-secret +

--- a/products/catalyst/chart/templates/sovereign-tls-vars-cm.yaml
+++ b/products/catalyst/chart/templates/sovereign-tls-vars-cm.yaml
@@ -150,6 +150,62 @@ parses it as the materialised listener list.
         "allowedRoutes" (dict "namespaces" (dict "from" "All"))
       ) }}
 {{- end }}
+{{- /* ─────────────────────────────────────────────────────────────────────
+       #4053 — POISON-PROOF CONSOLE GATEWAY ISOLATION
+       ─────────────────────────────────────────────────────────────────────
+       Cilium Gateway API compiles ALL of a Gateway's HTTPRoutes + backends
+       into ONE CiliumEnvoyConfig (CEC), committed ATOMICALLY by cilium-agent.
+       If ANY single backend Service is unresolvable (a half-converged app, a
+       vanished vcluster-bridge Service, an empty EndpointSlice), getK8sService
+       returns "retrieved nil details" → the WHOLE CEC upsert fails → cilium-
+       envoy gets 0 listeners → the entire gateway 404s, console included.
+       This is the unfixed upstream bug cilium#35728 / cilium#34982 — no config
+       flag, no version fix on the pinned Cilium 1.16.5 (Chart.lock truth).
+       Confirmed live on hw182 (newapi install #3831 bridge Service poisoned
+       the whole console).
+
+       Because the CEC is ONE-PER-GATEWAY, isolating the console onto its OWN
+       Gateway means a broken volatile app backend can only zero ITS gateway —
+       the console gateway (stable ClusterIP backends only: catalyst-ui +
+       catalyst-api) survives. This second key renders the console gateway's
+       listener set: the SAME per-prov wildcard cert (`*.<fqdn>` matches the
+       2-label-deep console.<fqdn> / api.<fqdn> operator endpoints), but on the
+       console gateway's OWN host ports (consoleGateway.httpsPort /
+       .httpPort, default 31443 / 31080 — distinct from the shared gateway's
+       30443 / 30080 so both bind in hostNetwork mode without collision).
+
+       Why a single `*.<fqdn>` listener pair (not the full per-zone fan-out):
+       the console + api hostnames always live under the Sovereign FQDN apex,
+       never under an org-pool zone (those are tenant/app surfaces and stay on
+       the SHARED gateway). One wildcard pair on the primary cert is therefore
+       sufficient and keeps the console CEC minimal.
+
+       Consumed by clusters/_template/sovereign-tls/cilium-gateway-console.yaml
+       at `listeners: ${CONSOLE_LISTENERS_YAML}` via the same Flux postBuild
+       substituteFrom the shared gateway uses for PARENT_DOMAINS_LISTENERS_YAML.
+*/ -}}
+{{- $consoleCfg := default dict .Values.consoleGateway }}
+{{- $consoleHttpsPort := default 31443 $consoleCfg.httpsPort }}
+{{- $consoleHttpPort := default 31080 $consoleCfg.httpPort }}
+{{- $consoleListeners := list }}
+{{- $consoleListeners = append $consoleListeners (dict
+      "name" "console-https"
+      "port" $consoleHttpsPort
+      "protocol" "HTTPS"
+      "hostname" (printf "*.%s" $fqdn)
+      "tls" (dict
+        "mode" "Terminate"
+        "certificateRefs" (list (dict "kind" "Secret" "name" $secretName))
+      )
+      "allowedRoutes" (dict "namespaces" (dict "from" "All"))
+    ) }}
+{{- $consoleListeners = append $consoleListeners (dict
+      "name" "console-http"
+      "port" $consoleHttpPort
+      "protocol" "HTTP"
+      "hostname" (printf "*.%s" $fqdn)
+      "allowedRoutes" (dict "namespaces" (dict "from" "All"))
+    ) }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -161,10 +217,22 @@ metadata:
     app.kubernetes.io/component: sovereign-tls-vars
     catalyst.openova.io/sovereign: {{ $fqdn | quote }}
 data:
-  # PARENT_DOMAINS_LISTENERS_YAML — JSON-flow array literal of the
-  # Cilium Gateway listener block. Consumed by Flux postBuild.
-  # substituteFrom on the sovereign-tls Kustomization (cloud-init
-  # writes that Kustomization). See cilium-gateway.yaml `listeners:
-  # ${PARENT_DOMAINS_LISTENERS_YAML}` for the consumer.
+  # PARENT_DOMAINS_LISTENERS_YAML — JSON-flow array literal of the SHARED
+  # Cilium Gateway listener block (all parent zones + the per-prov wildcard
+  # pair). Consumed by Flux postBuild.substituteFrom on the sovereign-tls
+  # Kustomization (cloud-init writes that Kustomization). See
+  # cilium-gateway.yaml `listeners: ${PARENT_DOMAINS_LISTENERS_YAML}` for the
+  # consumer. The SHARED gateway carries every VOLATILE route (keycloak,
+  # grafana, gitea, harbor, openbao, powerdns, newapi, marketplace, tenant +
+  # mgmt-vcluster app routes) — its CEC may be poisoned by a half-converged
+  # app, which is acceptable because the console no longer rides this gateway.
   PARENT_DOMAINS_LISTENERS_YAML: {{ toJson $listeners | quote }}
+  # CONSOLE_LISTENERS_YAML — #4053 — JSON-flow array literal of the dedicated
+  # CONSOLE Cilium Gateway listener block. Consumed by Flux postBuild.
+  # substituteFrom on the sovereign-tls Kustomization. See
+  # cilium-gateway-console.yaml `listeners: ${CONSOLE_LISTENERS_YAML}`. The
+  # console gateway carries ONLY the catalyst-ui + catalyst-api HTTPRoutes
+  # (stable ClusterIP backends that always resolve), so its CEC is structurally
+  # immune to the app-backend poisoning that can zero the shared gateway.
+  CONSOLE_LISTENERS_YAML: {{ toJson $consoleListeners | quote }}
 {{- end }}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -609,7 +609,9 @@ controllers:
       # 300d853 (2026-06-19) — controller-image-tag freshness sweep: the
       # pinned fc38403 had drifted 139 commits behind latest GHCR; bumped to
       # the current organization-controller GHCR tag to clear the staleness gate.
-      tag: "300d853"
+      # 34ff594 (2026-06-21, #4053) — freshness sweep on the console-gateway-
+      # isolation PR: 300d853 had drifted 174 commits behind latest GHCR.
+      tag: "34ff594"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -728,7 +730,9 @@ controllers:
       # — adds EnsureBranch before PutFile so Gitea's branch-missing
       # 404 (mapped to ErrRepoNotFound by the client) no longer dead-
       # loops the env-controller.
-      tag: "01db043"
+      # 34ff594 (2026-06-21, #4053) — freshness sweep on the console-gateway-
+      # isolation PR: 01db043 had drifted 437 commits behind latest GHCR.
+      tag: "34ff594"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -767,7 +771,9 @@ controllers:
       # (2026-06-02). enabled remains false until the bp-controller
       # surfaces are wired end-to-end; the pin matches the latest
       # successful push-on-main build per Inviolable Principle #4a.
-      tag: "01db043"
+      # 34ff594 (2026-06-21, #4053) — freshness sweep on the console-gateway-
+      # isolation PR: 01db043 had drifted 437 commits behind latest GHCR.
+      tag: "34ff594"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -800,7 +806,9 @@ controllers:
       # — drops cross-namespace ownerRef on the host-side Flux CRs
       # (was being silently GC'd by the K8s collector because
       # Application lives in a different namespace from flux-system).
-      tag: "01db043"
+      # 34ff594 (2026-06-21, #4053) — freshness sweep on the console-gateway-
+      # isolation PR: 01db043 had drifted 437 commits behind latest GHCR.
+      tag: "34ff594"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -858,7 +866,9 @@ controllers:
       # (#2745, 2026-06-03) — bumped from 8d01e2f (2026-05-31) to the
       # latest useraccess-controller main-HEAD push (2026-06-02).
       # #2851 closed the drift gap (auto-bump + sweep + freshness guard).
-      tag: "01db043"
+      # 34ff594 (2026-06-21, #4053) — freshness sweep on the console-gateway-
+      # isolation PR: 01db043 had drifted 437 commits behind latest GHCR.
+      tag: "34ff594"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -1112,6 +1112,33 @@ catalystApi:
   # broker by default).
   natsURL: ""
 
+# ─── #4053 — Dedicated console Gateway (poison-proof blast-radius isolation) ──
+# Cilium Gateway API compiles every HTTPRoute + backend of a Gateway into ONE
+# CiliumEnvoyConfig, committed atomically. A single unresolvable backend
+# Service (a half-converged app, a vanished vcluster-bridge Service) fails the
+# whole CEC upsert → cilium-envoy serves 0 listeners → the whole gateway 404s,
+# console included (cilium#35728 / cilium#34982, no fix on pinned 1.16.5;
+# confirmed live hw182). Because the CEC is one-per-Gateway, the console is
+# isolated onto its OWN Gateway (`cilium-gateway-console`) carrying ONLY the
+# catalyst-ui + catalyst-api HTTPRoutes — stable ClusterIP backends that always
+# resolve — so its CEC can never be poisoned by an app on the SHARED gateway.
+#
+# The console gateway binds its own host ports in Cilium hostNetwork mode
+# (distinct from the shared gateway's 30443/30080 so both coexist on every
+# node). A dedicated cloud LoadBalancer forwards public 443/80 → these host
+# ports; the console A-records (console./api.<fqdn>) point at THAT LB, while the
+# wildcard `*.<fqdn>` (every volatile app/tenant host) keeps pointing at the
+# shared gateway's LB. See clusters/_template/sovereign-tls/cilium-gateway-
+# console.yaml, infra/providers/{hetzner,huawei}/main.tf (console LB), and
+# core/pool-domain-manager (console-LB-IP DNS split).
+consoleGateway:
+  # Host ports the console gateway's cilium-envoy listeners bind (hostNetwork).
+  # MUST differ from the shared gateway's 30443/30080 so both gateways bind on
+  # the same node set without a port collision. The console LB forwards public
+  # 443→httpsPort and 80→httpPort. Operator-overridable for unusual topologies.
+  httpsPort: 31443
+  httpPort: 31080
+
 # ─── Sovereign HTTPRoute (Cilium Gateway API, issue #387) ─────────────────
 # Renders templates/httproute.yaml when `ingress.gateway.enabled=true`
 # (default) AND per-Sovereign overlay supplies `ingress.hosts.console.host`
@@ -1123,7 +1150,12 @@ ingress:
   gateway:
     enabled: true
     parentRef:
-      name: cilium-gateway
+      # #4053 — the console HTTPRoutes (catalyst-ui + catalyst-api) re-parent
+      # onto the DEDICATED console gateway so an app-backend poison on the
+      # shared `cilium-gateway` can never 404 the console. Every OTHER platform
+      # HTTPRoute (keycloak/grafana/gitea/harbor/openbao/powerdns/newapi/…)
+      # keeps its `cilium-gateway` default and stays on the shared gateway.
+      name: cilium-gateway-console
       namespace: kube-system
       # sectionName intentionally EMPTY (issue #1884, TBD-A30).
       #


### PR DESCRIPTION
## Problem (Refs #4053, live hw182)
Cilium Gateway API compiles **ALL** of a Gateway's HTTPRoutes + backends into **ONE** `CiliumEnvoyConfig`, committed **atomically**. If any single backend Service is unresolvable (a half-converged app, a vanished vcluster-bridge Service, an empty EndpointSlice), `getK8sService` returns "retrieved nil details" → the entire CEC upsert fails → cilium-envoy serves **0 listeners** → the whole gateway 404s, **console included**. Unfixed upstream (cilium#35728 / cilium#34982); no flag/version fix on the pinned **Cilium 1.16.5**. Confirmed live on hw182 (newapi install #3831 bridge Service poisoned the shared gateway and took down the console).

## Fix — blast-radius isolation via a dedicated console Gateway
Because the CEC is **one-per-Gateway**, the console is isolated onto its OWN Gateway `cilium-gateway-console` carrying ONLY the `catalyst-ui` + `catalyst-api` HTTPRoutes (stable ClusterIP backends that always resolve) → its CEC is **structurally immune** to the app-backend poisoning that can zero the SHARED `cilium-gateway`. Every volatile route (keycloak / grafana / gitea / harbor / openbao / powerdns / newapi / marketplace / tenant / mgmt-vcluster) stays on the shared gateway, where a poison only kills that gateway.

## LB-reaches-both-gateways: the chosen approach + why
Both Hetzner `lb11` and Huawei ELB do **TCP passthrough on 443** (TLS terminates at cilium-envoy, NOT the LB) → neither can SNI/Host-route. And **Cilium 1.16.5 does NOT reconcile a TLSRoute-passthrough front gateway** (TLSRoute is a startup CRD presence-check only on 1.16.x — verified against `Chart.lock`). So a single public `:443` reaches exactly one host port = one gateway. Isolation therefore requires a **second host port + second LB**:

- **Console gateway** binds host ports **31443/31080** (hostNetwork; distinct from the shared gateway's 30443/30080 so both coexist on every node).
- A **dedicated console LB** (Hetzner `hcloud_load_balancer.console` / Huawei `huaweicloud_elb_loadbalancer.console`) forwards public **443→31443**, **80→31080**.
- DNS split: `console.<fqdn>` / `api.<fqdn>` A-records point at the console LB; the wildcard `*.<fqdn>` (every volatile app/tenant host) keeps pointing at the shared gateway's LB.
- **Identical design across Hetzner + Huawei**; console stays on the canonical `https://console.<fqdn>/` `:443` URL. **No Cilium upgrade needed.**

Rejected alternatives (documented in code): single-IP TLSRoute-passthrough front gateway (blocked — Cilium 1.16.5 doesn't reconcile TLSRoute); a second public port like 8443 (browsers hit apps on :443); LB-level SNI (Hetzner can't; Huawei only by terminating TLS at the LB, breaking the in-cluster per-prov cert model).

## Files changed (1-line why)
- `products/catalyst/chart/templates/sovereign-tls-vars-cm.yaml` — emit new ConfigMap key `CONSOLE_LISTENERS_YAML` (console gateway listeners, 31443/31080, same per-prov wildcard cert).
- `products/catalyst/chart/values.yaml` — `consoleGateway.{httpsPort,httpPort}` + flip `ingress.gateway.parentRef.name` default `cilium-gateway`→`cilium-gateway-console`.
- `clusters/_template/sovereign-tls/cilium-gateway-console.yaml` — NEW dedicated console Gateway resource.
- `clusters/_template/sovereign-tls/kustomization.yaml` — add the new gateway to the resources list.
- `infra/providers/hetzner/main.tf` + `outputs.tf` — dedicated console LB (443→31443, 80→31080) + `console_load_balancer_ip` output.
- `infra/providers/huawei/main.tf` + `outputs.tf` — dedicated console ELB + `console_load_balancer_ip` output.
- `core/pool-domain-manager/internal/allocator/allocator.go` (+ `_test.go`, `handler/handler.go`, `api/openapi.yaml`) — optional `consoleLoadBalancerIP` routes `console`+`api` A-records to the console LB; empty = legacy single-LB behaviour.
- `products/catalyst/bootstrap/api/internal/{providers,provisioner,dynadot,pdm,handler}` — thread `console_load_balancer_ip` tofu output → PDM `/commit` + dynadot writer, empty-safe.
- `products/catalyst/chart/Chart.yaml` 1.4.759→1.4.760 + `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` pin lockstep.

## Validation
- `helm template` — both listener keys render; console HTTPRoutes parent to `cilium-gateway-console`; keycloak (volatile) unchanged on `cilium-gateway`; full chart render OK.
- `tofu test` — **Hetzner 10/10**, **Huawei 5/5** (both `init`+`validate`+`test` green; G36 gate).
- `go test` — pool-domain-manager + catalyst-api (handler/provisioner/dynadot/pdm) green; new `TestCanonicalRecordSetConsoleSplit`.
- `check-bootstrap-kit-pin-sync.sh` — `bp-catalyst-platform chart=1.4.760 pin=1.4.760 OK` (2 pre-existing unrelated `bp-newapi` drifts not in this diff).
- The shared-gateway baseline allow-world CNP (`reserved.ingress` identity) covers the console gateway automatically (hostNetwork ingress identity is shared, gateway-name-agnostic) — no netpol change needed.

## Residual risk / follow-up
- **Backward-compatible by design**: every new field is empty-safe — a tofu module / deployment record that pre-dates this PR falls back to the single LB for all records (byte-identical to today). The console-isolation only engages once a fresh prov emits `console_load_balancer_ip`.
- **Cost**: +1 LB (Hetzner lb11 ≈ €5/mo) + 1 public IPv4 (Huawei +1 EIP) per Sovereign — far cheaper than the rejected cluster-wide Cilium ≥1.17 upgrade.
- **Not live-walked**: this PR is chart+IaC+Go only (do-not-touch-live mandate). A fresh-prov walk should confirm: (a) the console LB materialises with a healthy 31443 target, (b) the console gateway's CEC survives while a deliberately-broken app poisons the shared gateway, (c) `console.<fqdn>` resolves to the console LB IP.
- **Follow-up backlog**: the cilium-envoy-tls-restart Job currently triggers on the shared wildcard Secret and restarts the whole DaemonSet (re-binds all host ports incl. 31443) — a future refinement could make its bind-probe port-aware per gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)