### PR TITLE
fix(catalyst-api): enforce Huawei resource floor — CP≥4vCPU, workers≥8vCPU (Refs #4055)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -1146,10 +1146,11 @@ func (h *Handler) CreateDeployment(w http.ResponseWriter, r *http.Request) {
 		// fewer nodes.
 		//
 		// Wave 5.146 (2026-05-27): CP flavor flipped to m7n.large.8
-		// (2vCPU/16GB), worker flavor stays m7n.xlarge.8 (4vCPU/32GB).
-		// The original 8-worker floor was load-bearing only for the
-		// undersized flavor — at m7n.xlarge.8 a 3-worker per-region
-		// floor fits the bootstrap-kit with headroom.
+		// (2vCPU/16GB), worker flavor m7n.xlarge.8 (4vCPU/32GB).
+		// SUPERSEDED by #4055 (2026-06-21) — the "fits with headroom"
+		// claim did NOT hold once the console + both vClusters + cnpg-pair
+		// landed together; 2vCPU CP / 4vCPU workers wedged on CPU. See the
+		// resource-floor block below for the corrected sizing.
 		//
 		// Refs #2536 (2026-05-28, founder direction): symmetric
 		// MGMT+RTZ+DMZ vClusters (Refs #2537) on 2 regions × 3 workers
@@ -1167,26 +1168,50 @@ func (h *Handler) CreateDeployment(w http.ResponseWriter, r *http.Request) {
 				req.Regions[i].WorkerCount = minWorkers
 			}
 		}
