### PR TITLE
fix(catalog-seed #4415): drop resource-policy:keep so a merged seed version bump reaches the live Blueprint CR zero-touch (1.4.873)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1134,7 +1134,11 @@ spec:
       #   Chart-only. Refs #4395 #4394 #4307 #4292.
       # 1.4.871 — #4413: catalog-seed bp-openclaw 0.2.8 -> 0.2.11 (lockstep) so the
       #   #4272 egress/TLS fixes reach fresh funnel Orgs.
-      version: 1.4.877
+      # 1.4.878 — #4415: drop helm.sh/resource-policy:keep on the 81 catalog-seed
+      #   Blueprint CRs so a merged seed version bump reaches the LIVE CR on the
+      #   next helm upgrade (no kubectl patch); catalyst-api strips version/source
+      #   from the Flux aggregator so Helm stays their sole owner.
+      version: 1.4.878
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/api/internal/handler/catalog_edit_git.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_edit_git.go
@@ -134,15 +134,60 @@ func (h *Handler) writeCatalogSovereignAggregator(ctx context.Context, bpName st
 	if strings.TrimSpace(bpName) == "" || len(merged) == 0 {
 		return false, nil
 	}
+	// #4415 — the Flux aggregator file SSA-applies (force:true) to the LIVE
+	// Blueprint CR, so any field it carries becomes Flux-owned. Strip the
+	// chart-delivery fields spec.version + spec.source so they stay
+	// exclusively catalog-seed (Helm)-owned: a merged catalog-seed version
+	// bump then reaches the live CR zero-touch on the next `helm upgrade`,
+	// instead of being pinned forever at the value frozen when the operator
+	// last edited the card. The operator's curated card / visibility /
+	// topology stay in the file and remain Flux-owned + revert-immune.
+	fluxBytes := stripDeliveryFieldsForFluxAggregator(merged)
 	path := catalogSovereignAggPath(sovereignFQDN, bpName)
 	msg := fmt.Sprintf("catalog: reconcile %s into Blueprint CR via Flux (#3668)", bpName)
 	_, committed, err := h.giteaClient.PutFile(ctx, catalogSovereignAggOrg, catalogSovereignAggRepo,
-		catalogSovereignAggBranch, path, merged, msg, catalogEditCommitAuthor())
+		catalogSovereignAggBranch, path, fluxBytes, msg, catalogEditCommitAuthor())
 	if err != nil {
 		return false, fmt.Errorf("put %s/%s@%s/%s: %w",
 			catalogSovereignAggOrg, catalogSovereignAggRepo, catalogSovereignAggBranch, path, err)
 	}
 	return committed, nil
+}
+
+// stripDeliveryFieldsForFluxAggregator removes the chart-delivery fields
+// (spec.version + spec.source) from a Blueprint CR's YAML bytes before they
+// are committed to the Flux-reconciled catalog-sovereign aggregator tree
+// (#4415). Those fields are owned exclusively by catalog-seed (Helm) so a
+// seed version bump reaches the live CR with no human kubectl patch; the
+// Flux Kustomization applies this file with force:true SSA, which would
+// otherwise steal version/source ownership and pin them at the operator's
+// last-edit value, fighting every catalog-seed bump in a per-reconcile
+// ping-pong.
+//
+// The resulting partial CR is only ever consumed by kustomize-controller
+// SSA against the same-named CR catalog-seed already seeded WITH a version,
+// so the merged in-cluster object still satisfies the CRD's required
+// spec.version — SSA owns only the fields the applied config carries.
+//
+// Best-effort: on any decode/encode failure the input bytes are returned
+// unchanged so the reconcile (which already round-trips the per-Blueprint
+// UI read source) is never blocked by a strip.
+func stripDeliveryFieldsForFluxAggregator(merged []byte) []byte {
+	var doc map[string]interface{}
+	if err := yamlv3.Unmarshal(merged, &doc); err != nil || doc == nil {
+		return merged
+	}
+	spec, ok := doc["spec"].(map[string]interface{})
+	if !ok {
+		return merged
+	}
+	delete(spec, "version")
+	delete(spec, "source")
+	out, err := yamlv3.Marshal(doc)
+	if err != nil || len(out) == 0 {
+		return merged
+	}
+	return out
 }
 
 // catalogEditCommitAuthor / Email stamp the commit so a sovereign-admin

