### PR TITLE
fix(bp-wordpress-tenant): add wordpress.image.pullSecrets for the now-PRIVATE custom WordPress image (0.4.11)

### DIFF
--- a/platform/wordpress-tenant/blueprint.yaml
+++ b/platform/wordpress-tenant/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: tenant-app
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.4.10
+  version: 0.4.11
   card:
     title: WordPress (per-Organization)
     summary: |

--- a/platform/wordpress-tenant/chart/Chart.yaml
+++ b/platform/wordpress-tenant/chart/Chart.yaml
@@ -118,7 +118,20 @@ name: bp-wordpress-tenant
 #     prefix for a host-qualified repository (first "/"-segment has a "." or ":")
 #     so a harbor overlay can't double-prefix the ghcr ref (mirrors the canonical
 #     bp-sso-bridge.image #2940 skip); also tolerate an empty digest (omit @digest).
-version: 0.4.10
+# 0.4.11 (#4152, Refs #3858): add `wordpress.image.pullSecrets` (default
+#   `[{name: ghcr-pull}]`) and wire it into the Pod spec of the runtime
+#   Deployment AND the admin-user Job. Since #4153 the runtime image is the
+#   PRIVATE `ghcr.io/openova-io/openova/wordpress-tenant-pg` package, so the
+#   kubelet's anonymous pull 401s ("failed to authorize: ... 401 Unauthorized")
+#   and the Pod stalls in ImagePullBackOff (confirmed live on omantel.biz demo
+#   Org / kom4dc). The old official `wordpress` image was public dockerhub, so
+#   no pull secret was ever needed — hence the chart shipped none. `ghcr-pull`
+#   is the canonical reflected Secret name (mirrors bp-newapi #952). The
+#   oidc-config Job (public `wordpress:cli-*` image) and the database-secret-
+#   sync Job (public proxy-dockerhub curl) intentionally keep NO pull secret.
+#   Per Inviolable Principle #4 the list is overrideable (set `[]` on clusters
+#   that mirror the image into a public registry).
+version: 0.4.11
 appVersion: "6"
 description: |
   Catalyst Blueprint scratch chart for in-vcluster WordPress, one

--- a/platform/wordpress-tenant/chart/templates/admin-user-job.yaml
+++ b/platform/wordpress-tenant/chart/templates/admin-user-job.yaml
@@ -45,6 +45,15 @@ spec:
         catalyst.openova.io/blueprint: bp-wordpress-tenant
     spec:
       restartPolicy: OnFailure
+      {{- with .Values.wordpress.image.pullSecrets }}
+      # #4152 (Refs #3858): this Job runs the PRIVATE custom WordPress image
+      # (`bp-wordpress-tenant.wordpressImage` = wordpress-tenant-pg) — same
+      # imagePullSecrets requirement as the Deployment. (The oidc-config Job by
+      # contrast runs the PUBLIC dockerhub `wordpress:cli-*` image, so it needs
+      # none.)
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.wordpress.podSecurityContext | nindent 8 }}
       containers:

