### PR TITLE
fix(bp-wordpress-tenant): managed-by:flux on oidc-config + admin-user hook Jobs too → finish un-rolling the per-Org WordPress upgrade (#4220)

### DIFF
--- a/platform/wordpress-tenant/blueprint.yaml
+++ b/platform/wordpress-tenant/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: tenant-app
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.4.14
+  version: 0.4.15
   card:
     title: WordPress (per-Organization)
     summary: |

--- a/platform/wordpress-tenant/chart/Chart.yaml
+++ b/platform/wordpress-tenant/chart/Chart.yaml
@@ -184,7 +184,7 @@ name: bp-wordpress-tenant
 #   now emits gateway.{enabled,host,parentRef} instead of the dead ingress
 #   block. Verified live: GET https://wordpress.<slug>.<pool>/ → 200 serving
 #   the WordPress site (was 404).
-version: 0.4.14
+version: 0.4.15
 appVersion: "6"
 description: |
   Catalyst Blueprint scratch chart for in-vcluster WordPress, one

--- a/platform/wordpress-tenant/chart/templates/admin-user-job.yaml
+++ b/platform/wordpress-tenant/chart/templates/admin-user-job.yaml
@@ -31,6 +31,11 @@ metadata:
   labels:
     {{- include "bp-wordpress-tenant.labels" . | nindent 4 }}
     catalyst.openova.io/component: wordpress-admin-user
+    # #4220: helm-controller-created hook Job — override the helper's
+    # `managed-by: Helm` to `flux` so the kyverno `flux-managed` Enforce policy
+    # admits it (else post-upgrade hook fails → release rollback → HTTPRoute
+    # dropped → customer host 404). Mirrors database-secret-sync-job.yaml.
+    app.kubernetes.io/managed-by: flux
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "15"

--- a/platform/wordpress-tenant/chart/templates/oidc-config-job.yaml
+++ b/platform/wordpress-tenant/chart/templates/oidc-config-job.yaml
@@ -57,6 +57,11 @@ metadata:
   labels:
     {{- include "bp-wordpress-tenant.labels" . | nindent 4 }}
     catalyst.openova.io/component: wordpress-oidc-config
+    # #4220: helm-controller-created hook Job — override the helper's
+    # `managed-by: Helm` to `flux` so the kyverno `flux-managed` Enforce policy
+    # admits it (else post-upgrade hook fails → release rollback → HTTPRoute
+    # dropped → customer host 404). Mirrors database-secret-sync-job.yaml.
+    app.kubernetes.io/managed-by: flux
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "10"


### PR DESCRIPTION
## Problem
Follow-up to #4230. After #4230 admitted the `db-secret-sync` hook Job (verified live: it succeeded), the `bp-wordpress-tenant` HR upgrade STILL rolled back — the next post-upgrade hook Job `oidc-config` was denied by the same `flux-managed` policy:

```
post-upgrade hooks failed: Hook post-upgrade oidc-config-job.yaml failed:
Job/...-oidc-config blocked: flux-managed: workload-must-be-flux-managed
```

The chart has THREE post-install/post-upgrade Helm-hook Jobs; #4230 only fixed one. `oidc-config-job.yaml` and `admin-user-job.yaml` both still inherit `managed-by: Helm` from the shared `.labels` helper → denied → release rollback → HTTPRoute dropped → customer host 404.

## Fix
Override `app.kubernetes.io/managed-by` to `flux` on the `oidc-config` and `admin-user` hook Jobs too (mirrors #4230's db-secret-sync fix). Chart `0.4.14` -> `0.4.15` (Chart.yaml + blueprint.yaml lockstep).

## Verified
- `helm template` renders all three hook Jobs (`database-secret-sync`, `oidc-config`, `admin-user`) with `app.kubernetes.io/managed-by: flux`.
- `helm lint` passes.
- Live: db-secret-sync Job `managed-by=flux succeeded=1` after #4230; this completes the set.

Refs #4220

🤖 Generated with [Claude Code](https://claude.com/claude-code)