### PR TITLE
fix(catalyst-api): register funnel-Org console hosts from the Org CR — the #4179 signed-in landing (Refs #4179)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1062,6 +1062,12 @@ spec:
       #   self-sovereignty cutover on handover (CATALYST_FIRE_CUTOVER_ON_HANDOVER
       #   now defaults false via catalystApi.fireCutoverOnHandover). Cutover is a
       #   DELIBERATE BSS-menu action; operator-initiated path unchanged.
+      # 1.4.816 — #4179 (criterion 4d, SIGNED-IN landing): deliver the catalyst-api
+      #   tenant-registry-from-Org-CRs reconcile (funnel Org console host becomes a
+      #   registered tenant_kind=org host so /auth/org-handover ACCEPTS the session)
+      #   + the slot-13 SOVEREIGN_LB_IP substitute fix (lbIP no longer empty on a
+      #   clean reconcile → org-controller pool-DNS fallback target restored, Refs
+      #   #4236). Clean version tag forces the Flux pull. Chart.yaml lockstep.
       # 1.4.814 — #4179/#4242: deliver org-controller 09dcc10 (per-Org 2-label
       #   console TLS cert+listener) to the Sovereign. The deploy-bot bumped the
       #   org-controller image pin 6cdbc50->09dcc10 in chart/values.yaml WITHOUT
@@ -1069,7 +1075,7 @@ spec:
       #   superseded the cached one on the Sovereign's Flux (helm-controller
       #   kept rendering the stale 6cdbc50 content). A fresh version tag forces
       #   a clean pull. Chart.yaml bumped in lockstep.
-      version: 1.4.815
+      version: 1.4.816
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform
@@ -1242,7 +1248,7 @@ spec:
       # and the chart renders an empty `lbIP` ConfigMap key — catalyst-api
       # then short-circuits the glue registration and falls back to plain
       # set_ns (legacy behaviour).
-      sovereignLBIP: ${SOVEREIGN_LB_IP}
+      sovereignLBIP: ${SOVEREIGN_LB_IP:-}
       # sovereignConsoleLBIP — the dedicated console-ELB IPv4 (#4053 isolation;
       # e.g. 212.72.24.33). Threaded from cloud-init's SOVEREIGN_CONSOLE_LB_IP
       # bootstrap-kit postBuild substitute (fed by infra console_load_balancer_ip).

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -476,6 +476,9 @@ write_files:
             SOVEREIGN_DEPLOYMENT_ID: ${deployment_id}
             # #4236 console-ELB IPv4 → slot-13 sovereignConsoleLBIP (see that file).
             SOVEREIGN_CONSOLE_LB_IP: ${console_load_balancer_ipv4}
+            # #4236/#4179: primary LB IPv4 → slot-13 sovereignLBIP → ConfigMap lbIP
+            # (was undeclared here → lbIP empty → org-controller pool-DNS skip).
+            SOVEREIGN_LB_IP: ${load_balancer_ipv4}
             # SOVEREIGN_OWNER_EMAIL (founder NS-3 #3263) — the deployment
             # owner's email (same org_email as sovereign.json's orgEmail).
             # bp-keycloak slot 09 threads it into sovereignRealm.ownerEmail;

--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -1040,6 +1040,20 @@ func main() {
 		}
 	}
 
+	// #4179 (criterion 4d) — reconcile the tenant registry from Organization
+	// CRs so a MARKETPLACE-funnel-created Org's console host
+	// (console.<slug>.<parentDomain>) is a registered tenant_kind=org host.
+	// Without this row, /auth/org-handover → resolveOrgScope refuses the
+	// session with `invalid audience: not an org console host` and the
+	// customer never lands signed-in. The BSS pipeline writes this row at
+	// Step 6, but the marketplace funnel (tenant-service → provisioning-service
+	// → Org CR) never runs that pipeline — so catalyst-api reconciles its own
+	// registry FROM the Org CRs (the one object both doors create), covering
+	// both doors with a single source of truth (same consolidation as #4236
+	// DNS + #4242 TLS). Async + best-effort: never blocks readiness, retries
+	// on a ticker, and a no-op when the registry/dynamic-client isn't wired.
+	go h.ReconcileTenantRegistryFromOrgCRs(context.Background())
+
 	// Unauthenticated cloud-init postback (issue #183, Option D + #634).
 	// The new Sovereign's control plane PUTs its rewritten kubeconfig
 	// here with `Authorization: Bearer <postback-token>`. PutKubeconfig

