### PR TITLE
feat(console+catalog): HelmReleases Target Namespace column + sync bp-postgres catalog-seed to 0.2.5 (active-hot-standby)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1080,6 +1080,10 @@ spec:
       #   storm that fills the node's ephemeral disk evicts THOSE reschedulable Pods
       #   first instead of the EVS-node-pinned (#4102) control-plane API (~17min
       #   console outage, omantel.biz 2026-06-24). Chart.yaml bumped in lockstep.
+      # 1.4.830 — #4281 + #4282: console Cloud HelmReleases list gains a
+      #   "Target Namespace" column (spec.targetNamespace) + catalog-seed
+      #   bp-postgres synced to 0.2.5 (placement modes incl. active-hot-standby
+      #   + topology configSchema). Chart.yaml bumped in lockstep.
       # 1.4.829 — #4280: catalog name + light/dark logo editing no longer silently
       #   vanishes for the Sovereign owner (auth.go owner-is-admin on the KC-reachable-
       #   not-in-group branch + CatalogDetail always-visible dual-logo profile pair +
@@ -1090,7 +1094,7 @@ spec:
       #   (application/organization/environment controllers) + adds the missing
       #   catalogSovereign secretRef values block + flips the env-controller's
       #   phantom gitea-flux-token default. Chart.yaml bumped in lockstep.
-      version: 1.4.829
+      version: 1.4.830
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/k8sColumns.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/k8sColumns.ts
@@ -71,6 +71,28 @@ export const COL_NAMESPACE: K8sListColumn = {
   extract: (o) => o.metadata?.namespace ?? '—',
 }
 
