### PR TITLE
fix(agenity): make the chat->provision North Star work live — MCP stdio framing + handover key alignment + claude-code runtime (#4111 #4114)

### DIFF
--- a/products/agenity/Containerfile
+++ b/products/agenity/Containerfile
@@ -110,6 +110,31 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Graphify (#725) — daemon-central codebase knowledge-graph plugin. Pinned.
 RUN pip3 install --no-cache-dir graphifyy==0.8.35
 
+# ── Agent runtime: node + claude-code (#4111) ──────────────────────────────
+# The bp-agenity image is the chepherd *daemon*; the separate chepherd-agent
+# image (Dockerfile.agent) carries the agent CLIs but is NOT loaded in-pod on
+# a Sovereign (no /agent-image.tar mount, no AGENT_IMAGE_REF), so chepherd
+# falls back to BareExecRuntime and forks the agent CLI directly on THIS host.
+# Without claude-code on the host, the solo agent cannot run at all —
+# spawning fails before any model call. Bake node 22 + the claude-code CLI in
+# at /usr/bin/claude (the path internal/ptyhost/agentcatalog expects) so a
+# BareExec spawn of the `claude-code` flavor works out of the box. node 22 is
+# the floor for the modern agent CLIs (#741). Pinned for reproducibility.
+ARG NODE_VERSION=22.14.0
+ARG CLAUDE_CODE_VERSION=2.1.185
+RUN curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz" \
+      -o /tmp/node.tar.gz \
+ && mkdir -p /opt/node \
+ && tar -xzf /tmp/node.tar.gz -C /opt/node --strip-components=1 \
+ && rm /tmp/node.tar.gz \
+ && ln -sf /opt/node/bin/node /usr/local/bin/node \
+ && ln -sf /opt/node/bin/npm  /usr/local/bin/npm \
+ && ln -sf /opt/node/bin/npx  /usr/local/bin/npx \
+ && npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+ # agentcatalog's claude-code row expects the binary at /usr/bin/claude.
+ && ln -sf /opt/node/bin/claude /usr/bin/claude \
+ && /usr/bin/claude --version
+
 # Non-root user for the chepherd process itself.
 RUN useradd -m -u 1000 -s /bin/bash chepherd \
     && mkdir -p /app/web /home/chepherd/.local/state/chepherd /home/chepherd/.local/share \

--- a/products/agenity/blueprint.yaml
+++ b/products/agenity/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.2.0
+  version: 0.3.0
   card:
     title: Agenity
     summary: |

--- a/products/agenity/chart/Chart.yaml
+++ b/products/agenity/chart/Chart.yaml
@@ -8,7 +8,7 @@ description: |
   (RBAC-scoped to the User's rights) to create more Applications in the
   User's own Organization — the north-star self-service journey.
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "0.9.4"
 keywords:
   - agenity

--- a/products/agenity/chart/templates/externalsecret-anthropic.yaml
+++ b/products/agenity/chart/templates/externalsecret-anthropic.yaml
@@ -27,4 +27,14 @@ spec:
       remoteRef:
         key: {{ .Values.anthropic.externalSecret.remoteKey }}
         property: {{ .Values.anthropic.externalSecret.remoteProperty }}
+    {{- if and .Values.anthropic.credentialsKey .Values.anthropic.externalSecret.remoteCredentialsProperty }}
+    # Full claude-code credentials.json blob (#4111) — the OAuth pair the
+    # spawned agent needs. ExternalSecret pulls it as an optional property so
+    # an openbao path that only has the bare token still renders (the agent
+    # then has no OAuth file and the operator must supply credentialsJson).
+    - secretKey: {{ .Values.anthropic.credentialsKey }}
+      remoteRef:
+        key: {{ .Values.anthropic.externalSecret.remoteKey }}
+        property: {{ .Values.anthropic.externalSecret.remoteCredentialsProperty }}
+    {{- end }}
 {{- end }}

--- a/products/agenity/chart/templates/statefulset.yaml
+++ b/products/agenity/chart/templates/statefulset.yaml
@@ -35,6 +35,46 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.anthropic.credentialsKey }}
+      initContainers:
+        # ── Seed claude-code OAuth credentials (#4111) ──────────────────────
+        # The spawned claude-code (BareExec) reads ~/.claude/.credentials.json
+        # on the chepherd host. Materialize it from the Secret's full
+        # credentials.json blob into a shared emptyDir mounted at
+        # /home/chepherd/.claude (writable so claude-code can rotate the OAuth
+        # pair). No-op when the Secret lacks the credentials key (key-only
+        # mode). Runs as uid 1000 to match the chepherd user the agent forks
+        # as. The Secret is mounted read-only at /creds.
+        - name: seed-claude-creds
+          image: {{ include "agenity.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              mkdir -p /claudehome/.claude/projects
+              if [ -s /creds/{{ .Values.anthropic.credentialsKey }} ]; then
+                cp /creds/{{ .Values.anthropic.credentialsKey }} /claudehome/.claude/.credentials.json
+                chmod 600 /claudehome/.claude/.credentials.json
+                echo "seeded ~/.claude/.credentials.json ($(wc -c < /claudehome/.claude/.credentials.json) bytes)"
+              else
+                echo "no credentials.json key in Secret — key-only mode"
+              fi
+              # Onboarding stub so claude-code does not re-run the first-run
+              # /login flow and auto-approves Bypass-permissions.
+              printf '%s' '{"hasCompletedOnboarding":true,"autoPermissionsNotificationCount":99}' > /claudehome/.claude.json
+              chmod 644 /claudehome/.claude.json
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+          volumeMounts:
+            - name: claude-home
+              mountPath: /claudehome
+            - name: anthropic-creds
+              mountPath: /creds
+              readOnly: true
+      {{- end }}
       containers:
         - name: chepherd
           image: {{ include "agenity.image" . }}
@@ -79,17 +119,30 @@ spec:
             # chepherd's own. The agent then calls create_application etc. on
             # the User's Org, RBAC-scoped (the openova MCP forwards the
             # caller's session bearer to the live catalyst-api).
+            {{- $apiURL := .Values.openovaMCP.catalystApiUrl }}
+            {{- if not $apiURL }}{{ $apiURL = printf "https://console.%s" (.Values.sovereignFqdn | default "openova.io") }}{{- end }}
             - name: CHEPHERD_EXTRA_MCP_JSON
               value: |-
                 {"mcpServers":{"openova":{
                   "command":{{ .Values.openovaMCP.binaryPath | quote }},
                   "env":{
-                    "OPENOVA_MCP_CATALYST_API_URL":{{ .Values.openovaMCP.catalystApiUrl | quote }},
+                    "OPENOVA_MCP_CATALYST_API_URL":{{ $apiURL | quote }},
                     "OPENOVA_MCP_CONTEXT":{{ .Values.openovaMCP.context | quote }},
                     "OPENOVA_MCP_VERIFY":{{ .Values.openovaMCP.verify | quote }},
-                    "OPENOVA_MCP_RS256_PUBKEY_PEM":"$(OPENOVA_MCP_RS256_PUBKEY_PEM)"
+                    "OPENOVA_MCP_RS256_PUBKEY_PEM":"$(OPENOVA_MCP_RS256_PUBKEY_PEM)"{{ if .Values.openovaMCP.bearerSecret.name }},
+                    "OPENOVA_MCP_BEARER":"$(OPENOVA_MCP_BEARER)"{{ end }}
                   }
                 }}}
+            {{- if .Values.openovaMCP.bearerSecret.name }}
+            # Interim per-call bearer (#4111) — an admin-tier, Org-pinned,
+            # handover-RS256-signed session JWT the MCP forwards to the
+            # catalyst-api. Production seam is the chat UI per-call _auth.token.
+            - name: OPENOVA_MCP_BEARER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.openovaMCP.bearerSecret.name }}
+                  key: {{ .Values.openovaMCP.bearerSecret.key }}
+            {{- end }}
             {{- if eq .Values.openovaMCP.verify "rs256" }}
             # The RS256 public key the MCP verifies caller bearers against,
             # reflected from the Sovereign's handover-jwt secret. Surfaced as
@@ -109,6 +162,16 @@ spec:
               mountPath: /var/chepherd/state
             - name: repo
               mountPath: /var/chepherd/repo
+            {{- if .Values.anthropic.credentialsKey }}
+            # claude-code reads ~/.claude/.credentials.json + ~/.claude.json;
+            # the init container seeded them into this writable emptyDir (#4111).
+            - name: claude-home
+              mountPath: /home/chepherd/.claude
+              subPath: .claude
+            - name: claude-home
+              mountPath: /home/chepherd/.claude.json
+              subPath: .claude.json
+            {{- end }}
             {{- if .Values.podman.inPod }}
             - name: fuse
               mountPath: /dev/fuse
@@ -142,6 +205,16 @@ spec:
           emptyDir: {}
         - name: repo
           emptyDir: {}
+        {{- end }}
+        {{- if .Values.anthropic.credentialsKey }}
+        # Writable home for claude-code creds/onboarding, seeded by the
+        # init container from the anthropic Secret (#4111).
+        - name: claude-home
+          emptyDir: {}
+        - name: anthropic-creds
+          secret:
+            secretName: {{ .Values.anthropic.secretName }}
+            optional: true
         {{- end }}
         {{- if .Values.podman.inPod }}
         - name: fuse

--- a/products/agenity/chart/values.yaml
+++ b/products/agenity/chart/values.yaml
@@ -13,6 +13,11 @@
 # flows through values → env → the runtime daemon; the Anthropic token
 # comes from a Secret (ExternalSecret/openbao), NEVER a literal here.
 
+# Sovereign primary FQDN (e.g. omantel.biz). Used to derive the public
+# console URL the openova MCP forwards calls to when openovaMCP.catalystApiUrl
+# is empty (#4111). The provisioning/install path stamps this per-Sovereign.
+sovereignFqdn: ""
+
 # ── Agenity runtime image (upstream chepherd daemon + openova-mcp) ─────────
 image:
   repository: ghcr.io/openova-io/bp-agenity
@@ -45,6 +50,18 @@ agent:
 anthropic:
   secretName: agenity-anthropic-token
   secretKey: anthropicApiKey
+  # ── claude-code OAuth credentials (#4111) ───────────────────────────────
+  # The spawned claude-code agent authenticates via a FULL credentials.json
+  # ({claudeAiOauth:{accessToken,refreshToken,expiresAt,scopes}}), NOT a bare
+  # ANTHROPIC_API_KEY — an OAuth token (sk-ant-oat01-…) in ANTHROPIC_API_KEY
+  # is rejected by claude-code, and the chepherd spawn path strips
+  # ANTHROPIC_API_KEY anyway. chepherd resolves claude-code creds from
+  # ~/.claude/.credentials.json on the chepherd host (BareExec) or the vault
+  # claude-oauth provider. When credentialsKey is present in the Secret, the
+  # chart's init container seeds ~/.claude/.credentials.json from it so the
+  # solo agent can call Claude. Empty = key-only mode (only works for a real
+  # sk-ant-api03 API key, which the OAuth journey does not use).
+  credentialsKey: credentialsJson
   externalSecret:
     enabled: true
     refreshInterval: 1h
@@ -54,6 +71,8 @@ anthropic:
     # openbao path + property holding the sk-ant-... token.
     remoteKey: anthropic/token
     remoteProperty: apiKey
+    # openbao property holding the full claude-code credentials.json blob.
+    remoteCredentialsProperty: credentialsJson
 
 # ── openova MCP integration ───────────────────────────────────────────────
 # The chepherd image bundles the `openova-mcp` binary at /usr/local/bin.
@@ -70,19 +89,38 @@ anthropic:
 openovaMCP:
   enabled: true
   binaryPath: /usr/local/bin/openova-mcp
-  # In-cluster catalyst-api the MCP forwards calls to. On a Sovereign this
-  # is the per-Org catalyst-api Service; the gateway terminates session auth.
-  catalystApiUrl: http://catalyst-api.catalyst-system.svc
+  # catalyst-api base URL the MCP forwards calls to. The agenity Application
+  # runs INSIDE the Org's vCluster, which cannot resolve the host
+  # catalyst-api.catalyst-system.svc name (#4111) — the host Service is not
+  # mirrored into the vCluster DNS. Use the Sovereign's public console FQDN
+  # (the Cilium Gateway routes /api/v1/* to catalyst-api and terminates
+  # session auth). Empty = the chart derives https://console.<sovereign-fqdn>
+  # from the Sovereign FQDN. Override for a host-namespace (non-vCluster)
+  # install where the in-cluster Service name resolves.
+  catalystApiUrl: ""
   # Pins the MCP to the Organization context so even a wider token cannot
   # widen the surface beyond the User's Org (defense in depth).
   context: organization
   # Bearer verification mode for the MCP (rs256 against the Sovereign
-  # handover pubkey by default). The pubkey is reflected in from the
-  # catalyst handover-jwt secret.
+  # handover signer pubkey). The pubkey is reflected in from the catalyst
+  # handover-jwt secret — it MUST match the key catalyst-api SIGNS sessions
+  # with (#4114: catalyst-api now publishes its runtime signer pubkey to
+  # catalyst-handover-jwt-public, the source of truth).
   verify: rs256
   rs256PubkeySecret:
     name: catalyst-handover-jwt
     key: handover-jwt-public.pem
+  # ── Per-call bearer injection (#4111) ───────────────────────────────────
+  # The openova MCP needs the User's session bearer per tools/call (via
+  # _auth.token or the OPENOVA_MCP_BEARER env). The production seam is the
+  # chat UI forwarding the signed-in User's session token into each call;
+  # that chepherd-side injection is tracked separately. As an interim, an
+  # operator may supply a bearer Secret the chart wires as OPENOVA_MCP_BEARER
+  # (admin-tier, Org-pinned, RS256-signed by the handover signer). Empty =
+  # rely on per-call _auth.token from the UI seam.
+  bearerSecret:
+    name: ""
+    key: bearer
 
 # ── Service (Agenity web UI + dashboard WS + MCP) ─────────────────────────
 service:

--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -13,6 +13,8 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	clientgofeatures "k8s.io/client-go/features"
 	"k8s.io/client-go/kubernetes"
@@ -218,6 +220,20 @@ func main() {
 		} else {
 			h.SetHandoverSigner(signer)
 			log.Info("handoverjwt: signer ready", "issuer", issuer)
+			// #4114 — publish the runtime signer's ACTUAL public JWK into
+			// the catalyst-handover-jwt-public Secret so every off-pod
+			// consumer (the agenity openova-mcp's RS256 bearer verifier,
+			// any future federation peer) verifies session bearers against
+			// the SAME key catalyst-api signs with. LoadOrGenerate may
+			// have minted a fresh keypair (cloud-init seeded only the
+			// public Secret, not the private PEM at keyPath), leaving the
+			// published Secret stale + mismatched → openova-mcp rejected
+			// every genuine bearer. Self-healing: PATCH on each boot.
+			if pubJWK, jwkErr := signer.PublicJWK(); jwkErr == nil {
+				publishHandoverPubkey(context.Background(), log, pubJWK)
+			} else {
+				log.Warn("handoverjwt: PublicJWK failed; published Secret may be stale (#4114)", "err", jwkErr)
+			}
 		}
 	}
 
