### PR TITLE
fix(bp-openclaw): kube-apiserver entity egress for the controller pod-reaper (0.2.6)

### DIFF
--- a/platform/openclaw/blueprint.yaml
+++ b/platform/openclaw/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-7-agentic-workspace
 spec:
-  version: 0.2.5
+  version: 0.2.6
   card:
     title: OpenClaw
     summary: |

--- a/platform/openclaw/chart/Chart.yaml
+++ b/platform/openclaw/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-openclaw
-version: 0.2.5
+version: 0.2.6
 appVersion: "0.2.0"
 description: |
   Catalyst Blueprint chart for the OpenClaw workspace controller pattern
@@ -31,6 +31,26 @@ description: |
 
   Changelog
   ─────────
+  0.2.6 (2026-06-25, #4272)
+    - Add in-cluster Kubernetes API egress for the controller pod-reaper.
+      Even after 0.2.5 (public-host JWKS :443) + #4300, the controller
+      stayed 0/1 on a fresh Org with `reaper: list pods 10.96.0.1:443
+      context deadline exceeded`. Root cause: the reaper dials the
+      `kubernetes.default` ClusterIP (10.96.0.1:443), which Cilium
+      classifies as the reserved `kube-apiserver` ENTITY — no K8s
+      NetworkPolicy selector (podSelector / namespaceSelector / ipBlock,
+      even 0.0.0.0/0 EXCLUDES it) can express it, so the K8s NP's
+      kube-system :443 rule did NOT admit it → every apiserver call
+      default-denied → never Ready.
+        • cilium-ingress-networkpolicy.yaml: add an `egress` block with
+          `toEntities: [kube-apiserver]` → :443/:6443 (the canonical idiom
+          from platform/sso-bridge cilium-networkpolicy-apiserver.yaml). The
+          CNP now opens BOTH the ingress (gateway + kubelet probe) AND the
+          egress (apiserver) reserved-entity hops; each half is independently
+          gated (`networkPolicy.ingress.allowGatewayEntity` /
+          `networkPolicy.egress.allowApiserverEntity`, both default true) and
+          the whole template stays gated on the cilium.io/v2 Capabilities
+          check (CRD-less kind CI installs unaffected).
   0.2.5 (2026-06-25, #4272)
     - Rework NetworkPolicy + exposure for the Cilium-Gateway Sovereign
       topology (was traefik + separate-keycloak-namespace). The controller

--- a/platform/openclaw/chart/templates/cilium-ingress-networkpolicy.yaml
+++ b/platform/openclaw/chart/templates/cilium-ingress-networkpolicy.yaml
@@ -1,7 +1,8 @@
 {{- /*
 #4272: the Cilium Gateway path to the OpenClaw controller is DEAD without
 this CNP, AND the kubelet readiness/liveness probe is dropped by the K8s
-NetworkPolicy on a Sovereign. Two facts drive this template:
+NetworkPolicy on a Sovereign, AND the controller's pod-reaper cannot reach
+the in-cluster Kubernetes API. Three facts drive this template:
 
   1. Cilium Gateway API traffic reaches the backend with the reserved
      `ingress` ENTITY identity (the Envoy proxy embedded in the cilium
@@ -20,16 +21,35 @@ NetworkPolicy on a Sovereign. Two facts drive this template:
      ingress, so the probe MUST be admitted here or the Pod stays 0/1 even
      after the JWKS egress is fixed.
 
-CiliumNetworkPolicy fromEntities is the canonical, ADDITIVE expression:
+  3. The controller's pod-reaper (and every other apiserver call: list/
+     create/delete per-user pods, get/list Secrets) dials the in-cluster
+     Kubernetes API at the `kubernetes.default` ClusterIP (10.96.0.1:443).
+     Cilium classifies that destination as the reserved `kube-apiserver`
+     ENTITY — which, like `ingress`/`host`, NO K8s NetworkPolicy selector
+     (podSelector / namespaceSelector / ipBlock — even ipBlock 0.0.0.0/0
+     EXCLUDES it) can express. The K8s NP's `namespaceSelector:
+     kube-system` :443 rule matches the kube-system Pods, NOT the
+     apiserver ENTITY, so every reaper `list pods` to 10.96.0.1:443 is
+     default-denied → `reaper: list pods 10.96.0.1:443 context deadline
+     exceeded` → the controller never becomes Ready (0/1). #4300 fixed the
+     public-host JWKS :443 egress but left this in-cluster-API hop denied.
+     `toEntities: [kube-apiserver]` is the canonical expression — same
+     idiom as platform/sso-bridge cilium-networkpolicy-apiserver.yaml.
+
+CiliumNetworkPolicy from/toEntities is the canonical, ADDITIVE expression:
 when both a K8s NetworkPolicy and a CNP select the same Pod the allow-sets
-UNION, so this only opens the gateway→controller + node→controller hops and
-leaves every other default-deny posture intact.
+UNION, so this only opens the gateway→controller + node→controller ingress
+hops and the controller→apiserver egress hop, and leaves every other
+default-deny posture intact.
 
 Gated on the cilium.io/v2 Capabilities check (the #2988/#3102 idiom) so the
 chart still installs on CRD-less clusters (kind CI), and on
-networkPolicy.ingress.allowGatewayEntity so a non-Cilium overlay can opt out.
+networkPolicy.ingress.allowGatewayEntity / networkPolicy.egress.
+allowApiserverEntity so a non-Cilium overlay can opt out of either half.
 */ -}}
-{{- if and .Values.controller.enabled .Values.networkPolicy.enabled .Values.networkPolicy.ingress.allowGatewayEntity (.Capabilities.APIVersions.Has "cilium.io/v2") }}
+{{- $apiserverEgress := .Values.networkPolicy.egress.allowApiserverEntity }}
+{{- $gatewayIngress := .Values.networkPolicy.ingress.allowGatewayEntity }}
+{{- if and .Values.controller.enabled .Values.networkPolicy.enabled (or $gatewayIngress $apiserverEgress) (.Capabilities.APIVersions.Has "cilium.io/v2") }}
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -42,6 +62,7 @@ spec:
     matchLabels:
       {{- include "bp-openclaw.selectorLabels" . | nindent 6 }}
       catalyst.openova.io/component: controller
+  {{- if $gatewayIngress }}
   ingress:
     - fromEntities:
         {{- toYaml .Values.networkPolicy.ingress.gatewayEntities | nindent 8 }}
@@ -49,4 +70,24 @@ spec:
         - ports:
             - port: {{ .Values.controller.port | quote }}
               protocol: TCP
+  {{- end }}
+  {{- if $apiserverEgress }}
+  egress:
+    # ── In-cluster Kubernetes API (the pod-reaper hop, #4272) ──────────────
+    # The controller's reaper lists/creates/deletes per-user pods + reads
+    # Secrets against the `kubernetes.default` ClusterIP (10.96.0.1:443).
+    # Cilium classifies that destination as the reserved `kube-apiserver`
+    # ENTITY — no K8s NetworkPolicy selector can express it (even ipBlock
+    # 0.0.0.0/0 EXCLUDES it), so the K8s NP's kube-system :443 rule does NOT
+    # admit it. Without this carve-out the reaper logs `list pods
+    # 10.96.0.1:443 context deadline exceeded` and the Pod stays 0/1.
+    - toEntities:
+        {{- toYaml .Values.networkPolicy.egress.apiserverEntities | nindent 8 }}
+      toPorts:
+        - ports:
+            {{- range .Values.networkPolicy.egress.apiserverPorts }}
+            - port: {{ . | quote }}
+              protocol: TCP
+            {{- end }}
+  {{- end }}
 {{- end }}

--- a/platform/openclaw/chart/values.yaml
+++ b/platform/openclaw/chart/values.yaml
@@ -270,6 +270,12 @@ httpRoute:
 #   - Cilium Gateway Envoy (`ingress` entity) + kubelet probe (`host` /
 #     `remote-node` entities) — admitted by the CNP, NOT the K8s NP
 #     (#4272 — reserved entities are not Pod-selectable).
+# Controller egress (reserved-entity, CNP-only):
+#   - in-cluster Kubernetes API (`kube-apiserver` entity, 10.96.0.1:443) —
+#     the pod-reaper hop; the K8s NP kube-system :443 rule does NOT match the
+#     apiserver entity, so it MUST be admitted by the CNP toEntities carve-out
+#     (#4272 — else `reaper: list pods 10.96.0.1:443 context deadline exceeded`
+#     keeps the controller 0/1, beyond the #4300 public-host JWKS :443 fix).
 # Per-user pods receive their NetworkPolicy from a controller-rendered
 # template at session-start, NOT from this chart.
 networkPolicy:
@@ -290,6 +296,32 @@ networkPolicy:
       - ingress
       - host
       - remote-node
+  # Reserved-ENTITY EGRESS (#4272). The controller's pod-reaper + every
+  # apiserver call (list/create/delete per-user pods, get/list Secrets) dials
+  # the in-cluster Kubernetes API at the `kubernetes.default` ClusterIP
+  # (10.96.0.1:443). Cilium classifies that destination as the reserved
+  # `kube-apiserver` ENTITY — no K8s NetworkPolicy selector can express it
+  # (even ipBlock 0.0.0.0/0 EXCLUDES it), so the K8s NP's kube-system :443
+  # rule does NOT admit it → `reaper: list pods 10.96.0.1:443 context deadline
+  # exceeded` → the controller never becomes Ready (0/1). The companion CNP
+  # opens this hop additively. #4300 fixed the public-host JWKS :443 egress
+  # but left this in-cluster-API hop denied — this knob closes that gap.
+  egress:
+    # Emit the CiliumNetworkPolicy toEntities egress carve-out for the
+    # apiserver. Default ON (a Sovereign needs it). A non-Cilium overlay can
+    # set this false — the template is also gated on the cilium.io/v2
+    # Capabilities check so it never breaks CRD-less installs.
+    allowApiserverEntity: true
+    # Reserved entities the controller may egress to. `kube-apiserver` is the
+    # canonical entity for the in-cluster API (10.96.0.1:443) on both a k3s
+    # host-process apiserver and a managed cluster.
+    apiserverEntities:
+      - kube-apiserver
+    # Ports the apiserver listens on. 443 is the in-cluster `kubernetes`
+    # Service port; 6443 covers k3s/embedded apiservers fronted directly.
+    apiserverPorts:
+      - "443"
+      - "6443"
   controller:
     ingress:
       # K8s namespace-selector ingress. EMPTY on a Sovereign — the gateway hop


### PR DESCRIPTION
## Problem

Fresh Org `tkt0625` (omantel.biz `omantel-region-a`) has bp-openclaw at chart **0.2.5** (the #4272 JWKS-egress / CNP / HTTPRoute fix delivered) but the controller Pod is **0/1** (not Ready). On the demo Org the live error is:

```
reaper: list pods 10.96.0.1:443 context deadline exceeded
```

`10.96.0.1:443` is the in-cluster `kubernetes.default` ClusterIP — the controller's pod-reaper (and every other apiserver call: list/create/delete per-user pods, get/list Secrets) can't reach the API server.

## Root cause — the egress gap beyond #4300

Cilium classifies traffic to `10.96.0.1:443` as the reserved **`kube-apiserver` ENTITY**, which NO K8s NetworkPolicy selector (`podSelector` / `namespaceSelector` / `ipBlock` — even `0.0.0.0/0` **excludes** it) can express. The controller's K8s NetworkPolicy has a `namespaceSelector: kube-system` :443 egress rule — but that matches kube-system **Pods**, NOT the apiserver entity. So every apiserver call was default-denied → the `/readyz` reaper path times out → the Pod never becomes Ready.

**#4300 fixed the public-host JWKS :443 egress** (the OIDC hairpin to the console-ELB) but left this **in-cluster-API** hop denied. Same failure class as the documented sso-bridge `kube-apiserver` entity saga (`platform/sso-bridge/chart/templates/cilium-networkpolicy-apiserver.yaml`).

## Fix

Extend the companion `cilium-ingress-networkpolicy.yaml` with an `egress` block:

```yaml
egress:
  - toEntities: [kube-apiserver]
    toPorts:
      - ports:
          - { port: "443", protocol: TCP }
          - { port: "6443", protocol: TCP }
```

This is the canonical idiom (mirrors `platform/sso-bridge`). The CNP now opens **both** reserved-entity hops the K8s NP cannot select:
- **ingress**: gateway Envoy (`ingress`) + kubelet probe (`host`/`remote-node`)
- **egress**: in-cluster API (`kube-apiserver`)

Each half is independently gated (`networkPolicy.ingress.allowGatewayEntity` / `networkPolicy.egress.allowApiserverEntity`, both default `true`), and the whole template stays gated on the `cilium.io/v2` Capabilities check so CRD-less kind CI renders no CNP.

Chart **0.2.5 → 0.2.6** (`Chart.yaml` + `blueprint.yaml` bumped in lockstep — #3910 trap).

## Validation

- `helm lint` green.
- `helm template` verified across all gate variants:
  - Sovereign (cilium cap present): CNP emits **both** ingress + egress(`kube-apiserver` → 443/6443).
  - kind CI (no cilium cap): **no** CNP resource rendered.
  - `egress.allowApiserverEntity=false`: ingress-only.
  - `ingress.allowGatewayEntity=false`: egress-only.
  - both off: no CNP.

## Would a fresh Org now converge openclaw?

Yes — the controller's `/readyz` reaper path needs the apiserver to `list pods`; with the `kube-apiserver` egress entity admitted, the reaper's `list pods 10.96.0.1:443` succeeds → readiness no longer times out → the controller reaches Ready (1/1) and the per-Org bp-openclaw HR converges. (Live-verify on a fresh Org once chart 0.2.6 is delivered + the Org Application re-pins; per the merged≠delivered rule, the running env needs the new pin rolled before the convergence is proven.)

Refs #4272

🤖 Generated with [Claude Code](https://claude.com/claude-code)