### PR TITLE
fix(catalyst): spine apps ADOPT bootstrap HR + config→spec.parameters + status.continuumRef — close the #4212 round-trip

### DIFF
--- a/core/controllers/application/internal/controller/application_controller.go
+++ b/core/controllers/application/internal/controller/application_controller.go
@@ -1123,8 +1123,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 	if continuumOwnerLabels == nil {
 		continuumOwnerLabels = fanoutOwnerLabels(envSpec, app)
 	}
-	if cerr := r.reconcileContinuumCR(ctx, app.GetName(), app.GetNamespace(),
-		resolvedTopoChoice, resolvedTopoVariant, plan, continuumOwnerLabels); cerr != nil {
+	// continuumRef carries the `<ns>/<name>` of any per-app Continuum CR
+	// minted below onto the status write at the end of Reconcile (#4416 —
+	// the back-pointer that closes the #4212 round-trip). Empty for a non-DR
+	// app (no CR produced).
+	continuumRef, cerr := r.reconcileContinuumCR(ctx, app.GetName(), app.GetNamespace(),
+		resolvedTopoChoice, resolvedTopoVariant, plan, continuumOwnerLabels)
+	if cerr != nil {
 		return r.markDegraded(ctx, app, ReasonRenderError,
 			fmt.Sprintf("per-app Continuum DR contract: %v", cerr))
 	}
@@ -1483,6 +1488,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 	readyByRegion := readbackByRegion(plan, finalPhase)
 	observed := observedTargetsFromPlan(plan, effectiveTargets, readyByRegion)
 	su.PlacementRecon, su.PlacementReason, su.ObservedTargets = reconStatusBlock(observed)
+
+	// #4416 — write the Continuum back-pointer the producer minted above so
+	// the spine→Continuum round-trip closes (the #4212 consumer-READ).
+	su.ContinuumRef = continuumRef
 
 	return r.updateStatus(ctx, app, su)
 }
@@ -2116,6 +2125,15 @@ type statusUpdate struct {
 	// `status.targets[]` — the same key the rebuilt Topology tab reads as
 	// the recon rollup fallback. Nil leaves the field untouched.
 	ObservedTargets []interface{}
+
+	// ContinuumRef — #4416. The `<namespace>/<name>` of the per-app
+	// Continuum DR contract this Application minted (e.g.
+	// `catalyst/dr-spine-gitea`). Surfaced via `status.continuumRef` — the
+	// consumer-READ back-pointer that CLOSES the spine→Continuum round-trip
+	// (#4212): an operator (or a console projection) reading the Application
+	// can hop straight to its Continuum. Empty leaves the field untouched
+	// (a non-DR app mints no Continuum and writes no back-ref).
+	ContinuumRef string
 }
 
 // updateStatus writes the status sub-resource via the dynamic client.
