### PR TITLE
fix(catalog): regenerate stale catalog-gen — wordpress-tenant 0.4.2→0.4.12 + 5 pins (#4160)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-21T16:38:23.254Z",
+  "generatedAt": "2026-06-23T15:35:57.107Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -1778,7 +1778,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.35",
+      "version": "1.2.36",
       "section": "pts-3-5-storage-and-data",
       "depends": [
         "bp-cnpg",
@@ -2126,7 +2126,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.4.35",
+      "version": "1.4.38",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-postgres"
@@ -3373,7 +3373,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "1.4.121",
+      "version": "1.4.123",
       "section": "pts-4-6-llm-serving",
       "depends": [
         "bp-cnpg",
@@ -4704,7 +4704,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.1.3",
+      "version": "0.1.5",
       "section": "pts-4-5-communication",
       "depends": [
         "bp-keycloak",
@@ -5159,7 +5159,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "section": "pts-4-1-data-services",
       "depends": [
         "bp-flux"
@@ -5511,7 +5511,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.4.2",
+      "version": "0.4.12",
       "section": "pts-7-org-tenant",
       "depends": [
         "bp-postgres",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -1913,7 +1913,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.2.35",
+    "version": "1.2.36",
     "section": "pts-3-5-storage-and-data",
     "depends": [
       "bp-cnpg",
@@ -2261,7 +2261,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.4.35",
+    "version": "1.4.38",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-postgres"
@@ -3508,7 +3508,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "1.4.121",
+    "version": "1.4.123",
     "section": "pts-4-6-llm-serving",
     "depends": [
       "bp-cnpg",
@@ -4839,7 +4839,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.1.3",
+    "version": "0.1.5",
     "section": "pts-4-5-communication",
     "depends": [
       "bp-keycloak",
@@ -5294,7 +5294,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "section": "pts-4-1-data-services",
     "depends": [
       "bp-flux"
@@ -5646,7 +5646,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.4.2",
+    "version": "0.4.12",
     "section": "pts-7-org-tenant",
     "depends": [
       "bp-postgres",


### PR DESCRIPTION
## Problem (completes #4160)
#4160/#4161 bumped the catalog-seed `blueprints.yaml` + source `platform/wordpress-tenant/blueprint.yaml` to **0.4.12** — but the **auto-generated** catalog artifacts were last generated **2026-06-21** and still pinned `bp-wordpress-tenant` at **0.4.2**:
- `products/catalyst/bootstrap/api/internal/catalog/blueprints.json` (API catalog)
- `products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts` (UI wizard — `StepComponents`/`StepProvisioning`)

So the funnel **wizard + API catalog still advertised 0.4.2** — the empty-`WORDPRESS_DB_PASSWORD` version (#4155) that #4160's seed bump was meant to retire. A signup driven through the wizard could still resolve the buggy version. **No CI gate catches catalog-gen drift** (the existing drift gates cover bootstrap-kit slot indent + Chart.yaml lockstep, not `build-catalog.mjs` output).

## Fix
Re-ran `products/catalyst/bootstrap/ui/scripts/build-catalog.mjs` (the canonical generator) — regenerates both files from the current `platform/*/blueprint.yaml` + `products/*/blueprint.yaml` source-of-truth. Net diff = 13 lines:
- `bp-wordpress-tenant` **0.4.2 → 0.4.12** (the #4160 target)
- 5 other 2-day-stale pins refreshed: `1.2.35→1.2.36`, `1.4.35→1.4.38`, `1.4.121→1.4.123`, `0.1.3→0.1.5`, `1.1.3→1.1.4`

Generated-only change; no hand edits (the files carry `AUTO-GENERATED — do not edit by hand`).

## Follow-up (not in this PR)
Add a CI gate that runs `build-catalog.mjs` and fails on diff, so catalog-gen never silently drifts again (the gap that let this lag 2 days). Noted for a separate issue.

Refs #4160