### PR TITLE
fix(org-provisioning): transient parent-index read no longer prunes sibling Org namespaces (Refs #4250)

### DIFF
--- a/core/services/provisioning/github/client.go
+++ b/core/services/provisioning/github/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -13,6 +14,18 @@ import (
 	"strings"
 	"time"
 )
+
+// ErrFileNotFound is returned by ReadFile when the contents API answers
+// 404 (the path genuinely does not exist on the branch). Callers MUST
+// distinguish this from a transient read failure (network error, 5xx,
+// decode failure): a 404 means "no such file yet" and an empty fallback
+// is safe, whereas a transient error means "we don't KNOW the file's
+// content" — fabricating an empty fallback there is the #4250 bug, because
+// the parent org-tenants kustomization.yaml is rebuilt via read-modify-
+// write and a phantom-empty read collapses it to a single-Org list, which
+// Flux's prune=true Kustomization then garbage-collects every SIBLING
+// Org's namespace from. Test/wrap with errors.Is(err, ErrFileNotFound).
+var ErrFileNotFound = errors.New("file not found")
 
 // Client provides methods to commit files to a GitHub repository via the
 // Git Data API. The API base URL is configurable so the client can target
@@ -929,7 +942,11 @@ func (c *Client) ReadFile(ctx context.Context, branch, path string) (string, err
 	defer resp.Body.Close()
 
 	if resp.StatusCode == 404 {
-		return "", fmt.Errorf("file not found: %s", path)
+		// Wrap the sentinel so callers can errors.Is(err, ErrFileNotFound)
+		// to safely treat a genuine 404 as "no such file yet" — distinct
+		// from a transient read failure where an empty fallback is unsafe
+		// (#4250).
+		return "", fmt.Errorf("%w: %s", ErrFileNotFound, path)
 	}
 	if resp.StatusCode != 200 {
 		body, _ := io.ReadAll(resp.Body)

--- a/core/services/provisioning/handlers/consumer.go
+++ b/core/services/provisioning/handlers/consumer.go
@@ -13,6 +13,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	ghclient "github.com/openova-io/openova/core/services/provisioning/github"
 	"github.com/openova-io/openova/core/services/provisioning/gitops"
 	"github.com/openova-io/openova/core/services/provisioning/store"
 	"github.com/openova-io/openova/core/services/shared/events"
@@ -622,9 +623,20 @@ func (h *Handler) handleTenantDeleted(ctx context.Context, event *events.Event) 
 	rebuild := func(ctx context.Context) (map[string]string, error) {
 		currentParent, readErr := h.GitHubClient.ReadFile(ctx, branch, parentPath)
 		files := map[string]string{}
-		if readErr == nil {
-			files[parentPath] = gitops.RemoveTenantFromParentKustomization(currentParent, data.Slug)
+		if readErr != nil {
+			// #4250 — a genuine 404 means the parent index is already gone
+			// (nothing to remove from); the tenantDir prune alone is correct.
+			// A TRANSIENT read error must NOT silently skip the parent
+			// rewrite: that would leave this slug listed in resources: while
+			// its directory is pruned, wedging Flux's org-tenants build (and
+			// on the retry the stale-listing race RemoveTenantFromParent was
+			// added to defend against). Fail the attempt so the retry re-reads.
+			if !errors.Is(readErr, ghclient.ErrFileNotFound) {
+				return nil, fmt.Errorf("read parent kustomization %s for teardown (refusing partial prune, #4250): %w", parentPath, readErr)
+			}
+			return files, nil
 		}
+		files[parentPath] = gitops.RemoveTenantFromParentKustomization(currentParent, data.Slug)
 		return files, nil
 	}
 
@@ -1056,6 +1068,42 @@ func dedupProvisionCreate(ctx context.Context, st provisionDedupStore, provision
 	return dedupDecision{provision: provision, fork: true}, nil
 }
 
+// provisionParentRebuild recomputes the file map for one provision commit
+// attempt: the static per-Org manifests PLUS the parent org-tenants
+// kustomization.yaml with this Org's slug merged in (read-modify-write off
+// the LIVE parent so a concurrent sibling write/teardown isn't clobbered).
+//
+// #4250 root-cause guard. UpdateParentKustomization appends one slug to
+// whatever parent content it's handed. If the parent ReadFile fails and we
+// fabricate an empty `resources: []`, the merged result lists ONLY this Org
+// — and Flux's org-tenants Kustomization runs prune=true, so committing
+// that truncated list garbage-collects every SIBLING Org's namespace (the
+// chronic `org-<uuid>` teardown that coincides with concurrent sibling
+// provisions). The empty seed is therefore ONLY legitimate on a genuine
+// 404 (ErrFileNotFound = first Org on this Sovereign). Any other read error
+// (network blip, Gitea 5xx, decode failure) returns an error so
+// CommitFilesWithPruneAndRebuild fails the attempt — the provision pipeline
+// retries on its own cadence instead of nuking live Orgs. #4214 fixed the
+// JSON-envelope corruption of the same file; this closes the residual
+// transient-error fallback.
+func (h *Handler) provisionParentRebuild(ctx context.Context, branch, parentKustomPath, subdomain string, manifests map[string]string) (map[string]string, error) {
+	currentParentKustom, readErr := h.GitHubClient.ReadFile(ctx, branch, parentKustomPath)
+	if readErr != nil {
+		if !errors.Is(readErr, ghclient.ErrFileNotFound) {
+			return nil, fmt.Errorf("read parent kustomization %s (refusing empty fallback that would prune sibling Orgs, #4250): %w", parentKustomPath, readErr)
+		}
+		slog.Info("parent kustomization absent (first Org on this Sovereign) — seeding empty", "path", parentKustomPath)
+		currentParentKustom = "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources: []\n"
+	}
+	// Copy the static tenant manifests + the freshly-merged parent.
+	fresh := make(map[string]string, len(manifests)+1)
+	for k, v := range manifests {
+		fresh[k] = v
+	}
+	fresh[parentKustomPath] = gitops.UpdateParentKustomization(currentParentKustom, subdomain)
+	return fresh, nil
+}
+
 // runProvisioningWorkflow performs real K8s provisioning via GitOps and
 // verifies each step against the host cluster (vCluster pods are visible
 // in the host tenant-<slug> namespace thanks to vCluster's pod sync).
@@ -1121,21 +1169,11 @@ func (h *Handler) runProvisioningWorkflow(provisionID, tenantID, subdomain, plan
 
 	// Re-read the parent kustomization on EACH commit attempt so a concurrent
 	// teardown's removal of another slug doesn't get reverted by our retry
-	// replaying a stale files map. Issue: live race observed 2026-05-06 where
-	// multitest provision's retry resurrected the just-deleted bookcheck slug.
+	// replaying a stale files map (live race observed 2026-05-06: multitest
+	// provision's retry resurrected the just-deleted bookcheck slug). The
+	// #4250 sibling-prune guard lives in provisionParentRebuild.
 	rebuild := func(ctx context.Context) (map[string]string, error) {
-		currentParentKustom, readErr := h.GitHubClient.ReadFile(ctx, branch, parentKustomPath)
-		if readErr != nil {
-			slog.Warn("could not read parent kustomization, using empty", "error", readErr)
-			currentParentKustom = "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources: []\n"
-		}
-		// Copy the static tenant manifests + the freshly-merged parent.
-		fresh := make(map[string]string, len(manifests)+1)
-		for k, v := range manifests {
-			fresh[k] = v
-		}
-		fresh[parentKustomPath] = gitops.UpdateParentKustomization(currentParentKustom, subdomain)
-		return fresh, nil
+		return h.provisionParentRebuild(ctx, branch, parentKustomPath, subdomain, manifests)
 	}
 
 	commitMsg := fmt.Sprintf("provision: deploy tenant %s (plan: %s, apps: %d)", subdomain, planSlug, len(appSlugs))

--- a/core/services/provisioning/handlers/consumer_parent_prune_test.go
+++ b/core/services/provisioning/handlers/consumer_parent_prune_test.go
@@ -1,0 +1,211 @@
+package handlers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	ghclient "github.com/openova-io/openova/core/services/provisioning/github"
+	"github.com/openova-io/openova/core/services/provisioning/gitops"
+)
+
+// #4250 — the per-Org org-tenants overlay parent index
+// (clusters/<fqdn>/org-tenants/kustomization.yaml) is rebuilt via a
+// read-modify-write each commit attempt. These tests freeze the invariant
+// that a SIBLING Org is NEVER dropped from that list because of a transient
+// read failure — dropping a sibling means Flux's prune=true Kustomization
+// garbage-collects that sibling Org's namespace, the chronic teardown the
+// issue describes.
+
+// giteaParentStub stands up an httptest server that mimics the Gitea
+// contents API for exactly one file (the parent kustomization). status
+// controls the GET response: 200 (serve body), 404 (not found), or any 5xx
+// (transient). All non-GET requests 200 so a commit can complete when the
+// test reaches that far.
+func giteaParentStub(t *testing.T, parentPath, parentBody string, status int) (*httptest.Server, *int32) {
+	t.Helper()
+	var getHits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/git/refs/heads/main"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"object":{"sha":"c3f4799deadbeef0000000000000000deadbeef"}}]`))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/contents/") && strings.Contains(r.URL.Path, parentPath):
+			atomic.AddInt32(&getHits, 1)
+			switch {
+			case status == http.StatusOK:
+				w.Header().Set("Content-Type", "application/json")
+				env := map[string]string{
+					"content":  base64.StdEncoding.EncodeToString([]byte(parentBody)),
+					"encoding": "base64",
+				}
+				_ = json.NewEncoder(w).Encode(env)
+			case status == http.StatusNotFound:
+				http.NotFound(w, r)
+			default:
+				http.Error(w, "gitea is having a bad day", status)
+			}
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/contents/"):
+			// Any other content GET (per-Org manifest existence probe) → 404
+			// so commitOnceContents treats it as create.
+			http.NotFound(w, r)
+		default:
+			// blob/tree/commit/updateRef and ChangeFiles batch — succeed.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"commit":{"sha":"newcommitsha0000000000000000000000000000"},"object":{"sha":"newcommitsha0000000000000000000000000000"}}`))
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &getHits
+}
+
+const twoSiblingParent = `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrepositories.yaml
+  - org-1111aaaa
+  - org-2222bbbb
+`
+
+// TestProvisionParentRebuild_TransientReadDoesNotPruneSiblings is the core
+// #4250 regression: a transient (503) read of the parent index MUST fail the
+// rebuild rather than fabricate an empty parent that lists only the new Org.
+func TestProvisionParentRebuild_TransientReadDoesNotPruneSiblings(t *testing.T) {
+	parentPath := "clusters/sovereign.example/org-tenants/kustomization.yaml"
+	srv, _ := giteaParentStub(t, parentPath, twoSiblingParent, http.StatusServiceUnavailable)
+
+	h := &Handler{
+		GitHubClient: ghclient.NewClientWithAPIURL("token", "owner", "repo", srv.URL),
+	}
+	manifests := map[string]string{
+		"clusters/sovereign.example/org-tenants/org-3333cccc/namespace.yaml": "kind: Namespace\n",
+	}
+
+	files, err := h.provisionParentRebuild(context.Background(), "main", parentPath, "org-3333cccc", manifests)
+	if err == nil {
+		t.Fatalf("expected an error on transient parent read so the commit is refused; got nil and files=%v", files)
+	}
+	if files != nil {
+		t.Fatalf("expected nil files on transient read error (commit must be aborted), got %v", files)
+	}
+	if !strings.Contains(err.Error(), "4250") {
+		t.Errorf("error should reference the #4250 guard, got: %v", err)
+	}
+}
+
+// TestProvisionParentRebuild_HealthyReadPreservesSiblings asserts the happy
+// path still merges the new Org WITHOUT dropping the two existing siblings.
+func TestProvisionParentRebuild_HealthyReadPreservesSiblings(t *testing.T) {
+	parentPath := "clusters/sovereign.example/org-tenants/kustomization.yaml"
+	srv, _ := giteaParentStub(t, parentPath, twoSiblingParent, http.StatusOK)
+
+	h := &Handler{
+		GitHubClient: ghclient.NewClientWithAPIURL("token", "owner", "repo", srv.URL),
+	}
+	manifests := map[string]string{
+		"clusters/sovereign.example/org-tenants/org-3333cccc/namespace.yaml": "kind: Namespace\n",
+	}
+
+	files, err := h.provisionParentRebuild(context.Background(), "main", parentPath, "org-3333cccc", manifests)
+	if err != nil {
+		t.Fatalf("healthy read should succeed, got: %v", err)
+	}
+	merged, ok := files[parentPath]
+	if !ok {
+		t.Fatalf("rebuild did not emit the parent kustomization at %s", parentPath)
+	}
+	for _, sibling := range []string{"  - org-1111aaaa", "  - org-2222bbbb"} {
+		if !strings.Contains(merged, sibling) {
+			t.Errorf("merged parent dropped sibling %q — sibling Org would be pruned:\n%s", sibling, merged)
+		}
+	}
+	if !strings.Contains(merged, "  - org-3333cccc") {
+		t.Errorf("merged parent missing the newly-provisioned Org:\n%s", merged)
+	}
+	if !strings.Contains(merged, "  - helmrepositories.yaml") {
+		t.Errorf("merged parent dropped the shared helmrepositories.yaml entry:\n%s", merged)
+	}
+}
+
+// TestProvisionParentRebuild_GenuineNotFoundSeedsEmpty asserts the safe
+// first-Org path: a genuine 404 seeds an empty parent and adds only this
+// Org (there are no siblings to preserve on a brand-new Sovereign).
+func TestProvisionParentRebuild_GenuineNotFoundSeedsEmpty(t *testing.T) {
+	parentPath := "clusters/sovereign.example/org-tenants/kustomization.yaml"
+	srv, _ := giteaParentStub(t, parentPath, "", http.StatusNotFound)
+
+	h := &Handler{
+		GitHubClient: ghclient.NewClientWithAPIURL("token", "owner", "repo", srv.URL),
+	}
+	manifests := map[string]string{
+		"clusters/sovereign.example/org-tenants/org-firstone/namespace.yaml": "kind: Namespace\n",
+	}
+
+	files, err := h.provisionParentRebuild(context.Background(), "main", parentPath, "org-firstone", manifests)
+	if err != nil {
+		t.Fatalf("genuine 404 (first Org) should seed empty + succeed, got: %v", err)
+	}
+	merged, ok := files[parentPath]
+	if !ok {
+		t.Fatalf("rebuild did not emit the parent kustomization at %s", parentPath)
+	}
+	if !strings.Contains(merged, "  - org-firstone") {
+		t.Errorf("first-Org parent missing the Org entry:\n%s", merged)
+	}
+}
+
+// TestReadFile_NotFoundSentinel asserts the sentinel the #4250 guard keys
+// off: a 404 is errors.Is(ErrFileNotFound), a 5xx is NOT.
+func TestReadFile_NotFoundSentinel(t *testing.T) {
+	// 404 path.
+	srv404, _ := giteaParentStub(t, "x/kustomization.yaml", "", http.StatusNotFound)
+	c404 := ghclient.NewClientWithAPIURL("token", "owner", "repo", srv404.URL)
+	_, err := c404.ReadFile(context.Background(), "main", "x/kustomization.yaml")
+	if err == nil {
+		t.Fatal("expected error on 404")
+	}
+	if got := isFileNotFound(err); !got {
+		t.Errorf("404 must satisfy errors.Is(err, ErrFileNotFound); err=%v", err)
+	}
+
+	// 5xx path.
+	srv503, _ := giteaParentStub(t, "x/kustomization.yaml", "", http.StatusBadGateway)
+	c503 := ghclient.NewClientWithAPIURL("token", "owner", "repo", srv503.URL)
+	_, err = c503.ReadFile(context.Background(), "main", "x/kustomization.yaml")
+	if err == nil {
+		t.Fatal("expected error on 502")
+	}
+	if isFileNotFound(err) {
+		t.Errorf("502 must NOT satisfy errors.Is(err, ErrFileNotFound); err=%v", err)
+	}
+}
+
+// TestUpdateParentKustomization_OnEmptyDropsSiblings documents WHY the guard
+// matters: feeding UpdateParentKustomization an empty parent (the pre-#4250
+// fallback) yields a single-Org list — the exact prune trigger. Pure-function
+// proof, no network.
+func TestUpdateParentKustomization_OnEmptyDropsSiblings(t *testing.T) {
+	empty := "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources: []\n"
+	got := gitops.UpdateParentKustomization(empty, "org-3333cccc")
+	for _, sibling := range []string{"org-1111aaaa", "org-2222bbbb"} {
+		if strings.Contains(got, sibling) {
+			t.Fatalf("test setup wrong: empty seed should not contain %q", sibling)
+		}
+	}
+	if !strings.Contains(got, "org-3333cccc") {
+		t.Fatalf("expected the new Org in the result:\n%s", got)
+	}
+	// The result lists ONLY org-3333cccc → committing it prunes every sibling.
+	// This is precisely what provisionParentRebuild now refuses to do on a
+	// transient read.
+}
+
+func isFileNotFound(err error) bool {
+	return errors.Is(err, ghclient.ErrFileNotFound)
+}


### PR DESCRIPTION
Refs #4250.

## Root cause (file:line + condition)

The per-Org `org-tenants` overlay parent index `clusters/<fqdn>/org-tenants/kustomization.yaml` is rebuilt via a **read-modify-write** on every provision/teardown commit attempt. `gitops.UpdateParentKustomization(current, slug)` appends ONE slug to whatever `current` content the rebuild closure hands it.

The defect was in the provision rebuild closure (`core/services/provisioning/handlers/consumer.go`, the `runProvisioningWorkflow` commit step):

```go
currentParentKustom, readErr := h.GitHubClient.ReadFile(ctx, branch, parentKustomPath)
if readErr != nil {
    slog.Warn("could not read parent kustomization, using empty", ...)
    currentParentKustom = "...resources: []..."   // <-- collapses the list
}
fresh[parentKustomPath] = gitops.UpdateParentKustomization(currentParentKustom, subdomain)
```

When the parent `ReadFile` returns a **transient** error (Gitea 5xx / network blip / decode failure) — distinct from a genuine 404 — the closure fabricated an empty `resources: []` parent and then appended ONLY the Org being provisioned. Flux's `org-tenants` Kustomization runs `prune=true`, so committing that truncated list **garbage-collects every SIBLING Org's namespace**.

That is the chronic `org-<uuid>` namespace teardown the issue describes — observed coinciding with concurrent sibling-Org creation, leaving the demo Org's apps NotFound minutes after they converge.

#4214 fixed the JSON-envelope corruption of the **same file** (`provisioning/github Client.ReadFile` returning the un-decoded Gitea base64 envelope). This PR closes the **residual transient-error fallback** that survives #4214: a read that fails for any reason OTHER than 404 must not collapse the list.

## Fix (in-place, idempotent)

- `github.Client` gains an exported `ErrFileNotFound` sentinel; `ReadFile` wraps the 404 with `fmt.Errorf("%w: ...", ErrFileNotFound, path)` so callers can `errors.Is()` a genuine not-found apart from a transient failure.
- The provision rebuild is extracted to a testable method `provisionParentRebuild`; both it and the teardown rebuild (`handleTenantDeleted`) now seed/skip the empty parent **ONLY on a genuine 404** (first Org on the Sovereign, or parent already gone on teardown). On any other read error they **return an error**, which makes `CommitFilesWithPruneAndRebuild` fail that attempt — the provision pipeline retries on its own cadence rather than committing a sibling-pruning parent index.

The fix is in-place reconciliation: a sibling-org change or a transient readback never deletes a converged Org's resources; only a genuine 404 (no parent yet) takes the empty-seed path.

## Regression tests (`consumer_parent_prune_test.go`)

- `TransientReadDoesNotPruneSiblings` — a 503 on the parent read fails the rebuild (returns error, nil files) instead of dropping the two pre-existing sibling Orgs. **Verified this test FAILS against the old empty-fallback behavior** (negative control: old code produced a parent listing only the new Org).
- `HealthyReadPreservesSiblings` — a 200 read merges the new Org while keeping both siblings + `helmrepositories.yaml`.
- `GenuineNotFoundSeedsEmpty` — a 404 still seeds the empty parent for the legitimate first-Org case.
- `ReadFile_NotFoundSentinel` — 404 satisfies `errors.Is(err, ErrFileNotFound)`; 5xx does not.

## Gates

- `go build ./...`, `go vet ./...`, `go test ./...` green for the provisioning module; `gofmt` clean.
- Chart version: not hand-bumped — `services-build.yaml` deploy-bot bumps `images.orgTag` (rolls the provisioning image) AND patch-bumps `Chart.yaml version`/`appVersion` atomically on merge (the #872/#4242 fix), so the new image and chart version move together; no stale-deploy trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)