### PR TITLE
fix(console): unblock sovereign-admin voucher issuance — drop showback gate on the vouchers route + add Vouchers nav link

### DIFF
--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -1813,10 +1813,21 @@ const consoleOrgRevenueRoute = createRoute({
   path: '/organizations/billing/revenue',
   component: () => <BillingModeGate><BssRevenuePage /></BillingModeGate>,
 })
+/* Vouchers is NOT BillingModeGate-wrapped (#4170). Voucher issuance is the
+ * Phase-0 sovereign-admin onboarding tool — the sovereign-admin mints
+ * prepaid signup codes (DoD.md Phase 0: marketplace + voucher onboarding)
+ * BEFORE any external customer exists, i.e. while the parent org is still
+ * showback by default. Gating it behind `real` mode (the way invoices /
+ * orders / revenue are, since those are real-customer payment surfaces)
+ * made onboarding circular: the operator could never reach the Issue-
+ * voucher CTA on a single-org Sovereign (console.omantel.biz), so the
+ * route rendered the showback notice instead. The backend gate
+ * (requireVoucherIssuer = superadmin OR sovereign-admin) is the real
+ * authority on who may issue; the route just needs to render. */
 const consoleOrgVouchersRoute = createRoute({
   getParentRoute: () => consoleLayoutRoute,
   path: '/organizations/billing/vouchers',
-  component: () => <BillingModeGate><BssVouchersPage /></BillingModeGate>,
+  component: () => <BssVouchersPage />,
 })
 const consoleOrgDomainsRoute = createRoute({
   getParentRoute: () => consoleLayoutRoute,

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationsDirectoryPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationsDirectoryPage.test.tsx
@@ -49,6 +49,7 @@ function renderDirectory(orgs: readonly OrgRow[]) {
     '/organizations/commerce/industries',
     '/organizations/commerce/apps',
     '/organizations/billing/billing',
+    '/organizations/billing/vouchers',
     '/organizations/domains',
   ]
   const sectionRoutes = sectionPaths.map((p) =>
@@ -97,6 +98,20 @@ describe('OrganizationsDirectoryPage — §5 empty-state law', () => {
     renderDirectory([parent])
     const btn = await screen.findByTestId('orgs-create-button')
     expect(btn.getAttribute('href')).toContain('/organizations/new')
+  })
+
+  // #4170 — Vouchers is a discoverable section link (sovereign-admin issues
+  // prepaid signup codes day-one, before the parent leaves showback). On a
+  // single-org Sovereign (console.omantel.biz) the parent is showback, yet
+  // the Vouchers entry must still be present and point at the voucher
+  // surface (the route is NOT BillingModeGate-wrapped — see router.tsx).
+  it('exposes a Vouchers section link day-one (showback parent)', async () => {
+    const parent = parentRowFromSelf({ deploymentId: 'dep-1', sovereignFQDN: 'hw130.omantel.biz' })
+    renderDirectory([parent])
+    await screen.findByTestId('organizations-directory-page')
+    const voucherLink = screen.getByTestId('organizations-nav-vouchers')
+    expect(voucherLink.getAttribute('href')).toBe('/organizations/billing/vouchers')
+    expect(voucherLink.textContent).toContain('Vouchers')
   })
 
   it('lists the parent FIRST, then sub-orgs (parent is first citizen)', async () => {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationsDirectoryPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationsDirectoryPage.tsx
@@ -43,6 +43,10 @@ const SECTION_LINKS: readonly { id: string; label: string; to: string }[] = [
   { id: 'commerce-industries', label: 'Industries', to: '/organizations/commerce/industries' },
   { id: 'commerce-apps', label: 'Apps', to: '/organizations/commerce/apps' },
   { id: 'billing', label: 'Billing', to: '/organizations/billing/billing' },
+  // #4170 — Vouchers is its own discoverable surface, not buried under the
+  // mode-gated Billing page. Voucher issuance is the Phase-0 sovereign-admin
+  // onboarding tool (DoD.md Phase 0), reachable day-one in any billing mode.
+  { id: 'vouchers', label: 'Vouchers', to: '/organizations/billing/vouchers' },
   { id: 'domains', label: 'Domains', to: '/organizations/domains' },
 ]
 


### PR DESCRIPTION
## Problem (verified live on console.omantel.biz)

A sovereign-admin could not issue vouchers from the operator console. The voucher page resolved to the **showback notice** ("This organization is in showback mode … Real billing (invoices, vouchers, checkout) exists when the marketplace sells to external organizations") instead of the voucher-issue surface, and there was **no nav link** to reach it.

## Root cause

The operator console — `products/catalyst/bootstrap/ui` (the `catalyst-ui` image served at `console.<sov-fqdn>`) — wrapped the vouchers route in `<BillingModeGate>`:

```tsx
path: '/organizations/billing/vouchers',
component: () => <BillingModeGate><BssVouchersPage /></BillingModeGate>,
```

`BillingModeGate` resolves the parent org's `billingMode`, which **defaults to `showback`** on a single-org Sovereign. In showback/chargeback it renders the consumption notice + `ShowbackPanel` and **never mounts** the wrapped page — so the fully-built `VouchersPage` (list + Issue modal → `POST /api/v1/org/billing/vouchers/issue`) was unreachable.

This conflated voucher issuance with real-mode payment flows. Per `docs/DOD.md` Phase 0, **voucher onboarding is the sovereign-admin tool used to mint prepaid signup codes BEFORE any external customer exists** — the prerequisite for the marketplace + voucher onboarding pillar, not a downstream payment action. Gating it behind `real` mode made Phase-0 onboarding circular.

## Fix

1. **Unwrap the vouchers route** from `BillingModeGate` (vouchers work day-one in any billing mode). Billing / Orders / Revenue stay gated — those are real-customer payment surfaces.
2. **Add a discoverable `Vouchers` section link** to the Organizations directory (`SECTION_LINKS` had Billing/Domains/Commerce but no Vouchers).
3. **Regression test**: the Vouchers section link is present + targets `/organizations/billing/vouchers` even with a showback parent.

## Backend already correct (verified live)

The backend (`POST /billing/vouchers/issue`, gated by `requireVoucherIssuer` = superadmin OR sovereign-admin) and the catalyst-api bridge (`/api/v1/org/billing/vouchers/*`) already exist. Live probe against console.omantel.biz:

- `POST /api/v1/org/billing/vouchers/issue` → **401** (auth required, route exists — not 404)
- `GET /api/v1/org/billing/vouchers/list` → **401** (route exists)
- `/sovereign/api/v1/healthz` → 200

The 404 the operator hit was purely the FE showback-gate + missing nav link.

## Build + tests

- `npm run build` (tsc -b && vite build) on `products/catalyst/bootstrap/ui` — **green**.
- Affected vitest suites — **40 tests pass** (organizationsRedirects, OrganizationsDirectoryPage incl. the new test, BillingModeGate, StepSuccess voucher-CTA).

Uses "Organization" not "tenant" in all new strings (#3383).

Refs #4170
Refs #3383

🤖 Generated with [Claude Code](https://claude.com/claude-code)