### PR TITLE
fix(provisioning): cross-region active-hot-standby — place the CNPG replica in region B, not region A (Refs #4282 #4275)

### DIFF
--- a/core/services/provisioning/gitops/appconfigs_test.go
+++ b/core/services/provisioning/gitops/appconfigs_test.go
@@ -118,7 +118,7 @@ func TestPostgres_AppConfigs_OutOfRangeFallsBack(t *testing.T) {
 		"deadbeef",
 		map[string]map[string]any{
 			"postgres": {
-				"replicas": float64(99), // out of [1,5]
+				"replicas": float64(99),  // out of [1,5]
 				"disk_gb":  float64(999), // out of [1,500]
 			},
 		},
@@ -285,11 +285,12 @@ func TestReadIntCfg_MistypeFallsBack(t *testing.T) {
 // With active_hot_standby=true + distinct primary_region/replica_region,
 // the rendered output MUST:
 //
-//	1. Emit `db-cnpg-pair.yaml` (the bp-cnpg-pair HelmRelease + its
-//	   companion HelmRepository + postgres-credentials Secret).
-//	2. NOT emit `db-postgres.yaml` (the legacy single-Pod Deployment
-//	   would collide on `postgres` Service name and credentials Secret).
-//	3. Carry the customer-chosen region pair into the HelmRelease values.
+//  1. Emit the split-side `db-cnpg-pair-primary.yaml` +
+//     `db-cnpg-pair-replica.yaml` (each a bp-cnpg-pair HelmRelease + its
+//     companion HelmRepository) plus the postgres-credentials Secret.
+//  2. NOT emit `db-postgres.yaml` (the legacy single-Pod Deployment
+//     would collide on `postgres` Service name and credentials Secret).
+//  3. Carry the customer-chosen region pair into the HelmRelease values.
 func TestPostgres_AppConfigs_ActiveHotStandby_GenericApp(t *testing.T) {
 	g := &ManifestGenerator{BasePath: "clusters/contabo-mkt/tenants"}
 	files := g.GenerateAllWithAppConfigs("acme", "flexi",
@@ -306,20 +307,34 @@ func TestPostgres_AppConfigs_ActiveHotStandby_GenericApp(t *testing.T) {
 		},
 	)
 
-	var pairManifest, legacyManifest string
+	var primaryManifest, replicaManifest, legacyManifest string
 	for path, content := range files {
-		if strings.HasSuffix(path, "db-cnpg-pair.yaml") {
-			pairManifest = content
+		if strings.HasSuffix(path, "db-cnpg-pair-primary.yaml") {
+			primaryManifest = content
+		}
+		if strings.HasSuffix(path, "db-cnpg-pair-replica.yaml") {
+			replicaManifest = content
 		}
 		if strings.HasSuffix(path, "db-postgres.yaml") {
 			legacyManifest = content
 		}
 	}
-	if pairManifest == "" {
-		t.Fatal("db-cnpg-pair.yaml NOT generated when active_hot_standby=true — Pillar 3 install path broken")
+	if primaryManifest == "" {
+		t.Fatal("db-cnpg-pair-primary.yaml NOT generated when active_hot_standby=true — Pillar 3 install path broken")
+	}
+	if replicaManifest == "" {
+		t.Fatal("db-cnpg-pair-replica.yaml NOT generated when active_hot_standby=true — cross-region standby broken (#4282)")
 	}
 	if legacyManifest != "" {
 		t.Errorf("legacy db-postgres.yaml ALSO generated alongside cluster-pair — would collide on `postgres` Service")
+	}
+	// Both side files carry the full region pair + sizing; only side + kubeConfig
+	// differ. Assert the side-gates + content on both.
+	if !strings.Contains(primaryManifest, "side: primary") {
+		t.Errorf("primary file missing cnpgPair.side: primary:\n%s", primaryManifest)
+	}
+	if !strings.Contains(replicaManifest, "side: replica") {
+		t.Errorf("replica file missing cnpgPair.side: replica:\n%s", replicaManifest)
 	}
 	must := []string{
 		"chart: bp-cnpg-pair",
@@ -329,9 +344,14 @@ func TestPostgres_AppConfigs_ActiveHotStandby_GenericApp(t *testing.T) {
 		"size: 50Gi",
 		"database: db_umami", // per-app database name
 	}
-	for _, want := range must {
-		if !strings.Contains(pairManifest, want) {
-			t.Errorf("db-cnpg-pair.yaml missing %q — full manifest:\n%s", want, pairManifest)
+	for _, side := range []struct {
+		name     string
+		manifest string
+	}{{"primary", primaryManifest}, {"replica", replicaManifest}} {
+		for _, want := range must {
+			if !strings.Contains(side.manifest, want) {
+				t.Errorf("db-cnpg-pair-%s.yaml missing %q — full manifest:\n%s", side.name, want, side.manifest)
+			}
 		}
 	}
 }
@@ -354,8 +374,8 @@ func TestPostgres_AppConfigs_ActiveHotStandby_OFF(t *testing.T) {
 		},
 	)
 	for path := range files {
-		if strings.HasSuffix(path, "db-cnpg-pair.yaml") {
-			t.Errorf("db-cnpg-pair.yaml emitted with active_hot_standby unset — should default-OFF")
+		if strings.Contains(path, "db-cnpg-pair") {
+			t.Errorf("a db-cnpg-pair-*.yaml emitted with active_hot_standby unset — should default-OFF (%s)", path)
 		}
 	}
 	var legacy string
@@ -377,9 +397,9 @@ func TestPostgres_AppConfigs_ActiveHotStandby_OFF(t *testing.T) {
 // Symmetric with the WP-tenant path (org_tenant_gitops.go:560).
 func TestPostgres_AppConfigs_ActiveHotStandby_InvalidRegionPair(t *testing.T) {
 	cases := []struct {
-		name           string
-		primary        string
-		replica        string
+		name            string
+		primary         string
+		replica         string
 		wantClusterPair bool
 	}{
 		{"identical regions", "hz-fsn-rtz-prod", "hz-fsn-rtz-prod", false},
@@ -405,7 +425,7 @@ func TestPostgres_AppConfigs_ActiveHotStandby_InvalidRegionPair(t *testing.T) {
 			gotPair := false
 			gotLegacy := false
 			for path := range files {
-				if strings.HasSuffix(path, "db-cnpg-pair.yaml") {
+				if strings.HasSuffix(path, "db-cnpg-pair-primary.yaml") || strings.HasSuffix(path, "db-cnpg-pair-replica.yaml") {
 					gotPair = true
 				}
 				if strings.HasSuffix(path, "db-postgres.yaml") {
@@ -448,12 +468,12 @@ func TestPostgres_AppConfigs_ActiveHotStandby_ReplicasClamped(t *testing.T) {
 	)
 	var pairManifest string
 	for path, content := range files {
-		if strings.HasSuffix(path, "db-cnpg-pair.yaml") {
+		if strings.HasSuffix(path, "db-cnpg-pair-primary.yaml") {
 			pairManifest = content
 		}
 	}
 	if pairManifest == "" {
-		t.Fatal("db-cnpg-pair.yaml not generated")
+		t.Fatal("db-cnpg-pair-primary.yaml not generated")
 	}
 	if !strings.Contains(pairManifest, "instances: 3") {
 		t.Errorf("replicas=1 not clamped to instances:3 — full manifest:\n%s", pairManifest)
@@ -504,14 +524,17 @@ func cnpgPairAppConfigs() map[string]map[string]any {
 	}
 }
 
+// cnpgPairManifest returns the PRIMARY-side HR (#4282 split). Both side files
+// carry the same storageClass in both their primary+replica values blocks, so
+// the storage-class occurrence-count assertions hold per-file unchanged.
 func cnpgPairManifest(t *testing.T, files map[string]string) string {
 	t.Helper()
 	for path, content := range files {
-		if strings.HasSuffix(path, "db-cnpg-pair.yaml") {
+		if strings.HasSuffix(path, "db-cnpg-pair-primary.yaml") {
 			return content
 		}
 	}
-	t.Fatal("db-cnpg-pair.yaml NOT generated when active_hot_standby=true — Pillar-3 install path broken")
+	t.Fatal("db-cnpg-pair-primary.yaml NOT generated when active_hot_standby=true — Pillar-3 install path broken")
 	return ""
 }
 
@@ -583,9 +606,9 @@ func TestCNPGStorageClass_Resolver(t *testing.T) {
 		{"huawei", "evs-ssd"},
 		{"Huawei", "evs-ssd"}, // case-insensitive
 		{"hetzner", "hcloud-volumes"},
-		{"", "hcloud-volumes"},        // empty → Hetzner default
+		{"", "hcloud-volumes"},            // empty → Hetzner default
 		{"  hetzner  ", "hcloud-volumes"}, // trimmed
-		{"gcp", "hcloud-volumes"},     // unknown → safe Hetzner fallback
+		{"gcp", "hcloud-volumes"},         // unknown → safe Hetzner fallback
 	}
 	for _, tc := range cases {
 		g := &ManifestGenerator{CloudProvider: tc.provider}

--- a/core/services/provisioning/gitops/apps_into_vcluster_4297_test.go
+++ b/core/services/provisioning/gitops/apps_into_vcluster_4297_test.go
@@ -113,8 +113,10 @@ func TestBoundaryIsVcluster_FunnelParity(t *testing.T) {
 // TestCNPGPair_VclusterTier_HRLevelKubeConfig — the active-hot-standby
 // bp-cnpg-pair HelmRelease is a HelmRelease CR, so it cannot be redirected into
 // the vcluster by the apps-sync Kustomization (no in-cluster helm-controller →
-// #3055 StateError). For the vcluster tier it must be a HOST file carrying
-// HR-level spec.kubeConfig (the host helm-controller installs INTO the vcluster).
+// #3055 StateError). For the vcluster tier the PRIMARY side is a HOST file
+// carrying HR-level spec.kubeConfig (the host helm-controller installs INTO the
+// vcluster on region A). #4282/#4275 — the pair is now SPLIT-SIDE across two
+// host files: db-cnpg-pair-primary.yaml + db-cnpg-pair-replica.yaml.
 func TestCNPGPair_VclusterTier_HRLevelKubeConfig(t *testing.T) {
 	g := NewManifestGenerator(testBasePath)
 	out := g.GenerateAllWithAppConfigs("acme", "m",
@@ -128,32 +130,40 @@ func TestCNPGPair_VclusterTier_HRLevelKubeConfig(t *testing.T) {
 		},
 	)
 
-	// The HR lives as a HOST file (NOT under apps/) so the host helm-controller
-	// reconciles it.
-	hostHR, ok := out[testBasePath+"/acme/db-cnpg-pair.yaml"]
+	// The PRIMARY HR lives as a HOST file (NOT under apps/) so the host
+	// helm-controller reconciles it; it installs the primary INTO the Org
+	// vcluster (region A) via the vcluster kubeconfig mirror.
+	hostHR, ok := out[testBasePath+"/acme/db-cnpg-pair-primary.yaml"]
 	if !ok {
-		t.Fatalf("vcluster-tier CNPG-pair HR not emitted as a HOST file (keys: %v)", keys(out))
+		t.Fatalf("vcluster-tier CNPG-pair PRIMARY HR not emitted as a HOST file (keys: %v)", keys(out))
 	}
-	if _, inApps := out[testBasePath+"/acme/apps/db-cnpg-pair.yaml"]; inApps {
-		t.Errorf("CNPG-pair HR must NOT be in the vcluster-redirected apps/ tree (it would StateError)")
+	// Neither side may land in the vcluster-redirected apps/ tree (StateError).
+	if _, inApps := out[testBasePath+"/acme/apps/db-cnpg-pair-primary.yaml"]; inApps {
+		t.Errorf("CNPG-pair PRIMARY HR must NOT be in the vcluster-redirected apps/ tree (it would StateError)")
+	}
+	if _, inApps := out[testBasePath+"/acme/apps/db-cnpg-pair-replica.yaml"]; inApps {
+		t.Errorf("CNPG-pair REPLICA HR must NOT be in the vcluster-redirected apps/ tree (it would StateError)")
 	}
 	if !strings.Contains(hostHR, "kind: HelmRelease") {
-		t.Errorf("host CNPG-pair file missing HelmRelease:\n%s", hostHR)
+		t.Errorf("host CNPG-pair PRIMARY file missing HelmRelease:\n%s", hostHR)
+	}
+	if !strings.Contains(hostHR, "side: primary") {
+		t.Errorf("PRIMARY HR must set cnpgPair.side: primary:\n%s", hostHR)
 	}
 	if !strings.Contains(hostHR, "kubeConfig:") {
-		t.Errorf("vcluster-tier CNPG-pair HR MISSING HR-level kubeConfig:\n%s", hostHR)
+		t.Errorf("vcluster-tier CNPG-pair PRIMARY HR MISSING HR-level kubeConfig:\n%s", hostHR)
 	}
 	if !strings.Contains(hostHR, "name: tenant-acme-kubeconfig") {
-		t.Errorf("vcluster-tier CNPG-pair HR kubeConfig must reference the mirror secret:\n%s", hostHR)
+		t.Errorf("vcluster-tier CNPG-pair PRIMARY HR kubeConfig must reference the vcluster mirror secret:\n%s", hostHR)
 	}
 	// HR authored in flux-system so the secretRef (no namespace field) resolves
 	// against the co-located mirror.
 	if !strings.Contains(hostHR, "namespace: flux-system") {
-		t.Errorf("vcluster-tier CNPG-pair HR must be authored in flux-system (mirror ns):\n%s", hostHR)
+		t.Errorf("vcluster-tier CNPG-pair PRIMARY HR must be authored in flux-system (mirror ns):\n%s", hostHR)
 	}
 	// Chart installs into the in-vcluster `<slug>` ns where the app pods live.
 	if !strings.Contains(hostHR, "targetNamespace: acme") {
-		t.Errorf("CNPG-pair chart targetNamespace must be the Org <slug> ns acme:\n%s", hostHR)
+		t.Errorf("CNPG-pair PRIMARY chart targetNamespace must be the Org <slug> ns acme:\n%s", hostHR)
 	}
 
 	// The standalone postgres-credentials Secret the app pods read lives INSIDE
@@ -170,10 +180,102 @@ func TestCNPGPair_VclusterTier_HRLevelKubeConfig(t *testing.T) {
 	}
 }
 
-// TestCNPGPair_HostTier_NoKubeConfig — for the host tier the CNPG-pair HR has
-// no vcluster to target, so it carries NO kubeConfig and is authored in the
-// host `<slug>` ns where the chart installs.
-func TestCNPGPair_HostTier_NoKubeConfig(t *testing.T) {
+// TestCNPGPair_XRegion_ReplicaTargetsRegionB is the #4282/#4275 fix lock — the
+// CROSS-REGION standby placement. The replica HR must target REGION B's
+// host-cluster kubeconfig (NOT region A / the vcluster mirror), set
+// cnpgPair.side: replica, and be authored in flux-system next to that mirror.
+// Without this the standby CNPG Cluster lands in region A, its region-B node-
+// affinity matches 0/N nodes, the *-pgbasebackup pod hangs Pending forever, and
+// the region-kill pillar has no standby to fail over to (live demo Org,
+// 2026-06-25). Verified for BOTH tiers — the standby always crosses regions.
+func TestCNPGPair_XRegion_ReplicaTargetsRegionB(t *testing.T) {
+	for _, plan := range []string{"m", "s"} {
+		t.Run("plan="+plan, func(t *testing.T) {
+			g := NewManifestGenerator(testBasePath)
+			out := g.GenerateAllWithAppConfigs("acme", plan,
+				[]string{"umami"}, "pw",
+				map[string]map[string]any{
+					"postgres": {
+						"active_hot_standby": true,
+						"primary_region":     "hz-fsn-rtz-prod",
+						"replica_region":     "hz-hel-rtz-prod",
+					},
+				},
+			)
+			replicaHR, ok := out[testBasePath+"/acme/db-cnpg-pair-replica.yaml"]
+			if !ok {
+				t.Fatalf("CNPG-pair REPLICA HR not emitted as a HOST file (keys: %v)", keys(out))
+			}
+			if !strings.Contains(replicaHR, "side: replica") {
+				t.Errorf("REPLICA HR must set cnpgPair.side: replica so the chart renders the standby Cluster ONLY:\n%s", replicaHR)
+			}
+			// THE FIX: the replica installs THROUGH region-B's host kubeconfig —
+			// not the region-A vcluster mirror — so the standby Cluster lands in
+			// region B where its node-affinity matches.
+			if !strings.Contains(replicaHR, "kubeConfig:") {
+				t.Errorf("REPLICA HR MUST carry an HR-level kubeConfig (region B is a separate cluster):\n%s", replicaHR)
+			}
+			if !strings.Contains(replicaHR, "name: "+replicaRegionKubeSecretDefault) {
+				t.Errorf("REPLICA HR kubeConfig must reference the region-B kubeconfig secret %q (NOT the region-A vcluster mirror):\n%s", replicaRegionKubeSecretDefault, replicaHR)
+			}
+			if strings.Contains(replicaHR, "name: tenant-acme-kubeconfig") {
+				t.Errorf("REPLICA HR must NOT target the region-A vcluster mirror — that lands the standby in region A (the #4282 bug):\n%s", replicaHR)
+			}
+			if !strings.Contains(replicaHR, "namespace: flux-system") {
+				t.Errorf("REPLICA HR must be authored in flux-system next to the region-B mirror:\n%s", replicaHR)
+			}
+			// Both HRs carry the full region pair (validateRegions + the replica's
+			// externalClusters source need both regions present).
+			if !strings.Contains(replicaHR, "region: hz-fsn-rtz-prod") || !strings.Contains(replicaHR, "region: hz-hel-rtz-prod") {
+				t.Errorf("REPLICA HR must carry BOTH primary + replica regions in values:\n%s", replicaHR)
+			}
+			// Distinct HR/release names so primary + replica (both in flux-system)
+			// never collide.
+			if !strings.Contains(replicaHR, "name: bp-cnpg-pair-replica") {
+				t.Errorf("REPLICA HR must use a side-suffixed name to avoid colliding with the primary HR in flux-system:\n%s", replicaHR)
+			}
+			if !strings.Contains(replicaHR, "releaseName: cnpg-pair-replica") {
+				t.Errorf("REPLICA HR must use a side-suffixed releaseName:\n%s", replicaHR)
+			}
+		})
+	}
+}
+
+// TestCNPGPair_XRegion_ReplicaSecretConfigurable — the region-B kubeconfig
+// secret name is overridable via ManifestGenerator.ReplicaRegionKubeSecret
+// (wired from CATALYST_REPLICA_REGION_KUBECONFIG_SECRET) so a Sovereign whose
+// bootstrap mirrors region B under a different name can point the replica HR
+// at it without a code change.
+func TestCNPGPair_XRegion_ReplicaSecretConfigurable(t *testing.T) {
+	g := NewManifestGenerator(testBasePath)
+	g.ReplicaRegionKubeSecret = "my-region-b-kubeconfig"
+	out := g.GenerateAllWithAppConfigs("acme", "m",
+		[]string{"umami"}, "pw",
+		map[string]map[string]any{
+			"postgres": {
+				"active_hot_standby": true,
+				"primary_region":     "hz-fsn-rtz-prod",
+				"replica_region":     "hz-hel-rtz-prod",
+			},
+		},
+	)
+	replicaHR := out[testBasePath+"/acme/db-cnpg-pair-replica.yaml"]
+	if !strings.Contains(replicaHR, "name: my-region-b-kubeconfig") {
+		t.Errorf("REPLICA HR must honour the overridden region-B kubeconfig secret name:\n%s", replicaHR)
+	}
+	// The secretRef must point at the override, not the default (the default
+	// name still appears in the explanatory header comment — assert on the live
+	// `name:` secretRef line, not the whole document).
+	if strings.Contains(replicaHR, "name: "+replicaRegionKubeSecretDefault) {
+		t.Errorf("REPLICA HR secretRef should not fall back to the default when an override is set:\n%s", replicaHR)
+	}
+}
+
+// TestCNPGPair_HostTier_PrimaryNoKubeConfig — for the host tier the PRIMARY side
+// has no vcluster to target, so it carries NO kubeConfig and is authored in the
+// host `<slug>` ns where the chart installs (region A). The REPLICA side still
+// crosses to region B (asserted in TestCNPGPair_XRegion_ReplicaTargetsRegionB).
+func TestCNPGPair_HostTier_PrimaryNoKubeConfig(t *testing.T) {
 	g := NewManifestGenerator(testBasePath)
 	out := g.GenerateAllWithAppConfigs("acme", "s",
 		[]string{"umami"}, "pw",
@@ -185,14 +287,14 @@ func TestCNPGPair_HostTier_NoKubeConfig(t *testing.T) {
 			},
 		},
 	)
-	hostHR, ok := out[testBasePath+"/acme/db-cnpg-pair.yaml"]
+	primaryHR, ok := out[testBasePath+"/acme/db-cnpg-pair-primary.yaml"]
 	if !ok {
-		t.Fatalf("host-tier CNPG-pair HR not emitted (keys: %v)", keys(out))
+		t.Fatalf("host-tier CNPG-pair PRIMARY HR not emitted (keys: %v)", keys(out))
 	}
-	if strings.Contains(hostHR, "kubeConfig:") {
-		t.Errorf("host-tier CNPG-pair HR MUST NOT carry kubeConfig (no vcluster):\n%s", hostHR)
+	if strings.Contains(primaryHR, "kubeConfig:") {
+		t.Errorf("host-tier CNPG-pair PRIMARY HR MUST NOT carry kubeConfig (no vcluster):\n%s", primaryHR)
 	}
-	if !strings.Contains(hostHR, "namespace: acme") {
-		t.Errorf("host-tier CNPG-pair HR must be authored in the host <slug> ns acme:\n%s", hostHR)
+	if !strings.Contains(primaryHR, "namespace: acme") {
+		t.Errorf("host-tier CNPG-pair PRIMARY HR must be authored in the host <slug> ns acme:\n%s", primaryHR)
 	}
 }

--- a/core/services/provisioning/gitops/gitops.go
+++ b/core/services/provisioning/gitops/gitops.go
@@ -163,7 +163,41 @@ type ManifestGenerator struct {
 	// Empty / unknown defaults to "hetzner" so the legacy contabo/Hetzner
 	// path renders hcloud-volumes unchanged (NO-REGRESS).
 	CloudProvider string
+
+	// ReplicaRegionKubeSecret is the flux-system Secret name that holds
+	// the STANDBY region's (region-B) host-cluster kubeconfig. The
+	// cross-region active-hot-standby standby Cluster CR must be reconciled
+	// into region-B's apiserver — NOT region-A's — because region B is the
+	// only place with nodes labelled `openova.io/region=<replica_region>`
+	// that the chart's replica-side node-affinity requires. The host
+	// helm-controller (region A) installs the replica HelmRelease INTO
+	// region B via HR-level `spec.kubeConfig.secretRef: <this>` (#4282/#4275).
+	//
+	// THE BUG (#4282): before this field the per-Org bp-cnpg-pair emitted a
+	// SINGLE HR (chart default `side: primary`) into ONE target cluster, so
+	// the replica half either never rendered or — via the WP-tenant inline
+	// path — landed in region A's cluster where its region-B affinity matched
+	// 0/N nodes → the standby pod (`*-pgbasebackup`) hung Pending for 16h and
+	// the HR install-timeouts. With no standby in region B the region-kill
+	// pillar (#4275) had nothing to fail over to (live demo Org, 2026-06-25).
+	//
+	// Populated from CATALYST_REPLICA_REGION_KUBECONFIG_SECRET in main.go;
+	// empty resolves to the deterministic default
+	// `sovereign-replica-region-kubeconfig` (replicaRegionKubeSecretDefault).
+	// The bootstrap mirrors region-B's host kubeconfig into flux-system under
+	// this name (companion to the secondary-kubeconfig handler that already
+	// persists it on the catalyst-api PVC at
+	// /var/lib/catalyst/kubeconfigs/<depID>-<region>.yaml).
+	ReplicaRegionKubeSecret string
 }
+
+// replicaRegionKubeSecretDefault is the deterministic flux-system Secret
+// name the cross-region standby HelmRelease's spec.kubeConfig.secretRef
+// targets when CATALYST_REPLICA_REGION_KUBECONFIG_SECRET is unset. The
+// bootstrap mirrors region-B's host kubeconfig into flux-system under this
+// name so the host helm-controller can install the replica CNPG Cluster
+// INTO region B (#4282/#4275).
+const replicaRegionKubeSecretDefault = "sovereign-replica-region-kubeconfig"
 
 // defaultVClusterRegistryMirror is the bootstrap Harbor proxy host.
 const defaultVClusterRegistryMirror = "harbor.openova.io"
@@ -196,6 +230,18 @@ func (g *ManifestGenerator) cnpgStorageClass() string {
 			"cloud_provider", g.CloudProvider, "storageClass", hetznerBlockStorageClass)
 		return hetznerBlockStorageClass
 	}
+}
+
+// replicaRegionKubeSecret resolves the flux-system Secret name holding the
+// standby region's (region-B) kubeconfig for the cross-region active-hot-
+// standby HelmRelease's HR-level spec.kubeConfig (#4282/#4275). Empty falls
+// back to the deterministic default the bootstrap mirrors region-B's host
+// kubeconfig into.
+func (g *ManifestGenerator) replicaRegionKubeSecret() string {
+	if s := strings.TrimSpace(g.ReplicaRegionKubeSecret); s != "" {
+		return s
+	}
+	return replicaRegionKubeSecretDefault
 }
 
 func NewManifestGenerator(basePath string) *ManifestGenerator {
@@ -395,9 +441,62 @@ func (g *ManifestGenerator) GenerateAllWithAppConfigs(slug, planSlug string, app
 			// chart target is `<slug>`, co-located with the app pods + the
 			// postgres-credentials Secret.
 			//
-			// HOST-reconciled HelmRelease (+ HelmRepository) with HR-level
-			// kubeConfig → installs the CNPG Clusters INTO the vcluster.
-			hostFiles["db-cnpg-pair.yaml"] = generateCNPGPair(slug, dbPassword, postgresApps, pgCfg, primaryRegion, replicaRegion, g.cnpgStorageClass(), cnpgKubeSecret)
+			// #4282/#4275 — CROSS-REGION SPLIT-SIDE. A 2-region Sovereign is
+			// TWO separate clusters joined by Cilium ClusterMesh; the chart is
+			// already split-side (cnpgPair.side primary|replica — each side
+			// renders ONLY its own Cluster CR, pinned to its region's nodes via
+			// node-affinity). The keystone emitted ONE HR (chart default
+			// side=primary) into ONE target cluster, so the standby Cluster
+			// either never rendered or landed in region-A's cluster where its
+			// region-B affinity matches 0/N nodes → the `*-pgbasebackup` pod
+			// hangs Pending forever and the region-kill pillar has no standby to
+			// fail over to. Fix: emit TWO HRs —
+			//   • PRIMARY side → region A. For the vcluster tier its kubeConfig
+			//     targets the Org vcluster (which lives on region A's host); the
+			//     primary Cluster's region-A affinity matches the local nodes.
+			//   • REPLICA side → region B. Its kubeConfig targets region-B's
+			//     host-cluster kubeconfig (the flux-system mirror), so the host
+			//     helm-controller installs the standby Cluster INTO region B,
+			//     where the matching `openova.io/region=<replica_region>` nodes
+			//     live. THIS is the cross-region placement the keystone's
+			//     spec.kubeConfig mechanism extended to the standby region.
+			// Both HRs carry the SAME full values (both regions + both storage
+			// blocks) so the chart's validateRegions + the replica's
+			// externalClusters source resolve; only `cnpgPair.side` and the
+			// kubeConfig differ. This mirrors the bootstrap-kit slot-16b path
+			// where each region's own Flux installs its side from the same chart.
+			hostFiles["db-cnpg-pair-primary.yaml"] = generateCNPGPair(cnpgPairOpts{
+				side:          "primary",
+				ns:            slug,
+				password:      dbPassword,
+				apps:          postgresApps,
+				cfg:           pgCfg,
+				primaryRegion: primaryRegion,
+				replicaRegion: replicaRegion,
+				storageClass:  g.cnpgStorageClass(),
+				kubeSecret:    cnpgKubeSecret,
+			})
+			// The replica HR ALWAYS carries a kubeConfig — even for the host
+			// tier — because the standby Cluster MUST land in region B's cluster,
+			// a DIFFERENT physical cluster than the host Flux's own (region A).
+			// For the host tier there is no vcluster, so the chart installs into
+			// region B's host `<slug>` ns; for the vcluster tier region B has no
+			// per-Org vcluster mirror, so the standby CNPG Cluster lands in region
+			// B's host `<slug>` ns and streams WAL to the region-A primary over
+			// ClusterMesh (CNPG replica clusters are mesh-reachable regardless of
+			// which side runs inside a vcluster). The target namespace is `<slug>`
+			// in region B either way.
+			hostFiles["db-cnpg-pair-replica.yaml"] = generateCNPGPair(cnpgPairOpts{
+				side:          "replica",
+				ns:            slug,
+				password:      dbPassword,
+				apps:          postgresApps,
+				cfg:           pgCfg,
+				primaryRegion: primaryRegion,
+				replicaRegion: replicaRegion,
+				storageClass:  g.cnpgStorageClass(),
+				kubeSecret:    g.replicaRegionKubeSecret(),
+			})
 			// The standalone postgres-credentials Secret the app pods read goes
 			// INSIDE the vcluster (apps/ tree), co-located with the app pods. It
 			// is authored with the apps-tree namespace ("apps"); the apps-sync
@@ -829,11 +928,52 @@ spec:
 // (where the apps-sync-rewritten app pods + postgres-credentials Secret live);
 // for the host tier the chart installs into the host `<slug>` ns.
 //
-// kubeSecret is the flux-system-co-located vcluster kubeconfig mirror
-// (`tenant-<slug>-kubeconfig`); empty for the host tier (no vcluster → the HR
-// reconciles on the host and the chart installs into the host `<slug>` ns).
-func generateCNPGPair(ns, password string, apps []string, cfg map[string]any, primaryRegion, replicaRegion, storageClass, kubeSecret string) string {
-	sortedApps := sortStrings(append([]string{}, apps...))
+// kubeSecret is the flux-system-co-located kubeconfig mirror the host
+// helm-controller installs THROUGH:
+//   - PRIMARY side, vcluster tier → `tenant-<slug>-kubeconfig` (the Org
+//     vcluster, on region A's host). Empty for the host tier (no vcluster →
+//     the HR reconciles on the host + chart installs into the host `<slug>`).
+//   - REPLICA side → ALWAYS the region-B host-cluster kubeconfig
+//     (`sovereign-replica-region-kubeconfig`), so the standby Cluster lands in
+//     region B where its region-B node-affinity matches the local nodes
+//     (#4282/#4275). Region B is a DIFFERENT physical cluster than region A's
+//     host Flux, so a kubeConfig is mandatory even for the host tier.
+//
+// #4282/#4275 — SPLIT-SIDE. opt.side selects WHICH half of the pair this HR
+// renders (the chart is side-gated: side=primary renders ONLY the primary
+// Cluster + mesh Service, side=replica renders ONLY the replica Cluster +
+// failover probe). The two sides MUST be installed into DIFFERENT regions'
+// clusters; a single HR (the keystone shape) could only ever reach one. The
+// HR / HelmRepository / releaseName are suffixed `-<side>` so the primary and
+// replica HRs (both authored in flux-system) never collide.
+
+// cnpgPairOpts is the option bag for generateCNPGPair — keeping the call site
+// readable now that side + per-side kubeConfig are threaded through.
+type cnpgPairOpts struct {
+	side          string // "primary" | "replica" — selects the chart's side-gate
+	ns            string // chart targetNamespace (= Org <slug>)
+	password      string
+	apps          []string
+	cfg           map[string]any
+	primaryRegion string
+	replicaRegion string
+	storageClass  string
+	kubeSecret    string // flux-system kubeconfig mirror the HR installs THROUGH
+}
+
+func generateCNPGPair(opt cnpgPairOpts) string {
+	ns := opt.ns
+	side := strings.TrimSpace(opt.side)
+	if side != "primary" && side != "replica" {
+		// Defensive: callers pass a literal; an unexpected side would render a
+		// chart the side-gate fails. Default to primary (the chart's own
+		// default) + log so the gap is visible rather than emitting garbage.
+		slog.Warn("generateCNPGPair: unexpected side — defaulting to primary",
+			"side", opt.side)
+		side = "primary"
+	}
+
+	sortedApps := sortStrings(append([]string{}, opt.apps...))
 	primaryDB := "appdb"
 	if len(sortedApps) > 0 {
 		primaryDB = "db_" + sortedApps[0]
@@ -847,7 +987,7 @@ func generateCNPGPair(ns, password string, apps []string, cfg map[string]any, pr
 	// (active-hot-standby HA requires a 3-node quorum per region). If
 	// the customer chose 1-2 we clamp to 3 and log loud so the gap is
 	// operator-visible.
-	requested := readIntCfg(cfg, "replicas", 3, 1, 5, "postgres")
+	requested := readIntCfg(opt.cfg, "replicas", 3, 1, 5, "postgres")
 	instances := requested
 	if instances < 3 {
 		slog.Warn("generateCNPGPair: replicas < 3 incompatible with active-hot-standby quorum — clamping to 3",
@@ -859,43 +999,57 @@ func generateCNPGPair(ns, password string, apps []string, cfg map[string]any, pr
 	// default of 100Gi when customer doesn't pick — but we default to
 	// the configSchema's 5GB floor for predictability + parity with
 	// the legacy single-cluster path).
-	diskGB := readIntCfg(cfg, "disk_gb", 5, 1, 500, "postgres")
+	diskGB := readIntCfg(opt.cfg, "disk_gb", 5, 1, 500, "postgres")
 
-	// HR-level kubeConfig (vcluster tier only). Flux's HelmRelease secretRef
-	// accepts name+key only — the namespace is implied from the HR's OWN
-	// namespace. The provisioning workflow mirrors `<slug>/vc-vcluster` →
-	// `flux-system/tenant-<slug>-kubeconfig`, so for the secretRef to resolve
-	// the HR (+ its HelmRepository) must ALSO live in flux-system. Authoring the
-	// HR in flux-system for the vcluster tier keeps the kubeconfig reachable and
-	// mirrors the apps-sync CR's placement. Host tier omits kubeConfig and the
-	// HR is authored in the host `<slug>` ns (= ns) where the chart installs.
+	// HR-level kubeConfig. Flux's HelmRelease secretRef accepts name+key only —
+	// the namespace is implied from the HR's OWN namespace — so for the secretRef
+	// to resolve the HR (+ its HelmRepository) must live alongside the mirror in
+	// flux-system. PRIMARY side, host tier carries NO kubeConfig (no vcluster →
+	// the HR reconciles on region A's host + chart installs into the host
+	// `<slug>` ns). REPLICA side ALWAYS carries a kubeConfig (region B is a
+	// separate cluster). When kubeSecret is set, author the HR in flux-system
+	// next to the mirror; otherwise author it in the host `<slug>` ns.
 	hrNamespace := ns
 	kubeConfigBlock := ""
-	if kubeSecret != "" {
+	if opt.kubeSecret != "" {
 		hrNamespace = "flux-system"
 		kubeConfigBlock = fmt.Sprintf(`
   kubeConfig:
     secretRef:
       name: %s
-      key: config`, kubeSecret)
+      key: config`, opt.kubeSecret)
 	}
 
-	return fmt.Sprintf(`# bp-cnpg-pair — Pillar-3 active-hot-standby install path for
-# postgres-backed marketplace apps (TBD-V17 #2068). Renders the
-# primary + replica CNPG Cluster CR pair across the two regions the
-# customer picked at signup. Synchronous WAL replication over Cilium
-# ClusterMesh; failover-readiness probe + audit ConfigMap wired by the
-# chart's own templates (platform/cnpg-pair/chart/templates/*).
+	// Per-side resource names so the primary + replica HRs (both in flux-system)
+	// never collide. The releaseName stays distinct too so the host
+	// helm-controller tracks two independent releases.
+	hrName := "bp-cnpg-pair-" + side
+	releaseName := "cnpg-pair-" + side
+
+	return fmt.Sprintf(`# bp-cnpg-pair (%s side) — Pillar-3 active-hot-standby install path for
+# postgres-backed marketplace apps (TBD-V17 #2068). A 2-region Sovereign is
+# TWO separate clusters joined by Cilium ClusterMesh, so the pair is installed
+# SPLIT-SIDE (chart 0.2.0): this HR renders ONLY the %s Cluster CR + its
+# side-local resources, pinned to its region's nodes via node-affinity.
 #
-# #4297 — HOST-reconciled HR with HR-level spec.kubeConfig (vcluster tier):
-# the host helm-controller installs the chart INTO the Org vCluster API so
-# the chart's CNPG Clusters land inside the vcluster. The companion
-# postgres-credentials Secret is emitted separately into the apps/ tree
-# (generateCNPGPairSecret) so the in-vcluster app pods can read it.
+# #4282/#4275 — the %s side is installed INTO its OWN region's cluster via the
+# HR-level spec.kubeConfig below. The PRIMARY side lands in region A (the host
+# Flux's own cluster / the Org vcluster on it); the REPLICA side lands in
+# region B (sovereign-replica-region-kubeconfig), where the
+# openova.io/region=%s nodes the replica node-affinity requires actually live.
+# Before this split the standby Cluster landed in region A and its
+# region-B affinity matched 0/N nodes → the *-pgbasebackup pod hung Pending
+# and the region-kill pillar had no standby to fail over to.
+#
+# Synchronous WAL replication over Cilium ClusterMesh; failover-readiness probe
+# + audit ConfigMap wired by the chart's own side-gated templates
+# (platform/cnpg-pair/chart/templates/*). The companion postgres-credentials
+# Secret is emitted separately into the apps/ tree (generateCNPGPairSecret) so
+# the in-vcluster app pods can read it.
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
 metadata:
-  name: bp-cnpg-pair
+  name: %s
   namespace: %s
 spec:
   type: oci
@@ -907,27 +1061,32 @@ spec:
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: bp-cnpg-pair
+  name: %s
   namespace: %s
   labels:
     catalyst.openova.io/component: cnpg-pair
+    catalyst.openova.io/cnpg-pair-side: %s
     openova.io/category: customer-facing-capability
     openova.io/pillar: "3"
 spec:
   interval: 15m
-  releaseName: cnpg-pair
+  releaseName: %s
   targetNamespace: %s%s
   chart:
     spec:
       chart: bp-cnpg-pair
-      # 0.1.2 — first version with synchronous replication default
-      # (remote_apply, numSync=1 — #2064 ship). Pinned via the
-      # bootstrap-kit slot when one lands (currently install via the
-      # vCluster HelmRepository above).
-      version: 0.1.2
+      # 0.2.7 — split-side topology (cnpgPair.side primary|replica): each
+      # side renders ONLY its own Cluster CR so the replica's region-B
+      # node-affinity matches the cluster it is APPLIED to. ≤0.1.x (the
+      # keystone's 0.1.2 pin) rendered BOTH Clusters in one release + relied
+      # on node-affinity to schedule each to its region — IMPOSSIBLE on two
+      # separate ClusterMesh clusters, so the replica wedged Pending forever
+      # in region A (#4282). The side-gate landed in 0.2.0; 0.2.7 is the
+      # current published chart.
+      version: 0.2.7
       sourceRef:
         kind: HelmRepository
-        name: bp-cnpg-pair
+        name: %s
         namespace: %s
   install:
     timeout: 15m
@@ -940,6 +1099,10 @@ spec:
   values:
     cnpgPair:
       enabled: true
+      # Which half of the pair this HR renders. Both HRs carry the SAME full
+      # values (both regions + both storage blocks) so validateRegions + the
+      # replica's externalClusters source resolve; only side + kubeConfig differ.
+      side: %s
       primary:
         region: %s
         instances: %d
@@ -963,7 +1126,15 @@ spec:
       # clusterMesh.enabled + audit subjects). Per-Sovereign overlays
       # may patch values via Flux postBuild substitute; we intentionally
       # do NOT override here.
-`, hrNamespace, hrNamespace, ns, kubeConfigBlock, hrNamespace, primaryRegion, instances, diskGB, storageClass, primaryDB, replicaRegion, instances, diskGB, storageClass)
+`,
+		side, side, side, opt.replicaRegion, // header comment
+		hrName, hrNamespace, // HelmRepository name/ns
+		hrName, hrNamespace, side, releaseName, ns, kubeConfigBlock, // HR metadata + spec head
+		hrName, hrNamespace, // sourceRef name/ns
+		side,                                                              // cnpgPair.side
+		opt.primaryRegion, instances, diskGB, opt.storageClass, primaryDB, // primary block
+		opt.replicaRegion, instances, diskGB, opt.storageClass, // replica block
+	)
 }
 
 // generateCNPGPairSecret emits the standalone postgres-credentials Secret the

--- a/core/services/provisioning/main.go
+++ b/core/services/provisioning/main.go
@@ -11,8 +11,8 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 
-	ghclient "github.com/openova-io/openova/core/services/provisioning/github"
 	"github.com/openova-io/openova/core/services/provisioning/gitguard"
+	ghclient "github.com/openova-io/openova/core/services/provisioning/github"
 	"github.com/openova-io/openova/core/services/provisioning/gitops"
 	"github.com/openova-io/openova/core/services/provisioning/handlers"
 	"github.com/openova-io/openova/core/services/provisioning/store"
@@ -179,6 +179,18 @@ func main() {
 	// forever → Pillar-3 silently dead for tenant Orgs. Empty / unknown
 	// defaults to the Hetzner class inside gitops.cnpgStorageClass().
 	generator.CloudProvider = getEnv("CLOUD_PROVIDER", "hetzner")
+
+	// #4282/#4275 CROSS-REGION STANDBY: the flux-system Secret name holding
+	// region-B's (the STANDBY region's) host-cluster kubeconfig. The per-Org
+	// active-hot-standby bp-cnpg-pair is now split-side — the primary HR lands
+	// in region A (host Flux's own cluster), the REPLICA HR is installed THROUGH
+	// this kubeconfig INTO region B, where the openova.io/region=<replica_region>
+	// nodes the standby's node-affinity requires actually live. Without this the
+	// standby Cluster landed in region A → 0/N node match → pgbasebackup Pending
+	// forever + no standby for the region-kill pillar (#4275). Empty falls back
+	// to the deterministic default `sovereign-replica-region-kubeconfig` the
+	// bootstrap mirrors region-B's kubeconfig into.
+	generator.ReplicaRegionKubeSecret = getEnv("CATALYST_REPLICA_REGION_KUBECONFIG_SECRET", "")
 
 	// ── Git host coordinates (issue #940) ────────────────────────────
 	// On Sovereigns the canonical Git target is the local Gitea (the

--- a/products/catalyst/chart/templates/org-services/provisioning.yaml
+++ b/products/catalyst/chart/templates/org-services/provisioning.yaml
@@ -412,6 +412,16 @@ spec:
             # provisioning defaults to "hetzner" (NO-REGRESS for contabo).
             - name: CLOUD_PROVIDER
               value: {{ .Values.global.cloudProvider | default "" | quote }}
+            # #4282/#4275 CROSS-REGION STANDBY: the flux-system Secret holding
+            # region-B's (the STANDBY region's) host-cluster kubeconfig. The
+            # per-Org active-hot-standby bp-cnpg-pair is split-side — the replica
+            # HR installs THROUGH this kubeconfig INTO region B so the standby
+            # CNPG Cluster lands where its openova.io/region=<replica_region>
+            # nodes live (NOT region A, where it wedged Pending forever). Empty →
+            # provisioning defaults to "sovereign-replica-region-kubeconfig",
+            # the name the bootstrap mirrors region-B's kubeconfig into.
+            - name: CATALYST_REPLICA_REGION_KUBECONFIG_SECRET
+              value: {{ .Values.orgServices.provisioning.replicaRegionKubeconfigSecret | default "" | quote }}
             - name: CATALOG_URL
               valueFrom:
                 configMapKeyRef:

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -2026,6 +2026,18 @@ orgServices:
     # harbor.openova.io for bootstrap; cutover Step-04 (ADR-0002) flips it to
     # harbor.<sovereign-fqdn> post-handover. Operator-overridable (Principle #4).
     vclusterImageRegistry: "harbor.openova.io"
+    # replicaRegionKubeconfigSecret (#4282/#4275 CROSS-REGION STANDBY): the
+    # flux-system Secret name holding region-B's (the STANDBY region's)
+    # host-cluster kubeconfig. The per-Org active-hot-standby bp-cnpg-pair is
+    # split-side — the replica HelmRelease installs THROUGH this kubeconfig
+    # INTO region B so the standby CNPG Cluster lands where its
+    # openova.io/region=<replica_region> nodes live (NOT region A, where the
+    # standby Cluster's region-B node-affinity matched 0/N nodes and the
+    # *-pgbasebackup pod hung Pending forever — the live #4282 failure). Empty
+    # → provisioning defaults to "sovereign-replica-region-kubeconfig", the
+    # name the bootstrap mirrors region-B's kubeconfig into. Operator-
+    # overridable (Principle #4).
+    replicaRegionKubeconfigSecret: ""
     # githubToken: Secret name + key the Deployment reads GITHUB_TOKEN
     # from. Defaults match the chart-emitted
     # templates/org-services/provisioning-github-token.yaml output


### PR DESCRIPTION
## What / Why

The per-Org active-hot-standby `bp-cnpg-pair` emitted **one** host-Flux HelmRelease (chart default `side: primary`) into **one** target cluster. The standby Cluster either never rendered, or — via the legacy WP-tenant inline path — landed in **region A's** cluster, where its region-B node-affinity (`openova.io/region=<replica_region>`) matched **0/N** nodes → the `*-pgbasebackup` pod hung **Pending for 16h**, the HR install-timed-out (`False`), and the region-kill pillar (#4275) had **no standby to fail over to**.

Caught live on the demo Org's `wordpress-db-replica` (2026-06-25, see #4282 comments):
- replica pod requires `openova.io/region In [hw-me-east-215-b-rtz-prod]` (region B)
- but instantiated in `omantel-region-a` → `0/6 nodes matched` → Pending forever
- region B has the matching nodes **+ an empty ready namespace** waiting

## The fix — cross-region split-side placement

A 2-region Sovereign is **two separate k8s clusters** joined by Cilium ClusterMesh. The `bp-cnpg-pair` chart is already split-side (`cnpgPair.side` primary|replica — each side renders **only** its own Cluster CR, pinned to its region via node-affinity). The keystone (#4297) introduced the `spec.kubeConfig`-into-the-target-cluster mechanism for per-Org apps; this PR **extends it to the standby region**.

`core/services/provisioning/gitops/gitops.go`:
- `generateCNPGPair` now takes a `cnpgPairOpts{side,...}` and emits side-suffixed HR / HelmRepository / `releaseName` (no flux-system collision).
- `GenerateAllWithAppConfigs` emits **two** host files:
  - `db-cnpg-pair-primary.yaml` — `side=primary` → **region A** (the vcluster mirror for the vcluster tier; no kubeConfig for the host tier).
  - `db-cnpg-pair-replica.yaml` — `side=replica` → **ALWAYS region B's** host-cluster kubeconfig (`sovereign-replica-region-kubeconfig`), so the host helm-controller installs the standby Cluster **INTO region B** where the matching nodes live. Region B is a different physical cluster, so the replica carries a kubeConfig even for the host tier.
- Both HRs carry the **same full values** (both regions + both storage blocks) so `validateRegions` + the replica's `externalClusters` source resolve; only `side` + `kubeConfig` differ — exactly the bootstrap-kit slot-16b shape.
- Chart pin **0.1.2 → 0.2.7**: 0.1.2 was the **pre-split** chart that rendered both Clusters in one release (the root of the mis-placement); 0.2.7 is the current published split-side chart with the side-gate.

Region-B kubeconfig secret name:
- `ManifestGenerator.ReplicaRegionKubeSecret` (env `CATALYST_REPLICA_REGION_KUBECONFIG_SECRET`); empty → deterministic default `sovereign-replica-region-kubeconfig` (the name the bootstrap mirrors region-B's host kubeconfig into — companion to the existing `sovereign_secondary_kubeconfig` handler that already persists it on the catalyst-api PVC).
- catalyst chart: wire the env + `values.orgServices.provisioning.replicaRegionKubeconfigSecret`.

## Tests / validation
- `go build/vet/test ./...` green (provisioning module).
- New unit tests: replica HR targets the **region-B** kubeconfig (NOT the region-A vcluster mirror) for both M and S tiers; side-gates (`side: primary` / `side: replica`); side-suffixed HR/release names; configurable secret name; updated the split-file region/storage/clamp locks.
- `helm template` of the cnpg-pair chart confirms `side=primary` renders **only** the primary Cluster (`openova.io/region: hz-fsn-rtz-prod`) and `side=replica` renders **only** the replica Cluster pinned to region B (node-affinity `values: ["hz-hel-rtz-prod"]`).
- Both rendered HR files parse as valid multi-doc YAML.

## Fresh-prov region-kill walk (acceptance)
1. Fresh-prov a 2-region Sovereign on a train carrying this + the keystone; bootstrap mirrors region-B's kubeconfig into `flux-system/sovereign-replica-region-kubeconfig`.
2. From the console, provision a PostgreSQL (or postgres-backed app) Application with `active_hot_standby=true` + distinct primary/replica regions.
3. Verify: `db-cnpg-pair-primary.yaml` → primary Cluster Ready in **region A**; `db-cnpg-pair-replica.yaml` → replica Cluster Ready in **region B** (`kubectl --kubeconfig <regionB> get cluster.postgresql.cnpg.io -A` shows the `-replica` Cluster; its `*-pgbasebackup` completes, no Pending). HR goes `True`.
4. Kill region A → CNPG/Continuum promotes the region-B standby; app reconnects. Screenshot + `kubectl get cluster` evidence both regions on the issue.

## Scope notes
- Builds on `fix/4297-apps-into-vcluster` (the #4293 keystone). READ-ONLY on live; no live mutation, no force-reconcile, no catalyst-api restart.
- `Refs #4282 #4275` (NOT Closes — the issue closes only after the operator's fresh-prov region-kill walk-with-screenshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)