### PR TITLE
fix(vcluster-epic): resolve the #4293/#4297 adversarial-review findings — CNPG-pair host-side, NP reconciled, no silent plan downgrade, tier-gated uninstall wait (Refs #4293 #4297)

### DIFF
--- a/core/controllers/organization/internal/controller/organization_controller_test.go
+++ b/core/controllers/organization/internal/controller/organization_controller_test.go
@@ -505,8 +505,8 @@ func TestReconcile_HappyPath(t *testing.T) {
 	if gs.createRepos != 1 {
 		t.Errorf("expected 1 gitea repo create, got %d", gs.createRepos)
 	}
-	if gs.createFiles != 6 {
-		t.Errorf("expected 6 gitea file creates (namespace, vcluster, resourcequota, limitrange, kustomization, apps/networkpolicy), got %d", gs.createFiles)
+	if gs.createFiles != 7 {
+		t.Errorf("expected 7 gitea file creates (namespace, vcluster, resourcequota, limitrange, kustomization, apps/networkpolicy, apps/kustomization), got %d", gs.createFiles)
 	}
 	if gs.updateFiles != 0 {
 		t.Errorf("expected 0 file updates on first reconcile, got %d", gs.updateFiles)
@@ -725,8 +725,8 @@ func TestReconcile_GiteaOrgAlreadyExists(t *testing.T) {
 	if gs.createRepos != 1 {
 		t.Errorf("expected 1 repo create even with pre-existing org, got %d", gs.createRepos)
 	}
-	if gs.createFiles != 6 {
-		t.Errorf("expected 6 file creates even with pre-existing org, got %d", gs.createFiles)
+	if gs.createFiles != 7 {
+		t.Errorf("expected 7 file creates even with pre-existing org, got %d", gs.createFiles)
 	}
 }
 

--- a/core/controllers/organization/internal/controller/per_org_flux.go
+++ b/core/controllers/organization/internal/controller/per_org_flux.go
@@ -79,6 +79,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/openova-io/openova/core/controllers/organization/internal/gitops"
 	orgapi "github.com/openova-io/openova/core/controllers/organization/internal/orgapi"
 	"github.com/openova-io/openova/core/controllers/pkg/fluxsource"
 )
@@ -111,6 +112,28 @@ var (
 func perOrgFluxNames(slug string) (gitRepo, kustomization string) {
 	return fmt.Sprintf("catalyst-tenant-%s", slug),
 		fmt.Sprintf("catalyst-tenant-%s-vcluster", slug)
+}
+
+// perOrgAppsKustomizationName is the #4293 MAJOR-2 second Kustomization that
+// reconciles the per-Org Gitea repo's `./vcluster/apps` tree (today: the
+// default-deny + same-Org-allow NetworkPolicy baseline) INTO the boundary the
+// Org's workloads actually run in. The `-vcluster` Kustomization above
+// reconciles `./vcluster` (ns/quota/limitrange/vcluster HR) onto the HOST and
+// does NOT list apps/, so the NP was committed to a path NOTHING reconciled —
+// intra-Org isolation stayed inert. This separate Kustomization closes that gap.
+func perOrgAppsKustomizationName(slug string) string {
+	return fmt.Sprintf("catalyst-tenant-%s-apps", slug)
+}
+
+// perOrgKubeconfigSecretName is the flux-system Secret the provisioning workflow
+// mirrors the per-Org vcluster's exported kubeconfig into (after the vcluster HR
+// goes Ready). The apps Kustomization references it via spec.kubeConfig for the
+// VCLUSTER tier so the NP lands in the vcluster apiserver (the syncer then
+// reflects it to the host `<slug>` ns). MUST match the funnel's apps-sync
+// consumer name (provisioning gitops.generateAppsSyncKustomization →
+// `tenant-<slug>-kubeconfig`) so both producers agree on the mirror.
+func perOrgKubeconfigSecretName(slug string) string {
+	return fmt.Sprintf("tenant-%s-kubeconfig", slug)
 }
 
 // reconcilePerOrgFlux find-or-creates the host-cluster Flux GitRepository +
@@ -227,10 +250,72 @@ func (r *Reconciler) reconcilePerOrgFlux(ctx context.Context, org *orgapi.Organi
 		return fmt.Errorf("upsert per-Org Kustomization %s/%s: %w", ns, kustomizationName, err)
 	}
 
+	// --- Apps Kustomization (./vcluster/apps → the WORKLOAD boundary) ---
+	// #4293 MAJOR-2. The `-vcluster` Kustomization above reconciles ./vcluster
+	// (ns/quota/limitrange/[vcluster HR]) onto the HOST and does NOT list apps/,
+	// so the default-deny NetworkPolicy the gitops renderer writes to
+	// vcluster/apps/networkpolicy.yaml was reconciled by nothing — intra-Org
+	// isolation stayed inert. This second Kustomization reconciles the apps/
+	// tree into the boundary the Org's workloads actually run in:
+	//   • VCLUSTER tier (paid M+): carries spec.kubeConfig → the host
+	//     kustomize-controller applies the NP INTO the Org vcluster apiserver,
+	//     where the syncer (sync.toHost.networkPolicies, enabled on the
+	//     org-vcluster) reflects it to the host `<slug>` ns Cilium enforces.
+	//   • HOST tier (free/S): NO kubeConfig → the NP applies straight to the
+	//     host `<slug>` ns (which IS the boundary). Emitting a kubeConfig for a
+	//     never-created vcluster mirror would StateError forever.
+	// targetNamespace rewrites the NP's authored `apps` ns → `<slug>` on apply,
+	// matching the funnel apps-sync's targetNamespace + the org-controller
+	// boundary ns. Self-healing: for the vcluster tier the kubeConfig mirror is
+	// created by the provisioning workflow after the vcluster HR is Ready; until
+	// then this Kustomization StateErrors-then-retries (same as the funnel
+	// apps-sync) — never a deadlock.
+	appsKustomizationName := perOrgAppsKustomizationName(slug)
+	appsKS := &unstructured.Unstructured{}
+	appsKS.SetGroupVersionKind(fluxKustomizationGVK)
+	appsKS.SetNamespace(ns)
+	appsKS.SetName(appsKustomizationName)
+	appsLabels := copyLabels(labels)
+	appsLabels["catalyst.openova.io/component"] = "per-org-apps-reconciler"
+	if err := unstructured.SetNestedMap(appsKS.Object, appsLabels, "metadata", "labels"); err != nil {
+		return fmt.Errorf("set apps Kustomization labels: %w", err)
+	}
+	appsKSSpec := map[string]any{
+		"interval":        fmt.Sprintf("%ds", interval),
+		"retryInterval":   fmt.Sprintf("%ds", interval),
+		"path":            "./vcluster/apps",
+		"prune":           true,
+		"targetNamespace": slug,
+		"sourceRef": map[string]any{
+			"kind":      "GitRepository",
+			"name":      gitRepoName,
+			"namespace": ns,
+		},
+	}
+	// Tier gate (#4292 BoundaryIsVcluster): only the vcluster tier routes the
+	// apps tree THROUGH the vcluster kubeconfig mirror. Host tier applies to the
+	// host ns directly (no kubeConfig).
+	if gitops.BoundaryIsVcluster(org.Spec.PlanSlug) {
+		appsKSSpec["kubeConfig"] = map[string]any{
+			"secretRef": map[string]any{
+				"name": perOrgKubeconfigSecretName(slug),
+				"key":  "config",
+			},
+		}
+	}
+	if err := unstructured.SetNestedMap(appsKS.Object, appsKSSpec, "spec"); err != nil {
+		return fmt.Errorf("set apps Kustomization spec: %w", err)
+	}
+	if err := r.upsertFluxResource(ctx, ns, appsKustomizationName, appsKS); err != nil {
+		return fmt.Errorf("upsert per-Org apps Kustomization %s/%s: %w", ns, appsKustomizationName, err)
+	}
+
 	r.Log.Info("reconciled per-Org vCluster Flux loop",
 		"organization", slug,
 		"git_repository", fmt.Sprintf("%s/%s", ns, gitRepoName),
 		"kustomization", fmt.Sprintf("%s/%s", ns, kustomizationName),
+		"apps_kustomization", fmt.Sprintf("%s/%s", ns, appsKustomizationName),
+		"apps_boundary_vcluster", gitops.BoundaryIsVcluster(org.Spec.PlanSlug),
 		"url", repoURL,
 		"branch", branch)
 	return nil
@@ -254,16 +339,19 @@ func (r *Reconciler) teardownPerOrgFlux(ctx context.Context, org *orgapi.Organiz
 		ns = "flux-system"
 	}
 	gitRepoName, kustomizationName := perOrgFluxNames(slug)
+	appsKustomizationName := perOrgAppsKustomizationName(slug)
 
-	// Delete the Kustomization first so Flux stops reconciling the tree
+	// Delete the Kustomizations first so Flux stops reconciling the trees
 	// before the source disappears (avoids a transient source-not-found
 	// error on the Kustomization's last reconcile). prune:true means the
-	// vCluster Namespace + HR are GC'd by Flux as the Kustomization is
-	// removed.
+	// vCluster Namespace + HR (and the apps NP) are GC'd by Flux as the
+	// Kustomizations are removed. The apps Kustomization is removed before the
+	// vcluster one + the source (#4293 MAJOR-2).
 	for _, target := range []struct {
 		gvk  schema.GroupVersionKind
 		name string
 	}{
+		{fluxKustomizationGVK, appsKustomizationName},
 		{fluxKustomizationGVK, kustomizationName},
 		{fluxGitRepositoryGVK, gitRepoName},
 	} {

--- a/core/controllers/organization/internal/controller/per_org_flux_test.go
+++ b/core/controllers/organization/internal/controller/per_org_flux_test.go
@@ -298,3 +298,118 @@ func TestTeardownPerOrgFlux_DeletesBoth(t *testing.T) {
 		t.Errorf("second teardown (absent) must succeed, got %v", err)
 	}
 }
+
+// newTestOrgPlan is newTestOrg with an explicit plan slug so the #4293 MAJOR-2
+// tier-gate on the apps Kustomization (kubeConfig only for the vcluster tier)
+// can be exercised.
+func newTestOrgPlan(slug, planSlug string) *orgapi.Organization {
+	o := newTestOrg(slug)
+	o.Spec.PlanSlug = planSlug
+	return o
+}
+
+// TestReconcilePerOrgFlux_AppsKustomization_VclusterTier is the #4293 MAJOR-2
+// lock. The default-deny NetworkPolicy the gitops renderer writes to
+// vcluster/apps/networkpolicy.yaml must be reconciled by SOMETHING. The
+// `-vcluster` Kustomization reconciles ./vcluster (and omits apps/); the funnel
+// apps-sync reads a DIFFERENT repo. So the org-controller authors a SECOND
+// Kustomization `catalyst-tenant-<slug>-apps` over ./vcluster/apps. For the
+// VCLUSTER tier it carries spec.kubeConfig → the NP lands in the vcluster
+// apiserver (the syncer reflects it to the host ns).
+func TestReconcilePerOrgFlux_AppsKustomization_VclusterTier(t *testing.T) {
+	const slug = "acme"
+	cl := fake.NewClientBuilder().WithScheme(fluxScheme(t)).Build()
+	r := &Reconciler{
+		Log:                logr.Discard(),
+		GiteaInClusterURL:  "http://gitea-http.gitea.svc.cluster.local:3000",
+		FluxGiteaSecretRef: "openova-org-tenants-git-auth",
+	}
+	r.Client = cl
+	if err := r.reconcilePerOrgFlux(context.Background(), newTestOrgPlan(slug, "m")); err != nil {
+		t.Fatalf("reconcilePerOrgFlux: %v", err)
+	}
+	appsName := perOrgAppsKustomizationName(slug)
+	ks := getFlux(t, cl, fluxKustomizationGVK, "flux-system", appsName)
+
+	if path, _, _ := unstructured.NestedString(ks.Object, "spec", "path"); path != "./vcluster/apps" {
+		t.Errorf("apps Kustomization spec.path = %q, want ./vcluster/apps", path)
+	}
+	if tns, _, _ := unstructured.NestedString(ks.Object, "spec", "targetNamespace"); tns != slug {
+		t.Errorf("apps Kustomization spec.targetNamespace = %q, want %q (rewrites the NP's apps ns → <slug>)", tns, slug)
+	}
+	// VCLUSTER tier MUST carry spec.kubeConfig referencing the vcluster mirror,
+	// else the NP lands on the host (never reflected back in) — the bug B fixes.
+	kcName, found, _ := unstructured.NestedString(ks.Object, "spec", "kubeConfig", "secretRef", "name")
+	if !found {
+		t.Fatalf("vcluster-tier apps Kustomization MISSING spec.kubeConfig — the NP would apply to the host, not the vcluster")
+	}
+	if kcName != perOrgKubeconfigSecretName(slug) {
+		t.Errorf("apps Kustomization kubeConfig.secretRef.name = %q, want %q (must match the funnel apps-sync mirror)", kcName, perOrgKubeconfigSecretName(slug))
+	}
+	if kcKey, _, _ := unstructured.NestedString(ks.Object, "spec", "kubeConfig", "secretRef", "key"); kcKey != "config" {
+		t.Errorf("apps Kustomization kubeConfig.secretRef.key = %q, want config", kcKey)
+	}
+	if prune, _, _ := unstructured.NestedBool(ks.Object, "spec", "prune"); !prune {
+		t.Errorf("apps Kustomization spec.prune must be true")
+	}
+}
+
+// TestReconcilePerOrgFlux_AppsKustomization_HostTier — for the HOST tier (free/S)
+// there is NO vcluster, so the apps Kustomization MUST NOT carry a kubeConfig
+// (a referenced never-created vcluster mirror would StateError forever). The NP
+// applies straight to the host `<slug>` ns (which IS the boundary).
+func TestReconcilePerOrgFlux_AppsKustomization_HostTier(t *testing.T) {
+	for _, plan := range []string{"s", "free", ""} {
+		t.Run("plan="+plan, func(t *testing.T) {
+			const slug = "acme"
+			cl := fake.NewClientBuilder().WithScheme(fluxScheme(t)).Build()
+			r := &Reconciler{
+				Log:                logr.Discard(),
+				GiteaInClusterURL:  "http://gitea-http.gitea.svc.cluster.local:3000",
+				FluxGiteaSecretRef: "openova-org-tenants-git-auth",
+			}
+			r.Client = cl
+			if err := r.reconcilePerOrgFlux(context.Background(), newTestOrgPlan(slug, plan)); err != nil {
+				t.Fatalf("reconcilePerOrgFlux: %v", err)
+			}
+			ks := getFlux(t, cl, fluxKustomizationGVK, "flux-system", perOrgAppsKustomizationName(slug))
+			if _, found, _ := unstructured.NestedMap(ks.Object, "spec", "kubeConfig"); found {
+				t.Errorf("host-tier (plan=%q) apps Kustomization MUST NOT carry kubeConfig — it would StateError on the never-created vcluster mirror", plan)
+			}
+			// Still targets the host `<slug>` ns so the NP applies there directly.
+			if tns, _, _ := unstructured.NestedString(ks.Object, "spec", "targetNamespace"); tns != slug {
+				t.Errorf("host-tier apps Kustomization spec.targetNamespace = %q, want %q", tns, slug)
+			}
+		})
+	}
+}
+
+// TestTeardownPerOrgFlux_DeletesAppsKustomization — the apps Kustomization must
+// be torn down with the rest of the per-Org Flux loop (#4293 MAJOR-2).
+func TestTeardownPerOrgFlux_DeletesAppsKustomization(t *testing.T) {
+	const slug = "acme"
+	cl := fake.NewClientBuilder().WithScheme(fluxScheme(t)).Build()
+	r := &Reconciler{
+		Log:                logr.Discard(),
+		GiteaInClusterURL:  "http://gitea-http.gitea.svc.cluster.local:3000",
+		FluxGiteaSecretRef: "openova-org-tenants-git-auth",
+	}
+	r.Client = cl
+	ctx := context.Background()
+	org := newTestOrgPlan(slug, "m")
+
+	if err := r.reconcilePerOrgFlux(ctx, org); err != nil {
+		t.Fatalf("setup reconcile: %v", err)
+	}
+	// Sanity: it exists before teardown.
+	_ = getFlux(t, cl, fluxKustomizationGVK, "flux-system", perOrgAppsKustomizationName(slug))
+
+	if err := r.teardownPerOrgFlux(ctx, org); err != nil {
+		t.Fatalf("teardownPerOrgFlux: %v", err)
+	}
+	ks := &unstructured.Unstructured{}
+	ks.SetGroupVersionKind(fluxKustomizationGVK)
+	if err := cl.Get(ctx, client.ObjectKey{Namespace: "flux-system", Name: perOrgAppsKustomizationName(slug)}, ks); err == nil {
+		t.Errorf("apps Kustomization must be deleted after teardown")
+	}
+}

--- a/core/controllers/organization/internal/gitops/manifests.go
+++ b/core/controllers/organization/internal/gitops/manifests.go
@@ -164,6 +164,14 @@ func boundaryIsVcluster(planSlug string) bool {
 	}
 }
 
+// BoundaryIsVcluster is the EXPORTED tier-gate predicate so the controller
+// package (per_org_flux.go, #4293 MAJOR-2) can decide whether the per-Org apps
+// Flux Kustomization reconciles the apps/ tree INTO the vcluster (kubeConfig)
+// or straight into the host `<slug>` ns. It MUST stay in lockstep with the
+// unexported boundaryIsVcluster (and the funnel's gitops.BoundaryIsVcluster) so
+// the NetworkPolicy reconciler targets the same boundary the apps land on.
+func BoundaryIsVcluster(planSlug string) bool { return boundaryIsVcluster(planSlug) }
+
 // renderTemplates is the named template set the controller uses.
 // Keep these inline (text/template) — the rendered output is YAML
 // that Flux applies via Kustomization. Per Inviolable Principle #4
@@ -417,6 +425,17 @@ resources:
 {{- end }}
 `
 
+// appsKustomizationTemplate is the kustomize index for the apps/ tree the
+// per-Org apps Flux Kustomization reconciles (#4293 MAJOR-2). Today it lists
+// only the default-deny NetworkPolicy baseline; the funnel's app-install tree
+// (a DIFFERENT repo) carries the customer's purchased Applications. Keeping an
+// explicit index here makes `kustomize build ./vcluster/apps` deterministic.
+const appsKustomizationTemplate = `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ` + networkPolicyDoc + `
+`
+
 // renderView is the data the templates execute against: the flat Inputs plus
 // the plan-derived fields (#4292). Embedding Inputs keeps every existing field
 // reachable as `.Slug`, `.Tier`, … while the added fields surface the resolved
@@ -516,10 +535,20 @@ func Render(in Inputs) (map[string][]byte, error) {
 	}
 	// The default-deny + same-Org-allow baseline lives in the apps tree so
 	// the syncer (sync.toHost.networkPolicies.enabled) reflects it to the
-	// host `<slug>` ns. It is reconciled by the funnel's apps-sync
-	// Kustomization, not the boundary kustomization, so it is NOT listed in
-	// res — it is a separate path under apps/.
+	// host `<slug>` ns (vcluster tier) / it applies directly (host tier). It is
+	// NOT listed in the boundary kustomization `res` — it is a SEPARATE path
+	// under apps/ reconciled by its OWN per-Org Flux Kustomization
+	// (catalyst-tenant-<slug>-apps, per_org_flux.go), tier-aware: the vcluster
+	// tier carries spec.kubeConfig so the NP lands in the vcluster apiserver;
+	// the host tier applies it to the host `<slug>` ns. #4293 MAJOR-2 closed the
+	// gap where this NP was committed to a path NO Kustomization referenced
+	// (the boundary kustomization omits apps/, and the funnel apps-sync reads a
+	// DIFFERENT repo) → intra-Org isolation stayed inert.
 	files["vcluster/apps/"+networkPolicyDoc] = networkPolicyTemplate
+	// Explicit apps/kustomization.yaml so the per-Org apps Flux Kustomization's
+	// `kustomize build ./vcluster/apps` enumerates the NP deterministically
+	// (mirrors the funnel apps-tree, which also ships its own kustomization.yaml).
+	files["vcluster/apps/kustomization.yaml"] = appsKustomizationTemplate
 
 	// Stable order for the kustomization resource list (map iteration above
 	// is randomized — keep the rendered kustomization byte-stable).

--- a/core/controllers/organization/internal/gitops/manifests_test.go
+++ b/core/controllers/organization/internal/gitops/manifests_test.go
@@ -23,7 +23,8 @@ func TestRender_AllPathsAndStructuralYAML(t *testing.T) {
 		t.Fatalf("Render: %v", err)
 	}
 	// #4292: the paid-tier set is namespace + vcluster + resourcequota +
-	// limitrange + kustomization + the apps-tree networkpolicy baseline.
+	// limitrange + kustomization + the apps-tree networkpolicy baseline +
+	// (#4293 MAJOR-2) the apps-tree kustomization index.
 	wantPaths := []string{
 		"vcluster/namespace.yaml",
 		"vcluster/vcluster.yaml",
@@ -31,6 +32,7 @@ func TestRender_AllPathsAndStructuralYAML(t *testing.T) {
 		"vcluster/limitrange.yaml",
 		"vcluster/kustomization.yaml",
 		"vcluster/apps/networkpolicy.yaml",
+		"vcluster/apps/kustomization.yaml",
 	}
 	for _, p := range wantPaths {
 		if _, ok := out[p]; !ok {

--- a/core/services/provisioning/gitops/apps_into_vcluster_4297_test.go
+++ b/core/services/provisioning/gitops/apps_into_vcluster_4297_test.go
@@ -110,73 +110,85 @@ func TestBoundaryIsVcluster_FunnelParity(t *testing.T) {
 	}
 }
 
-// TestCNPGPair_VclusterTier_HRLevelKubeConfig — the active-hot-standby
-// bp-cnpg-pair HelmRelease is a HelmRelease CR, so it cannot be redirected into
-// the vcluster by the apps-sync Kustomization (no in-cluster helm-controller →
-// #3055 StateError). For the vcluster tier the PRIMARY side is a HOST file
-// carrying HR-level spec.kubeConfig (the host helm-controller installs INTO the
-// vcluster on region A). #4282/#4275 — the pair is now SPLIT-SIDE across two
-// host files: db-cnpg-pair-primary.yaml + db-cnpg-pair-replica.yaml.
-func TestCNPGPair_VclusterTier_HRLevelKubeConfig(t *testing.T) {
-	g := NewManifestGenerator(testBasePath)
-	out := g.GenerateAllWithAppConfigs("acme", "m",
-		[]string{"umami"}, "pw",
-		map[string]map[string]any{
-			"postgres": {
-				"active_hot_standby": true,
-				"primary_region":     "hz-fsn-rtz-prod",
-				"replica_region":     "hz-hel-rtz-prod",
-			},
-		},
-	)
+// TestCNPGPair_PrimaryStaysHostSide_BothTiers is the #4293 BLOCKER-1 lock. The
+// bp-cnpg-pair chart ships ONLY postgresql.cnpg.io/v1 Cluster CRs — the operator
+// + CRD are cluster-singletons that live on the HOST (slot 16). A vcluster has
+// neither the CRD nor a watching operator, so a primary Cluster `helm install`ed
+// INTO the vcluster (the keystone's old HR-level kubeConfig shape) fails
+// `no matches for kind "Cluster"` and the paid M+ active-hot-standby HA path
+// WEDGES on every fresh prov. The PRIMARY side must therefore land on region A's
+// HOST `<slug>` ns — with NO vcluster kubeConfig — for BOTH tiers. The in-vcluster
+// app pods reach the DB via the synced `postgres` Service + the apps-tree
+// credentials Secret.
+func TestCNPGPair_PrimaryStaysHostSide_BothTiers(t *testing.T) {
+	for _, plan := range []string{"m", "s"} {
+		t.Run("plan="+plan, func(t *testing.T) {
+			g := NewManifestGenerator(testBasePath)
+			out := g.GenerateAllWithAppConfigs("acme", plan,
+				[]string{"umami"}, "pw",
+				map[string]map[string]any{
+					"postgres": {
+						"active_hot_standby": true,
+						"primary_region":     "hz-fsn-rtz-prod",
+						"replica_region":     "hz-hel-rtz-prod",
+					},
+				},
+			)
 
-	// The PRIMARY HR lives as a HOST file (NOT under apps/) so the host
-	// helm-controller reconciles it; it installs the primary INTO the Org
-	// vcluster (region A) via the vcluster kubeconfig mirror.
-	hostHR, ok := out[testBasePath+"/acme/db-cnpg-pair-primary.yaml"]
-	if !ok {
-		t.Fatalf("vcluster-tier CNPG-pair PRIMARY HR not emitted as a HOST file (keys: %v)", keys(out))
-	}
-	// Neither side may land in the vcluster-redirected apps/ tree (StateError).
-	if _, inApps := out[testBasePath+"/acme/apps/db-cnpg-pair-primary.yaml"]; inApps {
-		t.Errorf("CNPG-pair PRIMARY HR must NOT be in the vcluster-redirected apps/ tree (it would StateError)")
-	}
-	if _, inApps := out[testBasePath+"/acme/apps/db-cnpg-pair-replica.yaml"]; inApps {
-		t.Errorf("CNPG-pair REPLICA HR must NOT be in the vcluster-redirected apps/ tree (it would StateError)")
-	}
-	if !strings.Contains(hostHR, "kind: HelmRelease") {
-		t.Errorf("host CNPG-pair PRIMARY file missing HelmRelease:\n%s", hostHR)
-	}
-	if !strings.Contains(hostHR, "side: primary") {
-		t.Errorf("PRIMARY HR must set cnpgPair.side: primary:\n%s", hostHR)
-	}
-	if !strings.Contains(hostHR, "kubeConfig:") {
-		t.Errorf("vcluster-tier CNPG-pair PRIMARY HR MISSING HR-level kubeConfig:\n%s", hostHR)
-	}
-	if !strings.Contains(hostHR, "name: tenant-acme-kubeconfig") {
-		t.Errorf("vcluster-tier CNPG-pair PRIMARY HR kubeConfig must reference the vcluster mirror secret:\n%s", hostHR)
-	}
-	// HR authored in flux-system so the secretRef (no namespace field) resolves
-	// against the co-located mirror.
-	if !strings.Contains(hostHR, "namespace: flux-system") {
-		t.Errorf("vcluster-tier CNPG-pair PRIMARY HR must be authored in flux-system (mirror ns):\n%s", hostHR)
-	}
-	// Chart installs into the in-vcluster `<slug>` ns where the app pods live.
-	if !strings.Contains(hostHR, "targetNamespace: acme") {
-		t.Errorf("CNPG-pair PRIMARY chart targetNamespace must be the Org <slug> ns acme:\n%s", hostHR)
-	}
+			// The PRIMARY HR lives as a HOST file (NOT under apps/) so the host
+			// helm-controller reconciles it where the cnpg operator + CRD live.
+			hostHR, ok := out[testBasePath+"/acme/db-cnpg-pair-primary.yaml"]
+			if !ok {
+				t.Fatalf("CNPG-pair PRIMARY HR not emitted as a HOST file (keys: %v)", keys(out))
+			}
+			// Neither side may land in the vcluster-redirected apps/ tree (StateError).
+			if _, inApps := out[testBasePath+"/acme/apps/db-cnpg-pair-primary.yaml"]; inApps {
+				t.Errorf("CNPG-pair PRIMARY HR must NOT be in the vcluster-redirected apps/ tree (it would StateError)")
+			}
+			if _, inApps := out[testBasePath+"/acme/apps/db-cnpg-pair-replica.yaml"]; inApps {
+				t.Errorf("CNPG-pair REPLICA HR must NOT be in the vcluster-redirected apps/ tree (it would StateError)")
+			}
+			if !strings.Contains(hostHR, "kind: HelmRelease") {
+				t.Errorf("host CNPG-pair PRIMARY file missing HelmRelease:\n%s", hostHR)
+			}
+			if !strings.Contains(hostHR, "side: primary") {
+				t.Errorf("PRIMARY HR must set cnpgPair.side: primary:\n%s", hostHR)
+			}
+			// BLOCKER-1: the PRIMARY HR must NOT carry an HR-level kubeConfig — the
+			// Cluster CR has to reconcile on the HOST where the operator+CRD live.
+			if strings.Contains(hostHR, "kubeConfig:") {
+				t.Errorf("CNPG-pair PRIMARY HR (plan=%q) MUST NOT carry an HR-level kubeConfig — installing the Cluster CR into the vcluster fails on the missing postgresql.cnpg.io CRD (#4293 BLOCKER-1):\n%s", plan, hostHR)
+			}
+			if strings.Contains(hostHR, "tenant-acme-kubeconfig") {
+				t.Errorf("CNPG-pair PRIMARY HR (plan=%q) MUST NOT reference the vcluster kubeconfig mirror — that routes the primary Cluster INTO the vcluster (the BLOCKER-1 bug):\n%s", plan, hostHR)
+			}
+			// With no kubeConfig the HR is authored in the host `<slug>` ns (NOT
+			// flux-system, which is only for the kubeConfig-carrying replica/mirror).
+			if !strings.Contains(hostHR, "namespace: acme") {
+				t.Errorf("host-side CNPG-pair PRIMARY HR must be authored in the host `<slug>` ns acme (plan=%q):\n%s", plan, hostHR)
+			}
+			if strings.Contains(hostHR, "namespace: flux-system") {
+				t.Errorf("host-side CNPG-pair PRIMARY HR must NOT live in flux-system (no kubeConfig secretRef to co-locate) (plan=%q):\n%s", plan, hostHR)
+			}
+			// Chart installs into the host `<slug>` ns where the operator reconciles
+			// the Cluster + the synced Service the in-vcluster app pods dial.
+			if !strings.Contains(hostHR, "targetNamespace: acme") {
+				t.Errorf("CNPG-pair PRIMARY chart targetNamespace must be the host `<slug>` ns acme (plan=%q):\n%s", plan, hostHR)
+			}
 
-	// The standalone postgres-credentials Secret the app pods read lives INSIDE
-	// the vcluster (apps/ tree), NOT on the host.
-	secret, ok := out[testBasePath+"/acme/apps/db-cnpg-pair-secret.yaml"]
-	if !ok {
-		t.Fatalf("CNPG-pair postgres-credentials Secret not emitted into apps/ tree (keys: %v)", keys(out))
-	}
-	if !strings.Contains(secret, "kind: Secret") || !strings.Contains(secret, "name: postgres-credentials") {
-		t.Errorf("apps-tree CNPG secret wrong shape:\n%s", secret)
-	}
-	if strings.Contains(secret, "kind: HelmRelease") {
-		t.Errorf("apps-tree CNPG secret must NOT carry the HelmRelease (that lives on the host):\n%s", secret)
+			// The standalone postgres-credentials Secret the app pods read lives
+			// INSIDE the vcluster (apps/ tree), NOT on the host.
+			secret, ok := out[testBasePath+"/acme/apps/db-cnpg-pair-secret.yaml"]
+			if !ok {
+				t.Fatalf("CNPG-pair postgres-credentials Secret not emitted into apps/ tree (keys: %v)", keys(out))
+			}
+			if !strings.Contains(secret, "kind: Secret") || !strings.Contains(secret, "name: postgres-credentials") {
+				t.Errorf("apps-tree CNPG secret wrong shape:\n%s", secret)
+			}
+			if strings.Contains(secret, "kind: HelmRelease") {
+				t.Errorf("apps-tree CNPG secret must NOT carry the HelmRelease (that lives on the host):\n%s", secret)
+			}
+		})
 	}
 }
 

--- a/core/services/provisioning/gitops/gitops.go
+++ b/core/services/provisioning/gitops/gitops.go
@@ -422,23 +422,40 @@ func (g *ManifestGenerator) GenerateAllWithAppConfigs(slug, planSlug string, app
 			// NOT a plain manifest. The apps-sync Kustomization REDIRECTS the
 			// apps/ tree INTO the Org vCluster, but a vcluster runs NO
 			// in-cluster helm-controller (#3055 StateError), so an HR CR landing
-			// inside it would never reconcile. Instead emit it as a HOST file
-			// (reconciled by the host flux-system kustomization, alongside the
-			// apps-sync CR) carrying HR-level spec.kubeConfig → the HOST
-			// helm-controller runs `helm install` INTO the vcluster API. For the
-			// host tier there is no vcluster, so the HR reconciles on the host
-			// `<slug>` ns with no kubeConfig. See generateCNPGPair (isVcluster).
-			cnpgKubeSecret := ""
-			if isVcluster {
-				cnpgKubeSecret = "tenant-" + slug + "-kubeconfig"
-			}
-			// chartTargetNS — the namespace the chart installs into. For the
-			// vcluster tier the host helm-controller installs INTO the vcluster
-			// API, where the apps live in the `<slug>` namespace (the apps-sync
-			// Kustomization rewrites the apps/ tree's `apps` → `<slug>` on apply
-			// into the vcluster). For the host tier the HR reconciles on the host
-			// and the chart installs into the host `<slug>` ns. Either way the
-			// chart target is `<slug>`, co-located with the app pods + the
+			// inside it would never reconcile. So the pair HRs are emitted as
+			// HOST files (reconciled by the host flux-system kustomization,
+			// alongside the apps-sync CR), NOT under apps/.
+			//
+			// #4293 BLOCKER-1 FIX — the CNPG Cluster CRs must stay HOST-SIDE for
+			// BOTH tiers. bp-cnpg-pair ships ONLY `postgresql.cnpg.io/v1 Cluster`
+			// CRs — no operator, no CRD. The cnpg-system operator + the Cluster
+			// CRD are CLUSTER-SINGLETONS that live on the HOST (slot 16,
+			// `target: host`); they do NOT exist inside a per-Org vCluster
+			// apiserver (the vcluster syncs no CRDs and runs no cnpg operator).
+			// The keystone's earlier shape gave the PRIMARY side an HR-level
+			// kubeConfig → the host helm-controller ran `helm install` of the
+			// primary Cluster CR INTO the vcluster, where `helm install` fails
+			// `no matches for kind "Cluster" in version "postgresql.cnpg.io/v1"`
+			// and (even if the CRD were synced) nothing would reconcile it →
+			// the paid M+ active-hot-standby HA path WEDGES on every fresh prov.
+			// Fix: the PRIMARY HR carries NO vcluster kubeConfig regardless of
+			// tier, so it reconciles on region A's HOST where the operator+CRD
+			// live and the chart installs the primary Cluster into the host
+			// `<slug>` ns. The in-vcluster app pods reach the DB via the synced
+			// `postgres` Service (sync.toHost.services is enabled on the
+			// org-vcluster) — the credentials Secret (generateCNPGPairSecret)
+			// lands inside the vcluster apps/ tree pointing at that Service.
+			// This matches the EPIC's own "the per-component CNPG Clusters
+			// already live host-side" migration note + the cluster-singleton
+			// webhook invariant (exactly ONE cnpg operator, host-only). The
+			// _ = isVcluster reference is retained below only for the apps-sync /
+			// pod-name tier gate — the CNPG-pair primary is host-side for all.
+			//
+			// chartTargetNS — the namespace the chart installs into. For BOTH
+			// tiers the primary Cluster lands in the host `<slug>` ns (where the
+			// org-controller renders the boundary ns + quota), co-located with
+			// the host cnpg-system operator that reconciles it. The app pods
+			// inside the vcluster read the synced Service + the apps-tree
 			// postgres-credentials Secret.
 			//
 			// #4282/#4275 — CROSS-REGION SPLIT-SIDE. A 2-region Sovereign is
@@ -474,7 +491,12 @@ func (g *ManifestGenerator) GenerateAllWithAppConfigs(slug, planSlug string, app
 				primaryRegion: primaryRegion,
 				replicaRegion: replicaRegion,
 				storageClass:  g.cnpgStorageClass(),
-				kubeSecret:    cnpgKubeSecret,
+				// #4293 BLOCKER-1 — NO vcluster kubeConfig. The primary Cluster CR
+				// reconciles on region A's HOST (where the cnpg-system operator +
+				// the postgresql.cnpg.io CRD live), installing into the host
+				// `<slug>` ns for BOTH tiers. Routing it into the vcluster (the
+				// keystone's old shape) `helm install`-failed on the missing CRD.
+				kubeSecret: "",
 			})
 			// The replica HR ALWAYS carries a kubeConfig — even for the host
 			// tier — because the standby Cluster MUST land in region B's cluster,

--- a/core/services/provisioning/handlers/consumer.go
+++ b/core/services/provisioning/handlers/consumer.go
@@ -210,7 +210,14 @@ func (h *Handler) waitAndFinalizeInstall(ctx context.Context, data appChangeData
 	// #4297 TIER GATE — vcluster tiers (M+) sync app pods up to the host ns
 	// with the `-x-apps-x-vcluster` suffix; host tiers (free/S) run them with
 	// native names in the host ns. Match the right shape.
-	isVcluster := gitops.BoundaryIsVcluster(h.resolvePlanSlug(ctx, data.PlanID))
+	//
+	// #4293 MAJOR-3 — resolve the tier AUTHORITATIVELY off the Organization CR
+	// (immune to a transient catalog blip) so the pod-name matcher tracks the
+	// boundary the manifests were actually committed against, not a catalog-miss
+	// "s" downgrade. (This wait is for the matcher only; the manifests were
+	// already committed authoritatively by applyTenantChange, which fails-closed.)
+	planSlug, _ := h.resolveTenantPlanSlug(ctx, data.TenantSlug, data.PlanID)
+	isVcluster := gitops.BoundaryIsVcluster(planSlug)
 	waitSlugs := data.DeploySlugs
 	if len(waitSlugs) == 0 {
 		waitSlugs = []string{data.AppSlug}
@@ -328,7 +335,12 @@ func (h *Handler) waitAndFinalizeUninstall(ctx context.Context, data appChangeDa
 	h.markJobStep(ctx, job, 1, "running", "")
 	// #4290: org-controller-owned `<slug>` host namespace (single boundary).
 	hostNS := data.TenantSlug
-	if err := h.waitForVclusterAppGone(ctx, hostNS, data.AppSlug, 5*time.Minute); err != nil {
+	// #4293 MINOR-4 — tier-gate the uninstall wait so a host-tier (native pod
+	// name) Org isn't reported "gone" while its pod is still Terminating.
+	// Authoritative tier off the Organization CR (immune to a catalog blip).
+	planSlug, _ := h.resolveTenantPlanSlug(ctx, data.TenantSlug, data.PlanID)
+	isVcluster := gitops.BoundaryIsVcluster(planSlug)
+	if err := h.waitForVclusterAppGone(ctx, hostNS, data.AppSlug, 5*time.Minute, isVcluster); err != nil {
 		if ctx.Err() != nil {
 			slog.Warn("day-2 uninstall: wait canceled — tenant delete preempted",
 				"tenant", data.TenantSlug, "app", data.AppSlug, "job_id", job.ID)
@@ -425,7 +437,19 @@ func (h *Handler) applyTenantChange(ctx context.Context, data appChangeData, act
 		return fmt.Errorf("manifest generator not configured")
 	}
 
-	planSlug := h.resolvePlanSlug(ctx, data.PlanID)
+	// #4293 MAJOR-3 — fail-CLOSED tier resolution on the day-2 re-generation
+	// path. resolvePlanSlug returns "s" on ANY transient catalog failure; if
+	// that fired here for a paid (M+) Org we'd re-emit apps-sync WITHOUT
+	// kubeConfig (host tier) and Flux would RE-ROUTE the apps from the vcluster
+	// into the host `<slug>` ns, orphaning the in-vcluster copy. resolveTenantPlanSlug
+	// reads the AUTHORITATIVE `spec.planSlug` off the Organization CR first
+	// (immune to a catalog blip); ok=false means it could only guess (catalog
+	// unreachable AND no CR planSlug) — in that case ABORT the day-2 change so
+	// the job retries rather than silently downgrading the boundary.
+	planSlug, authoritative := h.resolveTenantPlanSlug(ctx, data.TenantSlug, data.PlanID)
+	if !authoritative {
+		return fmt.Errorf("day-2 %s aborted: could not authoritatively resolve plan tier for tenant %q (catalog unreachable + no persisted Organization.spec.planSlug) — refusing to re-generate manifests that could re-route apps to the wrong boundary (#4293 MAJOR-3); will retry", action, data.TenantSlug)
+	}
 	appSlugs := h.resolveAppSlugs(ctx, data.Apps)
 
 	// Preserve the existing DB password if a db file is present in Git.
@@ -492,10 +516,17 @@ func (h *Handler) readExistingDBPassword(ctx context.Context, tenantSlug string)
 
 // waitForVclusterAppGone is the inverse of waitForVclusterApp — it waits
 // until no pod matching the app slug exists in the host namespace.
-func (h *Handler) waitForVclusterAppGone(ctx context.Context, namespace, appSlug string, timeout time.Duration) error {
+//
+// #4293 MINOR-4 — TIER-GATED. The keystone tier-gated the install wait
+// (waitForVclusterApp via appPodNameMatches) but left this uninstall wait
+// hardcoded to the vcluster syncer suffix `-x-apps-x-vcluster`. For a host-tier
+// (free/S) Org the app pod has a NATIVE name (no suffix), so the hardcoded
+// matcher never found it → the "no matching pod" branch returned success on the
+// first poll, reporting "gone" while the native pod was still Terminating. Thread
+// isVcluster + reuse appPodNameMatches so both tiers wait on the right shape,
+// mirroring the install side.
+func (h *Handler) waitForVclusterAppGone(ctx context.Context, namespace, appSlug string, timeout time.Duration, isVcluster bool) error {
 	deadline := time.Now().Add(timeout)
-	prefix := appSlug + "-"
-	suffix := "-x-apps-x-vcluster"
 	for time.Now().Before(deadline) {
 		body, err := h.k8sGet(fmt.Sprintf("/api/v1/namespaces/%s/pods", namespace))
 		if err == nil {
@@ -509,7 +540,7 @@ func (h *Handler) waitForVclusterAppGone(ctx context.Context, namespace, appSlug
 			found := false
 			if jerr := json.Unmarshal(body, &podList); jerr == nil {
 				for _, pod := range podList.Items {
-					if strings.HasPrefix(pod.Metadata.Name, prefix) && strings.HasSuffix(pod.Metadata.Name, suffix) {
+					if appPodNameMatches(pod.Metadata.Name, appSlug, isVcluster) {
 						found = true
 						break
 					}

--- a/core/services/provisioning/handlers/handlers.go
+++ b/core/services/provisioning/handlers/handlers.go
@@ -372,6 +372,109 @@ func (h *Handler) resolvePlanSlug(ctx context.Context, planID string) string {
 	return "s"
 }
 
+// resolveTenantPlanSlug is the #4293 MAJOR-3 fail-safe resolver for the DAY-2
+// path. The bug it closes: resolvePlanSlug silently returns "s" on ANY transient
+// catalog failure (3s timeout, non-200, decode error, plan-not-found). On a
+// day-2 install/uninstall for a paid (M+) Org, if the catalog is briefly
+// unreachable at that instant, the day-2 manifests would be re-generated as the
+// HOST tier (no kubeConfig) and the apps RE-ROUTED out of the vcluster into the
+// host `<slug>` ns — orphaning the original in-vcluster copy. A transient blip
+// must NEVER silently downgrade a paid Org's boundary.
+//
+// Fix: read the AUTHORITATIVE persisted plan slug off the Organization CR
+// (`spec.planSlug`), which the funnel resolved ONCE at creation
+// (organization_create.go) and which the EPIC designates the single
+// truth-source for the resource cap + boundary tier. The CR read has no
+// dependency on the live catalog service, so it is immune to the transient. We
+// only fall back to the live catalog (resolvePlanSlug) when the CR genuinely
+// carries no planSlug (legacy tenants created before Workstream B, or a tenant
+// with no Organization CR) — and even then we surface ok=false so the caller can
+// fail-closed (retry) rather than commit a host-tier downgrade off a guess.
+//
+// Returns (slug, true) when the slug is authoritative (from the CR, or a
+// confirmed live catalog hit); (slug, false) when it could only be guessed
+// (catalog unreachable AND no CR planSlug) — the caller MUST treat false as
+// retryable for the day-2 boundary decision, never as a confirmed host-tier.
+func (h *Handler) resolveTenantPlanSlug(ctx context.Context, tenantSlug, planID string) (string, bool) {
+	// 1. Authoritative: the persisted Organization CR's spec.planSlug.
+	if tenantSlug != "" {
+		body, err := h.k8sGet("/apis/orgs.openova.io/v1/organizations/" + tenantSlug)
+		if err == nil {
+			var org struct {
+				Spec struct {
+					PlanSlug string `json:"planSlug"`
+				} `json:"spec"`
+			}
+			if jerr := json.Unmarshal(body, &org); jerr == nil {
+				if slug := strings.TrimSpace(org.Spec.PlanSlug); slug != "" {
+					return slug, true
+				}
+			}
+		}
+		// A 404 (no Organization CR — legacy tenant-service flow) or any read
+		// error falls through to the catalog lookup; it is not, by itself, a
+		// reason to fail the day-2 change.
+	}
+
+	// 2. Fallback: live catalog. Distinguish a CONFIRMED hit from the
+	// silent-"s" default so the caller can fail-closed on a transient. We
+	// re-run the lookup but inspect whether the catalog was actually reachable
+	// + the plan resolved, rather than trusting resolvePlanSlug's "s" sentinel.
+	slug, reachable := h.lookupPlanSlug(ctx, planID)
+	if reachable {
+		return slug, true
+	}
+	// Catalog unreachable AND no CR planSlug: return the historical "s" default
+	// but flag it non-authoritative so day-2 boundary decisions fail-closed.
+	return "s", false
+}
+
+// lookupPlanSlug is the catalog HTTP plan-slug lookup that DISTINGUISHES a
+// confirmed result from an unreachable-catalog transient. It returns
+// (slug, reachable): reachable=true means the catalog answered (the plan
+// resolved, or is genuinely absent → "s" is then a real answer); reachable=false
+// means the catalog could not be consulted (no URL / timeout / non-200 / decode
+// error) so the "s" is a GUESS, not a confirmed downgrade. resolvePlanSlug keeps
+// its original always-"s"-on-failure contract for the creation path (which is
+// self-consistent because it resolves once); the day-2 path uses this richer
+// signal via resolveTenantPlanSlug.
+func (h *Handler) lookupPlanSlug(ctx context.Context, planID string) (slug string, reachable bool) {
+	if h.CatalogURL == "" {
+		return "s", false
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, h.CatalogURL+"/catalog/plans", nil)
+	if err != nil {
+		return "s", false
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "s", false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		io.Copy(io.Discard, resp.Body)
+		return "s", false
+	}
+	var plans []struct {
+		ID   string `json:"id"`
+		Slug string `json:"slug"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&plans); err != nil {
+		return "s", false
+	}
+	// Catalog answered. A matching plan is authoritative; a genuine miss
+	// (unknown/empty planID) is a real "s" answer (reachable=true).
+	for _, p := range plans {
+		if p.ID == planID {
+			return p.Slug, true
+		}
+	}
+	return "s", true
+}
+
 // appDisplayName returns a human-readable name for an app.
 func appDisplayName(names map[string]string, id string) string {
 	if names != nil {

--- a/core/services/provisioning/handlers/resolve_plan_slug_4293_test.go
+++ b/core/services/provisioning/handlers/resolve_plan_slug_4293_test.go
@@ -1,0 +1,110 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// #4293 MAJOR-3 — resolvePlanSlug silently returned "s" on ANY transient
+// catalog failure, so a day-2 install for a paid (M+) Org could re-route apps
+// to the wrong boundary on a momentary catalog blip. The fix splits the lookup
+// so the day-2 path can DISTINGUISH a confirmed answer from an
+// unreachable-catalog guess (lookupPlanSlug → reachable bool) and reads the
+// authoritative spec.planSlug off the Organization CR first
+// (resolveTenantPlanSlug). These tests lock the new fail-closed signal.
+
+// catalogPlansStub stands up an httptest server serving /catalog/plans with the
+// given status + body. Returns the base URL to set as Handler.CatalogURL.
+func catalogPlansStub(t *testing.T, status int, body string) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/catalog/plans" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func TestLookupPlanSlug_ConfirmedHit(t *testing.T) {
+	url := catalogPlansStub(t, http.StatusOK, `[{"id":"plan-m-uuid","slug":"m"},{"id":"plan-s-uuid","slug":"s"}]`)
+	h := &Handler{CatalogURL: url}
+	slug, reachable := h.lookupPlanSlug(context.Background(), "plan-m-uuid")
+	if !reachable {
+		t.Fatalf("a 200 catalog response must be reachable=true")
+	}
+	if slug != "m" {
+		t.Errorf("slug = %q, want m", slug)
+	}
+}
+
+func TestLookupPlanSlug_GenuineMissIsReachable(t *testing.T) {
+	// Catalog answered, plan genuinely absent → "s" is a REAL answer (reachable).
+	url := catalogPlansStub(t, http.StatusOK, `[{"id":"other","slug":"l"}]`)
+	h := &Handler{CatalogURL: url}
+	slug, reachable := h.lookupPlanSlug(context.Background(), "unknown-uuid")
+	if !reachable {
+		t.Errorf("a genuine plan-miss on a reachable catalog must be reachable=true")
+	}
+	if slug != "s" {
+		t.Errorf("slug = %q, want s (default for a real miss)", slug)
+	}
+}
+
+func TestLookupPlanSlug_TransientFailuresAreUnreachable(t *testing.T) {
+	t.Run("non-200", func(t *testing.T) {
+		url := catalogPlansStub(t, http.StatusInternalServerError, `boom`)
+		h := &Handler{CatalogURL: url}
+		if slug, reachable := h.lookupPlanSlug(context.Background(), "plan-m-uuid"); reachable {
+			t.Errorf("a 500 must be reachable=false (transient), got slug=%q reachable=true", slug)
+		}
+	})
+	t.Run("decode-error", func(t *testing.T) {
+		url := catalogPlansStub(t, http.StatusOK, `{not-json`)
+		h := &Handler{CatalogURL: url}
+		if _, reachable := h.lookupPlanSlug(context.Background(), "plan-m-uuid"); reachable {
+			t.Errorf("a decode error must be reachable=false (transient)")
+		}
+	})
+	t.Run("no-catalog-url", func(t *testing.T) {
+		h := &Handler{CatalogURL: ""}
+		if _, reachable := h.lookupPlanSlug(context.Background(), "plan-m-uuid"); reachable {
+			t.Errorf("an empty CatalogURL must be reachable=false")
+		}
+	})
+}
+
+// TestResolveTenantPlanSlug_FailsClosedOnTransient is the headline MAJOR-3 lock.
+// With no in-cluster env (Org CR read fails) AND a transient catalog failure,
+// resolveTenantPlanSlug must return authoritative=false so the day-2 caller
+// ABORTS rather than silently downgrading a paid Org to host tier.
+func TestResolveTenantPlanSlug_FailsClosedOnTransient(t *testing.T) {
+	clearK8sEnv(t) // Org CR read returns "not running in cluster"
+	url := catalogPlansStub(t, http.StatusInternalServerError, `boom`)
+	h := &Handler{CatalogURL: url}
+	slug, authoritative := h.resolveTenantPlanSlug(context.Background(), "acme", "plan-m-uuid")
+	if authoritative {
+		t.Fatalf("catalog transient + no CR planSlug MUST be authoritative=false (fail-closed), got slug=%q authoritative=true", slug)
+	}
+}
+
+// TestResolveTenantPlanSlug_CatalogFallbackAuthoritative — when the Org CR read
+// fails (no in-cluster env) but the catalog is reachable, the confirmed catalog
+// hit is authoritative (the fresh-prov / catalog-up day-2 path keeps working).
+func TestResolveTenantPlanSlug_CatalogFallbackAuthoritative(t *testing.T) {
+	clearK8sEnv(t)
+	url := catalogPlansStub(t, http.StatusOK, `[{"id":"plan-m-uuid","slug":"m"}]`)
+	h := &Handler{CatalogURL: url}
+	slug, authoritative := h.resolveTenantPlanSlug(context.Background(), "acme", "plan-m-uuid")
+	if !authoritative {
+		t.Fatalf("a reachable-catalog confirmed hit must be authoritative=true")
+	}
+	if slug != "m" {
+		t.Errorf("slug = %q, want m", slug)
+	}
+}


### PR DESCRIPTION
## What / Why

Adversarial review of the vcluster EPIC #4293 keystone stack (#4297, comment 2026-06-25) flagged **1 CRITICAL + 2 MAJOR + 1 MINOR** — each blocking a fresh-prov validation. This PR fixes all four, stacked on `fix/4282-xregion-standby` (PR #4313, the cross-region CNPG split) so the CRITICAL fix composes with the region-A/region-B placement.

READ-ONLY on live; no merge/roll. `Refs #4293 #4297` (NOT Closes — the issues close only after the operator's fresh-prov walk-with-screenshot).

## Findings → fixes

### 🔴 CRITICAL-1 — CNPG-pair must stay HOST-side even for the vcluster tier
`core/services/provisioning/gitops/gitops.go`

The keystone gave the **PRIMARY** `bp-cnpg-pair` HR a vcluster kubeConfig → the host helm-controller `helm install`ed the `postgresql.cnpg.io/v1 Cluster` CR **INTO the Org vcluster**, which has **no Cluster CRD and no watching cnpg operator** (the operator + CRD are host-only cluster-singletons, slot 16). Result: `no matches for kind "Cluster"` → the **paid M+ active-hot-standby HA path wedged** on every fresh prov.

**Fix:** the PRIMARY HR carries **no vcluster kubeConfig regardless of tier** — it reconciles on region A's **host** `<slug>` ns where the operator + CRD live (`targetNamespace: acme`, `namespace: acme`, no `kubeConfig:`). The in-vcluster app pods reach the DB via the synced `postgres` Service + the apps-tree credentials Secret. Composes cleanly with #4313: replica side still targets the region-B kubeconfig (`sovereign-replica-region-kubeconfig`).

Render-verified (plan=m): primary HR `kubeConfig? false`, ns/targetNamespace `acme`; replica HR `kubeConfig? true` → region-B secret.

### 🟠 MAJOR-2 — the default-deny NetworkPolicy was reconciled by nothing
`core/controllers/organization/internal/controller/per_org_flux.go` + `.../internal/gitops/manifests.go`

The org-controller wrote `vcluster/apps/networkpolicy.yaml` to the per-Org **Gitea** repo, but the per-Org `-vcluster` Kustomization reconciles `./vcluster` (omits `apps/`) and the funnel apps-sync reads a **different (GitHub) repo** → the NP landed nowhere → intra-Org isolation stayed inert.

**Fix:** the org-controller now authors a **second per-Org Flux Kustomization** `catalyst-tenant-<slug>-apps` over `./vcluster/apps`, **tier-aware**:
- **vcluster tier** — carries `spec.kubeConfig` (→ `tenant-<slug>-kubeconfig`) so the NP lands in the vcluster apiserver; the syncer (`sync.toHost.networkPolicies`) reflects it to the host `<slug>` ns Cilium enforces.
- **host tier** — no kubeConfig; NP applies straight to the host `<slug>` ns.

`targetNamespace: <slug>` rewrites the NP's authored `apps` ns. Added an explicit `vcluster/apps/kustomization.yaml` index + teardown of the new Kustomization. Exported `gitops.BoundaryIsVcluster` for the tier gate.

### 🟠 MAJOR-3 — `resolvePlanSlug` silently defaulted to `"s"` on a transient catalog blip
`core/services/provisioning/handlers/handlers.go` + `consumer.go`

On a **day-2** install for a paid (M+) Org, a momentary catalog failure made `resolvePlanSlug` return `"s"` → `applyTenantChange` re-emitted apps-sync **without kubeConfig** → Flux re-routed the apps into the **host ns** and orphaned the in-vcluster copy.

**Fix:** new `resolveTenantPlanSlug` reads the **authoritative `spec.planSlug` off the Organization CR** first (immune to a catalog blip; the EPIC's single truth-source). `lookupPlanSlug` now returns a `reachable` bool so the day-2 re-generation path **fails-closed** (aborts → job retries) rather than committing a host-tier downgrade off a guess. The fresh-prov funnel path (resolves once, threads through) is unchanged.

### 🟡 MINOR-4 — `waitForVclusterAppGone` (day-2 uninstall) was not tier-gated
`core/services/provisioning/handlers/consumer.go`

It hardcoded the `-x-apps-x-vcluster` syncer suffix, so a host-tier uninstall (native pod name) reported "gone" prematurely. **Fix:** thread `isVcluster` + reuse `appPodNameMatches`, mirroring the install side.

## Tests / validation
- `go build` / `go vet` / `go test ./...` green for **both** modules (`core/services/provisioning`, `core/controllers/organization`).
- New/updated unit tests lock each fix:
  - `TestCNPGPair_PrimaryStaysHostSide_BothTiers` (m + s) — primary HR has no vcluster kubeConfig, host ns/targetNamespace.
  - `TestCNPGPair_XRegion_ReplicaTargetsRegionB` still green (composes with #4313).
  - `TestReconcilePerOrgFlux_AppsKustomization_VclusterTier` / `_HostTier` / `TestTeardownPerOrgFlux_DeletesAppsKustomization` — NP reconciled into the right boundary, tier-gated, torn down.
  - `TestLookupPlanSlug_*` + `TestResolveTenantPlanSlug_FailsClosedOnTransient` / `_CatalogFallbackAuthoritative` — no silent downgrade.
  - `TestAppPodNameMatches_TierAware` covers the MINOR-4 matcher the uninstall wait now reuses.
- Render-checked the generated apps Kustomization + NP and the host-side primary CNPG HR.

## Scope
- Builds on `fix/4282-xregion-standby` (#4313) → builds on `fix/4297-apps-into-vcluster` (the #4293 keystone). READ-ONLY on live; no live mutation, no force-reconcile, no catalyst-api restart.
- With CRITICAL-1 + MAJOR-2 fixed, the stack is fresh-prov-validation-ready (the two findings that failed the EPIC's own acceptance steps 3/4 + the Pillar-3 walk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
