### PR TITLE
fix(catalyst): re-fire spine Application-CR producer on startup so existing Sovereigns enroll + mint Continuum CRs (Refs #4212)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -527,6 +527,7 @@ func (h *Handler) restoreFromStore() {
 
 	resumed := 0
 	meshReconciles := 0
+	spineReconciles := 0
 	for _, rec := range records {
 		dep := fromRecord(rec)
 		h.deployments.Store(dep.ID, dep)
@@ -610,6 +611,22 @@ func (h *Handler) restoreFromStore() {
 			go h.runConvergedLateRescue(dep)
 		}
 
+		// #4212 — level-triggered spine Application-CR enrollment on startup.
+		// The spine producer (runPostHandoverSpineApplications) is otherwise
+		// one-shot (Phase-1 OutcomeReady + converged-late only), so a
+		// Sovereign that handed over before the producer shipped never
+		// enrolls its DR-capable spine into the object model and mints no
+		// Continuum CR. This re-fires the idempotent producer (force:true
+		// server-side-apply) for any ready, handed-over deployment, healing
+		// the seam zero-touch on the next catalyst-api roll. Independent of
+		// the rescue hook above — a normally-handed-over record never enters
+		// the converged-late branch, so the spine would otherwise stay
+		// unenrolled forever. No-op on an already-enrolled Sovereign.
+		if h.shouldStartupSpineReconcile(dep) {
+			spineReconciles++
+			go h.runPostHandoverSpineApplications(dep)
+		}
+
 		// #1907 — bake-time top-up of the canonical .omani.X org-pool.
 		// On a Pod restart the import already ran on a prior Pod and
 		// the on-disk record may still be short of 4 entries (the
@@ -624,6 +641,7 @@ func (h *Handler) restoreFromStore() {
 		"count", len(records),
 		"resumed", resumed,
 		"clusterMeshReconciles", meshReconciles,
+		"spineReconciles", spineReconciles,
 		"dir", h.store.Dir(),
 	)
 }

--- a/products/catalyst/bootstrap/api/internal/handler/post_handover_spine_apps.go
+++ b/products/catalyst/bootstrap/api/internal/handler/post_handover_spine_apps.go
@@ -169,6 +169,60 @@ const (
 	spineApplyPoll    = 30 * time.Second
 )
 
+// shouldStartupSpineReconcile reports whether a rehydrated deployment needs
+// the spine Application-CR producer kicked at catalyst-api startup — the
+// level-triggered sibling of shouldStartupClusterMeshReconcile (#3241) and
+// shouldConvergedLateRescue (#3319).
+//
+// THE GAP THIS CLOSES (#4212). runPostHandoverSpineApplications is wired ONLY
+// into the Phase-1 OutcomeReady terminal block (phase1_watch.go) + the
+// converged-late rescue (phase1_converged_late.go) — both ONE-SHOT, fired
+// once as a deployment first reaches handover. A Sovereign that handed over
+// BEFORE this producer shipped (or before a catalyst-api roll that carries a
+// later spine roster) therefore never enrolls its spine into the object
+// model: `kubectl get applications.apps.openova.io -n catalyst` is empty,
+// the DR-capable spine mints NO Continuum CR, and the seam stays inert with
+// no path to heal short of a fresh prov. Live-confirmed on omantel.biz (dep
+// 4635277cae4ffed9, 2026-06-26): the chart-templated bootstrap-owned spine
+// CRs (singleton, adopt-only) are present but the multi-region `spine-*`
+// producer CRs are absent, so `kubectl get continuums.dr.openova.io -A`
+// carries no spine row.
+//
+// The fix mirrors the ClusterMesh-reconcile heal: re-run the idempotent
+// producer at startup for any ready, handed-over deployment whose primary
+// kubeconfig is still readable on the PVC. Every step of the producer is a
+// force:true server-side-apply (CREATE-or-MERGE), so a re-run on an
+// already-enrolled Sovereign is a no-op merge — and one that handed over
+// pre-producer enrolls zero-touch on the next mothership roll. Status=ready
+// AND Result.HandoverFiredAt!=nil is the same "cleanly handed over" idiom the
+// handover-export resume gate uses (deployments.go). Mothership-self records
+// (no SovereignFQDN, no regions) and unresolvable-kubeconfig records are
+// warn-and-skipped so the loop never spins a budget on a lost file.
+func (h *Handler) shouldStartupSpineReconcile(dep *Deployment) bool {
+	dep.mu.Lock()
+	status := dep.Status
+	fired := dep.Result != nil && dep.Result.HandoverFiredAt != nil
+	regionCount := len(dep.Request.Regions)
+	if regionCount == 0 && strings.TrimSpace(dep.Request.Region) != "" {
+		regionCount = 1
+	}
+	dep.mu.Unlock()
+	if status != "ready" || !fired {
+		return false
+	}
+	if regionCount == 0 {
+		// Mothership-self / record with no declared regions — nothing to
+		// enroll a DR-capable spine over.
+		return false
+	}
+	if _, ok := h.resolvePrimaryKubeconfigPath(dep); !ok {
+		h.log.Warn("spine-apps: ready record has no resolvable kubeconfig; skipping startup enrollment",
+			"id", dep.ID)
+		return false
+	}
+	return true
+}
+
 // runPostHandoverSpineApplications enrolls every DR-capable bootstrap-spine
 // HelmRelease into the object model by stamping one idempotent Application
 // CR each. See file header.

--- a/products/catalyst/bootstrap/api/internal/handler/post_handover_spine_apps_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/post_handover_spine_apps_test.go
@@ -10,8 +10,11 @@ package handler
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"regexp"
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -477,5 +480,93 @@ func TestDRCapableSpineRoster_MatchesEPICSet(t *testing.T) {
 		default:
 			t.Fatalf("chart %q MultiRegionMode = %q, want a DR-capable multi-region mode", sc.Chart, sc.MultiRegionMode)
 		}
+	}
+}
+
+// TestShouldStartupSpineReconcile_Guards covers the #4212 startup-enrollment
+// gate: a ready, handed-over deployment with a readable kubeconfig re-fires
+// the idempotent spine producer (so an env that handed over before the
+// producer shipped heals zero-touch on the next catalyst-api roll), while
+// not-ready / not-handed-over / regionless / kubeconfig-lost records are
+// skipped.
+func TestShouldStartupSpineReconcile_Guards(t *testing.T) {
+	dir := t.TempDir()
+	h := &Handler{log: silentLogger(), kubeconfigsDir: dir}
+	kcPath := filepath.Join(dir, "depspine.yaml")
+	if err := os.WriteFile(kcPath, []byte("apiVersion: v1\nkind: Config\n"), 0o600); err != nil {
+		t.Fatalf("write kubeconfig: %v", err)
+	}
+	now := time.Now().UTC()
+	twoRegions := []provisioner.RegionSpec{
+		{Provider: "huawei", CloudRegion: "me-east-215-a"},
+		{Provider: "huawei", CloudRegion: "me-east-215-b"},
+	}
+	cases := []struct {
+		name string
+		dep  *Deployment
+		want bool
+	}{
+		{
+			name: "ready-handed-over-kubeconfig-present",
+			dep: &Deployment{ID: "s1", Status: "ready",
+				Request: provisioner.Request{SovereignFQDN: "t99.omani.works", Regions: twoRegions},
+				Result:  &provisioner.Result{KubeconfigPath: kcPath, HandoverFiredAt: &now}},
+			want: true,
+		},
+		{
+			name: "single-region-ready-handed-over-still-enrolls",
+			dep: &Deployment{ID: "s2", Status: "ready",
+				Request: provisioner.Request{SovereignFQDN: "t99.omani.works", Regions: twoRegions[:1]},
+				Result:  &provisioner.Result{KubeconfigPath: kcPath, HandoverFiredAt: &now}},
+			want: true,
+		},
+		{
+			name: "not-yet-handed-over-skipped",
+			dep: &Deployment{ID: "s3", Status: "ready",
+				Request: provisioner.Request{SovereignFQDN: "t99.omani.works", Regions: twoRegions},
+				Result:  &provisioner.Result{KubeconfigPath: kcPath}},
+			want: false,
+		},
+		{
+			name: "failed-status-skipped",
+			dep: &Deployment{ID: "s4", Status: "failed",
+				Request: provisioner.Request{SovereignFQDN: "t99.omani.works", Regions: twoRegions},
+				Result:  &provisioner.Result{KubeconfigPath: kcPath, HandoverFiredAt: &now}},
+			want: false,
+		},
+		{
+			name: "no-regions-mothership-self-skipped",
+			dep: &Deployment{ID: "s5", Status: "ready",
+				Request: provisioner.Request{},
+				Result:  &provisioner.Result{KubeconfigPath: kcPath, HandoverFiredAt: &now}},
+			want: false,
+		},
+		{
+			name: "kubeconfig-missing-warn-and-skip",
+			dep: &Deployment{ID: "s6", Status: "ready",
+				Request: provisioner.Request{SovereignFQDN: "t99.omani.works", Regions: twoRegions},
+				Result:  &provisioner.Result{KubeconfigPath: filepath.Join(dir, "absent.yaml"), HandoverFiredAt: &now}},
+			want: false,
+		},
+		{
+			name: "result-nil-skipped",
+			dep: &Deployment{ID: "s7", Status: "ready",
+				Request: provisioner.Request{SovereignFQDN: "t99.omani.works", Regions: twoRegions}},
+			want: false,
+		},
+		{
+			name: "single-region-via-request-region-field",
+			dep: &Deployment{ID: "s8", Status: "ready",
+				Request: provisioner.Request{SovereignFQDN: "t99.omani.works", Region: "me-east-215"},
+				Result:  &provisioner.Result{KubeconfigPath: kcPath, HandoverFiredAt: &now}},
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := h.shouldStartupSpineReconcile(tc.dep); got != tc.want {
+				t.Errorf("shouldStartupSpineReconcile = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What

`Refs #4212` (EPIC: ONE object-model/DR backbone — spine Application→Continuum seams).

The #4334 spine Application-CR producer (`runPostHandoverSpineApplications`) is wired ONLY into the one-shot Phase-1 `OutcomeReady` block (`phase1_watch.go`) and the converged-late rescue (`phase1_converged_late.go`). Both fire exactly once, as a deployment first reaches handover.

**Consequence:** every Sovereign that handed over *before* the producer shipped — including the live 2-region omantel.biz (dep `4635277cae4ffed9`) — never enrolls its DR-capable spine (openbao/keycloak/harbor/gitea) into the object model, and so never mints a spine Continuum CR. The seam is inert with no path to heal short of a fresh prov (which is provider-capacity-gated).

## Live evidence (omantel.biz, dep 4635277cae4ffed9, region-a + region-b, READ-ONLY 2026-06-26)

- `kubectl get applications.apps.openova.io -n catalyst` → **empty** (the #4334 `spine-*` producer CRs were never created).
- The only spine-shaped Application CRs present are chart-templated **bootstrap-owned singletons** (`openbao`/`keycloak`/`harbor`/`gitea` in their own namespaces, `placement: singleton`, `managed-by: Helm`, `apps.openova.io/bootstrap-owned: true`). These take the application-controller's adopt-only path (`application_controller.go:612` early-returns to `reconcileBootstrapOwned` BEFORE `reconcileContinuumCR` at :1060) — by design they represent one copy → singleton → `buildContinuumPlan` returns false → no Continuum.
- `kubectl get continuums.dr.openova.io -A` → only the pre-existing chart-stamped `cnpg-pair-bp-cnpg-pair-continuum` (Healthy, lease held). **No spine row.**
- Spine apps carry no `status.continuumRef` and no `status.effectivePlacementTargets` (#3969 read-model empty on the bootstrap path).
- catalyst-api `d0467b1` + org-controller `405ee6d` both contain #4334; catalyst-api logs show zero `spine-apps` producer activity (the one-shot hook already fired at original bootstrap, pre-#4334).

## Fix

Add `shouldStartupSpineReconcile` and wire it into `restoreFromStore` alongside the existing level-triggered startup hooks (ClusterMesh-reconcile #3241, converged-late-rescue #3319). It re-fires the **idempotent** producer (`force:true` server-side-apply, CREATE-or-MERGE) for any ready, handed-over deployment whose primary kubeconfig is still readable on the PVC.

Effect: the multi-region `spine-*` Application CRs land, enter the full reconcile fan-out (which DOES reach `reconcileContinuumCR`), and mint their Continuum CR — zero-touch on the next catalyst-api roll, no fresh prov required.

- No-op on an already-enrolled Sovereign (server-side-apply merge).
- Mothership-self (no regions) and kubeconfig-lost records are warn-and-skipped.
- Adopt-not-roll preserved (Invariant #3): the producer only stamps Application CRs, never re-renders or rolls a healthy spine pod.

## Tests

- `TestShouldStartupSpineReconcile_Guards` — 8 cases (ready+handed-over+kubeconfig → enroll; not-handed-over / failed / no-regions / kubeconfig-lost / result-nil → skip; single-region still enrolls).
- Full `internal/handler` suite green; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)