### PR TITLE
fix(bootstrap-ui): light up the Phase-1 bootstrap-kit timeline that fills the ~30-min provisioning void (Refs #3914)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/shared/lib/useProvisioningStream.test.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/lib/useProvisioningStream.test.ts
@@ -1,0 +1,170 @@
+/**
+ * useProvisioningStream.test.ts — lock-in for issue #3914.
+ *
+ * The regression this guards: the JobsPage "Bootstrapping cluster" timeline
+ * was wired (PR #4221) but `applyEvent` keyed purely on `ev.phase`. The
+ * catalyst-api emits every Phase-1 (bootstrap-kit) transition as
+ * `phase: "component"` with the REAL component id in `ev.component`
+ * (`cilium`, `cert-manager`, … via ComponentIDFromHelmRelease) plus an
+ * `ev.state` (`pending|installing|installed|degraded|failed`). The old hook
+ * never read `component`/`state`, so all 11 components collapsed into the
+ * `tofu-apply` fallback bucket — the bootstrap-kit rows (the ACTUAL ~30-min
+ * void) stayed grey/pending forever.
+ *
+ * These tests drive the pure `applyEvent` reducer with the exact wire shape
+ * the backend serialises (see provisioner.Event +
+ * helmwatch.PhaseComponent) and assert each component's BootstrapPhase row
+ * lights up independently.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  applyEvent,
+  emptyPhaseMap,
+  resolvePhaseId,
+  type ProvisioningEvent,
+} from './useProvisioningStream'
+
+function ev(partial: Partial<ProvisioningEvent>): ProvisioningEvent {
+  return {
+    time: '2026-06-25T00:00:00Z',
+    phase: 'component',
+    level: 'info',
+    message: '',
+    ...partial,
+  }
+}
+
+describe('resolvePhaseId — Phase-1 events route by component id (#3914)', () => {
+  it('maps phase:"component" to the component id, not the literal "component"', () => {
+    expect(resolvePhaseId(ev({ phase: 'component', component: 'cilium' }))).toBe('cilium')
+  })
+
+  it('aliases the umbrella component id to its bootstrap-kit phase id', () => {
+    // ComponentIDFromHelmRelease("bp-catalyst-platform") → "catalyst-platform",
+    // but the BootstrapPhase.id is "bp-catalyst-platform".
+    expect(resolvePhaseId(ev({ phase: 'component', component: 'catalyst-platform' }))).toBe(
+      'bp-catalyst-platform',
+    )
+  })
+
+  it('passes Phase-0 OpenTofu phase ids through unchanged', () => {
+    expect(resolvePhaseId(ev({ phase: 'tofu-apply', component: undefined }))).toBe('tofu-apply')
+  })
+
+  it('routes component-log lines by component id too', () => {
+    expect(resolvePhaseId(ev({ phase: 'component-log', component: 'keycloak' }))).toBe('keycloak')
+  })
+})
+
+describe('applyEvent — bootstrap-kit rows light up independently (#3914)', () => {
+  it('flips the matching bootstrap-kit phase to running on installing, not tofu-apply', () => {
+    let m = emptyPhaseMap()
+    m = applyEvent(m, ev({ phase: 'component', component: 'cilium', state: 'installing' }))
+    expect(m['cilium']!.status).toBe('running')
+    // The regression symptom: cilium's event must NOT have landed on tofu-apply.
+    expect(m['tofu-apply']!.status).toBe('pending')
+    // Sibling components stay pending.
+    expect(m['cert-manager']!.status).toBe('pending')
+    expect(m['bp-catalyst-platform']!.status).toBe('pending')
+  })
+
+  it('flips a component to done on state:"installed"', () => {
+    let m = emptyPhaseMap()
+    m = applyEvent(m, ev({ phase: 'component', component: 'cert-manager', state: 'installing' }))
+    expect(m['cert-manager']!.status).toBe('running')
+    m = applyEvent(m, ev({ phase: 'component', component: 'cert-manager', state: 'installed' }))
+    expect(m['cert-manager']!.status).toBe('done')
+    expect(m['cert-manager']!.endedAt).toBe('2026-06-25T00:00:00Z')
+  })
+
+  it('flips a component to failed on state:"failed" or "degraded"', () => {
+    let m = emptyPhaseMap()
+    m = applyEvent(m, ev({ phase: 'component', component: 'openbao', state: 'failed' }))
+    expect(m['openbao']!.status).toBe('failed')
+
+    let n = emptyPhaseMap()
+    n = applyEvent(n, ev({ phase: 'component', component: 'keycloak', state: 'degraded' }))
+    expect(n['keycloak']!.status).toBe('failed')
+  })
+
+  it('drives the umbrella row via its catalyst-platform component id', () => {
+    let m = emptyPhaseMap()
+    m = applyEvent(
+      m,
+      ev({ phase: 'component', component: 'catalyst-platform', state: 'installing' }),
+    )
+    expect(m['bp-catalyst-platform']!.status).toBe('running')
+    m = applyEvent(
+      m,
+      ev({ phase: 'component', component: 'catalyst-platform', state: 'installed' }),
+    )
+    expect(m['bp-catalyst-platform']!.status).toBe('done')
+  })
+
+  it('a component-log line keeps a running component running + updates the tail', () => {
+    let m = emptyPhaseMap()
+    m = applyEvent(m, ev({ phase: 'component', component: 'cilium', state: 'installing' }))
+    m = applyEvent(
+      m,
+      ev({ phase: 'component-log', component: 'cilium', message: 'cilium pod pulling image' }),
+    )
+    expect(m['cilium']!.status).toBe('running')
+    expect(m['cilium']!.lastEvent?.message).toBe('cilium pod pulling image')
+  })
+
+  it('a trailing component-log line does NOT revive a finished component', () => {
+    let m = emptyPhaseMap()
+    m = applyEvent(m, ev({ phase: 'component', component: 'flux', state: 'installed' }))
+    expect(m['flux']!.status).toBe('done')
+    m = applyEvent(
+      m,
+      ev({ phase: 'component-log', component: 'flux', message: 'late log line' }),
+    )
+    // Sticky: still done, not flipped back to running.
+    expect(m['flux']!.status).toBe('done')
+  })
+
+  it('the backend CAN re-flip a failed HR back through installing→installed', () => {
+    // helm-controller re-pin path: failed → installing → installed.
+    let m = emptyPhaseMap()
+    m = applyEvent(m, ev({ phase: 'component', component: 'gitea', state: 'failed' }))
+    expect(m['gitea']!.status).toBe('failed')
+    m = applyEvent(m, ev({ phase: 'component', component: 'gitea', state: 'installing' }))
+    expect(m['gitea']!.status).toBe('running')
+    m = applyEvent(m, ev({ phase: 'component', component: 'gitea', state: 'installed' }))
+    expect(m['gitea']!.status).toBe('done')
+  })
+
+  it('Phase-0 OpenTofu events still drive their own rows (no regression)', () => {
+    let m = emptyPhaseMap()
+    m = applyEvent(m, ev({ phase: 'tofu-init', level: 'info', component: undefined, state: undefined }))
+    expect(m['tofu-init']!.status).toBe('running')
+    m = applyEvent(m, ev({ phase: 'tofu-apply', level: 'info', component: undefined, state: undefined }))
+    // Phase boundary inference closes the earlier running tofu phase.
+    expect(m['tofu-init']!.status).toBe('done')
+    expect(m['tofu-apply']!.status).toBe('running')
+    // A level:error on a Phase-0 event still fails that phase.
+    m = applyEvent(m, ev({ phase: 'tofu-apply', level: 'error', message: 'boom' }))
+    expect(m['tofu-apply']!.status).toBe('failed')
+  })
+
+  it('a full Phase-1 sweep converges every bootstrap-kit row to done', () => {
+    const KIT = [
+      'cilium', 'cert-manager', 'flux', 'crossplane', 'sealed-secrets',
+      'spire', 'jetstream', 'openbao', 'keycloak', 'gitea',
+    ]
+    let m = emptyPhaseMap()
+    for (const c of KIT) {
+      m = applyEvent(m, ev({ phase: 'component', component: c, state: 'installing' }))
+    }
+    for (const c of KIT) {
+      m = applyEvent(m, ev({ phase: 'component', component: c, state: 'installed' }))
+    }
+    m = applyEvent(m, ev({ phase: 'component', component: 'catalyst-platform', state: 'installed' }))
+    for (const c of KIT) {
+      expect(m[c]!.status).toBe('done')
+    }
+    expect(m['bp-catalyst-platform']!.status).toBe('done')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/shared/lib/useProvisioningStream.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/lib/useProvisioningStream.ts
@@ -7,7 +7,14 @@
  *   POST /api/v1/deployments  → { id, status, streamURL: "/api/v1/deployments/<id>/logs" }
  *   GET  <streamURL>          → SSE stream emitting one of:
  *
- *     data: {"time":"...", "phase":"<id>", "level":"info|warn|error", "message":"..."}\n\n
+ *     // Phase-0 (OpenTofu) — `phase` is the BootstrapPhase.id directly:
+ *     data: {"time":"...", "phase":"tofu-apply", "level":"info|warn|error", "message":"..."}\n\n
+ *
+ *     // Phase-1 (bootstrap-kit) — `phase` is the constant "component"; the
+ *     // real id is in `component` and the lifecycle in `state`:
+ *     data: {"time":"...", "phase":"component", "component":"cilium",
+ *            "state":"pending|installing|installed|degraded|failed",
+ *            "level":"info|warn|error", "message":"... N/Y HRs ready ..."}\n\n
  *
  *     event: done
  *     data: { ...full Deployment.State() snapshot... }\n\n
@@ -35,12 +42,83 @@ export type EventLevel = 'info' | 'warn' | 'error'
 export interface ProvisioningEvent {
   /** RFC3339 UTC timestamp the backend emitted at. */
   time: string
-  /** Phase id — see shared/constants/bootstrap-phases.ts ALL_PHASES. */
+  /**
+   * Phase id. For Phase-0 (OpenTofu) events this is a `BootstrapPhase.id`
+   * from shared/constants/bootstrap-phases.ts (`tofu-init`, `tofu-apply`,
+   * `flux-bootstrap`, …). For Phase-1 (bootstrap-kit) events the backend
+   * sends the constant `"component"` (or `"component-log"`) here and carries
+   * the real per-component id in the `component` field below — see
+   * helmwatch.PhaseComponent + provisioner.Event in the catalyst-api.
+   */
   phase: string
   /** Severity. `error` flips that phase's status to `failed`. */
   level: EventLevel
   /** Free-form log line from the underlying tofu/Flux source. */
   message: string
+  /**
+   * Normalised component id for Phase-1 `phase:"component"` events
+   * (`"bp-cilium"` → `"cilium"` via helmwatch.ComponentIDFromHelmRelease).
+   * Empty for Phase-0 OpenTofu events. This — NOT `phase` — is what maps to
+   * a bootstrap-kit `BootstrapPhase.id`.
+   */
+  component?: string
+  /**
+   * Per-component lifecycle for `phase:"component"` events, one of
+   * `pending|installing|installed|degraded|failed`. Empty for Phase-0 events
+   * and for `phase:"component-log"` events (which carry an ordinary log
+   * line, not a state transition). Drives the bootstrap-kit row's status.
+   */
+  state?: string
+}
+
+/**
+ * The backend's Phase-1 events arrive with phase="component" and the real
+ * id in the `component` field. A handful of component ids don't match their
+ * BootstrapPhase.id 1:1 — chiefly the umbrella, whose HR is
+ * `bp-catalyst-platform` → ComponentIDFromHelmRelease strips only the
+ * `bp-` prefix → `catalyst-platform`, while the phase id retains the
+ * `bp-catalyst-platform` form. Map those aliases here; everything else
+ * (cilium, cert-manager, flux, crossplane, sealed-secrets, spire,
+ * jetstream, openbao, keycloak, gitea) is identity.
+ */
+const COMPONENT_ID_TO_PHASE_ID: Record<string, string> = {
+  'catalyst-platform': 'bp-catalyst-platform',
+}
+
+/**
+ * Resolve the bootstrap-kit phase id an event belongs to. For Phase-1
+ * `phase:"component"` / `phase:"component-log"` events this reads the
+ * `component` field (with the alias map applied); for Phase-0 events it
+ * returns the `phase` field unchanged.
+ */
+export function resolvePhaseId(ev: ProvisioningEvent): string {
+  if ((ev.phase === 'component' || ev.phase === 'component-log') && ev.component) {
+    const cid = ev.component
+    return COMPONENT_ID_TO_PHASE_ID[cid] ?? cid
+  }
+  return ev.phase
+}
+
+/**
+ * Translate the backend's per-component lifecycle (`ev.state`) into the
+ * widget's PhaseStatus. `installed` → done, `installing`/`pending` →
+ * running, `failed`/`degraded` → failed. A missing/unknown state (or a
+ * `component-log` line, which carries no state) returns null so the caller
+ * falls back to the generic level-based status derivation.
+ */
+function statusFromComponentState(state: string | undefined): PhaseStatus | null {
+  switch (state) {
+    case 'installed':
+      return 'done'
+    case 'installing':
+    case 'pending':
+      return 'running'
+    case 'failed':
+    case 'degraded':
+      return 'failed'
+    default:
+      return null
+  }
 }
 
 /** Snapshot the backend emits in the `done` event — Deployment.State(). */
