### PR TITLE
fix(bp-stalwart-tenant): converge per-Org Stalwart on fresh prov — pin v0.15.5, explicit --config, mount /etc/stalwart/tls cert (0.1.5)

### DIFF
--- a/platform/stalwart-tenant/blueprint.yaml
+++ b/platform/stalwart-tenant/blueprint.yaml
@@ -14,8 +14,17 @@ spec:
   # (`directory.keycloak.@type = "Oidc"`, `issuerUrl`, `claimUsername`,
   # `claimName`, `claimGroups`). setupJob defaults to enabled so a
   # fresh tenant has working OIDC at t=0.
+  # 0.1.5 (#4148) — the per-Org Stalwart never converged on a fresh prov.
+  # Three chart bugs, all live-validated on the omantel.biz demo Org (kom4dc):
+  # (a) image v0.16.3 CrashLooped on this chart's v0.15-era TOML (v0.16.x
+  # parser rewrite) → pinned v0.15.5 to match bp-stalwart-sovereign; (b) no
+  # explicit --config arg → inherited the image's wrong default config path
+  # → fixed with args: [--config, /opt/stalwart/etc/config.toml]; (c)
+  # config.toml's [certificate.default] read /etc/stalwart/tls/* with no such
+  # mount → added a tls Secret volume + a cert-manager Certificate for
+  # mail.<tenant-domain> (secret name via stalwart.tls.secretName).
   # Per #817 Chart.yaml version MUST equal blueprint.yaml spec.version.
-  version: 0.1.4
+  version: 0.1.5
   card:
     title: Stalwart (per-Organization)
     summary: |

--- a/platform/stalwart-tenant/chart/Chart.yaml
+++ b/platform/stalwart-tenant/chart/Chart.yaml
@@ -58,8 +58,25 @@ name: bp-stalwart-tenant
 # 0.1.4 (#4139): default image registry docker.io → harbor.openova.io/proxy-dockerhub
 #   for BOTH the StatefulSet + the mailbox-provision setup Job, so the kom4dc node
 #   cold-pull does not traverse the public internet (ImagePullBackOff on fresh prov).
-version: 0.1.4
-appVersion: "0.16.3"
+# 0.1.5 (#4148): the per-Org Stalwart never converged on a fresh prov — three
+#   chart bugs, all diagnosed + live-validated on the omantel.biz demo Org (kom4dc):
+#     a. image tag v0.16.3 CrashLooped on the v0.15-era TOML this chart emits
+#        (Stalwart v0.16.x rewrote the config parser → `expected value at line 1
+#        column 2`). Pinned image v0.16.3 → v0.15.5 (StatefulSet + setup Job),
+#        matching the WORKING bp-stalwart-sovereign chart. appVersion → 0.15.5.
+#     b. no explicit --config arg → the StatefulSet inherited the image's
+#        default `--config /etc/stalwart/config.json` (wrong path + format) and
+#        started in bootstrap mode. Added explicit
+#        `args: [--config, /opt/stalwart/etc/config.toml]`.
+#     c. config.toml's [certificate.default] reads /etc/stalwart/tls/{tls.crt,
+#        tls.key} but the StatefulSet mounted no such volume → cert file absent
+#        → config parse fails. Added a `tls` Secret volume + readOnly mount at
+#        /etc/stalwart/tls, plus a cert-manager Certificate (templates/
+#        certificate.yaml) for mail.<tenant-domain> that materialises the
+#        Secret zero-touch (secret name configurable via stalwart.tls.secretName,
+#        default stalwart-tls).
+version: 0.1.5
+appVersion: "0.15.5"
 description: |
   Catalyst Blueprint scratch chart for a per-Org (per-vcluster) dedicated
   Stalwart mail server. Implements locked decision [Q3] of EPIC #795

