### PR TITLE
feat(catalyst): auto-seed the per-Org Anthropic credential at Org-create — zero-touch agentic journey on a fresh Org (Refs #4277)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1080,6 +1080,11 @@ spec:
       #   storm that fills the node's ephemeral disk evicts THOSE reschedulable Pods
       #   first instead of the EVS-node-pinned (#4102) control-plane API (~17min
       #   console outage, omantel.biz 2026-06-24). Chart.yaml bumped in lockstep.
+      # 1.4.833 — #4277: catalyst-api auto-seeds the per-Org Anthropic credential
+      #   at Org-create (secret/catalyst/anthropic/token) so the agentic journey
+      #   (Pillar 4) is zero-touch on a fresh Org. Loud-skips until the founder
+      #   populates the sovereign-anthropic-credentials Secret once per Sovereign
+      #   (Principle #4 — no silent empty seed). Chart.yaml bumped in lockstep.
       # 1.4.830 — #4281 + #4282: console Cloud HelmReleases list gains a
       #   "Target Namespace" column (spec.targetNamespace) + catalog-seed
       #   bp-postgres synced to 0.2.5 (placement modes incl. active-hot-standby

--- a/products/agenity/README.md
+++ b/products/agenity/README.md
@@ -103,18 +103,48 @@ private base image (`ghcr.io/agenity-org/chepherd`) is gone.
   with the Org's Keycloak SSO (silent login). The agent presents the User's
   session bearer to the openova MCP on each `tools/call`.
 
-## Seeding the per-Org `anthropic/token` openbao path (#4111 / #4228)
+## Seeding the `catalyst/anthropic/token` openbao path (#4277 / #4111 / #4228)
 
 The chat runtime (the spawned `claude-code` solo agent) needs a **live
-Anthropic credential** in the Org's openbao. The chart's
+Anthropic credential** in the Sovereign's openbao. The chart's
 `templates/externalsecret-anthropic.yaml` reads it from the openbao path
-`anthropic/token` via the `vault-region1` ClusterSecretStore into the
-`agenity-anthropic-token` Secret. The chart can **never** carry the secret
-itself (Inviolable Principle #4 — no hardcoded secrets), so this one openbao
-write is **operator-driven**, exactly once per Sovereign, before the chat is
-expected to work. Until it is seeded the dashboard still renders, but the
-agent reports *"runtime offline · 0 workers"* / *"no Claude credential
-available"* on spawn.
+`secret/catalyst/anthropic/token` via the `vault-region1` ClusterSecretStore
+into the `agenity-anthropic-token` Secret. The chart can **never** carry the
+secret itself (Inviolable Principle #4 — no hardcoded secrets).
+
+**Auto-seeded at Org-create (#4277).** The catalyst-api producer
+`seedAnthropicToken` (called from `runOrganizationPipeline`) writes
+`secret/catalyst/anthropic/token` on **every** Org-create, sourcing the value
+from its own env (`CATALYST_ANTHROPIC_API_KEY` /
+`CATALYST_ANTHROPIC_CREDENTIALS_JSON`, wired via the
+`catalyst-openova-kc-credentials` Secret). So once the **platform-level**
+Anthropic credential is supplied **once per Sovereign**, every new Org is
+zero-touch by construction — no per-Org `bao kv put`.
+
+> **Why `catalyst/anthropic/token` and not bare `anthropic/token`?** A
+> Sovereign has **no writer** for `secret/anthropic/*` — the `external-secrets`
+> OpenBao role `vault-region1` reads with is read-only. The catalyst-api holds
+> the write-capable `catalyst-api-write` policy scoped to
+> `secret/{data,metadata}/catalyst/*`, so the producer writes under that
+> prefix. The path is **cluster-shared** — one seed serves every Org's agenity
+> install on that Sovereign.
+
+**Supplying the platform credential (the one founder action).** Set it once per
+Sovereign via either:
+- the operator-rotatable `catalyst-system/sovereign-anthropic-credentials`
+  Secret (keys `apiKey` / `credentialsJson`) — **source-wins**, so this is also
+  the seam to re-seed the EXPIRING OAuth blob without a chart upgrade; or
+- a per-Sovereign overlay setting `sovereign.anthropic.{apiKey,credentialsJson}`
+  on bp-catalyst-platform.
+
+Until it is supplied the dashboard still renders, but the seed **loud-skips**
+(catalyst-api logs `anthropic seed: SKIPPED — platform Anthropic credential
+unset`) and the agent reports *"runtime offline · 0 workers"* / *"no Claude
+credential available"* on spawn. This is the correct pre-seed state (the
+ExternalSecret renders, the key is simply absent) — never an empty seed.
+
+A direct `bao kv put` (below) remains valid for a one-off manual seed / hot
+re-seed of an already-running Sovereign.
 
 Two properties live at that one path:
 
@@ -129,7 +159,7 @@ in-vc-mgmt OpenBao root — never write the secret to a file on disk):
 ```bash
 # exec into an in-cluster pod that can reach the region-1 OpenBao; export
 # VAULT_ADDR + VAULT_TOKEN for that store, then:
-bao kv put anthropic/token \
+bao kv put secret/catalyst/anthropic/token \
   apiKey='sk-ant-…' \
   credentialsJson='{"claudeAiOauth":{"accessToken":"…","refreshToken":"…","expiresAt":<ms>,"scopes":["user:inference"]}}'
 ```
@@ -138,9 +168,10 @@ ESO refreshes `agenity-anthropic-token` within `refreshInterval` (1h, or force
 an immediate sync by annotating the ExternalSecret with
 `force-sync=$(date +%s)`); the init container then seeds
 `~/.claude/.credentials.json` from `credentialsJson` and the next agent spawn
-authenticates. This path is **shared per-Sovereign** (not per-Org-namespaced)
-by default — a single seed serves every Org's agenity install on that
-Sovereign.
+authenticates. This path is **shared per-Sovereign** (not per-Org-namespaced) —
+a single seed serves every Org's agenity install on that Sovereign. The
+preferred durable seam is the platform credential the catalyst-api producer
+auto-seeds (above); this `bao kv put` is a one-off / hot re-seed.
 
 ### 🛑 The OAuth access token EXPIRES — re-seed when the agent goes offline (#4111)
 
@@ -163,7 +194,7 @@ diagnose this without exec'ing into the pod:
 🛑 WARNING (#4111): seeded claude-code OAuth token is EXPIRED (~45h ago) — the
    spawned agent will fail '401 Invalid authentication credentials' and the
    dashboard will show 'runtime offline / 0 workers'. RE-SEED openbao
-   anthropic/token with a FRESH credentialsJson and force-sync the ExternalSecret.
+   catalyst/anthropic/token with a FRESH credentialsJson and force-sync the ExternalSecret.
 ```
 
 (A valid token instead logs `claude-code OAuth token valid (~Nh remaining).`)
@@ -173,7 +204,9 @@ keep serving) and never mutates the blob (`claude-code` owns rotation).
 **When the agent reports offline, re-seed:** mint a **fresh**
 `credentialsJson` (a current `claude` login on a workstation writes
 `~/.claude/.credentials.json`; copy that whole blob), `bao kv put
-anthropic/token credentialsJson='…'` as above, force-sync the ExternalSecret
+secret/catalyst/anthropic/token credentialsJson='…'` as above (or rotate the
+`sovereign-anthropic-credentials` Secret so the next Org-create re-seeds it),
+force-sync the ExternalSecret
 (`kubectl annotate externalsecret agenity-anthropic-token
 force-sync=$(date +%s) --overwrite`), and restart the StatefulSet pod (or wait
 for the next restart) so the init container re-seeds the new blob. The next

--- a/products/agenity/blueprint.yaml
+++ b/products/agenity/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.5.7
+  version: 0.5.8
   card:
     title: Agenity
     summary: |

--- a/products/agenity/chart/Chart.yaml
+++ b/products/agenity/chart/Chart.yaml
@@ -8,6 +8,14 @@ description: |
   (RBAC-scoped to the User's rights) to create more Applications in the
   User's own Organization — the north-star self-service journey.
 type: application
+# 0.5.7 -> 0.5.8 (#4277): the anthropic ExternalSecret remoteKey moves from the
+# bare `anthropic/token` to `catalyst/anthropic/token`. A Sovereign has NO
+# writer for `secret/anthropic/*` (the external-secrets role vault-region1
+# reads with is read-only), so the bare path stayed SecretSyncedError on every
+# fresh Org. The catalyst/ prefix is the only KV sub-tree a Sovereign CAN write
+# (catalyst-api-write policy), and the new catalyst-api producer
+# (seedAnthropicToken) writes it at Org-create — making the agentic journey
+# zero-touch by construction. Template-only change; appVersion unchanged.
 # 0.5.6 -> 0.5.7 (#4180 + #4111, combined on rebase): two ADDITIVE changes land
 # together — the workspaces dashboard image (appVersion 0.9.7, #4180) AND the
 # seed-claude-creds expired-OAuth detector (#4111). Both documented below.
@@ -54,7 +62,7 @@ type: application
 # `ingress` entity that no K8s NetworkPolicy can admit — without the CNP every
 # external hit to agenity.<slug>.<pool> returned envoy 503 "upstream connect
 # error". appVersion (dashboard image) stays 0.9.6 — image bytes unchanged.
-version: 0.5.7
+version: 0.5.8
 # Bumped appVersion 0.9.6 -> 0.9.7 (#4180): 0.9.7 is the FIRST image whose
 # /app/ mounts the WORKSPACES dashboard (Dashboardws bundle) rather than the
 # archaic single-column Dashboard.svelte. It is built from agenity#752

--- a/products/agenity/chart/templates/statefulset.yaml
+++ b/products/agenity/chart/templates/statefulset.yaml
@@ -98,7 +98,7 @@ spec:
                 # i.e. the exact "runtime offline · 0 workers" symptom with no
                 # other signal. So we parse expiresAt HERE and emit a LOUD,
                 # greppable line when the seeded token is ALREADY expired — the
-                # operator's cue to re-seed openbao anthropic/token with a fresh
+                # operator's cue to re-seed openbao catalyst/anthropic/token with a fresh
                 # credentialsJson (see README §Seeding). This is diagnostic
                 # ONLY: we never block the pod (the dashboard must still serve)
                 # and never mutate the blob (claude-code owns rotation). The
@@ -106,7 +106,7 @@ spec:
                 # block scalar stays whitespace-robust across Helm renders.
                 EXP=$(python3 -c 'import json,time;o=json.load(open("/claudehome/.claude/.credentials.json")).get("claudeAiOauth",{});e=int(o.get("expiresAt",0) or 0);n=int(time.time()*1000);print(("EXPIRED %d"%((n-e)//3600000)) if e and e<n else ("OK %d"%((e-n)//3600000)) if e else "NOEXP")' 2>/dev/null || echo "")
                 case "$EXP" in
-                  EXPIRED*) echo "🛑 WARNING (#4111): seeded claude-code OAuth token is EXPIRED (~${EXP#EXPIRED }h ago) — the spawned agent will fail '401 Invalid authentication credentials' and the dashboard will show 'runtime offline / 0 workers'. RE-SEED openbao anthropic/token with a FRESH credentialsJson and force-sync the ExternalSecret (see README: Seeding the per-Org anthropic/token openbao path)." ;;
+                  EXPIRED*) echo "🛑 WARNING (#4111): seeded claude-code OAuth token is EXPIRED (~${EXP#EXPIRED }h ago) — the spawned agent will fail '401 Invalid authentication credentials' and the dashboard will show 'runtime offline / 0 workers'. RE-SEED openbao catalyst/anthropic/token with a FRESH credentialsJson and force-sync the ExternalSecret (see README: Seeding the catalyst/anthropic/token openbao path)." ;;
                   OK*)      echo "claude-code OAuth token valid (~${EXP#OK }h remaining)." ;;
                   NOEXP)    echo "claude-code credentials.json has no expiresAt — assuming a non-expiring credential." ;;
                   *)        echo "could not parse claude-code OAuth expiry from credentials.json (non-fatal)." ;;

