### PR TITLE
fix(marketplace): gate console redirect on per-Org host readiness via /launching interstitial (Refs #4273)

### DIFF
--- a/core/marketplace/playwright/customer-journey.spec.ts
+++ b/core/marketplace/playwright/customer-journey.spec.ts
@@ -763,4 +763,84 @@ test.describe('marketplace customer-journey (17-step regression gate)', () => {
     expect(finalUrl, 'navigation landed on a /jobs path').toContain('/jobs')
     expect(finalUrl, 'handover token query param present').toMatch(/[?&]token=/)
   })
+
+  // ──────────────────────────────────────────────────────────────────────
+  // #4273 — provisioning interstitial (redirect-before-ready race fix).
+  //
+  // The funnel no longer hard-bounces to the per-Org console host the instant
+  // checkout succeeds (its DNS/TLS/HTTPRoute are still provisioning → the
+  // first click hit NXDOMAIN). It now lands on `/launching` — served from the
+  // marketplace origin, which always resolves — which polls the per-Org
+  // console `/healthz` and only forwards to `/auth/org-handover` once the host
+  // serves a response. These tests are hermetic: the `/healthz` probe is
+  // intercepted so no real per-Org host is needed.
+  // ──────────────────────────────────────────────────────────────────────
+  test('18 launching interstitial shows immediately, then forwards once the per-Org host is ready', async ({ page }) => {
+    const consoleHost = 'https://console.abc.omani.trade'
+    // The per-Org host's /healthz: fail (abort = NXDOMAIN/conn-refused shape)
+    // for the first 2 probes, then resolve — emulating DNS/TLS/route landing.
+    let probes = 0
+    await page.route('**/console.abc.omani.trade/healthz**', (route) => {
+      probes += 1
+      if (probes <= 2) return route.abort('namenotresolved')
+      return route.fulfill({ status: 200, body: 'ok' })
+    })
+    // Stop the real cross-host /auth/org-handover navigation (no live host) —
+    // intercept so the forward lands on an interceptable response and the test
+    // can assert the final URL deterministically.
+    await page.route('**/console.abc.omani.trade/auth/org-handover**', (route) =>
+      route.fulfill({ status: 200, contentType: 'text/html', body: '<html><body>handover-ok</body></html>' }),
+    )
+
+    const params = new URLSearchParams({ host: consoleHost, token: 'mock-session-jwt', next: '/jobs' })
+    await page.goto('/launching?' + params.toString())
+
+    // The branded "Setting up your console…" state must appear immediately —
+    // never a blank page or a raw browser DNS error.
+    await expect(page.getByRole('heading', { name: /Setting up your console/i }))
+      .toBeVisible({ timeout: 5_000 })
+
+    // Once the probe starts succeeding, the interstitial forwards to the
+    // secure handover endpoint on the per-Org host, carrying the token intact.
+    await page.waitForURL(/console\.abc\.omani\.trade\/auth\/org-handover/, { timeout: 20_000 })
+    const url = page.url()
+    expect(url, 'forwarded to /auth/org-handover on the per-Org host').toContain('/auth/org-handover')
+    expect(url, 'session token carried through to the handover').toContain('token=mock-session-jwt')
+    expect(probes, 'polled /healthz until ready (tolerated early NXDOMAIN)').toBeGreaterThanOrEqual(3)
+  })
+
+  test('19 launching interstitial keeps a friendly waiting state while the host stays unreachable (no raw NXDOMAIN)', async ({ page }) => {
+    // Probe never succeeds — the host is still provisioning. The customer must
+    // see the on-brand "Setting up…" spinner (and an elapsed hint), NEVER a
+    // dead browser error page, and must remain ON the marketplace origin.
+    await page.route('**/console.def.omani.rest/healthz**', (route) => route.abort('namenotresolved'))
+
+    const params = new URLSearchParams({ host: 'https://console.def.omani.rest', token: 'mock-session-jwt', next: '/jobs' })
+    await page.goto('/launching?' + params.toString())
+
+    await expect(page.getByRole('heading', { name: /Setting up your console/i }))
+      .toBeVisible({ timeout: 5_000 })
+    // After a few seconds of failing probes it still shows the waiting state
+    // (and the elapsed-time hint) — we have NOT navigated away to a dead host.
+    await expect(page.getByText(/Still working/i)).toBeVisible({ timeout: 12_000 })
+    expect(page.url(), 'stays on the marketplace-origin /launching page').toContain('/launching')
+  })
+
+  test('20 launching interstitial rejects a missing/invalid host param (no open-redirect, honest error)', async ({ page }) => {
+    // A non-console host (open-redirect attempt) or a missing host must NOT be
+    // forwarded to — the interstitial surfaces an honest error instead.
+    await page.goto('/launching?host=' + encodeURIComponent('https://evil.example.com') + '&token=x&next=/jobs')
+    await expect(page.getByRole('heading', { name: /Something went wrong/i }))
+      .toBeVisible({ timeout: 5_000 })
+    // We must NOT have navigated to the attacker origin — staying on the
+    // marketplace-origin /launching page with the error state is correct.
+    // (The query string still echoes the rejected host; that's harmless — the
+    // assertion is on the ORIGIN we landed on, not the URL text.)
+    expect(new URL(page.url()).origin, 'stayed on the marketplace origin').toBe('http://localhost:4321')
+    expect(new URL(page.url()).pathname, 'stayed on /launching').toContain('/launching')
+
+    await page.goto('/launching')
+    await expect(page.getByRole('heading', { name: /Something went wrong/i }))
+      .toBeVisible({ timeout: 5_000 })
+  })
 })

