### PR TITLE
fix(bp-catalyst-platform): revert NATS_URL to host-ns nats-system after #4291 de-vcluster — unwedge funnel org-services (1.4.850)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1109,7 +1109,11 @@ spec:
       # 1.4.847 — #4355: gitea repo-bootstrap hooks self-heal disk-vs-DB-drift
       #   repos (re-init main before branching) so a recovered-empty gitea never
       #   wedges the umbrella upgrade with BackoffLimitExceeded.
-      version: 1.4.849
+      # 1.4.850 — #4368 (Refs #3376 #4291 #4293): revert NATS_URL (org-services +
+      #   catalyst-api + projector) from the dead mgmt-vcluster-synced name back to
+      #   the host-ns `nats-jetstream.nats-system.svc` after #4291 de-vclustered
+      #   bp-nats-jetstream — unwedges the funnel (org-services CrashLoop on NATS).
+      version: 1.4.850
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3102,7 +3102,17 @@ name: bp-catalyst-platform
 #   re-inits `main` via the contents API before branching. Idempotent + bounded.
 #   lookup-source change; no new bootstrap state. Chart-version bump forces the
 #   Flux re-pull (deploy-bot mutable-tag trap). bootstrap-kit slot-13 lockstep.
-version: 1.4.849
+version: 1.4.850
+# 1.4.850 — #4368 (Refs #3376 #4291 #4293): revert the SME/org-services + catalyst-api
+#   NATS_URL from the dead mgmt-vcluster-synced name back to the host-ns Service.
+#   #4291/#4293 DE-VCLUSTERED bp-nats-jetstream into first-class host ns `nats-system`
+#   (placement.yaml: vcluster: host), but this chart's $defaultNATS (org-services
+#   configmap), services.projector.nats.url, and CATALYST_NATS_URL default kept
+#   pointing at `nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc` → NXDOMAIN
+#   (no mgmt vCluster) → every org-service (tenant/billing/provisioning/domain/
+#   notification) CrashLoops → funnel tenant.created never consumed → no Org CR.
+#   All four refs now dial `nats-jetstream.nats-system.svc.cluster.local:4222`.
+#   Chart-version bump forces the Flux re-pull; bootstrap-kit slot-13 lockstep.
 # 1.4.774 — #4082: application-controller ClusterRole gains dr.openova.io/continuums
 #   (get/list/watch/create/update/patch/delete) — was in the controller's own
 #   deploy/rbac.yaml but MISSING from this platform chart, so a singleton /
@@ -3213,7 +3223,7 @@ version: 1.4.849
 #   unsatisfiable on kom4dc (me-east-215-*), which kept the production
 #   Continuum seed unfireable. Backwards-compatible (all-letter labels
 #   still match). Flux CreateReplace flows it to live Sovereigns.
-appVersion: 1.4.849
+appVersion: 1.4.850
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/api-deployment-kustomize.yaml
+++ b/products/catalyst/chart/templates/api-deployment-kustomize.yaml
@@ -409,10 +409,12 @@ spec:
             # allowedPlatformNamespaces (see network-policies/
             # baseline-catalyst-system.yaml) so no extra CNP is needed.
             - name: CATALYST_NATS_URL
-              # G105 #2697 default flipped to the syncer-mangled name —
-              # post-G92.2 nats-jetstream runs INSIDE the mgmt vCluster
-              # and the host's `nats-system` namespace no longer exists.
-              value: '{{ .Values.catalystApi.natsURL | default "nats://nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc.cluster.local:4222" }}'
+              # #4368: #4291/#4293 DE-VCLUSTERED bp-nats-jetstream back into
+              # the first-class host ns `nats-system` (placement.yaml:
+              # `vcluster: host, namespace: nats-system`). The #2697 syncer-
+              # mangled mgmt name now returns NXDOMAIN (no mgmt vCluster);
+              # dial the host-ns Service directly.
+              value: '{{ .Values.catalystApi.natsURL | default "nats://nats-jetstream.nats-system.svc.cluster.local:4222" }}'
             # CATALYST_K8SCACHE_KUBECONFIGS_DIR — issue #321. Directory
             # the k8scache.Factory reads kubeconfigs from at startup.
             # The data-plane SharedInformerFactory opens one informer

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -482,10 +482,12 @@ spec:
             # allowedPlatformNamespaces (see network-policies/
             # baseline-catalyst-system.yaml) so no extra CNP is needed.
             - name: CATALYST_NATS_URL
