### PR TITLE
fix(bp-huawei-evs-csi): evs-ssd reclaimPolicy Retain -> Delete — stop the EVS volume-count quota leak wedging stateful PVCs (1.0.4)

### DIFF
--- a/clusters/_template/bootstrap-kit/55b-bp-huawei-evs-csi.yaml
+++ b/clusters/_template/bootstrap-kit/55b-bp-huawei-evs-csi.yaml
@@ -68,10 +68,13 @@
 #   - The EVS CSI controller Deployment (provisioner/attacher/resizer/
 #     snapshotter sidecars + the evs-csi-plugin) + node DaemonSet + CSIDriver
 #     `evs.csi.huaweicloud.com`.
-#   - The `evs-ssd` StorageClass — reclaimPolicy Retain (the backing EVS
-#     volume survives PVC/PV deletion), volumeBindingMode WaitForFirstConsumer
-#     (the volume lands in the consuming Pod's AZ), allowVolumeExpansion true,
-#     type SSD (HCS me-east-215 exposes SSD / SAS only).
+#   - The `evs-ssd` StorageClass — reclaimPolicy Delete (#4350: Retain on the
+#     cluster-default class LEAKED EVS volumes — every churned PVC left a
+#     Released PV whose backing volume stayed alive + billed + counting against
+#     Huawei's project-wide 400-volume hard quota, until kom4dc hit EVS.1034 /
+#     413 VolumeLimitExceeded and every new PVC went Pending), volumeBindingMode
+#     WaitForFirstConsumer (the volume lands in the consuming Pod's AZ),
+#     allowVolumeExpansion true, type SSD (HCS me-east-215 exposes SSD / SAS only).
 #   - VolumeSnapshotClass `evs-snapshots` (storage-level DR).
 #   - A post-install hook Job that promotes evs-ssd to cluster-default (the
 #     provisioner-agnostic flip hook reused from bp-hcloud-csi).
@@ -159,7 +162,11 @@ spec:
   chart:
     spec:
       chart: bp-huawei-evs-csi
-      version: 1.0.3
+      # 1.0.4 (#4350): evs-ssd default reclaimPolicy Retain → Delete to stop the
+      # EVS volume-count quota leak (Released PVs kept their EVS volume alive →
+      # project hit the 400 hard quota → gitea/harbor/per-Org PVCs Pending →
+      # bp-catalyst-platform never converged).
+      version: 1.0.4
       sourceRef:
         kind: HelmRepository
         name: bp-huawei-evs-csi

--- a/platform/huawei-evs-csi/blueprint.yaml
+++ b/platform/huawei-evs-csi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     catalyst.openova.io/provider: huawei
 spec:
-  version: 1.0.3
+  version: 1.0.4
   card:
     title: Huawei EVS CSI
     summary: |

--- a/platform/huawei-evs-csi/chart/Chart.yaml
+++ b/platform/huawei-evs-csi/chart/Chart.yaml
@@ -47,7 +47,16 @@ name: bp-huawei-evs-csi
 # storage tier wedged behind a GREEN evs-ssd StorageClass (verified live on
 # hw178). Fix: default imagePullSecrets:[ghcr-pull] on both pod specs + add
 # huawei-evs-csi to the reflection-namespaces in cloudinit-control-plane.tftpl.
-version: 1.0.3
+#
+# 1.0.4 (#4350, kom4dc dep 4635277cae4ffed9, 2026-06-25): flip the cluster-default
+# evs-ssd StorageClass reclaimPolicy Retain → Delete. Retain leaks EVS volumes:
+# Huawei enforces a project-wide volume-COUNT quota (400 hard), and Retain keeps
+# every churned PVC's backing EVS volume alive under a Released PV until the
+# project hit EVS.1034 "volume count exceeded" / 413 VolumeLimitExceeded →
+# gitea/harbor/seaweedfs/per-Org PVCs Pending → bp-gitea False →
+# bp-catalyst-platform never converged. Delete reclaim bounds the volume count.
+# Values-only change. Refs #4350 #3971.
+version: 1.0.4
 description: |
   Catalyst-curated Blueprint for the open-source huaweicloud-csi-driver EVS
   block-storage plugin (evs.csi.huaweicloud.com). Provides the durable

--- a/platform/huawei-evs-csi/chart/values.yaml
+++ b/platform/huawei-evs-csi/chart/values.yaml
@@ -72,12 +72,29 @@ idc: true
 # (confirmed live via the EVS cinder list-volume-types probe, main.tf line
 # ~1066) — SSD is pinned for production IOPS. The volume-type parameter key is
 # the FLAT `type` key (verified in pkg/evs/nodeserver.go:512 — NOT everest's
