### PR TITLE
fix(org-controller): per-Org 2-label console TLS cert+listener — console.<slug>.<pool> serves SAN-matching HTTPS (Refs #4241 #4179)

### DIFF
--- a/core/controllers/organization/internal/controller/organization_controller_test.go
+++ b/core/controllers/organization/internal/controller/organization_controller_test.go
@@ -1312,12 +1312,16 @@ func TestReconcile_PerOrgRealm_FinalizerTeardown(t *testing.T) {
 }
 
 // TestReconcileTenantConsoleTLS_IssuesCertAndAppendsListener covers
-// issue #4075: when an Org picks a free-subdomain hostname under a pool
-// parent zone, reconcileTenantConsoleTLS MUST (1) issue a cert-manager
-// Certificate for `*.<parentDomain>` via the DNS-01 ClusterIssuer and
-// (2) append a `*.<parentDomain>` HTTPS+HTTP listener pair to the
-// dedicated console Gateway WITHOUT touching the apex `*.<sovFQDN>`
-// listener. The append MUST be idempotent (a second pass is a no-op).
+// issues #4075/#4241: when an Org picks a free-subdomain hostname under a
+// pool parent zone, reconcileTenantConsoleTLS MUST (1) issue a cert-manager
+// Certificate for the 2-label SAN `*.<slug>.<parentDomain>` +
+// `<slug>.<parentDomain>` via the DNS-01 ClusterIssuer (the apex pool
+// wildcard `*.<parentDomain>` cannot cover the 2-label
+// `console.<slug>.<parentDomain>`) and (2) append a
+// `*.<slug>.<parentDomain>` HTTPS+HTTP listener pair to the dedicated
+// console Gateway WITHOUT touching the apex `*.<sovFQDN>` listener. The
+// append MUST be idempotent (a second pass is a no-op). The slug here is
+// the sampleOrg slug `acme`.
 func TestReconcileTenantConsoleTLS_IssuesCertAndAppendsListener(t *testing.T) {
 	t.Parallel()
 	org := sampleOrg()
@@ -1364,24 +1368,28 @@ func TestReconcileTenantConsoleTLS_IssuesCertAndAppendsListener(t *testing.T) {
 		t.Errorf("pass 1: expected changed=true (cert + listeners written)")
 	}
 
-	// Assert the Certificate.
+	// Assert the per-Org Certificate: name org-wildcard-tls-<slug>-<parent>,
+	// 2-label SAN covering console.<slug>.<parent>.
 	cert := unstructured.Unstructured{}
 	cert.SetGroupVersionKind(certificateGVK)
-	if err := r.Get(context.Background(), client.ObjectKey{Namespace: "kube-system", Name: "org-wildcard-tls-omani-homes"}, &cert); err != nil {
-		t.Fatalf("get Certificate org-wildcard-tls-omani-homes: %v", err)
+	if err := r.Get(context.Background(), client.ObjectKey{Namespace: "kube-system", Name: "org-wildcard-tls-acme-omani-homes"}, &cert); err != nil {
+		t.Fatalf("get Certificate org-wildcard-tls-acme-omani-homes: %v", err)
 	}
 	dnsNames, _, _ := unstructured.NestedStringSlice(cert.Object, "spec", "dnsNames")
-	if len(dnsNames) != 2 || dnsNames[0] != "*.omani.homes" || dnsNames[1] != "omani.homes" {
-		t.Errorf("cert dnsNames: got %v, want [*.omani.homes omani.homes]", dnsNames)
+	if len(dnsNames) != 2 || dnsNames[0] != "*.acme.omani.homes" || dnsNames[1] != "acme.omani.homes" {
+		t.Errorf("cert dnsNames: got %v, want [*.acme.omani.homes acme.omani.homes]", dnsNames)
 	}
-	if secret, _, _ := unstructured.NestedString(cert.Object, "spec", "secretName"); secret != "org-wildcard-tls-omani-homes" {
-		t.Errorf("cert secretName: got %q, want org-wildcard-tls-omani-homes", secret)
+	if cn, _, _ := unstructured.NestedString(cert.Object, "spec", "commonName"); cn != "acme.omani.homes" {
+		t.Errorf("cert commonName: got %q, want acme.omani.homes", cn)
+	}
+	if secret, _, _ := unstructured.NestedString(cert.Object, "spec", "secretName"); secret != "org-wildcard-tls-acme-omani-homes" {
+		t.Errorf("cert secretName: got %q, want org-wildcard-tls-acme-omani-homes", secret)
 	}
 	if issuer, _, _ := unstructured.NestedString(cert.Object, "spec", "issuerRef", "name"); issuer != "letsencrypt-dns01-prod-powerdns" {
 		t.Errorf("cert issuerRef.name: got %q, want letsencrypt-dns01-prod-powerdns", issuer)
 	}
 
-	// Assert the Gateway listeners: apex preserved + two pool listeners.
+	// Assert the Gateway listeners: apex preserved + two per-Org listeners.
 	gotGW := unstructured.Unstructured{}
 	gotGW.SetGroupVersionKind(gatewayGVK)
 	if err := r.Get(context.Background(), client.ObjectKey{Namespace: "kube-system", Name: "cilium-gateway-console"}, &gotGW); err != nil {
@@ -1399,20 +1407,20 @@ func TestReconcileTenantConsoleTLS_IssuesCertAndAppendsListener(t *testing.T) {
 	if _, ok := names["console-https"]; !ok {
 		t.Errorf("apex listener console-https was dropped — MUST be preserved (regression)")
 	}
-	httpsL, ok := names["pool-https-omani-homes"]
+	httpsL, ok := names["console-https-acme"]
 	if !ok {
-		t.Fatalf("pool HTTPS listener pool-https-omani-homes not appended")
+		t.Fatalf("per-Org HTTPS listener console-https-acme not appended")
 	}
-	if httpsL["hostname"] != "*.omani.homes" {
-		t.Errorf("pool HTTPS hostname: got %v, want *.omani.homes", httpsL["hostname"])
+	if httpsL["hostname"] != "*.acme.omani.homes" {
+		t.Errorf("per-Org HTTPS hostname: got %v, want *.acme.omani.homes", httpsL["hostname"])
 	}
 	tls := httpsL["tls"].(map[string]any)
 	refs := tls["certificateRefs"].([]any)
-	if len(refs) != 1 || refs[0].(map[string]any)["name"] != "org-wildcard-tls-omani-homes" {
-		t.Errorf("pool HTTPS certificateRefs: got %v, want secret org-wildcard-tls-omani-homes", refs)
+	if len(refs) != 1 || refs[0].(map[string]any)["name"] != "org-wildcard-tls-acme-omani-homes" {
+		t.Errorf("per-Org HTTPS certificateRefs: got %v, want secret org-wildcard-tls-acme-omani-homes", refs)
 	}
-	if _, ok := names["pool-http-omani-homes"]; !ok {
-		t.Errorf("pool HTTP listener pool-http-omani-homes not appended")
+	if _, ok := names["console-http-acme"]; !ok {
+		t.Errorf("per-Org HTTP listener console-http-acme not appended")
 	}
 
 	// Second pass: idempotent — no further change.

--- a/core/controllers/organization/internal/controller/tenant_console_tls.go
+++ b/core/controllers/organization/internal/controller/tenant_console_tls.go
@@ -1,40 +1,59 @@
-// tenant_console_tls.go — per-pool console-TLS reconciler (issue #4075).
+// tenant_console_tls.go — per-Org console-TLS reconciler (issues #4075, #4241).
 //
-// Problem (#4075, live on the permanent omantel.biz Sovereign, dep
+// Problem (#4075/#4241, live on the permanent omantel.biz Sovereign, dep
 // 4635277cae4ffed9): a customer Organization that picks a free-subdomain
-// hostname under a pool parent zone — e.g. `console.demo.omani.homes`
-// under the `omani.homes` org-pool parent — resolved in DNS to the
-// console LoadBalancer (212.72.24.33) but failed with
-// ERR_CONNECTION_CLOSED. Root cause: the bootstrap-rendered console
-// Cilium Gateway (clusters/_template/sovereign-tls/cilium-gateway-
-// console.yaml) carries ONLY the apex `*.<sovFQDN>` listener bound to
-// the apex wildcard Secret `sovereign-wildcard-tls-<sovFQDN-dashed>`.
-// There is NO `*.<parentDomain>` TLS Certificate and NO matching
-// listener, so a TLS ClientHello with SNI=console.<slug>.<parentDomain>
-// matches no listener → Envoy closes the connection before any HTTP is
-// exchanged. (`kubectl get certificate -A | grep <parentDomain>` = 0.)
+// hostname under a pool parent zone — e.g. `console.demo.omani.works`
+// under the `omani.works` org-pool parent — resolves in DNS to the
+// console LoadBalancer (212.72.24.33) and routes over HTTP, but the
+// HTTPS handshake fails the cert SAN match:
+//
+//	curl: (60) SSL: no alternative certificate subject name matches
+//	target host name 'console.demo.omani.works'
+//
+// Root cause (#4241): the bootstrap-rendered console Cilium Gateway
+// (clusters/_template/sovereign-tls/cilium-gateway-console.yaml) carries
+// the apex `*.<sovFQDN>` listener, and an earlier version of THIS
+// reconciler additionally appended a SHARED-pool `*.<parentDomain>`
+// (1-label) listener + cert. Neither covers the 2-label host
+// `console.<slug>.<parentDomain>`: Gateway-API hostname wildcards (and
+// Let's-Encrypt wildcard SANs) match exactly ONE label, so
+// `*.omani.works` can serve `f4179done.omani.works` but never
+// `console.f4179done.omani.works`. Every pool Org — including the BSS
+// `f4179walk` control — gets a SAN mismatch on its signed-in HTTPS
+// landing.
 //
 // The HTTPRoute alone (tenant_route.go) is necessary but NOT sufficient:
-// without the cert + listener the request never survives the TLS
-// handshake to reach a route. This reconciler supplies the two missing
-// pieces, idempotently and additively, whenever an Org sets
-// `spec.tenantPublic.parentDomain`:
+// without a SAN-matching cert + a matching listener, the request fails
+// the TLS handshake before any route is selected. This reconciler
+// supplies the two missing pieces, idempotently and additively,
+// whenever an Org sets `spec.tenantPublic.parentDomain` — issuing the
+// SAME per-Org cert/listener shape the catalyst-api BSS door already
+// emits (org_console_tls.go), so the funnel + BSS doors converge on
+// byte-identical resource names:
 //
-//  1. A cert-manager Certificate `org-wildcard-tls-<parentDomain-dashed>`
+//  1. A cert-manager Certificate `org-wildcard-tls-<slug>-<parent-dashed>`
 //     in the console Gateway's namespace, with dnsNames
-//     `*.<parentDomain>` + `<parentDomain>`, issued by the DNS-01
-//     ClusterIssuer (a wildcard SAN can ONLY be solved via DNS-01). The
-//     Certificate is shared by every Org under the same pool parent
-//     (one cert per parent zone, not per Org) so the Let's-Encrypt
-//     issuance count stays bounded regardless of Org count.
+//     `*.<slug>.<parentDomain>` + `<slug>.<parentDomain>`, issued by the
+//     DNS-01 ClusterIssuer (a wildcard SAN can ONLY be solved via
+//     DNS-01; the per-Org `*.<slug>` zone is solvable because #4236's
+//     org-controller already writes the `<slug>` A-record into the
+//     central pool zone). The 2-label `*.<slug>.<parent>` SAN is what
+//     covers `console.<slug>.<parent>` — the apex pool wildcard cannot.
 //
-//  2. A listener pair on the console Gateway — `pool-https-
-//     <parentDomain-dashed>` (HTTPS, terminates on the Secret above) and
-//     `pool-http-<parentDomain-dashed>` (HTTP) — hostnamed
-//     `*.<parentDomain>`, appended to the EXISTING listeners array
-//     WITHOUT touching the apex `*.<sovFQDN>` listeners. The append is
-//     idempotent: a listener whose name already exists is left
-//     untouched (no duplicate, no spec churn).
+//  2. A listener pair on the console Gateway — `console-https-<slug>`
+//     (HTTPS, terminates on the Secret above) and `console-http-<slug>`
+//     (HTTP) — hostnamed `*.<slug>.<parentDomain>`, appended to the
+//     EXISTING listeners array WITHOUT touching the apex `*.<sovFQDN>`
+//     listeners or any other Org's listeners. The append is idempotent:
+//     a listener whose name already exists is left untouched (no
+//     duplicate, no spec churn).
+//
+// Why per-Org (not one shared pool cert): the SAN must descend a label
+// per Org, so each Org needs its own cert + listener. The Let's-Encrypt
+// issuance count grows one cert per Org rather than one per pool zone —
+// acceptable for the funnel volume; if LE-throttled, the operator swaps
+// the pool TLD (omani.works ↔ omantel.biz) or points the issuer at the
+// staging ClusterIssuer for a demo (env-overridable, Principle #4).
 //
 // Why unstructured (not the cert-manager / gateway-api Go types): the
 // whole organization-controller already manipulates the Gateway-API
@@ -43,10 +62,10 @@
 // that discipline here — Certificate and Gateway are both written
 // through Unstructured.
 //
-// Per docs/INVIOLABLE-PRINCIPLES.md #4 every operationally-meaningful
-// value (Gateway name/namespace, ClusterIssuer, cert namespace, host
-// ports) flows through the Reconciler's env-configured fields — no
-// hardcoded names in the renderer.
+// Per docs/PRINCIPLES.md #4 every operationally-meaningful value (Gateway
+// name/namespace, ClusterIssuer, cert namespace, host ports) flows
+// through the Reconciler's env-configured fields — no hardcoded names in
+// the renderer.
 
 package controller
 
@@ -185,11 +204,42 @@ func (r *Reconciler) consoleUIBackend() (string, int32) {
 	return svc, port
 }
 
-// poolWildcardSecretName is the deterministic name of the per-pool
-// wildcard Certificate + Secret. One per parent zone (shared across all
-// Orgs under it). Mirrors the apex `sovereign-wildcard-tls-*` pattern.
-func poolWildcardSecretName(parentDomain string) string {
-	return "org-wildcard-tls-" + dnsDashed(parentDomain)
+// orgConsoleTLSNames bundles the deterministic per-Org resource names +
+// hosts the reconciler issues. Centralised so the cert secretName, the
+// listener certificateRef, the listener hostname, and the tests all agree
+// byte-for-byte — AND so they match the catalyst-api BSS-door emitter
+// (org_console_tls.go::orgConsoleTLSNames) exactly, the #4241 single-
+// source-of-truth consolidation: both doors render identically-named
+// resources, so whichever pipeline runs for a given Org, the gateway edge
+// sees one consistent cert/listener for `console.<slug>.<parent>`.
+type orgConsoleTLSNames struct {
+	Slug         string // org subdomain (tenantPublic.subdomain || spec.slug), lowercased
+	ParentDomain string // chosen org-pool parent (omani.works/homes/rest/trade)
+	WildcardHost string // *.<slug>.<parent>  — listener hostname + cert SAN (2-label)
+	OrgZone      string //  <slug>.<parent>   — cert CN + SAN
+	CertName     string // org-wildcard-tls-<slug>-<parent-dashed> (== secretName)
+	HTTPSName    string // console-https-<slug> — listener name
+	HTTPName     string // console-http-<slug>  — listener name
+}
+
+// orgConsoleTLSNamesFor computes the deterministic per-Org names from a
+// parentDomain + subdomain. The subdomain is the leftmost label of the
+// Org's public host (tenantPublic.subdomain, defaulting to spec.slug — the
+// same derivation tenant_route.go uses for the HTTPRoute hostname, so the
+// listener hostname + cert SAN + route host all line up).
+func orgConsoleTLSNamesFor(subdomain, parentDomain string) orgConsoleTLSNames {
+	slug := strings.ToLower(strings.TrimSpace(subdomain))
+	parent := strings.ToLower(strings.TrimSpace(parentDomain))
+	parentDashed := dnsDashed(parent)
+	return orgConsoleTLSNames{
+		Slug:         slug,
+		ParentDomain: parent,
+		WildcardHost: "*." + slug + "." + parent,
+		OrgZone:      slug + "." + parent,
+		CertName:     "org-wildcard-tls-" + slug + "-" + parentDashed,
+		HTTPSName:    "console-https-" + slug,
+		HTTPName:     "console-http-" + slug,
+	}
 }
 
 // reconcileTenantConsoleTLS issues the per-pool wildcard Certificate and
@@ -211,38 +261,57 @@ func (r *Reconciler) reconcileTenantConsoleTLS(ctx context.Context, org *orgapi.
 		return false, nil
 	}
 
-	certChanged, err := r.reconcilePoolWildcardCert(ctx, org, parentDomain)
-	if err != nil {
-		return false, fmt.Errorf("pool wildcard cert for %q: %w", parentDomain, err)
+	// Subdomain defaults to the Org slug — the SAME derivation
+	// tenant_route.go uses for the HTTPRoute hostname, so the per-Org cert
+	// SAN + listener hostname + route host all line up on
+	// `*.<slug>.<parent>` / `console.<slug>.<parent>`.
+	subdomain := strings.TrimSpace(org.Spec.TenantPublic.Subdomain)
+	if subdomain == "" {
+		subdomain = org.Spec.Slug
 	}
-	listenerChanged, err := r.ensureConsolePoolListener(ctx, parentDomain)
+	if strings.TrimSpace(subdomain) == "" {
+		// No slug at all — cannot form a 2-label host. No-op (the Org's
+		// other reconcile outputs still land); a later pass with a slug
+		// set re-runs this.
+		return false, nil
+	}
+	names := orgConsoleTLSNamesFor(subdomain, parentDomain)
+
+	certChanged, err := r.reconcileOrgWildcardCert(ctx, org, names)
 	if err != nil {
-		return certChanged, fmt.Errorf("console listener for %q: %w", parentDomain, err)
+		return false, fmt.Errorf("org wildcard cert for %q: %w", names.WildcardHost, err)
+	}
+	listenerChanged, err := r.ensureConsoleOrgListener(ctx, names)
+	if err != nil {
+		return certChanged, fmt.Errorf("console listener for %q: %w", names.WildcardHost, err)
 	}
 	return certChanged || listenerChanged, nil
 }
 
-// reconcilePoolWildcardCert create-or-updates the cert-manager
-// Certificate for `*.<parentDomain>`. Idempotent: re-applies the desired
-// spec on every pass (cert-manager treats an unchanged spec as a no-op,
-// so this does not trigger re-issuance).
-func (r *Reconciler) reconcilePoolWildcardCert(ctx context.Context, org *orgapi.Organization, parentDomain string) (bool, error) {
+// reconcileOrgWildcardCert create-or-updates the per-Org cert-manager
+// Certificate for `*.<slug>.<parentDomain>` + `<slug>.<parentDomain>`
+// (the 2-label SAN that covers `console.<slug>.<parentDomain>` — the
+// apex pool wildcard `*.<parentDomain>` cannot, #4241). Idempotent:
+// re-applies the desired spec only when it drifts (cert-manager treats
+// an unchanged spec as a no-op, so this does not trigger re-issuance).
+func (r *Reconciler) reconcileOrgWildcardCert(ctx context.Context, org *orgapi.Organization, names orgConsoleTLSNames) (bool, error) {
 	ns := r.consoleTLSCertNamespace()
-	name := poolWildcardSecretName(parentDomain)
+	name := names.CertName
 
 	labels := map[string]string{
-		"app.kubernetes.io/managed-by":    "catalyst",
-		"openova.io/managed-by":           "organization-controller",
-		"openova.io/sovereign":            org.Spec.SovereignRef,
-		"catalyst.openova.io/component":   "cilium-gateway-console",
-		"catalyst.openova.io/parent-zone": parentDomain,
+		"app.kubernetes.io/managed-by":      "catalyst",
+		"openova.io/managed-by":             "organization-controller",
+		"openova.io/sovereign":              org.Spec.SovereignRef,
+		"catalyst.openova.io/component":     "cilium-gateway-console",
+		"catalyst.openova.io/parent-zone":   names.ParentDomain,
+		"catalyst.openova.io/org-subdomain": names.Slug,
 	}
 
 	desiredSpec := map[string]any{
-		"commonName": parentDomain,
+		"commonName": names.OrgZone,
 		"dnsNames": []any{
-			"*." + parentDomain,
-			parentDomain,
+			names.WildcardHost,
+			names.OrgZone,
 		},
 		"secretName": name,
 		"issuerRef": map[string]any{
@@ -287,20 +356,24 @@ func (r *Reconciler) reconcilePoolWildcardCert(ctx context.Context, org *orgapi.
 	return true, nil
 }
 
-// ensureConsolePoolListener appends the `*.<parentDomain>` HTTPS+HTTP
-// listener pair to the console Gateway if (and only if) listeners with
-// those names don't already exist. The append is strictly additive — it
-// reads the live listeners array, leaves every existing entry byte-for-
-// byte intact, and writes back the array with the two new entries
-// appended. A second pass with both names already present is a no-op.
-func (r *Reconciler) ensureConsolePoolListener(ctx context.Context, parentDomain string) (bool, error) {
+// ensureConsoleOrgListener appends the per-Org `*.<slug>.<parentDomain>`
+// HTTPS+HTTP listener pair to the console Gateway if (and only if)
+// listeners with those names don't already exist. The append is strictly
+// additive — it reads the live listeners array, leaves every existing
+// entry byte-for-byte intact (the apex `*.<sovFQDN>` pair AND every other
+// Org's per-Org listeners), and writes back the array with the two new
+// entries appended. A second pass with both names already present is a
+// no-op. The listener names (`console-https-<slug>` / `console-http-<slug>`)
+// and the `*.<slug>.<parent>` hostname match the catalyst-api BSS-door
+// emitter byte-for-byte (#4241), so whichever door provisions a given Org,
+// the gateway edge converges on one consistent listener.
+func (r *Reconciler) ensureConsoleOrgListener(ctx context.Context, names orgConsoleTLSNames) (bool, error) {
 	gwNS := r.consoleGatewayNamespace()
 	gwName := r.consoleGatewayName()
-	dashed := dnsDashed(parentDomain)
-	httpsName := "pool-https-" + dashed
-	httpName := "pool-http-" + dashed
-	hostname := "*." + parentDomain
-	secretName := poolWildcardSecretName(parentDomain)
+	httpsName := names.HTTPSName
+	httpName := names.HTTPName
+	hostname := names.WildcardHost
+	secretName := names.CertName
 
 	gw := unstructured.Unstructured{}
 	gw.SetGroupVersionKind(gatewayGVK)


### PR DESCRIPTION
## What

The org-controller's `reconcileTenantConsoleTLS` (`core/controllers/organization/internal/controller/tenant_console_tls.go`) issued only a **SHARED-pool 1-label** cert `*.<parent>` + a `pool-https-<parent>` listener hostnamed `*.<parent>`. A 1-label wildcard cannot cover the **2-label** customer console host `console.<slug>.<parent>` — Gateway-API hostname wildcards and Let's-Encrypt wildcard SANs match exactly one label, so `*.omani.works` serves `f4179done.omani.works` but never `console.f4179done.omani.works`.

Result (live omantel.biz, 2026-06-24): every pool Org — the marketplace funnel AND the BSS `f4179walk` control — failed its signed-in HTTPS landing with:

```
curl: (60) SSL: no alternative certificate subject name matches target host name 'console.f4179done.omani.works'
# served cert: CN=omani.works, SAN=[*.omani.works, omani.works]
```

This is the **final layer of #4179** (#4236 just made the host RESOLVE + route over HTTP).

## The fix

Converge the org-controller emitter onto the SAME per-Org cert/listener shape the catalyst-api BSS door already renders (`products/catalyst/bootstrap/api/internal/handler/org_console_tls.go`), **byte-for-byte**, so the funnel + BSS doors produce one consistent cert/listener at the gateway edge (the #4236-style single-source-of-truth consolidation, now for the TLS layer):

- **Cert** `org-wildcard-tls-<slug>-<parent-dashed>`, SANs `*.<slug>.<parent>` + `<slug>.<parent>` (CN `<slug>.<parent>`), DNS-01 via the powerdns ClusterIssuer. The `*.<slug>` zone is DNS-01-solvable because #4236's org-controller already writes the `<slug>` A-record into the central pool zone.
- **Listener pair** `console-https-<slug>` / `console-http-<slug>` hostnamed `*.<slug>.<parent>`, appended **additively** to `cilium-gateway-console` (kube-system) — never touches the apex `*.<sovFQDN>` listeners or any other Org's listeners. Idempotent (existing names = no-op).
- Subdomain derivation matches `tenant_route.go` (`tenantPublic.subdomain || spec.slug`), so the cert SAN, listener hostname, and HTTPRoute host all line up on `console.<slug>.<parent>`.
- Non-fatal + requeued on transient failure (DNS-01 latency / Gateway-update conflict): the Org still goes Ready while the cert issues.
- All values stay env-overridable (Principle #4).

## Tests

`go build ./...` + `go vet` green on `core/controllers`. `TestReconcileTenantConsoleTLS_*` updated to assert the 2-label shape (cert `org-wildcard-tls-acme-omani-homes`, SAN `*.acme.omani.homes` + `acme.omani.homes`, listeners `console-https-acme` / `console-http-acme` hostnamed `*.acme.omani.homes`, apex listener preserved, idempotent second pass). Full organization-controller suite passes.

## Live verification (pending roll)

DoD per #4241/#4179: after this rolls to the live org-controller, `https://console.<slug>.omani.works/jobs` on a fresh funnel signup serves a valid cert covering the 2-label host and lands SIGNED-IN. Prove with `dig` resolves + `curl -v` (correct CN/SAN, trusted chain) + a Playwright signed-in screenshot over HTTPS, for both the funnel + the BSS `f4179walk` control. LE rate-limit note: per-Org certs multiply issuance on `omani.works` — if throttled, swap the pool TLD (`omani.works` ↔ `omantel.biz`) or point the issuer at the staging ClusterIssuer for the demo (env-overridable).

Refs #4241 #4179 #4236 #4075

🤖 Generated with [Claude Code](https://claude.com/claude-code)