### PR TITLE
fix(catalyst): Sovereign status excludes provider-inapplicable HRs from the Degraded roll-up (#4086)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -1016,7 +1016,11 @@ func (d *Deployment) regionHealthForStateLocked() (regions []provisioner.RegionH
 	}
 
 	primaryRegion := primaryRegionKey(&d.Request)
-	return provisioner.ComputeRegionHealth(primaryRegion, primaryStates, snapshotSecondaryStatesLocked(d))
+	// #4086 — pass the deployment provider so provider-inapplicable HRs (the
+	// hcloud control-plane HRs on a Huawei Sovereign, which are suspended and
+	// never go Ready) are excluded from the census, instead of permanently
+	// degrading a healthy non-Hetzner Sovereign.
+	return provisioner.ComputeRegionHealth(d.Request.Provider, primaryRegion, primaryStates, snapshotSecondaryStatesLocked(d))
 }
 
 func (h *Handler) CreateDeployment(w http.ResponseWriter, r *http.Request) {

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -658,6 +658,7 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 	// on each secondary watcher, which takes only the watcher's own lock
 	// (never dep.mu), so there is no lock-ordering hazard.
 	dep.Result.Regions, dep.Result.SecondaryDegraded = provisioner.ComputeRegionHealth(
+		dep.Request.Provider, // #4086 — exclude provider-inapplicable HRs from the census
 		primaryRegionKey(&dep.Request),
 		finalStates,
 		snapshotSecondaryStatesLocked(dep),

--- a/products/catalyst/bootstrap/api/internal/provisioner/region_health.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/region_health.go
@@ -1,5 +1,7 @@
 package provisioner
 
+import "strings"
+
 // Per-region HelmRelease health breakdown (#3611).
 //
 // A 2-region deployment flips to status="ready" the instant the PRIMARY
@@ -44,6 +46,85 @@ const (
 	regionDegradedRatioNumerator   = 9
 	regionDegradedRatioDenominator = 10
 )
+
+// providerInapplicableComponents lists the bootstrap-kit component IDs that
+// can NEVER reach the terminal "installed" state on a given provider because
+// they are gated OFF for that provider at the cluster (#4086).
+//
+// Today only Hetzner-only components qualify: bp-cluster-autoscaler-hcloud
+// (slot 50) and bp-hcloud-ccm (slot 55) are `spec.suspend=${HCLOUD_HR_SUSPEND}`
+// gated — HCLOUD_HR_SUSPEND="true" on Huawei (HCS) cloud-init. A suspended
+// HelmRelease is never marked Ready by Flux, so it stays non-installed forever
+// on a Huawei Sovereign. helmwatch.processEvent ALREADY coerces a suspended HR
+// to StateInstalled (Wave 5.103 / #2447), so on a correctly-gated cluster these
+// components do not drag the census down. This map is the DEFENSE-IN-DEPTH at
+// the roll-up layer: if the suspend gate is ever missing or the informer caches
+// the pre-suspend state, the health census still must not flag a healthy Huawei
+// Sovereign as permanently Degraded (the omantel.biz symptom).
+//
+// Keys are component IDs (HelmRelease name with the "bp-" prefix stripped, per
+// helmwatch.ComponentIDFromHelmRelease) because the per-region state maps this
+// file operates on are keyed that way.
+//
+// IMPORTANT — this is an EXPLICIT, narrow allow-list of components KNOWN to be
+// provider-gated-OFF, NOT a blind name prefix match. It must never grow to hide
+// a genuinely-failing component: a real non-Ready app on the correct provider
+// must still degrade the status. Note bp-hcloud-csi / bp-huawei-evs-csi are
+// deliberately NOT here — both are active-but-empty (Ready) on the other
+// provider (#3971/#892), so they are applicable everywhere and counted.
+var providerInapplicableComponents = map[string]map[string]bool{
+	// On any non-Hetzner provider (huawei today; future aws/gcp/etc), the
+	// hcloud control-plane components are suspended and never go Ready.
+	"huawei": {
+		"cluster-autoscaler-hcloud": true,
+		"hcloud-ccm":                true,
+	},
+}
+
+// normalizeProvider lower-cases/trims the provider string and applies the same
+// empty→"hetzner" default Validate() uses, so the census filter agrees with the
+// rest of the provisioner on what provider a deployment targets.
+func normalizeProvider(provider string) string {
+	p := strings.ToLower(strings.TrimSpace(provider))
+	if p == "" {
+		return "hetzner"
+	}
+	return p
+}
+
+// isComponentInapplicable reports whether component ID is provider-gated-OFF on
+// the given (already-normalized) provider and therefore must be excluded from
+// the health census. Components are applicable by default — only the explicit
+// per-provider allow-list above excludes them.
+func isComponentInapplicable(provider, componentID string) bool {
+	gated := providerInapplicableComponents[provider]
+	if gated == nil {
+		return false
+	}
+	return gated[componentID]
+}
+
+// filterApplicable returns a copy of states with provider-inapplicable
+// components dropped (#4086). The input map is never mutated. A nil/empty input
+// returns nil so countInstalled's nil-map path (0/0) is preserved. When the
+// provider gates nothing the input is returned as-is (no allocation).
+func filterApplicable(provider string, states map[string]string) map[string]string {
+	if len(states) == 0 {
+		return states
+	}
+	gated := providerInapplicableComponents[provider]
+	if len(gated) == 0 {
+		return states
+	}
+	out := make(map[string]string, len(states))
+	for k, v := range states {
+		if isComponentInapplicable(provider, k) {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
 
 // RegionHealth is the per-region HelmRelease census surfaced on the
 // deployment status so "ready" stops hiding a degraded secondary (#3611).
@@ -121,6 +202,12 @@ func regionDegraded(priReady, secReady, secTotal int) bool {
 // already-derived per-region state maps so it is fully table-testable
 // without a live cluster.
 //
+//   - provider: the deployment's cloud provider ("hetzner" / "huawei"; "" is
+//     treated as "hetzner"). Provider-inapplicable HRs — components gated OFF
+//     for this provider that can NEVER go Ready (e.g. the hcloud control-plane
+//     HRs on a Huawei Sovereign, #4086) — are EXCLUDED from the census so a
+//     fully-converged Sovereign is not flagged permanently Degraded by HRs that
+//     do not apply to it. A genuinely-failing applicable component still counts.
 //   - primaryRegion: the declared primary region key (Regions[0].CloudRegion);
 //     "" falls back to the label "primary".
 //   - primaryStates: the primary watcher's terminal component-state map
@@ -132,8 +219,9 @@ func regionDegraded(priReady, secReady, secTotal int) bool {
 // order for deterministic output) and secondaryDegraded = true when ANY
 // secondary is flagged degraded. secondaryDegraded is surface-only — callers
 // log it and expose it but MUST NOT gate "ready" on it.
-func ComputeRegionHealth(primaryRegion string, primaryStates map[string]string, secondaryStates map[string]map[string]string) (regions []RegionHealth, secondaryDegraded bool) {
-	priReady, priTotal := countInstalled(primaryStates)
+func ComputeRegionHealth(provider, primaryRegion string, primaryStates map[string]string, secondaryStates map[string]map[string]string) (regions []RegionHealth, secondaryDegraded bool) {
+	provider = normalizeProvider(provider)
+	priReady, priTotal := countInstalled(filterApplicable(provider, primaryStates))
 	primaryLabel := primaryRegion
 	if primaryLabel == "" {
 		primaryLabel = "primary"
@@ -156,7 +244,7 @@ func ComputeRegionHealth(primaryRegion string, primaryStates map[string]string, 
 	sortStrings(keys)
 
 	for _, region := range keys {
-		secReady, secTotal := countInstalled(secondaryStates[region])
+		secReady, secTotal := countInstalled(filterApplicable(provider, secondaryStates[region]))
 		degraded := regionDegraded(priReady, secReady, secTotal)
 		if degraded {
 			secondaryDegraded = true

--- a/products/catalyst/bootstrap/api/internal/provisioner/region_health_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/region_health_test.go
@@ -169,7 +169,9 @@ func TestComputeRegionHealth(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			gotRegions, gotDeg := ComputeRegionHealth(tc.primaryRegion, tc.primaryStates, tc.secondaryStates)
+			// "" provider → hetzner default, which gates nothing, so these
+			// pre-#4086 cases keep their exact expected census.
+			gotRegions, gotDeg := ComputeRegionHealth("", tc.primaryRegion, tc.primaryStates, tc.secondaryStates)
 			if gotDeg != tc.wantSecondaryDeg {
 				t.Errorf("secondaryDegraded = %v, want %v", gotDeg, tc.wantSecondaryDeg)
 			}
@@ -185,7 +187,7 @@ func TestComputeRegionHealth_PrimaryAlwaysFirstAndNeverDegraded(t *testing.T) {
 	// primary entry is never flagged Degraded — its own health is conveyed
 	// via dep.Status / Phase1Outcome, and Degraded is a secondary-only
 	// signal in this census.
-	regions, deg := ComputeRegionHealth("reg-a", installedN(10, 63), map[string]map[string]string{
+	regions, deg := ComputeRegionHealth("", "reg-a", installedN(10, 63), map[string]map[string]string{
 		"reg-b": installedN(63, 63),
 	})
 	if len(regions) != 2 {
@@ -226,6 +228,140 @@ func TestRegionDegraded_Gate(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestComputeRegionHealth_ExcludesProviderInapplicableHRs is the #4086
+// contract: on a Huawei Sovereign the hcloud control-plane HRs
+// (cluster-autoscaler-hcloud + hcloud-ccm) are suspended and never go Ready,
+// so they must be EXCLUDED from the health census. A Sovereign whose ONLY
+// non-installed HRs are those provider-inapplicable ones must read fully
+// converged (no degraded secondary), while a genuinely-failing applicable
+// component must still degrade the status.
+func TestComputeRegionHealth_ExcludesProviderInapplicableHRs(t *testing.T) {
+	// region-a (primary) + region-b (secondary). Both regions have 60
+	// applicable HRs all installed, PLUS the two hcloud HRs stuck
+	// non-installed (suspended/never-Ready on Huawei). Without the #4086
+	// filter the census would count 60/62 in each region; with the filter it
+	// is 60/60 in each — fully converged, no degraded badge.
+	mkHuaweiRegion := func(applicableInstalled, applicableTotal int) map[string]string {
+		m := installedN(applicableInstalled, applicableTotal)
+		// the inapplicable hcloud HRs, stuck non-installed forever on Huawei.
+		m["cluster-autoscaler-hcloud"] = "installing"
+		m["hcloud-ccm"] = "degraded"
+		return m
+	}
+
+	t.Run("huawei only-hcloud-non-ready -> not degraded, census excludes them", func(t *testing.T) {
+		regions, deg := ComputeRegionHealth("huawei", "me-east-215-a",
+			mkHuaweiRegion(60, 60),
+			map[string]map[string]string{
+				"me-east-215-b": mkHuaweiRegion(60, 60),
+			})
+		if deg {
+			t.Fatalf("secondaryDegraded = true, want false (only provider-inapplicable hcloud HRs are non-Ready)")
+		}
+		if len(regions) != 2 {
+			t.Fatalf("want 2 regions, got %d", len(regions))
+		}
+		// the hcloud HRs must NOT appear in the count — 60/60 not 60/62.
+		if regions[0].HRReady != 60 || regions[0].HRTotal != 60 {
+			t.Errorf("primary census = %d/%d, want 60/60 (hcloud HRs excluded)", regions[0].HRReady, regions[0].HRTotal)
+		}
+		if regions[1].HRReady != 60 || regions[1].HRTotal != 60 {
+			t.Errorf("secondary census = %d/%d, want 60/60 (hcloud HRs excluded)", regions[1].HRReady, regions[1].HRTotal)
+		}
+		if regions[1].Degraded {
+			t.Errorf("secondary must not be degraded when only inapplicable HRs are non-Ready; got %+v", regions[1])
+		}
+	})
+
+	t.Run("huawei real applicable app non-Ready -> still degraded", func(t *testing.T) {
+		// secondary has a REAL applicable component failing (48/60 applicable
+		// installed) on top of the excluded hcloud HRs. The applicable
+		// shortfall must still flag the secondary degraded — the filter must
+		// not mask genuine failures.
+		regions, deg := ComputeRegionHealth("huawei", "me-east-215-a",
+			mkHuaweiRegion(60, 60),
+			map[string]map[string]string{
+				"me-east-215-b": mkHuaweiRegion(48, 60),
+			})
+		if !deg {
+			t.Fatalf("secondaryDegraded = false, want true (a real applicable app is non-Ready)")
+		}
+		if regions[1].HRReady != 48 || regions[1].HRTotal != 60 {
+			t.Errorf("secondary census = %d/%d, want 48/60 (applicable only)", regions[1].HRReady, regions[1].HRTotal)
+		}
+		if !regions[1].Degraded {
+			t.Errorf("secondary should be degraded on a real applicable shortfall; got %+v", regions[1])
+		}
+	})
+
+	t.Run("hetzner does NOT exclude hcloud HRs — they are applicable there", func(t *testing.T) {
+		// On Hetzner the hcloud HRs ARE applicable. A primary with them
+		// non-installed genuinely lowers the count (here they are the only
+		// gap). The primary is never flagged degraded, but the census must
+		// include them: 60/62 not 60/60.
+		regions, _ := ComputeRegionHealth("hetzner", "fsn1",
+			mkHuaweiRegion(60, 60), // same shape: 60 applicable + 2 hcloud non-installed
+			nil)
+		if len(regions) != 1 {
+			t.Fatalf("want 1 region, got %d", len(regions))
+		}
+		if regions[0].HRTotal != 62 {
+			t.Errorf("hetzner total = %d, want 62 (hcloud HRs counted on hetzner)", regions[0].HRTotal)
+		}
+		if regions[0].HRReady != 60 {
+			t.Errorf("hetzner ready = %d, want 60", regions[0].HRReady)
+		}
+	})
+}
+
+// TestFilterApplicable covers the provider-gating helper directly.
+func TestFilterApplicable(t *testing.T) {
+	states := map[string]string{
+		"cilium":                    "installed",
+		"hcloud-ccm":                "installing",
+		"cluster-autoscaler-hcloud": "degraded",
+		"hcloud-csi":                "installed", // active-but-empty on Huawei — applicable, kept
+	}
+	t.Run("huawei drops the two suspended hcloud control-plane HRs", func(t *testing.T) {
+		got := filterApplicable("huawei", states)
+		if _, ok := got["hcloud-ccm"]; ok {
+			t.Errorf("hcloud-ccm must be excluded on huawei")
+		}
+		if _, ok := got["cluster-autoscaler-hcloud"]; ok {
+			t.Errorf("cluster-autoscaler-hcloud must be excluded on huawei")
+		}
+		if _, ok := got["cilium"]; !ok {
+			t.Errorf("cilium must be kept")
+		}
+		if _, ok := got["hcloud-csi"]; !ok {
+			t.Errorf("hcloud-csi is active-but-empty (Ready) on huawei — must be kept, not excluded")
+		}
+		// input not mutated.
+		if _, ok := states["hcloud-ccm"]; !ok {
+			t.Errorf("filterApplicable must not mutate its input map")
+		}
+	})
+	t.Run("hetzner keeps everything", func(t *testing.T) {
+		got := filterApplicable("hetzner", states)
+		if len(got) != len(states) {
+			t.Errorf("hetzner gates nothing: got %d entries, want %d", len(got), len(states))
+		}
+	})
+	t.Run("empty provider defaults to hetzner via normalizeProvider", func(t *testing.T) {
+		if normalizeProvider("") != "hetzner" {
+			t.Errorf("empty provider must default to hetzner")
+		}
+		if normalizeProvider("  HUAWEI ") != "huawei" {
+			t.Errorf("provider must be trimmed + lowercased")
+		}
+	})
+	t.Run("nil/empty states returns as-is (0/0 preserved)", func(t *testing.T) {
+		if got := filterApplicable("huawei", nil); got != nil {
+			t.Errorf("nil input must return nil, got %v", got)
+		}
+	})
 }
 
 func TestCountInstalled(t *testing.T) {


### PR DESCRIPTION
## What
Fix the console readiness chip reading **Degraded** forever on a healthy Huawei (kom4dc) Sovereign. The fix excludes provider-inapplicable HelmReleases from the health/Degraded computation, driven by the deployment's `provider` field.

Refs #4086

## Root cause
The per-region HelmRelease health census (`internal/provisioner/region_health.go` `ComputeRegionHealth`, surfaced via `regionHealthForStateLocked` + the `State()` roll-up as `secondaryDegraded`, consumed by `ui/.../ReadinessChip.tsx`) counted HRs that can **NEVER** go Ready on this provider.

`bp-cluster-autoscaler-hcloud` (slot 50) and `bp-hcloud-ccm` (slot 55) are Hetzner-only, `spec.suspend=${HCLOUD_HR_SUSPEND}`-gated — `HCLOUD_HR_SUSPEND="true"` on Huawei cloud-init. `helmwatch` already coerces a suspended HR to `StateInstalled` (Wave 5.103 / #2447), but when that coercion is missing or the informer cached the pre-suspend state these HRs stay non-installed forever and permanently drag the census down. Diagnosed live on omantel.biz.

## The fix
- New provider-keyed inapplicability filter in the provisioner package: a narrow, explicit per-provider allow-list (`huawei` -> `cluster-autoscaler-hcloud`, `hcloud-ccm`), keyed off the normalized provider — **NOT** a blind `bp-hcloud-*` prefix match that would hide real failures.
- `ComputeRegionHealth` now takes a `provider` arg and drops inapplicable HRs from both the primary and each secondary state map BEFORE counting Ready/total.
- Both call sites updated: the live `State()` path (`regionHealthForStateLocked`) and the persisted `phase1_watch` snapshot — both pass `dep.Request.Provider`.
- `bp-hcloud-csi` / `bp-huawei-evs-csi` are deliberately **not** excluded — they are active-but-empty (Ready) on the other provider (#3971/#892), so they remain applicable everywhere and counted.

A fully-converged Huawei Sovereign with only the hcloud HRs non-Ready now reads **Ready**; a real non-Ready applicable app still degrades the status.

## Computation file:line
- `products/catalyst/bootstrap/api/internal/provisioner/region_health.go` — `ComputeRegionHealth` (now `:219`), new `providerInapplicableComponents` / `normalizeProvider` / `isComponentInapplicable` / `filterApplicable`.
- `products/catalyst/bootstrap/api/internal/handler/deployments.go:1023` — `regionHealthForStateLocked` passes `d.Request.Provider`.
- `products/catalyst/bootstrap/api/internal/handler/phase1_watch.go:660` — persisted snapshot passes `dep.Request.Provider`.

## Tests
`internal/provisioner/region_health_test.go`:
- huawei + only hcloud HRs non-Ready -> not degraded, census 60/60 (hcloud excluded)
- huawei + a real applicable app non-Ready (48/60) -> still degraded
- hetzner does NOT exclude hcloud HRs (counted, 60/62)
- `TestFilterApplicable` (drop on huawei, keep on hetzner, normalize, nil/empty preserved)

`go build` / `go vet` / `go test ./...` green for the api module.

## Risk
Code only — zero live-env touch. Do not merge (founder-requested lower-priority fix off main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
