### PR TITLE
feat(catalyst-console): sophisticated shared YAML/IaC code editor (CodeMirror 6) everywhere

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -267,7 +267,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -332,6 +331,114 @@
       },
       "bin": {
         "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+      "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-yaml": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.3.tgz",
+      "integrity": "sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.2.0",
+        "@lezer/lr": "^1.0.0",
+        "@lezer/yaml": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+      "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.1.tgz",
+      "integrity": "sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.1.tgz",
+      "integrity": "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -864,6 +971,47 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/yaml": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@lezer/yaml/-/yaml-1.0.4.tgz",
+      "integrity": "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.4.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.5",
@@ -3666,6 +3814,59 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@uiw/codemirror-extensions-basic-setup": {
+      "version": "4.25.10",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.25.10.tgz",
+      "integrity": "sha512-P3vytLlpE62KYSWrMUnwDCv2lvaQDuDZzyj03mHntuHo5bSl34fRZpjTY3kQTPGuXHxkGSYpoPFFj+hMTqaaMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@codemirror/autocomplete": ">=6.0.0",
+        "@codemirror/commands": ">=6.0.0",
+        "@codemirror/language": ">=6.0.0",
+        "@codemirror/lint": ">=6.0.0",
+        "@codemirror/search": ">=6.0.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0"
+      }
+    },
+    "node_modules/@uiw/react-codemirror": {
+      "version": "4.25.10",
+      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.25.10.tgz",
+      "integrity": "sha512-DzgSMwM5qzB7v1FIb4gEeriYt67iiay756/HIOM9mAbeOVK0MO7rqefHf0O5c0269pJKMW7AH9FjclExD23V9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.6",
+        "@codemirror/commands": "^6.1.0",
+        "@codemirror/state": "^6.1.1",
+        "@codemirror/theme-one-dark": "^6.0.0",
+        "@uiw/codemirror-extensions-basic-setup": "4.25.10",
+        "codemirror": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.11.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/theme-one-dark": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0",
+        "codemirror": ">=6.0.0",
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
@@ -4093,6 +4294,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4152,6 +4368,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
       "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -6412,6 +6634,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6976,6 +7204,12 @@
         }
       }
     },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -7165,6 +7399,9 @@
     "products/catalyst/bootstrap/ui": {
       "version": "0.0.0",
       "dependencies": {
+        "@codemirror/lang-yaml": "^6.1.3",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.43.1",
         "@hookform/resolvers": "^5.2.2",
         "@openova/flow-canvas": "file:../../../openova-flow/canvas",
         "@openova/flow-core": "file:../../../openova-flow/core",
@@ -7192,6 +7429,7 @@
         "@tanstack/react-query-devtools": "^5.91.3",
         "@tanstack/react-router": "^1.170.10",
         "@tanstack/router-devtools": "^1.167.0",
+        "@uiw/react-codemirror": "^4.25.10",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-search": "^0.16.0",
         "class-variance-authority": "^0.7.1",

--- a/products/catalyst/bootstrap/ui/package.json
+++ b/products/catalyst/bootstrap/ui/package.json
@@ -16,6 +16,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@codemirror/lang-yaml": "^6.1.3",
+    "@codemirror/state": "^6.6.0",
+    "@codemirror/view": "^6.43.1",
     "@hookform/resolvers": "^5.2.2",
     "@openova/flow-canvas": "file:../../../openova-flow/canvas",
     "@openova/flow-core": "file:../../../openova-flow/core",
@@ -43,6 +46,7 @@
     "@tanstack/react-query-devtools": "^5.91.3",
     "@tanstack/react-router": "^1.170.10",
     "@tanstack/router-devtools": "^1.167.0",
+    "@uiw/react-codemirror": "^4.25.10",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
     "class-variance-authority": "^0.7.1",

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/InstallPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/InstallPage.tsx
@@ -40,6 +40,7 @@ import {
   type CatalogItem,
 } from '@/lib/catalog.api'
 import { InstallForm } from '@/widgets/install/InstallForm'
+import { CodeView } from '@/widgets/code/CodeView'
 
 interface InstallPageProps {
   /** Test seam — pre-selected Blueprint without going through the catalog grid. */
@@ -485,10 +486,7 @@ export function InstallPage({ preselectedBlueprint }: InstallPageProps = {}) {
             ) : null}
             {previewState.manifests.map((m) => (
               <div key={m.path} className="mb-3" data-testid={`install-page-preview-manifest-${m.path}`}>
-                <div className="text-xs font-mono text-[var(--color-text-dim)]">{m.path}</div>
-                <pre className="mt-1 overflow-auto rounded-md border border-[var(--color-border)] bg-[var(--color-bg-elev)] p-3 text-[11px] leading-5 text-[var(--color-text)]">
-                  {m.content}
-                </pre>
+                <CodeView value={m.content} title={m.path} readOnly maxHeight="22rem" />
               </div>
             ))}
           </div>

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceDetailPage.widgets.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceDetailPage.widgets.test.tsx
@@ -176,8 +176,8 @@ describe('ResourceDetailPage — Group A widget mount points (Refs #1099, follow
     expect(url).toMatch(/\/k8s\/metrics\/deployment\/default\/wp/)
   })
 
-  it('YAML tab mounts YamlEditor with seeded textarea (initial seed from initialObj is non-empty)', () => {
-    render(
+  it('YAML tab mounts YamlEditor with the live object seeded into the editor (non-empty)', async () => {
+    const { container } = render(
       <ResourceDetailPage
         deploymentId="dep"
         basePath="/cloud"
@@ -189,13 +189,16 @@ describe('ResourceDetailPage — Group A widget mount points (Refs #1099, follow
       />,
     )
     expect(screen.getByTestId('yaml-editor')).toBeTruthy()
-    // The textarea must seed from the live object so the operator can
-    // see the resource's current shape — the dark anti-pattern would
-    // be an empty textarea on a populated resource.
-    const textarea = screen.getByTestId('yaml-editor-textarea') as HTMLTextAreaElement
-    expect(textarea.value.length).toBeGreaterThan(0)
-    expect(textarea.value).toContain('Deployment')
-    expect(textarea.value).toContain('wp')
+    // The editor must seed from the live object so the operator can see the
+    // resource's current shape — the dark anti-pattern would be an empty
+    // editor on a populated resource. The editor is the shared CodeView
+    // (lazy CodeMirror), so wait for the editor surface to mount and assert
+    // against its rendered content.
+    await waitFor(() => expect(container.querySelector('.cm-content')).toBeTruthy())
+    const editorText = container.querySelector('.cm-content')?.textContent ?? ''
+    expect(editorText.length).toBeGreaterThan(0)
+    expect(editorText).toContain('Deployment')
+    expect(editorText).toContain('wp')
     // Validate + Apply buttons mount unconditionally — the server is
     // the authoritative gate per INVIOLABLE-PRINCIPLES.md #5.
     expect(screen.getByTestId('yaml-editor-validate')).toBeTruthy()

--- a/products/catalyst/bootstrap/ui/src/widgets/cloud-list/YamlEditor.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/cloud-list/YamlEditor.test.tsx
@@ -5,9 +5,17 @@
 
 import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest'
 import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import type { EditorView } from '@codemirror/view'
 
 import { YamlEditor } from './YamlEditor'
 import type { K8sObject } from '@/widgets/architecture-graph/useK8sCacheStream'
+
+/** Replace the editor's whole document, mimicking a user edit. The editor is
+ *  a CodeMirror contenteditable (not a textarea), so edits are driven through
+ *  the live EditorView captured via YamlEditor's onCreateEditor test seam. */
+function setEditorText(view: EditorView, text: string) {
+  view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: text } })
+}
 
 afterEach(() => cleanup())
 beforeEach(() => {
@@ -119,6 +127,7 @@ describe('YamlEditor — flux Apply opens PR (slice Z3)', () => {
         { status: 200, headers: { 'Content-Type': 'application/json' } },
       ),
     )
+    let view: EditorView | null = null
     render(
       <YamlEditor
         deploymentId="dep-z3"
@@ -126,12 +135,17 @@ describe('YamlEditor — flux Apply opens PR (slice Z3)', () => {
         ns="acme"
         name="cm-flux"
         obj={fluxObjOrgLabeled}
+        onCreateEditor={(v) => {
+          view = v
+        }}
       />,
     )
-    // Edit the textarea so dirty=true (Apply enabled).
-    fireEvent.change(screen.getByTestId('yaml-editor-textarea'), {
-      target: { value: 'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm-flux\n' },
-    })
+    // Edit the editor so dirty=true (Apply enabled).
+    await waitFor(() => expect(view).not.toBeNull())
+    setEditorText(view!, 'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm-flux\n')
+    await waitFor(() =>
+      expect((screen.getByTestId('yaml-editor-apply') as HTMLButtonElement).disabled).toBe(false),
+    )
     fireEvent.click(screen.getByTestId('yaml-editor-apply'))
 
     await waitFor(() => {
@@ -157,6 +171,7 @@ describe('YamlEditor — flux Apply opens PR (slice Z3)', () => {
     ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
       new Response('forbidden', { status: 403 }),
     )
+    let view: EditorView | null = null
     render(
       <YamlEditor
         deploymentId="dep-z3-err"
@@ -164,11 +179,16 @@ describe('YamlEditor — flux Apply opens PR (slice Z3)', () => {
         ns="acme"
         name="cm-flux"
         obj={fluxObjOrgLabeled}
+        onCreateEditor={(v) => {
+          view = v
+        }}
       />,
     )
-    fireEvent.change(screen.getByTestId('yaml-editor-textarea'), {
-      target: { value: 'changed: 1\n' },
-    })
+    await waitFor(() => expect(view).not.toBeNull())
+    setEditorText(view!, 'changed: 1\n')
+    await waitFor(() =>
+      expect((screen.getByTestId('yaml-editor-apply') as HTMLButtonElement).disabled).toBe(false),
+    )
     fireEvent.click(screen.getByTestId('yaml-editor-apply'))
     await waitFor(() => {
       expect(screen.getByTestId('yaml-editor-apply-err').textContent).toContain('403')

--- a/products/catalyst/bootstrap/ui/src/widgets/cloud-list/YamlEditor.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/cloud-list/YamlEditor.tsx
@@ -9,11 +9,12 @@
  *   - `managed-by: manual` resources OR no managed-by annotation → calls
  *     /k8s/{kind}/{ns}/{name}/apply for direct apply.
  *
- * The Monaco editor is intentionally NOT bundled (would add ~3 MB to the
- * SPA payload). Instead the editor uses a styled, monospaced textarea
- * with line numbers + a side-by-side diff that computes per-line LCS at
- * render time. Future slice can drop in @monaco-editor/react if visual
- * editing parity becomes a P0; the validate/apply contract is unchanged.
+ * The editor surface is the shared <CodeView> (CodeMirror 6, lazy-loaded so
+ * the ~200 KB core never lands in the initial SPA payload — Monaco's ~3 MB
+ * was rejected for that reason). CodeView gives syntax highlighting, line
+ * numbers, code folding, in-editor search, copy, and console light/dark
+ * theming. The side-by-side diff (computed per-line at render time) and the
+ * validate/apply contract are unchanged.
  *
  * Per docs/INVIOLABLE-PRINCIPLES.md:
  *   #4 (never hardcode) — every endpoint is composed via resource.api.ts.
@@ -24,6 +25,9 @@
 
 import { useMemo, useState } from 'react'
 
+import type { EditorView } from '@codemirror/view'
+
+import { CodeView } from '@/widgets/code/CodeView'
 import { editPRBlueprint, type BlueprintEditPRResponse } from '@/lib/catalog.api'
 import {
   applyYAML,
@@ -57,6 +61,10 @@ export interface YamlEditorProps {
   /** Optional label for the apply button when onCommit is set (default
    *  "Commit IaC"). */
   commitLabel?: string
+  /** Test seam — receives the live CodeMirror EditorView on mount so tests
+   *  can dispatch programmatic edits (the editor is a contenteditable, not a
+   *  textarea). Unused in production. */
+  onCreateEditor?: (view: EditorView) => void
 }
 
 /** Convert a JS object to canonical YAML — small subset suitable for
@@ -125,7 +133,7 @@ function computeDiff(left: string, right: string): DiffLine[] {
   return out
 }
 
-export function YamlEditor({ deploymentId, kind, ns, name, obj, fluxOverride, onCommit, commitLabel }: YamlEditorProps) {
+export function YamlEditor({ deploymentId, kind, ns, name, obj, fluxOverride, onCommit, commitLabel, onCreateEditor }: YamlEditorProps) {
   const initial = useMemo(() => (obj ? objectToYAML(obj) : ''), [obj])
   const [yaml, setYaml] = useState<string>(initial)
   const [showDiff, setShowDiff] = useState(false)
@@ -256,13 +264,15 @@ export function YamlEditor({ deploymentId, kind, ns, name, obj, fluxOverride, on
           </div>
         </div>
       ) : (
-        <textarea
-          aria-label="YAML editor"
-          data-testid="yaml-editor-textarea"
+        <CodeView
           value={yaml}
-          onChange={(e) => setYaml(e.target.value)}
-          spellCheck={false}
-          className="h-96 w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-1)] p-3 font-mono text-sm text-[var(--color-text)] focus:outline-none"
+          onChange={setYaml}
+          language="yaml"
+          ariaLabel="YAML editor"
+          height="24rem"
+          copyable
+          testId="yaml-editor-input"
+          onCreateEditor={onCreateEditor}
         />
       )}
 

--- a/products/catalyst/bootstrap/ui/src/widgets/code/CodeMirrorEditor.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/code/CodeMirrorEditor.tsx
@@ -1,0 +1,104 @@
+/**
+ * CodeMirrorEditor — the heavy CodeMirror 6 surface, kept behind a dynamic
+ * import (see CodeView.tsx) so the ~200 KB editor never lands in the initial
+ * SPA payload. It is the single source of truth for HOW code is rendered in
+ * the console: syntax highlighting, line numbers, code folding, in-editor
+ * search (Ctrl/Cmd-F), read-only vs edit modes, and console-themed colours
+ * (src/widgets/code/codeTheme.ts, bound to the light/dark CSS variables).
+ *
+ * Do not import this module directly from feature code — always go through
+ * <CodeView> / the YamlEditor, which add the chrome (copy button, header,
+ * Suspense fallback) and the lazy boundary.
+ */
+import { useMemo } from 'react'
+import CodeMirror from '@uiw/react-codemirror'
+import { EditorView, lineNumbers } from '@codemirror/view'
+import type { EditorState as CMEditorState } from '@codemirror/state'
+import { EditorState, type Extension } from '@codemirror/state'
+import { foldGutter, codeFolding } from '@codemirror/language'
+import { search, highlightSelectionMatches } from '@codemirror/search'
+import { yaml as yamlLang } from '@codemirror/lang-yaml'
+
+import { consoleCodeTheme } from './codeTheme'
+
+export type CodeLanguage = 'yaml' | 'plaintext'
+
+export interface CodeMirrorEditorProps {
+  value: string
+  onChange?: (value: string) => void
+  readOnly?: boolean
+  language?: CodeLanguage
+  /** CSS height (default 24rem). Read-only viewers usually pass a max via
+   *  `maxHeight` and let the editor grow to content. */
+  height?: string
+  maxHeight?: string
+  /** Accessible label forwarded to the editor's contenteditable surface. */
+  ariaLabel?: string
+  /** Stable hook for tests / e2e selectors. */
+  testId?: string
+  className?: string
+  /** Forwarded to CodeMirror — receives the live EditorView on mount.
+   *  Used by tests to dispatch programmatic edits. */
+  onCreateEditor?: (view: EditorView, state: CMEditorState) => void
+}
+
+function languageExtension(language: CodeLanguage): Extension[] {
+  // plaintext → no language parser (logs, free-form manifests that aren't
+  // strictly YAML still get line numbers + folding + search + theme).
+  return language === 'yaml' ? [yamlLang()] : []
+}
+
+export default function CodeMirrorEditor({
+  value,
+  onChange,
+  readOnly = false,
+  language = 'yaml',
+  height = '24rem',
+  maxHeight,
+  ariaLabel,
+  testId,
+  className,
+  onCreateEditor,
+}: CodeMirrorEditorProps) {
+  const extensions = useMemo<Extension[]>(() => {
+    const exts: Extension[] = [
+      lineNumbers(),
+      codeFolding(),
+      foldGutter(),
+      search({ top: true }),
+      highlightSelectionMatches(),
+      EditorView.lineWrapping,
+      consoleCodeTheme,
+      ...languageExtension(language),
+    ]
+    if (readOnly) exts.push(EditorState.readOnly.of(true), EditorView.editable.of(false))
+    return exts
+  }, [language, readOnly])
+
+  return (
+    <div data-testid={testId} className={className}>
+      <CodeMirror
+        value={value}
+        height={height}
+        maxHeight={maxHeight}
+        readOnly={readOnly}
+        editable={!readOnly}
+        extensions={extensions}
+        onChange={onChange}
+        onCreateEditor={onCreateEditor}
+        // We supply our own theme via consoleCodeTheme; disable the bundled
+        // light/dark presets so they don't override the CSS-variable theme.
+        theme="none"
+        basicSetup={{
+          lineNumbers: false, // provided explicitly above (themed gutter)
+          foldGutter: false, // provided explicitly above
+          searchKeymap: true,
+          highlightActiveLine: !readOnly,
+          highlightActiveLineGutter: !readOnly,
+          autocompletion: false,
+        }}
+        aria-label={ariaLabel}
+      />
+    </div>
+  )
+}

--- a/products/catalyst/bootstrap/ui/src/widgets/code/CodeView.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/code/CodeView.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * CodeView.test.tsx — the shared YAML/IaC code surface (#sophisticated-editor).
+ *
+ * Covers the contract the call-sites rely on:
+ *   • read-only viewer renders the content + a Copy button + optional title.
+ *   • the lazy CodeMirror core mounts (`.cm-editor`) in both modes.
+ *   • edit mode emits onChange when the live EditorView dispatches an edit.
+ *   • Copy writes the value to the clipboard.
+ */
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import type { EditorView } from '@codemirror/view'
+
+import { CodeView } from './CodeView'
+
+afterEach(() => cleanup())
+
+const SAMPLE = 'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\n'
+
+describe('CodeView — read-only viewer', () => {
+  it('renders the content via the lazy CodeMirror surface', async () => {
+    const { container } = render(
+      <CodeView value={SAMPLE} readOnly title="manifests/demo.yaml" testId="cv" />,
+    )
+    // Header title surfaces the manifest path.
+    expect(screen.getByTestId('cv-title').textContent).toBe('manifests/demo.yaml')
+    // CodeMirror mounts (lazy → wait for the editor DOM).
+    await waitFor(() => expect(container.querySelector('.cm-editor')).toBeTruthy())
+    expect(container.querySelector('.cm-content')?.textContent).toContain('ConfigMap')
+  })
+
+  it('shows a Copy button by default and hides it when copyable=false', () => {
+    const { rerender } = render(<CodeView value={SAMPLE} readOnly testId="cv" />)
+    expect(screen.getByTestId('cv-copy')).toBeTruthy()
+    rerender(<CodeView value={SAMPLE} readOnly copyable={false} title="t" testId="cv" />)
+    expect(screen.queryByTestId('cv-copy')).toBeNull()
+  })
+})
+
+describe('CodeView — copy', () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    })
+  })
+
+  it('copies the value to the clipboard and flips the label', async () => {
+    render(<CodeView value={SAMPLE} readOnly testId="cv" />)
+    fireEvent.click(screen.getByTestId('cv-copy'))
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(SAMPLE)
+    await waitFor(() => expect(screen.getByTestId('cv-copy').textContent).toContain('Copied'))
+  })
+})
+
+describe('CodeView — edit mode', () => {
+  it('emits onChange when the editor document is edited', async () => {
+    const onChange = vi.fn()
+    let view: EditorView | null = null
+    render(
+      <CodeView
+        value={SAMPLE}
+        onChange={onChange}
+        testId="cv"
+        onCreateEditor={(v) => {
+          view = v
+        }}
+      />,
+    )
+    await waitFor(() => expect(view).not.toBeNull())
+    view!.dispatch({ changes: { from: view!.state.doc.length, insert: '  extra: 1\n' } })
+    await waitFor(() => expect(onChange).toHaveBeenCalled())
+    expect(onChange.mock.calls.at(-1)![0]).toContain('extra: 1')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/widgets/code/CodeView.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/code/CodeView.tsx
@@ -1,0 +1,145 @@
+/**
+ * CodeView — the ONE reusable code surface for the whole console. Every place
+ * that shows or edits YAML / IaC routes through this component so the look,
+ * theming, and feature set (syntax highlighting, line numbers, folding,
+ * search, copy) are consistent everywhere:
+ *
+ *   • read-only viewer — install/upgrade/topology manifest previews, any
+ *     per-resource YAML display (default `readOnly`).
+ *   • editor — the cloud-list per-resource YAML tab and the catalog
+ *     "Edit IaC" surface drive it through <YamlEditor>, which composes
+ *     CodeView in edit mode.
+ *
+ * The heavy CodeMirror 6 core is lazy-loaded (React.lazy + Suspense) so it
+ * never bloats the initial SPA payload; while it streams in, a themed <pre>
+ * shows the same text so content is legible immediately (and a copy of the
+ * text is still selectable). This keeps `npm run build`'s main chunk lean.
+ */
+import { lazy, Suspense, useCallback, useState } from 'react'
+import type { EditorView } from '@codemirror/view'
+import type { EditorState as CMEditorState } from '@codemirror/state'
+
+import type { CodeLanguage } from './CodeMirrorEditor'
+
+const CodeMirrorEditor = lazy(() => import('./CodeMirrorEditor'))
+
+export interface CodeViewProps {
+  value: string
+  /** When provided the surface is editable and emits on every keystroke. */
+  onChange?: (value: string) => void
+  readOnly?: boolean
+  language?: CodeLanguage
+  /** Optional header label rendered above the editor (e.g. a manifest path). */
+  title?: string
+  /** Show the copy-to-clipboard button (default true). */
+  copyable?: boolean
+  height?: string
+  maxHeight?: string
+  ariaLabel?: string
+  testId?: string
+  className?: string
+  /** Forwarded to CodeMirror — receives the live EditorView on mount. */
+  onCreateEditor?: (view: EditorView, state: CMEditorState) => void
+}
+
+/** Themed fallback shown while the CodeMirror chunk loads (and as the SSR /
+ *  no-JS rendering). Same monospace + surface tokens as the live editor. */
+function CodeFallback({
+  value,
+  maxHeight,
+  height,
+  testId,
+}: {
+  value: string
+  maxHeight?: string
+  height?: string
+  testId?: string
+}) {
+  return (
+    <pre
+      data-testid={testId ? `${testId}-fallback` : undefined}
+      className="overflow-auto rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] p-3 font-mono text-[12px] leading-5 text-[var(--color-text)]"
+      style={{ maxHeight: maxHeight ?? height, margin: 0 }}
+    >
+      {value}
+    </pre>
+  )
+}
+
+export function CodeView({
+  value,
+  onChange,
+  readOnly,
+  language = 'yaml',
+  title,
+  copyable = true,
+  height,
+  maxHeight,
+  ariaLabel,
+  testId,
+  className,
+  onCreateEditor,
+}: CodeViewProps) {
+  const isReadOnly = readOnly ?? onChange === undefined
+  const [copied, setCopied] = useState(false)
+
+  const onCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard?.writeText(value)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1500)
+    } catch {
+      // Clipboard blocked (no permission / insecure context) — leave the
+      // button state unchanged; the text remains selectable in the editor.
+    }
+  }, [value])
+
+  const showHeader = title !== undefined || copyable
+
+  return (
+    <div data-testid={testId} className={className}>
+      {showHeader && (
+        <div className="flex items-center gap-2 px-1 pb-1.5">
+          {title !== undefined && (
+            <span
+              data-testid={testId ? `${testId}-title` : undefined}
+              className="truncate font-mono text-[11px] text-[var(--color-text-dim)]"
+              title={title}
+            >
+              {title}
+            </span>
+          )}
+          {copyable && (
+            <button
+              type="button"
+              onClick={onCopy}
+              data-testid={testId ? `${testId}-copy` : 'code-view-copy'}
+              className="ml-auto rounded border border-[var(--color-border)] px-2 py-0.5 text-[11px] text-[var(--color-text-dim)] hover:bg-[var(--color-bg-3)] hover:text-[var(--color-text)]"
+            >
+              {copied ? 'Copied ✓' : 'Copy'}
+            </button>
+          )}
+        </div>
+      )}
+      <Suspense
+        fallback={
+          <CodeFallback value={value} maxHeight={maxHeight} height={height} testId={testId} />
+        }
+      >
+        <CodeMirrorEditor
+          value={value}
+          onChange={onChange}
+          readOnly={isReadOnly}
+          language={language}
+          height={height ?? (isReadOnly ? undefined : '24rem')}
+          maxHeight={maxHeight}
+          ariaLabel={ariaLabel ?? title}
+          testId={testId ? `${testId}-cm` : undefined}
+          onCreateEditor={onCreateEditor}
+        />
+      </Suspense>
+    </div>
+  )
+}
+
+export default CodeView

--- a/products/catalyst/bootstrap/ui/src/widgets/code/codeTheme.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/code/codeTheme.ts
@@ -1,0 +1,120 @@
+/**
+ * codeTheme — a CodeMirror 6 theme + highlight style that binds to the
+ * console's CSS custom properties (defined in src/app/globals.css and
+ * flipped by `<html data-theme="light">`). Because CodeMirror applies its
+ * theme as inline CSS-in-JS that ends up as real stylesheet rules, `var(--…)`
+ * references resolve against whichever theme is active at paint time — so a
+ * single theme object tracks both the dark default and the light peer with
+ * zero JS theme-switching.
+ *
+ * Token colours intentionally reuse the existing accent / status palette so
+ * the editor reads as "part of the console" rather than a default Monaco /
+ * VS-Code drop-in. Syntax hues degrade gracefully: if a `--code-*` token is
+ * absent the `var()` fallback keeps the editor legible.
+ */
+import { EditorView } from '@codemirror/view'
+import { HighlightStyle, syntaxHighlighting } from '@codemirror/language'
+import { tags as t } from '@lezer/highlight'
+import type { Extension } from '@codemirror/state'
+
+/** Base editor chrome — gutters, selection, cursor, active line, search. */
+const baseTheme = EditorView.theme({
+  '&': {
+    color: 'var(--color-text, #e5e7eb)',
+    backgroundColor: 'var(--color-bg-2, #111827)',
+    fontSize: '13px',
+    borderRadius: 'var(--radius-md, 0.5rem)',
+    border: '1px solid var(--color-border, #1f2937)',
+  },
+  '&.cm-focused': {
+    outline: 'none',
+    borderColor: 'var(--color-accent, #3b82f6)',
+  },
+  '.cm-content': {
+    fontFamily:
+      'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace',
+    caretColor: 'var(--color-accent, #3b82f6)',
+    padding: '8px 0',
+  },
+  '.cm-scroller': {
+    fontFamily:
+      'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace',
+    lineHeight: '1.5',
+  },
+  '.cm-cursor, .cm-dropCursor': {
+    borderLeftColor: 'var(--color-accent, #3b82f6)',
+  },
+  '&.cm-focused .cm-selectionBackground, .cm-selectionBackground, ::selection': {
+    backgroundColor: 'color-mix(in oklab, var(--color-accent, #3b82f6) 28%, transparent)',
+  },
+  '.cm-gutters': {
+    backgroundColor: 'var(--color-bg, #0b1220)',
+    color: 'var(--color-text-dimmer, #6b7280)',
+    border: 'none',
+    borderRight: '1px solid var(--color-border, #1f2937)',
+  },
+  '.cm-activeLineGutter': {
+    backgroundColor: 'color-mix(in oklab, var(--color-accent, #3b82f6) 10%, transparent)',
+    color: 'var(--color-text-dim, #9ca3af)',
+  },
+  '.cm-activeLine': {
+    backgroundColor: 'color-mix(in oklab, var(--color-accent, #3b82f6) 6%, transparent)',
+  },
+  '.cm-foldGutter span': {
+    cursor: 'pointer',
+    color: 'var(--color-text-dimmer, #6b7280)',
+  },
+  '.cm-foldPlaceholder': {
+    backgroundColor: 'color-mix(in oklab, var(--color-accent, #3b82f6) 16%, transparent)',
+    border: 'none',
+    color: 'var(--color-text-dim, #9ca3af)',
+    padding: '0 6px',
+    borderRadius: '4px',
+  },
+  '.cm-panels': {
+    backgroundColor: 'var(--color-bg, #0b1220)',
+    color: 'var(--color-text, #e5e7eb)',
+    borderTop: '1px solid var(--color-border, #1f2937)',
+  },
+  '.cm-panels .cm-textfield': {
+    backgroundColor: 'var(--color-bg-2, #111827)',
+    color: 'var(--color-text, #e5e7eb)',
+    border: '1px solid var(--color-border, #1f2937)',
+    borderRadius: 'var(--radius-sm, 0.375rem)',
+  },
+  '.cm-panels button, .cm-panels .cm-button': {
+    backgroundColor: 'var(--color-bg-2, #111827)',
+    backgroundImage: 'none',
+    color: 'var(--color-text, #e5e7eb)',
+    border: '1px solid var(--color-border, #1f2937)',
+    borderRadius: 'var(--radius-sm, 0.375rem)',
+  },
+  '.cm-searchMatch': {
+    backgroundColor: 'color-mix(in oklab, var(--color-warn, #f59e0b) 35%, transparent)',
+    outline: '1px solid color-mix(in oklab, var(--color-warn, #f59e0b) 60%, transparent)',
+  },
+  '.cm-searchMatch.cm-searchMatch-selected': {
+    backgroundColor: 'color-mix(in oklab, var(--color-accent, #3b82f6) 45%, transparent)',
+  },
+  '.cm-tooltip': {
+    backgroundColor: 'var(--color-bg-2, #111827)',
+    color: 'var(--color-text, #e5e7eb)',
+    border: '1px solid var(--color-border, #1f2937)',
+    borderRadius: 'var(--radius-sm, 0.375rem)',
+  },
+})
+
+/** Syntax colours — keyed off the console palette so YAML keys / strings /
+ *  numbers / comments read in the same accent family as the rest of the UI. */
+const highlight = HighlightStyle.define([
+  { tag: [t.propertyName, t.definition(t.propertyName)], color: 'var(--color-accent, #60a5fa)' },
+  { tag: [t.string, t.special(t.string)], color: 'var(--color-success, #34d399)' },
+  { tag: [t.number, t.bool, t.null, t.atom], color: 'var(--color-warn, #fbbf24)' },
+  { tag: [t.keyword, t.operator], color: 'var(--color-accent-hover, #818cf8)' },
+  { tag: [t.comment, t.lineComment, t.blockComment], color: 'var(--color-text-dimmer, #6b7280)', fontStyle: 'italic' },
+  { tag: [t.meta, t.documentMeta], color: 'var(--color-text-dim, #9ca3af)' },
+  { tag: t.invalid, color: 'var(--color-danger, #f87171)' },
+])
+
+/** The complete theming extension bundle — chrome + syntax highlighting. */
+export const consoleCodeTheme: Extension = [baseTheme, syntaxHighlighting(highlight)]

--- a/products/catalyst/bootstrap/ui/src/widgets/install/UpgradeDialog.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/install/UpgradeDialog.tsx
@@ -23,6 +23,8 @@ import {
 } from '@/lib/catalog.api'
 import { useQuery } from '@tanstack/react-query'
 
+import { CodeView } from '@/widgets/code/CodeView'
+
 export interface UpgradeDialogProps {
   open: boolean
   onClose: () => void
@@ -186,10 +188,7 @@ export function UpgradeDialog({
             ) : null}
             {preview.manifests.map((m) => (
               <div key={m.path} className="mb-2">
-                <div className="text-xs font-mono text-[var(--color-text-dim)]">{m.path}</div>
-                <pre className="mt-1 max-h-60 overflow-auto rounded-md border border-[var(--color-border)] bg-[var(--color-bg-elev)] p-3 text-[11px] leading-5 text-[var(--color-text)]">
-                  {m.content}
-                </pre>
+                <CodeView value={m.content} title={m.path} readOnly maxHeight="15rem" />
               </div>
             ))}
           </div>

--- a/products/catalyst/bootstrap/ui/src/widgets/topology/TopologyEditor.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/topology/TopologyEditor.tsx
@@ -34,6 +34,7 @@ import {
   type CatalogItem,
 } from '@/lib/catalog.api'
 import type { BlueprintTopology } from '@/shared/constants/catalog.generated'
+import { CodeView } from '@/widgets/code/CodeView'
 
 export interface TopologyEditorProps {
   sovereignId: string
@@ -410,10 +411,7 @@ export function TopologyEditor({
             ) : null}
             {preview.manifests.map((m) => (
               <div key={m.path} className="mb-3" data-testid={`topology-editor-preview-manifest-${m.path}`}>
-                <div className="text-xs font-mono text-[var(--color-text-dim)]">{m.path}</div>
-                <pre className="mt-1 overflow-auto rounded-md border border-[var(--color-border)] bg-[var(--color-bg-elev)] p-3 text-[11px] leading-5 text-[var(--color-text)]">
-                  {m.content}
-                </pre>
+                <CodeView value={m.content} title={m.path} readOnly maxHeight="22rem" />
               </div>
             ))}
           </div>


### PR DESCRIPTION
## What

Replaces the bare/ugly YAML & IaC rendering across the Catalyst console (`products/catalyst/bootstrap/ui/`) with **one reusable, sophisticated code surface** built on **CodeMirror 6**, used everywhere YAML/IaC is shown or edited.

The previous state: a plain `<textarea>` for the editable cloud-list per-resource YAML tab and the catalog **Edit IaC** view, plus unstyled `<pre>` blocks for the install / upgrade / topology manifest previews — no syntax highlighting, line numbers, folding, search, or copy, and inconsistent styling.

## The reusable component

`src/widgets/code/` (new):
- **`CodeView.tsx`** — the single public component. Header (optional title) + **copy** button + Suspense/lazy boundary. Read-only by default; editable when `onChange` is provided. This is what every call-site imports.
- **`CodeMirrorEditor.tsx`** — the CodeMirror 6 core: **syntax highlighting, line numbers, code folding, in-editor search (Ctrl/Cmd-F), read-only vs edit modes**. **Lazy-loaded** (`React.lazy`) so the editor ships as its own chunk and never bloats the initial SPA bundle.
- **`codeTheme.ts`** — a CM theme + highlight style bound to the console's CSS custom properties (`--color-*`, `--radius-*`), so it tracks the existing **light/dark** themes with zero JS theme-switching.

**Why CodeMirror 6, not Monaco:** Monaco adds ~3 MB to the SPA (the prior `YamlEditor` comment explicitly rejected it for that reason). CodeMirror 6 is modular and ships here as a single **~433 KB (141 KB gzip) lazy chunk** that loads only when a YAML/IaC surface mounts — confirmed in the build output as a separate `CodeMirrorEditor-*.js` chunk, NOT in the main bundle.

## Call-sites migrated (all now use `CodeView`)

| Site | File | Mode |
|---|---|---|
| Cloud-list per-resource **YAML tab** + catalog **Edit IaC** | `widgets/cloud-list/YamlEditor.tsx` | editor (textarea → CodeView) |
| Install **manifest preview** | `pages/sovereign/InstallPage.tsx` | read-only (`<pre>` → CodeView) |
| Upgrade **manifest preview** | `widgets/install/UpgradeDialog.tsx` | read-only |
| Topology **manifest preview** | `widgets/topology/TopologyEditor.tsx` | read-only |

The `YamlEditor` diff / validate / apply / flux→PR / catalog-commit contract is unchanged — only the input surface swapped.

## Tests & gates

- New `widgets/code/CodeView.test.tsx` (read-only render, copy, edit-mode onChange).
- `YamlEditor.test.tsx` + `ResourceDetailPage.widgets.test.tsx` updated to drive the CodeMirror `EditorView` (a contenteditable, not a textarea) via an `onCreateEditor` test seam.
- `tsc -b` ✅ · `vite build` ✅ (CodeMirror confirmed as a separate lazy chunk) · `vitest` ✅ — **zero NEW failures vs baseline** (9 pre-existing failing files on `main` are unrelated: PinInput6, SettingsPage, ParentDomainsPage, etc.).
- New code is **lint-clean**; the only eslint errors in touched files pre-exist on `main` (`InstallPage`/`TopologyEditor` set-state-in-effect, untouched by this PR).

## Scope

Tertiary operator-console UI polish — **NOT a 5-pillar DoD advance** (founder-requested, lower priority). DOCS/UI code only, **zero live-env risk**. Off `main`; do not merge ahead of pillar work.

Refs #4091

🤖 Generated with [Claude Code](https://claude.com/claude-code)