--- a/products/catalyst/bootstrap/api/internal/handler/tenant_registry_reconcile.go
+++ b/products/catalyst/bootstrap/api/internal/handler/tenant_registry_reconcile.go
@@ -1,0 +1,225 @@
+// tenant_registry_reconcile.go — reconcile the tenant registry from
+// Organization CRs (issue #4179, criterion 4d — the SIGNED-IN landing).
+//
+// THE GAP this file closes (the #4179 FINAL layer):
+//
+// A fresh marketplace signup's customer is redirected to their console host
+// `console.<slug>.<parentDomain>` (#4184), which now RESOLVES (#4236) and
+// presents a SAN-matching TLS cert (#4242). But landing SIGNED-IN failed:
+// /auth/org-handover (org_handover.go) → resolveOrgScope (org_scope.go)
+// validates the request host against the tenant registry and REFUSES any host
+// it doesn't know as a tenant_kind=org console — returning
+// `invalid audience: not an org console host`. The customer saw the login page
+// but could never get a session.
+//
+// WHY the registry was empty for funnel Orgs:
+//   - The BSS door (organization_provisioning.go Step 6 / org_tenant_org_cr.go)
+//     WRITES the TenantRegistration at STSTenantRegistered.
+//   - The MARKETPLACE funnel door (tenant-service POST /api/tenant/orgs →
+//     tenant.created → provisioning-service createOrganizationCR) mints the
+//     Organization CR + DNS/TLS/route via the org-controller but NEVER runs the
+//     catalyst-api provisioning pipeline, so the registry row was never written.
+//
+// THE FIX (single source of truth, covers BOTH doors): the Organization CR is
+// the one object both doors create. catalyst-api OWNS the flat-file tenant
+// registry (its private PVC at CATALYST_DEPLOYMENTS_DIR/-tenant-registry.json —
+// the org-controller, a separate process, can't write it). So catalyst-api
+// reconciles its OWN registry FROM the Organization CRs: list every Org CR,
+// register `console.<slug>.<parentDomain> → {orgID, Org}`, idempotently. This
+// is the same single-source consolidation #4236 (DNS) + #4242 (TLS) applied to
+// registration — write it where the reconciler already converges every Org,
+// regardless of which door minted it.
+//
+// The Put is idempotent (upsert keyed by host); a steady-state re-reconcile is a
+// no-op. Best-effort: a transient apiserver/list failure is logged and retried
+// on the next tick — it never crashes the API. Out-of-cluster / CI (no dynamic
+// client) is a logged skip, matching every other dynamic-client path here.
+
+package handler
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+// tenantRegistryReconcileInterval is the steady-state cadence at which
+// catalyst-api re-syncs its tenant registry from the Organization CRs. A new
+// funnel Org becomes session-capable within one interval of its CR landing.
+// 60s matches the org-controller's own per-Org Flux interval — fast enough that
+// a fresh signup lands signed-in promptly, cheap enough that a List of a
+// few-thousand-Org cluster is negligible.
+const tenantRegistryReconcileInterval = 60 * time.Second
+
+// ReconcileTenantRegistryFromOrgCRs runs the registry reconcile loop until ctx
+// is cancelled. It performs one sync immediately (so a restart re-registers
+// every existing funnel Org before serving the first handover) then re-syncs on
+// a ticker. Wired from main.go as a background goroutine, mirroring
+// SelfHealSecondaryKubeconfigsOnDisk's async-startup idiom.
+//
+// No-op (returns immediately) when the tenant registry isn't wired — there is
+// nothing to reconcile into.
+func (h *Handler) ReconcileTenantRegistryFromOrgCRs(ctx context.Context) {
+	if h == nil || h.tenantRegistry == nil {
+		return
+	}
+	h.reconcileTenantRegistryOnce(ctx)
+	ticker := time.NewTicker(tenantRegistryReconcileInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			h.reconcileTenantRegistryOnce(ctx)
+		}
+	}
+}
+
+// reconcileTenantRegistryOnce lists every Organization CR and registers each
+// Org's console host into the tenant registry. Idempotent + best-effort:
+// per-Org failures are logged and skipped so one malformed CR never starves the
+// rest; a List failure is logged and the next tick retries.
+func (h *Handler) reconcileTenantRegistryOnce(ctx context.Context) {
+	if h.tenantRegistry == nil {
+		return
+	}
+	deps, err := h.sovereignDepsFor()
+	if err != nil || deps == nil || deps.dyn == nil {
+		// Out-of-cluster / CI: no apiserver to list from. The registry keeps
+		// whatever the BSS pipeline already wrote; the funnel-Org rows simply
+		// aren't synced here. On a real Sovereign this branch never fires.
+		h.log.Info("tenant-registry-reconcile: skipped — no in-cluster dynamic client",
+			"err", err)
+		return
+	}
+
+	list, err := deps.dyn.Resource(organizationGVR()).Namespace("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		h.log.Warn("tenant-registry-reconcile: list Organizations failed — will retry next tick",
+			"err", err)
+		return
+	}
+
+	sovereignFQDN := strings.TrimSpace(h.orgTenantDeps.OTECHFQDN)
+	registered, skipped := 0, 0
+	for i := range list.Items {
+		reg, ok := tenantRegistrationFromOrgCR(&list.Items[i], sovereignFQDN)
+		if !ok {
+			skipped++
+			continue
+		}
+		// Skip the write when the registry already has an identical row for
+		// this host so a steady-state reconcile produces zero file churn (Put
+		// rewrites the whole flat file). A registry row only changes when the
+		// host first appears or its realm/namespace fields change.
+		if cur, found := h.tenantRegistry.Get(reg.Host); found && tenantRegistrationEqual(cur, reg) {
+			continue
+		}
+		if err := h.tenantRegistry.Put(reg); err != nil {
+			h.log.Warn("tenant-registry-reconcile: Put failed for Org console host — will retry next tick",
+				"host", reg.Host, "tenant_id", reg.TenantID, "err", err)
+			skipped++
+			continue
+		}
+		registered++
+		h.log.Info("tenant-registry-reconcile: registered Org console host",
+			"host", reg.Host, "tenant_id", reg.TenantID)
+	}
+	if registered > 0 {
+		h.log.Info("tenant-registry-reconcile: pass complete",
+			"orgs", len(list.Items), "registered", registered, "skipped", skipped)
+	}
+}
+
+// tenantRegistrationFromOrgCR builds the TenantRegistration for an Organization
+// CR, mirroring the shape the BSS pipeline writes at Step 6
+// (organization_provisioning.go) byte-for-byte so both doors yield an identical
+// row. Returns (zero, false) when the CR can't produce a valid pool console host
+// (no slug, or no parentDomain — a single-domain Org rides the Sovereign apex
+// wildcard and is registered by the BSS pipeline, never the funnel).
+//
+// The TenantID comes from the `openova.io/tenant-id` label the funnel stamps
+// (org_tenant_org_cr.go) or the provisioning-service stamps; it falls back to
+// the slug so the row is never empty (Put requires a non-empty tenant_id).
+func tenantRegistrationFromOrgCR(obj *unstructured.Unstructured, sovereignFQDN string) (store.TenantRegistration, bool) {
+	slug := strings.ToLower(strings.TrimSpace(nestedString(obj.Object, "spec", "slug")))
+	if slug == "" {
+		slug = strings.ToLower(strings.TrimSpace(obj.GetName()))
+	}
+	if !orgSlugRE.MatchString(slug) {
+		return store.TenantRegistration{}, false
+	}
+
+	parentDomain := strings.ToLower(strings.TrimSpace(
+		nestedString(obj.Object, "spec", "tenantPublic", "parentDomain")))
+	if parentDomain == "" {
+		// Single-domain Org (no pool parent). Its console host
+		// `console.<slug>.<sovFQDN>` is covered by the Sovereign apex wildcard
+		// and registered by the BSS pipeline when it runs; the funnel never
+		// mints such an Org. Nothing to register here.
+		return store.TenantRegistration{}, false
+	}
+
+	subdomain := strings.ToLower(strings.TrimSpace(
+		nestedString(obj.Object, "spec", "tenantPublic", "subdomain")))
+	if subdomain == "" {
+		subdomain = slug
+	}
+
+	host := "console." + subdomain + "." + parentDomain
+
+	tenantID := strings.TrimSpace(obj.GetLabels()["openova.io/tenant-id"])
+	if tenantID == "" {
+		tenantID = slug
+	}
+
+	// Realm URL + admin endpoint mirror organization_provisioning.go Step 6:
+	// the issuer lives under the same parent zone as the console host, the
+	// realm is `org-<subdomain>`, and the in-cluster admin endpoint targets the
+	// per-Org Keycloak in the Org namespace (= slug, per the org-controller's
+	// namespace convention).
+	realmName := "org-" + subdomain
+	realmURL := fmt.Sprintf("https://keycloak.%s.%s/realms/%s", subdomain, parentDomain, realmName)
+	adminURL := fmt.Sprintf("http://keycloak-%s.%s.svc:8080", subdomain, slug)
+
+	return store.TenantRegistration{
+		Host:                  host,
+		TenantID:              tenantID,
+		TenantKind:            store.TenantKindOrg,
+		KeycloakRealmURL:      realmURL,
+		KeycloakClientID:      "catalyst-ui",
+		OrganizationNamespace: slug,
+		OrgKeycloakAdminURL:   adminURL,
+		OrgKeycloakRealmName:  realmName,
+	}, true
+}
+
+// tenantRegistrationEqual reports whether two registrations are field-for-field
+// identical (host is already lowercased by both producers). Used to short-
+// circuit a no-op Put so a steady-state reconcile never rewrites the flat file.
+func tenantRegistrationEqual(a, b store.TenantRegistration) bool {
+	return a.Host == b.Host &&
+		a.TenantID == b.TenantID &&
+		a.TenantKind == b.TenantKind &&
+		a.KeycloakRealmURL == b.KeycloakRealmURL &&
+		a.KeycloakClientID == b.KeycloakClientID &&
+		a.OrganizationNamespace == b.OrganizationNamespace &&
+		a.OrgKeycloakAdminURL == b.OrgKeycloakAdminURL &&
+		a.OrgKeycloakRealmName == b.OrgKeycloakRealmName
+}
+
+// nestedString reads a string at the given path from an unstructured object's
+// map, returning "" when the path is absent or not a string. A thin wrapper over
+// unstructured.NestedString that swallows the (found, err) tuple — every caller
+// here treats absent/typed-wrong identically as empty.
+func nestedString(obj map[string]any, fields ...string) string {
+	s, _, _ := unstructured.NestedString(obj, fields...)
+	return s
+}

