### PR TITLE
fix(catalyst): unwedge spine Application→Continuum round-trip after #4325 de-vcluster (Refs #4212 #4402)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -139,7 +139,7 @@ spec:
       #   readiness EXEC probes + server.livenessProbe ENABLED (sealed-tolerant)
       #   so the StatefulSet + sso-configure Deployment clear the host-ns Kyverno
       #   probes-present Enforce policy (post-#4325). Refs #4347 #4325.
-      version: 1.2.55
+      version: 1.2.56
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -226,7 +226,7 @@ spec:
       #   values.yaml wires keycloak.auth.existingSecret=keycloak-admin so the
       #   password is reused (never regenerated) across reinstall + re-home. Chart
       #   + blueprint bumped in lockstep.
-      version: 1.5.4
+      version: 1.5.5
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -174,7 +174,7 @@ spec:
       #   at admission → pre-upgrade gate failed → bp-gitea HR rollback-looped and
       #   stranded bp-catalyst-platform / bp-continuum / bp-sandbox. Fix: default the
       #   guard image to the harbor-proxy form. Refs #4369 #4367 #4354.
-      version: 1.2.45
+      version: 1.2.46
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1132,7 +1132,7 @@ spec:
       #   0.2.5 -> 0.2.8, bp-stalwart-tenant 0.1.3 -> 0.1.10) so #4394 reaches a funnel
       #   Org — the per-Org LimitRange (#4292) rejected the OLD Burstable pins.
       #   Chart-only. Refs #4395 #4394 #4307 #4292.
-      version: 1.4.866
+      version: 1.4.868
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -215,7 +215,7 @@ spec:
       # 1.2.39 — #4347: harbor-sso-configure liveness/readiness EXEC probes so
       #   it clears the host-ns Kyverno probes-present Enforce policy (post-#4325).
       #   Refs #4347 #4325.
-      version: 1.2.39
+      version: 1.2.40
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.45 # lockstep with chart/Chart.yaml (#4388 objectStorage seaweedfs → host-ns, #4325 fallout)
+  version: 1.2.46 # lockstep with chart/Chart.yaml (#4402 spine topology tier:mgmt → '' host-native, #4325 de-vcluster fallout)
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).
@@ -69,14 +69,21 @@ spec:
           rtoSeconds: 30
           rpoSeconds: 0
         placement:
-          tier: mgmt
+          # #4402 (#4325 de-vcluster fallout): the `mgmt` plane vCluster was
+          # removed; the spine lands host-native in its own host namespace.
+          # The #4334 spine producer drives this Blueprint through the
+          # application-controller fan-out, which resolved `tier: mgmt` → host
+          # ns `mgmt` (now absent) → `namespaces "mgmt" not found` and never
+          # reached the Continuum producer. Host placement = empty tier; keep
+          # the mgmt-A/-B region designators. Mirrors #4375/#4379.
+          tier: ''
           clusters: [mgmt-A, mgmt-B]
           roles:
             mgmt-A: active
             mgmt-B: passive
       singleton:
         placement:
-          tier: mgmt
+          tier: ''
           clusters: [mgmt-A]
           roles:
             mgmt-A: singleton

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -192,7 +192,7 @@ name: bp-gitea
 #   `seaweedfs-s3.seaweedfs.svc` / `seaweedfs-filer.seaweedfs.svc` (bp-seaweedfs
 #   re-homed to host ns by #4325). objectStorage/mirror are default-OFF. Test
 #   assertion updated in lockstep. Refs #4388 #4325.
-version: 1.2.45
+version: 1.2.46
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/harbor/blueprint.yaml
+++ b/platform/harbor/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-5-storage-and-data
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.39  # lockstep with chart/Chart.yaml (#4347 harbor-sso-configure liveness/readiness probes for host-ns Kyverno probes-present Enforce)
+  version: 1.2.40  # lockstep with chart/Chart.yaml (#4402 spine topology tier:mgmt → '' host-native, #4325 de-vcluster fallout)
   card:
     title: Harbor
     family: foundation
@@ -122,14 +122,21 @@ spec:
           rtoSeconds: 30
           rpoSeconds: 0
         placement:
