### PR TITLE
fix(bp-crossplane): crossplane-core OOMKilled at 2Gi → raise limit to 4Gi (1.1.5→1.1.6)

### DIFF
--- a/clusters/_template/bootstrap-kit/04-crossplane.yaml
+++ b/clusters/_template/bootstrap-kit/04-crossplane.yaml
@@ -41,7 +41,7 @@ spec:
   chart:
     spec:
       chart: bp-crossplane
-      version: 1.1.5
+      version: 1.1.6
       sourceRef:
         kind: HelmRepository
         name: bp-crossplane

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1138,7 +1138,7 @@ spec:
       #   Blueprint CRs so a merged seed version bump reaches the LIVE CR on the
       #   next helm upgrade (no kubectl patch); catalyst-api strips version/source
       #   from the Flux aggregator so Helm stays their sole owner.
-      version: 1.4.879
+      version: 1.4.880
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/crossplane/blueprint.yaml
+++ b/platform/crossplane/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-2-gitops-and-iac
 spec:
-  version: 1.1.5
+  version: 1.1.6
   card:
     title: crossplane
     summary: |

--- a/platform/crossplane/chart/Chart.yaml
+++ b/platform/crossplane/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-crossplane
-version: 1.1.5
+version: 1.1.6
 description: |
   Catalyst-curated Blueprint umbrella chart for Crossplane (controller-
   only payload). Depends on the upstream `crossplane` chart as a Helm

--- a/platform/crossplane/chart/values.yaml
+++ b/platform/crossplane/chart/values.yaml
@@ -25,22 +25,24 @@ catalystBlueprint:
 crossplane:
   # Crossplane CORE resources (#4212 Seam 1+2 — runtime-Observe blocker).
   #
-  # The 1Gi limit OOMKilled the core pod the moment provider-opentofu was
-  # installed + a Workspace was reconciled: measured live on omantel.biz
-  # (EPIC #4212) at CrashLoopBackOff with 144 restarts (exit 137). Core
-  # holds informer caches for the FULL managed-resource set the provider
-  # registers (provider-opentofu's Workspace + every adopted CloudAdoption),
-  # and that working set exceeds 1Gi on a Sovereign carrying the ~24
-  # Observe-first CloudAdoptions the adoption generator emits. With core
-  # OOM-looping, NO Workspace can ever reconcile to Synced+Ready — the seam
-  # stays inert regardless of provider install. Raise the limit to 2Gi and
-  # lift the request floor to 512Mi so the scheduler reserves real headroom
-  # (a 256Mi request against a 1Gi+ working set let the node overcommit core
-  # into the OOM window). RBAC-manager is untouched (it is not the OOM
+  # History: the original 1Gi limit OOMKilled core the moment
+  # provider-opentofu was installed (144 restarts, exit 137). The first fix
+  # raised it to 2Gi — but a capstone verify on omantel.biz (dep
+  # 4635277cae4ffed9, region-a) found core STILL CrashLoopBackOff at 2Gi
+  # with 55 restarts (OOMKilled, exit 137, killed ~90s after start) even
+  # though ZERO providers / ZERO CloudAdoptions were yet installed. core
+  # `start` builds discovery + composition/GC informer caches across EVERY
+  # CRD on the cluster (190 here, 8 compose.openova.io XRDs Established),
+  # and that startup working set alone overruns 2Gi on this Sovereign — so
+  # the seam can never reach the point of installing a provider. Raise the
+  # limit to 4Gi (2x the failing limit; the node carries ~64Gi allocatable,
+  # core is a cluster-singleton, ample headroom) and lift the request floor
+  # to 1Gi so the scheduler reserves real space instead of overcommitting
+  # core into the OOM window. RBAC-manager is untouched (it is not the OOM
   # offender). Operator-tunable per Inviolable Principle #4.
   resourcesCrossplane:
-    requests: { cpu: 100m, memory: 512Mi }
-    limits: { memory: 2Gi }
+    requests: { cpu: 100m, memory: 1Gi }
+    limits: { memory: 4Gi }
   # Prometheus metrics annotations — DEFAULT OFF.
   #
   # Per docs/INVIOLABLE-PRINCIPLES.md #4 and docs/BLUEPRINT-AUTHORING.md

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3191,7 +3191,15 @@ name: bp-catalyst-platform
 #   alike; operator card/visibility/topology curation stays Flux-owned +
 #   revert-immune. Render-diff: only the 81 keep annotations removed, the CRs
 #   otherwise byte-identical. Refs #4415 #3668 #3702.
