### PR TITLE
fix: converge secondary-region vc-mgmt — cross-region mangled DB-secret sync + -mesh-rw write host (Refs #4158)

### DIFF
--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -557,9 +557,30 @@ write_files:
             # (host/secret). In SHARED mode they must point at the shared
             # engine + the reflected hub Secret (#3284) or the consumers
             # would skip their bundled cluster yet still dial it.
-            SOVEREIGN_GITEA_PG_HOST: "${enable_shared_pg == "true" ? "shared-pg-rw.shared-data.svc.cluster.local" : "gitea-pg-rw.gitea.svc.cluster.local"}"
+            #
+            # #4158 cross-region host: gitea/harbor/keycloak run INSIDE vc-mgmt
+            # and read this host as a scalar (bitnami externalDatabase.host /
+            # an env value — NOT a secretKeyRef, so they cannot pick up the
+            # topology-aware `host` key bp-postgres bakes into the hub Secret
+            # the way grafana's hostPortKey does). The region-LOCAL `<instance>-rw`
+            # Service exists ONLY where the primary Cluster runs, so a SECONDARY
+            # control plane that dials `shared-pg-rw` gets NXDOMAIN (measured live
+            # on dep 4635277cae4ffed9 region-B: keycloak-0 `cannot resolve host
+            # shared-pg-rw…`, harbor-core/jobservice CrashLoop on the same). The
+            # ClusterMesh-global WRITE alias `shared-pg-mesh-rw` (bp-postgres
+            # publishes it on the primary as a `service.cilium.io/global` managed
+            # Service + a same-named replica stub) resolves in BOTH regions and
+            # routes writes to the current primary — and bp-continuum re-homes the
+            # `rw` selector on failover, so the host needs no change on promotion.
+            # Keyed on sovereign_region_role exactly like SECONDARY_HR_SUSPEND
+            # below; primary keeps `-rw` so single-region stays byte-identical.
+            SOVEREIGN_GITEA_PG_HOST: "${enable_shared_pg == "true" ? (sovereign_region_role == "primary" ? "shared-pg-rw.shared-data.svc.cluster.local" : "shared-pg-mesh-rw.shared-data.svc.cluster.local") : "gitea-pg-rw.gitea.svc.cluster.local"}"
             SOVEREIGN_GITEA_PG_SECRET: "${enable_shared_pg == "true" ? "gitea-database-secret" : "gitea-pg-app"}"
-            SOVEREIGN_HARBOR_PG_HOST: "${enable_shared_pg == "true" ? "shared-pg-rw.shared-data.svc.cluster.local" : "harbor-pg-rw.harbor.svc.cluster.local"}"
+            SOVEREIGN_HARBOR_PG_HOST: "${enable_shared_pg == "true" ? (sovereign_region_role == "primary" ? "shared-pg-rw.shared-data.svc.cluster.local" : "shared-pg-mesh-rw.shared-data.svc.cluster.local") : "harbor-pg-rw.harbor.svc.cluster.local"}"
+            # #4158: keycloak (slot 09 externalDatabase.host) had NO host var —
+            # it fell to the slot's bare `:=shared-pg-rw` default, which NXDOMAINs
+            # on the SECONDARY. Same cross-region treatment as gitea/harbor above.
+            SOVEREIGN_KEYCLOAK_PG_HOST: "${enable_shared_pg == "true" ? (sovereign_region_role == "primary" ? "shared-pg-rw.shared-data.svc.cluster.local" : "shared-pg-mesh-rw.shared-data.svc.cluster.local") : "shared-pg-rw.shared-data.svc.cluster.local"}"
             # #3188 three-instance model: the SAME one-flag contract
             # extends to instance A's third consumer (keycloak — slot 09
             # skips its bundled bitnami postgresql + flips to

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -360,6 +360,31 @@ var sharedPGReplicaAuthSecrets = func() []string {
 //
 // Sourced from the slot `reflect.secretName` values — keep in lockstep with
 // clusters/_template/bootstrap-kit/16{a,c,d}-bp-postgres-shared*.yaml.
+//
+// vc-mgmt mangled copies (#4158, Refs #3878): the four consumers that run
+// INSIDE vc-mgmt (keycloak/gitea/harbor on shared-pg, grafana on shared-pg-b)
+// declare `reflect.mangledTarget`, so role-secrets.yaml Pass 4 ALSO renders a
+// SECOND hub Secret named with the vCluster syncer-mangled object name
+// `<secretName>-x-<vclusterNamespace>-x-mgmt-vcluster` (annotated
+// `reflection-auto-namespaces: mgmt`). That mangled object is the EXACT host
+// Secret the in-vc-mgmt pod mounts in single-namespace mode — the failure
+// string `MountVolume.SetUp … secret "<…>-x-<ns>-x-mgmt-vcluster" not found`.
+// Like the plain copies these are PRIMARY-side only (the whole template is
+// `renderReplicaHalf`-gated) and the reflector never crosses the ClusterMesh,
+// so on a fresh active-hot-standby prov region-B's mgmt-vCluster keycloak (and
+// gitea/harbor/grafana) wedge at FailedMount for the mangled object that
+// nothing in region-B materialises — measured live on dep 4635277cae4ffed9
+// region-B `me-east-215-b` (keycloak-0 Init:0/2 x291 over 9h, cascading
+// bp-oidc-gate / bp-sso-bridge / bp-powerdns-admin / bp-newapi-host-seams into
+// `dependency 'mgmt/bp-keycloak' is not ready`). Copying the mangled copies
+// primary → replica (they carry the same `-mesh-rw` host so the readiness gate
+// passes, and the `reflection-auto-namespaces: mgmt` annotation so the
+// replica's own reflector re-pushes them into region-B's `mgmt` namespace)
+// closes the gap identically to the plain consumer copies. Mangled-name
+// pattern from role-secrets.yaml Pass 4 (`-x-mgmt-vcluster` is the default
+// vcluster); only the 4 vc-mgmt-homed bindings declare mangledTarget — the
+// shared-pg-c bindings (org/newapi/openova-flow) keep their `<ns>/*` fromHost
+// wildcard (#3876) and need NO mangled copy.
 var sharedPGConsumerHubSecrets = []string{
 	// instance A (shared-pg, slot 16a)
 	"harbor-database-secret",
@@ -373,6 +398,13 @@ var sharedPGConsumerHubSecrets = []string{
 	"org-database-secret",
 	"newapi-database-secret",
 	"openova-flow-database-secret",
+	// vc-mgmt mangled copies (#4158) — the host object the in-vc-mgmt pod
+	// mounts; rendered primary-side only by role-secrets.yaml Pass 4
+	// (reflect.mangledTarget), so they must cross the mesh too.
+	"harbor-database-secret-x-harbor-x-mgmt-vcluster",
+	"gitea-database-secret-x-gitea-x-mgmt-vcluster",
+	"keycloak-database-secret-x-keycloak-x-mgmt-vcluster",
+	"grafana-database-env-x-grafana-x-mgmt-vcluster",
 }
 
 // sharedPGMeshRWHostMarker — the substring a hub Secret's `host` key carries

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
@@ -2481,6 +2481,40 @@ func seedHubSecret(t *testing.T, cs kubernetes.Interface, name, host, password s
 	}
 }
 
+// seedMangledHubSecret creates a vc-mgmt MANGLED hub Secret (role-secrets.yaml
+// Pass 4, #3878) in shared-data — same shape as seedHubSecret but carrying the
+// `reflection-auto-namespaces: mgmt` annotation the mangled copy uses to
+// auto-push into the vCluster host namespace `mgmt` (#4158).
+func seedMangledHubSecret(t *testing.T, cs kubernetes.Interface, name, host, password string) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := cs.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: sharedPGNamespace},
+	}, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("create shared-data namespace: %v", err)
+	}
+	if _, err := cs.CoreV1().Secrets(sharedPGNamespace).Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: sharedPGNamespace,
+			Annotations: map[string]string{
+				"reflector.v1.k8s.emberstack.com/reflection-allowed":            "true",
+				"reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces": "mgmt",
+				"reflector.v1.k8s.emberstack.com/reflection-auto-enabled":       "true",
+				"reflector.v1.k8s.emberstack.com/reflection-auto-namespaces":    "mgmt",
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"host":     []byte(host),
+			"password": []byte(password),
+			"uri":      []byte("postgresql://owner:" + password + "@" + host + ":5432/db"),
+		},
+	}, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("create mangled hub Secret %s: %v", name, err)
+	}
+}
+
 // TestSyncSharedPGConsumerHubSecrets covers the #3629 best-effort cross-region
 // consumer-hub Secret sync: (1) a `-mesh-rw` source propagates to the replica
 // (correct host + password, overwriting the replica's divergent copy); (2) a
