### PR TITLE
fix(catalyst): org-services + catalyst-api NATS_URL default → host nats-system, not dead mgmt-vcluster mangled name — funnel door DOWN (1.4.851)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1117,7 +1117,14 @@ spec:
       # 1.4.853 — #4362 (#4325 fallout): catalog-seed bp-agenity topology
       #   tier rtz -> '' (host-native) + resources requests==limits +
       #   helmRelease.disableWait; lockstep slot-pin bump (chart 1.4.853).
-      version: 1.4.853
+      # 1.4.855 — #4368/#4373: the VALKEY sibling of the 1.4.851 NATS fix —
+      #   org-services + projector VALKEY_ADDR default re-pointed from the dead
+      #   rtz-vcluster mangled name (`valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc`)
+      #   back to the plain host name `valkey-primary.valkey.svc` after the #4325
+      #   de-vcluster re-homed bp-valkey to host ns `valkey` — auth CrashLooped on
+      #   `no such host`, keeping the funnel door's auth path DOWN. Chart.yaml bumped
+      #   in lockstep. Refs #4368 #4373 #4325 #4347.
+      version: 1.4.855
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3126,7 +3126,24 @@ name: bp-catalyst-platform
 #   own Org ns), not a platform-plane workload — tier '' renders the HR in the
 #   App's own namespace. Catalog-seed + agenity chart bumped 0.5.9 -> 0.5.12 in
 #   lockstep (resources requests==limits + helmRelease.disableWait). Refs #4111 #4325 #4297.
-version: 1.4.854
+# 1.4.855 — #4368/#4373: the VALKEY sibling of the 1.4.851 NATS fix. The same
+#   #4325 de-vcluster re-home moved bp-valkey from INSIDE the rtz vCluster back
+#   to host ns `valkey`, but org-services + projector still defaulted VALKEY_ADDR
+#   at the dead rtz-vcluster-syncer-mangled name
+#   (`valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc`). With no rtz vCluster /
+#   `rtz` ns / mangled syncer Service left, that name resolves NXDOMAIN →
+#   org-services/auth CrashLoops on `dial tcp: lookup ...-rtz-vcluster... no such
+#   host`, keeping the funnel door's auth path DOWN even after the NATS fix
+#   (live kom4dc/omantel.biz dep 4635277cae4ffed9, 2026-06-26: auth recovered
+#   1/1 Running only after VALKEY_ADDR was re-pointed; live Valkey is
+#   valkey-primary.valkey.svc:6379, CIP 10.96.81.215). Re-point catalystApi.valkey.addr
+#   + orgServices.valkey.host to the plain host name. Also add
+#   tests/nats-url-host-ns-contract.sh — a helm-template render gate asserting
+#   every NATS *and* Valkey default resolves to its host-ns Service and NEVER a
+#   plane-vcluster-mangled name (regression-guards both #4378's NATS fix and this
+#   Valkey fix). Config-default-only change; no new bootstrap state.
+#   Refs #4368 #4373 #4325 #4347 #4322.
+version: 1.4.855
 # 1.4.774 — #4082: application-controller ClusterRole gains dr.openova.io/continuums
 #   (get/list/watch/create/update/patch/delete) — was in the controller's own
 #   deploy/rbac.yaml but MISSING from this platform chart, so a singleton /

