### PR TITLE
fix(bp-agenity): chat-runtime — optional RS256-pubkey secretKeyRef + per-Org openbao anthropic/token seed runbook (0.5.5)

### DIFF
--- a/products/agenity/README.md
+++ b/products/agenity/README.md
@@ -103,6 +103,52 @@ private base image (`ghcr.io/agenity-org/chepherd`) is gone.
   with the Org's Keycloak SSO (silent login). The agent presents the User's
   session bearer to the openova MCP on each `tools/call`.
 
+## Seeding the per-Org `anthropic/token` openbao path (#4111 / #4228)
+
+The chat runtime (the spawned `claude-code` solo agent) needs a **live
+Anthropic credential** in the Org's openbao. The chart's
+`templates/externalsecret-anthropic.yaml` reads it from the openbao path
+`anthropic/token` via the `vault-region1` ClusterSecretStore into the
+`agenity-anthropic-token` Secret. The chart can **never** carry the secret
+itself (Inviolable Principle #4 — no hardcoded secrets), so this one openbao
+write is **operator-driven**, exactly once per Sovereign, before the chat is
+expected to work. Until it is seeded the dashboard still renders, but the
+agent reports *"runtime offline · 0 workers"* / *"no Claude credential
+available"* on spawn.
+
+Two properties live at that one path:
+
+| openbao property | chart value | what it is |
+|---|---|---|
+| `apiKey` | `anthropic.externalSecret.remoteProperty` | the `sk-ant-…` bare key (key-only fallback) |
+| `credentialsJson` | `anthropic.externalSecret.remoteCredentialsProperty` | the **full** `{"claudeAiOauth":{"accessToken":…,"refreshToken":…,"expiresAt":…,"scopes":[…]}}` blob — the channel the spawned `claude-code` actually authenticates with (#4111). A bare `sk-ant-oat01-…` OAuth token in `apiKey` alone is **rejected** by `claude-code`; seed `credentialsJson` for the OAuth journey. |
+
+Seed it from inside the cluster (the openbao admin token is the Org's
+in-vc-mgmt OpenBao root — never write the secret to a file on disk):
+
+```bash
+# exec into an in-cluster pod that can reach the region-1 OpenBao; export
+# VAULT_ADDR + VAULT_TOKEN for that store, then:
+bao kv put anthropic/token \
+  apiKey='sk-ant-…' \
+  credentialsJson='{"claudeAiOauth":{"accessToken":"…","refreshToken":"…","expiresAt":<ms>,"scopes":["user:inference"]}}'
+```
+
+ESO refreshes `agenity-anthropic-token` within `refreshInterval` (1h, or force
+an immediate sync by annotating the ExternalSecret with
+`force-sync=$(date +%s)`); the init container then seeds
+`~/.claude/.credentials.json` from `credentialsJson` and the next agent spawn
+authenticates. This path is **shared per-Sovereign** (not per-Org-namespaced)
+by default — a single seed serves every Org's agenity install on that
+Sovereign.
+
+> **Why not chart-seed it?** A Helm-seeded placeholder would pin an **empty**
+> value forever under the reflector/ESO empty-seed trap (the bp-wordpress-tenant
+> empty-password lesson) — the agent would then hold a permanently-blank
+> credential. Absent-and-unseeded (the ExternalSecret renders, the key is
+> simply missing) is the correct pre-seed state; the operator's one `bao kv put`
+> is the activation.
+
 ## What the fresh-prov walk should see
 
 The full live e2e walk runs in the orchestrator's wipe → prov → walk loop.

--- a/products/agenity/blueprint.yaml
+++ b/products/agenity/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.5.4
+  version: 0.5.5
   card:
     title: Agenity
     summary: |

--- a/products/agenity/chart/Chart.yaml
+++ b/products/agenity/chart/Chart.yaml
@@ -8,13 +8,24 @@ description: |
   (RBAC-scoped to the User's rights) to create more Applications in the
   User's own Organization — the north-star self-service journey.
 type: application
+# 0.5.4 -> 0.5.5 (#4228): make the OPENOVA_MCP_RS256_PUBKEY_PEM secretKeyRef
+# optional:true. Its source Secret (catalyst-handover-jwt-public, #4114) lives
+# in the host catalyst-system namespace, NOT the per-Org namespace this
+# Application installs into — so a non-optional ref stuck the chepherd
+# container at CreateContainerConfigError and the whole pod (dashboard AND
+# chat) never started on an Org install. With optional:true the pod schedules
+# even when the Secret is absent; the openova-mcp falls back to its inherited
+# process env (bearer_fallback). README gains the operator-driven openbao
+# anthropic/token seeding runbook (the chat-runtime credential). No placeholder
+# is Helm-seeded (reflector empty-seed trap). appVersion (dashboard image)
+# stays 0.9.6 — image bytes unchanged; 0.5.5 is ADDITIVE over 0.5.4.
 # 0.5.3 -> 0.5.4 (#4180): add templates/cilium-ingress-networkpolicy.yaml so a
 # per-Org (pool-domain) install is REACHABLE through the Cilium Gateway. The
 # HTTPRoute alone routed the host but the gateway traffic carries the reserved
 # `ingress` entity that no K8s NetworkPolicy can admit — without the CNP every
 # external hit to agenity.<slug>.<pool> returned envoy 503 "upstream connect
 # error". appVersion (dashboard image) stays 0.9.6 — image bytes unchanged.
-version: 0.5.4
+version: 0.5.5
 # Bumped appVersion 0.9.5 -> 0.9.6 (#4118): the 0.9.5 image bytes are correct
 # (its /app dashboard bundle is byte-identical to a fresh build of the #745
 # source — verified by md5 on omantel.biz), but 0.9.5 was published BEFORE

--- a/products/agenity/chart/templates/statefulset.yaml
+++ b/products/agenity/chart/templates/statefulset.yaml
@@ -240,14 +240,32 @@ spec:
             {{- end }}
             {{- if eq .Values.openovaMCP.verify "rs256" }}
             # The RS256 public key the MCP verifies caller bearers against,
-            # reflected from the Sovereign's handover-jwt secret. Surfaced as
-            # an env var so the EXTRA_MCP_JSON above can $(…)-expand it into
-            # the per-agent MCP server stanza.
+            # sourced from the Sovereign's handover-jwt-public secret. Surfaced
+            # as an env var that the forked openova-mcp inherits and reads
+            # natively (bearer_fallback=true).
+            #
+            # 🛑 optional:true is LOAD-BEARING for the chat runtime (#4228): the
+            # handover pubkey Secret (`catalyst-handover-jwt-public`, published
+            # by catalyst-api #4114) lives in the host catalyst-system namespace,
+            # NOT in the per-Org namespace this Application installs into — so a
+            # NON-optional secretKeyRef makes the chepherd container stick
+            # CreateContainerConfigError ("secret not found") and the whole pod —
+            # dashboard AND chat — never starts. The dashboard render does not
+            # use this key; only the MCP→catalyst-api create_application bearer
+            # verification does. With optional:true the pod schedules even when
+            # the Secret is absent (the env var is simply unset), so the
+            # dashboard always serves and the MCP bearer-verifies once the pubkey
+            # is reflected/seeded into the Org ns (rs256PubkeySecret override) or
+            # the openova-mcp falls back to its env (bearer_fallback). We do NOT
+            # Helm-seed a placeholder value here — an empty PEM would pin a bad
+            # key forever under the reflector empty-seed trap; absent-and-optional
+            # is the correct state until the real pubkey is reflected in.
             - name: OPENOVA_MCP_RS256_PUBKEY_PEM
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.openovaMCP.rs256PubkeySecret.name }}
                   key: {{ .Values.openovaMCP.rs256PubkeySecret.key }}
+                  optional: true
             {{- end }}
             {{- end }}
             - name: CHEPHERD_STATE_DIR

--- a/products/agenity/chart/values.yaml
+++ b/products/agenity/chart/values.yaml
@@ -111,10 +111,19 @@ openovaMCP:
   # widen the surface beyond the User's Org (defense in depth).
   context: organization
   # Bearer verification mode for the MCP (rs256 against the Sovereign
-  # handover signer pubkey). The pubkey is reflected in from the catalyst
-  # handover-jwt secret — it MUST match the key catalyst-api SIGNS sessions
-  # with (#4114: catalyst-api now publishes its runtime signer pubkey to
-  # catalyst-handover-jwt-public, the source of truth).
+  # handover signer pubkey). The pubkey MUST match the key catalyst-api
+  # SIGNS sessions with (#4114: catalyst-api publishes its runtime signer
+  # pubkey to the catalyst-handover-jwt-public Secret, the source of truth).
+  #
+  # 🛑 The secretKeyRef driven by rs256PubkeySecret is rendered optional:true
+  # in the StatefulSet (#4228): the source Secret lives in the host
+  # catalyst-system namespace, not the per-Org namespace this Application
+  # installs into, so a non-optional ref would block the pod from starting
+  # (dashboard AND chat) in an Org install. Absent → the env var is simply
+  # unset and the openova-mcp falls back to reading it from its inherited
+  # process env (bearer_fallback=true). To pin a real per-Org pubkey, reflect
+  # catalyst-handover-jwt-public into the Org ns and override name/key here —
+  # never Helm-seed a placeholder value (reflector empty-seed trap).
   verify: rs256
   rs256PubkeySecret:
     name: catalyst-handover-jwt


### PR DESCRIPTION
## Why

The agenity **dashboard** renders 0.9.6 (proven live, #4225). The agentic **CHAT runtime** — chepherd spawning the solo `claude-code` the User chats with — had two gaps that stopped the pod (or the spawned agent) from coming up on a per-Org install. This is additive chart/overlay/docs work on top of 0.5.4.

## What changed (`products/agenity/`)

**1. `OPENOVA_MCP_RS256_PUBKEY_PEM` secretKeyRef → `optional: true`** (`chart/templates/statefulset.yaml`)

The env sources the RS256 pubkey from Secret `catalyst-handover-jwt` / key `handover-jwt-public.pem`. Its real source — `catalyst-handover-jwt-public`, published by catalyst-api (#4114) — lives in the host `catalyst-system` namespace, **not** the per-Org namespace this Application installs into. With a **non-optional** ref the `chepherd` container sticks `CreateContainerConfigError` ("secret not found") and the **whole pod (dashboard AND chat) never starts** on an Org install.

The dashboard render does not use this key; only the openova-mcp→catalyst-api `create_application` bearer verification does, and the forked openova-mcp reads `OPENOVA_MCP_*` from its **inherited process env** (`bearer_fallback=true`). Rendering the ref `optional:true` lets the pod schedule when the Secret is absent (the env var is simply unset) and bearer-verifies once the pubkey is reflected/seeded into the Org ns via the `rs256PubkeySecret` override. No placeholder value is Helm-seeded (the reflector empty-seed trap).

**2. Per-Org openbao `anthropic/token` seeding runbook** (`README.md`)

The `agenity-anthropic-token` ExternalSecret (source openbao `anthropic/token`, #4111) holds the live `claudeAiOauth` blob the spawned `claude-code` authenticates with. The chart can **never** carry it (Inviolable Principle #4 — no hardcoded secrets), so the README now documents the exact operator-driven `bao kv put anthropic/token apiKey=… credentialsJson=…` step, the two properties (`apiKey` + `credentialsJson`), the ESO refresh, and why a chart placeholder would pin an empty credential forever.

**3. Version** `0.5.4 → 0.5.5` (`Chart.yaml` + `blueprint.yaml` `spec.version` in lockstep). `appVersion` stays **0.9.6** — image bytes unchanged. The Org overlay pins `ChartVersions.Agenity = *` (floats to latest published), so the demo Org picks up 0.5.5 with no Go change.

## Validation

- `helm lint` clean; full render is valid YAML.
- `optional: true` renders correctly under the secretKeyRef (verify=rs256 default); env block correctly omitted under verify≠rs256.
- Chart.yaml ↔ blueprint.yaml version lockstep holds (both 0.5.5).
- GUARD 1 (`no-upstream` annotation) + GUARD 2 (default render ≥5 lines) satisfied.
- `go build ./...` green on the bootstrap api (no Go files touched).

## Live chat-walk

Authoring + CI are independent of the live env. Live chat-runtime verification (spawn an agent + it responds) is **gated on env recovery** — the Sovereign catalyst-api is recovering from a disk-pressure eviction and the demo Org agenity must be installed first. Reported rather than forced.

## Coordination

A separate agent is verifying that 0.5.4's dashboard reaches the demo Org. 0.5.5 is **additive** (both serve 0.9.6), so no conflict.

Refs #4228 #4111