### PR TITLE
fix(bp-plane-isolation): admit kube-apiserver egress entity — unwedge CNPG/bp-newapi/bootstrap-kit on default-denied namespaces (0.1.5)

### DIFF
--- a/clusters/_template/bootstrap-kit/26b-bp-plane-isolation.yaml
+++ b/clusters/_template/bootstrap-kit/26b-bp-plane-isolation.yaml
@@ -81,7 +81,14 @@ spec:
       #   de-vcluster'd host namespaces opentelemetry/alloy/oidc-gate. A contract
       #   test (Case 30) now asserts the known dial graph is fully covered so a
       #   future de-vcluster/re-home can't silently drop an edge.
-      version: 0.1.4
+      # 0.1.5 (#4428 / Refs #4360 #4409): add a per-component kube-apiserver
+      #   egress CiliumNetworkPolicy (toEntities:[kube-apiserver]). The 0.1.2
+      #   egress union (namespaceSelector:{} + ipBlock 0.0.0.0/0) does not match
+      #   the reserved `kube-apiserver` identity the apiserver VIP 10.96.0.1:443
+      #   resolves to, so default-denied namespaces dropped all apiserver egress
+      #   → newapi CNPG instance-manager hung on `dial 10.96.0.1:443 i/o timeout`
+      #   → bp-newapi HR Failed → bootstrap-kit Kustomization stalled (#4409).
+      version: 0.1.5
       sourceRef:
         kind: HelmRepository
         name: bp-plane-isolation

--- a/platform/plane-isolation/blueprint.yaml
+++ b/platform/plane-isolation/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 0.1.4  # lockstep with chart/Chart.yaml (#4325 #4382 comprehensive dial-graph sweep — close all remaining de-vcluster ingress gaps)
+  version: 0.1.5  # lockstep with chart/Chart.yaml (#4428 — kube-apiserver egress CNP per component)
   card:
     title: Plane isolation (per-component default-deny)
     summary: |

--- a/platform/plane-isolation/chart/Chart.yaml
+++ b/platform/plane-isolation/chart/Chart.yaml
@@ -72,7 +72,27 @@ name: bp-plane-isolation
 #   dial graph is fully covered so a future de-vcluster/re-home can't silently
 #   drop an edge. Egress stays open (0.1.2 union) — only ingress edges added;
 #   default-deny posture intact. Refs #4325 #4382 #4361 #4380 #4383.
