### PR TITLE
fix(bp-cnpg): managed-by:flux on webhook Helm-hook Jobs → un-wedge platform cnpg-system upgrade → unblock #4222 catalyst-api roll + #4179 funnel close

### DIFF
--- a/clusters/_template/bootstrap-kit/16-cnpg.yaml
+++ b/clusters/_template/bootstrap-kit/16-cnpg.yaml
@@ -94,7 +94,12 @@ spec:
       # 1.0.11 (#4220): the webhook readiness-gate (Job/RBAC) + cert-bootstrap
       #         now SKIP rendering in webhook-less mode so the un-owned Helm-hook
       #         Job stops getting flux-managed-denied on per-Org installs.
-      version: 1.0.11
+      # 1.0.12 (#4226): stamp managed-by:flux on the two Helm-hook Jobs so the
+      #         PLATFORM (webhook-FULL) cnpg-system upgrade is admitted by the
+      #         flux-managed policy (the gate Job still renders here, unlike the
+      #         per-Org webhook-less case). Unblocks the bp-catalyst-platform
+      #         dependsOn → the #4222 catalyst-api roll → the #4179 funnel close.
+      version: 1.0.12
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg

--- a/platform/cnpg/blueprint.yaml
+++ b/platform/cnpg/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-4-1-data-services
 spec:
-  version: 1.0.11
+  version: 1.0.12
   card:
     title: CloudNativePG
     summary: |

--- a/platform/cnpg/chart/Chart.yaml
+++ b/platform/cnpg/chart/Chart.yaml
@@ -37,7 +37,19 @@ name: bp-cnpg
 # the webhook configs. This is a render-skip, NOT a policy exemption — the
 # flux-managed guardrail stays fully in force. Single-operator installs
 # (webhook configs created) keep the gate unchanged. Refs #4201 #4143.
-version: 1.0.11
+#
+# 1.0.12 (#4226, 2026-06-24): stamp `app.kubernetes.io/managed-by: flux` on the
+# two Helm-hook Jobs (webhook-gate-hook.yaml, webhook-cert-bootstrap.yaml). In
+# webhook-FULL mode (the PLATFORM cnpg-system install) the gate Job STILL renders
+# — #4223 only skipped it for webhook-LESS per-Org installs — and it is created
+# by the helm-controller with no Flux owner, so the flux-managed Kyverno Enforce
+# policy DENIED it → bp-cnpg post-upgrade hook failed → Helm rollback → bp-cnpg
+# Ready=False → bp-catalyst-platform (dependsOn bp-cnpg) wedged at 1.4.810,
+# blocking the #4222 pool-PowerDNS catalyst-api roll and the #4179 funnel close
+# (live omantel.biz dep 4635277cae4ffed9). The label is the policy's own
+# documented escape (same as openbao init-job #3374, gitea/harbor hooks
+# #3296→#3297) — guardrail stays fully in force. Refs #4179 #4223 #4220 #3374.
+version: 1.0.12
 description: |
   Catalyst-curated Blueprint umbrella chart for CloudNativePG. Depends on
   the upstream `cloudnative-pg` chart as a Helm subchart so

--- a/platform/cnpg/chart/templates/webhook-cert-bootstrap.yaml
+++ b/platform/cnpg/chart/templates/webhook-cert-bootstrap.yaml
@@ -113,6 +113,11 @@ metadata:
   labels:
     app.kubernetes.io/name: bp-cnpg
     app.kubernetes.io/component: webhook-cert-bootstrap
+    # #4226: Helm pre-upgrade hook Job — needs the flux-managed label so the
+    # kyverno baseline `flux-managed` Enforce policy admits it (same as the
+    # webhook-gate Job). Currently grandfathered on the live env (created at
+    # bootstrap before Enforce engaged) but denied on any fresh upgrade.
+    app.kubernetes.io/managed-by: flux
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "3"

--- a/platform/cnpg/chart/templates/webhook-gate-hook.yaml
+++ b/platform/cnpg/chart/templates/webhook-gate-hook.yaml
@@ -92,6 +92,15 @@ metadata:
     app.kubernetes.io/name: bp-cnpg
     app.kubernetes.io/instance: {{ .Release.Name }}
     catalyst.openova.io/component: webhook-gate
+    # #4226: this Helm post-upgrade hook Job is created by the helm-controller,
+    # not Flux directly, so the kyverno baseline `flux-managed` Enforce policy
+    # (workload-must-be-flux-managed, which matches kind Job) DENIES it without
+    # this label — wedging the platform (webhook-FULL) bp-cnpg upgrade into a
+    # rollback loop, which in turn blocks the bp-catalyst-platform dependsOn.
+    # #4223 only skipped this Job in webhook-LESS (per-Org) mode; the platform
+    # cnpg-system install still renders it. Same landmine as openbao init-job
+    # (#3374) and gitea/harbor sso-configure hooks (#3296→#3297).
+    app.kubernetes.io/managed-by: flux
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "5"


### PR DESCRIPTION
## What this fixes
On the live omantel.biz Sovereign (dep `4635277cae4ffed9`) the `bp-catalyst-platform` HelmRelease is stuck at chart **1.4.810** (catalyst-api `7c7ae4e`, PRE-#4222) and will NOT roll to 1.4.811 (the #4222 pool-PowerDNS catalyst-api), because its `dependsOn: bp-cnpg` is `Ready=False`:

```
bp-cnpg HR: Stalled RetriesExceeded
  Helm upgrade failed (bp-cnpg@1.0.11): post-upgrade hooks failed:
  Hook post-upgrade webhook-gate-hook.yaml failed:
  kyverno denied: Job/cnpg-system/cnpg-webhook-gate
  blocked by workload-must-be-flux-managed -> Helm rollback to 1.0.10
```

## Root cause
#4223 (1.0.11) only skips the webhook-gate Job in **webhook-LESS** (per-Org) mode. The **platform** cnpg-system install runs **webhook-FULL** (`webhookConfigsCreated=true`), so the gate Job still renders. It is created by the helm-controller with no Flux owner, so the kyverno baseline `flux-managed` Enforce policy (`workload-must-be-flux-managed`, which matches kind `Job`) denies it. `webhook-cert-bootstrap.yaml`'s Job has the same gap (grandfathered live, denied on fresh upgrade).

## Fix
Stamp `app.kubernetes.io/managed-by: flux` on both Helm-hook Jobs. This is the policy's own documented escape — identical to the openbao init-job (#3374) and gitea/harbor sso-configure hooks (#3296 then #3297) — a render-only label; the guardrail stays fully in force. The webhook-LESS render still emits ZERO gate resources (#4223 preserved). Chart 1.0.11 to 1.0.12 + blueprint.yaml + bootstrap-kit slot-16 pin in lockstep.

## Verification
- `helm template` webhook-FULL renders gate Job + cert-wait Job both carrying `managed-by: flux`.
- `helm template` webhook-LESS renders ZERO gate/cert resources (#4223 intact).
- Chart render test `tests/webhook-gate-render.sh` all assertions PASS.

## Impact
The final gate for the #4179 (#1 customer funnel) close: with bp-cnpg green the bp-catalyst-platform HR rolls the #4222 catalyst-api (the pool-PowerDNS A-record writer), so a fresh signup's `console.<slug>.omani.works` resolves and the stranger lands signed-in.

Refs #4179 #4226 #4223 #4220

Generated with Claude Code