-          tier: mgmt
+          # #4402 (#4325 de-vcluster fallout): the `mgmt` plane vCluster was
+          # removed; the spine lands host-native in its own host namespace.
+          # The #4334 spine producer drives this Blueprint through the
+          # application-controller fan-out, which resolved `tier: mgmt` → host
+          # ns `mgmt` (now absent) → `namespaces "mgmt" not found` and never
+          # reached the Continuum producer. Host placement = empty tier; keep
+          # the mgmt-A/-B region designators. Mirrors #4375/#4379.
+          tier: ''
           clusters: [mgmt-A, mgmt-B]
           roles:
             mgmt-A: active
             mgmt-B: passive
       singleton:
         placement:
-          tier: mgmt
+          tier: ''
           clusters: [mgmt-A]
           roles:
             mgmt-A: singleton

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -152,7 +152,7 @@ type: application
 #   Enforce ClusterPolicy admits it (after #4325 de-vcluster re-homed bp-harbor
 #   into a native host namespace). Adds tests/kyverno-probes-present.sh.
 #   Refs #4347 #4325.
-version: 1.2.39
+version: 1.2.40
 appVersion: "2.14.3"
 # 1.2.23 (G117.5 #2744, 2026-06-02): SSO defense-in-depth via Harbor's
 # `oidc_extra_redirect_parms` config field. The configure-oauth Job now

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.5.4
+  version: 1.5.5  # lockstep with chart/Chart.yaml (#4402 spine topology tier:mgmt → '' host-native, #4325 de-vcluster fallout)
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for Organizations, shared-sovereign for corporate).
@@ -69,14 +69,21 @@ spec:
           rtoSeconds: 30
           rpoSeconds: 0
         placement:
-          tier: mgmt
+          # #4402 (#4325 de-vcluster fallout): the `mgmt` plane vCluster was
+          # removed; the spine lands host-native in its own host namespace.
+          # The #4334 spine producer drives this Blueprint through the
+          # application-controller fan-out, which resolved `tier: mgmt` → host
+          # ns `mgmt` (now absent) → `namespaces "mgmt" not found` and never
+          # reached the Continuum producer. Host placement = empty tier; keep
+          # the mgmt-A/-B region designators. Mirrors #4375/#4379.
+          tier: ''
           clusters: [mgmt-A, mgmt-B]
           roles:
             mgmt-A: active
             mgmt-B: passive
       singleton:
         placement:
-          tier: mgmt
+          tier: ''
           clusters: [mgmt-A]
           roles:
             mgmt-A: singleton

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -425,7 +425,7 @@ name: bp-keycloak
 # images pass admission. No chart-content change beyond the version line + this
 # changelog — the 1.4.38 templates/values are byte-identical and already
 # proxy-compliant. Refs #3785 (sibling proxy-class defect for the WP image).
