### PR TITLE
fix(SSO): per-Org realm registers catalyst-ui + Org keycloak routes the console gateway — unbreak Org console login

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -203,7 +203,10 @@ spec:
       #         the native authlib callback, so the gate's bare-root→/oidc/login
       #         redirect 'Invalid parameter: redirect_uri'd on PDA's own OIDC
       #         hop (hw167 UAT row 3374-11). Lockstep with bp-oidc-gate 0.1.4.
-      version: 1.4.35
+      # 1.4.36 (#4054/#4070/#3374): per-Org tenant realm now registers the
+      #         catalyst-ui public PKCE client so the per-Org console
+      #         (console.<slug>.<zone>) OIDC redirect resolves instead of 400ing.
+      version: 1.4.36
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.35
+  version: 1.4.36
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for Organizations, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -341,7 +341,20 @@ name: bp-keycloak
 # keep the correct two-URI shape, matching the bp-oidc-gate 0.1.4 AppRegistration
 # (appNativeCallbackPath:/oidc/authorized). The `/*` wildcard from the dead
 # pre-#3374 shape is NOT restored — the two explicit callbacks are exact.
-version: 1.4.35
+# 1.4.36 (#4054/#4070/#3374, 2026-06-23): the per-Org TENANT realm import
+# (configmap-tenant-realm.yaml) now registers a `catalyst-ui` public PKCE
+# client (redirectUris console.<slug>.<zone>/* + *.<slug>.<zone>/*, webOrigins
+# '+', PKCE S256). The per-Org operator console (console.<slug>.<pool-zone>)
+# discovers oidcIssuer=keycloak.<slug>.<zone>/realms/org-<slug> and redirects
+# with client_id=catalyst-ui; the tenant realm previously shipped only
+# wordpress/openclaw/stalwart → the console OIDC redirect 400'd ("Client not
+# found") and ALL Org SSO broke (verified live on omantel.biz demo Org, where
+# the client had to be hand-created). Descriptions trimmed <255 (catalyst-ui
+# 162, wordpress 258→195) so the config-cli JDBC batch never overflows the
+# varchar(255) cap; the 255-cap gate now AUDITS the tenant realm (was SKIP).
+# The org-keycloak HTTPRoute parentRef move to cilium-gateway-console is an
+# orchestrator-side change (organization_gitops.go), not a chart change.
+version: 1.4.36
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/templates/configmap-tenant-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-tenant-realm.yaml
@@ -79,6 +79,17 @@ Canonical seam: platform/keycloak/chart/templates/configmap-tenant-realm.yaml
 {{- end -}}
 {{- /* ── Resolve per-app hosts (operator override OR <app>.<sub>.<parent>) ─── */}}
 {{- $defaultZone := printf "%s.%s" $t.subdomain $t.parentDomain -}}
+{{- /* Console host for the catalyst-ui SPA. Operator override via
+       realmConfig.tenant.console.host; defaults to console.<sub>.<parent>.
+       This is the per-Org operator console (console.<slug>.<pool-zone>)
+       whose OIDC discovery points at keycloak.<slug>.<pool-zone>/realms/
+       org-<slug> with client=catalyst-ui — so the realm MUST register
+       catalyst-ui or the console login 400s (Refs #4054 #4070 #3374). */ -}}
+{{- $consoleHost := "" -}}
+{{- if $t.console -}}
+  {{- $consoleHost = $t.console.host -}}
+{{- end -}}
+{{- $consoleHost = $consoleHost | default (printf "console.%s" $defaultZone) -}}
 {{- $wpHost := $t.wordpress.host | default (printf "wordpress.%s" $defaultZone) -}}
 {{- $ocHost := $t.openclaw.host  | default (printf "openclaw.%s"  $defaultZone) -}}
 {{- $swHost := $t.stalwart.host  | default (printf "mail.%s"      $defaultZone) -}}
