### PR TITLE
fix(bss): OrdersPage renders OMR from baisa — kill the 10×-inflated order total (Refs #4274)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/lib/bss.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/bss.api.ts
@@ -401,9 +401,15 @@ export interface Order {
   createdAt: string
   /** ISO-8601 last-status-change timestamp. Empty string tolerated. */
   updatedAt: string
-  /** Order total in cents. */
+  /** Order total in the currency's minor unit. The Sovereign billing
+   *  service is OMR-denominated and emits BAISA (1/1000 OMR), so for OMR
+   *  this is baisa, not cents — OrdersPage's formatCurrency scales by the
+   *  per-currency minor-unit divisor. The `Cents` suffix is the generic
+   *  minor-unit label kept for type stability. */
   totalCents: number
-  /** ISO-4217 currency code; defaults to USD when absent. */
+  /** ISO-4217 currency code; defaults to OMR (the Sovereign billing
+   *  currency) when absent so an omitted code never mis-renders the baisa
+   *  amount as 10×-inflated USD. */
   currency: string
 }
 
@@ -464,7 +470,7 @@ export async function getOrders(): Promise<OrdersResponse> {
               ? r.totalCents
               : 0,
           currency:
-            typeof r.currency === 'string' && r.currency !== '' ? r.currency : 'USD',
+            typeof r.currency === 'string' && r.currency !== '' ? r.currency : 'OMR',
         }
       })
       .filter((o): o is Order => o !== null)

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/OrdersPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/OrdersPage.tsx
@@ -399,13 +399,34 @@ function formatRelative(iso: string): { display: string; absolute: string } {
   return { display, absolute }
 }
 
-function formatCurrency(cents: number, currency: string): string {
-  const value = cents / 100
+/**
+ * MINOR_UNITS_PER_MAJOR — the integer minor-unit divisor per ISO-4217
+ * currency. The Sovereign billing service is OMR-denominated and emits
+ * amounts in BAISA (1/1000 OMR — three minor digits per ISO-4217), which
+ * the catalyst-api bridge (org_orders.go) carries verbatim in the generic
+ * `totalCents` minor-unit field. A blanket `/100` (the cents convention)
+ * therefore rendered every OMR order 10× inflated (a 9-OMR order showed
+ * as "OMR 90.00"). Look the scale up by currency so OMR/BHD/KWD divide by
+ * 1000 and dollar/euro-style codes keep /100 — mirrors RevenuePage's
+ * BAISA_PER_OMR fix (#4274). The currency itself drives Intl's fraction
+ * digits, so no explicit maximumFractionDigits is needed.
+ */
+const MINOR_UNITS_PER_MAJOR: Record<string, number> = {
+  OMR: 1000,
+  BHD: 1000,
+  KWD: 1000,
+}
+
+function minorUnitDivisor(currency: string): number {
+  return MINOR_UNITS_PER_MAJOR[currency.toUpperCase()] ?? 100
+}
+
+function formatCurrency(minor: number, currency: string): string {
+  const value = minor / minorUnitDivisor(currency)
   try {
     return new Intl.NumberFormat(undefined, {
       style: 'currency',
       currency,
-      maximumFractionDigits: 2,
     }).format(value)
   } catch {
     // Unknown ISO-4217 code → fall back to a plain numeric format with


### PR DESCRIPTION
## Problem (Refs #4274)
The console BSS `/billing/orders` page rendered every order **total 10× inflated** — a real 9-OMR order showed as **"OMR 90.00"**. This is the "wrong figures" half of #4274 (the empty/non-granular half was the catalyst-api bridge wire, already on `main`).

## Root cause
The catalyst-api bridge (`org_orders.go`) maps the billing service's `amount_baisa` (1/1000 OMR — three minor-unit digits per ISO-4217) **verbatim** into the FE's generic `totalCents` minor-unit field and sets `currency="OMR"`. But `OrdersPage.formatCurrency` divided by **100** (the cents convention). OMR's minor unit is baisa (÷1000), so `/100` over-scaled by exactly 10×. The sibling `RevenuePage` was already corrected to baisa/OMR under the #4274 work (`BAISA_PER_OMR`); `OrdersPage`'s formatter was left on the cents path.

## Fix (console UI only — 2 files, 33 insertions)
- **`OrdersPage.tsx`**: scale by a per-currency minor-unit divisor (`MINOR_UNITS_PER_MAJOR` — OMR/BHD/KWD = 1000, else 100) and let the currency drive `Intl`'s fraction digits. A 9000-baisa order now renders **"OMR 9.000"**. Mirrors `RevenuePage`'s `BAISA_PER_OMR` approach.
- **`bss.api.ts`**: default an absent order currency to **OMR** (the Sovereign billing currency) instead of USD, and document `totalCents` as the currency's minor unit (baisa for OMR), so an omitted code never mis-renders the baisa amount as 10×-inflated USD.

## Live evidence (READ-ONLY, console.omantel.biz)
The billing bridge already serves **real granular data** (delivered to the live Sovereign — catalyst-api `151d9f5`, billing `2fc31ca`, chart `bp-catalyst-platform@1.4.838`, all descending from the #4274 backend wire):
- `GET /billing/admin/orders` → HTTP 200, granular per-order rows: `id` / `tenant_id` (Org) / `plan_id` / `apps[]` / `amount_omr` (9, 5) / `amount_baisa` (9000, 5000) / `status: completed` / `created_at` / `promo_code`.
- `GET /billing/admin/revenue` → HTTP 200: `total_mrr: 102` OMR, `total_customers: 14`, `active_subscriptions: 11`.
- Both accept the **sovereign-admin** role (the #4274 widened-auth; previously superadmin-only → 403).

Prior to this fix the FE scaled those baisa amounts by `/100`; now the rendered totals match the real OMR.

## Build / test
- `tsc -b` + `vite build` green.
- The 69 pre-existing vitest failures (wizard cascade / pin-input / parent-domains / jobs / etc.) fail **identically on clean `origin/main`** and **none import the changed modules** — no new failures introduced.

Refs #4274

🤖 Generated with [Claude Code](https://claude.com/claude-code)