--- a/platform/wordpress-tenant/chart/templates/deployment.yaml
+++ b/platform/wordpress-tenant/chart/templates/deployment.yaml
@@ -53,6 +53,22 @@ spec:
         checksum/oidc-job: {{ include (print $.Template.BasePath "/oidc-config-job.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ include "bp-wordpress-tenant.serviceAccountName" . }}
+      {{- with .Values.wordpress.image.pullSecrets }}
+      # #4152 (Refs #3858): the WordPress runtime image is now the CUSTOM
+      # ghcr.io/openova-io/openova/wordpress-tenant-pg build — a PRIVATE ghcr
+      # package. kubelet's anonymous pull 401s ("failed to authorize: ...
+      # 401 Unauthorized"), stranding the Pod in ImagePullBackOff. This applies
+      # to EVERY container that uses `bp-wordpress-tenant.wordpressImage`: all
+      # three initContainers (wp-fix-perms, wp-content-bootstrap,
+      # wp-plugin-install) AND the main `wordpress` container. The `ghcr-pull`
+      # Secret is reflected by bp-reflector into every Org namespace (same
+      # canonical name bp-newapi consumes; cloud-init writes the source
+      # flux-system/ghcr-pull with reflection-auto-namespaces). Per Inviolable
+      # Principle #4 the secret list is overrideable (set `[]` on clusters that
+      # pull this image from a public mirror).
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.wordpress.podSecurityContext | nindent 8 }}
       initContainers:

--- a/platform/wordpress-tenant/chart/tests/imagepullsecrets-render.sh
+++ b/platform/wordpress-tenant/chart/tests/imagepullsecrets-render.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# bp-wordpress-tenant — imagePullSecrets render audit (#4152, Refs #3858).
+#
+# Since #4153 the WordPress runtime image is the CUSTOM
+# `ghcr.io/openova-io/openova/wordpress-tenant-pg` build (official base + the
+# pdo_pgsql/pgsql PHP extensions pg4wp REQUIRES to serve against bp-cnpg
+# Postgres). That ghcr package is PRIVATE, so the kubelet's anonymous pull
+# fails with `failed to authorize: ... 401 Unauthorized` and the Pod stalls in
+# ImagePullBackOff (root-caused live on omantel.biz demo Org / kom4dc). The old
+# official `wordpress` image was public dockerhub, so the chart shipped no pull
+# secret — hence this gap.
+#
+# Cases:
+#   1. Default render — the runtime Deployment carries
+#      `imagePullSecrets: [{name: ghcr-pull}]` (covers all three initContainers
+#      + the main `wordpress` container, which all use the PRIVATE image).
+#   2. admin-user Job (private image) also carries the reference.
+#   3. oidc-config Job (PUBLIC `wordpress:cli-*` image) must NOT carry it.
+#   4. db-secret-sync Job (PUBLIC proxy-dockerhub curl) must NOT carry it.
+#   5. Operator override `wordpress.image.pullSecrets: []` suppresses the block.
+#   6. Operator override with a custom secret name renders that name (per
+#      Inviolable Principle #4 — never hardcode).
+
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
+helm="${HELM_BIN:-helm}"
+
+# Build chart deps once so `helm template` does not error on the `common`
+# library subchart reference.
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+# adminUser.email is required for the admin-user Job to render; oidc.enabled
+# (default true) renders the oidc-config Job.
+base_values=$(mktemp)
+trap 'rm -f "$base_values"' EXIT
+cat > "$base_values" <<'EOF'
+adminUser:
+  email: admin@acme.omani.homes
+EOF
+
+# Extract the Job doc whose `metadata.name` contains the given suffix from a
+# multi-doc render. $1 = full render, $2 = name suffix. Matches the `name:`
+# LINE (not end-of-record) so the trailing Pod-spec content does not defeat the
+# anchor, and scopes to `kind: Job` so the shared-named ServiceAccount/Role/
+# RoleBinding docs (db-secret-sync) are excluded.
+job_by_name() {
+  echo "$1" | awk -v SUF="$2" '
+    BEGIN { RS="---\n" }
+    /kind: Job/ {
+      if ($0 ~ ("\n[[:space:]]*name: [^\n]*" SUF "\n")) print $0
+    }'
+}
+
+# ── Case 1: default render — runtime Deployment carries ghcr-pull ─────────
+echo "[bp-wordpress-tenant] Case 1: default render — Deployment imagePullSecrets present"
+out=$("$helm" template wp "$chart_dir" -f "$base_values" 2>&1)
+
+deployment_block=$(echo "$out" | awk '/^---$/{f=0} /^kind: Deployment$/{f=1} f')
+if [ -z "$deployment_block" ]; then
+  echo "FAIL: Deployment did not render"; exit 1
+fi
+if ! echo "$deployment_block" | grep -q "imagePullSecrets:"; then
+  echo "FAIL: Deployment has no imagePullSecrets block"; exit 1
+fi
+if ! echo "$deployment_block" | grep -q "name: ghcr-pull"; then
+  echo "FAIL: Deployment imagePullSecrets does not reference ghcr-pull"; exit 1
+fi
+echo "[bp-wordpress-tenant] Case 1: PASS"
+
+# ── Case 2: admin-user Job (private image) carries ghcr-pull ─────────────
+echo "[bp-wordpress-tenant] Case 2: admin-user Job — imagePullSecrets present"
+admin_job=$(job_by_name "$out" "-admin-user")
+if [ -z "$admin_job" ]; then
+  echo "FAIL: admin-user Job did not render (adminUser.email set?)"; exit 1
+fi
+if ! echo "$admin_job" | grep -q "imagePullSecrets:"; then
+  echo "FAIL: admin-user Job has no imagePullSecrets block"; exit 1
+fi
+if ! echo "$admin_job" | grep -q "name: ghcr-pull"; then
+  echo "FAIL: admin-user Job imagePullSecrets does not reference ghcr-pull"; exit 1
+fi
+echo "[bp-wordpress-tenant] Case 2: PASS"
+
+# ── Case 3: oidc-config Job (PUBLIC cli image) has NO imagePullSecrets ────
+echo "[bp-wordpress-tenant] Case 3: oidc-config Job — no imagePullSecrets (public cli image)"
+oidc_job=$(job_by_name "$out" "-oidc-config")
+if [ -z "$oidc_job" ]; then
+  echo "FAIL: oidc-config Job did not render"; exit 1
+fi
+if echo "$oidc_job" | grep -q "imagePullSecrets:"; then
+  echo "FAIL: oidc-config Job (public wordpress:cli-* image) must not carry imagePullSecrets"; exit 1
+fi
+echo "[bp-wordpress-tenant] Case 3: PASS"
+
+# ── Case 4: db-secret-sync Job (PUBLIC curl image) has NO imagePullSecrets ─
+echo "[bp-wordpress-tenant] Case 4: db-secret-sync Job — no imagePullSecrets (public curl image)"
+sync_job_doc=$(job_by_name "$out" "-db-secret-sync")
+if [ -z "$sync_job_doc" ]; then
+  echo "FAIL: db-secret-sync Job did not render"; exit 1
+fi
+if echo "$sync_job_doc" | grep -q "imagePullSecrets:"; then
+  echo "FAIL: db-secret-sync Job (public proxy-dockerhub curl) must not carry imagePullSecrets"; exit 1
+fi
+echo "[bp-wordpress-tenant] Case 4: PASS"
+
+# ── Case 5: operator override `pullSecrets: []` suppresses ───────────────
+echo "[bp-wordpress-tenant] Case 5: empty override — imagePullSecrets omitted"
+empty_values=$(mktemp)
+cat > "$empty_values" <<'EOF'
+adminUser:
+  email: admin@acme.omani.homes
+wordpress:
+  image:
+    pullSecrets: []
+EOF
+out5=$("$helm" template wp "$chart_dir" -f "$empty_values" 2>&1)
+rm -f "$empty_values"
+deployment_block5=$(echo "$out5" | awk '/^---$/{f=0} /^kind: Deployment$/{f=1} f')
+if [ -z "$deployment_block5" ]; then
+  echo "FAIL: Deployment did not render with empty pullSecrets"; exit 1
+fi
+if echo "$deployment_block5" | grep -q "imagePullSecrets:"; then
+  echo "FAIL: empty override should suppress imagePullSecrets block (Inviolable Principle #4)"; exit 1
+fi
+echo "[bp-wordpress-tenant] Case 5: PASS"
+
+# ── Case 6: custom secret name flows through ─────────────────────────────
+echo "[bp-wordpress-tenant] Case 6: custom secret name — operator override"
+custom_values=$(mktemp)
+cat > "$custom_values" <<'EOF'
+adminUser:
+  email: admin@acme.omani.homes
+wordpress:
+  image:
+    pullSecrets:
+      - name: my-private-registry-creds
+EOF
+out6=$("$helm" template wp "$chart_dir" -f "$custom_values" 2>&1)
+rm -f "$custom_values"
+deployment_block6=$(echo "$out6" | awk '/^---$/{f=0} /^kind: Deployment$/{f=1} f')
+if ! echo "$deployment_block6" | grep -q "name: my-private-registry-creds"; then
+  echo "FAIL: custom imagePullSecret name not propagated to Deployment"; exit 1
+fi
+if echo "$deployment_block6" | grep -q "name: ghcr-pull"; then
+  echo "FAIL: custom override leaked default ghcr-pull reference"; exit 1
+fi
+echo "[bp-wordpress-tenant] Case 6: PASS"
+
+echo "[bp-wordpress-tenant] All imagePullSecrets render cases PASS"

--- a/platform/wordpress-tenant/chart/values.yaml
+++ b/platform/wordpress-tenant/chart/values.yaml
@@ -84,6 +84,31 @@ wordpress:
     # still renders + pulls by tag during the bootstrap window.
     digest: "sha256:4c80995efad75400ef4a3ca34666cdac421abf4c9285b21cdaf33c85241c0b6c"
     pullPolicy: IfNotPresent
+    # ─── Image pull secrets (#4152, Refs #3858) ──────────────────────────
+    # Since #4153 the runtime image is the CUSTOM
+    # `ghcr.io/openova-io/openova/wordpress-tenant-pg` build (official base +
+    # the pdo_pgsql/pgsql PHP extensions pg4wp REQUIRES to serve against
+    # bp-cnpg Postgres). That ghcr package is PRIVATE, so the kubelet's
+    # anonymous pull fails with `failed to authorize: ... 401 Unauthorized`
+    # and the Pod stalls in ImagePullBackOff (root-caused live on
+    # omantel.biz demo Org / kom4dc). The old official `wordpress` image was
+    # public dockerhub, so no pull secret was ever needed — hence none was
+    # wired before.
+    #
+    # `ghcr-pull` is the canonical Secret name (mirrors bp-newapi #952): a
+    # `kubernetes.io/dockerconfigjson` Secret created in flux-system at
+    # cloud-init and reflected by bp-reflector into every Organization
+    # namespace (the source Secret carries the
+    # `reflector.v1.k8s.emberstack.com/reflection-auto-namespaces`
+    # annotation). It applies to BOTH the runtime Deployment (all three
+    # initContainers + the main container) AND the admin-user Job — every
+    # workload that pulls `bp-wordpress-tenant.wordpressImage`.
+    #
+    # Per Inviolable Principle #4 the list is overrideable from per-Sovereign
+    # overlays (set `[]` for clusters that mirror this image into a public
+    # registry).
+    pullSecrets:
+      - name: ghcr-pull
   port: 80
   resources:
     requests:


### PR DESCRIPTION
## What

`#4153` moved the per-Org WordPress runtime image to the custom
`ghcr.io/openova-io/openova/wordpress-tenant-pg` build (official base + the
`pdo_pgsql`/`pgsql` PHP extensions pg4wp REQUIRES to serve against bp-cnpg
Postgres). That ghcr package is **private**, so the kubelet's anonymous pull
fails:

```
failed to authorize: ... 401 Unauthorized
```

and the WordPress Pod stalls in `ImagePullBackOff`. The chart's Pod spec
carried **no** `imagePullSecrets` at all, because the old official `wordpress`
image was public dockerhub and none was ever needed.

Confirmed live on the omantel.biz demo Org (kom4dc): adding
`imagePullSecrets: [{name: ghcr-pull}]` to the Deployment fixes the pull — the
Org namespace already carries the `ghcr-pull` Secret
(`kubernetes.io/dockerconfigjson`, reflected by bp-reflector), exactly as
`bp-newapi` (`#952`) already does for its own private ghcr image.

## Changes

- **values.yaml** — new `wordpress.image.pullSecrets`, default
  `[{name: ghcr-pull}]`. `ghcr-pull` is the canonical reflected Secret name
  (same one bp-newapi consumes); cloud-init writes `flux-system/ghcr-pull` and
  bp-reflector mirrors it into every Organization namespace. Overrideable per
  Inviolable Principle #4 (set `[]` on clusters mirroring the image into a
  public registry).
