### PR TITLE
fix(catalyst): tier-aware org vclusterReadiness — host-tier (S/free) funnel Orgs reach apps phase without a vcluster HR

### DIFF
--- a/core/controllers/organization/internal/controller/organization_controller.go
+++ b/core/controllers/organization/internal/controller/organization_controller.go
@@ -599,7 +599,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// namespace to exist; until then it sits False with a reason naming
 	// what is pending, and the reconcile requeues so the status converges
 	// as Flux brings the vCluster up.
-	vcPhase, vcReady, vcMsg := r.vclusterReadiness(ctx, org.Spec.Slug)
+	//
+	// #4339 (Refs #4292): the readback is TIER-AWARE. A host-tier Org
+	// (""/s/free — the same gitops.BoundaryIsVcluster gate that decides the
+	// boundary primitive) renders NO vcluster HR, so there is nothing to
+	// wait on — the host `<slug>` namespace IS the boundary. Gating those
+	// Orgs on a `vcluster` HR that is correctly never authored wedged them
+	// at Ready=False:VClusterProvisioning forever, so ensureEnvironment
+	// never ran and the apps-install phase was never reached. We pass the
+	// plan slug through so vclusterReadiness can short-circuit to host-ns
+	// readiness for host-tier and only wait on the HR for the vcluster tier.
+	vcPhase, vcReady, vcMsg := r.vclusterReadiness(ctx, org.Spec.Slug, org.Spec.PlanSlug)
 
 	// 6a. Auto-ensure the parent Environment CR (issue #4077, Refs #3687)
 	// once the vCluster can actually host Applications. Without this, every
@@ -699,7 +709,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 // Org/host, no per-org-name special-casing (#3687 §7d). Read failures
 // other than NotFound degrade to Provisioning (transient API blips
 // shouldn't flip a healthy Org to Pending) and requeue.
