### PR TITLE
fix(bp-cnpg): durable webhook caBundle fix — cnpg-system operator no longer corrupts it with a leaf cert (1.0.13)

### DIFF
--- a/clusters/_template/bootstrap-kit/16-cnpg.yaml
+++ b/clusters/_template/bootstrap-kit/16-cnpg.yaml
@@ -99,7 +99,15 @@ spec:
       #         flux-managed policy (the gate Job still renders here, unlike the
       #         per-Org webhook-less case). Unblocks the bp-catalyst-platform
       #         dependsOn → the #4222 catalyst-api roll → the #4179 funnel close.
-      version: 1.0.12
+      # 1.0.13 (G64 #4322): durable fix for the cnpg-system operator CORRUPTING
+      #         the webhook caBundle with a LEAF cert (CA:FALSE) instead of the
+      #         cnpg-ca-secret CA (CA:TRUE) — upstream #9817, re-asserted hourly,
+      #         x509-rejecting EVERY Cluster create/patch cluster-wide. Sets the
+      #         operator config MANAGE_WEBHOOK_CONFIGURATIONS=false (stops the
+      #         corruption at source) + ships a webhook-cabundle-reasserter
+      #         (Helm-hook Job + 10m CronJob) that writes the real CA, + hardens
+      #         the gate to assert CA:TRUE. Fresh provs never hit the x509 wall.
+      version: 1.0.13
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg

