### PR TITLE
fix(catalyst-api): sync keycloak master-realm admin Secret primary→replica — kill region-B config-cli HTTP 401 / realm-import HR wedge (Refs #4158)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -417,6 +417,54 @@ var sharedPGConsumerHubSecrets = []string{
 // lands. Single-region / pre-flip hubs carry `-rw` and are correctly skipped.
 const sharedPGMeshRWHostMarker = "-mesh-rw."
 
+// keycloakAdminSecretName / keycloakAdminSecretNamespace — the HOST-cluster
+// name + namespace of the keycloak master-realm admin Secret (#4158, the layer
+// above the #4159 DB-secret fix).
+//
+// WHY THIS NEEDS A CROSS-REGION COPY (proven live on dep 4635277cae4ffed9
+// region-B `me-east-215-b`, 2026-06-23):
+//
+// The bp-keycloak chart pins NO `keycloak.auth.existingSecret` / `adminPassword`,
+// so the upstream bitnami subchart auto-GENERATES a RANDOM `admin-password` into
+// its `keycloak` Secret on each install — and that value DIVERGES per region
+// (region-A `1b58…`, region-B `2e7e…`, both 10 bytes). The vCluster syncer
+// surfaces the in-vc `keycloak/keycloak` Secret on the HOST as
+// `mgmt/keycloak-x-keycloak-x-mgmt-vcluster`.
+//
+// In active-hot-standby the keycloak SERVER in region-B boots against the
+// cross-region-replicated shared-pg Postgres, whose `admin` user password hash
+// was written by REGION-A's keycloak. So the only password that authenticates
+// against region-B's running keycloak is region-A's — verified live:
+//
+//	region-A pw → region-B server: login OK
+//	region-B pw → region-B server: "Invalid user credentials [invalid_grant]"
+//
+// But region-B's `keycloak-config-cli` post-upgrade hook (and every kcadm
+// consumer) reads region-B's LOCAL, divergent `admin-password` → HTTP 401
+// Unauthorized → the realm import never runs → the bp-keycloak HR's post-upgrade
+// hook times out → the whole mgmt-vCluster SSO tier (bp-oidc-gate / bp-sso-bridge
+// / bp-grafana / bp-gitea / bp-powerdns-admin / bp-newapi-host-seams) stays
+// `Ready=False` with `dependency 'mgmt/bp-keycloak' is not ready`.
+//
+// The emberstack reflector copies only WITHIN a cluster, never across the
+// ClusterMesh, and this Secret carries no reflection annotations anyway (it is a
+// plain Helm-minted Secret), so nothing materialises region-A's value on
+// region-B. catalyst-api is the only actor that spans both regions, so it copies
+// region-A's authoritative admin Secret primary → every replica directly into
+// the HOST `mgmt` namespace (the vCluster syncer then propagates the updated
+// bytes back down into the in-vc `keycloak/keycloak` Secret the config-cli +
+// kcadm consumers read). Idempotent + best-effort: on the steady-state pass the
+// bytes already match and copySecretAcrossClusters skips the write.
+//
+// UNLIKE the consumer-hub sync this is NOT gated on the `-mesh-rw` host marker:
+// the admin Secret carries no DB host, only the password, and region-A's value
+// is authoritative the moment region-A's keycloak has minted it — there is no
+// "pushing it would NXDOMAIN" window to wait out.
+const (
+	keycloakAdminSecretName      = "keycloak-x-keycloak-x-mgmt-vcluster"
+	keycloakAdminSecretNamespace = "mgmt"
+)
+
 // fluxKustomizationGVR — kustomize.toolkit.fluxcd.io/v1 Kustomizations,
 // addressed via the dynamic client (no Flux Go types vendored here).
 var fluxKustomizationGVR = schema.GroupVersionResource{
@@ -1203,6 +1251,19 @@ func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployme
 		// #3241/#3583 level-trigger re-run converges it. NEVER gates the flip.
 		if sharedPGOn {
 			h.syncSharedPGConsumerHubSecrets(ctx, dep, slots)
+			// #4158 (best-effort, never blocks): one layer above the #3629
+			// consumer-hub DB secrets — region-B's keycloak boots against the
+			// cross-region-replicated shared-pg catalog (so its admin password
+			// hash = region-A's), but its config-cli/kcadm read region-B's
+			// DIVERGENT local admin Secret → HTTP 401 → realm import never runs →
+			// the bp-keycloak HR post-upgrade hook times out → the whole
+			// mgmt-vCluster SSO tier stays Ready=False. Copy region-A's
+			// authoritative keycloak admin Secret primary → replica so the
+			// replica authenticates against its own (replicated) keycloak. NOT
+			// gated on `-mesh-rw` (no DB host on this Secret); a too-early pass
+			// (region-A keycloak not yet installed) is a harmless skip and the
+			// level-trigger re-run converges it. NEVER gates the flip.
+			h.syncKeycloakAdminSecret(ctx, dep, slots)
 		}
 	}
 	if patched == 0 {
@@ -1488,6 +1549,77 @@ func (h *Handler) syncSharedPGConsumerHubSecrets(ctx context.Context, dep *Deplo
 		h.emitClusterMeshProgress(dep, "info",
 			fmt.Sprintf("ClusterMesh: synced %d shared-pg consumer-hub Secret(s) (%s) primary → %d replica region(s) — cross-region consumer DB host/password (#3629)",
 				len(synced), strings.Join(synced, ", "), len(slots)-1))
+	}
+}
+
+// syncKeycloakAdminSecret copies the primary region's keycloak master-realm
+// admin Secret (keycloakAdminSecretName, namespace keycloakAdminSecretNamespace)
+// onto every replica region so the replica's keycloak-config-cli post-upgrade
+// hook (and every kcadm consumer) authenticates with the SAME `admin-password`
+// the running keycloak server expects (#4158 — one layer above the #4159
+// DB-secret fix). See keycloakAdminSecretName for the full divergence analysis +
+// the live region-B 401 evidence.
+//
+// BEST-EFFORT — like syncSharedPGConsumerHubSecrets this NEVER blocks/refuses the
+// cnpg-pair flip: the admin Secret is not part of the WAL-stream auth, so a
+// missing source (region-A's keycloak hasn't minted it yet) or a per-replica
+// copy failure is logged and SKIPPED, and the #3241/#3583 level-trigger re-run
+// converges it on a later pass. It returns nothing (the caller ignores the
+// outcome) precisely so it can never wedge convergence.
+//
+// NOT gated on the `-mesh-rw` host marker: the admin Secret carries only the
+// password (no DB host), and region-A's value is authoritative the moment
+// region-A's keycloak has minted it. Single-region (len(slots)<2) is a no-op.
+//
+// The destination is the HOST `mgmt` namespace where the vCluster syncer
+// surfaces the in-vc `keycloak/keycloak` Secret; overwriting the host object
+// makes the syncer propagate region-A's bytes down into the in-vc Secret the
+// config-cli + kcadm consumers read. Region-A's own keycloak is untouched (it is
+// the SOURCE, never a destination — slots[0] is skipped), so this can never
+// regress the working primary.
+func (h *Handler) syncKeycloakAdminSecret(ctx context.Context, dep *Deployment, slots []regionSlot) {
+	if len(slots) < 2 {
+		return // single-region — no replica to sync to
+	}
+	primary := &slots[0]
+	if primary.clientset == nil {
+		h.log.Warn("clustermesh: keycloak admin-secret sync: primary clientset nil — skipping (best-effort, re-run converges)",
+			"id", dep.ID)
+		return
+	}
+
+	getCtx, cancel := context.WithTimeout(ctx, clusterMeshCallTimeout)
+	src, err := primary.clientset.CoreV1().Secrets(keycloakAdminSecretNamespace).Get(getCtx, keycloakAdminSecretName, metav1.GetOptions{})
+	cancel()
+	if err != nil {
+		// region-A's keycloak (or its host-synced admin Secret) is not present
+		// yet — the mgmt-vCluster keycloak may still be installing. Skip quietly;
+		// the level-trigger re-run converges once it exists. Best-effort.
+		h.log.Info("clustermesh: keycloak admin-secret sync: source Secret not present on primary — skipping (mgmt-vCluster keycloak may still be installing; best-effort, re-run converges)",
+			"id", dep.ID, "namespace", keycloakAdminSecretNamespace, "secret", keycloakAdminSecretName)
+		return
+	}
+
+	copied := 0
+	for i := 1; i < len(slots); i++ {
+		replica := &slots[i]
+		if replica.clientset == nil {
+			continue
+		}
+		if err := h.copySecretAcrossClusters(ctx, src, replica.clientset, keycloakAdminSecretNamespace); err != nil {
+			h.log.Warn("clustermesh: keycloak admin-secret sync: copy to replica failed — skipping this region (best-effort, re-run converges)",
+				"id", dep.ID, "region", replica.key, "namespace", keycloakAdminSecretNamespace, "secret", keycloakAdminSecretName, "err", err)
+			continue
+		}
+		copied++
+	}
+
+	if copied > 0 {
+		h.log.Info("clustermesh: keycloak master-realm admin Secret synced primary → replica region(s) (#4158 — kill the region-B config-cli 401 / realm-import HR wedge)",
+			"id", dep.ID, "namespace", keycloakAdminSecretNamespace, "secret", keycloakAdminSecretName, "replicaRegions", copied)
+		h.emitClusterMeshProgress(dep, "info",
+			fmt.Sprintf("ClusterMesh: synced keycloak master-realm admin Secret (%s) primary → %d replica region(s) — the replica's config-cli + kcadm now authenticate against the replicated keycloak (#4158)",
+				keycloakAdminSecretName, copied))
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
@@ -2651,3 +2651,102 @@ func TestSyncSharedPGConsumerHubSecrets(t *testing.T) {
 		}
 	})
 }
