### PR TITLE
fix(bp-catalyst-platform): high PriorityClass for catalyst-api — survive co-tenant scanner/convergence disk-pressure storms (1.4.821)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1075,7 +1075,12 @@ spec:
       #   superseded the cached one on the Sovereign's Flux (helm-controller
       #   kept rendering the stale 6cdbc50 content). A fresh version tag forces
       #   a clean pull. Chart.yaml bumped in lockstep.
-      version: 1.4.820
+      # 1.4.821 — #4231: catalyst-api gets a HIGH PriorityClass (catalyst-control-
+      #   plane) so a co-tenant trivy/syft Day-2 scanner + convergence image-pull
+      #   storm that fills the node's ephemeral disk evicts THOSE reschedulable Pods
+      #   first instead of the EVS-node-pinned (#4102) control-plane API (~17min
+      #   console outage, omantel.biz 2026-06-24). Chart.yaml bumped in lockstep.
+      version: 1.4.821
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/.helmignore
+++ b/products/catalyst/chart/.helmignore
@@ -41,3 +41,7 @@ crds/tests/
 
 # G61 (#2612): Kustomize-mode sibling files (literal image refs for contabo-mkt)
 templates/api-deployment-kustomize.yaml
+# #4231: Kustomize-mode sibling of api-priorityclass.yaml (literal PriorityClass
+# for the contabo-mkt raw-Kustomize path). Helm renders only the templated
+# api-priorityclass.yaml; Kustomize renders only this literal one.
+templates/api-priorityclass-kustomize.yaml

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2992,7 +2992,19 @@ name: bp-catalyst-platform
 #   image pin (6cdbc50->09dcc10) in values.yaml without a chart version bump, so the
 #   re-pushed 1.4.813 OCI digest never superseded the digest cached on the Sovereign's
 #   Flux. A clean version tag forces the pull. bootstrap-kit slot-13 bumped in lockstep.
-version: 1.4.820
+# 1.4.821 — #4231: catalyst-api carries a HIGH PriorityClass (catalyst-control-plane,
+#   value 100000000) shipped by this chart (api-priorityclass{,-kustomize}.yaml). The
+#   API is node-pinned to its EVS volume (#4102) so it CANNOT reschedule off a pressured
+#   node; as a priority-0 Pod it was the eviction victim when co-tenant trivy/syft Day-2
+#   scanners + a convergence image-pull storm filled the 40GB ephemeral disk and the
+#   kubelet hit NodeHasDiskPressure (~17min console outage, omantel.biz 2026-06-24). The
+#   high priority makes the kubelet shed the reschedulable Day-2 Pods FIRST; the pinned
+#   control-plane API stays Running. Custom class (NOT the built-in system-cluster-
+#   critical, which the PodPriority admission plugin restricts to kube-system) since
+#   catalyst-api runs in catalyst-system. Pure-additive: priorityClassName/Value are new
+#   values, default-on; no other behaviour changes. Chart-version bump forces the Flux
+#   re-pull (the deploy-bot mutable-tag trap, #4257).
+version: 1.4.821
 # 1.4.774 — #4082: application-controller ClusterRole gains dr.openova.io/continuums
 #   (get/list/watch/create/update/patch/delete) — was in the controller's own
 #   deploy/rbac.yaml but MISSING from this platform chart, so a singleton /

--- a/products/catalyst/chart/templates/api-deployment-kustomize.yaml
+++ b/products/catalyst/chart/templates/api-deployment-kustomize.yaml
@@ -152,6 +152,13 @@ spec:
       # system:default and every cutover-status read returns 502
       # "configmaps is forbidden" (caught live on otech102, 2026-05-04).
       serviceAccountName: catalyst-api-cutover-driver
+      # High priority so a co-tenant disk/memory-pressure storm (trivy/syft
+      # Day-2 scanners + convergence image-pulls) evicts THOSE reschedulable
+      # Pods first instead of the control-plane API (#4231). Literal class name
+      # for the contabo-mkt raw-Kustomize path (kustomize-controller does not
+      # render Helm templates). Mirrors the Helm sibling api-deployment.yaml +
+      # the catalyst-control-plane PriorityClass in api-priorityclass.yaml.
+      priorityClassName: catalyst-control-plane
       imagePullSecrets:
         - name: ghcr-pull
       # fsGroup applies to the volumes mounted into the Pod so the

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -142,6 +142,19 @@ spec:
       # system:default and every cutover-status read returns 502
       # "configmaps is forbidden" (caught live on otech102, 2026-05-04).
       serviceAccountName: catalyst-api-cutover-driver
