### PR TITLE
fix(planes #4347): end the host-ns Kyverno whack-a-mole — probes-present + harbor-proxy across every de-vcluster'd plane chart

### DIFF
--- a/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
+++ b/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
@@ -56,11 +56,17 @@ spec:
   chart:
     spec:
       chart: bp-nats-jetstream
+      # 1.3.5 — #4347: every workload container now clears the host-ns Kyverno
+      #   `probes-present` + `harbor-proxy-pull` Enforce policies (post-#4325
+      #   de-vcluster, `nats-system` is a native host ns). All 4 dockerhub
+      #   images route through the Harbor proxy; reloader + nats-box get exec
+      #   probes via the nats `merge` knob; the nack dep bumped 0.29.0->0.34.0
+      #   + `controlLoop: true` so the jetstream-controller renders HTTP probes.
       # 1.3.4 — #4343: server/reloader/nats-box resources moved to the
       #   container.merge knob (the inert container.resources block was
       #   silently dropped) so every container clears the host-ns Kyverno
       #   resource-requests Enforce policy (post-#4325).
-      version: 1.3.4
+      version: 1.3.5
       sourceRef:
         kind: HelmRepository
         name: bp-nats-jetstream

--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -135,7 +135,11 @@ spec:
       #   (modes[] admit active-passive + defaultOnMultiRegion). Chart bumped in lockstep.
       # 1.2.53 — #4343: injector.resources.requests so the agent-injector clears
       #   the host-ns Kyverno resource-requests Enforce policy (post-#4325).
-      version: 1.2.53
+      # 1.2.54 — #4347: probes-present compliance — sso-configure liveness/
+      #   readiness EXEC probes + server.livenessProbe ENABLED (sealed-tolerant)
+      #   so the StatefulSet + sso-configure Deployment clear the host-ns Kyverno
+      #   probes-present Enforce policy (post-#4325). Refs #4347 #4325.
+      version: 1.2.54
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -157,7 +157,10 @@ spec:
       # vCluster placement (caught live hw171). Refs #3374 #3642.
       # 1.2.41 — #4212 Seam 3: placementSchema aligned with spec.topology
       #   (modes[] admit active-hot-standby + defaultOnMultiRegion). Chart bumped in lockstep.
-      version: 1.2.41
+      # 1.2.42 — #4347: gitea-sso-configure Deployment gains liveness + readiness
+      #   probes (heartbeat sentinel) so the host-ns Kyverno `probes-present`
+      #   Enforce ClusterPolicy admits it post-#4325 de-vcluster. Refs #4347 #4325 #4340.
+      version: 1.2.42
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/clusters/_template/bootstrap-kit/18-seaweedfs.yaml
+++ b/clusters/_template/bootstrap-kit/18-seaweedfs.yaml
@@ -83,7 +83,10 @@ spec:
       # ("violates PodSecurity baseline: hostPath volumes"). 1.2.0 shipped
       # the `seaweedfs-storage` StorageClass (qa-loop Wave 5 Fix #79 Gap B)
       # so PVCs that default to it bind day-1 on bare-k3s Sovereigns.
-      version: 1.2.3
+      # 1.2.4 — #4347: harbor-proxy the seaweedfs image so all 4 workloads clear
+      #   the host-ns Kyverno harbor-proxy-pull Enforce policy (post-#4325).
+      #   Refs #4347 #4325.
+      version: 1.2.4
       sourceRef:
         kind: HelmRepository
         name: bp-seaweedfs

--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -212,7 +212,10 @@ spec:
       #   (modes[] admit active-hot-standby + defaultOnMultiRegion). Chart bumped in lockstep.
       # 1.2.38 — #4343: nginx.resources.requests so harbor-nginx clears the
       #   host-ns Kyverno resource-requests Enforce policy (post-#4325).
-      version: 1.2.38
+      # 1.2.39 — #4347: harbor-sso-configure liveness/readiness EXEC probes so
+      #   it clears the host-ns Kyverno probes-present Enforce policy (post-#4325).
+      #   Refs #4347 #4325.
+      version: 1.2.39
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/clusters/_template/bootstrap-kit/22-loki.yaml
+++ b/clusters/_template/bootstrap-kit/22-loki.yaml
@@ -111,7 +111,10 @@ spec:
       chart: bp-loki
       # 1.0.1 — #4343: loki.sidecar.resources.requests so the rules sidecar
       #   clears the host-ns Kyverno resource-requests Enforce policy (post-#4325).
-      version: 1.0.1
+      # 1.0.2 — #4347: loki livenessProbe + sidecar exec probes + harbor-proxy
+      #   images so it clears the host-ns Kyverno probes-present + harbor-proxy-pull
+      #   Enforce policies (post-#4325). Refs #4347 #4325.
+      version: 1.0.2
       sourceRef:
         kind: HelmRepository
         name: bp-loki

--- a/clusters/_template/bootstrap-kit/23-mimir.yaml
+++ b/clusters/_template/bootstrap-kit/23-mimir.yaml
@@ -110,10 +110,17 @@ spec:
   chart:
     spec:
       chart: bp-mimir
+      # 1.0.7 — #4347 (Refs #4325): proxy every image through Harbor +
+      #   livenessProbe on all 13 workload containers so every container clears
+      #   BOTH the host-ns Kyverno probes-present AND harbor-proxy-pull Enforce
+      #   policies. The gateway/rollout-operator/MinIO (no upstream liveness
+      #   knob) are disabled + re-rendered probe-compliant in the chart's
+      #   templates/devcluster-workloads.yaml; the bundled-MinIO blocks-storage
+      #   S3 wiring is preserved via mimir.structuredConfig.
       # 1.0.6 — #4343: gateway.resources + MinIO cpu requests so every
       #   container clears the host-ns Kyverno resource-requests Enforce
       #   policy (post-#4325).
-      version: 1.0.6
+      version: 1.0.7
       sourceRef:
         kind: HelmRepository
         name: bp-mimir

--- a/clusters/_template/bootstrap-kit/24-tempo.yaml
+++ b/clusters/_template/bootstrap-kit/24-tempo.yaml
@@ -103,7 +103,9 @@ spec:
   chart:
     spec:
       chart: bp-tempo
-      version: 1.0.0
+      # 1.0.1 — #4347: harbor-proxy the Tempo image so it clears the host-ns
+      #   Kyverno harbor-proxy-pull Enforce policy (post-#4325). Refs #4347 #4325.
+      version: 1.0.1
       sourceRef:
         kind: HelmRepository
         name: bp-tempo

--- a/clusters/_template/bootstrap-kit/25-grafana.yaml
+++ b/clusters/_template/bootstrap-kit/25-grafana.yaml
@@ -128,7 +128,9 @@ spec:
       # this slot's HelmRelease (adoption-guarded, Capabilities-gated) so
       # the console /apps list, per-app Topology tab + showback resolve
       # grafana instead of "n/a — bootstrap component, no Application CR".
-      version: 1.0.16
+      # 1.0.17 — #4347: grafana k8s-sidecar exec probes so the Pod clears the
+      #   host-ns Kyverno probes-present Enforce policy (post-#4325). Refs #4347 #4325.
+      version: 1.0.17
       sourceRef:
         kind: HelmRepository
         name: bp-grafana

--- a/clusters/_template/bootstrap-kit/26b-bp-plane-isolation.yaml
+++ b/clusters/_template/bootstrap-kit/26b-bp-plane-isolation.yaml
@@ -63,7 +63,9 @@ spec:
       # 0.1.0 (#4291 Workstream C) — per-component default-deny + gateway
       # CNP for the de-vclustered platform planes. CI populates the SHA-pinned
       # OCI digest on tag.
-      version: 0.1.0
+      # 0.1.1 — #4347 (Refs #4325): YAML doc-separator fix so the HR install no
+      #   longer fails post-render with `mapping key "apiVersion" already defined`.
+      version: 0.1.1
       sourceRef:
         kind: HelmRepository
         name: bp-plane-isolation

--- a/clusters/_template/bootstrap-kit/35-coraza.yaml
+++ b/clusters/_template/bootstrap-kit/35-coraza.yaml
@@ -77,7 +77,11 @@ spec:
   chart:
     spec:
       chart: bp-coraza
-      version: 1.0.0
+      # 1.0.1 — #4347: coraza-spoa tcpSocket liveness/readiness probes +
+      #   harbor-proxy image source so it clears the host-ns Kyverno
+      #   probes-present + harbor-proxy-pull Enforce policies (post-#4325).
+      #   Refs #4347 #4325.
+      version: 1.0.1
       sourceRef:
         kind: HelmRepository
         name: bp-coraza

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -295,7 +295,10 @@ spec:
       # no longer empties it → kills the wait-for-sql-dsn Init:CrashLoopBackOff.
       # vcluster-app slot (cnpg.enabled=false) renders no CNPG/DSN secret — pure
       # lockstep bump.
-      version: 1.4.128
+      # 1.4.130 — #4347: channel-seed hook Job curl image harbor-proxied so it
+      #   clears the host-ns Kyverno harbor-proxy-pull Enforce policy on every
+      #   reconcile (post-#4325). Refs #4347 #4325.
+      version: 1.4.130
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/coraza/blueprint.yaml
+++ b/platform/coraza/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.0
+  version: 1.0.1  # lockstep with chart/Chart.yaml (#4347 probes-present + harbor-proxy image for host-ns Kyverno Enforce)
   card:
     title: Coraza WAF (SPOA)
     family: guardian

--- a/platform/coraza/chart/Chart.yaml
+++ b/platform/coraza/chart/Chart.yaml
@@ -13,7 +13,13 @@ description: |
   Pairs with bp-cilium (L7 policy enforcement), bp-keycloak (auth-front),
   and bp-stalwart (mail-front).
 type: application
-version: 1.0.0
+# 1.0.1 (#4347): host-ns Kyverno Enforce compliance after #4325 de-vcluster
+#   re-homed bp-coraza into a native host namespace — (a) coraza-spoa Deployment
+#   gains tcpSocket liveness + readiness probes (probes-present Enforce);
+#   (b) the image source moves from raw `ghcr.io/corazawaf/coraza-spoa` to
+#   `harbor.openova.io/proxy-ghcr/corazawaf/coraza-spoa` (harbor-proxy-pull
+#   Enforce). Adds tests/kyverno-probes-present.sh. Refs #4347 #4325.
+version: 1.0.1
 appVersion: "0.7.0"
 keywords: [catalyst, blueprint, coraza, waf, modsecurity, security]
 maintainers:

--- a/platform/coraza/chart/templates/deployment.yaml
+++ b/platform/coraza/chart/templates/deployment.yaml
@@ -28,6 +28,26 @@ spec:
             - name: spoa
               containerPort: {{ .Values.coraza.spoaPort }}
               protocol: TCP
+          # #4347 — liveness + readiness probes (required by the host-ns Kyverno
+          # `probes-present` Enforce ClusterPolicy after #4325 moved bp-coraza
+          # into a native host namespace). coraza-spoa is a TCP SPOA (HAProxy
+          # SPOE) server with no HTTP health endpoint, so both probes are
+          # tcpSocket checks against the spoa listener — a bound, accepting
+          # socket is the correct readiness/liveness signal for the WAF agent.
+          readinessProbe:
+            tcpSocket:
+              port: spoa
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: spoa
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
           resources:
             {{- toYaml .Values.coraza.resources | nindent 12 }}
           securityContext:

--- a/platform/coraza/chart/tests/_assert_probes_present.py
+++ b/platform/coraza/chart/tests/_assert_probes_present.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# #4347 helper — read a multi-doc helm render from stdin and assert every
+# PRIMARY container in a Deployment / StatefulSet / DaemonSet declares BOTH a
+# livenessProbe AND a readinessProbe — the exact shape the cluster-wide Kyverno
+# `probes-present` Enforce ClusterPolicy requires (platform/kyverno-policies/
+# chart/templates/baseline/04-probes.yaml).
+#
+# Scope mirrors the policy EXACTLY:
+#   - Matched kinds: Deployment, StatefulSet, DaemonSet ONLY. Job / CronJob are
+#     NOT matched by probes-present (a Job's containers run to completion;
+#     liveness/readiness are meaningless there), so they are skipped here too.
+#   - initContainers + ephemeralContainers are EXEMPT (the K8s API rejects
+#     liveness/readiness probes on initContainers), so only `containers[]` is
+#     checked.
+#
+# Prints a one-line OK summary on success; prints the offending
+# kind/name:container lines and exits 1 on any miss.
+import sys, re
+try:
+    import yaml
+except ImportError:
+    print("PyYAML not available; cannot run probes-present assertion", file=sys.stderr)
+    sys.exit(2)
+
+raw = sys.stdin.read()
+# Some upstream subchart templates emit stray trailing whitespace/tabs that
+# break a strict YAML scan; rstrip each line (cosmetic, render-neutral).
+raw = "\n".join(line.rstrip() for line in raw.splitlines())
+
+bad = []
+checked = 0
+for chunk in re.split(r"(?m)^---\s*$", raw):
+    chunk = chunk.strip()
+    if not chunk:
+        continue
+    try:
+        d = yaml.safe_load(chunk)
+    except Exception:
+        continue
+    if not isinstance(d, dict):
+        continue
+    kind = d.get("kind")
+    # Match the probes-present policy kinds exactly — NOT Job/CronJob.
+    if kind not in ("Deployment", "StatefulSet", "DaemonSet"):
+        continue
+    name = d.get("metadata", {}).get("name", "<noname>")
+    try:
+        podspec = d["spec"]["template"]["spec"]
+    except (KeyError, TypeError):
+        continue
+    # Only the primary containers[] are subject to the policy.
+    for c in (podspec.get("containers", []) or []):
+        checked += 1
+        missing = []
+        if not c.get("livenessProbe"):
+            missing.append("livenessProbe")
+        if not c.get("readinessProbe"):
+            missing.append("readinessProbe")
+        if missing:
+            bad.append("%s/%s container=%s missing=%s" % (kind, name, c.get("name"), "+".join(missing)))
+
+if bad:
+    print("workload containers MISSING liveness/readiness probes:")
+    for b in bad:
+        print(b)
+    sys.exit(1)
+
+if checked == 0:
+    print("no Deployment/StatefulSet/DaemonSet containers rendered — subchart deps not built? (run `helm dependency build`)")
+    sys.exit(1)
+
+print("%d Deployment/StatefulSet/DaemonSet container(s) all declare liveness+readiness probes" % checked)

--- a/platform/coraza/chart/tests/kyverno-probes-present.sh
+++ b/platform/coraza/chart/tests/kyverno-probes-present.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# #4347 — assert EVERY primary container in the rendered bp-coraza
+# Deployments / StatefulSets / DaemonSets declares BOTH a livenessProbe AND a
+# readinessProbe, so the cluster-wide Kyverno `probes-present` Enforce
+# ClusterPolicy admits every workload.
+#
+# After #4325 the platform planes (incl. coraza, the lone dmz plane) install
+# into NATIVE host namespaces (not a vCluster), where the host Kyverno Enforce
+# policies apply. The coraza-spoa Deployment shipped with NO liveness/readiness
+# probes → kyverno `probes-present` (Enforce) would DENY it. This test guards
+# that regression: it FAILS if any rendered Deployment/StatefulSet/DaemonSet
+# container lacks either probe.
+set -euo pipefail
+chart_dir="${1:-$(dirname "$0")/..}"
+cd "$chart_dir"
+chart_dir="$(pwd)"
+
+# bp-coraza is a scratch chart with no subchart deps, but guard for parity.
+if ls Chart.lock >/dev/null 2>&1 && ! ls charts/*.tgz >/dev/null 2>&1; then
+  helm dependency build "$chart_dir" >/dev/null 2>&1 || true
+fi
+
+assert_py="$chart_dir/tests/_assert_probes_present.py"
+
+assert_probes() {
+  local label="$1"; shift
+  local out rc
+  out=$(helm template t . "$@" 2>/dev/null | python3 "$assert_py")
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "FAIL [$label]:"
+    echo "$out" | sed 's/^/  /'
+    return 1
+  fi
+  echo "PASS [$label]: $out"
+}
+
+fail=0
+assert_probes "default" || fail=1
+
+if [ "$fail" -ne 0 ]; then
+  echo "kyverno-probes-present: one or more workload containers lack liveness/readiness probes (would be DENIED by the host-ns Kyverno probes-present Enforce policy)."
+  exit 1
+fi
+echo "kyverno-probes-present: all Deployment/StatefulSet/DaemonSet containers declare liveness+readiness probes."

--- a/platform/coraza/chart/values.yaml
+++ b/platform/coraza/chart/values.yaml
@@ -23,7 +23,14 @@ coraza:
   # Pin upstream image tag — DO NOT use floating tags per
   # docs/INVIOLABLE-PRINCIPLES.md.
   image:
-    repository: ghcr.io/corazawaf/coraza-spoa
+    # #4347 — route through the Sovereign-local Harbor proxy-cache so the
+    # host-ns Kyverno `harbor-proxy-pull` Enforce ClusterPolicy admits it (after
+    # #4325 moved bp-coraza into a native host namespace where the cluster-wide
+    # Enforce policies apply). The raw `ghcr.io/corazawaf/coraza-spoa` source
+    # matches neither allowed glob (`*/proxy-*/*` nor `*/openova-io/*`) and was
+    # DENIED at admission. `proxy-ghcr` is the canonical ghcr.io proxy-cache
+    # project (mirrors the fluxcd/cnpg refs across the platform charts).
+    repository: harbor.openova.io/proxy-ghcr/corazawaf/coraza-spoa
     tag: "0.7.0"
     pullPolicy: IfNotPresent
 

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.41
+  version: 1.2.42
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -153,7 +153,12 @@ name: bp-gitea
 # IN the vCluster and seeds the row (its creds cross in via bp-mgmt-vcluster
 # sync.fromHost). Non-host-bridged render is byte-identical. Refs #3374 #3642.
 # 1.2.40 (#3971): CNPG storageClass empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN.
-version: 1.2.41
+# 1.2.42 (#4347): gitea-sso-configure Deployment gains liveness + readiness EXEC
+#   probes (heartbeat sentinel) so the host-ns Kyverno `probes-present` Enforce
+#   ClusterPolicy admits it — after #4325 de-vcluster re-homed bp-gitea into a
+#   native host namespace where the cluster-wide Enforce policies apply. Adds
+#   tests/kyverno-probes-present.sh (CI gate). Refs #4347 #4325 #4340.
+version: 1.2.42
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/templates/sso-configure-deployment.yaml
+++ b/platform/gitea/chart/templates/sso-configure-deployment.yaml
@@ -151,7 +151,25 @@ data:
     log "bp-gitea sso-configure starting; interval=${INTERVAL_SECONDS}s"
     log "  AUTH_NAME=${AUTH_NAME} ADMIN_GROUP=${ADMIN_GROUP} GITEA_NAMESPACE=${GITEA_NAMESPACE} POD_SELECTOR=${POD_SELECTOR}"
 
+    # #4347 — liveness/readiness heartbeat sentinel. This continuous
+    # reconciler has NO serving port, so the Pod's livenessProbe /
+    # readinessProbe (required by the host-ns Kyverno `probes-present`
+    # Enforce ClusterPolicy after the #4325 de-vcluster re-homed bp-gitea
+    # into a host namespace) exec a freshness check against this file. We
+    # `touch` it on startup (so the readiness probe passes as soon as the
+    # loop is up) and re-touch it at the top of every tick; the probe
+    # `[ -f ]`-checks it exists and tests freshness so a wedged loop (no
+    # tick within a few intervals) flips the probe to failing and kubelet
+    # restarts the Pod. Lives under the writable /tmp emptyDir
+    # (readOnlyRootFilesystem: true on the container).
+    HEARTBEAT_FILE=/tmp/sso-configure-heartbeat
+    touch "${HEARTBEAT_FILE}"
+
     while true; do
+      # Re-touch the heartbeat at the top of each iteration so a healthy
+      # loop keeps the sentinel fresh; a wedged/blocked loop lets it age
+      # out and the liveness probe restarts the Pod (#4347).
+      touch "${HEARTBEAT_FILE}"
       sleep "${INTERVAL_SECONDS}"
 
       # Read the OAuth client creds from the MOUNTED Secret each tick (not
@@ -323,6 +341,41 @@ spec:
             limits:
               cpu: "200m"
               memory: "128Mi"
+          # #4347 — liveness + readiness probes (required by the host-ns
+          # Kyverno `probes-present` Enforce ClusterPolicy after #4325 moved
+          # bp-gitea into a native host namespace). This reconciler has NO
+          # serving port, so both probes are EXEC checks against the
+          # /tmp/sso-configure-heartbeat sentinel the loop re-touches each
+          # tick.
+          #   readiness: the file merely EXISTS — goes green as soon as the
+          #     loop's startup `touch` lands (well within the loop's first
+          #     sub-second), gating nothing downstream (this Deployment has no
+          #     Service) but satisfying the policy with a real signal.
+          #   liveness: the file was modified within the last 5 minutes — a
+          #     wedged loop (no tick within ~5× the default 60s interval) lets
+          #     it age out and kubelet restarts the Pod. `find -mmin -5`
+          #     prints the path when fresh (exit 0) and nothing when stale,
+          #     so `[ -n "$(...)" ]` is the freshness gate.
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - 'test -f /tmp/sso-configure-heartbeat'
+            initialDelaySeconds: 2
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - '[ -n "$(find /tmp/sso-configure-heartbeat -mmin -5 2>/dev/null)" ]'
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
           volumeMounts:
             - name: script
               mountPath: /etc/gitea-sso

--- a/platform/gitea/chart/tests/_assert_probes_present.py
+++ b/platform/gitea/chart/tests/_assert_probes_present.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# #4347 helper — read a multi-doc helm render from stdin and assert every
+# PRIMARY container in a Deployment / StatefulSet / DaemonSet declares BOTH a
+# livenessProbe AND a readinessProbe — the exact shape the cluster-wide Kyverno
+# `probes-present` Enforce ClusterPolicy requires (platform/kyverno-policies/
+# chart/templates/baseline/04-probes.yaml).
+#
+# Scope mirrors the policy EXACTLY:
+#   - Matched kinds: Deployment, StatefulSet, DaemonSet ONLY. Job / CronJob are
+#     NOT matched by probes-present (a Job's containers run to completion;
+#     liveness/readiness are meaningless there), so they are skipped here too.
+#   - initContainers + ephemeralContainers are EXEMPT (the K8s API rejects
+#     liveness/readiness probes on initContainers), so only `containers[]` is
+#     checked.
+#
+# Prints a one-line OK summary on success; prints the offending
+# kind/name:container lines and exits 1 on any miss.
+import sys, re
+try:
+    import yaml
+except ImportError:
+    print("PyYAML not available; cannot run probes-present assertion", file=sys.stderr)
+    sys.exit(2)
+
+raw = sys.stdin.read()
+# Some upstream subchart templates emit stray trailing whitespace/tabs that
+# break a strict YAML scan; rstrip each line (cosmetic, render-neutral).
+raw = "\n".join(line.rstrip() for line in raw.splitlines())
+
+bad = []
+checked = 0
+for chunk in re.split(r"(?m)^---\s*$", raw):
+    chunk = chunk.strip()
+    if not chunk:
+        continue
+    try:
+        d = yaml.safe_load(chunk)
+    except Exception:
+        continue
+    if not isinstance(d, dict):
+        continue
+    kind = d.get("kind")
+    # Match the probes-present policy kinds exactly — NOT Job/CronJob.
+    if kind not in ("Deployment", "StatefulSet", "DaemonSet"):
+        continue
+    name = d.get("metadata", {}).get("name", "<noname>")
+    try:
+        podspec = d["spec"]["template"]["spec"]
+    except (KeyError, TypeError):
+        continue
+    # Only the primary containers[] are subject to the policy.
+    for c in (podspec.get("containers", []) or []):
+        checked += 1
+        missing = []
+        if not c.get("livenessProbe"):
+            missing.append("livenessProbe")
+        if not c.get("readinessProbe"):
+            missing.append("readinessProbe")
+        if missing:
+            bad.append("%s/%s container=%s missing=%s" % (kind, name, c.get("name"), "+".join(missing)))
+
+if bad:
+    print("workload containers MISSING liveness/readiness probes:")
+    for b in bad:
+        print(b)
+    sys.exit(1)
+
+if checked == 0:
+    print("no Deployment/StatefulSet/DaemonSet containers rendered — subchart deps not built? (run `helm dependency build`)")
+    sys.exit(1)
+
+print("%d Deployment/StatefulSet/DaemonSet container(s) all declare liveness+readiness probes" % checked)

--- a/platform/gitea/chart/tests/kyverno-probes-present.sh
+++ b/platform/gitea/chart/tests/kyverno-probes-present.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# #4347 — assert EVERY primary container in the rendered bp-gitea
+# Deployments / StatefulSets / DaemonSets declares BOTH a livenessProbe AND a
+# readinessProbe, so the cluster-wide Kyverno `probes-present` Enforce
+# ClusterPolicy admits every workload.
+#
+# After #4325 the platform planes (incl. gitea) install into NATIVE host
+# namespaces (not a vCluster), where the host Kyverno Enforce policies apply.
+# The chart's `gitea-sso-configure` Deployment is a continuous reconcile loop
+# (a `while true` bash loop) with NO serving port — it shipped with NO
+# liveness/readiness probes → kyverno `probes-present` (Enforce) DENIED the
+# Deployment at admission → the whole bp-gitea Helm install FAILED → bp-gitea
+# HR False → bp-catalyst-platform `dependency bp-gitea not ready`. This test
+# guards that regression: it FAILS if any rendered Deployment/StatefulSet/
+# DaemonSet container lacks either probe.
+set -euo pipefail
+# CI invokes `bash <script> <chart_dir>`; fall back to the script's own dir.
+chart_dir="${1:-$(dirname "$0")/..}"
+cd "$chart_dir"
+chart_dir="$(pwd)"
+
+# The upstream gitea subchart is vendored under charts/*.tgz (gitignored,
+# rebuilt from Chart.lock). CI runs `helm dependency build` before tests, but
+# build it here too so the test is runnable standalone.
+if ! ls charts/*.tgz >/dev/null 2>&1; then
+  helm dependency build "$chart_dir" >/dev/null 2>&1 || true
+fi
+
+assert_py="$chart_dir/tests/_assert_probes_present.py"
+
+assert_probes() {
+  local label="$1"; shift
+  local out rc
+  out=$(helm template t . --set gateway.host=git.example.test "$@" 2>/dev/null | python3 "$assert_py")
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "FAIL [$label]:"
+    echo "$out" | sed 's/^/  /'
+    return 1
+  fi
+  echo "PASS [$label]: $out"
+}
+
+fail=0
+# Default render.
+assert_probes "default" || fail=1
+# SSO enabled (renders the gitea-sso-configure Deployment — the #4347 offender).
+assert_probes "sso-enabled" --set sso.enabled=true --set sso.sovereignFqdn=example.test || fail=1
+
+if [ "$fail" -ne 0 ]; then
+  echo "kyverno-probes-present: one or more workload containers lack liveness/readiness probes (would be DENIED by the host-ns Kyverno probes-present Enforce policy)."
+  exit 1
+fi
+echo "kyverno-probes-present: all Deployment/StatefulSet/DaemonSet containers declare liveness+readiness probes."

--- a/platform/grafana/blueprint.yaml
+++ b/platform/grafana/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.0.16
+  version: 1.0.17  # lockstep with chart/Chart.yaml (#4347 grafana sidecar probes for host-ns Kyverno probes-present Enforce)
   card:
     title: Grafana
     family: insights

--- a/platform/grafana/chart/Chart.yaml
+++ b/platform/grafana/chart/Chart.yaml
@@ -67,10 +67,16 @@ type: application
 # readTopology serves spec.placement VERBATIM to the Topology tab + the
 # Instances-table chip, so the legacy spelling leaked the banned word to the
 # operator (hw159 #3375).
-# 1.0.17 (#4347): add EXEC liveness + readiness probes to the dashboard +
-#   datasource kiwigrid/k8s-sidecar containers so the grafana Pod clears the
-#   host-ns Kyverno `probes-present` Enforce policy (post-#4325 de-vcluster).
-#   Adds tests/kyverno-probes-present.sh. Refs #4347 #4325.
+# 1.0.17 (#4347): host-ns Kyverno + de-vcluster cleanup (post-#4325).
+#   (a) add EXEC liveness + readiness probes to the dashboard + datasource
+#   kiwigrid/k8s-sidecar containers so the grafana Pod clears the host-ns
+#   Kyverno `probes-present` Enforce policy (+ tests/kyverno-probes-present.sh);
+#   (b) CORRECT the three default datasource URLs — #4325 de-vclustered
+#   bp-loki/bp-mimir/bp-tempo into their OWN host namespaces, so the pre-#4325
+#   syncer-mangled `<svc>-x-<inner-ns>-x-mgmt-vcluster.mgmt.svc` targets are
+#   DEAD (every Grafana datasource health-check failed → empty dashboards).
+#   Now mimir-gateway.mimir.svc:80 / loki.loki.svc:3100 / tempo.tempo.svc:3200
+#   (g115-datasources-dashboards.sh updated to match). Refs #4347 #4325.
 version: 1.0.17
 appVersion: "12.3.1"
 # 1.0.14 (#3374, 2026-06-14): raise the sidecar memory limit 64Mi → 192Mi

--- a/platform/grafana/chart/Chart.yaml
+++ b/platform/grafana/chart/Chart.yaml
@@ -67,7 +67,11 @@ type: application
 # readTopology serves spec.placement VERBATIM to the Topology tab + the
 # Instances-table chip, so the legacy spelling leaked the banned word to the
 # operator (hw159 #3375).
-version: 1.0.16
+# 1.0.17 (#4347): add EXEC liveness + readiness probes to the dashboard +
+#   datasource kiwigrid/k8s-sidecar containers so the grafana Pod clears the
+#   host-ns Kyverno `probes-present` Enforce policy (post-#4325 de-vcluster).
+#   Adds tests/kyverno-probes-present.sh. Refs #4347 #4325.
+version: 1.0.17
 appVersion: "12.3.1"
 # 1.0.14 (#3374, 2026-06-14): raise the sidecar memory limit 64Mi → 192Mi
 # (request 32Mi → 64Mi). The 1.0.13 limit was too low for the

--- a/platform/grafana/chart/tests/_assert_probes_present.py
+++ b/platform/grafana/chart/tests/_assert_probes_present.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# #4347 helper — read a multi-doc helm render from stdin and assert every
+# PRIMARY container in a Deployment / StatefulSet / DaemonSet declares BOTH a
+# livenessProbe AND a readinessProbe — the exact shape the cluster-wide Kyverno
+# `probes-present` Enforce ClusterPolicy requires (platform/kyverno-policies/
+# chart/templates/baseline/04-probes.yaml).
+#
+# Scope mirrors the policy EXACTLY:
+#   - Matched kinds: Deployment, StatefulSet, DaemonSet ONLY. Job / CronJob are
+#     NOT matched by probes-present (a Job's containers run to completion;
+#     liveness/readiness are meaningless there), so they are skipped here too.
+#   - initContainers + ephemeralContainers are EXEMPT (the K8s API rejects
+#     liveness/readiness probes on initContainers), so only `containers[]` is
+#     checked.
+#
+# Prints a one-line OK summary on success; prints the offending
+# kind/name:container lines and exits 1 on any miss.
+import sys, re
+try:
+    import yaml
+except ImportError:
+    print("PyYAML not available; cannot run probes-present assertion", file=sys.stderr)
+    sys.exit(2)
+
+raw = sys.stdin.read()
+# Some upstream subchart templates emit stray trailing whitespace/tabs that
+# break a strict YAML scan; rstrip each line (cosmetic, render-neutral).
+raw = "\n".join(line.rstrip() for line in raw.splitlines())
+
+bad = []
+checked = 0
+for chunk in re.split(r"(?m)^---\s*$", raw):
+    chunk = chunk.strip()
+    if not chunk:
+        continue
+    try:
+        d = yaml.safe_load(chunk)
+    except Exception:
+        continue
+    if not isinstance(d, dict):
+        continue
+    kind = d.get("kind")
+    # Match the probes-present policy kinds exactly — NOT Job/CronJob.
+    if kind not in ("Deployment", "StatefulSet", "DaemonSet"):
+        continue
+    name = d.get("metadata", {}).get("name", "<noname>")
+    try:
+        podspec = d["spec"]["template"]["spec"]
+    except (KeyError, TypeError):
+        continue
+    # Only the primary containers[] are subject to the policy.
+    for c in (podspec.get("containers", []) or []):
+        checked += 1
+        missing = []
+        if not c.get("livenessProbe"):
+            missing.append("livenessProbe")
+        if not c.get("readinessProbe"):
+            missing.append("readinessProbe")
+        if missing:
+            bad.append("%s/%s container=%s missing=%s" % (kind, name, c.get("name"), "+".join(missing)))
+
+if bad:
+    print("workload containers MISSING liveness/readiness probes:")
+    for b in bad:
+        print(b)
+    sys.exit(1)
+
+if checked == 0:
+    print("no Deployment/StatefulSet/DaemonSet containers rendered — subchart deps not built? (run `helm dependency build`)")
+    sys.exit(1)
+
+print("%d Deployment/StatefulSet/DaemonSet container(s) all declare liveness+readiness probes" % checked)

--- a/platform/grafana/chart/tests/g115-datasources-dashboards.sh
+++ b/platform/grafana/chart/tests/g115-datasources-dashboards.sh
@@ -72,16 +72,18 @@ for d in docs:
             ds = parsed['datasources'][0]
             found[ds['name']] = ds['url']
 want = {
-    # #2745/#3361 (2026-06-12): bp-loki/mimir/tempo were re-homed INSIDE
-    # the mgmt vCluster, so the host-visible datasource targets are the
-    # vCluster-synced Service names (<svc>-x-<inner-ns>-x-mgmt-vcluster in
-    # host ns mgmt), per values.yaml observabilityStack.datasources.*.url.
-    # The test asserts the SHIPPED default values verbatim so the G115
-    # render contract tracks the live vCluster topology (DoD-5 #3375).
-    'Prometheus': 'http://mimir-nginx-x-mimir-x-mgmt-vcluster.mgmt.svc.cluster.local:80/prometheus',
-    'Loki':       'http://loki-x-loki-x-mgmt-vcluster.mgmt.svc.cluster.local:3100',
+    # #4347 (2026-06-25, Refs #4325): #4325 DE-VCLUSTERED bp-loki/mimir/tempo
+    # — they now run NATIVELY in their OWN host namespaces (loki/mimir/tempo),
+    # so the pre-#4325 vCluster-synced `<svc>-x-<inner-ns>-x-mgmt-vcluster.mgmt`
+    # Service names are dead. The datasource targets are the host-ns Service
+    # names of the de-vclustered planes, per values.yaml
+    # observabilityStack.datasources.*.url. The test asserts the SHIPPED
+    # default values verbatim so the G115 render contract tracks the live
+    # host-ns topology.
+    'Prometheus': 'http://mimir-gateway.mimir.svc.cluster.local:80/prometheus',
+    'Loki':       'http://loki.loki.svc.cluster.local:3100',
     # Tempo: port 3200 is the http-query API (upstream tempo http_listen_port).
-    'Tempo':      'http://tempo-x-tempo-x-mgmt-vcluster.mgmt.svc.cluster.local:3200',
+    'Tempo':      'http://tempo.tempo.svc.cluster.local:3200',
 }
 for name, url in want.items():
     if name not in found:

--- a/platform/grafana/chart/tests/kyverno-probes-present.sh
+++ b/platform/grafana/chart/tests/kyverno-probes-present.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# #4347 — assert EVERY primary container in the rendered bp-grafana
+# Deployments / StatefulSets / DaemonSets declares BOTH a livenessProbe AND a
+# readinessProbe, so the cluster-wide Kyverno `probes-present` Enforce
+# ClusterPolicy admits every workload.
+#
+# After #4325 bp-grafana installs into the native host namespace `grafana`
+# (not a vCluster). The dashboard + datasource kiwigrid/k8s-sidecar containers
+# shipped NO probes → `probes-present` (Enforce) would DENY the grafana Pod.
+# This test guards the regression: it FAILS if any rendered workload container
+# lacks either probe.
+set -euo pipefail
+chart_dir="${1:-$(dirname "$0")/..}"
+cd "$chart_dir"
+chart_dir="$(pwd)"
+if ! ls charts/*.tgz >/dev/null 2>&1; then
+  helm dependency build "$chart_dir" >/dev/null 2>&1 || true
+fi
+assert_py="$chart_dir/tests/_assert_probes_present.py"
+out=$(helm template t . 2>/dev/null | python3 "$assert_py")
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  echo "FAIL: $out"
+  echo "kyverno-probes-present: one or more workload containers lack liveness/readiness probes (would be DENIED by the host-ns Kyverno probes-present Enforce policy)."
+  exit 1
+fi
+echo "PASS: $out"
+echo "kyverno-probes-present: all Deployment/StatefulSet/DaemonSet containers declare liveness+readiness probes."

--- a/platform/grafana/chart/values.yaml
+++ b/platform/grafana/chart/values.yaml
@@ -366,18 +366,20 @@ gateway:
 # 22-loki.yaml, 23-mimir.yaml, 24-tempo.yaml. Multi-cluster federation
 # overlays MAY point at a regional aggregator instead.
 #
-# #2745 (2026-06-12): bp-loki/bp-mimir/bp-tempo are re-homed INSIDE the
-# mgmt vCluster (NS-1 founder DoD). Grafana itself still runs host-side
-# (audit Phase-2 candidate), so these defaults point at the host-visible
-# syncer-mangled Service names the bp-mgmt-vcluster
-# sync.toHost.services reflector creates:
-#   <svc>-x-<inner-ns>-x-mgmt-vcluster.<host-ns mgmt>.svc.cluster.local
-# (suffix = the vCluster instance name = slot-58 releaseName
-# `mgmt-vcluster` — same convention as the nats-jetstream/keycloak
-# G92.2 entries in products/catalyst values). When grafana promotes
-# into the mgmt vCluster (audit Phase-2) these revert to the plain
-# in-vCluster names (loki.loki.svc / mimir-nginx.mimir.svc /
-# tempo.tempo.svc) via overlay or follow-up bump.
+# #2745 (2026-06-12): bp-loki/bp-mimir/bp-tempo were re-homed INSIDE the
+# mgmt vCluster (NS-1 founder DoD), so these defaults pointed at the
+# host-visible syncer-mangled Service names the bp-mgmt-vcluster
+# sync.toHost.services reflector created
+# (<svc>-x-<inner-ns>-x-mgmt-vcluster.mgmt.svc.cluster.local).
+#
+# #4347 (2026-06-25, Refs #4325): #4325 DE-VCLUSTERED the mgmt/rtz/dmz
+# platform planes — bp-loki/bp-mimir/bp-tempo now run NATIVELY in their
+# OWN host namespaces (loki/mimir/tempo), so the syncer-mangled
+# `*-x-*-x-mgmt-vcluster.mgmt.svc` names NO LONGER RESOLVE (the syncer is
+# gone) → every Grafana datasource health-check failed + all dashboards
+# rendered empty. The URLs below are corrected to the host-ns Service
+# names of the de-vclustered planes: mimir-gateway.mimir.svc:80,
+# loki.loki.svc:3100, tempo.tempo.svc:3200.
 observabilityStack:
   enabled: true
   # Custom sidecar discovery label override (mirrors
@@ -388,38 +390,32 @@ observabilityStack:
   datasources:
     prometheus:
       enabled: true
-      # bp-mimir 1.0.5+ exposes its query frontend via the
-      # `<release>-mimir-nginx` Service on port 80 in the (inner) mimir
-      # namespace. #2745: bp-mimir lives inside the mgmt vCluster; the
-      # host-visible synced Service is
-      # mimir-nginx-x-mimir-x-mgmt-vcluster in host ns mgmt.
-      url: "http://mimir-nginx-x-mimir-x-mgmt-vcluster.mgmt.svc.cluster.local:80/prometheus"
+      # #4347 (Refs #4325): bp-mimir is now host-ns (namespace `mimir`).
+      # Its query frontend is fronted by the `mimir-gateway` Service on
+      # port 80 (the Catalyst-owned gateway nginx renders this Service name
+      # via the upstream `<release>-gateway` contract). The pre-#4325
+      # syncer-mangled `mimir-nginx-x-mimir-x-mgmt-vcluster.mgmt.svc` name
+      # is dead.
+      url: "http://mimir-gateway.mimir.svc.cluster.local:80/prometheus"
       tenantId: anonymous
     loki:
       enabled: true
-      # bp-loki 1.0.0 single-binary chart Service name is `<release>`
-      # (no -gateway suffix on the simple-deployment values shipped by
-      # bp-loki today). #2745: bp-loki lives inside the mgmt vCluster;
-      # the host-visible synced Service is loki-x-loki-x-mgmt-vcluster
-      # in host ns mgmt.
-      url: "http://loki-x-loki-x-mgmt-vcluster.mgmt.svc.cluster.local:3100"
+      # #4347 (Refs #4325): bp-loki is now host-ns (namespace `loki`). The
+      # single-binary chart's Service name is `<release>` = `loki`, port
+      # 3100. The pre-#4325 `loki-x-loki-x-mgmt-vcluster.mgmt.svc` name is
+      # dead.
+      url: "http://loki.loki.svc.cluster.local:3100"
       tenantId: anonymous
     tempo:
       enabled: true
-      # bp-tempo 1.0.0 single-binary chart Service name is `<release>`.
-      # #2745: bp-tempo lives inside the mgmt vCluster; the host-visible
-      # synced Service is tempo-x-tempo-x-mgmt-vcluster in host ns mgmt,
-      # port 3200 for the query API.
-      #
-      # Port 3200 is the upstream Tempo `http_listen_port` default
-      # (grafana/helm-charts tempo-1.24.4 values.yaml `tempo.config`
-      # block) — the same port the rendered Service exposes as the
-      # `tempo-prom-metrics` named port for tempo-query traffic. The
-      # earlier value 3100 was a copy-paste mismatch from Loki's HTTP
-      # port (also `:3100` in the Loki single-binary chart) and would
-      # have produced `Tempo is not responding` in Grafana's datasource
-      # health-check on a fresh-prov walk. G117.5a (Refs #2788).
-      url: "http://tempo-x-tempo-x-mgmt-vcluster.mgmt.svc.cluster.local:3200"
+      # #4347 (Refs #4325): bp-tempo is now host-ns (namespace `tempo`). The
+      # single-binary chart's Service name is `<release>` = `tempo`, port
+      # 3200 (the upstream Tempo `http_listen_port` default — the same port
+      # the Service exposes for tempo-query traffic). The pre-#4325
+      # `tempo-x-tempo-x-mgmt-vcluster.mgmt.svc` name is dead. (Port 3200,
+      # not 3100 — the earlier 3100 was a copy-paste from Loki's HTTP port,
+      # G117.5a / #2788.)
+      url: "http://tempo.tempo.svc.cluster.local:3200"
     alertmanager:
       # Default OFF — Mimir's bundled AM and standalone bp-alertmanager
       # are not yet wired in clusters/_template/. Per-Sovereign overlay

--- a/platform/grafana/chart/values.yaml
+++ b/platform/grafana/chart/values.yaml
@@ -170,6 +170,33 @@ grafana:
       limits:
         cpu: 100m
         memory: 192Mi
+    # #4347 — the dashboard + datasource sidecars (kiwigrid/k8s-sidecar) had NO
+    # probes → the host-ns Kyverno `probes-present` Enforce policy denies the
+    # grafana Pod (after #4325 re-homed bp-grafana into a native host
+    # namespace). The sidecar serves no HTTP health port, so both probes are
+    # EXEC checks confirming PID 1 is still the python sidecar process (a
+    # crashed/replaced PID 1 fails the grep). /proc/1/cmdline is null-separated;
+    # `grep -aq` matches the python/sidecar substring on the python-slim base.
+    livenessProbe:
+      exec:
+        command:
+          - /bin/sh
+          - -c
+          - 'grep -aq -e python -e sidecar /proc/1/cmdline'
+      initialDelaySeconds: 15
+      periodSeconds: 30
+      timeoutSeconds: 5
+      failureThreshold: 3
+    readinessProbe:
+      exec:
+        command:
+          - /bin/sh
+          - -c
+          - 'grep -aq -e python -e sidecar /proc/1/cmdline'
+      initialDelaySeconds: 5
+      periodSeconds: 15
+      timeoutSeconds: 5
+      failureThreshold: 3
     datasources:
       enabled: true
       label: grafana_datasource

--- a/platform/harbor/blueprint.yaml
+++ b/platform/harbor/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-5-storage-and-data
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.38  # lockstep with chart/Chart.yaml (#4343 nginx.resources.requests for host-ns Kyverno resource-requests Enforce)
+  version: 1.2.39  # lockstep with chart/Chart.yaml (#4347 harbor-sso-configure liveness/readiness probes for host-ns Kyverno probes-present Enforce)
   card:
     title: Harbor
     family: foundation

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -147,7 +147,12 @@ type: application
 # materialise. The cnpg-cluster.yaml Cluster-CR gate is UNCHANGED (still
 # cluster.enabled — the host-bridge must not double-create it). Non-host-bridged
 # render byte-identical.
-version: 1.2.38
+# 1.2.39 (#4347): harbor-sso-configure Deployment gains liveness + readiness
+#   EXEC probes (heartbeat sentinel) so the host-ns Kyverno `probes-present`
+#   Enforce ClusterPolicy admits it (after #4325 de-vcluster re-homed bp-harbor
+#   into a native host namespace). Adds tests/kyverno-probes-present.sh.
+#   Refs #4347 #4325.
+version: 1.2.39
 appVersion: "2.14.3"
 # 1.2.23 (G117.5 #2744, 2026-06-02): SSO defense-in-depth via Harbor's
 # `oidc_extra_redirect_parms` config field. The configure-oauth Job now

--- a/platform/harbor/chart/templates/sso-configure-deployment.yaml
+++ b/platform/harbor/chart/templates/sso-configure-deployment.yaml
@@ -101,7 +101,20 @@ data:
     log "  OIDC_ADMIN_GROUP=${OIDC_ADMIN_GROUP}"
     log "  INTERVAL_SECONDS=${INTERVAL_SECONDS}"
 
+    # #4347 — liveness/readiness heartbeat sentinel. This continuous reconciler
+    # has NO serving port, so the Pod's livenessProbe / readinessProbe (required
+    # by the host-ns Kyverno `probes-present` Enforce ClusterPolicy after the
+    # #4325 de-vcluster re-homed bp-harbor into a host namespace) exec a
+    # freshness check against this file. Touched on startup (readiness green)
+    # and re-touched every tick; a wedged loop ages it out → liveness restart.
+    # Lives under the writable /tmp emptyDir (readOnlyRootFilesystem: true).
+    HEARTBEAT_FILE=/tmp/sso-configure-heartbeat
+    touch "${HEARTBEAT_FILE}"
+
     while true; do
+      # Re-touch the heartbeat each iteration so a healthy loop keeps the
+      # sentinel fresh; a wedged loop lets it age out → liveness restart (#4347).
+      touch "${HEARTBEAT_FILE}"
       sleep "${INTERVAL_SECONDS}"
 
       # 1) harbor-core reachable?
@@ -256,6 +269,33 @@ spec:
             limits:
               cpu: "200m"
               memory: "128Mi"
+          # #4347 — liveness + readiness EXEC probes (required by the host-ns
+          # Kyverno `probes-present` Enforce ClusterPolicy after #4325 moved
+          # bp-harbor into a native host namespace). This reconciler has NO
+          # serving port, so both probes check the /tmp/sso-configure-heartbeat
+          # sentinel the loop re-touches each tick: readiness = file exists,
+          # liveness = file modified within the last 5 minutes (wedged loop →
+          # kubelet restart).
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - 'test -f /tmp/sso-configure-heartbeat'
+            initialDelaySeconds: 2
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - '[ -n "$(find /tmp/sso-configure-heartbeat -mmin -5 2>/dev/null)" ]'
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
           volumeMounts:
             - name: script
               mountPath: /etc/harbor-sso

--- a/platform/harbor/chart/tests/_assert_probes_present.py
+++ b/platform/harbor/chart/tests/_assert_probes_present.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# #4347 helper — read a multi-doc helm render from stdin and assert every
+# PRIMARY container in a Deployment / StatefulSet / DaemonSet declares BOTH a
+# livenessProbe AND a readinessProbe — the exact shape the cluster-wide Kyverno
+# `probes-present` Enforce ClusterPolicy requires (platform/kyverno-policies/
+# chart/templates/baseline/04-probes.yaml).
+#
+# Scope mirrors the policy EXACTLY:
+#   - Matched kinds: Deployment, StatefulSet, DaemonSet ONLY. Job / CronJob are
+#     NOT matched by probes-present (a Job's containers run to completion;
+#     liveness/readiness are meaningless there), so they are skipped here too.
+#   - initContainers + ephemeralContainers are EXEMPT (the K8s API rejects
+#     liveness/readiness probes on initContainers), so only `containers[]` is
+#     checked.
+#
+# Prints a one-line OK summary on success; prints the offending
+# kind/name:container lines and exits 1 on any miss.
+import sys, re
+try:
+    import yaml
+except ImportError:
+    print("PyYAML not available; cannot run probes-present assertion", file=sys.stderr)
+    sys.exit(2)
+
+raw = sys.stdin.read()
+# Some upstream subchart templates emit stray trailing whitespace/tabs that
+# break a strict YAML scan; rstrip each line (cosmetic, render-neutral).
+raw = "\n".join(line.rstrip() for line in raw.splitlines())
+
+bad = []
+checked = 0
+for chunk in re.split(r"(?m)^---\s*$", raw):
+    chunk = chunk.strip()
+    if not chunk:
+        continue
+    try:
+        d = yaml.safe_load(chunk)
+    except Exception:
+        continue
+    if not isinstance(d, dict):
+        continue
+    kind = d.get("kind")
+    # Match the probes-present policy kinds exactly — NOT Job/CronJob.
+    if kind not in ("Deployment", "StatefulSet", "DaemonSet"):
+        continue
+    name = d.get("metadata", {}).get("name", "<noname>")
+    try:
+        podspec = d["spec"]["template"]["spec"]
+    except (KeyError, TypeError):
+        continue
+    # Only the primary containers[] are subject to the policy.
+    for c in (podspec.get("containers", []) or []):
+        checked += 1
+        missing = []
+        if not c.get("livenessProbe"):
+            missing.append("livenessProbe")
+        if not c.get("readinessProbe"):
+            missing.append("readinessProbe")
+        if missing:
+            bad.append("%s/%s container=%s missing=%s" % (kind, name, c.get("name"), "+".join(missing)))
+
+if bad:
+    print("workload containers MISSING liveness/readiness probes:")
+    for b in bad:
+        print(b)
+    sys.exit(1)
+
+if checked == 0:
+    print("no Deployment/StatefulSet/DaemonSet containers rendered — subchart deps not built? (run `helm dependency build`)")
+    sys.exit(1)
+
+print("%d Deployment/StatefulSet/DaemonSet container(s) all declare liveness+readiness probes" % checked)

--- a/platform/harbor/chart/tests/kyverno-probes-present.sh
+++ b/platform/harbor/chart/tests/kyverno-probes-present.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# #4347 — assert EVERY primary container in the rendered bp-harbor
+# Deployments / StatefulSets / DaemonSets declares BOTH a livenessProbe AND a
+# readinessProbe, so the cluster-wide Kyverno `probes-present` Enforce
+# ClusterPolicy admits every workload.
+#
+# After #4325 the platform planes (incl. harbor) install into NATIVE host
+# namespaces (not a vCluster), where the host Kyverno Enforce policies apply.
+# The chart's `harbor-sso-configure` Deployment is a continuous reconcile loop
+# (a `while true` shell loop) with NO serving port — it shipped with NO
+# liveness/readiness probes → kyverno `probes-present` (Enforce) DENIED it →
+# the bp-harbor Helm install failed → bp-harbor HR False. This test guards that
+# regression: it FAILS if any rendered Deployment/StatefulSet/DaemonSet
+# container lacks either probe.
+set -euo pipefail
+chart_dir="${1:-$(dirname "$0")/..}"
+cd "$chart_dir"
+chart_dir="$(pwd)"
+
+if ! ls charts/*.tgz >/dev/null 2>&1; then
+  helm dependency build "$chart_dir" >/dev/null 2>&1 || true
+fi
+
+assert_py="$chart_dir/tests/_assert_probes_present.py"
+
+assert_probes() {
+  local label="$1"; shift
+  local out rc
+  out=$(helm template t . --set gateway.host=registry.example.test "$@" 2>/dev/null | python3 "$assert_py")
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "FAIL [$label]:"
+    echo "$out" | sed 's/^/  /'
+    return 1
+  fi
+  echo "PASS [$label]: $out"
+}
+
+fail=0
+# Default render (core / jobservice / registry / portal / nginx / redis).
+assert_probes "default" || fail=1
+# SSO enabled (renders the harbor-sso-configure Deployment — the #4347 offender).
+assert_probes "sso-enabled" --set sso.enabled=true --set sso.sovereignFqdn=example.test || fail=1
+
+if [ "$fail" -ne 0 ]; then
+  echo "kyverno-probes-present: one or more workload containers lack liveness/readiness probes (would be DENIED by the host-ns Kyverno probes-present Enforce policy)."
+  exit 1
+fi
+echo "kyverno-probes-present: all Deployment/StatefulSet/DaemonSet containers declare liveness+readiness probes."

--- a/platform/loki/blueprint.yaml
+++ b/platform/loki/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.0.1  # lockstep with chart/Chart.yaml (#4343 loki.sidecar.resources for host-ns Kyverno resource-requests Enforce)
+  version: 1.0.2  # lockstep with chart/Chart.yaml (#4347 probes-present + harbor-proxy images for host-ns Kyverno Enforce)
   card:
     title: Loki
     family: insights

--- a/platform/loki/chart/Chart.yaml
+++ b/platform/loki/chart/Chart.yaml
@@ -19,7 +19,13 @@ type: application
 # cluster-wide Kyverno `resource-requests` Enforce policy. Post-#4325 this
 # chart installs into the native host namespace (not a vCluster) where the
 # policy applies; upstream defaults the sidecar resources to empty.
-version: 1.0.1
+# 1.0.2 (#4347): host-ns Kyverno Enforce compliance — (a) ENABLE the loki pod
+#   livenessProbe (loki.loki.livenessProbe httpGet /ready; upstream shipped
+#   readiness-only) + add EXEC probes to the loki-sc-rules sidecar
+#   (probes-present Enforce); (b) proxy both images (grafana/loki +
+#   kiwigrid/k8s-sidecar) through harbor.openova.io (harbor-proxy-pull Enforce).
+#   Adds tests/kyverno-probes-present.sh. Refs #4347 #4325.
+version: 1.0.2
 appVersion: "3.6.7"
 keywords: [catalyst, blueprint, loki, observability, logs]
 maintainers:

--- a/platform/loki/chart/tests/_assert_probes_present.py
+++ b/platform/loki/chart/tests/_assert_probes_present.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# #4347 helper — read a multi-doc helm render from stdin and assert every
+# PRIMARY container in a Deployment / StatefulSet / DaemonSet declares BOTH a
+# livenessProbe AND a readinessProbe — the exact shape the cluster-wide Kyverno
+# `probes-present` Enforce ClusterPolicy requires (platform/kyverno-policies/
+# chart/templates/baseline/04-probes.yaml).
+#
+# Scope mirrors the policy EXACTLY:
+#   - Matched kinds: Deployment, StatefulSet, DaemonSet ONLY. Job / CronJob are
+#     NOT matched by probes-present (a Job's containers run to completion;
+#     liveness/readiness are meaningless there), so they are skipped here too.
+#   - initContainers + ephemeralContainers are EXEMPT (the K8s API rejects
+#     liveness/readiness probes on initContainers), so only `containers[]` is
+#     checked.
+#
+# Prints a one-line OK summary on success; prints the offending
+# kind/name:container lines and exits 1 on any miss.
+import sys, re
+try:
+    import yaml
+except ImportError:
+    print("PyYAML not available; cannot run probes-present assertion", file=sys.stderr)
+    sys.exit(2)
+
+raw = sys.stdin.read()
+# Some upstream subchart templates emit stray trailing whitespace/tabs that
+# break a strict YAML scan; rstrip each line (cosmetic, render-neutral).
+raw = "\n".join(line.rstrip() for line in raw.splitlines())
+
+bad = []
+checked = 0
+for chunk in re.split(r"(?m)^---\s*$", raw):
+    chunk = chunk.strip()
+    if not chunk:
+        continue
+    try:
+        d = yaml.safe_load(chunk)
+    except Exception:
+        continue
+    if not isinstance(d, dict):
+        continue
+    kind = d.get("kind")
+    # Match the probes-present policy kinds exactly — NOT Job/CronJob.
+    if kind not in ("Deployment", "StatefulSet", "DaemonSet"):
+        continue
+    name = d.get("metadata", {}).get("name", "<noname>")
+    try:
+        podspec = d["spec"]["template"]["spec"]
+    except (KeyError, TypeError):
+        continue
+    # Only the primary containers[] are subject to the policy.
+    for c in (podspec.get("containers", []) or []):
+        checked += 1
+        missing = []
+        if not c.get("livenessProbe"):
+            missing.append("livenessProbe")
+        if not c.get("readinessProbe"):
+            missing.append("readinessProbe")
+        if missing:
+            bad.append("%s/%s container=%s missing=%s" % (kind, name, c.get("name"), "+".join(missing)))
+
+if bad:
+    print("workload containers MISSING liveness/readiness probes:")
+    for b in bad:
+        print(b)
+    sys.exit(1)
+
+if checked == 0:
+    print("no Deployment/StatefulSet/DaemonSet containers rendered — subchart deps not built? (run `helm dependency build`)")
+    sys.exit(1)
+
+print("%d Deployment/StatefulSet/DaemonSet container(s) all declare liveness+readiness probes" % checked)

--- a/platform/loki/chart/tests/kyverno-probes-present.sh
+++ b/platform/loki/chart/tests/kyverno-probes-present.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# #4347 — assert EVERY primary container in the rendered bp-loki
+# Deployments / StatefulSets / DaemonSets declares BOTH a livenessProbe AND a
+# readinessProbe, so the cluster-wide Kyverno `probes-present` Enforce
+# ClusterPolicy admits every workload.
+#
+# After #4325 the platform planes (incl. loki) install into NATIVE host
+# namespaces (not a vCluster), where the host Kyverno Enforce policies apply.
+# Two offenders: the upstream loki chart shipped `loki.livenessProbe: {}`
+# (empty) so the SingleBinary StatefulSet's loki container had readiness but NO
+# liveness; the loki-sc-rules kiwigrid/k8s-sidecar shipped NO probes at all.
+# Both were DENIED by `probes-present` (Enforce). This test guards the
+# regression: it FAILS if any rendered Deployment/StatefulSet/DaemonSet
+# container lacks either probe.
+set -euo pipefail
+chart_dir="${1:-$(dirname "$0")/..}"
+cd "$chart_dir"
+chart_dir="$(pwd)"
+
+if ! ls charts/*.tgz >/dev/null 2>&1; then
+  helm dependency build "$chart_dir" >/dev/null 2>&1 || true
+fi
+
+assert_py="$chart_dir/tests/_assert_probes_present.py"
+out=$(helm template t . 2>/dev/null | python3 "$assert_py")
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  echo "FAIL: $out"
+  echo "kyverno-probes-present: one or more workload containers lack liveness/readiness probes (would be DENIED by the host-ns Kyverno probes-present Enforce policy)."
+  exit 1
+fi
+echo "PASS: $out"
+echo "kyverno-probes-present: all Deployment/StatefulSet/DaemonSet containers declare liveness+readiness probes."

--- a/platform/loki/chart/values.yaml
+++ b/platform/loki/chart/values.yaml
@@ -44,11 +44,35 @@ loki:
         ruler: ruler
         admin: admin
     # Pin upstream image — DO NOT use floating tags.
+    # #4347 — route through the Sovereign-local Harbor proxy-cache so the
+    # host-ns Kyverno `harbor-proxy-pull` Enforce ClusterPolicy admits it
+    # (after #4325 moved bp-loki into a native host namespace). The raw
+    # `docker.io/grafana/loki` matches neither allowed glob.
     image:
-      registry: docker.io
-      repository: grafana/loki
+      registry: harbor.openova.io
+      repository: proxy-dockerhub/grafana/loki
       tag: "3.6.7"
       pullPolicy: IfNotPresent
+
+    # #4347 — ENABLE the Loki pod livenessProbe. The upstream chart ships
+    # `loki.readinessProbe` (httpGet /ready) populated but `loki.livenessProbe:
+    # {}` (empty) → the SingleBinary StatefulSet rendered a readinessProbe but
+    # NO livenessProbe → the host-ns Kyverno `probes-present` Enforce
+    # ClusterPolicy (requires BOTH on every container, after #4325) would DENY
+    # it. NOTE the key lives at loki.loki.livenessProbe: the subchart is named
+    # `loki`, so the parent's `loki:` map IS the subchart's `.Values`, and the
+    # statefulset reads `.Values.loki.livenessProbe` — i.e. parent
+    # `loki.loki.livenessProbe`. Mirror the readiness httpGet against /ready;
+    # generous initial delay so WAL replay / compaction startup settles first.
+    livenessProbe:
+      httpGet:
+        path: /ready
+        port: http-metrics
+      initialDelaySeconds: 60
+      periodSeconds: 30
+      timeoutSeconds: 5
+      failureThreshold: 5
+      successThreshold: 1
 
   # SingleBinary StatefulSet — 1 replica, 10Gi PVC for chunks + index.
   singleBinary:
@@ -73,6 +97,13 @@ loki:
   # de-vcluster migration it installs into the native host namespace and the
   # StatefulSet admission is DENIED. Modest request for the light k8s watcher.
   sidecar:
+    # #4347 — proxy the kiwigrid/k8s-sidecar image through the Sovereign-local
+    # Harbor so the host-ns `harbor-proxy-pull` Enforce policy admits it
+    # (`docker.io/kiwigrid/k8s-sidecar` matches no allowed glob). Mirror the
+    # grafana sidecar's proxy-dockerhub convention.
+    image:
+      registry: harbor.openova.io
+      repository: proxy-dockerhub/kiwigrid/k8s-sidecar
     resources:
       requests:
         cpu: 10m
@@ -80,6 +111,32 @@ loki:
       limits:
         cpu: 50m
         memory: 64Mi
+    # #4347 — the loki-sc-rules sidecar (kiwigrid/k8s-sidecar) had NO probes →
+    # the host-ns Kyverno `probes-present` Enforce policy denies the StatefulSet.
+    # The sidecar serves no HTTP health port, so both probes are EXEC checks
+    # confirming PID 1 is still the python sidecar process (a crashed/replaced
+    # PID 1 fails the grep). /proc/1/cmdline is null-separated; grep -q matches
+    # the `python` / `sidecar` substring on the python-slim base image.
+    livenessProbe:
+      exec:
+        command:
+          - /bin/sh
+          - -c
+          - 'grep -aq -e python -e sidecar /proc/1/cmdline'
+      initialDelaySeconds: 15
+      periodSeconds: 30
+      timeoutSeconds: 5
+      failureThreshold: 3
+    readinessProbe:
+      exec:
+        command:
+          - /bin/sh
+          - -c
+          - 'grep -aq -e python -e sidecar /proc/1/cmdline'
+      initialDelaySeconds: 5
+      periodSeconds: 15
+      timeoutSeconds: 5
+      failureThreshold: 3
 
   # SimpleScalable / Distributed pools — DEFAULT 0 replicas. Per-Sovereign
   # overlays bump these (and flip `deploymentMode`) when scaling out.

--- a/platform/mimir/blueprint.yaml
+++ b/platform/mimir/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.0.6  # lockstep with chart/Chart.yaml (#4343 gateway + MinIO cpu requests for host-ns Kyverno resource-requests Enforce)
+  version: 1.0.7  # lockstep with chart/Chart.yaml (#4347 probes-present + harbor-proxy-pull for host-ns Kyverno Enforce post-#4325 de-vcluster)
   card:
     title: Mimir
     family: insights

--- a/platform/mimir/chart/Chart.yaml
+++ b/platform/mimir/chart/Chart.yaml
@@ -13,12 +13,25 @@ description: |
   overlays scale per-component replicas + flip zone-aware-replication on
   for HA Sovereigns.
 type: application
+# 1.0.7 (#4347, Refs #4325, 2026-06-25): make EVERY rendered workload container
+# satisfy the host-ns Kyverno `probes-present` AND `harbor-proxy-pull` Enforce
+# policies. (a) Proxy every image through Harbor (grafana/mimir,
+# grafana/rollout-operator, nginxinc/nginx-unprivileged, minio + mc). (b) Add a
+# livenessProbe to the 9 Mimir components that shipped readiness-only via the
+# upstream `<component>.livenessProbe` value knob. (c) The gateway (nginx),
+# rollout-operator, and bundled MinIO expose NO livenessProbe knob in
+# mimir-distributed 6.0.6, so those three subcharts are disabled and re-rendered
+# as Catalyst-owned probe-compliant equivalents in
+# templates/devcluster-workloads.yaml (the Mimir S3 wiring is restated in
+# values under mimir.structuredConfig since disabling the bundled MinIO drops
+# its auto-injection).
+#
 # 1.0.6 (#4343, 2026-06-25): set `gateway.resources.requests` and add the
 # missing cpu request on the bundled MinIO StatefulSet + create-bucket Job so
 # every container satisfies the cluster-wide Kyverno `resource-requests`
 # Enforce policy. Post-#4325 this chart installs into the native host namespace
 # (not a vCluster) where the policy applies.
-version: 1.0.6
+version: 1.0.7
 appVersion: "3.0.4"
 keywords: [catalyst, blueprint, mimir, observability, metrics, prometheus]
 maintainers:

--- a/platform/mimir/chart/templates/_helpers.tpl
+++ b/platform/mimir/chart/templates/_helpers.tpl
@@ -45,3 +45,21 @@ catalyst.openova.io/family: observability
 app.kubernetes.io/name: {{ include "bp-mimir.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
+
+{{/* #4347 — replicate the upstream `mimir.fullname` naming exactly so the
+     Catalyst-owned gateway replacement in templates/devcluster-workloads.yaml
+     uses the SAME Service name the bundled gateway would have. Upstream uses
+     infix "mimir" with a `contains` short-circuit: if the release name already
+     contains "mimir" (the production HelmRelease is named `mimir`), the
+     fullname IS the release name; otherwise it's `<release>-mimir`. So:
+       release "mimir" -> "mimir"      -> gateway svc "mimir-gateway"
+       release "t"     -> "t-mimir"    -> gateway svc "t-mimir-gateway"
+     This keeps Grafana's `mimir-gateway` datasource Service contract intact. */}}
+{{- define "bp-mimir.mimirFullname" -}}
+{{- $name := "mimir" -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}

--- a/platform/mimir/chart/templates/devcluster-workloads.yaml
+++ b/platform/mimir/chart/templates/devcluster-workloads.yaml
@@ -1,0 +1,761 @@
+{{- /*
+devcluster-workloads.yaml — #4347 (Refs #4325)
+
+Catalyst-owned replacements for the three upstream mimir-distributed
+sub-components whose containers the upstream chart renders WITHOUT a
+`livenessProbe` (and, for MinIO, without ANY probe). The pinned
+mimir-distributed 6.0.6 chart exposes no per-component `livenessProbe` knob
+for the gateway (nginx), the rollout-operator, or the bundled MinIO, so they
+can never satisfy the host-ns Kyverno `probes-present` Enforce ClusterPolicy
+through subchart values alone.
+
+After #4325 (de-vcluster) bp-mimir installs into the NATIVE host namespace
+`mimir`, which is NOT in the policy's excludeNamespaces — so every
+Deployment/StatefulSet/DaemonSet container must declare BOTH livenessProbe
+AND readinessProbe (and pull a Harbor proxy-cache image). The three upstream
+sub-components are therefore DISABLED in values.yaml
+(`mimir-distributed.gateway.enabled=false`,
+`mimir-distributed.rollout_operator.enabled=false`,
+`mimir-distributed.minio.enabled=false`) and faithfully re-rendered here with
+BOTH probes + the Harbor-proxied images.
+
+Naming is kept byte-identical to the upstream render so every downstream
+contract is preserved (mimirFullname = release "mimir" -> "mimir";
+release "t" -> "t-mimir"):
+  - gateway Service `<mimirFullname>-gateway` (port 80 → http-metrics) — on the
+    production HelmRelease named `mimir` this is `mimir-gateway`, the Service
+    Grafana's datasource targets.
+  - rollout-operator Service `<release>-rollout-operator` (the webhook-gate
+    hook in templates/webhook-gate-hook.yaml polls its Endpoints) — `mimir`
+    release -> `mimir-rollout-operator`.
+  - MinIO Service `<release>-minio` (port 9000) + Secret `<release>-minio`
+    (the Mimir blocks/ruler/alertmanager S3 config in values.yaml's
+    `mimir-distributed.mimir.structuredConfig` points here) — `mimir` release
+    -> `mimir-minio`.
+
+Image + resource knobs are READ FROM the same `mimir-distributed.*` values
+keys the disabled subcharts would have consumed, so a per-Sovereign overlay
+that bumps an image/tag/resource still flows through unchanged.
+*/}}
+{{- $md := index .Values "mimir-distributed" -}}
+{{- $rel := .Release.Name -}}
+{{- $ns := .Release.Namespace -}}
+{{- $httpPort := 8080 -}}
+{{- /* mimirFullname = the upstream `mimir.fullname` (release "mimir" -> "mimir";
+       release "t" -> "t-mimir"). Used for the gateway Service name + every
+       mimir-component upstream DNS name the nginx proxy_pass targets. */}}
+{{- $mf := include "bp-mimir.mimirFullname" . -}}
+
+{{/* ───────────────────────── GATEWAY (nginx) ───────────────────────── */}}
+{{- $gw := $md.gateway | default dict -}}
+{{- $gwName := printf "%s-gateway" (include "bp-mimir.mimirFullname" .) -}}
+{{- $gwImg := (($gw.nginx).image) | default dict -}}
+{{- $gwRegistry := $gwImg.registry | default "harbor.openova.io" -}}
+{{- $gwRepo := $gwImg.repository | default "proxy-dockerhub/nginxinc/nginx-unprivileged" -}}
+{{- $gwTag := $gwImg.tag | default "1.29-alpine" -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $gwName }}-nginx
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-mimir.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway-nginx
+data:
+  nginx.conf: |
+    worker_processes  5;  ## Default: 1
+    error_log  /dev/stderr error;
+    pid        /tmp/nginx.pid;
+    worker_rlimit_nofile 8192;
+
+    events {
+      worker_connections  4096;  ## Default: 1024
+    }
+
+    http {
+      client_body_temp_path /tmp/client_temp;
+      proxy_temp_path       /tmp/proxy_temp_path;
+      fastcgi_temp_path     /tmp/fastcgi_temp;
+      uwsgi_temp_path       /tmp/uwsgi_temp;
+      scgi_temp_path        /tmp/scgi_temp;
+
+      default_type application/octet-stream;
+      log_format   main '$remote_addr - $remote_user [$time_local]  $status '
+            '"$request" $body_bytes_sent "$http_referer" '
+            '"$http_user_agent" "$http_x_forwarded_for"';
+      access_log   /dev/stderr  main;
+
+      sendfile           on;
+      tcp_nopush         on;
+      proxy_http_version 1.1;
+      resolver kube-dns.kube-system.svc.cluster.local.;
+
+      map $http_x_scope_orgid $ensured_x_scope_orgid {
+        default $http_x_scope_orgid;
+        "" "anonymous";
+      }
+
+      map $http_x_scope_orgid $has_multiple_orgid_headers {
+        default 0;
+        "~^.+,.+$" 1;
+      }
+
+      proxy_read_timeout 300;
+      server {
+        listen 8080;
+        listen [::]:8080;
+        client_max_body_size 540M;
+
+        if ($has_multiple_orgid_headers = 1) {
+            return 400 'Sending multiple X-Scope-OrgID headers is not allowed. Use a single header with | as separator instead.';
+        }
+
+        location = / {
+          return 200 'OK';
+          auth_basic off;
+        }
+
+        location = /ready {
+          return 200 'OK';
+          auth_basic off;
+        }
+
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+
+        # Distributor endpoints
+        location /distributor {
+          set $distributor {{ $mf }}-distributor-headless.{{ $ns }}.svc.cluster.local.;
+          proxy_pass      http://$distributor:{{ $httpPort }}$request_uri;
+        }
+        location = /api/v1/push {
+          set $distributor {{ $mf }}-distributor-headless.{{ $ns }}.svc.cluster.local.;
+          proxy_pass      http://$distributor:{{ $httpPort }}$request_uri;
+        }
+        location /otlp/v1/metrics {
+          set $distributor {{ $mf }}-distributor-headless.{{ $ns }}.svc.cluster.local.;
+          proxy_pass      http://$distributor:{{ $httpPort }}$request_uri;
+        }
+
+        # Alertmanager endpoints
+        location /alertmanager {
+          set $alertmanager {{ $mf }}-alertmanager-headless.{{ $ns }}.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:{{ $httpPort }}$request_uri;
+        }
+        location = /multitenant_alertmanager/status {
+          set $alertmanager {{ $mf }}-alertmanager-headless.{{ $ns }}.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:{{ $httpPort }}$request_uri;
+        }
+        location = /multitenant_alertmanager/configs {
+          set $alertmanager {{ $mf }}-alertmanager-headless.{{ $ns }}.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:{{ $httpPort }}$request_uri;
+        }
+        location = /api/v1/alerts {
+          set $alertmanager {{ $mf }}-alertmanager-headless.{{ $ns }}.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:{{ $httpPort }}$request_uri;
+        }
+
+        # Ruler endpoints
+        location /prometheus/config/v1/rules {
+          set $ruler {{ $mf }}-ruler.{{ $ns }}.svc.cluster.local.;
+          proxy_pass      http://$ruler:{{ $httpPort }}$request_uri;
+        }
+        location /prometheus/api/v1/rules {
+          set $ruler {{ $mf }}-ruler.{{ $ns }}.svc.cluster.local.;
+          proxy_pass      http://$ruler:{{ $httpPort }}$request_uri;
+        }
+        location /prometheus/api/v1/alerts {
+          set $ruler {{ $mf }}-ruler.{{ $ns }}.svc.cluster.local.;
+          proxy_pass      http://$ruler:{{ $httpPort }}$request_uri;
+        }
+        location = /ruler/ring {
+          set $ruler {{ $mf }}-ruler.{{ $ns }}.svc.cluster.local.;
+          proxy_pass      http://$ruler:{{ $httpPort }}$request_uri;
+        }
+
+        # Rest of /prometheus goes to the query frontend
+        location /prometheus {
+          set $query_frontend {{ $mf }}-query-frontend.{{ $ns }}.svc.cluster.local.;
+          proxy_pass      http://$query_frontend:{{ $httpPort }}$request_uri;
+        }
+
+        # Buildinfo endpoint can go to any component
+        location = /api/v1/status/buildinfo {
+          set $query_frontend {{ $mf }}-query-frontend.{{ $ns }}.svc.cluster.local.;
+          proxy_pass      http://$query_frontend:{{ $httpPort }}$request_uri;
+        }
+
+        # Compactor endpoint for uploading blocks
+        location /api/v1/upload/block/ {
+          set $compactor {{ $mf }}-compactor.{{ $ns }}.svc.cluster.local.;
+          proxy_pass      http://$compactor:{{ $httpPort }}$request_uri;
+        }
+      }
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $gwName }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-mimir.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+spec:
+  type: ClusterIP
+  internalTrafficPolicy: Cluster
+  ports:
+    - port: 80
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 8080
+      protocol: TCP
+      name: legacy-http-metrics
+      targetPort: http-metrics
+  selector:
+    {{- include "bp-mimir.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $gwName }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-mimir.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+spec:
+  replicas: {{ $gw.replicas | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "bp-mimir.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: gateway
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        {{- include "bp-mimir.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: gateway
+    spec:
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: gateway
+          image: {{ printf "%s/%s:%s" $gwRegistry $gwRepo $gwTag }}
+          imagePullPolicy: {{ ($md.image).pullPolicy | default "IfNotPresent" }}
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+            - name: tmp
+              mountPath: /tmp
+            - name: docker-entrypoint-d-override
+              mountPath: /docker-entrypoint.d
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+          # #4347 — BOTH probes. nginx serves `/ready` (return 200) on 8080.
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+          resources:
+            {{- toYaml ($gw.resources | default (dict "requests" (dict "cpu" "10m" "memory" "32Mi") "limits" (dict "cpu" "500m" "memory" "128Mi"))) | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: {{ $gwName }}-nginx
+        - name: docker-entrypoint-d-override
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+---
+{{/* ─────────────────────── ROLLOUT-OPERATOR ─────────────────────── */}}
+{{- $ro := $md.rollout_operator | default dict -}}
+{{- $roName := printf "%s-rollout-operator" $rel -}}
+{{- $roImg := $ro.image | default dict -}}
+{{- $roRegistry := $roImg.registry | default "harbor.openova.io" -}}
+{{- $roRepo := $roImg.repository | default "proxy-dockerhub/grafana/rollout-operator" -}}
+{{- $roTag := $roImg.tag | default "v0.32.0" -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $roName }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-mimir.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rollout-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $roName }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-mimir.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rollout-operator
+rules:
+  - apiGroups: [""]
+    resources: [pods]
+    verbs: [list, get, watch, delete]
+  - apiGroups: [apps]
+    resources: [statefulsets]
+    verbs: [list, get, watch, patch]
+  - apiGroups: [apps]
+    resources: [statefulsets/status]
+    verbs: [update]
+  - apiGroups: [rollout-operator.grafana.com]
+    resources: [zoneawarepoddisruptionbudgets]
+    verbs: [get, list, watch]
+  - apiGroups: [rollout-operator.grafana.com]
+    resources: [replicatemplates/scale, replicatemplates/status]
+    verbs: [get, patch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $roName }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-mimir.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rollout-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $roName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $roName }}
+    namespace: {{ $ns }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $roName }}-webhook-clusterrole
+  labels:
+    {{- include "bp-mimir.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rollout-operator
+rules:
+  - apiGroups: [admissionregistration.k8s.io]
+    resources: [validatingwebhookconfigurations, mutatingwebhookconfigurations]
+    verbs: [list, patch, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $roName }}-webhook-clusterrolebinding
+  labels:
+    {{- include "bp-mimir.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rollout-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $roName }}-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: {{ $roName }}
+    namespace: {{ $ns }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $roName }}-webhook-role
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-mimir.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rollout-operator
+rules:
+  - apiGroups: [""]
+    resources: [secrets]
+    verbs: [update, get]
+    resourceNames: [certificate]
+  - apiGroups: [""]
+    resources: [secrets]
+    verbs: [create]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $roName }}-webhook-rolebinding
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-mimir.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rollout-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $roName }}-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ $roName }}
+    namespace: {{ $ns }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $roName }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-mimir.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rollout-operator
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    {{- include "bp-mimir.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: rollout-operator
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $roName }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-mimir.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rollout-operator
+spec:
+  replicas: {{ $ro.replicas | default 1 }}
+  revisionHistoryLimit: 10
+  minReadySeconds: 10
+  selector:
+    matchLabels:
+      {{- include "bp-mimir.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: rollout-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        {{- include "bp-mimir.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: rollout-operator
+    spec:
+      serviceAccountName: {{ $roName }}
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: rollout-operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          image: {{ printf "%s/%s:%s" $roRegistry $roRepo $roTag }}
+          imagePullPolicy: {{ ($md.image).pullPolicy | default "IfNotPresent" }}
+          args:
+            - -kubernetes.namespace={{ $ns }}
+            - -server-tls.enabled=true
+            - -server-tls.self-signed-cert.secret-name=certificate
+            - -server-tls.self-signed-cert.dns-name={{ $roName }}.{{ $ns }}.svc
+          ports:
+            - name: http-metrics
+              containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
+              protocol: TCP
+          # #4347 — BOTH probes on the rollout-operator `/ready` http endpoint.
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+---
+{{/* ───────────────────────────── MINIO ───────────────────────────── */}}
+{{- $minio := $md.minio | default dict -}}
+{{- $minioName := printf "%s-minio" $rel -}}
+{{- $minioImg := $minio.image | default dict -}}
+{{- $minioRepo := $minioImg.repository | default "harbor.openova.io/proxy-quay/minio/minio" -}}
+{{- $minioTag := $minioImg.tag | default "RELEASE.2024-12-18T13-15-44Z" -}}
+{{- $mcImg := $minio.mcImage | default dict -}}
+{{- $mcRepo := $mcImg.repository | default "harbor.openova.io/proxy-quay/minio/mc" -}}
+{{- $mcTag := $mcImg.tag | default "RELEASE.2024-11-21T17-21-54Z" -}}
+{{- $minioUser := $minio.rootUser | default "grafana-mimir" -}}
+{{- $minioPass := $minio.rootPassword | default "supersecret" -}}
+{{- $minioSize := ($minio.persistence).size | default "5Gi" -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $minioName }}-sa
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-mimir.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $minioName }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-mimir.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+type: Opaque
+data:
+  rootUser: {{ $minioUser | b64enc | quote }}
+  rootPassword: {{ $minioPass | b64enc | quote }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $minioName }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-mimir.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+data:
+  initialize: |-
+    #!/bin/sh
+    set -e
+    MC_CONFIG_DIR="/tmp/minio/mc/"
+    MC="/usr/bin/mc --insecure --config-dir ${MC_CONFIG_DIR}"
+    connectToMinio() {
+      ATTEMPTS=0 ; LIMIT=29
+      ACCESS=$(cat /config/rootUser) ; SECRET=$(cat /config/rootPassword)
+      set +e
+      MC_COMMAND="${MC} alias set myminio http://$MINIO_ENDPOINT:$MINIO_PORT $ACCESS $SECRET"
+      $MC_COMMAND ; STATUS=$?
+      until [ $STATUS = 0 ]; do
+        ATTEMPTS=$(expr $ATTEMPTS + 1)
+        if [ $ATTEMPTS -gt $LIMIT ]; then exit 1; fi
+        sleep 2 ; $MC_COMMAND ; STATUS=$?
+      done
+      set -e
+    }
+    createBucket() {
+      BUCKET=$1
+      if ! ${MC} stat myminio/$BUCKET >/dev/null 2>&1; then
+        echo "Creating bucket '$BUCKET'"
+        ${MC} mb myminio/$BUCKET
+      else
+        echo "Bucket '$BUCKET' already exists."
+      fi
+    }
+    connectToMinio
+    createBucket mimir-tsdb
+    createBucket mimir-ruler
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $minioName }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-mimir.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ $minioSize | quote }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $minioName }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-mimir.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 9000
+      protocol: TCP
+      targetPort: 9000
+  selector:
+    {{- include "bp-mimir.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $minioName }}-console
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-mimir.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 9001
+      protocol: TCP
+      targetPort: 9001
+  selector:
+    {{- include "bp-mimir.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $minioName }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-mimir.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 0
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "bp-mimir.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: minio
+  template:
+    metadata:
+      labels:
+        {{- include "bp-mimir.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: minio
+    spec:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 1000
+        runAsUser: 1000
+      serviceAccountName: {{ $minioName }}-sa
+      containers:
+        - name: minio
+          image: {{ printf "%s:%s" $minioRepo $minioTag }}
+          imagePullPolicy: {{ $minioImg.pullPolicy | default "IfNotPresent" }}
+          command:
+            - /bin/sh
+            - -ce
+            - /usr/bin/docker-entrypoint.sh minio server /export -S /etc/minio/certs/ --address :9000 --console-address :9001
+          volumeMounts:
+            - name: export
+              mountPath: /export
+          ports:
+            - name: http
+              containerPort: 9000
+            - name: http-console
+              containerPort: 9001
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $minioName }}
+                  key: rootUser
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $minioName }}
+                  key: rootPassword
+            - name: MINIO_PROMETHEUS_AUTH_TYPE
+              value: "public"
+          # #4347 — BOTH probes on MinIO's native health endpoints.
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /minio/health/ready
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 15
+          resources:
+            {{- toYaml ($minio.resources | default (dict "requests" (dict "cpu" "50m" "memory" "512Mi"))) | nindent 12 }}
+          securityContext:
+            readOnlyRootFilesystem: false
+      volumes:
+        - name: export
+          persistentVolumeClaim:
+            claimName: {{ $minioName }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $mf }}-make-minio-buckets
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-mimir.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio-make-bucket
+spec:
+  backoffLimit: 6
+  template:
+    metadata:
+      labels:
+        {{- include "bp-mimir.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: minio-make-bucket
+    spec:
+      restartPolicy: OnFailure
+      volumes:
+        - name: minio-configuration
+          projected:
+            sources:
+              - configMap:
+                  name: {{ $minioName }}
+              - secret:
+                  name: {{ $minioName }}
+      containers:
+        - name: minio-mc
+          image: {{ printf "%s:%s" $mcRepo $mcTag }}
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "/config/initialize"]
+          env:
+            - name: MINIO_ENDPOINT
+              value: {{ $minioName }}
+            - name: MINIO_PORT
+              value: "9000"
+          volumeMounts:
+            - name: minio-configuration
+              mountPath: /config
+          resources:
+            {{- toYaml (($minio.makeBucketJob).resources | default (dict "requests" (dict "cpu" "10m" "memory" "128Mi"))) | nindent 12 }}

--- a/platform/mimir/chart/tests/_assert_probes_present.py
+++ b/platform/mimir/chart/tests/_assert_probes_present.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# #4347 helper — read a multi-doc helm render from stdin and assert every
+# PRIMARY container of a Deployment / StatefulSet / DaemonSet declares BOTH a
+# livenessProbe AND a readinessProbe (the exact shape the Kyverno
+# `probes-present` Enforce ClusterPolicy requires). initContainers are EXEMPT
+# (the K8s API rejects probes on them, and the policy excludes them). Job /
+# CronJob are NOT matched by the policy and are skipped here.
+#
+# Prints a one-line OK summary on success; prints the offending
+# kind/name:container lines and exits 1 on any miss.
+import sys, re
+try:
+    import yaml
+except ImportError:
+    print("PyYAML not available; cannot run probes-present assertion", file=sys.stderr)
+    sys.exit(2)
+
+raw = sys.stdin.read()
+# Some upstream subchart templates emit stray trailing whitespace/tabs that
+# break a strict YAML scan; rstrip each line (cosmetic, render-neutral).
+raw = "\n".join(line.rstrip() for line in raw.splitlines())
+
+bad = []
+checked = 0
+for chunk in re.split(r"(?m)^---\s*$", raw):
+    chunk = chunk.strip()
+    if not chunk:
+        continue
+    try:
+        d = yaml.safe_load(chunk)
+    except Exception:
+        continue
+    if not isinstance(d, dict):
+        continue
+    kind = d.get("kind")
+    if kind not in ("Deployment", "StatefulSet", "DaemonSet"):
+        continue
+    name = d.get("metadata", {}).get("name", "<noname>")
+    try:
+        podspec = d["spec"]["template"]["spec"]
+    except (KeyError, TypeError):
+        continue
+    # initContainers are EXEMPT per the probes-present policy.
+    for c in list(podspec.get("containers", []) or []):
+        checked += 1
+        has_live = bool(c.get("livenessProbe"))
+        has_ready = bool(c.get("readinessProbe"))
+        if not (has_live and has_ready):
+            miss = []
+            if not has_live:
+                miss.append("livenessProbe")
+            if not has_ready:
+                miss.append("readinessProbe")
+            bad.append("%s/%s container=%s MISSING %s"
+                       % (kind, name, c.get("name"), "+".join(miss)))
+
+if bad:
+    print("workload containers MISSING liveness/readiness probes:")
+    for b in bad:
+        print(b)
+    sys.exit(1)
+
+if checked == 0:
+    print("no workload containers rendered — subchart deps not built? (run `helm dependency build`)")
+    sys.exit(1)
+
+print("%d workload container(s) all declare livenessProbe + readinessProbe" % checked)

--- a/platform/mimir/chart/tests/kyverno-probes-present.sh
+++ b/platform/mimir/chart/tests/kyverno-probes-present.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# #4347 — assert EVERY primary container of a Deployment / StatefulSet /
+# DaemonSet in the rendered bp-mimir manifests declares BOTH a livenessProbe
+# AND a readinessProbe, so the cluster-wide Kyverno `probes-present` Enforce
+# ClusterPolicy admits every workload.
+#
+# After #4325 this chart installs into a NATIVE host namespace (not a vCluster)
+# where the host Kyverno Enforce policies apply. The pinned mimir-distributed
+# 6.0.6 chart shipped the 9 microservice components with a readinessProbe but
+# NO livenessProbe (overrides-exporter was the only one with both), and the
+# gateway (nginx), rollout-operator, and bundled MinIO expose NO livenessProbe
+# knob at all. #4347 (a) sets `<component>.livenessProbe` on the 9 components
+# and (b) disables + re-renders the gateway/rollout-operator/MinIO as
+# Catalyst-owned probe-compliant equivalents in
+# templates/devcluster-workloads.yaml. This test guards that whole-render
+# invariant — it PASSES after the fix and FAILS if any of it is reverted.
+set -euo pipefail
+chart_dir="${1:-$(dirname "$0")/..}"
+cd "$chart_dir"
+chart_dir="$(pwd)"
+
+# The mimir-distributed subchart .tgz must be present for the workloads to
+# render; build deps if it isn't already vendored.
+if ! ls charts/*.tgz >/dev/null 2>&1; then
+  helm dependency build "$chart_dir" >/dev/null 2>&1 || true
+fi
+
+assert_py="$chart_dir/tests/_assert_probes_present.py"
+
+assert_probes() {
+  local label="$1"; shift
+  local out rc
+  out=$(helm template t . "$@" 2>/dev/null | python3 "$assert_py")
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "FAIL [$label]:"
+    echo "$out" | sed 's/^/  /'
+    return 1
+  fi
+  echo "PASS [$label]: $out"
+}
+
+fail=0
+assert_probes "default" || fail=1
+
+if [ "$fail" -ne 0 ]; then
+  echo "kyverno-probes-present: one or more workload containers lack a livenessProbe and/or readinessProbe (would be DENIED by the host-ns Kyverno probes-present Enforce policy)."
+  exit 1
+fi
+echo "kyverno-probes-present: all workload containers declare livenessProbe + readinessProbe."

--- a/platform/mimir/chart/values.yaml
+++ b/platform/mimir/chart/values.yaml
@@ -16,10 +16,31 @@ catalystBlueprint:
 # ─── Upstream chart values (subchart key: mimir-distributed) ─────────────
 mimir-distributed:
   # Pin the global image tag — DO NOT use floating tags.
+  #
+  # #4347 — pull the Mimir image through the Sovereign's Harbor pull-through
+  # proxy so it satisfies the host-ns Kyverno `harbor-proxy-pull` Enforce
+  # ClusterPolicy (every image must match `*/proxy-*/*` or `*/openova-io/*`).
+  # The `mimir.imageReference` helper renders `<repository>:<tag>` (no registry
+  # field), so the proxy host is folded into the repository. dockerhub →
+  # `harbor.openova.io/proxy-dockerhub/<path>`. All 10 Mimir components
+  # (distributor/querier/query-frontend/query-scheduler/ruler/alertmanager/
+  # compactor/ingester/store-gateway/overrides-exporter) inherit this global
+  # image unless they set a per-component `image:` override (none do here).
   image:
-    repository: grafana/mimir
+    repository: harbor.openova.io/proxy-dockerhub/grafana/mimir
     tag: "3.0.4"
     pullPolicy: IfNotPresent
+
+  # #4347 — every Mimir component renders `readinessProbe` from its
+  # `<component>.readinessProbe` value but leaves `<component>.livenessProbe`
+  # empty by default (only `overrides_exporter` ships a default liveness). The
+  # host-ns Kyverno `probes-present` Enforce ClusterPolicy requires BOTH probes
+  # on every container of a Deployment/StatefulSet/DaemonSet; post-#4325 this
+  # chart installs into the native host namespace where that policy applies.
+  # Mirror each component's readiness shape (HTTP GET `/ready` on the
+  # `http-metrics` port — the Mimir process health endpoint) into a
+  # livenessProbe. The value path the upstream template renders is
+  # `mimir-distributed.<component>.livenessProbe`.
 
   # Per-component replicas — solo-Sovereign minimum is 1 each. Per-Sovereign
   # overlays scale these up and flip zoneAwareReplication on for HA.
@@ -27,33 +48,116 @@ mimir-distributed:
     replicas: 1
     zoneAwareReplication:
       enabled: false
+    # #4347 — mirror readinessProbe into livenessProbe (probes-present policy).
+    livenessProbe:
+      httpGet:
+        path: /ready
+        port: http-metrics
+      initialDelaySeconds: 45
   distributor:
     replicas: 1
+    # #4347 — mirror readinessProbe into livenessProbe (probes-present policy).
+    livenessProbe:
+      httpGet:
+        path: /ready
+        port: http-metrics
+      initialDelaySeconds: 45
   ingester:
     replicas: 1
     zoneAwareReplication:
       enabled: false
+    # #4347 — mirror readinessProbe into livenessProbe (probes-present policy).
+    livenessProbe:
+      httpGet:
+        path: /ready
+        port: http-metrics
+      initialDelaySeconds: 60
   querier:
     replicas: 1
+    # #4347 — mirror readinessProbe into livenessProbe (probes-present policy).
+    livenessProbe:
+      httpGet:
+        path: /ready
+        port: http-metrics
+      initialDelaySeconds: 45
   query_frontend:
     replicas: 1
+    # #4347 — mirror readinessProbe into livenessProbe (probes-present policy).
+    livenessProbe:
+      httpGet:
+        path: /ready
+        port: http-metrics
+      initialDelaySeconds: 45
   query_scheduler:
     replicas: 1
+    # #4347 — mirror readinessProbe into livenessProbe (probes-present policy).
+    livenessProbe:
+      httpGet:
+        path: /ready
+        port: http-metrics
+      initialDelaySeconds: 45
   store_gateway:
     replicas: 1
     zoneAwareReplication:
       enabled: false
+    # #4347 — mirror readinessProbe into livenessProbe (probes-present policy).
+    livenessProbe:
+      httpGet:
+        path: /ready
+        port: http-metrics
+      initialDelaySeconds: 60
   compactor:
     replicas: 1
+    # #4347 — mirror readinessProbe into livenessProbe (probes-present policy).
+    livenessProbe:
+      httpGet:
+        path: /ready
+        port: http-metrics
+      initialDelaySeconds: 60
   ruler:
     replicas: 1
+    # #4347 — mirror readinessProbe into livenessProbe (probes-present policy).
+    livenessProbe:
+      httpGet:
+        path: /ready
+        port: http-metrics
+      initialDelaySeconds: 45
   overrides_exporter:
     replicas: 1
+    # overrides_exporter already ships a default livenessProbe upstream (#4347
+    # leaves it untouched); its image inherits the proxied global image above.
 
-  # Gateway (nginx in front of Mimir) — keep enabled, scale to 1.
+  # Gateway (nginx in front of Mimir).
+  #
+  # #4347 — the upstream gateway Deployment template renders ONLY a
+  # readinessProbe (no livenessProbe knob), so its nginx container can never
+  # satisfy the host-ns `probes-present` Enforce policy through values alone.
+  # The bundled gateway is therefore DISABLED here and a Catalyst-owned
+  # equivalent — nginx ConfigMap + ClusterIP Service + Deployment with BOTH
+  # probes + the proxied image — is rendered by this umbrella in
+  # `templates/devcluster-workloads.yaml`. The replacement keeps the exact
+  # `mimir-nginx` Service name + port 80 contract that Grafana's datasource
+  # (`http://mimir-nginx...svc:80/prometheus`) depends on.
   gateway:
-    enabled: true
+    enabled: false
     replicas: 1
+    nginx:
+      # #4347 — route the nginx image through the Harbor pull-through proxy so
+      # it satisfies the host-ns Kyverno `harbor-proxy-pull` Enforce policy.
+      # The gateway template renders `<registry>/<repository>:<tag>`, so the
+      # proxy host goes in `registry` + the `proxy-dockerhub/` segment leads the
+      # repository → `harbor.openova.io/proxy-dockerhub/nginxinc/nginx-unprivileged`.
+      image:
+        registry: harbor.openova.io
+        repository: proxy-dockerhub/nginxinc/nginx-unprivileged
+        tag: 1.29-alpine
+    # #4347 — the upstream gateway template renders ONLY a readinessProbe (no
+    # livenessProbe knob exists). To satisfy the host-ns `probes-present`
+    # Enforce policy the bundled gateway Deployment is disabled below and a
+    # Catalyst-owned equivalent (with BOTH probes) is rendered by this umbrella
+    # at `templates/devcluster-workloads.yaml`. The upstream gateway Service +
+    # nginx ConfigMap + PodDisruptionBudget stay (they don't carry probes), so
+    # Grafana's `mimir-nginx` datasource Service selector is preserved.
     # #4343 — the gateway/nginx Deployment MUST declare resources.requests.
     # Upstream defaults `gateway.resources: {}` → the container renders with
     # NO requests. Pre-#4325 this chart ran INSIDE a vCluster where the host's
@@ -76,7 +180,29 @@ mimir-distributed:
   # The bundled MinIO is single-replica, ephemeral-friendly, and not for
   # production data.
   minio:
-    enabled: true
+    # #4347 — the bundled MinIO subchart renders its server Deployment with NO
+    # probes AT ALL (no livenessProbe knob, no readinessProbe knob), so it can
+    # never satisfy the host-ns `probes-present` Enforce policy through values
+    # alone. The bundled MinIO is therefore DISABLED here and a Catalyst-owned
+    # equivalent — Secret + ConfigMap (bucket-init) + PVC + Service + SA +
+    # Deployment (with BOTH probes on the minio `/minio/health/{live,ready}`
+    # endpoints) + bucket-creation Job — is rendered by this umbrella in
+    # `templates/devcluster-workloads.yaml` with the proxied images. The
+    # replacement keeps the exact `<release>-minio` Service + Secret contract the
+    # Mimir blocks-storage S3 config (`<release>-minio.<ns>.svc:9000`) expects.
+    enabled: false
+    # #4347 — route the MinIO server + `mc` client images through the Harbor
+    # pull-through proxy so they satisfy the host-ns `harbor-proxy-pull` Enforce
+    # policy. Both render `<repository>:<tag>` (no registry field), so the proxy
+    # host folds into the repository. quay → `harbor.openova.io/proxy-quay/...`.
+    # These values feed the Catalyst-owned MinIO render (the bundled subchart is
+    # disabled above) via `.Values.<...>.minio.image` lookups in the umbrella.
+    image:
+      repository: harbor.openova.io/proxy-quay/minio/minio
+      tag: RELEASE.2024-12-18T13-15-44Z
+    mcImage:
+      repository: harbor.openova.io/proxy-quay/minio/mc
+      tag: RELEASE.2024-11-21T17-21-54Z
     # #4343 — the bundled MinIO subchart's defaults declare ONLY a memory
     # request (server 16Gi, post-bucket Job 128Mi) with NO cpu. The cluster-
     # wide Kyverno `resource-requests` Enforce policy requires BOTH cpu AND
@@ -133,6 +259,43 @@ mimir-distributed:
       # Caught live on otech43.
       ingester:
         push_grpc_method_enabled: true
+      # #4347 — re-inject the MinIO S3 backend wiring. The upstream
+      # mimir-distributed config template only injects the blocks /
+      # ruler / alertmanager S3 stanzas when `minio.enabled=true`; since
+      # #4347 DISABLES the bundled MinIO subchart (its Deployment lacks a
+      # probes knob and so fails the host-ns `probes-present` Enforce
+      # policy) and re-renders a probe-compliant MinIO in
+      # templates/devcluster-workloads.yaml, the auto-wiring is gone and
+      # MUST be restated here so Mimir still points at the Catalyst-owned
+      # MinIO Service. Endpoint/creds/buckets are byte-identical to what
+      # the upstream `minio.enabled` path produced (`<release>-minio`,
+      # grafana-mimir / supersecret, mimir-tsdb / mimir-ruler) — a
+      # per-Sovereign overlay that swaps in SeaweedFS/cloud S3 overrides
+      # these three stanzas.
+      blocks_storage:
+        backend: s3
+        s3:
+          endpoint: "{{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc:9000"
+          bucket_name: mimir-tsdb
+          access_key_id: grafana-mimir
+          secret_access_key: supersecret
+          insecure: true
+      ruler_storage:
+        backend: s3
+        s3:
+          endpoint: "{{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc:9000"
+          bucket_name: mimir-ruler
+          access_key_id: grafana-mimir
+          secret_access_key: supersecret
+          insecure: true
+      alertmanager_storage:
+        backend: s3
+        s3:
+          endpoint: "{{ .Release.Name }}-minio.{{ .Release.Namespace }}.svc:9000"
+          bucket_name: mimir-ruler
+          access_key_id: grafana-mimir
+          secret_access_key: supersecret
+          insecure: true
 
   # MetaMonitoring (ServiceMonitor + Grafana dashboards) — DEFAULT FALSE
   # per docs/BLUEPRINT-AUTHORING.md §11.2.
@@ -162,11 +325,29 @@ mimir-distributed:
   continuous_test:
     enabled: false
 
-  # rollout-operator subchart — keep enabled (it manages zone-aware rollouts
-  # and is referenced by the upstream chart even with zone-awareness off).
+  # rollout-operator subchart.
+  #
+  # #4347 — the rollout-operator subchart renders its Deployment with ONLY a
+  # readinessProbe (no livenessProbe knob), so it can never satisfy the host-ns
+  # `probes-present` Enforce policy through values alone. The bundled
+  # rollout-operator is therefore DISABLED here and a Catalyst-owned equivalent
+  # — SA + Role/RoleBinding + webhook ClusterRole/Binding + Service + Deployment
+  # (with BOTH probes on `/ready`) + the proxied image — is rendered by this
+  # umbrella in `templates/devcluster-workloads.yaml`. It keeps the exact
+  # `<release>-rollout-operator` Service name that the webhook-gate hook polls
+  # and that the upstream `prepare-downscale-mimir.grafana.com` MutatingWebhook
+  # routes to.
   rollout_operator:
-    enabled: true
+    enabled: false
     replicas: 1
+    # #4347 — route the rollout-operator image through the Harbor pull-through
+    # proxy so it satisfies the host-ns `harbor-proxy-pull` Enforce policy.
+    # Consumed by the Catalyst-owned rollout-operator render (the bundled
+    # subchart is disabled above).
+    image:
+      registry: harbor.openova.io
+      repository: proxy-dockerhub/grafana/rollout-operator
+      tag: v0.32.0
 
   # Service account — chart manages its own.
   serviceAccount:
@@ -224,5 +405,9 @@ webhookGate:
     namespace: mimir
   timeoutSeconds: 300
   intervalSeconds: 2
-  image: "bitnamilegacy/kubectl:1.30.7"
+  # #4347 — route the webhook-gate kubectl image through the Harbor pull-through
+  # proxy so the pre-upgrade hook Job satisfies the host-ns `harbor-proxy-pull`
+  # Enforce policy (it covers Jobs too). Canonical proxied path used across the
+  # repo (cert-manager / cnpg / external-secrets-stores).
+  image: "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7"
   imagePullPolicy: IfNotPresent

--- a/platform/nats-jetstream/blueprint.yaml
+++ b/platform/nats-jetstream/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.3.4  # lockstep with chart/Chart.yaml (#4343 server/reloader/nats-box resources via container.merge for host-ns Kyverno resource-requests Enforce)
+  version: 1.3.5  # lockstep with chart/Chart.yaml (#4347 probes-present + harbor-proxy-pull on all workload containers for host-ns Kyverno Enforce post-#4325; nack 0.29.0->0.34.0 for jsc probes)
   card:
     title: nats-jetstream
     summary: Event spine for the Catalyst control plane. JetStream Streams + KV + Object Store via bundled nack JetStream Controller (Wave 5.45 #2254). Per-Organization Accounts. Replaces what was previously specified as Redpanda + Valkey for the control plane.

--- a/platform/nats-jetstream/chart/Chart.yaml
+++ b/platform/nats-jetstream/chart/Chart.yaml
@@ -1,5 +1,19 @@
 apiVersion: v2
 name: bp-nats-jetstream
+# 1.3.5 (#4347, 2026-06-25): make EVERY rendered workload container satisfy the
+# host-ns Kyverno `probes-present` AND `harbor-proxy-pull` Enforce policies now
+# that #4325 installs this chart into the native host namespace `nats-system`.
+#   - harbor-proxy-pull: route all 4 dockerhub images through the Sovereign
+#     Harbor proxy — nats server (proxy-dockerhub/library/nats), reloader +
+#     nats-box (proxy-dockerhub/natsio/*), and the nack jetstream-controller
+#     (proxy-dockerhub/natsio/jetstream-controller via nack.jetstream.image).
+#   - probes-present: inject exec liveness+readiness on the reloader sidecar
+#     (`pidof nats-server-config-reloader`) and the nats-box keep-alive
+#     (`pidof sleep`) via the nats `merge` knob; the nats SERVER already ships
+#     HTTP probes (monitor enabled). The nack jetstream-controller Deployment
+#     had NO probe hook in 0.29.0 → bump the nack dependency to 0.34.0 and set
+#     `nack.jetstream.controlLoop: true`, which renders upstream HTTP
+#     /healthz + /readyz probes on :8081. No Kyverno exclusion needed.
 # 1.3.4 (#4343, 2026-06-25): relocate the nats server resources from the
 # inert `container.resources` to `container.merge.resources` (the nats 1.2.0
 # loadMergePatch helper reads ONLY `.merge`/`.patch`, so the prior block was
@@ -7,7 +21,7 @@ name: bp-nats-jetstream
 # `reloader.merge.resources` + `natsBox.container.merge.resources`. Satisfies
 # the cluster-wide Kyverno `resource-requests` Enforce policy now that #4325
 # installs this chart into the native host namespace (not a vCluster).
-version: 1.3.4
+version: 1.3.5
 description: |
   Catalyst-curated Blueprint umbrella chart for NATS JetStream. Depends
   on TWO upstream subcharts:
@@ -46,6 +60,13 @@ dependencies:
     version: "1.2.0"
     repository: "https://nats-io.github.io/k8s/helm/charts"
   - name: nack
-    version: "0.29.0"
+    # #4347 — bumped 0.29.0 -> 0.34.0: the jetstream-controller Deployment
+    # template gained an HTTP /healthz + /readyz probe block (gated on the
+    # controller-runtime backend, enabled via nack.jetstream.controlLoop) so
+    # the host-ns Kyverno `probes-present` Enforce policy admits the workload.
+    # KeyValue + Stream CRDs remain served at jetstream.nats.io/v1beta2, so the
+    # Catalyst-curated templates/kv-buckets.yaml + templates/streams.yaml CRs
+    # are unchanged-compatible.
+    version: "0.34.0"
     repository: "https://nats-io.github.io/k8s/helm/charts"
     condition: nack.enabled

--- a/platform/nats-jetstream/chart/tests/_assert_probes_present.py
+++ b/platform/nats-jetstream/chart/tests/_assert_probes_present.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# #4347 helper — read a multi-doc helm render from stdin and assert every
+# PRIMARY container in a Deployment / StatefulSet / DaemonSet declares BOTH a
+# livenessProbe AND a readinessProbe — the exact shape the cluster-wide Kyverno
+# `probes-present` Enforce ClusterPolicy requires (platform/kyverno-policies/
+# chart/templates/baseline/04-probes.yaml).
+#
+# Scope mirrors the policy EXACTLY:
+#   - Matched kinds: Deployment, StatefulSet, DaemonSet ONLY. Job / CronJob are
+#     NOT matched by probes-present (a Job's containers run to completion;
+#     liveness/readiness are meaningless there), so they are skipped here too.
+#   - initContainers + ephemeralContainers are EXEMPT (the K8s API rejects
+#     liveness/readiness probes on initContainers), so only `containers[]` is
+#     checked.
+#
+# Prints a one-line OK summary on success; prints the offending
+# kind/name:container lines and exits 1 on any miss.
+import sys, re
+try:
+    import yaml
+except ImportError:
+    print("PyYAML not available; cannot run probes-present assertion", file=sys.stderr)
+    sys.exit(2)
+
+raw = sys.stdin.read()
+# Some upstream subchart templates emit stray trailing whitespace/tabs that
+# break a strict YAML scan; rstrip each line (cosmetic, render-neutral).
+raw = "\n".join(line.rstrip() for line in raw.splitlines())
+
+bad = []
+checked = 0
+for chunk in re.split(r"(?m)^---\s*$", raw):
+    chunk = chunk.strip()
+    if not chunk:
+        continue
+    try:
+        d = yaml.safe_load(chunk)
+    except Exception:
+        continue
+    if not isinstance(d, dict):
+        continue
+    kind = d.get("kind")
+    # Match the probes-present policy kinds exactly — NOT Job/CronJob.
+    if kind not in ("Deployment", "StatefulSet", "DaemonSet"):
+        continue
+    name = d.get("metadata", {}).get("name", "<noname>")
+    try:
+        podspec = d["spec"]["template"]["spec"]
+    except (KeyError, TypeError):
+        continue
+    # Only the primary containers[] are subject to the policy.
+    for c in (podspec.get("containers", []) or []):
+        checked += 1
+        missing = []
+        if not c.get("livenessProbe"):
+            missing.append("livenessProbe")
+        if not c.get("readinessProbe"):
+            missing.append("readinessProbe")
+        if missing:
+            bad.append("%s/%s container=%s missing=%s" % (kind, name, c.get("name"), "+".join(missing)))
+
+if bad:
+    print("workload containers MISSING liveness/readiness probes:")
+    for b in bad:
+        print(b)
+    sys.exit(1)
+
+if checked == 0:
+    print("no Deployment/StatefulSet/DaemonSet containers rendered — subchart deps not built? (run `helm dependency build`)")
+    sys.exit(1)
+
+print("%d Deployment/StatefulSet/DaemonSet container(s) all declare liveness+readiness probes" % checked)

--- a/platform/nats-jetstream/chart/tests/kyverno-probes-present.sh
+++ b/platform/nats-jetstream/chart/tests/kyverno-probes-present.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# #4347 — assert EVERY primary container in the rendered bp-nats-jetstream
+# Deployments / StatefulSets / DaemonSets declares BOTH a livenessProbe AND a
+# readinessProbe, so the cluster-wide Kyverno `probes-present` Enforce
+# ClusterPolicy admits every workload.
+#
+# After #4325 the platform planes (incl. nats-jetstream) install into NATIVE
+# host namespaces (`nats-system`, not a vCluster), where the host Kyverno
+# Enforce policies apply. Four offenders the host-ns migration exposed:
+#   - StatefulSet/<rel>-nats `reloader` sidecar — a config file-watcher with no
+#     serving port, shipped with NO probes;
+#   - Deployment/<rel>-nats-box `nats-box` — a `sleep infinity` debug toolbox
+#     with no serving port, shipped with NO probes;
+#   - Deployment/<rel> `jsc` (the nack jetstream-controller) — the nack 0.29.0
+#     Deployment template had NO probe hook at all (fixed by the 0.34.0 bump +
+#     `nack.jetstream.controlLoop: true`, which renders HTTP /healthz + /readyz
+#     on :8081);
+#   - (the nats SERVER container already ships HTTP probes from upstream when
+#     `config.monitor.enabled: true`, the default — it was never an offender.)
+# Each missing-probe container would be DENIED by `probes-present` (Enforce) →
+# bp-nats-jetstream InstallFailed → wedged bp-catalyst-platform (NATS is the
+# control-plane event spine). This test guards that regression: it FAILS if any
+# rendered Deployment/StatefulSet/DaemonSet container lacks either probe.
+set -euo pipefail
+# CI invokes `bash <script> <chart_dir>`; fall back to the script's own dir.
+chart_dir="${1:-$(dirname "$0")/..}"
+cd "$chart_dir"
+chart_dir="$(pwd)"
+
+# The upstream nats + nack subcharts are vendored under charts/*.tgz (gitignored,
+# rebuilt from Chart.lock). CI runs `helm dependency build` before tests, but
+# build it here too so the test is runnable standalone.
+if ! ls charts/*.tgz >/dev/null 2>&1; then
+  helm dependency build "$chart_dir" >/dev/null 2>&1 || true
+fi
+
+assert_py="$chart_dir/tests/_assert_probes_present.py"
+
+assert_probes() {
+  local label="$1"; shift
+  local out rc
+  out=$(helm template t . "$@" 2>/dev/null | python3 "$assert_py")
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "FAIL [$label]:"
+    echo "$out" | sed 's/^/  /'
+    return 1
+  fi
+  echo "PASS [$label]: $out"
+}
+
+fail=0
+# Default render (server StatefulSet + reloader sidecar + nats-box + jsc).
+assert_probes "default" || fail=1
+# Catalyst streams enabled (also renders the JetStream CRs; must not regress the
+# workload probe set).
+assert_probes "streams-enabled" --set catalystStreams.streamsEnabled=true || fail=1
+
+if [ "$fail" -ne 0 ]; then
+  echo "kyverno-probes-present: one or more workload containers lack liveness/readiness probes (would be DENIED by the host-ns Kyverno probes-present Enforce policy)."
+  exit 1
+fi
+echo "kyverno-probes-present: all Deployment/StatefulSet/DaemonSet containers declare liveness+readiness probes."

--- a/platform/nats-jetstream/chart/values.yaml
+++ b/platform/nats-jetstream/chart/values.yaml
@@ -33,6 +33,19 @@ nats:
         pvc:
           size: 10Gi
   container:
+    # #4347 — the nats SERVER image must route through the Sovereign-local
+    # Harbor dockerhub proxy so it satisfies the cluster-wide Kyverno
+    # `harbor-proxy-pull` Enforce ClusterPolicy (every container image must
+    # match glob `*/proxy-*/*` or `*/openova-io/*`). Post-#4325 this chart
+    # installs into the native host namespace `nats-system` where that policy
+    # applies. `nats` is an OFFICIAL (library) dockerhub image, so the proxy
+    # path is `proxy-dockerhub/library/nats` (mirrors platform/openbao +
+    # keycloak `proxy-dockerhub/library/*`). The nats.image helper composes
+    # `<registry>/<repository>:<tag>` → harbor.openova.io/proxy-dockerhub/
+    # library/nats:2.10.16-alpine. Tag unchanged.
+    image:
+      registry: harbor.openova.io
+      repository: proxy-dockerhub/library/nats
     # #4343 — the vendored nats 1.2.0 chart renders each container via the
     # file-based `loadMergePatch` helper, which consumes ONLY `.merge` (and
     # `.patch`) — NOT the top-level container dict. A bare `container.resources`
@@ -42,6 +55,10 @@ nats:
     # it, masking the gap; after the de-vcluster migration it installs into the
     # native host namespace and the StatefulSet admission is DENIED. Resources
     # MUST live under `container.merge.resources` to actually reach the pod.
+    # (The nats server container already ships liveness+readiness probes from
+    # the upstream chart — gated on `config.monitor.enabled: true`, which is
+    # the default — so it already satisfies the host-ns `probes-present`
+    # Enforce policy and needs no probe injection here.)
     merge:
       resources:
         requests: { cpu: 100m, memory: 256Mi }
@@ -51,20 +68,81 @@ nats:
   # resources. Set them via the same `merge` knob so the sidecar carries
   # requests.
   reloader:
+    # #4347 — route the reloader image through the Harbor dockerhub proxy
+    # (`harbor-proxy-pull` Enforce). `natsio/nats-server-config-reloader` is a
+    # namespaced (non-library) dockerhub repo, so the proxy path keeps the
+    # `natsio/` segment: proxy-dockerhub/natsio/nats-server-config-reloader.
+    # The nats.image helper composes <registry>/<repository>:<tag>. Tag kept.
+    image:
+      registry: harbor.openova.io
+      repository: proxy-dockerhub/natsio/nats-server-config-reloader
     merge:
       resources:
         requests: { cpu: 10m, memory: 16Mi }
         limits: { memory: 64Mi }
+      # #4347 — the reloader sidecar has NO serving/health HTTP port (it's a
+      # file-watcher that signals the nats-server via a PID file), so the
+      # host-ns Kyverno `probes-present` Enforce policy (which requires BOTH
+      # liveness + readiness on every Deployment/StatefulSet/DaemonSet
+      # container) was DENYING the StatefulSet. The image is alpine-based (NOT
+      # distroless — verified: ships /bin/sh + busybox `pidof`), and the
+      # entrypoint `exec`s the binary as PID 1, so a meaningful exec probe is
+      # `pidof nats-server-config-reloader` — it proves the watcher process is
+      # alive without any network dependency (never flaps on broker state).
+      livenessProbe:
+        exec:
+          command: ["/bin/sh", "-c", "pidof nats-server-config-reloader >/dev/null"]
+        initialDelaySeconds: 10
+        periodSeconds: 30
+        timeoutSeconds: 5
+        failureThreshold: 3
+      readinessProbe:
+        exec:
+          command: ["/bin/sh", "-c", "pidof nats-server-config-reloader >/dev/null"]
+        initialDelaySeconds: 5
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 3
   # #4343 — the nats-box utility Deployment (upstream default `natsBox.enabled:
   # true`) is a separate workload whose base container template ships NO
   # resources. Set them via `natsBox.container.merge` so its single container
   # carries requests.
   natsBox:
     container:
+      # #4347 — route the nats-box image through the Harbor dockerhub proxy
+      # (`harbor-proxy-pull` Enforce). `natsio/nats-box` is a namespaced
+      # dockerhub repo, so the proxy path keeps the `natsio/` segment:
+      # proxy-dockerhub/natsio/nats-box. Tag kept.
+      image:
+        registry: harbor.openova.io
+        repository: proxy-dockerhub/natsio/nats-box
       merge:
         resources:
           requests: { cpu: 10m, memory: 32Mi }
           limits: { memory: 64Mi }
+        # #4347 — nats-box is a debug toolbox Deployment whose only workload is
+        # a `sleep infinity` keep-alive (no serving port), so it shipped with
+        # NO probes and the host-ns Kyverno `probes-present` Enforce policy
+        # DENIED the Deployment. The image is alpine/busybox-based (verified:
+        # ships /bin/sh + `pidof`); PID 1 is `sh` running the keep-alive with
+        # `sleep` as its child. A meaningful, non-flapping exec probe is
+        # `pidof sleep` — it proves the box's keep-alive is alive. Deliberately
+        # NOT coupled to broker reachability: a debug toolbox must not flip
+        # NotReady whenever the NATS server restarts.
+        livenessProbe:
+          exec:
+            command: ["/bin/sh", "-c", "pidof sleep >/dev/null"]
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          exec:
+            command: ["/bin/sh", "-c", "pidof sleep >/dev/null"]
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
   # Prometheus exporter + PodMonitor — DEFAULT OFF.
   #
   # Per docs/INVIOLABLE-PRINCIPLES.md #4 and docs/BLUEPRINT-AUTHORING.md
@@ -163,12 +241,12 @@ catalystStreams:
 # release namespace (nats-system). Watch namespace empty = cluster-wide.
 nack:
   enabled: true
-  # #4343 — the nack 0.29.0 jetstream-controller container reads its resources
-  # from the TOP-LEVEL `resources` key (`{{- with .Values.resources }}` in
+  # #4343 — the nack jetstream-controller container reads its resources from
+  # the TOP-LEVEL `resources` key (`{{- with .Values.resources }}` in
   # deployment-jetstream-controller.yml), NOT `jetstream.resources` — the
-  # latter is inert in this chart version. Setting it here is what actually
-  # gives the `jsc` container requests, so it clears the host-ns Kyverno
-  # `resource-requests` Enforce policy (post-#4325). Modest controller request.
+  # latter is inert. Setting it here is what actually gives the `jsc` container
+  # requests, so it clears the host-ns Kyverno `resource-requests` Enforce
+  # policy (post-#4325). Modest controller request.
   resources:
     requests:
       cpu: 50m
@@ -177,6 +255,27 @@ nack:
       cpu: 200m
       memory: 256Mi
   jetstream:
+    # #4347 — route the jetstream-controller image through the Harbor
+    # dockerhub proxy (`harbor-proxy-pull` Enforce). The jsc.image helper
+    # composes `<registry>/<repository>:<tag>`; with the tag left empty it
+    # falls back to the nack subchart `.Chart.AppVersion` (0.23.0 for chart
+    # 0.34.0). `natsio/jetstream-controller` is a namespaced dockerhub repo,
+    # so the proxy path keeps the `natsio/` segment.
+    image:
+      registry: harbor.openova.io
+      repository: proxy-dockerhub/natsio/jetstream-controller
+    # #4347 — the nack 0.29.0 jetstream-controller Deployment template had NO
+    # livenessProbe/readinessProbe hook and exposed no health port, so the
+    # host-ns Kyverno `probes-present` Enforce policy DENIED the Deployment and
+    # there was NO values knob to inject probes. The clean upstream-native fix
+    # is the nack 0.34.0 dependency bump (Chart.yaml): its
+    # deployment-jetstream-controller.yml renders an HTTP `/healthz` liveness +
+    # `/readyz` readiness probe on port 8081 — BUT only when the controller
+    # runs its controller-runtime backend, which also binds the health probe
+    # address (`--health-probe-bind-address=:8081`). `controlLoop: true` is the
+    # flag that enables that backend AND the probe block in one switch. This is
+    # the upstream-recommended reconcile path; it needs no shell/exclusion.
+    controlLoop: true
     # Point at the broker subchart's Service. Same-namespace, no auth
     # required (NATS auth is operator-config'd separately if at all).
     nats:

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.129
+  version: 1.4.130  # lockstep with chart/Chart.yaml (#4347 channel-seed hook image harbor-proxy)
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -887,7 +887,13 @@ name: bp-newapi
 #   (cnpg.enabled=false) is unaffected — that path mirrors the DSN host→vc.
 #   Lockstep: 80-newapi.yaml + 80a-newapi-host-seams.yaml pins + blueprint.yaml
 #   → 1.4.128.
-version: 1.4.129
+# 1.4.130 (#4347): route the channel-seed post-install/post-upgrade hook Job's
+#   curl image through the Sovereign-local Harbor proxy-cache
+#   (`harbor.openova.io/proxy-dockerhub/curlimages/curl`) so the host-ns Kyverno
+#   `harbor-proxy-pull` Enforce policy admits it on every reconcile (the sibling
+#   db-dsn-sync Job already proxied it; channel-seed was the lone raw
+#   docker.io/curlimages/curl). Refs #4347 #4325.
+version: 1.4.130
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -677,8 +677,14 @@ channelSeed:
   # Image for the curl-based seed loop. Pinned at the upstream-mutable
   # default tag; production overlays SHA-pin per
   # docs/INVIOLABLE-PRINCIPLES.md #4a.
+  # #4347 — route through the Sovereign-local Harbor proxy-cache so the host-ns
+  # Kyverno `harbor-proxy-pull` Enforce ClusterPolicy admits this post-install/
+  # post-upgrade hook Job (applied on every reconcile, after #4325 re-homed
+  # bp-newapi into the native host ns `newapi`). The raw `docker.io/curlimages/
+  # curl` matches no allowed glob; the sibling db-dsn-sync Job already proxies
+  # the identical image.
   image:
-    repository: docker.io/curlimages/curl
+    repository: harbor.openova.io/proxy-dockerhub/curlimages/curl
     tag: "8.10.1"
     pullPolicy: IfNotPresent
   # Resource budget — small. Each channel is one GET (probe) + zero

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.53  # lockstep with chart/Chart.yaml (#4343 injector.resources.requests for host-ns Kyverno resource-requests Enforce)
+  version: 1.2.54  # lockstep with chart/Chart.yaml (#4347 probes-present: sso-configure probes + server.livenessProbe for host-ns Kyverno Enforce)
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -172,7 +172,13 @@ name: bp-openbao
 # Both default-OFF for host-side openbao (XCR off) → byte-identical render.
 # Verified GREEN live hw167 2026-06-19: bao.<fqdn>/ui/ → /sso/landing → lands
 # /ui/vault/secrets (sso-zero-click-probe openbao row GREEN). Pin in lockstep.
-version: 1.2.53
+# 1.2.54 (#4347): probes-present compliance for the host-ns Kyverno Enforce
+#   ClusterPolicy (after #4325 de-vcluster). (a) openbao-sso-configure
+#   Deployment gains liveness + readiness EXEC probes (heartbeat sentinel);
+#   (b) server.livenessProbe ENABLED (sealed-tolerant httpGet) — upstream
+#   shipped readiness-only, so the StatefulSet had no livenessProbe. Adds
+#   tests/kyverno-probes-present.sh. Refs #4347 #4325.
+version: 1.2.54
 # 1.2.51 (#3888, Refs #3847): prov-time openbao KV-seed mechanism — the
 # auth-bootstrap Job reads a one-shot cloud-init `openbao-bootstrap-seed`
 # Secret + writes its keys into KV at secret/<prefix>/* with the still-valid

--- a/platform/openbao/chart/templates/sso-configure-deployment.yaml
+++ b/platform/openbao/chart/templates/sso-configure-deployment.yaml
@@ -169,7 +169,21 @@ data:
 
     log "bp-openbao sso-configure starting; addr=${BAO_ADDR} interval=${INTERVAL_SECONDS}s"
 
+    # #4347 — liveness/readiness heartbeat sentinel. This continuous reconciler
+    # has NO serving port, so the Pod's livenessProbe / readinessProbe (required
+    # by the host-ns Kyverno `probes-present` Enforce ClusterPolicy after the
+    # #4325 de-vcluster re-homed bp-openbao into a host namespace) exec a
+    # freshness check against this file. We `touch` it on startup (readiness
+    # goes green as soon as the loop is up) and re-touch it at the top of every
+    # tick; the liveness probe ages it out and restarts a wedged loop. Lives
+    # under the writable /tmp emptyDir (readOnlyRootFilesystem: true).
+    HEARTBEAT_FILE=/tmp/sso-configure-heartbeat
+    touch "${HEARTBEAT_FILE}"
+
     while true; do
+      # Re-touch the heartbeat each iteration so a healthy loop keeps the
+      # sentinel fresh; a wedged loop lets it age out → liveness restart (#4347).
+      touch "${HEARTBEAT_FILE}"
       sleep "${INTERVAL_SECONDS}"
 
       # Skip until the ExternalSecret materialises.
@@ -456,6 +470,34 @@ spec:
             limits:
               cpu: "200m"
               memory: "128Mi"
+          # #4347 — liveness + readiness EXEC probes (required by the host-ns
+          # Kyverno `probes-present` Enforce ClusterPolicy after #4325 moved
+          # bp-openbao into a native host namespace). This reconciler has NO
+          # serving port, so both probes check the /tmp/sso-configure-heartbeat
+          # sentinel the loop re-touches each tick: readiness = file exists
+          # (green once the loop's startup touch lands), liveness = file
+          # modified within the last 5 minutes (a wedged loop ages it out →
+          # kubelet restart).
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - 'test -f /tmp/sso-configure-heartbeat'
+            initialDelaySeconds: 2
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - '[ -n "$(find /tmp/sso-configure-heartbeat -mmin -5 2>/dev/null)" ]'
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/platform/openbao/chart/tests/_assert_probes_present.py
+++ b/platform/openbao/chart/tests/_assert_probes_present.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# #4347 helper — read a multi-doc helm render from stdin and assert every
+# PRIMARY container in a Deployment / StatefulSet / DaemonSet declares BOTH a
+# livenessProbe AND a readinessProbe — the exact shape the cluster-wide Kyverno
+# `probes-present` Enforce ClusterPolicy requires (platform/kyverno-policies/
+# chart/templates/baseline/04-probes.yaml).
+#
+# Scope mirrors the policy EXACTLY:
+#   - Matched kinds: Deployment, StatefulSet, DaemonSet ONLY. Job / CronJob are
+#     NOT matched by probes-present (a Job's containers run to completion;
+#     liveness/readiness are meaningless there), so they are skipped here too.
+#   - initContainers + ephemeralContainers are EXEMPT (the K8s API rejects
+#     liveness/readiness probes on initContainers), so only `containers[]` is
+#     checked.
+#
+# Prints a one-line OK summary on success; prints the offending
+# kind/name:container lines and exits 1 on any miss.
+import sys, re
+try:
+    import yaml
+except ImportError:
+    print("PyYAML not available; cannot run probes-present assertion", file=sys.stderr)
+    sys.exit(2)
+
+raw = sys.stdin.read()
+# Some upstream subchart templates emit stray trailing whitespace/tabs that
+# break a strict YAML scan; rstrip each line (cosmetic, render-neutral).
+raw = "\n".join(line.rstrip() for line in raw.splitlines())
+
+bad = []
+checked = 0
+for chunk in re.split(r"(?m)^---\s*$", raw):
+    chunk = chunk.strip()
+    if not chunk:
+        continue
+    try:
+        d = yaml.safe_load(chunk)
+    except Exception:
+        continue
+    if not isinstance(d, dict):
+        continue
+    kind = d.get("kind")
+    # Match the probes-present policy kinds exactly — NOT Job/CronJob.
+    if kind not in ("Deployment", "StatefulSet", "DaemonSet"):
+        continue
+    name = d.get("metadata", {}).get("name", "<noname>")
+    try:
+        podspec = d["spec"]["template"]["spec"]
+    except (KeyError, TypeError):
+        continue
+    # Only the primary containers[] are subject to the policy.
+    for c in (podspec.get("containers", []) or []):
+        checked += 1
+        missing = []
+        if not c.get("livenessProbe"):
+            missing.append("livenessProbe")
+        if not c.get("readinessProbe"):
+            missing.append("readinessProbe")
+        if missing:
+            bad.append("%s/%s container=%s missing=%s" % (kind, name, c.get("name"), "+".join(missing)))
+
+if bad:
+    print("workload containers MISSING liveness/readiness probes:")
+    for b in bad:
+        print(b)
+    sys.exit(1)
+
+if checked == 0:
+    print("no Deployment/StatefulSet/DaemonSet containers rendered — subchart deps not built? (run `helm dependency build`)")
+    sys.exit(1)
+
+print("%d Deployment/StatefulSet/DaemonSet container(s) all declare liveness+readiness probes" % checked)

--- a/platform/openbao/chart/tests/kyverno-probes-present.sh
+++ b/platform/openbao/chart/tests/kyverno-probes-present.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# #4347 — assert EVERY primary container in the rendered bp-openbao
+# Deployments / StatefulSets / DaemonSets declares BOTH a livenessProbe AND a
+# readinessProbe, so the cluster-wide Kyverno `probes-present` Enforce
+# ClusterPolicy admits every workload.
+#
+# After #4325 the platform planes (incl. openbao) install into NATIVE host
+# namespaces (not a vCluster), where the host Kyverno Enforce policies apply.
+# Two offenders the host-ns migration exposed:
+#   - the openbao-sso-configure Deployment (a continuous reconcile loop with NO
+#     serving port) shipped with NO probes;
+#   - the upstream openbao subchart ships `server.readinessProbe.enabled: true`
+#     but `server.livenessProbe.enabled: false`, so the server StatefulSet had
+#     a readinessProbe but NO livenessProbe.
+# Both were DENIED by `probes-present` (Enforce) → bp-openbao InstallFailed →
+# wedged bp-external-secrets-stores → bp-sso-bridge. This test guards that
+# regression: it FAILS if any rendered Deployment/StatefulSet/DaemonSet
+# container lacks either probe.
+set -euo pipefail
+chart_dir="${1:-$(dirname "$0")/..}"
+cd "$chart_dir"
+chart_dir="$(pwd)"
+
+if ! ls charts/*.tgz >/dev/null 2>&1; then
+  helm dependency build "$chart_dir" >/dev/null 2>&1 || true
+fi
+
+assert_py="$chart_dir/tests/_assert_probes_present.py"
+
+assert_probes() {
+  local label="$1"; shift
+  local out rc
+  out=$(helm template t . --set gateway.host=bao.example.test "$@" 2>/dev/null | python3 "$assert_py")
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "FAIL [$label]:"
+    echo "$out" | sed 's/^/  /'
+    return 1
+  fi
+  echo "PASS [$label]: $out"
+}
+
+fail=0
+# Default render (server StatefulSet + agent-injector + sso-landing).
+assert_probes "default" || fail=1
+# SSO enabled (renders the openbao-sso-configure Deployment — a #4347 offender).
+assert_probes "sso-enabled" --set sso.enabled=true --set sso.sovereignFqdn=example.test || fail=1
+
+if [ "$fail" -ne 0 ]; then
+  echo "kyverno-probes-present: one or more workload containers lack liveness/readiness probes (would be DENIED by the host-ns Kyverno probes-present Enforce policy)."
+  exit 1
+fi
+echo "kyverno-probes-present: all Deployment/StatefulSet/DaemonSet containers declare liveness+readiness probes."

--- a/platform/openbao/chart/values.yaml
+++ b/platform/openbao/chart/values.yaml
@@ -42,6 +42,28 @@ openbao:
     resources:
       requests: { cpu: 100m, memory: 256Mi }
       limits: { memory: 512Mi }
+    # #4347 — ENABLE the server livenessProbe. The upstream openbao subchart
+    # ships `server.readinessProbe.enabled: true` but `server.livenessProbe.
+    # enabled: false` (liveness off by default), so the rendered StatefulSet had
+    # a readinessProbe but NO livenessProbe → the host-ns Kyverno
+    # `probes-present` Enforce ClusterPolicy (which requires BOTH on every
+    # container, after #4325 re-homed bp-openbao into a native host namespace)
+    # would DENY the StatefulSet on its next roll. Enable the httpGet liveness
+    # against /v1/sys/health with SEALED-TOLERANT query codes: a sealed /
+    # uninitialized / standby node returns 204 (success) so kubelet does NOT
+    # kill a healthy-but-sealed Pod (sealing needs an unseal, not a restart) —
+    # this is exactly why upstream defaults it off; the codes make it safe to
+    # turn on. Initial delay is generous so raft bootstrap + auto-unseal settle
+    # before liveness starts checking.
+    livenessProbe:
+      enabled: true
+      path: "/v1/sys/health?standbyok=true&sealedcode=204&uninitcode=204&drsecondarycode=204&performancestandbycode=204"
+      port: 8200
+      initialDelaySeconds: 120
+      periodSeconds: 30
+      timeoutSeconds: 5
+      failureThreshold: 5
+      successThreshold: 1
     dataStorage:
       size: 10Gi
   ui:

--- a/platform/plane-isolation/blueprint.yaml
+++ b/platform/plane-isolation/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 0.1.0
+  version: 0.1.1  # lockstep with chart/Chart.yaml (#4347 doc-separator fix)
   card:
     title: Plane isolation (per-component default-deny)
     summary: |

--- a/platform/plane-isolation/chart/Chart.yaml
+++ b/platform/plane-isolation/chart/Chart.yaml
@@ -19,7 +19,15 @@ name: bp-plane-isolation
 #       app-plane wedge). No `world` — only the gateway reaches them.
 # The allow-set tightens from coarse-namespace (whole-plane) to
 # per-component — one-component blast radius instead of whole-plane.
-version: 0.1.0
+# 0.1.1 (#4347 / Refs #4325): FIX the missing YAML document separator between
+#   rendered manifests. Both templates chomped the newline before `---` (the
+#   `{{- $ns := .namespace -}}` trailing `-}}`), gluing `---` onto the previous
+#   doc's last line (`cidr: 0.0.0.0/0---`, `- remote-node---`) → Helm's
+#   post-render saw ONE doc with N duplicate `apiVersion` keys → `unmarshal
+#   errors: mapping key "apiVersion" already defined` → bp-plane-isolation HR
+#   install FAILED (live on omantel.biz region-a). All 24 docs now separate
+#   cleanly. Dropped the `-}}` chomp on the $ns assignment in both templates.
+version: 0.1.1
 description: |
   Per-component default-deny + explicit-allow micro-segmentation for the
   de-vclustered platform planes (#4291 Workstream C). For each platform

--- a/platform/plane-isolation/chart/templates/default-deny-networkpolicy.yaml
+++ b/platform/plane-isolation/chart/templates/default-deny-networkpolicy.yaml
@@ -20,7 +20,7 @@ CiliumNetworkPolicy (Cilium unions every policy selecting an endpoint).
 {{- if .Values.enabled -}}
 {{- $dnsNamespace := .Values.dnsNamespace | default "kube-system" -}}
 {{- range .Values.components }}
-{{- $ns := .namespace -}}
+{{- $ns := .namespace }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/platform/plane-isolation/chart/templates/gateway-ingress-cnp.yaml
+++ b/platform/plane-isolation/chart/templates/gateway-ingress-cnp.yaml
@@ -32,7 +32,7 @@ chart still installs on CRD-less clusters (kind CI).
 {{- if and .Values.enabled (.Capabilities.APIVersions.Has "cilium.io/v2") -}}
 {{- range .Values.components }}
 {{- if .gatewayIngress }}
-{{- $ns := .namespace -}}
+{{- $ns := .namespace }}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy

--- a/platform/seaweedfs/blueprint.yaml
+++ b/platform/seaweedfs/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-5-storage-and-data
 spec:
-  version: 1.2.3
+  version: 1.2.4  # lockstep with chart/Chart.yaml (#4347 harbor-proxy image for host-ns Kyverno harbor-proxy-pull Enforce)
   card:
     title: SeaweedFS
     family: foundation

--- a/platform/seaweedfs/chart/Chart.yaml
+++ b/platform/seaweedfs/chart/Chart.yaml
@@ -35,7 +35,12 @@ type: application
 # csi.hetzner.cloud (durable). local-path is FORBIDDEN (k3s
 # --disable=local-storage + Kyverno ENFORCE deny). bp-hcloud-csi gates the
 # stateful root slots so the cloud CSI is Ready before any seaweedfs PVC binds.
-version: 1.2.3
+# 1.2.4 (#4347): route the seaweedfs image through the Sovereign-local Harbor
+#   proxy-cache (`harbor.openova.io/proxy-dockerhub/chrislusf/seaweedfs`) so the
+#   host-ns Kyverno `harbor-proxy-pull` Enforce policy admits all 4 seaweedfs
+#   workloads (master/volume/filer/s3) after #4325 re-homed bp-seaweedfs into
+#   the native host ns. Refs #4347 #4325.
+version: 1.2.4
 appVersion: "4.22"
 keywords: [catalyst, blueprint, seaweedfs, s3, object-storage, storage]
 maintainers:

--- a/platform/seaweedfs/chart/tests/_assert_probes_present.py
+++ b/platform/seaweedfs/chart/tests/_assert_probes_present.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# #4347 helper — read a multi-doc helm render from stdin and assert every
+# PRIMARY container in a Deployment / StatefulSet / DaemonSet declares BOTH a
+# livenessProbe AND a readinessProbe — the exact shape the cluster-wide Kyverno
+# `probes-present` Enforce ClusterPolicy requires (platform/kyverno-policies/
+# chart/templates/baseline/04-probes.yaml).
+#
+# Scope mirrors the policy EXACTLY:
+#   - Matched kinds: Deployment, StatefulSet, DaemonSet ONLY. Job / CronJob are
+#     NOT matched by probes-present (a Job's containers run to completion;
+#     liveness/readiness are meaningless there), so they are skipped here too.
+#   - initContainers + ephemeralContainers are EXEMPT (the K8s API rejects
+#     liveness/readiness probes on initContainers), so only `containers[]` is
+#     checked.
+#
+# Prints a one-line OK summary on success; prints the offending
+# kind/name:container lines and exits 1 on any miss.
+import sys, re
+try:
+    import yaml
+except ImportError:
+    print("PyYAML not available; cannot run probes-present assertion", file=sys.stderr)
+    sys.exit(2)
+
+raw = sys.stdin.read()
+# Some upstream subchart templates emit stray trailing whitespace/tabs that
+# break a strict YAML scan; rstrip each line (cosmetic, render-neutral).
+raw = "\n".join(line.rstrip() for line in raw.splitlines())
+
+bad = []
+checked = 0
+for chunk in re.split(r"(?m)^---\s*$", raw):
+    chunk = chunk.strip()
+    if not chunk:
+        continue
+    try:
+        d = yaml.safe_load(chunk)
+    except Exception:
+        continue
+    if not isinstance(d, dict):
+        continue
+    kind = d.get("kind")
+    # Match the probes-present policy kinds exactly — NOT Job/CronJob.
+    if kind not in ("Deployment", "StatefulSet", "DaemonSet"):
+        continue
+    name = d.get("metadata", {}).get("name", "<noname>")
+    try:
+        podspec = d["spec"]["template"]["spec"]
+    except (KeyError, TypeError):
+        continue
+    # Only the primary containers[] are subject to the policy.
+    for c in (podspec.get("containers", []) or []):
+        checked += 1
+        missing = []
+        if not c.get("livenessProbe"):
+            missing.append("livenessProbe")
+        if not c.get("readinessProbe"):
+            missing.append("readinessProbe")
+        if missing:
+            bad.append("%s/%s container=%s missing=%s" % (kind, name, c.get("name"), "+".join(missing)))
+
+if bad:
+    print("workload containers MISSING liveness/readiness probes:")
+    for b in bad:
+        print(b)
+    sys.exit(1)
+
+if checked == 0:
+    print("no Deployment/StatefulSet/DaemonSet containers rendered — subchart deps not built? (run `helm dependency build`)")
+    sys.exit(1)
+
+print("%d Deployment/StatefulSet/DaemonSet container(s) all declare liveness+readiness probes" % checked)

--- a/platform/seaweedfs/chart/tests/kyverno-probes-present.sh
+++ b/platform/seaweedfs/chart/tests/kyverno-probes-present.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# #4347 — assert EVERY primary container in the rendered bp-seaweedfs
+# Deployments / StatefulSets / DaemonSets declares BOTH a livenessProbe AND a
+# readinessProbe (the upstream seaweedfs chart already provides both; this is
+# the regression guard) so the cluster-wide Kyverno `probes-present` Enforce
+# ClusterPolicy admits every workload after #4325 re-homed bp-seaweedfs into
+# the native host namespace `seaweedfs`.
+set -euo pipefail
+chart_dir="${1:-$(dirname "$0")/..}"
+cd "$chart_dir"
+chart_dir="$(pwd)"
+if ls Chart.lock >/dev/null 2>&1 && ! ls charts/*.tgz >/dev/null 2>&1; then
+  helm dependency build "$chart_dir" >/dev/null 2>&1 || true
+fi
+assert_py="$chart_dir/tests/_assert_probes_present.py"
+out=$(helm template t . 2>/dev/null | python3 "$assert_py")
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  echo "FAIL: $out"
+  echo "kyverno-probes-present: one or more workload containers lack liveness/readiness probes."
+  exit 1
+fi
+echo "PASS: $out"
+echo "kyverno-probes-present: all Deployment/StatefulSet/DaemonSet containers declare liveness+readiness probes."

--- a/platform/seaweedfs/chart/values.yaml
+++ b/platform/seaweedfs/chart/values.yaml
@@ -36,7 +36,15 @@ seaweedfs:
     # _helpers.tpl seaweedfs.image renders `printf "%s/%s:%s" registry name tag`.
     # A trailing slash in registry produces a double slash: "chrislusf//seaweedfs:4.22"
     # which is an invalid image reference (issue #568).
-    registry: "chrislusf"
+    # #4347 — route through the Sovereign-local Harbor proxy-cache so the
+    # host-ns Kyverno `harbor-proxy-pull` Enforce ClusterPolicy admits it (after
+    # #4325 re-homed bp-seaweedfs into the native host ns `seaweedfs`). The raw
+    # `chrislusf/seaweedfs` (dockerhub) matches no allowed glob. The registry
+    # field carries the proxy prefix UP TO the chrislusf org segment so the
+    # `printf "%s/%s:%s" registry imageName imageTag` helper composes
+    # `harbor.openova.io/proxy-dockerhub/chrislusf/seaweedfs:4.22` (matches
+    # `*/proxy-*/*`).
+    registry: "harbor.openova.io/proxy-dockerhub/chrislusf"
     repository: ""
     imageName: seaweedfs
     imageTag: "4.22"

--- a/platform/tempo/blueprint.yaml
+++ b/platform/tempo/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.0.0
+  version: 1.0.1  # lockstep with chart/Chart.yaml (#4347 harbor-proxy image for host-ns Kyverno harbor-proxy-pull Enforce)
   card:
     title: Tempo
     family: insights

--- a/platform/tempo/chart/Chart.yaml
+++ b/platform/tempo/chart/Chart.yaml
@@ -14,7 +14,13 @@ description: |
   dependency by republishing this chart with a different `dependencies:`
   entry.
 type: application
-version: 1.0.0
+# 1.0.1 (#4347): route the Tempo image through the Sovereign-local Harbor
+#   proxy-cache (`harbor.openova.io/proxy-dockerhub/grafana/tempo`) so the
+#   host-ns Kyverno `harbor-proxy-pull` Enforce policy admits the Tempo
+#   StatefulSet after #4325 re-homed bp-tempo into the native host ns `tempo`.
+#   The upstream chart already ships both probes. Adds
+#   tests/kyverno-probes-present.sh. Refs #4347 #4325.
+version: 1.0.1
 appVersion: "2.9.0"
 keywords: [catalyst, blueprint, tempo, observability, traces]
 maintainers:

--- a/platform/tempo/chart/tests/_assert_probes_present.py
+++ b/platform/tempo/chart/tests/_assert_probes_present.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# #4347 helper — read a multi-doc helm render from stdin and assert every
+# PRIMARY container in a Deployment / StatefulSet / DaemonSet declares BOTH a
+# livenessProbe AND a readinessProbe — the exact shape the cluster-wide Kyverno
+# `probes-present` Enforce ClusterPolicy requires (platform/kyverno-policies/
+# chart/templates/baseline/04-probes.yaml).
+#
+# Scope mirrors the policy EXACTLY:
+#   - Matched kinds: Deployment, StatefulSet, DaemonSet ONLY. Job / CronJob are
+#     NOT matched by probes-present (a Job's containers run to completion;
+#     liveness/readiness are meaningless there), so they are skipped here too.
+#   - initContainers + ephemeralContainers are EXEMPT (the K8s API rejects
+#     liveness/readiness probes on initContainers), so only `containers[]` is
+#     checked.
+#
+# Prints a one-line OK summary on success; prints the offending
+# kind/name:container lines and exits 1 on any miss.
+import sys, re
+try:
+    import yaml
+except ImportError:
+    print("PyYAML not available; cannot run probes-present assertion", file=sys.stderr)
+    sys.exit(2)
+
+raw = sys.stdin.read()
+# Some upstream subchart templates emit stray trailing whitespace/tabs that
+# break a strict YAML scan; rstrip each line (cosmetic, render-neutral).
+raw = "\n".join(line.rstrip() for line in raw.splitlines())
+
+bad = []
+checked = 0
+for chunk in re.split(r"(?m)^---\s*$", raw):
+    chunk = chunk.strip()
+    if not chunk:
+        continue
+    try:
+        d = yaml.safe_load(chunk)
+    except Exception:
+        continue
+    if not isinstance(d, dict):
+        continue
+    kind = d.get("kind")
+    # Match the probes-present policy kinds exactly — NOT Job/CronJob.
+    if kind not in ("Deployment", "StatefulSet", "DaemonSet"):
+        continue
+    name = d.get("metadata", {}).get("name", "<noname>")
+    try:
+        podspec = d["spec"]["template"]["spec"]
+    except (KeyError, TypeError):
+        continue
+    # Only the primary containers[] are subject to the policy.
+    for c in (podspec.get("containers", []) or []):
+        checked += 1
+        missing = []
+        if not c.get("livenessProbe"):
+            missing.append("livenessProbe")
+        if not c.get("readinessProbe"):
+            missing.append("readinessProbe")
+        if missing:
+            bad.append("%s/%s container=%s missing=%s" % (kind, name, c.get("name"), "+".join(missing)))
+
+if bad:
+    print("workload containers MISSING liveness/readiness probes:")
+    for b in bad:
+        print(b)
+    sys.exit(1)
+
+if checked == 0:
+    print("no Deployment/StatefulSet/DaemonSet containers rendered — subchart deps not built? (run `helm dependency build`)")
+    sys.exit(1)
+
+print("%d Deployment/StatefulSet/DaemonSet container(s) all declare liveness+readiness probes" % checked)

--- a/platform/tempo/chart/tests/kyverno-probes-present.sh
+++ b/platform/tempo/chart/tests/kyverno-probes-present.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# #4347 — assert EVERY primary container in the rendered bp-tempo
+# Deployments / StatefulSets / DaemonSets declares BOTH a livenessProbe AND a
+# readinessProbe (the upstream tempo chart already provides both; this is the
+# regression guard) so the cluster-wide Kyverno `probes-present` Enforce
+# ClusterPolicy admits every workload after #4325 re-homed bp-tempo into the
+# native host namespace `tempo`.
+set -euo pipefail
+chart_dir="${1:-$(dirname "$0")/..}"
+cd "$chart_dir"
+chart_dir="$(pwd)"
+if ! ls charts/*.tgz >/dev/null 2>&1; then
+  helm dependency build "$chart_dir" >/dev/null 2>&1 || true
+fi
+assert_py="$chart_dir/tests/_assert_probes_present.py"
+out=$(helm template t . 2>/dev/null | python3 "$assert_py")
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  echo "FAIL: $out"
+  echo "kyverno-probes-present: one or more workload containers lack liveness/readiness probes."
+  exit 1
+fi
+echo "PASS: $out"
+echo "kyverno-probes-present: all Deployment/StatefulSet/DaemonSet containers declare liveness+readiness probes."

--- a/platform/tempo/chart/values.yaml
+++ b/platform/tempo/chart/values.yaml
@@ -18,9 +18,13 @@ tempo:
   replicas: 1
 
   # Pin upstream Tempo image tag — DO NOT use floating tags.
+  # #4347 — route through the Sovereign-local Harbor proxy-cache so the host-ns
+  # Kyverno `harbor-proxy-pull` Enforce ClusterPolicy admits it (after #4325
+  # re-homed bp-tempo into the native host ns `tempo`). The raw
+  # `docker.io/grafana/tempo` matches neither allowed glob.
   tempo:
-    registry: docker.io
-    repository: grafana/tempo
+    registry: harbor.openova.io
+    repository: proxy-dockerhub/grafana/tempo
     tag: "2.9.0"
     pullPolicy: IfNotPresent
     resources:


### PR DESCRIPTION
Refs #4347 #4325 #4340

## What

After #4325 de-vcluster moved the mgmt/rtz/dmz platform planes from inside vClusters into NATIVE host namespaces, the cluster-wide Kyverno **Enforce** ClusterPolicies (`probes-present`, `harbor-proxy-pull`) now apply to every plane component. #4343/#4345 fixed `resource-requests`; this PR sweeps the remaining two Enforce classes across the **whole de-vcluster'd cohort in ONE pass** so the platform converges in a single roll instead of one chart at a time.

The first symptom of #4347 (verified LIVE on omantel.biz region-a, kom4dc dep `4635277cae4ffed9`): bp-gitea 1.2.41's `gitea-sso-configure` Deployment (a continuous reconcile loop, no serving port) shipped **no** liveness/readiness probes → `admission webhook validate.kyverno.svc-fail denied ... probes-present` → bp-gitea HR False → bp-catalyst-platform `dependency bp-gitea not ready` → org-controller stuck. A comprehensive audit found the **same class across the whole cohort** plus raw image sources several charts carried (inert inside a vCluster, denied on the host).

## Live confirmation

The live kom4dc Sovereign showed the EXACT denial on every chart fixed here: bp-harbor / bp-openbao (`validate.kyverno.svc-fail denied`), bp-coraza / bp-loki / bp-tempo / bp-seaweedfs (`Helm install failed`), bp-mimir (`14 errors`), bp-nats-jetstream (`3 errors`), and bp-plane-isolation (`mapping key apiVersion already defined`). Hot-patching the live gitea HR to suppress the sso-configure Deployment made the Helm install **succeed** and advanced bp-catalyst-platform **past** the bp-gitea dependency (it then reported the next, unrelated `bp-crossplane-claims` dep) — proving the root cause. The live drift was reverted afterward (a Flux-owned HR `spec.values` patch cannot durably hold). Durable recovery follows merge → OCI publish → the Sovereign's Gitea mirror pulls the fixed pins.

## Fixes (chart × Enforce-policy)

**probes-present** (added liveness + readiness to every offending Deployment/StatefulSet/DaemonSet container):
- bp-gitea 1.2.42: `gitea-sso-configure` → heartbeat-sentinel EXEC probes
- bp-openbao 1.2.54: `openbao-sso-configure` EXEC probes + **ENABLE** `server.livenessProbe` (upstream shipped readiness-only; sealed-tolerant httpGet)
- bp-harbor 1.2.39: `harbor-sso-configure` → heartbeat-sentinel EXEC probes
- bp-coraza 1.0.1: `coraza-spoa` → tcpSocket probes on the SPOA port
- bp-loki 1.0.2: **ENABLE** `loki.loki.livenessProbe` (upstream readiness-only) + `loki-sc-rules` sidecar EXEC probes
- bp-grafana 1.0.17: dashboard + datasource k8s-sidecar containers → EXEC probes
- bp-nats-jetstream 1.3.5: reloader + nats-box EXEC probes (via the nats `merge` knob) + bump nack 0.29.0→0.34.0 so the jetstream-controller renders upstream `/healthz` + `/readyz` probes (0.29.0 had no probe hook)
- bp-mimir 1.0.7: 9 core components via the upstream `<component>.livenessProbe` knob; gateway/rollout-operator/bundled-MinIO (no liveness hook in mimir-distributed 6.0.6) re-rendered as Catalyst-owned probe-compliant equivalents with the S3 backend re-injected via `structuredConfig` so object storage is preserved

**harbor-proxy-pull** (routed raw registry images through the Sovereign-local Harbor proxy-cache → `*/proxy-*/*`):
- bp-coraza, bp-loki, bp-tempo 1.0.1, bp-seaweedfs 1.2.4 (×4 workloads), bp-newapi 1.4.130 (channel-seed hook Job), bp-nats-jetstream (×4), bp-mimir (grafana/mimir + rollout-operator + nginx + minio/minio + minio/mc + webhook-gate kubectl)

**document-separator** (a #4325 regression on the new chart):
- bp-plane-isolation 0.1.1: both templates chomped the newline before `---`, gluing it onto the previous manifest (`cidr: 0.0.0.0/0---`) → Helm post-render saw ONE doc with N duplicate `apiVersion` keys → HR install failed. Fixed → 24 docs separate cleanly.

## Validation

- Each touched chart bumps `Chart.yaml` + `blueprint.yaml` + its bootstrap-kit slot pin **in lockstep** (`scripts/check-bootstrap-kit-pin-sync.sh` PASS; `check-catalog-seed-lockstep.sh` PASS; `check-bootstrap-deps.sh` PASS — 0 drift, 0 cycles).
- Each chart ships `tests/kyverno-probes-present.sh` (+ `_assert_probes_present.py`) — a CI gate asserting every Deployment/StatefulSet/DaemonSet container declares BOTH probes (the kinds probes-present matches; Job/CronJob/initContainers exempt). All 10 gates run green + negative-tested.
- `helm template` proves every workload container across the touched charts now carries both probes AND a proxied image; mimir object-storage Service refs resolve on the production release name.
- nats fix independently verified via `kyverno apply` of the REAL `probes-present` + `harbor-proxy-pull` Enforce ClusterPolicies → pass:7 fail:0.

## Audited CLEAN (no change needed)

keycloak, guacamole, sandbox, vllm, valkey — clean across all Enforce policies. No `local-path` PVC/SC/PV anywhere; the `cilium-l7-mtls` label is auto-stamped by the existing mutate policy so no chart trips it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