+
+// seedKeycloakAdminSecret creates the host-cluster keycloak admin Secret
+// (mgmt/keycloak-x-keycloak-x-mgmt-vcluster, key admin-password) on the given
+// clientset — mirrors what the bitnami keycloak subchart mints + the vCluster
+// syncer surfaces on the host.
+func seedKeycloakAdminSecret(t *testing.T, cs kubernetes.Interface, adminPassword string) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := cs.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: keycloakAdminSecretNamespace},
+	}, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("create %s namespace: %v", keycloakAdminSecretNamespace, err)
+	}
+	if _, err := cs.CoreV1().Secrets(keycloakAdminSecretNamespace).Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      keycloakAdminSecretName,
+			Namespace: keycloakAdminSecretNamespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{"admin-password": []byte(adminPassword)},
+	}, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("create keycloak admin Secret: %v", err)
+	}
+}
+
+func getKeycloakAdminSecret(t *testing.T, cs kubernetes.Interface) (*corev1.Secret, bool) {
+	t.Helper()
+	s, err := cs.CoreV1().Secrets(keycloakAdminSecretNamespace).Get(context.Background(), keycloakAdminSecretName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil, false
+	}
+	if err != nil {
+		t.Fatalf("get keycloak admin Secret: %v", err)
+	}
+	return s, true
+}
+
+// TestSyncKeycloakAdminSecret covers the #4158 best-effort cross-region keycloak
+// master-realm admin Secret sync: (1) region-A's authoritative admin-password
+// overwrites the replica's DIVERGENT local value (the live region-B 401 root
+// cause); (2) a missing source is skipped (keycloak still installing); (3)
+// single-region is a no-op; (4) region-A (slots[0]) is NEVER written — the
+// primary's working keycloak must not regress.
+func TestSyncKeycloakAdminSecret(t *testing.T) {
+	h := &Handler{log: silentLogger()}
+	dep := &Deployment{ID: "dep-4158"}
+
+	t.Run("region-A-admin-password-overwrites-replica-divergent-copy", func(t *testing.T) {
+		primaryCS := kfake.NewSimpleClientset()
+		replicaCS := kfake.NewSimpleClientset()
+		// Region-A: the AUTHORITATIVE password whose hash lives in the
+		// cross-region-replicated keycloak catalog.
+		seedKeycloakAdminSecret(t, primaryCS, "1b58-region-A-pw")
+		// Region-B: its OWN divergent random password — the bitnami subchart
+		// generated a fresh one at install (the live 2e7e… defect) → 401.
+		seedKeycloakAdminSecret(t, replicaCS, "2e7e-region-B-pw")
+
+		slots := []regionSlot{
+			{key: "", clientset: primaryCS},
+			{key: "secondary", clientset: replicaCS},
+		}
+		h.syncKeycloakAdminSecret(context.Background(), dep, slots)
+
+		got, ok := getKeycloakAdminSecret(t, replicaCS)
+		if !ok {
+			t.Fatalf("replica keycloak admin Secret missing after sync")
+		}
+		if p := string(got.Data["admin-password"]); p != "1b58-region-A-pw" {
+			t.Errorf("replica admin-password = %q, want the authoritative region-A password (the replica's keycloak catalog has region-A's admin hash → only region-A's pw authenticates)", p)
+		}
+		// Region-A (the source) must be UNTOUCHED — the primary keycloak is
+		// working and must not regress.
+		src, _ := getKeycloakAdminSecret(t, primaryCS)
+		if p := string(src.Data["admin-password"]); p != "1b58-region-A-pw" {
+			t.Errorf("primary admin-password changed to %q — the source region must never be written", p)
+		}
+	})
+
+	t.Run("missing-source-is-skipped", func(t *testing.T) {
+		primaryCS := kfake.NewSimpleClientset() // no keycloak admin Secret yet
+		replicaCS := kfake.NewSimpleClientset()
+		slots := []regionSlot{
+			{key: "", clientset: primaryCS},
+			{key: "secondary", clientset: replicaCS},
+		}
+		// Must not panic / error — best-effort skip while keycloak still installs.
+		h.syncKeycloakAdminSecret(context.Background(), dep, slots)
+		if _, ok := getKeycloakAdminSecret(t, replicaCS); ok {
+			t.Errorf("replica unexpectedly gained an admin Secret from an empty primary")
+		}
+	})
+
+	t.Run("single-region-is-noop", func(t *testing.T) {
+		primaryCS := kfake.NewSimpleClientset()
+		seedKeycloakAdminSecret(t, primaryCS, "pw")
+		// len(slots) == 1 → no replica → must return immediately, no panic.
+		h.syncKeycloakAdminSecret(context.Background(), dep, []regionSlot{{key: "", clientset: primaryCS}})
+	})
+}


