### PR TITLE
fix(bp-catalyst #4447): PAT-sync hooks order RBAC before the Job + fail-loud on forbidden read — fresh-prov catalog + Org-provisioning unblock (1.4.886)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1138,7 +1138,7 @@ spec:
       #   Blueprint CRs so a merged seed version bump reaches the LIVE CR on the
       #   next helm upgrade (no kubectl patch); catalyst-api strips version/source
       #   from the Flux aggregator so Helm stays their sole owner.
-      version: 1.4.885
+      version: 1.4.886
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,22 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.886 — #4447 (2026-06-26): the two PAT-sync post-install hooks
+# (gitea-flux-auth-secrets-sync-job + provisioning-github-token-sync-job)
+# raced their OWN read-RBAC. The Job and its pat-reader Role/RoleBinding were
+# all hook-weight 20, so the Job pod started polling catalyst-gitea-token
+# BEFORE the RBAC bound; the kubectl read was a silent 403 (`2>/dev/null||true`)
+# for the FULL 300s poll budget, then hit the FATAL branch which `exit 0`'d
+# having created ZERO secrets. The HR sat Ready=True/InstallSucceeded at
+# revision v1 and never re-ran the hook → openova-catalog-sovereign-git-auth +
+# openova-org-tenants-git-auth + provisioning-github-token all ABSENT →
+# catalog-sovereign/org-tenants Flux sources stuck "Source artifact not found"
+# AND the provisioning service hung Init:0/1 → no catalog, no Org provisioning
+# (Pillar-1 dead). FIX: drop the ServiceAccount + all 4 RBAC objects to
+# hook-weight 15 (< the Job's 20) so Helm binds RBAC before the Job polls;
+# capture the kubectl error and, if the budget is exhausted on a *forbidden*
+# read, `exit 1` (OnFailure re-runs with RBAC bound) instead of masking it as
+# "PAT empty" — only the genuine never-minted-PAT case keeps the benign exit-0.
+# Root-caused live on fresh omantel.biz prov b9f9590b558262b6.
 # 1.4.761 — #4061 (2026-06-22): stop a PERMANENT Sovereign from auto-firing the
 # self-sovereignty cutover the moment the mothership completes handover. The
 # child catalyst-api's ReceiveTofuArchive (handover.go) seals the
@@ -3202,7 +3219,7 @@ name: bp-catalyst-platform
 #   versions are published OCI charts; the funnel door already resolves latest
 #   via version:"*", this aligns the catalog Blueprint-CR install path.
 #   Refs #4432 #4408 #4400 #4409 #4417.
-version: 1.4.885
+version: 1.4.886
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/
 #   platform/crossplane chart + blueprint.yaml + bootstrap-kit slot 04). crossplane-core
 #   was still OOMKilled (CrashLoopBackOff, 55 restarts, exit 137, killed ~90s after start)

--- a/products/catalyst/chart/templates/catalog-sovereign-flux/gitea-flux-auth-secrets-sync-job.yaml
+++ b/products/catalyst/chart/templates/catalog-sovereign-flux/gitea-flux-auth-secrets-sync-job.yaml
@@ -86,7 +86,15 @@ metadata:
     catalyst.openova.io/component: gitea-flux-auth-sync
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "20"
+    # weight 15 < the Job's weight 20 (#4447): Helm applies hooks in
+    # ascending weight order and waits for each weight band before the next,
+    # so the ServiceAccount + the pat-reader/writer RBAC below MUST land (and
+    # bind) BEFORE the Job pod starts polling. Same-weight RBAC raced the Job
+    # on hw-prov b9f9590b558262b6 — the pod polled the PAT for the full 300s
+    # budget WITHOUT read RBAC (silent 403), exhausted it, and exit-0'd the
+    # FATAL branch having created zero Secrets, while the HR sat
+    # Ready=True/InstallSucceeded and never re-ran the post-install hook.
+    helm.sh/hook-weight: "15"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 ---
 {{- /* Read the PAT from catalyst-gitea-token in the release namespace. */}}
@@ -99,7 +107,7 @@ metadata:
     catalyst.openova.io/blueprint: bp-catalyst-platform
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "20"
+    helm.sh/hook-weight: "15"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups: [""]
@@ -116,7 +124,7 @@ metadata:
     catalyst.openova.io/blueprint: bp-catalyst-platform
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "20"
+    helm.sh/hook-weight: "15"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 subjects:
   - kind: ServiceAccount
@@ -138,7 +146,7 @@ metadata:
     catalyst.openova.io/blueprint: bp-catalyst-platform
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "20"
+    helm.sh/hook-weight: "15"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups: [""]
@@ -154,7 +162,7 @@ metadata:
     catalyst.openova.io/blueprint: bp-catalyst-platform
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "20"
+    helm.sh/hook-weight: "15"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 subjects:
   - kind: ServiceAccount
@@ -278,18 +286,41 @@ spec:
               POLL_INTERVAL="${POLL_INTERVAL:-5}"
               i=1
               while [ "$i" -le "$POLL_ATTEMPTS" ]; do
+                # #4447: capture the kubectl error separately. A 403 (RBAC not
+                # yet bound) MUST NOT be swallowed as "PAT empty" — that was the
+                # silent-exit-0 bug. With the RBAC now at hook-weight 15 (< this
+                # Job's 20) the read should succeed on the first attempt, but if
+                # admission is momentarily lagging we still want the real error
+                # visible in the log instead of masquerading as a missing PAT.
+                geterr=$(kubectl -n "$PAT_NAMESPACE" get secret "$PAT_SECRET" \
+                  -o jsonpath="{.data.${PAT_KEY}}" 2>/tmp/geterr; cat /tmp/geterr) || geterr="$(cat /tmp/geterr 2>/dev/null)"
                 kubectl -n "$PAT_NAMESPACE" get secret "$PAT_SECRET" \
                   -o jsonpath="{.data.${PAT_KEY}}" 2>/dev/null | base64 -d > /tmp/password 2>/dev/null || true
                 if [ -s /tmp/password ]; then
                   echo "[gitea-flux-auth-sync] ${PAT_NAMESPACE}/${PAT_SECRET}.${PAT_KEY} populated (attempt $i/${POLL_ATTEMPTS})"
                   break
                 fi
-                echo "[gitea-flux-auth-sync] waiting for ${PAT_NAMESPACE}/${PAT_SECRET}.${PAT_KEY} ($i/${POLL_ATTEMPTS}) — mint hook not landed yet"
+                if printf '%s' "$geterr" | grep -qiE 'forbidden|cannot get|is not allowed'; then
+                  echo "[gitea-flux-auth-sync] RBAC not yet bound to read ${PAT_NAMESPACE}/${PAT_SECRET} ($i/${POLL_ATTEMPTS}): ${geterr}" >&2
+                else
+                  echo "[gitea-flux-auth-sync] waiting for ${PAT_NAMESPACE}/${PAT_SECRET}.${PAT_KEY} ($i/${POLL_ATTEMPTS}) — mint hook not landed yet"
+                fi
                 i=$((i + 1))
                 sleep "$POLL_INTERVAL"
               done
               if [ ! -s /tmp/password ]; then
-                echo "[gitea-flux-auth-sync] FATAL: ${PAT_NAMESPACE}/${PAT_SECRET}.${PAT_KEY} still empty after ${POLL_ATTEMPTS} attempts (~$((POLL_ATTEMPTS * POLL_INTERVAL))s) — catalyst-platform NOT wedged; the 2 Flux auth Secrets self-heal next reconcile once the mint lands (#3781 regression fix)" >&2
+                # #4447: if the budget was exhausted on RBAC-forbidden reads,
+                # FAIL LOUD (non-zero) so restartPolicy:OnFailure re-runs the pod
+                # — by which time the weight-15 RBAC is bound and the retry reads
+                # the PAT. Only the genuine "PAT never minted" case keeps the
+                # benign exit-0 (#3781) so a truly-absent mint doesn't wedge the
+                # whole bp-catalyst-platform upgrade. The distinguishing signal
+                # is whether the LAST read was a permission error.
+                if printf '%s' "$geterr" | grep -qiE 'forbidden|cannot get|is not allowed'; then
+                  echo "[gitea-flux-auth-sync] FATAL: still cannot READ ${PAT_NAMESPACE}/${PAT_SECRET} after ${POLL_ATTEMPTS} attempts — RBAC race (#4447). Failing so OnFailure re-runs with RBAC bound: ${geterr}" >&2
+                  exit 1
+                fi
+                echo "[gitea-flux-auth-sync] ${PAT_NAMESPACE}/${PAT_SECRET}.${PAT_KEY} still empty after ${POLL_ATTEMPTS} attempts (~$((POLL_ATTEMPTS * POLL_INTERVAL))s) — PAT not minted; catalyst-platform NOT wedged; the 2 Flux auth Secrets self-heal next reconcile once the mint lands (#3781)" >&2
                 exit 0
               fi
               # Idempotent create-or-update of one Flux basic-auth Secret.

--- a/products/catalyst/chart/templates/org-services/provisioning-github-token-sync-job.yaml
+++ b/products/catalyst/chart/templates/org-services/provisioning-github-token-sync-job.yaml
@@ -90,7 +90,13 @@ metadata:
     catalyst.openova.io/component: provisioning-github-token-sync
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "20"
+    # weight 15 < the Job's weight 20 (#4447): the ServiceAccount + the
+    # pat-reader/writer RBAC below MUST bind BEFORE the Job pod polls the PAT.
+    # Same-weight RBAC raced the Job on hw-prov b9f9590b558262b6 — the pod
+    # polled WITHOUT read RBAC (silent 403) for the full 300s budget, exit-0'd
+    # the FATAL branch creating NO Secret, leaving org-services/provisioning-
+    # github-token absent → the provisioning service hung Init:0/1 forever.
+    helm.sh/hook-weight: "15"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 ---
 {{- /* Read the PAT from catalyst-gitea-token in the source namespace. */}}
@@ -103,7 +109,7 @@ metadata:
     catalyst.openova.io/blueprint: bp-catalyst-platform
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "20"
+    helm.sh/hook-weight: "15"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups: [""]
@@ -120,7 +126,7 @@ metadata:
     catalyst.openova.io/blueprint: bp-catalyst-platform
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "20"
+    helm.sh/hook-weight: "15"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 subjects:
   - kind: ServiceAccount
@@ -142,7 +148,7 @@ metadata:
     catalyst.openova.io/blueprint: bp-catalyst-platform
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "20"
+    helm.sh/hook-weight: "15"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups: [""]
@@ -158,7 +164,7 @@ metadata:
     catalyst.openova.io/blueprint: bp-catalyst-platform
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "20"
+    helm.sh/hook-weight: "15"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 subjects:
   - kind: ServiceAccount
@@ -260,18 +266,38 @@ spec:
               POLL_INTERVAL="${POLL_INTERVAL:-5}"
               i=1
               while [ "$i" -le "$POLL_ATTEMPTS" ]; do
+                # #4447: keep the kubectl read error so a 403 (RBAC not yet
+                # bound) is NOT swallowed as "PAT empty" — that was the silent
+                # exit-0 that left provisioning-github-token absent. RBAC now
+                # lands at weight 15 (< this Job's 20) so the read should succeed
+                # immediately; the error capture is the belt-and-braces.
+                geterr=$(kubectl -n "$PAT_NAMESPACE" get secret "$PAT_SECRET" \
+                  -o jsonpath="{.data.${PAT_KEY}}" 2>/tmp/geterr; cat /tmp/geterr) || geterr="$(cat /tmp/geterr 2>/dev/null)"
                 kubectl -n "$PAT_NAMESPACE" get secret "$PAT_SECRET" \
                   -o jsonpath="{.data.${PAT_KEY}}" 2>/dev/null | base64 -d > /tmp/token 2>/dev/null || true
                 if [ -s /tmp/token ]; then
                   echo "[provisioning-github-token-sync] ${PAT_NAMESPACE}/${PAT_SECRET}.${PAT_KEY} populated (attempt $i/${POLL_ATTEMPTS})"
                   break
                 fi
-                echo "[provisioning-github-token-sync] waiting for ${PAT_NAMESPACE}/${PAT_SECRET}.${PAT_KEY} ($i/${POLL_ATTEMPTS}) — mint hook not landed yet"
+                if printf '%s' "$geterr" | grep -qiE 'forbidden|cannot get|is not allowed'; then
+                  echo "[provisioning-github-token-sync] RBAC not yet bound to read ${PAT_NAMESPACE}/${PAT_SECRET} ($i/${POLL_ATTEMPTS}): ${geterr}" >&2
+                else
+                  echo "[provisioning-github-token-sync] waiting for ${PAT_NAMESPACE}/${PAT_SECRET}.${PAT_KEY} ($i/${POLL_ATTEMPTS}) — mint hook not landed yet"
+                fi
                 i=$((i + 1))
                 sleep "$POLL_INTERVAL"
               done
               if [ ! -s /tmp/token ]; then
-                echo "[provisioning-github-token-sync] WARN: ${PAT_NAMESPACE}/${PAT_SECRET}.${PAT_KEY} still empty after ${POLL_ATTEMPTS} attempts (~$((POLL_ATTEMPTS * POLL_INTERVAL))s) — catalyst-platform NOT wedged; provisioning-github-token self-heals on the next reconcile once the mint lands" >&2
+                # #4447: budget exhausted on RBAC-forbidden reads → FAIL LOUD so
+                # restartPolicy:OnFailure re-runs (RBAC bound by then). Only the
+                # genuine "PAT never minted" case keeps the benign exit-0 (#3763)
+                # so a truly-absent mint doesn't wedge the catalyst-platform
+                # upgrade.
+                if printf '%s' "$geterr" | grep -qiE 'forbidden|cannot get|is not allowed'; then
+                  echo "[provisioning-github-token-sync] FATAL: still cannot READ ${PAT_NAMESPACE}/${PAT_SECRET} after ${POLL_ATTEMPTS} attempts — RBAC race (#4447). Failing so OnFailure re-runs with RBAC bound: ${geterr}" >&2
+                  exit 1
+                fi
+                echo "[provisioning-github-token-sync] WARN: ${PAT_NAMESPACE}/${PAT_SECRET}.${PAT_KEY} still empty after ${POLL_ATTEMPTS} attempts (~$((POLL_ATTEMPTS * POLL_INTERVAL))s) — PAT not minted; catalyst-platform NOT wedged; provisioning-github-token self-heals on the next reconcile once the mint lands (#3763)" >&2
                 exit 0
               fi
               # ── Idempotent create-or-update of the dest Secret with the PAT


### PR DESCRIPTION
## Problem (Pillar-1 dead on a fresh prov)
On a fresh `omantel.biz` prov (`b9f9590b558262b6`, 2026-06-26) the catalog + per-Org app layer never converges, and the provisioning engine never starts:

```
flux-system/catalog-sovereign  False  Source artifact not found, retrying in 30s
flux-system/org-tenants        False  Source artifact not found, retrying in 30s
org-services/provisioning      Init:0/1  wait-for-gitea-token: GITHUB_TOKEN not yet populated
```

Root: three secrets that gate the whole funnel were **absent** —
`openova-catalog-sovereign-git-auth`, `openova-org-tenants-git-auth` (Flux source auth) and `org-services/provisioning-github-token` (provisioning engine). No catalog + no provisioning ⇒ a voucher redeem can never provision an Org with a running WordPress.

## Root cause (verified live, not guessed)
Both post-install PAT-sync hooks raced their OWN read-RBAC:
- `templates/catalog-sovereign-flux/gitea-flux-auth-secrets-sync-job.yaml`
- `templates/org-services/provisioning-github-token-sync-job.yaml`

The Job **and** its `pat-reader` Role/RoleBinding were all `hook-weight: "20"`. Helm applies same-weight hooks together, so the Job pod started polling `catalyst-gitea-token` BEFORE its RBAC bound. The kubectl read was a silent 403 (`2>/dev/null ... || true`) for the **full 300s poll budget**, then hit the FATAL branch which `exit 0`'d having created **zero** secrets. The HR then sat `Ready=True / InstallSucceeded` at revision **v1** and never re-runs a post-install hook → no self-heal.

Live helm-release hook `last_run` proves it: Job started 10:20:45, completed 10:26:04 `Succeeded`; its pat-reader Role/RoleBinding were created at **10:26:04** — i.e. RBAC bound ~5m19s after the Job began polling, exactly when the budget elapsed.

The #4286 Kyverno floor (`inject-gitea-source-secretref`) guarantees `secretRef.name` is non-empty but does NOT guarantee the named secret EXISTS — so the source pointed at a secret nobody created.

## Fix (both jobs)
1. **Order RBAC before the Job**: drop the ServiceAccount + all 4 RBAC objects to `hook-weight: "15"` (< the Job's `20`). Helm binds RBAC, then runs the Job, so the very first PAT read succeeds.
2. **Fail loud on a forbidden read**: capture the kubectl error; if the budget is exhausted on a *forbidden* read, `exit 1` (restartPolicy:OnFailure re-runs with RBAC bound). Only the genuine *never-minted-PAT* case keeps the benign `exit 0` (#3763/#3781) so a truly-absent mint doesn't wedge the catalyst-platform upgrade.

`bp-catalyst-platform` chart 1.4.882 → **1.4.886**.

## Live evidence (this prov)
The immediate unblock (creating all three secrets by hand from the PAT) flipped both GitRepositories **Ready=True**, both Kustomizations **Reconciled** within 12s, and the catalog `blueprints.catalyst.openova.io` CRD + plan catalog converged. This PR makes that automatic on every fresh prov.

CAVEAT: full zero-touch fresh-prov re-verification of the hook firing correctly is pending — the live prov's Huawei me-east-215 EIP pool went unreachable mid-session (both regions' apiserver/ELB EIPs down; bastion .20 unaffected), so the post-fix re-roll couldn't be walked. The chart renders clean (`helm template` rc=0) and the weight/exit logic is deterministic; re-stamp on the next reachable fresh prov.

Refs #4447

🤖 Generated with [Claude Code](https://claude.com/claude-code)