### PR TITLE
fix(catalyst-api): org-handover on-demand registers the funnel Org host — kill the 'invalid audience' sign-in race (Refs #3376)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/org_handover.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_handover.go
@@ -111,6 +111,20 @@ func (h *Handler) AuthOrgHandover(w http.ResponseWriter, r *http.Request) {
 	// sovereign-admin session.
 	scope, ok := h.resolveOrgScope(r)
 	if !ok {
+		// On-demand registry sync (the #3376 terminal-step race): a fresh
+		// MARKETPLACE funnel Org is registered only by the periodic 60s
+		// ReconcileTenantRegistryFromOrgCRs loop — the funnel door never runs
+		// the BSS pipeline that writes the row synchronously. A stranger who
+		// completes checkout is redirected here IMMEDIATELY, so the row may not
+		// exist yet. Resolve the Org CR for THIS exact request host and register
+		// it now, then retry the scope resolution once. If the host still has no
+		// matching Org CR (or we're out-of-cluster), we refuse exactly as before
+		// — no regression for a genuinely-unknown host.
+		if h.ensureTenantRegisteredForHost(r.Context(), requestHost(r)) {
+			scope, ok = h.resolveOrgScope(r)
+		}
+	}
+	if !ok {
 		h.log.Warn("auth_org_handover: refused — request host is not a registered Org console",
 			"host", requestHost(r))
 		writeAuthError(w, "invalid audience: not an org console host")

--- a/products/catalyst/bootstrap/api/internal/handler/org_handover_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_handover_test.go
@@ -10,6 +10,10 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handoverjwt"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
@@ -153,6 +157,89 @@ func TestAuthOrgHandover_HappyPath(t *testing.T) {
 	}
 	if claims["email"] != "demo@openova.io" {
 		t.Errorf("email = %v, want demo@openova.io", claims["email"])
+	}
+}
+
+// TestAuthOrgHandover_OnDemandRegistersFunnelOrg is the #3376 terminal-step
+// race assertion: a fresh MARKETPLACE funnel stranger lands on org-handover
+// BEFORE the 60s tenant-registry reconcile tick has registered their console
+// host. The registry starts EMPTY; only the Organization CR exists. The handler
+// must do an on-demand single-host sync, register the host, and STILL land the
+// stranger signed-in (302 + Org-scoped cookie) — not bounce them to /login with
+// `invalid audience`.
+func TestAuthOrgHandover_OnDemandRegistersFunnelOrg(t *testing.T) {
+	dir := t.TempDir()
+
+	privPEM, _, err := handoverjwt.GenerateKeypair()
+	if err != nil {
+		t.Fatalf("GenerateKeypair: %v", err)
+	}
+	signer, err := handoverjwt.New(privPEM, "https://console.openova.io", 8*time.Hour)
+	if err != nil {
+		t.Fatalf("handoverjwt.New: %v", err)
+	}
+
+	// EMPTY registry — the periodic reconcile has not run for this funnel Org.
+	reg, err := store.NewTenantRegistry(dir)
+	if err != nil {
+		t.Fatalf("new registry: %v", err)
+	}
+	orgSecret := []byte("test-org-jwt-secret-aaaaaaaaaaaaaaaaaaaa")
+	h := &Handler{
+		log:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		handoverSigner: signer,
+		orgJWTSecret:   orgSecret,
+	}
+	h.SetTenantRegistry(reg)
+	h.SetOrganizationDeps(OrganizationDeps{OTECHFQDN: "omantel.biz"})
+	// The Organization CR for the funnel Org DOES exist on the apiserver.
+	h.SetSovereignDepsFactory(orgCRDepsFactory(orgCR("g4wpsso", "omani.works", "", "tnt-g4")))
+
+	token := mintMemberToken(t, orgSecret, "g4wpsso-stranger@omani.works", time.Now().Add(15*time.Minute))
+	req := httptest.NewRequest(http.MethodGet, "/auth/org-handover?token="+token, nil)
+	req.Header.Set("X-Forwarded-Host", "console.g4wpsso.omani.works")
+	req.Header.Set("X-Forwarded-Proto", "https")
+
+	rec := httptest.NewRecorder()
+	h.AuthOrgHandover(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302 (on-demand sync should rescue the empty-registry race); body=%s",
+			rec.Code, rec.Body.String())
+	}
+	if loc := rec.Header().Get("Location"); loc != "/jobs" {
+		t.Fatalf("Location = %q, want /jobs", loc)
+	}
+	var sess *http.Cookie
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "catalyst_session" {
+			sess = c
+		}
+	}
+	if sess == nil || sess.Value == "" {
+		t.Fatal("catalyst_session cookie must be set after the on-demand sync rescue")
+	}
+	// The host must now be persisted so subsequent requests resolve directly.
+	if _, ok := reg.Get("console.g4wpsso.omani.works"); !ok {
+		t.Error("on-demand sync should have persisted the funnel Org host into the registry")
+	}
+}
+
+// orgCRDepsFactory returns a SovereignDepsFactory backed by a fake dynamic
+// client seeded with the given Organization CRs (mirrors the wiring in
+// tenant_registry_reconcile_test.go's newRegistryReconcileHandler).
+func orgCRDepsFactory(orgs ...*unstructured.Unstructured) SovereignDepsFactory {
+	scheme := runtime.NewScheme()
+	gvrToList := map[schema.GroupVersionResource]string{
+		organizationGVR(): "OrganizationList",
+	}
+	seed := make([]runtime.Object, 0, len(orgs))
+	for _, o := range orgs {
+		seed = append(seed, o)
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToList, seed...)
+	return func() (*sovereignDeps, error) {
+		return &sovereignDeps{core: nil, dyn: dyn}, nil
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/tenant_registry_reconcile.go
+++ b/products/catalyst/bootstrap/api/internal/handler/tenant_registry_reconcile.go
@@ -138,6 +138,78 @@ func (h *Handler) reconcileTenantRegistryOnce(ctx context.Context) {
 	}
 }
 
+// ensureTenantRegisteredForHost performs an ON-DEMAND, single-host registry
+// sync: it lists Organization CRs, finds the one whose pool console host
+// equals `host`, and registers it immediately — without waiting for the next
+// 60s ReconcileTenantRegistryFromOrgCRs tick.
+//
+// THE RACE this closes (the #3376 terminal "signed-in" gate): a marketplace
+// funnel stranger completes checkout, the Organization CR lands, and the
+// marketplace IMMEDIATELY redirects the browser to
+// `console.<slug>.<pool>/auth/org-handover?token=…`. The funnel door never
+// runs the BSS provisioning pipeline (which writes the registry synchronously
+// at Step 6), so until the periodic reconcile loop next fires (up to 60s) the
+// registry has no row for this host → resolveOrgScope MISSES → AuthOrgHandover
+// returns 401 `invalid audience` → the stranger sees /login instead of landing
+// signed-in. This makes the registration deterministic at handover time rather
+// than dependent on the periodic tick's timing.
+//
+// Returns true when a row for `host` is present after the call (either it
+// already existed or this call just wrote it). Best-effort: any apiserver /
+// list / Put failure returns false and is logged — AuthOrgHandover then falls
+// back to refusing, exactly as before this method existed (no regression — the
+// periodic loop still backfills the row within one interval).
+func (h *Handler) ensureTenantRegisteredForHost(ctx context.Context, host string) bool {
+	if h == nil || h.tenantRegistry == nil {
+		return false
+	}
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "" {
+		return false
+	}
+	// Already known? Nothing to do — the steady-state path.
+	if _, found := h.tenantRegistry.Get(host); found {
+		return true
+	}
+
+	deps, err := h.sovereignDepsFor()
+	if err != nil || deps == nil || deps.dyn == nil {
+		// Out-of-cluster / CI: no apiserver to resolve the CR from. Refuse and
+		// let the caller surface the existing 401 — identical to pre-#3376.
+		h.log.Info("tenant-registry-ensure: skipped — no in-cluster dynamic client",
+			"host", host, "err", err)
+		return false
+	}
+
+	list, err := deps.dyn.Resource(organizationGVR()).Namespace("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		h.log.Warn("tenant-registry-ensure: list Organizations failed",
+			"host", host, "err", err)
+		return false
+	}
+
+	sovereignFQDN := strings.TrimSpace(h.orgTenantDeps.OTECHFQDN)
+	for i := range list.Items {
+		reg, ok := tenantRegistrationFromOrgCR(&list.Items[i], sovereignFQDN)
+		if !ok || reg.Host != host {
+			continue
+		}
+		if err := h.tenantRegistry.Put(reg); err != nil {
+			h.log.Warn("tenant-registry-ensure: Put failed for Org console host",
+				"host", reg.Host, "tenant_id", reg.TenantID, "err", err)
+			return false
+		}
+		h.log.Info("tenant-registry-ensure: on-demand registered Org console host",
+			"host", reg.Host, "tenant_id", reg.TenantID)
+		return true
+	}
+	// No Org CR matches this host yet — the CR has not been created (or its
+	// pool console host differs). Refuse; the caller surfaces 401.
+	h.log.Info("tenant-registry-ensure: no Organization CR matches host",
+		"host", host, "orgs", len(list.Items))
+	return false
+}
+
 // tenantRegistrationFromOrgCR builds the TenantRegistration for an Organization
 // CR, mirroring the shape the BSS pipeline writes at Step 6
 // (organization_provisioning.go) byte-for-byte so both doors yield an identical

