### PR TITLE
fix(application-controller): valid RFC-1123 HR names + default sourceRef.kind (#4079)

### DIFF
--- a/core/controllers/application/internal/controller/application_controller.go
+++ b/core/controllers/application/internal/controller/application_controller.go
@@ -939,7 +939,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 				Chart:               firstNonEmpty(blueprintChart(bp), spec.BlueprintName),
 				ChartVersion:        spec.BlueprintVersion,
 				SourceRefName:       ifEmpty(fanoutSourceRef, r.Cfg.CatalogSourceRef),
-				SourceRefKind:       fanoutSourceKind,
+				// #4079 — default the source kind when the Blueprint omits
+				// spec.manifests.source.kind. The catalog source
+				// (`openova-catalog`) is a Flux v1 HelmRepository; an empty
+				// sourceRef.kind renders an invalid HelmRelease.
+				SourceRefKind:       ifEmpty(fanoutSourceKind, "HelmRepository"),
 				SourceRefNamespace:  r.Cfg.SourceNamespace,
 				KubeConfigSecretFor: fanoutKubeSecretFor,
 				// #3373 — loft-sh vcluster exportKubeConfig data key
@@ -1111,7 +1115,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 			Standby:          rp.Standby,
 			BlueprintName:    spec.BlueprintName,
 			BlueprintVersion: spec.BlueprintVersion,
-			SourceKind:       bpSourceKind,
+			SourceKind:       ifEmpty(bpSourceKind, "HelmRepository"), // #4079 default
 			SourceRef:        ifEmpty(bpSourceRef, r.Cfg.CatalogSourceRef),
 			Chart:            bpChart,
 			Values:           merged,

--- a/core/controllers/application/internal/render/fanout.go
+++ b/core/controllers/application/internal/render/fanout.go
@@ -335,7 +335,14 @@ func renderOneHR(in FanoutInputs, cluster string) *unstructured.Unstructured {
 // cheap, stable across reconciles, and collision-resistant within a
 // single Sovereign.
 func HRNameFor(app, cluster string) string {
-	combined := fmt.Sprintf("%s-%s", app, cluster)
+	// HelmRelease names are k8s object names → must be RFC-1123 DNS
+	// labels: lowercase only. The cluster token can carry an
+	// uppercase region marker (e.g. clusterregistry.RegionA="A" →
+	// "rtz-A"), which would render an invalid name like
+	// `agenity-rtz-A`. Lowercase the composed name (#4079). Labels
+	// keep their original case (label values permit uppercase); only
+	// the object NAME is constrained.
+	combined := strings.ToLower(fmt.Sprintf("%s-%s", app, cluster))
 	if len(combined) <= HRName63 {
 		return combined
 	}

--- a/core/controllers/application/internal/render/fanout_test.go
+++ b/core/controllers/application/internal/render/fanout_test.go
@@ -38,8 +38,8 @@ func TestFanoutHRs_ActiveHotStandby_TwoClusters(t *testing.T) {
 	}
 
 	// First HR: mgmt-A active.
-	if got := hrs[0].GetName(); got != "obs-prod-mgmt-A" {
-		t.Fatalf("hr[0].name = %q, want obs-prod-mgmt-A", got)
+	if got := hrs[0].GetName(); got != "obs-prod-mgmt-a" {
+		t.Fatalf("hr[0].name = %q, want obs-prod-mgmt-a", got)
 	}
 	if got := hrs[0].GetLabels()[LabelRole]; got != RoleActive {
 		t.Fatalf("hr[0].role = %q, want active", got)
@@ -55,8 +55,8 @@ func TestFanoutHRs_ActiveHotStandby_TwoClusters(t *testing.T) {
 	}
 
 	// Second HR: mgmt-B passive.
-	if got := hrs[1].GetName(); got != "obs-prod-mgmt-B" {
-		t.Fatalf("hr[1].name = %q, want obs-prod-mgmt-B", got)
+	if got := hrs[1].GetName(); got != "obs-prod-mgmt-b" {
+		t.Fatalf("hr[1].name = %q, want obs-prod-mgmt-b", got)
 	}
 	if got := hrs[1].GetLabels()[LabelRole]; got != RolePassive {
 		t.Fatalf("hr[1].role = %q, want passive", got)
@@ -378,7 +378,7 @@ func TestFanoutHRs_Errors(t *testing.T) {
 
 func TestHRNameFor_NoTruncationUnder63(t *testing.T) {
 	got := HRNameFor("obs-prod", "mgmt-A")
-	want := "obs-prod-mgmt-A"
+	want := "obs-prod-mgmt-a"
 	if got != want {
 		t.Fatalf("HRNameFor = %q, want %q", got, want)
 	}
@@ -438,8 +438,8 @@ func TestPerClusterStatusesFor_TemplateShape(t *testing.T) {
 	if statuses[1].Cluster != "mgmt-B" || statuses[1].Role != RolePassive {
 		t.Fatalf("status[1] = %+v, want {mgmt-B,passive}", statuses[1])
 	}
-	if statuses[0].HR != "obs-mgmt-A" {
-		t.Fatalf("status[0].HR = %q, want obs-mgmt-A", statuses[0].HR)
+	if statuses[0].HR != "obs-mgmt-a" {
+		t.Fatalf("status[0].HR = %q, want obs-mgmt-a", statuses[0].HR)
 	}
 }
 
@@ -587,7 +587,7 @@ func TestFanoutHRs_PassiveDefaultsForMultiClusterMissingRolesMap(t *testing.T) {
 }
 
 // Sanity-check that the per-cluster names produced match the brief's
-// "obs-prod-mgmt-A" example exactly.
+// "obs-prod-mgmt-a" example exactly.
 func TestFanoutHRs_BriefExampleMapping(t *testing.T) {
 	bp := fixtureGrafanaTopology()
 	variant := bp.PerTopology[bpv1alpha1.BcpActiveHotStandby]
@@ -602,7 +602,7 @@ func TestFanoutHRs_BriefExampleMapping(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	got := []string{hrs[0].GetName(), hrs[1].GetName()}
-	want := []string{"obs-prod-mgmt-A", "obs-prod-mgmt-B"}
+	want := []string{"obs-prod-mgmt-a", "obs-prod-mgmt-b"}
 	for i := range got {
 		if got[i] != want[i] {
 			t.Fatalf("hr[%d].name = %q, want %q", i, got[i], want[i])


### PR DESCRIPTION
## What

Two defects that wedge a fanned-out Application's per-cluster HelmRelease (found walking the live agenity install on omantel.biz, after #4077 cleared EnvironmentMissing):

1. **Invalid HR name.** `HRNameFor` composed `<app>-<cluster>` verbatim; the cluster token carries an uppercase region marker (`clusterregistry.RegionA="A"` → `rtz-A`), so agenity rendered an invalid object name `agenity-rtz-A`. K8s object names must be lowercase RFC-1123 — **lowercase the composed name** (labels keep their case; label values legitimately permit uppercase).

2. **Missing `sourceRef.kind`.** `SourceRefKind`/`SourceKind` passed the Blueprint's `spec.manifests.source.kind` through with **no default** (unlike `SourceRefName` → `CatalogSourceRef`). A Blueprint that omits the kind rendered an HR with empty `spec.chart.spec.sourceRef.kind` → invalid. The catalog source (`openova-catalog`) is a Flux v1 HelmRepository — **default to `HelmRepository`** at both render paths (fanout + single-cluster).

## Tests
`go build`/`go vet`/`go test ./...` green. Updated `TestFanoutHRs_BriefExampleMapping` + `HRNameFor` assertions that encoded the old invalid uppercase names; cluster/label assertions (which keep `RegionA="A"`) unchanged.

## Lineage
This is the next blocker in the agentic-journey chain after #4077 (#4078). With #4072/#4074/#4076/#4078/#4079 a fresh prov should let agenity install reach Running.

Refs #4079 #4077 #3687

🤖 Generated with [Claude Code](https://claude.com/claude-code)