### PR TITLE
fix(#4220): un-break demo Org WordPress — bp-keycloak 1.5.1 jumps the stale ghcr 1.5.0 + bp-cnpg 1.0.11 skips the webhook-gate in webhook-less mode

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -221,7 +221,12 @@ spec:
       #         wedged Ready=False (live dep 4635277cae4ffed9 region-B). Fix:
       #         declare browser-no-idp its OWN forms + conditional-OTP subflows
       #         (OTP preserved); original `browser` flow untouched.
-      version: 1.4.38
+      # 1.5.1 (#4220): jump above the STALE ghcr bp-keycloak:1.5.0 (published
+      #         2026-05-10, pre-proxy-dockerhub-fix) so the per-Org HR's
+      #         chart.spec.version:"*" stops resolving to it (SemVer 1.5.0 >
+      #         1.4.38) and its non-proxied bitnamilegacy images stop tripping
+      #         harbor-proxy-pull. Chart content byte-identical to 1.4.38.
+      version: 1.5.1
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/clusters/_template/bootstrap-kit/16-cnpg.yaml
+++ b/clusters/_template/bootstrap-kit/16-cnpg.yaml
@@ -91,7 +91,10 @@ spec:
       # into every instance pod both pull harbor-proxied — bare ghcr.io ref
       # flaky-DNS ImagePullBackOff'd the cnpg-pair replica on hw126 region-B.
       # #3648 — lockstep with platform/cnpg Chart.yaml + blueprint.yaml 1.0.10.
-      version: 1.0.10
+      # 1.0.11 (#4220): the webhook readiness-gate (Job/RBAC) + cert-bootstrap
+      #         now SKIP rendering in webhook-less mode so the un-owned Helm-hook
+      #         Job stops getting flux-managed-denied on per-Org installs.
+      version: 1.0.11
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg

--- a/platform/cnpg/blueprint.yaml
+++ b/platform/cnpg/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-4-1-data-services
 spec:
-  version: 1.0.10
+  version: 1.0.11
   card:
     title: CloudNativePG
     summary: |

--- a/platform/cnpg/chart/Chart.yaml
+++ b/platform/cnpg/chart/Chart.yaml
@@ -20,7 +20,24 @@ name: bp-cnpg
 # webhookGate Job image proxied to proxy-dockerhub in the same pass.
 # #3648 — bumped in lockstep with blueprint.yaml spec.version (producesInstances
 # declaration) + the 16-cnpg.yaml bootstrap-kit pin.
-version: 1.0.10
+#
+# 1.0.11 (#4220, 2026-06-24): the G53 webhook-gate Job + G21 webhook-cert
+# bootstrap now SKIP RENDERING in webhook-LESS mode. A per-Org bp-cnpg install
+# sets cloudnative-pg.webhook.{mutating,validating}.create=false (#4143/#4201:
+# the per-Org operator must NOT fight the platform cnpg-system operator for the
+# cluster-singleton webhook configs). In that mode there is no webhook config to
+# gate, AND the gate Job — created directly by Helm with no Flux owner — was
+# DENIED by the flux-managed Kyverno Enforce policy
+# (`workload-must-be-flux-managed`), so the bp-cnpg HelmRelease InstallFailed and
+# the demo Org's WordPress (+ newapi/openclaw/stalwart) wedged Ready=False on
+# `dependency bp-cnpg is not ready` (live omantel.biz dep 4635277cae4ffed9,
+# #4220). New templates/_helpers.tpl `bp-cnpg.webhookGateEnabled` /
+# `bp-cnpg.webhookConfigsCreated` centralise the decision: the gate renders ONLY
+# when webhookGate.enabled (default true) AND the subchart is actually creating
+# the webhook configs. This is a render-skip, NOT a policy exemption — the
+# flux-managed guardrail stays fully in force. Single-operator installs
+# (webhook configs created) keep the gate unchanged. Refs #4201 #4143.
+version: 1.0.11
 description: |
   Catalyst-curated Blueprint umbrella chart for CloudNativePG. Depends on
   the upstream `cloudnative-pg` chart as a Helm subchart so

--- a/platform/cnpg/chart/templates/_helpers.tpl
+++ b/platform/cnpg/chart/templates/_helpers.tpl
@@ -1,0 +1,59 @@
+{{- /*
+1.0.11 (#4220, 2026-06-24): single source of truth for "should the webhook
+readiness-gate render at all?".
+
+The G53 (#2604) webhook-gate Job + its RBAC, and the G21 (#2570) webhook-cert
+bootstrap, ALL exist solely to cover the cluster-singleton webhook
+(cnpg-mutating-webhook-configuration / cnpg-validating-webhook-configuration +
+Service cnpg-webhook-service) coming up cleanly. A per-Org bp-cnpg install runs
+WEBHOOK-LESS (#4143 / #4201: organization_gitops.go sets
+cloudnative-pg.webhook.{mutating,validating}.create=false so the per-Org
+operator never fights the platform cnpg-system operator for the cluster
+singletons). In that mode:
+
+  - There is NO webhook config for the gate to poll → the Job would spin its
+    full 300s budget and FAIL the post-install hook every time.
+  - WORSE: the gate Job is created directly by Helm (no Flux ownerReference /
+    no `app.kubernetes.io/managed-by: flux` label), so the `flux-managed`
+    Kyverno Enforce policy (`workload-must-be-flux-managed`) DENIES it at
+    admission → the bp-cnpg HelmRelease InstallFailed → the demo Org's
+    WordPress (+ newapi/openclaw/stalwart) wedged Ready=False on
+    `dependency bp-cnpg is not ready` (live on omantel.biz dep
+    4635277cae4ffed9, #4220).
+
+So the gate (and the cert-bootstrap) MUST NOT render when the webhook configs
+aren't being created. This helper centralises that decision:
+
+  webhookGateEnabled = (webhookGate.enabled, default true)
+                       AND (the subchart is actually creating the webhook
+                            configs — i.e. NOT webhook-less)
+
+Webhook-less is detected when BOTH cloudnative-pg.webhook.mutating.create AND
+cloudnative-pg.webhook.validating.create are explicitly false. If an operator
+genuinely wants the gate in some bespoke topology they can still force it on
+via webhookGate.enabled: true paired with the webhook configs enabled; setting
+webhookGate.enabled: false always skips. This is a render-skip, not a policy
+exemption — the flux-managed guardrail stays fully in force.
+*/}}
+{{- define "bp-cnpg.webhookConfigsCreated" -}}
+{{- $cnpg := (index .Values "cloudnative-pg") | default dict -}}
+{{- $wh := (index $cnpg "webhook") | default dict -}}
+{{- $mut := (index $wh "mutating") | default dict -}}
+{{- $val := (index $wh "validating") | default dict -}}
+{{- /* Upstream default for both is `create: true`; treat an unset value as
+       true so existing single-operator installs keep the gate. Only an
+       EXPLICIT false on both flips us into webhook-less mode. */ -}}
+{{- $mutCreate := true -}}
+{{- if hasKey $mut "create" -}}{{- $mutCreate = $mut.create -}}{{- end -}}
+{{- $valCreate := true -}}
+{{- if hasKey $val "create" -}}{{- $valCreate = $val.create -}}{{- end -}}
+{{- if and (not $mutCreate) (not $valCreate) -}}false{{- else -}}true{{- end -}}
+{{- end -}}
+
+{{- define "bp-cnpg.webhookGateEnabled" -}}
+{{- $gate := .Values.webhookGate | default dict -}}
+{{- $gateEnabled := true -}}
+{{- if hasKey $gate "enabled" -}}{{- $gateEnabled = $gate.enabled -}}{{- end -}}
+{{- $configsCreated := eq (include "bp-cnpg.webhookConfigsCreated" .) "true" -}}
+{{- if and $gateEnabled $configsCreated -}}true{{- else -}}false{{- end -}}
+{{- end -}}

--- a/platform/cnpg/chart/templates/webhook-cert-bootstrap.yaml
+++ b/platform/cnpg/chart/templates/webhook-cert-bootstrap.yaml
@@ -44,7 +44,12 @@ Three resources:
 Required: bp-cert-manager (chart 1.2.x+) must be Ready before bp-cnpg
 installs. The bootstrap-kit dependsOn chain already enforces this.
 */}}
