### PR TITLE
feat(application-controller #3969): fan-out HR render from spec.placement.targets[] + placement validating webhook (§8c/§8d)

### DIFF
--- a/core/controllers/application/admission/placement_test.go
+++ b/core/controllers/application/admission/placement_test.go
@@ -1,0 +1,271 @@
+// placement_test.go — #3969 admission gate + validating webhook coverage.
+//
+// Two layers:
+//
+//  1. EvaluatePlacement (the pure gate) — the multi-primary capability gate,
+//     the role/standbyType invariants, the empty-targets no-op.
+//  2. PlacementWebhook.Review (the AdmissionReview decode→evaluate→respond) —
+//     proves an invalid placement is REJECTED at admission (allowed=false)
+//     with the actionable message, a valid one is allowed, and the legacy
+//     posture-string placement is never gated.
+package admission
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	bpv1alpha1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
+)
+
+func TestEvaluatePlacement(t *testing.T) {
+	cases := []struct {
+		name        string
+		placement   bpv1alpha1.Placement
+		capability  bpv1alpha1.PlacementCapability
+		wantAllowed bool
+		wantReason  string // substring expected in Message on deny
+	}{
+		{
+			name:        "empty targets — legacy posture, un-gated",
+			placement:   bpv1alpha1.Placement{},
+			capability:  bpv1alpha1.CapabilityPrimaryStandby,
+			wantAllowed: true,
+		},
+		{
+			name: "single Primary — allowed under primary+standby",
+			placement: bpv1alpha1.Placement{Targets: []bpv1alpha1.PlacementTarget{
+				{Region: "fsn", Cluster: "mgmt-A", Role: bpv1alpha1.DataRolePrimary},
+			}},
+			capability:  bpv1alpha1.CapabilityPrimaryStandby,
+			wantAllowed: true,
+		},
+		{
+			name: "Primary + Hot Standby — allowed under primary+standby",
+			placement: bpv1alpha1.Placement{Targets: []bpv1alpha1.PlacementTarget{
+				{Region: "fsn", Cluster: "mgmt-A", Role: bpv1alpha1.DataRolePrimary},
+				{Region: "nbg", Cluster: "mgmt-B", Role: bpv1alpha1.DataRoleStandby, StandbyType: bpv1alpha1.StandbyHot},
+			}},
+			capability:  bpv1alpha1.CapabilityPrimaryStandby,
+			wantAllowed: true,
+		},
+		{
+			name: "multi-primary REJECTED under primary+standby (the load-bearing gate)",
+			placement: bpv1alpha1.Placement{Targets: []bpv1alpha1.PlacementTarget{
+				{Region: "fsn", Cluster: "mgmt-A", Role: bpv1alpha1.DataRolePrimary},
+				{Region: "nbg", Cluster: "mgmt-B", Role: bpv1alpha1.DataRolePrimary},
+			}},
+			capability:  bpv1alpha1.CapabilityPrimaryStandby,
+			wantAllowed: false,
+			wantReason:  bpv1alpha1.MultiPrimaryNotSupportedReason,
+		},
+		{
+			name: "multi-primary ALLOWED under multi-primary capability",
+			placement: bpv1alpha1.Placement{Targets: []bpv1alpha1.PlacementTarget{
+				{Region: "fsn", Cluster: "mgmt-A", Role: bpv1alpha1.DataRolePrimary},
+				{Region: "nbg", Cluster: "mgmt-B", Role: bpv1alpha1.DataRolePrimary},
+			}},
+			capability:  bpv1alpha1.CapabilityMultiPrimary,
+			wantAllowed: true,
+		},
+		{
+			name: "Standby with no type REJECTED",
+			placement: bpv1alpha1.Placement{Targets: []bpv1alpha1.PlacementTarget{
+				{Region: "fsn", Cluster: "mgmt-A", Role: bpv1alpha1.DataRolePrimary},
+				{Region: "nbg", Cluster: "mgmt-B", Role: bpv1alpha1.DataRoleStandby},
+			}},
+			capability:  bpv1alpha1.CapabilityPrimaryStandby,
+			wantAllowed: false,
+			wantReason:  "StandbyMissingType",
+		},
+		{
+			name: "no Primary REJECTED",
+			placement: bpv1alpha1.Placement{Targets: []bpv1alpha1.PlacementTarget{
+				{Region: "nbg", Cluster: "mgmt-B", Role: bpv1alpha1.DataRoleStandby, StandbyType: bpv1alpha1.StandbyHot},
+			}},
+			capability:  bpv1alpha1.CapabilityPrimaryStandby,
+			wantAllowed: false,
+			wantReason:  "NoPrimary",
+		},
+		{
+			name: "empty capability folds to primary+standby — multi-primary still rejected",
+			placement: bpv1alpha1.Placement{Targets: []bpv1alpha1.PlacementTarget{
+				{Region: "fsn", Cluster: "mgmt-A", Role: bpv1alpha1.DataRolePrimary},
+				{Region: "nbg", Cluster: "mgmt-B", Role: bpv1alpha1.DataRolePrimary},
+			}},
+			capability:  "",
+			wantAllowed: false,
+			wantReason:  bpv1alpha1.MultiPrimaryNotSupportedReason,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := EvaluatePlacement(PlacementRequest{Placement: tc.placement, Capability: tc.capability})
+			if d.Allowed != tc.wantAllowed {
+				t.Fatalf("allowed=%v, want %v (decision=%s)", d.Allowed, tc.wantAllowed, d)
+			}
+			if !tc.wantAllowed {
+				if d.Code != CodePlacementInvalid {
+					t.Errorf("deny code=%q, want %q", d.Code, CodePlacementInvalid)
+				}
+				if tc.wantReason != "" && !strings.Contains(d.Message, tc.wantReason) {
+					t.Errorf("deny message %q must contain %q", d.Message, tc.wantReason)
+				}
+			}
+		})
+	}
+}
+
+// fixedCapability is a CapabilityResolver that always returns the same value.
+type fixedCapability bpv1alpha1.PlacementCapability
+
+func (f fixedCapability) CapabilityFor(_ context.Context, _ string) (bpv1alpha1.PlacementCapability, error) {
+	return bpv1alpha1.PlacementCapability(f), nil
+}
+
+// buildReview wraps an Application object body in an AdmissionReview CREATE
+// request (the shape the apiserver POSTs to the webhook).
+func buildReview(t *testing.T, appObj map[string]interface{}) *admissionv1.AdmissionReview {
+	t.Helper()
+	raw, err := json.Marshal(appObj)
+	if err != nil {
+		t.Fatalf("marshal app object: %v", err)
+	}
+	return &admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			UID:       "test-uid-1",
+			Operation: admissionv1.Create,
+			Object:    runtime.RawExtension{Raw: raw},
+		},
+	}
+}
+
+// TestPlacementWebhook_RejectsMultiPrimary — the headline acceptance: an
+// Application that declares a multi-primary placement against a
+// primary+standby Blueprint is REJECTED at admission (allowed=false), with
+// the MultiPrimaryNotSupported reason in the status message.
+func TestPlacementWebhook_RejectsMultiPrimary(t *testing.T) {
+	wh := &PlacementWebhook{Resolver: fixedCapability(bpv1alpha1.CapabilityPrimaryStandby)}
+	review := buildReview(t, map[string]interface{}{
+		"apiVersion": "apps.openova.io/v1",
+		"kind":       "Application",
+		"spec": map[string]interface{}{
+			"blueprintRef": map[string]interface{}{"name": "bp-grafana"},
+			"placement": map[string]interface{}{
+				"targets": []interface{}{
+					map[string]interface{}{"region": "fsn", "cluster": "mgmt-A", "role": "Primary"},
+					map[string]interface{}{"region": "nbg", "cluster": "mgmt-B", "role": "Primary"},
+				},
+			},
+		},
+	})
+	resp := wh.Review(context.Background(), review)
+	if resp.Allowed {
+		t.Fatalf("multi-primary on primary+standby Blueprint must be REJECTED at admission")
+	}
+	if resp.UID != "test-uid-1" {
+		t.Errorf("response UID=%q must echo request UID", resp.UID)
+	}
+	if resp.Result == nil || !strings.Contains(resp.Result.Message, bpv1alpha1.MultiPrimaryNotSupportedReason) {
+		t.Errorf("deny message must carry %q, got %+v", bpv1alpha1.MultiPrimaryNotSupportedReason, resp.Result)
+	}
+}
+
+// TestPlacementWebhook_AllowsValidPlacement — a valid Primary+Standby
+// placement is admitted.
+func TestPlacementWebhook_AllowsValidPlacement(t *testing.T) {
+	wh := &PlacementWebhook{Resolver: fixedCapability(bpv1alpha1.CapabilityPrimaryStandby)}
+	review := buildReview(t, map[string]interface{}{
+		"spec": map[string]interface{}{
+			"blueprintRef": map[string]interface{}{"name": "bp-grafana"},
+			"placement": map[string]interface{}{
+				"targets": []interface{}{
+					map[string]interface{}{"region": "fsn", "cluster": "mgmt-A", "role": "Primary"},
+					map[string]interface{}{"region": "nbg", "cluster": "mgmt-B", "role": "Standby", "standbyType": "Hot"},
+				},
+			},
+		},
+	})
+	resp := wh.Review(context.Background(), review)
+	if !resp.Allowed {
+		t.Fatalf("valid Primary+Hot-Standby placement must be admitted, got deny: %+v", resp.Result)
+	}
+}
+
+// TestPlacementWebhook_AllowsMultiPrimaryUnderCapability — multi-primary is
+// admitted when the Blueprint declares the multi-primary capability.
+func TestPlacementWebhook_AllowsMultiPrimaryUnderCapability(t *testing.T) {
+	wh := &PlacementWebhook{Resolver: fixedCapability(bpv1alpha1.CapabilityMultiPrimary)}
+	review := buildReview(t, map[string]interface{}{
+		"spec": map[string]interface{}{
+			"blueprintRef": map[string]interface{}{"name": "bp-clickhouse"},
+			"placement": map[string]interface{}{
+				"targets": []interface{}{
+					map[string]interface{}{"region": "fsn", "cluster": "mgmt-A", "role": "Primary"},
+					map[string]interface{}{"region": "nbg", "cluster": "mgmt-B", "role": "Primary"},
+				},
+			},
+		},
+	})
+	if resp := wh.Review(context.Background(), review); !resp.Allowed {
+		t.Fatalf("multi-primary under multi-primary capability must be admitted, got: %+v", resp.Result)
+	}
+}
+
+// TestPlacementWebhook_LegacyStringPlacement_Allowed — a bare legacy posture
+// string in spec.placement carries no targets[] and is never gated.
+func TestPlacementWebhook_LegacyStringPlacement_Allowed(t *testing.T) {
+	wh := &PlacementWebhook{Resolver: fixedCapability(bpv1alpha1.CapabilityPrimaryStandby)}
+	review := buildReview(t, map[string]interface{}{
+		"spec": map[string]interface{}{
+			"blueprintRef": map[string]interface{}{"name": "bp-grafana"},
+			"placement":    "active-hotstandby",
+		},
+	})
+	if resp := wh.Review(context.Background(), review); !resp.Allowed {
+		t.Fatalf("legacy string placement must be admitted (no targets ⇒ un-gated), got: %+v", resp.Result)
+	}
+}
+
+// TestPlacementWebhook_NoResolver_FoldsToPrimaryStandby — with no resolver
+// wired, the gate folds to the safe primary+standby default, so multi-primary
+// is rejected (fail-safe).
+func TestPlacementWebhook_NoResolver_FoldsToPrimaryStandby(t *testing.T) {
+	wh := &PlacementWebhook{} // nil resolver
+	review := buildReview(t, map[string]interface{}{
+		"spec": map[string]interface{}{
+			"blueprintRef": map[string]interface{}{"name": "bp-grafana"},
+			"placement": map[string]interface{}{
+				"targets": []interface{}{
+					map[string]interface{}{"region": "fsn", "cluster": "mgmt-A", "role": "Primary"},
+					map[string]interface{}{"region": "nbg", "cluster": "mgmt-B", "role": "Primary"},
+				},
+			},
+		},
+	})
+	if resp := wh.Review(context.Background(), review); resp.Allowed {
+		t.Fatalf("nil resolver must fold to primary+standby and reject multi-primary")
+	}
+}
+
+// TestPlacementWebhook_DeleteAlwaysAllowed — DELETE carries no object.
+func TestPlacementWebhook_DeleteAlwaysAllowed(t *testing.T) {
+	wh := &PlacementWebhook{Resolver: fixedCapability(bpv1alpha1.CapabilityPrimaryStandby)}
+	review := &admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			UID:       "del-1",
+			Operation: admissionv1.Delete,
+		},
+	}
+	if resp := wh.Review(context.Background(), review); !resp.Allowed {
+		t.Fatalf("DELETE must always be admitted")
+	}
+}
+
+// ensure metav1 import is used (Status shape referenced indirectly).
+var _ = metav1.Status{}

