### PR TITLE
fix(catalyst): Org console — project the Org's OWN apps + kill the deployment-stream wizard leak (Refs #4113 #4119)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -1773,6 +1773,19 @@ func main() {
 		// allowlist (org_scope.go orgSafePathPrefixes) — no surface widening.
 		rg.Post("/api/v1/org/applications", h.HandleOrgApplicationInstall)
 
+		// #4113 — the TRUE per-Org Apps projection. GET companion to the
+		// install POST above. An Org-scoped customer session on its own
+		// console used to render the SOVEREIGN-WIDE catalog grid (the only
+		// allowlisted Apps feed was /api/v1/sovereign/apps, which lists every
+		// HelmRelease + Application CR cluster-wide). This route lists ONLY the
+		// Application CRs + HelmReleases in the caller's OWN org-<uuid>
+		// namespace (resolved server-side via the tenant registry with the
+		// #4110 own-org binding) and projects each as a card with its open URL
+		// derived from the Org namespace's HTTPRoute set — so agenity surfaces
+		// with a working Open link. Already on the OrgScopeGuard allowlist
+		// (org_scope.go orgSafePathPrefixes) — no surface widening.
+		rg.Get("/api/v1/org/applications", h.HandleOrgApplications)
+
 		// Organization provisioning pipeline (issue #804). Marketplace
 		// signup → vCluster + bp-* charts + DNS + cert + SSO clients
 		// + Organization registry. State machine surfaced as steps[] in

--- a/products/catalyst/bootstrap/api/internal/handler/org_applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_applications.go
@@ -46,9 +46,17 @@
 package handler
 
 import (
+	"context"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/catalog"
 )
 
 // HandleOrgApplicationInstall — POST /api/v1/org/applications.
@@ -146,4 +154,222 @@ func (h *Handler) selfDeploymentID(r *http.Request) string {
 		return "sovereign-" + fqdn
 	}
 	return ""
