### PR TITLE
fix(continuum): k8s-lease witness + region fallback → healthy 2-region pair surfaces live DR (Topology tab, not singleton)

### DIFF
--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -197,7 +197,7 @@ spec:
       # 0.2.6 (#3740): replication-source mesh Service flipped
       # selectorType r→rw so the cross-region replica streams from the
       # PRIMARY's walsender (not a cascaded local standby) → sync_state=sync.
-      version: 0.2.6
+      version: 0.2.7
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg-pair

--- a/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
+++ b/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
@@ -137,7 +137,7 @@ spec:
       # PR #996), the 0.1.6 promoter would have failed on a real region-kill.
       # RBAC adds pods `delete` (the restart). Pin moves in lockstep
       # (Inviolable Principle #13).
-      version: 0.1.7
+      version: 0.1.8
       sourceRef:
         kind: HelmRepository
         name: bp-continuum

--- a/core/controllers/application/internal/controller/continuum.go
+++ b/core/controllers/application/internal/controller/continuum.go
@@ -70,14 +70,17 @@ var ContinuumGVR = schema.GroupVersionResource{
 const ContinuumNamePrefix = "dr-"
 
 // DefaultContinuumLeaseKind is the witness backend stamped on a produced
-// Continuum CR when the Blueprint variant does not name one. `dns-quorum`
-// is the canonical air-gappable witness (no Cloudflare dependency) and is
-// one of the two values the CRD's leaseClient.kind enum accepts
-// (`[cloudflare-kv, dns-quorum]` — `in-memory` is test-only and NOT a
-// valid CRD value). Per Inviolable Principle #4 the controller could be
-// taught to read this from env later; the default keeps a fresh prov's
-// DR contract self-contained.
-const DefaultContinuumLeaseKind = "dns-quorum"
+// Continuum CR when the Blueprint variant does not name one. `k8s-lease`
+// (#3829) is the canonical air-gappable witness: a native
+// coordination.k8s.io/v1 Lease in the control-plane cluster — zero
+// external dependency, durable etcd-backed CAS — and a value the CRD's
+// leaseClient.kind enum accepts (`[k8s-lease, cloudflare-kv,
+// dns-quorum]`). It replaces the prior `dns-quorum` default, which was a
+// never-completed Phase-1 POC (nil TXTWriter → every Acquire failed →
+// the produced CR sat Degraded/LeaseHeld=False forever). Per Inviolable
+// Principle #4 the controller could be taught to read this from env
+// later; the default keeps a fresh prov's DR contract self-contained.
+const DefaultContinuumLeaseKind = "k8s-lease"
 
 // continuumPlan is the minimal, resolved input the producer needs. It is
 // computed by the reconciler from the SAME placement.Plan + topology

--- a/core/controllers/continuum/cmd/main.go
+++ b/core/controllers/continuum/cmd/main.go
@@ -94,6 +94,14 @@ import (
 	// blank-import is the WIRING — removing it disables the kinds.
 	_ "github.com/openova-io/openova/core/controllers/continuum/internal/witness/cloudflarekv"
 	_ "github.com/openova-io/openova/core/controllers/continuum/internal/witness/dnsquorum"
+	// #3829 — k8s-lease witness: a native coordination.k8s.io/v1 Lease in
+	// the control-plane cluster. The air-gappable default (no Cloudflare,
+	// no PowerDNS-TXT dependency) — cloudflare-kv needs external egress +
+	// a Worker, and dns-quorum was a never-completed Phase-1 POC (nil
+	// TXTWriter → Acquire always fails). The blank-import registers its
+	// Factory; the controller stamps its dynamic client into the witness
+	// config (selectWitness) so the package needs no client-go ctor.
+	_ "github.com/openova-io/openova/core/controllers/continuum/internal/witness/k8slease"
 )
 
 var scheme = runtime.NewScheme()
@@ -211,12 +219,19 @@ func main() {
 		}
 	}
 
