### PR TITLE
fix(bp-agenity): per-Org overlay generator installs the dashboard zero-touch — 4 durable bugs (Refs #4180)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/organization_agenity_overlay_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_agenity_overlay_test.go
@@ -1,0 +1,230 @@
+// organization_agenity_overlay_test.go — #4180.
+//
+// Regression coverage for the FOUR durable bp-agenity overlay-generator
+// bugs diagnosed live on the omantel.biz demo Org (2026-06-24, dep
+// 4635277cae4ffed9) and previously only hot-fixed in Gitea:
+//
+//	BUG 1 — missing bp-agenity HelmRepository (sourceRef had no source).
+//	BUG 2 — Agenity version "*" resolved to the IMAGE tag (0.9.6), not the
+//	        chart; default must be the chart-range "0.5.x".
+//	BUG 3 — bp-agenity overlay lacked imagePullSecrets → ImagePullBackOff
+//	        on the private ghcr image in the Org ns.
+//	BUG 4 — the parent org-tenants/kustomization.yaml could be committed as
+//	        a Gitea contents-API JSON envelope, pruning every Org's bp-*
+//	        HelmReleases cluster-wide. Guard: never write a '{'-leading
+//	        parent index.
+package handler
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+func renderAgenityOverlay(t *testing.T, versions OrganizationChartVersions) map[string]string {
+	t.Helper()
+	rec := store.OrganizationProvisionRecord{
+		OrganizationID:  "t-acme",
+		Subdomain:       "acme",
+		DomainMode:      store.OrganizationDomainFreeSubdomain,
+		AdminEmail:      "admin@acme.test",
+		CompanyName:     "Acme Corp",
+		OTECHFQDN:       "otech.example",
+		ParentDomain:    "otech.example",
+		VClusterName:    "vc-acme",
+		TenantNamespace: "org-t-acme",
+	}
+	files, err := renderOrganizationOverlay(rec, versions)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	return files
+}
+
+// BUG 1 — the shared HelmRepositories file MUST declare bp-agenity, else
+// the rendered HelmRelease's sourceRef has no source.
+func TestBug1_AgenityHelmRepositoryDeclared(t *testing.T) {
+	if !strings.Contains(orgTenantSharedHelmRepositories, "name: bp-agenity") {
+		t.Fatalf("orgTenantSharedHelmRepositories missing bp-agenity HelmRepository block")
+	}
+	// Sanity: every HelmRepository the per-tenant overlay sourceRefs into
+	// must be present in the shared file. bp-agenity is the new one.
+	for _, want := range []string{
+		"name: bp-keycloak", "name: bp-cnpg", "name: bp-newapi",
+		"name: bp-wordpress-tenant", "name: bp-openclaw",
+		"name: bp-stalwart-tenant", "name: bp-agenity",
+	} {
+		if !strings.Contains(orgTenantSharedHelmRepositories, want) {
+			t.Errorf("shared HelmRepositories missing %q", want)
+		}
+	}
+	// Shape parity with the others: oci type + ghcr url + ghcr-pull secret.
+	idx := strings.Index(orgTenantSharedHelmRepositories, "name: bp-agenity")
+	block := orgTenantSharedHelmRepositories[idx:]
+	for _, want := range []string{"type: oci", "url: oci://ghcr.io/openova-io", "name: ghcr-pull"} {
+		if !strings.Contains(block, want) {
+			t.Errorf("bp-agenity HelmRepository block missing %q", want)
+		}
+	}
+}
+
+// BUG 2 — an empty CATALYST_ORG_BP_AGENITY_VER must default to the
+// chart-version range "0.5.x" (NOT "*", which resolves to the 0.9.x image).
+func TestBug2_AgenityVersionDefaultsToChartRange(t *testing.T) {
+	got := withVersionDefaults(OrganizationChartVersions{}).Agenity
+	if got != "0.5.x" {
+		t.Fatalf("empty Agenity version default = %q, want %q", got, "0.5.x")
+	}
+	if got == "*" {
+		t.Fatalf("Agenity default must NOT be '*' — it resolves to the 0.9.x IMAGE tag")
+	}
+	// An explicit value still wins.
+	if v := withVersionDefaults(OrganizationChartVersions{Agenity: "0.5.4"}).Agenity; v != "0.5.4" {
+		t.Fatalf("explicit Agenity version = %q, want 0.5.4", v)
+	}
+	// The OTHER charts still default to "*".
+	d := withVersionDefaults(OrganizationChartVersions{})
+	for name, v := range map[string]string{
+		"Keycloak": d.Keycloak, "CNPG": d.CNPG, "WordPress": d.WordPress,
+		"OpenClaw": d.OpenClaw, "Stalwart": d.Stalwart, "NewAPI": d.NewAPI,
+	} {
+		if v != "*" {
+			t.Errorf("%s default = %q, want '*' (only Agenity is special)", name, v)
+		}
+	}
+}
+
+// BUG 2 (rendered) — the emitted bp-agenity HelmRelease carries the
+// chart-range version when none is supplied.
+func TestBug2_RenderedAgenityVersion(t *testing.T) {
+	files := renderAgenityOverlay(t, OrganizationChartVersions{})
+	hr := parseAgenityHR(t, files)
+	if hr.Spec.Chart.Spec.Version != "0.5.x" {
+		t.Fatalf("rendered bp-agenity chart.spec.version = %q, want 0.5.x", hr.Spec.Chart.Spec.Version)
+	}
+	if hr.Spec.Chart.Spec.Chart != "bp-agenity" {
+		t.Fatalf("rendered chart name = %q, want bp-agenity", hr.Spec.Chart.Spec.Chart)
+	}
+}
+
+// BUG 3 — the rendered bp-agenity values MUST set imagePullSecrets to
+// [{name: ghcr-pull}] so the private-ghcr image pulls in the Org ns.
+func TestBug3_AgenityImagePullSecrets(t *testing.T) {
+	files := renderAgenityOverlay(t, OrganizationChartVersions{})
+	hr := parseAgenityHR(t, files)
+	ips, ok := hr.Spec.Values["imagePullSecrets"]
+	if !ok {
+		t.Fatalf("rendered bp-agenity values missing imagePullSecrets (private ghcr image → ImagePullBackOff)")
+	}
+	list, ok := ips.([]interface{})
+	if !ok || len(list) == 0 {
+		t.Fatalf("imagePullSecrets is not a non-empty list: %#v", ips)
+	}
+	first, _ := list[0].(map[string]interface{})
+	if first["name"] != "ghcr-pull" {
+		t.Fatalf("imagePullSecrets[0].name = %v, want ghcr-pull", first["name"])
+	}
+}
+
+// BUG 4 — writeParentTenantsIndex must produce a raw-YAML parent index
+// (comment banner + apiVersion: kustomize…), never a JSON envelope, and
+// must refuse to write a corrupt one.
+func TestBug4_ParentIndexIsRawYAML(t *testing.T) {
+	dir := t.TempDir()
+	// Seed one tenant subdir with its own kustomization.yaml so the index
+	// lists it.
+	sub := filepath.Join(dir, "t-acme")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "kustomization.yaml"), []byte("apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeParentTenantsIndex(dir); err != nil {
+		t.Fatalf("writeParentTenantsIndex: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, "kustomization.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(raw)
+	// The committed parent index must start with a '#' comment or the
+	// apiVersion line — never a '{' (JSON-envelope corruption signature).
+	trimmed := strings.TrimLeft(got, " \t\r\n")
+	if strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") {
+		t.Fatalf("parent index is a JSON envelope, not raw YAML:\n%s", got)
+	}
+	if !strings.HasPrefix(trimmed, "#") && !strings.HasPrefix(trimmed, "apiVersion: kustomize") {
+		t.Fatalf("parent index does not begin with '#' or 'apiVersion: kustomize':\n%s", got)
+	}
+	// It must enumerate the seeded tenant + the shared helmrepositories.yaml.
+	if !strings.Contains(got, "- t-acme") {
+		t.Errorf("parent index missing tenant subdir t-acme:\n%s", got)
+	}
+	if !strings.Contains(got, "- helmrepositories.yaml") {
+		t.Errorf("parent index missing helmrepositories.yaml:\n%s", got)
+	}
+	// And it must parse as a valid kustomization (non-empty resources).
+	var ks struct {
+		APIVersion string   `json:"apiVersion"`
+		Kind       string   `json:"kind"`
+		Resources  []string `json:"resources"`
+	}
+	if err := yaml.Unmarshal(raw, &ks); err != nil {
+		t.Fatalf("parent index does not parse as YAML: %v\n%s", err, got)
+	}
+	if ks.Kind != "Kustomization" || len(ks.Resources) == 0 {
+		t.Fatalf("parent index parsed to empty/invalid kustomization (this is the prune-everything trap): %+v", ks)
+	}
+}
+
+// BUG 4 — the validation helper rejects the exact JSON-envelope shape the
+// Gitea contents API returns, and accepts genuine raw YAML.
+func TestBug4_ValidateRawKustomizationYAML(t *testing.T) {
+	bad := []string{
+		`{"name":"kustomization.yaml","path":"clusters/x/org-tenants/kustomization.yaml","content":"YXBpVmVyc2lvbg==","encoding":"base64"}`,
+		`  {"content":"..."}`,
+		`["a","b"]`,
+		``,
+		"   \n\t",
+		"resources:\n  - foo\n", // missing apiVersion/comment prefix
+	}
+	for _, b := range bad {
+		if err := validateRawKustomizationYAML([]byte(b)); err == nil {
+			t.Errorf("validateRawKustomizationYAML accepted corrupt input %q", b)
+		}
+	}
+	good := []string{
+		"# banner\napiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources: []\n",
+		"apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\n",
+		"\uFEFF# BOM-prefixed banner\napiVersion: kustomize.config.k8s.io/v1beta1\n",
+	}
+	for _, g := range good {
+		if err := validateRawKustomizationYAML([]byte(g)); err != nil {
+			t.Errorf("validateRawKustomizationYAML rejected valid input %q: %v", g, err)
+		}
+	}
+}
+
+// parseAgenityHR decodes the rendered bp-agenity.yaml into the minimal HR
+// struct the assertions need.
+func parseAgenityHR(t *testing.T, files map[string]string) helmReleaseYAML {
+	t.Helper()
+	raw, ok := files["bp-agenity.yaml"]
+	if !ok {
+		t.Fatalf("overlay missing bp-agenity.yaml; got files: %v", keysOf(files))
+	}
+	var hr helmReleaseYAML
+	if err := yaml.Unmarshal([]byte(raw), &hr); err != nil {
+		t.Fatalf("bp-agenity.yaml does not parse as YAML: %v\n%s", err, raw)
+	}
+	if hr.Kind != "HelmRelease" {
+		t.Fatalf("bp-agenity.yaml kind = %q, want HelmRelease", hr.Kind)
+	}
+	return hr
+}

--- a/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
@@ -79,8 +79,12 @@ type OrganizationChartVersions struct {
 	Stalwart  string
 	NewAPI    string
 	// Agenity — the per-Org agentic dashboard (bp-agenity, #4180). Read
-	// from CATALYST_ORG_BP_AGENITY_VER; "*" when empty so Flux pulls the
-	// latest published chart (currently 0.5.4 / appVersion 0.9.6).
+	// from CATALYST_ORG_BP_AGENITY_VER. UNLIKE the other charts, when empty
+	// this defaults to the chart-version RANGE "0.5.x" (see
+	// agenityDefaultChartRange / withVersionDefaults), NOT "*": the
+	// bp-agenity OCI repo co-hosts the dashboard IMAGE tags (0.9.x) in the
+	// SAME package, and "*" resolves to the highest semver = the image, which
+	// is not a Helm chart. "0.5.x" pins Flux to the chart line (0.5.5 today).
 	Agenity string
 }
 
@@ -267,10 +271,62 @@ func writeParentTenantsIndex(parentDir string) error {
 		b.WriteString("\n")
 	}
 	indexPath := filepath.Join(parentDir, "kustomization.yaml")
+	// #4180 BUG-4 regression guard — the committed parent index MUST be raw
+	// kustomize YAML, never a Gitea contents-API JSON envelope. The
+	// catastrophe this defends against (live on omantel.biz 2026-06-24, dep
+	// 4635277cae4ffed9): a Gitea-API read path (core/services/provisioning/
+	// github/client.go ReadFile, the OTHER writer of this same shared
+	// org-tenants/kustomization.yaml) returned the envelope
+	//   {"name":"kustomization.yaml","content":"<base64>",...}
+	// verbatim, spliced the new Org subdir onto it, and committed the
+	// JSON-wrapped string back as the file. kustomize then parsed it to an
+	// EMPTY resource set and the org-tenants Flux Kustomization (prune=true)
+	// PRUNED every Org's bp-* HelmReleases cluster-wide. That ReadFile path
+	// is fixed upstream (#4214 / Refs #4206 #3785), but because this index is
+	// a SHARED file two code paths commit to, we assert here at the
+	// bootstrap-api write boundary so any future regression in either writer
+	// is caught before the corrupt bytes ever reach git — a corrupt index
+	// causes cross-Org data loss, so failing the write loudly beats
+	// committing a JSON blob. The bytes we generate above always start with
+	// the comment banner ('#') then 'apiVersion: kustomize…'; a leading '{'
+	// can only mean a JSON envelope leaked in.
+	if err := validateRawKustomizationYAML(b.Bytes()); err != nil {
+		return fmt.Errorf("refusing to write corrupt parent index %s: %w", indexPath, err)
+	}
 	if err := os.WriteFile(indexPath, b.Bytes(), 0o644); err != nil {
 		return fmt.Errorf("write index: %w", err)
 	}
 	return nil
+}
+
+// validateRawKustomizationYAML asserts the given bytes are raw kustomize
+// YAML (a comment banner or the apiVersion line), never a Gitea/GitHub
+// contents-API JSON envelope. See the #4180 BUG-4 note in
+// writeParentTenantsIndex for the cross-Org data-loss this prevents. The
+// only legal first non-space byte for the parent index is '#' (comment) or
+// 'a' (apiVersion: kustomize…); a '{' is the JSON-envelope corruption
+// signature.
+func validateRawKustomizationYAML(content []byte) error {
+	// Trim leading whitespace AND a possible UTF-8 BOM (U+FEFF) before
+	// inspecting the first meaningful byte.
+	trimmed := strings.TrimLeft(string(content), " \t\r\n\uFEFF")
+	if trimmed == "" {
+		return errors.New("parent kustomization index is empty")
+	}
+	if strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") {
+		return errors.New("parent kustomization index looks like a JSON/contents-API envelope (starts with '{' or '[') — expected raw kustomize YAML beginning with a '#' comment or 'apiVersion: kustomize'")
+	}
+	if !strings.HasPrefix(trimmed, "#") && !strings.HasPrefix(trimmed, "apiVersion: kustomize") {
+		return fmt.Errorf("parent kustomization index does not begin with a '#' comment or 'apiVersion: kustomize' (got %q…)", firstN(trimmed, 40))
+	}
+	return nil
+}
+
+func firstN(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
 }
 
 // orgTenantSharedHelmRepositories is the canonical HelmRepository
