### PR TITLE
fix(org-controller): cascade-delete per-Org tenant-networking on Org-CR delete (#4459)

### DIFF
--- a/core/controllers/organization/internal/controller/organization_controller.go
+++ b/core/controllers/organization/internal/controller/organization_controller.go
@@ -353,6 +353,38 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			log.Error(err, "per-org-flux teardown")
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
+		// Per-Org tenant-networking teardown (#4459). The console Gateway
+		// listener pair, the per-Org wildcard Certificate (+ its TLS Secret),
+		// the per-Org console HTTPRoute, and the central-PowerDNS pool
+		// A-records the up-path created all live OUTSIDE the Flux-pruned
+		// `<slug>` namespace (the listener is on the SHARED console Gateway in
+		// kube-system; the Certificate is in kube-system; the HTTPRoute is in
+		// catalyst-system; the DNS records are off-cluster) and carry NO
+		// ownerRef the GC follows — so without an explicit teardown they leak
+		// on every Org delete (dead listeners ACCUMULATE on the shared
+		// Gateway; a stale A-record points a re-prov at a dead console IP).
+		// Gated on the same engaged-feature signal as the up-path (a pool
+		// parentDomain), best-effort + absent-as-success, so a re-reconcile is
+		// idempotent. Run before dropping the finalizers so the CR still holds
+		// while we clean up.
+		if err := r.teardownTenantNetworking(ctx, &org); err != nil {
+			log.Error(err, "tenant-networking teardown")
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+		}
+		// Drop the tenant-networking finalizer once its cascade has run. This
+		// finalizer is what GUARANTEES the cascade fires (it holds the CR even
+		// when iac-bootstrap + per-Org-realm are unwired); removing it lets the
+		// CR proceed toward tombstone once its artifacts are gone.
+		if containsFinalizer(org.Finalizers, TenantNetworkingFinalizer) {
+			if removeTenantNetworkingFinalizer(&org) {
+				if uerr := r.Update(ctx, &org); uerr != nil {
+					return ctrl.Result{}, fmt.Errorf("remove tenant-networking finalizer: %w", uerr)
+				}
+				// Update changed resourceVersion; requeue so the next reconcile
+				// operates on the latest copy before touching the other finalizers.
+				return ctrl.Result{Requeue: true}, nil
+			}
+		}
 		if containsFinalizer(org.Finalizers, IacBootstrapFinalizer) {
 			if err := r.teardownIacBootstrap(ctx, &org); err != nil {
 				log.Error(err, "iac-bootstrap teardown")
@@ -417,6 +449,21 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if ensurePerOrgRealmFinalizer(&org) {
 			if err := r.Update(ctx, &org); err != nil {
 				return ctrl.Result{}, fmt.Errorf("add per-org-realm finalizer: %w", err)
+			}
+			return ctrl.Result{Requeue: true}, nil
+		}
+	}
+
+	// Add the tenant-networking finalizer on first observation when the Org
+	// engages the tenant-networking up-path (a pool parentDomain → console TLS
+	// + Gateway listener + HTTPRoute + pool DNS). This GUARANTEES the cascade
+	// teardown (#4459) fires on delete even when iac-bootstrap + per-Org-realm
+	// are unwired — those would otherwise be the only finalizers holding the CR
+	// long enough for the deletion branch to run. Same requeue-after-add pattern.
+	if orgEngagesTenantNetworking(&org) {
+		if ensureTenantNetworkingFinalizer(&org) {
+			if err := r.Update(ctx, &org); err != nil {
+				return ctrl.Result{}, fmt.Errorf("add tenant-networking finalizer: %w", err)
 			}
 			return ctrl.Result{Requeue: true}, nil
 		}

--- a/core/controllers/organization/internal/controller/organization_controller_test.go
+++ b/core/controllers/organization/internal/controller/organization_controller_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -451,10 +452,10 @@ func sampleOrg() *orgapi.Organization {
 			UID:        "00000000-0000-0000-0000-000000000001",
 		},
 		Spec: orgapi.OrganizationSpec{
-			Slug:                   "acme",
-			DisplayName:            "ACME Corp",
-			Kind:                   "customer",
-			Tier:                   "org",
+			Slug:        "acme",
+			DisplayName: "ACME Corp",
+			Kind:        "customer",
+			Tier:        "org",
 			// #4292: a paid plan → the renderer emits the vCluster boundary plus
 			// the plan-templated ResourceQuota + LimitRange + apps-tree
 			// NetworkPolicy baseline (6 files total).
@@ -920,11 +921,10 @@ func TestReconcile_TenantPublic_RendersHTTPRoute(t *testing.T) {
 		Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRouteList",
 	}, &unstructured.UnstructuredList{})
 
-	if _, err := r.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "acme"},
-	}); err != nil {
-		t.Fatalf("reconcile: %v", err)
-	}
+	// Two passes: pass 1 adds the tenant-networking finalizer + requeues (this
+	// Org has a pool parentDomain, #4459), pass 2 does the up-path work that
+	// renders the per-Org console HTTPRoute.
+	reconcileTwice(t, r, "acme")
 
 	// #4186: the per-Org console route now lands in catalyst-system (where
 	// catalyst-api + catalyst-ui Services live) and is named after the host
