### PR TITLE
fix(bp-gitea): preserve git-data PVC on vcluster→host-ns re-home — kill the #4353 DB↔disk drift (1.2.43)

### DIFF
--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -160,7 +160,15 @@ spec:
       # 1.2.42 — #4347: gitea-sso-configure Deployment gains liveness + readiness
       #   probes (heartbeat sentinel) so the host-ns Kyverno `probes-present`
       #   Enforce ClusterPolicy admits it post-#4325 de-vcluster. Refs #4347 #4325 #4340.
-      version: 1.2.42
+      # 1.2.43 — #4354: git-data PRESERVATION guard (pre-install,pre-upgrade hook).
+      #   The #4325 vCluster→host re-home via FRESH helm install provisioned a NEW
+      #   empty gitea-shared-storage PVC + abandoned the prior PV while the external
+      #   CNPG metadata DB survived → catastrophic DB↔disk drift (#4353 P0). The hook
+      #   ADOPTS an orphan Released/Available PV (Retain → clear claimRef → pre-bind
+      #   the host PVC via volumeName) so the re-home rides the SAME git-data volume,
+      #   NO-OPs on a fresh prov, and FAILS LOUD when the DB reports repos but no PV
+      #   can be adopted — no silent empty boot. Refs #4354 #4325 #4353 #4352.
+      version: 1.2.43
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.42
+  version: 1.2.43
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -158,7 +158,23 @@ name: bp-gitea
 #   ClusterPolicy admits it — after #4325 de-vcluster re-homed bp-gitea into a
 #   native host namespace where the cluster-wide Enforce policies apply. Adds
 #   tests/kyverno-probes-present.sh (CI gate). Refs #4347 #4325 #4340.
