### PR TITLE
fix(provisioning,bp-openclaw): resolvable shared-realm OIDC issuer for funnel Orgs when per-Org realm is disabled (Refs #4272)

### DIFF
--- a/core/services/provisioning/gitops/gitops.go
+++ b/core/services/provisioning/gitops/gitops.go
@@ -200,6 +200,33 @@ type ManifestGenerator struct {
 	// back to parentDomainDefault so a render never produces a bare `<slug>.`
 	// with no zone.
 	ParentDomain string
+
+	// SovereignFQDN is the per-Sovereign apex domain (e.g. "omantel.biz").
+	// On a Sovereign where the per-Org Keycloak realm is DISABLED (the
+	// intentional default — CATALYST_PER_ORG_REALM_ENABLED=false → the
+	// org-controller never provisions a `keycloak.<slug>.<parent>` host), the
+	// only resolvable OIDC issuer is the SHARED realm fronted at
+	// `auth.<SovereignFQDN>` (the same host the console + every other app
+	// authenticates against). bp-openclaw's controller /readyz runs
+	// ensureKeys, which fetches the issuer's `.well-known/openid-configuration`
+	// + JWKS; against the NXDOMAIN per-Org host it fails → 503 forever (the
+	// live #4272 re-walk on funnel Org `g11clawmail`). When SovereignFQDN is
+	// set, generateOpenClawHR points the issuer at the resolvable shared realm
+	// so JWKS resolves and /readyz returns 200. Empty (Catalyst-Zero, or no
+	// SOVEREIGN_FQDN wiring) falls back to the conventional per-Org realm host
+	// — the legacy behavior, harmless on a cluster that DOES run per-Org realms.
+	//
+	// Populated from SOVEREIGN_FQDN in main.go (the same env the Handler reads
+	// for the KC-broker URL + git-base-path guard). Never hardcoded (Inviolable
+	// Principle 4).
+	SovereignFQDN string
+
+	// SharedRealmName is the realm segment of the shared-realm issuer
+	// (`https://auth.<SovereignFQDN>/realms/<SharedRealmName>`). The canonical
+	// Sovereign realm name is `sovereign` (platform/keycloak/blueprint.yaml
+	// `realm: sovereign`; catalyst-api's CATALYST_KC_REALM default). Empty
+	// resolves to sharedRealmNameDefault.
+	SharedRealmName string
 }
 
 // parentDomain resolves the funnel's org-pool parent zone for the
@@ -212,10 +239,37 @@ func (g *ManifestGenerator) parentDomain() string {
 	return parentDomainDefault
 }
 
+// sharedRealmIssuer returns the resolvable SHARED-realm OIDC issuer
+// `https://auth.<SovereignFQDN>/realms/<SharedRealmName>` when SovereignFQDN is
+// set, else "" (the caller falls back to the per-Org realm host). This is the
+// issuer the HelmRelease-shaped per-Org apps (#4272 openclaw, #4307 stalwart)
+// MUST use on a Sovereign whose per-Org Keycloak realm is disabled — the
+// per-Org `keycloak.<slug>.<parent>` host is NXDOMAIN there, so its JWKS fetch
+// (openclaw controller /readyz ensureKeys) fails → 503 forever. The shared
+// realm at auth.<fqdn> is the SAME issuer the console + every other Sovereign
+// app resolves, so its discovery + JWKS endpoints are live.
+func (g *ManifestGenerator) sharedRealmIssuer() string {
+	fqdn := strings.TrimSpace(g.SovereignFQDN)
+	if fqdn == "" {
+		return ""
+	}
+	realm := strings.TrimSpace(g.SharedRealmName)
+	if realm == "" {
+		realm = sharedRealmNameDefault
+	}
+	return fmt.Sprintf("https://auth.%s/realms/%s", fqdn, realm)
+}
+
 // parentDomainDefault is the org-pool parent zone the funnel stamps onto the
 // HelmRelease-shaped per-Org app hostnames when ParentDomain is unset. Matches
 // the catalog-canon default pool (docs/DOD.md §Domains-canon).
 const parentDomainDefault = "omani.homes"
+
+// sharedRealmNameDefault is the canonical Sovereign-wide Keycloak realm name
+// the shared-realm issuer (`auth.<fqdn>/realms/<this>`) targets when
+// SharedRealmName is unset. Matches platform/keycloak/blueprint.yaml
+// (`realm: sovereign`) + catalyst-api's CATALYST_KC_REALM default.
+const sharedRealmNameDefault = "sovereign"
 
 // replicaRegionKubeSecretDefault is the deterministic flux-system Secret
 // name the cross-region standby HelmRelease's spec.kubeConfig.secretRef
@@ -617,6 +671,11 @@ func (g *ManifestGenerator) GenerateAllWithAppConfigs(slug, planSlug string, app
 			slug:         slug,
 			parentDomain: g.parentDomain(),
 			kubeSecret:   hrKubeSecret,
+			// #4272: the resolvable SHARED-realm OIDC issuer
+			// (auth.<fqdn>/realms/sovereign) when this Sovereign runs no
+			// per-Org realm. Empty falls the HR templates back to the per-Org
+			// keycloak.<slug>.<parent> host (legacy / Catalyst-Zero).
+			sharedRealmIssuer: g.sharedRealmIssuer(),
 		})
 	}
 