--- a/products/catalyst/bootstrap/api/internal/handler/tenant_registry_reconcile_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/tenant_registry_reconcile_test.go
@@ -1,0 +1,208 @@
+package handler
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+// orgCR builds a minimal Organization CR unstructured with the fields the
+// registry reconcile reads (slug, tenantPublic.{parentDomain,subdomain}, and
+// the openova.io/tenant-id label).
+func orgCR(slug, parentDomain, subdomain, tenantID string) *unstructured.Unstructured {
+	spec := map[string]any{"slug": slug}
+	if parentDomain != "" {
+		tp := map[string]any{"parentDomain": parentDomain}
+		if subdomain != "" {
+			tp["subdomain"] = subdomain
+		}
+		spec["tenantPublic"] = tp
+	}
+	meta := map[string]any{"name": slug}
+	if tenantID != "" {
+		meta["labels"] = map[string]any{"openova.io/tenant-id": tenantID}
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "orgs.openova.io/v1",
+		"kind":       "Organization",
+		"metadata":   meta,
+		"spec":       spec,
+	}}
+}
+
+// TestTenantRegistrationFromOrgCR covers the pure mapping: a pool-parent Org CR
+// produces a tenant_kind=org registration whose Host/realm/namespace mirror the
+// BSS-pipeline shape; a single-domain (no parentDomain) Org and an invalid-slug
+// Org produce no registration.
+func TestTenantRegistrationFromOrgCR(t *testing.T) {
+	t.Run("pool-parent Org → tenant_kind=org registration", func(t *testing.T) {
+		reg, ok := tenantRegistrationFromOrgCR(orgCR("acme", "omani.works", "", "tnt-123"), "omantel.biz")
+		if !ok {
+			t.Fatal("expected a registration for a pool-parent Org")
+		}
+		if reg.Host != "console.acme.omani.works" {
+			t.Errorf("host: want console.acme.omani.works got %q", reg.Host)
+		}
+		if reg.TenantKind != store.TenantKindOrg {
+			t.Errorf("kind: want org got %q", reg.TenantKind)
+		}
+		if reg.TenantID != "tnt-123" {
+			t.Errorf("tenant_id: want tnt-123 got %q", reg.TenantID)
+		}
+		if reg.KeycloakClientID != "catalyst-ui" {
+			t.Errorf("client_id: want catalyst-ui got %q", reg.KeycloakClientID)
+		}
+		if reg.OrgKeycloakRealmName != "org-acme" {
+			t.Errorf("realm: want org-acme got %q", reg.OrgKeycloakRealmName)
+		}
+		if reg.KeycloakRealmURL != "https://keycloak.acme.omani.works/realms/org-acme" {
+			t.Errorf("realm_url: got %q", reg.KeycloakRealmURL)
+		}
+		if reg.OrganizationNamespace != "acme" {
+			t.Errorf("namespace: want acme got %q", reg.OrganizationNamespace)
+		}
+	})
+
+	t.Run("explicit subdomain overrides slug in host", func(t *testing.T) {
+		reg, ok := tenantRegistrationFromOrgCR(orgCR("acme", "omani.works", "shop", "tnt-1"), "omantel.biz")
+		if !ok {
+			t.Fatal("expected a registration")
+		}
+		if reg.Host != "console.shop.omani.works" {
+			t.Errorf("host: want console.shop.omani.works got %q", reg.Host)
+		}
+	})
+
+	t.Run("missing tenant-id label falls back to slug", func(t *testing.T) {
+		reg, ok := tenantRegistrationFromOrgCR(orgCR("acme", "omani.works", "", ""), "omantel.biz")
+		if !ok {
+			t.Fatal("expected a registration")
+		}
+		if reg.TenantID != "acme" {
+			t.Errorf("tenant_id fallback: want acme got %q", reg.TenantID)
+		}
+	})
+
+	t.Run("single-domain Org (no parentDomain) → no registration", func(t *testing.T) {
+		if _, ok := tenantRegistrationFromOrgCR(orgCR("acme", "", "", "tnt-1"), "omantel.biz"); ok {
+			t.Error("expected no registration for an Org without a pool parentDomain")
+		}
+	})
+
+	t.Run("invalid slug → no registration", func(t *testing.T) {
+		// Leading digit fails orgSlugRE (mirrors the BSS-door guard).
+		if _, ok := tenantRegistrationFromOrgCR(orgCR("1bad", "omani.works", "", "t"), "omantel.biz"); ok {
+			t.Error("expected no registration for an invalid slug")
+		}
+	})
+}
+
+// newRegistryReconcileHandler wires a Handler with an empty tenant registry +
+// org-tenant OTECHFQDN + a fake dynamic client seeded with the supplied Org CRs.
+func newRegistryReconcileHandler(t *testing.T, orgs ...*unstructured.Unstructured) (*Handler, *store.TenantRegistry) {
+	t.Helper()
+	dir := t.TempDir()
+	registry, err := store.NewTenantRegistry(dir)
+	if err != nil {
+		t.Fatalf("tenant registry: %v", err)
+	}
+	h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	h.SetTenantRegistry(registry)
+	h.SetOrganizationDeps(OrganizationDeps{OTECHFQDN: "omantel.biz"})
+
+	scheme := runtime.NewScheme()
+	gvrToList := map[schema.GroupVersionResource]string{
+		organizationGVR(): "OrganizationList",
+	}
+	seed := make([]runtime.Object, 0, len(orgs))
+	for _, o := range orgs {
+		seed = append(seed, o)
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToList, seed...)
+	h.SetSovereignDepsFactory(func() (*sovereignDeps, error) {
+		return &sovereignDeps{core: nil, dyn: dyn}, nil
+	})
+	return h, registry
+}
+
+// TestReconcileTenantRegistryOnce_RegistersFunnelOrg is the #4179 criterion-4d
+// binary DoD at the unit level: a marketplace-funnel Org CR (pool parentDomain,
+// no BSS-pipeline run) gets its console host registered as tenant_kind=org —
+// the exact row /auth/org-handover → resolveOrgScope needs to ACCEPT the
+// session. A single-domain Org in the same list is correctly skipped.
+func TestReconcileTenantRegistryOnce_RegistersFunnelOrg(t *testing.T) {
+	h, registry := newRegistryReconcileHandler(t,
+		orgCR("funnelorg", "omani.works", "", "tnt-funnel"),
+		orgCR("legacyorg", "", "", "tnt-legacy"), // no pool parent → skipped
+	)
+
+	h.reconcileTenantRegistryOnce(context.Background())
+
+	got, ok := registry.Get("console.funnelorg.omani.works")
+	if !ok {
+		t.Fatal("funnel Org console host was not registered")
+	}
+	if got.TenantKind != store.TenantKindOrg {
+		t.Errorf("kind: want org got %q", got.TenantKind)
+	}
+	if got.TenantID != "tnt-funnel" {
+		t.Errorf("tenant_id: want tnt-funnel got %q", got.TenantID)
+	}
+	// resolveOrgScope keys off the host + tenant_kind=org; assert the single-
+	// domain Org produced no console.legacyorg.* row.
+	for _, r := range registry.List() {
+		if r.OrganizationNamespace == "legacyorg" {
+			t.Errorf("single-domain Org should not be registered: %+v", r)
+		}
+	}
+}
+
+// TestReconcileTenantRegistryOnce_Idempotent asserts a second pass over the same
+// Org CRs is a no-op (the row is unchanged), so the steady-state ticker never
+// churns the flat file.
+func TestReconcileTenantRegistryOnce_Idempotent(t *testing.T) {
+	h, registry := newRegistryReconcileHandler(t,
+		orgCR("acme", "omani.works", "", "tnt-1"),
+	)
+	h.reconcileTenantRegistryOnce(context.Background())
+	first, ok := registry.Get("console.acme.omani.works")
+	if !ok {
+		t.Fatal("first pass did not register the Org")
+	}
+	h.reconcileTenantRegistryOnce(context.Background())
+	second, ok := registry.Get("console.acme.omani.works")
+	if !ok {
+		t.Fatal("second pass dropped the Org")
+	}
+	if !tenantRegistrationEqual(first, second) {
+		t.Errorf("idempotency: row changed across passes\nfirst=%+v\nsecond=%+v", first, second)
+	}
+}
+
+// TestReconcileTenantRegistryOnce_NoDynamicClientIsNoop confirms the out-of-
+// cluster / CI degrade path: no dynamic client → no crash, registry untouched.
+func TestReconcileTenantRegistryOnce_NoDynamicClientIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	registry, err := store.NewTenantRegistry(dir)
+	if err != nil {
+		t.Fatalf("tenant registry: %v", err)
+	}
+	h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	h.SetTenantRegistry(registry)
+	h.SetSovereignDepsFactory(func() (*sovereignDeps, error) {
+		return &sovereignDeps{core: nil, dyn: nil}, nil
+	})
+	// Must not panic; registry stays empty.
+	h.reconcileTenantRegistryOnce(context.Background())
+	if n := len(registry.List()); n != 0 {
+		t.Errorf("registry should be empty, has %d rows", n)
+	}
+}

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2974,13 +2974,25 @@ name: bp-catalyst-platform
 #   handover (CATALYST_FIRE_CUTOVER_ON_HANDOVER now defaults false via
 #   catalystApi.fireCutoverOnHandover). Cutover is a DELIBERATE BSS-menu action; the
 #   operator-initiated path is unchanged (NO-REGRESS).
