### PR TITLE
fix(application-controller): route per-Org CNPG Blueprint Cluster CR host-side when placed in a vCluster (Refs #4282)

### DIFF
--- a/core/controllers/application/internal/controller/application_controller.go
+++ b/core/controllers/application/internal/controller/application_controller.go
@@ -918,6 +918,39 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 				fanoutKubeSecretFor = r.clusterResolver().SecretFor
 			}
 
+			// #4282 root-cause-B — CNPG-bearing Blueprints reconcile their
+			// `postgresql.cnpg.io/v1 Cluster` CR HOST-SIDE, never inside a
+			// per-Org / plane vCluster. A vCluster apiserver registers NO
+			// `postgresql.cnpg.io/v1` CRD and runs NO cnpg operator (the CNPG
+			// operator + its CRDs are CLUSTER-SINGLETONS owned by the host
+			// cnpg-system release at bootstrap-kit slot 16, and the per-Org
+			// host-ns operator the catalyst funnel installs is webhook-less +
+			// WATCH_NAMESPACE-scoped to that host ns). So a bp-postgres HR
+			// pivoted into a vCluster renders a hollow `InstallSucceeded`: the
+			// chart's `cluster.yaml` is gated on
+			// `.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1"`, which is
+			// FALSE in the vCluster, so ZERO Cluster CRs render and the
+			// Application hangs Provisioning forever (the #4282 shared-pg-d
+			// repro). This is the SAME invariant the funnel's bp-cnpg-pair path
+			// already enforces (#4293 BLOCKER-1 / TestCNPGPair_PrimaryStaysHost
+			// Side_BothTiers): keep the Cluster CR on the host where the
+			// operator+CRD live; the in-vCluster app pods reach the DB through
+			// the synced Service + the reflected credential Secret. Suppress the
+			// vCluster pivot (no kubeConfig secretRef) and author the HR in the
+			// Application's own host namespace so the host helm-controller
+			// installs the chart into a namespace the host/per-Org cnpg-system
+			// operator reconciles. Detection is by the Blueprint's
+			// `catalyst.openova.io/companion: bp-cnpg` label (present on the LIVE
+			// catalog-seed CR) with a fallback to a `spec.depends[].blueprint:
+			// bp-cnpg` edge for source-authored Blueprints. Non-CNPG Blueprints
+			// (grafana/keycloak/…) keep the proven vCluster pivot unchanged.
+			if placementTier != "" && blueprintRequiresHostCNPGOperator(bp) {
+				r.Log.Info("CNPG-bearing Blueprint placed in a vCluster tier — routing the Cluster CR host-side (no vCluster pivot) so the host cnpg-system operator reconciles it (#4282)",
+					"blueprint", spec.BlueprintName, "tier", placementTier, "hostNamespace", app.GetNamespace())
+				fanoutWriteNamespace = app.GetNamespace()
+				fanoutKubeSecretFor = nil
+			}
+
 			// Source-ref + chart: read from Blueprint.spec.manifests
 			// (same lookup as the per-region path below).
 			fanoutSourceKind, _, _ := unstructured.NestedString(bp.Object, "spec", "manifests", "source", "kind")
@@ -2658,6 +2691,46 @@ func blueprintChart(bp *unstructured.Unstructured) string {
 	}
 	c, _, _ := unstructured.NestedString(bp.Object, "spec", "manifests", "chart")
 	return c
