### PR TITLE
fix(bp-cnpg): kill the per-Org webhook-hijack RBAC vector + fix the reassert-job dash/pipefail crash (1.0.14, G65)

### DIFF
--- a/clusters/_template/bootstrap-kit/16-cnpg.yaml
+++ b/clusters/_template/bootstrap-kit/16-cnpg.yaml
@@ -107,7 +107,16 @@ spec:
       #         corruption at source) + ships a webhook-cabundle-reasserter
       #         (Helm-hook Job + 10m CronJob) that writes the real CA, + hardens
       #         the gate to assert CA:TRUE. Fresh provs never hit the x509 wall.
-      version: 1.0.13
+      # 1.0.14 (G65 #4322): (A) per-Org operator can no longer patch the cluster
+      #         webhook singleton — the upstream subchart's clusterwideRules
+      #         (get,patch on *webhookconfigurations) were granted UNCONDITIONALLY
+      #         even under clusterWide=false; the per-Org install now sets
+      #         cloudnative-pg.rbac.create=false + the umbrella renders minimal
+      #         replacement RBAC (no webhookconfigurations). (B) fix the #4326
+      #         reasserter Job BackoffLimitExceeded — /bin/sh (dash) rejected
+      #         `set -o pipefail`; switched to /bin/bash. Both halves end the
+      #         recurring caBundle re-hijack for good.
+      version: 1.0.14
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg

--- a/platform/cnpg/blueprint.yaml
+++ b/platform/cnpg/blueprint.yaml
@@ -7,7 +7,10 @@ metadata:
 spec:
   # 1.0.13 (G64 #4322): lockstep with chart/Chart.yaml — durable fix for the
   # cnpg-system operator corrupting the webhook caBundle with a leaf cert.
-  version: 1.0.13
+  # 1.0.14 (G65 #4322): lockstep — (A) per-Org operator RBAC can no longer patch
+  # the cluster webhook singleton (subchart rbac.create=false + minimal
+  # replacement RBAC), (B) reasserter Job /bin/sh→/bin/bash (#4326 fix).
+  version: 1.0.14
   card:
     title: CloudNativePG
     summary: |

--- a/platform/cnpg/chart/Chart.yaml
+++ b/platform/cnpg/chart/Chart.yaml
@@ -74,7 +74,34 @@ name: bp-cnpg
 #   (3) webhook-gate-hook.yaml now asserts the caBundle is a CA (CA:TRUE), not
 #       merely non-empty — the producer-side proof the reasserter landed; gate
 #       image bumped 1.30.7 -> 1.31.4 for openssl. Refs #4322 #4143 #4201.
-version: 1.0.13
+#
+# 1.0.14 (G65 #4322, 2026-06-25): TWO durable fixes for the recurring
+# cnpg-webhook caBundle re-hijack (the #4143/#4322 family).
+#   (A) ROGUE-RBAC VECTOR — the per-Org operator could STILL patch the
+#       cluster-singleton webhook. The upstream cloudnative-pg subchart's
+#       `clusterwideRules` (get,patch on mutating/validatingwebhookconfigurations)
+#       are included in the ClusterRole bp-cnpg-cloudnative-pg UNCONDITIONALLY,
+#       even under config.clusterWide=false — so a namespace-scoped, webhook-less
+#       per-Org operator was handed cluster-scoped webhook-patch and on each
+#       restart over-wrote the shared caBundle with its own org-ns leaf cert
+#       (CA:FALSE) → apiserver x509-fail → every CNPG Cluster create/patch
+#       rejected cluster-wide (live omantel.biz org-7283eb4a, #4322). FIX: the
+#       per-Org generator sets cloudnative-pg.rbac.create=false (subchart RBAC
+#       off) + the new templates/per-org-operator-rbac.yaml renders REPLACEMENT
+#       RBAC — a namespace Role (operator in-ns perms) + a minimal ClusterRole
+#       (nodes + clusterimagecatalogs reads ONLY, NO webhookconfigurations). The
+#       per-Org operator is now STRUCTURALLY INCAPABLE of patching the singleton.
+#   (B) #4326 REASSERT-JOB BackoffLimitExceeded — the webhook-cabundle-reasserter
+#       Job/CronJob ran `command: ["/bin/sh", ...]` with `set -euo pipefail`, but
+#       the bitnami kubectl image's /bin/sh is DASH, which rejects
+#       `set -o pipefail` ("Illegal option -o pipefail") → the script aborted on
+#       its FIRST line every run → the post-upgrade hook failed
+#       `BackoffLimitExceeded` → Helm rolled 1.0.13 back to 1.0.12, so the G64
+#       reassert defense never held (reproduced live 2026-06-25, dep
+#       4635277cae4ffed9). FIX: switch both to `command: ["/bin/bash", ...]`
+#       (the image carries /bin/bash + /usr/bin/openssl; webhook-gate-hook.yaml
+#       already uses bash). Refs #4322 #4143 #4201 #4326.
+version: 1.0.14
 description: |
   Catalyst-curated Blueprint umbrella chart for CloudNativePG. Depends on
   the upstream `cloudnative-pg` chart as a Helm subchart so