-{{- if .Values.webhookCertBootstrap.enabled -}}
+{{- /* 1.0.11 (#4220): never bootstrap a webhook cert when the chart is NOT
+   creating the webhook configs (webhook-less per-Org install). Defaults to
+   disabled anyway (G59), but the extra guard means an overlay that flips
+   webhookCertBootstrap.enabled=true can't resurrect an un-owned Helm-hook Job
+   that the flux-managed policy would deny in webhook-less mode. */ -}}
+{{- if and .Values.webhookCertBootstrap.enabled (eq (include "bp-cnpg.webhookConfigsCreated" .) "true") -}}
 ---
 # 1. Self-signed Issuer (bootstrap-only)
 apiVersion: cert-manager.io/v1

--- a/platform/cnpg/chart/templates/webhook-gate-hook.yaml
+++ b/platform/cnpg/chart/templates/webhook-gate-hook.yaml
@@ -66,12 +66,15 @@ If the gate times out: bp-cnpg HR reports InstallFailed → Flux
 remediation retries (chart-spec install.remediation.retries) — same
 defense as the original G50 retry tuning. Both layers protect.
 */}}
+{{- /*
+1.0.11 (#4220): skip the gate entirely in webhook-LESS mode (per-Org install
+sets cloudnative-pg.webhook.{mutating,validating}.create=false). See
+templates/_helpers.tpl "bp-cnpg.webhookGateEnabled" — there is nothing for the
+gate to poll, and the un-owned Helm-hook Job is denied by the flux-managed
+Kyverno policy, wedging the whole Org cascade (#4220).
+*/}}
 {{- $gate := .Values.webhookGate | default dict -}}
