### PR TITLE
fix(bp-sso-bridge #4437): re-read keycloak creds each tick — kill stale KC_ADDR starving grafana(+all) SSO secret seeding (503)

### DIFF
--- a/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
+++ b/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
@@ -152,7 +152,16 @@ spec:
       # 0.2.19: reconciler configmap generic gate coverage (#3374).
       # 0.2.21: keycloak/openbao egress namespace default → mgmt (#3820 #3642).
       # 0.2.22: #3374 — app-registration ExternalSecrets no longer self-deleted by the orphan sweep each tick.
-      version: 0.2.22
+      # 0.2.23 (#4437): re-read the keycloak credentials Secret EACH TICK so a
+      #   reflected addr/secret change (the #4325 de-vcluster host correction;
+      #   a #4344 admin-pw regen) is picked up with ZERO pod roll. The boot
+      #   secretKeyRef env snapshot (KC_ADDR) never hot-reloads, so the long-
+      #   lived reconciler kept dialing the dead keycloak-x-...-mgmt-vcluster
+      #   host → no KC token → no sso/<app> seed → grafana(+all) 503. Also
+      #   re-homes the stale `mgmt` keycloak/openbao egress NetworkPolicy
+      #   namespaces back to host ns keycloak/openbao (post-#4325/#4347).
+      #   Refs #4437 #4347 #4325.
+      version: 0.2.23
       sourceRef:
         kind: HelmRepository
         name: bp-sso-bridge

--- a/platform/sso-bridge/blueprint.yaml
+++ b/platform/sso-bridge/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.22
+  version: 0.2.23
   card:
     title: sso-bridge
     summary: |

--- a/platform/sso-bridge/chart/Chart.yaml
+++ b/platform/sso-bridge/chart/Chart.yaml
@@ -1,6 +1,44 @@
 apiVersion: v2
 name: bp-sso-bridge
-version: 0.2.22
+version: 0.2.23
+# 0.2.23 (#4437, 2026-06-26): re-read the keycloak credentials Secret EACH
+# TICK so a reflected `addr`/`client-secret` change is picked up without a
+# pod roll — the permanent fix for grafana (et al) 503 on omantel.biz.
+#
+# LIVE RCA (dep 4635277cae4ffed9): grafana Pod 2/3 CreateContainerConfigError
+# → 503; secret `grafana-sso-oidc-credentials` NotFound; the chart-side
+# ExternalSecret rendered fine but reported `SecretSyncedError: Secret does
+# not exist` for `sso/grafana` — the ClusterSecretStore vault-region1 was
+# Valid/Ready, so OpenBao was reachable but the path was UNSEEDED. bp-sso-
+# bridge seeds `secret/sso/<app>`, but it was `skipping tick (no KC token)`
+# on EVERY tick with `curl: (6) Could not resolve host:
+# keycloak-x-keycloak-x-mgmt-vcluster.mgmt.svc.cluster.local`. #4325/#4347
+# DE-VCLUSTERED the mgmt plane → keycloak moved back to host ns `keycloak`
+# (`keycloak.keycloak.svc`) and bp-keycloak re-emitted the CORRECTED `addr`
+# into catalyst-kc-sa-credentials. But KC_ADDR is consumed as an ENV VAR via
+# secretKeyRef, and env-var secretKeyRef values are snapshotted at Pod start
+# and NEVER hot-reload on Secret content change (only volume mounts do). The
+# 4d-old reconciler Pod kept the stale KC_ADDR forever, dialing the dead host
+# → no token → no `sso/grafana` seed → grafana chart ES failed → secret never
+# created → Pod wedged → 503.
+#   Fix (script): new `refresh_kc_credentials()` re-reads the live
+#   catalyst-kc-sa-credentials + catalyst-kc-master-admin-credentials Secrets
+#   by NAME at the start of every tick (before mint_kc_token), overriding the
+#   boot env snapshot; KC_ADDR/KC_SA_* boot guards relaxed to "" so the
+#   per-tick refresh can recover even a never-populated snapshot. RBAC already
+#   grants secrets:get cluster-wide. Self-healing by construction: reflected
+#   addr/secret drift is absorbed within one 60s tick, ZERO pod roll.
+#   Fix (deployment): pass KC_CREDENTIALS_SECRET_NAME /
+#   KC_MASTER_CREDENTIALS_SECRET_NAME / RECONCILER_NAMESPACE (downward API) so
+#   the script reads the live Secret by name.
+#   Fix (values): re-home the stale `mgmt` keycloak/openbao egress
+#   NetworkPolicy namespaces back to the de-vclustered host namespaces
+#   (`keycloak`/`openbao`) — once KC_ADDR is correct, Cilium egress must allow
+#   traffic to that namespace or it is policy-dropped. (Reverts 0.2.21's `mgmt`
+#   default, which was correct for the #3642 vCluster topology #4325 undid.)
+# Sibling of #4344 (keycloak admin-password regen) — the same secretKeyRef-
+# snapshot staleness trap on the SA client-secret, now also self-healed.
+# Refs #4437 #4347 #4325.
 # 0.2.22 (#3374 cleanup-race, 2026-06-19): STOP the app-registration
 # ExternalSecret create-then-delete churn. cleanup_orphans() deletes any ES
 # labelled `bp-sso-bridge.openova.io/managed=true` whose client-id is NOT in

--- a/platform/sso-bridge/chart/templates/configmap-reconciler.yaml
+++ b/platform/sso-bridge/chart/templates/configmap-reconciler.yaml
@@ -97,9 +97,18 @@ data:
       || echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) | WARN: kubeconfig bootstrap probe failed (server=${KAPI}) — ticks will retry" >&2
 
     : "${KC_REALM:?KC_REALM must be set}"
