### PR TITLE
fix(#4139): demo-Org convergence — empty wpContent.storageClass (local-path #3971 deny) + stalwart-tenant harbor-proxy images

### DIFF
--- a/platform/stalwart-tenant/blueprint.yaml
+++ b/platform/stalwart-tenant/blueprint.yaml
@@ -15,7 +15,7 @@ spec:
   # `claimName`, `claimGroups`). setupJob defaults to enabled so a
   # fresh tenant has working OIDC at t=0.
   # Per #817 Chart.yaml version MUST equal blueprint.yaml spec.version.
-  version: 0.1.3
+  version: 0.1.4
   card:
     title: Stalwart (per-Organization)
     summary: |

--- a/platform/stalwart-tenant/chart/Chart.yaml
+++ b/platform/stalwart-tenant/chart/Chart.yaml
@@ -55,7 +55,10 @@ name: bp-stalwart-tenant
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 0.1.3
+# 0.1.4 (#4139): default image registry docker.io → harbor.openova.io/proxy-dockerhub
+#   for BOTH the StatefulSet + the mailbox-provision setup Job, so the kom4dc node
+#   cold-pull does not traverse the public internet (ImagePullBackOff on fresh prov).
+version: 0.1.4
 appVersion: "0.16.3"
 description: |
   Catalyst Blueprint scratch chart for a per-Org (per-vcluster) dedicated

--- a/platform/stalwart-tenant/chart/values.yaml
+++ b/platform/stalwart-tenant/chart/values.yaml
@@ -34,7 +34,13 @@ stalwart:
   # Digest below is `docker.io/stalwartlabs/stalwart:v0.16.3` linux/amd64
   # (verified via Docker Hub API on 2026-05-04).
   image:
-    registry: docker.io
+    # #4139 — pull through the Sovereign Harbor proxy-dockerhub project so the
+    # kom4dc node cold-pull does NOT traverse the public internet to docker.io
+    # (which ImagePullBackOffs on a fresh prov, mirroring the #3859 vcluster
+    # coredns + #4137 valkey bitnamilegacy fixes). The proxy-cache mirror serves
+    # the SAME digest (verified 200 via harbor v2 API). A per-Sovereign overlay
+    # may still rewrite this via `global.imageRegistry` post-handover.
+    registry: harbor.openova.io/proxy-dockerhub
     repository: stalwartlabs/stalwart
     tag: "v0.16.3"
     digest: "sha256:5d75cff4e9c6d75e64636e9ef9674b1d877f8f6fb2e11ee8176fbad3faaa5289"
@@ -345,7 +351,11 @@ mailboxProvisioner:
       # stalwart-cli. SHA-pinned via the same digest as the StatefulSet
       # so the bytes trace back to a single source (#898 / #560 ADR-0001
       # §11.5 — Sovereign-local Harbor proxy-cache rewrites at runtime).
-      repository: stalwartlabs/stalwart
+      # #4139 — the mailbox-provision-job template composes `repository:tag`
+      # directly (no registry field), so the harbor proxy path is carried in
+      # the repository value, matching the StatefulSet's registry default and
+      # avoiding the docker.io cold-pull ImagePullBackOff on kom4dc.
+      repository: harbor.openova.io/proxy-dockerhub/stalwartlabs/stalwart
       tag: "v0.16.3"
       digest: "sha256:5d75cff4e9c6d75e64636e9ef9674b1d877f8f6fb2e11ee8176fbad3faaa5289"
       pullPolicy: IfNotPresent

--- a/platform/wordpress-tenant/blueprint.yaml
+++ b/platform/wordpress-tenant/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: tenant-app
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.4.2
+  version: 0.4.3
   card:
     title: WordPress (per-Organization)
     summary: |
@@ -150,8 +150,12 @@ spec:
                 type: string
                 default: 10Gi
               storageClass:
+                # #3971 / #4139 — empty ⇒ omit storageClassName ⇒ bind to the
+                # cluster-default durable cloud CSI. local-path is FORBIDDEN by
+                # the forbid-local-path-storage Kyverno ENFORCE policy (ephemeral
+                # node-local disk). Matches the chart values.yaml default ("").
                 type: string
-                default: local-path
+                default: ""
       ingress:
         type: object
         properties:

--- a/platform/wordpress-tenant/chart/Chart.yaml
+++ b/platform/wordpress-tenant/chart/Chart.yaml
@@ -95,7 +95,10 @@ name: bp-wordpress-tenant
 #     of bp-cnpg-pair §7): primary BLOCKS new writes when replica is
 #     unreachable; every COMMIT pays the inter-region RTT.
 # 0.4.2 (#3971): CNPG storageClass empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN.
-version: 0.4.2
+# 0.4.3 (#4139): blueprint.yaml configSchema wpContent.storageClass.default local-path → ""
+#   (was missed by #3971 — the schema default would re-introduce the FORBIDDEN
+#   local-path class on a fresh install, denied by forbid-local-path-storage).
+version: 0.4.3
 appVersion: "6"
 description: |
   Catalyst Blueprint scratch chart for in-vcluster WordPress, one

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -51,11 +51,14 @@ metadata:
     # must not claw it back (DoD §9.4).
     helm.sh/resource-policy: keep
 spec:
-  # 2026-06-19 (#3870): lockstep with platform/wordpress-tenant/blueprint.yaml
-  # spec.version 0.4.1 + the published chart ghcr.io/openova-io/bp-wordpress-tenant:0.4.1.
-  # The prior 0.2.0 pin was stale (chart had moved 0.2.0→0.4.1) — the operator
-  # catalog card would fetch an old chart on a fresh production prov.
-  version: "0.4.1"
+  # 2026-06-22 (#4139): lockstep with platform/wordpress-tenant/blueprint.yaml
+  # spec.version 0.4.3 + the published chart ghcr.io/openova-io/bp-wordpress-tenant:0.4.3.
+  # 0.4.1 (the prior pin) defaulted persistence.wpContent.storageClass: local-path,
+  # which the #3971 forbid-local-path-storage Kyverno ENFORCE policy DENIES on
+  # the wp-content PVC → the per-Org WordPress app can never install. 0.4.3 empties
+  # both the chart values.yaml AND the blueprint.yaml configSchema default so the
+  # PVC binds to the cluster-default durable cloud CSI. (#3870 history: 0.2.0→0.4.1.)
+  version: "0.4.3"
   visibility: listed
   card:
     title: "WordPress (per-Organization)"
@@ -77,7 +80,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-wordpress-tenant
-    version: 0.4.1
+    version: 0.4.3
   # G117.1+G117.4+G117.5 #2744-followup (2026-06-03): lockstep with
   # platform/wordpress-tenant/blueprint.yaml. Uses {{.AppName}} so
   # multi-instance tenants get distinct hostnames per Application.
@@ -182,7 +185,7 @@ metadata:
     # console edit/curate.
     helm.sh/resource-policy: keep
 spec:
-  version: "0.4.1"
+  version: "0.4.3"
   visibility: listed
   card:
     title: "WordPress"
@@ -204,7 +207,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-wordpress-tenant
-    version: 0.4.1
+    version: 0.4.3
   # Lockstep with the bp-wordpress-tenant entry above + platform/wordpress-tenant/
   # blueprint.yaml. Same chart bytes; this is the bare-slug entrypoint only.
   topology:


### PR DESCRIPTION
## What
Converge the omantel.biz demo customer Org's apps. Three independent root causes, fixed minimally.

### 1. bp-wordpress-tenant local-path PVC denial (the primary failure)
After `bp-cnpg` goes Ready, `bp-wordpress-tenant` install was **denied** by the #3971 `forbid-local-path-storage` Kyverno ENFORCE policy:
```
PersistentVolumeClaim .../bp-wordpress-tenant-wp-content requests the FORBIDDEN local-path StorageClass
```
The chart `values.yaml` was already fixed to `""` for #3971, but **`platform/wordpress-tenant/blueprint.yaml` configSchema still defaulted `wpContent.storageClass` to `local-path`** — a residual gap that re-introduces the forbidden class. Plus the live catalog pin was `0.4.1` (pre-fix).
- `blueprint.yaml`: `wpContent.storageClass.default` `local-path` to `""` (chart 0.4.2 to 0.4.3, lockstep).
- catalog-seed `blueprints.yaml`: bump bp-wordpress-tenant pin 0.4.1 to 0.4.3 (canonical entry + bare-slug `wordpress` alias, 4 pins).

### 2. bp-stalwart-tenant ImagePullBackOff
`bp-stalwart-tenant-0` (StatefulSet + mailbox-provision setup Job) pulled bare `docker.io/stalwartlabs/stalwart`, which cold-pull-fails on kom4dc nodes. Route both through the Sovereign Harbor proxy-cache (chart 0.1.3 to 0.1.4):
- `registry: docker.io` to `harbor.openova.io/proxy-dockerhub` (StatefulSet)
- setup-Job `repository:` prefixed with the proxy path (template composes `repository:tag` with no registry field).
Same digest (verified 200 via harbor v2 API). Mirrors #3859 (vcluster coredns) + #4137 (valkey).

## Live evidence (omantel.biz, dep 4635277cae4ffed9)
- `bp-cnpg` HR was `Stalled (RetriesExceeded)` on the #3859 `flux-managed` webhook-gate denial — the #3859 `openova.io/organization Exists` exclusion IS working (verified by server-dry-run); the HR just exhausted retries. **Reconciled (suspend/resume) to Ready=True**; cnpg operator pod Running. No chart change needed for cnpg.
- `coredns` (vc-demo) live-patched to `harbor.openova.io/proxy-dockerhub/coredns/coredns:1.11.3` to **1/1 Running** (matches the #3859 org-controller source pin for new Orgs).
- `bp-stalwart-tenant-0` image pull **resolved** (no more ImagePullBackOff; remaining `CreateContainerConfigError` is a missing `stalwart-admin` secret — a separate SSO-provisioning gap, not images).

## Not covered here
- `bp-openclaw-controller` uses a genuine `0.1.0-placeholder` scaffold image (no real image published) — not a registry-routing fix.
- The live demo-Org WordPress Apps recover once 0.4.3 publishes + the catalog pin reaches the Sovereign (the chart fix's deploy chain).

Refs #4139, #3971, #3859, #4137, #3870

🤖 Generated with [Claude Code](https://claude.com/claude-code)