--- a/platform/stalwart-tenant/chart/templates/certificate.yaml
+++ b/platform/stalwart-tenant/chart/templates/certificate.yaml
@@ -1,0 +1,56 @@
+{{- /*
+Server-TLS leaf certificate for the per-Org Stalwart (#4148).
+
+The bootstrap config.toml's `[certificate.default]` block reads the cert
++ key from `/etc/stalwart/tls/{tls.crt,tls.key}` at parse time. Stalwart
+presents this leaf on the implicit-TLS / STARTTLS listeners (submissions
+465, imaps 993, https 8443, plus STARTTLS on 587/143). The StatefulSet
+mounts the `stalwart.tls.secretName` Secret read-only at /etc/stalwart/tls;
+this cert-manager Certificate materialises that Secret zero-touch on a
+fresh prov so the pod never CrashLoops on a missing cert file.
+
+Two SANs:
+  - mail.<tenant-domain>  — the webmail host (matches webmailHost helper);
+  - <tenant-domain>       — the bare apex so MX-delivered STARTTLS on
+                            mail addressed to `<user>@<tenant-domain>`
+                            validates the hostname.
+
+Rendered ONLY when:
+  - stalwart.enabled
+  - stalwart.tls.certificate.enabled
+  - the tenant domain resolves (empty → smoke-render-safe skip, mirroring
+    ingress-webmail.yaml's empty-host gate so CI's default-values render
+    stays valid).
+
+Operators who would rather reflect an existing per-Org wildcard Secret
+set `stalwart.tls.certificate.enabled=false` and point
+`stalwart.tls.secretName` at that Secret (Inviolable Principle #4).
+*/}}
+{{- if and .Values.stalwart.enabled .Values.stalwart.tls.certificate.enabled }}
+{{- $domain := include "bp-stalwart-tenant.tenantDomain" . -}}
+{{- $host := include "bp-stalwart-tenant.webmailHost" . -}}
+{{- if and $domain $host }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ printf "%s-tls" (include "bp-stalwart-tenant.fullname" .) | trunc 63 | trimSuffix "-" }}
+  labels:
+    {{- include "bp-stalwart-tenant.labels" . | nindent 4 }}
+spec:
+  secretName: {{ .Values.stalwart.tls.secretName | quote }}
+  duration: {{ .Values.stalwart.tls.certificate.duration | quote }}
+  renewBefore: {{ .Values.stalwart.tls.certificate.renewBefore | quote }}
+  privateKey:
+    rotationPolicy: Always
+    algorithm: ECDSA
+    size: 256
+  dnsNames:
+    - {{ $host | quote }}
+    {{- if ne $host $domain }}
+    - {{ $domain | quote }}
+    {{- end }}
+  issuerRef:
+    name: {{ .Values.stalwart.tls.certificate.issuer | quote }}
+    kind: {{ .Values.stalwart.tls.certificate.issuerKind | quote }}
+{{- end }}
+{{- end }}

--- a/platform/stalwart-tenant/chart/templates/deployment.yaml
+++ b/platform/stalwart-tenant/chart/templates/deployment.yaml
@@ -38,6 +38,14 @@ spec:
         - name: stalwart
           image: {{ include "bp-stalwart-tenant.image" . | quote }}
           imagePullPolicy: {{ .Values.stalwart.image.pullPolicy }}
+          # #4148 — pin the config path explicitly. The upstream image's
+          # default CMD is `--config /etc/stalwart/config.json` (wrong path
+          # AND wrong format); inheriting it made the pod start in bootstrap
+          # mode ("No configuration file was found") on a fresh tenant. The
+          # bp-stalwart-sovereign pod runs the same explicit
+          # `--config /opt/stalwart/etc/config.toml` invocation. Pinning it
+          # here makes the StatefulSet image-version-independent.
+          args: ["--config", "/opt/stalwart/etc/config.toml"]
           securityContext:
             {{- toYaml .Values.stalwart.containerSecurityContext | nindent 12 }}
           ports:
@@ -81,6 +89,13 @@ spec:
             - name: config
               mountPath: /opt/stalwart/etc
               readOnly: true
+            # #4148 — the bootstrap config.toml's [certificate.default]
+            # block references %{file:/etc/stalwart/tls/tls.crt}% +
+            # tls.key. Without this mount the cert file is absent and the
+            # whole config fails to parse (root cause #3, verified live).
+            - name: tls
+              mountPath: /etc/stalwart/tls
+              readOnly: true
           livenessProbe:
             tcpSocket:
               port: smtp
