### PR TITLE
fix(bp-sso-bridge): CNP egress names openbao+keycloak+dns — the EGRESS half of #4449 (Cilium reserved-identity trap) (0.2.24)

### DIFF
--- a/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
+++ b/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
@@ -161,7 +161,16 @@ spec:
       #   re-homes the stale `mgmt` keycloak/openbao egress NetworkPolicy
       #   namespaces back to host ns keycloak/openbao (post-#4325/#4347).
       #   Refs #4437 #4347 #4325.
-      version: 0.2.23
+      # 0.2.24 (#4458): EGRESS half of the #4448/#4449 sso-bridge↔openbao gap.
+      #   The sso-bridge-reconciler-apiserver CiliumNetworkPolicy attaches an
+      #   egress rule → the reconciler endpoint becomes CNP-ENFORCED egress, so
+      #   the sibling K8s-NP openbao/keycloak/DNS egress allow is INERT (Cilium
+      #   reserved-identity supersession, same class as 0.2.7/#2861). Pre-fix the
+      #   CNP listed ONLY kube-apiserver → openbao:8200 + keycloak:8080 dials
+      #   policy-dropped → `no OpenBao token` every tick → grafana/hubble 503,
+      #   gitea 500. Fix: CNP egress now also names kube-dns + keycloak + openbao.
+      #   #4449 fixed the INGRESS side; this is the EGRESS side. Refs #4458 #4449.
+      version: 0.2.24
       sourceRef:
         kind: HelmRepository
         name: bp-sso-bridge

--- a/platform/sso-bridge/blueprint.yaml
+++ b/platform/sso-bridge/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.23
+  version: 0.2.24
   card:
     title: sso-bridge
     summary: |

--- a/platform/sso-bridge/chart/Chart.yaml
+++ b/platform/sso-bridge/chart/Chart.yaml
@@ -1,6 +1,26 @@
 apiVersion: v2
 name: bp-sso-bridge
-version: 0.2.23
+version: 0.2.24
+# 0.2.24 (#4458, 2026-06-26): EGRESS half of the #4448/#4449 sso-bridge↔openbao
+# netpol gap. THE CILIUM TRAP: the `sso-bridge-reconciler-apiserver`
+# CiliumNetworkPolicy attaches an egress rule to the reconciler endpoint, which
+# flips the endpoint to CNP-ENFORCED egress (Cilium default-deny) and renders
+# the sibling K8s `NetworkPolicy/bp-sso-bridge` egress allow-list (DNS, keycloak,
+# openbao) INERT — a plain K8s-NP `to openbao:8200` cannot override a CNP that
+# does not also name openbao (reserved-identity supersession, same class as
+# 0.2.7/#2861 ipBlock-excludes-kube-apiserver + openclaw #4401 JWKS-egress).
+# Pre-0.2.24 the CNP egress listed ONLY kube-apiserver, so the reconciler's
+# `openbao.openbao.svc:8200` + `keycloak.keycloak.svc:8080` dials were silently
+# policy-dropped at the Cilium datapath: `no OpenBao token` every tick, NO
+# `secret/sso/*` bundle written, grafana/hubble 503 + gitea 500 (their SSO secret
+# never seeded). §6's UAT walk caught the live failure; ade30ccb's #4449 note
+# ("sso-bridge's OWN egress NetworkPolicy already permits openbao:8200") was true
+# about the K8s-NP literal content but moot — the CNP supersedes it. Fix: the CNP
+# egress now ALSO names kube-dns (name-resolution must survive CNP enforcement),
+# keycloak, and openbao, keyed off the SAME `networkPolicy.*` namespace/port knobs
+# the K8s NetworkPolicy uses so the two stay in lockstep + overlay-tunable. New
+# chart test 4458-egress-cnp-openbao.sh guards the openbao egress entry. Refs
+# #4458 #4449 #4448 #4437 #4347 #4325.
 # 0.2.23 (#4437, 2026-06-26): re-read the keycloak credentials Secret EACH
 # TICK so a reflected `addr`/`client-secret` change is picked up without a
 # pod roll — the permanent fix for grafana (et al) 503 on omantel.biz.