--- a/platform/cnpg/chart/templates/per-org-operator-rbac.yaml
+++ b/platform/cnpg/chart/templates/per-org-operator-rbac.yaml
@@ -1,0 +1,212 @@
+{{- /*
+G65 (Refs #4322 #4143 #4201, 2026-06-25): KILL the per-Org operator's
+cluster-scoped webhook-hijack capability at its ROOT — the RBAC grant.
+
+THE HIJACK VECTOR
+=================
+The upstream cloudnative-pg subchart's `cloudnative-pg.clusterwideRules` helper
+ALWAYS grants `get,patch` on `mutating/validatingwebhookconfigurations` at
+CLUSTER scope, and the subchart's rbac.yaml includes those rules in the
+`ClusterRole bp-cnpg-cloudnative-pg` UNCONDITIONALLY — even when
+`config.clusterWide=false` (the namespace-scoped, webhook-LESS per-Org mode).
+So a per-Org operator, although it is supposed to touch only its own namespace,
+is handed `get,patch` on the cluster-singleton webhook configs. On each restart
+the per-Org operator (with MANAGE_WEBHOOK_CONFIGURATIONS at its default) injects
+ITS OWN org-namespace leaf cert (CN=cnpg-webhook-service.org-<id>.svc, CA:FALSE)
+into the shared cnpg webhook caBundle → apiserver x509-fails verifying the
+platform operator's served cert → EVERY postgresql.cnpg.io/v1.Cluster
+create/patch is rejected cluster-wide → all Postgres apps (wordpress, newapi)
+break. Live-confirmed on omantel.biz (dep 4635277cae4ffed9): the demo Org
+`org-7283eb4a…` had `auth can-i patch validatingwebhookconfigurations = yes`,
+newer Orgs did not — yet the grant is STILL templated for every per-Org install.
+
+THE FIX (two halves — this file + the per-Org generator)
+========================================================
+1. The per-Org generator (organization_gitops.go orgTenantBPCNPG) sets
+   `cloudnative-pg.rbac.create=false` so the upstream subchart renders NONE of
+   its RBAC (the ClusterRole carrying the webhookconfigurations patch verbs is
+   the object we must NOT create). It already sets
+   `cloudnative-pg.serviceAccount.create` to its default (true) — the operator
+   SA `bp-cnpg-cloudnative-pg` still exists.
+2. THIS template renders the REPLACEMENT RBAC for the per-Org operator —
+   structurally incapable of touching the cluster webhook singleton:
+     - a namespace-scoped Role with the operator's full in-namespace
+       permissions (mirrors the subchart `commonRules`), bound in the Org ns;
+     - a MINIMAL cluster-scoped ClusterRole granting ONLY the cluster reads a
+       namespace-scoped operator genuinely needs — `nodes` (get/list/watch) and
+       `clusterimagecatalogs` (get/list/watch) — and DELIBERATELY OMITTING
+       `*webhookconfigurations`. A per-Org operator can NEVER patch the
+       singleton again.
+
+This renders ONLY in webhook-LESS mode (per-Org). The platform cnpg-system
+install is webhook-FULL and keeps the upstream subchart RBAC unchanged
+(`cloudnative-pg.rbac.create` stays true there) — it is the single operator that
+legitimately owns the cluster webhook configs, and the G64 reasserter
+(MANAGE_WEBHOOK_CONFIGURATIONS=false + the reasserter Job/CronJob) owns the
+caBundle authoritatively. The `bp-cnpg.webhookConfigsCreated` helper is the
+inverse switch: false ⇒ webhook-LESS ⇒ this replacement RBAC renders.
+*/}}
+{{- $cnpg := (index .Values "cloudnative-pg") | default dict -}}
+{{- $rbac := (index $cnpg "rbac") | default dict -}}
+{{- /* Only render the replacement when the install is webhook-LESS (per-Org)
+       AND the subchart RBAC has been turned off (rbac.create=false). If an
+       operator leaves rbac.create at its true default in a webhook-less topology
+       we do NOT render — there would be two ClusterRoles of different names but
+       the subchart's would still carry the hijack grant, so the per-Org
+       generator MUST pair webhook-less with rbac.create=false (it does). */ -}}
+{{- $rbacCreate := true -}}
+{{- if hasKey $rbac "create" -}}{{- $rbacCreate = $rbac.create -}}{{- end -}}
+{{- $webhookLess := eq (include "bp-cnpg.webhookConfigsCreated" .) "false" -}}
+{{- if and $webhookLess (not $rbacCreate) }}
+{{- /* The operator SA name the subchart's `cloudnative-pg.serviceAccountName`
+       resolves to = its `cloudnative-pg.fullname`: if the release name already
+       CONTAINS the chart name "cloudnative-pg" use the release name verbatim,
+       else "<release>-cloudnative-pg". For the per-Org install the release is
+       "bp-cnpg" → "bp-cnpg-cloudnative-pg". Mirror it EXACTLY (`contains`, not
+       `hasPrefix`) so the bindings target the same SA the Deployment runs as.
+       Honour an explicit serviceAccount.name override if the overlay sets one. */ -}}
+{{- $sa := (index $cnpg "serviceAccount") | default dict -}}
+{{- $fullname := printf "%s-cloudnative-pg" .Release.Name -}}
+{{- if contains "cloudnative-pg" .Release.Name -}}{{- $fullname = (.Release.Name | trunc 63 | trimSuffix "-") -}}{{- end -}}
+{{- $saName := $fullname -}}
+{{- if (index $sa "name") -}}{{- $saName = (index $sa "name") -}}{{- end -}}
+{{- $roleName := $fullname -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $roleName }}-perorg
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: bp-cnpg
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    catalyst.openova.io/component: per-org-operator-rbac
+rules:
+  # In-namespace operator permissions — mirrors the upstream subchart
+  # `cloudnative-pg.commonRules`. A namespace-scoped (clusterWide=false)
+  # operator gets these as a Role, NOT a ClusterRole, so they cannot leak past
+  # the Org namespace.
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets", "services"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps/status", "secrets/status"]
+    verbs: ["get", "patch", "update"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims", "pods", "pods/exec"]
+    verbs: ["create", "delete", "get", "list", "patch", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/status"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["create", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create", "delete", "get", "list", "patch", "watch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create", "get", "update"]
+  - apiGroups: ["monitoring.coreos.com"]
+    resources: ["podmonitors"]
+    verbs: ["create", "delete", "get", "list", "patch", "watch"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources:
+      - backups
+      - clusters
+      - databases
+      - poolers
+      - publications
+      - scheduledbackups
+      - subscriptions
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["failoverquorums"]
+    verbs: ["create", "delete", "get", "list", "watch"]
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources:
+      - backups/status
+      - databases/status
+      - publications/status
+      - scheduledbackups/status
+      - subscriptions/status
+    verbs: ["get", "patch", "update"]
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["imagecatalogs"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["clusters/finalizers", "poolers/finalizers"]
+    verbs: ["update"]
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["clusters/status", "poolers/status", "failoverquorums/status"]
+    verbs: ["get", "patch", "update", "watch"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["rolebindings", "roles"]
+    verbs: ["create", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["create", "get", "list", "patch", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $roleName }}-perorg
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: bp-cnpg
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    catalyst.openova.io/component: per-org-operator-rbac
+subjects:
+  - kind: ServiceAccount
+    name: {{ $saName }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ $roleName }}-perorg
+  apiGroup: rbac.authorization.k8s.io
+---
+# MINIMAL cluster-scoped grant for the namespace-scoped per-Org operator:
+# ONLY the cluster reads it genuinely needs. NO admissionregistration.k8s.io —
+# the per-Org operator must be STRUCTURALLY INCAPABLE of patching the
+# cluster-singleton webhook configs (#4322 hijack vector).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $roleName }}-perorg
+  labels:
+    app.kubernetes.io/name: bp-cnpg
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    catalyst.openova.io/component: per-org-operator-rbac
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["clusterimagecatalogs"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $roleName }}-perorg
+  labels:
+    app.kubernetes.io/name: bp-cnpg
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    catalyst.openova.io/component: per-org-operator-rbac
+subjects:
+  - kind: ServiceAccount
+    name: {{ $saName }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ $roleName }}-perorg
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/platform/cnpg/chart/templates/webhook-cabundle-reasserter.yaml
+++ b/platform/cnpg/chart/templates/webhook-cabundle-reasserter.yaml
@@ -276,7 +276,16 @@ spec:
             - { name: MUT_WEBHOOK, value: {{ $mutName | quote }} }
             - { name: VAL_WEBHOOK, value: {{ $valName | quote }} }
             - { name: WAIT_SECONDS, value: {{ $bootstrapTimeout | quote }} }
-          command: ["/bin/sh", "-c"]
+          # G64-followup (#4322): MUST be /bin/bash, NOT /bin/sh. The bitnami
+          # kubectl image's /bin/sh is dash, which rejects `set -o pipefail`
+          # ("Illegal option -o pipefail") → the script aborts on its FIRST
+          # line → the hook Job fails its full backoffLimit → post-upgrade hook
+          # `job cnpg-cabundle-reassert failed: BackoffLimitExceeded` → Helm
+          # rolled bp-cnpg 1.0.13 back to 1.0.12 (live on omantel.biz dep
+          # 4635277cae4ffed9, reproduced 2026-06-25). The webhook-gate-hook.yaml
+          # already uses /bin/bash for the same reason; the image carries
+          # /bin/bash (and /usr/bin/openssl for the CA:TRUE assertion).
+          command: ["/bin/bash", "-c"]
           args:
             - |
               {{- $script | nindent 14 }}
@@ -338,7 +347,9 @@ spec:
                 # CronJob runs in steady state — the CA secret already exists,
                 # so a short wait is enough.
                 - { name: WAIT_SECONDS, value: "30" }
-              command: ["/bin/sh", "-c"]
+              # G64-followup (#4322): /bin/bash, NOT /bin/sh (dash) — see the
+              # hook Job above; `set -o pipefail` is a bash builtin.
+              command: ["/bin/bash", "-c"]
               args:
                 - |
                   {{- $script | nindent 18 }}

--- a/platform/cnpg/chart/tests/per-org-operator-rbac.sh
+++ b/platform/cnpg/chart/tests/per-org-operator-rbac.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# bp-cnpg — G65 (#4322 #4143 #4201) render gate for the per-Org webhook-HIJACK
+# RBAC fix.
+#
+# THE VECTOR: the upstream cloudnative-pg subchart includes its `clusterwideRules`
+# (which grant get,patch on mutating/validatingwebhookconfigurations at CLUSTER
+# scope) in the operator ClusterRole `bp-cnpg-cloudnative-pg` UNCONDITIONALLY —
+# even when config.clusterWide=false. So a namespace-scoped, webhook-LESS per-Org
+# operator was STILL granted cluster-scoped patch on the cnpg webhook singleton
+# and on each restart over-wrote the shared caBundle with its own org-ns leaf
+# cert (CA:FALSE) → apiserver x509-fail → every CNPG Cluster create/patch
+# rejected cluster-wide (live omantel.biz org-7283eb4a, #4322).
+#
+# THE FIX: in webhook-LESS mode the per-Org generator sets
+# cloudnative-pg.rbac.create=false (subchart RBAC off) and the umbrella's
+# templates/per-org-operator-rbac.yaml renders REPLACEMENT RBAC — a namespace
+# Role + a MINIMAL ClusterRole (nodes + clusterimagecatalogs reads ONLY, NO
+# webhookconfigurations). The per-Org operator becomes STRUCTURALLY INCAPABLE of
+# patching the cluster singleton.
+#
+# This test asserts (helm template only — no live cluster):
+#   A. WEBHOOK-LESS per-Org (webhook.create=false + rbac.create=false):
+#      - NO rendered RBAC rule anywhere grants *webhookconfigurations (the vector
+#        is gone);
+#      - the replacement per-Org Role + ClusterRole + bindings DO render and
+#        target the operator SA bp-cnpg-cloudnative-pg;
+#      - the minimal ClusterRole grants nodes + clusterimagecatalogs ONLY.
+#   B. PLATFORM webhook-FULL (defaults): the subchart's own ClusterRole STILL
+#      carries the legitimate webhookconfigurations grant (the single platform
+#      operator owns the singleton) AND the per-Org replacement RBAC does NOT
+#      render.
+#
+# Usage: bash tests/per-org-operator-rbac.sh [CHART_DIR]
+set -euo pipefail
+
+CHART_DIR="$(cd "${1:-$(dirname "$0")/..}" && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+if [ ! -d "$CHART_DIR/charts" ] || ! ls "$CHART_DIR"/charts/cloudnative-pg-*.tgz >/dev/null 2>&1; then
+  helm dependency build "$CHART_DIR" >/dev/null 2>&1 || true
+fi
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+# ── Case A: WEBHOOK-LESS per-Org install ────────────────────────────────────
+helm template bp-cnpg "$CHART_DIR" --namespace org-7283eb4a \
+  --set "cloudnative-pg.webhook.mutating.create=false" \
+  --set "cloudnative-pg.webhook.validating.create=false" \
+  --set "cloudnative-pg.rbac.create=false" \
+  --set "cloudnative-pg.crds.create=false" \
+  --set "cloudnative-pg.config.clusterWide=false" \
+  > "$TMP/perorg.yaml" 2>"$TMP/err" || { echo "helm template FAILED:"; cat "$TMP/err"; exit 1; }
+
+# A1. THE keystone — NO webhookconfigurations grant survives anywhere. This is
+#     the whole point: the per-Org operator cannot patch the cluster singleton.
+if grep -q "webhookconfigurations" "$TMP/perorg.yaml"; then
+  echo "--- offending ---"; grep -n "webhookconfigurations" "$TMP/perorg.yaml" | head
+  fail "webhook-less per-Org render STILL grants *webhookconfigurations — the hijack vector is NOT removed (#4322)"
+fi
+echo "PASS: webhook-less per-Org render grants NO *webhookconfigurations (hijack vector removed)"
+
+# A2. the replacement per-Org RBAC renders (Role + ClusterRole + both bindings).
+for obj in \
+  "kind: Role" \
+  "kind: RoleBinding" \
+  "kind: ClusterRole" \
+  "kind: ClusterRoleBinding"; do
+  awk -v k="$obj" 'BEGIN{RS="\n---\n"} $0 ~ k && /per-org-operator-rbac/ {found=1} END{exit !found}' "$TMP/perorg.yaml" \
+    || fail "webhook-less render is missing the replacement ${obj#kind: } (per-org-operator-rbac)"
+done
+echo "PASS: replacement per-Org Role + ClusterRole + bindings render"
+
+# A3. the bindings target the operator SA bp-cnpg-cloudnative-pg (so the operator
+#     Deployment actually receives these permissions).
+python3 - "$TMP/perorg.yaml" <<'PY' || exit 1
+import sys, yaml
+sa_ok = {"RoleBinding": False, "ClusterRoleBinding": False}
+for d in yaml.safe_load_all(open(sys.argv[1])):
+    if not d or d.get("kind") not in sa_ok: continue
+    comp = ((d.get("metadata") or {}).get("labels") or {}).get("catalyst.openova.io/component")
+    if comp != "per-org-operator-rbac": continue
+    subs = d.get("subjects") or []
+    if any(s.get("kind") == "ServiceAccount" and s.get("name") == "bp-cnpg-cloudnative-pg" for s in subs):
+        sa_ok[d["kind"]] = True
+bad = [k for k, v in sa_ok.items() if not v]
+if bad:
+    print("FAIL: per-Org", ", ".join(bad), "do(es) not bind SA bp-cnpg-cloudnative-pg")
+    sys.exit(1)
+print("PASS: per-Org Role/ClusterRole bindings target SA bp-cnpg-cloudnative-pg")
+PY
+
+# A4. the minimal ClusterRole grants ONLY nodes + clusterimagecatalogs reads.
+python3 - "$TMP/perorg.yaml" <<'PY' || exit 1
+import sys, yaml
+for d in yaml.safe_load_all(open(sys.argv[1])):
+    if not d or d.get("kind") != "ClusterRole": continue
+    comp = ((d.get("metadata") or {}).get("labels") or {}).get("catalyst.openova.io/component")
+    if comp != "per-org-operator-rbac": continue
+    res = set()
+    verbs = set()
+    for r in d.get("rules") or []:
+        res |= set(r.get("resources") or [])
+        verbs |= set(r.get("verbs") or [])
+    allowed_res = {"nodes", "clusterimagecatalogs"}
+    extra = res - allowed_res
+    if extra:
+        print("FAIL: per-Org ClusterRole grants unexpected cluster resources:", sorted(extra))
+        sys.exit(1)
+    write_verbs = verbs & {"create", "delete", "patch", "update", "deletecollection"}
+    if write_verbs:
+        print("FAIL: per-Org ClusterRole grants write verbs at cluster scope:", sorted(write_verbs))
+        sys.exit(1)
+    print("PASS: per-Org ClusterRole grants only", sorted(res), "with read verbs", sorted(verbs))
+    break
+else:
+    print("FAIL: per-Org ClusterRole not found")
+    sys.exit(1)
+PY
+
+# ── Case B: PLATFORM webhook-FULL (defaults) ────────────────────────────────
+helm template cnpg "$CHART_DIR" --namespace cnpg-system > "$TMP/full.yaml" 2>"$TMP/err" \
+  || { echo "helm template FAILED:"; cat "$TMP/err"; exit 1; }
+
+# B1. the platform (single-owner) operator KEEPS the legitimate webhook grant.
+grep -q "webhookconfigurations" "$TMP/full.yaml" \
+  || fail "platform webhook-FULL render lost the legitimate webhookconfigurations grant — the single operator must own the singleton"
+echo "PASS: platform webhook-FULL render keeps the legitimate webhookconfigurations grant"
+
+# B2. the per-Org replacement RBAC must NOT render in platform mode.
+if grep -q "per-org-operator-rbac" "$TMP/full.yaml"; then
+  echo "--- offending ---"; grep -n "per-org-operator-rbac" "$TMP/full.yaml" | head
+  fail "platform webhook-FULL render WRONGLY emits the per-Org replacement RBAC"
+fi
+echo "PASS: platform webhook-FULL render does NOT emit the per-Org replacement RBAC"
+
+echo "All bp-cnpg per-org-operator-rbac assertions passed (G65 #4322)."

--- a/products/catalyst/bootstrap/api/internal/handler/organization_cnpg_rbac_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_cnpg_rbac_test.go
@@ -1,0 +1,85 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+	"sigs.k8s.io/yaml"
+)
+
+// TestPerOrgBPCNPGWebhookHijackRBACOff is the generator-side guard for the
+// G65 (#4322 #4143 #4201) webhook-HIJACK fix.
+//
+// The per-Org bp-cnpg operator must be STRUCTURALLY INCAPABLE of patching the
+// cluster-singleton cnpg webhook configs. The upstream cloudnative-pg subchart
+// grants get,patch on *webhookconfigurations in the operator ClusterRole
+// UNCONDITIONALLY (even when clusterWide=false), so the per-Org install MUST
+// turn the subchart RBAC off (cloudnative-pg.rbac.create=false) — the bp-cnpg
+// umbrella then renders minimal replacement RBAC with NO webhookconfigurations
+// (asserted by platform/cnpg/chart/tests/per-org-operator-rbac.sh). This test
+// locks the generator half: the emitted HelmRelease values carry rbac.create
+// false alongside the existing webhook-less + namespace-scoped settings.
+func TestPerOrgBPCNPGWebhookHijackRBACOff(t *testing.T) {
+	rec := store.OrganizationProvisionRecord{
+		OrganizationID:  "t-acme",
+		Subdomain:       "acme",
+		DomainMode:      store.OrganizationDomainFreeSubdomain,
+		AdminEmail:      "admin@acme.test",
+		CompanyName:     "Acme Corp",
+		OTECHFQDN:       "otech.example",
+		ParentDomain:    "otech.example",
+		VClusterName:    "vc-acme",
+		TenantNamespace: "org-t-acme",
+	}
+	files, err := renderOrganizationOverlay(rec, OrganizationChartVersions{CNPG: "1.0.14"})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body, ok := files["bp-cnpg.yaml"]
+	if !ok {
+		t.Fatalf("bp-cnpg.yaml missing from render output")
+	}
+
+	var hr helmReleaseYAML
+	if err := yaml.Unmarshal([]byte(body), &hr); err != nil {
+		t.Fatalf("bp-cnpg.yaml does not parse as YAML: %v\n--- body ---\n%s", err, body)
+	}
+
+	cnpg, ok := hr.Spec.Values["cloudnative-pg"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("values.cloudnative-pg missing or not a map; values=%#v", hr.Spec.Values)
+	}
+
+	// rbac.create MUST be explicitly false — this is the keystone of the
+	// hijack-vector removal.
+	rbac, ok := cnpg["rbac"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("values.cloudnative-pg.rbac missing — the subchart RBAC (with the cluster webhookconfigurations grant) would still render")
+	}
+	if create, _ := rbac["create"].(bool); create {
+		t.Errorf("cloudnative-pg.rbac.create must be false (got true) — per-Org operator would retain cluster-scoped webhookconfigurations patch (#4322)")
+	}
+
+	// The pre-existing webhook-less + namespace-scoped invariants must remain.
+	webhook, ok := cnpg["webhook"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("values.cloudnative-pg.webhook missing — per-Org operator must be webhook-less")
+	}
+	for _, side := range []string{"mutating", "validating"} {
+		w, ok := webhook[side].(map[string]interface{})
+		if !ok {
+			t.Fatalf("values.cloudnative-pg.webhook.%s missing", side)
+		}
+		if create, _ := w["create"].(bool); create {
+			t.Errorf("cloudnative-pg.webhook.%s.create must be false (got true) — per-Org operator must not own the cluster webhook singleton", side)
+		}
+	}
+
+	cfg, ok := cnpg["config"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("values.cloudnative-pg.config missing")
+	}
+	if clusterWide, _ := cfg["clusterWide"].(bool); clusterWide {
+		t.Errorf("cloudnative-pg.config.clusterWide must be false (got true) — per-Org operator must be namespace-scoped")
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
@@ -1041,6 +1041,25 @@ spec:
           create: false
         validating:
           create: false
+      # #4322 (G65): KILL the webhook-HIJACK RBAC vector at its root. The
+      # upstream cloudnative-pg subchart includes its clusterwideRules
+      # (which grant get,patch on mutating/validatingwebhookconfigurations)
+      # in the ClusterRole bp-cnpg-cloudnative-pg UNCONDITIONALLY — even when
+      # clusterWide=false. So a per-Org operator, despite being namespace-
+      # scoped + webhook-less, was STILL granted cluster-scoped patch on the
+      # webhook singleton and on each restart over-wrote the shared caBundle
+      # with its own org-ns leaf cert (CA:FALSE) → apiserver x509-fail → every
+      # CNPG Cluster create/patch rejected cluster-wide (live omantel.biz
+      # org-7283eb4a, #4322). Turning OFF the subchart RBAC (rbac.create=false)
+      # stops that ClusterRole rendering; the bp-cnpg umbrella's
+      # templates/per-org-operator-rbac.yaml then renders REPLACEMENT RBAC —
+      # a namespace Role with the operator's in-ns permissions + a minimal
+      # ClusterRole (nodes + clusterimagecatalogs reads ONLY, NO
+      # webhookconfigurations) — so the per-Org operator is STRUCTURALLY
+      # INCAPABLE of patching the cluster singleton. (serviceAccount.create
+      # stays at its true default so the operator SA still exists.)
+      rbac:
+        create: false
       # #4143: namespace-scoped watch — the per-Org operator reconciles
       # ONLY its own Org namespace, never cluster-scoped singletons. The
       # platform cnpg-system operator stays cluster-wide and admits this


### PR DESCRIPTION
Durably kills the recurring cnpg cluster-webhook caBundle re-hijack (the #4143/#4322 family). Two root causes pinned LIVE on omantel.biz (kom4dc, dep `4635277cae4ffed9`):

## A. The rogue cluster-scoped RBAC vector
The upstream cloudnative-pg subchart's `clusterwideRules` grant `get,patch` on `mutating/validatingwebhookconfigurations` at **cluster** scope, and `rbac.yaml` includes them in the operator `ClusterRole bp-cnpg-cloudnative-pg` **UNCONDITIONALLY** — even when `config.clusterWide=false`. So a namespace-scoped, webhook-less per-Org operator was STILL granted cluster-scoped webhook-patch, and on each restart over-wrote the shared webhook `caBundle` with its own org-ns leaf cert (CA:FALSE) → apiserver `x509: certificate signed by unknown authority` → **every** `Cluster` create/patch rejected cluster-wide → wordpress/newapi break.

**Fix:** the per-Org generator (`organization_gitops.go orgTenantBPCNPG`) sets `cloudnative-pg.rbac.create=false` (subchart RBAC off) + the new `templates/per-org-operator-rbac.yaml` renders REPLACEMENT RBAC — a namespace Role (operator in-ns perms) + a minimal ClusterRole (`nodes` + `clusterimagecatalogs` reads ONLY, **NO** webhookconfigurations). The per-Org operator is now structurally incapable of patching the singleton. The platform (webhook-FULL) install is unchanged — it keeps the subchart RBAC, as the single legit owner.

## B. The #4326 reassert-job `BackoffLimitExceeded` (the defense never held)
`main` is on chart 1.0.13 (#4326 DID land), but the platform HR showed `Helm rollback to bp-cnpg@1.0.12` — `job cnpg-cabundle-reassert failed: BackoffLimitExceeded`. Reproduced live: the reasserter Job ran `command: ["/bin/sh", ...]` with `set -euo pipefail`, but the bitnami kubectl image's `/bin/sh` is **dash** → `set: Illegal option -o pipefail` → the script aborts on its first line every run → rollback. So the G64 reassert defense never ran.

**Fix:** switch the reasserter Job + CronJob to `command: ["/bin/bash", ...]` (the image carries `/bin/bash` + `/usr/bin/openssl`; `webhook-gate-hook.yaml` already uses bash).

## Live verification (post-fix, dep 4635277cae4ffed9)
- Fixed reasserter Job → **succeeded**: `verified cnpg-ca-secret ca.crt is CA:TRUE` + `reasserted CA caBundle on the drifted webhook(s)`. Both live webhook configs now `CN=cnpg-ca-secret CA:TRUE`.
- After applying the replacement RBAC to a test ns, the operator SA `auth can-i`:
  - `patch/get {mutating,validating}webhookconfigurations` = **no**
  - `patch clusters.postgresql.cnpg.io` (its ns) = **yes**, `get nodes` = **yes**

## Tests
- `platform/cnpg/chart/tests/per-org-operator-rbac.sh` (new) — per-Org render grants NO `*webhookconfigurations` + the replacement RBAC renders + the platform render keeps the legit grant.
- `organization_cnpg_rbac_test.go` (new) — generator emits `rbac.create=false` + webhook-less + namespace-scoped.
- Existing `webhook-cabundle-reasserter.sh` / `webhook-gate-render.sh` / `observability-toggle.sh` + full Go handler suite green.

Chart `1.0.13 → 1.0.14`; `blueprint.yaml` + `clusters/_template/bootstrap-kit/16-cnpg.yaml` bumped in lockstep.

Refs #4337 #4322 #4143 #4201 #4326

🤖 Generated with [Claude Code](https://claude.com/claude-code)