### PR TITLE
fix(d31): name CNPG storageClass + decode Gitea contents envelope — region-B Pending PVCs + org-overlay corruption (Refs #4206 #3785 #4060)

### DIFF
--- a/clusters/_template/bootstrap-kit-crs/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit-crs/10-gitea.yaml
@@ -150,6 +150,7 @@ spec:
       memory: 512Mi
   storage:
     size: 5Gi
+    storageClass: ${SOVEREIGN_CNPG_STORAGE_CLASS}
   enableSuperuserAccess: true
   monitoring:
     enablePodMonitor: false

--- a/clusters/_template/bootstrap-kit-crs/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit-crs/19-harbor.yaml
@@ -106,6 +106,7 @@ spec:
       memory: 512Mi
   storage:
     size: 5Gi
+    storageClass: ${SOVEREIGN_CNPG_STORAGE_CLASS}
   enableSuperuserAccess: true
   monitoring:
     enablePodMonitor: false

--- a/clusters/_template/bootstrap-kit-crs/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit-crs/52-bp-guacamole.yaml
@@ -88,6 +88,7 @@ spec:
       memory: 512Mi
   storage:
     size: 5Gi
+    storageClass: ${SOVEREIGN_CNPG_STORAGE_CLASS}
   enableSuperuserAccess: true
   monitoring:
     enablePodMonitor: false

--- a/clusters/_template/bootstrap-kit/placement.yaml
+++ b/clusters/_template/bootstrap-kit/placement.yaml
@@ -412,14 +412,20 @@ spec:
                   maintenance_work_mem: 64MB
                   log_statement: ddl
                   log_min_duration_statement: "1000"
-              # #4107 — OMIT storageClass entirely. An empty-string storageClass
-              # is NOT "cluster-default" — it means "use NO StorageClass", which
-              # produces an immediate-binding PVC with no provisioner that stays
-              # Pending forever (FailedBinding: "no persistent volumes available
-              # for this claim and no storage class is set"). Omitting the field
-              # is what makes cnpg fall back to the default StorageClass (evs-ssd
-              # on Huawei, hcloud-volumes on Hetzner). local-path remains
-              # forbidden via the forbid-local-path-storage Kyverno policy.
+              # #4206 (supersedes the #4107 OMIT) — NAME the storageClass via
+              # the per-provider durable-CSI var instead of omitting it. #4107
+              # correctly rejected an EMPTY-string class (which opts out of
+              # provisioning → Pending forever), but OMITTING the field is also
+              # unsafe: the admission-default plugin freezes "" the instant a
+              # PVC is created BEFORE any default SC exists (the fresh-prov
+              # ordering race), and that "" is PERMANENT → the gitea/harbor/
+              # guacamole-pg-1 PVCs stuck Pending<empty> 46h (region-B, dep
+              # 4635277cae4ffed9). Naming the class makes the PVC RACE-IMMUNE:
+              # it stays recoverably Pending until evs-ssd/hcloud-volumes lands,
+              # then binds with zero re-creation. The substitute is the tofu
+              # `default_storage_class` var (evs-ssd on Huawei, hcloud-volumes
+              # on Hetzner) — validation rejects "" and the forbidden
+              # local-path, so this can never render empty or ephemeral.
               resources:
                 requests:
                   cpu: 50m
@@ -429,6 +435,7 @@ spec:
                   memory: 512Mi
               storage:
                 size: 5Gi
+                storageClass: ${SOVEREIGN_CNPG_STORAGE_CLASS}
               enableSuperuserAccess: true
               monitoring:
                 enablePodMonitor: false
@@ -1070,14 +1077,20 @@ spec:
                   maintenance_work_mem: 64MB
                   log_statement: ddl
                   log_min_duration_statement: "1000"
-              # #4107 — OMIT storageClass entirely. An empty-string storageClass
-              # is NOT "cluster-default" — it means "use NO StorageClass", which
-              # produces an immediate-binding PVC with no provisioner that stays
-              # Pending forever (FailedBinding: "no persistent volumes available
-              # for this claim and no storage class is set"). Omitting the field
-              # is what makes cnpg fall back to the default StorageClass (evs-ssd
-              # on Huawei, hcloud-volumes on Hetzner). local-path remains
-              # forbidden via the forbid-local-path-storage Kyverno policy.
+              # #4206 (supersedes the #4107 OMIT) — NAME the storageClass via
+              # the per-provider durable-CSI var instead of omitting it. #4107
+              # correctly rejected an EMPTY-string class (which opts out of
+              # provisioning → Pending forever), but OMITTING the field is also
+              # unsafe: the admission-default plugin freezes "" the instant a
+              # PVC is created BEFORE any default SC exists (the fresh-prov
+              # ordering race), and that "" is PERMANENT → the gitea/harbor/
+              # guacamole-pg-1 PVCs stuck Pending<empty> 46h (region-B, dep
+              # 4635277cae4ffed9). Naming the class makes the PVC RACE-IMMUNE:
+              # it stays recoverably Pending until evs-ssd/hcloud-volumes lands,
+              # then binds with zero re-creation. The substitute is the tofu
+              # `default_storage_class` var (evs-ssd on Huawei, hcloud-volumes
+              # on Hetzner) — validation rejects "" and the forbidden
+              # local-path, so this can never render empty or ephemeral.
               resources:
                 requests:
                   cpu: 50m
@@ -1087,6 +1100,7 @@ spec:
                   memory: 512Mi
               storage:
                 size: 5Gi
+                storageClass: ${SOVEREIGN_CNPG_STORAGE_CLASS}
               enableSuperuserAccess: true
               monitoring:
                 enablePodMonitor: false
@@ -1305,14 +1319,17 @@ spec:
                 limits:
                   cpu: 500m
                   memory: 512Mi
-              # #4107 — OMIT storageClass entirely. An empty-string storageClass
-              # is NOT "cluster-default" — it means "use NO StorageClass", which
-              # produces an immediate-binding PVC with no provisioner that stays
-              # Pending forever. Omitting the field is what makes cnpg fall back
-              # to the default StorageClass (evs-ssd on Huawei, hcloud-volumes on
-              # Hetzner). local-path remains forbidden via Kyverno.
+              # #4206 (supersedes the #4107 OMIT) — NAME the storageClass via
+              # the per-provider durable-CSI var instead of omitting it. An
+              # OMITTED field lets the admission-default plugin freeze "" the
+              # instant a PVC is created BEFORE the default SC lands (fresh-prov
+              # ordering race), and that "" is PERMANENT → Pending forever.
+              # Naming it (evs-ssd on Huawei, hcloud-volumes on Hetzner; tofu
+              # var validation rejects "" and local-path) makes the PVC
+              # race-immune. local-path remains forbidden via Kyverno.
               storage:
                 size: 5Gi
+                storageClass: ${SOVEREIGN_CNPG_STORAGE_CLASS}
               enableSuperuserAccess: true
               monitoring:
                 enablePodMonitor: false

--- a/core/services/provisioning/github/client.go
+++ b/core/services/provisioning/github/client.go
@@ -940,5 +940,30 @@ func (c *Client) ReadFile(ctx context.Context, branch, path string) (string, err
 	if err != nil {
 		return "", err
 	}
-	return string(body), nil
+	// #4206 #3785 — the Gitea contents API (/api/v1/repos/.../contents/<path>)
+	// ALWAYS returns a JSON envelope `{"content":"<base64>","encoding":"base64",
+	// ...}` regardless of the `Accept: application/vnd.github.raw+json` header
+	// (which only GitHub.com honours). Returning that envelope verbatim is the
+	// bug that corrupted the org-tenants PARENT kustomization.yaml: the
+	// rebuild closure read this envelope, spliced the new Org subdir onto it,
+	// and committed the JSON-wrapped string back as the file — which Flux /
+	// kustomize cannot parse, so the whole org-tenants tree (incl. the demo
+	// Org) stopped reconciling and its namespace was pruned. Decode the
+	// envelope to the raw file content. If the body is NOT a Gitea envelope
+	// (e.g. a genuine GitHub raw response), fall back to the raw body.
+	var meta struct {
+		Content  string `json:"content"`
+		Encoding string `json:"encoding"`
+	}
+	if jerr := json.Unmarshal(body, &meta); jerr != nil || meta.Encoding == "" {
+		return string(body), nil
+	}
+	if meta.Encoding == "base64" {
+		decoded, derr := base64.StdEncoding.DecodeString(strings.ReplaceAll(meta.Content, "\n", ""))
+		if derr != nil {
+			return "", fmt.Errorf("decode gitea contents %s: %w", path, derr)
+		}
+		return string(decoded), nil
+	}
+	return meta.Content, nil
 }

--- a/core/services/provisioning/github/client_contents_test.go
+++ b/core/services/provisioning/github/client_contents_test.go
@@ -282,3 +282,55 @@ func TestCommitFiles_GiteaTarget_UpdateUsesExistingSHA(t *testing.T) {
 		t.Errorf("op.sha = %q, want %q (existing blob SHA)", payload.Files[0].SHA, existingSHA)
 	}
 }