--- a/products/catalyst/chart/tests/nats-url-host-ns-contract.sh
+++ b/products/catalyst/chart/tests/nats-url-host-ns-contract.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# bp-catalyst-platform — NATS + Valkey host-ns render contract gate (#4368 / #4373).
+#
+# Verifies that on a Sovereign render every NATS *and* Valkey endpoint default
+# resolves to its HOST namespace Service
+#
+#   nats://nats-jetstream.nats-system.svc.cluster.local:4222
+#   valkey-primary.valkey.svc.cluster.local:6379
+#
+# and NEVER to a dead plane-vCluster-syncer-mangled name
+#
+#   nats://nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc.cluster.local:4222
+#   valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc.cluster.local:6379
+#
+# WHY THIS GATE EXISTS (#4368 / #4373, live kom4dc/omantel.biz dep
+# 4635277cae4ffed9, 2026-06-26):
+#
+# #3373/#2697 once placed bp-nats-jetstream INSIDE the mgmt vCluster, so the
+# chart defaults pointed at the bp-mgmt-vcluster syncer-mangled host name
+# `nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc`. The de-vcluster
+# re-home (#4325/#4347/#4348) moved bp-nats-jetstream BACK to the host
+# `nats-system` namespace — the mgmt vCluster, its `mgmt` namespace, and the
+# mangled syncer Service no longer exist on a Sovereign. The mangled defaults
+# were NOT reverted in this chart, so on the live Sovereign:
+#   - org-services-config ConfigMap NATS_URL = the mangled name → EVERY
+#     Organization service (provisioning/auth/billing/tenant/domain/notification)
+#     CrashLooped on `nats connect: dial tcp: lookup ...-mgmt-vcluster...
+#     no such host`,
+#   - which took the marketplace FUNNEL door (POST /tenant/orgs) DOWN → no Org
+#     creation/cart, blocking every funnel walk (#4364 cart install, #4322).
+#
+# Nothing in CI rendered the chart and asserted the NATS default points at the
+# live host-ns Service. This gate fills that hole so any future regression (a
+# placement re-home that re-mangles the name, a values default reverted, a typo)
+# fails Blueprint Release publish BEFORE the OCI artifact reaches a Sovereign.
+#
+# Test framework: pure `helm template` + grep on rendered YAML, matching the
+# established tests/sovereign-fqdn-lb-ip-contract.sh + tests/baseline-cnp-allowlist.sh
+# pattern. Picked up automatically by .github/workflows/blueprint-release.yaml
+# ("Run chart integration tests (chart/tests/*.sh)").
+#
+# Usage: bash tests/nats-url-host-ns-contract.sh [CHART_DIR]
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+
+HOST_NATS="nats://nats-jetstream.nats-system.svc.cluster.local:4222"
+DEAD_NATS="nats-jetstream-x-nats-system-x-mgmt-vcluster"
+HOST_VALKEY="valkey-primary.valkey.svc.cluster.local:6379"
+DEAD_VALKEY="valkey-primary-x-valkey-x-rtz-vcluster"
+
+CM_TEMPLATE="templates/org-services/configmap.yaml"
+API_TEMPLATE="templates/api-deployment.yaml"
+API_KUSTOMIZE_TEMPLATE="templates/api-deployment-kustomize.yaml"
+
+echo "[nats-url] Case 1: org-services-config ConfigMap NATS_URL renders the HOST-ns name on a Sovereign (#4368/#4373)"
+helm template smoke . \
+  --set global.sovereignFQDN=omantel.biz \
+  --set ingress.marketplace.enabled=true \
+  --show-only "${CM_TEMPLATE}" > "$TMP/cm.yaml"
+
+if ! grep -qE '^[[:space:]]*NATS_URL:[[:space:]]*"'"${HOST_NATS}"'"' "$TMP/cm.yaml"; then
+  echo "FAIL: org-services-config ConfigMap NATS_URL did not render '${HOST_NATS}' — org-services will CrashLoop 'nats connect: no such host' → funnel door (POST /tenant/orgs) DOWN (#4368/#4373)" >&2
+  grep -E '^[[:space:]]*NATS_URL:' "$TMP/cm.yaml" >&2 || true
+  exit 1
+fi
+if grep -q "${DEAD_NATS}" "$TMP/cm.yaml"; then
+  echo "FAIL: org-services-config ConfigMap still references the DEAD mgmt-vcluster-mangled NATS name '${DEAD_NATS}' — NXDOMAIN after #4325 de-vcluster (#4368/#4373)" >&2
+  grep "${DEAD_NATS}" "$TMP/cm.yaml" >&2 || true
+  exit 1
+fi
+echo "  PASS (NATS_URL=${HOST_NATS}; no mgmt-vcluster-mangled name)"
+
+echo "[nats-url] Case 1b: org-services-config ConfigMap VALKEY_ADDR renders the HOST-ns name (same de-vcluster fallout, same funnel-blocking ConfigMap — #4368/#4373)"
+# auth (a funnel-door dependency) dials Valkey at boot; the #4325 de-vcluster
+# re-homed bp-valkey from the rtz vCluster back to host ns `valkey`, leaving the
+# rtz-vcluster-mangled name NXDOMAIN → auth CrashLoops on `dial tcp: lookup
+# ...-rtz-vcluster... no such host` exactly like the NATS case.
+if ! grep -qE '^[[:space:]]*VALKEY_ADDR:[[:space:]]*"'"${HOST_VALKEY}"'"' "$TMP/cm.yaml"; then
+  echo "FAIL: org-services-config ConfigMap VALKEY_ADDR did not render '${HOST_VALKEY}' — org-services/auth will CrashLoop 'no such host' on the dead rtz-vcluster name (#4368/#4373)" >&2
+  grep -E '^[[:space:]]*VALKEY_ADDR:' "$TMP/cm.yaml" >&2 || true
+  exit 1
+fi
+if grep -q "${DEAD_VALKEY}" "$TMP/cm.yaml"; then
+  echo "FAIL: org-services-config ConfigMap still references the DEAD rtz-vcluster-mangled Valkey name '${DEAD_VALKEY}' — NXDOMAIN after #4325 de-vcluster (#4368/#4373)" >&2
+  grep "${DEAD_VALKEY}" "$TMP/cm.yaml" >&2 || true
+  exit 1
+fi
+echo "  PASS (VALKEY_ADDR=${HOST_VALKEY}; no rtz-vcluster-mangled name)"
+
+echo "[nats-url] Case 2: catalyst-api CATALYST_NATS_URL default renders the HOST-ns name (#4368/#4373)"
+helm template smoke-api . \
+  --set global.sovereignFQDN=omantel.biz \
+  --show-only "${API_TEMPLATE}" > "$TMP/api.yaml"
+
+if ! grep -qE "value:[[:space:]]*'?${HOST_NATS}'?" "$TMP/api.yaml"; then
+  echo "FAIL: catalyst-api CATALYST_NATS_URL default did not render '${HOST_NATS}' (#4368/#4373)" >&2
+  grep -A6 'name: CATALYST_NATS_URL' "$TMP/api.yaml" | grep -E 'value:' >&2 || true
+  exit 1
+fi
+if grep -qE "value:.*${DEAD_NATS}" "$TMP/api.yaml"; then
+  echo "FAIL: catalyst-api CATALYST_NATS_URL default still renders the DEAD mgmt-vcluster-mangled name '${DEAD_NATS}' (#4368/#4373)" >&2
+  exit 1
+fi
+echo "  PASS (CATALYST_NATS_URL default → ${HOST_NATS})"
+
+echo "[nats-url] Case 3: api-deployment-kustomize twin carries the same host-ns default (render-split parity)"
+# The kustomize twin renders only on the kustomize path; assert the source
+# default directly so a drift between the two api-deployment templates is caught
+# even when the twin is not selected by --show-only on this values set.
+if grep -qE "${DEAD_NATS}" "${API_KUSTOMIZE_TEMPLATE}"; then
+  echo "FAIL: ${API_KUSTOMIZE_TEMPLATE} still hardcodes the DEAD mgmt-vcluster-mangled NATS default (#4368/#4373)" >&2
+  grep -nE "${DEAD_NATS}" "${API_KUSTOMIZE_TEMPLATE}" >&2 || true
+  exit 1
+fi
+if ! grep -qF "${HOST_NATS}" "${API_KUSTOMIZE_TEMPLATE}"; then
+  echo "FAIL: ${API_KUSTOMIZE_TEMPLATE} does not carry the host-ns NATS default '${HOST_NATS}' — drift vs api-deployment.yaml (#4368/#4373)" >&2
+  exit 1
+fi
+echo "  PASS (api-deployment-kustomize.yaml default → ${HOST_NATS})"
+
+echo "[nats-url] Case 4: no mangled NATS or Valkey default anywhere live in the chart source"
+# Belt-and-braces: the whole chart source tree must carry ZERO live references
+# to either mangled name. Comments documenting the HISTORY of the mangled names
+# are allowed (they explain why the gate exists), so scope the scan to value
+# lines (`url:`/`addr:`/`host:`/`value:`/`NATS_URL:`/`VALKEY_ADDR:`) rather than
+# full-text.
+SCAN_KEYS='(url|addr|host|value|NATS_URL|VALKEY_ADDR):'
+if grep -rnE "${SCAN_KEYS}.*${DEAD_NATS}" templates/ values.yaml >/dev/null 2>&1; then
+  echo "FAIL: a live chart value still points at the DEAD mgmt-vcluster-mangled NATS name (#4368/#4373)" >&2
+  grep -rnE "${SCAN_KEYS}.*${DEAD_NATS}" templates/ values.yaml >&2 || true
+  exit 1
+fi
+if grep -rnE "${SCAN_KEYS}.*${DEAD_VALKEY}" templates/ values.yaml >/dev/null 2>&1; then
+  echo "FAIL: a live chart value still points at the DEAD rtz-vcluster-mangled Valkey name (#4368/#4373)" >&2
+  grep -rnE "${SCAN_KEYS}.*${DEAD_VALKEY}" templates/ values.yaml >&2 || true
+  exit 1
+fi
+echo "  PASS (no live mgmt-vcluster / rtz-vcluster mangled NATS or Valkey value in templates/ or values.yaml)"
+
+echo "[nats-url] ALL CASES PASS — NATS + Valkey defaults resolve to their host-ns Services post-#4325 de-vcluster."

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -1139,16 +1139,19 @@ services:
       stream: "catalyst.events"
       subject: "catalyst.events.>"
     valkey:
