### PR TITLE
fix(pool-domain): default managed-domains to the full offered pool-TLD set — .omani.rest/.omani.trade customers couldn't land on console

### DIFF
--- a/core/pool-domain-manager/internal/dynadot/dynadot.go
+++ b/core/pool-domain-manager/internal/dynadot/dynadot.go
@@ -23,6 +23,29 @@ import (
 	"sync"
 )
 
+// defaultPoolTLDs is the canonical built-in default for the OpenOva
+// subdomain pool — used ONLY when neither DYNADOT_MANAGED_DOMAINS nor the
+// legacy DYNADOT_DOMAIN env var is configured (tests, or a deployment that
+// forgot to mount the secret). It MUST stay in lockstep with the pool TLDs
+// the signup funnel OFFERS to customers (`core/services/domain/store`
+// AllowedTLDs = omani.works / omani.rest / omani.trade / omani.homes).
+//
+// #4255 root cause: a default of only {openova.io, omani.works} meant the
+// PDM BootstrapParentZones never created a central PowerDNS zone (or the
+// NS-delegation glue) for omani.rest / omani.trade, yet the funnel still
+// ASSIGNED those TLDs to customers. The result was a customer landing on a
+// pool TLD whose zone 404s on the central pdns and whose registrar
+// delegation still points at the parking nameservers — wrong DNS + no cert.
+// Defaulting to the FULL offered set fails closed: every TLD the funnel can
+// hand out is one PDM will bootstrap + delegate.
+var defaultPoolTLDs = []string{
+	"openova.io",
+	"omani.works",
+	"omani.rest",
+	"omani.trade",
+	"omani.homes",
+}
+
 // managedDomainsState mirrors the catalyst-api dynadot package's runtime
 // resolution: env-var first, then legacy single-domain fallback, then a
 // minimal built-in default (kept ONLY so unit tests work without an env).
@@ -52,8 +75,12 @@ func computeManagedDomains() map[string]struct{} {
 		out[d] = struct{}{}
 		return out
 	}
-	out["openova.io"] = struct{}{}
-	out["omani.works"] = struct{}{}
+	// Last-resort default: the FULL offered pool-TLD set (#4255), so the
+	// bootstrapped/delegated set can never silently be a subset of the set
+	// the funnel offers. See defaultPoolTLDs.
+	for _, d := range defaultPoolTLDs {
+		out[d] = struct{}{}
+	}
 	return out
 }
 

--- a/core/pool-domain-manager/internal/dynadot/dynadot_test.go
+++ b/core/pool-domain-manager/internal/dynadot/dynadot_test.go
@@ -46,9 +46,15 @@ func TestIsManagedDomainBuiltInDefaults(t *testing.T) {
 	os.Unsetenv("DYNADOT_DOMAIN")
 	ResetManagedDomains()
 
-	for _, d := range []string{"openova.io", "omani.works"} {
+	// #4255: the built-in default MUST cover the FULL offered pool-TLD set
+	// (omani.works / omani.rest / omani.trade / omani.homes) — not just
+	// omani.works — so PDM BootstrapParentZones creates a central pdns zone
+	// + NS-delegation glue for every TLD the funnel can hand a customer.
+	// A default that is a strict subset is exactly the wrong-DNS-no-cert
+	// trap a .omani.rest customer hit.
+	for _, d := range []string{"openova.io", "omani.works", "omani.rest", "omani.trade", "omani.homes"} {
 		if !IsManagedDomain(d) {
-			t.Errorf("built-in default missing %q", d)
+			t.Errorf("built-in default missing %q (must cover the full offered pool-TLD set, #4255)", d)
 		}
 	}
 }

--- a/products/catalyst/bootstrap/api/internal/dynadot/dynadot.go
+++ b/products/catalyst/bootstrap/api/internal/dynadot/dynadot.go
@@ -243,13 +243,32 @@ func computeManagedDomains() map[string]struct{} {
 		return out
 	}
 
-	// 3. Built-in defaults — only the wizard's well-known pool domains.
+	// 3. Built-in defaults — the FULL offered pool-TLD set (#4255).
 	// These are the SAME values surfaced in SOVEREIGN_POOL_DOMAINS in the
-	// UI; keeping them as defensive defaults means a misconfigured
-	// deployment fails closed (refuses BYO DNS writes) rather than open.
-	out["openova.io"] = struct{}{}
-	out["omani.works"] = struct{}{}
+	// UI and offered by the signup funnel (core/services/domain/store
+	// AllowedTLDs = omani.works / omani.rest / omani.trade / omani.homes);
+	// keeping them as defensive defaults means a misconfigured deployment
+	// fails closed (refuses BYO DNS writes for an UNmanaged domain) while
+	// still treating EVERY funnel-offerable pool TLD as managed — so the
+	// PDM zone bootstrap + NS delegation can never be a strict subset of
+	// the set the funnel hands out (the #4255 wrong-DNS-no-cert trap).
+	for _, d := range defaultPoolTLDs {
+		out[d] = struct{}{}
+	}
 	return out
+}
+
+// defaultPoolTLDs is the canonical built-in default for the OpenOva
+// subdomain pool — used ONLY when neither DYNADOT_MANAGED_DOMAINS nor the
+// legacy DYNADOT_DOMAIN env var is configured. It MUST stay in lockstep
+// with the pool TLDs the signup funnel OFFERS (core/services/domain/store
+// AllowedTLDs). See #4255.
+var defaultPoolTLDs = []string{
+	"openova.io",
+	"omani.works",
+	"omani.rest",
+	"omani.trade",
+	"omani.homes",
 }
 
 // ResetManagedDomains clears the cached managed-domain set so the next