-version: 0.1.4
+# 0.1.5 (#4428 / Refs #4360 #4409 #4325): ADD a kube-apiserver-egress
+#   CiliumNetworkPolicy (toEntities:[kube-apiserver]) for EVERY component. The
+#   0.1.2 egress union (namespaceSelector:{} + ipBlock 0.0.0.0/0) covers
+#   in-cluster pod identities + Cilium `world`, but NEITHER matches the reserved
+#   `kube-apiserver` identity the apiserver ClusterIP VIP (10.96.0.1:443)
+#   resolves to under kube-proxy-replacement — so every pod that dials the
+#   kube-API in a default-denied namespace had its apiserver egress silently
+#   dropped. Live proof on omantel.biz region-a (kom4dc dep 4635277cae4ffed9,
+#   2026-06-26): the newapi CNPG instance-manager bootstrap initContainer hung
+#   `wait-for-get-cluster ... Get https://10.96.0.1:443/apis/postgresql.cnpg.io
+#   /v1/.../clusters/newapi-bp-newapi-newapi-pg: dial tcp 10.96.0.1:443: i/o
+#   timeout` → Postgres never started → `-rw` Service had no endpoints → the
+#   app CrashLooped → bp-newapi HR `Ready=False` Helm-rollback-context-deadline
+#   → the `bootstrap-kit` Kustomization (wait:true, gates on bp-newapi) stalled
+#   — the last blocker on #4409. Namespaces WITHOUT a plane-isolation
+#   default-deny (org-services/org-pg, shared-data/shared-pg) stayed healthy,
+#   isolating the cause to this chart's Egress policyType. A K8s NetworkPolicy
+#   cannot express reserved:kube-apiserver, so the allow lives in a
+#   CiliumNetworkPolicy — same reserved-entity class as the gateway `ingress`
+#   CNP this chart already ships, and the egress sibling of the #4360 fix.
+version: 0.1.5
 description: |
   Per-component default-deny + explicit-allow micro-segmentation for the
   de-vclustered platform planes (#4291 Workstream C). For each platform

--- a/platform/plane-isolation/chart/templates/apiserver-egress-cnp.yaml
+++ b/platform/plane-isolation/chart/templates/apiserver-egress-cnp.yaml
@@ -1,0 +1,70 @@
+{{- /*
+Per-component kube-apiserver-egress CiliumNetworkPolicy (#4428).
+
+THE egress sibling of the gateway-ingress-cnp.yaml `ingress`-entity admit,
+for the reserved `kube-apiserver` identity.
+
+The companion default-deny NetworkPolicy is podSelector:{} Ingress+Egress
+whose egress allow-list is (a) namespaceSelector:{} → every in-cluster pod
+identity (the #4360 fix) and (b) ipBlock 0.0.0.0/0 → the Cilium `world`
+entity. NEITHER matches the Kubernetes API server: under Cilium with
+kube-proxy-replacement the apiserver ClusterIP VIP (10.96.0.1:443) resolves
+to the reserved `kube-apiserver` security identity, which is NOT a pod (so
+namespaceSelector:{} misses it) and is NOT `world` (so ipBlock 0.0.0.0/0
+misses it). Result: every pod in an isolated namespace that must dial the
+kube-API gets its apiserver egress silently dropped:
+
+  wait-for-get-cluster ... Get "https://10.96.0.1:443/apis/postgresql.cnpg.io
+  /v1/namespaces/<ns>/clusters/<cluster>": dial tcp 10.96.0.1:443: i/o timeout
+
+The CNPG instance manager's bootstrap initContainer GETs its Cluster CR
+through this VIP before starting Postgres, so it hangs forever → Postgres
+never starts → the `-rw` Service has no endpoints → the app CrashLoops
+(connection refused) → the HelmRelease waits, rolls back, and re-deadlocks
+"context deadline exceeded". Caught live on omantel.biz region-a (kom4dc dep
+4635277cae4ffed9, 2026-06-26): the newapi CNPG cluster (`newapi-bp-newapi-
+newapi-pg`) wedged in a stuck failover with both instance managers logging
+`apiServerReachable:false`, which kept bp-newapi `Ready=False` and stalled
+the `bootstrap-kit` Kustomization (it has `wait:true` and gates on
+bp-newapi) — the last blocker on #4409. Namespaces WITHOUT a plane-isolation
+default-deny (org-services/org-pg, shared-data/shared-pg) stayed healthy,
+isolating the cause to this chart's Egress policyType.
+
+A vanilla K8s NetworkPolicy cannot express reserved:kube-apiserver, so —
+exactly like the gateway `ingress` entity — the allow lives in a
+CiliumNetworkPolicy. Cilium computes the UNION of every policy selecting an
+endpoint, so this is purely additive to the default-deny: it grants
+kube-API reachability without weakening isolation (no `world`).
+
+Rendered for EVERY component (not just gatewayIngress ones): CNPG-backed
+components (newapi/keycloak/gitea/harbor/grafana), webhook servers
+(openbao/cert-manager consumers), and external-secrets reconcilers all dial
+the kube-API — and a pure-backend component still runs nothing that should
+be denied the apiserver. The reserved `kube-apiserver` entity is a single
+control-plane identity, so admitting it carries no cross-component blast
+radius.
+
+Gated on the cilium.io/v2 Capabilities check (the #2988/#3102 idiom) so the
+chart still installs on CRD-less clusters (kind CI).
+*/ -}}
+{{- if and .Values.enabled (.Capabilities.APIVersions.Has "cilium.io/v2") -}}
+{{- range .Values.components }}
+{{- $ns := .namespace }}
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ $ns }}-allow-apiserver-egress
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-plane-isolation.labels" $ | nindent 4 }}
+    catalyst.openova.io/component: {{ $ns }}-apiserver-netpol
+spec:
+  # endpointSelector {} = every endpoint in this namespace, matching the
+  # default-deny policy's scope.
+  endpointSelector: {}
+  egress:
+    - toEntities:
+        - kube-apiserver
+{{- end }}
+{{- end -}}

