### PR TITLE
fix(bp-newapi): per-Org install no longer clobbers Sovereign newapi-admin redirectUris — kill live SSO 'Invalid parameter: redirect_uri' (1.4.122)

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -304,7 +304,10 @@ spec:
       # both vcluster-side). Kills the slot-80↔slot-80a circular deadlock. Also
       # absorbs the 1.4.113–1.4.116 deploy-bot upstream-v0.13.2 chart bumps.
       # 1.4.121 (#3948): sql-dsn-gate volume gate symmetry fix.
-      version: 1.4.121
+      # 1.4.122 (#4169): issuer-realm gate on the sovereign-realm newapi-admin
+      # AppRegistration (host-side concern; this vcluster-app slot already sets
+      # ssoBridgeSync.enabled=false so it never emitted it — pure lockstep bump).
+      version: 1.4.122
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/clusters/_template/bootstrap-kit/80a-newapi-host-seams.yaml
+++ b/clusters/_template/bootstrap-kit/80a-newapi-host-seams.yaml
@@ -75,7 +75,12 @@ spec:
       # the seed would block on a schema this side never migrates → deadlock).
       # It still renders the CNPG Cluster + DSN-sync Job + AppRegistration +
       # ExternalSecrets. Lockstep with slot 80 + blueprint.yaml → 1.4.121 (#3948).
-      version: 1.4.121
+      # 1.4.122 (#4169): issuer-realm gate on the sovereign-realm newapi-admin
+      # AppRegistration. This host-seams slot sets issuer .../realms/sovereign
+      # (below), so it STILL renders the ConfigMap — it is the CANONICAL owner of
+      # the sovereign-realm newapi-admin client. The gate only EXCLUDES per-Org
+      # tenant installs (issuer .../realms/org-<sub>) that were clobbering it.
+      version: 1.4.122
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.121
+  version: 1.4.122
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -807,7 +807,14 @@ name: bp-newapi
 # cnpg.enabled alone) — fixes `volumeMounts[0].name: Not found "sql-dsn-gate"`
 # install failure under placement.role=vcluster-app (cnpg.enabled=false +
 # database.existingSecret set). Lockstep: both slot pins + blueprint → 1.4.119.
-version: 1.4.121
+# 1.4.122 (#4169): gate the sovereign-realm `newapi-admin` AppRegistration
+# ConfigMap (templates/sso-app-registration.yaml) on the install's OIDC issuer
+# realm matching `sovereign`. A per-Org tenant install (issuer .../realms/
+# org-<sub>) no longer emits a SECOND `newapi-admin` ConfigMap that clobbered
+# the host's redirectUris in the shared sovereign realm -> kills the live
+# "Invalid parameter: redirect_uri" SSO regression on newapi.<sovereign-fqdn>.
+# Lockstep: both slot pins + blueprint → 1.4.122.
+version: 1.4.122
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/sso-app-registration.yaml
+++ b/platform/newapi/chart/templates/sso-app-registration.yaml
@@ -29,7 +29,36 @@ data.realm = "sovereign": the watcher only requires the realm to EXIST
    hardening disables wildcard redirectUris). providerSlug == sso.bootstrap.providerSlug. */ -}}
 {{- /* #3648 — standard sso.bootstrap.providerSlug first, then legacy adminSeed. */ -}}
 {{- $providerSlug := ((.Values.sso | default dict).bootstrap | default dict).providerSlug | default (.Values.adminSeed | default dict).providerSlug | default "sovereign" -}}
