### PR TITLE
refactor(catalog): rebrand bp-chepherd → bp-agenity (product identity only; runtime preserved)

### DIFF
--- a/.github/workflows/agenity-build.yaml
+++ b/.github/workflows/agenity-build.yaml
@@ -1,6 +1,6 @@
-name: Build bp-chepherd
+name: Build bp-agenity
 
-# Builds the bp-chepherd Application image: the upstream chepherd daemon
+# Builds the bp-agenity Application image: the upstream chepherd daemon
 # image with OpenOva's openova-mcp binary baked in (#4010). The build
 # context is the repo root because the openova-mcp module imports
 # core/services/shared/auth from this repo.
@@ -8,7 +8,7 @@ name: Build bp-chepherd
 on:
   push:
     paths:
-      - 'products/chepherd/**'
+      - 'products/agenity/**'
       - 'products/openova-mcp/**'
       - 'core/services/shared/auth/**'
     branches: [main]
@@ -16,9 +16,9 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE: ghcr.io/openova-io/bp-chepherd
+  IMAGE: ghcr.io/openova-io/bp-agenity
   # Pin the upstream chepherd daemon image the openova-mcp binary overlays.
-  # Digest-pinned to the v0.9.4 build that carries the bp-chepherd MCP seam
+  # Digest-pinned to the v0.9.4 build that carries the bp-agenity MCP seam
   # (chepherd #747 / #4010: CHEPHERD_EXTRA_MCP_JSON + CHEPHERD_DEFAULT_MODEL).
   CHEPHERD_BASE: ghcr.io/chepherd/chepherd:v0.9.4@sha256:b6f0c43b63b8933bfaad8cf09366642e63656d9664887eab20eac26e96d28b82
 
@@ -27,7 +27,7 @@ permissions:
   packages: write
 
 jobs:
-  build-bp-chepherd:
+  build-bp-agenity:
     runs-on: ubuntu-latest
     outputs:
       sha_short: ${{ steps.vars.outputs.sha_short }}
@@ -39,10 +39,10 @@ jobs:
         run: |
           echo "sha_short=$(echo $GITHUB_SHA | head -c 7)" >> "$GITHUB_OUTPUT"
           # The chart's image helper resolves to repository:<Chart.AppVersion>
-          # (chepherd.image in _helpers.tpl), so the published image MUST carry
+          # (agenity.image in _helpers.tpl), so the published image MUST carry
           # that exact tag or the StatefulSet ImagePullBackOffs. Derive it from
           # the chart so the tag can never drift from what the chart references.
-          APPVER=$(grep -E '^appVersion:' products/chepherd/chart/Chart.yaml | head -1 | sed -E 's/appVersion:[[:space:]]*"?([^"]+)"?/\1/')
+          APPVER=$(grep -E '^appVersion:' products/agenity/chart/Chart.yaml | head -1 | sed -E 's/appVersion:[[:space:]]*"?([^"]+)"?/\1/')
           echo "app_version=${APPVER}" >> "$GITHUB_OUTPUT"
 
       - name: Login to GHCR
@@ -56,7 +56,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: products/chepherd/Containerfile
+          file: products/agenity/Containerfile
           build-args: |
             CHEPHERD_BASE=${{ env.CHEPHERD_BASE }}
           push: true

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1052,9 +1052,11 @@ spec:
       #   Jobs so the Kyverno flux-managed (Enforce) policy admits them in
       #   catalyst-system. Pre-1.4.722 the pre-install hook was DENIED →
       #   console install failed pre-install on every Enforce Sovereign (hw172).
-      # 1.4.757 — bp-chepherd Blueprint missing required topology.defaults.multi-region
-      #   aborted the whole catalyst-platform install (console 404, hw182). Fixed.
-      version: 1.4.760
+      # 1.4.757 — bp-chepherd Blueprint (now bp-agenity) missing required
+      #   topology.defaults.multi-region aborted the whole catalyst-platform
+      #   install (console 404, hw182). Fixed.
+      # 1.4.761 — rebrand catalog-seed bp-chepherd → bp-agenity (#4058).
+      version: 1.4.761
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/agenity/Containerfile
+++ b/products/agenity/Containerfile
@@ -1,19 +1,19 @@
-# bp-chepherd image — chepherd runtime + the bundled openova-mcp binary.
+# bp-agenity image — Agenity runtime + the bundled openova-mcp binary.
 #
-# The bp-chepherd Application image is the upstream chepherd daemon image
+# The bp-agenity Application image is the upstream chepherd daemon image
 # with OpenOva's `openova-mcp` server binary baked in at
-# /usr/local/bin/openova-mcp. chepherd injects this MCP server into every
+# /usr/local/bin/openova-mcp. The daemon injects this MCP server into every
 # spawned agent's .mcp.json (via CHEPHERD_EXTRA_MCP_JSON, set by the
-# bp-chepherd Helm chart), so the User's solo agent (Claude Opus 4.7) can
+# bp-agenity Helm chart), so the User's solo agent (Claude Opus 4.7) can
 # create Applications in the User's own Organization through the
 # RBAC-scoped OpenOva MCP.
 #
 # Build context = the repo root (the build needs products/openova-mcp and
 # its go workspace). CHEPHERD_BASE pins the upstream chepherd daemon image.
 #
-#   docker build -f products/chepherd/Containerfile \
+#   docker build -f products/agenity/Containerfile \
 #     --build-arg CHEPHERD_BASE=ghcr.io/chepherd/chepherd:v0.9.4@sha256:b6f0c43b63b8933bfaad8cf09366642e63656d9664887eab20eac26e96d28b82 \
-#     -t ghcr.io/openova-io/bp-chepherd:dev .
+#     -t ghcr.io/openova-io/bp-agenity:dev .
 
 # CHEPHERD_BASE pins the upstream chepherd daemon image overlaid in stage 2.
 # It is declared HERE — before the first FROM — so it lives in the global
