### PR TITLE
fix(application-controller): roll vCluster-placed Application out of Provisioning when its per-cluster HR is Ready (Refs #4282)

### DIFF
--- a/core/controllers/application/internal/controller/application_controller.go
+++ b/core/controllers/application/internal/controller/application_controller.go
@@ -1088,12 +1088,30 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 				)
 			}
 
-			for _, s := range topo.PerClusterStatusesFor(hrs) {
+			// #4282 — seed each per-cluster row with the HR's authored
+			// namespace + a provisional "Provisioning" status. The status
+			// is NOT left hardcoded: the §10 HR readback below
+			// (observeRegionHelmReleases) flips each row to "Ready" once its
+			// per-cluster HelmRelease reports Ready=True, so a vCluster-placed
+			// Application (whose Cluster CR #4398 routes host-side) rolls up
+			// out of Provisioning the same way the single-HR host path does.
+			// The namespace is captured because a fan-out HR is authored in
+			// its WriteNamespace (host app-ns for #4398 CNPG routing, or the
+			// vCluster host-ns for the legacy pivot) — the readback must GET
+			// it where it was actually written, not always app.GetNamespace().
+			for i, s := range topo.PerClusterStatusesFor(hrs) {
+				hrNamespace := app.GetNamespace()
+				if i < len(hrs) {
+					if ns := hrs[i].GetNamespace(); ns != "" {
+						hrNamespace = ns
+					}
+				}
 				perClusterStatus = append(perClusterStatus, map[string]interface{}{
-					"cluster": s.Cluster,
-					"role":    s.Role,
-					"hr":      s.HR,
-					"status":  "Pending",
+					"cluster":   s.Cluster,
+					"role":      s.Role,
+					"hr":        s.HR,
+					"namespace": hrNamespace,
+					"status":    PhaseProvisioning,
 				})
 			}
 		}
@@ -1339,18 +1357,42 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 	// #4282 — the topology fan-out (placement.Clusters, e.g. a per-Org
 	// bp-postgres routed host-side by #4398) names each per-cluster HR
 	// `<app>-<cluster>` (HRNameFor), NOT the bare `<app>` the single-HR
-	// host path uses. The phase rollup must observe the ACTUAL fan-out HR
-	// names or it GETs `<app>` → NotFound → the Application is pinned at
-	// Provisioning forever even though `w4282-pg-rtz-a` is Ready=True.
-	// perClusterStatus carries the real names (hr.GetName()); pass them in.
-	fanoutHRNames := make([]string, 0, len(perClusterStatus))
+	// host path uses, and authors it in the HR's WriteNamespace (the host
+	// app-ns for #4398 CNPG routing, or the vCluster host-ns for the legacy
+	// pivot). The phase rollup must observe the ACTUAL fan-out HR names IN
+	// THEIR AUTHORED NAMESPACE or it GETs `<app>` (or the wrong ns)
+	// → NotFound → the Application is pinned at Provisioning forever even
+	// though `w4282-pg-rtz-a` is Ready=True. perClusterStatus carries the
+	// real names + namespaces (seeded above); pass them in.
+	fanoutHRRefs := make([]hrRef, 0, len(perClusterStatus))
 	for _, pcs := range perClusterStatus {
-		if n, _ := pcs["hr"].(string); n != "" {
-			fanoutHRNames = append(fanoutHRNames, n)
+		n, _ := pcs["hr"].(string)
+		if n == "" {
+			continue
+		}
+		ns, _ := pcs["namespace"].(string)
+		if ns == "" {
+			ns = app.GetNamespace()
+		}
+		fanoutHRRefs = append(fanoutHRRefs, hrRef{name: n, namespace: ns, region: n})
+	}
+	hrPhase, hrReason, hrMessage, perHRReady := r.observeRegionHelmReleases(ctx, app, plan, fanoutHRRefs)
+	regionStatuses = mergeRegionReadiness(regionStatuses, hrPhase, plan, ctx, r, app)
+
+	// #4282 — flip each per-cluster row's status from the provisional
+	// "Provisioning" seed to the HR's observed readiness so the console's
+	// per-cluster view (and any consumer rolling up perCluster[].status)
+	// reflects the live HelmRelease, not a hardcoded placeholder. A row
+	// with no live HR yet (NotFound) stays Provisioning.
+	for _, pcs := range perClusterStatus {
+		n, _ := pcs["hr"].(string)
+		switch perHRReady[n] {
+		case "True":
+			pcs["status"] = PhaseReady
+		case "False":
+			pcs["status"] = PhaseDegraded
 		}
 	}
-	hrPhase, hrReason, hrMessage := r.observeRegionHelmReleases(ctx, app, plan, fanoutHRNames)
-	regionStatuses = mergeRegionReadiness(regionStatuses, hrPhase, plan, ctx, r, app)
 
 	// 11. Status update — phase derived from observed HR readiness,
 	//     fall back to Provisioning when no signal is available yet.
@@ -1519,21 +1561,34 @@ func readbackByRegion(plan placement.Plan, phase string) map[string]regionReadba
 	return out
 }
 