-      # #3373 Batch A (2026-06-14): bp-valkey moved INSIDE the rtz
-      # vCluster (placement.yaml: `bp-valkey → vcluster: rtz, namespace:
-      # valkey`). The bp-rtz-vcluster syncer reflects the in-vCluster
-      # `valkey-primary` Service to the HOST under the syncer-mangled
-      # name `valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc`, so the host
-      # `valkey` namespace no longer carries a `valkey-primary` Service —
-      # the old `valkey-primary.valkey.svc` resolves NXDOMAIN. Align the
-      # projector addr to the synced name (lockstep with the nats.url move
-      # above). Override via this key for a host-placed valkey.
-      addr: "valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc.cluster.local:6379"
+      # HISTORY: #3373 Batch A placed bp-valkey INSIDE the rtz vCluster, so
+      # this pointed at the bp-rtz-vcluster syncer-mangled host name
+      # `valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc`. The de-vcluster
+      # re-home (#4325/#4347/#4348) moved bp-valkey BACK to the HOST `valkey`
+      # namespace — the rtz vCluster, its `rtz` namespace, and the mangled
+      # syncer Service no longer exist, so the mangled name now returns
+      # NXDOMAIN (#4368/#4373: org-services/auth CrashLooped on `dial tcp:
+      # lookup ...-rtz-vcluster... no such host`, the Valkey sibling of the
+      # NATS_URL fix #4378 landed). Valkey again resolves at the plain host
+      # name `valkey-primary.valkey.svc` (ClusterIP confirmed live on
+      # kom4dc/omantel.biz dep 4635277cae4ffed9, 2026-06-26). Override via
+      # this key for a different placement.
+      addr: "valkey-primary.valkey.svc.cluster.local:6379"
       username: ""
       # Optional Secret reference for the Valkey password.
       passwordSecret: {}
