### PR TITLE
fix(bootstrap-kit): drop orphaned `dependsOn: null` in 5 slots — unwedge the whole bootstrap-kit Kustomization (blocks #4340 roll)

### DIFF
--- a/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
+++ b/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
@@ -47,7 +47,12 @@ spec:
   # inside the vCluster and resolve `nats-jetstream.nats-system.svc.
   # cluster.local` natively via vCluster CoreDNS.
   targetNamespace: nats-system
-  dependsOn:
+  # dependsOn: (key removed #4341) — #4325 de-vcluster dropped the last
+  # `- name: bp-mgmt-vcluster` array item; leaving the bare `dependsOn:` key
+  # rendered `dependsOn: null`, which the HelmRelease CRD rejects
+  # (`spec.dependsOn must be of type array`) and wedged the WHOLE
+  # bootstrap-kit Kustomization. With the planes now native host namespaces
+  # there is no vc-mgmt Secret gate, so NATS has no remaining hard dependency.
   chart:
     spec:
       chart: bp-nats-jetstream

--- a/clusters/_template/bootstrap-kit/22-loki.yaml
+++ b/clusters/_template/bootstrap-kit/22-loki.yaml
@@ -84,23 +84,28 @@ spec:
   # and fails `namespaces "mgmt" not found` storing the release inside
   # the vCluster (createNamespace only creates the target `loki`).
   # mgmt vCluster (Flux v2 HelmRelease v2 contract). #2745.
-  dependsOn:
-    # bp-seaweedfs dependency REMOVED (Refs #840) — mirrors the slot-19
-    # bp-harbor seaweedfs-dep removal (ADR-0001 §13: "writes blobs directly
-    # to cloud Object Storage, not via SeaweedFS"). The DEFAULT Loki render
-    # is `loki.storage.type: filesystem` (platform/loki/chart/values.yaml —
-    # chunks + index on a local 10Gi PVC), NOT SeaweedFS S3. The "MUST
-    # replace storage with s3" per-Sovereign overlay every slot-comment
-    # assumed was specced but never written, so Loki never references
-    # `seaweedfs-s3` / `seaweedfs-s3-secret`. The old
-    # `dependsOn: bp-seaweedfs (ns rtz)` was therefore a FALSE coupling: it
-    # gated Loki — and grafana (slot 25, which dependsOn bp-loki) — on the
-    # rtz-vCluster seaweedfs HR reaching Ready. When seaweedfs is
-    # slow/not-Ready in the SECONDARY region's rtz vCluster, that needlessly
-    # wedged the whole LGTM+grafana chain there (hw159 region-b 41/55 vs
-    # region-a 55/55). Decoupled, Loki converges on its own PVC in BOTH
-    # regions. NOTE: a future overlay that actually flips Loki to SeaweedFS
-    # S3 MUST re-add this edge (with `namespace: rtz`) in lockstep.
+  # dependsOn: (key removed #4341) — #4325 de-vcluster dropped the last
+  # `- name: bp-mgmt-vcluster` array item; leaving the bare `dependsOn:` key
+  # rendered `dependsOn: null`, which the HelmRelease CRD rejects
+  # (`spec.dependsOn must be of type array`) and wedged the WHOLE bootstrap-kit
+  # Kustomization. With the planes now native host namespaces there is no
+  # vc-mgmt Secret gate, so Loki has no remaining hard dependency.
+  # bp-seaweedfs dependency REMOVED (Refs #840) — mirrors the slot-19
+  # bp-harbor seaweedfs-dep removal (ADR-0001 §13: "writes blobs directly
+  # to cloud Object Storage, not via SeaweedFS"). The DEFAULT Loki render
+  # is `loki.storage.type: filesystem` (platform/loki/chart/values.yaml —
+  # chunks + index on a local 10Gi PVC), NOT SeaweedFS S3. The "MUST
+  # replace storage with s3" per-Sovereign overlay every slot-comment
+  # assumed was specced but never written, so Loki never references
+  # `seaweedfs-s3` / `seaweedfs-s3-secret`. The old
+  # `dependsOn: bp-seaweedfs (ns rtz)` was therefore a FALSE coupling: it
+  # gated Loki — and grafana (slot 25, which dependsOn bp-loki) — on the
+  # rtz-vCluster seaweedfs HR reaching Ready. When seaweedfs is
+  # slow/not-Ready in the SECONDARY region's rtz vCluster, that needlessly
+  # wedged the whole LGTM+grafana chain there (hw159 region-b 41/55 vs
+  # region-a 55/55). Decoupled, Loki converges on its own PVC in BOTH
+  # regions. NOTE: a future overlay that actually flips Loki to SeaweedFS
+  # S3 MUST re-add this edge (with `namespace: rtz`) in lockstep.
   chart:
     spec:
       chart: bp-loki

--- a/clusters/_template/bootstrap-kit/23-mimir.yaml
+++ b/clusters/_template/bootstrap-kit/23-mimir.yaml
@@ -86,22 +86,27 @@ spec:
   # and fails `namespaces "mgmt" not found` storing the release inside
   # the vCluster (createNamespace only creates the target `mimir`).
   # mgmt vCluster (Flux v2 HelmRelease v2 contract). #2745.
-  dependsOn:
-    # bp-seaweedfs dependency REMOVED (Refs #840) — mirrors the slot-19
-    # bp-harbor seaweedfs-dep removal (ADR-0001 §13). The DEFAULT Mimir
-    # render runs its OWN bundled MinIO (`minio.enabled: true` in
-    # platform/mimir/chart/values.yaml — blocks-storage on the in-chart
-    # MinIO), NOT SeaweedFS S3. The "MUST set minio.enabled:false AND wire
-    # S3 at SeaweedFS" per-Sovereign overlay was specced but never written,
-    # so Mimir never references `seaweedfs-s3` / `seaweedfs-s3-secret`. The
-    # old `dependsOn: bp-seaweedfs (ns rtz)` was a FALSE coupling that gated
-    # Mimir — and grafana (slot 25, which dependsOn bp-mimir) — on the
-    # rtz-vCluster seaweedfs HR reaching Ready, needlessly wedging the
-    # LGTM+grafana chain in the SECONDARY region when seaweedfs is
-    # slow/not-Ready there (hw159 region-b 41/55). Decoupled, Mimir
-    # converges on its bundled MinIO in BOTH regions. NOTE: a future overlay
-    # that flips Mimir to SeaweedFS S3 MUST re-add this edge (ns rtz) in
-    # lockstep.
+  # dependsOn: (key removed #4341) — #4325 de-vcluster dropped the last
+  # `- name: bp-mgmt-vcluster` array item; leaving the bare `dependsOn:` key
+  # rendered `dependsOn: null`, which the HelmRelease CRD rejects and wedged
+  # the WHOLE bootstrap-kit Kustomization. With the planes now native host
+  # namespaces there is no vc-mgmt Secret gate, so Mimir has no remaining
+  # hard dependency.
+  # bp-seaweedfs dependency REMOVED (Refs #840) — mirrors the slot-19
+  # bp-harbor seaweedfs-dep removal (ADR-0001 §13). The DEFAULT Mimir
+  # render runs its OWN bundled MinIO (`minio.enabled: true` in
+  # platform/mimir/chart/values.yaml — blocks-storage on the in-chart
+  # MinIO), NOT SeaweedFS S3. The "MUST set minio.enabled:false AND wire
+  # S3 at SeaweedFS" per-Sovereign overlay was specced but never written,
+  # so Mimir never references `seaweedfs-s3` / `seaweedfs-s3-secret`. The
+  # old `dependsOn: bp-seaweedfs (ns rtz)` was a FALSE coupling that gated
+  # Mimir — and grafana (slot 25, which dependsOn bp-mimir) — on the
+  # rtz-vCluster seaweedfs HR reaching Ready, needlessly wedging the
+  # LGTM+grafana chain in the SECONDARY region when seaweedfs is
+  # slow/not-Ready there (hw159 region-b 41/55). Decoupled, Mimir
+  # converges on its bundled MinIO in BOTH regions. NOTE: a future overlay
+  # that flips Mimir to SeaweedFS S3 MUST re-add this edge (ns rtz) in
+  # lockstep.
   chart:
     spec:
       chart: bp-mimir

--- a/clusters/_template/bootstrap-kit/24-tempo.yaml
+++ b/clusters/_template/bootstrap-kit/24-tempo.yaml
@@ -80,21 +80,26 @@ spec:
   # and fails `namespaces "mgmt" not found` storing the release inside
   # the vCluster (createNamespace only creates the target `tempo`).
   # mgmt vCluster (Flux v2 HelmRelease v2 contract). #2745.
-  dependsOn:
-    # bp-seaweedfs dependency REMOVED (Refs #840) — mirrors the slot-19
-    # bp-harbor seaweedfs-dep removal (ADR-0001 §13). The DEFAULT Tempo
-    # render is `tempo.storage.trace.backend: local` (platform/tempo/chart/
-    # values.yaml — traces + WAL on a local 10Gi PVC), NOT SeaweedFS S3. The
-    # "MUST replace this with S3" per-Sovereign overlay every slot-comment
-    # assumed was specced but never written, so Tempo never references
-    # `seaweedfs-s3` / `seaweedfs-s3-secret`. The old
-    # `dependsOn: bp-seaweedfs (ns rtz)` was a FALSE coupling that gated
-    # Tempo — and grafana (slot 25, which dependsOn bp-tempo) — on the
-    # rtz-vCluster seaweedfs HR reaching Ready, needlessly wedging the
-    # LGTM+grafana chain in the SECONDARY region when seaweedfs is
-    # slow/not-Ready there (hw159 region-b 41/55). Decoupled, Tempo
-    # converges on its own PVC in BOTH regions. NOTE: a future overlay that
-    # flips Tempo to SeaweedFS S3 MUST re-add this edge (ns rtz) in lockstep.
+  # dependsOn: (key removed #4341) — #4325 de-vcluster dropped the last
+  # `- name: bp-mgmt-vcluster` array item; leaving the bare `dependsOn:` key
+  # rendered `dependsOn: null`, which the HelmRelease CRD rejects and wedged
+  # the WHOLE bootstrap-kit Kustomization. With the planes now native host
+  # namespaces there is no vc-mgmt Secret gate, so Tempo has no remaining
+  # hard dependency.
+  # bp-seaweedfs dependency REMOVED (Refs #840) — mirrors the slot-19
+  # bp-harbor seaweedfs-dep removal (ADR-0001 §13). The DEFAULT Tempo
+  # render is `tempo.storage.trace.backend: local` (platform/tempo/chart/
+  # values.yaml — traces + WAL on a local 10Gi PVC), NOT SeaweedFS S3. The
+  # "MUST replace this with S3" per-Sovereign overlay every slot-comment
+  # assumed was specced but never written, so Tempo never references
+  # `seaweedfs-s3` / `seaweedfs-s3-secret`. The old
+  # `dependsOn: bp-seaweedfs (ns rtz)` was a FALSE coupling that gated
+  # Tempo — and grafana (slot 25, which dependsOn bp-tempo) — on the
+  # rtz-vCluster seaweedfs HR reaching Ready, needlessly wedging the
+  # LGTM+grafana chain in the SECONDARY region when seaweedfs is
+  # slow/not-Ready there (hw159 region-b 41/55). Decoupled, Tempo
+  # converges on its own PVC in BOTH regions. NOTE: a future overlay that
+  # flips Tempo to SeaweedFS S3 MUST re-add this edge (ns rtz) in lockstep.
   chart:
     spec:
       chart: bp-tempo

--- a/clusters/_template/bootstrap-kit/39-bp-vllm.yaml
+++ b/clusters/_template/bootstrap-kit/39-bp-vllm.yaml
@@ -154,8 +154,12 @@ spec:
   interval: 15m
   releaseName: vllm
   targetNamespace: vllm
-  dependsOn:
-  # #3373 Batch A: bp-rtz-vcluster is the ONLY explicit dependsOn — the
+  # dependsOn: (key removed #4341) — #4325 de-vcluster dropped the last
+  # `- name: bp-rtz-vcluster` array item; leaving the bare `dependsOn:` key
+  # rendered `dependsOn: null`, which the HelmRelease CRD rejects and wedged
+  # the WHOLE bootstrap-kit Kustomization. With the planes now native host
+  # namespaces there is no vc-rtz Secret gate.
+  # #3373 Batch A: bp-rtz-vcluster WAS the ONLY explicit dependsOn — the
   # vc-rtz Secret doesn't exist until it is Ready (the kubeConfig pivot
   # dangles otherwise). The chart itself only needs CNI + Flux (implicit
   # cluster-bootstrap deps); no bp-kserve edge (slot 38 has no on-disk


### PR DESCRIPTION
## Problem (live, omantel.biz kom4dc dep `4635277cae4ffed9`, region-a)

The `bootstrap-kit` Flux Kustomization is **`Ready=False`**:

```
HelmRelease/flux-system/bp-loki dry-run failed (Invalid): HelmRelease "bp-loki" is invalid:
[spec.dependsOn: Invalid value: "null": spec.dependsOn in body must be of type array]
```

Because the Kustomization fails its server-side dry-run **as a whole**, NONE of the updated platform pins reach the live env. Concretely this freezes:

- **bp-cnpg** on **1.0.13** (the buggy `cnpg-cabundle-reassert` post-upgrade job → `BackoffLimitExceeded` → Helm rollback loop) instead of the fixed **1.0.14** (#4338). That cascades up the dependency chain: `bp-cnpg` → `bp-postgres-shared` → `bp-keycloak` → `bp-gitea` → **`bp-catalyst-platform` Ready=False**.
- **bp-catalyst-platform** on **1.4.838** instead of **1.4.844**, which carries the #4340 org-controller image `405ee6d` (tier-aware `vclusterReadiness`). **The #4340 roll cannot land until this Kustomization is green.**

## Root cause

Commit `158ea9e2c` (#4325, de-vcluster the platform planes) removed the last `- name: bp-{mgmt,rtz}-vcluster` array item from these slots' `dependsOn:` but **left the bare `dependsOn:` key**, with only comments under it → renders `dependsOn: null` → CRD schema rejection.

5 bootstrap-kit slots affected:
- `07-nats-jetstream.yaml`
- `22-loki.yaml`
- `23-mimir.yaml`
- `24-tempo.yaml`
- `39-bp-vllm.yaml`

## Fix

Remove the orphaned `dependsOn:` key in all 5 (rationale comments preserved as free-standing blocks). With the planes now native host namespaces (#4325) there is no vc-{mgmt,rtz} Secret gate, so these HRs have **no remaining hard dependency** — dropping the key is semantically correct, not merely a syntax patch.

The live `bootstrap-kit` Kustomization tracks `./clusters/_template/bootstrap-kit` on `main` directly, so on merge + Flux sync the dry-run clears and the frozen pins (bp-cnpg 1.0.14, bp-catalyst-platform 1.4.844 / #4340) roll.

Validated: all 5 files parse via `yaml.safe_load_all`; HelmRelease docs now have **no `dependsOn` key** (was `null`). Re-scan of every bootstrap-kit HR shows no remaining orphaned `dependsOn`/`valuesFrom`/`postRenderers` keys.

Refs #4341, #4340, #4338, #4325

🤖 Generated with [Claude Code](https://claude.com/claude-code)