### PR TITLE
fix(cloud-init): reflect ghcr-pull into bare-slug per-Org namespaces — drop the comma quantifier that broke #4332's slug regex

### DIFF
--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -204,9 +204,20 @@ write_files:
   # full-match REGEXes. #4293/#4295 renamed the per-Org ns from `org-<uuid>` to
   # the bare Organization SLUG (= subdomain, e.g. `tkt0626`; manifests.go
   # `name: {{ .Slug }}`), which matched NEITHER the static list NOR `org-.*` →
-  # 401 on every fresh Org (live omantel.biz). The slug regex
-  # `[a-z][a-z0-9-]{2,30}` (the signup validator, handlers.go:28) reflects into
-  # every slug-named Org ns; `org-.*` retained for legacy. Refs #3383, #4246, #4293, #4328.
+  # 401 on every fresh Org (live omantel.biz).
+  #
+  # #4423: the reflector parses each annotation value as a COMMA-SEPARATED list
+  # of regex entries, so a regex containing a literal comma is split mid-pattern.
+  # #4332 added the signup validator `[a-z][a-z0-9-]{2,30}` (handlers.go:28)
+  # verbatim — but the `{2,30}` quantifier's comma split it into the two broken
+  # fragments `[a-z][a-z0-9-]{2` + `30}`, neither of which matches any slug. So
+  # `ghcr-pull` STILL never reflected into a slug-named Org ns (oc272x9q etc.) →
+  # ImagePullBackOff persisted on every fresh funnel Org. Use the comma-FREE
+  # equivalent `[a-z][a-z0-9-]*` (leading lowercase letter + DNS-label tail,
+  # min length 1, unbounded) so the comma-split keeps it intact; it covers every
+  # slug the `{2,30}`-bounded validator accepts. `org-.*` retained for legacy
+  # org-<uuid> namespaces. NEVER put a `{m,n}` quantifier in a reflector list.
+  # Refs #3383, #4246, #4293, #4328, #4423.
   - path: /var/lib/catalyst/ghcr-pull-secret.yaml
     permissions: '0600'
     content: |
@@ -217,9 +228,9 @@ write_files:
         namespace: flux-system
         annotations:
           reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "org-services,catalyst,catalyst-system,gitea,harbor,cert-manager,kube-system,flux-system,reflector,reloader,kyverno,opentelemetry,openbao,seaweedfs,powerdns,grafana,loki,mimir,tempo,alloy,coraza,crossplane-system,sigstore-system,trivy-system,syft-grype,falco,vpa,valkey,vllm,dmz,mgmt,rtz,external-dns,external-secrets,cnpg-system,velero,nats-system,sealed-secrets,newapi,huawei-evs-csi,org-.*,[a-z][a-z0-9-]{2,30}"
+          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "org-services,catalyst,catalyst-system,gitea,harbor,cert-manager,kube-system,flux-system,reflector,reloader,kyverno,opentelemetry,openbao,seaweedfs,powerdns,grafana,loki,mimir,tempo,alloy,coraza,crossplane-system,sigstore-system,trivy-system,syft-grype,falco,vpa,valkey,vllm,dmz,mgmt,rtz,external-dns,external-secrets,cnpg-system,velero,nats-system,sealed-secrets,newapi,huawei-evs-csi,org-.*,[a-z][a-z0-9-]*"
           reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "org-services,catalyst,catalyst-system,gitea,harbor,cert-manager,kube-system,reflector,reloader,kyverno,opentelemetry,openbao,seaweedfs,powerdns,grafana,loki,mimir,tempo,alloy,coraza,crossplane-system,sigstore-system,trivy-system,syft-grype,falco,vpa,valkey,vllm,dmz,mgmt,rtz,external-dns,external-secrets,cnpg-system,velero,nats-system,sealed-secrets,newapi,huawei-evs-csi,org-.*,[a-z][a-z0-9-]{2,30}"
