### PR TITLE
fix(bp-catalyst): gitea-flux-auth-sync RBAC ordered before the Job + fail-loud on PAT read-error — *-git-auth Secrets land zero-touch (1.4.886)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1138,7 +1138,13 @@ spec:
       #   Blueprint CRs so a merged seed version bump reaches the LIVE CR on the
       #   next helm upgrade (no kubectl patch); catalyst-api strips version/source
       #   from the Flux aggregator so Helm stays their sole owner.
-      version: 1.4.885
+      # 1.4.886 — #4447: gitea-flux-auth-sync hook RBAC ordered strictly before
+      #   the Job (weight 15 < 20) + fail-loud on PAT read-error instead of
+      #   exit-0-with-zero-Secrets — the two Flux *-git-auth Secrets now land
+      #   zero-touch so catalog-sovereign + org-tenants GitRepositories reach
+      #   Ready on a fresh prov (no manual secret-recreation). Lockstep w/
+      #   Chart.yaml + the new guard test. Refs #4447.
+      version: 1.4.886
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3202,7 +3202,26 @@ name: bp-catalyst-platform
 #   versions are published OCI charts; the funnel door already resolves latest
 #   via version:"*", this aligns the catalog Blueprint-CR install path.
 #   Refs #4432 #4408 #4400 #4409 #4417.
-version: 1.4.885
+# 1.4.886 — #4447: gitea-flux-auth-sync hook no longer exit-0's on its own RBAC
+#   race. The sole creator of the two Flux basic-auth Secrets
+#   (openova-catalog-sovereign-git-auth + openova-org-tenants-git-auth) had its
+#   pat-reader Role/RoleBinding at hook-weight 20 — SAME as the Job — so the Job
+#   often polled the minted PAT before its RoleBinding bound → silent 403 for the
+#   whole budget → FATAL branch exit-0'd having created NEITHER Secret → both
+#   catalog-sovereign + org-tenants GitRepositories stuck "Source artifact not
+#   found" → catalog + per-Org provisioning never converged (fresh prov
+#   b9f9590b558262b6, Pillar-1 blocked, manual secret-recreation needed). FIX:
+#   (a) the SA + all four RBAC objects are hook-weight 15 (< the Job's 20) so
+#   Helm waits the RBAC batch Ready before the Job; (b) the PAT read now captures
+#   the kubectl exit code (no more 2>/dev/null||true swallow) + an `auth can-i`
+#   preflight — a budget exhausted with ANY read error fails LOUD (exit 1, retry)
+#   instead of masking a 403 as "empty"; only a CLEAN empty token stays the
+#   benign mint-race self-heal (exit 0, #3781); (c) a post-apply read-back
+#   verifies both Secrets exist with a non-empty password (task-4 defense in
+#   depth: #4286's secretRef.name floor guarantees name-set, NOT secret-exists).
+#   New guard chart/tests/gitea-flux-auth-sync-rbac-order.sh. Lockstep w/
+#   bootstrap-kit slot 13 pin. Refs #4447 #3780 #3765 #3781 #4286.
+version: 1.4.886
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/
 #   platform/crossplane chart + blueprint.yaml + bootstrap-kit slot 04). crossplane-core
 #   was still OOMKilled (CrashLoopBackOff, 55 restarts, exit 137, killed ~90s after start)

--- a/products/catalyst/chart/templates/catalog-sovereign-flux/gitea-flux-auth-secrets-sync-job.yaml
+++ b/products/catalyst/chart/templates/catalog-sovereign-flux/gitea-flux-auth-secrets-sync-job.yaml
@@ -86,7 +86,14 @@ metadata:
     catalyst.openova.io/component: gitea-flux-auth-sync
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "20"
+    # Weight 15 < the Job's weight 20 (#4447). The SA + both RBAC pairs MUST
+    # be created (and authorizer-effective) BEFORE the Job pod starts polling.
+    # Helm applies a lower-weight hook batch fully and waits for it Ready
+    # before the next-higher batch, so a strictly-lower weight guarantees the
+    # RoleBinding exists when the Job's `kubectl get secret` first fires —
+    # otherwise the read is a silent 403 for the whole poll budget and the
+    # Job exit-0's having created nothing (the #4447 fresh-prov failure).
+    helm.sh/hook-weight: "15"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 ---
 {{- /* Read the PAT from catalyst-gitea-token in the release namespace. */}}
