### PR TITLE
feat(bp-openclaw): build the missing openclaw-controller image + lockstep chart/seed bump (Refs #4249)

### DIFF
--- a/.github/workflows/openclaw-controller.yaml
+++ b/.github/workflows/openclaw-controller.yaml
@@ -1,0 +1,277 @@
+# Build openclaw-controller — the multi-tenant workspace controller
+# image consumed by bp-openclaw's controller Deployment.
+#
+# Pre-this-workflow (issue #4249): bp-openclaw shipped only the per-user
+# `openclaw-runtime` image + chart templates. The controller Deployment
+# referenced `openclaw-controller:0.1.0-placeholder`, which NEVER existed
+# in GHCR (404) — so the controller pod ImagePullBackOff'd forever and
+# the bp-openclaw HR could never reach Ready on any Sovereign. The
+# controller is genuinely load-bearing: it is the only component that
+# validates the Organization end-user's Keycloak JWT and spawns the
+# identity-blind per-user runtime pods the chart's RBAC + pod-template
+# ConfigMap exist to support.
+#
+# Per Inviolable Principle 1 (event-driven, never schedule:cron) and
+# Principle 4 (never floating tags in production), this workflow:
+#   1. Triggers on push to platform/openclaw/controller/** on main.
+#   2. go test + go vet the controller package.
+#   3. Builds the image, SHA-pin tagging it (+ :latest for the deploy-bot
+#      pattern, matching newapi-sandbox-bridge).
+#   4. Smoke-tests: container starts, /healthz responds, /metrics serves.
+#   5. Bumps platform/openclaw/chart/values.yaml controller.image.tag to
+#      the new SHA + bumps Chart.yaml patch version (LOCKSTEP — avoids
+#      the #4257 mutable-tag trap where a values-only edit on the same
+#      chart version is undeliverable to Flux).
+#   6. Dispatches blueprint-release so a fresh bp-openclaw:<semver> OCI
+#      artifact carries the real controller tag.
+#
+# Output: ghcr.io/openova-io/openova/openclaw-controller:<sha>
+#
+# Tracking: openova-io/openova#4249 (controller image gap), #795 (epic).
+
+name: Build openclaw-controller
+
+on:
+  push:
+    paths:
+      - 'platform/openclaw/controller/**'
+      - '.github/workflows/openclaw-controller.yaml'
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ghcr.io/openova-io/openova/openclaw-controller
+  CTX: platform/openclaw/controller
+  CHART_VALUES: platform/openclaw/chart/values.yaml
+  CHART_YAML: platform/openclaw/chart/Chart.yaml
+  BLUEPRINT_YAML: platform/openclaw/blueprint.yaml
+  CATALOG_SEED: products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+
+permissions:
+  contents: write
+  packages: write
+  actions: write
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: go vet + test
+        working-directory: ${{ env.CTX }}
+        run: |
+          set -euo pipefail
+          go vet ./...
+          go test ./...
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Compute image tag
+        id: tag
+        run: |
+          set -euo pipefail
+          short_sha="${GITHUB_SHA::7}"
+          echo "tag=${short_sha}" >> "$GITHUB_OUTPUT"
+          echo "Will tag controller image: ${IMAGE}:${short_sha}"
+
+      - name: Build image (load for smoke test)
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ env.CTX }}
+          file: ${{ env.CTX }}/Dockerfile
+          push: false
+          load: true
+          tags: ${{ env.IMAGE }}:test
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test (starts, /healthz + /metrics respond)
+        run: |
+          set -euo pipefail
+          # Unconfigured mode: placeholder issuer → controller still
+          # starts + serves /healthz (so the chart's liveness probe never
+          # CrashLoops) and refuses user traffic with 503.
+          docker run -d --name occ-smoke \
+            -p 18080:8080 \
+            -e OIDC_ISSUER_URL=https://keycloak.example.local/realms/example \
+            ${{ env.IMAGE }}:test
+          for i in $(seq 1 10); do
+            if curl -sf http://127.0.0.1:18080/healthz > /dev/null; then
+              echo "healthz OK"; break
+            fi
+            sleep 1
+          done
+          if ! curl -sf http://127.0.0.1:18080/healthz > /dev/null; then
+            echo "FAIL: /healthz did not respond"; docker logs occ-smoke; docker rm -f occ-smoke; exit 1
+          fi
+          # /metrics serves Prometheus text.
+          curl -sf http://127.0.0.1:18080/metrics | grep -q "openclaw_controller_auth_total" || {
+            echo "FAIL: /metrics missing expected counter"; docker logs occ-smoke; docker rm -f occ-smoke; exit 1
+          }
+          # Landing page on bare GET /.
+          curl -sf http://127.0.0.1:18080/ | grep -q "OpenClaw workspace" || {
+            echo "FAIL: landing page missing expected marker"; docker rm -f occ-smoke; exit 1
+          }
+          # Unauthenticated user traffic in unconfigured mode → 503 (not 200).
+          code=$(curl -s -o /dev/null -w '%{http_code}' -H 'Authorization: Bearer x.y.z' http://127.0.0.1:18080/v1/models)
+          if [ "$code" != "503" ]; then
+            echo "FAIL: expected 503 for user traffic in unconfigured mode, got $code"; docker rm -f occ-smoke; exit 1
+          fi
+          docker rm -f occ-smoke
+          echo "Smoke OK: container starts, /healthz + /metrics + landing serve, user traffic gated."
+
+      - name: Push image (SHA-pinned + latest)
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ env.CTX }}
+          file: ${{ env.CTX }}/Dockerfile
+          push: true
+          # SHA-pinned tag for production consumers (Inviolable Principle
+          # 4); :latest mirrors the newapi-sandbox-bridge deploy-bot
+          # convention so a re-run without a chart change re-publishes.
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.tag.outputs.tag }}
+            ${{ env.IMAGE }}:latest
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq \
+            https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Bump controller (+ runtime) tag in values.yaml
+        env:
+          NEW_TAG: ${{ steps.tag.outputs.tag }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Controller tag → the SHA we just published.
+          yq eval -i ".controller.image.repository = \"${IMAGE}\"" "${CHART_VALUES}"
+          yq eval -i ".controller.image.tag = \"${NEW_TAG}\"" "${CHART_VALUES}"
+          # Runtime tag → latest published openclaw-runtime SHA. The
+          # runtime workflow publishes the image but never bumped the
+          # chart pin, leaving perUserPod.image.tag stale at the
+          # placeholder (#4249 RC3 sibling — spawned per-user pods would
+          # ImagePullBackOff on the placeholder too). Resolve it to the
+          # newest published runtime tag here so the whole bp-openclaw
+          # release carries real, existing image tags (anti-pattern A12).
+          RUNTIME_IMAGE="ghcr.io/openova-io/openova/openclaw-runtime"
+          latest_runtime=$(gh api \
+            "/orgs/openova-io/packages/container/openova%2Fopenclaw-runtime/versions" \
+            --jq 'sort_by(.created_at) | reverse | .[0].metadata.container.tags[0]' 2>/dev/null || true)
+          if [ -n "${latest_runtime}" ] && [ "${latest_runtime}" != "null" ]; then
+            yq eval -i ".perUserPod.image.repository = \"${RUNTIME_IMAGE}\"" "${CHART_VALUES}"
+            yq eval -i ".perUserPod.image.tag = \"${latest_runtime}\"" "${CHART_VALUES}"
+            echo "perUserPod.image.tag -> ${latest_runtime}"
+          else
+            echo "WARN: could not resolve latest openclaw-runtime tag; leaving perUserPod.image.tag unchanged"
+          fi
+          echo "values.yaml images after update:"
+          yq eval '.controller.image, .perUserPod.image' "${CHART_VALUES}"
+
+      - name: Bump Chart.yaml + blueprint.yaml patch version
+        run: |
+          set -euo pipefail
+          current=$(yq eval '.version' "${CHART_YAML}")
+          IFS='.' read -r major minor patch <<<"${current}"
+          next="${major}.${minor}.$((patch + 1))"
+          yq eval -i ".version = \"${next}\"" "${CHART_YAML}"
+          # blueprint.yaml spec.version tracks the chart version (used by
+          # the catalog-seed lockstep + the on-disk Blueprint card).
+          yq eval -i ".spec.version = \"${next}\"" "${BLUEPRINT_YAML}"
+          echo "Chart.yaml + blueprint.yaml: version ${current} -> ${next}"
+          echo "CHART_OLD_VERSION=${current}" >> "$GITHUB_ENV"
+          echo "CHART_NEW_VERSION=${next}" >> "$GITHUB_ENV"
+
+      # The catalog-seed file is a Helm template (Go `{{ }}` syntax) so yq
+      # cannot parse it. Patch the bp-openclaw block's two version pins
+      # (spec.version + source.version) with a block-scoped sed: rewrite
+      # only `version: "<old>"` lines that fall between the `name:
+      # bp-openclaw` marker and the next `name: bp-` marker. This keeps
+      # the fresh-Org chart pin (Blueprint spec.version → HR chartVersion)
+      # in lockstep with the published bp-openclaw:<new> OCI artifact so a
+      # fresh Org pulls the chart that carries the real controller tag —
+      # never a tag that doesn't exist on GHCR (anti-pattern A12).
+      - name: Bump catalog-seed bp-openclaw version pins
+        env:
+          OLD: ${{ env.CHART_OLD_VERSION }}
+          NEW: ${{ env.CHART_NEW_VERSION }}
+        run: |
+          set -euo pipefail
+          python3 - "$CATALOG_SEED" "$OLD" "$NEW" <<'PY'
+          import re, sys
+          path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+          with open(path) as f:
+              lines = f.readlines()
+          in_block = False
+          changed = 0
+          for i, ln in enumerate(lines):
+              if re.match(r'\s*name:\s*bp-openclaw\s*$', ln):
+                  in_block = True
+                  continue
+              if in_block and re.match(r'\s*name:\s*bp-[a-z0-9-]+\s*$', ln):
+                  in_block = False
+              if in_block and re.match(rf'(\s*version:\s*)"{re.escape(old)}"\s*$', ln):
+                  lines[i] = re.sub(rf'"{re.escape(old)}"', f'"{new}"', ln)
+                  changed += 1
+          with open(path, 'w') as f:
+              f.writelines(lines)
+          print(f"catalog-seed: rewrote {changed} bp-openclaw version pin(s) {old} -> {new}")
+          if changed == 0:
+              print("WARN: no bp-openclaw version pin matched — seed may already be ahead", file=sys.stderr)
+          PY
+
+      - name: Commit and push chart + seed bump
+        id: deploy_commit
+        uses: ./.github/actions/deploy-bump
+        with:
+          paths: |
+            ${{ env.CHART_VALUES }}
+            ${{ env.CHART_YAML }}
+            ${{ env.BLUEPRINT_YAML }}
+            ${{ env.CATALOG_SEED }}
+          commit-message: "deploy: bump bp-openclaw controller ${{ steps.tag.outputs.tag }} chart ${{ env.CHART_NEW_VERSION }} + seed pin (Refs #4249)"
+
+      - name: Trigger blueprint-release
+        if: steps.deploy_commit.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run blueprint-release.yaml \
+            --repo "${{ github.repository }}" \
+            --ref main \
+            -f blueprint=openclaw \
+            -f tree=platform
+          echo "blueprint-release dispatched for platform/openclaw @ main"
+
+      - name: Summary
+        run: |
+          {
+            echo "## openclaw-controller published"
+            echo ""
+            echo "- Image: \`${IMAGE}:${{ steps.tag.outputs.tag }}\`"
+            echo "- Chart bumped to: \`${CHART_NEW_VERSION:-unchanged}\`"
+            echo "- Refs #4249 (#795 epic)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/platform/openclaw/README.md
+++ b/platform/openclaw/README.md
@@ -61,6 +61,7 @@ blind runtime image) is intentionally reusable.
 | `templates/controller-ingress.yaml` | Public hostname `openclaw.<sme-domain>` with cert-manager auto-issue |
 | `templates/per-user-pod-template.yaml` | ConfigMap holding the pod-spec the controller renders per session |
 | `templates/networkpolicy.yaml` | Controller NetworkPolicy. The per-user pod's NetworkPolicy is rendered by the controller at session-start (see "Per-user pod NetworkPolicy" below) |
+| `controller/` | Source for the multi-tenant **controller** container image (separate OCI artifact `openclaw-controller`, built by `.github/workflows/openclaw-controller.yaml`). Validates the Organization end-user's Keycloak JWT (OIDC discovery + JWKS RS256), spawns one identity-blind runtime pod per session from the mounted pod-template ConfigMap, reverse-proxies the user to it, and reaps idle pods. |
 | `runtime/` | Source for the per-user runtime container image (separate OCI artifact, built by `.github/workflows/openclaw-runtime.yaml`) |
 | `tests/render-toggles.sh` | Helm-template integration test exercised by the blueprint-release CI workflow |
 
@@ -164,19 +165,27 @@ workflow `.github/workflows/blueprint-release.yaml` whenever
 `platform/openclaw/chart/**` changes on `main`. Output:
 
 ```
-oci://ghcr.io/openova-io/bp-openclaw:0.1.0
+oci://ghcr.io/openova-io/bp-openclaw:<semver>
 ```
 
-The runtime image is built by a sister workflow,
-`.github/workflows/openclaw-runtime.yaml`, on push to
-`platform/openclaw/runtime/**`. Output:
+Two sister workflows build the container images, both event-driven (per
+Inviolable Principle 1 — no `schedule:` cron; `workflow_dispatch` is for
+re-runs only):
 
-```
-ghcr.io/openova-io/openova/openclaw-runtime:<sha>
-```
+| Workflow | Trigger | Output |
+|---|---|---|
+| `openclaw-controller.yaml` | push to `platform/openclaw/controller/**` | `ghcr.io/openova-io/openova/openclaw-controller:<sha>` |
+| `openclaw-runtime.yaml` | push to `platform/openclaw/runtime/**` | `ghcr.io/openova-io/openova/openclaw-runtime:<sha>` |
 
-Per Inviolable Principle 1, both workflows are event-driven; neither
-uses `schedule:` cron. `workflow_dispatch` is provided for re-runs only.
+The controller workflow additionally bumps the chart in lockstep:
+after publishing the SHA-pinned image it rewrites
+`chart/values.yaml` (`controller.image.tag` → the new SHA,
+`perUserPod.image.tag` → the latest published runtime SHA), bumps
+`chart/Chart.yaml` + `blueprint.yaml` `version`, bumps the catalog-seed
+`bp-openclaw` version pins, and dispatches `blueprint-release`. This keeps
+the fresh-Org chart pin pointing at an OCI artifact whose image tags
+actually exist on GHCR — never the placeholder (issue #4249) and never
+a same-version mutable-tag overwrite (issue #4257).
 
 ---
 

--- a/platform/openclaw/controller/Dockerfile
+++ b/platform/openclaw/controller/Dockerfile
@@ -1,0 +1,34 @@
+# OpenClaw workspace controller — multi-tenant front-door image.
+#
+# This is the process bp-openclaw's chart was scaffolded around but never
+# had: it authenticates the Organization end-user against the per-tenant
+# Keycloak realm (OIDC discovery + JWKS RS256 validation), spawns one
+# identity-blind runtime pod per active session from the mounted
+# pod-template ConfigMap, reverse-proxies the user to that pod, and reaps
+# idle pods. See controller/main.go for the full contract.
+#
+# Stdlib-only Go binary (no external deps) — the build is hermetic and
+# needs no `go mod download`.
+#
+# Contract (all env-driven, Inviolable Principle 4):
+#   - HTTP server on $PORT (default 8080)
+#   - GET /healthz   → 200 once config parsed (liveness)
+#   - GET /readyz    → 200 once api-server + OIDC JWKS reachable
+#   - GET /metrics   → Prometheus counters
+#   - ANY /*         → authenticate (Bearer JWT) → ensure pod → proxy
+#
+# Output: ghcr.io/openova-io/openova/openclaw-controller:<sha>
+
+FROM golang:1.22-alpine AS build
+WORKDIR /src
+COPY go.mod main.go ./
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /openclaw-controller .
+
+FROM gcr.io/distroless/static:nonroot
+LABEL org.opencontainers.image.source="https://github.com/openova-io/openova"
+LABEL org.opencontainers.image.description="OpenClaw workspace controller — per-tenant Keycloak OIDC auth + per-user runtime pod spawn/proxy/reap"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+COPY --from=build /openclaw-controller /openclaw-controller
+USER 65532:65532
+EXPOSE 8080
+ENTRYPOINT ["/openclaw-controller"]

--- a/platform/openclaw/controller/go.mod
+++ b/platform/openclaw/controller/go.mod
@@ -1,0 +1,3 @@
+module github.com/openova-io/openova/platform/openclaw/controller
+
+go 1.22

--- a/platform/openclaw/controller/main.go
+++ b/platform/openclaw/controller/main.go
@@ -1,0 +1,975 @@
+// OpenClaw workspace controller — the multi-tenant front door for the
+// per-user agentic workspace (epic openova-io/openova#795, ADR-0003).
+//
+// What this binary is (and why it exists): bp-openclaw's chart ships the
+// RBAC (pods create/get/list/watch/delete in the tenant namespace), the
+// per-user-pod ConfigMap template, the OIDC/LLM env wiring, and the idle
+// reaper config — but NONE of that does anything without a process that
+// (a) authenticates the Organization end-user against the per-tenant
+// Keycloak realm, (b) spawns one identity-blind runtime pod per active
+// session from the mounted pod-template, (c) reverse-proxies the user's
+// traffic to that pod, and (d) reaps idle pods. THIS is that process.
+//
+// Identity boundary (the whole point of the workspace-controller shape,
+// per README.md): the controller is the ONLY component that ever sees a
+// JWT from the Organization's own Keycloak realm. The runtime pods are
+// identity-blind — they read only NEWAPI_BASE_URL + NEWAPI_KEY from the
+// per-user `newapi-key-{uuid}` Secret (ADR-0003 §3.3). NewAPI therefore
+// only ever talks to its own per-user keys, never to a cross-realm JWT.
+//
+// Everything operationally meaningful is an env var (Inviolable
+// Principle 4 — never hardcode). The chart's controller-deployment.yaml
+// supplies them all:
+//
+//   OIDC_ISSUER_URL        per-tenant Keycloak realm issuer (iss claim)
+//   OIDC_CLIENT_ID         expected aud/azp on inbound JWTs
+//   TENANT_NAMESPACE       namespace where per-user pods + secrets live
+//   POD_TEMPLATE_CONFIGMAP name of the pod-template ConfigMap (mounted)
+//   IDLE_TIMEOUT_MINUTES   reaper deletes pods idle longer than this
+//   PORT                   listen port (default 8080)
+//
+// The pod-template is mounted at /etc/openclaw/pod-template.yaml (a
+// volume from the ConfigMap in controller-deployment.yaml). The
+// controller substitutes ${USER_UUID} and ${SECRET_NAME} per session.
+//
+// HTTP surface:
+//   GET  /healthz   200 once config is parsed (liveness)
+//   GET  /readyz    200 once the K8s api-server + OIDC JWKS are reachable
+//   GET  /metrics   Prometheus text-format counters
+//   GET  /          minimal landing page (browser confirm-loop)
+//   ANY  /*         authenticate (Bearer JWT) → ensure pod → proxy
+//
+// Stdlib only (no external Go deps) so the build is hermetic and the
+// Dockerfile mirrors the runtime's COPY-and-build pattern.
+
+package main
+
+import (
+	"context"
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	defaultPort        = "8080"
+	saTokenPath        = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	saCACertPath       = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+	podTemplatePath    = "/etc/openclaw/pod-template.yaml"
+	podReadyTimeout    = 60 * time.Second
+	upstreamPort       = 8080 // per-user runtime listens on :8080
+	jwksRefreshTimeout = 10 * time.Second
+)
+
+// config is the fully-resolved controller configuration, sourced
+// entirely from the environment (Inviolable Principle 4).
+type config struct {
+	port        string
+	issuerURL   string
+	clientID    string
+	tenantNS    string
+	idleTimeout time.Duration
+	k8sAPIHost  string
+	k8sAPIPort  string
+	saToken     string
+	httpClient  *http.Client // talks to the in-cluster api-server (CA-pinned)
+	requireAuth bool         // false only when OIDC is unconfigured (smoke)
+}
+
+func loadConfig() (*config, error) {
+	c := &config{
+		port:        getenvDefault("PORT", defaultPort),
+		issuerURL:   strings.TrimRight(os.Getenv("OIDC_ISSUER_URL"), "/"),
+		clientID:    os.Getenv("OIDC_CLIENT_ID"),
+		tenantNS:    os.Getenv("TENANT_NAMESPACE"),
+		k8sAPIHost:  getenvDefault("KUBERNETES_SERVICE_HOST", ""),
+		k8sAPIPort:  getenvDefault("KUBERNETES_SERVICE_PORT", "443"),
+		requireAuth: true,
+	}
+
+	idleMin := getenvDefault("IDLE_TIMEOUT_MINUTES", "30")
+	n, err := strconv.Atoi(idleMin)
+	if err != nil || n < 1 {
+		return nil, fmt.Errorf("invalid IDLE_TIMEOUT_MINUTES=%q: must be a positive integer", idleMin)
+	}
+	c.idleTimeout = time.Duration(n) * time.Minute
+
+	// The placeholder OIDC issuer (chart smoke-render default) means OIDC
+	// is not really configured. The controller still starts and serves
+	// /healthz so the chart's smoke install / probe path works, but it
+	// refuses to spawn pods (returns 503 on user traffic) rather than
+	// trusting unsigned requests. A real overlay sets a non-placeholder
+	// issuer.
+	if c.issuerURL == "" || c.issuerURL == "https://keycloak.example.local/realms/example" {
+		c.requireAuth = false
+		log.Printf("WARN: OIDC_ISSUER_URL is unset/placeholder (%q) — running in unconfigured mode; user traffic returns 503 until a real issuer is supplied", c.issuerURL)
+	}
+
+	// In-cluster ServiceAccount token + CA. Absent outside a cluster
+	// (e.g. local smoke run) — the controller degrades to readyz=false
+	// for the K8s leg but still serves /healthz.
+	if tok, err := os.ReadFile(saTokenPath); err == nil {
+		c.saToken = strings.TrimSpace(string(tok))
+	}
+	c.httpClient = buildAPIClient()
+
+	return c, nil
+}
+
+func getenvDefault(k, d string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return d
+}
+
+// buildAPIClient returns an http.Client trusting the in-cluster CA for
+// api-server calls; falls back to the system pool when the CA file is
+// absent (off-cluster).
+func buildAPIClient() *http.Client {
+	tlsCfg := &tls.Config{MinVersion: tls.VersionTLS12}
+	if ca, err := os.ReadFile(saCACertPath); err == nil {
+		pool := x509.NewCertPool()
+		if pool.AppendCertsFromPEM(ca) {
+			tlsCfg.RootCAs = pool
+		}
+	}
+	return &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: &http.Transport{TLSClientConfig: tlsCfg},
+	}
+}
+
+func main() {
+	cfg, err := loadConfig()
+	if err != nil {
+		log.Fatalf("FATAL: %v", err)
+	}
+
+	verifier := newJWTVerifier(cfg.issuerURL, cfg.clientID, cfg.httpClient)
+	spawner := newPodSpawner(cfg)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", healthzHandler)
+	mux.HandleFunc("/readyz", readyzHandler(cfg, verifier))
+	mux.HandleFunc("/metrics", metricsHandler)
+	mux.HandleFunc("/", rootHandler(cfg, verifier, spawner))
+
+	// Idle reaper — background loop deleting per-user pods idle past the
+	// configured timeout. Only runs when we have a usable api-server.
+	if cfg.saToken != "" && cfg.k8sAPIHost != "" {
+		go spawner.runReaper(context.Background())
+	}
+
+	addr := net.JoinHostPort("", cfg.port)
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	log.Printf("openclaw-controller listening on %s; issuer=%q tenantNS=%q idleTimeout=%s authRequired=%t",
+		addr, cfg.issuerURL, cfg.tenantNS, cfg.idleTimeout, cfg.requireAuth)
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Fatalf("FATAL: server error: %v", err)
+	}
+}
+
+// ─────────────────────────── HTTP handlers ───────────────────────────
+
+func healthzHandler(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = io.WriteString(w, "ok")
+}
+
+// readyzHandler asserts the controller's external dependencies are
+// reachable: the K8s api-server (for pod lifecycle) and the OIDC JWKS
+// (for JWT validation). In unconfigured/off-cluster smoke mode it still
+// reports ready so the chart's smoke probe passes.
+func readyzHandler(cfg *config, v *jwtVerifier) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		// K8s api-server reachability (only asserted when we expect one).
+		if cfg.saToken != "" && cfg.k8sAPIHost != "" {
+			if err := pingAPIServer(cfg); err != nil {
+				http.Error(w, fmt.Sprintf("readyz: api-server unreachable: %v", err), http.StatusServiceUnavailable)
+				return
+			}
+		}
+		// OIDC JWKS reachability (only when auth is required).
+		if cfg.requireAuth {
+			if err := v.ensureKeys(context.Background()); err != nil {
+				http.Error(w, fmt.Sprintf("readyz: OIDC JWKS unreachable: %v", err), http.StatusServiceUnavailable)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ready")
+	}
+}
+
+func metricsHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+	mets.write(w)
+}
+
+func rootHandler(cfg *config, v *jwtVerifier, s *podSpawner) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Browser landing page on bare GET / with no Authorization — lets
+		// the operator confirm-loop the controller in a browser.
+		if r.URL.Path == "/" && r.Header.Get("Authorization") == "" {
+			landingPage(w)
+			return
+		}
+
+		if !cfg.requireAuth {
+			http.Error(w, "openclaw-controller is not yet configured for this tenant (OIDC issuer unset)", http.StatusServiceUnavailable)
+			mets.inc(&mets.authUnconfigured)
+			return
+		}
+
+		// Authenticate the inbound Organization end-user JWT.
+		userUUID, err := authenticate(r, v)
+		if err != nil {
+			mets.inc(&mets.authFailures)
+			http.Error(w, "unauthorized: "+err.Error(), http.StatusUnauthorized)
+			return
+		}
+		mets.inc(&mets.authSuccess)
+
+		// Ensure a per-user runtime pod exists, then proxy to it.
+		podIP, err := s.ensurePod(r.Context(), userUUID)
+		if err != nil {
+			mets.inc(&mets.spawnFailures)
+			log.Printf("ensurePod(%s): %v", userUUID, err)
+			http.Error(w, "could not provision your workspace pod: "+err.Error(), http.StatusBadGateway)
+			return
+		}
+
+		proxyToPod(w, r, podIP)
+	}
+}
+
+func landingPage(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = io.WriteString(w, `<!doctype html>
+<html><head><title>OpenClaw workspace</title></head>
+<body style="font-family:system-ui,sans-serif;max-width:680px;margin:2rem auto;color:#222">
+<h1>OpenClaw workspace controller</h1>
+<p>Multi-tenant agentic workspace. Authenticate via your Organization's
+Keycloak realm; the controller spawns a private runtime pod for your
+session and proxies your requests to it.</p>
+<p>Send requests with <code>Authorization: Bearer &lt;your-OIDC-JWT&gt;</code>.</p>
+<p>Health: <code>/healthz</code> · Readiness: <code>/readyz</code> · Metrics: <code>/metrics</code></p>
+</body></html>
+`)
+}
+
+// authenticate extracts + validates the bearer JWT and returns the
+// user UUID (the `sub` claim, per ADR-0003 §3.3 the key to the per-user
+// newapi-key-{sub} Secret).
+func authenticate(r *http.Request, v *jwtVerifier) (string, error) {
+	auth := r.Header.Get("Authorization")
+	if auth == "" {
+		return "", errors.New("missing Authorization header")
+	}
+	const prefix = "Bearer "
+	if !strings.HasPrefix(auth, prefix) {
+		return "", errors.New("Authorization header must be a Bearer token")
+	}
+	raw := strings.TrimSpace(strings.TrimPrefix(auth, prefix))
+	claims, err := v.verify(r.Context(), raw)
+	if err != nil {
+		return "", err
+	}
+	if claims.Subject == "" {
+		return "", errors.New("token has no sub claim")
+	}
+	return claims.Subject, nil
+}
+
+func proxyToPod(w http.ResponseWriter, r *http.Request, podIP string) {
+	target := &url.URL{Scheme: "http", Host: net.JoinHostPort(podIP, strconv.Itoa(upstreamPort))}
+	rp := &httputil.ReverseProxy{
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			pr.SetURL(target)
+			// The runtime is identity-blind: strip the inbound Keycloak
+			// JWT so it NEVER reaches the per-user pod or NewAPI. The pod
+			// authenticates to NewAPI with its own mounted NEWAPI_KEY.
+			pr.Out.Header.Del("Authorization")
+			pr.Out.Header.Del("Cookie")
+		},
+		ErrorLog: log.New(os.Stderr, "proxy: ", log.LstdFlags),
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			log.Printf("proxy: error forwarding %s %s to %s: %v", r.Method, r.URL.Path, podIP, err)
+			http.Error(w, "workspace pod unreachable", http.StatusBadGateway)
+		},
+	}
+	mets.inc(&mets.proxiedRequests)
+	rp.ServeHTTP(w, r)
+}
+
+// ─────────────────────────── JWT verifier ────────────────────────────
+
+type jwtClaims struct {
+	Issuer    string `json:"iss"`
+	Subject   string `json:"sub"`
+	Audience  any    `json:"aud"` // string or []string
+	AZP       string `json:"azp"`
+	ExpiresAt int64  `json:"exp"`
+	NotBefore int64  `json:"nbf"`
+}
+
+type jwtVerifier struct {
+	issuerURL string
+	clientID  string
+	client    *http.Client
+
+	mu       sync.RWMutex
+	keys     map[string]*rsa.PublicKey // kid -> key
+	jwksURL  string
+	lastLoad time.Time
+}
+
+func newJWTVerifier(issuerURL, clientID string, client *http.Client) *jwtVerifier {
+	return &jwtVerifier{
+		issuerURL: issuerURL,
+		clientID:  clientID,
+		client:    client,
+		keys:      map[string]*rsa.PublicKey{},
+	}
+}
+
+type oidcDiscovery struct {
+	Issuer  string `json:"issuer"`
+	JWKSURI string `json:"jwks_uri"`
+}
+
+type jwk struct {
+	Kty string `json:"kty"`
+	Kid string `json:"kid"`
+	N   string `json:"n"`
+	E   string `json:"e"`
+	Use string `json:"use"`
+	Alg string `json:"alg"`
+}
+
+type jwksDoc struct {
+	Keys []jwk `json:"keys"`
+}
+
+// ensureKeys lazily loads (and refreshes if older than 5 min) the
+// realm's JWKS from the OIDC discovery document.
+func (v *jwtVerifier) ensureKeys(ctx context.Context) error {
+	v.mu.RLock()
+	fresh := time.Since(v.lastLoad) < 5*time.Minute && len(v.keys) > 0
+	v.mu.RUnlock()
+	if fresh {
+		return nil
+	}
+	return v.loadKeys(ctx)
+}
+
+func (v *jwtVerifier) loadKeys(ctx context.Context) error {
+	if v.issuerURL == "" {
+		return errors.New("OIDC issuer URL not configured")
+	}
+	ctx, cancel := context.WithTimeout(ctx, jwksRefreshTimeout)
+	defer cancel()
+
+	// 1. Discovery.
+	discURL := v.issuerURL + "/.well-known/openid-configuration"
+	var disc oidcDiscovery
+	if err := v.getJSON(ctx, discURL, &disc); err != nil {
+		return fmt.Errorf("OIDC discovery %s: %w", discURL, err)
+	}
+	jwksURL := disc.JWKSURI
+	if jwksURL == "" {
+		// Keycloak's conventional JWKS path under the realm.
+		jwksURL = v.issuerURL + "/protocol/openid-connect/certs"
+	}
+
+	// 2. JWKS.
+	var doc jwksDoc
+	if err := v.getJSON(ctx, jwksURL, &doc); err != nil {
+		return fmt.Errorf("JWKS fetch %s: %w", jwksURL, err)
+	}
+	keys := map[string]*rsa.PublicKey{}
+	for _, k := range doc.Keys {
+		if k.Kty != "RSA" {
+			continue
+		}
+		pub, err := jwkToRSA(k)
+		if err != nil {
+			log.Printf("WARN: skipping JWK kid=%s: %v", k.Kid, err)
+			continue
+		}
+		keys[k.Kid] = pub
+	}
+	if len(keys) == 0 {
+		return errors.New("JWKS contained no usable RSA keys")
+	}
+
+	v.mu.Lock()
+	v.keys = keys
+	v.jwksURL = jwksURL
+	v.lastLoad = time.Now()
+	v.mu.Unlock()
+	return nil
+}
+
+func (v *jwtVerifier) getJSON(ctx context.Context, u string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := v.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("GET %s: HTTP %d", u, resp.StatusCode)
+	}
+	return json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(out)
+}
+
+// verify validates the RS256 JWT signature against the realm JWKS and
+// checks the standard claims (iss, aud/azp, exp, nbf), returning the
+// decoded claims on success.
+func (v *jwtVerifier) verify(ctx context.Context, token string) (*jwtClaims, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, errors.New("malformed JWT (expected 3 segments)")
+	}
+	headerJSON, err := b64urlDecode(parts[0])
+	if err != nil {
+		return nil, fmt.Errorf("decode header: %w", err)
+	}
+	var hdr struct {
+		Alg string `json:"alg"`
+		Kid string `json:"kid"`
+	}
+	if err := json.Unmarshal(headerJSON, &hdr); err != nil {
+		return nil, fmt.Errorf("parse header: %w", err)
+	}
+	if hdr.Alg != "RS256" {
+		return nil, fmt.Errorf("unsupported alg %q (only RS256)", hdr.Alg)
+	}
+
+	if err := v.ensureKeys(ctx); err != nil {
+		return nil, fmt.Errorf("load signing keys: %w", err)
+	}
+	v.mu.RLock()
+	key, ok := v.keys[hdr.Kid]
+	v.mu.RUnlock()
+	if !ok {
+		// Unknown kid — force a refresh once (realm rotated keys).
+		if err := v.loadKeys(ctx); err != nil {
+			return nil, fmt.Errorf("refresh keys for kid %q: %w", hdr.Kid, err)
+		}
+		v.mu.RLock()
+		key, ok = v.keys[hdr.Kid]
+		v.mu.RUnlock()
+		if !ok {
+			return nil, fmt.Errorf("no signing key for kid %q", hdr.Kid)
+		}
+	}
+
+	signingInput := parts[0] + "." + parts[1]
+	sig, err := b64urlDecode(parts[2])
+	if err != nil {
+		return nil, fmt.Errorf("decode signature: %w", err)
+	}
+	if err := verifyRS256(key, []byte(signingInput), sig); err != nil {
+		return nil, fmt.Errorf("signature invalid: %w", err)
+	}
+
+	claimsJSON, err := b64urlDecode(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("decode claims: %w", err)
+	}
+	var claims jwtClaims
+	if err := json.Unmarshal(claimsJSON, &claims); err != nil {
+		return nil, fmt.Errorf("parse claims: %w", err)
+	}
+
+	now := time.Now().Unix()
+	if claims.ExpiresAt != 0 && now >= claims.ExpiresAt {
+		return nil, errors.New("token expired")
+	}
+	if claims.NotBefore != 0 && now < claims.NotBefore {
+		return nil, errors.New("token not yet valid")
+	}
+	if v.issuerURL != "" && strings.TrimRight(claims.Issuer, "/") != v.issuerURL {
+		return nil, fmt.Errorf("issuer mismatch: token iss=%q want %q", claims.Issuer, v.issuerURL)
+	}
+	if v.clientID != "" && !audienceMatches(claims, v.clientID) {
+		return nil, fmt.Errorf("audience mismatch: token not issued for client %q", v.clientID)
+	}
+	return &claims, nil
+}
+
+func audienceMatches(c jwtClaims, clientID string) bool {
+	// Keycloak access tokens often carry the client in `azp` and a
+	// generic `account` aud; accept a match on either azp or aud.
+	if c.AZP == clientID {
+		return true
+	}
+	switch a := c.Audience.(type) {
+	case string:
+		return a == clientID
+	case []any:
+		for _, x := range a {
+			if s, ok := x.(string); ok && s == clientID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func jwkToRSA(k jwk) (*rsa.PublicKey, error) {
+	nBytes, err := b64urlDecode(k.N)
+	if err != nil {
+		return nil, fmt.Errorf("decode modulus: %w", err)
+	}
+	eBytes, err := b64urlDecode(k.E)
+	if err != nil {
+		return nil, fmt.Errorf("decode exponent: %w", err)
+	}
+	n := new(big.Int).SetBytes(nBytes)
+	e := 0
+	for _, b := range eBytes {
+		e = e<<8 | int(b)
+	}
+	if e == 0 {
+		return nil, errors.New("zero exponent")
+	}
+	return &rsa.PublicKey{N: n, E: e}, nil
+}
+
+func b64urlDecode(s string) ([]byte, error) {
+	// JWT uses base64url without padding.
+	if m := len(s) % 4; m != 0 {
+		s += strings.Repeat("=", 4-m)
+	}
+	return base64.URLEncoding.DecodeString(s)
+}
+
+// ─────────────────────────── pod spawner ─────────────────────────────
+
+type podSpawner struct {
+	cfg      *config
+	template string // raw pod-template (mounted ConfigMap), or "" if absent
+}
+
+func newPodSpawner(cfg *config) *podSpawner {
+	s := &podSpawner{cfg: cfg}
+	if data, err := os.ReadFile(podTemplatePath); err == nil {
+		s.template = string(data)
+	} else {
+		log.Printf("WARN: pod-template not found at %s: %v — pod spawn disabled until the ConfigMap is mounted", podTemplatePath, err)
+	}
+	return s
+}
+
+// podName is the deterministic name for a user's session pod. ADR-0003
+// keys per-user state by the OIDC sub claim (a UUID); a stable name lets
+// us treat ensurePod idempotently (one pod per active user).
+func podName(userUUID string) string {
+	safe := strings.ToLower(userUUID)
+	safe = strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			return r
+		}
+		return '-'
+	}, safe)
+	// RFC1123 label max is 63 chars; the "openclaw-user-" prefix is 14,
+	// leaving 49 for the (already sanitized) user segment.
+	const prefix = "openclaw-user-"
+	if len(safe) > 63-len(prefix) {
+		safe = safe[:63-len(prefix)]
+	}
+	return prefix + strings.Trim(safe, "-")
+}
+
+func secretName(userUUID string) string {
+	return "newapi-key-" + userUUID
+}
+
+// ensurePod guarantees a runtime pod exists for the user and returns its
+// IP. If a pod already exists and is Running, it's reused (and its
+// last-seen annotation refreshed for the reaper); otherwise it's created
+// from the mounted template and we wait for it to get an IP.
+func (s *podSpawner) ensurePod(ctx context.Context, userUUID string) (string, error) {
+	if s.template == "" {
+		return "", errors.New("pod-template ConfigMap not mounted")
+	}
+	if s.cfg.saToken == "" || s.cfg.k8sAPIHost == "" {
+		return "", errors.New("no in-cluster Kubernetes API access")
+	}
+	name := podName(userUUID)
+
+	// Already exists?
+	pod, err := s.getPod(ctx, name)
+	if err == nil && pod != nil {
+		if pod.Status.Phase == "Running" && pod.Status.PodIP != "" {
+			_ = s.touchPod(ctx, name) // refresh idle timestamp; best-effort
+			return pod.Status.PodIP, nil
+		}
+		if pod.Status.Phase == "Failed" || pod.Status.Phase == "Succeeded" {
+			// Reap a terminated pod and recreate.
+			_ = s.deletePod(ctx, name)
+		} else {
+			// Pending — wait for it to come up.
+			return s.waitForIP(ctx, name)
+		}
+	}
+
+	// Create from template.
+	manifest := s.renderTemplate(userUUID)
+	if err := s.createPod(ctx, manifest); err != nil {
+		// Lost the create race? Re-fetch.
+		if existing, gerr := s.getPod(ctx, name); gerr == nil && existing != nil {
+			return s.waitForIP(ctx, name)
+		}
+		return "", fmt.Errorf("create pod: %w", err)
+	}
+	mets.inc(&mets.podsSpawned)
+	return s.waitForIP(ctx, name)
+}
+
+func (s *podSpawner) renderTemplate(userUUID string) string {
+	r := strings.NewReplacer(
+		"${USER_UUID}", userUUID,
+		"${SECRET_NAME}", secretName(userUUID),
+	)
+	out := r.Replace(s.template)
+	// Stamp the reaper's last-seen annotation so a freshly-created pod
+	// isn't immediately eligible for reaping.
+	out = injectIdleAnnotation(out, time.Now().UTC().Format(time.RFC3339))
+	return out
+}
+
+// injectIdleAnnotation inserts/updates the controller's last-seen
+// annotation into the pod manifest's metadata. The template ConfigMap
+// declares labels under metadata; we append an annotations block (or a
+// single annotation) the reaper reads. Done textually to stay
+// dependency-free, mirroring the template's ${VAR} substitution model.
+func injectIdleAnnotation(manifest, ts string) string {
+	const annKey = "catalyst.openova.io/openclaw-last-seen"
+	// If the controller already added it (idempotent re-render), replace.
+	if strings.Contains(manifest, annKey) {
+		return manifest
+	}
+	// Insert an annotations block right after the first `metadata:` line.
+	lines := strings.Split(manifest, "\n")
+	for i, ln := range lines {
+		if strings.TrimSpace(ln) == "metadata:" {
+			indent := ln[:len(ln)-len(strings.TrimLeft(ln, " "))]
+			ann := indent + "  annotations:\n" +
+				indent + "    " + annKey + ": \"" + ts + "\""
+			out := append([]string{}, lines[:i+1]...)
+			out = append(out, ann)
+			out = append(out, lines[i+1:]...)
+			return strings.Join(out, "\n")
+		}
+	}
+	return manifest
+}
+
+// ─────────────────── Kubernetes REST plumbing ────────────────────────
+
+type k8sPod struct {
+	Metadata struct {
+		Name        string            `json:"name"`
+		Namespace   string            `json:"namespace"`
+		Annotations map[string]string `json:"annotations"`
+		Labels      map[string]string `json:"labels"`
+	} `json:"metadata"`
+	Status struct {
+		Phase string `json:"phase"`
+		PodIP string `json:"podIP"`
+	} `json:"status"`
+}
+
+type k8sPodList struct {
+	Items []k8sPod `json:"items"`
+}
+
+func (s *podSpawner) apiBase() string {
+	host := net.JoinHostPort(s.cfg.k8sAPIHost, s.cfg.k8sAPIPort)
+	return fmt.Sprintf("https://%s/api/v1/namespaces/%s/pods", host, s.cfg.tenantNS)
+}
+
+func (s *podSpawner) apiReq(ctx context.Context, method, urlStr string, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, urlStr, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+s.cfg.saToken)
+	req.Header.Set("Accept", "application/json")
+	return req, nil
+}
+
+func (s *podSpawner) getPod(ctx context.Context, name string) (*k8sPod, error) {
+	req, err := s.apiReq(ctx, http.MethodGet, s.apiBase()+"/"+name, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.cfg.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("get pod %s: HTTP %d: %s", name, resp.StatusCode, strings.TrimSpace(string(b)))
+	}
+	var pod k8sPod
+	if err := json.NewDecoder(resp.Body).Decode(&pod); err != nil {
+		return nil, err
+	}
+	return &pod, nil
+}
+
+func (s *podSpawner) createPod(ctx context.Context, manifestYAML string) error {
+	// The api-server accepts YAML when Content-Type is application/yaml.
+	req, err := s.apiReq(ctx, http.MethodPost, s.apiBase(), strings.NewReader(manifestYAML))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/yaml")
+	resp, err := s.cfg.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusCreated || resp.StatusCode == http.StatusOK {
+		return nil
+	}
+	b, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
+	if resp.StatusCode == http.StatusConflict {
+		return fmt.Errorf("conflict: %s", strings.TrimSpace(string(b)))
+	}
+	return fmt.Errorf("create pod: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(b)))
+}
+
+func (s *podSpawner) deletePod(ctx context.Context, name string) error {
+	req, err := s.apiReq(ctx, http.MethodDelete, s.apiBase()+"/"+name, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := s.cfg.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusAccepted || resp.StatusCode == http.StatusNotFound {
+		mets.inc(&mets.podsReaped)
+		return nil
+	}
+	return fmt.Errorf("delete pod %s: HTTP %d", name, resp.StatusCode)
+}
+
+// touchPod refreshes the reaper's last-seen annotation via a strategic
+// merge patch so an in-use pod isn't reaped.
+func (s *podSpawner) touchPod(ctx context.Context, name string) error {
+	ts := time.Now().UTC().Format(time.RFC3339)
+	patch := fmt.Sprintf(`{"metadata":{"annotations":{"catalyst.openova.io/openclaw-last-seen":%q}}}`, ts)
+	req, err := s.apiReq(ctx, http.MethodPatch, s.apiBase()+"/"+name, strings.NewReader(patch))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/merge-patch+json")
+	resp, err := s.cfg.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("touch pod %s: HTTP %d", name, resp.StatusCode)
+	}
+	return nil
+}
+
+func (s *podSpawner) listUserPods(ctx context.Context) ([]k8sPod, error) {
+	u := s.apiBase() + "?labelSelector=" + url.QueryEscape("catalyst.openova.io/blueprint=bp-openclaw,app.kubernetes.io/component=per-user-pod")
+	req, err := s.apiReq(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.cfg.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("list pods: HTTP %d", resp.StatusCode)
+	}
+	var list k8sPodList
+	if err := json.NewDecoder(resp.Body).Decode(&list); err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}
+
+func (s *podSpawner) waitForIP(ctx context.Context, name string) (string, error) {
+	deadline := time.Now().Add(podReadyTimeout)
+	for time.Now().Before(deadline) {
+		pod, err := s.getPod(ctx, name)
+		if err == nil && pod != nil && pod.Status.PodIP != "" &&
+			(pod.Status.Phase == "Running" || pod.Status.Phase == "Pending") {
+			if pod.Status.Phase == "Running" {
+				return pod.Status.PodIP, nil
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(time.Second):
+		}
+	}
+	return "", fmt.Errorf("pod %s did not become Running within %s", name, podReadyTimeout)
+}
+
+// runReaper periodically deletes per-user pods whose last-seen annotation
+// is older than the idle timeout.
+func (s *podSpawner) runReaper(ctx context.Context) {
+	interval := s.cfg.idleTimeout / 4
+	if interval < time.Minute {
+		interval = time.Minute
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	log.Printf("idle reaper started: timeout=%s sweepInterval=%s", s.cfg.idleTimeout, interval)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.reapOnce(ctx)
+		}
+	}
+}
+
+func (s *podSpawner) reapOnce(ctx context.Context) {
+	pods, err := s.listUserPods(ctx)
+	if err != nil {
+		log.Printf("reaper: list pods: %v", err)
+		return
+	}
+	cutoff := time.Now().Add(-s.cfg.idleTimeout)
+	for _, p := range pods {
+		seen := p.Metadata.Annotations["catalyst.openova.io/openclaw-last-seen"]
+		if seen == "" {
+			continue // never stamped → leave it (just created)
+		}
+		t, err := time.Parse(time.RFC3339, seen)
+		if err != nil {
+			continue
+		}
+		if t.Before(cutoff) {
+			log.Printf("reaper: deleting idle pod %s (last-seen %s)", p.Metadata.Name, seen)
+			if derr := s.deletePod(ctx, p.Metadata.Name); derr != nil {
+				log.Printf("reaper: delete %s: %v", p.Metadata.Name, derr)
+			}
+		}
+	}
+}
+
+// ─────────────────────────── misc helpers ────────────────────────────
+
+func pingAPIServer(cfg *config) error {
+	host := net.JoinHostPort(cfg.k8sAPIHost, cfg.k8sAPIPort)
+	u := fmt.Sprintf("https://%s/api/v1/namespaces/%s/pods?limit=1", host, cfg.tenantNS)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+cfg.saToken)
+	resp, err := cfg.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode >= 500 {
+		return fmt.Errorf("api-server HTTP %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// ─────────────────────────── metrics ─────────────────────────────────
+
+type metrics struct {
+	mu               sync.Mutex
+	authSuccess      int64
+	authFailures     int64
+	authUnconfigured int64
+	podsSpawned      int64
+	podsReaped       int64
+	spawnFailures    int64
+	proxiedRequests  int64
+}
+
+var mets = &metrics{}
+
+func (m *metrics) inc(p *int64) {
+	m.mu.Lock()
+	*p++
+	m.mu.Unlock()
+}
+
+func (m *metrics) write(w io.Writer) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	fmt.Fprintf(w, "# HELP openclaw_controller_auth_total Authenticated request outcomes.\n")
+	fmt.Fprintf(w, "# TYPE openclaw_controller_auth_total counter\n")
+	fmt.Fprintf(w, "openclaw_controller_auth_total{result=\"success\"} %d\n", m.authSuccess)
+	fmt.Fprintf(w, "openclaw_controller_auth_total{result=\"failure\"} %d\n", m.authFailures)
+	fmt.Fprintf(w, "openclaw_controller_auth_total{result=\"unconfigured\"} %d\n", m.authUnconfigured)
+	fmt.Fprintf(w, "# HELP openclaw_controller_pods_spawned_total Per-user runtime pods created.\n")
+	fmt.Fprintf(w, "# TYPE openclaw_controller_pods_spawned_total counter\n")
+	fmt.Fprintf(w, "openclaw_controller_pods_spawned_total %d\n", m.podsSpawned)
+	fmt.Fprintf(w, "# HELP openclaw_controller_pods_reaped_total Per-user runtime pods deleted (idle or terminated).\n")
+	fmt.Fprintf(w, "# TYPE openclaw_controller_pods_reaped_total counter\n")
+	fmt.Fprintf(w, "openclaw_controller_pods_reaped_total %d\n", m.podsReaped)
+	fmt.Fprintf(w, "# HELP openclaw_controller_spawn_failures_total Pod-spawn failures.\n")
+	fmt.Fprintf(w, "# TYPE openclaw_controller_spawn_failures_total counter\n")
+	fmt.Fprintf(w, "openclaw_controller_spawn_failures_total %d\n", m.spawnFailures)
+	fmt.Fprintf(w, "# HELP openclaw_controller_proxied_requests_total Requests proxied to a per-user pod.\n")
+	fmt.Fprintf(w, "# TYPE openclaw_controller_proxied_requests_total counter\n")
+	fmt.Fprintf(w, "openclaw_controller_proxied_requests_total %d\n", m.proxiedRequests)
+}
+
+// verifyRS256 verifies a RSASSA-PKCS1-v1_5 SHA-256 signature (JWT alg
+// RS256) of signingInput against the public key.
+func verifyRS256(key *rsa.PublicKey, signingInput, sig []byte) error {
+	sum := sha256.Sum256(signingInput)
+	return rsa.VerifyPKCS1v15(key, crypto.SHA256, sum[:], sig)
+}

--- a/platform/openclaw/controller/main.go
+++ b/platform/openclaw/controller/main.go
@@ -239,7 +239,7 @@ func rootHandler(cfg *config, v *jwtVerifier, s *podSpawner) http.HandlerFunc {
 		}
 
 		if !cfg.requireAuth {
-			http.Error(w, "openclaw-controller is not yet configured for this tenant (OIDC issuer unset)", http.StatusServiceUnavailable)
+			http.Error(w, "openclaw-controller is not yet configured for this Organization (OIDC issuer unset)", http.StatusServiceUnavailable)
 			mets.inc(&mets.authUnconfigured)
 			return
 		}

--- a/platform/openclaw/controller/main_test.go
+++ b/platform/openclaw/controller/main_test.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// signJWT builds a minimal RS256 JWT for tests.
+func signJWT(t *testing.T, key *rsa.PrivateKey, kid string, claims map[string]any) string {
+	t.Helper()
+	header := map[string]any{"alg": "RS256", "typ": "JWT", "kid": kid}
+	hb, _ := json.Marshal(header)
+	cb, _ := json.Marshal(claims)
+	enc := func(b []byte) string { return base64.RawURLEncoding.EncodeToString(b) }
+	signingInput := enc(hb) + "." + enc(cb)
+	sum := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, sum[:])
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return signingInput + "." + enc(sig)
+}
+
+// jwksServer stands up an OIDC discovery + JWKS endpoint backed by key.
+func jwksServer(t *testing.T, key *rsa.PrivateKey, kid string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	var base string
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"issuer":   base,
+			"jwks_uri": base + "/protocol/openid-connect/certs",
+		})
+	})
+	mux.HandleFunc("/protocol/openid-connect/certs", func(w http.ResponseWriter, r *http.Request) {
+		n := base64.RawURLEncoding.EncodeToString(key.PublicKey.N.Bytes())
+		e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.PublicKey.E)).Bytes())
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"keys": []map[string]string{
+				{"kty": "RSA", "kid": kid, "alg": "RS256", "use": "sig", "n": n, "e": e},
+			},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	base = srv.URL
+	return srv
+}
+
+func TestVerifyValidToken(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	const kid = "test-kid"
+	srv := jwksServer(t, key, kid)
+	defer srv.Close()
+
+	v := newJWTVerifier(srv.URL, "openclaw", srv.Client())
+	tok := signJWT(t, key, kid, map[string]any{
+		"iss": srv.URL,
+		"sub": "user-abc-123",
+		"azp": "openclaw",
+		"exp": time.Now().Add(time.Hour).Unix(),
+		"nbf": time.Now().Add(-time.Minute).Unix(),
+	})
+	claims, err := v.verify(context.Background(), tok)
+	if err != nil {
+		t.Fatalf("verify valid token: %v", err)
+	}
+	if claims.Subject != "user-abc-123" {
+		t.Fatalf("sub = %q, want user-abc-123", claims.Subject)
+	}
+}
+
+func TestVerifyRejectsExpired(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	const kid = "k"
+	srv := jwksServer(t, key, kid)
+	defer srv.Close()
+	v := newJWTVerifier(srv.URL, "openclaw", srv.Client())
+	tok := signJWT(t, key, kid, map[string]any{
+		"iss": srv.URL, "sub": "u", "azp": "openclaw",
+		"exp": time.Now().Add(-time.Hour).Unix(),
+	})
+	if _, err := v.verify(context.Background(), tok); err == nil {
+		t.Fatal("expected expired token to be rejected")
+	}
+}
+
+func TestVerifyRejectsWrongIssuer(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	const kid = "k"
+	srv := jwksServer(t, key, kid)
+	defer srv.Close()
+	v := newJWTVerifier(srv.URL, "openclaw", srv.Client())
+	tok := signJWT(t, key, kid, map[string]any{
+		"iss": "https://evil.example/realms/x", "sub": "u", "azp": "openclaw",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	if _, err := v.verify(context.Background(), tok); err == nil {
+		t.Fatal("expected issuer-mismatch token to be rejected")
+	}
+}
+
+func TestVerifyRejectsWrongAudience(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	const kid = "k"
+	srv := jwksServer(t, key, kid)
+	defer srv.Close()
+	v := newJWTVerifier(srv.URL, "openclaw", srv.Client())
+	tok := signJWT(t, key, kid, map[string]any{
+		"iss": srv.URL, "sub": "u", "azp": "some-other-client", "aud": "account",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	if _, err := v.verify(context.Background(), tok); err == nil {
+		t.Fatal("expected audience-mismatch token to be rejected")
+	}
+}
+
+func TestVerifyRejectsTamperedSignature(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	const kid = "k"
+	srv := jwksServer(t, key, kid)
+	defer srv.Close()
+	v := newJWTVerifier(srv.URL, "openclaw", srv.Client())
+	tok := signJWT(t, key, kid, map[string]any{
+		"iss": srv.URL, "sub": "u", "azp": "openclaw",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	// Flip a character in the MIDDLE of the signature segment to a
+	// different valid base64url char — guaranteed to change the decoded
+	// signature bytes (flipping the final char can land in trailing
+	// padding bits that decode to the same value).
+	parts := strings.Split(tok, ".")
+	sig := []byte(parts[2])
+	mid := len(sig) / 2
+	if sig[mid] == 'A' {
+		sig[mid] = 'B'
+	} else {
+		sig[mid] = 'A'
+	}
+	tampered := parts[0] + "." + parts[1] + "." + string(sig)
+	if _, err := v.verify(context.Background(), tampered); err == nil {
+		t.Fatal("expected tampered signature to be rejected")
+	}
+}
+
+func TestAudienceMatches(t *testing.T) {
+	cases := []struct {
+		name   string
+		claims jwtClaims
+		want   bool
+	}{
+		{"azp match", jwtClaims{AZP: "openclaw"}, true},
+		{"aud string match", jwtClaims{Audience: "openclaw"}, true},
+		{"aud array match", jwtClaims{Audience: []any{"account", "openclaw"}}, true},
+		{"no match", jwtClaims{AZP: "x", Audience: []any{"account"}}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := audienceMatches(tc.claims, "openclaw"); got != tc.want {
+				t.Fatalf("audienceMatches = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPodNameSanitization(t *testing.T) {
+	cases := map[string]string{
+		"7283eb4a-19e5-4e86-9066-d4aa26762064": "openclaw-user-7283eb4a-19e5-4e86-9066-d4aa26762064",
+		"User_With.Bad@Chars":                  "openclaw-user-user-with-bad-chars",
+	}
+	for in, want := range cases {
+		if got := podName(in); got != want {
+			t.Fatalf("podName(%q) = %q, want %q", in, got, want)
+		}
+	}
+	// RFC1123 label constraints: lowercase, <=63 chars, no leading/trailing dash.
+	long := strings.Repeat("a", 200)
+	got := podName(long)
+	if len(got) > 63 {
+		t.Fatalf("podName too long: %d chars", len(got))
+	}
+	if strings.HasSuffix(got, "-") || strings.HasPrefix(got, "-") {
+		t.Fatalf("podName has dangling dash: %q", got)
+	}
+}
+
+func TestInjectIdleAnnotation(t *testing.T) {
+	manifest := "apiVersion: v1\nkind: Pod\nmetadata:\n  name: openclaw-user-x\n  labels:\n    a: b\nspec:\n  containers: []\n"
+	out := injectIdleAnnotation(manifest, "2026-06-24T00:00:00Z")
+	if !strings.Contains(out, "catalyst.openova.io/openclaw-last-seen") {
+		t.Fatalf("annotation not injected:\n%s", out)
+	}
+	if !strings.Contains(out, "2026-06-24T00:00:00Z") {
+		t.Fatalf("timestamp not present:\n%s", out)
+	}
+	// Idempotent — re-injecting must not duplicate.
+	out2 := injectIdleAnnotation(out, "2026-06-25T00:00:00Z")
+	if strings.Count(out2, "openclaw-last-seen") != 1 {
+		t.Fatalf("annotation duplicated on re-inject:\n%s", out2)
+	}
+}
+
+func TestRenderTemplateSubstitutes(t *testing.T) {
+	s := &podSpawner{
+		cfg:      &config{},
+		template: "metadata:\n  name: openclaw-user-${USER_UUID}\n  labels:\n    secret: ${SECRET_NAME}\n",
+	}
+	out := s.renderTemplate("abc-123")
+	if !strings.Contains(out, "openclaw-user-abc-123") {
+		t.Fatalf("USER_UUID not substituted:\n%s", out)
+	}
+	if !strings.Contains(out, "newapi-key-abc-123") {
+		t.Fatalf("SECRET_NAME not substituted:\n%s", out)
+	}
+}
+
+func TestHealthzAlwaysOK(t *testing.T) {
+	rec := httptest.NewRecorder()
+	healthzHandler(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("healthz = %d, want 200", rec.Code)
+	}
+}


### PR DESCRIPTION
## Problem (Refs #4249, sibling RC3 of #4246)

`bp-openclaw`'s controller Deployment referenced `ghcr.io/openova-io/openova/openclaw-controller:0.1.0-placeholder`, which **never existed on GHCR** (404) — there was no controller source, Dockerfile, or CI workflow (only the per-user `openclaw-runtime` is built). So the controller pod `ImagePullBackOff`'d forever (90m+ on the omantel.biz demo Org) and the bp-openclaw HR could never reach Ready on any Sovereign — blocking demo-Org full convergence.

## Decision: BUILD the controller (option a), not remove it

The controller is **genuinely load-bearing**, not vestigial scaffold. The entire chart is built around a controller process:
- `controller-rbac.yaml` grants pods `create`/`get`/`list`/`watch`/`delete` in the tenant namespace — meaningless without a process that creates per-user pods.
- `per-user-pod-template.yaml` is a ConfigMap holding a pod-spec with `${USER_UUID}`/`${SECRET_NAME}` placeholders the controller substitutes per session.
- The deployment injects `OIDC_*` envs (per-tenant Keycloak realm) and `IDLE_TIMEOUT_MINUTES`.
- The runtime is **identity-blind by design** (ADR-0003 §3.3) — it reads only `NEWAPI_BASE_URL`+`NEWAPI_KEY` and has no Keycloak/key-mgmt code, so it cannot validate JWTs or spawn pods. That work is the controller's by construction.

Removing the controller would defeat the documented workspace-controller identity boundary (#795: NewAPI must only ever talk to its own per-user keys, never a cross-realm JWT). So the correct fix is to write it.

## What this ships

- **`platform/openclaw/controller/{main.go,go.mod,Dockerfile}`** — stdlib-only Go controller (hermetic build, mirrors the runtime's COPY-and-build):
  - OIDC discovery + JWKS **RS256 JWT validation** against the per-tenant Keycloak realm (checks `iss`/`aud`|`azp`/`exp`/`nbf` + signature; refreshes JWKS on key rotation).
  - Per-user runtime-pod **spawn** from the mounted pod-template ConfigMap (substitutes `${USER_UUID}`/`${SECRET_NAME}`), idempotent (one pod per user, reuses Running pods), waits for pod IP.
  - **Reverse-proxy** the authenticated user to their pod — strips the Keycloak `Authorization` JWT so the identity-blind runtime never sees it.
  - **Idle reaper** deletes per-user pods idle past `IDLE_TIMEOUT_MINUTES` (last-seen annotation refreshed per request).
  - `/healthz` (always 200 → liveness never CrashLoops), `/readyz` (api-server + JWKS reachability), `/metrics` (Prometheus counters). In unconfigured/smoke mode user traffic returns **503**, never trusting unsigned requests.
- **`main_test.go`** — RS256 verify (valid / expired / wrong-issuer / wrong-aud / tampered-sig), audience matching, RFC1123 pod-name sanitization, template substitution, idle-annotation injection. `go test -race` green.
- **`.github/workflows/openclaw-controller.yaml`** — event-driven build (`go test`+`go vet` → docker build → smoke-test → SHA-pin publish), then bumps in **lockstep**: `values.yaml controller.image.tag` (new SHA) + `perUserPod.image.tag` (latest published runtime SHA — the runtime pin was also stale at the placeholder, so spawned per-user pods would ImagePullBackOff too), `Chart.yaml` + `blueprint.yaml` version, **and** the catalog-seed `bp-openclaw` version pins, then dispatches `blueprint-release`. Mirrors the proven `build-bp-newapi-sandbox-bridge` deploy-bump pattern.

## How this avoids the traps

- **#4257 mutable-tag trap** — the controller tag and the chart version bump in lockstep, so Flux re-pulls (never a values-only edit on the same chart version).
- **Anti-pattern A12 (chart-pin to a non-existent GHCR tag)** — this PR touches **only** `controller/**` + the workflow + README (no `chart/**` / `blueprint.yaml`), so merging it does **not** trigger `blueprint-release` and never publishes a placeholder-controller artifact. The controller workflow does the entire real-image chart+seed bump atomically on merge, and the catalog-seed `spec.version` is bumped to the same version the workflow publishes — so a fresh Org's HR `chartVersion` always resolves to an artifact whose image tags exist.

## DoD / verification

- `go vet` + `go test -race` green; binary smoke-verified locally: `/healthz`→200, `/readyz`→200, `/`→landing, `/metrics`→counters, user-traffic-in-unconfigured-mode→503.
- Existing `chart/tests/render-toggles.sh` still green (chart untouched in this PR).
- Live install verification is gated: per #4246 the demo-Org namespace was torn down by an in-flight funnel walk; once the controller workflow publishes the image on merge, a fresh Org install converges with real, existing image tags.

Refs #4249, Refs #4246, Refs #795.