### PR TITLE
fix(catalyst-api): org-tenant pool A-record writes target CENTRAL pdns.openova.io (#4218 — final #4179 funnel layer)

### DIFF
--- a/clusters/_template/sovereign-tls/powerdns-api-credentials.yaml
+++ b/clusters/_template/sovereign-tls/powerdns-api-credentials.yaml
@@ -45,6 +45,21 @@ metadata:
   labels:
     catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
     catalyst.openova.io/component: cert-manager-powerdns-webhook
+  annotations:
+    # #4218 — source-side opt-in so bp-reflector may PULL this CENTRAL
+    # pdns.openova.io key into `catalyst-system`, where catalyst-api's
+    # org-tenant DNS provisioner needs it to write the per-Org pool
+    # subdomain A-record (console.<slug>.<omani-pool>) on the central
+    # authoritative PowerDNS. The destination stub
+    # (products/catalyst/chart/templates/pool-powerdns-credentials-host-bridge.yaml)
+    # carries the matching `reflector…/reflects: cert-manager/powerdns-api-credentials`
+    # annotation, which renames it to `pool-powerdns-api-credentials` in
+    # catalyst-system. Without this opt-in the org-tenant write stays no-op
+    # (#4218 Layer A — empty key in catalyst-system → NewPowerDNSWriter nil).
+    # This is the SAME key bp-cert-manager-powerdns-webhook already uses for
+    # DNS-01 against pdns.openova.io — NOT a new credential.
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "catalyst-system"
 type: Opaque
 data:
   api-key: ${POWERDNS_API_KEY}

--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -983,9 +983,36 @@ func main() {
 			// post-signup redirect (the #4179 funnel landing).
 			pdnsURL := os.Getenv("CATALYST_POWERDNS_API_URL")
 			pdnsKey := os.Getenv("CATALYST_POWERDNS_API_KEY")
-			if writer := handler.NewPowerDNSWriter(pdnsURL, pdnsKey); writer != nil {
-				tdeps.DNS = handler.DefaultOrganizationDNSProvisioner{Writer: writer}
-				log.Info("org-tenant: powerdns writer wired", "url", pdnsURL)
+			localWriter := handler.NewPowerDNSWriter(pdnsURL, pdnsKey)
+			// #4218: pool-domain (omani.*) console A-records must be
+			// written to the CENTRAL authoritative PowerDNS (pdns.openova.io)
+			// with the CENTRAL pool key — NOT the Sovereign-local PowerDNS,
+			// which hosts only the Sovereign's own FQDN zone and has no
+			// omani.works zone (PATCH 404). On a production Sovereign the
+			// marketplace runs on the Sovereign domain while Orgs provision
+			// on separate omani.* pool domains, so the free-subdomain write
+			// (console.<slug>.<pool>) targets the central server. The pool
+			// env pair is independent of the local CATALYST_POWERDNS_API_*
+			// (which stays pointed at the local server for the #827/#829
+			// multi-zone admin flow). When the pool env is unset (a
+			// single-PowerDNS Sovereign where the pool IS the local zone)
+			// the provisioner falls back to localWriter automatically.
+			poolURL := os.Getenv("CATALYST_POOL_POWERDNS_API_URL")
+			poolKey := os.Getenv("CATALYST_POOL_POWERDNS_API_KEY")
+			poolWriter := handler.NewPowerDNSWriter(poolURL, poolKey)
+			if localWriter != nil || poolWriter != nil {
+				tdeps.DNS = handler.DefaultOrganizationDNSProvisioner{
+					Writer:     localWriter,
+					PoolWriter: poolWriter,
+				}
+				switch {
+				case poolWriter != nil:
+					log.Info("org-tenant: powerdns writer wired (pool-domain free-subdomain writes target central pdns)",
+						"local_url", pdnsURL, "pool_url", poolURL)
+				default:
+					log.Info("org-tenant: powerdns writer wired (local pdns only; no pool env — single-PowerDNS Sovereign)",
+						"local_url", pdnsURL)
+				}
 			} else {
 				tdeps.DNS = handler.NoopOrganizationDNSProvisioner{}
 				log.Info("org-tenant: powerdns env unset; using no-op DNS provisioner")

--- a/products/catalyst/bootstrap/api/internal/handler/organization_dns.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_dns.go
@@ -123,7 +123,24 @@ func zoneCanonical(zone string) string {
 // OrganizationDNSProvisioner. Wraps a PowerDNSWriter for free-subdomain
 // writes and net.LookupCNAME for BYO validation.
 type DefaultOrganizationDNSProvisioner struct {
+	// Writer — the LOCAL PowerDNS REST client (the Sovereign's own
+	// in-cluster powerdns.powerdns.svc), authoritative ONLY for the
+	// Sovereign's own FQDN (e.g. omantel.biz). Used for free-subdomain
+	// writes when the parent zone is the Sovereign's own domain
+	// (single-domain Sovereign / Catalyst-Zero back-compat) and never
+	// for the shared omani.* pool zones — those live on a separate
+	// authoritative server (see PoolWriter).
 	Writer *PowerDNSWriter
+	// PoolWriter — the CENTRAL PowerDNS REST client (pdns.openova.io),
+	// authoritative for the shared subdomain-pool zones (omani.works,
+	// omani.homes, omani.rest, omani.trade). On a production Sovereign
+	// the marketplace runs on the Sovereign FQDN while Orgs provision on
+	// SEPARATE pool domains; their `console.<slug>.<pool>` A-record MUST
+	// be written to the central server, not the Sovereign-local one
+	// (which has no pool zone → PATCH 404). When set, ProvisionFreeSubdomain
+	// prefers this writer; nil falls back to Writer (the single-PowerDNS
+	// Sovereign where the pool IS the local zone). #4218.
+	PoolWriter *PowerDNSWriter
 	// Resolver — net resolver used for BYO CNAME lookups. Defaults to
 	// net.DefaultResolver; tests inject a stub that returns canned
 	// responses without hitting the live DNS root.
@@ -144,8 +161,16 @@ type Resolver interface {
 // parentZone is operator-supplied (one of the Sovereign's
 // role:org-pool entries) — never inferred from a hardcoded OTECHFQDN.
 func (p DefaultOrganizationDNSProvisioner) ProvisionFreeSubdomain(ctx context.Context, subdomain, parentZone, ingressIPv4 string) error {
-	if p.Writer == nil {
-		return errors.New("powerdns writer not wired (CATALYST_POWERDNS_API_URL / CATALYST_POWERDNS_API_KEY)")
+	// #4218: pool-domain console A-records (omani.*) live on the CENTRAL
+	// authoritative PowerDNS (pdns.openova.io), not the Sovereign-local
+	// one. Prefer PoolWriter when wired; fall back to the local Writer for
+	// the single-PowerDNS Sovereign where the pool IS the local zone.
+	writer := p.Writer
+	if p.PoolWriter != nil {
+		writer = p.PoolWriter
+	}
+	if writer == nil {
+		return errors.New("powerdns writer not wired (CATALYST_POWERDNS_API_URL / CATALYST_POWERDNS_API_KEY, or CATALYST_POOL_POWERDNS_API_URL / CATALYST_POOL_POWERDNS_API_KEY)")
 	}
 	if strings.TrimSpace(ingressIPv4) == "" {
 		return errors.New("otech ingress IPv4 unconfigured")
@@ -182,7 +207,7 @@ func (p DefaultOrganizationDNSProvisioner) ProvisionFreeSubdomain(ctx context.Co
 			},
 		})
 	}
-	return p.Writer.PatchRRSets(ctx, zone, rrsets)
+	return writer.PatchRRSets(ctx, zone, rrsets)
 }
 
 // ValidateBYOCNAME implements OrganizationDNSProvisioner. Resolves

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
@@ -1253,6 +1253,64 @@ func TestProvisionFreeSubdomain_WritesWildcardREPLACE(t *testing.T) {
 	}
 }
 
+// TestProvisionFreeSubdomain_PrefersPoolWriter locks the #4218 fix: when a
+// dedicated PoolWriter (central pdns.openova.io) is wired, the pool-domain
+// console A-record write MUST go to the pool server, NOT the Sovereign-local
+// Writer (powerdns.powerdns.svc) — which has no omani.* zone and would 404.
+// The local Writer must receive ZERO requests for this pool write.
+func TestProvisionFreeSubdomain_PrefersPoolWriter(t *testing.T) {
+	var localHits, poolHits int
+	localSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		localHits++
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer localSrv.Close()
+	var poolBody string
+	poolSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		poolHits++
+		poolBody = readAll(r.Body)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer poolSrv.Close()
+
+	p := DefaultOrganizationDNSProvisioner{
+		Writer:     NewPowerDNSWriter(localSrv.URL, "local-key"),
+		PoolWriter: NewPowerDNSWriter(poolSrv.URL, "central-key"),
+	}
+	if err := p.ProvisionFreeSubdomain(context.Background(), "f4179close", "omani.works", "212.72.24.33"); err != nil {
+		t.Fatalf("ProvisionFreeSubdomain: %v", err)
+	}
+	if poolHits != 1 {
+		t.Errorf("expected exactly 1 write to the CENTRAL pool pdns, got %d", poolHits)
+	}
+	if localHits != 0 {
+		t.Errorf("regression (#4218): pool-domain write leaked to the Sovereign-LOCAL pdns (%d hits) — would 404 (no omani.works zone)", localHits)
+	}
+	if !strings.Contains(poolBody, `"name":"console.f4179close.omani.works."`) {
+		t.Errorf("central pdns did not receive the console A record\nbody: %s", poolBody)
+	}
+}
+
+// TestProvisionFreeSubdomain_FallsBackToLocalWriter locks the single-PowerDNS
+// Sovereign back-compat path: with no PoolWriter wired, the free-subdomain
+// write uses the local Writer (the pool IS the local zone there).
+func TestProvisionFreeSubdomain_FallsBackToLocalWriter(t *testing.T) {
+	var localHits int
+	localSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		localHits++
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer localSrv.Close()
+
+	p := DefaultOrganizationDNSProvisioner{Writer: NewPowerDNSWriter(localSrv.URL, "local-key")}
+	if err := p.ProvisionFreeSubdomain(context.Background(), "demo", "t01.omani.works", "212.72.24.33"); err != nil {
+		t.Fatalf("ProvisionFreeSubdomain: %v", err)
+	}
+	if localHits != 1 {
+		t.Errorf("expected the single-PowerDNS fallback to write to the local pdns, got %d hits", localHits)
+	}
+}
+
 // Read-once ioutil-equivalent helper for body inspection in tests.
 func readAll(r io.Reader) string {
 	b, _ := io.ReadAll(r)

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -693,6 +693,42 @@ spec:
             # CATALYST_POWERDNS_API_URL above).
             - name: CATALYST_POWERDNS_SERVER_ID
               value: "localhost"
+            # ── #4218 — CENTRAL pool-domain PowerDNS (pdns.openova.io) ─────────
+            # The org-tenant DNS provisioner writes each new Org's pool
+            # subdomain A-record `console.<slug>.<omani-pool>` so the
+            # fresh-signup redirect lands on a host that RESOLVES (the #4179
+            # funnel landing). That record belongs to the SHARED omani.*
+            # subdomain pool, authoritative on the CENTRAL PowerDNS at
+            # pdns.openova.io — NOT the Sovereign-LOCAL powerdns.powerdns.svc
+            # above (which hosts only the Sovereign's own FQDN zone and 404s a
+            # PATCH against an omani.works zone it doesn't have). These POOL env
+            # vars are INDEPENDENT of the LOCAL CATALYST_POWERDNS_API_* pair —
+            # the provisioner prefers the pool writer for free-subdomain writes
+            # and keeps the local writer for the #827/#829 multi-zone admin
+            # flow. When the pool env is unset (a single-PowerDNS Sovereign
+            # where the pool IS the local zone) the provisioner falls back to
+            # the local writer automatically (main.go org-tenant wiring).
+            #
+            # DUAL-MODE CONTRACT — a literal value (NOT a Helm directive) so the
+            # contabo Kustomize build of this file stays clean; per-Sovereign
+            # override via the HelmRelease overlay env patch (same pattern as
+            # CATALYST_POWERDNS_API_URL above).
+            - name: CATALYST_POOL_POWERDNS_API_URL
+              value: "https://pdns.openova.io"
+            # CATALYST_POOL_POWERDNS_API_KEY — the CENTRAL pdns.openova.io key,
+            # mirrored into catalyst-system as `pool-powerdns-api-credentials`
+            # by the #4218 reflector PULL-stub (templates/pool-powerdns-
+            # credentials-host-bridge.yaml; source cert-manager/powerdns-api-
+            # credentials). optional=true so the Pod schedules pre-reflection;
+            # an empty key degrades the org-tenant write to the no-op DNS
+            # provisioner (logged) until reflector lands the key — self-healing
+            # on the next reconcile, never a wedge.
+            - name: CATALYST_POOL_POWERDNS_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: pool-powerdns-api-credentials
+                  key: api-key
+                  optional: true
             # ── /auth/handover Keycloak service-account (issue #606) ──────────
             # CATALYST_KC_ADDR — Keycloak base URL. Defaults to in-cluster
             # service FQDN in code; override here for non-standard Sovereign

--- a/products/catalyst/chart/templates/pool-powerdns-credentials-host-bridge.yaml
+++ b/products/catalyst/chart/templates/pool-powerdns-credentials-host-bridge.yaml
@@ -1,0 +1,76 @@
+{{- /*
+Pool-domain PowerDNS credential bridge into catalyst-system (#4218).
+
+WHY THIS FILE EXISTS
+====================
+On a production Sovereign the catalyst-api Pod runs in `catalyst-system` and
+its org-tenant DNS provisioner must write the per-Org pool subdomain A-record
+`console.<slug>.<omani-pool>` (e.g. console.f4179close.omani.works) so the
+fresh-signup redirect lands on a host that RESOLVES. That record is NOT on the
+Sovereign-LOCAL PowerDNS (`powerdns.powerdns.svc`, authoritative only for the
+Sovereign's own FQDN, e.g. omantel.biz) — it belongs to the SHARED omani.*
+subdomain pool, which is authoritative on the CENTRAL PowerDNS at
+`https://pdns.openova.io`.
+
+So the provisioner needs the CENTRAL pool key, wired into catalyst-api as
+CATALYST_POOL_POWERDNS_API_KEY (api-deployment.yaml). That key already lives on
+every Sovereign as `cert-manager/powerdns-api-credentials` (clusters/_template/
+sovereign-tls/powerdns-api-credentials.yaml — the ${POWERDNS_API_KEY} central
+key bp-cert-manager-powerdns-webhook uses for DNS-01 against pdns.openova.io).
+But it is NOT present in `catalyst-system`: the cert-manager source only opts
+reflection into `catalyst-system` (added in the same #4218 change) and the
+bp-powerdns LOCAL secret never reaches catalyst-system at all.
+
+THE SEAM — a reflector PULL stub (rename + mirror)
+==================================================
+This STUB Secret carries the explicit
+`reflector.v1.k8s.emberstack.com/reflects: cert-manager/powerdns-api-credentials`
+annotation. bp-reflector copies the source's bytes into this stub, renaming
+`powerdns-api-credentials` → `pool-powerdns-api-credentials` in catalyst-system
+and keeping it in sync. This is the SAME cross-namespace pull idiom as
+platform/powerdns-admin/chart/templates/pdns-api-credentials-mirror.yaml and
+platform/sso-bridge/chart/templates/secret-kc-credentials-mirror.yaml.
+
+The distinct destination NAME (`pool-powerdns-api-credentials`, not
+`powerdns-api-credentials`) deliberately avoids any collision with the
+Sovereign-LOCAL `powerdns-api-credentials` (which bp-powerdns reflects into the
+`catalyst` ns). The two keys are DIFFERENT credentials for DIFFERENT
+authoritative servers; keeping the names distinct keeps the local-vs-central
+write targets unambiguous.
+
+EMPTY-SEED TRAP AVOIDED (reference_reflector_reflects_mode_preserves_empty_seed)
+===============================================================================
+reflector 'reflects' mode copies ONLY source keys ABSENT in the destination —
+so this stub MUST NOT seed an `api-key` value (no `data:`/`stringData:` block).
+reflector fills it within a reconcile interval once the source exists. The
+api-deployment.yaml secretKeyRef is `optional: true` so the Pod schedules
+pre-reflection and the empty-key path degrades to the no-op DNS provisioner
+(logged) until reflector lands the key — strictly better than a wedge, and
+self-healing on the next reconcile.
+
+GATING
+======
+Rendered only when .Values.poolPowerdnsBridge.enabled (default true on a
+franchised Sovereign). Flip false on Catalyst-Zero / contabo (no omani.* pool
+funnel runs there, and there is no separate central key to pull). Independent
+of keycloakHostBridge / giteaAdminBridge.
+*/}}
+{{- if .Values.poolPowerdnsBridge.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.poolPowerdnsBridge.destSecretName | default "pool-powerdns-api-credentials" }}
+  namespace: {{ .Values.poolPowerdnsBridge.destNamespace | default "catalyst-system" }}
+  labels:
+    catalyst.openova.io/blueprint: bp-catalyst-platform
+    catalyst.openova.io/component: pool-powerdns-credentials-bridge
+    app.kubernetes.io/part-of: catalyst
+    app.kubernetes.io/managed-by: flux
+  annotations:
+    catalyst.openova.io/mirrored-from: {{ printf "%s/%s (CENTRAL pdns.openova.io pool key; #4218)" (.Values.poolPowerdnsBridge.sourceNamespace | default "cert-manager") (.Values.poolPowerdnsBridge.sourceSecretName | default "powerdns-api-credentials") | quote }}
+    # Survive helm uninstall so the catalyst-system contract is stable across
+    # re-installs; reflector re-fills on every source reconcile.
+    helm.sh/resource-policy: keep
+    reflector.v1.k8s.emberstack.com/reflects: "{{ .Values.poolPowerdnsBridge.sourceNamespace | default "cert-manager" }}/{{ .Values.poolPowerdnsBridge.sourceSecretName | default "powerdns-api-credentials" }}"
+type: Opaque
+{{- end }}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -297,6 +297,33 @@ keycloakHostBridge:
   bitnamiSecretNamespace: mgmt
   bitnamiSecretName: keycloak-x-keycloak-x-mgmt-vcluster
   masterAdminUser: admin
+# ─── Pool-domain PowerDNS credential bridge (#4218) ────────────────────
+# The org-tenant DNS provisioner writes the per-Org pool subdomain A-record
+# (console.<slug>.<omani-pool>) on the CENTRAL authoritative PowerDNS
+# (pdns.openova.io), NOT the Sovereign-LOCAL one. It needs the CENTRAL pool
+# key in `catalyst-system` (catalyst-api's namespace). That key lives on every
+# Sovereign as `cert-manager/powerdns-api-credentials` (the ${POWERDNS_API_KEY}
+# central key) but is NOT present in catalyst-system. This bridge ships a
+# reflector PULL-stub that renames + mirrors it as
+# `catalyst-system/pool-powerdns-api-credentials`, which the catalyst-api
+# Deployment consumes via CATALYST_POOL_POWERDNS_API_KEY (optional secretKeyRef).
+# See templates/pool-powerdns-credentials-host-bridge.yaml for the full rationale.
+poolPowerdnsBridge:
+  # Master gate. true on a franchised Sovereign (the omani.* funnel runs
+  # there). Flip false on Catalyst-Zero / contabo (no separate central pool
+  # key to pull; no pool funnel).
+  enabled: true
+  # Source — the CENTRAL pdns.openova.io key, seeded into cert-manager by the
+  # sovereign-tls Kustomization (clusters/_template/sovereign-tls/
+  # powerdns-api-credentials.yaml). That source carries the matching
+  # reflection-allowed opt-in for catalyst-system.
+  sourceNamespace: cert-manager
+  sourceSecretName: powerdns-api-credentials
+  # Destination — catalyst-api's namespace + a NAME distinct from the
+  # Sovereign-LOCAL `powerdns-api-credentials` so the local-vs-central write
+  # targets stay unambiguous.
+  destNamespace: catalyst-system
+  destSecretName: pool-powerdns-api-credentials
 # ─── Gitea admin-secret host bridge (#3811, Refs #3642) ────────────────
 # #3642 moved bp-gitea INTO the mgmt vCluster (vc-mgmt). The gitea chart's
 # `gitea-admin-secret` (templates/admin-secret.yaml, random `randAlphaNum


### PR DESCRIPTION
## What & why

The FINAL layer of the #1 customer bug (#4179). A fresh customer signup on a Sovereign creates the Org with the correct redirect host `console.<slug>.<omani-pool>`, but that host is **NXDOMAIN** because the org-tenant DNS provisioner never writes the pool A-record. #4216 fixed the env NAME; this fixes the two remaining root causes (no workaround, no manual record writes):

- **Layer A** — the central PowerDNS key was absent from `catalyst-system` → `NewPowerDNSWriter(url, "")` returned `nil` → no-op provisioner.
- **Layer B** — even with a key, the single writer pointed at the **Sovereign-LOCAL** PowerDNS (`powerdns.powerdns.svc`, authoritative only for the Sovereign's own FQDN), which 404s a PATCH against an `omani.works` zone it does not host. The record belongs to the **shared `omani.*` pool**, authoritative on the **central** `pdns.openova.io`.

## Changes

**Code** (`organization_dns.go`, `cmd/api/main.go`)
- `DefaultOrganizationDNSProvisioner` gains a dedicated `PoolWriter` (central pdns) that is **preferred** for `ProvisionFreeSubdomain`; the local `Writer` stays for the #827/#829 multi-zone admin flow.
- `main.go` wires the pool writer from a NEW env pair `CATALYST_POOL_POWERDNS_API_URL` / `CATALYST_POOL_POWERDNS_API_KEY`, **independent** of the local `CATALYST_POWERDNS_API_*` (local URL never repointed → `omantel.biz` writes untouched). No pool env (single-PowerDNS Sovereign where the pool IS the local zone) → automatic fallback to the local writer.

**Deploy wiring** (`chart/templates/api-deployment.yaml`, `values.yaml`)
- catalyst-api Deployment renders `CATALYST_POOL_POWERDNS_API_URL` (literal `https://pdns.openova.io`, dual-mode-safe) + `CATALYST_POOL_POWERDNS_API_KEY` via `optional` secretKeyRef to `pool-powerdns-api-credentials`.
- The kustomize (contabo Catalyst-Zero) twin is **intentionally untouched** — no `omani.*` pool funnel runs there.

**Secret availability** (`pool-powerdns-credentials-host-bridge.yaml`, `clusters/_template/sovereign-tls/powerdns-api-credentials.yaml`)
- A reflector **PULL-stub** renames + mirrors the CENTRAL `cert-manager/powerdns-api-credentials` key into `catalyst-system` as `pool-powerdns-api-credentials`; the source gains the matching `catalyst-system` reflection-allowed opt-in.
- The stub seeds **NO** `api-key` value (avoids the reflector empty-seed trap) and the consumer secretKeyRef is `optional` so the Pod schedules pre-reflection and self-heals on reconcile.

## Seam choice — inline provisioner, not `core/pool-domain-manager`

The org-tenant pipeline already owns the `ProvisionFreeSubdomain` step and atomically writes all per-Org host records (console, wordpress, keycloak, …) at the right pipeline state. Routing through the separate `pool-domain-manager` reconciler would add a cross-service hop + new failure modes for no gain. The minimal correct fix is to give the inline provisioner the right writer for pool domains.

## Tests
- `TestProvisionFreeSubdomain_PrefersPoolWriter` — pool write goes to the central server, **zero** leak to the local writer.
- `TestProvisionFreeSubdomain_FallsBackToLocalWriter` — single-PowerDNS back-compat.
- Existing `TestProvisionFreeSubdomain_WritesWildcardREPLACE` (#4075) still green.
- `go build ./...`, full `internal/handler` test pkg, `helm template`, `kubectl kustomize build` all pass.

## Verification status
Code + chart + secret wiring landed and unit-green. **Not yet live-verified** — the roll requires the deploy-bot to rebuild the catalyst-api image + bump the bp-catalyst-platform pin, then Flux reconcile on the Sovereign (cold ghcr pull ~10min). The live signed-in funnel walk on `console.<slug>.omani.works` is the #4179 close gate and follows the roll.

Refs #4218 #4179