### PR TITLE
fix(bp-catalyst-platform): per-Application GitRepository clones Gitea WITH auth — console-created Applications converge (1.4.826)

### DIFF
--- a/core/controllers/application/internal/controller/application_controller_test.go
+++ b/core/controllers/application/internal/controller/application_controller_test.go
@@ -1033,6 +1033,81 @@ func TestReconcile_HostFluxBootstrap_CreatesGitRepoAndKustomization(t *testing.T
 	}
 }
 
+// TestReconcile_HostFluxBootstrap_GitRepositorySecretRef asserts the
+// per-Application GitRepository carries spec.secretRef.name when the
+// controller is configured with a FluxGiteaSecretRef, and omits it when
+// empty. This is the #4283 fix: bp-gitea runs REQUIRE_SIGNIN_VIEW=true so
+// an anonymous clone (absent secretRef) 401s "authentication required",
+// the per-app Kustomization reports "Source artifact not found", and the
+// console-created Application never reaches Ready (proven live on
+// omantel.biz dep 4635277cae4ffed9: shared-pg-d stuck Provisioning,
+// shared-pg-e Failed). The canonical Sovereign now defaults
+// controllers.application.fluxGiteaSecretRef=openova-org-tenants-git-auth
+// (values.yaml) — the SAME shared gitea_admin basic-auth Secret the
+// organization-controller already clones every per-Org catalyst-tenant
+// repo with (the proven #3454/#3376 pattern). Mirrors
+// per_org_flux_test.go's secretRef parity assertion.
+func TestReconcile_HostFluxBootstrap_GitRepositorySecretRef(t *testing.T) {
+	const secretName = "openova-org-tenants-git-auth"
+
+	newReconcilerWithSecretRef := func(t *testing.T, fg *fakeGitea, ref string, objs ...*unstructured.Unstructured) *Reconciler {
+		t.Helper()
+		r := newReconciler(t, fg, objs...)
+		r.Cfg.FluxGiteaSecretRef = ref
+		return r
+	}
+
+	// 1. Configured: secretRef stamped.
+	t.Run("present_when_configured", func(t *testing.T) {
+		bp := makeBlueprint("bp-pg", "1.0.0", nil, []string{"single-region"})
+		env := makeEnv("acme-prod", "acme", "prod")
+		org := makeOrg("acme")
+		app := makeApp("acme", "db", "acme-prod", "bp-pg", "1.0.0", "single-region",
+			[]string{"hetzner-fsn-rtz-prod"},
+			map[string]interface{}{"replicas": int64(1)})
+		fg := newFakeGitea()
+		fg.orgsExist["acme"] = true
+		r := newReconcilerWithSecretRef(t, fg, secretName, app, env, org, bp)
+
+		reconcileFromCluster(t, r, "acme", "db")
+
+		gr, err := r.Dynamic.Resource(FluxGitRepositoryGVR).Namespace("flux-system").
+			Get(context.Background(), "catalyst-app-acme-db", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected GitRepository catalyst-app-acme-db: %v", err)
+		}
+		name, found, _ := unstructured.NestedString(gr.Object, "spec", "secretRef", "name")
+		if !found || name != secretName {
+			t.Errorf("GitRepository.spec.secretRef.name = %q (found=%v), want %q — anonymous clone 401s against bp-gitea REQUIRE_SIGNIN_VIEW=true (#4283)",
+				name, found, secretName)
+		}
+	})
+
+	// 2. Empty: secretRef absent (operator opt-out path stays valid).
+	t.Run("absent_when_empty", func(t *testing.T) {
+		bp := makeBlueprint("bp-pg", "1.0.0", nil, []string{"single-region"})
+		env := makeEnv("acme-prod", "acme", "prod")
+		org := makeOrg("acme")
+		app := makeApp("acme", "db2", "acme-prod", "bp-pg", "1.0.0", "single-region",
+			[]string{"hetzner-fsn-rtz-prod"},
+			map[string]interface{}{"replicas": int64(1)})
+		fg := newFakeGitea()
+		fg.orgsExist["acme"] = true
+		r := newReconcilerWithSecretRef(t, fg, "", app, env, org, bp)
+
+		reconcileFromCluster(t, r, "acme", "db2")
+
+		gr, err := r.Dynamic.Resource(FluxGitRepositoryGVR).Namespace("flux-system").
+			Get(context.Background(), "catalyst-app-acme-db2", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected GitRepository catalyst-app-acme-db2: %v", err)
+		}
+		if _, found, _ := unstructured.NestedMap(gr.Object, "spec", "secretRef"); found {
+			t.Errorf("GitRepository.spec.secretRef must be absent when FluxGiteaSecretRef is empty (operator opt-out)")
+		}
+	})
+}
+
 // TestReconcile_HostFluxBootstrap_FanOutOnePerRegion asserts an
 // active-active Application with N regions produces 1 GitRepository
 // (shared by all regions on the same per-app Gitea repo) and N

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3004,7 +3004,19 @@ name: bp-catalyst-platform
 #   catalyst-api runs in catalyst-system. Pure-additive: priorityClassName/Value are new
 #   values, default-on; no other behaviour changes. Chart-version bump forces the Flux
 #   re-pull (the deploy-bot mutable-tag trap, #4257).