@@ -2170,6 +2188,11 @@ func (r *Reconciler) updateStatus(ctx context.Context, app *unstructured.Unstruc
 		// #3969 §7.4 — the observed per-target rollup the Topology tab
 		// reads. One status value, never two.
 		currentStatus["targets"] = su.ObservedTargets
+	}
+	if su.ContinuumRef != "" {
+		// #4416 — the back-pointer to this Application's per-app Continuum DR
+		// contract, closing the #4212 spine→Continuum round-trip.
+		currentStatus["continuumRef"] = su.ContinuumRef
 	}
 	if su.GiteaRepo != "" {
 		currentStatus["giteaRepo"] = su.GiteaRepo
@@ -2303,13 +2326,35 @@ func (r *Reconciler) reconcileBootstrapOwned(ctx context.Context, app *unstructu
 		break
 	}
 
+	// #4416 — mint the per-app Continuum DR contract for an ADOPTED
+	// DR-capable spine app (openbao/keycloak/harbor/gitea) + carry its
+	// back-pointer. The bootstrap-owned path is status-only (it never
+	// renders a fan-out HR), but the spine app is STILL a DR-capable
+	// multi-region Application whose Continuum contract must exist — that
+	// is the forward half of the #4212 round-trip. We resolve the contract
+	// from the CR's own spec.placement + spec.regions + the Blueprint
+	// topology variant (no fan-out render needed) and upsert the same
+	// Continuum CR the normal path would. A non-DR bootstrap app
+	// (singleton shared-pg, single-region) produces NO CR (the
+	// buildContinuumPlan gate) and writes no back-ref — the shared-pg
+	// adoption path is unchanged. Errors here are surfaced as Degraded so
+	// a missing DR contract retries (never silently passes).
+	continuumRef, cerr := r.reconcileBootstrapContinuum(ctx, app)
+	if cerr != nil {
+		return r.markDegraded(ctx, app, ReasonRenderError,
+			fmt.Sprintf("adopted spine Continuum DR contract: %v", cerr))
+	}
+
 	// Churn guard: a status write bumps resourceVersion → MODIFIED
 	// watch event → another reconcile. The normal path's Gitea
 	// byte-equality short-circuit naturally dampens that loop; this
 	// status-only path has no such stage, so skip the write when
 	// nothing meaningful changed (proven hot-looping at ~600ms/CR on
-	// the envtest adoption walk without this).
-	if bootstrapStatusUnchanged(app, phase, message, ready) {
+	// the envtest adoption walk without this). The continuumRef is part
+	// of the changed-set: an adoption that just minted its Continuum must
+	// write the back-ref even when the HR phase is unchanged.
+	if bootstrapStatusUnchanged(app, phase, message, ready) &&
+		bootstrapContinuumRefUnchanged(app, continuumRef) {
 		return nil
 	}
 
@@ -2317,7 +2362,8 @@ func (r *Reconciler) reconcileBootstrapOwned(ctx context.Context, app *unstructu
 		"app", app.GetName(),
 		"namespace", app.GetNamespace(),
 		"helmRelease", hrNamespace+"/"+hrName,
-		"phase", phase)
+		"phase", phase,
+		"continuumRef", continuumRef)
 
 	return r.updateStatus(ctx, app, statusUpdate{
 		Phase:            phase,
@@ -2325,7 +2371,117 @@ func (r *Reconciler) reconcileBootstrapOwned(ctx context.Context, app *unstructu
 		Message:          message,
 		Ready:            ready,
 		LastReconciledAt: now,
+		ContinuumRef:     continuumRef,
 	})
+}
+
+// reconcileBootstrapContinuum mints the per-app Continuum DR contract for a
+// bootstrap-owned (adopted) Application and returns its `<ns>/<name>`
+// back-pointer (#4416). It is the adoption-path equivalent of the normal
+// reconcile's step-7.5 Continuum producer: the adoption path never resolves
+// a fan-out render, so we resolve the minimal inputs the Continuum producer
+// needs (placement plan + Blueprint topology variant) directly from the
+// Application's own spec + the referenced Blueprint.
+//
+// A non-DR bootstrap app (singleton / single-region / Blueprint with no
+// switchover mechanism) produces NO CR — buildContinuumPlan returns
+// (zero,false) and reconcileContinuumCR is a no-op that returns "". So the
+// pre-existing shared-pg / substrate adoption apps are unaffected (they
+// keep being pure status-mirrors with no Continuum + no back-ref). Only a
+// DR-capable multi-region spine app mints a contract here.
+//
+// Resolution mirrors the normal path: spec.placement (the explicit posture
+// string the spine producer stamps — active-hot-standby / active-passive)
+// + spec.regions → placement.Resolve; the Blueprint's spec.topology variant
+// → the switchover mechanism. A missing/non-DR placement or a Blueprint
+// without a topology block simply yields no contract (returns "", nil),
+// never an error — the gate is the same buildContinuumPlan the normal path
+// applies.
+func (r *Reconciler) reconcileBootstrapContinuum(
+	ctx context.Context,
+	app *unstructured.Unstructured,
+) (string, error) {
+	spec, err := parseSpec(app)
+	if err != nil {
+		// A bootstrap app with an unparseable spec is not a DR contract we
+		// can mint — leave it a pure status-mirror rather than fail the
+		// adoption (the HR observation above is the load-bearing signal).
+		return "", nil
+	}
+	// Only an explicit single-primary DR posture has a switchover to drive.
+	// A singleton / active-active / empty posture is not a DR contract — skip
+	// without fetching the Blueprint (keeps the shared-pg adoption path a
+	// zero-extra-GET status-mirror).
+	switch spec.Placement {
+	case string(bpv1alpha1.BcpActiveHotStandby), string(bpv1alpha1.BcpActivePassive):
+		// DR-capable posture — resolve the contract below.
+	default:
+		return "", nil
+	}
+	if len(spec.Regions) < 2 {
+		// A DR contract needs ≥2 regions (primary + ≥1 standby). A
+		// single-region spine on a single-region Sovereign has nothing to
+		// fail over to — no CR.
+		return "", nil
+	}
+
+	plan, perr := placement.Resolve(spec.Placement, spec.Regions)
+	if perr != nil {
+		// An unresolvable placement is not mintable; do not fail the
+		// adoption over it (the HR is still healthy + observed).
+		r.Log.Warn("bootstrap-owned: placement resolve failed; no Continuum minted",
+			"app", app.GetName(), "placement", spec.Placement, "err", perr)
+		return "", nil
+	}
+
+	bp, berr := r.fetchBlueprint(ctx, spec.BlueprintName)
+	if berr != nil {
+		if isNotFound(berr) {
+			// Blueprint not yet in the catalog — retry on the next pass
+			// rather than minting an incomplete contract.
+			r.Log.Info("bootstrap-owned: Blueprint not found; Continuum mint deferred",
+				"app", app.GetName(), "blueprint", spec.BlueprintName)
+			return "", nil
+		}
+		return "", fmt.Errorf("fetch Blueprint %q: %w", spec.BlueprintName, berr)
+	}
+	bpTopo := parseBlueprintTopology(bp)
+	if bpTopo == nil {
+		// No topology block ⇒ no switchover variant ⇒ not a DR contract.
+		return "", nil
+	}
+	// Resolve the variant for the chosen posture (operator override = the
+	// explicit posture string; sovereignRegions = the CR's region count).
+	choice, variant, terr := topo.ResolveTopology(spec.Placement, bpTopo, len(spec.Regions))
+	if terr != nil {
+		r.Log.Warn("bootstrap-owned: topology resolve failed; no Continuum minted",
+			"app", app.GetName(), "blueprint", spec.BlueprintName,
+			"placement", spec.Placement, "err", terr)
+		return "", nil
+	}
+
+	ownerLabels := map[string]string{
+		"catalyst.openova.io/app-uid": string(app.GetUID()),
+	}
+	if org := app.GetLabels()["catalyst.openova.io/organization"]; org != "" {
+		ownerLabels["catalyst.openova.io/organization"] = org
+	}
+	return r.reconcileContinuumCR(ctx, app.GetName(), app.GetNamespace(),
+		choice, variant, plan, ownerLabels)
+}
+
+// bootstrapContinuumRefUnchanged reports whether the Application's current
+// status already carries the given Continuum back-ref (#4416). Part of the
+// adoption-path churn guard so a freshly-minted Continuum still writes its
+// back-ref even when the adopted HR's phase is unchanged.
+func bootstrapContinuumRefUnchanged(app *unstructured.Unstructured, continuumRef string) bool {
+	if continuumRef == "" {
+		// Nothing to write — never forces an extra status write on the
+		// non-DR adoption path.
+		return true
+	}
+	cur, _, _ := unstructured.NestedString(app.Object, "status", "continuumRef")
+	return cur == continuumRef
 }
 
 // bootstrapStatusUnchanged reports whether the Application's current

--- a/core/controllers/application/internal/controller/application_controller_bootstrap_test.go
+++ b/core/controllers/application/internal/controller/application_controller_bootstrap_test.go
@@ -268,3 +268,136 @@ func TestReconcile_BootstrapOwnedDeletion_NoTeardown(t *testing.T) {
 		t.Errorf("finalizer should be released on bootstrap-owned deletion")
 	}
 }