--- a/products/agenity/chart/values.yaml
+++ b/products/agenity/chart/values.yaml
@@ -78,7 +78,17 @@ anthropic:
     secretStoreRef: vault-region1
     secretStoreKind: ClusterSecretStore
     # openbao path + property holding the sk-ant-... token.
-    remoteKey: anthropic/token
+    #
+    # #4277 — the PRODUCER (catalyst-api seedAnthropicToken) writes this
+    # path at Org-create. It lives under the `catalyst/` prefix because
+    # that is the ONLY KV sub-tree a Sovereign can WRITE: the catalyst-api
+    # holds the `catalyst-api-write` OpenBao policy (secret/{data,metadata}/
+    # catalyst/*), whereas the `external-secrets` role `vault-region1`
+    # reads with is read-only. A bare `anthropic/token` path has no writer
+    # on a Sovereign, so the ExternalSecret stayed SecretSyncedError on
+    # every fresh Org. The path is cluster-shared — one seed serves every
+    # Org's agenity install.
+    remoteKey: catalyst/anthropic/token
     remoteProperty: apiKey
     # openbao property holding the full claude-code credentials.json blob.
     remoteCredentialsProperty: credentialsJson

--- a/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
@@ -1662,13 +1662,19 @@ spec:
         allowGatewayEntity: true
     # Anthropic token (+ claude-code credentials.json) for the solo agent,
     # pulled from the Org's openbao via the region-1 ClusterSecretStore.
-    # The chart's externalsecret-anthropic.yaml reads anthropic/token.
+    # The chart's externalsecret-anthropic.yaml reads
+    # secret/catalyst/anthropic/token — the path the catalyst-api producer
+    # (seedAnthropicToken, #4277) writes at Org-create. It MUST live under
+    # the catalyst/ prefix: that is the only KV sub-tree a Sovereign can
+    # WRITE (catalyst-api-write policy); the external-secrets role used by
+    # vault-region1 is read-only. The path is cluster-shared — one seed
+    # serves every Org's agenity install.
     anthropic:
       externalSecret:
         enabled: true
         secretStoreRef: vault-region1
         secretStoreKind: ClusterSecretStore
