### PR TITLE
fix(org-provisioning): per-Org bp-newapi overlay wires never-created/unreachable secrets → CrashLoop on fresh prov

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
@@ -993,14 +993,24 @@ spec:
 //   - auth.customerAPI       → keyIssuer=catalyst (Catalyst mints
 //     per-user bearer keys on signup; the
 //     upstream's self-serve portal is OFF).
-//   - database.existingSecret → newapi-pg-app — the Secret bp-cnpg's
-//     CNPG Cluster auto-renders for the
-//     "newapi" Database (cnpg.enabled=true so
-//     per-tenant Postgres auto-provisions per
-//     #943).
-//   - credentials.existingSecret → newapi-credentials — pulled from
-//     OpenBao via ExternalSecret carrying the
-//     SESSION_SECRET + CRYPTO_SECRET keys.
+//   - database (UNSET) → the chart OWNS its Postgres: cnpg.enabled=true
+//     (default) renders the per-Org CNPG Cluster +
+//     the `bp-newapi-newapi-db-dsn` placeholder Secret
+//     that the chart's own database-secret-sync-job
+//     PATCHes with the canonical `postgres://...?sslmode=
+//     require` DSN. deployment.yaml's $effDbSecret
+//     auto-resolves to that Secret when database.
+//     existingSecret is left unset (#3858/#3374 — the
+//     old `newapi-pg-app`/SQL_DSN override pointed at a
+//     name nothing creates and FailedMount'd).
+//   - credentials (UNSET) → credentials.autoProvision=true (default)
+//     auto-generates `bp-newapi-app-creds` with random
+//     SESSION_SECRET + CRYPTO_SECRET (the old
+//     `newapi-credentials` override pointed at an
+//     uncreated Secret → CreateContainerConfigError).
+//   - valkey.enabled=false → the chart's default valkey.url is the
+//     host-synced rtz-vCluster Redis, unreachable from
+//     inside an Org vCluster; NewAPI runs Postgres-only.
 //   - defaultChannels.qwenPartner → channel #1 = partner-hosted Qwen
 //     auto-seeded at install time (canonical
 //     first-otech default per #915 C4 PR #919).
@@ -1051,19 +1061,51 @@ spec:
     # ExternalSecrets (sovereign/<fqdn>/newapi/...). The sub.parent form
     # makes the path tenant-unique on a multi-tenant Sovereign.
     sovereignFQDN: {{.Subdomain}}.{{.ParentDomain}}
-    # ── Postgres backend (bp-cnpg in tenant ns auto-provisions) ────────
-    # bp-cnpg renders a per-database app Secret named "<db>-app" (#943).
-    # The NewAPI chart consumes the canonical SQL_DSN key.
-    database:
-      existingSecret: newapi-pg-app
-      existingSecretKey: SQL_DSN
+    # ── Postgres backend (chart-owned CNPG, auto-provisioned) ─────────
+    # The bp-newapi chart OWNS its Postgres: cnpg.enabled=true (chart
+    # default) renders a per-Org CNPG Cluster 'bp-newapi-newapi-pg' whose
+    # '-app' Secret carries the rotating password, plus the placeholder
+    # Secret 'bp-newapi-newapi-db-dsn' that the chart's own
+    # database-secret-sync-job PATCHes with the canonical DSN
+    #   postgres://newapi:<pw>@bp-newapi-newapi-pg-rw.<orgns>:5432/newapi?sslmode=require
+    # (scheme 'postgres://', which new-api's DB-driver detection requires —
+    # NOT the CNPG-native 'postgresql://'). deployment.yaml's $effDbSecret
+    # auto-resolves to that name+key when database.existingSecret is unset,
+    # so we MUST NOT override it.
+    #
+    # #3858 / #3374: a previous overlay pinned
+    #   database.existingSecret: newapi-pg-app  (key SQL_DSN)
+    # but NOTHING on a real Org creates a 'newapi-pg-app' Secret with a
+    # 'SQL_DSN' key — the in-vCluster CNPG renders 'bp-newapi-newapi-pg-app'
+    # (key 'uri', scheme 'postgresql://'). The Pod FailedMount on the missing
+    # Secret, then 'references non-existent secret key: SQL_DSN'. Leaving
+    # database unset lets the chart's canonical auto-provision path converge
+    # zero-touch (validated live on the omantel.biz demo Org: newapi 3/3
+    # Running, GET /api/status -> 200).
     # ── App credentials (SESSION_SECRET + CRYPTO_SECRET) ──────────────
