### PR TITLE
feat(bp-agenity): durable per-Org install + Cilium-gateway CNP so agenity.<slug>.<pool>/app/ serves the 0.9.6 dashboard

### DIFF
--- a/products/agenity/blueprint.yaml
+++ b/products/agenity/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.5.3
+  version: 0.5.4
   card:
     title: Agenity
     summary: |

--- a/products/agenity/chart/Chart.yaml
+++ b/products/agenity/chart/Chart.yaml
@@ -8,7 +8,13 @@ description: |
   (RBAC-scoped to the User's rights) to create more Applications in the
   User's own Organization — the north-star self-service journey.
 type: application
-version: 0.5.3
+# 0.5.3 -> 0.5.4 (#4180): add templates/cilium-ingress-networkpolicy.yaml so a
+# per-Org (pool-domain) install is REACHABLE through the Cilium Gateway. The
+# HTTPRoute alone routed the host but the gateway traffic carries the reserved
+# `ingress` entity that no K8s NetworkPolicy can admit — without the CNP every
+# external hit to agenity.<slug>.<pool> returned envoy 503 "upstream connect
+# error". appVersion (dashboard image) stays 0.9.6 — image bytes unchanged.
+version: 0.5.4
 # Bumped appVersion 0.9.5 -> 0.9.6 (#4118): the 0.9.5 image bytes are correct
 # (its /app dashboard bundle is byte-identical to a fresh build of the #745
 # source — verified by md5 on omantel.biz), but 0.9.5 was published BEFORE

--- a/products/agenity/chart/templates/cilium-ingress-networkpolicy.yaml
+++ b/products/agenity/chart/templates/cilium-ingress-networkpolicy.yaml
@@ -1,0 +1,48 @@
+{{- /*
+#4180: the Cilium Gateway path to Agenity is DEAD without this CNP — once
+the HTTPRoute (templates/httproute.yaml) attaches `agenity.<slug>.<pool>`
+to cilium-gateway-console, every external hit returns envoy 503
+"upstream connect error ... connection timeout" until a
+CiliumNetworkPolicy admits the gateway traffic. Root cause (identical to
+platform/newapi cilium-ingress-networkpolicy.yaml #3374 +
+platform/wordpress-tenant #3785 + the sso-bridge kube-apiserver entity
+saga): Cilium Gateway API traffic reaches the backend with the reserved
+`ingress` ENTITY identity (the Envoy proxy embedded in the cilium agent),
+which NO K8s NetworkPolicy selector (podSelector / namespaceSelector /
+ipBlock) can express. A `namespaceSelector: kube-system` is INERT for
+gateway traffic — the connection times out.
+
+CiliumNetworkPolicy fromEntities is the canonical, ADDITIVE expression:
+when both a K8s NetworkPolicy and a CNP select the same Pod the allow-sets
+UNION, so this only opens the gateway→agenity hop and leaves every other
+default-deny posture intact. The Agenity StatefulSet has historically
+shipped NO NetworkPolicy at all (the pod was reachable only through the
+in-cluster Service for the rtz platform install), so on a per-Org
+(pool-domain) Sovereign install where the host route is the ONLY ingress
+path this carve-out is what makes the dashboard reachable.
+
+Gated on the cilium.io/v2 Capabilities check (the #2988/#3102 idiom) so
+the chart still installs on CRD-less clusters (kind CI), and on
+networkPolicy.ingress.allowGatewayEntity so a non-Cilium overlay can opt
+out.
+*/ -}}
+{{- if and .Values.networkPolicy.enabled .Values.networkPolicy.ingress.allowGatewayEntity (.Capabilities.APIVersions.Has "cilium.io/v2") }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "agenity.fullname" . }}-gateway-ingress
+  labels:
+    {{- include "agenity.labels" . | nindent 4 }}
+    catalyst.openova.io/component: agenity-gateway-netpol
+spec:
+  endpointSelector:
+    matchLabels:
+      {{- include "agenity.selectorLabels" . | nindent 6 }}
+  ingress:
+    - fromEntities:
+        - ingress
+      toPorts:
+        - ports:
+            - port: {{ .Values.service.port | quote }}
+              protocol: TCP
+{{- end }}

--- a/products/agenity/chart/values.yaml
+++ b/products/agenity/chart/values.yaml
@@ -213,6 +213,24 @@ httpRoute:
     # in Location is unreachable behind a cloud ELB and hangs the browser.
     port: 443
 