@@ -1084,11 +1084,9 @@ func TestReconcile_TenantPublic_ParentDomainSet_BackendPending(t *testing.T) {
 
 	// MUST NOT error — the missing backendService is irrelevant to the
 	// console route (the console is catalyst-ui, not a product backend).
-	if _, err := r.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "acme"},
-	}); err != nil {
-		t.Fatalf("reconcile must succeed while backendService is pending, got: %v", err)
-	}
+	// Two passes: pass 1 adds the tenant-networking finalizer + requeues
+	// (pool parentDomain set, #4459), pass 2 does the up-path + status write.
+	reconcileTwice(t, r, "acme")
 
 	// The Org's Ready condition MUST NOT be TenantRouteFailed.
 	got := orgapi.Organization{}
@@ -1468,4 +1466,235 @@ func keysOf(m map[string]map[string]any) []string {
 		out = append(out, k)
 	}
 	return out
+}
+
+// TestTeardownTenantNetworking_CascadesAndIsSelective is the #4459 close-gate
+// (sibling of #4250): deleting an Organization CR MUST cascade-delete the
+// per-Org tenant-networking artifacts that live outside the Flux-pruned
+// `<slug>` namespace and carry no GC-followed ownerRef —
+//
+//  1. the `console-https-<slug>` / `console-http-<slug>` listener pair on the
+//     SHARED console Gateway (without removal these dead listeners ACCUMULATE),
+//  2. the per-Org wildcard Certificate (kube-system),
+//  3. the per-Org console HTTPRoute (catalyst-system),
+//  4. the central-PowerDNS pool A-records (off-cluster),
+//
+// while leaving the apex listener AND a SECOND Org's listeners byte-for-byte
+// intact (selectivity), and being idempotent on a repeated teardown.
+func TestTeardownTenantNetworking_CascadesAndIsSelective(t *testing.T) {
+	t.Parallel()
+	org := sampleOrg() // slug "acme"
+	org.Spec.TenantPublic = orgapi.OrganizationTenantPublic{ParentDomain: "omani.homes"}
+
+	r, _, _ := makeReconciler(t, org)
+	scheme := r.Scheme()
+	// Register Certificate + Gateway + HTTPRoute GVKs (+ Lists) so the fake
+	// client can serialise the unstructured objects the teardown deletes.
+	for _, gvk := range []schema.GroupVersionKind{certificateGVK, gatewayGVK, httpRouteGVK} {
+		scheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+		scheme.AddKnownTypeWithName(gvk.GroupVersion().WithKind(gvk.Kind+"List"), &unstructured.UnstructuredList{})
+	}
+
+	// Stub the central PowerDNS so the DNS-DELETE is captured.
+	var cap capturedPatch
+	pdns := newPDNSStub(t, &cap)
+	defer pdns.Close()
+	r.PoolPowerDNSURL = pdns.URL
+	r.PoolPowerDNSAPIKey = "central-pool-key"
+	r.TenantConsoleLBIPv4 = "212.72.24.33"
+
+	ctx := context.Background()
+
+	// Seed the shared console Gateway carrying: the apex listener, THIS Org's
+	// two per-Org listeners, AND a SECOND Org's two listeners (the selectivity
+	// guard — they must survive acme's teardown).
+	gw := &unstructured.Unstructured{}
+	gw.SetGroupVersionKind(gatewayGVK)
+	gw.SetName("cilium-gateway-console")
+	gw.SetNamespace("kube-system")
+	gw.Object["spec"] = map[string]any{
+		"gatewayClassName": "cilium",
+		"listeners": []any{
+			map[string]any{"name": "console-https", "hostname": "*.omantel.biz", "port": int64(31443), "protocol": "HTTPS"},
+			map[string]any{"name": "console-https-acme", "hostname": "*.acme.omani.homes", "port": int64(31443), "protocol": "HTTPS"},
+			map[string]any{"name": "console-http-acme", "hostname": "*.acme.omani.homes", "port": int64(31080), "protocol": "HTTP"},
+			map[string]any{"name": "console-https-globex", "hostname": "*.globex.omani.homes", "port": int64(31443), "protocol": "HTTPS"},
+			map[string]any{"name": "console-http-globex", "hostname": "*.globex.omani.homes", "port": int64(31080), "protocol": "HTTP"},
+		},
+	}
+	if err := r.Create(ctx, gw); err != nil {
+		t.Fatalf("seed console Gateway: %v", err)
+	}
+
+	// Seed the per-Org wildcard Certificate (kube-system).
+	cert := &unstructured.Unstructured{}
+	cert.SetGroupVersionKind(certificateGVK)
+	cert.SetName("org-wildcard-tls-acme-omani-homes")
+	cert.SetNamespace("kube-system")
+	cert.Object["spec"] = map[string]any{"secretName": "org-wildcard-tls-acme-omani-homes"}
+	if err := r.Create(ctx, cert); err != nil {
+		t.Fatalf("seed Certificate: %v", err)
+	}
+
+	// Seed the per-Org console HTTPRoute (catalyst-system, NOT the <slug> ns).
+	route := &unstructured.Unstructured{}
+	route.SetGroupVersionKind(httpRouteGVK)
+	route.SetName("catalyst-ui-console-acme-omani-homes")
+	route.SetNamespace("catalyst-system")
+	route.Object["spec"] = map[string]any{"hostnames": []any{"console.acme.omani.homes"}}
+	if err := r.Create(ctx, route); err != nil {
+		t.Fatalf("seed HTTPRoute: %v", err)
+	}
+
+	// ── Teardown pass 1: cascades all four artifacts ────────────────────
+	if err := r.teardownTenantNetworking(ctx, org); err != nil {
+		t.Fatalf("teardownTenantNetworking pass 1: %v", err)
+	}
+
+	// 1. Gateway: acme's two listeners gone; apex + globex's two preserved.
+	gotGW := unstructured.Unstructured{}
+	gotGW.SetGroupVersionKind(gatewayGVK)
+	if err := r.Get(ctx, client.ObjectKey{Namespace: "kube-system", Name: "cilium-gateway-console"}, &gotGW); err != nil {
+		t.Fatalf("get console Gateway: %v", err)
+	}
+	listeners, _, _ := unstructured.NestedSlice(gotGW.Object, "spec", "listeners")
+	got := map[string]bool{}
+	for _, l := range listeners {
+		got[l.(map[string]any)["name"].(string)] = true
+	}
+	if got["console-https-acme"] || got["console-http-acme"] {
+		t.Errorf("acme per-Org listeners NOT removed: %v", got)
+	}
+	for _, keep := range []string{"console-https", "console-https-globex", "console-http-globex"} {
+		if !got[keep] {
+			t.Errorf("listener %q was wrongly dropped — teardown must be selective: %v", keep, got)
+		}
+	}
+	if len(listeners) != 3 {
+		t.Errorf("listeners after teardown: got %d (%v), want 3 (apex + globex pair)", len(listeners), got)
+	}
+
+	// 2. Certificate deleted (cert-manager GCs the backing Secret with it).
+	gotCert := unstructured.Unstructured{}
+	gotCert.SetGroupVersionKind(certificateGVK)
+	if err := r.Get(ctx, client.ObjectKey{Namespace: "kube-system", Name: "org-wildcard-tls-acme-omani-homes"}, &gotCert); !apierrors.IsNotFound(err) {
+		t.Errorf("Certificate should be deleted, get err = %v (want NotFound)", err)
+	}
+
+	// 3. HTTPRoute deleted.
+	gotRoute := unstructured.Unstructured{}
+	gotRoute.SetGroupVersionKind(httpRouteGVK)
+	if err := r.Get(ctx, client.ObjectKey{Namespace: "catalyst-system", Name: "catalyst-ui-console-acme-omani-homes"}, &gotRoute); !apierrors.IsNotFound(err) {
+		t.Errorf("HTTPRoute should be deleted, get err = %v (want NotFound)", err)
+	}
+
+	// 4. DNS: two rrsets PATCHed with changetype=DELETE on the pool zone.
+	if want := "/api/v1/servers/localhost/zones/omani.homes."; cap.path != want {
+		t.Errorf("PATCH path: got %q, want %q", cap.path, want)
+	}
+	rrsets, _ := cap.body["rrsets"].([]any)
+	if len(rrsets) != 2 {
+		t.Fatalf("DNS rrsets: got %d, want 2 (console + wildcard DELETE)", len(rrsets))
+	}
+	dnsNames := map[string]map[string]any{}
+	for _, rs := range rrsets {
+		m := rs.(map[string]any)
+		dnsNames[m["name"].(string)] = m
+	}
+	for _, wantName := range []string{"console.acme.omani.homes.", "*.acme.omani.homes."} {
+		m, ok := dnsNames[wantName]
+		if !ok {
+			t.Fatalf("missing DELETE rrset %q (have %v)", wantName, keysOf(dnsNames))
+		}
+		if m["changetype"] != "DELETE" {
+			t.Errorf("%s changetype: got %v, want DELETE", wantName, m["changetype"])
+		}
+	}
+
+	// ── Teardown pass 2: idempotent — every artifact already gone ────────
+	if err := r.teardownTenantNetworking(ctx, org); err != nil {
+		t.Fatalf("teardownTenantNetworking pass 2 (idempotent): %v", err)
+	}
+	gotGW2 := unstructured.Unstructured{}
+	gotGW2.SetGroupVersionKind(gatewayGVK)
+	if err := r.Get(ctx, client.ObjectKey{Namespace: "kube-system", Name: "cilium-gateway-console"}, &gotGW2); err != nil {
+		t.Fatalf("get console Gateway pass 2: %v", err)
+	}
+	l2, _, _ := unstructured.NestedSlice(gotGW2.Object, "spec", "listeners")
+	if len(l2) != 3 {
+		t.Errorf("pass 2 listeners: got %d, want 3 (no further removal)", len(l2))
+	}
+}
+
+// TestTeardownTenantNetworking_NoopWhenNoParentDomain asserts the teardown is
+// a clean no-op for Orgs that never had a pool-parent public hostname (the
+// common case) — none of the up-path tenant-networking steps engaged, so the
+// teardown touches nothing.
+func TestTeardownTenantNetworking_NoopWhenNoParentDomain(t *testing.T) {
+	t.Parallel()
+	org := sampleOrg() // TenantPublic zero-value: ParentDomain == ""
+	r, _, _ := makeReconciler(t, org)
+	if err := r.teardownTenantNetworking(context.Background(), org); err != nil {
+		t.Fatalf("teardownTenantNetworking no-op: %v", err)
+	}
+}
+
+// TestReconcile_DeleteCascadesTenantNetworking drives the FULL Reconcile
+// deletion path (not just the orchestrator) to prove the cascade is wired into
+// the finalizer flow: a steady-state Org with a pool parentDomain → mark for
+// deletion → Reconcile → the per-Org HTTPRoute is gone (representative of the
+// whole tenant-networking set the orchestrator reaps before the CR tombstones).
+func TestReconcile_DeleteCascadesTenantNetworking(t *testing.T) {
+	t.Parallel()
+	org := sampleOrg()
+	org.Spec.TenantPublic = orgapi.OrganizationTenantPublic{ParentDomain: "omani.homes"}
+	r, _, _ := makeReconciler(t, org)
+	for _, gvk := range []schema.GroupVersionKind{certificateGVK, gatewayGVK, httpRouteGVK} {
+		r.Scheme().AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+		r.Scheme().AddKnownTypeWithName(gvk.GroupVersion().WithKind(gvk.Kind+"List"), &unstructured.UnstructuredList{})
+	}
+	ctx := context.Background()
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "acme"}}
+
+	// Drive reconciles to steady state: the first pass adds the
+	// tenant-networking finalizer + requeues, the second does the up-path work
+	// that lands the per-Org console HTTPRoute.
+	for i := 0; i < 4; i++ {
+		if _, err := r.Reconcile(ctx, req); err != nil {
+			t.Fatalf("up-path reconcile pass %d: %v", i+1, err)
+		}
+	}
+	routeKey := client.ObjectKey{Namespace: "catalyst-system", Name: "catalyst-ui-console-acme-omani-homes"}
+	probe := unstructured.Unstructured{}
+	probe.SetGroupVersionKind(httpRouteGVK)
+	if err := r.Get(ctx, routeKey, &probe); err != nil {
+		t.Fatalf("precondition: per-Org HTTPRoute should exist after up-path reconcile: %v", err)
+	}
+	// Precondition: the tenant-networking finalizer is present (it is what
+	// holds the CR through deletion so the cascade can run).
+	var steady orgapi.Organization
+	if err := r.Get(ctx, client.ObjectKey{Name: "acme"}, &steady); err != nil {
+		t.Fatalf("get steady: %v", err)
+	}
+	if !containsFinalizer(steady.Finalizers, TenantNetworkingFinalizer) {
+		t.Fatalf("precondition: tenant-networking finalizer should be present, got %v", steady.Finalizers)
+	}
+
+	// Mark for deletion + reconcile the deletion path (the cascade runs, then
+	// the finalizer is dropped + requeued).
+	if err := r.Delete(ctx, &steady); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		if _, err := r.Reconcile(ctx, req); err != nil {
+			t.Fatalf("delete reconcile pass %d: %v", i+1, err)
+		}
+	}
+
+	// The per-Org HTTPRoute must be cascade-deleted by the deletion path.
+	gone := unstructured.Unstructured{}
+	gone.SetGroupVersionKind(httpRouteGVK)
+	if err := r.Get(ctx, routeKey, &gone); !apierrors.IsNotFound(err) {
+		t.Errorf("per-Org HTTPRoute should be cascade-deleted on Org delete, get err = %v (want NotFound)", err)
+	}
 }

