### PR TITLE
fix(bp-kyverno-policies): exempt crossplane-system from harbor-proxy-pull — unblock bp-crossplane rollback-loop gating bp-catalyst-platform (1.0.42)

### DIFF
--- a/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
+++ b/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
@@ -138,7 +138,12 @@ spec:
       # CIDR-probe Service (`test-service-delete-me-*`) by name pattern so a
       # stale `openova.io/tenant`-labelled boundary no longer Enforce-denies it
       # → no more 11/11 vcluster-0 CrashLoop. Refs #4329 #4297 #4293.
-      version: 1.0.41
+      # 1.0.42 (#4349): exempt crossplane-system from harbor-proxy-pull — the
+      # upstream xpkg.upbound.io crossplane image is not Harbor-mirrored, so the
+      # Enforce policy denied the crossplane pod create → bp-crossplane
+      # rollback-loop gated bp-catalyst-platform via the crossplane-claims
+      # dependsOn chain. Refs #4349 #4212.
+      version: 1.0.42
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno

--- a/platform/kyverno-policies/blueprint.yaml
+++ b/platform/kyverno-policies/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.41
+  version: 1.0.42
   card:
     title: Kyverno Policy Library
     family: guardian

--- a/platform/kyverno-policies/chart/Chart.yaml
+++ b/platform/kyverno-policies/chart/Chart.yaml
@@ -281,7 +281,16 @@ type: application
 # unprotected user PVCs stay subject to the velero-backed requirement. Mirrors
 # the by-label CNPG carve-out on the flux-managed policy (#3374). Template-only
 # behavior change + new test fixtures. Refs #3971.
-version: 1.0.41
+# 1.0.42 (#4349, kom4dc dep 4635277cae4ffed9, 2026-06-25): EXEMPT crossplane-system
+# from harbor-proxy-pull. bp-crossplane's control-plane pod pulls upstream
+# xpkg.upbound.io/crossplane/crossplane:v1.18.0 (not Harbor-mirrored; chart
+# imageRegistry-rewrite unset on a fresh prov), which matches neither
+# */proxy-*/* nor */openova-io/*, so the Enforce policy denied the pod create →
+# bp-crossplane rollback-loop → bp-crossplane-claims → bp-catalyst-platform
+# never converged → org-controller roll gated. Added crossplane-system to the
+# policy-scoped harborProxyPull.extraExcludeNamespaces (same shape as
+# powerdns/trivy-system/org-services). Values-only change. Refs #4349 #4212.
+version: 1.0.42
 appVersion: "1.0.2"
 keywords: [catalyst, blueprint, kyverno, policy, compliance, audit]
 maintainers:

--- a/platform/kyverno-policies/chart/values.yaml
+++ b/platform/kyverno-policies/chart/values.yaml
@@ -277,6 +277,21 @@ compliancePolicies:
       # exact mixed-source shape the stale `sme` exempt (line 89) was added
       # for on hw130. org-services stays subject to every OTHER policy.
       - org-services
+      # crossplane-system (#4349, 2026-06-25, kom4dc dep 4635277cae4ffed9): the
+      # bp-crossplane Deployment + crossplane-rbac-manager pull the upstream
+      # control-plane image `xpkg.upbound.io/crossplane/crossplane:v1.18.0`
+      # (Upbound's registry — Crossplane core is NOT mirrored into Harbor and
+      # the chart's `global.imageRegistry` Harbor-rewrite is unset on a fresh
+      # prov, #560). Neither `*/proxy-*/*` nor `*/openova-io/*` matches, so
+      # harbor-proxy-pull (Enforce) denied the crossplane pod create
+      # (ReplicaSet FailedCreate) → the bp-crossplane HR sat in a 15m-timeout
+      # rollback loop → bp-crossplane-claims (dependsOn bp-crossplane) →
+      # bp-catalyst-platform (dependsOn bp-crossplane-claims) never converged →
+      # the org-controller roll was gated. crossplane-system is platform
+      # plumbing (every comparable plumbing ns — cilium/cert-manager/kyverno —
+      # is already exempt via complianceDefaultExcludes); exempt it here for
+      # the image-source glob only. It stays subject to every OTHER policy.
+      - crossplane-system
 
   imageTagPinned:
     enabled: true


### PR DESCRIPTION
## Root cause
On the omantel.biz Sovereign (Huawei kom4dc, dep `4635277cae4ffed9`) the `bp-crossplane` HelmRelease was stuck in a 15m-timeout rollback loop. The real cause was NOT a chart-internal failure — the `crossplane` Deployment could not create its pod:

```
Error creating: admission webhook "validate.kyverno.svc-fail" denied the request:
harbor-proxy-pull / image-from-harbor-proxy-pod:
  Container image does not match any allowed Harbor-source glob (*/proxy-*/* or */openova-io/*)
```

bp-crossplane pulls the upstream control-plane image `xpkg.upbound.io/crossplane/crossplane:v1.18.0`. Crossplane core is not mirrored into the Sovereign Harbor, and the chart's `global.imageRegistry` Harbor-rewrite is unset on a fresh prov (#560), so the image matches neither allowed glob. The Enforce `harbor-proxy-pull` policy denied the pod create → ReplicaSet `FailedCreate` → HR rollback loop.

## Critical-path — GATES convergence (NOT benign)
`bp-catalyst-platform` dependsOn `bp-crossplane-claims` dependsOn `bp-crossplane`. So although Crossplane is runtime-IDLE on a Sovereign (0 `*claims.compose.openova.io`), the Flux dependsOn chain still hard-gates `bp-catalyst-platform` → the org-controller roll (#4340).

## Fix
Add `crossplane-system` to `compliancePolicies.harborProxyPull.extraExcludeNamespaces` (the policy-scoped carve-out, same shape as powerdns/trivy-system/org-services). crossplane-system is platform plumbing — every comparable plumbing ns (cilium/cert-manager/kyverno) is already exempt. It stays subject to every other policy. Chart 1.0.41 → 1.0.42 + blueprint + bootstrap-kit pin.

## Live validation (kom4dc)
Patched the live policy exclude → the crossplane pod admitted immediately (`crossplane-69f777cff8-zbx2l 1/1 Running`) and the Deployment went `1/1 Available`, breaking the rollback loop. A suspend/resume then drove the HR into a clean `upgrade` (not rollback) action against the healthy deployment.

Refs #4349 #4212

🤖 Generated with [Claude Code](https://claude.com/claude-code)