@@ -102,6 +117,21 @@ spec:
             items:
               - key: config.toml
                 path: config.toml
+        # #4148 — kubernetes.io/tls Secret carrying tls.crt + tls.key.
+        # Emitted by templates/certificate.yaml (cert-manager Certificate
+        # for mail.<tenant-domain>) when stalwart.tls.certificate.enabled,
+        # or an operator-reflected per-Org wildcard Secret of the same name.
+        - name: tls
+          secret:
+            secretName: {{ .Values.stalwart.tls.secretName | quote }}
+            # NON-optional on purpose. If the Secret is not yet present the
+            # kubelet holds the pod at ContainerCreating until cert-manager
+            # issues the leaf into it — then it starts clean. An `optional:
+            # true` mount would let the pod start with an EMPTY /etc/stalwart/
+            # tls, the cert file would be absent, and the config.toml parse
+            # would fail → CrashLoop (the exact bug this fixes). Blocking at
+            # ContainerCreating until the cert exists is the correct
+            # convergence behaviour and matches bp-stalwart-sovereign.
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/platform/stalwart-tenant/chart/values.yaml
+++ b/platform/stalwart-tenant/chart/values.yaml
@@ -31,24 +31,65 @@ stalwart:
   # `global.imageRegistry` value (when set by the per-Sovereign overlay
   # post-handover) rewrites the registry on every pull.
   #
-  # Digest below is `docker.io/stalwartlabs/stalwart:v0.16.3` linux/amd64
-  # (verified via Docker Hub API on 2026-05-04).
+  # #4148 — PINNED to v0.15.5 (was v0.16.3). Stalwart v0.16.x rewrote the
+  # config parser: the v0.15-era TOML this chart emits in
+  # templates/config-configmap.yaml made the v0.16.3 image CrashLoop at
+  # startup with `⚠️ Startup failed: Failed to parse data store settings at
+  # /opt/stalwart/etc/config.toml: expected value at line 1 column 2` (the
+  # JSON-style parser choking on `[server]`). The WORKING bp-stalwart-sovereign
+  # chart runs v0.15.5 against the SAME TOML shape and stays 1/1 Running.
+  # Validated live on the omantel.biz demo Org (kom4dc): hand-patching the
+  # StatefulSet to v0.15.5 + the --config arg + the TLS mount brought the pod
+  # to 1/1 Running. Digest intentionally cleared — the `.image` helper honours
+  # `tag` when `digest` is empty, and we did not have a verified v0.15.5 digest
+  # at fix time. A per-Sovereign overlay may re-pin a digest if desired.
   image:
     # #4139 — pull through the Sovereign Harbor proxy-dockerhub project so the
     # kom4dc node cold-pull does NOT traverse the public internet to docker.io
     # (which ImagePullBackOffs on a fresh prov, mirroring the #3859 vcluster
-    # coredns + #4137 valkey bitnamilegacy fixes). The proxy-cache mirror serves
-    # the SAME digest (verified 200 via harbor v2 API). A per-Sovereign overlay
+    # coredns + #4137 valkey bitnamilegacy fixes). A per-Sovereign overlay
     # may still rewrite this via `global.imageRegistry` post-handover.
     registry: harbor.openova.io/proxy-dockerhub
     repository: stalwartlabs/stalwart
-    tag: "v0.16.3"
-    digest: "sha256:5d75cff4e9c6d75e64636e9ef9674b1d877f8f6fb2e11ee8176fbad3faaa5289"
+    tag: "v0.15.5"
+    digest: ""
     pullPolicy: IfNotPresent
     # Per-Sovereign Harbor pull secret. Empty by default — Sovereign
     # bootstrap-kit overlay supplies the tenant-namespace dockercfg
     # secret name once Harbor proxy-cache is wired (ADR-0001 §11.5).
     pullSecrets: []