@@ -1998,6 +2014,55 @@ func env(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// publishHandoverPubkey PATCHes the catalyst-handover-jwt-public Secret's
+// public.jwk with the runtime signer's ACTUAL public JWK so off-pod
+// consumers verify session bearers against the same key catalyst-api signs
+// with (#4114). Best-effort: a failure (no in-cluster config, RBAC denied,
+// Secret absent) is logged, never fatal — the handover signer still works
+// in-process; only the published mirror lags. The Secret name/namespace are
+// the chart defaults, overridable via env for non-standard installs.
+func publishHandoverPubkey(ctx context.Context, log *slog.Logger, pubJWK []byte) {
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		log.Warn("handoverjwt: no in-cluster config; skipping pubkey publish (#4114)", "err", err)
+		return
+	}
+	cs, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		log.Warn("handoverjwt: clientset build failed; skipping pubkey publish (#4114)", "err", err)
+		return
+	}
+	ns := env("CATALYST_HANDOVER_PUBKEY_SECRET_NAMESPACE", "")
+	if ns == "" {
+		if b, rErr := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); rErr == nil {
+			ns = strings.TrimSpace(string(b))
+		}
+	}
+	if ns == "" {
+		ns = "catalyst-system"
+	}
+	name := env("CATALYST_HANDOVER_PUBKEY_SECRET_NAME", "catalyst-handover-jwt-public")
+	key := env("CATALYST_HANDOVER_PUBKEY_SECRET_KEY", "public.jwk")
+
+	// Skip the write when the Secret already carries our exact JWK — avoids
+	// a needless write + Reloader bounce on every restart.
+	if cur, getErr := cs.CoreV1().Secrets(ns).Get(ctx, name, metav1.GetOptions{}); getErr == nil {
+		if existing, ok := cur.Data[key]; ok && string(existing) == string(pubJWK) {
+			log.Info("handoverjwt: published pubkey already current (#4114)", "secret", ns+"/"+name)
+			return
+		}
+	}
+
+	// strategic-merge patch on the stringData field — server base64-encodes it.
+	patch := fmt.Sprintf(`{"stringData":{%q:%q}}`, key, string(pubJWK))
+	if _, pErr := cs.CoreV1().Secrets(ns).Patch(ctx, name, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}); pErr != nil {
+		log.Warn("handoverjwt: publish pubkey PATCH failed; consumers may verify against a stale key (#4114)",
+			"secret", ns+"/"+name, "err", pErr)
+		return
+	}
+	log.Info("handoverjwt: published runtime signer pubkey to Secret (#4114)", "secret", ns+"/"+name)
 }
 
 // disableWatchListClient turns OFF the client-go WatchListClient feature gate