### PR DESCRIPTION
## Summary

Finishes the SECONDARY-region convergence of the permanent omantel.biz Sovereign by killing a precise cross-region credential mismatch that wedged region-B's keycloak realm import.

Advances **DoD Pillar 3** (region-kill failover) + **North Star #4** (multi-region active/passive): the secondary region's keycloak realm never finished importing, so every SSO + mgmt-vCluster app stayed `Ready=False` and the Sovereign read `secondaryDegraded`. This was the last layer blocking region-B convergence.

## Root cause (proven live on dep `4635277cae4ffed9`, region-B `me-east-215-b`)

The `bp-keycloak` chart pins **no** `keycloak.auth.existingSecret` / `adminPassword`, so the upstream bitnami subchart **auto-generates a random `admin-password`** into its `keycloak` Secret on each install. On an active-hot-standby Sovereign that value **diverges between regions**:

- region-A `admin-password` sha256 `1b58c3c8…` (10 bytes)
- region-B `admin-password` sha256 `2e7e04b4…` (10 bytes)

In active-hot-standby the region-B keycloak **server** boots against the cross-region-replicated `shared-pg` Postgres, whose `admin` user password hash was written by **region-A's** keycloak. So only region-A's password authenticates against the running region-B keycloak — verified live by `kcadm.sh` against the region-B server:

