### PR TITLE
fix(bp-wordpress-tenant): oidc-config Job emptyDir + pg4wp self-seed — kill RWO wp-content PVC Multi-Attach deadlock (0.4.16)

### DIFF
--- a/platform/wordpress-tenant/blueprint.yaml
+++ b/platform/wordpress-tenant/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: tenant-app
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.4.15
+  version: 0.4.16
   card:
     title: WordPress (per-Organization)
     summary: |

--- a/platform/wordpress-tenant/chart/Chart.yaml
+++ b/platform/wordpress-tenant/chart/Chart.yaml
@@ -184,7 +184,27 @@ name: bp-wordpress-tenant
 #   now emits gateway.{enabled,host,parentRef} instead of the dead ingress
 #   block. Verified live: GET https://wordpress.<slug>.<pool>/ → 200 serving
 #   the WordPress site (was 404).
-version: 0.4.15
+# 0.4.16 (#4220, Refs #4155): FIX the demo-Org WordPress post-upgrade hook
+#   DEADLOCK that left the HelmRelease Ready=False after the DB recovered.
+#   Root cause: templates/oidc-config-job.yaml mounted the SAME ReadWriteOnce
+#   `wp-content` PVC the runtime WordPress Deployment holds for its whole
+#   lifetime. A Sovereign's only StorageClass is RWO (evs-ssd / Huawei EVS —
+#   no RWX class exists), so the concurrent Job blocked forever on the kubelet
+#   "Multi-Attach error for volume ... Volume is already used by pod(s)
+#   bp-wordpress-tenant-..." → the post-install/post-upgrade hook never started
+#   → Helm timed out → HR Ready=False (and on a COLD install the failed hook
+#   rolls the release back, dropping the HTTPRoute → customer host 404).
+#   Confirmed live on the omantel.biz demo Org (kom4dc): the oidc-config Job pod
+#   sat ContainerCreating with FailedAttachVolume while the WordPress pod served
+#   200 with the PVC attached.
+#   FIX: the oidc-config Job now mounts its OWN emptyDir for wp-content (never
+#   the shared PVC) and self-seeds the pg4wp `wp-content/db.php` Postgres-adapter
+#   drop-in (same GitHub source + version 3.3.1 as the deployment's
+#   wp-plugin-install initContainer) so wp-cli reaches the bp-cnpg Postgres
+#   backend. The OIDC plugin settings + admin user persist in POSTGRES, not on
+#   the PVC, so an ephemeral wp-content is correct + deadlock-free. The recovered
+#   demo-Org HR converges Ready without the Multi-Attach stall.
+version: 0.4.16
 appVersion: "6"
 description: |
   Catalyst Blueprint scratch chart for in-vcluster WordPress, one

--- a/platform/wordpress-tenant/chart/templates/oidc-config-job.yaml
+++ b/platform/wordpress-tenant/chart/templates/oidc-config-job.yaml
@@ -133,9 +133,44 @@ spec:
               # The wordpress:cli image's default WORKDIR is /var/www/html;
               # wp-cli expects to find wp-config.php and the WordPress
               # core files there. We materialise wp-config.php inline so
-              # `wp` boots WordPress and chain-loads pg4wp from the
-              # mounted /var/www/html/wp-content PVC (db.php drop-in).
+              # `wp` boots WordPress and chain-loads pg4wp from a SELF-SEEDED
+              # /var/www/html/wp-content/db.php drop-in (step 0 below).
+              #
+              # #4220 (Refs #4155): this Job mounts its OWN emptyDir for
+              # wp-content, NOT the runtime Deployment's ReadWriteOnce
+              # `wp-content` PVC. The Sovereign's only StorageClass is
+              # RWO (evs-ssd / Huawei EVS — no RWX class exists), so a Job
+              # that mounted the same PVC while the WordPress Pod holds it
+              # deadlocked on the kubelet Multi-Attach error
+              # ("Volume is already used by pod(s) bp-wordpress-tenant-...")
+              # → the post-upgrade hook never started → Helm timed out →
+              # HR Ready=False (and on cold install the release would roll
+              # back, dropping the HTTPRoute → customer host 404). The OIDC
+              # plugin settings + admin user persist in POSTGRES, not on the
+              # PVC, so an ephemeral wp-content is correct; we only need the
+              # pg4wp db.php drop-in for Postgres connectivity, seeded below.
               cd /var/www/html