-{{- $enabled := true -}}
-{{- if hasKey $gate "enabled" -}}
-{{-   $enabled = $gate.enabled -}}
-{{- end -}}
-{{- if $enabled }}
+{{- if eq (include "bp-cnpg.webhookGateEnabled" .) "true" }}
 {{- $svcName := (($gate.service).name) | default "cnpg-webhook-service" -}}
 {{- $svcNs := (($gate.service).namespace) | default "cnpg-system" -}}
 {{- $mutName := $gate.mutatingWebhookName | default "cnpg-mutating-webhook-configuration" -}}

--- a/platform/cnpg/chart/templates/webhook-gate-rbac.yaml
+++ b/platform/cnpg/chart/templates/webhook-gate-rbac.yaml
@@ -8,12 +8,10 @@ Scoped to:
 
 Webhook-config GET is cluster-scoped → ClusterRole + ClusterRoleBinding.
 */}}
+{{- /* 1.0.11 (#4220): gate the RBAC in lockstep with the Job — webhook-less
+   per-Org installs render neither (see templates/_helpers.tpl). */ -}}
 {{- $gate := .Values.webhookGate | default dict -}}
-{{- $enabled := true -}}
-{{- if hasKey $gate "enabled" -}}
-{{-   $enabled = $gate.enabled -}}
-{{- end -}}
-{{- if $enabled }}
+{{- if eq (include "bp-cnpg.webhookGateEnabled" .) "true" }}
 {{- $svcNs := (($gate.service).namespace) | default "cnpg-system" -}}
 apiVersion: v1
 kind: ServiceAccount