--- a/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
+++ b/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
@@ -273,6 +273,16 @@ rules:
       - pods
       - secrets
     verbs: ["get", "list", "watch"]
+  # #4114 — publish the runtime handover signer's public JWK into the
+  # catalyst-handover-jwt-public Secret on boot so off-pod consumers
+  # (the agenity openova-mcp RS256 bearer verifier) trust the same key
+  # catalyst-api signs sessions with. Narrowly scoped to that one Secret
+  # via resourceNames; get is already granted by the rule above but is
+  # required alongside patch/update for a named-resource rule to apply.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["catalyst-handover-jwt-public"]
+    verbs: ["get", "update", "patch"]
   - apiGroups: ["apps"]
     resources: ["deployments", "statefulsets", "daemonsets", "replicasets"]
     verbs: ["get", "list", "watch"]

--- a/products/openova-mcp/cmd/openova-mcp/framing_test.go
+++ b/products/openova-mcp/cmd/openova-mcp/framing_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestReadFrame_NDJSON pins the #4111 fix: a newline-delimited JSON message
+// (the MCP stdio spec — what claude-code + the official SDKs send) is parsed
+// as one frame and reported as line-delimited so the reply mirrors it.
+func TestReadFrame_NDJSON(t *testing.T) {
+	const msg = `{"jsonrpc":"2.0","id":1,"method":"ping"}`
+	r := bufio.NewReader(strings.NewReader(msg + "\n"))
+	body, lineMode, err := readFrame(r)
+	if err != nil {
+		t.Fatalf("readFrame NDJSON: %v", err)
+	}
+	if !lineMode {
+		t.Error("NDJSON message must report lineMode=true")
+	}
+	if string(body) != msg {
+		t.Errorf("body = %q, want %q", body, msg)
+	}
+}
+
+// TestReadFrame_NDJSON_NoTrailingNewline — a final NDJSON line at EOF without
+// a trailing '\n' is still a complete message.
+func TestReadFrame_NDJSON_NoTrailingNewline(t *testing.T) {
+	const msg = `{"jsonrpc":"2.0","id":2,"method":"ping"}`
+	r := bufio.NewReader(strings.NewReader(msg))
+	body, lineMode, err := readFrame(r)
+	if err != nil {
+		t.Fatalf("readFrame NDJSON no-newline: %v", err)
+	}
+	if !lineMode || string(body) != msg {
+		t.Errorf("got lineMode=%v body=%q, want true / %q", lineMode, body, msg)
+	}
+}
+
+// TestReadFrame_ContentLength pins backwards-compat: an LSP Content-Length
+// frame still parses and reports lineMode=false.
+func TestReadFrame_ContentLength(t *testing.T) {
+	const msg = `{"jsonrpc":"2.0","id":3,"method":"ping"}`
+	framed := "Content-Length: " + itoa(len(msg)) + "\r\n\r\n" + msg
+	r := bufio.NewReader(strings.NewReader(framed))
+	body, lineMode, err := readFrame(r)
+	if err != nil {
+		t.Fatalf("readFrame Content-Length: %v", err)
+	}
+	if lineMode {
+		t.Error("Content-Length message must report lineMode=false")
+	}
+	if string(body) != msg {
+		t.Errorf("body = %q, want %q", body, msg)
+	}
+}
+
+// TestReadFrame_SkipsBlankSeparators — stray blank lines between NDJSON
+// frames are skipped, not treated as empty messages.
+func TestReadFrame_SkipsBlankSeparators(t *testing.T) {
+	const msg = `{"jsonrpc":"2.0","id":4,"method":"ping"}`
+	r := bufio.NewReader(strings.NewReader("\n\r\n" + msg + "\n"))
+	body, lineMode, err := readFrame(r)
+	if err != nil {
+		t.Fatalf("readFrame blank-prefixed: %v", err)
+	}
+	if !lineMode || string(body) != msg {
+		t.Errorf("got lineMode=%v body=%q", lineMode, body)
+	}
+}
+
+// TestWriteFrame_MirrorsInboundFraming — writeFrame emits NDJSON when the
+// peer spoke NDJSON, Content-Length otherwise.
+func TestWriteFrame_MirrorsInboundFraming(t *testing.T) {
+	// NDJSON reply.
+	var ndjson bytes.Buffer
+	s := &server{out: &ndjson, lineDelimited: true}
+	if err := s.writeResult(jsonNum(1), map[string]any{"pong": true}); err != nil {
+		t.Fatalf("writeResult NDJSON: %v", err)
+	}
+	out := ndjson.String()
+	if strings.Contains(out, "Content-Length") {
+		t.Errorf("NDJSON reply must not carry Content-Length header: %q", out)
+	}
+	if !strings.HasSuffix(out, "\n") {
+		t.Errorf("NDJSON reply must end with newline: %q", out)
+	}
+
+	// Content-Length reply.
+	var lsp bytes.Buffer
+	s2 := &server{out: &lsp, lineDelimited: false}
+	if err := s2.writeResult(jsonNum(2), map[string]any{"pong": true}); err != nil {
+		t.Fatalf("writeResult Content-Length: %v", err)
+	}
+	if !strings.HasPrefix(lsp.String(), "Content-Length: ") {
+		t.Errorf("LSP reply must start with Content-Length header: %q", lsp.String())
+	}
+}
+
+// itoa is a tiny local helper to avoid importing strconv just for tests.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}
+
+// jsonNum returns a JSON-RPC id as raw JSON.
+func jsonNum(n int) []byte { return []byte(itoa(n)) }

