### PR TITLE
fix(catalog-seed #4432): bump 3 stale catalog-seed pins to blueprint.yaml versions — fresh-prov permanence

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1138,7 +1138,7 @@ spec:
       #   Blueprint CRs so a merged seed version bump reaches the LIVE CR on the
       #   next helm upgrade (no kubectl patch); catalyst-api strips version/source
       #   from the Flux aggregator so Helm stays their sole owner.
-      version: 1.4.881
+      version: 1.4.882
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3191,7 +3191,18 @@ name: bp-catalyst-platform
 #   alike; operator card/visibility/topology curation stays Flux-owned +
 #   revert-immune. Render-diff: only the 81 keep annotations removed, the CRs
 #   otherwise byte-identical. Refs #4415 #3668 #3702.
-version: 1.4.881
+# 1.4.882 — #4432: pre-fresh-prov permanence — bump 3 stale catalog-seed pins to
+#   their canonical platform/<name>/blueprint.yaml + Chart.yaml versions so a
+#   merged session fix reaches the live Blueprint CR zero-touch (now that #4417
+#   dropped resource-policy:keep, a stale seed pin actively delivers an OLD
+#   chart): bp-openclaw 0.2.11 -> 0.2.13 (#4408 controller TLS SystemCertPool +
+#   #4399 resolvable shared-realm issuer), bp-stalwart-tenant 0.1.10 -> 0.1.12
+#   (#4400 SnappyMail webmail SPA), bp-external-secrets-stores 1.0.6 -> 1.0.9
+#   (#4409 flux managed-by label on webhook-gate hook Job). All 3 target
+#   versions are published OCI charts; the funnel door already resolves latest
+#   via version:"*", this aligns the catalog Blueprint-CR install path.
+#   Refs #4432 #4408 #4400 #4409 #4417.
+version: 1.4.882
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/
 #   platform/crossplane chart + blueprint.yaml + bootstrap-kit slot 04). crossplane-core
 #   was still OOMKilled (CrashLoopBackOff, 55 restarts, exit 137, killed ~90s after start)

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -2387,7 +2387,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.2.11"
+  version: "0.2.13"
   visibility: listed
   card:
     title: "OpenClaw"
@@ -2422,7 +2422,7 @@ hook (ADR-0003). Identity-blind by construction.
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-openclaw
-    version: "0.2.11"
+    version: "0.2.13"
   topology:
     supported:
       - singleton
@@ -2680,7 +2680,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.10"
+  version: "0.1.12"
   visibility: listed
   card:
     title: "Stalwart (per-Organization)"
@@ -2721,7 +2721,7 @@ is event-driven (ADR-0003 §3).
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-stalwart-tenant
-    version: "0.1.10"
+    version: "0.1.12"
   topology:
     supported:
     - active-passive
@@ -4099,7 +4099,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.0.6"
+  version: "1.0.9"
   visibility: unlisted
   card:
     title: "External Secrets — Stores"
@@ -4116,7 +4116,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-external-secrets-stores
-    version: "1.0.6"
+    version: "1.0.9"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Pre-re-provision permanence gate — closing the catalog-seed staleness gap

Part of the fresh-prov permanence audit (every session fix must be on `main` AND reproducible zero-touch from `main`). Three session fixes only reached `main` as a chart + `platform/<name>/blueprint.yaml` bump; the **catalog-seed** `blueprints.yaml` Blueprint-CR pin still lagged.

This matters now because #4417 dropped `helm.sh/resource-policy: keep` from the seeded Blueprint CRs — so a stale catalog-seed pin **actively delivers an OLD chart to the live Blueprint CR zero-touch** (the console-catalog "Install from catalog" + BSS-door + in-cluster fallback path all resolve the seed pin).

| Blueprint | catalog-seed (was) | blueprint.yaml + Chart.yaml (canonical) | Session fix not delivered |
|---|---|---|---|
| bp-openclaw | 0.2.11 | **0.2.13** | #4408 controller TLS `SystemCertPool` (OIDC JWKS `/readyz` x509), #4399 resolvable shared-realm issuer (chart half) |
| bp-stalwart-tenant | 0.1.10 | **0.1.12** | #4400 SnappyMail webmail SPA (`mail.<slug>` 404 without it) |
| bp-external-secrets-stores | 1.0.6 | **1.0.9** | #4409 flux `managed-by` label on webhook-gate hook Job |

All three target versions are **published OCI charts** (verified via `gh api .../packages/container/<bp>/versions`).

### Why this is the right (and minimal) fix
- The marketplace **funnel** already resolves the LATEST chart via `version: "*"` (`core/services/provisioning/gitops/helmrelease_apps.go`), so the funnel journey was never regressed. This PR aligns the **catalog Blueprint-CR install path** + console-catalog fallback that #4417 made zero-touch-live.
- bp-external-secrets-stores' bootstrap-kit slot pin (`15a`) is already 1.0.9, so bootstrap delivery was fine — only the seed CR was stale.

### Verification
- `bash scripts/check-catalog-seed-lockstep.sh` → **PASS** (checked 69, fail 0).
- `helm template products/catalyst/chart --show-only templates/catalog-seed/blueprints.yaml` → renders **81 Blueprint CRs**, no error.
- Bumps `bp-catalyst-platform` chart `1.4.881 -> 1.4.882` + `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` slot pin lockstep (the fresh-prov source per the cloudinit tftpl `path: ./clusters/_template/bootstrap-kit`).

Refs #4432 #4408 #4400 #4409 #4417

🤖 Generated with [Claude Code](https://claude.com/claude-code)