+	// #3829 — namespace where the k8s-lease witness stores its
+	// coordination.k8s.io/v1 Lease objects. CATALYST_LEASE_NS wins;
+	// otherwise the controller's own namespace (the leases live next to
+	// the controller, which already has the coordination.k8s.io RBAC).
+	leaseNamespace := env("CATALYST_LEASE_NS", podNamespace())
+
 	r := &controller.ContinuumReconciler{
 		Client:          mgr.GetClient(),
 		Scheme:          mgr.GetScheme(),
 		Dyn:             dyn,
 		WitnessSelector: sel,
 		HoldingRegion:   env("CATALYST_REGION", ""),
+		LeaseNamespace:  leaseNamespace,
 		PDMClient:       pdmClient,
 		Audit:           audit,
 		Drainer:         switchover.NewDynamicHTTPRouteDrainer(dyn),

--- a/core/controllers/continuum/internal/controller/continuum_controller.go
+++ b/core/controllers/continuum/internal/controller/continuum_controller.go
@@ -107,6 +107,14 @@ type ContinuumReconciler struct {
 	// the controller's CATALYST_REGION env var at startup.
 	HoldingRegion string
 
+	// LeaseNamespace is where the `k8s-lease` witness stores its
+	// coordination.k8s.io/v1 Lease objects (#3829). Defaults to the
+	// controller's own namespace at startup (CATALYST_LEASE_NS env or
+	// the in-cluster ServiceAccount namespace). A CR may override per
+	// slot via leaseClient.config.namespace. Unused by the other
+	// witness kinds.
+	LeaseNamespace string
+
 	// PDMClient is the pool-domain-manager HTTP client (shared).
 	PDMClient *pdm.Client
 
@@ -248,9 +256,21 @@ func (r *ContinuumReconciler) runPerCR(ctx context.Context, nn types.NamespacedN
 		ttl = DefaultLeaseTTLSeconds * time.Second
 	}
 
-	leaseState, err := w.Acquire(ctx, r.HoldingRegion, ttl)
+	// Resolve the region identity this controller holds the lease as.
+	// CATALYST_REGION (r.HoldingRegion) wins when set; otherwise we fall
+	// back to the CR's declared primaryRegion. The continuum-controller
+	// runs ONLY on the primary-side cluster (the cnpg-pair chart + the
+	// bp-continuum HR are side-gated to the primary), so the controller
+	// IS the primary region — falling back to spec.primaryRegion makes a
+	// healthy 2-region pair self-bootstrap the lease as leaseHolder=
+	// <primaryRegion> even when the env var was never wired (#3829).
+	holder := r.effectiveHoldingRegion(initialSpec)
+
+	leaseState, err := w.Acquire(ctx, holder, ttl)
 	if err == nil {
 		_ = r.publishLeaseAcquired(ctx, nn, initialSpec, leaseState)
+	} else {
+		log.Info("initial lease acquire failed; will retry on renew tick", "holder", holder, "err", err)
 	}
 
 	tick := time.NewTicker(renewInterval)
@@ -259,7 +279,7 @@ func (r *ContinuumReconciler) runPerCR(ctx context.Context, nn types.NamespacedN
 	for {
 		select {
 		case <-ctx.Done():
-			_ = w.Release(context.Background(), r.HoldingRegion)
+			_ = w.Release(context.Background(), holder)
 			log.Info("per-CR goroutine exiting")
 			return
 		case <-tick.C:
@@ -268,7 +288,7 @@ func (r *ContinuumReconciler) runPerCR(ctx context.Context, nn types.NamespacedN
 		cr, err := r.fetchCR(ctx, nn)
 		if apierrors.IsNotFound(err) {
 			log.Info("CR vanished mid-loop; exiting")
-			_ = w.Release(context.Background(), r.HoldingRegion)
+			_ = w.Release(context.Background(), holder)
 			return
 		}
 		if err != nil {
@@ -280,6 +300,9 @@ func (r *ContinuumReconciler) runPerCR(ctx context.Context, nn types.NamespacedN
 			log.Error(vErr, "spec invalid mid-loop")
 			continue
 		}
+		// Re-resolve in case the primaryRegion changed (and the env var
+		// is unset). Stable when CATALYST_REGION is wired.
+		holder = r.effectiveHoldingRegion(spec)
 
 		// F-1: detect spec drift on switchover-relevant fields and
 		// emit `continuum-config-changed` (rare; happens when the
@@ -296,10 +319,10 @@ func (r *ContinuumReconciler) runPerCR(ctx context.Context, nn types.NamespacedN
 			_ = r.publishConfigChanged(ctx, nn, spec, prevFingerprint, curFingerprint)
 		}
 
-		newState, rErr := w.Renew(ctx, r.HoldingRegion, ttl)
+		newState, rErr := w.Renew(ctx, holder, ttl)
 		if errors.Is(rErr, witness.ErrLeaseLost) {
 			_ = r.publishLeaseLost(ctx, nn, spec, leaseState)
-			if newState, err = w.Acquire(ctx, r.HoldingRegion, ttl); err != nil {
+			if newState, err = w.Acquire(ctx, holder, ttl); err != nil {
 				// F-1: distinguish "held by another" (collision) from generic acquire failure.
 				if errors.Is(err, witness.ErrLeaseHeldByAnother) {
 					_ = r.publishLeaseCollision(ctx, nn, spec, err)
@@ -636,6 +659,15 @@ func (r *ContinuumReconciler) ActiveCount() int {
 // selectWitness picks a Client for the CR and stamps a per-CR slot
 // key (NamespacedName) into the Selector config so the in-memory stub
 // gives this CR an isolated lease.
+//
+// For the `k8s-lease` witness (#3829) we also stamp the controller's
+// dynamic client + the Lease namespace into the config: that witness
+// stores the lease in a native coordination.k8s.io/v1 Lease object in
+// the control-plane cluster (zero external dependency — the
+// air-gappable default), and the witness package cannot construct a
+// dynamic client itself without an import cycle, so the controller
+// hands its already-built one through the config map. Harmless for the
+// other kinds (they ignore unknown cfg keys).
 func (r *ContinuumReconciler) selectWitness(nn types.NamespacedName, spec ContinuumSpec) (witness.Client, error) {
 	if r.WitnessSelector == nil {
 		return nil, errors.New("WitnessSelector not configured")
@@ -645,6 +677,16 @@ func (r *ContinuumReconciler) selectWitness(nn types.NamespacedName, spec Contin
 		cfg[k] = v
 	}
 	cfg["slot"] = nn.String()
+	if r.Dyn != nil {
+		cfg["dyn"] = r.Dyn
+	}
+	// Default the Lease namespace to the controller's own namespace when
+	// the CR didn't pin one via leaseClient.config.namespace.
+	if _, set := cfg["namespace"]; !set {
+		if ns := r.LeaseNamespace; ns != "" {
+			cfg["namespace"] = ns
+		}
+	}
 	return r.WitnessSelector.Select(spec.LeaseClientKind, cfg)
 }
 
@@ -679,6 +721,27 @@ func isSwitchoverRequested(cr *unstructured.Unstructured) bool {
 	return v
 }
 
+// effectiveHoldingRegion resolves the region identity this controller
+// instance holds the lease as. CATALYST_REGION (r.HoldingRegion) wins
+// when set; otherwise we fall back to the CR's declared primaryRegion.
+//
+// The fallback is correct AND load-bearing (#3829): the
+// continuum-controller runs ONLY on the primary-side cluster (the
+// cnpg-pair chart + the bp-continuum HelmRelease are side-gated to the
+// primary via `cnpg-pair.isPrimarySide`), so the running controller IS
+// the primary region. Without this fallback, a Sovereign whose
+// deployment never wired CATALYST_REGION (the live omantel.biz case)
+// holds the lease as the empty string → IsHeldBy("") is always false →
+// the CR is pinned Degraded / LeaseHeld=False forever even though the
+// witness acquired the slot cleanly. Falling back to spec.primaryRegion
+// makes a healthy 2-region pair self-bootstrap leaseHolder=<region-a>.
+func (r *ContinuumReconciler) effectiveHoldingRegion(spec ContinuumSpec) string {
+	if r.HoldingRegion != "" {
+		return r.HoldingRegion
+	}
+	return spec.PrimaryRegion
+}
+
 func (r *ContinuumReconciler) clearSwitchoverRequest(ctx context.Context, cr *unstructured.Unstructured) error {
 	_ = unstructured.SetNestedField(cr.Object, false, "spec", "switchover", "requested")
 	if r.Dyn == nil {
@@ -703,7 +766,8 @@ func (r *ContinuumReconciler) patchStatusFromCR(
 ) error {
 	maxLag := cnpg.MaxLagSeconds(primaryStatus, replicaStatus)
 	now := r.now()
-	heldByUs := lease.IsHeldBy(r.HoldingRegion, now)
+	self := r.effectiveHoldingRegion(spec)
+	heldByUs := lease.IsHeldBy(self, now)
 	phase := PhaseHealthy
 	if !heldByUs {
 		phase = PhaseDegraded
@@ -712,6 +776,7 @@ func (r *ContinuumReconciler) patchStatusFromCR(
 		Phase:                 phase,
 		PrimaryRegion:         spec.PrimaryRegion,
 		LeaseHolder:           lease.Holder,
+		SelfRegion:            self,
 		ReplicationLagSeconds: maxLag,
 		SwitchoverInProgress:  switchoverInProgress,
 		Step:                  stepLabel,
@@ -724,9 +789,15 @@ func (r *ContinuumReconciler) patchStatusFromCR(
 
 // statusUpdate — mutation set for one status patch.
 type statusUpdate struct {
-	Phase                 string
-	PrimaryRegion         string
-	LeaseHolder           string
+	Phase         string
+	PrimaryRegion string
+	LeaseHolder   string
+	// SelfRegion is the region identity THIS controller holds the lease
+	// as (CATALYST_REGION, or the CR's primaryRegion when unset — see
+	// effectiveHoldingRegion). The LeaseHeld condition is True iff
+	// LeaseHolder == SelfRegion. Empty falls back to r.HoldingRegion for
+	// back-compat with callers that don't set it (#3829).
+	SelfRegion            string
 	LeaseExpiresAt        string
 	ReplicationLagSeconds int
 	SwitchoverInProgress  bool
@@ -841,9 +912,17 @@ func (r *ContinuumReconciler) patchStatus(ctx context.Context, cr *unstructured.
 			conds = append(conds, c)
 		}
 	}
+	// LeaseHeld is True iff the lease's holder is THIS controller's
+	// region identity. SelfRegion (CATALYST_REGION, or the CR's
+	// primaryRegion fallback — #3829) is preferred; fall back to
+	// r.HoldingRegion for callers that don't stamp SelfRegion.
+	self := su.SelfRegion
+	if self == "" {
+		self = r.HoldingRegion
+	}
 	conds = append(conds, map[string]interface{}{
 		"type":               "LeaseHeld",
-		"status":             boolToCondStatus(su.LeaseHolder == r.HoldingRegion && su.LeaseHolder != ""),
+		"status":             boolToCondStatus(su.LeaseHolder == self && su.LeaseHolder != ""),
 		"reason":             firstNonEmpty(su.Reason, "Reconciled"),
 		"message":            firstNonEmpty(su.Message, ""),
 		"lastTransitionTime": r.now().UTC().Format(time.RFC3339),

--- a/core/controllers/continuum/internal/controller/continuum_controller_test.go
+++ b/core/controllers/continuum/internal/controller/continuum_controller_test.go
@@ -372,6 +372,79 @@ func TestPatchStatus_LuaRecordOnlyOnNonNil(t *testing.T) {
 	}
 }
 
+// TestEffectiveHoldingRegion_FallsBackToPrimary proves the #3829
+// second root-cause fix: when CATALYST_REGION is unset (HoldingRegion=""
+// — the live omantel.biz case), the controller holds the lease as the
+// CR's primaryRegion (it only runs on the primary-side cluster), so a
+// healthy pair is NOT pinned Degraded with leaseHolder empty.
+func TestEffectiveHoldingRegion_FallsBackToPrimary(t *testing.T) {
+	t.Parallel()
+	spec := ContinuumSpec{PrimaryRegion: "hw-me-east-215-a-rtz-prod"}
+
+	withEnv := &ContinuumReconciler{HoldingRegion: "explicit-region"}
+	if got := withEnv.effectiveHoldingRegion(spec); got != "explicit-region" {
+		t.Errorf("with env set: got %q, want explicit-region", got)
+	}
+
+	noEnv := &ContinuumReconciler{HoldingRegion: ""}
+	if got := noEnv.effectiveHoldingRegion(spec); got != "hw-me-east-215-a-rtz-prod" {
+		t.Errorf("without env: got %q, want primaryRegion fallback", got)
+	}
+}
+
+// TestPatchStatusFromCR_HealthyWhenHolderMatchesPrimary_NoEnv asserts
+// the end-to-end status outcome: HoldingRegion="" + a lease held by the
+// primaryRegion → phase=Healthy, Ready=True, LeaseHeld=True,
+// leaseHolder=<primary>, replicationLagSeconds rendered. This is exactly
+// the panel-state the Topology tab needs (rows 51/52/54/55/56/62/71).
+func TestPatchStatusFromCR_HealthyWhenHolderMatchesPrimary_NoEnv(t *testing.T) {
+	t.Parallel()
+	const primary = "hw-me-east-215-a-rtz-prod"
+	cr := newTestContinuumCR("cnpg", "dr", primary, []string{"hw-me-east-215-b-rtz-prod"}, "k8s-lease")
+	objs := append([]runtime.Object{cr}, newTestClusterPair("cnpg", "demo", 0)...)
+	r, _, _ := newReconciler(t, objs...)
+	// Simulate the live env: CATALYST_REGION was never wired.
+	r.HoldingRegion = ""
+
+	spec, err := parseSpec(cr)
+	if err != nil {
+		t.Fatalf("parseSpec: %v", err)
+	}
+	// A live lease the witness acquired, held by the primary region.
+	now := time.Now()
+	lease := witness.State{
+		Holder:    primary,
+		ExpiresAt: now.Add(30 * time.Second),
+	}
+	if err := r.patchStatusFromCR(context.Background(), cr, spec, lease, cnpg.Status{}, cnpg.Status{}, false, ""); err != nil {
+		t.Fatalf("patchStatusFromCR: %v", err)
+	}
+
+	got, _ := r.Dyn.Resource(ContinuumGVR).Namespace("cnpg").Get(context.Background(), "dr", metav1.GetOptions{})
+	phase, _, _ := unstructured.NestedString(got.Object, "status", "phase")
+	if phase != PhaseHealthy {
+		t.Fatalf("phase = %q, want Healthy", phase)
+	}
+	holder, _, _ := unstructured.NestedString(got.Object, "status", "leaseHolder")
+	if holder != primary {
+		t.Fatalf("leaseHolder = %q, want %q", holder, primary)
+	}
+	conds, _, _ := unstructured.NestedSlice(got.Object, "status", "conditions")
+	condStatus := map[string]string{}
+	for _, c := range conds {
+		cm, _ := c.(map[string]interface{})
+		t, _ := cm["type"].(string)
+		s, _ := cm["status"].(string)
+		condStatus[t] = s
+	}
+	if condStatus["Ready"] != "True" {
+		t.Errorf("Ready = %q, want True", condStatus["Ready"])
+	}
+	if condStatus["LeaseHeld"] != "True" {
+		t.Errorf("LeaseHeld = %q, want True", condStatus["LeaseHeld"])
+	}
+}
+
 // TestLuaRecordStatusValue_NilOnEmpty — pure-function helper guard.
 func TestLuaRecordStatusValue_NilOnEmpty(t *testing.T) {
 	t.Parallel()

--- a/core/controllers/continuum/internal/witness/k8slease/client.go
+++ b/core/controllers/continuum/internal/witness/k8slease/client.go
@@ -1,0 +1,438 @@
+// Package k8slease implements witness.Client over a native
+// coordination.k8s.io/v1 Lease object in the control-plane cluster.
+//
+// WHY THIS EXISTS (#3829 / #3375)
+// ──────────────────────────────
+// The two K-Cont-3 witnesses both depend on infrastructure that a
+// real, air-gapped Sovereign does not have:
+//
+//   - cloudflare-kv  needs an external Cloudflare Worker + KV namespace
+//   - an API token. A self-sovereign / air-gapped Sovereign has no
+//     egress to Cloudflare at all (Pillar 5 / ADR-0002).
+//   - dns-quorum     was shipped as a never-completed Phase-1 POC: the
+//     factory ALWAYS builds the client with a nil TXTWriter, so every
+//     Acquire fails at writeQuorum with "Writer not configured (Phase-1
+//     POC needs PDM /v1/txt — K-Cont-{4|5})". The read side also points
+//     at placeholder resolvers (10.43.0.10/11/12 — only .10 is kube-dns,
+//     .11/.12 are unallocated ClusterIPs) so readQuorum never reaches a
+//     2-of-3 majority → ErrQuorumUnavailable every 10s. NET RESULT on
+//     omantel.biz: the cnpg-pair Continuum CR sat Degraded forever,
+//     LeaseHeld=False, leaseHolder empty → the console Topology tab had
+//     no live lease/standby/lag to render and fell back to "singleton".
+//
+// The k8s-lease witness closes that gap with ZERO external dependency:
+// the control plane already talks to its own kube API, the
+// continuum-controller's ClusterRole ALREADY grants
+// coordination.k8s.io/leases {get,list,watch,create,update,patch,delete}
+// (see products/continuum/chart/templates/rbac.yaml), and a Lease is a
+// durable, replicated etcd object with built-in optimistic-concurrency
+// (resourceVersion) — exactly the atomic CAS the witness contract
+// requires.
+//
+// WIRE SHAPE
+// ──────────
+//
+//	One Lease object per Continuum slot, named  cw-<encodedSlot>  in the
+//	configured namespace (default: the controller's own namespace).
+//	'/' in the slot ('<ns>/<name>') is replaced with '-' to keep the
+//	object name DNS-label-safe.
+//
+//	spec.holderIdentity        = the region currently holding the lease
+//	                             (witness.State.Holder). Empty/absent =
+//	                             free slot.
+//	spec.leaseDurationSeconds  = ttl in seconds.
+//	spec.acquireTime           = first-acquisition time (preserved on
+//	                             same-holder re-acquire → State.AcquiredAt)
+//	spec.renewTime             = last renew time. ExpiresAt is computed
+//	                             as renewTime + leaseDurationSeconds.
+//	metadata.annotations[dr.openova.io/generation]
+//	                           = the monotonic CAS counter (witness.State
+//	                             .Generation). Bumped on every Acquire /
+//	                             Renew / Release write.
+//
+// CAS PROTOCOL
+// ────────────
+// The K8s apiserver enforces optimistic concurrency via resourceVersion:
+// an Update with a stale resourceVersion is rejected with a Conflict
+// (409). We thread the just-read resourceVersion into every write; a
+// Conflict means another writer (the standby region's controller, or a
+// racing reconcile) moved first → we surface the contract sentinel
+// (ErrLeaseHeldByAnother on Acquire, ErrLeaseLost on Renew) so the
+// caller never double-promotes. This is the SAME safety posture the
+// in-memory + cloudflare-kv impls provide, backed by etcd instead of a
+// process map / a CF Worker.
+//
+// EXPIRY
+// ──────
+// Expiry is wall-clock: a slot whose renewTime + leaseDurationSeconds is
+// in the past is takeable by anyone. The holder region renews every
+// renewSeconds (<< ttl) so a live primary never lets its slot expire;
+// when the primary's controller dies (region kill), the slot expires
+// after ttl and the standby's controller can Acquire it — the failover
+// path.
+package k8slease
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/openova-io/openova/core/controllers/continuum/internal/witness"
+)
+
+// GenerationAnnotation carries the monotonic CAS counter on the Lease
+// object's metadata.annotations. The Lease's own resourceVersion is the
+// apiserver-enforced CAS token; this annotation is the witness-contract
+// Generation surfaced on Continuum.status (so jq / the UI sees a stable
+// counter, not the opaque etcd resourceVersion).
+const GenerationAnnotation = "dr.openova.io/generation"
+
+// leaseGVR is the dynamic-client resource for coordination.k8s.io/v1
+// Leases. We use the dynamic client (not the typed coordinationv1
+// client) to stay consistent with the rest of the continuum-controller,
+// which is dynamic-only per ADR-0001 §2.7.
+var leaseGVR = schema.GroupVersionResource{
+	Group:    "coordination.k8s.io",
+	Version:  "v1",
+	Resource: "leases",
+}
+
+// DynLeaseAccess is the minimal dynamic-client surface the witness
+// needs. dynamic.Interface satisfies it; tests inject a fake.
+type DynLeaseAccess interface {
+	Resource(schema.GroupVersionResource) dynamic.NamespaceableResourceInterface
+}
+
+func init() {
+	witness.Register("k8s-lease", factory)
+}
+
+// K8sLeaseClient implements witness.Client over one coordination Lease.
+//
+// Concurrent-safe: every method is a read-modify-write against the
+// apiserver, which is the arbitration point (resourceVersion CAS). No
+// process-local mutable state.
+type K8sLeaseClient struct {
+	// Dyn is the dynamic client bound to the control-plane cluster.
+	Dyn DynLeaseAccess
+
+	// Namespace is where the Lease object lives. Defaults to the
+	// controller namespace via the factory.
+	Namespace string
+
+	// Slot is the per-CR identifier (`<ns>/<name>`); encoded into the
+	// Lease object name.
+	Slot string
+
+	// LeaseName is the resolved Lease object name (cw-<encodedSlot>).
+	LeaseName string
+}
+
+// New constructs a K8sLeaseClient. dyn + namespace + slot required.
+func New(dyn DynLeaseAccess, namespace, slot string) (*K8sLeaseClient, error) {
+	if dyn == nil {
+		return nil, errors.New("k8slease: dynamic client is required")
+	}
+	if strings.TrimSpace(namespace) == "" {
+		return nil, errors.New("k8slease: namespace is required")
+	}
+	if strings.TrimSpace(slot) == "" {
+		return nil, errors.New("k8slease: slot is required")
+	}
+	return &K8sLeaseClient{
+		Dyn:       dyn,
+		Namespace: strings.TrimSpace(namespace),
+		Slot:      strings.TrimSpace(slot),
+		LeaseName: leaseObjectName(slot),
+	}, nil
+}
+
+// factory is the witness.Factory registered at init() time.
+//
+// cfg keys:
+//
+//	slot       (string)  REQUIRED — `<ns>/<name>` (stamped by the
+//	                     reconciler's selectWitness).
+//	namespace  (string)  OPTIONAL — Lease namespace. The reconciler
+//	                     stamps "leaseNamespace" from CATALYST_LEASE_NS /
+//	                     the controller namespace; the CR may also set
+//	                     leaseClient.config.namespace to pin one.
+//
+// The k8s-lease witness needs NO SecretReader (no external creds) — the
+// in-cluster ServiceAccount token authenticates to the kube API. The
+// dynamic client is injected via cfg["dyn"] by the reconciler (the
+// witness package can't import client-go construction without a cycle,
+// so the controller passes its already-built dynamic client through the
+// config map).
+func factory(cfg map[string]any, _ witness.SecretReader) (witness.Client, error) {
+	slot, _ := cfg["slot"].(string)
+	namespace, _ := cfg["namespace"].(string)
+	if namespace == "" {
+		// Forward-compat alternate key the reconciler may stamp.
+		namespace, _ = cfg["leaseNamespace"].(string)
+	}
+	dyn, ok := cfg["dyn"].(DynLeaseAccess)
+	if !ok || dyn == nil {
+		return nil, errors.New("k8slease: dynamic client not provided in cfg[\"dyn\"] " +
+			"(the continuum-controller must stamp its dynamic client into the witness config)")
+	}
+	return New(dyn, namespace, slot)
+}
+
+// Acquire implements witness.Client. Read-modify-write with
+// resourceVersion CAS: a free/expired/own slot is takeable; a live slot
+// held by another region returns ErrLeaseHeldByAnother.
+func (c *K8sLeaseClient) Acquire(ctx context.Context, holder string, ttl time.Duration) (witness.State, error) {
+	if err := ctx.Err(); err != nil {
+		return witness.State{}, err
+	}
+	obj, st, found, err := c.read(ctx)
+	if err != nil {
+		return witness.State{}, err
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+
+	takeable := st.Holder == "" || !now.Before(st.ExpiresAt) || st.Holder == holder
+	if !takeable {
+		return st, witness.ErrLeaseHeldByAnother
+	}
+
+	acquiredAt := now
+	if st.Holder == holder && now.Before(st.ExpiresAt) && !st.AcquiredAt.IsZero() {
+		acquiredAt = st.AcquiredAt
+	}
+	next := witness.State{
+		Holder:     holder,
+		AcquiredAt: acquiredAt,
+		ExpiresAt:  now.Add(ttl),
+		Generation: st.Generation + 1,
+	}
+	if err := c.write(ctx, obj, found, next, ttl, now); err != nil {
+		if apierrors.IsConflict(err) {
+			// Lost the CAS race — another writer moved first. Never
+			// promote blind.
+			return st, witness.ErrLeaseHeldByAnother
+		}
+		return witness.State{}, err
+	}
+	return next, nil
+}
+
+// Renew implements witness.Client. Extends the slot iff `holder` still
+// owns it and it has not expired; otherwise ErrLeaseLost.
+func (c *K8sLeaseClient) Renew(ctx context.Context, holder string, ttl time.Duration) (witness.State, error) {
+	if err := ctx.Err(); err != nil {
+		return witness.State{}, err
+	}
+	obj, st, found, err := c.read(ctx)
+	if err != nil {
+		return witness.State{}, err
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	if !found || st.Holder != holder || !now.Before(st.ExpiresAt) {
+		return st, witness.ErrLeaseLost
+	}
+	next := witness.State{
+		Holder:     holder,
+		AcquiredAt: st.AcquiredAt,
+		ExpiresAt:  now.Add(ttl),
+		Generation: st.Generation + 1,
+	}
+	if err := c.write(ctx, obj, found, next, ttl, now); err != nil {
+		if apierrors.IsConflict(err) {
+			// Another writer completed a CAS while we were mid-renew →
+			// we lost the lease.
+			return st, witness.ErrLeaseLost
+		}
+		return witness.State{}, err
+	}
+	return next, nil
+}
+
+// Release implements witness.Client. Idempotent: a non-holder Release is
+// a no-op. Clears holderIdentity but bumps generation so a subsequent
+// Acquire sees a non-zero baseline (matches the other impls).
+func (c *K8sLeaseClient) Release(ctx context.Context, holder string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	obj, st, found, err := c.read(ctx)
+	if err != nil {
+		return err
+	}
+	if !found || st.Holder == "" || st.Holder != holder {
+		return nil
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	released := witness.State{Generation: st.Generation + 1}
+	if err := c.write(ctx, obj, found, released, 0, now); err != nil {
+		if apierrors.IsConflict(err) {
+			// Someone else already moved the slot — Release is
+			// idempotent, so swallow.
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// Read implements witness.Client.
+func (c *K8sLeaseClient) Read(ctx context.Context) (witness.State, error) {
+	if err := ctx.Err(); err != nil {
+		return witness.State{}, err
+	}
+	_, st, _, err := c.read(ctx)
+	if err != nil {
+		return witness.State{}, err
+	}
+	return st, nil
+}
+
+// read GETs the Lease and projects it into a witness.State. A NotFound
+// Lease is the "free slot" case (found=false, zero State). The returned
+// *unstructured.Unstructured is the live object (with resourceVersion)
+// to thread into the subsequent write for CAS; nil when not found.
+func (c *K8sLeaseClient) read(ctx context.Context) (*unstructured.Unstructured, witness.State, bool, error) {
+	obj, err := c.Dyn.Resource(leaseGVR).Namespace(c.Namespace).Get(ctx, c.LeaseName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil, witness.State{}, false, nil
+	}
+	if err != nil {
+		return nil, witness.State{}, false, fmt.Errorf("k8slease: get Lease %s/%s: %w", c.Namespace, c.LeaseName, err)
+	}
+	st, perr := leaseToState(obj)
+	if perr != nil {
+		return obj, witness.State{}, true, perr
+	}
+	return obj, st, true, nil
+}
+
+// write CREATEs (when the Lease is absent) or UPDATEs (threading the
+// existing resourceVersion for CAS) the Lease to reflect `next`.
+func (c *K8sLeaseClient) write(ctx context.Context, existing *unstructured.Unstructured, found bool, next witness.State, ttl time.Duration, now time.Time) error {
+	obj := buildLeaseObject(c.Namespace, c.LeaseName, c.Slot, next, ttl)
+	res := c.Dyn.Resource(leaseGVR).Namespace(c.Namespace)
+	if !found {
+		_, err := res.Create(ctx, obj, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(err) {
+			// Lost the create race — treat as a CAS conflict so the
+			// caller surfaces ErrLeaseHeldByAnother / ErrLeaseLost.
+			return apierrors.NewConflict(
+				schema.GroupResource{Group: leaseGVR.Group, Resource: leaseGVR.Resource},
+				c.LeaseName, errors.New("k8slease: lost create race"))
+		}
+		return err
+	}
+	// Thread the live resourceVersion so the apiserver enforces CAS.
+	obj.SetResourceVersion(existing.GetResourceVersion())
+	// Preserve any unrelated metadata (labels the chart/operator added).
+	if labels := existing.GetLabels(); len(labels) > 0 {
+		merged := obj.GetLabels()
+		for k, v := range labels {
+			if _, taken := merged[k]; !taken {
+				merged[k] = v
+			}
+		}
+		obj.SetLabels(merged)
+	}
+	_, err := res.Update(ctx, obj, metav1.UpdateOptions{})
+	return err
+}
+
+// leaseToState projects a coordination Lease's spec into a
+// witness.State. A Lease with no holderIdentity is the free slot.
+func leaseToState(obj *unstructured.Unstructured) (witness.State, error) {
+	st := witness.State{}
+	holder, _, _ := unstructured.NestedString(obj.Object, "spec", "holderIdentity")
+	st.Holder = holder
+
+	durSecs, _, _ := unstructured.NestedInt64(obj.Object, "spec", "leaseDurationSeconds")
+
+	if acq, ok, _ := unstructured.NestedString(obj.Object, "spec", "acquireTime"); ok && acq != "" {
+		if t, err := time.Parse(time.RFC3339, acq); err == nil {
+			st.AcquiredAt = t.UTC()
+		}
+	}
+	var renew time.Time
+	if rn, ok, _ := unstructured.NestedString(obj.Object, "spec", "renewTime"); ok && rn != "" {
+		if t, err := time.Parse(time.RFC3339, rn); err == nil {
+			renew = t.UTC()
+		}
+	}
+	if !renew.IsZero() && durSecs > 0 {
+		st.ExpiresAt = renew.Add(time.Duration(durSecs) * time.Second)
+	}
+
+	if ann := obj.GetAnnotations(); ann != nil {
+		if g, ok := ann[GenerationAnnotation]; ok && g != "" {
+			if n, err := strconv.ParseInt(g, 10, 64); err == nil {
+				st.Generation = n
+			}
+		}
+	}
+	return st, nil
+}
+
+// buildLeaseObject renders the Lease Unstructured for a target State.
+// A cleared State (Holder=="") writes an empty holderIdentity so the
+// slot reads as free, while still bumping the generation annotation.
+func buildLeaseObject(namespace, name, slot string, st witness.State, ttl time.Duration) *unstructured.Unstructured {
+	spec := map[string]interface{}{}
+	if st.Holder != "" {
+		spec["holderIdentity"] = st.Holder
+		if ttl > 0 {
+			spec["leaseDurationSeconds"] = int64(ttl / time.Second)
+		}
+		if !st.AcquiredAt.IsZero() {
+			spec["acquireTime"] = st.AcquiredAt.UTC().Format(microRFC3339)
+		}
+		if !st.ExpiresAt.IsZero() && ttl > 0 {
+			// renewTime = expiresAt - ttl (the moment of this write).
+			spec["renewTime"] = st.ExpiresAt.Add(-ttl).UTC().Format(microRFC3339)
+		}
+	}
+
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "coordination.k8s.io/v1",
+		"kind":       "Lease",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": namespace,
+			"labels": map[string]interface{}{
+				"app.kubernetes.io/managed-by": "continuum-controller",
+				"openova.io/witness":           "k8s-lease",
+			},
+			"annotations": map[string]interface{}{
+				GenerationAnnotation:       strconv.FormatInt(st.Generation, 10),
+				"dr.openova.io/slot":       slot,
+				"dr.openova.io/lease-kind": "continuum",
+			},
+		},
+		"spec": spec,
+	}}
+	return obj
+}
+
+// microRFC3339 matches the MicroTime serialization the apiserver uses
+// for Lease spec.acquireTime / spec.renewTime (metav1.MicroTime). Using
+// the canonical encoding avoids a needless rewrite-on-read drift.
+const microRFC3339 = "2006-01-02T15:04:05.000000Z07:00"
+
+// leaseObjectName encodes a Continuum slot (`<ns>/<name>`) into a
+// DNS-label-safe Lease object name. '/' → '-', prefixed with "cw-"
+// (continuum-witness) so the lease roster is self-describing.
+func leaseObjectName(slot string) string {
+	return "cw-" + strings.ReplaceAll(strings.TrimSpace(slot), "/", "-")
+}
+
+// Compile-time assertion that K8sLeaseClient satisfies witness.Client.
+var _ witness.Client = (*K8sLeaseClient)(nil)

--- a/core/controllers/continuum/internal/witness/k8slease/client_test.go
+++ b/core/controllers/continuum/internal/witness/k8slease/client_test.go
@@ -1,0 +1,256 @@
+// Tests for the k8s-lease witness (#3829). We exercise the CAS
+// contract against a fake dynamic client (k8s.io/client-go/dynamic/fake)
+// — the SAME fake the continuum-controller tests use — so the
+// read-modify-write path runs through real apimachinery codecs.
+//
+// The k8s Lease object is SECOND-granular by API design
+// (spec.leaseDurationSeconds is an integer), so this suite uses
+// second-scale TTLs rather than the witness/testing contract suite's
+// 100ms shortTTL (which assumes sub-second granularity the Lease wire
+// shape cannot carry).
+package k8slease
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/openova-io/openova/core/controllers/continuum/internal/witness"
+)
+
+func newFakeDyn() *dynamicfake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{
+			leaseGVR: "LeaseList",
+		})
+}
+
+func newClient(t *testing.T, dyn DynLeaseAccess, slot string) *K8sLeaseClient {
+	t.Helper()
+	c, err := New(dyn, "catalyst-system", slot)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+func TestFactory_RequiresDyn(t *testing.T) {
+	if _, err := factory(map[string]any{"slot": "ns/x"}, nil); err == nil {
+		t.Fatal("expected error when cfg[\"dyn\"] is absent")
+	}
+}
+
+func TestFactory_BuildsClient(t *testing.T) {
+	dyn := newFakeDyn()
+	c, err := factory(map[string]any{
+		"slot":      "cnpg/cnpg-pair-bp-cnpg-pair-continuum",
+		"namespace": "catalyst-system",
+		"dyn":       DynLeaseAccess(dyn),
+	}, nil)
+	if err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+	kc, ok := c.(*K8sLeaseClient)
+	if !ok {
+		t.Fatalf("want *K8sLeaseClient, got %T", c)
+	}
+	if kc.LeaseName != "cw-cnpg-cnpg-pair-bp-cnpg-pair-continuum" {
+		t.Fatalf("unexpected lease name %q", kc.LeaseName)
+	}
+}
+
+// TestAcquireOnEmptyCreatesLease is the core happy path that was broken
+// live: a healthy 2-region pair must yield a held lease so the Continuum
+// CR goes Ready=True / LeaseHeld=True with leaseHolder=<primary>.
+func TestAcquireOnEmptyCreatesLease(t *testing.T) {
+	dyn := newFakeDyn()
+	c := newClient(t, dyn, "cnpg/dr")
+
+	st, err := c.Acquire(context.Background(), "hw-me-east-215-a-rtz-prod", 30*time.Second)
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if st.Holder != "hw-me-east-215-a-rtz-prod" {
+		t.Fatalf("holder = %q, want region-a", st.Holder)
+	}
+	if st.Generation != 1 {
+		t.Fatalf("generation = %d, want 1", st.Generation)
+	}
+	if st.ExpiresAt.IsZero() || !st.ExpiresAt.After(time.Now()) {
+		t.Fatalf("expiresAt not in the future: %v", st.ExpiresAt)
+	}
+
+	// Read back through a fresh client (simulating the reconcile loop's
+	// status read) — the lease must be visible + held.
+	got, err := newClient(t, dyn, "cnpg/dr").Read(context.Background())
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got.Holder != "hw-me-east-215-a-rtz-prod" {
+		t.Fatalf("read-back holder = %q", got.Holder)
+	}
+}
+
+func TestAcquireBlockedByAnotherHolder(t *testing.T) {
+	dyn := newFakeDyn()
+	a := newClient(t, dyn, "cnpg/dr")
+	b := newClient(t, dyn, "cnpg/dr")
+
+	if _, err := a.Acquire(context.Background(), "region-a", 30*time.Second); err != nil {
+		t.Fatalf("a.Acquire: %v", err)
+	}
+	_, err := b.Acquire(context.Background(), "region-b", 30*time.Second)
+	if err != witness.ErrLeaseHeldByAnother {
+		t.Fatalf("b.Acquire err = %v, want ErrLeaseHeldByAnother", err)
+	}
+}
+
+func TestAcquireSameHolderExtendsAndPreservesAcquiredAt(t *testing.T) {
+	dyn := newFakeDyn()
+	c := newClient(t, dyn, "cnpg/dr")
+
+	first, err := c.Acquire(context.Background(), "region-a", 30*time.Second)
+	if err != nil {
+		t.Fatalf("first Acquire: %v", err)
+	}
+	time.Sleep(1100 * time.Millisecond) // cross a second boundary
+	second, err := c.Acquire(context.Background(), "region-a", 30*time.Second)
+	if err != nil {
+		t.Fatalf("second Acquire: %v", err)
+	}
+	if !second.AcquiredAt.Equal(first.AcquiredAt) {
+		t.Fatalf("acquiredAt drifted: first=%v second=%v", first.AcquiredAt, second.AcquiredAt)
+	}
+	if second.Generation <= first.Generation {
+		t.Fatalf("generation did not bump: %d -> %d", first.Generation, second.Generation)
+	}
+}
+
+func TestRenewExtendsAndBumpsGeneration(t *testing.T) {
+	dyn := newFakeDyn()
+	c := newClient(t, dyn, "cnpg/dr")
+
+	acq, err := c.Acquire(context.Background(), "region-a", 30*time.Second)
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	rn, err := c.Renew(context.Background(), "region-a", 30*time.Second)
+	if err != nil {
+		t.Fatalf("Renew: %v", err)
+	}
+	if rn.Generation <= acq.Generation {
+		t.Fatalf("renew did not bump generation: %d -> %d", acq.Generation, rn.Generation)
+	}
+}
+
+func TestRenewByNonHolderReturnsLost(t *testing.T) {
+	dyn := newFakeDyn()
+	a := newClient(t, dyn, "cnpg/dr")
+	if _, err := a.Acquire(context.Background(), "region-a", 30*time.Second); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	b := newClient(t, dyn, "cnpg/dr")
+	if _, err := b.Renew(context.Background(), "region-b", 30*time.Second); err != witness.ErrLeaseLost {
+		t.Fatalf("Renew(non-holder) = %v, want ErrLeaseLost", err)
+	}
+}
+
+// TestAcquireAfterExpiryAllowsFailover proves the region-kill path: an
+// expired lease (the dead primary stopped renewing) is takeable by the
+// standby region.
+func TestAcquireAfterExpiryAllowsFailover(t *testing.T) {
+	dyn := newFakeDyn()
+	a := newClient(t, dyn, "cnpg/dr")
+	// 1s TTL — the smallest the Lease wire shape carries.
+	if _, err := a.Acquire(context.Background(), "region-a", 1*time.Second); err != nil {
+		t.Fatalf("a.Acquire: %v", err)
+	}
+	// Wait past expiry (renewTime + 1s).
+	time.Sleep(2100 * time.Millisecond)
+
+	b := newClient(t, dyn, "cnpg/dr")
+	st, err := b.Acquire(context.Background(), "region-b", 30*time.Second)
+	if err != nil {
+		t.Fatalf("b.Acquire after expiry = %v, want success (failover)", err)
+	}
+	if st.Holder != "region-b" {
+		t.Fatalf("post-failover holder = %q, want region-b", st.Holder)
+	}
+}
+
+func TestRenewAfterExpiryReturnsLost(t *testing.T) {
+	dyn := newFakeDyn()
+	c := newClient(t, dyn, "cnpg/dr")
+	if _, err := c.Acquire(context.Background(), "region-a", 1*time.Second); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	time.Sleep(2100 * time.Millisecond)
+	if _, err := c.Renew(context.Background(), "region-a", 1*time.Second); err != witness.ErrLeaseLost {
+		t.Fatalf("Renew after expiry = %v, want ErrLeaseLost", err)
+	}
+}
+
+func TestReleaseIsIdempotent(t *testing.T) {
+	dyn := newFakeDyn()
+	c := newClient(t, dyn, "cnpg/dr")
+	if _, err := c.Acquire(context.Background(), "region-a", 30*time.Second); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if err := c.Release(context.Background(), "region-a"); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	// Slot is now free; a new holder can take it.
+	st, err := newClient(t, dyn, "cnpg/dr").Acquire(context.Background(), "region-b", 30*time.Second)
+	if err != nil {
+		t.Fatalf("Acquire after release: %v", err)
+	}
+	if st.Holder != "region-b" {
+		t.Fatalf("holder after release+acquire = %q", st.Holder)
+	}
+	// Non-holder Release is a no-op (does not evict region-b).
+	if err := c.Release(context.Background(), "region-a"); err != nil {
+		t.Fatalf("non-holder Release: %v", err)
+	}
+	got, _ := newClient(t, dyn, "cnpg/dr").Read(context.Background())
+	if got.Holder != "region-b" {
+		t.Fatalf("non-holder release evicted the live holder: %q", got.Holder)
+	}
+}
+
+func TestSlotIsolation(t *testing.T) {
+	dyn := newFakeDyn()
+	a := newClient(t, dyn, "cnpg/dr-one")
+	b := newClient(t, dyn, "cnpg/dr-two")
+	if _, err := a.Acquire(context.Background(), "region-a", 30*time.Second); err != nil {
+		t.Fatalf("a.Acquire: %v", err)
+	}
+	// b's slot is independent — acquiring it must succeed.
+	if _, err := b.Acquire(context.Background(), "region-x", 30*time.Second); err != nil {
+		t.Fatalf("b.Acquire (different slot) = %v, want success", err)
+	}
+	if a.LeaseName == b.LeaseName {
+		t.Fatalf("distinct slots produced identical lease names: %q", a.LeaseName)
+	}
+}
+
+func TestReadOnEmptySlotIsFree(t *testing.T) {
+	dyn := newFakeDyn()
+	st, err := newClient(t, dyn, "cnpg/dr").Read(context.Background())
+	if err != nil {
+		t.Fatalf("Read empty: %v", err)
+	}
+	if st.Holder != "" {
+		t.Fatalf("empty slot reported holder %q", st.Holder)
+	}
+}
+
+func TestLeaseObjectNameEncoding(t *testing.T) {
+	if got := leaseObjectName("cnpg/cnpg-pair-bp-cnpg-pair-continuum"); got != "cw-cnpg-cnpg-pair-bp-cnpg-pair-continuum" {
+		t.Fatalf("encoding = %q", got)
+	}
+}

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-9-disaster-recovery
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.2.6
+  version: 0.2.7
   card:
     title: CNPG Cluster-Pair (Active-Hotstandby DR)
     summary: |

--- a/platform/cnpg-pair/chart/Chart.yaml
+++ b/platform/cnpg-pair/chart/Chart.yaml
@@ -1,6 +1,15 @@
 apiVersion: v2
 name: bp-cnpg-pair
-version: 0.2.6
+# 0.2.7 (#3829, #3375): default the Continuum CR's lease witness to
+# `k8s-lease` (a native coordination.k8s.io/v1 Lease in the control
+# plane — zero external dependency, durable etcd CAS) and DROP the
+# placeholder dns-quorum resolvers (10.43.0.11/.12 were never DNS
+# servers; dns-quorum's TXTWriter was a never-completed POC → every
+# Acquire failed → the Continuum CR sat Degraded/LeaseHeld=False forever
+# and the console Topology tab fell back to "singleton"). The template
+# gains an optional leaseClient.namespace passthrough. Slot-16b pin moves
+# to 0.2.7 in lockstep (Inviolable Principle #13).
+version: 0.2.7
 appVersion: "0.2.1"
 description: |
   Catalyst-curated Blueprint for an active-hotstandby CNPG cluster-pair

--- a/platform/cnpg-pair/chart/templates/continuum.yaml
+++ b/platform/cnpg-pair/chart/templates/continuum.yaml
@@ -65,6 +65,9 @@ spec:
     config:
       ttlSeconds: {{ .Values.cnpgPair.continuum.leaseClient.ttlSeconds }}
       renewSeconds: {{ .Values.cnpgPair.continuum.leaseClient.renewSeconds }}
+      {{- with .Values.cnpgPair.continuum.leaseClient.namespace }}
+      namespace: {{ . | quote }}
+      {{- end }}
       {{- with .Values.cnpgPair.continuum.leaseClient.resolvers }}
       resolvers:
         {{- range . }}

--- a/platform/cnpg-pair/chart/values.yaml
+++ b/platform/cnpg-pair/chart/values.yaml
@@ -282,18 +282,21 @@ cnpgPair:
     # operator-confirmed action until the lease-witness + multi-vantage
     # DNS probe are validated on a fresh 2-region prov (Phase-2 walk).
     autoFailover: false
-    # Lease witness — dns-quorum is the in-cluster fallback (no external
-    # Cloudflare-KV dependency). The CRD requires 3-5 resolvers (2-of-3
-    # voting quorum); these default to a 3-entry placeholder set that
-    # overlays repoint at the Sovereign's real resolver IPs.
+    # Lease witness — k8s-lease (#3829) is the air-gappable DEFAULT: a
+    # native coordination.k8s.io/v1 Lease in the control-plane cluster,
+    # zero external dependency, durable etcd-backed CAS. This replaces
+    # the dns-quorum default, which was a never-completed Phase-1 POC
+    # (nil TXTWriter → every Acquire failed) wired against placeholder
+    # resolvers (10.43.0.11/.12 aren't DNS servers) → the cnpg-pair
+    # Continuum CR sat Degraded/LeaseHeld=False forever on omantel.biz.
+    # The continuum-controller ClusterRole already grants
+    # coordination.k8s.io/leases {get,list,...,create,update}, so no RBAC
+    # change is needed. The Lease object lands in the controller's
+    # namespace (override via leaseClient.namespace).
     leaseClient:
-      kind: dns-quorum
+      kind: k8s-lease
       ttlSeconds: 30
       renewSeconds: 10
-      resolvers:
-        - "10.43.0.10"
-        - "10.43.0.11"
-        - "10.43.0.12"
     # PDM zone for the lua-record flip target. Empty => the controller
     # falls back to the in-cluster pool-domain-manager Service default.
     pdmZone: ""

--- a/products/catalyst/chart/crds/continuum.yaml
+++ b/products/catalyst/chart/crds/continuum.yaml
@@ -98,19 +98,34 @@ spec:
                   properties:
                     kind:
                       type: string
-                      enum: [cloudflare-kv, dns-quorum]
+                      enum: [k8s-lease, cloudflare-kv, dns-quorum]
                       description: |
+                        k8s-lease = a native coordination.k8s.io/v1 Lease
+                        in the control-plane cluster (#3829). The
+                        air-gappable DEFAULT — zero external dependency,
+                        durable etcd-backed CAS via the Lease object's
+                        resourceVersion. Recommended for every Sovereign.
                         cloudflare-kv = lease in a Cloudflare Worker KV
-                        namespace (recommended per SRE.md §2.4).
-                        dns-quorum = 2-of-3 DNS resolver quorum
-                        (fallback when CF KV is unavailable).
+                        namespace — needs external egress + a Worker;
+                        unsuitable for air-gapped / self-sovereign.
+                        dns-quorum = 2-of-3 DNS resolver quorum over
+                        PowerDNS TXT (requires a TXT-write backend).
                     config:
                       type: object
                       description: |
-                        Kind-specific config. cloudflare-kv expects
-                        kvNamespaceId + accountId + tokenSecretRef.
-                        dns-quorum expects resolvers[] (2-of-3 voting set).
+                        Kind-specific config. k8s-lease optionally takes
+                        namespace (defaults to the controller namespace).
+                        cloudflare-kv expects kvNamespaceId + accountId +
+                        tokenSecretRef. dns-quorum expects resolvers[]
+                        (2-of-3 voting set) + a TXT-write backend.
                       properties:
+                        namespace:
+                          type: string
+                          description: |
+                            k8s-lease only — namespace for the
+                            coordination.k8s.io/v1 Lease object. Optional;
+                            defaults to the continuum-controller's own
+                            namespace.
                         kvNamespaceId:
                           type: string
                         accountId:

--- a/products/continuum/chart/Chart.yaml
+++ b/products/continuum/chart/Chart.yaml
@@ -55,7 +55,18 @@ type: application
 # raft-transition (bp-openbao). (Promote step corrected in 0.1.7 —
 # transition-to-primary is not an OSS command.) RBAC adds pods + pods/exec for
 # the raft promotion. Slot-62 pin moves to 0.1.6 in lockstep (Principle #13).
-version: 0.1.7
+# 0.1.8 (#3829, #3375): the continuum-controller image gains the
+# `k8s-lease` witness (native coordination.k8s.io/v1 Lease, air-gappable
+# default) + a CATALYST_REGION fallback to the CR's primaryRegion so a
+# healthy 2-region pair self-bootstraps leaseHolder=<region-a> even when
+# the deployment never wired CATALYST_REGION (the live omantel.biz case).
+# Before this the cnpg-pair Continuum CR sat Degraded/LeaseHeld=False
+# forever (dns-quorum POC never acquired) → the console Topology tab had
+# no live lease/standby/lag to render and fell back to "singleton". RBAC
+# already grants coordination.k8s.io/leases — no chart RBAC change. New
+# CATALYST_LEASE_NS env (defaults to the controller namespace). Slot-62
+# pin moves to 0.1.8 in lockstep (Inviolable Principle #13).
+version: 0.1.8
 appVersion: "0.1.0"
 home: https://openova.io
 sources:

--- a/products/continuum/chart/blueprint.yaml
+++ b/products/continuum/chart/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-9-disaster-recovery
     openova.io/category: customer-facing-capability
 spec:
-  version: 0.1.7
+  version: 0.1.8
   card:
     title: Continuum
     summary: |

--- a/products/continuum/chart/templates/deployment.yaml
+++ b/products/continuum/chart/templates/deployment.yaml
@@ -100,6 +100,22 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # #3829 — the host-cluster region this controller represents.
+            # Stamped on the k8s-lease holderIdentity. When unset, the
+            # controller falls back to the Continuum CR's primaryRegion
+            # (the controller runs only on the primary-side cluster), so
+            # a fresh prov that doesn't wire this still yields a held
+            # lease. Set continuum.region in an overlay to pin it
+            # explicitly.
+            {{- if .Values.continuum.region }}
+            - name: CATALYST_REGION
+              value: {{ .Values.continuum.region | quote }}
+            {{- end }}
+            # #3829 — namespace for the k8s-lease witness's
+            # coordination.k8s.io/v1 Lease objects. Defaults (controller
+            # binary side) to the controller's own namespace.
+            - name: CATALYST_LEASE_NS
+              value: {{ .Values.continuum.leaseNamespace | default .Release.Namespace | quote }}
             # K-Cont-2 / K-Cont-3 seams (sketched here; values currently
             # unused by the no-op Reconcile but part of the target-state
             # shape per Inviolable Principle #1).

--- a/products/continuum/chart/values.yaml
+++ b/products/continuum/chart/values.yaml
@@ -124,6 +124,20 @@ continuum:
   # in-cluster nats.openova-system.svc.cluster.local default.
   natsURL: ""
 
+  # #3829 — the host-cluster region this controller instance represents,
+  # stamped as the k8s-lease holderIdentity (CATALYST_REGION). Empty =
+  # the controller falls back to the Continuum CR's primaryRegion (it
+  # runs only on the primary-side cluster), which is correct for a single
+  # 2-region cnpg-pair. Pin explicitly in a per-Sovereign overlay if a
+  # cluster hosts continuum CRs whose primaryRegion is not this region.
+  region: ""
+
+  # #3829 — namespace for the k8s-lease witness's coordination.k8s.io/v1
+  # Lease objects (CATALYST_LEASE_NS). Empty = the controller's own
+  # namespace (.Release.Namespace), where the ClusterRole already grants
+  # coordination.k8s.io/leases.
+  leaseNamespace: ""
+
   # Lease witness defaults (overridden per-CR via Continuum.spec.leaseClient).
   # These are CONTROLLER-WIDE defaults; per-Continuum-CR config wins.
   lease:


### PR DESCRIPTION
## Problem (from the live UAT walk on omantel.biz, dep `4635277cae4ffed9`)

The console `/app/shared-pg` Topology tab rendered **Pattern: singleton** (one region-a primary card, no region-b standby, no Switchover button, no replication-lag) even though the app declares `active-hot-standby` and the physical 2-region CNPG pair is healthy (`Cluster in healthy state`, 3/3 Ready in both regions).

Root cause: the **Continuum DR layer** the Topology tab reads was broken. Live: `kubectl get continuum -A` → `cnpg-pair-bp-cnpg-pair-continuum` **Degraded, LEASE empty** (`LeaseHeld=False`, `Ready=False`), controller logging `witness read-quorum unavailable` every 10s.

## Exact lease-election root cause (file:line)

**Two independent fatal gaps**, both proven live:

1. **The `dns-quorum` witness never acquires a lease.**
   - `core/controllers/continuum/internal/witness/dnsquorum/client.go:208-213` — the factory **always** builds the client with a **nil `TXTWriter`**. `Acquire` → `writeQuorum` (`:434-435`) returns `"dnsquorum: Writer not configured (Phase-1 POC needs PDM /v1/txt — K-Cont-{4|5})"`. The PDM TXT-write backend was never wired.
   - The CR's resolvers (`platform/cnpg-pair/chart/values.yaml`) were placeholders `10.43.0.10/11/12` — only `.10` is kube-dns; `.11/.12` are unallocated ClusterIPs → only 1/3 reads succeed → below the 2-of-3 quorum → `ErrQuorumUnavailable` (the live log line).
   - `cloudflare-kv` (the only complete witness) needs external Cloudflare egress an air-gapped Sovereign does not have.
   - Net: lease never held → `phase=Degraded`, `LeaseHeld=False` forever → the Topology tab has no live lease/standby/lag → falls back to singleton.

2. **`CATALYST_REGION` is unset on the live deployment** → `HoldingRegion=""` → `lease.IsHeldBy("")` is always false (`continuum_controller.go`) → Degraded even if a witness acquired cleanly.

## Fix

1. **New `k8s-lease` witness** (`core/controllers/continuum/internal/witness/k8slease/`): a native `coordination.k8s.io/v1` Lease in the control-plane cluster. Zero external dependency (air-gappable), durable etcd-backed CAS via the Lease `resourceVersion`. The continuum-controller ClusterRole **already** grants `coordination.k8s.io/leases {get,list,watch,create,update,patch,delete}` — **no RBAC change**. Now the air-gappable **default** on:
   - the `bp-cnpg-pair` chart (`leaseClient.kind: k8s-lease`, placeholder resolvers dropped),
   - the application-controller per-app producer (`DefaultContinuumLeaseKind`),
   - the CRD `leaseClient.kind` enum.

2. **`effectiveHoldingRegion` fallback**: the continuum-controller runs **only** on the primary-side cluster (the cnpg-pair chart + bp-continuum HR are side-gated to the primary), so when `CATALYST_REGION` is unset it now holds the lease as the CR's `primaryRegion`. A healthy pair self-bootstraps `leaseHolder=<region-a>`. The chart also wires `CATALYST_REGION` / `CATALYST_LEASE_NS` explicitly.

## Does shared-pg need a minted Continuum?

No new mint needed for the DoD rows. The **cnpg-pair already owns the Continuum CR** (`cnpg-pair-bp-cnpg-pair-continuum`, `applicationRef: catalyst-platform`) that governs the `shared-pg` / `shared-pg-b` / `shared-pg-c` ↔ `-replica` 2-region pair. `shared-pg` itself is a bootstrap HelmRelease with no Application CR, so it has no per-app `dr-<app>` CR — it is the cnpg-pair CR that carries its DR state. This fix makes **that** CR go `Ready=True` with a live lease, which is what the Topology tab projects. (The per-app producer default flip to `k8s-lease` covers every future Application-CR DR app generically.)

## DoD rows this unblocks

Once rolled + reconciled, the cnpg-pair Continuum → `Ready=True`, `LeaseHeld=True`, `leaseHolder=<region-a>`, `replicationLagSeconds` populated, standby entry present → the Topology tab renders region-a primary + region-b standby as one active-hot-standby placement with an armed Switchover button + live DR section (rows 51/52/54/55/56/57/62/63/64/71).

## Tests
- `k8slease/client_test.go` — full CAS contract against the dynamic fake: acquire-on-empty, held-by-another, same-holder-extend (preserves acquiredAt), renew-bumps-gen, renew-by-non-holder=Lost, **acquire-after-expiry=failover**, release idempotency, slot isolation, read-empty=free.
- `continuum_controller_test.go` — `effectiveHoldingRegion` fallback + end-to-end: `HoldingRegion="" ` + lease held by `primaryRegion` → `phase=Healthy`, `Ready=True`, `LeaseHeld=True`, `leaseHolder=<primary>`.
- `go build ./...`, `go vet`, full continuum + application suites green; gofmt clean.

## Chart bumps (stale-deploy trap, #4242)
- `bp-cnpg-pair` 0.2.6 → **0.2.7** (Chart.yaml + blueprint.yaml + bootstrap-kit slot-16b)
- `bp-continuum` 0.1.7 → **0.1.8** (Chart.yaml + blueprint.yaml + bootstrap-kit slot-62)

## Live verification still required
This PR is **merged ≠ shipped**. The DoD rows flip only after the controller image + charts roll on a converged Sovereign and a Playwright walk of the Topology tab + `kubectl get continuum` shows `Ready=True` / a non-empty LEASE. Not claiming the rows flip without that live panel screenshot.

Refs #3829 #3375

🤖 Generated with [Claude Code](https://claude.com/claude-code)