### PR TITLE
fix(catalyst): org-services NATS_URL → host nats-system + controller pins 8c532a7 (1.4.851)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1109,7 +1109,12 @@ spec:
       # 1.4.847 — #4355: gitea repo-bootstrap hooks self-heal disk-vs-DB-drift
       #   repos (re-init main before branching) so a recovered-empty gitea never
       #   wedges the umbrella upgrade with BackoffLimitExceeded.
-      version: 1.4.849
+      # 1.4.851 — #4373: org-services NATS_URL default → host nats-system (de-vcluster
+      #   re-home left it on the dead mgmt-vcluster mangled name → provisioning
+      #   CrashLoop) + environment/blueprint/application controller pins → 8c532a7
+      #   (#4363 configSchema fix; clears the freshness gate). (slot-13 was also 2
+      #   behind: the deploy-bot 1.4.850 bump never synced this pin.) Refs #4373 #4363.
+      version: 1.4.851
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3102,7 +3102,22 @@ name: bp-catalyst-platform
 #   re-inits `main` via the contents API before branching. Idempotent + bounded.
 #   lookup-source change; no new bootstrap state. Chart-version bump forces the
 #   Flux re-pull (deploy-bot mutable-tag trap). bootstrap-kit slot-13 lockstep.
-version: 1.4.850
+# 1.4.851 — #4373: TWO fixes the de-vcluster re-home (#4291/#4325/#4347/#4348)
+#   left stale. (1) org-services NATS_URL default re-pointed from the dead
+#   mgmt-vcluster-syncer-mangled name
+#   (`nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc`) BACK to the plain
+#   host name `nats-jetstream.nats-system.svc` — bp-nats-jetstream was re-homed to
+#   the host `nats-system` ns, the mgmt vCluster + mangled syncer Service are gone,
+#   so the mangled default resolved NXDOMAIN → org-services/provisioning CrashLooped
+#   `nats connect: no such host`, wedging #4364's funnel-cart install (live
+#   kom4dc/omantel.biz dep 4635277cae4ffed9, 2026-06-26). Fixed in 4 places:
+#   org-services/configmap.yaml ($defaultNATS), values.yaml (catalystApi.nats.url),
+#   api-deployment.yaml + api-deployment-kustomize.yaml (CATALYST_NATS_URL default).
+#   (2) environment/blueprint/application controller pins bumped 895f961 -> 8c532a7
+#   (the #4363 application-controller typed-nil configSchema fix) — they were 223
+#   commits behind latest GHCR, tripping the Controller-image-tag freshness gate.
+#   Config-default + pin-bump only; no new bootstrap state. Refs #4373 #4363 #4322.
+version: 1.4.851
 # 1.4.774 — #4082: application-controller ClusterRole gains dr.openova.io/continuums
 #   (get/list/watch/create/update/patch/delete) — was in the controller's own
 #   deploy/rbac.yaml but MISSING from this platform chart, so a singleton /

--- a/products/catalyst/chart/templates/api-deployment-kustomize.yaml
+++ b/products/catalyst/chart/templates/api-deployment-kustomize.yaml
@@ -412,7 +412,7 @@ spec:
               # G105 #2697 default flipped to the syncer-mangled name —
               # post-G92.2 nats-jetstream runs INSIDE the mgmt vCluster
               # and the host's `nats-system` namespace no longer exists.
-              value: '{{ .Values.catalystApi.natsURL | default "nats://nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc.cluster.local:4222" }}'
+              value: '{{ .Values.catalystApi.natsURL | default "nats://nats-jetstream.nats-system.svc.cluster.local:4222" }}'
             # CATALYST_K8SCACHE_KUBECONFIGS_DIR — issue #321. Directory
             # the k8scache.Factory reads kubeconfigs from at startup.
             # The data-plane SharedInformerFactory opens one informer

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -485,7 +485,7 @@ spec:
               # G105 #2697 default flipped to the syncer-mangled name —
               # post-G92.2 nats-jetstream runs INSIDE the mgmt vCluster
               # and the host's `nats-system` namespace no longer exists.
-              value: '{{ .Values.catalystApi.natsURL | default "nats://nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc.cluster.local:4222" }}'
+              value: '{{ .Values.catalystApi.natsURL | default "nats://nats-jetstream.nats-system.svc.cluster.local:4222" }}'
             # CATALYST_K8SCACHE_KUBECONFIGS_DIR — issue #321. Directory
             # the k8scache.Factory reads kubeconfigs from at startup.
             # The data-plane SharedInformerFactory opens one informer

--- a/products/catalyst/chart/templates/org-services/configmap.yaml
+++ b/products/catalyst/chart/templates/org-services/configmap.yaml
@@ -77,7 +77,7 @@ Redpanda default so contabo's existing Organization consumers keep functioning.
        synced name in #2697; the Organization default was missed in the move.
        Align it here. Override via orgServices.eventBus.natsURL for a
        host-placed NATS. */ -}}
-  {{- $defaultNATS = "nats://nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc.cluster.local:4222" -}}
+  {{- $defaultNATS = "nats://nats-jetstream.nats-system.svc.cluster.local:4222" -}}
 {{- end -}}
 {{- $brokers := default $defaultBrokers (index (default (dict) .Values.orgServices.eventBus) "brokers") -}}
 {{- $natsURL := default $defaultNATS (index (default (dict) .Values.orgServices.eventBus) "natsURL") -}}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -821,7 +821,7 @@ controllers:
       # loops the env-controller.
       # 34ff594 (2026-06-21, #4053) — freshness sweep on the console-gateway-
       # isolation PR: 01db043 had drifted 437 commits behind latest GHCR.
-      tag: "895f961"
+      tag: "8c532a7"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -873,7 +873,7 @@ controllers:
       # successful push-on-main build per Inviolable Principle #4a.
       # 34ff594 (2026-06-21, #4053) — freshness sweep on the console-gateway-
       # isolation PR: 01db043 had drifted 437 commits behind latest GHCR.
-      tag: "895f961"
+      tag: "8c532a7"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -911,7 +911,7 @@ controllers:
       # 6d7aacd (2026-06-24, #4236) — freshness sweep on the funnel pool-DNS PR:
       # 34ff594 had drifted 183 commits behind latest GHCR (no code change here,
       # just clearing the staleness gate so the chart ships the current binary).
-      tag: "895f961"
+      tag: "8c532a7"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -1135,7 +1135,7 @@ services:
       # Pre-G92.2 default `nats-jetstream.nats-system.svc.cluster.local:4222`
       # returned NXDOMAIN because the `nats-system` namespace no longer
       # exists on the host k3s.
-      url: "nats://nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc.cluster.local:4222"
+      url: "nats://nats-jetstream.nats-system.svc.cluster.local:4222"
       stream: "catalyst.events"
       subject: "catalyst.events.>"
     valkey:


### PR DESCRIPTION
Clean rebase of the NATS host-ns revert onto current main (#4372 went CONFLICTING after the deploy-bot 1.4.850 commit). Folds in the controller-pin freshness fix (env/blueprint/application 895f961→8c532a7 = #4363) + slot-13 pin sync. NATS default re-pointed from the dead mgmt-vcluster mangled name to host nats-jetstream.nats-system (de-vcluster #4291/#4325/#4347/#4348 left it stale → provisioning CrashLoop 'no such host' on kom4dc dep 4635277cae4ffed9 → funnel cart can't land → #4322/#4297/#4292 gate on it). Supersedes #4372. Refs #4373 #4363 #4322.