### PR TITLE
fix(bp-postgres #4442): singleton operator-probe NP no longer default-denies host shared-data consumers on 5432

### DIFF
--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -143,7 +143,7 @@ spec:
       # (no fromHost mirror of a pod-mounted Secret → no vcluster-0.23.0
       # from-host/to-host deadlock, and no missing credential). Lockstep with
       # 16c/16d. Refs #3876 #3374 #3737.
-      version: 0.2.6
+      version: 0.2.7
       sourceRef:
         kind: HelmRepository
         name: bp-postgres
@@ -218,6 +218,14 @@ spec:
         region: '${SOVEREIGN_PRIMARY_REGION:-}'
       replica:
         region: '${SOVEREIGN_REPLICA_REGION:-}'
+      # #4442 — HOST shared-data instance: the singleton operator-probe NP
+      # (networkpolicy-singleton-operator-probe.yaml) default-denies 5432 to
+      # cross-namespace consumers (keycloak/gitea/harbor in OTHER namespaces,
+      # no allow-same-org here). Open 5432 cluster-wide so the SHARED engine's
+      # consumers reach it — the singleton analogue of the 0.2.1/#3577
+      # active-hot-standby consumer-allow. Live regression on b9f9590b.
+      networkPolicy:
+        sharedConsumers: true
     # The three bindings — the reuse proof. Three isolated databases +
     # three roles on ONE Cluster; each reflected into its consumer's
     # namespace.

--- a/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
+++ b/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
@@ -87,7 +87,7 @@ spec:
       # vc-mgmt as the syncer-mangled host object (no fromHost mirror → no
       # vcluster-0.23.0 deadlock, no missing GF_DATABASE_* env). Lockstep with
       # 16a/16d. Refs #3876 #3374 #3737.
-      version: 0.2.6
+      version: 0.2.7
       sourceRef:
         kind: HelmRepository
         name: bp-postgres
@@ -129,6 +129,11 @@ spec:
         region: '${SOVEREIGN_PRIMARY_REGION:-}'
       replica:
         region: '${SOVEREIGN_REPLICA_REGION:-}'
+      # #4442 — HOST shared-data instance: open 5432 to cross-namespace
+      # consumers (the singleton operator-probe NP otherwise default-denies
+      # them). See slot 16a for the full rationale.
+      networkPolicy:
+        sharedConsumers: true
     databases:
       # grafana — FLIPPED (see header). The extraData keys are grafana's
       # native GF_DATABASE_* env contract; GF_DATABASE_HOST carries

--- a/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
+++ b/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
@@ -75,7 +75,7 @@ spec:
       # the 4 vc-mgmt-homed deadlock apps; newapi keeps its `newapi/*` fromHost
       # wildcard per #3876), so this slot renders byte-identical to 0.2.2 on the
       # additive chart. Lockstep with 16a/16c. Refs #3876 #3374 #3737.
-      version: 0.2.6
+      version: 0.2.7
       sourceRef:
         kind: HelmRepository
         name: bp-postgres
@@ -117,6 +117,11 @@ spec:
         region: '${SOVEREIGN_PRIMARY_REGION:-}'
       replica:
         region: '${SOVEREIGN_REPLICA_REGION:-}'
+      # #4442 — HOST shared-data instance: open 5432 to cross-namespace
+      # consumers (the singleton operator-probe NP otherwise default-denies
+      # them). See slot 16a for the full rationale.
+      networkPolicy:
+        sharedConsumers: true
     # The Organization-mesh bindings: three isolated databases, ONE role `org`
     # (chart 0.1.5 dedupes the role + password Secret across same-owner
     # bindings). Database names mirror orgPostgres.cluster.database +

--- a/platform/postgres/blueprint.yaml
+++ b/platform/postgres/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-4-1-data-services
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.2.6
+  version: 0.2.7
   card:
     title: PostgreSQL
     summary: |

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -113,7 +113,17 @@ name: bp-postgres
 #   #3370 CRD (CEL-waived) — breaks the live upgrade-rollback deadlock that
 #   blocked keycloak->gitea->catalyst-platform on hw130.
 # 0.2.5 (#3971): CNPG storageClass empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN.
-version: 0.2.6
+# 0.2.7 (#4442): the SINGLETON operator-probe NetworkPolicy (#4282/#4398) selects the
+#   Cluster Pods with policyTypes:[Ingress] → DEFAULT-DENIES 5432 to cross-namespace
+#   consumers. That was written for the per-Org #4398 path (allow-same-org covers
+#   same-Org consumers) but ALSO renders for the HOST shared-data singletons
+#   (shared-pg/-b/-c) whose consumers (keycloak/gitea/harbor/grafana/powerdns/newapi)
+#   live in OTHER namespaces with NO allow-same-org → keycloak-0 → shared-pg-rw JDBC
+#   timeout, whole SSO chain wedged (live fresh-prov regression b9f9590b, 2026-06-26;
+#   the singleton analogue of the 0.2.1/#3577 active-hot-standby consumer-allow).
+#   Adds topology.networkPolicy.sharedConsumers (default false → per-Org byte-identical);
+#   slots 16a/16c/16d set it true → the probe NP also opens 5432 namespaceSelector:{}.
+version: 0.2.7
 appVersion: "0.1.2"
 description: |
   Catalyst-authored data-instance Blueprint for a shareable, reusable

--- a/platform/postgres/chart/templates/networkpolicy-singleton-operator-probe.yaml
+++ b/platform/postgres/chart/templates/networkpolicy-singleton-operator-probe.yaml
@@ -54,4 +54,24 @@ spec:
           protocol: TCP
         - port: {{ .Values.topology.networkPolicy.operatorMetricsPort }}
           protocol: TCP
+    {{- if .Values.topology.networkPolicy.sharedConsumers }}
+    # SHARED-PG CONSUMERS (#4442): this is a HOST shared-data instance, whose
+    # consumers (keycloak, gitea, harbor, grafana, powerdns, newapi,
+    # catalyst-api …) live in MANY OTHER namespaces and dial `<instance>-rw`
+    # on 5432. Because the operator-probe rule above selects ALL Cluster Pods
+    # with policyTypes:[Ingress], it default-denies every unlisted ingress —
+    # including those cross-namespace consumer connections (keycloak-0 →
+    # shared-pg-rw JDBC timeout, the whole SSO chain down). Open 5432 to every
+    # in-cluster Pod to restore the reach the pre-#4282 no-NetworkPolicy
+    # singleton had. `namespaceSelector:{}` matches Pods in EVERY namespace
+    # (the established repo idiom — the active-hot-standby networkpolicy.yaml
+    # uses the same shape for the identical shared-consumer need). Data-tier
+    # engine: consumers only WRITE app SQL on 5432, so the broad allow is
+    # scoped to that single port; the operator carve-out above is intact.
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - port: 5432
+          protocol: TCP
+    {{- end }}
 {{- end }}

--- a/platform/postgres/chart/values.yaml
+++ b/platform/postgres/chart/values.yaml
@@ -175,6 +175,30 @@ topology:
     operatorNamespace: cnpg-system
     operatorStatusPort: 8000
     operatorMetricsPort: 9187
+    # sharedConsumers (#4442) — when true, the SINGLETON operator-probe
+    # NetworkPolicy ALSO opens 5432 to every in-cluster namespace
+    # (namespaceSelector:{}), restoring cross-namespace consumer reach.
+    #
+    # Why this is needed for the HOST shared-data instances (slots 16a/16c/
+    # 16d): the singleton operator-probe NP (networkpolicy-singleton-
+    # operator-probe.yaml, #4282/#4398) selects the Cluster's Pods with
+    # policyTypes:[Ingress], which makes them DEFAULT-DENY on every unlisted
+    # ingress — including consumer 5432. That template was written for the
+    # #4398 PER-ORG path, where the per-Org namespace carries an
+    # `allow-same-org` policy covering same-Org consumers. The HOST
+    # `shared-data` instances have NO allow-same-org pair and their consumers
+    # (keycloak, gitea, harbor, grafana, powerdns, newapi, catalyst-api …)
+    # live in OTHER namespaces, so the probe-only NP silently default-denies
+    # their 5432 → keycloak-0 → shared-pg-rw JDBC timeout, the whole SSO chain
+    # down (live regression on fresh prov b9f9590b, 2026-06-26). This is the
+    # SINGLETON analogue of the 0.2.1/#3577 active-hot-standby consumer-allow
+    # (networkpolicy.yaml lines 42-62) — the AHS path already carries it, the
+    # singleton path lost it when #4282 added the probe-only NP.
+    #
+    # Default false keeps the #4398 per-Org render byte-identical (per-Org
+    # consumers are same-Org, covered by allow-same-org — no broad open). The
+    # host shared-data slots set it true.
+    sharedConsumers: false
 
 # ── Bindings (the shareable part) ───────────────────────────────────────
 # Each entry binds ONE consumer to this instance. The chart renders a


### PR DESCRIPTION
## Problem (live regression, fresh prov b9f9590b558262b6 / omantel.biz, 2026-06-26)

On a fresh 2-region Huawei prov, `keycloak-0` CrashLooped (4 restarts) on:
```
Trying to connect to PostgreSQL server shared-pg-rw.shared-data.svc.cluster.local...
timeout reached before the port went into state "inuse"
```
`bp-keycloak` HR stuck `Unknown` → `bp-gitea` → `bp-catalyst-platform` → the whole Phase-1 DAG wedged at ~46/64 HRs. Direct probe from the keycloak namespace: `nc shared-pg-rw.shared-data.svc:5432` → **Connection timed out**.

## Root cause

`platform/postgres/chart/templates/networkpolicy-singleton-operator-probe.yaml` (#4282/#4398) renders, in **singleton** mode, a NetworkPolicy selecting the Cluster Pods with `policyTypes:[Ingress]` that opens **only** the cnpg-operator probe ports (8000/9187 from cnpg-system). Any k8s NP with `policyTypes:[Ingress]` selecting a pod makes that pod **default-deny on all unlisted ingress** — including consumer 5432.

The template was written for the **#4398 per-Org** path, where the per-Org namespace carries an `allow-same-org` policy covering same-Org consumers. But it ALSO renders for the **HOST `shared-data`** singletons (`shared-pg`/`shared-pg-b`/`shared-pg-c`, slots 16a/16c/16d). `shared-data` is a host namespace with **NO allow-same-org pair and NO cluster-wide default-deny CCNP**; its consumers (keycloak, gitea, harbor, grafana, powerdns, newapi, catalyst-api) live in OTHER namespaces. Before this NP existed, shared-data had zero NetworkPolicies → Cilium default-allow → consumers reached 5432 freely. Adding the probe-only NP **creates** the default-deny it assumed was absent.

This is the **singleton analogue** of the 0.2.1/#3577 active-hot-standby consumer-allow (`networkpolicy.yaml` lines 42-62) — the AHS path already carries it; the singleton path lost it when #4282 added the probe-only NP.

## Fix

Add `topology.networkPolicy.sharedConsumers` (default **false** → per-Org render byte-identical). When true the singleton probe NP ALSO opens 5432 `namespaceSelector:{}`. Slots 16a/16c/16d (host shared-data, cross-namespace consumers) set it `true`. Chart `0.2.6 → 0.2.7`; slot pins bumped in lockstep.

## Verification

- `helm template` emits the 5432 rule **only** with `sharedConsumers=true` (count=1) and **0** with the default; probe NP intact in both.
- **Live**: applying the equivalent NetworkPolicy on b9f9590b drove `keycloak-0` → 1/1, `bp-keycloak` Ready=True, and the DAG resumed **46 → 53/64**. `nc shared-pg-rw:5432` → **open**.

Refs #4442 #4282 #4398 #3577

🤖 Generated with [Claude Code](https://claude.com/claude-code)