### PR TITLE
fix(bp-agenity): detect expired claude-code OAuth at seed + document re-seed — kill the silent 'runtime offline / 0 workers' chat runtime (0.5.6)

### DIFF
--- a/products/agenity/README.md
+++ b/products/agenity/README.md
@@ -142,6 +142,46 @@ authenticates. This path is **shared per-Sovereign** (not per-Org-namespaced)
 by default — a single seed serves every Org's agenity install on that
 Sovereign.
 
+### 🛑 The OAuth access token EXPIRES — re-seed when the agent goes offline (#4111)
+
+The `credentialsJson` blob is a **short-lived OAuth pair**: its `accessToken`
+(`sk-ant-oat01-…`) has an `expiresAt` only **hours** out, and the headless
+`claude-code` the chepherd BareExec path forks does **not** reliably refresh it
+from the `refreshToken`. So a credential that worked at seed-time **goes stale
+within hours** and every subsequent `+ spawn agent` then fails with
+`401 Invalid authentication credentials` — surfacing in the dashboard as the
+same *"runtime offline / 0 workers"* symptom as a never-seeded path. Confirmed
+live on omantel.biz 2026-06-24: a blob seeded ~45h earlier was correctly shaped
+(full `claudeAiOauth`, valid scopes, `subscriptionType: max`) yet every spawn
+401'd because the token had long expired.
+
+The chart's `seed-claude-creds` init container (chart `0.5.6`+) now **parses
+`expiresAt` at pod start** and logs a loud, greppable line so the operator can
+diagnose this without exec'ing into the pod:
+
+```
+🛑 WARNING (#4111): seeded claude-code OAuth token is EXPIRED (~45h ago) — the
+   spawned agent will fail '401 Invalid authentication credentials' and the
+   dashboard will show 'runtime offline / 0 workers'. RE-SEED openbao
+   anthropic/token with a FRESH credentialsJson and force-sync the ExternalSecret.
+```
+
+(A valid token instead logs `claude-code OAuth token valid (~Nh remaining).`)
+The check is **diagnostic-only** — it never blocks the pod (the dashboard must
+keep serving) and never mutates the blob (`claude-code` owns rotation).
+
+**When the agent reports offline, re-seed:** mint a **fresh**
+`credentialsJson` (a current `claude` login on a workstation writes
+`~/.claude/.credentials.json`; copy that whole blob), `bao kv put
+anthropic/token credentialsJson='…'` as above, force-sync the ExternalSecret
+(`kubectl annotate externalsecret agenity-anthropic-token
+force-sync=$(date +%s) --overwrite`), and restart the StatefulSet pod (or wait
+for the next restart) so the init container re-seeds the new blob. The next
+spawn then authenticates. This is the standing **operator activation cost** of
+the OAuth journey until upstream `claude-code` gains a reliable
+non-interactive refresh — track it as a recurring per-Sovereign chore, not a
+one-time seed.
+
 > **Why not chart-seed it?** A Helm-seeded placeholder would pin an **empty**
 > value forever under the reflector/ESO empty-seed trap (the bp-wordpress-tenant
 > empty-password lesson) — the agent would then hold a permanently-blank
@@ -155,7 +195,7 @@ The full live e2e walk runs in the orchestrator's wipe → prov → walk loop.
 On a fresh prov, after a User installs bp-agenity:
 
 1. `kubectl -n <org>-prod get statefulset,svc,httproute,externalsecret -l catalyst.openova.io/blueprint=bp-agenity` → all present; the StatefulSet pod becomes `Ready` (`/healthz` 200).