--- a/platform/sso-bridge/chart/templates/cilium-networkpolicy-apiserver.yaml
+++ b/platform/sso-bridge/chart/templates/cilium-networkpolicy-apiserver.yaml
@@ -15,6 +15,31 @@ CiliumNetworkPolicy toEntities is the canonical expression. Gated on
 the cilium.io/v2 Capabilities check (the #2988 idiom) so the chart
 still installs on CRD-less clusters (kind CI) where the K8s
 NetworkPolicy below is not enforced by an identity-aware agent anyway.
+
+0.2.24 (#4458 — the EGRESS half of the #4448/#4449 sso-bridge↔openbao
+netpol gap): THE CILIUM TRAP. The moment THIS CiliumNetworkPolicy
+attaches ANY egress rule to the reconciler endpoint, that endpoint's
+egress becomes CNP-ENFORCED (Cilium default-deny on the endpoint), and
+EVERY rule in the sibling K8s `NetworkPolicy/bp-sso-bridge` egress
+allow-list (DNS, keycloak, openbao) is rendered INERT — a plain
+K8s-NetworkPolicy `to openbao:8200` cannot override a CNP that does not
+name openbao (same reserved-identity supersession class as 0.2.7/#2861
+where ipBlock 0.0.0.0/0 excluded kube-apiserver, and openclaw #4401
+where a CNP egress had to add `toEntities:[world]` to un-block the JWKS
+fetch a K8s-NP ipBlock could no longer reach). So the pre-0.2.24 CNP —
+listing ONLY kube-apiserver — silently policy-DROPPED the reconciler's
+`openbao.openbao.svc:8200` + `keycloak.keycloak.svc:8080` dials at the
+Cilium datapath: every tick logged `no OpenBao token` / `mint Keycloak
+admin token` curl(28), NO `secret/sso/*` bundle was written, and
+grafana/hubble/gitea wedged at 503/500 with their SSO secret never
+seeded. This was the live failure §6's UAT walk caught; ade30ccb's
+#4449 note ("sso-bridge's OWN egress NetworkPolicy already permits
+openbao:8200") was true about the K8s-NP's literal content but moot —
+the CNP supersedes it. Fix: this CNP egress now ALSO names kube-dns
+(so name-resolution survives CNP enforcement), keycloak, and openbao,
+keyed off the SAME `.Values.networkPolicy.*` namespace/port knobs the
+K8s NetworkPolicy uses so the two stay in lockstep + overlay-tunable.
+Refs #4458 #4449 #4448 #4437 #4347 #4325.
 */ -}}
 {{- if and .Values.networkPolicy.enabled (.Capabilities.APIVersions.Has "cilium.io/v2") }}
 apiVersion: cilium.io/v2
@@ -31,6 +56,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: sso-bridge-reconciler
   egress:
+    # Kubernetes apiserver — list HRs cluster-wide, write ExternalSecret CRs.
     - toEntities:
         - kube-apiserver
       toPorts:
@@ -38,5 +64,43 @@ spec:
             - port: "6443"
               protocol: TCP
             - port: "443"
+              protocol: TCP
+    # Cluster DNS — once this CNP enforces egress, the K8s-NP kube-dns
+    # allow is inert too, so name-resolution MUST be re-stated here or the
+    # reconciler can no longer resolve keycloak/openbao Service names.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    # Keycloak admin endpoint — mirrors the K8s-NP keycloak egress
+    # (Service port + Pod target port 8080; Cilium enforces on the Pod
+    # target port — the 0.2.6/#2744 finding). Namespace + port from the
+    # SAME networkPolicy.keycloak* knobs so a per-Sovereign overlay that
+    # re-homes keycloak (e.g. into a vCluster `mgmt` ns) re-points BOTH
+    # the K8s NP and this CNP in one place.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: {{ .Values.networkPolicy.keycloakNamespace }}
+      toPorts:
+        - ports:
+            - port: {{ .Values.networkPolicy.keycloakPort | quote }}
+              protocol: TCP
+            - port: "8080"
+              protocol: TCP
+    # OpenBao admin endpoint — the gap §6 caught. Mirror of the K8s-NP
+    # openbao egress, keyed off networkPolicy.openbao* so it tracks any
+    # overlay relocation of openbao alongside the K8s NP.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: {{ .Values.networkPolicy.openbaoNamespace }}
+      toPorts:
+        - ports:
+            - port: {{ .Values.networkPolicy.openbaoPort | quote }}
               protocol: TCP
 {{- end }}

