### PR TITLE
fix(provisioning): funnel cart day-2 install commits to per-Org <slug>/catalyst-tenant repo's vcluster/apps tree, not global openova/openova (empty-SHA 404)

### DIFF
--- a/core/controllers/organization/internal/controller/organization_controller.go
+++ b/core/controllers/organization/internal/controller/organization_controller.go
@@ -487,6 +487,31 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		branch = "main"
 	}
 	for path, data := range manifests {
+		// #4384 — the funnel/day-2 cart install commits the customer's
+		// purchased Applications into THIS repo's `vcluster/apps/` tree and
+		// read-modify-writes `vcluster/apps/kustomization.yaml` to enumerate
+		// them (alongside the NP/CNP boundary baseline). If the controller
+		// kept overwriting that index with its baseline-only list on every
+		// reconcile, it would CLOBBER the funnel's app entries → Flux's
+		// `kustomize build ./vcluster/apps` would drop the customer's apps and
+		// the wordpress HelmRelease would never land. So the apps
+		// kustomization is SEED-ONLY here: the controller creates it once (so a
+		// fresh Org has a valid index before any cart install) and never
+		// overwrites it thereafter. The boundary docs it references
+		// (networkpolicy.yaml / ciliumnetworkpolicy.yaml) are still authored +
+		// kept current via their own PutFile entries above/below, and the
+		// funnel's merge always re-includes them, so the baseline stays live.
+		if path == "vcluster/apps/kustomization.yaml" {
+			if _, gerr := r.GiteaClient.GetFile(ctx, gOrg.Username, repoName, branch, path); gerr == nil {
+				// Already present (seeded earlier, possibly funnel-merged) —
+				// leave it untouched so cart app entries survive.
+				continue
+			} else if !errors.Is(gerr, gitea.ErrFileNotFound) {
+				return r.fail(ctx, &org, "GitopsWriteFailed",
+					fmt.Sprintf("probe %s: %s", path, gerr))
+			}
+			// Genuinely absent → fall through to create it.
+		}
 		if _, _, err := r.GiteaClient.PutFile(ctx,
 			gOrg.Username, repoName, branch, path, data,
 			fmt.Sprintf("organization-controller: reconcile %s for %s", path, org.Spec.Slug)); err != nil {

--- a/core/controllers/organization/internal/controller/perorg_apps_kustomization_seed_only_4384_test.go
+++ b/core/controllers/organization/internal/controller/perorg_apps_kustomization_seed_only_4384_test.go
@@ -1,0 +1,77 @@
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// #4384 — the org-controller must NOT clobber `vcluster/apps/kustomization.yaml`
+// once it exists. The funnel/day-2 cart install read-modify-writes that index
+// to enumerate the customer's purchased Applications (alongside the NP/CNP
+// boundary baseline). If a subsequent org reconcile overwrote it with its
+// baseline-only list, Flux's `kustomize build ./vcluster/apps` would drop the
+// customer's apps and the wordpress HelmRelease would never land. So the
+// controller SEEDS the index once and never overwrites it.
+func TestReconcile_AppsKustomization_SeedOnly_NotClobbered_4384(t *testing.T) {
+	t.Parallel()
+	org := sampleOrg()
+	r, gs, _ := makeReconciler(t, org)
+
+	// First reconcile seeds vcluster/apps/kustomization.yaml.
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "acme"},
+	}); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+
+	const kustKey = "acme/catalyst-tenant/vcluster/apps/kustomization.yaml"
+	seeded, ok := gs.files[kustKey]
+	if !ok {
+		t.Fatalf("controller did not seed %s", kustKey)
+	}
+	if !strings.Contains(string(seeded.content), "networkpolicy.yaml") {
+		t.Fatalf("seeded apps kustomization missing the NP baseline:\n%s", seeded.content)
+	}
+
+	// Simulate the funnel cart install merging the customer's wordpress app
+	// into the index (the read-modify-write the provisioning service does).
+	merged := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - app-wordpress.yaml
+  - ciliumnetworkpolicy.yaml
+  - db-mysql.yaml
+  - networkpolicy.yaml
+`
+	gs.files[kustKey] = fileEntry{sha: seeded.sha, content: []byte(merged)}
+
+	// Re-reconcile. The org-controller must leave the funnel-merged index
+	// untouched (seed-only).
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "acme"},
+	}); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+
+	after := string(gs.files[kustKey].content)
+	if !strings.Contains(after, "app-wordpress.yaml") {
+		t.Errorf("regression: org-controller CLOBBERED the funnel-merged apps kustomization — wordpress dropped:\n%s", after)
+	}
+	for _, want := range []string{"networkpolicy.yaml", "ciliumnetworkpolicy.yaml", "db-mysql.yaml"} {
+		if !strings.Contains(after, want) {
+			t.Errorf("apps kustomization lost %q after reconcile:\n%s", want, after)
+		}
+	}
+
+	// Sanity: the Org still resolves (no error path taken).
+	var got = sampleOrg()
+	if err := r.Get(context.Background(), client.ObjectKey{Name: "acme"}, got); err != nil {
+		t.Fatalf("get org: %v", err)
+	}
+}

--- a/core/services/provisioning/github/client.go
+++ b/core/services/provisioning/github/client.go
@@ -60,6 +60,21 @@ func NewClientWithAPIURL(token, owner, repo, apiURL string) *Client {
 	return &Client{Token: token, Owner: owner, Repo: repo, APIURL: strings.TrimRight(apiURL, "/")}
 }
 
+// WithRepo returns a shallow copy of the client retargeted at a different
+// owner/repo on the SAME API host + token. Used by the funnel/day-2 cart
+// install (#4384) to commit the customer's purchased Applications into the
+// per-Org `<slug>/catalyst-tenant` repo the org-controller bootstrapped —
+// instead of the globally-configured catalog repo (`openova/openova`), which
+// is the WRONG target for a Sovereign's per-Org apps (and 404s on the
+// empty-SHA tree path). The receiver is untouched, so the global client keeps
+// serving the legacy contabo per-tenant overlays.
+func (c *Client) WithRepo(owner, repo string) *Client {
+	clone := *c
+	clone.Owner = owner
+	clone.Repo = repo
+	return &clone
+}
+
 // commitAttemptsMax is how many times CommitFilesWithPrune retries a full
 // rebuild (getRef → tree → commit → updateRef) when updateRef returns
 // "Update is not a fast forward". Concurrent day-2 installs race at the
@@ -651,11 +666,45 @@ func (c *Client) getContentSHA(ctx context.Context, branch, path string) (string
 	return meta.SHA, nil
 }
 
+// resolveTreeish returns the tree-ish to feed `GET /git/trees/{sha}` for a
+// recursive listing of the commit `commitSHA`'s tree.
+//
+// #4384 — the EMPTY-SHA 404. On the upstream GitHub Git Data path the tree
+// endpoint expects a TREE SHA, so we first resolve commit→tree via
+// `GET /git/commits/{sha}`. But Gitea does NOT serve the Git Data commit-read
+// endpoint the same way: `getCommitTree` came back with an EMPTY tree SHA,
+// which then built `GET /git/trees/?recursive=1` (no SHA component) → 404 —
+// the exact failure the live day-2 cart install hit. Gitea's
+// `GET /git/trees/{sha}` accepts a COMMIT SHA (and even a branch name)
+// directly and resolves the tree itself, so on the Gitea path we skip the
+// broken commit-read hop and pass the commit SHA straight through. We also
+// fail LOUD on an empty resolved tree-ish instead of silently emitting the
+// SHA-less URL that 404s.
+func (c *Client) resolveTreeish(ctx context.Context, commitSHA string) (string, error) {
+	if strings.TrimSpace(commitSHA) == "" {
+		return "", fmt.Errorf("resolveTreeish: empty commit SHA (cannot list tree)")
+	}
+	if c.targetsGitea() {
+		// Gitea resolves commit→tree inside GET /git/trees/{sha}; no
+		// separate commit-read round-trip (which returns an empty tree SHA
+		// and 404s the listing — #4384).
+		return commitSHA, nil
+	}
+	treeSHA, err := c.getCommitTree(ctx, commitSHA)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(treeSHA) == "" {
+		return "", fmt.Errorf("resolveTreeish: commit %q resolved to an empty tree SHA", commitSHA)
+	}
+	return treeSHA, nil
+}
+
 // listTreeBlobsWithSHA is like listTreeBlobs but also returns each blob's
 // SHA, keyed by path. Used by commitOnceContents to populate update/delete
 // operations in the ChangeFiles batch.
 func (c *Client) listTreeBlobsWithSHA(ctx context.Context, commitSHA string, prefixes []string) (map[string]string, error) {
-	treeSHA, err := c.getCommitTree(ctx, commitSHA)
+	treeSHA, err := c.resolveTreeish(ctx, commitSHA)
 	if err != nil {
 		return nil, err
 	}
@@ -697,7 +746,7 @@ func (c *Client) listTreeBlobsWithSHA(ctx context.Context, commitSHA string, pre
 // listTreeBlobs returns all blob paths in commitSHA's tree that begin with any
 // of the given prefixes. Uses the recursive tree API for efficiency.
 func (c *Client) listTreeBlobs(ctx context.Context, commitSHA string, prefixes []string) ([]string, error) {
-	treeSHA, err := c.getCommitTree(ctx, commitSHA)
+	treeSHA, err := c.resolveTreeish(ctx, commitSHA)
 	if err != nil {
 		return nil, err
 	}

--- a/core/services/provisioning/github/client_treeish_4384_test.go
+++ b/core/services/provisioning/github/client_treeish_4384_test.go
@@ -1,0 +1,81 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// #4384 — the EMPTY-SHA tree 404. On the Gitea path commitOnceContents listed
+// the existing tree to compute prune/update SHAs; getCommitTree
+// (GET /git/commits/{sha}) returned an EMPTY tree SHA on Gitea, so the listing
+// built `GET /git/trees/?recursive=1` (no SHA segment) → 404, the live failure.
+//
+// The fix: on a Gitea target resolveTreeish passes the COMMIT SHA straight
+// through to GET /git/trees/{sha} (Gitea resolves commit→tree itself) and never
+// emits the SHA-less URL. This test asserts a Gitea-target prune commit lists
+// the tree at /git/trees/<commit-sha> (NOT /git/trees/?recursive=1) and never
+// reads /git/commits/.
+func TestGiteaPrune_NoEmptySHATreePath_4384(t *testing.T) {
+	const commitSHA = "c3f4799deadbeef0000000000000000deadbeef"
+	var (
+		mu            sync.Mutex
+		treePath      string
+		sawEmpty      bool
+		sawCommitRead bool
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/git/refs/heads/main"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"object":{"sha":"` + commitSHA + `"}}]`))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/git/commits/"):
+			sawCommitRead = true
+			// Gitea's broken-for-us shape: no usable tree SHA.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{}`))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/git/trees/"):
+			treePath = r.URL.Path
+			if strings.HasSuffix(r.URL.Path, "/git/trees/") {
+				sawEmpty = true
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"tree":[],"truncated":false}`))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/contents"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"commit":{"sha":"newcommit000000000000000000000000000000"}}`))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/contents/"):
+			http.NotFound(w, r)
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClientWithAPIURL("token", "g6wpwalk", "catalyst-tenant", srv.URL)
+	// Commit WITH a prune prefix → forces the tree-listing path that 404'd.
+	err := c.CommitFilesWithPrune(context.Background(), "main", "cart install",
+		map[string]string{"vcluster/apps/app-wordpress.yaml": "kind: HelmRelease\n"},
+		[]string{"vcluster/apps/app-", "vcluster/apps/db-"})
+	if err != nil {
+		t.Fatalf("CommitFilesWithPrune returned error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if sawEmpty {
+		t.Errorf("regression: hit the empty-SHA tree path /git/trees/ (the live 404)")
+	}
+	if sawCommitRead {
+		t.Errorf("Gitea path must NOT call GET /git/commits/ (it returns an empty tree SHA → empty-SHA 404); resolveTreeish passes the commit SHA through")
+	}
+	if !strings.Contains(treePath, commitSHA) {
+		t.Errorf("tree listing must use the commit SHA directly on Gitea, got path %q", treePath)
+	}
+}