+
+// TestReadFile_GiteaContentsEnvelope_Decoded asserts that ReadFile decodes the
+// Gitea contents-API JSON envelope ({"content":"<base64>","encoding":"base64"})
+// to the RAW file content, instead of returning the JSON wrapper verbatim.
+//
+// #4206 #3785 — returning the envelope verbatim corrupted the org-tenants
+// PARENT kustomization.yaml: the rebuild closure read the envelope, spliced the
+// new Org subdir onto it, and committed the JSON-wrapped string back, which
+// Flux/kustomize could not parse → the whole org-tenants tree (incl. the demo
+// Org) stopped reconciling and its namespace was pruned. Gitea ALWAYS returns
+// the JSON envelope (it ignores `Accept: application/vnd.github.raw+json`),
+// so the round-trip must decode it. The prior contents test only covered the
+// 404 (create) path, so this regression was never caught.
+func TestReadFile_GiteaContentsEnvelope_Decoded(t *testing.T) {
+	wantYAML := "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n  - helmrepositories.yaml\n  - 7283eb4a-19e5-4e86-9066-d4aa26762064\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/contents/") {
+			w.Header().Set("Content-Type", "application/json")
+			// Gitea wraps multi-line base64 — embed a newline to prove we strip it.
+			b64 := base64.StdEncoding.EncodeToString([]byte(wantYAML))
+			if len(b64) > 20 {
+				b64 = b64[:20] + "\n" + b64[20:]
+			}
+			env := map[string]any{
+				"name":     "kustomization.yaml",
+				"path":     "clusters/omantel.biz/org-tenants/kustomization.yaml",
+				"sha":      "deadbeef",
+				"type":     "file",
+				"encoding": "base64",
+				"content":  b64,
+			}
+			_ = json.NewEncoder(w).Encode(env)
+			return
+		}
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	c := NewClientWithAPIURL("token", "owner", "repo", srv.URL)
+	got, err := c.ReadFile(context.Background(), "org-tenants", "clusters/omantel.biz/org-tenants/kustomization.yaml")
+	if err != nil {
+		t.Fatalf("ReadFile returned error: %v", err)
+	}
+	if got != wantYAML {
+		t.Fatalf("ReadFile did not decode the Gitea envelope.\n got: %q\nwant: %q", got, wantYAML)
+	}
+	if strings.Contains(got, "\"content\"") || strings.Contains(got, "\"encoding\"") {
+		t.Fatalf("ReadFile returned the JSON envelope verbatim (the #4206 corruption): %q", got)
+	}
+}

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -870,6 +870,17 @@ write_files:
         postBuild:
           substitute:
             SOVEREIGN_FQDN: ${sovereign_fqdn}