--- a/core/controllers/organization/internal/controller/tenant_console_tls.go
+++ b/core/controllers/organization/internal/controller/tenant_console_tls.go
@@ -449,6 +449,118 @@ func (r *Reconciler) ensureConsoleOrgListener(ctx context.Context, names orgCons
 	return true, nil
 }
 
+// teardownTenantConsoleTLS removes the per-Org console-TLS artifacts the
+// up-path (reconcileTenantConsoleTLS) appended/created: the two named
+// listeners on the SHARED console Gateway and the per-Org wildcard
+// Certificate. This is the deletion-direction counterpart — without it,
+// deleting an Organization CR leaves dead `console-https-<slug>` /
+// `console-http-<slug>` listeners ACCUMULATING on the shared Gateway and
+// an orphan Certificate (+ its TLS Secret) in the Gateway namespace, since
+// neither sits in the Flux-pruned `<slug>` namespace nor carries an
+// ownerRef the GC follows (#4459). No-op (false, nil) when the Org never
+// had a pool parentDomain. Best-effort + absent-as-success — a missing
+// artifact is success, not an error, so a repeated reconcile is idempotent.
+func (r *Reconciler) teardownTenantConsoleTLS(ctx context.Context, org *orgapi.Organization) (bool, error) {
+	parentDomain := strings.TrimSpace(org.Spec.TenantPublic.ParentDomain)
+	if parentDomain == "" {
+		return false, nil
+	}
+	subdomain := strings.TrimSpace(org.Spec.TenantPublic.Subdomain)
+	if subdomain == "" {
+		subdomain = org.Spec.Slug
+	}
+	if strings.TrimSpace(subdomain) == "" {
+		return false, nil
+	}
+	names := orgConsoleTLSNamesFor(subdomain, parentDomain)
+
+	listenerChanged, err := r.removeConsoleOrgListener(ctx, names)
+	if err != nil {
+		return false, fmt.Errorf("remove console listener for %q: %w", names.WildcardHost, err)
+	}
+	certChanged, err := r.deleteOrgWildcardCert(ctx, names)
+	if err != nil {
+		return listenerChanged, fmt.Errorf("delete org wildcard cert %q: %w", names.CertName, err)
+	}
+	return listenerChanged || certChanged, nil
+}
+
+// removeConsoleOrgListener strips the per-Org `console-https-<slug>` /
+// `console-http-<slug>` listeners off the shared console Gateway, leaving
+// every OTHER listener (the apex `*.<sovFQDN>` pair AND every other Org's
+// per-Org listeners) byte-for-byte intact — the exact inverse of
+// ensureConsoleOrgListener's strictly-additive append. Returns (changed,
+// err): changed=true iff at least one listener was actually removed.
+// No-op when the Gateway is absent (already gone) or carries neither
+// listener (idempotent on a re-run).
+func (r *Reconciler) removeConsoleOrgListener(ctx context.Context, names orgConsoleTLSNames) (bool, error) {
+	gwNS := r.consoleGatewayNamespace()
+	gwName := r.consoleGatewayName()
+
+	gw := unstructured.Unstructured{}
+	gw.SetGroupVersionKind(gatewayGVK)
+	if err := r.Get(ctx, client.ObjectKey{Namespace: gwNS, Name: gwName}, &gw); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Gateway already gone — nothing to strip.
+			return false, nil
+		}
+		return false, fmt.Errorf("get Gateway %s/%s: %w", gwNS, gwName, err)
+	}
+
+	listeners, _, err := unstructured.NestedSlice(gw.Object, "spec", "listeners")
+	if err != nil {
+		return false, fmt.Errorf("read Gateway %s/%s listeners: %w", gwNS, gwName, err)
+	}
+
+	drop := map[string]bool{names.HTTPSName: true, names.HTTPName: true}
+	kept := make([]any, 0, len(listeners))
+	removed := false
+	for _, l := range listeners {
+		if m, ok := l.(map[string]any); ok {
+			if n, ok := m["name"].(string); ok && drop[n] {
+				removed = true
+				continue
+			}
+		}
+		kept = append(kept, l)
+	}
+	if !removed {
+		// Neither per-Org listener present — idempotent no-op.
+		return false, nil
+	}
+
+	if err := unstructured.SetNestedSlice(gw.Object, kept, "spec", "listeners"); err != nil {
+		return false, fmt.Errorf("set Gateway %s/%s listeners: %w", gwNS, gwName, err)
+	}
+	if err := r.Update(ctx, &gw); err != nil {
+		// A conflict means another writer touched the Gateway concurrently —
+		// surface it so the caller requeues and re-reads.
+		return false, fmt.Errorf("update Gateway %s/%s: %w", gwNS, gwName, err)
+	}
+	return true, nil
+}
+
+// deleteOrgWildcardCert removes the per-Org cert-manager Certificate the
+// up-path created. cert-manager garbage-collects the backing TLS Secret
+// once the Certificate is gone (the Secret carries an ownerRef to the
+// Certificate), so deleting the Certificate cascades the Secret. Returns
+// (changed, err): changed=true iff a Certificate was actually deleted.
+// Absent-as-success.
+func (r *Reconciler) deleteOrgWildcardCert(ctx context.Context, names orgConsoleTLSNames) (bool, error) {
+	ns := r.consoleTLSCertNamespace()
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(certificateGVK)
+	obj.SetNamespace(ns)
+	obj.SetName(names.CertName)
+	if err := r.Delete(ctx, obj); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("delete Certificate %s/%s: %w", ns, names.CertName, err)
+	}
+	return true, nil
+}
+
 // specEqual is a shallow structural compare of two map[string]any specs.
 // Used to decide whether a Certificate Update is worth issuing. It walks
 // nested maps/slices recursively comparing scalar values; differing