-version: 1.4.825
+# 1.4.826 — #4283: the application-controller's per-Application GitRepository
+#   (catalyst-app-<org>-<app>, ensureHostFluxBootstrap) now clones the Sovereign-local
+#   Gitea WITH auth. controllers.application.fluxGiteaSecretRef was "" (anonymous) — but
+#   bp-gitea sets REQUIRE_SIGNIN_VIEW=true so anonymous clone 401s "authentication
+#   required", the per-app Kustomization reports "Source artifact not found", and the
+#   console-created Application never reaches Ready (proven live omantel.biz dep
+#   4635277cae4ffed9: shared-pg-d stuck Provisioning, shared-pg-e Failed). Default flipped
+#   to the SAME openova-org-tenants-git-auth Secret the organization-controller already
+#   clones every per-Org catalyst-tenant repo with (the proven #3454/#3376 pattern; the
+#   gitea_admin PAT clones every Org's per-app repo). Secret pre-exists in flux-system via
+#   the gitea-flux-auth-secrets-sync-job post-install hook (#3749/#3668). Pure values
+#   default change; operator-overridable. Chart-version bump forces the Flux re-pull.
+version: 1.4.826
 # 1.4.774 — #4082: application-controller ClusterRole gains dr.openova.io/continuums
 #   (get/list/watch/create/update/patch/delete) — was in the controller's own
 #   deploy/rbac.yaml but MISSING from this platform chart, so a singleton /

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -907,9 +907,32 @@ controllers:
     # Kustomization (seconds). Defaults to 60s for fast initial Pod
     # spin-up; operators with hundreds of Apps may raise this.
     hostFluxIntervalSeconds: 60
-    # Optional Secret in HostFluxNamespace holding the Gitea token Flux
-    # uses to clone. Empty = anonymous (acceptable for in-cluster Gitea).
-    fluxGiteaSecretRef: ""
+    # Flux basic-auth Secret (in hostFluxNamespace) holding the Gitea PAT
+    # the per-Application GitRepository (catalyst-app-<org>-<app>,
+    # ensureHostFluxBootstrap) uses to clone. bp-gitea sets
+    # service.REQUIRE_SIGNIN_VIEW=true (platform/gitea/chart/values.yaml) —
+    # anonymous clone is disabled cluster-wide, so an EMPTY secretRef makes
+    # source-controller clone anonymously, Gitea 401s with "authentication
+    # required", the per-app Kustomization reports "Source artifact not
+    # found", and the console-created Application never reaches Ready (proven
+    # live on omantel.biz dep 4635277cae4ffed9: shared-pg-d stuck
+    # Provisioning, shared-pg-e Failed — #4283).
+    #
+    # `openova-org-tenants-git-auth` is the SAME shared Flux basic-auth Secret
+    # the organization-controller already clones every per-Org catalyst-tenant
+    # repo with (controllers.organization.fluxGiteaSecretRef above, the proven
+    # #3454 / #3376 pattern). It holds the gitea_admin PAT, so it can clone
+    # EVERY Org's per-Application repo — no per-app secret needed. The Secret
+    # is guaranteed to exist in flux-system by the
+    # catalog-sovereign-flux/gitea-flux-auth-secrets-sync-job.yaml
+    # post-install/post-upgrade hook (#3749 / #3668), which reads the
+    # runtime-minted catalyst-gitea-token PAT via secretKeyRef and applies it,
+    # so a fresh prov gets it the first time and any chart bump re-asserts it.
+    #
+    # Per Inviolable Principle #4 the secret name stays operator-overridable;
+    # set to "" to force anonymous clone (only valid if bp-gitea ever drops
+    # REQUIRE_SIGNIN_VIEW AND the per-app repo is made public).
+    fluxGiteaSecretRef: "openova-org-tenants-git-auth"
     env: {}
     nodeSelector: {}
     tolerations: []


### PR DESCRIPTION
## Root cause (one-line value divergence — proven live)
Console-created Applications fail to converge on omantel.biz dep `4635277cae4ffed9`:
- `shared-pg-d` (singleton, rtz) → Application stuck **Provisioning**.
- `shared-pg-e` (active-hot-standby, 2 regions) → Application **Failed**.

