### PR TITLE
fix(provisioning): funnel cart WordPress emits a Cilium-Gateway HTTPRoute — no more public 404 on a healthy Pod

### DIFF
--- a/core/services/provisioning/gitops/app_httproute_3376_test.go
+++ b/core/services/provisioning/gitops/app_httproute_3376_test.go
@@ -1,0 +1,114 @@
+package gitops
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3376 (funnel cart WordPress 404-without-route gap) — the funnel cart
+// WordPress is a Deployment-shaped app emitted inline by generateAppDeployment (NOT the
+// bp-wordpress-tenant chart, which already carries its own HTTPRoute from
+// #3785). The generator historically emitted the Deployment + Service but NO
+// HTTPRoute, so a healthy WordPress Pod returned public 404: the host
+// generateHostIngress() traefik Ingress is INERT on a Cilium-Gateway Sovereign
+// and is dropped entirely by the de-vcluster'd per-Org apps tree (#4384). These
+// tests are the render-proof that the co-located HTTPRoute now ships with the
+// app, with the right host + console-Gateway parentRef + plain-Service backendRef.
+
+// httpRouteDoc finds the app HTTPRoute inside the rendered app-<slug>.yaml doc.
+func wordpressAppDoc(t *testing.T, g *ManifestGenerator, slug, plan string) string {
+	t.Helper()
+	out := g.GenerateAllWithAppConfigs(slug, plan, []string{"wordpress"}, "pw", nil)
+	for path, body := range out {
+		if strings.HasSuffix(path, "/app-wordpress.yaml") {
+			return body
+		}
+	}
+	t.Fatalf("app-wordpress.yaml not rendered for slug=%q plan=%q (keys: %v)", slug, plan, keys(out))
+	return ""
+}
+
+// TestAppHTTPRoute_WordPress_Rendered — the funnel WordPress app doc carries a
+// Gateway-API HTTPRoute alongside the Deployment + Service.
+func TestAppHTTPRoute_WordPress_Rendered(t *testing.T) {
+	g := NewManifestGenerator("clusters/sov/tenants")
+	g.ParentDomain = "omani.homes"
+
+	for _, plan := range []string{"s", "m"} {
+		t.Run("plan="+plan, func(t *testing.T) {
+			doc := wordpressAppDoc(t, g, "g6wp", plan)
+
+			// The HTTPRoute object renders (Gateway API, NOT traefik Ingress).
+			if !strings.Contains(doc, "kind: HTTPRoute") {
+				t.Fatalf("app-wordpress.yaml MISSING the Gateway-API HTTPRoute (would 404 on a Cilium-Gateway Sovereign):\n%s", doc)
+			}
+			if !strings.Contains(doc, "apiVersion: gateway.networking.k8s.io/v1") {
+				t.Errorf("HTTPRoute not on the gateway.networking.k8s.io/v1 apiVersion:\n%s", doc)
+			}
+
+			// Host = <app>.<slug>.<parentDomain> (same convention as openclaw.<slug>.<parent>).
+			if !strings.Contains(doc, "- wordpress.g6wp.omani.homes") {
+				t.Errorf("HTTPRoute host is not wordpress.<slug>.<parentDomain>:\n%s", doc)
+			}
+
+			// parentRef = the dedicated console Gateway (wildcard *.<pool> TLS → no per-host cert).
+			if !strings.Contains(doc, "name: cilium-gateway-console") {
+				t.Errorf("HTTPRoute parentRef is not the console Cilium Gateway:\n%s", doc)
+			}
+			if !strings.Contains(doc, "namespace: kube-system") {
+				t.Errorf("HTTPRoute parentRef namespace is not kube-system:\n%s", doc)
+			}
+
+			// backendRef = the plain WordPress Service on :80 (co-located in the same boundary).
+			if !strings.Contains(doc, "backendRefs:") {
+				t.Errorf("HTTPRoute MISSING backendRefs:\n%s", doc)
+			}
+			if !strings.Contains(doc, "- name: wordpress\n          port: 80") {
+				t.Errorf("HTTPRoute backendRef is not the wordpress Service:80:\n%s", doc)
+			}
+		})
+	}
+}
+
+// TestAppHTTPRoute_ParentDomainDefault — with no ParentDomain wiring the host
+// falls back to the catalog-canon default pool (never a bare `<app>.<slug>.`).
+func TestAppHTTPRoute_ParentDomainDefault(t *testing.T) {
+	g := NewManifestGenerator("clusters/sov/tenants") // ParentDomain unset
+	doc := wordpressAppDoc(t, g, "g6wp", "s")
+	want := "- wordpress.g6wp." + parentDomainDefault
+	if !strings.Contains(doc, want) {
+		t.Errorf("HTTPRoute host did not fall back to %q:\n%s", want, doc)
+	}
+}
+
+// TestAppHTTPRoute_SurvivesPerOrgReRoot — the #4384 de-vcluster'd per-Org apps
+// tree drops the contabo host scaffolding (incl. the inert traefik ingress.yaml)
+// but the co-located HTTPRoute travels WITH the app under vcluster/apps/, so a
+// fresh funnel Org's WordPress is routed zero-touch (no hand-applied route).
+func TestAppHTTPRoute_SurvivesPerOrgReRoot(t *testing.T) {
+	g := NewManifestGenerator("clusters/sov/org-tenants")
+	g.ParentDomain = "omani.homes"
+
+	files, _ := g.GeneratePerOrgAppsTree("g6wp", "m", []string{"wordpress"}, "pw")
+	wp, ok := files["vcluster/apps/app-wordpress.yaml"]
+	if !ok {
+		t.Fatalf("app-wordpress.yaml missing from per-Org tree (keys: %v)", keys(files))
+	}
+	if !strings.Contains(wp, "kind: HTTPRoute") {
+		t.Fatalf("re-rooted app-wordpress.yaml lost its HTTPRoute — funnel Org would 404:\n%s", wp)
+	}
+	if !strings.Contains(wp, "- wordpress.g6wp.omani.homes") {
+		t.Errorf("re-rooted HTTPRoute host wrong:\n%s", wp)
+	}
+	if !strings.Contains(wp, "name: cilium-gateway-console") {
+		t.Errorf("re-rooted HTTPRoute parentRef wrong:\n%s", wp)
+	}
+
+	// The contabo host scaffolding (the inert traefik ingress.yaml) MUST NOT
+	// have leaked into the per-Org tree.
+	for p := range files {
+		if strings.HasSuffix(p, "/ingress.yaml") {
+			t.Errorf("inert traefik ingress.yaml leaked into per-Org tree at %q", p)
+		}
+	}
+}

