### PR TITLE
fix(bp-catalyst-platform): permanent Sovereign no longer auto-fires sovereignty-cutover on handover (1.4.761)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1054,7 +1054,11 @@ spec:
       #   console install failed pre-install on every Enforce Sovereign (hw172).
       # 1.4.757 — bp-chepherd Blueprint missing required topology.defaults.multi-region
       #   aborted the whole catalyst-platform install (console 404, hw182). Fixed.
-      version: 1.4.760
+      # 1.4.761 — #4061: child catalyst-api no longer auto-fires the
+      #   self-sovereignty cutover on handover (CATALYST_FIRE_CUTOVER_ON_HANDOVER
+      #   now defaults false via catalystApi.fireCutoverOnHandover). Cutover is a
+      #   DELIBERATE BSS-menu action; operator-initiated path unchanged.
+      version: 1.4.761
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,19 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.761 — #4061 (2026-06-22): stop a PERMANENT Sovereign from auto-firing the
+# self-sovereignty cutover the moment the mothership completes handover. The
+# child catalyst-api's ReceiveTofuArchive (handover.go) seals the
+# tofu-phase0-archive THEN fires the cutover engine with source="handover",
+# which the require-handover gate (cutover_internal.go) deliberately EXEMPTS —
+# and the in-code env default CATALYST_FIRE_CUTOVER_ON_HANDOVER is TRUE and was
+# set NOWHERE in any chart. Result: a converged customer-facing Sovereign
+# auto-entered the finite 8-step cutover (incl the 10-min deny-egress
+# NetworkPolicy hold) UNATTENDED. New knob `catalystApi.fireCutoverOnHandover`
+# (default false) wires CATALYST_FIRE_CUTOVER_ON_HANDOVER=false into the child
+# catalyst-api on Sovereign installs, making cutover a DELIBERATE BSS-menu
+# action ("Achieve True Sovereignty", source="operator"). NO-REGRESS: the
+# operator/BSS-initiated cutover is untouched and still fires; a throwaway test
+# prov sets fireCutoverOnHandover=true to drive the full unattended walk.
 # 1.4.722 — #3946 (Refs #3296 #3297 #3201, 2026-06-20): unblock console install
 # on every Sovereign where the Kyverno `flux-managed` ClusterPolicy is Enforce.
 # The `catalyst-gitea-token-mint` pre-install hook Job is created directly by
@@ -2933,7 +2947,7 @@ name: bp-catalyst-platform
 #   (renumbered 1.4.747→1.4.749, one above main's deploy-bot 1.4.748, to clear the pin collision.)
 # 1.4.757 — bp-chepherd Blueprint missing required topology.defaults.multi-region → whole
 #   catalyst-platform install aborted (console 404 on every fresh prov). Add multi-region: singleton.
-version: 1.4.760
+version: 1.4.761
 # 1.4.702 — #3819 #3854 #3859 (Refs #3383 #3376): sme→org-services rename TAIL — the
 #   funnel/BSS control-plane templates + values default the namespace to `org-services`
 #   instead of the dead `sme` ns: provisioning-github-token / valkey-cross-ns-secret +

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -940,6 +940,30 @@ spec:
             # token at rest. Sovereign-only (empty on Catalyst-Zero).
             - name: CATALYST_OPENBAO_K8S_AUTH_ROLE
               value: '{{ if .Values.global.sovereignFQDN }}{{ .Values.catalystApi.openbaoK8sAuthRole | default "catalyst-api" }}{{ end }}'
+            # CATALYST_FIRE_CUTOVER_ON_HANDOVER (#4061) — gates whether the
+            # child catalyst-api auto-fires the self-sovereignty cutover engine
+            # the instant the mothership completes handover. ReceiveTofuArchive
+            # (handover.go) seals the tofu-phase0-archive THEN fires the engine
+            # with source="handover", which the require-handover gate
+            # (cutover_internal.go) deliberately EXEMPTS — so without this env
+            # the in-code default TRUE makes a converged, permanent Sovereign
+            # auto-enter the finite 8-step cutover (incl the 10-min deny-egress
+            # NetworkPolicy hold) UNATTENDED. For a permanent customer-facing
+            # Sovereign the cutover MUST be a DELIBERATE, observed BSS-menu
+            # action ("Achieve True Sovereignty" CTA, source="operator"). So we
+            # render "false" by DEFAULT here (catalystApi.fireCutoverOnHandover).
+            #
+            # NO-REGRESS: this only changes the auto-on-handover DEFAULT. The
+            # operator/BSS-initiated cutover (HandleCutoverStart, source=
+            # "operator", behind RequireSession) is untouched and still fires.
+            # A throwaway test prov that wants the full unattended cutover walk
+            # sets catalystApi.fireCutoverOnHandover=true.
+            #
+            # Sovereign-only (gated on global.sovereignFQDN). Empty on
+            # Catalyst-Zero / the mothership, which is the handover SENDER, never
+            # a cutover subject — fireCutoverOnHandover never runs there.
+            - name: CATALYST_FIRE_CUTOVER_ON_HANDOVER
+              value: '{{ if .Values.global.sovereignFQDN }}{{ .Values.catalystApi.fireCutoverOnHandover | default false }}{{ end }}'
             # SOVEREIGN_FQDN — Sovereign's public FQDN. The /auth/handover
             # validator (auth_handover.go) reads this to compute the expected
             # JWT audience claim ("https://console." + SOVEREIGN_FQDN). When

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -1111,6 +1111,24 @@ catalystApi:
   # (uncommon; the bp-nats-jetstream Blueprint deploys an in-cluster
   # broker by default).
   natsURL: ""
