### PR TITLE
feat(catalyst+mcp): Org-scoped Application install — customer agent provisions in its OWN Org (#4116)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -1762,6 +1762,17 @@ func main() {
 		rg.Get("/api/v1/org/users", h.HandleListOrgUsers)
 		rg.Delete("/api/v1/org/users/{uuid}", h.HandleDeleteOrgUser)
 
+		// #4116 — Org-scoped Application install. An Org-scoped customer
+		// session (tier=org-admin) cannot reach the Sovereign-admin seam
+		// `POST /api/v1/sovereigns/{id}/applications` (OrgScopeGuard 403s it,
+		// the #4110/#4112 fix). This own-org route resolves the caller's own
+		// namespace from the request host via the tenant registry and reuses
+		// the shared install core, so the bp-agenity solo agent's openova-mcp
+		// create_application tool can install Applications in the User's own
+		// Org. `/api/v1/org/applications` is already on the OrgScopeGuard
+		// allowlist (org_scope.go orgSafePathPrefixes) — no surface widening.
+		rg.Post("/api/v1/org/applications", h.HandleOrgApplicationInstall)
+
 		// Organization provisioning pipeline (issue #804). Marketplace
 		// signup → vCluster + bp-* charts + DNS + cert + SSO clients
 		// + Organization registry. State machine surfaced as steps[] in

--- a/products/catalyst/bootstrap/api/internal/handler/applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications.go
@@ -378,6 +378,29 @@ func (h *Handler) HandleApplicationInstall(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	h.installApplicationCore(w, r, dep, depID, body)
+}
+
+// installApplicationCore performs the catalog-fetch → schema-validate →
+// ensure-namespace → create-Application-CR sequence that is the heart of an
+// Application install. It is the SHARED create core (#4116) called by BOTH
+// the Sovereign-admin path (HandleApplicationInstall, addressed by the
+// `/api/v1/sovereigns/{id}/applications` route) AND the Org-scoped path
+// (HandleOrgApplicationInstall, addressed by the OrgScopeGuard-allowlisted
+// `/api/v1/org/applications` route). The caller is responsible for resolving
+// `dep`, decoding+normalizing+validating `body`, and applying the right
+// authz BEFORE calling this — the core reimplements NO authz so the two
+// callers can apply their own (tier-admin for the sovereign path; own-org
+// binding for the org path). `body.OrganizationRef` MUST already be the
+// resolved Org identity (the org path forces it to the tenant's real
+// namespace before calling).
+func (h *Handler) installApplicationCore(w http.ResponseWriter, r *http.Request, dep *Deployment, depID string, body applicationInstallRequest) {
+	if h.catalogClient == nil {
+		writeApplicationInstallSoftError(w, "catalog-not-wired", http.StatusServiceUnavailable,
+			"catalog client unconfigured (CATALYST_CATALOG_URL); install requires the catalog upstream")
+		return
+	}
+
 	// 1. Fetch the Blueprint at the requested version. The catalog
 	//    populates `raw` on the version-pinned endpoint so we can
 	//    validate parameters against `spec.configSchema` without a

--- a/products/catalyst/bootstrap/api/internal/handler/org_applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_applications.go
@@ -1,0 +1,149 @@
+// org_applications.go — the Org-scoped Application install path (#4116).
+//
+// THE PROBLEM this closes: a customer Org-scoped session (a User on their
+// own console.<org>.<pool> console, tier=org-admin per org_scope.go) cannot
+// install an Application via the Sovereign-admin seam
+// `POST /api/v1/sovereigns/{id}/applications` (HandleApplicationInstall),
+// because:
+//
+//   1. OrgScopeGuard (org_scope.go) deny-by-defaults the
+//      `/api/v1/sovereigns/...` surface for org sessions (the #4110/#4112
+//      privilege-escalation fix) → 403 org-scoped-forbidden before the
+//      handler runs.
+//   2. Even if it reached the handler, applicationInstallCallerAuthorized
+//      rejects tier=org-admin (it wants tier-admin/owner/sovereign-admin).
+//   3. orgNamespace(ref) is a pure slugger and never consults the tenant
+//      registry — a free-subdomain Org (e.g. slug "demo", real namespace
+//      `org-<tenant-uuid>`) would land the CR in the wrong namespace.
+//
+// This is exactly what blocked the agentic journey: the bp-agenity solo
+// agent's openova-mcp create_application tool forwards the User's Org-scoped
+// session bearer, which got 403'd at the Sovereign seam.
+//
+// THE FIX (Approach A — respects the #4110/#4112 model, no surface widening):
+// a NEW Org-scoped route `POST /api/v1/org/applications` that is ALREADY on
+// the OrgScopeGuard allowlist (orgSafePathPrefixes in org_scope.go). It:
+//
+//   - resolves the caller's OWN Organization via resolveOrganization() — the
+//     same host→tenant-registry seam HandleCreateOrgUser uses, which returns
+//     tenant.OrganizationNamespace (the real `org-<uuid>` namespace, solving
+//     problem 3) AND enforces the #4110 cross-org binding (an Org-scoped
+//     session can only ever resolve its OWN Org, solving the confinement
+//     requirement),
+//   - forces body.OrganizationRef to that real namespace so the shared
+//     install core writes the Application CR into the caller's own namespace,
+//   - reuses h.installApplicationCore — the SAME catalog-fetch → validate →
+//     ensure-namespace → create-CR core the Sovereign path uses (no
+//     duplicated CR-write logic),
+//   - applies NO applicationInstallCallerAuthorized tier gate: reaching this
+//     route already proves an Org-scoped session confined to its own Org by
+//     resolveOrganization's binding — that IS the authz boundary.
+//
+// The Sovereign surface stays sealed: `/api/v1/sovereigns/{id}/applications`
+// is unchanged and still 403s org sessions. Only the dedicated
+// `/api/v1/org/applications` own-org route is opened.
+
+package handler
+
+import (
+	"net/http"
+	"os"
+	"strings"
+)
+
+// HandleOrgApplicationInstall — POST /api/v1/org/applications.
+//
+// Installs an Application into the CALLER'S OWN Organization. The target
+// namespace is resolved server-side from the request host (X-Tenant-Host)
+// via the tenant registry — the client cannot point this at another Org
+// (resolveOrganization enforces the #4110 own-org binding). The body is the
+// SAME applicationInstallRequest shape the Sovereign install seam accepts
+// (long-form or short-form), minus organizationRef/namespace, which are
+// forced to the resolved Org namespace and IGNORED if supplied.
+func (h *Handler) HandleOrgApplicationInstall(w http.ResponseWriter, r *http.Request) {
+	// Resolve the caller's own Organization (host → tenant registry). This
+	// returns tenant.OrganizationNamespace (the real `org-<uuid>` namespace)
+	// and enforces the #4110 cross-org binding: an Org-scoped session may
+	// only ever resolve its OWN Org (a forged X-Tenant-Host for a sibling
+	// Org is 403 org-scope-mismatch).
+	tenant, ok := h.resolveOrganization(w, r)
+	if !ok {
+		return
+	}
+	orgNS := strings.TrimSpace(tenant.OrganizationNamespace)
+	if orgNS == "" {
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{
+			"error":  "org-namespace-unresolved",
+			"detail": "tenant registry has no org_tenant_namespace for this Organization",
+		})
+		return
+	}
+
+	// Resolve the local Sovereign deployment. On a Sovereign chroot, ANY
+	// non-empty id resolves lookupDeploymentForInfra → chrootEnsureDeployment
+	// → the in-cluster client (sovereignDynamicClient), so the synthesized
+	// self id is sufficient. This mirrors HandleSovereignSelf's id-resolution
+	// ladder so the org path uses the same single self-registered cluster.
+	depID := h.selfDeploymentID(r)
+	dep, found := h.lookupDeploymentForInfra(depID)
+	if !found {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error":  "deployment-unresolved",
+			"detail": "could not resolve the local Sovereign deployment for an org-scoped install",
+		})
+		return
+	}
+
+	// Decode + normalize + validate the body, identical to the Sovereign
+	// path, so the same dual-shape (long/short-form) contract holds.
+	rawBody, readErr := readMutationBody(w, r)
+	if readErr {
+		return
+	}
+	body, decodeErr := decodeApplicationInstallBody(rawBody)
+	if decodeErr != nil {
+		writeApplicationInstallSoftError(w, "invalid-body", http.StatusBadRequest, decodeErr.Error())
+		return
+	}
+
+	// FORCE the target Org to the caller's own resolved namespace — the
+	// client's organizationRef / namespace are IGNORED so an org session can
+	// never create outside its own Org. orgNamespace() is idempotent on an
+	// already-valid RFC-1123 label (the `org-<uuid>` namespace is one), so
+	// the shared core's orgNamespace(body.OrganizationRef) == orgNS.
+	body.OrganizationRef = orgNS
+	body.NamespaceShort = ""
+
+	body = applicationInstallRequestNormalize(body)
+	if msg, ok := validateApplicationInstallRequest(body); !ok {
+		writeApplicationInstallSoftError(w, "invalid-application-install", http.StatusBadRequest, msg)
+		return
+	}
+
+	// No applicationInstallCallerAuthorized tier gate: reaching this
+	// OrgScopeGuard-allowlisted, own-org-bound route IS the authz boundary
+	// for an Org-scoped session (it can only ever touch its own Org).
+	h.installApplicationCore(w, r, dep, depID, body)
+}
+
+// selfDeploymentID resolves the local Sovereign's deployment id for an
+// org-scoped request, mirroring HandleSovereignSelf's ladder: the explicit
+// self-id env, then the session cookie claims, then a stable id synthesized
+// from SOVEREIGN_FQDN. Any non-empty value resolves to the in-cluster client
+// on a Sovereign chroot.
+func (h *Handler) selfDeploymentID(r *http.Request) string {
+	if id := strings.TrimSpace(os.Getenv("CATALYST_SELF_DEPLOYMENT_ID")); id != "" {
+		return id
+	}
+	if _, jwtDepID, ok := readSessionClaimsFromCookie(r); ok && strings.TrimSpace(jwtDepID) != "" {
+		return strings.TrimSpace(jwtDepID)
+	}
+	fqdn := strings.TrimSpace(os.Getenv("CATALYST_OTECH_FQDN"))
+	if fqdn == "" {
+		fqdn = strings.TrimSpace(os.Getenv("SOVEREIGN_FQDN"))
+	}
+	if fqdn != "" {
+		return "sovereign-" + fqdn
+	}
+	return ""
+}