+            # #4206 — the host-shared CNPG Cluster CRs reconciled by THIS
+            # Kustomization (gitea-pg / harbor-pg / guacamole-pg, slots
+            # 10/19/52) name their storageClass via this var so their PVCs are
+            # RACE-IMMUNE. Omitting the field (the prior #4107 shape) lets the
+            # admission-default plugin freeze "" the instant a PVC is created
+            # before the default SC lands (the fresh-prov ordering race) — and
+            # that "" is PERMANENT (opts out of dynamic provisioning) → Pending
+            # forever. The same per-provider durable class the bootstrap-kit
+            # block uses (evs-ssd on Huawei, hcloud-volumes on Hetzner); the
+            # tofu var validation rejects "" and "local-path".
+            SOVEREIGN_CNPG_STORAGE_CLASS: "${default_storage_class}"
 %{ if provider == "hetzner" ~}
       ---
       # infrastructure-config Kustomization — installs the Crossplane Provider


### PR DESCRIPTION
## D31 multi-region placement/storage systemic root

Fixes the systemic root blocking three issues + the live Sovereign "Degraded" banner on omantel.biz dep `4635277cae4ffed9`. Root-caused live across both regions.

### Layer 1 — #4206: region-B per-app CNPG PVCs Pending 46h (empty storageClassName)
The host-shared CNPG `Cluster` CRs (`gitea-pg` / `harbor-pg` / `guacamole-pg`, bootstrap-kit-crs slots 10/19/52) rendered `storage:` with **no** `storageClass`. An *omitted* field lets the admission-default plugin freeze `""` the instant a PVC is created **before** the per-provider default StorageClass (`evs-ssd` on Huawei) lands — the fresh-prov ordering race the cloud-init comments already document — and that `""` is **permanent** (opts out of dynamic provisioning) → PVCs Pending 46h while the healthy `evs-ssd (default)` SC sits unused.

