### PR TITLE
fix(catalyst-console): cloud-view graph-settle (~3s then STOP) + list k9s-style colour-coding (Refs #4084)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/K8sListPage.tone.test.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/K8sListPage.tone.test.ts
@@ -1,0 +1,186 @@
+/**
+ * K8sListPage.tone.test.ts — locks the k9s-style status COLOUR contract
+ * for the Cloud list view (#4084).
+ *
+ * The per-kind list must read like k9s: an operator scans a column and
+ * sees health by colour at a glance — green when ready==desired / Running /
+ * Reconciled, amber when partial / Pending / Reconciling / restarts>0, red
+ * when 0-ready / Failed / CrashLoop / Degraded, grey when Terminating /
+ * Unknown / Completed. Colour is layered ON TOP of the existing text
+ * (accessibility), so these tests assert BOTH the tone and the extracted
+ * label.
+ *
+ * The classifiers + column builders are pure, so we exercise them directly
+ * with synthetic K8s objects — no React/SSE harness required.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { K8sObject } from '@/widgets/architecture-graph/useK8sCacheStream'
+import {
+  tonePhase,
+  toneReconcile,
+  toneReadyVsDesired,
+  colReadyCount,
+  colPodRestarts,
+  colPodPhase,
+  colReconcileStatus,
+  colStatus,
+} from './k8sColumns'
+
+function obj(partial: Partial<K8sObject> & Record<string, unknown>): K8sObject {
+  return { metadata: { name: 'x' }, ...partial } as K8sObject
+}
+
+describe('tonePhase — phase → colour', () => {
+  it('healthy phases are green (ok)', () => {
+    for (const p of ['Running', 'Ready', 'Active', 'Bound', 'Available'])
+      expect(tonePhase(p)).toBe('ok')
+  })
+  it('in-progress phases are amber (warn)', () => {
+    for (const p of ['Pending', 'ContainerCreating', 'Progressing'])
+      expect(tonePhase(p)).toBe('warn')
+  })
+  it('failure phases are red (err)', () => {
+    for (const p of [
+      'CrashLoopBackOff',
+      'Failed',
+      'ImagePullBackOff',
+      'ErrImagePull',
+      'OOMKilled',
+      'Evicted',
+    ])
+      expect(tonePhase(p)).toBe('err')
+  })
+  it('terminal/neutral phases are grey (muted)', () => {
+    for (const p of ['Succeeded', 'Completed', 'Terminating', 'Unknown'])
+      expect(tonePhase(p)).toBe('muted')
+  })
+  it('unrecognised / empty → undefined (plain text)', () => {
+    expect(tonePhase('—')).toBeUndefined()
+    expect(tonePhase('')).toBeUndefined()
+    expect(tonePhase('SomethingCustom')).toBeUndefined()
+  })
+})
+
+describe('toneReconcile — recon vocabulary → colour', () => {
+  it('Reconciled green, Reconciling amber, Degraded red', () => {
+    expect(toneReconcile('Reconciled')).toBe('ok')
+    expect(toneReconcile('Reconciling')).toBe('warn')
+    expect(toneReconcile('Degraded')).toBe('err')
+  })
+})
+
+describe('toneReadyVsDesired — readiness → colour', () => {
+  it('ready==desired (>0) is green', () => {
+    expect(toneReadyVsDesired(3, 3)).toBe('ok')
+  })
+  it('partial readiness is amber', () => {
+    expect(toneReadyVsDesired(1, 3)).toBe('warn')
+  })
+  it('zero ready while desired>0 is red', () => {
+    expect(toneReadyVsDesired(0, 3)).toBe('err')
+  })
+  it('desired 0 is grey (nothing expected)', () => {
+    expect(toneReadyVsDesired(0, 0)).toBe('muted')
+  })
+  it('unknown desired → undefined (plain text)', () => {
+    expect(toneReadyVsDesired(2, undefined)).toBeUndefined()
+  })
+})
+
+describe('colReadyCount — ready/desired column', () => {
+  const col = colReadyCount('readyReplicas', 'replicas', { header: 'Ready' })
+
+  it('renders "<ready>/<desired>" and colours by readiness', () => {
+    const full = obj({ spec: { replicas: 3 }, status: { readyReplicas: 3 } })
+    expect(col.extract(full)).toBe('3/3')
+    expect(col.tone?.(full)).toBe('ok')
+
+    const partial = obj({ spec: { replicas: 3 }, status: { readyReplicas: 1 } })
+    expect(partial && col.extract(partial)).toBe('1/3')
+    expect(col.tone?.(partial)).toBe('warn')
+
+    const down = obj({ spec: { replicas: 3 }, status: {} })
+    expect(col.extract(down)).toBe('0/3')
+    expect(col.tone?.(down)).toBe('err')
+  })
+
+  it('supports desiredFrom:"status" for DaemonSets', () => {
+    const ds = colReadyCount('numberReady', 'desiredNumberScheduled', {
+      desiredFrom: 'status',
+    })
+    const o = obj({ status: { numberReady: 5, desiredNumberScheduled: 5 } })
+    expect(ds.extract(o)).toBe('5/5')
+    expect(ds.tone?.(o)).toBe('ok')
+  })
+})
+
+describe('colPodRestarts — restart count → colour', () => {
+  const col = colPodRestarts()
+  it('0 restarts is grey "0"', () => {
+    const o = obj({ status: { containerStatuses: [{ restartCount: 0 }] } })
+    expect(col.extract(o)).toBe('0')
+    expect(col.tone?.(o)).toBe('muted')
+  })
+  it('a few restarts are amber', () => {
+    const o = obj({ status: { containerStatuses: [{ restartCount: 2 }] } })
+    expect(col.extract(o)).toBe('2')
+    expect(col.tone?.(o)).toBe('warn')
+  })
+  it('many restarts (>=5, summed across containers) are red', () => {
+    const o = obj({
+      status: { containerStatuses: [{ restartCount: 3 }, { restartCount: 4 }] },
+    })
+    expect(col.extract(o)).toBe('7')
+    expect(col.tone?.(o)).toBe('err')
+  })
+})
+
+describe('colPodPhase — surfaces a crash-looping container behind "Running"', () => {
+  const col = colPodPhase()
+  it('a Running pod with a CrashLoopBackOff container reads red', () => {
+    const o = obj({
+      status: {
+        phase: 'Running',
+        containerStatuses: [
+          { state: { waiting: { reason: 'CrashLoopBackOff' } } },
+        ],
+      },
+    })
+    // The column shows the WAITING reason, not the misleading "Running".
+    expect(col.extract(o)).toBe('CrashLoopBackOff')
+    expect(col.tone?.(o)).toBe('err')
+  })
+  it('a genuinely Running pod reads green', () => {
+    const o = obj({
+      status: { phase: 'Running', containerStatuses: [{ ready: true, state: { running: {} } }] },
+    })
+    expect(col.extract(o)).toBe('Running')
+    expect(col.tone?.(o)).toBe('ok')
+  })
+})
+
+describe('colReconcileStatus / colStatus carry tone', () => {
+  it('colReconcileStatus colours by recon state', () => {
+    const col = colReconcileStatus('Status')
+    const ready = obj({ status: { conditions: [{ type: 'Ready', status: 'True' }] } })
+    expect(col.extract(ready)).toBe('Reconciled')
+    expect(col.tone?.(ready)).toBe('ok')
+
+    const stalled = obj({
+      status: {
+        conditions: [{ type: 'Ready', status: 'False', reason: 'RetriesExhausted' }],
+      },
+    })
+    expect(col.extract(stalled)).toBe('Degraded')
+    expect(col.tone?.(stalled)).toBe('err')
+  })
+
+  it('colStatus only tones when opts.tone is set', () => {
+    const plain = colStatus('phase', 'Phase')
+    const toned = colStatus('phase', 'Phase', { tone: true })
+    const o = obj({ status: { phase: 'Running' } })
+    expect(plain.tone).toBeUndefined()
+    expect(toned.tone?.(o)).toBe('ok')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/K8sListPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/K8sListPage.tsx
@@ -17,191 +17,14 @@ import { useCloud } from '../CloudPage'
 import type { K8sObject } from '@/widgets/architecture-graph/useK8sCacheStream'
 import { DETECTED_MODE } from '@/shared/lib/detectMode'
 import { resourceDetailHref } from './resource.api'
+import { CLOUD_K8S_TONE_CSS } from './cloudListCss'
+import type { K8sListPageProps } from './k8sColumns'
 
-export interface K8sListColumn {
-  /** Column header — short, ≤24 chars. */
-  header: string
-  /** Pull a string from the object. Returns "—" by convention when
-   *  the field is absent. */
-  extract: (obj: K8sObject) => string
-}
-
-export interface K8sListPageProps {
-  /** Kind name as registered in the k8scache registry (e.g. "pod",
-   *  "deployment", "service"). */
-  kind: string
-  /** H1-style page title. */
-  title: string
-  /** One-line description rendered under the title. */
-  tagline: string
-  /** Column definitions. Order is render order (left → right). */
-  columns: K8sListColumn[]
-  /** When true, items are sorted by namespace then name. Default true. */
-  sortByName?: boolean
-}
-
-/* ── Common column extractors ──────────────────────────────────── */
-
-export const COL_NAME: K8sListColumn = {
-  header: 'Name',
-  extract: (o) => o.metadata?.name ?? '—',
-}
-
-export const COL_NAMESPACE: K8sListColumn = {
-  header: 'Namespace',
-  extract: (o) => o.metadata?.namespace ?? '—',
-}
-
-export const COL_AGE: K8sListColumn = {
-  header: 'Age',
-  extract: (o) => {
-    const ts = o.metadata?.creationTimestamp
-    if (!ts) return '—'
-    const ms = Date.now() - new Date(ts).getTime()
-    const s = Math.max(0, Math.floor(ms / 1000))
-    if (s < 60) return `${s}s`
-    const m = Math.floor(s / 60)
-    if (m < 60) return `${m}m`
-    const h = Math.floor(m / 60)
-    if (h < 24) return `${h}h`
-    return `${Math.floor(h / 24)}d`
-  },
-}
-
-/** Pull a status field from `obj.status.<key>` as a string. */
-export function colStatus(key: string, header = 'Status'): K8sListColumn {
-  return {
-    header,
-    extract: (o) => {
-      const v = (o.status as Record<string, unknown> | undefined)?.[key]
-      return v == null ? '—' : String(v)
-    },
-  }
-}
-
-/** Pull a spec field from `obj.spec.<key>` as a string. */
-export function colSpec(key: string, header: string): K8sListColumn {
-  return {
-    header,
-    extract: (o) => {
-      const v = (o.spec as Record<string, unknown> | undefined)?.[key]
-      return v == null ? '—' : String(v)
-    },
-  }
-}
-
-/* ── Reconciler-status helpers (#3978 / Refs #3970) ───────────────── */
-
-/**
- * Find a status condition by `type` on a K8s object. Flux/cert-manager/
- * ESO/CNPG + the Catalyst CRs all expose `status.conditions[]` with the
- * canonical {type,status,reason,message} shape.
- */
-function findCondition(
-  o: K8sObject,
-  type: string,
-): { status?: string; reason?: string; message?: string } | undefined {
-  const conds = (o.status as Record<string, unknown> | undefined)?.[
-    'conditions'
-  ] as Array<Record<string, unknown>> | undefined
-  if (!Array.isArray(conds)) return undefined
-  const c = conds.find((x) => x?.['type'] === type)
-  if (!c) return undefined
-  return {
-    status: c['status'] as string | undefined,
-    reason: c['reason'] as string | undefined,
-    message: c['message'] as string | undefined,
-  }
-}
-
-/**
- * colReconcileStatus — render the canonical Ready condition of a
- * continuous reconciler in the Reconciliation vocabulary
- * (Reconciled / Reconciling / Degraded — NEVER Success/Failed). Mirrors
- * the backend reconciliation_dag.go sticky state machine:
- *   Ready=True              → Reconciled
- *   Ready=False (Stalled)   → Degraded   (reason contains "stall"/"retries exhausted")
- *   Ready=False (otherwise) → Reconciling (Flux is still retrying)
- *   no Ready condition yet   → Reconciling
- *
- * `conditionType` defaults to "Ready"; CNPG Clusters carry no Ready
- * condition so callers pass a phase-based extractor instead.
- */
-export function colReconcileStatus(
-  header = 'Status',
-  conditionType = 'Ready',
-): K8sListColumn {
-  return {
-    header,
-    extract: (o) => {
-      const c = findCondition(o, conditionType)
-      if (!c || c.status == null) return 'Reconciling'
-      if (c.status === 'True') return 'Reconciled'
-      // Ready=False: terminal-Degraded only when Flux has given up
-      // (Stalled), otherwise it's still self-healing → Reconciling.
-      const reason = (c.reason ?? '').toLowerCase()
-      const stalled =
-        reason.includes('stall') ||
-        reason.includes('retriesexhausted') ||
-        reason.includes('exhausted')
-      return stalled ? 'Degraded' : 'Reconciling'
-    },
-  }
-}
-
-/**
- * colCnpgStatus — CNPG Cluster has NO Ready condition; its health lives
- * in `status.phase` ("Cluster in healthy state", "Setting up primary",
- * "Failing over", …). Map onto the recon vocabulary so the column reads
- * the same as every other reconciler.
- */
-export function colCnpgStatus(header = 'Status'): K8sListColumn {
-  return {
-    header,
-    extract: (o) => {
-      const phase = (o.status as Record<string, unknown> | undefined)?.[
-        'phase'
-      ] as string | undefined
-      if (!phase) return 'Reconciling'
-      const p = phase.toLowerCase()
-      if (p.includes('healthy')) return 'Reconciled'
-      if (p.includes('fail') || p.includes('unrecoverable')) return 'Degraded'
-      return 'Reconciling'
-    },
-  }
-}
-
-/**
- * colCatalystCrStatus — the Catalyst control-plane CRs (Application /
- * Environment / Organization / Continuum / UserAccess) expose a
- * `status.phase` and/or a Ready condition. Prefer the Ready condition;
- * fall back to phase. Recon vocabulary.
- */
-export function colCatalystCrStatus(header = 'Status'): K8sListColumn {
-  return {
-    header,
-    extract: (o) => {
-      const c = findCondition(o, 'Ready')
-      if (c && c.status != null) {
-        if (c.status === 'True') return 'Reconciled'
-        const reason = (c.reason ?? '').toLowerCase()
-        if (reason.includes('degraded') || reason.includes('error'))
-          return 'Degraded'
-        return 'Reconciling'
-      }
-      const phase = (o.status as Record<string, unknown> | undefined)?.[
-        'phase'
-      ] as string | undefined
-      if (!phase) return 'Reconciling'
-      const p = phase.toLowerCase()
-      if (p.includes('ready') || p.includes('reconciled') || p.includes('active'))
-        return 'Reconciled'
-      if (p.includes('fail') || p.includes('error') || p.includes('degraded'))
-        return 'Degraded'
-      return 'Reconciling'
-    },
-  }
-}
+// Re-export the column types + builders + tone classifiers (#4084) from
+// their new home so existing importers of './K8sListPage' keep working;
+// the definitions live in k8sColumns.ts to keep THIS file component-only
+// (react-refresh/only-export-components).
+export type { CellTone, K8sListColumn, K8sListPageProps } from './k8sColumns'
 
 /* ── Page ───────────────────────────────────────────────────────── */
 
