### PR TITLE
feat: per-resource Compliance tab renders THAT resource's own findings table (not the global view) (#4085)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -1388,6 +1388,10 @@ func main() {
 		rg.Get("/api/v1/sovereigns/{id}/compliance/policies", h.HandleCompliancePolicies)
 		rg.Get("/api/v1/sovereigns/{id}/compliance/policies/{name}", h.HandleCompliancePolicyByName)
 		rg.Get("/api/v1/sovereigns/{id}/compliance/violations", h.HandleComplianceViolations)
+		// #4085 — per-resource compliance findings for the resource
+		// detail view's Compliance tab (kind+ns+name → its own policy
+		// pass/fail/skip table).
+		rg.Get("/api/v1/sovereigns/{id}/compliance/resource", h.HandleComplianceResource)
 		rg.Get("/api/v1/sovereigns/{id}/compliance/stream", h.HandleComplianceStream)
 		// Wave-2 Family-E (#1583/Family-E): runtime + supply-chain
 		// compliance aggregators. Falco runtime alerts (C11-008),

--- a/products/catalyst/bootstrap/api/internal/handler/compliance.go
+++ b/products/catalyst/bootstrap/api/internal/handler/compliance.go
@@ -200,6 +200,54 @@ type Violation struct {
 	Time        time.Time `json:"time"`
 }
 
+// ResourceFinding — one (policy → verdict) row for a SINGLE K8s
+// resource. The per-resource Compliance tab (#4085) renders these as a
+// table so the operator sees the policies/checks that apply to THIS
+// resource + their pass/fail/skip status, severity, and message —
+// instead of being bounced to the sovereign-wide /sre/compliance view.
+//
+// Rows are sourced from the resource's own per-policy verdicts
+// (resourceState.results) joined with the live ClusterPolicy metadata
+// (policyMetaByName) so each row carries Severity / Category / Title
+// straight off the Kyverno CR. Result is one of pass | fail | skip |
+// warn — same vocabulary as the rest of the compliance surface.
+type ResourceFinding struct {
+	Policy   string `json:"policy"`
+	Rule     string `json:"rule,omitempty"`
+	Result   string `json:"result"`
+	Message  string `json:"message,omitempty"`
+	Severity string `json:"severity,omitempty"`
+	Category string `json:"category,omitempty"`
+	Title    string `json:"title,omitempty"`
+	Source   string `json:"source,omitempty"` // kyverno | evaluator
+}
+
+// ResourceComplianceResponse — the /compliance/resource endpoint shape
+// (#4085). Carries the resource's own headline score + the flat list of
+// per-policy findings so the per-resource Compliance tab can render its
+// own table without a sovereign-wide scorecard round-trip.
+//
+// `found` is false (with an empty findings slice + null score) when the
+// aggregator has not yet observed any PolicyReport for this resource —
+// the UI renders an explicit "no policies have evaluated this resource
+// yet" empty state rather than an error.
+type ResourceComplianceResponse struct {
+	Resource    string            `json:"resource"`
+	Kind        string            `json:"kind,omitempty"`
+	Namespace   string            `json:"namespace,omitempty"`
+	Name        string            `json:"name,omitempty"`
+	Found       bool              `json:"found"`
+	Score       *int              `json:"score"`
+	Total       *int              `json:"total"`
+	Numerator   int               `json:"numerator"`
+	Denominator int               `json:"denominator"`
+	Violations  int               `json:"violations"`
+	Application string            `json:"application,omitempty"`
+	Environment string            `json:"environment,omitempty"`
+	Findings    []ResourceFinding `json:"findings"`
+	UpdatedAt   time.Time         `json:"updatedAt"`
+}
+
 // ScorecardResponse is the /scorecard endpoint shape. Sorted
 // children at every level for stable rendering.
 //
@@ -2075,6 +2123,147 @@ func (c *ComplianceHandler) violationsFor(clusterID, app string) []Violation {
 		return out[i].Policy < out[j].Policy
 	})
 	return out