-    # Materialised by an ExternalSecret pulling from the per-tenant
-    # OpenBao path. The chart's manifest fails render if the Secret is
-    # missing both keys; the operator overlay seeds them out-of-band on
-    # tenant creation (bootstrap-kit reflector setup).
-    credentials:
-      existingSecret: newapi-credentials
+    # credentials.autoProvision=true (chart default) auto-generates the
+    # 'bp-newapi-app-creds' Secret with random 64-char SESSION_SECRET +
+    # CRYPTO_SECRET (persistent across reconciles via Helm lookup +
+    # resource-policy: keep). We MUST NOT point credentials.existingSecret
+    # at an uncreated name: the previous overlay set
+    #   credentials.existingSecret: newapi-credentials
+    # which nothing creates -> CreateContainerConfigError: secret
+    # "newapi-credentials" not found (#3858 root cause #2). Leaving
+    # credentials unset lets the chart auto-provision them.
+    # ── Valkey cache: DISABLED for the per-Org overlay ────────────────
+    # The chart's default valkey.url points at a HOST-placed valkey
+    # synced from the rtz vCluster
+    #   redis://valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc.cluster.local:6379
+    # which is the correct target for the HOST-placed bp-newapi (#3373
+    # Batch A) but is UNREACHABLE from inside an Org's own vCluster. NewAPI
+    # treats REDIS_CONN_STRING as required when set and CrashLoops on
+    # '[FATAL] Redis ping test failed: context deadline exceeded' (#3858
+    # root cause #3). NewAPI falls back to an in-process cache when Valkey
+    # is off — Postgres holds all durable state — so disabling it is safe.
+    # If a genuinely reachable per-Org valkey ships later, set valkey.url to
+    # THAT instead of re-enabling this cross-vCluster host.
+    valkey:
+      enabled: false
     # ── Auth: ops-staff admin UI gated by per-tenant Keycloak ─────────
     # Customer-facing API uses Catalyst-minted keys (NewAPI's self-serve
     # portal stays OFF on Catalyst Sovereigns per platform/newapi).

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
@@ -609,8 +609,11 @@ func TestRenderOrganizationOverlay_OpenClawOIDCAndLLMBlocks(t *testing.T) {
 //   - Enable defaultChannels.qwenPartner so the chart's channel-seed
 //     post-install Job auto-seeds the partner-hosted Qwen at install time
 //     (canonical first-otech default per #915 C4 PR #919).
-//   - Reference newapi-pg-app for the database (bp-cnpg renders the
-//     app secret in tenant ns) + newapi-credentials for app secrets.
+//   - NOT pin database.existingSecret / credentials.existingSecret to
+//     names nothing creates (#3858) — leave them unset so the chart's
+//     own cnpg.enabled + database-secret-sync-job + credentials.
+//     autoProvision path converges, and set valkey.enabled: false
+//     (the default cross-vCluster Redis is unreachable from the Org vc).
 func TestRenderOrganizationOverlay_NewAPIEmitted(t *testing.T) {
 	rec := store.OrganizationProvisionRecord{
 		OrganizationID:  "t-alice",
@@ -691,16 +694,41 @@ func TestRenderOrganizationOverlay_NewAPIEmitted(t *testing.T) {
 		t.Errorf("bp-newapi.yaml customerAPI.keyIssuer must be 'catalyst' to disable the self-serve portal")
 	}
 
-	// Per-tenant database + credentials Secrets.
-	wantSecrets := []string{
-		"      existingSecret: newapi-pg-app",
-		"      existingSecretKey: SQL_DSN",
-		"      existingSecret: newapi-credentials",
+	// #3858 / #3374 — DB/credentials/Valkey convergence.
+	//
+	// The overlay MUST NOT pin database.existingSecret / credentials.
+	// existingSecret to names nothing creates. On a real Org the in-vCluster
+	// CNPG renders `bp-newapi-newapi-pg-app` (key `uri`), NOT a
+	// `newapi-pg-app`/SQL_DSN Secret, and nothing creates `newapi-credentials`.
+	// Pinning either crashed the Pod (FailedMount / CreateContainerConfigError).
+	// Leaving both UNSET lets the chart's canonical auto-provision path own
+	// them: cnpg.enabled + database-secret-sync-job for the
+	// `postgres://...?sslmode=require` DSN, credentials.autoProvision for the
+	// random SESSION/CRYPTO secret. Validated live on the omantel.biz demo Org
+	// (newapi 3/3 Running, GET /api/status → 200).
+	// Scan only ACTIVE (non-comment) YAML lines — the rationale comments
+	// intentionally name the old broken values, so a naive substring search
+	// over the whole body would false-positive on the documentation itself.
+	forbiddenSecretValues := []string{
+		"existingSecret: newapi-pg-app",     // nothing creates this name
+		"existingSecret: newapi-credentials", // nothing creates this name
 	}
-	for _, line := range wantSecrets {
-		if !strings.Contains(body, line) {
-			t.Errorf("bp-newapi.yaml DB/credentials missing line %q", line)
+	for _, raw := range strings.Split(body, "\n") {
+		line := strings.TrimSpace(raw)
+		if strings.HasPrefix(line, "#") { // skip rationale comments
+			continue
 		}
+		for _, bad := range forbiddenSecretValues {
+			if strings.Contains(line, bad) {
+				t.Errorf("bp-newapi.yaml must NOT pin a never-created Secret (%q) (#3858) — let the chart auto-provision\n--- rendered ---\n%s", bad, body)
+			}
+		}
+	}
+	// Valkey MUST be disabled for the per-Org overlay: the chart default
+	// valkey.url is a host-synced rtz-vCluster Redis, unreachable from inside
+	// an Org vCluster → NewAPI FATALs on the Redis ping probe.
+	if !strings.Contains(body, "    valkey:\n      enabled: false") {
+		t.Errorf("bp-newapi.yaml must set valkey.enabled: false for the per-Org overlay (#3858 — cross-vCluster Redis is unreachable)\n--- rendered ---\n%s", body)
 	}
 
 	// defaultChannels.qwenPartner — channel #1 auto-seeded by the


### PR DESCRIPTION
## Problem — per-Org NewAPI never converges on a fresh Sovereign prov

The per-Organization `bp-newapi` HelmRelease overlay
(`products/catalyst/bootstrap/api/internal/handler/organization_gitops.go`,
`orgTenantBPNewAPI`) wires the NewAPI Deployment to secret names **nothing
creates**, plus an **unreachable** Redis. Diagnosed live on the **omantel.biz
demo Org** (kom4dc, ns `org-7283eb4a-19e5-4e86-9066-d4aa26762064`) — three
distinct root causes:

1. **DSN secret name+key mismatch.** Overlay set
   `database.existingSecret: newapi-pg-app` (key `SQL_DSN`). On a real Org the
   in-vCluster CNPG generates `bp-newapi-newapi-pg-app` (key `uri`, value
   `postgresql://...`), **not** a `newapi-pg-app`/`SQL_DSN` secret. The
   Deployment `FailedMount: secret "newapi-pg-app" not found`, then
   `references non-existent secret key: SQL_DSN`.

2. **Credentials secret never created.** Overlay set
   `credentials.existingSecret: newapi-credentials` — nothing populates it →
   `CreateContainerConfigError: secret "newapi-credentials" not found`.

3. **Unreachable Redis.** The chart-default `valkey.url` is a HOST-synced
   rtz-vCluster Redis
   (`redis://valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc.cluster.local:6379`),
   correct for the host-placed bp-newapi (#3373 Batch A) but **unreachable
   from inside an Org vCluster** → NewAPI
   `[FATAL] Redis ping test failed: context deadline exceeded` → crash.

## Fix — defer to the chart's own canonical auto-provision path

The `bp-newapi` chart already ships a complete, fresh-prov-safe path for both
secrets; the overlay was bypassing it with names nothing fills.

- **DSN** — DROP the `database.existingSecret` / `existingSecretKey` overrides.
  With `cnpg.enabled` (chart default; overlay `placement.role` defaults to
  `all`) the chart renders the per-Org CNPG Cluster + the
  `database-secret-sync-job` that composes the canonical
  `postgres://newapi:<pw>@bp-newapi-newapi-pg-rw.<orgns>:5432/newapi?sslmode=require`
  DSN (scheme `postgres://`, which new-api's driver detection requires — not
  the CNPG-native `postgresql://`) and PATCHes it into
  `bp-newapi-newapi-db-dsn`. `deployment.yaml`'s `$effDbSecret` auto-resolves
  to that name+key when the override is unset.
- **Credentials** — DROP the `credentials.existingSecret` override.
  `credentials.autoProvision` (chart default) generates `bp-newapi-app-creds`
  with random 64-char SESSION/CRYPTO secrets (persistent via Helm `lookup` +
  `resource-policy: keep`).
- **Redis** — SET `valkey.enabled: false` for the Org overlay. NewAPI falls
  back to an in-process cache; Postgres holds all durable state.

## Live validation

Applying the equivalent of these three by hand on the omantel.biz demo Org
took NewAPI from **CrashLoop → 3/3 Running**, serving `GET /api/status → 200`.
This PR makes that durable so a fresh Org provision converges zero-touch.

## Tests

- `go build ./...` green.
- Updated `TestRenderOrganizationOverlay_NewAPIEmitted`: asserts the overlay no
  longer pins `newapi-pg-app` / `newapi-credentials` on any **active** YAML
  line (rationale comments still name the old values) and now sets
  `valkey.enabled: false`.
- Full `internal/handler` test package green.

Files changed:
- `products/catalyst/bootstrap/api/internal/handler/organization_gitops.go`
- `products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go`

Refs #3374
Refs #3858

🤖 Generated with [Claude Code](https://claude.com/claude-code)