### PR TITLE
fix(planes): resources.requests for host-ns plane components → Kyverno resource-requests Enforce admits openbao/harbor/loki/mimir/nats

### DIFF
--- a/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
+++ b/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
@@ -56,7 +56,11 @@ spec:
   chart:
     spec:
       chart: bp-nats-jetstream
-      version: 1.3.3
+      # 1.3.4 — #4343: server/reloader/nats-box resources moved to the
+      #   container.merge knob (the inert container.resources block was
+      #   silently dropped) so every container clears the host-ns Kyverno
+      #   resource-requests Enforce policy (post-#4325).
+      version: 1.3.4
       sourceRef:
         kind: HelmRepository
         name: bp-nats-jetstream

--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -133,7 +133,9 @@ spec:
       # 1.2.50: #3374 — in-vCluster k8s-auth mount + gateway-decoupled zero-click SSO landing.
       # 1.2.52 — #4212 Seam 3: placementSchema aligned with spec.topology
       #   (modes[] admit active-passive + defaultOnMultiRegion). Chart bumped in lockstep.
-      version: 1.2.52
+      # 1.2.53 — #4343: injector.resources.requests so the agent-injector clears
+      #   the host-ns Kyverno resource-requests Enforce policy (post-#4325).
+      version: 1.2.53
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -210,7 +210,9 @@ spec:
       # TRUE shared-pg mode. Non-host-bridged render byte-identical.
       # 1.2.37 — #4212 Seam 3: placementSchema aligned with spec.topology
       #   (modes[] admit active-hot-standby + defaultOnMultiRegion). Chart bumped in lockstep.
-      version: 1.2.37
+      # 1.2.38 — #4343: nginx.resources.requests so harbor-nginx clears the
+      #   host-ns Kyverno resource-requests Enforce policy (post-#4325).
+      version: 1.2.38
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/clusters/_template/bootstrap-kit/22-loki.yaml
+++ b/clusters/_template/bootstrap-kit/22-loki.yaml
@@ -109,7 +109,9 @@ spec:
   chart:
     spec:
       chart: bp-loki
-      version: 1.0.0
+      # 1.0.1 — #4343: loki.sidecar.resources.requests so the rules sidecar
+      #   clears the host-ns Kyverno resource-requests Enforce policy (post-#4325).
+      version: 1.0.1
       sourceRef:
         kind: HelmRepository
         name: bp-loki

--- a/clusters/_template/bootstrap-kit/23-mimir.yaml
+++ b/clusters/_template/bootstrap-kit/23-mimir.yaml
@@ -110,7 +110,10 @@ spec:
   chart:
     spec:
       chart: bp-mimir
-      version: 1.0.5
+      # 1.0.6 — #4343: gateway.resources + MinIO cpu requests so every
+      #   container clears the host-ns Kyverno resource-requests Enforce
+      #   policy (post-#4325).
+      version: 1.0.6
       sourceRef:
         kind: HelmRepository
         name: bp-mimir

--- a/platform/harbor/blueprint.yaml
+++ b/platform/harbor/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-5-storage-and-data
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.37
+  version: 1.2.38  # lockstep with chart/Chart.yaml (#4343 nginx.resources.requests for host-ns Kyverno resource-requests Enforce)
   card:
     title: Harbor
     family: foundation

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -38,6 +38,11 @@ description: |
   this Blueprint hard-depends on bp-cnpg + bp-cert-manager. The
   earlier dependency on bp-seaweedfs is REMOVED (cloud-direct S3 path).
 type: application
+# 1.2.38 (#4343, 2026-06-25): set `nginx.resources.requests` (cpu/memory) so
+# the harbor-nginx Deployment satisfies the cluster-wide Kyverno
+# `resource-requests` Enforce policy. Post-#4325 this chart installs into the
+# native host namespace (not a vCluster) where the policy applies; the upstream
+# goharbor subchart only emits nginx resources when `nginx.resources` is set.
 # 1.2.16 (Fix #163, 2026-05-11, MIRROR-EVERYTHING): database-secret-sync-job
 # hook image switched from curlimages/curl:8.10.1 to
 # harbor.openova.io/proxy-dockerhub/curlimages/curl:8.10.1 per CLAUDE.md
@@ -142,7 +147,7 @@ type: application
 # materialise. The cnpg-cluster.yaml Cluster-CR gate is UNCHANGED (still
 # cluster.enabled — the host-bridge must not double-create it). Non-host-bridged
 # render byte-identical.
-version: 1.2.37
+version: 1.2.38
 appVersion: "2.14.3"
 # 1.2.23 (G117.5 #2744, 2026-06-02): SSO defense-in-depth via Harbor's
 # `oidc_extra_redirect_parms` config field. The configure-oauth Job now