+}
+
+// HandleComplianceResource — GET
+// /api/v1/sovereigns/{id}/compliance/resource?kind=<k>&ns=<ns>&name=<n>
+//
+// Returns the per-policy compliance findings for ONE K8s resource so
+// the resource detail view's Compliance tab (#4085) can render a table
+// of THAT resource's own checks + pass/fail/skip status — instead of
+// linking the operator out to the sovereign-wide dashboard.
+//
+// `ns` may be empty for cluster-scoped resources (mirrors the
+// resourceKey "<kind>//<name>" shape). `kind` is matched
+// case-insensitively against the canonical lowercase key.
+func (h *Handler) HandleComplianceResource(w http.ResponseWriter, r *http.Request) {
+	if h.compliance == nil {
+		http.Error(w, "compliance handler not wired", http.StatusServiceUnavailable)
+		return
+	}
+	clusterID := chi.URLParam(r, "id")
+	if clusterID == "" {
+		http.Error(w, "missing sovereign id", http.StatusBadRequest)
+		return
+	}
+	clusterID = h.resolveChrootClusterID(clusterID)
+
+	q := r.URL.Query()
+	kind := strings.TrimSpace(q.Get("kind"))
+	ns := strings.TrimSpace(q.Get("ns"))
+	name := strings.TrimSpace(q.Get("name"))
+	// Accept the literal `_` sentinel the cloud-list routes use for the
+	// cluster-scoped namespace segment so the UI can pass through the
+	// route param unchanged.
+	if ns == "_" {
+		ns = ""
+	}
+	if kind == "" || name == "" {
+		http.Error(w, "missing kind or name", http.StatusBadRequest)
+		return
+	}
+
+	resp := h.compliance.resourceComplianceFor(clusterID, kind, ns, name)
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// resourceComplianceFor projects ONE resource's per-policy verdicts into
+// a ResourceComplianceResponse. Joins the resource's own results map
+// (resourceState.results) with the live ClusterPolicy metadata so each
+// finding carries Severity / Category / Title. Always returns a
+// well-shaped (non-nil findings) response — Found=false + null score
+// when the aggregator has not yet seen a PolicyReport for the resource.
+func (c *ComplianceHandler) resourceComplianceFor(clusterID, kind, ns, name string) ResourceComplianceResponse {
+	key := resourceKey(kind, ns, name)
+	resp := ResourceComplianceResponse{
+		Resource:  key,
+		Kind:      strings.ToLower(kind),
+		Namespace: ns,
+		Name:      name,
+		Found:     false,
+		Findings:  []ResourceFinding{},
+		UpdatedAt: time.Now().UTC(),
+	}
+	if c == nil {
+		return resp
+	}
+
+	c.mu.RLock()
+	cs, ok := c.state[clusterID]
+	var rsCopy *resourceState
+	if ok {
+		if rs := cs[key]; rs != nil {
+			rsCopy = cloneResourceState(rs)
+		}
+	}
+	// Snapshot the policy metadata under the read lock so the join below
+	// runs unlocked.
+	meta := make(map[string]policyMeta, len(c.policyMetaByName))
+	for n, m := range c.policyMetaByName {
+		meta[n] = m
+	}
+	c.mu.RUnlock()
+
+	if rsCopy == nil {
+		// No verdicts observed for this resource yet — return the empty
+		// shape so the UI renders its "no policies evaluated yet" state.
+		return resp
+	}
+
+	envSpec, _ := c.resolveEnvPolicyLocked(rsCopy.environment)
+	score := computeScore(rsCopy, envSpec)
+
+	resp.Found = true
+	resp.Score = score.Score
+	resp.Total = score.Total
+	resp.Numerator = score.Numerator
+	resp.Denominator = score.Denominator
+	resp.Violations = score.Violations
+	resp.Application = rsCopy.application
+	resp.Environment = rsCopy.environment
+	resp.UpdatedAt = rsCopy.updatedAt
+
+	for policy, v := range rsCopy.results {
+		m := meta[policy]
+		resp.Findings = append(resp.Findings, ResourceFinding{
+			Policy:   policy,
+			Rule:     v.rule,
+			Result:   v.result,
+			Message:  v.message,
+			Severity: m.severity,
+			Category: m.category,
+			Title:    m.title,
+			Source:   v.source,
+		})
+	}
+	// Stable order: failing/warning rows first (most actionable), then
+	// alphabetical by policy name within each result class.
+	sort.Slice(resp.Findings, func(i, j int) bool {
+		ri, rj := resultRank(resp.Findings[i].Result), resultRank(resp.Findings[j].Result)
+		if ri != rj {
+			return ri < rj
+		}
+		return resp.Findings[i].Policy < resp.Findings[j].Policy
+	})
+	return resp
+}
+
+// resultRank orders verdicts so the most actionable rows surface first:
+// fail < warn < skip < pass < (unknown). Used to sort the per-resource
+// findings table.
+func resultRank(result string) int {
+	switch strings.ToLower(strings.TrimSpace(result)) {
+	case "fail":
+		return 0
+	case "warn":
+		return 1
+	case "skip", "na":
+		return 2
+	case "pass":
+		return 3
+	default:
+		return 4
+	}
 }
 
 // SovereignAlertCount returns the number of currently-failing

--- a/products/catalyst/bootstrap/api/internal/handler/compliance_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/compliance_test.go
@@ -644,6 +644,110 @@ func TestCompliance_ViolationsPagination(t *testing.T) {
 	}
 }
 
