### PR TITLE
fix(cnpg): cross-region replica streams SYNC from PRIMARY (RPO=0) + per-Org cnpg operator stops hijacking the cluster webhook

### DIFF
--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -194,7 +194,10 @@ spec:
       # region labels; CRD pattern relaxed in lockstep, catalyst chart).
       # 0.2.5 (#3740): cross-region replica pinned as the synchronous
       # standby (standbyNamesPre + maxStandbyNamesFromCluster:0) → RPO=0.
-      version: 0.2.5
+      # 0.2.6 (#3740): replication-source mesh Service flipped
+      # selectorType r→rw so the cross-region replica streams from the
+      # PRIMARY's walsender (not a cascaded local standby) → sync_state=sync.
+      version: 0.2.6
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg-pair

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-9-disaster-recovery
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.2.5
+  version: 0.2.6
   card:
     title: CNPG Cluster-Pair (Active-Hotstandby DR)
     summary: |

--- a/platform/cnpg-pair/chart/Chart.yaml
+++ b/platform/cnpg-pair/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-cnpg-pair
-version: 0.2.5
+version: 0.2.6
 appVersion: "0.2.1"
 description: |
   Catalyst-curated Blueprint for an active-hotstandby CNPG cluster-pair
@@ -40,6 +40,36 @@ description: |
 
   Changelog
   ─────────
