### PR TITLE
fix(#4139): unblock bp-wordpress-tenant publish — repair #3985 rename residue in oidcIssuerURL/ingressHost helpers

### DIFF
--- a/platform/wordpress-tenant/chart/templates/_helpers.tpl
+++ b/platform/wordpress-tenant/chart/templates/_helpers.tpl
@@ -74,16 +74,20 @@ list digest published on Docker Hub.
 {{- end -}}
 
 {{/*
-Resolved ingress host. Templates `wordpress.<smeDomain>` when
+Resolved ingress host. Templates `wordpress.<orgDomain>` when
 `ingress.host` is empty; otherwise returns the operator-supplied host
-verbatim. The `smeDomain` placeholder default in values.yaml ensures
+verbatim. The `orgDomain` placeholder default in values.yaml ensures
 the smoke-render pass succeeds; per-Sovereign overlays MUST override.
+#4139: was `.Values.smeDomain` — a dead key after the #3985 SME→Organization
+rename moved the values.yaml default to `orgDomain`, so the host-derivation
+fallback rendered `wordpress.<no value>`. (Live HRs always set ingress.host
+explicitly, so this only bit the chart-default render path.)
 */}}
 {{- define "bp-wordpress-tenant.ingressHost" -}}
 {{- if .Values.ingress.host -}}
 {{- .Values.ingress.host -}}
 {{- else -}}
-{{- printf "wordpress.%s" .Values.smeDomain -}}
+{{- printf "wordpress.%s" .Values.orgDomain -}}
 {{- end -}}
 {{- end -}}
 
@@ -244,7 +248,14 @@ The placeholder is `https://keycloak.sme.local/realms/sme`.
 {{- define "bp-wordpress-tenant.oidcIssuerURL" -}}
 {{- $modern := .Values.oidc.issuerURL -}}
 {{- $legacy := .Values.keycloak.realmURL -}}
-{{- $placeholder := "https://keycloak.sme.local/realms/sme" -}}
+{{- /* #4139: lockstep with the values.yaml oidc.issuerURL placeholder default.
+       The #3985 SME→Organization rename moved the values.yaml default
+       sme.local/realms/sme → org.local/realms/org but left this constant
+       on the old string — so `ne $modern $placeholder` was ALWAYS true and
+       the legacy keycloak.realmURL fold (case 4) became unreachable, failing
+       chart test oidc-config.sh Case 2 + silently blocking every publish
+       since 0.4.1 (only 0.4.0/0.4.1 are on ghcr; 0.4.2 never shipped). */}}
+{{- $placeholder := "https://keycloak.org.local/realms/org" -}}
 {{- $sovFQDN := .Values.sovereign.fqdn | default "" -}}
 {{- $orgRealm := .Values.org.realm | default "" -}}
 {{- $smeSub := .Values.smeSubdomain | default "" -}}


### PR DESCRIPTION
## What
Repairs the #3985 SME→Organization rename residue that silently gated every `bp-wordpress-tenant` publish — the reason the #4139 `0.4.3` bump (PR #4140, already merged) **failed to publish** and the live omantel.biz demo Org's WordPress apps cannot pick up the local-path fix.

### Root cause (verified: test was already red on `main~1`)
`platform/wordpress-tenant/chart/templates/_helpers.tpl` `oidcIssuerURL` carried a hard-coded `$placeholder := "https://keycloak.sme.local/realms/sme"`, but the #3985 rename moved the `values.yaml` `oidc.issuerURL` default to `"https://keycloak.org.local/realms/org"`. So `ne $modern $placeholder` was **always true** → the legacy `keycloak.realmURL` fold (case 4) became unreachable → `tests/oidc-config.sh` Case 2 FAILED → the `blueprint-release` build job (runs every `tests/*.sh` before `helm push`) blocked the publish. That is why only `0.4.0`/`0.4.1` exist on ghcr — `0.4.2` and the `0.4.3` bump never shipped.

### Fix
- `oidcIssuerURL`: sync `$placeholder` to the current values.yaml default `https://keycloak.org.local/realms/org`.
- `ingressHost`: fallback `.Values.smeDomain` (dead key post-rename) → `.Values.orgDomain` — the chart-default render was producing `wordpress.<no value>` (live HRs set `ingress.host` explicitly, so only the default-render path bit).

### Verification
- `tests/oidc-config.sh` Case 2 now PASS (was the failing assertion). All 3 wordpress-tenant chart tests green.
- `helm lint` clean; default smoke render now yields `host: wordpress.org.local`.

Unblocks the `0.4.3` publish (catalog pin already points at `0.4.3` from PR #4140) → the omantel.biz `bp-wordpress` Blueprint CR can move `0.4.1 → 0.4.3`, re-rendering the demo-Org wordpress-tenant HRs without the FORBIDDEN local-path storageClass.

Refs #4139, #3985, #3971

🤖 Generated with [Claude Code](https://claude.com/claude-code)
