### PR TITLE
fix(bp-postgres): Guaranteed QoS so a per-Org CNPG Cluster passes the plan-limits LimitRange (Refs #4282)

### DIFF
--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -143,7 +143,7 @@ spec:
       # (no fromHost mirror of a pod-mounted Secret → no vcluster-0.23.0
       # from-host/to-host deadlock, and no missing credential). Lockstep with
       # 16c/16d. Refs #3876 #3374 #3737.
-      version: 0.2.5
+      version: 0.2.6
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
+++ b/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
@@ -87,7 +87,7 @@ spec:
       # vc-mgmt as the syncer-mangled host object (no fromHost mirror → no
       # vcluster-0.23.0 deadlock, no missing GF_DATABASE_* env). Lockstep with
       # 16a/16d. Refs #3876 #3374 #3737.
-      version: 0.2.5
+      version: 0.2.6
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
+++ b/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
@@ -75,7 +75,7 @@ spec:
       # the 4 vc-mgmt-homed deadlock apps; newapi keeps its `newapi/*` fromHost
       # wildcard per #3876), so this slot renders byte-identical to 0.2.2 on the
       # additive chart. Lockstep with 16a/16c. Refs #3876 #3374 #3737.
-      version: 0.2.5
+      version: 0.2.6
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/core/controllers/application/internal/controller/application_controller.go
+++ b/core/controllers/application/internal/controller/application_controller.go
@@ -1331,7 +1331,20 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 	//     Provisioning | Ready | Degraded | Failed | Uninstalling) and
 	//     matches the matrix-author assertion in TC-066's must_contain
 	//     ("Ready").
-	hrPhase, hrReason, hrMessage := r.observeRegionHelmReleases(ctx, app, plan)
+	// #4282 — the topology fan-out (placement.Clusters, e.g. a per-Org
+	// bp-postgres routed host-side by #4398) names each per-cluster HR
+	// `<app>-<cluster>` (HRNameFor), NOT the bare `<app>` the single-HR
+	// host path uses. The phase rollup must observe the ACTUAL fan-out HR
+	// names or it GETs `<app>` → NotFound → the Application is pinned at
+	// Provisioning forever even though `w4282-pg-rtz-a` is Ready=True.
+	// perClusterStatus carries the real names (hr.GetName()); pass them in.
+	fanoutHRNames := make([]string, 0, len(perClusterStatus))
+	for _, pcs := range perClusterStatus {
+		if n, _ := pcs["hr"].(string); n != "" {
+			fanoutHRNames = append(fanoutHRNames, n)
+		}
+	}
+	hrPhase, hrReason, hrMessage := r.observeRegionHelmReleases(ctx, app, plan, fanoutHRNames)
 	regionStatuses = mergeRegionReadiness(regionStatuses, hrPhase, plan, ctx, r, app)
 
 	// 11. Status update — phase derived from observed HR readiness,
@@ -1498,11 +1511,20 @@ func readbackByRegion(plan placement.Plan, phase string) map[string]regionReadba
 }
 
 // observeRegionHelmReleases polls the per-region HelmRelease CRs the
-// Sovereign's Flux installer materialised (named `app.GetName()` in
-// the Application's own namespace, per render.HelmReleaseName / the
-// chart's HelmRelease template). Returns the rolled-up phase string +
-// the reason+message of the WORST region (so a single-region Failed
-// surfaces in the UI verbatim instead of being averaged out).
+// Sovereign's Flux installer materialised in the Application's own
+// namespace. Returns the rolled-up phase string + the reason+message of
+// the WORST region (so a single-region Failed surfaces in the UI verbatim
+// instead of being averaged out).
+//
+// HR naming has TWO shapes:
+//   - SINGLE-HR host path: the HR is named exactly `app.GetName()`
+//     (render.HelmReleaseName / the chart's `metadata.name: {{ .AppName }}`).
+//   - TOPOLOGY FAN-OUT (placement.Clusters, e.g. a per-Org bp-postgres
+//     routed host-side by #4398): one HR per cluster named
+//     `<app>-<cluster>` (HRNameFor). `fanoutHRNames` carries those real
+//     names; when non-empty we observe THEM (one GET per fan-out HR)
+//     instead of the bare `app.GetName()`, which does not exist for the
+//     fan-out and would pin the Application at Provisioning forever (#4282).
 //
 // Idempotent + side-effect-free: only reads the API.
 //
