### PR TITLE
fix(catalyst): owner keeps catalog name+light/dark logo editing; non-admin sees both logos read-only (Refs #4280)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1080,13 +1080,17 @@ spec:
       #   storm that fills the node's ephemeral disk evicts THOSE reschedulable Pods
       #   first instead of the EVS-node-pinned (#4102) control-plane API (~17min
       #   console outage, omantel.biz 2026-06-24). Chart.yaml bumped in lockstep.
+      # 1.4.829 — #4280: catalog name + light/dark logo editing no longer silently
+      #   vanishes for the Sovereign owner (auth.go owner-is-admin on the KC-reachable-
+      #   not-in-group branch + CatalogDetail always-visible dual-logo profile pair +
+      #   non-admin read-only-with-hint). Chart.yaml bumped in lockstep.
       # 1.4.827 — #4285 (folds #4284): permanent root-cause for the generic
       #   Flux→local-Gitea "authentication required" class — one shared fluxsource
       #   builder + guard makes every local-Gitea source carry spec.secretRef
       #   (application/organization/environment controllers) + adds the missing
       #   catalogSovereign secretRef values block + flips the env-controller's
       #   phantom gitea-flux-token default. Chart.yaml bumped in lockstep.
-      version: 1.4.828
+      version: 1.4.829
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/api/internal/handler/auth.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth.go
@@ -127,9 +127,21 @@ type userGroupReader interface {
 	UserGroupPaths(ctx context.Context, email string) ([]string, error)
 }
 
+// isConfiguredOperatorEmail reports whether `email` (already lowercased +
+// trimmed) is the exactly-configured Sovereign owner (OPERATOR_EMAIL /
+// orgEmail). This is the ONE identity that is admin-by-ownership: their
+// mailbox proved control of the Sovereign's mail domain at PIN-issue, and
+// they are the franchise owner the deployment was provisioned for. Anything
+// else returns false — a NON-owner is NEVER elevated by this check.
+func isConfiguredOperatorEmail(email string) bool {
+	opEmail := strings.ToLower(strings.TrimSpace(os.Getenv("OPERATOR_EMAIL")))
+	return opEmail != "" && opEmail == email
+}
+
 // pinSessionAuthority resolves the (tier, realmRoles) a PIN-authenticated
 // email is entitled to, from live Keycloak group membership — the ONE
-// admin-authority source (#3374 §2 law #4, Layer C).
+// admin-authority source (#3374 §2 law #4, Layer C) — PLUS an
+// owner-is-always-admin guarantee for the configured Sovereign owner.
 //
 // Resolution:
 //  1. If the Keycloak client exposes UserGroupPaths and the email is in
@@ -137,13 +149,27 @@ type userGroupReader interface {
 //     composites catalyst-admin in the realm import, so a federated
 //     login of the same user is admin too — one source, both paths).
 //  2. If KC is reachable but the email is NOT in /sovereign-admins →
-//     viewer (read-only). A non-owner is NEVER silently granted owner.
+//     admin ONLY when the email is the configured Sovereign owner
+//     (OPERATOR_EMAIL); otherwise viewer (read-only). A non-owner is
+//     NEVER silently granted admin.
 //  3. If KC is unreachable / the client lacks the capability (CI, a
 //     just-installed Sovereign whose realm hasn't converged) → fall
 //     back to the configured operator email: an exact match yields
 //     admin (the chroot owner whose mailbox proved control), anything
 //     else viewer. This keeps the owner working through a realm-import
 //     race WITHOUT the old blanket owner-for-everyone grant.
+//
+// #4280 (2026-06-25): the owner-is-admin guarantee was previously confined
+// to branch 3 (the KC-unreachable fallback). On a converged Sovereign whose
+// realm import had NOT seeded the owner into /sovereign-admins (a seeding
+// race, a pre-#3263 realm, or a manual realm reset), branch 2 returned
+// `viewer` for the owner — silently stripping every catalog-edit affordance
+// (useCatalogAdmin → false) so the dual-logo picker + name editor vanished
+// with no operator-visible reason. The owner is the owner regardless of KC
+// reachability; the OPERATOR_EMAIL elevation now applies on BOTH the
+// KC-answered-not-in-group branch and the fallback branch. "Non-owner never
+// silently admin" is preserved — only the exactly-configured owner email is
+// elevated, never any other PIN-authenticated user.
 func (h *Handler) pinSessionAuthority(ctx context.Context, email string) (tier string, realmRoles []string) {
 	email = strings.ToLower(strings.TrimSpace(email))
 	if reader, ok := h.keycloakClientFor().(userGroupReader); ok && reader != nil {
@@ -157,12 +183,20 @@ func (h *Handler) pinSessionAuthority(ctx context.Context, email string) (tier s
 					return pinSessionAdminTier, []string{"catalyst-admin"}
 				}
 			}
-			// KC answered authoritatively: not in /sovereign-admins.
+			// KC answered authoritatively: not in /sovereign-admins. The
+			// configured Sovereign owner is admin-by-ownership even so — the
+			// realm seed may not have converged (#4280); a non-owner stays
+			// viewer.
+			if isConfiguredOperatorEmail(email) {
+				h.log.Info("pin/verify: owner not yet in /sovereign-admins; granting admin by OPERATOR_EMAIL ownership (#4280)",
+					"email", email)
+				return pinSessionAdminTier, []string{"catalyst-admin"}
+			}
 			return pinSessionDefaultTier, nil
 		}
 	}
 	// Fallback: KC unavailable or capability absent.
-	if opEmail := strings.ToLower(strings.TrimSpace(os.Getenv("OPERATOR_EMAIL"))); opEmail != "" && opEmail == email {
+	if isConfiguredOperatorEmail(email) {
 		return pinSessionAdminTier, []string{"catalyst-admin"}
 	}
 	return pinSessionDefaultTier, nil

--- a/products/catalyst/bootstrap/api/internal/handler/auth_pin_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth_pin_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -463,6 +464,113 @@ func TestPinVerify_NonAdminGetsViewerNotOwner(t *testing.T) {
 	// And the privileged gates must REJECT this session.
 	if policyModeCallerAuthorized(&claims) {
 		t.Error("policyModeCallerAuthorized: a non-admin PIN session must NOT pass the sovereign-admin gate")
+	}
+}
+
+// fakeGroupKC satisfies both keycloakClient (EnsureUser/ImpersonateToken)
+// AND userGroupReader (UserGroupPaths) so a test can exercise the
+// pinSessionAuthority KC-reachable branch with a deterministic group list.
+type fakeGroupKC struct {
+	stubKeycloakClient
+	groups []string // the paths UserGroupPaths returns
+	err    error    // when set, simulates a KC lookup failure
+}
+
+func (f *fakeGroupKC) UserGroupPaths(_ context.Context, _ string) ([]string, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.groups, nil
+}
+
+// pinTierForEmail drives a full pin/verify and returns the minted session
+// JWT's tier claim — the contract useCatalogAdmin (UI) keys on.
+func pinTierForEmail(t *testing.T, h *Handler, email string) auth.Claims {
+	t.Helper()
+	h.pinStore.put(email, "123456", "req-1")
+	body := `{"email":"` + email + `","pin":"123456","requestId":"req-1"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/pin/verify",
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.HandlePinVerify(w, req)
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d want 200 (body: %s)", resp.StatusCode, w.Body.String())
+	}
+	cookie := findCookie(resp.Cookies(), "catalyst_session")
+	if cookie == nil || cookie.Value == "" {
+		t.Fatal("catalyst_session cookie not set")
+	}
+	parts := strings.Split(cookie.Value, ".")
+	if len(parts) != 3 {
+		t.Fatalf("cookie value: got %d JWT parts want 3", len(parts))
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("decode JWT payload: %v", err)
+	}
+	var claims auth.Claims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		t.Fatalf("unmarshal claims: %v", err)
+	}
+	return claims
+}
+
+// TestPinVerify_OwnerAdminEvenWhenNotInGroup is the #4280 regression guard:
+// when Keycloak is REACHABLE and answers authoritatively that the owner is
+// NOT in /sovereign-admins (a realm-seed race / pre-#3263 realm), the
+// configured Sovereign owner (OPERATOR_EMAIL) is STILL granted tier=admin —
+// so the catalog dual-logo picker + name editor never silently vanish for
+// the owner. Pre-#4280 this branch returned viewer.
+func TestPinVerify_OwnerAdminEvenWhenNotInGroup(t *testing.T) {
+	t.Setenv("OPERATOR_EMAIL", "owner@example.com")
+	h := testPinSetup(t)
+	// KC reachable, owner present but NOT in /sovereign-admins.
+	h.kc = &fakeGroupKC{groups: []string{"/openova-users", "/sovereign-viewers"}}
+
+	claims := pinTierForEmail(t, h, "owner@example.com")
+	if claims.Tier != pinSessionAdminTier {
+		t.Errorf("owner tier (KC reachable, not in group): got %q want %q (#4280: owner is admin by ownership)",
+			claims.Tier, pinSessionAdminTier)
+	}
+	if !claims.HasRealmRole("catalyst-admin") {
+		t.Errorf("owner must carry catalyst-admin (got: %v)", claims.RealmAccess.Roles)
+	}
+	if !policyModeCallerAuthorized(&claims) {
+		t.Error("policyModeCallerAuthorized: owner session must pass the sovereign-admin gate")
+	}
+}
+
+// TestPinVerify_NonOwnerStillViewerWhenNotInGroup is the matching negative:
+// the #4280 elevation is confined to the EXACTLY-configured owner email. A
+// different PIN-authenticated user, KC reachable + not in /sovereign-admins,
+// stays viewer — "non-owner never silently admin" is preserved.
+func TestPinVerify_NonOwnerStillViewerWhenNotInGroup(t *testing.T) {
+	t.Setenv("OPERATOR_EMAIL", "owner@example.com")
+	h := testPinSetup(t)
+	h.kc = &fakeGroupKC{groups: []string{"/openova-users", "/sovereign-viewers"}}
+
+	claims := pinTierForEmail(t, h, "stranger@example.com")
+	if claims.Tier != pinSessionDefaultTier {
+		t.Errorf("non-owner tier: got %q want %q (must NOT be admin)", claims.Tier, pinSessionDefaultTier)
+	}
+	if claims.HasRealmRole("catalyst-admin") || claims.HasRealmRole("catalyst-owner") {
+		t.Errorf("non-owner must NOT carry catalyst-admin/owner (got: %v)", claims.RealmAccess.Roles)
+	}
+}
+
+// TestPinVerify_GroupMemberAdminRegardlessOfOperatorEmail confirms the
+// primary path is unchanged: a user IN /sovereign-admins is admin even when
+// they are NOT the OPERATOR_EMAIL (a delegated sovereign-admin).
+func TestPinVerify_GroupMemberAdminRegardlessOfOperatorEmail(t *testing.T) {
+	t.Setenv("OPERATOR_EMAIL", "owner@example.com")
+	h := testPinSetup(t)
+	h.kc = &fakeGroupKC{groups: []string{"/openova-users", "/sovereign-admins"}}
+
+	claims := pinTierForEmail(t, h, "delegate@example.com")
+	if claims.Tier != pinSessionAdminTier {
+		t.Errorf("group-member tier: got %q want %q", claims.Tier, pinSessionAdminTier)
 	}
 }
 

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.edit.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.edit.test.tsx
@@ -237,4 +237,52 @@ describe('CatalogDetail visual icon picker (#3668 §5B)', () => {
     const edit = saveSpy.mock.calls[0][1] as { icon_light: string }
     expect(edit.icon_light).toBe(grafana.url)
   })
+
+  it('the edit picker exposes an Upload control for BOTH light and dark (#4280)', async () => {
+    renderCatalog()
+    fireEvent.click(await screen.findByTestId('cif-icon-edit'))
+    // The founder's "upload a new logo" path — not only pick-from-library.
+    expect(screen.getByTestId('iconpicker-light-upload')).toBeTruthy()
+    expect(screen.getByTestId('iconpicker-dark-upload')).toBeTruthy()
+  })
+})
+
+describe('CatalogDetail always-visible light/dark logo pair (#4280)', () => {
+  it('surfaces BOTH stored logos for an admin WITHOUT entering edit mode', async () => {
+    renderCatalog()
+    await screen.findByTestId('catalog-title')
+    // The dedicated Logos section renders both theme tiles, always visible.
+    expect(screen.getByTestId('catalog-section-logos')).toBeTruthy()
+    expect(screen.getByTestId('catalog-logo-light')).toBeTruthy()
+    expect(screen.getByTestId('catalog-logo-dark')).toBeTruthy()
+  })
+
+  it('a non-admin SEES both logos read-only + the sovereign-admin hint, never a blank (#4280)', async () => {
+    adminHolder.value = false
+    renderCatalog()
+    await screen.findByTestId('catalog-title')
+    // The hero shows the read-only dual-logo profile pair (not a silent blank).
+    const pairs = screen.getAllByTestId('catalog-logo-pair')
+    expect(pairs.length).toBeGreaterThan(0)
+    // Both theme logos are present (multiple, since the always-visible section
+    // also renders them) — assert at least one of each.
+    expect(screen.getAllByTestId('catalog-logo-light').length).toBeGreaterThan(0)
+    expect(screen.getAllByTestId('catalog-logo-dark').length).toBeGreaterThan(0)
+    // The explicit "editing requires sovereign-admin" hint is shown — the
+    // feature is visibly present-but-locked, not silently removed.
+    const hints = screen.getAllByTestId('catalog-logo-admin-hint')
+    expect(hints.length).toBeGreaterThan(0)
+    expect(hints[0].textContent).toMatch(/sovereign-admin/i)
+  })
+
+  it('renders the light and dark logos with the resolved theme-appropriate src (#4280)', async () => {
+    adminHolder.value = false
+    renderCatalog()
+    await screen.findByTestId('catalog-title')
+    // Grafana fixture carries no IaC icons → both resolve to the bundled asset.
+    const lightTile = screen.getAllByTestId('catalog-logo-light')[0]
+    const darkTile = screen.getAllByTestId('catalog-logo-dark')[0]
+    expect(lightTile.querySelector('img')?.getAttribute('src')).toBeTruthy()
+    expect(darkTile.querySelector('img')?.getAttribute('src')).toBeTruthy()
+  })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
@@ -65,6 +65,62 @@ import { IconPicker } from './IconPicker'
  *   GET /catalyst/v1/catalog/{blueprint}/instances            → BlueprintInstance[]
  *        (fetched inside InstancesSection)
  */
+/**
+ * CatalogLogoPair — #4280: the read-only profile-picture-style display of a
+ * Blueprint's BOTH stored logos (light + dark) side by side. Each tile renders
+ * on the surface its theme targets (light tile on a light swatch, dark tile on
+ * a dark swatch) so the operator SEES the already-uploaded logos exactly as
+ * they appear in each console theme — the founder's "profile icon picker like
+ * approach", in its always-visible read-only form. A missing theme variant
+ * draws the letter-mark fallback rather than a broken image. An optional hint
+ * states why edit controls are absent (non-admin), so the feature is visibly
+ * present-but-locked, never silently gone.
+ */
+function CatalogLogoPair({
+  title,
+  light,
+  dark,
+  hint,
+}: {
+  title: string
+  light: string | null
+  dark: string | null
+  hint?: string
+}) {
+  const letter = title[0] ?? '?'
+  return (
+    <div className="catalog-logo-pair" data-testid="catalog-logo-pair">
+      <div className="clp-tiles">
+        <figure className="clp-tile clp-tile-light" data-testid="catalog-logo-light">
+          {light ? (
+            <img src={light} alt={`${title} light logo`} className="clp-img" loading="lazy" />
+          ) : (
+            <span className="clp-letter" aria-hidden="true">
+              {letter}
+            </span>
+          )}
+          <figcaption className="clp-caption">Light theme</figcaption>
+        </figure>
+        <figure className="clp-tile clp-tile-dark" data-testid="catalog-logo-dark">
+          {dark ? (
+            <img src={dark} alt={`${title} dark logo`} className="clp-img" loading="lazy" />
+          ) : (
+            <span className="clp-letter" aria-hidden="true">
+              {letter}
+            </span>
+          )}
+          <figcaption className="clp-caption">Dark theme</figcaption>
+        </figure>
+      </div>
+      {hint ? (
+        <p className="clp-hint" data-testid="catalog-logo-admin-hint">
+          {hint}
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
 export function CatalogDetail() {
   const params = useParams({ strict: false }) as {
     blueprintName?: string
@@ -196,6 +252,16 @@ export function CatalogDetail() {
   const bundledLogo = findComponent(name)?.logoUrl ?? null
   const logoUrl = resolveCatalogIcon(card, theme, bundledLogo)
 
+  // #4280 — the founder's literal ask ("SHOW the already-uploaded light AND
+  // dark logos … profile-picture-like view"). Resolve BOTH theme variants
+  // explicitly (each forced to its own theme via resolveCatalogIcon) so the
+  // detail page can render them side-by-side ALWAYS — for an admin AND a
+  // non-admin, inside edit mode or not. Before #4280 the hero showed only the
+  // single active-theme logo and a non-admin saw NO edit affordance at all,
+  // visually identical to the feature having been deleted.
+  const logoLightUrl = resolveCatalogIcon(card, 'light', bundledLogo)
+  const logoDarkUrl = resolveCatalogIcon(card, 'dark', bundledLogo)
+
   // #3668 §5A — the FULL current catalog-edit values, the merge base every
   // per-field inline save round-trips so editing one field never clobbers a
   // sibling (saveCatalogEdit does a full upsert). Light-icon pre-fills from the
@@ -284,12 +350,17 @@ export function CatalogDetail() {
             })}
             onSaved={refetchCatalog}
           />
-        ) : logoUrl ? (
-          <img src={logoUrl} alt={title} className="hero-logo" loading="lazy" />
         ) : (
-          <span className="hero-icon" style={{ background: '#1f2937' }}>
-            {title[0] ?? '?'}
-          </span>
+          // #4280 — non-admin: NEVER a blank/single-logo-with-no-affordance.
+          // Show BOTH stored logos read-only (the profile-picture pair) plus
+          // an explicit reason the edit controls are absent, so the feature is
+          // visibly present (just not editable) rather than silently gone.
+          <CatalogLogoPair
+            title={title}
+            light={logoLightUrl}
+            dark={logoDarkUrl}
+            hint="Editing the catalog requires sovereign-admin"
+          />
         )}
         <div className="hero-body">
           {/* #3668 §5A — the display name is a per-field inline editor. */}
@@ -458,6 +529,28 @@ export function CatalogDetail() {
           ) : null}
         </div>
       </div>
+
+      {/* #4280 — ALWAYS-visible light/dark logo pair (the founder's literal
+          "SHOW the already-uploaded light AND dark logos … profile-picture-like
+          view"). The hero renders ONE theme-appropriate logo; this strip
+          surfaces BOTH stored logos for everyone — admin and non-admin —
+          without entering edit mode, so "show the uploaded logos" always holds.
+          An admin still edits them via the hero icon picker (light + dark +
+          upload) above. */}
+      <section className="section" data-testid="catalog-section-logos">
+        <h2>Logos</h2>
+        <p className="section-hint">
+          The light- and dark-theme logos currently stored for {title}.
+          {isAdmin
+            ? ' Click the hero icon above to change either (pick from the gallery or upload a new image).'
+            : ' Editing the catalog requires sovereign-admin.'}
+        </p>
+        <CatalogLogoPair
+          title={title}
+          light={logoLightUrl}
+          dark={logoDarkUrl}
+        />
+      </section>
 
       {/* #3668 §5A — the per-field card editors (icon / name / summary /
           supported-topologies) live INLINE on the hero + topologies sections
@@ -874,6 +967,31 @@ const CATALOG_DETAIL_CSS = `
 .hero-icon-editors { display: flex; flex-wrap: wrap; gap: 1rem; }
 .hero-icon-editor { display: flex; flex-direction: column; gap: 0.35rem; min-width: 240px; flex: 1; }
 .hero-icon-editor-label { font-size: 0.72rem; font-weight: 600; color: var(--color-text-strong); }
+
+/* #4280 — read-only profile-picture-style light/dark logo pair. Each tile
+   renders the logo on the swatch matching its theme so the operator SEES both
+   uploaded logos as they appear in each theme, always-visible (no edit mode). */
+.catalog-logo-pair { display: flex; flex-direction: column; gap: 0.5rem; }
+.clp-tiles { display: flex; flex-wrap: wrap; gap: 0.8rem; }
+.clp-tile {
+  margin: 0; display: flex; flex-direction: column; align-items: center; gap: 0.35rem;
+  width: 96px; padding: 0.6rem; border-radius: 14px; border: 1px solid var(--color-border);
+}
+.clp-tile-light { background: #ffffff; }
+.clp-tile-dark { background: #0b0d12; }
+.clp-img { width: 56px; height: 56px; border-radius: 12px; object-fit: contain; }
+.clp-letter {
+  width: 56px; height: 56px; border-radius: 12px; display: inline-flex;
+  align-items: center; justify-content: center; font-size: 1.5rem; font-weight: 700;
+}
+.clp-tile-light .clp-letter { background: #1f2937; color: #fff; }
+.clp-tile-dark .clp-letter { background: #e5e7eb; color: #111827; }
+.clp-caption { font-size: 0.68rem; font-weight: 600; }
+.clp-tile-light .clp-caption { color: #5f6470; }
+.clp-tile-dark .clp-caption { color: #c4c8d4; }
+.clp-hint {
+  margin: 0; font-size: 0.78rem; color: var(--color-text-dim); font-style: italic;
+}
 .hero-meta { display: flex; gap: 0.4rem; flex-wrap: wrap; align-items: center; }
 .hero-tags { display: flex; gap: 0.35rem; flex-wrap: wrap; margin-top: 0.55rem; }
 .hero-docs { margin: 0.6rem 0 0; font-size: 0.85rem; }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/IconPicker.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/IconPicker.test.tsx
@@ -79,4 +79,23 @@ describe('IconPicker (#3668 visual gallery)', () => {
     fireEvent.click(screen.getByTestId('iconpicker-light-clear'))
     expect(onChange).toHaveBeenCalledWith('')
   })
+
+  // #4280 — the founder's ask includes "upload a new logo" (not only
+  // pick-from-library). This pins the upload path: choosing a file reads it
+  // into a self-contained data: URI and fires onChange with it, so an
+  // uploaded logo persists via the same saveCatalogEdit seam as a picked one.
+  it('uploading a new image file calls onChange with a data: URI', async () => {
+    render(<IconPicker which="dark" value="" onChange={onChange} />)
+    const fileInput = screen.getByTestId('iconpicker-dark-upload') as HTMLInputElement
+    expect(fileInput).toBeTruthy()
+    const file = new File(['<svg/>'], 'logo.svg', { type: 'image/svg+xml' })
+    fireEvent.change(fileInput, { target: { files: [file] } })
+    // FileReader.onload resolves async — wait for the data-URI onChange.
+    await vi.waitFor(() => {
+      expect(onChange).toHaveBeenCalledTimes(1)
+    })
+    const arg = onChange.mock.calls[0][0]
+    expect(typeof arg).toBe('string')
+    expect(arg.startsWith('data:')).toBe(true)
+  })
 })

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3004,7 +3004,7 @@ name: bp-catalyst-platform
 #   catalyst-api runs in catalyst-system. Pure-additive: priorityClassName/Value are new
 #   values, default-on; no other behaviour changes. Chart-version bump forces the Flux
 #   re-pull (the deploy-bot mutable-tag trap, #4257).
-# 1.4.828 — #4280: catalog name + light/dark logo editing no longer silently vanishes for
+# 1.4.829 — #4280: catalog name + light/dark logo editing no longer silently vanishes for
 #   the Sovereign owner. (api) auth.go pinSessionAuthority now grants the configured owner
 #   (OPERATOR_EMAIL) tier=admin even when Keycloak is REACHABLE but the realm seed hasn't
 #   put them in /sovereign-admins (a seeding race / pre-#3263 realm) — previously only the
@@ -3039,7 +3039,7 @@ name: bp-catalyst-platform
 #   every secret name stays operator-overridable; external ghcr/upstream sources are
 #   untouched (the guard applies only to the local-Gitea/Harbor host). Clean version tag
 #   forces the Flux re-pull (deploy-bot mutable-tag trap).
-version: 1.4.828
+version: 1.4.829
 # 1.4.774 — #4082: application-controller ClusterRole gains dr.openova.io/continuums
 #   (get/list/watch/create/update/patch/delete) — was in the controller's own
 #   deploy/rbac.yaml but MISSING from this platform chart, so a singleton /

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3004,6 +3004,19 @@ name: bp-catalyst-platform
 #   catalyst-api runs in catalyst-system. Pure-additive: priorityClassName/Value are new
 #   values, default-on; no other behaviour changes. Chart-version bump forces the Flux
 #   re-pull (the deploy-bot mutable-tag trap, #4257).
+# 1.4.828 — #4280: catalog name + light/dark logo editing no longer silently vanishes for
+#   the Sovereign owner. (api) auth.go pinSessionAuthority now grants the configured owner
+#   (OPERATOR_EMAIL) tier=admin even when Keycloak is REACHABLE but the realm seed hasn't
+#   put them in /sovereign-admins (a seeding race / pre-#3263 realm) — previously only the
+#   KC-unreachable fallback honoured the owner, so the converged-but-unseeded owner landed
+#   as viewer and useCatalogAdmin->false stripped every edit affordance. "Non-owner never
+#   silently admin" preserved (only the exact OPERATOR_EMAIL is elevated). (ui) CatalogDetail
+#   now ALWAYS surfaces BOTH stored light+dark logos in a profile-picture-style read-only
+#   pair (the founder's "show the already-uploaded logos" — visible without entering edit
+#   mode, for admin AND non-admin); a non-admin sees the dual logos read-only + an explicit
+#   "editing requires sovereign-admin" hint instead of a single logo with no affordance
+#   (the silent-drop). The admin hero icon picker (light+dark gallery + upload) is unchanged.
+#   Chart-version bump forces the Flux re-pull of the new catalyst-api + catalyst-ui images.
 # 1.4.827 — #4285 (folds/supersedes #4284): PERMANENT root-cause for the generic
 #   Flux→local-Gitea "authentication required" class — every code path that emits a
 #   Flux source for the Sovereign-local Gitea now carries spec.secretRef, enforced in


### PR DESCRIPTION
Refs #4280

## Problem
The Sovereign owner's catalog **name + dual-logo editing** silently vanished when their PIN session resolved to `viewer`. `useCatalogAdmin` gates the whole edit surface (dual `IconPicker` + name/summary/topology inline editors) on tier `admin|owner`, and `pinSessionAuthority` only honoured the owner (`OPERATOR_EMAIL`) on the **KC-unreachable** fallback. On a converged Sovereign whose realm seed had NOT put the owner into `/sovereign-admins` (a seeding race / pre-#3263 realm / manual realm reset), the **KC-reachable** branch returned `viewer` → every edit control disappeared with no operator-visible reason (the silent-drop anti-pattern, PR #1138 shape).

## Fix

### A — Immediate live (already satisfied on omantel.biz)
On the live Sovereign the owner `emrah.baysal@openova.io` is **already a member of `/sovereign-admins`** (verified via the catalyst-api SA's own `UserGroupPaths` calls). The live `catalyst-api` whoami returns `tier=owner` + `roles[catalyst-admin,catalyst-owner]` for an owner session → `useCatalogAdmin=true`, edit UI shows today. No live Keycloak mutation was needed (and the founder mailbox was never touched).

### B — Profile-picture dual-logo UX (the literal ask)
`CatalogDetail.tsx`:
- NEW always-visible **Logos** section + the non-admin hero now render **BOTH** stored light+dark logos in a profile-picture-style read-only pair (`CatalogLogoPair`) — for admin AND non-admin, **without entering edit mode** (the founder's "show the already-uploaded logos").
- A **non-admin** sees the dual logos read-only + an explicit *"editing requires sovereign-admin"* hint instead of a single logo with no affordance.
- The admin hero icon picker (light+dark gallery **+ upload**) is unchanged — the `IconPicker` upload→data-URI path already exists; added explicit test coverage for it.

### C — Durable admin fix (never recurs)
`auth.go` `pinSessionAuthority`: the configured Sovereign owner is now granted `tier=admin` **even on the KC-answered-not-in-group branch**, not only the KC-unreachable fallback (extracted `isConfiguredOperatorEmail`). **"Non-owner never silently admin" preserved** — only the exact `OPERATOR_EMAIL` is elevated; any other PIN user not in `/sovereign-admins` stays `viewer`. (The durable realm-import seed of the owner into `/sovereign-admins` already exists in `configmap-sovereign-realm.yaml` from #3263; this is the second belt-and-suspenders layer for the seed-race window.)
No-silent-vanish (C.3): the non-admin catalog detail renders the light+dark logos read-only + the hint, never a blank.

## Files
- `products/catalyst/bootstrap/api/internal/handler/auth.go` — owner-is-admin on both KC-reachable-not-in-group + fallback branches.
- `products/catalyst/bootstrap/api/internal/handler/auth_pin_test.go` — `fakeGroupKC` + 3 new guards.
- `products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx` — `CatalogLogoPair` + always-visible Logos section + non-admin dual-logo+hint.
- `products/catalyst/bootstrap/ui/src/pages/sovereign/IconPicker.test.tsx` — upload→data-URI test.
- `products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.edit.test.tsx` — dual-logo display/hint/upload-control coverage.
- `products/catalyst/chart/Chart.yaml` — **bp-catalyst-platform 1.4.825 → 1.4.826** (forces Flux re-pull of new catalyst-api + catalyst-ui). Flag: reconcile this version across parallel PRs.

## Tests
- `go build ./... ` + `go test ./internal/handler/` green (incl. 3 new #4280 guards).
- `tsc -b --noEmit` clean; `CatalogDetail` (27) + `IconPicker` (8) vitest suites green. Pre-existing unrelated test-env failures (PinInput6 / StepComponents etc.) confirmed present on the clean base branch.

## Live evidence
`catalyst-api` whoami on omantel.biz for the owner session:
```
{"email":"emrah.baysal@openova.io","tier":"owner","realm_access":{"roles":["catalyst-admin","catalyst-owner"]},"mode":"sovereign","sovereignFQDN":"omantel.biz"}
```
A live screenshot of the NEW dual-logo UI requires rolling the catalyst-ui image, deliberately deferred per the no-roll instruction (chart version reconciled across parallel PRs first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)