--- a/platform/cnpg/README.md
+++ b/platform/cnpg/README.md
@@ -200,6 +200,41 @@ spec:
       default_pool_size: "20"
 ```
 
+## Webhook caBundle integrity (G64, #4322)
+
+The platform (`cnpg-system`) install owns the cluster-singleton admission
+webhooks (`cnpg-{mutating,validating}-webhook-configuration`). Upstream CNPG
+(bug [#9817](https://github.com/cloudnative-pg/cloudnative-pg/issues/9817), fix
+PR #9819 unmerged) injects the **serving leaf** (`cnpg-webhook-cert` `tls.crt`,
+`CA:FALSE`) into the webhook `caBundle` instead of the CA
+(`cnpg-ca-secret` `ca.crt`, `CA:TRUE`), and re-asserts it on an hourly tick.
+When the served leaf rotates and diverges from the stale caBundle-leaf, the
+apiserver fails `x509: certificate signed by unknown authority` and **every
+`postgresql.cnpg.io/v1.Cluster` create/patch is rejected cluster-wide**.
+
+This chart fixes it durably (webhook-FULL platform install only — per-Org
+webhook-LESS installs skip all of it):
+
+- `cloudnative-pg.config.data.MANAGE_WEBHOOK_CONFIGURATIONS: "false"` — stops the
+  operator injecting (corrupting) the caBundle at the source (upstream
+  `operator_conf` opt-out for GitOps-managed CA injection; independent of
+  serving-cert/CA generation).
+- `templates/webhook-cabundle-reasserter.yaml` — the GitOps-side CA injector: a
+  post-install/upgrade hook Job + a 10-minute CronJob that read
+  `cnpg-ca-secret` `ca.crt` (validated `CA:TRUE`) and write it into both webhook
+  configs. The CronJob self-heals any residual re-corruption within minutes.
+- `webhook-gate-hook.yaml` asserts the caBundle is a **CA** (`CA:TRUE`), not
+  merely non-empty.
+
+Diagnose a recurrence:
+
+```bash
+kubectl get validatingwebhookconfiguration cnpg-validating-webhook-configuration \
+  -o jsonpath='{.webhooks[0].clientConfig.caBundle}' | base64 -d \
+  | openssl x509 -noout -subject -ext basicConstraints     # must be CA:TRUE / CN=cnpg-ca-secret
+kubectl -n cnpg-system get cronjob,job -l catalyst.openova.io/component=webhook-cabundle-reasserter
+```
+
 ---
 
 *Part of [OpenOva](https://openova.io)*

--- a/platform/cnpg/blueprint.yaml
+++ b/platform/cnpg/blueprint.yaml
@@ -5,7 +5,9 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-4-1-data-services
 spec:
-  version: 1.0.12
+  # 1.0.13 (G64 #4322): lockstep with chart/Chart.yaml — durable fix for the
+  # cnpg-system operator corrupting the webhook caBundle with a leaf cert.
+  version: 1.0.13
   card:
     title: CloudNativePG
     summary: |

--- a/platform/cnpg/chart/Chart.yaml
+++ b/platform/cnpg/chart/Chart.yaml
@@ -49,7 +49,32 @@ name: bp-cnpg
 # (live omantel.biz dep 4635277cae4ffed9). The label is the policy's own
 # documented escape (same as openbao init-job #3374, gitea/harbor hooks
 # #3296→#3297) — guardrail stays fully in force. Refs #4179 #4223 #4220 #3374.
-version: 1.0.12
+#
+# 1.0.13 (G64 #4322, 2026-06-25): durable fix for the cnpg-system operator
+# CORRUPTING the cluster-singleton webhook caBundle with a LEAF cert (CA:FALSE)
+# instead of the cnpg-ca-secret CA (CA:TRUE). Upstream cloudnative-pg bug #9817
+# (fix PR #9819 still UNMERGED): the operator's PKI reconciler injects the
+# webhook clientConfig.caBundle from cnpg-webhook-cert tls.crt (the serving
+# LEAF) and re-asserts it on an `@every 1h` tick + every restart. When the
+# served leaf and the stale caBundle-leaf diverge (cert renewal/regen/restart)
+# the apiserver fails `x509: certificate signed by unknown authority` → EVERY
+# postgresql.cnpg.io/v1.Cluster create/patch rejected cluster-wide (wordpress-db,
+# newapi-pg, all PG-backed apps). Live-confirmed on omantel.biz region-a.
+# THREE changes (webhook-FULL platform install only — webhook-LESS per-Org
+# installs skip all of it via bp-cnpg.webhookGateEnabled):
+#   (1) cloudnative-pg.config.data.MANAGE_WEBHOOK_CONFIGURATIONS="false" — stops
+#       the operator injecting (corrupting) the caBundle at the source (upstream
+#       operator_conf opt-out for GitOps-managed CA injection; independent of
+#       serving-cert/CA generation, so cnpg-ca-secret is still minted).
+#   (2) templates/webhook-cabundle-reasserter.yaml — the GitOps-side CA injector:
+#       a post-install/upgrade Helm-hook Job (weight 4) + a CronJob (every 10m)
+#       that read cnpg-ca-secret ca.crt (validated CA:TRUE) and write it into
+#       both webhook configs' caBundle. The CronJob self-heals against any
+#       residual re-corruption (pre-flip operator pod) within minutes.
+#   (3) webhook-gate-hook.yaml now asserts the caBundle is a CA (CA:TRUE), not
+#       merely non-empty — the producer-side proof the reasserter landed; gate
+#       image bumped 1.30.7 -> 1.31.4 for openssl. Refs #4322 #4143 #4201.
+version: 1.0.13
 description: |
   Catalyst-curated Blueprint umbrella chart for CloudNativePG. Depends on
   the upstream `cloudnative-pg` chart as a Helm subchart so

--- a/platform/cnpg/chart/templates/webhook-cabundle-reasserter.yaml
+++ b/platform/cnpg/chart/templates/webhook-cabundle-reasserter.yaml
@@ -1,0 +1,345 @@
+{{- /*
+G64 (Refs #4322 #4143 #4201, 2026-06-25): durable fix for the cnpg-system
+operator corrupting the cluster-singleton webhook caBundle with a LEAF cert.
+
+The bug (upstream cloudnative-pg #9817, fix PR #9819 still UNMERGED)
+====================================================================
+CNPG's PKI reconciler (`pkg/certs/k8s.go`, injectPublicKeyInto{Mutating,
+Validating}Webhook) writes the webhook `clientConfig.caBundle` from
+`cnpg-webhook-cert` `tls.crt` — i.e. the SERVING LEAF (X509 BasicConstraints
+CA:FALSE) — instead of `cnpg-ca-secret` `ca.crt` (the real CA, CA:TRUE). The
+operator re-runs this injection on a periodic maintenance tick (`@every 1h`)
+AND on every operator restart/leader-election, so it CONTINUOUSLY re-corrupts
+the field — a manual `kubectl patch` of the caBundle back to the CA survives
+at most ~1h.
+
+While the served leaf and the caBundle-leaf are byte-identical the apiserver
+accepts the degenerate single-cert chain, so admission "works" — but the
+moment the operator rotates/regenerates `cnpg-webhook-cert` (cert renewal,
+secret deletion, pod restart) the served leaf and the stale caBundle-leaf
+DIVERGE → the apiserver fails `x509: certificate signed by unknown authority`
+verifying the served chain → EVERY `postgresql.cnpg.io/v1.Cluster` create/patch
+is rejected CLUSTER-WIDE (wordpress-db, newapi-pg, every Postgres-backed app).
+Live-confirmed on omantel.biz region-a (#4322): caBundle held
+`CN=cnpg-webhook-service.cnpg-system.svc CA:FALSE`; the real CA in
+`cnpg-ca-secret` is `CN=cnpg-ca-secret CA:TRUE`.
+
+The durable fix — two complementary levers (this file + values.yaml)
+====================================================================
+1. values.yaml sets the operator config `MANAGE_WEBHOOK_CONFIGURATIONS: "false"`
+   (cnpg-controller-manager-config ConfigMap, read by the operator at startup).
+   Per the upstream operator_conf doc this STOPS the operator injecting the CA
+   bundle into the webhook configs — "Set to false when the CA bundle is
+   injected externally, for example by cert-manager's CA injector or by GitOps"
+   — and is INDEPENDENT of the serving-cert/CA generation (the operator still
+   mints `cnpg-ca-secret` + `cnpg-webhook-cert`). So the corruption STOPS at the
+   source, and a real CA is still available to read.
+
+2. THIS file is the GitOps-side injector that doc refers to: a tiny reasserter
+   that reads `ca.crt` (CA:TRUE) from `cnpg-ca-secret` and writes it into both
+   webhook configs' caBundle. It runs in two shapes for defence-in-depth:
+     (a) a post-install + post-upgrade Helm-hook Job — asserts the correct CA
+         immediately on every chart install/upgrade (before dependents that
+         create Cluster CRs reconcile), and
+     (b) a CronJob (default every 10m) — self-heals against ANY residual path
+         that re-corrupts the field: an operator that started BEFORE the config
+         flip took effect, a pre-flip operator image, a manual mis-patch, a
+         webhook-config re-create. Faster than the operator's 1h tick so the
+         window of corruption is bounded to minutes even in the worst case.
+
+Both poll until `cnpg-ca-secret` exists (the operator generates it
+asynchronously), validate `ca.crt` is genuinely a CA (CA:TRUE) before writing,
+and patch every webhook entry in BOTH configs.
+
+This renders ONLY in webhook-FULL mode (the PLATFORM cnpg-system install). A
+per-Org bp-cnpg install is webhook-LESS (#4143/#4201:
+cloudnative-pg.webhook.{mutating,validating}.create=false) — it owns no
+cluster-singleton webhook, so the reasserter (like the gate + cert-bootstrap)
+MUST NOT render. The same `bp-cnpg.webhookGateEnabled` helper gates it.
+
+Both Jobs carry `app.kubernetes.io/managed-by: flux` so the baseline
+`flux-managed` Kyverno Enforce policy admits the helm-controller-created Job /
+CronJob (same escape as the webhook-gate + cert-wait Jobs, #4226).
+*/}}
+{{- $ca := .Values.webhookCabundleReasserter | default dict -}}
+{{- /* `default true` would WRONGLY coerce an explicit `enabled: false` back to
+       true (Helm treats boolean false as "empty"), so read it via hasKey. */ -}}
+{{- $caEnabled := true -}}
+{{- if hasKey $ca "enabled" -}}{{- $caEnabled = $ca.enabled -}}{{- end -}}
+{{- if and (eq (include "bp-cnpg.webhookGateEnabled" .) "true") $caEnabled }}
+{{- $svcNs := (($ca.service).namespace) | default "cnpg-system" -}}
+{{- $caSecret := $ca.caSecretName | default "cnpg-ca-secret" -}}
+{{- $mutName := $ca.mutatingWebhookName | default "cnpg-mutating-webhook-configuration" -}}
+{{- $valName := $ca.validatingWebhookName | default "cnpg-validating-webhook-configuration" -}}
+{{- $image := $ca.image | default "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.31.4" -}}
+{{- $pullPolicy := $ca.imagePullPolicy | default "IfNotPresent" -}}
+{{- $schedule := $ca.cronSchedule | default "*/10 * * * *" -}}
+{{- $bootstrapTimeout := $ca.bootstrapTimeoutSeconds | default 300 -}}
+{{- /* The reassert script is shared verbatim by the hook Job and the CronJob. */ -}}
+{{- $script := `
+set -euo pipefail
+echo "cnpg webhook caBundle reasserter: source=${CA_SECRET}/ca.crt (must be CA:TRUE) -> ${MUT_WEBHOOK} + ${VAL_WEBHOOK}"
+
+# 1. Wait for the operator-generated CA secret to exist + carry ca.crt.
+deadline=$(( $(date +%s) + WAIT_SECONDS ))
+ca_b64=""
+while [ "$(date +%s)" -lt "${deadline}" ]; do
+  ca_b64="$(kubectl get secret "${CA_SECRET}" -n "${CA_NS}" \
+    --ignore-not-found -o jsonpath='{.data.ca\.crt}' 2>/dev/null || true)"
+  if [ -n "${ca_b64}" ]; then break; fi
+  echo "waiting for ${CA_NS}/${CA_SECRET} ca.crt ..."
+  sleep 5
+done
+if [ -z "${ca_b64}" ]; then
+  echo "FATAL: ${CA_NS}/${CA_SECRET} ca.crt not found within ${WAIT_SECONDS}s." >&2
+  exit 1
+fi
+
+# 2. Validate the source really is a CA (BasicConstraints CA:TRUE). NEVER write
+#    a leaf — that is the very corruption we are healing. openssl may be absent
+#    in a kubectl image, so fall back to a base64-decode sanity check.
+ca_pem="$(printf '%s' "${ca_b64}" | base64 -d 2>/dev/null || true)"
+if [ -z "${ca_pem}" ]; then
+  echo "FATAL: ca.crt is not valid base64 PEM." >&2
+  exit 1
+fi
+if command -v openssl >/dev/null 2>&1; then
+  bc="$(printf '%s' "${ca_pem}" | openssl x509 -noout -ext basicConstraints 2>/dev/null || true)"
+  case "${bc}" in
+    *CA:TRUE*) : ;;
+    *) echo "FATAL: ${CA_SECRET} ca.crt is NOT a CA (basicConstraints='${bc}'); refusing to write a non-CA caBundle." >&2; exit 1 ;;
+  esac
+  echo "verified ${CA_SECRET} ca.crt is CA:TRUE."
+else
+  echo "openssl unavailable; skipped CA:TRUE assertion (base64 PEM sanity passed)."
+fi
+
+# 3. Patch every webhook entry in BOTH configs whose caBundle != the CA.
+patch_config() {
+  kind="$1"; name="$2"
+  n="$(kubectl get "${kind}" "${name}" --ignore-not-found \
+    -o jsonpath='{.webhooks}' 2>/dev/null | tr ',' '\n' | grep -c 'clientConfig' || true)"
+  if [ -z "${n}" ] || [ "${n}" -eq 0 ]; then
+    echo "  ${kind}/${name}: not found or zero webhooks; skipping."
+    return 0
+  fi
+  i=0
+  ops=""
+  while [ "${i}" -lt "${n}" ]; do
+    cur="$(kubectl get "${kind}" "${name}" \
+      -o jsonpath="{.webhooks[${i}].clientConfig.caBundle}" 2>/dev/null || true)"
+    if [ "${cur}" != "${ca_b64}" ]; then
+      [ -n "${ops}" ] && ops="${ops},"
+      ops="${ops}{\"op\":\"replace\",\"path\":\"/webhooks/${i}/clientConfig/caBundle\",\"value\":\"${ca_b64}\"}"
+    fi
+    i=$(( i + 1 ))
+  done
+  if [ -z "${ops}" ]; then
+    echo "  ${kind}/${name}: caBundle already the CA on all ${n} webhook(s); no-op."
+    return 0
+  fi
+  kubectl patch "${kind}" "${name}" --type='json' -p "[${ops}]" >/dev/null
+  echo "  ${kind}/${name}: reasserted CA caBundle on the drifted webhook(s)."
+}
+
+patch_config mutatingwebhookconfiguration "${MUT_WEBHOOK}"
+patch_config validatingwebhookconfiguration "${VAL_WEBHOOK}"
+echo "cnpg webhook caBundle reasserter: done."
+` -}}
+---
+# ── RBAC (shared by the hook Job + the CronJob) ─────────────────────────────
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-cabundle-reasserter
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: bp-cnpg
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    catalyst.openova.io/component: webhook-cabundle-reasserter
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-cabundle-reasserter
+  namespace: {{ $svcNs | quote }}
+  labels:
+    app.kubernetes.io/name: bp-cnpg
+    catalyst.openova.io/component: webhook-cabundle-reasserter
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: [{{ $caSecret | quote }}]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-cabundle-reasserter
+  namespace: {{ $svcNs | quote }}
+  labels:
+    app.kubernetes.io/name: bp-cnpg
+    catalyst.openova.io/component: webhook-cabundle-reasserter
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-cabundle-reasserter
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}-cabundle-reasserter
+  apiGroup: rbac.authorization.k8s.io
+---
+# Cluster-scoped: webhook configurations live at cluster scope; GET + PATCH.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-cabundle-reasserter
+  labels:
+    app.kubernetes.io/name: bp-cnpg
+    catalyst.openova.io/component: webhook-cabundle-reasserter
+rules:
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+    verbs: ["get", "list", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-cabundle-reasserter
+  labels:
+    app.kubernetes.io/name: bp-cnpg
+    catalyst.openova.io/component: webhook-cabundle-reasserter
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-cabundle-reasserter
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Release.Name }}-cabundle-reasserter
+  apiGroup: rbac.authorization.k8s.io
+---
+# ── (a) post-install/post-upgrade Helm-hook Job: assert CA immediately ──────
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-cabundle-reassert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: bp-cnpg
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    catalyst.openova.io/component: webhook-cabundle-reasserter
+    # #4226: helm-controller-created hook Job needs the flux-managed label so
+    # the kyverno baseline `flux-managed` Enforce policy admits it.
+    app.kubernetes.io/managed-by: flux
+  annotations:
+    # hook-weight 4 = BEFORE the webhook-gate Job (weight 5). With
+    # MANAGE_WEBHOOK_CONFIGURATIONS=false the operator no longer injects the
+    # caBundle, so on a fresh install the field is empty until THIS reasserter
+    # writes the CA. It must therefore run first; the gate (weight 5) then
+    # validates the caBundle is a real CA (CA:TRUE) — see webhook-gate-hook.yaml.
+    # The reasserter itself polls cnpg-ca-secret (operator-generated
+    # asynchronously) so it tolerates the operator's PKI bootstrap still being
+    # in flight.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "4"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bp-cnpg
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        catalyst.openova.io/component: webhook-cabundle-reasserter
+    spec:
+      serviceAccountName: {{ .Release.Name }}-cabundle-reasserter
+      restartPolicy: Never
+      containers:
+        - name: reassert
+          image: {{ $image | quote }}
+          imagePullPolicy: {{ $pullPolicy | quote }}
+          resources:
+            requests: { cpu: "10m", memory: "32Mi" }
+            limits:   { cpu: "100m", memory: "128Mi" }
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: { drop: [ALL] }
+            seccompProfile: { type: RuntimeDefault }
+          env:
+            - { name: CA_SECRET,   value: {{ $caSecret | quote }} }
+            - { name: CA_NS,       value: {{ $svcNs | quote }} }
+            - { name: MUT_WEBHOOK, value: {{ $mutName | quote }} }
+            - { name: VAL_WEBHOOK, value: {{ $valName | quote }} }
+            - { name: WAIT_SECONDS, value: {{ $bootstrapTimeout | quote }} }
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              {{- $script | nindent 14 }}
+---
+# ── (b) CronJob: self-heal against any residual re-corruption ────────────────
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-cabundle-reassert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: bp-cnpg
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    catalyst.openova.io/component: webhook-cabundle-reasserter
+    app.kubernetes.io/managed-by: flux
+spec:
+  schedule: {{ $schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 2
+  startingDeadlineSeconds: 120
+  jobTemplate:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bp-cnpg
+        catalyst.openova.io/component: webhook-cabundle-reasserter
+        app.kubernetes.io/managed-by: flux
+    spec:
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 120
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: bp-cnpg
+            catalyst.openova.io/component: webhook-cabundle-reasserter
+        spec:
+          serviceAccountName: {{ .Release.Name }}-cabundle-reasserter
+          restartPolicy: Never
+          containers:
+            - name: reassert
+              image: {{ $image | quote }}
+              imagePullPolicy: {{ $pullPolicy | quote }}
+              resources:
+                requests: { cpu: "10m", memory: "32Mi" }
+                limits:   { cpu: "100m", memory: "128Mi" }
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1001
+                runAsGroup: 1001
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities: { drop: [ALL] }
+                seccompProfile: { type: RuntimeDefault }
+              env:
+                - { name: CA_SECRET,   value: {{ $caSecret | quote }} }
+                - { name: CA_NS,       value: {{ $svcNs | quote }} }
+                - { name: MUT_WEBHOOK, value: {{ $mutName | quote }} }
+                - { name: VAL_WEBHOOK, value: {{ $valName | quote }} }
+                # CronJob runs in steady state — the CA secret already exists,
+                # so a short wait is enough.
+                - { name: WAIT_SECONDS, value: "30" }
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  {{- $script | nindent 18 }}
+{{- end }}

--- a/platform/cnpg/chart/templates/webhook-gate-hook.yaml
+++ b/platform/cnpg/chart/templates/webhook-gate-hook.yaml
@@ -81,7 +81,12 @@ Kyverno policy, wedging the whole Org cascade (#4220).
 {{- $valName := $gate.validatingWebhookName | default "cnpg-validating-webhook-configuration" -}}
 {{- $timeout := $gate.timeoutSeconds | default 300 -}}
 {{- $interval := $gate.intervalSeconds | default 2 -}}
-{{- $image := $gate.image | default "bitnamilegacy/kubectl:1.30.7" -}}
+{{- /* G64 (#4322): kubectl image carries openssl so the gate can assert the
+       caBundle is a CA (CA:TRUE), not merely non-empty. Default flipped from
+       the openssl-less bitnamilegacy/kubectl:1.30.7 to the 1.31.4 ref already
+       used by webhookCertBootstrap / the reasserter. The CA assertion degrades
+       gracefully (warns, falls back to non-empty) if openssl is absent. */ -}}
+{{- $image := $gate.image | default "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.31.4" -}}
 {{- $pullPolicy := $gate.imagePullPolicy | default "IfNotPresent" -}}
 apiVersion: batch/v1
 kind: Job
@@ -155,7 +160,33 @@ spec:
           args:
             - |
               set -euo pipefail
-              echo "cnpg webhook gate: poll (a) endpoints/${WEBHOOK_NS}/${WEBHOOK_SVC} ready, (b) MutatingWebhookConfiguration ${MUT_WEBHOOK} caBundle, (c) ValidatingWebhookConfiguration ${VAL_WEBHOOK} caBundle (budget=${TIMEOUT_SECONDS}s, interval=${INTERVAL_SECONDS}s)"
+              echo "cnpg webhook gate: poll (a) endpoints/${WEBHOOK_NS}/${WEBHOOK_SVC} ready, (b) MutatingWebhookConfiguration ${MUT_WEBHOOK} caBundle is a CA, (c) ValidatingWebhookConfiguration ${VAL_WEBHOOK} caBundle is a CA (budget=${TIMEOUT_SECONDS}s, interval=${INTERVAL_SECONDS}s)"
+              # G64 (#4322): a NON-EMPTY caBundle is NOT enough — the upstream
+              # cloudnative-pg #9817 bug populated it with the SERVING LEAF
+              # (CA:FALSE), which works only until the served leaf rotates and
+              # then x509-fails apiserver verification of the served chain. The
+              # gate now asserts the caBundle is a genuine CA (BasicConstraints
+              # CA:TRUE). The webhook-cabundle-reasserter Job (hook-weight 4,
+              # runs BEFORE this gate at weight 5) writes the real CA from
+              # cnpg-ca-secret; this gate is the producer-side proof it landed.
+              HAVE_OPENSSL=0
+              if command -v openssl >/dev/null 2>&1; then HAVE_OPENSSL=1; else
+                echo "WARN: openssl not in image; falling back to non-empty caBundle check (cannot assert CA:TRUE)." >&2
+              fi
+              # caBundleIsCA <webhook-kind> <name> -> echoes "ca" | "leaf" | "empty"
+              caBundleIsCA() {
+                local kind="$1" name="$2" b64 pem bc
+                b64="$(kubectl get "${kind}" "${name}" --ignore-not-found \
+                  -o jsonpath='{.webhooks[0].clientConfig.caBundle}' 2>/dev/null || true)"
+                if [ -z "${b64}" ]; then echo "empty"; return; fi
+                if [ "${HAVE_OPENSSL}" -ne 1 ]; then echo "ca"; return; fi  # length-only fallback
+                pem="$(printf '%s' "${b64}" | base64 -d 2>/dev/null || true)"
+                bc="$(printf '%s' "${pem}" | openssl x509 -noout -ext basicConstraints 2>/dev/null || true)"
+                case "${bc}" in
+                  *CA:TRUE*) echo "ca" ;;
+                  *)         echo "leaf" ;;
+                esac
+              }
               deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
               attempt=0
               while [ "$(date +%s)" -lt "${deadline}" ]; do
@@ -166,28 +197,22 @@ spec:
                   --ignore-not-found \
                   -o jsonpath='{range .subsets[*]}{.addresses[*].ip}{"\n"}{end}' 2>/dev/null \
                   | tr ' ' '\n' | grep -c . || true)"
-                # (b) Mutating caBundle non-empty
-                mut_ca_len="$(kubectl get mutatingwebhookconfiguration "${MUT_WEBHOOK}" \
-                  --ignore-not-found \
-                  -o jsonpath='{.webhooks[0].clientConfig.caBundle}' 2>/dev/null \
-                  | wc -c | tr -d ' ')"
-                # (c) Validating caBundle non-empty
-                val_ca_len="$(kubectl get validatingwebhookconfiguration "${VAL_WEBHOOK}" \
-                  --ignore-not-found \
-                  -o jsonpath='{.webhooks[0].clientConfig.caBundle}' 2>/dev/null \
-                  | wc -c | tr -d ' ')"
-                if [ "${ep_count}" -ge 1 ] && [ "${mut_ca_len}" -gt 100 ] && [ "${val_ca_len}" -gt 100 ]; then
-                  echo "All three conditions cleared after ${attempt} attempt(s); endpoints=${ep_count} mut_caBundle_len=${mut_ca_len} val_caBundle_len=${val_ca_len}."
+                # (b)/(c) caBundle is a CA (CA:TRUE), not a leaf and not empty
+                mut_ca="$(caBundleIsCA mutatingwebhookconfiguration "${MUT_WEBHOOK}")"
+                val_ca="$(caBundleIsCA validatingwebhookconfiguration "${VAL_WEBHOOK}")"
+                if [ "${ep_count}" -ge 1 ] && [ "${mut_ca}" = "ca" ] && [ "${val_ca}" = "ca" ]; then
+                  echo "All three conditions cleared after ${attempt} attempt(s); endpoints=${ep_count} mut_caBundle=CA val_caBundle=CA."
                   exit 0
                 fi
-                echo "Attempt ${attempt}: endpoints=${ep_count} mut_caBundle_len=${mut_ca_len} val_caBundle_len=${val_ca_len}; sleeping ${INTERVAL_SECONDS}s."
+                echo "Attempt ${attempt}: endpoints=${ep_count} mut_caBundle=${mut_ca} val_caBundle=${val_ca}; sleeping ${INTERVAL_SECONDS}s."
                 sleep "${INTERVAL_SECONDS}"
               done
-              echo "FATAL: cnpg webhook gate did not clear within ${TIMEOUT_SECONDS}s." >&2
+              echo "FATAL: cnpg webhook gate did not clear within ${TIMEOUT_SECONDS}s (a caBundle is empty or a LEAF, not a CA)." >&2
               echo "Diagnose with:" >&2
               echo "  kubectl -n ${WEBHOOK_NS} get pods -l app.kubernetes.io/name=cloudnative-pg" >&2
               echo "  kubectl -n ${WEBHOOK_NS} get endpoints ${WEBHOOK_SVC}" >&2
-              echo "  kubectl get mutatingwebhookconfiguration ${MUT_WEBHOOK} -o yaml | grep -A2 caBundle | head -5" >&2
-              echo "  kubectl get certificate -n ${WEBHOOK_NS}" >&2
+              echo "  kubectl get mutatingwebhookconfiguration ${MUT_WEBHOOK} -o jsonpath='{.webhooks[0].clientConfig.caBundle}' | base64 -d | openssl x509 -noout -subject -ext basicConstraints" >&2
+              echo "  kubectl get secret cnpg-ca-secret -n ${WEBHOOK_NS} -o jsonpath='{.data.ca\\.crt}' | base64 -d | openssl x509 -noout -subject -ext basicConstraints  # source CA (should be CA:TRUE)" >&2
+              echo "  kubectl -n ${WEBHOOK_NS} get cronjob,job -l catalyst.openova.io/component=webhook-cabundle-reasserter  # the GitOps CA injector" >&2
               exit 1
 {{- end }}

--- a/platform/cnpg/chart/tests/webhook-cabundle-reasserter.sh
+++ b/platform/cnpg/chart/tests/webhook-cabundle-reasserter.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# bp-cnpg — G64 (#4322) render gate for the durable webhook-caBundle fix.
+#
+# The cnpg-system operator corrupts the cluster-singleton webhook caBundle with
+# a LEAF cert (CA:FALSE) instead of the cnpg-ca-secret CA (CA:TRUE) — upstream
+# cloudnative-pg #9817 (fix PR #9819 unmerged) — and re-asserts it hourly, so
+# every postgresql.cnpg.io/v1.Cluster create/patch is rejected cluster-wide the
+# moment the served leaf and the stale caBundle-leaf diverge. The durable fix:
+#   (1) cloudnative-pg.config.data.MANAGE_WEBHOOK_CONFIGURATIONS="false" stops
+#       the operator injecting (corrupting) the caBundle at the source.
+#   (2) templates/webhook-cabundle-reasserter.yaml writes the real CA from
+#       cnpg-ca-secret into both webhook configs (post-install Job + 10m CronJob).
+#   (3) webhook-gate-hook.yaml asserts the caBundle is a CA (CA:TRUE), not merely
+#       non-empty.
+#
+# This test asserts (helm template only — no live cluster):
+#   A. DEFAULT (webhook-FULL platform install):
+#      - operator config ConfigMap carries MANAGE_WEBHOOK_CONFIGURATIONS: "false"
+#      - reasserter Job + CronJob + RBAC render, flux-managed labelled
+#      - reasserter Job hook-weight (4) < webhook-gate Job hook-weight (5)
+#      - reasserter script refuses to write a non-CA (CA:TRUE guard present)
+#      - the webhook-gate asserts CA:TRUE (not just non-empty length)
+#   B. WEBHOOK-LESS (per-Org install): ZERO reasserter resources.
+#   C. EXPLICIT webhookCabundleReasserter.enabled=false: ZERO reasserter, gate stays.
+#
+# Usage: bash tests/webhook-cabundle-reasserter.sh [CHART_DIR]
+set -euo pipefail
+
+CHART_DIR="$(cd "${1:-$(dirname "$0")/..}" && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+if [ ! -d "$CHART_DIR/charts" ] || ! ls "$CHART_DIR"/charts/cloudnative-pg-*.tgz >/dev/null 2>&1; then
+  helm dependency build "$CHART_DIR" >/dev/null 2>&1 || true
+fi
+
+render() {
+  local out="$1"; shift
+  helm template bp-cnpg "$CHART_DIR" --namespace cnpg-system "$@" > "$out" 2>"$TMP/err" \
+    || { echo "helm template FAILED:"; cat "$TMP/err"; exit 1; }
+}
+fail() { echo "FAIL: $1"; exit 1; }
+
+# Count ACTUAL reasserter resources (object names), NOT mere substring mentions —
+# the webhook-gate Job's diagnostic echo lines reference "webhook-cabundle-
+# reasserter", so a loose grep would false-positive. A real resource declares
+# `name: bp-cnpg-cabundle-reassert` (the Job/CronJob) or
+# `name: bp-cnpg-cabundle-reasserter` (the SA/Role/etc.) at metadata indent.
+reasserter_resource_count() { grep -cE '^\s+name: bp-cnpg-cabundle-reassert(er)?\s*$' "$1" || true; }
+
+# ── Case A: DEFAULT — webhook-FULL platform install ─────────────────────────
+render "$TMP/full.yaml"
+
+# A1. operator stops managing (corrupting) the caBundle
+if ! grep -qE '^\s*MANAGE_WEBHOOK_CONFIGURATIONS:\s*"false"' "$TMP/full.yaml"; then
+  fail "operator config is missing MANAGE_WEBHOOK_CONFIGURATIONS: \"false\" (operator would keep corrupting the caBundle)"
+fi
+echo "PASS: operator config sets MANAGE_WEBHOOK_CONFIGURATIONS=false"
+
+# A2. reasserter resources render
+for kind in "kind: Job" "kind: CronJob"; do
+  awk -v k="$kind" 'BEGIN{RS="\n---\n"} $0 ~ k && /cabundle-reassert/ {found=1} END{exit !found}' "$TMP/full.yaml" \
+    || fail "default render is missing the reasserter ${kind#kind: } (cabundle-reassert)"
+done
+grep -q "bp-cnpg-cabundle-reasserter" "$TMP/full.yaml" || fail "reasserter RBAC (SA/Role/ClusterRole) missing"
+echo "PASS: reasserter Job + CronJob + RBAC render in webhook-FULL mode"
+
+# A3. CronJob schedule is faster than the operator's 1h corruption tick
+grep -qE 'schedule:\s*"\*/[0-9]+ \* \* \* \*"' "$TMP/full.yaml" \
+  || fail "reasserter CronJob has no sub-hourly schedule (must out-pace the operator's @every 1h corruption)"
+echo "PASS: reasserter CronJob has a sub-hourly self-heal schedule"
+
+# A4. reasserter Job + its CronJob are flux-managed (else kyverno denies them)
+#     count the managed-by:flux occurrences on the two reasserter workloads.
+flux_labels="$(awk 'BEGIN{RS="\n---\n"} /cabundle-reassert/ && /app.kubernetes.io\/managed-by: flux/ && (/kind: Job/||/kind: CronJob/){c++} END{print c+0}' "$TMP/full.yaml")"
+[ "$flux_labels" -ge 2 ] || fail "reasserter Job/CronJob missing app.kubernetes.io/managed-by: flux (got $flux_labels, need >=2; kyverno flux-managed would DENY them)"
+echo "PASS: reasserter Job + CronJob carry managed-by: flux"
+
+# A5. ordering — reasserter Job (weight 4) runs BEFORE the gate Job (weight 5)
+#     so the CA caBundle lands before the gate validates CA:TRUE. Parse with
+#     python (portable across awk variants; both reasserter Job+CronJob share a
+#     name, so key on kind==Job).
+read -r reassert_w gate_w < <(python3 - "$TMP/full.yaml" <<'PY'
+import sys, yaml
+rw=gw=""
+for d in yaml.safe_load_all(open(sys.argv[1])):
+    if not d or d.get("kind")!="Job": continue
+    name=(d.get("metadata") or {}).get("name","")
+    w=((d.get("metadata") or {}).get("annotations") or {}).get("helm.sh/hook-weight","")
+    if name=="bp-cnpg-cabundle-reassert": rw=w
+    if name=="bp-cnpg-webhook-gate":      gw=w
+print(rw or "NA", gw or "NA")
+PY
+)
+[ "$reassert_w" != "NA" ] && [ "$gate_w" != "NA" ] || fail "could not read hook-weights (reassert='$reassert_w' gate='$gate_w')"
+[ "$reassert_w" -lt "$gate_w" ] || fail "reasserter hook-weight ($reassert_w) must be < gate hook-weight ($gate_w) so the CA lands before the gate validates it"
+echo "PASS: reasserter Job (weight $reassert_w) runs before the gate Job (weight $gate_w)"
+
+# A6. reasserter REFUSES to write a non-CA (the CA:TRUE guard must be in-script)
+grep -q "CA:TRUE" "$TMP/full.yaml" || fail "reasserter/gate script lost the CA:TRUE assertion — could write a leaf caBundle"
+grep -q "refusing to write a non-CA caBundle" "$TMP/full.yaml" \
+  || fail "reasserter script lost its non-CA refusal guard"
+echo "PASS: reasserter refuses to write a non-CA caBundle (CA:TRUE guard present)"
+
+# A7. the webhook-gate asserts the caBundle is a CA, not just non-empty
+grep -q "caBundle is a CA" "$TMP/full.yaml" \
+  || fail "webhook-gate no longer asserts the caBundle is a CA (regressed to non-empty-only)"
+if grep -qE 'mut_ca_len.*-gt 100' "$TMP/full.yaml"; then
+  fail "webhook-gate still uses the OLD non-empty length check (mut_ca_len -gt 100) — should assert CA:TRUE"
+fi
+echo "PASS: webhook-gate asserts caBundle is a CA (CA:TRUE), not merely non-empty"
+
+# ── Case B: WEBHOOK-LESS — per-Org install → ZERO reasserter ────────────────
+render "$TMP/less.yaml" \
+  --set "cloudnative-pg.webhook.mutating.create=false" \
+  --set "cloudnative-pg.webhook.validating.create=false"
+n="$(reasserter_resource_count "$TMP/less.yaml")"
+if [ "$n" -ne 0 ]; then
+  echo "--- offending ---"; grep -nE '^\s+name: bp-cnpg-cabundle-reassert(er)?\s*$' "$TMP/less.yaml" | head
+  fail "webhook-less render STILL emits $n reasserter resource(s) (flux-managed would deny the un-owned hook Job; per-Org owns no cluster webhook anyway)"
+fi
+echo "PASS: webhook-less render emits ZERO reasserter resources"
+
+# ── Case C: EXPLICIT reasserter off → no reasserter, gate preserved ─────────
+render "$TMP/reassert-off.yaml" --set "webhookCabundleReasserter.enabled=false"
+n="$(reasserter_resource_count "$TMP/reassert-off.yaml")"
+[ "$n" -eq 0 ] || fail "webhookCabundleReasserter.enabled=false STILL emits $n reasserter resource(s)"
+grep -q "bp-cnpg-webhook-gate" "$TMP/reassert-off.yaml" \
+  || fail "disabling the reasserter must NOT remove the webhook-gate"
+echo "PASS: webhookCabundleReasserter.enabled=false suppresses the reasserter, keeps the gate"
+
+echo "All bp-cnpg webhook-cabundle-reasserter assertions passed (G64 #4322)."

--- a/platform/cnpg/chart/values.yaml
+++ b/platform/cnpg/chart/values.yaml
@@ -144,6 +144,38 @@ cloudnative-pg:
   monitoring:
     podMonitorEnabled: false
 
+  # G64 (Refs #4322 #4143, 2026-06-25): STOP the operator corrupting the
+  # cluster-singleton webhook caBundle.
+  #
+  # Upstream cloudnative-pg bug #9817 (fix PR #9819 still UNMERGED): the
+  # operator's PKI reconciler injects the webhook `clientConfig.caBundle` from
+  # `cnpg-webhook-cert` `tls.crt` — the SERVING LEAF (BasicConstraints
+  # CA:FALSE) — instead of `cnpg-ca-secret` `ca.crt` (the real CA, CA:TRUE),
+  # and re-asserts it on a periodic `@every 1h` tick + every restart. The
+  # moment the served leaf and the stale caBundle-leaf diverge (cert renewal,
+  # secret regen, pod restart) the apiserver fails `x509: certificate signed
+  # by unknown authority` verifying the served chain → EVERY
+  # postgresql.cnpg.io/v1.Cluster create/patch is rejected cluster-wide.
+  # Live-confirmed on omantel.biz region-a (#4322).
+  #
+  # `MANAGE_WEBHOOK_CONFIGURATIONS: "false"` tells the operator to STOP
+  # injecting the CA bundle into the webhook configs (upstream operator_conf:
+  # "Set to false when the CA bundle is injected externally, ... or by
+  # GitOps"). It is INDEPENDENT of serving-cert/CA generation — the operator
+  # still mints `cnpg-ca-secret` + `cnpg-webhook-cert`, so the GitOps-side
+  # injector (templates/webhook-cabundle-reasserter.yaml) still has a real CA
+  # to read. The corruption stops at the source; the reasserter owns the
+  # caBundle authoritatively (CA:TRUE). This config flows into the operator's
+  # `cnpg-controller-manager-config` ConfigMap (consumed via --config-map-name).
+  #
+  # NOTE: per-Org (webhook-LESS) installs set webhook.{mutating,validating}.
+  # create=false and config.clusterWide=false; they own no cluster-singleton
+  # webhook, so this flag is harmless there (nothing to manage). The reasserter
+  # itself renders ONLY in webhook-FULL mode (bp-cnpg.webhookGateEnabled).
+  config:
+    data:
+      MANAGE_WEBHOOK_CONFIGURATIONS: "false"
+
   # Webhook is enabled by default in upstream — keep it that way (CNPG
   # uses the webhook to validate Cluster CRs). cert-manager (bp-cert-
   # manager) provides the TLS cert per Sovereign convention.