+// TestCompliance_ResourceFindings — #4085 per-resource Compliance tab.
+//
+// GET /compliance/resource?kind&ns&name returns the resource's OWN
+// per-policy findings (pass/fail/skip) joined with ClusterPolicy
+// metadata (severity/category) so the resource detail view can render
+// its own table instead of bouncing to the sovereign-wide dashboard.
+func TestCompliance_ResourceFindings(t *testing.T) {
+	h, _, _, f := newComplianceTestRig(t)
+
+	// ClusterPolicy metadata so findings carry severity/category.
+	publishToFactory(f, "clusterpolicy", &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "kyverno.io/v1", "kind": "ClusterPolicy",
+		"metadata": map[string]any{
+			"name": "disallow-privileged-containers",
+			"annotations": map[string]any{
+				"policies.kyverno.io/severity": "high",
+				"policies.kyverno.io/category": "Pod Security Standards",
+			},
+		},
+		"spec": map[string]any{"rules": []any{map[string]any{"name": "privileged"}}},
+	}})
+	publishToFactory(f, "deployment", &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apps/v1", "kind": "Deployment",
+		"metadata": map[string]any{
+			"namespace": "ns1", "name": "web",
+			"labels": map[string]any{"catalyst.openova.io/application": "web"},
+		},
+	}})
+	// One fail + one pass for this resource.
+	publishToFactory(f, "policyreport", mkPolicyReport("ns1", "pr-fail", []map[string]any{
+		{"policy": "disallow-privileged-containers", "rule": "privileged", "result": "fail",
+			"message": "container runs privileged",
+			"resources": []any{map[string]any{"kind": "Deployment", "namespace": "ns1", "name": "web"}}},
+	}))
+	publishToFactory(f, "policyreport", mkPolicyReport("ns1", "pr-pass", []map[string]any{
+		{"policy": "require-run-as-nonroot", "rule": "nonroot", "result": "pass",
+			"resources": []any{map[string]any{"kind": "Deployment", "namespace": "ns1", "name": "web"}}},
+	}))
+	waitFor(t, 1*time.Second, func() bool {
+		return h.ComplianceHandler().resourceComplianceFor("acme", "Deployment", "ns1", "web").Found
+	})
+
+	r := chi.NewRouter()
+	r.Get("/api/v1/sovereigns/{id}/compliance/resource", h.HandleComplianceResource)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/acme/compliance/resource?kind=Deployment&ns=ns1&name=web", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("resource: %d %s", rec.Code, rec.Body.String())
+	}
+	var resp ResourceComplianceResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !resp.Found {
+		t.Fatalf("expected found=true, body=%s", rec.Body.String())
+	}
+	if len(resp.Findings) != 2 {
+		t.Fatalf("expected 2 findings, got %d: %+v", len(resp.Findings), resp.Findings)
+	}
+	// Fail row sorts first (most actionable) and carries the joined
+	// ClusterPolicy severity/category metadata.
+	first := resp.Findings[0]
+	if first.Result != "fail" {
+		t.Fatalf("expected fail row first, got %q", first.Result)
+	}
+	if first.Policy != "disallow-privileged-containers" || first.Severity != "high" || first.Category != "Pod Security Standards" {
+		t.Fatalf("fail row missing metadata: %+v", first)
+	}
+	if first.Message != "container runs privileged" {
+		t.Fatalf("fail row missing message: %+v", first)
+	}
+	if resp.Violations != 1 {
+		t.Fatalf("expected 1 violation, got %d", resp.Violations)
+	}
+
+	// Unknown resource → found=false + empty (non-nil) findings.
+	req2 := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/acme/compliance/resource?kind=Deployment&ns=ns1&name=nope", nil)
+	rec2 := httptest.NewRecorder()
+	r.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("unknown resource: %d %s", rec2.Code, rec2.Body.String())
+	}
+	var resp2 ResourceComplianceResponse
+	_ = json.Unmarshal(rec2.Body.Bytes(), &resp2)
+	if resp2.Found {
+		t.Fatalf("expected found=false for unknown resource")
+	}
+	if resp2.Findings == nil {
+		t.Fatalf("findings must be non-nil ([]), got nil")
+	}
+
+	// Missing required params → 400.
+	req3 := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/acme/compliance/resource?kind=Deployment", nil)
+	rec3 := httptest.NewRecorder()
+	r.ServeHTTP(rec3, req3)
+	if rec3.Code != http.StatusBadRequest {
+		t.Fatalf("missing name: expected 400, got %d", rec3.Code)
+	}
+}
+
 // TestCompliance_SovereignAlertCount — slice Z2 follow-up.
 //
 // SovereignAlertCount returns len(violationsFor(clusterID, "")). When

