### PR TITLE
fix(catalyst): Enter-org targets stored pool console host + per-Org DNS writes wildcard REPLACE (Refs #4075)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/org_enter_org.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_enter_org.go
@@ -117,15 +117,41 @@ func (h *Handler) HandleEnterOrg(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// The org's own console host. Per-org consoles are served at
-	// console.<org>.<sovereign-domain> (the limited-similar UI, §2.4).
-	orgConsoleHost := "console." + slug + "." + sovFQDN
+	// console.<subdomain>.<parent-zone> — and the parent zone is the
+	// pool/BYO domain captured at create time (epic #825), which is NOT
+	// necessarily the Sovereign FQDN. A free-subdomain Org created on a
+	// pool domain (e.g. omani.homes) on an omantel.biz Sovereign has its
+	// console at console.<org>.omani.homes, not console.<org>.omantel.biz.
+	// Re-synthesising the host from sovFQDN (#4075) minted a handover URL
+	// for the wrong host and an aud/sovereign_fqdn claim the org console
+	// would reject. Resolve the real console host from the stored provision
+	// record and fall back to the legacy synthesis only if no record/host
+	// is available.
+	//
+	// orgDomainSuffix is the host minus the leading "console." prefix
+	// (i.e. <subdomain>.<parent-zone>) — used to build the aud /
+	// sovereign_fqdn claim and the support principal so they match the
+	// host the browser actually lands on.
+	orgConsoleHost := ""
+	if h.orgTenantDeps.Store != nil {
+		for _, rec := range h.orgTenantDeps.Store.List() {
+			if strings.EqualFold(strings.TrimSpace(rec.Subdomain), slug) {
+				orgConsoleHost = deriveConsoleHost(rec)
+				break
+			}
+		}
+	}
+	if orgConsoleHost == "" {
+		orgConsoleHost = "console." + slug + "." + sovFQDN
+	}
+	orgDomainSuffix := strings.TrimPrefix(orgConsoleHost, "console.")
 	orgConsoleURL := "https://" + orgConsoleHost
 
 	// The support principal — a dedicated support identity in the org's
 	// realm, NEVER the owner's identity (§2.4). Derived from the
 	// operator's email so the audit trail ties the session to a real
 	// person while the principal that lands in the org is a support role.
-	supportPrincipal := "support+" + sanitizeEmailLocal(claims.Email) + "@" + slug + "." + sovFQDN
+	supportPrincipal := "support+" + sanitizeEmailLocal(claims.Email) + "@" + orgDomainSuffix
 
 	now := time.Now()
 	expiresAt := now.Add(enterOrgMaxTTL)
@@ -143,7 +169,7 @@ func (h *Handler) HandleEnterOrg(w http.ResponseWriter, r *http.Request) {
 		"email":          supportPrincipal,
 		"email_verified": true,
 		"role":           "sovereign-admin",
-		"sovereign_fqdn": slug + "." + sovFQDN,
+		"sovereign_fqdn": orgDomainSuffix,
 		"deployment_id":  "",
 		"iat":            now.Unix(),
 		"exp":            expiresAt.Unix(),

--- a/products/catalyst/bootstrap/api/internal/handler/org_enter_org_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_enter_org_test.go
@@ -4,10 +4,22 @@
 package handler
 
 import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/go-chi/chi/v5"
+	"github.com/golang-jwt/jwt/v5"
+
 	auth "github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
+	handoverjwt "github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handoverjwt"
+	store "github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
 )
 
 func TestEnterOrgCallerIsAdmin(t *testing.T) {
@@ -52,5 +64,95 @@ func TestEnterOrgTTLCappedAt60Min(t *testing.T) {
 	// 60min"). This guards a future edit from widening the constant.
 	if enterOrgMaxTTL > 60*time.Minute {
 		t.Fatalf("enterOrgMaxTTL = %v, must be ≤ 60m", enterOrgMaxTTL)
+	}
+}
+
+// TestEnterOrgUsesStoredParentDomain locks the #4075 fix: an Org created on
+// a free-subdomain POOL domain (ParentDomain) that differs from the Sovereign
+// FQDN must get a handover URL — and aud/sovereign_fqdn claims — pointed at
+// its REAL console host (console.<sub>.<parentDomain>), NOT the re-synthesised
+// console.<sub>.<sovereignFQDN>. On the omantel.biz Sovereign the demo Org
+// lives on omani.homes, so Enter-org must target console.demo.omani.homes.
+func TestEnterOrgUsesStoredParentDomain(t *testing.T) {
+	dir := t.TempDir()
+	st, err := store.NewOrganizationProvisionStore(dir)
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	// Seed the demo Org exactly as the real incident: free-subdomain on the
+	// omani.homes pool, Sovereign FQDN is omantel.biz.
+	if err := st.Put(store.OrganizationProvisionRecord{
+		OrganizationID: "org-demo-uuid",
+		Subdomain:      "demo",
+		DomainMode:     store.OrganizationDomainFreeSubdomain,
+		ParentDomain:   "omani.homes",
+		OTECHFQDN:      "omantel.biz",
+	}); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	privPEM, _, err := handoverjwt.GenerateKeypair()
+	if err != nil {
+		t.Fatalf("GenerateKeypair: %v", err)
+	}
+	signer, err := handoverjwt.New(privPEM, "https://console.openova.io", 8*time.Hour)
+	if err != nil {
+		t.Fatalf("handoverjwt.New: %v", err)
+	}
+
+	h := &Handler{
+		log:                       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		handoverSigner:            signer,
+		authHandoverSovereignFQDN: "omantel.biz",
+		orgTenantDeps:             OrganizationDeps{Store: st},
+	}
+
+	r := chi.NewRouter()
+	r.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			ctx := context.WithValue(req.Context(), auth.ClaimsKey, &auth.Claims{
+				Email:       "ops@omantel.biz",
+				RealmAccess: auth.RealmAccess{Roles: []string{"sovereign-admin"}},
+			})
+			next.ServeHTTP(w, req.WithContext(ctx))
+		})
+	})
+	r.Post("/api/v1/org/organizations/{slug}/enter", h.HandleEnterOrg)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/org/organizations/demo/enter", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp EnterOrgResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, rec.Body.String())
+	}
+
+	// The handover URL must point at the Org's real pool-domain console.
+	if !strings.HasPrefix(resp.HandoverURL, "https://console.demo.omani.homes/auth/handover?token=") {
+		t.Fatalf("regression (#4075): handoverURL targets the wrong host\n got: %s\nwant prefix: https://console.demo.omani.homes/auth/handover?token=", resp.HandoverURL)
+	}
+	// And must NOT fall back to the Sovereign FQDN.
+	if strings.Contains(resp.HandoverURL, "omantel.biz") {
+		t.Fatalf("regression (#4075): handoverURL leaked the Sovereign FQDN: %s", resp.HandoverURL)
+	}
+	// The support principal hangs off the pool domain too.
+	if !strings.HasSuffix(resp.SupportPrincipal, "@demo.omani.homes") {
+		t.Errorf("supportPrincipal not scoped to the pool domain: %s", resp.SupportPrincipal)
+	}
+
+	// The minted token's sovereign_fqdn claim must equal the pool host
+	// suffix so the org console's handover redemption accepts it.
+	token := strings.TrimPrefix(resp.HandoverURL, "https://console.demo.omani.homes/auth/handover?token=")
+	parsed, _, err := jwt.NewParser().ParseUnverified(token, jwt.MapClaims{})
+	if err != nil {
+		t.Fatalf("parse token: %v", err)
+	}
+	claims := parsed.Claims.(jwt.MapClaims)
+	if got := claims["sovereign_fqdn"]; got != "demo.omani.homes" {
+		t.Errorf("sovereign_fqdn claim = %v, want demo.omani.homes", got)
 	}
 }