@@ -99,7 +106,9 @@ metadata:
     catalyst.openova.io/blueprint: bp-catalyst-platform
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "20"
+    # Weight 15 < Job weight 20 (#4447) — bind the PAT-read grant BEFORE the
+    # Job polls, else the read 403s silently for the whole budget.
+    helm.sh/hook-weight: "15"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups: [""]
@@ -116,7 +125,8 @@ metadata:
     catalyst.openova.io/blueprint: bp-catalyst-platform
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "20"
+    # Weight 15 < Job weight 20 (#4447).
+    helm.sh/hook-weight: "15"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 subjects:
   - kind: ServiceAccount
@@ -138,7 +148,9 @@ metadata:
     catalyst.openova.io/blueprint: bp-catalyst-platform
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "20"
+    # Weight 15 < Job weight 20 (#4447) — bind the secret-write grant BEFORE
+    # the Job applies the two flux-system auth Secrets.
+    helm.sh/hook-weight: "15"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups: [""]
@@ -154,7 +166,8 @@ metadata:
     catalyst.openova.io/blueprint: bp-catalyst-platform
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "20"
+    # Weight 15 < Job weight 20 (#4447).
+    helm.sh/hook-weight: "15"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 subjects:
   - kind: ServiceAccount
@@ -178,14 +191,21 @@ metadata:
     app.kubernetes.io/managed-by: flux
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    # Weight 20 — post-* hooks already run after the whole install/upgrade
-    # action (which includes the pre-* mint), so cross-phase ordering is
-    # automatic; this weight only orders this Job's own RBAC (also weight 20,
-    # < this Job is fine — same weight is applied together) deterministically.
-    # The REAL ordering guard against the mint race is the bounded poll loop
-    # in the container args (#3763): pre-/post-* weights are independent
-    # phases, so no weight can sequence this after the mint — the job must
-    # WAIT for the token rather than FATAL on an empty read.
+    # Weight 20 — STRICTLY GREATER than this Job's own SA + RBAC (weight 15,
+    # #4447). Helm installs hooks in ascending weight batches and waits for
+    # each batch Ready before the next, so weight-15 RBAC is created AND
+    # authorizer-effective before this Job's pod issues its first
+    # `kubectl get secret`. Pre-#4447 the RBAC was ALSO weight 20 (same batch,
+    # applied together, no ordering guarantee) → the Job frequently started
+    # polling before its RoleBinding bound → every read was a silent 403 for
+    # the full poll budget → the FATAL branch exit-0'd having created neither
+    # *-git-auth Secret (the fresh-prov b9f9590b558262b6 failure).
+    #
+    # Cross-phase ordering vs the pre-* mint (catalyst-gitea-token-secret.yaml)
+    # is NOT a weight concern — pre-/post-* are independent phases, so no
+    # weight can sequence this after the mint. The guard against the mint
+    # landing a beat late is the bounded poll loop in the container args
+    # (#3763): the Job WAITS for a non-empty token rather than FATAL-on-empty.
     helm.sh/hook-weight: "20"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
@@ -276,20 +296,82 @@ spec:
               # ANY mint-vs-sync ordering, fresh-install OR upgrade.
               POLL_ATTEMPTS="${POLL_ATTEMPTS:-240}"
               POLL_INTERVAL="${POLL_INTERVAL:-5}"