+
+// makeBootstrapOwnedSpineApp mirrors the #4416 spine producer output: a
+// bootstrap-owned (adopt) Application that is ALSO a DR-capable multi-region
+// spine — spec.bootstrap=true + spec.helmRelease (adopt the healthy bootstrap
+// HR, no duplicate render) + an explicit DR posture (active-hot-standby) +
+// ≥2 regions (so the adoption path mints the per-app Continuum DR contract +
+// writes the status.continuumRef back-ref).
+func makeBootstrapOwnedSpineApp(namespace, name, bpName, bpVer, hrName string, regions []string) *unstructured.Unstructured {
+	rgs := make([]interface{}, len(regions))
+	for i, r := range regions {
+		rgs[i] = r
+	}
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("apps.openova.io/v1")
+	u.SetKind("Application")
+	u.SetNamespace(namespace)
+	u.SetName(name)
+	u.SetGeneration(1)
+	u.SetLabels(map[string]string{
+		"catalyst.openova.io/spine":        "true",
+		"catalyst.openova.io/organization": "platform",
+	})
+	u.Object["spec"] = map[string]interface{}{
+		"bootstrap":       true,
+		"environmentRef":  "omantel-biz-cp",
+		"organizationRef": "omantel-biz",
+		"placement":       "active-hot-standby",
+		"regions":         rgs,
+		"blueprintRef": map[string]interface{}{
+			"name":    bpName,
+			"version": bpVer,
+		},
+		"helmRelease": map[string]interface{}{
+			"name":      hrName,
+			"namespace": "flux-system",
+		},
+	}
+	return u
+}
+
+// TestReconcile_BootstrapOwnedSpineAdoption_MintsContinuumAndBackRef is the
+// #4416 round-trip acceptance: a DR-capable multi-region spine app that ADOPTS
+// its healthy bootstrap HR must STILL mint its per-app Continuum DR contract
+// (the forward half of #4212) AND write the status.continuumRef back-pointer
+// (the consumer-READ that closes the round-trip) — WITHOUT rendering a
+// duplicate HelmRelease (Invariant #3). This is the regression the live
+// omantel.biz spine apps tripped: adoption was gated on spec.bootstrap (never
+// set), so the controller render-duplicated failing installs.
+func TestReconcile_BootstrapOwnedSpineAdoption_MintsContinuumAndBackRef(t *testing.T) {
+	// DR-capable Blueprint (topology block w/ active-hot-standby + switchover).
+	bp := makeBlueprintDRTopology("bp-gitea", "1.2.24", "mgmt", []string{"mgmt-A", "mgmt-B"})
+	env := makeMultiRegionEnv("omantel-biz-cp", "omantel-biz", "prod")
+	org := makeOrg("omantel-biz")
+	hr := makeSlotHR("flux-system", "bp-gitea", "True",
+		"Helm upgrade succeeded for release gitea/gitea.v24 with chart bp-gitea@1.2.46")
+	app := makeBootstrapOwnedSpineApp("catalyst", "spine-gitea", "bp-gitea", "1.2.24",
+		"bp-gitea", []string{"hetzner-fsn-rtz-prod", "hetzner-nbg-rtz-prod"})
+
+	fg := newFakeGitea()
+	fg.orgsExist["omantel-biz"] = true
+	r := newReconciler(t, fg, app, env, org, bp, hr)
+
+	before := countHelmReleases(t, r)
+	reconcileFromCluster(t, r, "catalyst", "spine-gitea")
+	after := countHelmReleases(t, r)
+
+	// (1) ADOPT, never roll — no duplicate HelmRelease rendered.
+	if after != before {
+		t.Fatalf("ADOPTION VIOLATION: HelmRelease count changed %d -> %d — the spine adoption path rendered a duplicate install", before, after)
+	}
+	if fg.puts != 0 {
+		t.Errorf("expected 0 Gitea writes for an adopted spine app, got %d", fg.puts)
+	}
+
+	// (2) The per-app Continuum DR contract is minted (forward seam).
+	cr, err := r.Dynamic.Resource(ContinuumGVR).Namespace("catalyst").
+		Get(context.Background(), "dr-spine-gitea", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected per-app Continuum CR dr-spine-gitea in ns catalyst (the adoption path must mint the DR contract): %v", err)
+	}
+	appRef, _, _ := unstructured.NestedString(cr.Object, "spec", "applicationRef")
+	if appRef != "catalyst/spine-gitea" {
+		t.Errorf("Continuum applicationRef = %q, want catalyst/spine-gitea", appRef)
+	}
+	standby, _, _ := unstructured.NestedStringSlice(cr.Object, "spec", "hotStandbyRegions")
+	if len(standby) != 1 || standby[0] != "hetzner-nbg-rtz-prod" {
+		t.Errorf("hotStandbyRegions = %v, want [hetzner-nbg-rtz-prod]", standby)
+	}
+
+	// (3) The back-ref closes the round-trip.
+	got := readApp(t, r, "catalyst", "spine-gitea")
+	ref, _, _ := unstructured.NestedString(got.Object, "status", "continuumRef")
+	if ref != "catalyst/dr-spine-gitea" {
+		t.Fatalf("status.continuumRef = %q, want catalyst/dr-spine-gitea (the #4212 round-trip back-pointer)", ref)
+	}
+	// Adoption phase still mirrors the healthy bootstrap HR (Ready).
+	phase, reason, msg := readPhaseAndReason(t, got)
+	if phase != PhaseReady {
+		t.Errorf("phase = %q, want Ready (adopted HR is Ready=True); msg=%q", phase, msg)
+	}
+	if reason != ReasonBootstrapAdopted {
+		t.Errorf("reason = %q, want %q", reason, ReasonBootstrapAdopted)
+	}
+}
+
+// TestReconcile_BootstrapOwnedNonDRSpine_NoContinuum proves a SINGLETON
+// bootstrap-owned app (shared-pg shape, placement=single-region) still mints
+// NO Continuum + writes NO back-ref after the #4416 change — the shared-pg /
+// substrate adoption path is unchanged (zero-extra-GET status-mirror).
+func TestReconcile_BootstrapOwnedNonDRSpine_NoContinuum(t *testing.T) {
+	bp := makeBlueprint("bp-postgres", "0.1.6", nil, []string{"single-region"})
+	env := makeEnv("acme-prod", "acme", "prod")
+	org := makeOrg("acme")
+	hr := makeSlotHR("flux-system", "bp-postgres-shared", "True", "ok")
+	app := makeBootstrapOwnedApp("shared-data", "shared-pg", "bp-postgres-shared", "flux-system")
+	_ = unstructured.SetNestedField(app.Object, "acme-prod", "spec", "environmentRef")
+	_ = unstructured.SetNestedStringSlice(app.Object, []string{"hetzner-fsn-rtz-prod"}, "spec", "regions")
+
+	fg := newFakeGitea()
+	fg.orgsExist["acme"] = true
+	r := newReconciler(t, fg, app, env, org, bp, hr)
+
+	reconcileFromCluster(t, r, "shared-data", "shared-pg")
+
+	if _, err := r.Dynamic.Resource(ContinuumGVR).Namespace("shared-data").
+		Get(context.Background(), "dr-shared-pg", metav1.GetOptions{}); err == nil {
+		t.Fatalf("a singleton bootstrap-owned app must NOT mint a Continuum CR")
+	}
+	got := readApp(t, r, "shared-data", "shared-pg")
+	if ref, _, _ := unstructured.NestedString(got.Object, "status", "continuumRef"); ref != "" {
+		t.Errorf("status.continuumRef = %q, want empty for a non-DR bootstrap app", ref)
+	}
+}