@@ -257,6 +80,7 @@ export function K8sListPage({
 
   return (
     <div data-testid={`cloud-${kind}-list`}>
+      <style>{CLOUD_K8S_TONE_CSS}</style>
       <div className="mb-4">
         <h2 className="text-lg font-semibold text-[var(--color-text-strong)]">{title}</h2>
         <p className="text-sm text-[var(--color-text-dim)]">{tagline}</p>
@@ -316,11 +140,28 @@ export function K8sListPage({
                     role={href ? 'link' : undefined}
                     tabIndex={href ? 0 : undefined}
                   >
-                    {columns.map((c) => (
-                      <td key={c.header} className="px-3 py-2 text-[var(--color-text)]">
-                        {c.extract(obj)}
-                      </td>
-                    ))}
+                    {columns.map((c) => {
+                      const text = c.extract(obj)
+                      const tone = c.tone?.(obj)
+                      return (
+                        <td key={c.header} className="px-3 py-2 text-[var(--color-text)]">
+                          {tone ? (
+                            // k9s-style status chip (#4084). The text stays
+                            // inside the chip so colour is never the only
+                            // signal (accessible to colour-blind operators).
+                            <span
+                              className="cloud-k8s-tone"
+                              data-tone={tone}
+                              data-testid={`cloud-${kind}-cell-tone`}
+                            >
+                              {text}
+                            </span>
+                          ) : (
+                            text
+                          )}
+                        </td>
+                      )
+                    })}
                   </tr>
                 )
               })}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/cloudListCss.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/cloudListCss.ts
@@ -411,3 +411,54 @@ export const CLOUD_LIST_CSS = `
   background: color-mix(in srgb, var(--color-danger) 8%, transparent);
 }
 `
+
+/**
+ * CLOUD_K8S_TONE_CSS — k9s-style status-chip palette for the per-kind K8s
+ * list cells (#4084). The K8sListPage renders a `<span class="cloud-k8s-tone"
+ * data-tone="...">` carrying the cell text; the colour is keyed off the
+ * `data-tone` attribute so the TEXT always renders (colour is never the only
+ * signal). Tones reuse the same design-system status variables the rest of
+ * the console uses (--color-success / --color-warn / --color-danger /
+ * --color-info / --color-text-dim), so light/dark + console-override themes
+ * all flow through automatically. Tabular-nums keeps "3/5" counts aligned.
+ */
+export const CLOUD_K8S_TONE_CSS = `
+.cloud-k8s-tone {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  line-height: 1.2;
+  padding: 0.08rem 0.45rem;
+  border-radius: 999px;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+  border: 1px solid transparent;
+}
+.cloud-k8s-tone[data-tone="ok"] {
+  background: color-mix(in srgb, var(--color-success) 16%, transparent);
+  color: var(--color-success);
+  border-color: color-mix(in srgb, var(--color-success) 35%, transparent);
+}
+.cloud-k8s-tone[data-tone="warn"] {
+  background: color-mix(in srgb, var(--color-warn) 16%, transparent);
+  color: var(--color-warn);
+  border-color: color-mix(in srgb, var(--color-warn) 35%, transparent);
+}
+.cloud-k8s-tone[data-tone="err"] {
+  background: color-mix(in srgb, var(--color-danger) 16%, transparent);
+  color: var(--color-danger);
+  border-color: color-mix(in srgb, var(--color-danger) 35%, transparent);
+}
+.cloud-k8s-tone[data-tone="info"] {
+  background: color-mix(in srgb, var(--color-info) 16%, transparent);
+  color: var(--color-info);
+  border-color: color-mix(in srgb, var(--color-info) 35%, transparent);
+}
+.cloud-k8s-tone[data-tone="muted"] {
+  background: color-mix(in srgb, var(--color-text-dim) 14%, transparent);
+  color: var(--color-text-dim);
+  border-color: color-mix(in srgb, var(--color-text-dim) 28%, transparent);
+}
+`

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/k8sColumns.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/k8sColumns.ts
@@ -1,0 +1,395 @@
+/**
+ * k8sColumns.ts — column definitions, extractors, and the k9s-style status
+ * TONE classifiers for the Cloud per-kind list (K8sListPage).
+ *
+ * Split out of K8sListPage.tsx (#4084) so the page file stays
+ * component-only (react-refresh/only-export-components) — mirroring how
+ * layout.ts is split from GraphCanvas.tsx. Pure data/helpers, no JSX, so
+ * the column catalogue (kindsPages.tsx) and the unit tests import from
+ * here while K8sListPage.tsx imports the types + the COL_* primitives it
+ * renders.
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode) — column
+ * extractors are passed into K8sListPage by the kind catalogue, not
+ * hardcoded per page.
+ */
+
+import type { K8sObject } from '@/widgets/architecture-graph/useK8sCacheStream'
+
+/**
+ * Status TONE for a cell (#4084 — k9s-style colour coding). The list must
+ * read like k9s: an operator scans the column and sees health by COLOUR
+ * instantly. Mapped to the shared status palette:
+ *   ok    → green   (Running / Ready / Reconciled / ready==desired / Bound)
+ *   warn  → amber   (Pending / Reconciling / partial readiness / restarts>0)
+ *   err   → red     (Failed / CrashLoop / Degraded / 0-ready / Error)
+ *   info  → blue    (informational positive, e.g. Active)
+ *   muted → grey    (Terminating / Unknown / Completed / Succeeded)
+ * Returning `undefined` renders the cell as plain text (no chip). Colour
+ * is NEVER the only signal — the text label always renders alongside, so
+ * the surface stays accessible to colour-blind operators.
+ */
+export type CellTone = 'ok' | 'warn' | 'err' | 'info' | 'muted'
+
+export interface K8sListColumn {
+  /** Column header — short, ≤24 chars. */
+  header: string
+  /** Pull a string from the object. Returns "—" by convention when
+   *  the field is absent. */
+  extract: (obj: K8sObject) => string
+  /**
+   * Optional k9s-style status tone for this cell (#4084). When set, the
+   * cell renders as a coloured status chip carrying the extracted text;
+   * when omitted (or it returns undefined) the cell renders plain text.
+   */
+  tone?: (obj: K8sObject) => CellTone | undefined
+}
+
+export interface K8sListPageProps {
+  /** Kind name as registered in the k8scache registry (e.g. "pod",
+   *  "deployment", "service"). */
+  kind: string
+  /** H1-style page title. */
+  title: string
+  /** One-line description rendered under the title. */
+  tagline: string
+  /** Column definitions. Order is render order (left → right). */
+  columns: K8sListColumn[]
+  /** When true, items are sorted by namespace then name. Default true. */
+  sortByName?: boolean
+}
+
+/* ── Common column extractors ──────────────────────────────────── */
+
+export const COL_NAME: K8sListColumn = {
+  header: 'Name',
+  extract: (o) => o.metadata?.name ?? '—',
+}
+
+export const COL_NAMESPACE: K8sListColumn = {
+  header: 'Namespace',
+  extract: (o) => o.metadata?.namespace ?? '—',
+}
+
+export const COL_AGE: K8sListColumn = {
+  header: 'Age',
+  extract: (o) => {
+    const ts = o.metadata?.creationTimestamp
+    if (!ts) return '—'
+    const ms = Date.now() - new Date(ts).getTime()
+    const s = Math.max(0, Math.floor(ms / 1000))
+    if (s < 60) return `${s}s`
+    const m = Math.floor(s / 60)
+    if (m < 60) return `${m}m`
+    const h = Math.floor(m / 60)
+    if (h < 24) return `${h}h`
+    return `${Math.floor(h / 24)}d`
+  },
+}
+
+/** Pull a status field from `obj.status.<key>` as a string. Pass
+ *  `{ tone: true }` to colour the cell by phase (#4084). */
+export function colStatus(
+  key: string,
+  header = 'Status',
+  opts: { tone?: boolean } = {},
+): K8sListColumn {
+  const value = (o: K8sObject): string => {
+    const v = (o.status as Record<string, unknown> | undefined)?.[key]
+    return v == null ? '—' : String(v)
+  }
+  return {
+    header,
+    extract: value,
+    ...(opts.tone ? { tone: (o: K8sObject) => tonePhase(value(o)) } : {}),
+  }
+}
+
+/** Pull a spec field from `obj.spec.<key>` as a string. */
+export function colSpec(key: string, header: string): K8sListColumn {
+  return {
+    header,
+    extract: (o) => {
+      const v = (o.spec as Record<string, unknown> | undefined)?.[key]
+      return v == null ? '—' : String(v)
+    },
+  }
+}
+
+/* ── k9s-style status TONE helpers (#4084) ────────────────────────── */
+
+/** Classify a free-form K8s phase / state STRING into a status tone. Used
+ *  for pod.status.phase, namespace.status.phase, pv.status.phase, etc. */
+export function tonePhase(value: string): CellTone | undefined {
+  const v = value.trim().toLowerCase()
+  if (!v || v === '—') return undefined
+  if (
+    v === 'running' ||
+    v === 'ready' ||
+    v === 'active' ||
+    v === 'bound' ||
+    v === 'available'
+  )
+    return 'ok'
+  if (v === 'pending' || v === 'containercreating' || v === 'progressing')
+    return 'warn'
+  if (
+    v.includes('crashloop') ||
+    v.includes('error') ||
+    v === 'failed' ||
+    v === 'imagepullbackoff' ||
+    v === 'errimagepull' ||
+    v === 'oomkilled' ||
+    v === 'evicted' ||
+    v === 'released' ||
+    v === 'lost'
+  )
+    return 'err'
+  // Completed / Succeeded / Terminating / Unknown are neutral, not alarming.
+  if (
+    v === 'succeeded' ||
+    v === 'completed' ||
+    v === 'terminating' ||
+    v === 'unknown'
+  )
+    return 'muted'
+  return undefined
+}
+
+/** Tone for a Reconciliation-vocabulary status string (Reconciled /
+ *  Reconciling / Degraded), shared by every reconciler column. */
+export function toneReconcile(value: string): CellTone | undefined {
+  const v = value.trim().toLowerCase()
+  if (v === 'reconciled') return 'ok'
+  if (v === 'reconciling') return 'warn'
+  if (v === 'degraded') return 'err'
+  return undefined
+}
+
+/**
+ * Tone for a "ready vs desired" pair: green when ready==desired (and
+ * desired>0), red when ready==0 while desired>0, amber when partial.
+ * `desired` 0/undefined → grey (nothing expected). Non-numeric → undefined.
+ */
+export function toneReadyVsDesired(
+  ready: number | undefined,
+  desired: number | undefined,
+): CellTone | undefined {
+  if (desired == null || Number.isNaN(desired)) return undefined
+  const r = ready ?? 0
+  if (desired === 0) return 'muted'
+  if (r >= desired) return 'ok'
+  if (r === 0) return 'err'
+  return 'warn'
+}
+
+/** Read a numeric `obj.status.<key>` (or 0 when absent). */
+function statusNum(o: K8sObject, key: string): number | undefined {
+  const v = (o.status as Record<string, unknown> | undefined)?.[key]
+  if (v == null) return undefined
+  const n = Number(v)
+  return Number.isNaN(n) ? undefined : n
+}
+
+/** Read a numeric `obj.spec.<key>` (or undefined when absent). */
+function specNum(o: K8sObject, key: string): number | undefined {
+  const v = (o.spec as Record<string, unknown> | undefined)?.[key]
+  if (v == null) return undefined
+  const n = Number(v)
+  return Number.isNaN(n) ? undefined : n
+}
+
+/**
+ * colReadyCount — a k9s-style "Ready" column that renders `<ready>/<desired>`
+ * and colours by readiness. `readyKey` is the status field with the ready
+ * replica count; `desiredKey` (default same as readyKey's spec sibling)
+ * names where the desired count lives. `desiredFrom` chooses spec vs status.
+ */
+export function colReadyCount(
+  readyStatusKey: string,
+  desiredKey: string,
+  opts: { header?: string; desiredFrom?: 'spec' | 'status' } = {},
+): K8sListColumn {
+  const { header = 'Ready', desiredFrom = 'spec' } = opts
+  return {
+    header,
+    extract: (o) => {
+      const ready = statusNum(o, readyStatusKey) ?? 0
+      const desired =
+        desiredFrom === 'spec' ? specNum(o, desiredKey) : statusNum(o, desiredKey)
+      if (desired == null) return String(ready)
+      return `${ready}/${desired}`
+    },
+    tone: (o) => {
+      const ready = statusNum(o, readyStatusKey)
+      const desired =
+        desiredFrom === 'spec' ? specNum(o, desiredKey) : statusNum(o, desiredKey)
+      return toneReadyVsDesired(ready, desired)
+    },
+  }
+}
+
+/**
+ * colPodRestarts — sum container restartCount across the pod's
+ * status.containerStatuses[]. Any restart >0 is amber; a high count (≥5)
+ * is red (something is flapping). 0 restarts renders muted "0".
+ */
+export function colPodRestarts(header = 'Restarts'): K8sListColumn {
+  const count = (o: K8sObject): number => {
+    const cs = (o.status as Record<string, unknown> | undefined)?.[
+      'containerStatuses'
+    ] as Array<Record<string, unknown>> | undefined
+    if (!Array.isArray(cs)) return 0
+    return cs.reduce((sum, c) => sum + (Number(c?.['restartCount']) || 0), 0)
+  }
+  return {
+    header,
+    extract: (o) => String(count(o)),
+    tone: (o) => {
+      const n = count(o)
+      if (n === 0) return 'muted'
+      return n >= 5 ? 'err' : 'warn'
+    },
+  }
+}
+
+/**
+ * colPodPhase — the pod phase, but upgraded the k9s way: a pod whose phase
+ * is Running yet has a not-Ready / waiting container (CrashLoopBackOff,
+ * ImagePullBackOff, …) reads as the WAITING reason, coloured by it. This
+ * is what makes the list surface a crash-looping pod at a glance instead
+ * of a misleading green "Running".
+ */
+export function colPodPhase(header = 'Phase'): K8sListColumn {
+  const effective = (o: K8sObject): string => {
+    const phase =
+      ((o.status as Record<string, unknown> | undefined)?.['phase'] as
+        | string
+        | undefined) ?? '—'
+    const cs = (o.status as Record<string, unknown> | undefined)?.[
+      'containerStatuses'
+    ] as Array<Record<string, unknown>> | undefined
+    if (Array.isArray(cs)) {
+      for (const c of cs) {
+        const waiting = (c?.['state'] as Record<string, unknown> | undefined)?.[
+          'waiting'
+        ] as Record<string, unknown> | undefined
+        const reason = waiting?.['reason'] as string | undefined
+        if (reason && reason !== 'ContainerCreating') return reason
+      }
+    }
+    return phase
+  }
+  return {
+    header,
+    extract: effective,
+    tone: (o) => tonePhase(effective(o)),
+  }
+}
+
+/* ── Reconciler-status helpers (#3978 / Refs #3970) ───────────────── */
+
+/**
+ * Find a status condition by `type` on a K8s object. Flux/cert-manager/
+ * ESO/CNPG + the Catalyst CRs all expose `status.conditions[]` with the
+ * canonical {type,status,reason,message} shape.
+ */
+function findCondition(
+  o: K8sObject,
+  type: string,
+): { status?: string; reason?: string; message?: string } | undefined {
+  const conds = (o.status as Record<string, unknown> | undefined)?.[
+    'conditions'
+  ] as Array<Record<string, unknown>> | undefined
+  if (!Array.isArray(conds)) return undefined
+  const c = conds.find((x) => x?.['type'] === type)
+  if (!c) return undefined
+  return {
+    status: c['status'] as string | undefined,
+    reason: c['reason'] as string | undefined,
+    message: c['message'] as string | undefined,
+  }
+}
+
+/**
+ * colReconcileStatus — render the canonical Ready condition of a
+ * continuous reconciler in the Reconciliation vocabulary
+ * (Reconciled / Reconciling / Degraded — NEVER Success/Failed). Mirrors
+ * the backend reconciliation_dag.go sticky state machine:
+ *   Ready=True              → Reconciled
+ *   Ready=False (Stalled)   → Degraded   (reason contains "stall"/"retries exhausted")
+ *   Ready=False (otherwise) → Reconciling (Flux is still retrying)
+ *   no Ready condition yet   → Reconciling
+ *
+ * `conditionType` defaults to "Ready"; CNPG Clusters carry no Ready
+ * condition so callers pass a phase-based extractor instead.
+ */
+export function colReconcileStatus(
+  header = 'Status',
+  conditionType = 'Ready',
+): K8sListColumn {
+  const value = (o: K8sObject): string => {
+    const c = findCondition(o, conditionType)
+    if (!c || c.status == null) return 'Reconciling'
+    if (c.status === 'True') return 'Reconciled'
+    // Ready=False: terminal-Degraded only when Flux has given up
+    // (Stalled), otherwise it's still self-healing → Reconciling.
+    const reason = (c.reason ?? '').toLowerCase()
+    const stalled =
+      reason.includes('stall') ||
+      reason.includes('retriesexhausted') ||
+      reason.includes('exhausted')
+    return stalled ? 'Degraded' : 'Reconciling'
+  }
+  return { header, extract: value, tone: (o) => toneReconcile(value(o)) }
+}
+
+/**
+ * colCnpgStatus — CNPG Cluster has NO Ready condition; its health lives
+ * in `status.phase` ("Cluster in healthy state", "Setting up primary",
+ * "Failing over", …). Map onto the recon vocabulary so the column reads
+ * the same as every other reconciler.
+ */
+export function colCnpgStatus(header = 'Status'): K8sListColumn {
+  const value = (o: K8sObject): string => {
+    const phase = (o.status as Record<string, unknown> | undefined)?.[
+      'phase'
+    ] as string | undefined
+    if (!phase) return 'Reconciling'
+    const p = phase.toLowerCase()
+    if (p.includes('healthy')) return 'Reconciled'
+    if (p.includes('fail') || p.includes('unrecoverable')) return 'Degraded'
+    return 'Reconciling'
+  }
+  return { header, extract: value, tone: (o) => toneReconcile(value(o)) }
+}
+
+/**
+ * colCatalystCrStatus — the Catalyst control-plane CRs (Application /
+ * Environment / Organization / Continuum / UserAccess) expose a
+ * `status.phase` and/or a Ready condition. Prefer the Ready condition;
+ * fall back to phase. Recon vocabulary.
+ */
+export function colCatalystCrStatus(header = 'Status'): K8sListColumn {
+  const value = (o: K8sObject): string => {
+    const c = findCondition(o, 'Ready')
+    if (c && c.status != null) {
+      if (c.status === 'True') return 'Reconciled'
+      const reason = (c.reason ?? '').toLowerCase()
+      if (reason.includes('degraded') || reason.includes('error'))
+        return 'Degraded'
+      return 'Reconciling'
+    }
+    const phase = (o.status as Record<string, unknown> | undefined)?.[
+      'phase'
+    ] as string | undefined
+    if (!phase) return 'Reconciling'
+    const p = phase.toLowerCase()
+    if (p.includes('ready') || p.includes('reconciled') || p.includes('active'))
+      return 'Reconciled'
+    if (p.includes('fail') || p.includes('error') || p.includes('degraded'))
+      return 'Degraded'
+    return 'Reconciling'
+  }
+  return { header, extract: value, tone: (o) => toneReconcile(value(o)) }
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kinds.test.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kinds.test.ts
@@ -27,7 +27,7 @@ import {
   colReconcileStatus,
   colCnpgStatus,
   colCatalystCrStatus,
-} from './K8sListPage'
+} from './k8sColumns'
 
 /** The reconciler chip ids the founder required (#3978). */
 const RECONCILER_CHIP_IDS = [

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kindsPages.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kindsPages.tsx
@@ -8,8 +8,8 @@
  */
 
 import type { K8sObject } from '@/widgets/architecture-graph/useK8sCacheStream'
+import { K8sListPage } from './K8sListPage'
 import {
-  K8sListPage,
   COL_NAME,
   COL_NAMESPACE,
   COL_AGE,
@@ -18,7 +18,38 @@ import {
   colReconcileStatus,
   colCnpgStatus,
   colCatalystCrStatus,
-} from './K8sListPage'
+  colReadyCount,
+  colPodRestarts,
+  colPodPhase,
+  type CellTone,
+} from './k8sColumns'
+
+/** Pod READY column — `<ready containers>/<total containers>`, coloured by
+ *  readiness. k9s shows this as the headline health signal. */
+function podReadyColumn() {
+  const counts = (o: K8sObject): { ready: number; total: number } => {
+    const cs = (o.status as Record<string, unknown> | undefined)?.[
+      'containerStatuses'
+    ] as Array<Record<string, unknown>> | undefined
+    if (!Array.isArray(cs)) return { ready: 0, total: 0 }
+    const ready = cs.filter((c) => c?.['ready'] === true).length
+    return { ready, total: cs.length }
+  }
+  return {
+    header: 'Ready',
+    extract: (o: K8sObject) => {
+      const { ready, total } = counts(o)
+      return total === 0 ? '—' : `${ready}/${total}`
+    },
+    tone: (o: K8sObject): CellTone | undefined => {
+      const { ready, total } = counts(o)
+      if (total === 0) return undefined
+      if (ready >= total) return 'ok'
+      if (ready === 0) return 'err'
+      return 'warn'
+    },
+  }
+}
 
 export function PodsListPage() {
   return (
@@ -29,7 +60,9 @@ export function PodsListPage() {
       columns={[
         COL_NAMESPACE,
         COL_NAME,
-        colStatus('phase', 'Phase'),
+        podReadyColumn(),
+        colPodPhase('Status'),
+        colPodRestarts('Restarts'),
         colSpec('nodeName', 'Node'),
         COL_AGE,
       ]}
@@ -46,7 +79,8 @@ export function DeploymentsListPage() {
       columns={[
         COL_NAMESPACE,
         COL_NAME,
-        colSpec('replicas', 'Replicas'),
+        // k9s-style ready/desired with green/amber/red readiness colour.
+        colReadyCount('readyReplicas', 'replicas', { header: 'Ready' }),
         colStatus('availableReplicas', 'Available'),
         COL_AGE,
       ]}
@@ -63,8 +97,7 @@ export function StatefulSetsListPage() {
       columns={[
         COL_NAMESPACE,
         COL_NAME,
-        colSpec('replicas', 'Replicas'),
-        colStatus('readyReplicas', 'Ready'),
+        colReadyCount('readyReplicas', 'replicas', { header: 'Ready' }),
         COL_AGE,
       ]}
     />
@@ -81,7 +114,11 @@ export function DaemonSetsListPage() {
         COL_NAMESPACE,
         COL_NAME,
         colStatus('desiredNumberScheduled', 'Desired'),
-        colStatus('numberReady', 'Ready'),
+        // Both counts live in status for DaemonSets.
+        colReadyCount('numberReady', 'desiredNumberScheduled', {
+          header: 'Ready',
+          desiredFrom: 'status',
+        }),
         COL_AGE,
       ]}
     />
@@ -98,7 +135,7 @@ export function ReplicaSetsListPage() {
         COL_NAMESPACE,
         COL_NAME,
         colSpec('replicas', 'Desired'),
-        colStatus('readyReplicas', 'Ready'),
+        colReadyCount('readyReplicas', 'replicas', { header: 'Ready' }),
         COL_AGE,
       ]}
     />
@@ -143,7 +180,7 @@ export function NamespacesListPage() {
       tagline="Logical partitions. Per-namespace RBAC + resource quotas live here."
       columns={[
         COL_NAME,
-        colStatus('phase', 'Phase'),
+        colStatus('phase', 'Phase', { tone: true }),
         COL_AGE,
       ]}
     />
@@ -191,7 +228,7 @@ export function PersistentVolumesListPage() {
       columns={[
         COL_NAME,
         colSpec('storageClassName', 'Class'),
-        colStatus('phase', 'Phase'),
+        colStatus('phase', 'Phase', { tone: true }),
         COL_AGE,
       ]}
     />
@@ -333,6 +370,14 @@ export function GatewaysListPage() {
         {
           header: 'Programmed',
           extract: (o) => gatewayConditionStatus(o, 'Programmed'),
+          // True = front door is live (green); False = not programmed (red);
+          // missing (—) = still settling (amber).
+          tone: (o): CellTone | undefined => {
+            const s = gatewayConditionStatus(o, 'Programmed')
+            if (s === 'True') return 'ok'
+            if (s === 'False') return 'err'
+            return 'warn'
+          },
         },
         COL_AGE,
       ]}
@@ -588,6 +633,32 @@ export function DnsZonesListPage() {
 // (kinds.go: `policyreport` + `clusterpolicyreport`); these wrappers
 // render them as standard list pages with the canonical columns the
 // operator needs (resource being evaluated, pass/fail counts).
+/** A policy-report summary column. `pass` colours green when >0; `fail`
+ *  red when >0 (else green 0); `warn` amber when >0 (else muted). */
+function policyReportSummaryColumn(key: 'pass' | 'fail' | 'warn') {
+  const num = (o: K8sObject): number | null => {
+    const s = (o['summary'] as Record<string, unknown> | undefined) ?? {}
+    const v = s[key]
+    return v == null ? null : Number(v)
+  }
+  const header = key.charAt(0).toUpperCase() + key.slice(1)
+  return {
+    header,
+    extract: (o: K8sObject) => {
+      const n = num(o)
+      return n == null ? '—' : String(n)
+    },
+    tone: (o: K8sObject): CellTone | undefined => {
+      const n = num(o)
+      if (n == null) return undefined
+      if (key === 'pass') return n > 0 ? 'ok' : 'muted'
+      if (key === 'fail') return n > 0 ? 'err' : 'ok'
+      // warn
+      return n > 0 ? 'warn' : 'muted'
+    },
+  }
+}
+
 export function PolicyReportsListPage() {
   return (
     <K8sListPage
@@ -597,30 +668,9 @@ export function PolicyReportsListPage() {
       columns={[
         COL_NAMESPACE,
         COL_NAME,
-        {
-          header: 'Pass',
-          extract: (o) => {
-            const s = (o['summary'] as Record<string, unknown> | undefined) ?? {}
-            const v = s['pass']
-            return v == null ? '—' : String(v)
-          },
-        },
-        {
-          header: 'Fail',
-          extract: (o) => {
-            const s = (o['summary'] as Record<string, unknown> | undefined) ?? {}
-            const v = s['fail']
-            return v == null ? '—' : String(v)
-          },
-        },
-        {
-          header: 'Warn',
-          extract: (o) => {
-            const s = (o['summary'] as Record<string, unknown> | undefined) ?? {}
-            const v = s['warn']
-            return v == null ? '—' : String(v)
-          },
-        },
+        policyReportSummaryColumn('pass'),
+        policyReportSummaryColumn('fail'),
+        policyReportSummaryColumn('warn'),
         COL_AGE,
       ]}
     />
@@ -635,30 +685,9 @@ export function ClusterPolicyReportsListPage() {
       tagline="Cluster-scoped Kyverno ClusterPolicyReport evaluations — pass / fail counts."
       columns={[
         COL_NAME,
-        {
-          header: 'Pass',
-          extract: (o) => {
-            const s = (o['summary'] as Record<string, unknown> | undefined) ?? {}
-            const v = s['pass']
-            return v == null ? '—' : String(v)
-          },
-        },
-        {
-          header: 'Fail',
-          extract: (o) => {
-            const s = (o['summary'] as Record<string, unknown> | undefined) ?? {}
-            const v = s['fail']
-            return v == null ? '—' : String(v)
-          },
-        },
-        {
-          header: 'Warn',
-          extract: (o) => {
-            const s = (o['summary'] as Record<string, unknown> | undefined) ?? {}
-            const v = s['warn']
-            return v == null ? '—' : String(v)
-          },
-        },
+        policyReportSummaryColumn('pass'),
+        policyReportSummaryColumn('fail'),
+        policyReportSummaryColumn('warn'),
         COL_AGE,
       ]}
     />

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/GraphCanvas.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/GraphCanvas.tsx
@@ -23,7 +23,12 @@
  *   • type visibility: hide nodes of types in hiddenTypes
  *   • stats overlay: bottom-left badges (live node/edge count)
  *   • responsive: internal ResizeObserver
- *   • cooldownTicks Infinity — simulation stays alive
+ *   • converge-and-stop: the simulation settles within ~3.5s (alphaMin
+ *     or the SETTLE_CAP_MS hard cap) then freezes — it is NOT kept alive
+ *     perpetually. It only re-warms on a real structural/viewport change
+ *     or a user interaction (drag / relax / add / remove). A status-only
+ *     data refresh updates node fields in place WITHOUT re-warming
+ *     (#3980 convergence + #4084 settle-regression fix).
  *
  * Implementation note: the canonical spec referenced
  * react-force-graph-2d (canvas-based), but this codebase is uniformly
@@ -94,7 +99,13 @@ import {
 } from './types'
 import { shapeForCategory } from './shapes'
 import { GraphLegend } from './GraphLegend'
-import { BOUND_PADDING, NODE_R, physicsFor, phyllotaxisSeed } from './layout'
+import {
+  BOUND_PADDING,
+  NODE_R,
+  physicsFor,
+  phyllotaxisSeed,
+  structuralSignature,
+} from './layout'
 import { markerId, uniqueMarkerDefs } from './markers'
 
 /* ── Public types ────────────────────────────────────────────────── */
@@ -456,6 +467,25 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, GraphCanvasProps>(funct
   const liveEdgesRef = useRef<Map<string, LiveEdge>>(new Map())
   const simRef = useRef<Simulation<LiveNode, LiveEdge> | null>(null)
 
+  // ── Structural signature (#4084 — graph-settle regression) ──────────
+  // The sync effect below MUST re-warm the simulation ONLY when the
+  // STRUCTURE (the set of node ids + edge ids) actually changes — never
+  // on a poll that merely refreshes node status/metadata. The Cloud
+  // surface polls the reconciliation DAG every 4s (Architecture.tsx,
+  // RECON_POLL_MS); each poll hands buildCloudGraph a fresh array, so the
+  // upstream `nodes`/`edges` props (and therefore `visibleNodes`/
+  // `visibleEdges`) acquire NEW references every 4s even when the topology
+  // is identical. Re-warming on every such reference change re-heats the
+  // sim perpetually (CPU spin, never settles) — exactly the #3980
+  // convergence the founder reported regressed. We compare a content
+  // signature, not array identity, so a status-only delta updates the live
+  // nodes in place (done in the effect) but leaves the settled layout
+  // frozen. Initial '' guarantees the very first build always warms up.
+  const structureSigRef = useRef<string>('')
+  // Last viewport the layout warmed against — a real resize (not a
+  // status-only poll) DOES need a re-warm so the field re-fits the box.
+  const lastSizeRef = useRef<{ w: number; h: number }>({ w: 0, h: 0 })
+
   // ── Convergence bookkeeping (#3980 fix 2) ──────────────────────────
   // The force sim must CONVERGE in ~2-4s and then STOP — no perpetual
   // oscillation. We arm a deadline on every warm-up (initial layout,
@@ -698,7 +728,23 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, GraphCanvasProps>(funct
     // so after convergence the layout is perfectly static — no perpetual
     // alphaTarget>0 oscillation.
     sim.alphaDecay(phys.alphaDecay).alphaMin(0.02)
-    warmUp(0.7)
+
+    // CONDITIONAL re-warm (#4084): re-heat the simulation ONLY when the
+    // topology actually changed OR the viewport resized. A status-only
+    // refresh (the 4s reconciliation poll re-deriving the SAME node/edge
+    // set with new array references) updated the live node fields above
+    // but must NOT re-warm — otherwise the layout never settles and the
+    // CPU spins forever. The forces ARE re-tuned above every run (cheap);
+    // only the alpha kick is gated.
+    const nextSig = structuralSignature(visibleNodes, visibleEdges)
+    const sizeChanged =
+      lastSizeRef.current.w !== size.width || lastSizeRef.current.h !== size.height
+    const structureChanged = nextSig !== structureSigRef.current
+    structureSigRef.current = nextSig
+    lastSizeRef.current = { w: size.width, h: size.height }
+    if (structureChanged || sizeChanged) {
+      warmUp(0.7)
+    }
   }, [visibleNodes, visibleEdges, size.width, size.height])
 
   /* ── Drive the render via the simulation tick, then STOP ───────── */

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/layout.test.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/layout.test.ts
@@ -30,7 +30,14 @@ import {
   forceCenter,
   type Simulation,
 } from 'd3-force'
-import { physicsFor, phyllotaxisSeed, NODE_R, BOUND_PADDING } from './layout'
+import {
+  physicsFor,
+  phyllotaxisSeed,
+  NODE_R,
+  BOUND_PADDING,
+  structuralSignature,
+} from './layout'
+import type { GraphEdge, GraphNode } from './types'
 
 /* ── geometry contract (pure, no sim) ───────────────────────────── */
 
@@ -419,5 +426,74 @@ describe('force sim CONVERGES then STOPS (#3980 fix 2)', () => {
       expect(n.x).toBeCloseTo(before[i].x, 9)
       expect(n.y).toBeCloseTo(before[i].y, 9)
     })
+  })
+})
+
+/* ── structuralSignature — graph-settle regression contract (#4084) ──
+ *
+ * The Cloud surface re-derives the SAME node/edge set with fresh array
+ * references every 4s (Architecture.tsx reconciliation poll). GraphCanvas
+ * must re-warm the force simulation ONLY when the topology changes — a
+ * status-only refresh has to produce an IDENTICAL signature so the
+ * settled layout stays frozen instead of re-heating forever. */
+describe('structuralSignature — re-warm gate (#4084)', () => {
+  function node(id: string, status: GraphNode['status'] = 'healthy', label = id): GraphNode {
+    return { id, type: 'Pod', label, status }
+  }
+  function edge(id: string, source: string, target: string): GraphEdge {
+    return { id, source, target, type: 'contains' }
+  }
+
+  const nodesA = [node('a'), node('b'), node('c')]
+  const edgesA = [edge('e1', 'a', 'b'), edge('e2', 'b', 'c')]
+
+  it('is STABLE when only node status/label/metadata change (the 4s poll)', () => {
+    const before = structuralSignature(nodesA, edgesA)
+    // Same ids + edges, but every node flips status and gets a new label —
+    // exactly what a reconciliation poll delivers.
+    const refreshed = [
+      node('a', 'degraded', 'a (now degraded)'),
+      node('b', 'reconciling', 'b (now reconciling)'),
+      node('c', 'failed', 'c (now failed)'),
+    ]
+    const after = structuralSignature(refreshed, [edge('e1', 'a', 'b'), edge('e2', 'b', 'c')])
+    expect(after).toBe(before)
+  })
+
+  it('is STABLE under a different input ORDER of the same set', () => {
+    const before = structuralSignature(nodesA, edgesA)
+    const reordered = structuralSignature(
+      [node('c'), node('a'), node('b')],
+      [edge('e2', 'b', 'c'), edge('e1', 'a', 'b')],
+    )
+    expect(reordered).toBe(before)
+  })
+
+  it('CHANGES when a node is added (topology grew → must re-warm)', () => {
+    const before = structuralSignature(nodesA, edgesA)
+    const after = structuralSignature([...nodesA, node('d')], edgesA)
+    expect(after).not.toBe(before)
+  })
+
+  it('CHANGES when a node is removed', () => {
+    const before = structuralSignature(nodesA, edgesA)
+    const after = structuralSignature([node('a'), node('b')], [edge('e1', 'a', 'b')])
+    expect(after).not.toBe(before)
+  })
+
+  it('CHANGES when an edge is added/rewired (connectivity changed)', () => {
+    const before = structuralSignature(nodesA, edgesA)
+    const added = structuralSignature(nodesA, [...edgesA, edge('e3', 'a', 'c')])
+    expect(added).not.toBe(before)
+    const rewired = structuralSignature(nodesA, [edge('e1', 'a', 'c'), edge('e2', 'b', 'c')])
+    expect(rewired).not.toBe(before)
+  })
+
+  it('does not collide on adjacent-id concatenation (length-prefixed)', () => {
+    // Guard the join: {ab}+{} must not equal {a}+{b}. The length prefixes
+    // and the || separator make the encoding unambiguous.
+    const s1 = structuralSignature([node('ab'), node('c')], [])
+    const s2 = structuralSignature([node('a'), node('bc')], [])
+    expect(s1).not.toBe(s2)
   })
 })

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/layout.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/layout.ts
@@ -30,11 +30,36 @@
  *     safety net only.
  */
 
+import type { GraphEdge, GraphNode } from './types'
+
 /**
  * Floor radius for the node disc (#348 item 10). The actual drawn radius
  * is `max(NODE_R, radiusForDegree(node.degree))`.
  */
 export const NODE_R = 14
+
+/**
+ * structuralSignature — a stable hash of a graph's TOPOLOGY (#4084). Two
+ * node/edge sets with the SAME signature have identical structure (same
+ * node ids, same edge endpoints) even when node status / labels / x-y
+ * positions differ.
+ *
+ * The force layout depends only on the topology, so GraphCanvas re-warms
+ * the simulation iff this signature changes. A status-only refresh — the
+ * Cloud surface re-derives the SAME node/edge set with new array
+ * references every 4s (Architecture.tsx reconciliation poll) — produces
+ * the SAME signature, so the settled layout stays frozen instead of
+ * re-heating forever (the #3980 convergence regression this fixes).
+ *
+ * Sorted so a different INPUT ORDER (same set) never yields a spurious
+ * mismatch. Edge endpoints are read as ids; for the GraphEdge shape
+ * source/target are always string ids.
+ */
+export function structuralSignature(nodes: GraphNode[], edges: GraphEdge[]): string {
+  const n = nodes.map((x) => x.id).sort()
+  const e = edges.map((x) => `${x.source}${x.target}`).sort()
+  return `${n.length}|${n.join('')}||${e.length}|${e.join('')}`
+}
 
 /**
  * Bound padding inside the canvas — the bounded-physics safety-net force


### PR DESCRIPTION
Refs #4084. LOWER-PRIORITY console UI polish in the Cloud view (catalyst bootstrap UI — React + TSX + Tailwind). **Do NOT merge yet** (per founder direction); code + PR off `main` only, zero live-env touch.

## ITEM 1 — Cloud GRAPH converges in ~3s then STOPS (regression of #3980)

**Symptom:** the force-directed graph kept re-simulating indefinitely (CPU spin). #3980 added a converge-and-stop (`SETTLE_CAP_MS = 3500` + `freezeSimulation()`), but it regressed.

**Root cause:** `Architecture.tsx` polls the reconciliation DAG every 4s (`RECON_POLL_MS`). Each poll hands `buildCloudGraph` a fresh array → new `nodes`/`edges` (and `visibleNodes`/`visibleEdges`) references → `GraphCanvas`'s sync `useEffect` re-ran and called `warmUp(0.7)` **unconditionally** every 4s, re-heating the already-settled sim forever. The node/edge **set** is unchanged across polls; only status metadata changes.

**Fix:** gate the re-warm on a **structural signature** (sorted node ids + edge endpoints, new pure `structuralSignature` in `layout.ts`). The sim re-heats **only** when the topology actually changes OR the viewport resizes. A status-only refresh updates the live node fields in place (unchanged behaviour) but leaves the settled layout **frozen**, so it stops within the existing ~3.5s cap and stays stopped. Drag / relax / add / remove still warm up via the imperative handle.

## ITEM 2 — Cloud LIST view k9s-style status colour-coding

The per-kind `K8sListPage` rendered every cell as plain text. Added a status **TONE** channel:
- `K8sListColumn` gains an optional `tone()` classifier; the cell renders a coloured chip carrying the **text** (colour is never the only signal — accessible).
- Palette (reuses design-system vars): green `--color-success` (Running / Ready / Reconciled / ready==desired / Bound), amber `--color-warn` (Pending / Reconciling / partial readiness / restarts>0), red `--color-danger` (Failed / CrashLoop / Degraded / 0-ready), grey `--color-text-dim` (Terminating / Unknown / Completed).
- Wired into: **Pods** (`Ready n/n` + crash-loop-aware Status + Restarts), **Deployments / StatefulSets / DaemonSets / ReplicaSets** (ready/desired), **Namespaces / PersistentVolumes** (phase), **Gateways** (Programmed), **Policy/ClusterPolicyReports** (pass/fail/warn), and every reconciler **Status** column (Reconciled/Reconciling/Degraded).

## Structure / housekeeping
Extracted the column builders + tone classifiers from `K8sListPage.tsx` into a new `k8sColumns.ts` so the page file is **component-only** — this clears the `react-refresh/only-export-components` lint rule, including **8 pre-existing** violations in that file.

## Verification
- `tsc -b --noEmit` — clean
- `vite build` (production) — green
- `eslint` on every touched file — clean (0 errors)
- vitest: 50 new/touched tests pass (`structuralSignature` settle-gate contract + tone classifiers/columns); the cloud-list + architecture-graph suites are fully green. The ~69 failing tests elsewhere (`PinInput6`, `JobsPage`, `ParentDomainsPage`, …) are **pre-existing** on `main` — verified by re-running them with this branch's source stashed — and are the known, CI-tolerated failures (`catalyst-build.yaml` runs the vitest gate non-blocking).

Files: `widgets/architecture-graph/{GraphCanvas,layout,layout.test}.ts(x)` · `pages/sovereign/cloud-list/{K8sListPage,k8sColumns,kindsPages,cloudListCss,kinds.test,K8sListPage.tone.test}.ts(x)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)