-# `everest.io/disk-volume-type`). reclaimPolicy Retain gives the same
-# production-data durability posture as hcloud-volumes.
+# `everest.io/disk-volume-type`).
+#
+# reclaimPolicy: Delete (#4350, kom4dc dep 4635277cae4ffed9, 2026-06-25).
+# WAS Retain — but Retain on the CLUSTER-DEFAULT class is an EVS-volume LEAK:
+# Huawei EVS enforces a project-wide volume-COUNT hard quota (400), and with
+# Retain every PVC that is deleted/churned (re-prov, Org teardown, pod
+# reschedule, StatefulSet replica scale-down) leaves its backing EVS volume
+# ALIVE under a `Released` PV — still billed, still counting against the 400.
+# Live forensic on kom4dc: 72 Bound + 63 Released PVs in region-a alone (66
+# more in region-B) drove the project to EVS.1034 "volume count exceeded" /
+# 413 "Maximum number of volumes allowed (400) exceeded" → every new PVC
+# (gitea-shared-storage, harbor-jobservice, seaweedfs, per-Org wordpress
+# replicas) stuck Pending → bp-gitea False → bp-catalyst-platform (dependsOn
+# bp-gitea) never converged. Delete reclaim frees the EVS volume when the PV
+# is released, so churn no longer leaks count quota. Stateful tiers that need
+# true retain-on-delete durability (CNPG already streams its own barman WAL
+# backups, so it does NOT) can opt into a dedicated retain class via an extra
+# catalystStorageClasses entry; the cluster-DEFAULT must be Delete to bound
+# the volume count.
 catalystStorageClasses:
   - name: evs-ssd
     volumeType: SSD
-    reclaimPolicy: Retain
+    reclaimPolicy: Delete
     volumeBindingMode: WaitForFirstConsumer
     allowVolumeExpansion: true
     fsType: ext4


### PR DESCRIPTION
## Root cause
On omantel.biz Sovereign (Huawei kom4dc, dep `4635277cae4ffed9`) 23 PVCs were stuck `Pending` on `evs-ssd` (gitea-shared-storage, harbor-jobservice, all seaweedfs, per-Org wordpress-db-replica). This is NOT the #3971 local-path/CSI-missing problem (that's already fixed here — the EVS CSI driver is installed and actively provisioning). The live `csi-evs-controller` provisioner log shows the real error:

```
error creating EVS volume ... {"code":"EVS.1034","message":"volume count exceeded volume count quota!"}
POST .../volumes -> 413 {"message":"VolumeLimitExceeded: Maximum number of volumes allowed (400) exceeded for quota 'volumes'."}
```

The Huawei project-wide EVS volume-COUNT hard quota (400) is exhausted.

## Why it leaked
The cluster-default `evs-ssd` StorageClass shipped `reclaimPolicy: Retain`. With Retain, every churned PVC (re-prov, Org teardown, pod reschedule, StatefulSet replica scale-down) leaves its backing EVS volume ALIVE under a `Released` PV — still billed, still counting against the 400. Live forensic: **72 Bound + 63 Released PVs** in region-a (66 more in region-B) drove the project to the cap.

## Critical-path — GATES convergence
`bp-catalyst-platform` dependsOn `bp-gitea`; `bp-gitea` is False precisely because `gitea-shared-storage` is Pending (EVS quota). So the leak gates gitea → catalyst-platform → the org-controller roll (#4340).

## Fix
Flip the cluster-default `evs-ssd` reclaimPolicy `Retain` → `Delete` so a Released PV frees its backing EVS volume and churn no longer leaks count quota. Stateful tiers needing retain-on-delete (CNPG does NOT — it streams its own barman WAL backups) can opt into a dedicated retain class via an extra `catalystStorageClasses` entry; the cluster-default must be Delete to bound the volume count. Chart 1.0.3 → 1.0.4 + blueprint + bootstrap-kit pin + slot-header doc-sync.

## Live cleanup (separate from this chart change, tracked in #4350)
The ~63 already-Released PVs on kom4dc must be deleted ONCE (their EVS volumes won't auto-free under the OLD Retain PVs) to drop the project below 400 and unblock the currently-Pending PVCs. The chart change prevents re-accumulation going forward.

Refs #4350 #3971

🤖 Generated with [Claude Code](https://claude.com/claude-code)