### PR TITLE
fix(bp-huawei-evs-csi): pre-upgrade hook delete+recreate evs-ssd SC to apply reclaimPolicy Delete — unstall the HR the 1.0.4 immutable flip wedged (1.0.5)

### DIFF
--- a/clusters/_template/bootstrap-kit/55b-bp-huawei-evs-csi.yaml
+++ b/clusters/_template/bootstrap-kit/55b-bp-huawei-evs-csi.yaml
@@ -76,6 +76,11 @@
 #     WaitForFirstConsumer (the volume lands in the consuming Pod's AZ),
 #     allowVolumeExpansion true, type SSD (HCS me-east-215 exposes SSD / SAS only).
 #   - VolumeSnapshotClass `evs-snapshots` (storage-level DR).
+#   - A pre-install/pre-upgrade hook Job (#4350) that reconciles the evs-ssd SC
+#     reclaimPolicy: if the live SC still carries the OLD immutable Retain, it
+#     DELETES the SC so Helm recreates it with Delete (a values-only flip alone
+#     STALLS the HR because reclaimPolicy is immutable). Idempotent — a no-op
+#     when already Delete or on a fresh prov; Bound PVs/PVCs are unaffected.
 #   - A post-install hook Job that promotes evs-ssd to cluster-default (the
 #     provisioner-agnostic flip hook reused from bp-hcloud-csi).
 #
@@ -166,7 +171,13 @@ spec:
       # EVS volume-count quota leak (Released PVs kept their EVS volume alive →
       # project hit the 400 hard quota → gitea/harbor/per-Org PVCs Pending →
       # bp-catalyst-platform never converged).
-      version: 1.0.4
+      # 1.0.5 (#4350 follow-up): a pre-install/pre-upgrade hook DELETES + lets
+      # Helm RECREATE the evs-ssd SC when its live reclaimPolicy is still the OLD
+      # Retain — reclaimPolicy is IMMUTABLE so the 1.0.4 values-flip alone STALLS
+      # the HR on a live Sovereign that already had the Retain SC (the kom4dc
+      # convergence gate). Idempotent (no-op when already Delete / on fresh prov);
+      # existing Bound PVs/PVCs are unaffected.
+      version: 1.0.5
       sourceRef:
         kind: HelmRepository
         name: bp-huawei-evs-csi

--- a/platform/huawei-evs-csi/blueprint.yaml
+++ b/platform/huawei-evs-csi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     catalyst.openova.io/provider: huawei
 spec:
-  version: 1.0.4
+  version: 1.0.5
   card:
     title: Huawei EVS CSI
     summary: |

--- a/platform/huawei-evs-csi/chart/Chart.yaml
+++ b/platform/huawei-evs-csi/chart/Chart.yaml
@@ -56,7 +56,23 @@ name: bp-huawei-evs-csi
 # gitea/harbor/seaweedfs/per-Org PVCs Pending → bp-gitea False →
 # bp-catalyst-platform never converged. Delete reclaim bounds the volume count.
 # Values-only change. Refs #4350 #3971.
-version: 1.0.4
+#
+# 1.0.5 (#4350 follow-up, 2026-06-25): the 1.0.4 values-only flip is INERT on a
+# LIVE Huawei Sovereign that already carries the evs-ssd SC with the OLD
+# reclaimPolicy Retain — `reclaimPolicy` is an IMMUTABLE StorageClass field, so
+# Helm's apply of the 1.0.4 SC template is REJECTED (`reclaimPolicy: Forbidden:
+# updates to reclaimPolicy are forbidden`) → the bp-huawei-evs-csi HelmRelease
+# STALLS → the whole stateful chain that gates on it (bp-cnpg →
+# bp-postgres-shared → bp-keycloak → bp-gitea → bp-catalyst-platform) never
+# converges → the org-controller roll wedges (kom4dc dep 4635277cae4ffed9).
+# A StorageClass field can only be changed by DELETE + RECREATE. This release
+# adds a pre-install/pre-upgrade hook Job (templates/reclaim-reconcile-hook.yaml
+# + its RBAC) that reads the live evs-ssd reclaimPolicy and, if it differs from
+# the desired Delete, DELETES the stale SC so Helm's subsequent apply recreates
+# it with reclaimPolicy=Delete. Idempotent: a no-op when the SC is already
+# Delete or absent (fresh prov). Existing Bound PVs/PVCs are UNAFFECTED —
+# reclaimPolicy is stamped on the PV at bind time and never re-read from the SC.
+version: 1.0.5
 description: |
   Catalyst-curated Blueprint for the open-source huaweicloud-csi-driver EVS
   block-storage plugin (evs.csi.huaweicloud.com). Provides the durable