--- a/core/services/provisioning/gitops/perorg_apps_tree.go
+++ b/core/services/provisioning/gitops/perorg_apps_tree.go
@@ -1,0 +1,156 @@
+package gitops
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// PerOrgAppsDir is the directory inside the per-Org `<slug>/catalyst-tenant`
+// repo that the org-controller's per-Org apps Flux Kustomization
+// (`catalyst-tenant-<slug>-apps`, path `./vcluster/apps`, targetNamespace
+// `<slug>`) reconciles into the host `<slug>` namespace. The funnel/day-2 cart
+// install (#4384) commits the customer's purchased Application manifests here
+// so they land in the SAME boundary the org-controller already wired — instead
+// of the legacy contabo per-tenant overlay tree in the global `openova/openova`
+// repo, which no per-Org Kustomization watches on a Sovereign.
+const PerOrgAppsDir = "vcluster/apps"
+
+// perOrgAppsBaselineDocs are the boundary files the org-controller authored
+// into `vcluster/apps/` on Org create (#4292 boundary set). The funnel MUST
+// preserve them in the apps kustomization (they enforce intra-Org isolation),
+// so MergePerOrgAppsKustomization keeps them in the resources list even though
+// the funnel does not own/regenerate them.
+var perOrgAppsBaselineDocs = []string{
+	"networkpolicy.yaml",
+	"ciliumnetworkpolicy.yaml",
+}
+
+// GeneratePerOrgAppsTree renders the customer's purchased Applications for a
+// Sovereign's per-Org `<slug>/catalyst-tenant` repo (#4384). It reuses the
+// canonical generator (GenerateAllWithAppConfigs) and re-roots ONLY the app
+// workload payload into `vcluster/apps/`:
+//
+//   - the in-tree workloads under `<basePath>/<slug>/apps/<file>` →
+//     `vcluster/apps/<file>` (the Deployment-shaped apps + their db Secrets),
+//     EXCLUDING `apps/namespace.yaml` and `apps/kustomization.yaml` — the
+//     org-controller OWNS the boundary namespace + the apps kustomization, and
+//     re-creating the `apps` ns here would collide with the targetNamespace
+//     rewrite the org-controller's apps Kustomization applies.
+//   - the host-scoped HelmRelease-shaped apps `<basePath>/<slug>/app-<x>.yaml`
+//     (openclaw / stalwart-mail / any HR app) → `vcluster/apps/app-<x>.yaml`.
+//     On the de-vcluster'd host-native Sovereign these install straight into
+//     the host `<slug>` ns the apps Kustomization targets.
+//
+// The contabo-model host scaffolding (apps-sync.yaml, ingress.yaml,
+// provisioning-rbac.yaml, the host kustomization.yaml) is dropped: the
+// org-controller's per-Org Flux loop already provides the GitRepository +
+// apps Kustomization that this tree feeds, so re-emitting an apps-sync
+// Kustomization or a second namespace boundary would duplicate/fight it.
+//
+// Returns the re-rooted file map (paths relative to the per-Org repo root) and
+// the sorted list of app file basenames the caller merges into
+// `vcluster/apps/kustomization.yaml`.
+func (g *ManifestGenerator) GeneratePerOrgAppsTree(slug, planSlug string, appSlugs []string, dbPassword string) (files map[string]string, appDocs []string) {
+	raw := g.GenerateAllWithAppConfigs(slug, planSlug, appSlugs, dbPassword, nil)
+
+	tenantDir := g.TenantDir(slug)     // e.g. clusters/<fqdn>/org-tenants/<slug>
+	appsPrefix := tenantDir + "/apps/" // in-tree workload payload
+	hostHRPrefix := tenantDir + "/"    // host-scoped HR app files live directly here
+
+	out := make(map[string]string, len(raw))
+	docSet := map[string]struct{}{}
+
+	for path, content := range raw {
+		switch {
+		case strings.HasPrefix(path, appsPrefix):
+			name := strings.TrimPrefix(path, appsPrefix)
+			// The org-controller owns the boundary ns + the apps
+			// kustomization index — never re-emit them from the funnel.
+			if name == "namespace.yaml" || name == "kustomization.yaml" {
+				continue
+			}
+			out[PerOrgAppsDir+"/"+name] = content
+			docSet[name] = struct{}{}
+		case isHostHelmReleaseAppFile(path, hostHRPrefix):
+			name := strings.TrimPrefix(path, hostHRPrefix)
+			out[PerOrgAppsDir+"/"+name] = content
+			docSet[name] = struct{}{}
+		default:
+			// Drop the contabo-model host scaffolding (apps-sync, ingress,
+			// provisioning-rbac, host kustomization) — the org-controller's
+			// per-Org Flux loop supersedes it on a Sovereign.
+		}
+	}
+
+	appDocs = make([]string, 0, len(docSet))
+	for name := range docSet {
+		appDocs = append(appDocs, name)
+	}
+	sort.Strings(appDocs)
+	return out, appDocs
+}
+
+// isHostHelmReleaseAppFile reports whether `path` is a host-scoped
+// HelmRelease-shaped app file (`<hostPrefix>app-<x>.yaml`) directly under the
+// tenant dir — i.e. NOT nested under `apps/`. These are the bp-* HelmReleases
+// the generator emits as host files (openclaw / stalwart-mail / cnpg-pair).
+func isHostHelmReleaseAppFile(path, hostPrefix string) bool {
+	if !strings.HasPrefix(path, hostPrefix) {
+		return false
+	}
+	name := strings.TrimPrefix(path, hostPrefix)
+	if strings.Contains(name, "/") {
+		return false // nested (apps/...) — handled by the apps-prefix branch
+	}
+	return strings.HasPrefix(name, "app-") && strings.HasSuffix(name, ".yaml")
+}
+
+// MergePerOrgAppsKustomization rebuilds the `vcluster/apps/kustomization.yaml`
+// resources list so it enumerates BOTH the org-controller boundary baseline
+// (networkpolicy.yaml + ciliumnetworkpolicy.yaml) AND the funnel's app docs.
+//
+// `existing` is the current kustomization.yaml content read from the per-Org
+// repo (empty if absent). Any resource already listed there is preserved
+// (so a second cart install is additive, never destructive), the baseline docs
+// are force-included, and the new appDocs are unioned in. The result is
+// deterministic (sorted) so a re-render is byte-stable and the PutFile/commit
+// short-circuits when nothing changed.
+func MergePerOrgAppsKustomization(existing string, appDocs []string) string {
+	resources := map[string]struct{}{}
+	for _, d := range perOrgAppsBaselineDocs {
+		resources[d] = struct{}{}
+	}
+	for _, line := range strings.Split(existing, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "- ") {
+			continue
+		}
+		name := strings.TrimSpace(strings.TrimPrefix(line, "- "))
+		if name == "" || name == "kustomization.yaml" {
+			continue
+		}
+		resources[name] = struct{}{}
+	}
+	for _, d := range appDocs {
+		if d == "kustomization.yaml" {
+			continue
+		}
+		resources[d] = struct{}{}
+	}
+
+	names := make([]string, 0, len(resources))
+	for n := range resources {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	var b strings.Builder
+	b.WriteString("apiVersion: kustomize.config.k8s.io/v1beta1\n")
+	b.WriteString("kind: Kustomization\n")
+	b.WriteString("resources:\n")
+	for _, n := range names {
+		fmt.Fprintf(&b, "  - %s\n", n)
+	}
+	return b.String()
+}