--- a/platform/cnpg/chart/tests/webhook-gate-render.sh
+++ b/platform/cnpg/chart/tests/webhook-gate-render.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# bp-cnpg — #4220 render gate for the webhook readiness-gate skip in
+# webhook-LESS mode.
+#
+# A per-Org bp-cnpg install runs webhook-less (#4143/#4201:
+# cloudnative-pg.webhook.{mutating,validating}.create=false) so the per-Org
+# operator never fights the platform cnpg-system operator for the
+# cluster-singleton webhook configs. In that mode the G53 webhook-gate Job +
+# RBAC and the G21 webhook-cert bootstrap MUST NOT render — the gate Job is
+# created directly by Helm with no Flux owner, so the flux-managed Kyverno
+# Enforce policy DENIES it and the bp-cnpg HelmRelease InstallFailed, wedging
+# the whole Org cascade (live omantel.biz dep 4635277cae4ffed9, #4220).
+#
+# This test asserts:
+#   1. DEFAULT (single-operator, webhook configs created): the webhook-gate Job
+#      renders (gate behaviour preserved — no regression).
+#   2. WEBHOOK-LESS (both webhook.create=false): ZERO webhook-gate Job, ZERO
+#      gate RBAC, ZERO cert-bootstrap resources.
+#   3. EXPLICIT webhookGate.enabled=false: ZERO gate even with webhook configs on.
+#
+# Usage: bash tests/webhook-gate-render.sh [CHART_DIR]
+set -euo pipefail
+
+CHART_DIR="$(cd "${1:-$(dirname "$0")/..}" && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Build deps if the upstream subchart isn't vendored yet (CI builds before
+# tests, but support a clean local checkout too).
+if [ ! -d "$CHART_DIR/charts" ] || ! ls "$CHART_DIR"/charts/cloudnative-pg-*.tgz >/dev/null 2>&1; then
+  helm dependency build "$CHART_DIR" >/dev/null 2>&1 || true
+fi
+
+render() {
+  # $1 = output file, rest = extra --set args
+  local out="$1"; shift
+  helm template bp-cnpg "$CHART_DIR" \
+    --namespace org-demo \
+    "$@" > "$out" 2>"$TMP/err" || { echo "helm template FAILED:"; cat "$TMP/err"; exit 1; }
+}
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+# ── Case 1: DEFAULT — webhook configs created → gate Job MUST render ─────────
+render "$TMP/default.yaml"
+if ! grep -q "bp-cnpg-webhook-gate" "$TMP/default.yaml"; then
+  fail "default render is missing the webhook-gate Job (regression — single-operator installs still need the gate)"
+fi
+echo "PASS: default render emits the webhook-gate Job"
+
+# ── Case 2: WEBHOOK-LESS — both webhook.create=false → ZERO gate/cert ────────
+render "$TMP/webhookless.yaml" \
+  --set "cloudnative-pg.webhook.mutating.create=false" \
+  --set "cloudnative-pg.webhook.validating.create=false"
+if grep -q "webhook-gate" "$TMP/webhookless.yaml"; then
+  echo "--- offending render ---"; grep -n "webhook-gate" "$TMP/webhookless.yaml" | head
+  fail "webhook-less render STILL emits webhook-gate resources (flux-managed will deny the un-owned hook Job → #4220)"
+fi
+if grep -qE "cnpg-webhook-cert-wait|cnpg-webhook-bootstrap-issuer|cnpg-webhook-cert-bootstrap" "$TMP/webhookless.yaml"; then
+  fail "webhook-less render STILL emits webhook-cert-bootstrap resources"
+fi
+echo "PASS: webhook-less render emits ZERO webhook-gate + ZERO cert-bootstrap resources"
+
+# ── Case 3: EXPLICIT webhookGate.enabled=false → ZERO gate ──────────────────
+render "$TMP/explicit-off.yaml" --set "webhookGate.enabled=false"
+if grep -q "webhook-gate" "$TMP/explicit-off.yaml"; then
+  fail "webhookGate.enabled=false STILL emits the gate Job"
+fi
+echo "PASS: explicit webhookGate.enabled=false suppresses the gate"
+
+echo "All bp-cnpg webhook-gate render assertions passed (#4220)."

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.38
+  version: 1.5.1
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for Organizations, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -384,7 +384,26 @@ name: bp-keycloak
 # test (tests/realm-flow-subflow-resolution.sh) statically reproduces config-
 # cli's subflow-resolution rule across all realm templates so this class can
 # never regress silently again.
-version: 1.4.38
+# 1.5.1 (#4220, 2026-06-24): JUMP THE VERSION ABOVE THE STALE 1.5.0. An OLD
+# bp-keycloak:1.5.0 OCI artifact (published 2026-05-10 from the qa-loop iter-12
+# `version: 1.5.0` line — see the 1.5.0 changelog stanza further down) still
+# sits on ghcr.io/openova-io. The per-Org bp-keycloak HelmRelease pins
+# `chart.spec.version: "*"`, and SemVer ranks 1.5.0 ABOVE every 1.4.x — so Flux
+# resolved `*` to the STALE 1.5.0, which predates the #3263/#2737 proxy-dockerhub
+# image fix (landed 1.4.23, 2026-06-11). That stale chart still references bare
+# `docker.io/bitnamilegacy/…` images, so the `harbor-proxy-pull` Kyverno Enforce
+# policy DENIED the bp-keycloak StatefulSet initContainer + the
+# bp-keycloak-postgresql container on the demo Org of the permanent omantel.biz
+# Sovereign (dep 4635277cae4ffed9, verified live 2026-06-24) → the customer's
+# WordPress (+ newapi/openclaw/stalwart) stayed Ready=False on `dependency
+# bp-keycloak is not ready`. The DURABLE fix is to publish a tag that SemVer-ranks
+# ABOVE 1.5.0 carrying the CURRENT values.yaml (every Bitnami image already routed
+# through `harbor.openova.io/proxy-dockerhub/bitnamilegacy/…`, matching the
+# allowed glob `*/proxy-*/*`), so `*` resolves to THIS chart and the proxied
+# images pass admission. No chart-content change beyond the version line + this
+# changelog — the 1.4.38 templates/values are byte-identical and already
+# proxy-compliant. Refs #3785 (sibling proxy-class defect for the WP image).
+version: 1.5.1
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so


