### PR TITLE
feat(catalyst+bp-agenity): per-Org openova-MCP Catalyst bearer + verify-pubkey — close #4276 hop 7/7b (the agentic create_application credential)

### DIFF
--- a/products/agenity/README.md
+++ b/products/agenity/README.md
@@ -100,8 +100,13 @@ private base image (`ghcr.io/agenity-org/chepherd`) is gone.
 - **Multi-region**: single-region `singleton` only — Agenity is a
   per-Org control surface, not a replicated data plane.
 - **Auth**: the Agenity console is reached via the Cilium Gateway HTTPRoute
-  with the Org's Keycloak SSO (silent login). The agent presents the User's
-  session bearer to the openova MCP on each `tools/call`.
+  with the Org's Keycloak SSO (silent login). The agent's openova MCP calls
+  catalyst-api with an **Org-scoped service bearer** projected into the pod as
+  `OPENOVA_MCP_BEARER` (see the next section, #4276). The MCP verifies its own
+  bearer against the seeded RS256 pubkey (`OPENOVA_MCP_RS256_PUBKEY_PEM`); a
+  future enhancement may additionally forward the live User's per-call
+  `_auth.token` from the chat UI, but the auto-seeded service bearer is what
+  makes the agentic `create_application` journey work zero-touch today.
 
 ## Seeding the `catalyst/anthropic/token` openbao path (#4277 / #4111 / #4228)
 
@@ -221,6 +226,57 @@ one-time seed.
 > credential. Absent-and-unseeded (the ExternalSecret renders, the key is
 > simply missing) is the correct pre-seed state; the operator's one `bao kv put`
 > is the activation.
+
+## The openova-MCP Catalyst bearer (#4276 hop 7 — the create_application credential)
+
+Seeding the Anthropic credential (above) only lets the spawned `claude-code`
+talk to **Anthropic**. It does **not** give the agent a **Catalyst** identity to
+call `create_application`. The openova MCP forwards a **session bearer** to
+catalyst-api on every tool call, resolved from either a per-call `_auth.token`
+argument **or** the `OPENOVA_MCP_BEARER` env. On a fresh funnel Org neither was
+supplied, so every `create_application` returned **`-32001 unauthenticated`** —
+even with the Anthropic key seeded. #4276 closes that gap (hop 7) plus the
+coupled verify-pubkey gap (hop 7b).
+
+**Auto-seeded at Org-create (#4276).** The catalyst-api producer `seedMCPBearer`
+(called from `runOrganizationPipeline`, right beside `seedAnthropicToken`):
+
+1. **Mints an Org-scoped session JWT** via the handover signer
+   (`SignCustomClaims`) — the byte-for-byte shape `HandlePinVerify` /
+   `auth_org_handover` mint for an Org customer session: `tier=org-admin`,
+   `role=openova-user`, `typ=session`, `org`+`org_id=<slug>`,
+   `realm_access.roles=[org-admin]`, `iss=<CATALYST_PIN_ISSUER>`, RS256-signed.
+   This resolves in the MCP to `(context=organization, tier=admin, org_id=<org>)`
+   → `create_application` (`MinTier=Admin`) is allowed AND routes to the own-org
+   `POST /api/v1/org/applications` path (#4116); cross-Org create stays
+   forbidden. A sovereign-admin bearer would be **wrong** here (it 403s under the
+   #4110 host-scope guard).
+2. **Emits the matching RS256 verify pubkey** as PKIX **PEM** — the public half
+   of the same signer, the exact format `OPENOVA_MCP_RS256_PUBKEY_PEM` parses
+   (`x509.ParsePKIXPublicKey`). Bearer + verify-key travel together (gap 7b),
+   sidestepping the JWK-vs-PEM cross-namespace mismatch the host
+   `catalyst-handover-jwt-public` mirror (a JWK) would otherwise impose (#4228).
+3. **Writes both** to the **per-Org** OpenBao path
+   `secret/catalyst/agenity/<slug>/mcp-bearer` (properties `bearer` + `pubkeyPem`)
+   — per-Org because the bearer carries the Org slug, unlike the cluster-shared
+   Anthropic path. Same `catalyst/`-prefix write-policy reasoning as above.
+
+The chart's `templates/externalsecret-mcp-bearer.yaml` pulls both into the
+per-Org Secret `agenity-mcp-bearer`; the org-gitops emitter points
+`openovaMCP.bearerSecret` + `openovaMCP.rs256PubkeySecret` at it so the
+StatefulSet projects `OPENOVA_MCP_BEARER` + `OPENOVA_MCP_RS256_PUBKEY_PEM`. No
+per-Org hand action — zero-touch by construction.
+
+**TTL + re-mint.** A session JWT expires. The StatefulSet is long-lived, so the
+bearer is minted with a **1-year** service-identity TTL and **re-seeded
+idempotently on every Org reconcile** (`PutKVv2` overwrites — each reconcile
+pushes the expiry window forward). This mirrors the #4303 Anthropic-blob
+re-seed and the OAuth-expiry pre-flight class #4111 documents.
+
+> **Why not chart-seed the bearer/pubkey?** Same reflector/ESO empty-seed trap:
+> a Helm placeholder would pin an empty bearer forever. The values default
+> `mcpBearer.externalSecret.enabled=false` (no producer outside a Sovereign
+> Org-pipeline); the emitter enables it with the per-Org `remoteKey`.
 
 ## What the fresh-prov walk should see
 

--- a/products/agenity/blueprint.yaml
+++ b/products/agenity/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.5.8
+  version: 0.5.9
   card:
     title: Agenity
     summary: |

--- a/products/agenity/chart/Chart.yaml
+++ b/products/agenity/chart/Chart.yaml
@@ -8,6 +8,20 @@ description: |
   (RBAC-scoped to the User's rights) to create more Applications in the
   User's own Organization — the north-star self-service journey.
 type: application
+# 0.5.8 -> 0.5.9 (#4276 hop 7/7b): add the per-Org openova-MCP Catalyst-bearer
+# seam — templates/externalsecret-mcp-bearer.yaml + the openovaMCP.mcpBearer
+# values block. The catalyst-api org-pipeline producer (seedMCPBearer) mints an
+# Org-scoped session JWT (tier=org-admin, org_id=<slug>, role=openova-user,
+# typ=session, RS256-signed by the Sovereign handover signer) AND the matching
+# RS256 verify PUBKEY (PKIX PEM), writing BOTH to secret/catalyst/agenity/
+# <slug>/mcp-bearer. This ExternalSecret pulls them into the per-Org Secret
+# agenity-mcp-bearer; the org-gitops emitter points openovaMCP.bearerSecret +
+# rs256PubkeySecret at it so the StatefulSet projects OPENOVA_MCP_BEARER +
+# OPENOVA_MCP_RS256_PUBKEY_PEM. Closes the hop-7 gap: without a bearer the
+# spawned claude-code agent reached the openova MCP unauthenticated (-32001),
+# even after the Anthropic key (#4277) was seeded. externalSecret defaults to
+# DISABLED (no producer outside a Sovereign Org-pipeline); the emitter enables
+# it. Template-only change; appVersion unchanged.
 # 0.5.7 -> 0.5.8 (#4277): the anthropic ExternalSecret remoteKey moves from the
 # bare `anthropic/token` to `catalyst/anthropic/token`. A Sovereign has NO
 # writer for `secret/anthropic/*` (the external-secrets role vault-region1
@@ -62,7 +76,7 @@ type: application
 # `ingress` entity that no K8s NetworkPolicy can admit — without the CNP every
 # external hit to agenity.<slug>.<pool> returned envoy 503 "upstream connect
 # error". appVersion (dashboard image) stays 0.9.6 — image bytes unchanged.
-version: 0.5.8
+version: 0.5.9
 # Bumped appVersion 0.9.6 -> 0.9.7 (#4180): 0.9.7 is the FIRST image whose
 # /app/ mounts the WORKSPACES dashboard (Dashboardws bundle) rather than the
 # archaic single-column Dashboard.svelte. It is built from agenity#752

--- a/products/agenity/chart/templates/externalsecret-mcp-bearer.yaml
+++ b/products/agenity/chart/templates/externalsecret-mcp-bearer.yaml
@@ -1,0 +1,45 @@
+{{- if and .Values.openovaMCP.enabled .Values.openovaMCP.mcpBearer.externalSecret.enabled (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1") }}
+# Per-Org openova-MCP Catalyst bearer + RS256 verify-pubkey (#4276 hop 7/7b)
+# — pulled from the Org's openbao into the K8s Secret the StatefulSet
+# projects as OPENOVA_MCP_BEARER + OPENOVA_MCP_RS256_PUBKEY_PEM. Neither
+# value is ever written into the chart (Inviolable Principle #4 /
+# SECURITY.md); they are minted by the catalyst-api org-pipeline producer
+# (seedMCPBearer) and written to secret/catalyst/agenity/<slug>/mcp-bearer.
+#
+# Why bearer + pubkey in ONE Secret: the pubkey that VERIFIES the bearer is
+# the public half of the SAME handover signer that minted it; seeding both
+# through one path/ExternalSecret sidesteps the JWK-vs-PEM cross-namespace
+# mismatch the host catalyst-handover-jwt-public mirror would otherwise
+# impose (#4228).
+#
+# ESO-CRD guard (gold standard: bp-openbao sso-oauth-source-externalsecret):
+# without the Capabilities check, installing on a cluster where the
+# external-secrets.io CRDs are not yet established fails at manifest-build
+# time and wedges the install. With the guard, the resource is omitted
+# until the next Flux reconcile re-renders once the CRD exists.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.openovaMCP.mcpBearer.secretName }}
+  labels:
+    {{- include "agenity.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.openovaMCP.mcpBearer.externalSecret.refreshInterval }}
+  secretStoreRef:
+    name: {{ .Values.openovaMCP.mcpBearer.externalSecret.secretStoreRef }}
+    kind: {{ .Values.openovaMCP.mcpBearer.externalSecret.secretStoreKind }}
+  target:
+    name: {{ .Values.openovaMCP.mcpBearer.secretName }}
+    creationPolicy: Owner
+  data:
+    # The Org-scoped Catalyst session JWT the MCP forwards to catalyst-api.
+    - secretKey: {{ .Values.openovaMCP.mcpBearer.bearerKey }}
+      remoteRef:
+        key: {{ .Values.openovaMCP.mcpBearer.externalSecret.remoteKey }}
+        property: {{ .Values.openovaMCP.mcpBearer.externalSecret.remoteBearerProperty }}
+    # The RS256 PKIX public key (PEM) the MCP verifies that bearer with.
+    - secretKey: {{ .Values.openovaMCP.mcpBearer.pubkeyKey }}
+      remoteRef:
+        key: {{ .Values.openovaMCP.mcpBearer.externalSecret.remoteKey }}
+        property: {{ .Values.openovaMCP.mcpBearer.externalSecret.remotePubkeyProperty }}
+{{- end }}

--- a/products/agenity/chart/values.yaml
+++ b/products/agenity/chart/values.yaml
@@ -170,6 +170,45 @@ openovaMCP:
     name: ""
     key: bearer
 
+  # ── Per-Org MCP bearer + verify-pubkey ExternalSecret (#4276 hop 7/7b) ───
+  # The PRODUCER side of the OPENOVA_MCP_BEARER + OPENOVA_MCP_RS256_PUBKEY_PEM
+  # wiring. The catalyst-api org-pipeline (seedMCPBearer, #4276) mints an
+  # Org-scoped Catalyst session JWT (tier=org-admin, org_id=<slug>,
+  # role=openova-user, typ=session, RS256-signed by the Sovereign handover
+  # signer) AND the matching RS256 verify PUBKEY (PKIX PEM), and writes BOTH
+  # to the per-Org OpenBao path `secret/catalyst/agenity/<slug>/mcp-bearer`
+  # (properties `bearer` + `pubkeyPem`). With externalSecret.enabled, this
+  # chart pulls them into the per-Org K8s Secret `secretName`, and the
+  # org-gitops emitter (organization_gitops.go) points
+  # openovaMCP.bearerSecret + openovaMCP.rs256PubkeySecret at it so the
+  # StatefulSet projects OPENOVA_MCP_BEARER and OPENOVA_MCP_RS256_PUBKEY_PEM.
+  #
+  # Why bearer + pubkey travel together: the pubkey that VERIFIES the bearer
+  # is the public half of the SAME handover signer that MINTED it. Seeding
+  # them through one path/ExternalSecret sidesteps the JWK-vs-PEM
+  # cross-namespace mismatch (the only published mirror,
+  # catalyst-handover-jwt-public in catalyst-system, holds a JWK, while the
+  # MCP wants PKIX PEM and lives in the per-Org ns, #4228).
+  #
+  # Disabled by default (no producer outside a Sovereign Org-pipeline). When
+  # enabled, the org-gitops emitter sets remoteKey to the per-Org path.
+  mcpBearer:
+    secretName: agenity-mcp-bearer
+    externalSecret:
+      enabled: false
+      refreshInterval: 1h
+      secretStoreRef: vault-region1
+      secretStoreKind: ClusterSecretStore
+      # Per-Org OpenBao KV-v2 key — set by the org-gitops emitter to
+      # `catalyst/agenity/<slug>/mcp-bearer`.
+      remoteKey: ""
+      # KV-v2 property names the producer writes (seedMCPBearer).
+      remoteBearerProperty: bearer
+      remotePubkeyProperty: pubkeyPem
+    # K8s Secret keys the StatefulSet's bearerSecret/rs256PubkeySecret read.
+    bearerKey: bearer
+    pubkeyKey: pubkeyPem
+
 # ── Daemon HTTP auth (browser chat-box trust mode) ────────────────────────
 # The chepherd daemon's default auth mode is "local": it mints a bootstrap
 # Bearer token and the authMiddleware enforces it on every /api/v1/* path.

--- a/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
@@ -1677,6 +1677,36 @@ spec:
         remoteKey: catalyst/anthropic/token
         remoteProperty: apiKey
         remoteCredentialsProperty: credentialsJson
+    # openova-MCP Catalyst bearer + RS256 verify-pubkey (#4276 hop 7/7b).
+    # The catalyst-api org-pipeline producer (seedMCPBearer) mints an
+    # Org-scoped session JWT (tier=org-admin, org_id={{.Subdomain}},
+    # role=openova-user, typ=session, RS256-signed by the Sovereign handover
+    # signer) plus the matching RS256 verify pubkey (PKIX PEM), and writes
+    # BOTH to the per-Org OpenBao path secret/catalyst/agenity/{{.Subdomain}}
+    # /mcp-bearer (properties bearer + pubkeyPem). The chart's
+    # externalsecret-mcp-bearer.yaml pulls them into the per-Org Secret
+    # agenity-mcp-bearer; bearerSecret + rs256PubkeySecret below point the
+    # StatefulSet at it so it projects OPENOVA_MCP_BEARER +
+    # OPENOVA_MCP_RS256_PUBKEY_PEM. Without this the spawned claude-code
+    # agent reaches the openova MCP with NO bearer → -32001 unauthenticated,
+    # even after the Anthropic key (#4277) is seeded. The path MUST live
+    # under catalyst/ (the only KV sub-tree a Sovereign can WRITE via the
+    # catalyst-api-write policy; vault-region1's role is read-only).
+    openovaMCP:
+      bearerSecret:
+        name: agenity-mcp-bearer
+        key: bearer
+      rs256PubkeySecret:
+        name: agenity-mcp-bearer
+        key: pubkeyPem
+      mcpBearer:
+        externalSecret:
+          enabled: true
+          secretStoreRef: vault-region1
+          secretStoreKind: ClusterSecretStore
+          remoteKey: catalyst/agenity/{{.Subdomain}}/mcp-bearer
+          remoteBearerProperty: bearer
+          remotePubkeyProperty: pubkeyPem
 `
 
 const orgTenantBPStalwart = `# bp-stalwart-tenant (#801, OIDC wiring #915) — dedicated mail server

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
@@ -917,6 +917,21 @@ func (h *Handler) runOrganizationPipeline(ctx context.Context, rec store.Organiz
 		// every Org-create both makes new Orgs converge and keeps the
 		// short-lived OAuth blob fresh.
 		_ = h.seedAnthropicToken(ctx)
+
+		// #4276 (hop 7/7b) — seed the per-Org OpenBao
+		// `secret/catalyst/agenity/<slug>/mcp-bearer` with an Org-scoped
+		// Catalyst session bearer + the RS256 verify pubkey (PEM) so this
+		// Org's bp-agenity MCP authenticates create_application against
+		// catalyst-api. Without it the spawned claude-code agent reaches
+		// the openova MCP with NO bearer → -32001 unauthenticated, even
+		// after the Anthropic key (#4277) is seeded (that only authenticates
+		// claude-code to ANTHROPIC, not to CATALYST). Same posture as
+		// seedAnthropicToken: idempotent (PutKVv2 overwrites — refreshes the
+		// bearer's expiry every reconcile) and NEVER fails the pipeline (a
+		// signer/OpenBao gap only leaves the MCP create path unauthenticated;
+		// the agenity dashboard still serves). rec.Subdomain is the Org slug
+		// the bearer is scoped to; rec.AdminEmail is the owner subject.
+		_ = h.seedMCPBearer(ctx, rec.Subdomain, rec.AdminEmail)
 	}
 
 	// Step 2 — bp_charts_installed.

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
@@ -423,6 +423,51 @@ func TestDeleteOrganization_RemovesFromRegistry(t *testing.T) {
 	}
 }
 
+// TestRenderOrganizationOverlay_AgenityMCPBearerWiring is the #4276 hop 7/7b
+// emitter guard. The bp-agenity overlay MUST set openovaMCP.bearerSecret +
+// rs256PubkeySecret + enable the per-Org mcpBearer ExternalSecret pointed at
+// secret/catalyst/agenity/<slug>/mcp-bearer, so the StatefulSet projects
+// OPENOVA_MCP_BEARER + OPENOVA_MCP_RS256_PUBKEY_PEM. Without this the spawned
+// claude-code agent reaches the openova MCP with no bearer → -32001
+// unauthenticated, even after the Anthropic key (#4277) is seeded.
+func TestRenderOrganizationOverlay_AgenityMCPBearerWiring(t *testing.T) {
+	rec := store.OrganizationProvisionRecord{
+		OrganizationID:  "t-acme",
+		Subdomain:       "acme",
+		DomainMode:      store.OrganizationDomainFreeSubdomain,
+		AdminEmail:      "admin@acme.test",
+		OTECHFQDN:       "otech.example",
+		ParentDomain:    "omani.homes",
+		TenantNamespace: "org-t-acme",
+	}
+	files, err := renderOrganizationOverlay(rec, OrganizationChartVersions{})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body, ok := files["bp-agenity.yaml"]
+	if !ok {
+		t.Fatalf("bp-agenity.yaml missing")
+	}
+	for _, want := range []string{
+		"openovaMCP:",
+		"bearerSecret:",
+		"name: agenity-mcp-bearer",
+		"key: bearer",
+		"rs256PubkeySecret:",
+		"key: pubkeyPem",
+		"mcpBearer:",
+		"externalSecret:",
+		"enabled: true",
+		"remoteKey: catalyst/agenity/acme/mcp-bearer",
+		"remoteBearerProperty: bearer",
+		"remotePubkeyProperty: pubkeyPem",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("bp-agenity.yaml missing %q\n---\n%s", want, body)
+		}
+	}
+}
+
 func TestRenderOrganizationOverlay_FreeSubdomain_AllChartsPresent(t *testing.T) {
 	rec := store.OrganizationProvisionRecord{
 		OrganizationID:  "t-acme",

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_mcp_bearer_seed.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_mcp_bearer_seed.go
@@ -1,0 +1,308 @@
+// Per-Org openova-MCP Catalyst-bearer seeding (issue #4276 / #4111 — hop 7).
+//
+// Why this exists:
+//
+//	Pillar 4's terminal proof is the agentic mutation: the per-Org
+//	bp-agenity dashboard spawns a solo claude-code agent which calls the
+//	`openova` MCP's `create_application` tool, and a new Application is
+//	created in the Org. The MCP server (products/openova-mcp) is injected
+//	into every spawned agent (CHEPHERD_EXTRA_MCP_JSON, agenity
+//	statefulset.yaml) and `create_application` is wired to
+//	POST /api/v1/org/applications. But the MCP must present a Catalyst
+//	SESSION BEARER to catalyst-api, resolved from EITHER a per-call
+//	`_auth.token` argument OR the `OPENOVA_MCP_BEARER` env fallback
+//	(products/openova-mcp/cmd/openova-mcp/main.go). On a fresh funnel Org
+//	NEITHER is supplied:
+//	  - `_auth.token` is never injected (chepherd's #4010 seam merges the
+//	    MCP server DEFINITION, it does not forward a per-call bearer; no
+//	    code anywhere forwards the User's session JWT into the call).
+//	  - `OPENOVA_MCP_BEARER` is only projected when the chart value
+//	    `openovaMCP.bearerSecret.name` is non-empty, and the org-gitops
+//	    emitter `orgTenantBPAgenity` never set it.
+//	Result: every `create_application` from a fresh Org's agent hits the
+//	MCP with no bearer → -32001 unauthenticated — even after the Anthropic
+//	key (#4277/#4303) is seeded (that only lets claude-code talk to
+//	ANTHROPIC, not to CATALYST). This file is the missing producer.
+//
+//	Coupled gap 7b — the MCP also needs the RS256 PUBLIC KEY (PEM) to
+//	VERIFY the bearer it is handed (OPENOVA_MCP_RS256_PUBKEY_PEM,
+//	verify=rs256). The chart's default rs256PubkeySecret points at a host
+//	`catalyst-system` Secret that is absent in the per-Org namespace
+//	(optional:true ⇒ unset, #4228). So we seed the verify pubkey-PEM
+//	ALONGSIDE the bearer in the SAME openbao path and project it from the
+//	SAME ExternalSecret — the bearer and the key that verifies it travel
+//	together, sidestepping the JWK-vs-PEM cross-namespace reflection
+//	mismatch entirely (the only published mirror,
+//	catalyst-handover-jwt-public, holds a JWK; the MCP wants PKIX PEM).
+//
+// The bearer is an Org-SCOPED session JWT, NOT a sovereign-admin one:
+//
+//	The MCP runs with OPENOVA_MCP_CONTEXT=organization (chart default).
+//	The bearer carries the byte-for-byte shape HandlePinVerify /
+//	auth_org_handover mint for an Org-scoped customer session (auth.go
+//	#4110): tier=org-admin (auth.OrgScopedTier), role=openova-user,
+//	typ=session, org+org_id=<slug>, realm_access.roles=[org-admin],
+//	iss=<CATALYST_PIN_ISSUER>, RS256-signed by the Sovereign's handover
+//	signer (the SAME key whose pubkey the MCP verifies against). This
+//	resolves in the MCP to (context=organization, tier=admin,
+//	org_id=<org>) → create_application (MinTier=Admin) is allowed AND
+//	routes to the own-org POST /api/v1/org/applications path
+//	(OrgScopeGuard-allowlisted, #4116); cross-Org create stays forbidden
+//	(resolveCreateTargetOrg). A sovereign-admin bearer would resolve
+//	context=sovereign and 403 under the #4110 host-scope guard — the exact
+//	wedge values.yaml warns about.
+//
+// Why this path (NOT bare secret/agenity/...):
+//
+//	Identical reasoning to the Anthropic seed (sovereign_anthropic_seed.go):
+//	the catalyst-api Pod holds the write-capable `catalyst-api-write`
+//	OpenBao role scoped to `secret/{data,metadata}/catalyst/*`, while the
+//	`external-secrets` role vault-region1 authenticates with is read-only.
+//	So we write under the `catalyst/` prefix the platform can ALREADY
+//	write — zero new OpenBao policy/role. UNLIKE the cluster-shared
+//	Anthropic path, the bearer is PER-ORG (it carries the Org slug), so the
+//	path is per-Org: `secret/catalyst/agenity/<slug>/mcp-bearer`.
+//
+// TTL + re-mint policy:
+//
+//	A session JWT expires (pinSessionTTL = 8h). The agenity StatefulSet is
+//	long-lived, so an 8h bearer would go stale within the day. We therefore
+//	mint a LONG-LIVED service bearer (mcpBearerTTL = 1 year) for this
+//	headless Org-service identity, AND re-seed it idempotently on every Org
+//	reconcile (runOrganizationPipeline calls this on every create/reconcile,
+//	exactly like seedAnthropicToken). PutKVv2 overwrites, so each reconcile
+//	refreshes the token's expiry window — the bearer never ages out while
+//	the Org is actively reconciled, and a one-year floor covers quiescent
+//	gaps between reconciles. This mirrors the #4303 idempotent-re-seed
+//	pattern (the Anthropic OAuth blob is likewise refreshed every reconcile)
+//	and the OAuth-expiry pre-flight class #4111 documents.
+//
+// When this runs:
+//
+//	runOrganizationPipeline calls seedMCPBearer right after Step 1 (per-Org
+//	overlay committed), beside seedAnthropicToken. A nil h.openbao
+//	(Catalyst-Zero orchestrator) or nil h.handoverSigner is a non-fatal
+//	skip — the agenity HR still installs; only the MCP create_application
+//	path stays unauthenticated until the path is seeded.
+//
+// Per docs/PRINCIPLES.md #10 (credential hygiene): never logs the bearer
+// or the PEM — only byte lengths + outcome class.
+package handler
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+)
+
+// mcpBearerMountPath — the OpenBao KV-v2 mount the producer writes and the
+// agenity ExternalSecret reads. The per-Org secret PATH is built from the
+// Org slug (mcpBearerSecretPath); both are fixed-by-contract with the
+// agenity chart's mcpBearer.externalSecret.remoteKey and the org-gitops
+// emitter override (organization_gitops.go). The `catalyst/` prefix is the
+// ONLY sub-tree a Sovereign can write (see the file doc comment).
+const mcpBearerMountPath = "secret"
+
+// mcpBearerSecretPath builds the per-Org OpenBao KV-v2 path for the slug.
+// Per-Org (unlike the cluster-shared Anthropic path) because the bearer
+// carries the Org slug in its claims.
+func mcpBearerSecretPath(slug string) string {
+	return "catalyst/agenity/" + slug + "/mcp-bearer"
+}
+
+// mcpBearerKVProperties — the KV-v2 field names the agenity ExternalSecret
+// reads. `bearer` = the Org-scoped session JWT the MCP forwards to
+// catalyst-api; `pubkeyPem` = the RS256 PKIX public key (PEM) the MCP
+// verifies that bearer with (gap 7b). Fixed-by-contract with the chart's
+// mcpBearer.externalSecret remote-property values.
+const (
+	mcpBearerKVBearerProperty    = "bearer"
+	mcpBearerKVPubkeyPEMProperty = "pubkeyPem"
+)
+
+// mcpBearerTTL — the validity window of the minted Org-service bearer. A
+// long horizon (1 year) for this headless, idempotently-re-seeded service
+// identity: the 8h interactive pinSessionTTL would age out within the day
+// on a long-lived StatefulSet. Re-seeded every Org reconcile (PutKVv2
+// overwrites), so the live token's expiry is continuously pushed forward;
+// the 1y floor covers quiescent gaps between reconciles. See the file doc
+// comment §TTL.
+const mcpBearerTTL = 365 * 24 * time.Hour
+
+// MCPBearerSeedOutcome — terminal classification of one seed attempt.
+type MCPBearerSeedOutcome string
+
+const (
+	MCPBearerSeedOutcomeSeeded       MCPBearerSeedOutcome = "seeded"
+	MCPBearerSeedOutcomeSkippedNoBao MCPBearerSeedOutcome = "skipped-no-openbao"
+	MCPBearerSeedOutcomeSkippedNoSig MCPBearerSeedOutcome = "skipped-no-signer"
+	MCPBearerSeedOutcomeSkippedNoOrg MCPBearerSeedOutcome = "skipped-no-org-slug"
+	MCPBearerSeedOutcomeMintFailure  MCPBearerSeedOutcome = "mint-failure"
+	MCPBearerSeedOutcomeWriteFailure MCPBearerSeedOutcome = "write-failure"
+)
+
+// mintOrgScopedMCPBearer mints the Org-scoped session JWT the openova-MCP
+// forwards to catalyst-api. Exported-for-test-via-package: the claim shape
+// MUST match what HandlePinVerify / auth_org_handover mint (auth.go #4110)
+// so the MCP + OrgScopeGuard resolve it identically.
+//
+// `slug` is the Org slug (rec.Subdomain); `email` is the Org owner's
+// address (rec.AdminEmail), falling back to a synthetic service subject so
+// the claim is never empty.
+func mintOrgScopedMCPBearer(signer customClaimsSigner, slug, email string) (string, error) {
+	subject := strings.TrimSpace(email)
+	if subject == "" {
+		// Headless Org-service identity — no human owner address on the
+		// record. A stable, Org-scoped synthetic subject keeps the claim
+		// non-empty and audit-legible without inventing a real mailbox.
+		subject = "openova-mcp@" + slug
+	}
+	now := time.Now()
+	claims := jwt.MapClaims{
+		"iss":            pinIssuer,
+		"sub":            subject,
+		"email":          subject,
+		"email_verified": true,
+		"role":           pinSessionRole, // "openova-user"
+		"tier":           orgScopedTier,  // "org-admin" (auth.OrgScopedTier)
+		"realm_access": map[string]any{
+			"roles": []string{orgScopedRealmRole}, // ["org-admin"]
+		},
+		"iat":    now.Unix(),
+		"exp":    now.Add(mcpBearerTTL).Unix(),
+		"jti":    uuid.NewString(),
+		"typ":    "session",
+		"org":    slug,
+		"org_id": slug,
+	}
+	return signer.SignCustomClaims(claims)
+}
+
+// customClaimsSigner is the narrow surface this producer needs from the
+// handover signer — kept as an interface so the mint can be unit-tested
+// without a real RSA key path. *handoverjwt.Signer satisfies it.
+type customClaimsSigner interface {
+	SignCustomClaims(claims jwt.Claims) (string, error)
+}
+
+// handoverSignerPubkeyPEM returns the signer's RS256 public key as a PKIX
+// PEM block — the exact format the openova-MCP's
+// OPENOVA_MCP_RS256_PUBKEY_PEM expects (x509.ParsePKIXPublicKey, see
+// products/openova-mcp/cmd/openova-mcp/main.go). The MCP verifies caller
+// bearers against THIS key; it must be the public half of the SAME signer
+// that minted the bearer above, which is guaranteed because both come from
+// h.handoverSigner.
+func handoverSignerPubkeyPEM(h *Handler) (string, error) {
+	if h.handoverSigner == nil {
+		return "", fmt.Errorf("mcp bearer seed: handover signer unavailable")
+	}
+	pub, err := h.handoverSigner.PublicRSAKey()
+	if err != nil {
+		return "", fmt.Errorf("mcp bearer seed: read signer pubkey: %w", err)
+	}
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return "", fmt.Errorf("mcp bearer seed: marshal PKIX pubkey: %w", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
+	return string(pemBytes), nil
+}
+
+// seedMCPBearer mints an Org-scoped Catalyst session bearer + the RS256
+// verify pubkey (PEM) and writes them to the per-Org OpenBao path so the
+// Org's agenity ExternalSecret materialises OPENOVA_MCP_BEARER (and the
+// pubkey the MCP verifies it with) — closing #4276 hop 7/7b. Idempotent:
+// PutKVv2 overwrites, so every Org reconcile refreshes the bearer's expiry
+// window.
+//
+// Returns the terminal outcome so the caller can emit an SSE / log line.
+// NEVER returns an error that fails the Org pipeline — a signer/OpenBao gap
+// must not block the rest of the Org (the agenity HR still installs; only
+// its MCP create_application path stays unauthenticated until seeded). The
+// outcome is surfaced loudly instead.
+func (h *Handler) seedMCPBearer(ctx context.Context, slug, ownerEmail string) MCPBearerSeedOutcome {
+	slug = strings.TrimSpace(slug)
+
+	// Catalyst-Zero (the orchestrator) has no in-cluster OpenBao client and
+	// is never itself an agenity host — skip without noise. Production
+	// Sovereign catalyst-api always has h.openbao wired.
+	if h.openbao == nil {
+		if h.log != nil {
+			h.log.Debug("mcp bearer seed: skipped — no OpenBao client (orchestrator / Catalyst-Zero)")
+		}
+		return MCPBearerSeedOutcomeSkippedNoBao
+	}
+	if h.handoverSigner == nil {
+		if h.log != nil {
+			h.log.Warn("mcp bearer seed: SKIPPED — handover signer unavailable; agenity MCP create_application will stay unauthenticated until a bearer is seeded",
+				"openbaoPath", mcpBearerMountPath+"/"+mcpBearerSecretPath(slug),
+			)
+		}
+		return MCPBearerSeedOutcomeSkippedNoSig
+	}
+	if slug == "" {
+		// No Org slug ⇒ can't scope the bearer; refuse to seed a path with
+		// an empty/cross-Org claim (the resolveCreateTargetOrg guard the
+		// MCP relies on would otherwise be defeated).
+		if h.log != nil {
+			h.log.Warn("mcp bearer seed: SKIPPED — empty Org slug; cannot scope an Org bearer")
+		}
+		return MCPBearerSeedOutcomeSkippedNoOrg
+	}
+
+	// The org owner email comes from the record at the call site; the mint
+	// falls back to a synthetic Org-scoped subject when empty.
+	bearer, err := mintOrgScopedMCPBearer(h.handoverSigner, slug, ownerEmail)
+	if err != nil {
+		if h.log != nil {
+			h.log.Error("mcp bearer seed: mint failed", "slug", slug, "err", err)
+		}
+		return MCPBearerSeedOutcomeMintFailure
+	}
+
+	pubkeyPEM, err := handoverSignerPubkeyPEM(h)
+	if err != nil {
+		if h.log != nil {
+			h.log.Error("mcp bearer seed: pubkey PEM failed", "slug", slug, "err", err)
+		}
+		return MCPBearerSeedOutcomeMintFailure
+	}
+
+	// KV-v2 payload. Field names MUST match the agenity ExternalSecret's
+	// remoteRef.property values (bearer + pubkeyPem).
+	data := map[string]any{
+		mcpBearerKVBearerProperty:    bearer,
+		mcpBearerKVPubkeyPEMProperty: pubkeyPEM,
+	}
+
+	path := mcpBearerSecretPath(slug)
+	if err := h.openbao.PutKVv2(ctx, mcpBearerMountPath, path, data); err != nil {
+		if h.log != nil {
+			h.log.Error("mcp bearer seed: OpenBao write failed",
+				"openbaoPath", mcpBearerMountPath+"/"+path,
+				"err", err,
+			)
+		}
+		return MCPBearerSeedOutcomeWriteFailure
+	}
+
+	if h.log != nil {
+		// Per docs/PRINCIPLES.md #10: byte lengths + claim scope only,
+		// never the token/PEM plaintext.
+		h.log.Info("mcp bearer seed: wrote Org-scoped Catalyst bearer + verify pubkey so the agenity MCP create_application authenticates",
+			"openbaoPath", mcpBearerMountPath+"/"+path,
+			"slug", slug,
+			"tier", orgScopedTier,
+			"bearerBytes", len(bearer),
+			"pubkeyPemBytes", len(pubkeyPEM),
+			"ttl", mcpBearerTTL.String(),
+		)
+	}
+	return MCPBearerSeedOutcomeSeeded
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_mcp_bearer_seed_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_mcp_bearer_seed_test.go
@@ -1,0 +1,233 @@
+package handler
+
+import (
+	"context"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handoverjwt"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/openbao"
+)
+
+// newTestSigner builds a real handover signer over a fresh RSA keypair so
+// the mint + PEM emission exercise the production path (no mock signer).
+func newTestSigner(t *testing.T) *handoverjwt.Signer {
+	t.Helper()
+	priv, _, err := handoverjwt.GenerateKeypair()
+	if err != nil {
+		t.Fatalf("GenerateKeypair: %v", err)
+	}
+	s, err := handoverjwt.New(priv, "https://console.t99.omani.works", 8*time.Hour)
+	if err != nil {
+		t.Fatalf("handoverjwt.New: %v", err)
+	}
+	return s
+}
+
+// Test_seedMCPBearer_SeedsExpectedPathAndFields verifies the producer writes
+// the per-Org secret/catalyst/agenity/<slug>/mcp-bearer path with BOTH the
+// bearer and pubkeyPem properties the agenity ExternalSecret consumes
+// (#4276). The path + field names are the contract with the chart's
+// externalsecret-mcp-bearer.yaml + the org-gitops emitter — a drift here
+// re-breaks hop 7.
+func Test_seedMCPBearer_SeedsExpectedPathAndFields(t *testing.T) {
+	srv := newCaptureKVServer(t)
+	h := &Handler{log: silentLogger()}
+	h.openbao = &openbao.Client{Addr: srv.srv.URL, Token: "test-token", HTTP: srv.srv.Client()}
+	h.handoverSigner = newTestSigner(t)
+
+	outcome := h.seedMCPBearer(context.Background(), "acme", "owner@acme.omani.homes")
+	if outcome != MCPBearerSeedOutcomeSeeded {
+		t.Fatalf("outcome = %q, want %q", outcome, MCPBearerSeedOutcomeSeeded)
+	}
+
+	// KV-v2 PUT path is /v1/<mount>/data/<secretPath>.
+	wantPath := "/v1/secret/data/catalyst/agenity/acme/mcp-bearer"
+	srv.mu.Lock()
+	gotPath := srv.lastURL
+	srv.mu.Unlock()
+	if gotPath != wantPath {
+		t.Errorf("PUT path = %q, want %q", gotPath, wantPath)
+	}
+
+	bearer, ok := srv.dataField(mcpBearerKVBearerProperty)
+	if !ok || bearer == "" {
+		t.Fatalf("bearer field missing/empty (present=%v)", ok)
+	}
+	pubkeyPEM, ok := srv.dataField(mcpBearerKVPubkeyPEMProperty)
+	if !ok || pubkeyPEM == "" {
+		t.Fatalf("pubkeyPem field missing/empty (present=%v)", ok)
+	}
+
+	// The seeded pubkey MUST parse exactly the way the openova-MCP parses
+	// OPENOVA_MCP_RS256_PUBKEY_PEM (pem.Decode → x509.ParsePKIXPublicKey →
+	// *rsa.PublicKey), else the MCP cannot verify the bearer (gap 7b).
+	block, _ := pem.Decode([]byte(pubkeyPEM))
+	if block == nil {
+		t.Fatalf("seeded pubkeyPem is not a PEM block")
+	}
+	parsed, perr := x509.ParsePKIXPublicKey(block.Bytes)
+	if perr != nil {
+		t.Fatalf("seeded pubkeyPem failed PKIX parse (MCP would reject): %v", perr)
+	}
+	rsaPub, ok := parsed.(*rsa.PublicKey)
+	if !ok {
+		t.Fatalf("seeded pubkeyPem is not an RSA key")
+	}
+
+	// The seeded pubkey MUST verify the seeded bearer — they are the public
+	// half + signature of the SAME signer (the property the whole hop relies
+	// on). Parse the bearer with the seeded key.
+	tok, verr := jwt.Parse(bearer, func(tk *jwt.Token) (any, error) {
+		if _, methodOK := tk.Method.(*jwt.SigningMethodRSA); !methodOK {
+			return nil, jwt.ErrTokenSignatureInvalid
+		}
+		return rsaPub, nil
+	}, jwt.WithValidMethods([]string{"RS256"}))
+	if verr != nil || tok == nil || !tok.Valid {
+		t.Fatalf("seeded bearer did NOT verify against seeded pubkey: %v", verr)
+	}
+}
+
+// Test_mintOrgScopedMCPBearer_ClaimShape verifies the bearer carries the
+// EXACT Org-scoped session shape the MCP + OrgScopeGuard resolve to
+// (context=organization, tier=admin, org_id=<slug>) — tier=org-admin,
+// role=openova-user, typ=session, org+org_id=<slug>, realm_access roles
+// [org-admin], iss=pinIssuer, a long (service) TTL. A sovereign-admin shape
+// here would 403 under the #4110 host-scope guard.
+func Test_mintOrgScopedMCPBearer_ClaimShape(t *testing.T) {
+	signer := newTestSigner(t)
+
+	raw, err := mintOrgScopedMCPBearer(signer, "acme", "owner@acme.omani.homes")
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+
+	pub, _ := signer.PublicRSAKey()
+	claims := jwt.MapClaims{}
+	if _, perr := jwt.ParseWithClaims(raw, claims, func(*jwt.Token) (any, error) { return pub, nil },
+		jwt.WithValidMethods([]string{"RS256"})); perr != nil {
+		t.Fatalf("parse minted bearer: %v", perr)
+	}
+
+	wantStr := map[string]string{
+		"tier":   orgScopedTier, // "org-admin"
+		"role":   pinSessionRole, // "openova-user"
+		"typ":    "session",
+		"org":    "acme",
+		"org_id": "acme",
+		"iss":    pinIssuer,
+		"sub":    "owner@acme.omani.homes",
+		"email":  "owner@acme.omani.homes",
+	}
+	for k, want := range wantStr {
+		got, _ := claims[k].(string)
+		if got != want {
+			t.Errorf("claim %q = %q, want %q", k, got, want)
+		}
+	}
+
+	// realm_access.roles must be [org-admin] so the OrgScopeGuard resolves
+	// the org-scoped surface.
+	ra, ok := claims["realm_access"].(map[string]any)
+	if !ok {
+		t.Fatalf("realm_access missing or wrong type: %T", claims["realm_access"])
+	}
+	roles, ok := ra["roles"].([]any)
+	if !ok || len(roles) != 1 || roles[0] != orgScopedRealmRole {
+		t.Errorf("realm_access.roles = %v, want [%q]", ra["roles"], orgScopedRealmRole)
+	}
+
+	// email_verified must be true.
+	if v, _ := claims["email_verified"].(bool); !v {
+		t.Errorf("email_verified = false, want true")
+	}
+
+	// The bearer must be long-lived (service identity), not the 8h
+	// interactive session — assert exp is well beyond 8h from now.
+	expF, ok := claims["exp"].(float64)
+	if !ok {
+		t.Fatalf("exp missing/wrong type")
+	}
+	if remaining := time.Until(time.Unix(int64(expF), 0)); remaining < 30*24*time.Hour {
+		t.Errorf("bearer TTL too short for a long-lived service identity: %s remaining", remaining)
+	}
+}
+
+// Test_mintOrgScopedMCPBearer_SyntheticSubjectWhenNoEmail verifies the
+// headless-Org fallback: no owner email ⇒ a stable Org-scoped synthetic
+// subject (never an empty claim).
+func Test_mintOrgScopedMCPBearer_SyntheticSubjectWhenNoEmail(t *testing.T) {
+	signer := newTestSigner(t)
+	raw, err := mintOrgScopedMCPBearer(signer, "acme", "")
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	pub, _ := signer.PublicRSAKey()
+	claims := jwt.MapClaims{}
+	if _, perr := jwt.ParseWithClaims(raw, claims, func(*jwt.Token) (any, error) { return pub, nil },
+		jwt.WithValidMethods([]string{"RS256"})); perr != nil {
+		t.Fatalf("parse: %v", perr)
+	}
+	if sub, _ := claims["sub"].(string); sub != "openova-mcp@acme" {
+		t.Errorf("synthetic sub = %q, want openova-mcp@acme", sub)
+	}
+	// Still Org-scoped.
+	if org, _ := claims["org_id"].(string); org != "acme" {
+		t.Errorf("org_id = %q, want acme", org)
+	}
+}
+
+// Test_seedMCPBearer_SkipNoOpenBao verifies the Catalyst-Zero orchestrator
+// path: nil OpenBao client ⇒ non-fatal skip, no panic.
+func Test_seedMCPBearer_SkipNoOpenBao(t *testing.T) {
+	h := &Handler{log: silentLogger()}
+	h.handoverSigner = newTestSigner(t)
+	// h.openbao deliberately nil.
+	if outcome := h.seedMCPBearer(context.Background(), "acme", "x@y.z"); outcome != MCPBearerSeedOutcomeSkippedNoBao {
+		t.Fatalf("outcome = %q, want %q", outcome, MCPBearerSeedOutcomeSkippedNoBao)
+	}
+}
+
+// Test_seedMCPBearer_SkipNoSigner verifies the missing-signer guard: a nil
+// handover signer ⇒ loud skip, NO OpenBao write (we never seed a path
+// without a real bearer).
+func Test_seedMCPBearer_SkipNoSigner(t *testing.T) {
+	srv := newCaptureKVServer(t)
+	h := &Handler{log: silentLogger()}
+	h.openbao = &openbao.Client{Addr: srv.srv.URL, Token: "test-token", HTTP: srv.srv.Client()}
+	// h.handoverSigner deliberately nil.
+	if outcome := h.seedMCPBearer(context.Background(), "acme", "x@y.z"); outcome != MCPBearerSeedOutcomeSkippedNoSig {
+		t.Fatalf("outcome = %q, want %q", outcome, MCPBearerSeedOutcomeSkippedNoSig)
+	}
+	srv.mu.Lock()
+	wrote := srv.lastURL != ""
+	srv.mu.Unlock()
+	if wrote {
+		t.Errorf("expected NO OpenBao write when signer unavailable, but a write hit %q", srv.lastURL)
+	}
+}
+
+// Test_seedMCPBearer_SkipNoOrgSlug verifies the empty-slug guard: an empty
+// Org slug ⇒ skip, NO write (a bearer with no org_id would defeat the
+// cross-Org create guard the MCP relies on).
+func Test_seedMCPBearer_SkipNoOrgSlug(t *testing.T) {
+	srv := newCaptureKVServer(t)
+	h := &Handler{log: silentLogger()}
+	h.openbao = &openbao.Client{Addr: srv.srv.URL, Token: "test-token", HTTP: srv.srv.Client()}
+	h.handoverSigner = newTestSigner(t)
+	if outcome := h.seedMCPBearer(context.Background(), "   ", "x@y.z"); outcome != MCPBearerSeedOutcomeSkippedNoOrg {
+		t.Fatalf("outcome = %q, want %q", outcome, MCPBearerSeedOutcomeSkippedNoOrg)
+	}
+	srv.mu.Lock()
+	wrote := srv.lastURL != ""
+	srv.mu.Unlock()
+	if wrote {
+		t.Errorf("expected NO OpenBao write for empty slug, but a write hit %q", srv.lastURL)
+	}
+}


### PR DESCRIPTION
**Refs #4276 #4111**

Builds the **hop-7 gap** the #4276 completeness audit diagnosed: the spawned claude-code agent had **no Catalyst session bearer** to present to openova-mcp, so `create_application` returned **`-32001 unauthenticated`** even after the Anthropic key (#4277 / PR #4303) is seeded. Seeding the Anthropic key only authenticates claude-code to **Anthropic**; `create_application` needs a **Catalyst** identity — two different credentials.

> **Base:** branched off `fix/4277-seed-anthropic-token` (PR #4303) — the same seed seam this builds on. Sequence per the audit: land #4303 (hop 3) → land this (hop 7/7b) → the Pillar-4 acceptance walk passes first-try on key-drop.

## What was missing (verified on `main` + the #4303 branch)
- `OPENOVA_MCP_BEARER` projects only when `openovaMCP.bearerSecret.name` is non-empty — the org-gitops emitter `orgTenantBPAgenity` never set it, and nothing produced the bearer.
- `OPENOVA_MCP_RS256_PUBKEY_PEM` (the verify pubkey) is absent in an Org install — its source Secret lives in `catalyst-system`, ref `optional:true` (#4228), so the MCP could not verify a presented bearer (coupled gap 7b).

## The build (end-to-end)
1. **Mint** — `seedMCPBearer` (`sovereign_mcp_bearer_seed.go`) mints an **Org-scoped** session JWT via the handover signer's `SignCustomClaims` — the byte-for-byte shape `HandlePinVerify` / `auth_org_handover` mint: `tier=org-admin`, `role=openova-user`, `typ=session`, `org`+`org_id=<slug>`, `realm_access=[org-admin]`, `iss=CATALYST_PIN_ISSUER`, RS256-signed. Resolves in the MCP to `(context=organization, tier=admin, org_id=<org>)` → `create_application` (`MinTier=Admin`) allowed AND routed to own-org `POST /api/v1/org/applications` (#4116); cross-Org create stays forbidden. (A sovereign-admin bearer would 403 under the #4110 host-scope guard — explicitly avoided.)
2. **Verify-pubkey (7b)** — emits the matching RS256 pubkey as **PKIX PEM** (the exact format `OPENOVA_MCP_RS256_PUBKEY_PEM` parses) and seeds it **alongside** the bearer. Bearer + its verify-key travel through one path, sidestepping the JWK-vs-PEM cross-namespace mismatch the host `catalyst-handover-jwt-public` mirror (a JWK) would otherwise impose.
3. **Seed** — both written to the **per-Org** OpenBao path `secret/catalyst/agenity/<slug>/mcp-bearer` (`catalyst/` prefix = the only KV sub-tree a Sovereign can write; mirrors PR #4303's `seedAnthropicToken` seam). Called from `runOrganizationPipeline` beside `seedAnthropicToken`; idempotent (`PutKVv2` overwrites) and **never fails the pipeline**.
4. **Chart** — `bp-agenity` 0.5.8 → 0.5.9: new `templates/externalsecret-mcp-bearer.yaml` + `openovaMCP.mcpBearer` values pull `bearer`+`pubkeyPem` into the per-Org Secret `agenity-mcp-bearer`. `externalSecret` defaults **disabled** (zero-regression for non-emitter installs).
5. **Emitter** — `orgTenantBPAgenity` sets `openovaMCP.bearerSecret` + `rs256PubkeySecret` + enables `mcpBearer.externalSecret` with the per-Org `remoteKey`, so the StatefulSet projects both env vars.

## TTL + re-mint policy
A session JWT expires; the agenity StatefulSet is long-lived. The bearer is minted with a **1-year service-identity TTL** (the 8h interactive `pinSessionTTL` would age out within the day) and **re-seeded idempotently on every Org reconcile** — each reconcile pushes the live expiry forward. Mirrors the #4303 Anthropic-blob re-seed + the OAuth-expiry pre-flight class #4111 documents.

## Tests (all green)
- `Test_mintOrgScopedMCPBearer_ClaimShape` — exact Org-scoped claim shape + long TTL.
- `Test_seedMCPBearer_SeedsExpectedPathAndFields` — **end-to-end property**: the seeded pubkey `pem.Decode → x509.ParsePKIXPublicKey` (the exact MCP parse) **and verifies the seeded bearer** (same signer's public half + signature).
- synthetic-subject fallback; skip outcomes (no-bao / no-signer / no-slug, each asserting NO OpenBao write).
- `TestRenderOrganizationOverlay_AgenityMCPBearerWiring` — emitter renders the full `openovaMCP` bearer/pubkey/mcpBearer block with the per-Org path.
- Full `internal/handler` suite green; `go build`/`vet ./...` clean; `helm lint` + `helm template` (enabled + default-disabled) verified.

## Path now built end-to-end
agenity chat → claude-code (Anthropic key #4277) → openova-mcp → **bearer present + verifiable** → `create_application` → `POST /api/v1/org/applications` (own-Org, Admin-tier) → Application CR. The Pillar-4 acceptance walk should pass first-try once the founder drops the platform Anthropic key.

READ-ONLY on live; not merged/rolled. `status/uat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)