### PR TITLE
fix(bp-wordpress-tenant): reflector populates WORDPRESS_DB_PASSWORD — kill demo-Org HTTP 500 restart-loop (0.4.12)

### DIFF
--- a/platform/wordpress-tenant/blueprint.yaml
+++ b/platform/wordpress-tenant/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: tenant-app
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.4.11
+  version: 0.4.12
   card:
     title: WordPress (per-Organization)
     summary: |

--- a/platform/wordpress-tenant/chart/Chart.yaml
+++ b/platform/wordpress-tenant/chart/Chart.yaml
@@ -131,7 +131,26 @@ name: bp-wordpress-tenant
 #   sync Job (public proxy-dockerhub curl) intentionally keep NO pull secret.
 #   Per Inviolable Principle #4 the list is overrideable (set `[]` on clusters
 #   that mirror the image into a public registry).
-version: 0.4.11
+# 0.4.12 (#4152, Refs #3858): FIX the demo-Org WordPress HTTP-500 restart-loop —
+#   the FINAL convergence gap. Root cause was NOT pg4wp/WP-6.x/PHP-8.3
+#   incompatibility (pg4wp + pdo_pgsql + pgsql are all present and working).
+#   templates/database-secret.yaml seeded `data: { password: "" }`; reflector's
+#   `reflects` mode copies only source keys ABSENT in the destination, so it
+#   filled host/pgpass/uri/... but PRESERVED the empty Helm-seeded `password`
+#   forever (reflector logs: `Updated 0`). WORDPRESS_DB_PASSWORD bound to "" →
+#   pg4wp PDO `SQLSTATE[08006] fe_sendauth: no password supplied` → WP DB-boot
+#   fatal → Apache 500 (empty body) → liveness fail → CrashLoop. The post-install
+#   sync Job (safety net) never ran because the last HR upgrade FAILED (CNPG
+#   webhook x509), so its post-upgrade hook never fired.
+#   FIX: drop the `data.password: ""` seed entirely so reflector OWNS and
+#   populates `password` from the CNPG `<cluster>-app` source; mark the
+#   deployment's WORDPRESS_DB_PASSWORD secretKeyRef `optional: true` so the Pod
+#   schedules during the brief pre-reflection window instead of
+#   CreateContainerConfigError. Verified live (kom4dc demo Org): populating the
+#   key → `PDO_OK`, `curl / → HTTP 302 Location: /wp-admin/install.php`, pod 1/1
+#   Running 0 restarts; removing the key → reflector repopulated it (64 bytes)
+#   in <5s. Sync Job retained as belt-and-suspenders.
+version: 0.4.12
 appVersion: "6"
 description: |
   Catalyst Blueprint scratch chart for in-vcluster WordPress, one

--- a/platform/wordpress-tenant/chart/templates/database-secret.yaml
+++ b/platform/wordpress-tenant/chart/templates/database-secret.yaml
@@ -32,10 +32,23 @@ metadata:
     # post-install Job after initial creation).
     helm.sh/resource-policy: keep
 type: Opaque
-# Bootstrap empty data — reflector / the post-install Job overwrites
-# `password` once CNPG finishes provisioning <cluster>-app. Empty
-# values here prevent CreateContainerConfigError (secret key missing)
-# during initial render.
-data:
-  password: ""
+# 0.4.12 (#4152, Refs #3858): NO `data.password: ""` seed.
+#
+# The previous `data: { password: "" }` placeholder was the root cause
+# of the demo-Org HTTP-500 restart-loop (kom4dc, 2026-06-23). Reflector's
+# `reflects` mode copies only the source keys that are ABSENT in the
+# destination — it filled every other key (host/pgpass/uri/...) but
+# PRESERVED the Helm-seeded empty `password` and never overwrote it
+# (reflector logs: `Updated 0`). WORDPRESS_DB_PASSWORD therefore bound to
+# an empty string → pg4wp PDO `fe_sendauth: no password supplied` → WP DB
+# bootstrap fatal → Apache 500 → liveness fail → CrashLoop. Verified live:
+# removing the `password` key let reflector repopulate it (64 bytes) in
+# <5s and WordPress went `curl / → 302 /wp-admin/install.php`, pod 1/1.
+#
+# Omitting the `data` block entirely lets reflector OWN `password`
+# (and all sibling keys) from the CNPG `<cluster>-app` source. The
+# deployment's secretKeyRef is marked `optional: true` so the brief
+# pre-reflection window does not CreateContainerConfigError; the
+# post-install sync Job (database-secret-sync-job.yaml) remains the
+# belt-and-suspenders for the otech30-class Reflector race.
 {{- end }}

