### PR TITLE
fix(bp-openclaw): public-HTTPS egress for the /readyz JWKS hairpin — the titular #4272 egress-NetworkPolicy gap (0.2.11)

### DIFF
--- a/core/services/provisioning/gitops/helmrelease_apps.go
+++ b/core/services/provisioning/gitops/helmrelease_apps.go
@@ -246,6 +246,20 @@ spec:
       enabled: true
       ingress:
         allowGatewayEntity: true
+      # #4272 (the TITULAR egress gap): the controller's /readyz fetches the
+      # OIDC issuer's JWKS at the PUBLIC host (auth.<fqdn>, #4399), which
+      # hairpins out to the console-ELB EIP and back through the Cilium Gateway
+      # on :443. Once the companion CNP attaches an egress block (kube-apiserver
+      # entity), Cilium makes the controller egress CNP-enforced and an ipBlock
+      # 0.0.0.0/0 rule no longer matches the reserved identities the hairpin
+      # carries → JWKS egress-denied → /readyz 503 → controller 0/1 forever.
+      # allowPublicHttps emits the CNP toEntities :443 carve-out (world+cluster+
+      # host+remote-node). The chart default is already true; stamp it
+      # explicitly so a funnel openclaw is correct independent of any future
+      # chart-default flip.
+      egress:
+        allowApiserverEntity: true
+        allowPublicHttps: true
 `, helmRepoBlock("bp-openclaw"), opt.slug, opt.slug, opt.kubeConfigBlock(),
 		keycloakRealm, newapiBase, keycloakRealm, newapiBase, opt.slug, host)
 }

--- a/core/services/provisioning/gitops/helmrelease_apps_test.go
+++ b/core/services/provisioning/gitops/helmrelease_apps_test.go
@@ -92,6 +92,30 @@ func TestFunnelCart_OpenClawStalwart_RenderHelmReleases(t *testing.T) {
 	}
 }
 
+// TestFunnelCart_OpenClaw_PublicHttpsEgress — the TITULAR #4272 gap: the funnel
+// openclaw HR MUST stamp networkPolicy.egress.allowPublicHttps so the chart's
+// CiliumNetworkPolicy emits the :443 public-HTTPS egress carve-out the /readyz
+// JWKS hairpin to the public auth.<fqdn> host needs. Once the companion CNP
+// attaches the apiserver-entity egress block, Cilium makes the controller
+// egress CNP-enforced, so the K8s NP's ipBlock 0.0.0.0/0 :443 rule is inert for
+// the reserved-identity hairpin — the CNP must carry the egress itself.
+func TestFunnelCart_OpenClaw_PublicHttpsEgress(t *testing.T) {
+	out := cartOrgFor(t, "acme", "m", []string{"openclaw"})
+	openclaw, ok := out[testBasePath+"/acme/app-openclaw.yaml"]
+	if !ok {
+		t.Fatalf("bp-openclaw HelmRelease NOT rendered (keys: %v)", keys(out))
+	}
+	if !strings.Contains(openclaw, "allowPublicHttps: true") {
+		t.Errorf("funnel openclaw HR must stamp networkPolicy.egress.allowPublicHttps: true (#4272 titular egress gap):\n%s", openclaw)
+	}
+	if !strings.Contains(openclaw, "allowApiserverEntity: true") {
+		t.Errorf("funnel openclaw HR must keep networkPolicy.egress.allowApiserverEntity: true (#4319 reaper hop):\n%s", openclaw)
+	}
+	if !strings.Contains(openclaw, "allowGatewayEntity: true") {
+		t.Errorf("funnel openclaw HR must keep networkPolicy.ingress.allowGatewayEntity: true (#4300 gateway hop):\n%s", openclaw)
+	}
+}
+
 // TestFunnelCart_HRApps_NoDeploymentNoHostIngress — the HR apps must NOT also
 // produce a raw app-*.yaml Deployment in the vcluster apps/ tree, and must NOT
 // be wired into the traefik host ingress (they carry their own chart HTTPRoute

--- a/platform/openclaw/blueprint.yaml
+++ b/platform/openclaw/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-7-agentic-workspace
 spec:
-  version: 0.2.10
+  version: 0.2.11
   card:
     title: OpenClaw
     summary: |

--- a/platform/openclaw/chart/Chart.yaml
+++ b/platform/openclaw/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-openclaw
-version: 0.2.10
+version: 0.2.11
 appVersion: "0.2.0"
 description: |
   Catalyst Blueprint chart for the OpenClaw workspace controller pattern
@@ -31,6 +31,41 @@ description: |
 
   Changelog
   ─────────
+  0.2.11 (2026-06-26, #4272 — public-HTTPS egress for the JWKS hairpin: the
+          TITULAR egress-NetworkPolicy gap, the LAST openclaw layer)
+    - After 0.2.10 made the issuer RESOLVABLE (auth.<fqdn>/realms/sovereign), a
+      live re-walk (fresh Org w4282walk) found the controller STILL 0/1 with
+      /readyz 503: the issuer is correct + in-cluster-reachable, but the
+      controller's CILIUM egress allowed ONLY the kube-apiserver entity, so the
+      /readyz `ensureKeys` JWKS fetch to the PUBLIC auth.<fqdn> host (console-ELB
+      EIP, hairpinned back through the in-cluster Cilium Gateway on :443) was
+      egress-denied → 503 forever. This is the "NetworkPolicy assumption" in
+      #4272's own title — the final layer the prior two fixes (#4397 secret,
+      #4399 issuer) exposed.
+        • ROOT CAUSE: the companion CiliumNetworkPolicy
+          (cilium-ingress-networkpolicy.yaml) already attaches an `egress` block
+          (kube-apiserver entity, 0.2.6). On Cilium, the moment a CNP attaches
+          ANY egress rule to an endpoint, that endpoint's egress is
+          CNP-enforced. The K8s NetworkPolicy's `ipBlock 0.0.0.0/0 :443` rule
+          (networkpolicy.yaml `allowPublicHttps`) does NOT match the reserved
+          identities the JWKS hairpin carries — `world` for the external EIP,
+          `cluster`/`host`/`remote-node` for the gateway bounce — the exact
+          `policy-cidr-match-mode: ""` behaviour documented in
+          platform/external-dns/chart/templates/ciliumnetworkpolicy.yaml. So the
+          K8s NP world-:443 egress is INERT for the hairpin once the CNP egress
+          block exists.
+        • THE FIX: add a `toEntities` :443 egress to the CNP over the SAME
+          identity set the products/catalyst baseline-cilium-gateway allow-world
+          CNP admits (world + cluster + host + remote-node), covering BOTH the
+          genuine-external resolution AND the in-cluster gateway hairpin. Gated
+          on the new `networkPolicy.egress.allowPublicHttps` (default true) +
+          `publicHttpsEntities` / `publicHttpsPort`; the template now emits the
+          CNP `egress:` block when EITHER the apiserver OR the public-HTTPS rule
+          is enabled, each independently gated, still behind the cilium.io/v2
+          Capabilities check (CRD-less kind CI unaffected). The funnel generator
+          (core/services/provisioning/gitops generateOpenClawHR) now stamps
+          `networkPolicy.egress.allowPublicHttps: true` explicitly so a funnel
+          openclaw renders the carve-out independent of any chart-default flip.
   0.2.10 (2026-06-26, #4272 — resolvable OIDC issuer when per-Org realm OFF)
     - DOC-ONLY chart change paired with the provisioning-layer fix that
       stops the funnel generator emitting an UNRESOLVABLE OIDC issuer. After

--- a/platform/openclaw/chart/templates/cilium-ingress-networkpolicy.yaml
+++ b/platform/openclaw/chart/templates/cilium-ingress-networkpolicy.yaml
@@ -2,7 +2,9 @@
 #4272: the Cilium Gateway path to the OpenClaw controller is DEAD without
 this CNP, AND the kubelet readiness/liveness probe is dropped by the K8s
 NetworkPolicy on a Sovereign, AND the controller's pod-reaper cannot reach
-the in-cluster Kubernetes API. Three facts drive this template:
+the in-cluster Kubernetes API, AND the /readyz JWKS fetch to the PUBLIC
+auth.<fqdn> host (the console-ELB EIP, hairpinned back through the Cilium
+Gateway) is egress-denied. Four facts drive this template:
 
   1. Cilium Gateway API traffic reaches the backend with the reserved
      `ingress` ENTITY identity (the Envoy proxy embedded in the cilium
@@ -36,20 +38,49 @@ the in-cluster Kubernetes API. Three facts drive this template:
      `toEntities: [kube-apiserver]` is the canonical expression — same
      idiom as platform/sso-bridge cilium-networkpolicy-apiserver.yaml.
 
-CiliumNetworkPolicy from/toEntities is the canonical, ADDITIVE expression:
-when both a K8s NetworkPolicy and a CNP select the same Pod the allow-sets
-UNION, so this only opens the gateway→controller + node→controller ingress
-hops and the controller→apiserver egress hop, and leaves every other
-default-deny posture intact.
+  4. The controller's /readyz `ensureKeys` fetches the OIDC issuer's JWKS at
+     the PUBLIC host (https://auth.<fqdn>/realms/<realm> on a per-Org-realm-
+     disabled Sovereign — the SAME issuer the console resolves, #4399). That
+     host DNS-resolves to the console-ELB EIP, so the fetch hairpins OUT to
+     the EIP and BACK IN through the in-cluster Cilium Gateway on :443. The
+     K8s NP (networkpolicy.yaml `allowPublicHttps`) already allows `ipBlock
+     0.0.0.0/0 :443` — BUT (the subtle trap, the TITULAR #4272 gap) the
+     moment THIS CNP attaches an `egress` block to the controller endpoint
+     (fact 3's apiserver hop), Cilium makes the endpoint's egress
+     CNP-enforced, and an `ipBlock 0.0.0.0/0` rule does NOT match the
+     reserved identities the hairpin carries (`world` for the external EIP,
+     `cluster`/`host`/`remote-node` for the gateway bounce — the
+     `policy-cidr-match-mode: ""` behaviour documented in
+     platform/external-dns/chart/templates/ciliumnetworkpolicy.yaml). So the
+     K8s NP's world-:443 egress is INERT for the hairpin once the CNP egress
+     block exists → JWKS egress-denied → /readyz 503 → controller 0/1 forever.
+     A `toEntities` :443 egress over the baseline-cilium-gateway allow-set
+     (world + cluster + host + remote-node) admits BOTH the genuine-external
+     resolution AND the in-cluster gateway hairpin. NOTE: #4300's commit
+     message claimed the K8s NP :443 egress fixed this — it did NOT once the
+     0.2.6 CNP egress block landed; THIS rule is the real fix.
+
+CiliumNetworkPolicy from/toEntities is the canonical expression for the
+reserved-identity hops (gateway ingress, apiserver/public-HTTPS egress) that
+NO K8s NetworkPolicy selector (podSelector / namespaceSelector / ipBlock) can
+express. CAVEAT (the fact-4 trap): a CNP egress block makes the selected
+endpoint's egress CNP-enforced, so once ANY egress rule lands here EVERY
+permitted egress hop (apiserver AND public-HTTPS) must be enumerated in the
+CNP — a K8s NP ipBlock rule no longer suffices for a reserved-identity dest.
+Ingress stays a true union; egress here is the authoritative reserved-identity
+allow-set for this endpoint.
 
 Gated on the cilium.io/v2 Capabilities check (the #2988/#3102 idiom) so the
 chart still installs on CRD-less clusters (kind CI), and on
 networkPolicy.ingress.allowGatewayEntity / networkPolicy.egress.
-allowApiserverEntity so a non-Cilium overlay can opt out of either half.
+allowApiserverEntity / networkPolicy.egress.allowPublicHttps so a non-Cilium
+overlay (or a fully in-cluster issuer overlay) can opt out of any half.
 */ -}}
 {{- $apiserverEgress := .Values.networkPolicy.egress.allowApiserverEntity }}
+{{- $publicHttpsEgress := .Values.networkPolicy.egress.allowPublicHttps }}
 {{- $gatewayIngress := .Values.networkPolicy.ingress.allowGatewayEntity }}
-{{- if and .Values.controller.enabled .Values.networkPolicy.enabled (or $gatewayIngress $apiserverEgress) (.Capabilities.APIVersions.Has "cilium.io/v2") }}
+{{- $anyEgress := or $apiserverEgress $publicHttpsEgress }}
+{{- if and .Values.controller.enabled .Values.networkPolicy.enabled (or $gatewayIngress $anyEgress) (.Capabilities.APIVersions.Has "cilium.io/v2") }}
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -71,8 +102,9 @@ spec:
             - port: {{ .Values.controller.port | quote }}
               protocol: TCP
   {{- end }}
-  {{- if $apiserverEgress }}
+  {{- if $anyEgress }}
   egress:
+    {{- if $apiserverEgress }}
     # ── In-cluster Kubernetes API (the pod-reaper hop, #4272) ──────────────
     # The controller's reaper lists/creates/deletes per-user pods + reads
     # Secrets against the `kubernetes.default` ClusterIP (10.96.0.1:443).
@@ -89,5 +121,30 @@ spec:
             - port: {{ . | quote }}
               protocol: TCP
             {{- end }}
+    {{- end }}
+    {{- if $publicHttpsEgress }}
+    # ── Public-host HTTPS — the /readyz OIDC-JWKS hairpin (the TITULAR #4272 ──
+    # gap). The controller's OIDC issuer is the PUBLIC host
+    # (https://auth.<fqdn>/realms/<realm> on a per-Org-realm-disabled Sovereign
+    # — the SAME issuer the console resolves, #4399), which DNS-resolves to the
+    # console-ELB EIP. /readyz `ensureKeys` fetches that issuer's JWKS, so the
+    # request hairpins OUT to the EIP and BACK IN through the in-cluster Cilium
+    # Gateway on :443. The K8s NP already allows `ipBlock 0.0.0.0/0 :443`, but
+    # the moment THIS CNP attaches an egress block to the controller endpoint,
+    # Cilium makes the endpoint's egress CNP-enforced, and an `ipBlock
+    # 0.0.0.0/0` rule does NOT match the reserved identities the hairpin carries
+    # (`world` for the external EIP, `cluster`/`host`/`remote-node` for the
+    # gateway bounce — the `policy-cidr-match-mode: ""` behaviour documented in
+    # platform/external-dns/chart/templates/ciliumnetworkpolicy.yaml). Without
+    # this `toEntities` :443 carve-out the JWKS fetch is egress-denied → /readyz
+    # 503 → the controller never reaches Ready (0/1). The entity set mirrors the
+    # products/catalyst baseline-cilium-gateway allow-world CNP.
+    - toEntities:
+        {{- toYaml .Values.networkPolicy.egress.publicHttpsEntities | nindent 8 }}
+      toPorts:
+        - ports:
+            - port: {{ .Values.networkPolicy.egress.publicHttpsPort | quote }}
+              protocol: TCP
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/platform/openclaw/chart/values.yaml
+++ b/platform/openclaw/chart/values.yaml
@@ -339,6 +339,43 @@ networkPolicy:
     apiserverPorts:
       - "443"
       - "6443"
