### PR TITLE
fix(bp-agenity #4325): topology placement.tier rtz -> '' (host-native) — kill agenity 'namespaces "rtz" not found' Degraded

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1114,7 +1114,10 @@ spec:
       #   CrashLoop) + environment/blueprint/application controller pins → 8c532a7
       #   (#4363 configSchema fix; clears the freshness gate). (slot-13 was also 2
       #   behind: the deploy-bot 1.4.850 bump never synced this pin.) Refs #4373 #4363.
-      version: 1.4.852
+      # 1.4.853 — #4362 (#4325 fallout): catalog-seed bp-agenity topology
+      #   tier rtz -> '' (host-native) + resources requests==limits +
+      #   helmRelease.disableWait; lockstep slot-pin bump (chart 1.4.853).
+      version: 1.4.853
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/agenity/blueprint.yaml
+++ b/products/agenity/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.5.11
+  version: 0.5.12
   card:
     title: Agenity
     summary: |
@@ -109,6 +109,19 @@ spec:
     default: single-region
   manifests:
     chart: ./chart
+    helmRelease:
+      # disableWait — do NOT block the helm install on workload (pod)
+      # readiness. The agenity image (chepherd + claude-code + node runtime,
+      # appVersion 0.9.7) is large and cold-pulls slowly on a fresh Org node;
+      # with Flux's default --wait the install burns its timeout waiting for
+      # the Pod, then helm-controller UNINSTALLS the release (deleting the
+      # StatefulSet + Pod) and retries — restarting the image pull from zero
+      # every cycle, so the Pod never converges (live on the omantel.biz demo
+      # Org post-#4325, #4362). disableWait lets the release reach Released so
+      # the StatefulSet survives and the Pod finishes pulling on its own
+      # schedule. The dashboard SPA has zero dependsOn (it must serve while
+      # keycloak/cnpg converge), so nothing downstream needs the readiness gate.
+      disableWait: true
   depends:
     - blueprint: bp-external-secrets
       version: ^1.0

--- a/products/agenity/blueprint.yaml
+++ b/products/agenity/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.5.9
+  version: 0.5.10
   card:
     title: Agenity
     summary: |
@@ -130,7 +130,17 @@ spec:
     perTopology:
       singleton:
         placement:
-          tier: rtz
+          # #4325 de-vclustered the platform planes (mgmt/rtz/dmz → native
+          # host namespaces) and removed the `rtz` plane vCluster. A per-Org
+          # agentic dashboard is NOT a platform-plane workload — it lands on
+          # the HOST in its own Org namespace (#4297 keystone). tier MUST be
+          # '' (host-native, no vCluster pivot); a non-empty tier resolves
+          # through the controller's VClusterPlacements and the rendered HR
+          # is upserted into the removed `rtz` namespace → `namespaces "rtz"
+          # not found` (Degraded). The `rtz-A` cluster ID is the
+          # region-cluster designator (kept for the region pin), NOT a
+          # vCluster name.
+          tier: ''
           clusters:
             - rtz-A
           roles:

--- a/products/agenity/blueprint.yaml
+++ b/products/agenity/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.5.10
+  version: 0.5.11
   card:
     title: Agenity
     summary: |

--- a/products/agenity/chart/Chart.yaml
+++ b/products/agenity/chart/Chart.yaml
@@ -8,6 +8,16 @@ description: |
   (RBAC-scoped to the User's rights) to create more Applications in the
   User's own Organization — the north-star self-service journey.
 type: application
+# 0.5.10 -> 0.5.11 (#4362, #4325 fallout): set the chepherd container
+# resources requests == limits (Guaranteed QoS, 1:1 ratio). Once #4325 moved
+# agenity host-native into the per-Org namespace (above), the namespace's plan
+# `plan-limits` LimitRange (maxLimitRequestRatio cpu:1/memory:1 — the Sovereign
+# sells Guaranteed quota) REJECTED the prior Burstable spec (cpu 200m->2 = 10:1,
+# memory 512Mi->4Gi = 8:1) at pod admission: `max limit to request ratio per
+# Container is 1, but provided ratio is N`. The StatefulSet then never created a
+# Pod and the Application wedged Provisioning. requests == limits (cpu 1 / mem
+# 2Gi) keeps the pod admissible and right-sizes the singleton dashboard + one
+# solo claude REPL. Values-only change; appVersion image UNCHANGED.
 # 0.5.9 -> 0.5.10 (#4362, #4325 fallout): flip blueprint.yaml topology
 # singleton placement.tier `rtz` -> '' (host-native). #4325 de-vclustered the
 # platform planes (mgmt/rtz/dmz) into native host namespaces and removed the
@@ -87,7 +97,7 @@ type: application
 # `ingress` entity that no K8s NetworkPolicy can admit — without the CNP every
 # external hit to agenity.<slug>.<pool> returned envoy 503 "upstream connect
 # error". appVersion (dashboard image) stays 0.9.6 — image bytes unchanged.
-version: 0.5.10
+version: 0.5.11
 # Bumped appVersion 0.9.6 -> 0.9.7 (#4180): 0.9.7 is the FIRST image whose
 # /app/ mounts the WORKSPACES dashboard (Dashboardws bundle) rather than the
 # archaic single-column Dashboard.svelte. It is built from agenity#752

--- a/products/agenity/chart/Chart.yaml
+++ b/products/agenity/chart/Chart.yaml
@@ -8,6 +8,17 @@ description: |
   (RBAC-scoped to the User's rights) to create more Applications in the
   User's own Organization — the north-star self-service journey.
 type: application
+# 0.5.11 -> 0.5.12 (#4362, #4325 fallout): declare manifests.helmRelease.
+# disableWait=true so the application-controller stamps install.disableWait +
+# upgrade.disableWait on the rendered HR. The large agenity image (appVersion
+# 0.9.7) cold-pulls slowly on a fresh Org node; with Flux's default --wait the
+# helm install times out waiting for the Pod, helm-controller UNINSTALLS the
+# release (deleting the StatefulSet + Pod) and retries — restarting the image
+# pull from zero every cycle, so the Pod never converges (live on the
+# omantel.biz demo Org post-#4325). disableWait lets the release reach Released
+# so the StatefulSet survives and the Pod finishes pulling on its own schedule;
+# the dashboard SPA has zero dependsOn so nothing needs the readiness gate.
+# blueprint-metadata-only; chart TEMPLATES + appVersion image UNCHANGED.
 # 0.5.10 -> 0.5.11 (#4362, #4325 fallout): set the chepherd container
 # resources requests == limits (Guaranteed QoS, 1:1 ratio). Once #4325 moved
 # agenity host-native into the per-Org namespace (above), the namespace's plan
@@ -97,7 +108,7 @@ type: application
 # `ingress` entity that no K8s NetworkPolicy can admit — without the CNP every
 # external hit to agenity.<slug>.<pool> returned envoy 503 "upstream connect
 # error". appVersion (dashboard image) stays 0.9.6 — image bytes unchanged.
-version: 0.5.11
+version: 0.5.12
 # Bumped appVersion 0.9.6 -> 0.9.7 (#4180): 0.9.7 is the FIRST image whose
 # /app/ mounts the WORKSPACES dashboard (Dashboardws bundle) rather than the
 # archaic single-column Dashboard.svelte. It is built from agenity#752

--- a/products/agenity/chart/Chart.yaml
+++ b/products/agenity/chart/Chart.yaml
@@ -8,6 +8,17 @@ description: |
   (RBAC-scoped to the User's rights) to create more Applications in the
   User's own Organization — the north-star self-service journey.
 type: application
+# 0.5.9 -> 0.5.10 (#4362, #4325 fallout): flip blueprint.yaml topology
+# singleton placement.tier `rtz` -> '' (host-native). #4325 de-vclustered the
+# platform planes (mgmt/rtz/dmz) into native host namespaces and removed the
+# `rtz` plane vCluster; the application-controller resolved the agenity
+# Application's `tier: rtz` through VClusterPlacements and upserted the
+# per-cluster HelmRelease into the now-absent `rtz` namespace -> Ready=False
+# `namespaces "rtz" not found` (Degraded on the omantel.biz demo Org). A per-Org
+# agentic dashboard lands on the HOST in its own Org namespace (#4297 keystone),
+# so tier '' is correct: no vCluster pivot, HR renders in the App's own
+# namespace. The `rtz-A` cluster ID stays (region designator, not a vCluster).
+# blueprint-metadata-only change; chart TEMPLATES + appVersion image UNCHANGED.
 # 0.5.8 -> 0.5.9 (#4276 hop 7/7b): add the per-Org openova-MCP Catalyst-bearer
 # seam — templates/externalsecret-mcp-bearer.yaml + the openovaMCP.mcpBearer
 # values block. The catalyst-api org-pipeline producer (seedMCPBearer) mints an
@@ -76,7 +87,7 @@ type: application
 # `ingress` entity that no K8s NetworkPolicy can admit — without the CNP every
 # external hit to agenity.<slug>.<pool> returned envoy 503 "upstream connect
 # error". appVersion (dashboard image) stays 0.9.6 — image bytes unchanged.
-version: 0.5.9
+version: 0.5.10
 # Bumped appVersion 0.9.6 -> 0.9.7 (#4180): 0.9.7 is the FIRST image whose
 # /app/ mounts the WORKSPACES dashboard (Dashboardws bundle) rather than the
 # archaic single-column Dashboard.svelte. It is built from agenity#752

--- a/products/agenity/chart/values.yaml
+++ b/products/agenity/chart/values.yaml
@@ -305,13 +305,24 @@ persistence:
 # ── Resources ─────────────────────────────────────────────────────────────
 # chepherd itself is a light coordinator; the per-agent claude REPLs are the
 # heavy users and run as sidecar/podman children inside the pod.
+#
+# requests == limits (Guaranteed QoS, 1:1 ratio). A per-Org namespace carries
+# the plan `plan-limits` LimitRange with maxLimitRequestRatio cpu:1/memory:1
+# (the Sovereign sells Guaranteed quota — every reserved vCPU/GB is committed),
+# so a Burstable spec (e.g. cpu 200m->2 = 10:1, memory 512Mi->4Gi = 8:1) is
+# REJECTED at pod admission: `max limit to request ratio per Container is 1,
+# but provided ratio is N` → the StatefulSet never creates a Pod and the
+# Application wedges Provisioning (live on the omantel.biz demo Org post-#4325
+# de-vcluster, when agenity moved host-native into the Org namespace under the
+# plan LimitRange). Pinning requests == limits keeps the pod admissible AND
+# right-sizes the singleton dashboard + one solo claude REPL.
 resources:
   requests:
-    cpu: 200m
-    memory: 512Mi
+    cpu: "1"
+    memory: 2Gi
   limits:
-    cpu: "2"
-    memory: 4Gi
+    cpu: "1"
+    memory: 2Gi
 
 # ── Pod security / scheduling ─────────────────────────────────────────────
 podAnnotations: {}

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3117,7 +3117,16 @@ name: bp-catalyst-platform
 #   (the #4363 application-controller typed-nil configSchema fix) — they were 223
 #   commits behind latest GHCR, tripping the Controller-image-tag freshness gate.
 #   Config-default + pin-bump only; no new bootstrap state. Refs #4373 #4363 #4322.
-version: 1.4.852
+# 1.4.853 — #4362 (#4325 fallout): catalog-seed bp-agenity topology singleton
+#   placement.tier rtz -> '' (host-native). #4325 de-vclustered the platform planes
+#   and removed the `rtz` plane vCluster; the seeded bp-agenity Blueprint still
+#   declared tier: rtz, so the application-controller resolved it to the now-gone
+#   host namespace `rtz` and the agenity Application wedged Degraded
+#   `namespaces "rtz" not found`. A per-Org agentic dashboard is host-native (its
+#   own Org ns), not a platform-plane workload — tier '' renders the HR in the
+#   App's own namespace. Catalog-seed + agenity chart bumped 0.5.9 -> 0.5.12 in
+#   lockstep (resources requests==limits + helmRelease.disableWait). Refs #4111 #4325 #4297.
+version: 1.4.853
 # 1.4.774 — #4082: application-controller ClusterRole gains dr.openova.io/continuums
 #   (get/list/watch/create/update/patch/delete) — was in the controller's own
 #   deploy/rbac.yaml but MISSING from this platform chart, so a singleton /

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -6569,12 +6569,15 @@ spec:
 # with the built-in solo agent (Claude Opus 4.7, token pre-configured), and
 # the agent creates more Applications in the User's Org via the RBAC-scoped
 # openova MCP. The north-star self-service journey (UAT rows 218-223).
-# Lockstep with products/agenity/chart/Chart.yaml version 0.5.8 + the
-# published chart ghcr.io/openova-io/bp-agenity:0.5.8 (appVersion 0.9.7 — the
+# Lockstep with products/agenity/chart/Chart.yaml version 0.5.10 + the
+# published chart ghcr.io/openova-io/bp-agenity:0.5.10 (appVersion 0.9.7 — the
 # image whose /app mounts the WORKSPACES dashboard rather than the archaic
-# single-column one, built from agenity#752, #4180; chart 0.5.8 moves the
-# anthropic ExternalSecret remoteKey to the writable catalyst/anthropic/token
-# path the new catalyst-api producer seeds at Org-create, #4277, over 0.5.7).
+# single-column one, built from agenity#752, #4180). 0.5.10 (#4362, #4325
+# fallout) flips the topology singleton placement.tier `rtz` -> '' (host-native)
+# so a fresh Org's agenity Application lands on the HOST in its own Org
+# namespace (#4297) — #4325 de-vclustered mgmt/rtz/dmz into native host
+# namespaces and removed the `rtz` plane vCluster, so a `tier: rtz` resolves
+# to the absent `rtz` namespace -> Degraded `namespaces "rtz" not found`.
 # Fresh provs seed THIS pin,
 # so the chart-version here gates which image a new Sovereign installs — bump
 # in lockstep with the chart on every agenity release. (The per-Org install
@@ -6596,7 +6599,7 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
 spec:
-  version: "0.5.8"
+  version: "0.5.10"
   visibility: listed
   card:
     title: "Agenity"
@@ -6618,7 +6621,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-agenity
-    version: 0.5.3
+    version: 0.5.10
   topology:
     supported:
       - singleton
@@ -6628,7 +6631,15 @@ spec:
     perTopology:
       singleton:
         placement:
-          tier: rtz
+          # #4325 de-vclustered mgmt/rtz/dmz → native host namespaces and
+          # removed the `rtz` plane vCluster. A per-Org agentic dashboard
+          # lands on the HOST in its own Org namespace (#4297), so tier MUST
+          # be '' (host-native); a non-empty tier resolves through the
+          # controller's VClusterPlacements → HR upsert into the removed
+          # `rtz` namespace → `namespaces "rtz" not found` (Degraded). The
+          # `rtz-A` cluster ID is the region designator, NOT a vCluster.
+          # Lockstep with products/agenity/blueprint.yaml.
+          tier: ''
           clusters: [rtz-A]
           roles:
             rtz-A: singleton

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -6569,8 +6569,8 @@ spec:
 # with the built-in solo agent (Claude Opus 4.7, token pre-configured), and
 # the agent creates more Applications in the User's Org via the RBAC-scoped
 # openova MCP. The north-star self-service journey (UAT rows 218-223).
-# Lockstep with products/agenity/chart/Chart.yaml version 0.5.11 + the
-# published chart ghcr.io/openova-io/bp-agenity:0.5.11 (appVersion 0.9.7 — the
+# Lockstep with products/agenity/chart/Chart.yaml version 0.5.12 + the
+# published chart ghcr.io/openova-io/bp-agenity:0.5.12 (appVersion 0.9.7 — the
 # image whose /app mounts the WORKSPACES dashboard rather than the archaic
 # single-column one, built from agenity#752, #4180). 0.5.10 (#4362, #4325
 # fallout) flips the topology singleton placement.tier `rtz` -> '' (host-native)
@@ -6599,7 +6599,7 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
 spec:
-  version: "0.5.11"
+  version: "0.5.12"
   visibility: listed
   card:
     title: "Agenity"
@@ -6616,12 +6616,20 @@ spec:
     default: single-region
   manifests:
     chart: bp-agenity
+    helmRelease:
+      # disableWait — the large agenity image (appVersion 0.9.7) cold-pulls
+      # slowly on a fresh Org node; without this the helm install times out
+      # waiting for the Pod, helm-controller uninstalls + retries, and the
+      # image pull restarts from zero every cycle so the Pod never converges
+      # (live on the omantel.biz demo Org post-#4325, #4362). Lockstep with
+      # products/agenity/blueprint.yaml.
+      disableWait: true
   source:
     kind: HelmRepository
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-agenity
-    version: 0.5.11
+    version: 0.5.12
   topology:
     supported:
       - singleton

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -6569,8 +6569,8 @@ spec:
 # with the built-in solo agent (Claude Opus 4.7, token pre-configured), and
 # the agent creates more Applications in the User's Org via the RBAC-scoped
 # openova MCP. The north-star self-service journey (UAT rows 218-223).
-# Lockstep with products/agenity/chart/Chart.yaml version 0.5.10 + the
-# published chart ghcr.io/openova-io/bp-agenity:0.5.10 (appVersion 0.9.7 — the
+# Lockstep with products/agenity/chart/Chart.yaml version 0.5.11 + the
+# published chart ghcr.io/openova-io/bp-agenity:0.5.11 (appVersion 0.9.7 — the
 # image whose /app mounts the WORKSPACES dashboard rather than the archaic
 # single-column one, built from agenity#752, #4180). 0.5.10 (#4362, #4325
 # fallout) flips the topology singleton placement.tier `rtz` -> '' (host-native)
@@ -6599,7 +6599,7 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
 spec:
-  version: "0.5.10"
+  version: "0.5.11"
   visibility: listed
   card:
     title: "Agenity"
@@ -6621,7 +6621,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-agenity
-    version: 0.5.10
+    version: 0.5.11
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## What

#4325 de-vclustered the platform planes (mgmt/rtz/dmz) into native host namespaces and **removed the `rtz` plane vCluster**. bp-agenity's catalog blueprint still declared its singleton topology placement as `tier: rtz` + `clusters: [rtz-A]`. The application-controller resolves a non-empty tier through `VClusterPlacements` → host namespace `rtz` and upserts the per-cluster HelmRelease into it. Post-de-vcluster that namespace is gone, so the agenity Application wedges:

```
Ready=False | GiteaError | upsert per-cluster HelmRelease rtz/agenity-rtz-a: namespaces "rtz" not found   (Degraded)
```

Confirmed live on the omantel.biz demo Org (kom4dc dep `4635277cae4ffed9`, ctx omantel-region-a).

## Fix

A per-Org agentic dashboard is **not** a platform-plane workload — it lands on the HOST in its own Org namespace (#4297 keystone). Flip the topology singleton `placement.tier: rtz` → `''` (host-native, no vCluster pivot — the HR renders in the App's own namespace) in BOTH:

- `products/agenity/blueprint.yaml` (source)
- `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` (seed)

The `rtz-A` cluster ID is the **region-cluster designator** (region pin) and stays — it is NOT a vCluster name. Same class of #4325 fallout as the grafana-datasource repoint (#4347 / e9416f1e9).

Lockstep version bump: chart + blueprint `0.5.9 → 0.5.10`; catalog-seed projected Blueprint CR `spec.version 0.5.8 → 0.5.10` + source chart pull `0.5.3 → 0.5.10`. Chart TEMPLATES + appVersion (0.9.7 dashboard image) **unchanged**.

## Validation

- `helm lint` + `helm template` agenity — OK
- `helm template` catalog-seed renders `tier: ''` for agenity
- `scripts/check-catalog-seed-lockstep.sh` — PASS (0 fail)
- `scripts/audit-placement-conformance.py rendered` — PASS (64 slots, 0 in vClusters)
- bootstrap-api `go build` + handler tests — green
- application-controller `go build` + tests — green
- Live recovery of the demo Org agenity (HR Ready + 200) — evidence on #4362

Refs #4111 #4325 #4297