### PR TITLE
fix(catalyst-api): janitor orphan-sweep no longer reaps its own converged Sovereign (P0 #4454)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/janitor.go
+++ b/products/catalyst/bootstrap/api/internal/handler/janitor.go
@@ -390,6 +390,54 @@ func (h *Handler) cleanOrphanKubeconfigs(activeIDs map[string]struct{}) int {
 	return deleted
 }
 
+// buildActivePrefixes returns the set of 8-char deployment-ID prefixes
+// whose cloud infra (EIP / keypair / VPC) the orphan sweeps MUST NOT
+// reclaim. Shared by all three sweeps (EIPs / keypairs / VPCs).
+//
+// #4454 — FAIL-SAFE INVERSION. The earlier design was an ALLOWLIST that
+// protected only in-flight statuses (pending … phase1-watching, wiping)
+// and deliberately left ready/failed/wiped/adopted reclaimable. That
+// fails OPEN: the instant a fresh Sovereign flips to `ready` its prefix
+// dropped out of the protected set and its catalyst-<prefix>-* EIP /
+// keypair / VPC-peering / VPC were reaped as "orphans," cascading the
+// node deletion. On dep b9f9590b (omantel.biz) all 12 ECS nodes went
+// DELETED in a 1-second window ~2.5 min after convergence.
+//
+// We now PROTECT BY DEFAULT and exclude ONLY genuinely-wiped records.
+// A `wiped` record SHOULD have no cloud infra, so anything still bearing
+// its prefix is a true leak and stays sweep-eligible. EVERY other status
+// — pending … phase1-watching, ready, adopted, cutover-running,
+// cutover-complete, failed, AND any status added in the future —
+// protects its prefix. A future-added status therefore fails SAFE
+// (protected), not OPEN (reaped). `failed` is protected too, honouring
+// DEBUG-BEFORE-WIPE: never reap infra we may still need to forensically
+// read.
+func (h *Handler) buildActivePrefixes() map[string]struct{} {
+	activePrefixes := map[string]struct{}{}
+	h.deployments.Range(func(_, val any) bool {
+		dep, ok := val.(*Deployment)
+		if !ok || dep == nil {
+			return true
+		}
+		dep.mu.Lock()
+		st := dep.Status
+		id := dep.ID
+		dep.mu.Unlock()
+		switch st {
+		case "wiped":
+			// A wiped record SHOULD have no cloud infra; anything left
+			// is a genuine leak → eligible for the sweep. Do NOT protect.
+		default:
+			// ANY non-wiped record protects its prefix (fail-safe).
+			if len(id) >= 8 {
+				activePrefixes[id[:8]] = struct{}{}
+			}
+		}
+		return true
+	})
+	return activePrefixes
+}
+
 // cleanOrphanEIPsHuawei walks the per-deployment tfvars files on the
 // PVC to find a working set of huawei creds (any active deployment's
 // AK/SK/project_id/region), then calls huawei.Provider.SweepOrphanEIPs
@@ -462,34 +510,10 @@ func (h *Handler) cleanOrphanEIPsHuawei(tofuWorkDir string, activeIDs map[string
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
-	// G16 (Refs #2555): protect ONLY in-flight deployments. G15's first
-	// cut used activeIDs (every record on disk), which meant a FAILED
-	// deployment's EIPs were "skipped" forever because its record was
-	// still in the set. Result: hw43+hw44 failed deployments' EIPs
-	// piled up to project quota, starving the next prov.
-	// In-flight statuses (must protect): pending, provisioning,
-	// tofu-applying, flux-bootstrapping, phase1-watching, wiping.
-	// Terminal statuses (let janitor reclaim): ready (bound EIPs won't
-	// match orphan criteria anyway), failed, wiped, adopted.
-	activePrefixes := map[string]struct{}{}
-	h.deployments.Range(func(_, val any) bool {
-		dep, ok := val.(*Deployment)
-		if !ok || dep == nil {
-			return true
-		}
-		dep.mu.Lock()
-		st := dep.Status
-		id := dep.ID
-		dep.mu.Unlock()
-		switch st {
-		case "pending", "provisioning", "tofu-applying",
-			"flux-bootstrapping", "phase1-watching", "wiping":
-			if len(id) >= 8 {
-				activePrefixes[id[:8]] = struct{}{}
-			}
-		}
-		return true
-	})
+	// #4454: protect by DEFAULT (every non-wiped record), reclaim ONLY
+	// genuinely-wiped records' leaked infra. See buildActivePrefixes for
+	// the fail-safe-inversion rationale (the b9f9590b self-destruct).
+	activePrefixes := h.buildActivePrefixes()
 	deleted, err := hp.SweepOrphanEIPs(ctx, ak, sk, projectID, region, activePrefixes, func(msg string) {
 		h.log.Info("[JANITOR] " + msg)
 	})
@@ -510,11 +534,10 @@ func (h *Handler) cleanOrphanEIPsHuawei(tofuWorkDir string, activeIDs map[string
 // `tofu.auto.tfvars.json` carrying huawei creds, then calls
 // `huawei.Provider.SweepOrphanKeypairs` for the project-wide sweep.
 //
-// Same in-flight protection scheme as cleanOrphanEIPsHuawei: only
-// statuses `pending` / `provisioning` / `tofu-applying` /
-// `flux-bootstrapping` / `phase1-watching` / `wiping` mark a
-// deployment's 8-char ID prefix as protected. Terminal statuses
-// (ready / failed / wiped / adopted) leave their keypairs reclaimable.
+// Same fail-safe protection scheme as cleanOrphanEIPsHuawei (#4454):
+// buildActivePrefixes protects EVERY non-`wiped` record's 8-char ID
+// prefix. Only a `wiped` record (which SHOULD have no cloud infra) leaves
+// its keypairs reclaimable.
 func (h *Handler) cleanOrphanKeypairsHuawei(tofuWorkDir string, activeIDs map[string]struct{}) int {
 	if tofuWorkDir == "" {
 		return 0
@@ -567,25 +590,9 @@ func (h *Handler) cleanOrphanKeypairsHuawei(tofuWorkDir string, activeIDs map[st
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
-	activePrefixes := map[string]struct{}{}
-	h.deployments.Range(func(_, val any) bool {
-		dep, ok := val.(*Deployment)
-		if !ok || dep == nil {
-			return true
-		}
-		dep.mu.Lock()
-		st := dep.Status
-		id := dep.ID
-		dep.mu.Unlock()
-		switch st {
-		case "pending", "provisioning", "tofu-applying",
-			"flux-bootstrapping", "phase1-watching", "wiping":
-			if len(id) >= 8 {
-				activePrefixes[id[:8]] = struct{}{}
-			}
-		}
-		return true
-	})
+	// #4454: protect by DEFAULT (every non-wiped record). See
+	// buildActivePrefixes for the fail-safe-inversion rationale.
+	activePrefixes := h.buildActivePrefixes()
 	deleted, err := hp.SweepOrphanKeypairs(ctx, ak, sk, projectID, region, activePrefixes, func(msg string) {
 		h.log.Info("[JANITOR] " + msg)
 	})
@@ -606,12 +613,10 @@ func (h *Handler) cleanOrphanKeypairsHuawei(tofuWorkDir string, activeIDs map[st
 // "project at 5/5 VPCs". This sweep is the missing reclaim path: EIPs
 // and keypairs already had one, VPCs did not.
 //
-// Same in-flight protection scheme as its siblings: only statuses
-// pending / provisioning / tofu-applying / flux-bootstrapping /
-// phase1-watching / wiping mark a deployment's 8-char ID prefix as
-// protected. Terminal statuses (ready / failed / wiped / adopted) leave
-// their VPCs reclaimable. Bastion / non-catalyst VPCs are hard-protected
-// in SweepOrphanVPCs itself.
+// Same fail-safe protection scheme as its siblings (#4454):
+// buildActivePrefixes protects EVERY non-`wiped` record's 8-char ID
+// prefix; only a `wiped` record leaves its VPCs reclaimable. Bastion /
+// non-catalyst VPCs are hard-protected in SweepOrphanVPCs itself.
 func (h *Handler) cleanOrphanVPCsHuawei(tofuWorkDir string, activeIDs map[string]struct{}) int {
 	if tofuWorkDir == "" {
 		return 0
@@ -667,25 +672,9 @@ func (h *Handler) cleanOrphanVPCsHuawei(tofuWorkDir string, activeIDs map[string
 	// wider budget than the 2-minute sibling sweeps.
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
-	activePrefixes := map[string]struct{}{}
-	h.deployments.Range(func(_, val any) bool {
-		dep, ok := val.(*Deployment)
-		if !ok || dep == nil {
-			return true
-		}
-		dep.mu.Lock()
-		st := dep.Status
-		id := dep.ID
-		dep.mu.Unlock()
-		switch st {
-		case "pending", "provisioning", "tofu-applying",
-			"flux-bootstrapping", "phase1-watching", "wiping":
-			if len(id) >= 8 {
-				activePrefixes[id[:8]] = struct{}{}
-			}
-		}
-		return true
-	})
+	// #4454: protect by DEFAULT (every non-wiped record). See
+	// buildActivePrefixes for the fail-safe-inversion rationale.
+	activePrefixes := h.buildActivePrefixes()
 	deleted, err := hp.SweepOrphanVPCs(ctx, ak, sk, projectID, region, activePrefixes, func(msg string) {
 		h.log.Info("[JANITOR] " + msg)
 	})

--- a/products/catalyst/bootstrap/api/internal/handler/janitor_reap_protection_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/janitor_reap_protection_test.go
@@ -1,0 +1,97 @@
+package handler
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+)
+
+// TestBuildActivePrefixes_ProtectsEveryNonWipedStatus — #4454 regression.
+//
+// The orphan sweeps (EIP / keypair / VPC) reclaim cloud infra whose
+// 8-char deployment-ID prefix is NOT in buildActivePrefixes's protected
+// set. The original ALLOWLIST protected only in-flight statuses and left
+// `ready` (and failed / adopted / cutover-*) reclaimable — so the instant
+// a fresh Sovereign flipped to `ready` the janitor reaped its EIP /
+// keypair / VPC-peering / VPC and cascaded the node deletion (dep
+// b9f9590b, omantel.biz: all 12 ECS nodes DELETED ~2.5 min after
+// convergence).
+//
+// The fix is a DENYLIST: protect every non-`wiped` record (fail-safe),
+// reclaim ONLY genuinely-wiped records' leaked infra. This test asserts
+// that contract for one record in EACH status, with `ready` (the exact
+// production failure) called out explicitly. It FAILS on the old
+// allowlist code (ready/failed/adopted/cutover-* unprotected) and PASSES
+// on the inverted code.
+func TestBuildActivePrefixes_ProtectsEveryNonWipedStatus(t *testing.T) {
+	h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	// One record per status. IDs are distinct 16-hex so their 8-char
+	// prefixes don't collide — each prefix's presence/absence is a clean
+	// per-status signal.
+	type rec struct {
+		id        string
+		status    string
+		protected bool // expected: should this prefix be in the set?
+	}
+	records := []rec{
+		{"a0000000pending1", "pending", true},
+		{"a1111111provisn1", "provisioning", true},
+		{"a2222222tofuappl", "tofu-applying", true},
+		{"a3333333fluxboot", "flux-bootstrapping", true},
+		{"a4444444phase1wt", "phase1-watching", true},
+		{"a5555555readydep", "ready", true}, // the exact b9f9590b production failure
+		{"a6666666adopted1", "adopted", true},
+		{"a7777777cutoverr", "cutover-running", true},
+		{"a8888888cutoverc", "cutover-complete", true},
+		{"a9999999faileddp", "failed", true}, // DEBUG-BEFORE-WIPE: protect failed infra
+		{"aaaaaaaawipingdp", "wiping", true},
+		{"abbbbbbbwipeddpx", "wiped", false}, // wiped → reclaimable
+	}
+
+	for _, r := range records {
+		h.deployments.Store(r.id, &Deployment{ID: r.id, Status: r.status})
+	}
+
+	got := h.buildActivePrefixes()
+
+	for _, r := range records {
+		prefix := r.id[:8]
+		_, inSet := got[prefix]
+		if r.protected && !inSet {
+			t.Errorf("status %q (id %s): prefix %q MUST be protected but was reclaimable — its cloud infra would be reaped",
+				r.status, r.id, prefix)
+		}
+		if !r.protected && inSet {
+			t.Errorf("status %q (id %s): prefix %q should be reclaimable but was protected",
+				r.status, r.id, prefix)
+		}
+	}
+
+	// Explicit, named assertion on the exact production failure so a
+	// regression here reads unambiguously in CI output.
+	if _, ok := got["a5555555"]; !ok {
+		t.Fatalf("REGRESSION #4454: a `ready` deployment's prefix is NOT protected — the janitor will reap its EIP/keypair/VPC and self-destruct the fresh Sovereign ~2.5 min after convergence")
+	}
+
+	// And the inverse: a wiped record must NOT pin its (already-gone)
+	// infra, otherwise genuine leaks accumulate to project quota.
+	if _, ok := got["abbbbbbb"]; ok {
+		t.Fatalf("a `wiped` deployment's prefix is protected — genuine leaked infra would never be reclaimed, piling up against the project quota")
+	}
+}
+
+// TestBuildActivePrefixes_UnknownFutureStatusFailsSafe — #4454. The whole
+// point of the inversion is that a status nobody has added yet still
+// protects its infra. Assert a made-up future status is protected (fails
+// SAFE), so the next state added to the lifecycle can never silently
+// reintroduce the self-destruct.
+func TestBuildActivePrefixes_UnknownFutureStatusFailsSafe(t *testing.T) {
+	h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	h.deployments.Store("deadbeeffuturex", &Deployment{ID: "deadbeeffuturex", Status: "some-future-status-2027"})
+
+	got := h.buildActivePrefixes()
+	if _, ok := got["deadbeef"]; !ok {
+		t.Fatalf("an unrecognised future status was NOT protected — the inversion must fail SAFE so a new lifecycle state can't reintroduce the b9f9590b self-destruct")
+	}
+}


### PR DESCRIPTION
## Fault

The catalyst-api orphan-sweep janitor REAPED its own converged deployments, self-destructing every fresh Sovereign ~2.5 min after it reached `status: ready`. On dep `b9f9590b` (omantel.biz) all 12 ECS nodes went `DELETED` in a 1-second window at 10:48:03Z, 2.5 min after convergence (10:45:40Z); apiserver EIPs released; 283 EVS orphaned.

## Root cause

The three cloud-resource sweep functions (`cleanOrphanEIPsHuawei`, `cleanOrphanKeypairsHuawei`, `cleanOrphanVPCsHuawei`) each built their protected `activePrefixes` set from an **ALLOWLIST** of in-flight statuses:

```go
case "pending", "provisioning", "tofu-applying",
    "flux-bootstrapping", "phase1-watching", "wiping":
    activePrefixes[id[:8]] = struct{}{}
```

`"ready"` was missing (so were `"adopted"`, `"cutover-running"`, `"cutover-complete"`, `"failed"`). The instant a dep flipped to `ready`, its 8-char prefix dropped out of the protected set and its `catalyst-…-<prefix>-*` EIP / keypair / VPC-peering / VPC were reaped as "orphans," cascading the node deletion. The design failed **OPEN**.

## Fix — fail-safe INVERSION

Extracted a single `buildActivePrefixes` helper (called by all three sweeps) that uses a **DENYLIST**: protect every deployment by default, exclude ONLY genuinely-`wiped` records (which should have no cloud infra — anything left is a true leak).

```go
switch st {
case "wiped":
    // genuine leak → eligible for the sweep. Do NOT protect.
default:
    // ANY non-wiped record protects its prefix (fail-safe).
    if len(id) >= 8 {
        activePrefixes[id[:8]] = struct{}{}
    }
}
```

A future-added status now fails **SAFE** (protected), not OPEN (reaped). `failed` is protected too, honouring DEBUG-BEFORE-WIPE.

## Regression test

`janitor_reap_protection_test.go` builds a fake deployment list with one record in each status (`pending`, `provisioning`, `ready`, `adopted`, `cutover-running`, `cutover-complete`, `failed`, `wiped`, plus an unknown future status) and asserts every non-`wiped` status protects its prefix — with the `ready` case asserted explicitly (the exact production failure). Verified:
- PASSES on the inverted code.
- FAILS on the old allowlist (negative control — the `ready`/`adopted`/`cutover-*`/`failed` cases and the future-status case all fire).

`go build ./...` + `go vet ./internal/handler/...` clean.

## Ship note

This is a catalyst-api (mothership-image) change — it does not roll until the mothership re-rolls the image. No live env / bastion / mothership touched. The live proof (a fresh prov that SURVIVES convergence) comes on the re-prov, not merge-gated.

Refs #4454

🤖 Generated with [Claude Code](https://claude.com/claude-code)