### PR TITLE
fix(application-controller): typed-nil spec.parameters validates as {} (Refs #4282)

### DIFF
--- a/core/controllers/pkg/validate/parameters.go
+++ b/core/controllers/pkg/validate/parameters.go
@@ -112,7 +112,29 @@ func Parameters(schema interface{}, parameters interface{}) (Report, error) {
 	}
 
 	// Normalise parameters through JSON for the same reason.
-	normalised := parameters
+	//
+	// A nil/absent parameters block is treated as `{}` — an empty
+	// object. This is the canonical shape an Application carries when no
+	// explicit parameters are supplied (every configSchema property
+	// defaults; the engine applies its own defaults). JSON Schema's
+	// `required` keyword still catches any genuinely required-field
+	// omissions, so this is safe.
+	//
+	// CRITICAL (#4282): `parameters != nil` is NOT sufficient to detect
+	// "no parameters". The controller reads `spec.parameters` via
+	// `unstructured.NestedMap`, which — when the key is absent or
+	// explicitly `null` — returns a TYPED-nil `map[string]interface{}`.
+	// A typed-nil map boxed into an `interface{}` is `!= nil` (the
+	// interface carries a non-nil type descriptor), so it slips past the
+	// `!= nil` guard, then `json.Marshal` of a nil map emits `null`, and
+	// the schema rejects it as `#: expected object, but got null`. That
+	// was the live, recurring `shared-pg-d`/`shared-pg-e` failure: those
+	// Application CRs carry no `spec.parameters` key at all, so every
+	// reconcile pass produced this false-Invalid regardless of which
+	// producer wrote the CR. We therefore normalise FIRST, then treat a
+	// post-marshal `nil` (typed-nil map/slice/pointer, or literal null)
+	// as the empty object.
+	var normalised interface{} = map[string]interface{}{}
 	if parameters != nil {
 		paramBytes, err := json.Marshal(parameters)
 		if err != nil {
@@ -122,9 +144,11 @@ func Parameters(schema interface{}, parameters interface{}) (Report, error) {
 		if err := json.Unmarshal(paramBytes, &v); err != nil {
 			return Report{}, fmt.Errorf("validate: unmarshal parameters: %w", err)
 		}
-		normalised = v
-	} else {
-		normalised = map[string]interface{}{}
+		if v != nil {
+			normalised = v
+		}
+		// v == nil here means `parameters` was a typed-nil map/slice/
+		// pointer that marshalled to JSON null → keep the `{}` default.
 	}
 
 	if err := compiled.Validate(normalised); err != nil {

--- a/core/controllers/pkg/validate/parameters_test.go
+++ b/core/controllers/pkg/validate/parameters_test.go
@@ -119,6 +119,88 @@ func TestParameters_NilParameters(t *testing.T) {
 	}
 }
 
+// objectNoRequiredSchema mirrors the bp-postgres configSchema shape:
+// `type: object` with NO top-level `required` and every property
+// defaulting. `{}` (and an absent parameters block normalised to `{}`)
+// must validate cleanly against it.
+func objectNoRequiredSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"enabled": map[string]interface{}{
+				"type":    "boolean",
+				"default": true,
+			},
+			"topology": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"mode": map[string]interface{}{
+						"type": "string",
+						"enum": []interface{}{"singleton", "active-hot-standby"},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestParameters_TypedNilMap is the #4282 regression: the controller
+// reads `spec.parameters` via `unstructured.NestedMap`, which returns a
+// TYPED-nil `map[string]interface{}` when the key is absent (the live
+// shared-pg-d/shared-pg-e shape — those CRs carry no spec.parameters
+// key at all). A typed-nil map boxed into `interface{}` is NOT `== nil`,
+// so before the fix it slipped past the `!= nil` guard, marshalled to
+// JSON `null`, and the bp-postgres `type: object` schema rejected it as
+// `#: expected object, but got null` on EVERY reconcile — leaving the
+// Application Failed forever. The validator must normalise it to `{}`.
+func TestParameters_TypedNilMap(t *testing.T) {
+	var typedNil map[string]interface{} // typed-nil — NOT an untyped nil
+	rep, err := Parameters(objectNoRequiredSchema(), typedNil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !rep.Valid {
+		t.Fatalf("typed-nil map parameters against an object-no-required "+
+			"schema must validate (normalise to {}); got errors: %v", rep.Errors)
+	}
+	for _, e := range rep.Errors {
+		if strings.Contains(e, "expected object, but got null") {
+			t.Fatalf("regression #4282: typed-nil parameters produced the "+
+				"forbidden null error: %q", e)
+		}
+	}
+}
+
+// TestParameters_TypedNilMap_RequiredStillCaught proves the typed-nil
+// normalisation does NOT silence genuine `required` violations — a
+// typed-nil map against a schema with required fields is still invalid
+// (it validates as `{}`, which is missing the required field).
+func TestParameters_TypedNilMap_RequiredStillCaught(t *testing.T) {
+	var typedNil map[string]interface{}
+	rep, err := Parameters(sampleSchema(), typedNil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rep.Valid {
+		t.Error("typed-nil map against a schema with a required field must " +
+			"still be invalid (normalises to {}, which lacks the required field)")
+	}
+}
+
+// TestParameters_EmptyObject is the positive baseline: an explicit `{}`
+// against the bp-postgres-shaped schema validates (no required fields).
+func TestParameters_EmptyObject(t *testing.T) {
+	rep, err := Parameters(objectNoRequiredSchema(), map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !rep.Valid {
+		t.Errorf("empty object against object-no-required schema must validate; "+
+			"got errors: %v", rep.Errors)
+	}
+}
+
 func TestParameters_MalformedSchema(t *testing.T) {
 	// "type" with an unknown value is rejected by the compiler.
 	bad := map[string]interface{}{


### PR DESCRIPTION
## What

The application-controller's configSchema validator now treats a **typed-nil** `spec.parameters` as `{}` instead of letting it marshal to JSON `null`. This is the reconciler-side root cause of the recurring `configSchema: expected object, got null` failure on `shared-pg-d`/`shared-pg-e` (omantel.biz demo Org), which #4304's producer-side default never reached.

## Root cause (live, omantel.biz region-a, dep `4635277cae4ffed9`)

```
$ kubectl get application shared-pg-d shared-pg-e -n omantel-biz -o yaml
shared-pg-d  bp-postgres 0.1.6  ...  Failed
shared-pg-e  bp-postgres 0.1.6  ...  Failed
  status.conditions[Ready]:
    message: 'parameters do not match Blueprint configSchema: #: expected object, but got null'
    reason: Invalid
```

Both CRs carry **no `spec.parameters` key at all** (verified in the live yaml — the `spec` block ends at `regions:`). The controller reads `spec.parameters` via `unstructured.NestedMap` (`application_controller.go:2488`), which returns a **typed-nil** `map[string]interface{}` when the key is absent.

The validator (`core/controllers/pkg/validate/parameters.go`) intended to default nil → `{}` (its doc comment says so), but its guard was `if parameters != nil`. A typed-nil map boxed into an `interface{}` is **`!= nil`** in Go (the interface carries a non-nil type descriptor):

```go
var m map[string]interface{}      // typed nil
var i interface{} = m
i == nil                          // false!
json.Marshal(i)                   // "null"
```

So the typed-nil map slipped past the guard, marshalled to `null`, and the bp-postgres `type: object` schema rejected it as `#: expected object, but got null` — on **every** reconcile, for any Application with no parameters, regardless of which producer wrote the CR. #4304 fixed the bootstrap-api producers to stamp parameters on *new* CRs, but never touched the validator, so the existing `shared-pg-d/-e` (and any other no-parameters CR, plus the post-Git-round-trip `parameters: null` shape) stayed Failed.

## The fix

Normalise to `{}` **first**, then override only with a genuinely non-null parsed value:

```go
var normalised interface{} = map[string]interface{}{}
if parameters != nil {
    // marshal/unmarshal through JSON …
    if v != nil { normalised = v }
    // v == nil ⇒ typed-nil map/slice/pointer or literal null → keep {}
}
```

This makes the implementation finally honour the validator's documented contract. JSON Schema's `required` keyword still catches genuine required-field omissions, so a typed-nil map against a schema with a required field is still correctly Invalid.

## Tests (`parameters_test.go`)

- `TestParameters_TypedNilMap` — passes a typed-nil `map[string]interface{}` against a bp-postgres-shaped (`type: object`, no `required`) schema; asserts valid and that the forbidden `expected object, but got null` error is absent. **Fails without the fix with the exact live error string; passes with it** (verified by stashing the fix).
- `TestParameters_TypedNilMap_RequiredStillCaught` — typed-nil against a schema with a required field is still Invalid (no over-permissiveness).
- `TestParameters_EmptyObject` — positive baseline.

`go build ./... && go vet ./... && go test ./...` green for the full `core/controllers` module (39 packages, 0 failures).

## Rollout

The fix lives in `core/controllers/pkg/validate/`, inside the `application-controller` build path filter + Containerfile COPY scope, so merge rebuilds the application-controller image and auto-bumps `controllers.application.image.tag` in the chart. catalyst-api is **not** touched (no deploy-bot treadmill). Once the rolled controller re-reconciles the existing `shared-pg-d/-e`, the false-Invalid clears.

## Scope

This fixes the **validation half** that left `shared-pg-d/-e` Failed-on-configSchema. Full convergence to a Ready CNPG cluster for the `vcluster=rtz` placement path is the separate structural Root-B (no CNPG operator reconciling the `rtz` vCluster) tracked by EPIC #4293 (de-vclustering).

Refs #4282

🤖 Generated with [Claude Code](https://claude.com/claude-code)