### PR TITLE
fix(bp-plane-isolation): add org-services to gitea allowIngressFrom — provisioning→gitea HTTP 000 wedged funnel Org bootstrap (0.1.3)

### DIFF
--- a/clusters/_template/bootstrap-kit/26b-bp-plane-isolation.yaml
+++ b/clusters/_template/bootstrap-kit/26b-bp-plane-isolation.yaml
@@ -68,7 +68,12 @@ spec:
       # 0.1.2 — #4360 (Refs #4272 #4307 #4322 #4179): default-deny egress
       #   `ipBlock 0.0.0.0/0` is Cilium world-only → dropped ALL in-cluster dials
       #   (gitea→shared-pg etc.); add a `namespaceSelector {}` egress allow rule.
-      version: 0.1.2
+      # 0.1.3 — #4382 (Refs #4360 #4322 #4297 #4292): add org-services to gitea's
+      #   INGRESS allowlist — provisioning (org-services) dials gitea-http:3000 to
+      #   validate its bootstrap PAT + bootstrap per-Org gitops repos, but the
+      #   0.1.2 allowlist omitted org-services → Cilium dropped the dial → HTTP 000
+      #   → funnel Org bootstrap wedged even with gitea Ready + a valid PAT.
+      version: 0.1.3
       sourceRef:
         kind: HelmRepository
         name: bp-plane-isolation

--- a/platform/plane-isolation/blueprint.yaml
+++ b/platform/plane-isolation/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 0.1.2  # lockstep with chart/Chart.yaml (#4360 Cilium world-only egress fix)
+  version: 0.1.3  # lockstep with chart/Chart.yaml (#4382 add org-services to gitea allowIngressFrom)
   card:
     title: Plane isolation (per-component default-deny)
     summary: |

--- a/platform/plane-isolation/chart/Chart.yaml
+++ b/platform/plane-isolation/chart/Chart.yaml
@@ -39,7 +39,19 @@ name: bp-plane-isolation
 #   Orgs converge. Added a companion `namespaceSelector: {}` egress rule so the
 #   union admits in-cluster identities alongside world. Same reserved-entity
 #   class as the gateway `ingress` CNP this chart already ships.
-version: 0.1.2
+# 0.1.3 (#4382 / Refs #4360 #4322 #4297 #4292): ADD org-services to gitea's
+#   allowIngressFrom. The 0.1.2 gitea default-deny INGRESS allowlist covered
+#   cnpg-system/external-secrets-system/catalyst-system/flux-system but OMITTED
+#   org-services — so the provisioning service (org-services) dialing gitea-http
+#   :3000 to validate its bootstrap PAT + bootstrap per-Org gitops repos on the
+#   funnel CreateOrg path was Cilium-dropped → provisioning wait-for-gitea-token
+#   init got HTTP 000 (connection timeout, not a token reject) → funnel Org
+#   bootstrap wedged even with gitea Ready + a valid PAT. Live proof on
+#   omantel.biz region-a (kom4dc dep 4635277cae4ffed9, 2026-06-26):
+#   `curl --max-time 8 http://gitea-http.gitea.svc:3000/api/v1/version` → code=000
+#   exit=28 from the provisioning pod while the same PAT returns 200 from a gitea
+#   pod. core/services/provisioning/github/client.go is the legitimate consumer.
+version: 0.1.3
 description: |
   Per-component default-deny + explicit-allow micro-segmentation for the
   de-vclustered platform planes (#4291 Workstream C). For each platform

--- a/platform/plane-isolation/chart/values.yaml
+++ b/platform/plane-isolation/chart/values.yaml
@@ -49,6 +49,12 @@ components:
       - external-secrets-system    # ESO reconciles gitea SSO ExternalSecret
       - catalyst-system            # Flux GitRepository pull from gitea (per-app sources)
       - flux-system                # (also implicit) Flux source-controller mirrors the catalog
+      - org-services               # provisioning validates its bootstrap PAT (GET /api/v1/user)
+                                   # + bootstraps per-Org gitops repos on the funnel CreateOrg path
+                                   # (core/services/provisioning/github/client.go → gitea-http:3000).
+                                   # Without this the provisioning wait-for-gitea-token init dials
+                                   # gitea and Cilium drops it → HTTP 000 → funnel Org bootstrap
+                                   # wedged (#4382, live kom4dc dep 4635277cae4ffed9 2026-06-26).
   - namespace: harbor              # OCI registry
     gatewayIngress: true           # registry.<fqdn> public route
     allowIngressFrom:


### PR DESCRIPTION
## Problem (live, omantel.biz / kom4dc dep `4635277cae4ffed9`, 2026-06-26)

After bp-gitea recovered (1.2.44 Ready, #4377) and the NATS fix landed (#4378), `org-services/provisioning` STILL couldn't complete its `wait-for-gitea-token` init — raw curl proves a NETWORK block, not a token problem:

```
$ curl --max-time 8 http://gitea-http.gitea.svc.cluster.local:3000/api/v1/version
code=000 time=8.001 exit=28   # connection TIMEOUT (DNS → 10.42.2.135; PAT is valid, returns 200 from a gitea pod)
```

## Root cause

bp-plane-isolation 0.1.2's `gitea/gitea-default-deny` INGRESS allowlist covered `flux-system / cnpg-system / external-secrets-system / catalyst-system` but **omitted `org-services`**. The provisioning service (org-services) dials gitea-http:3000 — `core/services/provisioning/github/client.go` — to validate its bootstrap PAT and bootstrap per-Org gitops repos on the funnel CreateOrg path. Cilium dropped the dial → HTTP 000.

## Impact

The LAST gate for #4322/#4297/#4292: provisioning down ⇒ the funnel `tenant.created` → Organization-CR mint + per-Org gitops bootstrap can't run ⇒ no funnel Org converges.

## Fix

Add `org-services` to gitea's `allowIngressFrom` in `platform/plane-isolation/chart/values.yaml`. `helm template` confirms the rendered `gitea-default-deny` ingress now includes `org-services`. Chart 0.1.2 → 0.1.3; slot-26b bootstrap-kit pin synced (pin-sync-audit passes locally).

Refs #4382 #4360 #4322 #4297 #4292

🤖 Generated with [Claude Code](https://claude.com/claude-code)