### PR TITLE
fix(bp-agenity): resync catalog-seed pin + generated catalog to chart 0.5.7

### DIFF
--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-24T07:50:53.624Z",
+  "generatedAt": "2026-06-24T08:17:04.461Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -11,7 +11,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.5.6",
+      "version": "0.5.7",
       "section": "pts-7-org-tenant",
       "depends": [
         "bp-external-secrets"
@@ -3575,7 +3575,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "section": "pts-4-7-agentic-workspace",
       "depends": [
         "bp-newapi",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -146,7 +146,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.5.6",
+    "version": "0.5.7",
     "section": "pts-7-org-tenant",
     "depends": [
       "bp-external-secrets"
@@ -3710,7 +3710,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "section": "pts-4-7-agentic-workspace",
     "depends": [
       "bp-newapi",

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -6479,15 +6479,16 @@ spec:
 # with the built-in solo agent (Claude Opus 4.7, token pre-configured), and
 # the agent creates more Applications in the User's Org via the RBAC-scoped
 # openova MCP. The north-star self-service journey (UAT rows 218-223).
-# Lockstep with products/agenity/chart/Chart.yaml version 0.5.6 + the
-# published chart ghcr.io/openova-io/bp-agenity:0.5.6 (chart 0.5.6 / appVersion
-# 0.9.7 is the FIRST image whose /app mounts the WORKSPACES dashboard rather
-# than the archaic single-column one — built from agenity#752, #4180). Fresh
-# provs seed THIS pin, so the chart-version here gates which image a new
-# Sovereign installs — bump in lockstep with the chart on every agenity
-# release. (The per-Org install in organization_gitops.go pins `*` and so
-# auto-resolves the newest published chart; this seed pin is the catalog-card
-# version a fresh prov shows + installs.)
+# Lockstep with products/agenity/chart/Chart.yaml version 0.5.7 + the
+# published chart ghcr.io/openova-io/bp-agenity:0.5.7 (appVersion 0.9.7 — the
+# image whose /app mounts the WORKSPACES dashboard rather than the archaic
+# single-column one, built from agenity#752, #4180; chart 0.5.7 adds the
+# #4261 expired-OAuth seed detection over 0.5.6). Fresh provs seed THIS pin,
+# so the chart-version here gates which image a new Sovereign installs — bump
+# in lockstep with the chart on every agenity release. (The per-Org install
+# in organization_gitops.go pins `*` and so auto-resolves the newest published
+# chart; this seed pin is the catalog-card version a fresh prov shows +
+# installs.)
 apiVersion: catalyst.openova.io/v1
 kind: Blueprint
 metadata:
@@ -6503,7 +6504,7 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
 spec:
-  version: "0.5.6"
+  version: "0.5.7"
   visibility: listed
   card:
     title: "Agenity"


### PR DESCRIPTION
Refs #4180

#4261 bumped the bp-agenity chart + `blueprint.yaml` `0.5.6 → 0.5.7` (expired-OAuth seed detection; appVersion stays `0.9.7` — the workspaces `/app` dashboard) but did not move the catalog-seed pin or regenerate the catalog. That left a fresh prov seeding `0.5.6` while the published chart is `0.5.7`.

This resyncs:
- `catalog-seed/blueprints.yaml` bp-agenity pin `0.5.6 → 0.5.7`
- regenerated catalog (`blueprints.json` + `catalog.generated.ts`) → agenity `0.5.7`

Runtime is unaffected either way (the per-Org HR in `organization_gitops.go` pins `*` and auto-resolves the newest published chart), but the seed pin should match the chart for lockstep cleanliness so a fresh Sovereign seeds + offers the same `0.5.7` chart → `0.9.7` image. The monorepo-wide generator also resynced one concurrent `blueprint.yaml` drift (`0.2.2 → 0.2.3`, from #4249).