--- a/core/controllers/application/internal/controller/continuum.go
+++ b/core/controllers/application/internal/controller/continuum.go
@@ -312,10 +312,13 @@ func ContinuumNameFor(app string) string {
 
 // reconcileContinuumCR upserts the per-app Continuum CR for a DR-capable
 // Application, idempotently. Called from the fan-out persist block once
-// the per-cluster HelmReleases are written. Returns nil (no-op) when the
-// app is not a DR contract (buildContinuumPlan gate). Errors are surfaced
-// to the caller, which downgrades the Application to Degraded so the
-// reconcile retries — a missing DR contract must not silently pass.
+// the per-cluster HelmReleases are written. Returns ("", nil) (no-op) when
+// the app is not a DR contract (buildContinuumPlan gate); otherwise returns
+// the `<namespace>/<name>` of the produced Continuum CR so the caller can
+// write the `status.continuumRef` back-pointer (#4416 — the consumer-READ
+// that closes the #4212 round-trip). Errors are surfaced to the caller,
+// which downgrades the Application to Degraded so the reconcile retries — a
+// missing DR contract must not silently pass.
 func (r *Reconciler) reconcileContinuumCR(
 	ctx context.Context,
 	appName, namespace string,
@@ -323,7 +326,7 @@ func (r *Reconciler) reconcileContinuumCR(
 	variant *bpv1alpha1.TopologyVariant,
 	plan placement.Plan,
 	ownerLabels map[string]string,
-) error {
+) (string, error) {
 	appRef := namespace + "/" + appName
 	cp, ok := buildContinuumPlan(appRef, choice, variant, plan, ownerLabels)
 	if !ok {
@@ -331,11 +334,11 @@ func (r *Reconciler) reconcileContinuumCR(
 		// no switchover mechanism). If a stale CR exists from a PRIOR
 		// topology (operator downgraded active-hot-standby → singleton),
 		// remove it so the roster reflects reality.
-		return r.deleteContinuumCRIfExists(ctx, appName, namespace)
+		return "", r.deleteContinuumCRIfExists(ctx, appName, namespace)
 	}
 	cr := renderContinuumCR(appName, namespace, cp)
 	if err := r.upsertHostResource(ctx, ContinuumGVR, namespace, cr.GetName(), cr); err != nil {
-		return fmt.Errorf("upsert Continuum CR %s/%s: %w", namespace, cr.GetName(), err)
+		return "", fmt.Errorf("upsert Continuum CR %s/%s: %w", namespace, cr.GetName(), err)
 	}
 	r.Log.Info("upserted per-app Continuum CR",
 		"namespace", namespace, "name", cr.GetName(),
@@ -344,7 +347,7 @@ func (r *Reconciler) reconcileContinuumCR(
 		"primaryRegion", cp.PrimaryRegion,
 		"hotStandbyRegions", cp.StandbyRegions,
 	)
-	return nil
+	return namespace + "/" + cr.GetName(), nil
 }
 
 // deleteContinuumCRIfExists removes the per-app Continuum CR if present.

--- a/products/catalyst/bootstrap/api/internal/handler/post_handover_spine_apps.go
+++ b/products/catalyst/bootstrap/api/internal/handler/post_handover_spine_apps.go
@@ -496,21 +496,58 @@ func renderSpineApplicationCR(sc spineComponent, envRef, orgRef string, regions 
 			"version": sc.BlueprintVersion,
 		},
 		"regions": rgs,
+		// #4416 — ADOPT, never roll (Invariant #3). The spine HelmRelease is
+		// ALREADY installed + healthy by the bootstrap-kit (flux-system/bp-<chart>);
+		// stamping spec.bootstrap=true + spec.helmRelease routes the
+		// application-controller down its bootstrap-owned ADOPTION path
+		// (reconcileBootstrapOwned), which observes that existing HR's Ready
+		// condition for status and NEVER renders a fan-out HelmRelease.
+		//
+		// THE BUG THIS FIXES. The prior shape stamped only the
+		// `catalyst.openova.io/adopts-helmrelease` LABEL and left
+		// spec.bootstrap=false — but the controller's adoption guard
+		// (isBootstrapOwned) keys ONLY off spec.bootstrap, never the label. So
+		// the controller ran the full fan-out render and stamped DUPLICATE
+		// HelmReleases (spine-<chart>, spine-<chart>-mgmt-a/-b) carrying the
+		// producer's STALE catalog-seed chart pin (e.g. bp-harbor@1.2.26 vs the
+		// live healthy bootstrap bp-harbor@1.2.40). Those duplicate installs
+		// failed `context deadline exceeded`, wedging the spine app at
+		// Degraded/Provisioning and violating Invariant #3. The adoption path
+		// makes the spine app a pure status-mirror of the healthy bootstrap HR.
+		"bootstrap": true,
+		"helmRelease": map[string]interface{}{
+			"name":      sc.HRName,
+			"namespace": spineHRNamespace,
+		},
 	}
-	// #4402 — stamp the minimal spec.config the Blueprint configSchema requires
-	// (e.g. bp-keycloak's required `realmName`) so the Application passes
-	// validation and reaches the Continuum producer. Components with no required
-	// config carry a nil Config and stamp nothing.
+	// #4402/#4416 — stamp the minimal spec.parameters the Blueprint configSchema
+	// requires (e.g. bp-keycloak's required `realmName`) so the Application
+	// passes validation and reaches the Continuum producer. The controller
+	// validates spec.PARAMETERS (parseSpec reads `spec.parameters`; the CRD
+	// declares `spec.parameters`; the REST install path writes `spec.parameters`)
+	// — the prior `spec.config` key was never read, so spine-keycloak Failed
+	// validation `missing properties: 'realmName'` despite carrying the value
+	// under the wrong key. Components with no required config carry a nil Config
+	// and stamp nothing.
 	if len(sc.Config) > 0 {
-		cfg := make(map[string]interface{}, len(sc.Config))
+		params := make(map[string]interface{}, len(sc.Config))
 		for k, v := range sc.Config {
-			cfg[k] = v
+			params[k] = v
 		}
-		spec["config"] = cfg
+		spec["parameters"] = params
 	}
 	obj.Object["spec"] = spec
 	return obj
 }
+
+// spineHRNamespace — the namespace the bootstrap-spine HelmRelease CRs live in.
+// The bootstrap-kit installs every spine HR (bp-gitea/-harbor/-keycloak/-openbao)
+// as a Flux HelmRelease object in `flux-system` (the canonical bootstrap-kit
+// convention — the HR OBJECT is in flux-system even though it targets a
+// per-component release namespace). The adoption path (reconcileBootstrapOwned)
+// GETs the HelmRelease at spec.helmRelease.{name,namespace}; this is that
+// namespace.
+const spineHRNamespace = "flux-system"
 
 // spinePlacementMode picks the explicit placement mode to stamp on a spine
 // Application CR. On a single-region Sovereign the spine is a singleton; on

--- a/products/catalyst/bootstrap/api/internal/handler/post_handover_spine_apps_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/post_handover_spine_apps_test.go
@@ -121,6 +121,23 @@ func TestRenderSpineApplicationCR_ContractShape(t *testing.T) {
 		t.Fatalf("spec.placement = %q, want active-passive (multi-region openbao default)", pl)
 	}
 
+	// #4416 — ADOPT, never roll (Invariant #3): the CR is bootstrap-owned +
+	// names the existing bootstrap HelmRelease so the application-controller
+	// takes its adoption path (observe the healthy HR's Ready condition) and
+	// NEVER renders a duplicate fan-out HelmRelease.
+	boot, found, _ := unstructured.NestedBool(cr.Object, "spec", "bootstrap")
+	if !found || !boot {
+		t.Fatalf("spec.bootstrap must be true so the controller ADOPTS the existing spine HR (no duplicate render); got found=%v boot=%v", found, boot)
+	}
+	hrName, _, _ := unstructured.NestedString(cr.Object, "spec", "helmRelease", "name")
+	hrNS, _, _ := unstructured.NestedString(cr.Object, "spec", "helmRelease", "namespace")
+	if hrName != "bp-openbao" {
+		t.Fatalf("spec.helmRelease.name = %q, want bp-openbao", hrName)
+	}
+	if hrNS != "flux-system" {
+		t.Fatalf("spec.helmRelease.namespace = %q, want flux-system", hrNS)
+	}
+
 	// Adopt-not-roll contract (Invariant #3): the CR names the EXISTING
 	// HelmRelease it enrolls + is marked spine.
 	lbls := cr.GetLabels()
@@ -140,31 +157,38 @@ func TestRenderSpineApplicationCR_ContractShape(t *testing.T) {
 }
 
 // TestRenderSpineApplicationCR_StampsRequiredConfig proves the producer stamps
-// the minimal spec.config a Blueprint's configSchema requires (#4402). The live
-// bp-keycloak configSchema is `required: [realmName]`, so a spine-keycloak CR
-// with no config Fails validation in the application-controller
-// (`missing properties: 'realmName'`) BEFORE it can reach the Continuum
-// producer. A component whose roster row carries no Config stamps no spec.config.
+// the minimal spec.PARAMETERS a Blueprint's configSchema requires (#4402/#4416).
+// The live bp-keycloak configSchema is `required: [realmName]`, so a
+// spine-keycloak CR with no parameters Fails validation in the
+// application-controller (`missing properties: 'realmName'`) BEFORE it can reach
+// the Continuum producer. The controller validates `spec.parameters` (the CRD +
+// REST install + parseSpec all use that key) — the prior `spec.config` key was
+// never read, which is why spine-keycloak Failed despite carrying the value. A
+// component whose roster row carries no Config stamps no spec.parameters.
 func TestRenderSpineApplicationCR_StampsRequiredConfig(t *testing.T) {
 	owner := map[string]string{}
 
-	// keycloak roster row carries Config{realmName} → spec.config.realmName set.
+	// keycloak roster row carries Config{realmName} → spec.parameters.realmName set.
 	kc := spineComponent{Chart: "keycloak", HRName: "bp-keycloak", BlueprintName: "bp-keycloak", BlueprintVersion: "1.0.0", MultiRegionMode: "active-hot-standby", Config: map[string]interface{}{"realmName": "sovereign"}}
 	cr := renderSpineApplicationCR(kc, "t99-omani-works-cp", "t99-omani-works", []string{"me-east-215", "eu-west-101"}, owner)
-	realm, found, _ := unstructured.NestedString(cr.Object, "spec", "config", "realmName")
+	realm, found, _ := unstructured.NestedString(cr.Object, "spec", "parameters", "realmName")
 	if !found {
-		t.Fatalf("spec.config.realmName must be stamped for the keycloak spine (configSchema required: [realmName]); it was omitted")
+		t.Fatalf("spec.parameters.realmName must be stamped for the keycloak spine (configSchema required: [realmName]); it was omitted")
 	}
 	if realm != "sovereign" {
-		t.Fatalf("spec.config.realmName = %q, want sovereign", realm)
+		t.Fatalf("spec.parameters.realmName = %q, want sovereign", realm)
+	}
+	// Regression pin: the config must NOT land under the never-read spec.config key.
+	if _, badFound, _ := unstructured.NestedMap(cr.Object, "spec", "config"); badFound {
+		t.Fatalf("spec.config must NOT be set — the controller reads spec.parameters, never spec.config (the #4416 bug)")
 	}
 
-	// openbao roster row has no Config → no spec.config at all (Blueprint declares
-	// no required config; stamping an empty map would be noise).
+	// openbao roster row has no Config → no spec.parameters at all (Blueprint
+	// declares no required config; stamping an empty map would be noise).
 	ob := spineComponent{Chart: "openbao", HRName: "bp-openbao", BlueprintName: "bp-openbao", BlueprintVersion: "1.2.25", MultiRegionMode: "active-passive"}
 	crOB := renderSpineApplicationCR(ob, "t99-omani-works-cp", "t99-omani-works", []string{"me-east-215", "eu-west-101"}, owner)
-	if _, found, _ := unstructured.NestedMap(crOB.Object, "spec", "config"); found {
-		t.Fatalf("spec.config must be absent for a component with no required config (openbao)")
+	if _, found, _ := unstructured.NestedMap(crOB.Object, "spec", "parameters"); found {
+		t.Fatalf("spec.parameters must be absent for a component with no required config (openbao)")
 	}
 
 	// The live keycloak roster row carries the realmName config (regression pin).


### PR DESCRIPTION
## What

Finishes wiring the #4212 spine→Continuum round-trip. The forward seam already mints 3 spine Continuums (dr-spine-gitea/-harbor/-openbao, all Healthy on omantel.biz). A live verify (dep `4635277cae4ffed9`, 2026-06-26) found the round-trip still incomplete for 3 concrete, verified reasons — all fixed here as durable code.

## The 3 gaps (live-confirmed, then fixed)

### Gap 1 — spine apps render DUPLICATE failing installs instead of ADOPTING the bootstrap HR
The producer stamped only an `catalyst.openova.io/adopts-helmrelease` LABEL and left `spec.bootstrap=false`. The application-controller's adoption guard (`isBootstrapOwned`) keys SOLELY off `spec.bootstrap`, never the label. So the controller ran the full fan-out render and stamped DUPLICATE HelmReleases (`spine-<chart>`, `spine-<chart>-mgmt-a/-b`) carrying the producer's stale catalog-seed pin (e.g. `bp-harbor@1.2.26` vs the live healthy bootstrap `bp-harbor@1.2.40`). Those duplicate installs failed `context deadline exceeded`, wedging the spine app at Degraded/Provisioning and violating EPIC Invariant #3.

**Fix:** the producer now stamps `spec.bootstrap=true` + `spec.helmRelease={name:bp-<chart>, namespace:flux-system}` so the spine app takes the adoption path — a pure status-mirror of the healthy bootstrap HR, no duplicate render.

### Gap 2 — config stamped to the wrong field (`spec.config` vs `spec.parameters`)
`renderSpineApplicationCR` wrote the required config to `spec.config`, but the controller validates `spec.parameters` against the Blueprint configSchema (the CRD, REST install path, and `parseSpec` all use that key). spine-keycloak therefore Failed validation `parameters do not match Blueprint configSchema: #: missing properties: 'realmName'` despite carrying `realmName=sovereign` under the wrong key → never reached the Continuum producer → `dr-spine-keycloak` absent.

**Fix:** stamp to `spec.parameters`.

### Gap 3 — no `status.continuumRef` back-ref
`reconcileContinuumCR` minted the Continuum CR but never wrote a back-pointer onto the Application (`spine-gitea.status.continuumRef` empty). The consumer-READ that closes the round-trip was missing.

**Fix:** `reconcileContinuumCR` now returns the `<ns>/<name>` of the produced CR; both the normal render path AND the adoption path write `status.continuumRef`. The adoption path (`reconcileBootstrapOwned`) is extended to mint the per-app Continuum DR contract for a DR-capable multi-region spine (resolving plan + variant from the CR's own `spec.placement` + `spec.regions` + the Blueprint topology) and write the back-ref — so the forward Continuum seam stays green AND the round-trip closes. A non-DR bootstrap app (singleton shared-pg) mints nothing (the `buildContinuumPlan` gate) — that adoption path is unchanged.

## Expected post-roll spine state
After the catalyst-api + application-controller images roll, the 4 spine apps (gitea/harbor/openbao/keycloak) reconcile Ready via adoption of the healthy bootstrap HRs, each carries `status.continuumRef`, and each Continuum (incl. `dr-spine-keycloak`) reports Healthy. One-time migration note for the existing omantel.biz env: the orphaned duplicate `spine-*-mgmt-*` HelmReleases/Kustomizations the prior render path created need a one-time cleanup (they have no ownerReferences); a fresh prov never creates them.

## Tests
- Spine producer: asserts `spec.bootstrap=true` + `spec.helmRelease` + config in `spec.parameters` (not `spec.config`).
- Controller: new tests assert the adopted DR-spine mints `dr-<app>` + writes `status.continuumRef`, and the singleton bootstrap app mints nothing.
- Full application-controller + bootstrap-api handler suites green.

Refs #4212 #4416

🤖 Generated with [Claude Code](https://claude.com/claude-code)