### PR TITLE
feat(catalyst-api): auto-provision per-Org console TLS for every pool parent (Refs #4075)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/org_console_tls.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_console_tls.go
@@ -1,0 +1,435 @@
+// org_console_tls.go — #4075. Per-Organization console TLS auto-provisioning.
+//
+// A customer can pick ANY of the Sovereign's role=org-pool parent domains
+// (omani.homes / omani.rest / omani.trade / omani.works) as their free
+// subdomain. The Org's Catalyst console then lives at the 2-label host
+// `console.<slug>.<parent>` (deriveConsoleHost / org_enter_org.go) — that is
+// where the customer (and the Enter-Org support-impersonation handover) lands
+// to manage the Org and install Blueprints (bp-agenity, WordPress, …).
+//
+// THE GAP this file closes: that console host did NOT serve TLS on Org
+// creation, because none of the three resources it needs were ever
+// auto-provisioned:
+//
+//  1. A cert-manager Certificate covering `*.<slug>.<parent>` +
+//     `<slug>.<parent>`. The Sovereign's per-zone wildcard
+//     `*.<parent>` (sovereign-wildcard-certs.yaml) covers ONE label depth
+//     (`<slug>.<parent>`) but NOT the 2-label `console.<slug>.<parent>` —
+//     the documented remaining gap in sovereign-wildcard-certs.yaml:111-117.
+//     A wildcard requires DNS-01, so the issuer is the powerdns DNS-01
+//     ClusterIssuer (letsencrypt-dns01-prod-powerdns).
+//  2. A listener pair on the dedicated `cilium-gateway-console` Gateway
+//     (kube-system) for hostname `*.<slug>.<parent>`, binding the cert above.
+//     The console gateway is the poison-proof gateway that carries ONLY the
+//     stable catalyst-ui + catalyst-api backends (#4053), so per-Org consoles
+//     ride it rather than the volatile shared gateway.
+//  3. An HTTPRoute (catalyst-system) attaching `console.<slug>.<parent>` to
+//     the SAME catalyst-ui + catalyst-api backends the Sovereign's own
+//     `console.<fqdn>` route uses — a faithful clone of the canonical
+//     catalyst-ui HTTPRoute, just re-hostnamed.
+//
+// A peer agent verified this exact resource trio live for ONE Org (demo on
+// omani.homes) — Certificate `org-wildcard-tls-demo-omani-homes` (Ready),
+// listeners `console-https-demo`/`console-http-demo` on cilium-gateway-console,
+// and HTTPRoute `catalyst-ui-demo-omani-homes` → console.demo.omani.homes=200.
+// This file CODIFIES that live hand-fix as the deterministic provisioning
+// behaviour for EVERY Org on EVERY pool parent, durably.
+//
+// DURABILITY of the listener (the subtle part): `cilium-gateway-console`'s
+// base listener set is rendered statically by the chart into ConfigMap key
+// CONSOLE_LISTENERS_YAML and inlined by Flux postBuild — the kustomize-
+// controller owns the `console-https`/`console-http` apex pair via server-
+// side-apply. Gateway `spec.listeners` is a name-keyed list
+// (x-kubernetes-list-map-keys: [name]), so server-side-apply MERGES by
+// listener name and a manager only retains the keys it declares in its LATEST
+// apply, pruning keys it previously owned but no longer declares. We exploit
+// this with a PER-ORG field manager (catalyst-api-org-console-tls-<slug>): each
+// Org's apply declares ONLY that Org's two listeners, so it is independent and
+// additive — it never touches another Org's listeners (owned by a different
+// per-Org manager) nor the apex pair (owned by kustomize-controller). The
+// kustomize-controller's 5-min reconcile, which only declares the apex pair,
+// likewise leaves every per-Org listener untouched. This is why the listeners
+// are durable across Flux reconciles AND across many Orgs.
+//
+// NOTE — verified live on the omantel.biz Sovereign: a SHARED field manager is
+// WRONG here. With one manager, a second Org's apply (declaring only its own
+// listeners) pruned the first Org's listeners and 000'd its console. The
+// per-Org manager fixes that — each Org owns only its own keys.
+//
+// Wiring: a best-effort, non-gating finalisation step (provisionOrgConsoleTLS)
+// invoked at the STSTenantRegistered → STSDone transition right after
+// createOrgOrganizationCR, mirroring that helper's idiom exactly — resolve the
+// in-cluster dynamic client via sovereignDepsFor() (nil-tolerant for CI /
+// out-of-cluster), build unstructured objects, apply idempotently, and log
+// loud on failure without failing the Org pipeline (the substrate is already
+// valid; a transient apiserver failure is retried by the next reconcile /
+// HandleReconcileOrganization pass). BYO-domain Orgs are skipped — they carry
+// their own per-host Certificate (orgTenantCertificate IsBYO branch) and a
+// CNAME, not a pool-parent wildcard.
+
+package handler
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+// orgConsoleTLSFieldManagerPrefix builds the PER-ORG server-side-apply field
+// manager for that Org's console Gateway listeners — orgConsoleTLSFieldManager(slug)
+// returns "catalyst-api-org-console-tls-<slug>".
+//
+// CRITICAL: the field manager MUST be unique PER ORG, not a single shared
+// manager. SSA's name-keyed-list merge means a manager only retains the keys it
+// declares in its LATEST apply and PRUNES the keys it previously owned but no
+// longer declares. With a single shared manager, Org B's apply (which declares
+// only B's two listeners) would prune Org A's listeners — verified live on the
+// omantel.biz Sovereign: a second Org's apply under a shared manager dropped
+// the first Org's listeners and 000'd its console. A per-Org manager owns ONLY
+// that Org's two listeners, so each Org's apply is independent and additive;
+// SSA's per-key ownership keeps every Org's listeners (and the apex pair owned
+// by kustomize-controller) intact across reconciles.
+const orgConsoleTLSFieldManagerPrefix = "catalyst-api-org-console-tls-"
+
+func orgConsoleTLSFieldManager(slug string) string {
+	return orgConsoleTLSFieldManagerPrefix + slug
+}
+
+// orgConsoleTLSIssuer is the DNS-01 ClusterIssuer that issues the per-Org
+// wildcard. A wildcard SAN (`*.<slug>.<parent>`) can only be validated via
+// DNS-01, so this is the powerdns DNS-01 issuer shipped by
+// bp-cert-manager-powerdns-webhook — the same issuer
+// products/catalyst/chart/templates/sovereign-wildcard-certs.yaml uses for the
+// per-zone `*.<parent>` wildcards. Per Inviolable Principle #4 the name is the
+// canonical default and matches the chart's wildcardCert.issuerName default.
+const orgConsoleTLSIssuer = "letsencrypt-dns01-prod-powerdns"
+
+// console gateway + catalyst console backend placement. These match the
+// canonical Sovereign install: the dedicated console Gateway lives as
+// `cilium-gateway-console` in kube-system (#4053,
+// clusters/_template/sovereign-tls/cilium-gateway-console.yaml) and the
+// catalyst-ui + catalyst-api Services live in catalyst-system. The listeners
+// bind the console gateway's own host ports (31443 / 31080) — distinct from
+// the shared gateway's 30443 / 30080 so both coexist in hostNetwork mode.
+const (
+	consoleGatewayName       = "cilium-gateway-console"
+	consoleGatewayNamespace  = "kube-system"
+	consoleCertNamespace     = "kube-system"
+	catalystConsoleNamespace = "catalyst-system"
+	consoleListenerHTTPSPort = int64(31443)
+	consoleListenerHTTPPort  = int64(31080)
+	catalystUIServiceName    = "catalyst-ui"
+	catalystUIServicePort    = int64(80)
+	catalystAPIServiceName   = "catalyst-api"
+	catalystAPIServicePort   = int64(8080)
+)
+
+// consoleGatewayGVR — Gateway API v1 Gateway (for the per-Org listener SSA
+// patch). The Certificate + HTTPRoute reuse the package-level certificateGVR
+// (phase1_watch.go) + httpRouteGVR (sovereign.go) so the GVRs stay aligned
+// with the rest of the handler suite.
+var consoleGatewayGVR = schema.GroupVersionResource{
+	Group:    "gateway.networking.k8s.io",
+	Version:  "v1",
+	Resource: "gateways",
+}
+
+// orgConsoleTLSNames bundles the deterministic resource names + hosts for an
+// Org's console TLS trio. Centralised so the cert secretName, the listener
+// certificateRef, and the test all agree byte-for-byte.
+type orgConsoleTLSNames struct {
+	Slug         string // RFC-1123 org subdomain, lowercased
+	ParentDomain string // chosen org-pool parent (omani.homes/rest/trade/works)
+	WildcardHost string // *.<slug>.<parent>  — listener hostname + cert SAN
+	OrgZone      string //  <slug>.<parent>   — cert CN + SAN
+	ConsoleHost  string // console.<slug>.<parent> — HTTPRoute hostname
+	CertName     string // org-wildcard-tls-<slug>-<parent-dashed> (== secretName)
+	HTTPSName    string // console-https-<slug> — listener name
+	HTTPName     string // console-http-<slug>  — listener name
+	RouteName    string // catalyst-ui-<slug>-<parent-dashed>
+}
+
+// resolveOrgConsoleTLSNames computes the deterministic names/hosts from a
+// provision record. Returns (names, true) for a free-subdomain Org with a
+// valid slug + parent, or (zero, false) when the trio should NOT be
+// provisioned (BYO mode, blank slug/parent, or invalid slug).
+func resolveOrgConsoleTLSNames(rec store.OrganizationProvisionRecord) (orgConsoleTLSNames, bool) {
+	if rec.DomainMode == store.OrganizationDomainBYO {
+		// BYO Orgs bring their own host + per-host Certificate
+		// (orgTenantCertificate IsBYO branch) and a CNAME — no pool-parent
+		// wildcard listener applies.
+		return orgConsoleTLSNames{}, false
+	}
+	slug := strings.ToLower(strings.TrimSpace(rec.Subdomain))
+	if !orgSlugRE.MatchString(slug) {
+		return orgConsoleTLSNames{}, false
+	}
+	parent := strings.ToLower(strings.TrimSpace(rec.ParentDomain))
+	if parent == "" {
+		// Single-domain back-compat: the Org rides the Sovereign FQDN apex,
+		// whose own per-prov wildcard already covers console.<slug>.<fqdn>
+		// via the apex console-https listener. No per-Org resource needed.
+		return orgConsoleTLSNames{}, false
+	}
+	parentDashed := strings.ReplaceAll(parent, ".", "-")
+	return orgConsoleTLSNames{
+		Slug:         slug,
+		ParentDomain: parent,
+		WildcardHost: "*." + slug + "." + parent,
+		OrgZone:      slug + "." + parent,
+		ConsoleHost:  "console." + slug + "." + parent,
+		CertName:     "org-wildcard-tls-" + slug + "-" + parentDashed,
+		HTTPSName:    "console-https-" + slug,
+		HTTPName:     "console-http-" + slug,
+		RouteName:    "catalyst-ui-" + slug + "-" + parentDashed,
+	}, true
+}
+
+// provisionOrgConsoleTLS is the best-effort, non-gating finalisation step that
+// makes the Org's console host (`console.<slug>.<parent>`) serve TLS. Mirrors
+// createOrgOrganizationCR's idiom: resolve the in-cluster dynamic client via
+// sovereignDepsFor() (nil-tolerant for CI / out-of-cluster), apply the three
+// resources idempotently, and log loud on failure WITHOUT failing the Org
+// pipeline. Each sub-step is independent: a failure on one is logged and the
+// rest still run, and the org-controller / next HandleReconcileOrganization
+// pass retries the whole thing.
+func (h *Handler) provisionOrgConsoleTLS(ctx context.Context, rec store.OrganizationProvisionRecord) {
+	names, ok := resolveOrgConsoleTLSNames(rec)
+	if !ok {
+		h.log.Info("org-console-tls: skipped — not a free-subdomain pool-parent Org",
+			"org_tenant_id", rec.OrganizationID,
+			"subdomain", rec.Subdomain,
+			"domain_mode", rec.DomainMode,
+			"parent_domain", rec.ParentDomain,
+		)
+		return
+	}
+
+	deps, err := h.sovereignDepsFor()
+	if err != nil || deps == nil || deps.dyn == nil {
+		// Out-of-cluster / CI: the Org pipeline still completes; the console
+		// TLS trio is simply not applied (no apiserver to POST to). On a real
+		// Sovereign this branch never fires.
+		h.log.Info("org-console-tls: skipped — no in-cluster dynamic client",
+			"org_tenant_id", rec.OrganizationID, "err", err)
+		return
+	}
+
+	if err := ensureOrgConsoleCertificate(ctx, deps.dyn, names, rec); err != nil {
+		h.log.Error("org-console-tls: Certificate apply failed — reconcile will retry",
+			"cert", names.CertName, "host", names.WildcardHost, "err", err)
+	}
+	if err := ensureOrgConsoleListener(ctx, deps.dyn, names, rec); err != nil {
+		h.log.Error("org-console-tls: Gateway listener apply failed — reconcile will retry",
+			"gateway", consoleGatewayName, "https_listener", names.HTTPSName, "err", err)
+	}
+	if err := ensureOrgConsoleHTTPRoute(ctx, deps.dyn, names, rec); err != nil {
+		h.log.Error("org-console-tls: HTTPRoute apply failed — reconcile will retry",
+			"route", names.RouteName, "host", names.ConsoleHost, "err", err)
+	}
+	h.log.Info("org-console-tls: ensured per-Org console TLS trio",
+		"org_tenant_id", rec.OrganizationID,
+		"console_host", names.ConsoleHost,
+		"cert", names.CertName,
+		"https_listener", names.HTTPSName,
+		"route", names.RouteName,
+	)
+}
+
+// orgConsoleTLSLabels is the common label set stamped on all three resources
+// so an operator (and teardown) can find every per-Org console TLS object by
+// org-subdomain + pool-parent. Mirrors the labels the live demo Org carried.
+func orgConsoleTLSLabels(names orgConsoleTLSNames, rec store.OrganizationProvisionRecord, component string) map[string]any {
+	return map[string]any{
+		"catalyst.openova.io/component":     component,
+		"catalyst.openova.io/managed-by":    "catalyst-api",
+		"catalyst.openova.io/org-subdomain": names.Slug,
+		"catalyst.openova.io/pool-parent":   names.ParentDomain,
+		"catalyst.openova.io/sovereign":     strings.TrimSpace(rec.OTECHFQDN),
+		"app.kubernetes.io/managed-by":      "catalyst-api",
+	}
+}
+
+// ensureOrgConsoleCertificate Creates the per-Org wildcard Certificate
+// (idempotent — AlreadyExists = success). CN/SAN cover `*.<slug>.<parent>` +
+// `<slug>.<parent>` (the latter so the org-zone apex resolves too), issued via
+// the DNS-01 ClusterIssuer. secretName == the cert name so the listener's
+// certificateRef can reference it directly.
+func ensureOrgConsoleCertificate(ctx context.Context, dyn dynamic.Interface, names orgConsoleTLSNames, rec store.OrganizationProvisionRecord) error {
+	obj := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "cert-manager.io/v1",
+			"kind":       "Certificate",
+			"metadata": map[string]any{
+				"name":      names.CertName,
+				"namespace": consoleCertNamespace,
+				"labels":    orgConsoleTLSLabels(names, rec, consoleGatewayName),
+			},
+			"spec": map[string]any{
+				"secretName": names.CertName,
+				"commonName": names.OrgZone,
+				"dnsNames": []any{
+					names.WildcardHost,
+					names.OrgZone,
+				},
+				"issuerRef": map[string]any{
+					"name": orgConsoleTLSIssuer,
+					"kind": "ClusterIssuer",
+				},
+			},
+		},
+	}
+	if _, err := dyn.Resource(certificateGVR).Namespace(consoleCertNamespace).
+		Create(ctx, obj, metav1.CreateOptions{}); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return nil
+		}
+		return fmt.Errorf("create Certificate %s/%s: %w", consoleCertNamespace, names.CertName, err)
+	}
+	return nil
+}
+
+// ensureOrgConsoleListener server-side-applies the per-Org HTTPS + HTTP
+// listener pair onto cilium-gateway-console. SSA with our dedicated field
+// manager merges by listener name (the Gateway listeners list is keyed on
+// `name`), so the chart-driven kustomize-controller reconcile of the apex
+// pair never prunes these — durable across Flux reconciles (see file header).
+//
+// Force=true: SSA returns a conflict if another manager already owns a field
+// we declare (e.g. a prior live hand-fix attributed to kustomize-controller);
+// force claims ownership for our manager so the codified path heals the
+// hand-fix in place rather than erroring forever.
+func ensureOrgConsoleListener(ctx context.Context, dyn dynamic.Interface, names orgConsoleTLSNames, rec store.OrganizationProvisionRecord) error {
+	// Apply object carries ONLY the two per-Org listeners. SSA's name-keyed
+	// merge adds them to the existing listener set without touching the apex
+	// console-https/console-http pair owned by kustomize-controller.
+	apply := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "gateway.networking.k8s.io/v1",
+			"kind":       "Gateway",
+			"metadata": map[string]any{
+				"name":      consoleGatewayName,
+				"namespace": consoleGatewayNamespace,
+			},
+			"spec": map[string]any{
+				"listeners": []any{
+					map[string]any{
+						"name":     names.HTTPSName,
+						"port":     consoleListenerHTTPSPort,
+						"protocol": "HTTPS",
+						"hostname": names.WildcardHost,
+						"tls": map[string]any{
+							"mode": "Terminate",
+							"certificateRefs": []any{
+								map[string]any{"kind": "Secret", "name": names.CertName},
+							},
+						},
+						"allowedRoutes": map[string]any{
+							"namespaces": map[string]any{"from": "All"},
+						},
+					},
+					map[string]any{
+						"name":     names.HTTPName,
+						"port":     consoleListenerHTTPPort,
+						"protocol": "HTTP",
+						"hostname": names.WildcardHost,
+						"allowedRoutes": map[string]any{
+							"namespaces": map[string]any{"from": "All"},
+						},
+					},
+				},
+			},
+		},
+	}
+	data, err := apply.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf("marshal Gateway listener patch: %w", err)
+	}
+	force := true
+	if _, err := dyn.Resource(consoleGatewayGVR).Namespace(consoleGatewayNamespace).
+		Patch(ctx, consoleGatewayName, types.ApplyPatchType, data, metav1.PatchOptions{
+			FieldManager: orgConsoleTLSFieldManager(names.Slug),
+			Force:        &force,
+		}); err != nil {
+		return fmt.Errorf("apply Gateway listeners on %s/%s: %w", consoleGatewayNamespace, consoleGatewayName, err)
+	}
+	return nil
+}
+
+// ensureOrgConsoleHTTPRoute Creates the per-Org console HTTPRoute (idempotent
+// — AlreadyExists = success). A faithful clone of the canonical catalyst-ui
+// HTTPRoute (catalyst-api for /readyz, /healthz, /auth/handover, /api/,
+// /catalyst/; catalyst-ui for /), re-hostnamed to console.<slug>.<parent> and
+// parented on cilium-gateway-console. Lands in catalyst-system alongside the
+// catalyst-ui/catalyst-api Services it references (no ReferenceGrant needed).
+func ensureOrgConsoleHTTPRoute(ctx context.Context, dyn dynamic.Interface, names orgConsoleTLSNames, rec store.OrganizationProvisionRecord) error {
+	apiBackend := func() []any {
+		return []any{map[string]any{
+			"group": "", "kind": "Service",
+			"name": catalystAPIServiceName, "port": catalystAPIServicePort, "weight": int64(1),
+		}}
+	}
+	rule := func(backend []any, matches ...map[string]any) map[string]any {
+		ms := make([]any, 0, len(matches))
+		for _, m := range matches {
+			ms = append(ms, m)
+		}
+		return map[string]any{"backendRefs": backend, "matches": ms}
+	}
+	exact := func(p string) map[string]any {
+		return map[string]any{"path": map[string]any{"type": "Exact", "value": p}}
+	}
+	prefix := func(p string) map[string]any {
+		return map[string]any{"path": map[string]any{"type": "PathPrefix", "value": p}}
+	}
+
+	obj := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "gateway.networking.k8s.io/v1",
+			"kind":       "HTTPRoute",
+			"metadata": map[string]any{
+				"name":      names.RouteName,
+				"namespace": catalystConsoleNamespace,
+				"labels":    orgConsoleTLSLabels(names, rec, catalystUIServiceName),
+			},
+			"spec": map[string]any{
+				"parentRefs": []any{
+					map[string]any{
+						"group":     "gateway.networking.k8s.io",
+						"kind":      "Gateway",
+						"name":      consoleGatewayName,
+						"namespace": consoleGatewayNamespace,
+					},
+				},
+				"hostnames": []any{names.ConsoleHost},
+				"rules": []any{
+					rule(apiBackend(), exact("/readyz"), exact("/healthz")),
+					rule(apiBackend(), exact("/auth/handover")),
+					rule(apiBackend(), prefix("/api/")),
+					rule(apiBackend(), prefix("/catalyst/")),
+					rule([]any{map[string]any{
+						"group": "", "kind": "Service",
+						"name": catalystUIServiceName, "port": catalystUIServicePort, "weight": int64(1),
+					}}, prefix("/")),
+				},
+			},
+		},
+	}
+	if _, err := dyn.Resource(httpRouteGVR).Namespace(catalystConsoleNamespace).
+		Create(ctx, obj, metav1.CreateOptions{}); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return nil
+		}
+		return fmt.Errorf("create HTTPRoute %s/%s: %w", catalystConsoleNamespace, names.RouteName, err)
+	}
+	return nil
+}

