### PR TITLE
fix(bp-kyverno-policies): admit per-Org vCluster CIDR-probe Service by name — unblock 11/11 vcluster-0 CrashLoop (kom4dc)

### DIFF
--- a/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
+++ b/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
@@ -134,7 +134,11 @@ spec:
       # Scope GITEA ONLY (local-Harbor leg is the flagged follow-up); mechanism D
       # (env-controller cross-ns reflection) stacks behind the vcluster EPIC.
       # VERIFIED `kyverno test` 5/5. Refs #4286 #4285 #4283.
-      version: 1.0.40
+      # 1.0.41 (#4329): flux-managed (10) harden — admit the per-Org vCluster
+      # CIDR-probe Service (`test-service-delete-me-*`) by name pattern so a
+      # stale `openova.io/tenant`-labelled boundary no longer Enforce-denies it
+      # → no more 11/11 vcluster-0 CrashLoop. Refs #4329 #4297 #4293.
+      version: 1.0.41
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno

--- a/platform/kyverno-policies/blueprint.yaml
+++ b/platform/kyverno-policies/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.40
+  version: 1.0.41
   card:
     title: Kyverno Policy Library
     family: guardian

--- a/platform/kyverno-policies/chart/Chart.yaml
+++ b/platform/kyverno-policies/chart/Chart.yaml
@@ -1,5 +1,21 @@
 apiVersion: v2
 name: bp-kyverno-policies
+# 1.0.41 (#4329, proven live omantel.biz/kom4dc 2026-06-25): HARDEN the
+# flux-managed (10) carve-out for the per-Org vCluster CIDR-probe Service. The
+# #3859 exclusion only matched namespaces stamped `openova.io/organization`; the
+# retired pre-#4295 funnel `tenant-<slug>` boundary stamps `openova.io/tenant`
+# instead, so on a stale/legacy host ALL 11/11 customer vClusters CrashLooped
+# (277×/23h): vcluster 0.33.x's startup CIDR-detection Service
+# `test-service-delete-me-<rand>` was Enforce-denied → syncer fatal
+# `failed to get service cidr` → no vCluster booted → the #4297
+# apps-in-vCluster keystone unreachable. Added a label-convention-resilient
+# exclude that matches the throwaway probe Service DIRECTLY by name pattern
+# (`Service/test-service-delete-me-*`, any namespace) — admits ONLY that
+# definitionally-unmanageable ephemeral probe while every real customer/operator
+# Service stays gated. Mirrors the by-label CNPG operator carve-out (carve out
+# the unmanageable object, not the namespace). Template-only behavior change +
+# new `kyverno test tests/vcluster-cidr-probe-admitted/` (probe ADMITTED;
+# unlabeled real Service DENIED). Refs #4329 #4297 #4293.
 # 1.0.40 (EPIC #4286 mechanism B, 2026-06-25): NEW MUTATE policy
 # `inject-gitea-source-secretref` (templates/mutate/01-...) — the ADMISSION FLOOR
 # that auto-injects the canonical basic-auth `spec.secretRef.name`
@@ -265,7 +281,7 @@ type: application
 # unprotected user PVCs stay subject to the velero-backed requirement. Mirrors
 # the by-label CNPG carve-out on the flux-managed policy (#3374). Template-only
 # behavior change + new test fixtures. Refs #3971.
-version: 1.0.40
+version: 1.0.41
 appVersion: "1.0.2"
 keywords: [catalyst, blueprint, kyverno, policy, compliance, audit]
 maintainers:

--- a/platform/kyverno-policies/chart/templates/baseline/10-flux-managed.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/10-flux-managed.yaml
@@ -121,6 +121,36 @@ spec:
                 matchExpressions:
                   - key: openova.io/organization
                     operator: Exists