+# 1.4.816 — #4179 (criterion 4d, the SIGNED-IN landing): close the last layer of
+#   the #1 customer bug. (a) catalyst-api reconciles its tenant registry FROM the
+#   Organization CRs so a MARKETPLACE-funnel-created Org's console host
+#   (console.<slug>.<parentDomain>) becomes a registered tenant_kind=org host —
+#   without it /auth/org-handover refused the session `invalid audience: not an org
+#   console host` and the customer never landed signed-in. Single source of truth:
+#   the Org CR is the one object BOTH doors create, so the BSS-pipeline registration
+#   class can't recur on the funnel. (b) bootstrap-kit slot-13 now declares the
+#   SOVEREIGN_LB_IP substitute (was undeclared → `lbIP` resolved EMPTY on every
+#   clean reconcile), restoring the org-controller pool-DNS fallback target so
+#   new-Org DNS keeps writing without a runtime patch (Refs #4236). Clean version
+#   tag forces the Flux pull (the #4242 stale-digest trap); slot-13 bumped lockstep.
 # 1.4.814 — #4179/#4242: ship org-controller 09dcc10 (per-Org 2-label console TLS
 #   cert+listener — `*.<slug>.<parent>` SAN covers console.<slug>.<parent>, which the
 #   apex `*.<parent>` pool wildcard cannot). The deploy-bot bumped the org-controller
 #   image pin (6cdbc50->09dcc10) in values.yaml without a chart version bump, so the
 #   re-pushed 1.4.813 OCI digest never superseded the digest cached on the Sovereign's
 #   Flux. A clean version tag forces the pull. bootstrap-kit slot-13 bumped in lockstep.
