### PR TITLE
fix(provisioning): align funnel Org DNS pool with the apps-HTTPRoute pool (Refs #4421)

### DIFF
--- a/core/services/provisioning/gitops/gitops.go
+++ b/core/services/provisioning/gitops/gitops.go
@@ -233,7 +233,23 @@ type ManifestGenerator struct {
 // HelmRelease-shaped per-Org apps, falling back to parentDomainDefault when the
 // generator was constructed without a TENANT_PARENT_DOMAIN wiring.
 func (g *ManifestGenerator) parentDomain() string {
-	if pd := strings.TrimSpace(g.ParentDomain); pd != "" {
+	return ResolveParentDomain(g.ParentDomain)
+}
+
+// ResolveParentDomain is the SINGLE source of truth for the effective org-pool
+// parent zone the per-Org apps render under: the supplied TENANT_PARENT_DOMAIN
+// value when non-empty, else parentDomainDefault ("omani.homes"). It is exported
+// so the provisioning-service wiring (main.go) can resolve the SAME effective
+// value ONCE and hand it to BOTH the apps generator (this package) and the
+// tenant.created Organization-CR handler — guaranteeing the per-Org DNS-writer
+// pool (`Org.spec.tenantPublic.parentDomain`) can never diverge from the pool
+// the apps-HTTPRoute actually renders under (#4421). Without this, the generator
+// quietly defaulted to omani.homes while the handler saw an empty string, so a
+// Sovereign with no TENANT_PARENT_DOMAIN minted apps on omani.homes but wrote no
+// per-Org A-record there → the host fell through to a stale apex wildcard
+// (49.12.16.160).
+func ResolveParentDomain(parentDomain string) string {
+	if pd := strings.TrimSpace(parentDomain); pd != "" {
 		return pd
 	}
 	return parentDomainDefault

--- a/core/services/provisioning/handlers/handlers.go
+++ b/core/services/provisioning/handlers/handlers.go
@@ -57,6 +57,21 @@ type Handler struct {
 	// hardcoded — every Sovereign picks its own pool zone.
 	TenantParentDomain string
 
+	// AppsParentDomain is the EFFECTIVE org-pool parent zone the per-Org
+	// apps-HTTPRoute generator renders product hosts under (e.g.
+	// openclaw.<slug>.<this>). Unlike TenantParentDomain (empty = "feature
+	// disabled" for the day-2 patch), this is the RESOLVED value the apps
+	// generator actually uses — gitops.ResolveParentDomain(TENANT_PARENT_DOMAIN),
+	// which falls back to omani.homes when the env is unset. main.go resolves
+	// it ONCE and hands the SAME value to both the generator and this Handler,
+	// so the per-Org DNS-writer pool (Org.spec.tenantPublic.parentDomain) the
+	// createOrganizationCR handler stamps can never diverge from the pool the
+	// apps render under — the #4421 fix. Without it, a Sovereign with no
+	// TENANT_PARENT_DOMAIN minted apps on the omani.homes default but wrote the
+	// per-Org A-record under the customer's funnel pick (or none), so the app
+	// host fell through to a stale apex `*.omani.homes` wildcard → dead IP.
+	AppsParentDomain string
+
 	// PerOrgGitops enables the Sovereign per-Org commit target (#4384). When
 	// true, the day-2 cart install commits the customer's purchased
 	// Applications into the per-Org `<slug>/catalyst-tenant` repo's

--- a/core/services/provisioning/handlers/org_parentdomain_4421_test.go
+++ b/core/services/provisioning/handlers/org_parentdomain_4421_test.go
@@ -1,0 +1,138 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openova-io/openova/core/services/provisioning/gitops"
+)
+
+// TestResolveOrgParentDomain_4421 pins the #4421 invariant: the Organization
+// CR's pool (which the org-controller's DNS writer + console route key off) is
+// the SAME pool the per-Org apps-HTTPRoute renders under (h.AppsParentDomain).
+// A per-customer funnel pick (payload parent_domain) must NEVER override it on
+// a Sovereign that has an apps pool — otherwise the app host falls through to a
+// stale apex wildcard and resolves to a dead IP.
+func TestResolveOrgParentDomain_4421(t *testing.T) {
+	cases := []struct {
+		name        string
+		appsPool    string
+		payloadPool string
+		want        string
+	}{
+		{
+			// THE bug: customer picked omani.rest in the funnel but the
+			// Sovereign apps render under omani.homes. The apps pool must win
+			// so the per-Org A-record lands in omani.homes (where the app host
+			// resolves) instead of omani.rest (where it would never be looked
+			// up for the app host).
+			name:        "apps pool wins over a diverging payload pick",
+			appsPool:    "omani.homes",
+			payloadPool: "omani.rest",
+			want:        "omani.homes",
+		},
+		{
+			name:        "apps pool wins over omani.trade payload pick",
+			appsPool:    "omani.homes",
+			payloadPool: "omani.trade",
+			want:        "omani.homes",
+		},
+		{
+			name:        "apps pool used when payload is empty",
+			appsPool:    "omani.homes",
+			payloadPool: "",
+			want:        "omani.homes",
+		},
+		{
+			name:        "agreeing pools resolve to that pool",
+			appsPool:    "omani.homes",
+			payloadPool: "omani.homes",
+			want:        "omani.homes",
+		},
+		{
+			// Degenerate Sovereign with no apps pool wired at all — the
+			// payload survives as a last-resort fallback.
+			name:        "payload fallback when apps pool empty",
+			appsPool:    "",
+			payloadPool: "omani.rest",
+			want:        "omani.rest",
+		},
+		{
+			name:        "both empty resolves to empty (feature disabled)",
+			appsPool:    "",
+			payloadPool: "",
+			want:        "",
+		},
+		{
+			name:        "normalizes case + whitespace",
+			appsPool:    "  Omani.Homes  ",
+			payloadPool: "omani.rest",
+			want:        "omani.homes",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveOrgParentDomain(tc.appsPool, tc.payloadPool)
+			if got != tc.want {
+				t.Errorf("resolveOrgParentDomain(%q,%q) = %q; want %q",
+					tc.appsPool, tc.payloadPool, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveParentDomain_SingleSourceOfTruth_4421 proves the handler's apps
+// pool and the gitops apps-HTTPRoute generator pool come from the SAME
+// resolver, so they cannot drift: an unset TENANT_PARENT_DOMAIN defaults to
+// omani.homes on BOTH sides, and a set value flows through verbatim. This is
+// what main.go relies on when it sets
+// Handler.AppsParentDomain = gitops.ResolveParentDomain(tenantParentDomain).
+func TestResolveParentDomain_SingleSourceOfTruth_4421(t *testing.T) {
+	// Empty env: apps generator defaults to omani.homes; the handler, fed the
+	// SAME resolved value, must stamp the SAME pool on the Org CR.
+	appsPool := gitops.ResolveParentDomain("")
+	if appsPool != "omani.homes" {
+		t.Fatalf("apps generator default pool = %q; want omani.homes", appsPool)
+	}
+	if got := resolveOrgParentDomain(appsPool, "omani.rest"); got != appsPool {
+		t.Errorf("Org CR pool %q diverged from apps pool %q despite shared resolver", got, appsPool)
+	}
+
+	// Explicit env: flows through unchanged on both sides.
+	if got := gitops.ResolveParentDomain("omani.trade"); got != "omani.trade" {
+		t.Errorf("ResolveParentDomain(omani.trade) = %q; want omani.trade", got)
+	}
+	if got := resolveOrgParentDomain("omani.trade", "omani.homes"); got != "omani.trade" {
+		t.Errorf("Org CR pool = %q; want the apps pool omani.trade", got)
+	}
+}
+
+// TestCreateOrganizationCR_AppsPoolWins_NoFail_4421 drives the full handler
+// path with a diverging payload pick + a configured apps pool: the Org CR must
+// still mint (no provision.org_create_failed), confirming the #4421 override is
+// silent + non-fatal (it only realigns the pool, it does not reject the Org).
+func TestCreateOrganizationCR_AppsPoolWins_NoFail_4421(t *testing.T) {
+	clearK8sEnv(t)
+	pub := &recordingPublisher{}
+	h := &Handler{
+		Producer:         pub,
+		AppsParentDomain: "omani.homes", // Sovereign apps render here
+		SovereignFQDN:    "test.omani.works",
+	}
+	data := tenantCreatedPayload{
+		ID:           "tenant-abc",
+		Slug:         "acme",
+		OwnerEmail:   "owner@example.com",
+		PlanID:       "org-pool-basic",
+		ParentDomain: "omani.rest", // customer's diverging funnel pick
+	}
+	// k8s env is scrubbed → expect a non-nil "create Organization" error from
+	// the POST, but crucially NOT a validation failure event.
+	err := h.createOrganizationCR(context.Background(), data)
+	if err == nil {
+		t.Fatalf("expected non-nil error (k8s env scrubbed); got nil")
+	}
+	if pub.byType("provision.org_create_failed") != nil {
+		t.Errorf("diverging payload pool should be silently realigned, not fail-published")
+	}
+}

--- a/core/services/provisioning/handlers/organization_create.go
+++ b/core/services/provisioning/handlers/organization_create.go
@@ -106,19 +106,21 @@ func (h *Handler) createOrganizationCR(ctx context.Context, data tenantCreatedPa
 		return h.failOrgCreate(ctx, data.ID, slug,
 			"missing owner_email — cannot mint Organization CR without an owner roster entry")
 	}
-	// Parent domain resolution: payload override → Handler default.
-	// Both may legitimately be empty on a Sovereign that hasn't opted
-	// into the Organization-pool flow yet. In that case the Organization CR
-	// still mints (the controller skips the HTTPRoute step on empty
-	// parent), so we do NOT fail here — but we log loud so operators
-	// notice they're running half-configured.
-	parentDomain := strings.ToLower(strings.TrimSpace(data.ParentDomain))
-	if parentDomain == "" {
-		parentDomain = strings.ToLower(strings.TrimSpace(h.TenantParentDomain))
-	}
+	// Parent domain resolution (#4421) — see resolveOrgParentDomain. The Org
+	// CR's pool MUST equal the pool the per-Org apps-HTTPRoute renders under,
+	// else the app host falls through to a stale apex wildcard → dead IP.
+	parentDomain := resolveOrgParentDomain(h.AppsParentDomain, data.ParentDomain)
 	if parentDomain == "" {
 		slog.Warn("tenant.created consumer: no parent domain configured — Organization will mint without TenantPublic HTTPRoute",
 			"slug", slug)
+	} else if pd := strings.ToLower(strings.TrimSpace(data.ParentDomain)); pd != "" && pd != parentDomain {
+		// The customer's funnel pick disagrees with the Sovereign's apps
+		// pool. We deliberately override it (the apps zone is the one that
+		// must win, else the app host falls through to a stale wildcard) —
+		// log loud so an operator notices the funnel is offering a pool the
+		// Sovereign doesn't actually serve.
+		slog.Warn("tenant.created consumer: payload parent_domain overridden by the Sovereign apps pool to keep the Org DNS pool aligned with the apps-HTTPRoute pool (#4421)",
+			"slug", slug, "payload_parent_domain", pd, "apps_parent_domain", parentDomain)
 	}
 
 	tier := strings.TrimSpace(data.Tier)
@@ -228,6 +230,33 @@ func (h *Handler) createOrganizationCR(ctx context.Context, data tenantCreatedPa
 		"sovereign":     h.SovereignFQDN,
 	})
 	return nil
+}
+
+// resolveOrgParentDomain picks the org-pool parent zone the Organization CR's
+// spec.tenantPublic.parentDomain is stamped with (#4421). It returns
+// lowercased/trimmed.
+//
+// THE INVARIANT it enforces: the pool the org-controller's DNS writer
+// (tenant_dns.go) + console route (tenant_route.go) key off MUST equal the pool
+// the per-Org apps-HTTPRoute generator renders product hosts under. Otherwise
+// the per-Org A-records land in one zone (the customer's funnel pick) while the
+// app hosts `<app>.<slug>.<otherZone>` have no record and fall through to a
+// stale apex `*.<otherZone>` wildcard → a DEAD IP (the #4421 failure:
+// openclaw.<slug>.omani.homes → 49.12.16.160 when the Org's funnel pick was
+// omani.rest).
+//
+// appsParentDomain is the EFFECTIVE pool the apps generator renders under
+// (gitops.ResolveParentDomain(TENANT_PARENT_DOMAIN), defaulting to omani.homes),
+// resolved ONCE in main.go and handed to both the generator and this handler so
+// the two can never drift. It is non-empty on any real Sovereign (the apps
+// ALWAYS render under a zone), so it WINS — the per-customer payloadParentDomain
+// is honored only as a last-resort fallback on a degenerate Sovereign with no
+// apps pool wired at all.
+func resolveOrgParentDomain(appsParentDomain, payloadParentDomain string) string {
+	if pd := strings.ToLower(strings.TrimSpace(appsParentDomain)); pd != "" {
+		return pd
+	}
+	return strings.ToLower(strings.TrimSpace(payloadParentDomain))
 }
 
 // failOrgCreate logs + publishes a `provision.org_create_failed` event

--- a/core/services/provisioning/main.go
+++ b/core/services/provisioning/main.go
@@ -265,9 +265,14 @@ func main() {
 		SovereignFQDN:      sovereignFQDN,
 		GitBranch:          githubBranch,
 		TenantParentDomain: tenantParentDomain,
-		PerOrgGitops:       perOrgGitops,
-		PerOrgRepoName:     perOrgRepoName,
-		PerOrgBranch:       perOrgBranch,
+		// #4421: the EFFECTIVE apps pool — same gitops.ResolveParentDomain the
+		// generator uses (TENANT_PARENT_DOMAIN, defaulting to omani.homes).
+		// Resolved here so the Org-CR DNS-writer pool the tenant.created handler
+		// stamps always equals the pool the apps-HTTPRoute renders under.
+		AppsParentDomain: gitops.ResolveParentDomain(tenantParentDomain),
+		PerOrgGitops:     perOrgGitops,
+		PerOrgRepoName:   perOrgRepoName,
+		PerOrgBranch:     perOrgBranch,
 	}
 	slog.Info("tenant-public patch wired",
 		"tenant_parent_domain", tenantParentDomain,


### PR DESCRIPTION
Refs #4421

## Problem
Some funnel Org app hosts resolve to a dead IP (`49.12.16.160`) instead of the console-ELB EIP (`212.72.24.33`), so the app is publicly unreachable even with the Pod 1/1 serving in-cluster (e.g. `openclaw.oc4272fresh.omani.homes`).

Two pools were diverging:
- **Apps-HTTPRoute pool** — a per-Sovereign constant: `generator.ParentDomain` from `TENANT_PARENT_DOMAIN` env, defaulting to `omani.homes` (`gitops.parentDomainDefault`). The per-Org product hosts render as `<app>.<slug>.<this>`.
- **DNS-writer + console-route pool** — per-Org `Org.spec.tenantPublic.parentDomain`, which the `tenant.created` handler stamped from the customer's funnel pick (`payload.parent_domain`).

When the customer's pick diverged from the apps pool (e.g. `omani.rest` while apps render under `omani.homes`), the org-controller wrote the per-Org `*.<slug>.omani.rest` A-record (→ `212.72.24.33`) but the app host `<app>.<slug>.omani.homes` had no record and fell through to the stale apex `*.omani.homes` wildcard → dead IP.

Live confirmation on kom4dc (dep `4635277cae4ffed9`): `TENANT_PARENT_DOMAIN` is empty on the provisioning deployment, so the payload always won — Org CRs carried a scatter of pools (`omani.trade`, `omani.works`, `omani.rest`, `omani.homes`, empty) while every app rendered on the `omani.homes` default.

## Fix
Enforce the invariant: **`Org.spec.tenantPublic.parentDomain` == the apps-HTTPRoute pool**.

- `gitops.ResolveParentDomain` is now the single source of truth for the effective apps pool (env value, defaulting to `omani.homes`). `ManifestGenerator.parentDomain()` delegates to it.
- `main.go` resolves it once and hands the same value to both the generator (`generator.ParentDomain`) and the new `Handler.AppsParentDomain`.
- `createOrganizationCR` stamps `Handler.AppsParentDomain` on the Org CR, overriding a diverging payload `parent_domain` (logged loud). The payload survives only as a last-resort fallback on a Sovereign with no apps pool wired at all.
- `Handler.TenantParentDomain` (the day-2 tenant-public patch's "empty = disabled" knob) is left untouched — no regression to `tenant_public_patch.go`.

The guard: an empty `parentDomain` can no longer silently diverge from the apps pool, because both sides resolve through the same `ResolveParentDomain` and default identically.

## Live DNS correction (already applied, sanctioned per runbook)
The stale zone-level `*.omani.homes` catch-all on the mothership PowerDNS was repointed from dead `49.12.16.160` to the console-ELB EIP `212.72.24.33` via PowerDNS API PATCH REPLACE (HTTP 204) — NOT a Dynadot wipe. A previously-broken host now resolves correctly on public resolvers:
```
openclaw.oc4272fresh.omani.homes @1.1.1.1 -> 212.72.24.33   (was 49.12.16.160)
openclaw.oc4272fresh.omani.homes @8.8.8.8 -> 212.72.24.33
randomverify999.omani.homes      @1.1.1.1 -> 212.72.24.33   (catch-all now points at console-ELB)
```

## Tests
- `TestResolveOrgParentDomain_4421` — table: apps pool wins over a diverging payload pick (incl. `omani.rest`/`omani.trade`), payload fallback when apps pool empty, both-empty disabled, case/whitespace normalize.
- `TestResolveParentDomain_SingleSourceOfTruth_4421` — proves the handler pool and the generator pool come from the same resolver (no drift; empty env defaults to `omani.homes` on both sides).
- `TestCreateOrganizationCR_AppsPoolWins_NoFail_4421` — full handler path: a diverging payload pick is silently realigned, not fail-published.

`go build`, `go vet`, and `go test ./...` green for the provisioning module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)