--- a/platform/huawei-evs-csi/chart/templates/reclaim-reconcile-hook-rbac.yaml
+++ b/platform/huawei-evs-csi/chart/templates/reclaim-reconcile-hook-rbac.yaml
@@ -1,0 +1,68 @@
+{{- /*
+RBAC for the StorageClass reclaim-policy reconcile hook (#4350).
+
+The pre-install/pre-upgrade Job (templates/reclaim-reconcile-hook.yaml) reads
+the live `evs-ssd` StorageClass's reclaimPolicy and, when it differs from the
+chart's desired policy, DELETES the (immutable-reclaimPolicy) SC so Helm's
+subsequent apply recreates it with the correct policy. Reading + deleting a
+cluster-scoped StorageClass needs a ClusterRole + binding.
+
+Gated on the SAME .Values.enabled master gate as the hook + the StorageClass so
+a default-off / Hetzner render emits ZERO resources (smoke-render guard).
+
+hook-weight -15 (earlier than the Job's -10) so the SA + ClusterRole + Binding
+land BEFORE the Job that consumes them.
+*/}}
+{{- if .Values.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-reclaim-reconcile
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: bp-huawei-evs-csi
+    app.kubernetes.io/component: reclaim-reconcile-hook
+    catalyst.openova.io/blueprint: bp-huawei-evs-csi
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-15"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-reclaim-reconcile
+  labels:
+    app.kubernetes.io/name: bp-huawei-evs-csi
+    app.kubernetes.io/component: reclaim-reconcile-hook
+    catalyst.openova.io/blueprint: bp-huawei-evs-csi
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-15"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-reclaim-reconcile
+  labels:
+    app.kubernetes.io/name: bp-huawei-evs-csi
+    app.kubernetes.io/component: reclaim-reconcile-hook
+    catalyst.openova.io/blueprint: bp-huawei-evs-csi
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-15"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-reclaim-reconcile
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-reclaim-reconcile
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/platform/huawei-evs-csi/chart/templates/reclaim-reconcile-hook.yaml
+++ b/platform/huawei-evs-csi/chart/templates/reclaim-reconcile-hook.yaml
@@ -1,0 +1,147 @@
+{{- /*
+StorageClass reclaim-policy reconcile hook — bp-huawei-evs-csi (#4350).
+
+THE FIX
+=======
+#4352 (chart 1.0.4) flipped the catalystStorageClasses[].reclaimPolicy default
+Retain → Delete to stop the EVS volume-COUNT quota leak (Huawei enforces a
+project-wide 400 hard quota; Retain kept every churned PVC's backing EVS volume
+alive under a Released PV until the project hit EVS.1034 / 413). But a
+StorageClass's `reclaimPolicy` is an IMMUTABLE field — `kubectl apply` /
+`helm upgrade` against an EXISTING `evs-ssd` SC that still carries
+`reclaimPolicy: Retain` is REJECTED with `StorageClass.storage.k8s.io
+"evs-ssd" is invalid: reclaimPolicy: Forbidden: updates to reclaimPolicy are
+forbidden`. So on a LIVE Huawei Sovereign that already had the 1.0.x evs-ssd SC
+(Retain), the 1.0.4 upgrade STALLS the bp-huawei-evs-csi HelmRelease — and the
+whole stateful chain (bp-cnpg → bp-postgres-shared → bp-keycloak → bp-gitea →
+bp-catalyst-platform) that gates on it never converges, so the org-controller
+roll wedges (kom4dc dep 4635277cae4ffed9, #4350).
+
+A StorageClass field can only be changed by DELETE + RECREATE. This
+pre-install/pre-upgrade Job runs BEFORE Helm applies the rendered StorageClass
+template: it reads the live `evs-ssd` SC's reclaimPolicy and, if it differs
+from the DESIRED reclaimPolicy ({{ (index .Values.catalystStorageClasses 0).reclaimPolicy | default "Retain" }}),
+DELETES the stale SC so Helm's subsequent apply CREATES it fresh with the
+correct (immutable-at-create) reclaimPolicy. If the live SC already matches the
+desired policy — or does not exist yet (fresh prov) — the hook is a NO-OP.
+
+WHY DELETE-THEN-RECREATE IS SAFE FOR BOUND VOLUMES
+==================================================
+reclaimPolicy is stamped onto each PV at BIND time (the PV copies
+`.spec.persistentVolumeReclaimPolicy` from the SC when it is provisioned); it
+is NOT re-read from the SC afterwards. Deleting and recreating the SC therefore
+does NOT touch any EXISTING PV or Bound PVC — their reclaim behaviour is fixed
+on the PV object. Only NEW dynamic provisioning reads the SC's policy. The hook
+keeps the delete→recreate window tiny (the very next step is Helm applying the
+SC template), and the recreate is left to Helm so the SC's full spec stays the
+single source of truth in the chart (provisioner/parameters/volumeBindingMode/
+allowVolumeExpansion/default-class annotation are all re-applied by the regular
+StorageClass template + the post-upgrade default-class hook).
+
+IDEMPOTENCY
+===========
+  - Live reclaimPolicy already == desired → no-op (logs "already Delete").
+  - Live SC absent (fresh prov) → no-op (Helm just creates it).
+  - Live reclaimPolicy != desired → delete the SC (Helm recreates it).
+So the hook is safe on EVERY reconcile and on a fresh prov.
+
+Gated on .Values.enabled (the SAME master gate as the StorageClass + the
+default-class hook) so a default-off / Hetzner render emits ZERO resources
+(smoke-render guard). hook-weight -10 so it runs BEFORE the default-class hook
+(weight -5 RBAC / 0 Job) — but as a pre-* hook it runs before the main release
+apply regardless; the negative weight only orders it relative to its own RBAC.
+*/}}
+{{- if .Values.enabled }}
+{{- $sc := "evs-ssd" -}}
+{{- if .Values.catalystStorageClasses }}
+{{-   $sc = (index .Values.catalystStorageClasses 0).name -}}
+{{- end -}}
+{{- $desired := "Retain" -}}
+{{- if .Values.catalystStorageClasses }}
+{{-   $desired = ((index .Values.catalystStorageClasses 0).reclaimPolicy | default "Retain") -}}
+{{- end -}}
+{{- $image := "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7" -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-reclaim-reconcile
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: bp-huawei-evs-csi
+    app.kubernetes.io/component: reclaim-reconcile-hook
+    catalyst.openova.io/blueprint: bp-huawei-evs-csi
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bp-huawei-evs-csi
+        app.kubernetes.io/component: reclaim-reconcile-hook
+    spec:
+      serviceAccountName: {{ .Release.Name }}-reclaim-reconcile
+      restartPolicy: Never
+      containers:
+        - name: reconcile
+          image: {{ $image | quote }}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests: { cpu: 25m, memory: 32Mi }
+            limits: { memory: 96Mi }
+          env:
+            - name: TARGET_SC
+              value: {{ $sc | quote }}
+            - name: DESIRED_RECLAIM
+              value: {{ $desired | quote }}
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              set -euo pipefail
+              echo "bp-huawei-evs-csi reclaim-reconcile: StorageClass=${TARGET_SC} desired reclaimPolicy=${DESIRED_RECLAIM}"
+
+              # Fresh prov / first install: the SC does not exist yet. Helm's
+              # main apply will create it with the desired policy → no-op.
+              if ! kubectl get storageclass "${TARGET_SC}" >/dev/null 2>&1; then
+                echo "StorageClass ${TARGET_SC} does not exist yet — nothing to reconcile (Helm will create it)."
+                exit 0
+              fi
+
+              live="$(kubectl get storageclass "${TARGET_SC}" \
+                -o jsonpath='{.reclaimPolicy}' 2>/dev/null || true)"
+              echo "live reclaimPolicy = '${live:-<empty>}'"
+
+              # Already correct → idempotent no-op. (Empty live policy means the
+              # API server default 'Delete' — treat an empty desired-Delete match
+              # as already-correct too.)
+              if [ "${live}" = "${DESIRED_RECLAIM}" ]; then
+                echo "reclaimPolicy already ${DESIRED_RECLAIM} — no-op."
+                exit 0
+              fi
+              if [ -z "${live}" ] && [ "${DESIRED_RECLAIM}" = "Delete" ]; then
+                echo "reclaimPolicy unset (API default Delete) already matches desired Delete — no-op."
+                exit 0
+              fi
+
+              # reclaimPolicy is IMMUTABLE — the only way to change it is
+              # delete + recreate. Delete the stale SC; Helm's subsequent apply
+              # (this is a pre-* hook) recreates it with the desired policy.
+              # Existing Bound PVs/PVCs are UNAFFECTED (policy is stamped on the
+              # PV at bind time, never re-read from the SC).
+              echo "reclaimPolicy ${live} != desired ${DESIRED_RECLAIM} — deleting StorageClass ${TARGET_SC} so Helm recreates it with ${DESIRED_RECLAIM}."
+              kubectl delete storageclass "${TARGET_SC}" --wait=true --timeout=60s
+              echo "deleted ${TARGET_SC}; Helm will recreate it with reclaimPolicy=${DESIRED_RECLAIM}."
+{{- end }}

--- a/platform/huawei-evs-csi/chart/tests/reclaim-reconcile-hook/test.sh
+++ b/platform/huawei-evs-csi/chart/tests/reclaim-reconcile-hook/test.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Chart test for the StorageClass reclaim-policy reconcile hook (#4350).
+#
+# Two layers:
+#   A. RENDER assertions (helm template) — the pre-install/pre-upgrade hook +
+#      its RBAC render only when enabled, carry the correct desired reclaimPolicy,
+#      and a default-off render stays EMPTY (smoke-render guard).
+#   B. LOGIC assertions — extract the reconcile script from the rendered Job and
+#      run it against a FAKE kubectl to prove:
+#        1. Live reclaimPolicy already Delete  → NO-OP (no delete issued).
+#        2. Live reclaimPolicy Retain          → DELETE issued (recreate path).
+#        3. Live SC absent (fresh prov)        → NO-OP (Helm creates it).
+#        4. Live reclaimPolicy empty + desired Delete → NO-OP (API default).
+#
+# Run: bash platform/huawei-evs-csi/chart/tests/reclaim-reconcile-hook/test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+pass=0; fail=0
+ok()   { echo "  ok: $1"; pass=$((pass+1)); }
+bad()  { echo "  FAIL: $1"; fail=$((fail+1)); }
+
+echo "== A. render assertions =="
+
+# A0. default-off render must be EMPTY (no reconcile hook, no SC).
+empty="$(helm template t "${CHART_DIR}" 2>/dev/null | grep -c 'kind:' || true)"
+[ "${empty}" = "0" ] && ok "default-off render emits zero resources" \
+                      || bad "default-off render emitted ${empty} resources (expected 0)"
+
+# Enabled render (the bootstrap-kit slot-55b shape).
+helm template t "${CHART_DIR}" --set enabled=true --set defaultStorageClass=true \
+  > "${TMP}/render.yaml" 2>/dev/null
+
+# A1. The reconcile Job renders as a pre-install,pre-upgrade hook.
+if grep -q 'name: t-reclaim-reconcile' "${TMP}/render.yaml" \
+   && awk '/name: t-reclaim-reconcile$/{f=1} f' "${TMP}/render.yaml" \
+        | grep -q '"helm.sh/hook": pre-install,pre-upgrade'; then
+  ok "reconcile hook renders as pre-install,pre-upgrade"
+else
+  bad "reconcile hook missing or not a pre-install,pre-upgrade hook"
+fi
+
+# A2. The hook carries the DESIRED reclaimPolicy from values (Delete by default).
+if awk '/name: t-reclaim-reconcile$/{f=1} f' "${TMP}/render.yaml" \
+     | grep -A1 'name: DESIRED_RECLAIM' | grep -q 'value: "Delete"'; then
+  ok "reconcile hook desired reclaimPolicy = Delete (tracks values)"
+else
+  bad "reconcile hook DESIRED_RECLAIM is not Delete"
+fi
+
+# A3. The rendered StorageClass itself is Delete (the value the hook drives toward).
+# Scope to the StorageClass document only (stop at the next doc separator).
+if awk '/^kind: StorageClass$/{f=1} f&&/^---$/{exit} f' "${TMP}/render.yaml" \
+     | grep -q 'reclaimPolicy: "Delete"'; then
+  ok "evs-ssd StorageClass renders reclaimPolicy Delete"
+else
+  bad "evs-ssd StorageClass reclaimPolicy is not Delete"
+fi
+
+# A4. RBAC for the reconcile hook (delete verb on storageclasses) renders.
+if awk '/name: t-reclaim-reconcile$/{f=1} /^---/{if(seen)f=0} {if(/name: t-reclaim-reconcile/)seen=1} f' "${TMP}/render.yaml" >/dev/null \
+   && grep -q '"delete"' "${TMP}/render.yaml"; then
+  ok "reconcile hook RBAC grants delete on storageclasses"
+else
+  bad "reconcile hook RBAC missing delete verb"
+fi
+
+# A5. The desired reclaimPolicy is parameterised — overriding values flows through.
+helm template t "${CHART_DIR}" --set enabled=true \
+  --set 'catalystStorageClasses[0].name=evs-ssd' \
+  --set 'catalystStorageClasses[0].reclaimPolicy=Retain' \
+  2>/dev/null | awk '/name: t-reclaim-reconcile$/{f=1} f' \
+  | grep -A1 'name: DESIRED_RECLAIM' | grep -q 'value: "Retain"' \
+  && ok "DESIRED_RECLAIM follows an overridden values reclaimPolicy" \
+  || bad "DESIRED_RECLAIM did not follow the overridden reclaimPolicy"
+
+echo "== B. reconcile-script logic assertions =="
+
+# Extract the reconcile script body (the Job's args block) into a runnable file.
+# We pull the lines between the `- |` of the args and the end of the container.
+python3 - "${TMP}/render.yaml" "${TMP}/reconcile.sh" <<'PY'
+import sys, yaml
+docs = list(yaml.safe_load_all(open(sys.argv[1])))
+for d in docs:
+    if not d: continue
+    if d.get("kind") == "Job" and d["metadata"]["name"].endswith("reclaim-reconcile"):
+        args = d["spec"]["template"]["spec"]["containers"][0]["args"][0]
+        open(sys.argv[2], "w").write(args)
+        sys.exit(0)
+sys.exit("reclaim-reconcile Job not found")
+PY
+[ -s "${TMP}/reconcile.sh" ] && ok "extracted reconcile script from rendered Job" \
+                             || bad "could not extract reconcile script"
+
+# Fake kubectl harness: STATE controls what `kubectl get` returns; every
+# `kubectl delete` appends to DELETE_LOG so we can assert whether a delete fired.
+make_kubectl() {
+  local mode="$1" policy="$2"
+  cat > "${TMP}/bin/kubectl" <<EOF
+#!/usr/bin/env bash
+# fake kubectl — mode=${mode} policy=${policy}
+if [ "\$1" = "get" ] && [ "\$2" = "storageclass" ]; then
+  if [ "${mode}" = "absent" ]; then exit 1; fi
+  # jsonpath reclaimPolicy query
+  if printf '%s ' "\$@" | grep -q 'reclaimPolicy'; then
+    printf '%s' "${policy}"; exit 0
+  fi
+  exit 0  # existence probe
+fi
+if [ "\$1" = "delete" ] && [ "\$2" = "storageclass" ]; then
+  echo "DELETED \$3" >> "${TMP}/delete.log"; exit 0
+fi
+exit 0
+EOF
+  chmod +x "${TMP}/bin/kubectl"
+}
+
+mkdir -p "${TMP}/bin"
+run_case() {
+  local name="$1" mode="$2" policy="$3" expect_delete="$4"
+  : > "${TMP}/delete.log"
+  make_kubectl "${mode}" "${policy}"
+  # Inject env the render hard-codes, run with fake kubectl on PATH.
+  if ! PATH="${TMP}/bin:${PATH}" TARGET_SC=evs-ssd DESIRED_RECLAIM=Delete \
+        bash "${TMP}/reconcile.sh" > "${TMP}/out.log" 2>&1; then
+    bad "${name}: script exited non-zero"; cat "${TMP}/out.log"; return
+  fi
+  local fired="no"; [ -s "${TMP}/delete.log" ] && fired="yes"
+  if [ "${fired}" = "${expect_delete}" ]; then
+    ok "${name}: delete-fired=${fired} (expected ${expect_delete})"
+  else
+    bad "${name}: delete-fired=${fired} (expected ${expect_delete})"; cat "${TMP}/out.log"
+  fi
+}
+
+# 1. Already Delete → idempotent no-op.
+run_case "live=Delete idempotent"        present Delete no
+# 2. Retain → must delete so Helm recreates with Delete.
+run_case "live=Retain triggers recreate" present Retain yes
+# 3. Absent (fresh prov) → no-op.
+run_case "absent SC fresh-prov"          absent  ""     no
+# 4. Empty live policy + desired Delete (API default) → no-op.
+run_case "live=empty desired-Delete"     present ""     no
+
+echo
+echo "RESULT: ${pass} passed, ${fail} failed"
+[ "${fail}" -eq 0 ]


### PR DESCRIPTION
## Root cause — the 1.0.4 fix is inert on the live env
PR #4352 (chart 1.0.4) flipped the cluster-default `evs-ssd` StorageClass `reclaimPolicy` `Retain → Delete` to stop the EVS volume-COUNT quota leak. That is the correct durable values change, but it is **INERT on a live Huawei Sovereign that already carries the `evs-ssd` SC with the old `Retain` policy**: `reclaimPolicy` is an **IMMUTABLE** StorageClass field, so Helm's apply of the 1.0.4 SC template is rejected:

```
StorageClass.storage.k8s.io "evs-ssd" is invalid: reclaimPolicy: Forbidden: updates to reclaimPolicy are forbidden
```

→ the `bp-huawei-evs-csi` HelmRelease **Stalls** → the whole stateful chain that gates on it (`bp-huawei-evs-csi → bp-cnpg → bp-postgres-shared → bp-keycloak → bp-gitea → bp-catalyst-platform`) never converges → the **org-controller roll wedges** (kom4dc dep `4635277cae4ffed9`, #4340 never rolls; gitea data already recovered per #4353, so this EVS-CSI gate is the sole remaining gate).

## Durable fix — delete + recreate hook
A StorageClass field can only be changed by **delete + recreate**. This adds a `pre-install`/`pre-upgrade` hook Job (`templates/reclaim-reconcile-hook.yaml` + scoped `get`/`list`/`delete` RBAC) that:
- reads the live `evs-ssd` reclaimPolicy;
- if it differs from the desired `Delete`, **deletes** the stale SC so Helm's subsequent main apply **recreates** it with `reclaimPolicy=Delete` (immutable-at-create);
- is **idempotent** — a no-op when the SC is already `Delete`, when its policy is unset (API default `Delete`), or when it is **absent** (fresh prov), so it is safe on every reconcile.

The desired policy is read from `catalystStorageClasses[0].reclaimPolicy`, so the hook and the SC template stay in sync (one source of truth).

### Why this does not disturb any Bound PVC
`reclaimPolicy` is stamped onto each PV at **bind time** (`.spec.persistentVolumeReclaimPolicy`) and is never re-read from the SC afterwards. Deleting + recreating the SC therefore does not touch any existing PV or Bound PVC — only **new** dynamic provisioning reads the SC's policy. The delete→recreate window is tiny (the very next Helm step recreates the SC), and the recreate is left to Helm so the SC's full spec (provisioner / parameters / volumeBindingMode / allowVolumeExpansion / default-class annotation) stays chart-owned.

## Tests
`tests/reclaim-reconcile-hook/test.sh` asserts (11 checks, all green):
- default-off render emits zero resources (smoke-render guard intact);
- the hook renders as `pre-install,pre-upgrade` carrying desired `Delete`;
- the `evs-ssd` SC renders `reclaimPolicy: Delete`;
- RBAC grants `delete` on storageclasses;
- `DESIRED_RECLAIM` follows an overridden values policy;
- the reconcile script (extracted from the rendered Job) run against a fake `kubectl` is a **no-op** when already-Delete / unset / absent, and fires **exactly one delete** when the live policy is `Retain`.

`helm lint` + `helm template` clean in both default-off and enabled modes.

## Versioning
Chart `1.0.4 → 1.0.5` + `blueprint.yaml` + bootstrap-kit slot `55b` pin bumped in lockstep.

## Live recovery (separate, tracked in #4350)
On kom4dc the live `evs-ssd` SC is hand-recreated with `reclaimPolicy: Delete` to unstall the chain now (the #4352 reclaim already cleared the 63 orphan Released PVs); this hook makes the recreate automatic on every future reconcile + fresh prov.

Refs #4350 #4325

🤖 Generated with [Claude Code](https://claude.com/claude-code)