--- a/core/controllers/organization/internal/controller/tenant_dns.go
+++ b/core/controllers/organization/internal/controller/tenant_dns.go
@@ -171,6 +171,55 @@ func (r *Reconciler) reconcileTenantDNS(ctx context.Context, org *orgapi.Organiz
 	return true, nil
 }
 
+// teardownTenantDNS removes the per-Org pool A-records the up-path wrote to
+// the central PowerDNS (`console.<slug>.<parentDomain>` +
+// `*.<slug>.<parentDomain>`) when the Organization is deleted — otherwise the
+// stale records survive the Org and a later re-prov of the same slug points
+// at a DEAD console-ELB IP (#4459). Uses PATCH changetype=DELETE, the
+// canonical PowerDNS rrset removal (it does NOT need the record content, so
+// no console-IP env is required for the delete). Returns (changed, err). No-op
+// (false, nil) when the Org had no pool parentDomain or the central-pdns
+// writer is unwired. Idempotent: deleting an already-absent rrset is a 2xx
+// no-op on PowerDNS.
+func (r *Reconciler) teardownTenantDNS(ctx context.Context, org *orgapi.Organization) (bool, error) {
+	tp := org.Spec.TenantPublic
+	parentDomain := strings.TrimSpace(tp.ParentDomain)
+	if parentDomain == "" {
+		return false, nil
+	}
+	subdomain := strings.TrimSpace(tp.Subdomain)
+	if subdomain == "" {
+		subdomain = org.Spec.Slug
+	}
+	baseURL := strings.TrimSpace(r.PoolPowerDNSURL)
+	apiKey := strings.TrimSpace(r.PoolPowerDNSAPIKey)
+	if baseURL == "" || apiKey == "" {
+		// No central-pdns writer wired — nothing this controller can delete.
+		r.Log.Info("tenant-dns teardown: skipped — central pool PowerDNS not wired",
+			"organization", org.Name)
+		return false, nil
+	}
+
+	rrsets := make([]poolDNSRRSet, 0, 2)
+	for _, prefix := range []string{"console", "*"} {
+		fqdn := fmt.Sprintf("%s.%s.%s.", prefix, subdomain, parentDomain)
+		rrsets = append(rrsets, poolDNSRRSet{
+			Name:       fqdn,
+			Type:       "A",
+			TTL:        poolDNSTTL,
+			ChangeType: "DELETE",
+		})
+	}
+	if err := r.patchPoolZone(ctx, baseURL, apiKey, parentDomain, rrsets); err != nil {
+		return false, fmt.Errorf("delete pool zone rrsets %q for %q: %w", parentDomain, subdomain, err)
+	}
+	r.Log.Info("tenant-dns teardown: deleted per-Org pool A-records",
+		"organization", org.Name,
+		"console_host", fmt.Sprintf("console.%s.%s", subdomain, parentDomain),
+		"zone", parentDomain)
+	return true, nil
+}
+
 // tenantConsoleLBIPv4 resolves the A-record target IP: the dedicated console-ELB
 // EIP (CATALYST_TENANT_CONSOLE_LB_IPV4) when set, else the primary/shared LB
 // (CATALYST_OTECH_INGRESS_IPV4) for single-LB / pre-#4053 Sovereigns. Empty when

