### PR TITLE
feat(bp-wordpress-tenant): custom WordPress image w/ pdo_pgsql/pgsql for pg4wp → bp-cnpg Postgres (0.4.5)

### DIFF
--- a/.github/workflows/build-bp-wordpress-tenant-pg.yaml
+++ b/.github/workflows/build-bp-wordpress-tenant-pg.yaml
@@ -1,0 +1,212 @@
+name: Build bp-wordpress-tenant PG image
+
+# Builds the custom WordPress runtime image for bp-wordpress-tenant — the
+# official `wordpress:6-php8.3-apache` base EXTENDED with the PostgreSQL PHP
+# extensions (`pdo_pgsql` / `pgsql`) that pg4wp needs (#4152, Refs #3858 #4139).
+#
+# WHY (root-caused live on omantel.biz demo Org / kom4dc):
+# bp-wordpress-tenant runs WordPress against bp-cnpg PostgreSQL (#800). pg4wp's
+# wp-content/db.php sets DB_DRIVER='pgsql', but `php -m` in the official
+# wordpress image shows only mysqli/PDO/pdo_sqlite — NO pgsql/pdo_pgsql — so
+# every WordPress request 500s the moment pg4wp opens the Postgres connection
+# (the FINAL blocker after PR #4151 drove the pod from CrashLoop to Apache-
+# serving). This image bakes the PG driver in so WordPress can actually serve.
+#
+# This workflow:
+#   1. Builds platform/wordpress-tenant/image/Dockerfile (official WP +
+#      docker-php-ext-install pdo_pgsql pgsql; build-time `php -m` assertion
+#      the driver is present).
+#   2. Pushes to ghcr.io/openova-io/openova/wordpress-tenant-pg tagged with the
+#      commit short-SHA + `latest`.
+#   3. Updates platform/wordpress-tenant/chart/values.yaml
+#      `wordpress.image.{repository,tag,digest}` — repository = the full ghcr
+#      path, tag = the short-SHA, digest = the PUSHED manifest digest captured
+#      from build-push-action's `outputs.digest` so the chart stays digest-
+#      pinned per docs/PRINCIPLES.md #4 (INVIOLABLE-PRINCIPLES).
+#   4. Bumps platform/wordpress-tenant/chart/Chart.yaml `version` patch level +
+#      dispatches blueprint-release so a fresh bp-wordpress-tenant:<semver> OCI
+#      artifact carries the new image pin. (blueprint-release auto-locksteps
+#      blueprint.yaml spec.version to the Chart.yaml version.)
+#
+# On a Sovereign the containerd registry mirror rewrites ghcr.io ->
+# harbor.openova.io/proxy-ghcr transparently, so the chart references the full
+# ghcr path verbatim (the _helpers.tpl wordpressImage host-qualified skip
+# prevents a global.imageRegistry double-prefix).
+#
+# Triggers on any change under platform/wordpress-tenant/image/** so an
+# image-only PR (no chart change) also re-publishes the runtime image.
+
+on:
+  push:
+    paths:
+      - 'platform/wordpress-tenant/image/**'
+      - '.github/workflows/build-bp-wordpress-tenant-pg.yaml'
+    branches: [main]
+  pull_request:
+    paths:
+      - 'platform/wordpress-tenant/image/**'
+      - '.github/workflows/build-bp-wordpress-tenant-pg.yaml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  WP_IMAGE: ghcr.io/openova-io/openova/wordpress-tenant-pg
+  WP_CTX: platform/wordpress-tenant/image
+  CHART_VALUES: platform/wordpress-tenant/chart/values.yaml
+  CHART_YAML: platform/wordpress-tenant/chart/Chart.yaml
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      actions: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # On pull_request runs we stop before any push — image push requires
+      # `packages: write` against the openova-io org which only main-branch
+      # authors hold via GITHUB_TOKEN. Same PR-CI shape as every build-*
+      # workflow: the Dockerfile build itself + its build-time `php -m`
+      # assertion are the PR-time regression guard.
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Compute image tag
+        id: tag
+        run: |
+          set -euo pipefail
+          short_sha="${GITHUB_SHA::7}"
+          echo "tag=${short_sha}" >> "$GITHUB_OUTPUT"
+          echo "Will tag WordPress-PG image: ${WP_IMAGE}:${short_sha}"
+
+      # PR build (no push) — proves the Dockerfile builds + the `php -m`
+      # assertion passes without org-write creds.
+      - name: Build WordPress-PG image (PR validation, no push)
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ env.WP_CTX }}
+          file: ${{ env.WP_CTX }}/Dockerfile
+          push: false
+          load: false
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # provenance=false: containerd 1.7.x on k3s cannot pull the OCI
+          # image-index buildx emits by default (matches every other build-*).
+          provenance: false
+
+      - name: Build + push WordPress-PG image
+        id: build
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ env.WP_CTX }}
+          file: ${{ env.WP_CTX }}/Dockerfile
+          push: true
+          tags: |
+            ${{ env.WP_IMAGE }}:${{ steps.tag.outputs.tag }}
+            ${{ env.WP_IMAGE }}:latest
+          labels: |
+            org.opencontainers.image.source=https://github.com/openova-io/openova
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.title=wordpress-tenant-pg
+            org.opencontainers.image.description=Official WordPress + pdo_pgsql/pgsql for pg4wp -> bp-cnpg Postgres (#4152)
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign image (keyless)
+        if: github.event_name != 'pull_request'
+        env:
+          IMAGE: ${{ env.WP_IMAGE }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"
+
+      - name: Install yq
+        if: github.event_name != 'pull_request'
+        run: |
+          sudo wget -qO /usr/local/bin/yq \
+            https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Bump WordPress image repository/tag/digest in values.yaml
+        if: github.event_name != 'pull_request'
+        env:
+          NEW_TAG: ${{ steps.tag.outputs.tag }}
+          NEW_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NEW_DIGEST}" ]; then
+            echo "::error title=Missing image digest::build-push-action returned an empty outputs.digest; refusing to write an un-pinned image ref (docs/PRINCIPLES.md #4)."
+            exit 1
+          fi
+          yq eval -i ".wordpress.image.repository = \"${WP_IMAGE}\"" "${CHART_VALUES}"
+          yq eval -i ".wordpress.image.tag = \"${NEW_TAG}\"" "${CHART_VALUES}"
+          yq eval -i ".wordpress.image.digest = \"${NEW_DIGEST}\"" "${CHART_VALUES}"
+          echo "values.yaml after update:"
+          yq eval '.wordpress.image' "${CHART_VALUES}"
+
+      - name: Bump Chart.yaml patch version
+        if: github.event_name != 'pull_request'
+        run: |
+          set -euo pipefail
+          current=$(yq eval '.version' "${CHART_YAML}")
+          IFS='.' read -r major minor patch <<<"${current}"
+          next="${major}.${minor}.$((patch + 1))"
+          yq eval -i ".version = \"${next}\"" "${CHART_YAML}"
+          echo "Chart.yaml: version ${current} -> ${next}"
+          echo "CHART_NEW_VERSION=${next}" >> "$GITHUB_ENV"
+
+      - name: Commit and push chart bump
+        id: deploy_commit
+        if: github.event_name != 'pull_request'
+        uses: ./.github/actions/deploy-bump
+        with:
+          paths: |
+            ${{ env.CHART_VALUES }}
+            ${{ env.CHART_YAML }}
+          commit-message: "deploy: bump bp-wordpress-tenant PG image ${{ steps.tag.outputs.tag }} chart ${{ env.CHART_NEW_VERSION }} (#4152)"
+
+      - name: Trigger blueprint-release
+        if: github.event_name != 'pull_request' && steps.deploy_commit.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run blueprint-release.yaml \
+            --repo "${{ github.repository }}" \
+            --ref main \
+            -f blueprint=wordpress-tenant \
+            -f tree=platform
+          echo "blueprint-release dispatched for platform/wordpress-tenant @ main"
+
+      - name: Summary
+        if: github.event_name != 'pull_request'
+        run: |
+          {
+            echo "## bp-wordpress-tenant PG image published"
+            echo ""
+            echo "- Image: \`${WP_IMAGE}:${{ steps.tag.outputs.tag }}\`"
+            echo "- Digest: \`${{ steps.build.outputs.digest }}\`"
+            echo "- Chart bumped to: \`${CHART_NEW_VERSION:-unchanged}\`"
+            echo "- #4152 (pg4wp pdo_pgsql/pgsql), Refs #3858 #4139"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/platform/wordpress-tenant/README.md
+++ b/platform/wordpress-tenant/README.md
@@ -9,9 +9,31 @@ instance per SME tenant inside the SME's vcluster. Part of the
 | Path | Contents |
 |---|---|
 | `blueprint.yaml` | Catalyst Blueprint metadata (configSchema, depends, placementSchema) |
-| `chart/` | Helm chart `bp-wordpress-tenant` v0.1.0 — see `chart/README.md` |
+| `chart/` | Helm chart `bp-wordpress-tenant` — see `chart/README.md` |
 | `chart/templates/` | Deployment, Service, Ingress, PVC, CNPG Cluster, NetworkPolicy, ServiceAccount + 3 post-install Jobs (db-secret-sync, oidc-config, admin-user) |
-| `chart/tests/` | observability-toggle.sh (per #182) |
+| `chart/tests/` | observability-toggle.sh, oidc-config.sh, active-hot-standby-render.sh |
+| `image/Dockerfile` | Custom WordPress runtime image — official base + PG PHP driver (see below) |
+
+## Custom runtime image — `wordpress-tenant-pg` (#4152)
+
+This Blueprint runs WordPress against **bp-cnpg PostgreSQL** (#800), not
+MySQL. The `pg4wp` drop-in (`wp-content/db.php`, `DB_DRIVER='pgsql'`) needs
+PHP's `pdo_pgsql` / `pgsql` extensions, which the official
+`wordpress:6-php8.3-apache` image does NOT ship (`php -m` there shows only
+`mysqli` / `pdo_sqlite`) — so a bare-official WordPress 500s on every request
+against Postgres.
+
+`image/Dockerfile` extends the official image with those two extensions (the
+canonical docker-php ext-deps idiom that retains the runtime `libpq` after
+build cleanup) and asserts at build time that `php -m` lists the driver.
+`.github/workflows/build-bp-wordpress-tenant-pg.yaml` builds + pushes it to
+`ghcr.io/openova-io/openova/wordpress-tenant-pg:<short-sha>` (+ `:latest`),
+then digest-pins `chart/values.yaml` `wordpress.image.*` and dispatches
+`blueprint-release`. The chart references the full ghcr path verbatim; the
+`_helpers.tpl` `wordpressImage` helper skips the `global.imageRegistry` prefix
+for a host-qualified repository so a harbor overlay can't double-prefix it (on
+a Sovereign the containerd registry mirror rewrites `ghcr.io` →
+`harbor.openova.io/proxy-ghcr` transparently).
 
 ## Operator install
 

--- a/platform/wordpress-tenant/blueprint.yaml
+++ b/platform/wordpress-tenant/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: tenant-app
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.4.4
+  version: 0.4.5
   card:
     title: WordPress (per-Organization)
     summary: |

--- a/platform/wordpress-tenant/chart/Chart.yaml
+++ b/platform/wordpress-tenant/chart/Chart.yaml
@@ -105,7 +105,20 @@ name: bp-wordpress-tenant
 #   Mirrors bp-cnpg-pair primary-cluster.yaml (#3740). Also folds the #3985 rename
 #   residue in oidcIssuerURL/ingressHost helpers (the gate that blocked 0.4.2/0.4.3
 #   publish until repaired this session).
-version: 0.4.4
+# 0.4.5 (#4152, Refs #3858 #4139): the WordPress runtime image is now the custom
+#   ghcr.io/openova-io/openova/wordpress-tenant-pg build (official wordpress:6-php8.3-
+#   apache + the pdo_pgsql/pgsql PHP extensions pg4wp REQUIRES to serve against
+#   bp-cnpg Postgres — #800). The official image ships only mysqli/pdo_sqlite, so a
+#   bare-official WordPress 500s on every request against Postgres (FINAL blocker,
+#   root-caused live on omantel.biz demo Org / kom4dc). Built from image/Dockerfile,
+#   published by .github/workflows/build-bp-wordpress-tenant-pg.yaml.
+#   - values.yaml wordpress.image.repository → the full ghcr path; tag/digest
+#     overwritten by the build workflow per build.
+#   - _helpers.tpl wordpressImage + wpCliImage now SKIP the global.imageRegistry
+#     prefix for a host-qualified repository (first "/"-segment has a "." or ":")
+#     so a harbor overlay can't double-prefix the ghcr ref (mirrors the canonical
+#     bp-sso-bridge.image #2940 skip); also tolerate an empty digest (omit @digest).
+version: 0.4.5
 appVersion: "6"
 description: |
   Catalyst Blueprint scratch chart for in-vcluster WordPress, one

--- a/platform/wordpress-tenant/chart/templates/_helpers.tpl
+++ b/platform/wordpress-tenant/chart/templates/_helpers.tpl
@@ -58,18 +58,40 @@ ServiceAccount name.
 {{/*
 WordPress image reference, with optional `global.imageRegistry` rewrite
 for Sovereign Harbor proxy-cache. Returns
-`{registry/}repository:tag@digest` so consumers SHA-pin to the manifest-
-list digest published on Docker Hub.
+`{registry/}repository:tag@digest` (digest omitted when empty).
+
+#4152 — host-qualified-repository skip:
+  The chart's WordPress runtime image is now the custom
+  `ghcr.io/openova-io/openova/wordpress-tenant-pg` build (official image +
+  the pg4wp-required `pdo_pgsql`/`pgsql` extensions). That repository ALREADY
+  carries a registry host. When `.Values.wordpress.image.repository` is
+  host-qualified (its first "/"-segment contains a "." or ":", e.g.
+  "ghcr.io/..."), this helper honours it VERBATIM and does NOT prepend
+  `global.imageRegistry` — otherwise a harbor `global.imageRegistry` overlay
+  would emit a double-registry ref like
+  `harbor.openova.io/ghcr.io/openova-io/openova/wordpress-tenant-pg`, which is
+  unpullable. On a Sovereign the containerd registry mirror already rewrites
+  ghcr.io -> harbor.openova.io/proxy-ghcr transparently, so no chart-side
+  prefix is needed for ghcr images (same model as build-bp-huawei-evs-csi).
+  A BARE repository (the legacy dockerhub `wordpress`) is still prefixed by
+  `global.imageRegistry` when set, byte-identical to the prior behaviour.
+  Mirrors the canonical `bp-sso-bridge.image` host-qualified skip (#2940).
 */}}
 {{- define "bp-wordpress-tenant.wordpressImage" -}}
 {{- $reg := .Values.global.imageRegistry | default "" -}}
 {{- $repo := .Values.wordpress.image.repository -}}
 {{- $tag := .Values.wordpress.image.tag -}}
-{{- $digest := .Values.wordpress.image.digest -}}
-{{- if $reg -}}
-{{- printf "%s/%s:%s@%s" $reg $repo $tag $digest -}}
+{{- $digest := .Values.wordpress.image.digest | default "" -}}
+{{- $firstSeg := first (splitList "/" $repo) -}}
+{{- $hostQualified := or (contains "." $firstSeg) (contains ":" $firstSeg) -}}
+{{- $base := $repo -}}
+{{- if and $reg (not $hostQualified) -}}
+{{- $base = printf "%s/%s" $reg $repo -}}
+{{- end -}}
+{{- if $digest -}}
+{{- printf "%s:%s@%s" $base $tag $digest -}}
 {{- else -}}
-{{- printf "%s:%s@%s" $repo $tag $digest -}}
+{{- printf "%s:%s" $base $tag -}}
 {{- end -}}
 {{- end -}}
 
@@ -216,17 +238,30 @@ failure-isolation gain). Triggered only when enabled=true.
 wp-cli image reference, with optional `global.imageRegistry` rewrite for
 Sovereign Harbor proxy-cache. Mirrors `wordpressImage` so both runtime
 and CLI images route through the same proxy. Returns
-`{registry/}repository:tag@digest`.
+`{registry/}repository:tag@digest` (digest omitted when empty).
+
+#4152 — host-qualified-repository skip (same rule as wordpressImage):
+  honours a host-qualified `oidc.cliImage.repository` (first "/"-segment
+  contains "." or ":") verbatim and does NOT prepend `global.imageRegistry`.
+  The default cliImage is the bare dockerhub `wordpress` (cli-* tag), so the
+  prefix behaviour is byte-identical to before; the skip only fires if an
+  overlay points cliImage at a host-qualified path.
 */}}
 {{- define "bp-wordpress-tenant.wpCliImage" -}}
 {{- $reg := .Values.global.imageRegistry | default "" -}}
 {{- $repo := .Values.oidc.cliImage.repository -}}
 {{- $tag := .Values.oidc.cliImage.tag -}}