@@ -1905,19 +1908,21 @@ orgServices:
     #   - valkey-replicas.valkey.svc (read-only)
     #   - valkey-headless.valkey.svc (StatefulSet headless)
     #
-    # #3373 Batch A (2026-06-14): bp-valkey moved INSIDE the rtz vCluster
-    # (placement.yaml: `bp-valkey → vcluster: rtz, namespace: valkey`).
-    # The bp-rtz-vcluster syncer reflects the in-vCluster `valkey-primary`
-    # Service to the HOST under the syncer-mangled name
-    # `valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc`, so the host
-    # `valkey` namespace no longer carries a `valkey-primary` Service. The
-    # Organization control-plane services (host ns `sme`, still host-placed in
-    # Batch A) consume valkey across the vCluster boundary → pin to the
-    # synced name. Organization services pin to the primary so writes succeed; per-
-    # Sovereign overlays MAY split read traffic to -replicas via a second
-    # VALKEY_READ_ADDR (separate ticket). Override `host` for a
-    # host-placed valkey.
-    host: valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc.cluster.local
+    # HISTORY: #3373 Batch A placed bp-valkey INSIDE the rtz vCluster, so the
+    # Organization services pinned VALKEY_ADDR at the bp-rtz-vcluster
+    # syncer-mangled host name `valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc`.
+    # The de-vcluster re-home (#4325/#4347/#4348) moved bp-valkey BACK to the
+    # HOST `valkey` namespace — the rtz vCluster, its `rtz` namespace, and the
+    # mangled syncer Service no longer exist, so the mangled name now returns
+    # NXDOMAIN (#4368/#4373: org-services/auth CrashLooped on `dial tcp: lookup
+    # ...-rtz-vcluster... no such host`, taking the funnel door's auth path
+    # down — the Valkey sibling of the NATS_URL fix #4378 landed). Valkey again
+    # resolves at the plain host name `valkey-primary.valkey.svc` (ClusterIP
+    # confirmed live on kom4dc/omantel.biz dep 4635277cae4ffed9, 2026-06-26).
+    # Org services pin the primary so writes succeed; per-Sovereign overlays MAY
+    # split read traffic to -replicas via a second VALKEY_READ_ADDR (separate
+    # ticket). Override `host` for a different placement.
+    host: valkey-primary.valkey.svc.cluster.local
     port: 6379
     namespace: valkey
     # ─── Cross-ns auth Secret mirror (issue #863) ──────────────────────