-// observeRegionHelmReleases polls the per-region HelmRelease CRs the
-// Sovereign's Flux installer materialised in the Application's own
-// namespace. Returns the rolled-up phase string + the reason+message of
-// the WORST region (so a single-region Failed surfaces in the UI verbatim
-// instead of being averaged out).
+// hrRef is one HelmRelease the rollup observes: its name + the namespace
+// it was authored in + a region/cluster label for the worst-case message.
+// A fan-out HR is authored in its WriteNamespace (host app-ns for #4398
+// CNPG routing, the vCluster host-ns for the legacy pivot), so the
+// namespace MUST travel with the name — reading every HR from
+// app.GetNamespace() pins a vCluster-placed Application at Provisioning
+// forever (#4282).
+type hrRef struct{ name, namespace, region string }
+
+// observeRegionHelmReleases polls the per-region / per-cluster HelmRelease
+// CRs the Sovereign's Flux installer materialised. Returns the rolled-up
+// phase string + the reason+message of the WORST region (so a single-region
+// Failed surfaces in the UI verbatim instead of being averaged out) + a
+// per-HR readiness map (HR name → "True"|"False"|"" ) the caller uses to
+// flip each status.perCluster[] row.
 //
 // HR naming has TWO shapes:
 //   - SINGLE-HR host path: the HR is named exactly `app.GetName()`
-//     (render.HelmReleaseName / the chart's `metadata.name: {{ .AppName }}`).
+//     (render.HelmReleaseName / the chart's `metadata.name: {{ .AppName }}`)
+//     in the Application's own namespace. `fanoutRefs` empty ⇒ we synthesize
+//     one bare-name ref per planned region.
 //   - TOPOLOGY FAN-OUT (placement.Clusters, e.g. a per-Org bp-postgres
-//     routed host-side by #4398): one HR per cluster named
-//     `<app>-<cluster>` (HRNameFor). `fanoutHRNames` carries those real
-//     names; when non-empty we observe THEM (one GET per fan-out HR)
-//     instead of the bare `app.GetName()`, which does not exist for the
-//     fan-out and would pin the Application at Provisioning forever (#4282).
+//     routed host-side by #4398): one HR per cluster named `<app>-<cluster>`
+//     (HRNameFor), authored in its WriteNamespace. `fanoutRefs` carries those
+//     real names + namespaces; when non-empty we observe THEM (one GET per
+//     fan-out HR, each in ITS namespace) instead of the bare `app.GetName()`,
+//     which does not exist for the fan-out and would pin the Application at
+//     Provisioning forever (#4282).
 //
 // Idempotent + side-effect-free: only reads the API.
 //
