### PR TITLE
fix(bp-plane-isolation #4448): add sso-bridge to openbao allowIngressFrom — fresh-prov grafana/hubble/gitea SSO secrets never land (0.1.6)

### DIFF
--- a/clusters/_template/bootstrap-kit/26b-bp-plane-isolation.yaml
+++ b/clusters/_template/bootstrap-kit/26b-bp-plane-isolation.yaml
@@ -88,7 +88,17 @@ spec:
       #   resolves to, so default-denied namespaces dropped all apiserver egress
       #   → newapi CNPG instance-manager hung on `dial 10.96.0.1:443 i/o timeout`
       #   → bp-newapi HR Failed → bootstrap-kit Kustomization stalled (#4409).
-      version: 0.1.5
+      # 0.1.6 (#4448 / Refs #4325 #4382 #4437 #4354): add sso-bridge to openbao's
+      #   INGRESS allowlist. The openbao default-deny covered external-secrets-
+      #   system + cnpg-system but OMITTED sso-bridge — so bp-sso-bridge dialing
+      #   openbao.openbao.svc:8200 each reconciler tick (k8s-auth) was Cilium-
+      #   dropped → `curl (28) timeout` → `skipping tick (no OpenBao token)` → NO
+      #   secret/sso/* bundle written → grafana-sso-oidc-credentials / hubble-ui-
+      #   oauth2-proxy-oidc / gitea-oauth-source-credentials never materialized →
+      #   grafana 503 / hubble 503 / gitea 500. Same de-vcluster ingress-gap class
+      #   as #4382 (org-services→gitea). Network-only: openbao auth-bootstrap
+      #   already binds the sso-bridge SA (#2655). Live: kom4dc b9f9590b558262b6.
+      version: 0.1.6
       sourceRef:
         kind: HelmRepository
         name: bp-plane-isolation

--- a/platform/plane-isolation/blueprint.yaml
+++ b/platform/plane-isolation/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 0.1.5  # lockstep with chart/Chart.yaml (#4428 — kube-apiserver egress CNP per component)
+  version: 0.1.6  # lockstep with chart/Chart.yaml (#4448 — add sso-bridge to openbao allowIngressFrom)
   card:
     title: Plane isolation (per-component default-deny)
     summary: |

--- a/platform/plane-isolation/chart/Chart.yaml
+++ b/platform/plane-isolation/chart/Chart.yaml
@@ -92,7 +92,21 @@ name: bp-plane-isolation
 #   cannot express reserved:kube-apiserver, so the allow lives in a
 #   CiliumNetworkPolicy — same reserved-entity class as the gateway `ingress`
 #   CNP this chart already ships, and the egress sibling of the #4360 fix.
-version: 0.1.5
+# 0.1.6 (#4448 / Refs #4325 #4382 #4437 #4354): ADD sso-bridge to openbao's
+#   allowIngressFrom. The openbao default-deny INGRESS allowlist covered
+#   external-secrets-system + cnpg-system but OMITTED sso-bridge — so
+#   bp-sso-bridge's reconciler dialing openbao.openbao.svc:8200 each tick
+#   (k8s-auth, SA sso-bridge-reconciler) to fetch/store the per-app KC OIDC
+#   client_secret bundle was Cilium-dropped → `curl (28) timeout` → the
+#   reconciler logged `skipping tick (no OpenBao token)` and NO `secret/sso/*`
+#   bundle was ever written → grafana-sso-oidc-credentials / hubble-ui-oauth2-
+#   proxy-oidc / gitea-oauth-source-credentials never materialized → grafana
+#   503 / hubble 503 / gitea 500. Live proof on omantel.biz (kom4dc dep
+#   b9f9590b558262b6, 2026-06-26). openbao auth-bootstrap already binds the
+#   sso-bridge SA (#2655, bound_service_account_namespaces=sso-bridge) → this
+#   was purely the missing network ingress edge — the same de-vcluster gap
+#   class as #4382 (org-services→gitea) and the #4360/#4361/#4380/#4383 sweep.
+version: 0.1.6
 description: |
   Per-component default-deny + explicit-allow micro-segmentation for the
   de-vclustered platform planes (#4291 Workstream C). For each platform

--- a/platform/plane-isolation/chart/values.yaml
+++ b/platform/plane-isolation/chart/values.yaml
@@ -90,6 +90,16 @@ components:
     allowIngressFrom:
       - external-secrets-system    # ESO authenticates to openbao:8200 (the vault-region1 store)
       - cnpg-system                # CNPG operator → openbao audit/storage adjuncts (when used)
+      - sso-bridge                 # bp-sso-bridge (G91.1 #2652) logs into openbao.openbao.svc:8200
+                                   # each reconciler tick (k8s-auth, SA sso-bridge-reconciler) to
+                                   # fetch/store the per-app KC OIDC client_secret bundle under
+                                   # secret/sso/<cid>. De-vcluster split openbao into its own host
+                                   # ns post-#4325 → without this carve-out Cilium drops the dial →
+                                   # curl(28) timeout → `skipping tick (no OpenBao token)` → the
+                                   # grafana/hubble/gitea SSO secrets never materialize (503/503/500).
+                                   # openbao auth-bootstrap already binds this SA (#2655,
+                                   # bound_service_account_namespaces=sso-bridge) — network-only gap
+                                   # (Refs #4325 #4448 #4437 #4354).
   - namespace: guacamole           # remote-desktop gateway (was catalyst-system in vc-mgmt)
     gatewayIngress: true           # guacamole.<fqdn> public route
     allowIngressFrom:

--- a/tests/e2e/bootstrap-kit/main_test.go
+++ b/tests/e2e/bootstrap-kit/main_test.go
@@ -1148,6 +1148,12 @@ func TestBootstrapKit_PlaneIsolationDialGraphIsCovered(t *testing.T) {
 		"nats-system": {"org-services", "guacamole", "catalyst-system", "newapi"},
 		// Shared object store — its blob-storage consumers (default-off but legitimate).
 		"seaweedfs": {"gitea", "harbor", "loki", "mimir", "tempo", "velero", "guacamole", "catalyst-system", "sandbox"},
+		// Secrets engine — ESO reads it, CNPG operator manages adjuncts, and
+		// bp-sso-bridge logs in each reconciler tick (k8s-auth) to fetch/store
+		// the per-app KC OIDC client_secret bundle. Missing sso-bridge → the
+		// reconciler curl(28)-timeouts → no secret/sso/* → grafana/hubble/gitea
+		// SSO secrets never materialize → 503/503/500 (#4448, kom4dc b9f9590b).
+		"openbao": {"external-secrets-system", "cnpg-system", "sso-bridge"},
 		// Dashboards — SSO + ESO + its own Postgres backend.
 		"grafana": {"external-secrets-system", "cnpg-system"},
 		// Log/metric/trace stores — their queriers + shippers.


### PR DESCRIPTION
## Problem (live, fresh prov b9f9590b558262b6 / omantel.biz, kom4dc me-east-215-a, 2026-06-26)

`bp-sso-bridge`'s reconciler logs `curl (28) timeout` dialing `openbao.openbao.svc:8200` each tick → `skipping tick (no OpenBao token)` → the seeded SSO secrets never materialize:

- **grafana 503** — `grafana-sso-oidc-credentials` missing
- **hubble 503** — `hubble-ui-oauth2-proxy-oidc` missing
- **gitea 500** — `gitea-oauth-source-credentials` missing, sso-configure stuck

## Root cause — #4325 de-vcluster ingress gap

`bp-plane-isolation` (slot 26b) emits a per-component default-deny NetworkPolicy for openbao's host namespace. Its `allowIngressFrom` was only `{external-secrets-system, cnpg-system}` and **OMITTED `sso-bridge`** (`platform/plane-isolation/chart/values.yaml`, the `openbao` block).

`bp-sso-bridge` (G91.1 #2652) logs into `openbao.openbao.svc:8200` each reconciler tick (k8s-auth, SA `sso-bridge-reconciler`) to fetch/store the per-app Keycloak OIDC `client_secret` bundle under `secret/sso/<cid>`. De-vcluster (#4325) split openbao into its own host namespace → Cilium dropped the dial → HTTP 000 / curl(28) → `no OpenBao token` → no `secret/sso/*` bundle → the 3 downstream SSO secrets never land.

Same de-vcluster ingress-gap class as #4382 (org-services→gitea) and the #4360/#4361/#4380/#4383 sweep. **Network-only**: openbao's auth-bootstrap already binds the sso-bridge SA (#2655, `bound_service_account_namespaces=sso-bridge` on both the main and VC mounts) — no auth-bootstrap change needed. sso-bridge has no own default-deny in this chart, and the secret projection into grafana/hubble/gitea is done by external-secrets-system (already allowed), so no reciprocal allow is required.

## Fix

- `platform/plane-isolation/chart/values.yaml`: add `sso-bridge` to the `openbao` block's `allowIngressFrom`.
- Chart `0.1.5 → 0.1.6`; `blueprint.yaml` + bootstrap-kit slot 26b pin lockstep.
- `tests/e2e/bootstrap-kit` (Case 30 dial-graph contract): add the `openbao → {external-secrets-system, cnpg-system, sso-bridge}` edge to `wantEdges` — openbao had **NO entry at all**, which is exactly why this edge slipped. The test now guards it.

## Verification

- `helm lint` clean; the rendered `openbao-default-deny` NetworkPolicy now admits ingress from `sso-bridge`.
- `go test` Case-30 dial-graph contract **PASSES** with the fix and **FAILS** without it (reverted the values edit to prove the guard fires with the exact "add sso-bridge to the openbao entry" error).
- **Live** on `b9f9590b558262b6`: live-patch the running `openbao-default-deny` to admit sso-bridge → confirm sso-bridge OpenBao login succeeds (no more curl-28), the 3 secrets materialize, grafana/hubble → 200, gitea SSO → no 500.

## Re #4437 / #4354

The KC_ADDR-cache fix (#4440) for #4437 (grafana SSO) was a real but SECONDARY layer; the PRIMARY fresh-prov fault is this plane-isolation netpol gap. Once this rolls, grafana SSO (#4437) + gitea SSO (#4354) pass.

Refs #4448 #4325 #4382 #4437 #4354

🤖 Generated with [Claude Code](https://claude.com/claude-code)