+
+              # 0. Seed the pg4wp Postgres adapter drop-in into THIS Job's
+              #    ephemeral wp-content (same source + version as the
+              #    deployment's wp-plugin-install initContainer). WordPress
+              #    chain-loads wp-content/db.php on every boot; without it
+              #    wp-cli speaks MySQL and `wp db check` fails against the
+              #    bp-cnpg Postgres backend.
+              if [ ! -f wp-content/db.php ]; then
+                echo "[oidc-config] seeding pg4wp db.php drop-in (Postgres adapter)"
+                mkdir -p wp-content
+                curl -fsSL -o /tmp/pg4wp.zip \
+                  https://github.com/PostgreSQL-For-Wordpress/postgresql-for-wordpress/archive/refs/tags/3.3.1.zip
+                # wp-cli's bundled PHP can unzip without a system `unzip`.
+                php -r '$z=new ZipArchive();$z->open("/tmp/pg4wp.zip");$z->extractTo("/tmp/");$z->close();'
+                cp -a /tmp/postgresql-for-wordpress-3.3.1/pg4wp wp-content/
+                cp /tmp/postgresql-for-wordpress-3.3.1/pg4wp/db.php wp-content/db.php
+                rm -rf /tmp/postgresql-for-wordpress-3.3.1 /tmp/pg4wp.zip
+                echo "[oidc-config] pg4wp db.php seeded"
+              else
+                echo "[oidc-config] pg4wp db.php already present"
+              fi
 
               # 1. Materialise wp-config.php — same contract as the
               #    runtime container's WORDPRESS_CONFIG_EXTRA so the
@@ -168,9 +203,9 @@ spec:
 
               # 2. Wait for the database to be reachable. wp-cli
               #    `wp db check` returns non-zero when the DB isn't up;
-              #    we poll for up to 5 minutes. pg4wp's drop-in will
-              #    automatically run from wp-content/db.php, having been
-              #    seeded by the wp-plugin-install initContainer.
+              #    we poll for up to 5 minutes. pg4wp's drop-in runs
+              #    automatically from the wp-content/db.php seeded in
+              #    step 0 above.
               for i in $(seq 1 60); do
                 if wp db check --allow-root >/dev/null 2>&1; then
                   echo "[oidc-config] database reachable"
@@ -296,11 +331,14 @@ spec:
               cpu: 500m
               memory: 256Mi
       volumes:
+        # #4220 (Refs #4155): ALWAYS an emptyDir — never the runtime
+        # Deployment's ReadWriteOnce `wp-content` PVC. The WordPress Pod
+        # holds that RWO PVC for its whole lifetime; a concurrent Job that
+        # mounted it would block forever on the kubelet Multi-Attach error
+        # (the Sovereign has no RWX StorageClass). This Job only needs the
+        # pg4wp db.php drop-in (self-seeded in step 0) for Postgres
+        # connectivity; the OIDC settings it writes persist in Postgres,
+        # so the ephemeral wp-content is the correct, deadlock-free choice.
         - name: wp-content
-          {{- if .Values.persistence.wpContent.enabled }}
-          persistentVolumeClaim:
-            claimName: {{ include "bp-wordpress-tenant.fullname" . }}-wp-content
-          {{- else }}
           emptyDir: {}
-          {{- end }}
 {{- end }}

--- a/platform/wordpress-tenant/chart/tests/oidc-config.sh
+++ b/platform/wordpress-tenant/chart/tests/oidc-config.sh
@@ -195,13 +195,16 @@ if grep -qE '^kind: (HTTPRoute|Ingress)$' "$TMP/canonical.yaml"; then
 fi
 echo "  PASS"
 
-echo "[oidc-config] Case 7: wp-content PVC mounted in Job (so seeded plugin/db.php drop-in are visible)"
-# The Job MUST mount the same wp-content PVC the runtime container
-# uses, otherwise wp-cli won't find pg4wp's db.php drop-in and `wp db
-# check` will fall through to the default mysqli adapter (which fails
-# against bp-cnpg).
+echo "[oidc-config] Case 7: wp-content is an emptyDir (NOT the runtime RWO PVC) + the Job self-seeds pg4wp"
+# #4220 (Refs #4155): the Job MUST NOT mount the runtime Deployment's
+# ReadWriteOnce wp-content PVC. The WordPress Pod holds that RWO PVC for
+# its whole lifetime, and a Sovereign's only StorageClass is RWO (no RWX),
+# so a concurrent Job mounting the same PVC deadlocks on the kubelet
+# Multi-Attach error → the post-upgrade hook never runs → HR Ready=False.
+# Instead the Job mounts its OWN emptyDir and self-seeds the pg4wp db.php
+# drop-in so wp-cli still reaches the bp-cnpg Postgres backend.
 #
-# Extract just the oidc-config Job document and assert PVC mount.
+# Extract just the oidc-config Job document and assert the emptyDir mount.
 python3 - "$TMP/canonical.yaml" <<'PYEOF'
 import sys, yaml
 docs = list(yaml.safe_load_all(open(sys.argv[1])))
