### PR TITLE
fix(bp-openclaw): controller trusts public LE root + cluster CA so OIDC JWKS /readyz verifies (#4272 #4407)

### DIFF
--- a/platform/openclaw/blueprint.yaml
+++ b/platform/openclaw/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-7-agentic-workspace
 spec:
-  version: 0.2.11
+  version: 0.2.12
   card:
     title: OpenClaw
     summary: |

--- a/platform/openclaw/chart/Chart.yaml
+++ b/platform/openclaw/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-openclaw
-version: 0.2.11
+version: 0.2.12
 appVersion: "0.2.0"
 description: |
   Catalyst Blueprint chart for the OpenClaw workspace controller pattern
@@ -31,6 +31,30 @@ description: |
 
   Changelog
   ─────────
+  0.2.12 (2026-06-26, #4272 #4407 — controller TLS-trust: verify the PUBLIC
+          LE cert on the OIDC issuer, the 4th + FINAL openclaw layer)
+    - After 0.2.11 opened public-HTTPS egress so the JWKS hairpin REACHED
+      auth.<fqdn>, a live re-walk found /readyz STILL 503 — now at the TLS
+      handshake: `tls: failed to verify certificate: x509: certificate
+      signed by unknown authority`. auth.<fqdn> serves a valid Let's Encrypt
+      cert (curl from a CA-bundled pod verifies it), but the controller did
+      not.
+        • ROOT CAUSE (controller binary, not chart bytes): main.go
+          buildAPIClient() did `tlsCfg.RootCAs = clusterPool`, REPLACING the
+          system root pool with ONLY the in-cluster api-server CA (Go does
+          not merge system roots once RootCAs is set). main() hands that SAME
+          CA-pinned client to the OIDC verifier, so the discovery/JWKS fetch
+          to the public LE-signed issuer could not be verified → /readyz 503
+          forever. Masked until 0.2.6/0.2.11 egress fixes let the call reach
+          the handshake.
+        • THE FIX: base the trust pool on x509.SystemCertPool() (so the
+          public LE roots stay trusted) and APPEND the in-cluster api-server
+          CA (so api-server calls still verify) — one client trusts BOTH
+          peers. Off-cluster (no SA CA file) the system pool stands alone.
+          Regression unit-test: the combined pool verifies a cluster-CA-
+          signed leaf AND preserves the system roots (the old replace-pool
+          behaviour drops them). Controller image rebuilds on merge; the CI
+          deploy-bot bumps controller.image.tag to the new SHA.
   0.2.11 (2026-06-26, #4272 — public-HTTPS egress for the JWKS hairpin: the
           TITULAR egress-NetworkPolicy gap, the LAST openclaw layer)
     - After 0.2.10 made the issuer RESOLVABLE (auth.<fqdn>/realms/sovereign), a

--- a/platform/openclaw/controller/main.go
+++ b/platform/openclaw/controller/main.go
@@ -141,21 +141,67 @@ func getenvDefault(k, d string) string {
 	return d
 }
 
-// buildAPIClient returns an http.Client trusting the in-cluster CA for
-// api-server calls; falls back to the system pool when the CA file is
-// absent (off-cluster).
+// buildAPIClient returns an http.Client trusting BOTH the public system
+// root pool AND the in-cluster api-server CA. The same client is used for
+// two distinct TLS peers: the in-cluster api-server (signed by the cluster
+// CA at saCACertPath) and the PUBLIC OIDC issuer (auth.<sovereign-fqdn>,
+// signed by Let's Encrypt). Earlier this REPLACED the system pool with
+// only the cluster CA (`RootCAs = clusterPool`), which broke the OIDC
+// discovery/JWKS fetch with `x509: certificate signed by unknown
+// authority` because Go does not merge the system roots once RootCAs is
+// set (#4407). We now clone the system pool and APPEND the cluster CA so
+// both peers verify. Off-cluster (no CA file) the system pool stands
+// alone, exactly as before.
 func buildAPIClient() *http.Client {
 	tlsCfg := &tls.Config{MinVersion: tls.VersionTLS12}
-	if ca, err := os.ReadFile(saCACertPath); err == nil {
-		pool := x509.NewCertPool()
-		if pool.AppendCertsFromPEM(ca) {
-			tlsCfg.RootCAs = pool
-		}
-	}
+	tlsCfg.RootCAs = buildRootPool()
 	return &http.Client{
 		Timeout:   30 * time.Second,
 		Transport: &http.Transport{TLSClientConfig: tlsCfg},
 	}
+}
+
+// buildRootPool returns a cert pool that trusts the public system roots
+// (so the Let's-Encrypt-signed OIDC issuer verifies) with the in-cluster
+// api-server CA appended (so api-server calls verify too).
+//
+//	system roots present → cloned pool + cluster CA appended
+//	system roots absent   → fresh pool with just the cluster CA
+//	neither available     → nil, so crypto/tls falls back to its default
+//	                        (the host system roots) rather than trusting
+//	                        nothing
+func buildRootPool() *x509.CertPool {
+	var clusterCA []byte
+	if ca, err := os.ReadFile(saCACertPath); err == nil {
+		clusterCA = ca
+	}
+	return rootPoolFrom(clusterCA)
+}
+
+// rootPoolFrom builds the trust pool from the (optional) in-cluster CA
+// PEM, cloning the system root pool first so the public LE issuer stays
+// trusted. Split out from buildRootPool for testability (the CA PEM is
+// passed in rather than read from the const SA path).
+func rootPoolFrom(clusterCAPEM []byte) *x509.CertPool {
+	pool, err := x509.SystemCertPool()
+	haveSystem := err == nil && pool != nil
+	if !haveSystem {
+		// SystemCertPool can fail on a scratch image with no CA bundle.
+		// Start from an empty pool so we can still add the cluster CA.
+		pool = x509.NewCertPool()
+	}
+	haveClusterCA := false
+	if len(clusterCAPEM) > 0 {
+		// AppendCertsFromPEM is additive — the system roots already in the
+		// cloned pool are preserved, the cluster CA is added on top.
+		haveClusterCA = pool.AppendCertsFromPEM(clusterCAPEM)
+	}
+	if !haveSystem && !haveClusterCA {
+		// Nothing to seed the pool with — returning an empty pool would
+		// trust NO root. Return nil so crypto/tls uses the host default.
+		return nil
+	}
+	return pool
 }
 
 func main() {

--- a/platform/openclaw/controller/main_test.go
+++ b/platform/openclaw/controller/main_test.go
@@ -6,8 +6,12 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -229,5 +233,149 @@ func TestHealthzAlwaysOK(t *testing.T) {
 	healthzHandler(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("healthz = %d, want 200", rec.Code)
+	}
+}
+
+// makeCA returns a self-signed CA cert (the stand-in for the in-cluster
+// api-server CA) plus a leaf cert signed by it (the stand-in for the
+// api-server's serving cert). The CA is returned PEM-encoded.
+func makeCA(t *testing.T) (caPEM []byte, leaf *x509.Certificate) {
+	t.Helper()
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("gen CA key: %v", err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-cluster-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create CA cert: %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("parse CA cert: %v", err)
+	}
+	caPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+
+	leafKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("gen leaf key: %v", err)
+	}
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "kubernetes.default.svc"},
+		DNSNames:     []string{"kubernetes.default.svc"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create leaf cert: %v", err)
+	}
+	leaf, err = x509.ParseCertificate(leafDER)
+	if err != nil {
+		t.Fatalf("parse leaf cert: %v", err)
+	}
+	return caPEM, leaf
+}
+
+// TestRootPoolTrustsBothPublicAndClusterCA is the #4407 regression guard:
+// the controller shares one http.Client for the in-cluster api-server
+// (cluster-CA-signed) and the PUBLIC OIDC issuer (Let's-Encrypt-signed).
+// The trust pool must verify a cert chaining to the appended cluster CA
+// AND must still carry the public system roots (the old code REPLACED the
+// system pool with only the cluster CA → public LE issuer failed with
+// `x509: certificate signed by unknown authority`).
+func TestRootPoolTrustsBothPublicAndClusterCA(t *testing.T) {
+	caPEM, clusterLeaf := makeCA(t)
+
+	// Baseline: how many roots does the system pool carry on its own?
+	sysPool, sysErr := x509.SystemCertPool()
+	systemRootCount := 0
+	if sysErr == nil && sysPool != nil {
+		systemRootCount = len(sysPool.Subjects())
+	}
+
+	pool := rootPoolFrom(caPEM)
+	if pool == nil {
+		t.Fatal("rootPoolFrom returned nil with a cluster CA supplied")
+	}
+
+	// (1) The appended in-cluster CA must verify its own leaf.
+	if _, err := clusterLeaf.Verify(x509.VerifyOptions{
+		Roots:       pool,
+		CurrentTime: time.Now(),
+		KeyUsages:   []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}); err != nil {
+		t.Fatalf("cluster-CA-signed leaf must verify against the pool: %v", err)
+	}
+
+	// (2) The public system roots must be PRESERVED, not replaced. If the
+	// host carries system roots, the combined pool must be strictly larger
+	// than just the one cluster CA (proving the system roots survived the
+	// append). This is the exact property the old `RootCAs = clusterPool`
+	// code violated.
+	if systemRootCount > 0 {
+		clusterOnly := x509.NewCertPool()
+		if !clusterOnly.AppendCertsFromPEM(caPEM) {
+			t.Fatal("failed to build cluster-only reference pool")
+		}
+		if got, want := len(pool.Subjects()), len(clusterOnly.Subjects()); got <= want {
+			t.Fatalf("combined pool has %d subjects, want strictly more than the %d cluster-only subjects (system roots dropped)", got, want)
+		}
+		if len(pool.Subjects()) < systemRootCount {
+			t.Fatalf("combined pool (%d) lost system roots (had %d)", len(pool.Subjects()), systemRootCount)
+		}
+	} else {
+		t.Log("host has no system root pool; skipping public-root-preservation assertion")
+	}
+}
+
+// TestRootPoolWithoutClusterCAKeepsSystemRoots covers the off-cluster path
+// (no SA CA file): the pool must still be the system pool, so the public
+// OIDC issuer remains verifiable.
+func TestRootPoolWithoutClusterCAKeepsSystemRoots(t *testing.T) {
+	sysPool, sysErr := x509.SystemCertPool()
+	pool := rootPoolFrom(nil)
+	if sysErr == nil && sysPool != nil {
+		if pool == nil {
+			t.Fatal("rootPoolFrom(nil) returned nil despite available system roots")
+		}
+		if len(pool.Subjects()) < len(sysPool.Subjects()) {
+			t.Fatalf("off-cluster pool dropped system roots: got %d, want >= %d", len(pool.Subjects()), len(sysPool.Subjects()))
+		}
+	}
+}
+
+// TestBuildAPIClientTLSConfigured confirms the shared client is built with
+// a configured (non-empty) RootCAs / TLS-min-version, i.e. the OIDC
+// verifier it's handed in main() trusts a real root set.
+func TestBuildAPIClientTLSConfigured(t *testing.T) {
+	c := buildAPIClient()
+	tr, ok := c.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", c.Transport)
+	}
+	if tr.TLSClientConfig == nil {
+		t.Fatal("TLSClientConfig is nil")
+	}
+	if tr.TLSClientConfig.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("MinVersion = %x, want TLS1.2", tr.TLSClientConfig.MinVersion)
+	}
+	// On any host with a CA bundle, RootCAs must be a populated pool (the
+	// system roots) — never nil-with-no-fallback-and-no-trust.
+	if sysPool, err := x509.SystemCertPool(); err == nil && sysPool != nil && len(sysPool.Subjects()) > 0 {
+		if tr.TLSClientConfig.RootCAs == nil {
+			t.Fatal("RootCAs is nil despite available system roots — public issuer would not verify")
+		}
 	}
 }