--- a/core/services/provisioning/gitops/helmrelease_apps.go
+++ b/core/services/provisioning/gitops/helmrelease_apps.go
@@ -93,6 +93,17 @@ type helmReleaseAppOpts struct {
 	// tier so the host helm-controller installs the chart INTO the vcluster;
 	// empty on the host tier (install straight into the host `<slug>` ns).
 	kubeSecret string
+	// sharedRealmIssuer, when non-empty, is the resolvable SHARED-realm OIDC
+	// issuer (`https://auth.<sovereign-fqdn>/realms/sovereign`) the HR templates
+	// stamp instead of the per-Org `keycloak.<slug>.<parent>` realm host. On a
+	// Sovereign whose per-Org Keycloak realm is DISABLED (the default —
+	// CATALYST_PER_ORG_REALM_ENABLED=false) the per-Org host is NXDOMAIN, so
+	// openclaw's controller /readyz (which fetches the issuer's JWKS) hangs at
+	// 503 forever (#4272). The shared realm at auth.<fqdn> is the SAME issuer
+	// the console resolves, so its discovery + JWKS endpoints are live. Empty
+	// falls back to the per-Org realm host (legacy / Catalyst-Zero / a cluster
+	// that DOES run per-Org realms).
+	sharedRealmIssuer string
 }
 
 // generateHelmReleaseApp renders the HelmRepository + HelmRelease pair for a