--- a/products/catalyst/bootstrap/api/internal/handler/org_applications_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_applications_test.go
@@ -1,0 +1,121 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+// orgAppTestRegistry builds a tenant registry with a free-subdomain Org
+// (slug "demo", real namespace org-<uuid>) mirroring the live omantel.biz
+// demo Org (#4116).
+func orgAppTestRegistry(t *testing.T) *store.TenantRegistry {
+	t.Helper()
+	reg, err := store.NewTenantRegistry(t.TempDir())
+	if err != nil {
+		t.Fatalf("registry: %v", err)
+	}
+	if err := reg.Put(store.TenantRegistration{
+		Host:                  "console.demo.omani.homes",
+		TenantID:              "7283eb4a-19e5-4e86-9066-d4aa26762064",
+		TenantKind:            store.TenantKindOrg,
+		KeycloakRealmURL:      "https://keycloak.demo.omani.homes/realms/org-demo",
+		KeycloakClientID:      "catalyst-ui",
+		OrganizationNamespace: "org-7283eb4a-19e5-4e86-9066-d4aa26762064",
+		OrgKeycloakRealmName:  "org-demo",
+	}); err != nil {
+		t.Fatalf("put demo: %v", err)
+	}
+	// A sibling Org the demo session must NOT be able to target.
+	if err := reg.Put(store.TenantRegistration{
+		Host:                  "console.acme.omani.homes",
+		TenantID:              "acme-uuid",
+		TenantKind:            store.TenantKindOrg,
+		KeycloakRealmURL:      "https://keycloak.acme.omani.homes/realms/org-acme",
+		KeycloakClientID:      "catalyst-ui",
+		OrganizationNamespace: "org-acme-uuid",
+		OrgKeycloakRealmName:  "org-acme",
+	}); err != nil {
+		t.Fatalf("put acme: %v", err)
+	}
+	return reg
+}
+
+func orgAppPostBody(t *testing.T, host string, claims *auth.Claims, body map[string]any) *httptest.ResponseRecorder {
+	t.Helper()
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/org/applications", strings.NewReader(string(raw)))
+	req.Header.Set("X-Tenant-Host", host)
+	req.Header.Set("Content-Type", "application/json")
+	if claims != nil {
+		req = req.WithContext(context.WithValue(req.Context(), auth.ClaimsKey, claims))
+	}
+	t.Setenv("SOVEREIGN_FQDN", "omantel.biz")
+	h := &Handler{log: slog.New(slog.NewJSONHandler(io.Discard, nil))}
+	h.SetTenantRegistry(orgAppTestRegistry(t))
+	// catalogClient intentionally nil — the install core early-returns
+	// catalog-not-wired (503) AFTER org-resolution + namespace-forcing, so a
+	// 503 catalog-not-wired proves the org-scope plumbing all passed.
+	rec := httptest.NewRecorder()
+	h.HandleOrgApplicationInstall(rec, req)
+	return rec
+}
+
+// TestOrgAppInstall_ResolvesOwnOrgNamespace — a demo-org-scoped session
+// POSTing to /api/v1/org/applications resolves its OWN namespace from the
+// tenant registry and reaches the shared install core (catalog-not-wired
+// 503), proving the org-scope path is wired (no OrgScopeGuard 403, no
+// tier-admin rejection, namespace resolved server-side). #4116.
+func TestOrgAppInstall_ResolvesOwnOrgNamespace(t *testing.T) {
+	claims := &auth.Claims{Tier: orgScopedTier, Org: "demo"}
+	rec := orgAppPostBody(t, "console.demo.omani.homes", claims, map[string]any{
+		"blueprint": "bp-agenity", "version": "0.3.0", "name": "agenity",
+	})
+	// Reached the install core → catalog-not-wired soft-error (the
+	// writeApplicationInstallSoftError envelope is HTTP 200 carrying the
+	// "503"/catalog-not-wired tokens in the body, the canonical install
+	// wire-shape). If org resolution had failed we'd see a hard
+	// 400/403/404/422 status instead.
+	if !strings.Contains(rec.Body.String(), "catalog-not-wired") {
+		t.Fatalf("expected catalog-not-wired (core reached), got %d: %s", rec.Code, rec.Body.String())
+	}
+	if rec.Code == http.StatusForbidden || rec.Code == http.StatusNotFound || rec.Code == http.StatusUnprocessableEntity {
+		t.Fatalf("org resolution must have passed before the core, got hard status %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestOrgAppInstall_CrossOrgForged — a demo-org-scoped session forging a
+// sibling Org's host (console.acme) is 403 org-scope-mismatch (#4110
+// binding), never reaching the install core. #4116.
+func TestOrgAppInstall_CrossOrgForged(t *testing.T) {
+	claims := &auth.Claims{Tier: orgScopedTier, Org: "demo"}
+	rec := orgAppPostBody(t, "console.acme.omani.homes", claims, map[string]any{
+		"blueprint": "bp-wordpress", "version": "0.4.1", "name": "leak",
+	})
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 org-scope-mismatch, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "org-scope-mismatch") {
+		t.Fatalf("expected org-scope-mismatch body, got %s", rec.Body.String())
+	}
+}
+
+// TestOrgAppInstall_OTECHHostRejected — the Sovereign's own console host
+// (tenant_kind != org) is rejected (tenant-not-org), so the org-app route is
+// genuinely Org-only. #4116.
+func TestOrgAppInstall_UnknownHostRejected(t *testing.T) {
+	rec := orgAppPostBody(t, "console.unknown.example", nil, map[string]any{
+		"blueprint": "bp-wordpress", "version": "0.4.1", "name": "x",
+	})
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 tenant-not-registered, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/products/openova-mcp/cmd/openova-mcp/main.go
+++ b/products/openova-mcp/cmd/openova-mcp/main.go
@@ -43,6 +43,7 @@ import (
 	"io"
 	"log"
 	"net/textproto"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -80,6 +81,17 @@ type rpcError struct {
 	Data    any    `json:"data,omitempty"`
 }
 
+// hostFromURL returns the bare host (no port) of a URL string, or "" if it
+// cannot be parsed. Used to derive the X-Tenant-Host for the org-scoped
+// install path from OPENOVA_MCP_CATALYST_API_URL (#4116).
+func hostFromURL(raw string) string {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return ""
+	}
+	return u.Hostname()
+}
+
 func main() {
 	log.SetOutput(os.Stderr)
 	log.SetFlags(log.LstdFlags | log.Lmicroseconds | log.LUTC)
@@ -93,11 +105,29 @@ func main() {
 	var api *catalystapi.Client
 	if apiURL != "" {
 		api = catalystapi.New(apiURL)
+		// #4116 — the org-scoped install path (/api/v1/org/applications)
+		// passes X-Tenant-Host so the catalyst-api resolves the caller's own
+		// Org namespace. Prefer the explicit OPENOVA_MCP_TENANT_HOST; else
+		// fall back to the host of the catalyst-api URL itself (in the
+		// agenity wiring that URL IS the Org console host, e.g.
+		// console.demo.omani.homes), so a per-Org MCP instance is org-aware
+		// with zero extra config.
+		tenantHost := strings.TrimSpace(os.Getenv("OPENOVA_MCP_TENANT_HOST"))
+		if tenantHost == "" {
+			tenantHost = hostFromURL(apiURL)
+		}
+		if tenantHost != "" {
+			api.WithTenantHost(tenantHost)
+		}
 	}
 	reg := tools.NewRegistry(api)
 	srv := &server{reg: reg, resolver: resolver, fallbackBearer: os.Getenv("OPENOVA_MCP_BEARER"), out: os.Stdout}
-	log.Printf("env: catalyst_api=%q context_pin=%q verify=%q bearer_fallback=%v",
-		apiURL, os.Getenv("OPENOVA_MCP_CONTEXT"), verifyMode(), os.Getenv("OPENOVA_MCP_BEARER") != "")
+	tenantHostLog := ""
+	if api != nil {
+		tenantHostLog = api.TenantHost()
+	}
+	log.Printf("env: catalyst_api=%q context_pin=%q verify=%q bearer_fallback=%v tenant_host=%q",
+		apiURL, os.Getenv("OPENOVA_MCP_CONTEXT"), verifyMode(), os.Getenv("OPENOVA_MCP_BEARER") != "", tenantHostLog)
 
 	in := bufio.NewReader(os.Stdin)
 	for {

--- a/products/openova-mcp/internal/catalystapi/client.go
+++ b/products/openova-mcp/internal/catalystapi/client.go
@@ -36,6 +36,13 @@ import (
 type Client struct {
 	baseURL string
 	http    *http.Client
+
+	// tenantHost is the Organization console host (e.g.
+	// console.demo.omani.homes) the org-scoped install path passes as
+	// X-Tenant-Host so the catalyst-api resolves the caller's OWN Org
+	// namespace from the tenant registry (#4116). Empty = the org-create
+	// path omits the header (catalyst-api 400s tenant-required).
+	tenantHost string
 }
 
 // New returns a Client targeting baseURL (e.g.
@@ -48,6 +55,18 @@ func New(baseURL string) *Client {
 		http:    &http.Client{Timeout: 30 * time.Second},
 	}
 }
+
+// WithTenantHost sets the Organization console host the org-scoped install
+// path passes as X-Tenant-Host (#4116). The catalyst-api uses it to resolve
+// the caller's own Org namespace; the #4110 binding ensures an org session
+// can only ever resolve its OWN Org. Returns the receiver for chaining.
+func (c *Client) WithTenantHost(host string) *Client {
+	c.tenantHost = strings.TrimSpace(host)
+	return c
+}
+
+// TenantHost returns the configured Organization console host (may be empty).
+func (c *Client) TenantHost() string { return c.tenantHost }
 
 // WithHTTPClient overrides the underlying http.Client (used by tests to
 // inject a RoundTripper that serves canned catalyst-api responses).
@@ -120,6 +139,13 @@ func (c *Client) get(ctx context.Context, path, bearer string, out any) error {
 // arrives as a 200 body the tool layer inspects. Both paths are exercised
 // by the tool tests.
 func (c *Client) post(ctx context.Context, path, bearer string, in, out any) error {
+	return c.postWithHeaders(ctx, path, bearer, nil, in, out)
+}
+
+// postWithHeaders is post() with caller-supplied extra request headers (e.g.
+// X-Tenant-Host for the org-scoped install path, #4116). The bearer +
+// content/accept headers are set identically to post().
+func (c *Client) postWithHeaders(ctx context.Context, path, bearer string, extra map[string]string, in, out any) error {
 	payload, err := json.Marshal(in)
 	if err != nil {
 		return fmt.Errorf("catalyst-api: encode request: %w", err)
@@ -134,6 +160,11 @@ func (c *Client) post(ctx context.Context, path, bearer string, in, out any) err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
+	for k, v := range extra {
+		if k != "" && v != "" {
+			req.Header.Set(k, v)
+		}
+	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {
@@ -258,6 +289,30 @@ type CreateApplicationRequest struct {
 func (c *Client) CreateApplication(ctx context.Context, depID string, req CreateApplicationRequest, bearer string) (map[string]any, error) {
 	var out map[string]any
 	if err := c.post(ctx, fmt.Sprintf("/api/v1/sovereigns/%s/applications", depID), bearer, req, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// CreateApplicationOrg calls POST /api/v1/org/applications — the Org-scoped
+// install path (#4116). It is the seam an Org-scoped customer session
+// (tier=org-admin) uses: the Sovereign seam /api/v1/sovereigns/{id}/...
+// 403s for org sessions (OrgScopeGuard, the #4110/#4112 fix), so the agent's
+// forwarded org bearer must use this own-org route instead. The target Org
+// namespace is resolved SERVER-SIDE from the X-Tenant-Host header against the
+// tenant registry (the catalyst-api forces the CR into the caller's own
+// namespace and ignores any organizationRef in the body), with the #4110
+// binding ensuring an org session can only ever create in its OWN Org.
+//
+// req.OrganizationRef is irrelevant here (the server forces the namespace),
+// so a minimal {blueprintRef, name, [parameters]} body suffices.
+func (c *Client) CreateApplicationOrg(ctx context.Context, req CreateApplicationRequest, bearer string) (map[string]any, error) {
+	var out map[string]any
+	headers := map[string]string{}
+	if c.tenantHost != "" {
+		headers["X-Tenant-Host"] = c.tenantHost
+	}
+	if err := c.postWithHeaders(ctx, "/api/v1/org/applications", bearer, headers, req, &out); err != nil {
 		return nil, err
 	}
 	return out, nil

--- a/products/openova-mcp/internal/tools/catalogue.go
+++ b/products/openova-mcp/internal/tools/catalogue.go
@@ -242,11 +242,6 @@ func handleCreateApplication(ctx context.Context, id *identity.Identity, api *ca
 		return nil, err
 	}
 
-	depID, err := requireDeployment(id)
-	if err != nil {
-		return nil, err
-	}
-
 	req := catalystapi.CreateApplicationRequest{
 		BlueprintRef:    catalystapi.ApplicationBlueprintRef{Name: strings.TrimSpace(in.Blueprint), Version: strings.TrimSpace(in.Version)},
 		Name:            strings.TrimSpace(in.Name),
@@ -261,6 +256,23 @@ func handleCreateApplication(ctx context.Context, id *identity.Identity, api *ca
 		}
 	}
 
+	// Org-scoped path (#4116): an Org-context caller (a customer on their own
+	// console) uses the dedicated /api/v1/org/applications route. The
+	// Sovereign seam /api/v1/sovereigns/{id}/applications 403s an org session
+	// (OrgScopeGuard, the #4110/#4112 fix), so the agent's forwarded org
+	// bearer MUST use the own-org route. The target namespace is resolved
+	// server-side from X-Tenant-Host (set on the client) — no deployment_id
+	// is needed (the PIN session bearer carries none), and the #4110 binding
+	// guarantees own-org-only. A sovereign-admin caller keeps the
+	// deployment-addressed Sovereign seam (can create in any Org).
+	if id.Context == identity.ContextOrganization {
+		return api.CreateApplicationOrg(ctx, req, bearerOf(id))
+	}
+
+	depID, err := requireDeployment(id)
+	if err != nil {
+		return nil, err
+	}
 	return api.CreateApplication(ctx, depID, req, bearerOf(id))
 }
 

--- a/products/openova-mcp/internal/tools/tools_test.go
+++ b/products/openova-mcp/internal/tools/tools_test.go
@@ -227,23 +227,28 @@ func TestWhoami(t *testing.T) {
 // ── create_application (write tool, #3988 UAT rows 221-223) ──────────────
 
 // TestCreateApplicationOrgScopedSucceeds — an Org-scoped acme token creates
-// an Application in acme. The facade forwards the caller's bearer to the
-// SAME install endpoint the console posts to, with the canonical
-// install-request body (blueprintRef + name + organizationRef), and
-// surfaces the 201 envelope.
+// an Application in acme via the DEDICATED Org route /api/v1/org/applications
+// (#4116). An org session is 403'd at the Sovereign seam
+// /api/v1/sovereigns/{id}/applications by OrgScopeGuard (#4110/#4112), so the
+// facade routes org context to the own-org route instead, passing
+// X-Tenant-Host so the catalyst-api resolves the caller's own Org namespace.
+// No deployment_id is needed on the org path. The 201 envelope is surfaced.
 func TestCreateApplicationOrgScopedSucceeds(t *testing.T) {
-	var sawAuth, sawCookie, sawPath, sawMethod string
+	var sawAuth, sawCookie, sawPath, sawMethod, sawTenantHost string
 	var sawBody map[string]any
 	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		sawAuth = r.Header.Get("Authorization")
 		sawCookie = r.Header.Get("Cookie")
 		sawPath = r.URL.Path
 		sawMethod = r.Method
+		sawTenantHost = r.Header.Get("X-Tenant-Host")
 		raw, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(raw, &sawBody)
 		return jsonResp(201, `{"kind":"Application","name":"shop","namespace":"acme","uid":"u-1","httpStatus":"201","applied":true}`), nil
 	})
-	api := catalystapi.New("https://console.test").WithHTTPClient(&http.Client{Transport: rt})
+	api := catalystapi.New("https://console.acme.omani.homes").
+		WithTenantHost("console.acme.omani.homes").
+		WithHTTPClient(&http.Client{Transport: rt})
 	reg := NewRegistry(api)
 
 	args, _ := json.Marshal(map[string]any{
@@ -253,7 +258,7 @@ func TestCreateApplicationOrgScopedSucceeds(t *testing.T) {
 	if err != nil {
 		t.Fatalf("own-org create should succeed, got %v", err)
 	}
-	// Thin-facade: identity forwarded, correct verb + path.
+	// Thin-facade: identity forwarded, correct verb + dedicated org path.
 	if sawMethod != "POST" {
 		t.Errorf("want POST, got %q", sawMethod)
 	}
@@ -263,10 +268,15 @@ func TestCreateApplicationOrgScopedSucceeds(t *testing.T) {
 	if !strings.Contains(sawCookie, "catalyst_session=org-bearer") {
 		t.Errorf("session cookie not forwarded: %q", sawCookie)
 	}
-	if sawPath != "/api/v1/sovereigns/7bb723da8da06047/applications" {
-		t.Errorf("wrong path: %q", sawPath)
+	if sawPath != "/api/v1/org/applications" {
+		t.Errorf("org context must use the own-org route, got %q", sawPath)
 	}
-	// Org defaulted to the caller's own Org (organization arg omitted).
+	if sawTenantHost != "console.acme.omani.homes" {
+		t.Errorf("X-Tenant-Host not forwarded for own-org install: %q", sawTenantHost)
+	}
+	// Org defaulted to the caller's own Org (organization arg omitted). The
+	// server forces the real namespace from X-Tenant-Host, but the facade
+	// still stamps the caller's Org ref in the body.
 	if sawBody["organizationRef"] != "acme" {
 		t.Errorf("organizationRef should default to caller's Org, got %v", sawBody["organizationRef"])
 	}


### PR DESCRIPTION
## What
Makes the DEMO CUSTOMER agentic journey land in the **right Org**. The bp-agenity solo agent's openova-mcp `create_application` forwards the User's Org-scoped session bearer; on a Sovereign serving Org pool-domain consoles that bearer is `tier=org-admin` (the #4110/#4112 security fix). Three interlocking barriers (all confirmed LIVE on omantel.biz / dep 4635277cae4ffed9) made the agent's create either 403 or land in the wrong Org:

1. **OrgScopeGuard 403** — `POST /api/v1/sovereigns/{id}/applications` is NOT on the org-safe allowlist, so an org session is 403'd before the handler (live-verified: org bearer → 403 org-scoped-forbidden).
2. **Tier gate** — even past the guard, `applicationInstallCallerAuthorized` rejects `tier=org-admin`.
3. **Namespace** — `orgNamespace('demo')` → `demo`, but the free-subdomain demo Org's real namespace is `org-7283eb4a-…` (resolved only via the tenant registry).

So the earlier #4115 proof (sovereign-admin bearer) landed `agent-wp-*` in **omantel-biz**, not the demo customer Org.

## Fix (Approach A — respects #4110/#4112, no surface widening)
- **catalyst-api**: extract `installApplicationCore` from `HandleApplicationInstall`; add `HandleOrgApplicationInstall` on the NEW route `POST /api/v1/org/applications` (already on the OrgScopeGuard allowlist). It resolves the caller's OWN Org via `resolveOrganization` (tenant registry → `org_tenant_namespace`, with the #4110 cross-org binding), forces `OrganizationRef` to that namespace, and reuses the shared core. No tier gate — the own-org-bound route IS the authz boundary.
- **openova-mcp**: in organization context, `create_application` POSTs the own-org route with `X-Tenant-Host` (no `deployment_id` needed — the PIN session bearer carries none). Sovereign-admin keeps the deployment-addressed seam.

The Sovereign surface stays sealed: `/sovereigns/{id}/applications` still 403s org sessions.

## Tests
- `HandleOrgApplicationInstall`: own-org-resolve reaches the core; cross-org-forged host → 403 org-scope-mismatch; unknown host → 404.
- MCP org-context routes to `/api/v1/org/applications` + forwards `X-Tenant-Host`.
- Full catalyst-api handler suite green; openova-mcp suite green.

## RBAC live-verified (DoD #4, catalyst-api at c5f7034/#4112)
Minted a demo-org-scoped RS256 bearer (runtime handover signer) and hit the live Sovereign API with X-Forwarded-Host=console.demo.omani.homes:
- whoami → 200 `{tier:org-admin, orgScoped:true, org:demo}`; /deployments → 403; /organizations → 403; /sovereigns/{id}/applications → 403. The lockdown works; this PR adds the legitimate own-org create path.

Refs #4116 #4110 #4111

🤖 Generated with [Claude Code](https://claude.com/claude-code)