### PR TITLE
fix(bp-agenity): /app serves the workspaces (v0.9.4) dashboard — rebuild from agenity#752, appVersion 0.9.7

### DIFF
--- a/.github/workflows/agenity-build.yaml
+++ b/.github/workflows/agenity-build.yaml
@@ -24,15 +24,20 @@ env:
   REGISTRY: ghcr.io
   IMAGE: ghcr.io/openova-io/bp-agenity
   # Pin the PUBLIC agenity (chepherd daemon) SOURCE ref the Containerfile
-  # builds from. Never floating main: pinned to the #745 merge COMMIT SHA —
-  # the NEW agenity dashboard (main HEAD as of 2026-06-22). v0.9.4 (prior
-  # pin) predated #745 and served the OLD dashboard. No tag exists for the
-  # merge yet; the Containerfile's fetch stage accepts a full SHA. Carries
-  # the bp-agenity MCP seam (chepherd #747 / #4010: CHEPHERD_EXTRA_MCP_JSON
-  # + CHEPHERD_DEFAULT_MODEL). The old private base image
+  # builds from. Never floating main: pinned to a COMMIT SHA on agenity main.
+  # Pinned to the agenity-org/agenity#752 merge COMMIT (main HEAD as of
+  # 2026-06-24) — promotes the WORKSPACES (v0.9.4) dashboard to /app. The
+  # prior pin (bcd38b1, the #745 merge) BUILT the new dashboard at /v0.9.4
+  # but /app still mounted the archaic single-column Dashboard.svelte, AND
+  # #750/#751 then deleted the workspaces tree entirely. #752 restores that
+  # tree and wires /app → Dashboardws, so the agenity host serves the
+  # workspaces UI at /app/ directly. No tag exists for the merge yet; the
+  # Containerfile's fetch stage accepts a full SHA. Carries the bp-agenity
+  # MCP seam (chepherd #747 / #4010: CHEPHERD_EXTRA_MCP_JSON +
+  # CHEPHERD_DEFAULT_MODEL). The old private base image
   # (ghcr.io/agenity-org/chepherd) is GONE — built from source, no private
   # cross-org dep (#4097). Overridable via the workflow_dispatch input.
-  AGENITY_REF: bcd38b15816694e82bddbbc9d6385ff3de00e3cf
+  AGENITY_REF: 5620ad668197f146dc529c4f18f932371249cb72
 
 permissions:
   contents: read
@@ -125,20 +130,32 @@ jobs:
           echo "::group::agent runtime (node + claude-code)"
           docker run --rm --entrypoint sh "$IMG" -c 'node --version && /usr/bin/claude --version'
           echo "::endgroup::"
-          echo "::group::dashboard bundle is the NEW (#745) build"
-          # The /app/ SPA must mount a content-hashed Dashboard component (a
-          # stale/empty web layer would have no such reference) …
+          echo "::group::/app serves the WORKSPACES (v0.9.4) dashboard (#4180/#752)"
+          # The decisive archaic-vs-new check for THE ROUTE THE USER LOADS:
+          # /app/index.html must mount the WORKSPACES component bundle
+          # (Dashboardws.*.js), NOT the old single-column Dashboard.*.js. The
+          # prior gate accepted any `Dashboard[a-z]*` hash — which the archaic
+          # Dashboard.*.js ALSO matched — so a build that built the new
+          # dashboard at /v0.9.4 but left /app wired to the old one passed
+          # GREEN (the exact #4180 bug). Require the `ws` suffix explicitly.
           docker run --rm --entrypoint grep "$IMG" \