@@ -2570,5 +2604,50 @@ func TestSyncSharedPGConsumerHubSecrets(t *testing.T) {
 			"shared-pg-b-rw.shared-data.svc.cluster.local", "pw")
 		// len(slots) == 1 → no replica → must return immediately, no panic.
 		h.syncSharedPGConsumerHubSecrets(context.Background(), dep, []regionSlot{{key: "", clientset: primaryCS}})
+	})
+
+	// #4158: the vc-mgmt MANGLED hub copies (rendered primary-side only by
+	// role-secrets.yaml Pass 4 for the 4 in-vc-mgmt consumers) must cross the
+	// mesh too — otherwise region-B's mgmt-vCluster keycloak (and gitea/harbor/
+	// grafana) wedge at `FailedMount … secret "<…>-x-<ns>-x-mgmt-vcluster" not
+	// found`. The copy must carry the `reflection-auto-namespaces: mgmt`
+	// annotation through so the replica's own reflector re-pushes it into the
+	// replica's `mgmt` namespace (the object the in-vc pod actually mounts).
+	t.Run("mangled-vc-mgmt-copies-propagate-to-replica-with-mgmt-autoreflect", func(t *testing.T) {
+		primaryCS := kfake.NewSimpleClientset()
+		replicaCS := kfake.NewSimpleClientset()
+		// Seed all four mangled vc-mgmt hub copies on the primary, carrying the
+		// `-mesh-rw` host (readiness gate) + the `mgmt` auto-reflect annotation.
+		mangled := []string{
+			"keycloak-database-secret-x-keycloak-x-mgmt-vcluster",
+			"gitea-database-secret-x-gitea-x-mgmt-vcluster",
+			"harbor-database-secret-x-harbor-x-mgmt-vcluster",
+			"grafana-database-env-x-grafana-x-mgmt-vcluster",
+		}
+		for _, name := range mangled {
+			seedMangledHubSecret(t, primaryCS, name,
+				"shared-pg-mesh-rw.shared-data.svc.cluster.local", "region-A-pw")
+		}
+
+		slots := []regionSlot{
+			{key: "", clientset: primaryCS},
+			{key: "secondary", clientset: replicaCS},
+		}
+		h.syncSharedPGConsumerHubSecrets(context.Background(), dep, slots)
+
+		for _, name := range mangled {
+			got, ok := getSharedDataSecret(t, replicaCS, name)
+			if !ok {
+				t.Fatalf("replica missing mangled vc-mgmt hub Secret %q after sync — region-B mgmt-vCluster pod would FailedMount", name)
+			}
+			if p := string(got.Data["password"]); p != "region-A-pw" {
+				t.Errorf("%s: replica password = %q, want the authoritative region-A password", name, p)
+			}
+			// The `mgmt` auto-namespace annotation MUST carry over so the
+			// replica's reflector re-pushes the mangled object into `mgmt`.
+			if ns := got.Annotations["reflector.v1.k8s.emberstack.com/reflection-auto-namespaces"]; ns != "mgmt" {
+				t.Errorf("%s: replica lost reflection-auto-namespaces=mgmt (got %q) — the in-vc pod's host Secret would never materialise in region-B", name, ns)
+			}
+		}
 	})
 }


