### PR TITLE
fix(org-provisioning): reap stale duplicate vc-<subdomain>@0.19.x vcluster + idempotency guard (Refs #4188)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
@@ -359,18 +359,14 @@ spec:
   url: oci://ghcr.io/openova-io
   secretRef:
     name: ghcr-pull
----
-# vCluster (loft) — a non-OCI Helm repo for the vcluster chart
-# referenced by the per-tenant vcluster.yaml overlay.
-apiVersion: source.toolkit.fluxcd.io/v1beta2
-kind: HelmRepository
-metadata:
-  name: loft
-  namespace: flux-system
-spec:
-  interval: 15m
-  url: https://charts.loft.sh
 `
+// NOTE — the `loft` (https://charts.loft.sh) HelmRepository was removed
+// from this shared set in #4188 along with the legacy vc-<subdomain>
+// overlay. The per-Org vCluster (chart vcluster@0.33.x) is owned by the
+// CRD org-controller, which sources from its own `loft`/vcluster-system
+// HelmRepository (Harbor-mirrored). The org-tenant overlay no longer
+// pulls any chart from loft, so this entry was dead weight + the only
+// place this path referenced the upstream rancher/k3s distro.
 
 // DeleteTenantOverlay implements OrganizationGitOpsWriter. Removes the
 // per-tenant overlay directory. Idempotent — a missing path commits
@@ -454,7 +450,12 @@ func (w DefaultOrganizationGitOpsWriter) DeleteTenantOverlay(ctx context.Context
 type orgTenantTemplateData struct {
 	TenantID     string
 	Subdomain    string
-	Namespace    string
+	Namespace string
+	// VClusterName — retained for the store record + back-compat, but as
+	// of #4188 NO overlay template renders it. The per-Org vCluster is
+	// owned by the CRD org-controller (chart vcluster@0.33.x, ns
+	// <subdomain>); this path stopped emitting the legacy
+	// vc-<subdomain>@0.19.x duplicate. Do NOT wire a new template to it.
 	VClusterName string
 	OTECHFQDN    string
 	// ParentDomain — the chosen org-pool parent (multi-domain
@@ -660,10 +661,28 @@ func withVersionDefaults(v OrganizationChartVersions) OrganizationChartVersions 
 // new chart = a new entry here. Each template renders a single YAML
 // document; kustomization.yaml lists all of them so Flux materialises
 // them in topological order.
+// NOTE — the per-Org vCluster is intentionally NOT rendered here. The
+// canonical per-Organization vCluster backing is owned by the CRD
+// org-controller (core/controllers/organization/internal/gitops/
+// manifests.go → HelmRelease `vcluster`, chart vcluster@0.33.x, loft
+// vcluster-oss distro, Harbor-mirrored images, ns `<subdomain>`). The
+// legacy bootstrap-api path used to emit a SECOND vcluster HelmRelease
+// (`vc-<subdomain>`, chart 0.19.x, raw `rancher/k3s` image) into the
+// org-tenant overlay namespace. Nothing in the overlay consumed it (the
+// per-Org app HelmReleases install directly into the host org-tenant
+// namespace — none set kubeConfig/dependsOn against it), yet `rancher/
+// k3s` is not Harbor-mirrored so its Pod sat in Init:ImagePullBackOff
+// forever, the `vc-<subdomain>` HelmRelease stayed False on the spine,
+// and it was a fake-green trap for verifiers reading it as THE backing.
+//
+// Dropping the entry here is the idempotency fix (#4188): because the
+// org-tenants Flux Kustomization runs with prune=true, removing the
+// resource from the rendered overlay garbage-collects the stale
+// `vc-<subdomain>` HelmRelease on the next reconcile, AND a re-render of
+// any existing Org never re-creates the duplicate. Refs #4188.
 var orgTenantTemplates = map[string]string{
 	"kustomization.yaml":       orgTenantKustomization,
 	"namespace.yaml":           orgTenantNamespace,
-	"vcluster.yaml":            orgTenantVCluster,
 	"bp-keycloak.yaml":         orgTenantBPKeycloak,
 	"bp-cnpg.yaml":             orgTenantBPCNPG,
 	"bp-newapi.yaml":           orgTenantBPNewAPI,
@@ -683,8 +702,13 @@ const orgTenantKustomization = `# Generated at {{.GeneratedAt}} by catalyst-api/
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  # The per-Org vCluster is owned by the CRD org-controller (chart
+  # vcluster@0.33.x, ns <subdomain>), NOT this overlay. The legacy
+  # vc-<subdomain> (0.19.x / rancher-k3s) HelmRelease was removed in
+  # #4188 — leaving it here re-created a stale ImagePullBackOff duplicate
+  # on every render. prune=true on the org-tenants Kustomization reaps
+  # the old one.
   - namespace.yaml
-  - vcluster.yaml
   - bp-keycloak.yaml
   - bp-cnpg.yaml
   - bp-newapi.yaml
@@ -734,39 +758,16 @@ metadata:
     catalyst.openova.io/domain-mode: {{.DomainMode}}
 `
 
-const orgTenantVCluster = `# vCluster HelmRelease — the Organization's logical cluster lives here.
-# Per Inviolable Principle 7 (K8s-native tenancy) every Organization gets its
-# own vcluster control plane; the bp-* charts below install INTO that
-# vcluster via the vcluster syncer.
-apiVersion: helm.toolkit.fluxcd.io/v2
-kind: HelmRelease
-metadata:
-  name: {{.VClusterName}}
-  namespace: {{.Namespace}}
-spec:
-  interval: 10m
-  chart:
-    spec:
-      chart: vcluster
-      version: "0.19.x"
-      sourceRef:
-        kind: HelmRepository
-        name: loft
-        namespace: flux-system
-  values:
-    vcluster:
-      image: rancher/k3s:v1.29.1-k3s2
-    syncer:
-      extraArgs:
-        - --name={{.VClusterName}}
-        - --tls-san={{.ConsoleHost}}
-    storage:
-      persistence: true
-      size: 5Gi
-    sync:
-      ingresses:
-        enabled: true
-`
+// orgTenantVCluster was removed in #4188. The canonical per-Organization
+// vCluster backing is the CRD org-controller's `vcluster` HelmRelease
+// (chart vcluster@0.33.x, loft vcluster-oss distro, Harbor-mirrored
+// images, ns `<subdomain>`) — see core/controllers/organization/internal/
+// gitops/manifests.go. The legacy template here rendered a SECOND,
+// orphaned vCluster (`vc-<subdomain>`, chart 0.19.x, raw rancher/k3s
+// image) that nothing in the overlay consumed and that could never pull
+// its image on a Harbor-only Sovereign → permanent Init:ImagePullBackOff
+// + a False HelmRelease on the spine. Do NOT re-introduce it: a per-Org
+// vCluster belongs to the CRD org-controller, full stop.
 
 const orgTenantBPKeycloak = `# bp-keycloak per-tenant (issue #800/#803/#804/#910) — the Organization's
 # own Keycloak instance. Each tenant runs its own Keycloak Pod +

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
@@ -437,7 +437,8 @@ func TestRenderOrganizationOverlay_FreeSubdomain_AllChartsPresent(t *testing.T) 
 	for _, name := range []string{
 		"kustomization.yaml",
 		"namespace.yaml",
-		"vcluster.yaml",
+		// vcluster.yaml deliberately absent (#4188): the per-Org vCluster
+		// is owned by the CRD org-controller, not this overlay.
 		"bp-keycloak.yaml",
 		"bp-cnpg.yaml",
 		"bp-newapi.yaml",
@@ -458,6 +459,94 @@ func TestRenderOrganizationOverlay_FreeSubdomain_AllChartsPresent(t *testing.T) 
 	// Free-subdomain mode must NOT emit a Certificate.
 	if strings.Contains(files["certificate.yaml"], "kind: Certificate") {
 		t.Errorf("free-subdomain should not emit a Certificate; got: %s", files["certificate.yaml"])
+	}
+}
+
+// TestRenderOrganizationOverlay_NoVClusterDuplicate is the #4188
+// idempotency guard. The bootstrap-api org-tenant overlay used to render
+// a SECOND, orphaned vCluster HelmRelease (`vc-<subdomain>`, chart
+// vcluster@0.19.x, raw `rancher/k3s` image) alongside the canonical
+// per-Org vCluster the CRD org-controller owns (chart vcluster@0.33.x,
+// ns `<subdomain>`). On a Harbor-only Sovereign the rancher/k3s image
+// could never pull, so the duplicate sat in Init:ImagePullBackOff for
+// good and its HelmRelease stayed False on the spine — a fake-green trap.
+//
+// This test pins the overlay to NEVER emit a vCluster: no vcluster.yaml
+// file, no `vc-<subdomain>` HelmRelease in any rendered doc, no
+// `rancher/k3s` image, no `chart: vcluster` reference, and no `loft`
+// HelmRepository sourceRef. A re-render of any existing Org therefore
+// can't leave a stale-version vCluster duplicate behind (prune=true on
+// the org-tenants Kustomization then reaps any pre-existing one). Refs
+// #4188.
+func TestRenderOrganizationOverlay_NoVClusterDuplicate(t *testing.T) {
+	rec := store.OrganizationProvisionRecord{
+		OrganizationID:  "t-acme",
+		Subdomain:       "acme",
+		DomainMode:      store.OrganizationDomainFreeSubdomain,
+		AdminEmail:      "admin@acme.test",
+		CompanyName:     "Acme Corp",
+		OTECHFQDN:       "otech.example",
+		VClusterName:    "vc-acme",
+		TenantNamespace: "org-t-acme",
+	}
+	files, err := renderOrganizationOverlay(rec, OrganizationChartVersions{})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+
+	// 1. No standalone vcluster overlay file.
+	if body, ok := files["vcluster.yaml"]; ok {
+		t.Errorf("#4188 regression: overlay emitted vcluster.yaml — the per-Org vCluster belongs to the CRD org-controller, not this path; got:\n%s", body)
+	}
+
+	// 2. No rendered doc may carry the legacy vc-<subdomain> HelmRelease,
+	//    the rancher/k3s distro, the bare `chart: vcluster` ref, or a loft
+	//    sourceRef — any of those reintroduces the duplicate.
+	banned := []string{
+		"vc-acme",            // the legacy vc-<subdomain> HelmRelease name
+		"rancher/k3s",        // the un-mirrorable distro image
+		"chart: vcluster",    // the upstream vcluster chart
+		"name: loft",         // the loft HelmRepository sourceRef
+		`version: "0.19`,     // the stale 0.19.x pin
+	}
+	for name, body := range files {
+		for _, b := range banned {
+			if strings.Contains(body, b) {
+				t.Errorf("#4188 regression: overlay file %s contains banned vCluster token %q — the duplicate vCluster is back:\n%s", name, b, body)
+			}
+		}
+	}
+
+	// 3. The kustomization resource list must not reference vcluster.yaml.
+	if strings.Contains(files["kustomization.yaml"], "vcluster.yaml") {
+		t.Errorf("#4188 regression: kustomization.yaml still lists vcluster.yaml:\n%s", files["kustomization.yaml"])
+	}
+
+	// 4. Re-rendering the SAME record is byte-identical and STILL carries
+	//    no vCluster — idempotency across repeated provision re-runs.
+	files2, err := renderOrganizationOverlay(rec, OrganizationChartVersions{})
+	if err != nil {
+		t.Fatalf("re-render: %v", err)
+	}
+	if _, ok := files2["vcluster.yaml"]; ok {
+		t.Errorf("#4188 regression: re-render re-introduced vcluster.yaml")
+	}
+	if files["kustomization.yaml"] != files2["kustomization.yaml"] {
+		t.Errorf("#4188: kustomization.yaml not idempotent across re-render")
+	}
+}
+
+// TestOrgTenantSharedHelmRepositories_NoLoft pins the shared
+// HelmRepository set to NOT reference the upstream loft chart repo. The
+// loft repo was the only source the legacy vc-<subdomain> overlay pulled
+// from; with the vCluster removed (#4188) it is dead weight and its
+// presence would imply the duplicate could come back.
+func TestOrgTenantSharedHelmRepositories_NoLoft(t *testing.T) {
+	if strings.Contains(orgTenantSharedHelmRepositories, "charts.loft.sh") {
+		t.Errorf("#4188 regression: shared HelmRepositories still reference charts.loft.sh:\n%s", orgTenantSharedHelmRepositories)
+	}
+	if strings.Contains(orgTenantSharedHelmRepositories, "name: loft") {
+		t.Errorf("#4188 regression: shared HelmRepositories still declare the loft HelmRepository:\n%s", orgTenantSharedHelmRepositories)
 	}
 }
 


