### PR TITLE
fix(catalyst): ListParentDomains org-pool fallback unblocks Create-Org form on JWT-only-handover Sovereigns (Refs #4073)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/parent_domains.go
+++ b/products/catalyst/bootstrap/api/internal/handler/parent_domains.go
@@ -319,6 +319,33 @@ func removeParentDomainByName(dep *Deployment, name string) bool {
 // the function falls back to the env-var-based primary synthesis path
 // so single-Sovereign sandboxes + tests keep rendering the implicit
 // primary row.
+//
+// Org-pool fallback (issue #4073)
+// -------------------------------
+// On a Sovereign provisioned via a flat byo-api / JWT-only handover, NO
+// deployment record is imported (handover is JWT-only — nothing POSTs to
+// /api/v1/internal/deployments/import), so `activeDeployment()` returns
+// nil and the bake-time `chrootEnsureOrgPoolSeed` — which would seed the
+// four canonical .omani.X org-pool entries onto the record — never runs.
+// The result is that this list returned ONLY the synthesised primary, the
+// Create-Org form (which filters to role=org-pool) showed "No pool parents
+// available", and customer/internal sub-Orgs could not be created.
+//
+// Meanwhile the org-create POST validation (poolDomainsForOrgCreate →
+// OrganizationDeps.ParentDomains) is ALWAYS seeded at startup via
+// LoadOrganizationParentDomainsFromEnv() (which returns the four canonical
+// .omani.X entries even when CATALYST_ORG_POOL_DOMAINS is unset). So a POST
+// with parent_domain=omani.homes would already be accepted — the only thing
+// missing was the user's ability to SELECT it because the GET list was empty.
+//
+// This fallback closes that asymmetry: when neither the active deployment
+// nor any persisted record yields an org-pool entry, we surface the same
+// env-seeded org-pool the create handler validates against (via
+// h.orgTenantDeps.PoolDomains()). The GET list and the POST validation are
+// then sourced from the SAME pool, so what the form offers == what a create
+// accepts. No-op on Sovereigns that DO carry an adopted record with org-pool
+// rows (the chroot-seed path) — those entries already list and the fallback
+// is skipped.
 func (h *Handler) ListParentDomains(w http.ResponseWriter, r *http.Request) {
 	dep := h.activeDeployment()
 
@@ -347,6 +374,46 @@ func (h *Handler) ListParentDomains(w http.ResponseWriter, r *http.Request) {
 				AddedAt:    time.Time{},
 			}}, items...)
 		}