--- a/core/controllers/application/admission/validate.go
+++ b/core/controllers/application/admission/validate.go
@@ -46,6 +46,7 @@ import (
 	"strings"
 
 	appv1alpha1 "github.com/openova-io/openova/core/controllers/pkg/apis/application/v1alpha1"
+	bpv1alpha1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
 )
 
 // DecisionCode is the wire-stable identifier returned to clients on
@@ -73,6 +74,14 @@ const (
 	// CodeIsolationLevelInvalid — spec.isolationLevel is set to a
 	// value not in {namespace, vcluster}.
 	CodeIsolationLevelInvalid DecisionCode = "isolation-level-invalid"
+
+	// CodePlacementInvalid — #3969. spec.placement.targets[] violates a
+	// model invariant: an invalid role/standbyType, no Primary, or — the
+	// load-bearing gate — >1 Primary when the Blueprint capability is
+	// primary+standby (MultiPrimaryNotSupported). The Message carries the
+	// specific ValidatePlacement reason so the operator sees the actionable
+	// error at ADMISSION (not silently at reconcile).
+	CodePlacementInvalid DecisionCode = "placement-invalid"
 )
 
 // Decision is the verdict of an admission gate. Allowed=true means the
@@ -241,6 +250,59 @@ func EvaluateUpdate(req UpdateRequest) Decision {
 			Allowed: false,
 			Code:    CodeIsolationLevelInvalid,
 			Message: fmt.Sprintf("isolationLevel %q not in {namespace, vcluster}", req.NewIsolationLevel),
+		}
+	}
+	return AllowedDecision
+}
+
+// PlacementRequest is the locked projection of a placement-validation
+// admission request (#3969). The webhook decodes the incoming Application
+// CR into this shape — the desired-state placement (spec.placement.targets[]
+// + ownedDependencies) plus the Blueprint's placementCapability gate — and
+// calls EvaluatePlacement. Both fields come off the wire; the Blueprint
+// capability is resolved by the webhook from the referenced Blueprint (it
+// folds to the safe primary+standby default when the Blueprint omits it, per
+// NormalizeCapability), so a malformed/multi-primary placement is rejected
+// BEFORE the apiserver persists the CR.
+type PlacementRequest struct {
+	// Placement — the candidate desired-state placement off the wire.
+	Placement bpv1alpha1.Placement
+
+	// Capability — the referenced Blueprint's placementCapability. Empty /
+	// unrecognised folds to primary+standby (the single-Primary default)
+	// inside ValidatePlacement, so an absent gate is never accidentally
+	// treated as multi-primary.
+	Capability bpv1alpha1.PlacementCapability
+}
+
+// EvaluatePlacement runs the #3969 capability + role/standbyType invariant
+// gate at ADMISSION time. It is the authoritative pre-persist enforcement of
+// ValidatePlacement: a placement that declares >1 Primary against a
+// primary+standby Blueprint (or carries an invalid role / a Standby with no
+// type / no Primary at all) is REJECTED at admission rather than landing as a
+// silently-Degraded Application the reconciler only catches later.
+//
+// An empty target list is a no-op (the legacy posture-string path drives the
+// fan-out unchanged) → AllowedDecision.
+//
+// On rejection the Decision carries CodePlacementInvalid and the underlying
+// ValidatePlacement reason + message so the operator sees exactly which
+// invariant failed (e.g. MultiPrimaryNotSupported).
+func EvaluatePlacement(req PlacementRequest) Decision {
+	if len(req.Placement.Targets) == 0 {
+		return AllowedDecision
+	}
+	if err := bpv1alpha1.ValidatePlacement(req.Placement, req.Capability); err != nil {
+		msg := err.Error()
+		var pe *bpv1alpha1.PlacementError
+		if errors.As(err, &pe) {
+			// Surface the stable reason + the human message verbatim.
+			msg = pe.Reason + ": " + pe.Msg
+		}
+		return Decision{
+			Allowed: false,
+			Code:    CodePlacementInvalid,
+			Message: msg,
 		}
 	}
 	return AllowedDecision

--- a/core/controllers/application/admission/webhook.go
+++ b/core/controllers/application/admission/webhook.go
@@ -1,0 +1,246 @@
+package admission
+
+// webhook.go — #3969: the validating ADMISSION WEBHOOK that rejects an
+// invalid desired-state placement at the apiserver, not silently at reconcile.
+//
+// Before this, ValidatePlacement (placement_target.go) ran ONLY at reconcile
+// time — a multi-primary placement against a primary+standby Blueprint landed
+// as a persisted Application that the controller later marked Ready=False. The
+// operator had no synchronous signal at `kubectl apply` / `POST /apps`; the
+// CR was accepted, then quietly Degraded. This handler closes that gap: it is
+// a `ValidatingWebhookConfiguration` target that decodes the incoming
+// AdmissionReview, projects the Application's `spec.placement` + the referenced
+// Blueprint's `placementCapability`, runs EvaluatePlacement, and returns an
+// allow/deny AdmissionResponse. An invalid placement is rejected SYNCHRONOUSLY
+// at admission.
+//
+// The handler is deliberately thin + pure-ish: the capability lookup is
+// injected (CapabilityResolver) so the package builds with NO K8s client
+// dependency and the decode→evaluate→respond path is unit-testable against a
+// raw AdmissionReview body. The cmd entrypoint wires a real resolver (a dynamic
+// Blueprint GET) + TLS serving.
+//
+// Ref #3969 §7.3, "validating webhook for ValidatePlacement".
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	bpv1alpha1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
+)
+
+// CapabilityResolver resolves the placementCapability of the Blueprint an
+// Application references. The webhook injects this so the decode→evaluate path
+// stays free of a K8s client; the cmd entrypoint wires a dynamic Blueprint GET.
+// An error (Blueprint not found / API error) is surfaced by the handler as a
+// deny with a clear message — a placement can't be validated against an
+// unknown capability, and silently allowing it would defeat the gate.
+type CapabilityResolver interface {
+	// CapabilityFor returns the placementCapability for the named Blueprint
+	// (with or without the `bp-` prefix; the resolver normalises). It returns
+	// the safe primary+standby default (never multi-primary) when the
+	// Blueprint omits the field — that folding lives in the resolver impl, but
+	// the webhook also re-normalises defensively via NormalizeCapability.
+	CapabilityFor(ctx context.Context, blueprintRef string) (bpv1alpha1.PlacementCapability, error)
+}
+
+// CapabilityResolverFunc adapts a plain function to CapabilityResolver.
+type CapabilityResolverFunc func(ctx context.Context, blueprintRef string) (bpv1alpha1.PlacementCapability, error)
+
+// CapabilityFor implements CapabilityResolver.
+func (f CapabilityResolverFunc) CapabilityFor(ctx context.Context, blueprintRef string) (bpv1alpha1.PlacementCapability, error) {
+	return f(ctx, blueprintRef)
+}
+
+// PlacementWebhook is the http.Handler for the placement ValidatingWebhook.
+// It serves the `/validate-placement` path the ValidatingWebhookConfiguration
+// targets.
+type PlacementWebhook struct {
+	// Resolver resolves the referenced Blueprint's placementCapability. When
+	// nil, the webhook folds every Application to the safe primary+standby
+	// default (single-Primary) — so the multi-primary gate still fires, but a
+	// genuinely multi-primary Blueprint would be wrongly rejected. Production
+	// MUST wire a real resolver; the nil case is a unit-test convenience.
+	Resolver CapabilityResolver
+}
+
+// applicationPlacementShape is the minimal projection the webhook decodes out
+// of the AdmissionReview's `object.raw` (an Application CR). Only the fields
+// EvaluatePlacement needs are pulled — the desired-state placement + the
+// Blueprint reference (to resolve the capability gate).
+type applicationPlacementShape struct {
+	Spec struct {
+		BlueprintRef struct {
+			Name string `json:"name"`
+		} `json:"blueprintRef"`
+		// BlueprintName is the legacy flat form some CRs carry; either
+		// blueprintRef.name or blueprintName resolves the capability.
+		BlueprintName string                `json:"blueprintName"`
+		Placement     placementWireFragment `json:"placement"`
+	} `json:"spec"`
+}
+
+// placementWireFragment decodes ONLY the targets[] + ownedDependencies[] of
+// spec.placement. spec.placement may also be a bare legacy STRING (the posture
+// mode) — UnmarshalJSON tolerates that, decoding it as an empty placement (no
+// targets ⇒ EvaluatePlacement is a no-op, the legacy path is never gated).
+type placementWireFragment struct {
+	Targets           []bpv1alpha1.PlacementTarget         `json:"targets"`
+	OwnedDependencies []bpv1alpha1.OwnedDependencyOverride `json:"ownedDependencies"`
+}
+
+// UnmarshalJSON tolerates the dual-form spec.placement: the #3373 object form
+// (which carries targets[]) OR the legacy bare string posture. A string decodes
+// to the zero fragment (no targets) so the legacy posture is never rejected.
+func (p *placementWireFragment) UnmarshalJSON(data []byte) error {
+	// Legacy string form — decode to empty (un-gated).
+	if len(data) > 0 && data[0] == '"' {
+		*p = placementWireFragment{}
+		return nil
+	}
+	type alias placementWireFragment
+	var a alias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+	*p = placementWireFragment(a)
+	return nil
+}
+
+// ServeHTTP decodes the AdmissionReview, evaluates the placement gate, and
+// writes the AdmissionReview response. It always responds with HTTP 200 + an
+// AdmissionReview body (the apiserver contract) — a deny is carried in
+// response.allowed=false, never as an HTTP error.
+func (w *PlacementWebhook) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		http.Error(rw, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		http.Error(rw, "read body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	review := &admissionv1.AdmissionReview{}
+	if err := json.Unmarshal(body, review); err != nil {
+		http.Error(rw, "decode AdmissionReview: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	resp := w.Review(req.Context(), review)
+
+	out := &admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "admission.k8s.io/v1",
+			Kind:       "AdmissionReview",
+		},
+		Response: resp,
+	}
+	rw.Header().Set("Content-Type", "application/json")
+	rw.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(rw).Encode(out)
+}
+
+// Review is the pure decode→evaluate→respond core, factored out of ServeHTTP
+// so tests exercise it without an HTTP round-trip. It NEVER returns nil: a
+// malformed request or a capability-resolution failure becomes a deny with a
+// clear message (fail-closed — an un-validatable placement is rejected).
+func (w *PlacementWebhook) Review(ctx context.Context, review *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+	if review == nil || review.Request == nil {
+		return denyResponse("", "empty AdmissionReview request")
+	}
+	uid := review.Request.UID
+
+	// DELETE carries no object — always allow (nothing to validate).
+	if review.Request.Operation == admissionv1.Delete {
+		return allowResponse(uid)
+	}
+
+	raw := review.Request.Object.Raw
+	if len(raw) == 0 {
+		return denyResponseUID(uid, "admission request carries no object")
+	}
+	var app applicationPlacementShape
+	if err := json.Unmarshal(raw, &app); err != nil {
+		return denyResponseUID(uid, "decode Application object: "+err.Error())
+	}
+
+	// No desired-state targets ⇒ legacy posture path, un-gated.
+	if len(app.Spec.Placement.Targets) == 0 {
+		return allowResponse(uid)
+	}
+
+	capability, err := w.resolveCapability(ctx, firstNonEmptyStr(app.Spec.BlueprintRef.Name, app.Spec.BlueprintName))
+	if err != nil {
+		return denyResponseUID(uid, "resolve Blueprint placementCapability: "+err.Error())
+	}
+
+	decision := EvaluatePlacement(PlacementRequest{
+		Placement: bpv1alpha1.Placement{
+			Targets:           app.Spec.Placement.Targets,
+			OwnedDependencies: app.Spec.Placement.OwnedDependencies,
+		},
+		Capability: capability,
+	})
+	if !decision.Allowed {
+		return denyResponseUID(uid, fmt.Sprintf("%s: %s", decision.Code, decision.Message))
+	}
+	return allowResponse(uid)
+}
+
+// resolveCapability calls the injected resolver, folding to the safe
+// primary+standby default when no resolver is wired (unit-test convenience).
+func (w *PlacementWebhook) resolveCapability(ctx context.Context, blueprintRef string) (bpv1alpha1.PlacementCapability, error) {
+	if w.Resolver == nil {
+		return bpv1alpha1.CapabilityPrimaryStandby, nil
+	}
+	c, err := w.Resolver.CapabilityFor(ctx, blueprintRef)
+	if err != nil {
+		return "", err
+	}
+	return bpv1alpha1.NormalizeCapability(c), nil
+}
+
+// allowResponse builds an allow AdmissionResponse for the given request UID.
+func allowResponse(uid types.UID) *admissionv1.AdmissionResponse {
+	return &admissionv1.AdmissionResponse{
+		UID:     uid,
+		Allowed: true,
+	}
+}
+
+// denyResponseUID builds a deny AdmissionResponse carrying the message in the
+// status so `kubectl apply` surfaces it to the operator.
+func denyResponseUID(uid types.UID, msg string) *admissionv1.AdmissionResponse {
+	return &admissionv1.AdmissionResponse{
+		UID:     uid,
+		Allowed: false,
+		Result: &metav1.Status{
+			Status:  metav1.StatusFailure,
+			Message: msg,
+			Reason:  metav1.StatusReasonInvalid,
+			Code:    http.StatusUnprocessableEntity,
+		},
+	}
+}
+
+// denyResponse is denyResponseUID with an explicit (possibly empty) UID.
+func denyResponse(uid types.UID, msg string) *admissionv1.AdmissionResponse {
+	return denyResponseUID(uid, msg)
+}
+
+// firstNonEmptyStr returns the first non-empty argument.
+func firstNonEmptyStr(ss ...string) string {
+	for _, s := range ss {
+		if s != "" {
+			return s
+		}
+	}
+	return ""
+}

--- a/core/controllers/application/cmd/main.go
+++ b/core/controllers/application/cmd/main.go
@@ -154,6 +154,13 @@ func main() {
 	// per-Sovereign deployment of a new CRD version.
 	go runProbes(ctx, metricsAddr, probeAddr, logger)
 
+	// #3969 — the placement ValidatingWebhook. Disabled unless
+	// PLACEMENT_WEBHOOK_ADDR is set, so this is byte-additive for existing
+	// deployments. When enabled it rejects an invalid desired-state placement
+	// (multi-primary on a primary+standby Blueprint, etc.) synchronously at
+	// admission rather than silently at reconcile.
+	maybeRunPlacementWebhook(ctx, dyn, logger)
+
 	if err := r.Run(ctx); err != nil && ctx.Err() == nil {
 		logger.Error("controller exited", "err", err)
 		os.Exit(1)

--- a/core/controllers/application/cmd/placement_webhook.go
+++ b/core/controllers/application/cmd/placement_webhook.go
@@ -1,0 +1,114 @@
+package main
+
+// placement_webhook.go — #3969: serves the placement ValidatingWebhook.
+//
+// The validating webhook (admission.PlacementWebhook) rejects an invalid
+// desired-state placement (multi-primary on a primary+standby Blueprint, a
+// Standby with no type, no Primary…) at the apiserver — synchronously at
+// `kubectl apply` / `POST /apps`, not silently at reconcile. This file wires
+// the pure handler to a real Blueprint capability resolver (a dynamic GET) +
+// TLS serving inside the application-controller process.
+//
+// It is GATED behind PLACEMENT_WEBHOOK_ADDR: empty (the default) means the
+// webhook server is NOT started, so existing deployments are byte-unchanged
+// until a Sovereign opts in by setting the addr + cert paths and applying the
+// ValidatingWebhookConfiguration. This keeps the change additive.
+//
+// Ref #3969 §7.3.
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"os"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/openova-io/openova/core/controllers/application/admission"
+	bpv1alpha1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
+)
+
+// blueprintCapabilityResolver resolves a Blueprint's spec.placementCapability
+// via a dynamic GET, trying the v1 GVR then the v1alpha1 fallback (mirroring
+// the controller's dual-version Blueprint lookup). It implements
+// admission.CapabilityResolver.
+type blueprintCapabilityResolver struct {
+	dyn dynamic.Interface
+}
+
+var (
+	bpGVRv1 = schema.GroupVersionResource{
+		Group:    "catalyst.openova.io",
+		Version:  "v1",
+		Resource: "blueprints",
+	}
+	bpGVRv1alpha1 = schema.GroupVersionResource{
+		Group:    "catalyst.openova.io",
+		Version:  "v1alpha1",
+		Resource: "blueprints",
+	}
+)
+
+// CapabilityFor reads spec.placementCapability off the named Blueprint. A
+// missing field / unrecognised value folds to the safe primary+standby default
+// (NormalizeCapability). A Blueprint that cannot be fetched at all returns an
+// error so the webhook fails CLOSED (an un-validatable placement is rejected),
+// which is the correct conservative behaviour for the capability gate.
+func (b blueprintCapabilityResolver) CapabilityFor(ctx context.Context, blueprintRef string) (bpv1alpha1.PlacementCapability, error) {
+	bp, err := b.dyn.Resource(bpGVRv1).Namespace("").Get(ctx, blueprintRef, metav1.GetOptions{})
+	if err != nil {
+		bp, err = b.dyn.Resource(bpGVRv1alpha1).Namespace("").Get(ctx, blueprintRef, metav1.GetOptions{})
+		if err != nil {
+			return "", err
+		}
+	}
+	s, _, _ := unstructured.NestedString(bp.Object, "spec", "placementCapability")
+	return bpv1alpha1.NormalizeCapability(bpv1alpha1.PlacementCapability(s)), nil
+}
+
+// maybeRunPlacementWebhook starts the placement ValidatingWebhook server when
+// PLACEMENT_WEBHOOK_ADDR is set. It serves `/validate-placement` over TLS using
+// PLACEMENT_WEBHOOK_CERT + PLACEMENT_WEBHOOK_KEY. When the addr is empty the
+// webhook is disabled (no-op) — the additive default.
+func maybeRunPlacementWebhook(ctx context.Context, dyn dynamic.Interface, logger *slog.Logger) {
+	addr := os.Getenv("PLACEMENT_WEBHOOK_ADDR")
+	if addr == "" {
+		logger.Info("placement webhook disabled (set PLACEMENT_WEBHOOK_ADDR to enable)")
+		return
+	}
+	certFile := envOr("PLACEMENT_WEBHOOK_CERT", "/etc/webhook/tls/tls.crt")
+	keyFile := envOr("PLACEMENT_WEBHOOK_KEY", "/etc/webhook/tls/tls.key")
+
+	wh := &admission.PlacementWebhook{
+		Resolver: blueprintCapabilityResolver{dyn: dyn},
+	}
+	mux := http.NewServeMux()
+	mux.Handle("/validate-placement", wh)
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	srv := &http.Server{Addr: addr, Handler: mux}
+	go func() {
+		<-ctx.Done()
+		_ = srv.Close()
+	}()
+	go func() {
+		logger.Info("placement webhook listening", "addr", addr, "path", "/validate-placement")
+		if err := srv.ListenAndServeTLS(certFile, keyFile); err != nil && err != http.ErrServerClosed {
+			logger.Error("placement webhook server exited", "err", err)
+		}
+	}()
+}
+
+// envOr returns the env value or a default.
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}

--- a/core/controllers/application/internal/controller/application_controller.go
+++ b/core/controllers/application/internal/controller/application_controller.go
@@ -792,27 +792,60 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 	var resolvedTopoChoice bpv1alpha1.BcpTopology
 	var resolvedTopoVariant *bpv1alpha1.TopologyVariant
 	var continuumOwnerLabels map[string]string
-	if bpTopo != nil {
+	// #3969 §8c/§8d — the fan-out HR render now derives from the canonical
+	// desired-state placement (`spec.placement.targets[]`) when it is
+	// declared. The targets carry their own cluster IDs + Primary|Standby
+	// roles, so we synthesize the fan-out variant straight from them
+	// (placementVariantFromTargets) and feed the SAME proven render.FanoutHRs
+	// path — the per-region HelmReleases now FOLLOW the desired-state
+	// placement (provision-write / switchover / singleton→multi). The legacy
+	// `Blueprint.spec.topology` → ResolveTopology path is the FALLBACK only
+	// when no targets are declared (every pre-#3969 Application + the spine
+	// producer that still stamps the legacy posture string). No new logic is
+	// written against `Mode`/`BcpTopology` (§8d).
+	fanoutFromTargets := len(spec.PlacementTargets) > 0
+	if bpTopo != nil || fanoutFromTargets {
 		appTopo := spec.Topology
 		sovRegions := len(envSpec.Regions)
-		choice, variant, terr := topo.ResolveTopology(appTopo, bpTopo, sovRegions)
-		if terr != nil {
-			r.Log.Warn("topology resolution failed",
+		var (
+			choice  bpv1alpha1.BcpTopology
+			variant *bpv1alpha1.TopologyVariant
+		)
+		if fanoutFromTargets {
+			// §8c — desired-state targets drive the render. The capability
+			// gate already ran above (step 5.1); here we only map the
+			// targets onto the renderer's (choice, variant) inputs.
+			capability := blueprintPlacementCapability(bp)
+			choice, variant = placementVariantFromTargets(spec.PlacementTargets, capability)
+			r.Log.Info("placement targets resolved (desired-state fan-out)",
 				"app", app.GetName(),
 				"blueprint", spec.BlueprintName,
-				"appTopology", appTopo,
+				"choice", choice,
+				"targets", len(spec.PlacementTargets),
+				"clusters", placementClusters(variant))
+		} else {
+			// Legacy fallback — no desired-state targets; resolve the
+			// per-Application topology choice off `Blueprint.spec.topology`.
+			c, v, terr := topo.ResolveTopology(appTopo, bpTopo, sovRegions)
+			if terr != nil {
+				r.Log.Warn("topology resolution failed",
+					"app", app.GetName(),
+					"blueprint", spec.BlueprintName,
+					"appTopology", appTopo,
+					"sovereignRegions", sovRegions,
+					"err", terr)
+				// G117.6 acceptance: InvalidTopology must surface as
+				// Ready=False, reason=InvalidTopology, phase=Failed.
+				return r.markFailed(ctx, app, ReasonInvalidTopology, terr.Error())
+			}
+			choice, variant = c, v
+			r.Log.Info("topology resolved",
+				"app", app.GetName(),
+				"blueprint", spec.BlueprintName,
+				"choice", choice,
 				"sovereignRegions", sovRegions,
-				"err", terr)
-			// G117.6 acceptance: InvalidTopology must surface as
-			// Ready=False, reason=InvalidTopology, phase=Failed.
-			return r.markFailed(ctx, app, ReasonInvalidTopology, terr.Error())
+				"clusters", placementClusters(variant))
 		}
-		r.Log.Info("topology resolved",
-			"app", app.GetName(),
-			"blueprint", spec.BlueprintName,
-			"choice", choice,
-			"sovereignRegions", sovRegions,
-			"clusters", placementClusters(variant))
 
 		// #3375 DoD-3 — remember the resolved topology so the per-app
 		// Continuum CR producer (after placement.Resolve below) can mint

--- a/core/controllers/application/internal/controller/application_controller_placement_fanout_test.go
+++ b/core/controllers/application/internal/controller/application_controller_placement_fanout_test.go
@@ -1,0 +1,234 @@
+// application_controller_placement_fanout_test.go — #3969 §8c/§8d.
+//
+// Acceptance for the desired-state write-path: when an Application declares
+// the canonical `spec.placement.targets[]` (the PlacementTarget model), the
+// per-cluster HelmRelease fan-out RENDERS from those targets — one HR per
+// declared target cluster, with the per-target Primary|Standby role mapped
+// onto the active|passive|singleton HR role label — NOT from the legacy
+// `Blueprint.spec.topology` / ResolveTopology posture string.
+//
+// What we assert:
+//
+//  1. A 2-target {mgmt-A Primary, mgmt-B Standby/Hot} placement produces
+//     EXACTLY 2 HelmReleases, one per declared cluster, even though the
+//     Blueprint declares NO spec.topology (the legacy resolver would have
+//     produced zero fan-out HRs — the §8c gap).
+//
+//  2. The HR cluster labels are the targets' cluster IDs (mgmt-A / mgmt-B),
+//     and the roles are active (Primary) + passive (Standby).
+//
+//  3. A single-target {mgmt-A Primary} placement produces 1 HR with the
+//     singleton role (the lone-Primary fallback) — singleton→multi is a
+//     pure edit of the target list.
+//
+//  4. Legacy string-mode (no targets, Blueprint.spec.topology present) is
+//     unchanged — covered by application_controller_fanout_persist_test.go;
+//     here we add the explicit negative: an Application with NO targets and
+//     NO Blueprint topology produces no fan-out HRs (the per-region path
+//     owns it), i.e. the targets path is purely additive.
+package controller
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// makeAppWithTargets builds an Application whose spec.placement is the
+// #3969 OBJECT form carrying targets[]. `mode` seeds the legacy posture
+// string (placement.Resolve input); it does not gate the fan-out.
+func makeAppWithTargets(namespace, name, env, bpName, bpVer, mode string, regions []string, targets []map[string]interface{}) *unstructured.Unstructured {
+	u := makeApp(namespace, name, env, bpName, bpVer, "single-region", regions, nil)
+	spec := u.Object["spec"].(map[string]interface{})
+	targetsAny := make([]interface{}, len(targets))
+	for i, t := range targets {
+		targetsAny[i] = t
+	}
+	spec["placement"] = map[string]interface{}{
+		"mode":    mode,
+		"targets": targetsAny,
+	}
+	return u
+}
+
+// makeBlueprintNoTopology builds a Blueprint with NO spec.topology and NO
+// allowedPlacements/modes restriction — so the targets path is the SOLE
+// driver of the fan-out (the legacy resolver is a no-op for this Blueprint).
+func makeBlueprintNoTopology(name, version, capability string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("catalyst.openova.io/v1")
+	u.SetKind("Blueprint")
+	u.SetName(name)
+	u.SetGeneration(1)
+	spec := map[string]interface{}{
+		"version": version,
+		"card":    map[string]interface{}{"title": name},
+		"manifests": map[string]interface{}{
+			"chart": name,
+			"source": map[string]interface{}{
+				"kind": "HelmRepository",
+				"ref":  "openova-catalog",
+			},
+		},
+	}
+	if capability != "" {
+		spec["placementCapability"] = capability
+	}
+	u.Object["spec"] = spec
+	u.Object["status"] = map[string]interface{}{
+		"ociDigest": "sha256:no-topology-fixture",
+	}
+	return u
+}
+
+// TestReconcile_TargetsDriveFanout_TwoClustersTwoHRs — the central §8c
+// acceptance: a desired-state placement of 2 targets produces 2 per-cluster
+// HRs WITHOUT any Blueprint.spec.topology declaration.
+func TestReconcile_TargetsDriveFanout_TwoClustersTwoHRs(t *testing.T) {
+	bp := makeBlueprintNoTopology("bp-grafana", "1.0.6", "primary+standby")
+	env := makeMultiRegionEnv("acme-prod", "acme", "prod")
+	org := makeOrg("acme")
+	app := makeAppWithTargets("acme", "obs", "acme-prod", "bp-grafana", "1.0.6",
+		"active-hotstandby",
+		[]string{"hetzner-fsn-rtz-prod", "hetzner-nbg-rtz-prod"},
+		[]map[string]interface{}{
+			{"region": "fsn", "cluster": "mgmt-A", "vcluster": "mgmt", "role": "Primary"},
+			{"region": "nbg", "cluster": "mgmt-B", "vcluster": "mgmt", "role": "Standby", "standbyType": "Hot"},
+		},
+	)
+	fg := newFakeGitea()
+	fg.orgsExist["acme"] = true
+	r := newReconciler(t, fg, app, env, org, bp)
+
+	reconcileFromCluster(t, r, "acme", "obs")
+
+	got := readApp(t, r, "acme", "obs")
+	phase, reason, msg := readPhaseAndReason(t, got)
+	if phase == PhaseFailed {
+		t.Fatalf("unexpected Failed phase: reason=%q msg=%q", reason, msg)
+	}
+
+	// The targets carry vcluster=mgmt → HRs land in the mgmt host namespace.
+	hrList, err := r.Dynamic.Resource(FluxHelmReleaseGVR).
+		Namespace("mgmt").
+		List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list HRs in mgmt: %v", err)
+	}
+	if got := len(hrList.Items); got != 2 {
+		t.Fatalf("want 2 per-cluster HRs driven by targets[], got %d", got)
+	}
+
+	seenClusters := map[string]bool{}
+	roleByCluster := map[string]string{}
+	for _, hr := range hrList.Items {
+		labels := hr.GetLabels()
+		cluster := labels["catalyst.openova.io/cluster"]
+		seenClusters[cluster] = true
+		roleByCluster[cluster] = labels["catalyst.openova.io/role"]
+	}
+	if !seenClusters["mgmt-A"] || !seenClusters["mgmt-B"] {
+		t.Fatalf("HR cluster labels must be the targets' cluster IDs mgmt-A + mgmt-B, got %v", seenClusters)
+	}
+	if roleByCluster["mgmt-A"] != "active" {
+		t.Errorf("Primary target mgmt-A → role=active, got %q", roleByCluster["mgmt-A"])
+	}
+	if roleByCluster["mgmt-B"] != "passive" {
+		t.Errorf("Standby target mgmt-B → role=passive, got %q", roleByCluster["mgmt-B"])
+	}
+
+	// The local-region cluster (mgmt-A) pivots into vc-mgmt; the remote
+	// cluster (mgmt-B) carries no kubeConfig block (split-side default) —
+	// same registry resolution the legacy topology fan-out test asserts.
+	for _, hr := range hrList.Items {
+		cluster := hr.GetLabels()["catalyst.openova.io/cluster"]
+		kc, found, _ := unstructured.NestedMap(hr.Object, "spec", "kubeConfig")
+		if cluster == "mgmt-A" {
+			if !found {
+				t.Errorf("mgmt-A HR must carry a kubeConfig pivot")
+				continue
+			}
+			name, _, _ := unstructured.NestedString(kc, "secretRef", "name")
+			if name != "vc-mgmt" {
+				t.Errorf("mgmt-A kubeConfig secretRef.name = %q, want vc-mgmt", name)
+			}
+		}
+		if cluster == "mgmt-B" && found {
+			t.Errorf("mgmt-B HR (remote region) must NOT carry a kubeConfig block (split-side default)")
+		}
+	}
+}
+
+// TestReconcile_TargetsDriveFanout_SingletonSingleTarget — a lone Primary
+// target renders a single HR with the singleton role. singleton→multi is a
+// pure edit of the target list (add a Standby target).
+func TestReconcile_TargetsDriveFanout_SingletonSingleTarget(t *testing.T) {
+	bp := makeBlueprintNoTopology("bp-grafana", "1.0.6", "primary+standby")
+	env := makeMultiRegionEnv("acme-prod", "acme", "prod")
+	org := makeOrg("acme")
+	app := makeAppWithTargets("acme", "obs", "acme-prod", "bp-grafana", "1.0.6",
+		"singleton",
+		[]string{"hetzner-fsn-rtz-prod"},
+		[]map[string]interface{}{
+			{"region": "fsn", "cluster": "mgmt-A", "vcluster": "mgmt", "role": "Primary"},
+		},
+	)
+	fg := newFakeGitea()
+	fg.orgsExist["acme"] = true
+	r := newReconciler(t, fg, app, env, org, bp)
+
+	reconcileFromCluster(t, r, "acme", "obs")
+
+	got := readApp(t, r, "acme", "obs")
+	if phase, reason, msg := readPhaseAndReason(t, got); phase == PhaseFailed {
+		t.Fatalf("unexpected Failed phase: reason=%q msg=%q", reason, msg)
+	}
+
+	hrList, err := r.Dynamic.Resource(FluxHelmReleaseGVR).
+		Namespace("mgmt").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list HRs in mgmt: %v", err)
+	}
+	if got := len(hrList.Items); got != 1 {
+		t.Fatalf("want 1 singleton HR, got %d", got)
+	}
+	if role := hrList.Items[0].GetLabels()["catalyst.openova.io/role"]; role != "singleton" {
+		t.Errorf("lone Primary target → role=singleton, got %q", role)
+	}
+}
+
+// TestReconcile_NoTargets_NoBlueprintTopology_NoFanout — the additive
+// invariant: with NO desired-state targets AND NO Blueprint topology, the
+// targets path is dormant and produces zero fan-out HRs (the legacy
+// per-region render path owns the install). Proves §8c is purely additive.
+func TestReconcile_NoTargets_NoBlueprintTopology_NoFanout(t *testing.T) {
+	bp := makeBlueprintNoTopology("bp-grafana", "1.0.6", "")
+	env := makeEnv("acme-prod", "acme", "prod")
+	org := makeOrg("acme")
+	app := makeApp("acme", "obs", "acme-prod", "bp-grafana", "1.0.6",
+		"single-region", []string{"hetzner-fsn-rtz-prod"}, nil)
+	fg := newFakeGitea()
+	fg.orgsExist["acme"] = true
+	r := newReconciler(t, fg, app, env, org, bp)
+
+	reconcileFromCluster(t, r, "acme", "obs")
+
+	got := readApp(t, r, "acme", "obs")
+	if phase, reason, msg := readPhaseAndReason(t, got); phase == PhaseFailed {
+		t.Fatalf("unexpected Failed phase: reason=%q msg=%q", reason, msg)
+	}
+
+	// No fan-out HRs in any of the vCluster host namespaces.
+	for _, ns := range []string{"mgmt", "dmz", "rtz"} {
+		hrList, err := r.Dynamic.Resource(FluxHelmReleaseGVR).
+			Namespace(ns).List(context.Background(), metav1.ListOptions{})
+		if err != nil {
+			t.Fatalf("list HRs in %s: %v", ns, err)
+		}
+		if len(hrList.Items) != 0 {
+			t.Errorf("targets path must be dormant: expected 0 fan-out HRs in %s, got %d", ns, len(hrList.Items))
+		}
+	}
+}

--- a/core/controllers/application/internal/controller/placement_fanout.go
+++ b/core/controllers/application/internal/controller/placement_fanout.go
@@ -1,0 +1,144 @@
+package controller
+
+// placement_fanout.go — #3969 §8c/§8d: drive the per-cluster HelmRelease
+// fan-out RENDER from the canonical desired-state placement
+// (`spec.placement.targets[]` → the PlacementTarget model) instead of the
+// legacy `Blueprint.spec.topology` / `BcpTopology` posture string resolved
+// by `ResolveTopology`.
+//
+// # The gap this closes (§8c — the core write-path gap)
+//
+// Before this file the fan-out HRs were rendered EXCLUSIVELY from the
+// legacy `TopologyVariant` returned by `ResolveTopology(spec.Topology,
+// Blueprint.spec.topology, sovRegions)`. The new `Targets[]` /
+// `effectivePlacementTargets` fed ONLY the read-model (the observed-target
+// rollup + the backing-service cascade) — NOT the rendered HelmReleases. So
+// a provision-WRITE / switchover / singleton→multi edit of
+// `spec.placement.targets[]` changed the status read-model but NEVER moved
+// a single HelmRelease. DoD items 2/3/4 (provision-write, switchover,
+// singleton→multi) could not pass.
+//
+// This file builds a synthetic `TopologyVariant` straight from the
+// desired-state `Targets[]` so the EXISTING, proven `render.FanoutHRs`
+// renderer + the existing persistence loop project one HR per declared
+// target cluster, with the per-target Primary|Standby role mapped onto the
+// canonical active|passive|singleton HR role label. The renderer, the
+// kubeConfig pivot (clusterregistry), the standby `replicas:0` overlay, the
+// reconcile ordering, and the per-cluster status rollup are ALL reused
+// untouched — this file is a pure ADAPTER between the two models.
+//
+// # §8d — legacy retirement
+//
+// Once an Application declares `Targets[]`, the legacy `Mode` /
+// `BcpTopology` / `Blueprint.spec.topology` consumption is NOT used to
+// drive its render: `placementVariantFromTargets` supersedes
+// `ResolveTopology` for that Application. The legacy path stays as the
+// FALLBACK only when `Targets[]` is empty (every pre-#3969 Application + the
+// spine producer that still stamps the legacy posture string). No new logic
+// is written against `Mode`/`BcpTopology`; the fields remain for back-compat
+// read only.
+//
+// Ref #3969 §7.1, §7.3, §8c, §8d.
+
+import (
+	"github.com/openova-io/openova/core/controllers/application/internal/render"
+	bpv1alpha1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
+)
+
+// placementVariantFromTargets converts the canonical desired-state target
+// list into the (BcpTopology, *TopologyVariant) pair the fan-out renderer
+// consumes — WITHOUT consulting the legacy `Blueprint.spec.topology` or
+// `Mode`. It is the §8c bridge: it lets `render.FanoutHRs` (the SOLE HR
+// renderer) project the desired-state placement directly.
+//
+// Mapping:
+//
+//   - Variant.Placement.Clusters[] = the targets' Cluster IDs, in declared
+//     order (the renderer keys per-cluster HR names + the kubeConfig pivot
+//     off these).
+//   - Variant.Placement.Roles{cluster → "active"|"passive"} = Primary maps
+//     to active, Standby maps to passive. A single Primary with no standby
+//     is left to the renderer's singleton fallback (roleFor: one cluster, no
+//     role ⇒ singleton) so a 1-target placement renders the singleton HR
+//     shape, byte-identical to the legacy singleton path.
+//   - Variant.Placement.Tier = the targets' shared VCluster tier when every
+//     target agrees on one (the common case — an Org's app lands on ONE
+//     tier across regions). A mixed/empty tier folds to "" (host placement),
+//     matching the legacy default.
+//   - the topology label = DerivePattern(targets, capability) mapped onto
+//     the BcpTopology enum, for the LabelTopology label + observability only
+//     (it never gates the render — the per-target roles do).
+//
+// Returns (choice, variant). variant is always non-nil with a non-empty
+// Clusters slice when targets is non-empty (the caller guards len>0).
+func placementVariantFromTargets(
+	targets []bpv1alpha1.PlacementTarget,
+	capability bpv1alpha1.PlacementCapability,
+) (bpv1alpha1.BcpTopology, *bpv1alpha1.TopologyVariant) {
+	clusters := make([]string, 0, len(targets))
+	roles := make(map[string]string, len(targets))
+	tier := ""
+	tierSeen := false
+	tierAgreed := true
+
+	for _, t := range targets {
+		clusters = append(clusters, t.Cluster)
+		switch t.Role {
+		case bpv1alpha1.DataRolePrimary:
+			roles[t.Cluster] = render.RoleActive
+		case bpv1alpha1.DataRoleStandby:
+			roles[t.Cluster] = render.RolePassive
+		}
+		// The PlacementTarget.VCluster carries the tier ("mgmt"|"dmz"|"rtz"
+		// or "" = host). The fan-out renders per-cluster, but the host
+		// write-namespace + kubeConfig pivot are tier-scoped, so we surface
+		// a single shared tier when every target agrees.
+		vc := bpv1alpha1.NormalizeVCluster(t.VCluster)
+		if !tierSeen {
+			tier, tierSeen = vc, true
+		} else if vc != tier {
+			tierAgreed = false
+		}
+	}
+	if !tierAgreed {
+		// Mixed tiers across targets — fold to host so the renderer omits
+		// the tier-scoped pivot rather than picking an arbitrary winner.
+		tier = ""
+	}
+
+	// A lone Primary with no standby is a singleton: drop the explicit
+	// "active" role so render.roleFor's single-cluster fallback stamps
+	// "singleton" (byte-identical to the legacy singleton path). With ≥2
+	// clusters we keep the explicit roles so active/passive are stamped.
+	if len(clusters) == 1 {
+		roles = nil
+	}
+
+	variant := &bpv1alpha1.TopologyVariant{
+		Placement: &bpv1alpha1.PlacementSpec{
+			Tier:     tier,
+			Clusters: clusters,
+			Roles:    roles,
+		},
+	}
+
+	choice := patternToBcpTopology(bpv1alpha1.DerivePattern(targets, capability))
+	return choice, variant
+}
+
+// patternToBcpTopology maps the #3969 DERIVED pattern label onto the legacy
+// BcpTopology enum, used ONLY for the HR `LabelTopology` value +
+// observability rollups. It does not gate the render (the per-target roles
+// do). The mapping is the obvious 1:1 between the two vocabularies.
+func patternToBcpTopology(p bpv1alpha1.Pattern) bpv1alpha1.BcpTopology {
+	switch p {
+	case bpv1alpha1.PatternActiveActive:
+		return bpv1alpha1.BcpActiveActive
+	case bpv1alpha1.PatternActiveHotStandby:
+		return bpv1alpha1.BcpActiveHotStandby
+	case bpv1alpha1.PatternActivePassive:
+		return bpv1alpha1.BcpActivePassive
+	default:
+		return bpv1alpha1.BcpSingleton
+	}
+}


### PR DESCRIPTION
## Summary

Builds the three remaining backend items on the #3969 triage (issuecomment-4802703687). The model + read-model + frontend contradiction-machine deletion were already shipped (#4314); this PR wires the **desired-state → render write path**, retires the legacy consumption, and adds the **validating admission webhook**. Code-only — the EPIC's §12 live walk stays fresh-prov-gated (no eligible provider capacity per the standing gate), so this stays `status/uat`, NOT closed.

## §8c — fan-out projection drives the HR render from `effectiveTargets` (the core gap)

Before: `FanoutHRs` was fed `Topology: choice, Variant` from `ResolveTopology(appTopo, bpTopo, …)` (legacy `Blueprint.spec.topology`); `effectiveTargets` fed ONLY the read-model. So a provision-WRITE / switchover / singleton→multi edit of `spec.placement.targets[]` moved the status but never moved a HelmRelease.

Now: new `placement_fanout.go` synthesizes a `TopologyVariant` straight from `spec.placement.targets[]` — cluster IDs into `Placement.Clusters[]`, `Primary→active` / `Standby→passive` into `Placement.Roles`, the shared vCluster tier into `Placement.Tier` — and feeds the **same proven `render.FanoutHRs` path** (kubeConfig pivot, standby `replicas:0` overlay, reconcile ordering, per-cluster status rollup all reused untouched). The legacy `ResolveTopology` path is the **fallback only when `Targets[]` is empty** (every pre-#3969 Application + the spine producer's posture string). Legacy behavior preserved byte-for-byte.

## §8d — retire legacy `Mode`/`BcpTopology`/`Blueprint.spec.topology` consumption

No new logic is written against the legacy posture enums; the targets path consumes none of them. The fields remain for back-compat read (the legacy fallback) per the brief — not deleted, just no longer the write-path driver.

## Validating admission webhook for `ValidatePlacement`

Promotes the capability gate from reconcile-time to **admission**: an invalid placement (multi-primary on a `primary+standby` Blueprint, a Standby with no type, no Primary) is rejected **synchronously at apply**, not silently at reconcile.
- `admission.EvaluatePlacement` — the pure gate (same `Decision`/`Code` pattern as the existing multi-instance gates), new `placement-invalid` code.
- `admission.PlacementWebhook` — `AdmissionReview` decode → evaluate → respond; tolerates the dual-form `spec.placement` (legacy string ⇒ un-gated).
- Served by the application-controller behind `PLACEMENT_WEBHOOK_ADDR` (**disabled by default** → byte-additive for existing deployments); capability resolved via a dynamic Blueprint GET, fail-closed on resolution error.

## Tests (all green; `go build`/`vet`/`gofmt` clean)

- §8c: a `Targets[]`-shaped Application fans out to the right per-region HRs (2-cluster active/passive with the local-region `vc-mgmt` pivot + remote split-side; singleton single-target).
- Legacy string-mode unchanged; targets path dormant with no targets + no Blueprint topology (the additive invariant).
- `EvaluatePlacement` capability/role/standbyType matrix.
- Webhook rejects multi-primary, allows valid + multi-primary-under-capability, never gates the legacy posture string, fails-closed with no resolver, allows DELETE.

## Lockstep

Code-only PR (no chart edit). The deploy-bot bumps `bp-catalyst-platform`'s image tags + chart version post-merge (the `deploy: update catalyst images to <sha>` commit), so there is no chart-version collision to hand-manage.

## Remaining #3969 scope after this PR

- [ ] **Roll to live** — the org gitops still runs a pre-#4314 controller; `status.placementRecon` + the targets-driven fan-out populate once it rolls.
- [ ] **§12 live UAT walk (1–10)** on a fresh 2-region prov with a `targets[]`-shaped Application + screenshots — the EPIC's own close rule (fresh-prov-gated on provider capacity).

Refs #3969

🤖 Generated with [Claude Code](https://claude.com/claude-code)