@@ -1542,30 +1597,30 @@ func (r *Reconciler) observeRegionHelmReleases(
 	ctx context.Context,
 	app *unstructured.Unstructured,
 	plan placement.Plan,
-	fanoutHRNames []string,
-) (phase, reason, message string) {
+	fanoutRefs []hrRef,
+) (phase, reason, message string, perHRReady map[string]string) {
 	allReady := true
 	anyDegraded := false
 	worstReason := ""
 	worstMessage := ""
 	sawAny := false
-	// Build the (name, region-label) work list. Fan-out → the real
-	// per-cluster HR names; else one bare-name entry per planned region.
-	type hrRef struct{ name, region string }
-	refs := make([]hrRef, 0)
-	if len(fanoutHRNames) > 0 {
-		for _, n := range fanoutHRNames {
-			refs = append(refs, hrRef{name: n, region: n})
-		}
-	} else {
+	perHRReady = make(map[string]string, len(fanoutRefs))
+	// Build the work list. Fan-out → the real per-cluster HR names +
+	// namespaces; else one bare-name entry (app-ns) per planned region.
+	refs := fanoutRefs
+	if len(refs) == 0 {
+		refs = make([]hrRef, 0, len(plan.Regions))
 		for _, rp := range plan.Regions {
-			refs = append(refs, hrRef{name: app.GetName(), region: rp.Name})
+			refs = append(refs, hrRef{name: app.GetName(), namespace: app.GetNamespace(), region: rp.Name})
 		}
 	}
 	for _, ref := range refs {
-		// HR lives in the Application's own namespace.
+		ns := ref.namespace
+		if ns == "" {
+			ns = app.GetNamespace()
+		}
 		hr, err := r.Dynamic.Resource(FluxHelmReleaseGVR).
-			Namespace(app.GetNamespace()).
+			Namespace(ns).
 			Get(ctx, ref.name, metav1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
@@ -1575,7 +1630,7 @@ func (r *Reconciler) observeRegionHelmReleases(
 				continue
 			}
 			r.Log.Warn("application-controller: GET HelmRelease failed",
-				"namespace", app.GetNamespace(),
+				"namespace", ns,
 				"name", ref.name,
 				"region", ref.region,
 				"err", err)
@@ -1584,6 +1639,7 @@ func (r *Reconciler) observeRegionHelmReleases(
 		}
 		sawAny = true
 		ready, hrReason, hrMsg := readReadyCondition(hr)
+		perHRReady[ref.name] = ready
 		switch ready {
 		case "True":
 			// good — keep allReady
@@ -1601,11 +1657,11 @@ func (r *Reconciler) observeRegionHelmReleases(
 	}
 	switch {
 	case anyDegraded:
-		return PhaseDegraded, worstReason, worstMessage
+		return PhaseDegraded, worstReason, worstMessage, perHRReady
 	case allReady && sawAny:
-		return PhaseReady, "", ""
+		return PhaseReady, "", "", perHRReady
 	default:
-		return PhaseProvisioning, "", ""
+		return PhaseProvisioning, "", "", perHRReady
 	}
 }
 

--- a/core/controllers/application/internal/controller/application_controller_test.go
+++ b/core/controllers/application/internal/controller/application_controller_test.go
@@ -1428,16 +1428,20 @@ func TestObserveRegionHelmReleases_FanoutHRNames(t *testing.T) {
 	app.SetName("w4282-pg")
 	plan := placement.Plan{Regions: []placement.RegionPlan{{Name: "me-east-215-a", Role: "primary"}}}
 
-	// WITH the fan-out name → Ready (the fix).
-	phase, _, _ := r.observeRegionHelmReleases(context.Background(), app, plan, []string{"w4282-pg-rtz-a"})
+	// WITH the fan-out name + namespace → Ready (the fix).
+	phase, _, _, perHRReady := r.observeRegionHelmReleases(context.Background(), app, plan,
+		[]hrRef{{name: "w4282-pg-rtz-a", namespace: "w4282walk", region: "w4282-pg-rtz-a"}})
 	if phase != PhaseReady {
 		t.Errorf("fan-out HR-name rollup: phase=%q, want %q (the per-cluster HR w4282-pg-rtz-a is Ready=True)", phase, PhaseReady)
 	}
+	if perHRReady["w4282-pg-rtz-a"] != "True" {
+		t.Errorf("per-HR readiness for w4282-pg-rtz-a = %q, want \"True\"", perHRReady["w4282-pg-rtz-a"])
+	}
 
-	// WITHOUT the fan-out names → falls back to the bare `<app>` which does
+	// WITHOUT the fan-out refs → falls back to the bare `<app>` which does
 	// NOT exist for a fan-out → Provisioning (the pre-fix wrong behavior,
 	// preserved for the single-HR host path which legitimately uses <app>).
-	phaseBare, _, _ := r.observeRegionHelmReleases(context.Background(), app, plan, nil)
+	phaseBare, _, _, _ := r.observeRegionHelmReleases(context.Background(), app, plan, nil)
 	if phaseBare != PhaseProvisioning {
 		t.Errorf("bare-name fallback with no <app> HR: phase=%q, want %q", phaseBare, PhaseProvisioning)
 	}

--- a/core/controllers/application/internal/controller/application_controller_vcluster_rollup_test.go
+++ b/core/controllers/application/internal/controller/application_controller_vcluster_rollup_test.go
@@ -1,0 +1,182 @@
+// application_controller_vcluster_rollup_test.go — #4282 status-rollup.
+//
+// The LAST #4282 gap: a per-Org Application placed in a vCluster never left
+// `status.phase: Provisioning` even when its per-cluster HelmRelease was
+// Ready. Two bugs combined:
+//
+//  1. status.perCluster[].status was HARDCODED to "Pending" with no flip to
+//     the HR's observed readiness.
+//  2. observeRegionHelmReleases read every fan-out HR from app.GetNamespace()
+//     instead of the namespace the HR was AUTHORED in (a fan-out HR lands in
+//     its WriteNamespace — the host app-ns for #4398 CNPG routing or the
+//     vCluster host-ns for the legacy pivot), so a vCluster-placed HR GET-ed
+//     in the wrong namespace returned NotFound → Provisioning forever.
+//
+// These tests assert the rollup now leaves Provisioning when the per-cluster
+// HR is Ready, stays Provisioning when it is not, and that the host
+// single-HR path is unchanged.
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/openova-io/openova/core/controllers/internal/placement"
+)
+
+// readyHR returns a fan-out HelmRelease with the given name/namespace whose
+// Ready condition matches `status` ("True"|"False").
+func readyHR(name, namespace, status string) *unstructured.Unstructured {
+	hr := &unstructured.Unstructured{}
+	hr.SetAPIVersion("helm.toolkit.fluxcd.io/v2")
+	hr.SetKind("HelmRelease")
+	hr.SetNamespace(namespace)
+	hr.SetName(name)
+	reason := "InstallSucceeded"
+	msg := "Helm install succeeded"
+	if status != "True" {
+		reason = "InstallFailed"
+		msg = "Helm install failed"
+	}
+	hr.Object["status"] = map[string]interface{}{
+		"conditions": []interface{}{
+			map[string]interface{}{
+				"type": "Ready", "status": status, "reason": reason, "message": msg,
+			},
+		},
+	}
+	return hr
+}
+
+// perClusterStatuses reads status.perCluster[] back as a cluster→status map.
+func perClusterStatuses(t *testing.T, app *unstructured.Unstructured) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	rows, _, _ := unstructured.NestedSlice(app.Object, "status", "perCluster")
+	for _, row := range rows {
+		m, ok := row.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		cluster, _ := m["cluster"].(string)
+		status, _ := m["status"].(string)
+		out[cluster] = status
+	}
+	return out
+}
+
+// TestReconcile_VClusterPlaced_HRReady_RollsUpOutOfProvisioning — the
+// #4282 acceptance. A vCluster-placed (tier=mgmt) fan-out Application whose
+// local-region per-cluster HR (obs-mgmt-a) is Ready=True rolls up out of
+// Provisioning AND flips that cluster's perCluster[].status to Ready. The
+// remote-region cluster (mgmt-B, split-side, no local HR) leaves the phase
+// in Provisioning until its own region's Flux reports in — so we assert on
+// the single-cluster (singleton) shape to get a clean Ready rollup.
+func TestReconcile_VClusterPlaced_HRReady_RollsUpOutOfProvisioning(t *testing.T) {
+	bp := makeBlueprintWithActiveHotStandbyTopology(
+		"bp-postgres", "0.2.6", "mgmt",
+		[]string{"mgmt-A"},
+	)
+	env := makeEnv("acme-prod", "acme", "prod") // single-region → singleton variant
+	org := makeOrg("acme")
+	app := makeApp("acme", "obs", "acme-prod", "bp-postgres", "0.2.6",
+		"single-region",
+		[]string{"hetzner-fsn-rtz-prod"},
+		nil,
+	)
+	// Pre-seed the per-cluster HR Flux installs, Ready=True, in the
+	// vCluster host namespace (mgmt) where the fan-out authors it.
+	hr := readyHR("obs-mgmt-a", "mgmt", "True")
+
+	fg := newFakeGitea()
+	fg.orgsExist["acme"] = true
+	r := newReconciler(t, fg, app, env, org, bp, hr)
+
+	reconcileFromCluster(t, r, "acme", "obs")
+
+	got := readApp(t, r, "acme", "obs")
+	phase, _, _ := readPhaseAndReason(t, got)
+	if phase == PhaseProvisioning {
+		t.Fatalf("vCluster-placed Application with a Ready per-cluster HR stayed phase=Provisioning — the #4282 rollup gap")
+	}
+	if phase != PhaseReady {
+		t.Fatalf("phase = %q, want %q (the per-cluster HR obs-mgmt-a is Ready=True in ns mgmt)", phase, PhaseReady)
+	}
+	pc := perClusterStatuses(t, got)
+	if pc["mgmt-A"] != PhaseReady {
+		t.Errorf("perCluster[mgmt-A].status = %q, want %q (flipped from the hardcoded Provisioning seed)", pc["mgmt-A"], PhaseReady)
+	}
+}
+
+// TestReconcile_VClusterPlaced_HRNotReady_StaysProvisioning — the negative.
+// A vCluster-placed fan-out Application whose per-cluster HR has NOT
+// materialised (Flux still pulling) stays phase=Provisioning and its
+// perCluster row stays Provisioning. Guards against the fix over-rotating
+// every app to Ready.
+func TestReconcile_VClusterPlaced_HRNotReady_StaysProvisioning(t *testing.T) {
+	bp := makeBlueprintWithActiveHotStandbyTopology(
+		"bp-postgres", "0.2.6", "mgmt",
+		[]string{"mgmt-A"},
+	)
+	env := makeEnv("acme-prod", "acme", "prod")
+	org := makeOrg("acme")
+	app := makeApp("acme", "obs", "acme-prod", "bp-postgres", "0.2.6",
+		"single-region",
+		[]string{"hetzner-fsn-rtz-prod"},
+		nil,
+	)
+	// NO HR seeded — the reconciler authors it but Flux has not reported a
+	// Ready condition yet (the freshly-created HR carries no status).
+	fg := newFakeGitea()
+	fg.orgsExist["acme"] = true
+	r := newReconciler(t, fg, app, env, org, bp)
+
+	reconcileFromCluster(t, r, "acme", "obs")
+
+	got := readApp(t, r, "acme", "obs")
+	phase, _, _ := readPhaseAndReason(t, got)
+	if phase != PhaseProvisioning {
+		t.Fatalf("phase = %q, want %q (the per-cluster HR has no Ready condition yet)", phase, PhaseProvisioning)
+	}
+	pc := perClusterStatuses(t, got)
+	if pc["mgmt-A"] != PhaseProvisioning {
+		t.Errorf("perCluster[mgmt-A].status = %q, want %q (HR not Ready)", pc["mgmt-A"], PhaseProvisioning)
+	}
+}
+
+// TestObserveRegionHelmReleases_FanoutHR_NamespaceTravels — the namespace
+// half of #4282 in isolation. A fan-out HR authored in a DIFFERENT namespace
+// than the Application's own (the vCluster host-ns) is observed Ready when
+// the ref carries that namespace, and would be NotFound (Provisioning) if the
+// rollup defaulted to app.GetNamespace().
+func TestObserveRegionHelmReleases_FanoutHR_NamespaceTravels(t *testing.T) {
+	hr := readyHR("obs-mgmt-a", "mgmt", "True") // authored in mgmt, NOT the app-ns
+
+	fg := newFakeGitea()
+	r := newReconciler(t, fg, hr)
+
+	app := &unstructured.Unstructured{}
+	app.SetNamespace("acme") // app-ns differs from the HR-ns
+	app.SetName("obs")
+	plan := placement.Plan{Regions: []placement.RegionPlan{{Name: "hetzner-fsn-rtz-prod", Role: "primary"}}}
+
+	// Ref carries the HR's authored namespace → Ready.
+	phase, _, _, perHR := r.observeRegionHelmReleases(context.Background(), app, plan,
+		[]hrRef{{name: "obs-mgmt-a", namespace: "mgmt", region: "obs-mgmt-a"}})
+	if phase != PhaseReady {
+		t.Errorf("namespace-carrying ref: phase=%q, want %q", phase, PhaseReady)
+	}
+	if perHR["obs-mgmt-a"] != "True" {
+		t.Errorf("per-HR readiness = %q, want True", perHR["obs-mgmt-a"])
+	}
+
+	// Ref WITHOUT the namespace → defaults to app-ns (acme) → NotFound →
+	// Provisioning (proves the namespace must travel with the ref).
+	phaseWrongNS, _, _, _ := r.observeRegionHelmReleases(context.Background(), app, plan,
+		[]hrRef{{name: "obs-mgmt-a", region: "obs-mgmt-a"}})
+	if phaseWrongNS != PhaseProvisioning {
+		t.Errorf("ref without namespace (defaults to app-ns): phase=%q, want %q", phaseWrongNS, PhaseProvisioning)
+	}
+}


### PR DESCRIPTION
## What

Closes the LAST #4282 gap: a per-Org Application placed in a vCluster never left `status.phase: Provisioning` even when its CNPG Cluster / HelmRelease was Ready. A live close-walk already proved the data path works (Application `w4282fix-pg`, bp-postgres 0.2.6, `placement.vcluster:rtz` — #4398 routes the CNPG Cluster host-side, the chart NetworkPolicy renders, the Cluster stays Ready 1/1). The remaining defect was purely the status rollup.

## Root cause

`core/controllers/application/internal/controller/application_controller.go`, two combined causes:

1. **Hardcoded `perCluster[].status = "Pending"`** (the old fan-out status loop) — never flipped to the HR's observed readiness, so the per-cluster view stayed a placeholder regardless of the live HelmRelease. (`PerClusterStatusesFor`'s documented contract was that the reconciler fills the status in from each HR's `Ready` condition.)
2. **`observeRegionHelmReleases` read every fan-out HR from `app.GetNamespace()`** instead of the namespace the HR was authored in. A fan-out HR lands in its `WriteNamespace` — the host app-ns for #4398 CNPG host-routing, or the vCluster host-ns for the legacy pivot. GET-ing it in the wrong namespace returned `NotFound`, pinning the Application at Provisioning forever. This affected ALL vcluster-placed apps (`w4282fix-pg`, `shared-pg-d`, `shared-pg-e`).

## Fix

- Seed each per-cluster row with the HR's authored namespace + a provisional `Provisioning` status (no longer a hardcoded placeholder).
- `hrRef` now carries `name` + `namespace`; `observeRegionHelmReleases` GETs each fan-out HR in its authored namespace and returns a per-HR readiness map.
- Flip each `perCluster[].status` to `Ready`/`Degraded` from that readiness. The phase rollup uses the same per-HR signal, so a vCluster-placed Application rolls up out of Provisioning exactly as the single-HR host path does.
- Host single-HR path is unchanged (empty fan-out refs → bare app-name in app-ns, as before).

## Tests

- `TestReconcile_VClusterPlaced_HRReady_RollsUpOutOfProvisioning` — vcluster-placed app with a Ready per-cluster HR (authored in the vCluster host-ns) rolls up to Ready + flips `perCluster[].status` to Ready.
- `TestReconcile_VClusterPlaced_HRNotReady_StaysProvisioning` — HR with no Ready condition keeps the app Provisioning.
- `TestObserveRegionHelmReleases_FanoutHR_NamespaceTravels` — the namespace must travel with the ref; a ref without it defaults to app-ns → NotFound → Provisioning.
- Existing `TestObserveRegionHelmReleases_FanoutHRNames` updated to the new signature.

`go build` / `go vet` + the full application-controller suite green.

## Ships via

Controller Go change → application-controller image SHA bump (deploy-bot).

Refs #4282