### PR TITLE
fix(bp-plane-isolation): default-deny egress 0.0.0.0/0 is Cilium world-only → drops ALL in-cluster dials (0.1.2)

### DIFF
--- a/clusters/_template/bootstrap-kit/26b-bp-plane-isolation.yaml
+++ b/clusters/_template/bootstrap-kit/26b-bp-plane-isolation.yaml
@@ -65,7 +65,10 @@ spec:
       # OCI digest on tag.
       # 0.1.1 — #4347 (Refs #4325): YAML doc-separator fix so the HR install no
       #   longer fails post-render with `mapping key "apiVersion" already defined`.
-      version: 0.1.1
+      # 0.1.2 — #4360 (Refs #4272 #4307 #4322 #4179): default-deny egress
+      #   `ipBlock 0.0.0.0/0` is Cilium world-only → dropped ALL in-cluster dials
+      #   (gitea→shared-pg etc.); add a `namespaceSelector {}` egress allow rule.
+      version: 0.1.2
       sourceRef:
         kind: HelmRepository
         name: bp-plane-isolation

--- a/clusters/_template/bootstrap-kit/55b-bp-huawei-evs-csi.yaml
+++ b/clusters/_template/bootstrap-kit/55b-bp-huawei-evs-csi.yaml
@@ -182,7 +182,11 @@ spec:
       # Enforce policy admits it on a converged Sovereign — without it the
       # pre-upgrade hook was denied → HR stalled → the whole stateful chain
       # (bp-cnpg → bp-gitea → bp-catalyst-platform → org-controller) stayed gated.
-      version: 1.0.6
+      # 1.0.7 (#4350 follow-up): the POST-upgrade default-class-hook Job carries
+      # the same `managed-by: flux` label so the kyverno policy admits BOTH the
+      # pre- and post- hooks — without it the 1.0.6 upgrade rolled back on the
+      # post-upgrade phase and the HR stayed Stalled.
+      version: 1.0.7
       sourceRef:
         kind: HelmRepository
         name: bp-huawei-evs-csi

--- a/platform/huawei-evs-csi/blueprint.yaml
+++ b/platform/huawei-evs-csi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     catalyst.openova.io/provider: huawei
 spec:
-  version: 1.0.6
+  version: 1.0.7
   card:
     title: Huawei EVS CSI
     summary: |

--- a/platform/huawei-evs-csi/chart/Chart.yaml
+++ b/platform/huawei-evs-csi/chart/Chart.yaml
@@ -82,7 +82,14 @@ name: bp-huawei-evs-csi
 # (bp-cnpg → bp-gitea → bp-catalyst-platform → org-controller) stays
 # dependency-gated. Stamp the label on the Job metadata + pod template. Same
 # fix shape as bp-cnpg webhook-gate hooks (#4226) + gitea repo-bootstrap (#3462).
-version: 1.0.6
+# 1.0.7 (#4350 follow-up, kom4dc dep 4635277cae4ffed9, 2026-06-25): the
+# POST-upgrade default-class-hook Job hit the SAME kyverno `flux-managed`
+# denial the reclaim hook did in 1.0.6 ("Job/huawei-evs-csi-default-class is
+# not Flux-managed") — a post-* Helm hook also carries no HelmRelease
+# ownerReference. Stamp `app.kubernetes.io/managed-by: flux` on it too so the
+# 1.0.6 upgrade no longer rolls back on the post-upgrade phase. Completes the
+# hook-label sweep for this chart (both pre- and post- hooks now admitted).
+version: 1.0.7
 description: |
   Catalyst-curated Blueprint for the open-source huaweicloud-csi-driver EVS
   block-storage plugin (evs.csi.huaweicloud.com). Provides the durable

--- a/platform/huawei-evs-csi/chart/templates/default-class-hook.yaml
+++ b/platform/huawei-evs-csi/chart/templates/default-class-hook.yaml
@@ -44,6 +44,13 @@ metadata:
     app.kubernetes.io/name: bp-huawei-evs-csi
     app.kubernetes.io/component: default-class-hook
     catalyst.openova.io/blueprint: bp-huawei-evs-csi
+    # Required by the kyverno `flux-managed` Enforce policy on converged
+    # Sovereigns — a post-* Helm hook carries no HelmRelease ownerReference, so
+    # without this label the policy denies the Job ("...is not Flux-managed")
+    # → the post-upgrade hook fails → the bp-huawei-evs-csi upgrade rolls back
+    # → the whole stateful chain stays dependency-gated. Sibling of the
+    # reclaim-reconcile hook fix in the same chart (#4350).
+    app.kubernetes.io/managed-by: flux
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "0"
@@ -56,6 +63,7 @@ spec:
       labels:
         app.kubernetes.io/name: bp-huawei-evs-csi
         app.kubernetes.io/component: default-class-hook
+        app.kubernetes.io/managed-by: flux
     spec:
       serviceAccountName: {{ .Release.Name }}-default-class
       restartPolicy: Never

--- a/platform/plane-isolation/blueprint.yaml
+++ b/platform/plane-isolation/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 0.1.1  # lockstep with chart/Chart.yaml (#4347 doc-separator fix)
+  version: 0.1.2  # lockstep with chart/Chart.yaml (#4360 Cilium world-only egress fix)
   card:
     title: Plane isolation (per-component default-deny)
     summary: |