--- a/core/services/provisioning/gitops/gitops.go
+++ b/core/services/provisioning/gitops/gitops.go
@@ -649,7 +649,7 @@ func (g *ManifestGenerator) GenerateAllWithAppConfigs(slug, planSlug string, app
 		// a no-op when registryMirror is empty or the image is already
 		// proxied / on a registry without a Harbor proxy project.
 		spec.Image = proxyImage(spec.Image, g.registryMirror())
-		vcFiles[fmt.Sprintf("app-%s.yaml", a)] = generateAppDeployment(appNS, slug, planSlug, a, spec, dbPassword)
+		vcFiles[fmt.Sprintf("app-%s.yaml", a)] = generateAppDeployment(appNS, slug, planSlug, a, spec, dbPassword, g.parentDomain())
 	}
 	vcFiles["kustomization.yaml"] = generateKustomization(appNS, vcFiles)
 
@@ -1656,7 +1656,7 @@ func qosResources(planSlug, reqCPU, reqMem string) (cpu string, mem string, guar
 	}
 }
 
-func generateAppDeployment(ns, slug, planSlug, appSlug string, spec AppSpec, dbPassword string) string {
+func generateAppDeployment(ns, slug, planSlug, appSlug string, spec AppSpec, dbPassword, parentDomain string) string {
 	// QoS split (#4292): fixed tiers (S/M/L/XL) render limits==requests →
 	// Guaranteed (also what the per-Org LimitRange maxLimitRequestRatio
 	// {cpu:1,memory:1} requires to admit the pod); Flexi keeps the historical
@@ -1834,6 +1834,28 @@ spec:
 %s`, appSlug, spec.Image, spec.InitCommand, envLines)
 	}
 
+	// Cilium-Gateway HTTP exposure for the Deployment-shaped app (#3376 — the
+	// funnel cart WordPress 404-without-route gap). A Sovereign runs the
+	// Cilium Gateway API, NOT
+	// traefik — the host generateHostIngress() networking.k8s.io/v1 Ingress is
+	// INERT (never reconciled; its per-host `<app>-tls` Certificate sits False
+	// forever, no HTTP-01 solver) and is dropped entirely by the de-vcluster'd
+	// per-Org apps tree (#4384 GeneratePerOrgAppsTree). Without a route the
+	// purchased app (e.g. WordPress) is healthy in-pod yet returns public 404.
+	// This HTTPRoute is co-located with the Deployment+Service in the SAME
+	// app-<x>.yaml doc so it lands wherever the app lands — INSIDE the Org
+	// vCluster for the paid tier (the #4297 keystone redirects the apps tree
+	// there via spec.kubeConfig), on the host `<slug>` ns for free/S — binding
+	// the actual Service, never an empty host shell. It attaches the per-Org
+	// host to the dedicated console Gateway whose `*.<pool>` wildcard TLS
+	// listener terminates TLS (so NO per-host Certificate is needed), mirroring
+	// generateOpenClawHR / generateStalwartHR / platform/keycloak httproute.yaml.
+	// The reserved-entity gateway→pod hop (fromEntities:[ingress]) is already
+	// admitted namespace-wide by the org-controller's ciliumNetworkPolicyTemplate
+	// (endpointSelector:{}, fromEntities:[ingress,host,remote-node]) force-included
+	// in every per-Org apps tree, so NO per-app CNP is emitted here.
+	httpRoute := generateAppHTTPRoute(ns, slug, appSlug, parentDomain)
+
 	return fmt.Sprintf(`%sapiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1901,7 +1923,7 @@ spec:
   ports:
     - port: 80
       targetPort: %d
-`, pvcManifest,
+%s`, pvcManifest,
 		appSlug, ns, appSlug, slug,
 		appSlug, appSlug, slug,
 		initContainers,
@@ -1911,7 +1933,66 @@ spec:
 		spec.CPUMilli, spec.RAMMI,
 		limCPU, limMem,
 		volumeMounts, volumes,
-		appSlug, ns, appSlug, spec.Port)
+		appSlug, ns, appSlug, spec.Port,
+		httpRoute)
+}
+
+// appsGatewayName / appsGatewayNamespace are the dedicated console Gateway the
+// per-Org Deployment-shaped apps attach to — the SAME Gateway the HelmRelease-
+// shaped per-Org apps use (generateOpenClawHR / generateStalwartHR parentRef).
+// Its `*.<pool>` wildcard TLS listener terminates TLS for every per-Org host, so
+// a Deployment-shaped app needs NO per-host Certificate. Never hardcoded inline
+// (Inviolable Principle #4) — surfaced as named constants so the route and the
+// HR overlays stay in lockstep.
+const (
+	appsGatewayName      = "cilium-gateway-console"
+	appsGatewayNamespace = "kube-system"
+)
+
+// generateAppHTTPRoute emits the Gateway-API HTTPRoute that routes a
+// Deployment-shaped per-Org app's public host (<app>.<slug>.<parentDomain> —
+// the SAME convention generateOpenClawHR uses for openclaw.<slug>.<parent>) to
+// its in-boundary Service on :80. It is co-located with the Deployment+Service
+// in app-<x>.yaml so it lands on whatever boundary the app lands on (the Org
+// vCluster for paid tiers, the host `<slug>` ns for free/S) and references the
+// PLAIN Service name (the same boundary), exactly as the chart-emitted openclaw
+// HTTPRoute references its own plain `<fullname>-controller` Service.
+//
+// parentDomain is the Sovereign's org-pool parent zone (g.parentDomain(), e.g.
+// "omani.homes"); it falls back to parentDomainDefault upstream so the host is
+// never a bare `<app>.<slug>.`. The route attaches to the dedicated console
+// Gateway (appsGatewayName/appsGatewayNamespace) whose wildcard TLS listener
+// terminates TLS — no per-host cert. The gateway→pod reserved-entity hop is
+// admitted by the org-controller's namespace-wide CNP, so no per-app CNP here.
+func generateAppHTTPRoute(ns, slug, appSlug, parentDomain string) string {
+	host := fmt.Sprintf("%s.%s.%s", appSlug, slug, parentDomain)
+	return fmt.Sprintf(`---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: app-%s
+  namespace: %s
+  labels:
+    app: %s
+    openova.io/tenant: "%s"
+    catalyst.openova.io/component: per-org-app-route
+spec:
+  parentRefs:
+    - name: %s
+      namespace: %s
+  hostnames:
+    - %s
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: %s
+          port: 80
+`, appSlug, ns, appSlug, slug,
+		appsGatewayName, appsGatewayNamespace,
+		host, appSlug)
 }
 
 // generateProvisioningTenantRBAC emits a Role + RoleBinding that gives the