--- a/platform/sso-bridge/chart/tests/4458-egress-cnp-openbao.sh
+++ b/platform/sso-bridge/chart/tests/4458-egress-cnp-openbao.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# bp-sso-bridge — #4458 egress-CNP openbao/keycloak/DNS contract guard.
+#
+# THE CILIUM TRAP this guards against:
+#   The sibling K8s `NetworkPolicy/bp-sso-bridge` egress block names
+#   openbao:8200 + keycloak:8080 + kube-dns. BUT the
+#   `sso-bridge-reconciler-apiserver` CiliumNetworkPolicy attaches an
+#   egress rule to the SAME reconciler endpoint — which flips the
+#   endpoint to CNP-ENFORCED egress (Cilium default-deny), rendering the
+#   ENTIRE K8s-NP egress allow-list INERT (reserved-identity supersession,
+#   same class as 0.2.7/#2861 ipBlock-excludes-kube-apiserver + openclaw
+#   #4401 JWKS-egress). So the openbao/keycloak/DNS allows MUST be
+#   re-stated on the CNP itself, or the reconciler's
+#   `openbao.openbao.svc:8200` + `keycloak.keycloak.svc:8080` dials are
+#   silently policy-dropped → `no OpenBao token` every tick → grafana/
+#   hubble 503 + gitea 500 (their SSO secret never seeded).
+#
+# This script asserts the rendered CNP egress (the cilium.io/v2 render,
+# triggered via --api-versions) names:
+#   (1) kube-apiserver  (pre-existing apiserver hop — must NOT regress)
+#   (2) kube-dns        (name-resolution must survive CNP enforcement)
+#   (3) the openbao namespace on the openbao port
+#   (4) the keycloak namespace on the keycloak Pod target port 8080
+# and that the openbao/keycloak namespace + port track the SAME
+# networkPolicy.* knobs the K8s NetworkPolicy uses (overlay lockstep).
+#
+# Usage: bash tests/4458-egress-cnp-openbao.sh [CHART_DIR]
+
+set -euo pipefail
+
+CHART_DIR="$(cd "${1:-$(dirname "$0")/..}" && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+helm="${HELM_BIN:-helm}"
+
+CNP_NAME="sso-bridge-reconciler-apiserver"
+
+# Render WITH the cilium.io/v2 CRD capability so the CNP template fires.
+render() {
+  "$helm" template smoke "$CHART_DIR" \
+    --api-versions "cilium.io/v2" \
+    "$@" 2>/dev/null
+}
+
+# Extract the CiliumNetworkPolicy doc from a multi-doc render: print from
+# the `kind: CiliumNetworkPolicy` line up to the next doc separator. The
+# chart renders exactly one CNP, named $CNP_NAME (asserted in Case 1).
+extract_cnp() {
+  awk '/^kind: CiliumNetworkPolicy/{f=1} f&&/^---/{exit} f{print}' "$1"
+}
+
+# ── Case 1: default render — CNP egress names all four destinations ──────
+render > "$TMP/default.yaml"
+extract_cnp "$TMP/default.yaml" > "$TMP/cnp.yaml"
+
+if ! grep -q "kind: CiliumNetworkPolicy" "$TMP/cnp.yaml"; then
+  echo "FAIL: CiliumNetworkPolicy/$CNP_NAME did not render with --api-versions cilium.io/v2" >&2
+  exit 1
+fi
+
+assert_in_cnp() {
+  local needle="$1" why="$2"
+  if ! grep -qF "$needle" "$TMP/cnp.yaml"; then
+    echo "FAIL: CNP/$CNP_NAME egress missing: $needle" >&2
+    echo "      ($why)" >&2
+    echo "      Without it, the K8s-NP allow is INERT (Cilium CNP-enforced egress" >&2
+    echo "      supersession, #4458) and the reconciler dial is policy-dropped." >&2
+    echo "--- rendered CNP ---" >&2
+    cat "$TMP/cnp.yaml" >&2
+    exit 1
+  fi
+}
+
+# kube-apiserver hop must NOT regress.
+assert_in_cnp "kube-apiserver"  "apiserver egress — pre-existing, must not regress"
+# DNS must survive CNP enforcement.
+assert_in_cnp "k8s-app: kube-dns" "kube-dns egress — name-resolution under CNP-enforced egress"
+# openbao + keycloak namespaces (default knobs).
+assert_in_cnp "k8s:io.kubernetes.pod.namespace: openbao"  "openbao egress — the §6 gap (#4458)"
+assert_in_cnp "k8s:io.kubernetes.pod.namespace: keycloak" "keycloak egress — same trap as openbao"
+# openbao port (default 8200) + keycloak Pod target port 8080.
+assert_in_cnp 'port: "8200"' "openbao port 8200"
+assert_in_cnp 'port: "8080"' "keycloak Pod target port 8080 (Cilium enforces target port — 0.2.6/#2744)"
+
+# ── Case 2: namespace knobs flow into the CNP (overlay lockstep) ─────────
+# A per-Sovereign overlay re-homing openbao/keycloak (e.g. into a vCluster
+# `mgmt` ns) must re-point the CNP too — not just the K8s NP.
+render \
+  --set networkPolicy.openbaoNamespace=mgmt \
+  --set networkPolicy.keycloakNamespace=mgmt \
+  > "$TMP/override.yaml"
+extract_cnp "$TMP/override.yaml" > "$TMP/cnp-override.yaml"
+
+if ! grep -qF "k8s:io.kubernetes.pod.namespace: mgmt" "$TMP/cnp-override.yaml"; then
+  echo "FAIL: CNP egress does not track networkPolicy.{openbao,keycloak}Namespace override" >&2
+  echo "      Overlay re-homed openbao/keycloak to 'mgmt' but the CNP still names the default ns." >&2
+  echo "      The K8s NP and this CNP MUST move in lockstep, else the trap re-opens on the overlay." >&2
+  exit 1
+fi
+
+echo "PASS: #4458 egress-CNP openbao/keycloak/dns contract"
+echo "      CNP names kube-apiserver + kube-dns + openbao:8200 + keycloak:8080,"
+echo "      and tracks the networkPolicy.* namespace knobs in lockstep with the K8s NP."


