### PR TITLE
fix(funnel): make openclaw + stalwart deployable through the generic generator (Refs #4272 #4307 #4364)

### DIFF
--- a/core/services/catalog/handlers/seed.go
+++ b/core/services/catalog/handlers/seed.go
@@ -130,7 +130,7 @@ func (h *Handler) seedAllData(ctx context.Context) {
 				"BYOS / newapi-gated LLM gateway — no agent keys leak",
 				"Preview deploys at <pr>.<app>.<sb-owner>.<sov>",
 			},
-			RelatedApps:  []string{"gitea", "librechat", "dify"},
+			RelatedApps: []string{"gitea", "librechat", "dify"},
 			ConfigSchema: []store.ConfigField{
 				{
 					Key:         "agents",
@@ -848,31 +848,37 @@ func (h *Handler) migrateAppDependencies(ctx context.Context) {
 // silently filtered them out because they were missing here.
 func DeployableAppSlugs() map[string]bool {
 	return map[string]bool{
-		"wordpress":     true,
-		"ghost":         true,
-		"nextcloud":     true,
-		"bookstack":     true,
-		"uptime-kuma":   true,
-		"gitea":         true,
-		"vaultwarden":   true,
-		"umami":         true,
-		"nocodb":        true,
-		"cal-com":       true,
-		"invoiceshelf":  true,
-		"formbricks":    true,
-		"listmonk":      true, // fixed in #101 — DBEnvStyle:"listmonk" + InitCommand
-		// openclaw + stalwart-mail were flagged Deployable in #941 but have
-		// no entry in core/services/provisioning/gitops/apps.go KnownApps —
-		// the Organization provisioning service generates manifests via a single
-		// Deployment template that requires Image + Port; both apps need
-		// HelmRelease-shaped overlays (controller + runtime for openclaw;
-		// IMAP/SMTP services for stalwart-mail). Live failure 2026-05-06
-		// on tenant "test11": tenant-test11-apps Kustomization rejected
-		// `Deployment.apps "openclaw" is invalid: containers[0].image
-		// Required value`. Re-enabling these requires per-app overlay
-		// templates beyond the one-Deployment generator.
-		// "openclaw":      true, // #941 — disabled until proper overlay
-		// "stalwart-mail": true, // #941 — disabled until proper overlay
+		"wordpress":    true,
+		"ghost":        true,
+		"nextcloud":    true,
+		"bookstack":    true,
+		"uptime-kuma":  true,
+		"gitea":        true,
+		"vaultwarden":  true,
+		"umami":        true,
+		"nocodb":       true,
+		"cal-com":      true,
+		"invoiceshelf": true,
+		"formbricks":   true,
+		"listmonk":     true, // fixed in #101 — DBEnvStyle:"listmonk" + InitCommand
+		// openclaw (#4272) + stalwart-mail (#4307) — NOW DEPLOYABLE. They were
+		// flagged non-deployable since #941 because the generic provisioning
+		// generator only rendered a single Deployment (Image + Port) and both
+		// apps need HelmRelease-shaped overlays (controller + per-user pods +
+		// HTTPRoute for openclaw; StatefulSet + IMAP/SMTP/web Services + OIDC
+		// setup Job for stalwart-mail). Live failure 2026-05-06 on tenant
+		// "test11": `Deployment.apps "openclaw" is invalid: containers[0].image
+		// Required value`. The fix (core/services/provisioning/gitops/
+		// helmrelease_apps.go) emits the upstream bp-openclaw /
+		// bp-stalwart-tenant HelmReleases as HOST files from the generic
+		// generator — mirroring the BSS-door orgTenantBPOpenClaw /
+		// orgTenantBPStalwart overlays — so a funnel cart Org (#4364, which only
+		// dispatches DEPLOYABLE apps) now renders their HelmReleases into the
+		// per-Org gitops vcluster/apps tree. Flagging them deployable here is
+		// what re-opens the marketplace cards AND admits them through the funnel
+		// cart filter.
+		"openclaw":      true, // #4272 — bp-openclaw HelmRelease overlay
+		"stalwart-mail": true, // #4307 — bp-stalwart-tenant HelmRelease overlay
 		// Backing services are always deployable — they come bundled with
 		// whichever business app needs them. Marking them true so the
 		// catalog UI doesn't draw a 'Coming soon' overlay on them. #112.

--- a/core/services/catalog/handlers/seed_test.go
+++ b/core/services/catalog/handlers/seed_test.go
@@ -95,23 +95,24 @@ func TestExpectedSandboxPlans_Shape(t *testing.T) {
 	}
 }
 
-// TestDeployableAppSlugs_OpenclawStalwartDisabled asserts that openclaw and
-// stalwart-mail are NOT in the deployable map. They were briefly enabled by
-// #941 (catalog flag flipped) but the Organization provisioning generator at
-// core/services/provisioning/gitops/apps.go has no AppSpec for either, so
-// the rendered Deployment manifests are invalid (missing image + ports).
-// Live failure 2026-05-06 on tenant "test11":
+// TestDeployableAppSlugs_OpenclawStalwartEnabled asserts that openclaw and
+// stalwart-mail ARE deployable now that the generic provisioning generator
+// emits their HelmRelease overlays (#4272/#4307,
+// core/services/provisioning/gitops/helmrelease_apps.go). Before this fix they
+// were flagged non-deployable since #941 because the generator only rendered a
+// single Deployment (Image + Port) and both apps need HelmRelease-shaped
+// overlays — the live failure being `Deployment.apps "openclaw" is invalid:
+// containers[0].image: Required value` on tenant "test11" (2026-05-06).
 //
-//	tenant-test11-apps Kustomization rejected:
-//	Deployment.apps "openclaw" is invalid: containers[0].image: Required value
-//
-// Re-enabling these requires per-app HelmRelease overlays beyond the single
-// Deployment template the generator currently supports.
-func TestDeployableAppSlugs_OpenclawStalwartDisabled(t *testing.T) {
+// Deployable=true is load-bearing twice: it re-opens the marketplace cards
+// (no "COMING SOON" overlay) AND admits both apps through the funnel cart
+// filter (#4364 dispatches ONLY deployable apps), so a cart Org now renders
+// their HelmReleases into the per-Org gitops vcluster/apps tree.
+func TestDeployableAppSlugs_OpenclawStalwartEnabled(t *testing.T) {
 	d := DeployableAppSlugs()
 	for _, slug := range []string{"openclaw", "stalwart-mail"} {
-		if d[slug] {
-			t.Errorf("%q must NOT be deployable until per-app overlay exists in the Organization provisioning generator", slug)
+		if !d[slug] {
+			t.Errorf("%q must be deployable now that the generic generator emits its HelmRelease overlay (#4272/#4307)", slug)
 		}
 	}
 }
@@ -125,6 +126,10 @@ func TestDeployableAppSlugs_StableShape(t *testing.T) {
 		"wordpress", "ghost", "nextcloud", "bookstack", "uptime-kuma",
 		"gitea", "vaultwarden", "umami", "nocodb", "cal-com",
 		"invoiceshelf", "formbricks", "listmonk",
+		// HelmRelease-shaped per-Org apps (#4272/#4307) — render via the
+		// generic generator's HelmRelease overlay path, not the one-Deployment
+		// template.
+		"openclaw", "stalwart-mail",
 		"postgres", "mysql", "redis",
 		// Wave 4 — Sandbox marketplace catalog entry.
 		"sandbox",

--- a/core/services/provisioning/gitops/gitops.go
+++ b/core/services/provisioning/gitops/gitops.go
@@ -189,7 +189,33 @@ type ManifestGenerator struct {
 	// persists it on the catalyst-api PVC at
 	// /var/lib/catalyst/kubeconfigs/<depID>-<region>.yaml).
 	ReplicaRegionKubeSecret string
+
+	// ParentDomain is the per-Sovereign org-pool parent zone (e.g.
+	// "omani.homes") the funnel stamps onto the public hostnames of the
+	// HelmRelease-shaped per-Org apps (bp-openclaw → openclaw.<slug>.<parent>,
+	// bp-stalwart-tenant → mail.<slug>.<parent>). It is the SAME
+	// TENANT_PARENT_DOMAIN env the Handler reads for the tenant-public patch;
+	// wired through the generator in main.go so the openclaw/stalwart overlays
+	// (#4272/#4307) emit the correct console-isolation hostnames. Empty falls
+	// back to parentDomainDefault so a render never produces a bare `<slug>.`
+	// with no zone.
+	ParentDomain string
 }
+
+// parentDomain resolves the funnel's org-pool parent zone for the
+// HelmRelease-shaped per-Org apps, falling back to parentDomainDefault when the
+// generator was constructed without a TENANT_PARENT_DOMAIN wiring.
+func (g *ManifestGenerator) parentDomain() string {
+	if pd := strings.TrimSpace(g.ParentDomain); pd != "" {
+		return pd
+	}
+	return parentDomainDefault
+}
+
+// parentDomainDefault is the org-pool parent zone the funnel stamps onto the
+// HelmRelease-shaped per-Org app hostnames when ParentDomain is unset. Matches
+// the catalog-canon default pool (docs/DOD.md §Domains-canon).
+const parentDomainDefault = "omani.homes"
 
 // replicaRegionKubeSecretDefault is the deterministic flux-system Secret
 // name the cross-region standby HelmRelease's spec.kubeConfig.secretRef
@@ -549,6 +575,15 @@ func (g *ManifestGenerator) GenerateAllWithAppConfigs(slug, planSlug string, app
 		if a == "mysql" || a == "postgres" || a == "redis" {
 			continue
 		}
+		// HelmRelease-shaped apps (openclaw #4272, stalwart-mail #4307) are
+		// emitted as HOST files below (the helm-controller runs on the host,
+		// not inside the per-Org vcluster — #3055), NOT as a synced in-vcluster
+		// Deployment. Skip them here so the generic one-Deployment template
+		// doesn't render an invalid `image: Required value` manifest under
+		// their name (the #941 live failure that flagged them non-deployable).
+		if isHelmReleaseApp(a) {
+			continue
+		}
 		spec := GetAppSpec(a)
 		// MIRROR-EVERYTHING (#3785, Refs #3376 #3761): route the app image
 		// (main container + the InitCommand initContainer that reuses it)
@@ -563,6 +598,27 @@ func (g *ManifestGenerator) GenerateAllWithAppConfigs(slug, planSlug string, app
 		vcFiles[fmt.Sprintf("app-%s.yaml", a)] = generateAppDeployment(appNS, slug, planSlug, a, spec, dbPassword)
 	}
 	vcFiles["kustomization.yaml"] = generateKustomization(appNS, vcFiles)
+
+	// HelmRelease-shaped per-Org apps (openclaw #4272, stalwart-mail #4307) —
+	// emitted as HOST files (helm-controller runs on the host, NOT inside the
+	// per-Org vcluster, #3055), tier-aware via the SAME HR-level kubeConfig the
+	// bp-cnpg-pair path uses: vcluster tier installs the chart INTO the Org
+	// vcluster through the flux-system `tenant-<slug>-kubeconfig` mirror; host
+	// tier installs straight into the host `<slug>` ns (kubeSecret ""). Each HR
+	// ships its own bp-* HelmRepository so a fresh funnel Org resolves the
+	// sourceRef. Mirrors the BSS-door orgTenantBPOpenClaw / orgTenantBPStalwart
+	// overlays so a cart Org gets the SAME releases the BSS door emits.
+	hrKubeSecret := ""
+	if isVcluster {
+		hrKubeSecret = fmt.Sprintf("tenant-%s-kubeconfig", slug)
+	}
+	for _, a := range sortedHelmReleaseApps(appSlugs) {
+		hostFiles[fmt.Sprintf("app-%s.yaml", a)] = generateHelmReleaseApp(a, helmReleaseAppOpts{
+			slug:         slug,
+			parentDomain: g.parentDomain(),
+			kubeSecret:   hrKubeSecret,
+		})
+	}
 
 	// #4297: assemble the host kustomization.yaml LAST so it enumerates every
 	// host-scoped file including any host-reconciled HelmRelease the db block
@@ -665,6 +721,19 @@ spec:
 }
 
 func generateHostIngress(ns, slug string, appSlugs []string) string {
+	// HelmRelease-shaped apps (openclaw #4272, stalwart-mail #4307) carry their
+	// OWN chart-emitted HTTPRoute parented to cilium-gateway-console — they must
+	// NOT also appear in this traefik host ingress (a second route to a service
+	// that doesn't exist as `<app>-x-...-x-vcluster` would 404). Filter to the
+	// Deployment-shaped apps that actually sync a Service into the vcluster.
+	routable := make([]string, 0, len(appSlugs))
+	for _, a := range appSlugs {
+		if isHelmReleaseApp(a) {
+			continue
+		}
+		routable = append(routable, a)
+	}
+	appSlugs = routable
 	if len(appSlugs) == 0 {
 		return ""
 	}

--- a/core/services/provisioning/gitops/helmrelease_apps.go
+++ b/core/services/provisioning/gitops/helmrelease_apps.go
@@ -1,0 +1,327 @@
+package gitops
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// HelmRelease-shaped per-Org catalog apps (#4272 openclaw, #4307 stalwart).
+//
+// WHY THIS FILE EXISTS — the catalog-gap fix.
+//
+// The generic funnel/provisioning generator (ManifestGenerator.GenerateAll*)
+// renders most marketplace apps as a single raw Deployment (KnownApps +
+// generateAppDeployment). Two catalog apps cannot be expressed that way:
+//
+//   - openclaw (catalog slug `openclaw`)        → ships a controller + a
+//     per-user-pod template + an HTTPRoute + a CiliumNetworkPolicy; a one-
+//     Deployment template can't carry that shape (the rendered Deployment was
+//     `containers[0].image: Required value` — the live #941 failure on tenant
+//     test11).
+//   - stalwart-mail (catalog slug `stalwart-mail`) → ships a StatefulSet with
+//     IMAP/SMTP/web Services, a DNS-01 mail cert, an OIDC setup Job, and an
+//     admin-secret auto-provisioner.
+//
+// Because they had no render path here, DeployableAppSlugs() flagged both
+// Deployable=false, so the marketplace drew a "COMING SOON" overlay AND the
+// funnel cart-placement (#4364) skipped them (it only dispatches deployable
+// apps). A funnel Org therefore never got their HelmReleases — the exact
+// #4272/#4307 gap.
+//
+// THE FIX: emit the upstream bp-openclaw / bp-stalwart-tenant HelmReleases —
+// mirroring the BSS-door overlay emitters in
+// products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
+// (orgTenantBPOpenClaw / orgTenantBPStalwart) — directly from the generic
+// generator. The HRs are HOST files (helm-controller runs on the host, NOT
+// inside a per-Org vCluster — #3055), tier-aware via the same HR-level
+// kubeConfig the bp-cnpg-pair path uses (generateCNPGPair): vcluster tier →
+// install INTO the Org vCluster via the `tenant-<slug>-kubeconfig` mirror;
+// host tier → install straight into the host `<slug>` ns. Each HR ships its
+// own bp-* HelmRepository (flux-system) so a fresh funnel Org resolves the
+// sourceRef without the org-controller having to seed it.
+//
+// DIVERGENCE FROM THE BSS DOOR (intentional): the generic funnel path does NOT
+// emit a per-tenant bp-keycloak (the BSS door's Step-6 does). So these HRs
+// carry NO `dependsOn: bp-keycloak` — a dependsOn on a never-rendered HR would
+// wedge the release in `DependencyNotReady` forever. The OIDC values still
+// point at the conventional per-tenant Keycloak host (keycloak.<slug>.<parent>)
+// so that when the live walk wires SSO the issuer matches; until then the
+// charts render with their built-in placeholder OIDC values and start. This is
+// the same "plain version in the generic path" stance as wordpress (the
+// generic path installs `wordpress:6-apache`, not the SSO-pre-wired
+// bp-wordpress-tenant the BSS door installs).
+
+// helmReleaseAppSlugs is the set of catalog app slugs the generic generator
+// renders as a HelmRelease (via generateHelmReleaseApp) instead of a raw
+// Deployment. Keyed by the catalog seedApp slug (NOT the bp-* chart name).
+var helmReleaseAppSlugs = map[string]bool{
+	"openclaw":      true, // #4272 — bp-openclaw HelmRelease overlay
+	"stalwart-mail": true, // #4307 — bp-stalwart-tenant HelmRelease overlay
+}
+
+// isHelmReleaseApp reports whether the catalog slug is rendered as a
+// HelmRelease (host file) rather than a synced in-vcluster Deployment. The
+// generic generator uses it to route the slug to generateHelmReleaseApp and to
+// keep it out of generateHostIngress (these apps carry their OWN chart-emitted
+// HTTPRoute, parented to cilium-gateway-console, so the traefik host ingress
+// must not also try to route them).
+func isHelmReleaseApp(slug string) bool {
+	return helmReleaseAppSlugs[slug]
+}
+
+// hasHelmReleaseApp reports whether any slug in the cart renders as a
+// HelmRelease — used to decide whether the per-Org gitops tree needs the
+// shared ghcr-pull / source plumbing.
+func hasHelmReleaseApp(appSlugs []string) bool {
+	for _, a := range appSlugs {
+		if isHelmReleaseApp(a) {
+			return true
+		}
+	}
+	return false
+}
+
+// helmReleaseAppOpts carries the per-Org context the openclaw/stalwart HR
+// templates interpolate. slug is the Organization subdomain (== host ns).
+type helmReleaseAppOpts struct {
+	slug         string // Org subdomain == host namespace
+	parentDomain string // org-pool parent zone (e.g. omani.homes)
+	adminEmail   string // operator/admin email for stalwart
+	// kubeSecret, when non-empty, is the flux-system Secret holding the Org
+	// vCluster kubeconfig (`tenant-<slug>-kubeconfig`). Set on the vcluster
+	// tier so the host helm-controller installs the chart INTO the vcluster;
+	// empty on the host tier (install straight into the host `<slug>` ns).
+	kubeSecret string
+}
+
+// generateHelmReleaseApp renders the HelmRepository + HelmRelease pair for a
+// HelmRelease-shaped catalog app. Returns "" for a slug that is not a
+// HelmRelease app (defence in depth — callers gate on isHelmReleaseApp first).
+func generateHelmReleaseApp(appSlug string, opt helmReleaseAppOpts) string {
+	switch appSlug {
+	case "openclaw":
+		return generateOpenClawHR(opt)
+	case "stalwart-mail":
+		return generateStalwartHR(opt)
+	default:
+		return ""
+	}
+}
+
+// kubeConfigBlock renders the HR-level spec.kubeConfig the host helm-controller
+// uses to install INTO the Org vCluster (vcluster tier). Empty kubeSecret →
+// empty block (host tier installs into the host ns). Mirrors generateCNPGPair.
+func (opt helmReleaseAppOpts) kubeConfigBlock() string {
+	if strings.TrimSpace(opt.kubeSecret) == "" {
+		return ""
+	}
+	return fmt.Sprintf(`
+  kubeConfig:
+    secretRef:
+      name: %s
+      key: config`, opt.kubeSecret)
+}
+
+// helmRepoBlock renders the shared bp-* OCI HelmRepository the HR sourceRefs.
+// Every HR-shaped app ships its own so a fresh funnel Org resolves the
+// sourceRef without the org-controller seeding it (the BSS door seeds these in
+// orgTenantSharedHelmRepositories; the funnel path has no such shared block).
+func helmRepoBlock(name string) string {
+	return fmt.Sprintf(`apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: %s
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull`, name)
+}
+
+// generateOpenClawHR mirrors orgTenantBPOpenClaw (#4272) for the generic
+// funnel path: the per-Org OpenClaw controller, SSO-wired to the per-tenant
+// Keycloak realm + NewAPI gateway, exposed via the dedicated console Gateway.
+func generateOpenClawHR(opt helmReleaseAppOpts) string {
+	host := fmt.Sprintf("openclaw.%s.%s", opt.slug, opt.parentDomain)
+	keycloakRealm := fmt.Sprintf("https://keycloak.%s.%s/realms/org-%s", opt.slug, opt.parentDomain, opt.slug)
+	newapiBase := fmt.Sprintf("https://api.%s.%s/v1", opt.slug, opt.parentDomain)
+	return fmt.Sprintf(`# bp-openclaw (#4272) — per-Org workspace controller rendered by the generic
+# funnel generator. Mirrors the BSS-door orgTenantBPOpenClaw overlay so a cart
+# Org gets the SAME HelmRelease the BSS door emits. The generic funnel path
+# emits NO per-tenant bp-keycloak, so there is NO dependsOn here (a dependsOn on
+# a never-rendered HR would wedge the release forever); the OIDC values still
+# point at the conventional per-tenant Keycloak realm so SSO matches once the
+# realm exists. Public exposure rides the dedicated console Gateway (#4054).
+%s
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-openclaw
+  namespace: %s
+  labels:
+    catalyst.openova.io/app: openclaw
+    openova.io/category: customer-facing-capability
+spec:
+  interval: 10m
+  releaseName: openclaw
+  targetNamespace: %s%s
+  chart:
+    spec:
+      chart: bp-openclaw
+      version: "*"
+      sourceRef:
+        kind: HelmRepository
+        name: bp-openclaw
+        namespace: flux-system
+  install:
+    timeout: 15m
+    remediation:
+      retries: 3
+  upgrade:
+    timeout: 15m
+    remediation:
+      retries: 3
+  values:
+    oidc:
+      issuerURL: %s
+      clientId: openclaw
+      clientSecret:
+        name: openclaw-oidc-client-secret
+        key: OIDC_CLIENT_SECRET
+    llm:
+      baseURL: %s
+      apiKey:
+        name: openclaw-newapi-controller-token
+        key: NEWAPI_KEY
+      defaultModel: qwen3.6
+    keycloak:
+      realmURL: %s
+      clientID: openclaw
+      clientSecretName: openclaw-oidc-client-secret
+    newapi:
+      baseURL: %s
+    tenant:
+      namespace: %s
+    # Cilium Gateway API exposure (#4272) — a Sovereign runs the Cilium
+    # Gateway, NOT traefik; the chart's networking.k8s.io/v1 Ingress is inert
+    # here. Attach the controller host to the DEDICATED console Gateway whose
+    # *.<pool> wildcard TLS listener terminates TLS (no per-host cert),
+    # mirroring bp-agenity (#4180).
+    ingress:
+      enabled: false
+    httpRoute:
+      enabled: true
+      hostnames:
+        - %s
+      parentRef:
+        name: cilium-gateway-console
+        namespace: kube-system
+    networkPolicy:
+      enabled: true
+      ingress:
+        allowGatewayEntity: true
+`, helmRepoBlock("bp-openclaw"), opt.slug, opt.slug, opt.kubeConfigBlock(),
+		keycloakRealm, newapiBase, keycloakRealm, newapiBase, opt.slug, host)
+}
+
+// generateStalwartHR mirrors orgTenantBPStalwart (#4307) for the generic
+// funnel path: the per-Org Stalwart mail server, SSO-wired to the per-tenant
+// Keycloak realm, exposed via the dedicated console Gateway. disableWait +
+// admin.externalSecret:false carry the #4307/#4246 live-converged settings.
+func generateStalwartHR(opt helmReleaseAppOpts) string {
+	mailHost := fmt.Sprintf("mail.%s.%s", opt.slug, opt.parentDomain)
+	primaryDomain := fmt.Sprintf("%s.%s", opt.slug, opt.parentDomain)
+	keycloakRealm := fmt.Sprintf("https://keycloak.%s.%s/realms/org-%s", opt.slug, opt.parentDomain, opt.slug)
+	adminEmail := strings.TrimSpace(opt.adminEmail)
+	if adminEmail == "" {
+		adminEmail = fmt.Sprintf("admin@%s", primaryDomain)
+	}
+	return fmt.Sprintf(`# bp-stalwart-tenant (#4307) — per-Org mail server rendered by the generic
+# funnel generator. Mirrors the BSS-door orgTenantBPStalwart overlay. NO
+# dependsOn on bp-keycloak (the generic funnel path emits none — a dependsOn on
+# a never-rendered HR would wedge the release); the OIDC values point at the
+# conventional per-tenant Keycloak realm so SSO matches once it exists.
+# disableWait (#4307): the StatefulSet mounts stalwart-tls NON-optionally and
+# blocks at ContainerCreating until cert-manager issues the mail.<host> leaf;
+# without disableWait the install burns its 15m budget before the OIDC setup
+# Job (a Helm hook) ever runs. admin.externalSecret:false (#4246): nothing
+# seeds OpenBao at the admin path on a fresh per-Org install, so let the chart
+# auto-provision a persistent random ADMIN_PASSWORD.
+%s
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-stalwart-tenant
+  namespace: %s
+  labels:
+    catalyst.openova.io/app: stalwart-mail
+    openova.io/category: customer-facing-capability
+spec:
+  interval: 10m
+  releaseName: stalwart-tenant
+  targetNamespace: %s%s
+  chart:
+    spec:
+      chart: bp-stalwart-tenant
+      version: "*"
+      sourceRef:
+        kind: HelmRepository
+        name: bp-stalwart-tenant
+        namespace: flux-system
+  install:
+    timeout: 15m
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    timeout: 15m
+    cleanupOnFail: true
+    disableWait: true
+    remediation:
+      retries: 3
+  values:
+    domain:
+      primary: %s
+      mode: subdomain
+    ingress:
+      webmail:
+        host: %s
+        parentRef:
+          name: cilium-gateway-console
+          namespace: kube-system
+        tls:
+          enabled: true
+          issuer: letsencrypt-prod
+    adminEmail: %s
+    keycloak:
+      realmURL: %s
+      clientID: stalwart
+      clientSecretName: stalwart-oidc-client-secret
+    admin:
+      externalSecret:
+        enabled: false
+    mailboxProvisioner:
+      setupJob:
+        enabled: true
+`, helmRepoBlock("bp-stalwart-tenant"), opt.slug, opt.slug, opt.kubeConfigBlock(),
+		primaryDomain, mailHost, adminEmail, keycloakRealm)
+}
+
+// sortedHelmReleaseApps returns the HelmRelease-shaped slugs from appSlugs in a
+// stable order so the generated file set is deterministic across regenerate
+// (Go map/slice iteration order would otherwise churn the gitops diff).
+func sortedHelmReleaseApps(appSlugs []string) []string {
+	out := make([]string, 0, len(appSlugs))
+	for _, a := range appSlugs {
+		if isHelmReleaseApp(a) {
+			out = append(out, a)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/core/services/provisioning/gitops/helmrelease_apps_test.go
+++ b/core/services/provisioning/gitops/helmrelease_apps_test.go
@@ -1,0 +1,241 @@
+package gitops
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4272 (openclaw) + #4307 (stalwart-mail) — the funnel-deployable catalog gap.
+//
+// Both apps were flagged Deployable=false because the generic generator only
+// rendered a single Deployment (Image + Port) and they need HelmRelease-shaped
+// overlays. The fix (helmrelease_apps.go) emits the upstream bp-openclaw /
+// bp-stalwart-tenant HelmReleases as HOST files from the generic generator, so
+// a funnel cart Org (which #4364 dispatches through GenerateAllWithPassword)
+// now renders their HelmReleases into the per-Org gitops tree. These tests are
+// the render-proof: a cart Org with openclaw+stalwart produces their HRs.
+
+// cartOrgFor renders a funnel cart Org with the given apps + plan tier and
+// returns the full file map (mirrors the day-2 GenerateAllWithPassword call in
+// consumer.go: GenerateAllWithAppConfigs with an empty appConfigs map).
+func cartOrgFor(t *testing.T, slug, planSlug string, apps []string) map[string]string {
+	t.Helper()
+	g := NewManifestGenerator(testBasePath)
+	g.ParentDomain = "omani.homes"
+	return g.GenerateAllWithAppConfigs(slug, planSlug, apps, "pw", nil)
+}
+
+// TestFunnelCart_OpenClawStalwart_RenderHelmReleases is THE render-proof for
+// #4272/#4307: a cart Org carrying both apps emits a bp-openclaw +
+// bp-stalwart-tenant HelmRelease into the per-Org gitops tree. Run across both
+// boundary tiers so neither the host nor the vcluster path regresses.
+func TestFunnelCart_OpenClawStalwart_RenderHelmReleases(t *testing.T) {
+	for _, plan := range []string{"s", "m"} {
+		t.Run("plan="+plan, func(t *testing.T) {
+			out := cartOrgFor(t, "acme", plan, []string{"wordpress", "openclaw", "stalwart-mail"})
+
+			openclaw, ok := out[testBasePath+"/acme/app-openclaw.yaml"]
+			if !ok {
+				t.Fatalf("bp-openclaw HelmRelease NOT rendered for a cart Org (#4272) (keys: %v)", keys(out))
+			}
+			stalwart, ok := out[testBasePath+"/acme/app-stalwart-mail.yaml"]
+			if !ok {
+				t.Fatalf("bp-stalwart-tenant HelmRelease NOT rendered for a cart Org (#4307) (keys: %v)", keys(out))
+			}
+
+			// Each must be a real HelmRelease pointed at the right chart, NOT a
+			// Deployment (the old broken `image: Required value` shape).
+			for name, body := range map[string]string{"openclaw": openclaw, "stalwart": stalwart} {
+				if !strings.Contains(body, "kind: HelmRelease") {
+					t.Errorf("%s overlay is not a HelmRelease:\n%s", name, body)
+				}
+				if strings.Contains(body, "kind: Deployment") {
+					t.Errorf("%s overlay must NOT render a raw Deployment (the #941 broken path):\n%s", name, body)
+				}
+			}
+			if !strings.Contains(openclaw, "chart: bp-openclaw") {
+				t.Errorf("openclaw overlay must source the bp-openclaw chart:\n%s", openclaw)
+			}
+			if !strings.Contains(stalwart, "chart: bp-stalwart-tenant") {
+				t.Errorf("stalwart overlay must source the bp-stalwart-tenant chart:\n%s", stalwart)
+			}
+
+			// Each ships its own HelmRepository so a fresh funnel Org resolves
+			// the sourceRef (the org-controller seeds only the vcluster repo).
+			if !strings.Contains(openclaw, "kind: HelmRepository") || !strings.Contains(openclaw, "name: bp-openclaw") {
+				t.Errorf("openclaw overlay must ship its bp-openclaw HelmRepository:\n%s", openclaw)
+			}
+			if !strings.Contains(stalwart, "kind: HelmRepository") || !strings.Contains(stalwart, "name: bp-stalwart-tenant") {
+				t.Errorf("stalwart overlay must ship its bp-stalwart-tenant HelmRepository:\n%s", stalwart)
+			}
+
+			// They are HOST files (helm-controller runs on the host, #3055) —
+			// NOT in the vcluster-redirected apps/ tree (which runs no
+			// helm-controller, so an HR there never reconciles).
+			if _, inApps := out[testBasePath+"/acme/apps/app-openclaw.yaml"]; inApps {
+				t.Errorf("openclaw HR must be a HOST file, not in the vcluster apps/ tree")
+			}
+			if _, inApps := out[testBasePath+"/acme/apps/app-stalwart-mail.yaml"]; inApps {
+				t.Errorf("stalwart HR must be a HOST file, not in the vcluster apps/ tree")
+			}
+
+			// And the host kustomization must enumerate them (else Flux ignores
+			// the files).
+			hostKust := out[testBasePath+"/acme/kustomization.yaml"]
+			if !strings.Contains(hostKust, "app-openclaw.yaml") {
+				t.Errorf("host kustomization must list app-openclaw.yaml:\n%s", hostKust)
+			}
+			if !strings.Contains(hostKust, "app-stalwart-mail.yaml") {
+				t.Errorf("host kustomization must list app-stalwart-mail.yaml:\n%s", hostKust)
+			}
+		})
+	}
+}
+
+// TestFunnelCart_HRApps_NoDeploymentNoHostIngress — the HR apps must NOT also
+// produce a raw app-*.yaml Deployment in the vcluster apps/ tree, and must NOT
+// be wired into the traefik host ingress (they carry their own chart HTTPRoute
+// parented to cilium-gateway-console). A Deployment-shaped co-installed app
+// (wordpress) must still appear so the generic path keeps working.
+func TestFunnelCart_HRApps_NoDeploymentNoHostIngress(t *testing.T) {
+	out := cartOrgFor(t, "acme", "m", []string{"wordpress", "openclaw", "stalwart-mail"})
+
+	// No vcluster-tree Deployment for the HR apps.
+	if _, ok := out[testBasePath+"/acme/apps/app-openclaw.yaml"]; ok {
+		t.Errorf("openclaw must NOT render a raw Deployment under apps/")
+	}
+	if _, ok := out[testBasePath+"/acme/apps/app-stalwart-mail.yaml"]; ok {
+		t.Errorf("stalwart-mail must NOT render a raw Deployment under apps/")
+	}
+	// The Deployment-shaped co-installed app still renders under apps/.
+	if _, ok := out[testBasePath+"/acme/apps/app-wordpress.yaml"]; !ok {
+		t.Errorf("wordpress Deployment must still render under apps/ (generic path intact) (keys: %v)", keys(out))
+	}
+
+	// Host ingress must not route the HR apps (they have their own HTTPRoute).
+	ingress := out[testBasePath+"/acme/ingress.yaml"]
+	if strings.Contains(ingress, "openclaw") {
+		t.Errorf("host ingress must NOT route openclaw (chart owns its HTTPRoute):\n%s", ingress)
+	}
+	if strings.Contains(ingress, "stalwart") {
+		t.Errorf("host ingress must NOT route stalwart-mail (chart owns its HTTPRoute):\n%s", ingress)
+	}
+	// wordpress still routed.
+	if !strings.Contains(ingress, "wordpress-x-acme-x-vcluster") {
+		t.Errorf("host ingress must still route the Deployment-shaped wordpress:\n%s", ingress)
+	}
+}
+
+// TestFunnelCart_HRApps_TierAwareKubeConfig — the HR-level kubeConfig follows
+// the same tier gate as the apps-sync + bp-cnpg-pair: vcluster tier (M+)
+// installs the chart INTO the Org vcluster via the tenant-<slug>-kubeconfig
+// mirror; host tier (S/free) installs straight into the host <slug> ns with NO
+// kubeConfig.
+func TestFunnelCart_HRApps_TierAwareKubeConfig(t *testing.T) {
+	t.Run("vcluster-tier", func(t *testing.T) {
+		out := cartOrgFor(t, "acme", "m", []string{"openclaw", "stalwart-mail"})
+		for _, f := range []string{"app-openclaw.yaml", "app-stalwart-mail.yaml"} {
+			body := out[testBasePath+"/acme/"+f]
+			if !strings.Contains(body, "kubeConfig:") {
+				t.Errorf("vcluster tier %s MUST carry an HR-level kubeConfig so the host helm-controller installs INTO the vcluster:\n%s", f, body)
+			}
+			if !strings.Contains(body, "name: tenant-acme-kubeconfig") {
+				t.Errorf("vcluster tier %s kubeConfig must reference the tenant-<slug>-kubeconfig mirror:\n%s", f, body)
+			}
+		}
+	})
+	t.Run("host-tier", func(t *testing.T) {
+		for _, plan := range []string{"s", "free", ""} {
+			out := cartOrgFor(t, "acme", plan, []string{"openclaw", "stalwart-mail"})
+			for _, f := range []string{"app-openclaw.yaml", "app-stalwart-mail.yaml"} {
+				body := out[testBasePath+"/acme/"+f]
+				if strings.Contains(body, "kubeConfig:") {
+					t.Errorf("host tier (plan=%q) %s MUST NOT carry kubeConfig (no vcluster mirror exists):\n%s", plan, f, body)
+				}
+				if strings.Contains(body, "tenant-acme-kubeconfig") {
+					t.Errorf("host tier (plan=%q) %s MUST NOT reference the never-created vcluster mirror:\n%s", plan, f, body)
+				}
+			}
+		}
+	})
+}
+
+// TestFunnelCart_HRApps_HostnamesUseParentDomain — the public hostnames are
+// stamped from the generator's ParentDomain (TENANT_PARENT_DOMAIN), parented to
+// the dedicated console Gateway (console isolation #4054).
+func TestFunnelCart_HRApps_HostnamesUseParentDomain(t *testing.T) {
+	g := NewManifestGenerator(testBasePath)
+	g.ParentDomain = "omani.trade"
+	out := g.GenerateAllWithAppConfigs("acme", "m", []string{"openclaw", "stalwart-mail"}, "pw", nil)
+
+	openclaw := out[testBasePath+"/acme/app-openclaw.yaml"]
+	if !strings.Contains(openclaw, "openclaw.acme.omani.trade") {
+		t.Errorf("openclaw HTTPRoute host must be openclaw.<slug>.<parent>:\n%s", openclaw)
+	}
+	if !strings.Contains(openclaw, "name: cilium-gateway-console") {
+		t.Errorf("openclaw HTTPRoute must parent the dedicated console Gateway (#4054):\n%s", openclaw)
+	}
+
+	stalwart := out[testBasePath+"/acme/app-stalwart-mail.yaml"]
+	if !strings.Contains(stalwart, "mail.acme.omani.trade") {
+		t.Errorf("stalwart webmail host must be mail.<slug>.<parent>:\n%s", stalwart)
+	}
+	if !strings.Contains(stalwart, "name: cilium-gateway-console") {
+		t.Errorf("stalwart webmail ingress must parent the dedicated console Gateway (#4307):\n%s", stalwart)
+	}
+}
+
+// TestFunnelCart_Stalwart_LiveConvergedSettings — the #4307/#4246 settings the
+// live demo Org proved are required must be present: disableWait (so the OIDC
+// setup Job runs before the 15m budget burns) + admin.externalSecret:false (so
+// the chart auto-provisions ADMIN_PASSWORD; nothing seeds OpenBao on a fresh
+// funnel Org).
+func TestFunnelCart_Stalwart_LiveConvergedSettings(t *testing.T) {
+	out := cartOrgFor(t, "acme", "m", []string{"stalwart-mail"})
+	stalwart := out[testBasePath+"/acme/app-stalwart-mail.yaml"]
+	if !strings.Contains(stalwart, "disableWait: true") {
+		t.Errorf("stalwart HR must set disableWait (#4307) so the OIDC setup Job runs:\n%s", stalwart)
+	}
+	if !strings.Contains(stalwart, "externalSecret:\n        enabled: false") {
+		t.Errorf("stalwart HR must disable admin.externalSecret (#4246) so the chart auto-provisions ADMIN_PASSWORD:\n%s", stalwart)
+	}
+}
+
+// TestFunnelCart_HRApps_NoKeycloakDependsOn — the generic funnel path emits NO
+// per-tenant bp-keycloak, so the openclaw/stalwart HRs must carry NO
+// dependsOn (a dependsOn on a never-rendered HR wedges the release in
+// DependencyNotReady forever).
+func TestFunnelCart_HRApps_NoKeycloakDependsOn(t *testing.T) {
+	out := cartOrgFor(t, "acme", "m", []string{"openclaw", "stalwart-mail"})
+	for _, f := range []string{"app-openclaw.yaml", "app-stalwart-mail.yaml"} {
+		body := out[testBasePath+"/acme/"+f]
+		if strings.Contains(body, "dependsOn:") {
+			t.Errorf("%s must NOT carry dependsOn — the generic funnel path emits no bp-keycloak so the HR would wedge in DependencyNotReady:\n%s", f, body)
+		}
+	}
+}
+
+// TestFunnelCart_NoHRApps_NoHostHRFiles — a cart with only Deployment-shaped
+// apps produces NO HR app files (no regression / no stray empty host files).
+func TestFunnelCart_NoHRApps_NoHostHRFiles(t *testing.T) {
+	out := cartOrgFor(t, "acme", "m", []string{"wordpress", "ghost"})
+	for _, f := range []string{"app-openclaw.yaml", "app-stalwart-mail.yaml"} {
+		if _, ok := out[testBasePath+"/acme/"+f]; ok {
+			t.Errorf("no HR app in cart, but %s was emitted", f)
+		}
+	}
+}
+
+// TestParentDomain_DefaultFallback — an unset ParentDomain falls back to the
+// catalog-canon default pool so a render never produces a bare `<slug>.` host.
+func TestParentDomain_DefaultFallback(t *testing.T) {
+	g := NewManifestGenerator(testBasePath)
+	if got := g.parentDomain(); got != parentDomainDefault {
+		t.Errorf("parentDomain() default = %q, want %q", got, parentDomainDefault)
+	}
+	out := g.GenerateAllWithAppConfigs("acme", "m", []string{"openclaw"}, "pw", nil)
+	openclaw := out[testBasePath+"/acme/app-openclaw.yaml"]
+	if !strings.Contains(openclaw, "openclaw.acme."+parentDomainDefault) {
+		t.Errorf("default parent-domain host wrong:\n%s", openclaw)
+	}
+}

--- a/core/services/provisioning/main.go
+++ b/core/services/provisioning/main.go
@@ -192,6 +192,15 @@ func main() {
 	// bootstrap mirrors region-B's kubeconfig into.
 	generator.ReplicaRegionKubeSecret = getEnv("CATALYST_REPLICA_REGION_KUBECONFIG_SECRET", "")
 
+	// #4272/#4307: the per-Sovereign org-pool parent zone (e.g. "omani.homes")
+	// the funnel stamps onto the HelmRelease-shaped per-Org app hostnames
+	// (bp-openclaw → openclaw.<slug>.<parent>, bp-stalwart-tenant →
+	// mail.<slug>.<parent>). Same TENANT_PARENT_DOMAIN env the Handler reads
+	// for the tenant-public patch — wired through the generator so the
+	// openclaw/stalwart overlays emit the correct console-isolation hostnames.
+	// Empty falls back to the catalog-canon default pool inside the generator.
+	generator.ParentDomain = tenantParentDomain
+
 	// ── Git host coordinates (issue #940) ────────────────────────────
 	// On Sovereigns the canonical Git target is the local Gitea (the
 	// cutover step flipped the Sovereign's GitRepository CR to point


### PR DESCRIPTION
## Why

A prior funnel walk found **openclaw** (#4272) and **stalwart-mail** (#4307) are `Deployable=false` in the catalog. The funnel cart-placement fix (#4364) dispatches **only deployable** apps through provisioning's `ManifestGenerator.GenerateAllWithPassword` (gated by `DeployableAppSlugs()`), so even with a correct cart these two were silently skipped — their HelmReleases never landed in the per-Org gitops `vcluster/apps/` tree. (wordpress IS deployable and lands via #4364.)

## Root cause

The generic provisioning generator only rendered a single raw Deployment (`KnownApps` + `generateAppDeployment`, requires `Image` + `Port`). openclaw (controller + per-user pods + HTTPRoute + CiliumNetworkPolicy) and stalwart-mail (StatefulSet + IMAP/SMTP/web Services + DNS-01 mail cert + OIDC setup Job) cannot be expressed that way — the rendered Deployment was invalid (`containers[0].image: Required value`, the live #941 failure on tenant `test11`), so `DeployableAppSlugs()` excluded them and the marketplace drew a "COMING SOON" overlay.

## Fix

Mirrors the BSS-door `organization_gitops.go` `orgTenantBPOpenClaw` / `orgTenantBPStalwart` emitters into the generic generator path:

- **New `core/services/provisioning/gitops/helmrelease_apps.go`** — emits the upstream `bp-openclaw` / `bp-stalwart-tenant` HelmReleases (each with its own `bp-*` OCI HelmRepository) as **HOST files** (the helm-controller runs on the host, not inside the per-Org vcluster — #3055). **Tier-aware** via the same HR-level `kubeConfig` the `bp-cnpg-pair` path uses: vcluster tier (M+) installs INTO the Org vcluster through the `tenant-<slug>-kubeconfig` mirror; host tier (S/free) installs straight into the host `<slug>` ns. Public exposure rides the dedicated **console Gateway** (#4054); stalwart carries the #4307/#4246 live-converged settings (`disableWait` + `admin.externalSecret:false`).
- **No `dependsOn: bp-keycloak`** — the generic funnel path emits no per-tenant keycloak, and a dependsOn on a never-rendered HR would wedge the release in `DependencyNotReady` forever. OIDC values still point at the conventional per-tenant Keycloak realm so SSO matches once the live walk wires it (same "plain version in the generic path" stance as wordpress).
- **`ManifestGenerator.ParentDomain`** field, wired from `TENANT_PARENT_DOMAIN` in `main.go`, so the openclaw/stalwart hostnames stamp the correct console-isolation pool zone.
- **`generateHostIngress`** now skips HelmRelease apps (they own their chart HTTPRoute).
- **`DeployableAppSlugs()`** now includes `openclaw` + `stalwart-mail` — load-bearing twice: re-opens the marketplace cards AND admits both through the #4364 funnel cart filter.

## Render-proof

A cart Org (`plan=m`, `cart=[wordpress, openclaw, stalwart-mail]`) now produces this per-Org gitops tree:

```
clusters/sov/tenants/acme/app-openclaw.yaml        # bp-openclaw HelmRelease + HelmRepository (HOST file)
clusters/sov/tenants/acme/app-stalwart-mail.yaml   # bp-stalwart-tenant HelmRelease + HelmRepository (HOST file)
clusters/sov/tenants/acme/apps/app-wordpress.yaml  # Deployment-shaped, unchanged
clusters/sov/tenants/acme/apps/db-mysql.yaml
clusters/sov/tenants/acme/kustomization.yaml       # enumerates app-openclaw.yaml + app-stalwart-mail.yaml
clusters/sov/tenants/acme/ingress.yaml             # routes wordpress only (HR apps own their HTTPRoute)
...
```

`app-openclaw.yaml` emits a `bp-openclaw` HelmRelease (chart `bp-openclaw`, version `*`, HR-level `kubeConfig` → `tenant-acme-kubeconfig` on the vcluster tier, `httpRoute` host `openclaw.acme.<parent>` parented to `cilium-gateway-console`). `app-stalwart-mail.yaml` emits a `bp-stalwart-tenant` HelmRelease with `disableWait: true`, `admin.externalSecret.enabled: false`, webmail host `mail.acme.<parent>` on the console Gateway.

## Tests

- `helmrelease_apps_test.go` — render-proof (both tiers), tier-aware kubeConfig (vcluster vs host), host-ingress exclusion, no-keycloak-dependsOn, stalwart live-converged settings, parent-domain hostnames + default fallback.
- `seed_test.go` — flipped `TestDeployableAppSlugs_OpenclawStalwartDisabled` → `...Enabled`; `StableShape` now expects both slugs.
- `go build` + `go test ./...` green on the catalog and provisioning modules.

## Close criteria

Code fix only — full close needs the apps to install + serve on a live funnel Org (a sibling walk agent handles the live 200). Leaving #4272 + #4307 at `status/uat`.

Refs #4272 #4307 #4364

🤖 Generated with [Claude Code](https://claude.com/claude-code)