### PR TITLE
fix(catalyst): org-services NATS_URL default → host nats-system, not dead mgmt-vcluster mangled name (1.4.850)

### DIFF
--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3102,7 +3102,19 @@ name: bp-catalyst-platform
 #   re-inits `main` via the contents API before branching. Idempotent + bounded.
 #   lookup-source change; no new bootstrap state. Chart-version bump forces the
 #   Flux re-pull (deploy-bot mutable-tag trap). bootstrap-kit slot-13 lockstep.
-version: 1.4.849
+# 1.4.850 — #4373: org-services NATS_URL default re-pointed from the dead
+#   mgmt-vcluster-syncer-mangled name
+#   (`nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc`) back to the plain
+#   host name `nats-jetstream.nats-system.svc`. The de-vcluster re-home
+#   (#4325/#4347/#4348) moved bp-nats-jetstream BACK to the host `nats-system`
+#   ns; the mgmt vCluster + its mangled syncer Service no longer exist, so the
+#   mangled default resolved NXDOMAIN → org-services/provisioning CrashLooped on
+#   `nats connect: no such host`, wedging #4364's funnel-cart install (live
+#   kom4dc/omantel.biz dep 4635277cae4ffed9, 2026-06-26). Fixed in 4 places:
+#   org-services/configmap.yaml ($defaultNATS), values.yaml (catalystApi.nats.url),
+#   api-deployment.yaml + api-deployment-kustomize.yaml (CATALYST_NATS_URL default).
+#   Config-default-only change; no new bootstrap state. Refs #4325 #4347 #4322.
+version: 1.4.850
 # 1.4.774 — #4082: application-controller ClusterRole gains dr.openova.io/continuums
 #   (get/list/watch/create/update/patch/delete) — was in the controller's own
 #   deploy/rbac.yaml but MISSING from this platform chart, so a singleton /

--- a/products/catalyst/chart/templates/api-deployment-kustomize.yaml
+++ b/products/catalyst/chart/templates/api-deployment-kustomize.yaml
@@ -412,7 +412,7 @@ spec:
               # G105 #2697 default flipped to the syncer-mangled name —
               # post-G92.2 nats-jetstream runs INSIDE the mgmt vCluster
               # and the host's `nats-system` namespace no longer exists.
-              value: '{{ .Values.catalystApi.natsURL | default "nats://nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc.cluster.local:4222" }}'
+              value: '{{ .Values.catalystApi.natsURL | default "nats://nats-jetstream.nats-system.svc.cluster.local:4222" }}'
             # CATALYST_K8SCACHE_KUBECONFIGS_DIR — issue #321. Directory
             # the k8scache.Factory reads kubeconfigs from at startup.
             # The data-plane SharedInformerFactory opens one informer

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -485,7 +485,7 @@ spec:
               # G105 #2697 default flipped to the syncer-mangled name —
               # post-G92.2 nats-jetstream runs INSIDE the mgmt vCluster
               # and the host's `nats-system` namespace no longer exists.
-              value: '{{ .Values.catalystApi.natsURL | default "nats://nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc.cluster.local:4222" }}'
+              value: '{{ .Values.catalystApi.natsURL | default "nats://nats-jetstream.nats-system.svc.cluster.local:4222" }}'
             # CATALYST_K8SCACHE_KUBECONFIGS_DIR — issue #321. Directory
             # the k8scache.Factory reads kubeconfigs from at startup.
             # The data-plane SharedInformerFactory opens one informer

--- a/products/catalyst/chart/templates/org-services/configmap.yaml
+++ b/products/catalyst/chart/templates/org-services/configmap.yaml
@@ -60,24 +60,20 @@ Redpanda default so contabo's existing Organization consumers keep functioning.
   {{- /* Sovereign default: no Redpanda exists in cluster — leave empty
        so the Organization services skip the legacy Kafka transport entirely. */ -}}
   {{- $defaultBrokers = "" -}}
