### PR TITLE
fix(org-controller #4389/#4297): vcluster control-plane Guaranteed QoS — per-Org LimitRange (#4292) blocked vcluster-0 → m-tier Orgs never provisioned

### DIFF
--- a/core/controllers/organization/internal/gitops/manifests.go
+++ b/core/controllers/organization/internal/gitops/manifests.go
@@ -226,6 +226,17 @@ spec:
           image:
             registry: {{ .VClusterImageRegistry }}
             repository: proxy-ghcr/loft-sh/kubernetes
+          # #4389/#4297: the k8s-distro is initContainers[0] with an asymmetric
+          # 40m/100m + 64Mi/256Mi shape (ratio 2.5/4) — the per-Org LimitRange
+          # (#4292, maxLimitRequestRatio 1) rejects it alongside the syncer.
+          # Render requests==limits so the whole vcluster-0 pod is admitted.
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
       coredns:
         # #3859 (first proven walkorg/hw167): vcluster 0.33.x's baked-in default
         # coredns is coredns/coredns:1.14.1 — a tag that does NOT exist on
@@ -251,13 +262,22 @@ spec:
         image:
           registry: {{ .VClusterImageRegistry }}
           repository: proxy-ghcr/loft-sh/vcluster-oss
+        # #4389/#4297: the per-Org LimitRange (#4292) maxLimitRequestRatio
+        # {cpu:1,memory:1} ALSO applies to the vcluster control-plane
+        # StatefulSet (it runs natively in the Org host ns, NOT inside the
+        # vcluster) — the asymmetric 100m/2000m + 192Mi/2Gi shape was 'forbidden:
+        # cpu limit to request ratio is 20' → vcluster-0 never scheduled → m-tier
+        # Orgs could not provision their vcluster at all (#4297 keystone). Render
+        # requests==limits (Guaranteed QoS) so the LimitRange admits the syncer.
+        # The platform mgmt/rtz/dmz vclusters escape only because their ns has
+        # no LimitRange; the per-Org boundary must instead satisfy it.
         resources:
           requests:
-            cpu: 100m
-            memory: 192Mi
+            cpu: 500m
+            memory: 1Gi
           limits:
-            cpu: 2000m
-            memory: 2Gi
+            cpu: 500m
+            memory: 1Gi
         persistence:
           volumeClaim:
             size: 5Gi


### PR DESCRIPTION
## Problem (#4297 keystone)
m-tier (M/L/XL) funnel Orgs never get their vcluster: `vcluster-0` StatefulSet pod is `forbidden: cpu limit to request ratio is 1, but provided ratio is 20` → vcluster HR InstallFailed (context deadline) → no Org vcluster ever comes up (verified live on g10vc).

## Root cause
The per-Org LimitRange (#4292, `maxLimitRequestRatio {cpu:1,memory:1}`) is meant to cap CUSTOMER APP pods (which run INSIDE the vcluster, synced to host). But the vcluster CONTROL-PLANE StatefulSet runs NATIVELY in the Org host ns, so the LimitRange applies to it too. The chart's asymmetric shapes:
- syncer: 100m/2000m + 192Mi/2Gi (ratio 20 / 10.6)
- k8s-distro init: 40m/100m + 64Mi/256Mi (ratio 2.5 / 4)

…are all rejected. Platform mgmt/rtz/dmz vclusters escape only because their ns has no LimitRange.

## Fix
Render the vcluster syncer (500m/1Gi) AND the k8s-distro initContainer (200m/256Mi) as `requests==limits` (Guaranteed QoS) in the vcluster HR values, so the per-Org LimitRange admits the whole vcluster-0 pod.

## Verification
Live-patching the g10vc vcluster HR values, confirming vcluster-0 schedules + the m-tier keystone (#4297): app pods run INSIDE the Org vcluster.

Refs #4389 #4297 #4292

🤖 Generated with [Claude Code](https://claude.com/claude-code)