--- a/products/catalyst/bootstrap/api/internal/dynadot/dynadot_test.go
+++ b/products/catalyst/bootstrap/api/internal/dynadot/dynadot_test.go
@@ -452,8 +452,14 @@ func TestIsManagedDomain_PoolList(t *testing.T) {
 	}{
 		{"openova.io", true},
 		{"omani.works", true},
-		{"OPENOVA.IO", true},      // case-insensitive
-		{" openova.io ", true},    // trims whitespace
+		// #4255: the built-in default MUST include the FULL offered pool-TLD
+		// set, not just omani.works — a .omani.rest / .omani.trade customer
+		// must be treated as managed so its zone is bootstrapped + delegated.
+		{"omani.rest", true},
+		{"omani.trade", true},
+		{"omani.homes", true},
+		{"OPENOVA.IO", true},   // case-insensitive
+		{" omani.rest ", true}, // trims whitespace
 		{"customer-byo.com", false},
 		{"example.org", false},
 		{"", false},
@@ -589,13 +595,20 @@ func TestManagedDomains_TableDriven(t *testing.T) {
 			},
 		},
 		{
+			// #4255: defaults now cover the FULL offered pool-TLD set
+			// (omani.works / omani.rest / omani.trade / omani.homes) +
+			// openova.io, so the bootstrapped/delegated set can never be a
+			// strict subset of what the funnel offers.
 			name:      "defaults_fallback_when_neither_env_set",
 			envMulti:  "",
 			envLegacy: "",
-			wantSet:   []string{"omani.works", "openova.io"},
+			wantSet:   []string{"omani.homes", "omani.rest", "omani.trade", "omani.works", "openova.io"},
 			queries: []queryCase{
 				{"openova.io", true},
 				{"omani.works", true},
+				{"omani.rest", true},
+				{"omani.trade", true},
+				{"omani.homes", true},
 				{"customer-byo.com", false},
 			},
 		},


### PR DESCRIPTION
## Problem
A customer Organization whose server-assigned pool TLD is `.omani.rest` or `.omani.trade` could not land on their console (honest caveat from the #4179 close-walk). A fresh signup that got `console.<slug>.omani.rest` resolved to `45.151.123.50` (the central nameserver's own IP under the parking delegation, self-signed cert) instead of the console-ELB EIP `212.72.24.33`, and the per-Org cert was stuck mid-issuance. `.omani.works` / `.omani.homes` land cleanly.

## Root cause (verified live — NOT a code whitelist)
A two-part zone/delegation gap. The org-controller pool-DNS (`tenant_dns.go`) + console-TLS (`tenant_console_tls.go`) reconcilers are **fully generic over `parentDomain`**.

The built-in managed-domains DEFAULT in **both** dynadot helpers — PDM (`core/pool-domain-manager/internal/dynadot`) and catalyst-api (`products/catalyst/bootstrap/api/internal/dynadot`) — was `{openova.io, omani.works}`, a strict **subset** of the pool TLDs the signup funnel offers (`core/services/domain/store` `AllowedTLDs` = `omani.works / omani.rest / omani.trade / omani.homes`). The live mothership `dynadot-api-credentials/domains` secret matched (`openova.io,omani.works`).

PDM's `BootstrapParentZones` only ensures a central PowerDNS zone + NS-delegation glue for the **managed** set. So `omani.rest`/`omani.trade`:
1. Had **no central pdns zone** — `GET pdns.openova.io/.../zones/omani.rest.` → **HTTP 404**, so the org-controller's `console.<slug>.omani.rest` A-record PATCH 404s and is best-effort-skipped → nothing written.
2. Had their **registrar NS delegation never flipped** off the Dynadot parking nameservers (`ns1/ns2.dyna-ns.net`) to `ns1/ns2/ns3.openova.io` (the central pdns).

## Fix
**Code (this PR):** default the managed-domains list to the FULL offered pool-TLD set in both helpers, so the bootstrapped/delegated set can never be a strict subset of what the funnel offers (fail-closed). The `DYNADOT_MANAGED_DOMAINS` env override stays authoritative (Principle #4). Tests updated in both modules.

**Operational (applied live on the omantel.biz mothership, see #4255 comments):**
- Patched `dynadot-api-credentials/domains` → all four pool TLDs.
- Created the two central pdns zones (canonical pdns API, NS = ns1/ns2/ns3.openova.io, SOA mirroring omani.works — **not** a Dynadot record-wipe).
- Flipped the registrar NS delegation for `.omani.rest`/`.omani.trade` via the canonical Dynadot `set_ns` command (after `register_ns ns3.openova.io` glue — the #1500-class prereq).

## Live proof
Org-controller PATCH path now returns **HTTP 204** (was 404). Central pdns (`ns1.openova.io`) answers `console.<slug>.omani.rest` → `212.72.24.33`. TLD-registry NS propagation in progress (monitored on #4255).

Refs #4255 #4179