-version: 1.4.815
+version: 1.4.816
 # 1.4.774 — #4082: application-controller ClusterRole gains dr.openova.io/continuums
 #   (get/list/watch/create/update/patch/delete) — was in the controller's own
 #   deploy/rbac.yaml but MISSING from this platform chart, so a singleton /


### PR DESCRIPTION
## What

Lands the FINAL layer of the #1 customer bug **#4179** — criterion **4d (signed-in landing)**. Layers 4a (redirect host), 4b (DNS resolve), 4c (per-Org HTTPS cert SAN) are all live-proven. This PR makes the customer actually LAND SIGNED-IN.

## The gap (decisive proof from the close-walk)

A fresh marketplace signup reached its console host `console.<slug>.<parentDomain>` over a SAN-matching trusted cert, but `/auth/org-handover` refused the session: `{"error":"invalid audience: not an org console host"}`.

`resolveOrgScope` (`org_scope.go`) validates the request host against catalyst-api's **tenant registry**. The registry row is written ONLY by the **BSS pipeline** (`organization_provisioning.go` Step 6). The **marketplace funnel** door (`tenant-service POST /api/tenant/orgs` → `tenant.created` → `provisioning-service createOrganizationCR`) mints the Organization CR + DNS/TLS/route via the org-controller but **never runs that pipeline** — so the registry row was never written.