```
region-A pw → region-B keycloak server : Logging in … OK
region-B pw → region-B keycloak server : Invalid user credentials [invalid_grant]
```

But region-B's `keycloak-config-cli` post-upgrade hook reads region-B's **local, divergent** `admin-password` →

```
ERROR  KeycloakConfigRunner : Could not connect to keycloak in 300 seconds: HTTP 401 Unauthorized
de.adorsys.keycloak.config.exception.KeycloakProviderException
```

→ the realm import never runs → the `bp-keycloak` HR post-upgrade hook times out → cascade: `bp-oidc-gate` / `bp-sso-bridge` / `bp-grafana` / `bp-gitea` / `bp-powerdns-admin` / `bp-newapi-host-seams` all stuck `Ready=False` with `dependency 'mgmt/bp-keycloak' is not ready`.

This is the **same cross-region secret-consistency class #4159 fixed for the DB secret — one layer up** (the admin credential).

## Fix

The emberstack reflector copies only **within** a cluster (never across the ClusterMesh) and this plain Helm-minted Secret carries no reflection annotations, so nothing materialises region-A's value on region-B. catalyst-api is the only actor spanning both regions, so it now copies region-A's authoritative keycloak admin Secret (`mgmt/keycloak-x-keycloak-x-mgmt-vcluster`) **primary → every replica** directly into the host `mgmt` namespace; the vCluster syncer then propagates the bytes down into the in-vc `keycloak/keycloak` Secret the config-cli + kcadm consumers read.