Decisive live event:
```
Warning GitOperationFailed gitrepository/catalyst-app-omantel-biz-shared-pg-d
  failed to checkout and determine revision: unable to clone
  'http://gitea-http.gitea.svc.cluster.local:3000/omantel-biz/shared-pg-d.git': authentication required
```
Failure chain (all confirmed live):
1. `GitRepository catalyst-app-omantel-biz-shared-pg-d` has **no `spec.secretRef`** (`get gitrepository` SECRET column = `<none>`) → source-controller clones anonymously → bp-gitea `REQUIRE_SIGNIN_VIEW=true` → 401 `authentication required`.
2. `Kustomization catalyst-app-omantel-biz-shared-pg-d-me-east-215-a` → `Source artifact not found, retrying`.
3. Application never reaches Ready.

The application-controller stamps `secretRef` only when `Cfg.FluxGiteaSecretRef != ""` (`application_controller.go:1553`), and `values.yaml:912` defaulted `controllers.application.fluxGiteaSecretRef: ""` with a factually-wrong comment (`Empty = anonymous (acceptable)` — never true under `REQUIRE_SIGNIN_VIEW=true`).

The **organization-controller** path already learned this (#3454/#3749): `values.yaml:751` sets `controllers.organization.fluxGiteaSecretRef: "openova-org-tenants-git-auth"` — and **every live `catalyst-tenant-*` GitRepository clones successfully with SECRET=`openova-org-tenants-git-auth`, READY=True**. The application-controller (console-created Applications) was the one face left on the anonymous default.

## Relationship to #3376
Same root class. #3376's funnel/purchased-app fix wired the **organization-controller** (per-Org) source auth. This wires the **application-controller** (console-created Application) source auth — same shared `gitea_admin` basic-auth Secret, same fix shape. Two faces of the one per-app/per-Org Gitea-auth contract.

## Durable fix
- `products/catalyst/chart/values.yaml`: `controllers.application.fluxGiteaSecretRef` default `""` → `"openova-org-tenants-git-auth"` + corrected rationale comment. The Secret pre-exists in flux-system (live-confirmed present) via the `gitea-flux-auth-secrets-sync-job` post-install/post-upgrade hook (#3749/#3668) — the `gitea_admin` PAT clones every Org's per-app repo, so one shared Secret authenticates all Applications. No per-app secret, no new bootstrap state.
- `products/catalyst/chart/Chart.yaml`: `1.4.825` → `1.4.826` (mutable-tag trap — forces Flux re-pull).
- `application_controller_test.go`: parity test — per-app GitRepository carries `spec.secretRef.name` when configured, omits it when empty (mirrors `per_org_flux_test.go`).

Wiring chain validated end-to-end: values → `FLUX_GITEA_SECRET_REF` env (`helm template` confirmed renders `openova-org-tenants-git-auth`) → `main.go` → `Config.FluxGiteaSecretRef` → `ensureHostFluxBootstrap` stamps `spec.secretRef` (unit test confirmed).

## Validation evidence
- `go build ./application/...` — green.
- `go test ./application/...` — full suite green incl. new `TestReconcile_HostFluxBootstrap_GitRepositorySecretRef` (`present_when_configured` + `absent_when_empty`).
- `helm template` of the application-controller deployment renders `FLUX_GITEA_SECRET_REF: "openova-org-tenants-git-auth"`.
- Live: the working `openova-org-tenants-git-auth` Secret exists in flux-system; every `catalyst-tenant-*` GitRepository clones with it (READY=True), proving the same Secret authenticates the failing per-app repos.

## Roll needed to make new postgres Applications converge
This is the PERMANENT omantel.biz env — **NOT auto-merging / not rolling.** To make a new Application converge after merge:
1. Build + push catalyst-api/controller images and bump `bp-catalyst-platform` to `1.4.826` on the Sovereign's pinned chart (the deploy-bot path).
2. Flux re-renders the application-controller Deployment with `FLUX_GITEA_SECRET_REF=openova-org-tenants-git-auth`; the controller re-reconciles and stamps `spec.secretRef` onto each per-app GitRepository (`catalyst-app-omantel-biz-shared-pg-d`, `-shared-pg-e`, `-agenity`).
3. source-controller clones with auth → Kustomization finds the artifact → CNPG Cluster renders → Application reaches Ready.

For the two ALREADY-created wedged GitRepositories, the controller's `upsertHostResource` drift-restore re-stamps `secretRef` on the next reconcile after the rolled controller starts — no manual GitRepository edit required.

## Honest limits
Proven without a deploy: the root cause (live evidence), the wiring chain (helm template + unit tests), and that the chosen Secret already authenticates the analogous per-Org sources live. NOT proven without a deploy: the end-to-end Application-reaches-Ready convergence on omantel.biz, since that needs the controller rolled with the new env var (flagged for founder green-light per the PERMANENT-env discipline).

Refs #4283 #3376

🤖 Generated with [Claude Code](https://claude.com/claude-code)