-              # G105 #2697 default flipped to the syncer-mangled name —
-              # post-G92.2 nats-jetstream runs INSIDE the mgmt vCluster
-              # and the host's `nats-system` namespace no longer exists.
-              value: '{{ .Values.catalystApi.natsURL | default "nats://nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc.cluster.local:4222" }}'
+              # #4368: #4291/#4293 DE-VCLUSTERED bp-nats-jetstream back into
+              # the first-class host ns `nats-system` (placement.yaml:
+              # `vcluster: host, namespace: nats-system`). The #2697 syncer-
+              # mangled mgmt name now returns NXDOMAIN (no mgmt vCluster);
+              # dial the host-ns Service directly.
+              value: '{{ .Values.catalystApi.natsURL | default "nats://nats-jetstream.nats-system.svc.cluster.local:4222" }}'
             # CATALYST_K8SCACHE_KUBECONFIGS_DIR — issue #321. Directory
             # the k8scache.Factory reads kubeconfigs from at startup.
             # The data-plane SharedInformerFactory opens one informer

--- a/products/catalyst/chart/templates/org-services/configmap.yaml
+++ b/products/catalyst/chart/templates/org-services/configmap.yaml
@@ -60,24 +60,24 @@ Redpanda default so contabo's existing Organization consumers keep functioning.
   {{- /* Sovereign default: no Redpanda exists in cluster — leave empty
        so the Organization services skip the legacy Kafka transport entirely. */ -}}
   {{- $defaultBrokers = "" -}}