@@ -356,6 +412,23 @@ apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
 metadata:
   name: bp-stalwart-tenant
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+# bp-agenity (#4180) — the per-Org agentic dashboard. Without this
+# HelmRepository the rendered bp-agenity HelmRelease's sourceRef
+# (HelmRepository/bp-agenity@flux-system) has no source → the HelmChart
+# errors 'HelmRepository "bp-agenity" not found' and the dashboard never
+# installs. Live on omantel.biz demo Org 2026-06-24 (dep 4635277cae4ffed9).
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-agenity
   namespace: flux-system
 spec:
   type: oci
@@ -651,10 +724,37 @@ func renderOrganizationOverlay(rec store.OrganizationProvisionRecord, versions O
 	return out, nil
 }
 
+// agenityDefaultChartRange is the fallback Agenity version when
+// CATALYST_ORG_BP_AGENITY_VER is empty. It MUST be a chart-version range
+// that excludes the 0.9.x IMAGE line — NOT "*".
+//
+// #4180 (live on omantel.biz demo Org 2026-06-24, dep 4635277cae4ffed9):
+// the bp-agenity OCI repo ghcr.io/openova-io/bp-agenity co-hosts BOTH the
+// Helm CHART tags (0.5.3 / 0.5.4 / 0.5.5) AND the dashboard IMAGE tags
+// (0.9.4 / 0.9.5 / 0.9.6) in the SAME package. Flux's OCI "*" constraint
+// resolves to the highest semver = 0.9.6 (the IMAGE), which is not a Helm
+// chart, so the HelmChart pull fails:
+//   "manifest does not contain minimum number of descriptors (2),
+//    descriptors found: 1".
+// Constraining to "0.5.x" keeps Flux on the chart line (resolves to 0.5.5
+// today) and never reaches across to the 0.9.x image tags. This trap is
+// UNIQUE to bp-agenity — every other bp-* chart's repo holds chart tags
+// only, so "*" is still correct for them.
+const agenityDefaultChartRange = "0.5.x"
+
 func withVersionDefaults(v OrganizationChartVersions) OrganizationChartVersions {
 	star := func(s string) string {
 		if strings.TrimSpace(s) == "" {
 			return "*"
+		}
+		return s
+	}
+	// Agenity defaults to a chart-version RANGE (not "*") because its OCI
+	// repo co-hosts image tags that "*" would wrongly resolve to (#4180).
+	// An explicit CATALYST_ORG_BP_AGENITY_VER still wins.
+	agenity := func(s string) string {
+		if strings.TrimSpace(s) == "" {
+			return agenityDefaultChartRange
 		}
 		return s
 	}
@@ -665,7 +765,7 @@ func withVersionDefaults(v OrganizationChartVersions) OrganizationChartVersions 
 		OpenClaw:  star(v.OpenClaw),
 		Stalwart:  star(v.Stalwart),
 		NewAPI:    star(v.NewAPI),
-		Agenity:   star(v.Agenity),
+		Agenity:   agenity(v.Agenity),
 	}
 }
 