+# ── NetworkPolicy (Cilium Gateway ingress carve-out) ──────────────────────
+# The HTTPRoute alone routes `agenity.<slug>.<pool>` to this Service, but on
+# a Cilium Sovereign the gateway traffic arrives with the reserved `ingress`
+# ENTITY identity that NO K8s NetworkPolicy selector can match — so without a
+# CiliumNetworkPolicy fromEntities:[ingress] the gateway→agenity hop is
+# default-denied and the browser sees envoy 503 "upstream connect error ...
+# connection timeout" (the #4180 / #3785 / #3374 failure class). This block
+# drives templates/cilium-ingress-networkpolicy.yaml, which is ADDITIVE
+# (unions with any K8s NetworkPolicy) and gated on the cilium.io/v2
+# Capabilities check so the chart still renders on a CRD-less kind cluster.
+networkPolicy:
+  enabled: true
+  ingress:
+    # allowGatewayEntity → emit the CiliumNetworkPolicy that admits the
+    # reserved `ingress` entity (the Cilium Gateway Envoy) to service.port.
+    # Disable only on a non-Cilium overlay that fronts agenity differently.
+    allowGatewayEntity: true
+
 # ── Persistence — chepherd runtime state + per-agent repo/cache ───────────
 # CSI-backed PVCs. storageClass empty = the cluster's default CSI class.
 # NEVER local-path (#3971): leaving storageClass empty resolves to the

