### PR TITLE
fix(bp-keycloak #4344): stable admin-password across reinstall + de-vcluster re-home

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -216,7 +216,17 @@ spec:
       #         harbor-proxy-pull. Chart content byte-identical to 1.4.38.
       # 1.5.3 — #4212 Seam 3: placementSchema aligned with spec.topology
       #   (modes[] admit active-hot-standby + defaultOnMultiRegion). Chart bumped in lockstep.
-      version: 1.5.3
+      # 1.5.4 — #4344 (Refs #4325 #4340): STABLE master-realm admin password. The
+      #   #4325 de-vcluster re-homed keycloak into the host `keycloak` ns with a
+      #   FRESH helm install → the bitnami subchart regenerated the admin-password
+      #   while the keycloak DB persisted → keycloak-config-cli HTTP 401 → realm
+      #   import never ran → bp-keycloak HR not-Ready → bp-gitea/bp-catalyst-platform
+      #   wedged. New templates/admin-credentials.yaml materialises a stable
+      #   `keycloak-admin` Secret (lookup-or-generate + resource-policy: keep) and
+      #   values.yaml wires keycloak.auth.existingSecret=keycloak-admin so the
+      #   password is reused (never regenerated) across reinstall + re-home. Chart
+      #   + blueprint bumped in lockstep.
+      version: 1.5.4
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1101,7 +1101,12 @@ spec:
       #   (application/organization/environment controllers) + adds the missing
       #   catalogSovereign secretRef values block + flips the env-controller's
       #   phantom gitea-flux-token default. Chart.yaml bumped in lockstep.
-      version: 1.4.844
+      # 1.4.845 — #4344 (Refs #4325 #4340): keycloak-credentials host-bridge sources
+      #   the master-realm admin password from the stable host `keycloak/keycloak-admin`
+      #   Secret (bp-keycloak 1.5.4) FIRST, fixing the empty master-realm-admin-password
+      #   the bridge emitted after the #4325 de-vcluster re-homed keycloak host-side.
+      #   Chart.yaml bumped in lockstep.
+      version: 1.4.845
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.5.3
+  version: 1.5.4
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for Organizations, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -1,5 +1,27 @@
 apiVersion: v2
 name: bp-keycloak
+# 1.5.4 (#4344, Refs #4325 #4340, 2026-06-25): STABLE master-realm admin
+# password across HR re-install + topology re-home. The #4325 de-vcluster
+# moved keycloak from the mgmt vCluster into the host `keycloak` namespace
+# and did a FRESH helm install there; the bitnami subchart's
+# `common.secrets.passwords.manage` regenerated a fresh random admin-password
+# (no prior `keycloak` Secret in the brand-new namespace) while the keycloak
+# DB PERSISTS (external CNPG, days old). Keycloak only honours
+# KC_BOOTSTRAP_ADMIN_PASSWORD on an EMPTY-DB first boot, so the master `admin`
+# user kept its ORIGINAL password → keycloak-config-cli got HTTP 401
+# invalid_user_credentials → the sovereign-realm import never ran → bp-keycloak
+# HR never Ready → bp-gitea (gitea-http NXDOMAIN) → every Org GiteaOrgFailed →
+# bp-catalyst-platform never rolled (#4340 org-controller blocked). Root-caused
+# live omantel.biz kom4dc dep 4635277cae4ffed9. Durable fix (mirrors the 1.4.8
+# postgresql-credentials defense): new templates/admin-credentials.yaml
+# materialises a `keycloak-admin` Secret via lookup-or-generate +
+# helm.sh/resource-policy: keep, and values.yaml wires the bitnami subchart at
+# it (keycloak.auth.existingSecret=keycloak-admin + passwordSecretKey=
+# admin-password). BOTH the StatefulSet's KC_BOOTSTRAP_ADMIN_PASSWORD and
+# keycloak-config-cli's KEYCLOAK_PASSWORD read that one stable Secret, so the
+# password can never regenerate or diverge across reinstall/re-home. The
+# master-admin-credentials emission now sources from `keycloak-admin` too. New
+# chart test tests/admin-password-stable.sh locks all of it. Refs #4344 #4325 #4340.
 # 1.4.21 (#3150, 2026-06-09): federated user must inherit ZERO Keycloak
 # required actions on EVERY path. The sovereign realm is passwordless (every
 # user authenticates only through the catalyst-pin OIDC broker) but a fresh
@@ -403,7 +425,7 @@ name: bp-keycloak
 # images pass admission. No chart-content change beyond the version line + this
 # changelog — the 1.4.38 templates/values are byte-identical and already
 # proxy-compliant. Refs #3785 (sibling proxy-class defect for the WP image).
-version: 1.5.3
+version: 1.5.4
 description: |
   1.5.2 (#4246): the per-tenant `openclaw-oidc-client-secret` Secret now
   emits BOTH `client-secret` AND `OIDC_CLIENT_SECRET` keys (it previously

--- a/platform/keycloak/chart/templates/admin-credentials.yaml
+++ b/platform/keycloak/chart/templates/admin-credentials.yaml
@@ -1,0 +1,116 @@
+{{/*
+#4344 Defense fix — STABLE Keycloak master-realm `admin` password across
+HR re-installs AND across topology moves (de-vcluster: host ns ↔ vCluster ns).
+
+WHY THIS FILE EXISTS
+====================
+The bitnami keycloak subchart manages its `admin-password` Secret (named
+`keycloak`, the subchart fullname) via `common.secrets.passwords.manage`,
+which does a `lookup` of an EXISTING same-named Secret IN THE INSTALL
+NAMESPACE and reuses it, OR generates a fresh `randAlphaNum` when none is
+present. Keycloak only honours `KC_BOOTSTRAP_ADMIN_PASSWORD` on an EMPTY-DB
+first boot; against a PRE-EXISTING database the master-realm `admin` user
+keeps its ORIGINAL password.
+
+#4325 (de-vcluster) moved keycloak OUT of the `mgmt` vCluster INTO the host
+`keycloak` namespace and did a FRESH helm install there — while the keycloak
+database PERSISTS (external CNPG, `shared-pg-mesh-rw`, days old). The host
+`keycloak` namespace had NO prior `keycloak` Secret (the old one lived inside
+vc-mgmt), so `passwords.manage` regenerated a brand-new random admin-password
+that does NOT match the password baked into the persistent DB. Result
+(root-caused live, omantel.biz kom4dc dep 4635277cae4ffed9, 2026-06-25):
+
+  • keycloak-0 Ready 1/1 + serving, but logs spam
+    `type=LOGIN_ERROR error=invalid_user_credentials username=admin`.
+  • keycloak-config-cli reads KEYCLOAK_PASSWORD from the SAME `keycloak`
+    Secret → HTTP 401 Unauthorized → "Could not connect to keycloak in 300
+    seconds" → the sovereign-realm import (sovereign-realm.json) NEVER runs
+    → bp-keycloak HR never Ready → bp-gitea (gitea-http NXDOMAIN) → every
+    Org reconcile GiteaOrgFailed → bp-catalyst-platform never rolls →
+    org-controller stuck. The entire downstream chain wedged.
+
+THE FIX
+=======
+Materialise a parent-chart-owned `keycloak-admin` Secret (key
+`admin-password`) with the SAME lookup-or-generate + `helm.sh/resource-policy:
+keep` pattern templates/postgresql-credentials.yaml uses for the postgres
+password, then wire the bitnami subchart at it via:
+  keycloak.auth.existingSecret:    keycloak-admin
+  keycloak.auth.passwordSecretKey: admin-password
+(both set in values.yaml). When `auth.existingSecret` is set the subchart
+SKIPS creating its own `keycloak` Secret and reads the admin password from
+THIS Secret — so BOTH consumers stay in lockstep:
+  • the StatefulSet's KC_BOOTSTRAP_ADMIN_PASSWORD (keycloak.secretName/Key)
+  • keycloak-config-cli's KEYCLOAK_PASSWORD (keycloak-config-cli-job.yaml,
+    same keycloak.secretName/Key helper).
+
+Because this Secret carries `helm.sh/resource-policy: keep`, it SURVIVES a
+helm uninstall/reinstall AND a namespace re-home — once the value is fixed it
+NEVER re-randomises, so the regenerate-vs-persistent-DB mismatch can never
+recur on this or any future topology move. This is the EXACT defense
+templates/postgresql-credentials.yaml already applies to the postgres
+password (the consistent (data, credential) pair invariant); the admin
+password was the remaining gap.
+
+LOOKUP CHAIN (highest priority first)
+=====================================
+  1. .Values.keycloakAdminPasswordOverride — operator-supplied (sealed-secret
+     / external replication). Same knob the master-admin Secret already honours.
+  2. existing `keycloak-admin` Secret in the release namespace — the steady
+     state after first install (resource-policy: keep persists it).
+  3. existing bitnami `keycloak` Secret's `admin-password` — MIGRATION
+     CONTINUITY: on the FIRST reconcile that introduces this template into a
+     namespace where the bitnami subchart had already created its own
+     `keycloak` Secret (i.e. a topology where the admin password was already
+     in sync with the DB), adopt THAT value verbatim so we don't rotate a
+     working credential. (Does NOT help the broken de-vcluster case where the
+     bitnami value is the WRONG regenerated one — that path is repaired live
+     per the #4344 runbook by re-syncing the DB admin to this stable value.)
+  4. fresh randAlphaNum 32 — zero-touch first install on an empty DB
+     (KC_BOOTSTRAP_ADMIN_PASSWORD seeds the empty DB with this value).
+
+Per INVIOLABLE-PRINCIPLES #4 the override knob + the admin user are
+operator-overridable; per #10 no plaintext credential is committed — the
+value is computed at render time and only lands in the Secret bytes.
+*/}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace "keycloak-admin" -}}
+{{- $bitnami := lookup "v1" "Secret" .Release.Namespace "keycloak" -}}
+{{- $adminPassword := "" -}}
+{{- if .Values.keycloakAdminPasswordOverride -}}
+  {{- $adminPassword = .Values.keycloakAdminPasswordOverride -}}
+{{- else if and $existing $existing.data (index $existing.data "admin-password") -}}
+  {{- $adminPassword = index $existing.data "admin-password" | b64dec -}}
+{{- else if and $bitnami $bitnami.data (index $bitnami.data "admin-password") -}}
+  {{- $adminPassword = index $bitnami.data "admin-password" | b64dec -}}
+{{- else -}}
+  {{- $adminPassword = randAlphaNum 32 -}}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-admin
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    # `helm.sh/resource-policy: keep` — helm uninstall must NEVER drop this
+    # Secret. The keycloak DATABASE (external CNPG, or the bundled postgres
+    # STS volumeClaimTemplate PVC) persists across uninstall, so the
+    # master-realm admin password MUST persist alongside it. Together they
+    # form a consistent (data, credential) pair across the full install /
+    # uninstall / re-install / re-home lifecycle (#4344).
+    helm.sh/resource-policy: keep
+    catalyst.openova.io/comment: |
+      Stable Keycloak master-realm admin password (#4344). Wired into the
+      bitnami subchart via keycloak.auth.existingSecret=keycloak-admin so a
+      reinstall against a persistent DB keeps the SAME password — never
+      regenerated. Consumed by both the keycloak StatefulSet
+      (KC_BOOTSTRAP_ADMIN_PASSWORD) and keycloak-config-cli (KEYCLOAK_PASSWORD).
+  labels:
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/part-of: keycloak
+    app.kubernetes.io/managed-by: flux
+    catalyst.openova.io/component: keycloak-admin-credentials
+type: Opaque
+stringData:
+  admin-password: {{ $adminPassword | quote }}

--- a/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
@@ -1352,9 +1352,21 @@ stringData:
 {{- if .Values.keycloakAdminPasswordOverride -}}
   {{- $masterAdminPassword = .Values.keycloakAdminPasswordOverride -}}
 {{- else -}}
-  {{- $bitnamiAdmin := lookup "v1" "Secret" .Release.Namespace "keycloak" -}}
-  {{- if $bitnamiAdmin -}}
-    {{- $masterAdminPassword = index $bitnamiAdmin.data "admin-password" | b64dec -}}
+  {{- /* #4344: source the admin password from the STABLE parent-chart
+         `keycloak-admin` Secret (templates/admin-credentials.yaml) that the
+         bitnami subchart now reads via keycloak.auth.existingSecret. With
+         existingSecret set the subchart no longer creates its own `keycloak`
+         Secret, so the legacy bitnami lookup would always miss. Fall back to
+         the bitnami `keycloak` Secret for back-compat on any older topology
+         where existingSecret was unset and the subchart owned the Secret. */ -}}
+  {{- $stableAdmin := lookup "v1" "Secret" .Release.Namespace "keycloak-admin" -}}
+  {{- if and $stableAdmin $stableAdmin.data (index $stableAdmin.data "admin-password") -}}
+    {{- $masterAdminPassword = index $stableAdmin.data "admin-password" | b64dec -}}
+  {{- else -}}
+    {{- $bitnamiAdmin := lookup "v1" "Secret" .Release.Namespace "keycloak" -}}
+    {{- if and $bitnamiAdmin $bitnamiAdmin.data (index $bitnamiAdmin.data "admin-password") -}}
+      {{- $masterAdminPassword = index $bitnamiAdmin.data "admin-password" | b64dec -}}
+    {{- end -}}
   {{- end -}}
 {{- end }}
 apiVersion: v1

--- a/platform/keycloak/chart/tests/admin-password-stable.sh
+++ b/platform/keycloak/chart/tests/admin-password-stable.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# #4344 — bp-keycloak STABLE admin password defense.
+#
+# The #4325 de-vcluster moved keycloak from the mgmt vCluster into the host
+# `keycloak` namespace and did a FRESH helm install. The bitnami subchart's
+# `common.secrets.passwords.manage` regenerated a fresh random admin-password
+# (no prior `keycloak` Secret in the new namespace) while the keycloak DB
+# PERSISTS → keycloak-config-cli got HTTP 401 → realm import never ran →
+# bp-keycloak HR never Ready → bp-gitea / bp-catalyst-platform wedged.
+#
+# This test asserts the durable fix:
+#   1. The chart materialises a `keycloak-admin` Secret with key admin-password.
+#   2. That Secret carries `helm.sh/resource-policy: keep` so a helm uninstall
+#      NEVER drops it → the password is STABLE across reinstall + re-home.
+#   3. The bitnami subchart is wired at it (keycloak.auth.existingSecret=
+#      keycloak-admin) so it does NOT create its own `keycloak` Secret and
+#      does NOT regenerate the password.
+#   4. keycloak-config-cli's KEYCLOAK_PASSWORD reads from `keycloak-admin`
+#      (so the config-cli credential MATCHES what the StatefulSet boots with).
+#   5. The StatefulSet's admin-password file is projected from `keycloak-admin`
+#      (so KC_BOOTSTRAP_ADMIN_PASSWORD_FILE and config-cli stay in lockstep).
+#   6. .Values.keycloakAdminPasswordOverride is the highest-priority source
+#      (sealed-secret / external replication) — stable by construction.
+set -euo pipefail
+
+CHART_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$CHART_DIR"
+
+COMMON_ARGS=(--set sovereignFQDN=hw00.omani.works --set gateway.host=auth.hw00.omani.works)
+
+render() {
+  helm template kc-stable "$CHART_DIR" "${COMMON_ARGS[@]}" "$@" 2>/dev/null
+}
+
+echo "=== #4344 admin-password-stable tests ==="
+
+OUT="$(render)"
+
+# Test 1: keycloak-admin Secret exists with an admin-password key
+PW="$(echo "$OUT" | yq 'select(.kind=="Secret" and .metadata.name=="keycloak-admin") | .stringData["admin-password"]')"
+if [ -z "$PW" ] || [ "$PW" = "null" ]; then
+  echo "FAIL 1: keycloak-admin Secret missing or empty admin-password"
+  exit 1
+fi
+echo "PASS 1: keycloak-admin Secret renders admin-password (${PW:0:6}...)"
+
+# Test 2: resource-policy: keep so the password persists across uninstall
+KEEP="$(echo "$OUT" | yq 'select(.kind=="Secret" and .metadata.name=="keycloak-admin") | .metadata.annotations["helm.sh/resource-policy"]')"
+if [ "$KEEP" != "keep" ]; then
+  echo "FAIL 2: keycloak-admin Secret lacks helm.sh/resource-policy: keep (got '$KEEP') — password would NOT be stable across reinstall"
+  exit 1
+fi
+echo "PASS 2: keycloak-admin carries resource-policy: keep (stable across reinstall/re-home)"
+
+# Test 3: bitnami subchart wired at keycloak-admin → does NOT mint its own
+# `keycloak` Secret (which would re-randomize on a fresh-namespace install).
+BITNAMI_SECRET="$(echo "$OUT" | yq 'select(.kind=="Secret" and .metadata.name=="keycloak") | .metadata.name' | head -1)"
+if [ -n "$BITNAMI_SECRET" ] && [ "$BITNAMI_SECRET" != "null" ]; then
+  echo "FAIL 3: bitnami subchart still mints its own 'keycloak' Secret — auth.existingSecret not wired, password will regenerate"
+  exit 1
+fi
+echo "PASS 3: bitnami subchart does NOT mint its own keycloak Secret (existingSecret wired)"
+
+# Test 4: keycloak-config-cli reads KEYCLOAK_PASSWORD from keycloak-admin
+CFG_SECRET="$(echo "$OUT" | yq 'select(.kind=="Job") | .spec.template.spec.containers[].env[] | select(.name=="KEYCLOAK_PASSWORD") | .valueFrom.secretKeyRef.name')"
+CFG_KEY="$(echo "$OUT" | yq 'select(.kind=="Job") | .spec.template.spec.containers[].env[] | select(.name=="KEYCLOAK_PASSWORD") | .valueFrom.secretKeyRef.key')"
+if [ "$CFG_SECRET" != "keycloak-admin" ] || [ "$CFG_KEY" != "admin-password" ]; then
+  echo "FAIL 4: keycloak-config-cli KEYCLOAK_PASSWORD reads $CFG_SECRET/$CFG_KEY, expected keycloak-admin/admin-password"
+  exit 1
+fi
+echo "PASS 4: keycloak-config-cli KEYCLOAK_PASSWORD := keycloak-admin/admin-password"
+
+# Test 5: the StatefulSet projects the admin-password from keycloak-admin
+PROJECTED="$(echo "$OUT" | yq 'select(.kind=="StatefulSet") | .spec.template.spec.volumes[] | select(.name=="keycloak-secrets") | .projected.sources[].secret.name' | grep -x "keycloak-admin" || true)"
+if [ "$PROJECTED" != "keycloak-admin" ]; then
+  echo "FAIL 5: StatefulSet keycloak-secrets volume does NOT project keycloak-admin — KC_BOOTSTRAP_ADMIN_PASSWORD_FILE would diverge from config-cli"
+  exit 1
+fi
+echo "PASS 5: StatefulSet projects admin-password from keycloak-admin (lockstep with config-cli)"
+
+# Test 6: operator override is the highest-priority, stable source
+OVR_OUT="$(render --set keycloakAdminPasswordOverride=Operator-Pinned-Pw-4344)"
+OVR_PW="$(echo "$OVR_OUT" | yq 'select(.kind=="Secret" and .metadata.name=="keycloak-admin") | .stringData["admin-password"]')"
+if [ "$OVR_PW" != "Operator-Pinned-Pw-4344" ]; then
+  echo "FAIL 6: keycloakAdminPasswordOverride did not pin the admin-password (got '$OVR_PW')"
+  exit 1
+fi
+echo "PASS 6: keycloakAdminPasswordOverride pins the admin-password (sealed-secret/external replication path)"
+
+echo "=== ALL TESTS PASS ==="

--- a/platform/keycloak/chart/values.yaml
+++ b/platform/keycloak/chart/values.yaml
@@ -124,6 +124,16 @@ sovereignRealm:
 # value here.
 catalystApiServerClientSecret: ""
 
+# keycloakAdminPasswordOverride: operator-supplied master-realm `admin`
+# password (#2914 / #4344). When set it is the highest-priority source for
+# BOTH the parent-chart `keycloak-admin` Secret (templates/admin-credentials.yaml,
+# wired into the bitnami subchart via keycloak.auth.existingSecret) AND the
+# catalyst-kc-master-admin-credentials Secret bp-sso-bridge consumes. Leave
+# empty for self-bootstrap (lookup-or-generate). Set only when replicating a
+# known admin password from a sealed-secret / external store. Per
+# INVIOLABLE-PRINCIPLES #10 NEVER commit a real value here.
+keycloakAdminPasswordOverride: ""
+
 # ─── SMTP for outbound realm email (welcome / password-reset) (issue #604) ─
 #
 # Pre-handover default: contabo Stalwart relay (cluster-internal FQDN, reachable
@@ -296,6 +306,28 @@ keycloak:
     app.kubernetes.io/managed-by: flux
   auth:
     adminUser: admin
+    # ─── Stable admin password (#4344) ─────────────────────────────────────
+    # Point the bitnami subchart at the parent-chart-owned `keycloak-admin`
+    # Secret (templates/admin-credentials.yaml, lookup-or-generate +
+    # helm.sh/resource-policy: keep) instead of letting the subchart manage
+    # its own `keycloak` Secret. The subchart's `common.secrets.passwords.
+    # manage` regenerates a FRESH random admin-password whenever no prior
+    # same-named Secret exists IN THE INSTALL NAMESPACE — which is exactly
+    # what happens on a topology re-home (the #4325 de-vcluster moved keycloak
+    # from the `mgmt` vCluster into the host `keycloak` ns: brand-new ns, no
+    # prior Secret, fresh random password). Keycloak only honours
+    # KC_BOOTSTRAP_ADMIN_PASSWORD on an EMPTY-DB first boot, so against the
+    # PERSISTENT keycloak DB the master `admin` user kept its ORIGINAL
+    # password → keycloak-config-cli got HTTP 401 → realm import never ran →
+    # bp-keycloak HR never Ready → bp-gitea/bp-catalyst-platform wedged
+    # (#4344, root-caused live omantel.biz kom4dc 2026-06-25). With the
+    # existingSecret pinned to a `keep`-annotated parent Secret the password
+    # is STABLE across reinstall + re-home and can never regenerate.
+    # BOTH the StatefulSet's KC_BOOTSTRAP_ADMIN_PASSWORD and
+    # keycloak-config-cli's KEYCLOAK_PASSWORD read keycloak.secretName/
+    # secretKey → this same Secret, so they stay in lockstep.
+    existingSecret: "keycloak-admin"
+    passwordSecretKey: "admin-password"
   production: true
   # Chart 25.x renamed `proxy: edge` to `proxyHeaders: "xforwarded"`. Catalyst
   # fronts Keycloak with Cilium Gateway (which sets `X-Forwarded-*`), and we

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3083,7 +3083,18 @@ name: bp-catalyst-platform
 #   every secret name stays operator-overridable; external ghcr/upstream sources are
 #   untouched (the guard applies only to the local-Gitea/Harbor host). Clean version tag
 #   forces the Flux re-pull (deploy-bot mutable-tag trap).
-version: 1.4.844
+# 1.4.845 — #4344 (Refs #4325 #4340): the keycloak-credentials host-bridge
+#   (templates/catalyst-keycloak-credentials-host-bridge.yaml) now sources the
+#   master-realm admin password from the STABLE host `keycloak/keycloak-admin`
+#   Secret (minted by bp-keycloak 1.5.4) FIRST, falling back to the legacy
+#   vCluster-syncer-mangled `keycloak-x-keycloak-x-mgmt-vcluster`/`mgmt` lookup
+#   for back-compat. After the #4325 de-vcluster re-homed keycloak into the host
+#   `keycloak` ns, that vCluster-mangled secret no longer exists host-side, so
+#   the bridge was emitting an EMPTY master-realm-admin-password (the seam the
+#   #4344 issue flagged) → bp-sso-bridge could not POST /admin/realms. Pure
+#   lookup-source change; no new bootstrap state. Chart-version bump forces the
+#   Flux re-pull (deploy-bot mutable-tag trap). bootstrap-kit slot-13 lockstep.
+version: 1.4.845
 # 1.4.774 — #4082: application-controller ClusterRole gains dr.openova.io/continuums
 #   (get/list/watch/create/update/patch/delete) — was in the controller's own
 #   deploy/rbac.yaml but MISSING from this platform chart, so a singleton /

--- a/products/catalyst/chart/templates/catalyst-keycloak-credentials-host-bridge.yaml
+++ b/products/catalyst/chart/templates/catalyst-keycloak-credentials-host-bridge.yaml
@@ -157,12 +157,27 @@ coordinates + destination namespace flow through .Values.keycloakHostBridge.*.
        reconcile of this chart (interval) back-fills once the bitnami
        mirror lands. Same soft-degrade the keycloak chart's own
        master-admin template documents. */ -}}
+{{- /* #4344: the #4325 de-vcluster moved keycloak from vc-mgmt INTO the host
+       `keycloak` namespace, where bp-keycloak now materialises a STABLE
+       `keycloak-admin` Secret (platform/keycloak/.../admin-credentials.yaml,
+       lookup-or-generate + resource-policy: keep). PREFER that secret — it is
+       the canonical, host-routable source of the master admin password and is
+       in the SAME namespace this bridge writes into. The legacy
+       vCluster-syncer-mangled `keycloak-x-keycloak-x-mgmt-vcluster`/`mgmt`
+       lookup (the #3642 in-vCluster path) no longer resolves post-de-vcluster
+       → it was emitting an EMPTY master-realm-admin-password (the seam the
+       #4344 issue flagged). Fall back to the configured bitnami-mangled secret
+       for back-compat on any topology where keycloak still runs in vc-mgmt. */ -}}
+{{- $stableNs := .Values.keycloakHostBridge.keycloakReleaseNamespace | default "keycloak" -}}
+{{- $stable := lookup "v1" "Secret" $stableNs "keycloak-admin" -}}
 {{- $bitnamiNs := .Values.keycloakHostBridge.bitnamiSecretNamespace | default "mgmt" -}}
 {{- $bitnamiName := .Values.keycloakHostBridge.bitnamiSecretName | default "keycloak-x-keycloak-x-mgmt-vcluster" -}}
 {{- $bitnami := lookup "v1" "Secret" $bitnamiNs $bitnamiName -}}
 {{- $masterAdminUser := .Values.keycloakHostBridge.masterAdminUser | default "admin" -}}
 {{- $masterAdminPassword := "" -}}
-{{- if and $bitnami $bitnami.data (index $bitnami.data "admin-password") -}}
+{{- if and $stable $stable.data (index $stable.data "admin-password") -}}
+{{- $masterAdminPassword = index $stable.data "admin-password" | b64dec -}}
+{{- else if and $bitnami $bitnami.data (index $bitnami.data "admin-password") -}}
 {{- $masterAdminPassword = index $bitnami.data "admin-password" | b64dec -}}
 {{- end -}}
 {{- $commonLabels := dict


### PR DESCRIPTION
## Problem (Refs #4344 #4325 #4340)

The #4325 de-vcluster moved keycloak from the `mgmt` vCluster into the host `keycloak` namespace and did a **fresh helm install**. The bitnami keycloak subchart's `common.secrets.passwords.manage` **regenerated** the `keycloak` Secret `admin-password` (no prior same-named Secret in the brand-new host namespace) — while the keycloak **DB persists** (external CNPG `shared-pg-mesh-rw`, days old). Keycloak only honours `KC_BOOTSTRAP_ADMIN_PASSWORD` on an EMPTY-DB first boot, so the master-realm `admin` user kept its **original** password. Result:

- `keycloak-0` Ready 1/1 but logs spam `LOGIN_ERROR error=invalid_user_credentials username=admin`.
- `keycloak-config-cli` reads the SAME Secret → **HTTP 401** → the sovereign-realm import never runs → `bp-keycloak` HR never Ready.
- Downstream wedged: `bp-gitea` (gitea-http NXDOMAIN) → every Org `GiteaOrgFailed` → `bp-catalyst-platform` never rolls 1.4.844 → **#4340 org-controller blocked**.

## Durable fix

Mirrors the existing 1.4.8 `postgresql-credentials.yaml` defense for the postgres password:

- **`platform/keycloak`** — new `templates/admin-credentials.yaml` materialises a stable `keycloak-admin` Secret via **lookup-or-generate + `helm.sh/resource-policy: keep`**. `values.yaml` wires the subchart at it (`keycloak.auth.existingSecret: keycloak-admin` + `passwordSecretKey: admin-password`). Both the StatefulSet's `KC_BOOTSTRAP_ADMIN_PASSWORD` and config-cli's `KEYCLOAK_PASSWORD` resolve through `keycloak.secretName`/`secretKey` → this one stable Secret, so the password can **never** regenerate or diverge across reinstall / namespace re-home. The `catalyst-kc-master-admin-credentials` emission sources from `keycloak-admin` too.
- **`products/catalyst`** — the keycloak-credentials host-bridge sources the master admin password from the host `keycloak/keycloak-admin` Secret **first** (the vCluster-syncer-mangled lookup no longer resolves post-de-vcluster → it was emitting an empty `master-realm-admin-password`).
- New chart test `tests/admin-password-stable.sh` asserts the admin-password is sourced from a persisted `keep`-annotated secret (not re-randomized), that the bitnami subchart no longer mints its own `keycloak` Secret, and that the StatefulSet + config-cli both read `keycloak-admin`.
- Lockstep: `bp-keycloak` chart/blueprint/slot-09 → **1.5.4**; `bp-catalyst-platform` chart/slot-13 → **1.4.845**.

## Validation

- `helm dependency build` + `helm template` clean on both charts; `helm lint` clean.
- All **13** bp-keycloak chart tests pass (incl. the new one); catalog-seed lockstep guard green.
- **Live recovery on omantel.biz kom4dc (dep `4635277cae4ffed9`, region-a)** per the #4344 documented SAFE path: created a temporary `kc.sh bootstrap-admin user` against the persistent DB, used it to `kcadm.sh set-password` the master-realm `admin` user to match the live Secret (no demo-Org user touched), removed the temp admin. Result: `admin` authenticates ✅ → config-cli 401 cleared → **sovereign realm imported (19 clients + sovereign-admins/ops/viewers groups)** → **`bp-keycloak` HR `True :: InstallSucceeded`**, LOGIN_ERRORs stopped. The keycloak→config-cli→realm chain is recovered. The chain then advances to a **separate** bp-gitea kyverno `probes-present` block on `gitea-sso-configure` (distinct from #4344 — filed as follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)