### PR TITLE
fix(bp-harbor): render DB-secret rename Job in #3642 host-bridge path — kill registry 502 / harbor 404 on fresh prov (1.2.36)

### DIFF
--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -221,7 +221,15 @@ spec:
       # ExternalSecret is suppressed via sso.externalSecret.enabled), so
       # auth_mode=oidc_auth is PUT in the mgmt vCluster placement (caught live
       # hw171: systeminfo auth_mode=db_auth). Refs #3374 #3642.
-      version: 1.2.35
+      # 1.2.36 (#4059 / Refs #3642 #3953): decouple the harbor-pg-app →
+      # harbor-database-secret rename bridge onto postgres.databaseSecretSync
+      # .enabled (default true), independent of postgres.cluster.enabled (which
+      # the #3642 host-bridge ALSO flips false). The renamer was wrongly skipped
+      # in the host-bridge path → harbor-core CreateContainerConfigError →
+      # registry.<fqdn> 502 / harbor.<fqdn> 404 (hw172/hw173). databaseSecretSync
+      # follows SOVEREIGN_HARBOR_PG_OWN_CLUSTER (own-vs-shared), set false only in
+      # TRUE shared-pg mode. Non-host-bridged render byte-identical.
+      version: 1.2.36
       sourceRef:
         kind: HelmRepository
         name: bp-harbor
@@ -345,7 +353,21 @@ spec:
         # Service. The `registry` Database + role + reflected
         # harbor-database-secret are provisioned by the shared bp-postgres
         # instance (slot 16a).
+        #
+        # NOTE (#4059, Refs #3642): the #3642 host-bridge placement ALSO renders
+        # this false (the harbor-pg Cluster CR is host-rendered via placement.yaml,
+        # not in-vc), so cluster.enabled=false does NOT imply shared-pg. The
+        # DB-secret renamer is gated separately on databaseSecretSync.enabled below.
         enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      # #4059: gate the harbor-pg-app → harbor-database-secret rename bridge on
+      # whether harbor OWNS a harbor-pg Cluster — true in BOTH the embedded and
+      # the #3642 host-bridge paths (both mint harbor-pg-app), false ONLY in
+      # TRUE shared-pg mode (bp-postgres mints harbor-database-secret directly,
+      # no harbor-pg-app to poll). This follows SOVEREIGN_HARBOR_PG_OWN_CLUSTER
+      # (the canonical own-vs-shared switch), NOT cluster.enabled (which the
+      # host-bridge also flips false). Default true = own cluster.
+      databaseSecretSync:
+        enabled: ${SOVEREIGN_HARBOR_PG_OWN_CLUSTER:=true}
     objectStorage:
       enabled: true
       useExistingSecret: false

--- a/platform/harbor/blueprint.yaml
+++ b/platform/harbor/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-5-storage-and-data
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.35
+  version: 1.2.36
   card:
     title: Harbor
     family: foundation

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -123,7 +123,26 @@ type: application
 # sso.enabled stays true so the configurator runs IN the vCluster against
 # harbor-core. Non-host-bridged render byte-identical. Refs #3374 #3642.
 # 1.2.35 (#3971): CNPG storageClass empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN.
-version: 1.2.35
+# 1.2.36 (#4059 / Refs #3642 #3953, 2026-06-22): DB-secret rename bridge
+# regression in the host-bridge path. harbor-core reads its DB password from a
+# Secret NAMED `harbor-database-secret`, but CNPG mints `harbor-pg-app` — the
+# templates/database-secret.yaml placeholder + database-secret-sync-job.yaml
+# renamer bridge that. Both were gated on `postgres.cluster.enabled != false`,
+# which the #3642 host-bridge placement ALSO flips false (the harbor-pg Cluster
+# CR is host-rendered, not in-vc) → the renamer was wrongly SKIPPED → harbor
+# never got `harbor-database-secret` → harbor-core CreateContainerConfigError
+# ("harbor-database-secret-x-harbor-x-mgmt-vcluster" not found), harbor-jobservice
+# CrashLoop, registry.<fqdn> 502 / harbor.<fqdn> 404 on a fresh prov (caught live
+# hw172/hw173, BOTH regions). New value postgres.databaseSecretSync.enabled
+# (default true) gates the renamer independently of cluster.enabled: it runs
+# whenever harbor OWNS a harbor-pg Cluster (embedded OR host-bridge — both produce
+# harbor-pg-app), and is set false only in TRUE shared-pg mode (bp-postgres mints
+# the secret). Rendering the Job is ALSO what references harbor-pg-app inside
+# vc-mgmt, so it makes the bp-mgmt-vcluster sync.fromHost.secrets import (#3953)
+# materialise. The cnpg-cluster.yaml Cluster-CR gate is UNCHANGED (still
+# cluster.enabled — the host-bridge must not double-create it). Non-host-bridged
+# render byte-identical.
+version: 1.2.36
 appVersion: "2.14.3"
 # 1.2.23 (G117.5 #2744, 2026-06-02): SSO defense-in-depth via Harbor's
 # `oidc_extra_redirect_parms` config field. The configure-oauth Job now

