### PR TITLE
fix(catalyst-api): disable client-go WatchListClient gate — kill persistent 'Failed to watch apps.openova.io/applications' reflector spam (Refs #4071)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-chi/cors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"k8s.io/client-go/dynamic"
+	clientgofeatures "k8s.io/client-go/features"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
@@ -44,6 +45,37 @@ func main() {
 	corsOrigin := env("CORS_ORIGIN", "*")
 
 	log := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	// #4071 — disable client-go's WatchListClient feature gate BEFORE any
+	// client / informer is constructed.
+	//
+	// Root cause: client-go v0.36 ships WatchListClient as a Beta gate that
+	// is DEFAULT-ON from v1.35 (see k8s.io/client-go/features). With it on,
+	// the reflector's primary path is the streaming watch-list
+	// (`?sendInitialEvents=true&resourceVersionMatch=NotOlderThan&watch=true`)
+	// instead of the classic LIST+WATCH. On the Sovereign chroot's k3s
+	// apiserver this streaming-list path intermittently returns
+	// `the server could not find the requested resource` for freshly-served
+	// CRDs (apps.openova.io/applications, orgs.openova.io/organizations,
+	// catalyst.openova.io/{blueprints,environments}, dr.openova.io/{continuums,
+	// cnpgpairs}, sandbox.openova.io/sandboxes). The reflector logs
+	// `reflector.go "Failed to watch"` and retries the SAME failing streaming
+	// path forever — it never falls through to the plain LIST+WATCH that the
+	// apiserver serves perfectly (verified live on omantel.biz: a direct
+	// `GET /apis/apps.openova.io/v1/applications` returns 200 with items, yet
+	// the in-process informer 404s on every retry). A pod restart does NOT fix
+	// it because every fresh reflector re-takes the same broken streaming path.
+	// Net effect: the Application/Org/Blueprint/Environment informers never
+	// sync → the console Apps view shows every platform app PENDING, and
+	// user-installed apps (agenity/WordPress) never reach Ready through the
+	// k8scache SSE stream either.
+	//
+	// Disabling the gate forces the reflector back to LIST+WATCH (the path
+	// proven working against this apiserver), recovering WITHOUT a restart on
+	// the next reflector relist. Set programmatically so the fix travels with
+	// the binary and protects every fresh prov regardless of chart env wiring;
+	// an operator can still re-enable via KUBE_FEATURE_WatchListClient=true.
+	disableWatchListClient(log)
 
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)
@@ -1962,6 +1994,44 @@ func env(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// disableWatchListClient turns OFF the client-go WatchListClient feature gate
+// so every reflector built by this process uses the classic LIST+WATCH path
+// instead of the streaming watch-list (#4071 — see the call site in main for
+// the full root-cause analysis).
+//
+// The default client-go feature-gate implementation (k8s.io/client-go/features
+// FeatureGates()) is an *envVarFeatureGates, whose concrete type carries a
+// `Set(Feature, bool) error` method that takes precedence over both the
+// built-in default and the KUBE_FEATURE_* env var. We type-assert to that
+// method set (the exported Gates interface only declares Enabled) and Set the
+// gate to false. The Set MUST happen before the first Enabled() read — i.e.
+// before any client/informer is constructed — because the env-var snapshot is
+// loaded exactly once on the first Enabled() call. main calls this as its first
+// real action, so the ordering holds.
+//
+// If the assertion ever fails (a future client-go swaps the default gate
+// implementation), fall back to the supported env-var mechanism so the gate is
+// still disabled; both are honoured by client-go's own resolution order.
+func disableWatchListClient(log *slog.Logger) {
+	type settableGates interface {
+		Set(clientgofeatures.Feature, bool) error
+	}
+	if g, ok := clientgofeatures.FeatureGates().(settableGates); ok {
+		if err := g.Set(clientgofeatures.WatchListClient, false); err != nil {
+			log.Warn("client-go: failed to disable WatchListClient via Set; falling back to env var",
+				"err", err)
+			_ = os.Setenv("KUBE_FEATURE_WatchListClient", "false")
+			return
+		}
+		log.Info("client-go: WatchListClient feature gate disabled (reflectors use classic LIST+WATCH) — #4071")
+		return
+	}
+	// Default gate implementation not settable — use the env-var mechanism,
+	// which client-go reads on the first Enabled() call.
+	_ = os.Setenv("KUBE_FEATURE_WatchListClient", "false")
+	log.Info("client-go: WatchListClient disabled via KUBE_FEATURE_WatchListClient env var — #4071")
 }
 
 // envInt returns the parsed integer value of an env var, or fallback

--- a/products/catalyst/bootstrap/api/cmd/api/main_test.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main_test.go
@@ -21,9 +21,29 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clientgofeatures "k8s.io/client-go/features"
 
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler"
 )
+
+// TestDisableWatchListClient_TurnsGateOff is the #4071 regression guard.
+// client-go v0.36 ships WatchListClient default-ON (Beta from v1.35); on the
+// Sovereign chroot's k3s apiserver the streaming watch-list path that gate
+// selects 404s freshly-served CRDs (apps.openova.io/applications et al) and
+// the reflector never falls back to the working LIST+WATCH. disableWatchListClient
+// must flip the effective gate OFF so reflectors use classic LIST+WATCH.
+func TestDisableWatchListClient_TurnsGateOff(t *testing.T) {
+	// Sanity: default is ON for the client-go version we build against — if a
+	// future bump flips the default OFF, this test's premise is moot (and the
+	// production call becomes a harmless no-op), so just skip rather than fail.
+	if !clientgofeatures.FeatureGates().Enabled(clientgofeatures.WatchListClient) {
+		t.Skip("WatchListClient already disabled by default in this client-go version; #4071 call is a no-op")
+	}
+	disableWatchListClient(silentLogger())
+	if clientgofeatures.FeatureGates().Enabled(clientgofeatures.WatchListClient) {
+		t.Fatalf("WatchListClient still enabled after disableWatchListClient — reflectors will take the broken streaming watch-list path (#4071)")
+	}
+}
 
 // newBakeTimeSeedFakeClient — mirrors the fake-dynamic-client pattern
 // in handler/user_access_owner_seed_test.go::newOwnerSeedFakeClient


### PR DESCRIPTION
## Root cause (Refs #4071)

`client-go v0.36` ships the **`WatchListClient`** feature gate **default-ON** (Beta from v1.35 — see `k8s.io/client-go/features`). With it on, every reflector's primary path is the **streaming watch-list** (`?sendInitialEvents=true&resourceVersionMatch=NotOlderThan&watch=true`) instead of the classic LIST+WATCH.

On the Sovereign chroot's **k3s** apiserver that streaming-list path intermittently returns `the server could not find the requested resource` for freshly-served CRDs — and the reflector **retries the SAME broken path forever**, never falling through to the plain LIST+WATCH the apiserver serves perfectly.

### Live evidence (omantel.biz, dep `4635277cae4ffed9`)

The in-cluster catalyst-api reflector logs, continuously and right now:

```
reflector.go "Failed to watch" err="failed to list apps.openova.io/v1, Resource=applications: the server could not find the requested resource" type="apps.openova.io/v1, Resource=applications"
```

…for the WHOLE Catalyst CRD family: `apps.openova.io/applications`, `orgs.openova.io/organizations`, `catalyst.openova.io/{blueprints,environments}`, `dr.openova.io/{continuums,cnpgpairs}`, `sandbox.openova.io/sandboxes`.

Yet, against the **same apiserver with the same SA token**:
- discovery serves the GVR with all verbs (`/apis/apps.openova.io/v1` -> `applications` incl. `list`,`watch`)
- a direct `GET /apis/apps.openova.io/v1/applications` returns **200 with items**
- `kubectl auth can-i list applications.apps.openova.io --as=...catalyst-api-cutover-driver` -> **yes**
- the ClusterRole + ClusterRoleBinding both grant `applications` get/list/watch

So it is **not** RBAC, not discovery staleness, not an establishment race (a pod restart provably does NOT fix it — every fresh reflector re-takes the same streaming path). The CRD informers never sync, so the k8scache-backed surfaces (the `/cloud?view=list&kind=application` per-kind list, the Reconciliation DAG, the dashboard treemap) render these kinds empty/PENDING.

## Fix

Disable the `WatchListClient` gate at the very start of `main()`, **before any client/informer is constructed**, forcing reflectors back to the classic LIST+WATCH path (proven working against this apiserver). Set **programmatically** via the client-go feature-gate `Set()` method (with `KUBE_FEATURE_WatchListClient=false` env-var fallback) so the fix travels with the binary and protects **every fresh prov** regardless of chart env wiring. Recovers **without a pod restart** on the next reflector relist.

## Scope — does this affect USER-installed Application status?

**No.** The dedicated `/applications` API (`HandleApplicationList`) and per-app status stream (`HandleApplicationStream`) read Application `status.phase` **directly via the dynamic client**, NOT the broken informer — confirmed live: the 3 Applications report `status.phase: Ready` and the list/AppDetail paths surface that correctly. So installed-app Ready status (agenity / WordPress) is **unaffected**, and the agentic-journey walk is **not held up** by this.

The defect is confined to the **k8scache informer-backed display surfaces** (per-kind cloud-list, recon DAG, treemap for these CRD kinds).

## Tests

- `go build ./cmd/api/` green
- `go vet ./cmd/api/` green
- `go test ./cmd/api/` green — adds `TestDisableWatchListClient_TurnsGateOff` regression guard (asserts the effective gate flips OFF; skips if a future client-go bump defaults it OFF).

## Verification still owed (orchestrator / fresh-prov walk)

This Sovereign's image is pinned, so the live fix can't be rolled here. On the next catalyst-api image bump + fresh prov: confirm the `reflector.go "Failed to watch ... apps.openova.io"` spam is GONE and `k8scache: informer synced kind=application` appears.

Refs #4071 #3687