+          {{- /*
+            #4329 (2026-06-25, proven live on omantel.biz/kom4dc — ALL 11/11
+            customer vClusters CrashLoopBackOff 277×/23h): the #3859 carve-out
+            above only matches namespaces stamped `openova.io/organization`.
+            The org-controller (post-#4295 single boundary producer) stamps
+            exactly that on its `<slug>` namespaces — but the retired pre-#4295
+            funnel `tenant-<slug>` boundary stamped `openova.io/tenant: <slug>`
+            + `openova.io/managed-by: provisioning` instead, so its vCluster
+            CIDR-probe Service is denied → the syncer's startup
+            `failed to get service cidr` is fatal → vcluster-0 CrashLoops
+            forever → the #4297 apps-in-vCluster keystone is unreachable.
+
+            Rather than chase every boundary-label convention (organization vs
+            tenant vs a not-yet-invented key), exclude the vCluster
+            CIDR-detection probe Service DIRECTLY. vCluster 0.33.x
+            (servicecidr/servicecidr.go) creates a throwaway Service named
+            `test-service-delete-me-<rand>` purely to read the apiserver's
+            ipFamily error, then deletes it — by design it can NEVER carry a
+            Flux label/ownerRef. Matching it by name pattern (cluster-wide, in
+            ANY namespace) admits ONLY that ephemeral probe while every real
+            customer/operator Service stays fully gated. Convention-resilient:
+            it survives any future drift in the Org-namespace label. Mirrors
+            the by-label CNPG operator carve-out above — carve out the
+            definitionally-unmanageable object, not the namespace.
+          */}}
+          - resources:
+              kinds:
+                - Service
+              names:
+                - "test-service-delete-me-*"
       validate:
         message: >-
           {{ `{{request.object.kind}}/{{request.object.metadata.name}}` }} is

--- a/platform/kyverno-policies/chart/tests/vcluster-cidr-probe-admitted/kyverno-test.yaml
+++ b/platform/kyverno-policies/chart/tests/vcluster-cidr-probe-admitted/kyverno-test.yaml
@@ -1,0 +1,52 @@
+# #4329 — Kyverno conformance test for the flux-managed (10) carve-out that
+# admits the per-Org vCluster CIDR-probe Service.
+#
+# Run with the Kyverno CLI:
+#   cd platform/kyverno-policies/chart
+#   # re-render the policy if the template/values changed:
+#   helm template . --set compliancePolicies.fluxManaged.action=Enforce \
+#     --show-only templates/baseline/10-flux-managed.yaml \
+#     | grep -v '^# Source:' | sed '/^---$/d' \
+#     > tests/vcluster-cidr-probe-admitted/policy.yaml
+#   kyverno test tests/vcluster-cidr-probe-admitted/
+#
+# `policy.yaml` is the rendered ClusterPolicy (committed so the test is
+# self-contained + CI-runnable without a Helm pass in the test step).
+#
+# THREE cases prove the fix (LIVE shape: omantel.biz/kom4dc, ALL 11/11 customer
+# vClusters CrashLoopBackOff 277×/23h because the probe Service was Enforce-denied):
+#   1. probe Service in the legacy `openova.io/tenant` boundary → ADMITTED (pass)
+#   2. probe Service in a label-less namespace               → ADMITTED (pass)
+#   3. REAL non-probe Service in the same boundary, no Flux label → DENIED (fail)
+#      (proves the carve-out is name-scoped, not a blanket namespace exemption)
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: vcluster-cidr-probe-admitted-test
+policies:
+  - policy.yaml
+resources:
+  - resource-namespaces.yaml
+  - resource-services.yaml
+results:
+  # 1. CIDR-probe Service in the legacy openova.io/tenant boundary → admitted.
+  - policy: flux-managed
+    rule: workload-must-be-flux-managed
+    resources:
+      - tenant-demo/test-service-delete-me-qwgml
+    kind: Service
+    result: pass
+  # 2. CIDR-probe Service in a namespace with NO Org-boundary label → admitted.
+  - policy: flux-managed
+    rule: workload-must-be-flux-managed
+    resources:
+      - app-prod/test-service-delete-me-qgxrt
+    kind: Service
+    result: pass
+  # 3. REAL non-probe Service, no Flux label, same legacy boundary → DENIED.
+  - policy: flux-managed
+    rule: workload-must-be-flux-managed
+    resources:
+      - tenant-demo/customer-api
+    kind: Service
+    result: fail