+      # ── Survive a co-tenant disk/memory-pressure storm (#4231) ───────────
+      # catalyst-api is pinned to its EVS node (nodeName below, #4102) so it
+      # CANNOT reschedule off a pressured node. Without a priority it is an
+      # ordinary priority-0 Pod competing with co-tenant Day-2 trivy/syft
+      # scanners + convergence image-pulls; when that node hit DiskPressure the
+      # kubelet evicted the control-plane API (11+ Evicted tombstones → ~17min
+      # console outage, omantel.biz 2026-06-24). priorityClassName puts it far
+      # above those reschedulable Day-2 Pods, so the kubelet sheds THEM first
+      # under node pressure and the pinned API stays Running. The class itself
+      # is shipped by this chart (api-priorityclass.yaml) — a custom class
+      # because the built-in system-cluster-critical is admission-restricted to
+      # the kube-system namespace and catalyst-api runs in catalyst-system.
+      priorityClassName: {{ .Values.catalystApi.priorityClassName | default "catalyst-control-plane" }}
       # ── Zero-downtime roll: pin to the EVS volume's node (#4100) ──────────
       # catalyst-api mounts two RWO Huawei-EVS PVCs (catalyst-api-deployments,
       # catalyst-api-cache). The EVS PV nodeAffinity is ZONE-scoped

