### PR TITLE
fix(console): wire orphan BootstrapProgress into /jobs — fill the ~30-min provisioning void (Refs #3914)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.bootstrap-progress.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.bootstrap-progress.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * JobsPage.bootstrap-progress.test.tsx — lock-in for issue #3914.
+ *
+ * The orphan `BootstrapProgress` widget (widgets/bootstrap-progress/) was
+ * built + merged but imported NOWHERE, so the ~30-min "Provision
+ * <provider>: Success" void on /provision/<id>/jobs was never filled with
+ * live per-phase progress. This file asserts the widget is now mounted on
+ * the customer's provisioning landing surface (JobsPage) during the live
+ * provisioning window, and correctly hidden once provisioning terminates.
+ *
+ * The EventSource attach is suppressed via `disableStream` (jsdom has no
+ * EventSource) — the widget then renders from its initial all-pending
+ * phase map, which is exactly what the operator sees on first paint before
+ * the SSE delivers events. The DOM-presence gating (in-flight vs.
+ * completed vs. sovereign-chroot) is what this file verifies.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { JobsPage } from './JobsPage'
+import { useWizardStore } from '@/entities/deployment/store'
+import { INITIAL_WIZARD_STATE } from '@/entities/deployment/model'
+
+function renderJobs(
+  deploymentId: string,
+  props: { disableBootstrapProgress?: boolean } = {},
+) {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const jobsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/jobs',
+    component: () => (
+      // disableStream suppresses BOTH the deployment-events SSE and the
+      // bootstrap-progress SSE (jsdom has no EventSource); the widget DOM
+      // still renders from its initial all-pending phase map.
+      <JobsPage disableStream disableJobsBackfill {...props} />
+    ),
+  })
+  const homeRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId',
+    component: () => <div data-testid="apps-target" />,
+  })
+  const jobDetailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/jobs/$jobId',
+    component: () => <div data-testid="job-detail-target" />,
+  })
+  const tree = rootRoute.addChildren([jobsRoute, homeRoute, jobDetailRoute])
+  const router = createRouter({
+    routeTree: tree,
+    history: createMemoryHistory({
+      initialEntries: [`/provision/${deploymentId}/jobs`],
+    }),
+  })
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => cleanup())
+
+describe('JobsPage — #3914 BootstrapProgress timeline (in-flight)', () => {
+  beforeEach(() => {
+    useWizardStore.setState({ ...INITIAL_WIZARD_STATE })
+    // `done: false` keeps the deployment in-flight (streamStatus stays
+    // connecting/streaming), which is the window the void appears in.
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ events: [], state: undefined, done: false }),
+      } as unknown as Response),
+    ) as unknown as typeof fetch
+  })
+
+  it('mounts the BootstrapProgress timeline while provisioning is in-flight', async () => {
+    renderJobs('d-1')
+    // Jobs table renders first (waterfall), then the timeline section.
+    await screen.findByTestId('jobs-table')
+    const section = await screen.findByTestId('sov-jobs-bootstrap-progress')
+    expect(section).toBeTruthy()
+    // The widget's own landmark (a <nav aria-label="Bootstrap provisioning
+    // progress">) confirms the actual BootstrapProgress component — not an
+    // empty shell — rendered inside the section.
+    const nav = section.querySelector('nav[aria-label="Bootstrap provisioning progress"]')
+    expect(nav).toBeTruthy()
+  })
+
+  it('renders the Phase-0 OpenTofu + Phase-1 bootstrap-kit section headers', async () => {
+    renderJobs('d-1')
+    const section = await screen.findByTestId('sov-jobs-bootstrap-progress')
+    // The widget always renders both section headers from ALL_PHASES even
+    // before any event arrives — the operator sees the full plan up-front.
+    expect(section.textContent).toContain('Phase 0')
+    expect(section.textContent).toContain('OpenTofu')
+    expect(section.textContent).toContain('Phase 1')
+    expect(section.textContent).toContain('Bootstrap kit')
+  })
+
+  it('honours the disableBootstrapProgress test seam', async () => {
+    renderJobs('d-1', { disableBootstrapProgress: true })
+    await screen.findByTestId('jobs-table')
+    expect(screen.queryByTestId('sov-jobs-bootstrap-progress')).toBeNull()
+  })
+})
+
+describe('JobsPage — #3914 BootstrapProgress timeline (terminal)', () => {
+  beforeEach(() => {
+    useWizardStore.setState({ ...INITIAL_WIZARD_STATE })
+  })
+
+  it('hides the timeline once the deployment reports ready (void is gone)', async () => {
+    // `done: true` + status ready flips streamStatus to 'completed', so the
+    // in-flight gate closes and the timeline must NOT render — the jobs
+    // table now carries the full history.
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            events: [],
+            state: { id: 'd-1', status: 'ready', sovereignFQDN: 'x.omani.works' },
+            done: true,
+          }),
+      } as unknown as Response),
+    ) as unknown as typeof fetch
+
+    renderJobs('d-1')
+    await screen.findByTestId('jobs-table')
+    // Allow the GET /events replay microtask to flip streamStatus.
+    await new Promise((r) => setTimeout(r, 0))
+    expect(screen.queryByTestId('sov-jobs-bootstrap-progress')).toBeNull()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.tsx
@@ -59,6 +59,8 @@ import { DETECTED_MODE } from '@/shared/lib/detectMode'
 import type { Job } from '@/lib/jobs.types'
 import { HandoverRedirectBanner } from './HandoverRedirectBanner'
 import { HANDOVER_REDIRECT_BANNER_CSS } from './HandoverRedirectBanner.css'