-              i=1
-              while [ "$i" -le "$POLL_ATTEMPTS" ]; do
-                kubectl -n "$PAT_NAMESPACE" get secret "$PAT_SECRET" \
-                  -o jsonpath="{.data.${PAT_KEY}}" 2>/dev/null | base64 -d > /tmp/password 2>/dev/null || true
-                if [ -s /tmp/password ]; then
-                  echo "[gitea-flux-auth-sync] ${PAT_NAMESPACE}/${PAT_SECRET}.${PAT_KEY} populated (attempt $i/${POLL_ATTEMPTS})"
+              # #4447 — DISTINGUISH "RBAC/API read FAILING" from "token genuinely
+              # empty". Pre-fix the read swallowed every error with
+              # `2>/dev/null … || true`, so a 403 (RBAC not bound yet) was
+              # indistinguishable from an empty `.data.token`. The budget then
+              # exhausted on a SILENT 403 and the FATAL branch exit-0'd having
+              # created NOTHING — the fresh-prov failure. We now:
+              #   (a) preflight `kubectl auth can-i get secret/<PAT>` — fail
+              #       LOUD (exit 1, retry) if RBAC is genuinely missing, so the
+              #       hook never "succeeds" without ever being able to read;
+              #   (b) on each poll, capture the read's stderr + exit code so a
+              #       transient API/authorizer-propagation error is logged and
+              #       retried, NOT misread as "token empty";
+              #   (c) only treat a CLEAN read of empty `.data.token` as the
+              #       benign mint-race (self-heals next reconcile, exit 0);
+              #       any other terminal state is exit 1 (fail-loud).
+              #
+              # (a) Preflight: with the weight-15 RBAC (< this Job's 20) the
+              # RoleBinding is created before this pod starts, but authorizer
+              # cache propagation can lag a beat — so we POLL can-i briefly
+              # rather than asserting once. If it never resolves, the grant is
+              # genuinely absent (a chart/RBAC bug) → fail loud.
+              rbac_ok=""
+              j=1
+              while [ "$j" -le 12 ]; do
+                if kubectl -n "$PAT_NAMESPACE" auth can-i get \
+                     "secret/${PAT_SECRET}" >/dev/null 2>/tmp/canierr; then
+                  rbac_ok=1
                   break
                 fi
-                echo "[gitea-flux-auth-sync] waiting for ${PAT_NAMESPACE}/${PAT_SECRET}.${PAT_KEY} ($i/${POLL_ATTEMPTS}) — mint hook not landed yet"
+                echo "[gitea-flux-auth-sync] waiting for PAT-read RBAC to bind on ${PAT_NAMESPACE}/${PAT_SECRET} ($j/12): $(cat /tmp/canierr 2>/dev/null)"
+                j=$((j + 1))
+                sleep 5
+              done
+              if [ -z "$rbac_ok" ]; then
+                echo "[gitea-flux-auth-sync] FATAL(#4447): cannot 'get secret/${PAT_SECRET}' in ${PAT_NAMESPACE} after RBAC wait — the pat-reader Role/RoleBinding (hook-weight 15) did not bind. This is an RBAC bug, NOT a benign mint-race; failing LOUD so the Job retries and the umbrella install surfaces it rather than silently creating zero auth Secrets." >&2
+                exit 1
+              fi
+              # (b)+(c) Poll the token. A non-zero kubectl exit = a READ ERROR
+              # (API/authorizer/connection) → retry, never confuse with empty.
+              read_errors=0
+              i=1
+              while [ "$i" -le "$POLL_ATTEMPTS" ]; do
+                # errexit-safe: a non-zero kubectl exit in a `var=$(...)`
+                # assignment would trip `set -e` BEFORE we can inspect rc, so
+                # capture rc with `|| rc=$?` and default rc=0 on success.
+                rc=0
+                rawb64="$(kubectl -n "$PAT_NAMESPACE" get secret "$PAT_SECRET" \
+                  -o jsonpath="{.data.${PAT_KEY}}" 2>/tmp/readerr)" || rc=$?
+                if [ "$rc" -ne 0 ]; then
+                  read_errors=$((read_errors + 1))
+                  echo "[gitea-flux-auth-sync] read error on ${PAT_NAMESPACE}/${PAT_SECRET} (attempt $i/${POLL_ATTEMPTS}, rc=$rc): $(cat /tmp/readerr 2>/dev/null) — retrying"
+                else
+                  printf '%s' "$rawb64" | base64 -d > /tmp/password 2>/dev/null || true
+                  if [ -s /tmp/password ]; then
+                    echo "[gitea-flux-auth-sync] ${PAT_NAMESPACE}/${PAT_SECRET}.${PAT_KEY} populated (attempt $i/${POLL_ATTEMPTS})"
+                    break
+                  fi
+                  echo "[gitea-flux-auth-sync] ${PAT_NAMESPACE}/${PAT_SECRET}.${PAT_KEY} present but empty ($i/${POLL_ATTEMPTS}) — mint hook not landed yet"
+                fi
                 i=$((i + 1))
                 sleep "$POLL_INTERVAL"
               done
               if [ ! -s /tmp/password ]; then
