### PR TITLE
fix(org-provisioning): converge per-Org tertiary apps — image-pull + DSN-deadlock + stalwart-admin (Refs #4246)

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -226,7 +226,7 @@ spec:
       #         chart.spec.version:"*" stops resolving to it (SemVer 1.5.0 >
       #         1.4.38) and its non-proxied bitnamilegacy images stop tripping
       #         harbor-proxy-pull. Chart content byte-identical to 1.4.38.
-      version: 1.5.1
+      version: 1.5.2
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -195,6 +195,19 @@ write_files:
   # funnel/BSS mesh (admin/auth/billing/catalog/console/domain/gateway/marketplace/
   # notification/organization/provisioning) → marketplace 503. Point the reflect
   # lists at the post-#3383 mesh namespace. Refs #3383.
+  #
+  # #4246 (per-Org image-pull): per-Organization workload namespaces are created
+  # dynamically as `org-<uuid>` when an Organization is franchised — they CANNOT
+  # be enumerated statically here. Their HelmReleases run private
+  # `ghcr.io/openova-io/openova/*` runtime images (newapi-sandbox-bridge,
+  # services-metering-sidecar, openclaw-controller/-runtime, …) that need the
+  # `ghcr-pull` credential. Without a matching entry the reflector skips every
+  # `org-*` namespace → the private images fall back to an anonymous pull →
+  # `failed to fetch anonymous token … 401 Unauthorized` → ImagePullBackOff
+  # (bp-newapi + bp-openclaw never converge on the demo Org). The emberstack
+  # reflector treats each comma-separated entry as a REGULAR EXPRESSION
+  # (full-match), so `org-.*` auto-reflects `ghcr-pull` into every per-Org
+  # namespace the moment it is created. Refs #3383, #4246.
   - path: /var/lib/catalyst/ghcr-pull-secret.yaml
     permissions: '0600'
     content: |
@@ -205,9 +218,9 @@ write_files:
         namespace: flux-system
         annotations:
           reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "org-services,catalyst,catalyst-system,gitea,harbor,cert-manager,kube-system,flux-system,reflector,reloader,kyverno,opentelemetry,openbao,seaweedfs,powerdns,grafana,loki,mimir,tempo,alloy,coraza,crossplane-system,sigstore-system,trivy-system,syft-grype,falco,vpa,valkey,vllm,dmz,mgmt,rtz,external-dns,external-secrets,cnpg-system,velero,nats-system,sealed-secrets,newapi,huawei-evs-csi"
+          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "org-services,catalyst,catalyst-system,gitea,harbor,cert-manager,kube-system,flux-system,reflector,reloader,kyverno,opentelemetry,openbao,seaweedfs,powerdns,grafana,loki,mimir,tempo,alloy,coraza,crossplane-system,sigstore-system,trivy-system,syft-grype,falco,vpa,valkey,vllm,dmz,mgmt,rtz,external-dns,external-secrets,cnpg-system,velero,nats-system,sealed-secrets,newapi,huawei-evs-csi,org-.*"
           reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "org-services,catalyst,catalyst-system,gitea,harbor,cert-manager,kube-system,reflector,reloader,kyverno,opentelemetry,openbao,seaweedfs,powerdns,grafana,loki,mimir,tempo,alloy,coraza,crossplane-system,sigstore-system,trivy-system,syft-grype,falco,vpa,valkey,vllm,dmz,mgmt,rtz,external-dns,external-secrets,cnpg-system,velero,nats-system,sealed-secrets,newapi,huawei-evs-csi"
+          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "org-services,catalyst,catalyst-system,gitea,harbor,cert-manager,kube-system,reflector,reloader,kyverno,opentelemetry,openbao,seaweedfs,powerdns,grafana,loki,mimir,tempo,alloy,coraza,crossplane-system,sigstore-system,trivy-system,syft-grype,falco,vpa,valkey,vllm,dmz,mgmt,rtz,external-dns,external-secrets,cnpg-system,velero,nats-system,sealed-secrets,newapi,huawei-evs-csi,org-.*"
       type: kubernetes.io/dockerconfigjson
       data:
         .dockerconfigjson: ${base64encode(jsonencode({

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.5.1
+  version: 1.5.2
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for Organizations, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -403,8 +403,14 @@ name: bp-keycloak
 # images pass admission. No chart-content change beyond the version line + this
 # changelog — the 1.4.38 templates/values are byte-identical and already
 # proxy-compliant. Refs #3785 (sibling proxy-class defect for the WP image).
-version: 1.5.1
+version: 1.5.2
 description: |
+  1.5.2 (#4246): the per-tenant `openclaw-oidc-client-secret` Secret now
+  emits BOTH `client-secret` AND `OIDC_CLIENT_SECRET` keys (it previously
+  emitted only `client-secret`). The bp-openclaw controller Deployment
+  reads key `OIDC_CLIENT_SECRET`, so the single-key Secret left the per-Org
+  Pod in CreateContainerConfigError "couldn't find key OIDC_CLIENT_SECRET".
+  Mirrors the dual-key shape already used by the stalwart Secret.
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so
   `helm dependency build` pulls the upstream payload into this artifact;

--- a/platform/keycloak/chart/templates/configmap-tenant-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-tenant-realm.yaml
@@ -532,12 +532,18 @@ metadata:
       Per-tenant Keycloak OIDC client secret for the `openclaw` client
       registered in realm `{{ $t.realmName }}`. The bp-openclaw chart
       consumes this Secret via .Values.keycloak.clientSecretName
-      (default `openclaw-oidc-client-secret`). Bytes persist across
-      `helm upgrade` via lookup-or-generate (issue #915 / C1).
+      (default `openclaw-oidc-client-secret`); the controller Deployment's
+      secretKeyRef reads key `OIDC_CLIENT_SECRET` (chart default
+      bp-openclaw.oidc.clientSecretKey), so that key MUST be present —
+      emitting only `client-secret` left the per-Org bp-openclaw Pod in
+      CreateContainerConfigError "couldn't find key OIDC_CLIENT_SECRET"
+      (#4246). Emit BOTH keys (mirrors the stalwart Secret below). Bytes
+      persist across `helm upgrade` via lookup-or-generate (issue #915 / C1).
     helm.sh/resource-policy: keep
 type: Opaque
 stringData:
   client-secret: {{ $ocSecret | quote }}
+  OIDC_CLIENT_SECRET: {{ $ocSecret | quote }}
 {{- /* ── stalwart-oidc-client-secret ─────────────────────────────────── */}}
 ---
 apiVersion: v1

--- a/platform/keycloak/chart/tests/tenant-realm-oidc-clients.sh
+++ b/platform/keycloak/chart/tests/tenant-realm-oidc-clients.sh
@@ -220,6 +220,16 @@ sw_data = sw_secret.get('stringData') or sw_secret.get('data') or {}
 assert 'client-secret' in sw_data, "stalwart secret missing client-secret key"
 assert 'OIDC_CLIENT_SECRET' in sw_data, "stalwart secret missing OIDC_CLIENT_SECRET key"
 
+# #4246 — OpenClaw Secret MUST likewise carry BOTH keys. The bp-openclaw
+# controller Deployment's secretKeyRef reads key OIDC_CLIENT_SECRET (chart
+# default bp-openclaw.oidc.clientSecretKey); emitting only client-secret left
+# the per-Org Pod in CreateContainerConfigError "couldn't find key
+# OIDC_CLIENT_SECRET".
+oc_secret = secrets['openclaw-oidc-client-secret']
+oc_data = oc_secret.get('stringData') or oc_secret.get('data') or {}
+assert 'client-secret' in oc_data, "openclaw secret missing client-secret key"
+assert 'OIDC_CLIENT_SECRET' in oc_data, "openclaw secret missing OIDC_CLIENT_SECRET key (#4246)"
+
 # Realm secrets must match Secret bytes (single-template-scope invariant).
 def _val(s, key):
     sd = s.get('stringData') or {}

--- a/platform/openclaw/blueprint.yaml
+++ b/platform/openclaw/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-7-agentic-workspace
 spec:
-  version: 0.2.3
+  version: 0.2.4
   card:
     title: OpenClaw
     summary: |

--- a/platform/openclaw/chart/Chart.yaml
+++ b/platform/openclaw/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-openclaw
-version: 0.2.3
+version: 0.2.4
 appVersion: "0.2.0"
 description: |
   Catalyst Blueprint chart for the OpenClaw workspace controller pattern
@@ -31,6 +31,16 @@ description: |
 
   Changelog
   ─────────
+  0.2.4 (2026-06-24, #4246)
+    - Add `imagePullSecrets: [ghcr-pull]` (new top-level `imagePullSecrets`
+      value) to the controller Deployment AND the per-user-pod template.
+      The controller (`openclaw-controller`) + per-user-pod (`openclaw-
+      runtime`) images live under the PRIVATE
+      `ghcr.io/openova-io/openova/*` path; without a pull credential the
+      kubelet pulled them anonymously → `401 Unauthorized` → ImagePullBackOff
+      so the per-Org bp-openclaw HR never converged. The `ghcr-pull` Secret
+      is reflected into every per-Org namespace (see cloud-init `org-.*`
+      reflector match, #4246). Overlays may override/clear `imagePullSecrets`.
   0.2.0 (2026-05-05, umbrella #915)
     - Add canonical `oidc.{issuerURL,clientId,clientSecret}` block
       (per-tenant Keycloak SSO).

--- a/platform/openclaw/chart/templates/controller-deployment.yaml
+++ b/platform/openclaw/chart/templates/controller-deployment.yaml
@@ -23,6 +23,11 @@ spec:
         checksum/pod-template: {{ include (print $.Template.BasePath "/per-user-pod-template.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ include "bp-openclaw.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      # #4246 — private ghcr.io/openova-io/openova/openclaw-controller pull cred.
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.controller.securityContext | nindent 8 }}
       containers:

--- a/platform/openclaw/chart/templates/per-user-pod-template.yaml
+++ b/platform/openclaw/chart/templates/per-user-pod-template.yaml
@@ -40,6 +40,11 @@ data:
     spec:
       restartPolicy: Never
       automountServiceAccountToken: false
+      {{- with .Values.imagePullSecrets }}
+      # #4246 — private ghcr.io/openova-io/openova/openclaw-runtime pull cred.
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.perUserPod.securityContext | nindent 8 }}
       containers:

--- a/platform/openclaw/chart/values.yaml
+++ b/platform/openclaw/chart/values.yaml
@@ -42,6 +42,19 @@ catalystBlueprint:
 # render passes (the smoke run uses defaults — placeholders are valid
 # bytes for render-time syntax checks but non-functional at runtime).
 assertNoPlaceholders: false
+# ─── Image pull secrets (#4246) ──────────────────────────────────────────
+# The controller + per-user-pod images live under the PRIVATE
+# `ghcr.io/openova-io/openova/*` registry path, so every Pod that runs them
+# MUST present a dockerconfigjson pull credential. On a Sovereign the
+# `ghcr-pull` Secret is seeded in flux-system by cloud-init and reflected
+# into every per-Org namespace via the emberstack reflector (`org-.*`
+# match, #4246). Without these `imagePullSecrets` the kubelet falls back to
+# an anonymous pull → `failed to fetch anonymous token … 401 Unauthorized`
+# → ImagePullBackOff (bp-openclaw never converged on the demo Org). Default
+# to the canonical `ghcr-pull` name; an overlay may override or clear it for
+# clusters that mirror these images into a pull-through cache.
+imagePullSecrets:
+  - name: ghcr-pull
 # ─── Controller (multi-tenant) ───────────────────────────────────────────
 controller:
   enabled: true

--- a/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
@@ -1112,11 +1112,23 @@ spec:
         kind: HelmRepository
         name: bp-newapi
         namespace: flux-system
+  # #4246 — disableWait: the bp-newapi Deployment gates on a non-empty SQL_DSN
+  # via its wait-for-sql-dsn initContainer, and that DSN is PATCHed in by the
+  # chart's db-dsn-sync POST-INSTALL Helm hook (which composes the DSN from the
+  # CNPG cluster-app Secret). With wait enabled Helm blocks on the Deployment
+  # becoming Ready BEFORE it runs post-install hooks, so the init never unblocks
+  # (SQL_DSN stays empty), the install burns its 15m budget and exits with a
+  # context deadline, and the post-install DSN-sync hook never fires: a hard
+  # deadlock (verified on the omantel.biz demo Org 2026-06-24). disableWait lets
+  # the release reach hook execution, the DSN syncs, and the Pod converges.
+  # CNPG/Keycloak readiness is still gated by dependsOn below.
   install:
     timeout: 15m
+    disableWait: true
   upgrade:
     timeout: 15m
     cleanupOnFail: true
+    disableWait: true
   dependsOn:
     - name: bp-keycloak
       namespace: {{.Namespace}}
@@ -1702,14 +1714,21 @@ spec:
           key: sovereign/{{.OTECHFQDN}}/stalwart/{{.TenantID}}/oidc
           property: OIDC_CLIENT_SECRET
     admin:
+      # #4246 — DO NOT source ADMIN_PASSWORD from an ExternalSecret on a fresh
+      # per-Org install. Nothing seeds OpenBao at the
+      # sovereign/<fqdn>/stalwart/<tenant>/admin path when an Organization is
+      # franchised, so an enabled admin.externalSecret leaves the stalwart-admin
+      # Secret unmaterialised, the StatefulSet hits a missing-secret mount
+      # (secret stalwart-admin not found) and CreateContainerConfigError, and
+      # the bp-stalwart-tenant HR never converges (verified on the omantel.biz
+      # demo Org 2026-06-24; matches the chart's own #898 note in
+      # admin-secret.yaml). Leaving externalSecret disabled lets the chart's
+      # admin-secret.yaml auto-provision a persistent random ADMIN_PASSWORD
+      # (lookup-or-generate with resource-policy: keep). An operator who
+      # genuinely manages this credential in OpenBao can re-enable
+      # externalSecret in a cluster overlay.
       externalSecret:
-        enabled: true
-        secretStoreRef:
-          kind: ClusterSecretStore
-          name: vault-region1
-        remoteRef:
-          key: sovereign/{{.OTECHFQDN}}/stalwart/{{.TenantID}}/admin
-          property: ADMIN_PASSWORD
+        enabled: false
     # The post-install setup Job seeds the OIDC directory entry into
     # Stalwart's runtime settings KV store via ` + "`/api/settings`" + ` so
     # the very first webmail/IMAP/SMTP login flows through Keycloak.

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
@@ -752,6 +752,20 @@ func TestRenderOrganizationOverlay_NewAPIEmitted(t *testing.T) {
 		}
 	}
 
+	// #4246 — install.disableWait + upgrade.disableWait MUST be set. The Pod
+	// gates on a non-empty SQL_DSN that the chart's POST-INSTALL db-dsn-sync hook
+	// PATCHes in; with wait enabled Helm blocks on Pod-Ready before running that
+	// hook → permanent deadlock + 15m install timeout. disableWait breaks it.
+	for _, line := range []string{
+		"  install:",
+		"  upgrade:",
+		"    disableWait: true",
+	} {
+		if !strings.Contains(body, line) {
+			t.Errorf("bp-newapi.yaml missing disableWait line %q (#4246 DSN deadlock)\n--- rendered ---\n%s", line, body)
+		}
+	}
+
 	// Ingress hosts — customer-API + admin UI.
 	wantIngress := []string{
 		"      host: api.alice.omantel.omani.works",
@@ -1068,16 +1082,27 @@ func TestRenderOrganizationOverlay_StalwartEmitsKeycloakOIDC(t *testing.T) {
 	if !strings.Contains(body, wantRealmURL) {
 		t.Errorf("realmURL missing — want %s in body", wantRealmURL)
 	}
-	// Confidential client ID + ExternalSecret-store remoteRef path.
+	// Confidential client ID + the OIDC ExternalSecret-store remoteRef path.
+	// (The OIDC client secret IS materialised on a fresh Org — it is created by
+	// the per-Org Keycloak SSO bridge — so sourcing it from the store is valid.)
 	for _, want := range []string{
 		"clientID: stalwart",
 		"clientSecretName: stalwart-oidc-client-secret",
 		"sovereign/omantel.omani.works/stalwart/t-acme/oidc",
-		"sovereign/omantel.omani.works/stalwart/t-acme/admin",
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("expected %q in bp-stalwart-tenant.yaml — got:\n%s", want, body)
 		}
+	}
+	// #4246 — the ADMIN_PASSWORD must NOT be sourced from an ExternalSecret on a
+	// fresh per-Org install (nothing seeds OpenBao at .../stalwart/<tenant>/admin
+	// → CreateContainerConfigError). admin.externalSecret MUST be disabled so the
+	// chart auto-provisions a persistent random ADMIN_PASSWORD.
+	if strings.Contains(body, "sovereign/omantel.omani.works/stalwart/t-acme/admin") {
+		t.Errorf("admin ExternalSecret remoteRef must NOT be emitted (#4246) — fresh Org has no OpenBao admin seed")
+	}
+	if !strings.Contains(body, "admin:\n      # #4246") {
+		t.Errorf("expected admin block to carry the #4246 disabled-externalSecret note")
 	}
 	// dependsOn: bp-keycloak so the Helm install order is deterministic.
 	if !strings.Contains(body, "name: bp-keycloak") {


### PR DESCRIPTION
## What

Per-Org Organizations on a Sovereign never converged `bp-newapi`, `bp-openclaw`, or `bp-stalwart-tenant`. Root-caused live on the omantel.biz demo Org (dep `4635277cae4ffed9`, ns `org-7283eb4a-19e5-4e86-9066-d4aa26762064`). Four independent durable root causes, each fixed permanently (chart-version-bumped / template-fixed) so a fresh prov inherits the fix.

### 1. `ghcr-pull` never reflected into per-Org (`org-*`) namespaces
The reflector `reflection-allowed/auto-namespaces` lists in `infra/providers/_shared/cloudinit-control-plane.tftpl` (L208/L210) were a **static enumeration of platform namespaces** with no entry matching dynamic `org-<uuid>` namespaces. Private `ghcr.io/openova-io/openova/*` runtime images (`newapi-sandbox-bridge`, `services-metering-sidecar`, `openclaw-controller`, `openclaw-runtime`) fell back to an anonymous pull → `failed to fetch anonymous token … 401 Unauthorized` → ImagePullBackOff. **Fix:** add the regex `org-.*` to both reflector lists (emberstack reflector matches each entry as a regex) so `ghcr-pull` auto-reflects into every per-Org namespace on creation. *Live-confirmed:* after patching the live source secret, `ghcr-pull` appeared in the demo Org ns and the newapi sandbox-bridge init pulled successfully.

### 2. `bp-openclaw` chart never set `imagePullSecrets`
The controller Deployment + per-user-pod template referenced no pull secret, so even with `ghcr-pull` reflected the Pods had no credential. **Fix:** add a top-level `imagePullSecrets` value (default `ghcr-pull`) wired into both Pod specs. Chart `0.2.3 → 0.2.4`.

### 3. `bp-newapi` per-Org HR missing `disableWait` (DSN deadlock)
The Pod gates on a non-empty `SQL_DSN` via its `wait-for-sql-dsn` init; that DSN is PATCHed in by the chart's **post-install** `db-dsn-sync` hook. With wait enabled, Helm blocks on Pod-Ready **before** running post-install hooks → the init never unblocks (`SQL_DSN` stays `""`) → 15m install timeout context-deadline → permanent deadlock. *Live-confirmed:* the live DSN secret key was `SQL_DSN: ""` and the gate logged `waiting for a non-empty SQL_DSN`. **Fix:** set `install.disableWait` + `upgrade.disableWait` on the per-Org HR.

### 4. `bp-stalwart-tenant` per-Org HR admin secret from unseeded OpenBao
The HR enabled `admin.externalSecret` pointing at `sovereign/<fqdn>/stalwart/<tenant>/admin` — a path nothing seeds on a fresh Org — leaving `stalwart-admin` unmaterialised → `secret "stalwart-admin" not found` → CreateContainerConfigError. This is the chart's own #898 anti-pattern. **Fix:** disable the admin `externalSecret` so the chart auto-provisions a persistent random `ADMIN_PASSWORD` (lookup-or-generate, `resource-policy: keep`).

## Tests
- `TestRenderOrganizationOverlay_NewAPIEmitted` — asserts `install/upgrade.disableWait: true`.
- `TestRenderOrganizationOverlay_StalwartEmitsKeycloakOIDC` — asserts admin ESO remoteRef NOT emitted + auto-provision note present; OIDC ESO retained.
- `platform/openclaw/chart/tests/render-toggles.sh` + `helm template` confirm `imagePullSecrets: [ghcr-pull]` renders on both Pod specs.
- `go test ./internal/handler/` green.

## No regression
Each change is additive: the reflector lists keep every existing platform namespace; the openclaw `imagePullSecrets` value is overridable/clearable; `disableWait` does not touch `dependsOn` (CNPG/Keycloak ordering preserved); stalwart OIDC ESO + setup Job unchanged.

Refs #4246

🤖 Generated with [Claude Code](https://claude.com/claude-code)