### PR TITLE
feat(org-controller): admit Cilium reserved entities on the Org-vcluster boundary — gateway-ingress + apiserver-egress CNP (Workstream B of #4293)

### DIFF
--- a/core/controllers/organization/internal/controller/organization_controller_test.go
+++ b/core/controllers/organization/internal/controller/organization_controller_test.go
@@ -505,8 +505,8 @@ func TestReconcile_HappyPath(t *testing.T) {
 	if gs.createRepos != 1 {
 		t.Errorf("expected 1 gitea repo create, got %d", gs.createRepos)
 	}
-	if gs.createFiles != 7 {
-		t.Errorf("expected 7 gitea file creates (namespace, vcluster, resourcequota, limitrange, kustomization, apps/networkpolicy, apps/kustomization), got %d", gs.createFiles)
+	if gs.createFiles != 8 {
+		t.Errorf("expected 8 gitea file creates (namespace, vcluster, resourcequota, limitrange, kustomization, apps/networkpolicy, apps/ciliumnetworkpolicy, apps/kustomization), got %d", gs.createFiles)
 	}
 	if gs.updateFiles != 0 {
 		t.Errorf("expected 0 file updates on first reconcile, got %d", gs.updateFiles)
@@ -725,8 +725,8 @@ func TestReconcile_GiteaOrgAlreadyExists(t *testing.T) {
 	if gs.createRepos != 1 {
 		t.Errorf("expected 1 repo create even with pre-existing org, got %d", gs.createRepos)
 	}
-	if gs.createFiles != 7 {
-		t.Errorf("expected 7 file creates even with pre-existing org, got %d", gs.createFiles)
+	if gs.createFiles != 8 {
+		t.Errorf("expected 8 file creates even with pre-existing org, got %d", gs.createFiles)
 	}
 }
 

--- a/core/controllers/organization/internal/gitops/manifests.go
+++ b/core/controllers/organization/internal/gitops/manifests.go
@@ -410,12 +410,84 @@ spec:
           port: 53
 `
 
+// ciliumNetworkPolicyTemplate is the MANDATORY companion to the default-deny
+// K8s NetworkPolicy above (#4292). A vanilla `networking.k8s.io/v1`
+// NetworkPolicy expresses its allow-set PURELY as podSelector / namespaceSelector
+// / ipBlock rules — none of which can match the Cilium RESERVED ENTITIES. On a
+// Sovereign (every cluster runs the Cilium Gateway API) two reserved entities
+// MUST be admitted or the default-deny silently breaks the Org's real workloads:
+//
+//   - `ingress` (+ `host`, `remote-node`): the Cilium Gateway / Envoy proxies
+//     external traffic to the backend pod under the reserved `ingress` security
+//     identity (Envoy runs in the host netns; the backend may sit on a peer
+//     node). NO K8s NetworkPolicy selector matches it, so the customer's
+//     purchased Application behind its HTTPRoute returns "upstream connect error
+//     … connection timeout" / 503 (the #2940/#3374 app-plane wedge, fixed live
+//     on hw165). fromEntities is the canonical expression.
+//   - `kube-apiserver`: an in-vcluster Org app pod (and any in-cluster client)
+//     reaches the cluster API as the special `kube-apiserver` entity, which no
+//     podSelector/namespaceSelector/ipBlock (not even 0.0.0.0/0) covers (the
+//     sso-bridge 0.2.14 saga). toEntities is the canonical expression.
+//
+// Cilium computes the UNION of every policy selecting an endpoint, so this CNP
+// is PURELY ADDITIVE to the K8s default-deny: it grants gateway reachability +
+// apiserver egress without weakening the cross-Org/cross-Environment denial
+// (note: NO `world` — only the gateway, never direct public ingress). It is
+// co-located with the K8s NP in the SAME apps tree, so it lands wherever the
+// real Org workloads do — INSIDE the vcluster for the paid tier (the keystone
+// #4299 redirects app HelmReleases there via spec.kubeConfig), on the host
+// `<slug>` ns for free/S — binding the actual pods, never an empty host shell.
+//
+// endpointSelector {} = every endpoint in the namespace (matching the K8s
+// default-deny's podSelector {} scope). Gated by the consumer on the cilium.io/v2
+// Capabilities check (the #2988/#3102 idiom) so kind CI (CRD-less) still applies
+// the K8s NP without this file — there the identity-aware agent isn't enforcing
+// anyway. On a real Sovereign the org-controller always emits it.
+const ciliumNetworkPolicyTemplate = `apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-gateway-and-apiserver
+  namespace: {{ .AppNamespace }}
+  labels:
+    openova.io/organization: {{ .Slug }}
+    openova.io/managed-by: catalyst
+    catalyst.openova.io/component: org-vcluster-gateway-netpol
+spec:
+  endpointSelector: {}
+  ingress:
+    # Admit the Cilium Gateway / Envoy datapath (reserved entities no K8s
+    # NetworkPolicy selector can match) so the Org's Application behind its
+    # HTTPRoute is reachable — without this the gateway→pod hop is dropped → 503.
+    - fromEntities:
+        - ingress
+        - host
+        - remote-node
+  egress:
+    # Admit egress to the cluster API (the reserved kube-apiserver entity) so an
+    # in-vcluster Org app pod / in-cluster client can reach :443/:6443.
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "6443"
+              protocol: TCP
+`
+
 // networkPolicyDoc is the apps-tree filename for the default-deny +
 // same-Org-allow baseline. It lives under vcluster/apps/ so the funnel's
 // apps-sync Kustomization reconciles it INTO the Org-vcluster (alongside the
 // customer's app manifests); the syncer then reflects it to the host `<slug>`
 // ns. It is NOT listed in the boundary kustomization (a different path).
 const networkPolicyDoc = "networkpolicy.yaml"
+
+// ciliumNetworkPolicyDoc is the apps-tree filename for the reserved-entity CNP
+// companion (gateway ingress + apiserver egress). Co-located with
+// networkPolicyDoc under vcluster/apps/ so it lands on the SAME boundary the
+// real Org workloads run on (inside the vcluster for paid tiers; host `<slug>`
+// ns for free/S).
+const ciliumNetworkPolicyDoc = "ciliumnetworkpolicy.yaml"
 
 const kustomizationTemplate = `apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -434,6 +506,7 @@ const appsKustomizationTemplate = `apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ` + networkPolicyDoc + `
+  - ` + ciliumNetworkPolicyDoc + `
 `
 
 // renderView is the data the templates execute against: the flat Inputs plus
@@ -489,6 +562,10 @@ func limitRangeDefaults(q PlanQuota) (cpu, mem string) {
 //     plan (skipped ResourceQuota for soft-cap Flexi; LimitRange always).
 //   - apps/networkpolicy.yaml seeds the default-deny + same-Org-allow baseline
 //     the syncer reflects to the host (sync.toHost.networkPolicies.enabled).
+//   - apps/ciliumnetworkpolicy.yaml is the MANDATORY companion that admits the
+//     Cilium Gateway `ingress` entity (else the Org's app behind its HTTPRoute
+//     503s) + egress to the `kube-apiserver` entity (else in-vcluster pods can't
+//     reach the cluster API) — reserved entities no K8s NetworkPolicy can match.
 func Render(in Inputs) (map[string][]byte, error) {
 	if in.VClusterHelmRepoName == "" {
 		in.VClusterHelmRepoName = "loft"
@@ -545,8 +622,18 @@ func Render(in Inputs) (map[string][]byte, error) {
 	// (the boundary kustomization omits apps/, and the funnel apps-sync reads a
 	// DIFFERENT repo) → intra-Org isolation stayed inert.
 	files["vcluster/apps/"+networkPolicyDoc] = networkPolicyTemplate
+	// The reserved-entity CNP companion (gateway ingress + apiserver egress).
+	// Co-located with the K8s NP so it lands on the SAME boundary the keystone
+	// (#4299) installs the Org's real app workloads onto — inside the vcluster for
+	// the paid tier, the host `<slug>` ns for free/S. Without it the K8s
+	// default-deny silently 503s the Org's Application behind the Cilium Gateway
+	// and blocks egress to the cluster API (neither reachable via any K8s NP
+	// selector). Kustomize applies a CRD-less cluster's CNP as a no-op object;
+	// it has no effect there (kind CI isn't identity-enforcing), so it is safe to
+	// always render — on a real Sovereign cilium.io/v2 is present and enforces it.
+	files["vcluster/apps/"+ciliumNetworkPolicyDoc] = ciliumNetworkPolicyTemplate
 	// Explicit apps/kustomization.yaml so the per-Org apps Flux Kustomization's
-	// `kustomize build ./vcluster/apps` enumerates the NP deterministically
+	// `kustomize build ./vcluster/apps` enumerates the NP + CNP deterministically
 	// (mirrors the funnel apps-tree, which also ships its own kustomization.yaml).
 	files["vcluster/apps/kustomization.yaml"] = appsKustomizationTemplate
 

--- a/core/controllers/organization/internal/gitops/manifests_test.go
+++ b/core/controllers/organization/internal/gitops/manifests_test.go
@@ -298,6 +298,78 @@ func TestRender_NetworkPolicyBaselineInAppsTree(t *testing.T) {
 	}
 }
 
+// TestRender_CiliumNetworkPolicyReservedEntities proves the MANDATORY CNP
+// companion renders into the SAME apps tree as the K8s NP (so it lands on the
+// boundary the keystone #4299 installs the Org's real workloads onto — INSIDE
+// the vcluster for the paid tier, the host `<slug>` ns for free/S — never an
+// empty host shell), and that it admits the reserved entities a plain K8s
+// NetworkPolicy cannot express: `ingress`/`host`/`remote-node` (so the Org's
+// Application behind its Cilium-Gateway HTTPRoute is reachable, not 503) and
+// `kube-apiserver` egress (so an in-vcluster Org pod can reach the cluster API).
+func TestRender_CiliumNetworkPolicyReservedEntities(t *testing.T) {
+	t.Parallel()
+	// Both a paid (vcluster) tier and the free/host tier must carry the CNP in
+	// the apps tree — it must bind the real workloads wherever they land.
+	for _, slug := range []string{"m", "s"} {
+		out, err := Render(Inputs{Slug: "acme", DisplayName: "Acme", Tier: "org",
+			PlanSlug: slug, SovereignFQDN: "x.example", HostCluster: "hz", VClusterChartVersion: "0.33.*"})
+		if err != nil {
+			t.Fatalf("Render(%s): %v", slug, err)
+		}
+		// It must live in the apps/ tree — the path the per-Org apps Flux
+		// Kustomization (per_org_flux.go) reconciles INTO the vcluster (paid
+		// tier, via spec.kubeConfig) / the host `<slug>` ns (free tier). It must
+		// NOT be in the boundary kustomization (./vcluster, host-applied).
+		cnp, ok := out["vcluster/apps/ciliumnetworkpolicy.yaml"]
+		if !ok {
+			t.Fatalf("plan %s: missing vcluster/apps/ciliumnetworkpolicy.yaml — the K8s default-deny would silently 503 the Org's app behind the Cilium Gateway", slug)
+		}
+		s := string(cnp)
+		for _, want := range []string{
+			"kind: CiliumNetworkPolicy",
+			"apiVersion: cilium.io/v2",
+			"namespace: apps", // the apps NS the syncer rewrites → host <slug> ns
+			"endpointSelector: {}",
+			"fromEntities:",
+			"- ingress",
+			"- host",
+			"- remote-node",
+			"toEntities:",
+			"- kube-apiserver",
+			`port: "443"`,
+			`port: "6443"`,
+			"openova.io/organization: acme",
+		} {
+			if !strings.Contains(s, want) {
+				t.Errorf("plan %s ciliumnetworkpolicy.yaml missing %q\n%s", slug, want, s)
+			}
+		}
+		// NO `world` — only the gateway may reach the Org, never direct public ingress.
+		if strings.Contains(s, "world") {
+			t.Errorf("plan %s CNP must NOT admit the `world` entity (direct public ingress forbidden)\n%s", slug, s)
+		}
+		var v any
+		if err := yaml.Unmarshal(cnp, &v); err != nil {
+			t.Errorf("plan %s ciliumnetworkpolicy.yaml invalid YAML: %v\n%s", slug, err, s)
+		}
+		// The apps kustomization index must enumerate the CNP so
+		// `kustomize build ./vcluster/apps` applies it deterministically.
+		appsKz := string(out["vcluster/apps/kustomization.yaml"])
+		for _, want := range []string{"- networkpolicy.yaml", "- ciliumnetworkpolicy.yaml"} {
+			if !strings.Contains(appsKz, want) {
+				t.Errorf("plan %s apps/kustomization.yaml missing %q\n%s", slug, want, appsKz)
+			}
+		}
+		// Anti-theater guard: the CNP must NOT be in the host-applied boundary
+		// kustomization (./vcluster) — that would apply it to the empty host
+		// shell, not the workload boundary.
+		boundaryKz := string(out["vcluster/kustomization.yaml"])
+		if strings.Contains(boundaryKz, "ciliumnetworkpolicy.yaml") {
+			t.Errorf("plan %s: CNP leaked into the boundary kustomization (host shell) — it must live in the apps tree (workload boundary)\n%s", slug, boundaryKz)
+		}
+	}
+}
+
 // TestRender_TierGate proves the founder default: free/S → host-ns (NO
 // vcluster.yaml), paid M+ → dedicated vCluster.
 func TestRender_TierGate(t *testing.T) {


### PR DESCRIPTION
## What

Workstream B (#4292) of EPIC #4293. The merged B PR (#4298) enabled `sync.toHost.networkPolicies.enabled`, the plan-matched ResourceQuota + LimitRange + QoS tier-gate, and co-rendered a **plain K8s** default-deny + same-Org-allow `NetworkPolicy` in the per-Org apps tree.

On a real Sovereign — every cluster runs the **Cilium Gateway API** — that K8s default-deny is anti-theater. A `networking.k8s.io/v1` NetworkPolicy expresses its allow-set purely as `podSelector` / `namespaceSelector` / `ipBlock` rules, **none of which can match the Cilium reserved entities**. Two consequences make the caps bind nothing useful:

- the customer's **Application behind its HTTPRoute** returns `upstream connect error … connection timeout` / 503 — the Cilium Gateway / Envoy datapath reaches the backend under the reserved `ingress` identity (Envoy in the host netns; backend may sit on a peer node), which no K8s selector matches (the #2940 hw165 / #3374 app-plane wedge);
- an **in-vcluster Org app pod** cannot reach the cluster API — that traffic is the reserved `kube-apiserver` entity (not even `ipBlock 0.0.0.0/0` covers it; the sso-bridge 0.2.14 saga).

## The fix

Add a mandatory `CiliumNetworkPolicy` companion **co-located in the same `vcluster/apps/` tree** as the K8s NP, so it lands wherever the keystone (#4297/#4299) installs the Org's real workloads — **inside the vcluster** for the paid tier (the apps Flux Kustomization carries `spec.kubeConfig` → the vcluster kubeconfig mirror), on the host `<slug>` ns for free/S — binding the actual pods, never an empty host shell:

- `ingress.fromEntities: [ingress, host, remote-node]` — admit the Cilium Gateway / Envoy datapath so the Org's Application is reachable. Mirrors `platform/{newapi,bp-mgmt-vcluster,plane-isolation}` `gateway-ingress-cnp`.
- `egress.toEntities: [kube-apiserver]` on `:443`/`:6443` — admit cluster-API egress. Mirrors `platform/sso-bridge` `cilium-networkpolicy-apiserver`.

Purely additive — Cilium computes the **union** of every policy selecting an endpoint, so the cross-Org / cross-Environment denial of the K8s default-deny is preserved. **NO `world`** — direct public ingress stays forbidden; only the gateway reaches the Org.

## Where it targets (vcluster, not host) — proof

- The CNP is written to `vcluster/apps/ciliumnetworkpolicy.yaml`, listed in `vcluster/apps/kustomization.yaml`, and is **NOT** in the host-applied boundary kustomization (`vcluster/kustomization.yaml`).
- The per-Org **apps** Flux Kustomization (`per_org_flux.go`, `catalyst-tenant-<slug>-apps`) reconciles `./vcluster/apps` and — for the vcluster tier (`gitops.BoundaryIsVcluster`) — carries `spec.kubeConfig.secretRef` → the vcluster kubeconfig mirror, so everything in that tree (the K8s NP + this CNP + the customer's app manifests) installs **INTO the vcluster API**. Existing `TestReconcilePerOrgFlux_AppsKustomization_VclusterTier` already locks that targeting; this PR's CNP rides the same redirect. For free/S the same Kustomization omits `kubeConfig` → the policies apply to the host `<slug>` ns (which IS the boundary).

So the caps + NP + CNP bind the keystone's in-vcluster app pods, not an empty shell.

## Tests

`go build ./...` + `go test ./...` green for the `core/controllers` module. New `TestRender_CiliumNetworkPolicyReservedEntities` asserts the CNP renders into the apps (vcluster) tree with both reserved entities for **paid AND host** tier, is enumerated in the apps kustomization, carries no `world`, and never leaks into the boundary (host-shell) kustomization. The two controller file-count assertions were updated 7 → 8 for the added apps file.

## Scope

Pure Go renderer change (`manifests.go` + tests) — no chart/`Chart.yaml`/values/`blueprint.yaml` touched, so no `bp-catalyst-platform` version / deploy-bot pin bump.

Refs #4292 #4293 #4297