-                echo "[gitea-flux-auth-sync] FATAL: ${PAT_NAMESPACE}/${PAT_SECRET}.${PAT_KEY} still empty after ${POLL_ATTEMPTS} attempts (~$((POLL_ATTEMPTS * POLL_INTERVAL))s) — catalyst-platform NOT wedged; the 2 Flux auth Secrets self-heal next reconcile once the mint lands (#3781 regression fix)" >&2
+                # Budget exhausted with no usable PAT. Two terminal cases:
+                #   - reads were ERRORING (API/RBAC/connection) → fail LOUD
+                #     (exit 1) so backoffLimit retries + the install surfaces
+                #     the real fault; NEVER mask a read failure as success.
+                #   - reads were CLEAN but `.data.token` stayed empty → the
+                #     benign mint-race (#3781): the mint genuinely hasn't
+                #     populated the token; the 2 auth Secrets self-heal on the
+                #     next reconcile once it does → exit 0.
+                if [ "$read_errors" -gt 0 ]; then
+                  echo "[gitea-flux-auth-sync] FATAL(#4447): ${read_errors} read error(s) on ${PAT_NAMESPACE}/${PAT_SECRET} across ${POLL_ATTEMPTS} attempts — the PAT was never readable (API/RBAC fault), so ZERO auth Secrets were created. Failing LOUD (exit 1) so the Job retries; last error: $(cat /tmp/readerr 2>/dev/null)" >&2
+                  exit 1
+                fi
+                echo "[gitea-flux-auth-sync] ${PAT_NAMESPACE}/${PAT_SECRET}.${PAT_KEY} still empty after ${POLL_ATTEMPTS} attempts (~$((POLL_ATTEMPTS * POLL_INTERVAL))s) but READABLE — benign mint-race; the 2 Flux auth Secrets self-heal next reconcile once the mint lands (#3781). exit 0." >&2
                 exit 0
               fi
               # Idempotent create-or-update of one Flux basic-auth Secret.
@@ -338,7 +420,32 @@ spec:
               apply_secret "$CAT_SECRET_NS" "$CAT_SECRET_NAME" "$CAT_USER"
               apply_secret "$ORG_SECRET_NS" "$ORG_SECRET_NAME" "$ORG_USER" "${ORG_REFLECT_NAMESPACES:-}"
               rm -f /tmp/password /tmp/username