@@ -146,7 +157,18 @@ spec:
 // Keycloak realm + NewAPI gateway, exposed via the dedicated console Gateway.
 func generateOpenClawHR(opt helmReleaseAppOpts) string {
 	host := fmt.Sprintf("openclaw.%s.%s", opt.slug, opt.parentDomain)
-	keycloakRealm := fmt.Sprintf("https://keycloak.%s.%s/realms/org-%s", opt.slug, opt.parentDomain, opt.slug)
+	// #4272: the OIDC issuer openclaw's controller /readyz validates the JWKS
+	// against. On a Sovereign whose per-Org realm is DISABLED the per-Org
+	// `keycloak.<slug>.<parent>` host is NXDOMAIN → the JWKS fetch fails →
+	// /readyz 503 forever → openclaw.<slug>/ serves public 503. When the
+	// generator resolves a shared-realm issuer (auth.<fqdn>/realms/sovereign —
+	// the SAME live issuer the console uses), stamp THAT so JWKS resolves and
+	// /readyz returns 200. Empty falls back to the per-Org realm host (legacy /
+	// Catalyst-Zero / a cluster that genuinely runs per-Org realms).
+	keycloakRealm := strings.TrimSpace(opt.sharedRealmIssuer)
+	if keycloakRealm == "" {
+		keycloakRealm = fmt.Sprintf("https://keycloak.%s.%s/realms/org-%s", opt.slug, opt.parentDomain, opt.slug)
+	}
 	newapiBase := fmt.Sprintf("https://api.%s.%s/v1", opt.slug, opt.parentDomain)
 	return fmt.Sprintf(`# bp-openclaw (#4272) — per-Org workspace controller rendered by the generic
 # funnel generator. Mirrors the BSS-door orgTenantBPOpenClaw overlay so a cart
@@ -235,7 +257,14 @@ spec:
 func generateStalwartHR(opt helmReleaseAppOpts) string {
 	mailHost := fmt.Sprintf("mail.%s.%s", opt.slug, opt.parentDomain)
 	primaryDomain := fmt.Sprintf("%s.%s", opt.slug, opt.parentDomain)
-	keycloakRealm := fmt.Sprintf("https://keycloak.%s.%s/realms/org-%s", opt.slug, opt.parentDomain, opt.slug)
+	// #4272/#4307: same resolvable-issuer rule as openclaw — on a per-Org-realm-
+	// disabled Sovereign the per-Org keycloak.<slug>.<parent> host is NXDOMAIN,
+	// so point SSO at the shared realm (auth.<fqdn>/realms/sovereign) when the
+	// generator resolved one; else fall back to the per-Org realm host.
+	keycloakRealm := strings.TrimSpace(opt.sharedRealmIssuer)
+	if keycloakRealm == "" {
+		keycloakRealm = fmt.Sprintf("https://keycloak.%s.%s/realms/org-%s", opt.slug, opt.parentDomain, opt.slug)
+	}
 	adminEmail := strings.TrimSpace(opt.adminEmail)
 	if adminEmail == "" {
 		adminEmail = fmt.Sprintf("admin@%s", primaryDomain)

--- a/core/services/provisioning/gitops/helmrelease_apps_test.go
+++ b/core/services/provisioning/gitops/helmrelease_apps_test.go
@@ -226,6 +226,79 @@ func TestFunnelCart_NoHRApps_NoHostHRFiles(t *testing.T) {
 	}
 }
 
+// TestFunnelCart_HRApps_SharedRealmIssuer — THE #4272 render-proof. On a
+// Sovereign whose per-Org Keycloak realm is DISABLED (the default), the
+// per-Org `keycloak.<slug>.<parent>` host is NXDOMAIN, so openclaw's controller
+// /readyz (which fetches the issuer's JWKS) hangs at 503 forever. When the
+// generator carries a SovereignFQDN it MUST stamp the resolvable SHARED-realm
+// issuer (auth.<fqdn>/realms/sovereign — the SAME live issuer the console uses)
+// onto BOTH the canonical oidc.issuerURL and the legacy keycloak.realmURL, and
+// must NOT emit the NXDOMAIN per-Org host.
+func TestFunnelCart_HRApps_SharedRealmIssuer(t *testing.T) {
+	g := NewManifestGenerator(testBasePath)
+	g.ParentDomain = "omani.homes"
+	g.SovereignFQDN = "omantel.biz"
+	out := g.GenerateAllWithAppConfigs("acme", "m", []string{"openclaw", "stalwart-mail"}, "pw", nil)
+
+	const wantIssuer = "https://auth.omantel.biz/realms/sovereign"
+	const nxPerOrg = "keycloak.acme.omani.homes"
+
+	openclaw := out[testBasePath+"/acme/app-openclaw.yaml"]
+	if !strings.Contains(openclaw, "issuerURL: "+wantIssuer) {
+		t.Errorf("openclaw oidc.issuerURL must be the resolvable shared realm %q:\n%s", wantIssuer, openclaw)
+	}
+	if !strings.Contains(openclaw, "realmURL: "+wantIssuer) {
+		t.Errorf("openclaw keycloak.realmURL must be the resolvable shared realm %q:\n%s", wantIssuer, openclaw)
+	}
+	if strings.Contains(openclaw, nxPerOrg) {
+		t.Errorf("openclaw must NOT emit the NXDOMAIN per-Org realm host %q when the per-Org realm is disabled:\n%s", nxPerOrg, openclaw)
+	}
+
+	stalwart := out[testBasePath+"/acme/app-stalwart-mail.yaml"]
+	if !strings.Contains(stalwart, "realmURL: "+wantIssuer) {
+		t.Errorf("stalwart keycloak.realmURL must be the resolvable shared realm %q:\n%s", wantIssuer, stalwart)
+	}
+	if strings.Contains(stalwart, nxPerOrg) {
+		t.Errorf("stalwart must NOT emit the NXDOMAIN per-Org realm host %q when the per-Org realm is disabled:\n%s", nxPerOrg, stalwart)
+	}
+}
+
+// TestFunnelCart_HRApps_PerOrgRealmFallback — when SovereignFQDN is unset
+// (Catalyst-Zero, or a cluster that genuinely runs per-Org realms), the issuer
+// stays on the conventional per-Org realm host (NO-REGRESS for the legacy path).
+func TestFunnelCart_HRApps_PerOrgRealmFallback(t *testing.T) {
+	g := NewManifestGenerator(testBasePath)
+	g.ParentDomain = "omani.homes"
+	// SovereignFQDN intentionally unset.
+	out := g.GenerateAllWithAppConfigs("acme", "m", []string{"openclaw", "stalwart-mail"}, "pw", nil)
+
+	const perOrg = "https://keycloak.acme.omani.homes/realms/org-acme"
+	openclaw := out[testBasePath+"/acme/app-openclaw.yaml"]
+	if !strings.Contains(openclaw, "issuerURL: "+perOrg) {
+		t.Errorf("openclaw must fall back to the per-Org realm host when SovereignFQDN is unset:\n%s", openclaw)
+	}
+	stalwart := out[testBasePath+"/acme/app-stalwart-mail.yaml"]
+	if !strings.Contains(stalwart, "realmURL: "+perOrg) {
+		t.Errorf("stalwart must fall back to the per-Org realm host when SovereignFQDN is unset:\n%s", stalwart)
+	}
+}
+
+// TestSharedRealmIssuer_RealmOverride — CATALYST_KC_REALM override flows into
+// the shared issuer realm segment (so a Sovereign with a non-default realm name
+// still gets a resolvable issuer).
+func TestSharedRealmIssuer_RealmOverride(t *testing.T) {
+	g := NewManifestGenerator(testBasePath)
+	g.SovereignFQDN = "omantel.biz"
+	g.SharedRealmName = "catalyst"
+	if got, want := g.sharedRealmIssuer(), "https://auth.omantel.biz/realms/catalyst"; got != want {
+		t.Errorf("sharedRealmIssuer() = %q, want %q", got, want)
+	}
+	g.SovereignFQDN = ""
+	if got := g.sharedRealmIssuer(); got != "" {
+		t.Errorf("sharedRealmIssuer() with empty SovereignFQDN = %q, want empty", got)
+	}
+}
+
 // TestParentDomain_DefaultFallback — an unset ParentDomain falls back to the
 // catalog-canon default pool so a render never produces a bare `<slug>.` host.
 func TestParentDomain_DefaultFallback(t *testing.T) {

--- a/core/services/provisioning/main.go
+++ b/core/services/provisioning/main.go
@@ -201,6 +201,22 @@ func main() {
 	// Empty falls back to the catalog-canon default pool inside the generator.
 	generator.ParentDomain = tenantParentDomain
 
+	// #4272: the per-Sovereign apex domain (e.g. "omantel.biz") + the shared
+	// Keycloak realm name. On a Sovereign whose per-Org Keycloak realm is
+	// DISABLED (the default — CATALYST_PER_ORG_REALM_ENABLED=false → no
+	// keycloak.<slug>.<parent> host is ever provisioned, so that host is
+	// NXDOMAIN), the HelmRelease-shaped per-Org apps (bp-openclaw #4272,
+	// bp-stalwart-tenant #4307) MUST point their OIDC issuer at the resolvable
+	// SHARED realm fronted at auth.<fqdn> — the SAME issuer the console + every
+	// other app uses — or openclaw's controller /readyz (which fetches the
+	// issuer's JWKS) hangs at 503 forever. SOVEREIGN_FQDN is the same env the
+	// git-base-path guard + KC-broker URL read; CATALYST_KC_REALM defaults to
+	// "sovereign" (platform/keycloak/blueprint.yaml realm: sovereign). Empty
+	// SOVEREIGN_FQDN (Catalyst-Zero) leaves the generator on the legacy per-Org
+	// realm host — harmless on a cluster that genuinely runs per-Org realms.
+	generator.SovereignFQDN = sovereignFQDN
+	generator.SharedRealmName = getEnv("CATALYST_KC_REALM", "sovereign")
+
 	// ── Git host coordinates (issue #940) ────────────────────────────
 	// On Sovereigns the canonical Git target is the local Gitea (the
 	// cutover step flipped the Sovereign's GitRepository CR to point

--- a/platform/openclaw/blueprint.yaml
+++ b/platform/openclaw/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-7-agentic-workspace
 spec:
-  version: 0.2.9
+  version: 0.2.10
   card:
     title: OpenClaw
     summary: |

--- a/platform/openclaw/chart/Chart.yaml
+++ b/platform/openclaw/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-openclaw
-version: 0.2.9
+version: 0.2.10
 appVersion: "0.2.0"
 description: |
   Catalyst Blueprint chart for the OpenClaw workspace controller pattern
@@ -31,6 +31,35 @@ description: |
 
   Changelog
   ─────────
+  0.2.10 (2026-06-26, #4272 — resolvable OIDC issuer when per-Org realm OFF)
+    - DOC-ONLY chart change paired with the provisioning-layer fix that
+      stops the funnel generator emitting an UNRESOLVABLE OIDC issuer. After
+      0.2.9 let the controller Pod START on a per-Org-realm-disabled Org, a
+      live re-walk found /readyz still 503: the funnel overlay set
+      `oidc.issuerURL` to the PER-ORG realm host
+      `https://keycloak.<slug>.<parent>/realms/org-<slug>`, but per-Org realms
+      are disabled on the Sovereign (CATALYST_PER_ORG_REALM_ENABLED=false) → no
+      such bp-keycloak host exists → that hostname is NXDOMAIN. The controller's
+      /readyz handler runs the JWKS `ensureKeys` fetch against the issuer's
+      `.well-known/openid-configuration`; an NXDOMAIN issuer fails the fetch →
+      /readyz 503 forever → openclaw.<slug>/ serves public HTTP 503.
+        • THE FIX (provisioning layer, not chart bytes): the funnel generator
+          (core/services/provisioning/gitops) now points the issuer at the
+          RESOLVABLE shared realm `https://auth.<sovereign-fqdn>/realms/sovereign`
+          — the SAME live issuer the console + every other Sovereign app uses —
+          whenever SOVEREIGN_FQDN is set. Its discovery + JWKS endpoints are
+          live, so ensureKeys succeeds and /readyz returns 200. The shared-realm
+          host/name come from the Sovereign config (SOVEREIGN_FQDN +
+          CATALYST_KC_REALM, default `sovereign`), never hardcoded. Empty
+          SOVEREIGN_FQDN (Catalyst-Zero / a cluster that DOES run per-Org
+          realms) falls back to the per-Org realm host (NO-REGRESS).
+        • The chart's `oidc.issuerURL` value is unchanged — it has always been
+          the overlay-supplied issuer; the controller's /readyz JWKS gate is
+          unchanged. NOTE: OIDC *login* additionally needs openclaw's client
+          registered in the shared realm (the 0.2.9 self-gen secret + this
+          resolvable issuer get the Pod to /readyz-200; full login-client
+          registration in the shared realm is follow-up beyond the #4272
+          /readyz-200 acceptance).
   0.2.9 (2026-06-26, #4272 #4307 — FINAL gate)
     - Self-generate the per-Org OIDC client_secret + make the controller's
       OIDC secretKeyRef optional, so the controller Pod STARTS on a funnel


### PR DESCRIPTION
## Refs #4272

### Remaining root cause (live re-walk on funnel Org `g11clawmail`)
#4397 (chart 0.2.9) let the controller Pod START on a per-Org-realm-disabled Sovereign by self-generating its OIDC client_secret. A live re-walk found `/readyz` still 503: the funnel generator set the openclaw (and stalwart) OIDC issuer to the **per-Org** realm host

```
https://keycloak.<slug>.<parent>/realms/org-<slug>
```

But per-Org realms are **disabled** on this Sovereign (`CATALYST_PER_ORG_REALM_ENABLED=false` — the default; the funnel path deliberately emits **no** per-tenant `bp-keycloak`). So that host is never provisioned → **NXDOMAIN**. The controller's `/readyz` runs `ensureKeys`, which fetches the issuer's `.well-known/openid-configuration` + JWKS; against an NXDOMAIN host the fetch fails → `/readyz` 503 forever → `openclaw.<slug>/` serves public HTTP 503.

### Where the issuer was set
`core/services/provisioning/gitops/helmrelease_apps.go` :: `generateOpenClawHR` (and `generateStalwartHR`) hardcoded `keycloak.<slug>.<parent>/realms/org-<slug>` as both `oidc.issuerURL` and `keycloak.realmURL`.

### The fix (provisioning layer — the layer that computes the per-Org issuer)
- `gitops.ManifestGenerator` gains `SovereignFQDN` + `SharedRealmName` and a `sharedRealmIssuer()` helper returning `https://auth.<fqdn>/realms/sovereign` — the **same live issuer** the console + every other Sovereign app resolves, so its discovery + JWKS endpoints are up. Host + realm name come from the Sovereign config (`SOVEREIGN_FQDN` + `CATALYST_KC_REALM`, default `sovereign`, matching `platform/keycloak/blueprint.yaml`), never hardcoded.
- `generateOpenClawHR` + `generateStalwartHR` stamp that resolvable issuer when `SovereignFQDN` is set; empty (Catalyst-Zero, or a cluster that genuinely runs per-Org realms) falls back to the per-Org realm host (NO-REGRESS).
- `main.go` wires `SOVEREIGN_FQDN` + `CATALYST_KC_REALM` into the generator.

The **BSS door is untouched on purpose**: it emits a per-tenant `bp-keycloak`, so its per-Org issuer host resolves there — only the funnel path (which omits `bp-keycloak`) was affected.

### Render proof
Funnel Org `g11clawmail`, `SOVEREIGN_FQDN=omantel.biz`:

```
oidc.issuerURL: https://auth.omantel.biz/realms/sovereign   # resolvable
keycloak.realmURL: https://auth.omantel.biz/realms/sovereign
# NOT keycloak.g11clawmail.omani.homes  (the NXDOMAIN per-Org host)
hostnames: [openclaw.g11clawmail.omani.homes]   # unchanged public app host
```

New render-proof tests (`helmrelease_apps_test.go`): shared-realm issuer when `SovereignFQDN` set; per-Org-host fallback when unset; `CATALYST_KC_REALM` override flows through. Full provisioning module + bp-openclaw chart `render-toggles.sh` green.

### bp-openclaw chart bump
`0.2.9 -> 0.2.10` (changelog documenting the issuer-resolution behavior; chart bytes unchanged — `oidc.issuerURL` has always been the overlay-supplied value, and the `/readyz` JWKS gate is unchanged). Installs at `version: "*"`, so no catalog-seed pin edit needed.

### Follow-up (beyond this PR's `/readyz`-200 acceptance)
Actual OIDC **login** additionally needs openclaw's client registered in the shared realm. The #4397 self-gen secret + this resolvable issuer get the Pod to `/readyz`-200 (the #4272 acceptance); registering the login client in the shared realm is follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)