+
+  # ─── Server TLS certificate (#4148) ──────────────────────────────────
+  # The bootstrap config.toml's `[certificate.default]` block references
+  # `%{file:/etc/stalwart/tls/tls.crt}%` + `tls.key`. Stalwart reads those
+  # files at parse time, so the StatefulSet MUST mount a kubernetes.io/tls
+  # Secret at `/etc/stalwart/tls` or the config never parses and the pod
+  # CrashLoops (root cause #3 — verified live on the omantel.biz demo Org).
+  #
+  # `secretName` is the kubernetes.io/tls Secret the StatefulSet mounts
+  # read-only at `/etc/stalwart/tls` (keys `tls.crt` + `tls.key`). When
+  # `certificate.enabled=true` (default) the chart emits a cert-manager
+  # Certificate for `mail.<tenant-domain>` against `certificate.issuer`,
+  # which cert-manager materialises INTO this same Secret name — so the
+  # mount is satisfied zero-touch on a fresh prov. Operators who want to
+  # reflect an existing per-Org wildcard Secret instead may set
+  # `certificate.enabled=false` and point `secretName` at the reflected
+  # Secret (Inviolable Principle #4 — every knob overridable).
+  tls:
+    secretName: "stalwart-tls"
+    certificate:
+      # Emit a cert-manager Certificate for mail.<tenant-domain> →
+      # `secretName`. Default ON so a fresh tenant gets a real leaf cert
+      # with NO operator action. Skipped automatically when the tenant
+      # domain is empty (smoke-render-safe).
+      enabled: true
+      # ClusterIssuer to sign against. Defaults to the same issuer the
+      # webmail Ingress uses (`letsencrypt-prod`); a per-Sovereign overlay
+      # may swap to a staging/internal issuer.
+      issuerKind: "ClusterIssuer"
+      issuer: "letsencrypt-prod"
+      duration: "2160h"      # 90d
+      renewBefore: "360h"    # 15d
 
   resources:
     requests:
@@ -60,7 +101,7 @@ stalwart:
 
   # SecurityContext — non-root + NET_BIND_SERVICE (issue #898).
   #
-  # Stalwart's upstream image (docker.io/stalwartlabs/stalwart:v0.16.3)
+  # Stalwart's upstream image (docker.io/stalwartlabs/stalwart:v0.15.5)
   # creates an in-image `stalwart` user at UID 2000 and ships the
   # binary at /usr/local/bin/stalwart with file capability
   # `cap_net_bind_service=ep`. The binary needs that capability to
@@ -355,9 +396,12 @@ mailboxProvisioner:
       # directly (no registry field), so the harbor proxy path is carried in
       # the repository value, matching the StatefulSet's registry default and
       # avoiding the docker.io cold-pull ImagePullBackOff on kom4dc.
+      # #4148 — PINNED to v0.15.5 in lockstep with the StatefulSet image so the
+      # setup-Job's stalwart-cli / curl bytes trace back to the SAME running
+      # image. Digest cleared (tag-pinned) per the StatefulSet note above.
       repository: harbor.openova.io/proxy-dockerhub/stalwartlabs/stalwart
-      tag: "v0.16.3"
-      digest: "sha256:5d75cff4e9c6d75e64636e9ef9674b1d877f8f6fb2e11ee8176fbad3faaa5289"
+      tag: "v0.15.5"
+      digest: ""
       pullPolicy: IfNotPresent
     # Job timeout — the Stalwart pod must be Ready before the Job's
     # API calls succeed. 10 min is generous for cold starts on small


### PR DESCRIPTION
## Summary
The per-Org (per-vcluster) Stalwart mailbox app (`bp-stalwart-tenant`) **never reached `1/1 Running` on a fresh Sovereign prov**. Three chart bugs combined to make the StatefulSet pod CrashLoop at startup on the bootstrap config.toml. All three were **diagnosed LIVE and validated on the omantel.biz demo Org (Huawei kom4dc)** — hand-patching the live StatefulSet with these exact three changes brought the pod to `1/1 Running`. This PR makes those live patches **durable in the chart** so a fresh prov converges zero-touch.

> Live env was **NOT rolled** — the HR is suspended; the hand-patches are holding. Deliverable is the merge-ready PR only.

## Root causes (all verified live)