+}
+
+// blueprintRequiresHostCNPGOperator reports whether the Blueprint renders
+// a `postgresql.cnpg.io/v1` resource and therefore needs the host-side CNPG
+// operator (the cluster-singleton bp-cnpg) to reconcile it — which means its
+// per-cluster HelmRelease must NOT pivot into a vCluster (#4282 root-cause-B).
+//
+// Two equivalent signals, either of which is authoritative:
+//
+//   - the `catalyst.openova.io/companion: bp-cnpg` metadata label — set on
+//     the LIVE catalog-seed Blueprint CR (products/catalyst/chart/templates/
+//     catalog-seed/blueprints.yaml) AND on platform/postgres/blueprint.yaml.
+//     This is the primary signal because the seed (the source the catalyst-api
+//     actually materializes into the cluster) carries the label but NOT the
+//     full `spec.depends[]` block.
+//   - a `spec.depends[].blueprint: bp-cnpg` edge — present on source-authored
+//     Blueprints (platform/postgres/blueprint.yaml). Fallback for CRs
+//     reconciled straight from source without the curated seed.
+//
+// A future CNPG-bearing Blueprint (e.g. a dedicated bp-cnpg-pair instance card)
+// inherits the routing for free by declaring either signal — there is no
+// hard-coded `bp-postgres` name here.
+func blueprintRequiresHostCNPGOperator(bp *unstructured.Unstructured) bool {
+	if bp == nil {
+		return false
+	}
+	if bp.GetLabels()["catalyst.openova.io/companion"] == "bp-cnpg" {
+		return true
+	}
+	deps, _, _ := unstructured.NestedSlice(bp.Object, "spec", "depends")
+	for _, d := range deps {
+		dm, ok := d.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if name, _ := dm["blueprint"].(string); name == "bp-cnpg" {
+			return true
+		}
+	}
+	return false
 }
 
 // fanoutOwnerLabels builds the org / env-type / app-uid label set the

