### PR TITLE
fix(provisioning): wire per-Org apps INTO the Org vCluster, tier-aware — the #4293 keystone (Refs #4297)

### DIFF
--- a/core/services/provisioning/gitops/apps_into_vcluster_4297_test.go
+++ b/core/services/provisioning/gitops/apps_into_vcluster_4297_test.go
@@ -1,0 +1,198 @@
+package gitops
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4297 (keystone of EPIC #4293) — per-Org apps land INSIDE the Org vCluster,
+// TIER-AWARE. The funnel's apps-sync Flux Kustomization carries
+// spec.kubeConfig.secretRef ONLY for the vcluster tier (paid M+), so the host
+// Flux reconciles the apps tree INTO the Org vCluster apiserver. For the host
+// tier (free/S) there is NO vcluster — emitting a kubeConfig referencing the
+// never-created `vc-vcluster` mirror would StateError forever, so the apps-sync
+// omits kubeConfig and the apps reconcile straight into the host `<slug>` ns.
+
+const testBasePath = "clusters/sov/tenants"
+
+func appsSyncFor(t *testing.T, slug, planSlug string) string {
+	t.Helper()
+	g := NewManifestGenerator(testBasePath)
+	out := g.GenerateAllWithAppConfigs(slug, planSlug, []string{"wordpress"}, "pw", nil)
+	path := testBasePath + "/" + slug + "/apps-sync.yaml"
+	body, ok := out[path]
+	if !ok {
+		t.Fatalf("apps-sync.yaml missing for slug=%q plan=%q (keys: %v)", slug, planSlug, keys(out))
+	}
+	return body
+}
+
+func keys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// TestAppsSync_VclusterTier_HasKubeConfig — a paid (M) tier Org's apps-sync
+// Kustomization carries the kubeConfig secretRef so the apps land inside the
+// vcluster. targetNamespace stays the org-controller `<slug>` ns.
+func TestAppsSync_VclusterTier_HasKubeConfig(t *testing.T) {
+	body := appsSyncFor(t, "acme", "m")
+	if !strings.Contains(body, "kubeConfig:") {
+		t.Errorf("vcluster tier apps-sync MISSING kubeConfig block:\n%s", body)
+	}
+	if !strings.Contains(body, "name: tenant-acme-kubeconfig") {
+		t.Errorf("vcluster tier apps-sync MISSING the kubeconfig mirror secretRef name:\n%s", body)
+	}
+	if !strings.Contains(body, "key: config") {
+		t.Errorf("vcluster tier apps-sync MISSING secretRef key: config:\n%s", body)
+	}
+	if !strings.Contains(body, "targetNamespace: acme") {
+		t.Errorf("vcluster tier apps-sync targetNamespace is not <slug> acme:\n%s", body)
+	}
+}
+
+// TestAppsSync_HostTier_NoKubeConfig — free/S/"" tier Orgs have no vcluster, so
+// the apps-sync carries NO kubeConfig (apps reconcile into the host `<slug>` ns
+// directly). The apps tree must still render.
+func TestAppsSync_HostTier_NoKubeConfig(t *testing.T) {
+	for _, plan := range []string{"s", "free", ""} {
+		t.Run("plan="+plan, func(t *testing.T) {
+			body := appsSyncFor(t, "acme", plan)
+			if strings.Contains(body, "kubeConfig:") {
+				t.Errorf("host tier (plan=%q) apps-sync MUST NOT carry kubeConfig — it would StateError on the never-created vc-vcluster mirror:\n%s", plan, body)
+			}
+			if strings.Contains(body, "tenant-acme-kubeconfig") {
+				t.Errorf("host tier (plan=%q) apps-sync MUST NOT reference the kubeconfig mirror:\n%s", plan, body)
+			}
+			// Still targets the host `<slug>` ns + points at the apps path.
+			if !strings.Contains(body, "targetNamespace: acme") {
+				t.Errorf("host tier (plan=%q) apps-sync targetNamespace is not <slug> acme:\n%s", plan, body)
+			}
+			if !strings.Contains(body, "path: ./"+testBasePath+"/acme/apps") {
+				t.Errorf("host tier (plan=%q) apps-sync path wrong:\n%s", plan, body)
+			}
+
+			// The apps tree itself must still render so apps actually deploy.
+			g := NewManifestGenerator(testBasePath)
+			out := g.GenerateAllWithAppConfigs("acme", plan, []string{"wordpress"}, "pw", nil)
+			if _, ok := out[testBasePath+"/acme/apps/app-wordpress.yaml"]; !ok {
+				t.Errorf("host tier (plan=%q) MISSING app-wordpress.yaml (keys: %v)", plan, keys(out))
+			}
+		})
+	}
+}
+
+// TestBoundaryIsVcluster_FunnelParity locks the funnel's tier gate in lockstep
+// with the org-controller's authoritative boundaryIsVcluster gate (#4292,
+// core/controllers/organization/internal/gitops/manifests.go). The two are
+// intentional duplicates (Go internal/ package boundary); this table guards
+// against silent drift.
+func TestBoundaryIsVcluster_FunnelParity(t *testing.T) {
+	cases := map[string]bool{
+		"":      false,
+		"s":     false,
+		"S":     false,
+		"free":  false,
+		" s ":   false,
+		"m":     true,
+		"l":     true,
+		"xl":    true,
+		"flexi": true,
+		"M":     true,
+	}
+	for plan, want := range cases {
+		if got := BoundaryIsVcluster(plan); got != want {
+			t.Errorf("BoundaryIsVcluster(%q) = %v, want %v", plan, got, want)
+		}
+	}
+}
+
+// TestCNPGPair_VclusterTier_HRLevelKubeConfig — the active-hot-standby
+// bp-cnpg-pair HelmRelease is a HelmRelease CR, so it cannot be redirected into
+// the vcluster by the apps-sync Kustomization (no in-cluster helm-controller →
+// #3055 StateError). For the vcluster tier it must be a HOST file carrying
+// HR-level spec.kubeConfig (the host helm-controller installs INTO the vcluster).
+func TestCNPGPair_VclusterTier_HRLevelKubeConfig(t *testing.T) {
+	g := NewManifestGenerator(testBasePath)
+	out := g.GenerateAllWithAppConfigs("acme", "m",
+		[]string{"umami"}, "pw",
+		map[string]map[string]any{
+			"postgres": {
+				"active_hot_standby": true,
+				"primary_region":     "hz-fsn-rtz-prod",
+				"replica_region":     "hz-hel-rtz-prod",
+			},
+		},
+	)
+
+	// The HR lives as a HOST file (NOT under apps/) so the host helm-controller
+	// reconciles it.
+	hostHR, ok := out[testBasePath+"/acme/db-cnpg-pair.yaml"]
+	if !ok {
+		t.Fatalf("vcluster-tier CNPG-pair HR not emitted as a HOST file (keys: %v)", keys(out))
+	}
+	if _, inApps := out[testBasePath+"/acme/apps/db-cnpg-pair.yaml"]; inApps {
+		t.Errorf("CNPG-pair HR must NOT be in the vcluster-redirected apps/ tree (it would StateError)")
+	}
+	if !strings.Contains(hostHR, "kind: HelmRelease") {
+		t.Errorf("host CNPG-pair file missing HelmRelease:\n%s", hostHR)
+	}
+	if !strings.Contains(hostHR, "kubeConfig:") {
+		t.Errorf("vcluster-tier CNPG-pair HR MISSING HR-level kubeConfig:\n%s", hostHR)
+	}
+	if !strings.Contains(hostHR, "name: tenant-acme-kubeconfig") {
+		t.Errorf("vcluster-tier CNPG-pair HR kubeConfig must reference the mirror secret:\n%s", hostHR)
+	}
+	// HR authored in flux-system so the secretRef (no namespace field) resolves
+	// against the co-located mirror.
+	if !strings.Contains(hostHR, "namespace: flux-system") {
+		t.Errorf("vcluster-tier CNPG-pair HR must be authored in flux-system (mirror ns):\n%s", hostHR)
+	}
+	// Chart installs into the in-vcluster `<slug>` ns where the app pods live.
+	if !strings.Contains(hostHR, "targetNamespace: acme") {
+		t.Errorf("CNPG-pair chart targetNamespace must be the Org <slug> ns acme:\n%s", hostHR)
+	}
+
+	// The standalone postgres-credentials Secret the app pods read lives INSIDE
+	// the vcluster (apps/ tree), NOT on the host.
+	secret, ok := out[testBasePath+"/acme/apps/db-cnpg-pair-secret.yaml"]
+	if !ok {
+		t.Fatalf("CNPG-pair postgres-credentials Secret not emitted into apps/ tree (keys: %v)", keys(out))
+	}
+	if !strings.Contains(secret, "kind: Secret") || !strings.Contains(secret, "name: postgres-credentials") {
+		t.Errorf("apps-tree CNPG secret wrong shape:\n%s", secret)
+	}
+	if strings.Contains(secret, "kind: HelmRelease") {
+		t.Errorf("apps-tree CNPG secret must NOT carry the HelmRelease (that lives on the host):\n%s", secret)
+	}
+}
+
+// TestCNPGPair_HostTier_NoKubeConfig — for the host tier the CNPG-pair HR has
+// no vcluster to target, so it carries NO kubeConfig and is authored in the
+// host `<slug>` ns where the chart installs.
+func TestCNPGPair_HostTier_NoKubeConfig(t *testing.T) {
+	g := NewManifestGenerator(testBasePath)
+	out := g.GenerateAllWithAppConfigs("acme", "s",
+		[]string{"umami"}, "pw",
+		map[string]map[string]any{
+			"postgres": {
+				"active_hot_standby": true,
+				"primary_region":     "hz-fsn-rtz-prod",
+				"replica_region":     "hz-hel-rtz-prod",
+			},
+		},
+	)
+	hostHR, ok := out[testBasePath+"/acme/db-cnpg-pair.yaml"]
+	if !ok {
+		t.Fatalf("host-tier CNPG-pair HR not emitted (keys: %v)", keys(out))
+	}
+	if strings.Contains(hostHR, "kubeConfig:") {
+		t.Errorf("host-tier CNPG-pair HR MUST NOT carry kubeConfig (no vcluster):\n%s", hostHR)
+	}
+	if !strings.Contains(hostHR, "namespace: acme") {
+		t.Errorf("host-tier CNPG-pair HR must be authored in the host <slug> ns acme:\n%s", hostHR)
+	}
+}

--- a/core/services/provisioning/gitops/gitops.go
+++ b/core/services/provisioning/gitops/gitops.go
@@ -240,6 +240,34 @@ func (g *ManifestGenerator) GenerateAllWithPassword(slug, planSlug string, appSl
 	return g.GenerateAllWithAppConfigs(slug, planSlug, appSlugs, dbPassword, nil)
 }
 
+// BoundaryIsVcluster is the funnel-side TIER GATE (#4297, keystone of EPIC
+// #4293). It MUST stay in lockstep with the org-controller's authoritative
+// gate `boundaryIsVcluster` in
+// core/controllers/organization/internal/gitops/manifests.go (const
+// allTiersVcluster + the same free/S/"" → host-ns, m/l/xl/flexi → vCluster
+// switch). That gate lives in an `internal/` package the provisioning module
+// cannot import, so this is a deliberate small duplicate, NOT a divergence —
+// flip both together if the Sovereign-level policy changes.
+//
+// The funnel uses it to decide whether the per-Org app-install tree is
+// REDIRECTED into the Org vCluster (paid M+ tiers — the apps-sync Kustomization
+// carries spec.kubeConfig so the host Flux installs INTO the vcluster API) or
+// reconciled straight into the host `<slug>` namespace (free/S tiers — NO
+// kubeConfig, the org-controller's `<slug>` ns IS the boundary). Exported so
+// the provisioning consumer can gate its vcluster-only waits (vcluster-HR
+// Ready / kubeconfig-mirror / synced-pod-name match) on the same predicate.
+func BoundaryIsVcluster(planSlug string) bool {
+	switch strings.ToLower(strings.TrimSpace(planSlug)) {
+	case "", "s", "free":
+		// free/S → the host `<slug>` ns IS the boundary; apps reconcile there
+		// directly (the org-controller still renders the ns + quota + np).
+		return false
+	default:
+		// m/l/xl/flexi → dedicated Org vCluster; apps are redirected into it.
+		return true
+	}
+}
+
 // GenerateAllWithAppConfigs is the canonical entry point (TBD-V27 #2042).
 // `appConfigs` carries the customer-chosen configSchema values keyed by
 // app SLUG (e.g. {"postgres": {"replicas": 3, "disk_gb": 20,
@@ -268,6 +296,15 @@ func (g *ManifestGenerator) GenerateAllWithAppConfigs(slug, planSlug string, app
 	hostNS := slug
 	appNS := "apps"
 
+	// #4297 (keystone of EPIC #4293) — TIER GATE. Paid M+ Orgs get a dedicated
+	// vCluster; the apps-sync Kustomization REDIRECTS the apps/ tree INTO it via
+	// spec.kubeConfig (the host helm/kustomize controller installs into the
+	// vcluster API). Free/S Orgs have NO vcluster — the org-controller's `<slug>`
+	// host ns IS the boundary, so the apps-sync reconciles straight into it with
+	// NO kubeConfig (a kubeConfig referencing the never-created `vc-vcluster`
+	// mirror would StateError forever → host-tier apps would never deploy).
+	isVcluster := BoundaryIsVcluster(planSlug)
+
 	// --- databases required by selected apps ---
 	needsRedis := false
 	mysqlApps := []string{}
@@ -295,12 +332,15 @@ func (g *ManifestGenerator) GenerateAllWithAppConfigs(slug, planSlug string, app
 	// ONLY: the apps-sync Flux Kustomization (reconciles apps/ into that
 	// vCluster), the provisioning ServiceAccount RBAC the sync needs, and the
 	// host ingress for the synced services — all targeting `<slug>`.
+	// #4297: the host kustomization.yaml is assembled LAST (below) so it can
+	// include any host-reconciled HelmRelease the db block adds (e.g. the
+	// bp-cnpg-pair HR, which must live on the host with HR-level kubeConfig —
+	// never inside the vcluster-redirected apps/ tree).
 	hostFiles := map[string]string{
 		"ingress.yaml":           generateHostIngress(hostNS, slug, appSlugs),
-		"apps-sync.yaml":         generateAppsSyncKustomization(hostNS, slug, g.BasePath),
+		"apps-sync.yaml":         generateAppsSyncKustomization(hostNS, slug, g.BasePath, isVcluster),
 		"provisioning-rbac.yaml": generateProvisioningTenantRBAC(hostNS),
 	}
-	hostFiles["kustomization.yaml"] = generateKustomization("", hostFiles)
 
 	// --- in-vCluster files under apps/ ---
 	vcFiles := map[string]string{
@@ -332,7 +372,38 @@ func (g *ManifestGenerator) GenerateAllWithAppConfigs(slug, planSlug string, app
 		primaryRegion := strings.TrimSpace(readStringCfg(pgCfg, "primary_region", "", "postgres"))
 		replicaRegion := strings.TrimSpace(readStringCfg(pgCfg, "replica_region", "", "postgres"))
 		if enableHA && primaryRegion != "" && replicaRegion != "" && primaryRegion != replicaRegion {
-			vcFiles["db-cnpg-pair.yaml"] = generateCNPGPair(appNS, dbPassword, postgresApps, pgCfg, primaryRegion, replicaRegion, g.cnpgStorageClass())
+			// #4297 keystone — the bp-cnpg-pair HelmRelease is a HelmRelease CR,
+			// NOT a plain manifest. The apps-sync Kustomization REDIRECTS the
+			// apps/ tree INTO the Org vCluster, but a vcluster runs NO
+			// in-cluster helm-controller (#3055 StateError), so an HR CR landing
+			// inside it would never reconcile. Instead emit it as a HOST file
+			// (reconciled by the host flux-system kustomization, alongside the
+			// apps-sync CR) carrying HR-level spec.kubeConfig → the HOST
+			// helm-controller runs `helm install` INTO the vcluster API. For the
+			// host tier there is no vcluster, so the HR reconciles on the host
+			// `<slug>` ns with no kubeConfig. See generateCNPGPair (isVcluster).
+			cnpgKubeSecret := ""
+			if isVcluster {
+				cnpgKubeSecret = "tenant-" + slug + "-kubeconfig"
+			}
+			// chartTargetNS — the namespace the chart installs into. For the
+			// vcluster tier the host helm-controller installs INTO the vcluster
+			// API, where the apps live in the `<slug>` namespace (the apps-sync
+			// Kustomization rewrites the apps/ tree's `apps` → `<slug>` on apply
+			// into the vcluster). For the host tier the HR reconciles on the host
+			// and the chart installs into the host `<slug>` ns. Either way the
+			// chart target is `<slug>`, co-located with the app pods + the
+			// postgres-credentials Secret.
+			//
+			// HOST-reconciled HelmRelease (+ HelmRepository) with HR-level
+			// kubeConfig → installs the CNPG Clusters INTO the vcluster.
+			hostFiles["db-cnpg-pair.yaml"] = generateCNPGPair(slug, dbPassword, postgresApps, pgCfg, primaryRegion, replicaRegion, g.cnpgStorageClass(), cnpgKubeSecret)
+			// The standalone postgres-credentials Secret the app pods read goes
+			// INSIDE the vcluster (apps/ tree), co-located with the app pods. It
+			// is authored with the apps-tree namespace ("apps"); the apps-sync
+			// Kustomization rewrites it to `<slug>` on apply, matching the chart
+			// targetNamespace above.
+			vcFiles["db-cnpg-pair-secret.yaml"] = generateCNPGPairSecret(appNS, dbPassword, postgresApps)
 		} else {
 			if enableHA {
 				// Operator opted in but didn't supply distinct region
@@ -372,6 +443,14 @@ func (g *ManifestGenerator) GenerateAllWithAppConfigs(slug, planSlug string, app
 	}
 	vcFiles["kustomization.yaml"] = generateKustomization(appNS, vcFiles)
 
+	// #4297: assemble the host kustomization.yaml LAST so it enumerates every
+	// host-scoped file including any host-reconciled HelmRelease the db block
+	// added above (the bp-cnpg-pair HR lives here, not in apps/). The host
+	// kustomization carries no `namespace:` — the apps-sync CR + ingress are
+	// flux-system / host-namespaced by their own metadata, and the cnpg-pair HR
+	// stamps its own namespace.
+	hostFiles["kustomization.yaml"] = generateKustomization("", hostFiles)
+
 	// --- assemble paths prefixed by tenant dir ---
 	dir := g.TenantDir(slug)
 	result := make(map[string]string, len(hostFiles)+len(vcFiles))
@@ -406,18 +485,44 @@ func (g *ManifestGenerator) GenerateAllWithAppConfigs(slug, planSlug string, app
 // by the teardown handler and its finalizer completes against a still-live
 // flux-system namespace.
 //
-// spec.targetNamespace is informational here because reconciliation is
-// redirected into the vCluster via spec.kubeConfig; we still set it so the
-// intent ("these resources belong to tenant-<slug>") is visible in the CR.
+// spec.targetNamespace stamps the destination ns. For BOTH tiers it is the
+// org-controller-owned `<slug>` namespace — for the vcluster tier it is the
+// in-vcluster namespace the synced resources land in; for the host tier it is
+// the host namespace the resources are applied into directly.
 //
-// kubeConfig.secretRef: Flux's Kustomization API only accepts `name` and
-// `key` on secretRef (no namespace override), so the secret must live in
-// flux-system. The vcluster HelmRelease writes the kubeconfig to
-// `tenant-<slug>/vc-vcluster`; the provisioning workflow mirrors that secret
-// into `flux-system/tenant-<slug>-kubeconfig` after HelmRelease becomes
-// Ready (see handlers.MirrorVClusterKubeconfig). The mirror is deleted
-// during teardown.
-func generateAppsSyncKustomization(ns, slug, basePath string) string {
+// #4297 keystone — TIER-AWARE kubeConfig. For the VCLUSTER tier (isVcluster
+// true) the Kustomization carries spec.kubeConfig.secretRef so the host Flux
+// kustomize-controller reconciles the apps tree INTO the Org vCluster apiserver
+// (the apps then run inside the vcluster, not on the host). For the HOST tier
+// (free/S) there is NO vcluster — emitting a kubeConfig referencing the
+// never-created `vc-vcluster` mirror would StateError forever and the host-tier
+// Org's apps would never deploy. So host-tier omits kubeConfig entirely and the
+// apps reconcile straight into the host `<slug>` ns (which IS the boundary).
+//
+// kubeConfig.secretRef (vcluster tier only): Flux's Kustomization API accepts
+// only `name`+`key` on secretRef (no namespace override), so the secret must
+// live in flux-system alongside the CR. The org-controller's `vcluster`
+// HelmRelease exports the kubeconfig to `<slug>/vc-vcluster`; the provisioning
+// workflow mirrors that into `flux-system/tenant-<slug>-kubeconfig` after the
+// vcluster HelmRelease becomes Ready (handlers.mirrorVClusterKubeconfig). The
+// mirror is deleted during teardown.
+//
+// Readiness gating: NO manifest-level dependsOn is used (Flux Kustomization
+// dependsOn references other Kustomizations, not the vcluster HelmRelease). The
+// gate is enforced in code: the consumer waits for the vcluster HR Ready and
+// mirrors the kubeconfig BEFORE the apps are expected up; until the mirror
+// exists this Kustomization simply StateErrors-then-retries (retryInterval 1m)
+// — the intended self-healing for the vcluster tier. The host tier has no
+// secret dependency at all, so it reconciles immediately.
+func generateAppsSyncKustomization(ns, slug, basePath string, isVcluster bool) string {
+	kubeConfig := ""
+	if isVcluster {
+		kubeConfig = fmt.Sprintf(`
+  kubeConfig:
+    secretRef:
+      name: tenant-%s-kubeconfig
+      key: config`, slug)
+	}
 	return fmt.Sprintf(`apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -434,12 +539,8 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  path: ./%s/%s/apps
-  kubeConfig:
-    secretRef:
-      name: tenant-%s-kubeconfig
-      key: config
-`, slug, ns, basePath, slug, slug)
+  path: ./%s/%s/apps%s
+`, slug, ns, basePath, slug, kubeConfig)
 }
 
 func generateHostIngress(ns, slug string, appSlugs []string) string {
@@ -707,7 +808,31 @@ spec:
 // per-Sovereign overlay MUST pin a SHA digest. Leaving it empty in the
 // orchestrator output keeps the contract that overlay layer is the
 // single owner of image pins.
-func generateCNPGPair(ns, password string, apps []string, cfg map[string]any, primaryRegion, replicaRegion, storageClass string) string {
+// #4297 — generateCNPGPair emits a HelmRelease CR. Unlike the plain-manifest db
+// paths (generatePostgres/MySQL/Redis), an HR CR cannot simply be redirected
+// INTO the vcluster by the apps-sync Kustomization: vclusters run NO in-cluster
+// helm-controller, so the synced HR StateErrors (#3055). The robust model is
+// HelmRelease.spec.kubeConfig — the HR CR + its HelmRepository live on the HOST
+// (reconciled by the host helm-controller / flux-system kustomization), and the
+// host helm-controller runs `helm install` INTO the vcluster API named by
+// kubeSecret. The chart's resources (CNPG Clusters etc.) then land in the
+// vcluster `targetNamespace` (= ns, "apps").
+//
+// The `postgres-credentials` Secret is NOT chart-templated — the marketplace
+// app pods read its POSTGRES_* keys directly. It must therefore live INSIDE the
+// vcluster alongside the app pods, so it is emitted SEPARATELY by
+// generateCNPGPairSecret into the apps/ tree (Kustomization-redirected), NOT
+// here on the host.
+//
+// ns is the chart TARGET namespace (= the Org `<slug>`): for the vcluster tier
+// the host helm-controller installs the chart into the vcluster's `<slug>` ns
+// (where the apps-sync-rewritten app pods + postgres-credentials Secret live);
+// for the host tier the chart installs into the host `<slug>` ns.
+//
+// kubeSecret is the flux-system-co-located vcluster kubeconfig mirror
+// (`tenant-<slug>-kubeconfig`); empty for the host tier (no vcluster → the HR
+// reconciles on the host and the chart installs into the host `<slug>` ns).
+func generateCNPGPair(ns, password string, apps []string, cfg map[string]any, primaryRegion, replicaRegion, storageClass, kubeSecret string) string {
 	sortedApps := sortStrings(append([]string{}, apps...))
 	primaryDB := "appdb"
 	if len(sortedApps) > 0 {
@@ -736,6 +861,25 @@ func generateCNPGPair(ns, password string, apps []string, cfg map[string]any, pr
 	// the legacy single-cluster path).
 	diskGB := readIntCfg(cfg, "disk_gb", 5, 1, 500, "postgres")
 
+	// HR-level kubeConfig (vcluster tier only). Flux's HelmRelease secretRef
+	// accepts name+key only — the namespace is implied from the HR's OWN
+	// namespace. The provisioning workflow mirrors `<slug>/vc-vcluster` →
+	// `flux-system/tenant-<slug>-kubeconfig`, so for the secretRef to resolve
+	// the HR (+ its HelmRepository) must ALSO live in flux-system. Authoring the
+	// HR in flux-system for the vcluster tier keeps the kubeconfig reachable and
+	// mirrors the apps-sync CR's placement. Host tier omits kubeConfig and the
+	// HR is authored in the host `<slug>` ns (= ns) where the chart installs.
+	hrNamespace := ns
+	kubeConfigBlock := ""
+	if kubeSecret != "" {
+		hrNamespace = "flux-system"
+		kubeConfigBlock = fmt.Sprintf(`
+  kubeConfig:
+    secretRef:
+      name: %s
+      key: config`, kubeSecret)
+	}
+
 	return fmt.Sprintf(`# bp-cnpg-pair — Pillar-3 active-hot-standby install path for
 # postgres-backed marketplace apps (TBD-V17 #2068). Renders the
 # primary + replica CNPG Cluster CR pair across the two regions the
@@ -743,23 +887,11 @@ func generateCNPGPair(ns, password string, apps []string, cfg map[string]any, pr
 # ClusterMesh; failover-readiness probe + audit ConfigMap wired by the
 # chart's own templates (platform/cnpg-pair/chart/templates/*).
 #
-# postgres-credentials Secret carries the same shape the legacy
-# single-cluster path emits so co-installed marketplace apps' env
-# bindings (POSTGRES_HOST=postgres, POSTGRES_USER=app, etc.) keep
-# working. The Service the apps connect to is the primary Cluster
-# CR's bootstrap-managed RW endpoint (cnpgPair.primary.bootstrap.database
-# = primary DB name).
-apiVersion: v1
-kind: Secret
-metadata:
-  name: postgres-credentials
-  namespace: %s
-type: Opaque
-stringData:
-  POSTGRES_USER: app
-  POSTGRES_PASSWORD: "%s"
-  POSTGRES_DB: %s
----
+# #4297 — HOST-reconciled HR with HR-level spec.kubeConfig (vcluster tier):
+# the host helm-controller installs the chart INTO the Org vCluster API so
+# the chart's CNPG Clusters land inside the vcluster. The companion
+# postgres-credentials Secret is emitted separately into the apps/ tree
+# (generateCNPGPairSecret) so the in-vcluster app pods can read it.
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
 metadata:
@@ -784,7 +916,7 @@ metadata:
 spec:
   interval: 15m
   releaseName: cnpg-pair
-  targetNamespace: %s
+  targetNamespace: %s%s
   chart:
     spec:
       chart: bp-cnpg-pair
@@ -831,7 +963,37 @@ spec:
       # clusterMesh.enabled + audit subjects). Per-Sovereign overlays
       # may patch values via Flux postBuild substitute; we intentionally
       # do NOT override here.
-`, ns, password, primaryDB, ns, ns, ns, ns, primaryRegion, instances, diskGB, storageClass, primaryDB, replicaRegion, instances, diskGB, storageClass)
+`, hrNamespace, hrNamespace, ns, kubeConfigBlock, hrNamespace, primaryRegion, instances, diskGB, storageClass, primaryDB, replicaRegion, instances, diskGB, storageClass)
+}
+
+// generateCNPGPairSecret emits the standalone postgres-credentials Secret the
+// marketplace app pods read (POSTGRES_USER/PASSWORD/DB). It is NOT chart-
+// templated, so it must live INSIDE the vcluster alongside the app pods — it is
+// emitted into the apps/ tree (Kustomization-redirected into the vcluster),
+// separate from the host-reconciled HelmRelease (#4297). ns is the in-vcluster
+// app namespace ("apps"); targetNamespace on the apps-sync Kustomization rewrites
+// it to the vcluster's `<slug>` on apply.
+func generateCNPGPairSecret(ns, password string, apps []string) string {
+	sortedApps := sortStrings(append([]string{}, apps...))
+	primaryDB := "appdb"
+	if len(sortedApps) > 0 {
+		primaryDB = "db_" + sortedApps[0]
+	}
+	return fmt.Sprintf(`# postgres-credentials — read by the in-vcluster marketplace app pods
+# (POSTGRES_HOST=postgres, POSTGRES_USER=app, etc.). Lives inside the vcluster
+# (apps/ tree) so it co-locates with the app pods; the CNPG Clusters are
+# installed by the host-reconciled bp-cnpg-pair HelmRelease (#4297).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-credentials
+  namespace: %s
+type: Opaque
+stringData:
+  POSTGRES_USER: app
+  POSTGRES_PASSWORD: "%s"
+  POSTGRES_DB: %s
+`, ns, password, primaryDB)
 }
 
 func generateMySQL(ns, password string, apps []string, cfg map[string]any, registryMirror string) string {

--- a/core/services/provisioning/handlers/app_pod_match_4297_test.go
+++ b/core/services/provisioning/handlers/app_pod_match_4297_test.go
@@ -1,0 +1,41 @@
+package handlers
+
+import "testing"
+
+// #4297 — the provisioning workflow's app-readiness poll must match the right
+// pod-name shape per tier. Vcluster-tier (M+) app pods are synced up to the
+// host ns as `<appSlug>-...-x-apps-x-vcluster`; host-tier (free/S, no vcluster)
+// pods run natively in the host ns as `<appSlug>-...`. A host-tier wait that
+// looked for the syncer suffix would never match → 10-min timeout → false
+// provision failure. This locks the pure matcher.
+func TestAppPodNameMatches_TierAware(t *testing.T) {
+	cases := []struct {
+		name       string
+		podName    string
+		appSlug    string
+		isVcluster bool
+		want       bool
+	}{
+		// Vcluster tier — only the syncer-suffixed pod matches.
+		{"vcluster synced pod matches", "wordpress-7d9f-x-apps-x-vcluster", "wordpress", true, true},
+		{"vcluster native pod does NOT match", "wordpress-7d9f", "wordpress", true, false},
+		{"vcluster wrong app", "ghost-7d9f-x-apps-x-vcluster", "wordpress", true, false},
+
+		// Host tier — only the native-named pod matches; a stray synced pod from
+		// a sibling vcluster Org sharing the ns must NOT satisfy the wait.
+		{"host native pod matches", "wordpress-7d9f", "wordpress", false, true},
+		{"host rejects synced pod", "wordpress-7d9f-x-apps-x-vcluster", "wordpress", false, false},
+		{"host wrong app", "ghost-7d9f", "wordpress", false, false},
+
+		// Prefix discipline — a different app whose name starts similarly.
+		{"prefix boundary respected", "wordpress2-7d9f", "wordpress", false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := appPodNameMatches(tc.podName, tc.appSlug, tc.isVcluster); got != tc.want {
+				t.Errorf("appPodNameMatches(%q, %q, isVcluster=%v) = %v, want %v",
+					tc.podName, tc.appSlug, tc.isVcluster, got, tc.want)
+			}
+		})
+	}
+}

--- a/core/services/provisioning/handlers/consumer.go
+++ b/core/services/provisioning/handlers/consumer.go
@@ -207,12 +207,16 @@ func (h *Handler) waitAndFinalizeInstall(ctx context.Context, data appChangeData
 	h.markJobStep(ctx, job, 1, "running", "")
 	// #4290: org-controller-owned `<slug>` host namespace (single boundary).
 	hostNS := data.TenantSlug
+	// #4297 TIER GATE — vcluster tiers (M+) sync app pods up to the host ns
+	// with the `-x-apps-x-vcluster` suffix; host tiers (free/S) run them with
+	// native names in the host ns. Match the right shape.
+	isVcluster := gitops.BoundaryIsVcluster(h.resolvePlanSlug(ctx, data.PlanID))
 	waitSlugs := data.DeploySlugs
 	if len(waitSlugs) == 0 {
 		waitSlugs = []string{data.AppSlug}
 	}
 	for _, slug := range waitSlugs {
-		if err := h.waitForVclusterApp(ctx, hostNS, slug, 10*time.Minute); err != nil {
+		if err := h.waitForVclusterApp(ctx, hostNS, slug, 10*time.Minute, isVcluster); err != nil {
 			if ctx.Err() != nil {
 				slog.Warn("day-2 install: wait canceled — tenant delete preempted",
 					"tenant", data.TenantSlug, "app", slug, "job_id", job.ID)
@@ -1075,6 +1079,14 @@ func (h *Handler) runProvisioningWorkflow(provisionID, tenantID, subdomain, plan
 	// `tenant-<slug>`. The vCluster pods sync up into `<slug>`; every wait /
 	// pod-status / TLS poll below targets it.
 	hostNS := subdomain
+	// #4297 TIER GATE (keystone of EPIC #4293) — paid M+ Orgs get a dedicated
+	// vCluster (the apps are reconciled INTO it via the apps-sync Kustomization's
+	// kubeConfig); free/S Orgs have NO vcluster, so the apps land directly in the
+	// host `<slug>` ns. The vcluster-HR wait, the DNS-sync kick, and the
+	// kubeconfig mirror below are ALL vcluster-only — running them for a host-tier
+	// Org would block forever (no `vcluster` HelmRelease, no `vc-vcluster` secret
+	// ever appears). Gate every vcluster-specific step on this predicate.
+	isVcluster := gitops.BoundaryIsVcluster(planSlug)
 	stepIdx := 0
 
 	// --- Step: Generate manifests ---
@@ -1141,39 +1153,54 @@ func (h *Handler) runProvisioningWorkflow(provisionID, tenantID, subdomain, plan
 	stepIdx++
 
 	// --- Step: Wait for vCluster HelmRelease Ready ---
+	// #4297 TIER GATE — vcluster-only. The "Provisioning vCluster" step stays in
+	// the timeline for BOTH tiers (step indices must stay stable), but for the
+	// HOST tier (free/S — no vcluster) there is no `vcluster` HelmRelease, no
+	// syncer DNS to kick, and no `vc-vcluster` kubeconfig to mirror. Running any
+	// of those waits would block the host-tier provision forever. So host-tier
+	// completes this step immediately with an explanatory message and lets the
+	// apps-sync Kustomization reconcile the apps straight into the host `<slug>`
+	// ns (no kubeConfig — see generateAppsSyncKustomization).
 	vcStepIdx := stepIdx
 	h.markStep(ctx, provisionID, vcStepIdx, prov.Steps[vcStepIdx].Name, "running")
-	if err := h.waitForHelmRelease(ctx, hostNS, "vcluster", 10*time.Minute); err != nil {
-		h.failStep(ctx, provisionID, tenantID, vcStepIdx, prov.Steps[vcStepIdx].Name, err.Error())
-		h.failProvision(ctx, provisionID, tenantID, vcStepIdx, fmt.Sprintf("vcluster not ready: %s", err))
-		return
+	if isVcluster {
+		if err := h.waitForHelmRelease(ctx, hostNS, "vcluster", 10*time.Minute); err != nil {
+			h.failStep(ctx, provisionID, tenantID, vcStepIdx, prov.Steps[vcStepIdx].Name, err.Error())
+			h.failProvision(ctx, provisionID, tenantID, vcStepIdx, fmt.Sprintf("vcluster not ready: %s", err))
+			return
+		}
+		// HelmRelease Ready only guarantees vcluster-0 is up; the syncer's initial
+		// DNS reconciliation is racy and sometimes leaves kube-dns-x-kube-system-x-
+		// vcluster absent from the host NS. Without that service, app pods inside
+		// the vcluster can't resolve DNS and stay Pending for their full 10-min
+		// wait. Issue #103. Observed on tenant e2e90689b today — gitea + vaultwarden
+		// timed out as a side effect. Gate the next step on DNS being synced and
+		// bounce vcluster-0 once if it doesn't appear, before letting app installs
+		// dispatch.
+		if err := h.waitForVclusterDNSOrKick(ctx, hostNS); err != nil {
+			slog.Warn("vcluster DNS did not sync after kick — proceeding anyway",
+				"ns", hostNS, "error", err)
+			// Don't fail provisioning: apps might still come up if DNS syncs late,
+			// and a hard fail here would strand the tenant. We've done what we can.
+		}
+		// Mirror the vCluster kubeconfig into flux-system so the per-tenant Flux
+		// Kustomization CR (which now lives in flux-system — see issue #97) can
+		// resolve its spec.kubeConfig.secretRef. Without this mirror the CR
+		// reconciles into "secret not found" and tenant apps never deploy.
+		if err := h.mirrorVClusterKubeconfig(ctx, subdomain); err != nil {
+			slog.Error("failed to mirror vcluster kubeconfig", "tenant", subdomain, "error", err)
+			h.failStep(ctx, provisionID, tenantID, vcStepIdx, prov.Steps[vcStepIdx].Name, err.Error())
+			h.failProvision(ctx, provisionID, tenantID, vcStepIdx,
+				fmt.Sprintf("mirror kubeconfig to flux-system: %s", err))
+			return
+		}
+		h.completeStep(ctx, provisionID, tenantID, vcStepIdx, prov.Steps[vcStepIdx].Name, totalSteps)
+	} else {
+		slog.Info("host-tier Org (no vCluster) — skipping vcluster HR wait / DNS kick / kubeconfig mirror; apps reconcile into the host namespace",
+			"tenant", subdomain, "plan", planSlug, "ns", hostNS)
+		h.completeStepWithMessage(ctx, provisionID, tenantID, vcStepIdx, prov.Steps[vcStepIdx].Name, totalSteps,
+			"host-tier plan — apps run directly in the Org namespace (no dedicated vCluster)")
 	}
-	// HelmRelease Ready only guarantees vcluster-0 is up; the syncer's initial
-	// DNS reconciliation is racy and sometimes leaves kube-dns-x-kube-system-x-
-	// vcluster absent from the host NS. Without that service, app pods inside
-	// the vcluster can't resolve DNS and stay Pending for their full 10-min
-	// wait. Issue #103. Observed on tenant e2e90689b today — gitea + vaultwarden
-	// timed out as a side effect. Gate the next step on DNS being synced and
-	// bounce vcluster-0 once if it doesn't appear, before letting app installs
-	// dispatch.
-	if err := h.waitForVclusterDNSOrKick(ctx, hostNS); err != nil {
-		slog.Warn("vcluster DNS did not sync after kick — proceeding anyway",
-			"ns", hostNS, "error", err)
-		// Don't fail provisioning: apps might still come up if DNS syncs late,
-		// and a hard fail here would strand the tenant. We've done what we can.
-	}
-	// Mirror the vCluster kubeconfig into flux-system so the per-tenant Flux
-	// Kustomization CR (which now lives in flux-system — see issue #97) can
-	// resolve its spec.kubeConfig.secretRef. Without this mirror the CR
-	// reconciles into "secret not found" and tenant apps never deploy.
-	if err := h.mirrorVClusterKubeconfig(ctx, subdomain); err != nil {
-		slog.Error("failed to mirror vcluster kubeconfig", "tenant", subdomain, "error", err)
-		h.failStep(ctx, provisionID, tenantID, vcStepIdx, prov.Steps[vcStepIdx].Name, err.Error())
-		h.failProvision(ctx, provisionID, tenantID, vcStepIdx,
-			fmt.Sprintf("mirror kubeconfig to flux-system: %s", err))
-		return
-	}
-	h.completeStep(ctx, provisionID, tenantID, vcStepIdx, prov.Steps[vcStepIdx].Name, totalSteps)
 	stepIdx++
 
 	// --- Steps: Parallel dependency installs ---
@@ -1192,7 +1219,7 @@ func (h *Handler) runProvisioningWorkflow(provisionID, tenantID, subdomain, plan
 			depWG.Add(1)
 			go func(depSlug, stepName string, stepIdx int) {
 				defer depWG.Done()
-				if err := h.waitForVclusterApp(ctx, hostNS, depSlug, 10*time.Minute); err != nil {
+				if err := h.waitForVclusterApp(ctx, hostNS, depSlug, 10*time.Minute, isVcluster); err != nil {
 					depFailed.Store(true)
 					h.failStep(ctx, provisionID, tenantID, stepIdx, stepName, err.Error())
 					return
@@ -1222,7 +1249,7 @@ func (h *Handler) runProvisioningWorkflow(provisionID, tenantID, subdomain, plan
 		wg.Add(1)
 		go func(appSlug, stepName string, stepIdx int) {
 			defer wg.Done()
-			if err := h.waitForVclusterApp(ctx, hostNS, appSlug, 10*time.Minute); err != nil {
+			if err := h.waitForVclusterApp(ctx, hostNS, appSlug, 10*time.Minute, isVcluster); err != nil {
 				failed.Store(true)
 				h.failStep(ctx, provisionID, tenantID, stepIdx, stepName, err.Error())
 				return

--- a/core/services/provisioning/handlers/handlers.go
+++ b/core/services/provisioning/handlers/handlers.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"time"
 
-	ghclient "github.com/openova-io/openova/core/services/provisioning/github"
 	"github.com/openova-io/openova/core/services/provisioning/gitguard"
+	ghclient "github.com/openova-io/openova/core/services/provisioning/github"
 	"github.com/openova-io/openova/core/services/provisioning/gitops"
 	"github.com/openova-io/openova/core/services/provisioning/store"
 	"github.com/openova-io/openova/core/services/shared/events"
@@ -538,14 +538,42 @@ func (h *Handler) waitForHelmRelease(ctx context.Context, namespace, name string
 	return fmt.Errorf("helmrelease %s/%s not ready after %s", namespace, name, timeout)
 }
 
-// waitForVclusterApp waits until a vCluster-synced pod for the given app slug
-// is Running+Ready in the host namespace. vCluster syncs pods using the name
-// pattern <pod>-x-<inner-ns>-x-<vcluster-name> — the inner ns is "apps" and the
-// vcluster helm release name is "vcluster", so we look for `<appSlug>-...-x-apps-x-vcluster`.
-func (h *Handler) waitForVclusterApp(ctx context.Context, namespace, appSlug string, timeout time.Duration) error {
-	deadline := time.Now().Add(timeout)
+// waitForVclusterApp waits until an app pod for the given app slug is
+// Running+Ready in the host namespace.
+//
+// #4297 TIER-AWARE: for the VCLUSTER tier, vCluster syncs pods up to the host
+// ns under the name pattern <pod>-x-<inner-ns>-x-<vcluster-name> — inner ns is
+// "apps", vcluster release is "vcluster", so the synced pod is
+// `<appSlug>-...-x-apps-x-vcluster`. For the HOST tier (free/S, no vcluster)
+// the apps-sync Kustomization applies the Deployment straight into the host
+// `<slug>` ns, so the pod carries its NATIVE name `<appSlug>-...` with NO
+// syncer suffix. Callers pass `isVcluster` so the right pod-name shape is
+// matched; a host-tier wait that looked for the `-x-apps-x-vcluster` suffix
+// would never match and would always time out.
+// appPodNameMatches is the #4297 TIER-AWARE pod-name matcher. For the VCLUSTER
+// tier the app pod is synced up to the host ns with the
+// `<appSlug>-...-x-apps-x-vcluster` shape; for the HOST tier (no vcluster) the
+// pod runs natively in the host ns as `<appSlug>-...`. Extracted as a pure
+// function so the tier split is unit-testable without a live kube-API.
+//
+// The host-tier match is intentionally STRICT: it requires the slug-prefixed
+// name to NOT carry the vcluster syncer suffix, so a stray synced pod from a
+// sibling vcluster Org sharing the host ns can't satisfy a host-tier wait.
+func appPodNameMatches(podName, appSlug string, isVcluster bool) bool {
 	prefix := appSlug + "-"
-	suffix := "-x-apps-x-vcluster"
+	if !strings.HasPrefix(podName, prefix) {
+		return false
+	}
+	const vclusterSuffix = "-x-apps-x-vcluster"
+	if isVcluster {
+		return strings.HasSuffix(podName, vclusterSuffix)
+	}
+	// Host tier — native name, MUST NOT be a synced vcluster pod.
+	return !strings.HasSuffix(podName, vclusterSuffix)
+}
+
+func (h *Handler) waitForVclusterApp(ctx context.Context, namespace, appSlug string, timeout time.Duration, isVcluster bool) error {
+	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		body, err := h.k8sGet(fmt.Sprintf("/api/v1/namespaces/%s/pods", namespace))
 		if err == nil {
@@ -566,7 +594,7 @@ func (h *Handler) waitForVclusterApp(ctx context.Context, namespace, appSlug str
 			if jerr := json.Unmarshal(body, &podList); jerr == nil {
 				for _, pod := range podList.Items {
 					name := pod.Metadata.Name
-					if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, suffix) {
+					if !appPodNameMatches(name, appSlug, isVcluster) {
 						continue
 					}
 					if pod.Status.Phase != "Running" {


### PR DESCRIPTION
## Keystone of EPIC #4293 — apps land INSIDE the Org vCluster, tier-aware

Refs #4297. **Stacks on Workstream B** (base `fix/4292-org-vcluster-boundary`, PR #4298), which itself contains Workstream A.

### The bug
Every Organization gets its own vCluster, but the Org's apps were installing into the **host** namespace, leaving every tenant vCluster an empty shell — tenant control-plane isolation a silent no-op. Live-confirmed on omantel.biz: the demo Org's 7 app HelmReleases sit in host ns `org-7283eb4a-…` with `spec.kubeConfig = <none>`; the `demo` vcluster has **0** app namespaces.

### Emission site fixed
The per-Org app-install tree is emitted by the **provisioning funnel** (`core/services/provisioning/gitops/gitops.go`), reconciled by the host Flux. Post-A it already targeted `<slug>`, but:
- the apps-sync Flux Kustomization set its `kubeConfig` **unconditionally**, so **host-tier** Orgs (free/S, which have **no** vcluster per B's tier-gate) would StateError forever on the never-created `vc-vcluster` mirror → host-tier apps never deploy;
- the Pillar-3 **bp-cnpg-pair HelmRelease** was emitted *inside* the vcluster-redirected `apps/` tree — a vcluster runs no in-cluster helm-controller (#3055), so a synced HR CR StateErrors.

### The tier-aware fix
1. **`BoundaryIsVcluster(planSlug)`** — funnel tier gate in lockstep with B's authoritative `boundaryIsVcluster` (org-controller). free/S/"" → host-ns; m/l/xl/flexi → vcluster.
2. **`generateAppsSyncKustomization` is tier-aware**: vcluster-tier carries `spec.kubeConfig.secretRef: { name: tenant-<slug>-kubeconfig, key: config }` (host Flux installs **INTO** the vcluster API); host-tier omits kubeConfig (apps reconcile into the host `<slug>` ns, which **is** the boundary).
3. **CNPG-pair split** (Pillar-3 preserved, not deferred): the HR + HelmRepository become a **HOST** file (`flux-system`) with **HR-level** `spec.kubeConfig` → the host helm-controller `helm install`s the CNPG Clusters **into** the vcluster `<slug>` ns; the standalone `postgres-credentials` Secret moves to the `apps/` tree (in-vcluster, co-located with the app pods). Host-tier: no kubeConfig, HR in the host `<slug>` ns.
4. **Consumer (`consumer.go`)**: gate the three vcluster-only waits (vcluster-HR Ready / DNS-sync kick / kubeconfig mirror) on the tier — running them for a host-tier Org would block the provision forever. The "Provisioning vCluster" timeline step stays (stable indices) but completes immediately for host-tier.
5. **`waitForVclusterApp` is tier-aware** via the pure `appPodNameMatches` helper — vcluster pods carry the `-x-apps-x-vcluster` syncer suffix; host-tier pods run native names.

### Readiness gating
No manifest-level `dependsOn` (Flux Kustomization `dependsOn` references Kustomizations, not the vcluster HelmRelease). The gate is code-level: the consumer waits for the vcluster HR Ready + mirrors the kubeconfig before apps are expected; until the mirror exists the apps-sync Kustomization StateErrors-then-retries (`retryInterval: 1m`) — intended self-healing. Host-tier has no secret dependency → reconciles immediately.

### Render-diff

`apps-sync.yaml` — **vcluster tier (M)** vs **host tier (S)**:
```diff
   path: ./clusters/sov/tenants/acme/apps
-  kubeConfig:            # vcluster tier (M) — apps redirected INTO the vcluster
-    secretRef:
-      name: tenant-acme-kubeconfig
-      key: config
+  # host tier (S) — NO kubeConfig; apps reconcile into the host <slug> ns
```

`db-cnpg-pair.yaml` — **vcluster tier**, HOST file with HR-level kubeConfig:
```yaml
kind: HelmRelease
metadata:
  name: bp-cnpg-pair
  namespace: flux-system          # host file (mirror ns) so secretRef resolves
spec:
  targetNamespace: acme           # chart installs into the in-vcluster <slug> ns
  kubeConfig:
    secretRef:
      name: tenant-acme-kubeconfig
      key: config
```
…and the companion `apps/db-cnpg-pair-secret.yaml` (in-vcluster `postgres-credentials` Secret).

### Tests
`go build ./... && go vet ./... && go test ./...` green for the provisioning module; B's org-controller module untouched + green. New:
- `TestAppsSync_VclusterTier_HasKubeConfig`, `TestAppsSync_HostTier_NoKubeConfig` (s/free/"")
- `TestBoundaryIsVcluster_FunnelParity` (locks funnel↔B gate against drift)
- `TestCNPGPair_VclusterTier_HRLevelKubeConfig`, `TestCNPGPair_HostTier_NoKubeConfig`
- `TestAppPodNameMatches_TierAware`
- existing `TestWorkstreamA_FunnelRendersNoBoundary` + all `TestCNPGPair_*` / `TestPostgres_*` stay green.

### Guardrails
- **omantel.biz is PERMANENT, never-wipe.** Code-only; no live-env roll, no auto-merge. The live host-`org-<uuid>` apps keep serving until a validated migration PR moves them in (a follow-up, not this PR).
- `Refs #4297` (not `Closes`). Base = `fix/4292-org-vcluster-boundary` (stacks on B).
- No chart version bump needed (no chart files touched).

### Fresh-Org live walk (run when provider capacity opens)
On a **fresh M-tier Org** `<slug>`:
```bash
# 1. apps RUN INSIDE the vcluster
kubectl --context <slug>-vcluster get pods -A
# 2. NO parallel host org-<uuid> / tenant-<slug> app ns carrying the same pods
kubectl --context omantel-region-a get ns | grep -E 'org-|tenant-' ; \
kubectl --context omantel-region-a get hr -n <slug>
# 3. per-Org ResourceQuota + LimitRange + NetworkPolicies bind the real workloads (B)
kubectl --context <slug>-vcluster get resourcequota,limitrange,networkpolicy -A
```
DONE = screenshot + `kubectl get pods -A` (vcluster context) showing the Org's apps Running **inside** the vcluster + absence of the host app ns, posted on #4297.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