-2. The Agenity pod env carries `CHEPHERD_DEFAULT_MODEL=claude-opus-4-7`, `ANTHROPIC_API_KEY` (from the Secret), and `CHEPHERD_EXTRA_MCP_JSON` with the `openova` server stanza.
+2. The Agenity pod env carries `CHEPHERD_DEFAULT_MODEL=claude-opus-4-7` and `CHEPHERD_EXTRA_MCP_JSON` with the `openova` server stanza. In OAuth mode (`anthropic.credentialsKey` set, the default) the spawned agent authenticates from the init-seeded `~/.claude/.credentials.json` blob — `ANTHROPIC_API_KEY` is deliberately **omitted** (an `sk-ant-oat01-…` OAuth token in that env is rejected by `claude-code`, and it would shadow the valid `credentials.json`); only key-only mode (no `credentialsKey`) sets `ANTHROPIC_API_KEY` from the Secret. The `seed-claude-creds` init log states whether the seeded OAuth token is valid or expired.
 3. The Agenity console loads at `agenity.<org>.<sovereign-fqdn>` (SSO).
 4. Spawning the solo agent → its `.mcp.json` lists **both** the `chepherd` runtime MCP and the `openova` MCP servers, and the agent was launched with `--model claude-opus-4-7`.
 5. Asking the agent to install an app → a new `Application` CR appears in the User's Org namespace, created via the openova MCP `create_application` tool (tier-admin-gated, Org-pinned).

--- a/products/agenity/blueprint.yaml
+++ b/products/agenity/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.5.6
+  version: 0.5.7
   card:
     title: Agenity
     summary: |