--- a/platform/harbor/chart/tests/_assert_resource_requests.py
+++ b/platform/harbor/chart/tests/_assert_resource_requests.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# #4343 helper — read a multi-doc helm render from stdin and assert every
+# workload container (Deployment/StatefulSet/DaemonSet/Job/CronJob, incl.
+# initContainers) declares resources.requests.cpu AND resources.requests.memory
+# (the exact shape the Kyverno `resource-requests` Enforce ClusterPolicy
+# requires). Prints a one-line OK summary on success; prints the offending
+# kind/name:container lines and exits 1 on any miss.
+import sys, re
+try:
+    import yaml
+except ImportError:
+    print("PyYAML not available; cannot run resource-requests assertion", file=sys.stderr)
+    sys.exit(2)
+
+raw = sys.stdin.read()
+# Some upstream subchart templates emit stray trailing whitespace/tabs that
+# break a strict YAML scan; rstrip each line (cosmetic, render-neutral).
+raw = "\n".join(line.rstrip() for line in raw.splitlines())
+
+bad = []
+checked = 0
+for chunk in re.split(r"(?m)^---\s*$", raw):
+    chunk = chunk.strip()
+    if not chunk:
+        continue
+    try:
+        d = yaml.safe_load(chunk)
+    except Exception:
+        continue
+    if not isinstance(d, dict):
+        continue
+    kind = d.get("kind")
+    if kind not in ("Deployment", "StatefulSet", "DaemonSet", "Job", "CronJob"):
+        continue
+    name = d.get("metadata", {}).get("name", "<noname>")
+    try:
+        if kind == "CronJob":
+            podspec = d["spec"]["jobTemplate"]["spec"]["template"]["spec"]
+        else:
+            podspec = d["spec"]["template"]["spec"]
+    except (KeyError, TypeError):
+        continue
+    containers = list(podspec.get("containers", []) or []) + list(podspec.get("initContainers", []) or [])
+    for c in containers:
+        checked += 1
+        req = (c.get("resources") or {}).get("requests") or {}
+        if "cpu" not in req or "memory" not in req:
+            bad.append("%s/%s container=%s requests=%s" % (kind, name, c.get("name"), dict(req)))
+
+if bad:
+    print("workload containers MISSING cpu+memory requests:")
+    for b in bad:
+        print(b)
+    sys.exit(1)
+
+if checked == 0:
+    print("no workload containers rendered — subchart deps not built? (run `helm dependency build`)")
+    sys.exit(1)
+
+print("%d workload container(s) all declare cpu+memory requests" % checked)