-    : "${KC_ADDR:?KC_ADDR must be set}"
-    : "${KC_SA_CLIENT_ID:?KC_SA_CLIENT_ID must be set}"
-    : "${KC_SA_CLIENT_SECRET:?KC_SA_CLIENT_SECRET must be set}"
+    # 0.2.23 (#4437): KC_ADDR / KC_SA_CLIENT_ID / KC_SA_CLIENT_SECRET are NO
+    # LONGER hard-required at boot — they are a boot-time secretKeyRef env
+    # snapshot that NEVER hot-reloads when the reflected
+    # catalyst-kc-sa-credentials Secret changes (the #4325 de-vcluster
+    # addr correction was the live trap: the pod kept curling the dead
+    # `keycloak-x-keycloak-x-mgmt-vcluster.mgmt.svc` host forever). The new
+    # refresh_kc_credentials() re-reads the LIVE Secret at the start of
+    # every tick, so the boot snapshot may be empty/stale; default to ""
+    # under `set -u` and let the per-tick refresh populate them.
+    KC_ADDR="${KC_ADDR:-}"
+    KC_SA_CLIENT_ID="${KC_SA_CLIENT_ID:-}"
+    KC_SA_CLIENT_SECRET="${KC_SA_CLIENT_SECRET:-}"
     : "${OPENBAO_ADDR:?OPENBAO_ADDR must be set}"
     : "${OPENBAO_KV_MOUNT:?OPENBAO_KV_MOUNT must be set}"
     : "${OPENBAO_K8S_AUTH_PATH:?OPENBAO_K8S_AUTH_PATH must be set}"
@@ -112,6 +121,15 @@ data:
     : "${SOVEREIGN_FQDN_SOVEREIGN_FQDN_KEY:?SOVEREIGN_FQDN_SOVEREIGN_FQDN_KEY must be set}"
 
     OPERATOR_EMAIL_OVERRIDE="${OPERATOR_EMAIL_OVERRIDE:-}"
+
+    # 0.2.23 (#4437): the keycloak credentials Secret names + the namespace
+    # this reconciler runs in, so refresh_kc_credentials() can re-read the
+    # LIVE Secret each tick (the KC_ADDR/KC_SA_* env vars below are only a
+    # BOOT-TIME snapshot — see the function docstring). Safe fallbacks so an
+    # older deployment.yaml (or a smoke render) still starts.
+    KC_CREDENTIALS_SECRET_NAME="${KC_CREDENTIALS_SECRET_NAME:-catalyst-kc-sa-credentials}"
+    KC_MASTER_CREDENTIALS_SECRET_NAME="${KC_MASTER_CREDENTIALS_SECRET_NAME:-catalyst-kc-master-admin-credentials}"
+    RECONCILER_NAMESPACE="${RECONCILER_NAMESPACE:-$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace 2>/dev/null || echo sso-bridge)}"
 
     log() { printf '%s | %s\n' "$(date -u +%FT%TZ)" "$*"; }
     warn() { log "WARN: $*" >&2; }
