### PR TITLE
fix(bp-wordpress-tenant): oidc-config hook fetches pg4wp from v3.3.1 tag (un-prefixed 404'd → fresh-Org HR Ready=False) (0.4.17)

### DIFF
--- a/platform/wordpress-tenant/blueprint.yaml
+++ b/platform/wordpress-tenant/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: tenant-app
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.4.16
+  version: 0.4.17
   card:
     title: WordPress (per-Organization)
     summary: |

--- a/platform/wordpress-tenant/chart/Chart.yaml
+++ b/platform/wordpress-tenant/chart/Chart.yaml
@@ -204,7 +204,25 @@ name: bp-wordpress-tenant
 #   backend. The OIDC plugin settings + admin user persist in POSTGRES, not on
 #   the PVC, so an ephemeral wp-content is correct + deadlock-free. The recovered
 #   demo-Org HR converges Ready without the Multi-Attach stall.
-version: 0.4.16
+# 0.4.17 (Refs #4220 #4155): FIX the oidc-config hook Job 404 that left a FRESH
+#   Org's HelmRelease Ready=False. The 0.4.16 emptyDir self-seed (above) fetched
+#   the pg4wp adapter from the GitHub tag archive but used the path
+#   `.../tags/3.3.1.zip` — the release tag is `v3.3.1`, so the un-prefixed path
+#   returns HTTP 404 ("curl: (22) The requested URL returned error: 404"). The
+#   hook is hook-weight 10 (the first thing after db-secret-sync), so on a fresh
+#   Org it failed on its VERY FIRST run → db.php never seeded → wp-cli could not
+#   reach the bp-cnpg Postgres backend → the post-install/post-upgrade hook
+#   errored → Helm timed out → HR Ready=False. The deployment's wp-plugin-install
+#   initContainer already used the CORRECT `.../tags/v3.3.1.zip` (so the runtime
+#   data-plane Pod served fine) — only the Job's URL was wrong, hence the split
+#   where the WordPress Pod was 1/1 Running 302 but the HR stayed False.
+#   FIX: align the Job's pg4wp fetch URL to `v3.3.1.zip` (identical to the
+#   deployment). The extracted top-level dir is still `postgresql-for-wordpress-
+#   3.3.1` (GitHub strips the `v`), so the cp paths are unchanged. Root-caused
+#   live on the tkt0625 fresh Org (omantel.biz region-a, 2026-06-25): the live
+#   oidc-config pod logged exactly `[oidc-config] seeding pg4wp db.php drop-in
+#   (Postgres adapter)` then `curl: (22) ... error: 404`; `v3.3.1.zip` returns 200.
+version: 0.4.17
 appVersion: "6"
 description: |
   Catalyst Blueprint scratch chart for in-vcluster WordPress, one

--- a/platform/wordpress-tenant/chart/templates/oidc-config-job.yaml
+++ b/platform/wordpress-tenant/chart/templates/oidc-config-job.yaml
@@ -160,8 +160,20 @@ spec:
               if [ ! -f wp-content/db.php ]; then
                 echo "[oidc-config] seeding pg4wp db.php drop-in (Postgres adapter)"
                 mkdir -p wp-content
+                # The release tag is `v3.3.1` — the GitHub archive path keeps
+                # the `v` prefix (this is the SAME URL the deployment's
+                # wp-plugin-install initContainer uses). The bare `3.3.1.zip`
+                # (no `v`) returns HTTP 404, which left this Job FATAL
+                # ("curl: (22) The requested URL returned error: 404") on the
+                # FIRST post-install/post-upgrade hook of a fresh Org — the hook
+                # never seeded db.php, `wp` could not reach the bp-cnpg Postgres
+                # backend, the hook errored, Helm timed out and the HelmRelease
+                # stuck Ready=False (root-caused live on the tkt0625 fresh Org,
+                # omantel.biz region-a). GitHub still extracts the archive to
+                # `postgresql-for-wordpress-3.3.1` (the `v` is stripped from the
+                # top-level directory name), so the cp paths below are unchanged.
                 curl -fsSL -o /tmp/pg4wp.zip \
-                  https://github.com/PostgreSQL-For-Wordpress/postgresql-for-wordpress/archive/refs/tags/3.3.1.zip
+                  https://github.com/PostgreSQL-For-Wordpress/postgresql-for-wordpress/archive/refs/tags/v3.3.1.zip
                 # wp-cli's bundled PHP can unzip without a system `unzip`.
                 php -r '$z=new ZipArchive();$z->open("/tmp/pg4wp.zip");$z->extractTo("/tmp/");$z->close();'
                 cp -a /tmp/postgresql-for-wordpress-3.3.1/pg4wp wp-content/

--- a/platform/wordpress-tenant/chart/tests/oidc-config.sh
+++ b/platform/wordpress-tenant/chart/tests/oidc-config.sh
@@ -234,7 +234,15 @@ cmd = "\n".join(spec['containers'][0].get('command') or []) \
     + "\n".join(spec['containers'][0].get('args') or [])
 assert 'pg4wp' in cmd and 'db.php' in cmd, \
   "oidc-config Job command must self-seed the pg4wp db.php drop-in"
-print(f"  emptyDir wp-content -> {mount['mountPath']}; pg4wp db.php self-seeded")
+# 0.4.17 (Refs #4220): the pg4wp GitHub archive tag is `v3.3.1` — the bare
+# `tags/3.3.1.zip` (no `v`) 404s, which left a fresh Org's HR Ready=False
+# (the hook errored on its first run). Assert the `v`-prefixed URL and reject
+# the un-prefixed form so the regression cannot recur.
+assert 'archive/refs/tags/v3.3.1.zip' in cmd, \
+  "oidc-config Job must fetch pg4wp from the v-prefixed tag (v3.3.1.zip), not a 404 path"
+assert 'archive/refs/tags/3.3.1.zip' not in cmd, \
+  "oidc-config Job must NOT use the un-prefixed pg4wp tag (3.3.1.zip 404s)"
+print(f"  emptyDir wp-content -> {mount['mountPath']}; pg4wp db.php self-seeded (v3.3.1)")
 PYEOF
 echo "  PASS"
 


### PR DESCRIPTION
## Root cause (live, omantel.biz region-a)

Fresh Org `tkt0625` (ns `org-5d392c0b-3f8d-4365-8123-5d6a06af6b9a`) — `bp-wordpress-tenant` HelmRelease **Ready=False**. Two layers were found; **this PR fixes the chart layer.**

### Chart bug — oidc-config hook pg4wp fetch 404 (THIS PR)

`chart/templates/oidc-config-job.yaml` (the #4220 emptyDir self-seed) fetched pg4wp from `.../archive/refs/tags/3.3.1.zip`. The upstream release **tag is `v3.3.1`**, so the un-prefixed path returns **HTTP 404**:

```
[oidc-config] seeding pg4wp db.php drop-in (Postgres adapter)
curl: (22) The requested URL returned error: 404
```

The Job is hook-weight 10 (first post-install/upgrade hook after db-secret-sync), so on a FRESH Org it failed on its very first run → `db.php` never seeded → wp-cli could not reach the bp-cnpg Postgres backend → hook errored → Helm timed out → **HR Ready=False**. The runtime data-plane Pod served HTTP 302 fine because the deployment's `wp-plugin-install` initContainer already used the correct `v3.3.1.zip` — only the Job's URL was wrong (hence the split: Pod 1/1 Running but HR False).

**Fix:** align the Job URL to `v3.3.1.zip`. GitHub still extracts to `postgresql-for-wordpress-3.3.1` (the `v` is stripped from the dir name), so cp paths are unchanged. Adds a render-gate assertion that the Job uses the v-prefixed tag and rejects the 404 path.

## Verification

- `helm lint` 0 failed; `helm template` renders the Job with `v3.3.1.zip`.
- `chart/tests/oidc-config.sh` — all 7 cases PASS incl. the new v3.3.1 assertion.
- **Live in-cluster proof (tkt0625 ns, real wp-cli image):** `FETCH_OK bytes=1477110` + `db.php` present with `v3.3.1.zip`; `3.3.1.zip` → 404.
- **Live convergence chain proven:** patching the corrupted cnpg webhook caBundle (see below) admitted the previously-rejected `wordpress-db` Cluster → DB 1/1 healthy → WordPress Pod 1/1 served `GET / → 302` (was 500) + the `db-secret-sync` belt-and-suspenders Job Completed + reflector populated the 64-byte password. The only remaining live failure was the oidc-config 404 this PR fixes.

## Separate env-state P0 (NOT this chart, tracked in #4322)

The cluster-singleton cnpg webhook caBundle holds a **leaf cert (CA:FALSE)** instead of the `cnpg-ca-secret` **CA**, so the apiserver `x509: certificate signed by unknown authority` rejects every new CNPG Cluster cluster-wide (incl. `wordpress-db`). The cnpg-system operator **re-corrupts** the caBundle on each webhook reconcile (residue of the #4143 hijack; #4201 made per-Org operators webhook-less but this env's cnpg-system operator itself writes the wrong bytes). Producer-side gap: `platform/cnpg` webhook-gate checks the caBundle is non-empty, not that it is a valid CA signing the served leaf. That is bp-cnpg / operator work, NOT this chart.

## Would a fresh Org now converge wordpress?

Yes — **once both** (a) this chart fix (0.4.17) is delivered AND (b) the cnpg-system caBundle stops being corrupted (the #4322 env-state P0). With the caBundle patched, the full chain converged live except for the 404 this PR removes.

Refs #4322 #4220 #4155 #4143 #4201

🤖 Generated with [Claude Code](https://claude.com/claude-code)