+}
+
+// HandleOrgApplications — GET /api/v1/org/applications.
+//
+// #4113 — the TRUE per-Org Apps projection. An Org-scoped customer session
+// on its own console (console.<org>.<pool>) used to render the SOVEREIGN-WIDE
+// catalog grid because the only allowlisted Apps feed was
+// /api/v1/sovereign/apps (HandleSovereignApps lists every HelmRelease +
+// Application CR + catalog blueprint cluster-wide). A customer must see ONLY
+// their OWN estate.
+//
+// This handler resolves the caller's OWN Organization namespace from the
+// request host (resolveOrganization → tenant.OrganizationNamespace, the real
+// `org-<uuid>` namespace, with the #4110 own-org binding enforced) and lists
+// ONLY the Application CRs + HelmReleases that live in that namespace. Each
+// row is projected as an instance card with its open/launch URL derived from
+// the Org namespace's HTTPRoute set (the host of the route fronting the
+// release). agenity-demo (HR Ready, HTTPRoute host agenity.<org>.<pool>) thus
+// surfaces with a working Open link; the demo-wp Application CRs surface as
+// their own cards even while still Pending.
+//
+// Response shape is the SAME sovereignAppsResponse the FE's AppsPage already
+// consumes (instance rows), so the SPA reuses its existing card-rendering and
+// silent-SSO Open path with zero new wire-types — it only swaps the endpoint
+// when whoami.orgScoped is true.
+func (h *Handler) HandleOrgApplications(w http.ResponseWriter, r *http.Request) {
+	// Resolve the caller's own Organization (host → tenant registry). Enforces
+	// the #4110 own-org binding: an Org session can only ever resolve its OWN
+	// Org (a forged sibling host is 403 org-scope-mismatch). Returns the real
+	// `org-<uuid>` namespace.
+	tenant, ok := h.resolveOrganization(w, r)
+	if !ok {
+		return
+	}
+	orgNS := strings.TrimSpace(tenant.OrganizationNamespace)
+	if orgNS == "" {
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{
+			"error":  "org-namespace-unresolved",
+			"detail": "tenant registry has no org_tenant_namespace for this Organization",
+		})
+		return
+	}
+
+	resp := sovereignAppsResponse{Apps: []sovereignAppItem{}, BootstrapKit: []string{}}
+
+	deps, depsErr := h.sovereignDepsFor()
+	if depsErr != nil {
+		// No in-cluster client (e.g. CI) — return an empty-but-valid estate
+		// rather than a 500, mirroring HandleSovereignApps' best-effort
+		// posture. The customer sees the empty-state affordance, not an error.
+		if gen, gErr := catalog.GeneratedAt(); gErr == nil {
+			resp.GeneratedAt = gen
+		}
+		writeJSON(w, http.StatusOK, resp)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	// Build the per-Org HTTPRoute index: (name → url) and (backend-service
+	// name → url), all within the Org namespace. The agenity route is named
+	// `agenity` but its backendRef Service is `agenity-demo-bp-agenity`, so we
+	// index BOTH so the release→route join below resolves whichever key the
+	// chart used.
+	urlByKey := map[string]string{}
+	if rts, err := deps.dyn.Resource(httpRouteGVR).Namespace(orgNS).List(ctx, metav1.ListOptions{}); err == nil {
+		for _, rt := range rts.Items {
+			hosts, _, _ := unstructured.NestedStringSlice(rt.Object, "spec", "hostnames")
+			if len(hosts) == 0 || hosts[0] == "" {
+				continue
+			}
+			url := "https://" + hosts[0]
+			urlByKey[rt.GetName()] = url
+			rules, _, _ := unstructured.NestedSlice(rt.Object, "spec", "rules")
+			for _, rl := range rules {
+				rm, isMap := rl.(map[string]interface{})
+				if !isMap {
+					continue
+				}
+				refs, _, _ := unstructured.NestedSlice(rm, "backendRefs")
+				for _, ref := range refs {
+					rfm, isMap := ref.(map[string]interface{})
+					if !isMap {
+						continue
+					}
+					if svc, _, _ := unstructured.NestedString(rfm, "name"); svc != "" {
+						if _, exists := urlByKey[svc]; !exists {
+							urlByKey[svc] = url
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Index the Org namespace's HelmReleases by name so an Application CR's
+	// spec.helmRelease.name resolves to ready-state + a launch URL, and so an
+	// HR WITHOUT a companion Application CR (e.g. agenity-demo on the demo Org)
+	// still projects as its own card.
+	type orgHR struct {
+		ready bool
+		// urlKeys — candidate HTTPRoute index keys to resolve the open URL:
+		// the release name and `<release>-<chart>` (the Service-name shape the
+		// agenity route's backendRef uses). First hit in urlByKey wins.
+		urlKeys []string
+		chart   string
+	}
+	hrByName := map[string]orgHR{}
+	if hrs, err := deps.dyn.Resource(helmReleaseGVR).Namespace(orgNS).List(ctx, metav1.ListOptions{}); err == nil {
+		for i := range hrs.Items {
+			hr := &hrs.Items[i]
+			name := hr.GetName()
+			rel, _, _ := unstructured.NestedString(hr.Object, "spec", "releaseName")
+			if rel == "" {
+				rel = name
+			}
+			chart, _, _ := unstructured.NestedString(hr.Object, "spec", "chart", "spec", "chart")
+			if chart == "" {
+				chart = strings.TrimPrefix(name, "bp-")
+			}
+			hrByName[name] = orgHR{
+				ready:   helmReleaseReady(hr),
+				urlKeys: []string{rel, rel + "-" + chart, rel + "-bp-" + strings.TrimPrefix(chart, "bp-"), name},
+				chart:   chart,
+			}
+		}
+	}
+	resolveOpenURL := func(keys []string) string {
+		for _, k := range keys {
+			if u, ok := urlByKey[k]; ok && u != "" {
+				return u
+			}
+		}
+		return ""
+	}
+
+	rows := []sovereignAppItem{}
+	adopted := map[string]bool{} // HR names already projected via an Application CR
+
+	// Application CR pass — each CR in the Org namespace is one card.
+	if appList, err := deps.dyn.Resource(applicationGVR).Namespace(orgNS).List(ctx, metav1.ListOptions{}); err == nil {
+		for i := range appList.Items {
+			app := &appList.Items[i]
+			bpFull, _, _ := unstructured.NestedString(app.Object, "spec", "blueprintRef", "name")
+			slug := strings.TrimPrefix(bpFull, "bp-")
+			phase, _, _ := unstructured.NestedString(app.Object, "status", "phase")
+			status := "installing"
+			if strings.EqualFold(phase, "Ready") {
+				status = "installed"
+			}
+			env, _, _ := unstructured.NestedString(app.Object, "spec", "environmentRef")
+			if env == "" {
+				env = defaultSovereignEnvironment
+			}
+			externalURL := ""
+			if hrName, _, _ := unstructured.NestedString(app.Object, "spec", "helmRelease", "name"); hrName != "" {
+				adopted[hrName] = true
+				if hr, ok := hrByName[hrName]; ok {
+					externalURL = resolveOpenURL(hr.urlKeys)
+				}
+			}
+			topology, _, _ := unstructured.NestedString(app.Object, "spec", "placement")
+			rows = append(rows, sovereignAppItem{
+				ID:          app.GetName(),
+				Slug:        slug,
+				Title:       app.GetName(),
+				Status:      status,
+				Environment: env,
+				ExternalURL: externalURL,
+				Instance:    true,
+				Blueprint:   bpFull,
+				Topology:    topology,
+			})
+		}
+	}
+
+	// HelmRelease pass — any HR in the Org namespace WITHOUT a companion
+	// Application CR (e.g. agenity-demo) projects as its own card. Internal
+	// platform spines for the Org's own vCluster (vc-*, bp-cnpg) carry no
+	// customer-facing UI; we still surface them as cards (the customer owns
+	// their estate) but only attach an Open link when an HTTPRoute resolves.
+	hrNames := make([]string, 0, len(hrByName))
+	for name := range hrByName {
+		hrNames = append(hrNames, name)
+	}
+	sort.Strings(hrNames)
+	for _, name := range hrNames {
+		if adopted[name] {
+			continue
+		}
+		hr := hrByName[name]
+		status := "installing"
+		if hr.ready {
+			status = "installed"
+		}
+		slug := strings.TrimPrefix(hr.chart, "bp-")
+		bpFull := hr.chart
+		if !strings.HasPrefix(bpFull, "bp-") {
+			bpFull = "bp-" + bpFull
+		}
+		rows = append(rows, sovereignAppItem{
+			ID:          name,
+			Slug:        slug,
+			Title:       name,
+			Status:      status,
+			Environment: defaultSovereignEnvironment,
+			ExternalURL: resolveOpenURL(hr.urlKeys),
+			Instance:    true,
+			Blueprint:   bpFull,
+		})
+	}
+
+	resp.Apps = rows
+	if gen, gErr := catalog.GeneratedAt(); gErr == nil {
+		resp.GeneratedAt = gen
+	}
+	writeJSON(w, http.StatusOK, resp)
 }

--- a/products/catalyst/bootstrap/api/internal/handler/org_applications_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_applications_test.go
@@ -10,6 +10,9 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
 )
@@ -117,5 +120,139 @@ func TestOrgAppInstall_UnknownHostRejected(t *testing.T) {
 	})
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 tenant-not-registered, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// orgAppsGet drives GET /api/v1/org/applications for the given host/claims
+// against a handler seeded with the supplied dynamic objects (HRs, HTTPRoutes,
+// Application CRs).
+func orgAppsGet(t *testing.T, host string, claims *auth.Claims, dynObjs []runtime.Object) *httptest.ResponseRecorder {
+	t.Helper()
+	t.Setenv("SOVEREIGN_FQDN", "omantel.biz")
+	h := newSovereignHandler(t, nil, dynObjs)
+	h.SetTenantRegistry(orgAppTestRegistry(t))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/org/applications", nil)
+	req.Header.Set("X-Tenant-Host", host)
+	if claims != nil {
+		req = req.WithContext(context.WithValue(req.Context(), auth.ClaimsKey, claims))
+	}
+	rec := httptest.NewRecorder()
+	h.HandleOrgApplications(rec, req)
+	return rec
+}
+
+// makeHRWithRelease is makeHR plus a spec.chart.spec.chart + spec.releaseName,
+// so the projection can resolve the open URL by the release/Service-name shape.
+func makeHRWithRelease(name, ns, ready, chart, release string) *unstructured.Unstructured {
+	u := makeHR(name, ns, ready)
+	_ = unstructured.SetNestedField(u.Object, chart, "spec", "chart", "spec", "chart")
+	if release != "" {
+		_ = unstructured.SetNestedField(u.Object, release, "spec", "releaseName")
+	}
+	return u
+}
+
+// makeHTTPRouteWithBackend is makeHTTPRoute plus a backendRef Service name so
+// the projection's (ns, service-name)→url index resolves the agenity route
+// whose name (`agenity`) differs from its Service (`agenity-demo-bp-agenity`).
+func makeHTTPRouteWithBackend(name, ns string, hosts []string, backendSvc string) *unstructured.Unstructured {
+	u := makeHTTPRoute(name, ns, hosts)
+	rules := []interface{}{
+		map[string]interface{}{
+			"backendRefs": []interface{}{
+				map[string]interface{}{"name": backendSvc},
+			},
+		},
+	}
+	_ = unstructured.SetNestedSlice(u.Object, rules, "spec", "rules")
+	return u
+}
+
+// makeApplicationFull is makeApplication plus spec.blueprintRef.name +
+// status.phase so the projection can render its blueprint + status.
+func makeApplicationFull(name, ns, bp, phase string) *unstructured.Unstructured {
+	u := makeApplication(name, ns, ns+"-prod")
+	_ = unstructured.SetNestedField(u.Object, bp, "spec", "blueprintRef", "name")
+	if phase != "" {
+		_ = unstructured.SetNestedField(u.Object, phase, "status", "phase")
+	}
+	return u
+}
+
+const demoOrgNS = "org-7283eb4a-19e5-4e86-9066-d4aa26762064"
+
+// TestOrgApplications_ProjectsOwnNamespaceOnly — #4113. A demo-org session GET
+// /api/v1/org/applications sees ONLY its own namespace's estate: the agenity
+// HR (with its Open URL resolved from the in-namespace HTTPRoute) + the two
+// wordpress Application CRs. A sibling Org's app + a sovereign-wide app in a
+// foreign namespace must NOT appear.
+func TestOrgApplications_ProjectsOwnNamespaceOnly(t *testing.T) {
+	dynObjs := []runtime.Object{
+		// demo Org's own estate.
+		makeHRWithRelease("agenity-demo", demoOrgNS, "True", "bp-agenity", ""),
+		makeHTTPRouteWithBackend("agenity", demoOrgNS, []string{"agenity.demo.omani.homes"}, "agenity-demo-bp-agenity"),
+		makeApplicationFull("demo-wp-shop", demoOrgNS, "bp-wordpress", "Pending"),
+		makeApplicationFull("demo-wp-blog", demoOrgNS, "bp-wordpress", "Pending"),
+		// FOREIGN estate — must never leak into the demo projection.
+		makeHRWithRelease("agenity-acme", "org-acme-uuid", "True", "bp-agenity", ""),
+		makeHR("bp-cilium", "flux-system", "True"), // sovereign spine
+	}
+	claims := &auth.Claims{Tier: orgScopedTier, Org: "demo"}
+	rec := orgAppsGet(t, "console.demo.omani.homes", claims, dynObjs)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Apps []struct {
+			ID          string `json:"id"`
+			Blueprint   string `json:"blueprint"`
+			Status      string `json:"status"`
+			ExternalURL string `json:"externalURL"`
+		} `json:"apps"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	byID := map[string]struct {
+		bp, status, url string
+	}{}
+	for _, a := range resp.Apps {
+		byID[a.ID] = struct{ bp, status, url string }{a.Blueprint, a.Status, a.ExternalURL}
+	}
+	// agenity present + Ready + Open URL resolved.
+	ag, ok := byID["agenity-demo"]
+	if !ok {
+		t.Fatalf("agenity-demo missing from org projection; got %v", byID)
+	}
+	if ag.status != "installed" {
+		t.Errorf("agenity status = %q, want installed", ag.status)
+	}
+	if ag.url != "https://agenity.demo.omani.homes" {
+		t.Errorf("agenity externalURL = %q, want https://agenity.demo.omani.homes", ag.url)
+	}
+	// Both wordpress Application CRs present.
+	for _, want := range []string{"demo-wp-shop", "demo-wp-blog"} {
+		if _, ok := byID[want]; !ok {
+			t.Errorf("%s missing from org projection; got %v", want, byID)
+		}
+	}
+	// Foreign estate absent.
+	for _, forbidden := range []string{"agenity-acme", "bp-cilium"} {
+		if _, leaked := byID[forbidden]; leaked {
+			t.Errorf("FOREIGN app %s leaked into demo org projection: %v", forbidden, byID)
+		}
+	}
+}
+
+// TestOrgApplications_CrossOrgForged — a demo session forging the acme host is
+// 403 org-scope-mismatch (the #4110 binding), never projecting acme's estate.
+func TestOrgApplications_CrossOrgForged(t *testing.T) {
+	claims := &auth.Claims{Tier: orgScopedTier, Org: "demo"}
+	rec := orgAppsGet(t, "console.acme.omani.homes", claims, nil)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 org-scope-mismatch, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "org-scope-mismatch") {
+		t.Fatalf("expected org-scope-mismatch body, got %s", rec.Body.String())
 	}
 }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.orgscope.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.orgscope.test.tsx
@@ -1,0 +1,220 @@
+/**
+ * AppsPage.orgscope.test.tsx — #4113 + #4119 lock-in.
+ *
+ * Two founder-visible gaps on the Org-scoped customer console
+ * (console.<org>.<pool>, e.g. console.demo.omani.homes):
+ *
+ *   GAP 1 (#4119): the Sovereign provisioning/deployment-stream surface must
+ *     NOT mount for an Org session. catalyst-api 403s /api/v1/deployments/*
+ *     for an Org session, so an attached stream flips to `unreachable` → the
+ *     "Couldn't reach the deployment stream … Retry / Cancel & Wipe" banner
+ *     leaking to a customer. This file proves the Org session fires ZERO
+ *     /deployments/* requests and renders NO failure banner.
+ *
+ *   GAP 2 (#4113): the Apps page must project the Org's OWN apps (from
+ *     /api/v1/org/applications, with X-Tenant-Host), not the sovereign-wide
+ *     catalog feed (/api/v1/sovereign/apps). This file proves the live query
+ *     targets /org/applications and renders the agenity card with a working
+ *     Open button, and renders NO sovereign bootstrap-kit spine cards.
+ *
+ * The complementary sovereign-admin behaviour (full provisioning surface,
+ * /sovereign/apps feed) is unchanged and covered by AppsPage.test.tsx +
+ * AppsPage.handover.test.tsx (which run with the default orgScoped=false).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { NotificationProvider } from '@/shared/ui/notifications'
+
+// Sovereign mode so the live-apps query runs (an Org console IS a Sovereign
+// host — console.demo.omani.homes). detectMode reads the hostname; mock it to
+// the demo Org console host.
+vi.mock('@/shared/lib/detectMode', () => ({
+  DETECTED_MODE: { mode: 'sovereign', sovereignFQDN: 'demo.omani.homes' },
+  detectMode: () => ({ mode: 'sovereign', sovereignFQDN: 'demo.omani.homes' }),
+}))
+
+// Force the console scope to Org-scoped (demo). This is the #4112 hook the
+// real session resolves from GET /whoami; here we pin it so the page renders
+// the Org branch deterministically.
+vi.mock('@/shared/lib/useConsoleScope', () => ({
+  useConsoleScope: () => ({ orgScoped: true, org: 'demo', loading: false }),
+}))
+
+// Observe the silent-SSO launch path without a network round-trip.
+const getLaunchURL = vi.fn()
+vi.mock('@/lib/catalog.api', () => ({
+  getLaunchURL: (...args: unknown[]) => getLaunchURL(...args),
+}))
+
+import { AppsPage } from './AppsPage'
+import { useWizardStore } from '@/entities/deployment/store'
+import { INITIAL_WIZARD_STATE } from '@/entities/deployment/model'
+
+const ORG_APPS_RESPONSE = {
+  apps: [
+    {
+      id: 'agenity-demo',
+      slug: 'agenity',
+      blueprint: 'bp-agenity',
+      status: 'installed',
+      environment: 'demo-prod',
+      externalURL: 'https://agenity.demo.omani.homes',
+      instance: true,
+      topology: '',
+    },
+    {
+      id: 'demo-wp-shop',
+      slug: 'wordpress',
+      blueprint: 'bp-wordpress',
+      status: 'installing',
+      environment: 'demo-prod',
+      externalURL: '',
+      instance: true,
+      topology: '',
+    },
+  ],
+  bootstrapKit: [],
+}
+
+/** Records every fetched URL so the test can assert which endpoints were hit. */
+let fetchedURLs: string[]
+let orgAppsHeaders: Headers | null
+
+function installFetchMock() {
+  fetchedURLs = []
+  orgAppsHeaders = null
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      fetchedURLs.push(url)
+      if (url.includes('/v1/org/applications')) {
+        orgAppsHeaders = new Headers(init?.headers)
+        return new Response(JSON.stringify(ORG_APPS_RESPONSE), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      // Any /deployments/* or /sovereign/apps hit is a BUG for an Org session
+      // — return 403 so a regression surfaces as a visible failure rather than
+      // a silent pass.
+      return new Response('{"error":"org-scoped-forbidden"}', { status: 403 })
+    }),
+  )
+}
+
+function renderOrgApps() {
+  const rootRoute = createRootRoute({
+    component: () => (
+      <NotificationProvider>
+        <Outlet />
+      </NotificationProvider>
+    ),
+  })
+  // Clean-root /apps route (the Sovereign Console URL shape — no deploymentId
+  // param; resolved via /sovereign/self, which our fetch mock answers 403 →
+  // useResolvedDeploymentId returns null, exactly as an Org session behaves).
+  const appsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/apps',
+    component: () => <AppsPage />,
+  })
+  const catalogRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/catalog',
+    component: () => <div data-testid="catalog-page-target" />,
+  })
+  const tree = rootRoute.addChildren([appsRoute, catalogRoute])
+  const router = createRouter({
+    routeTree: tree,
+    history: createMemoryHistory({ initialEntries: ['/apps'] }),
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router as never} />
+    </QueryClientProvider>,
+  )
+}
+
+describe('AppsPage — Org-scoped console (#4113 + #4119)', () => {
+  beforeEach(() => {
+    useWizardStore.setState({ ...INITIAL_WIZARD_STATE })
+    installFetchMock()
+    // Pin the host so X-Tenant-Host carries the demo Org console host.
+    Object.defineProperty(window, 'location', {
+      value: { host: 'console.demo.omani.homes', hostname: 'console.demo.omani.homes', search: '', pathname: '/apps', hash: '' },
+      writable: true,
+    })
+  })
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  // Plain-DOM helpers — this suite avoids jest-dom matchers
+  // (toBeInTheDocument/toHaveAttribute), which are NOT registered in this
+  // project's vitest setup (src/test/setup.ts). Mirrors the querySelector +
+  // chai-truthy style of AppsPage.open-button.test.tsx.
+  const byId = (id: string) => document.querySelector(`[data-testid="${id}"]`)
+
+  it('GAP 2: projects the Org estate from /org/applications with X-Tenant-Host + renders agenity Open', async () => {
+    renderOrgApps()
+
+    // agenity card renders with a working Open button.
+    await waitFor(() => expect(byId('sov-app-open-agenity-demo')).toBeTruthy(), {
+      timeout: 4000,
+    })
+    expect(byId('sov-app-open-agenity-demo')?.getAttribute('data-external-url')).toBe(
+      'https://agenity.demo.omani.homes',
+    )
+    // The wordpress instance card renders too.
+    expect(byId('sov-app-card-demo-wp-shop')).toBeTruthy()
+
+    // The live query targeted the per-Org projection, NOT the sovereign feed.
+    expect(fetchedURLs.some((u) => u.includes('/v1/org/applications'))).toBe(true)
+    expect(fetchedURLs.some((u) => u.includes('/v1/sovereign/apps'))).toBe(false)
+    // X-Tenant-Host carries the Org console host.
+    expect(orgAppsHeaders?.get('X-Tenant-Host')).toBe('console.demo.omani.homes')
+  })
+
+  it('GAP 1: never fetches the deployment-stream + renders NO failure banner', async () => {
+    renderOrgApps()
+
+    await waitFor(() => expect(byId('sov-app-card-agenity-demo')).toBeTruthy(), {
+      timeout: 4000,
+    })
+
+    // ZERO /deployments/* requests — the stream is gated off for an Org session.
+    const deploymentHits = fetchedURLs.filter((u) => u.includes('/v1/deployments/'))
+    expect(deploymentHits).toEqual([])
+
+    // No "Couldn't reach the deployment stream" / "Provisioning failed" banner,
+    // no Cancel & Wipe action, no provisioning pill.
+    expect(screen.queryByText(/Couldn’t reach the deployment stream/i)).toBeNull()
+    expect(screen.queryByText(/Provisioning failed/i)).toBeNull()
+    expect(byId('sov-failure-wipe')).toBeNull()
+    expect(byId('sov-provisioning-pill')).toBeNull()
+  })
+
+  it('GAP 2: does NOT render sovereign bootstrap-kit spine cards', async () => {
+    renderOrgApps()
+    await waitFor(() => expect(byId('sov-app-card-agenity-demo')).toBeTruthy(), {
+      timeout: 4000,
+    })
+    // Only the org-projection instance cards render; no cilium/flux/etc spine.
+    expect(byId('sov-app-card-bp-cilium')).toBeNull()
+    expect(byId('sov-app-card-bp-flux')).toBeNull()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
@@ -39,6 +39,7 @@ import { DETECTED_MODE } from '@/shared/lib/detectMode'
 import { API_BASE } from '@/shared/config/urls'
 import { authedFetch } from '@/shared/lib/authedFetch'
 import { useWizardStore } from '@/entities/deployment/store'
+import { useConsoleScope } from '@/shared/lib/useConsoleScope'
 import { PortalShell } from './PortalShell'
 import { resolveApplications, type ApplicationDescriptor } from './applicationCatalog'
 import { findComponent } from '@/pages/wizard/steps/componentGroups'
@@ -73,6 +74,18 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
   const router = useRouter()
   const store = useWizardStore()
 
+  // #4113 / #4119 — Org-console scope. On an Org-scoped customer session
+  // (whoami.orgScoped, host console.<org>.<pool>) the page must render the
+  // Org's OWN application estate (from /api/v1/org/applications) and must NOT
+  // mount the Sovereign provisioning/deployment-stream surface (which 403s for
+  // an Org session → the "couldn't reach the deployment stream" banner). While
+  // the scope is still loading we treat the session as sovereign (the common
+  // case) — but the deployment-stream stays disabled until proven sovereign so
+  // a customer never flashes the provisioning banner; the catalyst-api 403s
+  // the data regardless (hide AND enforce).
+  const { orgScoped, loading: scopeLoading } = useConsoleScope()
+  const deploymentStreamEnabled = !orgScoped && !scopeLoading
+
   const applications = useMemo(
     () => resolveApplications(store.selectedComponents),
     [store.selectedComponents],
@@ -83,6 +96,8 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
     deploymentId,
     applicationIds,
     disableStream,
+    // #4119 — never attach the deployment-stream on an Org session.
+    enabled: deploymentStreamEnabled,
   })
 
   // On Sovereign mode the imported reducer state is FROZEN at mother's
@@ -133,13 +148,30 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
     bootstrapKit: boolean
   }
   const liveAppsQuery = useQuery<LiveAppsData>({
-    queryKey: ['sovereign-apps-live'],
-    enabled: isSovereignMode,
+    // #4113 — the query key carries the scope so flipping between a sovereign
+    // and an org session (or scope resolving) re-fetches against the right
+    // endpoint rather than serving a cached cross-scope estate.
+    queryKey: ['sovereign-apps-live', orgScoped ? 'org' : 'sovereign'],
+    // Hold the fetch until the scope is known so an Org session never briefly
+    // hits /sovereign/apps (the full catalog) before /org/applications.
+    enabled: isSovereignMode && !scopeLoading,
     refetchInterval: 5_000,
     queryFn: async () => {
-      const r = await authedFetch(`${API_BASE}/v1/sovereign/apps`, {
-        headers: { Accept: 'application/json' },
-      })
+      // #4113 — Org-scoped session reads its OWN estate from
+      // /api/v1/org/applications (the per-Org projection: only Application CRs
+      // + HelmReleases in the Org's own namespace, each with its open URL).
+      // A sovereign-admin session keeps the cluster-wide /sovereign/apps feed.
+      const endpoint = orgScoped ? '/v1/org/applications' : '/v1/sovereign/apps'
+      const headers: HeadersInit = orgScoped
+        ? {
+            Accept: 'application/json',
+            // The org-scoped projection resolves the caller's own Org from the
+            // request host; X-Tenant-Host carries it (same contract as the
+            // org/users + org/applications-install clients).
+            'X-Tenant-Host': typeof window !== 'undefined' ? window.location.host : '',
+          }
+        : { Accept: 'application/json' }
+      const r = await authedFetch(`${API_BASE}${endpoint}`, { headers })
       if (!r.ok) throw new Error(`live apps fetch ${r.status}`)
       const body = (await r.json()) as {
         apps?: Array<{
@@ -245,7 +277,12 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
   const { notify, dismiss } = useNotifications()
   useEffect(() => {
     const id = `deployment-failure:${deploymentId}`
-    if (!isFailed) {
+    // #4119 — the deployment-stream failure toast (with the "Retry stream /
+    // Cancel & Wipe / Back to wizard" actions) is a SOVEREIGN provisioning
+    // surface. It must never render for an Org-scoped customer session. The
+    // hook is already disabled for org sessions (so isFailed stays false), but
+    // we hard-gate here too so a customer can never see it.
+    if (!isFailed || !deploymentStreamEnabled) {
       dismiss(id)
       return
     }
@@ -285,7 +322,7 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
     })
     // The dismiss-on-recovery branch above handles cleanup; no return
     // closure needed because notification ids are stable per deployment.
-  }, [isFailed, streamStatus, failureMessage, deploymentId, notify, dismiss, retry, router])
+  }, [isFailed, streamStatus, failureMessage, deploymentId, notify, dismiss, retry, router, deploymentStreamEnabled])
 
   useEffect(() => {
     const id = `phase1-unavailable:${deploymentId}`
@@ -476,8 +513,15 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
     return out
   }, [applications, state.apps])
   const installedApps = useMemo(
-    () => catalogApps.filter((a) => deployedIds.has(a.id)),
-    [catalogApps, deployedIds],
+    () =>
+      // #4113 — on an Org-scoped session the blueprint/bootstrap-kit cards
+      // (cilium, flux, keycloak … the SOVEREIGN spine, derived from the wizard
+      // catalog) must NEVER render: a customer sees ONLY their own estate,
+      // which arrives exclusively as the `liveInstances` rows projected by
+      // /api/v1/org/applications. The bootstrap-kit `out.add(app.id)` above
+      // would otherwise leak the sovereign spine onto the Org Apps page.
+      orgScoped ? [] : catalogApps.filter((a) => deployedIds.has(a.id)),
+    [catalogApps, deployedIds, orgScoped],
   )
 
   const [query, setQuery] = useState<string>('')
@@ -497,7 +541,10 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
     return [...filtered].sort((a, b) => a.title.localeCompare(b.title))
   }, [installedApps, query])
 
-  const isProvisioning = streamStatus === 'connecting' || streamStatus === 'streaming'
+  // #4119 — the "Provisioning" pill + "View jobs" link is a sovereign
+  // provisioning affordance; never render it for an Org-scoped session.
+  const isProvisioning =
+    deploymentStreamEnabled && (streamStatus === 'connecting' || streamStatus === 'streaming')
 
   return (
     <PortalShell

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/useDeploymentEvents.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/useDeploymentEvents.ts
@@ -240,6 +240,18 @@ export interface UseDeploymentEventsOptions {
    * flag the legacy ProvisionPage exposed.
    */
   disableStream?: boolean
+  /**
+   * #4119 — gate the ENTIRE deployment-stream (both the GET /events replay
+   * AND the SSE /logs attach) off for an Org-scoped customer session. The
+   * deployment-stream is a SOVEREIGN provisioning surface: catalyst-api 403s
+   * /api/v1/deployments/* for an Org session (the #4110/#4112 fix), so an Org
+   * session that still attaches gets streamStatus='unreachable' → the
+   * "Couldn't reach the deployment stream … Retry / Cancel & Wipe" banner
+   * leaking to a customer. Default true (sovereign sessions unchanged); set
+   * false on an Org console so the hook returns idle state and fires no
+   * /deployments calls at all.
+   */
+  enabled?: boolean
 }
 
 export interface UseDeploymentEventsResult {
@@ -265,7 +277,7 @@ export interface UseDeploymentEventsResult {
 export function useDeploymentEvents(
   opts: UseDeploymentEventsOptions,
 ): UseDeploymentEventsResult {
-  const { deploymentId, applicationIds, disableStream = false } = opts
+  const { deploymentId, applicationIds, disableStream = false, enabled = true } = opts
 
   // Stable identity for applicationIds — sort + join so a fresh array
   // with the same membership doesn't re-seed state on every render.
@@ -273,7 +285,14 @@ export function useDeploymentEvents(
 
   const [state, setState] = useState<ReducerState>(() => buildInitialState(applicationIds))
   const [snapshot, setSnapshot] = useState<DeploymentSnapshot | null>(null)
-  const [streamStatus, setStreamStatus] = useState<StreamStatus>('connecting')
+  // #4119 — when the hook is disabled (Org-scoped session), start in a
+  // terminal-quiet `completed` state so AppsPage never shows the
+  // provisioning spinner pill NOR the "couldn't reach the deployment stream"
+  // unreachable banner. No /deployments call is ever made (both effects
+  // early-return on !enabled).
+  const [streamStatus, setStreamStatus] = useState<StreamStatus>(
+    enabled ? 'connecting' : 'completed',
+  )
   const [streamError, setStreamError] = useState<string | null>(null)
   const [startedAt, setStartedAt] = useState<number | null>(null)
   const [finishedAt, setFinishedAt] = useState<number | null>(null)
@@ -303,6 +322,10 @@ export function useDeploymentEvents(
   const historyCountRef = useRef(0)
 
   useEffect(() => {
+    // #4119 — Org-scoped session: never fetch /deployments/{id}/events
+    // (catalyst-api 403s it for an Org session). The hook stays in the
+    // idle `completed` state seeded above.
+    if (!enabled) return
     if (!deploymentId) return
     let cancelled = false
     const url = `${API_BASE}/v1/deployments/${encodeURIComponent(deploymentId)}/events`
@@ -387,10 +410,12 @@ export function useDeploymentEvents(
     return () => {
       cancelled = true
     }
-  }, [deploymentId, retryNonce])
+  }, [deploymentId, retryNonce, enabled])
 
   // SSE live stream — opens after history replay seeds the reducer.
   useEffect(() => {
+    // #4119 — Org-scoped session: never open the SSE /logs stream.
+    if (!enabled) return
     if (disableStream) return
     if (!deploymentId) return
     setStreamStatus('connecting')
@@ -625,7 +650,7 @@ export function useDeploymentEvents(
         es.close()
       }
     }
-  }, [deploymentId, retryNonce, disableStream])
+  }, [deploymentId, retryNonce, disableStream, enabled])
 
   // Stable callback — referential identity matters because callers
   // (e.g. AppsPage's notification effect) include `retry` in their


### PR DESCRIPTION
Closes the two founder-visible gaps on the Org-scoped customer console (`console.demo.omani.homes`, dep `4635277cae4ffed9`) that remained after the #4110/#4112/#4117 RBAC isolation fix.

## GAP 1 (#4119) — provisioning/deployment-stream wizard leaked to customers
`AppsPage` → `useDeploymentEvents` polled `/api/v1/deployments/<depId>/{events,logs}`, which catalyst-api now **403**s for an Org session → `streamStatus='unreachable'` → the **"Couldn't reach the deployment stream … Retry stream / Cancel & Wipe / Back to wizard"** banner rendered on the customer console.

- `useDeploymentEvents` gains an `enabled` flag; `AppsPage` passes `enabled = !orgScoped` so the hook makes **zero** `/deployments` calls and seeds an idle `completed` state for an Org session.
- The failure-toast effect + the "Provisioning" pill are hard-gated on `!orgScoped` (hide AND enforce).

## GAP 2 (#4113) — Apps page showed the sovereign catalog, not the Org's apps
The only allowlisted feed was `/api/v1/sovereign/apps` (lists every HR + Application CR cluster-wide).

- **New BE** `GET /api/v1/org/applications` (`HandleOrgApplications`): resolves the caller's OWN `org-<uuid>` namespace via the tenant registry (with the #4110 own-org binding) and projects ONLY the Application CRs + HelmReleases in that namespace, each with its **Open** URL derived from the Org namespace's HTTPRoute set. Already on the OrgScopeGuard allowlist — no surface widening.
- `AppsPage` swaps its live query to `/org/applications` (with `X-Tenant-Host`) when `orgScoped`, and suppresses the sovereign bootstrap-kit spine cards so only the Org estate renders.
- Live-verified placement: the demo Org's `agenity-demo` HR (Ready) + HTTPRoute `agenity` (host `agenity.demo.omani.homes`, 200) + the `demo-wp-shop`/`demo-wp-blog` Application CRs all live in `org-7283eb4a-19e5-4e86-9066-d4aa26762064`.

## Tests
- `org_applications_test.go`: per-Org projection returns agenity (Ready + Open URL `https://agenity.demo.omani.homes`) + both wordpress CRs; foreign-namespace + sibling-org apps excluded; cross-org forged host 403.
- `AppsPage.orgscope.test.tsx`: GAP 1 (no `/deployments/*` fetch, no banner, no pill), GAP 2 (queries `/org/applications` with `X-Tenant-Host`, renders agenity Open, no spine cards).
- `go test ./internal/handler` green; UI `tsc` + `vite build` green.

Sovereign-admin behaviour is unchanged (the full provisioning surface + `/sovereign/apps` feed still render for a non-org session) — covered by the existing `AppsPage.test.tsx` / `AppsPage.handover.test.tsx`.

Refs #4113 #4119 #4110 #4112 #4117

🤖 Generated with [Claude Code](https://claude.com/claude-code)