### PR TITLE
fix(bp-keycloak): account-console SSO-landing — non-delegating browser flow for built-in consoles (#3934 part-4)

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -206,7 +206,14 @@ spec:
       # 1.4.36 (#4054/#4070/#3374): per-Org tenant realm now registers the
       #         catalyst-ui public PKCE client so the per-Org console
       #         (console.<slug>.<zone>) OIDC redirect resolves instead of 400ing.
-      version: 1.4.36
+      # 1.4.37 (#3934, Refs #3642): account-console SSO-landing — KC's built-in
+      #         account-console + security-admin-console now bind to a new
+      #         `browser-no-idp` flow so a hint-less, cookie-less nav is NOT
+      #         force-bounced into /broker/catalyst-pin/login (400 cookie_not_
+      #         found → "We are sorry"). The SSO app clients keep the delegating
+      #         `browser` flow untouched (gitea/harbor/openbao/oidc-gate). 4th
+      #         SSO-landing surface from the #3642 pivot, caught live hw182.
+      version: 1.4.37
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.36
+  version: 1.4.37
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for Organizations, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -354,7 +354,20 @@ name: bp-keycloak
 # varchar(255) cap; the 255-cap gate now AUDITS the tenant realm (was SKIP).
 # The org-keycloak HTTPRoute parentRef move to cilium-gateway-console is an
 # orchestrator-side change (organization_gitops.go), not a chart change.
-version: 1.4.36
+# 1.4.37 (#3934, Refs #3642, 2026-06-23): account-console SSO-landing fix —
+# Keycloak's built-in `account-console` + `security-admin-console` clients were
+# force-bounced by the sovereign realm's identity-provider-redirector
+# (defaultProvider=catalyst-pin) into /broker/catalyst-pin/login, which 400s
+# `cookie_not_found` on a hint-less, cookie-less nav → operator saw "We are
+# sorry... cookie not found" (4th SSO-landing surface broken by the #3642
+# mgmt-vCluster pivot, caught live hw182). The realm import now declares a
+# second top-level browser flow `browser-no-idp` (identical to `browser` minus
+# the auto-delegating redirector) and binds the two consoles to it via
+# authenticationFlowBindingOverrides.browser. The SSO app clients
+# (gitea/harbor/openbao/oidc-gate) keep the `browser` flow + defaultProvider
+# delegation untouched — gitea in the mgmt-vCluster placement still relies on
+# it (its openidConnect provider cannot carry a kc_idp_hint).
+version: 1.4.37
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
@@ -552,6 +552,30 @@ data:
             "post.logout.redirect.uris": "https://console.{{ .Values.sovereignFQDN }}/*"
           }
         },
+        {{- /*
+        #3934 part-4 (Refs #3642): bind Keycloak's built-in account + admin
+        consoles to the `browser-no-idp` flow so they are NOT force-bounced
+        into the catalyst-pin broker (which 400s `cookie_not_found` on a
+        hint-less, cookie-less nav). These are KC realm-import DEFAULT clients;
+        re-declaring them by clientId MERGES the override onto the default
+        client (KC keeps every unspecified default attribute, incl. the
+        baseUrl/redirectUris the import generates for them). Only the
+        authenticationFlowBindingOverrides.browser field is asserted here —
+        everything else stays KC-default. `account` is the account REST
+        client (no browser flow); only the two consoles need the override.
+        */ -}}
+        {
+          "clientId": "account-console",
+          "authenticationFlowBindingOverrides": {
+            "browser": "browser-no-idp"
+          }
+        },
+        {
+          "clientId": "security-admin-console",
+          "authenticationFlowBindingOverrides": {
+            "browser": "browser-no-idp"
+          }
+        },
         {
           "clientId": "catalyst-api-server",
           "name": "Catalyst API Server (service account)",
@@ -980,6 +1004,43 @@ data:
             { "authenticator": "auth-cookie", "requirement": "ALTERNATIVE", "priority": 10, "autheticatorFlow": false },
             { "authenticator": "auth-spnego", "requirement": "DISABLED", "priority": 20, "autheticatorFlow": false },
             { "authenticator": "identity-provider-redirector", "authenticatorConfig": "catalyst-pin-redirector", "requirement": "ALTERNATIVE", "priority": 25, "autheticatorFlow": false },
+            { "flowAlias": "forms", "requirement": "ALTERNATIVE", "priority": 30, "autheticatorFlow": true }
+          ]
+        },
+        {{- /*
+        #3934 part-4 (Refs #3642, 2026-06-23, caught live hw182): the
+        `browser` flow above auto-delegates EVERY hint-less, cookie-less login
+        to the catalyst-pin broker because its identity-provider-redirector
+        carries `defaultProvider=catalyst-pin`. That is correct for the SSO
+        app clients (gitea/harbor/openbao/oidc-gate — they DO want zero-click
+        delegation, and gitea in the #3642 mgmt-vCluster placement relies on
+        `defaultProvider` since its openidConnect provider cannot carry a
+        kc_idp_hint). But Keycloak's OWN `account-console` + `security-admin-
+        console` clients send NO kc_idp_hint and hold NO session on a fresh
+        nav, so they are force-bounced into `/broker/catalyst-pin/login`,
+        which 400s `cookie_not_found` → the operator sees "We are sorry...
+        cookie not found" instead of the account page (4-surface SSO-landing
+        regression, #3934).
+
+        Fix: a SECOND top-level browser flow IDENTICAL to `browser` but
+        WITHOUT the auto-delegating redirector. The account/admin consoles
+        bind to it via `authenticationFlowBindingOverrides.browser` (the two
+        minimal client declarations below), so a hint-less nav falls through
+        to the standard `forms` login instead of crashing — while every SSO
+        app client keeps `browser` (defaultProvider delegation) untouched.
+        Verify post-deploy: `GET /realms/sovereign/account/` no longer 400s
+        at `/broker/catalyst-pin/login`; it renders the account page or the
+        plain sign-in form.
+        */ -}}
+        {
+          "alias": "browser-no-idp",
+          "description": "#3934 — browser flow WITHOUT catalyst-pin auto-delegation, for account-console / security-admin-console (hint-less clients KC must not force-bounce to the PIN broker).",
+          "providerId": "basic-flow",
+          "topLevel": true,
+          "builtIn": false,
+          "authenticationExecutions": [
+            { "authenticator": "auth-cookie", "requirement": "ALTERNATIVE", "priority": 10, "autheticatorFlow": false },
+            { "authenticator": "auth-spnego", "requirement": "DISABLED", "priority": 20, "autheticatorFlow": false },
             { "flowAlias": "forms", "requirement": "ALTERNATIVE", "priority": 30, "autheticatorFlow": true }
           ]
         },