--- a/products/openova-mcp/cmd/openova-mcp/main.go
+++ b/products/openova-mcp/cmd/openova-mcp/main.go
@@ -101,7 +101,7 @@ func main() {
 
 	in := bufio.NewReader(os.Stdin)
 	for {
-		msg, err := readFrame(in)
+		msg, lineMode, err := readFrame(in)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				log.Printf("stdin EOF — exiting")
@@ -110,6 +110,12 @@ func main() {
 			log.Printf("read frame: %v", err)
 			return
 		}
+		// Reply in the SAME framing the peer used. The MCP stdio
+		// transport spec is newline-delimited JSON (claude-code, the
+		// MCP TS/Python SDKs all send NDJSON); LSP-style Content-Length
+		// framing is also accepted for backwards-compat. Latching the
+		// mode per-message keeps a mixed stream honest (#4111).
+		srv.lineDelimited = lineMode
 		if err := srv.dispatch(msg); err != nil {
 			log.Printf("dispatch: %v", err)
 		}
@@ -122,6 +128,12 @@ type server struct {
 	resolver       *identity.Resolver
 	fallbackBearer string
 	out            io.Writer
+
+	// lineDelimited records the framing the most-recent inbound message
+	// used: true = newline-delimited JSON (the MCP stdio spec default),
+	// false = LSP Content-Length framing. writeFrame mirrors it so the
+	// peer's transport reader can parse the reply (#4111).
+	lineDelimited bool
 }
 
 func (s *server) dispatch(raw []byte) error {
@@ -349,6 +361,17 @@ func (s *server) writeFrame(resp rpcResponse) error {
 	if err != nil {
 		return err
 	}
+	// Newline-delimited JSON when the peer spoke NDJSON (the MCP stdio
+	// spec — claude-code + the official SDKs); LSP Content-Length framing
+	// otherwise (#4111). A reply in the wrong framing is silently
+	// undecodable by the peer's transport reader → "failed to connect".
+	if s.lineDelimited {
+		if _, err := s.out.Write(body); err != nil {
+			return err
+		}
+		_, err = s.out.Write([]byte("\n"))
+		return err
+	}
 	if _, err := fmt.Fprintf(s.out, "Content-Length: %d\r\n\r\n", len(body)); err != nil {
 		return err
 	}
@@ -356,23 +379,67 @@ func (s *server) writeFrame(resp rpcResponse) error {
 	return err
 }
 
-func readFrame(r *bufio.Reader) ([]byte, error) {
+// readFrame reads one JSON-RPC message off the stdio transport. It
+// auto-detects the framing per-message (#4111): a frame whose first
+// non-blank byte is '{' or '[' is a newline-delimited JSON message (the
+// MCP stdio spec — claude-code, the MCP TS/Python SDKs); anything else
+// is parsed as an LSP-style Content-Length-prefixed frame. The returned
+// bool is true for NDJSON so the caller can reply in kind.
+func readFrame(r *bufio.Reader) ([]byte, bool, error) {
+	// Skip blank separator lines that some peers emit between frames,
+	// then peek the first content byte to choose the framing.
+	for {
+		b, err := r.Peek(1)
+		if err != nil {
+			return nil, false, err
+		}
+		if b[0] == '\r' || b[0] == '\n' {
+			if _, err := r.ReadByte(); err != nil {
+				return nil, false, err
+			}
+			continue
+		}
+		break
+	}
+
+	first, err := r.Peek(1)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// NDJSON: a single line that is itself a complete JSON value.
+	if first[0] == '{' || first[0] == '[' {
+		line, err := r.ReadBytes('\n')
+		if err != nil && len(line) == 0 {
+			return nil, false, err
+		}
+		// ReadBytes may return the final line without a trailing '\n' at
+		// EOF; that's still a complete message. Trim the line terminator.
+		line = []byte(strings.TrimRight(string(line), "\r\n"))
+		if len(line) == 0 {
+			// Defensive: a stray blank slipped through — recurse.
+			return readFrame(r)
+		}
+		return line, true, nil
+	}
+
+	// LSP Content-Length framing (backwards-compat).
 	tp := textproto.NewReader(r)
 	header, err := tp.ReadMIMEHeader()
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	clStr := header.Get("Content-Length")
 	if clStr == "" {
-		return nil, errors.New("missing Content-Length")
+		return nil, false, errors.New("missing Content-Length")
 	}
 	cl, err := strconv.Atoi(clStr)
 	if err != nil {
-		return nil, fmt.Errorf("bad Content-Length: %w", err)
+		return nil, false, fmt.Errorf("bad Content-Length: %w", err)
 	}
 	body := make([]byte, cl)
 	if _, err := io.ReadFull(r, body); err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	return body, nil
+	return body, false, nil
 }


### PR DESCRIPTION
## What

Makes the agenity North Star work **live** on omantel.biz: a chat to the solo agent spawns a claude-code agent that calls Claude, uses the bundled openova-mcp, and **creates a new Application in the demo Org**. Proven end-to-end (see Evidence).

Four interlocking gaps were blocking it; this PR fixes all four durably.

### 1. openova-mcp stdio framing (the gating bug) — `products/openova-mcp`
openova-mcp only accepted LSP-style `Content-Length` framing. claude-code (and the official MCP SDKs) speak **newline-delimited JSON** over stdio per the MCP spec, so every message was rejected (`malformed MIME header line`) and claude-code reported the server as **Failed to connect** — the spawned agent never saw the openova tools. `readFrame`/`writeFrame` now auto-detect framing per-message and reply in kind (Content-Length callers unchanged). + regression tests.

### 2. handover-jwt keypair mismatch (#4114) — `products/catalyst`
catalyst-api's runtime signer minted a fresh keypair (cloud-init seeded only the *public* Secret, not the private PEM), so the published `catalyst-handover-jwt-public` Secret was stale and **mismatched** against the key catalyst-api signs sessions with. The openova-mcp (verifying bearers against the published key) rejected every genuine session bearer. catalyst-api now PATCHes the Secret with its actual runtime signer pubkey on boot (self-healing, idempotent), + a narrowly-scoped RBAC rule for the patch.

### 3. claude-code runtime missing — `products/agenity/Containerfile`
The bp-agenity image shipped only the chepherd daemon; `/usr/bin/claude` lived only in the separate chepherd-agent image, which isn't loaded in-pod on a Sovereign (→ BareExecRuntime forks the agent CLI on the host, but there was no `claude` binary). Baked node 22 + `@anthropic-ai/claude-code` into the image.

### 4. OAuth creds + reachable catalyst-api URL — `products/agenity/chart`
- Init container seeds `~/.claude/.credentials.json` (full `claudeAiOauth` blob) + onboarding stub from the anthropic Secret — claude-code authenticates via the OAuth file, not `ANTHROPIC_API_KEY` (an `sk-ant-oat01` token there is rejected, and the spawn path strips it anyway).
- The agenity Application runs inside the Org vCluster, which can't resolve `catalyst-api.catalyst-system.svc`; default `catalystApiUrl` to the public `https://console.<sovereignFqdn>`. + interim `OPENOVA_MCP_BEARER` seam.

## Evidence (live, omantel.biz / dep 4635277cae4ffed9, demo Org omantel-biz)
- `claude mcp list`: **Failed to connect → ✔ Connected** after the framing fix.
- Spawned claude-code agent: stream-json shows `"type":"tool_use" "name":"mcp__openova__create_application"` → `HTTP 201` → `"is_error":false`.
- `kubectl -n omantel-biz get application.apps.openova.io`: NEW `agent-wp-shop` + `agent-wp-blog` (bp-wordpress 0.4.1) created by the agent, with the exact parameters it passed.

## Follow-ups
- Per-call bearer injection from the chat UI (the production seam) is the remaining chepherd-side work — tracked; the interim OPENOVA_MCP_BEARER seam + verified manual path prove the capability.

Refs #4111 #4114

🤖 Generated with [Claude Code](https://claude.com/claude-code)