--- a/platform/wordpress-tenant/chart/templates/deployment.yaml
+++ b/platform/wordpress-tenant/chart/templates/deployment.yaml
@@ -263,6 +263,13 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.database.secretName }}
                   key: password
+                  # 0.4.12 (#4152, Refs #3858): the password key is no
+                  # longer Helm-seeded — reflector / the sync Job populate
+                  # it from the CNPG `<cluster>-app` source. `optional`
+                  # lets the Pod schedule during the brief pre-reflection
+                  # window instead of CreateContainerConfigError; once the
+                  # key lands the Pod's next start binds the real value.
+                  optional: true
             # ── Site URL (used by WP to construct admin/login links) ─
             - name: WORDPRESS_CONFIG_EXTRA
               value: |


### PR DESCRIPTION
## Problem

The per-Org WordPress app returned **HTTP 500** and the main container restart-looped on the omantel.biz demo Org (kom4dc, ns `org-7283eb4a-19e5-4e86-9066-d4aa26762064`) — the final convergence gap for `bp-wordpress-tenant`.

The 500 is **not** a pg4wp / WP-6.x / PHP-8.3 incompatibility. pg4wp, `pdo_pgsql` and `pgsql` are all present and functional. It was an **empty DB password**.

## Root cause

The Deployment binds `WORDPRESS_DB_PASSWORD` from secret `wordpress-database-secret` key `password`. That key was **0 bytes**, while the CNPG source `wordpress-db-app.password` held the real 64-byte credential.

`templates/database-secret.yaml` seeded `data: { password: "" }`. Reflector's `reflects` mode copies only the source keys that are **absent** in the destination — it filled `host`/`pgpass`/`uri`/... but **preserved the empty Helm-seeded `password`** and never overwrote it (reflector logs: `Updated 0` for this secret).

Consequence chain:
- `WORDPRESS_DB_PASSWORD` bound to `""`
- pg4wp PDO connect → `SQLSTATE[08006] [7] ... fe_sendauth: no password supplied`
- WordPress DB bootstrap fatal → Apache 500 (empty body)
- liveness probe fails → Pod CrashLoop

The post-install sync Job (the safety net) never ran on the latest reconcile because the HR upgrade **failed** on the CNPG mutating webhook x509, so its `post-upgrade` hook never fired.

## Fix

- **`database-secret.yaml`**: drop the `data.password: ""` seed entirely so reflector **owns** and populates `password` from the CNPG `<cluster>-app` source.
- **`deployment.yaml`**: mark the `WORDPRESS_DB_PASSWORD` secretKeyRef `optional: true` so the Pod schedules during the brief pre-reflection window instead of `CreateContainerConfigError`.
- **`Chart.yaml` + `blueprint.yaml`**: `0.4.11` → `0.4.12` lockstep.

The hook-ordered Jobs (sync weight 5, oidc 10, admin 15) keep their hard password dependency. Reflector now converges the Deployment even when Helm hooks do not fire on a failed reconcile.

## Live verification (kom4dc demo Org)

Mechanism proven on the running env:

| Check | Result |
|---|---|
| Source `wordpress-db-app.password` | 64 bytes (present) |
| Dest `wordpress-database-secret.password` (before) | **0 bytes** (the bug) |
| PDO connect (before) | `fe_sendauth: no password supplied` |
| Populate dest password → PDO connect | `PDO_OK` |
| `curl /` from the pod | **HTTP 302 → Location: /wp-admin/install.php** |
| Pod state | **1/1 Running, 0 restarts** (restart-loop broken) |
| Delete dest `password` key → reflector | **repopulated 64 bytes in <5s** (confirms the seed was the bug) |

All 4 chart render gates green (`active-hot-standby`, `imagepullsecrets`, `observability-toggle`, `oidc-config`); `helm lint` clean.

Refs #4152 Refs #3858