### PR DESCRIPTION
## Problem (live on the PERMANENT omantel.biz Sovereign, dep `4635277cae4ffed9`)

The demo Org's customer **WordPress is DOWN** (+ newapi/openclaw/stalwart) — all stuck on `dependency bp-keycloak is not ready`. Two upstream HelmReleases failed Helm install via Kyverno admission denies (verified live 2026-06-24):

### Defect A — bp-keycloak `*` → stale 1.5.0 with non-proxied images
The per-Org `bp-keycloak` HR pins `chart.spec.version: "*"` (org overlay defaults every chart version to `*` — `organization_gitops.go` `withVersionDefaults`). An **OLD `bp-keycloak:1.5.0` OCI artifact** (published **2026-05-10**) still sits on `ghcr.io/openova-io`. SemVer ranks **`1.5.0 > 1.4.38`**, so Flux resolved `*` to the stale `1.5.0` — which **predates the proxy-dockerhub image fix** that landed in `1.4.23` on **2026-06-11**. That stale chart references bare `docker.io/bitnamilegacy/…` images, so `harbor-proxy-pull` (Kyverno Enforce) **DENIED** the `bp-keycloak` StatefulSet `initContainers/0/image` + the `bp-keycloak-postgresql` container.

**Root fix:** bump the source chart **`1.4.38 → 1.5.1`** (above the stale `1.5.0`) carrying the CURRENT `values.yaml` — every Bitnami image already routes through `harbor.openova.io/proxy-dockerhub/bitnamilegacy/…` (matches the allowed glob `*/proxy-*/*`). `*` now resolves to `1.5.1` and the proxied images pass admission. **No chart-content change beyond the version line + changelog** — the templates/values are byte-identical and already proxy-compliant. Render-verified in tenant mode: all 4 images (keycloak app, init container, postgresql, config-cli) proxied; **13/13 keycloak chart tests green**.

### Defect B — bp-cnpg webhook-gate Helm-hook denied by flux-managed
A per-Org `bp-cnpg` install runs **webhook-less** (#4143/#4201: `cloudnative-pg.webhook.{mutating,validating}.create=false` so the per-Org operator never fights the platform `cnpg-system` operator for the cluster-singleton webhook configs). But the G53 webhook-gate Job + RBAC and the G21 webhook-cert bootstrap were gated on the **separate** `webhookGate.enabled` / `webhookCertBootstrap.enabled` flags — NOT on the webhook-create state — so the gate Job still rendered. It is created directly by Helm with **no Flux owner**, so `flux-managed` (`workload-must-be-flux-managed`) **DENIED** it → `bp-cnpg` HR `InstallFailed`.

**Root fix:** new `platform/cnpg/chart/templates/_helpers.tpl` (`bp-cnpg.webhookGateEnabled` / `bp-cnpg.webhookConfigsCreated`) centralises the decision — the gate (and cert-bootstrap) render **only** when `webhookGate.enabled` (default true) **AND** the subchart is actually creating the webhook configs. Webhook-less per-Org installs emit **ZERO** gate/cert resources. **This is a render-skip, NOT a policy exemption** — the `flux-managed` guardrail stays fully in force. Single-operator installs (webhook configs created) keep the gate unchanged. Chart `1.0.10 → 1.0.11` + blueprint.yaml in lockstep.

## What this PR does NOT do
- Does NOT disable, delete, exempt, or namespace-carve-out any Kyverno policy. The policies are correct sovereignty guardrails; the **charts** are made to comply.

## Validation
- `helm lint` clean on both charts; chart `charts/` deps gitignored.
- `bp-keycloak`: 13/13 `chart/tests/*.sh` green after the bump (no regression). Tenant-mode render: 0 non-proxied images.
- `bp-cnpg`: new `chart/tests/webhook-gate-render.sh` asserts (1) default render still emits the gate, (2) webhook-less render emits ZERO gate/cert, (3) explicit `webhookGate.enabled=false` suppresses the gate — all green; existing `observability-toggle.sh` green.
- No Go change (org_gitops.go already carries #4201's webhook-less values); `go build ./internal/handler/` clean.

## Delivery note
Per "merged ≠ delivered": after the blueprint-release pipeline republishes `bp-keycloak:1.5.1` + `bp-cnpg:1.0.11`, the demo Org HRs must roll to them and go Ready before this is done. Live HR-Ready + WordPress screenshot to follow on the issue.

Refs #4220 #4201 #4143 #3785
