### PR TITLE
fix(cloud-init): reflect ghcr-pull into slug-named per-Org namespaces — kill 401 ImagePullBackOff on every fresh Org

### DIFF
--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -196,18 +196,17 @@ write_files:
   # notification/organization/provisioning) → marketplace 503. Point the reflect
   # lists at the post-#3383 mesh namespace. Refs #3383.
   #
-  # #4246 (per-Org image-pull): per-Organization workload namespaces are created
-  # dynamically as `org-<uuid>` when an Organization is franchised — they CANNOT
-  # be enumerated statically here. Their HelmReleases run private
-  # `ghcr.io/openova-io/openova/*` runtime images (newapi-sandbox-bridge,
-  # services-metering-sidecar, openclaw-controller/-runtime, …) that need the
-  # `ghcr-pull` credential. Without a matching entry the reflector skips every
-  # `org-*` namespace → the private images fall back to an anonymous pull →
-  # `failed to fetch anonymous token … 401 Unauthorized` → ImagePullBackOff
-  # (bp-newapi + bp-openclaw never converge on the demo Org). The emberstack
-  # reflector treats each comma-separated entry as a REGULAR EXPRESSION
-  # (full-match), so `org-.*` auto-reflects `ghcr-pull` into every per-Org
-  # namespace the moment it is created. Refs #3383, #4246.
+  # #4246/#4328 (per-Org image-pull): per-Org workload namespaces are created
+  # dynamically and CANNOT be enumerated statically. Their HelmReleases run
+  # private `ghcr.io/openova-io/openova/*` images (newapi, wordpress-tenant-pg,
+  # openclaw, stalwart-tenant) needing `ghcr-pull`; an unmatched ns falls back to
+  # anonymous pull → `401 Unauthorized` → ImagePullBackOff. Reflector entries are
+  # full-match REGEXes. #4293/#4295 renamed the per-Org ns from `org-<uuid>` to
+  # the bare Organization SLUG (= subdomain, e.g. `tkt0626`; manifests.go
+  # `name: {{ .Slug }}`), which matched NEITHER the static list NOR `org-.*` →
+  # 401 on every fresh Org (live omantel.biz). The slug regex
+  # `[a-z][a-z0-9-]{2,30}` (the signup validator, handlers.go:28) reflects into
+  # every slug-named Org ns; `org-.*` retained for legacy. Refs #3383, #4246, #4293, #4328.
   - path: /var/lib/catalyst/ghcr-pull-secret.yaml
     permissions: '0600'
     content: |
@@ -218,9 +217,9 @@ write_files:
         namespace: flux-system
         annotations:
           reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "org-services,catalyst,catalyst-system,gitea,harbor,cert-manager,kube-system,flux-system,reflector,reloader,kyverno,opentelemetry,openbao,seaweedfs,powerdns,grafana,loki,mimir,tempo,alloy,coraza,crossplane-system,sigstore-system,trivy-system,syft-grype,falco,vpa,valkey,vllm,dmz,mgmt,rtz,external-dns,external-secrets,cnpg-system,velero,nats-system,sealed-secrets,newapi,huawei-evs-csi,org-.*"
+          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "org-services,catalyst,catalyst-system,gitea,harbor,cert-manager,kube-system,flux-system,reflector,reloader,kyverno,opentelemetry,openbao,seaweedfs,powerdns,grafana,loki,mimir,tempo,alloy,coraza,crossplane-system,sigstore-system,trivy-system,syft-grype,falco,vpa,valkey,vllm,dmz,mgmt,rtz,external-dns,external-secrets,cnpg-system,velero,nats-system,sealed-secrets,newapi,huawei-evs-csi,org-.*,[a-z][a-z0-9-]{2,30}"
           reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "org-services,catalyst,catalyst-system,gitea,harbor,cert-manager,kube-system,reflector,reloader,kyverno,opentelemetry,openbao,seaweedfs,powerdns,grafana,loki,mimir,tempo,alloy,coraza,crossplane-system,sigstore-system,trivy-system,syft-grype,falco,vpa,valkey,vllm,dmz,mgmt,rtz,external-dns,external-secrets,cnpg-system,velero,nats-system,sealed-secrets,newapi,huawei-evs-csi,org-.*"
