### PR TITLE
fix(bp-catalyst-platform): pin catalyst-api to its EVS volume node for same-node Recreate reattach (zero ~10-min 503)

### DIFF
--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2974,7 +2974,7 @@ name: bp-catalyst-platform
 #   handover (CATALYST_FIRE_CUTOVER_ON_HANDOVER now defaults false via
 #   catalystApi.fireCutoverOnHandover). Cutover is a DELIBERATE BSS-menu action; the
 #   operator-initiated path is unchanged (NO-REGRESS).
-version: 1.4.775
+version: 1.4.776
 # 1.4.774 — #4082: application-controller ClusterRole gains dr.openova.io/continuums
 #   (get/list/watch/create/update/patch/delete) — was in the controller's own
 #   deploy/rbac.yaml but MISSING from this platform chart, so a singleton /

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -142,6 +142,34 @@ spec:
       # system:default and every cutover-status read returns 502
       # "configmaps is forbidden" (caught live on otech102, 2026-05-04).
       serviceAccountName: catalyst-api-cutover-driver
+      # ── Zero-downtime roll: pin to the EVS volume's node (#4100) ──────────
+      # catalyst-api mounts two RWO Huawei-EVS PVCs (catalyst-api-deployments,
+      # catalyst-api-cache). The EVS PV nodeAffinity is ZONE-scoped
+      # (topology.evs.csi.huaweicloud.com/zone), NOT node-scoped — every worker
+      # in the zone satisfies it. With strategy: Recreate and no scheduling
+      # constraint, a roll can place the new Pod on a DIFFERENT node than the one
+      # holding the live EVS attachment. Huawei EVS then has to detach the volume
+      # from the old node and reattach it across nodes — a ~10-min stall during
+      # which console/api 503 (live-confirmed on omantel.biz dep
+      # 4635277cae4ffed9, 2026-06-22). Same-node reattach is seconds.
+      #
+      # catalystApi.nodeName (default empty) pins the Deployment to the node
+      # currently holding the volumes so the replacement Pod reattaches
+      # same-node. Empty on fresh installs — WaitForFirstConsumer binds the RWO
+      # PVs to the first consumer's node at install time, so the very first Pod
+      # has nothing to collide with; the operator sets nodeName on the
+      # per-Sovereign HelmRelease overlay (or it is patched live) to the bound
+      # node ONCE, after which every future roll is same-node and fast.
+      # catalystApi.affinity is an additional passthrough for operators who
+      # prefer a soft/zone nodeAffinity over a hard nodeName pin. Both default
+      # empty so fresh installs keep today's behaviour (no regression).
+      {{- with .Values.catalystApi.nodeName }}
+      nodeName: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.catalystApi.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       imagePullSecrets:
         - name: ghcr-pull
       # fsGroup applies to the volumes mounted into the Pod so the

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -1104,6 +1104,26 @@ provisioningState:
 # operator-overridable from the per-Sovereign overlay without rebuilding
 # the chart.
 catalystApi:
+  # ── Zero-downtime roll: pin to the EVS volume's node (#4100) ──────────
+  # catalyst-api mounts two RWO Huawei-EVS PVCs whose PV nodeAffinity is
+  # ZONE-scoped (not node-scoped). With strategy: Recreate, a roll can land the
+  # replacement Pod on a different node than the one holding the live EVS
+  # attachment → a ~10-min cross-node detach/reattach → console/api 503
+  # (live-confirmed on omantel.biz, 2026-06-22). Setting nodeName to the node
+  # currently bound to the volumes forces same-node reattach (seconds).
+  #
+  # Default EMPTY = no scheduling constraint (today's behaviour) so fresh
+  # installs are unaffected — WaitForFirstConsumer binds the RWO PVs to the
+  # first consumer's node and there is no second Pod to collide with on the
+  # very first install. The operator/automation sets this ONCE (per-Sovereign
+  # HelmRelease overlay or live patch) to the node returned by:
+  #   kubectl -n catalyst-system get pod -l app.kubernetes.io/name=catalyst-api \
+  #     -o jsonpath='{.items[0].spec.nodeName}'
+  # after which every future roll is same-node and fast.
+  nodeName: ""
+  # affinity — optional passthrough for operators who prefer a soft/zone
+  # nodeAffinity over a hard nodeName pin above. Default empty (no affinity).
+  affinity: {}
   # OpenBao address for the bare-URL SSO shim (#3374). Rendered into
   # CATALYST_OPENBAO_ADDR on Sovereign installs only (gated on
   # global.sovereignFQDN in api-deployment.yaml). Empty = the canonical


### PR DESCRIPTION
## Problem
catalyst-api mounts two RWO Huawei-EVS PVCs (`catalyst-api-deployments`, `catalyst-api-cache`). The EVS PV `nodeAffinity` is **zone-scoped** (`topology.evs.csi.huaweicloud.com/zone`), not node-scoped — every worker in the zone satisfies it. The Deployment is single-replica with `strategy: Recreate` and had **no scheduling constraint**, so a roll could place the new Pod on a DIFFERENT node than the one holding the live EVS attachment. Huawei EVS then detaches the volume from the old node and reattaches it across nodes — a ~10-min stall during which `console.omantel.biz`/`api.omantel.biz` 503. Live-confirmed on omantel.biz dep `4635277cae4ffed9` (2026-06-22).

## Fix
Add a `catalystApi.nodeName` pin (+ `catalystApi.affinity` passthrough) to the catalyst-api Deployment so the replacement Pod schedules onto the node already holding its EVS volumes → same-node reattach is seconds.

- **Default empty** = today's behaviour, so **fresh installs are unaffected** (WaitForFirstConsumer binds the RWO PVs to the first consumer's node; there is no second Pod to collide with on first install).
- Operator sets `nodeName` once (per-Sovereign HelmRelease overlay or live patch) to the bound node; every future roll is then same-node and fast.

## Validation
`helm template` confirmed:
- default render emits NO `nodeName`/`affinity` key (only comments)
- `--set catalystApi.nodeName=X` emits `nodeName: "X"` before `imagePullSecrets`

Chart bumped 1.4.775 → 1.4.776.

Refs #4100

🤖 Generated with [Claude Code](https://claude.com/claude-code)