### PR TITLE
fix(catalyst): secure marketplace→console session handoff — no token in URL + auto-route per-Org console (Refs #4182 #4186)

### DIFF
--- a/core/controllers/organization/cmd/main.go
+++ b/core/controllers/organization/cmd/main.go
@@ -131,6 +131,17 @@ func main() {
 	consoleTLSIssuer := envOr("CATALYST_CONSOLE_TLS_CLUSTER_ISSUER", "letsencrypt-dns01-prod-powerdns")
 	consoleTLSCertNs := envOr("CATALYST_CONSOLE_TLS_CERT_NAMESPACE", "kube-system")
 
+	// #4186 — per-Org console HTTPRoute backends. The console host
+	// (console.<slug>.<pool>) is served by catalyst-ui + catalyst-api in
+	// catalyst-system; the route + backendRefs share that namespace so they
+	// resolve without a ReferenceGrant. Defaults match the catalyst chart
+	// Service names/ports; env-overridable per Inviolable Principle #4.
+	consoleRouteNs := envOr("CATALYST_CONSOLE_ROUTE_NAMESPACE", "catalyst-system")
+	consoleAPISvc := envOr("CATALYST_CONSOLE_API_SERVICE", "catalyst-api")
+	consoleUISvc := envOr("CATALYST_CONSOLE_UI_SERVICE", "catalyst-ui")
+	consoleAPIPort := int32(envIntOr("CATALYST_CONSOLE_API_PORT", 8080))
+	consoleUIPort := int32(envIntOr("CATALYST_CONSOLE_UI_PORT", 80))
+
 	// G117.3 W2.C3 — IaC repo bootstrap (ADR-0009).
 	// OpenBao seam for per-Org Gitea robot-token storage. Optional:
 	// when CATALYST_OPENBAO_ADDR is unset the bootstrap flow renders
@@ -211,6 +222,11 @@ func main() {
 		ConsoleGatewayNamespace:   consoleGatewayNs,
 		ConsoleTLSClusterIssuer:   consoleTLSIssuer,
 		ConsoleTLSCertNamespace:   consoleTLSCertNs,
+		ConsoleRouteNamespace:     consoleRouteNs,
+		ConsoleAPIService:         consoleAPISvc,
+		ConsoleUIService:          consoleUISvc,
+		ConsoleAPIPort:            consoleAPIPort,
+		ConsoleUIPort:             consoleUIPort,
 	}
 	if err := r.SetupWithManager(mgr); err != nil {
 		log.Error(err, "setup reconciler")

--- a/core/controllers/organization/internal/controller/organization_controller.go
+++ b/core/controllers/organization/internal/controller/organization_controller.go
@@ -243,6 +243,29 @@ type Reconciler struct {
 	// same-namespace by default) resolve without a ReferenceGrant.
 	// Default: kube-system.
 	ConsoleTLSCertNamespace string
+
+	// ── Per-Org console HTTPRoute backends (#4186) ────────────────────────
+	// The per-Org console host (console.<slug>.<pool>) is served by the
+	// catalyst-ui SPA + catalyst-api (the SAME Sovereign console + API the
+	// operator front door uses), NOT by an Org-namespace product backend.
+	// The route + these Services live in ConsoleRouteNamespace (catalyst-
+	// system) so the backendRefs resolve same-namespace without a
+	// ReferenceGrant — matching the hand-applied `issue-4075-live-unblock`
+	// route the funnel previously needed. All env-overridable (Principle #4).
+
+	// ConsoleRouteNamespace is the namespace the per-Org console HTTPRoute is
+	// written to. MUST be the namespace where catalyst-api + catalyst-ui
+	// Services live so backendRefs resolve same-namespace. Default:
+	// catalyst-system.
+	ConsoleRouteNamespace string
+	// ConsoleAPIService / ConsoleAPIPort — catalyst-api Service (the auth
+	// handover + /api/ + /catalyst/ backend). Default catalyst-api:8080.
+	ConsoleAPIService string
+	ConsoleAPIPort    int32
+	// ConsoleUIService / ConsoleUIPort — catalyst-ui Service (the SPA catch-
+	// all `/` backend). Default catalyst-ui:80.
+	ConsoleUIService string
+	ConsoleUIPort    int32
 }
 
 // SetupWithManager registers the reconciler with the controller-runtime

--- a/core/controllers/organization/internal/controller/organization_controller_test.go
+++ b/core/controllers/organization/internal/controller/organization_controller_test.go
@@ -922,12 +922,18 @@ func TestReconcile_TenantPublic_RendersHTTPRoute(t *testing.T) {
 		t.Fatalf("reconcile: %v", err)
 	}
 
+	// #4186: the per-Org console route now lands in catalyst-system (where
+	// catalyst-api + catalyst-ui Services live) and is named after the host
+	// (catalyst-ui-<host-dashed>), NOT in the Org namespace named after the
+	// slug. The route serves the catalyst-ui SPA + catalyst-api — the
+	// console host is never a product backend.
 	hr := unstructured.Unstructured{}
 	hr.SetGroupVersionKind(schema.GroupVersionKind{
 		Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute",
 	})
-	if err := r.Get(context.Background(), client.ObjectKey{Namespace: "acme", Name: "acme"}, &hr); err != nil {
-		t.Fatalf("get HTTPRoute acme/acme: %v", err)
+	wantName := "catalyst-ui-console-acme-omani-homes"
+	if err := r.Get(context.Background(), client.ObjectKey{Namespace: "catalyst-system", Name: wantName}, &hr); err != nil {
+		t.Fatalf("get HTTPRoute catalyst-system/%s: %v", wantName, err)
 	}
 	hostnames, _, _ := unstructured.NestedSlice(hr.Object, "spec", "hostnames")
 	if len(hostnames) != 1 || hostnames[0] != "console.acme.omani.homes" {
@@ -955,17 +961,35 @@ func TestReconcile_TenantPublic_RendersHTTPRoute(t *testing.T) {
 	if pr["name"] != "cilium-gateway-console" || pr["namespace"] != "kube-system" {
 		t.Errorf("parentRef: got %+v, want cilium-gateway-console/kube-system", pr)
 	}
+	// #4186 console-route shape: 5 rules. The catch-all `/` → catalyst-ui
+	// is LAST; the auth/api/catalyst rules → catalyst-api. Crucially the
+	// /auth/org-handover endpoint (the secure marketplace→console session
+	// handoff, #4182) is routed to catalyst-api.
 	rules, _, _ := unstructured.NestedSlice(hr.Object, "spec", "rules")
-	if len(rules) != 1 {
-		t.Fatalf("rules: got %d, want 1", len(rules))
+	if len(rules) != 5 {
+		t.Fatalf("rules: got %d, want 5 (health/handover/api/catalyst/catch-all)", len(rules))
 	}
-	brs, _, _ := unstructured.NestedSlice(rules[0].(map[string]any), "backendRefs")
-	if len(brs) != 1 {
-		t.Fatalf("backendRefs: got %d, want 1", len(brs))
+	// Last rule is the catch-all `/` → catalyst-ui.
+	lastBrs, _, _ := unstructured.NestedSlice(rules[4].(map[string]any), "backendRefs")
+	if len(lastBrs) != 1 || lastBrs[0].(map[string]any)["name"] != "catalyst-ui" {
+		t.Errorf("catch-all rule backend: got %v, want catalyst-ui", lastBrs)
 	}
-	br := brs[0].(map[string]any)
-	if br["name"] != "wordpress-x-acme-x-vcluster" {
-		t.Errorf("backendRef name: got %v, want wordpress-x-acme-x-vcluster", br["name"])
+	// The handover rule (rule[1]) routes BOTH /auth/handover and
+	// /auth/org-handover to catalyst-api.
+	handoverMatches, _, _ := unstructured.NestedSlice(rules[1].(map[string]any), "matches")
+	var sawOrgHandover bool
+	for _, m := range handoverMatches {
+		p, _, _ := unstructured.NestedString(m.(map[string]any), "path", "value")
+		if p == "/auth/org-handover" {
+			sawOrgHandover = true
+		}
+	}
+	if !sawOrgHandover {
+		t.Errorf("console route MUST route /auth/org-handover to catalyst-api (#4182), matches=%v", handoverMatches)
+	}
+	handoverBrs, _, _ := unstructured.NestedSlice(rules[1].(map[string]any), "backendRefs")
+	if len(handoverBrs) != 1 || handoverBrs[0].(map[string]any)["name"] != "catalyst-api" {
+		t.Errorf("handover rule backend: got %v, want catalyst-api", handoverBrs)
 	}
 	labels := hr.GetLabels()
 	if labels["catalyst.openova.io/tenant-product"] != "wordpress" {
@@ -975,6 +999,10 @@ func TestReconcile_TenantPublic_RendersHTTPRoute(t *testing.T) {
 	if labels["catalyst.openova.io/parent-zone"] != "omani.homes" {
 		t.Errorf("expected parent-zone=omani.homes label, got %q",
 			labels["catalyst.openova.io/parent-zone"])
+	}
+	if labels["catalyst.openova.io/component"] != "catalyst-ui" {
+		t.Errorf("expected component=catalyst-ui label, got %q",
+			labels["catalyst.openova.io/component"])
 	}
 }
 
@@ -1019,15 +1047,19 @@ func TestReconcile_TenantPublic_DisabledByDefault(t *testing.T) {
 // spec.tenantPublic.{parentDomain,subdomain} set but NO backendService
 // (the provisioning service patches backendService LATER, once the
 // purchased product is Ready — tenant_public_patch.go). The reconciler
-// MUST treat "parentDomain set, backendService not-yet-set" as a normal
-// transient window: the whole Org reconcile MUST still succeed (NOT fail
-// with TenantRouteFailed), and simply NO HTTPRoute is written yet (it
-// lands on the later reconcile that the backendService PATCH triggers).
+// MUST still succeed (NOT fail with TenantRouteFailed), and — #4186 —
+// the console HTTPRoute MUST now be rendered EVEN WHILE backendService is
+// pending. The console host (console.<slug>.<pool>) is served by
+// catalyst-ui + catalyst-api, NOT a product backend, so the customer must
+// be able to SIGN IN and land on /jobs the moment the Org has a public
+// hostname — long before any purchased product becomes Ready. The old
+// behavior (skip the route until backendService is patched) is exactly
+// why pool Orgs bounced /jobs → /login and the route had to be
+// hand-applied per-Org (#4186).
 //
 // Before the #3376 fix this path returned an error from
 // reconcileTenantRoute → the caller's fail() path marked the whole Org
-// Failed and requeued forever, so the Org never went Ready and the
-// customer's `console.<slug>.<pool-tld>` console never served.
+// Failed and requeued forever; that must still not happen.
 func TestReconcile_TenantPublic_ParentDomainSet_BackendPending(t *testing.T) {
 	t.Parallel()
 	org := sampleOrg()
@@ -1046,36 +1078,38 @@ func TestReconcile_TenantPublic_ParentDomainSet_BackendPending(t *testing.T) {
 		Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRouteList",
 	}, &unstructured.UnstructuredList{})
 
-	// MUST NOT error — the missing backendService is a transient ordering
-	// window, not a failure.
+	// MUST NOT error — the missing backendService is irrelevant to the
+	// console route (the console is catalyst-ui, not a product backend).
 	if _, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "acme"},
 	}); err != nil {
-		t.Fatalf("reconcile must succeed while backendService is pending (#3376), got: %v", err)
+		t.Fatalf("reconcile must succeed while backendService is pending, got: %v", err)
 	}
 
-	// The Org's Ready condition MUST NOT be TenantRouteFailed — the route
-	// step was skipped, not failed.
+	// The Org's Ready condition MUST NOT be TenantRouteFailed.
 	got := orgapi.Organization{}
 	if err := r.Get(context.Background(), client.ObjectKey{Name: "acme"}, &got); err != nil {
 		t.Fatalf("get Organization acme: %v", err)
 	}
 	for _, c := range got.Status.Conditions {
 		if c.Type == "Ready" && c.Reason == "TenantRouteFailed" {
-			t.Errorf("Ready condition must NOT be TenantRouteFailed when backendService is merely pending (#3376); got %+v", c)
+			t.Errorf("Ready condition must NOT be TenantRouteFailed; got %+v", c)
 		}
 	}
 
-	// No HTTPRoute is written yet — it lands once backendService is patched.
-	hrList := unstructured.UnstructuredList{}
-	hrList.SetGroupVersionKind(schema.GroupVersionKind{
-		Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRouteList",
+	// #4186: the console route IS now written even with backendService
+	// pending — in catalyst-system, named after the host.
+	hr := unstructured.Unstructured{}
+	hr.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute",
 	})
-	if err := r.List(context.Background(), &hrList); err != nil {
-		t.Fatalf("list HTTPRoute: %v", err)
+	wantName := "catalyst-ui-console-acme-omani-homes"
+	if err := r.Get(context.Background(), client.ObjectKey{Namespace: "catalyst-system", Name: wantName}, &hr); err != nil {
+		t.Fatalf("console route MUST render while backendService is pending (#4186); get catalyst-system/%s: %v", wantName, err)
 	}
-	if len(hrList.Items) != 0 {
-		t.Errorf("expected 0 HTTPRoutes while backendService is pending, got %d", len(hrList.Items))
+	rules, _, _ := unstructured.NestedSlice(hr.Object, "spec", "rules")
+	if len(rules) != 5 {
+		t.Fatalf("rules: got %d, want 5 console-route rules", len(rules))
 	}
 }
 

--- a/core/controllers/organization/internal/controller/tenant_console_tls.go
+++ b/core/controllers/organization/internal/controller/tenant_console_tls.go
@@ -92,6 +92,14 @@ const (
 	consoleTLSDefaultClusterIssuer = "letsencrypt-dns01-prod-powerdns"
 	consoleTLSDefaultCertNamespace = "kube-system"
 
+	// Per-Org console HTTPRoute backend defaults (#4186). The route + these
+	// Services live in catalyst-system so backendRefs resolve same-namespace.
+	consoleRouteDefaultNamespace = "catalyst-system"
+	consoleAPIDefaultService     = "catalyst-api"
+	consoleAPIDefaultPort        = int32(8080)
+	consoleUIDefaultService      = "catalyst-ui"
+	consoleUIDefaultPort         = int32(80)
+
 	// Host ports the console Gateway's listeners bind — the dedicated
 	// console Gateway uses 31443/31080 (NOT the shared gateway's
 	// 30443/30080). See cilium-gateway-console.yaml header for the
@@ -136,6 +144,45 @@ func (r *Reconciler) consoleTLSCertNamespace() string {
 		return v
 	}
 	return consoleTLSDefaultCertNamespace
+}
+
+// consoleRouteNamespace is the namespace the per-Org console HTTPRoute is
+// written to — MUST be where catalyst-api + catalyst-ui Services live so the
+// route's backendRefs resolve same-namespace (no ReferenceGrant). Default:
+// catalyst-system (#4186).
+func (r *Reconciler) consoleRouteNamespace() string {
+	if v := strings.TrimSpace(r.ConsoleRouteNamespace); v != "" {
+		return v
+	}
+	return consoleRouteDefaultNamespace
+}
+
+// consoleAPIBackend returns the catalyst-api Service name + port for the
+// per-Org console route's auth/api/catalyst rules (#4186).
+func (r *Reconciler) consoleAPIBackend() (string, int32) {
+	svc := strings.TrimSpace(r.ConsoleAPIService)
+	if svc == "" {
+		svc = consoleAPIDefaultService
+	}
+	port := r.ConsoleAPIPort
+	if port == 0 {
+		port = consoleAPIDefaultPort
+	}
+	return svc, port
+}
+
+// consoleUIBackend returns the catalyst-ui Service name + port for the
+// per-Org console route's catch-all `/` rule (#4186).
+func (r *Reconciler) consoleUIBackend() (string, int32) {
+	svc := strings.TrimSpace(r.ConsoleUIService)
+	if svc == "" {
+		svc = consoleUIDefaultService
+	}
+	port := r.ConsoleUIPort
+	if port == 0 {
+		port = consoleUIDefaultPort
+	}
+	return svc, port
 }
 
 // poolWildcardSecretName is the deterministic name of the per-pool

--- a/core/controllers/organization/internal/controller/tenant_route.go
+++ b/core/controllers/organization/internal/controller/tenant_route.go
@@ -111,28 +111,20 @@ func (r *Reconciler) reconcileTenantRoute(ctx context.Context, org *orgapi.Organ
 	if subdomain == "" {
 		subdomain = org.Spec.Slug
 	}
-	backend := strings.TrimSpace(tp.BackendService)
-	if backend == "" {
-		// #3376 fix: the funnel mints the Organization CR with
-		// tenantPublic.{parentDomain,subdomain} set but NO backendService —
-		// the provisioning service patches backendService LATER, once the
-		// purchased product becomes Ready (provision.completed /
-		// provision.app_ready → patchOrgTenantPublic, tenant_public_patch.go).
-		// Treating "parentDomain set, backendService not-yet-set" as a HARD
-		// ERROR failed the WHOLE Org reconcile at this step (the caller's
-		// fail() path) — so the Org never went Ready, the per-Org Flux loop +
-		// realm + UserAccess status never converged, and no HTTPRoute ever
-		// landed even after the product came up. This is a normal transient
-		// ordering window, NOT a failure: skip the route render (no-op) and
-		// let a later reconcile — triggered by the backendService PATCH —
-		// emit it. The Sovereign-wide `*.<sovFQDN>` tenant-wildcard route
-		// keeps the Org reachable in the meantime.
-		return false, nil
-	}
-	port := tp.BackendPort
-	if port == 0 {
-		port = tenantRouteDefaultBackendPort
-	}
+	// #4186: the per-Org console host (console.<slug>.<pool>) is served by
+	// the catalyst-ui SPA + catalyst-api — the SAME Sovereign console + API
+	// the operator front door uses — NOT by an Org-namespace product
+	// backend. (The Org's PRODUCTS get their own hosts, e.g.
+	// agenity.<slug>.<pool>, rendered elsewhere.) Therefore the console
+	// route is INDEPENDENT of tenantPublic.backendService: it MUST land as
+	// soon as the Org has a public hostname so the customer can SIGN IN and
+	// land on /jobs even before any product is Ready. Gating it on
+	// backendService (the old product-route model) is exactly why this route
+	// never auto-rendered and had to be hand-applied per-Org
+	// (`managed-by: issue-4075-live-unblock`), leaving pool Orgs bouncing
+	// /jobs → /login (#4186). The marketplace→console secure handoff
+	// (/auth/org-handover, #4182) is one of the catalyst-api rules below —
+	// without it the customer's session is never established on the pool host.
 
 	// TBD-A67 issue #1990: hostname is `console.<subdomain>.<parentDomain>`
 	// — the `console.` infix is the canonical per-tenant console host
@@ -140,21 +132,37 @@ func (r *Reconciler) reconcileTenantRoute(ctx context.Context, org *orgapi.Organ
 	// runtime reconciler emitted `<slug>.<parent>` while the chart-side
 	// overlay emitted `console.<slug>.<parent>` and the two drifted.
 	hostname := fmt.Sprintf("console.%s.%s", subdomain, parentDomain)
-	ns := org.Spec.Slug
-	name := org.Spec.Slug
+	// The route + its backendRefs live in catalyst-system (where catalyst-api
+	// + catalyst-ui Services are) so the refs resolve same-namespace without
+	// a ReferenceGrant — matching the hand-applied route shape. The name is
+	// derived from the host so each Org's console route is distinct and
+	// deterministic (catalyst-ui-<host-dashed>).
+	ns := r.consoleRouteNamespace()
+	name := "catalyst-ui-" + dnsDashed(hostname)
 
 	labels := map[string]string{
-		"openova.io/organization":         org.Spec.Slug,
-		"openova.io/sovereign":            org.Spec.SovereignRef,
-		"openova.io/managed-by":           "organization-controller",
-		"app.kubernetes.io/managed-by":    "catalyst",
-		"catalyst.openova.io/component":   "tenant-public-route",
-		"catalyst.openova.io/parent-zone": parentDomain,
+		"openova.io/organization":           org.Spec.Slug,
+		"openova.io/sovereign":              org.Spec.SovereignRef,
+		"openova.io/managed-by":             "organization-controller",
+		"app.kubernetes.io/managed-by":      "catalyst",
+		"catalyst.openova.io/component":     "catalyst-ui",
+		"catalyst.openova.io/parent-zone":   parentDomain,
+		"catalyst.openova.io/org-subdomain": subdomain,
 	}
 	if p := strings.TrimSpace(tp.Product); p != "" {
 		labels["catalyst.openova.io/tenant-product"] = p
 	}
 
+	apiSvc, apiPort := r.consoleAPIBackend()
+	uiSvc, uiPort := r.consoleUIBackend()
+	apiBackendRefs := []any{
+		map[string]any{"name": apiSvc, "port": int64(apiPort)},
+	}
+	// catalyst-api rules: health probes, BOTH handover endpoints (the
+	// mothership→Sovereign /auth/handover AND the marketplace→console
+	// /auth/org-handover #4182), and the /api/ + /catalyst/ surfaces the
+	// SPA's whoami + every authed fetch hit. The catch-all `/` →
+	// catalyst-ui rule is LAST so the more-specific prefixes win.
 	desiredSpec := map[string]any{
 		"parentRefs": []any{
 			map[string]any{
@@ -166,18 +174,36 @@ func (r *Reconciler) reconcileTenantRoute(ctx context.Context, org *orgapi.Organ
 		"rules": []any{
 			map[string]any{
 				"matches": []any{
-					map[string]any{
-						"path": map[string]any{
-							"type":  "PathPrefix",
-							"value": "/",
-						},
-					},
+					map[string]any{"path": map[string]any{"type": "Exact", "value": "/readyz"}},
+					map[string]any{"path": map[string]any{"type": "Exact", "value": "/healthz"}},
+				},
+				"backendRefs": apiBackendRefs,
+			},
+			map[string]any{
+				"matches": []any{
+					map[string]any{"path": map[string]any{"type": "Exact", "value": "/auth/handover"}},
+					map[string]any{"path": map[string]any{"type": "Exact", "value": "/auth/org-handover"}},
+				},
+				"backendRefs": apiBackendRefs,
+			},
+			map[string]any{
+				"matches": []any{
+					map[string]any{"path": map[string]any{"type": "PathPrefix", "value": "/api/"}},
+				},
+				"backendRefs": apiBackendRefs,
+			},
+			map[string]any{
+				"matches": []any{
+					map[string]any{"path": map[string]any{"type": "PathPrefix", "value": "/catalyst/"}},
+				},
+				"backendRefs": apiBackendRefs,
+			},
+			map[string]any{
+				"matches": []any{
+					map[string]any{"path": map[string]any{"type": "PathPrefix", "value": "/"}},
 				},
 				"backendRefs": []any{
-					map[string]any{
-						"name": backend,
-						"port": int64(port),
-					},
+					map[string]any{"name": uiSvc, "port": int64(uiPort)},
 				},
 			},
 		},

--- a/core/marketplace/src/components/CheckoutStep.svelte
+++ b/core/marketplace/src/components/CheckoutStep.svelte
@@ -2,7 +2,7 @@
   import { sendMagicLink, verifyMagicLink, getMe, createTenant, getMyOrgs, createCheckout, startProvisioning, getProvisionByTenant, checkSlug, getPlans, getAddons, getCreditBalance, redeemVoucherPreview, setAuthTokens, setActiveOrg, setActiveOrgSlug, setActiveOrgConsoleHost, type User, type Provision, type Plan, type AddOn } from '../lib/api';
   import { readCart, clearCart } from '../lib/cart';
   import { formatOMR } from '../lib/currency';
-  import { consoleHref } from '../lib/config';
+  import { consoleHandoffHref } from '../lib/config';
   import PinInput6 from './PinInput6.svelte';
 
   let cart = $state(readCart());
@@ -208,19 +208,20 @@
   });
 
   function redirectToConsole(slug?: string) {
-    const tok = encodeURIComponent(localStorage.getItem('org-token') || '');
-    const refresh = encodeURIComponent(localStorage.getItem('org-refresh-token') || '');
+    const tok = localStorage.getItem('org-token') || '';
+    const refresh = localStorage.getItem('org-refresh-token') || '';
     // TBD-V10 #2001: pass the tenant slug so `deriveConsoleURL` composes
     // `console.<slug>.<sov-fqdn>` (per-tenant) instead of
     // `console.<sov-fqdn>` (operator). If `slug` is undefined the helper
     // falls back to the slug persisted in localStorage by
     // `setActiveOrgSlug` (see api.ts) — covers the Stripe-return path
     // when the function is called without an explicit argument.
-    window.location.href = consoleHref(
-      '/jobs',
-      { token: decodeURIComponent(tok), refresh_token: decodeURIComponent(refresh) },
-      { slug },
-    );
+    //
+    // #4182/#4186: hand off via the SECURE /auth/org-handover endpoint —
+    // catalyst-api burns the token into an HttpOnly cookie and 302s to a
+    // clean /jobs. NO token/refresh ever lands in the browser address bar
+    // after the hop; the refresh token stays in client storage.
+    window.location.href = consoleHandoffHref(tok, refresh, { slug });
   }
 
   async function handleSendCode() {
@@ -506,9 +507,9 @@
         </div>
         {#if provision.status === 'completed'}
           <a
-            href={consoleHref(
-              '/jobs',
-              { token: localStorage.getItem('org-token') || '', refresh_token: localStorage.getItem('org-refresh-token') || '' },
+            href={consoleHandoffHref(
+              localStorage.getItem('org-token') || '',
+              localStorage.getItem('org-refresh-token') || '',
               { slug: (typeof localStorage !== 'undefined' ? localStorage.getItem('org-active-org-slug') : null) || undefined },
             )}
             class="mt-6 flex w-full items-center justify-center gap-2 rounded-xl bg-[var(--color-success)] px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-[var(--color-success)]/90 no-underline"

--- a/core/marketplace/src/components/Header.svelte
+++ b/core/marketplace/src/components/Header.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { readCart, cartItemCount, type CartState } from '../lib/cart';
   import { getMe, logout as apiLogout, AUTH_CHANGED_EVENT, type User } from '../lib/api';
-  import { consoleHref } from '../lib/config';
+  import { consoleHref, consoleHandoffHref } from '../lib/config';
 
   let { currentStep = 0 }: { currentStep?: number } = $props();
 
@@ -115,9 +115,9 @@
     const t = typeof localStorage !== 'undefined' ? localStorage.getItem('org-token') : null;
     const r = typeof localStorage !== 'undefined' ? localStorage.getItem('org-refresh-token') : null;
     if (!t) return consoleHref();
-    const params: Record<string, string> = { token: t };
-    if (r) params.refresh_token = r;
-    return consoleHref('', params);
+    // #4182/#4186: secure server-side handoff — no token/refresh in the URL
+    // after the hop (catalyst-api burns the token into an HttpOnly cookie).
+    return consoleHandoffHref(t, r);
   }
 </script>
 

--- a/core/marketplace/src/layouts/Layout.astro
+++ b/core/marketplace/src/layouts/Layout.astro
@@ -137,19 +137,31 @@ const { title, step = 0 } = Astro.props;
         var MOTHERSHIP_HOST = 'marketplace.' + ['openova', 'io'].join('.');
         var host = (window.location.hostname || '').toLowerCase();
         var base = 'https://console.' + MOTHERSHIP_HOST.substring('marketplace.'.length) + '/nova';
+        // perTenant: a per-Org Sovereign console (console.<slug>.<sov>) gets
+        // the SECURE server-side handoff at /auth/org-handover (#4182/#4186)
+        // — catalyst-api validates the member token, mints an HttpOnly
+        // catalyst_session cookie, and 302s to a clean /jobs. The mothership
+        // legacy /nova console keeps the historical /?token= shape.
+        var perTenant = false;
         if (host && host !== MOTHERSHIP_HOST && host.indexOf('marketplace.') === 0) {
           var sovFqdn = host.substring('marketplace.'.length);
           if (sovFqdn) {
             var s = (slug || '').toLowerCase().trim();
             if (s) {
               base = 'https://console.' + s + '.' + sovFqdn;
+              perTenant = true;
             } else {
               base = 'https://console.' + sovFqdn;
             }
           }
         }
-        var url = base + '/?token=' + encodeURIComponent(token);
-        if (refresh) url += '&refresh_token=' + encodeURIComponent(refresh);
+        // #4182: NEVER put the refresh_token in the URL. The session token is
+        // handed to the secure server endpoint which burns it into a cookie;
+        // the refresh stays in client storage (org-refresh-token, written by
+        // setAuthTokens). On the secure path the landing URL is a clean /jobs.
+        var url = perTenant
+          ? base + '/auth/org-handover?token=' + encodeURIComponent(token)
+          : base + '/?token=' + encodeURIComponent(token) + (refresh ? '&refresh_token=' + encodeURIComponent(refresh) : '');
         window.location.replace(url);
       }
     })();

--- a/core/marketplace/src/lib/config.ts
+++ b/core/marketplace/src/lib/config.ts
@@ -235,5 +235,46 @@ export const consoleHref = (
   return `${base}${suffix}${qs}`;
 };
 
+/**
+ * #4182 + #4186 — build the SECURE session-handoff URL the marketplace
+ * redirects to after checkout / from the Header "Portal" link.
+ *
+ * The previous shape `console.<slug>.<sov>/jobs?token=<JWT>&refresh_token=<uuid>`
+ * leaked a live bearer + refresh token via browser history, proxy/CDN access
+ * logs, and the Referer header (#4182), AND never established a session cookie,
+ * so `/jobs` bounced to `/login` (#4186).
+ *
+ * For a per-Org Sovereign console (`console.<slug>.<sov-fqdn>`) this returns
+ * `console.<slug>.<sov-fqdn>/auth/org-handover?token=<sessionJWT>` — the
+ * server-side catalyst-api validates the token, mints an HttpOnly
+ * `catalyst_session` cookie, and 302s to a clean `/jobs`. The refresh token is
+ * NEVER placed in the URL (it stays in client storage via `setAuthTokens`).
+ *
+ * For the mothership `/nova` console (no per-Org host) the legacy
+ * `/jobs?token=&refresh_token=` shape is preserved — that console redeems the
+ * token in its own SSR path and is out of scope for #4182.
+ *
+ * Pass `opts.slug` to override the active-org-slug read from localStorage.
+ */
+export const consoleHandoffHref = (
+  token: string,
+  refreshToken?: string | null,
+  opts?: { slug?: string | null },
+): string => {
+  const base = opts && opts.slug !== undefined
+    ? deriveConsoleURL(opts.slug)
+    : CONSOLE_URL;
+  // The mothership console URL carries the /nova path prefix; everything
+  // else is a per-Org (or operator) Sovereign console served by catalyst-api,
+  // which exposes the secure /auth/org-handover endpoint.
+  const isMothership = base.includes('/nova');
+  if (isMothership) {
+    const params: Record<string, string> = { token };
+    if (refreshToken) params.refresh_token = refreshToken;
+    return `${base}/jobs?${new URLSearchParams(params).toString()}`;
+  }
+  return `${base}/auth/org-handover?token=${encodeURIComponent(token)}`;
+};
+
 /** Prepend base to an internal marketplace route (strip leading '/'). */
 export const path = (p: string): string => `${BASE}${p.replace(/^\//, '')}`;

--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -82,7 +82,13 @@ func main() {
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP)
-	r.Use(middleware.Logger)
+	// #4182: use the path-only formatter, NOT chi's default middleware.Logger.
+	// The default emits r.RequestURI verbatim, which leaks every credential
+	// carried in a query string to stdout/access logs — the /auth/handover +
+	// /auth/org-handover `?token=<jwt>` handoff tokens and the chroot SPA's
+	// `?access_token=<jwt>` EventSource tokens. pathOnlyLogFormatter logs the
+	// path only (never the query). Credential hygiene per CLAUDE.md §10.
+	r.Use(middleware.RequestLogger(pathOnlyLogFormatter{}))
 	r.Use(middleware.Recoverer)
 	r.Use(cors.Handler(cors.Options{
 		AllowedOrigins: []string{corsOrigin},

--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -1028,6 +1028,22 @@ func main() {
 	// subsequent /sovereign/api/v1/* call inside the RequireSession group.
 	r.Get("/auth/handover", h.AuthHandover)
 
+	// Secure marketplace→console session handoff (issue #4182 + #4186).
+	// The marketplace post-checkout redirect lands the browser here with
+	// the Org member-session token (HS256, signed with the Org mesh's
+	// sme-secrets/JWT_SECRET). AuthOrgHandover validates it against
+	// CATALYST_ORG_JWT_SECRET, resolves the Org from the request host,
+	// mints an RS256 Org-scoped catalyst_session, sets the HttpOnly Secure
+	// SameSite=Lax cookie, stamps Referrer-Policy: no-referrer, and 302s to
+	// a clean /jobs. Like AuthHandover above, the token IS the auth (no
+	// catalyst_session cookie exists yet — this handler MINTS one), so the
+	// route MUST live OUTSIDE the RequireSession group below; inside it
+	// every handoff would 401 {"error":"unauthenticated"} before the
+	// handler ever ran. This replaces the old token-in-URL handoff that
+	// leaked the bearer+refresh via history/logs/Referer (#4182) and never
+	// established a cookie, bouncing /jobs→/login (#4186).
+	r.Get("/auth/org-handover", h.AuthOrgHandover)
+
 	// In-cluster Self-Sovereignty Cutover trigger (issue #935 Bug 2).
 	// The bp-self-sovereign-cutover chart's auto-trigger Helm
 	// post-install Job (templates/10-auto-trigger-job.yaml, added in

--- a/products/catalyst/bootstrap/api/internal/handler/org_handover.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_handover.go
@@ -1,0 +1,215 @@
+// org_handover.go — GET /auth/org-handover?token=<member-session-jwt>
+//
+// The SECURE marketplace→console session handoff (issue #4182 + #4186).
+//
+// THE BUG this file closes (live on omantel.biz dep 4635277cae4ffed9,
+// 2026-06-22/23):
+//
+//   - The marketplace post-checkout redirect went straight to
+//     `https://console.<slug>.<pool>/jobs?token=<JWT>&refresh_token=<uuid>`.
+//     The bearer + refresh sat in the URL query → leaked via browser
+//     history, proxy/CDN access logs, and the Referer header on every
+//     subsequent asset/XHR (#4182).
+//   - Worse, NOTHING redeemed that token into a session cookie. The
+//     `/jobs` landing is the catalyst-ui Sovereign-console SPA, which
+//     authenticates with the HttpOnly RS256 `catalyst_session` cookie via
+//     /api/v1/whoami. With no cookie set, whoami 401'd and the SPA bounced
+//     /jobs → /login (#4186).
+//
+// Why the existing /auth/handover (auth_handover.go) could NOT be reused:
+// that endpoint validates an RS256 sovereign-admin handover JWT minted by
+// the mothership. The marketplace member session is an HS256 token signed
+// with the Organization mesh's `sme-secrets/JWT_SECRET` (the same secret
+// catalyst-api already mints bridge tokens with — h.orgJWTSecret). The two
+// are different signers and different identities (sovereign-admin vs Org
+// member). auth.ValidateToken even hard-rejects any non-RS256 alg, so a
+// member token can never be a valid catalyst_session on its own.
+//
+// THE FIX (root cause, permanent): this handler accepts the member token,
+// validates it against h.orgJWTSecret, resolves the Org scope from the
+// REQUEST HOST (the trust anchor — the Cilium Gateway routes the Org
+// console host here and sets X-Forwarded-Host, which a browser on the Org
+// console can never forge), then mints an RS256 Org-scoped catalyst_session
+// — byte-for-byte the same shape HandlePinVerify mints for a customer who
+// PIN-logs-in on their Org console (auth.go #4110 Org-scoping). It sets the
+// HttpOnly Secure SameSite=Lax cookie scoped to the request host, stamps
+// `Referrer-Policy: no-referrer` so the (now token-free) URL never leaks,
+// and 302s to a clean /jobs.
+//
+// Result: the marketplace redirects to /auth/org-handover?token=<member>
+// (NO refresh_token in the URL — it stays in client storage via
+// setAuthTokens), the browser lands signed-in on a clean /jobs, the cookie
+// is established, and no credential is ever in the address bar after the
+// hop. The single remaining `?token=` is burned into a cookie immediately
+// and the redirect lands on a clean path; future hardening can swap it for
+// a one-time code without a contract change (the marketplace only knows the
+// /auth/org-handover URL).
+package handler
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+)
+
+// orgHandoverClaims is the subset of the marketplace member-session token
+// (HS256, signed with sme-secrets/JWT_SECRET) this handler relies on. The
+// marketplace `auth` service stamps {sub, email, role:member, typ:session,
+// iat, exp}; we only need sub/email + standard registered claims.
+type orgHandoverClaims struct {
+	jwt.RegisteredClaims
+	Email string `json:"email"`
+	Role  string `json:"role"`
+	Typ   string `json:"typ"`
+}
+
+// AuthOrgHandover handles GET /auth/org-handover?token=<member-jwt>.
+//
+// It MUST live OUTSIDE the RequireSession middleware group (the token IS
+// the auth — there is no catalyst_session cookie yet; this handler MINTS
+// one), exactly like AuthHandover.
+func (h *Handler) AuthOrgHandover(w http.ResponseWriter, r *http.Request) {
+	// Never leak the (token-bearing) URL to downstream assets, history-
+	// scraping extensions, or third-party Referer sinks. Stamped before any
+	// early return so even the error paths are no-referrer.
+	w.Header().Set("Referrer-Policy", "no-referrer")
+
+	raw := strings.TrimSpace(r.URL.Query().Get("token"))
+	if raw == "" {
+		// A bare visit by an already-signed-in browser is benign — bounce
+		// to the dashboard rather than an error. Otherwise send the SPA
+		// (it will probe whoami and redirect to /login if truly signed-out).
+		if h.hasValidCatalystSession(r) {
+			http.Redirect(w, r, "/jobs", http.StatusFound)
+			return
+		}
+		writeAuthError(w, "missing token parameter")
+		return
+	}
+
+	// ── 1. The Org JWT secret must be wired ─────────────────────────────
+	// CATALYST_ORG_JWT_SECRET is fed from the reflector-mirrored
+	// sme-secrets/JWT_SECRET (SetOrgJWTSecret in main.go). Without it this
+	// catalyst-api cannot validate a member token — surface a terse 401
+	// (no secret material in the body, per INVIOLABLE-PRINCIPLES #10).
+	if len(h.orgJWTSecret) == 0 {
+		h.log.Error("auth_org_handover: CATALYST_ORG_JWT_SECRET unset — cannot validate member token")
+		writeAuthError(w, "server misconfiguration: org session secret unavailable")
+		return
+	}
+
+	// ── 2. Resolve Org scope from the REQUEST HOST (trust anchor) ───────
+	// The session minted here is ALWAYS Org-scoped (tier=org-admin) and is
+	// bound to the Org whose console host the browser walked through. A
+	// handoff that lands on the Sovereign's own front door
+	// (console.<sov-fqdn>) — or any host the tenant registry does not know
+	// as an Org console — is REFUSED: we never mint an Org session on a
+	// non-Org host, and we never escalate a member token to a
+	// sovereign-admin session.
+	scope, ok := h.resolveOrgScope(r)
+	if !ok {
+		h.log.Warn("auth_org_handover: refused — request host is not a registered Org console",
+			"host", requestHost(r))
+		writeAuthError(w, "invalid audience: not an org console host")
+		return
+	}
+
+	// ── 3. Validate the member token (HS256, sme-secrets/JWT_SECRET) ────
+	var claims orgHandoverClaims
+	tok, perr := jwt.ParseWithClaims(raw, &claims,
+		func(t *jwt.Token) (any, error) {
+			if _, methodOK := t.Method.(*jwt.SigningMethodHMAC); !methodOK {
+				return nil, jwt.ErrTokenSignatureInvalid
+			}
+			return h.orgJWTSecret, nil
+		},
+		jwt.WithValidMethods([]string{"HS256"}),
+		jwt.WithExpirationRequired(),
+	)
+	if perr != nil || tok == nil || !tok.Valid {
+		h.log.Warn("auth_org_handover: member token invalid", "err", perr)
+		writeAuthError(w, "invalid token")
+		return
+	}
+
+	email := strings.TrimSpace(claims.Email)
+	if email == "" {
+		// Some marketplace tokens carry the email only in `sub`. Fall back
+		// to the subject when it looks like an address.
+		if sub := strings.TrimSpace(claims.Subject); strings.Contains(sub, "@") {
+			email = sub
+		}
+	}
+	if email == "" {
+		writeAuthError(w, "missing email claim")
+		return
+	}
+
+	// ── 4. Mint an RS256 Org-scoped catalyst_session ────────────────────
+	// Byte-for-byte the shape HandlePinVerify mints for an Org-scoped PIN
+	// session (auth.go #4110): tier=org-admin, realm_access.roles=[org-admin],
+	// the org slug in BOTH wire tags (org + org_id), typ=session. The
+	// OrgScopeGuard middleware then confines this session to its own Org's
+	// surfaces (deny-by-default outside the Org-safe allowlist).
+	if h.handoverSigner == nil {
+		h.log.Error("auth_org_handover: handover signer unavailable (CATALYST_HANDOVER_SIGNER_PATH not set)")
+		writeAuthError(w, "server misconfiguration: session signer unavailable")
+		return
+	}
+	now := time.Now()
+	sessionClaims := jwt.MapClaims{
+		"iss":            pinIssuer,
+		"sub":            email,
+		"email":          email,
+		"email_verified": true,
+		"role":           pinSessionRole,
+		"tier":           orgScopedTier,
+		"realm_access": map[string]any{
+			"roles": []string{orgScopedRealmRole},
+		},
+		"iat":    now.Unix(),
+		"exp":    now.Add(pinSessionTTL).Unix(),
+		"jti":    uuid.NewString(),
+		"typ":    "session",
+		"org":    scope.Org,
+		"org_id": scope.Org,
+	}
+	accessToken, serr := h.handoverSigner.SignCustomClaims(sessionClaims)
+	if serr != nil {
+		h.log.Error("auth_org_handover: SignCustomClaims failed", "err", serr)
+		writeAuthError(w, "internal error")
+		return
+	}
+
+	// ── 5. Set the cookie + redirect to a clean /jobs ───────────────────
+	cookieMaxAge := int(pinSessionTTL.Seconds())
+	secure := r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https"
+	// Derive the Domain from the REQUEST HOST (#4101) so the cookie is
+	// accepted by the Org pool-domain console (console.<slug>.<pool>) and
+	// covers console./api. of the same Org family — never the unrelated
+	// Sovereign zone (which the browser would reject for this host).
+	cookieDomain := sessionCookieDomain(r)
+
+	// Drop any stale Set-Cookie an upstream middleware may have appended so
+	// the freshly minted JWT is the ONLY catalyst_session the browser sees
+	// (same defence as HandlePinVerify, TBD-F7/#1730).
+	w.Header().Del("Set-Cookie")
+	http.SetCookie(w, &http.Cookie{
+		Name:     "catalyst_session",
+		Value:    accessToken,
+		Path:     "/",
+		Domain:   cookieDomain,
+		MaxAge:   cookieMaxAge,
+		HttpOnly: true,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+	})
+
+	h.log.Info("auth_org_handover: org session established",
+		"email", email, "org", scope.Org, "host", scope.Host)
+
+	http.Redirect(w, r, "/jobs", http.StatusFound)
+}

--- a/products/catalyst/bootstrap/api/internal/handler/org_handover_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_handover_test.go
@@ -1,0 +1,231 @@
+package handler
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handoverjwt"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+// orgHandoverTestSetup wires a Handler for AuthOrgHandover tests: a real
+// RS256 handover signer (mints the catalyst_session), the org HS256 secret
+// (validates the member token), and a tenant registry with one Org console
+// host so resolveOrgScope succeeds.
+func orgHandoverTestSetup(t *testing.T) (*Handler, []byte) {
+	t.Helper()
+	dir := t.TempDir()
+
+	privPEM, _, err := handoverjwt.GenerateKeypair()
+	if err != nil {
+		t.Fatalf("GenerateKeypair: %v", err)
+	}
+	signer, err := handoverjwt.New(privPEM, "https://console.openova.io", 8*time.Hour)
+	if err != nil {
+		t.Fatalf("handoverjwt.New: %v", err)
+	}
+
+	reg, err := store.NewTenantRegistry(dir)
+	if err != nil {
+		t.Fatalf("new registry: %v", err)
+	}
+	if err := reg.Put(store.TenantRegistration{
+		Host:       "console.demo.omani.homes",
+		TenantID:   "7283eb4a",
+		TenantKind: store.TenantKindOrg,
+	}); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	orgSecret := []byte("test-org-jwt-secret-aaaaaaaaaaaaaaaaaaaa")
+	h := &Handler{
+		log:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		handoverSigner: signer,
+		orgJWTSecret:   orgSecret,
+		tenantRegistry: reg,
+	}
+	return h, orgSecret
+}
+
+// mintMemberToken signs an HS256 member-session token shaped like the one the
+// marketplace `auth` service emits.
+func mintMemberToken(t *testing.T, secret []byte, email string, exp time.Time) string {
+	t.Helper()
+	claims := jwt.MapClaims{
+		"sub":   "fb6e3ed7-0000-0000-0000-000000000001",
+		"email": email,
+		"role":  "member",
+		"typ":   "session",
+		"iat":   time.Now().Unix(),
+		"exp":   exp.Unix(),
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := tok.SignedString(secret)
+	if err != nil {
+		t.Fatalf("sign member token: %v", err)
+	}
+	return signed
+}
+
+func orgHandoverRequest(token string) *http.Request {
+	url := "/auth/org-handover"
+	if token != "" {
+		url += "?token=" + token
+	}
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	req.Header.Set("X-Forwarded-Host", "console.demo.omani.homes")
+	req.Header.Set("X-Forwarded-Proto", "https")
+	return req
+}
+
+// TestAuthOrgHandover_HappyPath is the core #4182/#4186 assertion: a valid
+// member token on an Org console host mints an Org-scoped catalyst_session
+// cookie and 302s to a CLEAN /jobs (NO token in the Location), and the
+// Referrer-Policy header is set.
+func TestAuthOrgHandover_HappyPath(t *testing.T) {
+	h, secret := orgHandoverTestSetup(t)
+	token := mintMemberToken(t, secret, "demo@openova.io", time.Now().Add(15*time.Minute))
+
+	rec := httptest.NewRecorder()
+	h.AuthOrgHandover(rec, orgHandoverRequest(token))
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302; body=%s", rec.Code, rec.Body.String())
+	}
+	loc := rec.Header().Get("Location")
+	if loc != "/jobs" {
+		t.Fatalf("Location = %q, want clean /jobs (no token)", loc)
+	}
+	if strings.Contains(loc, "token") || strings.Contains(loc, "refresh") {
+		t.Fatalf("Location leaks a credential: %q", loc)
+	}
+	if rp := rec.Header().Get("Referrer-Policy"); rp != "no-referrer" {
+		t.Fatalf("Referrer-Policy = %q, want no-referrer", rp)
+	}
+
+	// Cookie set, HttpOnly + Secure + Lax, carrying an RS256 Org-scoped JWT.
+	var sess *http.Cookie
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "catalyst_session" {
+			sess = c
+		}
+	}
+	if sess == nil {
+		t.Fatal("catalyst_session cookie not set")
+	}
+	if !sess.HttpOnly {
+		t.Error("catalyst_session must be HttpOnly")
+	}
+	if !sess.Secure {
+		t.Error("catalyst_session must be Secure")
+	}
+	if sess.SameSite != http.SameSiteLaxMode {
+		t.Errorf("catalyst_session SameSite = %v, want Lax", sess.SameSite)
+	}
+	if sess.Value == "" || len(strings.Split(sess.Value, ".")) != 3 {
+		t.Fatalf("catalyst_session is not a JWT: %q", sess.Value)
+	}
+
+	// The minted session must be Org-scoped (tier=org-admin, org=demo) so the
+	// OrgScopeGuard confines it — never sovereign-admin.
+	pub, err := h.handoverSigner.PublicRSAKey()
+	if err != nil {
+		t.Fatalf("PublicRSAKey: %v", err)
+	}
+	var claims jwt.MapClaims
+	if _, err := jwt.ParseWithClaims(sess.Value, &claims, func(*jwt.Token) (any, error) {
+		return pub, nil
+	}, jwt.WithValidMethods([]string{"RS256"})); err != nil {
+		t.Fatalf("parse minted session: %v", err)
+	}
+	if claims["tier"] != orgScopedTier {
+		t.Errorf("tier = %v, want %s", claims["tier"], orgScopedTier)
+	}
+	if claims["org"] != "demo" {
+		t.Errorf("org = %v, want demo", claims["org"])
+	}
+	if claims["email"] != "demo@openova.io" {
+		t.Errorf("email = %v, want demo@openova.io", claims["email"])
+	}
+}
+
+// TestAuthOrgHandover_RefusesNonOrgHost: a handoff that lands on the
+// Sovereign's own front door (or any non-Org host) must be refused — never
+// escalate a member token to a session on a non-Org host.
+func TestAuthOrgHandover_RefusesNonOrgHost(t *testing.T) {
+	h, secret := orgHandoverTestSetup(t)
+	token := mintMemberToken(t, secret, "demo@openova.io", time.Now().Add(15*time.Minute))
+
+	req := orgHandoverRequest(token)
+	req.Header.Set("X-Forwarded-Host", "console.omantel.biz") // not in registry
+
+	rec := httptest.NewRecorder()
+	h.AuthOrgHandover(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 on non-Org host", rec.Code)
+	}
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "catalyst_session" && c.Value != "" {
+			t.Fatal("must NOT mint a session on a non-Org host")
+		}
+	}
+}
+
+// TestAuthOrgHandover_RejectsBadToken: a token signed with the wrong secret
+// (or an RS256 token) is rejected.
+func TestAuthOrgHandover_RejectsBadToken(t *testing.T) {
+	h, _ := orgHandoverTestSetup(t)
+	bad := mintMemberToken(t, []byte("WRONG-secret-bbbbbbbbbbbbbbbbbbbbbbbbbbbb"), "demo@openova.io", time.Now().Add(15*time.Minute))
+
+	rec := httptest.NewRecorder()
+	h.AuthOrgHandover(rec, orgHandoverRequest(bad))
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 on bad-signature token", rec.Code)
+	}
+}
+
+// TestAuthOrgHandover_RejectsExpiredToken.
+func TestAuthOrgHandover_RejectsExpiredToken(t *testing.T) {
+	h, secret := orgHandoverTestSetup(t)
+	expired := mintMemberToken(t, secret, "demo@openova.io", time.Now().Add(-1*time.Minute))
+
+	rec := httptest.NewRecorder()
+	h.AuthOrgHandover(rec, orgHandoverRequest(expired))
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 on expired token", rec.Code)
+	}
+}
+
+// TestAuthOrgHandover_MissingToken returns 401 (no session).
+func TestAuthOrgHandover_MissingToken(t *testing.T) {
+	h, _ := orgHandoverTestSetup(t)
+	rec := httptest.NewRecorder()
+	h.AuthOrgHandover(rec, orgHandoverRequest(""))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 on missing token", rec.Code)
+	}
+}
+
+// TestAuthOrgHandover_NoOrgSecret returns 401 when CATALYST_ORG_JWT_SECRET is
+// unwired (cannot validate any member token).
+func TestAuthOrgHandover_NoOrgSecret(t *testing.T) {
+	h, secret := orgHandoverTestSetup(t)
+	h.orgJWTSecret = nil
+	token := mintMemberToken(t, secret, "demo@openova.io", time.Now().Add(15*time.Minute))
+
+	rec := httptest.NewRecorder()
+	h.AuthOrgHandover(rec, orgHandoverRequest(token))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 when org secret unwired", rec.Code)
+	}
+}


### PR DESCRIPTION
## What

Fixes the broken marketplace→console session handoff that (a) leaked a live bearer + refresh token in the URL query (**#4182**) and (b) never established a session cookie, so a signed-in customer's `/jobs` bounced to `/login` (**#4186**). Same root cause, fixed together.

## Root cause (verified live on omantel.biz dep `4635277cae4ffed9`)

- Marketplace redirected to `console.<slug>.<pool>/jobs?token=<HS256-member-JWT>&refresh_token=<uuid>`.
- The member session is **HS256** (org-mesh `sme-secrets/JWT_SECRET`); the Sovereign console (`/jobs`, catalyst-ui SPA) authenticates via the **RS256** `catalyst_session` cookie validated by catalyst-api. Two separate identity systems — `auth.ValidateToken` even hard-rejects non-RS256. The existing RS256 sovereign-admin `/auth/handover` could not accept a member token.
- Nothing redeemed the URL token into a cookie → `/api/v1/whoami` 401 → SPA treats user signed-out → `/jobs` → `/login`. Confirmed on both `console.demo.omani.homes` and a fresh pool Org.

## Fix (permanent, root cause)

1. **catalyst-api — new `GET /auth/org-handover`** (`org_handover.go`): validates the member token against `CATALYST_ORG_JWT_SECRET` (already wired on the pod), resolves the Org from the **request host** (must be a registered Org console — never escalates to sovereign-admin, never mints on the Sovereign front door), mints an **RS256 Org-scoped `catalyst_session`** (mirrors the #4110 PIN Org-scoped path), sets the cookie `HttpOnly; Secure; SameSite=Lax` scoped to the request host, stamps `Referrer-Policy: no-referrer`, and **302s to a clean `/jobs`**. Registered outside `RequireSession` (the token IS the auth).
2. **marketplace UI** (`config.ts` `consoleHandoffHref`, `Layout.astro`, `CheckoutStep.svelte` ×2, `Header.svelte`): redirect to `/auth/org-handover?token=<session>` for every per-Org Sovereign console. **`refresh_token` is dropped from the URL entirely** (stays in client storage via `setAuthTokens`). Mothership `/nova` keeps the legacy shape.
3. **org-controller `reconcileTenantRoute`**: now renders the **console route shape** (catalyst-ui SPA + catalyst-api, incl. `/auth/handover` + `/auth/org-handover` + `/api/`) in `catalyst-system`, **independent of `tenantPublic.backendService`**. This is the #4186 routing gap — the old product-route model gated the console route on a backend the console host never uses, so it never auto-rendered and had to be hand-applied per-Org (`managed-by: issue-4075-live-unblock`).

## Tests

- `org_handover_test.go`: happy path (no token in `Location`, `HttpOnly`/`Secure`/`Lax` cookie, Org-scoped claims), non-Org-host refused, bad/expired/missing token, no-secret.
- Updated tenant-route tests to the 5-rule console shape; assert `/auth/org-handover` → catalyst-api and the route renders while `backendService` is pending.

## Rollout

Rolling live on omantel.biz (rebuild marketplace + catalyst-api/ui, reconcile). Browser-evidence DoD (screenshots: clean URL bar, cookie flags, signed-in `/jobs` on both a pool Org and `console.demo.omani.homes`, server access-log clean) attached to #4182/#4186.

Refs #4182 #4186

🤖 Generated with [Claude Code](https://claude.com/claude-code)