### PR DESCRIPTION
Refs #3376

## Problem
The funnel cart WordPress is a **Deployment-shaped** app emitted inline by `generateAppDeployment` in `core/services/provisioning/gitops/gitops.go` — NOT the `bp-wordpress-tenant` chart (which already got its HTTPRoute in #3785). The generator emitted the Deployment + Service but **no HTTPRoute**, so a healthy WordPress Pod returned public **404**:

- The host `generateHostIngress()` route is a traefik `networking.k8s.io/v1` Ingress, which is **inert** on a Cilium-Gateway Sovereign (never reconciled; its per-host `<app>-tls` Certificate sits False forever, no HTTP-01 solver).
- The de-vcluster'd per-Org apps tree (#4384 `GeneratePerOrgAppsTree`) **drops** that host scaffolding entirely.

So nothing routed `<wp-host>.<slug>.<pool>` to the WordPress Service — a live close-walk confirmed the one serving Org had a *hand-applied* route.

## Fix
Emit a Gateway-API **HTTPRoute** co-located with the Deployment+Service in the SAME `app-<x>.yaml` doc, so it travels with the app into `vcluster/apps/` (zero-touch, no hand-applied route):

- **host** = `<app>.<slug>.<parentDomain>` (same convention `generateOpenClawHR` uses for `openclaw.<slug>.<parent>`)
- **parentRefs** = `cilium-gateway-console` / `kube-system` — the dedicated console Gateway whose `*.<pool>` wildcard TLS listener terminates TLS, so **no per-host cert** (mirrors generateOpenClawHR / generateStalwartHR / platform/keycloak httproute.yaml)
- **backendRefs** = the plain `<app>` Service on :80 (same boundary as the route — exactly as the chart-emitted openclaw HTTPRoute references its own plain Service)

**No per-app CiliumNetworkPolicy needed:** the org-controller's namespace-wide `ciliumNetworkPolicyTemplate` already admits `fromEntities:[ingress,host,remote-node]` for every per-Org app pod (`endpointSelector:{}`, force-included in every apps tree via `perOrgAppsBaselineDocs`). The gateway→pod 503 hop is covered.

It lands wherever the app lands — inside the Org vCluster for the paid tier (#4297 keystone redirects the apps tree via `spec.kubeConfig`), on the host `<slug>` ns for free/S.

## Render-proof
```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: app-wordpress
  namespace: apps          # apps-Kustomization rewrites to <slug> on apply
  labels:
    catalyst.openova.io/component: per-org-app-route
spec:
  parentRefs:
    - name: cilium-gateway-console
      namespace: kube-system
  hostnames:
    - wordpress.g6wp.omani.homes
  rules:
    - matches:
        - path: {type: PathPrefix, value: /}
      backendRefs:
        - name: wordpress
          port: 80
```
The rendered `app-wordpress.yaml` parses into 3 well-formed docs: Deployment, Service, HTTPRoute.

## Tests
`gitops/app_httproute_3376_test.go` asserts the HTTPRoute renders with the right host + console-Gateway parentRef + plain-Service backendRef:
- in the raw generator output (plans s + m),
- on the `ParentDomain` default fallback,
- after the #4384 per-Org re-root (and that the inert traefik ingress does not leak in).

`go build` / `go vet ./...` / `go test ./...` green in `core/services/provisioning`. Ships via the orgTag image SHA bump — no chart edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)