--- a/products/catalyst/bootstrap/ui/src/lib/compliance.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/compliance.api.ts
@@ -18,13 +18,22 @@ export {
   getSBOMForPod,
   getSBOMSummary,
   getPolicyByName,
+  // #4085 — per-resource findings for the cloud-list resource detail
+  // Compliance tab. Re-exported here so the tab imports flat (lib/* →
+  // pages/*) like its SBOM sibling.
+  getResourceCompliance,
+  scoreColor,
+  scoreLabel,
   COMPLIANCE_FRAMEWORKS,
 } from '@/pages/admin/compliance/compliance.api'
 export type {
   ComplianceFramework,
   ComplianceFrameworkId,
+  ComplianceResult,
   FalcoEvent,
   FalcoEventsResponse,
+  ResourceFinding,
+  ResourceComplianceResponse,
   VulnerabilitySeverityCounts,
   SBOMComponent,
   SBOMContainerEntry,

--- a/products/catalyst/bootstrap/ui/src/pages/admin/compliance/compliance.api.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/admin/compliance/compliance.api.ts
@@ -227,6 +227,90 @@ export async function getViolations(
   return res.json()
 }
 
+/* ── Per-resource findings (#4085) ───────────────────────────────── */
+
+/**
+ * ResourceFinding — one (policy → verdict) row for a single K8s
+ * resource. Mirrors `internal/handler/compliance.go.ResourceFinding`.
+ * Rendered as a table row in the resource detail view's Compliance tab.
+ */
+export interface ResourceFinding {
+  policy: string
+  rule?: string
+  result: ComplianceResult | string
+  message?: string
+  severity?: string
+  category?: string
+  title?: string
+  source?: PolicySource | string
+}
+
+/**
+ * ResourceComplianceResponse — the /compliance/resource endpoint shape.
+ * `found` is false (with an empty findings array + null score) when the
+ * aggregator has not yet observed a PolicyReport for this resource.
+ * Mirrors `internal/handler/compliance.go.ResourceComplianceResponse`.
+ */
+export interface ResourceComplianceResponse {
+  resource: string
+  kind?: string
+  namespace?: string
+  name?: string
+  found: boolean
+  score: number | null
+  total: number | null
+  numerator: number
+  denominator: number
+  violations: number
+  application?: string
+  environment?: string
+  findings: ResourceFinding[]
+  updatedAt: string
+}
+
+/**
+ * getResourceCompliance — fetch one resource's own per-policy findings
+ * so the resource detail Compliance tab renders THAT resource's table
+ * (pass/fail/skip + severity + message), not the global view.
+ *
+ * `ns` is omitted (server treats absent/`_` as cluster-scoped) for
+ * cluster-scoped kinds.
+ */
+export async function getResourceCompliance(
+  sovereignId: string,
+  kind: string,
+  ns: string | undefined,
+  name: string,
+): Promise<ResourceComplianceResponse> {
+  const params = new URLSearchParams()
+  params.set('kind', kind)
+  if (ns) params.set('ns', ns)
+  params.set('name', name)
+  const url = `${complianceBase(sovereignId)}/resource?${params.toString()}`
+  const res = await authedFetch(url, { headers: { Accept: 'application/json' } })
+  if (!res.ok) {
+    throw new Error(`resource compliance: HTTP ${res.status}`)
+  }
+  const raw = (await res.json()) as Partial<ResourceComplianceResponse> | null
+  const safe = raw ?? {}
+  return {
+    resource: safe.resource ?? `${kind}/${ns ?? ''}/${name}`,
+    kind: safe.kind ?? kind,
+    namespace: safe.namespace ?? ns,
+    name: safe.name ?? name,
+    found: !!safe.found,
+    score: typeof safe.score === 'number' ? safe.score : null,
+    total: typeof safe.total === 'number' ? safe.total : null,
+    numerator: typeof safe.numerator === 'number' ? safe.numerator : 0,
+    denominator: typeof safe.denominator === 'number' ? safe.denominator : 0,
+    violations: typeof safe.violations === 'number' ? safe.violations : 0,
+    application: safe.application,
+    environment: safe.environment,
+    findings: Array.isArray(safe.findings) ? safe.findings : [],
+    updatedAt: safe.updatedAt ?? new Date().toISOString(),
+  }
+}
+
 /**
  * putEnvironmentPolicyMode — U5 toggle PUT call.
  *

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceComplianceTab.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceComplianceTab.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * ResourceComplianceTab.test — #4085.
+ *
+ * Asserts the per-resource Compliance tab renders THIS resource's own
+ * findings as a table (policy / severity / status / message) — and the
+ * empty state when no policies have evaluated the resource yet.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ResourceComplianceTab } from './ResourceComplianceTab'
+import type { ResourceComplianceResponse } from '@/lib/compliance.api'
+
+afterEach(() => cleanup())
+
+function renderTab(initialData: ResourceComplianceResponse) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <ResourceComplianceTab
+        sovereignId="dep"
+        kind="deployment"
+        ns="acme"
+        name="web"
+        initialData={initialData}
+      />
+    </QueryClientProvider>,
+  )
+}
+
+const FOUND: ResourceComplianceResponse = {
+  resource: 'deployment/acme/web',
+  kind: 'deployment',
+  namespace: 'acme',
+  name: 'web',
+  found: true,
+  score: 50,
+  total: 50,
+  numerator: 1,
+  denominator: 2,
+  violations: 1,
+  application: 'web',
+  environment: 'acme-prod',
+  findings: [
+    {
+      policy: 'disallow-privileged-containers',
+      rule: 'privileged',
+      result: 'fail',
+      message: 'container runs privileged',
+      severity: 'high',
+      category: 'Pod Security Standards',
+      source: 'kyverno',
+    },
+    {
+      policy: 'require-run-as-nonroot',
+      rule: 'nonroot',
+      result: 'pass',
+      severity: 'medium',
+      source: 'kyverno',
+    },
+  ],
+  updatedAt: '2026-06-22T00:00:00Z',
+}
+
+describe('ResourceComplianceTab', () => {
+  it('renders a table of THIS resource own findings (policy/severity/status/message)', () => {
+    renderTab(FOUND)
+    // The findings table is present (not a redirect-only blurb).
+    expect(screen.getByTestId('resource-compliance-table')).toBeTruthy()
+    // Both per-policy rows render.
+    expect(screen.getByTestId('resource-compliance-row-disallow-privileged-containers')).toBeTruthy()
+    expect(screen.getByTestId('resource-compliance-row-require-run-as-nonroot')).toBeTruthy()
+    // Status + severity + message for the failing row.
+    expect(screen.getByTestId('resource-compliance-result-fail')).toBeTruthy()
+    expect(screen.getByTestId('resource-compliance-severity-high')).toBeTruthy()
+    expect(screen.getByText('container runs privileged')).toBeTruthy()
+    // Score hero + violation count.
+    expect(screen.getByTestId('resource-compliance-score-hero')).toBeTruthy()
+    expect(screen.getByTestId('resource-compliance-violation-count').textContent).toContain('1 violation')
+  })
+
+  it('renders the empty state when no policies have evaluated the resource', () => {
+    renderTab({ ...FOUND, found: false, score: null, total: null, findings: [], violations: 0 })
+    expect(screen.getByTestId('resource-compliance-empty')).toBeTruthy()
+    expect(screen.queryByTestId('resource-compliance-table')).toBeNull()
+  })
+
+  it('keeps the drill-out to the full Compliance dashboard as a secondary affordance', () => {
+    renderTab(FOUND)
+    const link = screen.getByTestId('resource-detail-compliance-drilldown') as HTMLAnchorElement
+    expect(link.getAttribute('href')).toContain('/sre/compliance?resource=')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceComplianceTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceComplianceTab.tsx
@@ -1,0 +1,265 @@
+/**
+ * ResourceComplianceTab — #4085.
+ *
+ * Per-resource compliance findings for the cloud-list resource detail
+ * view's Compliance tab. Renders a TABLE of THAT resource's own
+ * policies/checks + pass/fail/skip status, severity, and message —
+ * sourced from `/api/v1/sovereigns/{id}/compliance/resource?kind&ns&name`
+ * which projects the resource's own per-policy verdicts joined with the
+ * live ClusterPolicy metadata.
+ *
+ * Before this, the tab only showed a one-line blurb + a link to the
+ * sovereign-wide `/sre/compliance` dashboard — the founder bug this
+ * fixes: a resource's Compliance tab must show ITS OWN findings, not the
+ * global view.
+ *
+ * Empty-state matrix (per docs/INVIOLABLE-PRINCIPLES.md #2 — never seed
+ * synthetic data):
+ *   • found=false → "No policies have evaluated this resource yet"
+ *   • found=true  → score hero + per-policy findings table
+ *
+ * The "Open in Compliance Dashboard" deep-link is kept as a secondary
+ * affordance below the table (drill-out to the full dashboard), not as
+ * the primary content.
+ */
+
+import { useQuery } from '@tanstack/react-query'
+import {
+  getResourceCompliance,
+  scoreColor,
+  scoreLabel,
+  type ResourceComplianceResponse,
+  type ResourceFinding,
+} from '@/lib/compliance.api'
+
+export interface ResourceComplianceTabProps {
+  /** Sovereign id (deploymentId on chroot). */
+  sovereignId: string
+  /** Canonical (singular) kind, e.g. "deployment". */
+  kind: string
+  /** Namespace ('' for cluster-scoped). */
+  ns: string
+  /** Resource name. */
+  name: string
+  /** Test seam — bypass the live fetch. */
+  initialData?: ResourceComplianceResponse
+}
+
+export function ResourceComplianceTab({
+  sovereignId,
+  kind,
+  ns,
+  name,
+  initialData,
+}: ResourceComplianceTabProps) {
+  const q = useQuery({
+    queryKey: ['compliance', sovereignId, 'resource', kind, ns, name],
+    queryFn: () => getResourceCompliance(sovereignId, kind, ns || undefined, name),
+    enabled: !initialData && !!sovereignId && !!kind && !!name,
+    staleTime: 30_000,
+  })
+
+  const data = initialData ?? q.data ?? null
+  const drilldownHref = `/sre/compliance?resource=${encodeURIComponent(`${kind}/${ns}/${name}`)}`
+
+  return (
+    <div
+      data-testid="resource-detail-compliance"
+      className="space-y-4"
+    >
+      <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-2)] p-4">
+        <h3 className="mb-1 text-sm font-semibold text-[var(--color-text-strong)]">
+          Per-resource policy compliance
+        </h3>
+        <p className="text-xs text-[var(--color-text-dim)]">
+          Kyverno + custom-evaluator policy reports for this{' '}
+          <code className="font-mono">
+            {kind}/{ns ? `${ns}/` : ''}
+            {name}
+          </code>
+          .
+        </p>
+      </div>
+
+      {/* Loading / error / empty / table. */}
+      {q.isLoading && !data ? (
+        <div
+          data-testid="resource-compliance-loading"
+          className="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-2)] p-6 text-sm text-[var(--color-text-dim)]"
+        >
+          Loading compliance findings…
+        </div>
+      ) : q.isError && !data ? (
+        <div
+          data-testid="resource-compliance-error"
+          className="rounded-lg border border-rose-500 bg-[var(--color-bg-2)] p-6 text-sm text-rose-300"
+        >
+          {q.error instanceof Error ? q.error.message : 'Failed to load compliance findings.'}
+        </div>
+      ) : !data || !data.found || data.findings.length === 0 ? (
+        <div
+          data-testid="resource-compliance-empty"
+          className="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-2)] p-6 text-sm text-[var(--color-text-dim)]"
+        >
+          No policies have evaluated this {kind} yet. Kyverno PolicyReports for{' '}
+          <code className="ml-1 font-mono">
+            {ns ? `${ns}/` : ''}
+            {name}
+          </code>{' '}
+          will appear here as admission webhooks evaluate this resource.
+        </div>
+      ) : (
+        <>
+          <ScoreHero data={data} />
+          <FindingsTable findings={data.findings} />
+        </>
+      )}
+
+      {/* Secondary affordance: drill out to the full dashboard. */}
+      <a
+        href={drilldownHref}
+        className="inline-block rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-1.5 text-xs text-[var(--color-text)] no-underline hover:bg-[var(--color-surface-hover)]"
+        data-testid="resource-detail-compliance-drilldown"
+      >
+        Open in Compliance Dashboard →
+      </a>
+    </div>
+  )
+}
+
+function ScoreHero({ data }: { data: ResourceComplianceResponse }) {
+  const total = data.score ?? data.total ?? null
+  const pillColor = scoreColor(total, 'resilience')
+  return (
+    <div className="flex items-center gap-4 rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] p-4">
+      <div
+        className="flex h-16 w-16 items-center justify-center rounded-md font-mono text-xl font-bold text-white"
+        style={{ background: pillColor }}
+        data-testid="resource-compliance-score-hero"
+      >
+        {scoreLabel(total)}
+        {total !== null ? '%' : ''}
+      </div>
+      <div className="flex-1">
+        <div className="text-sm font-semibold text-[var(--color-text-strong)]">
+          Compliance score
+        </div>
+        <p className="text-xs text-[var(--color-text-dim)]">
+          {data.numerator} of {data.denominator} policy weight passing ·{' '}
+          <span data-testid="resource-compliance-violation-count">
+            {data.violations} violation{data.violations === 1 ? '' : 's'}
+          </span>
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function FindingsTable({ findings }: { findings: ResourceFinding[] }) {
+  return (
+    <div className="overflow-x-auto rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-2)]">
+      <table className="w-full text-sm" data-testid="resource-compliance-table">
+        <thead className="text-xs uppercase tracking-wide text-[var(--color-text-dim)]">
+          <tr className="border-b border-[var(--color-border)] text-left">
+            <th className="px-3 py-2">Policy</th>
+            <th className="px-3 py-2">Severity</th>
+            <th className="px-3 py-2">Status</th>
+            <th className="px-3 py-2">Message</th>
+          </tr>
+        </thead>
+        <tbody>
+          {findings.map((f, i) => (
+            <tr
+              key={`${f.policy}-${f.rule ?? ''}-${i}`}
+              data-testid={`resource-compliance-row-${f.policy}`}
+              className="border-t border-[var(--color-border)] align-top"
+            >
+              <td className="px-3 py-2">
+                <code className="font-mono text-[var(--color-text)]">{f.policy}</code>
+                {f.rule ? (
+                  <span className="ml-2 text-xs text-[var(--color-text-dim)]">/ {f.rule}</span>
+                ) : null}
+                {f.category ? (
+                  <div className="mt-0.5 text-[10px] uppercase tracking-wide text-[var(--color-text-dim)]">
+                    {f.category}
+                  </div>
+                ) : null}
+              </td>
+              <td className="px-3 py-2">
+                <SeverityPill severity={f.severity} />
+              </td>
+              <td className="px-3 py-2">
+                <ResultPill result={f.result} />
+              </td>
+              <td className="px-3 py-2 text-xs text-[var(--color-text-dim)]">
+                {f.message || '—'}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function ResultPill({ result }: { result: string }) {
+  const r = (result || '').toLowerCase()
+  const palette = resultPalette(r)
+  return (
+    <span
+      data-testid={`resource-compliance-result-${r}`}
+      className="inline-flex items-center justify-center rounded-md px-2 py-0.5 text-[10px] font-semibold uppercase"
+      style={{ background: palette.bg, color: palette.fg, border: `1px solid ${palette.border}` }}
+    >
+      {r || 'unknown'}
+    </span>
+  )
+}
+
+function SeverityPill({ severity }: { severity?: string }) {
+  if (!severity) {
+    return <span className="text-xs text-[var(--color-text-dim)]">—</span>
+  }
+  const s = severity.toLowerCase()
+  const palette = severityPalette(s)
+  return (
+    <span
+      data-testid={`resource-compliance-severity-${s}`}
+      className="inline-flex items-center justify-center rounded-md px-2 py-0.5 text-[10px] font-semibold uppercase"
+      style={{ background: palette.bg, color: palette.fg, border: `1px solid ${palette.border}` }}
+    >
+      {s}
+    </span>
+  )
+}
+
+function resultPalette(result: string): { bg: string; fg: string; border: string } {
+  switch (result) {
+    case 'pass':
+      return { bg: 'rgba(34, 197, 94, 0.10)', fg: '#86efac', border: 'rgba(34, 197, 94, 0.40)' }
+    case 'fail':
+      return { bg: 'rgba(239, 68, 68, 0.12)', fg: '#fca5a5', border: 'rgba(239, 68, 68, 0.45)' }
+    case 'skip':
+    case 'na':
+      return { bg: 'rgba(125, 125, 125, 0.20)', fg: '#cbd5e1', border: 'rgba(125, 125, 125, 0.50)' }
+    case 'warn':
+      return { bg: 'rgba(245, 158, 11, 0.12)', fg: '#fcd34d', border: 'rgba(245, 158, 11, 0.45)' }
+    default:
+      return { bg: 'rgba(125, 125, 125, 0.10)', fg: '#cbd5e1', border: 'rgba(125, 125, 125, 0.30)' }
+  }
+}
+
+function severityPalette(severity: string): { bg: string; fg: string; border: string } {
+  switch (severity) {
+    case 'critical':
+      return { bg: 'rgba(220, 38, 38, 0.18)', fg: '#fecaca', border: 'rgba(220, 38, 38, 0.50)' }
+    case 'high':
+      return { bg: 'rgba(249, 115, 22, 0.18)', fg: '#fed7aa', border: 'rgba(249, 115, 22, 0.50)' }
+    case 'medium':
+      return { bg: 'rgba(245, 158, 11, 0.15)', fg: '#fcd34d', border: 'rgba(245, 158, 11, 0.45)' }
+    case 'low':
+      return { bg: 'rgba(59, 130, 246, 0.12)', fg: '#bfdbfe', border: 'rgba(59, 130, 246, 0.45)' }
+    default:
+      return { bg: 'rgba(125, 125, 125, 0.15)', fg: '#cbd5e1', border: 'rgba(125, 125, 125, 0.35)' }
+  }
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceDetailPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceDetailPage.tsx
@@ -60,6 +60,8 @@ import { LogViewer } from '@/widgets/cloud-list/LogViewer'
 import { ExecPanel } from '@/widgets/cloud-list/ExecPanel'
 // Wave-2 Family-E (#1583, C11-010): per-Pod SBOM + CVE drill-down.
 import { SBOMTab } from './SBOMTab'
+// #4085 — per-resource compliance findings table.
+import { ResourceComplianceTab } from './ResourceComplianceTab'
 // #3996 — the lightweight ArgoCD/Flux management tab (Flux reconciler kinds).
 import { ReconcileTab, isReconcilerManageable } from './ReconcileTab'
 import type { K8sObject } from '@/widgets/architecture-graph/useK8sCacheStream'
@@ -352,26 +354,12 @@ export function ResourceDetailPage(props: ResourceDetailPageProps) {
             )
           )}
           {tab === 'compliance' && (
-            <div
-              data-testid="resource-detail-compliance"
-              className="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-2)] p-6"
-            >
-              <h3 className="text-sm font-semibold text-[var(--color-text)] mb-3">
-                Per-resource policy compliance
-              </h3>
-              <p className="text-xs text-[var(--color-text-dim)] mb-4">
-                Wave 5.79 (#2408) — Kyverno + custom-evaluator policy
-                reports filtered to this {apiKind} <code className="font-mono">{ns}/{name}</code>.
-                Drill-down opens in the full Compliance dashboard.
-              </p>
-              <a
-                href={`/sre/compliance?resource=${encodeURIComponent(`${apiKind}/${ns}/${name}`)}`}
-                className="inline-block rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-1.5 text-xs text-[var(--color-text)] hover:bg-[var(--color-surface-hover)] no-underline"
-                data-testid="resource-detail-compliance-drilldown"
-              >
-                Open in Compliance Dashboard →
-              </a>
-            </div>
+            <ResourceComplianceTab
+              sovereignId={deploymentId}
+              kind={apiKind}
+              ns={ns}
+              name={name}
+            />
           )}
           {tab === 'reconcile' && (
             isReconcilerManageable(apiKind) ? (
@@ -951,6 +939,8 @@ function tabLabel(tab: ResourceDetailTab): string {
       return 'Metrics'
     case 'sbom':
       return 'SBOM'
+    case 'compliance':
+      return 'Compliance'
     case 'reconcile':
       return 'Reconcile'
     case 'tree':


### PR DESCRIPTION
## What

In the cloud-list **resource detail view** the tab strip (Overview · YAML · Logs · Exec · Events · Metrics · SBOM · **Compliance** · Reconcile · Tree) had a Compliance tab, but its body was only a one-line blurb plus a link to the sovereign-wide `/sre/compliance` dashboard — it **never showed the resource's own compliance**. Founder ask: the Compliance tab must render a **table of THAT resource's own findings** (the policies/checks that apply to it + pass/fail status), not a blank tab or a redirect.

This PR wires a real per-resource findings table.

## API (catalyst-api)

`products/catalyst/bootstrap/api/internal/handler/compliance.go`:
- `ResourceFinding` + `ResourceComplianceResponse` wire types.
- `HandleComplianceResource` + `resourceComplianceFor` — project ONE resource's per-policy verdicts (`resourceState.results`) joined with the live ClusterPolicy metadata (severity / category / title) into a findings list; reuses the existing `computeScore` for the headline. `found=false` + null score + empty (non-nil) findings when the aggregator hasn't yet seen a PolicyReport for the resource.
- Filter is by the existing per-resource key `<kind>/<ns>/<name>` (the same key the aggregator already maintains) — minimal + additive, no new state.
- New route: `GET /api/v1/sovereigns/{id}/compliance/resource?kind&ns&name` (`cmd/api/main.go`).
- Unit test `TestCompliance_ResourceFindings` — fail-row-first ordering, joined severity/category/message, empty state, 400 on missing params.

## UI (catalyst console)

- `getResourceCompliance` + `ResourceFinding`/`ResourceComplianceResponse` types in `compliance.api.ts`; re-exported via the `lib/compliance.api` shim.
- New `ResourceComplianceTab.tsx` — TanStack Query fetch + score hero + per-policy findings table (policy / severity / status / message) + loading/error/empty states; keeps the dashboard drill-out as a secondary affordance. Plus vitest.
- `ResourceDetailPage.tsx` — replace the placeholder Compliance tab body with `<ResourceComplianceTab>`; add the `Compliance` `tabLabel` case (it was previously missing).

## Tests
- API: `go build ./...` + `go vet` + `go test ./internal/handler/` green.
- UI: `tsc -b --noEmit` green; `vitest` 153 passed across compliance / AppDetail / cloud-list / compliance widgets (incl. the new `ResourceComplianceTab.test.tsx`).

## Notes
- Pre-existing `react-hooks/set-state-in-effect` lint error at `ResourceDetailPage.tsx:148` is unchanged from main (not introduced here); the new files are lint-clean.
- Code + PR only, off `main`. No live env touched. **Do not merge.**

Refs #4085

🤖 Generated with [Claude Code](https://claude.com/claude-code)