-		// Wave 5.146: server-side stamp away exhausted s7n.large.4
-		// flavor on Huawei provs. The wizard / test rig may still send
-		// s7n.large.4 if the operator hasn't refreshed the SKU list;
-		// rewrite to m7n.large.8 (2vCPU/16GB drop-in replacement) so
-		// HCS scheduler can actually place the VMs.
-		if req.ControlPlaneSize == "s7n.large.4" || req.ControlPlaneSize == "" {
-			req.ControlPlaneSize = "m7n.large.8"
+		// Wave 5.146 → #4055 (founder direction 2026-06-21): ENFORCE an
+		// adequate resource FLOOR — stop shipping under-provisioned
+		// Sovereigns. The full Catalyst platform (console + cnpg-pair +
+		// mgmt/dmz vClusters + keycloak/harbor/gitea/openbao/guacamole/
+		// newapi + trivy/falco/crossplane) does NOT fit on 2vCPU nodes.
+		// hw182 came up with m7n.large.8 (2vCPU/16GB) for BOTH the CP and
+		// all 5 workers and wedged: "0/6 nodes available: Insufficient
+		// cpu" → bp-catalyst-platform's post-install hook timed out →
+		// install/uninstall oscillation → the console never scheduled.
+		//
+		// The OLD guard only rewrote the deprecated s7n.large.4 + empty,
+		// so a 2vCPU m7n.large.8 (the CP flavor wrongly sent as the
+		// worker flavor) slipped straight through un-bumped. The floor:
+		//   control-plane >= m7n.xlarge.8  (4 vCPU / 32 GB)
+		//   workers       >= m7n.2xlarge.8 (8 vCPU / 64 GB)
+		// Every known-undersized Huawei flavor is now rewritten UP to the
+		// floor; a larger explicit flavor is honoured untouched. The m7n
+		// family is unconstrained in the SKU matrix (sku_availability.go),
+		// so these pass IsSkuAvailableInRegion in every kom4dc region.
+		const (
+			hwCPFloor     = "m7n.xlarge.8"  // 4 vCPU / 32 GB
+			hwWorkerFloor = "m7n.2xlarge.8" // 8 vCPU / 64 GB
+		)
+		// undersizedCP/undersizedWorker = flavors strictly below the floor
+		// for that role (plus "" = unset). m7n.large.8 (2vCPU) is too
+		// small for BOTH roles; m7n.xlarge.8 (4vCPU) meets the CP floor
+		// but is still below the worker floor.
+		undersizedCP := map[string]bool{"": true, "s7n.large.4": true, "m7n.large.8": true}
+		undersizedWorker := map[string]bool{"": true, "s7n.large.4": true, "m7n.large.8": true, "m7n.xlarge.8": true}
+		if undersizedCP[req.ControlPlaneSize] {
+			req.ControlPlaneSize = hwCPFloor
 		}
-		if req.WorkerSize == "s7n.large.4" || req.WorkerSize == "" {
-			req.WorkerSize = "m7n.xlarge.8"
+		if undersizedWorker[req.WorkerSize] {
+			req.WorkerSize = hwWorkerFloor
 		}
 		for i := range req.Regions {
 			if req.Regions[i].Provider != "huawei" {
 				continue
 			}
-			if req.Regions[i].ControlPlaneSize == "s7n.large.4" || req.Regions[i].ControlPlaneSize == "" {
-				req.Regions[i].ControlPlaneSize = "m7n.large.8"
+			if undersizedCP[req.Regions[i].ControlPlaneSize] {
+				req.Regions[i].ControlPlaneSize = hwCPFloor
 			}
-			if req.Regions[i].WorkerSize == "s7n.large.4" || req.Regions[i].WorkerSize == "" {
-				req.Regions[i].WorkerSize = "m7n.xlarge.8"
+			if undersizedWorker[req.Regions[i].WorkerSize] {
+				req.Regions[i].WorkerSize = hwWorkerFloor
 			}
 		}
 		// Issue #2528: Huawei OBS (Object Storage Service) on HCS Kom4DC

--- a/products/catalyst/bootstrap/api/internal/handler/deployments_huawei_dispatch_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments_huawei_dispatch_test.go
@@ -133,6 +133,74 @@ func TestCreateDeployment_Huawei_DispatchesToHuaweiAdapter(t *testing.T) {
 	}
 }
 
+// TestCreateDeployment_Huawei_EnforcesResourceFloor — #4055 regression.
+// hw182 shipped with m7n.large.8 (2vCPU/16GB) for BOTH the control plane
+// AND all 5 workers and wedged on "0/6 nodes available: Insufficient
+// cpu": bp-catalyst-platform's post-install hook timed out, the install
+// oscillated, and the console never scheduled. The old guard only
+// rewrote the deprecated s7n.large.4/empty, so a 2vCPU m7n.large.8
+// (the CP flavor wrongly sent for workers) slipped through un-bumped.
+// The handler must now floor undersized Huawei flavors UP:
+// control-plane >= m7n.xlarge.8 (4vCPU/32GB), workers >= m7n.2xlarge.8
+// (8vCPU/64GB).
+func TestCreateDeployment_Huawei_EnforcesResourceFloor(t *testing.T) {
+	t.Setenv("DYNADOT_MANAGED_DOMAINS", "omani.works")
+	t.Setenv("CATALYST_HARBOR_ROBOT_TOKEN", "harbor_TEST_PLACEHOLDER")
+	t.Setenv("CATALYST_HUAWEI_ACCESS_KEY", "TESTAK1234567890")
+	t.Setenv("CATALYST_HUAWEI_SECRET_KEY", "TESTSKABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890")
+	t.Setenv("CATALYST_HUAWEI_PROJECT_ID", "0a1b2c3d4e5f6789abcd")
+	t.Setenv("CATALYST_HUAWEI_REGION", "me-east-215")
+	pdm.ResetManagedDomains()
+
+	fake := &fakePDM{}
+	h := NewWithPDM(slog.Default(), fake)
+
+	// Reproduce hw182's undersized request verbatim: 2vCPU m7n.large.8
+	// for BOTH roles. The handler must floor them up.
+	body, _ := json.Marshal(map[string]any{
+		"provider":               "huawei",
+		"sovereignFQDN":          "hcs.example.om",
+		"sovereignDomainMode":    "byo",
+		"sovereignSubdomain":     "hcs",
+		"region":                 "me-east-215",
+		"orgName":                "Example HCS Customer",
+		"orgEmail":               "ops@example.om",
+		"sshPublicKey":           "ssh-ed25519 AAAA test",
+		"controlPlaneSize":       "m7n.large.8",
+		"workerSize":             "m7n.large.8",
+		"workerCount":            5,
+		"objectStorageRegion":    "me-east-215",
+		"objectStorageAccessKey": "TESTAK1234567890",
+		"objectStorageSecretKey": "TESTSKABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
+	})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/deployments", bytes.NewReader(body))
+	h.CreateDeployment(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		ID string `json:"id"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	val, ok := h.deployments.Load(resp.ID)
+	if !ok {
+		t.Fatalf("deployment %s missing from sync.Map", resp.ID)
+	}
+	dep := val.(*Deployment)
+
+	if dep.Request.ControlPlaneSize != "m7n.xlarge.8" {
+		t.Errorf("ControlPlaneSize = %q, want m7n.xlarge.8 (2vCPU m7n.large.8 must floor to 4vCPU)",
+			dep.Request.ControlPlaneSize)
+	}
+	if dep.Request.WorkerSize != "m7n.2xlarge.8" {
+		t.Errorf("WorkerSize = %q, want m7n.2xlarge.8 (2vCPU m7n.large.8 must floor to 8vCPU)",
+			dep.Request.WorkerSize)
+	}
+}
+
 // TestCreateDeployment_Huawei_MissingAccessKey_Rejected — defensive
 // check: provider=huawei with NO CATALYST_HUAWEI_ACCESS_KEY env var
 // set (or set but empty) must reject at /api/v1/deployments POST with


### PR DESCRIPTION
## Why
Fresh Huawei (kom4dc) Sovereigns shipped **2vCPU `m7n.large.8` for the control plane AND every worker**. Verified live on **hw182** (dep `b78e8dcd13e6e6d6`): all 6 nodes = 2 vCPU → scheduler `0/6 nodes available: Insufficient cpu` → `bp-catalyst-platform` post-install hook **timed out** → install/uninstall oscillation → **catalyst-ui/api never scheduled** → `console.hw182.omani.works` **404**. Actual CPU usage was 4-28% — it's CPU *requests* exhaustion, not load.

## Root cause
`handler/deployments.go` rewrote only the deprecated `s7n.large.4`/empty → `m7n.xlarge.8`. A `m7n.large.8` (2vCPU) worker request slipped through un-bumped.

## Fix
Enforce a resource **floor** on Huawei provs:
- control-plane ≥ `m7n.xlarge.8` (4vCPU/32GB)
- workers ≥ `m7n.2xlarge.8` (8vCPU/64GB)

Every known-undersized flavor (`s7n.large.4`, `m7n.large.8`, empty; plus `m7n.xlarge.8` for workers) is rewritten up to the floor. Larger explicit flavors are honoured. The `m7n` family is unconstrained in `sku_availability.go`, so the floored flavors pass `IsSkuAvailableInRegion` in every kom4dc region.

## Tests
- `TestCreateDeployment_Huawei_EnforcesResourceFloor` reproduces hw182's exact 2vCPU request and asserts CP→`m7n.xlarge.8`, workers→`m7n.2xlarge.8`.
- `go build`/`go vet` clean; full handler + provisioner suites green.

Refs #4055, #3971

🤖 Generated with [Claude Code](https://claude.com/claude-code)