### PR TITLE
fix(tenant): funnel CreateOrg renders selected cart Applications into the per-Org gitops tree (Refs #4272 #4307 #4322 #4179)

### DIFF
--- a/core/services/tenant/handlers/funnel_cart_install_test.go
+++ b/core/services/tenant/handlers/funnel_cart_install_test.go
@@ -1,0 +1,99 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/openova-io/openova/core/services/shared/events"
+	"github.com/openova-io/openova/core/services/tenant/store"
+)
+
+// recordingProducer captures every event Publish receives so a test can assert
+// exactly which app-install dispatches the funnel cart emitted.
+type recordingProducer struct {
+	published []*events.Event
+}
+
+func (p *recordingProducer) Publish(_ context.Context, _ string, e *events.Event) error {
+	p.published = append(p.published, e)
+	return nil
+}
+func (p *recordingProducer) Close() {}
+
+// appSlugsFromInstallEvents pulls the app_slug out of every
+// tenant.app_install_requested event the producer recorded.
+func appSlugsFromInstallEvents(t *testing.T, evs []*events.Event) []string {
+	t.Helper()
+	var out []string
+	for _, e := range evs {
+		if e.Type != "tenant.app_install_requested" {
+			continue
+		}
+		var data map[string]any
+		if err := json.Unmarshal(e.Data, &data); err != nil {
+			t.Fatalf("decode app_install_requested data: %v", err)
+		}
+		if s, ok := data["app_slug"].(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// TestDispatchFunnelCartInstall_DispatchesDeployableAppsSkipsSandbox proves the
+// funnel cart-placement gap fix (#4360): a funnel Org created with cart apps
+// emits a tenant.app_install_requested per cart app so the provisioning service
+// renders the Applications into the per-Org gitops tree — the funnel analogue
+// of the BSS door's Step-6. `sandbox` is excluded (it has its own
+// tenant.sandbox_requested dispatch). With the Catalog unwired the helper
+// dispatches the raw cart slugs (capacity was validated at checkout).
+func TestDispatchFunnelCartInstall_DispatchesDeployableAppsSkipsSandbox(t *testing.T) {
+	prod := &recordingProducer{}
+	h := &Handler{
+		Producer: prod,
+		// Catalog nil → raw-slug dispatch path; ProvisioningURL empty → the
+		// HTTP leg errors (logged, non-fatal) and the event leg still fires.
+	}
+
+	tenant := &store.Tenant{
+		ID:        "tid-1",
+		Slug:      "acme",
+		Subdomain: "acme",
+		PlanID:    "plan-s",
+		Apps:      []string{"wordpress", "sandbox", "umami"},
+	}
+
+	h.dispatchFunnelCartInstall(context.Background(), tenant)
+
+	got := appSlugsFromInstallEvents(t, prod.published)
+	want := map[string]bool{"wordpress": true, "umami": true}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d install dispatches, got %d (%v)", len(want), len(got), got)
+	}
+	for _, s := range got {
+		if !want[s] {
+			t.Errorf("unexpected dispatch for %q (sandbox must be excluded; only cart apps dispatched)", s)
+		}
+		delete(want, s)
+	}
+	for s := range want {
+		t.Errorf("missing dispatch for cart app %q", s)
+	}
+}
+
+// TestDispatchFunnelCartInstall_EmptyCartNoOp proves an Org created with no cart
+// apps emits nothing (the funnel still mints the Org shell via tenant.created;
+// this helper is purely additive for cart placement).
+func TestDispatchFunnelCartInstall_EmptyCartNoOp(t *testing.T) {
+	prod := &recordingProducer{}
+	h := &Handler{Producer: prod}
+
+	h.dispatchFunnelCartInstall(context.Background(), &store.Tenant{ID: "tid", Subdomain: "acme"})
+	if len(prod.published) != 0 {
+		t.Fatalf("expected zero events for empty cart, got %d", len(prod.published))
+	}
+
+	// nil tenant must not panic.
+	h.dispatchFunnelCartInstall(context.Background(), nil)
+}

--- a/core/services/tenant/handlers/handlers.go
+++ b/core/services/tenant/handlers/handlers.go
@@ -300,6 +300,26 @@ func (h *Handler) CreateOrg(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// #4360 funnel cart-placement (Refs #4272 #4307 #4322 #4179): the
+	// marketplace funnel persists the selected cart `Apps` on the Tenant +
+	// emits `tenant.created` (which mints ONLY the Organization CR — the
+	// org-controller renders the boundary ns + vCluster + network policies,
+	// but NO cart Applications). Without an explicit install dispatch the
+	// customer's purchased apps NEVER land in the per-Org gitops tree (the
+	// `vcluster/apps/` tree carried only networkpolicy.yaml) — the exact
+	// BSS-vs-funnel divergence #4179 catalogs, this time for cart placement
+	// (the BSS door's Step-6 renders the cart; the funnel door skipped it).
+	//
+	// Mirror the day-2 InstallApp path: for each deployable cart app, fire
+	// `tenant.app_install_requested` + the HTTP `/provisioning/apps/install`
+	// so the provisioning service renders the Applications into the per-Org
+	// gitops tree (same applyTenantChange → GenerateAllWithPassword path Flux
+	// reconciles once the org-controller boundary is up). Best-effort: a
+	// dispatch failure logs loud but does NOT fail Org creation (the shell is
+	// already minted; the day-2 page can re-install). `sandbox` is excluded
+	// here — it has its own `tenant.sandbox_requested` path below.
+	h.dispatchFunnelCartInstall(r.Context(), tenant)
+
 	// Wave 4 — Sandbox: when the cart contains the sandbox product,
 	// emit a sibling `tenant.sandbox_requested` event so the
 	// sandbox-controller (or its upstream orchestrator) can mint a
@@ -347,6 +367,115 @@ func (h *Handler) CreateOrg(w http.ResponseWriter, r *http.Request) {
 		Tenant:      tenant,
 		ConsoleHost: deriveTenantConsoleHost(tenant),
 	})
+}
+
+// dispatchFunnelCartInstall renders the customer's selected cart apps into the
+// per-Org gitops tree at signup time (#4360, Refs #4272 #4307 #4322 #4179).
+//
+// The marketplace funnel (CreateOrg) persists the chosen `Apps` on the Tenant
+// and emits `tenant.created`, which mints ONLY the Organization CR — the
+// org-controller then renders the boundary namespace + vCluster + network
+// policies, but NOT the cart Applications. This helper closes that gap by
+// dispatching the SAME day-2 install path InstallApp uses for each deployable
+// cart app, so the provisioning service commits the Applications into the
+// per-Org `vcluster/apps/` tree (the applyTenantChange → GenerateAllWithPassword
+// path Flux reconciles into the Org boundary once it is up). It is the funnel
+// analogue of the BSS door's Step-6 cart placement.
+//
+// Best-effort + non-fatal: a catalog miss, a non-deployable slug, or a publish
+// failure is logged loud but never fails Org creation (the shell is already
+// minted; the day-2 page can re-install). `sandbox` is excluded — it has its
+// own `tenant.sandbox_requested` dispatch. When the Catalog client is unwired
+// (capacity was validated at checkout, the consumer resolves slugs itself) the
+// helper still dispatches the raw cart slugs so provisioning can render them.
+func (h *Handler) dispatchFunnelCartInstall(ctx context.Context, t *store.Tenant) {
+	if t == nil || len(t.Apps) == 0 {
+		return
+	}
+
+	// Resolve the catalog so we can (a) filter to deployable apps and (b) map
+	// slug↔ID. When the Catalog is unwired we cannot filter, so we fall back to
+	// dispatching the raw cart entries (minus sandbox) and let the provisioning
+	// consumer resolve + skip non-deployable slugs.
+	var bySlug map[string]*catalog.App
+	var byID map[string]*catalog.App
+	if h.Catalog != nil {
+		if apps, err := h.Catalog.ListApps(ctx); err == nil {
+			bySlug = make(map[string]*catalog.App, len(apps))
+			byID = make(map[string]*catalog.App, len(apps))
+			for i := range apps {
+				bySlug[apps[i].Slug] = &apps[i]
+				byID[apps[i].ID] = &apps[i]
+			}
+		} else {
+			slog.Warn("funnel cart-install: catalog list failed — dispatching raw cart slugs",
+				"tenant_id", t.ID, "slug", t.Subdomain, "error", err)
+		}
+	}
+
+	for _, entry := range t.Apps {
+		// Cart entries may be catalog IDs or slugs depending on the marketplace
+		// build. Normalize to (slug, id) via whichever index hits.
+		slug, id := entry, ""
+		if byID != nil {
+			if a, ok := byID[entry]; ok {
+				slug, id = a.Slug, a.ID
+			} else if a, ok := bySlug[entry]; ok {
+				slug, id = a.Slug, a.ID
+			}
+		}
+		// Sandbox has its own dispatch (tenant.sandbox_requested) — never push it
+		// through the app-install path (it has no provisioning Deployment template).
+		if slug == "sandbox" {
+			continue
+		}
+		// Filter to deployable apps when the catalog is available. A catalog entry
+		// that is listed-but-not-deployable (e.g. openclaw/stalwart-mail, which
+		// need HelmRelease overlays the one-Deployment generator can't emit) is
+		// skipped with a loud log rather than dispatched to fail downstream.
+		if bySlug != nil {
+			a, ok := bySlug[slug]
+			if !ok {
+				slog.Warn("funnel cart-install: cart app not in catalog — skipping",
+					"tenant_id", t.ID, "slug", t.Subdomain, "app", slug)
+				continue
+			}
+			if !a.Deployable {
+				slog.Warn("funnel cart-install: cart app not deployable yet — skipping (day-2 page can retry once the template ships)",
+					"tenant_id", t.ID, "slug", t.Subdomain, "app", slug)
+				continue
+			}
+		}
+
+		// Mirror InstallApp's dispatch shape exactly so the provisioning service
+		// dedups + renders identically across the funnel and day-2 doors.
+		idempotencyKey := t.ID + ":cart:" + slug
+		payload := map[string]any{
+			"tenant_id":       t.ID,
+			"tenant_slug":     t.Subdomain,
+			"plan_id":         t.PlanID,
+			"app_slug":        slug,
+			"app_id":          id,
+			"idempotency_key": idempotencyKey,
+			"deploy_ids":      []string{},
+			"deploy_slugs":    []string{slug},
+			"apps":            t.Apps,
+		}
+		if err := h.callProvisioning(ctx, "/provisioning/apps/install", payload); err != nil {
+			slog.Error("funnel cart-install: provisioning HTTP call failed (event fallback still fires)",
+				"tenant_id", t.ID, "slug", t.Subdomain, "app", slug, "error", err)
+		}
+		if evt, err := events.NewEvent("tenant.app_install_requested", "tenant-service", t.ID, payload); err == nil {
+			pubCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			if pubErr := h.Producer.Publish(pubCtx, "org.tenant.events", evt); pubErr != nil {
+				slog.Debug("funnel cart-install: event publish (best-effort)",
+					"tenant_id", t.ID, "app", slug, "error", pubErr)
+			}
+			cancel()
+		}
+		slog.Info("funnel cart-install: dispatched cart app",
+			"tenant_id", t.ID, "slug", t.Subdomain, "app", slug)
+	}
 }
 
 // deriveTenantConsoleHost composes the per-Org customer console host:


### PR DESCRIPTION
## Problem (the funnel cart-placement gap, live on omantel.biz)

The marketplace funnel (`POST /tenant/orgs` -> `CreateOrg`) persists the chosen cart `Apps` on the Tenant and emits `tenant.created` — which mints ONLY the Organization CR. The org-controller then renders the boundary namespace + vCluster + network policies, but **NO cart Applications**.

Live-proof: funnel Orgs `g5funnel` / `g2signup` have their Org shell `Ready=True` yet ZERO HelmReleases in their namespaces, and their per-Org `vcluster/apps/` tree contains only:
```
ciliumnetworkpolicy.yaml
kustomization.yaml
networkpolicy.yaml
```
The customer's purchased apps never land. This is the BSS-vs-funnel divergence #4179 catalogs, now for **cart placement** — the BSS door's Step-6 renders the cart; the funnel door skipped it. The only existing install dispatch was the day-2 `InstallApp` handler (`POST /tenant/orgs/{id}/apps`); the signup path special-cased only `sandbox`.

## Fix

`dispatchFunnelCartInstall` mirrors the day-2 `InstallApp` dispatch for each deployable cart app right after the Org shell is requested: fires `tenant.app_install_requested` + the HTTP `/provisioning/apps/install`, so the provisioning service commits the Applications into the per-Org gitops tree (`applyTenantChange` -> `GenerateAllWithPassword`, which Flux reconciles into the Org boundary once the org-controller brings it up).

- Deployable-filtered: skips listed-but-not-deployable entries (e.g. `openclaw` / `stalwart-mail`, which need HelmRelease overlays the one-Deployment generator can't emit — they are intentionally `Deployable=false`).
- `sandbox` excluded (has its own `tenant.sandbox_requested` dispatch).
- Best-effort + non-fatal: a catalog miss / publish failure logs loud but never fails Org creation.

Unit tests assert: deployable cart apps dispatch, `sandbox` is skipped, empty cart is a no-op, nil tenant doesn't panic.

NOTE: this depends on the substrate fix PR #4361 (bp-plane-isolation egress) — without it gitea is down and NO Org converges at all.

Refs #4272 #4307 #4322 #4179

🤖 Generated with [Claude Code](https://claude.com/claude-code)