### PR TITLE
fix(bp-gitea): gitdata-preservation guard image → harbor-proxy form (Kyverno admits the pre-upgrade hook) — 1.2.44

### DIFF
--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -168,7 +168,13 @@ spec:
       #   the host PVC via volumeName) so the re-home rides the SAME git-data volume,
       #   NO-OPs on a fresh prov, and FAILS LOUD when the DB reports repos but no PV
       #   can be adopted — no silent empty boot. Refs #4354 #4325 #4353 #4352.
-      version: 1.2.43
+      # 1.2.44 — #4369: the 1.2.43 guard Job defaulted its kubectl image to a BARE
+      #   docker.io ref → the cluster-wide Kyverno harbor-proxy-pull Enforce policy
+      #   (admits `*/proxy-*/*` or `*/openova-io/*`) DENIED the pre-upgrade hook Job
+      #   at admission → pre-upgrade gate failed → bp-gitea HR rollback-looped and
+      #   stranded bp-catalyst-platform / bp-continuum / bp-sandbox. Fix: default the
+      #   guard image to the harbor-proxy form. Refs #4369 #4367 #4354.
+      version: 1.2.44
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.43
+  version: 1.2.44
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -174,7 +174,19 @@ name: bp-gitea
 #   so the silent empty boot can never recur. Gated `gitDataMigration.enabled`
 #   (default true; safe no-op when no prior state). Adds
 #   tests/gitdata-preservation-guard.sh (CI gate). Refs #4354 #4325 #4353 #4352.
-version: 1.2.43
+# 1.2.44 (#4369, Refs #4367 #4354): the 1.2.43 gitdata-preservation guard Job
+#   defaulted its kubectl image to a BARE `bitnamilegacy/kubectl:1.30.7`
+#   (docker.io) ref. On a converged Sovereign the cluster-wide Kyverno
+#   `harbor-proxy-pull` Enforce policy admits ONLY `*/proxy-*/*` (proxy-cache) or
+#   `*/openova-io/*` (native-push) — the bare ref is DENIED at admission, the
+#   pre-upgrade hook Job can't schedule, the pre-upgrade gate FAILS, and the whole
+#   bp-gitea HR rollback-loops 1.2.43→1.2.42 → bp-catalyst-platform / bp-continuum /
+#   bp-sandbox all blocked. Fix: default the guard image to the Harbor-proxy form
+#   `harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7` in BOTH
+#   values.yaml and the template inline default (mirrors sso-configure-deployment.yaml
+#   / database-secret-sync-job.yaml). Adds tests/kyverno-harbor-proxy-images.sh
+#   (CI gate asserting every rendered image passes harbor-proxy-pull + image-pin).
+version: 1.2.44
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/templates/gitdata-preservation-hook.yaml
+++ b/platform/gitea/chart/templates/gitdata-preservation-hook.yaml
@@ -203,7 +203,11 @@ spec:
           emptyDir: {}
       containers:
         - name: guard
-          image: {{ .Values.gitDataMigration.image | default "bitnamilegacy/kubectl:1.30.7" | quote }}
+          # #4369: harbor-proxy form so the cluster-wide Kyverno harbor-proxy-pull
+          # Enforce policy (admits `*/proxy-*/*` or `*/openova-io/*`) ADMITS this
+          # pre-upgrade hook Job — a bare docker.io ref is DENIED at admission and
+          # rollback-loops the gitea HR. Inline default mirrors values.yaml.
+          image: {{ .Values.gitDataMigration.image | default "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7" | quote }}
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: tmp