--- a/platform/harbor/chart/tests/kyverno-resource-requests.sh
+++ b/platform/harbor/chart/tests/kyverno-resource-requests.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# #4343 — assert EVERY workload container in the rendered bp-harbor manifests
+# declares resources.requests.cpu AND resources.requests.memory, so the
+# cluster-wide Kyverno `resource-requests` Enforce ClusterPolicy admits every
+# Pod/Deployment/StatefulSet/DaemonSet/Job/CronJob.
+#
+# After #4325 this chart installs into a NATIVE host namespace (not a vCluster)
+# where the host Kyverno Enforce policies apply. The upstream goharbor subchart
+# only emits `resources:` on the nginx Deployment when `nginx.resources` is set
+# — left unset, harbor-nginx shipped with NO requests → DENIED → bp-harbor
+# InstallFailed. This test guards that regression.
+set -euo pipefail
+chart_dir="${1:-$(dirname "$0")/..}"
+cd "$chart_dir"
+chart_dir="$(pwd)"
+
+if ! ls charts/*.tgz >/dev/null 2>&1; then
+  helm dependency build "$chart_dir" >/dev/null 2>&1 || true
+fi
+
+assert_py="$chart_dir/tests/_assert_resource_requests.py"
+
+assert_requests() {
+  local label="$1"; shift
+  local out rc
+  out=$(helm template t . --set gateway.host=registry.example.test "$@" 2>/dev/null | python3 "$assert_py")
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "FAIL [$label]:"
+    echo "$out" | sed 's/^/  /'
+    return 1
+  fi
+  echo "PASS [$label]: $out"
+}
+
+fail=0
+assert_requests "default" || fail=1
+
+if [ "$fail" -ne 0 ]; then
+  echo "kyverno-resource-requests: one or more workload containers lack resources.requests (would be DENIED by the host-ns Kyverno resource-requests Enforce policy)."
+  exit 1
+fi
+echo "kyverno-resource-requests: all workload containers declare cpu+memory requests."

--- a/platform/harbor/chart/values.yaml
+++ b/platform/harbor/chart/values.yaml
@@ -231,6 +231,22 @@ harbor:
     image:
       repository: harbor.openova.io/proxy-dockerhub/goharbor/nginx-photon
       tag: "v2.14.3"
+    # #4343 — the harbor-nginx Deployment MUST declare resources.requests. The
+    # upstream goharbor subchart only renders `resources:` when
+    # `.Values.nginx.resources` is set; left unset, harbor-nginx ships with NO
+    # requests. Pre-#4325 this chart ran INSIDE a vCluster where the host's
+    # Kyverno `resource-requests` Enforce ClusterPolicy didn't reach it; after
+    # the de-vcluster migration it installs into the native host namespace and
+    # the `Deployment/harbor-nginx` admission is DENIED, timing out the Helm
+    # install → bp-harbor InstallFailed. Mirror the portal/core sibling
+    # requests — modest for the reverse-proxy front door.
+    resources:
+      requests:
+        memory: 64Mi
+        cpu: 50m
+      limits:
+        memory: 256Mi
+        cpu: 500m
 
   # ─── Component replica counts ──────────────────────────────────────────
   portal:

--- a/platform/loki/blueprint.yaml
+++ b/platform/loki/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.0.0
+  version: 1.0.1  # lockstep with chart/Chart.yaml (#4343 loki.sidecar.resources for host-ns Kyverno resource-requests Enforce)
   card:
     title: Loki
     family: insights

--- a/platform/loki/chart/Chart.yaml
+++ b/platform/loki/chart/Chart.yaml
@@ -14,7 +14,12 @@ description: |
   overlays MUST flip storage to S3 (SeaweedFS / cloud) when SimpleScalable
   or Distributed is selected — the upstream chart enforces this.
 type: application
-version: 1.0.0
+# 1.0.1 (#4343, 2026-06-25): set `loki.sidecar.resources.requests` so the
+# rules sidecar (loki-sc-rules) in the SingleBinary StatefulSet satisfies the
+# cluster-wide Kyverno `resource-requests` Enforce policy. Post-#4325 this
+# chart installs into the native host namespace (not a vCluster) where the
+# policy applies; upstream defaults the sidecar resources to empty.
+version: 1.0.1
 appVersion: "3.6.7"
 keywords: [catalyst, blueprint, loki, observability, logs]
 maintainers:

--- a/platform/loki/chart/tests/_assert_resource_requests.py
+++ b/platform/loki/chart/tests/_assert_resource_requests.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# #4343 helper — read a multi-doc helm render from stdin and assert every
+# workload container (Deployment/StatefulSet/DaemonSet/Job/CronJob, incl.
+# initContainers) declares resources.requests.cpu AND resources.requests.memory
+# (the exact shape the Kyverno `resource-requests` Enforce ClusterPolicy
+# requires). Prints a one-line OK summary on success; prints the offending
+# kind/name:container lines and exits 1 on any miss.
+import sys, re
+try:
+    import yaml
+except ImportError:
+    print("PyYAML not available; cannot run resource-requests assertion", file=sys.stderr)
+    sys.exit(2)
+
+raw = sys.stdin.read()
+# Some upstream subchart templates emit stray trailing whitespace/tabs that
+# break a strict YAML scan; rstrip each line (cosmetic, render-neutral).
+raw = "\n".join(line.rstrip() for line in raw.splitlines())
+
+bad = []
+checked = 0
+for chunk in re.split(r"(?m)^---\s*$", raw):
+    chunk = chunk.strip()
+    if not chunk:
+        continue
+    try:
+        d = yaml.safe_load(chunk)
+    except Exception:
+        continue
+    if not isinstance(d, dict):
+        continue
+    kind = d.get("kind")
+    if kind not in ("Deployment", "StatefulSet", "DaemonSet", "Job", "CronJob"):
+        continue
+    name = d.get("metadata", {}).get("name", "<noname>")
+    try:
+        if kind == "CronJob":
+            podspec = d["spec"]["jobTemplate"]["spec"]["template"]["spec"]
+        else:
+            podspec = d["spec"]["template"]["spec"]
+    except (KeyError, TypeError):
+        continue
+    containers = list(podspec.get("containers", []) or []) + list(podspec.get("initContainers", []) or [])
+    for c in containers:
+        checked += 1
+        req = (c.get("resources") or {}).get("requests") or {}
+        if "cpu" not in req or "memory" not in req:
+            bad.append("%s/%s container=%s requests=%s" % (kind, name, c.get("name"), dict(req)))
+
+if bad:
+    print("workload containers MISSING cpu+memory requests:")
+    for b in bad:
+        print(b)
+    sys.exit(1)
+
+if checked == 0:
+    print("no workload containers rendered — subchart deps not built? (run `helm dependency build`)")
+    sys.exit(1)
+
+print("%d workload container(s) all declare cpu+memory requests" % checked)

--- a/platform/loki/chart/tests/kyverno-resource-requests.sh
+++ b/platform/loki/chart/tests/kyverno-resource-requests.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# #4343 — assert EVERY workload container in the rendered bp-loki manifests
+# declares resources.requests.cpu AND resources.requests.memory, so the
+# cluster-wide Kyverno `resource-requests` Enforce ClusterPolicy admits every
+# Pod/Deployment/StatefulSet/DaemonSet/Job/CronJob.
+#
+# After #4325 this chart installs into a NATIVE host namespace (not a vCluster)
+# where the host Kyverno Enforce policies apply. The upstream loki chart runs
+# a rules sidecar (loki-sc-rules) in the SingleBinary StatefulSet whose
+# resources default to `{}` — so the sidecar container shipped with NO requests
+# → the StatefulSet admission was DENIED. This test guards that regression.
+set -euo pipefail
+chart_dir="${1:-$(dirname "$0")/..}"
+cd "$chart_dir"
+chart_dir="$(pwd)"
+
+if ! ls charts/*.tgz >/dev/null 2>&1; then
+  helm dependency build "$chart_dir" >/dev/null 2>&1 || true
+fi
+
+assert_py="$chart_dir/tests/_assert_resource_requests.py"
+
+assert_requests() {
+  local label="$1"; shift
+  local out rc
+  out=$(helm template t . "$@" 2>/dev/null | python3 "$assert_py")
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "FAIL [$label]:"
+    echo "$out" | sed 's/^/  /'
+    return 1
+  fi
+  echo "PASS [$label]: $out"
+}
+
+fail=0
+assert_requests "default" || fail=1
+
+if [ "$fail" -ne 0 ]; then
+  echo "kyverno-resource-requests: one or more workload containers lack resources.requests (would be DENIED by the host-ns Kyverno resource-requests Enforce policy)."
+  exit 1
+fi
+echo "kyverno-resource-requests: all workload containers declare cpu+memory requests."

--- a/platform/loki/chart/values.yaml
+++ b/platform/loki/chart/values.yaml
@@ -64,6 +64,23 @@ loki:
         cpu: 1
         memory: 1Gi
 
+  # #4343 — the rules sidecar (kiwigrid/k8s-sidecar `loki-sc-rules`) co-runs
+  # in the SingleBinary StatefulSet whenever the upstream `sidecar.rules.enabled`
+  # default (true) holds. Its resources come from `sidecar.resources`, which
+  # upstream defaults to `{}` → the sidecar container renders with NO requests.
+  # Pre-#4325 this chart ran INSIDE a vCluster where the host's Kyverno
+  # `resource-requests` Enforce ClusterPolicy didn't reach it; after the
+  # de-vcluster migration it installs into the native host namespace and the
+  # StatefulSet admission is DENIED. Modest request for the light k8s watcher.
+  sidecar:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 50m
+        memory: 64Mi
+
   # SimpleScalable / Distributed pools — DEFAULT 0 replicas. Per-Sovereign
   # overlays bump these (and flip `deploymentMode`) when scaling out.
   read:

--- a/platform/mimir/blueprint.yaml
+++ b/platform/mimir/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.0.5
+  version: 1.0.6  # lockstep with chart/Chart.yaml (#4343 gateway + MinIO cpu requests for host-ns Kyverno resource-requests Enforce)
   card:
     title: Mimir
     family: insights

--- a/platform/mimir/chart/Chart.yaml
+++ b/platform/mimir/chart/Chart.yaml
@@ -13,7 +13,12 @@ description: |
   overlays scale per-component replicas + flip zone-aware-replication on
   for HA Sovereigns.
 type: application
-version: 1.0.5
+# 1.0.6 (#4343, 2026-06-25): set `gateway.resources.requests` and add the
+# missing cpu request on the bundled MinIO StatefulSet + create-bucket Job so
+# every container satisfies the cluster-wide Kyverno `resource-requests`
+# Enforce policy. Post-#4325 this chart installs into the native host namespace
+# (not a vCluster) where the policy applies.
+version: 1.0.6
 appVersion: "3.0.4"
 keywords: [catalyst, blueprint, mimir, observability, metrics, prometheus]
 maintainers:

--- a/platform/mimir/chart/tests/_assert_resource_requests.py
+++ b/platform/mimir/chart/tests/_assert_resource_requests.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# #4343 helper — read a multi-doc helm render from stdin and assert every
+# workload container (Deployment/StatefulSet/DaemonSet/Job/CronJob, incl.
+# initContainers) declares resources.requests.cpu AND resources.requests.memory
+# (the exact shape the Kyverno `resource-requests` Enforce ClusterPolicy
+# requires). Prints a one-line OK summary on success; prints the offending
+# kind/name:container lines and exits 1 on any miss.
+import sys, re
+try:
+    import yaml
+except ImportError:
+    print("PyYAML not available; cannot run resource-requests assertion", file=sys.stderr)
+    sys.exit(2)
+
+raw = sys.stdin.read()
+# Some upstream subchart templates emit stray trailing whitespace/tabs that
+# break a strict YAML scan; rstrip each line (cosmetic, render-neutral).
+raw = "\n".join(line.rstrip() for line in raw.splitlines())
+
+bad = []
+checked = 0
+for chunk in re.split(r"(?m)^---\s*$", raw):
+    chunk = chunk.strip()
+    if not chunk:
+        continue
+    try:
+        d = yaml.safe_load(chunk)
+    except Exception:
+        continue
+    if not isinstance(d, dict):
+        continue
+    kind = d.get("kind")
+    if kind not in ("Deployment", "StatefulSet", "DaemonSet", "Job", "CronJob"):
+        continue
+    name = d.get("metadata", {}).get("name", "<noname>")
+    try:
+        if kind == "CronJob":
+            podspec = d["spec"]["jobTemplate"]["spec"]["template"]["spec"]
+        else:
+            podspec = d["spec"]["template"]["spec"]
+    except (KeyError, TypeError):
+        continue
+    containers = list(podspec.get("containers", []) or []) + list(podspec.get("initContainers", []) or [])
+    for c in containers:
+        checked += 1
+        req = (c.get("resources") or {}).get("requests") or {}
+        if "cpu" not in req or "memory" not in req:
+            bad.append("%s/%s container=%s requests=%s" % (kind, name, c.get("name"), dict(req)))
+
+if bad:
+    print("workload containers MISSING cpu+memory requests:")
+    for b in bad:
+        print(b)
+    sys.exit(1)
+
+if checked == 0:
+    print("no workload containers rendered — subchart deps not built? (run `helm dependency build`)")
+    sys.exit(1)
+
+print("%d workload container(s) all declare cpu+memory requests" % checked)

--- a/platform/mimir/chart/tests/kyverno-resource-requests.sh
+++ b/platform/mimir/chart/tests/kyverno-resource-requests.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# #4343 — assert EVERY workload container in the rendered bp-mimir manifests
+# declares resources.requests.cpu AND resources.requests.memory, so the
+# cluster-wide Kyverno `resource-requests` Enforce ClusterPolicy admits every
+# Pod/Deployment/StatefulSet/DaemonSet/Job/CronJob.
+#
+# After #4325 this chart installs into a NATIVE host namespace (not a vCluster)
+# where the host Kyverno Enforce policies apply. The upstream mimir-distributed
+# chart left the gateway/nginx with empty resources, and the bundled MinIO
+# StatefulSet + create-bucket/make-user/make-policy hook Jobs default to a
+# MEMORY-ONLY request — both classes were DENIED by a cpu+memory policy. This
+# test guards that regression across the whole render.
+set -euo pipefail
+chart_dir="${1:-$(dirname "$0")/..}"
+cd "$chart_dir"
+chart_dir="$(pwd)"
+
+if ! ls charts/*.tgz >/dev/null 2>&1; then
+  helm dependency build "$chart_dir" >/dev/null 2>&1 || true
+fi
+
+assert_py="$chart_dir/tests/_assert_resource_requests.py"
+
+assert_requests() {
+  local label="$1"; shift
+  local out rc
+  out=$(helm template t . "$@" 2>/dev/null | python3 "$assert_py")
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "FAIL [$label]:"
+    echo "$out" | sed 's/^/  /'
+    return 1
+  fi
+  echo "PASS [$label]: $out"
+}
+
+fail=0
+assert_requests "default" || fail=1
+
+if [ "$fail" -ne 0 ]; then
+  echo "kyverno-resource-requests: one or more workload containers lack resources.requests (would be DENIED by the host-ns Kyverno resource-requests Enforce policy)."
+  exit 1
+fi
+echo "kyverno-resource-requests: all workload containers declare cpu+memory requests."

--- a/platform/mimir/chart/values.yaml
+++ b/platform/mimir/chart/values.yaml
@@ -54,6 +54,20 @@ mimir-distributed:
   gateway:
     enabled: true
     replicas: 1
+    # #4343 — the gateway/nginx Deployment MUST declare resources.requests.
+    # Upstream defaults `gateway.resources: {}` → the container renders with
+    # NO requests. Pre-#4325 this chart ran INSIDE a vCluster where the host's
+    # Kyverno `resource-requests` Enforce ClusterPolicy didn't reach it; after
+    # the de-vcluster migration it installs into the native host namespace and
+    # the `Deployment/mimir-gateway` admission is DENIED. Modest reverse-proxy
+    # request.
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 500m
+        memory: 128Mi
 
   # Bundled MinIO — DEFAULT ON only as a stop-gap so the chart renders;
   # Catalyst routes object storage through SeaweedFS. Per-Sovereign
@@ -63,6 +77,36 @@ mimir-distributed:
   # production data.
   minio:
     enabled: true
+    # #4343 — the bundled MinIO subchart's defaults declare ONLY a memory
+    # request (server 16Gi, post-bucket Job 128Mi) with NO cpu. The cluster-
+    # wide Kyverno `resource-requests` Enforce policy requires BOTH cpu AND
+    # memory, so on a host-ns install (post-#4325) the MinIO StatefulSet and
+    # the create-bucket Job are DENIED. Add the missing cpu request and pull
+    # the oversized 16Gi memory default down to a sane stop-gap value (this
+    # MinIO is single-replica + ephemeral; production overlays disable it).
+    resources:
+      requests:
+        cpu: 50m
+        memory: 512Mi
+    # The MinIO post-install hook Job renders one container per configured
+    # bucket/user/policy list; the default `users:` list (the `console`
+    # account) makes `makeUserJob` render too. Both Job containers default to
+    # a memory-only request → add cpu so they clear the Kyverno policy.
+    makeBucketJob:
+      resources:
+        requests:
+          cpu: 10m
+          memory: 128Mi
+    makeUserJob:
+      resources:
+        requests:
+          cpu: 10m
+          memory: 128Mi
+    makePolicyJob:
+      resources:
+        requests:
+          cpu: 10m
+          memory: 128Mi
 
   # Kafka (ingest-storage architecture) — DISABLED. The classic blocks-
   # storage architecture is the Catalyst default; Kafka ingest-storage is
@@ -105,8 +149,16 @@ mimir-distributed:
         enabled: false
 
   # Smoke + continuous-test pods — disabled in production.
+  # #4343 — the smoke-test renders as a `helm.sh/hook: test` Job (only created
+  # by `helm test`, not on install), but its container defaults to empty
+  # resources. Give it requests so that if an operator ever runs the test hook
+  # on a host-ns install it still clears the Kyverno `resource-requests` policy.
   smoke_test:
     enabled: false
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
   continuous_test:
     enabled: false
 

--- a/platform/nats-jetstream/blueprint.yaml
+++ b/platform/nats-jetstream/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.3.3
+  version: 1.3.4  # lockstep with chart/Chart.yaml (#4343 server/reloader/nats-box resources via container.merge for host-ns Kyverno resource-requests Enforce)
   card:
     title: nats-jetstream
     summary: Event spine for the Catalyst control plane. JetStream Streams + KV + Object Store via bundled nack JetStream Controller (Wave 5.45 #2254). Per-Organization Accounts. Replaces what was previously specified as Redpanda + Valkey for the control plane.

--- a/platform/nats-jetstream/chart/Chart.yaml
+++ b/platform/nats-jetstream/chart/Chart.yaml
@@ -1,6 +1,13 @@
 apiVersion: v2
 name: bp-nats-jetstream
-version: 1.3.3
+# 1.3.4 (#4343, 2026-06-25): relocate the nats server resources from the
+# inert `container.resources` to `container.merge.resources` (the nats 1.2.0
+# loadMergePatch helper reads ONLY `.merge`/`.patch`, so the prior block was
+# silently dropped and the server container rendered with NO requests) and add
+# `reloader.merge.resources` + `natsBox.container.merge.resources`. Satisfies
+# the cluster-wide Kyverno `resource-requests` Enforce policy now that #4325
+# installs this chart into the native host namespace (not a vCluster).
+version: 1.3.4
 description: |
   Catalyst-curated Blueprint umbrella chart for NATS JetStream. Depends
   on TWO upstream subcharts:

--- a/platform/nats-jetstream/chart/tests/_assert_resource_requests.py
+++ b/platform/nats-jetstream/chart/tests/_assert_resource_requests.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# #4343 helper — read a multi-doc helm render from stdin and assert every
+# workload container (Deployment/StatefulSet/DaemonSet/Job/CronJob, incl.
+# initContainers) declares resources.requests.cpu AND resources.requests.memory
+# (the exact shape the Kyverno `resource-requests` Enforce ClusterPolicy
+# requires). Prints a one-line OK summary on success; prints the offending
+# kind/name:container lines and exits 1 on any miss.
+import sys, re
+try:
+    import yaml
+except ImportError:
+    print("PyYAML not available; cannot run resource-requests assertion", file=sys.stderr)
+    sys.exit(2)
+
+raw = sys.stdin.read()
+# Some upstream subchart templates emit stray trailing whitespace/tabs that
+# break a strict YAML scan; rstrip each line (cosmetic, render-neutral).
+raw = "\n".join(line.rstrip() for line in raw.splitlines())
+
+bad = []
+checked = 0
+for chunk in re.split(r"(?m)^---\s*$", raw):
+    chunk = chunk.strip()
+    if not chunk:
+        continue
+    try:
+        d = yaml.safe_load(chunk)
+    except Exception:
+        continue
+    if not isinstance(d, dict):
+        continue
+    kind = d.get("kind")
+    if kind not in ("Deployment", "StatefulSet", "DaemonSet", "Job", "CronJob"):
+        continue
+    name = d.get("metadata", {}).get("name", "<noname>")
+    try:
+        if kind == "CronJob":
+            podspec = d["spec"]["jobTemplate"]["spec"]["template"]["spec"]
+        else:
+            podspec = d["spec"]["template"]["spec"]
+    except (KeyError, TypeError):
+        continue
+    containers = list(podspec.get("containers", []) or []) + list(podspec.get("initContainers", []) or [])
+    for c in containers:
+        checked += 1
+        req = (c.get("resources") or {}).get("requests") or {}
+        if "cpu" not in req or "memory" not in req:
+            bad.append("%s/%s container=%s requests=%s" % (kind, name, c.get("name"), dict(req)))
+
+if bad:
+    print("workload containers MISSING cpu+memory requests:")
+    for b in bad:
+        print(b)
+    sys.exit(1)
+
+if checked == 0:
+    print("no workload containers rendered — subchart deps not built? (run `helm dependency build`)")
+    sys.exit(1)
+
+print("%d workload container(s) all declare cpu+memory requests" % checked)

--- a/platform/nats-jetstream/chart/tests/kyverno-resource-requests.sh
+++ b/platform/nats-jetstream/chart/tests/kyverno-resource-requests.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# #4343 — assert EVERY workload container in the rendered bp-nats-jetstream
+# manifests declares resources.requests.cpu AND resources.requests.memory, so
+# the cluster-wide Kyverno `resource-requests` Enforce ClusterPolicy admits
+# every Pod/Deployment/StatefulSet/DaemonSet/Job/CronJob.
+#
+# After #4325 this chart installs into a NATIVE host namespace (not a vCluster)
+# where the host Kyverno Enforce policies apply. TWO inert-knob bugs surfaced:
+#   - the nats 1.2.0 chart's loadMergePatch helper reads ONLY `.merge`/`.patch`,
+#     so the prior `nats.container.resources` block was silently dropped and the
+#     server container (plus the reloader + nats-box sidecars) shipped with NO
+#     requests;
+#   - the nack 0.29.0 controller reads top-level `resources`, not
+#     `jetstream.resources`, so the `jsc` container shipped with NO requests.
+# Both classes were DENIED. This test guards the regression.
+set -euo pipefail
+chart_dir="${1:-$(dirname "$0")/..}"
+cd "$chart_dir"
+chart_dir="$(pwd)"
+
+if ! ls charts/*.tgz >/dev/null 2>&1; then
+  helm dependency build "$chart_dir" >/dev/null 2>&1 || true
+fi
+
+assert_py="$chart_dir/tests/_assert_resource_requests.py"
+
+assert_requests() {
+  local label="$1"; shift
+  local out rc
+  out=$(helm template t . "$@" 2>/dev/null | python3 "$assert_py")
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "FAIL [$label]:"
+    echo "$out" | sed 's/^/  /'
+    return 1
+  fi
+  echo "PASS [$label]: $out"
+}
+
+fail=0
+assert_requests "default" || fail=1
+
+if [ "$fail" -ne 0 ]; then
+  echo "kyverno-resource-requests: one or more workload containers lack resources.requests (would be DENIED by the host-ns Kyverno resource-requests Enforce policy)."
+  exit 1
+fi
+echo "kyverno-resource-requests: all workload containers declare cpu+memory requests."

--- a/platform/nats-jetstream/chart/values.yaml
+++ b/platform/nats-jetstream/chart/values.yaml
@@ -33,9 +33,38 @@ nats:
         pvc:
           size: 10Gi
   container:
-    resources:
-      requests: { cpu: 100m, memory: 256Mi }
-      limits: { memory: 1Gi }
+    # #4343 — the vendored nats 1.2.0 chart renders each container via the
+    # file-based `loadMergePatch` helper, which consumes ONLY `.merge` (and
+    # `.patch`) — NOT the top-level container dict. A bare `container.resources`
+    # is therefore SILENTLY DROPPED and the nats server container rendered with
+    # NO resources.requests. Pre-#4325 this chart ran INSIDE a vCluster where
+    # the host's Kyverno `resource-requests` Enforce ClusterPolicy didn't reach
+    # it, masking the gap; after the de-vcluster migration it installs into the
+    # native host namespace and the StatefulSet admission is DENIED. Resources
+    # MUST live under `container.merge.resources` to actually reach the pod.
+    merge:
+      resources:
+        requests: { cpu: 100m, memory: 256Mi }
+        limits: { memory: 1Gi }
+  # #4343 — the config-reloader sidecar (upstream default `reloader.enabled:
+  # true`) shares the StatefulSet pod and its base container template ships NO
+  # resources. Set them via the same `merge` knob so the sidecar carries
+  # requests.
+  reloader:
+    merge:
+      resources:
+        requests: { cpu: 10m, memory: 16Mi }
+        limits: { memory: 64Mi }
+  # #4343 — the nats-box utility Deployment (upstream default `natsBox.enabled:
+  # true`) is a separate workload whose base container template ships NO
+  # resources. Set them via `natsBox.container.merge` so its single container
+  # carries requests.
+  natsBox:
+    container:
+      merge:
+        resources:
+          requests: { cpu: 10m, memory: 32Mi }
+          limits: { memory: 64Mi }
   # Prometheus exporter + PodMonitor — DEFAULT OFF.
   #
   # Per docs/INVIOLABLE-PRINCIPLES.md #4 and docs/BLUEPRINT-AUTHORING.md
@@ -134,6 +163,19 @@ catalystStreams:
 # release namespace (nats-system). Watch namespace empty = cluster-wide.
 nack:
   enabled: true
+  # #4343 — the nack 0.29.0 jetstream-controller container reads its resources
+  # from the TOP-LEVEL `resources` key (`{{- with .Values.resources }}` in
+  # deployment-jetstream-controller.yml), NOT `jetstream.resources` — the
+  # latter is inert in this chart version. Setting it here is what actually
+  # gives the `jsc` container requests, so it clears the host-ns Kyverno
+  # `resource-requests` Enforce policy (post-#4325). Modest controller request.
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
   jetstream:
     # Point at the broker subchart's Service. Same-namespace, no auth
     # required (NATS auth is operator-config'd separately if at all).
@@ -142,13 +184,6 @@ nack:
     # Modest defaults at solo-Sovereign scale. Bump replicas via overlay
     # when HA is sized.
     replicas: 1
-    resources:
-      requests:
-        cpu: 50m
-        memory: 64Mi
-      limits:
-        cpu: 200m
-        memory: 256Mi
   # No webhook or PodMonitor for the controller in our solo profile.
   podMonitor:
     enabled: false

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.52  # lockstep with chart/Chart.yaml (#3888 prov-time openbao KV-seed mechanism for evicting inline cloud-init Secrets to Flux ExternalSecrets)
+  version: 1.2.53  # lockstep with chart/Chart.yaml (#4343 injector.resources.requests for host-ns Kyverno resource-requests Enforce)
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -1,5 +1,10 @@
 apiVersion: v2
 name: bp-openbao
+# 1.2.53 (#4343, 2026-06-25): set `injector.resources.requests` (cpu/memory)
+# so the agent-injector Deployment satisfies the cluster-wide Kyverno
+# `resource-requests` Enforce policy. Post-#4325 this chart installs into the
+# native host namespace (not a vCluster) where the policy applies; the
+# upstream injector defaults to empty resources → InstallFailed without this.
 # 1.2.26 (#3150, 2026-06-09): two sso-configure-deployment.yaml fixes that
 # together defeated openbao silent SSO.
 #   (a) BAO_ADDR hardcoded `<release>-openbao` → with spec.releaseName=openbao
@@ -167,7 +172,7 @@ name: bp-openbao
 # Both default-OFF for host-side openbao (XCR off) → byte-identical render.
 # Verified GREEN live hw167 2026-06-19: bao.<fqdn>/ui/ → /sso/landing → lands
 # /ui/vault/secrets (sso-zero-click-probe openbao row GREEN). Pin in lockstep.
-version: 1.2.52
+version: 1.2.53
 # 1.2.51 (#3888, Refs #3847): prov-time openbao KV-seed mechanism — the
 # auth-bootstrap Job reads a one-shot cloud-init `openbao-bootstrap-seed`
 # Secret + writes its keys into KV at secret/<prefix>/* with the still-valid

--- a/platform/openbao/chart/tests/_assert_resource_requests.py
+++ b/platform/openbao/chart/tests/_assert_resource_requests.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# #4343 helper — read a multi-doc helm render from stdin and assert every
+# workload container (Deployment/StatefulSet/DaemonSet/Job/CronJob, incl.
+# initContainers) declares resources.requests.cpu AND resources.requests.memory
+# (the exact shape the Kyverno `resource-requests` Enforce ClusterPolicy
+# requires). Prints a one-line OK summary on success; prints the offending
+# kind/name:container lines and exits 1 on any miss.
+import sys, re
+try:
+    import yaml
+except ImportError:
+    print("PyYAML not available; cannot run resource-requests assertion", file=sys.stderr)
+    sys.exit(2)
+
+raw = sys.stdin.read()
+# Some upstream subchart templates emit stray trailing whitespace/tabs that
+# break a strict YAML scan; rstrip each line (cosmetic, render-neutral).
+raw = "\n".join(line.rstrip() for line in raw.splitlines())
+
+bad = []
+checked = 0
+for chunk in re.split(r"(?m)^---\s*$", raw):
+    chunk = chunk.strip()
+    if not chunk:
+        continue
+    try:
+        d = yaml.safe_load(chunk)
+    except Exception:
+        continue
+    if not isinstance(d, dict):
+        continue
+    kind = d.get("kind")
+    if kind not in ("Deployment", "StatefulSet", "DaemonSet", "Job", "CronJob"):
+        continue
+    name = d.get("metadata", {}).get("name", "<noname>")
+    try:
+        if kind == "CronJob":
+            podspec = d["spec"]["jobTemplate"]["spec"]["template"]["spec"]
+        else:
+            podspec = d["spec"]["template"]["spec"]
+    except (KeyError, TypeError):
+        continue
+    containers = list(podspec.get("containers", []) or []) + list(podspec.get("initContainers", []) or [])
+    for c in containers:
+        checked += 1
+        req = (c.get("resources") or {}).get("requests") or {}
+        if "cpu" not in req or "memory" not in req:
+            bad.append("%s/%s container=%s requests=%s" % (kind, name, c.get("name"), dict(req)))
+
+if bad:
+    print("workload containers MISSING cpu+memory requests:")
+    for b in bad:
+        print(b)
+    sys.exit(1)
+
+if checked == 0:
+    print("no workload containers rendered — subchart deps not built? (run `helm dependency build`)")
+    sys.exit(1)
+
+print("%d workload container(s) all declare cpu+memory requests" % checked)

--- a/platform/openbao/chart/tests/kyverno-resource-requests.sh
+++ b/platform/openbao/chart/tests/kyverno-resource-requests.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# #4343 — assert EVERY workload container in the rendered bp-openbao manifests
+# declares resources.requests.cpu AND resources.requests.memory, so the
+# cluster-wide Kyverno `resource-requests` Enforce ClusterPolicy admits every
+# Pod/Deployment/StatefulSet/DaemonSet/Job/CronJob.
+#
+# After #4325 the platform planes install into NATIVE host namespaces (not a
+# vCluster), where the host Kyverno Enforce policies apply. The upstream
+# openbao subchart defaults `injector.resources: {}` (empty) → the
+# agent-injector Deployment shipped with NO requests → DENIED → bp-openbao
+# InstallFailed → wedged bp-external-secrets-stores → bp-sso-bridge. This test
+# guards that regression: it FAILS if any rendered workload container lacks
+# cpu+memory requests.
+set -euo pipefail
+# CI invokes `bash <script> <chart_dir>`; fall back to the script's own dir.
+chart_dir="${1:-$(dirname "$0")/..}"
+cd "$chart_dir"
+chart_dir="$(pwd)"
+
+# The upstream subchart is vendored under charts/*.tgz (gitignored, rebuilt
+# from Chart.lock). CI runs `helm dependency build` before tests, but build it
+# here too so the test is runnable standalone.
+if ! ls charts/*.tgz >/dev/null 2>&1; then
+  helm dependency build "$chart_dir" >/dev/null 2>&1 || true
+fi
+
+assert_py="$chart_dir/tests/_assert_resource_requests.py"
+
+assert_requests() {
+  local label="$1"; shift
+  local out rc
+  out=$(helm template t . --set gateway.host=bao.example.test "$@" 2>/dev/null | python3 "$assert_py")
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "FAIL [$label]:"
+    echo "$out" | sed 's/^/  /'
+    return 1
+  fi
+  echo "PASS [$label]: $out"
+}
+
+fail=0
+assert_requests "default" || fail=1
+
+if [ "$fail" -ne 0 ]; then
+  echo "kyverno-resource-requests: one or more workload containers lack resources.requests (would be DENIED by the host-ns Kyverno resource-requests Enforce policy)."
+  exit 1
+fi
+echo "kyverno-resource-requests: all workload containers declare cpu+memory requests."

--- a/platform/openbao/chart/values.yaml
+++ b/platform/openbao/chart/values.yaml
@@ -50,6 +50,21 @@ openbao:
   injector:
     metrics:
       enabled: false
+    # #4343 — the agent-injector Deployment MUST declare resources.requests.
+    # The upstream subchart defaults `injector.resources: {}` (empty), so the
+    # injector container renders with NO requests. Pre-#4325 this chart ran
+    # INSIDE a vCluster where the host's Kyverno `resource-requests` Enforce
+    # ClusterPolicy didn't reach it; after the de-vcluster migration it
+    # installs into the native host namespace and the first
+    # `Deployment/openbao-agent-injector` admission is DENIED
+    # (`requests-workload: Every container must declare resources.requests.cpu
+    # and resources.requests.memory`), timing out the Helm install →
+    # bp-openbao InstallFailed → wedges bp-external-secrets-stores →
+    # bp-sso-bridge. Modest sidecar request (the injector is a lightweight
+    # mutating-webhook controller).
+    resources:
+      requests: { cpu: 50m, memory: 64Mi }
+      limits: { memory: 128Mi }
     # #3375 — proxy-glob the agent-injector images through the Sovereign's
     # local Harbor so the kyverno `harbor-proxy-pull` Enforce policy admits
     # them. The upstream subchart defaults the injector to


### PR DESCRIPTION
## Problem

The #4325 de-vcluster change moved the platform planes (mgmt/rtz/dmz) from inside vClusters into **native host namespaces**, where the cluster-wide Kyverno `resource-requests` Enforce ClusterPolicy applies. Several plane chart containers ship with **no `resources.requests`** and are denied at admission:

```
admission webhook "validate.kyverno.svc-fail" denied the request:
resource Deployment/openbao/openbao-agent-injector was blocked due to policy resource-requests:
  requests-workload: Every container must declare resources.requests.cpu and resources.requests.memory
```

Confirmed live on `bp-openbao` (agent-injector) + `bp-harbor` (harbor-nginx); the issue also lists loki/mimir/nats. This wedges `bp-openbao` → `bp-external-secrets-stores` → `bp-sso-bridge` and keeps the LGTM observability stack down.

## Fix

Requests set via each chart's canonical values knob (modest, right-sized for platform sidecars). Two **latent inert-knob bugs** the host-ns migration exposed are fixed in passing:

- **bp-nats-jetstream** set `nats.container.resources`, but the nats 1.2.0 `loadMergePatch` helper reads only `.merge`/`.patch` — the block was silently dropped, so the server + reloader + nats-box containers rendered with no requests. Moved to `container.merge.resources` (+ `reloader.merge`, `natsBox.container.merge`). The nack 0.29.0 controller reads top-level `resources`, not `jetstream.resources` (also inert) — moved so the `jsc` container gets requests.

### Per-component requests added

| Chart | bump | container(s) fixed | request |
|---|---|---|---|
| bp-openbao | 1.2.52 → 1.2.53 | agent-injector (`injector.resources`) | 50m / 64Mi |
| bp-harbor | 1.2.37 → 1.2.38 | harbor-nginx (`nginx.resources`) | 50m / 64Mi |
| bp-loki | 1.0.0 → 1.0.1 | loki-sc-rules (`loki.sidecar.resources`) | 10m / 32Mi |
| bp-mimir | 1.0.5 → 1.0.6 | gateway (`gateway.resources`) 10m/32Mi; MinIO server + make-bucket/user/policy Jobs + smoke-test hook (added cpu) | — |
| bp-nats-jetstream | 1.3.3 → 1.3.4 | nats server / reloader / nats-box (`container.merge.resources`); nack `jsc` (top-level `resources`) | 50m/64Mi |

Chart.yaml + blueprint.yaml + bootstrap-kit slot pins bumped in **lockstep** per chart.

## Verification

`helm template` of each chart (with vendored subcharts) renders **36 workload containers across the 5 charts, every one carrying `resources.requests.{cpu,memory}` — 0 offenders**. Each chart ships a new `chart/tests/kyverno-resource-requests.sh` (already a CI gate via `blueprint-release.yaml`) that asserts this, **negative-tested** to fail (`exit 1`, pinpointing the offending container) when a fix is reverted.

So the affected HRs would now pass the Kyverno `resource-requests` Enforce policy on a host-ns install. READ-ONLY on live — no cluster mutation in this PR.

Refs #4343 #4325