-  {{- /* Sovereign default NATS URL (#3376 funnel fix). #3373/#2697 moved
-       bp-nats-jetstream INSIDE the mgmt vCluster (placement.yaml:
-       `bp-nats-jetstream → vcluster: mgmt, namespace: nats-system`). The
-       bp-mgmt-vcluster syncer reflects the in-vCluster Service to the
-       HOST under the syncer-mangled name
-       `nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc`, so the
-       host `nats-system` namespace no longer carries a `nats-jetstream`
-       Service — the old default `nats-jetstream.nats-system.svc`
+  {{- /* Sovereign default NATS URL (#4368 funnel fix). HISTORY: #3373/#2697
+       once moved bp-nats-jetstream INSIDE the mgmt vCluster, exposing it on
+       the host under the syncer-mangled name
+       `nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc`. #4291/#4293
+       (DE-VCLUSTER, placement.yaml:
+       `bp-nats-jetstream → vcluster: host, target: host, namespace: nats-system`)
+       REVERTED that — the control-plane event bus is a platform plane, not a
+       tenant boundary, so it now runs in the FIRST-CLASS host namespace
+       `nats-system` and serves at `nats-jetstream.nats-system.svc.cluster.local`
+       again. There is no mgmt vCluster, so the old syncer-mangled name now
        resolves NXDOMAIN and EVERY Organization service (billing/tenant/
        provisioning/domain/notification) CrashLoops on `nats connect:
-       no such host`, wedging the funnel (measured live hw130
-       2026-06-13: provisioning Init:0/1, billing/tenant/domain/
-       notification CrashLoopBackOff). The catalyst-api/continuum config
-       (values.yaml catalystApi.nats.url) was already updated to the
-       synced name in #2697; the Organization default was missed in the move.
-       Align it here. Override via orgServices.eventBus.natsURL for a
-       host-placed NATS. */ -}}
-  {{- $defaultNATS = "nats://nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc.cluster.local:4222" -}}
+       no such host`, wedging the funnel (measured live omantel.biz kom4dc
+       2026-06-25: provisioning Init:0/1 + the others CrashLoopBackOff; the
+       catalyst-platform chart NATS refs were missed in the #4291 move).
+       Align it back to the host-ns name. Override via
+       orgServices.eventBus.natsURL for a differently-placed NATS. */ -}}
+  {{- $defaultNATS = "nats://nats-jetstream.nats-system.svc.cluster.local:4222" -}}
 {{- end -}}
 {{- $brokers := default $defaultBrokers (index (default (dict) .Values.orgServices.eventBus) "brokers") -}}
 {{- $natsURL := default $defaultNATS (index (default (dict) .Values.orgServices.eventBus) "natsURL") -}}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -2562,3 +2562,5 @@ migrations:
     dryRun: false
     serviceAccountName: catalyst-application-migrator
     image: ghcr.io/openova-io/catalyst-migrator:0.1.0
+
+# (#4368 ci-trigger touch — NATS host-ns revert; no value change)

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -821,7 +821,10 @@ controllers:
       # loops the env-controller.
       # 34ff594 (2026-06-21, #4053) — freshness sweep on the console-gateway-
       # isolation PR: 01db043 had drifted 437 commits behind latest GHCR.
-      tag: "895f961"
+      # 8c532a7 (2026-06-26, #4368 freshness sweep): 895f961 had drifted 223
+      # commits behind latest GHCR; the controller-image-tag-freshness gate
+      # (50-commit threshold) tripped on this PR's values.yaml touch.
+      tag: "8c532a7"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -873,7 +876,10 @@ controllers:
       # successful push-on-main build per Inviolable Principle #4a.
       # 34ff594 (2026-06-21, #4053) — freshness sweep on the console-gateway-
       # isolation PR: 01db043 had drifted 437 commits behind latest GHCR.
-      tag: "895f961"
+      # 8c532a7 (2026-06-26, #4368 freshness sweep): 895f961 had drifted 223
+      # commits behind latest GHCR; the controller-image-tag-freshness gate
+      # (50-commit threshold) tripped on this PR's values.yaml touch.
+      tag: "8c532a7"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -911,7 +917,10 @@ controllers:
       # 6d7aacd (2026-06-24, #4236) — freshness sweep on the funnel pool-DNS PR:
       # 34ff594 had drifted 183 commits behind latest GHCR (no code change here,
       # just clearing the staleness gate so the chart ships the current binary).
-      tag: "895f961"
+      # 8c532a7 (2026-06-26, #4368 freshness sweep): 895f961 had drifted 223
+      # commits behind latest GHCR; the controller-image-tag-freshness gate
+      # (50-commit threshold) tripped on this PR's values.yaml touch.
+      tag: "8c532a7"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -1126,16 +1135,18 @@ services:
     nats:
       # In-cluster NATS JetStream Service URL.
       #
-      # G105 #2697 (2026-06-01): post-G92.2 #2687, bp-nats-jetstream's
-      # HR carries `placementSchema.vcluster: mgmt` so the chart lives
-      # INSIDE the mgmt vCluster (Service `nats-jetstream.nats-system`
-      # in vCluster apiserver). The bp-mgmt-vcluster syncer reflects
-      # it to the host as the syncer-mangled name
-      # `nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc.cluster.local:4222`.
-      # Pre-G92.2 default `nats-jetstream.nats-system.svc.cluster.local:4222`
-      # returned NXDOMAIN because the `nats-system` namespace no longer
-      # exists on the host k3s.
-      url: "nats://nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc.cluster.local:4222"
+      # #4368 (2026-06-26): bp-nats-jetstream is now DE-VCLUSTERED. HISTORY:
+      # G105 #2697 once placed it INSIDE the mgmt vCluster, exposing it on the
+      # host under the syncer-mangled name
+      # `nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc`. #4291/#4293
+      # (DE-VCLUSTER, placement.yaml:
+      # `bp-nats-jetstream → vcluster: host, target: host, namespace: nats-system`)
+      # reverted that — the control-plane event bus is a platform plane, not a
+      # tenant boundary, so it runs in the first-class host ns `nats-system`
+      # and serves at `nats-jetstream.nats-system.svc.cluster.local:4222` again.
+      # The mgmt-synced name now returns NXDOMAIN (no mgmt vCluster), so the
+      # SME services + catalyst-api/continuum must dial the host-ns name.
+      url: "nats://nats-jetstream.nats-system.svc.cluster.local:4222"
       stream: "catalyst.events"
       subject: "catalyst.events.>"
     valkey:


### PR DESCRIPTION
## Problem
On live omantel.biz (kom4dc, dep `4635277cae4ffed9`) every org-services microservice (`tenant`/`billing`/`provisioning`/`domain`/`notification`) CrashLoops:

```
ERROR failed to connect to NATS url=nats://nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc.cluster.local:4222
  error="nats connect: dial tcp: lookup ...mgmt.svc.cluster.local: no such host"