-{{- if and (eq (include "bp-newapi.renderSeams" .) "true") .Values.newapi.enabled $kcMode $sync.enabled .Values.sovereignFQDN }}
+{{- /* #4169 — this AppRegistration ConfigMap registers the `newapi-admin` KC
+   client into the SHARED `sovereign` realm (data.realm below). That client is
+   OWNED by the host/Sovereign ops-staff admin UI install (bootstrap-kit slot
+   80a, placement.role=host-seams, sovereignFQDN=<sovereign-fqdn>). A per-Org
+   tenant install (organization_gitops.go: placement UNSET => role `all`,
+   chart-default ssoBridgeSync.enabled=true) ALSO matched this gate and emitted
+   a SECOND `newapi-admin` ConfigMap with the SAME clientId+realm but
+   redirectUris templated to the ORG domain (newapi.<org-fqdn>). bp-sso-bridge's
+   upsert_per_org_client keys on clientId and PUT-overwrites, so the later
+   per-Org reconcile clobbered the host's redirectUris -> Keycloak returned
+   "Invalid parameter: redirect_uri" for newapi.<sovereign-fqdn>/oauth/sovereign.
+
+   The sovereign-realm `newapi-admin` client is a HOST/Sovereign-scoped concern.
+   A per-Org install MUST NOT register into the shared `sovereign` realm: its
+   own OIDC issuer targets a PER-ORG realm (.../realms/org-<sub>). Gate this
+   ConfigMap on the install's issuer realm segment matching the `sovereign`
+   realm we register into. The host slots (80/80a) set issuer
+   https://auth.<fqdn>/realms/sovereign (or leave it empty and inherit the
+   sovereign default), so they still render; the per-Org overlay (issuer
+   .../realms/org-<sub>) no longer does. */ -}}
+{{- $issuer := .Values.auth.adminUI.keycloak.issuer | default "" -}}
+{{- $issuerRealm := "" -}}
+{{- if $issuer -}}
+{{- $issuerRealm = regexReplaceAll ".*/realms/([^/?#]+).*" $issuer "${1}" -}}
+{{- end -}}
+{{- /* The registration target realm (data.realm). Empty issuer => host-default
+   `sovereign`, so an unset issuer is allowed (matches). A non-`sovereign`
+   issuer realm (a per-Org realm) is excluded. */ -}}
+{{- $issuerIsSovereign := or (not $issuer) (eq $issuerRealm "sovereign") -}}
+{{- if and (eq (include "bp-newapi.renderSeams" .) "true") .Values.newapi.enabled $kcMode $sync.enabled .Values.sovereignFQDN $issuerIsSovereign }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
@@ -1125,6 +1125,18 @@ spec:
           clientId: newapi-admin
           callbackPath: /oauth/callback
           existingSecret: newapi-oidc-client-secret
+          # #4169 — this per-Org install authenticates against its OWN per-Org
+          # realm (issuer above: .../realms/org-<sub>). It MUST NOT push a
+          # newapi-admin AppRegistration ConfigMap into the SHARED sovereign
+          # realm: that client is owned by the host/Sovereign ops-staff admin UI
+          # (bootstrap-kit slot 80a), and a per-Org ConfigMap with the same
+          # clientId clobbers the host's redirectUris (bp-sso-bridge keys on
+          # clientId and PUT-overwrites) -> Keycloak "Invalid parameter:
+          # redirect_uri" on newapi.<sovereign-fqdn> SSO. Disable the sync here
+          # explicitly. (The chart also defends via an issuer-realm gate in
+          # templates/sso-app-registration.yaml, but the overlay states intent.)
+          ssoBridgeSync:
+            enabled: false
       customerAPI:
         keyIssuer: catalyst
     # ── Ingress + cert-manager TLS ────────────────────────────────────


### PR DESCRIPTION
Refs #4169 #3858 #3374 #3831

## Symptom (live regression — omantel.biz, UAT row 38, was PASS 2026-06-22)

Bare `https://newapi.omantel.biz` auto-redirects into Keycloak SSO, but Keycloak rejected the request with **"Invalid parameter: redirect_uri"** for `client_id=newapi-admin`, `redirect_uri=https://newapi.omantel.biz/oauth/sovereign` — despite the newapi host app being healthy (3/3 Running). Pure redirectUris-allowlist mismatch on the shared sovereign-realm `newapi-admin` Keycloak client.

## Root cause

The `newapi-admin` client lives in the shared **`sovereign` realm** and is OWNED by the host/Sovereign ops-staff admin UI install (bootstrap-kit slot 80a, `placement.role=host-seams`, `sovereignFQDN=<sovereign-fqdn>`).

The **per-Org** bp-newapi install (every tenant Organization runs its own NewAPI) renders with `placement` UNSET (`role: all`) and chart-default `auth.adminUI.keycloak.ssoBridgeSync.enabled: true`, so it ALSO emitted a `newapi-admin` AppRegistration ConfigMap with `data.realm: sovereign` and the SAME `clientId` — but `redirectUris` templated to the ORG domain (`https://newapi.<org-fqdn>/*`). bp-sso-bridge's `upsert_per_org_client` keys on `clientId` and PUT-overwrites, so the later per-Org reconcile clobbered the host's redirectUris.

### Live evidence (Keycloak admin API, sovereign realm, BEFORE)
```
newapi-admin.redirectUris = [
  https://newapi.demo.omani.homes/*,
  https://newapi.demo.omani.homes/oauth/sovereign,
  https://newapi.demo.omani.homes/oauth/callback
]
```
…while the newapi HTTPRoute serves `newapi.omantel.biz` — host mismatch -> rejected redirect_uri.

## Fix (durable, two layers)

1. **Chart** (`platform/newapi/chart/templates/sso-app-registration.yaml`): gate the sovereign-realm AppRegistration ConfigMap on the install's OIDC issuer realm segment matching `sovereign`. Host slots (issuer `.../realms/sovereign`, or empty -> sovereign default) STILL render it (canonical owner); a per-Org install (issuer `.../realms/org-<sub>`) no longer renders it.
2. **Overlay** (`organization_gitops.go` `orgTenantBPNewAPI`): set `auth.adminUI.keycloak.ssoBridgeSync.enabled: false` explicitly — the per-Org install authenticates against its OWN per-Org realm.

## Verification

`helm template` across 3 scenarios:
- host-seams (issuer sovereign) -> ConfigMap rendered with `<sovereign-fqdn>` ✓
- per-Org (issuer `org-<sub>`) -> ConfigMap **SUPPRESSED** ✓
- standalone `all` (no issuer) -> ConfigMap rendered (back-compat) ✓

All 4 existing chart render tests pass; `go build` clean; per-Org overlay YAML re-validated (`ssoBridgeSync.enabled: false`).

**Live end-to-end** (omantel.biz, throwaway kcadm probe applying the host redirectUris):
- GOOD `https://newapi.omantel.biz/oauth/sovereign` -> HTTP 303 into the `catalyst-pin` broker login flow, **no rejection**.
- CONTROL `https://evil.example/x` -> HTTP 400 + "Invalid parameter: redirect_uri" (allowlist still enforced).

The live patch is throwaway; this PR is the durable output — on the next reconcile of the per-Org HR + the host-seams HR the chart will re-converge the host's redirectUris and never let a per-Org install clobber them.

Lockstep: Chart.yaml + blueprint.yaml + slot 80 + slot 80a -> 1.4.122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)