-        remoteKey: anthropic/token
+        remoteKey: catalyst/anthropic/token
         remoteProperty: apiKey
         remoteCredentialsProperty: credentialsJson
 `

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
@@ -902,6 +902,21 @@ func (h *Handler) runOrganizationPipeline(ctx context.Context, rec store.Organiz
 		rec.LastError = ""
 		rec.RetryCount = 0
 		rec = persist(rec)
+
+		// #4277 — seed the Sovereign's OpenBao
+		// `secret/catalyst/anthropic/token` so this Org's (and every
+		// Org's — the path is cluster-shared) bp-agenity ExternalSecret
+		// resolves and the spawned claude-code authenticates zero-touch.
+		// The READ side (chart init container + ExternalSecret) was already
+		// wired (#4111); this is the missing producer. Deliberately NOT
+		// gated on success: a credential gap or transient OpenBao blip must
+		// not fail the Org pipeline (the agenity HR still installs; only its
+		// chat-runtime stays offline until the path is seeded). seedAnthropicToken
+		// surfaces the outcome loudly via the catalyst-api log and never
+		// returns an error. Idempotent (PutKVv2 overwrites) so re-running on
+		// every Org-create both makes new Orgs converge and keeps the
+		// short-lived OAuth blob fresh.
+		_ = h.seedAnthropicToken(ctx)
 	}
 
 	// Step 2 — bp_charts_installed.

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_anthropic_seed.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_anthropic_seed.go
@@ -1,0 +1,186 @@
+// Sovereign-side Anthropic credential seeding (issue #4277).
+//
+// Why this exists:
+//
+//	Every Organization's bp-agenity dashboard runs a solo claude-code
+//	agent. That agent authenticates from `~/.claude/.credentials.json`,
+//	which the chart's `seed-claude-creds` init container materialises
+//	from the per-Org `agenity-anthropic-token` Secret. That Secret is
+//	populated by an ExternalSecret that reads the Sovereign's OpenBao at
+//	`secret/catalyst/anthropic/token` via the `vault-region1`
+//	ClusterSecretStore (properties `apiKey` + `credentialsJson`).
+//
+//	The READ side (chart init container + ExternalSecret) is wired and
+//	shipped (#4111/#4233/#4261). The PRODUCER — the thing that writes the
+//	OpenBao path at Org-create — did NOT exist. Result: on every fresh
+//	funnel Org the `agenity-anthropic-token` ExternalSecret stayed
+//	READY=False / SecretSyncedError, no OAuth cred reached the agent, and
+//	the agentic journey (Pillar 4) failed until an operator hand-ran
+//	`bao kv put` (the manual one-shot #4111 documents). This file is that
+//	missing producer.
+//
+// Why `secret/catalyst/anthropic/token` (NOT bare `secret/anthropic/token`):
+//
+//	The agenity chart's historical default read `secret/anthropic/token`,
+//	but NOTHING on a Sovereign can WRITE there: the `external-secrets`
+//	OpenBao role (which `vault-region1` authenticates with) holds the
+//	read-only `external-secrets-read` policy, and no other role grants
+//	write on `secret/anthropic/*`. The catalyst-api Pod, by contrast,
+//	ALREADY holds a write-capable role (`catalyst-api-write`, scoped to
+//	`secret/{data,metadata}/catalyst/*` — see
+//	platform/openbao/chart/templates/auth-bootstrap-job.yaml #3376) that
+//	its existing `h.openbao` client (the same one that seals the cutover
+//	fact at `secret/catalyst/cutover-complete`) authenticates with. So we
+//	write under the `catalyst/` prefix the platform can ALREADY write —
+//	zero new OpenBao policy/role, zero PushSecret, zero cloud-init change.
+//	The agenity read-path (chart default + the org-gitops emitter
+//	override) is moved to this path in lock-step.
+//
+// Where the credential VALUE comes from:
+//
+//	The catalyst-api carries the platform-supplied Anthropic credential
+//	in its environment — CATALYST_ANTHROPIC_API_KEY (a real `sk-ant-…`
+//	key, optional) and CATALYST_ANTHROPIC_CREDENTIALS_JSON (the full
+//	`{"claudeAiOauth":{...}}` blob the spawned claude-code authenticates
+//	with). These are wired via secretKeyRef in the catalyst chart exactly
+//	like CATALYST_SMTP_USER/PASS (the #883 SMTP-relay precedent this file
+//	mirrors). The blob is REFRESHABLE: the claude-code OAuth accessToken
+//	is short-lived (hours) and headless claude-code does NOT reliably
+//	refresh it, so the operator rotates the env-sourced Secret and the
+//	next Org-create (or reconcile) re-seeds the fresh blob — PutKVv2
+//	overwrites, so re-seed is idempotent.
+//
+//	🛑 FOUNDER-SUPPLIED-SECRET GAP: if BOTH env vars are empty the seed is
+//	a LOUD no-op (same posture as the SMTP seed's skipped-no-env). The
+//	platform holds no Anthropic credential by default — registering one is
+//	a founder action (mirror of the Hetzner-token case). The exact target
+//	to populate is documented on the deployment SSE event + this file's
+//	doc comment: set CATALYST_ANTHROPIC_CREDENTIALS_JSON (and optionally
+//	CATALYST_ANTHROPIC_API_KEY) on the catalyst-api via the chart values
+//	`sovereign.anthropic.*` (products/catalyst/chart/values.yaml).
+//
+// When this runs:
+//
+//	runOrganizationPipeline calls seedAnthropicToken right after Step 1
+//	(per-Org overlay committed) on every Org-create. The OpenBao path is
+//	cluster-shared (one `secret/catalyst/anthropic/token` serves every
+//	Org's agenity install on the Sovereign), so the FIRST Org-create makes
+//	every Org converge; subsequent Org-creates re-seed harmlessly (and
+//	keep the OAuth blob fresh). A nil `h.openbao` client (the Catalyst-Zero
+//	orchestrator, never itself an agenity host) is a non-fatal skip.
+//
+// Per docs/PRINCIPLES.md #10 (credential hygiene): this never logs the
+// key or the credentials.json blob — only byte lengths + outcome class.
+package handler
+
+import (
+	"context"
+	"os"
+	"strings"
+)
+
+// anthropicSeedMountPath / anthropicSeedSecretPath — the OpenBao KV-v2
+// location the producer writes and the agenity ExternalSecret reads.
+// Fixed-by-contract with the agenity chart's
+// anthropic.externalSecret.remoteKey (products/agenity/chart/values.yaml)
+// and the org-gitops emitter override (organization_gitops.go). The
+// `catalyst/` prefix is the ONLY path a Sovereign can write (see the
+// file doc comment).
+const (
+	anthropicSeedMountPath  = "secret"
+	anthropicSeedSecretPath = "catalyst/anthropic/token"
+)
+
+// anthropicSeedAPIKeyEnv / anthropicSeedCredentialsJSONEnv — the
+// catalyst-api env vars carrying the platform-supplied Anthropic
+// credential. Wired via secretKeyRef in the catalyst chart (mirror of
+// CATALYST_SMTP_USER/PASS). At least ONE must be non-empty for the seed
+// to write; both empty ⇒ founder-supplied gap, loud skip.
+const (
+	anthropicSeedAPIKeyEnv          = "CATALYST_ANTHROPIC_API_KEY"
+	anthropicSeedCredentialsJSONEnv = "CATALYST_ANTHROPIC_CREDENTIALS_JSON"
+)
+
+// AnthropicSeedOutcome — terminal classification of one seed attempt.
+type AnthropicSeedOutcome string
+
+const (
+	AnthropicSeedOutcomeSeeded       AnthropicSeedOutcome = "seeded"
+	AnthropicSeedOutcomeSkippedNoEnv AnthropicSeedOutcome = "skipped-no-env"
+	AnthropicSeedOutcomeSkippedNoBao AnthropicSeedOutcome = "skipped-no-openbao"
+	AnthropicSeedOutcomeWriteFailure AnthropicSeedOutcome = "write-failure"
+)
+
+// seedAnthropicToken writes the Sovereign's OpenBao
+// `secret/catalyst/anthropic/token` path with the platform-supplied
+// Anthropic credential so every Org's agenity ExternalSecret resolves
+// (issue #4277). Idempotent: PutKVv2 overwrites, so repeated Org-creates
+// re-seed harmlessly and keep the (expiring) OAuth blob current.
+//
+// Returns the terminal outcome so the caller can emit an SSE / log line
+// without coupling this helper to the emit machinery. NEVER returns an
+// error that fails the Org pipeline — a credential gap or transient
+// OpenBao blip must not block the rest of the Org (the agenity HR still
+// installs; only its chat-runtime stays offline until the path is
+// seeded). The outcome is surfaced loudly instead.
+func (h *Handler) seedAnthropicToken(ctx context.Context) AnthropicSeedOutcome {
+	// Catalyst-Zero (the orchestrator) has no in-cluster OpenBao client
+	// and is never itself an agenity host — skip without noise beyond a
+	// debug line. Production Sovereign catalyst-api always has h.openbao
+	// wired (SetOpenBao, main.go).
+	if h.openbao == nil {
+		if h.log != nil {
+			h.log.Debug("anthropic seed: skipped — no OpenBao client (orchestrator / Catalyst-Zero)")
+		}
+		return AnthropicSeedOutcomeSkippedNoBao
+	}
+
+	apiKey := strings.TrimSpace(os.Getenv(anthropicSeedAPIKeyEnv))
+	credsJSON := strings.TrimSpace(os.Getenv(anthropicSeedCredentialsJSONEnv))
+	if apiKey == "" && credsJSON == "" {
+		// 🛑 FOUNDER-SUPPLIED-SECRET GAP: the platform holds no Anthropic
+		// credential. Surface loud + skip rather than seed an empty path
+		// that pretends to work (the reflector/ESO empty-seed trap the
+		// agenity README §"Why not chart-seed it?" warns about).
+		if h.log != nil {
+			h.log.Warn("anthropic seed: SKIPPED — platform Anthropic credential unset; agenity chat-runtime will stay offline until the founder supplies it",
+				"apiKeyEnv", anthropicSeedAPIKeyEnv,
+				"credentialsJsonEnv", anthropicSeedCredentialsJSONEnv,
+				"openbaoPath", anthropicSeedMountPath+"/"+anthropicSeedSecretPath,
+			)
+		}
+		return AnthropicSeedOutcomeSkippedNoEnv
+	}
+
+	// KV-v2 payload. Field names MUST match the agenity ExternalSecret's
+	// remoteRef.property values: `apiKey` (anthropic.externalSecret
+	// .remoteProperty) + `credentialsJson` (remoteCredentialsProperty).
+	// Both keys are always present so the ExternalSecret's optional
+	// credentialsJson property resolves cleanly; an empty value for a
+	// missing env var is fine (the chart's seed-claude-creds init
+	// container treats a 0-byte credentialsJson as key-only mode).
+	data := map[string]any{
+		"apiKey":          apiKey,
+		"credentialsJson": credsJSON,
+	}
+
+	if err := h.openbao.PutKVv2(ctx, anthropicSeedMountPath, anthropicSeedSecretPath, data); err != nil {
+		if h.log != nil {
+			h.log.Error("anthropic seed: OpenBao write failed",
+				"openbaoPath", anthropicSeedMountPath+"/"+anthropicSeedSecretPath,
+				"err", err,
+			)
+		}
+		return AnthropicSeedOutcomeWriteFailure
+	}
+
+	if h.log != nil {
+		// Per docs/PRINCIPLES.md #10: byte lengths only, never plaintext.
+		h.log.Info("anthropic seed: wrote OpenBao path so every Org's agenity ExternalSecret resolves",
+			"openbaoPath", anthropicSeedMountPath+"/"+anthropicSeedSecretPath,
+			"apiKeyBytes", len(apiKey),
+			"credentialsJsonBytes", len(credsJSON),
+		)
+	}
+	return AnthropicSeedOutcomeSeeded
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_anthropic_seed_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_anthropic_seed_test.go
@@ -1,0 +1,147 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/openbao"
+)
+
+// captureKVServer is a fake OpenBao KV-v2 endpoint that records the last
+// PUT path + payload so the test can assert the producer wrote the exact
+// `secret/catalyst/anthropic/token` path with the `apiKey` +
+// `credentialsJson` fields the agenity ExternalSecret expects.
+type captureKVServer struct {
+	mu      sync.Mutex
+	lastURL string
+	lastReq map[string]any
+	srv     *httptest.Server
+}
+
+func newCaptureKVServer(t *testing.T) *captureKVServer {
+	t.Helper()
+	c := &captureKVServer{}
+	c.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var parsed map[string]any
+		_ = json.Unmarshal(body, &parsed)
+		c.mu.Lock()
+		c.lastURL = r.URL.Path
+		c.lastReq = parsed
+		c.mu.Unlock()
+		// KV-v2 write success envelope.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"version":1}}`))
+	}))
+	t.Cleanup(c.srv.Close)
+	return c
+}
+
+func (c *captureKVServer) dataField(key string) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.lastReq == nil {
+		return "", false
+	}
+	data, ok := c.lastReq["data"].(map[string]any)
+	if !ok {
+		return "", false
+	}
+	v, ok := data[key].(string)
+	return v, ok
+}
+
+// Test_seedAnthropicToken_SeedsExpectedPathAndFields verifies the producer
+// writes secret/catalyst/anthropic/token with both properties the read-path
+// consumes (#4277). The path + field names are the contract with the agenity
+// chart's externalsecret-anthropic.yaml — a drift here re-breaks the journey.
+func Test_seedAnthropicToken_SeedsExpectedPathAndFields(t *testing.T) {
+	srv := newCaptureKVServer(t)
+	h := &Handler{log: silentLogger()}
+	h.openbao = &openbao.Client{Addr: srv.srv.URL, Token: "test-token", HTTP: srv.srv.Client()}
+
+	t.Setenv(anthropicSeedAPIKeyEnv, "sk-ant-test-key")
+	t.Setenv(anthropicSeedCredentialsJSONEnv, `{"claudeAiOauth":{"accessToken":"oat-x","refreshToken":"r","expiresAt":1,"scopes":["user:inference"]}}`)
+
+	outcome := h.seedAnthropicToken(context.Background())
+	if outcome != AnthropicSeedOutcomeSeeded {
+		t.Fatalf("outcome = %q, want %q", outcome, AnthropicSeedOutcomeSeeded)
+	}
+
+	// KV-v2 PUT path is /v1/<mount>/data/<secretPath>.
+	wantPath := "/v1/secret/data/catalyst/anthropic/token"
+	srv.mu.Lock()
+	gotPath := srv.lastURL
+	srv.mu.Unlock()
+	if gotPath != wantPath {
+		t.Errorf("PUT path = %q, want %q", gotPath, wantPath)
+	}
+
+	if v, ok := srv.dataField("apiKey"); !ok || v != "sk-ant-test-key" {
+		t.Errorf("apiKey field = %q (present=%v), want sk-ant-test-key", v, ok)
+	}
+	if v, ok := srv.dataField("credentialsJson"); !ok || v == "" {
+		t.Errorf("credentialsJson field missing/empty (present=%v)", ok)
+	}
+}
+
+// Test_seedAnthropicToken_CredentialsJSONOnly verifies the OAuth-only path
+// (no bare api key) still seeds — the agenity OAuth journey supplies only
+// credentialsJson.
+func Test_seedAnthropicToken_CredentialsJSONOnly(t *testing.T) {
+	srv := newCaptureKVServer(t)
+	h := &Handler{log: silentLogger()}
+	h.openbao = &openbao.Client{Addr: srv.srv.URL, Token: "test-token", HTTP: srv.srv.Client()}
+
+	t.Setenv(anthropicSeedAPIKeyEnv, "")
+	t.Setenv(anthropicSeedCredentialsJSONEnv, `{"claudeAiOauth":{"accessToken":"oat-x"}}`)
+
+	if outcome := h.seedAnthropicToken(context.Background()); outcome != AnthropicSeedOutcomeSeeded {
+		t.Fatalf("outcome = %q, want %q", outcome, AnthropicSeedOutcomeSeeded)
+	}
+	if v, ok := srv.dataField("credentialsJson"); !ok || v == "" {
+		t.Errorf("credentialsJson field missing/empty (present=%v)", ok)
+	}
+	if v, _ := srv.dataField("apiKey"); v != "" {
+		t.Errorf("apiKey field = %q, want empty", v)
+	}
+}
+
+// Test_seedAnthropicToken_SkipNoEnv verifies the founder-supplied-secret gap:
+// both env vars empty ⇒ loud skip, NO OpenBao write (an empty path would
+// pin the ESO/reflector empty-seed trap).
+func Test_seedAnthropicToken_SkipNoEnv(t *testing.T) {
+	srv := newCaptureKVServer(t)
+	h := &Handler{log: silentLogger()}
+	h.openbao = &openbao.Client{Addr: srv.srv.URL, Token: "test-token", HTTP: srv.srv.Client()}
+
+	t.Setenv(anthropicSeedAPIKeyEnv, "")
+	t.Setenv(anthropicSeedCredentialsJSONEnv, "")
+
+	if outcome := h.seedAnthropicToken(context.Background()); outcome != AnthropicSeedOutcomeSkippedNoEnv {
+		t.Fatalf("outcome = %q, want %q", outcome, AnthropicSeedOutcomeSkippedNoEnv)
+	}
+	srv.mu.Lock()
+	wrote := srv.lastURL != ""
+	srv.mu.Unlock()
+	if wrote {
+		t.Errorf("expected NO OpenBao write when credential unset, but a write hit %q", srv.lastURL)
+	}
+}
+
+// Test_seedAnthropicToken_SkipNoOpenBao verifies the Catalyst-Zero
+// orchestrator path: nil OpenBao client ⇒ non-fatal skip, no panic.
+func Test_seedAnthropicToken_SkipNoOpenBao(t *testing.T) {
+	h := &Handler{log: silentLogger()}
+	// h.openbao deliberately nil.
+	t.Setenv(anthropicSeedAPIKeyEnv, "sk-ant-test-key")
+	if outcome := h.seedAnthropicToken(context.Background()); outcome != AnthropicSeedOutcomeSkippedNoBao {
+		t.Fatalf("outcome = %q, want %q", outcome, AnthropicSeedOutcomeSkippedNoBao)
+	}
+}

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3004,6 +3004,33 @@ name: bp-catalyst-platform
 #   catalyst-api runs in catalyst-system. Pure-additive: priorityClassName/Value are new
 #   values, default-on; no other behaviour changes. Chart-version bump forces the Flux
 #   re-pull (the deploy-bot mutable-tag trap, #4257).
+# 1.4.833 — #4277: auto-seed the per-Org Anthropic credential so the agentic
+#   journey (Pillar 4) is zero-touch on a FRESH Org. The READ side (bp-agenity
+#   seed-claude-creds init container + anthropic ExternalSecret, #4111) was
+#   already wired but the PRODUCER — the thing that writes the Sovereign OpenBao
+#   path at Org-create — did not exist, so every fresh funnel Org's
+#   agenity-anthropic-token ExternalSecret stayed SecretSyncedError. This bump:
+#     - new catalyst-api producer seedAnthropicToken (called from
+#       runOrganizationPipeline after the per-Org overlay commit) writes
+#       secret/catalyst/anthropic/token (fields apiKey + credentialsJson) via
+#       the catalyst-api's existing write-capable OpenBao client. The catalyst/
+#       prefix is deliberate: it is the ONLY KV sub-tree a Sovereign can WRITE
+#       (catalyst-api-write policy); the bare secret/anthropic/* the agenity
+#       chart historically read has no writer. The agenity remoteKey moves to
+#       catalyst/anthropic/token in lockstep (bp-agenity 0.5.7→0.5.8 + the
+#       catalog-seed pin).
+#     - api-deployment(.yaml/-kustomize.yaml) wire CATALYST_ANTHROPIC_API_KEY +
+#       CATALYST_ANTHROPIC_CREDENTIALS_JSON (optional secretKeyRef, mirror of
+#       the #883 SMTP relay env).
+#     - catalyst-openova-kc-credentials Secret carries anthropic-api-key /
+#       anthropic-credentials-json (source-wins from the operator-rotatable
+#       sovereign-anthropic-credentials Secret — the seam to re-seed the
+#       EXPIRING OAuth blob — falling back to sovereign.anthropic.* values).
+#   🛑 FOUNDER-SUPPLIED-SECRET GAP: the platform ships NO Anthropic credential
+#   (Principle #4). Until the founder populates it ONCE per Sovereign (via the
+#   sovereign-anthropic-credentials Secret or sovereign.anthropic.* values) the
+#   seed loud-skips and agenity stays offline — the correct pre-seed state, NOT
+#   a silent empty seed (the ESO/reflector empty-seed trap).
 # 1.4.830 — #4281 + #4282 (two console/catalog fixes, one chart bump):
 #   #4281 — console Cloud HelmReleases list gains a "Target Namespace" column
 #     (spec.targetNamespace, falling back to metadata.namespace). Host-shared

--- a/products/catalyst/chart/templates/api-deployment-kustomize.yaml
+++ b/products/catalyst/chart/templates/api-deployment-kustomize.yaml
@@ -1368,6 +1368,26 @@ spec:
                   name: catalyst-openova-kc-credentials
                   key: smtp-from
                   optional: true
+            # ── Anthropic credential for the per-Org agentic agent (#4277) ──
+            # See api-deployment.yaml for the full rationale. The catalyst-api
+            # producer (seedAnthropicToken) writes the Sovereign OpenBao
+            # `secret/catalyst/anthropic/token` from these at Org-create so
+            # every Org's bp-agenity ExternalSecret resolves zero-touch. Both
+            # optional so a Sovereign without the platform credential renders
+            # cleanly (loud-skip + agenity offline until the founder supplies
+            # source Secret keys anthropic-api-key / anthropic-credentials-json).
+            - name: CATALYST_ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: catalyst-openova-kc-credentials
+                  key: anthropic-api-key
+                  optional: true
+            - name: CATALYST_ANTHROPIC_CREDENTIALS_JSON
+              valueFrom:
+                secretKeyRef:
+                  name: catalyst-openova-kc-credentials
+                  key: anthropic-credentials-json
+                  optional: true
             # CATALYST_SESSION_COOKIE_DOMAIN — optional domain scoping for the
             # catalyst_session + catalyst_refresh cookies.
             #

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -1598,6 +1598,31 @@ spec:
                   name: catalyst-openova-kc-credentials
                   key: smtp-from
                   optional: true
+            # ── Anthropic credential for the per-Org agentic agent (#4277) ──
+            # The catalyst-api producer (seedAnthropicToken) writes the
+            # Sovereign OpenBao `secret/catalyst/anthropic/token` from these
+            # at Org-create so every Org's bp-agenity ExternalSecret resolves
+            # and the spawned claude-code authenticates zero-touch. Both are
+            # `optional: true` so a Sovereign whose operator has not supplied
+            # the platform Anthropic credential renders cleanly (the seed
+            # loud-skips and agenity stays in key-only/offline mode until the
+            # founder populates the source Secret keys `anthropic-api-key` /
+            # `anthropic-credentials-json`). credentials-json is the full
+            # `{"claudeAiOauth":{...}}` blob the OAuth journey needs; the
+            # bare api-key is the key-only fallback. Mirrors the SMTP relay
+            # wiring above (#883).
+            - name: CATALYST_ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: catalyst-openova-kc-credentials
+                  key: anthropic-api-key
+                  optional: true
+            - name: CATALYST_ANTHROPIC_CREDENTIALS_JSON
+              valueFrom:
+                secretKeyRef:
+                  name: catalyst-openova-kc-credentials
+                  key: anthropic-credentials-json
+                  optional: true
             # CATALYST_SESSION_COOKIE_DOMAIN — optional domain scoping for the
             # catalyst_session + catalyst_refresh cookies.
             #

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -6537,11 +6537,13 @@ spec:
 # with the built-in solo agent (Claude Opus 4.7, token pre-configured), and
 # the agent creates more Applications in the User's Org via the RBAC-scoped
 # openova MCP. The north-star self-service journey (UAT rows 218-223).
-# Lockstep with products/agenity/chart/Chart.yaml version 0.5.7 + the
-# published chart ghcr.io/openova-io/bp-agenity:0.5.7 (appVersion 0.9.7 — the
+# Lockstep with products/agenity/chart/Chart.yaml version 0.5.8 + the
+# published chart ghcr.io/openova-io/bp-agenity:0.5.8 (appVersion 0.9.7 — the
 # image whose /app mounts the WORKSPACES dashboard rather than the archaic
-# single-column one, built from agenity#752, #4180; chart 0.5.7 adds the
-# #4261 expired-OAuth seed detection over 0.5.6). Fresh provs seed THIS pin,
+# single-column one, built from agenity#752, #4180; chart 0.5.8 moves the
+# anthropic ExternalSecret remoteKey to the writable catalyst/anthropic/token
+# path the new catalyst-api producer seeds at Org-create, #4277, over 0.5.7).
+# Fresh provs seed THIS pin,
 # so the chart-version here gates which image a new Sovereign installs — bump
 # in lockstep with the chart on every agenity release. (The per-Org install
 # in organization_gitops.go pins `*` and so auto-resolves the newest published
@@ -6562,7 +6564,7 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
 spec:
-  version: "0.5.7"
+  version: "0.5.8"
   visibility: listed
   card:
     title: "Agenity"

--- a/products/catalyst/chart/templates/catalyst-openova-kc-credentials-secret.yaml
+++ b/products/catalyst/chart/templates/catalyst-openova-kc-credentials-secret.yaml
@@ -270,6 +270,33 @@ defaults).
 {{- else if and $existing $existing.data (index $existing.data "smtp-from") -}}
   {{- $smtpFrom = index $existing.data "smtp-from" | b64dec -}}
 {{- end -}}
+{{- /* ---- Anthropic creds (#4277): SOURCE-wins lookup against
+       sovereign-anthropic-credentials ----
+       The catalyst-api producer (seedAnthropicToken) reads these from its
+       env (CATALYST_ANTHROPIC_API_KEY / CATALYST_ANTHROPIC_CREDENTIALS_JSON)
+       and writes the Sovereign OpenBao `secret/catalyst/anthropic/token` at
+       Org-create so every Org's bp-agenity ExternalSecret resolves.
+       Operator-rotatable seam: the operator (or a future mothership seed,
+       mirroring #883 SMTP) creates/edits the `sovereign-anthropic-credentials`
+       Secret with keys `apiKey` / `credentialsJson`; source-wins so the next
+       reconcile re-projects the (expiring) OAuth blob. Values-default
+       (`.Values.sovereign.anthropic.*`, empty by default → founder-supplied
+       gap) is the floor; existing-target is the back-compat fallback when the
+       source is absent after a helm reinstall. Same posture as the SMTP block
+       above (single source of truth, no lookup-derived drift). */ -}}
+{{- $anthSrc := lookup "v1" "Secret" $namespace "sovereign-anthropic-credentials" -}}
+{{- $anthApiKey := (((.Values.sovereign).anthropic).apiKey | default "") -}}
+{{- $anthCredsJSON := (((.Values.sovereign).anthropic).credentialsJson | default "") -}}
+{{- if and $anthSrc $anthSrc.data (index $anthSrc.data "apiKey") -}}
+  {{- $anthApiKey = index $anthSrc.data "apiKey" | b64dec -}}
+{{- else if and $existing $existing.data (index $existing.data "anthropic-api-key") -}}
+  {{- $anthApiKey = index $existing.data "anthropic-api-key" | b64dec -}}
+{{- end -}}
+{{- if and $anthSrc $anthSrc.data (index $anthSrc.data "credentialsJson") -}}
+  {{- $anthCredsJSON = index $anthSrc.data "credentialsJson" | b64dec -}}
+{{- else if and $existing $existing.data (index $existing.data "anthropic-credentials-json") -}}
+  {{- $anthCredsJSON = index $existing.data "anthropic-credentials-json" | b64dec -}}
+{{- end -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -296,5 +323,12 @@ data:
   smtp-from: {{ $smtpFrom | b64enc | quote }}
   smtp-user: {{ $smtpUser | b64enc | quote }}
   smtp-pass: {{ $smtpPass | b64enc | quote }}
+  # Anthropic credential (#4277) — consumed by the catalyst-api env
+  # (CATALYST_ANTHROPIC_API_KEY / CATALYST_ANTHROPIC_CREDENTIALS_JSON) and
+  # seeded into OpenBao secret/catalyst/anthropic/token at Org-create.
+  # Empty by default (founder-supplied gap); the api-deployment secretKeyRef
+  # is optional:true so empty keys render cleanly.
+  anthropic-api-key: {{ $anthApiKey | b64enc | quote }}
+  anthropic-credentials-json: {{ $anthCredsJSON | b64enc | quote }}
 {{- end }}
 {{- end }}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -689,10 +689,7 @@ controllers:
       # 34ff594 had drifted 470 commits behind latest GHCR. The merge-time
       # build-organization-controller.yaml auto-bump re-pins this to the image
       # built from THIS PR's tenant_dns.go code.
-      # 895f961 (controller-image-tag freshness sweep) — 09dcc10 had drifted 118
-      # commits behind latest GHCR; bumped to the current organization-controller
-      # GHCR tag to clear the staleness gate. The merge-time auto-bump re-pins.
-      tag: "895f961"
+      tag: "09dcc10"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -824,7 +821,7 @@ controllers:
       # loops the env-controller.
       # 34ff594 (2026-06-21, #4053) — freshness sweep on the console-gateway-
       # isolation PR: 01db043 had drifted 437 commits behind latest GHCR.
-      tag: "895f961"
+      tag: "34ff594"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -876,7 +873,7 @@ controllers:
       # successful push-on-main build per Inviolable Principle #4a.
       # 34ff594 (2026-06-21, #4053) — freshness sweep on the console-gateway-
       # isolation PR: 01db043 had drifted 437 commits behind latest GHCR.
-      tag: "895f961"
+      tag: "34ff594"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -914,7 +911,7 @@ controllers:
       # 6d7aacd (2026-06-24, #4236) — freshness sweep on the funnel pool-DNS PR:
       # 34ff594 had drifted 183 commits behind latest GHCR (no code change here,
       # just clearing the staleness gate so the chart ships the current binary).
-      tag: "895f961"
+      tag: "6d7aacd"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -983,7 +980,7 @@ controllers:
       # #2851 closed the drift gap (auto-bump + sweep + freshness guard).
       # 34ff594 (2026-06-21, #4053) — freshness sweep on the console-gateway-
       # isolation PR: 01db043 had drifted 437 commits behind latest GHCR.
-      tag: "895f961"
+      tag: "34ff594"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -689,7 +689,10 @@ controllers:
       # 34ff594 had drifted 470 commits behind latest GHCR. The merge-time
       # build-organization-controller.yaml auto-bump re-pins this to the image
       # built from THIS PR's tenant_dns.go code.
-      tag: "09dcc10"
+      # 895f961 (controller-image-tag freshness sweep) — 09dcc10 had drifted 118
+      # commits behind latest GHCR; bumped to the current organization-controller
+      # GHCR tag to clear the staleness gate. The merge-time auto-bump re-pins.
+      tag: "895f961"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -821,7 +824,7 @@ controllers:
       # loops the env-controller.
       # 34ff594 (2026-06-21, #4053) — freshness sweep on the console-gateway-
       # isolation PR: 01db043 had drifted 437 commits behind latest GHCR.
-      tag: "34ff594"
+      tag: "895f961"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -873,7 +876,7 @@ controllers:
       # successful push-on-main build per Inviolable Principle #4a.
       # 34ff594 (2026-06-21, #4053) — freshness sweep on the console-gateway-
       # isolation PR: 01db043 had drifted 437 commits behind latest GHCR.
-      tag: "34ff594"
+      tag: "895f961"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -911,7 +914,7 @@ controllers:
       # 6d7aacd (2026-06-24, #4236) — freshness sweep on the funnel pool-DNS PR:
       # 34ff594 had drifted 183 commits behind latest GHCR (no code change here,
       # just clearing the staleness gate so the chart ships the current binary).
-      tag: "6d7aacd"
+      tag: "895f961"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -980,7 +983,7 @@ controllers:
       # #2851 closed the drift gap (auto-bump + sweep + freshness guard).
       # 34ff594 (2026-06-21, #4053) — freshness sweep on the console-gateway-
       # isolation PR: 01db043 had drifted 437 commits behind latest GHCR.
-      tag: "34ff594"
+      tag: "895f961"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -92,6 +92,30 @@ sovereign:
     host: mail.openova.io
     port: "587"
     from: noreply@openova.io
+  # ── Anthropic credential for the per-Org agentic agent (#4277) ──
+  # Consumed by the auto-provisioned `catalyst-openova-kc-credentials`
+  # Secret (anthropic-api-key / anthropic-credentials-json keys) → the
+  # catalyst-api env (CATALYST_ANTHROPIC_*) → the producer seedAnthropicToken,
+  # which writes the Sovereign OpenBao `secret/catalyst/anthropic/token` at
+  # Org-create so every Org's bp-agenity ExternalSecret resolves and the
+  # spawned claude-code authenticates zero-touch.
+  #
+  # 🛑 EMPTY by default — FOUNDER-SUPPLIED-SECRET GAP. The platform ships no
+  # Anthropic credential (Principle #4: never hardcode secrets). To make the
+  # agentic journey zero-touch on every Org, the operator supplies the
+  # credential ONCE per Sovereign via one of:
+  #   (a) the operator-rotatable `catalyst-system/sovereign-anthropic-credentials`
+  #       Secret (keys `apiKey` / `credentialsJson`) — source-wins, the seam
+  #       to re-seed the EXPIRING OAuth blob without a chart upgrade; OR
+  #   (b) a per-Sovereign overlay setting these values.
+  # `credentialsJson` is the full `{"claudeAiOauth":{...}}` blob the OAuth
+  # journey needs (the channel claude-code actually authenticates with);
+  # `apiKey` is the bare `sk-ant-…` key-only fallback. Until supplied, the
+  # seed loud-skips and agenity stays offline (the ExternalSecret renders,
+  # the key is simply absent — the correct pre-seed state).
+  anthropic:
+    apiKey: ""
+    credentialsJson: ""
   # ── Configured-but-not-active regions (qa-loop iter-16 Fix #88) ──
   # Hetzner regions the operator declared at provision time. The
   # provisioner's tofu module currently materialises the *first* entry

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -689,7 +689,7 @@ controllers:
       # 34ff594 had drifted 470 commits behind latest GHCR. The merge-time
       # build-organization-controller.yaml auto-bump re-pins this to the image
       # built from THIS PR's tenant_dns.go code.
-      tag: "09dcc10"
+      tag: "724668b"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -821,7 +821,7 @@ controllers:
       # loops the env-controller.
       # 34ff594 (2026-06-21, #4053) — freshness sweep on the console-gateway-
       # isolation PR: 01db043 had drifted 437 commits behind latest GHCR.
-      tag: "34ff594"
+      tag: "895f961"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -873,7 +873,7 @@ controllers:
       # successful push-on-main build per Inviolable Principle #4a.
       # 34ff594 (2026-06-21, #4053) — freshness sweep on the console-gateway-
       # isolation PR: 01db043 had drifted 437 commits behind latest GHCR.
-      tag: "34ff594"
+      tag: "895f961"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -911,7 +911,7 @@ controllers:
       # 6d7aacd (2026-06-24, #4236) — freshness sweep on the funnel pool-DNS PR:
       # 34ff594 had drifted 183 commits behind latest GHCR (no code change here,
       # just clearing the staleness gate so the chart ships the current binary).
-      tag: "6d7aacd"
+      tag: "895f961"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -980,7 +980,7 @@ controllers:
       # #2851 closed the drift gap (auto-bump + sweep + freshness guard).
       # 34ff594 (2026-06-21, #4053) — freshness sweep on the console-gateway-
       # isolation PR: 01db043 had drifted 437 commits behind latest GHCR.
-      tag: "34ff594"
+      tag: "895f961"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:


### PR DESCRIPTION
## Refs #4277

The bp-agenity **read-path** (the `seed-claude-creds` init container + the `anthropic` ExternalSecret, #4111/#4233/#4261) was already wired and shipped, but the **PRODUCER** — the thing that writes the Sovereign OpenBao path at Org-create — did not exist. So on every fresh funnel Org the `agenity-anthropic-token` ExternalSecret stayed **READY=False / SecretSyncedError**, no OAuth cred reached the spawned `claude-code`, and the agentic journey (Pillar 4) failed until an operator hand-ran `bao kv put`. This PR is that missing producer.

## What I traced (the read-path — NOT rebuilt)
- `products/agenity/chart/templates/externalsecret-anthropic.yaml` reads OpenBao via ClusterSecretStore `vault-region1` (KV mount `secret`, v2) into K8s Secret `agenity-anthropic-token`, properties **`apiKey`** + **`credentialsJson`**.
- The `seed-claude-creds` init container writes `~/.claude/.credentials.json` from `credentialsJson`. The path is **cluster-shared** (one seed serves every Org).

## The seed (producer side)
1. **New catalyst-api producer** `seedAnthropicToken` (`sovereign_anthropic_seed.go`), called from `runOrganizationPipeline` right after the per-Org overlay commit. Writes `secret/catalyst/anthropic/token` (fields `apiKey` + `credentialsJson`) via the catalyst-api's **existing** write-capable OpenBao client (the same one that seals the cutover fact at `secret/catalyst/cutover-complete`). Idempotent (`PutKVv2` overwrites) → converges every new Org **and** keeps the short-lived OAuth blob fresh. Mirrors the #883 SMTP-relay seed precedent.
2. **Read-path moves** `anthropic/token` → **`catalyst/anthropic/token`** in lockstep (agenity chart default + the org-gitops emitter). **Why:** a Sovereign has **no writer** for `secret/anthropic/*` — the `external-secrets` role `vault-region1` reads with is **read-only** (`external-secrets-read` policy). The `catalyst/` prefix is the **only** KV sub-tree the catalyst-api can WRITE (`catalyst-api-write` policy, `secret/{data,metadata}/catalyst/*`). bp-agenity `0.5.7→0.5.8` + the catalog-seed pin in lockstep.
3. **Env + Secret wiring:** `CATALYST_ANTHROPIC_API_KEY` / `CATALYST_ANTHROPIC_CREDENTIALS_JSON` (optional `secretKeyRef`, mirror of the SMTP relay); the `catalyst-openova-kc-credentials` Secret carries `anthropic-api-key` / `anthropic-credentials-json` (**source-wins** from the operator-rotatable `sovereign-anthropic-credentials` Secret — the seam to re-seed the EXPIRING OAuth blob — falling back to `sovereign.anthropic.*`). bp-catalyst-platform `1.4.830→1.4.831`.

## WHERE the credential value comes from
The catalyst-api carries the platform-supplied Anthropic credential in its env, sourced via the `catalyst-openova-kc-credentials` Secret. **🛑 FOUNDER-SUPPLIED-SECRET GAP (like the Hetzner-token case):** the platform ships **no** Anthropic credential by default (Principle #4; the BYOS path uses a `PLACEHOLDER-AWAITING-FOUNDER-REGISTRATION` sentinel and no platform OAuth client is registered). Until the founder supplies it **once per Sovereign**, the seed **loud-skips** (`anthropic seed: SKIPPED — platform Anthropic credential unset`) and agenity stays offline — the correct pre-seed state, NOT a silent empty seed (the ESO/reflector empty-seed trap).

**Exact target the founder must populate (once per Sovereign):** either
- the operator-rotatable `catalyst-system/sovereign-anthropic-credentials` Secret with keys `apiKey` / `credentialsJson`; or
- a per-Sovereign overlay setting `sovereign.anthropic.{apiKey,credentialsJson}` on bp-catalyst-platform.

`credentialsJson` is the full `{"claudeAiOauth":{...}}` blob the OAuth journey needs.

## Validation (render + unit)
- `helm template` confirms the agenity ExternalSecret now renders `key: catalyst/anthropic/token` for **both** `apiKey` + `credentialsJson` properties; whole catalyst chart renders clean (223 resources, no error).
- Unit tests (`sovereign_anthropic_seed_test.go`): exact path+field assertion (`/v1/secret/data/catalyst/anthropic/token`), OAuth-only path, founder-gap **loud-skip-no-write**, nil-OpenBao orchestrator skip. Full handler suite green.
- `scripts/check-catalog-seed-lockstep.sh` PASS.

## LIVE chat-online walk (the acceptance — a WALK, not performed here)
On a fresh Sovereign with the platform Anthropic credential supplied once:
1. **Supply the credential once:** `kubectl -n catalyst-system create secret generic sovereign-anthropic-credentials --from-literal=apiKey='sk-ant-…' --from-literal=credentialsJson='{"claudeAiOauth":{…}}'` (or set `sovereign.anthropic.*` in the overlay) → catalyst-api picks it up into `CATALYST_ANTHROPIC_*`.
2. **Create a brand-new Org via the live funnel** (marketplace voucher redeem → console).
3. **Verify the producer fired:** catalyst-api log line `anthropic seed: wrote OpenBao path …` (byte lengths, no plaintext). `kubectl -n org-<id> get externalsecret agenity-anthropic-token` → **READY=True** with NO manual seed.
4. **Verify the agent authenticates:** `kubectl -n org-<id> logs bp-agenity-0 -c seed-claude-creds` → `seeded ~/.claude/.credentials.json (<N> bytes)` + `claude-code OAuth token valid (~Nh remaining)`.
5. **Open `https://agenity.<slug>.<pool>/app/`** → chat is **online** (workers > 0); send a prompt → the spawned claude-code responds (no `401 Invalid authentication credentials`, no "runtime offline / 0 workers"). Screenshot + the init-container log line are the acceptance artifacts on #4277.

## Collision-avoidance
Based on `origin/fix/4292-org-vcluster-boundary` (Workstream B). **Did NOT touch** the vcluster-keystone agent's files (`manifests.go`, the app-HR emitter, `MirrorVClusterKubeconfig`). The only `organization_gitops.go` change is the localized agenity `remoteKey` + comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)