### PR DESCRIPTION
## Problem (Refs #4188)

On the live demo Org (omantel.biz, dep `4635277cae4ffed9`) there were **two** vCluster backings:

1. **Canonical** — ns `demo`, HR `vcluster` Ready=True, chart `vcluster@0.33.4` (loft vcluster-oss, Harbor-mirrored), owned by the CRD **org-controller**. This is the real backing.
2. **Stale duplicate** — ns `org-7283eb4a-…`, HR `vc-demo` Ready=False, chart `vcluster@0.19.10`, image `rancher/k3s:v1.29.1-k3s2`, pod `vc-demo-0` `Init:ImagePullBackOff` (3500+ retries over 13h). `rancher/k3s` is NOT Harbor-mirrored so it can never pull.

The duplicate came from the **bootstrap-api org-tenant overlay** path, which still rendered a `vc-<subdomain>` HelmRelease (`vcluster.yaml`) on top of the org-controller's canonical vCluster. Nothing in the overlay consumed it (the per-Org app HelmReleases — keycloak/cnpg/wordpress-tenant/newapi/stalwart/openclaw — install directly into the host org-tenant namespace; none set `kubeConfig`/`dependsOn` against `vc-demo`). It was pure orphan noise + a fake-green spine entry.

## Root-cause fix (idempotency)