--- a/products/catalyst/bootstrap/api/internal/handler/tenant_registry_reconcile_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/tenant_registry_reconcile_test.go
@@ -187,6 +187,78 @@ func TestReconcileTenantRegistryOnce_Idempotent(t *testing.T) {
 	}
 }
 
+// TestEnsureTenantRegisteredForHost is the #3376 terminal-step race fix at the
+// unit level: a fresh funnel Org's row is NOT yet in the registry (the periodic
+// reconcile tick has not fired), but its Organization CR exists. An on-demand
+// sync for the exact console host must resolve + register it immediately so the
+// very next resolveOrgScope ACCEPTS the org-handover.
+func TestEnsureTenantRegisteredForHost(t *testing.T) {
+	t.Run("on-demand registers the matching host", func(t *testing.T) {
+		h, registry := newRegistryReconcileHandler(t,
+			orgCR("funnelorg", "omani.works", "", "tnt-funnel"),
+			orgCR("other", "omani.rest", "", "tnt-other"),
+		)
+		// Registry starts empty (no periodic tick has run).
+		if n := len(registry.List()); n != 0 {
+			t.Fatalf("registry should start empty, has %d", n)
+		}
+
+		if !h.ensureTenantRegisteredForHost(context.Background(), "console.funnelorg.omani.works") {
+			t.Fatal("ensureTenantRegisteredForHost should have registered the funnel Org host")
+		}
+		got, ok := registry.Get("console.funnelorg.omani.works")
+		if !ok {
+			t.Fatal("funnel Org host not in registry after on-demand sync")
+		}
+		if got.TenantKind != store.TenantKindOrg || got.TenantID != "tnt-funnel" {
+			t.Errorf("unexpected row: %+v", got)
+		}
+		// Only the requested host is written — the unrelated Org is not pulled in.
+		if _, ok := registry.Get("console.other.omani.rest"); ok {
+			t.Error("on-demand sync must only register the requested host, not every Org")
+		}
+	})
+
+	t.Run("already-registered host is a fast no-op true", func(t *testing.T) {
+		h, registry := newRegistryReconcileHandler(t,
+			orgCR("acme", "omani.works", "", "tnt-1"),
+		)
+		if err := registry.Put(store.TenantRegistration{
+			Host: "console.acme.omani.works", TenantID: "tnt-1", TenantKind: store.TenantKindOrg,
+		}); err != nil {
+			t.Fatalf("seed put: %v", err)
+		}
+		if !h.ensureTenantRegisteredForHost(context.Background(), "console.acme.omani.works") {
+			t.Fatal("already-registered host should return true")
+		}
+	})
+
+	t.Run("no matching Org CR → false (caller refuses)", func(t *testing.T) {
+		h, _ := newRegistryReconcileHandler(t,
+			orgCR("acme", "omani.works", "", "tnt-1"),
+		)
+		if h.ensureTenantRegisteredForHost(context.Background(), "console.ghost.omani.works") {
+			t.Fatal("a host with no Organization CR must NOT register")
+		}
+	})
+
+	t.Run("no dynamic client → false, no panic", func(t *testing.T) {
+		dir := t.TempDir()
+		registry, err := store.NewTenantRegistry(dir)
+		if err != nil {
+			t.Fatalf("tenant registry: %v", err)
+		}
+		h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+		h.SetTenantRegistry(registry)
+		h.SetSovereignDepsFactory(func() (*sovereignDeps, error) {
+			return &sovereignDeps{core: nil, dyn: nil}, nil
+		})
+		if h.ensureTenantRegisteredForHost(context.Background(), "console.acme.omani.works") {
+			t.Fatal("out-of-cluster ensure must return false")
+		}
+	})
+}
+
 // TestReconcileTenantRegistryOnce_NoDynamicClientIsNoop confirms the out-of-
 // cluster / CI degrade path: no dynamic client → no crash, registry untouched.
 func TestReconcileTenantRegistryOnce_NoDynamicClientIsNoop(t *testing.T) {


### PR DESCRIPTION
## What

Closes the last intermittent failure on the **#3376 terminal step** — *a stranger with a voucher ends signed-in in their OWN Org console*. On the door-collapse keystone (`fix/4297-apps-into-vcluster`), the funnel reaches checkout → Org CR → pool-host console redirect, but the very last hop (`/auth/org-handover` → mint an Org session) **intermittently bounced the stranger to `/login`** with `invalid audience: not an org console host`.

## The broken step

`AuthOrgHandover` (`org_handover.go`) authorizes the handover via `resolveOrgScope` (`org_scope.go`), which reads the flat-file **tenant registry**:

- The **BSS door** writes the registry row synchronously (`organization_provisioning.go` Step 6).
- The **MARKETPLACE funnel door** does NOT — for funnel Orgs the row is written ONLY by the periodic 60s reconcile loop (`tenant_registry_reconcile.go`, `tenantRegistryReconcileInterval = 60s`).

A stranger who completes checkout is redirected **immediately** to `console.<slug>.<pool>/auth/org-handover?token=…`. For up to 60s the registry has no row for that host → `resolveOrgScope` misses → `AuthOrgHandover` returns 401 → the SPA shows `/login` instead of landing signed-in. The 2026-06-24 GREEN walk passed on timing luck (its own comment records a transient negative-cache second at the launch instant).

## The fix

When `resolveOrgScope` misses, `AuthOrgHandover` now performs an **on-demand, single-host registry sync** (`ensureTenantRegisteredForHost`): list Organization CRs, find the one whose pool console host equals the request host, register it, and retry the scope resolution once. This collapses the handover-time window to zero.

- A genuinely-unknown host (no matching Org CR, or out-of-cluster / CI) still **refuses exactly as before** — no regression for non-Org hosts.
- The periodic reconcile loop is untouched and keeps backfilling steady-state.
- Only the requested host is written (not every Org), and an already-registered host is a fast no-op.

Pure catalyst-api Go change — no chart template touched, so **no chart version bump**; the deploy-bot rolls the catalyst-api image on merge.

## Files

- `products/catalyst/bootstrap/api/internal/handler/org_handover.go` — on-demand sync + retry when `resolveOrgScope` misses.
- `products/catalyst/bootstrap/api/internal/handler/tenant_registry_reconcile.go` — new `ensureTenantRegisteredForHost` (single-host, best-effort, idempotent).
- `+ tests` for both.

## Tests

- `TestAuthOrgHandover_OnDemandRegistersFunnelOrg` — empty registry + Org CR present → **302 + Org-scoped cookie + host persisted** (the race scenario).
- `TestEnsureTenantRegisteredForHost` — registers the matching host only / fast no-op when already present / refuses an unknown host / no-panic out-of-cluster.
- Existing `TestAuthOrgHandover_*` + `TestReconcileTenantRegistry*` still green.
- Full `internal/handler` package passes under `-race`; `go vet` clean.

## Fresh-voucher walk (the acceptance)

1. Operator mints a voucher in BSS.
2. Stranger opens `marketplace.<fqdn>/redeem/?code=<CODE>` → plans → WordPress → pool domain (e.g. `g4wpsso.omani.works`) → review → checkout.
3. PIN-login (Stalwart magic PIN) → voucher applied → **OMR 0.000 due** → "Launch my tenant".
4. `POST /api/tenant/orgs` 201 → marketplace redirects to `console.<slug>.<pool>/auth/org-handover?token=<member-JWT>`.
5. **Even if the periodic registry tick has not yet fired**, `AuthOrgHandover` on-demand-registers the host → mints the RS256 Org-scoped `catalyst_session` cookie → **302 → /jobs, signed-in on the OWN Org console, zero-click** (no `/login` bounce).
6. The purchased app (WordPress) reconciles into the Org vCluster (the apps-into-vcluster keystone), serving at its pool host.

Base: `fix/4297-apps-into-vcluster` (the #4293/Workstream-A door-collapse keystone). Retarget to `main` once the keystone lands.

`Refs #3376`