--- a/products/agenity/chart/Chart.yaml
+++ b/products/agenity/chart/Chart.yaml
@@ -8,6 +8,9 @@ description: |
   (RBAC-scoped to the User's rights) to create more Applications in the
   User's own Organization — the north-star self-service journey.
 type: application
+# 0.5.6 -> 0.5.7 (#4180 + #4111, combined on rebase): two ADDITIVE changes land
+# together — the workspaces dashboard image (appVersion 0.9.7, #4180) AND the
+# seed-claude-creds expired-OAuth detector (#4111). Both documented below.
 # 0.5.5 -> 0.5.6 (#4180): publish the bp-agenity build from agenity#752 —
 # /app now serves the WORKSPACES (v0.9.4) multi-pane dashboard (Work/Terminal/
 # Talk/Board tabs + Sessions/Terminal/Details panes), NOT the archaic
@@ -17,6 +20,23 @@ type: application
 # the chart version bump publishes it so a fresh-Org install (HR pins `*`)
 # auto-resolves to it. ADDITIVE over 0.5.5 (no chart-template change — the
 # delta is the image bytes the new appVersion points at).
+# 0.5.5 -> 0.5.6 (#4111): the seed-claude-creds init container now parses the
+# seeded credentialsJson's claudeAiOauth.expiresAt and emits a LOUD, greppable
+# WARNING when the OAuth token is ALREADY expired. Live root-cause on
+# omantel.biz 2026-06-24: the seeded blob was correctly shaped (full
+# claudeAiOauth pair) but its accessToken had expired ~45h prior, and
+# claude-code's headless BareExec spawn does NOT reliably refresh from the
+# refreshToken — so every "+ spawn agent" failed "401 Invalid authentication
+# credentials" while the dashboard still served (the silent "runtime offline /
+# 0 workers" symptom). The check is diagnostic-only: it never blocks the pod
+# (the dashboard must still serve) and never mutates the blob (claude-code owns
+# rotation) — it converts an invisible auth failure into an actionable
+# re-seed cue. README gains the OAuth-token-expiry reality + the "agent went
+# offline → re-seed" operator step. appVersion (dashboard image) stays 0.9.6 —
+# image bytes UNCHANGED; 0.5.6 is ADDITIVE (chart-only) over 0.5.5. (The
+# image's claude-code binary + the chart's forceLocalSpawner/authMode/
+# runAsUser/creds-seed wiring — the issue's three named blockers — all already
+# landed in #4115/#4138/#4173/#4225/#4233 and are confirmed present live.)
 # 0.5.4 -> 0.5.5 (#4228): make the OPENOVA_MCP_RS256_PUBKEY_PEM secretKeyRef
 # optional:true. Its source Secret (catalyst-handover-jwt-public, #4114) lives
 # in the host catalyst-system namespace, NOT the per-Org namespace this
@@ -34,7 +54,7 @@ type: application
 # `ingress` entity that no K8s NetworkPolicy can admit — without the CNP every
 # external hit to agenity.<slug>.<pool> returned envoy 503 "upstream connect
 # error". appVersion (dashboard image) stays 0.9.6 — image bytes unchanged.
-version: 0.5.6
+version: 0.5.7
 # Bumped appVersion 0.9.6 -> 0.9.7 (#4180): 0.9.7 is the FIRST image whose
 # /app/ mounts the WORKSPACES dashboard (Dashboardws bundle) rather than the
 # archaic single-column Dashboard.svelte. It is built from agenity#752

--- a/products/agenity/chart/templates/statefulset.yaml
+++ b/products/agenity/chart/templates/statefulset.yaml
@@ -88,6 +88,29 @@ spec:
                 cp /creds/{{ .Values.anthropic.credentialsKey }} /claudehome/.claude/.credentials.json
                 chmod 600 /claudehome/.claude/.credentials.json
                 echo "seeded ~/.claude/.credentials.json ($(wc -c < /claudehome/.claude/.credentials.json) bytes)"
+                # ── OAuth-expiry pre-flight (#4111) ──────────────────────────
+                # The seeded blob is a claudeAiOauth pair whose accessToken has
+                # a SHORT lifetime (hours). claude-code's headless BareExec
+                # spawn path does NOT reliably refresh it from the refreshToken
+                # — verified live on omantel.biz 2026-06-24: a token expired
+                # ~45h prior left every spawn failing "401 Invalid
+                # authentication credentials" while the dashboard still served,
+                # i.e. the exact "runtime offline · 0 workers" symptom with no
+                # other signal. So we parse expiresAt HERE and emit a LOUD,
+                # greppable line when the seeded token is ALREADY expired — the
+                # operator's cue to re-seed openbao anthropic/token with a fresh
+                # credentialsJson (see README §Seeding). This is diagnostic
+                # ONLY: we never block the pod (the dashboard must still serve)
+                # and never mutate the blob (claude-code owns rotation). The
+                # parser is a single-line python3 -c (no heredoc) so the YAML
+                # block scalar stays whitespace-robust across Helm renders.
+                EXP=$(python3 -c 'import json,time;o=json.load(open("/claudehome/.claude/.credentials.json")).get("claudeAiOauth",{});e=int(o.get("expiresAt",0) or 0);n=int(time.time()*1000);print(("EXPIRED %d"%((n-e)//3600000)) if e and e<n else ("OK %d"%((e-n)//3600000)) if e else "NOEXP")' 2>/dev/null || echo "")
+                case "$EXP" in
+                  EXPIRED*) echo "🛑 WARNING (#4111): seeded claude-code OAuth token is EXPIRED (~${EXP#EXPIRED }h ago) — the spawned agent will fail '401 Invalid authentication credentials' and the dashboard will show 'runtime offline / 0 workers'. RE-SEED openbao anthropic/token with a FRESH credentialsJson and force-sync the ExternalSecret (see README: Seeding the per-Org anthropic/token openbao path)." ;;
+                  OK*)      echo "claude-code OAuth token valid (~${EXP#OK }h remaining)." ;;
+                  NOEXP)    echo "claude-code credentials.json has no expiresAt — assuming a non-expiring credential." ;;
+                  *)        echo "could not parse claude-code OAuth expiry from credentials.json (non-fatal)." ;;
+                esac
               else
                 echo "no credentials.json key in Secret — key-only mode"
               fi


### PR DESCRIPTION
## Which of the three named gaps was live?

I root-caused all three against the live agenity on omantel.biz (dep `4635277cae4ffed9`, the only running agenity — `agenity-rtz-a` in the `rtz` platform vCluster; the demo Org was re-provisioned ~16h prior and has no agenity HR):

