### PR TITLE
fix(bp-continuum): bump 0.1.8->0.1.9 to force Flux re-pull of #4254 k8s-lease controller (image 9c91a7e)

### DIFF
--- a/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
+++ b/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
@@ -137,7 +137,10 @@ spec:
       # PR #996), the 0.1.6 promoter would have failed on a real region-kill.
       # RBAC adds pods `delete` (the restart). Pin moves in lockstep
       # (Inviolable Principle #13).
-      version: 0.1.8
+      # 0.1.9 (#4257): pure version bump (image still 9c91a7e) to force
+      # Flux to re-pull — the 0.1.8 deploy-bot image-tag overwrite did not
+      # change the version so the #4254 k8s-lease controller never rolled.
+      version: 0.1.9
       sourceRef:
         kind: HelmRepository
         name: bp-continuum

--- a/products/continuum/chart/Chart.yaml
+++ b/products/continuum/chart/Chart.yaml
@@ -66,7 +66,18 @@ type: application
 # already grants coordination.k8s.io/leases — no chart RBAC change. New
 # CATALYST_LEASE_NS env (defaults to the controller namespace). Slot-62
 # pin moves to 0.1.8 in lockstep (Inviolable Principle #13).
-version: 0.1.8
+# 0.1.9 (#4257): NO source change — pure version bump to force Flux to
+# re-pull. The deploy-bot patched values.yaml image cf33522->9c91a7e
+# (the #4254 build) WITHOUT bumping the chart version, so GHCR
+# bp-continuum:0.1.8 was overwritten in place (digest 8207b07->c8e32e59).
+# Flux's ChartVersion reconcileStrategy already recorded release v2 at
+# 0.1.8 and refuses to re-pull the changed digest under the same version
+# (suspend/resume does not force it). The live omantel.biz Sovereign was
+# left running the stale cf33522 controller -> Continuum CR stuck
+# Degraded/leaseHolder-empty -> Topology DR undeliverable. Bumping to
+# 0.1.9 (image still 9c91a7e) forces the re-pull. Slot-62 pin moves to
+# 0.1.9 in lockstep (Inviolable Principle #13).
+version: 0.1.9
 appVersion: "0.1.0"
 home: https://openova.io
 sources:

--- a/products/continuum/chart/blueprint.yaml
+++ b/products/continuum/chart/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-9-disaster-recovery
     openova.io/category: customer-facing-capability
 spec:
-  version: 0.1.8
+  version: 0.1.9
   card:
     title: Continuum
     summary: |


### PR DESCRIPTION
## Why

#4254 published the k8s-lease witness controller as image `9c91a7e` and the deploy-bot patched `products/continuum/chart/values.yaml` tag `cf33522`->`9c91a7e` **without bumping the chart version**. GHCR `bp-continuum:0.1.8` was overwritten in place (digest `8207b07`->`c8e32e59`).

Flux `ChartVersion` on the live omantel.biz Sovereign already recorded release `continuum.v2` at `0.1.8` and refuses to re-pull the changed digest under the same version — suspend/resume + HelmRepository re-annotate do **not** force it. The Sovereign was left running stale `cf33522`, so the `cnpg-pair-bp-cnpg-pair-continuum` Continuum CR sits **Degraded / leaseHolder empty** instead of Ready/lease-held. This blocks the Topology DR walk (UAT rows 51/52/54/55/56/57/62/63/64/71).

This is the documented deploy-bot-treadmill / Principle-#13 trap.

## What

Pure chart **version bump 0.1.8 -> 0.1.9** (image stays `9c91a7e`, already on GHCR — verified present). Bootstrap-kit slot-62 pin + `blueprint.yaml` moved to 0.1.9 in lockstep (Inviolable Principle #13). No source/template change; `helm lint` clean; renders `continuum-controller:9c91a7e`.

## Verify

Post-merge + reconcile on omantel.biz: `continuum-controller` deploy rolls to `9c91a7e`, `cnpg-pair-bp-cnpg-pair-continuum` flips to Ready with a non-empty leaseHolder + a `cw-*` Lease, and the console Topology tab surfaces region-a primary / region-b standby.

Refs #4257 #4254 #3829 #3375

🤖 Generated with [Claude Code](https://claude.com/claude-code)