**Fix:** NAME the class via the existing per-provider durable-CSI var `SOVEREIGN_CNPG_STORAGE_CLASS` (`evs-ssd` on Huawei / `hcloud-volumes` on Hetzner; the tofu `default_storage_class` var validation rejects `""` and `local-path`, so it can never render empty/ephemeral). Threaded into the `bootstrap-kit-crs` Kustomization `postBuild.substitute` (it previously only passed `SOVEREIGN_FQDN`) + the three `Cluster` CR `storage:` blocks (`placement.yaml` source-of-truth + regenerated `bootstrap-kit-crs` slots via `render-slot-placement.py`). **Supersedes the #4107 OMIT shape** (which correctly rejected the empty-string class but left the omit-race open).

### Layer 2 — #3785/#4206: the TRUE systemic root of the org-overlay corruption
`core/services/provisioning/github/client.go` `ReadFile` returned the **raw Gitea contents-API JSON envelope** (`{"content":"<base64>","encoding":"base64",…}`) verbatim — Gitea ignores the `Accept: application/vnd.github.raw+json` header that only GitHub.com honours. The org-tenant `rebuild` closure read this envelope, spliced the new Org subdir onto it, and committed the JSON-wrapped string back as the **parent** `clusters/<fqdn>/org-tenants/kustomization.yaml`. Flux/kustomize cannot parse it → the **whole org-tenants tree (incl. the demo Org `7283eb4a`) stopped reconciling** and its namespace was pruned (stuck Terminating on 3 `application.apps.openova.io` finalizers). This is the live "wordpress HR Ready=False → Sovereign DEGRADED" trail's deepest cause.

**Fix:** `ReadFile` now decodes the Gitea envelope (base64, newline-stripped) to raw content, with a fall-through for genuine GitHub raw bodies. New regression test `TestReadFile_GiteaContentsEnvelope_Decoded` covers the 200+base64 path — the prior contents test only covered 404/create, so this slipped through.

### Layer 3 — #4060: CNPG-pair provider-aware storageClass
Verified **already fixed** on main — `generateCNPGPair` is provider-aware via `cnpgStorageClass()` (Huawei→`evs-ssd`, Hetzner→`hcloud-volumes`), wired from `CLOUD_PROVIDER`. Unit tests `TestCNPGPair_StorageClass_{Huawei,Hetzner,DefaultsToHetzner}` + `TestCNPGStorageClass_Resolver` pass. No code change; covered here for the D31 story.

### Demo Org hot-standby
The demo customer WordPress is a **single-region singleton** (North Star). The org overlay already defaults `SOVEREIGN_ENABLE_HOT_STANDBY` **OFF** (`organization_gitops.go:579-593`, with defence-in-depth) — so a fresh prov renders **no** cross-region `wordpress-db-replica`. The live env carried a *stale* `pg.activeHotStandby.enabled=true` from an older image render; dropped via the live org-overlay repair (the misplaced replica's pgbasebackup pod was Pending forever on region-B node affinity in a region-A namespace → HR Ready=False → DEGRADED banner).

## Validation
- `tofu validate` (hetzner provider): **Success — configuration valid** (cloud-init tftpl edit).
- `go build ./...` + `go vet`: clean.
- `go test ./github/` (incl. new ReadFile test) + `go test ./gitops/` (#4060 provider tests) + org-overlay hot-standby tests: **pass**.
- Live before/after on omantel.biz documented in the issue threads.

## DoD
- region-B Pending PVCs → bound (chart fix prevents recurrence on every fresh prov)
- demo wordpress HR → Ready (replica dropped; namespace recovered)
- Sovereign banner → not Degraded
- org-overlay corruption → fixed at root (no recurrence on next provision)

Refs #4206 #3785 #4060

🤖 Generated with [Claude Code](https://claude.com/claude-code)