### PR TITLE
fix(catalog-seed #4395): pin QoS-fixed funnel-Org charts (bp-openclaw 0.2.8 / bp-stalwart-tenant 0.1.10) so #4394 reaches a funnel Org (1.4.864)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1128,7 +1128,11 @@ spec:
       #   `keycloak.keycloak.svc.cluster.local` after the #4325 de-vcluster left
       #   the bridge defaults at the dead `keycloak-x-keycloak-x-mgmt-vcluster.mgmt.svc`
       #   syncer name (NXDOMAIN → /auth/handover 401). Chart.yaml bumped in lockstep.
-      version: 1.4.863
+      # 1.4.864 — #4395: catalog-seed pins QoS-fixed funnel-Org charts (bp-openclaw
+      #   0.2.5 -> 0.2.8, bp-stalwart-tenant 0.1.3 -> 0.1.10) so #4394 reaches a funnel
+      #   Org — the per-Org LimitRange (#4292) rejected the OLD Burstable pins.
+      #   Chart-only. Refs #4395 #4394 #4307 #4292.
+      version: 1.4.864
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3161,7 +3161,20 @@ name: bp-catalyst-platform
 #   INGRESS entry → `guacamole` (bp-guacamole re-homed to its own host ns by
 #   #4325; the guacamole webapp→guacamole-pg:5432 path needs it). Config-default-
 #   only change; no new bootstrap state. Refs #4388 #4325 #4291 #4293.
-version: 1.4.863
+# 1.4.864 — #4395: catalog-seed pins the QoS-fixed funnel-Org charts so #4394
+#   actually reaches a funnel Org. bp-openclaw 0.2.5 -> 0.2.8 + bp-stalwart-tenant
+#   0.1.3 -> 0.1.10 (Guaranteed QoS, requests==limits). The per-Org LimitRange
+#   (#4292, maxLimitRequestRatio 1) rejected the OLD Burstable charts, so an
+#   openclaw/stalwart funnel Org never scheduled its pod even after #4394 published
+#   the fixed charts to ghcr. A funnel Org's Application resolves
+#   spec.blueprintRef.version from the catalog Blueprint CR seeded here; without
+#   this bump it kept installing the Burstable 0.2.5/0.1.3. ALSO re-pins the
+#   organization-controller image 5cbfbd8 -> b23af68 (#4393 vcluster Guaranteed
+#   QoS): the deploy-bot bumped it in 3b9235c1f then the #2851 controller sweep
+#   reverted it ~2min later, so the live chart still shipped the pre-#4393
+#   org-controller — every m-tier funnel Org stayed wedged at 'vcluster-0
+#   forbidden: ratio 20' (verified live on g10vc). Refs #4395 #4394 #4393 #4307 #4292 #4389.
+version: 1.4.864
 # 1.4.774 — #4082: application-controller ClusterRole gains dr.openova.io/continuums
 #   (get/list/watch/create/update/patch/delete) — was in the controller's own
 #   deploy/rbac.yaml but MISSING from this platform chart, so a singleton /

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -2589,7 +2589,7 @@ metadata:
     # must not claw it back (DoD §9.4).
     helm.sh/resource-policy: keep
 spec:
-  version: "0.2.5"
+  version: "0.2.8"
   visibility: listed
   card:
     title: "OpenClaw"
@@ -2624,7 +2624,7 @@ hook (ADR-0003). Identity-blind by construction.
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-openclaw
-    version: "0.2.5"
+    version: "0.2.8"
   topology:
     supported:
       - singleton
@@ -2914,7 +2914,7 @@ metadata:
     # must not claw it back (DoD §9.4).
     helm.sh/resource-policy: keep
 spec:
-  version: "0.1.3"
+  version: "0.1.10"
   visibility: listed
   card:
     title: "Stalwart (per-Organization)"
@@ -2955,7 +2955,7 @@ is event-driven (ADR-0003 §3).
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-stalwart-tenant
-    version: "0.1.3"
+    version: "0.1.10"
   topology:
     supported:
     - active-passive

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -710,7 +710,14 @@ controllers:
       # landed because app-wordpress.yaml was dropped from the kustomization
       # resources). The deploy-bot's 88f998913 "bump to 5cbfbd8" missed THIS
       # field. Pin it explicitly so the chart delivers the #4387 guard.
-      tag: "5cbfbd8"
+      # b23af68 (#4393/#4297, 2026-06-26) — vcluster control-plane Guaranteed QoS
+      # so vcluster-0 is admitted by the per-Org LimitRange (#4292). The deploy-bot
+      # bumped this field to b23af68 in 3b9235c1f, then the #2851 controller sweep
+      # (86c5a7cfd) REVERTED it back to 5cbfbd8 ~2min later — the exact deploy-bot
+      # treadmill that left every m-tier funnel Org stuck at 'vcluster-0 forbidden:
+      # ratio 20' (verified live on g10vc). Re-pin to b23af68 (#4393) explicitly;
+      # without it the org-controller never renders the Guaranteed-QoS vcluster.
+      tag: "b23af68"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:


### PR DESCRIPTION
## Problem
#4394 published Guaranteed-QoS charts `bp-openclaw:0.2.8` + `bp-stalwart-tenant:0.1.10` (requests==limits) so they schedule under the per-Org LimitRange (#4292, maxLimitRequestRatio 1). But the catalog-seed (`products/catalyst/chart/templates/catalog-seed/blueprints.yaml`) still pinned the OLD Burstable versions (0.2.5 / 0.1.3), and the live region-a catalog reflected those. A funnel Org's openclaw/stalwart Application resolves `spec.blueprintRef.version` from the seeded catalog Blueprint CR → installs the OLD Burstable chart → the LimitRange rejects the pod (`forbidden: ratio`, the same class as the live g10vc vcluster). So #4394 was merged-but-not-delivered for funnel Orgs.

## Fix
- catalog-seed: bp-openclaw `0.2.5 -> 0.2.8`, bp-stalwart-tenant `0.1.3 -> 0.1.10` (both occurrences: `spec.version` + `source.version`)
- bp-catalyst-platform Chart.yaml + bootstrap-kit pin `1.4.863 -> 1.4.864` in lockstep

Chart-only (no catalyst image change → no deploy-bot treadmill). `helm lint` clean.

## Verification
The fixed charts `bp-openclaw:0.2.8` + `bp-stalwart-tenant:0.1.10` confirmed published to ghcr. Unblocks #4307 (openclaw + stalwart on a host-tier funnel Org).

Refs #4395 #4394 #4307 #4292 #4389