-version: 1.4.879
+version: 1.4.880
+# 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/
+#   platform/crossplane chart + blueprint.yaml + bootstrap-kit slot 04). crossplane-core
+#   was still OOMKilled (CrashLoopBackOff, 55 restarts, exit 137, killed ~90s after start)
+#   at the prior 2Gi limit on omantel.biz region-a (dep 4635277cae4ffed9) with ZERO
+#   providers/CloudAdoptions installed — core `start` builds discovery/composition/GC
+#   informer caches across every CRD (190) and that startup working set overran 2Gi. 1.1.6
+#   raises resourcesCrossplane to limits.memory 4Gi / requests.memory 1Gi so the seam can
+#   reach the point of installing provider-opentofu.
 # 1.4.871 — #4413: catalog-seed bp-openclaw pin 0.2.8 -> 0.2.11 (lockstep w/ blueprint.yaml)
 #   so the #4272 egress CNP (#4401) + controller TLS-trust (#4408) actually reach
 #   fresh funnel Orgs — the catalog Blueprint was serving 0.2.8 (pre-fix) on omantel.biz.

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -3910,7 +3910,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.1.5"
+  version: "1.1.6"
   visibility: unlisted
   card:
     title: "Crossplane"
@@ -3927,7 +3927,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-crossplane
-    version: "1.1.5"
+    version: "1.1.6"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## What

crossplane-core on omantel.biz region-a (dep `4635277cae4ffed9`) was `CrashLoopBackOff` with **55 restarts** — OOMKilled (exit 137), dying ~90s after each start — at the prior **2Gi** limit, even with **zero** `providers.pkg.crossplane.io` and **zero** CloudAdoptions installed. With core OOM-looping it registered no providers and no managed resources, so the Crossplane object-model seam (#4018) could not converge.

## Root cause

`core start` builds discovery + composition/GC informer caches across **every** CRD on the cluster (190 here, incl. 8 `compose.openova.io` XRDs Established). Live `kubectl top` on the recovered pod shows the steady-state working set is **~3.5Gi** — so the 1Gi (original) and 2Gi (first fix) limits were both far below it; the pod OOMed before it could ever reach the point of installing a provider.

## Fix

`resourcesCrossplane` → `limits.memory: 4Gi` / `requests.memory: 1Gi` (node carries ~64Gi allocatable; core is a cluster-singleton, ~500Mi headroom over the live 3.5Gi working set). RBAC-manager untouched.

Lockstep `1.1.5`→`1.1.6`: `platform/crossplane/chart/{values,Chart}.yaml` + `platform/crossplane/blueprint.yaml` + `clusters/_template/bootstrap-kit/04-crossplane.yaml` + the `bp-catalyst-platform` catalog-seed entry; umbrella `bp-catalyst-platform` `1.4.879`→`1.4.880` so the seed re-rolls. `helm lint` + `check-catalog-seed-lockstep.sh` both pass.

## Live evidence (omantel.biz region-a, dep `4635277cae4ffed9`)

- Before: pod `crossplane-fbf546bd6-q57mh` — 55 restarts, `lastState.terminated.reason=OOMKilled` exit 137 at the 2Gi limit.
- Memory-limit patch applied live to the idle crashlooping deployment (sanctioned in-place fix; no catalyst-api restart, no serving-HR force-reconcile).
- After: new pod `crossplane-77f6986674-5ddhm` — **Running 1/1, restartCount=0, lastState={}**, stable across **24 consecutive checks over ~6m42s** (vs ~90s death point before). `kubectl top` = **3534Mi** under the 4Gi limit. Deploy `available=1 ready=1 updated=1`.
- Provider acceptance probe: applied a `Provider` CR → it was **accepted and listed** by `providers.pkg.crossplane.io` (previously empty — the package manager couldn't run while core was OOM-looping) and core stayed Running with 0 restarts under the load. Probe removed afterward (no residue).

## Scope

This unblocks #4212 Seam 1+2 / #4018 (crossplane-core OOM gate). The FULL #4212 close still needs the fresh-prov CloudAdoptions walk — **#4212 stays `status/uat`**, not closed.

Refs #4212 #4018

🤖 Generated with [Claude Code](https://claude.com/claude-code)