@@ -213,17 +216,25 @@ job = next(
 assert job, "oidc-config Job missing"
 spec = job['spec']['template']['spec']
 volumes = spec.get('volumes') or []
+# MUST NOT carry any PVC volume (that would Multi-Attach-deadlock the RWO PVC).
 pvc_vols = [v for v in volumes if v.get('persistentVolumeClaim')]
-assert pvc_vols, "oidc-config Job has no PVC volumes"
-claim = pvc_vols[0]['persistentVolumeClaim']['claimName']
-assert claim.endswith('-wp-content'), f"unexpected PVC claim: {claim}"
+assert not pvc_vols, f"oidc-config Job must not mount a PVC (Multi-Attach deadlock); found: {pvc_vols}"
+# MUST mount an emptyDir named wp-content at the WordPress wp-content path.
+wp_vols = [v for v in volumes if v.get('name') == 'wp-content']
+assert wp_vols, "oidc-config Job has no wp-content volume"
+assert 'emptyDir' in wp_vols[0], f"wp-content volume must be emptyDir, got: {wp_vols[0]}"
 mounts = spec['containers'][0].get('volumeMounts') or []
-mount_names = [m['name'] for m in mounts]
-assert pvc_vols[0]['name'] in mount_names, "PVC volume not mounted into container"
-mount = next(m for m in mounts if m['name'] == pvc_vols[0]['name'])
+mount = next((m for m in mounts if m['name'] == 'wp-content'), None)
+assert mount, "wp-content volume not mounted into container"
 assert mount['mountPath'] == '/var/www/html/wp-content', \
   f"unexpected mountPath: {mount['mountPath']}"
-print(f"  PVC {claim} -> {mount['mountPath']}")
+# The Job's command MUST self-seed the pg4wp db.php drop-in (so wp-cli
+# speaks Postgres without depending on the runtime PVC's seeded copy).
+cmd = "\n".join(spec['containers'][0].get('command') or []) \
+    + "\n".join(spec['containers'][0].get('args') or [])
+assert 'pg4wp' in cmd and 'db.php' in cmd, \
+  "oidc-config Job command must self-seed the pg4wp db.php drop-in"
+print(f"  emptyDir wp-content -> {mount['mountPath']}; pg4wp db.php self-seeded")
 PYEOF
 echo "  PASS"
 


### PR DESCRIPTION
## Problem (live on the omantel.biz demo Org / kom4dc)

After the demo-Org WordPress DB was recovered, the `bp-wordpress-tenant` HelmRelease stayed **Ready=False** — `post-upgrade hooks failed: timed out waiting for the condition`. The WordPress Pod itself served HTTP 200 (the public page `https://wordpress.demo.omani.homes/` loaded the install screen), but the HR never converged.

Root cause: `templates/oidc-config-job.yaml` mounted the **same ReadWriteOnce `wp-content` PVC** the runtime WordPress Deployment holds for its whole lifetime. A Sovereign's only StorageClass is RWO (`evs-ssd` / Huawei EVS — there is **no RWX class**), so the concurrent post-install/post-upgrade Job blocked forever on the kubelet:

```
Multi-Attach error for volume "pvc-..." Volume is already used by pod(s) bp-wordpress-tenant-...
```

→ the hook Job pod sat `ContainerCreating` / `FailedAttachVolume` → Helm timed out → HR Ready=False. On a **cold install** the failed hook rolls the release back, which drops the HTTPRoute → customer host 404.

## Fix

The oidc-config Job now mounts its **OWN `emptyDir`** for `wp-content` (never the shared PVC) and **self-seeds the pg4wp `wp-content/db.php`** Postgres-adapter drop-in (same GitHub source + version `3.3.1` as the deployment's `wp-plugin-install` initContainer) so `wp-cli` reaches the bp-cnpg Postgres backend. The OIDC plugin settings + admin user persist in **Postgres**, not on the PVC, so an ephemeral `wp-content` is correct and deadlock-free.

- `templates/oidc-config-job.yaml`: `wp-content` volume `persistentVolumeClaim` → `emptyDir`; new step-0 pg4wp `db.php` self-seed before `wp db check`.
- `tests/oidc-config.sh` **Case 7**: was asserting the PVC mount (the broken behavior); now asserts the emptyDir (no PVC) + pg4wp self-seed.
- `Chart.yaml` 0.4.15 → 0.4.16; `blueprint.yaml` version bump lockstep.

## Note — the empty-seed trap is NOT recurring

This is distinct from #4155's reflector empty-seed trap. The 0.4.15 chart already correctly drops the `data.password: ""` seed and marks the `WORDPRESS_DB_PASSWORD` secretKeyRef `optional: true` — verified by render. The recurrence on the live env was the **CNPG webhook caBundle drift** blocking the HR install entirely (recovered live, separate from this chart change), then this Multi-Attach hook deadlock surfaced once the install proceeded.

## Gates

- `helm lint` clean.
- All 4 chart render-gate tests pass (`oidc-config.sh` 7/7, `active-hot-standby-render.sh`, `imagepullsecrets-render.sh`, `observability-toggle.sh`).
- Full `helm template` render OK; rendered YAML valid; zero `persistentVolumeClaim` in the oidc-config Job.

Refs #4220 #4155

🤖 Generated with [Claude Code](https://claude.com/claude-code)