+  0.2.6 (2026-06-24, cross-region replica streams from PRIMARY not a standby — RPO=0 completion, Refs #3740 / #3375)
+    - FIX (Pillar-3 zero-tx-loss, the missing half of the 0.2.5 fix): the
+      ClusterMesh replication-source Service (`-primary-mesh`, consumed by
+      the replica's externalCluster) now uses `selectorType: rw` (PRIMARY
+      only) instead of `selectorType: r` (ALL instances). 0.2.5 correctly
+      pinned `synchronous_standby_names = FIRST 1 ("<replicaName>")`, but
+      the `r` selector round-robins the cross-region replica's WAL receiver
+      across the primary AND its local HA standbys (cnpg.io/podRole=
+      instance). When it landed on a LOCAL STANDBY the replica CASCADED off
+      that standby — a cascaded standby can never be a synchronous standby
+      of the primary, so the replica appeared in pg_stat_replication only on
+      the STANDBY (sync_state=async, sender pg_is_in_recovery()=t) and NEVER
+      on the primary. `FIRST 1 ("<replicaName>")` then stayed permanently
+      unsatisfiable, and with dataDurability:required the primary BLOCKED
+      ALL WRITES. Caught LIVE on omantel.biz kom4dc (2026-06-23): replica
+      byte-caught-up, its walsender on primary-3 [a standby], and an INSERT
+      on the real primary (primary-2) hung. `rw` selects ONLY the current
+      primary (cnpg.io/instanceRole=primary, a single endpoint), so the
+      replica streams DIRECTLY from the primary's walsender → it appears in
+      the PRIMARY's pg_stat_replication → standbyNamesPre matches →
+      sync_state=sync → RPO=0. CNPG re-points the `-rw` selector at the
+      newly-promoted instance after a Continuum switchover, so the mesh
+      alias keeps tracking the live primary with no chart change.
+    - Render-gate test (chart/tests/cnpg-pair-render.sh) now asserts
+      `selectorType: rw` on the side=primary mesh Service (and that `r` is
+      NOT used there).
+    - Default-OFF contract UNCHANGED: cnpgPair.enabled=false renders ZERO
+      resources on BOTH sides. Resource COUNTS unchanged (one selectorType
+      value flipped r→rw).
+
   0.2.5 (2026-06-17, cross-region sync target — RPO=0 fix, Refs #3740 / #3375)
     - FIX (Pillar-3 zero-tx-loss): the primary Cluster CR's CNPG-native
       `spec.postgresql.synchronous` block now pins the CROSS-REGION

--- a/platform/cnpg-pair/chart/templates/primary-cluster.yaml
+++ b/platform/cnpg-pair/chart/templates/primary-cluster.yaml
@@ -172,11 +172,31 @@ spec:
   # annotation so Cilium ClusterMesh publishes it across every peer.
   # The replica's externalCluster connectionParameters.host points at
   # this Service name.
+  #
+  # 🛑 selectorType MUST be `rw`, NOT `r` (#3740, hw158 + omantel.biz
+  # kom4dc 2026-06-23). `r` selects EVERY instance in the primary
+  # cluster (primary + its local HA standbys: cnpg.io/podRole=instance),
+  # so the cross-region replica's WAL receiver round-robins onto a LOCAL
+  # STANDBY and CASCADES off it instead of streaming from the real
+  # primary's walsender. A cascaded standby can NEVER be a synchronous
+  # standby of the primary — so the replica shows up in pg_stat_replication
+  # on the STANDBY (sync_state=async, sender pg_is_in_recovery()=t) and
+  # NEVER on the primary, leaving `synchronous_standby_names =
+  # FIRST 1 ("<replica>")` permanently unsatisfiable. With
+  # dataDurability:required the primary then BLOCKS ALL WRITES (caught
+  # LIVE on kom4dc: replica byte-caught-up, walsender on primary-3 [a
+  # standby], primary-2 INSERT hangs). `rw` selects ONLY the current
+  # primary (cnpg.io/instanceRole=primary), so the replica streams
+  # directly from the primary's walsender → it appears in the primary's
+  # pg_stat_replication → standbyNamesPre matches → sync_state=sync →
+  # RPO=0. After a Continuum switchover CNPG re-points the `-rw`
+  # selector at the newly-promoted instance, so the mesh alias keeps
+  # tracking the live primary with no chart change.
   {{- if .Values.cnpgPair.clusterMesh.enabled }}
   managed:
     services:
       additional:
-        - selectorType: r
+        - selectorType: rw
           serviceTemplate:
             metadata:
               name: {{ include "cnpg-pair.replicationServiceName" . }}

--- a/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
+++ b/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
@@ -138,6 +138,21 @@ grep -q 'service.cilium.io/global: "true"' "$TMP/primary.yaml" || {
   echo "FAIL: primary Cluster CR missing managed.services.additional service.cilium.io/global=true annotation." >&2
   exit 1
 }
+# #3740 (the missing half of 0.2.5): the cross-region replication-source
+# Service MUST use selectorType: rw (PRIMARY only), NOT r (ALL instances).
+# With `r` the replica's WAL receiver round-robins onto a LOCAL STANDBY and
+# CASCADES off it; a cascaded standby can never be a synchronous standby of
+# the primary, so synchronous_standby_names stays unsatisfiable and
+# dataDurability:required BLOCKS WRITES (caught live on omantel.biz kom4dc).
+grep -qE '^\s+- selectorType: rw' "$TMP/primary.yaml" || {
+  echo "FAIL: primary Cluster CR managed.services.additional uses the wrong selectorType — must be 'rw' (primary-only) so the cross-region replica streams directly from the primary's walsender and sync engages (RPO=0). See #3740." >&2
+  grep -nE 'selectorType:' "$TMP/primary.yaml" >&2
+  exit 1
+}
+if grep -qE '^\s+- selectorType: r$' "$TMP/primary.yaml"; then
+  echo "FAIL: primary Cluster CR managed.services.additional uses selectorType: r (all instances) — the cross-region replica would cascade off a local standby and never be a synchronous standby of the primary. See #3740." >&2
+  exit 1
+fi
 grep -q "kind: ConfigMap" "$TMP/primary.yaml" || {
   echo "FAIL: audit-config ConfigMap not rendered on side=primary (bp-continuum prerequisite probe reads it there)." >&2
   exit 1

--- a/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
@@ -944,6 +944,33 @@ const orgTenantBPCNPG = `# bp-cnpg in the Organization tenant namespace — Post
 # Earlier orchestrator versions emitted ` + "`namespace`" + ` and ` + "`operator.enabled`" + `
 # at the top level — the chart silently ignored them. Fixed to the
 # canonical subchart-keyed shape.
+#
+# 🛑 NAMESPACE-SCOPED, WEBHOOK-LESS per-Org operator (#4143). The
+# cloudnative-pg "single operator per cluster" guidance: the
+# Mutating/ValidatingWebhookConfiguration objects it registers
+# (cnpg-mutating-webhook-configuration / cnpg-validating-webhook-
+# configuration) are CLUSTER-SCOPED SINGLETONS with FIXED names AND the
+# webhook serving Service name (cnpg-webhook-service) is hardcoded
+# upstream ("DO NOT CHANGE THE SERVICE NAME"). When a per-Org operator
+# also creates these, it and the platform cnpg-system operator both
+# reconcile the SAME singletons — whichever writes last repoints the
+# webhook clientConfig.service at ITS namespace's cnpg-webhook-service
+# with a caBundle the other operator's served cert does not match, so
+# admission fails "x509: certificate signed by unknown authority" and
+# every NEW Cluster CR (e.g. wordpress-db) is blocked. Live outage on
+# omantel.biz kom4dc (dep 4635277cae4ffed9): the singleton webhook ended
+# up owned by an Org-namespace release, breaking the platform operator.
+#
+# Fix: the per-Org operator runs WEBHOOK-LESS and NAMESPACE-SCOPED.
+#   - webhook.{mutating,validating}.create=false → it never touches the
+#     cluster-singleton webhook configs; the single platform cnpg-system
+#     operator owns them and admits Cluster CRs in EVERY namespace
+#     (including this Org's) via its cluster-wide webhook.
+#   - config.clusterWide=false + WATCH_NAMESPACE pinned to this Org ns →
+#     the per-Org operator reconciles ONLY its own namespace and can
+#     never contend cluster-scoped resources owned by the platform
+#     operator. (The per-Org operator still manages this Org's own
+#     Cluster/Backup CRs; it just stops fighting over the singletons.)
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -971,6 +998,22 @@ spec:
         # the per-tenant install must NOT re-create them or apiserver
         # rejects the manifest with "already exists, owned by ...".
         create: false
+      # #4143: do NOT register the cluster-scoped webhook configs — they
+      # are singletons owned by the platform cnpg-system operator. A
+      # per-Org copy fights over them and breaks admission cluster-wide.
+      webhook:
+        mutating:
+          create: false
+        validating:
+          create: false
+      # #4143: namespace-scoped watch — the per-Org operator reconciles
+      # ONLY its own Org namespace, never cluster-scoped singletons. The
+      # platform cnpg-system operator stays cluster-wide and admits this
+      # Org's Cluster CRs via the cluster-singleton webhook.
+      config:
+        clusterWide: false
+        data:
+          WATCH_NAMESPACE: {{.Namespace}}
       monitoring:
         # Default OFF per docs/BLUEPRINT-AUTHORING.md §11.2.
         podMonitorEnabled: false


### PR DESCRIPTION
## Two related CNPG defects, both diagnosed LIVE on omantel.biz kom4dc (dep `4635277cae4ffed9`)

### #3740 — cross-region replica was ASYNC (RPO>0); then BLOCKED WRITES
Chart `0.2.5` correctly pinned `synchronous_standby_names = FIRST 1 ("<replica>")` with `maxStandbyNamesFromCluster:0` + `standbyNamesPre:[<replica>]` — **but the WAL stream never reached the primary**. The `-primary-mesh` replication-source Service (consumed by the replica's `externalCluster`) used `selectorType: r`, which selects **every** instance in the primary cluster (`cnpg.io/podRole=instance` → primary + local HA standbys). The cross-region replica's WAL receiver round-robined onto a **local standby** and **cascaded** off it. A cascaded standby can never be a synchronous standby of the primary, so the replica appeared in `pg_stat_replication` only on the **standby** (`sync_state=async`, sender `pg_is_in_recovery()=t`) and **never on the primary**. `FIRST 1 ("<replica>")` stayed permanently unsatisfiable → with `dataDurability:required` the primary **BLOCKED ALL WRITES**.

**Live evidence (before):** replica byte-caught-up, its walsender on `primary-3` (a standby), an `INSERT` on `primary-2` (the real primary) **hung** (timeout/SIGTERM).

**Fix:** flip the mesh Service to `selectorType: rw` (`cnpg.io/instanceRole=primary` → a single endpoint = the current primary). The replica streams **directly from the primary's walsender** → appears in the **primary's** `pg_stat_replication` → `standbyNamesPre` matches → `sync_state=sync` → **RPO=0**. CNPG re-points the `-rw` selector after a Continuum switchover, so the mesh alias keeps tracking the live primary with no chart change.

**Live proof (after patching `selectorType: rw` on the live Cluster CR):**
```
-- primary-2 pg_stat_replication
application_name                  | state     | sync_state
cnpg-pair-bp-cnpg-pair-primary-1  | streaming | async
cnpg-pair-bp-cnpg-pair-primary-3  | streaming | async
cnpg-pair-bp-cnpg-pair-replica    | streaming | sync     <-- cross-region replica is SYNC
-- sync_priority=1, replay_lag empty (caught up)
-- INSERT on primary-2 now returns immediately (previously hung)
-- Continuum replicationLagSeconds: 0
```
The live patch was reverted by Flux (HR still pinned `0.2.5` → re-rendered `r`), which is exactly why the durable fix is this merged chart bump (`0.2.5 → 0.2.6`; `blueprint.yaml` + bootstrap-kit slot-16b in lockstep). Render gate now asserts `selectorType: rw` (and rejects `r`).

### #4143 — per-Org cnpg operator HIJACKED the cluster-singleton webhook
The `cloudnative-pg` subchart registers **cluster-scoped** `Mutating/ValidatingWebhookConfiguration` **singletons** with FIXED names + a hardcoded webhook Service name. The per-Org `bp-cnpg` HelmRelease ran a **second full cluster-wide operator** that reconciled the **same singletons**; whichever wrote last repointed `clientConfig.service` at **its** namespace's `cnpg-webhook-service` with a `caBundle` the other operator's served cert did not match → admission failed `x509: certificate signed by unknown authority` → every **new** Org Cluster CR (e.g. `wordpress-db`) blocked.

**Live evidence:** the singleton `cnpg-mutating-webhook-configuration` was owned by an Org-namespace release (`meta.helm.sh/release-namespace=org-7283eb4a…`), pointing at the Org-namespace webhook service — the platform `cnpg-system` operator was hijacked.

**Fix:** the per-Org operator now runs **webhook-less + namespace-scoped** (`orgTenantBPCNPG` in `organization_gitops.go`):
- `webhook.{mutating,validating}.create=false` → it never touches the cluster singletons; the single platform `cnpg-system` operator owns them and admits Cluster CRs in **every** namespace (incl. this Org's) via its cluster-wide webhook.
- `config.clusterWide=false` + `WATCH_NAMESPACE=<org-ns>` → the per-Org operator reconciles **only its own namespace** and can never contend cluster-scoped resources.

**Render proof:**
- per-Org `bp-cnpg` → **0** webhook configs, `WATCH_NAMESPACE=<org-ns>` (deployment env + controller config-map).
- platform `bp-cnpg` (cnpg-system, default) **UNCHANGED** → 2 webhook configs, cluster-wide (no `WATCH_NAMESPACE`).

## Validation
- `bash platform/cnpg-pair/chart/tests/cnpg-pair-render.sh` → all 11 gates green (incl. new `selectorType: rw` assertion).
- `go build ./internal/handler/` + `go test ./internal/handler/` → green.
- Live: `sync_state=sync` on the cross-region replica + writes unblocked (#3740); per-Org render emits 0 webhook configs (#4143).

## Follow-up (separate defects, not this fix)
- Continuum CR still `Degraded`/no-lease-holder because the `leaseClient.resolvers` are the **placeholder set** (`10.43.0.10/11/12`); the witness read-quorum is unavailable (`witness: read quorum unavailable`). This is Continuum lease-witness resolver wiring (per-Sovereign overlay), **distinct** from the cnpg-pair sync defect fixed here — my fix already drove `replicationLagSeconds: 0`.
- `bp-wordpress-tenant`'s `cnpg-cluster.yaml` uses the same `selectorType: r` mesh pattern; it's masked today by single-instance clusters (no local standby to cascade from) but should adopt `rw` for symmetry when its active-hot-standby path goes multi-instance (coordinate with the #4158 agent who owns that chart's region-B path).

Refs #3740 #4143

🤖 Generated with [Claude Code](https://claude.com/claude-code)