`syncKeycloakAdminSecret` runs alongside the existing `syncSharedPGConsumerHubSecrets` (#3629) in `AutoEstablishClusterMesh`:

- **Best-effort** — never gates the cnpg-pair flip; a missing source (region-A keycloak still installing) is a quiet skip; the #3241/#3583 level-trigger re-run converges it.
- **Not gated** on the `-mesh-rw` host marker (the admin Secret carries no DB host).
- `slots[0]` (region-A) is never a destination → the working primary keycloak cannot regress.

## Files changed

- `products/catalyst/bootstrap/api/internal/handler/clustermesh.go` — `keycloakAdminSecret{Name,Namespace}` constants + `syncKeycloakAdminSecret` + call site in the shared-pg block.
- `products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go` — `TestSyncKeycloakAdminSecret` (overwrite-divergent / missing-source-skip / single-region-noop / primary-never-written).

Go-only change — no chart/blueprint version bump; the deploy-bot rebuilds the catalyst-api image and bumps the bp-catalyst-platform pin on merge.

## Live verification (region-B)

Equivalent fix applied as a throwaway probe (copy region-A admin Secret → region-B host `mgmt`):

- region-B host `admin-password` sha256 now `1b58c3c8…` (== region-A).
- `kcadm.sh` against the region-B server with the new value: **login OK**.
- Fresh `keycloak-config-cli` pod: **no 401** — `Importing file 'file:/config/sovereign-realm.json'` and processing the sovereign realm (previously errored within seconds).
- `bp-keycloak` HR: moved from `Helm upgrade failed … post-upgrade hooks failed: timed out` → `Running 'upgrade' action` with the config-cli hook executing.

Final HR-flip + cascade-clear evidence posted to #4158.

Refs #4158

🤖 Generated with [Claude Code](https://claude.com/claude-code)