-            -qE '_astro/Dashboard[a-z]*\.[A-Za-z0-9_-]+\.js' /app/web/dist/app/index.html \
-            || { echo "FAIL: /app/index.html does not reference a hashed Dashboard bundle — stale/empty web layer"; exit 1; }
-          # … and the dist MUST carry the #745-era routes the OLD (pre-#745,
-          # archaic) dashboard did NOT have. This is the decisive archaic-vs-new
-          # discriminator: a cache-served old web layer fails HERE, before push.
+            -qE '_astro/Dashboardws\.[A-Za-z0-9_-]+\.js' /app/web/dist/app/index.html \
+            || { echo "FAIL: /app/index.html does NOT mount the workspaces Dashboardws bundle — /app is still wired to the ARCHAIC single-column dashboard (#4180)"; exit 1; }
+          # And the archaic single-column Dashboard.*.js must NOT be what /app
+          # loads (belt-and-suspenders against a regression that re-wires it).
+          docker run --rm --entrypoint sh "$IMG" \
+            -c '! grep -qE "_astro/Dashboard\.[A-Za-z0-9_-]+\.js" /app/web/dist/app/index.html' \
+            || { echo "FAIL: /app/index.html references the archaic Dashboard.*.js single-column bundle (#4180)"; exit 1; }
+          echo "::endgroup::"
+          echo "::group::dist carries the #745-era dashboard routes"
+          # The dist MUST also carry the #745-era routes the OLD (pre-#745,
+          # archaic) dashboard did NOT have. A cache-served old web layer fails
+          # HERE, before push.
           docker run --rm --entrypoint sh "$IMG" \
             -c 'test -d /app/web/dist/v09-stage4-preview && test -d /app/web/dist/v0.9.4' \
             || { echo "FAIL: built /app dist is missing the #745 dashboard routes (v0.9.4 / v09-stage4-preview) — a cache-served ARCHAIC dashboard layer shipped"; exit 1; }
           echo "::endgroup::"
-          echo "smoke gate PASSED — agent runtime present, NEW dashboard bundle confirmed"
+          echo "smoke gate PASSED — agent runtime present, /app serves the workspaces dashboard"
 
       - name: Push image (only after smoke gate is green)
         run: |

--- a/products/agenity/blueprint.yaml
+++ b/products/agenity/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.5.5
+  version: 0.5.6
   card:
     title: Agenity
     summary: |