```

`provisioning` is the marketplace FUNNEL door's `tenant.created` → `Organization` CR producer. With it down, a fresh voucher signup never produces an Org CR → the **#3376 funnel terminal walk dead-ends at checkout**.

## Root cause (verified live)
`#4291`/`#4293` **de-vclustered** `bp-nats-jetstream` out of the mgmt vCluster back into the first-class host ns `nats-system` — `clusters/_template/bootstrap-kit/placement.yaml:167` now reads `vcluster: host, target: host, namespace: nats-system`. NATS serves at `nats-jetstream.nats-system.svc.cluster.local:4222` again, and there is no mgmt vCluster on the Sovereign.

But the `bp-catalyst-platform` chart's NATS_URL defaults were missed in that move and still point at the now-dead mgmt-vcluster-synced name. Probed live from `org-pg-1`:
- `nats-jetstream.nats-system.svc.cluster.local` → ClusterIP `10.96.187.208` (exit 0)
- `nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc.cluster.local` → NXDOMAIN (exit 2)

Live `org-services-config` ConfigMap (Helm-rendered) carried the dead name.

## Fix
Revert all four chart NATS refs to the host-ns Service `nats://nats-jetstream.nats-system.svc.cluster.local:4222`:
- `templates/org-services/configmap.yaml` — `$defaultNATS` (renders `org-services-config` `NATS_URL`)
- `values.yaml` — `services.projector.nats.url`
- `templates/api-deployment.yaml` + `templates/api-deployment-kustomize.yaml` — `CATALYST_NATS_URL` default

Chart `1.4.849 → 1.4.850` (forces Flux re-pull past the deploy-bot mutable-tag trap), bootstrap-kit slot-13 pin in lockstep. Render green on both Sovereign + Catalyst-Zero topologies. Mirror-image of #3407 (which moved the URL INTO the mgmt vCluster).

## Out of this change (follow-up)
The same #4291 de-vcluster left the chart's **keycloak** host-bridge (`keycloakHostBridge.keycloakAddr` / `bitnamiSecretName`) and **mimir** URL pointing at mgmt-synced names too. Those do NOT block the funnel sign-in (org-handover returns 401 not 5xx on a live org host; keycloak-0 is Running), so they are left for the dedicated de-vcluster remediation train (#4344/#4347/#4367) to avoid colliding with in-flight work.

## DoD
- [x] Chart render green (Sovereign + Catalyst-Zero); no active NATS ref points at the mgmt-synced name
- [ ] Post-roll: org-services pods `1/1 Running` (no NATS CrashLoop); live #3376 funnel terminal walk (voucher-redeem UI → signed-in own console)

Refs #3376 #4368 #4291 #4293