### PR DESCRIPTION
## What

The 4th and final SSO-landing surface broken by the #3642 host→mgmt-vCluster pivot. Gitea / harbor / guacamole were fixed by #3938 (split-gate) and the oidc-gate CrashLoop by #3894. This closes the remaining **keycloak account-console** regression.

## Root cause (confirmed live on hw182, dep `4635277cae4ffed9`)

The sovereign realm's `browser` flow has an `identity-provider-redirector` with `defaultProvider=catalyst-pin`. That auto-delegates **every** hint-less, cookie-less browser login to `/broker/catalyst-pin/login`, which `400`s `cookie_not_found` on a fresh nav. Keycloak's own `account-console` (and `security-admin-console`) send no `kc_idp_hint` and hold no session on a fresh visit, so they get force-bounced and the operator sees **"We are sorry... cookie not found"** instead of the account page.

The delegation is **correct** for the SSO app clients (gitea/harbor/openbao/oidc-gate — they want zero-click delegation, and gitea in the mgmt-vCluster placement depends on `defaultProvider` because its openidConnect provider cannot carry a `kc_idp_hint`). So the redirector stays; the fix scopes the delegation OUT of the two consoles.

## Fix

- New top-level browser flow `browser-no-idp` — identical to `browser` minus the auto-delegating redirector execution.
- `account-console` + `security-admin-console` (KC realm-import default clients, re-declared by `clientId` so the import merges) bind to it via `authenticationFlowBindingOverrides.browser`. All other clients keep the `browser` flow + `defaultProvider` delegation untouched.
- bp-keycloak `1.4.36 → 1.4.37` (Chart.yaml + blueprint.yaml + slot-09 pin, lockstep).

## Live evidence (hw182)

Applied the equivalent flow + client override via the KC admin REST API:

| Surface | Before | After |
|---|---|---|
| `GET /realms/sovereign/account/` | FINAL **400** at `/broker/catalyst-pin/login` ("We are sorry / cookie not found") | FINAL **200** rendering `kc-form-login` (Sign in form) |
| gitea `/user/oauth2/openova-sso` | delegates to catalyst-pin | **unchanged** — still delegates (no regression) |
| harbor `/c/oidc/login` | `kc_idp_hint=catalyst-pin` | **unchanged** — hint still present (no regression) |

## Tests

All bp-keycloak chart tests pass, including `g117-5-tier1-sso-clients Case 7` (catalyst-pin IDR + authenticationFlows preserved) and the `255-cap` realm-audit gate. `helm lint` clean.

## Roll note

The chart change reaches a Sovereign only on a fresh prov or after the mothership picks up bp-keycloak 1.4.37 + the slot-09 pin. The live evidence above was produced by applying the exact equivalent via the KC admin API on the running env (throwaway test patch — the durable output is this PR).

Refs #3934 #3642 #3374