@@ -153,7 +171,74 @@ data:
       return 1
     }
 
+    # 0.2.23 (#4437): re-read the keycloak credentials from the LIVE
+    # catalyst-kc-sa-credentials / catalyst-kc-master-admin-credentials
+    # Secrets at the start of every tick, overriding the boot-time
+    # secretKeyRef env snapshot.
+    #
+    # WHY this is the permanent fix (live RCA, omantel.biz dep
+    # 4635277cae4ffed9, 2026-06-26): #4325/#3642 de-vclustered the mgmt
+    # plane, re-homing keycloak from the `mgmt` vCluster (syncer-mangled
+    # Service `keycloak-x-keycloak-x-mgmt-vcluster.mgmt.svc`) back into the
+    # native host ns `keycloak` (`keycloak.keycloak.svc`). bp-keycloak
+    # re-emitted the CORRECTED `addr` into catalyst-kc-sa-credentials — but
+    # KC_ADDR is consumed as an ENV VAR via secretKeyRef, and env-var
+    # secretKeyRef values are snapshotted at Pod start and NEVER
+    # propagate when the Secret content changes (only VOLUME-mounted
+    # secrets hot-reload). The long-lived reconciler Pod therefore kept
+    # curling the DEAD syncer-mangled host (`Could not resolve host` ->
+    # `failed to mint Keycloak admin token` -> `skipping tick`), so the
+    # OpenBao `sso/<app>` bundles (grafana/harbor/openbao/gitea/...) were
+    # NEVER written -> every chart-side ExternalSecret reported
+    # `SecretSyncedError: Secret does not exist` -> the *-sso-oidc-
+    # credentials Secret never materialised -> the app Pod wedged at
+    # CreateContainerConfigError -> 503. Re-reading the Secret each tick
+    # makes the reconciler pick up any reflected addr/secret drift within
+    # one interval, self-healing by construction (matches the idempotent-
+    # tick design) with ZERO pod roll. Sibling of the #4344 keycloak
+    # admin-password-regen drift (same secretKeyRef-snapshot trap on the
+    # SA client-secret).
+    refresh_kc_credentials() {
+      local sec addr cid csec
+      sec="$(k_retry get secret "${KC_CREDENTIALS_SECRET_NAME}" -n "${RECONCILER_NAMESPACE}" -o json)" || {
+        warn "refresh_kc_credentials: could not read Secret ${RECONCILER_NAMESPACE}/${KC_CREDENTIALS_SECRET_NAME} (using boot env snapshot)"
+        return 0
+      }
+      addr="$(printf '%s' "${sec}" | jq -r '.data.addr            // "" | @base64d')"
+      cid="$(printf '%s'  "${sec}" | jq -r '.data["client-id"]    // "" | @base64d')"
+      csec="$(printf '%s' "${sec}" | jq -r '.data["client-secret"]// "" | @base64d')"
+      # Only override a field when the live Secret actually carries it, so a
+      # transiently-empty reflected key never blanks a working value.
+      [ -n "${addr}" ] && {
+        if [ "${addr}" != "${KC_ADDR}" ]; then
+          log "refresh_kc_credentials: KC_ADDR drift detected (was '${KC_ADDR:-<empty>}' -> '${addr}')"
+        fi
+        KC_ADDR="${addr}"
+      }
+      [ -n "${cid}" ]  && KC_SA_CLIENT_ID="${cid}"
+      [ -n "${csec}" ] && KC_SA_CLIENT_SECRET="${csec}"
+
+      # Master-realm admin creds (provision_org_realm). Optional Secret —
+      # absent until reflector mirrors bp-keycloak's catalyst-kc-master-
+      # admin-credentials; tolerate NotFound silently (same as the boot
+      # env's `optional: true`).
+      local msec
+      msec="$(k_retry get secret "${KC_MASTER_CREDENTIALS_SECRET_NAME}" -n "${RECONCILER_NAMESPACE}" -o json)" || return 0
+      local mrealm muser mpass
+      mrealm="$(printf '%s' "${msec}" | jq -r '.data["master-realm"]              // "" | @base64d')"
+      muser="$(printf '%s'  "${msec}" | jq -r '.data["master-realm-admin-user"]   // "" | @base64d')"
+      mpass="$(printf '%s'  "${msec}" | jq -r '.data["master-realm-admin-password"]// "" | @base64d')"
+      [ -n "${mrealm}" ] && KC_MASTER_REALM="${mrealm}"
+      [ -n "${muser}" ]  && KC_MASTER_ADMIN_USER="${muser}"
+      [ -n "${mpass}" ]  && KC_MASTER_ADMIN_PASSWORD="${mpass}"
+      return 0
+    }
+
     mint_kc_token() {
+      if [ -z "${KC_ADDR}" ] || [ -z "${KC_SA_CLIENT_ID}" ] || [ -z "${KC_SA_CLIENT_SECRET}" ]; then
+        err "keycloak credentials unresolved (KC_ADDR/KC_SA_CLIENT_ID/KC_SA_CLIENT_SECRET empty) — reflector may not have mirrored ${KC_CREDENTIALS_SECRET_NAME} yet"
+        return 1
+      fi
       KC_ADMIN_TOKEN="$(curl --max-time 20 --connect-timeout 7 -fsS \
         -X POST "${KC_ADDR%/}/realms/${KC_REALM}/protocol/openid-connect/token" \
         -H "Content-Type: application/x-www-form-urlencoded" \
@@ -1040,6 +1125,13 @@ data:
       # 0.2.13: bound SA tokens rotate (~1h) — refresh the synthesized
       # kubeconfig's credential each tick so long-lived pods keep working.
       kubectl config set-credentials sa --token="$(cat "${SA_DIR}/token")" >/dev/null 2>&1 || true
+
+      # 0.2.23 (#4437): re-read the live keycloak credentials Secret BEFORE
+      # minting the token, so a reflected addr/secret change (the #4325
+      # de-vcluster host correction, or a #4344 admin-password regen) is
+      # picked up THIS tick — the boot-time secretKeyRef env snapshot never
+      # hot-reloads on its own.
+      refresh_kc_credentials
 
       mint_kc_token || { warn "skipping tick (no KC token)"; sleep "${INTERVAL_SECONDS}"; continue; }
       openbao_login || { warn "skipping tick (no OpenBao token)"; sleep "${INTERVAL_SECONDS}"; continue; }

--- a/platform/sso-bridge/chart/templates/deployment.yaml
+++ b/platform/sso-bridge/chart/templates/deployment.yaml
@@ -77,6 +77,23 @@ spec:
                   key: addr
             - name: KC_REALM
               value: {{ .Values.keycloak.realm | quote }}
+            # 0.2.23 (#4437): the Secret NAMES + this Pod's namespace so the
+            # reconcile loop's refresh_kc_credentials() can re-read the LIVE
+            # Secret each tick. A secretKeyRef env (KC_ADDR/KC_SA_* below) is
+            # snapshotted at Pod start and NEVER hot-reloads when the
+            # reflected Secret content changes — the #4325 de-vcluster
+            # keycloak-addr correction left the long-lived reconciler curling
+            # the dead `keycloak-x-keycloak-x-mgmt-vcluster.mgmt.svc` host
+            # forever, so NO `sso/<app>` bundle was seeded and grafana (et al)
+            # wedged at 503. These let the script re-read by NAME each tick.
+            - name: KC_CREDENTIALS_SECRET_NAME
+              value: {{ .Values.keycloak.credentialsSecretName | quote }}
+            - name: KC_MASTER_CREDENTIALS_SECRET_NAME
+              value: {{ .Values.keycloak.masterAdminCredentialsSecretName | quote }}
+            - name: RECONCILER_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: KC_SA_CLIENT_ID
               valueFrom:
                 secretKeyRef:

--- a/platform/sso-bridge/chart/tests/4437-kc-credentials-pertick-refresh.sh
+++ b/platform/sso-bridge/chart/tests/4437-kc-credentials-pertick-refresh.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# bp-sso-bridge — #4437 render test: the reconcile loop re-reads the
+# keycloak credentials Secret EACH TICK so a reflected `addr`/`client-secret`
+# change is picked up WITHOUT a pod roll.
+#
+# LIVE RCA (omantel.biz dep 4635277cae4ffed9): grafana 2/3
+# CreateContainerConfigError → 503 because `grafana-sso-oidc-credentials`
+# never materialised — its chart ExternalSecret reported
+# `SecretSyncedError: Secret does not exist` for OpenBao `sso/grafana`, which
+# bp-sso-bridge never seeded because it was `skipping tick (no KC token)`
+# every tick with `Could not resolve host:
+# keycloak-x-keycloak-x-mgmt-vcluster.mgmt.svc`. #4325/#4347 de-vclustered
+# keycloak back to host ns `keycloak`; bp-keycloak re-emitted the corrected
+# `addr`, but KC_ADDR is a secretKeyRef ENV snapshot that never hot-reloads,
+# so the long-lived reconciler kept the stale dead host. The fix re-reads the
+# live Secret each tick + re-homes the stale `mgmt` egress NetworkPolicy
+# namespaces to the host namespaces.
+#
+# Pure render test (helm template) — no cluster needed.
+set -euo pipefail
+
+CHART_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+RENDER="$(helm template sso-bridge "$CHART_DIR" --set enabled=true)"
+
+fail() { echo "[4437-kc-credentials-pertick-refresh] FAIL: $1" >&2; exit 1; }
+
+# Here-strings (<<<), NOT `echo | grep -q` — see 3646 test for the SIGPIPE
+# rationale on >64KB renders.
+
+# 1. The reconcile script defines refresh_kc_credentials().
+grep -q 'refresh_kc_credentials() {' <<<"$RENDER" \
+  || fail "refresh_kc_credentials() function not present in reconcile.sh"
+
+# 2. It is CALLED in the main loop BEFORE mint_kc_token (so the live Secret
+#    is re-read before the token mint each tick).
+SCRIPT="$(awk '/refresh_kc_credentials$/{print "CALL"} /mint_kc_token \|\| \{ warn "skipping tick/{print "MINT"}' <<<"$RENDER")"
+# The first non-definition occurrence must be the bare call, and it must
+# precede the loop's mint_kc_token guard.
+CALL_LINE="$(grep -n '^      refresh_kc_credentials$' <<<"$RENDER" | head -1 | cut -d: -f1)"
+MINT_LINE="$(grep -n 'mint_kc_token || { warn "skipping tick' <<<"$RENDER" | head -1 | cut -d: -f1)"
+[ -n "$CALL_LINE" ] || fail "refresh_kc_credentials is never CALLED in the loop"
+[ -n "$MINT_LINE" ] || fail "mint_kc_token loop guard not found"
+[ "$CALL_LINE" -lt "$MINT_LINE" ] \
+  || fail "refresh_kc_credentials must be called BEFORE mint_kc_token (call=$CALL_LINE mint=$MINT_LINE)"
+
+# 3. The refresh reads from the configured Secret NAME (not a hardcoded one)
+#    and resolves it in the reconciler's own namespace.
+grep -q 'get secret "${KC_CREDENTIALS_SECRET_NAME}" -n "${RECONCILER_NAMESPACE}"' <<<"$RENDER" \
+  || fail "refresh does not read \${KC_CREDENTIALS_SECRET_NAME} in \${RECONCILER_NAMESPACE}"
+
+# 4. The Deployment passes the Secret names + namespace (downward API) so the
+#    script can read the live Secret by name.
+grep -q 'name: KC_CREDENTIALS_SECRET_NAME' <<<"$RENDER" \
+  || fail "Deployment missing KC_CREDENTIALS_SECRET_NAME env"
+grep -q 'name: RECONCILER_NAMESPACE' <<<"$RENDER" \
+  || fail "Deployment missing RECONCILER_NAMESPACE env"
+grep -q 'fieldPath: metadata.namespace' <<<"$RENDER" \
+  || fail "RECONCILER_NAMESPACE not sourced from the downward API (metadata.namespace)"
+
+# 5. The egress NetworkPolicy targets the DE-VCLUSTERED host namespaces
+#    (keycloak / openbao), NOT the dead `mgmt` vCluster namespace — once
+#    KC_ADDR is corrected, Cilium egress must allow that namespace or the
+#    traffic is policy-dropped.
+NP_BLOCK="$(awk '/^kind: NetworkPolicy$/{c=1} c{print} c&&/^---/{c=0}' <<<"$RENDER")"
+grep -q 'kubernetes.io/metadata.name: "keycloak"' <<<"$NP_BLOCK" \
+  || fail "egress NetworkPolicy does not allow the host ns 'keycloak'"
+grep -q 'kubernetes.io/metadata.name: "openbao"' <<<"$NP_BLOCK" \
+  || fail "egress NetworkPolicy does not allow the host ns 'openbao'"
+if grep -q 'kubernetes.io/metadata.name: "mgmt"' <<<"$NP_BLOCK"; then
+  fail "egress NetworkPolicy still targets the dead 'mgmt' vCluster namespace (post-#4325 it must be keycloak/openbao)"
+fi
+
+echo "[4437-kc-credentials-pertick-refresh] PASS"

--- a/platform/sso-bridge/chart/values.yaml
+++ b/platform/sso-bridge/chart/values.yaml
@@ -229,28 +229,28 @@ deploymentAnnotations:
 #
 # keycloak + openbao egress Namespaces.
 #
-# #3642 (and follow-ons #3760/#3737) re-homed BOTH keycloak and openbao INTO
-# the mgmt vCluster. Their workload Pods now run in the `mgmt` HOST namespace
-# as the syncer-mangled `keycloak-x-keycloak-x-mgmt-vcluster` /
-# `openbao-x-openbao-x-mgmt-vcluster` (the legacy `keycloak`/`openbao` host
-# namespaces still exist but are EMPTY of the actual workload). Cilium enforces
-# egress NetworkPolicy on the DESTINATION Pod's namespace+target-port, so a
-# `keycloakNamespace: keycloak` selector matches NOTHING the reconciler dials —
-# every `mint Keycloak admin token` curl times out (curl(28)) and NO
-# `secret/sso/*` bundle is ever written, leaving grafana/harbor/openbao/gitea
-# (+ every oidc-gate consumer) without their SSO secret → 503. hw165 live RCA
-# (#3820): the reconciler timed out to keycloak even co-located on keycloak's
-# own node, because this K8s NetworkPolicy egress targeted the wrong namespace;
-# a probe Pod with a different `app.kubernetes.io/name` label (so NOT selected
-# by this policy) reached keycloak fine. Default to `mgmt` — the post-#3642
-# canonical topology. A single-region / pre-#3642 placement that keeps keycloak
-# and openbao host-side in their own namespaces overrides these via per-Sovereign
-# overlay. Refs #3820 #3642.
+# Cilium enforces egress NetworkPolicy on the DESTINATION Pod's
+# namespace+target-port, so these MUST name the namespace the reconciler
+# actually dials — a wrong namespace selector matches NOTHING, every
+# `mint Keycloak admin token` curl times out, and NO `secret/sso/*` bundle is
+# ever written, leaving grafana/harbor/openbao/gitea (+ every oidc-gate
+# consumer) without their SSO secret → 503. hw165 live RCA (#3820): the
+# reconciler timed out to keycloak even co-located on keycloak's own node
+# because this egress targeted the wrong namespace; a probe Pod with a
+# different label (so NOT selected) reached keycloak fine.
+#
+# #3642 transiently re-homed keycloak/openbao INTO the mgmt vCluster (host ns
+# `mgmt`, syncer-mangled Service names). #4325/#4347 (2026-06-25) DE-VCLUSTERED
+# the mgmt/rtz/dmz planes — keycloak + openbao now run NATIVELY in their OWN
+# host namespaces (`keycloak` / `openbao`); the syncer is gone and the `mgmt`
+# namespace is EMPTY. So the egress namespaces revert to the host-ns names. A
+# placement that keeps keycloak/openbao inside a vCluster overrides these via
+# per-Sovereign overlay (e.g. `mgmt`). Refs #4437 #4347 #4325 #3820 #3642.
 networkPolicy:
   enabled: true
-  keycloakNamespace: mgmt
+  keycloakNamespace: keycloak
   keycloakPort: 80
-  openbaoNamespace: mgmt
+  openbaoNamespace: openbao
   openbaoPort: 8200
 
 # #2989 residual (0.2.9): the Sovereign's own FQDN as a chart value, used


### PR DESCRIPTION
## Root cause (live RCA, omantel.biz dep `4635277cae4ffed9`)

`grafana` Pod **2/3 CreateContainerConfigError → 503** (UAT rows 30/67/112). Secret `grafana-sso-oidc-credentials` **NotFound**. The chart-side ExternalSecret renders fine but reports:

```
SecretSyncedError: error retrieving secret at .data[0], key: sso/grafana, err: Secret does not exist
```

The ClusterSecretStore `vault-region1` is **Valid/Ready** — OpenBao is reachable. The path `secret/sso/grafana` is simply **unseeded**.

bp-sso-bridge is the seeder, but it is **`skipping tick (no KC token)` on EVERY tick**:

```
curl: (6) Could not resolve host: keycloak-x-keycloak-x-mgmt-vcluster.mgmt.svc.cluster.local
ERR : failed to mint Keycloak admin token
```

It dials the **dead pre-#4325 syncer-mangled** keycloak host. But the live source Secret `catalyst-kc-sa-credentials.addr` is **already CORRECT** (`http://keycloak.keycloak.svc.cluster.local`).

`KC_ADDR` is consumed as an **env var via `secretKeyRef`** — env-var `secretKeyRef` values are snapshotted at Pod-start and **NEVER hot-reload** when the Secret content changes (only volume-mounted secrets reload). Live proof on the running 4d-old pod:

```
$ exec ... -- sh -c 'echo $KC_ADDR'
KC_ADDR=http://keycloak-x-keycloak-x-mgmt-vcluster.mgmt.svc.cluster.local   # STALE snapshot
$ get secret catalyst-kc-sa-credentials -o jsonpath='{.data.addr}' | base64 -d
http://keycloak.keycloak.svc.cluster.local                                  # CORRECTED in Secret
```

### Chain
#4325/#4347 de-vcluster keycloak host→mgmt-vc→host → bp-keycloak re-emits corrected `addr` → **reconciler's env-var snapshot is never refreshed** → can't mint KC token → never seeds OpenBao `sso/grafana` (+ every SSO consumer) → grafana chart ES `SecretSyncedError` → `grafana-sso-oidc-credentials` never created → grafana 2/3 → 503.

## Fix (permanent, fresh-prov-clean, self-healing)

- **script**: new `refresh_kc_credentials()` re-reads the live `catalyst-kc-sa-credentials` + `catalyst-kc-master-admin-credentials` Secrets **by name** at the start of every tick (before `mint_kc_token`), overriding the boot env snapshot. Only overrides a field when the live Secret carries it (a transiently-empty reflected key never blanks a working value). `KC_ADDR`/`KC_SA_*` boot guards relaxed to `""` so the per-tick refresh recovers even a never-populated snapshot. RBAC already grants `secrets:get` cluster-wide. Reflected addr/secret drift is absorbed within one 60s tick — **ZERO pod roll**.
- **deployment**: pass `KC_CREDENTIALS_SECRET_NAME` / `KC_MASTER_CREDENTIALS_SECRET_NAME` + `RECONCILER_NAMESPACE` (downward API).
- **values**: re-home the stale `mgmt` keycloak/openbao egress NetworkPolicy namespaces back to the de-vclustered host namespaces (`keycloak`/`openbao`) — once `KC_ADDR` is correct, Cilium egress must allow that namespace or the traffic is policy-dropped (reverts 0.2.21's `mgmt` default that #4325 undid).
- **guard**: `tests/4437-kc-credentials-pertick-refresh.sh`.

Sibling of #4344 (keycloak admin-password regen) — same `secretKeyRef`-snapshot staleness trap on the SA client-secret, now also self-healed.

## Render proof

```
$ helm template sso-bridge . --set sovereign.fqdn=omantel.biz   # RENDER OK + helm lint clean
$ bash tests/4437-kc-credentials-pertick-refresh.sh             # PASS
$ for t in tests/*.sh; do bash $t; done                         # ALL PASS
```

Functional sim confirms: stale `KC_ADDR` is overridden with the live `keycloak.keycloak.svc` value via `@base64d`; a transiently-missing key does NOT blank a working value.

## Fresh-prov reproducibility

Lockstep version bump: chart **0.2.23**, `blueprint.yaml` **0.2.23**, bootstrap-kit slot 13b **0.2.23**. Any prov where the reflected keycloak addr (or SA client-secret on a #4344 admin-pw regen) changes after the reconciler pod starts now self-heals within one tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs #4437