### PR TITLE
fix(provisioning): warm bootstrap-kit COMPONENT private images to bastion Harbor (Refs #4049)

### DIFF
--- a/.github/workflows/catalyst-build.yaml
+++ b/.github/workflows/catalyst-build.yaml
@@ -403,7 +403,11 @@ jobs:
   # infra/providers/huawei/main.tf) — but the hosted project only serves what
   # has been PUSHED into it. This job NATIVE-PUSHES the current catalyst image
   # set into that bastion project on EVERY catalyst build (catalyst changes
-  # every build, so its tags must be re-warmed each time), MIRRORING the
+  # every build, so its tags must be re-warmed each time) PLUS the bootstrap-kit
+  # COMPONENT charts' private images (k8s-ws-proxy, openova-flow-*, evs-csi-plugin,
+  # …) — ROOT-CAUSE #2: those live in platform/*/chart, NOT in
+  # products/catalyst/chart, so the catalyst render never warmed them and they
+  # ImagePullBackOff'd on fresh provs. MIRRORING the
   # sovereignty-cutover 03-harbor-prewarm Job's skopeo flags + retry discipline
   # (--insecure-policy, --retry-times 5, --command-timeout, parallel fan-out,
   # OUTER per-image retry). After this lands, every kom4dc node pulls catalyst
@@ -532,9 +536,26 @@ jobs:
             "ghcr.io/openova-io/openova/catalyst-api:latest" \
             "ghcr.io/openova-io/openova/catalyst-ui:latest")"
 
+          # #4049 ROOT-CAUSE #2 — the bootstrap-kit COMPONENT charts' PRIVATE
+          # images (k8s-ws-proxy, openova-flow-server, openova-flow-adapter-flux,
+          # evs-csi-plugin, …) are NOT in products/catalyst/chart, so the render
+          # above never warmed them → they ImagePullBackOff on fresh kom4dc provs
+          # (anon proxy-ghcr 404s private packages → node cold-pulls DIRECT from
+          # ghcr → 15-min FirstSeenTimeout). Warm them too, DATA-DRIVEN from each
+          # component chart's pinned `repository:`/`tag:` (NOT a hardcoded list
+          # that rots — the deploy-bot bumps these tags, this tracks them). For
+          # every `repository: ghcr.io/openova-io/openova/X` we take the FIRST
+          # `tag:` that follows it in the same image block; empty / "latest" /
+          # *placeholder* tags are skipped (unwarmable / non-pinned).
+          compfile="$(mktemp)"
+          for f in $(grep -rlE "repository:[[:space:]]*ghcr\.io/openova-io/openova/" openova-src/platform openova-src/products --include=values.yaml 2>/dev/null | sort -u); do
+            awk 'match($0, /repository:[[:space:]]*ghcr\.io\/openova-io\/openova\/[A-Za-z0-9._\/-]+/) { line=substr($0, RSTART, RLENGTH); sub(/^.*repository:[[:space:]]*/, "", line); repo=line; have=1; next } have && match($0, /^[[:space:]]*tag:[[:space:]]*/) { t=$0; sub(/^[[:space:]]*tag:[[:space:]]*/, "", t); gsub(/["'"'"']/, "", t); sub(/[[:space:]]*#.*$/, "", t); gsub(/[[:space:]]/, "", t); if (t != "" && t != "latest" && t !~ /placeholder/) { print repo ":" t } have=0 }' "$f" >>"${compfile}"
+          done
+          components="$(cat "${compfile}"; rm -f "${compfile}")"
+
           # Union + dedup; strip any leading/trailing whitespace and blank lines
           # so every line is a clean `docker://`-able ref.
-          images="$(printf '%s\n%s\n' "${images}" "${extra}" \
+          images="$(printf '%s\n%s\n%s\n' "${images}" "${extra}" "${components}" \
             | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e '/^$/d' \
             | sort -u)"
 


### PR DESCRIPTION
## Root-cause #2 of the omantel.biz fresh-prov failures

The #4049 bastion Harbor warmup (`catalyst-build.yaml` → `warmup-bastion-harbor`) rendered **only** `products/catalyst/chart`, so it seeded the catalyst CORE (19 repos: catalyst-api/ui/console/controllers/services) into the bastion hosted `openova-io` project — but **NOT** the bootstrap-kit component charts' private images, which live in `platform/*/chart`:

- `ghcr.io/openova-io/openova/k8s-ws-proxy`
- `ghcr.io/openova-io/openova/openova-flow-server`
- `ghcr.io/openova-io/openova/openova-flow-adapter-flux`
- `ghcr.io/openova-io/openova/evs-csi-plugin`
- (+ guacd/guacamole-server, nemo-guardrails, newapi-mirror, newapi-sandbox-bridge, cert-manager-dynadot-webhook, sandbox-controller, services-metering-sidecar)

These were never pushed into the bastion project, and the anonymous `proxy-ghcr` cache **404s private packages** (can't do ghcr's 2-step bearer flow). So fresh kom4dc nodes cold-pulled them **DIRECT from ghcr** (~2.3 MB/s over the throttled Huawei→ghcr NAT) and `ImagePullBackOff`'d past the 15-min `FirstSeenTimeout`.

## Fix

Extend the warmup render step to ALSO warm every component chart's pinned private image, **data-driven** from each chart's `repository:`/`tag:` — NOT a hardcoded list that rots, since the deploy-bot bumps these tags and the awk pass tracks them automatically.

For each `repository: ghcr.io/openova-io/openova/X`, take the first `tag:` in the same image block; skip empty / `latest` / `*placeholder*` tags (unwarmable / non-pinned, e.g. anthropic-adapter, openclaw, axon).

## Verification

- Locally simulated the exact workflow snippet over `platform/` + `products/` → extracts all **12** component private images with correct tags (incl. the 4 critical ones), correctly skipping the empty/`latest`/`placeholder` tags.
- YAML parses (`yaml.safe_load`).
- The 4 critical images were **also warm-pushed live** to the bastion `openova-io` project (digest-verified against the hw173 node testdata: k8s-ws-proxy `0e3c679c…`) to unblock the in-flight omantel.biz re-fire.

Refs #4049

🤖 Generated with [Claude Code](https://claude.com/claude-code)