### PR TITLE
fix(bp-newapi): admin-promote CronJob gets its own release-managed SA — stop the missing-SA loop wedging the HR (1.4.126)

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -307,7 +307,7 @@ spec:
       # 1.4.122 (#4169): issuer-realm gate on the sovereign-realm newapi-admin
       # AppRegistration (host-side concern; this vcluster-app slot already sets
       # ssoBridgeSync.enabled=false so it never emitted it — pure lockstep bump).
-      version: 1.4.124
+      version: 1.4.126
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/clusters/_template/bootstrap-kit/80a-newapi-host-seams.yaml
+++ b/clusters/_template/bootstrap-kit/80a-newapi-host-seams.yaml
@@ -80,7 +80,7 @@ spec:
       # (below), so it STILL renders the ConfigMap — it is the CANONICAL owner of
       # the sovereign-realm newapi-admin client. The gate only EXCLUDES per-Org
       # tenant installs (issuer .../realms/org-<sub>) that were clobbering it.
-      version: 1.4.124
+      version: 1.4.126
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.125
+  version: 1.4.126
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -1,5 +1,42 @@
 apiVersion: v2
 name: bp-newapi
+# 1.4.126 (#4278, 2026-06-25): admin-promote CronJob no longer loops forever
+# on a missing ServiceAccount → bp-newapi HR can reach Ready on a fresh Org.
+#
+# ROOT CAUSE (measured live, omantel.biz demo Org org-7283eb4a-…, chart 1.4.125):
+#   The per-minute admin-promote CronJob (a REGULAR, release-managed resource)
+#   set serviceAccountName to the one-shot admin-SEED Job's ServiceAccount
+#   `bp-newapi-admin-seed`, which is a Helm HOOK resource
+#   (post-install,post-upgrade + hook-delete-policy: before-hook-creation).
+#   When the install/upgrade hook phase failed or timed out, Helm's
+#   before-hook-creation cleanup DELETED that hook-scoped SA (+ Role +
+#   RoleBinding + the scripts ConfigMap), but the long-lived CronJob survived
+#   and fired every minute against a now-missing SA:
+#     pods "bp-newapi-admin-promote-…-" is forbidden: error looking up
+#     service account …/bp-newapi-admin-seed: serviceaccount
+#     "bp-newapi-admin-seed" not found
+#   → every spawned Job DeadlineExceeded → the Helm post-install hook never
+#   completed → bp-newapi HR wedged "context deadline exceeded" (release stuck
+#   at v1, install-failed) even though the newapi data plane was 3/3 Running.
+#   This is the canonical "a long-lived CronJob must not depend on Helm-hook
+#   lifecycle resources" defect — every other long-lived CronJob in this repo
+#   (openbao snapshot-replication, self-sovereign-cutover mirror-resync,
+#   syft-grype, flux stuck-HR-recovery) uses its OWN release-managed RBAC.
+#
+# FIX (#4278):
+#   - The admin-promote CronJob now has a DEDICATED, release-managed
+#     ServiceAccount + Role + RoleBinding (`bp-newapi-admin-promote`, NO Helm
+#     hook annotations), bound with exactly the verbs promote.sh needs (get the
+#     CNPG -app Secret; get+patch the NewAPI Deployment for the hash-gated
+#     reload). The CronJob binds this SA, never the hook seed SA.
+#   - The shared scripts ConfigMap (`bp-newapi-admin-seed-scripts`) is now a
+#     release-managed resource (no before-hook-creation hook) so it can't
+#     vanish out from under the CronJob either; it is applied in the main
+#     install/upgrade phase, before any hook OR CronJob Pod starts.
+#   - The one-shot admin-SEED Job + its SA/Role/RoleBinding REMAIN Helm hooks
+#     (correct — they are genuinely one-shot post-install/post-upgrade work).
+#   Regression guard: tests/admin-promote-rbac-render.sh.
+#
 # 1.4.109 (#3858, 2026-06-19): stop the seed/promote Jobs masquerading as
 # newapi Service endpoints → kill the intermittent "upstream connect error
 # 111" on newapi.<fqdn>.
@@ -814,7 +851,7 @@ name: bp-newapi
 # the host's redirectUris in the shared sovereign realm -> kills the live
 # "Invalid parameter: redirect_uri" SSO regression on newapi.<sovereign-fqdn>.
 # Lockstep: both slot pins + blueprint → 1.4.122.
