### PR TITLE
fix(bp-catalyst-platform): bump chart 1.4.813->1.4.814 to deliver org-controller 09dcc10 (#4242 per-Org console TLS) to the Sovereign

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1062,7 +1062,14 @@ spec:
       #   self-sovereignty cutover on handover (CATALYST_FIRE_CUTOVER_ON_HANDOVER
       #   now defaults false via catalystApi.fireCutoverOnHandover). Cutover is a
       #   DELIBERATE BSS-menu action; operator-initiated path unchanged.
-      version: 1.4.813
+      # 1.4.814 — #4179/#4242: deliver org-controller 09dcc10 (per-Org 2-label
+      #   console TLS cert+listener) to the Sovereign. The deploy-bot bumped the
+      #   org-controller image pin 6cdbc50->09dcc10 in chart/values.yaml WITHOUT
+      #   a chart version bump, so the re-pushed 1.4.813 OCI digest never
+      #   superseded the cached one on the Sovereign's Flux (helm-controller
+      #   kept rendering the stale 6cdbc50 content). A fresh version tag forces
+      #   a clean pull. Chart.yaml bumped in lockstep.
+      version: 1.4.814
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -307,7 +307,7 @@ spec:
       # 1.4.122 (#4169): issuer-realm gate on the sovereign-realm newapi-admin
       # AppRegistration (host-side concern; this vcluster-app slot already sets
       # ssoBridgeSync.enabled=false so it never emitted it — pure lockstep bump).
-      version: 1.4.122
+      version: 1.4.123
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/clusters/_template/bootstrap-kit/80a-newapi-host-seams.yaml
+++ b/clusters/_template/bootstrap-kit/80a-newapi-host-seams.yaml
@@ -80,7 +80,7 @@ spec:
       # (below), so it STILL renders the ConfigMap — it is the CANONICAL owner of
       # the sovereign-realm newapi-admin client. The gate only EXCLUDES per-Org
       # tenant installs (issuer .../realms/org-<sub>) that were clobbering it.
-      version: 1.4.122
+      version: 1.4.123
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2974,7 +2974,13 @@ name: bp-catalyst-platform
 #   handover (CATALYST_FIRE_CUTOVER_ON_HANDOVER now defaults false via
 #   catalystApi.fireCutoverOnHandover). Cutover is a DELIBERATE BSS-menu action; the
 #   operator-initiated path is unchanged (NO-REGRESS).
-version: 1.4.813
+# 1.4.814 — #4179/#4242: ship org-controller 09dcc10 (per-Org 2-label console TLS
+#   cert+listener — `*.<slug>.<parent>` SAN covers console.<slug>.<parent>, which the
+#   apex `*.<parent>` pool wildcard cannot). The deploy-bot bumped the org-controller
+#   image pin (6cdbc50->09dcc10) in values.yaml without a chart version bump, so the
+#   re-pushed 1.4.813 OCI digest never superseded the digest cached on the Sovereign's
+#   Flux. A clean version tag forces the pull. bootstrap-kit slot-13 bumped in lockstep.
+version: 1.4.814
 # 1.4.774 — #4082: application-controller ClusterRole gains dr.openova.io/continuums
 #   (get/list/watch/create/update/patch/delete) — was in the controller's own
 #   deploy/rbac.yaml but MISSING from this platform chart, so a singleton /


### PR DESCRIPTION
## Problem

The org-controller fix for the #1 customer bug (#4179) — #4242's `reconcileTenantConsoleTLS`, which issues a per-Org **2-label** console TLS cert (`*.<slug>.<parent>` SAN, covering `console.<slug>.<parent>` — the apex `*.<parent>` pool wildcard cannot) + a `console-https-<slug>` listener — was built into org-controller image `09dcc10` and published to GHCR.

The deploy-bot bumped the org-controller image pin (`6cdbc50` -> `09dcc10`, commit `842d82bfa`) in `products/catalyst/chart/values.yaml` **without bumping the chart version**. It re-pushed the `1.4.813` OCI tag to a new digest (`sha256:13b012…`), but the live Sovereign's Flux `helm-controller` kept rendering the **stale `6cdbc50` content** from the previously-resolved `1.4.813` digest — every forced reconcile (and helm-controller restart) produced a release revision still pinning `6cdbc50`. Verified live on omantel.biz: GHCR `1.4.813` = `09dcc10` (fresh `helm pull`), but release v94/v95/v96 manifests = `6cdbc50`.

This is the deploy-bot-treadmill / re-pushed-same-tag trap (cf. closed #2272, #712).

## Fix

- `Chart.yaml` `1.4.813` -> `1.4.814` (drives the OCI publish tag — a brand-new tag Flux has never cached)
- bootstrap-kit slot-13 pin `1.4.813` -> `1.4.814` (lockstep)
- bootstrap-kit `bp-newapi` pins `1.4.122` -> `1.4.123` (catch up a pre-existing deploy-bot lag; `bp-newapi:1.4.123` is already published in GHCR — unblocks the `check-bootstrap-kit-pin-sync` gate which was already red on main)

`scripts/check-bootstrap-kit-pin-sync.sh` → PASS.

## Verification path

Once `bp-catalyst-platform:1.4.814` publishes and the bootstrap-kit pin rolls, the Sovereign's org-controller advances to `09dcc10` and `reconcileTenantConsoleTLS` lands the per-Org cert+listener. The #4179 end-to-end close-gate walk (fresh signup → SAN-matching HTTPS → signed-in `/jobs`) runs on top of this.

Refs #4179 #4242

🤖 Generated with [Claude Code](https://claude.com/claude-code)