-              echo "[gitea-flux-auth-sync] done — both Flux basic-auth Secrets present"
+              # #4447 (task 4 — defense in depth): READ BACK both Secrets with a
+              # non-empty `password` key. The Kyverno floor (#4286
+              # inject-gitea-source-secretref) guarantees the GitRepository's
+              # secretRef.name is non-empty, but name-set != secret-EXISTS — the
+              # exact gap that left both sources stuck "Source artifact not
+              # found". This Job is the sole creator, so it MUST confirm its own
+              # output landed; fail LOUD (exit 1, retry) if either is absent or
+              # empty rather than reporting Succeeded on a phantom secret.
+              verify_secret() {
+                VNS="$1"; VNAME="$2"
+                # Read the base64 `password` value into a var FIRST (errexit-safe
+                # via `|| vrc=$?`) so a kubectl failure is captured directly,
+                # NOT masked by a trailing `| wc -c` whose exit hides kubectl's.
+                vrc=0
+                vpw="$(kubectl -n "$VNS" get secret "$VNAME" \
+                  -o jsonpath='{.data.password}' 2>/tmp/verifyerr)" || vrc=$?
+                if [ "$vrc" -ne 0 ] || [ -z "$vpw" ]; then
+                  echo "[gitea-flux-auth-sync] FATAL(#4447): post-apply verify FAILED for ${VNS}/${VNAME} (rc=$vrc, password-empty=$([ -z "$vpw" ] && echo yes || echo no)) — the GitRepository secretRef would point at a missing/empty Secret. Failing LOUD so the Job retries; err: $(cat /tmp/verifyerr 2>/dev/null)" >&2
+                  return 1
+                fi
+                echo "[gitea-flux-auth-sync] verified ${VNS}/${VNAME} present with non-empty password"
+                return 0
+              }
+              verify_secret "$CAT_SECRET_NS" "$CAT_SECRET_NAME" || exit 1
+              verify_secret "$ORG_SECRET_NS" "$ORG_SECRET_NAME" || exit 1
+              echo "[gitea-flux-auth-sync] done — both Flux basic-auth Secrets present + verified"
           resources:
             requests: { cpu: 50m, memory: 64Mi }
             limits:   { memory: 256Mi }

