### PR TITLE
feat(bp-kyverno-policies): Kyverno admission floor injects secretRef on local-Gitea Flux sources (EPIC #4286 mechanism B) — 1.0.40

### DIFF
--- a/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
+++ b/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
@@ -118,7 +118,23 @@ spec:
       # barman/object-store WAL-streaming, not Velero, so the over-broad rule
       # stranded the entire DB tier (harbor-pg/gitea-pg/guacamole-pg/pdns-pg).
       # Mirrors the by-label CNPG carve-out on flux-managed (#3374).
-      version: 1.0.39
+      # 1.0.40 (EPIC #4286 mechanism B, 2026-06-25): NEW MUTATE policy
+      # `inject-gitea-source-secretref` — the ADMISSION FLOOR that auto-injects
+      # the canonical basic-auth secretRef (openova-org-tenants-git-auth) on any
+      # Flux GitRepository/HelmRepository/OCIRepository whose `spec.url` host
+      # targets the Sovereign-local Gitea AND which has an empty/absent secretRef.
+      # bp-gitea REQUIRE_SIGNIN_VIEW=true makes anonymous clone 401 for every
+      # repo, so a secretRef-less local-Gitea source sits "authentication
+      # required" forever (the #4283/#4284/#4285 bug class across 4 generators).
+      # Mechanism A (shared fluxsource Go factory, #4285) fixes the 3 in-tree Go
+      # generators; THIS policy is the regression-proof admission layer covering
+      # ANY origin (charts/Blueprints/hand-applied CRs/future generator). Host
+      # law mirrors fluxsource.IsLocalSovereignSource (`gitea` substring);
+      # github.com untouched; idempotent (never overrides org/operator secret).
+      # Scope GITEA ONLY (local-Harbor leg is the flagged follow-up); mechanism D
+      # (env-controller cross-ns reflection) stacks behind the vcluster EPIC.
+      # VERIFIED `kyverno test` 5/5. Refs #4286 #4285 #4283.
+      version: 1.0.40
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno

--- a/platform/kyverno-policies/blueprint.yaml
+++ b/platform/kyverno-policies/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.39
+  version: 1.0.40
   card:
     title: Kyverno Policy Library
     family: guardian

--- a/platform/kyverno-policies/chart/Chart.yaml
+++ b/platform/kyverno-policies/chart/Chart.yaml
@@ -1,5 +1,37 @@
 apiVersion: v2
 name: bp-kyverno-policies
+# 1.0.40 (EPIC #4286 mechanism B, 2026-06-25): NEW MUTATE policy
+# `inject-gitea-source-secretref` (templates/mutate/01-...) — the ADMISSION FLOOR
+# that auto-injects the canonical basic-auth `spec.secretRef.name`
+# (openova-org-tenants-git-auth) on any Flux GitRepository/HelmRepository/
+# OCIRepository whose `spec.url` host targets the Sovereign-local Gitea AND which
+# has an empty/absent secretRef. bp-gitea ships `service.REQUIRE_SIGNIN_VIEW=true`
+# (platform/gitea/chart/values.yaml), so an ANONYMOUS clone of the in-cluster
+# Gitea returns HTTP 401 "authentication required" for EVERY repo — a
+# secretRef-less local-Gitea source is therefore structurally invalid and sits
+# "authentication required" forever (the #4283 → #4284 → #4285 bug class that
+# recurred across 4 separate generators). Mechanism A (the shared
+# `core/controllers/pkg/fluxsource` Go factory, #4285) closes this for the 3
+# in-tree Go generators; THIS policy is the regression-proof admission layer that
+# ALSO covers sources from ANY OTHER origin (charts, Blueprints, hand-applied
+# CRs, a future fourth generator) — the layer that structurally defeats "the Nth
+# generator forgets". The host law mirrors fluxsource.IsLocalSovereignSource
+# (host carries the `gitea` substring): the in-cluster
+# `gitea-http.gitea.svc.cluster.local` service AND the per-Sovereign
+# `gitea.<loc>.<dom>` DNS match; github.com catalog-mirror sources do NOT and are
+# left untouched. MUTATE (not VALIDATE/deny) so a not-yet-migrated generator is
+# silently healed rather than fail-closed; idempotent — fires only when
+# secretRef.name is empty/absent, never overrides the org-controller/operator
+# value (the 19 catalyst-tenant-* sources are untouched). Scope is GITEA ONLY;
+# the local-Harbor leg (post-bp-self-sovereign-cutover registry pivot) reuses the
+# SAME admission guarantee and is the flagged follow-up. Mechanism D
+# (env-controller cross-namespace secret reflection) is OUT OF SCOPE — it stacks
+# behind the vcluster EPIC reshaping the env-controller. VERIFIED with
+# `kyverno test tests/inject-gitea-source-secretref/` (5/5 pass): a secretRef-less
+# in-cluster + per-Sovereign Gitea GitRepository (and an OCIRepository at a Gitea
+# host) are mutate-injected with openova-org-tenants-git-auth; a github.com source
+# is untouched; an already-secretRef'd source is untouched. Default ENABLED
+# (non-rejecting mutate). Refs #4286 #4285 #4283.
 # 1.0.36 (#3825, hw165, 2026-06-19): EXEMPT the `trivy-system` namespace from
 # BOTH the flux-managed (10) and harbor-proxy-pull (11) Enforce policies via
 # the existing per-policy `extraExcludeNamespaces` carve-outs. The
@@ -233,7 +265,7 @@ type: application
 # unprotected user PVCs stay subject to the velero-backed requirement. Mirrors
 # the by-label CNPG carve-out on the flux-managed policy (#3374). Template-only
 # behavior change + new test fixtures. Refs #3971.
-version: 1.0.39
+version: 1.0.40
 appVersion: "1.0.2"
 keywords: [catalyst, blueprint, kyverno, policy, compliance, audit]
 maintainers:

--- a/platform/kyverno-policies/chart/templates/mutate/01-inject-gitea-source-secretref.yaml
+++ b/platform/kyverno-policies/chart/templates/mutate/01-inject-gitea-source-secretref.yaml
@@ -1,0 +1,148 @@
+{{/*
+EPIC #4286 mechanism B (Refs #4286, 2026-06-25) — Kyverno MUTATING admission
+floor that makes "a Flux source pointing at the Sovereign-local Gitea is
+authenticated by construction" structurally true at ADMISSION, so the Nth future
+generator (controller / chart / Blueprint / hand-applied CR) can NOT reintroduce
+the empty-secretRef 401 bug that produced #4283 → #4284 → #4285.
+
+THE LAW THIS ENFORCES (the same invariant as core/controllers/pkg/fluxsource)
+  bp-gitea ships `service.REQUIRE_SIGNIN_VIEW=true`
+  (platform/gitea/chart/values.yaml). Under that setting an ANONYMOUS git clone
+  of the in-cluster Gitea returns HTTP 401 "authentication required" for EVERY
+  repo — public included. Therefore a Flux source whose `spec.url` targets the
+  Sovereign-local Gitea WITHOUT a basic-auth `spec.secretRef` is INVALID — an
+  invariant of the Sovereign, not a per-controller option. Mechanism A (the
+  shared `fluxsource` Go factory, #4285) enforces this for the three in-tree Go
+  generators; THIS policy is the admission floor that also covers sources from
+  ANY OTHER origin (charts, Blueprints, hand-applied CRs, a future fourth
+  generator) — the layer that structurally defeats "the Nth generator forgets".
+
+WHY MUTATE, NOT VALIDATE
+  A VALIDATE(deny) policy would REJECT a secretRef-less local-Gitea source —
+  which would fail-closed any generator that hasn't yet been routed through the
+  shared factory, and could wedge a fresh prov. A MUTATE silently INJECTS the
+  canonical secretRef so the source becomes authenticated and Ready=True. The
+  Go factory (A) is the loud unit-test/reconcile-error guard for in-tree code;
+  this policy is the silent, always-on safety net for everything else. Belt and
+  suspenders at the construction (A) and admission (B) altitudes.
+
+THE HOST LAW — MIRRORS fluxsource.IsLocalSovereignSource
+  fluxsource classifies a URL as Sovereign-local when its HOST contains the
+  substring `gitea` (the in-cluster `gitea-http.gitea.svc.cluster.local` service
+  AND the per-Sovereign `gitea.<location-code>.<sovereign-domain>` DNS). This
+  policy keys on the same `gitea` host marker. Scope is GITEA ONLY (the
+  empty-secretRef bug class #4283/#4284/#4285); the local-Harbor leg
+  (post-`bp-self-sovereign-cutover` registry pivot) reuses the SAME admission
+  guarantee and is the forward-looking follow-up the EPIC flags, NOT this PR.
+
+  github.com sources (the public `openova` catalog mirror) are UNTOUCHED — they
+  carry no `gitea` host substring, need no auth, and are Ready=True without a
+  secretRef. The mothership proxy-cache `harbor.openova.io` is likewise out of
+  scope here (Gitea-only).
+
+WHAT IT INJECTS
+  `spec.secretRef.name: openova-org-tenants-git-auth` — the canonical
+  flux-system basic-auth Secret minted by the catalyst chart's
+  gitea-flux-auth-secrets-sync-job (the gitea_admin PAT that clones every repo).
+  This is the EXACT secret the only correctly-wired leg (organization-controller,
+  products/catalyst/chart/values.yaml:751) already uses, and the same default
+  mechanism A injects. Operator-overridable per
+  docs/INVIOLABLE-PRINCIPLES.md #4 via
+  `.Values.compliancePolicies.injectGiteaSourceSecretRef.secretRefName`.
+
+IDEMPOTENCY / NON-OVERRIDE
+  The precondition fires ONLY when `spec.secretRef.name` is empty/absent — a
+  source that ALREADY carries a secretRef (the org-controller's 19
+  catalyst-tenant-* sources, or any operator-set value) is left UNTOUCHED. The
+  `+(secretRef)` add-when-missing anchor is a second idempotency guard at the
+  patch layer. The precondition is ALSO what makes Kyverno register the resource
+  mutating webhook for these source kinds (a precondition-less +(...) patch is
+  treated as no-op-eligible and the webhook never registers — the same lesson as
+  the 00-stamp-cilium-enforced-label policy).
+
+SCOPE / KINDS
+  GitRepository / HelmRepository / OCIRepository (source.toolkit.fluxcd.io/v1).
+  A Gitea host only legitimately backs a GitRepository today, but the EPIC's
+  acceptance names all three source kinds (and OCIRepository becomes relevant
+  for the local-Harbor leg), so all three are matched for forward-compatibility;
+  the `gitea` host precondition means HelmRepository/OCIRepository are only ever
+  touched if they genuinely target the local Gitea host.
+
+  Sources live in flux-system (the 3 live failures) and — post-mechanism-D — in
+  per-Org/env namespaces; this policy is cluster-scoped (ClusterPolicy) and does
+  NOT namespace-exclude, because a secretRef-less local-Gitea source is invalid
+  in EVERY namespace. (Mechanism D handles REFLECTING the secret into those
+  namespaces; B guarantees the source REFERENCES it.)
+
+VERIFIED with `kyverno test` (see chart/tests/inject-gitea-source-secretref/) +
+`kyverno apply` two-directionally: a secretRef-less in-cluster-Gitea
+GitRepository is mutate-injected to carry `openova-org-tenants-git-auth`; a
+github.com source is left untouched; an already-secretRef'd source is left
+untouched. The live conformance (`kubectl apply` a secretRef-less source on a
+running Sovereign → observe the injected secretRef) is the DEFERRED live proof
+called out in the PR body (controlled apply is out of this read-only session's
+scope).
+*/}}
+{{- if and (hasKey .Values.compliancePolicies "injectGiteaSourceSecretRef") .Values.compliancePolicies.injectGiteaSourceSecretRef.enabled -}}
+{{- $secretRefName := .Values.compliancePolicies.injectGiteaSourceSecretRef.secretRefName | default "openova-org-tenants-git-auth" -}}
+{{- $hostMarker := .Values.compliancePolicies.injectGiteaSourceSecretRef.giteaHostMarker | default "gitea" -}}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: inject-gitea-source-secretref
+  labels:
+    app.kubernetes.io/name: bp-kyverno
+    app.kubernetes.io/component: compliance-policy
+    catalyst.openova.io/policy-tier: compliance
+    catalyst.openova.io/policy-domain: security
+  annotations:
+    policies.kyverno.io/title: Auto-inject secretRef on Sovereign-local Gitea Flux sources
+    policies.kyverno.io/category: catalyst-compliance
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/description: >-
+      MUTATE policy (EPIC #4286 mechanism B): on CREATE/UPDATE of a Flux
+      GitRepository/HelmRepository/OCIRepository whose spec.url host targets the
+      Sovereign-local Gitea and which has an empty/absent spec.secretRef.name,
+      inject the canonical basic-auth secretRef. bp-gitea
+      REQUIRE_SIGNIN_VIEW=true makes anonymous clone 401 for every repo, so an
+      unauthenticated local-Gitea source is structurally invalid — this is the
+      admission floor that makes it impossible (Refs #4286, #4285, #4283).
+spec:
+  # MUTATE on admission only (CREATE/UPDATE); no background scan needed — Flux
+  # re-emits desired-state source CRs, so the mutate re-fires on the next
+  # reconcile of any stale CR. Matches 00-stamp-cilium-enforced-label / 21.
+  background: false
+  rules:
+    - name: inject-secretref-on-local-gitea-source
+      match:
+        any:
+          - resources:
+              kinds:
+                - GitRepository
+                - HelmRepository
+                - OCIRepository
+      preconditions:
+        all:
+          # (1) spec.url host targets the Sovereign-local Gitea — mirror
+          # fluxsource.IsLocalSovereignSource's `gitea` host marker. `contains()`
+          # is matched against the whole url string; an external repo would need
+          # `gitea` in its host to match, which the local Gitea service
+          # (gitea-http.gitea.svc...) and per-Sovereign DNS (gitea.<loc>.<dom>)
+          # both carry and github.com does not. `|| ''` keeps it nil-safe when
+          # spec.url is somehow absent.
+          - key: {{ printf "{{ contains(request.object.spec.url || '', '%s') }}" $hostMarker | quote }}
+            operator: Equals
+            value: true
+          # (2) secretRef.name is empty/absent — fire ONLY on unauthenticated
+          # sources; never override an operator-set / org-controller-set secret.
+          - key: {{ `"{{ request.object.spec.secretRef.name || '' }}"` }}
+            operator: Equals
+            value: ""
+      mutate:
+        patchStrategicMerge:
+          spec:
+            # `+(secretRef)` adds the secretRef block only when absent — second
+            # idempotency guard beyond the precondition.
+            +(secretRef):
+              name: {{ $secretRefName | quote }}
+{{- end -}}

--- a/platform/kyverno-policies/chart/tests/fixtures/README.md
+++ b/platform/kyverno-policies/chart/tests/fixtures/README.md
@@ -75,3 +75,32 @@ The end-to-end mutate-before-validate proof (admission-time ordering against
 the REAL 09/11 Enforce baselines on a kind + kyverno v1.18 cluster) is captured
 in the PR body — `kyverno apply` exercises only the policy logic offline, not
 the apiserver's webhook phase ordering.
+
+## EPIC #4286 mechanism B — `inject-gitea-source-secretref`
+
+The `inject-gitea-source-secretref` MUTATE policy (the regression-proof
+admission floor for Flux→Sovereign-local-Gitea source auth) has its own
+self-contained `kyverno test` suite — NOT in this `fixtures/` tree but in the
+sibling `tests/inject-gitea-source-secretref/` directory, because it ships a
+formal `kyverno-test.yaml` with `patchedResource` assertions (the canonical
+mutate-conformance gate) plus a committed rendered `policy.yaml`.
+
+```bash
+cd platform/kyverno-policies/chart
+# (re-render policy.yaml if the template/values changed — see the header
+#  of tests/inject-gitea-source-secretref/kyverno-test.yaml)
+kyverno test tests/inject-gitea-source-secretref/
+# → 5 tests passed and 0 tests failed
+```
+
+| Case | Input fixture | Expectation |
+|---|---|---|
+| in-cluster Gitea, no secretRef | `resource-incluster-gitea-no-secretref.yaml` | MUTATE → inject `openova-org-tenants-git-auth` (`patched-incluster-gitea.yaml`) |
+| per-Sovereign Gitea DNS, no secretRef | `resource-persovereign-gitea-no-secretref.yaml` | MUTATE → inject (`patched-persovereign-gitea.yaml`) |
+| github.com public, no secretRef | `resource-github-public-no-secretref.yaml` | SKIP (no `gitea` host substring) |
+| local Gitea WITH secretRef | `resource-incluster-gitea-with-secretref.yaml` | SKIP (idempotent — never overrides) |
+| OCIRepository at Gitea host, no secretRef | `resource-ocirepository-gitea-no-secretref.yaml` | MUTATE → inject (cross-kind coverage; `patched-ocirepository-gitea.yaml`) |
+
+The DEFERRED live-conformance proof (a controlled `kubectl apply` on a running
+Sovereign → observe the injected secretRef) is the command in the PR body;
+a controlled live apply is out of the read-only audit session's scope.

--- a/platform/kyverno-policies/chart/tests/inject-gitea-source-secretref/kyverno-test.yaml
+++ b/platform/kyverno-policies/chart/tests/inject-gitea-source-secretref/kyverno-test.yaml
@@ -1,0 +1,76 @@
+# EPIC #4286 mechanism B — Kyverno conformance test for the
+# `inject-gitea-source-secretref` MUTATE ClusterPolicy.
+#
+# Run with the Kyverno CLI:
+#   cd platform/kyverno-policies/chart
+#   # re-render the policy if the template/values changed:
+#   helm template . --set compliancePolicies.bootstrapMode=false \
+#     --show-only templates/mutate/01-inject-gitea-source-secretref.yaml \
+#     | grep -v '^---$' | grep -v '^# Source:' \
+#     > tests/inject-gitea-source-secretref/policy.yaml
+#   kyverno test tests/inject-gitea-source-secretref/
+#
+# `policy.yaml` is the rendered ClusterPolicy (committed so the test is
+# self-contained + CI-runnable without a Helm pass in the test step).
+#
+# FOUR cases prove the EPIC's mechanism-B acceptance bullet
+# ("an applied secretRef-less local-Gitea source is mutate-injected to carry the
+# canonical secret; a github.com source is left untouched; an already-secretRef'd
+# source is left untouched"):
+#   1. in-cluster Gitea, no secretRef        → MUTATE (inject) → pass + patchedResource
+#   2. per-Sovereign Gitea DNS, no secretRef  → MUTATE (inject) → pass + patchedResource
+#   3. github.com public, no secretRef        → SKIP (precond 1 false) → result: skip
+#   4. in-cluster Gitea WITH secretRef        → SKIP (precond 2 false, idempotent) → result: skip
+#   5. OCIRepository at Gitea host, no secretRef → MUTATE (inject) → pass (cross-kind coverage)
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: inject-gitea-source-secretref-test
+policies:
+  - policy.yaml
+resources:
+  - resource-incluster-gitea-no-secretref.yaml
+  - resource-persovereign-gitea-no-secretref.yaml
+  - resource-github-public-no-secretref.yaml
+  - resource-incluster-gitea-with-secretref.yaml
+  - resource-ocirepository-gitea-no-secretref.yaml
+results:
+  # 1. secretRef-less in-cluster Gitea source → injected.
+  - policy: inject-gitea-source-secretref
+    rule: inject-secretref-on-local-gitea-source
+    resources:
+      - catalyst-app-omantel-biz-agenity
+    kind: GitRepository
+    patchedResources: patched-incluster-gitea.yaml
+    result: pass
+  # 2. secretRef-less per-Sovereign Gitea DNS source → injected.
+  - policy: inject-gitea-source-secretref
+    rule: inject-secretref-on-local-gitea-source
+    resources:
+      - openova-catalog-sovereign
+    kind: GitRepository
+    patchedResources: patched-persovereign-gitea.yaml
+    result: pass
+  # 3. github.com catalog-mirror → UNTOUCHED (no `gitea` host substring).
+  - policy: inject-gitea-source-secretref
+    rule: inject-secretref-on-local-gitea-source
+    resources:
+      - openova
+    kind: GitRepository
+    result: skip
+  # 4. already-secretRef'd local-Gitea source → UNTOUCHED (idempotent;
+  #    never overrides the org-controller / operator-set value).
+  - policy: inject-gitea-source-secretref
+    rule: inject-secretref-on-local-gitea-source
+    resources:
+      - catalyst-tenant-walkorg
+    kind: GitRepository
+    result: skip
+  # 5. OCIRepository at a Gitea host, no secretRef → injected (cross-kind).
+  - policy: inject-gitea-source-secretref
+    rule: inject-secretref-on-local-gitea-source
+    resources:
+      - catalyst-app-omantel-biz-chart
+    kind: OCIRepository
+    patchedResources: patched-ocirepository-gitea.yaml
+    result: pass

--- a/platform/kyverno-policies/chart/tests/inject-gitea-source-secretref/patched-incluster-gitea.yaml
+++ b/platform/kyverno-policies/chart/tests/inject-gitea-source-secretref/patched-incluster-gitea.yaml
@@ -1,0 +1,15 @@
+# EPIC #4286 mechanism B — EXPECTED patched resource for the in-cluster-Gitea
+# secretRef-less GitRepository after the inject-gitea-source-secretref mutate.
+# spec.secretRef.name=openova-org-tenants-git-auth has been injected.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: catalyst-app-omantel-biz-agenity
+  namespace: flux-system
+spec:
+  interval: 60s
+  ref:
+    branch: main
+  secretRef:
+    name: openova-org-tenants-git-auth
+  url: http://gitea-http.gitea.svc.cluster.local:3000/omantel-biz/agenity.git

--- a/platform/kyverno-policies/chart/tests/inject-gitea-source-secretref/patched-ocirepository-gitea.yaml
+++ b/platform/kyverno-policies/chart/tests/inject-gitea-source-secretref/patched-ocirepository-gitea.yaml
@@ -1,0 +1,15 @@
+# EPIC #4286 mechanism B — EXPECTED patched OCIRepository after the
+# inject-gitea-source-secretref mutate. secretRef injected identically to the
+# GitRepository case, proving cross-kind coverage.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: catalyst-app-omantel-biz-chart
+  namespace: flux-system
+spec:
+  interval: 60s
+  ref:
+    tag: latest
+  secretRef:
+    name: openova-org-tenants-git-auth
+  url: oci://gitea-http.gitea.svc.cluster.local:3000/omantel-biz/chart

--- a/platform/kyverno-policies/chart/tests/inject-gitea-source-secretref/patched-persovereign-gitea.yaml
+++ b/platform/kyverno-policies/chart/tests/inject-gitea-source-secretref/patched-persovereign-gitea.yaml
@@ -1,0 +1,15 @@
+# EPIC #4286 mechanism B — EXPECTED patched resource for the per-Sovereign Gitea
+# DNS secretRef-less GitRepository after the inject-gitea-source-secretref
+# mutate. spec.secretRef.name=openova-org-tenants-git-auth has been injected.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: openova-catalog-sovereign
+  namespace: flux-system
+spec:
+  interval: 60s
+  ref:
+    branch: main
+  secretRef:
+    name: openova-org-tenants-git-auth
+  url: https://gitea.hfmp.omantel.biz/openova/openova

--- a/platform/kyverno-policies/chart/tests/inject-gitea-source-secretref/policy.yaml
+++ b/platform/kyverno-policies/chart/tests/inject-gitea-source-secretref/policy.yaml
@@ -1,0 +1,59 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: inject-gitea-source-secretref
+  labels:
+    app.kubernetes.io/name: bp-kyverno
+    app.kubernetes.io/component: compliance-policy
+    catalyst.openova.io/policy-tier: compliance
+    catalyst.openova.io/policy-domain: security
+  annotations:
+    policies.kyverno.io/title: Auto-inject secretRef on Sovereign-local Gitea Flux sources
+    policies.kyverno.io/category: catalyst-compliance
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/description: >-
+      MUTATE policy (EPIC #4286 mechanism B): on CREATE/UPDATE of a Flux
+      GitRepository/HelmRepository/OCIRepository whose spec.url host targets the
+      Sovereign-local Gitea and which has an empty/absent spec.secretRef.name,
+      inject the canonical basic-auth secretRef. bp-gitea
+      REQUIRE_SIGNIN_VIEW=true makes anonymous clone 401 for every repo, so an
+      unauthenticated local-Gitea source is structurally invalid — this is the
+      admission floor that makes it impossible (Refs #4286, #4285, #4283).
+spec:
+  # MUTATE on admission only (CREATE/UPDATE); no background scan needed — Flux
+  # re-emits desired-state source CRs, so the mutate re-fires on the next
+  # reconcile of any stale CR. Matches 00-stamp-cilium-enforced-label / 21.
+  background: false
+  rules:
+    - name: inject-secretref-on-local-gitea-source
+      match:
+        any:
+          - resources:
+              kinds:
+                - GitRepository
+                - HelmRepository
+                - OCIRepository
+      preconditions:
+        all:
+          # (1) spec.url host targets the Sovereign-local Gitea — mirror
+          # fluxsource.IsLocalSovereignSource's `gitea` host marker. `contains()`
+          # is matched against the whole url string; an external repo would need
+          # `gitea` in its host to match, which the local Gitea service
+          # (gitea-http.gitea.svc...) and per-Sovereign DNS (gitea.<loc>.<dom>)
+          # both carry and github.com does not. `|| ''` keeps it nil-safe when
+          # spec.url is somehow absent.
+          - key: "{{ contains(request.object.spec.url || '', 'gitea') }}"
+            operator: Equals
+            value: true
+          # (2) secretRef.name is empty/absent — fire ONLY on unauthenticated
+          # sources; never override an operator-set / org-controller-set secret.
+          - key: "{{ request.object.spec.secretRef.name || '' }}"
+            operator: Equals
+            value: ""
+      mutate:
+        patchStrategicMerge:
+          spec:
+            # `+(secretRef)` adds the secretRef block only when absent — second
+            # idempotency guard beyond the precondition.
+            +(secretRef):
+              name: "openova-org-tenants-git-auth"

--- a/platform/kyverno-policies/chart/tests/inject-gitea-source-secretref/resource-github-public-no-secretref.yaml
+++ b/platform/kyverno-policies/chart/tests/inject-gitea-source-secretref/resource-github-public-no-secretref.yaml
@@ -1,0 +1,15 @@
+# EPIC #4286 mechanism B — INPUT fixture (NEGATIVE): the public github.com
+# catalog-mirror source. host=github.com carries NO `gitea` substring, needs no
+# auth, and is Ready=True without a secretRef. The mutate policy MUST leave it
+# UNTOUCHED (precondition (1) `contains(url,'gitea')` is false). This is the
+# `openova` GitRepository in the live measured state.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: openova
+  namespace: flux-system
+spec:
+  interval: 60s
+  url: https://github.com/openova-io/openova
+  ref:
+    branch: main

--- a/platform/kyverno-policies/chart/tests/inject-gitea-source-secretref/resource-incluster-gitea-no-secretref.yaml
+++ b/platform/kyverno-policies/chart/tests/inject-gitea-source-secretref/resource-incluster-gitea-no-secretref.yaml
@@ -1,0 +1,16 @@
+# EPIC #4286 mechanism B — INPUT fixture: a Flux GitRepository targeting the
+# IN-CLUSTER Gitea service (gitea-http.gitea.svc.cluster.local) with NO
+# secretRef. This is the EXACT shape of the live #4283/#4285 failures
+# (catalyst-app-omantel-biz-agenity / -shared-pg-d, secretRef <none> →
+# "authentication required"). The inject-gitea-source-secretref mutate policy
+# MUST inject spec.secretRef.name=openova-org-tenants-git-auth.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: catalyst-app-omantel-biz-agenity
+  namespace: flux-system
+spec:
+  interval: 60s
+  url: http://gitea-http.gitea.svc.cluster.local:3000/omantel-biz/agenity.git
+  ref:
+    branch: main

--- a/platform/kyverno-policies/chart/tests/inject-gitea-source-secretref/resource-incluster-gitea-with-secretref.yaml
+++ b/platform/kyverno-policies/chart/tests/inject-gitea-source-secretref/resource-incluster-gitea-with-secretref.yaml
@@ -1,0 +1,17 @@
+# EPIC #4286 mechanism B — INPUT fixture (NEGATIVE / idempotency): a local-Gitea
+# GitRepository that ALREADY carries a secretRef (the correctly-wired
+# organization-controller leg — the 19 live catalyst-tenant-* sources). The
+# mutate policy MUST leave it UNTOUCHED (precondition (2)
+# `secretRef.name == ''` is false) — never override an operator/org-set value.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: catalyst-tenant-walkorg
+  namespace: flux-system
+spec:
+  interval: 60s
+  url: http://gitea-http.gitea.svc.cluster.local:3000/walkorg/walkorg.git
+  ref:
+    branch: main
+  secretRef:
+    name: openova-org-tenants-git-auth

--- a/platform/kyverno-policies/chart/tests/inject-gitea-source-secretref/resource-ocirepository-gitea-no-secretref.yaml
+++ b/platform/kyverno-policies/chart/tests/inject-gitea-source-secretref/resource-ocirepository-gitea-no-secretref.yaml
@@ -1,0 +1,15 @@
+# EPIC #4286 mechanism B — INPUT fixture (kind coverage): an OCIRepository
+# targeting a Sovereign-local Gitea host with NO secretRef. The EPIC's
+# acceptance names all three source kinds; this proves the mutate is NOT
+# GitRepository-only — OCIRepository / HelmRepository pointing at the local
+# Gitea host are injected identically (forward-compat for the local-Harbor leg).
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: catalyst-app-omantel-biz-chart
+  namespace: flux-system
+spec:
+  interval: 60s
+  url: oci://gitea-http.gitea.svc.cluster.local:3000/omantel-biz/chart
+  ref:
+    tag: latest

--- a/platform/kyverno-policies/chart/tests/inject-gitea-source-secretref/resource-persovereign-gitea-no-secretref.yaml
+++ b/platform/kyverno-policies/chart/tests/inject-gitea-source-secretref/resource-persovereign-gitea-no-secretref.yaml
@@ -1,0 +1,15 @@
+# EPIC #4286 mechanism B — INPUT fixture: a Flux GitRepository targeting the
+# PER-SOVEREIGN Gitea DNS (gitea.<location-code>.<sovereign-domain>) with NO
+# secretRef. fluxsource.IsLocalSovereignSource classifies this host as
+# Sovereign-local via the `gitea` substring exactly like the in-cluster service.
+# The mutate policy MUST inject the canonical secretRef here too.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: openova-catalog-sovereign
+  namespace: flux-system
+spec:
+  interval: 60s
+  url: https://gitea.hfmp.omantel.biz/openova/openova
+  ref:
+    branch: main

--- a/platform/kyverno-policies/chart/values.yaml
+++ b/platform/kyverno-policies/chart/values.yaml
@@ -461,3 +461,51 @@ compliancePolicies:
   ciliumEnforcedLabelMutate:
     enabled: true
     excludeNamespaces: *complianceDefaultExcludes
+
+  # EPIC #4286 mechanism B (Refs #4286, 2026-06-25) — MUTATE policy that
+  # auto-injects the canonical basic-auth `spec.secretRef.name` on any Flux
+  # GitRepository/HelmRepository/OCIRepository whose `spec.url` host targets the
+  # Sovereign-local Gitea AND which has an empty/absent secretRef.
+  #
+  # WHY: bp-gitea ships `service.REQUIRE_SIGNIN_VIEW=true`
+  # (platform/gitea/chart/values.yaml), so an ANONYMOUS git clone of the
+  # in-cluster Gitea returns HTTP 401 "authentication required" for EVERY repo
+  # (public included). A Flux source targeting the local Gitea WITHOUT a
+  # secretRef is therefore structurally invalid — it sits "authentication
+  # required" forever (the #4283/#4284/#4285 bug class across 4 generators).
+  # Mechanism A (the shared `core/controllers/pkg/fluxsource` Go factory, #4285)
+  # enforces this for the 3 in-tree Go generators; THIS policy is the admission
+  # floor that ALSO covers sources from ANY OTHER origin (charts, Blueprints,
+  # hand-applied CRs, a future fourth generator) — the regression-proof layer
+  # that structurally defeats "the Nth generator forgets".
+  #
+  # The host law mirrors fluxsource.IsLocalSovereignSource exactly: a URL is
+  # Sovereign-local when its host carries the `gitea` substring (the in-cluster
+  # `gitea-http.gitea.svc...` service AND the per-Sovereign
+  # `gitea.<loc>.<dom>` DNS). github.com catalog-mirror sources carry no such
+  # substring and are left untouched (they need no auth). Scope is GITEA ONLY;
+  # the local-Harbor leg (post-cutover registry pivot) reuses the same
+  # admission guarantee and is the forward-looking follow-up the EPIC flags.
+  #
+  # MUTATE (not VALIDATE/deny): a deny would fail-closed any not-yet-migrated
+  # generator and could wedge a fresh prov; the mutate silently injects the
+  # secretRef so the source becomes authenticated + Ready=True. Idempotent — the
+  # precondition fires ONLY when secretRef.name is empty/absent (never overrides
+  # an operator-set or org-controller-set value) and the `+(secretRef)`
+  # add-when-missing anchor is a second guard. Per docs/INVIOLABLE-PRINCIPLES.md
+  # #4 the injected secret name + host marker are operator-overridable.
+  #
+  # Enabled by default — a non-rejecting MUTATE cannot block any workload; it
+  # only enriches an otherwise-dead source. NOT bootstrapMode-gated (a mutate
+  # has no validationFailureAction; it injects in Audit and Enforce alike).
+  injectGiteaSourceSecretRef:
+    enabled: true
+    # Canonical flux-system basic-auth Secret (the gitea_admin PAT) minted by
+    # the catalyst chart's gitea-flux-auth-secrets-sync-job — the EXACT secret
+    # the correctly-wired organization-controller leg uses
+    # (products/catalyst/chart/values.yaml:751). Operator-overridable.
+    secretRefName: openova-org-tenants-git-auth
+    # Host substring that marks a URL as targeting the Sovereign-local Gitea —
+    # mirrors fluxsource.localSourceHostMarkers (`gitea`). Operator-overridable
+    # for a Sovereign that renames its in-cluster Gitea host.
+    giteaHostMarker: gitea


### PR DESCRIPTION
## EPIC #4286 mechanism B — the Kyverno mutating admission floor

Makes **"a Flux source pointing at the Sovereign-local Gitea is authenticated by construction"** structurally true at **admission**, so the Nth future generator (controller / chart / Blueprint / hand-applied CR) can't reintroduce the empty-`secretRef` 401 bug that recurred across four separate live failures (#4283 → #4284 → #4285 → this EPIC).

#4285 closed the *symptom* via the shared `core/controllers/pkg/fluxsource` factory = mechanisms **A** (construction funnel) + **C** (non-empty config). This PR adds the regression-proof layer **B**: the Kyverno mutate `ClusterPolicy`. Mechanism **D** (env-controller cross-namespace secret reflection) is **excluded from this PR** — it touches the env-controller the vcluster EPIC is reshaping; it stacks behind that EPIC.

## The law this enforces

bp-gitea ships `service.REQUIRE_SIGNIN_VIEW=true` (`platform/gitea/chart/values.yaml`), so an **anonymous** git clone of the in-cluster Gitea returns **HTTP 401 "authentication required" for EVERY repo** — public included. A Flux source targeting the local Gitea **without** a basic-auth `spec.secretRef` is therefore structurally invalid: it sits `authentication required` forever. The shared Go factory (A) enforces this for the 3 in-tree generators; this policy is the admission floor that **also** covers sources from **any other origin**.

## What it does

New MUTATE `ClusterPolicy` `inject-gitea-source-secretref` (`platform/kyverno-policies/chart/templates/mutate/01-inject-gitea-source-secretref.yaml`): on CREATE/UPDATE of a Flux `GitRepository` / `HelmRepository` / `OCIRepository` whose `spec.url` host targets the Sovereign-local Gitea **and** which has an empty/absent `spec.secretRef.name`, it injects the canonical basic-auth secretRef **`openova-org-tenants-git-auth`** (the exact secret the correctly-wired organization-controller leg uses — `products/catalyst/chart/values.yaml:751`, and the default mechanism A injects).

- **Host law mirrors `fluxsource.IsLocalSovereignSource`**: a URL is Sovereign-local when its host carries the `gitea` substring — the in-cluster `gitea-http.gitea.svc.cluster.local` service **and** the per-Sovereign `gitea.<location-code>.<sovereign-domain>` DNS. `github.com` catalog-mirror sources carry no such substring → **untouched**.
- **MUTATE, not VALIDATE/deny**: a deny would fail-closed a not-yet-migrated generator and could wedge a fresh prov; the mutate silently heals the source → `Ready=True`. Belt-and-suspenders with the loud Go factory (A).
- **Idempotent**: precondition fires **only** when `secretRef.name` is empty/absent → never overrides the org-controller's 19 `catalyst-tenant-*` sources or any operator-set value; `+(secretRef)` add-when-missing is a second guard.
- **Scope is GITEA ONLY** (the empty-secretRef bug class). The **local-Harbor leg** (post-`bp-self-sovereign-cutover` registry pivot) reuses the *same* admission guarantee and is the flagged forward-looking follow-up.

## Bootstrap-kit slot + version bumps (monotonic, lockstep)

Ships through the existing **slot 27a** `bp-kyverno-policies` HelmRelease (`clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml`) — the bootstrap-kit slot that installs on every Sovereign. As a new policy *template* within that chart it installs via the same HR (the canonical pattern all 22 existing policies follow):

| File | 1.0.39 → |
|---|---|
| `platform/kyverno-policies/chart/Chart.yaml` | **1.0.40** |
| `platform/kyverno-policies/blueprint.yaml` | **1.0.40** |
| `clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml` (HR pin) | **1.0.40** |

Default **ENABLED** (non-rejecting mutate); `secretRefName` + `giteaHostMarker` operator-overridable per Inviolable Principle #4. Not `bootstrapMode`-gated (a mutate has no `validationFailureAction`).

## Verification — `kyverno test` conformance (5/5 pass)

Self-contained suite at `platform/kyverno-policies/chart/tests/inject-gitea-source-secretref/` (committed rendered `policy.yaml` + `kyverno-test.yaml` with `patchedResource` assertions):

```
$ kyverno test tests/inject-gitea-source-secretref/
Test Summary: 5 tests passed and 0 tests failed
```

| Case | Expectation | Result |
|---|---|---|
| in-cluster Gitea, no secretRef | MUTATE → inject `openova-org-tenants-git-auth` | ✅ pass + patchedResource |
| per-Sovereign Gitea DNS, no secretRef | MUTATE → inject | ✅ pass + patchedResource |
| `github.com` public, no secretRef | SKIP (no `gitea` host substring) | ✅ untouched |
| local Gitea **WITH** secretRef | SKIP (idempotent — never overrides) | ✅ untouched |
| OCIRepository at Gitea host, no secretRef | MUTATE → inject (cross-kind) | ✅ pass + patchedResource |

Full chart `helm template` renders cleanly (23 ClusterPolicies). The values change is **purely additive** (new `injectGiteaSourceSecretRef` block, no image-glob keys) → the proxy-images CI gate is unaffected.

## ⏳ Deferred live conformance (the EPIC's acceptance bullet — out of this read-only session's scope)

A controlled `kubectl apply` against a running Sovereign is the live proof; **not applied to the live cluster this session** (read-only). Run on a Sovereign once 1.0.40 rolls:

```bash
# 1. Apply a secretRef-less GitRepository targeting the in-cluster Gitea:
cat <<'YAML' | kubectl apply -f -
apiVersion: source.toolkit.fluxcd.io/v1
kind: GitRepository
metadata:
  name: epic4286-b-conformance
  namespace: flux-system
spec:
  interval: 60s
  url: http://gitea-http.gitea.svc.cluster.local:3000/openova/openova.git
  ref:
    branch: main
YAML

# 2. Observe the mutate-injected secretRef (expect: openova-org-tenants-git-auth):
kubectl -n flux-system get gitrepository epic4286-b-conformance \
  -o jsonpath='{.spec.secretRef.name}{"\n"}'
# → openova-org-tenants-git-auth

# 3. (negative) a github.com source must NOT be mutated:
#    apply url: https://github.com/openova-io/openova → .spec.secretRef.name stays empty.

# 4. cleanup:
kubectl -n flux-system delete gitrepository epic4286-b-conformance
```

## Scope guard

No `core/` / env / org / application controller files touched — this PR is the admission `ClusterPolicy` + its bootstrap slot pin + tests only.

Refs #4286 #4285 #4283

🤖 Generated with [Claude Code](https://claude.com/claude-code)