-{{- $digest := .Values.oidc.cliImage.digest -}}
-{{- if $reg -}}
-{{- printf "%s/%s:%s@%s" $reg $repo $tag $digest -}}
+{{- $digest := .Values.oidc.cliImage.digest | default "" -}}
+{{- $firstSeg := first (splitList "/" $repo) -}}
+{{- $hostQualified := or (contains "." $firstSeg) (contains ":" $firstSeg) -}}
+{{- $base := $repo -}}
+{{- if and $reg (not $hostQualified) -}}
+{{- $base = printf "%s/%s" $reg $repo -}}
+{{- end -}}
+{{- if $digest -}}
+{{- printf "%s:%s@%s" $base $tag $digest -}}
 {{- else -}}
-{{- printf "%s:%s@%s" $repo $tag $digest -}}
+{{- printf "%s:%s" $base $tag -}}
 {{- end -}}
 {{- end -}}
 

--- a/platform/wordpress-tenant/chart/values.yaml
+++ b/platform/wordpress-tenant/chart/values.yaml
@@ -31,7 +31,9 @@ catalystBlueprint:
     version: ""
     repo: ""
     images:
-      wordpress: "wordpress"
+      # #4152 — custom WordPress image (official base + pdo_pgsql/pgsql for
+      # pg4wp → bp-cnpg Postgres). See wordpress.image below + image/Dockerfile.
+      wordpress: "ghcr.io/openova-io/openova/wordpress-tenant-pg"
 
 # ─── Organization tenant identity ────────────────────────────────────────────────
 # `orgDomain` is the customer's free-subdomain (e.g. acme.<otech-fqdn>)
