### PR TITLE
feat(provisioning): storage class is a choosable user input with per-provider CSI defaults (#4057)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1493,7 +1493,16 @@ spec:
       cnpgPrimaryRegion: ${QA_CNPG_PRIMARY_REGION:-hz-fsn-rtz-prod}
       cnpgReplicaRegion: ${QA_CNPG_REPLICA_REGION:-hz-fsn-rtz-prod}
       cnpgImage: ${QA_CNPG_IMAGE:-ghcr.io/cloudnative-pg/postgresql:16.4-1}
-      cnpgStorageClass: ${QA_CNPG_STORAGE_CLASS:-local-path}
+      # #4057/#3971 — empty default ⇒ the qaFixtures CNPG Cluster CR OMITS
+      # storageClass (the chart's `{{- with .Values.qaFixtures.cnpgStorageClass }}`
+      # guard), so CNPG uses the cluster-DEFAULT durable cloud CSI class
+      # (hcloud-volumes / evs-ssd). The former `local-path` default is now
+      # FORBIDDEN — k3s runs `--disable=local-storage` and the K23 Kyverno
+      # ENFORCE policy DENIES any PVC referencing local-path, so a QA Sovereign
+      # left on the old default had its qa-fixture CNPG PVCs rejected. An
+      # operator may still pin a specific class via QA_CNPG_STORAGE_CLASS, but
+      # local-path is never a valid value.
+      cnpgStorageClass: ${QA_CNPG_STORAGE_CLASS:-}
       cnpgStorageSize: ${QA_CNPG_STORAGE_SIZE:-1Gi}
       # Kyverno baseline policies (Fix #37). disallow-privileged-containers
       # ships in Enforce mode; the other 18 baseline policies in Audit so

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -645,7 +645,14 @@ write_files:
             # that NAMES the class instead stays Pending (not frozen) until the
             # class exists, then binds — race-immune. On Hetzner the CSI default
             # is hcloud-volumes.
-            SOVEREIGN_CNPG_STORAGE_CLASS: "hcloud-volumes"
+            #
+            # #4057 — the class is now the operator-chosen
+            # `default_storage_class` tofu var (catalyst-api
+            # Request.StorageClass, defaulted to the per-provider durable CSI
+            # class `hcloud-volumes` when the wizard field is omitted). The tofu
+            # variable validation rejects "" and "local-path", so this substitute
+            # can never render an empty or ephemeral class.
+            SOVEREIGN_CNPG_STORAGE_CLASS: "${default_storage_class}"
 %{ endif ~}
 %{ if provider == "huawei" ~}
             # Huawei: no cloud CCM. Cilium LB-IPAM assigns the clustermesh
@@ -697,7 +704,14 @@ write_files:
             # instead keeps the PVC Pending (recoverable) until evs-ssd exists,
             # then binds with zero re-creation — so the moment EVS_CSI_ENABLED
             # flips true (or the SC lands by any path) these three converge.
-            SOVEREIGN_CNPG_STORAGE_CLASS: "evs-ssd"
+            #
+            # #4057 — the class is now the operator-chosen
+            # `default_storage_class` tofu var (catalyst-api
+            # Request.StorageClass, defaulted to the per-provider durable CSI
+            # class `evs-ssd` when the wizard field is omitted). The tofu
+            # variable validation rejects "" and "local-path", so this substitute
+            # can never render an empty or ephemeral class.
+            SOVEREIGN_CNPG_STORAGE_CLASS: "${default_storage_class}"
             SECONDARY_HR_SUSPEND: "${sovereign_region_role == "primary" ? "false" : "true"}"
             CILIUM_LB_IPAM_ENABLED: "true"
             CILIUM_LB_IPAM_CIDRS: "${node_external_ip_value}/32"

--- a/infra/providers/hetzner/main.tf
+++ b/infra/providers/hetzner/main.tf
@@ -876,6 +876,7 @@ locals {
     bcp_topology             = var.bcp_topology
     enable_hot_standby       = var.enable_hot_standby
     enable_shared_pg         = var.enable_shared_pg
+    default_storage_class    = var.default_storage_class
     sovereign_cnpg_instances = length(var.regions) > 1 ? "2" : "1"
     continuum_enabled        = length(var.regions) > 1 ? "true" : "false"
     parent_domains_yaml = coalesce(
@@ -1311,6 +1312,7 @@ locals {
       bcp_topology             = var.bcp_topology
       enable_hot_standby       = var.enable_hot_standby
       enable_shared_pg         = var.enable_shared_pg
+      default_storage_class    = var.default_storage_class
       sovereign_cnpg_instances = length(var.regions) > 1 ? "2" : "1"
       continuum_enabled        = length(var.regions) > 1 ? "true" : "false"
       parent_domains_yaml = coalesce(

--- a/infra/providers/hetzner/tests/multi_region.tftest.hcl
+++ b/infra/providers/hetzner/tests/multi_region.tftest.hcl
@@ -694,3 +694,49 @@ run "per_region_cloud_init_carries_secondarys_own_region" {
     error_message = "Primary cloud-init must NOT carry the legacy hardcoded `openova.io/region=hz-fsn-rtz-prod` literal when var.region != fsn1 — broke t114-omani-works (primary=hel1) and every other non-fsn1 Sovereign."
   }
 }
+
+# ── #4057: SOVEREIGN_CNPG_STORAGE_CLASS reflects the operator's
+# ── default_storage_class tofu var (no longer a hardcoded literal) ──────────
+# The catalyst-api Request.StorageClass → var.default_storage_class → the
+# cloud-init Kustomization postBuild.substitute SOVEREIGN_CNPG_STORAGE_CLASS →
+# the host-shared CNPG Cluster CRs (slots 10/19/52) + the bp-cnpg/bp-mgmt-
+# vcluster default class. local-path is FORBIDDEN; the var validation rejects
+# "" and "local-path" so this substitute can never render ephemeral storage.
+run "default_storage_class_falls_back_to_hcloud_volumes" {
+  command = plan
+
+  variables {
+    region = "hel1"
+    # default_storage_class NOT set → the variables.tf default `hcloud-volumes`
+    # applies (the per-provider Hetzner CSI durable class).
+  }
+
+  assert {
+    condition     = strcontains(local.control_plane_cloud_init, "SOVEREIGN_CNPG_STORAGE_CLASS: \"hcloud-volumes\"")
+    error_message = "Primary cloud-init must render SOVEREIGN_CNPG_STORAGE_CLASS=\"hcloud-volumes\" when default_storage_class is unset (the per-provider Hetzner CSI default). #4057"
+  }
+
+  assert {
+    condition     = !strcontains(local.control_plane_cloud_init, "SOVEREIGN_CNPG_STORAGE_CLASS: \"local-path\"")
+    error_message = "Primary cloud-init must NEVER render SOVEREIGN_CNPG_STORAGE_CLASS=\"local-path\" — local-path is FORBIDDEN (#3971/#892)."
+  }
+}
+
+run "default_storage_class_operator_override_renders" {
+  command = plan
+
+  variables {
+    region                = "hel1"
+    default_storage_class = "hcloud-volumes-xfs"
+  }
+
+  assert {
+    condition     = strcontains(local.control_plane_cloud_init, "SOVEREIGN_CNPG_STORAGE_CLASS: \"hcloud-volumes-xfs\"")
+    error_message = "Primary cloud-init must render the operator-chosen default_storage_class verbatim into SOVEREIGN_CNPG_STORAGE_CLASS. #4057 — founder point #1 (storage class is a user input)."
+  }
+
+  assert {
+    condition     = !strcontains(local.control_plane_cloud_init, "SOVEREIGN_CNPG_STORAGE_CLASS: \"hcloud-volumes\"")
+    error_message = "When the operator overrides default_storage_class, the cloud-init must carry ONLY the chosen class, not the default literal."
+  }
+}

--- a/infra/providers/hetzner/variables.tf
+++ b/infra/providers/hetzner/variables.tf
@@ -120,6 +120,31 @@ variable "enable_shared_pg" {
   }
 }
 
+# default_storage_class — the operator-chosen default StorageClass for the
+# Sovereign's stateful workloads (#4057, founder point #1: "storage class is
+# an INPUT chosen by the user, with defaults"). catalyst-api's
+# provisioner.Request.StorageClass flows into this var; deriveStorageClass()
+# fills the per-provider durable cloud CSI default when the operator omits the
+# wizard field — on Hetzner that is `hcloud-volumes` (bp-hcloud-csi slot 55a /
+# csi.hetzner.cloud). The cloud-init template interpolates this var into the
+# bootstrap-kit Kustomization postBuild.substitute SOVEREIGN_CNPG_STORAGE_CLASS
+# (which previously HARDCODED the per-provider literal), so the host-shared
+# CNPG Cluster CRs (gitea-pg / harbor-pg / guacamole-pg, slots 10/19/52) + the
+# bp-cnpg / bp-mgmt-vcluster default class all name the chosen class. The k3s
+# ephemeral local-path provisioner is FORBIDDEN (--disable=local-storage + the
+# K23 Kyverno ENFORCE deny, #3971/#892); the validation below rejects it so an
+# operator can never select non-durable node-local storage. Default
+# 'hcloud-volumes' keeps a fresh Hetzner prov byte-identical to today.
+variable "default_storage_class" {
+  type        = string
+  description = "Default StorageClass name for the Sovereign's stateful workloads (#4057). Chosen by the operator in the wizard; catalyst-api defaults it to the per-provider durable cloud CSI class (Hetzner: hcloud-volumes) when empty. local-path is FORBIDDEN."
+  default     = "hcloud-volumes"
+  validation {
+    condition     = var.default_storage_class != "" && var.default_storage_class != "local-path"
+    error_message = "default_storage_class must be a non-empty durable cloud CSI class; the ephemeral k3s 'local-path' is FORBIDDEN (#3971/#892)."
+  }
+}
+
 # ── QA fixtures auto-enable (Fix #73 — qa-loop bounded-cycle iter-16) ──
 # When set, bp-catalyst-platform's qaFixtures stack (qa-<sov> namespace +
 # qa-wp Application + Continuum CR + CNPGPair + PDM CRs + ScheduledBackup

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -931,6 +931,7 @@ locals {
       bcp_topology             = var.bcp_topology
       enable_hot_standby       = var.enable_hot_standby
       enable_shared_pg         = var.enable_shared_pg
+      default_storage_class    = var.default_storage_class
       sovereign_cnpg_instances = length(var.regions) > 1 ? "2" : "1"
       continuum_enabled        = length(var.regions) > 1 ? "true" : "false"
       marketplace_enabled      = var.marketplace_enabled

--- a/infra/providers/huawei/tests/multi_region.tftest.hcl
+++ b/infra/providers/huawei/tests/multi_region.tftest.hcl
@@ -358,3 +358,70 @@ run "ha_three_cp_per_region" {
     error_message = "Wave 5.7: even in HA (count=3) only the primary CP per region gets an EIP."
   }
 }
+
+# ── #4057: SOVEREIGN_CNPG_STORAGE_CLASS reflects the operator's
+# ── default_storage_class tofu var (no longer a hardcoded `evs-ssd`) ────────
+# The catalyst-api Request.StorageClass → var.default_storage_class → the
+# cloud-init Kustomization postBuild.substitute SOVEREIGN_CNPG_STORAGE_CLASS →
+# the host-shared CNPG Cluster CRs + the bp-cnpg/bp-mgmt-vcluster default class.
+# On Huawei the per-provider durable default is `evs-ssd` (bp-huawei-evs-csi
+# slot 55b). local-path is FORBIDDEN; the var validation rejects "" and
+# "local-path".
+run "default_storage_class_falls_back_to_evs_ssd" {
+  command = plan
+
+  variables {
+    regions = [
+      {
+        code               = "me-east-215-a"
+        role               = "primary"
+        control_plane_size = "s7n.large.4"
+        worker_size        = "m7n.xlarge.8"
+        worker_count       = 2
+      }
+    ]
+    # default_storage_class NOT set → the variables.tf default `evs-ssd`
+    # applies (the per-provider Huawei EVS CSI durable class).
+  }
+
+  assert {
+    condition = strcontains(
+      local.cp_cloud_init_by_region["me-east-215-a"],
+      "SOVEREIGN_CNPG_STORAGE_CLASS: \"evs-ssd\""
+    )
+    error_message = "Primary-CP cloud-init must render SOVEREIGN_CNPG_STORAGE_CLASS=\"evs-ssd\" when default_storage_class is unset (the per-provider Huawei EVS CSI default). #4057"
+  }
+
+  assert {
+    condition = !strcontains(
+      local.cp_cloud_init_by_region["me-east-215-a"],
+      "SOVEREIGN_CNPG_STORAGE_CLASS: \"local-path\""
+    )
+    error_message = "Primary-CP cloud-init must NEVER render SOVEREIGN_CNPG_STORAGE_CLASS=\"local-path\" — local-path is FORBIDDEN (#3971/#892)."
+  }
+}
+
+run "default_storage_class_operator_override_renders_huawei" {
+  command = plan
+
+  variables {
+    regions = [
+      {
+        code               = "me-east-215-a"
+        role               = "primary"
+        control_plane_size = "s7n.large.4"
+        worker_size        = "m7n.xlarge.8"
+        worker_count       = 2
+      }
+    ]
+    default_storage_class = "evs-sas"
+  }
+
+  assert {
+    condition = strcontains(
+      local.cp_cloud_init_by_region["me-east-215-a"],
+      "SOVEREIGN_CNPG_STORAGE_CLASS: \"evs-sas\""
+    )
+    error_message = "Primary-CP cloud-init must render the operator-chosen default_storage_class verbatim into SOVEREIGN_CNPG_STORAGE_CLASS. #4057"
+  }
+}

--- a/infra/providers/huawei/variables.tf
+++ b/infra/providers/huawei/variables.tf
@@ -454,6 +454,32 @@ variable "enable_shared_pg" {
   }
 }
 
+# default_storage_class — the operator-chosen default StorageClass for the
+# Sovereign's stateful workloads (#4057, founder point #1: "storage class is
+# an INPUT chosen by the user, with defaults"). catalyst-api's
+# provisioner.Request.StorageClass flows into this var; deriveStorageClass()
+# fills the per-provider durable cloud CSI default when the operator omits the
+# wizard field — on Huawei that is `evs-ssd` (bp-huawei-evs-csi slot 55b /
+# evs.csi.huaweicloud.com). The cloud-init template interpolates this var into
+# the bootstrap-kit Kustomization postBuild.substitute
+# SOVEREIGN_CNPG_STORAGE_CLASS (which previously HARDCODED the per-provider
+# literal), so the host-shared CNPG Cluster CRs (gitea-pg / harbor-pg /
+# guacamole-pg, slots 10/19/52) + the bp-cnpg / bp-mgmt-vcluster default class
+# all name the chosen class. The k3s ephemeral local-path provisioner is
+# FORBIDDEN (--disable=local-storage + the K23 Kyverno ENFORCE deny,
+# #3971/#892); the validation below rejects it so an operator can never select
+# non-durable node-local storage. Default 'evs-ssd' keeps a fresh Huawei prov
+# byte-identical to today.
+variable "default_storage_class" {
+  type        = string
+  description = "Default StorageClass name for the Sovereign's stateful workloads (#4057). Chosen by the operator in the wizard; catalyst-api defaults it to the per-provider durable cloud CSI class (Huawei: evs-ssd) when empty. local-path is FORBIDDEN."
+  default     = "evs-ssd"
+  validation {
+    condition     = var.default_storage_class != "" && var.default_storage_class != "local-path"
+    error_message = "default_storage_class must be a non-empty durable cloud CSI class; the ephemeral k3s 'local-path' is FORBIDDEN (#3971/#892)."
+  }
+}
+
 variable "wildcard_cert_use_staging" {
   type        = string
   default     = "false"

--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -840,6 +840,13 @@ func (d *Deployment) State() map[string]any {
 	if v := d.Request.ControlPlaneSize; v != "" {
 		out["controlPlaneSize"] = v
 	}
+	// #4057 — surface the EFFECTIVE default StorageClass so the chroot
+	// Settings page renders the operator's choice (or the per-provider CSI
+	// default when they accepted it) instead of an em-dash. deriveStorageClass
+	// fills the per-provider durable class (hcloud-volumes / evs-ssd) when the
+	// stored value is empty, so the page always shows a real durable class
+	// (never empty, never local-path).
+	out["storageClass"] = provisioner.DeriveStorageClass(d.Request)
 	if v := d.Request.SovereignPoolDomain; v != "" {
 		out["sovereignPoolDomain"] = v
 	}

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -235,6 +235,56 @@ func bcpTopologyEnableHotStandby(topology string) string {
 	}
 }
 
+// Per-provider default StorageClass names — the durable cloud-block-storage
+// CSI class each provider's bootstrap-kit installs and flips to
+// cluster-default (#3971/#892). These are the FALLBACKS the operator gets
+// when Request.StorageClass is empty (the common case). They mirror the
+// hardcoded `SOVEREIGN_CNPG_STORAGE_CLASS` literals the cloud-init template
+// carried before #4057 made the class a choosable input — Hetzner installs
+// `hcloud-volumes` (bp-hcloud-csi slot 55a / csi.hetzner.cloud); Huawei
+// installs `evs-ssd` (bp-huawei-evs-csi slot 55b / evs.csi.huaweicloud.com).
+// local-path is FORBIDDEN on both (k3s `--disable=local-storage` + the K23
+// Kyverno ENFORCE deny), so a per-provider cloud CSI class is ALWAYS the
+// default — never an ephemeral fallback.
+const (
+	StorageClassDefaultHetzner = "hcloud-volumes"
+	StorageClassDefaultHuawei  = "evs-ssd"
+)
+
+// defaultStorageClassForProvider returns the per-provider default cloud CSI
+// StorageClass name. Provider names are the normalized lower-cased values
+// Validate() guarantees (`hetzner` / `huawei`); any unrecognized provider
+// falls back to the Hetzner default so a future provider added to the wire
+// without a storage default still lands on a non-local-path class. A wrong
+// literal here cannot silently land ephemeral storage: the Phase-1
+// storage-durability gate independently fails any prov whose resolved
+// default class is local-path or absent.
+func defaultStorageClassForProvider(provider string) string {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "huawei":
+		return StorageClassDefaultHuawei
+	default:
+		return StorageClassDefaultHetzner
+	}
+}
+
+// DeriveStorageClass applies the #4057 defaulting rule for Request.StorageClass:
+//
+//   - Explicit non-empty value (operator chose a class in the wizard or via
+//     the API) → preserved verbatim, trimmed of surrounding whitespace.
+//   - Empty (the common case — operator accepted the wizard's pre-selected
+//     default, or a legacy/automation payload omits the field) → the
+//     per-provider cloud CSI default (hcloud-volumes / evs-ssd).
+//
+// One source of truth shared by Validate(), writeTfvars(), and the unit
+// tests — exactly one place decides the effective StorageClass for a Request.
+func DeriveStorageClass(req Request) string {
+	if sc := strings.TrimSpace(req.StorageClass); sc != "" {
+		return sc
+	}
+	return defaultStorageClassForProvider(req.Provider)
+}
+
 // RegionSpec is one entry in Request.Regions — the per-region sizing
 // payload the wizard's StepProvider produces. Each topology slot has its
 // own provider, its own cloud-region, and its own SKU vocabulary, so the
@@ -253,6 +303,21 @@ type RegionSpec struct {
 	ControlPlaneSize string `json:"controlPlaneSize"`
 	WorkerSize       string `json:"workerSize"`
 	WorkerCount      int    `json:"workerCount"`
+
+	// StorageClass — optional per-region StorageClass carried on the wire
+	// for forward-compatibility (#4057). Today the effective class is a
+	// single per-Sovereign value: Validate() folds Regions[0].StorageClass
+	// into the umbrella Request.StorageClass when the umbrella value is
+	// empty (mirroring the ControlPlaneSize/WorkerSize per-region→singular
+	// derivation), and writeTfvars threads that one umbrella value into the
+	// `default_storage_class` tofu var → the cloud-init
+	// `SOVEREIGN_CNPG_STORAGE_CLASS` substitute. Per-region cloud-init
+	// rendering of distinct classes (the mixed-provider multi-region case)
+	// would also require extending the tofu `regions` object type and the
+	// template substitute, which is out of scope here — so a value set on a
+	// non-primary region is currently accepted but not independently
+	// rendered. Kept on the struct so that extension is additive.
+	StorageClass string `json:"storageClass,omitempty"`
 
 	// ClusterMeshName — Cilium ClusterMesh peer name override for this
 	// secondary region. Empty = auto-derive as
@@ -371,6 +436,38 @@ type Request struct {
 	ControlPlaneSize string `json:"controlPlaneSize"`
 	WorkerSize       string `json:"workerSize"`
 	WorkerCount      int    `json:"workerCount"`
+
+	// StorageClass — the operator-chosen default StorageClass for this
+	// Sovereign's stateful workloads (founder point #1: "storage class is
+	// an INPUT that needs to be chosen by the user and like all the other
+	// choosable options it needs to have its defaults as well"). Issue
+	// #4057.
+	//
+	// This is an OPTIONAL input with a per-provider default. When empty
+	// (the common case — the wizard pre-selects the per-provider CSI class
+	// and most operators accept it, and every legacy/automation payload
+	// omits the field) DeriveStorageClass() fills in the durable
+	// cloud-block-storage CSI class for the chosen provider: Hetzner →
+	// `hcloud-volumes` (bp-hcloud-csi slot 55a), Huawei → `evs-ssd`
+	// (bp-huawei-evs-csi slot 55b). The k3s ephemeral local-path
+	// provisioner is FORBIDDEN (`--disable=local-storage` + the K23 Kyverno
+	// ENFORCE deny, #3971/#892) so the default is ALWAYS a durable cloud
+	// class — there is no ephemeral fallback. An operator MAY override with
+	// any class their CSI installs (e.g. a second hcloud `hcloud-volumes-
+	// xfs` profile) but the value is passed verbatim to the cloud — a class
+	// the cluster does not install leaves PVCs Pending, the same as any
+	// other unknown class name.
+	//
+	// Threading mirrors the BcpTopology / EnableSharedPostgres seam
+	// exactly: this Request field → writeTfvars `default_storage_class`
+	// tofu var (the per-provider literal when empty) → the cloud-init Flux
+	// Kustomization postBuild.substitute `SOVEREIGN_CNPG_STORAGE_CLASS`
+	// (which previously HARDCODED the per-provider literal) → the
+	// host-shared CNPG Cluster CRs in slots 10/19/52 + the bp-cnpg /
+	// bp-mgmt-vcluster default class. The matching string variable
+	// `default_storage_class` is declared in
+	// infra/providers/{hetzner,huawei}/variables.tf.
+	StorageClass string `json:"storageClass,omitempty"`
 
 	HAEnabled bool `json:"haEnabled"`
 
@@ -737,6 +834,15 @@ func (r *Request) Validate() error {
 		r.ControlPlaneSize = r.Regions[0].ControlPlaneSize
 		r.WorkerSize = r.Regions[0].WorkerSize
 		r.WorkerCount = r.Regions[0].WorkerCount
+		// #4057 — mirror the primary region's StorageClass into the
+		// umbrella singular field ONLY when the umbrella value is empty, so
+		// an operator who set the class at the top level (the common wizard
+		// shape) keeps it, while a per-region-only payload still surfaces a
+		// class to writeTfvars. Empty here flows through DeriveStorageClass
+		// to the per-provider CSI default.
+		if strings.TrimSpace(r.StorageClass) == "" {
+			r.StorageClass = r.Regions[0].StorageClass
+		}
 	}
 
 	// Provider switch (Wave 4 — Refs #2140). Empty value defaults to
@@ -2502,6 +2608,22 @@ func writeTfvars(deployDir string, req Request) error {
 		// infra/providers/{hetzner,huawei}/variables.tf carry the matching
 		// `["true","false"]` validation so a typo fails at `tofu plan`.
 		"enable_shared_pg": map[bool]string{true: "true", false: "false"}[req.EnableSharedPostgres],
+
+		// Operator-chosen default StorageClass (#4057 — founder point #1:
+		// "storage class is an INPUT chosen by the user, with defaults").
+		// DeriveStorageClass returns the operator's explicit class verbatim,
+		// or the per-provider durable cloud CSI default when empty (Hetzner
+		// → hcloud-volumes, Huawei → evs-ssd). NEVER empty, NEVER local-path
+		// (which is FORBIDDEN by --disable=local-storage + the K23 Kyverno
+		// ENFORCE deny). The Hetzner + Huawei cloud-init templates interpolate
+		// this var into the bootstrap-kit Kustomization postBuild.substitute
+		// `SOVEREIGN_CNPG_STORAGE_CLASS` — which previously HARDCODED the
+		// per-provider literal — so the host-shared CNPG Cluster CRs (slots
+		// 10/19/52) + the bp-cnpg / bp-mgmt-vcluster default class all name the
+		// chosen class. infra/providers/{hetzner,huawei}/variables.tf declare
+		// the matching string variable; a fresh prov that omits the wizard
+		// field lands byte-identical to today (the per-provider default).
+		"default_storage_class": DeriveStorageClass(req),
 
 		// QA namespace + Organization names — derived from the Sovereign
 		// FQDN's first label at provision time per principle #4 (never

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner_storage_class_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner_storage_class_test.go
@@ -1,0 +1,170 @@
+// provisioner_storage_class_test.go — #4057 coverage for the
+// operator-choosable default StorageClass seam (founder point #1: "storage
+// class is an INPUT chosen by the user, with defaults").
+//
+// The class threads Request.StorageClass → writeTfvars `default_storage_class`
+// tofu var → the cloud-init `SOVEREIGN_CNPG_STORAGE_CLASS` substitute (which
+// previously HARDCODED the per-provider literal) → the host-shared CNPG
+// Cluster CRs (slots 10/19/52) + the bp-cnpg / bp-mgmt-vcluster default class.
+//
+// These tests pin the wire:
+//
+//  1. Empty + Hetzner → hcloud-volumes (the per-provider durable CSI default).
+//  2. Empty + Huawei  → evs-ssd        (the per-provider durable CSI default).
+//  3. Explicit value  → preserved verbatim (operator chose a class).
+//  4. Per-region value folds into the umbrella when the umbrella is empty.
+//  5. local-path is NEVER emitted — the default is always a durable cloud class.
+package provisioner
+
+import "testing"
+
+// huaweiTfvarsRequest returns a minimal valid Huawei Request for the
+// storage-class tests. The Huawei credentials are `json:"-"` server-side
+// fields, so they are set directly here (the same way the handler stamps them
+// from env at POST time).
+func huaweiTfvarsRequest(t *testing.T) Request {
+	t.Helper()
+	r := baseValidateRequest(t)
+	r.Provider = "huawei"
+	// Hetzner creds are not required once Provider=huawei; the Huawei triplet is.
+	r.HetznerToken = ""
+	r.HetznerProjectID = ""
+	r.HuaweiAccessKey = "AKIA-huawei-fake"
+	r.HuaweiSecretKey = "SK-huawei-fake"
+	r.HuaweiProjectID = "f27698137bdc4b00ad509cf27f1e5547"
+	r.HuaweiRegion = "me-east-215"
+	r.Region = "me-east-215-a"
+	r.ControlPlaneSize = "s7n.large.4"
+	return *r
+}
+
+// 1. Empty StorageClass on a Hetzner prov resolves to the durable hcloud CSI
+//    default — never empty, never local-path.
+func TestWriteTfvars_StorageClass_HetznerDefault(t *testing.T) {
+	req := tfvarsRequest(t) // Hetzner base; StorageClass left empty.
+
+	out := writeTfvarsSharedPG(t, req)
+
+	if got := out["default_storage_class"]; got != StorageClassDefaultHetzner {
+		t.Errorf("default_storage_class = %v, want %q (empty input → per-provider Hetzner CSI default)", got, StorageClassDefaultHetzner)
+	}
+}
+
+// 2. Empty StorageClass on a Huawei prov resolves to the durable EVS CSI
+//    default (evs-ssd) — the bp-huawei-evs-csi slot-55b default class.
+func TestWriteTfvars_StorageClass_HuaweiDefault(t *testing.T) {
+	req := huaweiTfvarsRequest(t) // StorageClass left empty.
+
+	out := writeTfvarsSharedPG(t, req)
+
+	if got := out["default_storage_class"]; got != StorageClassDefaultHuawei {
+		t.Errorf("default_storage_class = %v, want %q (empty input → per-provider Huawei CSI default)", got, StorageClassDefaultHuawei)
+	}
+}
+
+// 3. An explicit operator choice is preserved verbatim (the founder's "INPUT
+//    chosen by the user" requirement). Surrounding whitespace is trimmed.
+func TestWriteTfvars_StorageClass_ExplicitHonored(t *testing.T) {
+	req := tfvarsRequest(t)
+	req.StorageClass = "  hcloud-volumes-xfs  " // operator chose a non-default class.
+
+	out := writeTfvarsSharedPG(t, req)
+
+	if got := out["default_storage_class"]; got != "hcloud-volumes-xfs" {
+		t.Errorf("default_storage_class = %v, want %q (explicit operator choice preserved, trimmed)", got, "hcloud-volumes-xfs")
+	}
+}
+
+// 4. A per-region StorageClass folds into the umbrella value when the umbrella
+//    field is empty (mirrors the ControlPlaneSize/WorkerSize Regions[0]
+//    derivation), so a Regions-only payload still surfaces a class to tofu.
+func TestWriteTfvars_StorageClass_PerRegionFoldsToUmbrella(t *testing.T) {
+	req := tfvarsRequest(t)
+	req.StorageClass = "" // umbrella empty.
+	req.Regions = []RegionSpec{
+		{
+			Provider:         "hetzner",
+			CloudRegion:      "fsn1",
+			ControlPlaneSize: "cpx32",
+			WorkerCount:      0,
+			StorageClass:     "hcloud-volumes-fast",
+		},
+	}
+
+	out := writeTfvarsSharedPG(t, req)
+
+	if got := out["default_storage_class"]; got != "hcloud-volumes-fast" {
+		t.Errorf("default_storage_class = %v, want %q (Regions[0].StorageClass folded into umbrella)", got, "hcloud-volumes-fast")
+	}
+}
+
+// 5. An umbrella StorageClass wins over a per-region value (the common wizard
+//    shape sets the class at the top level).
+func TestWriteTfvars_StorageClass_UmbrellaWinsOverRegion(t *testing.T) {
+	req := tfvarsRequest(t)
+	req.StorageClass = "hcloud-volumes" // umbrella set.
+	req.Regions = []RegionSpec{
+		{
+			Provider:         "hetzner",
+			CloudRegion:      "fsn1",
+			ControlPlaneSize: "cpx32",
+			WorkerCount:      0,
+			StorageClass:     "should-be-ignored",
+		},
+	}
+
+	out := writeTfvarsSharedPG(t, req)
+
+	if got := out["default_storage_class"]; got != "hcloud-volumes" {
+		t.Errorf("default_storage_class = %v, want %q (umbrella value wins over per-region)", got, "hcloud-volumes")
+	}
+}
+
+// DeriveStorageClass / defaultStorageClassForProvider unit coverage — the
+// single source of truth for the effective class. local-path is NEVER a
+// possible output.
+func TestDeriveStorageClass(t *testing.T) {
+	cases := []struct {
+		name     string
+		provider string
+		input    string
+		want     string
+	}{
+		{"hetzner-empty", "hetzner", "", StorageClassDefaultHetzner},
+		{"huawei-empty", "huawei", "", StorageClassDefaultHuawei},
+		{"empty-provider-falls-back-hetzner", "", "", StorageClassDefaultHetzner},
+		{"unknown-provider-falls-back-hetzner", "aws", "", StorageClassDefaultHetzner},
+		{"explicit-honored", "hetzner", "my-class", "my-class"},
+		{"explicit-trimmed", "huawei", "  evs-sas  ", "evs-sas"},
+		{"explicit-overrides-provider-default", "huawei", "custom", "custom"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := DeriveStorageClass(Request{Provider: tc.provider, StorageClass: tc.input})
+			if got != tc.want {
+				t.Errorf("DeriveStorageClass(provider=%q, input=%q) = %q, want %q", tc.provider, tc.input, got, tc.want)
+			}
+			if got == "local-path" || got == "" {
+				t.Errorf("DeriveStorageClass returned a FORBIDDEN/empty class %q — the default must always be a durable cloud CSI class (#3971/#892)", got)
+			}
+		})
+	}
+}
+
+// defaultStorageClassForProvider returns the right per-provider class and is
+// case/space-insensitive on the provider name.
+func TestDefaultStorageClassForProvider(t *testing.T) {
+	cases := map[string]string{
+		"hetzner":   StorageClassDefaultHetzner,
+		"Hetzner":   StorageClassDefaultHetzner,
+		"  huawei ": StorageClassDefaultHuawei,
+		"HUAWEI":    StorageClassDefaultHuawei,
+		"":          StorageClassDefaultHetzner,
+		"oci":       StorageClassDefaultHetzner,
+	}
+	for provider, want := range cases {
+		if got := defaultStorageClassForProvider(provider); got != want {
+			t.Errorf("defaultStorageClassForProvider(%q) = %q, want %q", provider, got, want)
+		}
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/store/store.go
+++ b/products/catalyst/bootstrap/api/internal/store/store.go
@@ -170,6 +170,15 @@ type RedactedRequest struct {
 	WorkerSize       string `json:"workerSize,omitempty"`
 	WorkerCount      int    `json:"workerCount,omitempty"`
 
+	// StorageClass — the operator-chosen default StorageClass (#4057),
+	// non-secret. Persisted so a reload after a Pod restart preserves the
+	// wizard's storage choice for the Settings page + FailureCard
+	// diagnostic context (the same rationale Provider/ControlPlaneSize are
+	// persisted). Empty means the operator accepted the per-provider CSI
+	// default; the effective value is re-derived by deriveStorageClass at
+	// writeTfvars time.
+	StorageClass string `json:"storageClass,omitempty"`
+
 	HAEnabled bool `json:"haEnabled,omitempty"`
 
 	Regions []provisioner.RegionSpec `json:"regions,omitempty"`
@@ -230,6 +239,7 @@ func Redact(req provisioner.Request) RedactedRequest {
 		ControlPlaneSize:    req.ControlPlaneSize,
 		WorkerSize:          req.WorkerSize,
 		WorkerCount:         req.WorkerCount,
+		StorageClass:        req.StorageClass, // #4057 — persist the operator's storage choice (non-secret)
 		HAEnabled:           req.HAEnabled,
 		Regions:             req.Regions,
 		SSHPublicKey:        req.SSHPublicKey,
@@ -297,6 +307,7 @@ func (r RedactedRequest) ToProvisionerRequest() provisioner.Request {
 		ControlPlaneSize: r.ControlPlaneSize,
 		WorkerSize:       r.WorkerSize,
 		WorkerCount:      r.WorkerCount,
+		StorageClass:     r.StorageClass, // #4057 — restore the operator's storage choice
 		HAEnabled:        r.HAEnabled,
 		Regions:          r.Regions,
 		SSHPublicKey:     r.SSHPublicKey,

--- a/products/catalyst/bootstrap/ui/src/entities/deployment/model.ts
+++ b/products/catalyst/bootstrap/ui/src/entities/deployment/model.ts
@@ -237,6 +237,16 @@ export interface WizardState {
   regions: Region[]
   controlPlaneSize: NodeSize; workerSize: NodeSize; workerCount: number; haEnabled: boolean
   /**
+   * Default storage class for the Sovereign (issue #4057). OPTIONAL —
+   * an empty string means "let the backend fill the per-provider default"
+   * (Hetzner → `hcloud-volumes`, Huawei → `evs-ssd`). The catalyst-api
+   * Request struct (`provisioner.Request.StorageClass`) already accepts
+   * this field and defaults it per-provider when empty; this is the UI
+   * seam so an operator can override the durable cloud-volume class.
+   * `local-path` is intentionally NOT a permitted value (durability).
+   */
+  storageClass: string
+  /**
    * Marketplace mode toggle (issue #710 wave 3a). When true, the
    * provisioner sets `marketplace_enabled=true` on the OpenTofu var that
    * cloud-init substitutes into the bp-catalyst-platform HelmRelease,
@@ -488,6 +498,12 @@ export const INITIAL_WIZARD_STATE: WizardState = {
   // scale agreement (issue #733). Operators can dial it back to 0
   // explicitly for solo dev/POC topologies.
   regions: [], controlPlaneSize: '', workerSize: '', workerCount: 2,
+  // Default storage class (issue #4057) — empty means "accept the
+  // per-provider backend default" (hetzner→hcloud-volumes, huawei→evs-ssd).
+  // Never seed a provider literal here: provider is null at init, so a
+  // hardcoded class would be wrong for whichever provider the operator
+  // ends up picking. The StepProvider override input fills it on demand.
+  storageClass: '',
   haEnabled: false, selectedComponents: [...computeDefaultSelection()].sort(),
   // Marketplace mode (issue #710 wave 3a) — DEFAULT ON for D27 zero-touch.
   // Founder ruling 2026-05-16: a Sovereign is provisioned ready to host

--- a/products/catalyst/bootstrap/ui/src/entities/deployment/store.ts
+++ b/products/catalyst/bootstrap/ui/src/entities/deployment/store.ts
@@ -194,6 +194,10 @@ interface WizardActions {
   setWorkerSize: (size: NodeSize) => void
   setWorkerCount: (count: number) => void
   setHaEnabled: (enabled: boolean) => void
+  // Step — Default storage class (issue #4057). Simple mirror of the
+  // setMarketplaceEnabled pattern; empty string = accept the backend's
+  // per-provider default.
+  setStorageClass: (sc: string) => void
 
   // Step — Marketplace (issue #710 wave 3a). Both setters are simple
   // mirrors of the setHaEnabled pattern; the brand setter takes a
@@ -522,6 +526,13 @@ export const useWizardStore = create<WizardStore>()(
         setWorkerSize: (workerSize) => set({ workerSize }, false, 'wizard/setWorkerSize'),
         setWorkerCount: (workerCount) => set({ workerCount }, false, 'wizard/setWorkerCount'),
         setHaEnabled: (haEnabled) => set({ haEnabled }, false, 'wizard/setHaEnabled'),
+
+        // Default storage class — issue #4057. Empty string is the common
+        // case: the catalyst-api Request struct fills the per-provider
+        // default (hetzner→hcloud-volumes, huawei→evs-ssd) when it arrives
+        // blank. A non-empty value overrides that default.
+        setStorageClass: (storageClass) =>
+          set({ storageClass }, false, 'wizard/setStorageClass'),
 
         // Marketplace mode — issue #710 wave 3a. Toggle persists via the
         // existing deploy-request → tofu var → cloud-init → Flux substitute

--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepProvider.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepProvider.tsx
@@ -488,6 +488,14 @@ export function StepProvider({ mode = 'wizard' }: StepProviderProps = {}) {
   /* Max 3 cards per row */
   const gridCols = `repeat(${Math.min(totalCards, 3)}, 1fr)`
 
+  /* Per-provider default storage class (issue #4057) — placeholder for the
+     optional override input below. Mirrors the catalyst-api Request struct's
+     server-side default so the operator sees what they'll get if they leave
+     the field blank. store.provider tracks Region 1's provider; fall back to
+     the Hetzner default when no provider is selected yet. */
+  const storageClassPlaceholder =
+    store.provider === 'huawei' ? 'evs-ssd' : 'hcloud-volumes'
+
   return (
     <StepShell
       title="Cloud provider per region"
@@ -560,6 +568,49 @@ export function StepProvider({ mode = 'wizard' }: StepProviderProps = {}) {
           €{totalHourly.toFixed(3)}/hr · €{(totalHourly * 730).toFixed(0)}/mo
         </span>
       </div>
+
+      {/* Default storage class (issue #4057) — a single OPTIONAL override.
+          Empty is the common case: the catalyst-api Request struct fills the
+          per-provider default (hetzner→hcloud-volumes, huawei→evs-ssd) when
+          this arrives blank. The placeholder mirrors that backend default so
+          the operator sees what they'll get. `local-path` is not permitted —
+          PVCs must land on a durable cloud-volume class. */}
+      <label
+        style={{
+          marginTop: 6,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 4,
+          fontSize: '0.78rem',
+          fontWeight: 600,
+          color: 'var(--wiz-text-md)',
+          letterSpacing: '0.02em',
+        }}
+      >
+        Default storage class
+        <input
+          type="text"
+          data-testid="step-provider-storage-class"
+          placeholder={storageClassPlaceholder}
+          value={store.storageClass}
+          onChange={e => store.setStorageClass(e.target.value)}
+          style={{
+            width: '100%',
+            padding: '0.55rem 0.7rem',
+            background: 'var(--wiz-bg-input)',
+            border: '1px solid var(--wiz-border-sub)',
+            borderRadius: 7,
+            color: 'var(--wiz-text-hi)',
+            font: 'inherit',
+            fontSize: '0.88rem',
+          }}
+        />
+        <span style={{ fontSize: '0.74rem', fontWeight: 400, color: 'var(--wiz-text-sub)', lineHeight: 1.45 }}>
+          Optional — defaults to the per-provider durable cloud volume class
+          {' '}(<code style={{ fontFamily: 'JetBrains Mono, monospace' }}>{storageClassPlaceholder}</code>).
+          {' '}local-path is not permitted.
+        </span>
+      </label>
     </StepShell>
   )
 }

--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepReview.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepReview.tsx
@@ -750,6 +750,12 @@ export function StepReview() {
           workerSize:       r0.workerSize,
           workerCount:      r0.workerCount,
           haEnabled:        store.haEnabled,
+          // Default storage class (issue #4057). Optional — an empty
+          // string lets the catalyst-api Request struct fill the
+          // per-provider default (hetzner→hcloud-volumes, huawei→evs-ssd).
+          // Captured on StepProvider as a sizing-adjacent cluster knob.
+          // `local-path` is not a permitted value (durability guarantee).
+          storageClass:     store.storageClass,
           // Canonical per-region payload — multi-region tofu wiring is
           // structural-correct but only Region 1 (solo path) is end-to-end
           // exercised today against a real Hetzner project. Emitting the

--- a/scripts/lint-cloudinit.sh
+++ b/scripts/lint-cloudinit.sh
@@ -112,6 +112,7 @@ fixture_common() {
     bcp_topology                      = "single-region"
     enable_hot_standby                = "false"
     enable_shared_pg                  = "false"
+    default_storage_class             = "hcloud-volumes"
     sovereign_cnpg_instances          = "1"
     wildcard_cert_issuer              = "letsencrypt-dns01-prod-powerdns"
     parent_domains_yaml               = "[{name: \"t99.omani.works\", role: \"primary\"}]"


### PR DESCRIPTION
## What & why

Founder point #1 (verbatim): *"storage class is an INPUT that needs to be chosen by the user and like all the other choosable options it needs to have its defaults as well."* Connects to the #3971 / #892 governance: local-path is FORBIDDEN; the per-provider cloud CSI must be the cluster-default StorageClass.

## The Huawei EVS CSI auth gap — already resolved on main, LIVE-PROVEN on hw182

The "EVS CSI can't authenticate" problem from the prior branches is **already fixed on `main`** (the `idc` no-Keystone AK/SK bypass, merged via #4013) and is **live-working on hw182 (dep `b78e8dcd13e6e6d6`) right now**:

- EVS CSI controller 2/2 + node 6/6, **0 restarts, 5h28m uptime** — no CrashLoop.
- Driver log: `Successfully obtained volume list, size: 189` — real SDK-HMAC-SHA256-signed EVS API calls returning 189 actual volumes. **Zero APIGW.0101 / Keystone / 401 errors.**
- `evs-ssd` is the single cluster-**default** StorageClass (`storageclass.kubernetes.io/is-default-class: "true"`), provisioner `evs.csi.huaweicloud.com`, reclaimPolicy Retain.
- cloud-config secret carries `idc=true` + correct AK/SK/project-id/region/cloud/auth-url.
- **35+ PVCs Bound on evs-ssd.** The 4 Pending PVCs are `WaitForFirstConsumer` waiting on CPU-starved pods (`0/6 nodes: Insufficient cpu`) — that is #4055 (under-provisioned Huawei workers), **not** a CSI fault.

So the chart/cluster half of #3971/#892 (EVS chart 1.0.3 idc bypass, ghcr-pull imagePullSecret, snapshotclass-off, dependsOn bp-reflector, both CSIs default-class, k3s `--disable=local-storage`, K23 Kyverno ENFORCE deny) is **done on main**. The remaining gap was the **INPUT**: `SOVEREIGN_CNPG_STORAGE_CLASS` was a hardcoded per-provider literal with no operator override. This PR closes that gap.

## Changes

**Backend (catalyst-api)**
- `provisioner.Request.StorageClass` (+ `RegionSpec.StorageClass`) — optional input.
- `DeriveStorageClass` / `defaultStorageClassForProvider` — one source of truth: explicit value verbatim, else the per-provider durable CSI default (`hetzner`→`hcloud-volumes`, `huawei`→`evs-ssd`). Never empty, never local-path.
- `writeTfvars` emits `default_storage_class`; `Validate` folds `Regions[0]` into the umbrella; `store.Redact` / `ToProvisionerRequest` persist it; `State()` surfaces the effective class for the Settings page.

**Infra (tofu)**
- `default_storage_class` string var on both providers (validation rejects `""` and `"local-path"`); per-provider default keeps a fresh prov byte-identical.
- cloud-init `SOVEREIGN_CNPG_STORAGE_CLASS` now renders `${default_storage_class}` instead of the hardcoded `hcloud-volumes` / `evs-ssd` literals.

**UI (wizard)**
- `storageClass` on `WizardState` + `setStorageClass` + an optional "Default storage class" input in `StepProvider` (per-provider placeholder) + the POST body in `StepReview`.

**No-chart-relies-on-local-path**
- The one remaining `local-path` literal (`13-bp-catalyst-platform.yaml` QA-fixtures `cnpgStorageClass`) flips `local-path` → empty so a QA Sovereign's qa-fixture CNPG uses the cluster-default durable class (the K23 Enforce policy would otherwise deny a local-path PVC).

## Verification

- `go build ./...`, `go vet ./...` clean.
- New Go tests: 14 cases (per-provider default, explicit honored, per-region fold, umbrella-wins, local-path never emitted). `provisioner` + `store` + `handler` suites green.
- New tofu cloud-init render assertions: default (`hcloud-volumes` / `evs-ssd`) + operator override land in `SOVEREIGN_CNPG_STORAGE_CLASS`, never `local-path`. **Both providers' tofu test suites pass: hetzner 12/12, huawei 7/7.**
- `scripts/lint-cloudinit.sh both` renders + `dash -n` passes for both providers.
- EVS chart `helm template` (enabled, default-class) renders `evs-ssd` + `is-default-class: "true"` + `provisioner: evs.csi.huaweicloud.com`. bootstrap-kit `kustomize build` clean.
- UI `tsc -b --noEmit` clean.

## Confirmations
- **local-path is FORBIDDEN**: tofu var validation rejects it; k3s `--disable=local-storage` + K23 Kyverno ENFORCE deny (on main); the one QA literal removed here.
- **per-provider CSI is the cluster DEFAULT**: `hcloud-volumes` (Hetzner) / `evs-ssd` (Huawei), annotated `is-default-class: "true"` (on main); the operator-chosen class threads through the same seam.
- **No Hetzner regression**: hcloud-csi default + tofu tests unchanged-green; the var defaults to `hcloud-volumes` on Hetzner.

Refs #4057 #3971 #892

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- storage class user input; per-provider CSI defaults; refs 4057 3971 892 -->