-version: 1.5.4
+version: 1.5.5
 description: |
   1.5.2 (#4246): the per-tenant `openclaw-oidc-client-secret` Secret now
   emits BOTH `client-secret` AND `OIDC_CLIENT_SECRET` keys (it previously

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.55  # lockstep with chart/Chart.yaml (#4388 snapshot-replication seaweedfs → host-ns, #4325 fallout)
+  version: 1.2.56  # lockstep with chart/Chart.yaml (#4402 spine topology tier:mgmt → '' host-native, #4325 de-vcluster fallout)
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.
@@ -75,14 +75,23 @@ spec:
           rtoSeconds: 60
           rpoSeconds: 30
         placement:
-          tier: mgmt
+          # #4402 (#4325 de-vcluster fallout): the `mgmt` plane vCluster was
+          # removed; the spine lands host-native in its own host namespace
+          # (openbao/keycloak/harbor/gitea). The #4334 spine producer drives
+          # this Blueprint through the application-controller fan-out, which
+          # resolved `tier: mgmt` → host ns `mgmt` (now absent) → the spine
+          # Application Degraded with `namespaces "mgmt" not found` and never
+          # reached the Continuum producer. Host placement = empty tier; keep
+          # the mgmt-A/-B region designators for the multi-region split.
+          # Mirrors the per-Org #4375/#4379 tier:rtz→'' repoint.
+          tier: ''
           clusters: [mgmt-A, mgmt-B]
           roles:
             mgmt-A: active
             mgmt-B: passive
       singleton:
         placement:
-          tier: mgmt
+          tier: ''
           clusters: [mgmt-A]
           roles:
             mgmt-A: singleton

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -184,7 +184,7 @@ name: bp-openbao
 #   `seaweedfs-s3.seaweedfs.svc` / ns `seaweedfs` (bp-seaweedfs re-homed to host
 #   ns by #4325). snapshot-replication is default-OFF — applies only when an
 #   operator enables it. Test assertions updated in lockstep. Refs #4388 #4325.
-version: 1.2.55
+version: 1.2.56
 # 1.2.51 (#3888, Refs #3847): prov-time openbao KV-seed mechanism — the
 # auth-bootstrap Job reads a one-shot cloud-init `openbao-bootstrap-seed`
 # Secret + writes its keys into KV at secret/<prefix>/* with the still-valid

--- a/products/catalyst/bootstrap/api/internal/handler/post_handover_spine_apps.go
+++ b/products/catalyst/bootstrap/api/internal/handler/post_handover_spine_apps.go
@@ -107,6 +107,18 @@ type spineComponent struct {
 	// consumer. Stamping the explicit multi-region mode here closes that
 	// half of Seam 3 so the write actually flows to the Continuum reader.
 	MultiRegionMode string
+
+	// Config is the minimal spec.config the producer must stamp so the
+	// Application passes the Blueprint configSchema validation in the
+	// application-controller (#4402). Most spine Blueprints declare no
+	// required config; bp-keycloak's live catalog-seed configSchema has
+	// `required: [realmName]`, so a spine-keycloak CR with no config Fails
+	// validation (`missing properties: 'realmName'`) BEFORE it can reach the
+	// Continuum producer. The spine adopts the already-installed bootstrap
+	// HR (catalyst.openova.io/adopts-helmrelease) and never re-renders it, so
+	// this value only has to satisfy schema validation — the realm value is
+	// the platform SSO realm the bootstrap Keycloak already serves.
+	Config map[string]interface{}
 }
 
 // drCapableSpine — the canonical DR-capable bootstrap-spine roster.
@@ -139,7 +151,7 @@ type spineComponent struct {
 // standby pair, which buildContinuumPlan needs to mint the Continuum CR.
 var drCapableSpine = []spineComponent{
 	{Chart: "openbao", HRName: "bp-openbao", BlueprintName: "bp-openbao", BlueprintVersion: "1.2.25", MultiRegionMode: "active-passive"},
-	{Chart: "keycloak", HRName: "bp-keycloak", BlueprintName: "bp-keycloak", BlueprintVersion: "1.0.0", MultiRegionMode: "active-hot-standby"},
+	{Chart: "keycloak", HRName: "bp-keycloak", BlueprintName: "bp-keycloak", BlueprintVersion: "1.0.0", MultiRegionMode: "active-hot-standby", Config: map[string]interface{}{"realmName": "sovereign"}},
 	{Chart: "harbor", HRName: "bp-harbor", BlueprintName: "bp-harbor", BlueprintVersion: "1.2.26", MultiRegionMode: "active-hot-standby"},
 	{Chart: "gitea", HRName: "bp-gitea", BlueprintName: "bp-gitea", BlueprintVersion: "1.2.24", MultiRegionMode: "active-hot-standby"},
 }
@@ -485,6 +497,17 @@ func renderSpineApplicationCR(sc spineComponent, envRef, orgRef string, regions 
 		},
 		"regions": rgs,
 	}
+	// #4402 — stamp the minimal spec.config the Blueprint configSchema requires
+	// (e.g. bp-keycloak's required `realmName`) so the Application passes
+	// validation and reaches the Continuum producer. Components with no required
+	// config carry a nil Config and stamp nothing.
+	if len(sc.Config) > 0 {
+		cfg := make(map[string]interface{}, len(sc.Config))
+		for k, v := range sc.Config {
+			cfg[k] = v
+		}
+		spec["config"] = cfg
+	}
 	obj.Object["spec"] = spec
 	return obj
 }
@@ -610,12 +633,21 @@ func (h *Handler) ensureSpineOrganization(dyn dynamic.Interface, dep *Deployment
 	if email != "" {
 		owners = append(owners, map[string]interface{}{"email": email, "role": "owner"})
 	}
+	// CRD-valid enums (#4402): the Organization CRD admits tier∈{org,corporate},
+	// billingMode∈{real,chargeback,showback}, kind∈{customer,internal}. An earlier
+	// draft stamped tier:"platform"/billingMode:"free" — both rejected by the live
+	// CRD, so the control-plane Organization never landed → the spine Environment
+	// could not resolve → spine apps wedged and minted no Continuum. The spine is
+	// the Sovereign-self internal control plane, billed to no one: tier:"org",
+	// billingMode:"showback" (cost-attribution-only, never invoiced), kind:"internal".
+	// The `openova.io/scope: platform` label below is what marks it the control-plane
+	// self-org, distinct from a customer tenant Org.
 	spec := map[string]interface{}{
 		"slug":         orgRef,
 		"displayName":  display,
 		"kind":         "internal",
-		"tier":         "platform",
-		"billingMode":  "free",
+		"tier":         "org",
+		"billingMode":  "showback",
 		"sovereignRef": fqdn,
 	}
 	if len(owners) > 0 {

--- a/products/catalyst/bootstrap/api/internal/handler/post_handover_spine_apps_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/post_handover_spine_apps_test.go
@@ -139,6 +139,44 @@ func TestRenderSpineApplicationCR_ContractShape(t *testing.T) {
 	}
 }
 
+// TestRenderSpineApplicationCR_StampsRequiredConfig proves the producer stamps
+// the minimal spec.config a Blueprint's configSchema requires (#4402). The live
+// bp-keycloak configSchema is `required: [realmName]`, so a spine-keycloak CR
+// with no config Fails validation in the application-controller
+// (`missing properties: 'realmName'`) BEFORE it can reach the Continuum
+// producer. A component whose roster row carries no Config stamps no spec.config.
+func TestRenderSpineApplicationCR_StampsRequiredConfig(t *testing.T) {
+	owner := map[string]string{}
+
+	// keycloak roster row carries Config{realmName} → spec.config.realmName set.
+	kc := spineComponent{Chart: "keycloak", HRName: "bp-keycloak", BlueprintName: "bp-keycloak", BlueprintVersion: "1.0.0", MultiRegionMode: "active-hot-standby", Config: map[string]interface{}{"realmName": "sovereign"}}
+	cr := renderSpineApplicationCR(kc, "t99-omani-works-cp", "t99-omani-works", []string{"me-east-215", "eu-west-101"}, owner)
+	realm, found, _ := unstructured.NestedString(cr.Object, "spec", "config", "realmName")
+	if !found {
+		t.Fatalf("spec.config.realmName must be stamped for the keycloak spine (configSchema required: [realmName]); it was omitted")
+	}
+	if realm != "sovereign" {
+		t.Fatalf("spec.config.realmName = %q, want sovereign", realm)
+	}
+
+	// openbao roster row has no Config → no spec.config at all (Blueprint declares
+	// no required config; stamping an empty map would be noise).
+	ob := spineComponent{Chart: "openbao", HRName: "bp-openbao", BlueprintName: "bp-openbao", BlueprintVersion: "1.2.25", MultiRegionMode: "active-passive"}
+	crOB := renderSpineApplicationCR(ob, "t99-omani-works-cp", "t99-omani-works", []string{"me-east-215", "eu-west-101"}, owner)
+	if _, found, _ := unstructured.NestedMap(crOB.Object, "spec", "config"); found {
+		t.Fatalf("spec.config must be absent for a component with no required config (openbao)")
+	}
+
+	// The live keycloak roster row carries the realmName config (regression pin).
+	for _, sc := range drCapableSpine {
+		if sc.Chart == "keycloak" {
+			if sc.Config["realmName"] != "sovereign" {
+				t.Fatalf("drCapableSpine keycloak Config.realmName = %v, want sovereign", sc.Config["realmName"])
+			}
+		}
+	}
+}
+
 // TestSpinePlacementMode_SingleVsMultiRegion proves the producer stamps
 // singleton on a single-region Sovereign and the Blueprint's multi-region
 // default on a ≥2-region one — the exact gate buildContinuumPlan reads.
@@ -408,6 +446,21 @@ func TestEnsureSpinePrereqs_OrgAndMultiRegionEnv(t *testing.T) {
 	}
 	if org.GetLabels()["openova.io/scope"] != "platform" {
 		t.Fatalf("Organization missing platform-scope label: %v", org.GetLabels())
+	}
+	// #4402 — spec.tier/billingMode/kind MUST be CRD-valid enum values, else
+	// the apiserver rejects the Organization (tier∈{org,corporate},
+	// billingMode∈{real,chargeback,showback}, kind∈{customer,internal}). An
+	// earlier draft stamped tier:"platform"/billingMode:"free" — both rejected
+	// live → the control-plane Org never landed → the spine wedged with no
+	// Continuum. Pin the valid values so the regression can't return.
+	if tier, _, _ := unstructured.NestedString(org.Object, "spec", "tier"); tier != "org" {
+		t.Fatalf("Organization spec.tier = %q, want CRD-valid %q", tier, "org")
+	}
+	if bm, _, _ := unstructured.NestedString(org.Object, "spec", "billingMode"); bm != "showback" {
+		t.Fatalf("Organization spec.billingMode = %q, want CRD-valid %q", bm, "showback")
+	}
+	if kind, _, _ := unstructured.NestedString(org.Object, "spec", "kind"); kind != "internal" {
+		t.Fatalf("Organization spec.kind = %q, want CRD-valid %q", kind, "internal")
 	}
 
 	// Environment exists, references the org, and carries the REAL region

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3174,7 +3174,7 @@ name: bp-catalyst-platform
 #   reverted it ~2min later, so the live chart still shipped the pre-#4393
 #   org-controller — every m-tier funnel Org stayed wedged at 'vcluster-0
 #   forbidden: ratio 20' (verified live on g10vc). Refs #4395 #4394 #4393 #4307 #4292 #4389.
-version: 1.4.867
+version: 1.4.868
 # 1.4.774 — #4082: application-controller ClusterRole gains dr.openova.io/continuums
 #   (get/list/watch/create/update/patch/delete) — was in the controller's own
 #   deploy/rbac.yaml but MISSING from this platform chart, so a singleton /

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -634,14 +634,18 @@ spec:
           rtoSeconds: 30
           rpoSeconds: 0
         placement:
-          tier: mgmt
+          # #4402 (#4325 de-vcluster fallout): spine lands host-native (own host
+          # ns); the #4334 producer drives this via the app-controller fan-out
+          # which resolved tier:mgmt → absent host ns mgmt → no Continuum. Empty
+          # tier = host placement; keep mgmt-A/-B region designators. (#4375/#4379)
+          tier: ''
           clusters: [mgmt-A, mgmt-B]
           roles:
             mgmt-A: active
             mgmt-B: passive
       singleton:
         placement:
-          tier: mgmt
+          tier: ''
           clusters: [mgmt-A]
           roles:
             mgmt-A: singleton
@@ -3609,7 +3613,11 @@ spec:
           rtoSeconds: 30
           rpoSeconds: 0
         placement:
-          tier: mgmt
+          # #4402 (#4325 de-vcluster fallout): spine lands host-native (own host
+          # ns); the #4334 producer drives this via the app-controller fan-out
+          # which resolved tier:mgmt → absent host ns mgmt → no Continuum. Empty
+          # tier = host placement; keep mgmt-A/-B region designators. (#4375/#4379)
+          tier: ''
           clusters:
           - mgmt-A
           - mgmt-B
@@ -3618,7 +3626,7 @@ spec:
             mgmt-B: passive
       singleton:
         placement:
-          tier: mgmt
+          tier: ''
           clusters:
           - mgmt-A
           roles:
@@ -3725,7 +3733,11 @@ spec:
           rtoSeconds: 30
           rpoSeconds: 0
         placement:
-          tier: mgmt
+          # #4402 (#4325 de-vcluster fallout): spine lands host-native (own host
+          # ns); the #4334 producer drives this via the app-controller fan-out
+          # which resolved tier:mgmt → absent host ns mgmt → no Continuum. Empty
+          # tier = host placement; keep mgmt-A/-B region designators. (#4375/#4379)
+          tier: ''
           clusters:
           - mgmt-A
           - mgmt-B
@@ -3734,7 +3746,7 @@ spec:
             mgmt-B: passive
       singleton:
         placement:
-          tier: mgmt
+          tier: ''
           clusters:
           - mgmt-A
           roles:
@@ -4763,14 +4775,18 @@ spec:
           rtoSeconds: 30
           rpoSeconds: 0
         placement:
-          tier: mgmt
+          # #4402 (#4325 de-vcluster fallout): spine lands host-native (own host
+          # ns); the #4334 producer drives this via the app-controller fan-out
+          # which resolved tier:mgmt → absent host ns mgmt → no Continuum. Empty
+          # tier = host placement; keep mgmt-A/-B region designators. (#4375/#4379)
+          tier: ''
           clusters: [mgmt-A, mgmt-B]
           roles:
             mgmt-A: active
             mgmt-B: passive
       singleton:
         placement:
-          tier: mgmt
+          tier: ''
           clusters: [mgmt-A]
           roles:
             mgmt-A: singleton


### PR DESCRIPTION
## What

EPIC #4212 Seam 3 is the spine Application-CR producer → Continuum round-trip. PR #4334 added the producer and #4366 re-fires it on startup. **Both now run live on omantel.biz** (catalyst-api \`b0e3287\` contains both; the startup hook fired — \`get applications -n catalyst\` lists \`spine-openbao/keycloak/harbor/gitea\`). But the round-trip is INERT: every spine app fails BEFORE \`reconcileContinuumCR\`, so **zero spine Continuum CRs are minted** and \`status.continuumRef\`/\`status.effectivePlacementTargets\` are empty.

Root cause: three fields the producer/topology stamp became invalid after **#4325 de-vclustered the mgmt plane into host namespaces** (the producer + spine blueprints were authored before #4325 landed).

## Live evidence (omantel.biz, dep \`4635277cae4ffed9\`, region-a, READ-ONLY 2026-06-26)

\`\`\`
$ kubectl get applications.apps.openova.io -n catalyst
spine-gitea      bp-gitea      Degraded   upsert per-cluster HelmRelease mgmt/spine-gitea-mgmt-a: namespaces "mgmt" not found
spine-harbor     bp-harbor     Degraded   …namespaces "mgmt" not found
spine-keycloak   bp-keycloak   Failed     parameters do not match Blueprint configSchema: #: missing properties: 'realmName'
spine-openbao    bp-openbao    Degraded   …namespaces "mgmt" not found

$ kubectl get continuums.dr.openova.io -A
cnpg-pair-bp-cnpg-pair-continuum   Healthy   (no spine row)
\`\`\`

catalyst-api log on the 21:18Z pod start: \`restored deployments from PVC … spineReconciles:1\` → \`spine-apps: ensure control-plane Organization failed … Organization … is invalid: [spec.tier: Unsupported value: "platform" …, spec.billingMode: Unsupported value: "free" …]\` → \`spine-apps: enrolled DR-capable spine into the object model … enrolled:4\`.

## The three gaps, fixed

1. **Control-plane Organization rejected.** \`ensureSpineOrganization\` stamped \`tier:"platform"\`/\`billingMode:"free"\`; the live CRD enum is \`tier∈{org,corporate}\`, \`billingMode∈{real,chargeback,showback}\`. → Org never landed → spine Environment could not resolve. Fix: \`tier:"org"\` + \`billingMode:"showback"\` (\`kind:"internal"\` already valid).

2. **\`placement.tier:mgmt\` → namespace gone.** The spine blueprints' topology pinned \`placement.tier:mgmt\`; the app-controller resolved it to host ns \`mgmt\` (removed by #4325) → \`namespaces "mgmt" not found\`. Flip \`tier:mgmt → ''\` (host-native — the spine runs in its own \`openbao\`/\`keycloak\`/\`harbor\`/\`gitea\` host ns) in BOTH the source \`platform/<x>/blueprint.yaml\` AND the inline catalog-seed (the live by-name source), keeping the \`mgmt-A\`/\`mgmt-B\` region designators. Mirrors the per-Org #4375/#4379 \`tier:rtz → ''\` repoint.

3. **keycloak \`realmName\` unset.** \`bp-keycloak\`'s configSchema is \`required:[realmName]\`; the producer stamped no \`spec.config\` → validation Failed. Stamp \`spec.config.realmName="sovereign"\` (the platform SSO realm; the spine adopts the existing HR and never re-renders it, so this only satisfies schema validation).

## Versions (lockstep blueprint.yaml + Chart.yaml)

openbao 1.2.55→1.2.56, keycloak 1.5.4→1.5.5, harbor 1.2.39→1.2.40, gitea 1.2.45→1.2.46; bp-catalyst-platform 1.4.867→1.4.868 (catalog-seed change). Producer code rides the catalyst-api image.

## Tests

- Org test: CRD-valid \`tier\`/\`billingMode\`/\`kind\` enum assertions (regression pin).
- New \`TestRenderSpineApplicationCR_StampsRequiredConfig\`: keycloak spine carries \`spec.config.realmName\`; no-required-config components stamp no config.
- Full \`internal/handler\` suite + application-controller placement tests green; \`check-catalog-seed-lockstep\` PASS; all 4 spine charts + catalyst chart helm-render clean.

## Acceptance (live, after this rolls onto omantel.biz)

- \`get applications -n catalyst\` → spine-* no longer Degraded/Failed on the above.
- \`get continuums.dr.openova.io -A\` → one spine Continuum row per DR-capable spine.
- Spine apps carry \`status.continuumRef\` + \`status.effectivePlacementTargets\`.

Refs #4212 #4402 #3829 #4325 #4375

🤖 Generated with [Claude Code](https://claude.com/claude-code)