@@ -101,8 +179,9 @@ export interface ProvisioningStreamState {
 
 /**
  * Initial per-phase state: every phase starts pending with no events.
+ * Exported for unit tests that drive applyEvent directly.
  */
-function emptyPhaseMap(): Record<string, PhaseState> {
+export function emptyPhaseMap(): Record<string, PhaseState> {
   const out: Record<string, PhaseState> = {}
   for (const p of ALL_PHASES) {
     out[p.id] = {
@@ -129,16 +208,23 @@ function emptyPhaseMap(): Record<string, PhaseState> {
  *   place in ALL_PHASES) flips to `done` — backend doesn't emit per-phase
  *   completion events, so we infer it from "phase boundary crossed".
  */
-function applyEvent(
+export function applyEvent(
   phases: Record<string, PhaseState>,
   ev: ProvisioningEvent,
 ): Record<string, PhaseState> {
-  const known = findPhase(ev.phase)
-  // Unknown phase id (e.g. "tofu" generic stdout from streamLines) — record
-  // it on whichever opentofu/* phase is currently running, so the user still
-  // sees the line. Fall through to the active running phase.
+  // Phase-1 events carry the real id in `component`; Phase-0 events use
+  // `phase` directly. resolvePhaseId hides that asymmetry (#3914 — without
+  // it every bootstrap-kit component collapsed into the tofu-apply fallback
+  // and the 11-row Phase-1 timeline — the actual ~30-min void — never lit
+  // up).
+  const resolvedId = resolvePhaseId(ev)
+  const known = findPhase(resolvedId)
+  // Unknown phase id (e.g. a generic "tofu" stdout line from streamLines, or
+  // a component-log line whose component is somehow off-map) — record it on
+  // whichever phase is currently running so the user still sees the line.
+  // Fall through to the active running phase, else tofu-apply.
   const targetId = known
-    ? ev.phase
+    ? resolvedId
     : (Object.keys(phases).find((id) => phases[id]!.status === 'running') ??
        'tofu-apply')
 
@@ -149,7 +235,11 @@ function applyEvent(
   const wasPending = target.status === 'pending'
 
   // If a NEW phase starts running, mark all earlier-in-order phases that
-  // are still `running` as `done` — phase boundary inference.
+  // are still `running` as `done` — phase boundary inference. Flux installs
+  // several bootstrap-kit HRs in parallel, but the backend still emits an
+  // explicit `installed` state per component, so this only fills the gap for
+  // phases the stream never closes explicitly (chiefly the Phase-0→Phase-1
+  // hand-off).
   if (wasPending) {
     const targetIdx = ALL_PHASES.findIndex((p) => p.id === targetId)
     for (let i = 0; i < targetIdx; i++) {
@@ -161,10 +251,27 @@ function applyEvent(
     }
   }
 
+  // Status precedence:
+  //   1. An explicit per-component lifecycle (`ev.state`, Phase-1) is the
+  //      authoritative signal — `installed`→done, `installing`/`pending`→
+  //      running, `failed`/`degraded`→failed. It overrides everything,
+  //      including a prior terminal status, because the backend genuinely
+  //      re-flips an HR (failed → installing → installed on a chart re-pin).
+  //   2. Otherwise (no state — e.g. a `component-log` line, or a generic
+  //      stdout line) a terminal status is sticky: a trailing log tail must
+  //      NOT revive a phase the stream already marked done/failed.
+  //   3. Otherwise level=error → failed.
+  //   4. Default → running (a log line on an in-flight phase).
+  const fromState = statusFromComponentState(ev.state)
   const newStatus: PhaseStatus =
-    ev.level === 'error' ? 'failed'
-    : target.status === 'failed' ? 'failed'   // sticky once failed
+    fromState !== null ? fromState
+    : target.status === 'done' || target.status === 'failed' ? target.status // sticky
+    : ev.level === 'error' ? 'failed'
     : 'running'
+
+  // A done/failed component freezes endedAt; running/pending leaves it open
+  // so the live duration label keeps ticking.
+  const terminal = newStatus === 'done' || newStatus === 'failed'
 
   next[targetId] = {
     ...target,
@@ -172,7 +279,7 @@ function applyEvent(
     lastEvent: ev,
     eventCount: target.eventCount + 1,
     startedAt: target.startedAt ?? ev.time,
-    endedAt: newStatus === 'failed' ? ev.time : target.endedAt,
+    endedAt: terminal ? ev.time : target.endedAt,
   }
   return next
 }
@@ -218,10 +325,15 @@ export function useProvisioningStream(streamURL: string | null): ProvisioningStr
         const data = JSON.parse(msg.data) as ProvisioningEvent
         setEvents((prev) => [...prev, data])
         setPhases((prev) => applyEvent(prev, data))
-        if (data.level === 'error') {
-          setFailedPhase((prev) => prev ?? data.phase)
+        // activePhase / failedPhase must carry the RESOLVED phase id (the
+        // bootstrap-kit component id for Phase-1 events), not the raw
+        // `"component"` constant — BootstrapProgress highlights the row keyed
+        // by this value (#3914).
+        const phaseId = resolvePhaseId(data)
+        if (data.level === 'error' || data.state === 'failed' || data.state === 'degraded') {
+          setFailedPhase((prev) => prev ?? phaseId)
         } else {
-          setActivePhase(data.phase)
+          setActivePhase(phaseId)
         }
       } catch (err) {
         // Malformed JSON — log and continue. We never silently drop events


### PR DESCRIPTION
## Refs #3914

PR #4221 wired the `BootstrapProgress` "Bootstrapping cluster" timeline into `JobsPage` at `/provision/<id>/jobs` — but a read of the data path shows it only animated **Phase-0 (the ~2-min OpenTofu run)**. The entire **Phase-1 bootstrap-kit row set — the 11 components that ARE the ~30-min void this issue is about — stayed grey/pending**, so the operator still watched a static surface during the gap. This PR closes that runtime gap.

## Root cause (orphan was fixed; the data wire was not)

`useProvisioningStream.applyEvent` keyed purely on `ev.phase`. The catalyst-api emits every Phase-1 transition (see `helmwatch.PhaseComponent` + `provisioner.Event`) as:

```json
{"phase":"component","component":"cilium","state":"installing","level":"info","message":"… N/Y HRs ready …"}
```

The real id lives in `ev.component` (`cilium`/`cert-manager`/… normalised by `ComponentIDFromHelmRelease`, `bp-` stripped) and the lifecycle in `ev.state` (`pending|installing|installed|degraded|failed`). Because the literal string `"component"` is not a `BootstrapPhase.id`, **all 11 components fell through to the `tofu-apply` fallback bucket** in `applyEvent` and never reached their own rows. The widget was correct; the hook feeding it was blind to `component`/`state`.

(Note: the sibling Admin-shell reducer `eventReducer` already handled this wire shape correctly — this PR brings the JobsPage timeline path to parity.)

## The fix (pure frontend, existing read endpoints — no new reconciler)

In `shared/lib/useProvisioningStream.ts`:

- **`resolvePhaseId()`** — routes `phase:"component"` / `"component-log"` events by `ev.component`, with a `catalyst-platform → bp-catalyst-platform` alias for the umbrella (whose HR strips only the `bp-` prefix while the phase id keeps the full form). Phase-0 phase ids pass through unchanged.
- **`statusFromComponentState()`** — maps the backend lifecycle to the widget's `PhaseStatus` (`installed → done`, `installing`/`pending → running`, `failed`/`degraded → failed`). Explicit `state` is authoritative, so helm-controller's genuine `failed → installing → installed` re-pin path animates; a trailing `component-log` line is **sticky** and never revives a finished row.
- **`activePhase` / `failedPhase`** now carry the resolved phase id so `BootstrapProgress` highlights the correct component row instead of a phantom `"component"` id.

Data sources used (all pre-existing, per the issue): the catalyst-api SSE log channel `GET /api/v1/deployments/<id>/logs` — the same stream the jobs surface already consumes — which carries the Phase-0 `tofu-*` events, the `flux-bootstrap` hand-off, and the Phase-1 per-component `state` transitions (the in-cluster HelmRelease census the helmwatch snapshot exposes). No backend aggregation endpoint was needed.

## Build / test

- `tsc -b` green · `vite build` green.
- New `useProvisioningStream.test.ts` — **13 cases** driving the exact backend wire shape: per-component routing (not `tofu-apply`), the umbrella alias, `installed → done`, `failed`/`degraded → failed`, sticky terminal vs `component-log` tail, the re-pin path, and a full Phase-1 sweep converging all 11 rows + the umbrella to `done`. Plus the 4 existing `JobsPage.bootstrap-progress` wiring tests still pass → **17/17**.
- Full vitest: **69 failed / 1703 passed** — identical to the documented `origin/main` pre-existing failure set. Verified by stashing this change and re-running the only two files on the touched path (`JobsPage.test.tsx` 2-fail, `ProvisionPage.sse-url.test.tsx` 3-fail) — they fail **identically without** this change (stale-route/`Show-as-Flow` assertions unrelated to #3914). **Zero added failures.**

## Fresh-prov walk (for later — gated on provider capacity, do NOT provision now)

The true end-to-end proof is a live ~30-min prov; capacity-gated right now (Hetzner needs an hcloud token absent on the mothership; Huawei me-east-215 EIP pool held by the permanent NEVER-WIPE omantel.biz). When a slot frees:

1. `POST /sovereign/api/v1/deployments` to start a fresh prov; land on `/provision/<id>/jobs`.
2. Watch the **Phase 0 · OpenTofu** section advance (`tofu-init → … → flux-bootstrap`), then the top bar flip to ~31% as Phase 1 opens.
3. **The new behaviour:** watch the **Phase 1 · Bootstrap kit** rows light up **one-by-one** as Flux reconciles — `cilium` → `cert-manager` → `flux` → `crossplane` → `sealed-secrets` → `spire` → `jetstream` → `openbao` → `keycloak` → `gitea` → `Catalyst Platform`, each flipping pending → running (blue spinner + live log tail showing the `N/Y HRs ready` census) → done (green check). Section count climbs `1/11 … 11/11`.
4. Confirm the bar reaches 100% / `CONVERGED` when `bp-catalyst-platform` goes `installed`, then the timeline hides (in-flight gate closes) and the handover banner takes over.
5. Screenshot the Phase-1 section mid-install (several rows running, several done) as the void-filled evidence; attach to #3914.

`Refs #3914` — not auto-closed; stays `status/uat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)