--- a/products/catalyst/chart/tests/gitea-flux-auth-sync-rbac-order.sh
+++ b/products/catalyst/chart/tests/gitea-flux-auth-sync-rbac-order.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# bp-catalyst-platform — gitea-flux-auth-sync hook RBAC-ordering + fail-loud gate (#4447).
+#
+# The post-install hook templates/catalog-sovereign-flux/gitea-flux-auth-secrets-sync-job.yaml
+# is the SOLE creator of the two Flux basic-auth Secrets the catalog-sovereign +
+# org-tenants GitRepository sources authenticate with
+# (openova-catalog-sovereign-git-auth + openova-org-tenants-git-auth). On the
+# fresh prov b9f9590b558262b6 (omantel.biz, 2026-06-26) it exit-0'd having
+# created NEITHER secret, so both sources stuck "Source artifact not found" and
+# the whole catalog (→ every per-Org provisioning) never converged — Pillar-1
+# blocked, manual secret-recreation required (NOT zero-touch).
+#
+# Two root causes (both guarded here):
+#
+#   1. RBAC RACE. The Job's pat-reader Role/RoleBinding (the grant that lets it
+#      read the minted PAT) was hook-weight 20 — the SAME weight as the Job. Helm
+#      applies a same-weight hook batch together with NO ordering guarantee, so
+#      the Job pod frequently started polling before its RoleBinding bound → the
+#      `kubectl get secret catalyst-gitea-token` read was a silent 403 for the
+#      entire poll budget. FIX: the SA + all four RBAC objects are hook-weight 15
+#      (strictly < the Job's 20), so Helm installs+waits the RBAC batch Ready
+#      BEFORE the Job batch.
+#
+#   2. SILENT-SWALLOW + exit-0-on-nothing. The PAT read used `2>/dev/null … ||
+#      true`, making a 403 indistinguishable from an empty token; the budget then
+#      exhausted and the FATAL branch `exit 0`'d unconditionally — reporting
+#      Succeeded while creating ZERO secrets. FIX: the read now captures the
+#      kubectl exit code; a budget exhausted with ANY read error fails LOUD
+#      (exit 1, retry via backoffLimit); only a CLEAN read of an empty token is
+#      treated as the benign mint-race (exit 0, self-heals). A post-apply
+#      read-back verifies both Secrets exist with a non-empty password.
+#
+# Nothing in CI rendered this hook and asserted the RBAC ordering, nor exercised
+# the read-error-vs-empty branch. This gate fills that hole: a regression that
+# re-collapses the RBAC weight back to 20, or re-introduces a blanket exit-0,
+# fails Blueprint Release publish BEFORE the OCI artifact reaches a Sovereign.
+#
+# Test framework: `helm template` + grep on rendered YAML for the weights, plus
+# a behavioral drive of the rendered container script against a stub `kubectl`
+# (matches the established tests/sovereign-fqdn-lb-ip-contract.sh pattern; picked
+# up automatically by .github/workflows/blueprint-release.yaml).
+#
+# Usage: bash tests/gitea-flux-auth-sync-rbac-order.sh [CHART_DIR]
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+
+TEMPLATE="templates/catalog-sovereign-flux/gitea-flux-auth-secrets-sync-job.yaml"
+
+# The hook is gated on a Sovereign (global.sovereignFQDN) + marketplace enabled.
+helm template smoke . \
+  --set global.sovereignFQDN=omantel.biz \
+  --set ingress.marketplace.enabled=true \
+  --show-only "${TEMPLATE}" > "$TMP/hook.yaml"
+
+# ── Gate 1: RBAC strictly precedes the Job ────────────────────────────────────
+# Split the rendered manifest into per-document files and inspect hook-weight by
+# kind/name so we assert the SA + RBAC are 15 and the Job is 20.
+python3 - "$TMP/hook.yaml" <<'PY'
+import sys, yaml
+docs = [d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+by = {}
+for d in docs:
+    k = d.get("kind")
+    name = d.get("metadata", {}).get("name", "")
+    w = d.get("metadata", {}).get("annotations", {}).get("helm.sh/hook-weight")
+    by[(k, name)] = w
+
+def want(kind, name, weight):
+    got = by.get((kind, name))
+    if got != weight:
+        print(f"FAIL(#4447): {kind}/{name} hook-weight={got!r}, expected {weight!r}", file=sys.stderr)
+        sys.exit(1)
+
+# SA + both RBAC pairs MUST be weight 15 (< the Job's 20).
+want("ServiceAccount", "catalyst-gitea-flux-auth-sync", "15")
+want("Role",        "catalyst-gitea-flux-auth-sync-pat-reader", "15")
+want("RoleBinding", "catalyst-gitea-flux-auth-sync-pat-reader", "15")
+want("Role",        "catalyst-gitea-flux-auth-sync-writer", "15")
+want("RoleBinding", "catalyst-gitea-flux-auth-sync-writer", "15")
+# The Job MUST be strictly greater so Helm waits the RBAC batch Ready first.
+want("Job", "catalyst-gitea-flux-auth-sync", "20")
+
+job_w = int(by[("Job", "catalyst-gitea-flux-auth-sync")])
+for (k, n), w in by.items():
+    if k in ("Role", "RoleBinding", "ServiceAccount"):
+        if int(w) >= job_w:
+            print(f"FAIL(#4447): {k}/{n} weight {w} >= Job weight {job_w} — RBAC not ordered before the Job", file=sys.stderr)
+            sys.exit(1)
+print("  PASS gate-1: SA + all RBAC are hook-weight 15, strictly before the Job (20)")
+PY
+
+# ── Gate 2: behavioral — fail-loud on read-error, self-heal on empty ──────────
+# Extract the rendered container script and drive it against a stub kubectl.
+python3 - "$TMP/hook.yaml" > "$TMP/script.sh" <<'PY'
+import sys, yaml
+for d in yaml.safe_load_all(open(sys.argv[1])):
+    if d and d.get("kind") == "Job":
+        sys.stdout.write(d["spec"]["template"]["spec"]["containers"][0]["args"][0])
+PY
+
+# Syntax must be valid POSIX sh (the image runs `sh -c`).
+if ! sh -n "$TMP/script.sh"; then
+  echo "FAIL(#4447): rendered container script is not valid POSIX sh" >&2
+  exit 1
+fi
+echo "  PASS gate-2a: rendered container script passes 'sh -n'"
+
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/kubectl" <<'EOF'
+#!/bin/sh
+ARGS="$*"
+case "$ARGS" in
+  *"auth can-i"*)
+    [ "$RBAC" = "deny" ] && { echo "no" >&2; exit 1; }
+    echo "yes"; exit 0 ;;
+  *"get secret"*"jsonpath={.data.password}"*)
+    [ "$VERIFY" = "fail" ] && { echo "" >&2; exit 1; }
+    printf 'cGFzcw=='; exit 0 ;;
+  *"get secret"*"jsonpath={.data."*)
+    case "$SCENARIO" in
+      read_error)  echo "Error from server (Forbidden): secrets is forbidden" >&2; exit 1 ;;
+      empty_token) echo ""; exit 0 ;;
+      success)     printf 'c2hhMXRva2Vu'; exit 0 ;;
+    esac ;;
+  *"create secret"*) printf 'apiVersion: v1\nkind: Secret\nmetadata: {name: x, namespace: y}\ndata: {username: dXNlcg==, password: cGFzcw==}\n' ;;
+  *"label --local"*)    cat ;;
+  *"annotate --local"*) cat ;;
+  *"apply"*) echo "secret/x applied" ;;
+  *) exit 0 ;;
+esac
+EOF
+chmod +x "$TMP/bin/kubectl"
+printf '#!/bin/sh\nexit 0\n' > "$TMP/bin/sleep"
+chmod +x "$TMP/bin/sleep"
+
+drive() { # SCENARIO RBAC VERIFY
+  PATH="$TMP/bin:$PATH" POLL_ATTEMPTS=3 POLL_INTERVAL=0 \
+    PAT_NAMESPACE=catalyst-system PAT_SECRET=catalyst-gitea-token PAT_KEY=token \
+    CAT_SECRET_NAME=openova-catalog-sovereign-git-auth CAT_SECRET_NS=flux-system CAT_USER=gitea_admin \
+    ORG_SECRET_NAME=openova-org-tenants-git-auth ORG_SECRET_NS=flux-system ORG_USER=gitea_admin \
+    ORG_REFLECT_NAMESPACES="" \
+    SCENARIO="$1" RBAC="${2:-allow}" VERIFY="${3:-ok}" \
+    sh "$TMP/script.sh" >/dev/null 2>&1
+}
+
+# success → exit 0
+if ! drive success allow ok; then
+  echo "FAIL(#4447): script exited non-zero on the happy path (token present, verify ok)" >&2; exit 1
+fi
+# RBAC denied → MUST fail loud (the pre-fix bug silently exit-0'd here)
+if drive success deny ok; then
+  echo "FAIL(#4447): script exited 0 when RBAC denies the PAT read — must fail LOUD so the Job retries" >&2; exit 1
+fi
+# Read error for the whole budget → MUST fail loud (the core #4447 403-swallow bug)
+if drive read_error allow ok; then
+  echo "FAIL(#4447): script exited 0 when the PAT read errors for the whole budget — must fail LOUD, not report Succeeded with zero Secrets" >&2; exit 1
+fi
+# Genuine empty token (clean read) → benign self-heal exit 0 (preserve #3781)
+if ! drive empty_token allow ok; then
+  echo "FAIL(#4447): script failed on a CLEAN empty-token read — the benign mint-race must exit 0 and self-heal (#3781)" >&2; exit 1
+fi
+# Post-apply verify fails → MUST fail loud (task-4 defense in depth)
+if drive success allow fail; then
+  echo "FAIL(#4447): script exited 0 when post-apply verify shows an absent/empty Secret — must fail LOUD" >&2; exit 1
+fi
+echo "  PASS gate-2b: fail-loud on RBAC-deny / read-error / verify-fail; self-heal only on a clean empty token"
+
+echo "[gitea-flux-auth-sync] All gates green (#4447)."