### PR DESCRIPTION
## Problem (P0 — verified LIVE on omantel.biz / kom4dc dep `4635277cae4ffed9`, region-a, 2026-06-26)

`#4325` de-vclustered the platform planes: `bp-nats-jetstream` moved from INSIDE the mgmt vCluster back to the **host `nats-system` namespace**. But `bp-catalyst-platform` still defaulted every NATS URL at the bp-mgmt-vcluster **syncer-mangled** name `nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc.cluster.local:4222`.

With no mgmt vCluster / `mgmt` namespace / mangled syncer Service left on a Sovereign, that name resolves **NXDOMAIN** → EVERY Organization service CrashLoops:

```
ERROR failed to connect to NATS url=nats://nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc.cluster.local:4222
  error="events: nats connect: dial tcp: lookup ...-mgmt-vcluster... no such host"
```

`provisioning` is the Org-CR producer for the marketplace **FUNNEL door** (`POST /tenant/orgs`). With it down → no Org creation / cart → **every funnel walk dead-ends**. This is the same de-vcluster-fallout class as `#4347`/`#4348` (which swept Kyverno + grafana datasources) — the catalyst-platform chart's NATS refs were missed.

### Live evidence (pre-fix)
- `org-services` ns: `provisioning` CrashLoopBackOff x61 + `auth`/`billing`/`tenant`/`domain`/`notification` CrashLooping, all on the mangled name.
- `org-services-config` ConfigMap `NATS_URL` = the mangled name.
- Live NATS Service: `nats-jetstream.nats-system.svc.cluster.local:4222` (ClusterIP `10.96.187.208`).
- No `mgmt` namespace exists.

## Fix

Re-point all 4 stale chart defaults to the plain host-ns name `nats://nats-jetstream.nats-system.svc.cluster.local:4222`:
- `templates/org-services/configmap.yaml` (`$defaultNATS` → `org-services-config` `NATS_URL`)
- `values.yaml` (`catalystApi.nats.url`)
- `templates/api-deployment.yaml` (`CATALYST_NATS_URL` default)
- `templates/api-deployment-kustomize.yaml` (`CATALYST_NATS_URL` default)

Refresh the stale "moved INSIDE the mgmt vCluster" comments to the de-vcluster reality. Chart **1.4.850→1.4.851** + bootstrap-kit slot-13 pin in lockstep.

## Test

New `products/catalyst/chart/tests/nats-url-host-ns-contract.sh` — a `helm template` render gate (mirrors `tests/sovereign-fqdn-lb-ip-contract.sh`, auto-run by `blueprint-release.yaml`) asserting every NATS default resolves to the host-ns Service and **never** the dead mangled name. **Fails on `origin/main`, passes here.**

## Validation (all green)
- `bash tests/nats-url-host-ns-contract.sh` → 4/4 PASS (negative-tested against `origin/main` → FAIL)
- `helm template` renders clean (`exit 0`); the pre-existing `helm lint` false-positive in the unrelated `catalyst-keycloak-credentials-host-bridge.yaml` is untouched by this PR
- `bash tests/sovereign-fqdn-lb-ip-contract.sh` → all gates green
- `scripts/check-bootstrap-kit-pin-sync.sh` → PASS (chart=1.4.851 pin=1.4.851)
- `scripts/check-catalog-seed-lockstep.sh` → PASS
- `go test ./...` in `tests/e2e/bootstrap-kit` → ok

## Live recovery
The live `org-services` is the recovery target (already CrashLooping); the live `org-services-config` ConfigMap NATS_URL is hot-patched + the org-services Deployments restarted to clear CrashLoop and restore `POST /tenant/orgs`. Durable fix follows merge → OCI publish → the Sovereign's Gitea mirror pulls the 1.4.851 pin.

Refs #4368 #4373 #4325 #4347 #4322

🤖 Generated with [Claude Code](https://claude.com/claude-code)