@@ -196,5 +228,37 @@ webhookGate:
   # kubectl` ref pulled straight from dockerhub — same harbor-proxy-pull
   # baseline violation + ghcr/dockerhub DNS-flake exposure as the operator
   # image, and the gate Job runs on every install (enabled: true).
-  image: "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7"
+  #
+  # G64 (#4322): bumped 1.30.7 -> 1.31.4 so the gate image carries openssl —
+  # the gate now asserts the caBundle is a CA (CA:TRUE), not merely non-empty.
+  image: "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.31.4"
+  imagePullPolicy: IfNotPresent
+
+# G64 (Refs #4322 #4143, 2026-06-25): webhook caBundle reasserter — the
+# GitOps-side CA injector paired with cloudnative-pg.config.data.
+# MANAGE_WEBHOOK_CONFIGURATIONS=false above. Reads `ca.crt` (CA:TRUE) from
+# cnpg-ca-secret and writes it into both webhook configs' caBundle, healing the
+# upstream #9817 leaf-in-caBundle corruption. Runs as a post-install/upgrade
+# Helm-hook Job (immediate) + a CronJob (every 10m self-heal). Renders ONLY in
+# webhook-FULL mode (the platform cnpg-system install); per-Org webhook-LESS
+# installs skip it via the bp-cnpg.webhookGateEnabled helper. See
+# templates/webhook-cabundle-reasserter.yaml for the full rationale.
+webhookCabundleReasserter:
+  enabled: true
+  service:
+    namespace: cnpg-system
+  caSecretName: cnpg-ca-secret
+  mutatingWebhookName: cnpg-mutating-webhook-configuration
+  validatingWebhookName: cnpg-validating-webhook-configuration
+  # Self-heal cadence — must be faster than the operator's 1h corruption tick
+  # so the worst-case window where the caBundle holds a leaf is bounded to
+  # minutes (relevant only if the operator config flip hasn't taken effect on
+  # a not-yet-restarted pre-flip operator pod).
+  cronSchedule: "*/10 * * * *"
+  # The operator generates cnpg-ca-secret asynchronously after install; the
+  # post-install Job polls up to this long for ca.crt to appear.
+  bootstrapTimeoutSeconds: 300
+  # Pinned to the in-Sovereign Harbor proxy-cache (kubectl image carries
+  # openssl for the CA:TRUE assertion). Matches webhookCertBootstrap.kubectlImage.
+  image: "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.31.4"
   imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## Problem (live, omantel.biz region-a — #4322 root cause 2)

