### PR TITLE
fix(bp-plane-isolation #4444): defer per-component default-deny when its namespace is absent (break fresh-prov circular deadlock)

### DIFF
--- a/clusters/_template/bootstrap-kit/26b-bp-plane-isolation.yaml
+++ b/clusters/_template/bootstrap-kit/26b-bp-plane-isolation.yaml
@@ -98,7 +98,18 @@ spec:
       #   grafana 503 / hubble 503 / gitea 500. Same de-vcluster ingress-gap class
       #   as #4382 (org-services→gitea). Network-only: openbao auth-bootstrap
       #   already binds the sso-bridge SA (#2655). Live: kom4dc b9f9590b558262b6.
-      version: 0.1.6
+      # 0.1.7 (#4442 / Refs #4444 #4325): the per-component default-deny NetworkPolicy
+      #   now DEFERS a component whose namespace does not yet exist (lookup-guard)
+      #   instead of failing the whole atomic Helm release. On a fresh prov `sandbox`
+      #   is created LATE (bp-sandbox, gated behind bp-catalyst-platform) while this
+      #   chart installs EARLY → "namespaces sandbox not found" atomic-fail meant NONE
+      #   of the per-component policies applied → gitea default-deny never landed →
+      #   catalyst-system → gitea blocked → gitea-token-mint CrashLooped →
+      #   bp-catalyst-platform hung → bp-sandbox never created `sandbox` → CIRCULAR
+      #   DEADLOCK (live b9f9590b, 2026-06-26). Cilium unions every policy +
+      #   helm-controller reconciles on interval, so the deferred policy lands on the
+      #   NEXT reconcile once the namespace exists.
+      version: 0.1.7
       sourceRef:
         kind: HelmRepository
         name: bp-plane-isolation

--- a/platform/plane-isolation/blueprint.yaml
+++ b/platform/plane-isolation/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 0.1.6  # lockstep with chart/Chart.yaml (#4448 — add sso-bridge to openbao allowIngressFrom)
+  version: 0.1.7  # lockstep with chart/Chart.yaml (#4442 — defer per-component default-deny when its namespace is absent)
   card:
     title: Plane isolation (per-component default-deny)
     summary: |

--- a/platform/plane-isolation/chart/Chart.yaml
+++ b/platform/plane-isolation/chart/Chart.yaml
@@ -106,7 +106,21 @@ name: bp-plane-isolation
 #   sso-bridge SA (#2655, bound_service_account_namespaces=sso-bridge) → this
 #   was purely the missing network ingress edge — the same de-vcluster gap
 #   class as #4382 (org-services→gitea) and the #4360/#4361/#4380/#4383 sweep.
-version: 0.1.6
+# 0.1.7 (#4442 / Refs #4444 #4325 #4291): the per-component default-deny NetworkPolicy
+#   now DEFERS a component whose namespace does not yet exist (lookup-guard) instead
+#   of failing the whole atomic Helm release. On a fresh prov `sandbox` is created
+#   LATE (bp-sandbox, gated behind bp-catalyst-platform) while this chart installs
+#   EARLY → the "namespaces sandbox not found" atomic-fail meant NONE of the
+#   per-component policies applied → the gitea default-deny (which admits
+#   catalyst-system) never landed → catalyst-system → gitea blocked → gitea-token-mint
+#   CrashLooped → bp-catalyst-platform install hung → bp-sandbox never created
+#   `sandbox` → CIRCULAR DEADLOCK (live b9f9590b, 2026-06-26). Cilium unions every
+#   policy + helm-controller reconciles on interval, so a deferred namespace's policy
+#   lands on the NEXT reconcile once its consumer chart creates it. Per-component
+#   `ensureNamespacePresent: false` opts back into the old hard-require behavior;
+#   chart-level `renderUnconditional: true` forces all components to render regardless
+#   of lookup (the static dial-graph contract render / CI client-side template path).
+version: 0.1.7
 description: |
   Per-component default-deny + explicit-allow micro-segmentation for the
   de-vclustered platform planes (#4291 Workstream C). For each platform

--- a/platform/plane-isolation/chart/templates/default-deny-networkpolicy.yaml
+++ b/platform/plane-isolation/chart/templates/default-deny-networkpolicy.yaml
@@ -21,6 +21,45 @@ CiliumNetworkPolicy (Cilium unions every policy selecting an endpoint).
 {{- $dnsNamespace := .Values.dnsNamespace | default "kube-system" -}}
 {{- range .Values.components }}
 {{- $ns := .namespace }}
+{{- /*
+  #4442 deadlock fix — skip a component whose namespace does NOT yet exist.
+
+  The NetworkPolicy `namespace: <ns>` field requires <ns> to exist at apply
+  time; Helm install is ATOMIC, so a single missing namespace fails the whole
+  release → NONE of the per-component policies apply (incl. the gitea/keycloak/
+  harbor ones that unblock catalyst-system → the SSO chain). On a fresh prov
+  `sandbox` is created LATE (bp-sandbox, createNamespace:true, gated behind
+  bp-catalyst-platform) while bp-plane-isolation installs EARLY (after
+  bp-cilium/bp-network-policies) → atomic fail on "namespaces sandbox not
+  found" → gitea default-deny never lands → catalyst-system → gitea blocked →
+  gitea-token-mint CrashLoops → bp-catalyst-platform install hangs →
+  bp-sandbox never creates `sandbox` → CIRCULAR DEADLOCK (live b9f9590b,
+  2026-06-26).
+
+  Cilium evaluates the UNION of every policy selecting an endpoint, and
+  helm-controller reconciles on its interval, so skipping a not-yet-existent
+  namespace's policy at install + applying it on the NEXT reconcile (once the
+  consumer chart has created the namespace) converges WITHOUT the atomic-fail
+  deadlock. lookup runs against the LIVE cluster under helm-controller (not a
+  dry-run), so already-present namespaces (gitea/keycloak/harbor/… created by
+  their own HRs) are found + policied at install; only the genuinely-absent
+  ones defer. `ensureNamespacePresent: false` (per-component override) opts a
+  component out of the guard if an overlay needs the old hard-require behavior.
+*/ -}}
+{{- /* guardNamespace defaults TRUE; only an explicit `ensureNamespacePresent: false`
+       disables the defer-if-absent guard. Compared as a string to dodge the Sprig
+       `default` bool gotcha (default coerces a literal false back to true). */ -}}
+{{- $guardNamespace := not (eq (toString .ensureNamespacePresent) "false") }}
+{{- /* renderUnconditional (chart-level) forces EVERY component to render its
+       default-deny regardless of `lookup`. Needed because `lookup` ALWAYS returns
+       empty under a client-side render (`helm template`, `--dry-run=client`, and
+       the #4325 dial-graph contract test) — without this escape hatch the guard
+       would defer every component there and the static dial-graph coverage could
+       never be asserted. On a live helm-controller install this stays false, so
+       the lookup-guard does its job and the deadlock fix holds. */ -}}
+{{- if and $guardNamespace (not $.Values.renderUnconditional) (not (lookup "v1" "Namespace" "" $ns)) }}
+{{- /* namespace not present yet — defer this component's policy to a later reconcile */ -}}
+{{- else }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -93,5 +132,6 @@ spec:
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0
-{{- end }}
+{{- end }}{{/* end namespace-present guard */}}
+{{- end }}{{/* end range components */}}
 {{- end -}}

--- a/platform/plane-isolation/chart/values.yaml
+++ b/platform/plane-isolation/chart/values.yaml
@@ -11,6 +11,17 @@ enabled: true
 # kube-system.
 dnsNamespace: kube-system
 
+# #4442 deferral escape hatch. The per-component default-deny is normally
+# DEFERRED for a component whose namespace does not yet exist (a `lookup` guard
+# that breaks the fresh-prov circular deadlock — see Chart.yaml 0.1.7). But
+# `lookup` ALWAYS returns empty under a CLIENT-side render (`helm template`,
+# `--dry-run=client`, the #4325 dial-graph contract test), which would defer
+# EVERY component there. Set `renderUnconditional: true` to force every
+# component to render regardless of `lookup` — used by the static dial-graph
+# coverage render. MUST stay false on a live helm-controller install so the
+# deferral (and thus the deadlock fix) actually engages.
+renderUnconditional: false
+
 # ── Per-component policy set ───────────────────────────────────────────────
 # Each entry is ONE de-vclustered platform component's host namespace. The
 # generator renders, for each:

--- a/tests/e2e/bootstrap-kit/main_test.go
+++ b/tests/e2e/bootstrap-kit/main_test.go
@@ -1059,7 +1059,17 @@ func TestBootstrapKit_PlaneIsolationDialGraphIsCovered(t *testing.T) {
 
 	// Render with the cilium.io/v2 API present so the gateway-ingress CNP also
 	// renders (we assert its presence for gateway-fronted components).
-	cmd := exec.Command(helmBin, "template", "plane-isolation", ".", "--api-versions", "cilium.io/v2")
+	//
+	// renderUnconditional=true bypasses the #4442 lookup-guard: on a live
+	// helm-controller install the default-deny for a not-yet-created namespace
+	// is DEFERRED (breaks the fresh-prov circular deadlock — see chart 0.1.7),
+	// but `lookup` ALWAYS returns empty under this client-side `helm template`,
+	// so without the flag every component would defer and the static dial-graph
+	// coverage below could never be asserted. The flag forces every component to
+	// render so this test validates the allow-list CONTENT (the contract);
+	// the deferral mechanism is a live-delivery concern orthogonal to content.
+	cmd := exec.Command(helmBin, "template", "plane-isolation", ".",
+		"--api-versions", "cilium.io/v2", "--set", "renderUnconditional=true")
 	cmd.Dir = chartDir
 	out, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
## Problem (live regression, fresh prov b9f9590b558262b6 / omantel.biz, 2026-06-26)

After #4442 unblocked keycloak/gitea, `bp-catalyst-platform` install **hung** — its `catalyst-gitea-token-mint` hook Job CrashLooped (6 restarts, `gitea api reachable (HTTP 000000)`, curl exit 28). catalyst-system → gitea-http:3000 was **blocked**.

## Root cause — circular deadlock (#4325 de-vcluster family)

`bp-plane-isolation` emits a per-component default-deny NetworkPolicy (`namespace: <ns>`) for every `.Values.components[]`. The gitea one admits catalyst-system. But Helm install is **atomic** and one component namespace, `sandbox`, doesn't exist at install time:

- `sandbox` is created LATE by `bp-sandbox` (createNamespace:true) which `dependsOn bp-catalyst-platform`.
- `bp-catalyst-platform` hangs on `gitea-token-mint` which needs the gitea default-deny to admit catalyst-system.
- That gitea policy is in the SAME atomic `bp-plane-isolation` release that fails on `namespaces "sandbox" not found`.

→ atomic fail → no gitea CNP → catalyst-system→gitea blocked → token-mint CrashLoops → catalyst-platform hangs → bp-sandbox never creates `sandbox` → **CIRCULAR DEADLOCK**.

## Fix

The default-deny NP now **defers** a component whose namespace doesn't yet exist (`lookup` guard) instead of failing the atomic release. Cilium unions every policy + helm-controller reconciles on interval, so a deferred policy lands on the next reconcile once its consumer chart creates the namespace. Present namespaces are found + policied at install (lookup runs live under helm-controller). Per-component `ensureNamespacePresent: false` restores the old hard-require behavior. Chart `0.1.5 → 0.1.6`; slot 26b pin bumped.

## Verification

- `helm lint` clean; `ensureNamespacePresent:false` renders unconditionally (count=1), default + absent-ns defers (count=0).
- **Live**: creating `sandbox` on b9f9590b drove bp-plane-isolation → Ready=True, the gitea CNP + default-deny landed admitting catalyst-system, `catalyst-system → gitea:3000` reachable (EXIT=0), gitea-token-mint succeeded, bp-catalyst-platform resumed (catalyst-api + all 4 controllers ContainerCreating).

Refs #4444 #4325 #4291 #4442

🤖 Generated with [Claude Code](https://claude.com/claude-code)