-version: 1.4.125
+version: 1.4.126
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/admin-sso-seed-job.yaml
+++ b/platform/newapi/chart/templates/admin-sso-seed-job.yaml
@@ -208,12 +208,115 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 {{- /*
+#4278 (2026-06-25) — DEDICATED, NON-HOOK ServiceAccount + Role + RoleBinding
+for the per-minute admin-promote CronJob, RELEASE-MANAGED (NOT a Helm hook).
+
+ROOT CAUSE measured live (omantel.biz demo Org `org-7283eb4a-…`, chart 1.4.125):
+the admin-promote CronJob fired every minute but its Pods were
+`forbidden: error looking up service account …/bp-newapi-admin-seed:
+serviceaccount "bp-newapi-admin-seed" not found` → every spawned Job
+DeadlineExceeded → the Helm post-install hook never completed →
+`bp-newapi` HR stuck `context deadline exceeded` (release wedged at v1,
+install-failed) even though the newapi data plane was 3/3 Running.
+
+WHY the SA vanished while the CronJob persisted: the CronJob borrowed the
+admin-SEED Job's ServiceAccount (`{{ $jobName }}`), which is a Helm HOOK
+resource (`post-install,post-upgrade` + `hook-delete-policy:
+before-hook-creation`). A long-lived per-minute CronJob is NOT a one-shot
+hook — but it had been annotated as one (no hook-weight ⇒ weight 0 ⇒ created
+FIRST, before its weight-8 SA). When the install's hook phase timed out,
+Helm's `before-hook-creation` cleanup deleted the hook-scoped
+SA/Role/RoleBinding/ConfigMap, yet the CronJob — already spawning child Jobs
+— was left orphaned, firing forever against a ServiceAccount that no longer
+existed. This is the canonical "long-lived CronJob must not be a Helm hook"
+defect: every other long-lived CronJob in this repo (openbao
+snapshot-replication, self-sovereign-cutover mirror-resync, syft-grype, flux
+stuck-HR-recovery) is a plain release-managed resource with its OWN
+release-managed RBAC — bp-newapi was the odd one out.
+
+FIX: give the CronJob a dedicated SA/Role/RoleBinding that are ordinary
+release resources (no hook annotations) so they are ALWAYS present for the
+long-lived CronJob and Flux reconciles them in lockstep with it — fully
+decoupled from the one-shot seed Job's hook lifecycle. The promote path only
+needs to READ the CNPG `-app` Secret and run promote.sh's reload (get+patch
+the NewAPI Deployment), so this Role mirrors the seed Role's verbs exactly
+(minus the OIDC secret, which promote.sh never reads). The SA/Role/RoleBinding
+kinds are NOT gated by the kyverno `flux-managed` Enforce policy (it matches
+only Deployment/StatefulSet/DaemonSet/Job/CronJob/Service/Ingress), so they
+carry the normal `bp-newapi.labels`. The CronJob itself DOES need
+`managed-by: flux` (hookLabels) to clear that gate — see its block below.
+*/ -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $cronName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-newapi.labels" . | nindent 4 }}
+    catalyst.openova.io/component: admin-promote
+  {{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $cronName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-newapi.labels" . | nindent 4 }}
+    catalyst.openova.io/component: admin-promote
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      - {{ $cnpgSecretName | quote }}
+    verbs: ["get"]
+  # promote.sh runs reload_newapi_provider → get+patch EXACTLY the NewAPI
+  # Deployment (idempotent, hash-gated rollout-restart). Same scope as the
+  # seed Role's deployment rule.
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    resourceNames:
+      - {{ $deployName | quote }}
+    verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $cronName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-newapi.labels" . | nindent 4 }}
+    catalyst.openova.io/component: admin-promote
+subjects:
+  - kind: ServiceAccount
+    name: {{ $cronName }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ $cronName }}
+  apiGroup: rbac.authorization.k8s.io
+---
+{{- /*
 The SQL is identical for the one-shot seed Job and the periodic promote
 CronJob's catch-up, so it lives in one ConfigMap mounted into both. Two
 scripts: seed.sh (full init, Job) + promote.sh (promote-only, CronJob).
 The CNPG <cluster>-app Secret (basic-auth) carries host/port/dbname/user/
 password; we read them from a mounted Secret volume rather than env so the
 plaintext never lands in the Pod manifest.
+
+#4278 (2026-06-25) — this scripts ConfigMap is now a RELEASE-MANAGED resource
+(no Helm-hook annotations), NOT a `before-hook-creation` hook. It is mounted
+by BOTH the one-shot seed Job (a hook) AND the long-lived admin-promote
+CronJob (now also non-hook). A `before-hook-creation` ConfigMap would be
+deleted-then-recreated on every reconcile and, like the SA, vanish out from
+under the orphaned CronJob — leaving promote Pods unable to mount /scripts.
+As a plain release resource it is applied (and updated in place) during the
+main install/upgrade phase, so it always exists before any post-install hook
+Pod OR CronJob Pod starts. ConfigMap is not gated by the kyverno
+`flux-managed` policy, so `bp-newapi.labels` is sufficient.
 */ -}}
 apiVersion: v1
 kind: ConfigMap
@@ -223,10 +326,6 @@ metadata:
   labels:
     {{- include "bp-newapi.labels" . | nindent 4 }}
     catalyst.openova.io/component: admin-seed
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "8"
-    "helm.sh/hook-delete-policy": before-hook-creation
 data:
   common.sh: |
     # Shared: build PSQL from the mounted CNPG -app Secret + wait for tables.
@@ -676,7 +775,19 @@ spec:
             catalyst.openova.io/component: admin-promote
         spec:
           restartPolicy: OnFailure
-          serviceAccountName: {{ $jobName }}
+          # #4278 (2026-06-25) — bind to the CronJob's OWN dedicated,
+          # release-managed ServiceAccount ($cronName), NOT the one-shot seed
+          # Job's HOOK SA ($jobName). The seed SA is a `before-hook-creation`
+          # Helm hook resource; when an install/upgrade hook phase fails or
+          # times out, Helm deletes it, but this long-lived (regular-resource)
+          # CronJob survives and then fires forever against a now-missing SA
+          # → every spawned Job is `forbidden: serviceaccount …admin-seed not
+          # found` → DeadlineExceeded → the Helm post-install hook never
+          # completes → bp-newapi HR wedged "context deadline exceeded"
+          # (measured live omantel.biz demo Org 2026-06-24). The dedicated
+          # $cronName SA/Role/RoleBinding are release-managed, so they always
+          # exist for the CronJob's lifetime.
+          serviceAccountName: {{ $cronName }}
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets:
             {{- toYaml . | nindent 12 }}

--- a/platform/newapi/chart/tests/admin-promote-rbac-render.sh
+++ b/platform/newapi/chart/tests/admin-promote-rbac-render.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# bp-newapi — admin-promote CronJob RBAC render audit (issue #4278).
+#
+# REGRESSION GUARD for the live defect measured on omantel.biz demo Org
+# `org-7283eb4a-…` (chart 1.4.125): the per-minute admin-promote CronJob
+# referenced the one-shot admin-SEED Job's Helm-HOOK ServiceAccount
+# (`bp-newapi-admin-seed`). On a failed/timed-out install the hook phase
+# deleted that hook-scoped SA, but the long-lived (regular-resource)
+# CronJob survived and fired forever against a now-missing SA →
+#   pods "...-..." is forbidden: error looking up service account
+#   .../bp-newapi-admin-seed: serviceaccount "bp-newapi-admin-seed" not found
+# → every spawned Job DeadlineExceeded → the Helm post-install hook never
+# completed → bp-newapi HR wedged "context deadline exceeded".
+#
+# FIX (#4278): the admin-promote CronJob now has its OWN dedicated,
+# RELEASE-MANAGED ServiceAccount + Role + RoleBinding (`bp-newapi-admin-promote`,
+# no Helm-hook annotations), and the shared scripts ConfigMap is also
+# release-managed (not a `before-hook-creation` hook). This test asserts:
+#
+#   1. A `bp-newapi-admin-promote` ServiceAccount renders WITHOUT any
+#      helm.sh/hook annotation (release-managed, never deleted by hook cleanup).
+#   2. A matching Role + RoleBinding (`bp-newapi-admin-promote`) render,
+#      release-managed, and the RoleBinding binds the SA to that Role.
+#   3. The CronJob's pod-template `serviceAccountName` is `bp-newapi-admin-promote`
+#      (its own SA) — NOT `bp-newapi-admin-seed` (the hook SA).
+#   4. The scripts ConfigMap `bp-newapi-admin-seed-scripts` is release-managed
+#      (carries NO helm.sh/hook annotation) so it cannot vanish out from under
+#      the orphaned CronJob.
+#   5. The one-shot admin-seed Job + its SA REMAIN Helm hooks (correct —
+#      they are genuinely one-shot post-install/post-upgrade work).
+
+set -euo pipefail
+
+# CI invokes `bash <script> <chart_dir>`; fall back to the script's parent.
+chart_dir="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+helm="${HELM_BIN:-helm}"
+
+# Build chart deps once so `helm template` does not error on the `common`
+# library subchart reference.
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+# Values that flip the admin-seed render gate to TRUE:
+#   and $seedEnabled .Values.newapi.enabled (keycloak adminUI) .Values.cnpg.enabled .Values.sovereignFQDN
+# The chart defaults already set newapi/cnpg enabled + keycloak mode + sso
+# bootstrap; we only need a sovereignFQDN to satisfy the final gate term.
+#
+# Release name `bp-newapi`: bp-newapi.fullname collapses to `bp-newapi`
+# (the release name already contains the chart name), so the rendered
+# object names match the live per-Org names asserted below
+# (`bp-newapi-admin-promote`, `bp-newapi-admin-seed`).
+out=$("$helm" template bp-newapi "$chart_dir" \
+  --set sovereignFQDN=t99.omani.works \
+  --namespace org-test \
+  --show-only templates/admin-sso-seed-job.yaml 2>&1)
+
+if [ -z "$out" ]; then
+  echo "FAIL: admin-sso-seed-job.yaml rendered EMPTY — render gate not satisfied"
+  echo "$out"
+  exit 1
+fi
+
+# Split the multi-doc render into per-document files, then locate the doc
+# for a given kind+name. Several objects share a kind (ServiceAccount,
+# Role, RoleBinding), so we key on BOTH kind and name to assert hook-vs-
+# release on the RIGHT object.
+tmpd=$(mktemp -d)
+trap 'rm -rf "$tmpd"' EXIT
+echo "$out" | awk -v d="$tmpd" '
+  BEGIN { n=0 }
+  /^---$/ { n++; next }
+  { print >> (d "/doc-" n ".yaml") }
+'
+
+find_doc() {  # find_doc <kind> <name> → prints path of the matching doc
+  local want_kind="$1" want_name="$2" f
+  for f in "$tmpd"/doc-*.yaml; do
+    [ -f "$f" ] || continue
+    if grep -qx "kind: $want_kind" "$f" && grep -qx "  name: $want_name" "$f"; then
+      echo "$f"; return 0
+    fi
+  done
+  return 1
+}
+
+assert_no_hook() {  # assert_no_hook <file> <human-label>
+  if grep -q 'helm.sh/hook"' "$1" || grep -q '"helm.sh/hook":' "$1"; then
+    echo "FAIL: $2 carries a helm.sh/hook annotation — must be RELEASE-managed (#4278)"
+    sed -n '1,25p' "$1"
+    exit 1
+  fi
+}
+
+assert_has_hook() {  # assert_has_hook <file> <human-label>
+  if ! grep -q 'helm.sh/hook' "$1"; then
+    echo "FAIL: $2 is missing its helm.sh/hook annotation — one-shot seed must stay a hook (#4278)"
+    sed -n '1,25p' "$1"
+    exit 1
+  fi
+}
+
+# ── Case 1: admin-promote ServiceAccount renders, release-managed ──────
+echo "[bp-newapi] Case 1: admin-promote ServiceAccount — release-managed, no hook"
+sa_doc=$(find_doc ServiceAccount bp-newapi-admin-promote) || {
+  echo "FAIL: ServiceAccount/bp-newapi-admin-promote did not render"
+  exit 1
+}
+assert_no_hook "$sa_doc" "ServiceAccount/bp-newapi-admin-promote"
+echo "[bp-newapi] Case 1: PASS"
+
+# ── Case 2: admin-promote Role + RoleBinding render, bound correctly ───
+echo "[bp-newapi] Case 2: admin-promote Role + RoleBinding — release-managed, bound to its SA"
+role_doc=$(find_doc Role bp-newapi-admin-promote) || {
+  echo "FAIL: Role/bp-newapi-admin-promote did not render"
+  exit 1
+}
+assert_no_hook "$role_doc" "Role/bp-newapi-admin-promote"
+
+rb_doc=$(find_doc RoleBinding bp-newapi-admin-promote) || {
+  echo "FAIL: RoleBinding/bp-newapi-admin-promote did not render"
+  exit 1
+}
+assert_no_hook "$rb_doc" "RoleBinding/bp-newapi-admin-promote"
+# RoleBinding subject SA + roleRef both point at bp-newapi-admin-promote.
+if ! grep -q 'name: bp-newapi-admin-promote' "$rb_doc"; then
+  echo "FAIL: RoleBinding/bp-newapi-admin-promote does not reference SA/Role bp-newapi-admin-promote"
+  cat "$rb_doc"
+  exit 1
+fi
+echo "[bp-newapi] Case 2: PASS"
+
+# ── Case 3: CronJob pod serviceAccountName == its OWN SA, not the hook SA ─
+echo "[bp-newapi] Case 3: admin-promote CronJob serviceAccountName == bp-newapi-admin-promote"
+cron_doc=$(find_doc CronJob bp-newapi-admin-promote) || {
+  echo "FAIL: CronJob/bp-newapi-admin-promote did not render"
+  exit 1
+}
+if ! grep -q 'serviceAccountName: bp-newapi-admin-promote' "$cron_doc"; then
+  echo "FAIL: CronJob does not use serviceAccountName: bp-newapi-admin-promote"
+  grep -n 'serviceAccountName' "$cron_doc" || true
+  exit 1
+fi
+if grep -q 'serviceAccountName: bp-newapi-admin-seed' "$cron_doc"; then
+  echo "FAIL: CronJob still binds the HOOK SA bp-newapi-admin-seed (#4278 regression)"
+  exit 1
+fi
+echo "[bp-newapi] Case 3: PASS"
+
+# ── Case 4: shared scripts ConfigMap is release-managed (no hook) ──────
+echo "[bp-newapi] Case 4: scripts ConfigMap — release-managed, no hook"
+cm_doc=$(find_doc ConfigMap bp-newapi-admin-seed-scripts) || {
+  echo "FAIL: ConfigMap/bp-newapi-admin-seed-scripts did not render"
+  exit 1
+}
+assert_no_hook "$cm_doc" "ConfigMap/bp-newapi-admin-seed-scripts"
+echo "[bp-newapi] Case 4: PASS"
+
+# ── Case 5: one-shot admin-seed Job + SA REMAIN Helm hooks ─────────────
+echo "[bp-newapi] Case 5: admin-seed Job + SA remain Helm hooks (one-shot)"
+seed_sa_doc=$(find_doc ServiceAccount bp-newapi-admin-seed) || {
+  echo "FAIL: ServiceAccount/bp-newapi-admin-seed did not render"
+  exit 1
+}
+assert_has_hook "$seed_sa_doc" "ServiceAccount/bp-newapi-admin-seed"
+
+seed_job_doc=$(find_doc Job bp-newapi-admin-seed) || {
+  echo "FAIL: Job/bp-newapi-admin-seed did not render"
+  exit 1
+}
+assert_has_hook "$seed_job_doc" "Job/bp-newapi-admin-seed"
+# The seed Job correctly still binds its own hook SA.
+if ! grep -q 'serviceAccountName: bp-newapi-admin-seed' "$seed_job_doc"; then
+  echo "FAIL: seed Job does not bind serviceAccountName: bp-newapi-admin-seed"
+  exit 1
+fi
+echo "[bp-newapi] Case 5: PASS"
+
+echo "[bp-newapi] All admin-promote RBAC render cases PASS"


### PR DESCRIPTION
## Refs #4278

### Real loop root cause (live evidence)
On the omantel.biz demo Org (`org-7283eb4a-19e5-4e86-9066-d4aa26762064`, chart **1.4.125**), the per-minute `bp-newapi-admin-promote` CronJob fired forever and every spawned Job failed:

```
Error creating: pods "bp-newapi-admin-promote-29705455-" is forbidden:
error looking up service account org-7283eb4a-.../bp-newapi-admin-seed:
serviceaccount "bp-newapi-admin-seed" not found
→ Job was active longer than specified deadline (DeadlineExceeded)
```

HR condition:
```
Helm install failed for release …/bp-newapi with chart bp-newapi@1.4.125:
context deadline exceeded
```

Confirmed live (read-only): the namespace had the CronJob + its failing child Jobs, but **no** `bp-newapi-admin-seed` ServiceAccount / Role / RoleBinding / scripts ConfigMap, and the Helm release was stuck at `sh.helm.release.v1.bp-newapi.v1` (install-failed). The newapi data plane was **3/3 Running** — this is purely a hook/RBAC defect.

**Why the SA vanished while the CronJob persisted:** the admin-promote CronJob is a *regular, release-managed* resource, but it set `serviceAccountName` to the **one-shot admin-SEED Job's Helm-HOOK ServiceAccount** (`bp-newapi-admin-seed`, annotated `post-install,post-upgrade` + `hook-delete-policy: before-hook-creation`). When the install/upgrade hook phase failed or timed out, Helm's `before-hook-creation` cleanup deleted that hook-scoped SA (+ Role + RoleBinding + scripts ConfigMap), but the long-lived CronJob survived and kept firing against an SA that no longer existed → DeadlineExceeded loop → the Helm post-install hook never completed → HR wedged `context deadline exceeded`.

This is the canonical *"a long-lived CronJob must not depend on Helm-hook lifecycle resources"* defect. Every other long-lived CronJob in this repo (openbao `snapshot-replication`, `self-sovereign-cutover` mirror-resync, `syft-grype`, flux stuck-HR-recovery) uses its **own release-managed RBAC** — bp-newapi was the odd one out.

### The chart change (`platform/newapi/chart/templates/admin-sso-seed-job.yaml`)
- **Dedicated, release-managed `ServiceAccount` + `Role` + `RoleBinding`** named `bp-newapi-admin-promote` for the CronJob (no Helm-hook annotations), with exactly the verbs `promote.sh` needs: `get` on the CNPG `-app` Secret + `get,patch` on the NewAPI Deployment (the hash-gated reload). The CronJob now binds **its own** SA, never the hook seed SA.
- **Shared scripts ConfigMap** (`bp-newapi-admin-seed-scripts`) converted from a `before-hook-creation` hook to a **release-managed** resource, so it likewise can't be deleted out from under the orphaned CronJob; it is applied in the main install/upgrade phase, before any hook OR CronJob Pod starts.
- The **one-shot admin-SEED Job + its SA/Role/RoleBinding remain Helm hooks** (correct — genuinely one-shot post-install/post-upgrade work). The CronJob carries `managed-by: flux` (hookLabels) to clear the kyverno `flux-managed` Enforce gate; the SA/Role/RoleBinding/ConfigMap kinds are not gated by that policy, so they use the normal labels.

### Version bump + pin
- Chart **1.4.125 → 1.4.126** (monotonic). bp-newapi is a per-Org catalog Blueprint installed via the Org funnel / bootstrap-kit slot 80; the live HR pin is resolved by the private gitops + deploy-bot to the latest published chart, so there is no in-(public)-repo slot-pin file to bump in lockstep — publishing 1.4.126 makes the fix available.

### Verification
- `helm template` renders clean (default + seed-gate-ON). The CronJob's `serviceAccountName: bp-newapi-admin-promote` matches a rendered SA + RoleBinding.
- New regression guard `tests/admin-promote-rbac-render.sh` (5 cases): promote SA/Role/RoleBinding are release-managed and bound; CronJob binds its own SA (not the hook seed SA); scripts ConfigMap is release-managed; seed Job + SA remain hooks. **All green.**
- All 4 pre-existing newapi chart tests still pass.
- `helm lint` emits a **pre-existing** false-positive ("invalid Yaml document separator") that occurs on the unmodified file too (a known `{{- /* */ -}}` chomp quirk); `helm template` — the authoritative render the CI uses — is clean.

Live cluster touched **read-only** only; nothing applied/rolled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)