The cluster-singleton cnpg webhook (`cnpg-{mutating,validating}-webhook-configuration`) `caBundle` held a **LEAF cert** (`CN=cnpg-webhook-service.cnpg-system.svc`, **CA:FALSE**) instead of the CA (`cnpg-ca-secret` `ca.crt`, `CN=cnpg-ca-secret`, **CA:TRUE**). The `cnpg-system` operator **re-corrupts** it on every webhook reconcile, so a `kubectl patch` to CA:TRUE reverts.

**Root cause (confirmed):** upstream CloudNativePG bug [#9817](https://github.com/cloudnative-pg/cloudnative-pg/issues/9817) (fix PR #9819 still **UNMERGED** as of this writing). In `pkg/certs/k8s.go`, `injectPublicKeyInto{Mutating,Validating}Webhook` sets `caBundle = cnpg-webhook-cert.tls.crt` — the **serving leaf** — instead of `cnpg-ca-secret.ca.crt`. The operator re-runs this on a periodic `@every 1h` PKI-maintenance tick **and** on every restart/leader-election. While the served leaf and the caBundle-leaf are byte-identical the apiserver accepts the degenerate single-cert chain; the moment the operator rotates/regenerates `cnpg-webhook-cert` (renewal, secret regen, pod restart) the served leaf and the **stale** caBundle-leaf diverge → apiserver `x509: certificate signed by unknown authority` → **EVERY `postgresql.cnpg.io/v1.Cluster` create/patch rejected cluster-wide** (wordpress-db, newapi-pg, every Postgres-backed app).

This is the `#4143` hijack **family**; `#4201`/`#4223`/`#4226` already made per-Org operators webhook-less (verified) — so the culprit here is the **cnpg-system (platform) operator's own webhook caBundle management**.

### Live confirmation (this PR's diagnosis)
```
caBundle on webhook:  CN=cnpg-webhook-service.cnpg-system.svc   CA:FALSE   <- leaf (wrong)
cnpg-ca-secret ca.crt: CN=cnpg-ca-secret                        CA:TRUE    <- the CA (right)
```

## Durable fix (webhook-FULL platform install only — per-Org webhook-LESS installs skip ALL of it via `bp-cnpg.webhookGateEnabled`)

1. **Stop the corruption at the source** — `cloudnative-pg.config.data.MANAGE_WEBHOOK_CONFIGURATIONS: "false"` in the operator config (`cnpg-controller-manager-config`). Per the upstream `operator_conf` doc this is the supported opt-out: *"Set to false when the CA bundle is injected externally, ... or by GitOps."* It is **independent** of serving-cert/CA generation, so the operator still mints `cnpg-ca-secret` — the reasserter has a real CA to read.

2. **GitOps-side CA injector** — `templates/webhook-cabundle-reasserter.yaml`: a post-install/upgrade **Helm-hook Job** (weight 4, before the gate) + a **10-minute CronJob** that read `cnpg-ca-secret` `ca.crt` (validated **CA:TRUE** — refuses to write a leaf) and write it into both webhook configs' `caBundle`. The CronJob self-heals any residual re-corruption (e.g. a not-yet-restarted pre-flip operator pod) within minutes, far ahead of the operator's 1h tick. Both carry `app.kubernetes.io/managed-by: flux` so the baseline kyverno policy admits them.

3. **Harden the webhook-gate** — `webhook-gate-hook.yaml` now asserts the caBundle is a **CA (CA:TRUE)**, not merely non-empty (the old `mut_ca_len -gt 100` check passed on a leaf). Gate image bumped `1.30.7 -> 1.31.4` for openssl; degrades gracefully if openssl is absent.

## Why a fresh Sovereign now never hits this

On a fresh prov the bootstrap-kit installs `bp-cnpg` 1.0.13 → the operator config disables caBundle management → the reasserter Helm-hook Job writes the CA before any dependent creates a Cluster CR → the gate proves CA:TRUE before the HR goes Ready → the CronJob holds it CA:TRUE in steady state. No path leaves a leaf in the caBundle, so no x509 wall.

## Validation
- `helm lint` clean; full + webhook-less renders parse (34 docs valid YAML).
- 3 chart tests green: new `tests/webhook-cabundle-reasserter.sh` (operator config flip, reasserter Job+CronJob+RBAC render, flux-managed labels, hook-weight ordering 4<5, CA:TRUE guard, webhook-less + explicit-off suppression) + existing `webhook-gate-render.sh` + `observability-toggle.sh`.
- Reasserter shell scripts pass `shellcheck -S error` (sh) and `bash -n`.
- Live recovery applied to the affected env (caBundle patched to CA:TRUE) per the documented recovery — the deliverable is the durable chart fix.

Chart `1.0.12 -> 1.0.13` + `blueprint.yaml` + `_template/bootstrap-kit/16-cnpg.yaml` pin in lockstep. Per-Sovereign overlays (pinned 1.0.0) left to their own gitops/deploy-bot roll.

Refs #4322 #4143 #4201

🤖 Generated with [Claude Code](https://claude.com/claude-code)