### PR TITLE
fix(org-provisioning): keycloak realmConfig.tenant.subdomain + openova.io/organization org-ns label (demo Org backing-stack wedge)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
@@ -712,6 +712,21 @@ metadata:
     catalyst.openova.io/org-tenant: {{.TenantID}}
     catalyst.openova.io/org-subdomain: {{.Subdomain}}
     catalyst.openova.io/managed-by: catalyst-api
+    # openova.io/organization — the canonical per-Org join key
+    # (ARCHITECTURE.md §org-attribution). The CRD org-controller stamps it
+    # via core/controllers/organization/internal/gitops/manifests.go; the
+    # bootstrap-api org-tenant pipeline MUST stamp the same label so the
+    # two provisioning paths produce identical namespace shape. CRITICAL:
+    # the harbor-proxy-pull / customer-vCluster Kyverno exemptions
+    # (platform/kyverno-policies/.../11-harbor-proxy.yaml, #3859) key off an
+    # openova.io/organization namespaceSelector — without this label the
+    # per-Org vCluster's syncer init images are DENIED (they pull upstream
+    # k8s images, not Harbor-proxy globs) and vc-<slug> never installs,
+    # wedging the whole Org backing stack. Refs #4099 #3859.
+    openova.io/organization: {{.Subdomain}}
+    openova.io/sovereign: {{.OTECHFQDN}}
+    openova.io/managed-by: catalyst
+    openova.io/tier: org
   annotations:
     catalyst.openova.io/admin-email: {{.AdminEmail}}
     catalyst.openova.io/company-name: {{.CompanyName}}
@@ -875,6 +890,17 @@ spec:
     realmConfig:
       tenant:
         enabled: true
+        # subdomain — the Org slug. bp-keycloak >= 1.5.0's
+        # configmap-tenant-realm.yaml HARD-REQUIRES this when
+        # tenant.enabled=true ("realmConfig.tenant.enabled=true requires
+        # realmConfig.tenant.subdomain — Inviolable Principle #4"). Earlier
+        # orchestrator versions omitted it because the realmConfig.tenant.*
+        # block was a forward-looking marker the chart silently ignored;
+        # once the chart's tenant-mode realm template landed, a missing
+        # subdomain wedged the per-Org Keycloak install and cascaded to
+        # every dependent HR (bp-newapi/openclaw/stalwart/wordpress-tenant).
+        # Refs #4099.
+        subdomain: {{.Subdomain}}
         realmName: org-{{.Subdomain}}
         displayName: {{.CompanyName}}
         adminEmail: {{.AdminEmail}}

--- a/products/catalyst/bootstrap/api/internal/handler/organization_keycloak_values_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_keycloak_values_test.go
@@ -198,6 +198,43 @@ func TestBPKeycloakValuesContract(t *testing.T) {
 	if got, _ := tenant["realmName"].(string); got != "org-acme" {
 		t.Errorf("realmConfig.tenant.realmName: want org-acme got %q", got)
 	}
+	// realmConfig.tenant.subdomain — REQUIRED by bp-keycloak >= 1.5.0's
+	// configmap-tenant-realm.yaml when tenant.enabled=true. A missing
+	// subdomain wedged the per-Org Keycloak install on the live demo Org
+	// ("realmConfig.tenant.enabled=true requires realmConfig.tenant.subdomain
+	// — Inviolable Principle #4") and cascaded to every dependent HR.
+	// Refs #4099.
+	if got, _ := tenant["subdomain"].(string); got != "acme" {
+		t.Errorf("realmConfig.tenant.subdomain: want acme (the Org slug) got %q", got)
+	}
+}
+
+// TestOrgTenantNamespaceCarriesOrganizationLabel — Refs #4099 / #3859.
+//
+// The harbor-proxy-pull (and other) Kyverno ClusterPolicies exempt
+// customer-Org namespaces via a `openova.io/organization` Exists
+// namespaceSelector. The CRD org-controller stamps that label; the
+// bootstrap-api org-tenant pipeline MUST too, otherwise the per-Org
+// vCluster's syncer init images (upstream k8s images, not Harbor-proxy
+// globs) are DENIED at admission and vc-<slug> never installs — wedging
+// the entire Org backing stack.
+func TestOrgTenantNamespaceCarriesOrganizationLabel(t *testing.T) {
+	files := mustRenderTenantOverlay(t)
+	body, ok := files["namespace.yaml"]
+	if !ok {
+		t.Fatalf("namespace.yaml missing from render output; have: %v", keysOf(files))
+	}
+	var ns struct {
+		Metadata struct {
+			Labels map[string]string `json:"labels"`
+		} `json:"metadata"`
+	}
+	if err := yaml.Unmarshal([]byte(body), &ns); err != nil {
+		t.Fatalf("namespace.yaml does not parse: %v\n--- body ---\n%s", err, body)
+	}
+	if got := ns.Metadata.Labels["openova.io/organization"]; got != "acme" {
+		t.Errorf("namespace label openova.io/organization: want acme (the Org slug) got %q — Kyverno harbor-proxy-pull exemption keys off this", got)
+	}
 }
 
 // TestBPKeycloakValuesContract_NoLegacyKeys — guards against