-version: 1.2.42
+# 1.2.43 (#4354, Refs #4325 #4353): git-data PRESERVATION guard. The #4325
+#   de-vcluster re-homed gitea vCluster→host via a FRESH helm install, which
+#   dynamically provisioned a brand-NEW empty `gitea-shared-storage` PVC and
+#   ABANDONED the prior PV — while gitea's EXTERNAL CNPG metadata DB survived →
+#   catastrophic DB↔disk drift (42 repos `empty:false` but every contents 500s
+#   "no such file or directory"; the live #4353 P0). New
+#   templates/gitdata-preservation-hook.yaml (pre-install,pre-upgrade Helm hook)
+#   enforces: never boot a fresh-empty git-data volume when prior data or a
+#   non-empty metadata DB exists. It (1) NO-OPs on a fresh prov / steady state,
+#   (2) ADOPTS an orphan Released/Available PV (force reclaimPolicy Retain →
+#   clear claimRef → pre-bind the host-ns PVC via volumeName so the chart PVC
+#   rides the SAME data volume), and (3) FAILS LOUD (blocks the gitea
+#   Deployment) when the DB reports repos but no git-data PV can be adopted —
+#   so the silent empty boot can never recur. Gated `gitDataMigration.enabled`
+#   (default true; safe no-op when no prior state). Adds
+#   tests/gitdata-preservation-guard.sh (CI gate). Refs #4354 #4325 #4353 #4352.
+version: 1.2.43
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/templates/gitdata-preservation-hook.yaml
+++ b/platform/gitea/chart/templates/gitdata-preservation-hook.yaml
@@ -1,0 +1,385 @@
+{{- /*
+git-data preservation guard (#4354, Refs #4325 #4353).
+
+THE BUG this hook closes
+========================
+#4325 de-vclustered the platform planes: gitea moved from the mgmt vCluster
+into the host `gitea` namespace via a FRESH helm install. A fresh install lets
+the upstream gitea subchart dynamically PROVISION a brand-new empty
+`gitea-shared-storage` PVC (→ a fresh empty PV) and SILENTLY ABANDONS the prior
+per-vCluster PV. Gitea's metadata lives in an EXTERNAL CNPG database (its own
+`gitea-pg` Cluster / a shared-pg instance) whose PVC is untouched by the re-home,
+so the DB survives with all 42 repo rows while the disk is empty. The product is
+a catastrophic DB↔disk drift (#4353 live P0): the API reports repos
+`empty:false`/`main`, but every `contents?ref=main` 500s "no such file or
+directory" because `/data/git/gitea-repositories` is empty → 22/23 Flux
+GitRepository sources `pkt-line EOF` → catalyst-platform upgrade wedged.
+
+THE INVARIANT this hook enforces
+================================
+A stateful plane re-home (vCluster → host-ns) MUST NEVER boot a fresh-empty
+git-data volume when a prior populated git-data volume exists OR the metadata DB
+already reports repositories. Either the prior data volume is ADOPTED (reused),
+or the install FAILS LOUD so an operator restores from backup — never a silent
+empty boot.
+
+WHY A pre-install,pre-upgrade HOOK (not a post-render Job, not a chart rename)
+=============================================================================
+The PVC the upstream subchart renders binds to whatever PV the provisioner hands
+it the moment the manifest lands. To ride the existing PV across the re-home we
+must PRE-BIND the host-ns PVC (set spec.volumeName) to the orphan PV BEFORE the
+subchart's PVC manifest is applied. A Helm `pre-install,pre-upgrade` hook runs in
+exactly that window. It mirrors the proven guacamole
+`recordings-pvc-migrate-hook.yaml` shape (kubectl in a one-shot Job, hook-weight
+ordering, before-hook-creation delete policy) — but where guacamole DELETES a
+mismatched PVC, this hook PRESERVES the data by adoption and otherwise REFUSES to
+proceed.
+
+DECISION MATRIX (idempotent — re-runs cleanly on every reconcile)
+=================================================================
+  1. PVC <claimName> already Bound .................. NO-OP (steady state).
+  2. No PVC, an adoptable orphan PV exists .......... ADOPT it:
+       a. force the PV's reclaimPolicy → Retain (a transient unbind during
+          adoption can never delete the data — closes the #4352 Retain→Delete
+          interaction),
+       b. clear the PV's stale claimRef (Released → Available),
+       c. pre-create the host-ns PVC with spec.volumeName = that PV so the
+          chart-rendered PVC (which carries helm.sh/resource-policy: keep, same
+          name) adopts it and binds to the SAME data volume.
+  3. No PVC, no adoptable PV, metadata DB reports repos > 0 ... FAIL LOUD
+       (exit 1) unless failOnDbDiskDrift=false. The pre-upgrade gate fails; the
+       gitea Deployment is never rolled against an empty volume.
+  4. No PVC, no adoptable PV, DB empty/absent (FRESH prov) ... NO-OP. The only
+       case where provisioning a fresh empty PVC is correct.
+
+ADOPTABLE PV DEFINITION (case 2)
+================================
+A PV is adoptable when it is Released or Available (i.e. not Bound to a live
+PVC) AND its `spec.claimRef.name` equals <claimName> (the canonical name the
+upstream gitea PVC always used — identical across the vCluster and host-ns
+installs). The claimRef NAME is the durable join key: vCluster syncer-mangled
+namespaces differ, but the claim name is stable. We additionally prefer a PV
+carrying this chart's git-data label when present, but match on claimRef.name
+alone so PVs created before this chart existed are still recoverable.
+*/ -}}
+{{- if .Values.gitDataMigration.enabled }}
+{{- $claim := .Values.gitDataMigration.claimName | default "gitea-shared-storage" }}
+{{- $pgCluster := .Values.postgres.cluster.name | default "gitea-pg" }}
+{{- $pgDatabase := .Values.postgres.cluster.database | default "gitea" }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-gitdata-guard
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-gitea
+    app.kubernetes.io/name: gitea-gitdata-guard
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation
+---
+# Cluster-scoped: PersistentVolumes are NOT namespaced, and the guard must
+# read/patch the orphan PV (reclaimPolicy + claimRef). Tightly scoped to the
+# two verbs on the two resources it actually needs.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-gitdata-guard
+  labels:
+    catalyst.openova.io/blueprint: bp-gitea
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-gitdata-guard
+  labels:
+    catalyst.openova.io/blueprint: bp-gitea
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-gitdata-guard
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-gitdata-guard
+    namespace: {{ .Release.Namespace }}
+---
+# Namespaced: create/get the host-ns PVC (case 2 pre-bind) + read the gitea Pod
+# and the CNPG app Secret + exec into the live postgres Pod to count repos.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-gitdata-guard
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-gitea
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "create"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-gitdata-guard
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-gitea
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-gitdata-guard
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-gitdata-guard
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-gitdata-guard
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-gitea
+    catalyst.openova.io/component: gitdata-guard
+    # kyverno flux-managed (Enforce): hook Jobs carry no HR ownerReference
+    # (#3297 class — same carve-out the sso-configure / guacamole hooks use).
+    app.kubernetes.io/managed-by: flux
+  annotations:
+    # weight -10 runs AFTER the RBAC above (-20) so the ServiceAccount + roles
+    # exist before the Job's Pod starts. Still well before the chart's own
+    # resources (default weight 0).
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        catalyst.openova.io/blueprint: bp-gitea
+        catalyst.openova.io/component: gitdata-guard
+    spec:
+      serviceAccountName: {{ .Release.Name }}-gitdata-guard
+      restartPolicy: Never
+      {{- with .Values.gitea.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        # readOnlyRootFilesystem=true ⇒ /tmp must be a writable emptyDir for the
+        # guard to stage the PVC manifest it kubectl-applies.
+        - name: tmp
+          emptyDir: {}
+      containers:
+        - name: guard
+          image: {{ .Values.gitDataMigration.image | default "bitnamilegacy/kubectl:1.30.7" | quote }}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            requests: {cpu: 50m, memory: 64Mi}
+            limits: {cpu: 200m, memory: 192Mi}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: CLAIM_NAME
+              value: {{ $claim | quote }}
+            - name: NS
+              value: {{ .Release.Namespace | quote }}
+            - name: PG_CLUSTER
+              value: {{ $pgCluster | quote }}
+            - name: PG_DATABASE
+              value: {{ $pgDatabase | quote }}
+            - name: FAIL_ON_DRIFT
+              value: {{ .Values.gitDataMigration.failOnDbDiskDrift | default true | quote }}
+            - name: RELEASE_NAME
+              value: {{ .Release.Name | quote }}
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              set -euo pipefail
+              echo "[gitdata-guard] claim=${CLAIM_NAME} ns=${NS} pgCluster=${PG_CLUSTER} db=${PG_DATABASE} failOnDrift=${FAIL_ON_DRIFT}"
+
+              # ── case 1: PVC already exists → steady state, nothing to do ──
+              if kubectl get pvc "${CLAIM_NAME}" -n "${NS}" >/dev/null 2>&1; then
+                PHASE="$(kubectl get pvc "${CLAIM_NAME}" -n "${NS}" -o jsonpath='{.status.phase}' 2>/dev/null || echo '')"
+                echo "[gitdata-guard] PVC ${NS}/${CLAIM_NAME} already exists (phase=${PHASE}) — no migration needed."
+                exit 0
+              fi
+
+              # ── case 2: look for an ADOPTABLE orphan PV ──
+              # A PV is adoptable when its claimRef.name == CLAIM_NAME and it is
+              # NOT Bound to a live PVC (phase Released or Available). claimRef
+              # name is the durable join key across the vCluster→host re-home.
+              echo "[gitdata-guard] no live PVC — scanning for an adoptable orphan PV (claimRef.name=${CLAIM_NAME})..."
+              ADOPT_PV=""
+              # iterate PVs whose claimRef.name matches; pick the first Released/Available one
+              for pv in $(kubectl get pv -o jsonpath="{range .items[?(@.spec.claimRef.name=='${CLAIM_NAME}')]}{.metadata.name}{'\n'}{end}" 2>/dev/null || true); do
+                [ -z "${pv}" ] && continue
+                PV_PHASE="$(kubectl get pv "${pv}" -o jsonpath='{.status.phase}' 2>/dev/null || echo '')"
+                if [ "${PV_PHASE}" = "Released" ] || [ "${PV_PHASE}" = "Available" ]; then
+                  ADOPT_PV="${pv}"
+                  echo "[gitdata-guard] adoptable PV found: ${pv} (phase=${PV_PHASE})"
+                  break
+                else
+                  echo "[gitdata-guard] PV ${pv} matches claimRef but phase=${PV_PHASE} (not adoptable) — skipping."
+                fi
+              done
+
+              if [ -n "${ADOPT_PV}" ]; then
+                echo "[gitdata-guard] ADOPTING PV ${ADOPT_PV} → preserve git-data across the re-home."
+                # (a) force reclaimPolicy Retain so a transient unbind can never
+                #     delete the data (#4352 evs-ssd Retain→Delete interaction).
+                kubectl patch pv "${ADOPT_PV}" --type=merge \
+                  -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+                # (b) clear the stale claimRef so the PV goes Available and our
+                #     pre-bound PVC (volumeName) can claim it cleanly.
+                kubectl patch pv "${ADOPT_PV}" --type=json \
+                  -p '[{"op":"remove","path":"/spec/claimRef"}]' 2>/dev/null || \
+                  kubectl patch pv "${ADOPT_PV}" --type=merge -p '{"spec":{"claimRef":null}}'
+                # (c) discover the PV's capacity + storageClass so the new PVC's
+                #     request matches (a smaller request than the PV capacity
+                #     still binds; we mirror the PV to avoid any class mismatch).
+                PV_SIZE="$(kubectl get pv "${ADOPT_PV}" -o jsonpath='{.spec.capacity.storage}' 2>/dev/null || echo '20Gi')"
+                PV_SC="$(kubectl get pv "${ADOPT_PV}" -o jsonpath='{.spec.storageClassName}' 2>/dev/null || echo '')"
+                echo "[gitdata-guard] pre-creating PVC ${NS}/${CLAIM_NAME} bound to ${ADOPT_PV} (size=${PV_SIZE} sc=${PV_SC:-<none>})."
+                # helm.sh/resource-policy: keep so a later helm rollback/uninstall
+                # never reaps the adopted claim; the chart's own PVC carries the
+                # same name + keep policy, so Helm adopts (does not recreate) it.
+                #
+                # Build the manifest flush-left into /tmp (emptyDir) with printf
+                # so the YAML passed to kubectl carries NO ambient indentation —
+                # a here-doc inside this `|` literal would leak the template's
+                # leading spaces into the document and break the parse.
+                # Helm-ownership metadata so the subsequent `helm install/upgrade`
+                # ADOPTS this pre-created PVC (Helm 3 imports an existing object
+                # only when it carries managed-by:Helm + the release name/ns) —
+                # the subchart's PVC manifest (same name, persistence.create=true)
+                # then matches it instead of erroring "exists and cannot be
+                # imported", and binds to the adopted PV.
+                MANIFEST=/tmp/gitdata-pvc.yaml
+                {
+                  printf 'apiVersion: v1\n'
+                  printf 'kind: PersistentVolumeClaim\n'
+                  printf 'metadata:\n'
+                  printf '  name: %s\n' "${CLAIM_NAME}"
+                  printf '  namespace: %s\n' "${NS}"
+                  printf '  labels:\n'
+                  printf '    catalyst.openova.io/blueprint: bp-gitea\n'
+                  printf '    catalyst.openova.io/git-data: "true"\n'
+                  printf '    app.kubernetes.io/managed-by: Helm\n'
+                  printf '  annotations:\n'
+                  printf '    helm.sh/resource-policy: keep\n'
+                  printf '    meta.helm.sh/release-name: "%s"\n' "${RELEASE_NAME}"
+                  printf '    meta.helm.sh/release-namespace: "%s"\n' "${NS}"
+                  printf '    catalyst.openova.io/adopted-pv: "%s"\n' "${ADOPT_PV}"
+                  printf 'spec:\n'
+                  printf '  accessModes: ["ReadWriteOnce"]\n'
+                  printf '  volumeName: %s\n' "${ADOPT_PV}"
+                  if [ -n "${PV_SC}" ]; then printf '  storageClassName: %s\n' "${PV_SC}"; fi
+                  printf '  resources:\n'
+                  printf '    requests:\n'
+                  printf '      storage: %s\n' "${PV_SIZE}"
+                } > "${MANIFEST}"
+                kubectl apply -f "${MANIFEST}"
+                echo "[gitdata-guard] adoption complete — chart PVC will bind to the preserved git-data volume."
+                exit 0
+              fi
+
+              # ── no adoptable PV: discriminate FRESH prov (case 4) from
+              #    DB↔disk DRIFT (case 3) by probing the metadata DB repo count ──
+              echo "[gitdata-guard] no adoptable PV — probing metadata DB to tell a fresh prov from a data-loss drift."
+              REPO_COUNT="unknown"
+              PG_POD="$(kubectl get pods -n "${NS}" \
+                -l "cnpg.io/cluster=${PG_CLUSTER},role=primary" \
+                -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+              if [ -z "${PG_POD}" ]; then
+                # role label vary by CNPG version; fall back to any cluster pod.
+                PG_POD="$(kubectl get pods -n "${NS}" \
+                  -l "cnpg.io/cluster=${PG_CLUSTER}" \
+                  -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+              fi
+              if [ -n "${PG_POD}" ]; then
+                echo "[gitdata-guard] probing repo count via ${NS}/${PG_POD} (db=${PG_DATABASE})."
+                # `repository` is gitea's core metadata table. psql is present in
+                # the CNPG image; we exec as the in-pod postgres superuser (local
+                # peer auth) so no DB password is needed in this Job.
+                set +e
+                # Capture psql output WITHOUT a pipe so $? is kubectl-exec's real
+                # exit (a `| tr` would make $? reflect tr, masking a probe failure
+                # as success). Strip whitespace after, in the same shell.
+                RAW="$(kubectl exec -n "${NS}" "${PG_POD}" -c postgres -- \
+                  psql -tAX -U postgres -d "${PG_DATABASE}" \
+                  -c "SELECT count(*) FROM repository;" 2>/dev/null)"
+                RC=$?
+                REPO_COUNT="$(printf '%s' "${RAW}" | tr -d '[:space:]')"
+                set -e
+                if [ "${RC}" -ne 0 ] || [ -z "${REPO_COUNT}" ]; then
+                  # DB unreachable / table absent → treat as fresh (case 4). A
+                  # genuinely populated DB whose pod is up will answer; an absent
+                  # table means initdb hasn't run a gitea schema yet.
+                  echo "[gitdata-guard] repo-count probe inconclusive (rc=${RC}) — treating as fresh DB."
+                  REPO_COUNT="0"
+                fi
+              else
+                echo "[gitdata-guard] no CNPG pod for cluster ${PG_CLUSTER} in ${NS} — DB not yet provisioned, treating as fresh prov."
+                REPO_COUNT="0"
+              fi
+              echo "[gitdata-guard] metadata DB repository count = ${REPO_COUNT}"
+
+              if [ "${REPO_COUNT}" != "0" ] && [ "${REPO_COUNT}" != "unknown" ]; then
+                # case 3: DB says non-empty but NO git-data volume to adopt.
+                if [ "${FAIL_ON_DRIFT}" = "true" ]; then
+                  echo "[gitdata-guard] ❌ DB↔disk DRIFT: metadata DB reports ${REPO_COUNT} repositories but no git-data PV exists to adopt."
+                  echo "[gitdata-guard] Refusing to boot gitea on an EMPTY git-data volume (would reproduce #4353)."
+                  echo "[gitdata-guard] Restore git-data from backup (Velero / SeaweedFS object-store mirror) OR set gitDataMigration.failOnDbDiskDrift=false to allow a deliberate empty rebuild."
+                  exit 1
+                fi
+                echo "[gitdata-guard] ⚠️ DB↔disk drift detected (${REPO_COUNT} repos, empty disk) but failOnDbDiskDrift=false — allowing empty boot per operator override."
+                exit 0
+              fi
+
+              # case 4: empty/absent DB + no PV → genuinely fresh prov.
+              echo "[gitdata-guard] fresh prov (empty DB, no prior git-data) — chart provisions a fresh PVC. OK."
+              exit 0
+{{- end }}

--- a/platform/gitea/chart/tests/gitdata-preservation-guard.sh
+++ b/platform/gitea/chart/tests/gitdata-preservation-guard.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# #4354 (Refs #4325 #4353) — assert the git-data PRESERVATION guard is wired so a
+# vCluster→host-ns re-home of gitea can NEVER boot a fresh-empty git-data volume
+# while a prior PV or a non-empty metadata DB exists.
+#
+# THE REGRESSION this gate locks down
+# ===================================
+# #4325 de-vclustered gitea (mgmt vCluster → host ns `gitea`) via a FRESH helm
+# install. The upstream subchart dynamically provisioned a brand-NEW empty
+# `gitea-shared-storage` PVC and ABANDONED the prior PV, while gitea's external
+# CNPG metadata DB survived → catastrophic DB↔disk drift (the live #4353 P0: 42
+# repos `empty:false` but every contents 500s "no such file or directory").
+#
+# The fix is templates/gitdata-preservation-hook.yaml — a pre-install,pre-upgrade
+# Helm hook that ADOPTS an orphan PV (preserve), NO-OPs on a fresh prov, and
+# FAILS LOUD when the DB reports repos but no PV can be adopted. This test proves
+# the hook renders with all three guarantees and is a clean no-op when disabled.
+#
+# Self-contained `helm template` assertions only (no kind cluster), per the CI
+# convention in .github/workflows/blueprint-release.yaml.
+set -euo pipefail
+
+# CI invokes `bash <script> <chart_dir>`; fall back to the script's own dir.
+chart_dir="${1:-$(dirname "$0")/..}"
+cd "$chart_dir"
+chart_dir="$(pwd)"
+
+# The upstream gitea subchart is vendored under charts/*.tgz (gitignored, rebuilt
+# from Chart.lock). CI runs `helm dependency build` before tests; build it here
+# too so the test is runnable standalone.
+if ! ls charts/*.tgz >/dev/null 2>&1; then
+  helm dependency build "$chart_dir" >/dev/null 2>&1 || true
+fi
+
+render() {
+  # All renders set sso.sovereignFqdn so the sso-configure Deployment also
+  # renders (unrelated, but keeps the manifest set realistic).
+  helm template gitea . \
+    --set sso.sovereignFqdn=example.test \
+    --set global.sovereignFQDN=example.test \
+    --namespace gitea "$@" 2>/dev/null
+}
+
+fail=0
+note() { echo "  $1"; }
+ok()   { echo "PASS [$1]"; }
+bad()  { echo "FAIL [$1]"; fail=1; }
+
+DEFAULT="$(render)"
+DISABLED="$(render --set gitDataMigration.enabled=false)"
+
+# ── 1. By default the guard renders (enabled). ────────────────────────────────
+if grep -q "catalyst.openova.io/component: gitdata-guard" <<<"$DEFAULT"; then
+  ok "guard renders by default"
+else
+  bad "guard renders by default"; note "expected a gitdata-guard Job in the default render"
+fi
+
+# ── 2. It is a pre-install,pre-upgrade hook (runs BEFORE the chart PVC). ───────
+# Isolate the guard hook's own document set and assert the Job carries the hook
+# annotation. A post-render Job would land too late to pre-bind the PVC.
+GUARD_BLOCK="$(awk '
+  /^# Source:/ { src=$0 }
+  src=="# Source: bp-gitea/templates/gitdata-preservation-hook.yaml" { print }
+' <<<"$DEFAULT")"
+if grep -q 'pre-install,pre-upgrade' <<<"$GUARD_BLOCK"; then
+  ok "guard is a pre-install,pre-upgrade hook"
+else
+  bad "guard is a pre-install,pre-upgrade hook"; note "the hook MUST run before the subchart PVC lands"
+fi
+
+# ── 3. The guard owns a Job + its RBAC (SA, ClusterRole for PV, Role for PVC). ─
+for kind in "kind: ServiceAccount" "kind: ClusterRole" "kind: ClusterRoleBinding" "kind: Role" "kind: RoleBinding" "kind: Job"; do
+  if grep -q "$kind" <<<"$GUARD_BLOCK"; then
+    ok "guard renders $kind"
+  else
+    bad "guard renders $kind"
+  fi
+done
+
+# ClusterRole must grant patch on persistentvolumes (force Retain + clear claimRef).
+if grep -q 'persistentvolumes' <<<"$GUARD_BLOCK" && grep -Eq '"get", "list", "patch"' <<<"$GUARD_BLOCK"; then
+  ok "guard ClusterRole can patch PersistentVolumes"
+else
+  bad "guard ClusterRole can patch PersistentVolumes"; note "needed to force reclaimPolicy Retain + clear claimRef on the orphan PV"
+fi
+
+# ── 4. ADOPT path: the guard pre-binds the host PVC to the orphan PV via
+#       volumeName (preserve), and forces Retain so the data can't be reaped. ──
+if grep -q 'volumeName:' <<<"$GUARD_BLOCK"; then
+  ok "guard pre-binds the PVC via volumeName (PV adoption, not fresh provision)"
+else
+  bad "guard pre-binds the PVC via volumeName"; note "without volumeName the re-home would provision a FRESH empty PV (the #4354 bug)"
+fi
+if grep -q 'persistentVolumeReclaimPolicy":"Retain' <<<"$GUARD_BLOCK"; then
+  ok "guard forces reclaimPolicy Retain on the adopted PV"
+else
+  bad "guard forces reclaimPolicy Retain on the adopted PV"; note "closes the #4352 evs-ssd Retain→Delete interaction"
+fi
+
+# ── 5. FAIL-LOUD path: the guard exits non-zero on DB↔disk drift. ─────────────
+# The bash carries the explicit `exit 1` drift guard + the FAIL_ON_DRIFT switch.
+if grep -q 'FAIL_ON_DRIFT' <<<"$GUARD_BLOCK" && grep -Eq 'DB.disk DRIFT' <<<"$GUARD_BLOCK" && grep -q 'exit 1' <<<"$GUARD_BLOCK"; then
+  ok "guard FAILS LOUD on DB↔disk drift (no silent empty boot)"
+else
+  bad "guard FAILS LOUD on DB↔disk drift"; note "must exit non-zero when the DB reports repos but no git-data PV can be adopted"
+fi
+
+# ── 6. failOnDbDiskDrift default true is surfaced into the Job env. ───────────
+if grep -A1 'name: FAIL_ON_DRIFT' <<<"$GUARD_BLOCK" | grep -q 'value: "true"'; then
+  ok "failOnDbDiskDrift defaults to true (fail-closed)"
+else
+  bad "failOnDbDiskDrift defaults to true"; note "the safe default is to BLOCK the install on drift, not allow an empty boot"
+fi
+
+# ── 7. Disabled → ZERO guard resources (clean opt-out for object-store-only). ─
+if grep -q 'gitdata-guard' <<<"$DISABLED"; then
+  bad "disabled removes ALL guard resources"; note "gitDataMigration.enabled=false should render no guard"
+else
+  ok "disabled removes ALL guard resources"
+fi
+
+# ── 8. The render is still valid YAML with the guard present. ─────────────────
+if python3 -c "import sys,yaml; list(yaml.safe_load_all(sys.stdin))" <<<"$DEFAULT" 2>/dev/null; then
+  ok "rendered manifest set is valid YAML"
+else
+  bad "rendered manifest set is valid YAML"
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "gitdata-preservation-guard: one or more guarantees failed — a vCluster→host re-home could boot an EMPTY git-data volume (#4354 regression)."
+  exit 1
+fi
+echo "gitdata-preservation-guard: git-data is preserved on re-home (adopt-or-fail-loud); the silent empty-PVC boot of #4353 cannot recur."

--- a/platform/gitea/chart/values.yaml
+++ b/platform/gitea/chart/values.yaml
@@ -537,3 +537,61 @@ bootstrapOwned:
   helmRelease:
     name: ""
     namespace: flux-system
+
+# ─── git-data preservation guard (#4354, Refs #4325 #4353) ───────────────────
+# The #4325 de-vcluster re-homes gitea from the mgmt vCluster into the host
+# `gitea` namespace via a FRESH helm install. The fresh install's PVC
+# (`gitea-shared-storage`) dynamically provisions a BRAND-NEW empty PV and
+# ABANDONS the prior per-vCluster PV — while gitea's external CNPG metadata DB
+# (which lives in its OWN persistent PVC, untouched by the re-home) survives.
+# The result is a catastrophic DB↔disk drift: the API reports N repos
+# `empty:false` but every `contents?ref=main` 500s "no such file or directory"
+# because /data/git/gitea-repositories is empty (the live #4353 P0).
+#
+# This guard runs as a Helm pre-install,pre-upgrade hook Job — BEFORE the
+# upstream subchart's PVC manifest lands and BEFORE the gitea Deployment boots —
+# and enforces the invariant: gitea MUST NOT boot a fresh-empty git-data volume
+# whenever a prior populated git-data volume exists OR its metadata DB already
+# reports repositories.
+#
+# Decision matrix (idempotent on every reconcile):
+#   1. PVC `gitea-shared-storage` already Bound          → NO-OP (steady state).
+#   2. No PVC, but a RELEASED/AVAILABLE orphan PV carries
+#      the prior gitea git-data (matched by the claimRef
+#      name the upstream chart used + the git-data label
+#      this chart stamps)                                 → ADOPT: force the
+#      adopted PV's reclaim policy to Retain (so a transient unbind can never
+#      delete it — #4352 evs-ssd Retain→Delete interaction), clear its stale
+#      claimRef, then pre-create the host-ns PVC with `volumeName` set to that
+#      PV so the chart-rendered PVC binds to the SAME data volume (the re-home
+#      rides the existing repositories across).
+#   3. No PVC and no adoptable PV, but the external metadata
+#      DB already reports repositories (host-ns re-home onto
+#      a surviving DB whose disk was lost)                → FAIL LOUD: the hook
+#      exits non-zero, the pre-upgrade gate fails, and the gitea Deployment is
+#      NEVER rolled against an empty volume. The operator restores git-data
+#      from backup (Velero / SeaweedFS object-store mirror) or re-mirrors from
+#      upstream before the install can proceed — no silent empty boot.
+#   4. No PVC, no adoptable PV, empty/absent metadata DB
+#      (a genuinely FRESH prov)                           → NO-OP: the chart
+#      provisions a fresh PVC normally. This is the only case where an empty
+#      git-data volume is correct.
+gitDataMigration:
+  # Master switch. Default ON — the guard is a no-op on a fresh prov (case 4)
+  # and only acts when prior state exists, so it is always safe to leave on.
+  # An operator who has externalised ALL git-data to object storage
+  # (objectStorage.enabled=true with no local repositories) MAY disable it.
+  enabled: true
+  # The canonical PVC name the upstream gitea subchart binds /data to
+  # (gitea.persistence.claimName upstream default). Keep in lockstep with any
+  # gitea.persistence.claimName override.
+  claimName: gitea-shared-storage
+  # When the metadata DB reports repos but no git-data volume can be adopted,
+  # the guard fails the install (case 3). Set false ONLY for a deliberate
+  # destroy-and-rebuild where losing repositories is acceptable (the guard then
+  # logs the drift and allows the empty boot). NEVER flip this to suppress a
+  # real data-loss — that is the exact #4353 footgun.
+  failOnDbDiskDrift: true
+  # kubectl image for the guard Job (mirrors the guacamole recordings-migrate
+  # hook convention). Operator-overridable per docs/PRINCIPLES.md #4a.
+  image: bitnamilegacy/kubectl:1.30.7


### PR DESCRIPTION
## Refs #4354 #4325 #4353 #4352

### The regression (root cause of today's gitea data-loss #4353)
#4325 de-vclustered the platform planes: gitea moved from the mgmt vCluster into the host `gitea` namespace via a **FRESH helm install**. The fresh install let the upstream gitea subchart dynamically provision a **brand-NEW empty `gitea-shared-storage` PVC** and **ABANDON the prior per-vCluster PV** — while gitea's **external CNPG metadata DB** (its own persistent PVC, untouched by the re-home) survived.

The product was a catastrophic **DB↔disk drift** (the live #4353 P0): the API reported 42 repos `empty:false`/`main`, but every `contents?ref=main` 500'd `"no such file or directory"` because `/data/git/gitea-repositories` was empty → 22/23 Flux GitRepository sources `pkt-line EOF` → catalyst-platform upgrade wedged → org-controller stuck.

**A stateful plane re-home (vCluster → host-ns) must MIGRATE or PRESERVE the data PVC, never silently create an empty one.**

### The durable fix — git-data preservation guard
New `platform/gitea/chart/templates/gitdata-preservation-hook.yaml`: a **pre-install,pre-upgrade Helm hook Job** that runs BEFORE the subchart's PVC manifest lands and BEFORE the gitea Deployment boots. It mirrors the proven guacamole `recordings-pvc-migrate-hook` shape, but **preserves data by adoption** (or refuses to proceed) instead of deleting. Idempotent decision matrix:

| Case | Condition | Action |
|---|---|---|
| 1 | PVC `gitea-shared-storage` already Bound | **NO-OP** (steady state) |
| 2 | Orphan Released/Available PV (`claimRef.name == gitea-shared-storage`) exists | **ADOPT**: force the PV's reclaimPolicy → `Retain` (closes the #4352 evs-ssd Retain→Delete interaction), clear its stale `claimRef`, then **pre-create the host-ns PVC with `volumeName`** set to that PV so the chart-rendered PVC (same name, `resource-policy: keep`) **binds to the SAME data volume** — the re-home rides the existing repositories across |
| 3 | No adoptable PV, but metadata DB reports repos > 0 | **FAIL LOUD** (`exit 1`): the pre-upgrade gate fails, the gitea Deployment is **NEVER** rolled against an empty volume. Operator restores from backup (Velero / SeaweedFS object-store mirror) or re-mirrors before the install proceeds — **no silent empty boot** |
| 4 | No adoptable PV, empty/absent DB (genuinely fresh prov) | **NO-OP**: chart provisions a fresh PVC — the only case where an empty git-data volume is correct |

The claimRef **name** (`gitea-shared-storage`) is the durable join key across the vCluster→host re-home — syncer-mangled namespaces differ, but the canonical upstream claim name is stable.

Gated `gitDataMigration.enabled` (default `true`; the guard is a no-op on a fresh prov / steady state, so it is always safe to leave on). `failOnDbDiskDrift` defaults `true` (fail-closed). Tightly-scoped RBAC: ClusterRole `get/list/patch persistentvolumes`; Role `persistentvolumeclaims create/get`, `pods get/list`, `pods/exec create` (repo-count probe via the in-pod postgres **peer auth** — no DB password in the Job).

### The guard/test (no empty-PVC-on-re-home)
New `platform/gitea/chart/tests/gitdata-preservation-guard.sh` — CI gate, **15 assertions** (auto-run by `blueprint-release.yaml` chart-tests step). It proves the hook:
- renders by default as a `pre-install,pre-upgrade` hook (runs before the chart PVC),
- pre-binds the PVC via **`volumeName`** (PV adoption, **not** fresh provision — the exact #4354 bug),
- forces `reclaimPolicy: Retain` on the adopted PV,
- **FAILS LOUD** on DB↔disk drift (`exit 1`) with a fail-closed default,
- is a clean **no-op when disabled**,
- and the full render is valid YAML.

### Why a chart-side guard (not a controller / not chart-rename)
The PVC binds to whatever PV the provisioner hands it the moment the manifest lands; to ride the existing PV across the re-home we must pre-bind the host-ns PVC (`spec.volumeName`) **before** the subchart's PVC applies. A `pre-install,pre-upgrade` hook is exactly that window. Keycloak/harbor are stateless on disk (state in external CNPG DB, already defended by the #4344 admin-credentials lookup pattern); **gitea is the one plane whose git-data is local + load-bearing**, which is why #4353 hit it specifically.

### Validation (all green)
- `helm lint platform/gitea/chart` → 0 failed
- all 5 bp-gitea chart tests PASS — incl. `kyverno-probes-present` (the hook **Job** is not a Deployment, so it doesn't trip the host-ns probes-present Enforce policy) + the new `gitdata-preservation-guard` (15/15)
- `helm template` → 25 docs, valid YAML, guard renders enabled / absent when disabled
- `tests/e2e/bootstrap-kit` go test → ok
- `check-bootstrap-kit-pin-sync` → `bp-gitea chart=1.2.43 pin=1.2.43`
- `check-catalog-seed-lockstep` → 69/69 PASS
- `render-slot-placement check` → 64 slots, 0 drift
- `products/catalyst/bootstrap/api` go build → ok

Chart/blueprint **1.2.42 → 1.2.43**, slot 10 pin bumped in lockstep.

### Acceptance status
This is a **fresh-prov-durability** fix — full acceptance is a clean vCluster→host re-home **drill on a throwaway env** with git-data preserved. Leaving #4354 at **status/uat** pending that drill; the durable mechanism is merged so it can never silently recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)