- **templates/deployment.yaml** — render `imagePullSecrets` on the Pod spec
  near `serviceAccountName`. Applies to **all three** initContainers
  (`wp-fix-perms`, `wp-content-bootstrap`, `wp-plugin-install`) AND the main
  `wordpress` container — every one uses `bp-wordpress-tenant.wordpressImage`.
- **templates/admin-user-job.yaml** — same `imagePullSecrets`; this Job also
  runs the private image.
- The **oidc-config Job** (public `wordpress:cli-*` image) and the
  **db-secret-sync Job** (public `proxy-dockerhub/curlimages/curl`)
  intentionally keep no pull secret.
- **Chart.yaml + blueprint.yaml** bumped `0.4.10 -> 0.4.11` in lockstep.
- New **tests/imagepullsecrets-render.sh** (6 cases).

## Evidence

`helm template` of the default render:

```
=== Deployment ===
kind: Deployment
      serviceAccountName: wp-bp-wordpress-tenant
      imagePullSecrets:
        - name: ghcr-pull

--- Jobs (by name) ---
Job[admin-user]: imagePullSecrets=1 ghcr-pull=1
Job[db-secret-sync]: imagePullSecrets=0 ghcr-pull=0
Job[oidc-config]: imagePullSecrets=0 ghcr-pull=0
```

`helm lint` clean; all 4 chart test suites green
(`active-hot-standby-render`, `imagepullsecrets-render`, `observability-toggle`,
`oidc-config`). The new `imagepullsecrets-render.sh` asserts: Deployment +
admin-user carry `ghcr-pull`; oidc-config + db-secret-sync do not; `[]`
suppresses the block; a custom name flows through without leaking the default.

Refs #4152 #3858

🤖 Generated with [Claude Code](https://claude.com/claude-code)