--- a/core/controllers/organization/internal/controller/tenant_networking_teardown.go
+++ b/core/controllers/organization/internal/controller/tenant_networking_teardown.go
@@ -1,0 +1,136 @@
+// tenant_networking_teardown.go — cascade-delete the per-Org tenant-networking
+// artifacts when an Organization CR is removed (#4459, sibling of #4250).
+//
+// THE GAP THIS CLOSES
+// -------------------
+// The org-controller's deletion path already reaps everything that sits inside
+// the per-Org `<slug>` namespace or carries an ownerRef the K8s garbage
+// collector follows:
+//
+//   - the vCluster Namespace + HelmRelease + in-namespace NetworkPolicies — via
+//     teardownPerOrgFlux (the per-Org Flux Kustomizations carry prune:true);
+//   - the per-Org Keycloak realm — via teardownPerOrgRealm;
+//   - the per-Org IaC repo + robot token — via teardownIacBootstrap;
+//   - the Environment CR + the UserAccess CRs — via cluster-scoped
+//     ownerReferences (GC-safe).
+//
+// But the per-Org artifacts the controller writes OUTSIDE that namespace, with
+// NO ownerRef the GC follows, were left orphaned on every Org delete:
+//
+//   1. the `console-https-<slug>` / `console-http-<slug>` listener pair the
+//      up-path appended to the SHARED console Gateway (cilium-gateway-console /
+//      kube-system) — dead listeners ACCUMULATE on a shared resource;
+//   2. the per-Org wildcard Certificate `org-wildcard-tls-<slug>-<parent>`
+//      (+ its backing TLS Secret, cert-manager-GC'd with it) in kube-system;
+//   3. the per-Org console HTTPRoute `catalyst-ui-<host-dashed>` in
+//      catalyst-system (NOT the Org's `<slug>` ns → the ns-prune never reaches it);
+//   4. the central-PowerDNS pool A-records `console.<slug>.<parent>` +
+//      `*.<slug>.<parent>` (off-cluster → no GC at all; a stale record points a
+//      later re-prov of the same slug at a DEAD console-ELB IP).
+//
+// A clean boundary must tear down as cleanly as it stands up: the same producer
+// that materialized these artifacts from the CR (the org-controller) must
+// de-materialize them when the CR is deleted. This orchestrator chains the four
+// best-effort, absent-as-success teardown helpers each up-path step exposes, so
+// the deletion path is idempotent and leaves no orphan on a repeated reconcile.
+//
+// OUT OF SCOPE (tracked separately): the Keycloak Sovereign-realm GROUP at
+// `/<slug>` and the Gitea Org have no DeleteGroup / DeleteOrg client method
+// today — adding those expands the shared core/controllers/pkg surface and is a
+// follow-up. They are NOT part of this orchestrator.
+
+package controller
+
+import (
+	"context"
+	"strings"
+
+	orgapi "github.com/openova-io/openova/core/controllers/organization/internal/orgapi"
+)
+
+// TenantNetworkingFinalizer guarantees the per-Org tenant-networking cascade
+// runs before the CR tombstones — INDEPENDENT of whether the iac-bootstrap or
+// per-Org-realm features are wired/enabled. Without a finalizer the deletion
+// branch (incl. teardownTenantNetworking) only fires while SOME other finalizer
+// holds the CR; a plain Org with neither iac nor realm wired would be removed by
+// the API server the instant it is deleted and the cascade would never run,
+// leaving the dead Gateway listeners / Certificate / HTTPRoute / DNS records
+// behind (#4459). Scoped to the orgs.openova.io group per the finalizer-naming
+// convention, parallel to IacBootstrapFinalizer / PerOrgRealmFinalizer.
+const TenantNetworkingFinalizer = "orgs.openova.io/tenant-networking"
+
+// orgEngagesTenantNetworking reports whether an Org engaged the tenant-
+// networking up-path (a pool parentDomain → console TLS + listener + HTTPRoute +
+// pool DNS were authored). Only such an Org needs the finalizer + teardown; a
+// plain single-domain Org authored none of these, so adding a finalizer for a
+// flow that will never run would needlessly delay its deletion.
+func orgEngagesTenantNetworking(org *orgapi.Organization) bool {
+	return strings.TrimSpace(org.Spec.TenantPublic.ParentDomain) != ""
+}
+
+// ensureTenantNetworkingFinalizer adds the finalizer if missing. Returns true
+// when the caller should patch the CR so subsequent code uses the updated copy.
+func ensureTenantNetworkingFinalizer(org *orgapi.Organization) bool {
+	for _, f := range org.Finalizers {
+		if f == TenantNetworkingFinalizer {
+			return false
+		}
+	}
+	org.Finalizers = append(org.Finalizers, TenantNetworkingFinalizer)
+	return true
+}
+
+// removeTenantNetworkingFinalizer drops the finalizer. Returns true when the
+// caller should patch the CR.
+func removeTenantNetworkingFinalizer(org *orgapi.Organization) bool {
+	keep := org.Finalizers[:0]
+	removed := false
+	for _, f := range org.Finalizers {
+		if f == TenantNetworkingFinalizer {
+			removed = true
+			continue
+		}
+		keep = append(keep, f)
+	}
+	org.Finalizers = keep
+	return removed
+}
+
+// teardownTenantNetworking removes the per-Org tenant-networking artifacts that
+// live outside the Flux-pruned `<slug>` namespace + carry no GC-followed
+// ownerRef: the shared-Gateway listener pair, the per-Org wildcard Certificate,
+// the per-Org console HTTPRoute, and the central-PowerDNS pool A-records.
+//
+// Each sub-teardown is best-effort + absent-as-success (a missing artifact is
+// success), so the orchestrator is idempotent — a re-reconcile of an
+// already-cleaned Org is a clean no-op. We attempt ALL four even if an earlier
+// one errored, accumulating the FIRST error to return (so the caller requeues
+// and retries the whole set) — this avoids a single transient PowerDNS hiccup
+// stranding the Certificate/HTTPRoute/listener cleanup. A no-pool-parentDomain
+// Org engaged none of these up-path steps, so every helper short-circuits to a
+// no-op.
+func (r *Reconciler) teardownTenantNetworking(ctx context.Context, org *orgapi.Organization) error {
+	var firstErr error
+	note := func(err error) {
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	// 1+2. Shared-Gateway listener pair + per-Org wildcard Certificate.
+	if _, err := r.teardownTenantConsoleTLS(ctx, org); err != nil {
+		r.Log.Error(err, "tenant-networking teardown: console TLS", "organization", org.Name)
+		note(err)
+	}
+	// 3. Per-Org console HTTPRoute (catalyst-system).
+	if _, err := r.teardownTenantRoute(ctx, org); err != nil {
+		r.Log.Error(err, "tenant-networking teardown: console HTTPRoute", "organization", org.Name)
+		note(err)
+	}
+	// 4. Central-PowerDNS pool A-records.
+	if _, err := r.teardownTenantDNS(ctx, org); err != nil {
+		r.Log.Error(err, "tenant-networking teardown: pool DNS", "organization", org.Name)
+		note(err)
+	}
+	return firstErr
+}

--- a/core/controllers/organization/internal/controller/tenant_route.go
+++ b/core/controllers/organization/internal/controller/tenant_route.go
@@ -243,3 +243,48 @@ func (r *Reconciler) reconcileTenantRoute(ctx context.Context, org *orgapi.Organ
 	}
 	return true, nil
 }