@@ -57,15 +59,34 @@ wordpress:
   replicas: 1
 
   image:
-    # Official WordPress image. SHA-pinned per
-    # docs/INVIOLABLE-PRINCIPLES.md #4 — the manifest-list digest below
-    # corresponds to `wordpress:6-php8.3-apache` as published on Docker
-    # Hub; the human-readable tag is kept alongside for forensics.
-    repository: wordpress
-    tag: "6-php8.3-apache"
-    # Multi-arch manifest-list digest for `wordpress:6-php8.3-apache`
-    # (verified against registry-1.docker.io 2026-05-04).
-    digest: "sha256:054e611334390d547c732a38b41b8f42feeb8606a29f0a934deba44e0f17b196"
+    # #4152 — CUSTOM WordPress image: the official `wordpress:6-php8.3-apache`
+    # base + the PostgreSQL PHP extensions (`pdo_pgsql` / `pgsql`) that pg4wp
+    # (wp-content/db.php, DB_DRIVER='pgsql') REQUIRES to talk to bp-cnpg
+    # Postgres (#800). The official image ships only mysqli/pdo_sqlite, so a
+    # bare-official-image WordPress 500s on every request against Postgres
+    # (root-caused live on omantel.biz demo Org / kom4dc). Built from
+    # platform/wordpress-tenant/image/Dockerfile and published by
+    # .github/workflows/build-bp-wordpress-tenant-pg.yaml to the full ghcr
+    # path below. That workflow OVERWRITES `tag` (with the build short-SHA)
+    # and `digest` (with the pushed manifest digest) on every build — the
+    # values committed here are the initial bootstrap pins.
+    #
+    # Repository is host-qualified (`ghcr.io/...`). _helpers.tpl
+    # bp-wordpress-tenant.wordpressImage honours it VERBATIM and does NOT
+    # prepend `global.imageRegistry` (a harbor overlay would otherwise emit a
+    # double-registry, unpullable ref). On a Sovereign the containerd registry
+    # mirror rewrites ghcr.io -> harbor.openova.io/proxy-ghcr transparently.
+    #
+    # SHA-pinned per docs/PRINCIPLES.md #4 — the digest below is the manifest
+    # digest of the published image; the human-readable tag is kept alongside
+    # for forensics.
+    repository: ghcr.io/openova-io/openova/wordpress-tenant-pg
+    tag: "latest"
+    # Pushed manifest digest of `wordpress-tenant-pg:<tag>` — populated by the
+    # build workflow's build-push-action `outputs.digest` on first build.
+    # Empty until then; the helper omits `@digest` when empty so the chart
+    # still renders + pulls by tag during the bootstrap window.
+    digest: ""
     pullPolicy: IfNotPresent
 
   port: 80

