### PR TITLE
fix(catalog-seed #4413): bp-openclaw 0.2.8 → 0.2.11 so #4272 egress/TLS fixes reach funnel Orgs

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1132,7 +1132,9 @@ spec:
       #   0.2.5 -> 0.2.8, bp-stalwart-tenant 0.1.3 -> 0.1.10) so #4394 reaches a funnel
       #   Org — the per-Org LimitRange (#4292) rejected the OLD Burstable pins.
       #   Chart-only. Refs #4395 #4394 #4307 #4292.
-      version: 1.4.869
+      # 1.4.871 — #4413: catalog-seed bp-openclaw 0.2.8 -> 0.2.11 (lockstep) so the
+      #   #4272 egress/TLS fixes reach fresh funnel Orgs.
+      version: 1.4.871
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3174,7 +3174,10 @@ name: bp-catalyst-platform
 #   reverted it ~2min later, so the live chart still shipped the pre-#4393
 #   org-controller — every m-tier funnel Org stayed wedged at 'vcluster-0
 #   forbidden: ratio 20' (verified live on g10vc). Refs #4395 #4394 #4393 #4307 #4292 #4389.
-version: 1.4.870
+version: 1.4.871
+# 1.4.871 — #4413: catalog-seed bp-openclaw pin 0.2.8 -> 0.2.11 (lockstep w/ blueprint.yaml)
+#   so the #4272 egress CNP (#4401) + controller TLS-trust (#4408) actually reach
+#   fresh funnel Orgs — the catalog Blueprint was serving 0.2.8 (pre-fix) on omantel.biz.
 # 1.4.774 — #4082: application-controller ClusterRole gains dr.openova.io/continuums
 #   (get/list/watch/create/update/patch/delete) — was in the controller's own
 #   deploy/rbac.yaml but MISSING from this platform chart, so a singleton /

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -2593,7 +2593,7 @@ metadata:
     # must not claw it back (DoD §9.4).
     helm.sh/resource-policy: keep
 spec:
-  version: "0.2.8"
+  version: "0.2.11"
   visibility: listed
   card:
     title: "OpenClaw"
@@ -2628,7 +2628,7 @@ hook (ADR-0003). Identity-blind by construction.
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-openclaw
-    version: "0.2.8"
+    version: "0.2.11"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Merged ≠ delivered (the #4272 gap)

The #4272 openclaw fixes shipped in **bp-openclaw 0.2.11** (#4401 public-HTTPS egress CNP, #4408 controller TLS-trust) and `platform/openclaw/blueprint.yaml spec.version` is **0.2.11** — but the **catalyst-platform catalog-seed** (`products/catalyst/chart/templates/catalog-seed/blueprints.yaml`) still pinned bp-openclaw at **0.2.8** (both `spec.version` and `source.version`).

The Sovereign's registered Blueprint CR is seeded from this catalog-seed. **Verified live on omantel.biz:** `kubectl get blueprints.catalyst.openova.io bp-openclaw` → `version=0.2.8`. So every fresh funnel Org installs openclaw **0.2.8 — WITHOUT** the #4401 egress CNP and #4408 TLS-trust → `/readyz` stays 503 on the JWKS hairpin. The titular #4272 fix never reaches a fresh Org.

## Fix

Lockstep the catalog-seed bp-openclaw pin **0.2.8 → 0.2.11** (both version fields) + bump the catalyst chart **1.4.870 → 1.4.871** so the seed rolls. bp-openclaw 0.2.11 is published to ghcr.

`bash scripts/check-catalog-seed-lockstep.sh` → **PASS 69/69**.

Refs #4272 #4401 #4408 #4413

🤖 Generated with [Claude Code](https://claude.com/claude-code)