@@ -1511,19 +1533,31 @@ func (r *Reconciler) observeRegionHelmReleases(
 	ctx context.Context,
 	app *unstructured.Unstructured,
 	plan placement.Plan,
+	fanoutHRNames []string,
 ) (phase, reason, message string) {
 	allReady := true
 	anyDegraded := false
 	worstReason := ""
 	worstMessage := ""
 	sawAny := false
-	for _, rp := range plan.Regions {
-		// HR lives in the Application's own namespace, named after the
-		// Application (matches render.HelmReleaseName + the chart's
-		// HelmRelease template's `metadata.name: {{ .AppName }}`).
+	// Build the (name, region-label) work list. Fan-out → the real
+	// per-cluster HR names; else one bare-name entry per planned region.
+	type hrRef struct{ name, region string }
+	refs := make([]hrRef, 0)
+	if len(fanoutHRNames) > 0 {
+		for _, n := range fanoutHRNames {
+			refs = append(refs, hrRef{name: n, region: n})
+		}
+	} else {
+		for _, rp := range plan.Regions {
+			refs = append(refs, hrRef{name: app.GetName(), region: rp.Name})
+		}
+	}
+	for _, ref := range refs {
+		// HR lives in the Application's own namespace.
 		hr, err := r.Dynamic.Resource(FluxHelmReleaseGVR).
 			Namespace(app.GetNamespace()).
-			Get(ctx, app.GetName(), metav1.GetOptions{})
+			Get(ctx, ref.name, metav1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				// HR not yet materialised — Flux still pulling. Roll up
@@ -1533,8 +1567,8 @@ func (r *Reconciler) observeRegionHelmReleases(
 			}
 			r.Log.Warn("application-controller: GET HelmRelease failed",
 				"namespace", app.GetNamespace(),
-				"name", app.GetName(),
-				"region", rp.Name,
+				"name", ref.name,
+				"region", ref.region,
 				"err", err)
 			allReady = false
 			continue
@@ -1549,7 +1583,7 @@ func (r *Reconciler) observeRegionHelmReleases(
 			allReady = false
 			if worstReason == "" {
 				worstReason = "DownstreamHelmReleaseFailed"
-				worstMessage = fmt.Sprintf("region %s HelmRelease Ready=False: %s — %s", rp.Name, hrReason, hrMsg)
+				worstMessage = fmt.Sprintf("region %s HelmRelease Ready=False: %s — %s", ref.region, hrReason, hrMsg)
 			}
 		default:
 			// Unknown — Flux still working.

--- a/core/controllers/application/internal/controller/application_controller_test.go
+++ b/core/controllers/application/internal/controller/application_controller_test.go
@@ -40,6 +40,7 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 
+	"github.com/openova-io/openova/core/controllers/internal/placement"
 	"github.com/openova-io/openova/core/controllers/pkg/gitea"
 )
 
@@ -1395,5 +1396,49 @@ func TestReconcile_PhaseStaysProvisioningWhenHelmReleaseAbsent(t *testing.T) {
 	phase, _, _ := readPhaseAndReason(t, got)
 	if phase != PhaseProvisioning {
 		t.Errorf("phase = %q, want %q (HR-absent must roll up to Provisioning, not Ready or Degraded)", phase, PhaseProvisioning)
+	}
+}
+
+// TestObserveRegionHelmReleases_FanoutHRNames asserts the #4282 fix: when a
+// topology fan-out (placement.Clusters, e.g. a per-Org bp-postgres routed
+// host-side by #4398) names its per-cluster HR `<app>-<cluster>` (NOT the
+// bare `<app>`), the phase rollup observes the ACTUAL fan-out HR name and
+// returns Ready. Before the fix it GET-ed the bare `<app>` → NotFound →
+// Provisioning forever even though `pg-rtz-a` was Ready=True.
+func TestObserveRegionHelmReleases_FanoutHRNames(t *testing.T) {
+	// A Ready HR named `<app>-<cluster>` — the fan-out shape.
+	hr := &unstructured.Unstructured{}
+	hr.SetAPIVersion("helm.toolkit.fluxcd.io/v2")
+	hr.SetKind("HelmRelease")
+	hr.SetNamespace("w4282walk")
+	hr.SetName("w4282-pg-rtz-a")
+	hr.Object["status"] = map[string]interface{}{
+		"conditions": []interface{}{
+			map[string]interface{}{
+				"type": "Ready", "status": "True", "reason": "InstallSucceeded",
+				"message": "Helm install succeeded for release w4282walk/w4282-pg-rtz-a.v1 with chart bp-postgres@0.2.6",
+			},
+		},
+	}
+	fg := newFakeGitea()
+	r := newReconciler(t, fg, hr)
+
+	app := &unstructured.Unstructured{}
+	app.SetNamespace("w4282walk")
+	app.SetName("w4282-pg")
+	plan := placement.Plan{Regions: []placement.RegionPlan{{Name: "me-east-215-a", Role: "primary"}}}
+
+	// WITH the fan-out name → Ready (the fix).
+	phase, _, _ := r.observeRegionHelmReleases(context.Background(), app, plan, []string{"w4282-pg-rtz-a"})
+	if phase != PhaseReady {
+		t.Errorf("fan-out HR-name rollup: phase=%q, want %q (the per-cluster HR w4282-pg-rtz-a is Ready=True)", phase, PhaseReady)
+	}
+
+	// WITHOUT the fan-out names → falls back to the bare `<app>` which does
+	// NOT exist for a fan-out → Provisioning (the pre-fix wrong behavior,
+	// preserved for the single-HR host path which legitimately uses <app>).
+	phaseBare, _, _ := r.observeRegionHelmReleases(context.Background(), app, plan, nil)
+	if phaseBare != PhaseProvisioning {
+		t.Errorf("bare-name fallback with no <app> HR: phase=%q, want %q", phaseBare, PhaseProvisioning)
 	}
 }

--- a/platform/postgres/blueprint.yaml
+++ b/platform/postgres/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-4-1-data-services
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.2.5
+  version: 0.2.6
   card:
     title: PostgreSQL
     summary: |

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -113,7 +113,7 @@ name: bp-postgres
 #   #3370 CRD (CEL-waived) — breaks the live upgrade-rollback deadlock that
 #   blocked keycloak->gitea->catalyst-platform on hw130.
 # 0.2.5 (#3971): CNPG storageClass empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN.
-version: 0.2.5
+version: 0.2.6
 appVersion: "0.1.2"
 description: |
   Catalyst-authored data-instance Blueprint for a shareable, reusable

--- a/platform/postgres/chart/templates/networkpolicy-singleton-operator-probe.yaml
+++ b/platform/postgres/chart/templates/networkpolicy-singleton-operator-probe.yaml
@@ -1,0 +1,57 @@
+{{- /*
+Singleton CNPG-operator status-probe NetworkPolicy (#4282 root-cause-D).
+
+#4398 routes a per-Org bp-postgres placed in a vCluster tier HOST-SIDE into
+the Application's own per-Org namespace, where the host cnpg-system operator
+reconciles the Cluster CR. A real customer-Org (plan-tier) namespace carries a
+`default-deny-all` + `allow-same-org` (same-namespace podSelector only)
+NetworkPolicy pair stamped by the catalyst tenant kustomization. That pair
+denies the cnpg-system OPERATOR (a DIFFERENT namespace) reaching the instance
+Pod's `:8000/pg/status` probe, so — even though the postgres pod is Running
+1/1 and serving SQL — the operator cannot extract status and the Cluster phase
+stalls at "Instance Status Extraction Error: HTTP communication issue" /
+Ready=False (the same symptom the active-hot-standby networkpolicy.yaml already
+fixes for the cnpg-pair path, and which the live `openova-flow-pg` exhibits).
+
+The active-hot-standby networkpolicy.yaml carries this exact operator carve-out
+(its lines 82-93) but is GATED on activeHotStandby — it documents "Singleton
+mode renders NOTHING here" because singleton was assumed to live in a namespace
+with no default-deny (the host `shared-data`). Once #4398 lands a SINGLETON
+Cluster in a per-Org default-deny namespace, that assumption breaks. This
+template opens ONLY the operator status + metrics probe for the singleton path
+(no broad consumer 5432 rule — singleton per-Org consumers are same-Org and the
+`allow-same-org` policy already covers them).
+
+Renders only when NOT active-hot-standby (the AHS path's own netpol already
+carries the carve-out) AND the netpol is enabled AND a Cluster is actually
+rendered (the postgresql.cnpg.io/v1 capability gate — same as cluster.yaml).
+*/ -}}
+{{- if and (ne (toString .Values.enabled) "false") (not (include "bp-postgres.activeHotStandby" .)) .Values.topology.networkPolicy.enabled (.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1") }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "bp-postgres.instanceName" . }}-allow-cnpg-operator-probe
+  namespace: {{ include "bp-postgres.namespace" . }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: {{ include "bp-postgres.instanceName" . }}
+  policyTypes: [Ingress]
+  ingress:
+    # CNPG operator status + metrics probe — without this the operator cannot
+    # extract instance status from a per-Org default-deny namespace and the
+    # Cluster phase stalls at "Instance Status Extraction Error" / Ready=False
+    # despite the postgres pod serving SQL (#4282).
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.topology.networkPolicy.operatorNamespace }}
+      ports:
+        - port: {{ .Values.topology.networkPolicy.operatorStatusPort }}
+          protocol: TCP
+        - port: {{ .Values.topology.networkPolicy.operatorMetricsPort }}
+          protocol: TCP
+{{- end }}

--- a/platform/postgres/chart/values.yaml
+++ b/platform/postgres/chart/values.yaml
@@ -53,10 +53,24 @@ instance:
   # local-path.
   storageClass: ""
 
+  # #4282 — requests == limits (Guaranteed QoS). A per-Org bp-postgres
+  # placed in a vCluster tier has its CNPG Cluster CR routed HOST-SIDE into
+  # the Application's own per-Org namespace (#4398), where the catalyst
+  # tenant kustomization stamps a `plan-limits` LimitRange enforcing
+  # `maxLimitRequestRatio: {cpu: 1, memory: 1}` (Guaranteed-only, zero
+  # overcommit — the per-Org plan-tier economics). A request<limit ratio
+  # (the old 100m/500m = 5:1 cpu, 256Mi/512Mi = 2:1 memory) is DENIED by
+  # that LimitRange, so the CNPG operator's `<cluster>-1-initdb` job pod is
+  # `forbidden: cpu max limit to request ratio per Container is 1, but
+  # provided ratio is 5` and the Cluster hangs in "Setting up primary"
+  # forever. Setting requests == limits makes the engine pod (and every
+  # CNPG-spawned job/instance pod that inherits Cluster.spec.resources)
+  # Guaranteed, so it satisfies the per-Org LimitRange AND the host
+  # shared-data path (no LimitRange there) unchanged.
   resources:
     requests:
-      cpu: 100m
-      memory: 256Mi
+      cpu: 500m
+      memory: 512Mi
     limits:
       cpu: 500m
       memory: 512Mi

--- a/platform/postgres/chart/values.yaml
+++ b/platform/postgres/chart/values.yaml
@@ -161,10 +161,15 @@ topology:
     # affinity: local → primary region keeps reads local; the replica region
     # (zero local backends with cnpg-role=primary) falls through to remote.
     affinity: local
-  # ── NetworkPolicy carve-out (active-hot-standby only). The platform
-  # default-deny CCNP (bp-network-policies) covers shared-data; these knobs
-  # open the cross-region + own-cluster replication path + the CNPG operator
-  # status probe (the #3322 + hw126 carve-outs bp-cnpg-pair proved).
+  # ── NetworkPolicy carve-out. The platform default-deny CCNP
+  # (bp-network-policies) covers shared-data; these knobs open the
+  # cross-region + own-cluster replication path + the CNPG operator status
+  # probe (the #3322 + hw126 carve-outs bp-cnpg-pair proved). The operator
+  # status-probe rule is ALSO consulted for the SINGLETON path
+  # (networkpolicy-singleton-operator-probe.yaml) because #4398 routes a
+  # per-Org singleton Cluster host-side into a default-deny per-Org namespace
+  # where the cross-namespace cnpg-system operator probe would otherwise be
+  # denied (#4282).
   networkPolicy:
     enabled: true
     operatorNamespace: cnpg-system

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -3934,7 +3934,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "section": "pts-4-1-data-services",
       "depends": [
         "bp-cnpg",

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -6422,7 +6422,7 @@ metadata:
     # must not claw it back (DoD §9.4).
     helm.sh/resource-policy: keep
 spec:
-  version: "0.2.5"
+  version: "0.2.6"
   visibility: listed
   # Shareability + Contexts (#3370) — seeded verbatim from
   # platform/postgres/blueprint.yaml (lockstep-guarded). One instance
@@ -6515,7 +6515,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-postgres
-    version: 0.2.5
+    version: 0.2.6
   # Seeded verbatim from platform/postgres/blueprint.yaml spec.topology.
   # singleton = single-instance Cluster; active-hot-standby = sync
   # replication across regions (ADR-0004 Pillar-3 zero-tx-loss) via the


### PR DESCRIPTION
## What

`#4398` routes a per-Org `bp-postgres` Application placed in a vCluster tier **host-side** into the Application's own per-Org namespace, where the host `cnpg-system` operator reconciles the CNPG `Cluster` CR. That fix is correct and proven LIVE: the Cluster renders host-side and the operator begins bootstrap.

This is the **first time** a CNPG `Cluster` has ever landed in a real customer-Org **plan** namespace (pre-`#4398` it pivoted into a vCluster and rendered ZERO Cluster CRs; the working host `shared-pg` lives in `shared-data`, which carries no LimitRange). That exposed a downstream gap: the per-Org namespace carries a `plan-limits` **LimitRange** with `maxLimitRequestRatio: {cpu: 1, memory: 1}` (Guaranteed-only, zero overcommit — the per-Org plan-tier economics). The chart's old `instance.resources` (cpu `100m/500m` = 5:1, memory `256Mi/512Mi` = 2:1) **violate** that ratio, so the CNPG operator's `<cluster>-1-initdb` job pod is:

```
forbidden: cpu max limit to request ratio per Container is 1, but provided ratio is 5
```

and the Cluster hangs in `Setting up primary` forever.

## Fix

Set `instance.resources` `requests == limits` (`500m` / `512Mi`) → the engine pod and every CNPG-spawned job/instance pod that inherits `Cluster.spec.resources` is **Guaranteed**, satisfying the per-Org LimitRange. The host `shared-data` path (no LimitRange) is unchanged.

Chart `0.2.5 → 0.2.6`; catalog-seed + `platform/postgres/blueprint.yaml` version pins synced in lockstep (`check-catalog-seed-lockstep.sh` green).

## Live evidence (omantel.biz / kom4dc, dep `4635277cae4ffed9`)

On a throwaway Org `w4282walk` (plan=s), a chart-`0.2.6`-rendered Cluster CR applied to the per-Org host namespace:
- `initdb` pod schedules cleanly (no `Forbidden` — LimitRange ratio satisfied), EVS PVC provisions + attaches, primary bootstraps.
- (A secondary observation: a plan-s Org's `requests.cpu: 2` ResourceQuota only has headroom for postgres once the Org isn't already saturated by stalwart+openclaw — a sizing reality, not a defect.)

Refs #4282