### PR TITLE
fix(funnel): org-tenant DNS provisioner reads CATALYST_POWERDNS_API_URL — new Orgs get their pool A-record (#4215)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -972,7 +972,16 @@ func main() {
 			}
 			// DNS provisioner — wraps PowerDNS for free-subdomain
 			// writes; falls back to a no-op when env unset.
-			pdnsURL := os.Getenv("CATALYST_POWERDNS_URL")
+			//
+			// #4215: read CATALYST_POWERDNS_API_URL — the canonical name
+			// used by every other PowerDNS reader (main.go:353,
+			// parent_domains.go, the chart api-deployment templates) and
+			// the only name the deployment actually sets. The legacy
+			// CATALYST_POWERDNS_URL was never wired, so this org-tenant DNS
+			// provisioner was permanently no-op'd → new Orgs never got their
+			// console.<slug>.<pool> A-record → ERR_NAME_NOT_RESOLVED on the
+			// post-signup redirect (the #4179 funnel landing).
+			pdnsURL := os.Getenv("CATALYST_POWERDNS_API_URL")
 			pdnsKey := os.Getenv("CATALYST_POWERDNS_API_KEY")
 			if writer := handler.NewPowerDNSWriter(pdnsURL, pdnsKey); writer != nil {
 				tdeps.DNS = handler.DefaultOrganizationDNSProvisioner{Writer: writer}

--- a/products/catalyst/bootstrap/api/internal/handler/organization_dns.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_dns.go
@@ -17,7 +17,7 @@
 //     loop.
 //
 // Per docs/INVIOLABLE-PRINCIPLES.md #4 the PowerDNS endpoint + API
-// key are env-configured (CATALYST_POWERDNS_URL,
+// key are env-configured (CATALYST_POWERDNS_API_URL,
 // CATALYST_POWERDNS_API_KEY). A nil writer (env unset) returns a
 // graceful error rather than a panic; the orchestrator surfaces that
 // as a transient `dns:transient:powerdns not wired` until the
@@ -145,7 +145,7 @@ type Resolver interface {
 // role:org-pool entries) — never inferred from a hardcoded OTECHFQDN.
 func (p DefaultOrganizationDNSProvisioner) ProvisionFreeSubdomain(ctx context.Context, subdomain, parentZone, ingressIPv4 string) error {
 	if p.Writer == nil {
-		return errors.New("powerdns writer not wired (CATALYST_POWERDNS_URL / CATALYST_POWERDNS_API_KEY)")
+		return errors.New("powerdns writer not wired (CATALYST_POWERDNS_API_URL / CATALYST_POWERDNS_API_KEY)")
 	}
 	if strings.TrimSpace(ingressIPv4) == "" {
 		return errors.New("otech ingress IPv4 unconfigured")
@@ -229,7 +229,7 @@ func (p DefaultOrganizationDNSProvisioner) ValidateBYOCNAME(ctx context.Context,
 // NoopOrganizationDNSProvisioner satisfies OrganizationDNSProvisioner with
 // success-on-call no-ops. Used in CI / test environments without
 // PowerDNS or a public DNS resolver. Production main.go wires this
-// only when both env knobs (CATALYST_POWERDNS_URL,
+// only when both env knobs (CATALYST_POWERDNS_API_URL,
 // CATALYST_POWERDNS_API_KEY) are absent — that's an explicit signal
 // from the operator that they're not running the DNS step here.
 type NoopOrganizationDNSProvisioner struct{}


### PR DESCRIPTION
## Problem
Live E2E walk of the #4179 funnel (omantel.biz, fresh signup `qa4179walk` on `omani.works`):
- The #4179 redirect-host fix **works** — `POST /api/tenant/orgs` → 201 with `parent_domain=omani.works`, Org CR stores `spec.tenantPublic.parentDomain: omani.works`, and the marketplace correctly redirects to the POOL host `https://console.qa4179walk.omani.works/auth/org-handover?token=…` (NOT the dead `console.qa4179walk.omantel.biz`).
- BUT the landing fails: **`net::ERR_NAME_NOT_RESOLVED`** — `console.qa4179walk.omani.works` has no DNS A-record (confirmed absent on authoritative `ns1.openova.io` and in the mothership PowerDNS `pdns` DB).

## Root cause
`products/catalyst/bootstrap/api/cmd/api/main.go` (org-tenant DNS provisioner) read **`CATALYST_POWERDNS_URL`** — a name set NOWHERE. Every other PowerDNS reader (main.go:353, parent_domains.go, the chart `api-deployment` templates) uses the canonical **`CATALYST_POWERDNS_API_URL`**. So `NewPowerDNSWriter("", key)` returned nil → `NoopOrganizationDNSProvisioner`, permanently. New Orgs never got their `console.<slug>.<pool>` A-record.

Mothership log proof: `org-tenant: powerdns env unset; using no-op DNS provisioner` — while `CATALYST_POWERDNS_API_URL` (`http://powerdns.openova-system.svc.cluster.local:8081`) and a 48-char `CATALYST_POWERDNS_API_KEY` were BOTH populated on the pod.

## Fix
Read the canonical `CATALYST_POWERDNS_API_URL`. URL + key are already wired on the deployment, so the writer becomes non-nil and the per-Org pool A-record is written on Org creation. Also aligns the doc/error strings in `organization_dns.go` to the canonical name.

`go build ./cmd/api/ ./internal/handler/` clean.

## Impact
Unblocks the #4179 funnel DoD step 8 (land SIGNED-IN on `console.<slug>.omani.works/jobs`). After this rolls, a fresh signup's pool host will resolve and the secure org-handover hop can complete.

Refs #4215 #4179