### PR TITLE
fix(catalyst): SECURITY — customer Org console must be Org-scoped, not sovereign-admin god-mode (Refs #4110)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -1081,6 +1081,16 @@ func main() {
 	// proceed without any auth check, preserving existing behaviour.
 	r.Group(func(rg chi.Router) {
 		rg.Use(auth.RequireSession(h.GetAuthConfig(), log))
+		// #4110 — Org-console scope guard. Transparent passthrough for
+		// Sovereign-admin/operator sessions (zero regression); for an
+		// Org-scoped customer session (PIN-authenticated on an Org pool-
+		// domain console host, e.g. console.demo.omani.homes) it enforces a
+		// deny-by-default allowlist so the customer can reach ONLY their own
+		// Organization's surfaces — never the deployments API / deployment-
+		// stream, the whole-cluster estate, BSS/billing, parent-domains, the
+		// cross-org directory, or sovereign settings. Must run AFTER
+		// RequireSession (which populates auth.ClaimsFromContext).
+		rg.Use(h.OrgScopeGuard)
 
 		// Whoami — UI auth guard polls this; 401 → redirect to /login.
 		rg.Get("/api/v1/whoami", h.HandleWhoami)

--- a/products/catalyst/bootstrap/api/internal/auth/middleware.go
+++ b/products/catalyst/bootstrap/api/internal/auth/middleware.go
@@ -114,6 +114,16 @@ const sovereignOperatorRoleName = "catalyst-owner"
 // whoamiTierInheritance — owner inherits admin/operator/developer/viewer.
 const sovereignOperatorTier = "owner"
 
+// OrgScopedTier is the tier stamped on an Org-scoped customer session
+// (#4110): a PIN session minted on an Org pool-domain console host
+// (console.<org>.<pool-zone>). It is deliberately OUTSIDE the sovereign
+// tier inheritance chain (viewer<developer<operator<admin<owner) so no
+// sovereign-admin gate ever accepts it, and it is the single authoritative
+// marker the API authz guard (handler.requireNotOrgScoped) and the
+// owner-stamp guard above key off. Exported so the handler package shares
+// the exact same string (handler.orgScopedTier aliases this).
+const OrgScopedTier = "org-admin"
+
 // stampSovereignOperatorClaim enriches the JWT-derived Claims when the
 // bearer matches the Sovereign operator's email. The operator email comes
 // from OPERATOR_EMAIL env (orchestrator-stamped at chroot install time
@@ -128,6 +138,17 @@ const sovereignOperatorTier = "owner"
 // now accept the operator without a per-handler email check.
 func stampSovereignOperatorClaim(claims *Claims) {
 	if claims == nil {
+		return
+	}
+	// #4110 — NEVER upgrade an Org-scoped customer session to Sovereign
+	// owner, even if the customer's email coincides with OPERATOR_EMAIL.
+	// An Org-scoped PIN session (minted on console.<org>.<pool-zone>) is
+	// stamped tier=OrgScopedTier by HandlePinVerify; that tier is the
+	// authoritative "this is a customer, confine to their Org" marker, and
+	// the email-match owner-stamp must defer to it. Without this guard the
+	// suspenders (G97) would silently re-open the very privilege-escalation
+	// hole the host-scoping closes.
+	if strings.EqualFold(strings.TrimSpace(claims.Tier), OrgScopedTier) {
 		return
 	}
 	opEmail := strings.ToLower(strings.TrimSpace(os.Getenv("OPERATOR_EMAIL")))

--- a/products/catalyst/bootstrap/api/internal/handler/auth.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth.go
@@ -879,6 +879,40 @@ func (h *Handler) HandlePinVerify(w http.ResponseWriter, r *http.Request) {
 	// stamp happens ONLY at PIN-verify (i.e. only after the operator
 	// proved IMAP control); pre-PIN sessions never carry these claims.
 	sessionTier, sessionRealmRoles := h.pinSessionAuthority(r.Context(), email)
+
+	// ── #4110 Org-console scoping (THE security fix) ────────────────────
+	//
+	// pinSessionAuthority() above resolves authority purely from the
+	// SOVEREIGN realm's /sovereign-admins membership and IGNORES the
+	// request host. On a Sovereign that also serves Org pool-domain
+	// consoles (console.<org>.<pool-zone> e.g. console.demo.omani.homes),
+	// that meant a customer PIN-authenticating on THEIR Org console was
+	// minted the SAME sovereign-admin session as the operator on the
+	// Sovereign's own front door — full god-mode (provisioning wizard,
+	// deployment-stream, every Org, cloud view, sovereign DNS/parent-
+	// domain/BSS settings). Live privilege escalation on omantel.biz.
+	//
+	// The trust anchor is the REQUEST HOST: the Cilium Gateway routes the
+	// Org console host to this catalyst-api and sets X-Forwarded-Host to
+	// the real browser host, which a browser on the Org console can never
+	// forge. When the host resolves (via the tenant registry) to a
+	// tenant_kind=org console, the session is FORCED Org-scoped: a
+	// non-sovereign tier (org-admin) + the org slug, NEVER catalyst-admin/
+	// sovereign-admin — regardless of what /sovereign-admins says. The
+	// org slug is also stamped so org-scoped handlers + the console confine
+	// to this one Organization. The API authz gate (OrgScopeGuard) then
+	// 403s any sovereign/other-org endpoint for this session (deny-by-
+	// default outside the Org-safe allowlist), so the confinement holds
+	// even if the SPA is bypassed.
+	orgClaim := ""
+	if scope, ok := h.resolveOrgScope(r); ok {
+		sessionTier = orgScopedTier
+		sessionRealmRoles = []string{orgScopedRealmRole}
+		orgClaim = scope.Org
+		h.log.Info("pin/verify: Org-scoped session",
+			"email", email, "org", scope.Org, "host", scope.Host)
+	}
+
 	sessionClaims := jwt.MapClaims{
 		"iss":            pinIssuer,
 		"sub":            email, // email == subject; downstream reads claims.Email
@@ -893,6 +927,14 @@ func (h *Handler) HandlePinVerify(w http.ResponseWriter, r *http.Request) {
 		"exp": time.Now().Add(pinSessionTTL).Unix(),
 		"jti": uuid.NewString(),
 		"typ": "session",
+	}
+	// Stamp the Org slug only for an Org-scoped session — both wire tags
+	// (`org` legacy + `org_id` Wave-1b) so auth.Claims.UnmarshalJSON picks
+	// it up regardless of which it reads. A Sovereign-admin session never
+	// carries an org claim.
+	if orgClaim != "" {
+		sessionClaims["org"] = orgClaim
+		sessionClaims["org_id"] = orgClaim
 	}
 	accessToken, err := h.handoverSigner.SignCustomClaims(sessionClaims)
 	if err != nil {
@@ -1232,6 +1274,15 @@ type whoamiResponse struct {
 	SovereignFQDN string             `json:"sovereignFQDN,omitempty"`
 	Mode          string             `json:"mode,omitempty"`
 	Tier          string             `json:"tier,omitempty"`
+	// #4110 — Org-scope context for the SPA. When the session is an
+	// Org-scoped customer session (minted on console.<org>.<pool-zone>),
+	// OrgScoped=true and Org carries the Organization slug. The console
+	// reads OrgScoped to render the scoped chrome (hide the provisioning
+	// wizard, deployment-stream, cross-org directory, sovereign DNS/parent-
+	// domain/BSS settings) and scope every estate query to Org. Both are
+	// omitempty so the Sovereign-admin whoami shape is byte-unchanged.
+	OrgScoped bool   `json:"orgScoped,omitempty"`
+	Org       string `json:"org,omitempty"`
 	// RealmAccess is a pointer so `omitempty` actually drops the key when
 	// the operator's session carries no RBAC claims. A struct value would
 	// always serialize as `{}` regardless of omitempty (Go encoding/json
@@ -1288,6 +1339,13 @@ func (h *Handler) HandleWhoami(w http.ResponseWriter, r *http.Request) {
 		Sub:      claims.Sub,
 		Verified: claims.EmailVerified,
 		Tier:     strings.ToLower(strings.TrimSpace(claims.Tier)),
+	}
+	// #4110 — surface the Org-scope so the SPA renders the scoped console.
+	// The org-scoped marker is the tier (set by HandlePinVerify on an Org
+	// pool-domain host); the Org slug rides the `org`/`org_id` claim.
+	if claimsAreOrgScoped(claims) {
+		resp.OrgScoped = true
+		resp.Org = strings.TrimSpace(claims.Org)
 	}
 	if len(claims.RealmAccess.Roles) > 0 {
 		resp.RealmAccess = &whoamiRealmAccess{

--- a/products/catalyst/bootstrap/api/internal/handler/org_scope.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_scope.go
@@ -1,0 +1,234 @@
+// org_scope.go — request-host → Organization scope resolution + the
+// authorization guard that confines an Org-scoped session to its OWN
+// Organization (issue #4110).
+//
+// THE BUG this file closes (live on omantel.biz dep 4635277cae4ffed9,
+// 2026-06-22): a customer (demo@openova.io) PIN-authenticating on their
+// Org pool-domain console (console.demo.omani.homes) was minted the SAME
+// sovereign-admin session the operator gets on console.omantel.biz.
+// pinSessionAuthority() derived the tier purely from /sovereign-admins
+// group membership in the SOVEREIGN realm and NEVER consulted the request
+// host, so a session minted on an Org host carried full god-mode:
+// provisioning wizard, the Sovereign's own deployment-stream, every Org,
+// the whole cloud view, sovereign DNS / parent-domain / BSS settings.
+//
+// The fix has two halves, both in this file:
+//
+//  1. resolveOrgScope(r) — resolves the request host against the tenant
+//     registry. When the host is a registered tenant_kind=org console
+//     (e.g. console.demo.omani.homes → org-demo), the session minted on
+//     that host MUST be Org-scoped: a non-sovereign tier + the org slug,
+//     NEVER catalyst-admin/sovereign-admin. HandlePinVerify consumes this
+//     to stamp the JWT (org + tier) at mint time.
+//
+//  2. OrgScopeGuard / claimsAreOrgScoped(claims) — the authorization guard.
+//     A session whose JWT carries the org-scoped tier is a customer; it is
+//     FORBIDDEN (deny-by-default outside orgSafePathPrefixes) from the
+//     sovereign-admin + cross-org surfaces (the deployments API, parent-
+//     domains, the all-orgs directory, sovereign settings, the whole-cluster
+//     estate). Enforced as middleware on the RequireSession group so the API
+//     returns 403 even if the SPA is bypassed — defense in depth, not
+//     UI-only hiding.
+//
+// Why the request host is the trust anchor: catalyst-api sits behind the
+// Cilium Gateway which sets X-Forwarded-Host to the real browser host. A
+// browser on console.demo.omani.homes can only ever send that host (the
+// gateway routes the Org console host to this same catalyst-api). The PIN
+// itself proves inbox control, but the HOST proves WHICH console door the
+// customer walked through — and an Org door must never open onto the
+// Sovereign estate.
+
+package handler
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+// orgScopedTier is the tier stamped on an Org-scoped PIN session. It is
+// deliberately NOT one of the sovereign tiers (viewer/developer/operator/
+// admin/owner consumed by the sovereign-admin RBAC gates): an Org owner is
+// the top of THEIR org, but holds zero authority over the Sovereign. The
+// console reads tier=org-admin to render the scoped chrome; the API gate
+// (requireNotOrgScoped) reads it to 403 sovereign endpoints.
+//
+// Single source of truth: aliases auth.OrgScopedTier so the middleware's
+// owner-stamp guard (auth.stampSovereignOperatorClaim) and this package
+// agree on the exact marker string.
+const orgScopedTier = auth.OrgScopedTier
+
+// orgScopedRealmRole mirrors orgScopedTier in the realm_access.roles list
+// so the SPA's role-chip projection has something to show without ever
+// emitting catalyst-admin/catalyst-owner (which would light up the
+// sovereign nav). It is intentionally a NON-catalyst role name so no
+// existing sovereign-admin gate (which matches catalyst-*/sovereign-*)
+// ever accepts it.
+const orgScopedRealmRole = "org-admin"
+
+// orgScope is the resolved Org identity for a request host.
+type orgScope struct {
+	// Org is the Organization slug (e.g. "demo"). Stamped as the JWT `org`
+	// claim so downstream Org-scoped handlers (org_users.go etc.) and the
+	// console scope to this Org.
+	Org string
+	// TenantID is the opaque tenant id from the registry.
+	TenantID string
+	// Host is the resolved (lowercased, port-stripped) request host.
+	Host string
+}
+
+// resolveOrgScope reports whether the request arrived on a registered
+// Organization console host (tenant_kind=org) and, if so, returns the Org
+// scope. The second return is false for the Sovereign's own front door
+// (console.<sov-fqdn>) or any host the registry does not know — those keep
+// the existing sovereign-admin resolution path.
+//
+// Resolution:
+//  1. requestHost(r) — the real browser host via X-Forwarded-Host.
+//  2. tenant registry lookup. A tenant_kind=org match → Org scope.
+//
+// A host that is NOT in the registry, OR is registered as tenant_kind=otech
+// (the Sovereign's own console), is NOT Org-scoped.
+func (h *Handler) resolveOrgScope(r *http.Request) (orgScope, bool) {
+	if h == nil || h.tenantRegistry == nil {
+		return orgScope{}, false
+	}
+	host := requestHost(r)
+	if host == "" {
+		return orgScope{}, false
+	}
+	t, ok := h.tenantRegistry.Get(host)
+	if !ok || t.TenantKind != store.TenantKindOrg {
+		return orgScope{}, false
+	}
+	// The Org slug is the first label of the console host
+	// (console.<slug>.<zone>). Fall back to the tenant id when the host
+	// shape is unusual so the claim is never empty.
+	slug := orgSlugFromHost(host)
+	if slug == "" {
+		slug = t.TenantID
+	}
+	return orgScope{Org: slug, TenantID: t.TenantID, Host: host}, true
+}
+
+// orgSlugFromHost extracts the Org slug from a console host. For
+// "console.demo.omani.homes" it returns "demo" (the label after the
+// leading service label). Returns "" when the host has no recognisable
+// service label or too few labels to carry a slug.
+func orgSlugFromHost(host string) string {
+	host = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+	labels := strings.Split(host, ".")
+	if len(labels) < 3 {
+		return ""
+	}
+	switch labels[0] {
+	case "console", "api", "marketplace", "auth":
+		return labels[1]
+	}
+	return ""
+}
+
+// claimsAreOrgScoped reports whether a session is confined to a single
+// Organization (a customer session minted on an Org console host). Such a
+// session must never reach the Sovereign-admin or other-org surfaces.
+//
+// The marker is the dedicated tier value (orgScopedTier) carried in the
+// JWT. It is a single, unambiguous discriminant that survives the JWT
+// round-trip (the generic auth.Claims has no bool-marker field, but Tier
+// is a first-class claim already validated end-to-end). An Org-scoped
+// session ALWAYS carries tier=org-admin AND a non-empty Org.
+func claimsAreOrgScoped(claims *auth.Claims) bool {
+	if claims == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(claims.Tier), orgScopedTier)
+}
+
+// orgSafePathPrefixes is the DENY-BY-DEFAULT allowlist: the ONLY API path
+// prefixes an Org-scoped customer session may reach. Everything else under
+// the RequireSession group (deployments + deployment-stream, the whole-
+// cluster /sovereigns/{id}/k8s estate, BSS/billing/commerce, parent-domains,
+// the cross-org organizations directory, sovereign settings) is 403'd.
+//
+// Deny-by-default is the secure posture for a privilege-escalation fix: a
+// new sovereign-admin endpoint added later is locked to customers by
+// default and must be EXPLICITLY allowlisted here to reach an Org session —
+// the inverse of an allow-by-default block-list, which silently re-leaks on
+// every new route. Each entry below is an Org-OWN surface:
+//
+//   - /api/v1/whoami            — identity + scope (the SPA bootstrap)
+//   - /api/v1/auth/             — login/logout/session lifecycle
+//   - /api/v1/tenant/discover   — host→tenant bootstrap (public anyway)
+//   - /api/v1/org/users         — the Org's OWN users (scoped by X-Tenant-Host)
+//   - /api/v1/org/roles         — the Org's OWN role assignments
+//   - /api/v1/org/apps          — the Org's OWN application estate
+//   - /api/v1/org/applications  — alias of the above
+//   - /api/v1/org/self          — the Org's identity card
+//   - /api/v1/catalog           — the read-only blueprint catalog (browse)
+//   - /api/v1/sandbox/          — the Org's own Sandbox (scoped by sub/org)
+//
+// NOTE: BSS / billing / commerce / consumption / organizations-directory
+// are Sovereign-WIDE operator surfaces despite some carrying an `/org/`
+// path prefix — they are intentionally NOT allowlisted.
+var orgSafePathPrefixes = []string{
+	"/api/v1/whoami",
+	"/api/v1/auth/",
+	"/api/v1/tenant/discover",
+	"/api/v1/org/users",
+	"/api/v1/org/roles",
+	"/api/v1/org/apps",
+	"/api/v1/org/applications",
+	"/api/v1/org/self",
+	"/api/v1/catalog",
+	"/api/v1/sandbox/",
+	"/api/v1/sandbox",
+}
+
+// pathIsOrgSafe reports whether the request path is on the Org-scoped
+// allowlist. Matches an exact path or a path under an allowlisted prefix.
+func pathIsOrgSafe(p string) bool {
+	for _, pre := range orgSafePathPrefixes {
+		if p == pre || strings.HasPrefix(p, strings.TrimSuffix(pre, "/")+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// OrgScopeGuard is a chi-compatible middleware applied to the whole
+// RequireSession group in cmd/api/main.go. For a NON-Org-scoped session
+// (Sovereign-admin / operator) it is a transparent passthrough — zero
+// behaviour change. For an Org-scoped customer session it enforces the
+// deny-by-default allowlist: anything outside orgSafePathPrefixes is 403'd
+// (org-scoped-forbidden). RequireSession must run first so
+// auth.ClaimsFromContext is populated.
+//
+// Exposed as a method on *Handler so cmd/api/main.go installs it with
+// rg.Use(h.OrgScopeGuard) right after rg.Use(auth.RequireSession(...)).
+func (h *Handler) OrgScopeGuard(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// OPTIONS pre-flights pass through (CORS).
+		if r.Method == http.MethodOptions {
+			next.ServeHTTP(w, r)
+			return
+		}
+		claims := auth.ClaimsFromContext(r.Context())
+		// Non-Org sessions are unaffected — full Sovereign-admin surface.
+		if !claimsAreOrgScoped(claims) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		// Org-scoped customer session: deny-by-default outside the allowlist.
+		if pathIsOrgSafe(r.URL.Path) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		writeJSON(w, http.StatusForbidden, map[string]string{
+			"error":  "org-scoped-forbidden",
+			"detail": "this Organization session has no access to Sovereign-admin or cross-organization resources",
+		})
+	})
+}

--- a/products/catalyst/bootstrap/api/internal/handler/org_scope.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_scope.go
@@ -169,10 +169,22 @@ func claimsAreOrgScoped(claims *auth.Claims) bool {
 //   - /api/v1/org/self          — the Org's identity card
 //   - /api/v1/catalog           — the read-only blueprint catalog (browse)
 //   - /api/v1/sandbox/          — the Org's own Sandbox (scoped by sub/org)
+//   - /api/v1/sovereign/self    — self-discovery (deployment id + FQDN) the
+//                                 SovereignConsoleLayout + Apps page bootstrap
+//                                 read; carries no per-org secrets.
+//   - /api/v1/sovereign/apps    — the Apps grid feed. This is the blueprint
+//                                 CATALOG + per-app install status + launch URL
+//                                 (NOT another Org's secrets/resources); the
+//                                 Org console needs it to render its Apps page
+//                                 incl. the agenity Open link. A true per-Org
+//                                 apps PROJECTION (filtering to the Org's own
+//                                 namespaces + vClusters) is the #4113 follow-up.
 //
-// NOTE: BSS / billing / commerce / consumption / organizations-directory
-// are Sovereign-WIDE operator surfaces despite some carrying an `/org/`
-// path prefix — they are intentionally NOT allowlisted.
+// NOTE: BSS / billing / commerce / consumption / organizations-directory /
+// the deployments API / the whole-cluster /sovereigns/{id}/k8s estate /
+// parent-domains are Sovereign-WIDE operator surfaces (some despite an
+// `/org/` path prefix) — they are intentionally NOT allowlisted and 403 for
+// an Org session.
 var orgSafePathPrefixes = []string{
 	"/api/v1/whoami",
 	"/api/v1/auth/",
@@ -185,6 +197,8 @@ var orgSafePathPrefixes = []string{
 	"/api/v1/catalog",
 	"/api/v1/sandbox/",
 	"/api/v1/sandbox",
+	"/api/v1/sovereign/self",
+	"/api/v1/sovereign/apps",
 }
 
 // pathIsOrgSafe reports whether the request path is on the Org-scoped

--- a/products/catalyst/bootstrap/api/internal/handler/org_scope_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_scope_test.go
@@ -57,6 +57,8 @@ func TestPathIsOrgSafe(t *testing.T) {
 		"/api/v1/catalog",
 		"/api/v1/catalog/bp-agenity",
 		"/api/v1/sandbox/sessions",
+		"/api/v1/sovereign/apps",
+		"/api/v1/sovereign/self",
 	}
 	for _, p := range safe {
 		if !pathIsOrgSafe(p) {

--- a/products/catalyst/bootstrap/api/internal/handler/org_scope_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_scope_test.go
@@ -1,0 +1,166 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+func TestOrgSlugFromHost(t *testing.T) {
+	cases := []struct {
+		host string
+		want string
+	}{
+		{"console.demo.omani.homes", "demo"},
+		{"api.demo.omani.homes", "demo"},
+		{"marketplace.acme.omani.rest", "acme"},
+		{"console.omantel.biz", "omantel"}, // resolved against registry, not slug-trusted
+		{"demo.omani.homes", ""},           // no service label
+		{"omani.homes", ""},                // too short
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := orgSlugFromHost(c.host); got != c.want {
+			t.Errorf("orgSlugFromHost(%q) = %q, want %q", c.host, got, c.want)
+		}
+	}
+}
+
+func TestClaimsAreOrgScoped(t *testing.T) {
+	if claimsAreOrgScoped(nil) {
+		t.Fatal("nil claims must not be org-scoped")
+	}
+	if claimsAreOrgScoped(&auth.Claims{Tier: "owner"}) {
+		t.Fatal("owner tier must not be org-scoped")
+	}
+	if claimsAreOrgScoped(&auth.Claims{Tier: "admin"}) {
+		t.Fatal("admin tier must not be org-scoped")
+	}
+	if !claimsAreOrgScoped(&auth.Claims{Tier: orgScopedTier}) {
+		t.Fatal("org-admin tier must be org-scoped")
+	}
+	if !claimsAreOrgScoped(&auth.Claims{Tier: "ORG-ADMIN"}) {
+		t.Fatal("org-scoped tier match must be case-insensitive")
+	}
+}
+
+func TestPathIsOrgSafe(t *testing.T) {
+	safe := []string{
+		"/api/v1/whoami",
+		"/api/v1/auth/session",
+		"/api/v1/org/users",
+		"/api/v1/org/users/abc",
+		"/api/v1/catalog",
+		"/api/v1/catalog/bp-agenity",
+		"/api/v1/sandbox/sessions",
+	}
+	for _, p := range safe {
+		if !pathIsOrgSafe(p) {
+			t.Errorf("expected %q to be Org-safe", p)
+		}
+	}
+	unsafe := []string{
+		"/api/v1/deployments",
+		"/api/v1/deployments/4635277cae4ffed9",
+		"/api/v1/deployments/4635277cae4ffed9/logs",
+		"/api/v1/sovereigns/abc/k8s/pods",
+		"/api/v1/org/bss/overview",
+		"/api/v1/org/billing/revenue",
+		"/api/v1/organizations",
+		"/api/v1/parent-domains",
+		"/api/v1/org/commerce/plans",
+	}
+	for _, p := range unsafe {
+		if pathIsOrgSafe(p) {
+			t.Errorf("expected %q to be DENIED (not Org-safe)", p)
+		}
+	}
+}
+
+// orgScopeGuardTestHandler is the protected target the guard wraps.
+func orgScopeGuardTestHandler(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"ok":true}`))
+}
+
+func TestOrgScopeGuard_SovereignAdmin_Passthrough(t *testing.T) {
+	h := &Handler{log: quietLog()}
+	guard := h.OrgScopeGuard(http.HandlerFunc(orgScopeGuardTestHandler))
+
+	// Sovereign-admin (owner) session reaches a sovereign-only endpoint.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/deployments/4635277cae4ffed9", nil)
+	req = req.WithContext(context.WithValue(req.Context(), auth.ClaimsKey,
+		&auth.Claims{Email: "emrah.baysal@openova.io", Tier: "owner"}))
+	rec := httptest.NewRecorder()
+	guard.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("owner must pass deployments endpoint, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestOrgScopeGuard_OrgScoped_DeniesSovereignEndpoint(t *testing.T) {
+	h := &Handler{log: quietLog()}
+	guard := h.OrgScopeGuard(http.HandlerFunc(orgScopeGuardTestHandler))
+
+	// Org-scoped customer session hits the deployments API — must 403.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/deployments/4635277cae4ffed9", nil)
+	req = req.WithContext(context.WithValue(req.Context(), auth.ClaimsKey,
+		&auth.Claims{Email: "demo@openova.io", Tier: orgScopedTier, Org: "demo"}))
+	rec := httptest.NewRecorder()
+	guard.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("org-scoped session must be 403'd on deployments, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestOrgScopeGuard_OrgScoped_AllowsOwnSurface(t *testing.T) {
+	h := &Handler{log: quietLog()}
+	guard := h.OrgScopeGuard(http.HandlerFunc(orgScopeGuardTestHandler))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/whoami", nil)
+	req = req.WithContext(context.WithValue(req.Context(), auth.ClaimsKey,
+		&auth.Claims{Email: "demo@openova.io", Tier: orgScopedTier, Org: "demo"}))
+	rec := httptest.NewRecorder()
+	guard.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("org-scoped session must reach whoami, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestResolveOrgScope_OrgHost(t *testing.T) {
+	dir := t.TempDir()
+	reg, err := store.NewTenantRegistry(dir)
+	if err != nil {
+		t.Fatalf("new registry: %v", err)
+	}
+	if err := reg.Put(store.TenantRegistration{
+		Host:       "console.demo.omani.homes",
+		TenantID:   "7283eb4a",
+		TenantKind: store.TenantKindOrg,
+	}); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	h := &Handler{log: quietLog(), tenantRegistry: reg}
+
+	// Org host → Org scope.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/pin/verify", nil)
+	req.Header.Set("X-Forwarded-Host", "console.demo.omani.homes")
+	scope, ok := h.resolveOrgScope(req)
+	if !ok {
+		t.Fatal("expected Org scope for console.demo.omani.homes")
+	}
+	if scope.Org != "demo" {
+		t.Fatalf("scope.Org = %q, want demo", scope.Org)
+	}
+
+	// Unknown host (the Sovereign's own front door) → no Org scope.
+	req2 := httptest.NewRequest(http.MethodPost, "/api/v1/auth/pin/verify", nil)
+	req2.Header.Set("X-Forwarded-Host", "console.omantel.biz")
+	if _, ok := h.resolveOrgScope(req2); ok {
+		t.Fatal("Sovereign front door must NOT resolve to an Org scope")
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/org_users.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_users.go
@@ -60,6 +60,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/newapi"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
 )
@@ -158,6 +159,24 @@ func (h *Handler) resolveOrganization(w http.ResponseWriter, r *http.Request) (s
 			"detail": "endpoint is restricted to tenant_kind=org; got " + string(t.TenantKind),
 		})
 		return store.TenantRegistration{}, false
+	}
+	// #4110 — cross-org binding. An Org-scoped customer session may only
+	// resolve to its OWN Organization. X-Tenant-Host is a client-supplied
+	// header; a malicious customer could forge a sibling org's host to read
+	// another Organization's users/roles. Bind the resolved tenant to the
+	// session's `org` claim (stamped from the request host at PIN-verify,
+	// which the customer cannot forge). A Sovereign-admin session has no
+	// org claim and is unaffected (it may legitimately operate any Org).
+	if claims := auth.ClaimsFromContext(r.Context()); claimsAreOrgScoped(claims) {
+		sessionOrg := strings.ToLower(strings.TrimSpace(claims.Org))
+		resolvedSlug := strings.ToLower(strings.TrimSpace(orgSlugFromHost(host)))
+		if sessionOrg != "" && resolvedSlug != "" && sessionOrg != resolvedSlug {
+			writeJSON(w, http.StatusForbidden, map[string]string{
+				"error":  "org-scope-mismatch",
+				"detail": "this Organization session may only access its own Organization",
+			})
+			return store.TenantRegistration{}, false
+		}
 	}
 	return t, true
 }

--- a/products/catalyst/bootstrap/ui/src/app/layouts/SovereignConsoleLayout.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/layouts/SovereignConsoleLayout.tsx
@@ -102,6 +102,39 @@ interface WhoamiClaims {
   email: string
   sub: string
   verified: boolean
+  // #4110 — Org-console scope. When orgScoped is true the session is a
+  // customer confined to one Organization (minted on console.<org>.<pool>);
+  // the layout redirects away from any Sovereign-admin path.
+  orgScoped?: boolean
+  org?: string
+}
+
+/**
+ * #4110 — Sovereign-admin path prefixes an Org-scoped customer session must
+ * never reach. A deep-link / stale bookmark to any of these on an Org
+ * console is redirected to /apps (the Org's own estate landing). The
+ * catalyst-api ALSO 403s the underlying data calls, so this redirect is the
+ * UX half of the hide-AND-enforce contract — never the only guard.
+ *
+ * Allowed for an Org session (NOT in this list): /apps, /catalog, /sandbox,
+ * /users, /settings, /login, /auth/*.
+ */
+const SOVEREIGN_ONLY_PATH_RES: readonly RegExp[] = [
+  /^\/dashboard(\/|$)/,
+  /^\/cloud(\/|$)/,
+  /^\/infrastructure(\/|$)/,
+  /^\/jobs(\/|$)/,
+  /^\/organizations(\/|$)/,
+  /^\/(sre|sec)\/compliance(\/|$)/,
+  /^\/compliance(\/|$)/,
+  /^\/provision(\/|$)/,
+  /^\/deployments(\/|$)/,
+  /^\/decommission(\/|$)/,
+  /^\/sovereignty(\/|$)/,
+]
+
+function pathIsSovereignOnly(p: string): boolean {
+  return SOVEREIGN_ONLY_PATH_RES.some((re) => re.test(p))
 }
 
 /**
@@ -229,6 +262,22 @@ export function SovereignConsoleLayout() {
 
     void initAuth()
   }, [sovereignFQDN])
+
+  // #4110 — Org-console scope redirect. When the resolved session is an
+  // Org-scoped customer session and the operator has deep-linked / bookmarked
+  // a Sovereign-admin path (the provisioning wizard, deployment-stream,
+  // cloud view, the cross-org directory, sovereign settings groups), bounce
+  // them to /apps (their own estate). The catalyst-api 403s the data behind
+  // those pages too — this is the UX redirect, not the security boundary.
+  useEffect(() => {
+    if (authState.status !== 'cookie-authenticated') return
+    if (!authState.claims.orgScoped) return
+    if (typeof window === 'undefined') return
+    const here = currentPathRelativeToBasepath()
+    if (pathIsSovereignOnly(here)) {
+      window.location.replace(`${uiBase()}/apps`)
+    }
+  }, [authState])
 
   function handleRequiredActionsComplete(tokens: TokenSet) {
     setAuthState({ status: 'authenticated', tokens, requiredActions: [] })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.orgscope.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.orgscope.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * SovereignSidebar.orgscope.test.tsx — #4110 Org-console scoping.
+ *
+ * Asserts that an Org-scoped customer session sees ONLY its own-estate nav
+ * (Apps / Catalog / Sandbox / Users / Settings) and NONE of the sovereign-
+ * admin nav (Dashboard / Cloud / Jobs / Compliance / Organizations), while
+ * a Sovereign-admin session still sees the full nav (zero regression).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+
+// Mock the scope hook so the test drives orgScoped directly.
+const scopeMock = vi.fn()
+vi.mock('@/shared/lib/useConsoleScope', () => ({
+  useConsoleScope: () => scopeMock(),
+}))
+// Dynamic blueprint sidebar entries — irrelevant here; return empty.
+vi.mock('@/lib/console-ui.api', () => ({
+  getSidebarEntries: async () => [],
+}))
+vi.mock('@/shared/lib/useResolvedDeploymentId', () => ({
+  useResolvedDeploymentId: () => ({ deploymentId: '' }),
+}))
+
+import { SovereignSidebar } from './SovereignSidebar'
+
+function renderSidebar() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const host = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/apps',
+    component: () => <SovereignSidebar sovereignFQDN="demo.omani.homes" />,
+  })
+  const catchAll = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/$',
+    component: () => <SovereignSidebar sovereignFQDN="demo.omani.homes" />,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([host, catchAll]),
+    history: createMemoryHistory({ initialEntries: ['/apps'] }),
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router as never} />
+    </QueryClientProvider>,
+  )
+}
+
+describe('SovereignSidebar — #4110 Org-console scope', () => {
+  beforeEach(() => scopeMock.mockReset())
+  afterEach(() => cleanup())
+
+  it('Org-scoped session hides every sovereign-admin nav item', async () => {
+    scopeMock.mockReturnValue({ orgScoped: true, org: 'demo', loading: false })
+    renderSidebar()
+    // Own-estate nav present.
+    expect(await screen.findByTestId('sov-console-nav-apps')).toBeTruthy()
+    expect(screen.getByTestId('sov-console-nav-catalog')).toBeTruthy()
+    expect(screen.getByTestId('sov-console-nav-sandbox')).toBeTruthy()
+    expect(screen.getByTestId('sov-console-nav-users')).toBeTruthy()
+    expect(screen.getByTestId('sov-console-nav-settings')).toBeTruthy()
+    // Sovereign-admin nav HIDDEN.
+    expect(screen.queryByTestId('sov-console-nav-dashboard')).toBeNull()
+    expect(screen.queryByTestId('sov-console-nav-cloud')).toBeNull()
+    expect(screen.queryByTestId('sov-console-nav-jobs')).toBeNull()
+    expect(screen.queryByTestId('sov-console-nav-compliance')).toBeNull()
+    expect(screen.queryByTestId('sov-console-nav-organizations')).toBeNull()
+  })
+
+  it('Sovereign-admin session shows the full nav (zero regression)', async () => {
+    scopeMock.mockReturnValue({ orgScoped: false, org: null, loading: false })
+    renderSidebar()
+    expect(await screen.findByTestId('sov-console-nav-dashboard')).toBeTruthy()
+    expect(screen.getByTestId('sov-console-nav-cloud')).toBeTruthy()
+    expect(screen.getByTestId('sov-console-nav-jobs')).toBeTruthy()
+    expect(screen.getByTestId('sov-console-nav-organizations')).toBeTruthy()
+    expect(screen.getByTestId('sov-console-nav-apps')).toBeTruthy()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
@@ -26,7 +26,22 @@ import { useQuery } from '@tanstack/react-query'
 import { loadTokens, parseJWTClaims } from '@/shared/lib/oidc'
 import { DETECTED_MODE } from '@/shared/lib/detectMode'
 import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
+import { useConsoleScope } from '@/shared/lib/useConsoleScope'
 import { getSidebarEntries, type SidebarEntry } from '@/lib/console-ui.api'
+
+// #4110 — the ONLY nav items an Org-scoped customer console may show. The
+// customer sees their OWN estate (apps + catalog browse + sandbox + their
+// users) and their OWN settings; every sovereign-admin surface (Dashboard
+// fleet/treemap, the whole-cluster Cloud view, provisioning Jobs, the
+// Sovereign Compliance dashboards, the cross-org Organizations directory)
+// is hidden. Settings is handled separately (rendered after FLAT_NAV) and
+// is allowed for an Org session — it shows only the Org's own settings.
+const ORG_SCOPED_NAV_IDS: ReadonlySet<FlatNavItem['id']> = new Set([
+  'apps',
+  'catalog',
+  'sandbox',
+  'users',
+])
 
 interface SovereignSidebarProps {
   /** Sovereign FQDN derived from window.location.hostname. */
@@ -223,6 +238,17 @@ export function SovereignSidebar({ sovereignFQDN }: SovereignSidebarProps) {
   const pathname = useRouterState({ select: (s) => s.location.pathname })
   const activeSection = deriveActiveSection(pathname)
 
+  // #4110 — Org-console scoping. When the backend reports an Org-scoped
+  // session (whoami.orgScoped), filter the nav to the Org-safe items only.
+  // Fail safe: while the scope is still loading we render the FULL nav for a
+  // Sovereign-admin (the common case) but treat an explicit orgScoped=true
+  // as the authoritative trigger to hide. The catalyst-api 403s the hidden
+  // surfaces regardless, so a momentary nav flash can never be acted on.
+  const { orgScoped } = useConsoleScope()
+  const navItems = orgScoped
+    ? FLAT_NAV.filter((item) => ORG_SCOPED_NAV_IDS.has(item.id))
+    : FLAT_NAV
+
   // Wave 5.69c (#2396) — dynamic sidebar entries from installed
   // Blueprints' spec.consoleUI.sidebarEntry (Wave 5.69 CRD + Wave
   // 5.69b /console-ui/sidebar-entries handler). Splices into the
@@ -354,7 +380,7 @@ export function SovereignSidebar({ sovereignFQDN }: SovereignSidebarProps) {
             the mark place mutst be just aotnerh menu under console
             like https://console.<sov>/bss". The BSS group below is the
             new canonical surface (in-SPA, RBAC-gated, no external tab). */}
-        {FLAT_NAV.map((item) => {
+        {navItems.map((item) => {
           const isActive = activeSection === item.id
           const cls = isActive
             ? 'bg-[var(--color-accent)]/10 text-[var(--color-accent)]'
@@ -375,8 +401,10 @@ export function SovereignSidebar({ sovereignFQDN }: SovereignSidebarProps) {
 
         {/* Wave 5.69c (#2396) dynamic sidebar entries — Blueprints
             opted in via spec.consoleUI.sidebarEntry=true. Rendered
-            between hardcoded FLAT_NAV and pinned Settings. */}
-        {dynamicEntries.map((entry) => {
+            between hardcoded FLAT_NAV and pinned Settings.
+            #4110: suppressed on an Org-scoped console (these are
+            Sovereign-level Blueprint nav entries). */}
+        {(orgScoped ? [] : dynamicEntries).map((entry) => {
           const isActive = pathname.startsWith(entry.route)
           const cls = isActive
             ? 'bg-[var(--color-accent)]/10 text-[var(--color-accent)]'

--- a/products/catalyst/bootstrap/ui/src/shared/lib/useConsoleScope.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/lib/useConsoleScope.ts
@@ -1,0 +1,73 @@
+/**
+ * useConsoleScope — resolves whether the current Sovereign Console session
+ * is an Org-scoped customer session vs a Sovereign-admin/operator session
+ * (#4110).
+ *
+ * THE SECURITY CONTEXT: the same catalyst-ui bundle is served on BOTH the
+ * Sovereign's own front door (console.<sov-fqdn>, e.g. console.omantel.biz)
+ * AND every Org pool-domain console (console.<org>.<pool-zone>, e.g.
+ * console.demo.omani.homes). detectMode() can't tell them apart (both strip
+ * a leading `console.`), so the SPA used to render the FULL sovereign-admin
+ * console — provisioning wizard, deployment-stream, every Org, cloud view,
+ * sovereign DNS/parent-domain/BSS settings — on an Org console too. A
+ * customer thus saw god-mode (live privilege escalation on omantel.biz).
+ *
+ * The authoritative scope comes from the BACKEND: GET /api/v1/whoami now
+ * returns `orgScoped: true` + `org: "<slug>"` when the session was minted on
+ * an Org console host (catalyst-api stamps the PIN session Org-scoped from
+ * the request host — auth.go HandlePinVerify + org_scope.go). The SPA reads
+ * that flag to render the scoped chrome and hide the sovereign-admin
+ * surfaces. The backend ALSO 403s those surfaces, so this is defense-in-
+ * depth (hide AND enforce), not UI-only hiding.
+ *
+ * Returns:
+ *   - orgScoped — true when the session is confined to one Organization.
+ *   - org       — the Organization slug (e.g. "demo") when orgScoped.
+ *   - loading   — true on first fetch (treat as NOT-yet-known; callers that
+ *                 must fail safe should render the scoped/minimal view while
+ *                 loading rather than flashing the admin nav).
+ */
+
+import { useQuery } from '@tanstack/react-query'
+import { API_BASE } from '@/shared/config/urls'
+
+interface WhoamiScopeResponse {
+  orgScoped?: boolean
+  org?: string
+}
+
+export interface ConsoleScope {
+  orgScoped: boolean
+  org: string | null
+  loading: boolean
+}
+
+const CONSOLE_SCOPE_QUERY_KEY = ['catalyst', 'console-scope', 'whoami'] as const
+
+async function fetchConsoleScope(): Promise<WhoamiScopeResponse | null> {
+  const res = await fetch(`${API_BASE}/v1/whoami`, {
+    method: 'GET',
+    credentials: 'include',
+    headers: { Accept: 'application/json' },
+  })
+  if (res.status === 401) return null
+  if (!res.ok) throw new Error(`whoami: HTTP ${res.status}`)
+  return (await res.json()) as WhoamiScopeResponse
+}
+
+export function useConsoleScope(): ConsoleScope {
+  const q = useQuery({
+    queryKey: CONSOLE_SCOPE_QUERY_KEY,
+    queryFn: fetchConsoleScope,
+    refetchOnWindowFocus: false,
+    retry: 1,
+    staleTime: 60_000,
+    networkMode: 'always',
+  })
+  const data = q.data ?? null
+  return {
+    orgScoped: data?.orgScoped === true,
+    org: data?.org ?? null,
+    loading: q.isLoading,
+  }
+}


### PR DESCRIPTION
## What

Closes the live privilege-escalation bug (#4110) where a customer logging into their Org pool-domain console (`console.<org>.<pool-zone>`, e.g. `console.demo.omani.homes`) was minted the SAME sovereign-admin session as the operator on the Sovereign's own front door — full god-mode (provisioning wizard, the Sovereign's own deployment-stream, every Org, cloud view, sovereign DNS/parent-domain/BSS settings). Live on omantel.biz dep `4635277cae4ffed9`.

## Root cause

- `internal/handler/auth.go` `pinSessionAuthority()` derived the PIN tier purely from the SOVEREIGN realm's `/sovereign-admins` membership and **ignored the request host**; no Org scope was ever stamped.
- `ui/src/shared/lib/detectMode.ts` treated `console.demo.omani.homes` identically to `console.omantel.biz` (both → `mode:'sovereign'`); the SPA rendered the full sovereign-admin console on an Org console.
- No host/Org authorization on the sovereign-admin API endpoints.

## Fix (hide AND enforce, both layers)

**Backend**
- `HandlePinVerify` resolves the request host against the tenant registry; a `tenant_kind=org` host **forces** an Org-scoped session (`tier=org-admin` + org slug, never `catalyst-admin`/`sovereign-admin`), regardless of `/sovereign-admins`. The host (set by the Cilium Gateway via `X-Forwarded-Host`) is the trust anchor a customer cannot forge.
- `OrgScopeGuard` middleware on the `RequireSession` group: transparent passthrough for sovereign-admin sessions (zero regression); **deny-by-default allowlist** for Org-scoped sessions → 403 `org-scoped-forbidden` on the deployments API, the whole-cluster estate, BSS/billing, parent-domains, the cross-org directory, sovereign settings.
- `resolveOrganization()` binds an Org session to its own Org (forged `X-Tenant-Host` → 403 `org-scope-mismatch`).
- `auth/middleware.go`: the `OPERATOR_EMAIL` owner-stamp never upgrades an Org-scoped session.
- `whoami` exposes `orgScoped` + `org`.

**Frontend**
- `useConsoleScope` hook (reads `whoami.orgScoped`).
- `SovereignSidebar` filters to the own-estate nav (Apps/Catalog/Sandbox/Users/Settings) when Org-scoped.
- `SovereignConsoleLayout` redirects an Org session off any sovereign-admin deep-link to `/apps`.

## Tests
- `org_scope_test.go` — slug derivation, path allowlist, guard 403 vs passthrough, host resolution.
- `SovereignSidebar.orgscope.test.tsx` — Org nav filter + Sovereign-admin zero-regression.
- Full `go test ./internal/handler ./internal/auth` green; `tsc --noEmit` + eslint clean.

## Deploy
This rides a coordinated catalyst-api + catalyst-ui roll (the orchestrator owns rolls). Builds on the #4104 login fix already live on `6b22cba`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)