### PR TITLE
feat(console-settings): re-home Parent Domains as a granular #parent-domains section (drop the odd-one-out left-pane item)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/admin/parent-domains/ParentDomainsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/admin/parent-domains/ParentDomainsPage.tsx
@@ -2,50 +2,39 @@
  * ParentDomainsPage — admin "Parent Domains" surface (issue #829, parent
  * epic #825).
  *
- * Mounted at /console/parent-domains in the SovereignConsoleLayout.
- * Visible only to operator-admin role (gating handled at route level
- * via the same RequireSession guard the rest of /console/* uses).
+ * Mounted at /organizations/domains in the SovereignConsoleLayout (the
+ * legacy /parent-domains route redirects here — see router.tsx
+ * ORGANIZATIONS_REDIRECTS, #3378). Visible only to operator-admin role
+ * (gating handled at route level via the same RequireSession guard the
+ * rest of /console/* uses).
  *
- * Layout:
- *   • Header with title + "+ Add another domain" CTA
- *   • Table: Name | Role | Status | Registrar | Added | (Delete)
- *   • Each row expands inline into a PropagationPanel
- *   • Add modal: name, role, registrarKind, registrarToken
+ * Issue #4089 (founder UX-polish): the inner content now lives in the
+ * reusable `ParentDomainsSection` so the SAME surface can render BOTH as
+ * this standalone page AND as the `#parent-domains` anchor section of the
+ * unified /settings page (consistent with #dns, #marketplace, …). This
+ * page is now a thin PortalShell wrapper — zero functional change to the
+ * standalone route; the table / propagation drawer / add-domain modal /
+ * remove flow all live in ParentDomainsSection.
  *
  * Per docs/INVIOLABLE-PRINCIPLES.md:
- *   #1 (waterfall, target-state shape): the page renders the empty
- *       state on first paint while the fetch runs in the background; the
- *       table replaces the empty state once the response lands.
+ *   #1 (waterfall, target-state shape): the section renders the empty
+ *       state on first paint while the fetch runs in the background.
  *   #4 (never hardcode): every URL flows through the
  *       parentDomains.api.ts wrappers; no inline `/api/...` strings.
  *   #10 (credential hygiene): the registrarToken field uses input
- *       type="password" so the operator's screen recording / shoulder
- *       surfing risk is minimised. The token is sent once on POST and
- *       never returned in the GET list response.
+ *       type="password"; the token is sent once on POST and never
+ *       returned in the GET list response.
  */
 
-import { useEffect, useState } from 'react'
 import {
-  addParentDomain,
-  deleteParentDomain,
-  flipStatusLabel,
-  flipStatusTone,
-  listParentDomains,
-  type AddParentDomainRequest,
-  type ParentDomain,
-  type ParentDomainRole,
-} from './parentDomains.api'
-import { PropagationPanel } from './PropagationPanel'
+  ParentDomainsSection,
+  type ParentDomainsSectionProps,
+} from './ParentDomainsSection'
 import { PortalShell } from '@/pages/sovereign/PortalShell'
 import { DETECTED_MODE } from '@/shared/lib/detectMode'
 import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
 
-export interface ParentDomainsPageProps {
-  /** Test seam — supplies the initial list synchronously. */
-  initialItems?: ParentDomain[]
-  /** Test seam — disables fetch + propagation polling. */
-  disableFetch?: boolean
-}
+export type ParentDomainsPageProps = ParentDomainsSectionProps
 
 export function ParentDomainsPage({
   initialItems,
@@ -53,51 +42,6 @@ export function ParentDomainsPage({
 }: ParentDomainsPageProps = {}) {
   const sovereignFQDN = DETECTED_MODE.sovereignFQDN ?? ''
   const { deploymentId } = useResolvedDeploymentId()
-  const [items, setItems] = useState<ParentDomain[]>(initialItems ?? [])
-  const [loading, setLoading] = useState<boolean>(!initialItems && !disableFetch)
-  const [error, setError] = useState<string | null>(null)
-  const [showModal, setShowModal] = useState(false)
-  const [expanded, setExpanded] = useState<string | null>(null)
-
-  async function refresh() {
-    try {
-      setLoading(true)
-      const rows = await listParentDomains()
-      setItems(rows)
-      setError(null)
-    } catch (err) {
-      setError((err as Error).message)
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  useEffect(() => {
-    if (disableFetch) return
-    void refresh()
-    // refresh is intentionally re-created on every render; we only want
-    // to refire on disableFetch changes (i.e. test seam toggle).
-  }, [disableFetch])
-
-  async function onDelete(item: ParentDomain) {
-    if (item.role === 'primary') {
-      alert('Cannot remove the Sovereign primary domain.')
-      return
-    }
-    if (
-      !confirm(
-        `Remove parent domain "${item.name}"? Organizations already using subdomains under this zone will continue to work; only NEW Organization signups stop being offered this domain.`,
-      )
-    ) {
-      return
-    }
-    try {
-      await deleteParentDomain(item.name)
-      setItems((rows) => rows.filter((r) => r.name !== item.name))
-    } catch (err) {
-      setError((err as Error).message)
-    }
-  }
 
   return (
     <PortalShell
@@ -105,339 +49,7 @@ export function ParentDomainsPage({
       sovereignFQDN={sovereignFQDN}
       pageTitle="Parent Domains"
     >
-    <div data-testid="parent-domains-page">
-      <div className="mb-4 flex items-center justify-between">
-        <div>
-          <p className="text-sm text-[var(--color-text-dim)]">
-            Domains served by this Sovereign's PowerDNS. The primary hosts your console + API; pool domains are offered to Organizations for free subdomain allocation.
-          </p>
-        </div>
-        <button
-          type="button"
-          data-testid="parent-domains-add-cta"
-          onClick={() => setShowModal(true)}
-          className="rounded-md bg-[var(--color-accent)] px-3 py-1.5 text-sm font-medium text-white hover:opacity-90"
-        >
-          + Add another domain
-        </button>
-      </div>
-
-      {error ? (
-        <div
-          data-testid="parent-domains-error"
-          className="mb-3 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-300"
-        >
-          {error}
-        </div>
-      ) : null}
-
-      {loading ? (
-        <div data-testid="parent-domains-loading" className="text-sm text-[var(--color-text-dim)]">
-          Loading…
-        </div>
-      ) : items.length === 0 ? (
-        <div
-          data-testid="parent-domains-empty"
-          className="rounded-md border border-[var(--color-border)] px-4 py-8 text-center text-sm text-[var(--color-text-dim)]"
-        >
-          No parent domains in the pool yet. Click "+ Add another domain" to flip a domain's NS records to this Sovereign.
-        </div>
-      ) : (
-        <table
-          data-testid="parent-domains-table"
-          className="w-full border-collapse text-sm"
-        >
-          <thead>
-            <tr className="border-b border-[var(--color-border)] text-left text-xs uppercase text-[var(--color-text-dim)]">
-              <th className="py-2 pr-3">Domain</th>
-              <th className="py-2 pr-3">Role</th>
-              <th className="py-2 pr-3">Status</th>
-              <th className="py-2 pr-3">Registrar</th>
-              <th className="py-2 pr-3">Added</th>
-              <th className="py-2 pr-3 text-right" aria-label="actions" />
-            </tr>
-          </thead>
-          <tbody>
-            {items.map((item) => {
-              const isExpanded = expanded === item.name
-              return (
-                <ParentDomainRow
-                  key={item.name}
-                  item={item}
-                  expanded={isExpanded}
-                  disablePolling={disableFetch}
-                  onToggle={() => setExpanded(isExpanded ? null : item.name)}
-                  onDelete={() => onDelete(item)}
-                />
-              )
-            })}
-          </tbody>
-        </table>
-      )}
-
-      {showModal && (
-        <AddDomainModal
-          onClose={() => setShowModal(false)}
-          onCreated={async (created) => {
-            setShowModal(false)
-            setItems((rows) => [...rows.filter((r) => r.name !== created.name), created])
-            setExpanded(created.name)
-            // Background refresh so any stub rows produced server-side
-            // are reconciled.
-            void refresh()
-          }}
-        />
-      )}
-    </div>
+      <ParentDomainsSection initialItems={initialItems} disableFetch={disableFetch} />
     </PortalShell>
-  )
-}
-
-interface RowProps {
-  item: ParentDomain
-  expanded: boolean
-  disablePolling: boolean
-  onToggle: () => void
-  onDelete: () => void
-}
-
-function ParentDomainRow({ item, expanded, disablePolling, onToggle, onDelete }: RowProps) {
-  return (
-    <>
-      <tr
-        data-testid={`parent-domain-row-${item.name}`}
-        className="border-b border-[var(--color-border)] hover:bg-[var(--color-bg-2)]"
-      >
-        <td className="py-2 pr-3">
-          <button
-            type="button"
-            data-testid={`parent-domain-toggle-${item.name}`}
-            onClick={onToggle}
-            className="flex items-center gap-1 font-mono text-[var(--color-text)] hover:underline"
-          >
-            <span aria-hidden>{expanded ? '▾' : '▸'}</span>
-            {item.name}
-          </button>
-        </td>
-        <td className="py-2 pr-3">
-          <span
-            data-testid={`parent-domain-role-${item.name}`}
-            className={`rounded-full px-2 py-0.5 text-xs ${
-              item.role === 'primary'
-                ? 'bg-blue-500/15 text-blue-300'
-                : 'bg-purple-500/15 text-purple-300'
-            }`}
-          >
-            {item.role}
-          </span>
-        </td>
-        <td className="py-2 pr-3">
-          <FlipStatusBadge item={item} />
-        </td>
-        <td className="py-2 pr-3 text-xs text-[var(--color-text-dim)]">
-          {item.registrarKind ?? '—'}
-        </td>
-        <td className="py-2 pr-3 text-xs text-[var(--color-text-dim)]">
-          {item.addedAt && item.addedAt.startsWith('0001')
-            ? '—'
-            : new Date(item.addedAt).toLocaleDateString()}
-        </td>
-        <td className="py-2 pr-3 text-right">
-          {item.role === 'primary' ? (
-            <span className="text-xs text-[var(--color-text-dim)]">locked</span>
-          ) : (
-            <button
-              type="button"
-              data-testid={`parent-domain-delete-${item.name}`}
-              onClick={onDelete}
-              className="text-xs text-red-400 hover:underline"
-            >
-              Remove
-            </button>
-          )}
-        </td>
-      </tr>
-      {expanded && (
-        <tr data-testid={`parent-domain-drawer-${item.name}`}>
-          <td
-            colSpan={6}
-            className="bg-[var(--color-bg-2)] border-b border-[var(--color-border)]"
-          >
-            <PropagationPanel domainName={item.name} disablePolling={disablePolling} />
-          </td>
-        </tr>
-      )}
-    </>
-  )
-}
-
-function FlipStatusBadge({ item }: { item: ParentDomain }) {
-  const tone = flipStatusTone(item.flipStatus)
-  const label = flipStatusLabel(item.flipStatus)
-  return (
-    <span
-      data-testid={`parent-domain-status-${item.name}`}
-      title={item.flipMessage}
-      className={`inline-block rounded-full px-2 py-0.5 text-[11px] font-semibold ${
-        tone === 'green'
-          ? 'bg-emerald-500/15 text-emerald-300'
-          : tone === 'amber'
-            ? 'bg-amber-500/15 text-amber-300'
-            : tone === 'red'
-              ? 'bg-red-500/15 text-red-300'
-              : 'bg-blue-500/15 text-blue-300'
-      }`}
-    >
-      {label}
-    </span>
-  )
-}
-
-interface AddDomainModalProps {
-  onClose: () => void
-  onCreated: (item: ParentDomain) => void
-}
-
-function AddDomainModal({ onClose, onCreated }: AddDomainModalProps) {
-  const [name, setName] = useState('')
-  const [role, setRole] = useState<ParentDomainRole>('org-pool')
-  const [registrarKind, setRegistrarKind] = useState('dynadot')
-  const [token, setToken] = useState('')
-  const [submitting, setSubmitting] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-
-  async function onSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    if (!name.trim() || !token.trim()) {
-      setError('Name and registrar token are required.')
-      return
-    }
-    setSubmitting(true)
-    setError(null)
-    try {
-      const req: AddParentDomainRequest = {
-        name: name.trim(),
-        role,
-        registrarKind,
-        registrarToken: token,
-      }
-      const created = await addParentDomain(req)
-      onCreated(created)
-    } catch (err) {
-      setError((err as Error).message)
-    } finally {
-      setSubmitting(false)
-    }
-  }
-
-  return (
-    <div
-      data-testid="add-domain-modal"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      onClick={onClose}
-      role="presentation"
-    >
-      <form
-        onSubmit={onSubmit}
-        onClick={(e) => e.stopPropagation()}
-        className="w-full max-w-md rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] p-6 shadow-xl"
-      >
-        <h2 className="mb-1 text-lg font-semibold text-[var(--color-text-strong)]">
-          Add another parent domain
-        </h2>
-        <p className="mb-4 text-xs text-[var(--color-text-dim)]">
-          OpenOva flips this domain's NS records via the registrar API, bootstraps the PowerDNS zone
-          on this Sovereign, and issues a wildcard cert via cert-manager. Propagation across public
-          resolvers takes up to 48h (gTLD NS TTL).
-        </p>
-
-        {error && (
-          <div
-            data-testid="add-domain-error"
-            className="mb-3 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-xs text-red-300"
-          >
-            {error}
-          </div>
-        )}
-
-        <label className="mb-3 block">
-          <div className="mb-1 text-xs font-medium text-[var(--color-text-dim)]">Domain</div>
-          <input
-            data-testid="add-domain-name"
-            type="text"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="omani.trade"
-            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-3 py-2 text-sm text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
-            autoFocus
-          />
-        </label>
-
-        <label className="mb-3 block">
-          <div className="mb-1 text-xs font-medium text-[var(--color-text-dim)]">Role</div>
-          <select
-            data-testid="add-domain-role"
-            value={role}
-            onChange={(e) => setRole(e.target.value as ParentDomainRole)}
-            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-3 py-2 text-sm text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
-          >
-            <option value="org-pool">pool — offered to Organizations</option>
-            <option value="primary">primary — operator's own domain</option>
-          </select>
-        </label>
-
-        <label className="mb-3 block">
-          <div className="mb-1 text-xs font-medium text-[var(--color-text-dim)]">Registrar</div>
-          <select
-            data-testid="add-domain-registrar"
-            value={registrarKind}
-            onChange={(e) => setRegistrarKind(e.target.value)}
-            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-3 py-2 text-sm text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
-          >
-            <option value="dynadot">Dynadot</option>
-            <option value="cloudflare">Cloudflare</option>
-            <option value="namecheap">Namecheap</option>
-            <option value="godaddy">GoDaddy</option>
-            <option value="ovh">OVH</option>
-          </select>
-        </label>
-
-        <label className="mb-4 block">
-          <div className="mb-1 text-xs font-medium text-[var(--color-text-dim)]">
-            Registrar API token
-          </div>
-          <input
-            data-testid="add-domain-token"
-            type="password"
-            value={token}
-            onChange={(e) => setToken(e.target.value)}
-            placeholder="••••••••••••••••"
-            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-3 py-2 text-sm font-mono text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
-            autoComplete="off"
-          />
-          <div className="mt-1 text-[10px] text-[var(--color-text-dim)]">
-            Used once to flip the NS records. Never logged or persisted in plaintext.
-          </div>
-        </label>
-
-        <div className="flex items-center justify-end gap-2">
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-md px-3 py-1.5 text-sm text-[var(--color-text-dim)] hover:bg-[var(--color-bg-2)]"
-          >
-            Cancel
-          </button>
-          <button
-            type="submit"
-            data-testid="add-domain-submit"
-            disabled={submitting}
-            className="rounded-md bg-[var(--color-accent)] px-4 py-1.5 text-sm font-medium text-white hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {submitting ? 'Adding…' : 'Add domain'}
-          </button>
-        </div>
-      </form>
-    </div>
   )
 }

--- a/products/catalyst/bootstrap/ui/src/pages/admin/parent-domains/ParentDomainsSection.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/admin/parent-domains/ParentDomainsSection.tsx
@@ -1,0 +1,440 @@
+/**
+ * ParentDomainsSection — the inner Parent-Domains admin surface, with
+ * NO PortalShell / page chrome of its own.
+ *
+ * Issue #4089 (founder UX-polish): Parent Domains was the lone child in
+ * SovereignSidebar's SETTINGS_SUB_NAV — the only odd-one-out sub-left-
+ * pane menu item. The founder wants it to be a granular, anchor-
+ * navigable section of the unified /settings page, consistent with #dns
+ * and the other sections — exactly the same move MarketplaceSection got
+ * in Wave 5 (2026-05-17).
+ *
+ * This component renders ONLY the inner content (header CTA + table +
+ * propagation drawer + add-domain modal). The section header / title /
+ * description is owned by the parent `<SectionCard id="parent-domains">`
+ * in SettingsPage.tsx; the PortalShell chrome is owned by SettingsPage.
+ *
+ * The same component is reused by ParentDomainsPage.tsx, which wraps it
+ * in a PortalShell so the standalone /organizations/domains route (and
+ * the /parent-domains redirect that lands there) keep working byte-for-
+ * byte. Zero functional change to either surface — this is a re-home,
+ * not a rewrite.
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md:
+ *   #1 (waterfall, target-state shape): the section renders the empty
+ *       state on first paint while the fetch runs in the background; the
+ *       table replaces the empty state once the response lands.
+ *   #4 (never hardcode): every URL flows through the
+ *       parentDomains.api.ts wrappers; no inline `/api/...` strings.
+ *   #10 (credential hygiene): the registrarToken field uses input
+ *       type="password" so the operator's screen recording / shoulder
+ *       surfing risk is minimised. The token is sent once on POST and
+ *       never returned in the GET list response.
+ */
+
+import { useEffect, useState } from 'react'
+import {
+  addParentDomain,
+  deleteParentDomain,
+  flipStatusLabel,
+  flipStatusTone,
+  listParentDomains,
+  type AddParentDomainRequest,
+  type ParentDomain,
+  type ParentDomainRole,
+} from './parentDomains.api'
+import { PropagationPanel } from './PropagationPanel'
+
+export interface ParentDomainsSectionProps {
+  /** Test seam — supplies the initial list synchronously. */
+  initialItems?: ParentDomain[]
+  /** Test seam — disables fetch + propagation polling. */
+  disableFetch?: boolean
+}
+
+export function ParentDomainsSection({
+  initialItems,
+  disableFetch = false,
+}: ParentDomainsSectionProps = {}) {
+  const [items, setItems] = useState<ParentDomain[]>(initialItems ?? [])
+  const [loading, setLoading] = useState<boolean>(!initialItems && !disableFetch)
+  const [error, setError] = useState<string | null>(null)
+  const [showModal, setShowModal] = useState(false)
+  const [expanded, setExpanded] = useState<string | null>(null)
+
+  async function refresh() {
+    try {
+      setLoading(true)
+      const rows = await listParentDomains()
+      setItems(rows)
+      setError(null)
+    } catch (err) {
+      setError((err as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    if (disableFetch) return
+    void refresh()
+    // refresh is intentionally re-created on every render; we only want
+    // to refire on disableFetch changes (i.e. test seam toggle).
+  }, [disableFetch])
+
+  async function onDelete(item: ParentDomain) {
+    if (item.role === 'primary') {
+      alert('Cannot remove the Sovereign primary domain.')
+      return
+    }
+    if (
+      !confirm(
+        `Remove parent domain "${item.name}"? Organizations already using subdomains under this zone will continue to work; only NEW Organization signups stop being offered this domain.`,
+      )
+    ) {
+      return
+    }
+    try {
+      await deleteParentDomain(item.name)
+      setItems((rows) => rows.filter((r) => r.name !== item.name))
+    } catch (err) {
+      setError((err as Error).message)
+    }
+  }
+
+  return (
+    <div data-testid="parent-domains-page">
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <p className="text-sm text-[var(--color-text-dim)]">
+            Domains served by this Sovereign's PowerDNS. The primary hosts your console + API; pool domains are offered to Organizations for free subdomain allocation.
+          </p>
+        </div>
+        <button
+          type="button"
+          data-testid="parent-domains-add-cta"
+          onClick={() => setShowModal(true)}
+          className="rounded-md bg-[var(--color-accent)] px-3 py-1.5 text-sm font-medium text-white hover:opacity-90"
+        >
+          + Add another domain
+        </button>
+      </div>
+
+      {error ? (
+        <div
+          data-testid="parent-domains-error"
+          className="mb-3 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-300"
+        >
+          {error}
+        </div>
+      ) : null}
+
+      {loading ? (
+        <div data-testid="parent-domains-loading" className="text-sm text-[var(--color-text-dim)]">
+          Loading…
+        </div>
+      ) : items.length === 0 ? (
+        <div
+          data-testid="parent-domains-empty"
+          className="rounded-md border border-[var(--color-border)] px-4 py-8 text-center text-sm text-[var(--color-text-dim)]"
+        >
+          No parent domains in the pool yet. Click "+ Add another domain" to flip a domain's NS records to this Sovereign.
+        </div>
+      ) : (
+        <table
+          data-testid="parent-domains-table"
+          className="w-full border-collapse text-sm"
+        >
+          <thead>
+            <tr className="border-b border-[var(--color-border)] text-left text-xs uppercase text-[var(--color-text-dim)]">
+              <th className="py-2 pr-3">Domain</th>
+              <th className="py-2 pr-3">Role</th>
+              <th className="py-2 pr-3">Status</th>
+              <th className="py-2 pr-3">Registrar</th>
+              <th className="py-2 pr-3">Added</th>
+              <th className="py-2 pr-3 text-right" aria-label="actions" />
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((item) => {
+              const isExpanded = expanded === item.name
+              return (
+                <ParentDomainRow
+                  key={item.name}
+                  item={item}
+                  expanded={isExpanded}
+                  disablePolling={disableFetch}
+                  onToggle={() => setExpanded(isExpanded ? null : item.name)}
+                  onDelete={() => onDelete(item)}
+                />
+              )
+            })}
+          </tbody>
+        </table>
+      )}
+
+      {showModal && (
+        <AddDomainModal
+          onClose={() => setShowModal(false)}
+          onCreated={async (created) => {
+            setShowModal(false)
+            setItems((rows) => [...rows.filter((r) => r.name !== created.name), created])
+            setExpanded(created.name)
+            // Background refresh so any stub rows produced server-side
+            // are reconciled.
+            void refresh()
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+interface RowProps {
+  item: ParentDomain
+  expanded: boolean
+  disablePolling: boolean
+  onToggle: () => void
+  onDelete: () => void
+}
+
+function ParentDomainRow({ item, expanded, disablePolling, onToggle, onDelete }: RowProps) {
+  return (
+    <>
+      <tr
+        data-testid={`parent-domain-row-${item.name}`}
+        className="border-b border-[var(--color-border)] hover:bg-[var(--color-bg-2)]"
+      >
+        <td className="py-2 pr-3">
+          <button
+            type="button"
+            data-testid={`parent-domain-toggle-${item.name}`}
+            onClick={onToggle}
+            className="flex items-center gap-1 font-mono text-[var(--color-text)] hover:underline"
+          >
+            <span aria-hidden>{expanded ? '▾' : '▸'}</span>
+            {item.name}
+          </button>
+        </td>
+        <td className="py-2 pr-3">
+          <span
+            data-testid={`parent-domain-role-${item.name}`}
+            className={`rounded-full px-2 py-0.5 text-xs ${
+              item.role === 'primary'
+                ? 'bg-blue-500/15 text-blue-300'
+                : 'bg-purple-500/15 text-purple-300'
+            }`}
+          >
+            {item.role}
+          </span>
+        </td>
+        <td className="py-2 pr-3">
+          <FlipStatusBadge item={item} />
+        </td>
+        <td className="py-2 pr-3 text-xs text-[var(--color-text-dim)]">
+          {item.registrarKind ?? '—'}
+        </td>
+        <td className="py-2 pr-3 text-xs text-[var(--color-text-dim)]">
+          {item.addedAt && item.addedAt.startsWith('0001')
+            ? '—'
+            : new Date(item.addedAt).toLocaleDateString()}
+        </td>
+        <td className="py-2 pr-3 text-right">
+          {item.role === 'primary' ? (
+            <span className="text-xs text-[var(--color-text-dim)]">locked</span>
+          ) : (
+            <button
+              type="button"
+              data-testid={`parent-domain-delete-${item.name}`}
+              onClick={onDelete}
+              className="text-xs text-red-400 hover:underline"
+            >
+              Remove
+            </button>
+          )}
+        </td>
+      </tr>
+      {expanded && (
+        <tr data-testid={`parent-domain-drawer-${item.name}`}>
+          <td
+            colSpan={6}
+            className="bg-[var(--color-bg-2)] border-b border-[var(--color-border)]"
+          >
+            <PropagationPanel domainName={item.name} disablePolling={disablePolling} />
+          </td>
+        </tr>
+      )}
+    </>
+  )
+}
+
+function FlipStatusBadge({ item }: { item: ParentDomain }) {
+  const tone = flipStatusTone(item.flipStatus)
+  const label = flipStatusLabel(item.flipStatus)
+  return (
+    <span
+      data-testid={`parent-domain-status-${item.name}`}
+      title={item.flipMessage}
+      className={`inline-block rounded-full px-2 py-0.5 text-[11px] font-semibold ${
+        tone === 'green'
+          ? 'bg-emerald-500/15 text-emerald-300'
+          : tone === 'amber'
+            ? 'bg-amber-500/15 text-amber-300'
+            : tone === 'red'
+              ? 'bg-red-500/15 text-red-300'
+              : 'bg-blue-500/15 text-blue-300'
+      }`}
+    >
+      {label}
+    </span>
+  )
+}
+
+interface AddDomainModalProps {
+  onClose: () => void
+  onCreated: (item: ParentDomain) => void
+}
+
+function AddDomainModal({ onClose, onCreated }: AddDomainModalProps) {
+  const [name, setName] = useState('')
+  const [role, setRole] = useState<ParentDomainRole>('org-pool')
+  const [registrarKind, setRegistrarKind] = useState('dynadot')
+  const [token, setToken] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!name.trim() || !token.trim()) {
+      setError('Name and registrar token are required.')
+      return
+    }
+    setSubmitting(true)
+    setError(null)
+    try {
+      const req: AddParentDomainRequest = {
+        name: name.trim(),
+        role,
+        registrarKind,
+        registrarToken: token,
+      }
+      const created = await addParentDomain(req)
+      onCreated(created)
+    } catch (err) {
+      setError((err as Error).message)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      data-testid="add-domain-modal"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onClick={onClose}
+      role="presentation"
+    >
+      <form
+        onSubmit={onSubmit}
+        onClick={(e) => e.stopPropagation()}
+        className="w-full max-w-md rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] p-6 shadow-xl"
+      >
+        <h2 className="mb-1 text-lg font-semibold text-[var(--color-text-strong)]">
+          Add another parent domain
+        </h2>
+        <p className="mb-4 text-xs text-[var(--color-text-dim)]">
+          OpenOva flips this domain's NS records via the registrar API, bootstraps the PowerDNS zone
+          on this Sovereign, and issues a wildcard cert via cert-manager. Propagation across public
+          resolvers takes up to 48h (gTLD NS TTL).
+        </p>
+
+        {error && (
+          <div
+            data-testid="add-domain-error"
+            className="mb-3 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-xs text-red-300"
+          >
+            {error}
+          </div>
+        )}
+
+        <label className="mb-3 block">
+          <div className="mb-1 text-xs font-medium text-[var(--color-text-dim)]">Domain</div>
+          <input
+            data-testid="add-domain-name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="omani.trade"
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-3 py-2 text-sm text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
+            autoFocus
+          />
+        </label>
+
+        <label className="mb-3 block">
+          <div className="mb-1 text-xs font-medium text-[var(--color-text-dim)]">Role</div>
+          <select
+            data-testid="add-domain-role"
+            value={role}
+            onChange={(e) => setRole(e.target.value as ParentDomainRole)}
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-3 py-2 text-sm text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
+          >
+            <option value="org-pool">pool — offered to Organizations</option>
+            <option value="primary">primary — operator's own domain</option>
+          </select>
+        </label>
+
+        <label className="mb-3 block">
+          <div className="mb-1 text-xs font-medium text-[var(--color-text-dim)]">Registrar</div>
+          <select
+            data-testid="add-domain-registrar"
+            value={registrarKind}
+            onChange={(e) => setRegistrarKind(e.target.value)}
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-3 py-2 text-sm text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
+          >
+            <option value="dynadot">Dynadot</option>
+            <option value="cloudflare">Cloudflare</option>
+            <option value="namecheap">Namecheap</option>
+            <option value="godaddy">GoDaddy</option>
+            <option value="ovh">OVH</option>
+          </select>
+        </label>
+
+        <label className="mb-4 block">
+          <div className="mb-1 text-xs font-medium text-[var(--color-text-dim)]">
+            Registrar API token
+          </div>
+          <input
+            data-testid="add-domain-token"
+            type="password"
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            placeholder="••••••••••••••••"
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-3 py-2 text-sm font-mono text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
+            autoComplete="off"
+          />
+          <div className="mt-1 text-[10px] text-[var(--color-text-dim)]">
+            Used once to flip the NS records. Never logged or persisted in plaintext.
+          </div>
+        </label>
+
+        <div className="flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md px-3 py-1.5 text-sm text-[var(--color-text-dim)] hover:bg-[var(--color-bg-2)]"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            data-testid="add-domain-submit"
+            disabled={submitting}
+            className="rounded-md bg-[var(--color-accent)] px-4 py-1.5 text-sm font-medium text-white hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {submitting ? 'Adding…' : 'Add domain'}
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/SettingsPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/SettingsPage.test.tsx
@@ -5,9 +5,9 @@
  * Coverage:
  *   • Page renders inside PortalShell with the canonical sidebar +
  *     header chrome.
- *   • All 9 sections are present (organization, sovereign, api-tokens,
- *     cloud-credentials, dns, domain-mode, notifications, members,
- *     danger-zone).
+ *   • All sections are present (organization, sovereign, api-tokens,
+ *     cloud-credentials, dns, domain-mode, parent-domains [#4089],
+ *     marketplace, notifications, members, danger-zone).
  *   • In-page TOC entries point at the matching anchors.
  *   • Sovereign info reflects the live snapshot fields (FQDN, region,
  *     deployment id) — the page is not a static placeholder.
@@ -120,6 +120,10 @@ const ALL_SECTIONS = [
   'cloud-credentials',
   'dns',
   'domain-mode',
+  // #4089: Parent Domains re-homed from the lone Settings sub-nav child
+  // into a granular anchor section, consistent with #dns.
+  'parent-domains',
+  'marketplace',
   'notifications',
   'members',
   'danger-zone',
@@ -144,7 +148,7 @@ describe('SettingsPage — chrome', () => {
 })
 
 describe('SettingsPage — section catalogue', () => {
-  it('renders all 9 industry-standard sections', async () => {
+  it('renders all industry-standard sections (incl. #parent-domains, #4089)', async () => {
     renderSettings('d-test-1234')
     for (const id of ALL_SECTIONS) {
       expect(await screen.findByTestId(`settings-section-${id}`)).toBeTruthy()

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/SettingsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/SettingsPage.tsx
@@ -59,6 +59,7 @@ import { useDeploymentEvents } from './useDeploymentEvents'
 import { useWizardStore } from '@/entities/deployment/store'
 import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
 import { MarketplaceSection } from './settings/MarketplaceSection'
+import { ParentDomainsSection } from '@/pages/admin/parent-domains/ParentDomainsSection'
 import { SovereigntyCard } from '@/widgets/sovereignty'
 
 /* ── Constants ──────────────────────────────────────────────────── */
@@ -92,6 +93,15 @@ const SECTIONS: readonly SectionDef[] = [
   { id: 'cloud-credentials', label: 'Cloud credentials', description: 'Hetzner provider token + S3 backup keys.' },
   { id: 'dns', label: 'DNS', description: 'Pool domain, subdomain, TLS issuer status.' },
   { id: 'domain-mode', label: 'Domain mode', description: 'Pool vs Bring-Your-Own — read-only after activation.' },
+  // #4089 (founder UX-polish): Parent Domains was the lone child in
+  // SovereignSidebar's SETTINGS_SUB_NAV — the only odd-one-out sub-left-
+  // pane menu item. Re-homed as a granular `<SectionCard id="parent-
+  // domains">` anchor section here, consistent with #dns and the move
+  // Marketplace already got (Wave 5). Sits right after Domain mode since
+  // both are domain-config surfaces. The standalone page lives on at
+  // /organizations/domains (the same ParentDomainsSection in a
+  // PortalShell), and /parent-domains still redirects there.
+  { id: 'parent-domains', label: 'Parent domains', description: 'The pool of registrar domains this Sovereign serves via PowerDNS — add / remove pool domains, watch NS-flip + DNS propagation.' },
   // Wave 5 (2026-05-17, founder UX-polish review): marketplace toggle
   // moved off the Settings sub-nav + standalone /settings/marketplace
   // page INTO this anchor section. Founder ruling: *"if market place
@@ -111,6 +121,13 @@ const SECTIONS: readonly SectionDef[] = [
 ] as const
 
 const TOKEN_MASK = '••••••••••••••••'
+
+/** Look a section's description up by id so the render code never has to
+ *  track fragile numeric `SECTIONS[N]` offsets when sections are inserted
+ *  (e.g. #4089 added `parent-domains` mid-array). */
+function desc(id: string): string {
+  return SECTIONS.find((s) => s.id === id)?.description ?? ''
+}
 
 /* ── Page ───────────────────────────────────────────────────────── */
 
@@ -223,7 +240,7 @@ export function SettingsPage({ disableStream = false }: SettingsPageProps = {}) 
           {/* ── Right pane — sections stacked ─────────────────── */}
           <main className="flex min-w-0 flex-1 flex-col gap-6">
             {/* 1. Organization */}
-            <SectionCard id="organization" title="Organization" description={SECTIONS[0]!.description}>
+            <SectionCard id="organization" title="Organization" description={desc('organization')}>
               <FieldGrid>
                 <Field label="Name" value={orgName} testId="settings-org-name" />
                 <Field label="Billing email" value={orgEmail} testId="settings-org-email" />
@@ -233,7 +250,7 @@ export function SettingsPage({ disableStream = false }: SettingsPageProps = {}) 
             </SectionCard>
 
             {/* 2. Sovereign */}
-            <SectionCard id="sovereign" title="Sovereign" description={SECTIONS[1]!.description}>
+            <SectionCard id="sovereign" title="Sovereign" description={desc('sovereign')}>
               <FieldGrid>
                 <Field label="Sovereign FQDN" value={sovereignFQDN} mono testId="settings-sov-fqdn" />
                 <Field label="Region" value={region} mono testId="settings-sov-region" />
@@ -263,7 +280,7 @@ export function SettingsPage({ disableStream = false }: SettingsPageProps = {}) 
             <SectionCard
               id="api-tokens"
               title="API tokens"
-              description={SECTIONS[2]!.description}
+              description={desc('api-tokens')}
               actionLabel="Create token"
               actionTestId="settings-tokens-create"
               pendingApi
@@ -302,7 +319,7 @@ export function SettingsPage({ disableStream = false }: SettingsPageProps = {}) 
             <SectionCard
               id="cloud-credentials"
               title="Cloud credentials"
-              description={SECTIONS[3]!.description}
+              description={desc('cloud-credentials')}
               pendingApi
             >
               <ul className="flex flex-col gap-2" data-testid="settings-cloud-creds-list">
@@ -313,7 +330,7 @@ export function SettingsPage({ disableStream = false }: SettingsPageProps = {}) 
             </SectionCard>
 
             {/* 5. DNS */}
-            <SectionCard id="dns" title="DNS" description={SECTIONS[4]!.description}>
+            <SectionCard id="dns" title="DNS" description={desc('dns')}>
               <FieldGrid>
                 <Field label="Pool domain" value={poolDomain} mono testId="settings-dns-pool-domain" />
                 <Field
@@ -332,7 +349,7 @@ export function SettingsPage({ disableStream = false }: SettingsPageProps = {}) 
             </SectionCard>
 
             {/* 6. Domain mode */}
-            <SectionCard id="domain-mode" title="Domain mode" description={SECTIONS[5]!.description}>
+            <SectionCard id="domain-mode" title="Domain mode" description={desc('domain-mode')}>
               <FieldGrid>
                 <Field label="Mode" value={domainMode} testId="settings-domain-mode-value" />
                 <Field
@@ -343,18 +360,27 @@ export function SettingsPage({ disableStream = false }: SettingsPageProps = {}) 
               </FieldGrid>
             </SectionCard>
 
-            {/* 7. Marketplace — Wave 5 (2026-05-17): moved here from
+            {/* 7. Parent domains — #4089 (2026-06-22): re-homed from the
+                lone Settings sub-nav child / standalone /parent-domains
+                route into this anchor section, consistent with #dns +
+                the move Marketplace already got. Same ParentDomainsSection
+                the standalone /organizations/domains page renders. */}
+            <SectionCard id="parent-domains" title="Parent domains" description={desc('parent-domains')}>
+              <ParentDomainsSection />
+            </SectionCard>
+
+            {/* 8. Marketplace — Wave 5 (2026-05-17): moved here from
                 the retired /settings/marketplace standalone page +
                 Settings sub-nav child. */}
-            <SectionCard id="marketplace" title="Marketplace" description={SECTIONS[6]!.description}>
+            <SectionCard id="marketplace" title="Marketplace" description={desc('marketplace')}>
               <MarketplaceSection />
             </SectionCard>
 
-            {/* 8. Notifications */}
+            {/* 9. Notifications */}
             <SectionCard
               id="notifications"
               title="Notifications"
-              description={SECTIONS[7]!.description}
+              description={desc('notifications')}
               pendingApi
             >
               <FieldGrid>
@@ -363,8 +389,8 @@ export function SettingsPage({ disableStream = false }: SettingsPageProps = {}) 
               </FieldGrid>
             </SectionCard>
 
-            {/* 9. Members — link to existing User Access page */}
-            <SectionCard id="members" title="Members" description={SECTIONS[8]!.description}>
+            {/* 10. Members — link to existing User Access page */}
+            <SectionCard id="members" title="Members" description={desc('members')}>
               <p className="text-sm text-[var(--color-text-dim)]">
                 Operators are managed on the dedicated User Access page so role bindings, app
                 grants, and namespace scopes share one editor.
@@ -378,11 +404,11 @@ export function SettingsPage({ disableStream = false }: SettingsPageProps = {}) 
               </Link>
             </SectionCard>
 
-            {/* 10. Danger zone */}
+            {/* 11. Danger zone */}
             <SectionCard
               id="danger-zone"
               title="Danger zone"
-              description={SECTIONS[9]!.description}
+              description={desc('danger-zone')}
               tone="danger"
             >
               <ul className="flex flex-col gap-3">
@@ -416,7 +442,7 @@ export function SettingsPage({ disableStream = false }: SettingsPageProps = {}) 
               </ul>
             </SectionCard>
 
-            {/* 11. Sovereignty — #793 production mount of the cutover card
+            {/* 12. Sovereignty — #793 production mount of the cutover card
                 (was only reachable at the /sovereignty/preview harness route).
                 Self-contained widget: renders its own header/badge/CTA and
                 self-fetches cutover status, so it is not wrapped in a

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
@@ -156,34 +156,29 @@ const SETTINGS_ITEM: FlatNavItem = {
   icon: 'M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z M15 12a3 3 0 11-6 0 3 3 0 016 0z',
 }
 
-// ── Settings sub-nav ──────────────────────────────────────────────────────────
+// ── Settings: no sub-nav children ─────────────────────────────────────────────
 //
-// Wave 5 (2026-05-17, founder UX-polish review): Marketplace moved off
-// the sub-nav and INTO SettingsPage as a `<SectionCard id="marketplace">`
-// anchor section (same pattern as #dns, #sovereign, #notifications).
-// Founder: *"if market place is just a toggle etting under setting it
-// dosnt need tohave a sdicated page and it doesnt need to have child
-// left pane menu item"*. The dedicated /settings/marketplace route was
-// retired in the same PR.
+// Settings has NO sub-left-pane children — every settings surface is a
+// granular anchor section of the unified /settings page (#organization,
+// #sovereign, #dns, #domain-mode, #parent-domains, #marketplace, …).
 //
-// Parent Domains remains a sub-nav child for now — it's a substantial
-// admin surface (registrar tokens, DNS propagation panels, "+ Add
-// another parent domain" modal), not a single toggle, so the sub-page
-// model still fits.
-interface SubNavItem {
-  id: string
-  label: string
-  to: string
-}
-
-const SETTINGS_SUB_NAV: SubNavItem[] = [
-  // Parent Domains — admin "Add another parent domain" + DNS propagation
-  // status panel (issue #829). Lives under Settings so the sidebar
-  // surface stays compact for the typical Organization tenant who never sees
-  // this surface; operator-admins reach it via /console/parent-domains
-  // directly from the welcome email or by clicking through Settings.
-  { id: 'parent-domains', label: 'Parent Domains', to: '/parent-domains' },
-]
+// History:
+//   • Wave 5 (2026-05-17): Marketplace moved off the sub-nav INTO
+//     SettingsPage as `<SectionCard id="marketplace">`. Founder: *"if
+//     market place is just a toggle etting under setting it dosnt need
+//     tohave a sdicated page and it doesnt need to have child left pane
+//     menu item"*.
+//   • #4089 (2026-06-22): Parent Domains was the LAST sub-nav child —
+//     the only odd-one-out sub-left-pane item. Founder: *"currently the
+//     parent domains are showing under settings as a sub left-pane menu
+//     which is the only weird/odd-one-out … It needs to be granular as
+//     other settings such as …/settings#dns"*. Re-homed to
+//     `<SectionCard id="parent-domains">` in SettingsPage.tsx. The
+//     standalone surface lives on at /organizations/domains (the legacy
+//     /parent-domains route redirects there — router.tsx).
+//
+// With the sub-nav now empty, the Settings entry is a single flat link
+// like every other top-level nav item.
 
 // ── Active-state derivation ───────────────────────────────────────────────────
 
@@ -213,23 +208,13 @@ function deriveActiveSection(pathname: string): ActiveSection {
   // highlights for the directory, the internal door, and every moved
   // sub-surface (billing/orders/revenue/vouchers/domains). Issue #3378.
   if (/^\/organizations(\/|$)/.test(pathname)) return 'organizations'
-  // /settings/* OR /parent-domains → 'settings' so the Settings nav
-  // item highlights and the sub-nav (Marketplace + Parent Domains)
-  // expands. Per inviolable principle #4, the path list is pulled
-  // from SETTINGS_SUB_NAV rather than re-typed here.
+  // /settings/* → 'settings' so the Settings nav item highlights. There
+  // is no longer a settings sub-nav (#4089): Parent Domains — the last
+  // child — became the `#parent-domains` anchor section of /settings, so
+  // the legacy /parent-domains highlight is gone (it redirects to
+  // /organizations/domains, which lights up Organizations).
   if (/^\/settings(\/|$)/.test(pathname)) return 'settings'
-  if (SETTINGS_SUB_NAV.some((s) => pathname.startsWith(s.to))) return 'settings'
   return 'apps'
-}
-
-// deriveActiveSettingsSubItem returns the id of the active settings
-// sub-nav entry, or null when no sub-page is active. Drives the
-// expanded sub-list rendering under the Settings nav item.
-function deriveActiveSettingsSubItem(pathname: string): string | null {
-  for (const sub of SETTINGS_SUB_NAV) {
-    if (pathname.startsWith(sub.to)) return sub.id
-  }
-  return null
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────
@@ -237,8 +222,6 @@ function deriveActiveSettingsSubItem(pathname: string): string | null {
 export function SovereignSidebar({ sovereignFQDN }: SovereignSidebarProps) {
   const pathname = useRouterState({ select: (s) => s.location.pathname })
   const activeSection = deriveActiveSection(pathname)
-  const activeSettingsSub = deriveActiveSettingsSubItem(pathname)
-  const settingsExpanded = activeSection === 'settings'
 
   // Wave 5.69c (#2396) — dynamic sidebar entries from installed
   // Blueprints' spec.consoleUI.sidebarEntry (Wave 5.69 CRD + Wave
@@ -431,34 +414,9 @@ export function SovereignSidebar({ sovereignFQDN }: SovereignSidebarProps) {
           )
         })()}
 
-        {/* Settings sub-nav — visible only when the operator is inside
-            /console/settings/*. Keeps the sidebar compact by default and
-            mirrors the GitLab-style "category > sub-page" expansion. */}
-        {settingsExpanded ? (
-          <ul
-            className="mx-2 mt-0.5 flex flex-col gap-0.5"
-            data-testid="sov-console-settings-sub-nav"
-          >
-            {SETTINGS_SUB_NAV.map((sub) => {
-              const isActive = activeSettingsSub === sub.id
-              const cls = isActive
-                ? 'text-[var(--color-accent)]'
-                : 'text-[var(--color-text-dim)] hover:text-[var(--color-text)]'
-              return (
-                <li key={sub.id}>
-                  <Link
-                    to={sub.to as never}
-                    className={`block rounded-md py-1.5 pl-10 pr-3 text-xs no-underline transition-colors ${cls}`}
-                    data-testid={`sov-console-nav-settings-${sub.id}`}
-                    aria-current={isActive ? 'page' : undefined}
-                  >
-                    {sub.label}
-                  </Link>
-                </li>
-              )
-            })}
-          </ul>
-        ) : null}
+        {/* #4089: Settings has no sub-nav children — every settings
+            surface (including Parent Domains) is a granular anchor
+            section of the unified /settings page. */}
       </nav>
 
       {/* User card at the bottom */}


### PR DESCRIPTION
Refs #4089, Refs #825, Refs #3378, Refs #516

## Founder ask (verbatim)

> currently the parent domains are showing under settings as a sub left-pane menu which is the only weird/odd-one-out sub left-pane menu option. It needs to be granular as other settings such as https://console.omantel.biz/settings#dns. … I do not want any of them dropped silently.

## The re-home

The Sovereign operator console (`products/catalyst/bootstrap/ui/`) has a unified `/settings` page whose left rail is a TOC of in-page anchor sections — `#organization`, `#sovereign`, `#api-tokens`, `#cloud-credentials`, `#dns`, `#domain-mode`, `#marketplace`, `#notifications`, `#members`, `#danger-zone`, `#sovereignty`. Each is a `<SectionCard id="...">` reachable by `href="#id"`.

**Parent Domains was the odd one out**: the lone child in `SovereignSidebar.tsx`'s `SETTINGS_SUB_NAV`, rendering as an expandable sub-left-pane item → standalone `/parent-domains` route. Marketplace already got this exact treatment in Wave 5 (the code even commented Parent Domains "remains a sub-nav child for now"). This finishes the migration.

Now reachable at **`/settings#parent-domains`**, consistent with `#dns`.

## What changed (console settings UI only)

- **New `ParentDomainsSection.tsx`** — the inner Parent-Domains surface with no `PortalShell`/chrome, same idiom as `MarketplaceSection`. Carries over **every** capability verbatim: list pools, role badge, flip-status badge, inline NS-propagation drawer (`PropagationPanel`), "+ Add another domain" modal (name / role / registrar / token), remove flow, primary-row delete lock. Every `data-testid` preserved.
- **`SettingsPage.tsx`** — registered `{ id: 'parent-domains' }` in `SECTIONS` (drives the TOC + heading) and rendered `<SectionCard id="parent-domains"><ParentDomainsSection /></SectionCard>` right after Domain mode. Switched the per-card descriptions from fragile `SECTIONS[N]` index lookups to an id-based `desc()` helper so the mid-array insert can't drift the others.
- **`ParentDomainsPage.tsx`** — reduced to a thin `PortalShell` wrapper around `ParentDomainsSection`, so the standalone `/organizations/domains` route **and** the legacy `/parent-domains` redirect that lands there keep working byte-for-byte. No deep-link breaks.
- **`SovereignSidebar.tsx`** — dropped the now-empty `SETTINGS_SUB_NAV` + the whole sub-nav expansion machinery (`deriveActiveSettingsSubItem`, `settingsExpanded`, the sub-list render). Settings is now a single flat link like every other top-level nav entry.
- **`SettingsPage.test.tsx`** — added `parent-domains` (and the always-rendered `marketplace`) to `ALL_SECTIONS` so the section-catalogue + TOC tests cover the new anchor.

## Premise refinement (reported, not dropped)

The `ParentDomainsPage` component itself had already been re-mounted under Organizations at `/organizations/domains` (#3378); `/parent-domains` is a redirect to it. The leftover odd-one-out the founder is looking at was purely the **Settings sub-nav child**. Both standalone surfaces are kept intact; only the Settings sub-nav item is gone and replaced by the `#parent-domains` anchor section.

## Capabilities verified preserved

list pools · role + flip-status badges · inline propagation drawer · add-domain modal (name/role/registrar/token, password-masked token) · remove (with primary-row lock) · background refresh after add. All `data-testid`s unchanged → `ParentDomainsPage.test.tsx` assertions still apply to the same DOM.

## Gates

- `tsc -b --noEmit` → clean
- `vite build` → clean (`✓ built`)
- eslint: my files carry only the pre-existing repo-wide `set-state-in-effect` pattern (fires 33× on main; the original `ParentDomainsPage` had the identical effect) — no new error class.
- vitest: `SettingsPage.test` + `ParentDomainsPage.test` fail **identically on pristine HEAD** (`Cannot read properties of null (reading 'isServer')` from `@tanstack/react-router` 1.170.15 inside `useParams`/`useMatch` without a QueryClientProvider) — a pre-existing test-harness/version incompatibility on `main`, not a regression from this PR. Other router-based suites (e.g. `LoadBalancersPage.test`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)