--- a/products/catalyst/bootstrap/api/internal/handler/organization_dns.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_dns.go
@@ -155,7 +155,22 @@ func (p DefaultOrganizationDNSProvisioner) ProvisionFreeSubdomain(ctx context.Co
 	}
 	zone := parentZone
 	rrsets := []pdnsRRSet{}
-	for _, prefix := range []string{"console", "wordpress", "openclaw", "mail", "keycloak"} {
+	// Per-Org host A records. The leading "*" wildcard is REQUIRED, not a
+	// nicety: parentZone is a SHARED pool domain (epic #825), and a prior
+	// environment that used the same pool commonly leaves a broad apex
+	// wildcard (e.g. `*.<parentZone> A <old-ingress-ip>`) behind after a
+	// wipe. Without an explicit `*.<subdomain>.<parentZone>` record, every
+	// Org host NOT in the fixed prefix list below (and any app subdomain
+	// the per-tenant overlay later adds) falls through to that stale apex
+	// wildcard and resolves to a DEAD prior-env IP — the #4075 failure
+	// ("console unreachable, served 49.12.16.160 from a wiped env"). The
+	// explicit per-Org wildcard shadows the apex wildcard for this Org's
+	// entire subtree and pins it to THIS Sovereign's current ingress IP.
+	//
+	// ChangeType=REPLACE makes every write an unconditional upsert, so a
+	// stale same-name record (if one ever existed) is overwritten rather
+	// than skipped.
+	for _, prefix := range []string{"*", "console", "wordpress", "openclaw", "mail", "keycloak"} {
 		fqdn := fmt.Sprintf("%s.%s.%s.", prefix, subdomain, parentZone)
 		rrsets = append(rrsets, pdnsRRSet{
 			Name:       fqdn,

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
@@ -1093,6 +1093,43 @@ func TestPowerDNSWriter_PATCH_NonOK(t *testing.T) {
 	}
 }
 
+// TestProvisionFreeSubdomain_WritesWildcardREPLACE locks the #4075 fix:
+// the per-Org DNS write MUST emit an explicit `*.<sub>.<parent>` A record
+// (so the Org's whole subtree shadows any stale apex pool wildcard left by
+// a wiped prior env) AND must use ChangeType=REPLACE on every record so a
+// same-name stale record is overwritten rather than skipped.
+func TestProvisionFreeSubdomain_WritesWildcardREPLACE(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody = readAll(r.Body)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	p := DefaultOrganizationDNSProvisioner{Writer: NewPowerDNSWriter(srv.URL, "key")}
+	if err := p.ProvisionFreeSubdomain(context.Background(), "demo", "omani.homes", "212.72.24.33"); err != nil {
+		t.Fatalf("ProvisionFreeSubdomain: %v", err)
+	}
+
+	// The explicit per-Org wildcard pinned to the current ingress IP — the
+	// record that shadows a stale `*.omani.homes` apex wildcard.
+	if !strings.Contains(gotBody, `"name":"*.demo.omani.homes."`) {
+		t.Errorf("regression (#4075): missing explicit `*.demo.omani.homes.` wildcard A record\nbody: %s", gotBody)
+	}
+	// The console host itself.
+	if !strings.Contains(gotBody, `"name":"console.demo.omani.homes."`) {
+		t.Errorf("missing console A record\nbody: %s", gotBody)
+	}
+	// Pinned to THIS Sovereign's ingress, not a stale IP.
+	if !strings.Contains(gotBody, `"content":"212.72.24.33"`) {
+		t.Errorf("records not pinned to the supplied ingress IP\nbody: %s", gotBody)
+	}
+	// Every write is an unconditional upsert.
+	if strings.Contains(gotBody, `"changetype":"CREATE"`) || !strings.Contains(gotBody, `"changetype":"REPLACE"`) {
+		t.Errorf("expected ChangeType=REPLACE on every rrset (upsert/overwrite stale)\nbody: %s", gotBody)
+	}
+}
+
 // Read-once ioutil-equivalent helper for body inspection in tests.
 func readAll(r io.Reader) string {
 	b, _ := io.ReadAll(r)


### PR DESCRIPTION
## Refs #4075 — customer-Org console unreachable on omantel.biz (dep 4635277cae4ffed9)

The demo Org was created free-subdomain on the `omani.homes` pool (different from the Sovereign FQDN `omantel.biz`), and the agentic journey dead-ended at *Enter org*. Three distinct defects; this PR carries the two **durable code** fixes. The **live DNS fix** and the **cert finding** are recorded on the issue.

### (2) FE/handler — Enter-org wrong host
`HandleEnterOrg` (`products/catalyst/bootstrap/api/internal/handler/org_enter_org.go`) re-synthesised the org console as `console.<slug>.<sovereignFQDN>` (= `console.demo.omantel.biz`), ignoring the Org's stored `ParentDomain`. The Org's real console is `console.<slug>.<parentDomain>` (= `console.demo.omani.homes`), so the minted handover URL — and its `aud`/`sovereign_fqdn`/`support_principal` claims — pointed at a host the org console would reject.
**Fix:** resolve the host from the provision record via the existing `deriveConsoleHost()`, falling back to the legacy synthesis only when no record matches. The `sovereign_fqdn` claim + support principal now hang off the resolved `<slug>.<parentDomain>` suffix.
*(Note: the investigation confirmed the FE `EnterOrgButton`/`OrganizationDetailPage` already use the stored `consoleHost` correctly — the wrong host was minted server-side in this Go handler, not in the SPA.)*

### (1) Provisioner — per-Org DNS must overwrite stale pool wildcards
`ProvisionFreeSubdomain` (`organization_dns.go`) already wrote per-Org A records with `ChangeType=REPLACE`, but only for a fixed prefix list (`console/wordpress/openclaw/mail/keycloak`). On a **shared pool domain**, a wiped prior env leaves a broad apex wildcard (`*.omani.homes A <old-ip>`); any Org host not in that list falls through to it and resolves to a dead IP — exactly the #4075 symptom (served `49.12.16.160` from a wiped env).
**Fix:** also emit an explicit `*.<sub>.<parent>` A record (REPLACE), shadowing the apex wildcard for the Org's entire subtree and pinning it to THIS Sovereign's ingress IP.

### Tests
- `TestEnterOrgUsesStoredParentDomain` — drives `HandleEnterOrg` with a seeded pool-domain Org; asserts the handover URL + `sovereign_fqdn` claim + support principal target `console.demo.omani.homes`, never `omantel.biz`.
- `TestProvisionFreeSubdomain_WritesWildcardREPLACE` — captures the PowerDNS PATCH body; asserts the explicit `*.demo.omani.homes.` wildcard + `ChangeType=REPLACE` + the supplied ingress IP.

Full `go test ./internal/handler/` green; `go vet` clean.

### Out of scope here (on the issue)
- **Live DNS fix (done):** REPLACE `console.demo.omani.homes` + `*.demo.omani.homes` → `212.72.24.33` in the mothership PowerDNS `omani.homes.` zone; verified `getent hosts console.demo.omani.homes → 212.72.24.33`.
- **Defect (3) cert (read-only finding):** no `*.omani.homes` wildcard Certificate exists on the Sovereign (only `*.omantel.biz`), and there is no per-Org console Gateway listener/HTTPRoute for the demo host — TLS to `console.demo.omani.homes:443` returns *no peer certificate*. `omani.homes` was a prior-env pool domain never registered as an org-pool wildcard-cert parent zone on this omantel.biz Sovereign. Tracked on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)