+	}
+
+	// Org-pool fallback (#4073). When the record-backed list carries no
+	// role=org-pool entry, surface the env-seeded org-pool that the
+	// org-create POST validation already accepts. Keeps the form's
+	// dropdown == the create handler's accept-set on JWT-only-handover
+	// Sovereigns with no imported deployment record.
+	hasOrgPool := false
+	for _, it := range items {
+		if it.Role == RoleOrgPool {
+			hasOrgPool = true
+			break
+		}
+	}
+	if !hasOrgPool {
+		seen := map[string]struct{}{}
+		for _, it := range items {
+			seen[strings.ToLower(it.Name)] = struct{}{}
+		}
+		for _, p := range h.orgTenantDeps.PoolDomains() {
+			key := strings.ToLower(strings.TrimSpace(p.Name))
+			if key == "" {
+				continue
+			}
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			flip := FlipStatusReady
+			if !p.NSFlipReady {
+				flip = FlipStatusFlipping
+			}
+			items = append(items, ParentDomain{
+				Name:       key,
+				Role:       RoleOrgPool,
+				FlipStatus: flip,
+				AddedAt:    time.Time{},
+			})
+			seen[key] = struct{}{}
+		}
+		sort.Slice(items, func(i, j int) bool { return items[i].Name < items[j].Name })
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{

--- a/products/catalyst/bootstrap/api/internal/handler/parent_domains_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/parent_domains_test.go
@@ -121,6 +121,67 @@ func TestListParentDomains_PrimaryFromEnv(t *testing.T) {
 	}
 }
 
+// TestListParentDomains_OrgPoolFallbackFromEnv (#4073). On a Sovereign
+// with NO imported deployment record (flat byo-api / JWT-only handover),
+// activeDeployment() is nil and chrootEnsureOrgPoolSeed never ran, so the
+// record-backed list carries no org-pool entry. The Create-Org form filters
+// to role=org-pool and showed "No pool parents available", blocking sub-Org
+// creation — even though the org-create POST validation already accepts the
+// env-seeded pool. ListParentDomains must fall back to the same env-seeded
+// org-pool (OrganizationDeps.ParentDomains) so the dropdown == the accept-set.
+func TestListParentDomains_OrgPoolFallbackFromEnv(t *testing.T) {
+	t.Setenv("CATALYST_PRIMARY_DOMAIN", "omantel.biz")
+	h := &Handler{log: slog.Default()}
+	// Seed the same canonical org-pool the create handler validates against
+	// (what LoadOrganizationParentDomainsFromEnv() returns at startup).
+	h.SetOrganizationDeps(OrganizationDeps{
+		OTECHFQDN: "omantel.biz",
+		ParentDomains: []OrganizationParentDomain{
+			{Name: "omani.homes", Role: "org-pool", NSFlipReady: true},
+			{Name: "omani.rest", Role: "org-pool", NSFlipReady: true},
+			{Name: "omani.trade", Role: "org-pool", NSFlipReady: true},
+			{Name: "omani.works", Role: "org-pool", NSFlipReady: true},
+		},
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sovereign/parent-domains", nil)
+	newParentDomainsRouter(h).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Items []ParentDomain `json:"items"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	// Expect the synthesised primary + every canonical org-pool entry.
+	orgPool := map[string]bool{}
+	var primarySeen bool
+	for _, it := range resp.Items {
+		switch it.Role {
+		case RoleOrgPool:
+			if it.FlipStatus != FlipStatusReady {
+				t.Fatalf("org-pool %s want FlipStatus=ready, got %s", it.Name, it.FlipStatus)
+			}
+			orgPool[it.Name] = true
+		case RolePrimary:
+			if it.Name == "omantel.biz" {
+				primarySeen = true
+			}
+		}
+	}
+	if !primarySeen {
+		t.Fatalf("expected synthesised primary omantel.biz, got %+v", resp.Items)
+	}
+	for _, want := range []string{"omani.homes", "omani.rest", "omani.trade", "omani.works"} {
+		if !orgPool[want] {
+			t.Fatalf("expected org-pool entry %q in fallback list, got %+v", want, resp.Items)
+		}
+	}
+}
+
 func TestAddParentDomain_ValidationErrors(t *testing.T) {
 	t.Setenv("CATALYST_PRIMARY_DOMAIN", "")
 	h := &Handler{log: slog.Default()}


### PR DESCRIPTION
## Problem (Refs #4073)

On the live permanent omantel.biz Sovereign (dep `4635277cae4ffed9`), the Create-Org form showed **"No pool parents available"** and no customer/internal sub-Org could be created — blocking the agentic self-service journey at step 1.

## Root cause

The form reads `GET /api/v1/sovereign/parent-domains?role=org-pool` (`ListParentDomains`), which sources **only** from the adopted Deployment record (`activeDeployment()`) + the synthesised implicit primary. On a Sovereign provisioned via a flat byo-api / **JWT-only handover**, no deployment record is imported (`/var/lib/catalyst/deployments/` had zero `<id>.json` records), so:

- `activeDeployment()` returns nil
- the bake-time `chrootEnsureOrgPoolSeed` (which seeds the 4 canonical `.omani.X` org-pool entries) never runs
- the list returns only `omantel.biz` (role=primary)
- the form filters to role=org-pool → empty → "No pool parents available"

**Asymmetry:** the org-create **POST validation** (`poolDomainsForOrgCreate` → `OrganizationDeps.ParentDomains`) is *always* seeded at startup via `LoadOrganizationParentDomainsFromEnv()` (returns `omani.homes/rest/trade/works` even with `CATALYST_ORG_POOL_DOMAINS` unset). So a POST with `parent_domain=omani.homes` was already accepted — the user just couldn't **select** it because the GET list was empty.

## Fix

`ListParentDomains` now falls back to the same env-seeded org-pool (`h.orgTenantDeps.PoolDomains()`) when neither the active deployment nor a persisted record yields an org-pool entry. The GET list and POST validation are then sourced from the **same** pool — what the form offers == what a create accepts. No-op on Sovereigns that carry an adopted record with org-pool rows (the chroot-seed path).

## Live verification (omantel.biz, dep 4635277cae4ffed9)

After replaying the handover import (`POST /api/v1/internal/deployments/import` — the same handover-export the mothership runs; ran `chrootEnsureOrgPoolSeed` and persisted the 4 `.omani.X` org-pool entries), the Create-Org form now:

- lists `omani.homes`, `omani.rest`, `omani.trade`, `omani.works` in the parent-domain dropdown
- renders console-URL preview `console.demo.omani.homes` for slug `demo`

This PR makes the fix durable for **future fresh provs** that take the JWT-only-handover path so the import-replay live workaround is never needed again.

## Tests

- `TestListParentDomains_OrgPoolFallbackFromEnv` — new; asserts the fallback surfaces the env-seeded org-pool when no adopted deployment exists.
- Full `internal/handler` suite green (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)