--- a/products/agenity/chart/Chart.yaml
+++ b/products/agenity/chart/Chart.yaml
@@ -8,6 +8,15 @@ description: |
   (RBAC-scoped to the User's rights) to create more Applications in the
   User's own Organization — the north-star self-service journey.
 type: application
+# 0.5.5 -> 0.5.6 (#4180): publish the bp-agenity build from agenity#752 —
+# /app now serves the WORKSPACES (v0.9.4) multi-pane dashboard (Work/Terminal/
+# Talk/Board tabs + Sessions/Terminal/Details panes), NOT the archaic
+# single-column Dashboard.svelte. The prior images (<= 0.9.6) built the
+# workspaces dashboard at /v0.9.4 but left /app wired to the old one. A FRESH
+# appVersion 0.9.7 (below) is the first image whose /app mounts Dashboardws;
+# the chart version bump publishes it so a fresh-Org install (HR pins `*`)
+# auto-resolves to it. ADDITIVE over 0.5.5 (no chart-template change — the
+# delta is the image bytes the new appVersion points at).
 # 0.5.4 -> 0.5.5 (#4228): make the OPENOVA_MCP_RS256_PUBKEY_PEM secretKeyRef
 # optional:true. Its source Secret (catalyst-handover-jwt-public, #4114) lives
 # in the host catalyst-system namespace, NOT the per-Org namespace this
@@ -25,7 +34,17 @@ type: application
 # `ingress` entity that no K8s NetworkPolicy can admit — without the CNP every
 # external hit to agenity.<slug>.<pool> returned envoy 503 "upstream connect
 # error". appVersion (dashboard image) stays 0.9.6 — image bytes unchanged.
-version: 0.5.5
+version: 0.5.6
+# Bumped appVersion 0.9.6 -> 0.9.7 (#4180): 0.9.7 is the FIRST image whose
+# /app/ mounts the WORKSPACES dashboard (Dashboardws bundle) rather than the
+# archaic single-column Dashboard.svelte. It is built from agenity#752
+# (AGENITY_REF in agenity-build.yaml), which restored the workspaces tree the
+# #750/#751 "lean cleanup" deleted and wired app.astro → Dashboardws. The
+# <= 0.9.6 images served the archaic /app even though their bundle md5'd clean
+# (they shipped the OLD route wiring). A distinct tag forces the per-Org HR
+# (`*` pin) to pull NEW bytes — never re-tag 0.9.6 (the #4118 stale-layer
+# trap). The hardened smoke gate now asserts /app mounts Dashboardws before
+# the image is pushed, so an archaic-/app build can never publish again.
 # Bumped appVersion 0.9.5 -> 0.9.6 (#4118): the 0.9.5 image bytes are correct
 # (its /app dashboard bundle is byte-identical to a fresh build of the #745
 # source — verified by md5 on omantel.biz), but 0.9.5 was published BEFORE
@@ -36,7 +55,7 @@ version: 0.5.5
 # distinct value keeps the hardened-pipeline image from masquerading under the
 # old tag. Chart version bumped 0.5.2 -> 0.5.3 to publish the no-cache-HTML
 # HTTPRoute change (the durable fix for the founder's stale-browser-cache view).
-appVersion: "0.9.6"
+appVersion: "0.9.7"
 keywords:
   - agenity
   - agent-runtime

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-24T00:49:28.745Z",
+  "generatedAt": "2026-06-24T07:50:53.624Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -11,7 +11,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.5.4",
+      "version": "0.5.6",
       "section": "pts-7-org-tenant",
       "depends": [
         "bp-external-secrets"
@@ -741,7 +741,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.0.10",
+      "version": "1.0.12",
       "section": "pts-4-1-data-services",
       "depends": [
         "bp-flux"
@@ -796,7 +796,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "section": "pts-9-disaster-recovery",
       "depends": [
         "bp-cnpg",
@@ -2126,7 +2126,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.4.38",
+      "version": "1.5.1",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-postgres"
@@ -3373,7 +3373,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "1.4.123",
+      "version": "1.4.125",
       "section": "pts-4-6-llm-serving",
       "depends": [
         "bp-cnpg",
@@ -3575,7 +3575,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "section": "pts-4-7-agentic-workspace",
       "depends": [
         "bp-newapi",
@@ -4704,7 +4704,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "section": "pts-4-5-communication",
       "depends": [
         "bp-keycloak",
@@ -5511,7 +5511,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.4.13",
+      "version": "0.4.16",
       "section": "pts-7-org-tenant",
       "depends": [
         "bp-postgres",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -146,7 +146,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.5.4",
+    "version": "0.5.6",
     "section": "pts-7-org-tenant",
     "depends": [
       "bp-external-secrets"
@@ -876,7 +876,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.0.10",
+    "version": "1.0.12",
     "section": "pts-4-1-data-services",
     "depends": [
       "bp-flux"
@@ -931,7 +931,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.2.6",
+    "version": "0.2.7",
     "section": "pts-9-disaster-recovery",
     "depends": [
       "bp-cnpg",
@@ -2261,7 +2261,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.4.38",
+    "version": "1.5.1",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-postgres"
@@ -3508,7 +3508,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "1.4.123",
+    "version": "1.4.125",
     "section": "pts-4-6-llm-serving",
     "depends": [
       "bp-cnpg",
@@ -3710,7 +3710,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "section": "pts-4-7-agentic-workspace",
     "depends": [
       "bp-newapi",
@@ -4839,7 +4839,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "section": "pts-4-5-communication",
     "depends": [
       "bp-keycloak",
@@ -5646,7 +5646,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.4.13",
+    "version": "0.4.16",
     "section": "pts-7-org-tenant",
     "depends": [
       "bp-postgres",

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -6479,12 +6479,15 @@ spec:
 # with the built-in solo agent (Claude Opus 4.7, token pre-configured), and
 # the agent creates more Applications in the User's Org via the RBAC-scoped
 # openova MCP. The north-star self-service journey (UAT rows 218-223).
-# Lockstep with products/agenity/chart/Chart.yaml version 0.5.3 + the
-# published chart ghcr.io/openova-io/bp-agenity:0.5.3 (chart 0.5.3 ships the
-# #4118 no-cache-HTML HTTPRoute + appVersion 0.9.6, the first image built by
-# the hardened no-cache + smoke-gated agenity-build pipeline). Fresh provs
-# seed THIS pin, so the chart-version here gates which image a new Sovereign
-# installs — bump in lockstep with the chart on every agenity release.
+# Lockstep with products/agenity/chart/Chart.yaml version 0.5.6 + the
+# published chart ghcr.io/openova-io/bp-agenity:0.5.6 (chart 0.5.6 / appVersion
+# 0.9.7 is the FIRST image whose /app mounts the WORKSPACES dashboard rather
+# than the archaic single-column one — built from agenity#752, #4180). Fresh
+# provs seed THIS pin, so the chart-version here gates which image a new
+# Sovereign installs — bump in lockstep with the chart on every agenity
+# release. (The per-Org install in organization_gitops.go pins `*` and so
+# auto-resolves the newest published chart; this seed pin is the catalog-card
+# version a fresh prov shows + installs.)
 apiVersion: catalyst.openova.io/v1
 kind: Blueprint
 metadata:
@@ -6500,7 +6503,7 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
 spec:
-  version: "0.5.3"
+  version: "0.5.6"
   visibility: listed
   card:
     title: "Agenity"


### PR DESCRIPTION
Refs #4180

## What

The bp-agenity `/app/` route served the ARCHAIC single-column dashboard. The workspaces (v0.9.4) multi-pane redesign (Work/Terminal/Talk/Board tabs + Sessions/Terminal/Details panes) only ever rendered at `/v0.9.4` and was never promoted to `/app`. [agenity-org/agenity#752](https://github.com/agenity-org/agenity/pull/752) restored the workspaces tree (the #750/#751 cleanup had deleted it) and wired `app.astro → Dashboardws` (agenity `main` = `5620ad668197f146dc529c4f18f932371249cb72`).

## Change — makes the new dashboard permanent for every newly-provisioned Org

- **`agenity-build.yaml`**: `AGENITY_REF → 5620ad6` (the #752 merge). Smoke gate **hardened** — it now asserts `/app/index.html` mounts the workspaces `Dashboardws` bundle (and does NOT reference the archaic `Dashboard.*.js`) before the image is pushed. The prior gate accepted any `Dashboard[a-z]*` hash, so a build that wired `/app` to the old dashboard passed green — the exact #4180 bug.
- **`Chart.yaml`**: appVersion `0.9.6 → 0.9.7` (fresh unique tag — never re-tag, the #4118 stale-layer trap), version `0.5.5 → 0.5.6`.
- **`blueprint.yaml`**: `spec.version → 0.5.6` (lockstep).
- **`catalog-seed/blueprints.yaml`**: bp-agenity pin `0.5.3 → 0.5.6` (the version a fresh prov seeds + installs).
- **Regenerated the catalog** (`build-catalog.mjs`). The generator is monorepo-wide + all-or-nothing, so it also resyncs pre-existing `blueprint.yaml` drift the committed catalog had fallen behind on.

## Fresh Orgs inherit it automatically

The per-Org HelmRelease in `organization_gitops.go` pins chart `*`, so it auto-resolves the new `0.5.6` chart → `appVersion 0.9.7` image once the Build bp-agenity workflow publishes it.

## Verification (so far)

- agenity `web` build green: `/app/index.html` bundles `Dashboardws.*.js` (workspaces) not `Dashboard.*.js`; bundle carries Work/Terminal/Talk/Board/Sessions labels.
- `helm lint products/agenity/chart` passes; chart templates `image: …/bp-agenity:0.9.7`.
- Pending: Build bp-agenity run (publishes 0.9.7), demo redeploy, incognito Playwright proof on `agenity.demo.omani.homes/app/`.