### PR TITLE
fix(bp-catalyst-platform): permanent root-cause for Flux→local-Gitea 'authentication required' — one shared fluxsource builder + guard across all generators (1.4.827)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1080,7 +1080,13 @@ spec:
       #   storm that fills the node's ephemeral disk evicts THOSE reschedulable Pods
       #   first instead of the EVS-node-pinned (#4102) control-plane API (~17min
       #   console outage, omantel.biz 2026-06-24). Chart.yaml bumped in lockstep.
-      version: 1.4.825
+      # 1.4.827 — #4285 (folds #4284): permanent root-cause for the generic
+      #   Flux→local-Gitea "authentication required" class — one shared fluxsource
+      #   builder + guard makes every local-Gitea source carry spec.secretRef
+      #   (application/organization/environment controllers) + adds the missing
+      #   catalogSovereign secretRef values block + flips the env-controller's
+      #   phantom gitea-flux-token default. Chart.yaml bumped in lockstep.
+      version: 1.4.827
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/core/controllers/application/internal/controller/application_controller.go
+++ b/core/controllers/application/internal/controller/application_controller.go
@@ -65,6 +65,7 @@ import (
 	"github.com/openova-io/openova/core/controllers/internal/placement"
 	"github.com/openova-io/openova/core/controllers/internal/semver"
 	bpv1alpha1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
+	"github.com/openova-io/openova/core/controllers/pkg/fluxsource"
 	"github.com/openova-io/openova/core/controllers/pkg/gitea"
 	"github.com/openova-io/openova/core/controllers/pkg/render"
 	"github.com/openova-io/openova/core/controllers/pkg/validate"
@@ -931,14 +932,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 			continuumOwnerLabels = fanoutOwnerLabels(envSpec, app)
 
 			hrs, ferr := topo.FanoutHRs(topo.FanoutInputs{
-				AppName:             app.GetName(),
-				AppNamespace:        app.GetNamespace(),
-				WriteNamespace:      fanoutWriteNamespace,
-				Topology:            choice,
-				Variant:             fanoutVariant,
-				Chart:               firstNonEmpty(blueprintChart(bp), spec.BlueprintName),
-				ChartVersion:        spec.BlueprintVersion,
-				SourceRefName:       ifEmpty(fanoutSourceRef, r.Cfg.CatalogSourceRef),
+				AppName:        app.GetName(),
+				AppNamespace:   app.GetNamespace(),
+				WriteNamespace: fanoutWriteNamespace,
+				Topology:       choice,
+				Variant:        fanoutVariant,
+				Chart:          firstNonEmpty(blueprintChart(bp), spec.BlueprintName),
+				ChartVersion:   spec.BlueprintVersion,
+				SourceRefName:  ifEmpty(fanoutSourceRef, r.Cfg.CatalogSourceRef),
 				// #4079 — default the source kind when the Blueprint omits
 				// spec.manifests.source.kind. The catalog source
 				// (`openova-catalog`) is a Flux v1 HelmRepository; an empty
@@ -1543,17 +1544,19 @@ func (r *Reconciler) ensureHostFluxBootstrap(
 	if err := unstructured.SetNestedMap(gr.Object, commonLabels, "metadata", "labels"); err != nil {
 		return fmt.Errorf("set GitRepository labels: %w", err)
 	}
-	grSpec := map[string]interface{}{
-		"interval": fmt.Sprintf("%ds", r.Cfg.HostFluxIntervalSeconds),
-		"url":      repoURL,
-		"ref": map[string]interface{}{
-			"branch": branch,
-		},
-	}
-	if r.Cfg.FluxGiteaSecretRef != "" {
-		grSpec["secretRef"] = map[string]interface{}{
-			"name": r.Cfg.FluxGiteaSecretRef,
-		}
+	// #4285 — route through the shared fluxsource builder so the
+	// "local-Gitea source MUST carry a secretRef" law is enforced in ONE
+	// place. bp-gitea REQUIRE_SIGNIN_VIEW=true makes anonymous clone 401;
+	// an empty secretRef on this (always Sovereign-local) source is a hard
+	// error, not a silently-dead 401 source.
+	grSpec, err := fluxsource.BuildGitRepositorySpec(fluxsource.GitRepositorySpecInput{
+		URL:             repoURL,
+		Branch:          branch,
+		IntervalSeconds: r.Cfg.HostFluxIntervalSeconds,
+		SecretRef:       r.Cfg.FluxGiteaSecretRef,
+	})
+	if err != nil {
+		return fmt.Errorf("build GitRepository spec for %s: %w", repoName, err)
 	}
 	if err := unstructured.SetNestedMap(gr.Object, grSpec, "spec"); err != nil {
 		return fmt.Errorf("set GitRepository spec: %w", err)

--- a/core/controllers/application/internal/controller/application_controller_test.go
+++ b/core/controllers/application/internal/controller/application_controller_test.go
@@ -352,6 +352,10 @@ func newReconciler(t *testing.T, fg *fakeGitea, objs ...*unstructured.Unstructur
 		HostFluxNamespace:       "flux-system",
 		GiteaInClusterURL:       "http://gitea.test.svc.cluster.local:3000",
 		HostFluxIntervalSeconds: 60,
+		// #4285 — the chart default is non-empty; the per-Application
+		// GitRepository targets the Sovereign-local Gitea, so a secretRef is
+		// mandatory (bp-gitea REQUIRE_SIGNIN_VIEW=true → anonymous clone 401).
+		FluxGiteaSecretRef: "openova-org-tenants-git-auth",
 	}, nil)
 }
 
@@ -982,6 +986,12 @@ func TestReconcile_HostFluxBootstrap_CreatesGitRepoAndKustomization(t *testing.T
 	if branch != "main" {
 		t.Errorf("GitRepository.spec.ref.branch = %q, want %q (envType=prod → branch=main)", branch, "main")
 	}
+	// #4285 — the per-Application source targets the Sovereign-local Gitea, so
+	// it MUST carry the configured secretRef (else bp-gitea
+	// REQUIRE_SIGNIN_VIEW=true returns 401 'authentication required').
+	if name, found, _ := unstructured.NestedString(gr.Object, "spec", "secretRef", "name"); !found || name != "openova-org-tenants-git-auth" {
+		t.Errorf("GitRepository.spec.secretRef.name = %q (found=%v), want openova-org-tenants-git-auth", name, found)
+	}
 	// NO ownerRef — cross-namespace ownerRefs would trigger the K8s GC
 	// to immediately delete the GitRepository (Application is in
 	// `acme`, GitRepository is in `flux-system`). Cross-namespace lookup
@@ -1030,6 +1040,52 @@ func TestReconcile_HostFluxBootstrap_CreatesGitRepoAndKustomization(t *testing.T
 	gotKsAppNS, _, _ := unstructured.NestedString(ks.Object, "metadata", "labels", "catalyst.openova.io/app-namespace")
 	if gotKsAppNS != "acme" {
 		t.Errorf("Kustomization missing catalyst.openova.io/app-namespace label = %q, want %q", gotKsAppNS, "acme")
+	}
+}
+
+// TestReconcile_HostFluxBootstrap_EmptySecretRefDegrades is the #4285 guard at
+// the application leg: when FluxGiteaSecretRef is empty the per-Application
+// GitRepository (a Sovereign-local Gitea source) MUST NOT be emitted anonymous
+// — the controller fails the reconcile (Degraded) so the misconfiguration is
+// LOUD, not a live 401 source. The chart default is non-empty; this proves the
+// guard fires if an operator ever blanks it.
+func TestReconcile_HostFluxBootstrap_EmptySecretRefDegrades(t *testing.T) {
+	bp := makeBlueprint("bp-wp", "1.0.0", nil, []string{"single-region"})
+	env := makeEnv("acme-prod", "acme", "prod")
+	org := makeOrg("acme")
+	app := makeApp("acme", "site", "acme-prod", "bp-wp", "1.0.0", "single-region",
+		[]string{"hetzner-fsn-rtz-prod"},
+		map[string]interface{}{"replicas": int64(1)})
+	fg := newFakeGitea()
+	fg.orgsExist["acme"] = true
+
+	scheme := newScheme()
+	objsAny := []runtime.Object{app.DeepCopy(), env.DeepCopy(), org.DeepCopy(), bp.DeepCopy()}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKindMap(), objsAny...)
+	r := New(dyn, fg, fakeClassifier{}, Config{
+		GiteaPublicURL:             "https://gitea.test.openova.io",
+		HelmReleaseIntervalSeconds: 600,
+		SourceNamespace:            "flux-system",
+		CatalogSourceRef:           "openova-catalog",
+		HostFluxNamespace:          "flux-system",
+		GiteaInClusterURL:          "http://gitea.test.svc.cluster.local:3000",
+		HostFluxIntervalSeconds:    60,
+		// FluxGiteaSecretRef intentionally empty — the #4285 defect.
+	}, nil)
+
+	reconcileFromCluster(t, r, "acme", "site")
+	got := readApp(t, r, "acme", "site")
+	phase, _, message := readPhaseAndReason(t, got)
+	if phase != PhaseDegraded {
+		t.Fatalf("phase = %q, want %q when secretRef is empty (msg=%q)", phase, PhaseDegraded, message)
+	}
+	if !strings.Contains(message, "secretRef is empty") {
+		t.Errorf("Degraded message should cite the #4285 secretRef guard; got %q", message)
+	}
+	// And NO GitRepository should have been created.
+	if _, err := r.Dynamic.Resource(FluxGitRepositoryGVR).Namespace("flux-system").
+		Get(context.Background(), "catalyst-app-acme-site", metav1.GetOptions{}); err == nil {
+		t.Errorf("no GitRepository must be created when the secretRef guard fires")
 	}
 }
 

--- a/core/controllers/environment/cmd/main.go
+++ b/core/controllers/environment/cmd/main.go
@@ -116,11 +116,14 @@ func loadConfigFromEnv() controller.Config {
 		FluxNamespace:       getEnvDefault("FLUX_NAMESPACE", "flux-system"),
 		FluxIntervalSeconds: getEnvIntDefault("FLUX_INTERVAL_SECONDS", 60),
 		GiteaPublicURL:      os.Getenv("GITEA_PUBLIC_URL"),
-		GiteaSecretRef:      getEnvDefault("GITEA_SECRET_REF", "gitea-flux-token"),
-		CommitAuthorName:    getEnvDefault("COMMIT_AUTHOR_NAME", "environment-controller"),
-		CommitAuthorEmail:   getEnvDefault("COMMIT_AUTHOR_EMAIL", "environment-controller@openova.io"),
-		EnvRepoSuffix:       getEnvDefault("ENV_REPO_SUFFIX", "-environment"),
-		RequeueAfter:        time.Duration(getEnvIntDefault("REQUEUE_AFTER_SECONDS", 300)) * time.Second,
+		// #4285 — default to the real shared Gitea basic-auth secret, NOT the
+		// phantom `gitea-flux-token` that no Job ever minted (leg D). The chart
+		// always sets GITEA_SECRET_REF; this binary default is defense-in-depth.
+		GiteaSecretRef:    getEnvDefault("GITEA_SECRET_REF", "openova-org-tenants-git-auth"),
+		CommitAuthorName:  getEnvDefault("COMMIT_AUTHOR_NAME", "environment-controller"),
+		CommitAuthorEmail: getEnvDefault("COMMIT_AUTHOR_EMAIL", "environment-controller@openova.io"),
+		EnvRepoSuffix:     getEnvDefault("ENV_REPO_SUFFIX", "-environment"),
+		RequeueAfter:      time.Duration(getEnvIntDefault("REQUEUE_AFTER_SECONDS", 300)) * time.Second,
 	}
 	return cfg.Defaults()
 }

--- a/core/controllers/environment/internal/gitops/render.go
+++ b/core/controllers/environment/internal/gitops/render.go
@@ -24,6 +24,7 @@ import (
 	"text/template"
 
 	envv1 "github.com/openova-io/openova/core/controllers/environment/api/v1"
+	"github.com/openova-io/openova/core/controllers/pkg/fluxsource"
 )
 
 // BranchForEnvType maps the canonical env_type values to Gitea branch
@@ -179,6 +180,16 @@ spec:
 func RenderGitRepository(in RenderInputs) ([]byte, error) {
 	if in.EnvName == "" || in.Namespace == "" || in.RepoURL == "" || in.Branch == "" {
 		return nil, fmt.Errorf("gitops: RenderGitRepository: EnvName, Namespace, RepoURL, Branch required (got %+v)", in)
+	}
+	// #4285 — enforce the shared "local-Gitea source MUST carry a secretRef"
+	// law: bp-gitea REQUIRE_SIGNIN_VIEW=true makes anonymous clone 401, so a
+	// Sovereign-local GitRepository with an empty SecretRef is a hard render
+	// error (caught by the controller's "RenderError" markDegraded path), not
+	// a silently-dead 401 source. This is the leg-D fix — the env-controller
+	// previously defaulted SecretRef to the phantom `gitea-flux-token` that no
+	// Job mints; the chart now defaults it to openova-org-tenants-git-auth.
+	if err := fluxsource.ValidateGiteaSecretRef(in.RepoURL, in.SecretRef); err != nil {
+		return nil, fmt.Errorf("gitops: RenderGitRepository: %w", err)
 	}
 	if in.IntervalSeconds <= 0 {
 		in.IntervalSeconds = 60

--- a/core/controllers/environment/internal/gitops/render_test.go
+++ b/core/controllers/environment/internal/gitops/render_test.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"testing"
 
+	envv1 "github.com/openova-io/openova/core/controllers/environment/api/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	envv1 "github.com/openova-io/openova/core/controllers/environment/api/v1"
 )
 
 // Verify the env_type→branch mapping table, the load-bearing rule from
@@ -93,17 +93,20 @@ func TestRenderGitRepository_DeterministicAndComplete(t *testing.T) {
 	assert.Contains(t, body, "managed-by: environment-controller")
 }
 
-// Verify SecretRef omission renders an anonymous source.
-func TestRenderGitRepository_AnonymousWhenNoSecret(t *testing.T) {
-	body, err := RenderGitRepository(RenderInputs{
+// #4285 — a local-Gitea source with NO secretRef is now a hard render error,
+// not a silently-emitted anonymous source. bp-gitea REQUIRE_SIGNIN_VIEW=true
+// makes anonymous clone 401, so the env-controller must never author one.
+func TestRenderGitRepository_LocalGiteaWithoutSecretErrors(t *testing.T) {
+	_, err := RenderGitRepository(RenderInputs{
 		EnvName:         "acme-dev",
 		Namespace:       "flux-system",
 		RepoURL:         "https://gitea.hfmp.acme.openova.io/acme/acme-environment.git",
 		Branch:          "develop",
 		IntervalSeconds: 60,
+		// SecretRef intentionally empty — the exact #4285 leg-D defect.
 	})
-	require.NoError(t, err)
-	assert.NotContains(t, string(body), "secretRef")
+	require.Error(t, err, "local-Gitea source with empty secretRef must error")
+	require.Contains(t, err.Error(), "secretRef is empty")
 }
 
 // Verify default interval is applied when unspecified.

--- a/core/controllers/organization/internal/controller/per_org_flux.go
+++ b/core/controllers/organization/internal/controller/per_org_flux.go
@@ -80,6 +80,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	orgapi "github.com/openova-io/openova/core/controllers/organization/internal/orgapi"
+	"github.com/openova-io/openova/core/controllers/pkg/fluxsource"
 )
 
 // perOrgTenantRepoName is the per-Org Gitea repo the vCluster manifests
@@ -170,20 +171,21 @@ func (r *Reconciler) reconcilePerOrgFlux(ctx context.Context, org *orgapi.Organi
 	if err := unstructured.SetNestedMap(gr.Object, copyLabels(labels), "metadata", "labels"); err != nil {
 		return fmt.Errorf("set GitRepository labels: %w", err)
 	}
-	grSpec := map[string]any{
-		"interval": fmt.Sprintf("%ds", interval),
-		"url":      repoURL,
-		"ref": map[string]any{
-			"branch": branch,
-		},
-	}
-	// REQUIRE_SIGNIN_VIEW=true on bp-gitea makes anonymous clone 401 even
-	// for the per-Org repo — when an operator wires a Flux basic-auth
-	// Secret (the catalyst-gitea-token PAT), reference it so source-
-	// controller can authenticate. Empty == anonymous (matches the
-	// application-controller's FluxGiteaSecretRef default).
-	if s := strings.TrimSpace(r.FluxGiteaSecretRef); s != "" {
-		grSpec["secretRef"] = map[string]any{"name": s}
+	// #4285 — route through the shared fluxsource builder. This per-Org
+	// source has ALWAYS carried a secretRef (the chart default
+	// `openova-org-tenants-git-auth` — why every catalyst-tenant-* source is
+	// Ready=True), so this is a no-behavior-change refactor that adds the
+	// SAME guard the application- and environment-controllers gained: an
+	// empty secretRef on this Sovereign-local Gitea source is now a hard
+	// error, not a silently-dead 401 source (bp-gitea REQUIRE_SIGNIN_VIEW=true).
+	grSpec, err := fluxsource.BuildGitRepositorySpec(fluxsource.GitRepositorySpecInput{
+		URL:             repoURL,
+		Branch:          branch,
+		IntervalSeconds: interval,
+		SecretRef:       r.FluxGiteaSecretRef,
+	})
+	if err != nil {
+		return fmt.Errorf("build per-Org GitRepository spec for %s: %w", gitRepoName, err)
 	}
 	if err := unstructured.SetNestedMap(gr.Object, grSpec, "spec"); err != nil {
 		return fmt.Errorf("set GitRepository spec: %w", err)

--- a/core/controllers/organization/internal/controller/per_org_flux_test.go
+++ b/core/controllers/organization/internal/controller/per_org_flux_test.go
@@ -73,6 +73,9 @@ func TestReconcilePerOrgFlux_CreatesGitRepositoryAndKustomization(t *testing.T) 
 		FluxNamespace:       "flux-system",
 		FluxIntervalSeconds: 60,
 		Branch:              "main",
+		// #4285 — the chart default is non-empty; a local-Gitea source MUST
+		// carry a secretRef (bp-gitea REQUIRE_SIGNIN_VIEW=true → 401 anon).
+		FluxGiteaSecretRef: "openova-org-tenants-git-auth",
 	}
 	r.Client = cl
 
@@ -96,8 +99,9 @@ func TestReconcilePerOrgFlux_CreatesGitRepositoryAndKustomization(t *testing.T) 
 	if br != "main" {
 		t.Errorf("GitRepository spec.ref.branch = %q, want main", br)
 	}
-	if _, found, _ := unstructured.NestedMap(gr.Object, "spec", "secretRef"); found {
-		t.Errorf("GitRepository spec.secretRef must be absent when FluxGiteaSecretRef is empty")
+	// #4285 — secretRef is mandatory for the (Sovereign-local) per-Org source.
+	if name, found, _ := unstructured.NestedString(gr.Object, "spec", "secretRef", "name"); !found || name != "openova-org-tenants-git-auth" {
+		t.Errorf("GitRepository spec.secretRef.name = %q (found=%v), want openova-org-tenants-git-auth", name, found)
 	}
 	if org, _, _ := unstructured.NestedString(gr.Object, "metadata", "labels", "openova.io/organization"); org != slug {
 		t.Errorf("GitRepository missing openova.io/organization=%s label (got %q)", slug, org)
@@ -155,6 +159,25 @@ func TestReconcilePerOrgFlux_SecretRefWhenConfigured(t *testing.T) {
 	}
 }
 
+// TestReconcilePerOrgFlux_EmptySecretErrors is the #4285 guard at the org leg:
+// reconciling a per-Org Flux source against the Sovereign-local Gitea with an
+// empty FluxGiteaSecretRef MUST fail loudly (so a future forgotten chart
+// default fails CI / the reconcile, not live as a 401 source) rather than
+// emit a dead anonymous source.
+func TestReconcilePerOrgFlux_EmptySecretErrors(t *testing.T) {
+	const slug = "acme"
+	cl := fake.NewClientBuilder().WithScheme(fluxScheme(t)).Build()
+	r := &Reconciler{
+		Log:               logr.Discard(),
+		GiteaInClusterURL: "http://gitea-http.gitea.svc.cluster.local:3000",
+		// FluxGiteaSecretRef intentionally empty — the #4285 defect.
+	}
+	r.Client = cl
+	if err := r.reconcilePerOrgFlux(context.Background(), newTestOrg(slug)); err == nil {
+		t.Fatal("expected error for empty FluxGiteaSecretRef on local-Gitea source, got nil")
+	}
+}
+
 func TestReconcilePerOrgFlux_NoopWhenGiteaURLUnset(t *testing.T) {
 	const slug = "acme"
 	cl := fake.NewClientBuilder().WithScheme(fluxScheme(t)).Build()
@@ -181,8 +204,9 @@ func TestReconcilePerOrgFlux_IdempotentSecondPass(t *testing.T) {
 	const slug = "acme"
 	cl := fake.NewClientBuilder().WithScheme(fluxScheme(t)).Build()
 	r := &Reconciler{
-		Log:               logr.Discard(),
-		GiteaInClusterURL: "http://gitea-http.gitea.svc.cluster.local:3000",
+		Log:                logr.Discard(),
+		GiteaInClusterURL:  "http://gitea-http.gitea.svc.cluster.local:3000",
+		FluxGiteaSecretRef: "openova-org-tenants-git-auth", // #4285 — mandatory for local Gitea
 	}
 	r.Client = cl
 	ctx := context.Background()
@@ -218,6 +242,7 @@ func TestReconcile_WiresPerOrgFluxEndToEnd(t *testing.T) {
 	r.GiteaInClusterURL = "http://gitea-http.gitea.svc.cluster.local:3000"
 	r.FluxNamespace = "flux-system"
 	r.FluxIntervalSeconds = 60
+	r.FluxGiteaSecretRef = "openova-org-tenants-git-auth" // #4285 — mandatory for local Gitea
 
 	if _, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "acme"},
@@ -241,8 +266,9 @@ func TestTeardownPerOrgFlux_DeletesBoth(t *testing.T) {
 	const slug = "acme"
 	cl := fake.NewClientBuilder().WithScheme(fluxScheme(t)).Build()
 	r := &Reconciler{
-		Log:               logr.Discard(),
-		GiteaInClusterURL: "http://gitea-http.gitea.svc.cluster.local:3000",
+		Log:                logr.Discard(),
+		GiteaInClusterURL:  "http://gitea-http.gitea.svc.cluster.local:3000",
+		FluxGiteaSecretRef: "openova-org-tenants-git-auth", // #4285 — mandatory for local Gitea
 	}
 	r.Client = cl
 	ctx := context.Background()

--- a/core/controllers/pkg/fluxsource/fluxsource.go
+++ b/core/controllers/pkg/fluxsource/fluxsource.go
@@ -1,0 +1,182 @@
+// Package fluxsource is the SINGLE shared builder for every Flux source CR
+// (GitRepository / HelmRepository / OCIRepository) that points at the
+// Sovereign-LOCAL Gitea or Harbor.
+//
+// WHY THIS PACKAGE EXISTS (issue #4285)
+// =====================================
+// bp-gitea sets `service.REQUIRE_SIGNIN_VIEW=true`
+// (platform/gitea/chart/values.yaml). Under that setting an ANONYMOUS git
+// clone returns HTTP 401 "authentication required" for EVERY repo —
+// including public ones. Therefore EVERY Flux source that clones the
+// Sovereign-local Gitea MUST carry a basic-auth `spec.secretRef`. There are
+// no exceptions.
+//
+// Before this package the rule lived, re-implemented, in three independent
+// generators — application-controller, organization-controller and
+// environment-controller — each with its OWN `if secretRef != "" { stamp }`
+// guard and its OWN chart default. Two of the three defaulted the secretRef
+// to empty (application-controller, and environment-controller's phantom
+// `gitea-flux-token` that no Job ever mints), so they silently emitted
+// unauthenticated sources that sat "authentication required" forever. The
+// organization-controller had the correct default and worked. That asymmetry
+// across three copies of the same law IS the bug class #4285 closes.
+//
+// THE FIX
+// =======
+// This package centralizes the law: building a Flux source whose URL targets
+// the Sovereign-local Gitea/Harbor with an EMPTY secretRef is an ERROR, not a
+// silently-degraded source. A future fourth generator that forgets the secret
+// fails LOUDLY (controller reconcile error / failing unit test) instead of
+// shipping a dead 401 source to a live Sovereign.
+//
+// External sources are UNAFFECTED: ghcr.io OCI HelmRepositories (auth'd via
+// `ghcr-pull`), upstream public chart repos, etc. do not route through this
+// guard — only hosts classified as the local Gitea or local Harbor do.
+package fluxsource
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// ErrLocalSourceNeedsSecret is returned (wrapped) when a Flux source whose URL
+// targets the Sovereign-local Gitea/Harbor is built with an empty secretRef.
+// Callers can errors.As against it; it always carries the offending URL.
+type ErrLocalSourceNeedsSecret struct {
+	URL string
+}
+
+func (e *ErrLocalSourceNeedsSecret) Error() string {
+	return fmt.Sprintf(
+		"fluxsource: Flux source url %q targets the Sovereign-local Gitea/Harbor "+
+			"but secretRef is empty — bp-gitea REQUIRE_SIGNIN_VIEW=true makes "+
+			"anonymous clone return 401 'authentication required' for EVERY repo "+
+			"(issue #4285). A secretRef (e.g. openova-org-tenants-git-auth) is "+
+			"mandatory for local-Gitea/Harbor sources",
+		e.URL,
+	)
+}
+
+// localSourceHostMarkers are the case-insensitive host substrings that mark a
+// URL as targeting the Sovereign-LOCAL Gitea or Harbor (the two hosts behind
+// REQUIRE_SIGNIN_VIEW / robot-auth). Matched against the URL host only, never
+// the path, so an external repo with "gitea" in its PATH is not misclassified.
+//
+//   - In-cluster Gitea service: gitea-http.gitea.svc.cluster.local
+//   - Per-Sovereign Gitea DNS:  gitea.<location-code>.<sovereign-domain>
+//   - In-cluster / per-Sovereign Harbor: harbor.<...> / harbor-core.<...>
+//
+// harbor.openova.io (the MOTHERSHIP proxy-cache, anonymously pullable for the
+// public catalog) is deliberately EXCLUDED — only Sovereign-LOCAL hosts need
+// the guard. See isMothershipHarbor.
+var localSourceHostMarkers = []string{
+	"gitea",  // gitea-http.gitea.svc..., gitea.<loc>.<dom>
+	"harbor", // harbor.<loc>.<dom>, harbor-core.<ns>.svc...
+}
+
+// IsLocalSovereignSource reports whether rawURL targets the Sovereign-local
+// Gitea or Harbor (the hosts that REQUIRE authentication). It is host-based
+// and resilient to a missing scheme (callers sometimes pass
+// `gitea-http.gitea.svc.cluster.local:3000/org/repo.git`). External hosts
+// (ghcr.io, upstream chart repos, the mothership proxy-cache) return false.
+func IsLocalSovereignSource(rawURL string) bool {
+	host := hostOf(rawURL)
+	if host == "" {
+		return false
+	}
+	if isMothershipHarbor(host) {
+		// harbor.openova.io is the mothership public proxy-cache, not a
+		// Sovereign-local auth'd source.
+		return false
+	}
+	for _, marker := range localSourceHostMarkers {
+		if strings.Contains(host, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// isMothershipHarbor matches the mothership proxy-cache Harbor
+// (harbor.openova.io), which is anonymously pullable and must NOT be forced
+// through the secretRef guard.
+func isMothershipHarbor(host string) bool {
+	return host == "harbor.openova.io"
+}
+
+// hostOf extracts the lower-cased host (no port) from a URL that may or may not
+// carry a scheme. Returns "" when no host can be determined.
+func hostOf(rawURL string) string {
+	s := strings.TrimSpace(rawURL)
+	if s == "" {
+		return ""
+	}
+	// url.Parse needs a scheme to populate u.Host; synthesize one when absent
+	// so bare `gitea-http.gitea.svc.cluster.local:3000/...` parses correctly.
+	if !strings.Contains(s, "://") {
+		s = "http://" + s
+	}
+	u, err := url.Parse(s)
+	if err != nil {
+		return ""
+	}
+	return strings.ToLower(u.Hostname())
+}
+
+// GitRepositorySpecInput is the minimal field set every generator already has
+// when it builds a Flux GitRepository spec.
+type GitRepositorySpecInput struct {
+	// URL is the GitRepository spec.url (the Gitea HTTP clone URL).
+	URL string
+	// Branch is the spec.ref.branch.
+	Branch string
+	// IntervalSeconds is the spec.interval (seconds). <=0 defaults to 60.
+	IntervalSeconds int
+	// SecretRef is the name of the Flux basic-auth Secret. MUST be non-empty
+	// when URL targets the Sovereign-local Gitea/Harbor.
+	SecretRef string
+}
+
+// BuildGitRepositorySpec returns the `spec` map for a Flux GitRepository,
+// enforcing the local-Gitea-needs-secretRef law. It is the canonical builder
+// for the unstructured-client generators (application- and
+// organization-controller).
+//
+// Returns *ErrLocalSourceNeedsSecret when the URL is a local Sovereign source
+// and SecretRef is empty. For external sources an empty SecretRef is fine and
+// no secretRef key is emitted.
+func BuildGitRepositorySpec(in GitRepositorySpecInput) (map[string]interface{}, error) {
+	secret := strings.TrimSpace(in.SecretRef)
+	if secret == "" && IsLocalSovereignSource(in.URL) {
+		return nil, &ErrLocalSourceNeedsSecret{URL: in.URL}
+	}
+	interval := in.IntervalSeconds
+	if interval <= 0 {
+		interval = 60
+	}
+	spec := map[string]interface{}{
+		"interval": fmt.Sprintf("%ds", interval),
+		"url":      in.URL,
+		"ref": map[string]interface{}{
+			"branch": in.Branch,
+		},
+	}
+	if secret != "" {
+		spec["secretRef"] = map[string]interface{}{"name": secret}
+	}
+	return spec, nil
+}
+
+// ValidateGiteaSecretRef is the guard for generators that render their Flux
+// source via a path BuildGitRepositorySpec can't produce (e.g. the
+// environment-controller's text/template YAML). Call it with the source URL +
+// the secretRef before committing the rendered manifest; it returns
+// *ErrLocalSourceNeedsSecret when a local Sovereign source has an empty
+// secretRef, nil otherwise.
+func ValidateGiteaSecretRef(rawURL, secretRef string) error {
+	if strings.TrimSpace(secretRef) == "" && IsLocalSovereignSource(rawURL) {
+		return &ErrLocalSourceNeedsSecret{URL: rawURL}
+	}
+	return nil
+}

--- a/core/controllers/pkg/fluxsource/fluxsource_test.go
+++ b/core/controllers/pkg/fluxsource/fluxsource_test.go
@@ -1,0 +1,108 @@
+package fluxsource
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsLocalSovereignSource(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{"in-cluster gitea service", "http://gitea-http.gitea.svc.cluster.local:3000/omantel-biz/agenity.git", true},
+		{"in-cluster gitea no scheme", "gitea-http.gitea.svc.cluster.local:3000/omantel-biz/agenity.git", true},
+		{"per-sovereign gitea dns", "https://gitea.hfmp.omantel.biz/openova/openova", true},
+		{"per-sovereign harbor", "https://harbor.hfmp.omantel.biz/proxy-ghcr/loft-sh/vcluster", true},
+		{"in-cluster harbor-core service", "http://harbor-core.harbor.svc.cluster.local/x", true},
+		// External sources MUST NOT be guarded:
+		{"ghcr oci helmrepo", "oci://ghcr.io/openova-io/bp-wordpress", false},
+		{"ghcr https", "https://ghcr.io/openova-io/openova", false},
+		{"mothership proxy-cache harbor", "https://harbor.openova.io/proxy-ghcr/loft-sh/vcluster", false},
+		{"upstream public chart repo", "https://charts.bitnami.com/bitnami", false},
+		{"empty url", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsLocalSovereignSource(tc.url); got != tc.want {
+				t.Fatalf("IsLocalSovereignSource(%q) = %v, want %v", tc.url, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildGitRepositorySpec_LocalGiteaEmptySecretErrors is the load-bearing
+// CI guard for #4285: emitting a Gitea-targeted GitRepository spec with an
+// empty secretRef MUST be a hard error so a future forgotten secret fails in
+// CI, not live as a 401 "authentication required" source.
+func TestBuildGitRepositorySpec_LocalGiteaEmptySecretErrors(t *testing.T) {
+	_, err := BuildGitRepositorySpec(GitRepositorySpecInput{
+		URL:             "http://gitea-http.gitea.svc.cluster.local:3000/omantel-biz/shared-pg-d.git",
+		Branch:          "main",
+		IntervalSeconds: 60,
+		SecretRef:       "", // forgotten — the exact #4285 defect
+	})
+	if err == nil {
+		t.Fatal("expected error for local-Gitea source with empty secretRef, got nil")
+	}
+	var target *ErrLocalSourceNeedsSecret
+	if !errors.As(err, &target) {
+		t.Fatalf("expected *ErrLocalSourceNeedsSecret, got %T: %v", err, err)
+	}
+}
+
+func TestBuildGitRepositorySpec_LocalGiteaWithSecretStampsRef(t *testing.T) {
+	spec, err := BuildGitRepositorySpec(GitRepositorySpecInput{
+		URL:             "http://gitea-http.gitea.svc.cluster.local:3000/omantel-biz/shared-pg-d.git",
+		Branch:          "main",
+		IntervalSeconds: 30,
+		SecretRef:       "openova-org-tenants-git-auth",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sr, ok := spec["secretRef"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected secretRef map, got %#v", spec["secretRef"])
+	}
+	if sr["name"] != "openova-org-tenants-git-auth" {
+		t.Fatalf("secretRef.name = %v, want openova-org-tenants-git-auth", sr["name"])
+	}
+	if spec["interval"] != "30s" {
+		t.Fatalf("interval = %v, want 30s", spec["interval"])
+	}
+}
+
+// TestBuildGitRepositorySpec_ExternalSourceNoSecretOK confirms the guard does
+// NOT fire for external (ghcr / upstream) sources — an empty secretRef there
+// is legitimate and no secretRef key is emitted.
+func TestBuildGitRepositorySpec_ExternalSourceNoSecretOK(t *testing.T) {
+	spec, err := BuildGitRepositorySpec(GitRepositorySpecInput{
+		URL:             "https://ghcr.io/openova-io/openova",
+		Branch:          "main",
+		IntervalSeconds: 60,
+		SecretRef:       "",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error for external source: %v", err)
+	}
+	if _, present := spec["secretRef"]; present {
+		t.Fatalf("external source must not carry a secretRef, got %#v", spec["secretRef"])
+	}
+}
+
+func TestValidateGiteaSecretRef(t *testing.T) {
+	// Local Gitea + empty secret => error.
+	if err := ValidateGiteaSecretRef("http://gitea-http.gitea.svc.cluster.local:3000/o/r.git", ""); err == nil {
+		t.Fatal("expected error for local-Gitea url with empty secretRef")
+	}
+	// Local Gitea + secret => nil.
+	if err := ValidateGiteaSecretRef("http://gitea-http.gitea.svc.cluster.local:3000/o/r.git", "openova-org-tenants-git-auth"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// External + empty secret => nil.
+	if err := ValidateGiteaSecretRef("oci://ghcr.io/openova-io/bp-x", ""); err != nil {
+		t.Fatalf("unexpected error for external source: %v", err)
+	}
+}

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3004,7 +3004,29 @@ name: bp-catalyst-platform
 #   catalyst-api runs in catalyst-system. Pure-additive: priorityClassName/Value are new
 #   values, default-on; no other behaviour changes. Chart-version bump forces the Flux
 #   re-pull (the deploy-bot mutable-tag trap, #4257).
-version: 1.4.825
+# 1.4.827 — #4285 (folds/supersedes #4284): PERMANENT root-cause for the generic
+#   Flux→local-Gitea "authentication required" class — every code path that emits a
+#   Flux source for the Sovereign-local Gitea now carries spec.secretRef, enforced in
+#   ONE place. bp-gitea REQUIRE_SIGNIN_VIEW=true makes anonymous clone 401 for EVERY
+#   repo, so an empty secretRef on a local-Gitea source is a permanent dead-401 source.
+#   A new shared Go builder (core/controllers/pkg/fluxsource) constructs every local-
+#   Gitea GitRepository spec and ERRORS (refuses) when the target is the local Gitea and
+#   secretRef is empty; the application-, organization- and environment-controllers all
+#   route through it (a future 4th generator inherits the guard, fails CI not live).
+#   Chart legs: (A) controllers.application.fluxGiteaSecretRef default flipped ""→
+#   openova-org-tenants-git-auth (per-Application source was anonymous → 401); (C) added
+#   the MISSING top-level catalogSovereign.gitRepository.secretRef block (grep count was
+#   0 → the openova-catalog-sovereign source rendered with no secretRef despite the
+#   sibling secret existing); (D) controllers.environment.giteaSecretRef default flipped
+#   from the PHANTOM gitea-flux-token (no Job ever minted it) to openova-org-tenants-git-
+#   auth. All three referenced secrets are minted by the existing gitea-flux-auth-secrets-
+#   sync-job (no new bootstrap state). On a roll the 3 live-failing sources self-heal
+#   (catalyst-app-omantel-biz-shared-pg-d, catalyst-app-omantel-biz-agenity,
+#   openova-catalog-sovereign → secretRef set, Ready=True). Per Inviolable Principle #4
+#   every secret name stays operator-overridable; external ghcr/upstream sources are
+#   untouched (the guard applies only to the local-Gitea/Harbor host). Clean version tag
+#   forces the Flux re-pull (deploy-bot mutable-tag trap).
+version: 1.4.827
 # 1.4.774 — #4082: application-controller ClusterRole gains dr.openova.io/continuums
 #   (get/list/watch/create/update/patch/delete) — was in the controller's own
 #   deploy/rbac.yaml but MISSING from this platform chart, so a singleton /

--- a/products/catalyst/chart/templates/controllers/environment-controller-deployment.yaml
+++ b/products/catalyst/chart/templates/controllers/environment-controller-deployment.yaml
@@ -79,7 +79,9 @@ spec:
                   key: gitea-public-url
                   optional: true
             - name: GITEA_SECRET_REF
-              value: {{ .Values.controllers.environment.giteaSecretRef | default "gitea-flux-token" | quote }}
+              # #4285 — default to the real shared Gitea basic-auth secret, NOT
+              # the phantom `gitea-flux-token` (no Job mints it). See values.yaml.
+              value: {{ .Values.controllers.environment.giteaSecretRef | default "openova-org-tenants-git-auth" | quote }}
             - name: FLUX_NAMESPACE
               value: {{ .Values.controllers.environment.fluxNamespace | default "flux-system" | quote }}
             - name: FLUX_INTERVAL_SECONDS

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -809,7 +809,18 @@ controllers:
       limits:
         memory: 512Mi
     giteaURL: ""
-    giteaSecretRef: "gitea-flux-token"
+    # #4285 — the env-controller's per-Environment GitRepository clones the
+    # SAME Sovereign-local Gitea (gitea-http.gitea.svc), so under bp-gitea
+    # REQUIRE_SIGNIN_VIEW=true it MUST carry a basic-auth secretRef. The
+    # previous default `gitea-flux-token` was a PHANTOM — NO Job ever minted
+    # it (leg D of the #4285 class). Point at the real shared secret
+    # openova-org-tenants-git-auth (the gitea_admin PAT clones every Org's
+    # repo, including <org>-environment), guaranteed present in flux-system by
+    # catalog-sovereign-flux/gitea-flux-auth-secrets-sync-job.yaml. Per
+    # Inviolable Principle #4 the name stays operator-overridable; set "" only
+    # if bp-gitea ever drops REQUIRE_SIGNIN_VIEW (the fluxsource guard then
+    # no-ops because the source is still the local Gitea — keep the secret).
+    giteaSecretRef: "openova-org-tenants-git-auth"
     fluxNamespace: "flux-system"
     fluxIntervalSeconds: 60
     commitAuthor:
@@ -907,9 +918,18 @@ controllers:
     # Kustomization (seconds). Defaults to 60s for fast initial Pod
     # spin-up; operators with hundreds of Apps may raise this.
     hostFluxIntervalSeconds: 60
-    # Optional Secret in HostFluxNamespace holding the Gitea token Flux
-    # uses to clone. Empty = anonymous (acceptable for in-cluster Gitea).
-    fluxGiteaSecretRef: ""
+    # Secret in HostFluxNamespace holding the Gitea basic-auth Flux uses to
+    # clone each per-Application repo. #4285 (leg A): the prior default `""`
+    # (with a FACTUALLY-WRONG "Empty = anonymous (acceptable)" rationale)
+    # produced unauthenticated per-Application GitRepository sources — bp-gitea
+    # REQUIRE_SIGNIN_VIEW=true returns 401 for ALL repos, so anonymous is NEVER
+    # acceptable. Default to the same shared secret the organization-controller
+    # uses (:751 above) — the gitea_admin PAT clones every Org's per-app repo,
+    # guaranteed present in flux-system by gitea-flux-auth-secrets-sync-job.yaml.
+    # Per Inviolable Principle #4 the name stays operator-overridable; an empty
+    # value now makes the application-controller's fluxsource builder ERROR for
+    # the (always Sovereign-local) per-app source rather than ship a dead 401.
+    fluxGiteaSecretRef: "openova-org-tenants-git-auth"
     env: {}
     nodeSelector: {}
     tolerations: []
@@ -1524,6 +1544,44 @@ orgTenants:
     org: openova
     repo: openova
     branch: org-tenants
+
+# ─── catalog-sovereign Flux source (#3668 / #4285 leg C) ──────────────
+# The `openova-catalog-sovereign` GitRepository
+# (templates/catalog-sovereign-flux/catalog-sovereign-gitrepository.yaml)
+# tracks the `catalog-sovereign` branch of the local Gitea `openova/openova`
+# repo so a console catalog edit → Gitea commit → live Blueprint CR.
+#
+# #4285 leg C — this top-level `catalogSovereign:` key was MISSING entirely
+# (grep count 0). The GitRepository template guards `{{- if $gr.secretRef }}`,
+# so with no values block `$gr.secretRef` was nil → the source rendered with
+# NO secretRef → bp-gitea REQUIRE_SIGNIN_VIEW=true returned 401 "authentication
+# required" forever, even though the sibling secret
+# `openova-catalog-sovereign-git-auth` already exists (minted by
+# catalog-sovereign-flux/gitea-flux-auth-secrets-sync-job.yaml). Defining the
+# block — byte-for-byte mirroring orgTenants.gitRepository.secretRef above —
+# makes the source clone WITH auth. The sync Job already reads this same
+# `.Values.catalogSovereign.gitRepository.secretRef` ($catGR); the explicit
+# block keeps the secret name single-sourced rather than relying on two
+# independent template `default`s agreeing. Per Inviolable Principle #4 every
+# value stays operator-overridable.
+catalogSovereign:
+  gitRepository:
+    name: openova-catalog-sovereign
+    namespace: flux-system
+    apiURL: "http://gitea-http.gitea.svc.cluster.local:3000"
+    org: openova
+    repo: openova
+    branch: catalog-sovereign
+    interval: 1m
+    secretRef:
+      # Flux basic-auth Secret in flux-system (same name the auth-secret-sync
+      # Job applies). Without it the catalog-sovereign source sits 401.
+      name: openova-catalog-sovereign-git-auth
+      # Gitea account the PAT belongs to; PAT sourced from catalyst-gitea-token
+      # at RUNTIME by the sync Job (never a render-time lookup).
+      username: gitea_admin
+      patSourceSecretName: catalyst-gitea-token
+      patSourceKey: token
 
 # ─── Per-Organization public HTTPRoutes (issue #1629 follow-up) ───────
 # PowerDNS now resolves `<slug>.<parentDomain>` for every Org that maps


### PR DESCRIPTION
## Permanent root-cause fix for the generic Flux→local-Gitea \`authentication required\` class

Closes the class at the ROOT so it can NEVER recur per-generator. Folds/supersedes #4284 (the partial leg-A fix).

### The law
bp-gitea sets \`service.REQUIRE_SIGNIN_VIEW=true\` (\`platform/gitea/chart/values.yaml:93\`) → anonymous git clone returns **401 for EVERY repo** (public included). Therefore **every** Flux source that clones the Sovereign-local Gitea MUST carry a basic-auth \`spec.secretRef\`. The secrets already exist in \`flux-system\` (\`openova-org-tenants-git-auth\` + \`openova-catalog-sovereign-git-auth\`, minted by \`gitea-flux-auth-secrets-sync-job.yaml\`). This was pure wiring asymmetry across generators.

### The shared builder (new) — \`core/controllers/pkg/fluxsource\`
A single Go package that constructs every local-Gitea GitRepository spec and **returns an error (refuses) when the target is the Sovereign-local Gitea/Harbor and secretRef is empty**:
- \`BuildGitRepositorySpec\` — for the unstructured-client generators (LEG A, LEG B).
- \`ValidateGiteaSecretRef\` — for the text/template generator (LEG D).
- \`IsLocalSovereignSource\` — host-based classifier; \`ghcr.io\`/upstream charts/the mothership proxy-cache \`harbor.openova.io\` are **excluded** (the guard applies only to the local Gitea/Harbor host).

A future 4th generator that forgets the secret **fails CI / the reconcile**, not live as a dead 401 source.

### Legs fixed
| Leg | Generator | Before | After |
|---|---|---|---|
| **A** | application-controller (\`application_controller.go:~1547\`) | \`fluxGiteaSecretRef\` default \`""\` → anonymous per-app source 401 | default \`openova-org-tenants-git-auth\`; built via \`fluxsource\` |
| **B** | organization-controller (\`per_org_flux.go:~185\`) | already worked (correct default) | routed through \`fluxsource\` for consistency + the guard |
| **C** | catalog-sovereign chart template | **no \`catalogSovereign:\` values block** (grep count 0) → source rendered with no secretRef | added \`catalogSovereign.gitRepository.secretRef\` block → renders authenticated |
| **D** | environment-controller (\`render.go\` / \`cmd/main.go\`) | default \`gitea-flux-token\` — a **phantom** no Job mints | default \`openova-org-tenants-git-auth\`; guard added in \`RenderGitRepository\` |

All three referenced secrets are minted by the existing \`gitea-flux-auth-secrets-sync-job\` — **no new bootstrap state**.

### How the 3 live failures heal on a roll
\`catalyst-app-omantel-biz-shared-pg-d\` + \`catalyst-app-omantel-biz-agenity\` (LEG A — controller \`upsertHostResource\` drift-restores secretRef on next reconcile) and \`openova-catalog-sovereign\` (LEG C — Flux re-renders the GitRepository with the secretRef) → secretRef set, \`Ready=True\`, zero 401.

### Validation (no roll — flagged for founder per PERMANENT-env discipline)
- \`go build ./... && go test ./...\` — **39 packages green**, incl. the new \`fluxsource\` guard test asserting an empty-secret Gitea source **ERRORS** (so a forgotten secret fails CI), plus updated application/organization/environment tests asserting the secretRef is stamped + the guard fires.
- \`helm template\` (Sovereign mode, exit 0): \`openova-catalog-sovereign\` GitRepository now renders \`secretRef.name: openova-catalog-sovereign-git-auth\`; application-controller \`FLUX_GITEA_SECRET_REF\` and environment-controller \`GITEA_SECRET_REF\` both render \`openova-org-tenants-git-auth\`. Catalyst-Zero mode also renders clean.
- **Cannot prove end-to-end live convergence without a roll** — NOT rolling. Bumped \`bp-catalyst-platform\` chart \`1.4.825\`→**\`1.4.827\`** (one above #4284's 1.4.826, since this supersedes it).

Per Inviolable Principle #4 every secret name stays operator-overridable.

Refs #4285 #4284

🤖 Generated with [Claude Code](https://claude.com/claude-code)