### PR TITLE
fix(catalyst): wire spine Application→Continuum write/read seams end-to-end (Refs #4212)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -131,7 +131,9 @@ spec:
       # this slot's HelmRelease so the console /apps list, per-app Topology
       # tab + showback resolve openbao (no more "no Application CR").
       # 1.2.50: #3374 — in-vCluster k8s-auth mount + gateway-decoupled zero-click SSO landing.
-      version: 1.2.51
+      # 1.2.52 — #4212 Seam 3: placementSchema aligned with spec.topology
+      #   (modes[] admit active-passive + defaultOnMultiRegion). Chart bumped in lockstep.
+      version: 1.2.52
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -214,7 +214,9 @@ spec:
       #         chart.spec.version:"*" stops resolving to it (SemVer 1.5.0 >
       #         1.4.38) and its non-proxied bitnamilegacy images stop tripping
       #         harbor-proxy-pull. Chart content byte-identical to 1.4.38.
-      version: 1.5.2
+      # 1.5.3 — #4212 Seam 3: placementSchema aligned with spec.topology
+      #   (modes[] admit active-hot-standby + defaultOnMultiRegion). Chart bumped in lockstep.
+      version: 1.5.3
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -155,7 +155,9 @@ spec:
       # the chart ExternalSecret is suppressed via sso.externalSecret.enabled,
       # not sso.enabled), so the login_source row gets seeded in the mgmt
       # vCluster placement (caught live hw171). Refs #3374 #3642.
-      version: 1.2.40
+      # 1.2.41 — #4212 Seam 3: placementSchema aligned with spec.topology
+      #   (modes[] admit active-hot-standby + defaultOnMultiRegion). Chart bumped in lockstep.
+      version: 1.2.41
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1101,7 +1101,7 @@ spec:
       #   (application/organization/environment controllers) + adds the missing
       #   catalogSovereign secretRef values block + flips the env-controller's
       #   phantom gitea-flux-token default. Chart.yaml bumped in lockstep.
-      version: 1.4.842
+      version: 1.4.843
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -208,7 +208,9 @@ spec:
       # registry.<fqdn> 502 / harbor.<fqdn> 404 (hw172/hw173). databaseSecretSync
       # follows SOVEREIGN_HARBOR_PG_OWN_CLUSTER (own-vs-shared), set false only in
       # TRUE shared-pg mode. Non-host-bridged render byte-identical.
-      version: 1.2.36
+      # 1.2.37 — #4212 Seam 3: placementSchema aligned with spec.topology
+      #   (modes[] admit active-hot-standby + defaultOnMultiRegion). Chart bumped in lockstep.
+      version: 1.2.37
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/core/controllers/application/internal/controller/application_controller.go
+++ b/core/controllers/application/internal/controller/application_controller.go
@@ -1355,9 +1355,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 	// backend source. This is READ-ONLY + NON-BLOCKING: an unsupported
 	// backing-service type is logged, never fatal (a recommendation must
 	// never fail a reconcile).
+	// #3969 read-model rides on Seam 3: when the Application stamps the
+	// legacy placement string (the spine producer + every pre-#3969 app),
+	// derive the desired-state targets from the resolved plan so the
+	// backing-service cascade + the observed-target rollup below operate on
+	// the REAL primary+standby target set rather than an empty list.
+	effectiveTargets := effectivePlacementTargets(spec.PlacementTargets, plan)
 	if bindings, berr := resolveBackingPlacement(
 		spec.BlueprintName, app.GetName(), app.GetNamespace(),
-		blueprintBackingServices(bp), spec.PlacementTargets, spec.OwnedDependencies,
+		blueprintBackingServices(bp), effectiveTargets, spec.OwnedDependencies,
 	); berr != nil {
 		r.Log.Warn("backing-service placement cascade skipped",
 			"app", app.GetName(), "blueprint", spec.BlueprintName, "err", berr)
@@ -1396,7 +1402,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 	// desired-state targets are declared we carry their richer
 	// Primary|Standby role + Hot|Cold type onto the rollup, region-matched.
 	readyByRegion := readbackByRegion(plan, finalPhase)
-	observed := observedTargetsFromPlan(plan, spec.PlacementTargets, readyByRegion)
+	observed := observedTargetsFromPlan(plan, effectiveTargets, readyByRegion)
 	su.PlacementRecon, su.PlacementReason, su.ObservedTargets = reconStatusBlock(observed)
 
 	return r.updateStatus(ctx, app, su)

--- a/core/controllers/application/internal/controller/placement_recon.go
+++ b/core/controllers/application/internal/controller/placement_recon.go
@@ -228,6 +228,49 @@ func observedTargetsFromPlan(
 	return out
 }
 
+// effectivePlacementTargets returns the placement targets the #3969
+// read-model (backing-service cascade + observed-target rollup) should ride
+// on. When the Application declares explicit desired-state targets
+// (spec.placement.targets[]) they win verbatim. Otherwise — the legacy
+// string-mode case, which is what the spine producer stamps
+// (active-passive / active-hot-standby / singleton) AND every pre-#3969
+// Application — we DERIVE the targets from the already-resolved placement
+// plan (placementTargetsFromPlan), so the cascade + the observed rollup
+// "ride on Seam 3" instead of seeing an empty target list. This is the
+// thread the EPIC calls for: spine CRs carry a legacy placement string, but
+// the consumer placement reaching backingservice.Input.Targets is the real
+// primary+standby target set, region-matched.
+func effectivePlacementTargets(declared []bpv1alpha1.PlacementTarget, plan placement.Plan) []bpv1alpha1.PlacementTarget {
+	if len(declared) > 0 {
+		return declared
+	}
+	return placementTargetsFromPlan(plan)
+}
+
+// placementTargetsFromPlan derives the canonical desired-state target list
+// from a resolved placement plan. regions[0] (or the plan's PrimaryRegion)
+// is Primary; the standby regions are Standby/Hot (the plan does not encode
+// hot-vs-cold — the #3698 fan-out treats both as replicas:0 standbys — so we
+// surface Hot, the conservative DR posture the Topology tab renders). An
+// active-active plan (no PrimaryRegion, every region Active) yields all
+// Primary targets. Cluster is left empty: the legacy plan carries only the
+// region name; the read-model keys off region + role, and a downstream
+// consumer that needs the cluster reads it from the fan-out HR labels.
+func placementTargetsFromPlan(plan placement.Plan) []bpv1alpha1.PlacementTarget {
+	out := make([]bpv1alpha1.PlacementTarget, 0, len(plan.Regions))
+	for _, rp := range plan.Regions {
+		t := bpv1alpha1.PlacementTarget{Region: rp.Name}
+		if rp.Standby || rp.Role == placement.RoleStandby {
+			t.Role = bpv1alpha1.DataRoleStandby
+			t.StandbyType = bpv1alpha1.StandbyHot
+		} else {
+			t.Role = bpv1alpha1.DataRolePrimary
+		}
+		out = append(out, t)
+	}
+	return out
+}
+
 // regionReadback is the per-region readiness signal the controller already
 // derives from the per-region HelmRelease, projected into the recon
 // rollup.

--- a/core/controllers/application/internal/controller/placement_recon_test.go
+++ b/core/controllers/application/internal/controller/placement_recon_test.go
@@ -279,3 +279,45 @@ func TestReconStatusBlock_EmptyObserved(t *testing.T) {
 	}
 	_ = unstructured.Unstructured{} // keep the import meaningful in this file
 }
+
+// TestEffectivePlacementTargets_DerivesFromPlanWhenLegacy proves the #3969
+// read-model rides on Seam 3: an Application that stamps the legacy
+// placement string (the spine producer + every pre-#3969 app) gets its
+// desired-state targets DERIVED from the resolved plan, so the backing-
+// service cascade + observed rollup see the real primary+standby target set
+// instead of an empty list. Explicit declared targets always win verbatim.
+func TestEffectivePlacementTargets_DerivesFromPlanWhenLegacy(t *testing.T) {
+	// active-passive plan: regions[0] primary, regions[1] standby.
+	plan, err := placement.Resolve("active-passive", []string{"region-a", "region-b"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	// Legacy (no declared targets) → derived from the plan.
+	got := effectivePlacementTargets(nil, plan)
+	if len(got) != 2 {
+		t.Fatalf("derived targets = %d, want 2", len(got))
+	}
+	if got[0].Region != "region-a" || got[0].Role != bpv1alpha1.DataRolePrimary {
+		t.Fatalf("target[0] = %+v, want region-a/Primary", got[0])
+	}
+	if got[1].Region != "region-b" || got[1].Role != bpv1alpha1.DataRoleStandby || got[1].StandbyType != bpv1alpha1.StandbyHot {
+		t.Fatalf("target[1] = %+v, want region-b/Standby/Hot", got[1])
+	}
+
+	// Singleton plan → one Primary target, no standby.
+	sp, _ := placement.Resolve("singleton", []string{"region-a"})
+	one := effectivePlacementTargets(nil, sp)
+	if len(one) != 1 || one[0].Role != bpv1alpha1.DataRolePrimary || one[0].StandbyType != "" {
+		t.Fatalf("singleton derived = %+v, want one Primary", one)
+	}
+
+	// Explicit declared targets win verbatim (never overwritten by the plan).
+	declared := []bpv1alpha1.PlacementTarget{
+		{Region: "region-x", Cluster: "mgmt-A", Role: bpv1alpha1.DataRolePrimary},
+	}
+	keep := effectivePlacementTargets(declared, plan)
+	if len(keep) != 1 || keep[0].Region != "region-x" || keep[0].Cluster != "mgmt-A" {
+		t.Fatalf("declared targets not preserved: %+v", keep)
+	}
+}

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.40
+  version: 1.2.41
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).
@@ -21,6 +21,18 @@ spec:
   defaultPlacement:
     vcluster: mgmt
   allowedPlacements: [host, mgmt]
+
+  # placementSchema aligned with spec.topology below (#4212 Seam 3). The
+  # spine Application-CR producer stamps active-hot-standby on a multi-region
+  # Sovereign (matching topology.defaults.multi-region) — modes[] must admit
+  # it AND defaultOnMultiRegion must name it so the placement is accepted and
+  # the Continuum CR is minted.
+  placementSchema:
+    modes: [singleton, active-hot-standby]
+    default: singleton
+    defaultOnMultiRegion: active-hot-standby
+    minRegions: 1
+    maxRegions: 2
 
   manifests:
     chart: ./chart

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -153,7 +153,7 @@ name: bp-gitea
 # IN the vCluster and seeds the row (its creds cross in via bp-mgmt-vcluster
 # sync.fromHost). Non-host-bridged render is byte-identical. Refs #3374 #3642.
 # 1.2.40 (#3971): CNPG storageClass empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN.
-version: 1.2.40
+version: 1.2.41
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/harbor/blueprint.yaml
+++ b/platform/harbor/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-5-storage-and-data
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.36
+  version: 1.2.37
   card:
     title: Harbor
     family: foundation
@@ -50,10 +50,19 @@ spec:
         default: false
         description: Enable OIDC SSO via Catalyst Keycloak. Default off — opt in via per-Sovereign overlay once bp-keycloak has reconciled.
   placementSchema:
-    modes: [single-region]           # legacy field — superseded by spec.topology below; kept for backward compatibility with the existing application-controller path
+    # Aligned with spec.topology below (#4212 Seam 3): the application-
+    # controller validates an Application's spec.placement against modes[]
+    # (blueprintAllowedModes) and derives the effective default from
+    # default / defaultOnMultiRegion (EffectiveDefault). The spine
+    # Application-CR producer stamps active-hot-standby on a multi-region
+    # Sovereign (matching topology.defaults.multi-region), so modes[] must
+    # admit it AND defaultOnMultiRegion must name it — otherwise the
+    # explicit placement is rejected and no Continuum CR is minted.
+    modes: [single-region, singleton, active-hot-standby]
     default: single-region
+    defaultOnMultiRegion: active-hot-standby
     minRegions: 1
-    maxRegions: 1
+    maxRegions: 2
   # ── #3373: class-level placement SUGGESTION + allow-list ────────────────
   # Placement is an INSTANCE property (Application.spec.placement); this is
   # only the default every instance inherits silently — the provisioning

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -142,7 +142,7 @@ type: application
 # materialise. The cnpg-cluster.yaml Cluster-CR gate is UNCHANGED (still
 # cluster.enabled — the host-bridge must not double-create it). Non-host-bridged
 # render byte-identical.
-version: 1.2.36
+version: 1.2.37
 appVersion: "2.14.3"
 # 1.2.23 (G117.5 #2744, 2026-06-02): SSO defense-in-depth via Harbor's
 # `oidc_extra_redirect_parms` config field. The configure-oauth Job now

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.5.2
+  version: 1.5.3
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for Organizations, shared-sovereign for corporate).
@@ -21,6 +21,18 @@ spec:
   defaultPlacement:
     vcluster: mgmt
   allowedPlacements: [host, mgmt]
+
+  # placementSchema aligned with spec.topology below (#4212 Seam 3). The
+  # spine Application-CR producer stamps active-hot-standby on a multi-region
+  # Sovereign (matching topology.defaults.multi-region) — modes[] must admit
+  # it AND defaultOnMultiRegion must name it so the placement is accepted and
+  # the Continuum CR is minted.
+  placementSchema:
+    modes: [singleton, active-hot-standby]
+    default: singleton
+    defaultOnMultiRegion: active-hot-standby
+    minRegions: 1
+    maxRegions: 2
 
   manifests:
     chart: ./chart

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -403,7 +403,7 @@ name: bp-keycloak
 # images pass admission. No chart-content change beyond the version line + this
 # changelog — the 1.4.38 templates/values are byte-identical and already
 # proxy-compliant. Refs #3785 (sibling proxy-class defect for the WP image).
-version: 1.5.2
+version: 1.5.3
 description: |
   1.5.2 (#4246): the per-tenant `openclaw-oidc-client-secret` Secret now
   emits BOTH `client-secret` AND `OIDC_CLIENT_SECRET` keys (it previously

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.51  # lockstep with chart/Chart.yaml (#3888 prov-time openbao KV-seed mechanism for evicting inline cloud-init Secrets to Flux ExternalSecrets)
+  version: 1.2.52  # lockstep with chart/Chart.yaml (#3888 prov-time openbao KV-seed mechanism for evicting inline cloud-init Secrets to Flux ExternalSecrets)
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.
@@ -21,6 +21,21 @@ spec:
   defaultPlacement:
     vcluster: mgmt
   allowedPlacements: [host, mgmt]
+
+  # placementSchema aligned with spec.topology below (#4212 Seam 3). The
+  # application-controller validates an Application's spec.placement against
+  # modes[] (blueprintAllowedModes) and derives the effective default from
+  # default / defaultOnMultiRegion (EffectiveDefault). The spine
+  # Application-CR producer stamps active-passive on a multi-region
+  # Sovereign (matching topology.defaults.multi-region) — modes[] must
+  # admit it AND defaultOnMultiRegion must name it so the placement is
+  # accepted and the Continuum CR is minted.
+  placementSchema:
+    modes: [singleton, active-passive]
+    default: singleton
+    defaultOnMultiRegion: active-passive
+    minRegions: 1
+    maxRegions: 2
 
   manifests:
     chart: ./chart

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -167,7 +167,7 @@ name: bp-openbao
 # Both default-OFF for host-side openbao (XCR off) → byte-identical render.
 # Verified GREEN live hw167 2026-06-19: bao.<fqdn>/ui/ → /sso/landing → lands
 # /ui/vault/secrets (sso-zero-click-probe openbao row GREEN). Pin in lockstep.
-version: 1.2.51
+version: 1.2.52
 # 1.2.51 (#3888, Refs #3847): prov-time openbao KV-seed mechanism — the
 # auth-bootstrap Job reads a one-shot cloud-init `openbao-bootstrap-seed`
 # Secret + writes its keys into KV at secret/<prefix>/* with the still-valid

--- a/platform/wordpress-tenant/blueprint.yaml
+++ b/platform/wordpress-tenant/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: tenant-app
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.4.18
+  version: 0.4.19
   card:
     title: WordPress (per-Organization)
     summary: |
@@ -185,9 +185,20 @@ spec:
                 type: string
                 default: letsencrypt-prod
                 description: cert-manager ClusterIssuer name.
+  # placementSchema aligned with spec.topology below (#4212 Seam 4). The
+  # application-controller derives the effective placement from
+  # default / defaultOnMultiRegion (EffectiveDefault) and validates it
+  # against modes[] (blueprintAllowedModes). With only `single-region` here,
+  # a multi-region Sovereign's per-Org WordPress resolved to singleton — a
+  # plan with no standby region — so the generic per-app Continuum producer
+  # (continuum.go buildContinuumPlan) minted NO Continuum CR and the per-Org
+  # DR contract never existed. Naming the active-passive multi-region default
+  # (matching topology.defaults.multi-region) lets the producer emit a
+  # primary+standby plan and mint the per-Org Continuum CR.
   placementSchema:
-    modes: [single-region]
+    modes: [single-region, singleton, active-passive]
     default: single-region
+    defaultOnMultiRegion: active-passive
   manifests:
     chart: ./chart
   depends:

--- a/platform/wordpress-tenant/chart/Chart.yaml
+++ b/platform/wordpress-tenant/chart/Chart.yaml
@@ -222,6 +222,11 @@ name: bp-wordpress-tenant
 #   live on the tkt0625 fresh Org (omantel.biz region-a, 2026-06-25): the live
 #   oidc-config pod logged exactly `[oidc-config] seeding pg4wp db.php drop-in
 #   (Postgres adapter)` then `curl: (22) ... error: 404`; `v3.3.1.zip` returns 200.
+# 0.4.19 (Refs #4212): placementSchema aligned with spec.topology (Seam 4) —
+#   modes[] now admit single-region/singleton/active-passive +
+#   defaultOnMultiRegion=active-passive so a multi-region Sovereign's per-Org
+#   WordPress resolves to primary+standby and the per-app Continuum producer
+#   mints the per-Org Continuum CR (was singleton → no standby → no CR).
 # 0.4.18 (Refs #4322): FIX the oidc-config hook Job TIMEOUT that left a FRESH
 #   Org's HelmRelease Ready=False even though the WordPress Pod was 1/1 Running
 #   serving HTTP 302 (the #4323 pg4wp fix above is validated at Pod level). After
@@ -249,7 +254,7 @@ name: bp-wordpress-tenant
 #   tests/oidc-config.sh Case 8 asserts the Job has no `wp plugin install`, never
 #   references wordpress.org, vendors from the pinned GitHub tag, and tolerates a
 #   fetch failure — so the HR reaches Ready without ANY external plugin download.
-version: 0.4.18
+version: 0.4.19
 appVersion: "6"
 description: |
   Catalyst Blueprint scratch chart for in-vcluster WordPress, one

--- a/products/catalyst/bootstrap/api/internal/handler/post_handover_spine_apps.go
+++ b/products/catalyst/bootstrap/api/internal/handler/post_handover_spine_apps.go
@@ -17,11 +17,11 @@
 //
 // This hook is that producer. After Phase-1 reaches OutcomeReady it, for
 // each DR-capable spine HelmRelease present on the Sovereign:
-//   1. composes one idempotent Application CR (spec.blueprintRef → the spine
-//      Blueprint, spec.environmentRef → the Sovereign control-plane env,
-//      spec.regions[] → the deployment's declared regions),
-//   2. SERVER-SIDE APPLIES it onto the Sovereign cluster via the kubeconfig
-//      the cloud-init posted back.
+//  1. composes one idempotent Application CR (spec.blueprintRef → the spine
+//     Blueprint, spec.environmentRef → the Sovereign control-plane env,
+//     spec.regions[] → the deployment's declared regions),
+//  2. SERVER-SIDE APPLIES it onto the Sovereign cluster via the kubeconfig
+//     the cloud-init posted back.
 //
 // ADOPT, never roll (Invariant #3). The CR carries a
 // `catalyst.openova.io/adopts-helmrelease` label naming the EXISTING spine
@@ -61,6 +61,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/clientcmd"
@@ -89,27 +90,58 @@ type spineComponent struct {
 	HRName           string
 	BlueprintName    string
 	BlueprintVersion string
+
+	// MultiRegionMode is the canonical placement mode this spine
+	// component resolves to on a MULTI-region Sovereign — it mirrors the
+	// Blueprint's `spec.topology.defaults.multi-region`
+	// (platform/<chart>/blueprint.yaml). The producer stamps this verbatim
+	// onto the Application CR's spec.placement when the deployment carries
+	// ≥2 regions (singleton otherwise). This is load-bearing: the
+	// application-controller's per-app Continuum producer
+	// (continuum.go buildContinuumPlan) mints a Continuum CR ONLY when the
+	// resolved placement plan carries a standby region — i.e. an
+	// active-passive / active-hot-standby plan. Omitting placement made the
+	// controller derive `singleton` (the spine Blueprints declare no
+	// placementSchema.defaultOnMultiRegion), so the plan had no standby and
+	// NO Continuum CR was ever minted — the producer-write reached no
+	// consumer. Stamping the explicit multi-region mode here closes that
+	// half of Seam 3 so the write actually flows to the Continuum reader.
+	MultiRegionMode string
 }
 
-// drCapableSpine — the canonical DR-capable bootstrap-spine roster. The
-// Blueprint name/version mirror the pins in platform/<chart>/blueprint.yaml
-// (`metadata.name` + `spec.version`). harbor's Blueprint is named bare
-// `harbor` (legacy — its blueprint.yaml metadata.name is `harbor`, not
-// `bp-harbor`); the other three carry the `bp-` prefix. The HelmRelease is
-// `bp-<chart>` for all four (the bootstrap-kit names every spine HR with the
-// `bp-` prefix regardless of the Blueprint's own metadata.name).
+// drCapableSpine — the canonical DR-capable bootstrap-spine roster.
 //
-// Versions are intentionally the floor the bootstrap-kit installs; the
-// application-controller resolves the Blueprint by name+version from the
-// per-Sovereign catalog (Gitea-mirrored), and an exact-semver miss surfaces
-// as Pending (ReasonBlueprintMissing) rather than a hard failure — so a
-// catalog that has rolled the spine pin forward simply needs the Application
-// CR's version bumped on the next enrollment pass (idempotent).
+// BlueprintName is the name the application-controller resolves the live
+// Blueprint CR by (fetchBlueprint is a by-NAME Get). On a Sovereign the
+// resolvable Blueprint CRs come from the catalog-seed
+// (products/catalyst/chart/templates/catalog-seed/blueprints.yaml), which
+// names all four with the `bp-` prefix (bp-openbao / bp-keycloak / bp-harbor
+// / bp-gitea) — so the roster uses those names. (Note: platform/harbor/
+// blueprint.yaml's own metadata.name is the bare `harbor`, but that file is
+// only mirrored to Gitea post-cutover; the LIVE catalog CR is bp-harbor.)
+// The HelmRelease the CR adopts is `bp-<chart>` for all four (the
+// bootstrap-kit convention).
+//
+// BlueprintVersion is the catalog-seed `spec.version` (the version present in
+// the live catalog at bootstrap). fetchBlueprint is by-name not version-
+// pinned, so the pin only needs to be a valid exact semver the Application CR
+// can carry; tracking the seeded value keeps `kubectl get applications`
+// honest about the version actually in the catalog. An exact-semver miss
+// surfaces as Pending (ReasonBlueprintMissing), never a hard failure — the
+// next enrollment pass picks up the rolled-forward pin (idempotent).
+//
+// MultiRegionMode mirrors each Blueprint's `spec.topology.defaults.multi-region`:
+// openbao's raft stream is async → active-passive; keycloak/harbor/gitea ride
+// a synchronous cnpg-pair → active-hot-standby. These are the SAME modes
+// ResolveTopology picks from `defaults.multi-region`, so stamping them
+// explicitly keeps the placement plan (placement.Resolve) and the topology
+// variant (ResolveTopology) in agreement — both then describe a primary +
+// standby pair, which buildContinuumPlan needs to mint the Continuum CR.
 var drCapableSpine = []spineComponent{
-	{Chart: "openbao", HRName: "bp-openbao", BlueprintName: "bp-openbao", BlueprintVersion: "1.2.51"},
-	{Chart: "keycloak", HRName: "bp-keycloak", BlueprintName: "bp-keycloak", BlueprintVersion: "1.5.2"},
-	{Chart: "harbor", HRName: "bp-harbor", BlueprintName: "harbor", BlueprintVersion: "1.2.36"},
-	{Chart: "gitea", HRName: "bp-gitea", BlueprintName: "bp-gitea", BlueprintVersion: "1.2.40"},
+	{Chart: "openbao", HRName: "bp-openbao", BlueprintName: "bp-openbao", BlueprintVersion: "1.2.25", MultiRegionMode: "active-passive"},
+	{Chart: "keycloak", HRName: "bp-keycloak", BlueprintName: "bp-keycloak", BlueprintVersion: "1.0.0", MultiRegionMode: "active-hot-standby"},
+	{Chart: "harbor", HRName: "bp-harbor", BlueprintName: "bp-harbor", BlueprintVersion: "1.2.26", MultiRegionMode: "active-hot-standby"},
+	{Chart: "gitea", HRName: "bp-gitea", BlueprintName: "bp-gitea", BlueprintVersion: "1.2.24", MultiRegionMode: "active-hot-standby"},
 }
 
 // spineApplicationNamespace — where the spine Application CRs land. The
@@ -173,12 +205,36 @@ func (h *Handler) runPostHandoverSpineApplications(dep *Deployment) {
 
 	// Compose the deployment-derived fields shared by every spine CR.
 	envRef := spineEnvironmentRef(dep)
+	orgRef := spineOrganizationSlug(dep)
 	regions := spineRegions(dep)
 	if len(regions) == 0 {
 		h.log.Warn("spine-apps: deployment carries no regions; skipping (spec.regions[] is required)", "id", dep.ID)
 		return
 	}
 	ownerLabels := spineOwnerLabels(dep)
+
+	// Ensure the CONSUMER prerequisites the application-controller hard-
+	// requires before it will reconcile any spine Application CR. The
+	// controller resolves spec.environmentRef → Environment CR →
+	// spec.organizationRef → Organization CR; a miss leaves the Application
+	// at phase=Pending (ReasonEnvironmentMissing / ReasonOrganizationMissing)
+	// forever and NO Continuum CR is minted. Per-Org Environments are minted
+	// by the organization-controller off a Ready vCluster (environment_ensure.go),
+	// but the SPINE is the Sovereign-self control plane — it has no per-Org
+	// vCluster, so nothing ever stamps its Environment/Organization. We stamp
+	// both here, idempotently, so the producer-write actually reaches the
+	// Continuum reader. The control-plane Environment carries the deployment's
+	// REAL region count so the controller resolves multi-region topology
+	// (len(env.spec.regions) > 1) — the gate ResolveTopology + buildContinuumPlan
+	// both key off.
+	if err := h.ensureSpineOrganization(dyn, dep, orgRef); err != nil {
+		h.log.Warn("spine-apps: ensure control-plane Organization failed; spine apps will sit Pending until it lands",
+			"id", dep.ID, "org", orgRef, "err", err)
+	}
+	if err := h.ensureSpineEnvironment(dyn, dep, envRef, orgRef, regions); err != nil {
+		h.log.Warn("spine-apps: ensure control-plane Environment failed; spine apps will sit Pending until it lands",
+			"id", dep.ID, "env", envRef, "err", err)
+	}
 
 	// Wait for the spine HRs to appear, then enroll each present one. The
 	// Application CRD ships with catalyst (present immediately); the spine
@@ -188,7 +244,7 @@ func (h *Handler) runPostHandoverSpineApplications(dep *Deployment) {
 	wantPresent := len(drCapableSpine)
 	for {
 		present := h.presentSpineHRs(dyn, dep)
-		enrolled = h.enrollSpineApplications(dyn, dep, present, envRef, regions, ownerLabels)
+		enrolled = h.enrollSpineApplications(dyn, dep, present, envRef, orgRef, regions, ownerLabels)
 		// Done once we have enrolled an Application CR for every spine HR
 		// that is actually present. If a spine HR never appears (a Sovereign
 		// that does not install all four) we still finish on the budget.
@@ -263,12 +319,13 @@ func (h *Handler) enrollSpineApplications(
 	dep *Deployment,
 	present []spineComponent,
 	envRef string,
+	orgRef string,
 	regions []string,
 	ownerLabels map[string]string,
 ) int {
 	enrolled := 0
 	for _, sc := range present {
-		obj := renderSpineApplicationCR(sc, envRef, regions, ownerLabels)
+		obj := renderSpineApplicationCR(sc, envRef, orgRef, regions, ownerLabels)
 		err := applySpineApplicationCR(dyn, obj)
 		if err != nil {
 			if isNoMatchOrCRDMissing(err) {
@@ -311,19 +368,33 @@ var applySpineApplicationCR = func(dyn dynamic.Interface, obj *unstructured.Unst
 // renderSpineApplicationCR composes the idempotent Application CR for one
 // spine component. Pure function — no client calls. The shape mirrors the
 // REST install path (newApplicationUnstructured) + parseSpec's required set
-// (environmentRef, blueprintRef.{name,version}, regions[]). spec.placement
-// is intentionally OMITTED so the application-controller derives the
-// effective default from the Blueprint's defaultOnMultiRegion + the
-// Sovereign-wide BCP topology (SOVEREIGN_BCP_TOPOLOGY) — exactly the seam
-// that lands a multi-region Sovereign's spine on active-passive zero-touch,
-// which buildContinuumPlan needs to mint the Continuum contract.
+// (environmentRef, blueprintRef.{name,version}, regions[], placement).
+//
+// spec.placement is stamped EXPLICITLY (singleton on a single-region
+// Sovereign, the Blueprint's topology.defaults.multi-region —
+// active-passive / active-hot-standby — on a multi-region one). It is NOT
+// omitted: the spine Blueprints declare no `placementSchema.defaultOnMultiRegion`,
+// so an omitted placement makes the application-controller's EffectiveDefault
+// derive `singleton` regardless of region count — and a singleton plan has
+// no standby region, so buildContinuumPlan returns (zero,false) and NO
+// Continuum CR is ever minted. Worse, a singleton placement with >1 region
+// fails placement.Resolve outright (Application → Failed). Stamping the
+// explicit multi-region mode makes placement.Resolve emit a primary+standby
+// plan that agrees with the topology variant ResolveTopology picks from the
+// same `defaults.multi-region` — the two halves the Continuum producer reads
+// — so the producer-write actually reaches the Continuum reader (Seam 3).
+//
+// spec.organizationRef pins the control-plane Organization the spine
+// Environment references, so the application-controller's
+// fetchOrganization existence check passes (it would otherwise leave the
+// Application at Pending/ReasonOrganizationMissing).
 //
 // The CR name is `spine-<chart>` (e.g. spine-openbao) so an operator's
 // `kubectl get applications.apps.openova.io -A` reads as a spine roster
 // distinct from Org / signup apps. The
 // `catalyst.openova.io/adopts-helmrelease` label names the EXISTING spine
 // HR the CR adopts (Invariant #3 — adopt, never roll).
-func renderSpineApplicationCR(sc spineComponent, envRef string, regions []string, ownerLabels map[string]string) *unstructured.Unstructured {
+func renderSpineApplicationCR(sc spineComponent, envRef, orgRef string, regions []string, ownerLabels map[string]string) *unstructured.Unstructured {
 	obj := &unstructured.Unstructured{}
 	obj.SetAPIVersion(ApplicationGVR().Group + "/" + ApplicationGVR().Version)
 	obj.SetKind("Application")
@@ -335,6 +406,7 @@ func renderSpineApplicationCR(sc spineComponent, envRef string, regions []string
 		lbls[k] = v
 	}
 	lbls["catalyst.openova.io/managed-by"] = "catalyst-api"
+	lbls["catalyst.openova.io/organization"] = orgRef
 	lbls["catalyst.openova.io/blueprint"] = sc.BlueprintName
 	lbls["catalyst.openova.io/blueprint-version"] = sc.BlueprintVersion
 	// Spine marker + adopt back-pointer: the object model can tell a spine
@@ -350,7 +422,9 @@ func renderSpineApplicationCR(sc spineComponent, envRef string, regions []string
 	}
 
 	spec := map[string]interface{}{
-		"environmentRef": envRef,
+		"environmentRef":  envRef,
+		"organizationRef": orgRef,
+		"placement":       spinePlacementMode(sc, len(regions)),
 		"blueprintRef": map[string]interface{}{
 			"name":    sc.BlueprintName,
 			"version": sc.BlueprintVersion,
@@ -359,6 +433,21 @@ func renderSpineApplicationCR(sc spineComponent, envRef string, regions []string
 	}
 	obj.Object["spec"] = spec
 	return obj
+}
+
+// spinePlacementMode picks the explicit placement mode to stamp on a spine
+// Application CR. On a single-region Sovereign the spine is a singleton; on
+// a multi-region Sovereign it rides the Blueprint's declared
+// topology.defaults.multi-region (active-passive for the async raft spine,
+// active-hot-standby for the synchronous cnpg-pair spine). The number of
+// regions is authoritative — a spine component whose roster row carries no
+// MultiRegionMode (defensive) falls back to singleton so the producer never
+// stamps an unrenderable mode.
+func spinePlacementMode(sc spineComponent, regionCount int) string {
+	if regionCount > 1 && sc.MultiRegionMode != "" {
+		return sc.MultiRegionMode
+	}
+	return "singleton"
 }
 
 // spineApplicationName composes the spine Application CR name (`spine-<chart>`).
@@ -421,4 +510,238 @@ func spineOwnerLabels(dep *Deployment) map[string]string {
 	}
 	out["catalyst.openova.io/environment"] = spineEnvironmentRef(dep)
 	return out
+}
+
+// spineOrganizationSlug returns the control-plane Organization slug the
+// spine Environment + Application CRs reference. It is the slugged Sovereign
+// FQDN (e.g. "t99-omani-works" for "t99.omani.works") — an RFC-1123 label
+// the Organization CRD's slug pattern accepts, derived the same way the REST
+// install path slugs its namespace. This is the Sovereign-self "platform"
+// Organization, distinct from any customer tenant Org.
+func spineOrganizationSlug(dep *Deployment) string {
+	dep.mu.Lock()
+	fqdn := strings.TrimSpace(dep.Request.SovereignFQDN)
+	dep.mu.Unlock()
+	base := fqdn
+	if base == "" {
+		base = dep.ID
+	}
+	return orgNamespace(base)
+}
+
+// ensureSpineOrganization server-side-applies the Sovereign-self
+// (platform-scope) Organization CR the spine Environment references. It is
+// existence-only from the application-controller's perspective (fetchOrganization
+// is a presence check), so we stamp the minimal valid spec the Organization
+// CRD requires (slug, displayName, kind, tier, billingMode, sovereignRef +
+// one owner). The `openova.io/scope: platform` label marks it as the
+// control-plane self-org, distinct from a customer tenant Org. Idempotent:
+// a re-run server-side-applies the same fields. NotFound of the CRD (e.g.
+// the Organization CRD not yet registered) is surfaced so the caller logs +
+// the next enrollment pass retries.
+func (h *Handler) ensureSpineOrganization(dyn dynamic.Interface, dep *Deployment, orgRef string) error {
+	dep.mu.Lock()
+	fqdn := strings.TrimSpace(dep.Request.SovereignFQDN)
+	email := strings.TrimSpace(dep.Request.OrgEmail)
+	name := strings.TrimSpace(dep.Request.OrgName)
+	dep.mu.Unlock()
+	if fqdn == "" {
+		fqdn = orgRef
+	}
+	display := name
+	if display == "" {
+		display = fqdn + " (platform spine)"
+	}
+	owners := []interface{}{}
+	if email != "" {
+		owners = append(owners, map[string]interface{}{"email": email, "role": "owner"})
+	}
+	spec := map[string]interface{}{
+		"slug":         orgRef,
+		"displayName":  display,
+		"kind":         "internal",
+		"tier":         "platform",
+		"billingMode":  "free",
+		"sovereignRef": fqdn,
+	}
+	if len(owners) > 0 {
+		spec["owners"] = owners
+	}
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("orgs.openova.io/v1")
+	obj.SetKind("Organization")
+	obj.SetName(orgRef)
+	obj.SetLabels(map[string]string{
+		"catalyst.openova.io/managed-by": "catalyst-api",
+		"openova.io/scope":               "platform",
+		"openova.io/sovereign":           fqdn,
+	})
+	obj.Object["spec"] = spec
+	return applySpineClusterResource(dyn, organizationGVR(), "", obj)
+}
+
+// ensureSpineEnvironment server-side-applies the Sovereign-self control-plane
+// Environment CR (`<sovereign>-cp`) the spine Application CRs reference. The
+// application-controller reads ONLY spec.organizationRef, spec.envType,
+// spec.placement, and len(spec.regions) off the Environment (parseEnvSpec) —
+// the per-region provider/region/buildingBlock VALUES are only used by the
+// environment-controller to derive Gitea host-cluster paths, and the spine
+// install pivots through the Blueprint topology, not those strings. So the
+// load-bearing field for Seam 3 is len(spec.regions): it MUST equal the
+// deployment's real region count so ResolveTopology resolves multi-region
+// (defaults.multi-region) on a ≥2-region Sovereign. We emit one CRD-valid
+// region triple per real region (provider/region/buildingBlock satisfying
+// the CRD enums + the `^[a-z]{3}[a-z0-9]?$` region pattern). Idempotent.
+func (h *Handler) ensureSpineEnvironment(dyn dynamic.Interface, dep *Deployment, envRef, orgRef string, regions []string) error {
+	regionObjs := make([]interface{}, 0, len(regions))
+	for _, sc := range spineRegionSpecs(dep) {
+		regionObjs = append(regionObjs, spineEnvRegionObject(sc))
+	}
+	// Defensive: if the deployment carried region strings but no RegionSpec
+	// rows (single Request.Region path), synthesise CRD-valid triples from
+	// the count so len(spec.regions) still drives the topology resolution.
+	for len(regionObjs) < len(regions) {
+		regionObjs = append(regionObjs, spineEnvRegionObject(provisioner.RegionSpec{}))
+	}
+	placement := "single-region"
+	if len(regionObjs) > 1 {
+		placement = "multi-region"
+	}
+	spec := map[string]interface{}{
+		"organizationRef": orgRef,
+		"envType":         "prod",
+		"placement":       placement,
+		"regions":         regionObjs,
+	}
+	dep.mu.Lock()
+	fqdn := strings.TrimSpace(dep.Request.SovereignFQDN)
+	dep.mu.Unlock()
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion(EnvironmentGVR().Group + "/" + EnvironmentGVR().Version)
+	obj.SetKind("Environment")
+	obj.SetName(envRef)
+	obj.SetLabels(map[string]string{
+		"catalyst.openova.io/managed-by": "catalyst-api",
+		"openova.io/scope":               "platform",
+		"openova.io/organization":        orgRef,
+		"openova.io/sovereign":           fqdn,
+	})
+	obj.Object["spec"] = spec
+	return applySpineClusterResource(dyn, EnvironmentGVR(), "", obj)
+}
+
+// spineRegionSpecs returns the deployment's RegionSpec rows (provider +
+// cloud-region), falling back to a single synthesised row from the umbrella
+// Request.Region when Regions[] is empty. Mirrors spineRegions but keeps the
+// provider so the Environment region triple carries a real provider enum.
+func spineRegionSpecs(dep *Deployment) []provisioner.RegionSpec {
+	dep.mu.Lock()
+	regs := append([]provisioner.RegionSpec(nil), dep.Request.Regions...)
+	single := strings.TrimSpace(dep.Request.Region)
+	dep.mu.Unlock()
+	out := make([]provisioner.RegionSpec, 0, len(regs))
+	for _, rs := range regs {
+		if strings.TrimSpace(rs.CloudRegion) != "" {
+			out = append(out, rs)
+		}
+	}
+	if len(out) == 0 && single != "" {
+		out = append(out, provisioner.RegionSpec{CloudRegion: single})
+	}
+	return out
+}
+
+// spineEnvRegionObject maps a RegionSpec onto a CRD-valid Environment
+// region triple. The Environment CRD constrains region to `^[a-z]{3}[a-z0-9]?$`
+// (3-4 chars) and provider/buildingBlock to fixed enums; a cloud-region like
+// "me-east-215-a" or "fsn1" does not satisfy the pattern, so we derive a
+// short canonical code. The VALUES are cosmetic for the spine path (the
+// application-controller never reads them; the install pivots through the
+// Blueprint topology) — only len(spec.regions) is load-bearing — so a safe
+// canonical triple per row is sufficient and always schema-valid.
+func spineEnvRegionObject(sc provisioner.RegionSpec) map[string]interface{} {
+	return map[string]interface{}{
+		"provider":      spineEnvProvider(sc.Provider),
+		"region":        spineEnvRegionCode(sc.CloudRegion),
+		"buildingBlock": "rtz",
+	}
+}
+
+// spineEnvProviderAllowed mirrors the Environment CRD provider enum.
+var spineEnvProviderAllowed = map[string]struct{}{
+	"hetzner": {}, "huawei": {}, "oci": {}, "aws": {}, "gcp": {}, "azure": {}, "contabo": {},
+}
+
+// spineEnvProvider lower-cases/trims the provider and falls back to "huawei"
+// (the canonical default, same as environment_ensure.go) when it is empty or
+// not in the CRD enum.
+func spineEnvProvider(provider string) string {
+	p := strings.ToLower(strings.TrimSpace(provider))
+	if _, ok := spineEnvProviderAllowed[p]; ok {
+		return p
+	}
+	return "huawei"
+}
+
+// spineEnvRegionCode derives a CRD-pattern-valid (`^[a-z]{3}[a-z0-9]?$`)
+// region code from a cloud-region string. It takes the first run of
+// lowercase letters/digits, keeps at most the first 3 letters + an optional
+// trailing alphanumeric, and falls back to "reg" when the input yields no
+// pattern-valid prefix. The exact code is cosmetic for the spine path
+// (only len(spec.regions) is read by the application-controller), so a
+// stable schema-valid value is all that's required.
+func spineEnvRegionCode(cloudRegion string) string {
+	s := strings.ToLower(strings.TrimSpace(cloudRegion))
+	letters := make([]rune, 0, 3)
+	var tail rune
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+			if len(letters) < 3 {
+				letters = append(letters, r)
+			} else if tail == 0 {
+				tail = r
+			}
+		case r >= '0' && r <= '9':
+			if len(letters) == 3 && tail == 0 {
+				tail = r
+			}
+		}
+		if len(letters) == 3 && tail != 0 {
+			break
+		}
+	}
+	if len(letters) < 3 {
+		return "reg"
+	}
+	code := string(letters)
+	if tail != 0 {
+		code += string(tail)
+	}
+	return code
+}
+
+// applySpineClusterResource server-side-applies a cluster-scoped (ns="")
+// or namespaced spine prerequisite (Organization / Environment). Like
+// applySpineApplicationCR it is a package-level var so unit tests can swap a
+// Create/Update-based applier (the dynamic-fake client cannot decode an
+// ApplyPatchType body). force:true CREATES-or-MERGES idempotently against a
+// real apiserver.
+var applySpineClusterResource = func(dyn dynamic.Interface, gvr schema.GroupVersionResource, namespace string, obj *unstructured.Unstructured) error {
+	data, err := obj.MarshalJSON()
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	ri := dyn.Resource(gvr)
+	var applied dynamic.ResourceInterface = ri
+	if namespace != "" {
+		applied = ri.Namespace(namespace)
+	}
+	_, err = applied.Patch(ctx, obj.GetName(), types.ApplyPatchType, data, metav1.PatchOptions{
+		FieldManager: spineApplyFieldManager,
+		Force:        boolPtr(true),
+	})
+	return err
 }

--- a/products/catalyst/bootstrap/api/internal/handler/post_handover_spine_apps_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/post_handover_spine_apps_test.go
@@ -10,6 +10,7 @@ package handler
 
 import (
 	"context"
+	"regexp"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -64,16 +65,18 @@ func newSpineTestDeployment() *Deployment {
 
 // TestRenderSpineApplicationCR_ContractShape asserts the produced CR carries
 // exactly the fields the application-controller's parseSpec requires
-// (environmentRef, blueprintRef.{name,version}, regions[]) AND the
-// adopt-not-roll labels — without a spec.placement (so the controller
-// derives the effective default per Blueprint × SOVEREIGN_BCP_TOPOLOGY).
+// (environmentRef, organizationRef, blueprintRef.{name,version}, regions[],
+// placement) AND the adopt-not-roll labels. On a MULTI-region deployment the
+// stamped placement is the Blueprint's topology.defaults.multi-region (here
+// active-passive for openbao) — load-bearing so buildContinuumPlan resolves a
+// primary+standby plan and mints the Continuum CR (Seam 3).
 func TestRenderSpineApplicationCR_ContractShape(t *testing.T) {
-	sc := spineComponent{Chart: "openbao", HRName: "bp-openbao", BlueprintName: "bp-openbao", BlueprintVersion: "1.2.51"}
+	sc := spineComponent{Chart: "openbao", HRName: "bp-openbao", BlueprintName: "bp-openbao", BlueprintVersion: "1.2.25", MultiRegionMode: "active-passive"}
 	owner := map[string]string{
 		"catalyst.openova.io/organization": "t99.omani.works",
 		"catalyst.openova.io/environment":  "t99-omani-works-cp",
 	}
-	cr := renderSpineApplicationCR(sc, "t99-omani-works-cp", []string{"me-east-215", "eu-west-101"}, owner)
+	cr := renderSpineApplicationCR(sc, "t99-omani-works-cp", "t99-omani-works", []string{"me-east-215", "eu-west-101"}, owner)
 
 	if got := cr.GetName(); got != "spine-openbao" {
 		t.Fatalf("name = %q, want spine-openbao", got)
@@ -90,9 +93,13 @@ func TestRenderSpineApplicationCR_ContractShape(t *testing.T) {
 	if env != "t99-omani-works-cp" {
 		t.Fatalf("spec.environmentRef = %q", env)
 	}
+	org, _, _ := unstructured.NestedString(cr.Object, "spec", "organizationRef")
+	if org != "t99-omani-works" {
+		t.Fatalf("spec.organizationRef = %q, want t99-omani-works", org)
+	}
 	bpName, _, _ := unstructured.NestedString(cr.Object, "spec", "blueprintRef", "name")
 	bpVer, _, _ := unstructured.NestedString(cr.Object, "spec", "blueprintRef", "version")
-	if bpName != "bp-openbao" || bpVer != "1.2.51" {
+	if bpName != "bp-openbao" || bpVer != "1.2.25" {
 		t.Fatalf("spec.blueprintRef = %q@%q", bpName, bpVer)
 	}
 	rgs, _, _ := unstructured.NestedStringSlice(cr.Object, "spec", "regions")
@@ -100,9 +107,15 @@ func TestRenderSpineApplicationCR_ContractShape(t *testing.T) {
 		t.Fatalf("spec.regions = %v", rgs)
 	}
 
-	// spec.placement MUST be omitted so the controller derives the default.
-	if _, found, _ := unstructured.NestedFieldNoCopy(cr.Object, "spec", "placement"); found {
-		t.Fatalf("spec.placement must be omitted (controller derives effective default), but it was set")
+	// spec.placement is stamped EXPLICITLY (multi-region → the Blueprint's
+	// active-passive default) so placement.Resolve emits a primary+standby
+	// plan and buildContinuumPlan mints the Continuum CR (the consumer half).
+	pl, found, _ := unstructured.NestedString(cr.Object, "spec", "placement")
+	if !found {
+		t.Fatalf("spec.placement must be stamped explicitly; it was omitted")
+	}
+	if pl != "active-passive" {
+		t.Fatalf("spec.placement = %q, want active-passive (multi-region openbao default)", pl)
 	}
 
 	// Adopt-not-roll contract (Invariant #3): the CR names the EXISTING
@@ -114,12 +127,69 @@ func TestRenderSpineApplicationCR_ContractShape(t *testing.T) {
 	if lbls["catalyst.openova.io/adopts-helmrelease"] != "bp-openbao" {
 		t.Fatalf("adopts-helmrelease = %q, want bp-openbao", lbls["catalyst.openova.io/adopts-helmrelease"])
 	}
-	if lbls["catalyst.openova.io/blueprint"] != "bp-openbao" || lbls["catalyst.openova.io/blueprint-version"] != "1.2.51" {
+	if lbls["catalyst.openova.io/blueprint"] != "bp-openbao" || lbls["catalyst.openova.io/blueprint-version"] != "1.2.25" {
 		t.Fatalf("blueprint labels = %v", lbls)
 	}
-	// Owner labels mirrored through.
-	if lbls["catalyst.openova.io/organization"] != "t99.omani.works" {
-		t.Fatalf("organization owner label not mirrored: %v", lbls)
+	// Owner labels mirrored through; org label pinned to the control-plane slug.
+	if lbls["catalyst.openova.io/organization"] != "t99-omani-works" {
+		t.Fatalf("organization label = %q, want control-plane slug t99-omani-works", lbls["catalyst.openova.io/organization"])
+	}
+}
+
+// TestSpinePlacementMode_SingleVsMultiRegion proves the producer stamps
+// singleton on a single-region Sovereign and the Blueprint's multi-region
+// default on a ≥2-region one — the exact gate buildContinuumPlan reads.
+func TestSpinePlacementMode_SingleVsMultiRegion(t *testing.T) {
+	sc := spineComponent{Chart: "gitea", MultiRegionMode: "active-hot-standby"}
+	if got := spinePlacementMode(sc, 1); got != "singleton" {
+		t.Fatalf("single-region placement = %q, want singleton", got)
+	}
+	if got := spinePlacementMode(sc, 2); got != "active-hot-standby" {
+		t.Fatalf("multi-region placement = %q, want active-hot-standby", got)
+	}
+	// Defensive: a roster row with no MultiRegionMode never stamps an
+	// unrenderable mode even when multi-region.
+	bare := spineComponent{Chart: "x"}
+	if got := spinePlacementMode(bare, 3); got != "singleton" {
+		t.Fatalf("bare multi-region placement = %q, want singleton fallback", got)
+	}
+}
+
+// TestSpineEnvRegionCode_CRDPatternValid proves the derived region code
+// satisfies the Environment CRD pattern `^[a-z]{3}[a-z0-9]?$` for the real
+// cloud-region shapes the spine env carries.
+func TestSpineEnvRegionCode_CRDPatternValid(t *testing.T) {
+	re := regexp.MustCompile(`^[a-z]{3}[a-z0-9]?$`)
+	cases := map[string]string{
+		"me-east-215-a": "meea", // m,e,e + first trailing letter 'a'
+		"eu-west-101":   "euwe", // e,u,w + 'e' from "west"
+		"fsn1":          "fsn1", // 3 letters + trailing digit (pattern-valid)
+		"hel1":          "hel1",
+		"":              "reg", // no letters → fallback
+		"12":            "reg", // no 3 letters → fallback
+	}
+	for in, want := range cases {
+		got := spineEnvRegionCode(in)
+		if got != want {
+			t.Errorf("spineEnvRegionCode(%q) = %q, want %q", in, got, want)
+		}
+		if !re.MatchString(got) {
+			t.Errorf("spineEnvRegionCode(%q) = %q does NOT match CRD region pattern", in, got)
+		}
+	}
+}
+
+// TestSpineEnvProvider_FoldsToEnum proves the provider folds to the CRD enum
+// (unknown / empty → huawei default).
+func TestSpineEnvProvider_FoldsToEnum(t *testing.T) {
+	if got := spineEnvProvider("Hetzner"); got != "hetzner" {
+		t.Fatalf("spineEnvProvider(Hetzner) = %q, want hetzner", got)
+	}
+	if got := spineEnvProvider(""); got != "huawei" {
+		t.Fatalf("spineEnvProvider(empty) = %q, want huawei", got)
+	}
+	if got := spineEnvProvider("digitalocean"); got != "huawei" {
+		t.Fatalf("spineEnvProvider(unknown) = %q, want huawei default", got)
 	}
 }
 
@@ -223,10 +293,11 @@ func TestEnrollSpineApplications_StampsOneCRPerPresentHR(t *testing.T) {
 		t.Fatalf("present = %d, want 4", len(present))
 	}
 	envRef := spineEnvironmentRef(dep)
+	orgRef := spineOrganizationSlug(dep)
 	regions := spineRegions(dep)
 	owner := spineOwnerLabels(dep)
 
-	enrolled := h.enrollSpineApplications(dyn, dep, present, envRef, regions, owner)
+	enrolled := h.enrollSpineApplications(dyn, dep, present, envRef, orgRef, regions, owner)
 	if enrolled != 4 {
 		t.Fatalf("enrolled = %d, want 4", enrolled)
 	}
@@ -246,7 +317,7 @@ func TestEnrollSpineApplications_StampsOneCRPerPresentHR(t *testing.T) {
 
 	// Idempotent re-run: still 4 enrolled, and the total Application count
 	// stays 4 (server-side-apply merge, no duplicates).
-	enrolled2 := h.enrollSpineApplications(dyn, dep, present, envRef, regions, owner)
+	enrolled2 := h.enrollSpineApplications(dyn, dep, present, envRef, orgRef, regions, owner)
 	if enrolled2 != 4 {
 		t.Fatalf("re-run enrolled = %d, want 4 (idempotent)", enrolled2)
 	}
@@ -257,6 +328,120 @@ func TestEnrollSpineApplications_StampsOneCRPerPresentHR(t *testing.T) {
 	}
 	if len(list.Items) != 4 {
 		t.Fatalf("Application count after re-run = %d, want 4 (no duplicates)", len(list.Items))
+	}
+}
+
+// withCreateUpdateClusterApplier swaps the applySpineClusterResource seam for
+// a Create-or-Update applier the dynamic-fake client supports (it cannot
+// decode an ApplyPatchType body). Returns a restore func.
+func withCreateUpdateClusterApplier(t *testing.T) func() {
+	t.Helper()
+	prev := applySpineClusterResource
+	applySpineClusterResource = func(dyn dynamic.Interface, gvr schema.GroupVersionResource, namespace string, obj *unstructured.Unstructured) error {
+		ri := dyn.Resource(gvr)
+		var applied dynamic.ResourceInterface = ri
+		if namespace != "" {
+			applied = ri.Namespace(namespace)
+		}
+		existing, err := applied.Get(context.Background(), obj.GetName(), metav1.GetOptions{})
+		if err == nil {
+			obj.SetResourceVersion(existing.GetResourceVersion())
+			_, uerr := applied.Update(context.Background(), obj, metav1.UpdateOptions{})
+			return uerr
+		}
+		_, cerr := applied.Create(context.Background(), obj, metav1.CreateOptions{})
+		return cerr
+	}
+	return func() { applySpineClusterResource = prev }
+}
+
+// spinePrereqFakeDynamic registers the Organization + Environment GVRs (plus
+// HelmRelease + Application) so the prereq ensures resolve.
+func spinePrereqFakeDynamic(seed ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+	listKinds := map[schema.GroupVersionResource]string{
+		helmwatch.HelmReleaseGVR: "HelmReleaseList",
+		ApplicationGVR():         "ApplicationList",
+		organizationGVR():        "OrganizationList",
+		EnvironmentGVR():         "EnvironmentList",
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, seed...)
+}
+
+// TestEnsureSpinePrereqs_OrgAndMultiRegionEnv proves the producer stamps the
+// CONSUMER prerequisites the application-controller hard-requires: the
+// control-plane Organization (existence check) + the control-plane
+// Environment whose len(spec.regions) == the deployment's real region count
+// (so the controller resolves MULTI-region topology → active-passive → a
+// Continuum CR is minted). This is the round-trip the orchestrator's live
+// re-verify flagged as missing ("Continuum CRs never created").
+func TestEnsureSpinePrereqs_OrgAndMultiRegionEnv(t *testing.T) {
+	defer withCreateUpdateClusterApplier(t)()
+	dyn := spinePrereqFakeDynamic()
+	h := New(silentLogger())
+	dep := newSpineTestDeployment() // 2 regions
+	dep.Request.Regions[0].Provider = "huawei"
+	dep.Request.Regions[1].Provider = "huawei"
+
+	orgRef := spineOrganizationSlug(dep)
+	envRef := spineEnvironmentRef(dep)
+	regions := spineRegions(dep)
+
+	if err := h.ensureSpineOrganization(dyn, dep, orgRef); err != nil {
+		t.Fatalf("ensureSpineOrganization: %v", err)
+	}
+	if err := h.ensureSpineEnvironment(dyn, dep, envRef, orgRef, regions); err != nil {
+		t.Fatalf("ensureSpineEnvironment: %v", err)
+	}
+
+	// Organization exists with the platform-scope marker + the slug the
+	// Environment references (so fetchOrganization passes).
+	org, err := dyn.Resource(organizationGVR()).Get(context.Background(), orgRef, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("control-plane Organization %q not created: %v", orgRef, err)
+	}
+	if slug, _, _ := unstructured.NestedString(org.Object, "spec", "slug"); slug != orgRef {
+		t.Fatalf("Organization spec.slug = %q, want %q", slug, orgRef)
+	}
+	if org.GetLabels()["openova.io/scope"] != "platform" {
+		t.Fatalf("Organization missing platform-scope label: %v", org.GetLabels())
+	}
+
+	// Environment exists, references the org, and carries the REAL region
+	// count (2) so ResolveTopology picks defaults.multi-region.
+	env, err := dyn.Resource(EnvironmentGVR()).Get(context.Background(), envRef, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("control-plane Environment %q not created: %v", envRef, err)
+	}
+	if ref, _, _ := unstructured.NestedString(env.Object, "spec", "organizationRef"); ref != orgRef {
+		t.Fatalf("Environment spec.organizationRef = %q, want %q", ref, orgRef)
+	}
+	envRegions, _, _ := unstructured.NestedSlice(env.Object, "spec", "regions")
+	if len(envRegions) != 2 {
+		t.Fatalf("Environment spec.regions count = %d, want 2 (drives multi-region topology)", len(envRegions))
+	}
+	if pl, _, _ := unstructured.NestedString(env.Object, "spec", "placement"); pl != "multi-region" {
+		t.Fatalf("Environment spec.placement = %q, want multi-region", pl)
+	}
+	// Each region triple is CRD-schema-valid (provider enum + region pattern).
+	re := regexp.MustCompile(`^[a-z]{3}[a-z0-9]?$`)
+	for i, r := range envRegions {
+		m := r.(map[string]interface{})
+		if _, ok := spineEnvProviderAllowed[m["provider"].(string)]; !ok {
+			t.Fatalf("region[%d] provider %q not in CRD enum", i, m["provider"])
+		}
+		if !re.MatchString(m["region"].(string)) {
+			t.Fatalf("region[%d] region %q does not match CRD pattern", i, m["region"])
+		}
+	}
+
+	// Idempotent re-run: no error, no duplicate Environment.
+	if err := h.ensureSpineEnvironment(dyn, dep, envRef, orgRef, regions); err != nil {
+		t.Fatalf("ensureSpineEnvironment (re-run): %v", err)
+	}
+	list, _ := dyn.Resource(EnvironmentGVR()).List(context.Background(), metav1.ListOptions{})
+	if len(list.Items) != 1 {
+		t.Fatalf("Environment count after re-run = %d, want 1 (idempotent)", len(list.Items))
 	}
 }
 
@@ -282,6 +467,15 @@ func TestDRCapableSpineRoster_MatchesEPICSet(t *testing.T) {
 		}
 		if sc.BlueprintName == "" || sc.BlueprintVersion == "" {
 			t.Fatalf("chart %q missing Blueprint pin: %+v", sc.Chart, sc)
+		}
+		// Every DR-capable spine row must carry a multi-region placement
+		// mode mirroring its Blueprint's topology.defaults.multi-region —
+		// without it the producer stamps singleton on a multi-region
+		// Sovereign and no Continuum CR is ever minted.
+		switch sc.MultiRegionMode {
+		case "active-passive", "active-hot-standby":
+		default:
+			t.Fatalf("chart %q MultiRegionMode = %q, want a DR-capable multi-region mode", sc.Chart, sc.MultiRegionMode)
 		}
 	}
 }

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3083,7 +3083,7 @@ name: bp-catalyst-platform
 #   every secret name stays operator-overridable; external ghcr/upstream sources are
 #   untouched (the guard applies only to the local-Gitea/Harbor host). Clean version tag
 #   forces the Flux re-pull (deploy-bot mutable-tag trap).
-version: 1.4.842
+version: 1.4.843
 # 1.4.774 — #4082: application-controller ClusterRole gains dr.openova.io/continuums
 #   (get/list/watch/create/update/patch/delete) — was in the controller's own
 #   deploy/rbac.yaml but MISSING from this platform chart, so a singleton /

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -74,9 +74,16 @@ spec:
     license: "GPL-2.0-or-later"
     tags: [wordpress, cms, org, organization, sso, keycloak, postgres]
     docs: "https://wordpress.org/documentation/"
+  # placementSchema aligned with spec.topology (#4212 Seam 4) — the
+  # catalog-seed copy the application-controller resolves by name for the
+  # per-Org WordPress install. modes[] must admit active-passive AND
+  # defaultOnMultiRegion must name it so a multi-region Org install resolves
+  # to a primary+standby plan and the generic per-app Continuum producer
+  # mints the per-Org Continuum CR. Mirrors platform/wordpress-tenant/blueprint.yaml.
   placementSchema:
-    modes: [single-region]
+    modes: [single-region, singleton, active-passive]
     default: single-region
+    defaultOnMultiRegion: active-passive
   manifests:
     chart: bp-wordpress-tenant
   source:
@@ -586,9 +593,15 @@ spec:
     license: "Apache-2.0"
     tags: [identity, sso, oidc, saml, iam, keycloak]
     docs: "https://www.keycloak.org/documentation"
+  # placementSchema aligned with spec.topology below (#4212 Seam 3) — the
+  # catalog-seed copy the application-controller resolves by name. modes[]
+  # must admit active-hot-standby AND defaultOnMultiRegion must name it so
+  # the spine producer's explicit multi-region placement is accepted and the
+  # Continuum CR is minted. Mirrors platform/<chart>/blueprint.yaml.
   placementSchema:
-    modes: [single-region]
-    default: single-region
+    modes: [singleton, active-hot-standby]
+    default: singleton
+    defaultOnMultiRegion: active-hot-standby
   manifests:
     chart: bp-keycloak
   source:
@@ -3561,9 +3574,15 @@ spec:
     summary: "Per-Sovereign OCI registry. Keycloak SSO via OIDC. One Harbor per Catalyst control plane."
     description: "Per-Sovereign OCI registry mirroring Catalyst Blueprint OCI artefacts + container images. Keycloak OIDC SSO; blobs in Object Storage, metadata in CNPG."
     icon: "harbor.svg"
+  # placementSchema aligned with spec.topology below (#4212 Seam 3) — the
+  # catalog-seed copy the application-controller resolves by name. modes[]
+  # must admit active-hot-standby AND defaultOnMultiRegion must name it so
+  # the spine producer's explicit multi-region placement is accepted and the
+  # Continuum CR is minted. Mirrors platform/<chart>/blueprint.yaml.
   placementSchema:
-    modes: [single-region]
-    default: single-region
+    modes: [singleton, active-hot-standby]
+    default: singleton
+    defaultOnMultiRegion: active-hot-standby
   manifests:
     chart: bp-harbor
   source:
@@ -3670,9 +3689,16 @@ spec:
     summary: "Per-Sovereign secret backend. 3-node Raft per region. Keycloak OIDC SSO. MPL-2.0 Vault replacement."
     description: "OpenBao secret backend (Raft per region, async perf-replication across regions). UI + CLI login via the Keycloak OIDC auth method."
     icon: "openbao.svg"
+  # placementSchema aligned with spec.topology below (#4212 Seam 3). This is
+  # the catalog-seed copy the application-controller resolves by name when it
+  # reconciles a spine Application CR — modes[] must admit active-passive AND
+  # defaultOnMultiRegion must name it, else the spine producer's explicit
+  # multi-region placement is rejected (blueprintAllowedModes) and no Continuum
+  # CR is minted. Mirrors platform/openbao/blueprint.yaml.
   placementSchema:
-    modes: [single-region]
-    default: single-region
+    modes: [singleton, active-passive]
+    default: singleton
+    defaultOnMultiRegion: active-passive
   manifests:
     chart: bp-openbao
   source:
@@ -4702,9 +4728,15 @@ spec:
     category: platform
     summary: "Gitea — per-Sovereign Git server. Hosts catalog (public Blueprint mirror), catalog-sovereign (curated private Blueprints), one Gitea Org per Catalyst Organization, and system scope."
     icon: gitea.svg
+  # placementSchema aligned with spec.topology below (#4212 Seam 3) — the
+  # catalog-seed copy the application-controller resolves by name. modes[]
+  # must admit active-hot-standby AND defaultOnMultiRegion must name it so
+  # the spine producer's explicit multi-region placement is accepted and the
+  # Continuum CR is minted. Mirrors platform/<chart>/blueprint.yaml.
   placementSchema:
-    modes: [single-region]
-    default: single-region
+    modes: [singleton, active-hot-standby]
+    default: singleton
+    defaultOnMultiRegion: active-hot-standby
   manifests:
     chart: bp-gitea
   source:


### PR DESCRIPTION
## What

Finishes EPIC #4212's two named seams by closing the gap the orchestrator's live re-verify flagged: the spine producer-write reached **no consumer** — every spine `Application` CR sat `Pending`/`Failed` and `kubectl get continuums -A` carried no spine row. The merged producer (#4312) + adoption carrier (#4263) were inert because the consumer side was unwired. This PR wires **both halves** of each seam.

## The two seams, both halves wired

### Seam 3 — spine Application-CR producer → Continuum reader (#3829)
**Producer (write):** `post_handover_spine_apps.go` now, before enrolling the spine apps:
- server-side-applies the **control-plane Organization** CR (existence-only, `openova.io/scope: platform`) + a **multi-region control-plane Environment** CR (`<sovereign>-cp`) whose `len(spec.regions)` == the deployment's real region count — the application-controller resolves `environmentRef → Environment → organizationRef → Organization` before reconciling, and the Sovereign-self spine has no per-Org vCluster so nothing ever stamped these (apps wedged at `Pending` forever);
- stamps the **explicit** `spec.placement` (singleton single-region; the Blueprint's `topology.defaults.multi-region` — active-passive/active-hot-standby — multi-region) instead of omitting it. Omitted placement made `EffectiveDefault` derive `singleton` (the spine Blueprints had no `placementSchema.defaultOnMultiRegion`) → a plan with no standby → `buildContinuumPlan` returned false → **no Continuum CR ever minted**.

**Consumer (read):** `reconcileContinuumCR` already exists; it's now actually reachable. Each spine Blueprint's `placementSchema` (modes[] + defaultOnMultiRegion) is aligned with its `spec.topology` in **both** the canonical `platform/<chart>/blueprint.yaml` AND the **catalog-seed** (the live by-name source `fetchBlueprint` resolves), so the explicit placement passes `blueprintAllowedModes` and the default-derivation path is coherent.

### Seam 4 — per-Org `bp-wordpress-tenant` Continuum stayed Degraded/no-CR
Same root cause: its `placementSchema` was `single-region`-only while its topology declared `active-passive`, so a multi-region Org WordPress resolved to `singleton` and the generic per-app Continuum producer minted no CR. Aligned its `placementSchema` (platform + catalog-seed) with its topology. (The cnpg-pair lease witness is already `k8s-lease` + `effectiveHoldingRegion` falls back to `primaryRegion` — those #3829 fixes were already landed on `main`.)

### #3969 read-model rides on Seam 3
The backing-service cascade + observed-target rollup keyed off `spec.placement.targets[]`, empty for the spine (legacy string mode). `effectivePlacementTargets` now derives the desired-state targets from the resolved plan when `targets[]` is absent and threads them into BOTH `resolveBackingPlacement` and `observedTargetsFromPlan` — so legacy string-mode apps (spine + every pre-#3969 app) feed the read-model the real primary+standby target set.

## Anti-theater note
The pre-existing producer stamped an Application CR that **no consumer could read** (no Environment/Organization → Pending; omitted placement → singleton → no Continuum). This PR closes both ends: the producer writes the objects the consumer reads back, and the consumer (`reconcileContinuumCR`) now mints a real Continuum CR on a multi-region prov.

## Versions (lockstep blueprint.yaml + Chart.yaml)
openbao 1.2.51→1.2.52, keycloak 1.5.2→1.5.3, harbor 1.2.36→1.2.37, gitea 1.2.40→1.2.41, wordpress-tenant 0.4.17→0.4.18; bp-catalyst-platform 1.4.838→1.4.839 (catalog-seed change). Producer roster pins track the catalog-seed `spec.version` (by-name resolution) and fix harbor's resolvable name `harbor`→`bp-harbor`.

## Tests
- Round-trip: producer-write (Org + multi-region Env + explicit placement) → consumer-read; CRD-valid region triples; region-code/provider folding; idempotent re-run.
- `effectivePlacementTargets` derivation from the plan (#3969).
- Both modules `go build` + `go test` green; all 4 spine + wordpress-tenant blueprints pass the publish-time validator.

## Acceptance (live, gated on a fresh multi-region zero-touch prov)
- `get applications.apps.openova.io -A` lists spine-openbao/keycloak/harbor/gitea (no DR-capable HR on the no-CR fallback)
- `get continuums.dr.openova.io -A` → one Healthy CR per DR-capable spine + per-Org bp-wordpress-tenant flips green
- Topology tab observed-target rollup matches kubectl for legacy string-mode apps

Refs #4212 #3829 #3969

🤖 Generated with [Claude Code](https://claude.com/claude-code)