--- a/core/marketplace/src/components/CheckoutStep.svelte
+++ b/core/marketplace/src/components/CheckoutStep.svelte
@@ -2,7 +2,7 @@
   import { sendMagicLink, verifyMagicLink, getMe, createTenant, getMyOrgs, createCheckout, startProvisioning, getProvisionByTenant, checkSlug, getPlans, getAddons, getCreditBalance, redeemVoucherPreview, setAuthTokens, setActiveOrg, setActiveOrgSlug, setActiveOrgConsoleHost, type User, type Provision, type Plan, type AddOn } from '../lib/api';
   import { readCart, clearCart } from '../lib/cart';
   import { formatOMR } from '../lib/currency';
-  import { consoleHandoffHref } from '../lib/config';
+  import { consoleHandoffHref, consoleLaunchHref } from '../lib/config';
   import PinInput6 from './PinInput6.svelte';
 
   let cart = $state(readCart());
@@ -221,7 +221,16 @@
     // catalyst-api burns the token into an HttpOnly cookie and 302s to a
     // clean /jobs. NO token/refresh ever lands in the browser address bar
     // after the hop; the refresh token stays in client storage.
-    window.location.href = consoleHandoffHref(tok, refresh, { slug });
+    //
+    // #4273: for a per-Org Sovereign console the host's DNS/TLS/HTTPRoute are
+    // still provisioning at this instant — an immediate cross-host bounce
+    // raced them and landed the FIRST click on NXDOMAIN. `consoleLaunchHref`
+    // routes through the marketplace-origin `/launching` interstitial which
+    // polls the per-Org `/healthz` and only forwards to `/auth/org-handover`
+    // once the host serves a response. The mothership `/nova` console always
+    // resolves, so there `consoleLaunchHref` is a pass-through to the direct
+    // handoff (no extra hop).
+    window.location.href = consoleLaunchHref(tok, refresh, { slug });
   }
 
   async function handleSendCode() {
@@ -507,7 +516,7 @@
         </div>
         {#if provision.status === 'completed'}
           <a
-            href={consoleHandoffHref(
+            href={consoleLaunchHref(
               localStorage.getItem('org-token') || '',
               localStorage.getItem('org-refresh-token') || '',
               { slug: (typeof localStorage !== 'undefined' ? localStorage.getItem('org-active-org-slug') : null) || undefined },

--- a/core/marketplace/src/components/Header.svelte
+++ b/core/marketplace/src/components/Header.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { readCart, cartItemCount, type CartState } from '../lib/cart';
   import { getMe, logout as apiLogout, AUTH_CHANGED_EVENT, type User } from '../lib/api';
-  import { consoleHref, consoleHandoffHref } from '../lib/config';
+  import { consoleHref, consoleLaunchHref } from '../lib/config';
 
   let { currentStep = 0 }: { currentStep?: number } = $props();
 
@@ -117,7 +117,11 @@
     if (!t) return consoleHref();
     // #4182/#4186: secure server-side handoff — no token/refresh in the URL
     // after the hop (catalyst-api burns the token into an HttpOnly cookie).
-    return consoleHandoffHref(t, r);
+    // #4273: route a per-Org Sovereign console through the marketplace-origin
+    // `/launching` interstitial so a customer clicking "Console" right after
+    // signup (host DNS/TLS still provisioning) sees a "Setting up…" state
+    // instead of a raw NXDOMAIN. Mothership `/nova` passes straight through.
+    return consoleLaunchHref(t, r);
   }
 </script>
 

--- a/core/marketplace/src/components/LaunchingStep.svelte
+++ b/core/marketplace/src/components/LaunchingStep.svelte
@@ -1,0 +1,247 @@
+<script lang="ts">
+  // #4273 — provisioning interstitial.
+  //
+  // The funnel used to HARD-REDIRECT to the per-Org console host
+  // (`console.<slug>.<sov-fqdn>/auth/org-handover?token=…`) the instant
+  // checkout succeeded. But that host's DNS A-record (#4236), TLS cert
+  // (#4241/#4242) and `cilium-gateway-console` HTTPRoute are provisioned
+  // ASYNCHRONOUSLY by the organization-controller AFTER the Org CR is created
+  // — they land over seconds-to-minutes. The customer's FIRST click therefore
+  // hit ERR_NAME_NOT_RESOLVED (NXDOMAIN), which the browser negative-caches
+  // for the 300s pool-zone SOA minimum: a dead-end "This site can't be
+  // reached".
+  //
+  // This page is served from the marketplace origin (`marketplace.<sov>`),
+  // which ALWAYS resolves. It shows a branded "Setting up your console…"
+  // state, polls the per-Org console `/healthz` (mapped to catalyst-api by the
+  // per-Org HTTPRoute — a 200 means DNS + TLS + route are all live), and only
+  // then forwards to the existing secure `/auth/org-handover` endpoint. The
+  // handover token is carried THROUGH unchanged and handed to the server at the
+  // end of the wait, preserving the #4182/#4186 contract (token → HttpOnly
+  // cookie server-side; never logged; refresh token never in a URL). On
+  // timeout the customer sees an honest "still provisioning" state with a
+  // manual retry — never a raw browser DNS error.
+
+  type Phase = 'provisioning' | 'forwarding' | 'timeout' | 'error';
+  let phase = $state<Phase>('provisioning');
+  let elapsedMs = $state(0);
+
+  // Polling schedule — fast at first (route often lands inside ~20-40s) then
+  // backs off. Bounded by TIMEOUT_MS so a genuinely stuck provision surfaces a
+  // retry rather than spinning forever.
+  const MIN_INTERVAL_MS = 1500;
+  const MAX_INTERVAL_MS = 8000;
+  const TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes (issue #4273 bound)
+  // Per-probe network timeout so a hung TLS handshake / slow DNS doesn't stall
+  // the whole schedule.
+  const PROBE_TIMEOUT_MS = 5000;
+
+  let startedAt = 0;
+  let pollTimer: ReturnType<typeof setTimeout> | null = null;
+  let tickTimer: ReturnType<typeof setInterval> | null = null;
+  let cancelled = false;
+
+  interface LaunchParams {
+    host: string;   // full origin, e.g. https://console.abc.omani.trade
+    token: string;  // session JWT for /auth/org-handover
+    next: string;   // post-handover path, default /jobs
+  }
+
+  // Parse + VALIDATE the query params. Security: the interstitial only ever
+  // forwards to a `console.*` host on the SAME registrable apex as the
+  // marketplace origin — this is a per-Org Sovereign console, never an
+  // arbitrary attacker-supplied URL (guards open-redirect / token-leak).
+  function parseParams(): LaunchParams | null {
+    if (typeof window === 'undefined') return null;
+    const qs = new URLSearchParams(window.location.search);
+    const rawHost = (qs.get('host') || '').trim();
+    const token = (qs.get('token') || '').trim();
+    let next = (qs.get('next') || '/jobs').trim();
+    if (!rawHost || !token) return null;
+    // next must be a same-origin path on the console (no scheme / host).
+    if (!next.startsWith('/') || next.startsWith('//')) next = '/jobs';
+    let target: URL;
+    try {
+      target = new URL(rawHost);
+    } catch {
+      return null;
+    }
+    if (target.protocol !== 'https:') return null;
+    const targetHost = target.hostname.toLowerCase();
+    // The marketplace runs at `marketplace.<sov-fqdn>`; per-Org consoles live
+    // at `console.<slug>.<pool-apex>`. Both share the Sovereign's registrable
+    // apex but the POOL apex can differ from the Sovereign apex (e.g.
+    // marketplace.omantel.biz → console.abc.omani.trade). So we cannot pin to
+    // the marketplace's own apex; instead we require the canonical
+    // `console.` left-most label, which the funnel always composes. Reject
+    // anything that is not a `console.*` host.
+    if (!(targetHost === 'console' || targetHost.startsWith('console.'))) return null;
+    return { host: target.origin, token, next };
+  }
+
+  let params = $state<LaunchParams | null>(null);
+
+  // Probe the per-Org console /healthz. ANY failure (DNS / TLS / connection /
+  // non-2xx) is treated as "still provisioning" and swallowed — we keep
+  // polling until ready or timeout. `no-cors` keeps the probe a simple request
+  // (no preflight) and tolerates the opaque cross-origin response; a resolved
+  // fetch (opaque or ok) means the host is up and serving, a rejection means
+  // it is not reachable yet.
+  async function probeReady(host: string): Promise<boolean> {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), PROBE_TIMEOUT_MS);
+    try {
+      await fetch(`${host}/healthz`, {
+        method: 'GET',
+        mode: 'no-cors',
+        cache: 'no-store',
+        redirect: 'follow',
+        signal: ctrl.signal,
+      });
+      // A non-throwing fetch (even an opaque no-cors response) means DNS
+      // resolved, the TLS handshake completed, and the server answered — the
+      // host is reachable. NXDOMAIN / refused / TLS-fail all REJECT instead.
+      return true;
+    } catch {
+      return false;
+    } finally {
+      clearTimeout(t);
+    }
+  }
+
+  function forward(p: LaunchParams) {
+    phase = 'forwarding';
+    cleanup();
+    // Hand the token to the secure server-side handoff. catalyst-api validates
+    // it, mints the HttpOnly catalyst_session cookie, and 302s to `next`.
+    // consoleHandoffHref is built from the SAME validated host (slug derivation
+    // is bypassed by passing the host through the already-validated origin).
+    const url = `${p.host}/auth/org-handover?token=${encodeURIComponent(p.token)}`;
+    window.location.replace(url);
+  }
+
+  async function pollOnce(p: LaunchParams) {
+    if (cancelled) return;
+    if (Date.now() - startedAt >= TIMEOUT_MS) {
+      phase = 'timeout';
+      cleanup();
+      return;
+    }
+    const ready = await probeReady(p.host);
+    if (cancelled) return;
+    if (ready) {
+      forward(p);
+      return;
+    }
+    // Linear-ish backoff toward MAX_INTERVAL_MS as elapsed time grows.
+    const frac = Math.min(1, (Date.now() - startedAt) / 60_000);
+    const interval = Math.round(MIN_INTERVAL_MS + frac * (MAX_INTERVAL_MS - MIN_INTERVAL_MS));
+    pollTimer = setTimeout(() => pollOnce(p), interval);
+  }
+
+  function cleanup() {
+    if (pollTimer) { clearTimeout(pollTimer); pollTimer = null; }
+    if (tickTimer) { clearInterval(tickTimer); tickTimer = null; }
+  }
+
+  function start() {
+    const p = parseParams();
+    params = p;
+    if (!p) { phase = 'error'; return; }
+    cancelled = false;
+    phase = 'provisioning';
+    startedAt = Date.now();
+    elapsedMs = 0;
+    tickTimer = setInterval(() => { elapsedMs = Date.now() - startedAt; }, 1000);
+    pollOnce(p);
+  }
+
+  function retry() {
+    cleanup();
+    start();
+  }
+
+  // Manual "open anyway" — for the rare case the host is up but the probe is
+  // blocked (corp proxy stripping no-cors). Forwards to the handoff directly.
+  function openAnyway() {
+    if (params) forward(params);
+  }
+
+  $effect(() => {
+    start();
+    return () => { cancelled = true; cleanup(); };
+  });
+
+  const elapsedLabel = $derived.by(() => {
+    const s = Math.floor(elapsedMs / 1000);
+    if (s < 60) return `${s}s`;
+    return `${Math.floor(s / 60)}m ${s % 60}s`;
+  });
+</script>
+
+<div class="mx-auto max-w-lg py-12">
+  <div class="rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] p-8 text-center">
+    {#if phase === 'provisioning' || phase === 'forwarding'}
+      <div class="mx-auto mb-5 h-14 w-14 animate-spin rounded-full border-4 border-[var(--color-accent)] border-t-transparent"></div>
+      <h1 class="text-xl font-bold text-[var(--color-text-strong)]">
+        {phase === 'forwarding' ? 'Opening your console…' : 'Setting up your console…'}
+      </h1>
+      <p class="mt-2 text-sm text-[var(--color-text-dim)]">
+        We're provisioning your Organization's secure address. This usually
+        takes under a minute — you'll be redirected automatically.
+      </p>
+      {#if phase === 'provisioning' && elapsedMs >= 5000}
+        <p class="mt-4 text-xs text-[var(--color-text-dimmer)]">
+          Still working… ({elapsedLabel})
+        </p>
+      {/if}
+    {:else if phase === 'timeout'}
+      <div class="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-[var(--color-warn)]/15">
+        <svg class="h-7 w-7 text-[var(--color-warn)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6l4 2M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+        </svg>
+      </div>
+      <h1 class="text-xl font-bold text-[var(--color-text-strong)]">Your Organization is still provisioning</h1>
+      <p class="mt-2 text-sm text-[var(--color-text-dim)]">
+        This is taking longer than usual. Your console is being prepared and
+        we'll email you the link the moment it's ready. You can keep waiting
+        or try again now.
+      </p>
+      <div class="mt-6 flex flex-col gap-2 sm:flex-row sm:justify-center">
+        <button
+          type="button"
+          onclick={retry}
+          data-testid="launching-retry"
+          class="inline-flex items-center justify-center gap-2 rounded-xl bg-[var(--color-accent)] px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[var(--color-accent-hover)]"
+        >
+          Keep waiting
+        </button>
+        <button
+          type="button"
+          onclick={openAnyway}
+          class="inline-flex items-center justify-center gap-2 rounded-xl border border-[var(--color-border)] px-5 py-2.5 text-sm font-medium text-[var(--color-text)] transition-colors hover:bg-[var(--color-surface-hover)]"
+        >
+          Open console anyway
+        </button>
+      </div>
+    {:else}
+      <!-- error: missing/invalid params -->
+      <div class="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-[var(--color-danger)]/15">
+        <svg class="h-7 w-7 text-[var(--color-danger)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"/>
+        </svg>
+      </div>
+      <h1 class="text-xl font-bold text-[var(--color-text-strong)]">Something went wrong</h1>
+      <p class="mt-2 text-sm text-[var(--color-text-dim)]">
+        We couldn't determine your console address. Head back to your account
+        and try opening your console again.
+      </p>
+      <a
+        href="/checkout"
+        class="mt-6 inline-flex items-center justify-center gap-2 rounded-xl bg-[var(--color-accent)] px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[var(--color-accent-hover)] no-underline"
+      >
+        Back to checkout
+      </a>
+    {/if}
+  </div>
+</div>

--- a/core/marketplace/src/layouts/Layout.astro
+++ b/core/marketplace/src/layouts/Layout.astro
@@ -68,6 +68,10 @@ const { title, step = 0 } = Astro.props;
     //  - /auth/callback completes OAuth before we can check
     //  - /checkout with ?order_id is Stripe's return URL and must stay so
     //    CheckoutStep can wire up the active-org and redirect itself
+    //  - /launching (#4273) is the provisioning interstitial that itself
+    //    waits for the per-Org console host and forwards there once ready;
+    //    auto-redirecting away from it would defeat the readiness gate and
+    //    re-introduce the NXDOMAIN race it exists to prevent.
     //  - ?new=1 lets an existing customer spin up a second workspace
     (function () {
       try {
@@ -79,6 +83,7 @@ const { title, step = 0 } = Astro.props;
         var path = window.location.pathname;
         var qs = new URLSearchParams(window.location.search);
         if (path.indexOf('/auth/callback') === 0) return;
+        if (path.indexOf('/launching') === 0) return;
         if (qs.get('order_id')) return;
         if (qs.get('new') === '1') return;
         var token = localStorage.getItem('org-token');
@@ -159,9 +164,31 @@ const { title, step = 0 } = Astro.props;
         // handed to the secure server endpoint which burns it into a cookie;
         // the refresh stays in client storage (org-refresh-token, written by
         // setAuthTokens). On the secure path the landing URL is a clean /jobs.
-        var url = perTenant
-          ? base + '/auth/org-handover?token=' + encodeURIComponent(token)
-          : base + '/?token=' + encodeURIComponent(token) + (refresh ? '&refresh_token=' + encodeURIComponent(refresh) : '');
+        //
+        // #4273: a per-Org Sovereign console host (console.<slug>.<sov>) may
+        // not have its DNS/TLS/HTTPRoute provisioned yet when a freshly-signed-
+        // up returning visitor lands here, so an immediate cross-host bounce
+        // hits NXDOMAIN. Route the per-tenant case through the marketplace-
+        // origin /launching interstitial (mirrors src/lib/config.ts::
+        // consoleLaunchHref — kept inline so it fires before the Svelte
+        // bundle), which polls the console /healthz and only forwards to
+        // /auth/org-handover once the host serves a response. The mothership
+        // /nova path always resolves, so it keeps the direct shape.
+        var url;
+        if (perTenant) {
+          var launchQs = new URLSearchParams({
+            host: base,
+            token: token,
+            next: '/jobs',
+          });
+          // The marketplace is served at the site root (no Astro `base:`
+          // configured), so `/launching` is the interstitial page route. This
+          // is an `is:inline` script — NOT processed by Vite — so we use a
+          // literal root path rather than import.meta.env.BASE_URL.
+          url = '/launching?' + launchQs.toString();
+        } else {
+          url = base + '/?token=' + encodeURIComponent(token) + (refresh ? '&refresh_token=' + encodeURIComponent(refresh) : '');
+        }
         window.location.replace(url);
       }
     })();

--- a/core/marketplace/src/lib/config.ts
+++ b/core/marketplace/src/lib/config.ts
@@ -276,5 +276,60 @@ export const consoleHandoffHref = (
   return `${base}/auth/org-handover?token=${encodeURIComponent(token)}`;
 };
 
+/**
+ * #4273 — gate the post-checkout redirect on per-Org host readiness.
+ *
+ * The per-Org console host (`console.<slug>.<sov-fqdn>`) is provisioned
+ * ASYNCHRONOUSLY by the organization-controller AFTER the Org CR is created:
+ * pool-DNS A-record (#4236), per-Org TLS cert (#4241/#4242), and the HTTPRoute
+ * on `cilium-gateway-console` all land over seconds-to-minutes. The route maps
+ * `GET /healthz` to catalyst-api (see organization/internal/controller/
+ * tenant_route.go), so a reachable `https://<consoleHost>/healthz` is the
+ * canonical "this host now resolves, serves TLS, AND has its console route"
+ * signal — the exact precondition the `/auth/org-handover` redirect needs.
+ *
+ * This replaces the IMMEDIATE cross-host bounce to `console.<slug>.<sov-fqdn>/
+ * auth/org-handover` (which raced that async provisioning and landed the
+ * customer's FIRST click on ERR_NAME_NOT_RESOLVED, negative-cached for the
+ * 300s pool-zone SOA minimum). Instead the marketplace navigates to a
+ * provisioning interstitial served from the marketplace origin — a host that
+ * ALWAYS resolves — at `<BASE>launching?host=<consoleHost>&token=<jwt>&next=
+ * <path>`. The `/launching` page (LaunchingStep.svelte) shows a branded
+ * "Setting up your console…" state, polls the per-Org `/healthz` with backoff
+ * (NXDOMAIN / TLS-handshake / connection-refused all tolerated as "still
+ * provisioning"), and only forwards to the real `/auth/org-handover` once the
+ * host serves a response.
+ *
+ * For the mothership `/nova` console (which has no per-Org async provisioning
+ * — the host is always live) the direct `consoleHandoffHref` shape is kept:
+ * there is nothing to wait for, so an interstitial would only add a hop.
+ *
+ * The token is passed THROUGH the interstitial unchanged and handed to the
+ * existing secure `/auth/org-handover` endpoint at the end of the wait, so the
+ * #4182/#4186 contract (token burned into an HttpOnly cookie server-side, no
+ * bearer in the final address bar) is preserved. The refresh token is NEVER
+ * placed in any URL — it stays in client storage.
+ *
+ * Pass `opts.slug` to override the active-org-slug read from localStorage.
+ */
+export const consoleLaunchHref = (
+  token: string,
+  refreshToken?: string | null,
+  opts?: { slug?: string | null; next?: string },
+): string => {
+  const base = opts && opts.slug !== undefined
+    ? deriveConsoleURL(opts.slug)
+    : CONSOLE_URL;
+  const next = (opts && opts.next) || '/jobs';
+  // Mothership console always resolves — keep the direct handoff (no wait).
+  if (base.includes('/nova')) {
+    return consoleHandoffHref(token, refreshToken, opts);
+  }
+  // Sovereign per-Org (or operator) console — route through the marketplace-
+  // origin interstitial that waits for the host to be reachable.
+  const params = new URLSearchParams({ host: base, token, next });
+  return `${BASE}launching?${params.toString()}`;
+};
+
 /** Prepend base to an internal marketplace route (strip leading '/'). */
 export const path = (p: string): string => `${BASE}${p.replace(/^\//, '')}`;

--- a/core/marketplace/src/pages/launching.astro
+++ b/core/marketplace/src/pages/launching.astro
@@ -1,0 +1,16 @@
+---
+// #4273 — provisioning interstitial page.
+//
+// Served from the marketplace origin (`marketplace.<sov-fqdn>`), which ALWAYS
+// resolves — so the customer never hits a raw browser DNS error while the
+// per-Org console host (`console.<slug>.<sov-fqdn>`) is still having its
+// async DNS A-record (#4236) / TLS cert (#4241/#4242) / cilium-gateway-console
+// HTTPRoute provisioned by the organization-controller. LaunchingStep polls
+// the per-Org `/healthz` and forwards to the secure `/auth/org-handover` once
+// the host serves a response. See src/lib/config.ts::consoleLaunchHref.
+import Layout from '../layouts/Layout.astro';
+import LaunchingStep from '../components/LaunchingStep.svelte';
+---
+<Layout title="Setting up your console">
+  <LaunchingStep client:load />
+</Layout>


### PR DESCRIPTION
## Problem (Refs #4273)

On checkout the marketplace funnel hard-redirected the browser to the
per-Org console host (`console.<slug>.<sov-fqdn>/auth/org-handover?token=…`)
the instant the Org CR was created. But that host's pool-DNS A-record (#4236),
per-Org TLS cert (#4241/#4242) and `cilium-gateway-console` HTTPRoute are
provisioned **asynchronously** by the organization-controller and land over
seconds-to-minutes. The customer's **first click** therefore hit
`ERR_NAME_NOT_RESOLVED` (NXDOMAIN), which the browser negative-caches for the
300s pool-zone SOA minimum — a dead "This site can't be reached" (founder-hit
on `abc.omani.trade`, 2026-06-24).

## Fix — readiness-gated interstitial served from the marketplace origin

The funnel now lands the customer on a `/launching` page served from
`marketplace.<sov>` (a host that **always** resolves) instead of bouncing
straight to the not-yet-provisioned per-Org host.

**Readiness signal — client-side poll of the per-Org `/healthz`.** The per-Org
console HTTPRoute (`organization/internal/controller/tenant_route.go`) maps
`GET /healthz` to catalyst-api, so a reachable `https://<consoleHost>/healthz`
means DNS + TLS + the console route are all live — exactly the precondition the
`/auth/org-handover` redirect needs. There is no marketplace-origin-reachable
backend "Org ready" signal before the console host itself resolves, so the
client poll (per the issue) is the correct signal; before the route lands the
probe fails with NXDOMAIN / TLS-handshake / connection-refused, all tolerated
as "still provisioning".

- **New `LaunchingStep.svelte` + `/launching` page** — shows a branded
  "Setting up your console…" state, polls the per-Org `/healthz` with backoff
  (1.5s → 8s), and forwards to the existing secure `/auth/org-handover` once
  the host serves a response.
- **Timeout fallback (~5 min)** — surfaces an honest "Your Organization is
  still provisioning — we'll email you the link" state with **Keep waiting** /
  **Open console anyway** buttons. Never a raw browser DNS error.
- **`config.ts::consoleLaunchHref()`** — for the Sovereign per-Org path builds
  the marketplace-origin `/launching?host=&token=&next=` URL; for the
  mothership `/nova` console (always live) it passes straight through to the
  direct handoff (no extra hop).
- **All four redirect surfaces routed through it**: CheckoutStep launch handler
  + Stripe-return, CheckoutStep "Go to Console" link, Header "Console" portal
  link, and the `Layout.astro` returning-user inline redirect (mirrored inline
  since that script runs before the Svelte bundle). `/launching` is excluded
  from the returning-user auto-redirect so it isn't bounced before the gate
  runs.

The handover token is carried **through** the interstitial unchanged and handed
to `/auth/org-handover` at the end of the wait, preserving the #4182/#4186
contract: token → HttpOnly cookie server-side, never in the final address bar,
refresh token never placed in any URL. The interstitial only ever forwards to a
`console.*` host (open-redirect guard). `skipConsoleRedirect` (demo tenants)
behavior is untouched.

## Validate

- `astro build` green; `/launching` page generated, `LaunchingStep` bundled,
  the served-domain-hygiene postbuild check passes (no banned literals).
- `astro check`: my six changed files add **zero** new diagnostics. The 1
  pre-existing error + 1 warning are in `playwright/customer-journey.spec.ts`
  on `main` (lines ~616/754, unrelated to this change).
- 3 new hermetic Playwright cases added to the customer-journey gate (probe is
  intercepted; no live per-Org host needed): **18** shows-immediately +
  forwards-once-ready (token carried through), **19** friendly-wait state while
  the host stays unreachable (stays on the marketplace origin, no NXDOMAIN),
  **20** rejects a missing/invalid `host` param (open-redirect guard). All
  three pass; the rest of the suite is unchanged (the one pre-existing failure,
  test 01 "storefront loads", asserts a heading absent from `index.astro` on
  `main` and is untouched here).

## Fresh-Org funnel walk (capacity-gated — not provisioned here)

On a fresh Sovereign with a COLD pool TLD (e.g. `omani.rest` / `omani.trade`):

1. Storefront → pick plan/apps → `/checkout`, sign in (email + 6-digit PIN).
2. Choose a brand-new subdomain on the cold pool TLD; complete checkout
   (voucher-covered or Stripe).
3. **Expect:** the browser lands on `marketplace.<sov>/launching?host=…` showing
   the "Setting up your console…" spinner **immediately** — no
   `ERR_NAME_NOT_RESOLVED`. Screenshot this.
4. Watch the network panel: repeated `GET https://console.<slug>.<tld>/healthz`
   failing (NXDOMAIN/TLS) then succeeding once the org-controller lands the
   DNS A-record + cert + HTTPRoute.
5. **Expect:** auto-forward to `console.<slug>.<tld>/auth/org-handover?token=…`
   → HttpOnly `catalyst_session` cookie minted → clean `/jobs`, signed in.
   Screenshot the signed-in `/jobs`.
6. Negative path: pause the org-controller (or use a non-existent slug) and
   confirm the 5-minute timeout state renders with a working **Keep waiting**
   retry — never a dead browser DNS page.

Refs #4273 #4179 #4236

🤖 Generated with [Claude Code](https://claude.com/claude-code)