--- a/platform/harbor/chart/templates/database-secret-sync-job.yaml
+++ b/platform/harbor/chart/templates/database-secret-sync-job.yaml
@@ -42,18 +42,26 @@ the Secret is named for the lifetime of the release). Reflector
 annotations are kept harmless — they just become a redundant
 no-op once this Job has populated the Secret.
 
-ADR-0010 SHARING gate (#3285): when harbor SHARES a bp-postgres instance
-(`postgres.cluster.enabled=false`) there is NO `harbor-pg-app` Secret in
-the harbor namespace — the shared engine's `shared-pg-harbor` role Secret
-lives in shared-data and bp-postgres-shared already reflects the populated
-`harbor-database-secret` into the harbor namespace (the #3284 source-side
-push). This sync Job would poll a non-existent `harbor-pg-app` for 10 min,
-time out (exit 1), exhaust backoffLimit, and FAIL the post-install hook →
-Helm rolls the bp-harbor release back. So skip the whole Job (+ its SA /
-Role / RoleBinding) when the embedded cluster is disabled — the SAME gate
-the cnpg-cluster.yaml + database-secret.yaml templates already carry.
+ADR-0010 SHARING gate (#3285) — REPLACED by databaseSecretSync gate (#4059):
+the renamer runs whenever harbor OWNS a `harbor-pg` Cluster (so `harbor-pg-app`
+exists to rename). That is BOTH the legacy embedded path AND the #3642
+host-bridge path (where the Cluster CR is host-rendered but harbor still owns
+harbor-pg). It is skipped ONLY in TRUE shared-pg mode, where bp-postgres mints
+`harbor-database-secret` directly and there is no `harbor-pg-app` to poll — that
+mode flips `postgres.databaseSecretSync.enabled=false` in the per-Sovereign
+overlay (alongside SOVEREIGN_HARBOR_PG_OWN_CLUSTER=false).
+
+PREVIOUS BUG: the gate was `postgres.cluster.enabled != false`, which the #3642
+host-bridge placement ALSO flips false (Cluster CR host-rendered, not in-vc) →
+the renamer was wrongly skipped → `harbor-database-secret` never created →
+harbor-core CreateContainerConfigError ("harbor-database-secret-x-harbor-x-
+mgmt-vcluster" not found) → registry.<fqdn> 502 / harbor.<fqdn> 404 on a fresh
+prov (hw172/hw173). Decoupling onto `databaseSecretSync` restores it. The Job is
+also the in-vc consumer of `harbor-pg-app`, so rendering it is what makes the
+bp-mgmt-vcluster `sync.fromHost.secrets` import (#3953) actually materialise
+`harbor-pg-app` inside vc-mgmt. (#4059)
 */}}
-{{- if ne (toString .Values.postgres.cluster.enabled) "false" }}
+{{- if .Values.postgres.databaseSecretSync.enabled }}
 {{- $ns := .Values.postgres.cluster.namespace | default .Release.Namespace }}
 {{- $clusterName := .Values.postgres.cluster.name | default "harbor-pg" }}
 apiVersion: batch/v1

--- a/platform/harbor/chart/templates/database-secret.yaml
+++ b/platform/harbor/chart/templates/database-secret.yaml
@@ -57,14 +57,17 @@ Per docs/INVIOLABLE-PRINCIPLES.md #10 (credential hygiene): no plaintext
 credentials appear in this committed template. The reflector copies bytes from
 a live cluster Secret.
 
-ADR-0010 SHARING gate: when harbor SHARES a bp-postgres instance
-(`postgres.cluster.enabled=false`), the SHARED instance provisions and
-reflects `harbor-database-secret` from ITS role Secret. This template must
-NOT also create the same-named Secret (it would race / conflict and
-reflect from a non-existent `harbor-pg-app`). So skip it when the embedded
-cluster is disabled.
+ADR-0010 SHARING gate — REPLACED by databaseSecretSync gate (#4059): this
+placeholder Secret + its companion sync Job render whenever harbor owns a
+`harbor-pg` Cluster (embedded OR #3642 host-bridge — both produce `harbor-pg-app`
+for the Job to rename into this Secret). It is skipped ONLY in TRUE shared-pg
+mode, where bp-postgres provisions + reflects `harbor-database-secret` from its
+role Secret (so this template must NOT also create the same-named Secret — it
+would race / reflect from a non-existent `harbor-pg-app`). That mode flips
+`postgres.databaseSecretSync.enabled=false` in the per-Sovereign overlay.
+See database-secret-sync-job.yaml for the full #4059 RCA (host-bridge regression).
 */}}
-{{- if ne (toString .Values.postgres.cluster.enabled) "false" }}
+{{- if .Values.postgres.databaseSecretSync.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/platform/harbor/chart/tests/shared-pg-consumer-wiring.sh
+++ b/platform/harbor/chart/tests/shared-pg-consumer-wiring.sh
@@ -52,10 +52,15 @@ grep -q 'POSTGRESQL_HOST: "harbor-pg-rw.harbor.svc.cluster.local"' "$tmp/own.yam
   || fail "own-cluster: DB host must be harbor-pg-rw.harbor"
 echo "  PASS"
 
-# ── Case 2: SHARED mode ─────────────────────────────────────────────────
-echo "[shared-pg] Case 2: SHARED → no bundled Cluster, no sync Job, reads reflected harbor-database-secret"
+# ── Case 2: TRUE shared-pg mode ─────────────────────────────────────────
+# bp-postgres mints harbor-database-secret directly; there is NO harbor-pg-app
+# to rename, so BOTH the bundled Cluster AND the rename bridge must be OFF.
+# #4059: the true-shared-pg overlay flips databaseSecretSync.enabled=false
+# alongside postgres.cluster.enabled=false (SOVEREIGN_HARBOR_PG_OWN_CLUSTER=false).
+echo "[shared-pg] Case 2: TRUE shared-pg → no bundled Cluster, no sync Job, reads reflected harbor-database-secret"
 "$helm" template smoke "$chart_dir" \
   --set postgres.cluster.enabled=false \
+  --set postgres.databaseSecretSync.enabled=false \
   --set 'harbor.database.external.host=shared-pg-rw.shared-data.svc.cluster.local' \
   --api-versions postgresql.cnpg.io/v1 \
   > "$tmp/shared.yaml" 2> "$tmp/shared.err" || { cat "$tmp/shared.err" >&2; fail "shared render errored"; }
@@ -74,6 +79,35 @@ grep -A4 'name: POSTGRESQL_PASSWORD' "$tmp/shared.yaml" | grep -q 'key: password
   || fail "SHARED: POSTGRESQL_PASSWORD key must be 'password'"
 grep -q 'POSTGRESQL_HOST: "shared-pg-rw.shared-data.svc.cluster.local"' "$tmp/shared.yaml" \
   || fail "SHARED: DB host must point at the shared engine -rw Service"
+echo "  PASS"
+
+# ── Case 3: #3642 host-bridge mode (#4059 regression guard) ─────────────
+# Harbor runs INSIDE the mgmt vCluster; the harbor-pg Cluster CR is
+# HOST-rendered (placement.yaml hostBridge) so the in-vc chart sets
+# postgres.cluster.enabled=false — BUT harbor STILL owns harbor-pg, so the
+# CNPG-minted harbor-pg-app MUST be renamed → harbor-database-secret by the
+# in-vc sync Job. databaseSecretSync.enabled stays true (own cluster). The
+# renamer being skipped here was the hw172/hw173 harbor-core
+# CreateContainerConfigError → registry 502 / harbor 404. This case locks it:
+# Cluster CR OFF (host renders it) but BOTH the renamer Job AND its placeholder
+# Secret MUST render.
+echo "[shared-pg] Case 3: host-bridge → no in-vc Cluster CR, but renamer Job + placeholder Secret PRESENT (#4059)"
+"$helm" template smoke "$chart_dir" \
+  --set postgres.cluster.enabled=false \
+  --set postgres.databaseSecretSync.enabled=true \
+  --api-versions postgresql.cnpg.io/v1 \
+  > "$tmp/hostbridge.yaml" 2> "$tmp/hostbridge.err" || { cat "$tmp/hostbridge.err" >&2; fail "host-bridge render errored"; }
+
+[ "$(grep -cE '^kind: Cluster$' "$tmp/hostbridge.yaml")" -eq 0 ] \
+  || fail "host-bridge: in-vc Cluster CR must NOT render (host placement renders it)"
+grep -q 'name: harbor-database-secret-sync$' "$tmp/hostbridge.yaml" \
+  || fail "host-bridge: renamer sync Job MUST render (#4059 — harbor-pg-app→harbor-database-secret)"
+grep -q 'value: "harbor-pg-app"' "$tmp/hostbridge.yaml" \
+  || fail "host-bridge: sync Job SOURCE_SECRET must be harbor-pg-app"
+# placeholder harbor-database-secret Secret MUST render so harbor-core can mount it.
+if ! awk '/^kind: Secret$/{k=1;next} k&&/^  name: harbor-database-secret$/{print "x"} /^---$/{k=0}' "$tmp/hostbridge.yaml" | grep -q x; then
+  fail "host-bridge: placeholder harbor-database-secret Secret MUST render (#4059)"
+fi
 echo "  PASS"
 
 echo

--- a/platform/harbor/chart/values.yaml
+++ b/platform/harbor/chart/values.yaml
@@ -586,6 +586,37 @@ postgres:
     resources:
       requests: { cpu: 50m, memory: 128Mi }
       limits:   { cpu: 500m, memory: 512Mi }
+  # ── DB-secret rename bridge (harbor-pg-app → harbor-database-secret) ──────
+  # Harbor upstream reads its DB password from a Secret NAMED
+  # `harbor-database-secret` (key `password` / `HARBOR_DATABASE_PASSWORD`),
+  # but CNPG mints `harbor-pg-app`. The placeholder Secret
+  # (templates/database-secret.yaml) + post-install Job
+  # (templates/database-secret-sync-job.yaml) bridge that rename.
+  #
+  # This MUST run whenever harbor OWNS a `harbor-pg` Cluster (i.e. there is a
+  # `harbor-pg-app` to rename) — and that is true in BOTH:
+  #   (a) the legacy embedded path   (postgres.cluster.enabled=true,  in-vc render), AND
+  #   (b) the #3642 host-bridge path (postgres.cluster.enabled=false, host renders
+  #       the Cluster CR but harbor STILL owns harbor-pg → harbor-pg-app exists).
+  # It MUST be OFF only in TRUE shared-pg mode (ADR-0010), where bp-postgres
+  # mints `harbor-database-secret` directly and no `harbor-pg-app` exists to poll.
+  #
+  # Previously the Job + placeholder were gated on `postgres.cluster.enabled`
+  # — which the #3642 host-bridge placement ALSO flips false (the Cluster CR
+  # is host-rendered, not in-vc). That conflation SKIPPED the renamer in the
+  # host-bridge path → `harbor-database-secret` never created → harbor-core
+  # `CreateContainerConfigError` (secret
+  # "harbor-database-secret-x-harbor-x-mgmt-vcluster" not found) → registry.<fqdn>
+  # 502 / harbor.<fqdn> 404 on a fresh prov (caught live hw172/hw173, BOTH regions).
+  # The sync Job is also the in-vCluster consumer of `harbor-pg-app`, so its
+  # absence ALSO meant nothing referenced `harbor-pg-app` inside vc-mgmt → the
+  # bp-mgmt-vcluster `sync.fromHost.secrets` import (#3953) never materialised
+  # it either. Rendering the Job fixes BOTH layers. (#4059, Refs #3642 #3953.)
+  # Default true (every own-cluster prov, embedded + host-bridge); a
+  # per-Sovereign TRUE-shared-pg overlay sets it false alongside the
+  # SOVEREIGN_HARBOR_PG_OWN_CLUSTER=false flip.
+  databaseSecretSync:
+    enabled: true
 
 objectStorage:
   # When false, no credentials Secret is rendered (contabo, local dev,


### PR DESCRIPTION
## 🔴 Zero-touch regression

On a fresh Huawei prov, **harbor/registry come up BROKEN** → `registry.<fqdn>` 502, `harbor.<fqdn>` 404.

## Root cause (verified by render)

harbor-core reads its DB password from a Secret **NAMED** `harbor-database-secret` (`POSTGRESQL_PASSWORD` secretKeyRef), but CNPG mints `harbor-pg-app`. Two templates bridge that rename:
- `platform/harbor/chart/templates/database-secret.yaml` (placeholder Secret)
- `platform/harbor/chart/templates/database-secret-sync-job.yaml` (post-install renamer Job)

**Both were gated on** (`database-secret-sync-job.yaml:56`, `database-secret.yaml:67`):
```gotemplate
{{- if ne (toString .Values.postgres.cluster.enabled) "false" }}
```

But the #3642 harbor host-bridge sets `postgres.cluster.enabled: false` in `clusters/_template/bootstrap-kit/placement.yaml:965` (the harbor-pg Cluster CR is **HOST-rendered** via placement.yaml `hostDocuments`, not in-vCluster). So in the host-bridge path the renamer Job + placeholder Secret were **wrongly SKIPPED** → `harbor-database-secret` never landed in vc-mgmt → harbor-core `CreateContainerConfigError` (`harbor-database-secret-x-harbor-x-mgmt-vcluster` not found), harbor-jobservice CrashLoop → registry/harbor down (caught live hw172/hw173, both regions).

`cluster.enabled=false` was overloaded to mean BOTH "host-bridge" AND "true shared-pg" — only the latter should skip the renamer.

## Fix — exact gate change

Decouple the renamer onto a NEW independent value `postgres.databaseSecretSync.enabled` (default `true`):

| File | Line | Before | After |
|---|---|---|---|
| `templates/database-secret-sync-job.yaml` | 56 | `{{- if ne (toString .Values.postgres.cluster.enabled) "false" }}` | `{{- if .Values.postgres.databaseSecretSync.enabled }}` |
| `templates/database-secret.yaml` | 67 | `{{- if ne (toString .Values.postgres.cluster.enabled) "false" }}` | `{{- if .Values.postgres.databaseSecretSync.enabled }}` |

It renders whenever harbor OWNS a harbor-pg Cluster (embedded OR host-bridge — both mint `harbor-pg-app`), and is set `false` ONLY in TRUE shared-pg mode (bp-postgres mints `harbor-database-secret` directly). The `cnpg-cluster.yaml` Cluster-CR gate is **UNCHANGED** (still `cluster.enabled` — the host-bridge must not double-create the Cluster). Non-host-bridged render is byte-identical.

Bootstrap-kit slot `19-harbor.yaml` wires `databaseSecretSync.enabled = ${SOVEREIGN_HARBOR_PG_OWN_CLUSTER:=true}` (follows the canonical own-vs-shared switch, not cluster.enabled).

## Render proof — `helm template platform/harbor/chart`

```
CASE A: DEFAULT own-cluster (cluster.enabled=true)
  kind: Cluster count = 1   rename Job = YES   placeholder Secret = YES
  POSTGRESQL_PASSWORD secretKeyRef → harbor-database-secret   ✅ byte-identical

CASE B: HOST-BRIDGE (cluster.enabled=false, databaseSecretSync default=true)   ← THE BUG
  kind: Cluster count = 0   rename Job = YES   placeholder Secret = YES   ← THE FIX
  POSTGRESQL_PASSWORD secretKeyRef → harbor-database-secret (now satisfied)  ✅

CASE C: TRUE shared-pg (both flags false)
  kind: Cluster count = 0   rename Job = NO   placeholder Secret = NO   ✅ no regression
```

All **5 harbor chart tests PASS** incl. the new `shared-pg-consumer-wiring.sh` **Case 3** (host-bridge regression guard: Cluster CR OFF but renamer Job + placeholder Secret PRESENT). `helm lint` clean. `placement check` PASSED (no drift). pin-sync `--changed-only` PASSED (`bp-harbor chart=1.2.36 pin=1.2.36`).

## Version + pin (lockstep)

- `Chart.yaml`: 1.2.35 → **1.2.36** (1.2.35 was already taken on main by #3971's CSI-default change — version collision avoided)
- `19-harbor.yaml` pin: 1.2.35 → **1.2.36**

## NO-REGRESS

The `cluster.enabled=true` path (non-bridge embedded installs) is byte-identical (Case A). The cnpg Cluster-CR gate is untouched. TRUE shared-pg still skips the renamer (Case C).

Refs #4059 #3948 #3952 #3642 #3953