@@ -1594,6 +1694,21 @@ spec:
     timeout: 15m
     cleanupOnFail: true
   values:
+    # imagePullSecrets — bp-agenity's image (ghcr.io/openova-io/bp-agenity:
+    # 0.9.x) is a PRIVATE ghcr package. The Org namespace has no default ghcr
+    # auth, so without this the init+main containers get a 401 anonymous
+    # token → ImagePullBackOff (live on omantel.biz demo Org 2026-06-24, dep
+    # 4635277cae4ffed9). The canonical ghcr-pull Secret is reflected into
+    # EVERY namespace (incl. this Org ns) by bp-reflector at bootstrap-kit
+    # slot 05a (flux-system/ghcr-pull carries reflection-auto-enabled:"true"
+    # + reflection-auto-namespaces:"" → all-namespaces mirror, #543), so the
+    # Secret already exists here — we only need to reference it. Same pattern
+    # as platform/guacamole (Chart.yaml 0.1.3: default imagePullSecrets to
+    # [name: ghcr-pull]). Unlike bp-wordpress-tenant/bp-keycloak — which
+    # pull through harbor.openova.io/proxy-* and so avoid private-ghcr auth —
+    # bp-agenity pulls DIRECT from private ghcr and genuinely needs this.
+    imagePullSecrets:
+      - name: ghcr-pull
     # Per-Org identity zone — the openova-MCP derives
     # https://console.<sovereignFqdn> from this when catalystApiUrl is empty.
     sovereignFqdn: {{.Subdomain}}.{{.ParentDomain}}