+  # Whether the child catalyst-api auto-fires the self-sovereignty cutover
+  # engine the instant the mothership completes handover (#4061). Wires
+  # CATALYST_FIRE_CUTOVER_ON_HANDOVER on Sovereign installs only (gated on
+  # global.sovereignFQDN in api-deployment.yaml).
+  #
+  # DEFAULT false — for a permanent customer-facing Sovereign the cutover
+  # MUST be a DELIBERATE, observed BSS-menu action ("Achieve True
+  # Sovereignty" CTA, source="operator"), never an unattended auto-run.
+  # Without this, a converged Sovereign auto-enters the finite 8-step
+  # cutover (incl the 10-min deny-egress NetworkPolicy hold) the moment
+  # handover seals the tofu-phase0-archive — because ReceiveTofuArchive
+  # fires the engine with source="handover", which the require-handover
+  # gate (cutover_internal.go) exempts, and the in-code env default is TRUE.
+  #
+  # Set true only on a throwaway test prov that should drive the full
+  # cutover walk end-to-end with no operator click. Flipping this to true
+  # does NOT change the operator/BSS CTA path — that always fires.
+  fireCutoverOnHandover: false
 
 # ─── Sovereign HTTPRoute (Cilium Gateway API, issue #387) ─────────────────
 # Renders templates/httproute.yaml when `ingress.gateway.enabled=true`


### PR DESCRIPTION
## Problem

A converged, permanent customer-facing Sovereign auto-entered the finite 8-step self-sovereignty cutover (including the **10-minute deny-egress NetworkPolicy hold**) **UNATTENDED**, the moment the mothership completed auto-handover. For a permanent Sovereign that is wrong — cutover must be a **DELIBERATE, observed BSS-menu action**.

## Root cause (file:line)

| Step | Location |
|---|---|
| Mothership auto-handover POSTs the tofu-archive to the child (at Phase-1-done + on every "Open console" re-mint) | `phase1_watch.go` |
| Child `ReceiveTofuArchive` seals the archive **then** fires the cutover engine with `source="handover"` | `handover.go:417` |
| The require-handover gate checks **only** `source=="internal"` — the handover path is exempt, so it SKIPS the gate | `cutover_internal.go:539` |
| Whether the handover path fires is keyed on `CATALYST_FIRE_CUTOVER_ON_HANDOVER`, which **defaults TRUE in code** and is set NOWHERE in any chart | `cutover_internal.go:144` |

## Fix

New chart knob `catalystApi.fireCutoverOnHandover` (**default `false`**) on `bp-catalyst-platform` wires `CATALYST_FIRE_CUTOVER_ON_HANDOVER=false` into the **child** catalyst-api Deployment on Sovereign installs (gated on `global.sovereignFQDN`). Cutover becomes a deliberate BSS-menu action ("Achieve True Sovereignty", `source="operator"`).

### helm-template proof (chart 1.4.761)

```
Sovereign default          -> value: 'false'   # auto-fire disabled
Sovereign + override=true  -> value: 'true'    # full unattended walk on a test prov
mothership (no FQDN)       -> value: ''         # sender, never a cutover subject
```

## NO-REGRESS

`fireCutoverOnHandover()` is referenced **only** at `handover.go:417` (the auto-on-handover path). The operator CTA `HandleCutoverStart` (`source="operator"`, behind `RequireSession`) dispatches via `runCutoverFromTrigger` → `fireCutoverEngine` directly and **never consults** `fireCutoverOnHandover()` — so the deliberate BSS cutover walk is **untouched**. This PR only changes the auto-on-handover **DEFAULT** to not-auto.

- Chart version + bootstrap-kit slot pin (`13-bp-catalyst-platform.yaml`) bumped `1.4.760` → `1.4.761` in **lockstep**.
- Full `helm template` renders clean (exit 0).
- No Go code change.

Refs #4061

🤖 Generated with [Claude Code](https://claude.com/claude-code)