--- a/products/catalyst/bootstrap/api/internal/handler/org_console_tls_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_console_tls_test.go
@@ -1,0 +1,271 @@
+// org_console_tls_test.go — #4075. Tests the per-Org console TLS trio:
+// deterministic name/host derivation (incl. the skip cases) and the
+// idempotent apply of the Certificate + Gateway listener + HTTPRoute against a
+// fake dynamic client, generalised across ALL four pool parents.
+
+package handler
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+// TestResolveOrgConsoleTLSNames_AllPoolParents proves the naming/host
+// derivation is generic across every role=org-pool parent (omani.homes/rest/
+// trade/works) — NOT hardcoded to omani.homes — and matches the live demo Org
+// shape byte-for-byte (Certificate org-wildcard-tls-demo-omani-homes etc.).
+func TestResolveOrgConsoleTLSNames_AllPoolParents(t *testing.T) {
+	parents := []string{"omani.homes", "omani.rest", "omani.trade", "omani.works"}
+	for _, parent := range parents {
+		parent := parent
+		t.Run(parent, func(t *testing.T) {
+			rec := store.OrganizationProvisionRecord{
+				OrganizationID: "t-acme",
+				Subdomain:      "acme",
+				DomainMode:     store.OrganizationDomainFreeSubdomain,
+				ParentDomain:   parent,
+				OTECHFQDN:      "omantel.biz",
+			}
+			n, ok := resolveOrgConsoleTLSNames(rec)
+			if !ok {
+				t.Fatalf("expected provisioning for pool parent %q", parent)
+			}
+			dashed := strings.ReplaceAll(parent, ".", "-")
+			wantCert := "org-wildcard-tls-acme-" + dashed
+			wantRoute := "catalyst-ui-acme-" + dashed
+			if n.CertName != wantCert {
+				t.Errorf("CertName = %q, want %q", n.CertName, wantCert)
+			}
+			if n.RouteName != wantRoute {
+				t.Errorf("RouteName = %q, want %q", n.RouteName, wantRoute)
+			}
+			if n.WildcardHost != "*.acme."+parent {
+				t.Errorf("WildcardHost = %q, want *.acme.%s", n.WildcardHost, parent)
+			}
+			if n.ConsoleHost != "console.acme."+parent {
+				t.Errorf("ConsoleHost = %q, want console.acme.%s", n.ConsoleHost, parent)
+			}
+			if n.OrgZone != "acme."+parent {
+				t.Errorf("OrgZone = %q, want acme.%s", n.OrgZone, parent)
+			}
+			if n.HTTPSName != "console-https-acme" || n.HTTPName != "console-http-acme" {
+				t.Errorf("listener names = %q/%q, want console-https-acme/console-http-acme", n.HTTPSName, n.HTTPName)
+			}
+		})
+	}
+}
+
+// TestResolveOrgConsoleTLSNames_SkipCases proves the trio is NOT provisioned
+// for BYO Orgs (own cert + CNAME), blank parent (single-domain back-compat —
+// apex wildcard already covers it), and invalid slugs.
+func TestResolveOrgConsoleTLSNames_SkipCases(t *testing.T) {
+	cases := []struct {
+		name string
+		rec  store.OrganizationProvisionRecord
+	}{
+		{"byo-mode", store.OrganizationProvisionRecord{
+			Subdomain: "acme", DomainMode: store.OrganizationDomainBYO,
+			BYODomain: "acme.example.com", ParentDomain: "omani.homes",
+		}},
+		{"blank-parent", store.OrganizationProvisionRecord{
+			Subdomain: "acme", DomainMode: store.OrganizationDomainFreeSubdomain,
+			ParentDomain: "", OTECHFQDN: "omantel.biz",
+		}},
+		{"invalid-slug-leading-digit", store.OrganizationProvisionRecord{
+			Subdomain: "1acme", DomainMode: store.OrganizationDomainFreeSubdomain,
+			ParentDomain: "omani.homes",
+		}},
+		{"invalid-slug-too-short", store.OrganizationProvisionRecord{
+			Subdomain: "ab", DomainMode: store.OrganizationDomainFreeSubdomain,
+			ParentDomain: "omani.homes",
+		}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if _, ok := resolveOrgConsoleTLSNames(tc.rec); ok {
+				t.Errorf("expected skip for %s, got provisioning", tc.name)
+			}
+		})
+	}
+}
+
+// fakeDynForConsoleTLS builds a fake dynamic client registering the three GVRs
+// the console-TLS trio writes (Certificate, Gateway, HTTPRoute), seeded with
+// the apex-only cilium-gateway-console Gateway (so the listener apply patches
+// an existing object, mirroring the live Sovereign).
+func fakeDynForConsoleTLS(t *testing.T) *dynamicfake.FakeDynamicClient {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	gvrToList := map[schema.GroupVersionResource]string{
+		certificateGVR:    "CertificateList",
+		consoleGatewayGVR: "GatewayList",
+		httpRouteGVR:      "HTTPRouteList",
+	}
+	gw := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "Gateway",
+		"metadata": map[string]any{
+			"name":      consoleGatewayName,
+			"namespace": consoleGatewayNamespace,
+		},
+		"spec": map[string]any{
+			"gatewayClassName": "cilium",
+			"listeners": []any{
+				map[string]any{"name": "console-https", "port": int64(31443), "protocol": "HTTPS", "hostname": "*.omantel.biz"},
+				map[string]any{"name": "console-http", "port": int64(31080), "protocol": "HTTP", "hostname": "*.omantel.biz"},
+			},
+		},
+	}}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToList, gw)
+}
+
+func newConsoleTLSHandler(t *testing.T, dyn *dynamicfake.FakeDynamicClient) *Handler {
+	t.Helper()
+	h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	h.SetSovereignDepsFactory(func() (*sovereignDeps, error) {
+		return &sovereignDeps{core: nil, dyn: dyn}, nil
+	})
+	return h
+}
+
+// TestProvisionOrgConsoleTLS_AppliesTrio is the binary DoD: a completed
+// free-subdomain Org on a pool parent gets a Certificate + Gateway listener
+// patch + console HTTPRoute applied to the live cluster.
+func TestProvisionOrgConsoleTLS_AppliesTrio(t *testing.T) {
+	dyn := fakeDynForConsoleTLS(t)
+	h := newConsoleTLSHandler(t, dyn)
+	rec := store.OrganizationProvisionRecord{
+		OrganizationID: "t-acme",
+		Subdomain:      "acme",
+		DomainMode:     store.OrganizationDomainFreeSubdomain,
+		ParentDomain:   "omani.rest",
+		OTECHFQDN:      "omantel.biz",
+		CompanyName:    "Acme Corp",
+		AdminEmail:     "admin@acme.test",
+	}
+	ctx := context.Background()
+	h.provisionOrgConsoleTLS(ctx, rec)
+
+	// 1) Certificate exists in kube-system with the wildcard SAN + DNS-01 issuer.
+	cert, err := dyn.Resource(certificateGVR).Namespace(consoleCertNamespace).
+		Get(ctx, "org-wildcard-tls-acme-omani-rest", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Certificate not created: %v", err)
+	}
+	spec, _, _ := unstructured.NestedMap(cert.Object, "spec")
+	if got, _, _ := unstructured.NestedString(cert.Object, "spec", "secretName"); got != "org-wildcard-tls-acme-omani-rest" {
+		t.Errorf("cert secretName = %q", got)
+	}
+	if got, _, _ := unstructured.NestedString(cert.Object, "spec", "issuerRef", "name"); got != orgConsoleTLSIssuer {
+		t.Errorf("cert issuer = %q, want %q", got, orgConsoleTLSIssuer)
+	}
+	dnsNames, _, _ := unstructured.NestedStringSlice(cert.Object, "spec", "dnsNames")
+	if !sliceContains(dnsNames, "*.acme.omani.rest") || !sliceContains(dnsNames, "acme.omani.rest") {
+		t.Errorf("cert dnsNames = %v, want *.acme.omani.rest + acme.omani.rest", dnsNames)
+	}
+	_ = spec
+
+	// 2) HTTPRoute exists in catalyst-system → cilium-gateway-console, hostname
+	//    console.acme.omani.rest, with the catalyst-ui + catalyst-api backends.
+	route, err := dyn.Resource(httpRouteGVR).Namespace(catalystConsoleNamespace).
+		Get(ctx, "catalyst-ui-acme-omani-rest", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("HTTPRoute not created: %v", err)
+	}
+	hosts, _, _ := unstructured.NestedStringSlice(route.Object, "spec", "hostnames")
+	if !sliceContains(hosts, "console.acme.omani.rest") {
+		t.Errorf("route hostnames = %v, want console.acme.omani.rest", hosts)
+	}
+	parents, _, _ := unstructured.NestedSlice(route.Object, "spec", "parentRefs")
+	if len(parents) != 1 {
+		t.Fatalf("route parentRefs = %d, want 1", len(parents))
+	}
+	pr, _ := parents[0].(map[string]any)
+	if pr["name"] != consoleGatewayName || pr["namespace"] != consoleGatewayNamespace {
+		t.Errorf("route parent = %v/%v, want %s/%s", pr["namespace"], pr["name"], consoleGatewayNamespace, consoleGatewayName)
+	}
+	rules, _, _ := unstructured.NestedSlice(route.Object, "spec", "rules")
+	if len(rules) != 5 {
+		t.Errorf("route rules = %d, want 5 (readyz/healthz, auth/handover, /api/, /catalyst/, /)", len(rules))
+	}
+
+	// 3) Gateway listener apply was invoked against cilium-gateway-console.
+	//    (The fake's SSA does not merge keyed lists like a real apiserver, so
+	//    we assert the apply ACTION was issued rather than re-deriving merge
+	//    semantics here; the live merge is verified on the Sovereign.)
+	sawGatewayApply := false
+	for _, a := range dyn.Actions() {
+		if a.GetResource() == consoleGatewayGVR && a.GetVerb() == "patch" {
+			if pa, ok := a.(interface{ GetName() string }); ok && pa.GetName() == consoleGatewayName {
+				sawGatewayApply = true
+			}
+		}
+	}
+	if !sawGatewayApply {
+		t.Errorf("expected a server-side-apply patch against Gateway %s; actions=%v", consoleGatewayName, dyn.Actions())
+	}
+}
+
+// TestProvisionOrgConsoleTLS_Idempotent proves a second pass does not error
+// (Create returns AlreadyExists which the helpers treat as success).
+func TestProvisionOrgConsoleTLS_Idempotent(t *testing.T) {
+	dyn := fakeDynForConsoleTLS(t)
+	h := newConsoleTLSHandler(t, dyn)
+	rec := store.OrganizationProvisionRecord{
+		OrganizationID: "t-acme",
+		Subdomain:      "acme",
+		DomainMode:     store.OrganizationDomainFreeSubdomain,
+		ParentDomain:   "omani.homes",
+		OTECHFQDN:      "omantel.biz",
+	}
+	ctx := context.Background()
+	h.provisionOrgConsoleTLS(ctx, rec)
+	h.provisionOrgConsoleTLS(ctx, rec) // second pass must not panic / error out
+
+	if _, err := dyn.Resource(certificateGVR).Namespace(consoleCertNamespace).
+		Get(ctx, "org-wildcard-tls-acme-omani-homes", metav1.GetOptions{}); err != nil {
+		t.Fatalf("Certificate missing after idempotent re-run: %v", err)
+	}
+}
+
+// TestProvisionOrgConsoleTLS_SkipsBYO proves a BYO Org applies NOTHING (no
+// dynamic-client calls beyond the skip log).
+func TestProvisionOrgConsoleTLS_SkipsBYO(t *testing.T) {
+	dyn := fakeDynForConsoleTLS(t)
+	h := newConsoleTLSHandler(t, dyn)
+	rec := store.OrganizationProvisionRecord{
+		OrganizationID: "t-acme",
+		Subdomain:      "acme",
+		DomainMode:     store.OrganizationDomainBYO,
+		BYODomain:      "acme.example.com",
+		OTECHFQDN:      "omantel.biz",
+	}
+	ctx := context.Background()
+	h.provisionOrgConsoleTLS(ctx, rec)
+
+	if _, err := dyn.Resource(certificateGVR).Namespace(consoleCertNamespace).
+		Get(ctx, "org-wildcard-tls-acme-example-com", metav1.GetOptions{}); err == nil {
+		t.Error("BYO Org should NOT have a pool-parent wildcard Certificate")
+	}
+}
+
+func sliceContains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
@@ -312,18 +312,18 @@ func resolveOrgShape(req orgTenantCreateRequest) orgShape {
 }
 
 type orgTenantResponse struct {
-	OrganizationID     string                        `json:"org_tenant_id"`
+	OrganizationID  string                           `json:"org_tenant_id"`
 	State           store.OrganizationProvisionState `json:"state"`
-	Subdomain       string                        `json:"subdomain"`
-	DomainMode      store.OrganizationDomainMode           `json:"domain_mode"`
-	BYODomain       string                        `json:"byo_domain,omitempty"`
-	ParentDomain    string                        `json:"parent_domain,omitempty"`
-	AdminEmail      string                        `json:"admin_email"`
-	CompanyName     string                        `json:"company_name,omitempty"`
-	OTECHFQDN       string                        `json:"otech_fqdn"`
-	VClusterName    string                        `json:"vcluster_name"`
-	TenantNamespace string                        `json:"tenant_namespace"`
-	ConsoleHost     string                        `json:"console_host"`
+	Subdomain       string                           `json:"subdomain"`
+	DomainMode      store.OrganizationDomainMode     `json:"domain_mode"`
+	BYODomain       string                           `json:"byo_domain,omitempty"`
+	ParentDomain    string                           `json:"parent_domain,omitempty"`
+	AdminEmail      string                           `json:"admin_email"`
+	CompanyName     string                           `json:"company_name,omitempty"`
+	OTECHFQDN       string                           `json:"otech_fqdn"`
+	VClusterName    string                           `json:"vcluster_name"`
+	TenantNamespace string                           `json:"tenant_namespace"`
+	ConsoleHost     string                           `json:"console_host"`
 	// Organizations model (issue #3378 B1) — surfaced so the directory
 	// can badge the org by kind/tier/billingMode/isolation.
 	Kind        string         `json:"kind,omitempty"`
@@ -427,7 +427,7 @@ func stepsForState(state store.OrganizationProvisionState, lastError string) org
 
 func orgTenantRecordToResponse(rec store.OrganizationProvisionRecord) orgTenantResponse {
 	return orgTenantResponse{
-		OrganizationID:     rec.OrganizationID,
+		OrganizationID:  rec.OrganizationID,
 		State:           rec.State,
 		Subdomain:       rec.Subdomain,
 		DomainMode:      rec.DomainMode,
@@ -630,7 +630,7 @@ func (h *Handler) HandleCreateOrganization(w http.ResponseWriter, r *http.Reques
 
 	orgTenantID := uuid.New().String()
 	rec := store.OrganizationProvisionRecord{
-		OrganizationID:     orgTenantID,
+		OrganizationID:  orgTenantID,
 		State:           store.STSPending,
 		Subdomain:       subdomain,
 		DomainMode:      store.OrganizationDomainMode(mode),
@@ -970,14 +970,14 @@ func (h *Handler) runOrganizationPipeline(ctx context.Context, rec store.Organiz
 			realmURL := fmt.Sprintf("https://keycloak.%s.%s/realms/%s",
 				rec.Subdomain, realmZone, "org-"+rec.Subdomain)
 			reg := store.TenantRegistration{
-				Host:                 host,
-				TenantID:             rec.OrganizationID,
-				TenantKind:           store.TenantKindOrg,
-				KeycloakRealmURL:     realmURL,
-				KeycloakClientID:     "catalyst-ui",
-				OrganizationNamespace:   rec.TenantNamespace,
-				OrgKeycloakAdminURL:  fmt.Sprintf("http://keycloak-%s.%s.svc:8080", rec.Subdomain, rec.TenantNamespace),
-				OrgKeycloakRealmName: "org-" + rec.Subdomain,
+				Host:                  host,
+				TenantID:              rec.OrganizationID,
+				TenantKind:            store.TenantKindOrg,
+				KeycloakRealmURL:      realmURL,
+				KeycloakClientID:      "catalyst-ui",
+				OrganizationNamespace: rec.TenantNamespace,
+				OrgKeycloakAdminURL:   fmt.Sprintf("http://keycloak-%s.%s.svc:8080", rec.Subdomain, rec.TenantNamespace),
+				OrgKeycloakRealmName:  "org-" + rec.Subdomain,
 			}
 			if err := deps.TenantRegistry.Put(reg); err != nil {
 				return failTransient(rec, "registry", err)
@@ -1001,6 +1001,18 @@ func (h *Handler) runOrganizationPipeline(ctx context.Context, rec store.Organiz
 		// provision (the substrate is already valid), and the org-controller's
 		// level-triggered reconcile + a pipeline re-run land the CR on retry.
 		h.createOrgOrganizationCR(ctx, rec)
+
+		// #4075 — make the Org's console host (console.<slug>.<parent>) serve
+		// TLS. A free-subdomain Org on a role=org-pool parent (omani.homes/
+		// rest/trade/works) needs three resources the substrate above never
+		// provisioned: a wildcard Certificate for *.<slug>.<parent>, a
+		// listener pair on cilium-gateway-console binding it, and the console
+		// HTTPRoute → catalyst-ui/catalyst-api. Best-effort + idempotent +
+		// non-gating (mirrors createOrgOrganizationCR): a transient apiserver
+		// failure logs loud but does NOT fail the provision (the substrate is
+		// valid), and a later reconcile / HandleReconcileOrganization pass
+		// re-applies the trio. BYO Orgs are skipped (own cert + CNAME).
+		h.provisionOrgConsoleTLS(ctx, rec)
 
 		rec.State = store.STSDone
 		rec.LastError = ""


### PR DESCRIPTION
## What

Makes every customer Organization's Catalyst console (`console.<slug>.<parent>`) serve TLS **automatically on Org creation**, for **all four** role=org-pool parent domains (`omani.homes` / `omani.rest` / `omani.trade` / `omani.works`) — not just the one a peer agent hand-fixed live.

Closes ask #3 of #4075 ("Confirm the per-Org wildcard cert is issued so the Org console serves TLS") and the durable generalisation the founder directed.

## The gap

A free-subdomain Org on a pool parent lands its console at the **2-label** host `console.<slug>.<parent>`. None of the three resources that host needs were ever auto-provisioned:
1. a cert-manager **Certificate** for `*.<slug>.<parent>` — the Sovereign's per-zone `*.<parent>` wildcard only covers **one** label depth (`<slug>.<parent>`), NOT the 2-label console host (documented gap in `sovereign-wildcard-certs.yaml:111-117`);
2. a **listener** on the dedicated `cilium-gateway-console` Gateway binding it;
3. an **HTTPRoute** routing the host to catalyst-ui/catalyst-api.

## The fix

New `provisionOrgConsoleTLS` finalisation step at the `STSTenantRegistered → STSDone` pipeline transition, right after `createOrgOrganizationCR` and mirroring its idiom exactly (best-effort, idempotent, non-gating, nil-tolerant dynamic client via `sovereignDepsFor`). It applies the trio via the in-cluster dynamic client:

| Resource | Name | Namespace | Notes |
|---|---|---|---|
| Certificate | `org-wildcard-tls-<slug>-<parent-dashed>` | kube-system | `*.<slug>.<parent>` + `<slug>.<parent>`, issuer `letsencrypt-dns01-prod-powerdns` (wildcard SAN ⇒ DNS-01) |
| Gateway listeners | `console-https-<slug>` / `console-http-<slug>` | kube-system (`cilium-gateway-console`) | server-side-apply under a **per-Org** field manager |
| HTTPRoute | `catalyst-ui-<slug>-<parent-dashed>` | catalyst-system | clone of the canonical catalyst-ui route, re-hostnamed |

### Why a per-Org field manager (the load-bearing detail)

Gateway `spec.listeners` is a name-keyed list. SSA retains only the keys a manager declares in its latest apply and prunes keys it previously owned but no longer declares. A **shared** manager would therefore make Org B's apply prune Org A's listeners. **Verified live**: a shared-manager apply for a second Org dropped the first Org's listeners and 000'd its console. A per-Org manager (`catalyst-api-org-console-tls-<slug>`) owns only that Org's two keys, so every Org's apply is independent + additive, and the chart-owned apex pair (owned by kustomize-controller) is never touched — durable across Flux reconciles AND across many Orgs.

## Generic / skip behaviour

- Works for all four pool parents (no `omani.homes` hardcode — derived from `rec.ParentDomain`).
- BYO Orgs skipped (own per-host cert + CNAME).
- Single-domain back-compat skipped (apex wildcard already covers `console.<slug>.<fqdn>`).

## Live proof (omantel.biz Sovereign, dep `4635277cae4ffed9`)

Applied the exact codified trio for a throwaway Org `prooftls` on `omani.homes`:
- Certificate issued real **LE** cert — served cert `CN=prooftls.omani.homes`, issuer `Let's Encrypt`.
- `console.prooftls.omani.homes` → **HTTP 200** (via console-ELB 212.72.24.33).
- **Zero regression**: `console.demo.omani.homes`, `console.omantel.biz`, `marketplace.omantel.biz` all stayed **200** throughout; per-Org-manager coexistence confirmed (apex + demo + prooftls listeners side-by-side).
- Throwaway resources cleaned up afterwards.

## Tests

`org_console_tls_test.go`: name/host derivation across all 4 pool parents, skip cases (BYO / blank-parent / invalid-slug), apply-trio against a fake dynamic client, idempotency, BYO-skip. Full handler suite green.

Refs #4075 · area/catalyst

🤖 Generated with [Claude Code](https://claude.com/claude-code)