### PR TITLE
fix(bp-openclaw/bp-stalwart-tenant #4389/#4292): Guaranteed QoS resources — per-Org LimitRange rejected the Burstable pods

### DIFF
--- a/platform/openclaw/blueprint.yaml
+++ b/platform/openclaw/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-7-agentic-workspace
 spec:
-  version: 0.2.7
+  version: 0.2.8
   card:
     title: OpenClaw
     summary: |

--- a/platform/openclaw/chart/Chart.yaml
+++ b/platform/openclaw/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-openclaw
-version: 0.2.7
+version: 0.2.8
 appVersion: "0.2.0"
 description: |
   Catalyst Blueprint chart for the OpenClaw workspace controller pattern

--- a/platform/openclaw/chart/values.yaml
+++ b/platform/openclaw/chart/values.yaml
@@ -67,10 +67,13 @@ controller:
     tag: "d82cfaf" # OVERRIDE on install with SHA-pinned tag
     pullPolicy: IfNotPresent
   port: 8080
+  # #4389/#4292: per-Org LimitRange maxLimitRequestRatio {cpu:1,memory:1}
+  # rejects Burstable pods (a funnel Org's boundary forces Guaranteed QoS).
+  # Render requests==limits so the controller pod is admitted.
   resources:
     requests:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 500m
+      memory: 512Mi
     limits:
       cpu: 500m
       memory: 512Mi
@@ -183,12 +186,13 @@ perUserPod:
     repository: ghcr.io/openova-io/openova/openclaw-runtime
     tag: "34ff594" # OVERRIDE on install with SHA-pinned tag
     pullPolicy: IfNotPresent
+  # #4389/#4292: Guaranteed QoS for the per-Org LimitRange.
   resources:
     requests:
-      cpu: 100m
-      memory: 256Mi
+      cpu: "1"
+      memory: 1Gi
     limits:
-      cpu: 1
+      cpu: "1"
       memory: 1Gi
   securityContext:
     runAsNonRoot: true

--- a/platform/stalwart-tenant/blueprint.yaml
+++ b/platform/stalwart-tenant/blueprint.yaml
@@ -43,7 +43,7 @@ spec:
   # and wired it onto the Job container. Verified live on the tkt0625
   # demo Org (omantel.biz region-a).
   # Per #817 Chart.yaml version MUST equal blueprint.yaml spec.version.
-  version: 0.1.9
+  version: 0.1.10
   card:
     title: Stalwart (per-Organization)
     summary: |

--- a/platform/stalwart-tenant/chart/Chart.yaml
+++ b/platform/stalwart-tenant/chart/Chart.yaml
@@ -114,7 +114,7 @@ name: bp-stalwart-tenant
 #   100m/64Mi — overridable) and wired it onto the Job container. The
 #   StatefulSet already declared resources (stalwart.resources); only the
 #   hook Job was missing them. Mirrors the bp-newapi hook-Job convention.
-version: 0.1.9
+version: 0.1.10
 appVersion: "0.15.5"
 description: |
   Catalyst Blueprint scratch chart for a per-Org (per-vcluster) dedicated

--- a/platform/stalwart-tenant/chart/values.yaml
+++ b/platform/stalwart-tenant/chart/values.yaml
@@ -96,12 +96,15 @@ stalwart:
       duration: "2160h"      # 90d
       renewBefore: "360h"    # 15d
 
+  # #4389/#4292: per-Org LimitRange maxLimitRequestRatio {cpu:1,memory:1}
+  # forces Guaranteed QoS — render requests==limits or the StatefulSet pod is
+  # 'forbidden: limit to request ratio is 1'.
   resources:
     requests:
-      cpu: 100m
-      memory: 256Mi
+      cpu: "1"
+      memory: 1Gi
     limits:
-      cpu: 1
+      cpu: "1"
       memory: 1Gi
 
   # SecurityContext — non-root + NET_BIND_SERVICE (issue #898).
@@ -437,10 +440,12 @@ mailboxProvisioner:
     # nothing — mirror the bp-newapi hook-Job footprint
     # (database-secret-sync-job etc.). Overridable per Inviolable
     # Principle #4.
+    # #4389/#4292: Guaranteed QoS for the per-Org LimitRange (the setup Job
+    # runs in the Org ns too).
     resources:
       requests:
-        cpu: 10m
-        memory: 32Mi
+        cpu: 100m
+        memory: 64Mi
       limits:
         cpu: 100m
         memory: 64Mi


### PR DESCRIPTION
## Problem (#4307)
A funnel Org with openclaw + stalwart-mail: the HRs install + Services come up, but NO pod schedules — the per-Org LimitRange (#4292, `maxLimitRequestRatio {cpu:1,memory:1}`) rejects them (verified live on g8mail):
- openclaw-controller: ratio 5/4 → forbidden
- stalwart StatefulSet: ratio 10/4 → forbidden
- stalwart setup Job: ratio 10/2 → forbidden

So openclaw `/readyz` + `mail.<slug>` webmail are unreachable.

## Fix
Render requests==limits (Guaranteed QoS) on all four container resource blocks so the per-Org LimitRange admits them:
- openclaw controller 500m/512Mi, runtime 1/1Gi
- stalwart-tenant main 1/1Gi, setup Job 100m/64Mi

helm lint + template clean. Charts bumped (openclaw 0.2.8, stalwart-tenant 0.1.10).

## Verification
Live-delivering the Guaranteed values to g8mail's HRs, confirming openclaw `/readyz` 200 + stalwart webmail. Sibling of the funnel-gen DB/app fix (PR #4390 merged) and the vcluster fix (PR #4393).

Refs #4389 #4292 #4307 #4272

🤖 Generated with [Claude Code](https://claude.com/claude-code)