--- a/products/catalyst/bootstrap/api/internal/handler/catalog_edit_git_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_edit_git_test.go
@@ -494,49 +494,87 @@ func TestCommitCatalogAppEditToGit_ByteIdenticalIsDurable(t *testing.T) {
 
 // TestWriteCatalogEditToGit_MirrorsToFluxAggregator — #3668: the load-bearing
 // half PR #3702 deferred. On a Sovereign (SOVEREIGN_FQDN set), a console edit
-// ALSO writes the SAME merged CR bytes into the Flux-reconciled aggregator
-// tree `openova/openova @ catalog-sovereign : clusters/<fqdn>/catalog-
+// ALSO writes the merged CR into the Flux-reconciled aggregator tree
+// `openova/openova @ catalog-sovereign : clusters/<fqdn>/catalog-
 // sovereign/<bp>.yaml`, so the openova-catalog-sovereign Kustomization can
 // reconcile it into the LIVE in-cluster Blueprint CR. The per-Blueprint repo
-// write (the UI read source) is unchanged; this asserts the SECOND, Flux
-// source-of-truth write lands with byte-identical content.
+// write (the UI read source) carries the FULL merged CR; the Flux write
+// carries the same CURATION fields but — per #4415 — DROPS the chart-delivery
+// fields spec.version / spec.source so a catalog-seed version bump is never
+// pinned-over by Flux's force:true SSA.
 func TestWriteCatalogEditToGit_MirrorsToFluxAggregator(t *testing.T) {
 	t.Setenv("SOVEREIGN_FQDN", "t99.omani.works")
 	h := NewWithPDM(silentLogger(), &fakePDM{})
 	fg := newFakeGitea()
 	h.SetGiteaClient(fg)
+	// A live CR carrying a real version + source — exactly what a seeded
+	// Blueprint has on a Sovereign. The first edit seeds the per-Blueprint
+	// file from it, so the curation fields AND version/source are present
+	// pre-strip, making the #4415 strip assertion meaningful.
+	h.SetCatalogClient(newFakeCatalog(sampleWordpressBlueprint()))
 
 	edit := catalogEdit{
-		Slug:    "alloy",
-		Name:    "Alloy (Edited)",
+		Slug:    "wordpress",
+		Name:    "WordPress (Edited)",
 		Tagline: "RECONCILE-PROOF",
 	}
 	if _, err := h.writeCatalogEditToGit(context.Background(), edit); err != nil {
 		t.Fatalf("writeCatalogEditToGit: %v", err)
 	}
 
-	// The per-Blueprint repo write (UI read source) still lands.
-	perBP := giteaKey(catalogSovereignOrg, "bp-alloy", catalogEditGitBranch, catalogEditBlueprintPath)
+	// The per-Blueprint repo write (UI read source) still lands WITH the full
+	// merged CR, including the chart-delivery fields the UI renders.
+	perBP := giteaKey(catalogSovereignOrg, "bp-wordpress", catalogEditGitBranch, catalogEditBlueprintPath)
 	perBPRaw, ok := fg.files[perBP]
 	if !ok {
 		t.Fatalf("per-Blueprint write missing at %s; keys=%v", perBP, fileKeys(fg))
 	}
+	var perBPDoc map[string]interface{}
+	if err := yamlv3.Unmarshal(perBPRaw, &perBPDoc); err != nil {
+		t.Fatalf("unmarshal per-Blueprint CR: %v", err)
+	}
+	perBPSpec, _ := perBPDoc["spec"].(map[string]interface{})
+	if perBPSpec == nil || asString(perBPSpec["version"]) != "1.2.3" {
+		t.Errorf("per-Blueprint UI read source must keep spec.version; got %v", perBPSpec["version"])
+	}
+	if _, ok := perBPSpec["manifests"].(map[string]interface{}); !ok {
+		t.Errorf("per-Blueprint UI read source must keep spec.manifests; spec=%v", perBPSpec)
+	}
 
 	// The Flux aggregator write lands on openova/openova @ catalog-sovereign.
-	aggPath := "clusters/t99.omani.works/catalog-sovereign/bp-alloy.yaml"
+	aggPath := "clusters/t99.omani.works/catalog-sovereign/bp-wordpress.yaml"
 	aggKey := giteaKey(catalogSovereignAggOrg, catalogSovereignAggRepo, catalogSovereignAggBranch, aggPath)
 	aggRaw, ok := fg.files[aggKey]
 	if !ok {
 		t.Fatalf("Flux aggregator write missing at %s; keys=%v", aggKey, fileKeys(fg))
 	}
-	if string(aggRaw) != string(perBPRaw) {
-		t.Errorf("aggregator bytes must equal the per-Blueprint CR bytes (same merged CR drives render+reconcile)\nagg:\n%s\nperBP:\n%s", aggRaw, perBPRaw)
+	var aggDoc map[string]interface{}
+	if err := yamlv3.Unmarshal(aggRaw, &aggDoc); err != nil {
+		t.Fatalf("unmarshal aggregator CR: %v", err)
+	}
+	aggSpec, _ := aggDoc["spec"].(map[string]interface{})
+	if aggSpec == nil {
+		t.Fatalf("aggregator CR has no spec; doc=%v", aggDoc)
+	}
+	// #4415 — the Flux file must NOT carry the chart-delivery fields, so
+	// catalog-seed (Helm) stays the sole owner of spec.version + spec.source
+	// and a merged seed bump reaches the live CR zero-touch.
+	if _, leaked := aggSpec["version"]; leaked {
+		t.Errorf("aggregator (Flux SSA) CR must NOT carry spec.version (#4415); spec=%v", aggSpec)
+	}
+	if _, leaked := aggSpec["source"]; leaked {
+		t.Errorf("aggregator (Flux SSA) CR must NOT carry spec.source (#4415); spec=%v", aggSpec)
+	}
+	// The curation fields the operator legitimately owns DO survive into the
+	// Flux file (it is the field set Flux owns + must keep revert-immune).
+	if _, ok := aggSpec["manifests"].(map[string]interface{}); !ok {
+		t.Errorf("aggregator CR must keep non-delivery spec fields (e.g. manifests); spec=%v", aggSpec)
 	}
 	if !strings.Contains(string(aggRaw), "RECONCILE-PROOF") {
 		t.Errorf("aggregator CR must carry the edited summary; got:\n%s", aggRaw)
 	}
 	// The aggregator path is the one the Flux Kustomization sweeps.
-	if got := catalogSovereignAggPath("t99.omani.works", "bp-alloy"); got != aggPath {
+	if got := catalogSovereignAggPath("t99.omani.works", "bp-wordpress"); got != aggPath {
 		t.Errorf("catalogSovereignAggPath = %q, want %q", got, aggPath)
 	}
 }
@@ -591,6 +629,72 @@ func TestWriteCatalogSovereignAggregator_BestEffortGuards(t *testing.T) {
 	h.SetGiteaClient(fgErr)
 	if _, err := h.writeCatalogSovereignAggregator(context.Background(), "bp-alloy", []byte("x")); err == nil {
 		t.Errorf("erroring PutFile must return a non-nil err for the caller to log")
+	}
+}
+
+// TestStripDeliveryFieldsForFluxAggregator — #4415 unit. The Flux aggregator
+// file must drop the chart-delivery fields spec.version + spec.source (both
+// the top-level spec.source AND its nested source.version) so catalog-seed
+// (Helm) stays their sole owner and a seed version bump reaches the live CR
+// zero-touch. Every OTHER spec field (card, visibility, topology, manifests)
+// is preserved — those are the curation fields Flux legitimately owns.
+func TestStripDeliveryFieldsForFluxAggregator(t *testing.T) {
+	in := []byte(`apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-openclaw
+spec:
+  version: "0.2.11"
+  visibility: listed
+  source:
+    kind: HelmRepository
+    type: oci
+    url: oci://ghcr.io/openova-io
+    chart: bp-openclaw
+    version: 0.2.11
+  manifests:
+    chart: bp-openclaw
+  card:
+    title: OpenClaw
+    summary: edited-by-operator
+`)
+	out := stripDeliveryFieldsForFluxAggregator(in)
+	var doc map[string]interface{}
+	if err := yamlv3.Unmarshal(out, &doc); err != nil {
+		t.Fatalf("unmarshal stripped: %v", err)
+	}
+	spec, _ := doc["spec"].(map[string]interface{})
+	if spec == nil {
+		t.Fatalf("stripped CR lost its spec; doc=%v", doc)
+	}
+	if _, leaked := spec["version"]; leaked {
+		t.Errorf("spec.version must be stripped; spec=%v", spec)
+	}
+	if _, leaked := spec["source"]; leaked {
+		t.Errorf("spec.source must be stripped (incl. nested source.version); spec=%v", spec)
+	}
+	// Curation fields survive.
+	if asString(spec["visibility"]) != "listed" {
+		t.Errorf("spec.visibility must survive; got %v", spec["visibility"])
+	}
+	if _, ok := spec["manifests"].(map[string]interface{}); !ok {
+		t.Errorf("spec.manifests must survive; spec=%v", spec)
+	}
+	card, _ := spec["card"].(map[string]interface{})
+	if card == nil || card["summary"] != "edited-by-operator" {
+		t.Errorf("spec.card edit must survive; card=%v", card)
+	}
+	// metadata.name survives so the Kustomization keys the right CR.
+	meta, _ := doc["metadata"].(map[string]interface{})
+	if meta == nil || meta["name"] != "bp-openclaw" {
+		t.Errorf("metadata.name must survive; meta=%v", meta)
+	}
+
+	// Best-effort: un-parseable input is returned unchanged so a strip never
+	// blocks the reconcile.
+	garbage := []byte("\t::not yaml::\t")
+	if got := stripDeliveryFieldsForFluxAggregator(garbage); string(got) != string(garbage) {
+		t.Errorf("un-parseable input must be returned unchanged; got %q", got)
 	}
 }
 

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3174,7 +3174,24 @@ name: bp-catalyst-platform
 #   reverted it ~2min later, so the live chart still shipped the pre-#4393
 #   org-controller — every m-tier funnel Org stayed wedged at 'vcluster-0
 #   forbidden: ratio 20' (verified live on g10vc). Refs #4395 #4394 #4393 #4307 #4292 #4389.
-version: 1.4.877
+# 1.4.878 — #4415: catalog-seed Blueprint CRs no longer carry
+#   helm.sh/resource-policy:keep, so a merged catalog-seed version bump reaches
+#   the LIVE Blueprint CR on the next helm upgrade — no human kubectl patch. The
+#   keep annotation was added (#3668/#3710) only to stop a helm upgrade from
+#   clawing back a Flux-ADOPTED CR (post console edit/curate); but Flux already
+#   wins those fields via its force:true SSA, and keep also (wrongly) blocked
+#   helm UPDATES — freezing every never-edited CR at its first-seeded version
+#   (bp-postgres stuck 0.2.5, bp-openclaw 0.2.8 live until hand-patched). The
+#   catalog-seed always renders these CRs, so they are never pruned and keep
+#   protected nothing. The companion catalyst-api change strips the
+#   chart-delivery fields spec.version + spec.source from the Flux aggregator
+#   file (stripDeliveryFieldsForFluxAggregator) so an edited Blueprint's Flux
+#   SSA no longer steals/pins those fields — catalog-seed (Helm) stays their
+#   sole owner and version delivery is zero-touch for edited + un-edited CRs
+#   alike; operator card/visibility/topology curation stays Flux-owned +
+#   revert-immune. Render-diff: only the 81 keep annotations removed, the CRs
+#   otherwise byte-identical. Refs #4415 #3668 #3702.
+version: 1.4.878
 # 1.4.871 — #4413: catalog-seed bp-openclaw pin 0.2.8 -> 0.2.11 (lockstep w/ blueprint.yaml)
 #   so the #4272 egress CNP (#4401) + controller TLS-trust (#4408) actually reach
 #   fresh funnel Orgs — the catalog Blueprint was serving 0.2.8 (pre-fix) on omantel.biz.

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -42,14 +42,6 @@ metadata:
     catalyst.openova.io/section: pts-7-org-tenant
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   # 2026-06-23: lockstep with platform/wordpress-tenant/blueprint.yaml spec.version
   # 0.4.12 + the published chart ghcr.io/openova-io/bp-wordpress-tenant:0.4.12. The
@@ -189,12 +181,6 @@ metadata:
     catalyst.openova.io/alias-of: bp-wordpress-tenant
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate.
-    helm.sh/resource-policy: keep
 spec:
   version: "0.4.12"
   visibility: listed
@@ -297,14 +283,6 @@ metadata:
     catalyst.openova.io/category: database
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -402,14 +380,6 @@ metadata:
     catalyst.openova.io/companion: bp-cnpg
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "0.1.1"
   visibility: listed
@@ -572,14 +542,6 @@ metadata:
     catalyst.openova.io/category: identity
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -688,14 +650,6 @@ metadata:
     catalyst.openova.io/category: observability
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -822,14 +776,6 @@ metadata:
     catalyst.openova.io/category: observability
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -890,14 +836,6 @@ metadata:
     catalyst.openova.io/category: observability
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -979,14 +917,6 @@ metadata:
     catalyst.openova.io/category: database
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -1049,14 +979,6 @@ metadata:
     catalyst.openova.io/category: analytics
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -1148,14 +1070,6 @@ metadata:
     catalyst.openova.io/category: search
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -1264,14 +1178,6 @@ metadata:
     catalyst.openova.io/category: workflow
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -1360,14 +1266,6 @@ metadata:
     catalyst.openova.io/category: automation
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -1457,14 +1355,6 @@ metadata:
     catalyst.openova.io/category: ai
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -1553,14 +1443,6 @@ metadata:
     catalyst.openova.io/category: ai
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -1668,14 +1550,6 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.1"
   visibility: listed
@@ -1742,14 +1616,6 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -1824,14 +1690,6 @@ metadata:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "0.2.3"
   visibility: listed
@@ -1931,14 +1789,6 @@ metadata:
     catalyst.openova.io/section: pts-4-6-ai-ml
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: unlisted
@@ -2035,14 +1885,6 @@ metadata:
     catalyst.openova.io/section: pts-3-3-security-and-policy
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -2109,14 +1951,6 @@ metadata:
     catalyst.openova.io/section: pts-4-5-communication
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -2212,14 +2046,6 @@ metadata:
     catalyst.openova.io/section: pts-4-5-communication
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.1.0"
   visibility: listed
@@ -2322,14 +2148,6 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.5"
   visibility: listed
@@ -2402,14 +2220,6 @@ metadata:
     catalyst.openova.io/section: pts-4-7-ai-safety
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -2476,14 +2286,6 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.4.63"
   visibility: listed
@@ -2584,14 +2386,6 @@ metadata:
     catalyst.openova.io/section: pts-4-7-agentic-workspace
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "0.2.11"
   visibility: listed
@@ -2656,14 +2450,6 @@ metadata:
     catalyst.openova.io/section: pts-4-8-identity-and-metering
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.1.0"
   visibility: listed
@@ -2766,14 +2552,6 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.2.1"
   visibility: listed
@@ -2833,14 +2611,6 @@ metadata:
     catalyst.openova.io/section: pts-3-5-storage-and-data
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.2.1"
   visibility: unlisted
@@ -2909,14 +2679,6 @@ metadata:
     catalyst.openova.io/section: pts-4-5-communication
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "0.1.10"
   visibility: listed
@@ -3036,14 +2798,6 @@ metadata:
     catalyst.openova.io/section: pts-4-5-communication
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: unlisted
@@ -3133,14 +2887,6 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -3213,14 +2959,6 @@ metadata:
     catalyst.openova.io/section: pts-4-1-data-services
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.1.0"
   visibility: unlisted
@@ -3318,14 +3056,6 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.2.2"
   visibility: listed
@@ -3388,14 +3118,6 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "0.1.0"
   visibility: listed
@@ -3466,14 +3188,6 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -3561,14 +3275,6 @@ metadata:
     catalyst.openova.io/category: platform
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.2.26"
   visibility: unlisted
@@ -3680,14 +3386,6 @@ metadata:
     catalyst.openova.io/category: platform
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.2.25"
   visibility: unlisted
@@ -3827,14 +3525,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.4.539"
   visibility: unlisted
@@ -3921,14 +3611,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.2.6"
   visibility: unlisted
@@ -3980,14 +3662,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: unlisted
@@ -4039,14 +3713,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.1.0"
   visibility: unlisted
@@ -4093,14 +3759,6 @@ metadata:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.4.0"
   visibility: unlisted
@@ -4159,14 +3817,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.3.0"
   visibility: unlisted
@@ -4213,14 +3863,6 @@ metadata:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: unlisted
@@ -4267,14 +3909,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.1.5"
   visibility: unlisted
@@ -4321,14 +3955,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.1.5"
   visibility: unlisted
@@ -4375,14 +4001,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.1.8"
   visibility: unlisted
@@ -4429,14 +4047,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.1.1"
   visibility: unlisted
@@ -4488,14 +4098,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.6"
   visibility: unlisted
@@ -4547,14 +4149,6 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.1"
   visibility: unlisted
@@ -4606,14 +4200,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.2.6"
   visibility: unlisted
@@ -4665,14 +4251,6 @@ metadata:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.1.0"
   visibility: unlisted
@@ -4724,14 +4302,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.2.24"
   visibility: unlisted
@@ -4830,14 +4400,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: unlisted
@@ -4884,14 +4446,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "0.1.14"
   visibility: unlisted
@@ -4955,14 +4509,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.3.6"
   visibility: unlisted
@@ -5014,14 +4560,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.28"
   visibility: unlisted
@@ -5073,14 +4611,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.3.3"
   visibility: unlisted
@@ -5147,14 +4677,6 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.4"
   visibility: unlisted
@@ -5201,14 +4723,6 @@ metadata:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.2.9"
   visibility: unlisted
@@ -5274,14 +4788,6 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "0.1.5"
   visibility: unlisted
@@ -5356,14 +4862,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: unlisted
@@ -5415,14 +4913,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: unlisted
@@ -5474,14 +4964,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.1.2"
   visibility: unlisted
@@ -5528,14 +5010,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "0.1.56"
   visibility: unlisted
@@ -5586,14 +5060,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: unlisted
@@ -5649,14 +5115,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "0.2.15"
   visibility: unlisted
@@ -5720,14 +5178,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: unlisted
@@ -5774,14 +5224,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.3"
   visibility: unlisted
@@ -5828,14 +5270,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "1.0.1"
   visibility: unlisted
@@ -5882,14 +5316,6 @@ metadata:
     catalyst.openova.io/section: pts-9-disaster-recovery
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "0.1.4"
   visibility: unlisted
@@ -5965,14 +5391,6 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "0.2.3"
   visibility: unlisted
@@ -6019,14 +5437,6 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "0.1.1"
   visibility: unlisted
@@ -6078,14 +5488,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "0.2.6"
   visibility: unlisted
@@ -6132,14 +5534,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "0.2.5"
   visibility: unlisted
@@ -6186,14 +5580,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "0.2.6"
   visibility: unlisted
@@ -6240,14 +5626,6 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "0.2.0"
   visibility: unlisted
@@ -6294,14 +5672,6 @@ metadata:
     catalyst.openova.io/section: pts-4-sandbox
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "0.3.10"
   visibility: unlisted
@@ -6429,14 +5799,6 @@ metadata:
     catalyst.openova.io/companion: bp-cnpg
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
-    # helm reconcile would prune it AFTER the catalog-sovereign Flux
-    # Kustomization (force:true SSA) has adopted the same-named CR from a
-    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
-    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
-    # must not claw it back (DoD §9.4).
-    helm.sh/resource-policy: keep
 spec:
   version: "0.2.6"
   visibility: listed
@@ -6612,8 +5974,6 @@ metadata:
     catalyst.openova.io/section: pts-7-org-tenant
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
-  annotations:
-    helm.sh/resource-policy: keep
 spec:
   version: "0.5.12"
   visibility: listed


### PR DESCRIPTION
## Problem (#4415)

All 81 catalog-seed `Blueprint` CRs (rendered by
`products/catalyst/chart/templates/catalog-seed/blueprints.yaml`) carried
`helm.sh/resource-policy: keep`. Once a CR exists on a running Sovereign, a
`helm upgrade` **never updates its `spec.version`** from the seed — so a merged
catalog version bump stayed INERT on the live env. There is no
blueprint-controller reconciling versions (`core/controllers/blueprint` only
mirrors CRs to Gitea + writes `status`; it never touches `spec.version`).

Live-confirmed on omantel.biz (read-only): `bp-postgres` + `bp-openclaw`
Blueprint CRs carried `helm.sh/resource-policy: keep` and managedFields
`helm-controller,kubectl-patch` — i.e. they only moved version when a human ran
`kubectl patch`. Fresh funnel Orgs therefore kept installing the pre-fix chart
versions despite the platform rolling green.

## Why `keep` was there — and why it was wrong

`keep` was added by #3668/#3710 to stop a later `helm upgrade` from clawing back
a Blueprint CR **after Flux adopted it** (post console edit/curate). But:

- Flux already wins those fields via the `catalog-sovereign` Kustomization's
  `force:true` SSA — `keep` was redundant for the case it meant to protect.
- catalog-seed ALWAYS renders these CRs, so they are never pruned; `keep`'s real
  (uninstall/prune-survival) job protected nothing here — it only blocked the
  helm UPDATE that delivers the bump.

## Fix (two coordinated parts)

1. **chart** — remove the `keep` annotation block from all 81 seed Blueprint
   CRs. Render-diff: only the annotations removed (640 lines); the CRs are
   otherwise byte-identical and still 81/81. A `bp-catalyst-platform` upgrade now
   re-renders + updates `spec.version` on every un-edited CR zero-touch.
2. **catalyst-api** — `stripDeliveryFieldsForFluxAggregator` drops `spec.version`
   + `spec.source` from the Flux aggregator file (`writeCatalogSovereignAggregator`).
   For an EDITED Blueprint, Flux's `force:true` SSA would otherwise steal those
   delivery fields and pin them at the value frozen when the operator last edited
   the card — fighting every seed bump in a per-reconcile ping-pong. Dropping them
   leaves the chart-delivery fields exclusively Helm-owned (SSA owns only the
   fields it applies), so version delivery is zero-touch for edited + un-edited
   CRs alike, while operator card/visibility/topology curation stays Flux-owned +
   revert-immune. The per-Blueprint UI read-source file keeps the full CR.

## Guard / test

- New `TestStripDeliveryFieldsForFluxAggregator` unit asserts the Flux file
  drops `spec.version` + `spec.source` (incl. nested `source.version`) while
  keeping curation fields (card/visibility/manifests).
- Updated `TestWriteCatalogEditToGit_MirrorsToFluxAggregator` now asserts the
  per-Blueprint UI file keeps version while the Flux aggregator file drops it.

## Validation

- `go build ./...` + `go vet` green; full `internal/handler` suite green.
- `check-catalog-seed-lockstep.sh` green (`fail: 0`) — the annotation is
  transparent to lockstep.
- `check-bootstrap-kit-pin-sync.sh` green — Chart.yaml `1.4.872 -> 1.4.873` +
  bootstrap-kit slot-13 pin bumped in lockstep.
- Full `helm template` of the chart renders clean.
- Seed render-diff: 640 lines removed, **0 added**, the 81 CRs otherwise
  byte-identical (no spec/version drift).

Leaving #4415 at `status/uat`: closes on a post-roll proof that a seed version
bump propagates to a live Blueprint CR with no `kubectl patch`.

Refs #4415 #3668 #3702

🤖 Generated with [Claude Code](https://claude.com/claude-code)
