### PR TITLE
fix(catalog #4375): per-Org blueprints land host-native post-de-vcluster — flip removed tier: rtz → ''

### DIFF
--- a/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
+++ b/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
@@ -184,7 +184,9 @@ spec:
       # 0.3.10 (#3189): topology source drift fix —
       # switchover.mechanism leader-election → bp-continuum (valid CRD
       # enum) + non-empty metrics hostnameTemplate; matches catalog-seed.
-      version: 0.3.10
+      # 0.3.11 (#4375): topology placement.tier rtz → '' (host-native)
+      # post-#4325 de-vcluster — lockstep with the chart + blueprint bump.
+      version: 0.3.11
       sourceRef:
         kind: HelmRepository
         name: bp-sandbox

--- a/platform/openclaw/blueprint.yaml
+++ b/platform/openclaw/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-7-agentic-workspace
 spec:
-  version: 0.2.6
+  version: 0.2.7
   card:
     title: OpenClaw
     summary: |
@@ -124,7 +124,11 @@ spec:
     perTopology:
       singleton:
         placement:
-          tier: rtz
+          # #4375 (#4325 de-vcluster fallout): the `rtz` plane vCluster was
+          # removed; per-Org apps land host-native in their OWN Org namespace
+          # (#4297 keystone). Host placement = empty tier; keep the rtz-A
+          # region designator (clusters/roles).
+          tier: ''
           clusters:
             - rtz-A
           roles:

--- a/platform/openclaw/chart/Chart.yaml
+++ b/platform/openclaw/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-openclaw
-version: 0.2.6
+version: 0.2.7
 appVersion: "0.2.0"
 description: |
   Catalyst Blueprint chart for the OpenClaw workspace controller pattern

--- a/platform/sandbox/blueprint.yaml
+++ b/platform/sandbox/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-sandbox
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.3.10
+  version: 0.3.11
   card:
     title: Sandbox
     summary: |
@@ -98,14 +98,18 @@ spec:
           rtoSeconds: 30
           rpoSeconds: 0
         placement:
-          tier: rtz
+          # #4375 (#4325 de-vcluster fallout): the `rtz` plane vCluster was
+          # removed; per-Org apps land host-native in their OWN Org namespace
+          # (#4297 keystone). Host placement = empty tier; keep the rtz-A/-B
+          # region designators (clusters/roles) for the multi-region split.
+          tier: ''
           clusters: [rtz-A, rtz-B]
           roles:
             rtz-A: active
             rtz-B: passive
       singleton:
         placement:
-          tier: rtz
+          tier: ''
           clusters: [rtz-A]
           roles:
             rtz-A: singleton

--- a/platform/sandbox/chart/Chart.yaml
+++ b/platform/sandbox/chart/Chart.yaml
@@ -119,7 +119,7 @@ annotations:
 # `helm template newapi platform/newapi/chart/ -s templates/service.yaml`
 # → metadata.name: newapi-bp-newapi. Walker on t38 (chart 1.4.216,
 # substrate be4f78bc872e2c56) caught the live regression.
-version: 0.3.10
+version: 0.3.11
 appVersion: "0.3.7"
 keywords:
   - catalyst

--- a/platform/stalwart-tenant/blueprint.yaml
+++ b/platform/stalwart-tenant/blueprint.yaml
@@ -43,7 +43,7 @@ spec:
   # and wired it onto the Job container. Verified live on the tkt0625
   # demo Org (omantel.biz region-a).
   # Per #817 Chart.yaml version MUST equal blueprint.yaml spec.version.
-  version: 0.1.8
+  version: 0.1.9
   card:
     title: Stalwart (per-Organization)
     summary: |
@@ -234,7 +234,11 @@ spec:
           rtoSeconds: 60
           rpoSeconds: 0
         placement:
-          tier: rtz
+          # #4375 (#4325 de-vcluster fallout): the `rtz` plane vCluster was
+          # removed; per-Org apps land host-native in their OWN Org namespace
+          # (#4297 keystone). Host placement = empty tier; keep the rtz-A/-B
+          # region designators (clusters/roles) for the multi-region split.
+          tier: ''
           clusters:
           - rtz-A
           - rtz-B
@@ -243,7 +247,7 @@ spec:
             rtz-B: passive
       singleton:
         placement:
-          tier: rtz
+          tier: ''
           clusters:
           - rtz-A
           roles:

--- a/platform/stalwart-tenant/chart/Chart.yaml
+++ b/platform/stalwart-tenant/chart/Chart.yaml
@@ -114,7 +114,7 @@ name: bp-stalwart-tenant
 #   100m/64Mi — overridable) and wired it onto the Job container. The
 #   StatefulSet already declared resources (stalwart.resources); only the
 #   hook Job was missing them. Mirrors the bp-newapi hook-Job convention.
-version: 0.1.8
+version: 0.1.9
 appVersion: "0.15.5"
 description: |
   Catalyst Blueprint scratch chart for a per-Org (per-vcluster) dedicated

--- a/platform/wordpress-tenant/blueprint.yaml
+++ b/platform/wordpress-tenant/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: tenant-app
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.4.19
+  version: 0.4.20
   card:
     title: WordPress (per-Organization)
     summary: |
@@ -246,7 +246,11 @@ spec:
           rtoSeconds: 60
           rpoSeconds: 0
         placement:
-          tier: rtz
+          # #4375 (#4325 de-vcluster fallout): the `rtz` plane vCluster was
+          # removed; per-Org apps land host-native in their OWN Org namespace
+          # (#4297 keystone). Host placement = empty tier; keep the rtz-A/-B
+          # region designators (clusters/roles) for the multi-region split.
+          tier: ''
           clusters:
           - rtz-A
           - rtz-B
@@ -255,7 +259,7 @@ spec:
             rtz-B: passive
       singleton:
         placement:
-          tier: rtz
+          tier: ''
           clusters:
           - rtz-A
           roles:

--- a/platform/wordpress-tenant/chart/Chart.yaml
+++ b/platform/wordpress-tenant/chart/Chart.yaml
@@ -254,7 +254,7 @@ name: bp-wordpress-tenant
 #   tests/oidc-config.sh Case 8 asserts the Job has no `wp plugin install`, never
 #   references wordpress.org, vendors from the pinned GitHub tag, and tolerates a
 #   fetch failure — so the HR reaches Ready without ANY external plugin download.
-version: 0.4.19
+version: 0.4.20
 appVersion: "6"
 description: |
   Catalyst Blueprint scratch chart for in-vcluster WordPress, one

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -113,14 +113,14 @@ spec:
           rtoSeconds: 60
           rpoSeconds: 0
         placement:
-          tier: rtz
+          tier: ''
           clusters: [rtz-A, rtz-B]
           roles:
             rtz-A: active
             rtz-B: passive
       singleton:
         placement:
-          tier: rtz
+          tier: ''
           clusters: [rtz-A]
           roles:
             rtz-A: singleton
@@ -239,14 +239,14 @@ spec:
           rtoSeconds: 60
           rpoSeconds: 0
         placement:
-          tier: rtz
+          tier: ''
           clusters: [rtz-A, rtz-B]
           roles:
             rtz-A: active
             rtz-B: passive
       singleton:
         placement:
-          tier: rtz
+          tier: ''
           clusters: [rtz-A]
           roles:
             rtz-A: singleton
@@ -2973,7 +2973,7 @@ is event-driven (ADR-0003 §3).
           rtoSeconds: 60
           rpoSeconds: 0
         placement:
-          tier: rtz
+          tier: ''
           clusters:
           - rtz-A
           - rtz-B
@@ -2982,7 +2982,7 @@ is event-driven (ADR-0003 §3).
             rtz-B: passive
       singleton:
         placement:
-          tier: rtz
+          tier: ''
           clusters:
           - rtz-A
           roles:
@@ -6335,14 +6335,14 @@ spec:
           rtoSeconds: 30
           rpoSeconds: 0
         placement:
-          tier: rtz
+          tier: ''
           clusters: [rtz-A, rtz-B]
           roles:
             rtz-A: active
             rtz-B: passive
       singleton:
         placement:
-          tier: rtz
+          tier: ''
           clusters: [rtz-A]
           roles:
             rtz-A: singleton

--- a/tests/e2e/bootstrap-kit/main_test.go
+++ b/tests/e2e/bootstrap-kit/main_test.go
@@ -554,6 +554,152 @@ func errEOF() error {
 
 var errEOFSentinel = fmt.Errorf("EOF")
 
+// perOrgCatalogBlueprints are the catalog Blueprints that install through
+// the application-controller fan-out into a per-Organization namespace
+// (#4297 keystone). For these, the topology variant's placement.tier is
+// LIVE — the controller resolves it through VClusterPlacements and upserts
+// the per-cluster HelmRelease into that tier's host namespace. After #4325
+// de-vclustered the mgmt/rtz/dmz platform planes (their plane vClusters +
+// host namespaces were removed), a per-Org Blueprint that still pins
+// `tier: rtz` (or mgmt/dmz) Degrades the instant it installs with
+// `namespaces "rtz" not found` (#4362 agenity, #4375 cohort). A per-Org app
+// MUST land HOST-native in its OWN Org namespace → placement.tier == "" (or
+// the "host" sentinel). The rtz-A / rtz-B cluster IDs (region designators)
+// are unaffected and stay.
+//
+// NOTE: platform-PLANE Blueprints (loki/redis/temporal/llm-gateway/openmeter/
+// …) that legitimately carry `tier: mgmt|rtz` in their catalog topology are
+// DORMANT for bootstrap installs — they are placed by the bootstrap-kit
+// placement.yaml (already host-flipped by #4325), not by the catalog topology.
+// They are deliberately NOT in this set.
+var perOrgCatalogBlueprints = map[string]string{
+	"bp-wordpress-tenant": "wordpress-tenant",
+	"bp-stalwart-tenant":  "stalwart-tenant",
+	"bp-openclaw":         "openclaw",
+	"bp-sandbox":          "sandbox",
+}
+
+// deVclusteredPlanes are the platform-plane vCluster tiers removed by #4325.
+// A per-Org topology placement.tier MUST NOT reference any of them.
+var deVclusteredPlanes = map[string]bool{"mgmt": true, "rtz": true, "dmz": true}
+
+// topologyDoc is the minimal shape needed to read the per-variant placement
+// tier out of a Blueprint manifest (source blueprint.yaml OR a rendered
+// catalog-seed doc).
+type topologyDoc struct {
+	Kind     string `yaml:"kind"`
+	Metadata struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	Spec struct {
+		Topology struct {
+			PerTopology map[string]struct {
+				Placement struct {
+					Tier string `yaml:"tier"`
+				} `yaml:"placement"`
+			} `yaml:"perTopology"`
+		} `yaml:"topology"`
+	} `yaml:"spec"`
+}
+
+// assertHostNativeTopology fails t if any perTopology variant in doc pins a
+// placement.tier that names a de-vclustered plane. src is a human-readable
+// origin label for the error message.
+func assertHostNativeTopology(t *testing.T, src string, doc topologyDoc) {
+	t.Helper()
+	if len(doc.Spec.Topology.PerTopology) == 0 {
+		t.Errorf("%s (%s): no topology.perTopology variants found — a per-Org Blueprint must declare its host-native placement", src, doc.Metadata.Name)
+		return
+	}
+	for variant, v := range doc.Spec.Topology.PerTopology {
+		tier := strings.TrimSpace(v.Placement.Tier)
+		if deVclusteredPlanes[tier] {
+			t.Errorf("%s (%s): topology variant %q pins placement.tier=%q — a removed (#4325 de-vcluster) plane vCluster. Per-Org apps land HOST-native in their own Org namespace; flip to tier: '' (#4375)", src, doc.Metadata.Name, variant, tier)
+		}
+	}
+}
+
+// TestBootstrapKit_PerOrgBlueprintsAreHostNative locks the #4375 (#4325
+// fallout) contract: every PER-ORG catalog Blueprint — the ones that install
+// through the application-controller fan-out into a per-Organization
+// namespace — declares a HOST-native topology placement (tier ""/host), NOT
+// a removed mgmt/rtz/dmz plane vCluster. It checks BOTH sides that must stay
+// in lockstep:
+//
+//	(1) the source platform/<x>/blueprint.yaml, and
+//	(2) the rendered products/catalyst catalog-seed Blueprint CR (the
+//	    in-cluster fallback the bp-catalog-client reads when the Gitea
+//	    catalog repo 404s).
+//
+// Without this lock, the next edit to either side can re-introduce a
+// `tier: rtz` that Degrades a fresh Org's app with `namespaces "rtz" not
+// found` the moment it installs.
+func TestBootstrapKit_PerOrgBlueprintsAreHostNative(t *testing.T) {
+	root := repoRoot(t)
+
+	// (1) Source blueprints.
+	for bpName, dir := range perOrgCatalogBlueprints {
+		t.Run("source/"+dir, func(t *testing.T) {
+			bpPath := filepath.Join(root, "platform", dir, "blueprint.yaml")
+			raw, err := os.ReadFile(bpPath)
+			if err != nil {
+				t.Fatalf("read source blueprint %s: %v", bpPath, err)
+			}
+			var doc topologyDoc
+			if err := yaml.Unmarshal(raw, &doc); err != nil {
+				t.Fatalf("unmarshal %s: %v", bpPath, err)
+			}
+			if doc.Metadata.Name != bpName {
+				t.Errorf("%s metadata.name = %q, want %q", bpPath, doc.Metadata.Name, bpName)
+			}
+			assertHostNativeTopology(t, "platform/"+dir+"/blueprint.yaml", doc)
+		})
+	}
+
+	// (2) Rendered catalog-seed. helm collapses the `{{ "{{" }}` escape
+	// tokens to literal runtime placeholders so the docs parse as YAML.
+	// Skip gracefully if helm is unavailable in the runner.
+	helmBin := os.Getenv("HELM_BIN")
+	if helmBin == "" {
+		helmBin = "helm"
+	}
+	if _, err := exec.LookPath(helmBin); err != nil {
+		t.Skipf("helm not on PATH (%v) — skipping rendered catalog-seed half; the source-blueprint half above still runs", err)
+	}
+	chartDir := filepath.Join(root, "products", "catalyst", "chart")
+	cmd := exec.Command(helmBin, "template", ".", "--show-only", "templates/catalog-seed/blueprints.yaml")
+	cmd.Dir = chartDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("helm template catalog-seed failed: %v\noutput:\n%s", err, out)
+	}
+	// The rendered output also carries the per-Org WordPress alias
+	// (bp-wordpress), which points at the same wordpress-tenant chart and
+	// shares the per-Org topology — assert it too.
+	perOrgSeedNames := map[string]bool{"bp-wordpress": true}
+	for bpName := range perOrgCatalogBlueprints {
+		perOrgSeedNames[bpName] = true
+	}
+	seen := map[string]bool{}
+	dec := yaml.NewDecoder(strings.NewReader(string(out)))
+	for {
+		var doc topologyDoc
+		if derr := dec.Decode(&doc); derr != nil {
+			break
+		}
+		if doc.Kind != "Blueprint" || !perOrgSeedNames[doc.Metadata.Name] {
+			continue
+		}
+		seen[doc.Metadata.Name] = true
+		assertHostNativeTopology(t, "catalog-seed:"+doc.Metadata.Name, doc)
+	}
+	for name := range perOrgSeedNames {
+		if !seen[name] {
+			t.Errorf("catalog-seed: per-Org Blueprint %q not found in rendered seed — the #4375 host-native lock cannot verify it", name)
+		}
+	}
+}
+
 // TestBootstrapKit_DependencyOrderMatchesCanonical loads every blueprint.yaml
 // in the bootstrap-kit list and verifies that the implicit ordering — by
 // blueprint metadata.name — matches the canonical 11-phase order from


### PR DESCRIPTION
## What

#4325 de-vclustered the mgmt/rtz/dmz platform planes into native host namespaces and **removed the rtz/mgmt/dmz plane vClusters**. The PER-ORG catalog blueprints that install through the application-controller fan-out still pinned `placement.tier: rtz` in their topology variants. On a de-vclustered Sovereign the controller resolves `rtz` through `VClusterPlacements` → host ns `rtz` (now absent) and upserts the per-cluster `HelmRelease` into it → the Application **Degrades with `namespaces "rtz" not found`** the instant it installs on a fresh Org. Same class as #4362 (agenity) and the #4348 grafana-datasource repoint.

Per the #4297 keystone a per-Org app lands HOST-native in its OWN Org namespace. This flips `placement.tier: rtz → ''` (host) in both the source `platform/<x>/blueprint.yaml` and the inline catalog-seed copy, keeping the `rtz-A`/`rtz-B` cluster IDs (region designators) for the multi-region split.

The application-controller reads the inline catalog-seed `spec.topology` directly; an empty tier renders the HR in the Application's own namespace with **no vCluster pivot** (`application_controller.go`: `placementTier == ""` → host placement, no `kubeConfig` block). ~30 platform blueprints already use `tier: ''` after #4325 — this is the canonical host-native value.

## Scope

Strictly the **per-Org fan-out blueprints** named in #4375:

| Blueprint | source tier | seed tier | version bump |
|---|---|---|---|
| `bp-wordpress-tenant` | `rtz`→`''` (×2) | `rtz`→`''` (×2) | `0.4.19`→`0.4.20` |
| `bp-wordpress` (alias) | — | `rtz`→`''` (×2) | (aliases wordpress-tenant chart) |
| `bp-stalwart-tenant` | `rtz`→`''` (×2) | `rtz`→`''` (×2) | `0.1.8`→`0.1.9` |
| `bp-openclaw` | `rtz`→`''` (×1) | already host-native | `0.2.6`→`0.2.7` |
| `bp-sandbox` | `rtz`→`''` (×2) | `rtz`→`''` (×2) | `0.3.10`→`0.3.11` |

**NOT touched (deliberately):** platform-PLANE blueprints (loki/redis/temporal/openmeter/llm-gateway/…) keep their **dormant** catalog `tier: rtz` — they are placed by the bootstrap-kit `placement.yaml` (host-flipped by #4325), not by the catalog topology, so their tier is inert for bootstrap installs. **agenity (#4362)** is owned by a sibling agent — untouched here.

## Lockstep

Each component bumps `Chart.yaml version` + `blueprint.yaml spec.version` together (per #817). The catalog-seed `spec.version`/chart pins are the curated stable pins (CI-managed for openclaw) and are intentionally NOT chased — the **topology fix is delivered through the inline `spec.topology`**, not the chart bytes.

## Test

New `TestBootstrapKit_PerOrgBlueprintsAreHostNative` asserts no per-Org catalog blueprint — checked on BOTH the source `platform/<x>/blueprint.yaml` AND the **rendered** catalog-seed Blueprint CR — pins a removed `mgmt`/`rtz`/`dmz` plane tier. **Negative-tested**: reintroducing a `tier: rtz` makes it FAIL with the exact offending blueprint+variant.

## Validation (all green)

- `helm template` of all 4 charts (after `helm dependency build`) + the catalog-seed → renders clean
- `scripts/check-catalog-seed-lockstep.sh` → PASS (69 checked, 0 fail)
- `go build ./...` + `go test ./...` for `tests/e2e/bootstrap-kit` (incl. the new assertion + existing version-lockstep sweep) → green
- The pre-existing bp-catalyst-platform pin drift (1.4.850 vs 1.4.849) is on `origin/main`, untouched by this PR (deploy-bot auto-bump lag)

#4375 left at `status/uat` for the live funnel-Org walk (sibling agent) — no live Sovereign was touched.

Refs #4375 #4325 #4297

🤖 Generated with [Claude Code](https://claude.com/claude-code)