+          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "org-services,catalyst,catalyst-system,gitea,harbor,cert-manager,kube-system,reflector,reloader,kyverno,opentelemetry,openbao,seaweedfs,powerdns,grafana,loki,mimir,tempo,alloy,coraza,crossplane-system,sigstore-system,trivy-system,syft-grype,falco,vpa,valkey,vllm,dmz,mgmt,rtz,external-dns,external-secrets,cnpg-system,velero,nats-system,sealed-secrets,newapi,huawei-evs-csi,org-.*,[a-z][a-z0-9-]*"
       type: kubernetes.io/dockerconfigjson
       data:
         .dockerconfigjson: ${base64encode(jsonencode({

--- a/products/catalyst/bootstrap/api/internal/provisioner/cloudinit_path_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/cloudinit_path_test.go
@@ -26,6 +26,7 @@ package provisioner
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -219,5 +220,60 @@ func TestCloudInit_NoPerFQDNPathReferences(t *testing.T) {
 			continue
 		}
 		t.Errorf("line %d carries per-FQDN path `clusters/${sovereign_fqdn}` outside a comment — issue #218 regression:\n  %s", i+1, line)
+	}
+}
+
+// reflectorNamespacesRE matches an operative reflector reflection-{allowed,auto}-namespaces
+// annotation line and captures the quoted CSV value.
+var reflectorNamespacesRE = regexp.MustCompile(
+	`reflector\.v1\.k8s\.emberstack\.com/reflection-(?:allowed|auto)-namespaces:\s*"([^"]*)"`,
+)
+
+// commaQuantifierRE matches a regex bounded-repetition quantifier that contains a
+// literal comma, e.g. `{2,30}` or `{1,}`. The emberstack reflector parses a
+// reflection-*-namespaces annotation as a COMMA-SEPARATED list of regex entries,
+// so any `{m,n}` quantifier is split mid-pattern into two broken fragments.
+var commaQuantifierRE = regexp.MustCompile(`\{\d+,\d*\}`)
+
+// TestCloudInit_ReflectorNamespacesNoCommaQuantifier is the #4423 regression guard.
+//
+// #4332 added the signup slug validator `[a-z][a-z0-9-]{2,30}` verbatim to the
+// `ghcr-pull` reflector reflection-{allowed,auto}-namespaces annotations so the
+// pull secret would reflect into bare-slug per-Org namespaces (`oc272x9q` etc.,
+// renamed from `org-<uuid>` in #4293). But the reflector splits each annotation
+// value on commas BEFORE compiling each entry as a regex — so `{2,30}`'s comma
+// split the pattern into `[a-z][a-z0-9-]{2` + `30}`, neither of which matches any
+// slug. `ghcr-pull` therefore STILL never reflected → openclaw-controller (a
+// private ghcr image) stayed ImagePullBackOff on every fresh funnel Org, the last
+// blocker on #4272. The comma-FREE equivalent `[a-z][a-z0-9-]*` survives the
+// split and covers every slug `{2,30}` accepted.
+//
+// This guard fails if ANY reflector reflection-*-namespaces annotation re-
+// introduces a `{m,n}` comma quantifier, and asserts the comma-free slug pattern
+// stays present so the fix can't silently regress back to the broken form.
+func TestCloudInit_ReflectorNamespacesNoCommaQuantifier(t *testing.T) {
+	tpl := readCloudInit(t)
+
+	sawSlugPattern := false
+	for i, line := range strings.Split(tpl, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
+			continue // comment — explanatory references to the old broken form are fine
+		}
+		m := reflectorNamespacesRE.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		value := m[1]
+		if loc := commaQuantifierRE.FindString(value); loc != "" {
+			t.Errorf("line %d: reflector reflection-*-namespaces carries a comma-bearing quantifier %q — #4423 regression. The reflector comma-splits this annotation, breaking the regex mid-pattern. Use a comma-free form (e.g. `[a-z][a-z0-9-]*`):\n  %s", i+1, loc, trimmed)
+		}
+		if strings.Contains(value, "[a-z][a-z0-9-]*") {
+			sawSlugPattern = true
+		}
+	}
+
+	if !sawSlugPattern {
+		t.Errorf("expected the comma-free slug pattern `[a-z][a-z0-9-]*` in at least one reflector reflection-*-namespaces annotation so bare-slug per-Org namespaces (oc272x9q etc.) receive ghcr-pull — #4423 fix not in place")
 	}
 }


### PR DESCRIPTION
Refs #4423 #4272

## Root cause — code gap, not a delivery gap (verdict)

The emberstack reflector parses each `reflection-{allowed,auto}-namespaces`
annotation on the `flux-system/ghcr-pull` source secret as a **comma-separated
list of regex entries**, splitting on commas *before* compiling each entry.

`#4332` added the signup slug validator `[a-z][a-z0-9-]{2,30}` (the same regex
`core/services/tenant/handlers/handlers.go:28` uses) verbatim into both lists so
`ghcr-pull` would reflect into the bare-slug per-Org namespaces that `#4293`
renamed from `org-<uuid>`. But the `{2,30}` quantifier contains a comma, so the
reflector's comma-split shattered the pattern into the two broken fragments
`[a-z][a-z0-9-]{2` + `30}` — neither matches any slug. The other list entry
`org-.*` only matches legacy `org-<uuid>` namespaces, not bare slugs.

Net effect: `ghcr-pull` **still** never reflected into a fresh Org namespace
(`oc272x9q`, `w3376x7k`, …), so `openclaw-controller` (a private
`ghcr.io/openova-io/*` image) stayed `ImagePullBackOff / 401 Unauthorized` on
every fresh funnel Org — the last item gating the #4272 fresh-funnel close.

This is present on `main`'s tftpl AND on the running omantel.biz Sovereign (the
live annotation displayed the regex via jsonpath but the reflector silently
ignored the comma-shattered fragments — reflecting into exactly 34 static
namespaces, never the Org slugs).

## Fix

Replace the comma-bearing slug regex with the comma-free equivalent
`[a-z][a-z0-9-]*` on both annotation lines. It survives the comma-split and
matches every slug the `{2,30}`-bounded validator accepts (leading lowercase
letter + DNS-label tail). `org-.*` retained for legacy `org-<uuid>` namespaces.

Added `TestCloudInit_ReflectorNamespacesNoCommaQuantifier`: fails if any
reflector `reflection-*-namespaces` annotation re-introduces a `{m,n}` comma
quantifier, and asserts the comma-free slug pattern stays present. Verified it
fails on the old broken form and passes on the fix.

## Live verification (omantel.biz / kom4dc, sanctioned annotation patch)

Patched the live `flux-system/ghcr-pull` annotation to the comma-free form (the
secret carries no Flux labels — applied once by cloud-init `kubectl apply` at
node boot, NOT Flux-reconciled, so the patch persists; a fresh prov picks up the
corrected tftpl). Reflector immediately:
```
Auto-reflected flux-system/ghcr-pull where permitted. Created 43 - Updated 34 ...
Created oc272x9q/ghcr-pull as a reflection of flux-system/ghcr-pull
Created w3376x7k/ghcr-pull as a reflection of flux-system/ghcr-pull
Created oc4272walk/ghcr-pull ...  Created oc4272fresh/ghcr-pull ...
```
`openclaw-bp-openclaw-controller` in `oc272x9q` went `ImagePullBackOff → Running 1/1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)