- Registered `console.demo.omani.homes` + dummy token → `invalid token` (host check PASSES).
- Unregistered `console.f4179final.omani.works` + dummy token → `invalid audience` (host check FAILS).

## The fix — single source of truth, covers BOTH doors

The **Organization CR** is the one object both doors create, and catalyst-api **owns** the flat-file tenant registry (its private PVC — the org-controller, a separate process, can't write it). So catalyst-api reconciles its OWN registry **from** the Org CRs:

- New `tenant_registry_reconcile.go`: a background loop (`ReconcileTenantRegistryFromOrgCRs`) lists every Organization CR and registers `console.<slug>.<parentDomain> → {tenantID, TenantKind:Org}`, idempotently (no-op on a steady-state pass; no flat-file churn).
- The registration shape mirrors BSS Step 6 byte-for-byte (Host, TenantID, TenantKind:Org, KeycloakRealmURL, clientID `catalyst-ui`, OrganizationNamespace, admin URL, realm name).
- Same single-source consolidation as #4236 (DNS) + #4242 (TLS) applied to registration — the BSS-only-registration class can't recur on the funnel.
- Async + best-effort: never blocks readiness, retries on a 60s ticker, no-op when the registry / dynamic-client isn't wired (CI / out-of-cluster).

## Also durably fixes the empty-`lbIP` gap (Refs #4236)

slot-13 referenced `${SOVEREIGN_LB_IP}` (no `:-` default) but the bootstrap-kit Kustomization `substitute:` block never declared it, so kustomize-controller resolved the `sovereign-fqdn` ConfigMap `lbIP` key to **EMPTY** on every clean reconcile. With both `consoleLBIP` AND `lbIP` empty, the org-controller pool-DNS writer had no target IP and skipped the per-Org A-record (which is why the live env needed a hand-patch).

- Declares `SOVEREIGN_LB_IP: ${load_balancer_ipv4}` in the bootstrap-kit substitute block (the same tofu output the other Kustomizations already read).
- Adds the `:-` default to `sovereignLBIP` in slot-13 (matches `sovereignConsoleLBIP`).

So new-Org DNS keeps writing without a runtime patch.

## Delivery (avoiding the #4242 stale-digest trap)

This changes catalyst-api Go code, so the chart is bumped **1.4.815 → 1.4.816** + bootstrap-kit slot-13 pin **lockstep** — Flux pulls a clean tag instead of a re-pushed digest the helm-controller caches.

## Tests / gates

- `tenant_registry_reconcile_test.go`: pure mapping (pool-parent → Org row, explicit-subdomain host, tenant-id fallback, single-domain skip, invalid-slug skip) + reconcile pass (funnel Org registered, single-domain skipped), idempotency, no-dynamic-client no-op.
- `go build ./...`, `go vet`, `gofmt -l` clean.
- Full `internal/handler` suite green (100s, incl. the sometimes-flaky `TestCheckSubdomain_BYONXDomainAvailable`).
- org-controller module + `tofu fmt -check` clean.

## DoD

A fresh marketplace signup → `console.<slug>.omani.works` (resolves, valid cert) → `/auth/org-handover` now ACCEPTS the host → customer lands SIGNED-IN on `/jobs` over HTTPS (HttpOnly cookie, no token in URL). Re-walk after this rolls, then #4179 is closeable.

Refs #4179
Refs #4236