### PR DESCRIPTION
## What

The per-Org `openclaw-controller` on a Sovereign stayed `0/1` with `/readyz` 503 even after the prior three #4272 layers converged (#4397 secret, #4399 issuer, #4401 egress). With egress finally open, the JWKS / OIDC-discovery fetch reached `auth.<sovereign-fqdn>` and failed at the TLS handshake:

```
tls: failed to verify certificate: x509: certificate signed by unknown authority
```

`auth.<fqdn>` serves a valid Let's Encrypt cert (`curl` from a CA-bundled pod verifies it). The controller did not.

## Root cause — `platform/openclaw/controller/main.go`

`buildAPIClient()` set `tlsCfg.RootCAs = clusterPool`, **replacing** the system root pool with only the in-cluster api-server CA (Go does not merge the system roots once `RootCAs` is set). `main()` hands that **same** CA-pinned client to the OIDC verifier (`newJWTVerifier(... cfg.httpClient)`), so the public LE-signed issuer's discovery + JWKS fetch could not be verified → `/readyz` 503 forever. This was masked until the egress fixes let the call reach the handshake — the 4th and final layer the earlier fixes exposed.

## The fix

Base the trust pool on `x509.SystemCertPool()` (so the public LE roots stay trusted) and **append** the in-cluster api-server CA (so api-server calls still verify). One shared client trusts **both** TLS peers; off-cluster (no SA CA file) the system pool stands alone, exactly as before. Extracted `rootPoolFrom()` so the pool logic is unit-testable.

## Test

`TestRootPoolTrustsBothPublicAndClusterCA` (+ `TestRootPoolWithoutClusterCAKeepsSystemRoots`, `TestBuildAPIClientTLSConfigured`): the combined pool verifies a cluster-CA-signed leaf **and** preserves the system roots. Confirmed it is a genuine guard — it FAILS against the old replace-pool behaviour (`combined pool has 1 subjects, want strictly more`) and PASSES against the fix. `go build ./...` + `go vet ./...` + full `go test ./...` green; `helm lint` green.

## Rollout

Chart bumped `0.2.11` -> `0.2.12` (lockstep). The controller image rebuilds on merge via `.github/workflows/openclaw-controller.yaml`, which SHA-pin tags the image and bumps `controller.image.tag` in `values.yaml` automatically — so the new build rolls without a manual tag edit.

## Acceptance

A fresh-Org openclaw reaches `1/1` / `/readyz`-200 on a live Sovereign once the rebuilt controller image rolls (the remaining #4272 walk gap). No live mutation in this change — code only.

Refs #4272 #4407

🤖 Generated with [Claude Code](https://claude.com/claude-code)