### PR DESCRIPTION
## Problem

On the live active-hot-standby Sovereign (dep `4635277cae4ffed9`, kom4dc), the **secondary region** (`me-east-215-b`) mgmt-vCluster never converged: keycloak-0 wedged at `Init:0/2` `FailedMount` for 9h, cascading `bp-oidc-gate` / `bp-sso-bridge` / `bp-powerdns-admin` / `bp-newapi-host-seams` / `bp-gitea` / `bp-grafana` / `bp-guacamole` into `dependency 'mgmt/bp-keycloak' is not ready`. Console reports `secondaryDegraded: true` (#4086). Region-kill failover (DoD Pillar 3 / North Star #4 multi-region active/passive) is impossible until the secondary converges.

Two stacked region-B-only gaps — both fixed here so a fresh prov delivers a converged secondary in EVERY region.

## Layer 1 — mangled vc-mgmt DB-secret never crossed the mesh (#4158)

`platform/postgres` `role-secrets.yaml` Pass 4 renders the syncer-mangled hub Secret `<name>-x-<ns>-x-mgmt-vcluster` (the exact host object the in-vc-mgmt pod mounts) **primary-side only** (`renderReplicaHalf` gate), and the emberstack reflector copies a Secret only WITHIN a cluster. catalyst-api's #3629 `syncSharedPGConsumerHubSecrets` already copies the PLAIN hub copies primary -> replica, but `sharedPGConsumerHubSecrets` did NOT include the four **mangled vc-mgmt copies** (keycloak/gitea/harbor on shared-pg, grafana on shared-pg-b), so region-B's `mgmt` namespace never got the object the kubelet mounts.

Fix: add the four mangled names. They carry the `-mesh-rw` host (readiness gate passes) + `reflection-auto-namespaces: mgmt`, so the existing copy path + the replica-side reflector delivers them into region-B's `mgmt` namespace exactly as on the primary. New `TestSyncSharedPGConsumerHubSecrets` subcase asserts the mangled copies propagate with the `mgmt` auto-reflect annotation preserved.

## Layer 2 — replica dialed the region-local `-rw` write host (NXDOMAIN)

gitea/harbor/keycloak run inside vc-mgmt and read the DB host as a SCALAR (bitnami `externalDatabase.host` / an env value, not a secretKeyRef), so they cannot pick up the topology-aware `host` key bp-postgres bakes into the hub Secret the way grafana's `hostPortKey` does. The region-local `<instance>-rw` Service exists only where the primary Cluster runs, so a secondary control plane dialing `shared-pg-rw` gets NXDOMAIN (`cannot resolve host shared-pg-rw…`).

Fix: point the three `*_PG_HOST` cloud-init seams at the ClusterMesh-global write alias `shared-pg-mesh-rw` on the SECONDARY (keyed on `sovereign_region_role`, exactly like the existing `SECONDARY_HR_SUSPEND` seam); primary keeps `-rw` so single-region renders byte-identical. keycloak had NO host var at all (fell to the slot-09 `:=shared-pg-rw` default) — added `SOVEREIGN_KEYCLOAK_PG_HOST`.

## Live evidence (dep 4635277cae4ffed9 region-B `me-east-215-b`)

BEFORE:
```
keycloak-0-x-keycloak-x-mgmt-vcluster  0/1  Init:0/2  (x291 FailedMount over 9h)
  secret "keycloak-database-secret-x-keycloak-x-mgmt-vcluster" not found
… then (after L1): cannot resolve host "shared-pg-rw.shared-data.svc.cluster.local"
```
AFTER both fixes applied as live probes:
```
keycloak-0-x-keycloak-x-mgmt-vcluster  1/1  Running
  Keycloak 26.3.3 … started in 6.097s. Listening on http://0.0.0.0:8080
  (Liquibase + Infinispan green, dialing shared-pg-mesh-rw)
```
The four mangled secrets reflected into region-B `mgmt` within ~50s of the cross-region copy. Nested-ternary cloud-init render validated via `tofu console` (secondary -> `-mesh-rw`, primary -> `-rw`, own-cluster path byte-identical).

## Scope notes
- Pure catalyst-api Go change + a surgical cloud-init host-seam change. No bp-postgres chart bump (the slots 16a/16c already declare `mangledTarget` correctly). The deploy-bot bumps `bp-catalyst-platform` on the catalyst-api image rebuild.
- Does NOT touch the keycloak realm-import config (#4157 territory).

Refs #4158 #3629 #3878 #3876 #4086

🤖 Generated with [Claude Code](https://claude.com/claude-code)