### PR TITLE
fix(catalyst-api): pool-domain Org login — request-host session cookie + Enter-org handover accepts local signer key (Refs #4101)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/auth.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth.go
@@ -233,6 +233,116 @@ func (h *Handler) openovaKCClient() keycloakClient {
 	return keycloak.New(addr, realm, clientID, secret)
 }
 
+// requestHost returns the originating host of a request, preferring the
+// X-Forwarded-Host header set by the upstream proxy (Envoy / Cilium
+// Gateway) over r.Host, with any :port suffix stripped. The Sovereign
+// catalyst-api sits behind a gateway, so r.Host can be the in-cluster
+// Service authority; X-Forwarded-Host carries the real browser host
+// (console.demo.omani.homes) the cookie must be scoped to.
+func requestHost(r *http.Request) string {
+	host := strings.TrimSpace(r.Header.Get("X-Forwarded-Host"))
+	if host == "" {
+		host = strings.TrimSpace(r.Host)
+	}
+	// X-Forwarded-Host may carry a comma-separated proxy chain; take the
+	// first (client-facing) entry.
+	if i := strings.IndexByte(host, ','); i >= 0 {
+		host = strings.TrimSpace(host[:i])
+	}
+	if i := strings.IndexByte(host, ':'); i >= 0 {
+		host = host[:i]
+	}
+	return strings.ToLower(host)
+}
+
+// sessionCookieDomain derives the Domain attribute for the catalyst_session
+// cookie from the REQUEST HOST (#4101, 2026-06-22).
+//
+// Resolution order:
+//  1. CATALYST_SESSION_COOKIE_DOMAIN env — explicit operator override
+//     (used on Catalyst-Zero / contabo, e.g. "console.openova.io"). Wins
+//     unconditionally so existing deployments are unaffected.
+//  2. Request host under the Sovereign FQDN (console.<fqdn>, api.<fqdn>,
+//     the bare <fqdn>, or any *.<fqdn>): scope to ".<SOVEREIGN_FQDN>" so
+//     the cookie covers console./api./marketplace. of the Sovereign's own
+//     front door (the G113-followup hw86 behaviour — preserved).
+//  3. Pool-domain Org host (console.<org>.<pool-zone> on a Sovereign whose
+//     FQDN is a DIFFERENT registrable domain — e.g. console.demo.omani.homes
+//     on an omantel.biz Sovereign): strip the leading service label
+//     (console./api./marketplace.) and scope to ".<org>.<pool-zone>"
+//     (".demo.omani.homes"). This covers the Org's console + api +
+//     marketplace hosts WITHOUT bleeding the session to sibling Orgs on the
+//     same pool zone (a ".omani.homes" wide cookie would let demo's session
+//     reach acme.omani.homes — a cross-Org leak we deliberately avoid).
+//  4. No SOVEREIGN_FQDN and an unrecognised host (CI, local dev): empty
+//     Domain → host-only cookie (unchanged legacy fallback).
+//
+// The empty-Domain return is also used when the host can't be sensibly
+// scoped (a bare hostname with no dot), keeping the cookie host-only rather
+// than emitting an invalid Domain attribute the browser would reject.
+func sessionCookieDomain(r *http.Request) string {
+	if v := strings.TrimSpace(os.Getenv("CATALYST_SESSION_COOKIE_DOMAIN")); v != "" {
+		return v
+	}
+	host := requestHost(r)
+	sovFQDN := strings.ToLower(strings.TrimSpace(os.Getenv("SOVEREIGN_FQDN")))
+
+	// Request host belongs to the Sovereign's own zone → .<SOVEREIGN_FQDN>.
+	if sovFQDN != "" {
+		if host == sovFQDN || strings.HasSuffix(host, "."+sovFQDN) {
+			return "." + sovFQDN
+		}
+	}
+
+	// Pool-domain Org host (or any host outside the Sovereign zone): scope
+	// to the per-Org suffix = host minus its leading service label. For
+	// "console.demo.omani.homes" that yields ".demo.omani.homes".
+	if suffix := orgCookieSuffix(host); suffix != "" {
+		return "." + suffix
+	}
+
+	// Last-resort fallback: preserve the legacy .<SOVEREIGN_FQDN> when we
+	// have one (e.g. an odd host shape on the Sovereign) so we never widen
+	// behaviour for the Sovereign's own console.
+	if sovFQDN != "" {
+		return "." + sovFQDN
+	}
+	return ""
+}
+
+// orgCookieSuffix strips a single leading service label (console / api /
+// marketplace / auth) from a per-Org host and returns the remaining
+// suffix, which is the correct cookie Domain seed for that Org's family of
+// subdomains. Returns "" when the host has no recognisable service label
+// or is too short to scope safely (≤2 labels → would over-widen to the
+// registrable domain).
+//
+// Examples:
+//
+//	console.demo.omani.homes   → demo.omani.homes
+//	api.demo.omani.homes       → demo.omani.homes
+//	marketplace.acme.omani.rest→ acme.omani.rest
+//	demo.omani.homes           → "" (no service label; don't over-scope)
+//	omani.homes                → "" (registrable apex; never set)
+func orgCookieSuffix(host string) string {
+	host = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+	if host == "" {
+		return ""
+	}
+	labels := strings.Split(host, ".")
+	if len(labels) < 4 {
+		// Need at least <service>.<org>.<zone-l2>.<zone-tld> to safely
+		// scope to .<org>.<zone>. Fewer labels can't be narrowed without
+		// risking a registrable-apex cookie.
+		return ""
+	}
+	switch labels[0] {
+	case "console", "api", "marketplace", "auth":
+		return strings.Join(labels[1:], ".")
+	}
+	return ""
+}
+
 // pinStoreFor lazily wires h.pinStore on first use. Tests inject a
 // pre-built store via h.pinStore directly so this helper is a no-op.
 func (h *Handler) pinStoreFor() *pinStore {
@@ -796,20 +906,16 @@ func (h *Handler) HandlePinVerify(w http.ResponseWriter, r *http.Request) {
 
 	cookieMaxAge := int(pinSessionTTL.Seconds())
 	secure := r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https"
-	cookieDomain := os.Getenv("CATALYST_SESSION_COOKIE_DOMAIN") // e.g. "console.openova.io"
-	// G113-followup hw86 2026-06-02 04:26Z: if the env is unset on a Sovereign,
-	// auto-derive `.<SOVEREIGN_FQDN>` so the catalyst_session cookie covers
-	// BOTH console.<fqdn> AND api.<fqdn>. Without this, the cookie is host-only
-	// on console.<fqdn> → KC's broker redirect to api.<fqdn>/oidc/auth doesn't
-	// carry the cookie → silent SSO bounces to /login (founder symptom 2026-06-02
-	// 04:18Z: "it keep redirecting me to here despite I already login with pin
-	// multiple times when I click on grafana sso login"). Mirrors PR #2729's
-	// auto-derive pattern for CATALYST_OIDC_PROVIDER_ISSUER_URL.
-	if cookieDomain == "" {
-		if sovFQDN := strings.TrimSpace(os.Getenv("SOVEREIGN_FQDN")); sovFQDN != "" {
-			cookieDomain = "." + sovFQDN
-		}
-	}
+	// #4101 (2026-06-22): derive the cookie Domain from the REQUEST HOST,
+	// not blindly from SOVEREIGN_FQDN. A pool-domain Org console is served
+	// at console.<org>.<pool-zone> (e.g. console.demo.omani.homes) by the
+	// SAME Sovereign catalyst-api whose SOVEREIGN_FQDN is the Sovereign
+	// front door (omantel.biz). The previous logic stamped Domain=.omantel.biz
+	// on a Set-Cookie issued for console.demo.omani.homes — the browser
+	// REJECTS a cookie whose Domain doesn't cover the current host, so the
+	// catalyst_session cookie was silently dropped and the very next whoami
+	// on the same host returned 401 (BUG 1, live on omantel.biz 2026-06-22).
+	cookieDomain := sessionCookieDomain(r)
 
 	// ── Session-replay defence (TBD-F7 / #1730, Wave 28-F discovery) ─────
 	//
@@ -969,14 +1075,11 @@ func (h *Handler) HandleAuthLogout(w http.ResponseWriter, r *http.Request) {
 	// explicitly negative-aged the cookie. Browsers honour both `=-1`
 	// and `=0` per RFC 6265bis (any non-positive value = immediate
 	// expiry), so this is a wire-shape choice, not a semantic one.
-	cookieDomain := os.Getenv("CATALYST_SESSION_COOKIE_DOMAIN")
-	// Mirror auto-derive from HandlePinVerify so logout clears the same
-	// cross-subdomain cookie the login set.
-	if cookieDomain == "" {
-		if sovFQDN := strings.TrimSpace(os.Getenv("SOVEREIGN_FQDN")); sovFQDN != "" {
-			cookieDomain = "." + sovFQDN
-		}
-	}
+	// #4101: mirror the request-host-derived domain from HandlePinVerify so
+	// logout clears the SAME cookie the login set — including pool-domain Org
+	// consoles where the cookie is scoped to .<org>.<pool-zone> rather than
+	// .<SOVEREIGN_FQDN>. Browsers require an exact Domain match to delete.
+	cookieDomain := sessionCookieDomain(r)
 	secure := r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https"
 	w.Header().Add("Set-Cookie", buildClearSessionCookie(auth.SessionCookieName, cookieDomain, secure))
 	w.Header().Add("Set-Cookie", buildClearSessionCookie("catalyst_refresh", cookieDomain, secure))

--- a/products/catalyst/bootstrap/api/internal/handler/auth_handover.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth_handover.go
@@ -78,6 +78,21 @@ type authHandoverClaims struct {
 	// hex). Used by chroot pages to scope deployment-keyed API paths
 	// once /sovereign/self resolution is JWT-driven.
 	DeploymentID string `json:"deployment_id"`
+
+	// SupportSession marks an "Enter org" impersonation handover (#3378
+	// B2, minted by org_enter_org.go). Unlike the mothership→Sovereign
+	// handover, this token is signed by the SOVEREIGN's OWN handover
+	// signer (the same catalyst-api both mints and redeems it) and
+	// targets a pool-domain Org console — so it is verified against the
+	// local signer key and validated against sovereign_fqdn rather than
+	// the aud=console.<own-fqdn> claim. (#4101)
+	SupportSession bool `json:"support_session"`
+
+	// SupportPrincipal / ImpersonatedOrg / InitiatedBy carry the audit
+	// context for the support session and drive the in-console banner.
+	SupportPrincipal string `json:"support_principal"`
+	ImpersonatedOrg  string `json:"impersonated_org"`
+	InitiatedBy      string `json:"initiated_by"`
 }
 
 // AuthHandover handles GET /auth/handover?token=<jwt>.
@@ -158,20 +173,57 @@ func (h *Handler) AuthHandover(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// #4101: the verifier must also accept tokens signed by THIS
+	// catalyst-api's OWN handover signer. The mothership→Sovereign
+	// handover is signed by the mothership and verified with the mounted
+	// mothership public key (pubKey above). But the "Enter org" support
+	// handover (#3378 B2, org_enter_org.go) is signed by the SOVEREIGN's
+	// own handoverSigner — the same Pod both mints and redeems it — yet
+	// still stamps iss=console.openova.io. Verifying ONLY with the
+	// mothership key rejected every Enter-org token with
+	// "crypto/rsa: verification error" → "invalid token" (live on
+	// omantel.biz entering console.demo.omani.homes, 2026-06-22). Collect
+	// the local signer's public key as an additional candidate; the
+	// keyfunc tries the mounted key first, then the local one.
+	var localPub *rsa.PublicKey
+	if h.handoverSigner != nil {
+		if lp, lerr := h.handoverSigner.PublicRSAKey(); lerr == nil {
+			localPub = lp
+		}
+	}
+
 	// ── 2. Parse + verify JWT ───────────────────────────────────────────
+	//
+	// We verify the signature manually against each candidate key because
+	// jwt.ParseWithClaims short-circuits on the first key returned by the
+	// keyfunc. To try multiple keys we attempt the parse once per key and
+	// accept the first that validates.
 	var claims authHandoverClaims
-	tok, err := jwt.ParseWithClaims(raw, &claims,
-		func(t *jwt.Token) (any, error) {
-			if _, ok := t.Method.(*jwt.SigningMethodRSA); !ok {
-				return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
-			}
-			return pubKey, nil
-		},
-		jwt.WithValidMethods([]string{"RS256"}),
-		jwt.WithExpirationRequired(),
-	)
-	if err != nil || !tok.Valid {
-		h.log.Warn("auth_handover: JWT parse failed", "err", err)
+	var tok *jwt.Token
+	candidates := []*rsa.PublicKey{pubKey}
+	if localPub != nil && (pubKey == nil || localPub.N.Cmp(pubKey.N) != 0) {
+		candidates = append(candidates, localPub)
+	}
+	var parseErr error
+	for _, cand := range candidates {
+		claims = authHandoverClaims{}
+		key := cand
+		tok, parseErr = jwt.ParseWithClaims(raw, &claims,
+			func(t *jwt.Token) (any, error) {
+				if _, ok := t.Method.(*jwt.SigningMethodRSA); !ok {
+					return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+				}
+				return key, nil
+			},
+			jwt.WithValidMethods([]string{"RS256"}),
+			jwt.WithExpirationRequired(),
+		)
+		if parseErr == nil && tok != nil && tok.Valid {
+			break
+		}
+	}
+	if parseErr != nil || tok == nil || !tok.Valid {
+		h.log.Warn("auth_handover: JWT parse failed", "err", parseErr)
 		writeAuthError(w, "invalid token")
 		return
 	}
@@ -184,20 +236,53 @@ func (h *Handler) AuthHandover(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// aud must contain the Sovereign's console URL.
-	soverFQDN := h.sovereignFQDN()
-	expectedAud := "https://console." + soverFQDN
-	auds, _ := claims.GetAudience()
-	found := false
-	for _, a := range auds {
-		if a == expectedAud {
-			found = true
-			break
+	// Audience / target-host validation.
+	//
+	// #4101: an "Enter org" support handover (support_session=true) targets
+	// a pool-domain Org console that the redeeming Sovereign catalyst-api
+	// also serves — e.g. console.demo.omani.homes on an omantel.biz
+	// Sovereign. org_enter_org.go mints it WITHOUT an aud claim and instead
+	// carries sovereign_fqdn=<org-host-suffix> (demo.omani.homes). The
+	// classic aud=console.<own-fqdn> check (console.omantel.biz) can never
+	// match such a token, so validate the support session against the
+	// request host instead: the token's sovereign_fqdn must equal the Org
+	// suffix of the host the browser actually landed on.
+	if claims.SupportSession {
+		wantSuffix := strings.ToLower(strings.TrimSpace(claims.SovereignFQDN))
+		if wantSuffix == "" {
+			writeAuthError(w, "invalid token")
+			return
 		}
-	}
-	if !found {
-		writeAuthError(w, "invalid audience")
-		return
+		reqHost := requestHost(r)
+		// Accept when the request host is console.<suffix> / <suffix> /
+		// *.<suffix> so the support session lands only on the org it was
+		// minted for.
+		if reqHost != "" &&
+			reqHost != "console."+wantSuffix &&
+			reqHost != wantSuffix &&
+			!strings.HasSuffix(reqHost, "."+wantSuffix) {
+			h.log.Warn("auth_handover: support-session host mismatch",
+				"tokenSuffix", wantSuffix, "reqHost", reqHost)
+			writeAuthError(w, "invalid audience")
+			return
+		}
+	} else {
+		// Standard mothership→Sovereign handover: aud must contain the
+		// Sovereign's own console URL.
+		soverFQDN := h.sovereignFQDN()
+		expectedAud := "https://console." + soverFQDN
+		auds, _ := claims.GetAudience()
+		found := false
+		for _, a := range auds {
+			if a == expectedAud {
+				found = true
+				break
+			}
+		}
+		if !found {
+			writeAuthError(w, "invalid audience")
+			return
+		}
 	}
 
 	if claims.Role != "sovereign-admin" {
@@ -236,16 +321,42 @@ func (h *Handler) AuthHandover(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// ── 5. EnsureUser in Keycloak ───────────────────────────────────────
+	//
+	// #4101: for an "Enter org" support session the Keycloak EnsureUser is
+	// BEST-EFFORT, not a hard gate. The support principal is an ephemeral,
+	// time-boxed (≤60min) impersonation identity — the session JWT we mint
+	// below is the source of truth for the support banner + audit context,
+	// not a durable Keycloak user record. The target Org's realm may still
+	// be converging (a just-provisioned pool Org) and must not block the
+	// sovereign-admin from entering for support. A standard
+	// mothership→Sovereign handover still hard-fails on EnsureUser because
+	// that establishes the durable Sovereign owner identity.
+	var userID string
 	kc := h.keycloakClientFor()
-	if kc == nil {
-		writeAuthError(w, "server misconfiguration: keycloak not configured")
-		return
-	}
-	userID, err := kc.EnsureUser(r.Context(), claims.Email, "sovereign-admins")
-	if err != nil {
-		h.log.Error("auth_handover: EnsureUser failed", "email", claims.Email, "err", err)
-		writeAuthError(w, "keycloak error: ensure user")
-		return
+	if claims.SupportSession {
+		if kc != nil {
+			if uid, eerr := kc.EnsureUser(r.Context(), claims.Email, "sovereign-admins"); eerr != nil {
+				h.log.Warn("auth_handover: support-session EnsureUser failed (best-effort)",
+					"email", claims.Email, "err", eerr)
+			} else {
+				userID = uid
+			}
+		} else {
+			h.log.Warn("auth_handover: support-session EnsureUser skipped — keycloak not configured",
+				"email", claims.Email)
+		}
+	} else {
+		if kc == nil {
+			writeAuthError(w, "server misconfiguration: keycloak not configured")
+			return
+		}
+		uid, eerr := kc.EnsureUser(r.Context(), claims.Email, "sovereign-admins")
+		if eerr != nil {
+			h.log.Error("auth_handover: EnsureUser failed", "email", claims.Email, "err", eerr)
+			writeAuthError(w, "keycloak error: ensure user")
+			return
+		}
+		userID = uid
 	}
 
 	// ── 5b. Auto-seed owner UserAccess CR (D21) ─────────────────────────
@@ -311,6 +422,22 @@ func (h *Handler) AuthHandover(w http.ResponseWriter, r *http.Request) {
 		"sovereign_fqdn": claims.SovereignFQDN,
 		"deployment_id":  claims.DeploymentID,
 	}
+	// #4101: propagate the support-session markers into the minted session
+	// JWT so whoami + the in-console support banner can render the support
+	// principal + impersonated org, and the audit trail ties back to the
+	// initiating sovereign-admin.
+	if claims.SupportSession {
+		sessionClaims["support_session"] = true
+		if claims.SupportPrincipal != "" {
+			sessionClaims["support_principal"] = claims.SupportPrincipal
+		}
+		if claims.ImpersonatedOrg != "" {
+			sessionClaims["impersonated_org"] = claims.ImpersonatedOrg
+		}
+		if claims.InitiatedBy != "" {
+			sessionClaims["initiated_by"] = claims.InitiatedBy
+		}
+	}
 	accessToken, err := h.handoverSigner.SignCustomClaims(sessionClaims)
 	if err != nil {
 		h.log.Error("auth_handover: SignCustomClaims failed", "err", err)
@@ -329,14 +456,19 @@ func (h *Handler) AuthHandover(w http.ResponseWriter, r *http.Request) {
 	// zero-click chain from a handover-established session bounced to the
 	// console PIN form (measured live on hw130 2026-06-13: fresh handover
 	// -> grafana.<fqdn> landed on console./login?next=...oidc/auth...).
-	// The PIN path was fixed on hw86 2026-06-02; the handover path missed
-	// the same fix. Resolution order: explicit env > SOVEREIGN_FQDN env >
-	// the validated handover claim (this handler always has it).
-	cookieDomain := os.Getenv("CATALYST_SESSION_COOKIE_DOMAIN")
+	//
+	// #4101 (2026-06-22): use the shared request-host-derived helper so a
+	// support handover landing on a POOL-domain Org console
+	// (console.demo.omani.homes) scopes the cookie to .demo.omani.homes —
+	// NOT .<SOVEREIGN_FQDN> (.omantel.biz), which the browser would reject
+	// for that host (the same cross-domain drop that broke PIN login,
+	// BUG 1). sessionCookieDomain honours CATALYST_SESSION_COOKIE_DOMAIN,
+	// then the Sovereign zone, then the per-Org suffix.
+	cookieDomain := sessionCookieDomain(r)
 	if cookieDomain == "" {
-		if sovFQDN := strings.TrimSpace(os.Getenv("SOVEREIGN_FQDN")); sovFQDN != "" {
-			cookieDomain = "." + sovFQDN
-		} else if fq := strings.TrimSpace(claims.SovereignFQDN); fq != "" {
+		// Last-resort: the validated handover claim's sovereign_fqdn (this
+		// handler always has it) so the cookie is never host-only.
+		if fq := strings.TrimSpace(claims.SovereignFQDN); fq != "" {
 			cookieDomain = "." + fq
 		}
 	}

--- a/products/catalyst/bootstrap/api/internal/handler/auth_handover_support_session_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth_handover_support_session_test.go
@@ -1,0 +1,218 @@
+// auth_handover_support_session_test.go — #4101 BUG 2 coverage.
+//
+// An "Enter org" support handover (org_enter_org.go, #3378 B2) is signed
+// by the SOVEREIGN's OWN handover signer (the same catalyst-api both mints
+// AND redeems it) but stamps iss=https://console.openova.io and targets a
+// POOL-domain Org console (console.demo.omani.homes) that the omantel.biz
+// Sovereign also serves.
+//
+// Pre-#4101 the /auth/handover verifier accepted ONLY the mounted MOTHERSHIP
+// public key, so a token signed by the local signer failed with
+// "crypto/rsa: verification error" → "invalid token" (live on omantel.biz
+// 2026-06-22). And the aud=console.<own-fqdn> check could never match a
+// support token (no aud claim; carries sovereign_fqdn=<org-suffix>).
+//
+// These tests lock both halves of the fix:
+//   - the local signer key is accepted EVEN WHEN the mounted verify key is a
+//     DIFFERENT (mothership) key;
+//   - the support session is validated against the request host's Org suffix
+//     instead of the Sovereign's own console aud;
+//   - the minted session cookie is scoped to the pool-domain Org host.
+package handler
+
+import (
+	"crypto/rsa"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handoverjwt"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jtistore"
+)
+
+// supportSessionSetup wires a Handler whose MOUNTED verify key (the
+// "mothership" public JWK) is DIFFERENT from its local handoverSigner key
+// (the "Sovereign" signer). This reproduces the live omantel.biz topology
+// where the Sovereign signs Enter-org tokens with its own key but the
+// /auth/handover verifier has the mothership's public key mounted.
+func supportSessionSetup(t *testing.T) (h *Handler, localSigner *handoverjwt.Signer) {
+	t.Helper()
+	dir := t.TempDir()
+
+	// "Mothership" key — only its PUBLIC half is mounted as the verify key.
+	mothershipPriv, mothershipPubJWK, err := handoverjwt.GenerateKeypair()
+	if err != nil {
+		t.Fatalf("mothership GenerateKeypair: %v", err)
+	}
+	_ = mothershipPriv
+	keyPath := filepath.Join(dir, "mothership-public.jwk")
+	if err := os.WriteFile(keyPath, mothershipPubJWK, 0o644); err != nil {
+		t.Fatalf("write mothership pubJWK: %v", err)
+	}
+
+	// "Sovereign" signer — a DIFFERENT keypair, used to sign the Enter-org
+	// support token (org_enter_org.go signs with h.handoverSigner).
+	sovPriv, _, err := handoverjwt.GenerateKeypair()
+	if err != nil {
+		t.Fatalf("sovereign GenerateKeypair: %v", err)
+	}
+	localSigner, err = handoverjwt.New(sovPriv, "https://console.openova.io", 8*time.Hour)
+	if err != nil {
+		t.Fatalf("handoverjwt.New(sovereign): %v", err)
+	}
+
+	h = &Handler{
+		log:                       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		handoverJWTPublicKeyPath:  keyPath, // mothership key mounted
+		handoverSigner:            localSigner,
+		authHandoverSovereignFQDN: "omantel.biz",
+		authHandoverRedirect:      "/dashboard",
+		jtiStore:                  jtistore.New(filepath.Join(dir, "jti.log")),
+		kc:                        &stubKeycloakClient{},
+	}
+	return h, localSigner
+}
+
+// mintSupportToken builds the exact claim shape org_enter_org.go mints for
+// entering the demo Org on a pool domain, and signs it with the given signer.
+func mintSupportToken(t *testing.T, signer *handoverjwt.Signer, orgSuffix string) string {
+	t.Helper()
+	now := time.Now()
+	principal := "support+ops@" + orgSuffix
+	claims := jwt.MapClaims{
+		"iss":               "https://console.openova.io",
+		"sub":               principal,
+		"email":             principal,
+		"email_verified":    true,
+		"role":              "sovereign-admin",
+		"sovereign_fqdn":    orgSuffix,
+		"deployment_id":     "",
+		"iat":               now.Unix(),
+		"exp":               now.Add(30 * time.Minute).Unix(),
+		"jti":               "support-" + orgSuffix + "-" + time.Now().Format("150405.000000000"),
+		"support_session":   true,
+		"support_principal": principal,
+		"impersonated_org":  "demo",
+		"initiated_by":      "ops@omantel.biz",
+	}
+	tok, err := signer.SignCustomClaims(claims)
+	if err != nil {
+		t.Fatalf("SignCustomClaims: %v", err)
+	}
+	return tok
+}
+
+// TestAuthHandover_SupportSession_LocalSignerAccepted is the BUG 2 fix:
+// a support token signed by the LOCAL signer is accepted at /auth/handover
+// even though the mounted verify key is the (different) mothership key, and
+// the request lands on the pool-domain Org console host.
+func TestAuthHandover_SupportSession_LocalSignerAccepted(t *testing.T) {
+	h, signer := supportSessionSetup(t)
+	tok := mintSupportToken(t, signer, "demo.omani.homes")
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/handover?token="+tok, nil)
+	// The browser lands on the pool-domain Org console host.
+	req.Header.Set("X-Forwarded-Host", "console.demo.omani.homes")
+	req.Header.Set("X-Forwarded-Proto", "https")
+	w := httptest.NewRecorder()
+	h.AuthHandover(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("status: got %d want 302 (BUG 2 regression — support handover rejected); body=%s",
+			resp.StatusCode, w.Body.String())
+	}
+	if loc := resp.Header.Get("Location"); loc != "/dashboard" {
+		t.Errorf("Location: got %q want /dashboard", loc)
+	}
+
+	sessionCookie := findCookie(resp.Cookies(), "catalyst_session")
+	if sessionCookie == nil {
+		t.Fatal("catalyst_session cookie not set on support handover")
+	}
+	// BUG 1+2: the cookie must be scoped to the pool-domain Org host suffix,
+	// NOT the Sovereign FQDN — otherwise the browser drops it and the next
+	// whoami on console.demo.omani.homes is 401.
+	if sessionCookie.Domain != "demo.omani.homes" {
+		t.Errorf("catalyst_session Domain: got %q want %q (pool-domain Org scope)",
+			sessionCookie.Domain, "demo.omani.homes")
+	}
+
+	// The minted session JWT must carry the support markers.
+	parsed, err := jwt.Parse(sessionCookie.Value, func(tok *jwt.Token) (interface{}, error) {
+		pk, _ := signer.PublicRSAKey()
+		return pk, nil
+	})
+	if err != nil || !parsed.Valid {
+		t.Fatalf("session JWT validate: err=%v", err)
+	}
+	m := parsed.Claims.(jwt.MapClaims)
+	if m["support_session"] != true {
+		t.Errorf("session.support_session: got %v want true", m["support_session"])
+	}
+	if m["impersonated_org"] != "demo" {
+		t.Errorf("session.impersonated_org: got %v want demo", m["impersonated_org"])
+	}
+}
+
+// TestAuthHandover_SupportSession_HostMismatchRejected guards against a
+// support token being redeemed on a DIFFERENT Org's host than it was minted
+// for (token sovereign_fqdn=demo.omani.homes redeemed on
+// console.acme.omani.homes must be rejected).
+func TestAuthHandover_SupportSession_HostMismatchRejected(t *testing.T) {
+	h, signer := supportSessionSetup(t)
+	tok := mintSupportToken(t, signer, "demo.omani.homes")
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/handover?token="+tok, nil)
+	req.Header.Set("X-Forwarded-Host", "console.acme.omani.homes")
+	req.Header.Set("X-Forwarded-Proto", "https")
+	w := httptest.NewRecorder()
+	h.AuthHandover(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status: got %d want 401 (host mismatch must be rejected); body=%s",
+			w.Code, w.Body.String())
+	}
+}
+
+// TestAuthHandover_NonSupportToken_LocalSignerStillRejectedWrongKey ensures
+// the local-signer fallback does NOT weaken the standard mothership handover:
+// a NON-support token signed by the wrong (local) key with no aud is still
+// rejected (it would fail the aud check even if the signature passed). This
+// documents that the local-key fallback is gated to legitimate use.
+func TestAuthHandover_NonSupportToken_AudStillEnforced(t *testing.T) {
+	h, signer := supportSessionSetup(t)
+	// A non-support token signed by the local signer for the wrong aud.
+	now := time.Now()
+	claims := jwt.MapClaims{
+		"iss":            "https://console.openova.io",
+		"sub":            "admin@evil.test",
+		"email":          "admin@evil.test",
+		"email_verified": true,
+		"role":           "sovereign-admin",
+		"aud":            "https://console.evil.test", // not console.omantel.biz
+		"iat":            now.Unix(),
+		"exp":            now.Add(5 * time.Minute).Unix(),
+		"jti":            "non-support-" + time.Now().Format("150405.000000000"),
+	}
+	tok, err := signer.SignCustomClaims(claims)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/auth/handover?token="+tok, nil)
+	req.Header.Set("X-Forwarded-Host", "console.omantel.biz")
+	req.Header.Set("X-Forwarded-Proto", "https")
+	w := httptest.NewRecorder()
+	h.AuthHandover(w, req)
+	// Signature now verifies (local key), but the aud gate rejects it.
+	assertAuthError(t, w, http.StatusUnauthorized, "invalid audience")
+}
+
+var _ = (*rsa.PublicKey)(nil)

--- a/products/catalyst/bootstrap/api/internal/handler/auth_pin_cookie_domain_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth_pin_cookie_domain_test.go
@@ -1,0 +1,166 @@
+// auth_pin_cookie_domain_test.go — #4101 BUG 1 coverage.
+//
+// On a Sovereign (SOVEREIGN_FQDN=omantel.biz) that ALSO serves a pool-domain
+// Org console (console.demo.omani.homes), HandlePinVerify must scope the
+// catalyst_session cookie to the REQUEST HOST, not blindly to .omantel.biz.
+//
+// Pre-#4101: the cookie carried Domain=.omantel.biz even when the PIN was
+// verified on console.demo.omani.homes. Browsers REJECT a Set-Cookie whose
+// Domain doesn't cover the current host, so the cookie was silently dropped
+// and the very next whoami on console.demo.omani.homes returned 401 (live on
+// omantel.biz 2026-06-22).
+//
+// These tests pin sessionCookieDomain() and the HandlePinVerify wiring.
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestSessionCookieDomain_Table covers the request-host → cookie-Domain
+// derivation matrix (#4101).
+func TestSessionCookieDomain_Table(t *testing.T) {
+	cases := []struct {
+		name       string
+		envDomain  string // CATALYST_SESSION_COOKIE_DOMAIN
+		sovFQDN    string // SOVEREIGN_FQDN
+		fwdHost    string // X-Forwarded-Host
+		rawHost    string // r.Host (used when fwdHost empty)
+		wantDomain string // expected Set-Cookie Domain seed (with leading dot or "")
+	}{
+		{
+			name:       "explicit env override wins",
+			envDomain:  "console.openova.io",
+			sovFQDN:    "omantel.biz",
+			fwdHost:    "console.demo.omani.homes",
+			wantDomain: "console.openova.io",
+		},
+		{
+			name:       "sovereign own console → .<sovereign-fqdn>",
+			sovFQDN:    "omantel.biz",
+			fwdHost:    "console.omantel.biz",
+			wantDomain: ".omantel.biz",
+		},
+		{
+			name:       "sovereign api host → .<sovereign-fqdn>",
+			sovFQDN:    "omantel.biz",
+			fwdHost:    "api.omantel.biz",
+			wantDomain: ".omantel.biz",
+		},
+		{
+			name:       "POOL-domain Org console → .<org>.<pool-zone> (BUG 1)",
+			sovFQDN:    "omantel.biz",
+			fwdHost:    "console.demo.omani.homes",
+			wantDomain: ".demo.omani.homes",
+		},
+		{
+			name:       "POOL-domain Org api host → .<org>.<pool-zone>",
+			sovFQDN:    "omantel.biz",
+			fwdHost:    "api.demo.omani.homes",
+			wantDomain: ".demo.omani.homes",
+		},
+		{
+			name:       "host with port stripped",
+			sovFQDN:    "omantel.biz",
+			fwdHost:    "console.demo.omani.homes:443",
+			wantDomain: ".demo.omani.homes",
+		},
+		{
+			name:       "falls back to r.Host when no X-Forwarded-Host",
+			sovFQDN:    "omantel.biz",
+			rawHost:    "console.demo.omani.homes",
+			wantDomain: ".demo.omani.homes",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("CATALYST_SESSION_COOKIE_DOMAIN", tc.envDomain)
+			t.Setenv("SOVEREIGN_FQDN", tc.sovFQDN)
+
+			req := httptest.NewRequest(http.MethodGet, "/x", nil)
+			if tc.rawHost != "" {
+				req.Host = tc.rawHost
+			}
+			if tc.fwdHost != "" {
+				req.Header.Set("X-Forwarded-Host", tc.fwdHost)
+			}
+			got := sessionCookieDomain(req)
+			if got != tc.wantDomain {
+				t.Errorf("sessionCookieDomain = %q, want %q", got, tc.wantDomain)
+			}
+		})
+	}
+}
+
+// TestPinVerify_PoolDomainCookieScopedToOrgHost is the end-to-end BUG 1
+// guard: a PIN verified on console.demo.omani.homes must mint a cookie the
+// browser will actually keep (Domain scoped to the Org host), NOT .omantel.biz.
+func TestPinVerify_PoolDomainCookieScopedToOrgHost(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "omantel.biz")
+	t.Setenv("CATALYST_SESSION_COOKIE_DOMAIN", "")
+
+	h := testPinSetup(t)
+	h.pinStore.put("demo@openova.io", "123456", "req-1")
+
+	body := `{"email":"demo@openova.io","pin":"123456","requestId":"req-1"}`
+	req := httptest.NewRequest(http.MethodPost,
+		"http://console.demo.omani.homes/api/v1/auth/pin/verify",
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Forwarded-Host", "console.demo.omani.homes")
+	req.Header.Set("X-Forwarded-Proto", "https")
+	w := httptest.NewRecorder()
+	h.HandlePinVerify(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", w.Code, w.Body.String())
+	}
+	sc := findCookie(w.Result().Cookies(), "catalyst_session")
+	if sc == nil {
+		t.Fatal("catalyst_session cookie not set")
+	}
+	// Go serialises Domain without the leading dot.
+	if sc.Domain != "demo.omani.homes" {
+		t.Errorf("catalyst_session Domain: got %q want %q (BUG 1 — a .omantel.biz cookie is dropped by the browser on this host → whoami 401)",
+			sc.Domain, "demo.omani.homes")
+	}
+	if !sc.Secure {
+		t.Error("catalyst_session must be Secure on an https forwarded request")
+	}
+}
+
+// TestPinVerify_SovereignConsoleCookieUnchanged confirms the Sovereign's OWN
+// console keeps the historical .<SOVEREIGN_FQDN> scope (no regression of the
+// G113-followup hw86 fix).
+func TestPinVerify_SovereignConsoleCookieUnchanged(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "omantel.biz")
+	t.Setenv("CATALYST_SESSION_COOKIE_DOMAIN", "")
+
+	h := testPinSetup(t)
+	h.pinStore.put("ops@omantel.biz", "123456", "req-1")
+
+	body := `{"email":"ops@omantel.biz","pin":"123456","requestId":"req-1"}`
+	req := httptest.NewRequest(http.MethodPost,
+		"http://console.omantel.biz/api/v1/auth/pin/verify",
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Forwarded-Host", "console.omantel.biz")
+	req.Header.Set("X-Forwarded-Proto", "https")
+	w := httptest.NewRecorder()
+	h.HandlePinVerify(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", w.Code, w.Body.String())
+	}
+	sc := findCookie(w.Result().Cookies(), "catalyst_session")
+	if sc == nil {
+		t.Fatal("catalyst_session cookie not set")
+	}
+	if sc.Domain != "omantel.biz" {
+		t.Errorf("catalyst_session Domain: got %q want %q (Sovereign own console)", sc.Domain, "omantel.biz")
+	}
+}


### PR DESCRIPTION
Refs #4101

Two confirmed live failures on the **omantel.biz Sovereign** serving a pool-domain Org console (`console.demo.omani.homes`, owner demo@openova.io). Both pinned from live catalyst-api logs (mothership kubeconfig `4635277cae4ffed9`).

## BUG 1 — PIN login: whoami 401 immediately after pin/verify 200
`HandlePinVerify` scoped `catalyst_session` to `Domain=.<SOVEREIGN_FQDN>` (`.omantel.biz`) even when the PIN was verified on a pool-domain Org host (`console.demo.omani.homes` — a **different registrable domain**). Browsers reject a Set-Cookie whose Domain doesn't cover the current host, so the cookie was silently dropped and the next `whoami` carried no cookie → 401.

**Fix:** new `sessionCookieDomain(r)` derives the cookie Domain from the **request host**:
- Sovereign's own console/api (`*.omantel.biz`) → `.omantel.biz` (unchanged — preserves the #3374 / hw86 silent-SSO fix)
- pool-domain Org host (`console.demo.omani.homes`) → `.demo.omani.homes` (covers that Org's console/api/marketplace; no session bleed to sibling Orgs on the same pool zone)
- honours `CATALYST_SESSION_COOKIE_DOMAIN` override; X-Forwarded-Host aware.

Applied to `HandlePinVerify`, `HandleAuthLogout`, and the `AuthHandover` cookie-set.

## BUG 2 — Enter-org handover: `{"error":"invalid token"}`
Live log: `auth_handover: JWT parse failed err="token signature is invalid: crypto/rsa: verification error"`.

The Enter-org support token (`org_enter_org.go`) is signed by the **Sovereign's OWN** handover signer (the same catalyst-api both mints and redeems it) but stamps `iss=console.openova.io`. `/auth/handover` verified **only** with the mounted **mothership** public key — which differs from the local signer key → signature fails. The support token also carries **no `aud`** (carries `sovereign_fqdn=<org-suffix>`), so the `aud=console.<own-fqdn>` gate could never match.

Verified live on omantel.biz: mothership signer pub `n[:60]=u8CasMst...` (mounted verify key) vs Sovereign signer pub `n[:60]=99K7ZsJ0...` (signs Enter-org tokens) — different keys.

**Fix:**
1. verify against the **local handover signer's public key** in addition to the mounted mothership key (the Enter-org self-handover case);
2. for `support_session` tokens, validate the token's `sovereign_fqdn` against the **request host's Org suffix** instead of the `aud` claim;
3. make Keycloak `EnsureUser` **best-effort** for support sessions (ephemeral ≤60min principal; Org realm may still be converging) — never hard-fail the entry;
4. propagate `support_session`/`support_principal`/`impersonated_org`/`initiated_by` into the minted session JWT for the in-console support banner + audit.

The standard mothership→Sovereign handover path is unchanged (still aud-gated + EnsureUser-hard-gated).

## Tests
- `auth_pin_cookie_domain_test.go` — `sessionCookieDomain` matrix + PIN verify on pool-domain host scopes cookie to `.demo.omani.homes` + Sovereign own console unchanged.
- `auth_handover_support_session_test.go` — local-signer token accepted with a DIFFERENT mounted mothership verify key; host-mismatch rejected; non-support aud gate preserved.
- Full `internal/handler` + `internal/auth` suites green; `go vet` clean.

## Notes
- Passwordless 6-digit PIN remains the only login (no password/OIDC-password added).
- I did NOT roll/restart the live catalyst-api — the RELEASE-COORDINATOR owns the roll; this PR rides it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)