### PR DESCRIPTION
## Summary

Fixes **four durable catalyst-api per-Org overlay-generator bugs** that blocked the bp-agenity dashboard (#4180) from installing on a fresh prov. All four were diagnosed live on the **omantel.biz demo Org (2026-06-24, dep `4635277cae4ffed9`)** and were previously only hot-fixed in Gitea (throwaway). This PR makes the CODE reproduce a working install with **zero hand-patches** on a fresh prov / overlay-regen.

Primary file: `products/catalyst/bootstrap/api/internal/handler/organization_gitops.go`. New regression test: `products/catalyst/bootstrap/api/internal/handler/organization_agenity_overlay_test.go`.

## The four fixes (file:line)

### BUG 1 — missing bp-agenity HelmRepository
`orgTenantSharedHelmRepositories` declared HelmRepositories for every bp-* chart **except** bp-agenity, so the rendered HelmRelease's `sourceRef: HelmRepository/bp-agenity@flux-system` had no source → HelmChart `HelmRepository "bp-agenity" not found`.
**Fix:** appended a `bp-agenity` HelmRepository block (oci / interval 15m / `oci://ghcr.io/openova-io` / secretRef `ghcr-pull`) — `organization_gitops.go` ~L367-380 (just after the `bp-stalwart-tenant` block).

### BUG 2 — version `"*"` resolved to the IMAGE tag, not the chart
The `ghcr.io/openova-io/bp-agenity` OCI repo co-hosts CHART tags (0.5.3/0.5.4/0.5.5) **and** IMAGE tags (0.9.4/0.9.5/0.9.6) in the same package. Flux's OCI `*` resolves to the highest semver = 0.9.6 (the image, not a Helm chart) → `manifest does not contain minimum number of descriptors (2), descriptors found: 1`. Unique to bp-agenity.
**Fix:** `withVersionDefaults` now defaults `Agenity` to the chart-range `"0.5.x"` via the new `agenityDefaultChartRange` const (NOT `star()`); an explicit `CATALYST_ORG_BP_AGENITY_VER` still wins. Every other chart keeps `"*"`. `organization_gitops.go` ~L686-714 (`agenityDefaultChartRange` + `withVersionDefaults`). Verified live: `version: "0.5.x"` resolves to chart 0.5.5.

### BUG 3 — bp-agenity overlay lacked imagePullSecrets
`ghcr.io/openova-io/bp-agenity:0.9.x` is a **private** ghcr package; the Org ns has no default ghcr auth → 401 anonymous-token / ImagePullBackOff.
**Fix:** added `imagePullSecrets: [{name: ghcr-pull}]` to the rendered `orgTenantBPAgenity` values — `organization_gitops.go` ~L1696-1711.
**Secret availability:** the Org ns already HAS `ghcr-pull`: bp-reflector at bootstrap-kit slot 05a (`clusters/_template/bootstrap-kit/05a-reflector.yaml`) mirrors `flux-system/ghcr-pull` (carries `reflection-auto-enabled: "true"` + `reflection-auto-namespaces: ""` → all-namespaces) into **every** namespace. No extra seed needed — same mechanism `platform/guacamole` relies on (Chart.yaml 0.1.3: default `imagePullSecrets: [{name: ghcr-pull}]`). The chart consumes top-level `imagePullSecrets` (`products/agenity/chart/templates/statefulset.yaml:52`, default `[]`).

### BUG 4 (most important — cross-Org data loss) — parent kustomization.yaml as a JSON envelope
After an overlay regen the parent index `clusters/<otech-fqdn>/org-tenants/kustomization.yaml` could end up containing a Gitea contents-API JSON envelope (`{"name":...,"content":"<base64>",...}`) instead of raw kustomize YAML. kustomize then parses an **empty** resource set → the `org-tenants` Flux Kustomization (`prune=true`) PRUNES every Org's bp-* HelmReleases cluster-wide.

**Corruption entry point found:** NOT this bootstrap-api path. `WriteTenantOverlay` → `writeParentTenantsIndex` (`organization_gitops.go` L89, L206) uses pure `git clone` + `os.ReadDir` + `os.WriteFile`, regenerating the index from scratch — structurally immune to the envelope. The actual writer that corrupts this **shared** file is the OTHER provisioning path: `core/services/provisioning/github/client.go::ReadFile`, which returned the Gitea `/contents/` JSON envelope verbatim; the rebuild closure spliced the new Org subdir onto it and committed the JSON-wrapped string back. **That root cause is already fixed on main** in `f89563b8a` (#4214, Refs #4206 #3785) — see the `ReadFile` decode at `client.go:943-968`. The prior manual Gitea fix (`939b19f2`) was re-corrupted by the next provision (`2739582d`) precisely because that ReadFile bug was still live at the time.

**This PR adds a defensive regression guard** at the bootstrap-api write boundary (since the index is a file two code paths commit to): `writeParentTenantsIndex` now calls the new `validateRawKustomizationYAML` and refuses to write an index that doesn't start with a `#` comment or `apiVersion: kustomize` (rejects a leading `{` or `[`). `organization_gitops.go` ~L269-330. Any future regression in either writer is caught before the corrupt bytes reach git.

## Tests
`organization_agenity_overlay_test.go` — 6 tests, all green:
- BUG 1: bp-agenity HelmRepository declared with correct oci/url/secret shape.
- BUG 2: empty default = `0.5.x` (other charts still `*`); explicit value wins; rendered HR version = `0.5.x`.
- BUG 3: rendered values `imagePullSecrets[0].name == ghcr-pull`.
- BUG 4: `writeParentTenantsIndex` output is raw YAML + parses to a non-empty kustomization; `validateRawKustomizationYAML` rejects the JSON-envelope shape and accepts raw YAML.

`go build ./...` and `go test ./...` green for `products/catalyst/bootstrap/api` (handler package incl. new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)