### PR DESCRIPTION
## Problem (Refs #4447)

On the fresh prov `b9f9590b558262b6` (omantel.biz, 2026-06-26) the catalog + per-Org app layer never converged:

```
flux-system/catalog-sovereign  False  Source artifact not found, retrying in 30s
flux-system/org-tenants        False  Source artifact not found, retrying in 30s
```

Both `*-git-auth` Secrets were **absent** → no catalog → no Org provisioning → **Pillar-1 blocked**. A walker had to recreate the Secrets by hand (Gitea API 200) for the GitRepositories to go Ready — i.e. NOT zero-touch.

The post-install hook `gitea-flux-auth-secrets-sync-job.yaml` is the **sole creator** of both Secrets and it reported **Succeeded having created neither**.

## Root cause (two, both fixed)

**1. RBAC race.** The Job's `pat-reader` Role/RoleBinding (the grant that lets it read the minted PAT) was `hook-weight: 20` — the SAME weight as the Job. Helm applies a same-weight hook batch together with no ordering guarantee, so the Job pod frequently started polling before its RoleBinding bound → the `kubectl get secret catalyst-gitea-token` read was a silent **403 for the entire poll budget**.

**2. Silent-swallow + exit-0-on-nothing.** The PAT read used `2>/dev/null … || true`, making a 403 indistinguishable from an empty token. The budget exhausted and the FATAL branch `exit 0`'d **unconditionally** (the #3780/#3781 change, intended only for the genuine mint-race) — reporting Succeeded while creating zero Secrets, and the HR never re-runs a post-install hook → no self-heal.

