### PR TITLE
fix(bp-wordpress-tenant): wp-plugin-install init runs as root (apt needs root) — un-CrashLoop demo-Org wordpress

### DIFF
--- a/platform/wordpress-tenant/blueprint.yaml
+++ b/platform/wordpress-tenant/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: tenant-app
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.4.4
+  version: 0.4.5
   card:
     title: WordPress (per-Organization)
     summary: |

--- a/platform/wordpress-tenant/chart/Chart.yaml
+++ b/platform/wordpress-tenant/chart/Chart.yaml
@@ -105,7 +105,7 @@ name: bp-wordpress-tenant
 #   Mirrors bp-cnpg-pair primary-cluster.yaml (#3740). Also folds the #3985 rename
 #   residue in oidcIssuerURL/ingressHost helpers (the gate that blocked 0.4.2/0.4.3
 #   publish until repaired this session).
-version: 0.4.4
+version: 0.4.5
 appVersion: "6"
 description: |
   Catalyst Blueprint scratch chart for in-vcluster WordPress, one

--- a/platform/wordpress-tenant/chart/templates/deployment.yaml
+++ b/platform/wordpress-tenant/chart/templates/deployment.yaml
@@ -100,7 +100,18 @@ spec:
           image: {{ include "bp-wordpress-tenant.wordpressImage" . | quote }}
           imagePullPolicy: {{ .Values.wordpress.image.pullPolicy }}
           securityContext:
-            {{- toYaml .Values.wordpress.containerSecurityContext | nindent 12 }}
+            # wp-plugin-install runs `apt-get install unzip` (root-only) on the
+            # first-PVC seed; the MAIN wordpress container keeps the shared
+            # wordpress.containerSecurityContext (uid 33). Init-as-root for a
+            # one-time setup step is standard; the rest stays locked down.
+            # (demo-Org convergence 2026-06-23: this init CrashLooped on
+            # `E: ... /var/lib/apt/lists/partial ... Permission denied` as uid 33.)
+            runAsUser: 0
+            runAsNonRoot: false
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop: ["ALL"]
           command:
             - /bin/bash
             - -c


### PR DESCRIPTION
**Live on omantel.biz (demo Org), 2026-06-23:** `demo-wp-blog`/`demo-wp-shop` stuck Pending because `bp-wordpress-tenant`'s `wp-plugin-install` init CrashLooped: it runs `apt-get install unzip` (one-time, first-PVC seed) but inherited the uid-33 container securityContext → `/var/lib/apt/lists/partial: Permission denied`. This init now runs as root (caps dropped, no priv-esc, RO-fs off for the apt write) while the **main** container keeps the locked-down uid-33 context. Live-patched first → init progressed past the crash. Refs #3971.