+/**
+ * COL_TARGET_NAMESPACE — where a Flux HelmRelease actually installs its
+ * workload (`spec.targetNamespace`), as opposed to where the HelmRelease
+ * RECORD lives (`metadata.namespace`). For host-shared platform
+ * Blueprints every HelmRelease record sits in `flux-system`, which made
+ * the list read as if everything is dumped there (#4281); the real
+ * workload home is the targetNamespace (catalyst-system, cert-manager,
+ * kube-system, …). Helm defaults the install namespace to the release
+ * namespace when `spec.targetNamespace` is unset, so an empty value
+ * falls back to `metadata.namespace` to match runtime reality.
+ */
+export const COL_TARGET_NAMESPACE: K8sListColumn = {
+  header: 'Target Namespace',
+  extract: (o) => {
+    const target = (o.spec as Record<string, unknown> | undefined)?.[
+      'targetNamespace'
+    ] as string | undefined
+    if (target && target.trim() !== '') return target
+    return o.metadata?.namespace ?? '—'
+  },
+}
+
 export const COL_AGE: K8sListColumn = {
   header: 'Age',
   extract: (o) => {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kinds.test.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kinds.test.ts
@@ -27,6 +27,7 @@ import {
   colReconcileStatus,
   colCnpgStatus,
   colCatalystCrStatus,
+  COL_TARGET_NAMESPACE,
 } from './k8sColumns'
 
 /** The reconciler chip ids the founder required (#3978). */
@@ -204,5 +205,46 @@ describe('reconcile-status helpers use the Reconciliation vocabulary', () => {
       status: { phase: 'Ready' },
     }
     expect(colCatalystCrStatus().extract(o)).toBe('Reconciled')
+  })
+})
+
+describe('COL_TARGET_NAMESPACE — workload home, not the flux-system record (#4281)', () => {
+  it('has the "Target Namespace" header', () => {
+    expect(COL_TARGET_NAMESPACE.header).toBe('Target Namespace')
+  })
+
+  it('shows spec.targetNamespace — the real workload home', () => {
+    // A host-shared platform Blueprint: the HelmRelease record lives in
+    // flux-system but the workload runs in catalyst-system.
+    const hr: K8sObject = {
+      apiVersion: 'helm.toolkit.fluxcd.io/v2',
+      kind: 'HelmRelease',
+      metadata: { name: 'bp-catalyst-platform', namespace: 'flux-system' },
+      spec: { targetNamespace: 'catalyst-system' },
+    }
+    expect(COL_TARGET_NAMESPACE.extract(hr)).toBe('catalyst-system')
+  })
+
+  it('falls back to metadata.namespace when targetNamespace is unset (Helm default)', () => {
+    // Helm installs into the release namespace when spec.targetNamespace
+    // is absent — so the column reflects runtime reality, not a "—".
+    const hr: K8sObject = {
+      metadata: { name: 'vcluster', namespace: 'acme' },
+      spec: {},
+    }
+    expect(COL_TARGET_NAMESPACE.extract(hr)).toBe('acme')
+  })
+
+  it('treats a blank/whitespace targetNamespace as unset (falls back)', () => {
+    const hr: K8sObject = {
+      metadata: { name: 'x', namespace: 'demo' },
+      spec: { targetNamespace: '   ' },
+    }
+    expect(COL_TARGET_NAMESPACE.extract(hr)).toBe('demo')
+  })
+
+  it('renders "—" when neither targetNamespace nor metadata.namespace exist', () => {
+    const hr: K8sObject = { metadata: { name: 'x' } }
+    expect(COL_TARGET_NAMESPACE.extract(hr)).toBe('—')
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kindsPages.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kindsPages.tsx
@@ -12,6 +12,7 @@ import { K8sListPage } from './K8sListPage'
 import {
   COL_NAME,
   COL_NAMESPACE,
+  COL_TARGET_NAMESPACE,
   COL_AGE,
   colSpec,
   colStatus,
@@ -711,10 +712,15 @@ export function HelmReleasesListPage() {
     <K8sListPage
       kind="helmrelease"
       title="HelmReleases"
-      tagline="Flux HelmReleases — one per installed Blueprint. Chart / revision / reconcile state."
+      tagline="Flux HelmReleases — one per installed Blueprint. Target namespace / chart / revision / reconcile state."
       columns={[
         COL_NAMESPACE,
         COL_NAME,
+        // #4281 — the HelmRelease RECORD lives in flux-system for every
+        // host-shared platform Blueprint; the workload actually runs in
+        // spec.targetNamespace. Surface it so the operator sees the real
+        // home, not a misleading "everything's in flux-system".
+        COL_TARGET_NAMESPACE,
         {
           header: 'Chart',
           extract: (o) => {

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3004,6 +3004,23 @@ name: bp-catalyst-platform
 #   catalyst-api runs in catalyst-system. Pure-additive: priorityClassName/Value are new
 #   values, default-on; no other behaviour changes. Chart-version bump forces the Flux
 #   re-pull (the deploy-bot mutable-tag trap, #4257).
+# 1.4.830 — #4281 + #4282 (two console/catalog fixes, one chart bump):
+#   #4281 — console Cloud HelmReleases list gains a "Target Namespace" column
+#     (spec.targetNamespace, falling back to metadata.namespace). Host-shared
+#     platform Blueprints keep their HR RECORD in flux-system while the
+#     workload runs in its target namespace (catalyst-system, cert-manager,
+#     kube-system, …); the list now surfaces the real workload home instead
+#     of looking like everything is dumped in flux-system. UI-only (the
+#     k8scache redactor already preserves spec.targetNamespace on the wire).
+#   #4282 — catalog-seed bp-postgres synced to platform/postgres/blueprint.yaml
+#     (#3784, commit 509a6ec8e): spec.version 0.1.6→0.2.5, source.version
+#     0.1.6→0.2.5, placementSchema.modes legacy [single-region, active-active]
+#     → canonical [singleton, active-active, active-hot-standby, active-passive],
+#     and the previously-absent configSchema.topology block (mode enum
+#     [singleton, active-hot-standby]) — so a multi-region active-hot-standby
+#     pick is no longer rejected by the stale Blueprint CR (shared-pg-e Failed).
+#     Lockstep-guard fields (topology.supported / endpoints / sso / shareable /
+#     contextSchema) were already aligned and stay green.
 # 1.4.829 — #4280: catalog name + light/dark logo editing no longer silently vanishes for
 #   the Sovereign owner. (api) auth.go pinSessionAuthority now grants the configured owner
 #   (OPERATOR_EMAIL) tier=admin even when Keycloak is REACHABLE but the realm seed hasn't
@@ -3039,7 +3056,7 @@ name: bp-catalyst-platform
 #   every secret name stays operator-overridable; external ghcr/upstream sources are
 #   untouched (the guard applies only to the local-Gitea/Harbor host). Clean version tag
 #   forces the Flux re-pull (deploy-bot mutable-tag trap).
-version: 1.4.829
+version: 1.4.830
 # 1.4.774 — #4082: application-controller ClusterRole gains dr.openova.io/continuums
 #   (get/list/watch/create/update/patch/delete) — was in the controller's own
 #   deploy/rbac.yaml but MISSING from this platform chart, so a singleton /

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -6390,7 +6390,7 @@ metadata:
     # must not claw it back (DoD §9.4).
     helm.sh/resource-policy: keep
 spec:
-  version: "0.1.6"
+  version: "0.2.5"
   visibility: listed
   # Shareability + Contexts (#3370) — seeded verbatim from
   # platform/postgres/blueprint.yaml (lockstep-guarded). One instance
@@ -6415,9 +6415,67 @@ spec:
     license: "Apache-2.0"
     tags: [database, postgres, sql, data, shareable, cnpg, adr-0010]
     docs: "https://cloudnative-pg.io/documentation/"
+  # Seeded verbatim from platform/postgres/blueprint.yaml spec.configSchema
+  # (#3784, commit 509a6ec8e). The topology block is what the bp-postgres
+  # Blueprint CR validates a picked mode against — the seed previously
+  # lacked it, so a multi-region active-hot-standby pick was rejected
+  # before anything built (#4282, shared-pg-e Failed). singleton =
+  # single-instance Cluster; active-hot-standby = synchronous replication
+  # across regions (ADR-0004 Pillar-3 zero-tx-loss).
+  configSchema:
+    type: object
+    properties:
+      enabled:
+        type: boolean
+        default: true
+        description: |
+          Master gate. false → the install renders ZERO resources (an
+          empty Ready release). The bootstrap-kit slot 16a wires this to
+          ${SOVEREIGN_ENABLE_SHARED_PG:=false} so a non-sharing Sovereign
+          gets a Ready bp-postgres-shared HR without deploying an unused
+          shared-pg Cluster.
+      instance:
+        type: object
+        description: |
+          The data instance (one CNPG Cluster). name surfaces as the
+          App-card title and the dependsOn target consumers reference.
+        properties:
+          name:
+            type: string
+            default: postgres
+            description: Cluster name = the data-instance identity.
+          storageSize:
+            type: string
+            default: "5Gi"
+            description: Per-instance PVC size (k8s resource quantity).
+          pgVersion:
+            type: string
+            default: "16"
+            description: PostgreSQL major version (CNPG image tag).
+      topology:
+        type: object
+        properties:
+          mode:
+            type: string
+            enum: [singleton, active-hot-standby]
+            default: singleton
+            description: |
+              singleton = single-instance Cluster (no cross-region HA).
+              active-hot-standby = multi-instance Cluster with synchronous
+              replication across regions (ADR-0004 Pillar-3 zero-tx-loss).
+          instances:
+            type: integer
+            minimum: 1
+            maximum: 5
+            default: 1
   placementSchema:
-    modes: [single-region, active-active]
-    default: single-region
+    # Canonical placement vocabulary (#3375 / #3768 / #3784). The catalog
+    # New-instance picker reads these modes off the wire; the seed
+    # previously served the BANNED legacy dialect single-region /
+    # active-active. Aligned to placement.CanonicalModes so the picker
+    # offers all four canonical classes and never a banned spelling.
+    modes: [singleton, active-active, active-hot-standby, active-passive]
+    default: singleton
   manifests:
     chart: bp-postgres
   source:
@@ -6425,7 +6483,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-postgres
-    version: 0.1.6
+    version: 0.2.5
   # Seeded verbatim from platform/postgres/blueprint.yaml spec.topology.
   # singleton = single-instance Cluster; active-hot-standby = sync
   # replication across regions (ADR-0004 Pillar-3 zero-tx-loss) via the


### PR DESCRIPTION
Two small independent fixes, one chart-version bump (**1.4.825 → 1.4.826**). I reconcile this version across parallel PRs.

## FIX 1 — Console "Target Namespace" column (#4281)

The Cloud HelmReleases list (`/cloud?view=list&kind=helmreleases`) showed each HelmRelease's own `metadata.namespace` — which is `flux-system` for every host-shared platform Blueprint — and had **no** column for where the workload actually runs (`spec.targetNamespace`). It looked like everything is dumped in flux-system; it is not (only the Flux records live there).

**Build:** added a reusable `COL_TARGET_NAMESPACE` (reads `spec.targetNamespace`, falls back to `metadata.namespace` when empty — Helm installs into the release namespace by default) and wired it into `HelmReleasesListPage`, between Name and Chart. Styling/tone tokens unchanged (plain-text column, same as `COL_NAMESPACE`).

**Cloud API note:** no backend change needed. The k8scache redactor (`bootstrap/api/internal/k8scache/redact.go`) already preserves `spec` + `status` on the SSE wire, so `spec.targetNamespace` was already present on every HelmRelease object — the column just surfaces it. Live-confirmed on `omantel-region-a`: `flux-system` HRs carry distinct targets (`catalyst-system`, `cert-manager`, `kube-system`, …) while in-vCluster `vcluster` HRs have `<none>` and correctly fall back to their record namespace.

Files:
- `products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/k8sColumns.ts` — new `COL_TARGET_NAMESPACE`
- `products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kindsPages.tsx` — import + column in `HelmReleasesListPage`
- `products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kinds.test.ts` — 5 new unit tests

## FIX 2 — Postgres catalog-seed sync for active-hot-standby (#4282)

`shared-pg-e` Failed because the catalog-seed `bp-postgres` was a stale copy: `spec.version` **0.1.6** + `source.version` **0.1.6** + the **banned legacy** `placementSchema.modes [single-region, active-active]`, and **no `configSchema`** at all. The Sovereign's bp-postgres Blueprint CR therefore rejected an `active-hot-standby` topology pick before anything built.

**Build:** synced the seed to `platform/postgres/blueprint.yaml` (#3784, commit 509a6ec8e) — the source of truth:
- `spec.version` 0.1.6 → **0.2.5**
- `spec.source.version` 0.1.6 → **0.2.5**
- `placementSchema.modes` → canonical **`[singleton, active-active, active-hot-standby, active-passive]`**, default `singleton`
- added the previously-absent `configSchema.topology` block (mode enum **`[singleton, active-hot-standby]`**) + `enabled`/`instance` properties, verbatim from the platform source

The lockstep-guarded fields (`topology.supported` / `endpoints` / `sso` / `shareable` / `contextSchema`) were already aligned and stay green — `check-catalog-seed-lockstep.sh` does not gate on version/modes/configSchema, which is why the stale entry slipped through.

File:
- `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` (~L6393/6419)

**Other lagging seeds found (noted, not fixed):** a `spec.version` drift audit across all 69 seeded Blueprints with a platform source found ~35 entries whose seed `spec.version` lags the platform `spec.version` (e.g. bp-newapi 1.4.63 vs 1.4.125, bp-keycloak 1.0.0 vs 1.5.2, bp-openbao 1.2.25 vs 1.2.51, bp-gitea 1.2.24 vs 1.2.40, …). Postgres was the only one where the staleness was a **functional placement/mode-validation reject**, not just a cosmetic version-number lag; the rest are catalog-hygiene and out of this change's verified scope. Worth a follow-up sweep.

## Gates
- `tsc -b --noEmit`: clean
- `vitest` cloud-list: **80/80** (incl. 5 new `COL_TARGET_NAMESPACE` tests)
- `helm template` full chart: exit 0
- `scripts/check-catalog-seed-lockstep.sh`: PASS (69 checked, 0 fail)

Refs #4281 #4282

🤖 Generated with [Claude Code](https://claude.com/claude-code)