### PR TITLE
fix(#4139): bp-wordpress-tenant active-hot-standby CNPG sync via native spec.postgresql.synchronous (0.4.4)

### DIFF
--- a/platform/wordpress-tenant/blueprint.yaml
+++ b/platform/wordpress-tenant/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: tenant-app
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.4.3
+  version: 0.4.4
   card:
     title: WordPress (per-Organization)
     summary: |

--- a/platform/wordpress-tenant/chart/Chart.yaml
+++ b/platform/wordpress-tenant/chart/Chart.yaml
@@ -98,7 +98,14 @@ name: bp-wordpress-tenant
 # 0.4.3 (#4139): blueprint.yaml configSchema wpContent.storageClass.default local-path → ""
 #   (was missed by #3971 — the schema default would re-introduce the FORBIDDEN
 #   local-path class on a fresh install, denied by forbid-local-path-storage).
-version: 0.4.3
+# 0.4.4 (#4139): active-hot-standby CNPG cluster declares synchronous replication via
+#   the CNPG-native spec.postgresql.synchronous block instead of the raw
+#   synchronous_standby_names parameter (CNPG FIXED param — the vcluster.cnpg.io
+#   admission webhook rejected it: "Can't set fixed configuration parameter").
+#   Mirrors bp-cnpg-pair primary-cluster.yaml (#3740). Also folds the #3985 rename
+#   residue in oidcIssuerURL/ingressHost helpers (the gate that blocked 0.4.2/0.4.3
+#   publish until repaired this session).
+version: 0.4.4
 appVersion: "6"
 description: |
   Catalyst Blueprint scratch chart for in-vcluster WordPress, one

--- a/platform/wordpress-tenant/chart/templates/cnpg-cluster.yaml
+++ b/platform/wordpress-tenant/chart/templates/cnpg-cluster.yaml
@@ -141,10 +141,32 @@ spec:
       */ -}}
       {{- $replMode := default "sync" .Values.pg.activeHotStandby.replication.mode }}
       {{- if eq $replMode "sync" }}
+      # `synchronous_commit` (remote_apply) IS a settable GUC → stays a raw
+      # parameter. `synchronous_standby_names` is NOT — CNPG marks it a FIXED
+      # configuration parameter and the admission webhook REJECTS any explicit
+      # set in `parameters` with "Can't set fixed configuration parameter"
+      # (#4139, caught live on omantel.biz vcluster.cnpg.io). Declare it via
+      # the CNPG-native `spec.postgresql.synchronous` block below instead —
+      # the SAME shape bp-cnpg-pair primary-cluster.yaml uses (#3740).
       synchronous_commit: {{ default "remote_apply" .Values.pg.activeHotStandby.replication.sync.commit | quote }}
-      synchronous_standby_names: {{ printf "FIRST %d (%s)" (int (default 1 .Values.pg.activeHotStandby.replication.sync.numSync)) (include "bp-wordpress-tenant.cnpgPairReplicaName" .) | quote }}
       {{- end }}
       {{- end }}
+    {{- if and $haEnabled (eq (default "sync" .Values.pg.activeHotStandby.replication.mode) "sync") }}
+    # ── Synchronous replication — CNPG-native (NOT a raw parameter) ────
+    # method=first + number=N + standbyNamesPre:[<replica>] +
+    # maxStandbyNamesFromCluster:0 renders
+    # `synchronous_standby_names = FIRST N ("<replica>")` targeting the
+    # CROSS-REGION replica Cluster CR, NOT a local HA peer. Mirrors
+    # bp-cnpg-pair primary-cluster.yaml (#3740, #4139). dataDurability=required
+    # enforces the Pillar-3 zero-tx-loss bar.
+    synchronous:
+      method: first
+      number: {{ int (default 1 .Values.pg.activeHotStandby.replication.sync.numSync) }}
+      dataDurability: required
+      maxStandbyNamesFromCluster: 0
+      standbyNamesPre:
+        - {{ include "bp-wordpress-tenant.cnpgPairReplicaName" . | quote }}
+    {{- end }}
 
   resources:
     {{- toYaml .Values.database.cluster.resources | nindent 4 }}

--- a/platform/wordpress-tenant/chart/tests/active-hot-standby-render.sh
+++ b/platform/wordpress-tenant/chart/tests/active-hot-standby-render.sh
@@ -152,7 +152,16 @@ for c in clusters:
     pg_params = ((spec.get("postgresql") or {}).get("parameters") or {})
     has_hot_standby = "hot_standby" in pg_params
     sync_commit = pg_params.get("synchronous_commit", "")