--- a/products/catalyst/chart/templates/api-priorityclass-kustomize.yaml
+++ b/products/catalyst/chart/templates/api-priorityclass-kustomize.yaml
@@ -1,0 +1,25 @@
+# Kustomize-mode sibling of api-priorityclass.yaml (#4231). Contabo-mkt applies
+# the chart's templates/ via raw Kustomize, which does NOT render Helm
+# templating, so the Helm sibling (which uses Values templating) cannot be listed in
+# kustomization.yaml. This literal copy is. The api-deployment-kustomize.yaml
+# Pod references `priorityClassName: catalyst-control-plane`; without this
+# object the Kustomize render dangles a non-existent class. Same Helm-vs-
+# Kustomize split as serviceaccount/clusterrolebinding-cutover-driver.
+#
+# See api-priorityclass.yaml for the full rationale (EVS-pinned control-plane
+# API must outrank co-tenant trivy/syft Day-2 scanners + convergence pulls so
+# THEY are evicted first under node disk/memory pressure, not the API).
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: catalyst-control-plane
+  labels:
+    app.kubernetes.io/name: catalyst-api
+    app.kubernetes.io/component: priority
+value: 100000000
+globalDefault: false
+description: >-
+  High priority for the Catalyst control-plane API (catalyst-api). Pinned to its
+  EVS node (#4102) and therefore unable to reschedule, so it must outrank Day-2
+  trivy/syft scanners and convergence image-pull Pods during node disk/memory
+  pressure — those reschedule freely and are evicted first (#4231).

--- a/products/catalyst/chart/templates/api-priorityclass.yaml
+++ b/products/catalyst/chart/templates/api-priorityclass.yaml
@@ -1,0 +1,60 @@
+# ── catalyst-api PriorityClass (#4231) ──────────────────────────────────────
+# Why this exists
+# ---------------
+# #4102 pins catalyst-api to its EVS-volume node via `nodeName` (so a Recreate
+# roll reattaches the two RWO Huawei-EVS PVCs same-node — see api-deployment.yaml
+# §"Zero-downtime roll"). That pin is correct for fast reattach, but it makes the
+# control-plane API the ONE Pod that cannot escape its node. When that node ran
+# co-tenant Day-2 trivy vulnerability-report scanners (which cold-pull every image
+# to scan) PLUS the demo-Org convergence image-pull storm on a 40GB ephemeral
+# disk, the kubelet hit NodeHasDiskPressure and EVICTED pods by priority. The
+# node-pinned catalyst-api — an ordinary priority-0 Pod competing with the
+# scanners — was the victim (11+ Evicted tombstones) and could only recreate
+# back onto the same pressured node → a long cold re-pull while the console API
+# stayed 0/1 DOWN for ~17min (omantel.biz dep 4635277cae4ffed9, 2026-06-24 01:17Z).
+#
+# The fix
+# -------
+# Give catalyst-api a HIGH PriorityClass so the kubelet's eviction ranking sheds
+# the LOW-priority trivy/syft scanners + convergence pull pods (all of which can
+# reschedule freely on other nodes) BEFORE it ever considers the pinned, escape-
+# less control-plane API. Eviction under node-pressure is priority-ordered: lower
+# priority + over-its-request pods go first. catalyst-api now sits far above the
+# default-0 Day-2 workloads.
+#
+# Why a CUSTOM class, not the built-in `system-cluster-critical`
+# -------------------------------------------------------------
+# The built-in `system-cluster-critical` (value 2000000000) is gated by the
+# `PodPriority` admission plugin to Pods in the `kube-system` namespace ONLY —
+# applying it to a Pod in `catalyst-system` is REJECTED at admission
+# ("priorityClass ... is forbidden ... only kube-system"). catalyst-api runs in
+# catalyst-system, so we ship our own class. The value (100000000) is well below
+# the system-* band (so we never starve genuine cluster-critical kube-system
+# add-ons) yet far above any Day-2 scanner / convergence Pod (priority 0).
+#
+# globalDefault stays false: this class applies ONLY to Pods that name it.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ .Values.catalystApi.priorityClassName | default "catalyst-control-plane" }}
+  labels:
+    app.kubernetes.io/name: catalyst-api
+    app.kubernetes.io/component: priority
+  annotations:
+    # Flux force-recreates this immutable object if its value ever changes
+    # (PriorityClass.value is immutable; an in-place edit would otherwise
+    # wedge the Kustomization at Ready=False).
+    kustomize.toolkit.fluxcd.io/force: enabled
+# 100_000_000 — above every Day-2 / convergence Pod (priority 0), below the
+# system-cluster-critical / system-node-critical band (2_000_000_000 /
+# 2_000_001_000) so kube-system add-ons still outrank the control-plane API.
+# int64 wrap is REQUIRED: sprig's `default` returns a float64 for a large int,
+# which Helm serialises as `1e+08` — the K8s API server rejects that for the
+# int32 PriorityClass.value field. `int64` forces a clean integer literal.
+value: {{ .Values.catalystApi.priorityClassValue | default 100000000 | int64 }}
+globalDefault: false
+description: >-
+  High priority for the Catalyst control-plane API (catalyst-api). Pinned to its
+  EVS node (#4102) and therefore unable to reschedule, so it must outrank Day-2
+  trivy/syft scanners and convergence image-pull Pods during node disk/memory
+  pressure — those reschedule freely and are evicted first (#4231).

--- a/products/catalyst/chart/templates/kustomization.yaml
+++ b/products/catalyst/chart/templates/kustomization.yaml
@@ -2,6 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: catalyst
 resources:
+  # PriorityClass referenced by api-deployment-kustomize.yaml's
+  # priorityClassName (#4231) — must be present in the render or the Pod
+  # dangles a non-existent class. Cluster-scoped; the namespace: catalyst
+  # transformer above is a no-op on it.
+  - api-priorityclass-kustomize.yaml
   - ui-deployment.yaml
   - ui-service.yaml
   - api-deployment-kustomize.yaml

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -1179,6 +1179,25 @@ catalystApi:
   # affinity — optional passthrough for operators who prefer a soft/zone
   # nodeAffinity over a hard nodeName pin above. Default empty (no affinity).
   affinity: {}
+  # ── Survive a co-tenant disk/memory-pressure storm (#4231) ──────────────
+  # catalyst-api is pinned to its EVS node (nodeName above, #4102) so it CANNOT
+  # reschedule off a pressured node. With the default priority (0) it competed
+  # with co-tenant Day-2 trivy/syft scanners + convergence image-pulls; when the
+  # node hit DiskPressure the kubelet evicted the control-plane API itself
+  # (~17min console outage, omantel.biz 2026-06-24). This names a HIGH-priority
+  # PriorityClass (shipped by this chart in api-priorityclass.yaml) so the
+  # kubelet sheds the reschedulable Day-2 Pods FIRST and the pinned API survives.
+  #
+  # A custom class — NOT the built-in system-cluster-critical, which the
+  # PodPriority admission plugin restricts to the kube-system namespace
+  # (catalyst-api runs in catalyst-system). The chart creates the class with
+  # this name and value. Override both ONLY if a Sovereign already has a class
+  # by this name; leave default otherwise.
+  priorityClassName: catalyst-control-plane
+  # value of the shipped class. 100_000_000 sits far above every Day-2 /
+  # convergence Pod (priority 0) and below the system-cluster-critical /
+  # system-node-critical band (2_000_000_000+) so kube-system add-ons still win.
+  priorityClassValue: 100000000
   # OpenBao address for the bare-URL SSO shim (#3374). Rendered into
   # CATALYST_OPENBAO_ADDR on Sovereign installs only (gated on
   # global.sovereignFQDN in api-deployment.yaml). Empty = the canonical


### PR DESCRIPTION
## Problem (Refs #4231)
#4102 pins `catalyst-api` to its EVS-volume node via `nodeName` (for same-node Recreate reattach of the two RWO Huawei-EVS PVCs) — so it **cannot reschedule** off a pressured node. On omantel.biz 2026-06-24 ~01:17Z that node hit `NodeHasDiskPressure` (co-tenant **trivy/syft** vulnerability-report scanners cold-pulling every image + a demo-Org **convergence image-pull storm** on a 40GB ephemeral disk). The kubelet evicts by Pod priority, and `catalyst-api` was an ordinary **priority-0** Pod competing with the scanners → it was the eviction victim (11+ `Evicted` tombstones) and could only recreate back onto the same pressured node → **~17min console-API outage**.

The control-plane API must never be the eviction victim of a Day-2 scanner / convergence storm.

## Fix (durable — fresh provs inherit it)
Ship a **custom high PriorityClass** `catalyst-control-plane` (value `100000000`) and set `priorityClassName` on the `catalyst-api` Deployment. Eviction under node pressure is priority-ordered, so the kubelet now sheds the **reschedulable** Day-2 scanner / convergence Pods (priority 0) **first**, and the pinned control-plane API stays `Running`.

**Why a custom class, not built-in `system-cluster-critical`:** the `PodPriority` admission plugin restricts `system-cluster-critical` to the **kube-system** namespace; `catalyst-api` runs in `catalyst-system`, so applying it there is admission-rejected. The custom value `100000000` sits far above any Day-2 Pod (0) and **below** the system-cluster-critical / system-node-critical band (`2000000000+`), so genuine kube-system add-ons still outrank it.

## Changes
| File | Change |
|---|---|
| `templates/api-priorityclass.yaml` | new — Helm-templated PriorityClass (Sovereigns). `value` wrapped in `int64` so it renders `100000000`, not `1e+08` (which the int32 API field rejects) |
| `templates/api-priorityclass-kustomize.yaml` | new — literal sibling for the contabo-mkt raw-Kustomize path |
| `templates/api-deployment.yaml` | `priorityClassName` on the Pod spec (Helm) |
| `templates/api-deployment-kustomize.yaml` | `priorityClassName` on the Pod spec (Kustomize) |
| `templates/kustomization.yaml` | add the kustomize PriorityClass to the resource list |
| `.helmignore` | exclude the kustomize sibling from Helm render (so Helm parses only the templated one) |
| `values.yaml` | `catalystApi.priorityClassName` / `priorityClassValue` (default-on, overridable) |
| `Chart.yaml` | `1.4.820 -> 1.4.821` |
| `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` | slot-13 pin `1.4.820 -> 1.4.821` lockstep — forces the Flux re-pull (the deploy-bot mutable-tag trap, #4257) |

## Validation
- `helm template` rc=0 → rendered `kind: PriorityClass / name: catalyst-control-plane / value: 100000000` (clean int) + Deployment `priorityClassName: catalyst-control-plane`.
- `kubectl kustomize` rc=0 → same PriorityClass + `priorityClassName` on the contabo path.
- No Go files touched (Go gates N/A). Pre-existing `helm lint` YAML-separator warning on `catalyst-keycloak-credentials-host-bridge.yaml` is unchanged from main and unrelated.

## DoD
`catalyst-api` carries a high PriorityClass; under node disk/memory pressure the trivy/convergence Pods are evicted first and the pinned API stays Running. **A fresh prov inherits it** — it lives in the chart + bootstrap-kit, not a live patch.

Refs #4231 #4102 #880

🤖 Generated with [Claude Code](https://claude.com/claude-code)