+
+// tenantRouteNameNS computes the deterministic (namespace, name) of the
+// per-Org console HTTPRoute the up-path renders, so the teardown targets
+// exactly what reconcileTenantRoute created. Returns ok=false when the Org
+// has no pool parentDomain (the feature was never engaged → nothing to
+// remove). Kept in lockstep with the up-path derivation:
+//
+//	host = console.<subdomain>.<parentDomain>; name = catalyst-ui-<host-dashed>;
+//	ns   = consoleRouteNamespace (catalyst-system).
+func (r *Reconciler) tenantRouteNameNS(org *orgapi.Organization) (ns, name string, ok bool) {
+	parentDomain := strings.TrimSpace(org.Spec.TenantPublic.ParentDomain)
+	if parentDomain == "" {
+		return "", "", false
+	}
+	subdomain := strings.TrimSpace(org.Spec.TenantPublic.Subdomain)
+	if subdomain == "" {
+		subdomain = org.Spec.Slug
+	}
+	hostname := fmt.Sprintf("console.%s.%s", subdomain, parentDomain)
+	return r.consoleRouteNamespace(), "catalyst-ui-" + dnsDashed(hostname), true
+}
+
+// teardownTenantRoute deletes the per-Org console HTTPRoute on Org delete.
+// The route lands in catalyst-system (NOT the Org's `<slug>` namespace), so
+// neither the Flux `<slug>`-namespace prune nor a same-namespace ownerRef
+// reaps it — it leaks unless explicitly removed (#4459). Returns (changed,
+// err); changed=true iff a route was actually deleted. No-op when the Org
+// had no pool parentDomain. Absent-as-success → idempotent on a re-run.
+func (r *Reconciler) teardownTenantRoute(ctx context.Context, org *orgapi.Organization) (bool, error) {
+	ns, name, ok := r.tenantRouteNameNS(org)
+	if !ok {
+		return false, nil
+	}
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(httpRouteGVK)
+	obj.SetNamespace(ns)
+	obj.SetName(name)
+	if err := r.Delete(ctx, obj); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("delete HTTPRoute %s/%s: %w", ns, name, err)
+	}
+	return true, nil
+}


