### PR TITLE
fix(ci): agenity-build smoke-gate must --entrypoint past the chepherd daemon (#4118)

### DIFF
--- a/.github/workflows/agenity-build.yaml
+++ b/.github/workflows/agenity-build.yaml
@@ -117,20 +117,25 @@ jobs:
         run: |
           set -euo pipefail
           IMG="${{ env.IMAGE }}:${{ steps.vars.outputs.app_version }}"
+          # NOTE: the image ENTRYPOINT is the `chepherd` daemon, so a bare
+          # `docker run "$IMG" sh -c …` passes `sh -c …` as ARGS to chepherd
+          # ("unknown shorthand flag: 'c'") and the gate crashes on its own
+          # invocation before testing anything. Every probe MUST override the
+          # entrypoint with `--entrypoint`.
           echo "::group::agent runtime (node + claude-code)"
-          docker run --rm "$IMG" sh -c 'node --version && /usr/bin/claude --version'
+          docker run --rm --entrypoint sh "$IMG" -c 'node --version && /usr/bin/claude --version'
           echo "::endgroup::"
           echo "::group::dashboard bundle is the NEW (#745) build"
           # The /app/ SPA must mount a content-hashed Dashboard component (a
           # stale/empty web layer would have no such reference) …
-          docker run --rm "$IMG" \
-            grep -qE '_astro/Dashboard[a-z]*\.[A-Za-z0-9_-]+\.js' /app/web/dist/app/index.html \
+          docker run --rm --entrypoint grep "$IMG" \
+            -qE '_astro/Dashboard[a-z]*\.[A-Za-z0-9_-]+\.js' /app/web/dist/app/index.html \
             || { echo "FAIL: /app/index.html does not reference a hashed Dashboard bundle — stale/empty web layer"; exit 1; }
           # … and the dist MUST carry the #745-era routes the OLD (pre-#745,
           # archaic) dashboard did NOT have. This is the decisive archaic-vs-new
           # discriminator: a cache-served old web layer fails HERE, before push.
-          docker run --rm "$IMG" \
-            sh -c 'test -d /app/web/dist/v09-stage4-preview && test -d /app/web/dist/v0.9.4' \
+          docker run --rm --entrypoint sh "$IMG" \
+            -c 'test -d /app/web/dist/v09-stage4-preview && test -d /app/web/dist/v0.9.4' \
             || { echo "FAIL: built /app dist is missing the #745 dashboard routes (v0.9.4 / v09-stage4-preview) — a cache-served ARCHAIC dashboard layer shipped"; exit 1; }
           echo "::endgroup::"
           echo "smoke gate PASSED — agent runtime present, NEW dashboard bundle confirmed"


### PR DESCRIPTION
## Problem
The 0.9.6 durable agenity image never publishes — the **#4118 smoke-gate** (added in #4173) fails on its **own invocation**, before testing anything.

The agenity image's ENTRYPOINT is the `chepherd` daemon. The gate ran:
```
docker run --rm "$IMG" sh -c 'node --version && /usr/bin/claude --version'
```
so `sh -c …` was passed as **args to chepherd**, not run as a shell:
```
Error: unknown shorthand flag: 'c' in -c
chepherd: unknown shorthand flag: 'c' in -c
##[error]Process completed with exit code 1.
```
(live failure: run [28028823238](https://github.com/openova-io/openova/actions/runs/28028823238)). Net effect: `bp-agenity:0.9.6` never reaches GHCR → the chart-baked `no-cache` + smoke-gate hardening (#4173) can't roll.

## Fix
Override the entrypoint on all three probes so they actually run:
- `docker run --rm --entrypoint sh "$IMG" -c 'node --version && /usr/bin/claude --version'`
- `docker run --rm --entrypoint grep "$IMG" -qE '…' /app/web/dist/app/index.html`
- `docker run --rm --entrypoint sh "$IMG" -c 'test -d …/v09-stage4-preview && test -d …/v0.9.4'`

Single-file CI change; YAML validated. The gate's logic (agent-runtime present + NEW #745 dashboard bundle) is unchanged — it can now reach it.

## Note
The live env already serves the **new** dashboard (`bp-agenity:0.9.5`, `Dashboard.BmDlYS5Q.js`, `no-cache` via the live HTTPRoute patch). This unblocks publishing the **durable** `0.9.6` image so the no-cache header + smoke-gate are baked into the chart for every future roll/prov.

Refs #4118