-func (r *Reconciler) vclusterReadiness(ctx context.Context, slug string) (phase string, ready bool, message string) {
+//
+// #4339 (Refs #4292): TIER-AWARE. For a host-tier Org (""/s/free — same
+// gitops.BoundaryIsVcluster gate that decides the boundary primitive) the
+// controller authors NO vcluster HR; the host `<slug>` namespace IS the
+// boundary. So host-tier readiness keys solely off the namespace existing —
+// waiting on a `vcluster` HR that is correctly never rendered would wedge the
+// Org at Ready=False forever and never reach the apps-install phase. Only the
+// vcluster tier (m/l/xl/flexi) reads back + waits on the HR.
+func (r *Reconciler) vclusterReadiness(ctx context.Context, slug, planSlug string) (phase string, ready bool, message string) {
 	nsExists := false
 	ns := &corev1.Namespace{}
 	switch err := r.Get(ctx, types.NamespacedName{Name: slug}, ns); {
@@ -710,6 +728,18 @@ func (r *Reconciler) vclusterReadiness(ctx context.Context, slug string) (phase 
 	default:
 		return "Provisioning", false,
 			fmt.Sprintf("vCluster namespace readback error (transient): %s", err)
+	}
+
+	// Host-tier boundary: no vcluster HR is ever authored (gitops.Render omits
+	// vcluster.yaml from ./vcluster for ""/s/free). Readiness = the host ns is
+	// Active. The phase string stays "Ready"/"Pending" so the existing status
+	// projection + the vcReady-gated ensureEnvironment / apps phase proceed.
+	if !gitops.BoundaryIsVcluster(planSlug) {
+		if nsExists {
+			return "Ready", true, ""
+		}
+		return "Pending", false,
+			"host-tier Org namespace not yet Active (no vCluster HR is authored for this tier; the host namespace is the boundary)"
 	}
 
 	hr := &unstructured.Unstructured{}

--- a/core/controllers/organization/internal/controller/vcluster_readiness_test.go
+++ b/core/controllers/organization/internal/controller/vcluster_readiness_test.go
@@ -72,39 +72,76 @@ func TestVClusterReadiness_PhaseLadder(t *testing.T) {
 
 	cases := []struct {
 		name      string
+		planSlug  string
 		objs      []runtime.Object
 		wantPhase string
 		wantReady bool
 	}{
+		// ── vcluster tier (m/l/xl/flexi): readiness keys off the vcluster HR. ──
 		{
-			name:      "no HR, no namespace → Pending (orphaned bytes, NOT Ready)",
+			name:      "vcluster tier: no HR, no namespace → Pending (orphaned bytes, NOT Ready)",
+			planSlug:  "m",
 			objs:      nil,
 			wantPhase: "Pending",
 			wantReady: false,
 		},
 		{
-			name:      "HR present but Ready=False → Provisioning",
+			name:      "vcluster tier: HR present but Ready=False → Provisioning",
+			planSlug:  "m",
 			objs:      []runtime.Object{newNS(slug), newHR(slug, "False")},
 			wantPhase: "Provisioning",
 			wantReady: false,
 		},
 		{
-			name:      "HR present, no Ready condition yet → Provisioning",
+			name:      "vcluster tier: HR present, no Ready condition yet → Provisioning",
+			planSlug:  "m",
 			objs:      []runtime.Object{newNS(slug), newHR(slug, "")},
 			wantPhase: "Provisioning",
 			wantReady: false,
 		},
 		{
-			name:      "HR Ready=True but namespace missing → Provisioning",
+			name:      "vcluster tier: HR Ready=True but namespace missing → Provisioning",
+			planSlug:  "m",
 			objs:      []runtime.Object{newHR(slug, "True")},
 			wantPhase: "Provisioning",
 			wantReady: false,
 		},
 		{
-			name:      "HR Ready=True AND namespace Active → Ready",
+			name:      "vcluster tier: HR Ready=True AND namespace Active → Ready",
+			planSlug:  "m",
 			objs:      []runtime.Object{newNS(slug), newHR(slug, "True")},
 			wantPhase: "Ready",
 			wantReady: true,
+		},
+		// ── host tier (""/s/free): NO vcluster HR is ever authored, so
+		//    readiness keys SOLELY off the host namespace existing (#4339). ──
+		{
+			name:      "host tier (s): namespace Active, NO HR → Ready (do NOT wait on a vcluster HR)",
+			planSlug:  "s",
+			objs:      []runtime.Object{newNS(slug)},
+			wantPhase: "Ready",
+			wantReady: true,
+		},
+		{
+			name:      "host tier (free): namespace Active, NO HR → Ready",
+			planSlug:  "free",
+			objs:      []runtime.Object{newNS(slug)},
+			wantPhase: "Ready",
+			wantReady: true,
+		},
+		{
+			name:      "host tier (empty plan): namespace Active, NO HR → Ready",
+			planSlug:  "",
+			objs:      []runtime.Object{newNS(slug)},
+			wantPhase: "Ready",
+			wantReady: true,
+		},
+		{
+			name:      "host tier (s): namespace missing → Pending (host ns is the boundary)",
+			planSlug:  "s",
+			objs:      nil,
+			wantPhase: "Pending",
+			wantReady: false,
 		},
 	}
 
@@ -117,7 +154,7 @@ func TestVClusterReadiness_PhaseLadder(t *testing.T) {
 			r := &Reconciler{Log: logr.Discard()}
 			r.Client = cl
 
-			phase, ready, msg := r.vclusterReadiness(context.Background(), slug)
+			phase, ready, msg := r.vclusterReadiness(context.Background(), slug, tc.planSlug)
 			if phase != tc.wantPhase {
 				t.Errorf("phase = %q, want %q (msg=%q)", phase, tc.wantPhase, msg)
 			}
@@ -130,6 +167,40 @@ func TestVClusterReadiness_PhaseLadder(t *testing.T) {
 				t.Errorf("not-Ready result must carry a non-empty message")
 			}
 		})
+	}
+}
+
+// TestVClusterReadiness_HostTierDoesNotWaitOnVclusterHR locks the #4339
+// contract directly: a host-tier (S/free/"") Org reaches Ready as soon as its
+// host namespace is Active, even though NO vcluster HR exists — whereas the
+// identical-shaped vcluster-tier (M) Org with the same single namespace stays
+// not-Ready because it is still waiting on its (absent) vcluster HR. This is
+// the regression that wedged host-tier funnel Orgs at
+// Ready=False:VClusterProvisioning forever so the apps-install phase was never
+// reached.
+func TestVClusterReadiness_HostTierDoesNotWaitOnVclusterHR(t *testing.T) {
+	const slug = "g5funnel"
+
+	// Only the host namespace exists — no vcluster HR (correctly never authored
+	// for host tier; never yet reconciled for the vcluster tier).
+	cl := fake.NewClientBuilder().
+		WithScheme(readbackScheme(t)).
+		WithObjects(toClientObjects([]runtime.Object{newNS(slug)})...).
+		Build()
+	r := &Reconciler{Log: logr.Discard()}
+	r.Client = cl
+
+	for _, plan := range []string{"", "s", "free"} {
+		_, ready, msg := r.vclusterReadiness(context.Background(), slug, plan)
+		if !ready {
+			t.Errorf("host-tier plan %q with an Active namespace must be Ready (no vcluster HR to wait on); got not-Ready (msg=%q)", plan, msg)
+		}
+	}
+
+	// The vcluster tier with the SAME single namespace must NOT be Ready — it is
+	// still waiting on the vcluster HR that has not reconciled yet.
+	if _, ready, _ := r.vclusterReadiness(context.Background(), slug, "m"); ready {
+		t.Errorf("vcluster-tier plan \"m\" must wait on the vcluster HR; got Ready with only the namespace present")
 	}
 }
 


### PR DESCRIPTION
## Problem
A live funnel-door walk on omantel.biz (kom4dc, dep `4635277cae4ffed9`) found that **host-tier (S/free/"") funnel Organizations never install their apps**.

The org-controller's `vclusterReadiness()` (in `core/controllers/organization/internal/controller/organization_controller.go`) gated the reconcile — both `ensureEnvironment` and the `Ready` condition — on a vcluster HelmRelease at namespace `<slug>` / name `vcluster` being Ready. But a host-tier Org correctly renders **no** vcluster HR per the #4292 `boundaryIsVcluster` gate (`""/s/free` → host-ns boundary; `m/l/xl/flexi` → vcluster). So host-tier funnel Orgs looped:

```
Ready=False reason=VClusterProvisioning "awaiting first reconcile of ./vcluster"
```

forever → `ensureEnvironment` never ran → the apps-install phase was never reached → no `catalyst-tenant-<slug>-apps` Kustomization apps landed → openclaw/stalwart/wordpress returned 404 (app-not-installed) over public DNS+TLS even though DNS, the Org CR, and the per-Org wildcard TLS cert were all correctly created.

### Live evidence (Org g5funnel, S-tier, pool omani.trade)
- `kubectl get organizations g5funnel` → exists, tier=org, plan=s, Ready=False reason=VClusterProvisioning.
- Gitea repo `vcluster/kustomization.yaml` lists ONLY namespace/limitrange/resourcequota — `vcluster.yaml` correctly omitted for S-tier — but readiness still waited on a `vcluster` HR that never exists.
- `console/mail/keycloak/wordpress/openclaw.g5funnel.omani.trade` resolve to 212.72.24.33 + TLS green; mail/wordpress 404 (no backend) because the apps never installed.

## Fix
- `vclusterReadiness()` now takes the plan slug and reuses the **same** `gitops.BoundaryIsVcluster` predicate #4292 uses (no parallel gate invented). A host-tier Org keys readiness solely off the host `<slug>` namespace being Active — the host ns IS the boundary; there is no HR to wait on. Only the vcluster tier (`m/l/xl/flexi`) reads back + waits on the `vcluster` HR. Host-tier Orgs now reach Ready → `ensureEnvironment` runs → the apps-install phase is reached.
- Confirmed the downstream apps-install (`catalyst-tenant-<slug>-apps` Kustomization in `per_org_flux.go`) was **already** tier-aware and unconditionally upserted — only the `kubeConfig` routing differs by tier (host tier applies straight to the host `<slug>` ns). No change needed there; the only gate was the readiness wait.

This unblocks the per-component public validation of #4272 (openclaw), #4307 (stalwart), #4322 (wordpress) on a host-tier funnel Org.

## Tests
- `go build ./...` + `go test ./...` green for `core/controllers`.
- Phase-ladder test now covers BOTH tiers: vcluster-tier (m) still requires the HR Ready+ns; host-tier (s/free/"") goes Ready on namespace alone, Pending when the ns is missing.
- New `TestVClusterReadiness_HostTierDoesNotWaitOnVclusterHR`: an S/free/"" Org with only its namespace reaches Ready, while an identically-shaped M-tier Org stays not-Ready (still waiting on its absent vcluster HR).

Refs #4339 #4297 #4272 #4307 #4322

🤖 Generated with [Claude Code](https://claude.com/claude-code)