### PR TITLE
fix(catalyst-api #4450): preserve mothership-injected handover pubkey on Sovereigns (owner zero-login)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -2123,6 +2123,57 @@ func env(key, fallback string) string {
 	return fallback
 }
 
+// pubkeyPublishDecision is the outcome of the guard that decides whether the
+// runtime signer's pubkey may overwrite the catalyst-handover-jwt-public
+// Secret. Pure + table-testable (no cluster) — see main_test.go.
+type pubkeyPublishDecision int
+
+const (
+	// pubkeyPublishWrite — the Secret's current value differs from ours and it
+	// is safe to overwrite (mothership / Catalyst-Zero, or the Sovereign Secret
+	// is empty/absent so there is no injected key to clobber).
+	pubkeyPublishWrite pubkeyPublishDecision = iota
+	// pubkeyPublishAlreadyCurrent — the Secret already carries our exact JWK.
+	pubkeyPublishAlreadyCurrent
+	// pubkeyPublishPreserveInjected — this is a Sovereign and the Secret already
+	// holds a DIFFERENT key (the mothership-injected inbound-handover key).
+	// Preserve it; publishing our local-signer key here would break owner
+	// handover (#4450).
+	pubkeyPublishPreserveInjected
+)
+
+// decidePubkeyPublish is the pure core of publishHandoverPubkey's write guard
+// (#4450). Given the runtime signer's JWK, the Secret's current value (nil when
+// the key is absent / Secret missing) and whether this process is a Sovereign
+// (SOVEREIGN_FQDN set), it decides whether to overwrite.
+//
+// Why the Sovereign guard exists (#4450 root cause):
+//
+//	cloud-init seeds catalyst-handover-jwt-public with the MOTHERSHIP's public
+//	key (the key the inbound owner-handover JWT must verify against — read by
+//	auth_handover.go). On a Sovereign the local handoverSigner is a SEPARATE,
+//	self-generated keypair (the mothership never shares its private key —
+//	sovereignty). #4114 added an unconditional per-boot PATCH that published the
+//	LOCAL signer's pubkey over the injected mothership key, so every
+//	mothership-signed owner handover 401'd "invalid token". The local signer's
+//	pubkey already reaches its real consumer (agenity openova-mcp) via openbao
+//	(seedMCPBearer → secret/catalyst/agenity/<slug>/mcp-bearer), so the Secret
+//	mirror is not needed on a Sovereign — preserve the injected key there.
+//
+// On the mothership (SOVEREIGN_FQDN empty) the Secret IS the local signer's
+// mirror, so the original #4114 self-heal still applies: overwrite when stale.
+func decidePubkeyPublish(pubJWK, current []byte, isSovereign bool) pubkeyPublishDecision {
+	if current != nil && string(current) == string(pubJWK) {
+		return pubkeyPublishAlreadyCurrent
+	}
+	// A non-empty, DIFFERENT existing value on a Sovereign is the
+	// mothership-injected inbound-handover key — never clobber it.
+	if isSovereign && len(current) > 0 {
+		return pubkeyPublishPreserveInjected
+	}
+	return pubkeyPublishWrite
+}
+
 // publishHandoverPubkey PATCHes the catalyst-handover-jwt-public Secret's
 // public.jwk with the runtime signer's ACTUAL public JWK so off-pod
 // consumers verify session bearers against the same key catalyst-api signs