--- a/core/services/provisioning/gitops/perorg_apps_tree_test.go
+++ b/core/services/provisioning/gitops/perorg_apps_tree_test.go
@@ -1,0 +1,101 @@
+package gitops
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestGeneratePerOrgAppsTree_WordpressCart is the #4384 render-proof: a funnel
+// wordpress cart Org re-roots its app payload under `vcluster/apps/` (the
+// per-Org `<slug>/catalyst-tenant` tree the org-controller's apps Kustomization
+// reconciles), NOT under the legacy contabo `clusters/.../<slug>/apps/` tree
+// that lands in the global openova/openova repo.
+func TestGeneratePerOrgAppsTree_WordpressCart(t *testing.T) {
+	g := NewManifestGenerator("clusters/sov/org-tenants")
+	g.ParentDomain = "omani.homes"
+
+	for _, plan := range []string{"s", "m"} {
+		t.Run("plan="+plan, func(t *testing.T) {
+			files, docs := g.GeneratePerOrgAppsTree("g6wpwalk", plan, []string{"wordpress"}, "pw123")
+
+			// The wordpress workload MUST land at vcluster/apps/app-wordpress.yaml.
+			wp, ok := files["vcluster/apps/app-wordpress.yaml"]
+			if !ok {
+				t.Fatalf("wordpress HelmRelease NOT at vcluster/apps/app-wordpress.yaml (#4384) (keys: %v)", keys(files))
+			}
+			if !strings.Contains(wp, "wordpress") {
+				t.Errorf("app-wordpress.yaml does not mention wordpress:\n%s", wp)
+			}
+
+			// Its DB Secret must travel with it under vcluster/apps/.
+			if _, ok := files["vcluster/apps/db-mysql.yaml"]; !ok {
+				t.Errorf("wordpress db Secret NOT at vcluster/apps/db-mysql.yaml (keys: %v)", keys(files))
+			}
+
+			// NOTHING may land under the legacy contabo tenant-dir tree — that
+			// repo (openova/openova) is the wrong target for a Sovereign's
+			// per-Org apps (#4384 root cause).
+			for p := range files {
+				if strings.HasPrefix(p, "clusters/") {
+					t.Errorf("per-Org tree leaked a contabo-model path %q — must be vcluster/apps relative", p)
+				}
+				if !strings.HasPrefix(p, "vcluster/apps/") {
+					t.Errorf("per-Org tree path %q is not under vcluster/apps/", p)
+				}
+			}
+
+			// The org-controller OWNS the boundary ns + the apps kustomization;
+			// the funnel must NOT re-emit them.
+			if _, ok := files["vcluster/apps/namespace.yaml"]; ok {
+				t.Errorf("funnel must NOT re-emit vcluster/apps/namespace.yaml (org-controller owns the boundary ns)")
+			}
+
+			// appDocs must enumerate the app files for the kustomization merge.
+			if !contains(docs, "app-wordpress.yaml") {
+				t.Errorf("appDocs missing app-wordpress.yaml: %v", docs)
+			}
+		})
+	}
+}
+
+// TestMergePerOrgAppsKustomization preserves the org-controller's NP/CNP
+// baseline AND adds the funnel's app docs, deterministically + idempotently.
+func TestMergePerOrgAppsKustomization(t *testing.T) {
+	existing := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - networkpolicy.yaml
+  - ciliumnetworkpolicy.yaml
+`
+	out := MergePerOrgAppsKustomization(existing, []string{"app-wordpress.yaml", "db-mysql.yaml"})
+
+	for _, want := range []string{"networkpolicy.yaml", "ciliumnetworkpolicy.yaml", "app-wordpress.yaml", "db-mysql.yaml"} {
+		if !strings.Contains(out, "- "+want) {
+			t.Errorf("merged kustomization missing %q:\n%s", want, out)
+		}
+	}
+
+	// Idempotent: merging the same docs into the produced output is byte-stable.
+	out2 := MergePerOrgAppsKustomization(out, []string{"app-wordpress.yaml", "db-mysql.yaml"})
+	if out != out2 {
+		t.Errorf("MergePerOrgAppsKustomization not idempotent:\n--- first ---\n%s\n--- second ---\n%s", out, out2)
+	}
+
+	// Empty existing seeds the baseline from scratch.
+	fresh := MergePerOrgAppsKustomization("", []string{"app-wordpress.yaml"})
+	if !strings.Contains(fresh, "- networkpolicy.yaml") || !strings.Contains(fresh, "- ciliumnetworkpolicy.yaml") {
+		t.Errorf("empty-existing merge must seed the NP/CNP baseline:\n%s", fresh)
+	}
+	if !strings.Contains(fresh, "- app-wordpress.yaml") {
+		t.Errorf("empty-existing merge must include the new app doc:\n%s", fresh)
+	}
+}
+
+func contains(ss []string, s string) bool {
+	for _, x := range ss {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}

--- a/core/services/provisioning/handlers/consumer.go
+++ b/core/services/provisioning/handlers/consumer.go
@@ -452,6 +452,21 @@ func (h *Handler) applyTenantChange(ctx context.Context, data appChangeData, act
 	}
 	appSlugs := h.resolveAppSlugs(ctx, data.Apps)
 
+	branch := h.GitBranch
+	if branch == "" {
+		branch = "main"
+	}
+
+	// #4384 — on a Sovereign the customer's purchased Applications belong in
+	// the per-Org `<slug>/catalyst-tenant` repo's `vcluster/apps/` tree (the
+	// one the org-controller bootstrapped + wired a Flux Kustomization for),
+	// NOT the globally-configured catalog repo (openova/openova). Retarget the
+	// commit there. The legacy contabo per-tenant overlay path keeps using the
+	// global repo + tenant-dir tree below.
+	if h.PerOrgGitops {
+		return h.applyTenantChangePerOrg(ctx, data, action, planSlug, appSlugs, branch)
+	}
+
 	// Preserve the existing DB password if a db file is present in Git.
 	// Without this, regenerating the Secret mints a fresh password and the
 	// running DB pods keep the old one — apps would fail to connect.
@@ -478,10 +493,6 @@ func (h *Handler) applyTenantChange(ctx context.Context, data appChangeData, act
 		return fmt.Errorf("commit guard: %w", err)
 	}
 
-	branch := h.GitBranch
-	if branch == "" {
-		branch = "main"
-	}
 	commitMsg := fmt.Sprintf("day-2: %s %s on tenant %s (apps: %d)",
 		action, data.AppSlug, data.TenantSlug, len(appSlugs))
 	if err := h.GitHubClient.CommitFilesWithPrune(ctx, branch, commitMsg, manifests, prunePrefixes); err != nil {
@@ -490,6 +501,124 @@ func (h *Handler) applyTenantChange(ctx context.Context, data appChangeData, act
 	slog.Info("day-2: committed tenant manifests",
 		"tenant", data.TenantSlug, "action", action, "apps", len(appSlugs))
 	return nil
+}
+
+// perOrgRepoName returns the per-Org Gitea repo the funnel cart install
+// targets (matches the org-controller's `catalyst-tenant` constant). Operator-
+// overridable via TENANT_GITOPS_REPO; defaults "catalyst-tenant".
+func (h *Handler) perOrgRepoName() string {
+	if strings.TrimSpace(h.PerOrgRepoName) != "" {
+		return h.PerOrgRepoName
+	}
+	return "catalyst-tenant"
+}
+
+// perOrgBranch returns the branch the per-Org `<slug>/catalyst-tenant` repo
+// commits land on. Defaults "main" (the org-controller's per-Org Flux
+// GitRepository ref.branch) — explicitly NOT the global GitBranch.
+func (h *Handler) perOrgBranch() string {
+	if strings.TrimSpace(h.PerOrgBranch) != "" {
+		return h.PerOrgBranch
+	}
+	return "main"
+}
+
+// applyTenantChangePerOrg is the Sovereign per-Org commit path (#4384). It
+// renders ONLY the customer's app payload, re-roots it into `vcluster/apps/`,
+// and commits to the per-Org `<slug>/catalyst-tenant` repo — the tree the
+// org-controller's `catalyst-tenant-<slug>-apps` Flux Kustomization reconciles
+// into the host `<slug>` namespace. The funnel-owned app files are pruned (so
+// an uninstall removes them) WITHOUT touching the org-controller's boundary
+// baseline (networkpolicy.yaml / ciliumnetworkpolicy.yaml), which is preserved
+// in the merged kustomization.
+func (h *Handler) applyTenantChangePerOrg(ctx context.Context, data appChangeData, action, planSlug string, appSlugs []string, _ string) error {
+	slug := data.TenantSlug
+	repoClient := h.GitHubClient.WithRepo(slug, h.perOrgRepoName())
+	// The per-Org repo tracks `main`, NOT the global GitBranch (`org-tenants`
+	// on a Sovereign). Commit to the branch the org-controller's per-Org Flux
+	// GitRepository actually watches.
+	branch := h.perOrgBranch()
+
+	// Preserve the existing DB password if the per-Org repo already carries a
+	// db Secret (so a second cart install / day-2 change keeps the running DB
+	// password). Read from the SAME per-Org tree we write to.
+	dbPassword := readDBPasswordFromTree(ctx, repoClient, branch, gitops.PerOrgAppsDir)
+	if dbPassword == "" {
+		slog.Info("day-2: no existing DB password found in per-Org repo — generating fresh (first DB install)",
+			"tenant", slug, "action", action, "repo", slug+"/"+h.perOrgRepoName())
+	}
+
+	appFiles, appDocs := h.Generator.GeneratePerOrgAppsTree(slug, planSlug, appSlugs, dbPassword)
+	if len(appFiles) == 0 && action == "install" {
+		// No deployable Application payload on an INSTALL (e.g. the cart held
+		// only HR-overlay apps the generic generator can't emit, or an empty
+		// cart). Nothing to commit — not an error. On an UNINSTALL we still
+		// fall through to prune the stale file + rebuild the kustomization.
+		slog.Info("day-2 (per-Org): no deployable app payload to commit",
+			"tenant", slug, "action", action, "apps", len(appSlugs))
+		return nil
+	}
+	if appFiles == nil {
+		appFiles = map[string]string{}
+	}
+
+	// Merge the new app docs into the org-controller's vcluster/apps
+	// kustomization (read-modify-write so the NP/CNP baseline + any prior
+	// cart apps survive). On uninstall, the rebuilt list reflects ONLY the
+	// surviving app docs (appDocs no longer lists the removed app) plus the
+	// baseline. Empty existing → MergePerOrgAppsKustomization seeds the
+	// baseline + the current docs.
+	kustPath := gitops.PerOrgAppsDir + "/kustomization.yaml"
+	existingKust := ""
+	if content, err := repoClient.ReadFile(ctx, branch, kustPath); err == nil {
+		existingKust = content
+	}
+	if action == "uninstall" {
+		// Rebuild from the baseline + the SURVIVING app docs only, so the
+		// removed app is dropped from resources (a plain merge would preserve
+		// it because it's still listed in the existing kustomization).
+		appFiles[kustPath] = gitops.MergePerOrgAppsKustomization("", appDocs)
+	} else {
+		appFiles[kustPath] = gitops.MergePerOrgAppsKustomization(existingKust, appDocs)
+	}
+
+	// Prune scope: ONLY the funnel-owned app docs (so uninstalled apps are
+	// removed), never the whole vcluster/apps tree — pruning the org-controller
+	// baseline (networkpolicy.yaml / ciliumnetworkpolicy.yaml) would tear down
+	// intra-Org isolation. CommitFilesWithPrune deletes blobs under a prune
+	// prefix that are NOT in the committed file set; we re-commit every funnel
+	// app doc each render, so a removed app's stale file is the only thing
+	// pruned. Scope the prefix to app-/db- files under the apps dir.
+	prunePrefixes := []string{
+		gitops.PerOrgAppsDir + "/app-",
+		gitops.PerOrgAppsDir + "/db-",
+	}
+
+	commitMsg := fmt.Sprintf("day-2: %s %s on Org %s (apps: %d) → vcluster/apps",
+		action, data.AppSlug, slug, len(appSlugs))
+	if err := repoClient.CommitFilesWithPrune(ctx, branch, commitMsg, appFiles, prunePrefixes); err != nil {
+		return fmt.Errorf("commit to per-Org repo %s/%s: %w", slug, h.perOrgRepoName(), err)
+	}
+	slog.Info("day-2 (per-Org): committed app manifests to per-Org repo",
+		"tenant", slug, "action", action, "apps", len(appSlugs),
+		"repo", slug+"/"+h.perOrgRepoName(), "branch", branch, "files", len(appFiles))
+	return nil
+}
+
+// readDBPasswordFromTree reads db-postgres.yaml / db-mysql.yaml from the given
+// dir in the given repo client + branch and extracts the DB password, "" if
+// neither exists (first install) or it can't be parsed.
+func readDBPasswordFromTree(ctx context.Context, client *ghclient.Client, branch, dir string) string {
+	for _, name := range []string{"db-postgres.yaml", "db-mysql.yaml"} {
+		content, err := client.ReadFile(ctx, branch, dir+"/"+name)
+		if err != nil {
+			continue
+		}
+		if pw := gitops.ExtractDBPassword(content); pw != "" {
+			return pw
+		}
+	}
+	return ""
 }
 
 // readExistingDBPassword tries db-postgres.yaml then db-mysql.yaml from the

--- a/core/services/provisioning/handlers/handlers.go
+++ b/core/services/provisioning/handlers/handlers.go
@@ -57,6 +57,35 @@ type Handler struct {
 	// hardcoded — every Sovereign picks its own pool zone.
 	TenantParentDomain string
 
+	// PerOrgGitops enables the Sovereign per-Org commit target (#4384). When
+	// true, the day-2 cart install commits the customer's purchased
+	// Applications into the per-Org `<slug>/catalyst-tenant` repo's
+	// `vcluster/apps/` tree (the one the org-controller bootstrapped + wired a
+	// Flux Kustomization for) instead of the globally-configured catalog repo
+	// (GITHUB_OWNER/GITHUB_REPO = openova/openova on a Sovereign). The global
+	// repo is the WRONG target for per-Org apps on a Sovereign and 404'd on the
+	// empty-SHA tree path. Sourced from TENANT_GITOPS_PER_ORG env; defaults ON
+	// when SOVEREIGN_FQDN is set (the same signal that flips the chart's git
+	// coordinates to the local Gitea). Off (legacy contabo per-tenant overlay
+	// path) when empty.
+	PerOrgGitops bool
+
+	// PerOrgRepoName is the per-Org Gitea repo the org-controller bootstraps
+	// and the funnel cart install targets when PerOrgGitops is true. Matches
+	// the org-controller's `catalyst-tenant` constant (organization_controller.go).
+	// Operator-overridable via TENANT_GITOPS_REPO env; defaults "catalyst-tenant".
+	PerOrgRepoName string
+
+	// PerOrgBranch is the branch the per-Org `<slug>/catalyst-tenant` repo
+	// commits land on. CRITICAL: this is NOT the global GitBranch — on a
+	// Sovereign GitBranch is `org-tenants` (the cutover-mirror-protected branch
+	// of the global openova/openova catalog repo), but the per-Org repo the
+	// org-controller bootstrapped tracks branch `main` (per_org_flux.go's
+	// GitRepository ref.branch + the org-controller's own PutFile branch). A
+	// commit to the wrong branch would land on a ref no Flux GitRepository
+	// watches. Operator-overridable via TENANT_GITOPS_BRANCH env; defaults "main".
+	PerOrgBranch string
+
 	// day2Cancels tracks in-flight day-2 job wait contexts so tenant.deleted
 	// can preempt them (issue #99). Zero value is ready to use.
 	day2Cancels day2CancelRegistry

--- a/core/services/provisioning/handlers/perorg_cart_install_4384_test.go
+++ b/core/services/provisioning/handlers/perorg_cart_install_4384_test.go
@@ -1,0 +1,190 @@
+package handlers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	ghclient "github.com/openova-io/openova/core/services/provisioning/github"
+	"github.com/openova-io/openova/core/services/provisioning/gitops"
+)
+
+// #4384 — the funnel cart day-2 install committed the wordpress HelmRelease to
+// the GLOBAL openova/openova repo (wrong target for a Sovereign's per-Org apps)
+// and 404'd on the empty-SHA tree path (`GET .../git/trees/?recursive=1`). The
+// fix retargets the commit to the per-Org `<slug>/catalyst-tenant` repo's
+// `vcluster/apps/` tree and resolves the branch SHA correctly.
+//
+// This test stands up a fake Gitea contents API, drives applyTenantChange with
+// PerOrgGitops=true, and asserts:
+//  1. the ChangeFiles batch commits to /repos/<slug>/catalyst-tenant/contents
+//     (NOT /repos/openova/openova/...),
+//  2. the batch carries vcluster/apps/app-wordpress.yaml,
+//  3. NO request ever hits the empty-SHA tree path (the live 404).
+
+type recordedReq struct {
+	Method string
+	Path   string
+	Body   []byte
+}
+
+func fakeGiteaForCart(t *testing.T) (*httptest.Server, *[]recordedReq, *sync.Mutex) {
+	t.Helper()
+	var (
+		mu   sync.Mutex
+		reqs []recordedReq
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		reqs = append(reqs, recordedReq{Method: r.Method, Path: r.URL.Path, Body: body})
+		mu.Unlock()
+
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/catalog/plans"):
+			// Catalog plan lookup so resolveTenantPlanSlug is authoritative
+			// (reachable=true) without needing a live Org CR.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":"s","slug":"s"}]`))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/git/refs/heads/main"):
+			// Branch ref resolves to a real commit SHA (repo healthy).
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"object":{"sha":"c3f4799deadbeef0000000000000000deadbeef"}}]`))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/git/trees/"):
+			// The empty-SHA tree path is /git/trees/?recursive=1 (no SHA
+			// segment). The #4384 fix passes the COMMIT SHA straight through to
+			// Gitea, so the path carries a real SHA. Serve an empty tree
+			// (nothing to prune yet) so commitOnceContents proceeds to create.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"tree":[],"truncated":false}`))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/contents/"):
+			// kustomization.yaml / db file existence probes → 404 (fresh Org).
+			http.NotFound(w, r)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/contents"):
+			// Batch ChangeFiles commit succeeds.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"commit":{"sha":"newcommitsha0000000000000000000000000000"}}`))
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &reqs, &mu
+}
+
+func TestApplyTenantChangePerOrg_CommitsToPerOrgRepo_4384(t *testing.T) {
+	srv, reqs, mu := fakeGiteaForCart(t)
+
+	gen := gitops.NewManifestGenerator("clusters/sov/org-tenants")
+	gen.ParentDomain = "omani.homes"
+
+	h := &Handler{
+		Generator: gen,
+		// Globally configured at openova/openova (the WRONG target for per-Org
+		// apps) — the fix must retarget to g6wpwalk/catalyst-tenant.
+		GitHubClient: ghclient.NewClientWithAPIURL("token", "openova", "openova", srv.URL),
+		GitBranch:    "main",
+		PerOrgGitops: true,
+		// Authoritative plan resolution via the stub catalog (so the #4293
+		// fail-closed gate passes without a live Org CR).
+		CatalogURL: srv.URL,
+	}
+
+	// Drive the day-2 install path directly (applyTenantChange → per-Org branch).
+	err := h.applyTenantChange(context.Background(), appChangeData{
+		TenantSlug: "g6wpwalk",
+		AppSlug:    "wordpress",
+		Apps:       []string{"wordpress"},
+		PlanID:     "s",
+	}, "install")
+	if err != nil {
+		t.Fatalf("applyTenantChange (per-Org) returned error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	var sawPerOrgBatch bool
+	var batchBody []byte
+	for _, rq := range *reqs {
+		// The #4384 root-cause failure: a tree GET with NO SHA segment.
+		if rq.Method == http.MethodGet && strings.Contains(rq.Path, "/git/trees/?") {
+			t.Errorf("regression: empty-SHA tree path hit (%s) — the live 404", rq.Path)
+		}
+		if rq.Method == http.MethodGet && strings.HasSuffix(rq.Path, "/git/trees/") {
+			t.Errorf("regression: empty-SHA tree path hit (%s) — the live 404", rq.Path)
+		}
+		// Any write to the GLOBAL openova/openova repo is the wrong target.
+		if strings.Contains(rq.Path, "/repos/openova/openova/contents") {
+			t.Errorf("regression: committed to GLOBAL openova/openova repo (#4384 wrong target): %s", rq.Path)
+		}
+		if rq.Method == http.MethodPost && strings.HasSuffix(rq.Path, "/contents") {
+			if strings.Contains(rq.Path, "/repos/g6wpwalk/catalyst-tenant/contents") {
+				sawPerOrgBatch = true
+				batchBody = rq.Body
+			}
+		}
+	}
+
+	if !sawPerOrgBatch {
+		t.Fatalf("cart install did NOT commit to /repos/g6wpwalk/catalyst-tenant/contents (#4384). requests:\n%s", dumpPaths(*reqs))
+	}
+
+	// The batch must carry the wordpress HelmRelease at vcluster/apps/app-wordpress.yaml.
+	var payload struct {
+		Branch string `json:"branch"`
+		Files  []struct {
+			Operation string `json:"operation"`
+			Path      string `json:"path"`
+			Content   string `json:"content"`
+		} `json:"files"`
+	}
+	if err := json.Unmarshal(batchBody, &payload); err != nil {
+		t.Fatalf("batch body not JSON: %v\n%s", err, batchBody)
+	}
+	if payload.Branch != "main" {
+		t.Errorf("batch branch = %q, want main", payload.Branch)
+	}
+	var sawWordpress, sawKust bool
+	for _, f := range payload.Files {
+		if f.Path == "vcluster/apps/app-wordpress.yaml" {
+			sawWordpress = true
+			dec, _ := base64.StdEncoding.DecodeString(f.Content)
+			if !strings.Contains(string(dec), "wordpress") {
+				t.Errorf("app-wordpress.yaml content missing wordpress:\n%s", dec)
+			}
+		}
+		if f.Path == "vcluster/apps/kustomization.yaml" {
+			sawKust = true
+			dec, _ := base64.StdEncoding.DecodeString(f.Content)
+			// The merged kustomization preserves the org-controller NP/CNP
+			// baseline AND lists the new app.
+			for _, want := range []string{"networkpolicy.yaml", "ciliumnetworkpolicy.yaml", "app-wordpress.yaml"} {
+				if !strings.Contains(string(dec), want) {
+					t.Errorf("merged kustomization missing %q:\n%s", want, dec)
+				}
+			}
+		}
+	}
+	if !sawWordpress {
+		t.Errorf("batch did NOT carry vcluster/apps/app-wordpress.yaml (#4384 close criteria)")
+	}
+	if !sawKust {
+		t.Errorf("batch did NOT carry the merged vcluster/apps/kustomization.yaml")
+	}
+}
+
+func dumpPaths(reqs []recordedReq) string {
+	var b strings.Builder
+	for _, r := range reqs {
+		b.WriteString(r.Method + " " + r.Path + "\n")
+	}
+	return b.String()
+}

--- a/core/services/provisioning/main.go
+++ b/core/services/provisioning/main.go
@@ -220,6 +220,25 @@ func main() {
 		slog.Warn("GITHUB_TOKEN not set — provisioning will fail to commit manifests")
 	}
 
+	// #4384 — Sovereign per-Org commit target. On a Sovereign the funnel/day-2
+	// cart install commits the customer's purchased Applications into the
+	// per-Org `<slug>/catalyst-tenant` repo's `vcluster/apps/` tree (the one
+	// the org-controller bootstrapped + wired a Flux Kustomization for) instead
+	// of the global catalog repo (GITHUB_OWNER/GITHUB_REPO = openova/openova),
+	// which is the WRONG target for per-Org apps on a Sovereign and 404'd on
+	// the empty-SHA tree path. Default ON when SOVEREIGN_FQDN is set (the same
+	// signal that flips the chart's git coordinates to the local Gitea);
+	// explicitly overridable via TENANT_GITOPS_PER_ORG (true|false).
+	perOrgGitops := sovereignFQDN != ""
+	if v := getEnv("TENANT_GITOPS_PER_ORG", ""); v != "" {
+		perOrgGitops = strings.EqualFold(strings.TrimSpace(v), "true")
+	}
+	perOrgRepoName := getEnv("TENANT_GITOPS_REPO", "catalyst-tenant")
+	// The per-Org repo tracks `main` (the org-controller's per-Org Flux
+	// GitRepository ref.branch) — NOT the global GITHUB_BRANCH (`org-tenants`
+	// on a Sovereign, the cutover-mirror-protected branch of openova/openova).
+	perOrgBranch := getEnv("TENANT_GITOPS_BRANCH", "main")
+
 	h := &handlers.Handler{
 		Store:              provisionStore,
 		Producer:           publisher,
@@ -230,10 +249,16 @@ func main() {
 		SovereignFQDN:      sovereignFQDN,
 		GitBranch:          githubBranch,
 		TenantParentDomain: tenantParentDomain,
+		PerOrgGitops:       perOrgGitops,
+		PerOrgRepoName:     perOrgRepoName,
+		PerOrgBranch:       perOrgBranch,
 	}
 	slog.Info("tenant-public patch wired",
 		"tenant_parent_domain", tenantParentDomain,
 		"enabled", tenantParentDomain != "")
+	slog.Info("per-Org gitops commit target wired (#4384)",
+		"per_org_gitops", perOrgGitops, "per_org_repo", perOrgRepoName,
+		"per_org_branch", perOrgBranch, "sovereign_fqdn_set", sovereignFQDN != "")
 
 	// Start event consumer in a background goroutine. The subscriber
 	// fans events in from BOTH transports (whichever the operator wired

--- a/products/catalyst/chart/templates/org-services/provisioning.yaml
+++ b/products/catalyst/chart/templates/org-services/provisioning.yaml
@@ -507,6 +507,32 @@ spec:
             {{- else }}
               value: "main"
             {{- end }}
+            # ── #4384 — Sovereign per-Org commit target ───────────────────
+            # On a Sovereign the funnel/day-2 cart install commits the
+            # customer's purchased Applications into the per-Org
+            # `<slug>/catalyst-tenant` repo's `vcluster/apps/` tree (the one
+            # the org-controller bootstrapped + wired a Flux Kustomization for),
+            # NOT the global catalog repo (GITHUB_OWNER/GITHUB_REPO =
+            # openova/openova on a Sovereign). The global repo is the WRONG
+            # target for a Sovereign's per-Org apps and 404'd on the empty-SHA
+            # tree path → the wordpress HelmRelease never landed.
+            #
+            # Default ON when global.sovereignFQDN is set (the same signal that
+            # flips GITHUB_API_URL/GITHUB_OWNER to the local Gitea). Empty on
+            # Catalyst-Zero (contabo) → the legacy per-tenant-overlay path.
+            # Operator-overridable per Inviolable Principle #4.
+            - name: TENANT_GITOPS_PER_ORG
+              value: {{ .Values.orgServices.provisioning.perOrgGitops | default (ternary "true" "" (ne (.Values.global.sovereignFQDN | default "") "")) | quote }}
+            # The per-Org Gitea repo name the org-controller bootstraps (matches
+            # its `catalyst-tenant` constant).
+            - name: TENANT_GITOPS_REPO
+              value: {{ .Values.orgServices.provisioning.perOrgRepo | default "catalyst-tenant" | quote }}
+            # CRITICAL: the per-Org repo tracks `main`, NOT the org-tenants
+            # GITHUB_BRANCH above (which is the cutover-mirror-protected branch
+            # of the GLOBAL openova/openova catalog repo). The org-controller's
+            # per-Org Flux GitRepository watches `main` of <slug>/catalyst-tenant.
+            - name: TENANT_GITOPS_BRANCH
+              value: {{ .Values.orgServices.provisioning.perOrgBranch | default "main" | quote }}
           resources:
             requests:
               cpu: 25m


### PR DESCRIPTION
## Problem (the final #4322 gating defect)

A live funnel walk (omantel.biz / kom4dc, host-tier Org `g6wpwalk`, `apps:[wordpress]`) provisioned the Org shell + #4292 boundary set correctly, but the **wordpress cart app never landed**:

```
ERROR day-2 install (http) tenant=g6wpwalk error="commit: list existing tree:
  GET http://gitea-http.gitea.svc:3000/api/v1/repos/openova/openova/git/trees/?recursive=1: 404"
```

The funnel cart day-2 install (`#4364`'s `dispatchFunnelCartInstall` → `tenant.app_install_requested` / `POST /provisioning/apps/install` → `runInstallJob` → `applyTenantChange` → `CommitFilesWithPrune`) used the **globally-configured** provisioning git client, which on a Sovereign is `GITHUB_OWNER=openova GITHUB_REPO=openova`. **Two coupled defects:**

1. **Wrong repo target** — committed the customer's purchased Applications to `openova/openova` (the catalog mirror / legacy contabo `clusters/.../tenants/<id>/` model) instead of the per-Org `<slug>/catalyst-tenant` repo the org-controller bootstrapped + wired a Flux Kustomization (`catalyst-tenant-<slug>-apps`, path `./vcluster/apps`, `targetNamespace <slug>`) for.
2. **Empty refSHA → 404** — on the Gitea contents path the prune-tree listing resolved the tree via `GET /git/commits/{sha}` (`getCommitTree`), which Gitea returns with an **empty tree SHA** → the listing built `GET /git/trees/?recursive=1` (no SHA segment) → 404. So even against `openova/openova` the commit failed and the wordpress HelmRelease never landed.

This is the next layer of the BSS-vs-funnel divergence #4179: #4364 made the funnel DISPATCH the cart, but the dispatch landed in a day-2 install that targeted the wrong repo model for a Sovereign.

## Fix

- **`github.Client.WithRepo`** retargets the day-2 cart commit at `<slug>/catalyst-tenant`.
- **`resolveTreeish`** — on a Gitea target, pass the **commit SHA** straight through to `GET /git/trees/{sha}` (Gitea resolves commit→tree itself); fail loud on an empty tree-ish instead of emitting the SHA-less 404 URL. Kills the live empty-SHA 404.
- **`gitops.GeneratePerOrgAppsTree`** re-roots the app workload payload into `vcluster/apps/` (dropping the contabo-model host scaffolding — apps-sync/ingress/provisioning-rbac/host-kustomization — that the org-controller's per-Org Flux loop supersedes). **`MergePerOrgAppsKustomization`** read-modify-writes `vcluster/apps/kustomization.yaml` to enumerate the customer's apps **alongside** the NP/CNP boundary baseline (idempotent + additive).
- **`applyTenantChangePerOrg`** commits to the per-Org repo on branch **`main`** (NOT the global `org-tenants` branch — that's the cutover-mirror-protected branch of `openova/openova`; the org-controller's per-Org Flux GitRepository watches `main` of `<slug>/catalyst-tenant`). Prune is scoped to the funnel-owned `app-`/`db-` files only, never the org-controller baseline.
- **org-controller** seeds `vcluster/apps/kustomization.yaml` once and never overwrites it, so the funnel-merged app entries survive every reconcile (otherwise the baseline-only PutFile would clobber wordpress back out).
- **Chart** wires `TENANT_GITOPS_PER_ORG` (default ON when `global.sovereignFQDN` set), `TENANT_GITOPS_REPO` (`catalyst-tenant`), `TENANT_GITOPS_BRANCH` (`main`). Contabo render → off (legacy per-tenant-overlay path preserved).

## Render / trace proof

`TestApplyTenantChangePerOrg_CommitsToPerOrgRepo_4384` drives the day-2 path against a fake Gitea and asserts the ChangeFiles batch commits to `/repos/g6wpwalk/catalyst-tenant/contents` (NOT `/repos/openova/openova/...`), carries `vcluster/apps/app-wordpress.yaml`, merges the kustomization (NP+CNP+wordpress), and **never hits the empty-SHA tree path**. `TestGiteaPrune_NoEmptySHATreePath_4384` proves the Gitea prune path lists the tree at `/git/trees/<commit-sha>` and never calls `/git/commits/`. `TestReconcile_AppsKustomization_SeedOnly_NotClobbered_4384` proves a re-reconcile leaves the funnel-merged index intact.

Helm render (Sovereign): `TENANT_GITOPS_PER_ORG=true TENANT_GITOPS_REPO=catalyst-tenant TENANT_GITOPS_BRANCH=main`. Contabo: `PER_ORG=""` (off).

## Close criteria

`status/uat` until a fresh funnel Org with a wordpress cart is re-walked live → the HR lands + `wordpress.<slug>.<pool>` 200 → then #4322 closes. catalyst-api/org-controller + provisioning images auto-bump on merge (deploy-bot + blueprint-release), so this delivers on the next chart roll.

Refs #4384 #4322 #4364 #4179

🤖 Generated with [Claude Code](https://claude.com/claude-code)