--- a/platform/gitea/chart/tests/kyverno-harbor-proxy-images.sh
+++ b/platform/gitea/chart/tests/kyverno-harbor-proxy-images.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# #4369 (Refs #4367 #4354) — assert EVERY image in the rendered bp-gitea
+# install/upgrade manifest set is sourced through the local Harbor, so the
+# cluster-wide Kyverno `harbor-proxy-pull` Enforce ClusterPolicy admits every
+# Pod/Job on a converged Sovereign.
+#
+# THE REGRESSION this gate locks down
+# ===================================
+# #4367 (chart 1.2.43) added templates/gitdata-preservation-hook.yaml. Its guard
+# Job defaulted its kubectl image to a BARE `bitnamilegacy/kubectl:1.30.7`
+# (docker.io) ref. `harbor-proxy-pull` admits ONLY an image matching
+# `*/proxy-*/*` (proxy-cache) OR `*/openova-io/*` (native-push). The bare ref was
+# DENIED at admission ⇒ the pre-install,pre-upgrade hook Job could not schedule ⇒
+# the pre-upgrade gate FAILED ⇒ the whole bp-gitea HR rollback-looped 1.2.43→1.2.42
+# ⇒ bp-catalyst-platform / bp-continuum / bp-sandbox all stranded (the live #4369
+# P0 on kom4dc). #4369 defaults the guard image to the harbor-proxy form in BOTH
+# values.yaml and the template inline default.
+#
+# WHAT THIS TEST ASSERTS
+# ======================
+# Across the realistic render set (default, sso-enabled, the explicit override
+# path), NO container `image:` is a raw docker.io / quay.io / ghcr.io / bare
+# `repo/name` ref. Every image must be either:
+#   - `harbor.openova.io/proxy-*/...`  (proxy-cache, matches `*/proxy-*/*`), or
+#   - `harbor.openova.io/openova-io/...`(native-push, matches `*/openova-io/*`).
+#
+# SCOPING: the upstream gitea subchart ships a `helm test` connection-probe Pod
+# (charts/gitea/templates/tests/test-http-connection.yaml, `busybox:latest`).
+# That is a `helm.sh/hook: test` artifact — it is NEVER applied during
+# install/upgrade admission (only on an explicit `helm test`), so it is not part
+# of the admitted workload set and is excluded here. Everything that lands during
+# install/upgrade (incl. the #4369 guard hook Job) MUST be Harbor-compliant.
+#
+# Self-contained `helm template` assertions only (no kind cluster), per the CI
+# convention in .github/workflows/blueprint-release.yaml.
+set -euo pipefail
+
+# CI invokes `bash <script> <chart_dir>`; fall back to the script's own dir.
+chart_dir="${1:-$(dirname "$0")/..}"
+cd "$chart_dir"
+chart_dir="$(pwd)"
+
+# The upstream gitea subchart is vendored under charts/*.tgz (gitignored, rebuilt
+# from Chart.lock). CI runs `helm dependency build` before tests; build it here
+# too so the test is runnable standalone.
+if ! ls charts/*.tgz >/dev/null 2>&1; then
+  helm dependency build "$chart_dir" >/dev/null 2>&1 || true
+fi
+
+fail=0
+
+# Extract every container `image:` value, dropping the upstream `helm test` Pod's
+# image (it is hook=test, never admitted on install/upgrade — see header).
+images_of() {
+  helm template gitea . \
+    --namespace gitea \
+    --set sso.sovereignFqdn=example.test \
+    --set global.sovereignFQDN=example.test \
+    "$@" 2>/dev/null \
+  | awk '
+      /^# Source:/ { src=$0 }
+      # Skip the upstream helm-test connection probe (hook=test, not admitted).
+      src ~ /templates\/tests\/test-http-connection\.yaml/ { next }
+      /^[[:space:]]*image:[[:space:]]*/ {
+        line=$0
+        sub(/^[[:space:]]*image:[[:space:]]*/, "", line)
+        gsub(/"/, "", line)
+        print line
+      }
+    ' | sort -u
+}
+
+# A Harbor-compliant image matches the harbor-proxy-pull globs:
+#   `*/proxy-*/*`  (e.g. harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:..)
+#   `*/openova-io/*` (native-push)
+compliant() {
+  case "$1" in
+    */proxy-*/*) return 0 ;;
+    */openova-io/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+check() {
+  local label="$1"; shift
+  local bad=""
+  while IFS= read -r img; do
+    [ -z "$img" ] && continue
+    if ! compliant "$img"; then
+      bad+="    $img"$'\n'
+    fi
+  done < <(images_of "$@")
+  if [ -n "$bad" ]; then
+    echo "FAIL [$label]: image(s) NOT matching harbor-proxy-pull (\`*/proxy-*/*\` or \`*/openova-io/*\`):"
+    printf '%s' "$bad"
+    fail=1
+  else
+    echo "PASS [$label]: all admitted images route through the local Harbor"
+  fi
+}
+
+# 1. Default render — the guard hook renders (gitDataMigration.enabled default true).
+check "default"
+# 2. SSO enabled — renders the sso-configure Deployment too.
+check "sso-enabled" --set sso.enabled=true
+# 3. Explicit operator override of the guard image (must stay overridable + the
+#    proxy default must NOT be hard-coded past the override).
+check "guard-image-override" \
+  --set gitDataMigration.image=harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.31.0
+
+# 4. Pinpoint assertion: the #4369 offender — the gitdata-guard Job image — is the
+#    harbor-proxy form by DEFAULT (no override), and is NOT a bare docker.io ref.
+GUARD_IMG="$(helm template gitea . \
+  --namespace gitea \
+  --set sso.sovereignFqdn=example.test \
+  --set global.sovereignFQDN=example.test 2>/dev/null \
+  | awk '
+      /^# Source:/ { src=$0 }
+      src ~ /templates\/gitdata-preservation-hook\.yaml/ && /^[[:space:]]*image:/ {
+        line=$0; sub(/^[[:space:]]*image:[[:space:]]*/, "", line); gsub(/"/, "", line); print line
+      }')"
+if [ -z "$GUARD_IMG" ]; then
+  echo "FAIL [guard-image-default]: could not locate the gitdata-guard Job image in the render"
+  fail=1
+elif compliant "$GUARD_IMG"; then
+  echo "PASS [guard-image-default]: gitdata-guard image is Harbor-proxy compliant ($GUARD_IMG)"
+else
+  echo "FAIL [guard-image-default]: gitdata-guard image is NOT Harbor-proxy compliant ($GUARD_IMG)"
+  echo "  → Kyverno harbor-proxy-pull (Enforce) would DENY the pre-upgrade hook Job (the #4369 regression)."
+  fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "[kyverno-harbor-proxy-images] FAILED — one or more bp-gitea images would be DENIED by the host-ns Kyverno harbor-proxy-pull Enforce policy."
+  exit 1
+fi
+echo "[kyverno-harbor-proxy-images] All bp-gitea install/upgrade images are Harbor-proxy compliant; the #4369 pre-upgrade-hook denial cannot recur."

--- a/platform/gitea/chart/values.yaml
+++ b/platform/gitea/chart/values.yaml
@@ -594,4 +594,9 @@ gitDataMigration:
   failOnDbDiskDrift: true
   # kubectl image for the guard Job (mirrors the guacamole recordings-migrate
   # hook convention). Operator-overridable per docs/PRINCIPLES.md #4a.
-  image: bitnamilegacy/kubectl:1.30.7
+  # #4369: MUST be the Harbor-proxy form so the cluster-wide Kyverno
+  # `harbor-proxy-pull` Enforce policy (admits `*/proxy-*/*` or `*/openova-io/*`)
+  # ADMITS the pre-upgrade hook Job. A bare docker.io ref is DENIED at admission,
+  # which fails the pre-upgrade gate and rollback-loops the whole gitea HR.
+  # Identical proxy ref to sso-configure-deployment.yaml / database-secret-sync-job.yaml.
+  image: harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7


### PR DESCRIPTION
## What

`bp-gitea` 1.2.43's `gitdata-preservation-hook` Job (shipped in #4367) defaulted its kubectl image to a **bare `docker.io` ref** (`bitnamilegacy/kubectl:1.30.7`). On a converged Sovereign the cluster-wide Kyverno `harbor-proxy-pull` **Enforce** ClusterPolicy admits ONLY `*/proxy-*/*` (proxy-cache) or `*/openova-io/*` (native-push). The bare ref is **DENIED at admission** → the `pre-install,pre-upgrade` hook Job can't schedule → the pre-upgrade gate **fails** → the whole `bp-gitea` HR rollback-loops `1.2.43→1.2.42` → `bp-catalyst-platform` / `bp-continuum` / `bp-sandbox` all stranded (the live #4369 P0 on kom4dc).

## Fix

Default the guard image to the harbor-proxy form `harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7` — identical to how `sso-configure-deployment.yaml` and `database-secret-sync-job.yaml` already reference their images.

- `platform/gitea/chart/values.yaml` — `gitDataMigration.image` default → harbor-proxy form.
- `platform/gitea/chart/templates/gitdata-preservation-hook.yaml` — inline `default` → harbor-proxy form (defense-in-depth so an empty override still renders compliant).
- `platform/gitea/chart/tests/kyverno-harbor-proxy-images.sh` — **new CI gate** asserting every admitted bp-gitea image matches `harbor-proxy-pull` (`*/proxy-*/*` or `*/openova-io/*`) + a pinpoint assertion on the `gitdata-guard` image. The upstream gitea `helm test` connection-probe Pod (`busybox:latest`, `hook: test`, never admitted on install/upgrade) is excluded by Source.
- chart `1.2.43→1.2.44` + `blueprint.yaml` + bootstrap-kit slot `10-gitea.yaml` in lockstep.

## Policy-pass proof

Rendered guard image is now the harbor-proxy form, which the `*/proxy-*/*` glob admits:
```
PASS [guard-image-default]: gitdata-guard image is Harbor-proxy compliant (harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7)
[kyverno-harbor-proxy-images] All bp-gitea install/upgrade images are Harbor-proxy compliant; the #4369 pre-upgrade-hook denial cannot recur.
```

**Negative control** (anti-theater — proves the test bites): temporarily reverting the values.yaml default back to the bare `bitnamilegacy/kubectl:1.30.7` makes the new test **FAIL** (exit 1) on the `default`, `sso-enabled`, and `guard-image-default` cases; restoring the proxy ref returns it to **PASS** (exit 0).

`helm lint` clean; all 9 gitea chart tests green.

## Note

The pre-existing `bp-catalyst-platform` `1.4.850/1.4.849` pin-sync drift on `main` (deploy-bot treadmill) is unrelated to this PR and untouched.

Refs #4369 #4367 #4354

🤖 Generated with [Claude Code](https://claude.com/claude-code)