### PR DESCRIPTION
## What was leaking
Deleting an `Organization` CR did **not** fully tear down the per-Org boundary. The org-controller deletion path already GCs the per-Org Flux CRs (their `prune:true` reaps the vCluster ns + HR + in-ns NetworkPolicies), the per-Org realm, the IaC repo + token, and the Environment/UserAccess CRs (cluster-scoped ownerRefs). But the per-Org artifacts the controller writes **outside** the pruned `<slug>` namespace with **no** ownerRef the GC follows were orphaned on every delete:

1. the `console-https-<slug>` / `console-http-<slug>` listener pair appended to the **SHARED** console Gateway (`cilium-gateway-console`/`kube-system`) — dead listeners ACCUMULATE on a shared resource (worst offender);
2. the per-Org wildcard Certificate `org-wildcard-tls-<slug>-<parent>` (+ its TLS Secret) in `kube-system`;
3. the per-Org console HTTPRoute `catalyst-ui-<host-dashed>` in `catalyst-system` (NOT the `<slug>` ns → ns-prune never reaches it);
4. the central-PowerDNS pool A-records `console.<slug>.<parent>` + `*.<slug>.<parent>` (off-cluster → no GC; a stale record points a later re-prov at a DEAD console-ELB IP).

This is the deletion-direction sibling of the chronic-teardown defect #4250 and reinforces the #4290 keystone law: the one producer that materializes the boundary from the CR must also de-materialize it.