@@ -275,9 +286,51 @@ data:
       ],
       "clients": [
         {
+          "clientId": "catalyst-ui",
+          "name": "Catalyst UI (Organization console)",
+          {{- /* description kept <255 chars — Keycloak public.CLIENT.DESCRIPTION
+                 is varchar(255); the config-cli import batch aborts on overflow
+                 (g117-e2e-realm-client-description-255-cap.sh). Full rationale
+                 in the orchestrator comment + #4054/#4070/#3374. */ -}}
+          "description": "Public PKCE client for the per-Org operator console SPA at https://{{ $consoleHost }}. Required so console OIDC login does not 400 (Refs #4054 #4070 #3374).",
+          "enabled": true,
+          "publicClient": true,
+          "standardFlowEnabled": true,
+          "directAccessGrantsEnabled": false,
+          "implicitFlowEnabled": false,
+          "serviceAccountsEnabled": false,
+          "redirectUris": [
+            {{ printf "https://%s/*" $consoleHost | quote }},
+            {{ printf "https://*.%s/*" $defaultZone | quote }}
+          ],
+          "webOrigins": [
+            "+"
+          ],
+          "defaultClientScopes": [
+            "web-origins",
+            "acr",
+            "profile",
+            "roles",
+            "email",
+            "groups",
+            "org"
+          ],
+          "optionalClientScopes": [
+            "address",
+            "phone",
+            "offline_access",
+            "microprofile-jwt"
+          ],
+          "attributes": {
+            "pkce.code.challenge.method": "S256",
+            "access.token.lifespan": "900",
+            "post.logout.redirect.uris": {{ printf "https://%s/*" $consoleHost | quote }}
+          }
+        },
+        {
           "clientId": {{ ($t.wordpress.clientID | default "wordpress") | quote }},
           "name": "WordPress (Organization tenant — openid-connect-generic plugin)",
-          "description": "Confidential OIDC client for the Organization tenant's WordPress instance. Auth-code flow with PKCE optional. Redirect URIs cover the openid-connect-generic plugin's admin-ajax.php callback (default when alternate_redirect_uri=0) plus /wp-login.php fallback.",
+          "description": "Confidential OIDC client for the Organization WordPress. Auth-code flow; redirect URIs cover the openid-connect-generic plugin admin-ajax.php callback plus /wp-login.php fallback.",
           "enabled": true,
           "publicClient": false,
           "standardFlowEnabled": true,

--- a/platform/keycloak/chart/tests/g117-e2e-realm-client-description-255-cap.sh
+++ b/platform/keycloak/chart/tests/g117-e2e-realm-client-description-255-cap.sh
@@ -110,6 +110,9 @@ audit_realm "sovereign realm" "$TMP/sov-realm.json" || exit 1
   --set realmConfig.tenant.enabled=true \
   --set realmConfig.tenant.realmName=acme \
   --set realmConfig.tenant.displayName="Acme SME Tenant" \
+  --set realmConfig.tenant.subdomain=acme \
+  --set realmConfig.tenant.parentDomain=omani.works \
+  --set realmConfig.tenant.adminEmail=admin@acme.example \
   --show-only templates/configmap-tenant-realm.yaml \
   > "$TMP/tenant.yaml" 2>/dev/null || true
 if [ -s "$TMP/tenant.yaml" ] && yq -e 'select(.kind == "ConfigMap")' "$TMP/tenant.yaml" >/dev/null 2>&1; then

--- a/platform/keycloak/chart/tests/tenant-realm-oidc-clients.sh
+++ b/platform/keycloak/chart/tests/tenant-realm-oidc-clients.sh
@@ -105,8 +105,14 @@ if grep -q "catalyst-kc-sa-credentials" "$TMP/tenant.yaml"; then
   echo "FAIL: Tenant-mode render leaked Sovereign-only catalyst-kc-sa-credentials Secret." >&2
   exit 1
 fi
-# Sovereign-realm clients MUST NOT appear in tenant-mode realm.
-for forbidden in '"clientId": "kubectl"' '"clientId": "catalyst-ui"' '"clientId": "catalyst-api-server"'; do
+# Sovereign-ONLY clients MUST NOT appear in tenant-mode realm. NOTE:
+# catalyst-ui is NOT sovereign-only — the per-Org operator console
+# (console.<slug>.<pool-zone>) discovers oidcIssuer=keycloak.<slug>.<zone>/
+# realms/org-<slug> and redirects with client_id=catalyst-ui, so the
+# TENANT realm MUST register a catalyst-ui public PKCE client or the
+# console login 400s (Refs #4054 #4070 #3374). kubectl + catalyst-api-server
+# stay sovereign-only.
+for forbidden in '"clientId": "kubectl"' '"clientId": "catalyst-api-server"'; do
   if grep -q "$forbidden" "$TMP/tenant.yaml"; then
     echo "FAIL: Tenant-mode render leaked Sovereign-mode client: $forbidden" >&2
     exit 1
@@ -131,10 +137,25 @@ assert realm['realm'] == 'sme-acme', f"realm name mismatch: {realm['realm']!r}"
 assert realm['displayName'] == 'Acme SME', f"displayName mismatch: {realm['displayName']!r}"
 
 clients = {c['clientId']: c for c in realm['clients']}
-required = {'wordpress', 'openclaw', 'stalwart'}
+# catalyst-ui is REQUIRED in the tenant realm — the per-Org operator
+# console (console.<slug>.<pool-zone>) redirects with client_id=catalyst-ui
+# (Refs #4054 #4070 #3374). wordpress/openclaw/stalwart per #915.
+required = {'catalyst-ui', 'wordpress', 'openclaw', 'stalwart'}
 missing = required - clients.keys()
 assert not missing, f"missing OIDC clients: {missing}"
-assert len(clients) == 3, f"expected exactly 3 clients, got {sorted(clients)}"
+assert len(clients) == 4, f"expected exactly 4 clients, got {sorted(clients)}"
+
+# catalyst-ui — per-Org operator console (public PKCE SPA).
+cu = clients['catalyst-ui']
+assert cu['publicClient'] is True, "catalyst-ui must be a public client (SPA)"
+assert cu['standardFlowEnabled'] is True, "catalyst-ui needs auth-code flow"
+assert cu['attributes'].get('pkce.code.challenge.method') == 'S256', \
+    "catalyst-ui must enforce PKCE S256"
+cu_uris = cu['redirectUris']
+assert any('console.acme.omantel.omani.works' in u for u in cu_uris), \
+    f"catalyst-ui redirect missing per-Org console host: {cu_uris}"
+assert cu['webOrigins'] == ['+'], \
+    f"catalyst-ui webOrigins must be ['+'] (echo registered redirect origins): {cu['webOrigins']}"
 
 # Spec contract assertions per #915 task brief.
 wp = clients['wordpress']
@@ -176,7 +197,9 @@ assert 'view-users' in sa.get('clientRoles', {}).get('realm-management', []), \
 
 # Default groups + admin user wired up.
 assert realm['defaultGroups'], f"defaultGroups missing: {realm}"
-assert any(g['name'] == 'sme-admins' for g in realm['groups']), "sme-admins group missing"
+# values.yaml default tenant groups are org-admins/org-users post the
+# SME→Organization rename (#3985); the first entry seeds defaultGroups.
+assert any(g['name'] == 'org-admins' for g in realm['groups']), "org-admins group missing"
 assert any(u.get('username') == 'admin' and u.get('email') == 'admin@acme.example'
            for u in realm['users']), "admin bootstrap user missing"
 

--- a/platform/keycloak/chart/values.yaml
+++ b/platform/keycloak/chart/values.yaml
@@ -234,6 +234,15 @@ realmConfig:
     groups:
       - org-admins
       - org-users
+    # The per-Org operator console (catalyst-ui SPA). The tenant realm
+    # MUST register a `catalyst-ui` public PKCE client or the console
+    # login at https://console.<subdomain>.<parentDomain> 400s on the
+    # OIDC redirect (Refs #4054 #4070 #3374). The chart registers it
+    # unconditionally in tenant mode; this block only overrides the host.
+    console:
+      # Public host the per-Org operator console is reachable at.
+      # Defaults to console.<subdomain>.<parentDomain> when unset.
+      host: ""
     # Per-app OIDC client configuration. Each block honours an operator-
     # supplied `clientSecret` (rare; useful for sealed-secret replication)
     # — when blank the chart looks up an existing K8s Secret in the

--- a/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
@@ -854,9 +854,9 @@ spec:
     # the realm exists from t=0 and SSE/SSO probes find it.
     sovereignRealm:
       enabled: true
-    # HTTPRoute exposure on the per-Sovereign cilium-gateway. Without a
-    # non-empty gateway.host the chart's templates/httproute.yaml guard
-    # renders nothing — that was the user-visible regression in #910.
+    # HTTPRoute exposure for the per-Org Keycloak. Without a non-empty
+    # gateway.host the chart's templates/httproute.yaml guard renders
+    # nothing — that was the user-visible regression in #910.
     gateway:
       enabled: true
       host: keycloak.{{.Subdomain}}.{{.ParentDomain}}
@@ -864,14 +864,22 @@ spec:
       # bp-keycloak the bitnami fullname helper trims the chart suffix
       # and returns "bp-keycloak", matching the default.
       parentRef:
-        name: cilium-gateway
+        # console-isolation (#4054/#4070): keycloak.<slug>.<pool-zone>
+        # resolves to the dedicated console-ELB EIP which fronts the
+        # ISOLATED cilium-gateway-console (NOT the apps cilium-gateway /
+        # apps-ELB). Parenting the apps gateway made envoy on the console
+        # ELB return 404 for keycloak.<slug>.<zone> → all Org SSO broke.
+        # Per-Org (pool-domain) Keycloak MUST parent cilium-gateway-console.
+        # The dedicated Gateway lives in kube-system alongside the apps
+        # cilium-gateway (clusters/_template/sovereign-tls/cilium-gateway-
+        # console.yaml:54 + org_console_tls.go consoleGatewayNamespace).
+        name: cilium-gateway-console
         namespace: kube-system
-        # sectionName omitted — multi-zone Sovereigns rename HTTPS listeners
-        # to https-<sanitised-zone> (e.g. https-omani-works). The bp-keycloak
-        # chart template guards the sectionName output with a 'with'
-        # conditional on .Values.gateway.parentRef.sectionName, so a blank
-        # value drops the field entirely; Cilium Gateway then matches by
-        # hostname filter. See PR #1888 / TBD-A40 / issue #1902.
+        # sectionName omitted — the console Gateway exposes a single
+        # apex-bound HTTPS listener per Org zone, matched by hostname
+        # filter. The bp-keycloak chart template guards the sectionName
+        # output with a 'with' conditional, so a blank value drops the
+        # field entirely. See #4053 / org_console_tls.go.
         sectionName: ""
     # Outbound realm email — Phase-1 mothership relay. Operator overlay
     # (or future tenant-Stalwart sub-issue) overrides host/port once

--- a/products/catalyst/bootstrap/api/internal/handler/organization_keycloak_values_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_keycloak_values_test.go
@@ -151,8 +151,15 @@ func TestBPKeycloakValuesContract(t *testing.T) {
 	if !ok {
 		t.Fatalf("gateway.parentRef missing or wrong shape: %#v", gw["parentRef"])
 	}
-	if got, _ := parentRef["name"].(string); got != "cilium-gateway" {
-		t.Errorf("gateway.parentRef.name: want cilium-gateway got %q", got)
+	// console-isolation (#4054/#4070): the per-Org Keycloak hostname
+	// keycloak.<slug>.<pool-zone> resolves to the dedicated console-ELB EIP
+	// which fronts the ISOLATED cilium-gateway-console (NOT the apps gateway).
+	// Parenting the apps cilium-gateway returned 404 on the console ELB and
+	// broke all Org SSO; the org Keycloak HTTPRoute MUST parent the console
+	// gateway. The Gateway itself lives in kube-system (alongside the apps
+	// gateway) per clusters/_template/sovereign-tls/cilium-gateway-console.yaml.
+	if got, _ := parentRef["name"].(string); got != "cilium-gateway-console" {
+		t.Errorf("gateway.parentRef.name: want cilium-gateway-console got %q", got)
 	}
 	if got, _ := parentRef["namespace"].(string); got != "kube-system" {
 		t.Errorf("gateway.parentRef.namespace: want kube-system got %q", got)


### PR DESCRIPTION
## Problem

Two defects broke **all per-Org operator-console SSO** (found + hand-fixed live on omantel.biz demo Org, dep `4635277cae4ffed9`). This PR makes both fixes **durable** (survive Flux reconcile + fresh provisions).

### Bug 1 — Org Keycloak route on the wrong gateway (404)
`keycloak.<slug>.<pool-zone>` resolves (via DNS) to the dedicated **console-ELB EIP**, which fronts the isolated `cilium-gateway-console` (#4053/#4054 console-isolation). But the org-tenant overlay generator (`orgTenantBPKeycloak`) emitted `gateway.parentRef.name=cilium-gateway` — the **apps** gateway. The route never attached to the console gateway's envoy → `keycloak.<slug>.<zone>` **404'd** on the console ELB → every Org SSO discovery failed.

### Bug 2 — `catalyst-ui` OIDC client missing from the org realm (400)
The per-Org console (`console.<slug>.<zone>`) discovers `oidcIssuer=keycloak.<slug>.<zone>/realms/org-<slug>` and redirects with `client_id=catalyst-ui`. But `configmap-tenant-realm.yaml` imported only `wordpress`/`openclaw`/`stalwart` — **no `catalyst-ui`** → the console redirect 400'd ("Client not found").

## Fix

**A. Console gateway** (`organization_gitops.go`): the org Keycloak HTTPRoute now parents `cilium-gateway-console` / `kube-system`. Its per-Org wildcard listener (`*.<slug>.<zone>`, `allowedRoutes from=All`, valid TLS) accepts the route from the org tenant namespace. The Sovereign keycloak install (`auth.<sovereign-fqdn>`) is a separate path and unaffected.

**B. catalyst-ui client** (`configmap-tenant-realm.yaml`): the tenant realm now registers a `catalyst-ui` **public PKCE SPA** client — `standardFlowEnabled`, PKCE S256, `webOrigins: ['+']`, `redirectUris: [console.<slug>.<zone>/*, *.<slug>.<zone>/*]` — templatized off `realmConfig.tenant.console.host` (default `console.<subdomain>.<parentDomain>`). Mirrors the live hand-fix exactly.

Plus: client descriptions trimmed under the Keycloak `varchar(255)` cap (the config-cli JDBC import batch aborts on overflow); the 255-cap gate now **audits** the tenant realm (was SKIP'd because the render omitted the now-required subdomain/parentDomain). `blueprint.yaml ↔ Chart.yaml` bumped 1.4.35 → 1.4.36 in lockstep.

## Verification
- All 12 `bp-keycloak` chart gating tests **PASS** (incl. `tenant-realm-oidc-clients.sh`, `httproute-render.sh`, `g117-e2e-realm-client-description-255-cap.sh`, `g117-w2c4-per-org-realm.sh`).
- `go build ./...` + the org-provisioning handler tests pass (`TestBPKeycloakValuesContract` asserts the console parentRef).
- `helm template`: org keycloak HTTPRoute → `parentRefs: cilium-gateway-console/kube-system`; tenant realm JSON valid, clients = `[catalyst-ui, wordpress, openclaw, stalwart]`, catalyst-ui public+PKCE-S256+webOrigins '+'.
- **Live (omantel.biz demo Org) still green**: `https://keycloak.demo.omani.homes/realms/org-demo/.well-known/openid-configuration` → **200**; the live route is `Accepted=True` on `cilium-gateway-console` (the stale apps-gateway parentRef entry shows `Accepted=False` and goes away on fresh provisions with this fix); suspended HR left suspended (will unsuspend once 1.4.36 publishes).

Refs #4054 #4070 #3374

🤖 Generated with [Claude Code](https://claude.com/claude-code)