### PR TITLE
fix: per-Org HR disableWait passthrough (newapi DSN deadlock) + real Sovereign cert issuer (stalwart/openclaw/newapi) — unstick demo-Org tertiary apps (Refs #4246)

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -307,7 +307,7 @@ spec:
       # 1.4.122 (#4169): issuer-realm gate on the sovereign-realm newapi-admin
       # AppRegistration (host-side concern; this vcluster-app slot already sets
       # ssoBridgeSync.enabled=false so it never emitted it — pure lockstep bump).
-      version: 1.4.123
+      version: 1.4.124
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/clusters/_template/bootstrap-kit/80a-newapi-host-seams.yaml
+++ b/clusters/_template/bootstrap-kit/80a-newapi-host-seams.yaml
@@ -80,7 +80,7 @@ spec:
       # (below), so it STILL renders the ConfigMap — it is the CANONICAL owner of
       # the sovereign-realm newapi-admin client. The gate only EXCLUDES per-Org
       # tenant installs (issuer .../realms/org-<sub>) that were clobbering it.
-      version: 1.4.123
+      version: 1.4.124
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/core/controllers/application/internal/controller/application_controller.go
+++ b/core/controllers/application/internal/controller/application_controller.go
@@ -1070,6 +1070,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 	bpSourceRef, _, _ := unstructured.NestedString(bp.Object, "spec", "manifests", "source", "ref")
 	bpChart, _, _ := unstructured.NestedString(bp.Object, "spec", "manifests", "chart")
 	bpDigest, _, _ := unstructured.NestedString(bp.Object, "status", "ociDigest")
+	// #4246 — Blueprint authors set spec.manifests.helmRelease.disableWait=true
+	// for charts whose workload Pod gates on a value populated by one of the
+	// chart's OWN post-install/post-upgrade Helm hooks (e.g. bp-newapi's
+	// DSN-gate initContainer + database-secret-sync-job post-install hook).
+	// Without it, Flux's default --wait deadlocks the install. The bootstrap-
+	// kit newapi HR has this hard-coded; this propagates it to the per-Org
+	// Application render path.
+	bpDisableWait, _, _ := unstructured.NestedBool(bp.Object, "spec", "manifests", "helmRelease", "disableWait")
 	// G92.1 #2660 — Blueprint authors declare the vCluster the
 	// rendered HelmRelease targets via spec.placementSchema.vcluster
 	// (dmz|mgmt|rtz). Empty/unset = install onto the host k3s
@@ -1131,6 +1139,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 			VCluster:                 bpVCluster,
 			VClusterHostNamespace:    vcPlacement.HostNamespace,
 			VClusterKubeconfigSecret: vcPlacement.KubeconfigSecret,
+			// #4246 — propagate the Blueprint's DSN-gate / hook-deadlock
+			// avoidance flag onto the rendered HR's install + upgrade.
+			DisableWait: bpDisableWait,
 		})
 		if err != nil {
 			return r.markDegraded(ctx, app, ReasonRenderError,

--- a/core/controllers/pkg/render/manifests.go
+++ b/core/controllers/pkg/render/manifests.go
@@ -167,6 +167,25 @@ type Inputs struct {
 	// `vc-mgmt`, `vc-rtz`. Stamped on
 	// `spec.kubeconfig.secretRef.name`.
 	VClusterKubeconfigSecret string
+
+	// DisableWait, when true, stamps `install.disableWait: true` +
+	// `upgrade.disableWait: true` on the rendered HelmRelease so Flux's
+	// helm-controller does NOT block on workload readiness before running
+	// post-install/post-upgrade hooks.
+	//
+	// Required by charts whose workload Pod gates on a value that one of
+	// the chart's OWN post-install/post-upgrade Helm hooks populates —
+	// e.g. bp-newapi's `wait-for-sql-dsn` initContainer blocks until the
+	// `database-secret-sync-job` (a post-install hook) PATCHes the DSN
+	// Secret. With the default `--wait`, helm-controller waits for the
+	// Deployment to be Ready BEFORE running post-install hooks → the hook
+	// that unblocks the Pod never runs → deadlock → install times out
+	// (#4246). The bootstrap-kit newapi HR sets this by hand
+	// (clusters/_template/bootstrap-kit/80-newapi.yaml); the per-Org
+	// Application path could not, until this field. Sourced from the
+	// Blueprint's `spec.manifests.helmRelease.disableWait`. Default false
+	// (byte-identical legacy shape for every chart that doesn't need it).
+	DisableWait bool
 }
 
 // Source kind constants — mirror the Blueprint CRD enum.
@@ -386,9 +405,18 @@ spec:
     # (target-state): the controller works without an operator
     # pre-creating the namespace.
     createNamespace: true
+{{- if .DisableWait }}
+    # disableWait — do NOT block on workload readiness before running
+    # post-install hooks. Required by charts whose Pod gates on a value a
+    # post-install hook populates (e.g. bp-newapi DSN-gate, #4246).
+    disableWait: true
+{{- end }}
     remediation:
       retries: 3
   upgrade:
+{{- if .DisableWait }}
+    disableWait: true
+{{- end }}
     remediation:
       retries: 3
 {{- if .ValuesYAML }}

--- a/core/controllers/pkg/render/manifests_test.go
+++ b/core/controllers/pkg/render/manifests_test.go
@@ -207,6 +207,37 @@ func TestRender_CreateNamespaceTrue(t *testing.T) {
 	}
 }
 
+// TestRender_DisableWaitDefaultOff asserts that when the Blueprint does NOT
+// set helmRelease.disableWait, the rendered HR carries NO disableWait line —
+// preserving the byte-identical legacy wait:true shape for every chart that
+// doesn't need it (#4246).
+func TestRender_DisableWaitDefaultOff(t *testing.T) {
+	res, err := Render(baseInputs())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(string(res.HelmReleaseYAML), "disableWait") {
+		t.Errorf("disableWait must be absent by default; got:\n%s", res.HelmReleaseYAML)
+	}
+}
+
+// TestRender_DisableWaitStampsInstallAndUpgrade asserts that DisableWait=true
+// stamps install.disableWait + upgrade.disableWait so charts whose Pod gates
+// on a post-install hook (e.g. bp-newapi's DSN-gate) don't deadlock (#4246).
+func TestRender_DisableWaitStampsInstallAndUpgrade(t *testing.T) {
+	in := baseInputs()
+	in.DisableWait = true
+	res, err := Render(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	hr := string(res.HelmReleaseYAML)
+	// Exactly two disableWait lines — one under install:, one under upgrade:.
+	if n := strings.Count(hr, "disableWait: true"); n != 2 {
+		t.Errorf("expected disableWait: true under BOTH install and upgrade (2 occurrences), got %d:\n%s", n, hr)
+	}
+}
+
 // TestRender_VClusterPlacementMGMT asserts the rendered HelmRelease
 // installs INTO the MGMT vCluster (G92.1 #2660 + #2639 EPIC). The
 // vCluster pivot uses Flux v2's spec.kubeConfig.secretRef contract;

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.123
+  version: 1.4.124
   card:
     title: NewAPI
     summary: |
@@ -68,8 +68,8 @@ spec:
             description: Customer-facing API hostname (operator-supplied, e.g. api.<sovereign-fqdn>).
           tlsIssuer:
             type: string
-            default: letsencrypt-prod
-            description: cert-manager ClusterIssuer name.
+            default: letsencrypt-dns01-prod-powerdns
+            description: cert-manager ClusterIssuer name (DNS-01 PowerDNS — the canonical per-Org Sovereign issuer; letsencrypt-prod does not exist on a real Sovereign, #4246).
       database:
         type: object
         required: [existingSecret]
@@ -261,6 +261,17 @@ spec:
   allowedPlacements: [host, mgmt]
   manifests:
     chart: ./chart
+    helmRelease:
+      # #4246 — newapi's wait-for-sql-dsn initContainer blocks until the
+      # database-secret-sync-job (a post-install/post-upgrade Helm hook)
+      # PATCHes the SQL_DSN Secret. With Flux's default --wait, helm-
+      # controller waits for the Deployment to be Ready BEFORE running the
+      # post-install hooks → the hook that unblocks the Pod never runs →
+      # install deadlocks + times out. disableWait lets the hooks run
+      # immediately so the DSN populates and the Pod proceeds. The
+      # bootstrap-kit newapi HR sets this by hand; this propagates it to
+      # the per-Org Application render path (fanout via pkg/render).
+      disableWait: true
   depends:
     - blueprint: bp-cnpg
       version: ^1.0

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -814,7 +814,7 @@ name: bp-newapi
 # the host's redirectUris in the shared sovereign realm -> kills the live
 # "Invalid parameter: redirect_uri" SSO regression on newapi.<sovereign-fqdn>.
 # Lockstep: both slot pins + blueprint → 1.4.122.
-version: 1.4.123
+version: 1.4.124
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -859,7 +859,9 @@ ingress:
   # 2026-05-18. No separate admin.<sov-fqdn> hostname.
   tls:
     enabled: true
-    issuer: "letsencrypt-prod" # cert-manager ClusterIssuer
+    # DNS-01 PowerDNS ClusterIssuer — canonical per-Org Sovereign issuer
+    # (#4246). `letsencrypt-prod` does not exist on a real Sovereign.
+    issuer: "letsencrypt-dns01-prod-powerdns" # cert-manager ClusterIssuer
     apiSecretName: "newapi-api-tls"
   # Path allowlist for the customer-facing host. Anything not on this
   # list returns 404. Locks down the upstream portal UI surface.

--- a/platform/openclaw/blueprint.yaml
+++ b/platform/openclaw/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-7-agentic-workspace
 spec:
-  version: 0.2.1
+  version: 0.2.2
   card:
     title: OpenClaw
     summary: |
@@ -100,8 +100,8 @@ spec:
             properties:
               issuer:
                 type: string
-                default: letsencrypt-prod
-                description: cert-manager ClusterIssuer.
+                default: letsencrypt-dns01-prod-powerdns
+                description: cert-manager ClusterIssuer (DNS-01 PowerDNS — the canonical per-Org Sovereign issuer; letsencrypt-prod does not exist on a real Sovereign, #4246).
   placementSchema:
     modes: [single-region]
     default: single-region

--- a/platform/openclaw/chart/Chart.yaml
+++ b/platform/openclaw/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-openclaw
-version: 0.2.1
+version: 0.2.2
 appVersion: "0.2.0"
 description: |
   Catalyst Blueprint chart for the OpenClaw workspace controller pattern

--- a/platform/openclaw/chart/tests/render-toggles.sh
+++ b/platform/openclaw/chart/tests/render-toggles.sh
@@ -190,7 +190,9 @@ done
 echo "  PASS"
 
 echo "[render-toggles] Case 7: ingress carries cert-manager cluster-issuer annotation"
-if ! grep -q 'cert-manager.io/cluster-issuer: "letsencrypt-prod"' "$TMP/default.yaml"; then
+# #4246 — default issuer is the DNS-01 PowerDNS ClusterIssuer that every
+# Sovereign installs; `letsencrypt-prod` does not exist on a real Sovereign.
+if ! grep -q 'cert-manager.io/cluster-issuer: "letsencrypt-dns01-prod-powerdns"' "$TMP/default.yaml"; then
   echo "FAIL: ingress is missing cert-manager.io/cluster-issuer annotation — ACME auto-issue won't fire." >&2
   exit 1
 fi

--- a/platform/openclaw/chart/values.yaml
+++ b/platform/openclaw/chart/values.yaml
@@ -220,7 +220,11 @@ ingress:
   host: "openclaw.example.local"
   tls:
     enabled: true
-    issuer: "letsencrypt-prod"    # cert-manager ClusterIssuer
+    # DNS-01 PowerDNS ClusterIssuer — the canonical per-Org issuer on every
+    # Sovereign (#4246). `letsencrypt-prod` does NOT exist on a real
+    # Sovereign and the Cilium-gateway Sovereign wires no per-host HTTP-01
+    # solver, so DNS-01 is required.
+    issuer: "letsencrypt-dns01-prod-powerdns"    # cert-manager ClusterIssuer
     secretName: "openclaw-tls"
   annotations: {}
 

--- a/platform/stalwart-tenant/blueprint.yaml
+++ b/platform/stalwart-tenant/blueprint.yaml
@@ -24,7 +24,7 @@ spec:
   # mount → added a tls Secret volume + a cert-manager Certificate for
   # mail.<tenant-domain> (secret name via stalwart.tls.secretName).
   # Per #817 Chart.yaml version MUST equal blueprint.yaml spec.version.
-  version: 0.1.5
+  version: 0.1.6
   card:
     title: Stalwart (per-Organization)
     summary: |

--- a/platform/stalwart-tenant/chart/Chart.yaml
+++ b/platform/stalwart-tenant/chart/Chart.yaml
@@ -75,7 +75,7 @@ name: bp-stalwart-tenant
 #        certificate.yaml) for mail.<tenant-domain> that materialises the
 #        Secret zero-touch (secret name configurable via stalwart.tls.secretName,
 #        default stalwart-tls).
-version: 0.1.5
+version: 0.1.6
 appVersion: "0.15.5"
 description: |
   Catalyst Blueprint scratch chart for a per-Org (per-vcluster) dedicated

--- a/platform/stalwart-tenant/chart/values.yaml
+++ b/platform/stalwart-tenant/chart/values.yaml
@@ -83,11 +83,16 @@ stalwart:
       # with NO operator action. Skipped automatically when the tenant
       # domain is empty (smoke-render-safe).
       enabled: true
-      # ClusterIssuer to sign against. Defaults to the same issuer the
-      # webmail Ingress uses (`letsencrypt-prod`); a per-Sovereign overlay
-      # may swap to a staging/internal issuer.
+      # ClusterIssuer to sign against. Defaults to the DNS-01 PowerDNS
+      # ClusterIssuer every Sovereign installs (`letsencrypt-dns01-prod-
+      # powerdns`) — the canonical per-Org issuer (matches catalyst-api's
+      # CATALYST_CONSOLE_TLS_CLUSTER_ISSUER default + the org-controller's
+      # consoleTLSDefaultClusterIssuer). `letsencrypt-prod` does NOT exist
+      # on a real Sovereign (issue #4246); DNS-01 is also required because
+      # the Cilium-gateway Sovereign does not wire a per-host HTTP-01
+      # solver. A per-Sovereign overlay may swap to a staging issuer.
       issuerKind: "ClusterIssuer"
-      issuer: "letsencrypt-prod"
+      issuer: "letsencrypt-dns01-prod-powerdns"
       duration: "2160h"      # 90d
       renewBefore: "360h"    # 15d
 
@@ -350,7 +355,8 @@ ingress:
     # on the gateway's wildcard cert.
     tls:
       enabled: true
-      issuer: "letsencrypt-prod"
+      # See note above — `letsencrypt-prod` is absent on Sovereigns (#4246).
+      issuer: "letsencrypt-dns01-prod-powerdns"
       secretName: "stalwart-webmail-tls"
     # ingress fallback (mode=ingress)
     ingressClassName: "traefik"

--- a/products/catalyst/chart/crds/blueprint.yaml
+++ b/products/catalyst/chart/crds/blueprint.yaml
@@ -345,6 +345,22 @@ spec:
                     values:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
+                    helmRelease:
+                      type: object
+                      description: |
+                        Flux HelmRelease install/upgrade behaviour the
+                        application-controller stamps on the rendered HR (#4246).
+                      properties:
+                        disableWait:
+                          type: boolean
+                          description: |
+                            Stamp install.disableWait + upgrade.disableWait on the
+                            rendered HelmRelease so helm-controller does NOT block on
+                            workload readiness before running post-install/post-upgrade
+                            hooks. Required by charts whose Pod gates on a value one of
+                            the chart's own post-install hooks populates (e.g. bp-newapi
+                            DSN-gate). Default false.
+                      x-kubernetes-preserve-unknown-fields: true
                   x-kubernetes-preserve-unknown-fields: true
                 upgrades:
                   type: object


### PR DESCRIPTION
## Problem
On the PERMANENT omantel.biz Sovereign (dep `4635277cae4ffed9`), the demo Org's three TERTIARY apps never reach Ready on a fresh Org (verified live 2026-06-24). The North Star apps (agenity, WordPress) + keycloak + cnpg converge; bp-newapi / bp-stalwart-tenant / bp-openclaw do not. Two durable root causes, both chart/controller-side and env-independent.

## RC1 — per-Org Application HRs had NO `install.disableWait` → bp-newapi DSN-gate deadlock
`bp-newapi`'s `wait-for-sql-dsn` initContainer blocks until the `database-secret-sync-job` (a `post-install,post-upgrade` Helm hook) PATCHes the SQL_DSN Secret. With Flux's default `--wait`, helm-controller waits for the Deployment to be Ready **before** running post-install hooks → the hook that unblocks the Pod never runs → install times out at 15m → CrashLoop. The **bootstrap-kit** newapi HR hard-codes `install.disableWait: true`; the **per-Org Application** render path (`core/controllers/pkg/render`) had no way to express it.

- `pkg/render` `Inputs` gains `DisableWait`; the HR template stamps `install.disableWait` + `upgrade.disableWait` when set (default off ⇒ byte-identical legacy shape).
- `application_controller` reads `spec.manifests.helmRelease.disableWait` from the Blueprint and passes it through.
- `bp-newapi` blueprint declares `manifests.helmRelease.disableWait: true`.
- Blueprint CRD schema declares the new field.
- New render tests: default-off (no `disableWait` line) + on (2 lines, install + upgrade).

## RC2 — chart-default cert issuer `letsencrypt-prod` does not exist on a Sovereign
A real Sovereign's ClusterIssuers are `letsencrypt-http01-prod`, `letsencrypt-dns01-prod-powerdns`, `letsencrypt-dns01-staging-powerdns`, `kyverno-selfsigned-issuer` — there is **no `letsencrypt-prod`**. The per-Org `stalwart-tls` / `openclaw-tls` CertificateRequests failed `Referenced "ClusterIssuer" not found` → Secrets never materialised → bp-stalwart-tenant pod stuck `ContainerCreating` (`secret "stalwart-tls" not found`) + bp-openclaw cert stuck. Defaulted all three charts (+ blueprint schemas) to `letsencrypt-dns01-prod-powerdns` — the canonical per-Org Sovereign issuer (matches catalyst-api's `CATALYST_CONSOLE_TLS_CLUSTER_ISSUER` + the org-controller's `consoleTLSDefaultClusterIssuer`). DNS-01 is also required because the Cilium-gateway Sovereign wires no per-host HTTP-01 solver. Updated the openclaw render-toggles assertion.

Charts bumped: `bp-newapi 1.4.123→1.4.124`, `bp-stalwart-tenant 0.1.5→0.1.6`, `bp-openclaw 0.2.1→0.2.2` (chart + blueprint lockstep).

## NOT fixed here (split to follow-up — deep scaffold gap)
`bp-openclaw`'s controller image `ghcr.io/openova-io/openova/openclaw-controller:0.1.0-placeholder` **does not exist** — there is no controller source, Dockerfile, or CI workflow (only `openclaw-runtime` is built). The controller Deployment ImagePullBackOffs regardless of the cert fix. bp-openclaw cannot converge until the controller binary is built + published; tracked in #4246.

## Verification
- `go build ./pkg/render/... ./application/...` green; `go test` green (render + application controller suites).
- New `TestRender_DisableWaitDefaultOff` + `TestRender_DisableWaitStampsInstallAndUpgrade` pass; existing render tests unchanged (default path byte-identical).
- `helm template` smoke green on all three charts; openclaw `render-toggles.sh` green.
- Live diagnosis: the cnpg-webhook P0 (#4143) is confirmed FIXED on the Sovereign (server-dry-run Cluster admission succeeds); a force-reconciled bp-newapi created a healthy CNPG cluster `bp-newapi-newapi-pg`, then deadlocked exactly as RC1 predicts (DSN never populated). Manually PATCHing the DSN unblocked the init container — confirming the disableWait fix is the durable remedy.

## Note on the live demo Org
While diagnosing, the live demo Org namespace `org-7283eb4a-...` was concurrently torn down (deletionTimestamp 04:16:25Z) by an in-flight FUNNEL E2E walk (#4179 — `f4179final` vcluster spun up 2m before). The live recovery target no longer exists; these durable fixes apply to every fresh Org including the funnel's successors.

Refs #4246, Refs #4220, Refs #4179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
