### PR TITLE
fix(bp-self-sovereign-cutover): apply default-deny egress CCNP under defaultDenyEgress:true — witnessed hold, not assertion-only (Refs #3379)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -571,7 +571,10 @@ spec:
       # the running-Pod set with the declared workload-template set (Deployments
       # + StatefulSets + DaemonSets + CronJob/Job templates) so the mirror list
       # is complete regardless of which pods are Running — a strict superset.
-      version: 0.1.78
+      # 0.1.79 (#3379, omantel.biz 2026-06-24): step-08 egress-block now APPLIES
+      # the default-deny CCNP under the shipped defaultDenyEgress:true (the apply
+      # was stranded in the legacy else-branch → assertion-only hold).
+      version: 0.1.79
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.78
+  version: 0.1.79
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -978,7 +978,15 @@ name: bp-self-sovereign-cutover
 # `helm template` + `sh -n`/`dash -n` clean; live host-view enumeration on the
 # permanent omantel.biz Sovereign confirmed the union covers all 35 openova-io
 # images. Lockstep: 06a pin + blueprint.yaml + generated catalog.
-version: 0.1.78
+# 0.1.78 -> 0.1.79 (#3379, omantel.biz 2026-06-24): hoist the egress-deny
+# `kubectl apply` into a SHARED path so the SHIPPED `defaultDenyEgress: true`
+# (#3678) mode actually APPLIES the default-deny CCNP. The apply previously
+# lived only in the legacy subtractive `else` branch, so under the default the
+# manifest was written but never applied → POLICY_APPLIED empty → the #3678
+# call-home + #3647 fresh-pull proofs skipped → the 600s hold was assertion-only
+# and cutoverComplete=true could be earned WITHOUT a witnessed deny-egress.
+# Lockstep: blueprint.yaml bumped in step.
+version: 0.1.79
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
@@ -347,18 +347,31 @@ data:
                   done
                 } >/work/egress-deny.yaml
                 # /work is a writable emptyDir (readOnlyRootFilesystem:true
-                # makes /tmp unwritable). Without this the apply below is
-                # never reached and the deny-egress hold is assertion-only.
+                # makes /tmp unwritable). The subtractive manifest is written
+                # here; the SHARED apply below (outside this if/elif/else)
+                # applies whichever branch emitted it.
+              fi
+              # ── #3379 (omantel.biz, 2026-06-24): SHARED apply path. The
+              # `kubectl apply` + POLICY_APPLIED + teardown trap PREVIOUSLY
+              # lived ONLY in the legacy subtractive `else` branch above, so
+              # under the shipped `defaultDenyEgress: true` (#3678) the
+              # default-deny CCNP was WRITTEN to /work/egress-deny.yaml but
+              # NEVER applied: POLICY_APPLIED stayed empty, the #3678 call-home
+              # and #3647 fresh-pull proofs (both gated on POLICY_APPLIED=yes)
+              # were skipped, and the 600s survival window degenerated to an
+              # assertion-only hold. cutoverComplete=true could then be earned
+              # WITHOUT a witnessed deny-egress — the exact opposite of the
+              # ADR-0002 proof. Applying whichever manifest the branch above
+              # emitted (default-deny OR legacy subtractive), once, fixes both.
+              if [ -f /work/egress-deny.yaml ]; then
                 if kubectl apply -f /work/egress-deny.yaml; then
                   POLICY_APPLIED="yes"
                   # Trap teardown so an abnormal exit (activeDeadline SIGTERM,
                   # eviction) can't strand a cluster-wide egressDeny on the
-                  # Sovereign. Runs in addition to the inline delete below.
-                  # (reviewer PR #3072 — SIGKILL/OOM is the only uncovered
-                  # path; the policy only denies the 3 post-cutover upstreams
-                  # so a stray is the intended end-state, not a wedge.)
+                  # Sovereign (reviewer PR #3072 — SIGKILL/OOM is the only
+                  # uncovered path).
                   trap 'kubectl delete ciliumclusterwidenetworkpolicy cutover-egress-block --ignore-not-found=true 2>/dev/null || true' TERM EXIT
-                  echo "[egress-block-test] egressDeny applied — hidden runtime tethers will now surface as NotReady"
+                  echo "[egress-block-test] egressDeny applied (default-deny=${DEFAULT_DENY_EGRESS}) — hidden runtime tethers will now surface as NotReady"
                 else
                   echo "  WARN — egressDeny apply failed; assertion-only fallback (fail-safe)"
                 fi


### PR DESCRIPTION
## Problem
In `08-egress-block-test-job.yaml`, under the SHIPPED `egressTest.defaultDenyEgress: true` (#3678), the cluster-wide default-deny CiliumClusterwideNetworkPolicy was WRITTEN to `/work/egress-deny.yaml` but never applied: the `kubectl apply` + `POLICY_APPLIED="yes"` + teardown trap lived ONLY in the legacy subtractive `else` branch (`defaultDenyEgress: false`). Under the default this means:
- `POLICY_APPLIED` stays empty.
- The #3678 active call-home assertion is skipped (gated on `POLICY_APPLIED=yes`).
- The #3647 fresh-pull-under-deny-egress proof is skipped (same gate).
- The 600s survival window runs with NO egress policy applied → assertion-only hold.
- `cutoverComplete=true` could be earned WITHOUT a witnessed deny-egress — the opposite of the ADR-0002 sovereignty proof.

Found live on the permanent omantel.biz Sovereign during the #3374/#3376/#3379 walk (#4268).

## Fix
Hoist the `kubectl apply` + `POLICY_APPLIED="yes"` + teardown trap out of the legacy `else` branch into a single SHARED path that runs after the if/elif/else, applying whichever manifest the branch emitted (`/work/egress-deny.yaml`). Both the default-deny and the legacy-subtractive modes now apply their policy; the assertion-only fallback (zero public IPs / enforce-off) writes no file and correctly applies nothing.

## Validation
- `helm template` renders clean (5450 lines).
- `sh -n` AND `dash -n` on the extracted step-08 script pass (busybox-ash-compatible per #3634).
- Lockstep chart 0.1.78 -> 0.1.79 + blueprint.yaml 0.1.79 so Flux rolls the changed template.

Refs #3379. Cutover remains founder-gated (NOT triggered on the permanent env).