--- a/platform/kyverno-policies/chart/tests/vcluster-cidr-probe-admitted/policy.yaml
+++ b/platform/kyverno-policies/chart/tests/vcluster-cidr-probe-admitted/policy.yaml
@@ -1,0 +1,97 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: flux-managed
+  labels:
+    app.kubernetes.io/name: bp-kyverno
+    app.kubernetes.io/component: compliance-policy
+    catalyst.openova.io/policy-tier: compliance
+    catalyst.openova.io/policy-domain: governance
+  annotations:
+    policies.kyverno.io/title: Workloads must be managed by Flux
+    policies.kyverno.io/category: catalyst-compliance
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/description: >-
+      Workload-rendering resources must carry
+      `app.kubernetes.io/managed-by: flux` (the upstream Flux label) OR
+      have an ownerReference pointing at a HelmRelease / Kustomization.
+      Direct kubectl apply is rejected — IaC-first per
+      docs/INVIOLABLE-PRINCIPLES.md #3.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: workload-must-be-flux-managed
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+                - DaemonSet
+                - Job
+                - CronJob
+                - Service
+                - Ingress
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - kube-system
+                - flux-system
+                - cilium
+                - cilium-gateway
+                - cert-manager
+                - openova-system
+                - catalyst
+                - kyverno
+                - monitoring
+                - ingress
+                - dmz
+                - mgmt
+                - rtz
+                - sso-bridge
+                - cnpg
+                - shared-data
+                - powerdns-admin
+                - trivy-system
+          - resources:
+              selector:
+                matchLabels:
+                  app.kubernetes.io/managed-by: cloudnative-pg
+          - resources:
+              namespaceSelector:
+                matchExpressions:
+                  - key: openova.io/organization
+                    operator: Exists
+          - resources:
+              kinds:
+                - Service
+              names:
+                - "test-service-delete-me-*"
+      validate:
+        message: >-
+          {{request.object.kind}}/{{request.object.metadata.name}} is
+          not Flux-managed. Add label
+          `app.kubernetes.io/managed-by: flux` on metadata.labels OR
+          attach an ownerReference to a HelmRelease / Kustomization.
+        deny:
+          conditions:
+            all:
+              - key: '{{ request.object.metadata.labels."app.kubernetes.io/managed-by" || '''' }}'
+                operator: NotEquals
+                value: flux
+              # Wave 5.97 nil-safety: check Flux-applied labels instead of
+              # ownerReferences. Flux sets BOTH helm.toolkit.fluxcd.io/name AND
+              # kustomize.toolkit.fluxcd.io/name on every resource it manages.
+              # The original JMESPath filter `ownerReferences[?kind==X]` errors
+              # when ownerReferences is nil (most kubectl-created Pods + debug
+              # pods + admission-time injected sidecars), and admission webhook
+              # failurePolicy=Fail blocks all pod creation cluster-wide.
+              # Label-based check is nil-safe via the `||` JMESPath fallback.
+              - key: '{{ request.object.metadata.labels."helm.toolkit.fluxcd.io/name" || '''' }}'
+                operator: Equals
+                value: ''
+              - key: '{{ request.object.metadata.labels."kustomize.toolkit.fluxcd.io/name" || '''' }}'
+                operator: Equals
+                value: ''

--- a/platform/kyverno-policies/chart/tests/vcluster-cidr-probe-admitted/resource-namespaces.yaml
+++ b/platform/kyverno-policies/chart/tests/vcluster-cidr-probe-admitted/resource-namespaces.yaml
@@ -1,0 +1,23 @@
+# #4329 — INPUT fixtures: the two host-cluster namespaces the test exercises.
+#
+#   tenant-demo  — the STALE/legacy funnel boundary (retired pre-#4295 path).
+#                  Carries `openova.io/tenant: demo` + `openova.io/managed-by:
+#                  provisioning` — NOT `openova.io/organization`. This is the
+#                  EXACT live shape on omantel.biz/kom4dc where ALL 11/11
+#                  vClusters CrashLooped. The #3859 `openova.io/organization`
+#                  namespaceSelector carve-out does NOT match it.
+#   app-prod     — an ordinary application namespace with NO Org-boundary label.
+#                  A real, non-probe Service here MUST stay Enforce-denied to
+#                  prove the policy's real intent is preserved.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tenant-demo
+  labels:
+    openova.io/tenant: demo
+    openova.io/managed-by: provisioning
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: app-prod

--- a/platform/kyverno-policies/chart/tests/vcluster-cidr-probe-admitted/resource-services.yaml
+++ b/platform/kyverno-policies/chart/tests/vcluster-cidr-probe-admitted/resource-services.yaml
@@ -1,0 +1,44 @@
+# #4329 — INPUT fixtures: the Services the flux-managed (Enforce) policy judges.
+# None carry a Flux label/ownerRef (no `app.kubernetes.io/managed-by: flux`, no
+# `helm.toolkit.fluxcd.io/name`, no `kustomize.toolkit.fluxcd.io/name`), so the
+# deny rule's conditions are all true UNLESS an exclude carve-out spares them.
+
+# 1. The vCluster 0.33.x CIDR-detection probe Service, in the legacy
+#    `openova.io/tenant`-labelled boundary. Name matches `test-service-delete-me-*`.
+#    MUST be ADMITTED by the new name-pattern carve-out (else vcluster-0 syncer
+#    is fatal at `failed to get service cidr` → the live 11/11 CrashLoop).
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-service-delete-me-qwgml
+  namespace: tenant-demo
+spec:
+  ports:
+    - port: 80
+---
+# 2. The SAME probe Service shape but in a namespace with NO Org-boundary label.
+#    The carve-out is keyed on the probe's NAME (any namespace), so this is also
+#    ADMITTED — the syncer's host-CIDR probe must succeed even before any
+#    Org-boundary label exists.
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-service-delete-me-qgxrt
+  namespace: app-prod
+spec:
+  ports:
+    - port: 80
+---
+# 3. NEGATIVE control: a REAL, non-probe Service in the same legacy
+#    `openova.io/tenant` boundary, with no Flux label. The new carve-out keys on
+#    the `test-service-delete-me-*` name, NOT the namespace, so this real
+#    Service stays Enforce-DENIED — proving the policy's intent is preserved and
+#    the carve-out is not a blanket namespace exemption.
+apiVersion: v1
+kind: Service
+metadata:
+  name: customer-api
+  namespace: tenant-demo
+spec:
+  ports:
+    - port: 8080


### PR DESCRIPTION
Refs #4329 #4297 #4293

## Problem (proven LIVE on omantel.biz / kom4dc, dep 4635277cae4ffed9)

ALL 11/11 customer vClusters were `CrashLoopBackOff` (277+ restarts/23h). `vcluster-0` (vcluster 0.33.x) syncer init is fatal:

```
servicecidr/servicecidr.go:293  failed to create service ...: admission webhook "validate.kyverno.svc-fail" denied the request:
  resource Service/tenant-demo/test-service-delete-me-qwgml was blocked due to the following policies
  flux-managed:
    workload-must-be-flux-managed: Service/test-service-delete-me-qwgml is not Flux-managed.
error  initialize: ... failed to get service cidr ...
```

vCluster detects the host service CIDR at startup by CREATING a throwaway probe Service (`test-service-delete-me-<rand>`) and reading the apiserver error. That probe can never carry a Flux label/ownerRef, so `flux-managed` (Enforce) denied it → syncer fatal → no vCluster booted → the #4297 apps-in-vCluster keystone unreachable.

## Root cause — label-convention drift (live confirmation)

The `flux-managed` ClusterPolicy already carves out per-Org vCluster namespaces (#3859) — but only by `namespaceSelector: openova.io/organization Exists`.

- Live policy exclusion matched: `openova.io/organization` Exists.
- The CrashLooping `tenant-<slug>` namespaces carried `openova.io/tenant: <slug>` + `openova.io/managed-by: provisioning` — NOT `openova.io/organization`.

So the carve-out missed these namespaces and the probe Service was denied. (Current `main` already collapsed the funnel onto the org-controller as single boundary producer in #4295, which stamps `<slug>` namespaces with `openova.io/organization`; the live env runs stale pre-#4295 code. The policy is now hardened so NO label-convention drift can re-deny the probe.)

## Fix

Harden the `flux-managed` carve-out to admit the vCluster CIDR-probe Service DIRECTLY by name pattern (`Service/test-service-delete-me-*`, any namespace) rather than chasing the boundary-label convention. Admits ONLY that definitionally-unmanageable ephemeral probe; every real customer/operator Service stays gated. Convention-resilient — survives any future Org-namespace label drift. Mirrors the existing by-label CNPG operator carve-out (carve out the unmanageable object, not the namespace).

- `platform/kyverno-policies/chart/templates/baseline/10-flux-managed.yaml` — new probe-Service exclude.
- Chart `1.0.40 → 1.0.41`; bootstrap-kit slot 27a pin lockstep.
- New `kyverno test tests/vcluster-cidr-probe-admitted/` (3/3): probe in `openova.io/tenant` boundary ADMITTED; probe in label-less ns ADMITTED; real non-probe Service in same boundary DENIED.

## Verification

- `kyverno test tests/vcluster-cidr-probe-admitted/` — 3/3 pass.
- `kyverno apply` against the real non-probe Service — genuinely `fail: 1` (still denied), proving the carve-out is name-scoped, not a blanket namespace exemption.
- Existing `tests/inject-gitea-source-secretref/` — 5/5 still green; `helm lint` + full `helm template` clean.
- LIVE on kom4dc: hot-patched the live policy with the carve-out, deleted `tenant-demo/vcluster-0` → it booted `1/1 Running` in 49s; logs show the vCluster apiserver `Serving securely on 127.0.0.1:6443` (CIDR probe passed, no more `failed to get service cidr` / `denied`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)