@@ -22,7 +22,7 @@
 # this global value (default or --build-arg override) into that stage. An ARG
 # declared only inside stage 2 is NOT visible to its own FROM, which is what
 # caused "base name (${CHEPHERD_BASE}) should not be blank" (UndefinedArgInFrom).
-# Digest-pinned to the v0.9.4 build carrying the bp-chepherd MCP seam
+# Digest-pinned to the v0.9.4 build carrying the bp-agenity MCP seam
 # (chepherd #747 / #4010: CHEPHERD_EXTRA_MCP_JSON + CHEPHERD_DEFAULT_MODEL).
 ARG CHEPHERD_BASE=ghcr.io/chepherd/chepherd:v0.9.4@sha256:b6f0c43b63b8933bfaad8cf09366642e63656d9664887eab20eac26e96d28b82
 
@@ -49,4 +49,4 @@ FROM ${CHEPHERD_BASE}
 COPY --from=mcp-builder /usr/local/bin/openova-mcp /usr/local/bin/openova-mcp
 
 # The chepherd image already defines its ENTRYPOINT (chepherd-entrypoint)
-# and EXPOSEs 8080/9090; bp-chepherd inherits them unchanged.
+# and EXPOSEs 8080/9090; bp-agenity inherits them unchanged.

--- a/products/agenity/README.md
+++ b/products/agenity/README.md
@@ -1,33 +1,39 @@
-# bp-chepherd — chepherd as an OpenOva Application Blueprint (#4010)
+# bp-agenity — Agenity as an OpenOva Application Blueprint (#4010)
 
