### PR TITLE
fix(bp-wordpress-tenant): managed-by:flux on db-secret-sync hook Job → un-roll-back the per-Org WordPress upgrade → keep the HTTPRoute alive (#4220)

### DIFF
--- a/platform/wordpress-tenant/blueprint.yaml
+++ b/platform/wordpress-tenant/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: tenant-app
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.4.13
+  version: 0.4.14
   card:
     title: WordPress (per-Organization)
     summary: |

--- a/platform/wordpress-tenant/chart/Chart.yaml
+++ b/platform/wordpress-tenant/chart/Chart.yaml
@@ -184,7 +184,7 @@ name: bp-wordpress-tenant
 #   now emits gateway.{enabled,host,parentRef} instead of the dead ingress
 #   block. Verified live: GET https://wordpress.<slug>.<pool>/ → 200 serving
 #   the WordPress site (was 404).
-version: 0.4.13
+version: 0.4.14
 appVersion: "6"
 description: |
   Catalyst Blueprint scratch chart for in-vcluster WordPress, one

--- a/platform/wordpress-tenant/chart/templates/database-secret-sync-job.yaml
+++ b/platform/wordpress-tenant/chart/templates/database-secret-sync-job.yaml
@@ -26,6 +26,15 @@ metadata:
   labels:
     {{- include "bp-wordpress-tenant.labels" . | nindent 4 }}
     catalyst.openova.io/component: wordpress-database-secret-sync
+    # #4220: this Helm post-install/post-upgrade hook Job is created by the
+    # helm-controller, not Flux directly, so the kyverno baseline `flux-managed`
+    # Enforce policy (workload-must-be-flux-managed, which matches kind Job)
+    # DENIES it — the shared `.labels` helper stamps `managed-by: Helm`. Override
+    # to `flux` so the Job is admitted; otherwise the post-upgrade hook fails →
+    # Helm rolls the release back → the HTTPRoute is dropped → the customer host
+    # 404s. Same landmine as bp-cnpg webhook-gate (#4226) + gitea/harbor
+    # sso-configure hooks (#3296→#3297) + openbao init-job (#3374).
+    app.kubernetes.io/managed-by: flux
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "5"


### PR DESCRIPTION
## Problem
On the omantel.biz Sovereign demo Org, after bp-keycloak `1.5.1` + bp-cnpg `1.0.12` un-blocked the customer WordPress install, the `bp-wordpress-tenant` HR still fails to reach Ready:

```
Helm upgrade failed ... post-upgrade hooks failed: Hook post-upgrade
bp-wordpress-tenant/templates/database-secret-sync-job.yaml failed:
admission webhook "validate.kyverno.svc-fail" denied the request:
Job/bp-wordpress-tenant-db-secret-sync ... flux-managed:
  workload-must-be-flux-managed: 'Job ... is not Flux-managed. Add label
  app.kubernetes.io/managed-by: flux ...'
```

The `<release>-db-secret-sync` post-install/post-upgrade hook Job is created by the helm-controller, not Flux directly, so the baseline `flux-managed` Enforce ClusterPolicy (which matches kind `Job`) DENIES it — the shared `bp-wordpress-tenant.labels` helper stamps `managed-by: Helm`. When the hook fails, Helm rolls the release back, which drops the rendered `HTTPRoute`, so the customer host `wordpress.<sub>.<pool>` returns a bare envoy 404 on the console ELB — even though the WordPress Pod serves `302 → /wp-admin/install.php` internally (DB auth healthy).

## Fix
Override the Job's `app.kubernetes.io/managed-by` to `flux` (the later label key wins over the helper). Only the `Job` needs it — the SA/Role/RoleBinding kinds are not matched by the policy (`Deployment/StatefulSet/DaemonSet/Job/CronJob/Service/Ingress`).

Same landmine already fixed for bp-cnpg webhook-gate (#4226) and the gitea/harbor sso-configure hooks (#3296→#3297).

Chart `0.4.13` -> `0.4.14` (Chart.yaml + blueprint.yaml lockstep).

## Verified
- `helm template ... --show-only database-secret-sync-job.yaml` renders the Job with `app.kubernetes.io/managed-by: flux`.
- `helm lint` passes.
- Live on the Sovereign: WordPress Pod 1/1, serves `302 → install.php` internally; the HTTPRoute for `wordpress.demo.omani.homes` renders once the upgrade is admitted.

Refs #4220

🤖 Generated with [Claude Code](https://claude.com/claude-code)