--- a/platform/wordpress-tenant/image/Dockerfile
+++ b/platform/wordpress-tenant/image/Dockerfile
@@ -1,0 +1,46 @@
+# bp-wordpress-tenant runtime image — official WordPress + PostgreSQL PHP driver.
+#
+# WHY THIS IMAGE EXISTS (#4152, root-caused live on omantel.biz / kom4dc):
+# bp-wordpress-tenant runs WordPress against bp-cnpg PostgreSQL (ticket #800),
+# NOT MySQL. The pg4wp drop-in (wp-content/db.php) sets DB_DRIVER='pgsql' and
+# talks to Postgres via PHP's `pdo_pgsql` / `pgsql` extensions. The official
+# `wordpress:6-php8.3-apache` image ships ONLY `mysqli` / `PDO` / `pdo_sqlite`
+# — `php -m` there shows NO `pgsql` / `pdo_pgsql`, so every WordPress request
+# 500s the moment pg4wp tries to open the Postgres connection (the FINAL
+# blocker after PR #4151 drove the pod from CrashLoop to Apache-serving).
+#
+# This image extends the official WordPress image with the two PG extensions
+# using the canonical docker-php ext-deps idiom: it installs `libpq-dev` to
+# BUILD the extensions, then walks the freshly-built `pdo_pgsql.so`'s shared-
+# object dependencies (via `ldd`) and re-marks the runtime `libpq` package as
+# manually-installed BEFORE `apt-get purge --auto-remove` strips the build-only
+# `-dev` packages. Without that ldd/dpkg-query dance the auto-remove would also
+# evict `libpq5`, breaking the extension at runtime. Same idiom the official
+# php/docker library uses for native ext deps.
+#
+# Built + published to ghcr.io/openova-io/openova/wordpress-tenant-pg by
+# .github/workflows/build-bp-wordpress-tenant-pg.yaml on every push touching
+# platform/wordpress-tenant/image/**. On a Sovereign the containerd registry
+# mirror rewrites ghcr.io -> harbor.openova.io/proxy-ghcr transparently, so the
+# chart references the full ghcr path verbatim (NOT via global.imageRegistry —
+# see _helpers.tpl bp-wordpress-tenant.wordpressImage host-qualified skip).
+FROM wordpress:6-php8.3-apache
+
+RUN set -eux; \
+    savedAptMark="$(apt-mark showmanual)"; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends libpq-dev; \
+    docker-php-ext-install -j"$(nproc)" pdo_pgsql pgsql; \
+    apt-mark auto '.*' > /dev/null; \
+    apt-mark manual $savedAptMark > /dev/null; \
+    ldd "$(php -r 'echo ini_get("extension_dir");')"/pdo_pgsql.so \
+      | awk '/=>/ { so=$(NF-1); if (index(so, "/usr/local/") == 1) next; gsub("^/(usr/)?","/",so); printf "*%s\n", so }' \
+      | sort -u | xargs -r dpkg-query --search 2>/dev/null \
+      | cut -d: -f1 | sort -u | xargs -r apt-mark manual > /dev/null; \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+    rm -rf /var/lib/apt/lists/*
+
+# Build-time assertion: fail the image build if the PG driver did not land.
+# This is the regression guard for #4152 — a future base-image bump that drops
+# the extension can never silently ship.
+RUN php -m | grep -E 'pdo_pgsql|^pgsql$'


### PR DESCRIPTION
## Custom WordPress image with the PostgreSQL PHP driver

bp-wordpress-tenant runs WordPress against bp-cnpg PostgreSQL (#800). pg4wp sets DB_DRIVER=pgsql, but the official wordpress:6-php8.3-apache image has only mysqli/PDO/pdo_sqlite — no pgsql/pdo_pgsql — so every request 500s. This was the final piece after #4151 drove the pod from CrashLoop to Apache-serving (root-caused live on the omantel.biz demo Org / kom4dc, #4152).

Ships a custom WordPress runtime image (official base + the PG PHP driver via docker-php-ext-install pdo_pgsql pgsql) and points the chart at it.

### Files
- platform/wordpress-tenant/image/Dockerfile — official base + PG driver + a build-time php -m assertion.
- .github/workflows/build-bp-wordpress-tenant-pg.yaml — builds + pushes ghcr.io/openova-io/openova/wordpress-tenant-pg, digest-pins values.yaml, bumps Chart.yaml, dispatches blueprint-release.
- platform/wordpress-tenant/chart/values.yaml — image repository to the ghcr path.
- platform/wordpress-tenant/chart/templates/_helpers.tpl — skip the global.imageRegistry prefix for host-qualified repos (the bp-sso-bridge #2940 pattern); tolerate empty digest.
- Chart.yaml + blueprint.yaml — lockstep bump.

helm template verified in both registry modes (no double-registry); all 3 chart test suites green; lockstep verified.

Refs #4152 #3858 #4139