### 1. Image version drift broke config parsing
`chart/values.yaml` pinned image tag `v0.16.3` (StatefulSet **and** the mailbox-provision setup-Job image), but the chart emits **v0.15-era TOML**. Stalwart v0.16.x rewrote the config parser, so the live pod crashed with:
```
⚠️ Startup failed: Failed to parse data store settings at /opt/stalwart/etc/config.toml: expected value at line 1 column 2
```
(a JSON-style parser choking on `[server]`). The WORKING `bp-stalwart-sovereign` chart runs **v0.15.5** against the SAME TOML shape and stays `1/1 Running` for days.
**Fix:** pin image `v0.16.3 → v0.15.5` in BOTH places; digest cleared so the `.image` helper honours the tag. `appVersion` → `0.15.5`.

### 2. No explicit `--config` arg → wrong image-default path
The v0.16.3 image's default CMD is `--config /etc/stalwart/config.json` (wrong path AND format). The StatefulSet set no `command`/`args`, so it inherited that bad default → `Server started in bootstrap mode ... No configuration file was found`. The sovereign pod runs `--config /opt/stalwart/etc/config.toml`.
**Fix:** add `args: ["--config", "/opt/stalwart/etc/config.toml"]` — image-version-independent.

### 3. Missing TLS cert mount
`config.toml`'s `[certificate.default]` references `%{file:/etc/stalwart/tls/tls.crt}%` + `tls.key`, but the StatefulSet mounted ONLY `/opt/stalwart` (data) + `/opt/stalwart/etc` (config). No `/etc/stalwart/tls` mount → cert file absent → config parse fails.
**Fix:** add a `tls` Secret volume + readOnly mount at `/etc/stalwart/tls`, plus a **cert-manager `Certificate`** (`templates/certificate.yaml`) for `mail.<tenant-domain>` (+ bare-apex SAN) that materialises the Secret zero-touch. The mount is **non-optional** (pod blocks at `ContainerCreating` until cert-manager issues the leaf, then starts clean — never an empty-dir CrashLoop). Secret name configurable via `stalwart.tls.secretName` (default `stalwart-tls`); the Certificate is skippable (`stalwart.tls.certificate.enabled=false`) for operators who reflect an existing per-Org wildcard instead.

## Files changed
- `platform/stalwart-tenant/chart/values.yaml` — image tag `v0.16.3→v0.15.5` + digest cleared (StatefulSet + setup-Job); new `stalwart.tls` block (secretName + cert-manager Certificate knobs); securityContext comment version corrected.
- `platform/stalwart-tenant/chart/templates/deployment.yaml` (StatefulSet) — `args: [--config, /opt/stalwart/etc/config.toml]`; `tls` volumeMount at `/etc/stalwart/tls`; `tls` Secret volume.
- `platform/stalwart-tenant/chart/templates/certificate.yaml` — **new** cert-manager Certificate for `mail.<tenant-domain>` → `stalwart.tls.secretName` (smoke-render-safe: skipped on empty domain).
- `platform/stalwart-tenant/chart/Chart.yaml` — version `0.1.4→0.1.5`; `appVersion 0.16.3→0.15.5`.
- `platform/stalwart-tenant/blueprint.yaml` — `spec.version 0.1.4→0.1.5` (lockstep with Chart.yaml per #817).

## helm-template evidence (representative values: `domain.primary=acme.omantel.omani.works`)
```
(a) image:    harbor.openova.io/proxy-dockerhub/stalwartlabs/stalwart:v0.15.5   (StatefulSet + setup Job)
(b) args:     ["--config", "/opt/stalwart/etc/config.toml"]
(c) tls mount: - name: tls / mountPath: /etc/stalwart/tls (readOnly); volume secretName: "stalwart-tls"
(d) Certificate: kind: Certificate / dnsNames: [mail.acme.omantel.omani.works, acme.omantel.omani.works]
                 secretName: stalwart-tls / issuerRef: letsencrypt-prod (ClusterIssuer)
```
- `chart/tests/oidc-render.sh` → **PASS** (config.toml still parses as valid TOML; OIDC settings keys intact).
- `chart/tests/expression-syntax.sh` → **PASS**.
- `helm lint` → 0 failures.
- Default-values smoke render → clean; Certificate correctly **skipped** on empty domain (smoke-render-safe).

Refs #4148, Refs #4139