--- a/platform/plane-isolation/chart/Chart.yaml
+++ b/platform/plane-isolation/chart/Chart.yaml
@@ -27,7 +27,19 @@ name: bp-plane-isolation
 #   errors: mapping key "apiVersion" already defined` → bp-plane-isolation HR
 #   install FAILED (live on omantel.biz region-a). All 24 docs now separate
 #   cleanly. Dropped the `-}}` chomp on the $ns assignment in both templates.
-version: 0.1.1
+# 0.1.2 (#4360 / Refs #4272 #4307 #4322 #4179): FIX the default-deny egress
+#   rule silently dropping ALL in-cluster traffic under Cilium. The egress
+#   allow was `ipBlock: 0.0.0.0/0` ONLY — but a K8s NetworkPolicy CIDR rule
+#   matches Cilium's `world` entity, NOT in-cluster pod identities, so every
+#   covered component's cross-component dial (gitea→shared-pg, keycloak→CNPG,
+#   harbor→openbao, …) was Policy-denied. Live proof on omantel.biz region-a:
+#   `cilium monitor` drop `identity gitea->shared-pg 10.42.2.135 -> 10.42.4.241:5432
+#   tcp SYN` → gitea SQL 2m timeouts → all git auth 401 → every funnel Org's
+#   GitRepository source False → org-controller GiteaOrgFailed → ZERO funnel
+#   Orgs converge. Added a companion `namespaceSelector: {}` egress rule so the
+#   union admits in-cluster identities alongside world. Same reserved-entity
+#   class as the gateway `ingress` CNP this chart already ships.
+version: 0.1.2
 description: |
   Per-component default-deny + explicit-allow micro-segmentation for the
   de-vclustered platform planes (#4291 Workstream C). For each platform

--- a/platform/plane-isolation/chart/templates/default-deny-networkpolicy.yaml
+++ b/platform/plane-isolation/chart/templates/default-deny-networkpolicy.yaml
@@ -73,8 +73,23 @@ spec:
     # Egress is otherwise unconstrained (the whole-plane policy left egress
     # open too). Per-component egress narrowing is a follow-up once the live
     # call graph is captured — tightening egress blind risks severing a
-    # legitimate cross-component dial. An empty `to:`/`ports:` rule allows
-    # all remaining egress (the documented K8s NetworkPolicy allow-all shape).
+    # legitimate cross-component dial.
+    #
+    # 🛑 CILIUM GOTCHA (#4360): a K8s NetworkPolicy `ipBlock: 0.0.0.0/0`
+    # egress rule matches ONLY the Cilium `world`/CIDR entity — it does NOT
+    # match in-cluster pod identities. So a CIDR-only "allow all" egress rule
+    # silently DROPS every cluster-internal dial (e.g. gitea → shared-pg
+    # postgres, keycloak → its CNPG, harbor → openbao). This is the SAME
+    # reserved-entity trap the gateway `ingress` CNP guards against, applied
+    # to egress. We therefore emit TWO egress allow rules so the union covers
+    # BOTH planes of the address space:
+    #   - namespaceSelector:{} → every in-cluster pod identity (the dropped
+    #     cross-component dials), AND
+    #   - ipBlock 0.0.0.0/0 → genuinely-external (world) egress.
+    # Without the namespaceSelector rule the Egress policyType strands every
+    # covered component the moment it talks to another in-cluster pod.
+    - to:
+        - namespaceSelector: {}
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0


### PR DESCRIPTION
## Problem (P0, live on omantel.biz / kom4dc region-a)

`bp-plane-isolation` 0.1.1 renders a per-component `<ns>-default-deny` K8s NetworkPolicy with `policyTypes: [Ingress, Egress]`. Its egress allow-set is DNS + a single `ipBlock: 0.0.0.0/0` rule (intended "allow all remaining egress").

Under **Cilium**, a K8s NetworkPolicy `ipBlock: 0.0.0.0/0` egress rule matches ONLY the Cilium `world`/CIDR entity — it does NOT match in-cluster pod identities. So every covered component's cross-component dial was Policy-denied.

### Packet-level proof (cilium monitor, gitea node)
```
xx drop (Policy denied) identity 4734964->4723366: 10.42.2.135:34588 -> 10.42.4.241:5432 tcp SYN
```
gitea (4734964) -> shared-pg primary (10.42.4.241:5432) dropped -> gitea SQL 2m timeouts -> all git auth 401 -> every catalyst-tenant-<slug> Flux GitRepository source False -> org-controller GiteaOrgFailed -> ZERO funnel Orgs converge, no cart Blueprint can land. Sibling drops to :6222/:9000/:8080 from other covered components confirm it is Sovereign-wide, not gitea-only.

## Fix

Emit a companion `namespaceSelector: {}` egress rule so the union admits in-cluster pod identities alongside `world`. Same reserved-entity class as the gateway `ingress` CNP this chart already ships. Chart 0.1.1 -> 0.1.2 (+ blueprint.yaml + bootstrap-kit pin lockstep).

Hot-patched live (all 16 `*-default-deny` NPs) to recover the env — verified gitea -> shared-pg open, gitea API 200 in 14ms, all GitRepository sources True, g5funnel Org Ready=True.

Refs #4272 #4307 #4322 #4179

🤖 Generated with [Claude Code](https://claude.com/claude-code)
