### PR TITLE
fix(bp-catalyst-platform #4389): orgTag b3465e8 -> 903eed4 — deploy-bot reverted #4387, HR-app cart still hit global openova/openova (1.4.860)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1128,10 +1128,6 @@ spec:
       #   `keycloak.keycloak.svc.cluster.local` after the #4325 de-vcluster left
       #   the bridge defaults at the dead `keycloak-x-keycloak-x-mgmt-vcluster.mgmt.svc`
       #   syncer name (NXDOMAIN → /auth/handover 401). Chart.yaml bumped in lockstep.
-      # 1.4.860 — #4388 (#4325 fallout completeness sweep): repoint the remaining
-      #   ACTIVE dead plane-vCluster references (CATALYST_MIMIR_URL, keycloak/gitea
-      #   bridges, qaFixtures S3, baseline CNP mgmt→guacamole). Chart.yaml bumped in
-      #   lockstep. Refs #4388 #4325 #4291 #4293.
       version: 1.4.862
       sourceRef:
         kind: HelmRepository

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1132,7 +1132,7 @@ spec:
       #   ACTIVE dead plane-vCluster references (CATALYST_MIMIR_URL, keycloak/gitea
       #   bridges, qaFixtures S3, baseline CNP mgmt→guacamole). Chart.yaml bumped in
       #   lockstep. Refs #4388 #4325 #4291 #4293.
-      version: 1.4.860
+      version: 1.4.862
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3143,6 +3143,12 @@ name: bp-catalyst-platform
 #   plane-vcluster-mangled name (regression-guards both #4378's NATS fix and this
 #   Valkey fix). Config-default-only change; no new bootstrap state.
 #   Refs #4368 #4373 #4325 #4347 #4322.
+# 1.4.862 — #4389: orgTag b3465e8 -> 903eed4 — the deploy-bot's a48e7b3be
+#   REVERTED orgTag from 5cbfbd8 (the #4387 per-Org-repo fix) back to the stale
+#   b3465e8, so every org-service regressed to pre-#4387 and the HelmRelease-
+#   shaped cart apps (openclaw #4272 / stalwart-mail #4307) still committed to
+#   the GLOBAL openova/openova repo (404). 903eed4 = main-post-#4390, carries
+#   #4387 for the HR-app path. Refs #4389 #4387 #4307 #4272.
 # 1.4.860 — #4388 (#4325 fallout completeness sweep): repoint the remaining
 #   ACTIVE dead plane-vCluster references that the one-at-a-time live walks had
 #   not yet hit. CATALYST_MIMIR_URL (api-deployment + -kustomize) → host-ns
@@ -3155,7 +3161,7 @@ name: bp-catalyst-platform
 #   INGRESS entry → `guacamole` (bp-guacamole re-homed to its own host ns by
 #   #4325; the guacamole webapp→guacamole-pg:5432 path needs it). Config-default-
 #   only change; no new bootstrap state. Refs #4388 #4325 #4291 #4293.
-version: 1.4.861
+version: 1.4.862
 # 1.4.774 — #4082: application-controller ClusterRole gains dr.openova.io/continuums
 #   (get/list/watch/create/update/patch/delete) — was in the controller's own
 #   deploy/rbac.yaml but MISSING from this platform chart, so a singleton /

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -556,7 +556,15 @@ images:
   # the live Organization CRD rejects 422 ("Unsupported value sme: supported
   # values org, corporate"), so only 34ff594 lets tenant.created mint the Org CR.
   # Refs #3964 #3995.
-  orgTag: "b3465e8"
+  # 903eed4 (#4389, 2026-06-26) — the deploy-bot's a48e7b3be REVERTED orgTag
+  # from 5cbfbd8 (the #4387 per-Org-repo fix, set by 6b9a210b2) back to the
+  # stale b3465e8, so EVERY org-service (provisioning incl.) lost #4387: the
+  # HelmRelease-shaped cart apps (openclaw #4272 / stalwart-mail #4307) still
+  # committed to the GLOBAL openova/openova repo → 404 'list existing tree'
+  # (verified live on g8mail). 903eed4 is the image built from main AFTER
+  # #4390 merged — it carries #4387 (per-Org <slug>/catalyst-tenant commit) for
+  # the HR-app path too. Pin it so the cart HR apps land in the per-Org repo.
+  orgTag: "903eed4"
 
 # ─── Runtime service coordinates (qa-loop iter-1, cluster
 # `catalyst-runtime-config-missing`) ────────────────────────────────────


### PR DESCRIPTION
## Problem
HelmRelease-shaped funnel cart apps (openclaw #4272, stalwart-mail #4307) still commit to the GLOBAL `openova/openova` repo and 404 (verified live on g8mail):
```
day-2 install (http) tenant=g8mail error="commit: list existing tree: ... repos/openova/openova/git/trees/?recursive=1: 404"
```
The raw-Deployment wordpress path already lands in the per-Org repo (per #4387), but the HR-app path regressed.

## Root cause
The deploy-bot's `a48e7b3be` ("update org service images to 903eed4 + bump chart to 1.4.859") **REVERTED** `orgTag` from `5cbfbd8` (the #4387 per-Org-repo fix, set by `6b9a210b2`) back to the stale `b3465e8`. So every org-service (provisioning included) regressed to pre-#4387 and the HR-app commit target fell back to `openova/openova`.

## Fix
`orgTag: b3465e8 → 903eed4` (the image built from main AFTER #4390 merged — carries #4387 for the HR-app path). Chart 1.4.859 → 1.4.860.

## Verification
Live-delivering 903eed4 to the org-services provisioning on omantel.biz, then re-running the openclaw+stalwart cart walk (#4307).

Refs #4389 #4387 #4307 #4272

🤖 Generated with [Claude Code](https://claude.com/claude-code)