--- a/core/controllers/application/internal/controller/application_controller_cnpg_hostside_4282_test.go
+++ b/core/controllers/application/internal/controller/application_controller_cnpg_hostside_4282_test.go
@@ -1,0 +1,212 @@
+// application_controller_cnpg_hostside_4282_test.go — #4282 root-cause-B.
+//
+// A per-Org bp-postgres Application placed into a vCluster tier must render
+// its `postgresql.cnpg.io/v1 Cluster` CR HOST-SIDE — never pivoted into the
+// vCluster — because a vCluster apiserver registers NO postgresql.cnpg.io CRD
+// and runs NO cnpg operator. The CNPG operator + its CRDs are cluster-
+// singletons owned by the host cnpg-system release (bootstrap-kit slot 16) /
+// the per-Org host-ns webhook-less operator the catalyst funnel installs. A HR
+// pivoted into the vCluster renders a hollow `InstallSucceeded` (the chart's
+// cluster.yaml is gated on `.Capabilities.APIVersions.Has
+// "postgresql.cnpg.io/v1"`, FALSE there) → 0 Cluster CRs → the Application
+// hangs Provisioning forever (the live shared-pg-d repro).
+//
+// This is the SAME host-side invariant the funnel's bp-cnpg-pair path already
+// enforces (#4293 BLOCKER-1 / gitops TestCNPGPair_PrimaryStaysHostSide_Both
+// Tiers): the Cluster CR stays where the operator+CRD live; the in-vCluster app
+// pods reach the DB through the synced Service + the reflected credential
+// Secret.
+//
+// What we assert:
+//
+//  1. A CNPG-bearing Blueprint (companion=bp-cnpg) placed in a vCluster tier
+//     renders its HR in the Application's OWN host namespace (the Org host ns,
+//     where the host cnpg-system operator reconciles), NOT the vCluster host
+//     namespace, and the HR carries NO spec.kubeConfig pivot.
+//
+//  2. The `spec.depends[].blueprint: bp-cnpg` edge is an equivalent signal —
+//     a Blueprint declaring it (but WITHOUT the companion label) routes
+//     host-side too.
+//
+//  3. A NON-CNPG Blueprint placed in the SAME vCluster tier is UNCHANGED — it
+//     keeps the proven vCluster pivot (kubeConfig secretRef → vc-<tier>, HR in
+//     the vCluster host ns). The host-routing is CNPG-only, not a blanket
+//     vCluster-pivot retirement.
+package controller
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// makeBlueprintCNPGSingleton builds a CNPG-bearing data-instance Blueprint
+// (mirrors bp-postgres): a single-target singleton placement into the given
+// vCluster tier, carrying the `catalyst.openova.io/companion: bp-cnpg` label
+// (the LIVE catalog-seed signal) when withCompanionLabel, and/or a
+// `spec.depends[].blueprint: bp-cnpg` edge when withDependsEdge.
+func makeBlueprintCNPGSingleton(name, version, tier, cluster string, withCompanionLabel, withDependsEdge bool) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("catalyst.openova.io/v1")
+	u.SetKind("Blueprint")
+	u.SetName(name)
+	u.SetGeneration(1)
+	if withCompanionLabel {
+		u.SetLabels(map[string]string{"catalyst.openova.io/companion": "bp-cnpg"})
+	}
+	spec := map[string]interface{}{
+		"version": version,
+		"card":    map[string]interface{}{"title": name},
+		"manifests": map[string]interface{}{
+			"chart": name,
+			"source": map[string]interface{}{
+				"kind": "HelmRepository",
+				"ref":  "openova-catalog",
+			},
+		},
+	}
+	if withDependsEdge {
+		spec["depends"] = []interface{}{
+			map[string]interface{}{"blueprint": "bp-cnpg", "version": "^1", "alias": "cnpg"},
+		}
+	}
+	u.Object["spec"] = spec
+	u.Object["status"] = map[string]interface{}{"ociDigest": "sha256:cnpg-fixture"}
+	return u
+}
+
+// reconcileCNPGSingletonHRs reconciles a single-target (Primary) Application of
+// the given Blueprint into the given vCluster tier and returns the rendered
+// HRs in BOTH the Application's host namespace and the vCluster host namespace.
+func reconcileCNPGSingletonHRs(t *testing.T, bp *unstructured.Unstructured, tier, cluster string) (hostNS, vclusterNS []unstructured.Unstructured) {
+	t.Helper()
+	env := makeMultiRegionEnv("acme-prod", "acme", "prod")
+	org := makeOrg("acme")
+	app := makeAppWithTargets("acme", "db", "acme-prod", bp.GetName(), "0.2.5",
+		"singleton",
+		[]string{"hetzner-fsn-rtz-prod"},
+		[]map[string]interface{}{
+			{"region": "fsn", "cluster": cluster, "vcluster": tier, "role": "Primary"},
+		},
+	)
+	fg := newFakeGitea()
+	fg.orgsExist["acme"] = true
+	r := newReconciler(t, fg, app, env, org, bp)
+
+	reconcileFromCluster(t, r, "acme", "db")
+
+	got := readApp(t, r, "acme", "db")
+	if phase, reason, msg := readPhaseAndReason(t, got); phase == PhaseFailed {
+		t.Fatalf("unexpected Failed phase: reason=%q msg=%q", reason, msg)
+	}
+
+	hostList, err := r.Dynamic.Resource(FluxHelmReleaseGVR).
+		Namespace("acme").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list HRs in host ns acme: %v", err)
+	}
+	vcHostNS := tier
+	if vcHostNS == "" {
+		vcHostNS = "mgmt"
+	}
+	vcList, err := r.Dynamic.Resource(FluxHelmReleaseGVR).
+		Namespace(vcHostNS).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list HRs in vcluster host ns %s: %v", vcHostNS, err)
+	}
+	return hostList.Items, vcList.Items
+}
+
+// TestReconcile_CNPGBlueprint_VClusterPlacement_RoutesHostSide — a CNPG-bearing
+// Blueprint (companion=bp-cnpg) placed in the mgmt vCluster tier renders its HR
+// host-side (Application ns, NO kubeConfig pivot) so the host cnpg-system
+// operator reconciles the Cluster CR. #4282 root-cause-B.
+func TestReconcile_CNPGBlueprint_VClusterPlacement_RoutesHostSide(t *testing.T) {
+	bp := makeBlueprintCNPGSingleton("bp-postgres", "0.2.5", "mgmt", "mgmt-A", true, true)
+	hostNS, vclusterNS := reconcileCNPGSingletonHRs(t, bp, "mgmt", "mgmt-A")
+
+	if len(vclusterNS) != 0 {
+		t.Fatalf("CNPG-bearing HR must NOT land in the vCluster host ns (mgmt) — it would render a hollow InstallSucceeded with 0 Cluster CRs; got %d HRs there", len(vclusterNS))
+	}
+	if len(hostNS) != 1 {
+		t.Fatalf("CNPG-bearing HR must land in the Application's own host ns (acme) where the cnpg operator reconciles; want 1, got %d", len(hostNS))
+	}
+	hr := hostNS[0]
+	if _, found, _ := unstructured.NestedMap(hr.Object, "spec", "kubeConfig"); found {
+		t.Errorf("CNPG-bearing host-side HR must carry NO spec.kubeConfig pivot (routing the Cluster CR into a vCluster fails on the missing postgresql.cnpg.io CRD):\n%v", hr.Object["spec"])
+	}
+	if ns := hr.GetNamespace(); ns != "acme" {
+		t.Errorf("CNPG-bearing host-side HR namespace = %q, want the Application host ns acme", ns)
+	}
+}
+
+// TestReconcile_CNPGBlueprint_DependsEdgeOnly_RoutesHostSide — the
+// `spec.depends[].blueprint: bp-cnpg` edge alone (no companion label) is an
+// equivalent host-routing signal for source-authored Blueprints.
+func TestReconcile_CNPGBlueprint_DependsEdgeOnly_RoutesHostSide(t *testing.T) {
+	bp := makeBlueprintCNPGSingleton("bp-postgres", "0.2.5", "rtz", "rtz-A", false, true)
+	hostNS, vclusterNS := reconcileCNPGSingletonHRs(t, bp, "rtz", "rtz-A")
+
+	if len(vclusterNS) != 0 {
+		t.Fatalf("CNPG depends-edge HR must NOT land in the vCluster host ns (rtz); got %d HRs there", len(vclusterNS))
+	}
+	if len(hostNS) != 1 {
+		t.Fatalf("CNPG depends-edge HR must land in the Application host ns (acme); want 1, got %d", len(hostNS))
+	}
+	if _, found, _ := unstructured.NestedMap(hostNS[0].Object, "spec", "kubeConfig"); found {
+		t.Errorf("CNPG depends-edge host-side HR must carry NO spec.kubeConfig pivot")
+	}
+}
+
+// TestReconcile_NonCNPGBlueprint_VClusterPlacement_KeepsPivot — a NON-CNPG
+// Blueprint placed in the SAME vCluster tier is UNCHANGED: it keeps the proven
+// vCluster pivot (kubeConfig secretRef → vc-mgmt, HR in the vCluster host ns).
+// The host-routing is CNPG-only — never a blanket pivot retirement.
+func TestReconcile_NonCNPGBlueprint_VClusterPlacement_KeepsPivot(t *testing.T) {
+	bp := makeBlueprintCNPGSingleton("bp-grafana", "1.0.6", "mgmt", "mgmt-A", false, false)
+	hostNS, vclusterNS := reconcileCNPGSingletonHRs(t, bp, "mgmt", "mgmt-A")
+
+	if len(vclusterNS) != 1 {
+		t.Fatalf("NON-CNPG HR must keep the vCluster pivot and land in the vCluster host ns (mgmt); want 1, got %d", len(vclusterNS))
+	}
+	if len(hostNS) != 0 {
+		t.Fatalf("NON-CNPG HR must NOT be routed into the Application host ns (acme); got %d HRs there", len(hostNS))
+	}
+	kc, found, _ := unstructured.NestedMap(vclusterNS[0].Object, "spec", "kubeConfig")
+	if !found {
+		t.Fatalf("NON-CNPG vCluster HR must carry a spec.kubeConfig pivot")
+	}
+	if name, _, _ := unstructured.NestedString(kc, "secretRef", "name"); name != "vc-mgmt" {
+		t.Errorf("NON-CNPG vCluster HR kubeConfig secretRef.name = %q, want vc-mgmt", name)
+	}
+}
+
+// TestBlueprintRequiresHostCNPGOperator_Signals — unit coverage of the
+// detection helper across the companion label, the depends edge, both, and
+// neither.
+func TestBlueprintRequiresHostCNPGOperator_Signals(t *testing.T) {
+	cases := []struct {
+		name           string
+		companionLabel bool
+		dependsEdge    bool
+		want           bool
+	}{
+		{"companion-label-only", true, false, true},
+		{"depends-edge-only", false, true, true},
+		{"both", true, true, true},
+		{"neither", false, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bp := makeBlueprintCNPGSingleton("bp-x", "1.0.0", "mgmt", "mgmt-A", tc.companionLabel, tc.dependsEdge)
+			if got := blueprintRequiresHostCNPGOperator(bp); got != tc.want {
+				t.Errorf("blueprintRequiresHostCNPGOperator() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+	if blueprintRequiresHostCNPGOperator(nil) {
+		t.Errorf("blueprintRequiresHostCNPGOperator(nil) must be false")
+	}
+}


### PR DESCRIPTION
Refs #4282 (root-cause-B — leave the issue at `status/uat`; the live walk validates criterion 3).

## The gap
A per-Org bp-postgres Application placed into a vCluster tier renders its HelmRelease with a `spec.kubeConfig` pivot INTO the target vCluster. A vCluster apiserver registers NO `postgresql.cnpg.io/v1` CRD and runs NO CNPG operator (the operator + its CRDs are cluster-singletons owned by the host `cnpg-system` release at bootstrap-kit slot 16; the per-Org host-ns operator the catalyst funnel installs is webhook-less + `WATCH_NAMESPACE`-scoped to the host ns). The bp-postgres chart`s `cluster.yaml` is gated on `.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1"` — FALSE in the vCluster — so ZERO `Cluster` CRs render (a hollow `InstallSucceeded`) and the Application hangs `Provisioning` forever (the live `shared-pg-d` repro).

## Approach — option (b): route the Cluster CR host-side
This is the SAME host-side invariant the funnel`s `bp-cnpg-pair` path already enforces (#4293 GATE-1 / `TestCNPGPair_PrimaryStaysHostSide_BothTiers`): keep the `Cluster` CR where the operator + CRD live; the in-vCluster app pods reach the DB through the synced Service + the reflected credential Secret.

Chosen over option (a) (reconcile a per-Org bp-cnpg operator INTO each target vCluster) because it is strictly less code, introduces NO new per-Org operator install path, and reuses the exact, already-proven host-side routing the cnpg-pair path uses — least likely to regress.

When a CNPG-bearing Blueprint is placed in a vCluster tier, the fan-out now:
- suppresses the vCluster pivot (`fanoutKubeSecretFor = nil`), and
- authors the HR in the Application`s own host namespace (`fanoutWriteNamespace = app.GetNamespace()`),

so the host helm-controller installs the chart into a namespace the host/per-Org `cnpg-system` operator reconciles.

## Detection (no hard-coded blueprint name)
New `blueprintRequiresHostCNPGOperator(bp)` helper keys off either signal:
- `catalyst.openova.io/companion: bp-cnpg` metadata label — present on the LIVE catalog-seed CR (`products/catalyst/chart/templates/catalog-seed/blueprints.yaml`) and on `platform/postgres/blueprint.yaml` (primary signal — the seed carries the label but not the full `spec.depends[]` block), or
- a `spec.depends[].blueprint: bp-cnpg` edge — fallback for source-authored Blueprints.

A future CNPG-bearing card inherits the routing for free.

## Guard / tests
`core/controllers/application/internal/controller/application_controller_cnpg_hostside_4282_test.go`:
- CNPG-via-label → HR host-side (Application ns), NO kubeConfig pivot, 0 HRs in the vCluster host ns.
- CNPG-via-depends-edge (no label) → same host-side routing.
- NON-CNPG Blueprint in the same tier → UNCHANGED: keeps the `vc-mgmt` pivot, HR in the vCluster host ns. The routing is CNPG-only, never a blanket pivot retirement.
- Helper unit table across label / edge / both / neither / nil.

Full `core/controllers/application/...` suite green; `go vet` clean.

## Scope guards honoured
- Does NOT touch the `dmz/mgmt/rtz` de-vcluster plane vocabulary (`DefaultVClusterPlacements`, `application_controller.go:368-370`) — that is #4296/#4293 scope.
- No chart change → no version bump needed (pure controller logic + test).
- Surgical: per-Org CNPG-operator coverage only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)