### PR TITLE
fix(bp-huawei-evs-csi): post-upgrade default-class hook Job carries managed-by:flux — complete the kyverno hook-label sweep (1.0.7)

### DIFF
--- a/clusters/_template/bootstrap-kit/55b-bp-huawei-evs-csi.yaml
+++ b/clusters/_template/bootstrap-kit/55b-bp-huawei-evs-csi.yaml
@@ -182,7 +182,11 @@ spec:
       # Enforce policy admits it on a converged Sovereign — without it the
       # pre-upgrade hook was denied → HR stalled → the whole stateful chain
       # (bp-cnpg → bp-gitea → bp-catalyst-platform → org-controller) stayed gated.
-      version: 1.0.6
+      # 1.0.7 (#4350 follow-up): the POST-upgrade default-class-hook Job carries
+      # the same `managed-by: flux` label so the kyverno policy admits BOTH the
+      # pre- and post- hooks — without it the 1.0.6 upgrade rolled back on the
+      # post-upgrade phase and the HR stayed Stalled.
+      version: 1.0.7
       sourceRef:
         kind: HelmRepository
         name: bp-huawei-evs-csi

--- a/platform/huawei-evs-csi/blueprint.yaml
+++ b/platform/huawei-evs-csi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     catalyst.openova.io/provider: huawei
 spec:
-  version: 1.0.6
+  version: 1.0.7
   card:
     title: Huawei EVS CSI
     summary: |

--- a/platform/huawei-evs-csi/chart/Chart.yaml
+++ b/platform/huawei-evs-csi/chart/Chart.yaml
@@ -82,7 +82,14 @@ name: bp-huawei-evs-csi
 # (bp-cnpg → bp-gitea → bp-catalyst-platform → org-controller) stays
 # dependency-gated. Stamp the label on the Job metadata + pod template. Same
 # fix shape as bp-cnpg webhook-gate hooks (#4226) + gitea repo-bootstrap (#3462).
-version: 1.0.6
+# 1.0.7 (#4350 follow-up, kom4dc dep 4635277cae4ffed9, 2026-06-25): the
+# POST-upgrade default-class-hook Job hit the SAME kyverno `flux-managed`
+# denial the reclaim hook did in 1.0.6 ("Job/huawei-evs-csi-default-class is
+# not Flux-managed") — a post-* Helm hook also carries no HelmRelease
+# ownerReference. Stamp `app.kubernetes.io/managed-by: flux` on it too so the
+# 1.0.6 upgrade no longer rolls back on the post-upgrade phase. Completes the
+# hook-label sweep for this chart (both pre- and post- hooks now admitted).
+version: 1.0.7
 description: |
   Catalyst-curated Blueprint for the open-source huaweicloud-csi-driver EVS
   block-storage plugin (evs.csi.huaweicloud.com). Provides the durable

--- a/platform/huawei-evs-csi/chart/templates/default-class-hook.yaml
+++ b/platform/huawei-evs-csi/chart/templates/default-class-hook.yaml
@@ -44,6 +44,13 @@ metadata:
     app.kubernetes.io/name: bp-huawei-evs-csi
     app.kubernetes.io/component: default-class-hook
     catalyst.openova.io/blueprint: bp-huawei-evs-csi
+    # Required by the kyverno `flux-managed` Enforce policy on converged
+    # Sovereigns — a post-* Helm hook carries no HelmRelease ownerReference, so
+    # without this label the policy denies the Job ("...is not Flux-managed")
+    # → the post-upgrade hook fails → the bp-huawei-evs-csi upgrade rolls back
+    # → the whole stateful chain stays dependency-gated. Sibling of the
+    # reclaim-reconcile hook fix in the same chart (#4350).
+    app.kubernetes.io/managed-by: flux
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "0"
@@ -56,6 +63,7 @@ spec:
       labels:
         app.kubernetes.io/name: bp-huawei-evs-csi
         app.kubernetes.io/component: default-class-hook
+        app.kubernetes.io/managed-by: flux
     spec:
       serviceAccountName: {{ .Release.Name }}-default-class
       restartPolicy: Never


### PR DESCRIPTION
## Problem (live, kom4dc dep `4635277cae4ffed9`)

After #4358 (1.0.6) admitted the PRE-upgrade reclaim-reconcile hook, the bp-huawei-evs-csi upgrade got further but then **rolled back on the POST-upgrade phase** — the `default-class-hook` Job hit the identical kyverno `flux-managed` denial:

```
Hook post-upgrade bp-huawei-evs-csi/templates/default-class-hook.yaml failed:
Job/huawei-evs-csi-default-class is not Flux-managed. Add label
`app.kubernetes.io/managed-by: flux` ...
```

A post-* Helm hook also carries no HelmRelease ownerReference, so it needs the same label. The HR re-Stalled (`RetriesExceeded`, rolled back to 1.0.4), keeping the stateful chain (`bp-cnpg → bp-gitea → bp-catalyst-platform → org-controller`) dependency-gated.

## Fix

Stamp `app.kubernetes.io/managed-by: flux` on the `default-class-hook` Job metadata + pod template. Both pre- AND post- hook Jobs in this chart are now admitted, completing the hook-label sweep so the upgrade runs to `UpgradeSucceeded`.

`helm template` renders the Job with the label on both metadata + pod template.

Chart `1.0.6 → 1.0.7` + blueprint.yaml + bootstrap-kit slot-55b lockstep.

Refs #4350 #4356 #4340

🤖 Generated with [Claude Code](https://claude.com/claude-code)