### PR TITLE
fix(marketplace): org-creation redirect uses server console_host (pool domain) not Sovereign domain (#4176)

### DIFF
--- a/core/marketplace/src/components/CheckoutStep.svelte
+++ b/core/marketplace/src/components/CheckoutStep.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { sendMagicLink, verifyMagicLink, getMe, createTenant, getMyOrgs, createCheckout, startProvisioning, getProvisionByTenant, checkSlug, getPlans, getAddons, getCreditBalance, redeemVoucherPreview, setAuthTokens, setActiveOrg, setActiveOrgSlug, type User, type Provision, type Plan, type AddOn } from '../lib/api';
+  import { sendMagicLink, verifyMagicLink, getMe, createTenant, getMyOrgs, createCheckout, startProvisioning, getProvisionByTenant, checkSlug, getPlans, getAddons, getCreditBalance, redeemVoucherPreview, setAuthTokens, setActiveOrg, setActiveOrgSlug, setActiveOrgConsoleHost, type User, type Provision, type Plan, type AddOn } from '../lib/api';
   import { readCart, clearCart } from '../lib/cart';
   import { formatOMR } from '../lib/currency';
   import { consoleHref } from '../lib/config';
@@ -255,7 +255,7 @@
     authLoading = false;
   }
 
-  async function createTenantWithRetry(baseSlug: string, name: string): Promise<{ id: string; slug: string }> {
+  async function createTenantWithRetry(baseSlug: string, name: string): Promise<{ id: string; slug: string; console_host?: string }> {
     // Try the requested slug first, then -2, -3, ... up to -6 on 409.
     let lastErr: any;
     for (let i = 0; i < 6; i++) {
@@ -283,7 +283,7 @@
           // configSchema (Ghost / Nextcloud / Sandbox today).
           app_configs: cart.appConfigs || {},
         });
-        return { id: t.id, slug: t.slug || s };
+        return { id: t.id, slug: t.slug || s, console_host: t.console_host };
       } catch (e: any) {
         lastErr = e;
         const msg = String(e?.message || '');
@@ -305,13 +305,13 @@
       // phantom tenant_id to billing and produces an orphan provision.
       const cartKey = `org-tenant:${user.id}:${cart.plan}:${derivedSlug()}`;
       const cachedTenantId = localStorage.getItem(cartKey);
-      let tenant: { id: string; slug: string } | null = null;
+      let tenant: { id: string; slug: string; console_host?: string } | null = null;
       if (cachedTenantId) {
         try {
           const orgs = await getMyOrgs();
           const match = orgs.find(o => o.id === cachedTenantId && o.status !== 'deleted');
           if (match) {
-            tenant = { id: match.id, slug: match.slug || derivedSlug() };
+            tenant = { id: match.id, slug: match.slug || derivedSlug(), console_host: match.console_host };
           } else {
             localStorage.removeItem(cartKey);
           }
@@ -380,6 +380,10 @@
       // `console.<slug>.<sov-fqdn>` instead of bouncing to the operator
       // console at `console.<sov-fqdn>`.
       setActiveOrgSlug(tenant.slug);
+      // #4176 — persist the SERVER-AUTHORITATIVE console host (console.<slug>.<chosen
+      // pool domain>) so the redirect goes to the Org's selected domain, NOT
+      // console.<slug>.<marketplace-host-domain> (= the Sovereign domain → unreachable).
+      if (tenant.console_host) setActiveOrgConsoleHost(tenant.console_host);
       clearCart();
       redirectToConsole(tenant.slug);
     } catch (e: any) {

--- a/core/marketplace/src/lib/api.ts
+++ b/core/marketplace/src/lib/api.ts
@@ -43,6 +43,21 @@ export function setActiveOrgSlug(slug: string): void {
   notifyAuthChanged();
 }
 
+/**
+ * #4176 — persist the Org's SERVER-AUTHORITATIVE console host
+ * (`console.<slug>.<parentDomain>`, e.g. console.demo.omani.works) so
+ * `deriveConsoleURL` redirects to the chosen pool domain instead of
+ * re-deriving `console.<slug>.<marketplace-host-domain>` (which on
+ * marketplace.omantel.biz is the Sovereign domain → console.<slug>.omantel.biz,
+ * an unreachable host that breaks every org creation). Canonical key:
+ * `src/lib/config.ts::ACTIVE_CONSOLE_HOST_KEY`.
+ */
+export function setActiveOrgConsoleHost(host: string): void {
+  if (!host) return;
+  localStorage.setItem('org-active-console-host', host.trim().toLowerCase());
+  notifyAuthChanged();
+}
+
 async function request<T>(path: string, opts?: RequestInit): Promise<T> {
   const token = localStorage.getItem('org-token');
   const headers: Record<string, string> = {
@@ -223,6 +238,7 @@ export async function logout(): Promise<void> {
   localStorage.removeItem('org-refresh-token');
   localStorage.removeItem('org-active-org');
   localStorage.removeItem('org-active-org-slug');
+  localStorage.removeItem('org-active-console-host'); // #4176
   localStorage.removeItem('org-cart');
   localStorage.removeItem('org-checkout-tenant');
   localStorage.removeItem('org-checkout-tenant-slug');
@@ -499,6 +515,13 @@ export interface Tenant {
   plan_id: string;
   apps: string[];
   status: string;
+  // #4176 — server-authoritative console host: `console.<slug>.<parentDomain>`
+  // (e.g. console.demo.omani.works). Derived server-side from the Org's chosen
+  // pool parent domain; the client MUST use this for the post-checkout redirect
+  // rather than re-deriving from the marketplace host (which on a Sovereign whose
+  // marketplace runs on the Sovereign domain yields the wrong, unreachable host).
+  console_host?: string;
+  parent_domain?: string;
 }
 
 export interface CheckoutRequest {

--- a/core/marketplace/src/lib/config.ts
+++ b/core/marketplace/src/lib/config.ts
@@ -78,6 +78,26 @@ function readActiveOrgSlug(): string | null {
 }
 
 /**
+ * #4176 — the Org's SERVER-AUTHORITATIVE console host (`console.<slug>.<parentDomain>`,
+ * e.g. console.demo.omani.works), persisted by `setActiveOrgConsoleHost` right after
+ * `createTenant`. This is the canonical fix for the pool-domain redirect bug: on a
+ * Sovereign whose marketplace runs on the Sovereign domain (marketplace.omantel.biz)
+ * while Orgs provision on a SEPARATE pool domain (omani.works), re-deriving the host
+ * from the marketplace domain yields console.<slug>.omantel.biz — an unreachable host.
+ */
+export const ACTIVE_CONSOLE_HOST_KEY = 'org-active-console-host';
+
+function readActiveConsoleHost(): string | null {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    const h = localStorage.getItem(ACTIVE_CONSOLE_HOST_KEY);
+    return h && h.trim() ? h.trim().toLowerCase() : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Derive the customer console URL from the current marketplace host AND the
  * active tenant slug (if known).
  *
@@ -124,6 +144,19 @@ function deriveConsoleURL(slug?: string | null): string {
   if (!host) return mothershipConsoleURL();
   // Mothership marketplace keeps the canonical /nova prefix.
   if (host === MOTHERSHIP_HOST) return mothershipConsoleURL();
+  // #4176 — PREFER the server-authoritative console host (console.<slug>.<parentDomain>)
+  // persisted post-createTenant. This is the ONLY source that knows the Org's chosen
+  // POOL parent domain. Re-deriving from the marketplace host (below) is correct only
+  // when the marketplace runs ON the pool domain; on a Sovereign whose marketplace is
+  // on the Sovereign domain (marketplace.omantel.biz) with Orgs on a SEPARATE pool
+  // (omani.works), the derivation yields console.<slug>.omantel.biz — an unreachable
+  // host that breaks every org creation. Trust the stored host only when it matches the
+  // requested slug (guards a stale value when consoleHref is called for a different Org).
+  const storedHost = readActiveConsoleHost();
+  if (storedHost && storedHost.startsWith('console.')) {
+    const s = (slug ?? readActiveOrgSlug());
+    if (!s || storedHost.startsWith(`console.${s}.`)) return `https://${storedHost}`;
+  }
   // Sovereign pattern: marketplace.<sov-fqdn> — ALL franchised hosts, incl.
   // partner-vanity FQDNs (#3376: never bounce a cut-over customer to the
   // mothership). The per-tenant console is `console.<slug>.<sov-fqdn>`,


### PR DESCRIPTION
## P0 — every org creation on the production Sovereign lands on an unreachable host
Founder-reported: create an Org as demo@openova.io selecting **`demo.omani.works`** → redirected to **`https://console.demo.omantel.biz/jobs?token=…`** (the Sovereign domain, `omantel.biz`) → fails. Expected `console.demo.omani.works`.

## Root cause
`config.ts::deriveConsoleURL` splices the slug onto the **current marketplace host's domain** (`marketplace.omantel.biz` → `omantel.biz`), assuming the marketplace runs on the org-pool parent domain. On the production omantel.biz Sovereign the marketplace is on the **Sovereign** domain while Orgs provision on **separate** `omani.*` pool domains → it emits `console.<slug>.omantel.biz`, an unreachable host. **100% of org creations broken on the real Sovereign.**

The server already returns the correct `console_host` (`console.<slug>.<parentDomain>`) in the create-org response; the client ignored it.

## Fix
Persist + use the server's authoritative `console_host`:
- `api.ts` — `Tenant.console_host`/`parent_domain`; `setActiveOrgConsoleHost()`; cleared on logout.
- `config.ts` — `deriveConsoleURL` PREFERS the persisted `console_host` (slug-guarded) before the marketplace-host fallback.
- `CheckoutStep.svelte` — persists `tenant.console_host` post-`createTenant` (create + cache paths).

## Verification
- Build/types gate via CI (local astro env not installed here).
- **Live walk required before claiming fixed**: drive a real create→redirect on omantel.biz selecting `omani.works` → must land on `console.<slug>.omani.works` signed-in. UAT rows 84–86 stay ❌ until then.

## Honest note
My earlier read-only funnel walk marked UAT rows 75–82 ✅ (page render) but never drove the org-creation mutation (rows 84–86) — which is exactly where this P0 lives. Read-only ≠ acceptance.

Refs #4176