### PR TITLE
fix(bp-external-secrets-stores #4409): flux-managed label on webhook-gate hook Job + hourly pin-propagation safety-net

### DIFF
--- a/.github/workflows/test-bootstrap-kit.yaml
+++ b/.github/workflows/test-bootstrap-kit.yaml
@@ -43,6 +43,23 @@ on:
       - 'scripts/audit-placement-conformance.py'
       - '.github/workflows/test-bootstrap-kit.yaml'
   workflow_dispatch:
+  # #4409 — periodic pin-propagation safety-net. The slot-pin auto-bump
+  # runs in a SEPARATE async workflow (blueprint-release.yaml, TBD-A6)
+  # that the deploy-bot dispatches per chart bump. When that dispatch
+  # fails, leapfrogs a version, or the OCI publish fails, the slot pin is
+  # left permanently lagging (or pinned-at-a-never-published tag) and the
+  # push-mode audit that saw the transient drift already passed green
+  # (continue-on-error) and never re-runs — so the permanent drift rides
+  # silently until the NEXT bump of that chart happens to heal it.
+  # Concrete failure observed 2026-06-26: bp-catalyst-platform 1.4.867 +
+  # 1.4.861 advanced in Chart.yaml but were never published to ghcr while
+  # the slot pin leapfrogged past them. This hourly full-sweep +
+  # --check-ghcr run catches any such residual drift (lag OR
+  # pinned-but-unpublished) within the hour and fails LOUD (the scheduled
+  # event is excluded from the continue-on-error umbrella below — by then
+  # there is no auto-bump race to excuse the drift).
+  schedule:
+    - cron: '17 * * * *'
 
 jobs:
   dependency-graph-audit:
@@ -53,6 +70,10 @@ jobs:
     # every PR that touches a bootstrap-kit HR or the audit data files. Owned by
     # W2.K0; consumed by W2.K1-K4 PRs to validate slot 15-48 additions.
     runs-on: ubuntu-latest
+    # The hourly #4409 cron exists solely to re-run the pin-propagation
+    # safety-net (pin-sync-audit). The DAG/manifest audits below are
+    # change-driven and don't need an hourly cadence — skip them on schedule.
+    if: github.event_name != 'schedule'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -155,6 +176,11 @@ jobs:
     # The job summary surfaces the missing-tag list for any operator
     # who notices the warning.
     runs-on: ubuntu-latest
+    # push/dispatch are observational (they race the auto-bump hook, #4409
+    # comment in `on.schedule` above). The `schedule` event is NOT excused:
+    # by the time the hourly run fires there is no auto-bump race, so any
+    # residual drift (lagging slot pin or pinned-but-unpublished tag) is a
+    # genuine propagation failure and MUST fail the run loudly.
     continue-on-error: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     permissions:
       # `gh api /orgs/<org>/packages/container/<chart>/versions` needs
@@ -183,6 +209,10 @@ jobs:
             echo "Running --changed-only against base ${base}"
             bash scripts/check-bootstrap-kit-pin-sync.sh --changed-only --base "${base}"
           else
+            # push / workflow_dispatch / schedule all run the full sweep +
+            # --check-ghcr. On `schedule` (#4409) this is fail-loud — the
+            # job-level continue-on-error does NOT cover the schedule event,
+            # so residual propagation drift turns the hourly run red.
             echo "Running full sweep + --check-ghcr (event=${{ github.event_name }})"
             bash scripts/check-bootstrap-kit-pin-sync.sh --check-ghcr
           fi
@@ -191,6 +221,8 @@ jobs:
     # Static-only validation: blueprint.yaml + chart Chart.yaml + clusters/_template
     # parsing + dependency order check. Runs on every push.
     runs-on: ubuntu-latest
+    # Change-driven; not part of the #4409 hourly pin-propagation cron.
+    if: github.event_name != 'schedule'
     needs: dependency-graph-audit
     defaults:
       run:

--- a/clusters/_template/bootstrap-kit/15a-external-secrets-stores.yaml
+++ b/clusters/_template/bootstrap-kit/15a-external-secrets-stores.yaml
@@ -81,7 +81,7 @@ spec:
       # (denied live on hw54 13:46Z → HR Unknown → downstream HRs
       # blocked). 10m/32Mi req + 100m/128Mi lim — sized for ~15s
       # kubectl-poll loop, no idle headroom needed.
-      version: 1.0.8
+      version: 1.0.9
       sourceRef:
         kind: HelmRepository
         name: bp-external-secrets-stores

--- a/platform/external-secrets-stores/blueprint.yaml
+++ b/platform/external-secrets-stores/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.8 # lockstep with chart/Chart.yaml (#4388 clusterSecretStore.server → host-ns openbao, #4325 fallout)
+  version: 1.0.9 # lockstep with chart/Chart.yaml (#4409 webhook-gate hook Job flux-managed label)
   card:
     title: External Secrets — Stores
     summary: |

--- a/platform/external-secrets-stores/chart/Chart.yaml
+++ b/platform/external-secrets-stores/chart/Chart.yaml
@@ -63,7 +63,14 @@ name: bp-external-secrets-stores
 #   to the host-native `openbao.openbao.svc.cluster.local:8200` (bp-openbao
 #   re-homed to host ns by #4325 — the mangled name is the only address now gone).
 #   Config-default-only. Refs #4388 #4325.
-version: 1.0.8
+# 1.0.9 — #4409: add `app.kubernetes.io/managed-by: flux` to the webhook-gate
+#   pre-install/pre-upgrade hook Job so the kyverno baseline `flux-managed`
+#   Enforce policy (matches kind Job) admits it. Without the label the hook was
+#   denied at admission, the HR upgrade rolled back to 1.0.7, and the
+#   bootstrap-kit Kustomization stalled on the Failed HR — freezing the roll of
+#   every newer bootstrap-kit pin. Same landmine as bp-cnpg #4226 / bp-openbao
+#   #3374. Refs #4409.
+version: 1.0.9
 description: |
   Catalyst-curated Blueprint chart for the default ESO ClusterSecretStore(s)
   that wire each Sovereign's bp-external-secrets controller to its bp-openbao

--- a/platform/external-secrets-stores/chart/templates/webhook-gate-hook.yaml
+++ b/platform/external-secrets-stores/chart/templates/webhook-gate-hook.yaml
@@ -80,6 +80,17 @@ metadata:
     app.kubernetes.io/name: bp-external-secrets-stores
     app.kubernetes.io/instance: {{ .Release.Name }}
     catalyst.openova.io/component: webhook-gate
+    # #4409: this Helm pre-install/pre-upgrade hook Job is created by the
+    # helm-controller, not Flux directly, so the kyverno baseline
+    # `flux-managed` Enforce policy (workload-must-be-flux-managed, which
+    # matches kind Job) DENIES it without this label — the hook fails at
+    # admission, the HR upgrade rolls back, and the bootstrap-kit
+    # Kustomization health-gate stalls on the Failed HR (no kit-green, no
+    # roll). Same landmine already fixed for the sibling charts: bp-cnpg
+    # webhook-gate (#4226), bp-openbao init-job (#3374), bp-gitea/bp-harbor
+    # sso-configure hooks (#3296→#3297). The policy checks the Job's OWN
+    # metadata.labels, so the label belongs here (not the pod template).
+    app.kubernetes.io/managed-by: flux
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-10"


### PR DESCRIPTION
## What

Two related delivery fixes that unstall the live bootstrap-kit Kustomization on kom4dc (dep `4635277cae4ffed9`) and harden pin propagation.

### 1. bp-external-secrets-stores webhook-gate hook Job — `flux-managed` label (the live stall)

Live on kom4dc region-a, `kubectl -n flux-system get kustomization bootstrap-kit`:
```
bootstrap-kit  False  health check failed ... stalled resources: [HelmRelease/flux-system/bp-external-secrets-stores status: 'Failed']
```
The `bp-external-secrets-stores` HR (chart 1.0.8):
```
Stalled=True RetriesExceeded :: Failed to upgrade after 4 attempt(s)
Released=False UpgradeFailed :: pre-upgrade hooks failed: Hook webhook-gate-hook.yaml failed:
  admission webhook "validate.kyverno.svc-fail" denied the request:
  Job/external-secrets-stores-webhook-gate is not Flux-managed.
  Add label `app.kubernetes.io/managed-by: flux` on metadata.labels
```
HR rolled back to 1.0.7; the kit stayed `Ready=False`.

**Root cause:** the `webhook-gate-hook.yaml` pre-install/pre-upgrade hook Job is created by the helm-controller (no Flux ownerRef), so the Kyverno baseline `flux-managed` Enforce policy (`workload-must-be-flux-managed`, matches `kind: Job`) denies it without `app.kubernetes.io/managed-by: flux`. The exact landmine already fixed for bp-cnpg (#4226), bp-openbao (#3374), bp-gitea/bp-harbor (#3296→#3297). bp-external-secrets-stores was the remaining hook-bearing chart that never got the label.

**Fix:** add the label to the hook Job's `metadata.labels` (where the policy reads). Chart 1.0.8 → 1.0.9 + slot-15a pin in lockstep. `helm template` confirms the label renders on the Job metadata; `helm lint` clean; pin-sync audit `OK`.

### 2. Hourly pin-propagation safety-net (the systemic delivery gap)

The bp-catalyst-platform slot-13 pin auto-bump runs in a SEPARATE async workflow (`blueprint-release.yaml`, TBD-A6) dispatched per chart bump. When that dispatch fails, leapfrogs a version, or the OCI publish fails, the slot pin is left permanently lagging or pinned at a never-published tag — and the push-mode audit that saw the transient drift already passed green (`continue-on-error`) and never re-runs.

Observed 2026-06-26: `bp-catalyst-platform` `1.4.867` + `1.4.861` advanced in `Chart.yaml` but were **never published to ghcr** (tags `...866, 868, 869` — 867 missing), while the slot pin leapfrogged past them.

**Fix:** add `schedule: 17 * * * *` to `test-bootstrap-kit.yaml`. The hourly run executes the full-sweep `--check-ghcr` pin-sync audit and **fails loud** on any residual drift (the schedule event is excluded from the `continue-on-error` umbrella — by then there is no auto-bump race to excuse the drift). The change-driven DAG/manifest audits and the heavy `kind-reconciliation` job are skipped on the cron, so the hourly run does only the pin safety-net.

## Live state captured (kom4dc region-a, 2026-06-26)

- bootstrap-kit Kustomization: `Ready=False, HealthCheckFailed` on the stalled `bp-external-secrets-stores` HR — syncing latest rev `main@sha1:513297b62` (the 1.4.869 slot bump).
- bp-catalyst-platform HR: `spec.version=1.4.869`, `lastApplied=1.4.868`, `Ready=True UpgradeSucceeded` — the catalyst-platform roll is NOT hard-blocked (the Kustomization applies the manifests regardless of the health-gate); it lags only by the propagation window and rolls forward once each slot pin lands.

## Verification

- `helm lint platform/external-secrets-stores/chart` — clean.
- `helm template ... --show-only templates/webhook-gate-hook.yaml` — `app.kubernetes.io/managed-by: flux` renders on the Job `metadata.labels`.
- `scripts/check-bootstrap-kit-pin-sync.sh` — exit 0; `bp-external-secrets-stores: chart=1.0.9 pin=1.0.9 OK`.
- `scripts/render-slot-placement.py check` — PASSED (64 slots, no placement drift).
- Workflow YAML parses; 4 jobs, triggers `push/pull_request/workflow_dispatch/schedule`.

Refs #4409

🤖 Generated with [Claude Code](https://claude.com/claude-code)