-**What it is.** [chepherd](https://github.com/chepherd/chepherd) is a
-multi-agent runtime + dashboard. **bp-chepherd** packages it as an
-installable OpenOva **Application Blueprint**: a User installs it into their
-own **Organization** from the catalog, then chats with its built-in **solo
-agent** (Claude Opus 4.7, token pre-configured). The agent reaches the
-**OpenOva MCP** — scoped to exactly what that User can do in the console —
-to **create more Applications in the User's own Organization** on the User's
-behalf.
+**What it is.** **Agenity** is a multi-agent runtime + dashboard, built on the
+upstream [chepherd](https://github.com/chepherd/chepherd) daemon. **bp-agenity**
+packages it as an installable OpenOva **Application Blueprint**: a User installs
+it into their own **Organization** from the catalog, then chats with its
+built-in **solo agent** (Claude Opus 4.7, token pre-configured). The agent
+reaches the **OpenOva MCP** — scoped to exactly what that User can do in the
+console — to **create more Applications in the User's own Organization** on the
+User's behalf.
 
 **Role in Catalyst.** An **Application Blueprint** (not control plane). It
 installs into an Organization's Environment like any other catalog app, and
 is the missing piece of the north-star self-service journey
 ([`docs/ledger/UAT.md`](../../docs/ledger/UAT.md) rows 218–223):
-coupon → Org → passwordless PIN → install chepherd → chat solo-agent →
+coupon → Org → passwordless PIN → install Agenity → chat solo-agent →
 agent creates apps via the MCP.
 
 See [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md) for where Blueprints
 sit in the model and [`docs/GLOSSARY.md`](../../docs/GLOSSARY.md) for the
 Organization / Application / Blueprint canon.
 
+> **Brand vs runtime.** *Agenity* is the OpenOva product/catalog brand. It
+> packages the upstream *chepherd* multi-agent runtime daemon; the daemon's
+> own contract — the `chepherd run` CLI, the `CHEPHERD_*` env vars, the
+> `chepherd` MCP-server namespace — is passed through unchanged so the
+> overlaid image keeps working. Only the product identity is rebranded.
+
 ## The journey this enables (UAT 218–223)
 
 1. A User, signed into their Org (passwordless 6-digit PIN), opens the
-   catalog and installs **Chepherd** (this Helm chart).
+   catalog and installs **Agenity** (this Helm chart).
 2. The Application provisions: a `StatefulSet` running `chepherd run
    --headless`, a `Service`, an `HTTPRoute` at
-   `chepherd.<org>.<sovereign-fqdn>`, CSI-backed PVCs.
-3. The User opens the chepherd console and **chats** with the solo agent —
+   `agenity.<org>.<sovereign-fqdn>`, CSI-backed PVCs.
+3. The User opens the Agenity console and **chats** with the solo agent —
    Claude **Opus 4.7**, whose Anthropic token is already wired from a Secret.
 4. The User asks the agent to "install WordPress in my org". The agent calls
    the **`create_application`** tool on the **openova MCP**, which forwards
@@ -41,8 +47,8 @@ Organization / Application / Blueprint canon.
 
 | Concern | Wiring |
 |---|---|
-| **Model = Claude Opus 4.7** | `agent.model: claude-opus-4-7` → `CHEPHERD_DEFAULT_MODEL` env → chepherd passes `--model claude-opus-4-7` to the spawned `claude-code` (chepherd #4010 default-model fallback). |
-| **Anthropic token (pre-configured)** | `ANTHROPIC_API_KEY` env sourced from the `chepherd-anthropic-token` **Secret** (an `ExternalSecret` pulls `sk-ant-…` from the Org's openbao by default — **never hardcoded**, per Inviolable Principle #4). chepherd seeds its vault `anthropic-api` provider from this env; the agent inherits it at spawn. |
+| **Model = Claude Opus 4.7** | `agent.model: claude-opus-4-7` → `CHEPHERD_DEFAULT_MODEL` env → the runtime passes `--model claude-opus-4-7` to the spawned `claude-code` (chepherd #4010 default-model fallback). |
+| **Anthropic token (pre-configured)** | `ANTHROPIC_API_KEY` env sourced from the `agenity-anthropic-token` **Secret** (an `ExternalSecret` pulls `sk-ant-…` from the Org's openbao by default — **never hardcoded**, per Inviolable Principle #4). The runtime seeds its vault `anthropic-api` provider from this env; the agent inherits it at spawn. |
 | **Solo (no supervisor)** | `agent.solo: true` → `chepherd run --no-shepherd` — a single worker agent the User chats 1:1 with. |
 | **openova MCP** | `CHEPHERD_EXTRA_MCP_JSON` (set by the chart) merges an `openova` MCP-server stanza into **every** spawned agent's `.mcp.json` (chepherd #4010 merge seam), pointing at the bundled `/usr/local/bin/openova-mcp` binary. The MCP holds **no privileged token** — it forwards the caller's session bearer to the live catalyst-api, so the endpoint's own authz is the final word. |
 
@@ -67,18 +73,18 @@ write/mutating MCP tool):
 |---|---|---|
 | `agent.model` | `claude-opus-4-7` | The Claude model the solo agent runs on. |
 | `agent.solo` | `true` | Single solo agent (no shepherd). |
-| `anthropic.secretName` | `chepherd-anthropic-token` | Secret holding `sk-ant-…`. |
+| `anthropic.secretName` | `agenity-anthropic-token` | Secret holding `sk-ant-…`. |
 | `anthropic.externalSecret.enabled` | `true` | Pull the token from openbao via ESO; set `false` to pre-create the Secret out-of-band. |
 | `openovaMCP.enabled` | `true` | Inject the openova MCP into spawned agents. |
 | `openovaMCP.context` | `organization` | Pins the MCP to the User's Org (defense in depth). |
-| `persistence.state.size` | `5Gi` | chepherd runtime-state PVC (CSI default class — **local-path forbidden**, #3971). |
+| `persistence.state.size` | `5Gi` | Agenity runtime-state PVC (CSI default class — **local-path forbidden**, #3971). |
 
 ## Image
 
-`ghcr.io/openova-io/bp-chepherd` is the **upstream chepherd daemon image**
+`ghcr.io/openova-io/bp-agenity` is the **upstream chepherd daemon image**
 with the **`openova-mcp`** binary baked in at `/usr/local/bin/openova-mcp`
 (see [`Containerfile`](Containerfile) + the
-[`chepherd-build.yaml`](../../.github/workflows/chepherd-build.yaml) workflow).
+[`agenity-build.yaml`](../../.github/workflows/agenity-build.yaml) workflow).
 The build context is the repo root because the openova-mcp module imports
 `core/services/shared/auth` from this repo. `CHEPHERD_BASE` pins the upstream
 chepherd daemon image the binary overlays.
@@ -87,21 +93,21 @@ chepherd daemon image the binary overlays.
 
 - **Storage**: state + per-agent repo PVCs use the cluster's **default CSI
   StorageClass** (leave `storageClass` empty). Never local-path (#3971).
-- **Backups**: the chepherd state PVC holds session history + the credential
+- **Backups**: the Agenity state PVC holds session history + the credential
   vault; back it up with the Org's standard PVC backup policy.
-- **Multi-region**: single-region `singleton` only — chepherd is a
+- **Multi-region**: single-region `singleton` only — Agenity is a
   per-Org control surface, not a replicated data plane.
-- **Auth**: the chepherd console is reached via the Cilium Gateway HTTPRoute
+- **Auth**: the Agenity console is reached via the Cilium Gateway HTTPRoute
   with the Org's Keycloak SSO (silent login). The agent presents the User's
   session bearer to the openova MCP on each `tools/call`.
 
 ## What the fresh-prov walk should see
 
 The full live e2e walk runs in the orchestrator's wipe → prov → walk loop.
-On a fresh prov, after a User installs bp-chepherd:
+On a fresh prov, after a User installs bp-agenity:
 
-1. `kubectl -n <org>-prod get statefulset,svc,httproute,externalsecret -l catalyst.openova.io/blueprint=bp-chepherd` → all present; the StatefulSet pod becomes `Ready` (`/healthz` 200).
-2. The chepherd pod env carries `CHEPHERD_DEFAULT_MODEL=claude-opus-4-7`, `ANTHROPIC_API_KEY` (from the Secret), and `CHEPHERD_EXTRA_MCP_JSON` with the `openova` server stanza.
-3. The chepherd console loads at `chepherd.<org>.<sovereign-fqdn>` (SSO).
-4. Spawning the solo agent → its `.mcp.json` lists **both** `chepherd` and `openova` MCP servers, and the agent was launched with `--model claude-opus-4-7`.
+1. `kubectl -n <org>-prod get statefulset,svc,httproute,externalsecret -l catalyst.openova.io/blueprint=bp-agenity` → all present; the StatefulSet pod becomes `Ready` (`/healthz` 200).
+2. The Agenity pod env carries `CHEPHERD_DEFAULT_MODEL=claude-opus-4-7`, `ANTHROPIC_API_KEY` (from the Secret), and `CHEPHERD_EXTRA_MCP_JSON` with the `openova` server stanza.
+3. The Agenity console loads at `agenity.<org>.<sovereign-fqdn>` (SSO).
+4. Spawning the solo agent → its `.mcp.json` lists **both** the `chepherd` runtime MCP and the `openova` MCP servers, and the agent was launched with `--model claude-opus-4-7`.
 5. Asking the agent to install an app → a new `Application` CR appears in the User's Org namespace, created via the openova MCP `create_application` tool (tier-admin-gated, Org-pinned).

--- a/products/agenity/blueprint.yaml
+++ b/products/agenity/blueprint.yaml
@@ -1,25 +1,25 @@
 apiVersion: catalyst.openova.io/v1alpha1
 kind: Blueprint
 metadata:
-  name: bp-chepherd
+  name: bp-agenity
   labels:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
   version: 0.1.0
   card:
-    title: Chepherd
+    title: Agenity
     summary: |
       Your AI engineering team — a multi-agent runtime + dashboard you
       install into your own Organization. Chat with the built-in solo
       agent (Claude Opus 4.7, token pre-configured); it creates and
       manages Applications in YOUR Organization on your behalf through the
       OpenOva MCP, scoped to exactly what you can do in the console.
-    icon: chepherd.svg
+    icon: agenity.svg
     category: ai-runtime
     family: agent-runtime
-    tags: [chepherd, agent, multi-agent, claude, opus, mcp, self-service]
-    documentation: https://github.com/chepherd/chepherd
+    tags: [agenity, agent, multi-agent, claude, opus, mcp, self-service]
+    documentation: https://github.com/openova-io/openova
     license: MIT
   visibility: listed
   owner:
@@ -60,7 +60,7 @@ spec:
         properties:
           secretName:
             type: string
-            default: chepherd-anthropic-token
+            default: agenity-anthropic-token
           externalSecret:
             type: object
             properties:
@@ -102,7 +102,7 @@ spec:
                 type: string
                 default: 5Gi
             description: |
-              chepherd runtime state PVC. Backed by the cluster's default
+              Agenity runtime state PVC. Backed by the cluster's default
               CSI StorageClass — local-path is forbidden (#3971).
   placementSchema:
     modes: [single-region]
@@ -122,7 +122,7 @@ spec:
     supported:
       - singleton
     defaults:
-      # chepherd is a region-pinned singleton coordinator/agent console — it
+      # Agenity is a region-pinned singleton coordinator/agent console — it
       # does not replicate across regions, so both BCP defaults resolve to the
       # single in-region instance (schema requires both keys; G116).
       multi-region: singleton
@@ -137,7 +137,7 @@ spec:
             rtz-A: singleton
   endpoints:
     - name: console
-      hostnameTemplate: chepherd.{{.OrgSlug}}.{{.SovereignFQDN}}
+      hostnameTemplate: agenity.{{.OrgSlug}}.{{.SovereignFQDN}}
       port: 443
       protocol: https
       tls: true

--- a/products/agenity/chart/Chart.yaml
+++ b/products/agenity/chart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-name: bp-chepherd
+name: bp-agenity
 description: |
-  Chepherd — multi-agent runtime + dashboard, packaged as an installable
-  OpenOva Application Blueprint. A User installs chepherd into their own
+  Agenity — multi-agent runtime + dashboard, packaged as an installable
+  OpenOva Application Blueprint. A User installs Agenity into their own
   Organization from the catalog, then chats with its solo agent (Claude
   Opus 4.7, token pre-configured). The agent reaches the openova MCP server
   (RBAC-scoped to the User's rights) to create more Applications in the
@@ -11,7 +11,7 @@ type: application
 version: 0.1.0
 appVersion: "0.9.4"
 keywords:
-  - chepherd
+  - agenity
   - agent-runtime
   - multi-agent
   - solo-agent
@@ -20,10 +20,13 @@ maintainers:
   - name: OpenOva
     url: https://github.com/openova-io/openova
 sources:
+  # Upstream multi-agent daemon image overlaid by this Blueprint (runtime
+  # base — see Containerfile CHEPHERD_BASE). The Agenity brand is OpenOva's;
+  # the runtime daemon it packages is the upstream project below.
   - https://github.com/chepherd/chepherd
   - https://github.com/openova-io/openova
 # Opt out of the hollow-chart guard (Blueprint-Release workflow / issue #181):
-# this is a product chart deploying a single upstream image (chepherd) with
+# this is a product chart deploying a single upstream daemon image with
 # Catalyst-authored resources (StatefulSet + Service + HTTPRoute + MCP
 # ConfigMap + ExternalSecret). No bundled upstream Helm subchart — same
 # shape as products/axon (PR), bp-continuum, bp-kyverno-policies.

--- a/products/agenity/chart/templates/_helpers.tpl
+++ b/products/agenity/chart/templates/_helpers.tpl
@@ -1,10 +1,10 @@
 {{/* chart name */}}
-{{- define "chepherd.name" -}}
+{{- define "agenity.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/* fully-qualified name */}}
-{{- define "chepherd.fullname" -}}
+{{- define "agenity.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- if contains $name .Release.Name -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
@@ -14,21 +14,21 @@
 {{- end -}}
 
 {{/* common labels */}}
-{{- define "chepherd.labels" -}}
-app.kubernetes.io/name: {{ include "chepherd.name" . }}
+{{- define "agenity.labels" -}}
+app.kubernetes.io/name: {{ include "agenity.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-catalyst.openova.io/blueprint: bp-chepherd
+catalyst.openova.io/blueprint: bp-agenity
 {{- end -}}
 
 {{/* selector labels */}}
-{{- define "chepherd.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "chepherd.name" . }}
+{{- define "agenity.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "agenity.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{/* image ref */}}
-{{- define "chepherd.image" -}}
+{{- define "agenity.image" -}}
 {{- printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) -}}
 {{- end -}}

--- a/products/agenity/chart/templates/externalsecret-anthropic.yaml
+++ b/products/agenity/chart/templates/externalsecret-anthropic.yaml
@@ -13,7 +13,7 @@ kind: ExternalSecret
 metadata:
   name: {{ .Values.anthropic.secretName }}
   labels:
-    {{- include "chepherd.labels" . | nindent 4 }}
+    {{- include "agenity.labels" . | nindent 4 }}
 spec:
   refreshInterval: {{ .Values.anthropic.externalSecret.refreshInterval }}
   secretStoreRef:

--- a/products/agenity/chart/templates/httproute.yaml
+++ b/products/agenity/chart/templates/httproute.yaml
@@ -2,9 +2,9 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: {{ include "chepherd.fullname" . }}
+  name: {{ include "agenity.fullname" . }}
   labels:
-    {{- include "chepherd.labels" . | nindent 4 }}
+    {{- include "agenity.labels" . | nindent 4 }}
 spec:
   parentRefs:
     - name: {{ .Values.httpRoute.parentRef.name }}
@@ -19,6 +19,6 @@ spec:
             type: PathPrefix
             value: /
       backendRefs:
-        - name: {{ include "chepherd.fullname" . }}
+        - name: {{ include "agenity.fullname" . }}
           port: {{ .Values.service.port }}
 {{- end }}

--- a/products/agenity/chart/templates/service.yaml
+++ b/products/agenity/chart/templates/service.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "chepherd.fullname" . }}
+  name: {{ include "agenity.fullname" . }}
   labels:
-    {{- include "chepherd.labels" . | nindent 4 }}
+    {{- include "agenity.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   selector:
-    {{- include "chepherd.selectorLabels" . | nindent 4 }}
+    {{- include "agenity.selectorLabels" . | nindent 4 }}
   ports:
     - name: http
       port: {{ .Values.service.port }}

--- a/products/agenity/chart/templates/statefulset.yaml
+++ b/products/agenity/chart/templates/statefulset.yaml
@@ -1,19 +1,19 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "chepherd.fullname" . }}
+  name: {{ include "agenity.fullname" . }}
   labels:
-    {{- include "chepherd.labels" . | nindent 4 }}
+    {{- include "agenity.labels" . | nindent 4 }}
 spec:
-  serviceName: {{ include "chepherd.fullname" . }}
+  serviceName: {{ include "agenity.fullname" . }}
   replicas: 1
   selector:
     matchLabels:
-      {{- include "chepherd.selectorLabels" . | nindent 6 }}
+      {{- include "agenity.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "chepherd.selectorLabels" . | nindent 8 }}
+        {{- include "agenity.selectorLabels" . | nindent 8 }}
       {{- with .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
@@ -37,7 +37,7 @@ spec:
       {{- end }}
       containers:
         - name: chepherd
-          image: {{ include "chepherd.image" . }}
+          image: {{ include "agenity.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - run

--- a/products/agenity/chart/values.yaml
+++ b/products/agenity/chart/values.yaml
@@ -1,17 +1,21 @@
-# bp-chepherd — default values
+# bp-agenity — default values
 #
-# Deploys chepherd as an OpenOva Application into a User's Organization /
+# Deploys Agenity as an OpenOva Application into a User's Organization /
 # Environment. The User installs this from the catalog; its solo agent
 # (Claude Opus 4.7) then creates more Applications in the User's own Org
 # via the RBAC-scoped openova MCP server.
 #
+# Agenity packages the upstream chepherd multi-agent runtime daemon; the
+# runtime env-var names (CHEPHERD_*) + CLI (`chepherd run`) below are the
+# daemon's own contract and are passed through unchanged.
+#
 # Inviolable Principle #4: no hardcoded secrets/config in code — every knob
-# flows through values → env → the chepherd binary; the Anthropic token
+# flows through values → env → the runtime daemon; the Anthropic token
 # comes from a Secret (ExternalSecret/openbao), NEVER a literal here.
 
-# ── chepherd runtime image ────────────────────────────────────────────────
+# ── Agenity runtime image (upstream chepherd daemon + openova-mcp) ─────────
 image:
-  repository: ghcr.io/openova-io/bp-chepherd
+  repository: ghcr.io/openova-io/bp-agenity
   tag: ""                 # defaults to .Chart.AppVersion
   pullPolicy: IfNotPresent
 
@@ -39,7 +43,7 @@ agent:
 #   externalSecret.enabled=false: the operator pre-creates a Secret named
 #     `secretName` with key `anthropicApiKey` out-of-band (e.g. sealed-secret).
 anthropic:
-  secretName: chepherd-anthropic-token
+  secretName: agenity-anthropic-token
   secretKey: anthropicApiKey
   externalSecret:
     enabled: true
@@ -80,13 +84,13 @@ openovaMCP:
     name: catalyst-handover-jwt
     key: handover-jwt-public.pem
 
-# ── Service (chepherd web UI + dashboard WS + MCP) ────────────────────────
+# ── Service (Agenity web UI + dashboard WS + MCP) ─────────────────────────
 service:
   type: ClusterIP
-  port: 8080            # chepherd web UI + dashboard WS + MCP HTTP
+  port: 8080            # Agenity web UI + dashboard WS + MCP HTTP
   metricsPort: 9090     # Prometheus scrape
 
-# ── HTTPRoute (Cilium Gateway) — the User reaches the chepherd console ─────
+# ── HTTPRoute (Cilium Gateway) — the User reaches the Agenity console ──────
 httpRoute:
   enabled: true
   hostnames: []         # default: discovered from the Org/Sovereign FQDN

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,6 +1,48 @@
 {
-  "generatedAt": "2026-06-21T07:17:19.566Z",
+  "generatedAt": "2026-06-21T16:38:23.254Z",
   "blueprints": [
+    {
+      "id": "bp-agenity",
+      "slug": "agenity",
+      "title": "Agenity",
+      "summary": "|",
+      "icon": "agenity.svg",
+      "category": "ai-runtime",
+      "tagline": null,
+      "tags": [],
+      "visibility": "listed",
+      "version": "0.1.0",
+      "section": "pts-7-org-tenant",
+      "depends": [
+        "bp-external-secrets"
+      ],
+      "shareable": false,
+      "contextSchema": null,
+      "producesInstances": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      },
+      "hasUserUIEndpoint": true
+    },
     {
       "id": "bp-alloy",
       "slug": "alloy",
@@ -470,48 +512,6 @@
         }
       },
       "hasUserUIEndpoint": false
-    },
-    {
-      "id": "bp-chepherd",
-      "slug": "chepherd",
-      "title": "Chepherd",
-      "summary": "|",
-      "icon": "chepherd.svg",
-      "category": "ai-runtime",
-      "tagline": null,
-      "tags": [],
-      "visibility": "listed",
-      "version": "0.1.0",
-      "section": "pts-7-org-tenant",
-      "depends": [
-        "bp-external-secrets"
-      ],
-      "shareable": false,
-      "contextSchema": null,
-      "producesInstances": null,
-      "topology": {
-        "supported": [
-          "singleton"
-        ],
-        "multiRegion": "singleton",
-        "singleRegion": "singleton",
-        "perTopology": {
-          "singleton": {
-            "replication": null,
-            "switchover": null,
-            "placement": {
-              "tier": "rtz",
-              "clusters": [
-                "rtz-A"
-              ],
-              "roles": {
-                "rtz-A": "singleton"
-              }
-            }
-          }
-        }
-      },
-      "hasUserUIEndpoint": true
     },
     {
       "id": "bp-cilium",

--- a/products/catalyst/bootstrap/api/internal/handler/console_ui.go
+++ b/products/catalyst/bootstrap/api/internal/handler/console_ui.go
@@ -16,7 +16,7 @@
 //
 //	{
 //	  "entries": [
-//	    { "id": "bp-chepherd", "label": "Chepherd", "route": "/apps/bp-chepherd/dashboard", "order": 50, "icon": "<svg-path>" },
+//	    { "id": "bp-agenity", "label": "Agenity", "route": "/apps/bp-agenity/dashboard", "order": 50, "icon": "<svg-path>" },
 //	    ...
 //	  ]
 //	}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/sandbox/SandboxLanding.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/sandbox/SandboxLanding.tsx
@@ -54,18 +54,18 @@ export function SandboxLanding({
   const { deploymentId: resolvedId } = useResolvedDeploymentId()
   const deploymentId = resolvedId ?? ''
 
-  // Wave 5.71 (chepherd lift, #2316) — when bp-chepherd is installed
-  // on the Sovereign AND build-time env CATALYST_SANDBOX_REDIRECT_TO_CHEPHERD
-  // is "true", the /sandbox route 302s to /apps/bp-chepherd/dashboard.
-  // chepherd-side replaces the openova-native Sandbox surface; this
+  // Wave 5.71 (Agenity lift, #2316) — when bp-agenity is installed
+  // on the Sovereign AND build-time env CATALYST_SANDBOX_REDIRECT_TO_AGENITY
+  // is "true", the /sandbox route 302s to /apps/bp-agenity/dashboard.
+  // Agenity replaces the openova-native Sandbox surface; this
   // single-line redirect avoids dual UX during the lift transition.
   // Operator can disable per-Sovereign via env override (Inviolable
   // Principle #4 — every knob operator-tunable).
-  const redirectToChepherd =
+  const redirectToAgenity =
     typeof import.meta !== 'undefined' &&
-    (import.meta as { env?: Record<string, string> }).env?.VITE_SANDBOX_REDIRECT_TO_CHEPHERD === 'true'
-  if (redirectToChepherd && typeof window !== 'undefined') {
-    window.location.replace('/apps/bp-chepherd/dashboard')
+    (import.meta as { env?: Record<string, string> }).env?.VITE_SANDBOX_REDIRECT_TO_AGENITY === 'true'
+  if (redirectToAgenity && typeof window !== 'undefined') {
+    window.location.replace('/apps/bp-agenity/dashboard')
     return null
   }
 

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -137,6 +137,48 @@ export interface BlueprintTopologyVariant {
  */
 export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
   {
+    "id": "bp-agenity",
+    "slug": "agenity",
+    "title": "Agenity",
+    "summary": "|",
+    "icon": "agenity.svg",
+    "category": "ai-runtime",
+    "tagline": null,
+    "tags": [],
+    "visibility": "listed",
+    "version": "0.1.0",
+    "section": "pts-7-org-tenant",
+    "depends": [
+      "bp-external-secrets"
+    ],
+    "shareable": false,
+    "contextSchema": null,
+    "producesInstances": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    },
+    "hasUserUIEndpoint": true
+  },
+  {
     "id": "bp-alloy",
     "slug": "alloy",
     "title": "Alloy",
@@ -605,48 +647,6 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       }
     },
     "hasUserUIEndpoint": false
-  },
-  {
-    "id": "bp-chepherd",
-    "slug": "chepherd",
-    "title": "Chepherd",
-    "summary": "|",
-    "icon": "chepherd.svg",
-    "category": "ai-runtime",
-    "tagline": null,
-    "tags": [],
-    "visibility": "listed",
-    "version": "0.1.0",
-    "section": "pts-7-org-tenant",
-    "depends": [
-      "bp-external-secrets"
-    ],
-    "shareable": false,
-    "contextSchema": null,
-    "producesInstances": null,
-    "topology": {
-      "supported": [
-        "singleton"
-      ],
-      "multiRegion": "singleton",
-      "singleRegion": "singleton",
-      "perTopology": {
-        "singleton": {
-          "replication": null,
-          "switchover": null,
-          "placement": {
-            "tier": "rtz",
-            "clusters": [
-              "rtz-A"
-            ],
-            "roles": {
-              "rtz-A": "singleton"
-            }
-          }
-        }
-      }
-    },
-    "hasUserUIEndpoint": true
   },
   {
     "id": "bp-cilium",
@@ -5736,6 +5736,7 @@ export const TOPOLOGY_BY_ID: Readonly<Record<string, BlueprintTopology>> = Objec
 
 /** Source files this catalog was built from (for diagnostics / CI logs). */
 export const PLATFORM_BLUEPRINT_FILES: readonly string[] = [
+  "platform/agenity/blueprint.yaml",
   "platform/alloy/blueprint.yaml",
   "platform/anthropic-adapter/blueprint.yaml",
   "platform/bge/blueprint.yaml",
@@ -5744,7 +5745,6 @@ export const PLATFORM_BLUEPRINT_FILES: readonly string[] = [
   "platform/cert-manager-issuers/blueprint.yaml",
   "platform/cert-manager-powerdns-webhook/blueprint.yaml",
   "platform/cert-manager/blueprint.yaml",
-  "platform/chepherd/blueprint.yaml",
   "platform/cilium-policies/blueprint.yaml",
   "platform/cilium/blueprint.yaml",
   "platform/clickhouse/blueprint.yaml",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2931,9 +2931,12 @@ name: bp-catalyst-platform
 #   clusters name an explicit per-provider storageClass so their PVCs never freeze
 #   "" before the default StorageClass lands (hw174: 3 PVCs stuck Pending<empty>).
 #   (renumbered 1.4.747→1.4.749, one above main's deploy-bot 1.4.748, to clear the pin collision.)
-# 1.4.757 — bp-chepherd Blueprint missing required topology.defaults.multi-region → whole
-#   catalyst-platform install aborted (console 404 on every fresh prov). Add multi-region: singleton.
-version: 1.4.760
+# 1.4.757 — bp-chepherd Blueprint (now bp-agenity) missing required topology.defaults.multi-region →
+#   whole catalyst-platform install aborted (console 404 on every fresh prov). Add multi-region: singleton.
+# 1.4.761 — rebrand catalog-seed bp-chepherd → bp-agenity (#4058): metadata.name, card (title/desc/
+#   tags/icon/docs), manifests.chart + source.chart bp-agenity, endpoint hostname agenity.<org>.<fqdn>.
+#   topology.defaults KEEPS BOTH multi-region: singleton + single-region: singleton (#4051 preserved).
+version: 1.4.761
 # 1.4.702 — #3819 #3854 #3859 (Refs #3383 #3376): sme→org-services rename TAIL — the
 #   funnel/BSS control-plane templates + values default the namespace to `org-services`
 #   instead of the dead `sme` ns: provisioning-github-token / valkey-cross-ns-secret +

--- a/products/catalyst/chart/crds/blueprint.yaml
+++ b/products/catalyst/chart/crds/blueprint.yaml
@@ -128,7 +128,7 @@ spec:
                   type: object
                   description: |
                     Wave 5.69 (#2370) — Sovereign-console UI registration
-                    contract for third-party Blueprints (bp-chepherd is
+                    contract for third-party Blueprints (bp-agenity is
                     the first consumer; see docs/INTEGRATION-OPENOVA-MCP.md
                     §5). When sidebarEntry=true the SovereignSidebar.tsx
                     appends a nav entry between the hardcoded last entry
@@ -144,7 +144,7 @@ spec:
                       description: Display label (operator-overridable per Sovereign overlay).
                     sidebarRoute:
                       type: string
-                      description: Route path the nav link navigates to (e.g. /apps/bp-chepherd/dashboard).
+                      description: Route path the nav link navigates to (e.g. /apps/bp-agenity/dashboard).
                     sidebarOrder:
                       type: integer
                       minimum: 0

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -6467,17 +6467,17 @@ spec:
     namingTemplate: "{{ "{{" }}.AppName{{ "}}" }}-{{ "{{" }}.InstanceID{{ "}}" }}"
     isolationLevel: namespace
 ---
-# bp-chepherd (#4010) — chepherd as an installable Application Blueprint.
+# bp-agenity (#4010) — Agenity as an installable Application Blueprint.
 # A User installs this into their own Organization from the catalog, chats
 # with the built-in solo agent (Claude Opus 4.7, token pre-configured), and
 # the agent creates more Applications in the User's Org via the RBAC-scoped
 # openova MCP. The north-star self-service journey (UAT rows 218-223).
-# Lockstep with products/chepherd/blueprint.yaml spec.version 0.1.0 + the
-# published chart ghcr.io/openova-io/bp-chepherd:0.1.0.
+# Lockstep with products/agenity/blueprint.yaml spec.version 0.1.0 + the
+# published chart ghcr.io/openova-io/bp-agenity:0.1.0.
 apiVersion: catalyst.openova.io/v1
 kind: Blueprint
 metadata:
-  name: bp-chepherd
+  name: bp-agenity
   labels:
     catalyst.openova.io/managed-by: catalog-seed
     catalyst.openova.io/origin: openova-public
@@ -6492,25 +6492,25 @@ spec:
   version: "0.1.0"
   visibility: listed
   card:
-    title: "Chepherd"
+    title: "Agenity"
     category: ai-runtime
     family: agent-runtime
     summary: "Your AI engineering team — chat with a built-in solo agent (Claude Opus 4.7) that creates Applications in your Organization for you."
-    description: "Install chepherd into your Organization and chat with its solo agent (Claude Opus 4.7, token pre-configured). The agent reaches the OpenOva MCP — scoped to exactly what you can do in the console — to create and manage Applications in YOUR Organization on your behalf."
-    icon: chepherd.svg
+    description: "Install Agenity into your Organization and chat with its solo agent (Claude Opus 4.7, token pre-configured). The agent reaches the OpenOva MCP — scoped to exactly what you can do in the console — to create and manage Applications in YOUR Organization on your behalf."
+    icon: agenity.svg
     license: "MIT"
-    tags: [chepherd, agent, multi-agent, claude, opus, mcp, self-service]
-    docs: "https://github.com/chepherd/chepherd"
+    tags: [agenity, agent, multi-agent, claude, opus, mcp, self-service]
+    docs: "https://github.com/openova-io/openova"
   placementSchema:
     modes: [single-region]
     default: single-region
   manifests:
-    chart: bp-chepherd
+    chart: bp-agenity
   source:
     kind: HelmRepository
     type: oci
     url: oci://ghcr.io/openova-io
-    chart: bp-chepherd
+    chart: bp-agenity
     version: 0.1.0
   topology:
     supported:
@@ -6527,7 +6527,7 @@ spec:
             rtz-A: singleton
   endpoints:
     - name: console
-      hostnameTemplate: "chepherd.{{ "{{" }}.OrgSlug{{ "}}" }}.{{ "{{" }}.SovereignFQDN{{ "}}" }}"
+      hostnameTemplate: "agenity.{{ "{{" }}.OrgSlug{{ "}}" }}.{{ "{{" }}.SovereignFQDN{{ "}}" }}"
       port: 443
       protocol: https
       tls: true

--- a/products/openova-mcp/README.md
+++ b/products/openova-mcp/README.md
@@ -91,7 +91,7 @@ See the walk evidence on issue #3988.
 Per #3988 §5, the following are explicitly out of this slice and tracked as
 follow-ups:
 
-- **chepherd integration** — the `bp-openova-mcp dependsOn bp-chepherd`
+- **Agenity integration** — the `bp-openova-mcp dependsOn bp-agenity`
   Blueprint chart, the `openovaMCP.*` repoint, the `.mcp.json` injection.
 - **HTTP/SSE transport** — this slice uses stdio; the long-lived
   per-Org/per-Sovereign Service needs streamable-HTTP/SSE + stable DNS.


### PR DESCRIPTION
Refs #4058 #4010 #4051

## What

Rebrands the catalog Blueprint/product **bp-chepherd → bp-agenity** everywhere it is a **product/brand** identity, in ONE clean PR off `main`. The internal orchestration **runtime/daemon** (env-var names, the upstream daemon image, CLI, paths, MCP namespace) is deliberately **preserved** — renaming an identifier the running image consumes would break the seam.

## Files (20)

**Folder rename `products/chepherd/` → `products/agenity/` (git mv):**
- `blueprint.yaml` — `name: bp-agenity`, card (title `Agenity` / summary / `icon: agenity.svg` / tags / docs), `hostnameTemplate: agenity.<org>.<fqdn>`, `anthropic.secretName: agenity-anthropic-token`. **#4051 `topology.defaults` PRESERVED** (both `single-region: singleton` + `multi-region: singleton`).
- `chart/Chart.yaml` — `name: bp-agenity`, description/keywords/sources rebranded (appVersion `0.9.4` kept — upstream daemon version).
- `chart/values.yaml` — `image.repository: ghcr.io/openova-io/bp-agenity`, `anthropic.secretName: agenity-anthropic-token`, brand prose.
- `chart/templates/_helpers.tpl` — helper namespace `chepherd.* → agenity.*`, blueprint label `bp-agenity`.
- `chart/templates/{service,httproute,externalsecret-anthropic,statefulset}.yaml` — helper-include renames.
- `Containerfile`, `README.md` — brand rebrand.

**Catalog + control plane:**
- `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` — bp-agenity entry; **#4051 topology.defaults intact**.
- `products/catalyst/bootstrap/api/internal/catalog/blueprints.json` + `…/ui/src/shared/constants/catalog.generated.ts` — **regenerated** via `build-catalog.mjs` (derives slug from folder name).
- `products/catalyst/bootstrap/api/internal/handler/console_ui.go` — doc-comment example.
- `products/catalyst/bootstrap/ui/src/pages/sovereign/sandbox/SandboxLanding.tsx` — `/apps/bp-agenity/dashboard` route + `VITE_SANDBOX_REDIRECT_TO_AGENITY` (the flag is read ONLY here, set nowhere else — safe self-contained rename).
- `products/catalyst/chart/crds/blueprint.yaml` — doc-example references.
- `products/openova-mcp/README.md` — `dependsOn bp-agenity`.
- `.github/workflows/chepherd-build.yaml → agenity-build.yaml` — `IMAGE: ghcr.io/openova-io/bp-agenity`, paths `products/agenity/**`.
- `products/catalyst/chart/Chart.yaml` 1.4.760 → **1.4.761** + `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` pin **lockstep**.

## Runtime internals deliberately LEFT alone (ambiguous runtime vs brand)

These describe / are consumed by the upstream chepherd daemon — renaming without rebuilding the runtime image would regress:
- Env-var **names**: `CHEPHERD_DEFAULT_MODEL`, `CHEPHERD_DEFAULT_SYSTEM_PROMPT`, `CHEPHERD_EXTRA_MCP_JSON`, `CHEPHERD_STATE_DIR`.
- Paths `/var/chepherd/state`, `/var/chepherd/repo`; CLI `chepherd run --headless --no-shepherd`; pod container `name: chepherd`.
- `CHEPHERD_BASE` build-arg + upstream image `ghcr.io/chepherd/chepherd:v0.9.4@sha256:…`.
- The `chepherd` MCP-server namespace the daemon registers.
- `.gitignore` "Chepherd scheduler lock" (`.claude/scheduled_tasks.lock`).
- `cmd/api/{main.go,exec_stream_wire.go}` "chepherd reference implementation" pattern comments.

## Follow-up PR (not a product chart)

- `docs/INTEGRATION-OPENOVA-MCP.md` (chepherd-runtime integration spec, densely runtime-flavored: `chepherd-system` ns, `chepherd.*` tools, the chepherd team).
- Cron-refreshed ledger: `docs/ledger/UAT.md` rows 218-223, `TRACKER.md`, `uat-walkthrough/e2e-chepherd-journey.md` — these track the live journey + are auto-refreshed; renaming the `bp-chepherd` id there is a follow-up.
- `.claude/templates/`, `docs/sessions/templates/`, `docs/archive/` — historical / template docs.

## In-flight branches needing rebase

`feat/4010-bp-chepherd`, `docs/3988-chepherd-e2e-walkthrough` (bp-chepherd as an installable Application + MCP) will need rebasing onto this rename.

## Validation

- `helm template products/agenity/chart` + `helm lint` — render clean (runtime env/paths/CLI preserved, `bp-agenity` labels/image/Secret).
- catalog-seed renders the `bp-agenity` Blueprint with **both topology defaults singleton** (#4051 confirmed).
- `go build ./...` + `go vet ./...` + `go test` (bootstrap api) — green.
- `tsc -b --noEmit` (UI) — green. (Pre-existing vitest failures on `main` are unrelated — StepComponents/PinInput6/etc. fail identically on `origin/main`; my rename adds zero new failures.)
- `scripts/check-bootstrap-kit-pin-sync.sh` — `bp-catalyst-platform 1.4.761 pin=1.4.761 OK`. (2 pre-existing `bp-newapi` pin drifts on `main` are unrelated to this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