+    # #4139: synchronous_standby_names is NOT a raw parameter (CNPG FIXED param —
+    # admission webhook rejects it). It is declared via the CNPG-native
+    # spec.postgresql.synchronous block, which CNPG renders into
+    # synchronous_standby_names at runtime. Assert the native block instead.
     sync_standby = pg_params.get("synchronous_standby_names", "")
+    sync_block = (spec.get("postgresql") or {}).get("synchronous") or {}
+    sync_method = sync_block.get("method", "")
+    sync_number = sync_block.get("number", "")
+    sync_pre = ",".join(sync_block.get("standbyNamesPre", []) or [])
+    sync_maxfromcluster = sync_block.get("maxStandbyNamesFromCluster", "")
     affinity_regions = []
     aff = (spec.get("affinity") or {}).get("nodeAffinity") or {}
     rdsi = (aff.get("requiredDuringSchedulingIgnoredDuringExecution") or {})
@@ -175,6 +184,10 @@ for c in clusters:
     print(f"HAS_HOT_STANDBY={has_hot_standby}")
     print(f"SYNC_COMMIT={sync_commit}")
     print(f"SYNC_STANDBY={sync_standby}")
+    print(f"SYNC_METHOD={sync_method}")
+    print(f"SYNC_NUMBER={sync_number}")
+    print(f"SYNC_STANDBY_PRE={sync_pre}")
+    print(f"SYNC_MAXFROMCLUSTER={sync_maxfromcluster}")
 PYEOF
 then
   echo "FAIL: enabled render output failed to parse as YAML" >&2
@@ -237,17 +250,36 @@ grep -q '^HAS_INITDB=True$' "$TMP/primary-facts" || {
   exit 1
 }
 # Pillar 3 (chart 0.3.2): synchronous replication MUST be the default
-# on the primary when database.mode=active-hot-standby. The primary's
-# postgresql.parameters block carries:
-#   synchronous_commit: "remote_apply"
-#   synchronous_standby_names: "FIRST 1 (wordpress-db-replica)"
+# on the primary when database.mode=active-hot-standby. The primary carries:
+#   postgresql.parameters.synchronous_commit: "remote_apply"  (settable GUC)
+#   postgresql.synchronous: {method: first, number: 1,
+#     standbyNamesPre: [wordpress-db-replica], maxStandbyNamesFromCluster: 0}
+# #4139: synchronous_standby_names is NOT a raw parameter — CNPG marks it a
+# FIXED config param and the admission webhook rejects any explicit set in
+# `parameters`. It is declared via the CNPG-native spec.postgresql.synchronous
+# block (CNPG ≥1.24), mirroring bp-cnpg-pair primary-cluster.yaml (#3740).
 grep -q '^SYNC_COMMIT=remote_apply$' "$TMP/primary-facts" || {
   echo "FAIL: primary Cluster missing synchronous_commit=remote_apply (Pillar 3 zero-tx-loss default)." >&2
   cat "$TMP/primary-facts" >&2
   exit 1
 }