+import { BootstrapProgress } from '@/widgets/bootstrap-progress/BootstrapProgress'
+import { useProvisioningStream } from '@/shared/lib/useProvisioningStream'
 
 interface JobsPageProps {
   /** Test seam — disables the live SSE EventSource attach. */
@@ -72,12 +74,21 @@ interface JobsPageProps {
    * or window.location. Production call sites never set this.
    */
   disableHandoverAutoRedirect?: boolean
+  /**
+   * Test seam — disables the BootstrapProgress EventSource attach (the
+   * second SSE that drives the per-phase provisioning timeline). The
+   * widget DOM still renders from its initial all-pending phase map so
+   * tests can assert its presence without booting EventSource in jsdom.
+   * Production call sites never set this.
+   */
+  disableBootstrapProgress?: boolean
 }
 
 export function JobsPage({
   disableStream = false,
   disableJobsBackfill = false,
   disableHandoverAutoRedirect = false,
+  disableBootstrapProgress = false,
 }: JobsPageProps = {}) {
   const { deploymentId: resolvedId } = useResolvedDeploymentId()
   const deploymentId = resolvedId ?? ''
@@ -116,6 +127,34 @@ export function JobsPage({
     enabled: !disableJobsBackfill,
     disablePolling: disableJobsBackfill || (!inFlight && !isSovereignMode),
   })
+
+  // #3914 — fill the ~30-min "Provision <provider>: Success" void. The
+  // BootstrapProgress widget renders a live per-phase timeline (the 5
+  // OpenTofu checkpoints + the 11 bootstrap-kit components) driven by the
+  // SAME catalyst-api SSE log channel the jobs surface streams from. It
+  // gives the operator continuous motion — "Nodes booting · cloud-init",
+  // "k3s up · kubeconfig received", "Flux installing — Cilium … Catalyst
+  // Platform" — during the gap between tofu-apply finishing and the
+  // in-cluster HelmReleases reconciling, instead of a static Success badge
+  // over a silent half-hour.
+  //
+  // Gated to the live mothership provisioning window: the mothership owns
+  // the /provision/<id>/jobs surface during Phase 0/1, so we attach the
+  // stream only while the deployment is in-flight on the mothership. On a
+  // chrooted Sovereign (post-handover, frozen snapshot) the phase timeline
+  // is historical, so we don't re-open the stream there.
+  // DOM visibility: the timeline shows whenever a mothership prov is
+  // in-flight, even under the test seams (it then renders its initial
+  // all-pending phase map). The live SSE attach is gated separately so
+  // jsdom tests can mount the widget without an EventSource polyfill.
+  const showBootstrapProgress =
+    !!deploymentId && inFlight && !isSovereignMode && !disableBootstrapProgress
+  const bootstrapStreamURL =
+    showBootstrapProgress && !disableStream
+      ? `/v1/deployments/${encodeURIComponent(deploymentId)}/logs`
+      : null
+  const { phases: bootstrapPhases, activePhase } =
+    useProvisioningStream(bootstrapStreamURL)
 
   // ONE honest list: the backend payload wins outright. The reducer tail
   // is shown only before the first live fetch returns (waterfall paint),
@@ -165,6 +204,23 @@ export function JobsPage({
           <span className="text-[var(--color-accent)] font-semibold">Live state stream re-attached.</span>{' '}
           Refreshing from the catalyst-api every 5s.
         </div>
+      ) : null}
+
+      {/* #3914 — live "Bootstrapping cluster" timeline. Fills the ~30-min
+          void between "Provision <provider>: Success" and the in-cluster
+          convergence so the operator watches cloud-init → k3s → Flux →
+          per-component install in real time instead of a static badge. */}
+      {showBootstrapProgress ? (
+        <section
+          data-testid="sov-jobs-bootstrap-progress"
+          aria-label="Live provisioning progress"
+          className="mt-4 rounded-lg border border-[var(--color-surface-border)] bg-[var(--color-surface-1)] p-2"
+        >
+          <BootstrapProgress
+            phases={bootstrapPhases}
+            focusedPhaseId={activePhase}
+          />
+        </section>
       ) : null}
 
       <div className="mt-6" data-testid="sov-jobs-list">


### PR DESCRIPTION
## Problem (Refs #3914)

On the provisioning timeline (`/sovereign/provision/<id>/jobs`), the "Provision <provider>" lifecycle group flips to **Success** the moment `tofu apply` finishes — then a **silent ~30-min void** before any in-cluster bootstrap/convergence activity appears. The customer sees a static "Success" badge for half an hour and reasonably concludes the prov is stuck/dead, when the cluster is actually bootstrapping (cloud-init → k3s → kubeconfig-PUT → Flux installing → HRs reconciling).

## Root cause: orphan component, never wired

The `BootstrapProgress` widget (`products/catalyst/bootstrap/ui/src/widgets/bootstrap-progress/BootstrapProgress.tsx`) — a complete, well-built vertical step-progress indicator for the 5 OpenTofu checkpoints + the 11 bootstrap-kit phases (built for #121) — was **imported NOWHERE**. Verified: `grep -rn "BootstrapProgress" .../ui/src` returns only its own definition file. Its companion `useProvisioningStream` hook + `LogStream` widget were likewise dead at runtime — the whole #121/#122 trio was orphaned when the original wizard `StepProvisioning` surface got replaced by the AppsPage/JobsPage pivot. **Orphan, not incomplete** — no logic changes needed to the widget itself.

## Fix: mount it on the customer's provisioning landing surface

`JobsPage` (the `/provision/<id>/jobs` surface the customer lands on during provisioning) now renders `BootstrapProgress` above the jobs table, fed by `useProvisioningStream` off the **same** catalyst-api SSE log channel (`/api/v1/deployments/<id>/logs`) the jobs surface already streams. The sovereign-admin watches the 16 phases advance in real time during the gap — continuous motion, never a static Success over a silent void.

Gating:
- **in-flight only** (`streamStatus` not completed/failed) — exactly the void window
- **mothership only** (not the chrooted Sovereign's frozen post-handover snapshot)
- `disableBootstrapProgress` test seam; the live SSE attach also respects the existing `disableStream` seam so jsdom mounts the widget with no EventSource polyfill

The widget uses the `--wiz-*` design tokens that are defined globally at `:root` in `globals.css` (verified all 10 referenced tokens are present), so it renders correctly in the console context outside the wizard shell.

## Tests

- 4 new lock-in tests (`JobsPage.bootstrap-progress.test.tsx`): timeline mounts during in-flight prov, renders both Phase-0/Phase-1 section headers, is hidden once the deployment reports `ready`, and honours the test seam.
- `tsc -b` green · `vite build` green · full vitest: **69 failed / 1680 passed** vs pristine origin/main **71 failed / 1678 passed** — i.e. my change is a net +2 (the 4 new tests; the remaining failures are pre-existing unrelated debt in PinInput6 / SettingsPage / StepComponents / etc., confirmed identical on pristine main).

## DoD pillar

Pillar 1 (Marketplace + voucher onboarding) — the operator-facing provisioning observability surface during the fresh-prov walk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)