+    # ── Public-host HTTPS egress, CNP layer (the TITULAR #4272 gap) ────────
+    # The controller's /readyz fetches the OIDC issuer's JWKS at the PUBLIC
+    # host (https://auth.<fqdn>/realms/<realm> on a Sovereign whose per-Org
+    # realm is disabled — the SAME issuer the console resolves, #4399). That
+    # host resolves to the console-ELB EIP, so the fetch hairpins OUT to the
+    # EIP and BACK IN through the in-cluster Cilium Gateway on :443. The K8s
+    # NetworkPolicy already allows `ipBlock 0.0.0.0/0 :443` — but the moment
+    # THIS CNP attaches an `egress` block to the controller endpoint (for the
+    # apiserver hop above), Cilium makes the controller's egress CNP-enforced,
+    # and an `ipBlock 0.0.0.0/0` rule does NOT match the reserved identities
+    # the hairpin carries (`world` for the genuine-external EIP, but
+    # `cluster`/`host`/`remote-node` for the gateway bounce — the exact
+    # `policy-cidr-match-mode: ""` behaviour documented in
+    # platform/external-dns/chart/templates/ciliumnetworkpolicy.yaml). So the
+    # JWKS hairpin is egress-denied → `ensureKeys` fails → /readyz 503 → the
+    # controller stays 0/1 forever. THIS is the LAST openclaw layer (#4272).
+    #
+    # The canonical Cilium expression is a `toEntities` :443 egress over the
+    # SAME identity set the baseline-cilium-gateway allow-world CNP admits
+    # (world + cluster + host + remote-node), so both the genuine-external
+    # resolution AND the in-cluster gateway hairpin are covered. Default ON (a
+    # Sovereign needs it). Set false on a fully in-cluster overlay whose
+    # issuer resolves to an in-namespace Keycloak Service.
+    allowPublicHttps: true
+    # Reserved entities the controller may egress to on the public-HTTPS port.
+    # `world` covers the genuine external EIP; `cluster`/`host`/`remote-node`
+    # cover the JWKS hairpin bounced back through the in-cluster Cilium Gateway
+    # (the reserved-identity hop no ipBlock can express). Mirrors the allow-set
+    # in products/catalyst baseline-cilium-gateway.yaml.
+    publicHttpsEntities:
+      - world
+      - cluster
+      - host
+      - remote-node
+    # Port the public OIDC issuer (auth.<fqdn>) terminates TLS on. 443 is the
+    # console-ELB / Cilium-Gateway HTTPS listener.
+    publicHttpsPort: 443
   controller:
     ingress:
       # K8s namespace-selector ingress. EMPTY on a Sovereign — the gateway hop


