### PR TITLE
fix(bp-huawei-evs-csi): reclaim-reconcile hook Job carries managed-by:flux so kyverno admits it — unstall the HR gating the whole stateful chain (1.0.6)

### DIFF
--- a/clusters/_template/bootstrap-kit/55b-bp-huawei-evs-csi.yaml
+++ b/clusters/_template/bootstrap-kit/55b-bp-huawei-evs-csi.yaml
@@ -177,7 +177,12 @@ spec:
       # the HR on a live Sovereign that already had the Retain SC (the kom4dc
       # convergence gate). Idempotent (no-op when already Delete / on fresh prov);
       # existing Bound PVs/PVCs are unaffected.
-      version: 1.0.5
+      # 1.0.6 (#4350 follow-up): the 1.0.5 reclaim-reconcile hook Job carries the
+      # `app.kubernetes.io/managed-by: flux` label so the kyverno `flux-managed`
+      # Enforce policy admits it on a converged Sovereign — without it the
+      # pre-upgrade hook was denied → HR stalled → the whole stateful chain
+      # (bp-cnpg → bp-gitea → bp-catalyst-platform → org-controller) stayed gated.
+      version: 1.0.6
       sourceRef:
         kind: HelmRepository
         name: bp-huawei-evs-csi

--- a/platform/huawei-evs-csi/blueprint.yaml
+++ b/platform/huawei-evs-csi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     catalyst.openova.io/provider: huawei
 spec:
-  version: 1.0.5
+  version: 1.0.6
   card:
     title: Huawei EVS CSI
     summary: |

--- a/platform/huawei-evs-csi/chart/Chart.yaml
+++ b/platform/huawei-evs-csi/chart/Chart.yaml
@@ -72,7 +72,17 @@ name: bp-huawei-evs-csi
 # it with reclaimPolicy=Delete. Idempotent: a no-op when the SC is already
 # Delete or absent (fresh prov). Existing Bound PVs/PVCs are UNAFFECTED —
 # reclaimPolicy is stamped on the PV at bind time and never re-read from the SC.
-version: 1.0.5
+# 1.0.6 (#4350 follow-up, kom4dc dep 4635277cae4ffed9, 2026-06-25): the 1.0.5
+# reclaim-reconcile hook Job is DENIED admission on a converged Sovereign by the
+# kyverno `flux-managed` Enforce policy ("Job/huawei-evs-csi-reclaim-reconcile
+# is not Flux-managed") — a pre-* Helm hook carries NO HelmRelease
+# ownerReference, so the policy needs the `app.kubernetes.io/managed-by: flux`
+# label to admit it. Without it the pre-upgrade hook fails → bp-huawei-evs-csi
+# rolls back to 1.0.4 (Stalled RetriesExceeded) → the entire stateful chain
+# (bp-cnpg → bp-gitea → bp-catalyst-platform → org-controller) stays
+# dependency-gated. Stamp the label on the Job metadata + pod template. Same
+# fix shape as bp-cnpg webhook-gate hooks (#4226) + gitea repo-bootstrap (#3462).
+version: 1.0.6
 description: |
   Catalyst-curated Blueprint for the open-source huaweicloud-csi-driver EVS
   block-storage plugin (evs.csi.huaweicloud.com). Provides the durable

--- a/platform/huawei-evs-csi/chart/templates/reclaim-reconcile-hook.yaml
+++ b/platform/huawei-evs-csi/chart/templates/reclaim-reconcile-hook.yaml
@@ -70,6 +70,15 @@ metadata:
     app.kubernetes.io/name: bp-huawei-evs-csi
     app.kubernetes.io/component: reclaim-reconcile-hook
     catalyst.openova.io/blueprint: bp-huawei-evs-csi
+    # Required by the kyverno `flux-managed` Enforce policy on converged
+    # Sovereigns. Helm hook Jobs are applied directly by the helm-controller
+    # (no HelmRelease ownerReference is stamped on a pre-* hook resource), so
+    # without this label the policy denies admission ("...is not Flux-managed")
+    # → the pre-upgrade hook fails → the bp-huawei-evs-csi upgrade rolls back
+    # → bp-cnpg/gitea/catalyst-platform stay dependency-gated. Same fix shape
+    # as the bp-cnpg webhook-gate hooks (#4226) and the gitea repo-bootstrap
+    # hook (#3462).
+    app.kubernetes.io/managed-by: flux
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-10"
@@ -82,6 +91,7 @@ spec:
       labels:
         app.kubernetes.io/name: bp-huawei-evs-csi
         app.kubernetes.io/component: reclaim-reconcile-hook
+        app.kubernetes.io/managed-by: flux
     spec:
       serviceAccountName: {{ .Release.Name }}-reclaim-reconcile
       restartPolicy: Never


### PR DESCRIPTION
## Problem (live, omantel.biz / kom4dc dep `4635277cae4ffed9`)

`bp-huawei-evs-csi@1.0.5` (the #4356 reclaim-reconcile chart) **Stalled=RetriesExceeded** because its pre-upgrade hook Job is denied by the kyverno `flux-managed` Enforce policy:

```
admission webhook "validate.kyverno.svc-fail" denied the request:
Job/huawei-evs-csi-reclaim-reconcile is not Flux-managed. Add label
`app.kubernetes.io/managed-by: flux` on metadata.labels OR attach an
ownerReference to a HelmRelease / Kustomization.
```

A pre-* Helm hook carries NO HelmRelease ownerReference (the helm-controller applies it directly before the main release), so the label is the only path that admits it. With the hook denied, the HR rolled back to 1.0.4 and the **entire stateful dependency chain that gates on it never converges**:

`bp-huawei-evs-csi` (Stalled) → `bp-cnpg` (DependencyNotReady) → `bp-gitea` → `bp-catalyst-platform` → **org-controller roll wedged**.

## Fix

Stamp `app.kubernetes.io/managed-by: flux` on the reclaim-reconcile Job's `metadata.labels` AND pod template labels. Same one-line-class fix as the bp-cnpg webhook-gate hooks (#4226) and the gitea repo-bootstrap hook (#3462).

`helm template` renders the Job with the label on both metadata + pod template.

Chart `1.0.5 → 1.0.6` + bootstrap-kit slot-55b lockstep.

Refs #4350 #4356 #4340

🤖 Generated with [Claude Code](https://claude.com/claude-code)