@@ -2130,6 +2181,11 @@ func env(key, fallback string) string {
 // Secret absent) is logged, never fatal — the handover signer still works
 // in-process; only the published mirror lags. The Secret name/namespace are
 // the chart defaults, overridable via env for non-standard installs.
+//
+// #4450: on a Sovereign the Secret holds the MOTHERSHIP-injected public key
+// (the inbound owner-handover verification key), NOT a mirror of the local
+// signer — so the write is gated by decidePubkeyPublish to preserve it. See
+// that function's doc for the full root-cause.
 func publishHandoverPubkey(ctx context.Context, log *slog.Logger, pubJWK []byte) {
 	cfg, err := rest.InClusterConfig()
 	if err != nil {
@@ -2153,13 +2209,30 @@ func publishHandoverPubkey(ctx context.Context, log *slog.Logger, pubJWK []byte)
 	name := env("CATALYST_HANDOVER_PUBKEY_SECRET_NAME", "catalyst-handover-jwt-public")
 	key := env("CATALYST_HANDOVER_PUBKEY_SECRET_KEY", "public.jwk")
 
-	// Skip the write when the Secret already carries our exact JWK — avoids
-	// a needless write + Reloader bounce on every restart.
+	// A Sovereign always carries SOVEREIGN_FQDN; the mothership / Catalyst-Zero
+	// leaves it empty (see api-deployment.yaml line ~798).
+	isSovereign := strings.TrimSpace(os.Getenv("SOVEREIGN_FQDN")) != ""
+
+	var current []byte
 	if cur, getErr := cs.CoreV1().Secrets(ns).Get(ctx, name, metav1.GetOptions{}); getErr == nil {
-		if existing, ok := cur.Data[key]; ok && string(existing) == string(pubJWK) {
-			log.Info("handoverjwt: published pubkey already current (#4114)", "secret", ns+"/"+name)
-			return
+		if existing, ok := cur.Data[key]; ok {
+			current = existing
 		}
+	}
+
+	switch decidePubkeyPublish(pubJWK, current, isSovereign) {
+	case pubkeyPublishAlreadyCurrent:
+		// Skip the write — avoids a needless write + Reloader bounce on every restart.
+		log.Info("handoverjwt: published pubkey already current (#4114)", "secret", ns+"/"+name)
+		return
+	case pubkeyPublishPreserveInjected:
+		// #4450: preserve the mothership-injected inbound-handover key on a
+		// Sovereign — overwriting it 401's every owner-handover JWT. The local
+		// signer's pubkey reaches openova-mcp via openbao (seedMCPBearer), not
+		// this Secret, so no consumer is regressed.
+		log.Info("handoverjwt: preserving mothership-injected handover pubkey; not publishing local signer key (#4450)",
+			"secret", ns+"/"+name)
+		return
 	}
 
 	// strategic-merge patch on the stringData field — server base64-encodes it.

--- a/products/catalyst/bootstrap/api/cmd/api/main_test.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main_test.go
@@ -209,3 +209,83 @@ func TestRunBakeTimeOwnerSeed_IdempotentReRun(t *testing.T) {
 func silentLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
+
+// TestDecidePubkeyPublish locks the #4450 write guard: on a Sovereign the
+// runtime signer's local pubkey must NEVER overwrite a pre-existing,
+// DIFFERENT key in catalyst-handover-jwt-public (the mothership-injected
+// inbound-handover verification key). On the mothership (SOVEREIGN_FQDN
+// empty) the original #4114 self-heal still applies.
+func TestDecidePubkeyPublish(t *testing.T) {
+	const (
+		localJWK = `{"kty":"RSA","alg":"RS256","n":"wjDc-local","e":"AQAB"}`
+		mothJWK  = `{"kty":"RSA","alg":"RS256","n":"u8Ca-mothership","e":"AQAB"}`
+	)
+	cases := []struct {
+		name        string
+		pubJWK      string
+		current     []byte // nil ⇒ Secret key absent
+		isSovereign bool
+		want        pubkeyPublishDecision
+	}{
+		{
+			// THE #4450 REGRESSION GUARD: Sovereign, Secret already holds the
+			// mothership key, runtime signer is the self-gen local key. Must
+			// PRESERVE the injected key, not overwrite.
+			name:        "sovereign preserves injected mothership key",
+			pubJWK:      localJWK,
+			current:     []byte(mothJWK),
+			isSovereign: true,
+			want:        pubkeyPublishPreserveInjected,
+		},
+		{
+			// Sovereign, Secret empty/absent (no injected key to clobber) —
+			// safe to publish so off-pod consumers have something.
+			name:        "sovereign with empty secret writes",
+			pubJWK:      localJWK,
+			current:     nil,
+			isSovereign: true,
+			want:        pubkeyPublishWrite,
+		},
+		{
+			// Sovereign, Secret already carries our exact JWK — no-op (avoids
+			// Reloader bounce). Should win over the preserve branch.
+			name:        "sovereign already current is no-op",
+			pubJWK:      mothJWK,
+			current:     []byte(mothJWK),
+			isSovereign: true,
+			want:        pubkeyPublishAlreadyCurrent,
+		},
+		{
+			// Mothership / Catalyst-Zero: the Secret IS the local signer's
+			// mirror, so a stale differing value must be overwritten (#4114).
+			name:        "mothership overwrites stale mirror",
+			pubJWK:      localJWK,
+			current:     []byte(`{"kty":"RSA","n":"stale-self","e":"AQAB"}`),
+			isSovereign: false,
+			want:        pubkeyPublishWrite,
+		},
+		{
+			name:        "mothership already current is no-op",
+			pubJWK:      localJWK,
+			current:     []byte(localJWK),
+			isSovereign: false,
+			want:        pubkeyPublishAlreadyCurrent,
+		},
+		{
+			name:        "mothership empty secret writes",
+			pubJWK:      localJWK,
+			current:     nil,
+			isSovereign: false,
+			want:        pubkeyPublishWrite,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decidePubkeyPublish([]byte(tc.pubJWK), tc.current, tc.isSovereign)
+			if got != tc.want {
+				t.Errorf("decidePubkeyPublish(isSovereign=%v, current=%q) = %d, want %d",
+					tc.isSovereign, string(tc.current), got, tc.want)
+			}
+		})
+	}
+}

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -1464,7 +1464,19 @@ spec:
             # CATALYST_HANDOVER_SIGNER_PATH — path to the RS256 PRIVATE
             # key catalyst-api uses to mint magic-link + handover JWTs. The
             # signer auto-generates the keypair on first start if absent.
-            # MUST be on a writable PVC mount. Catalyst-Zero only.
+            # MUST be on a writable PVC mount.
+            #
+            # On a SOVEREIGN this auto-generated keypair is the Sovereign's
+            # OWN local signer (for PIN-auth sessions, locally-minted session
+            # JWTs and Enter-org support tokens). It is a SEPARATE key from the
+            # MOTHERSHIP-injected handover pubkey (catalyst-handover-jwt-public,
+            # seeded by cloud-init) that auth_handover.go verifies inbound owner
+            # handover JWTs against — the mothership never shares its private
+            # key (sovereignty). #4450: cmd/api/main.go's publishHandoverPubkey
+            # MUST NOT overwrite that injected pubkey with this local key on a
+            # Sovereign (it 401'd every owner handover); the local signer's
+            # pubkey reaches openova-mcp via openbao (seedMCPBearer), not this
+            # Secret. See decidePubkeyPublish.
             #
             # NB: env name was CATALYST_HANDOVER_KEY_PATH until 2026-06-03.
             # Renamed because Kyverno cluster-policy


### PR DESCRIPTION
## Problem
On every fresh Sovereign (dep `b9f9590b558262b6`, omantel.biz) the live `catalyst-handover-jwt-public` Secret held a **self-generated** RS256 public key (`n=wjDc…`) instead of the **mothership-injected** key (`n=u8Ca…`) — even though the injected key was present in the deployment's `tofu.auto.tfvars.json` `handover_jwt_public_key` AND in the Secret's `kubectl.kubernetes.io/last-applied-configuration`. A mothership-signed owner-handover JWT therefore 401'd "invalid token" at `/auth/handover`, breaking the canonical zero-login **"Open Sovereign console"** owner flow on every prov.

## Root cause
Three colliding facts:
1. Cloud-init (`infra/providers/_shared/cloudinit-control-plane.tftpl`) seeds `catalyst-handover-jwt-public` (catalyst-system) with the **mothership public key** via `kubectl apply` — the key the inbound owner-handover JWT must verify against (`auth_handover.go` reads it from the Secret-mounted `public.jwk`).
2. The Helm `api-deployment.yaml` (renders on **every Sovereign**) unconditionally sets `CATALYST_HANDOVER_SIGNER_PATH=/var/lib/catalyst/handover-jwt-private.pem` — comment said "Catalyst-Zero only" but there was **no gate**. Cloud-init never seeds a private PEM there, so `handoverjwt.LoadOrGenerate` **self-generates a fresh keypair** (`wjDc…`) for the Sovereign's *local* signer (legit — PIN-auth + locally-minted session + Enter-org tokens; the mothership never shares its private key — sovereignty).
3. `cmd/api/main.go` then calls `publishHandoverPubkey` (#4114), which **PATCHed `catalyst-handover-jwt-public` with the local signer's pubkey** — clobbering the mothership's `u8Ca…` with `wjDc…`. The per-boot PATCH wins on every restart.

The two keys are **legitimately different**; #4114 wrongly forced both into one Secret key.

The #4114 consumer (agenity openova-mcp) no longer depends on this Secret for its production path — `seedMCPBearer` derives the verify-pubkey straight from `h.handoverSigner.PublicRSAKey()` into openbao (`secret/catalyst/agenity/<slug>/mcp-bearer`); the Secret-mount is an `optional:true` fallback (#4228). So preserving the mothership key here does **not** regress openova-mcp.

## Fix (zero-touch)
`publishHandoverPubkey` is gated by a new pure helper `decidePubkeyPublish`:
- **Sovereign** (`SOVEREIGN_FQDN` set) + Secret already holds a **different** value ⇒ that is the mothership-injected inbound-handover key ⇒ **preserve it** (don't publish the local key). The injected key wins; mothership-signed owner JWT verifies again.
- Sovereign + Secret empty/absent ⇒ safe to write.
- Mothership (`SOVEREIGN_FQDN` empty) ⇒ Secret IS the local signer's mirror ⇒ original #4114 self-heal still overwrites when stale.
- Already-current ⇒ no-op (no Reloader bounce).

Also corrects the misleading "Catalyst-Zero only" chart comment.

## Proof
- `go build ./cmd/api/` clean, `go vet` clean, `gofmt -l` clean.
- New 6-case table test `TestDecidePubkeyPublish` — incl. the regression guard `sovereign preserves injected mothership key` — PASS.
- `go test ./cmd/api/ ./internal/handler/ ./internal/handoverjwt/` all green.
- `helm template` of `api-deployment.yaml` renders cleanly; env block unchanged (comment-only chart edit).

## Delivery
**Image-baked, no mothership roll.** The fix is in the catalyst-api Go binary; on merge, CI `catalyst-build.yaml` (triggers on `products/catalyst/bootstrap/**`) builds a new image, auto-bumps `images.catalystApi.tag` + `Chart.yaml` patch version, Blueprint Release re-publishes the `bp-catalyst-platform` OCI chart, and Flux rolls every Sovereign. Chart version is **not** hand-bumped here (CI owns it — a manual bump would collide).

## Live verification (pending env recovery)
omantel.biz dep `b9f9590b558262b6` is mid EIP self-heal at filing time. Once the bumped image rolls: confirm `catalyst-handover-jwt-public/public.jwk` retains `n=u8Ca…`, mint a mothership-signed owner-handover JWT, hit `/auth/handover?token=…` → expect 302 to `/dashboard` (not 401).

Refs #4450 #4290