### PR TITLE
fix(bp-openclaw): Cilium-Gateway NetworkPolicy + HTTPRoute so the controller reaches Ready on a Sovereign — chart 0.2.5 (Refs #4272)

### DIFF
--- a/platform/openclaw/README.md
+++ b/platform/openclaw/README.md
@@ -11,7 +11,8 @@ unified-rbac user-create hook ([ADR-0003](../../docs/adr/0003-rbac-newapi-user-c
 ## Architecture
 
 ```
-                       openclaw.<sme-domain>            (Traefik ingress + cert-manager TLS)
+                       openclaw.<org>.<pool>            (Cilium Gateway API HTTPRoute on a Sovereign;
+                                                         optional Traefik Ingress off-Sovereign, #4272)
                               │
                               ▼
               ┌──────────────────────────────────┐
@@ -58,9 +59,11 @@ blind runtime image) is intentionally reusable.
 | `templates/controller-rbac.yaml` | Namespaced `Role` + `RoleBinding` in **tenant** ns. `create` verbs split into separate rules WITHOUT `resourceNames` per `feedback_rbac_create_no_resourcenames.md` |
 | `templates/controller-deployment.yaml` | Multi-tenant controller pod |
 | `templates/controller-service.yaml` | ClusterIP Service for the controller |
-| `templates/controller-ingress.yaml` | Public hostname `openclaw.<sme-domain>` with cert-manager auto-issue |
+| `templates/httproute.yaml` | **(Sovereign exposure)** Cilium Gateway API `HTTPRoute` attaching `openclaw.<org>.<pool>` to the dedicated `cilium-gateway-console` (wildcard `*.<pool>` TLS listener ⇒ no per-host cert). Default `httpRoute.enabled: false`; the org-gitops overlay sets enabled + hostnames (#4272) |
+| `templates/controller-ingress.yaml` | **(off-Sovereign only)** Traefik `networking.k8s.io/v1` Ingress with cert-manager auto-issue. Default `ingress.enabled: false` — a Sovereign runs Cilium Gateway, not traefik, so this Ingress is INERT there and its per-host cert never issues (#4272) |
 | `templates/per-user-pod-template.yaml` | ConfigMap holding the pod-spec the controller renders per session |
-| `templates/networkpolicy.yaml` | Controller NetworkPolicy. The per-user pod's NetworkPolicy is rendered by the controller at session-start (see "Per-user pod NetworkPolicy" below) |
+| `templates/networkpolicy.yaml` | Controller K8s `NetworkPolicy` (Pod-selectable hops). Egress now includes the public-host `:443` JWKS hairpin the `/readyz` handler needs (#4272). The per-user pod's NetworkPolicy is rendered by the controller at session-start (see "Per-user pod NetworkPolicy" below) |
+| `templates/cilium-ingress-networkpolicy.yaml` | Controller `CiliumNetworkPolicy` `fromEntities:[ingress,host,remote-node]` → `:8080` — admits the Cilium Gateway Envoy (`ingress`) + kubelet readiness/liveness probe (`host`/`remote-node`), reserved entities no K8s `NetworkPolicy` selector can express. Gated on `cilium.io/v2` + `networkPolicy.ingress.allowGatewayEntity` (#4272) |
 | `controller/` | Source for the multi-tenant **controller** container image (separate OCI artifact `openclaw-controller`, built by `.github/workflows/openclaw-controller.yaml`). Validates the Organization end-user's Keycloak JWT (OIDC discovery + JWKS RS256), spawns one identity-blind runtime pod per session from the mounted pod-template ConfigMap, reverse-proxies the user to it, and reaps idle pods. |
 | `runtime/` | Source for the per-user runtime container image (separate OCI artifact, built by `.github/workflows/openclaw-runtime.yaml`) |
 | `tests/render-toggles.sh` | Helm-template integration test exercised by the blueprint-release CI workflow |

--- a/platform/openclaw/blueprint.yaml
+++ b/platform/openclaw/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-7-agentic-workspace
 spec:
-  version: 0.2.4
+  version: 0.2.5
   card:
     title: OpenClaw
     summary: |

--- a/platform/openclaw/chart/Chart.yaml
+++ b/platform/openclaw/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-openclaw
-version: 0.2.4
+version: 0.2.5
 appVersion: "0.2.0"
 description: |
   Catalyst Blueprint chart for the OpenClaw workspace controller pattern
@@ -31,6 +31,36 @@ description: |
 
   Changelog
   ─────────
+  0.2.5 (2026-06-25, #4272)
+    - Rework NetworkPolicy + exposure for the Cilium-Gateway Sovereign
+      topology (was traefik + separate-keycloak-namespace). The controller
+      ran but stayed 0/1 (not Ready) because its /readyz handler gates on
+      OIDC-JWKS reachability and the issuer is the PUBLIC host
+      (https://keycloak.<org>.<pool>/realms/org-<org>) — that JWKS fetch
+      hairpins out to the console-ELB EIP and back through the Cilium
+      Gateway on :443, but the old K8s NetworkPolicy only allowed :443 to
+      kube-system and :8443 to a separate `keycloak` namespace → JWKS
+      egress-denied → readyz 503 → never Ready.
+        • K8s NetworkPolicy: add public-host HTTPS egress
+          (`networkPolicy.controller.egress.allowPublicHttps`, default true,
+          :443 to 0.0.0.0/0 with optional CIDR `except`) for the JWKS
+          hairpin; ingress `fromNamespaceLabels` now defaults EMPTY (the
+          dead traefik-namespace rule is gone — the gateway hop is a
+          reserved entity no K8s selector can express).
+        • New CiliumNetworkPolicy (cilium-ingress-networkpolicy.yaml):
+          `fromEntities:[ingress,host,remote-node]` → controller :8080,
+          admitting BOTH the Cilium Gateway Envoy (`ingress`) and the
+          kubelet readiness/liveness probe (`host`/`remote-node`). Gated on
+          the cilium.io/v2 Capabilities check + `networkPolicy.ingress.
+          allowGatewayEntity` (default true). Mirrors bp-agenity (#4180) +
+          bp-newapi (#3374).
+        • New HTTPRoute (httproute.yaml) on `cilium-gateway-console`/
+          kube-system (wildcard `*.<pool>` TLS listener ⇒ no per-host cert),
+          replacing the INERT traefik Ingress. `httpRoute.enabled` default
+          false; `ingress.enabled` flipped to default false (the traefik
+          Ingress is never reconciled on a Sovereign and its `openclaw-tls`
+          Certificate sits False forever). assertNoPlaceholders no longer
+          trips on `ingress.host` when the Ingress is disabled.
   0.2.4 (2026-06-24, #4246)
     - Add `imagePullSecrets: [ghcr-pull]` (new top-level `imagePullSecrets`
       value) to the controller Deployment AND the per-user-pod template.

--- a/platform/openclaw/chart/templates/_helpers.tpl
+++ b/platform/openclaw/chart/templates/_helpers.tpl
@@ -195,8 +195,11 @@ HelmRelease.
 {{- if eq .Values.tenant.namespace "sme-example" }}
 {{- fail "tenant.namespace is still the placeholder — overlay must supply the SME tenant namespace" }}
 {{- end }}
-{{- if eq .Values.ingress.host "openclaw.example.local" }}
-{{- fail "ingress.host is still the placeholder — overlay must supply the controller public hostname" }}
+{{- /* #4272: ingress.host only matters when the traefik Ingress is rendered.
+       On a Sovereign the public exposure is httpRoute.hostnames (Cilium Gateway)
+       and ingress.enabled is false, so the placeholder host is harmless. */}}
+{{- if and .Values.ingress.enabled (eq .Values.ingress.host "openclaw.example.local") }}
+{{- fail "ingress.host is still the placeholder — overlay must supply the controller public hostname (or use httpRoute.hostnames on a Cilium-Gateway Sovereign)" }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/platform/openclaw/chart/templates/cilium-ingress-networkpolicy.yaml
+++ b/platform/openclaw/chart/templates/cilium-ingress-networkpolicy.yaml
@@ -1,0 +1,52 @@
+{{- /*
+#4272: the Cilium Gateway path to the OpenClaw controller is DEAD without
+this CNP, AND the kubelet readiness/liveness probe is dropped by the K8s
+NetworkPolicy on a Sovereign. Two facts drive this template:
+
+  1. Cilium Gateway API traffic reaches the backend with the reserved
+     `ingress` ENTITY identity (the Envoy proxy embedded in the cilium
+     agent), which NO K8s NetworkPolicy selector (podSelector /
+     namespaceSelector / ipBlock) can express — the exact failure class of
+     platform/newapi cilium-ingress-networkpolicy.yaml (#3374),
+     products/agenity (#4180), platform/wordpress-tenant (#3785) and the
+     sso-bridge kube-apiserver entity saga. A `namespaceSelector: traefik`
+     is INERT for gateway traffic.
+
+  2. The kubelet's /readyz + /healthz probe reaches the Pod from the node
+     with the reserved `host` (same node) / `remote-node` (other node)
+     entity — also NOT a Pod the K8s NetworkPolicy can select. Once the
+     traefik-namespace ingress rule is removed (the chart no longer
+     synthesises a dead rule on a Sovereign), the K8s NP is default-deny on
+     ingress, so the probe MUST be admitted here or the Pod stays 0/1 even
+     after the JWKS egress is fixed.
+
+CiliumNetworkPolicy fromEntities is the canonical, ADDITIVE expression:
+when both a K8s NetworkPolicy and a CNP select the same Pod the allow-sets
+UNION, so this only opens the gateway→controller + node→controller hops and
+leaves every other default-deny posture intact.
+
+Gated on the cilium.io/v2 Capabilities check (the #2988/#3102 idiom) so the
+chart still installs on CRD-less clusters (kind CI), and on
+networkPolicy.ingress.allowGatewayEntity so a non-Cilium overlay can opt out.
+*/ -}}
+{{- if and .Values.controller.enabled .Values.networkPolicy.enabled .Values.networkPolicy.ingress.allowGatewayEntity (.Capabilities.APIVersions.Has "cilium.io/v2") }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "bp-openclaw.fullname" . }}-controller-gateway-ingress
+  labels:
+    {{- include "bp-openclaw.labels" . | nindent 4 }}
+    catalyst.openova.io/component: controller-gateway-netpol
+spec:
+  endpointSelector:
+    matchLabels:
+      {{- include "bp-openclaw.selectorLabels" . | nindent 6 }}
+      catalyst.openova.io/component: controller
+  ingress:
+    - fromEntities:
+        {{- toYaml .Values.networkPolicy.ingress.gatewayEntities | nindent 8 }}
+      toPorts:
+        - ports:
+            - port: {{ .Values.controller.port | quote }}
+              protocol: TCP
+{{- end }}

--- a/platform/openclaw/chart/templates/httproute.yaml
+++ b/platform/openclaw/chart/templates/httproute.yaml
@@ -1,0 +1,41 @@
+{{- /*
+#4272: Cilium-Gateway HTTP exposure for the OpenClaw controller, replacing
+the traefik `networking.k8s.io/v1` Ingress (controller-ingress.yaml) which is
+INERT on a Sovereign — Sovereigns run the Cilium Gateway API, not traefik, so
+the Ingress object is never reconciled and the per-host `openclaw-tls`
+Certificate sits False forever (no HTTP-01 solver). This HTTPRoute attaches the
+per-Org host to the dedicated console Gateway whose `*.<pool>` wildcard TLS
+listener terminates TLS (so NO per-host Certificate is needed), mirroring
+products/agenity (#4180) + platform/keycloak httproute.yaml.
+
+Default OFF (httpRoute.enabled=false) so `helm template` smoke-renders cleanly
+without a host; the org-gitops overlay sets enabled + hostnames + parentRef.
+*/ -}}
+{{- if and .Values.controller.enabled .Values.httpRoute.enabled }}
+{{- if .Values.httpRoute.hostnames }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "bp-openclaw.fullname" . }}-controller
+  labels:
+    {{- include "bp-openclaw.labels" . | nindent 4 }}
+    catalyst.openova.io/component: controller
+spec:
+  parentRefs:
+    - name: {{ .Values.httpRoute.parentRef.name | quote }}
+      namespace: {{ .Values.httpRoute.parentRef.namespace | quote }}
+      {{- with .Values.httpRoute.parentRef.sectionName }}
+      sectionName: {{ . | quote }}
+      {{- end }}
+  hostnames:
+    {{- toYaml .Values.httpRoute.hostnames | nindent 4 }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ .Values.httpRoute.path | default "/" | quote }}
+      backendRefs:
+        - name: {{ include "bp-openclaw.fullname" . }}-controller
+          port: {{ .Values.service.port }}
+{{- end }}
+{{- end }}

--- a/platform/openclaw/chart/templates/networkpolicy.yaml
+++ b/platform/openclaw/chart/templates/networkpolicy.yaml
@@ -1,10 +1,17 @@
 {{- if and .Values.controller.enabled .Values.networkPolicy.enabled }}
 {{- $fullName := include "bp-openclaw.fullname" . -}}
 ---
-# ─── Controller NetworkPolicy ────────────────────────────────────────────
-# Ingress: traefik (public-facing) → controller :8080
-# Egress:  controller → kube-system (api-server + DNS), keycloak (OIDC),
-#          per-user pods in tenant namespace (proxy traffic)
+# ─── Controller NetworkPolicy (K8s, Pod-selectable hops) ─────────────────
+# Ingress: optional namespace-selector (e.g. a traefik ingress namespace on
+#          NON-Sovereign clusters). On a Cilium-Gateway Sovereign the public
+#          ingress hop is carried by the reserved `ingress` ENTITY, which NO
+#          K8s NetworkPolicy selector can express — that hop is admitted by
+#          the companion CiliumNetworkPolicy (cilium-ingress-networkpolicy.yaml,
+#          #4272). Leave fromNamespaceLabels empty on a Sovereign so this
+#          template does not synthesise a dead traefik-namespace rule.
+# Egress:  controller → kube-system (api-server + DNS), in-cluster Keycloak,
+#          public-host HTTPS (the /readyz OIDC-JWKS hairpin, #4272),
+#          per-user pods in the tenant namespace (proxy traffic).
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -21,13 +28,24 @@ spec:
     - Ingress
     - Egress
   ingress:
+    {{- /*
+    Optional namespace-selector ingress. On a Sovereign the gateway hop is
+    admitted by the CNP fromEntities:[ingress] carve-out, so the chart leaves
+    fromNamespaceLabels EMPTY (no rule synthesised). A non-Cilium overlay may
+    set fromNamespaceLabels (e.g. {kubernetes.io/metadata.name: traefik}) to
+    admit a traffic source K8s selectors CAN express. The kubelet health probe
+    (readiness/liveness) reaches the Pod with the `host`/`remote-node` entity,
+    also admitted by the companion CNP — NOT by a K8s NetworkPolicy.
+    */}}
+    {{- with .Values.networkPolicy.controller.ingress.fromNamespaceLabels }}
     - from:
         - namespaceSelector:
             matchLabels:
-              {{- toYaml .Values.networkPolicy.controller.ingress.fromNamespaceLabels | nindent 14 }}
+              {{- toYaml . | nindent 14 }}
       ports:
-        - port: {{ .Values.controller.port }}
+        - port: {{ $.Values.controller.port }}
           protocol: TCP
+    {{- end }}
   egress:
     # K8s api-server (pod create/delete + Secret list/get).
     # The kubernetes.default Service ClusterIP route is not always
@@ -47,7 +65,8 @@ spec:
           protocol: UDP
         - port: 53
           protocol: TCP
-    # Organization-vcluster Keycloak (OIDC discovery + JWKS).
+    # In-cluster Organization-vcluster Keycloak (OIDC discovery + JWKS) when
+    # the issuer resolves to an in-namespace/in-cluster Keycloak Service.
     - to:
         - namespaceSelector:
             matchLabels:
@@ -55,6 +74,28 @@ spec:
       ports:
         - port: {{ .Values.networkPolicy.controller.egress.keycloakPort }}
           protocol: TCP
+    {{- if .Values.networkPolicy.controller.egress.allowPublicHttps }}
+    # ── Public-host HTTPS — the /readyz OIDC-JWKS hairpin (#4272) ──────────
+    # On a Sovereign the controller's OIDC issuer is the PUBLIC host
+    # (https://keycloak.<org>.<pool>/realms/org-<org>) so the JWKS fetch
+    # MUST match the JWT `iss` claim — it cannot use the in-cluster Service
+    # name. That fetch hairpins out to the console-ELB EIP and back in through
+    # the Cilium Gateway on :443. Egress :443 to the world (no Pod selector
+    # can name an external EIP) is required, else the readyz JWKS fetch is
+    # default-denied → readyz 503 → the controller never reaches Ready.
+    # Set allowPublicHttps=false on a fully in-cluster overlay that resolves
+    # the issuer to an in-namespace Keycloak Service.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            {{- with .Values.networkPolicy.controller.egress.publicHttpsExcept }}
+            except:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+      ports:
+        - port: {{ .Values.networkPolicy.controller.egress.publicHttpsPort }}
+          protocol: TCP
+    {{- end }}
     # Per-user pod range — the controller proxies WebSocket/SSE traffic
     # to the runtime container in the tenant namespace.
     - to:

--- a/platform/openclaw/chart/tests/render-toggles.sh
+++ b/platform/openclaw/chart/tests/render-toggles.sh
@@ -28,12 +28,21 @@ if ! helm template smoke-openclaw . > "$TMP/default.yaml" 2> "$TMP/default.err";
   cat "$TMP/default.err" >&2
   exit 1
 fi
-for kind in Deployment Service Ingress Role RoleBinding ConfigMap NetworkPolicy ServiceAccount; do
+# #4272: Ingress is NO LONGER a default-rendered kind — a Sovereign runs the
+# Cilium Gateway, not traefik, so ingress.enabled defaults false and the
+# traefik Ingress is INERT there. HTTPRoute is the Sovereign exposure (asserted
+# in Case 8 with httpRoute.enabled=true).
+for kind in Deployment Service Role RoleBinding ConfigMap NetworkPolicy ServiceAccount; do
   if ! grep -qE "^kind: ${kind}$" "$TMP/default.yaml"; then
     echo "FAIL: default render is missing kind=${kind}" >&2
     exit 1
   fi
 done
+# The traefik Ingress must NOT render by default (it is inert on a Sovereign).
+if grep -qE "^kind: Ingress$" "$TMP/default.yaml"; then
+  echo "FAIL: default render still emits a traefik Ingress — ingress.enabled must default false on a Cilium-Gateway Sovereign (#4272)." >&2
+  exit 1
+fi
 echo "  PASS"
 
 echo "[render-toggles] Case 2: assertNoPlaceholders=true with default values FAILS render"
@@ -189,13 +198,98 @@ for placeholder in '${USER_UUID}' '${SECRET_NAME}'; do
 done
 echo "  PASS"
 
-echo "[render-toggles] Case 7: ingress carries cert-manager cluster-issuer annotation"
-# #4246 — default issuer is the DNS-01 PowerDNS ClusterIssuer that every
+echo "[render-toggles] Case 7: ingress (when explicitly enabled) carries cert-manager cluster-issuer annotation"
+# #4272 — ingress.enabled now defaults false (inert traefik Ingress on a
+# Sovereign), so enable it explicitly here for the NON-Sovereign portability
+# path. #4246 — default issuer is the DNS-01 PowerDNS ClusterIssuer every
 # Sovereign installs; `letsencrypt-prod` does not exist on a real Sovereign.
-if ! grep -q 'cert-manager.io/cluster-issuer: "letsencrypt-dns01-prod-powerdns"' "$TMP/default.yaml"; then
+if ! helm template smoke-openclaw . \
+    --set "ingress.enabled=true" \
+    > "$TMP/ingress-on.yaml" 2> "$TMP/ingress-on.err"; then
+  echo "FAIL: ingress.enabled=true render failed:" >&2
+  cat "$TMP/ingress-on.err" >&2
+  exit 1
+fi
+if ! grep -qE "^kind: Ingress$" "$TMP/ingress-on.yaml"; then
+  echo "FAIL: ingress.enabled=true did not render an Ingress — toggle is broken." >&2
+  exit 1
+fi
+if ! grep -q 'cert-manager.io/cluster-issuer: "letsencrypt-dns01-prod-powerdns"' "$TMP/ingress-on.yaml"; then
   echo "FAIL: ingress is missing cert-manager.io/cluster-issuer annotation — ACME auto-issue won't fire." >&2
   exit 1
 fi
+echo "  PASS"
+
+echo "[render-toggles] Case 8: Cilium-Gateway exposure — CNP fromEntities + HTTPRoute (#4272)"
+# A Sovereign needs the CiliumNetworkPolicy fromEntities:[ingress,host,
+# remote-node] carve-out (gateway hop + kubelet probe) AND an HTTPRoute on the
+# console gateway. The CNP renders by default (cilium.io/v2 present in the
+# helm-template Capabilities set); the HTTPRoute requires enabled + hostnames.
+if ! helm template smoke-openclaw . \
+    --api-versions "cilium.io/v2" \
+    --set "httpRoute.enabled=true" \
+    --set "httpRoute.hostnames[0]=openclaw.acme.omani.homes" \
+    > "$TMP/gw.yaml" 2> "$TMP/gw.err"; then
+  echo "FAIL: Cilium-Gateway render failed:" >&2
+  cat "$TMP/gw.err" >&2
+  exit 1
+fi
+# CNP present + correct fromEntities + the bare traefik-namespace ingress rule
+# is GONE from the K8s NetworkPolicy (fromNamespaceLabels defaults empty).
+RENDER_OUT="$TMP/gw.yaml" python3 - <<'PY'
+import os, sys, yaml
+docs = [d for d in yaml.safe_load_all(open(os.environ["RENDER_OUT"])) if d]
+cnp = [d for d in docs if d.get("kind") == "CiliumNetworkPolicy"]
+if not cnp:
+    print("FAIL: no CiliumNetworkPolicy rendered with cilium.io/v2 present (#4272 gateway hop would be default-denied).", file=sys.stderr); sys.exit(1)
+ents = set()
+for d in cnp:
+    for rule in d.get("spec", {}).get("ingress", []) or []:
+        ents.update(rule.get("fromEntities", []) or [])
+missing = {"ingress", "host", "remote-node"} - ents
+if missing:
+    print(f"FAIL: CNP fromEntities missing {sorted(missing)} (gateway/probe hop denied).", file=sys.stderr); sys.exit(1)
+# K8s NetworkPolicy must NOT carry a traefik-namespace ingress rule by default.
+for d in docs:
+    if d.get("kind") != "NetworkPolicy":
+        continue
+    for rule in d.get("spec", {}).get("ingress", []) or []:
+        for frm in rule.get("from", []) or []:
+            lbls = (frm.get("namespaceSelector") or {}).get("matchLabels") or {}
+            if lbls.get("kubernetes.io/metadata.name") == "traefik":
+                print("FAIL: K8s NetworkPolicy still synthesises a dead traefik-namespace ingress rule (#4272).", file=sys.stderr); sys.exit(1)
+PY
+if ! grep -qE "^kind: HTTPRoute$" "$TMP/gw.yaml"; then
+  echo "FAIL: httpRoute.enabled=true with a hostname did not render an HTTPRoute (#4272)." >&2
+  exit 1
+fi
+if ! grep -q "cilium-gateway-console" "$TMP/gw.yaml"; then
+  echo "FAIL: HTTPRoute does not parent cilium-gateway-console (would 404 on the console ELB, #4054/#4070)." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[render-toggles] Case 9: K8s NetworkPolicy egress permits the public-host :443 JWKS hairpin (#4272)"
+# The /readyz handler fetches JWKS from the PUBLIC issuer host, which hairpins
+# through the Cilium Gateway on :443. The egress rule must allow :443 to
+# 0.0.0.0/0 (no Pod selector can name the external EIP), else readyz 503.
+RENDER_OUT="$TMP/default.yaml" python3 - <<'PY'
+import os, sys, yaml
+docs = [d for d in yaml.safe_load_all(open(os.environ["RENDER_OUT"])) if d]
+ok = False
+for d in docs:
+    if d.get("kind") != "NetworkPolicy":
+        continue
+    for rule in d.get("spec", {}).get("egress", []) or []:
+        tos = rule.get("to", []) or []
+        has_world = any((t.get("ipBlock") or {}).get("cidr") == "0.0.0.0/0" for t in tos)
+        has_443 = any(p.get("port") == 443 for p in (rule.get("ports") or []))
+        if has_world and has_443:
+            ok = True
+if not ok:
+    print("FAIL: K8s NetworkPolicy egress is missing the :443 → 0.0.0.0/0 public-host JWKS hairpin rule — readyz would 503 (#4272).", file=sys.stderr)
+    sys.exit(1)
+PY
 echo "  PASS"
 
 echo "[render-toggles] All bp-openclaw render-toggle gates green."

--- a/platform/openclaw/chart/values.yaml
+++ b/platform/openclaw/chart/values.yaml
@@ -212,14 +212,16 @@ service:
 serviceAccount:
   create: true
   name: ""
-# ─── Ingress + cert-manager TLS ──────────────────────────────────────────
-# Public hostname for the controller. Per Q-mine-1 of #795:
-# `openclaw.<org-domain-or-subdomain>`. cert-manager auto-issues a
-# per-host certificate via the operator's ACME issuer.
+# ─── Ingress (traefik, NON-Sovereign only) ───────────────────────────────
+# DEFAULT OFF (#4272). A Sovereign runs the Cilium Gateway API, NOT traefik —
+# a `networking.k8s.io/v1` Ingress is INERT there (never reconciled) and its
+# per-host `openclaw-tls` Certificate sits False forever (no HTTP-01 solver).
+# Public exposure on a Sovereign is the `httpRoute` block below. Operators on a
+# non-Cilium cluster that genuinely runs traefik may set ingress.enabled=true.
 ingress:
-  enabled: true
+  enabled: false
   className: "traefik"
-  # Required at install time. Placeholder default lets smoke render pass.
+  # Required when ingress.enabled=true. Placeholder default lets smoke render.
   host: "openclaw.example.local"
   tls:
     enabled: true
@@ -230,32 +232,87 @@ ingress:
     issuer: "letsencrypt-dns01-prod-powerdns" # cert-manager ClusterIssuer
     secretName: "openclaw-tls"
   annotations: {}
+# ─── HTTPRoute (Cilium Gateway API — the Sovereign exposure) ──────────────
+# #4272: the canonical per-Org HTTP exposure on a Sovereign. Attaches the
+# controller's public host to the DEDICATED console Gateway whose `*.<pool>`
+# wildcard TLS listener terminates TLS (so NO per-host Certificate is needed),
+# mirroring products/agenity (#4180) + platform/keycloak. Default OFF so smoke
+# render passes without a host; the org-gitops overlay sets enabled + hostnames.
+httpRoute:
+  enabled: false
+  # Per-Org host(s) — e.g. [openclaw.<slug>.<pool>]. Empty ⇒ template renders
+  # nothing (the guard fails closed, matching the agenity pattern).
+  hostnames: []
+  parentRef:
+    # console-isolation (#4054/#4070): openclaw.<slug>.<pool> resolves to the
+    # dedicated console-ELB EIP fronting the ISOLATED cilium-gateway-console
+    # (NOT the apps cilium-gateway). The console Gateway carries the *.<pool>
+    # wildcard TLS listener so TLS terminates on the wildcard cert; parenting
+    # the apps gateway → envoy 404 on the console ELB.
+    name: "cilium-gateway-console"
+    namespace: "kube-system"
+    # sectionName omitted by default — the console Gateway exposes a single
+    # apex-bound HTTPS listener per Org zone, matched by the hostname filter.
+    sectionName: ""
+  # Backend path prefix (the controller serves the UI/API at /).
+  path: "/"
 # ─── NetworkPolicy ───────────────────────────────────────────────────────
-# Default-allow ingress from the platform's gateway namespace (traefik).
-# Egress from CONTROLLER:
-#   - Organization-vcluster Keycloak (OIDC discovery + JWKS)
-#   - K8s api-server (pod create/delete; goes to kube-system endpoint)
+# K8s NetworkPolicy (Pod-selectable hops) + a companion CiliumNetworkPolicy
+# (cilium-ingress-networkpolicy.yaml) for the reserved-ENTITY hops that NO K8s
+# selector can express. Controller egress:
+#   - K8s api-server (pod create/delete; kube-system endpoint) + DNS
+#   - in-cluster Keycloak Service (when the issuer is in-cluster)
+#   - public-host HTTPS (the /readyz OIDC-JWKS hairpin to the Cilium Gateway
+#     on :443 — #4272; the issuer is the PUBLIC host so it cannot use the
+#     in-cluster Service name)
 #   - per-user pod range in tenant namespace (proxy WebSocket/SSE)
-#   - DNS
-# Egress from PER-USER pod (separate NetworkPolicy applied at pod-spawn
-# time by the controller, NOT by this chart's render — see
-# README.md §"per-user-pod NetworkPolicy"):
-#   - NewAPI Service (cluster-internal hostname or external ingress)
-#   - DNS
-# This chart's NetworkPolicy template covers the controller pod only;
-# per-user pods receive their NetworkPolicy from a controller-rendered
-# template at session-start.
+# Controller ingress:
+#   - Cilium Gateway Envoy (`ingress` entity) + kubelet probe (`host` /
+#     `remote-node` entities) — admitted by the CNP, NOT the K8s NP
+#     (#4272 — reserved entities are not Pod-selectable).
+# Per-user pods receive their NetworkPolicy from a controller-rendered
+# template at session-start, NOT from this chart.
 networkPolicy:
   enabled: true
+  # Cilium-Gateway awareness (#4272). The CNP fromEntities carve-out admits
+  # the gateway + kubelet-probe hops the K8s NP cannot select.
+  ingress:
+    # Emit the CiliumNetworkPolicy fromEntities carve-out. Default ON (a
+    # Sovereign needs it). A non-Cilium overlay (e.g. kind CI w/o the CRD, or
+    # a traefik cluster) can set this false — the template is also gated on the
+    # cilium.io/v2 Capabilities check so it never breaks CRD-less installs.
+    allowGatewayEntity: true
+    # Reserved entities admitted to the controller :8080:
+    #   - ingress      : the Cilium Gateway Envoy (public hop)
+    #   - host         : the kubelet readiness/liveness probe (same node)
+    #   - remote-node   : the kubelet probe when scheduled on another node
+    gatewayEntities:
+      - ingress
+      - host
+      - remote-node
   controller:
     ingress:
-      fromNamespaceLabels:
-        kubernetes.io/metadata.name: traefik
+      # K8s namespace-selector ingress. EMPTY on a Sovereign — the gateway hop
+      # is the reserved `ingress` entity (admitted by the CNP above), and a
+      # traefik-namespace rule would be a dead no-op. A genuine-traefik overlay
+      # may set {kubernetes.io/metadata.name: traefik} here.
+      fromNamespaceLabels: {}
     # Egress targets — operator may extend if Organization-vcluster Keycloak
     # reaches the controller via a different namespace label.
     egress:
       keycloakNamespaceLabel: "keycloak"
       keycloakPort: 8443
+      # Public-host HTTPS egress for the /readyz OIDC-JWKS hairpin (#4272).
+      # The controller's OIDC issuer is the PUBLIC host so the JWKS fetch
+      # hairpins out to the console-ELB EIP and back through the Cilium Gateway
+      # on :443. No Pod selector can name an external EIP ⇒ egress to the world
+      # on :443 is required, else readyz 503 → never Ready. Set false on a
+      # fully in-cluster overlay whose issuer is an in-namespace Service.
+      allowPublicHttps: true
+      publicHttpsPort: 443
+      # Optional CIDR exclusions (e.g. lock down to the console-ELB EIP /32 on
+      # a hardened overlay). Empty ⇒ the whole 0.0.0.0/0 :443 is permitted.
+      publicHttpsExcept: []
 # ─── ServiceMonitor ──────────────────────────────────────────────────────
 # Default false per docs/BLUEPRINT-AUTHORING.md §11.2 (Observability
 # toggles must default false). Operator opts in via per-cluster overlay

--- a/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
@@ -1545,10 +1545,36 @@ spec:
       baseURL: https://api.{{.Subdomain}}.{{.ParentDomain}}/v1
     tenant:
       namespace: {{.Namespace}}
+    # ── Public exposure: Cilium Gateway API (#4272) ────────────────────
+    # A Sovereign runs the Cilium Gateway, NOT traefik — the chart's
+    # networking.k8s.io/v1 Ingress is INERT here (never reconciled) and
+    # its per-host openclaw-tls Certificate sits False forever. Disable it
+    # and attach the controller host to the DEDICATED console Gateway whose
+    # *.<pool> wildcard TLS listener terminates TLS (no per-host cert),
+    # mirroring bp-agenity (#4180).
     ingress:
-      host: {{.OpenClawHost}}
-      tls:
-        issuer: letsencrypt-prod
+      enabled: false
+    httpRoute:
+      enabled: true
+      hostnames:
+        - {{.OpenClawHost}}
+      parentRef:
+        # console-isolation (#4054/#4070): openclaw.<slug>.<pool> resolves
+        # to the dedicated console-ELB EIP fronting cilium-gateway-console
+        # (NOT the apps cilium-gateway). The console Gateway carries the
+        # *.<pool> wildcard TLS listener so TLS terminates on the wildcard
+        # cert; parenting the apps gateway → envoy 404 on the console ELB.
+        name: cilium-gateway-console
+        namespace: kube-system
+    # CiliumNetworkPolicy fromEntities:[ingress,host,remote-node] — admits
+    # BOTH the Cilium Gateway Envoy (so the readyz OIDC-JWKS hairpin to the
+    # public host on :443 resolves and the dashboard is reachable) AND the
+    # kubelet readiness/liveness probe (else the controller stays 0/1 even
+    # after the JWKS egress is fixed). #4272.
+    networkPolicy:
+      enabled: true
+      ingress:
+        allowGatewayEntity: true
 `
 
 const orgTenantBPAgenity = `# bp-agenity (#4180) — the per-Organization agentic dashboard. The User

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -2576,7 +2576,7 @@ metadata:
     # must not claw it back (DoD §9.4).
     helm.sh/resource-policy: keep
 spec:
-  version: "0.2.0"
+  version: "0.2.5"
   visibility: listed
   card:
     title: "OpenClaw"
@@ -2611,7 +2611,7 @@ hook (ADR-0003). Identity-blind by construction.
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-openclaw
-    version: "0.2.0"
+    version: "0.2.5"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Refs #4272

`bp-openclaw` controller ran (`openclaw-controller listening on :8080`) but stayed **0/1 (not Ready)** on the omantel.biz demo Org. Its `/readyz` handler (`platform/openclaw/controller/main.go:206`) gates on **OIDC-JWKS reachability**; the OIDC issuer is the **public host** (`https://keycloak.<org>.<pool>/realms/org-<org>`, to match the JWT `iss` claim), so the JWKS fetch hairpins out to the console-ELB EIP and back through the **Cilium Gateway on :443**. The chart was built for a **traefik + separate-keycloak-namespace** topology, so that hairpin was egress-denied → readyz 503 → never Ready.

### Live root cause (READ-ONLY on `omantel-region-a`, ns `org-7283eb4a-…`)
```
pod/bp-openclaw-controller-5db8664b87-lvw59   0/1   Running   9h
pod/bp-openclaw-controller-77c49fc797-4hx24   0/1   Running   9h
Warning  Unhealthy  53s (x3538 over 9h)  kubelet
  Readiness probe failed: Get "http://10.42.1.21:8080/readyz": context deadline exceeded
```
Chart shipped a traefik **Ingress** + a single K8s **NetworkPolicy** — **no CiliumNetworkPolicy, no HTTPRoute**. The K8s NP allowed `:443` only to `kube-system` and `:8443` to a `keycloak` namespace, so the public-host JWKS hairpin was default-denied.

### Fix (the established pattern — mirrors bp-agenity #4180 / bp-newapi #3374 / bp-wordpress-tenant #3785)
- **`networkpolicy.yaml`** — add public-host HTTPS egress (`:443 → 0.0.0.0/0`, optional CIDR `except`) for the JWKS hairpin; ingress `fromNamespaceLabels` now defaults **empty** (no dead traefik-namespace rule).
- **`cilium-ingress-networkpolicy.yaml` (NEW)** — `CiliumNetworkPolicy` `fromEntities:[ingress,host,remote-node]` → controller `:8080`. Admits the Cilium Gateway Envoy (`ingress`) **and** the kubelet readiness/liveness probe (`host`/`remote-node`) — reserved entities no K8s `NetworkPolicy` selector can express. Gated on `cilium.io/v2` Capabilities + `networkPolicy.ingress.allowGatewayEntity` (default true; kind-CI safe).
- **`httproute.yaml` (NEW)** — `HTTPRoute` on `cilium-gateway-console`/`kube-system` (wildcard `*.<pool>` TLS listener ⇒ no per-host cert), replacing the inert traefik Ingress. `httpRoute.enabled` default **false**; `ingress.enabled` flipped to default **false**. `assertNoPlaceholders` no longer trips on `ingress.host` when the Ingress is disabled.
- **`organization_gitops.go`** — the per-Org openclaw HelmRelease now sets `ingress.enabled=false` + `httpRoute.{enabled,hostnames,parentRef}` + `networkPolicy.ingress.allowGatewayEntity` so the funnel actually delivers the fix.

### Version bump + pins (lockstep)
- `Chart.yaml` `0.2.4 → 0.2.5` (+ changelog)
- `platform/openclaw/blueprint.yaml` `0.2.4 → 0.2.5`
- catalog-seed `blueprints.yaml` `spec.version` + `source.version` `0.2.0 → 0.2.5`

### Verify
- `helm lint` clean; `tests/render-toggles.sh` **11/11 green** (added: CNP `fromEntities` shape + HTTPRoute parents console gateway; egress `:443` hairpin present; Ingress off by default).
- Rendered CNP/HTTPRoute match the keycloak/newapi/agenity reference shape.
- CNP correctly suppressed when `networkPolicy.enabled=false`, `allowGatewayEntity=false`, or `cilium.io/v2` CRD absent (kind CI).
- `go build` + handler/store tests pass; org-gitops openclaw HR renders valid YAML with the new values.
- **Not applied live** (READ-ONLY guardrail). The live block matches the diagnosis exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)