Drop the vCluster from the bootstrap-api org-tenant overlay entirely:
- removed `vcluster.yaml` from `orgTenantTemplates` + the kustomization `resources:` list
- deleted the `orgTenantVCluster` constant (the 0.19.x / rancher-k3s HR)
- removed the now-dead `loft` HelmRepository from the shared `orgTenantSharedHelmRepositories` set

The per-Org vCluster is owned by the CRD **org-controller** (`core/controllers/organization/internal/gitops/manifests.go` → HR `vcluster`, chart `vcluster@0.33.x`, ns `<subdomain>`), full stop. Because the `org-tenants` Flux Kustomization runs `prune=true`, removing the resource from the rendered overlay **garbage-collects** the stale `vc-<subdomain>` HelmRelease on the next reconcile, AND a re-render of any existing Org never re-creates the duplicate.

## Regression guards

- `TestRenderOrganizationOverlay_NoVClusterDuplicate` — the overlay must NOT emit a `vcluster.yaml`, a `vc-<subdomain>` HR, `rancher/k3s`, `chart: vcluster`, a `loft` sourceRef, or a `0.19.x` pin — across a repeated, byte-identical re-render (idempotency).
- `TestOrgTenantSharedHelmRepositories_NoLoft` — pins `charts.loft.sh` / the `loft` HelmRepository out of the shared set.

## Files

- `products/catalyst/bootstrap/api/internal/handler/organization_gitops.go`
- `products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go`

## Validation

- `go build ./...` clean, `go vet ./internal/handler/` clean.
- Full `go test ./internal/handler/` suite green (incl. the two new guards + the existing hot-standby / overlay render tests).
- Live reap of the stale `vc-demo` on omantel.biz performed out-of-band (HR + StatefulSet + pod + orphan PVC removed; the canonical `vcluster@0.33.4` in ns `demo` untouched and still 1/1 Running) — kubectl before/after captured in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)