--- a/tests/e2e/bootstrap-kit/main_test.go
+++ b/tests/e2e/bootstrap-kit/main_test.go
@@ -1083,7 +1083,9 @@ func TestBootstrapKit_PlaneIsolationDialGraphIsCovered(t *testing.T) {
 		} `yaml:"spec"`
 	}
 	ingressFrom := map[string]map[string]bool{} // targetNs -> set(sourceNs)
-	gatewayCNP := map[string]bool{}             // targetNs that have an ingress-entity CNP
+	gatewayCNP := map[string]bool{}             // targetNs that have a gateway-ingress (`ingress` entity) CNP
+	apiserverCNP := map[string]bool{}           // targetNs that have a kube-apiserver-egress CNP (#4428)
+	allComponentNs := map[string]bool{}         // every ns that has a default-deny NetworkPolicy
 
 	dec := yaml.NewDecoder(strings.NewReader(string(out)))
 	for {
@@ -1107,6 +1109,7 @@ func TestBootstrapKit_PlaneIsolationDialGraphIsCovered(t *testing.T) {
 			if ingressFrom[ns] == nil {
 				ingressFrom[ns] = map[string]bool{}
 			}
+			allComponentNs[ns] = true
 			for _, rule := range d.Spec.Ingress {
 				for _, f := range rule.From {
 					if f.NamespaceSelector != nil {
@@ -1118,7 +1121,18 @@ func TestBootstrapKit_PlaneIsolationDialGraphIsCovered(t *testing.T) {
 			}
 		case "CiliumNetworkPolicy":
 			meta, _ := raw["metadata"].(map[string]any)
-			if ns, _ := meta["namespace"].(string); ns != "" {
+			ns, _ := meta["namespace"].(string)
+			name, _ := meta["name"].(string)
+			if ns == "" {
+				continue
+			}
+			// Disambiguate the two CNP kinds this chart ships by name suffix:
+			// the gateway-ingress (`ingress` entity) CNP and the kube-apiserver
+			// egress CNP (#4428). Both select endpointSelector:{}.
+			switch {
+			case strings.HasSuffix(name, "-allow-apiserver-egress"):
+				apiserverCNP[ns] = true
+			case strings.HasSuffix(name, "-allow-gateway-ingress"):
 				gatewayCNP[ns] = true
 			}
 		}
@@ -1170,6 +1184,20 @@ func TestBootstrapKit_PlaneIsolationDialGraphIsCovered(t *testing.T) {
 	for _, ns := range wantGatewayCNP {
 		if !gatewayCNP[ns] {
 			t.Errorf("bp-plane-isolation: gateway-fronted component %q is MISSING its allow-gateway-ingress CiliumNetworkPolicy — public route traffic (reserved `ingress` entity) will be dropped → 000/503. Set gatewayIngress: true on the %q entry", ns, ns)
+		}
+	}
+
+	// EVERY default-denied component MUST carry the kube-apiserver-egress CNP
+	// (#4428). The default-deny's egress union (namespaceSelector:{} for
+	// in-cluster pods + ipBlock 0.0.0.0/0 for `world`) does NOT match the
+	// reserved `kube-apiserver` identity the apiserver VIP 10.96.0.1:443
+	// resolves to under Cilium kube-proxy-replacement — so without this CNP
+	// every pod that dials the kube-API (CNPG instance-manager, webhooks, ESO
+	// reconcilers) has its apiserver egress silently dropped → `dial
+	// 10.96.0.1:443 i/o timeout` (the live bp-newapi/bootstrap-kit wedge, #4409).
+	for ns := range allComponentNs {
+		if !apiserverCNP[ns] {
+			t.Errorf("bp-plane-isolation: default-denied component %q is MISSING its allow-apiserver-egress CiliumNetworkPolicy — pods that dial the kube-API (e.g. the CNPG instance-manager) will time out on 10.96.0.1:443 → HR wedge (#4428 #4409). apiserver-egress-cnp.yaml renders for every component; this gap means a render regression", ns)
 		}
 	}
 }


### PR DESCRIPTION
## Root cause (verified live on omantel.biz region-a, kom4dc dep `4635277cae4ffed9`)

`bp-plane-isolation`'s per-component default-deny NetworkPolicy gives each isolated namespace an Egress policyType whose allow union is:
- `namespaceSelector: {}` → in-cluster **pod** identities (the #4360 fix), and
- `ipBlock: 0.0.0.0/0` → the Cilium **`world`** entity.

Neither matches the reserved **`kube-apiserver`** identity that the apiserver ClusterIP VIP `10.96.0.1:443` resolves to under Cilium kube-proxy-replacement. So any pod that dials the kube-API in a default-denied namespace has its apiserver egress silently dropped.

This wedged the **bp-newapi HelmRelease** — the last item on #4409:

```
wait-for-get-cluster ... Get "https://10.96.0.1:443/apis/postgresql.cnpg.io/v1/namespaces/newapi/clusters/newapi-bp-newapi-newapi-pg": dial tcp 10.96.0.1:443: i/o timeout
```

The CNPG instance-manager bootstrap initContainer GETs its Cluster CR through that VIP before starting Postgres → hangs forever → `-rw` Service has no endpoints → newapi app CrashLoops (`connection refused`) → bp-newapi HR `Ready=False, Helm rollback ... context deadline exceeded` → the `bootstrap-kit` Kustomization (`wait:true`, gates on bp-newapi) stays `Reconciling`.

Namespaces WITHOUT a plane-isolation default-deny (`org-services`/org-pg, `shared-data`/shared-pg) have healthy CNPG clusters — isolating the cause to this chart.

## Fix

New `apiserver-egress-cnp.yaml`: a per-component CiliumNetworkPolicy admitting `egress: [{toEntities: [kube-apiserver]}]` for **every** component (CNPG/webhook/external-secrets consumers all dial the kube-API). `endpointSelector: {}` matches the default-deny scope; Cilium unions every policy so this is purely additive — no `world`, isolation intact. Capability-gated on `cilium.io/v2` so the chart still installs on CRD-less kind CI.

Same reserved-entity class as the gateway `ingress` CNP this chart already ships, and the egress sibling of #4360.

## Verification

- `helm template ... --api-versions cilium.io/v2` → 19 `*-allow-apiserver-egress` CNPs (one per component, incl. `newapi`); full render parses as valid YAML.
- CRD-less render (kind CI) → 0 apiserver CNPs, no error (capability gate holds).
- `TestBootstrapKit_PlaneIsolationDialGraphIsCovered` extended to assert every default-denied component carries its apiserver-egress CNP; lockstep sweep green.
- Chart `0.1.4 -> 0.1.5`; bootstrap-kit slot 26b pin lockstep.
- **Live on omantel.biz**: applied the equivalent CNP → CNPG `Cluster in healthy state ready=2/2`, `-rw` endpoint up; then drove the HR to a clean upgrade → bp-newapi HR `Ready=True reason=UpgradeSucceeded`, newapi app `3/3`.

Refs #4428 #4409 #4360 #4325

🤖 Generated with [Claude Code](https://claude.com/claude-code)