### PR TITLE
fix(bp-catalyst-api): route console/api/marketplace at the console LB IP in PowerDNS parent-zone write (Refs #4069 #4054)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_dns_records.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_dns_records.go
@@ -34,6 +34,7 @@ package handler
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/powerdns"
@@ -92,14 +93,88 @@ var CanonicalSovereignSubdomains = []string{
 	"sandbox",
 }
 
+// ConsoleGatewaySubdomains — the subset of CanonicalSovereignSubdomains whose
+// HTTPRoutes parent the DEDICATED console gateway (`cilium-gateway-console`,
+// #4053 / #4054) rather than the shared `cilium-gateway`. Their A-records MUST
+// point at the console load-balancer IP (the console ELB / dedicated console LB)
+// — the shared gateway carries no listener/route for these hosts, so resolving
+// them at the shared LB IP returns 404.
+//
+// Source of truth — this MUST stay in lockstep with the chart's console-gateway
+// membership, which is the single `ingress.gateway.parentRef.name:
+// cilium-gateway-console` default applied to exactly these HTTPRoutes:
+//   - products/catalyst/chart/templates/httproute.yaml          (catalyst-ui → console.<fqdn>, catalyst-api → api.<fqdn>)
+//   - products/catalyst/chart/templates/services/catalog/httproute.yaml (catalyst-catalog → api.<fqdn>)
+//   - products/catalyst/chart/templates/org-services/marketplace-routes.yaml (marketplace → marketplace.<fqdn>)
+//
+// Verified live on the permanent omantel.biz Sovereign (dep 4635277cae4ffed9,
+// 2026-06-22): `kubectl get httproute -A` showed catalyst-ui/catalyst-api/
+// catalyst-catalog/marketplace parenting cilium-gateway-console (EIP …33) while
+// every other route parented cilium-gateway (EIP …31). console/api/marketplace
+// served 404 on …31 and 200 on …33 (Refs #4069). The #4054 commit message
+// claimed marketplace stays on the shared gateway — the live cluster contradicts
+// it because the marketplace route inherits the same parentRef default.
+//
+// Operator-overridable via CATALYST_CONSOLE_GATEWAY_SUBDOMAINS (comma-separated)
+// for the rare topology that re-parents a different subset. Any entry here that
+// is NOT also in CanonicalSovereignSubdomains is still written (so an operator
+// can add a console-gateway-only host), but the canonical set already contains
+// all three so no record is dropped.
+var ConsoleGatewaySubdomains = []string{
+	"console",
+	"api",
+	"marketplace",
+}
+
+// consoleGatewaySubdomainSet returns ConsoleGatewaySubdomains as a lookup set,
+// honouring the CATALYST_CONSOLE_GATEWAY_SUBDOMAINS override.
+func consoleGatewaySubdomainSet() map[string]struct{} {
+	subs := ConsoleGatewaySubdomains
+	if raw := strings.TrimSpace(os.Getenv("CATALYST_CONSOLE_GATEWAY_SUBDOMAINS")); raw != "" {
+		subs = nil
+		for _, tok := range strings.Split(raw, ",") {
+			if tok = strings.TrimSpace(tok); tok != "" {
+				subs = append(subs, tok)
+			}
+		}
+	}
+	out := make(map[string]struct{}, len(subs))
+	for _, s := range subs {
+		out[strings.ToLower(s)] = struct{}{}
+	}
+	return out
+}
+
+// recordTargetIP picks the A-record target for a given canonical subdomain:
+// the console LB IP for console-gateway hosts (when a dedicated console LB
+// exists), otherwise the shared/primary LB IP. consoleLBIP == "" (module
+// pre-#4053, or no console-gateway isolation) collapses to lbIP for every host
+// — byte-identical to the pre-#4069 behaviour.
+func recordTargetIP(subdomain, lbIP, consoleLBIP string, consoleSet map[string]struct{}) string {
+	if consoleLBIP == "" {
+		return lbIP
+	}
+	if _, ok := consoleSet[strings.ToLower(subdomain)]; ok {
+		return consoleLBIP
+	}
+	return lbIP
+}
+
 // upsertSovereignParentZoneRecords PATCHes the parent zone with A
 // records that route every CanonicalSovereignSubdomain at the
-// Sovereign's primary load-balancer IP.
+// Sovereign's primary load-balancer IP — except the ConsoleGatewaySubdomains,
+// which point at consoleLBIP (the dedicated console LB) when one exists (#4069).
 //
 // Inputs come from the Phase-0 tofu output:
 //   - sovereignFQDN: e.g. "t111.omani.works"
 //   - parentZone:    e.g. "omani.works"  (parent of sovereignFQDN)
-//   - lbIP:          e.g. "77.42.11.95"  (primary region Hetzner LB)
+//   - lbIP:          e.g. "77.42.11.95"  (primary/shared region LB)
+//   - consoleLBIP:   optional (variadic so existing callers compile). #4069.
+//     When non-empty, the ConsoleGatewaySubdomains (console/api/marketplace —
+//     the hosts whose HTTPRoutes parent the dedicated cilium-gateway-console)
+//     point HERE instead of lbIP, so a fresh prov writes the console front
+//     doors at the console LB. Empty/omitted → every record points at lbIP
+//     (byte-identical to pre-#4069 behaviour for module-pre-#4053 Sovereigns).
 //
 // Idempotent: PowerDNS PATCH REPLACE rewrites the rrset on every call.
 //
@@ -107,7 +182,7 @@ var CanonicalSovereignSubdomains = []string{
 // provision or log + continue (today we log + continue so the Sovereign
 // still reaches phase1-watching even if PowerDNS is briefly unavailable;
 // the operator can re-trigger via the parent-domain refresh endpoint).
-func (h *Handler) upsertSovereignParentZoneRecords(ctx context.Context, sovereignFQDN, parentZone, lbIP string) error {
+func (h *Handler) upsertSovereignParentZoneRecords(ctx context.Context, sovereignFQDN, parentZone, lbIP string, consoleLBIP ...string) error {
 	if h.powerdnsZoneClient == nil {
 		h.log.Info("sovereign-dns-records: skipping (no powerdns client wired)",
 			"sovereignFQDN", sovereignFQDN,
@@ -131,20 +206,30 @@ func (h *Handler) upsertSovereignParentZoneRecords(ctx context.Context, sovereig
 		}
 	}
 
+	// #4069 — resolve the console front-door IP (defaults to lbIP when the
+	// console gateway is not isolated, i.e. consoleLBIP is omitted/empty).
+	consoleIP := ""
+	if len(consoleLBIP) > 0 {
+		consoleIP = strings.TrimSpace(consoleLBIP[0])
+	}
+	consoleSet := consoleGatewaySubdomainSet()
+
 	subdomains := CanonicalSovereignSubdomains
 	rrsets := make([]powerdns.RRSet, 0, len(subdomains)+1)
 	for _, sub := range subdomains {
+		target := recordTargetIP(sub, lbIP, consoleIP, consoleSet)
 		rrsets = append(rrsets, powerdns.RRSet{
 			Name:       sub + "." + sovereignFQDN + ".",
 			Type:       "A",
 			TTL:        60,
 			ChangeType: "REPLACE",
-			Records:    []powerdns.Record{{Content: lbIP, Disabled: false}},
+			Records:    []powerdns.Record{{Content: target, Disabled: false}},
 		})
 	}
 	// Also stamp the bare FQDN apex (e.g. t111.omani.works. itself) for
 	// dashboard "Open Sovereign Console →" deep-links and for ACME
-	// clients that probe the apex first.
+	// clients that probe the apex first. The apex is NOT a console-gateway
+	// host (it has no isolated HTTPRoute) so it stays on the shared lbIP.
 	rrsets = append(rrsets, powerdns.RRSet{
 		Name:       sovereignFQDN + ".",
 		Type:       "A",
@@ -160,6 +245,7 @@ func (h *Handler) upsertSovereignParentZoneRecords(ctx context.Context, sovereig
 		"sovereignFQDN", sovereignFQDN,
 		"parentZone", parentZone,
 		"lbIP", lbIP,
+		"consoleLBIP", consoleIP,
 		"recordCount", len(rrsets),
 	)
 	return nil
@@ -209,7 +295,7 @@ func (h *Handler) upsertSovereignParentZoneRecordsFromResult(ctx context.Context
 	}
 
 	for _, parent := range parents {
-		err := h.upsertSovereignParentZoneRecords(ctx, result.SovereignFQDN, parent, result.LoadBalancerIP)
+		err := h.upsertSovereignParentZoneRecords(ctx, result.SovereignFQDN, parent, result.LoadBalancerIP, result.ConsoleLoadBalancerIP)
 		if err == nil {
 			continue
 		}
@@ -232,7 +318,7 @@ func (h *Handler) upsertSovereignParentZoneRecordsFromResult(ctx context.Context
 					"originalParent", parent,
 					"derivedParent", derivedParent,
 				)
-				if err2 := h.upsertSovereignParentZoneRecords(ctx, result.SovereignFQDN, derivedParent, result.LoadBalancerIP); err2 == nil {
+				if err2 := h.upsertSovereignParentZoneRecords(ctx, result.SovereignFQDN, derivedParent, result.LoadBalancerIP, result.ConsoleLoadBalancerIP); err2 == nil {
 					continue
 				} else {
 					err = fmt.Errorf("original=%w, derived-fallback=%v", err, err2)

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_dns_records_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_dns_records_test.go
@@ -1,6 +1,8 @@
 package handler
 
-import "testing"
+import (
+	"testing"
+)
 
 // TestCanonicalSovereignSubdomainsCoversBrowserFacingApps guards the parent-zone
 // A-record allowlist against the recurring class of bug where a Sovereign app
@@ -49,5 +51,101 @@ func TestCanonicalSovereignSubdomainsCoversBrowserFacingApps(t *testing.T) {
 		if _, ok := have[sub]; !ok {
 			t.Errorf("CanonicalSovereignSubdomains is missing %q — its HTTPRoute is Accepted but %s.<fqdn> will return NXDOMAIN (the #3263/#3225 gap class)", sub, sub)
 		}
+	}
+}
+
+// TestConsoleGatewaySubdomainsAreCanonicalSubset guards #4069: every host that
+// parents the dedicated cilium-gateway-console (and thus must resolve at the
+// console LB IP) MUST also be a CanonicalSovereignSubdomain, otherwise the
+// DNS-write loop would never visit it and the console LB record would never be
+// written. It also pins the expected set (console/api/marketplace) so a future
+// re-parenting in the chart is reflected here in lockstep.
+func TestConsoleGatewaySubdomainsAreCanonicalSubset(t *testing.T) {
+	canon := make(map[string]struct{}, len(CanonicalSovereignSubdomains))
+	for _, s := range CanonicalSovereignSubdomains {
+		canon[s] = struct{}{}
+	}
+	for _, s := range ConsoleGatewaySubdomains {
+		if _, ok := canon[s]; !ok {
+			t.Errorf("ConsoleGatewaySubdomains entry %q is not in CanonicalSovereignSubdomains — the DNS-write loop iterates the canonical set, so %s.<fqdn> would never be written at the console LB", s, s)
+		}
+	}
+
+	want := map[string]struct{}{"console": {}, "api": {}, "marketplace": {}}
+	if len(ConsoleGatewaySubdomains) != len(want) {
+		t.Fatalf("ConsoleGatewaySubdomains = %v; want exactly console/api/marketplace (the live cilium-gateway-console membership on omantel.biz, Refs #4069)", ConsoleGatewaySubdomains)
+	}
+	for _, s := range ConsoleGatewaySubdomains {
+		if _, ok := want[s]; !ok {
+			t.Errorf("unexpected ConsoleGatewaySubdomains entry %q — keep in lockstep with the chart's cilium-gateway-console parentRef membership", s)
+		}
+	}
+}
+
+// TestRecordTargetIP is the heart of #4069: console-gateway hosts resolve at the
+// console LB IP when one exists; everything else stays on the shared LB IP; and
+// an empty consoleLBIP (module pre-#4053) collapses every host to the shared IP
+// — byte-identical to the pre-#4069 behaviour.
+func TestRecordTargetIP(t *testing.T) {
+	const (
+		sharedIP  = "212.72.24.31"
+		consoleIP = "212.72.24.33"
+	)
+	set := consoleGatewaySubdomainSet()
+
+	cases := []struct {
+		name       string
+		sub        string
+		lbIP       string
+		consoleLB  string
+		wantTarget string
+	}{
+		// Split active: console-gateway hosts → console LB.
+		{"console→consoleLB", "console", sharedIP, consoleIP, consoleIP},
+		{"api→consoleLB", "api", sharedIP, consoleIP, consoleIP},
+		{"marketplace→consoleLB", "marketplace", sharedIP, consoleIP, consoleIP},
+		// Split active: shared-gateway hosts stay on the shared LB.
+		{"gitea→sharedLB", "gitea", sharedIP, consoleIP, sharedIP},
+		{"auth→sharedLB", "auth", sharedIP, consoleIP, sharedIP},
+		{"registry→sharedLB", "registry", sharedIP, consoleIP, sharedIP},
+		{"newapi→sharedLB", "newapi", sharedIP, consoleIP, sharedIP},
+		{"sandbox→sharedLB", "sandbox", sharedIP, consoleIP, sharedIP},
+		// Case-insensitivity on the subdomain.
+		{"CONSOLE upper→consoleLB", "CONSOLE", sharedIP, consoleIP, consoleIP},
+		// No split (module pre-#4053): everything collapses to lbIP.
+		{"console no-split", "console", sharedIP, "", sharedIP},
+		{"api no-split", "api", sharedIP, "", sharedIP},
+		{"gitea no-split", "gitea", sharedIP, "", sharedIP},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := recordTargetIP(tc.sub, tc.lbIP, tc.consoleLB, set)
+			if got != tc.wantTarget {
+				t.Errorf("recordTargetIP(%q, %q, %q) = %q; want %q",
+					tc.sub, tc.lbIP, tc.consoleLB, got, tc.wantTarget)
+			}
+		})
+	}
+}
+
+// TestConsoleGatewaySubdomainSetOverride verifies the
+// CATALYST_CONSOLE_GATEWAY_SUBDOMAINS env override replaces (not appends-to) the
+// compiled-in set, so an unusual topology can re-parent a different subset.
+func TestConsoleGatewaySubdomainSetOverride(t *testing.T) {
+	t.Setenv("CATALYST_CONSOLE_GATEWAY_SUBDOMAINS", "console, api ,foo")
+	set := consoleGatewaySubdomainSet()
+	for _, want := range []string{"console", "api", "foo"} {
+		if _, ok := set[want]; !ok {
+			t.Errorf("override set missing %q", want)
+		}
+	}
+	if _, ok := set["marketplace"]; ok {
+		t.Errorf("override should REPLACE the default set, but marketplace leaked through")
+	}
+	if got := recordTargetIP("foo", "1.1.1.1", "2.2.2.2", set); got != "2.2.2.2" {
+		t.Errorf("override host foo should resolve to consoleLB; got %q", got)
+	}
+	if got := recordTargetIP("marketplace", "1.1.1.1", "2.2.2.2", set); got != "1.1.1.1" {
+		t.Errorf("marketplace no longer in overridden set → should resolve to sharedLB; got %q", got)
 	}
 }

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_dns_republish.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_dns_republish.go
@@ -169,7 +169,7 @@ func (h *Handler) HandleRepublishDNS(w http.ResponseWriter, r *http.Request) {
 	var errs []string
 	resolvedParents := make([]string, 0, len(parents))
 	for _, parent := range parents {
-		if err := h.upsertSovereignParentZoneRecords(r.Context(), result.SovereignFQDN, parent, result.LoadBalancerIP); err == nil {
+		if err := h.upsertSovereignParentZoneRecords(r.Context(), result.SovereignFQDN, parent, result.LoadBalancerIP, result.ConsoleLoadBalancerIP); err == nil {
 			resolvedParents = append(resolvedParents, parent)
 			continue
 		} else if strings.Contains(err.Error(), "status 404") && parent == result.SovereignFQDN {
@@ -180,7 +180,7 @@ func (h *Handler) HandleRepublishDNS(w http.ResponseWriter, r *http.Request) {
 					"originalParent", parent,
 					"derivedParent", derivedParent,
 				)
-				if err2 := h.upsertSovereignParentZoneRecords(r.Context(), result.SovereignFQDN, derivedParent, result.LoadBalancerIP); err2 == nil {
+				if err2 := h.upsertSovereignParentZoneRecords(r.Context(), result.SovereignFQDN, derivedParent, result.LoadBalancerIP, result.ConsoleLoadBalancerIP); err2 == nil {
 					resolvedParents = append(resolvedParents, derivedParent)
 					continue
 				} else {


### PR DESCRIPTION
## Problem

#4054 (commit 79c091a69, Refs #4053) isolated the customer-facing front doors onto a dedicated `cilium-gateway-console` fronted by its own cloud LB (the console ELB). The Dynadot pool-domain helper (`AddSovereignRecords`) got the console-LB-IP split — but the **PowerDNS parent-zone writer**, which is the path that actually serves a delegated byo-api Sovereign, was never updated. It writes every `CanonicalSovereignSubdomain` → the single primary `LoadBalancerIP`, so `console`/`api`/`marketplace` resolve to the **shared** ELB (whose gateway has no route for them) → **404**.

## Live proof (permanent omantel.biz Sovereign, dep 4635277cae4ffed9, Huawei kom4dc)

`omantel.biz` is delegated to `ns1/ns2.openova.io` (mothership PowerDNS). The authoritative zone had:

```
console.omantel.biz.      A  212.72.24.31   (shared ELB → 404)
api.omantel.biz.          A  212.72.24.31   (shared ELB → 404)
marketplace.omantel.biz.  A  212.72.24.31   (shared ELB → 404)
```

The deployment result already carried `consoleLoadBalancerIP: 212.72.24.33` — the data was present; the DNS-write dropped it.

Live HTTPRoute parent membership (ground truth, `kubectl get httproute -A`):
- console / api / marketplace (+ catalyst-catalog) → **cilium-gateway-console** (EIP …33)
- gitea / grafana / harbor(registry) / auth / newapi / bao / guacamole / pdns / hubble / openova-flow / pdns-admin → cilium-gateway (EIP …31)

```
curl --resolve console.omantel.biz:443:212.72.24.33 https://console.omantel.biz/ → 200  <title>OpenOva Corporate</title>
curl --resolve console.omantel.biz:443:212.72.24.31 https://console.omantel.biz/ → 404
curl --resolve marketplace.omantel.biz:443:212.72.24.33 …                        → 200
curl --resolve marketplace.omantel.biz:443:212.72.24.31 …                        → 404
```

(The #4054 commit message claimed marketplace stays on the shared gateway — the live cluster contradicts it, because `templates/org-services/marketplace-routes.yaml` inherits the `ingress.gateway.parentRef.name: cilium-gateway-console` default. So the correct console-EIP set is console + api + marketplace.)

## Fix

- New `ConsoleGatewaySubdomains` set (`console`/`api`/`marketplace`) kept in lockstep with the chart's `cilium-gateway-console` parentRef membership; overridable via `CATALYST_CONSOLE_GATEWAY_SUBDOMAINS`.
- `recordTargetIP()` routes console-gateway hosts at the console LB IP when one exists; everything else (and the apex) stays on the shared LB. Empty `consoleLBIP` (module pre-#4053) collapses to `lbIP` — byte-identical legacy behaviour.
- Threads `result.ConsoleLoadBalancerIP` through `upsertSovereignParentZoneRecords` at **both** writers: prov-time (`upsertSovereignParentZoneRecordsFromResult`) and the operator `HandleRepublishDNS` re-trigger.
- Tests: split matrix (incl. no-split + case-insensitivity), console-set ⊆ canonical-set guard, env-override replace semantics. `go build ./...` + `go test ./internal/handler/` green.

## Live mitigation (already applied out-of-band)

Surgical PowerDNS PATCH (REPLACE) of the 3 rrsets → 212.72.24.33 on the mothership `omantel.biz` zone (serial 2026062108 → 2026062109). `https://console.omantel.biz/` now serves 200 via real DNS. This PR makes it permanent so a fresh prov never re-hits it.

Refs #4069 #4053 #4054

🤖 Generated with [Claude Code](https://claude.com/claude-code)