### PR TITLE
fix(catalyst): SECURITY #4110 — host-anchor Org-console scope (stale sovereign-admin cookie can't god-mode an Org console)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/auth.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth.go
@@ -1375,6 +1375,27 @@ func (h *Handler) HandleWhoami(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// #4110 host-anchor (defense against a STALE / replayed sovereign-admin
+	// cookie): the REQUEST HOST is the trust anchor, not the session JWT.
+	// When this whoami arrived on a tenant_kind=org console host
+	// (resolveOrgScope ok — the gateway-stamped X-Forwarded-Host an
+	// Org-console browser can never forge), the response MUST render scoped
+	// REGARDLESS of what the JWT claims — force orgScoped + the Org tier +
+	// the Org realm role, overriding any sovereign tier/role the projection
+	// above synthesized. This makes the SPA hide every sovereign-admin
+	// surface even for a god-mode cookie minted before this fix shipped, so
+	// the customer never needs to clear cookies. The Sovereign's own console
+	// host (tenant_kind=otech) makes resolveOrgScope return false → the
+	// operator whoami is byte-unchanged → ZERO regression.
+	if scope, ok := h.resolveOrgScope(r); ok {
+		resp.OrgScoped = true
+		if strings.TrimSpace(resp.Org) == "" {
+			resp.Org = scope.Org
+		}
+		resp.Tier = orgScopedTier
+		resp.RealmAccess = &whoamiRealmAccess{Roles: []string{orgScopedRealmRole}}
+	}
+
 	// Sovereign-context enrichment — same precedence as HandleSovereignSelf
 	// so the two endpoints never disagree about which sovereign this is.
 	deploymentID := strings.TrimSpace(claims.DeploymentID)

--- a/products/catalyst/bootstrap/api/internal/handler/org_scope.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_scope.go
@@ -230,8 +230,21 @@ func (h *Handler) OrgScopeGuard(next http.Handler) http.Handler {
 			return
 		}
 		claims := auth.ClaimsFromContext(r.Context())
-		// Non-Org sessions are unaffected — full Sovereign-admin surface.
-		if !claimsAreOrgScoped(claims) {
+		// #4110 host-anchor: the REQUEST HOST is the trust anchor, NOT the
+		// session JWT. A request is Org-scoped if EITHER the session was
+		// minted Org-scoped (fresh PIN login on an Org console — claims tier
+		// = org-admin) OR it simply arrived on a tenant_kind=org console host
+		// (resolveOrgScope). The host predicate is what makes this immune to
+		// a STALE / replayed sovereign-admin cookie: an `admin`-tier session
+		// minted before this fix (or forged) that lands on console.<org>.<zone>
+		// is still confined — the gateway sets X-Forwarded-Host to the real
+		// browser host, which an Org-console browser can never forge.
+		//
+		// The Sovereign's OWN console host (tenant_kind=otech, e.g.
+		// console.<sov-fqdn>) makes resolveOrgScope return false → the genuine
+		// operator session is a transparent passthrough → ZERO regression.
+		_, hostOrgScoped := h.resolveOrgScope(r)
+		if !claimsAreOrgScoped(claims) && !hostOrgScoped {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/products/catalyst/bootstrap/api/internal/handler/org_scope_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_scope_test.go
@@ -166,3 +166,68 @@ func TestResolveOrgScope_OrgHost(t *testing.T) {
 		t.Fatal("Sovereign front door must NOT resolve to an Org scope")
 	}
 }
+
+// TestOrgScopeGuard_HostAnchored_StaleAdminCookieOnOrgHost_Denied is THE
+// #4110 regression: a STALE sovereign-admin cookie (tier=admin, minted
+// before the Org-scoping fix shipped, or replayed/forged) that lands on an
+// Org console host must STILL be confined to the Org allowlist — the
+// request HOST is the trust anchor, not the JWT tier. Without host-anchoring
+// the guard keyed solely off claimsAreOrgScoped(claims), so a tier=admin
+// cookie sailed straight through to /deployments — the live god-mode leak.
+func TestOrgScopeGuard_HostAnchored_StaleAdminCookieOnOrgHost_Denied(t *testing.T) {
+	dir := t.TempDir()
+	reg, err := store.NewTenantRegistry(dir)
+	if err != nil {
+		t.Fatalf("new registry: %v", err)
+	}
+	if err := reg.Put(store.TenantRegistration{
+		Host:       "console.demo.omani.homes",
+		TenantID:   "7283eb4a",
+		TenantKind: store.TenantKindOrg,
+	}); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	h := &Handler{log: quietLog(), tenantRegistry: reg}
+	guard := h.OrgScopeGuard(http.HandlerFunc(orgScopeGuardTestHandler))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/deployments/4635277cae4ffed9", nil)
+	req.Header.Set("X-Forwarded-Host", "console.demo.omani.homes")
+	req = req.WithContext(context.WithValue(req.Context(), auth.ClaimsKey,
+		&auth.Claims{Email: "demo@openova.io", Tier: "admin"})) // stale god-mode cookie
+	rec := httptest.NewRecorder()
+	guard.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("stale admin cookie on Org host must be 403'd on deployments, got %d body=%s",
+			rec.Code, rec.Body.String())
+	}
+}
+
+// TestOrgScopeGuard_HostAnchored_AdminOnSovereignHost_Passthrough proves the
+// host-anchor introduces ZERO regression: the genuine operator on the
+// Sovereign's OWN console host (tenant_kind=otech) is untouched.
+func TestOrgScopeGuard_HostAnchored_AdminOnSovereignHost_Passthrough(t *testing.T) {
+	dir := t.TempDir()
+	reg, err := store.NewTenantRegistry(dir)
+	if err != nil {
+		t.Fatalf("new registry: %v", err)
+	}
+	if err := reg.Put(store.TenantRegistration{
+		Host:       "console.omantel.biz",
+		TenantID:   "4635277cae4ffed9",
+		TenantKind: store.TenantKindOTECH,
+	}); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	h := &Handler{log: quietLog(), tenantRegistry: reg}
+	guard := h.OrgScopeGuard(http.HandlerFunc(orgScopeGuardTestHandler))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/deployments/4635277cae4ffed9", nil)
+	req.Header.Set("X-Forwarded-Host", "console.omantel.biz")
+	req = req.WithContext(context.WithValue(req.Context(), auth.ClaimsKey,
+		&auth.Claims{Email: "emrah.baysal@openova.io", Tier: "owner"}))
+	rec := httptest.NewRecorder()
+	guard.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("operator on Sovereign host must pass, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}


### PR DESCRIPTION
## Problem (live on omantel.biz, founder-reported 2026-06-22)
`demo@` logs into **console.demo.omani.homes** and sees the **full sovereign-admin god-mode** estate (every Org, cloud view, deployments, BSS, parent-domains).

## Root cause
#4112 confined an Org session by the **session JWT tier** (`claimsAreOrgScoped`) only. `console.demo.omani.homes` *does* resolve to `tenant_kind=org` and a **fresh** PIN login *is* stamped `org-admin` — but a sovereign-admin cookie minted **before** the fix (or replayed) is **never re-evaluated against the request host**, so it keeps god-mode. The `OrgScopeGuard` was also tier-based, so it couldn't catch it either.

## Fix — host-anchor (the request HOST is the trust anchor, not the JWT)
- **`OrgScopeGuard`**: a request is Org-scoped if EITHER the JWT is org-scoped OR it arrived on a `tenant_kind=org` console host (`resolveOrgScope(r)`). → 403 on every sovereign/cross-org endpoint even for a `tier=admin` cookie.
- **`HandleWhoami`**: force `orgScoped`+`org-admin` tier/role from the request host, overriding any sovereign tier the role projection synthesized — so the **existing `dc30503` catalyst-ui bundle hides every sovereign surface with no UI rebuild**.

The gateway stamps `X-Forwarded-Host` to the real browser host, which an Org-console browser can never forge.

## Zero regression
The Sovereign's own console host (`tenant_kind=otech`, e.g. console.omantel.biz) → `resolveOrgScope` false → operator session byte-unchanged. Tests assert both the deny (stale admin cookie on Org host → 403) and the passthrough (operator on Sovereign host → 200).

## Tests
`go test ./internal/handler/ -run OrgScope|HostAnchored` — 7/7 PASS incl. 2 new host-anchored cases.

Refs #4110