-grep -q '^SYNC_STANDBY=FIRST 1 (wordpress-db-replica)$' "$TMP/primary-facts" || {
-  echo "FAIL: primary Cluster missing synchronous_standby_names=FIRST 1 (wordpress-db-replica)." >&2
+grep -q '^SYNC_STANDBY=$' "$TMP/primary-facts" || {
+  echo "FAIL: synchronous_standby_names must NOT be a raw postgresql.parameter (#4139 — CNPG FIXED param, webhook rejects it)." >&2
+  cat "$TMP/primary-facts" >&2
+  exit 1
+}
+grep -q '^SYNC_METHOD=first$' "$TMP/primary-facts" || {
+  echo "FAIL: primary Cluster missing spec.postgresql.synchronous.method=first." >&2
+  cat "$TMP/primary-facts" >&2
+  exit 1
+}
+grep -q '^SYNC_STANDBY_PRE=wordpress-db-replica$' "$TMP/primary-facts" || {
+  echo "FAIL: primary Cluster missing spec.postgresql.synchronous.standbyNamesPre=[wordpress-db-replica]." >&2
+  cat "$TMP/primary-facts" >&2
+  exit 1
+}
+grep -q '^SYNC_MAXFROMCLUSTER=0$' "$TMP/primary-facts" || {
+  echo "FAIL: primary Cluster missing spec.postgresql.synchronous.maxStandbyNamesFromCluster=0 (cross-region replica must be the ONLY sync target)." >&2
   cat "$TMP/primary-facts" >&2
   exit 1
 }

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -52,13 +52,15 @@ metadata:
     helm.sh/resource-policy: keep
 spec:
   # 2026-06-22 (#4139): lockstep with platform/wordpress-tenant/blueprint.yaml
-  # spec.version 0.4.3 + the published chart ghcr.io/openova-io/bp-wordpress-tenant:0.4.3.
+  # spec.version 0.4.4 + the published chart ghcr.io/openova-io/bp-wordpress-tenant:0.4.4.
   # 0.4.1 (the prior pin) defaulted persistence.wpContent.storageClass: local-path,
   # which the #3971 forbid-local-path-storage Kyverno ENFORCE policy DENIES on
-  # the wp-content PVC → the per-Org WordPress app can never install. 0.4.3 empties
-  # both the chart values.yaml AND the blueprint.yaml configSchema default so the
-  # PVC binds to the cluster-default durable cloud CSI. (#3870 history: 0.2.0→0.4.1.)
-  version: "0.4.3"
+  # the wp-content PVC → the per-Org WordPress app can never install. 0.4.3 emptied
+  # both the chart values.yaml AND the blueprint.yaml configSchema default; 0.4.4
+  # also moves active-hot-standby CNPG sync to the native spec.postgresql.synchronous
+  # block (the raw synchronous_standby_names param is rejected by vcluster.cnpg.io).
+  # (#3870 history: 0.2.0→0.4.1.)
+  version: "0.4.4"
   visibility: listed
   card:
     title: "WordPress (per-Organization)"
@@ -80,7 +82,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-wordpress-tenant
-    version: 0.4.3
+    version: 0.4.4
   # G117.1+G117.4+G117.5 #2744-followup (2026-06-03): lockstep with
   # platform/wordpress-tenant/blueprint.yaml. Uses {{.AppName}} so
   # multi-instance tenants get distinct hostnames per Application.
@@ -185,7 +187,7 @@ metadata:
     # console edit/curate.
     helm.sh/resource-policy: keep
 spec:
-  version: "0.4.3"
+  version: "0.4.4"
   visibility: listed
   card:
     title: "WordPress"
@@ -207,7 +209,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-wordpress-tenant
-    version: 0.4.3
+    version: 0.4.4
   # Lockstep with the bp-wordpress-tenant entry above + platform/wordpress-tenant/
   # blueprint.yaml. Same chart bytes; this is the bare-slug entrypoint only.
   topology:


### PR DESCRIPTION
## What
After the local-path fix (PR #4140/#4141, chart 0.4.3) bound the demo Org's WordPress wp-content PVC to the durable `evs-ssd` CSI, the **multi-region** WordPress (`pg.activeHotStandby.enabled=true`, two regions) hit the NEXT genuine failure on omantel.biz: the in-vcluster CNPG admission webhook rejected the primary Cluster CR.

```
admission webhook "vcluster.cnpg.io" denied the request:
Cluster.postgresql.cnpg.io "wordpress-db" is invalid:
  spec.postgresql.parameters.synchronous_standby_names:
    Invalid value: "FIRST 1 (wordpress-db-replica)": Can't set fixed configuration parameter
```

### Root cause
The chart set `synchronous_standby_names` as a **raw `postgresql.parameters` entry**. CNPG (≥1.24) marks that a FIXED configuration parameter (the operator owns it) and the admission webhook rejects any explicit set. `bp-cnpg-pair/primary-cluster.yaml` already solved this (#3740) — declare synchronous replication via the **CNPG-native `spec.postgresql.synchronous` block**, which CNPG renders into `synchronous_standby_names` at runtime.

### Fix (chart 0.4.3 → 0.4.4)
- `cnpg-cluster.yaml`: remove the raw `synchronous_standby_names` parameter; add the native `spec.postgresql.synchronous` block (`method: first`, `number: N`, `standbyNamesPre: [<replica>]`, `maxStandbyNamesFromCluster: 0`, `dataDurability: required`) — mirroring bp-cnpg-pair. `synchronous_commit` stays a raw param (it IS a settable GUC).
- `active-hot-standby-render.sh`: Case 2 now asserts the native block (method/number/standbyNamesPre/maxStandbyNamesFromCluster) and that `synchronous_standby_names` is NOT a raw param. Case 6 (async) unchanged.
- blueprint.yaml + catalog-seed pins bumped to 0.4.4 (4 pins, lockstep).

### Verification
- All 3 wordpress-tenant chart tests green; `helm lint` clean.
- Rendered native block: `method: first / number: 1 / standbyNamesPre: ["wordpress-db-replica"] / maxStandbyNamesFromCluster: 0`; no raw `synchronous_standby_names` key.

This is the chart-default fix for every multi-region per-Org WordPress; the local-path fix (0.4.3) is already live on the demo Org (PVC Bound on evs-ssd).

Refs #4139, #3740, #3971

🤖 Generated with [Claude Code](https://claude.com/claude-code)