-  {{- /* Sovereign default NATS URL (#3376 funnel fix). #3373/#2697 moved
-       bp-nats-jetstream INSIDE the mgmt vCluster (placement.yaml:
-       `bp-nats-jetstream → vcluster: mgmt, namespace: nats-system`). The
-       bp-mgmt-vcluster syncer reflects the in-vCluster Service to the
-       HOST under the syncer-mangled name
-       `nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc`, so the
-       host `nats-system` namespace no longer carries a `nats-jetstream`
-       Service — the old default `nats-jetstream.nats-system.svc`
-       resolves NXDOMAIN and EVERY Organization service (billing/tenant/
-       provisioning/domain/notification) CrashLoops on `nats connect:
-       no such host`, wedging the funnel (measured live hw130
-       2026-06-13: provisioning Init:0/1, billing/tenant/domain/
-       notification CrashLoopBackOff). The catalyst-api/continuum config
-       (values.yaml catalystApi.nats.url) was already updated to the
-       synced name in #2697; the Organization default was missed in the move.
-       Align it here. Override via orgServices.eventBus.natsURL for a
-       host-placed NATS. */ -}}
-  {{- $defaultNATS = "nats://nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc.cluster.local:4222" -}}
+  {{- /* Sovereign default NATS URL. HISTORY: #3373/#2697 moved
+       bp-nats-jetstream INSIDE the mgmt vCluster, so the default pointed at
+       the syncer-mangled host name
+       `nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc`. The de-vcluster
+       re-home (#4325/#4347/#4348) moved bp-nats-jetstream BACK to the HOST
+       `nats-system` namespace: the mgmt vCluster + its `mgmt` namespace + the
+       mangled syncer Service no longer exist, so the mangled default resolves
+       NXDOMAIN and `org-services/provisioning` CrashLoops on
+       `nats connect: dial tcp: lookup ...-mgmt-vcluster... no such host`,
+       wedging #4364's funnel-cart install (measured live kom4dc/omantel.biz
+       dep 4635277cae4ffed9, 2026-06-26; #4373). NATS again resolves at the
+       plain host name `nats-jetstream.nats-system.svc`. Override via
+       orgServices.eventBus.natsURL for a different placement. */ -}}
+  {{- $defaultNATS = "nats://nats-jetstream.nats-system.svc.cluster.local:4222" -}}
 {{- end -}}
 {{- $brokers := default $defaultBrokers (index (default (dict) .Values.orgServices.eventBus) "brokers") -}}
 {{- $natsURL := default $defaultNATS (index (default (dict) .Values.orgServices.eventBus) "natsURL") -}}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -1126,16 +1126,14 @@ services:
     nats:
       # In-cluster NATS JetStream Service URL.
       #
-      # G105 #2697 (2026-06-01): post-G92.2 #2687, bp-nats-jetstream's
-      # HR carries `placementSchema.vcluster: mgmt` so the chart lives
-      # INSIDE the mgmt vCluster (Service `nats-jetstream.nats-system`
-      # in vCluster apiserver). The bp-mgmt-vcluster syncer reflects
-      # it to the host as the syncer-mangled name
-      # `nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc.cluster.local:4222`.
-      # Pre-G92.2 default `nats-jetstream.nats-system.svc.cluster.local:4222`
-      # returned NXDOMAIN because the `nats-system` namespace no longer
-      # exists on the host k3s.
-      url: "nats://nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc.cluster.local:4222"
+      # HISTORY: G105 #2697 placed bp-nats-jetstream INSIDE the mgmt vCluster,
+      # so this pointed at the syncer-mangled host name
+      # `nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc`. The de-vcluster
+      # re-home (#4325/#4347/#4348) moved bp-nats-jetstream BACK to the HOST
+      # `nats-system` namespace — the mgmt vCluster, its `mgmt` namespace, and
+      # the mangled syncer Service no longer exist, so the mangled name now
+      # returns NXDOMAIN (#4373). NATS again resolves at the plain host name.
+      url: "nats://nats-jetstream.nats-system.svc.cluster.local:4222"
       stream: "catalyst.events"
       subject: "catalyst.events.>"
     valkey:


### PR DESCRIPTION
## Problem

The org-services NATS default still pointed at the mgmt-vcluster-syncer-mangled name `nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc.cluster.local:4222` (set when bp-nats-jetstream lived inside the mgmt vCluster — #2697/#3376). The de-vcluster re-home (#4325/#4347/#4348) moved bp-nats-jetstream BACK to the host `nats-system` namespace. The mgmt vCluster, its `mgmt` namespace, and the mangled syncer Service no longer exist → the mangled default resolves NXDOMAIN:

```
ERROR failed to connect to NATS url=nats://nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc.cluster.local:4222
  error="nats connect: dial tcp: lookup ...-mgmt-vcluster... no such host"
```

→ `org-services/provisioning` CrashLoopBackOff (live kom4dc/omantel.biz dep `4635277cae4ffed9`, 2026-06-26). #4364's `dispatchFunnelCartInstall` fires `tenant.app_install_requested` + `/provisioning/apps/install` at a DOWN provisioning service → funnel cart apps never commit → #4322 cannot land.

Live cluster confirms NATS now runs on the host: `nats-jetstream-{0,1,2}` in `nats-system`, Service `nats-jetstream.nats-system.svc.cluster.local:4222`; no mangled service, no `mgmt` namespace.

## Fix

Re-point the NATS default to the plain host name in all 4 places:
- `products/catalyst/chart/templates/org-services/configmap.yaml` (`$defaultNATS`)
- `products/catalyst/chart/values.yaml` (`catalystApi.nats.url`)
- `products/catalyst/chart/templates/api-deployment.yaml` (`CATALYST_NATS_URL` default)
- `products/catalyst/chart/templates/api-deployment-kustomize.yaml` (`CATALYST_NATS_URL` default)

Chart 1.4.849 → 1.4.850.

Refs #4373 #4325 #4347 #4322

🤖 Generated with [Claude Code](https://claude.com/claude-code)