### PR TITLE
fix(bootstrap-kit-crs): harbor-pg/gitea-pg/guacamole-pg cnpg never bind — drop classless storageClass:'' + add resource requests (#4107)

### DIFF
--- a/clusters/_template/bootstrap-kit-crs/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit-crs/10-gitea.yaml
@@ -141,9 +141,15 @@ spec:
       maintenance_work_mem: 64MB
       log_statement: ddl
       log_min_duration_statement: '1000'
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
   storage:
     size: 5Gi
-    storageClass: ''
   enableSuperuserAccess: true
   monitoring:
     enablePodMonitor: false

--- a/clusters/_template/bootstrap-kit-crs/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit-crs/19-harbor.yaml
@@ -97,9 +97,15 @@ spec:
       maintenance_work_mem: 64MB
       log_statement: ddl
       log_min_duration_statement: '1000'
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
   storage:
     size: 5Gi
-    storageClass: ''
   enableSuperuserAccess: true
   monitoring:
     enablePodMonitor: false

--- a/clusters/_template/bootstrap-kit-crs/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit-crs/52-bp-guacamole.yaml
@@ -84,10 +84,10 @@ spec:
       cpu: 50m
       memory: 128Mi
     limits:
+      cpu: 500m
       memory: 512Mi
   storage:
     size: 5Gi
-    storageClass: ''
   enableSuperuserAccess: true
   monitoring:
     enablePodMonitor: false

--- a/clusters/_template/bootstrap-kit/placement.yaml
+++ b/clusters/_template/bootstrap-kit/placement.yaml
@@ -412,9 +412,23 @@ spec:
                   maintenance_work_mem: 64MB
                   log_statement: ddl
                   log_min_duration_statement: "1000"
+              # #4107 — OMIT storageClass entirely. An empty-string storageClass
+              # is NOT "cluster-default" — it means "use NO StorageClass", which
+              # produces an immediate-binding PVC with no provisioner that stays
+              # Pending forever (FailedBinding: "no persistent volumes available
+              # for this claim and no storage class is set"). Omitting the field
+              # is what makes cnpg fall back to the default StorageClass (evs-ssd
+              # on Huawei, hcloud-volumes on Hetzner). local-path remains
+              # forbidden via the forbid-local-path-storage Kyverno policy.
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
               storage:
                 size: 5Gi
-                storageClass: ""  # #3971 — empty ⇒ CNPG cluster-default durable cloud CSI; local-path FORBIDDEN
               enableSuperuserAccess: true
               monitoring:
                 enablePodMonitor: false
@@ -1056,9 +1070,23 @@ spec:
                   maintenance_work_mem: 64MB
                   log_statement: ddl
                   log_min_duration_statement: "1000"
+              # #4107 — OMIT storageClass entirely. An empty-string storageClass
+              # is NOT "cluster-default" — it means "use NO StorageClass", which
+              # produces an immediate-binding PVC with no provisioner that stays
+              # Pending forever (FailedBinding: "no persistent volumes available
+              # for this claim and no storage class is set"). Omitting the field
+              # is what makes cnpg fall back to the default StorageClass (evs-ssd
+              # on Huawei, hcloud-volumes on Hetzner). local-path remains
+              # forbidden via the forbid-local-path-storage Kyverno policy.
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
               storage:
                 size: 5Gi
-                storageClass: ""  # #3971 — empty ⇒ CNPG cluster-default durable cloud CSI; local-path FORBIDDEN
               enableSuperuserAccess: true
               monitoring:
                 enablePodMonitor: false
@@ -1275,10 +1303,16 @@ spec:
                   cpu: 50m
                   memory: 128Mi
                 limits:
+                  cpu: 500m
                   memory: 512Mi
+              # #4107 — OMIT storageClass entirely. An empty-string storageClass
+              # is NOT "cluster-default" — it means "use NO StorageClass", which
+              # produces an immediate-binding PVC with no provisioner that stays
+              # Pending forever. Omitting the field is what makes cnpg fall back
+              # to the default StorageClass (evs-ssd on Huawei, hcloud-volumes on
+              # Hetzner). local-path remains forbidden via Kyverno.
               storage:
                 size: 5Gi
-                storageClass: ""  # #3971 — empty ⇒ CNPG cluster-default durable cloud CSI; local-path FORBIDDEN
               enableSuperuserAccess: true
               monitoring:
                 enablePodMonitor: false


### PR DESCRIPTION
## Problem (live, omantel.biz dep 4635277cae4ffed9)
`harbor/harbor-pg`, `gitea/gitea-pg`, `catalyst-system/guacamole-pg` cnpg Clusters wedge at `phase=Setting up primary` (0 ready, 9h+). Downstream: **Harbor never serves → the on-Sovereign registry mirror returns errors → EVERY org image pull (bp-keycloak, vc-demo, bp-agenity) ImagePullBackOffs.** Gitea + Guacamole DBs also down.

## Root cause — TWO defects in the cnpg Cluster manifests
1. **`storage.storageClass: ''`** — an empty string is NOT 'use the cluster default'; it means 'use NO StorageClass' → immediate-binding PVC, no provisioner → permanently Pending. Live event: `FailedBinding: no persistent volumes available for this claim and no storage class is set`. Healthy clusters (shared-pg, openova-flow-pg, newapi-pg) OMIT the field → cnpg falls back to default SC `evs-ssd`/`hcloud-volumes` → bind fine.
2. **Missing resource requests** (harbor-pg + gitea-pg shipped `resources: {}`) — the cnpg initdb pod has no `resources.requests.{cpu,memory}` → blocked by the **Enforce** Kyverno policy `resource-requests/requests-pod` in the harbor + gitea namespaces (catalyst-system is excluded) → cnpg can NEVER (re)create the initdb job. guacamole-pg also gets its missing `limits.cpu`.

The two compound: PVC won't bind → initdb pod reschedules forever → any Job recreate trips the requests policy → PVC-deletion alone can't recover.

## Fix
- Omit `storageClass` entirely in all three cnpg Clusters (fall back to default SC).
- Add a `resources: {requests, limits}` block matching the healthy-cluster pattern.

Source of truth is `placement.yaml` hostBridge.hostDocuments; `bootstrap-kit-crs/*.yaml` regenerated via `scripts/render-slot-placement.py fix` (check PASSED — 67 slots).

## Verification
Live recreation of the 3 Clusters on omantel.biz + an ImagePullBackOff→pull-success proof is being applied; evidence will be posted on #4107.

Refs #4107

🤖 Generated with [Claude Code](https://claude.com/claude-code)