### PR TITLE
fix(bp-gitea): gitdata-preservation-hook image through Harbor proxy-cache — unstall the rollback-looped gitea HR (1.2.44)

### DIFF
--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -168,7 +168,13 @@ spec:
       #   the host PVC via volumeName) so the re-home rides the SAME git-data volume,
       #   NO-OPs on a fresh prov, and FAILS LOUD when the DB reports repos but no PV
       #   can be adopted — no silent empty boot. Refs #4354 #4325 #4353 #4352.
-      version: 1.2.43
+      # 1.2.44 — #4369: gitdata-preservation-hook guard image pulls THROUGH the
+      #   Sovereign Harbor proxy-cache (harbor.openova.io/proxy-dockerhub/
+      #   bitnamilegacy/kubectl:1.30.7). 1.2.43 shipped a bare docker.io ref that
+      #   kyverno harbor-proxy-pull (Enforce) DENIED → the pre-upgrade Job
+      #   gitea-gitdata-guard was blocked → gitea HR rollback-looped 1.2.43→1.2.42,
+      #   stranding bp-catalyst-platform/-continuum/-sandbox. Refs #4369 #4367.
+      version: 1.2.44
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.43
+  version: 1.2.44
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -174,7 +174,16 @@ name: bp-gitea
 #   so the silent empty boot can never recur. Gated `gitDataMigration.enabled`
 #   (default true; safe no-op when no prior state). Adds
 #   tests/gitdata-preservation-guard.sh (CI gate). Refs #4354 #4325 #4353 #4352.
-version: 1.2.43
+# 1.2.44 (#4369, Refs #4367): gitdata-preservation-hook guard image MUST pull
+#   through the Sovereign Harbor proxy-cache. 1.2.43 shipped a bare docker.io
+#   ref (`bitnamilegacy/kubectl:1.30.7`) in both the template default AND the
+#   gitDataMigration.image value — which matches NEITHER kyverno harbor-proxy-pull
+#   Enforce glob (`*/proxy-*/*`, `*/openova-io/*`), so the pre-upgrade Job
+#   gitea-gitdata-guard was DENIED → gitea HR rolled back 1.2.43→1.2.42 in a loop
+#   → bp-catalyst-platform/-continuum/-sandbox all stranded on the dep. Re-point
+#   to `harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7` (mirrors
+#   sso-configure-deployment.yaml + every other gitea hook image). Refs #4369 #4367.
+version: 1.2.44
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/templates/gitdata-preservation-hook.yaml
+++ b/platform/gitea/chart/templates/gitdata-preservation-hook.yaml
@@ -203,7 +203,7 @@ spec:
           emptyDir: {}
       containers:
         - name: guard
-          image: {{ .Values.gitDataMigration.image | default "bitnamilegacy/kubectl:1.30.7" | quote }}
+          image: {{ .Values.gitDataMigration.image | default "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7" | quote }}
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: tmp

--- a/platform/gitea/chart/values.yaml
+++ b/platform/gitea/chart/values.yaml
@@ -594,4 +594,9 @@ gitDataMigration:
   failOnDbDiskDrift: true
   # kubectl image for the guard Job (mirrors the guacamole recordings-migrate
   # hook convention). Operator-overridable per docs/PRINCIPLES.md #4a.
-  image: bitnamilegacy/kubectl:1.30.7
+  # MUST pull through the Sovereign's Harbor proxy-cache: a bare docker.io ref
+  # (bitnamilegacy/kubectl) matches NEITHER kyverno harbor-proxy-pull glob
+  # (`*/proxy-*/*` proxy-cache, `*/openova-io/*` native-push) so the Enforce
+  # policy DENIES the pre-upgrade Job → gitea HR rollback-loops (#4369). Mirror
+  # the sso-configure-deployment.yaml convention already in this chart.
+  image: harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7


### PR DESCRIPTION
## Problem

`bp-gitea` 1.2.43 (#4367) shipped `templates/gitdata-preservation-hook.yaml` whose guard container defaulted to a bare docker.io ref `bitnamilegacy/kubectl:1.30.7` — in both the template `default` and the `gitDataMigration.image` value. On a converged Sovereign that ref matches NEITHER kyverno `harbor-proxy-pull` Enforce glob (`*/proxy-*/*`, `*/openova-io/*`), so the pre-upgrade Job `gitea-gitdata-guard` is DENIED at admission → gitea HR rolls back 1.2.43→1.2.42 in a loop.

Live on omantel.biz (kom4dc dep `4635277cae4ffed9`):
```
Helm upgrade failed for release gitea/gitea with chart bp-gitea@1.2.43: pre-upgrade hooks failed:
 admission webhook "validate.kyverno.svc-fail" denied the request:
  Job/gitea/gitea-gitdata-guard blocked by harbor-proxy-pull
```

Cascade: `bp-gitea` not Ready → `bp-catalyst-platform` (dependency not ready) → `bp-continuum` + `bp-sandbox` stranded → merged #4364 funnel-cart chart never rolls; `org-services/provisioning` wedged in `wait-for-gitea-token` init. Blocks the #4322/#4297/#4292 delivery walk.

## Fix

Re-point the guard image to `harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7` in both the values.yaml value and the template default — mirrors `sso-configure-deployment.yaml` and every other gitea hook image. Chart 1.2.43 → 1.2.44.

`helm template` confirms the rendered guard image is now `harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7`.

Refs #4369 #4367

🤖 Generated with [Claude Code](https://claude.com/claude-code)