| #4111 gap | Live state | Verdict |
|---|---|---|
| 1. No `claude` binary | `/usr/bin/claude` present, **v2.1.185** | **already fixed** (image, #4115) |
| 2. No OAuth `credentials.json` | A **full, correctly-shaped** `claudeAiOauth` blob is present (accessToken `sk-ant-oat01-…`, refreshToken, scopes incl. `user:inference`/`user:mcp_servers`, `subscriptionType: max`) — **but the accessToken had EXPIRED ~45h ago** → every spawn `401 Invalid authentication credentials` | **THE LIVE FAILURE (staleness, not wiring)** |
| 3. operator/BareExec spawner + auth | `forceLocalSpawner`/`authMode: none`/`runAsUser: 1000` | **already fixed in chart 0.5.5** (#4225/#4233); the live rtz pod runs ancient chart `0.1.0` so it still shows `spawner: operator` + `auth: local`, but that is a stale-install problem, not a chart gap |

So the issue's three named gaps are **all durably fixed on main** (#4115/#4138/#4173/#4225/#4233). The founder already proved the full chat→spawn→Claude→MCP→`create_application` North Star end-to-end on 2026-06-22 (issue comment — created `agent-wp-shop` + `agent-wp-blog` Applications).

What was *still* failing live is the one thing the chart could not previously make visible: **the seeded OAuth access token expires within hours, claude-code's headless BareExec spawn does not reliably refresh it from the refreshToken, and the failure is silent** — the dashboard keeps serving while every `+ spawn agent` 401s, surfacing only as *"runtime offline / 0 workers"*.

## The durable fix (chart-only — image bytes unchanged)

1. **`seed-claude-creds` init container now parses `claudeAiOauth.expiresAt`** and emits a loud, greppable line at pod start:
   - expired → `WARNING (#4111): seeded claude-code OAuth token is EXPIRED (~Nh ago) — … RE-SEED openbao anthropic/token …`
   - valid → `claude-code OAuth token valid (~Nh remaining).`

   Diagnostic-only: **never stops the pod** (the dashboard must keep serving) and **never mutates the blob** (claude-code owns rotation). Parser is a single-line `python3 -c` (no heredoc) so the YAML block scalar stays whitespace-robust across Helm renders; `sh -n` + `helm template`/`helm lint` verified; the python one-liner returns `EXPIRED 45` / `OK 7` on sample blobs.

2. **README** gains a `The OAuth access token EXPIRES` subsection: the hours-long lifetime, the no-refresh reality, the new init log line, and the operator re-seed step (mint fresh `credentialsJson` → `bao kv put anthropic/token credentialsJson='…'` → force-sync the ExternalSecret → restart the pod). Also corrected the fresh-prov walk step that mis-stated `ANTHROPIC_API_KEY` is set in OAuth mode (it is deliberately **omitted** — an `sk-ant-oat01` token in that env is rejected and shadows the valid `credentials.json`).

3. chart `0.5.5 → 0.5.6` (additive). `appVersion` stays `0.9.6`.

## Operator runbook (the operator-driven seed, per Principle #4)

The chart can never carry a live OAuth blob. When the agent goes offline, next action:
```bash
# mint a fresh credentialsJson (a current `claude` login writes ~/.claude/.credentials.json — copy that whole blob)
bao kv put anthropic/token \
  apiKey='sk-ant-…' \
  credentialsJson='{"claudeAiOauth":{"accessToken":"…","refreshToken":"…","expiresAt":<ms>,"scopes":["user:inference"]}}'
kubectl annotate externalsecret agenity-anthropic-token force-sync=$(date +%s) --overwrite
# restart the StatefulSet pod so seed-claude-creds re-seeds the fresh blob
```

## Live proof

- Live read (dep 4635277cae4ffed9): seeded blob `expiresAt: 1782124190335` vs now → **expired 45.4h ago**; `claude --print` as uid 1000 with the seeded creds → `Failed to authenticate. API Error: 401 Invalid authentication credentials`; the blob was *not* refreshed by the run.
- `helm template` + `helm lint` clean; rendered init script passes `sh -n`; expiry parser validated against expired (`EXPIRED 45`) and valid (`OK 7`) sample blobs.
- A full end-to-end live re-proof needs a fresh `credentialsJson` seed (operator activation) + the 0.5.6 chart rolled to a live Org agenity — the demo Org currently has no agenity install (re-prov'd), tracked on #4180. The remaining work is therefore **operational** (fresh-token seed + Org agenity install), not a code/wiring gap.

## Coordinate
Chart-only; `appVersion` untouched (0.9.6), so this does not collide with the parallel agenity **image** bump (workspaces dashboard, AGENITY_REF #752). The two land independently — this rides the same chart line additively.

Refs #4111