## The cascade fix (imperative delete, mirroring the existing teardownPerOrgFlux style)
Per-helper teardowns co-located with their up-path step, each best-effort + absent-as-success:
- `teardownTenantConsoleTLS` → `removeConsoleOrgListener` (strips the two named listeners off the shared Gateway, leaving the apex + every OTHER Org's listeners byte-for-byte intact — the exact inverse of the additive append) + `deleteOrgWildcardCert` (cert-manager GCs the backing Secret with the Certificate).
- `teardownTenantRoute` → deletes the per-Org console HTTPRoute.
- `teardownTenantDNS` → PATCH `changetype=DELETE` the two pool rrsets.
- `teardownTenantNetworking` orchestrates the three (first-error accumulate → caller requeues), idempotent on a re-run.

ownerRef-driven GC was not viable here: the listener lives on a shared cluster-singleton Gateway (can't be owned by one Org), and the Certificate/HTTPRoute are namespaced while the Org CR is cluster-scoped (K8s rejects namespaced→cluster ownerRefs). So imperative delete matches both the constraint and the existing `teardownPerOrgFlux` precedent.

A new **`TenantNetworkingFinalizer`** GUARANTEES the cascade fires even when iac-bootstrap + per-Org-realm are unwired — otherwise nothing holds the CR long enough for the deletion branch to run. Added on the up-path only when the Org engages tenant-networking (pool parentDomain set).

## Out of clean-fix scope (follow-up)
The Keycloak Sovereign-realm GROUP at `/<slug>` and the Gitea Org have no `DeleteGroup`/`DeleteOrg` client method today — adding those expands the shared `core/controllers/pkg` surface.

## Tests
- `TestTeardownTenantNetworking_CascadesAndIsSelective` — fake client seeded with the Org + its Gateway-listener pair + a SECOND Org's listeners + Certificate + HTTPRoute + a stub PowerDNS → reconcile-delete → all four of THIS Org's artifacts gone, apex + the other Org's listeners untouched, DNS DELETE issued, repeat-reconcile idempotent.
- `TestTeardownTenantNetworking_NoopWhenNoParentDomain` — clean no-op for single-domain Orgs.
- `TestReconcile_DeleteCascadesTenantNetworking` — full `Reconcile` deletion path via the finalizer.
- `go build ./...` + `go vet` + org-controller suite green. Two existing tenant-route tests gained a second reconcile pass for the new finalizer-add requeue.

## Image-pin lockstep
The org-controller is a microservice; `build-organization-controller.yaml` auto-bumps `controllers.organization.image.tag` in `products/catalyst/chart/values.yaml` via the deploy-bump action on merge — no manual chart edit needed.

Refs #4290 #4250

🤖 Generated with [Claude Code](https://claude.com/claude-code)