### PR DESCRIPTION
## What

The EGRESS half of the #4448/#4449 sso-bridge↔openbao netpol gap that §6's UAT walk caught on the fresh prov. #4449 fixed the INGRESS side (added `sso-bridge` to openbao-default-deny's `allowIngressFrom`). This PR fixes the EGRESS side.

## Reconciliation of the two conflicting claims (the task)

Two policies select the SAME endpoint (`app.kubernetes.io/name: sso-bridge-reconciler`):

| Policy | File | openbao:8200 egress? |
|---|---|---|
| K8s `NetworkPolicy/bp-sso-bridge` | `platform/sso-bridge/chart/templates/networkpolicy.yaml` (L110-117) | YES (literal allow) |
| `CiliumNetworkPolicy/sso-bridge-reconciler-apiserver` | `platform/sso-bridge/chart/templates/cilium-networkpolicy-apiserver.yaml` | NO (only `toEntities:[kube-apiserver]`) |

**THE CILIUM TRAP** (same class as 0.2.7/#2861 where `ipBlock 0.0.0.0/0` excluded kube-apiserver, and openclaw #4401 JWKS-egress): the moment a CNP attaches ANY egress rule to an endpoint, that endpoint's egress becomes CNP-ENFORCED (Cilium default-deny), and the entire sibling K8s-NetworkPolicy egress allow-list (DNS, keycloak, openbao) is rendered **INERT**. A plain K8s-NP `to openbao:8200` cannot override a CNP that does not also name openbao (reserved-identity supersession).

So pre-fix, the reconciler's `openbao.openbao.svc:8200` + `keycloak.keycloak.svc:8080` dials were silently policy-dropped at the Cilium datapath → `no OpenBao token` every tick → NO `secret/sso/*` bundle written → grafana/hubble 503, gitea 500.

**Both observations were correct and do NOT contradict:**
- §6 (the UAT walker) is right about the live failure — the reconciler genuinely times out to openbao.
- ade30ccb (#4449 author) is right that the K8s-NP literally permits openbao:8200 — but that allow is moot because the CNP supersedes the NP.

The CNP — not the K8s NP — is the load-bearing egress policy here.

## Fix

Extend the `sso-bridge-reconciler-apiserver` CNP egress to ALSO name:
- `kube-dns` (name-resolution must survive CNP-enforced egress)
- keycloak namespace on Service port + Pod target port 8080
- openbao namespace on port 8200

All keyed off the SAME `.Values.networkPolicy.{keycloak,openbao}Namespace/Port` knobs the K8s NetworkPolicy already uses, so a per-Sovereign overlay that re-homes keycloak/openbao (e.g. into a vCluster `mgmt` ns) re-points BOTH policies in one place.

## Lockstep + tests

- Chart `0.2.23` → `0.2.24`; bootstrap-kit slot 13b pin bumped in lockstep (`scripts/check-bootstrap-kit-pin-sync.sh` green).
- New contract test `tests/4458-egress-cnp-openbao.sh` asserts the CNP egress names kube-apiserver + kube-dns + openbao:8200 + keycloak:8080 and tracks the namespace knobs. **Verified it FAILS on the pre-fix CNP and PASSES on the fixed one.**
- All 9 existing sso-bridge chart tests pass; `helm lint` clean.
- CNP stays CRD-capability-gated (`cilium.io/v2`) so kind CI default render is unchanged (CNP absent, K8s NP present).

Refs #4458 #4449 #4448 #4437 #4347 #4325

🤖 Generated with [Claude Code](https://claude.com/claude-code)