### PR DESCRIPTION
## What

Durable fix for two org-provisioning defects that wedge a fresh customer Org's backing stack, surfaced LIVE on the permanent omantel.biz Sovereign (demo Org `org-7283eb4a-19e5-4e86-9066-d4aa26762064`, `console.demo.omani.homes`).

Both live in the bootstrap-api org-tenant gitops writer `products/catalyst/bootstrap/api/internal/handler/organization_gitops.go` (the `org-tenants` Flux Kustomization path).

### Defect 1 — bp-keycloak HR missing `realmConfig.tenant.subdomain`
```
Helm install failed for release .../bp-keycloak with chart bp-keycloak@1.5.0:
execution error at (bp-keycloak/templates/configmap-tenant-realm.yaml:78:6):
realmConfig.tenant.enabled=true requires realmConfig.tenant.subdomain — Inviolable Principle #4 (never hardcode)
```
The `orgTenantBPKeycloak` template set `realmConfig.tenant.{enabled,realmName,displayName,adminEmail,groups,clients,parentDomain}` but not `subdomain`. The template comment still treated `realmConfig.tenant.*` as a forward-looking marker the chart ignored; bp-keycloak >= 1.5.0 now consumes it and hard-requires `subdomain`. Missing it failed the keycloak install → cascaded to bp-newapi / bp-openclaw / bp-stalwart-tenant / bp-wordpress-tenant ('dependency bp-keycloak not ready'). Now sets `subdomain: {{.Subdomain}}` (the Org slug).

### Defect 2 — org namespace missing `openova.io/organization` label → vc-`<slug>` Kyverno-denied
```
admission webhook validate.kyverno.svc-fail denied the request:
StatefulSet/.../vc-demo blocked by policy harbor-proxy-pull
  (image-from-harbor-proxy-workload, /spec/template/spec/initContainers/0/image/)
```
The `harbor-proxy-pull` ClusterPolicy (`platform/kyverno-policies/.../11-harbor-proxy.yaml`, #3859) is **designed** to exempt customer-Org namespaces via a `openova.io/organization` Exists namespaceSelector — its own comment: *'exempt by the openova.io/organization label the org-controller stamps on every per-Org vCluster namespace'*. The CRD org-controller (`core/controllers/organization/internal/gitops/manifests.go`) stamps it; the bootstrap-api gitops writer did NOT. So the demo org ns (labels only `catalyst.openova.io/org-tenant`/`org-subdomain`) was not exempt and the vCluster's syncer init images (upstream k8s images, not Harbor-proxy globs) were denied → `vc-<slug>` never installed → whole Org backing stack wedged. Now stamps `openova.io/organization` (+ `openova.io/sovereign`/`managed-by`/`tier`) on the org ns, matching the controller's `namespaceTemplate`.

## Tests
`products/catalyst/bootstrap/api/internal/handler/organization_keycloak_values_test.go`:
- `TestBPKeycloakValuesContract` now asserts `realmConfig.tenant.subdomain == <slug>`.
- New `TestOrgTenantNamespaceCarriesOrganizationLabel` asserts the namespace carries `openova.io/organization == <slug>`.

All handler tests pass (`go test ./internal/handler/ -run 'TestBPKeycloak|TestOrgTenantNamespace|TestBPCNPG'`), build + vet clean.

## Live status
The live demo Org HRs were patched directly (subdomain + ns label) with the `org-tenants` Kustomization suspended (demo-Org-only scope) so Flux stops reverting — live patches are throwaway; this PR is the durable source so re-provisioned/fresh Orgs don't re-hit it. NOTE: the live org-tenants overlay is regenerated by catalyst-api on (re-)provision, so the live env fully converges on the fixed shape once catalyst-api ships this code.

Refs #4099 #3859 #910

🤖 Generated with [Claude Code](https://claude.com/claude-code)