### PR TITLE
fix(catalog-seed): bump bp-wordpress-tenant pin 0.4.4->0.4.12 (lockstep w/ chart+blueprint)

### DIFF
--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -51,16 +51,18 @@ metadata:
     # must not claw it back (DoD §9.4).
     helm.sh/resource-policy: keep
 spec:
-  # 2026-06-22 (#4139): lockstep with platform/wordpress-tenant/blueprint.yaml
-  # spec.version 0.4.4 + the published chart ghcr.io/openova-io/bp-wordpress-tenant:0.4.4.
-  # 0.4.1 (the prior pin) defaulted persistence.wpContent.storageClass: local-path,
-  # which the #3971 forbid-local-path-storage Kyverno ENFORCE policy DENIES on
-  # the wp-content PVC → the per-Org WordPress app can never install. 0.4.3 emptied
-  # both the chart values.yaml AND the blueprint.yaml configSchema default; 0.4.4
-  # also moves active-hot-standby CNPG sync to the native spec.postgresql.synchronous
-  # block (the raw synchronous_standby_names param is rejected by vcluster.cnpg.io).
-  # (#3870 history: 0.2.0→0.4.1.)
-  version: "0.4.4"
+  # 2026-06-23: lockstep with platform/wordpress-tenant/blueprint.yaml spec.version
+  # 0.4.12 + the published chart ghcr.io/openova-io/bp-wordpress-tenant:0.4.12. The
+  # seed pin lagged at 0.4.4 while the chart shipped the per-Org WordPress
+  # convergence chain — 0.4.10 (init perms/PHP/URLs #4151, pg-driver image #4153),
+  # 0.4.11 (imagePullSecrets #4154), 0.4.12 (DROP the empty WORDPRESS_DB_PASSWORD
+  # seed so bp-reflector populates it from the CNPG <cluster>-app source #4155). A
+  # fresh prov on the stale 0.4.4 pin re-hits the empty-password 500. Earlier
+  # lineage: 0.4.1 defaulted wpContent.storageClass: local-path (DENIED by the
+  # #3971 forbid-local-path Kyverno ENFORCE policy); 0.4.4 moved active-hot-standby
+  # CNPG sync to the native spec.postgresql.synchronous block. (#3870: 0.2.0→0.4.1;
+  # #4139: →0.4.4.)
+  version: "0.4.12"
   visibility: listed
   card:
     title: "WordPress (per-Organization)"
@@ -82,7 +84,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-wordpress-tenant
-    version: 0.4.4
+    version: 0.4.12
   # G117.1+G117.4+G117.5 #2744-followup (2026-06-03): lockstep with
   # platform/wordpress-tenant/blueprint.yaml. Uses {{.AppName}} so
   # multi-instance tenants get distinct hostnames per Application.
@@ -187,7 +189,7 @@ metadata:
     # console edit/curate.
     helm.sh/resource-policy: keep
 spec:
-  version: "0.4.4"
+  version: "0.4.12"
   visibility: listed
   card:
     title: "WordPress"
@@ -209,7 +211,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-wordpress-tenant
-    version: 0.4.4
+    version: 0.4.12
   # Lockstep with the bp-wordpress-tenant entry above + platform/wordpress-tenant/
   # blueprint.yaml. Same chart bytes; this is the bare-slug entrypoint only.
   topology:


### PR DESCRIPTION
Refs #4160

## Problem
The catalog-seed pinned `bp-wordpress-tenant` chart **0.4.4** while `platform/wordpress-tenant` Chart.yaml + blueprint.yaml advanced to **0.4.12**. A fresh prov / new org install seeds the pre-fix chart, re-hitting the per-Org WordPress empty-`WORDPRESS_DB_PASSWORD` 500 (bp-reflector empty-seed trap, fixed in 0.4.12 / #4155).

## Fix
Bump both catalog-seed entries (canonical `bp-wordpress-tenant` + bare-slug `bp-wordpress` alias) chart+spec version 0.4.4 -> 0.4.12. Pure lockstep with the platform chart/blueprint (both already 0.4.12).

## Verification
- chart 0.4.12 published to ghcr (versions: 0.4.4/0.4.10/0.4.11/0.4.12).
- `helm template products/catalyst/chart` renders clean.
- Live on omantel.biz: demo Org HR uses `version: "*"`, resolved to a stale-mirror 0.4.10 still carrying the empty-password seed; 0.4.12 drops it so bp-reflector populates the password from the CNPG `<cluster>-app` source.