--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -968,6 +968,7 @@ func main() {
 					OpenClaw:  os.Getenv("CATALYST_ORG_BP_OPENCLAW_VER"),
 					Stalwart:  os.Getenv("CATALYST_ORG_BP_STALWART_VER"),
 					NewAPI:    os.Getenv("CATALYST_ORG_BP_NEWAPI_VER"),
+					Agenity:   os.Getenv("CATALYST_ORG_BP_AGENITY_VER"),
 				},
 			}
 			// DNS provisioner — wraps PowerDNS for free-subdomain

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-23T18:56:05.652Z",
+  "generatedAt": "2026-06-24T00:49:28.745Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -11,7 +11,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "section": "pts-7-org-tenant",
       "depends": [
         "bp-external-secrets"
@@ -796,7 +796,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "section": "pts-9-disaster-recovery",
       "depends": [
         "bp-cnpg",
@@ -5511,7 +5511,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.4.12",
+      "version": "0.4.13",
       "section": "pts-7-org-tenant",
       "depends": [
         "bp-postgres",

--- a/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
@@ -78,6 +78,10 @@ type OrganizationChartVersions struct {
 	OpenClaw  string
 	Stalwart  string
 	NewAPI    string
+	// Agenity — the per-Org agentic dashboard (bp-agenity, #4180). Read
+	// from CATALYST_ORG_BP_AGENITY_VER; "*" when empty so Flux pulls the
+	// latest published chart (currently 0.5.4 / appVersion 0.9.6).
+	Agenity string
 }
 
 // WriteTenantOverlay implements OrganizationGitOpsWriter. Returns the
@@ -467,6 +471,11 @@ type orgTenantTemplateData struct {
 	WordPressHost string
 	OpenClawHost  string
 	MailHost      string
+	// AgenityHost — the per-Org agentic dashboard host
+	// (agenity.<slug>.<pool>), derived from ConsoleHost by swapping the
+	// `console.` prefix. Drives bp-agenity's httpRoute.hostnames so the
+	// chart attaches the route to cilium-gateway-console (#4180).
+	AgenityHost string
 	AdminEmail    string
 	CompanyName   string
 	DomainMode    string
@@ -569,6 +578,7 @@ func renderOrganizationOverlay(rec store.OrganizationProvisionRecord, versions O
 	wpHost := strings.Replace(host, "console.", "wordpress.", 1)
 	owHost := strings.Replace(host, "console.", "openclaw.", 1)
 	mailHost := strings.Replace(host, "console.", "mail.", 1)
+	agenityHost := strings.Replace(host, "console.", "agenity.", 1)
 
 	// D31 active-hot-standby — read the Sovereign-level toggle + region
 	// pair from the catalyst-api Pod env at render time. Wired by
@@ -612,6 +622,7 @@ func renderOrganizationOverlay(rec store.OrganizationProvisionRecord, versions O
 		WordPressHost:         wpHost,
 		OpenClawHost:          owHost,
 		MailHost:              mailHost,
+		AgenityHost:           agenityHost,
 		AdminEmail:            rec.AdminEmail,
 		CompanyName:           rec.CompanyName,
 		DomainMode:            string(rec.DomainMode),
@@ -654,6 +665,7 @@ func withVersionDefaults(v OrganizationChartVersions) OrganizationChartVersions 
 		OpenClaw:  star(v.OpenClaw),
 		Stalwart:  star(v.Stalwart),
 		NewAPI:    star(v.NewAPI),
+		Agenity:   star(v.Agenity),
 	}
 }
 
@@ -689,6 +701,7 @@ var orgTenantTemplates = map[string]string{
 	"bp-wordpress-tenant.yaml": orgTenantBPWordPress,
 	"bp-openclaw.yaml":         orgTenantBPOpenClaw,
 	"bp-stalwart-tenant.yaml":  orgTenantBPStalwart,
+	"bp-agenity.yaml":          orgTenantBPAgenity,
 	"certificate.yaml":         orgTenantCertificate,
 	// #2066 — per-Application Continuum CR. The template evaluates to
 	// the empty string when EnableHotStandby=false; the writer in
@@ -715,6 +728,7 @@ resources:
   - bp-wordpress-tenant.yaml
   - bp-openclaw.yaml
   - bp-stalwart-tenant.yaml
+  - bp-agenity.yaml
   - certificate.yaml
 {{- if .EnableHotStandby }}
   # D31 / Pillar 3 — per-Application Continuum CR (Refs #2066) that
@@ -1523,6 +1537,102 @@ spec:
       host: {{.OpenClawHost}}
       tls:
         issuer: letsencrypt-prod
+`
+
+const orgTenantBPAgenity = `# bp-agenity (#4180) — the per-Organization agentic dashboard. The User
+# installs Agenity into their own Org and chats with the built-in solo
+# agent (Claude Opus, token pre-configured via the Org's openbao); the
+# agent creates Applications in the User's own Org through the RBAC-scoped
+# openova MCP. This is the founder's North-Star agentic surface served at
+# https://agenity.<slug>.<pool>/app/.
+#
+# Why this HelmRelease has NO dependsOn (verified live, #4180):
+#   - The dashboard SPA (/app/) is served by the chepherd daemon's static
+#     build and renders INDEPENDENT of keycloak (SSO) and cnpg (DB). The
+#     rtz platform agenity install runs with zero dependsOn. Gating agenity
+#     on bp-keycloak would needlessly hold the dashboard hostage to the
+#     Org's SSO stack — the founder's URL must serve the new dashboard even
+#     while keycloak/cnpg converge. The agent runtime authenticates to
+#     Anthropic via the Org openbao token (ExternalSecret), not keycloak.
+#
+# Chart contract (products/agenity/chart/values.yaml):
+#   - sovereignFqdn        : the per-Org identity zone (<slug>.<pool>) the
+#                            openova-MCP derives https://console.<fqdn> from.
+#   - httpRoute.hostnames  : [agenity.<slug>.<pool>] — the per-Org host the
+#                            chart attaches to cilium-gateway-console.
+#   - httpRoute.parentRef  : cilium-gateway-console / kube-system — the
+#                            DEDICATED console Gateway carrying the
+#                            *.<pool> wildcard TLS listener (#4054/#4070);
+#                            parenting the apps cilium-gateway → envoy 404.
+#                            The wildcard listener terminates TLS so NO
+#                            per-host Certificate is needed.
+#   - networkPolicy.ingress.allowGatewayEntity : emits the CNP
+#                            fromEntities:[ingress] carve-out — without it
+#                            the gateway→agenity hop is default-denied and
+#                            the browser sees envoy 503 (#4180).
+#   - anthropic.externalSecret : pulls the sk-ant token (+ claude-code
+#                            credentials.json) from the Org's openbao via
+#                            vault-region1 so the solo agent can call Claude.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-agenity
+  namespace: {{.Namespace}}
+spec:
+  interval: 10m
+  chart:
+    spec:
+      chart: bp-agenity
+      version: "{{.ChartVersions.Agenity}}"
+      sourceRef:
+        kind: HelmRepository
+        name: bp-agenity
+        namespace: flux-system
+  install:
+    timeout: 15m
+  upgrade:
+    timeout: 15m
+    cleanupOnFail: true
+  values:
+    # Per-Org identity zone — the openova-MCP derives
+    # https://console.<sovereignFqdn> from this when catalystApiUrl is empty.
+    sovereignFqdn: {{.Subdomain}}.{{.ParentDomain}}
+    # HTTPRoute exposure for the per-Org dashboard. Without a non-empty
+    # hostnames the chart's templates/httproute.yaml guard renders nothing.
+    httpRoute:
+      enabled: true
+      hostnames:
+        - {{.AgenityHost}}
+      parentRef:
+        # console-isolation (#4054/#4070): agenity.<slug>.<pool> resolves to
+        # the dedicated console-ELB EIP which fronts the ISOLATED
+        # cilium-gateway-console (NOT the apps cilium-gateway / apps-ELB).
+        # The console Gateway carries the *.<pool> wildcard TLS listener so
+        # TLS terminates on the wildcard cert and no per-host Certificate is
+        # needed; parenting the apps gateway → envoy 404 on the console ELB.
+        name: cilium-gateway-console
+        namespace: kube-system
+        # sectionName omitted — the console Gateway exposes a single
+        # apex-bound HTTPS listener per Org zone, matched by hostname filter.
+        # The chart guards the field with a 'with' conditional.
+    # CiliumNetworkPolicy fromEntities:[ingress] — admits the Cilium Gateway
+    # Envoy to the agenity Service so the gateway→pod hop is not
+    # default-denied (else envoy 503 "upstream connect error", #4180).
+    networkPolicy:
+      enabled: true
+      ingress:
+        allowGatewayEntity: true
+    # Anthropic token (+ claude-code credentials.json) for the solo agent,
+    # pulled from the Org's openbao via the region-1 ClusterSecretStore.
+    # The chart's externalsecret-anthropic.yaml reads anthropic/token.
+    anthropic:
+      externalSecret:
+        enabled: true
+        secretStoreRef: vault-region1
+        secretStoreKind: ClusterSecretStore
+        remoteKey: anthropic/token
+        remoteProperty: apiKey
+        remoteCredentialsProperty: credentialsJson
 `
 
 const orgTenantBPStalwart = `# bp-stalwart-tenant (#801, OIDC wiring #915) — dedicated mail server

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -146,7 +146,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.5.3",
+    "version": "0.5.4",
     "section": "pts-7-org-tenant",
     "depends": [
       "bp-external-secrets"
@@ -931,7 +931,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "section": "pts-9-disaster-recovery",
     "depends": [
       "bp-cnpg",
@@ -5646,7 +5646,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.4.12",
+    "version": "0.4.13",
     "section": "pts-7-org-tenant",
     "depends": [
       "bp-postgres",


### PR DESCRIPTION
## What

Make the per-Org agentic dashboard `https://agenity.<slug>.<pool>/app/` serve the latest (0.9.6) dashboard DURABLY — install pinned in Git/CR state, not a hand-patch a reconcile reverts.

Live ground truth (omantel.biz demo Org, 2026-06-24): `agenity.demo.omani.homes/app/` returned a hard 404 — the demo Org had **NO bp-agenity HelmRelease** and **no agenity HTTPRoute** (the prior install + its hand-applied route were wiped by a re-prov). The only agenity was `agenity-rtz-a` in the platform `rtz` vCluster (old `0.9.4`, ClusterIP-only, unrouted).

An HTTPRoute alone is not enough — it would route to nothing, and even with a backend the Cilium-gateway hop would 503 because the agenity chart shipped **no CiliumNetworkPolicy**.

## Changes (durable: chart + overlay)

- **products/agenity/chart** — add `templates/cilium-ingress-networkpolicy.yaml`: a `fromEntities:[ingress]` CiliumNetworkPolicy admitting the Cilium Gateway Envoy to `service.port`. Mirrors `platform/newapi` + `platform/wordpress-tenant`. Without it the gateway→agenity hop is default-denied and envoy returns 503 "upstream connect error". New `networkPolicy` values block. Chart `0.5.3` → `0.5.4` (appVersion / dashboard image stays `0.9.6`).
- **products/catalyst/bootstrap/api** org-tenant generator — render a `bp-agenity` HelmRelease into every Org's `catalyst-tenant` overlay (same pipeline as `bp-keycloak` / `bp-wordpress-tenant`). Wires `sovereignFqdn`, `httpRoute.hostnames=[agenity.<slug>.<pool>]`, `httpRoute.parentRef=cilium-gateway-console/kube-system` (the dedicated console Gateway with the `*.<pool>` wildcard TLS listener → no per-host cert), the CNP carve-out, and the anthropic openbao ExternalSecret. New `AgenityHost` field + `Agenity` chart-version (`CATALYST_ORG_BP_AGENITY_VER`).
- **No `dependsOn` keycloak/cnpg** — the dashboard SPA renders independent of the Org SSO/DB stack (the rtz install runs with zero dependsOn), so the founder's URL serves the new dashboard even while keycloak/cnpg converge. The agent runtime authenticates to Anthropic via the Org openbao token, not keycloak.
- **catalog regen** (`build-catalog.mjs`) — a FRESH install offers chart `0.5.4`; also clears pre-existing stale drift (`cnpg-pair 0.2.6`, `wordpress-tenant 0.4.13`).

## Verification

- `go build ./...` + `go vet` green; org-tenant generator tests pass.
- `helm template` renders the CNP (`fromEntities:[ingress]` → 8080) and the HTTPRoute parented to `cilium-gateway-console` with host `agenity.demo.omani.homes`.
- Console gateway confirmed live to carry a `console-https-demo` listener for `*.demo.omani.homes` (wildcard TLS terminates, no per-host cert).
- Live transient probe result + Playwright dashboard-hash evidence posted as an issue comment (per "merged ≠ delivered").

Refs #4180