### PR DESCRIPTION
## The last openclaw layer — the titular #4272 egress-NetworkPolicy gap

After the prior two layers landed and went live:
- **#4397** — self-generate the per-Org OIDC client_secret so the controller Pod starts.
- **#4399** — point the funnel issuer at the resolvable shared realm `https://auth.<fqdn>/realms/sovereign` (the per-Org realm host was NXDOMAIN).

a live re-walk (fresh Org `w4282walk` on omantel.biz) found the controller **still 0/1** with `/readyz` 503. The issuer is correct and in-cluster reachable, but the controller's **Cilium egress allowed ONLY the kube-apiserver entity**, so the `/readyz` `ensureKeys` JWKS fetch to the public `auth.<fqdn>` host timed out. This is the exact "NetworkPolicy assumption" in #4272's own title.

## Root cause

The companion CiliumNetworkPolicy (`cilium-ingress-networkpolicy.yaml`) already attaches an `egress` block — the kube-apiserver-entity pod-reaper hop (0.2.6, #4319). **On Cilium, the moment a CNP attaches any egress rule to an endpoint, that endpoint's egress is CNP-enforced.**

The `/readyz` JWKS fetch goes to the PUBLIC `auth.<fqdn>` host, which DNS-resolves to the console-ELB EIP and **hairpins back into the cluster through the Cilium Gateway on :443**. The K8s NetworkPolicy's `ipBlock 0.0.0.0/0 :443` egress (already rendered) does NOT match the reserved identities that hairpin carries — `world` for the external EIP, `cluster`/`host`/`remote-node` for the gateway bounce — the `policy-cidr-match-mode: ""` behaviour documented in `platform/external-dns/chart/templates/ciliumnetworkpolicy.yaml`. So the K8s NP world-:443 egress is **inert** for the hairpin once the CNP egress block exists → JWKS egress-denied → 503 forever.

## Fix — both layers

1. **Chart CNP** (`platform/openclaw/chart/templates/cilium-ingress-networkpolicy.yaml`): add a `toEntities` :443 egress over the same allow-set the `products/catalyst` baseline-cilium-gateway allow-world CNP admits — `world + cluster + host + remote-node` — covering both the genuine-external resolution AND the in-cluster gateway hairpin. Gated on the new `networkPolicy.egress.allowPublicHttps` (default true) + `publicHttpsEntities` / `publicHttpsPort`. The egress block now renders when EITHER the apiserver OR the public-HTTPS rule is enabled, each independently gated, still behind the `cilium.io/v2` Capabilities check (CRD-less kind CI unaffected).

2. **Funnel generator** (`core/services/provisioning/gitops/helmrelease_apps.go :: generateOpenClawHR`): stamp `networkPolicy.egress.allowPublicHttps: true` explicitly so a funnel openclaw renders the carve-out independent of any chart-default flip.

## Render proof (the new :443 egress)

Feeding the actual `generateOpenClawHR` output into `helm template --api-versions cilium.io/v2` renders the CNP with **both** egress rules:

```yaml
  egress:
    - toEntities:
        - kube-apiserver
      toPorts:
        - ports:
            - port: "443"
            - port: "6443"
    - toEntities:          # NEW — the JWKS hairpin
        - world
        - cluster
        - host
        - remote-node
      toPorts:
        - ports:
            - port: "443"
```

The K8s NetworkPolicy still renders its `ipBlock 0.0.0.0/0 :443` egress (CNI-agnostic fallback preserved). On a CRD-less kind install (no `cilium.io/v2`) the CNP no-ops.

## Versioning / tests

- Chart `0.2.10 → 0.2.11`, `blueprint.yaml` lockstep, changelog entry added.
- `helm lint` + full-chart smoke render (cilium + non-cilium) green; `check-chart-annotations.sh` green for openclaw.
- New `TestFunnelCart_OpenClaw_PublicHttpsEgress` asserts the funnel HR stamps the egress knobs; full `core/services/provisioning` test suite green.

The live `/readyz`-200 re-walk (after the services-provisioning image rolls) is the acceptance — #4272 stays `status/uat` until then.

Refs #4272

🤖 Generated with [Claude Code](https://claude.com/claude-code)