## Fix

- **Order RBAC strictly before the Job**: the ServiceAccount + all four RBAC objects are now `hook-weight: 15` (< the Job's 20), so Helm installs+waits the RBAC batch Ready before the Job batch.
- **Distinguish read-error from empty token**: an `auth can-i` preflight (polls briefly for authorizer propagation) + a read that captures kubectl's exit code (no more swallow). A budget exhausted with **any read error** fails LOUD (`exit 1`, retry via `backoffLimit`). Only a **clean read of an empty token** stays the benign mint-race self-heal (`exit 0`, preserving #3781).
- **Post-apply read-back verify** (task 4, defense in depth): confirm both Secrets exist with a non-empty `password` before reporting done — #4286's `secretRef.name` floor guarantees name-set, NOT secret-exists.

## Proof

- `helm template` + `helm lint` clean (full umbrella renders, 191 docs, no error).
- New guard `chart/tests/gitea-flux-auth-sync-rbac-order.sh` (picked up by `blueprint-release.yaml`):
  - gate-1 asserts SA + all RBAC are weight 15, strictly before the Job (20).
  - gate-2 drives the **rendered** container script through RBAC-deny / read-error / empty-token / verify-fail against a stub kubectl — locking fail-loud on the first three, self-heal only on a clean empty token.
- Negative control confirmed the guard catches the OLD blanket-`exit 0` (a buggy script exits 0 on `read_error`, which the test flags).
- `check-bootstrap-kit-pin-sync.sh` green: `bp-catalyst-platform: chart=1.4.886 pin=1.4.886`. `check-bootstrap-deps.sh` green.
- All four existing catalyst chart tests still pass.

Lockstep: `Chart.yaml` 1.4.885 → **1.4.886** + bootstrap-kit slot 13 pin.

Once the env recovers from its EIP self-heal, a fresh reconcile should materialize both `*-git-auth` Secrets and drive both GitRepositories Ready without manual intervention.

Refs #4447 #3780 #3765 #3781 #4286

🤖 Generated with [Claude Code](https://claude.com/claude-code)