+          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "org-services,catalyst,catalyst-system,gitea,harbor,cert-manager,kube-system,reflector,reloader,kyverno,opentelemetry,openbao,seaweedfs,powerdns,grafana,loki,mimir,tempo,alloy,coraza,crossplane-system,sigstore-system,trivy-system,syft-grype,falco,vpa,valkey,vllm,dmz,mgmt,rtz,external-dns,external-secrets,cnpg-system,velero,nats-system,sealed-secrets,newapi,huawei-evs-csi,org-.*,[a-z][a-z0-9-]{2,30}"
       type: kubernetes.io/dockerconfigjson
       data:
         .dockerconfigjson: ${base64encode(jsonencode({


### PR DESCRIPTION
## Problem (LIVE on omantel.biz / kom4dc region-a)
Every freshly-created Organization's private-image app pods fail `Init:ImagePullBackOff`. Confirmed live on Org namespace `tkt0626`:
- `bp-newapi` + `bp-wordpress-tenant` both `Init:ImagePullBackOff`.
- `kubectl get secret ghcr-pull -n tkt0626` → **NotFound**.
- newapi pod event (verbatim): `Failed to pull image "ghcr.io/openova-io/openova/newapi-sandbox-bridge:5d818d4": … failed to fetch anonymous token: … 401 Unauthorized`.
- Pod specs DO reference `imagePullSecrets:[{name: ghcr-pull}]` (chart side correct) — the reflected secret was simply absent.

## Root cause
EPIC #4293 / Workstream A (#4295, commit `b90121128`) collapsed the Organization-provisioning doors onto the org-controller and **renamed the per-Org host namespace from the legacy `org-<uuid>` to the bare Organization slug** (= subdomain, e.g. `tkt0626`) — `core/controllers/organization/internal/gitops/manifests.go` (`name: {{ .Slug }}`).

The emberstack-reflector allow-lists on `flux-system/ghcr-pull` (in `infra/providers/_shared/cloudinit-control-plane.tftpl`) only carried the static platform enumeration + `org-.*`. A bare slug like `tkt0626` full-matches **neither** → `ghcr-pull` stopped reflecting into every fresh Org → private `ghcr.io/openova-io/openova/*` images fall back to an anonymous pull → 401 → ImagePullBackOff.

## Fix — two layers
**Layer 1 (durable, this PR):** add the signup-validator slug regex `[a-z][a-z0-9-]{2,30}` (the exact `^[a-z][a-z0-9-]{2,30}$` guard from `core/services/tenant/handlers/handlers.go:28` + `provisioning consumer.go:27`) to **both** `reflection-allowed-namespaces` and `reflection-auto-namespaces` on `flux-system/ghcr-pull`, so the secret reflects into every slug-named per-Org namespace the moment it is created. `org-.*` retained for legacy `org-<uuid>` namespaces.

**Layer 2 (already satisfied):** `imagePullSecrets:[ghcr-pull]` is already set on `bp-newapi`, `bp-wordpress-tenant`, `bp-openclaw`, `bp-stalwart-tenant` — verified rendering (`helm template` emits it on Deployment + Job pods). No chart change required.

## Live proof the fix works
Hot-creating `ghcr-pull` in `tkt0626` (validation only):
- `bp-wordpress-tenant`: `Init:ImagePullBackOff` → **1/1 Running** (the 401ing `wordpress-tenant-pg` image now pulls).
- `bp-newapi`: `Init:ImagePullBackOff` → **1/3 Init:1/2** (sandbox-bridge image now pulls; advancing). Sole root cause confirmed.

## THIN cloud-init mandate honored
Net change is **13 insertions / 14 deletions** (comment trimmed) → rendered cloud-init is slightly **smaller**, not larger.
- `tofu test` (Hetzner): **12 passed, 0 failed** — incl. the G36 32256-byte `user_data` cap gate.
- `lint-cloudinit.sh both`: hetzner + huawei render OK, `dash -n` PASS on all runcmd items.

Refs #4328 #4272 #4278 #4322 #4293

🤖 Generated with [Claude Code](https://claude.com/claude-code)