### PR TITLE
fix(bp-postgres): decouple -mesh/-mesh-rw global Service aliases from the cnpg-pair flip — kill region-B NXDOMAIN on fresh 2-region prov (0.2.7) (Refs #4439)

### DIFF
--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -143,7 +143,17 @@ spec:
       # (no fromHost mirror of a pod-mounted Secret → no vcluster-0.23.0
       # from-host/to-host deadlock, and no missing credential). Lockstep with
       # 16c/16d. Refs #3876 #3374 #3737.
-      version: 0.2.7
+      # 0.2.8 (#4460, Refs #4439 #4436 #4275): the ClusterMesh-global
+      # `shared-pg-mesh`/`-mesh-rw` Service aliases now render on the MULTI-REGION
+      # signal (both primary.region + replica.region stamped — cloud-init sets
+      # both on every region at boot) instead of gated on the LATE cnpg-pair flip
+      # ($ahs/crossRegion). The secondary region's keycloak/gitea/harbor host is
+      # baked to `shared-pg-mesh-rw` at cloud-init regardless of the flip, so the
+      # alias must exist the moment the mesh peers — else region-B keycloak/gitea/
+      # harbor NXDOMAIN'd on a fresh 2-region prov (0 remote clusters ready). The
+      # cross-mesh consumer-5432 path is already opened by 0.2.7's sharedConsumers
+      # (#4442). Lockstep with 16c/16d.
+      version: 0.2.8
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
+++ b/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
@@ -87,7 +87,11 @@ spec:
       # vc-mgmt as the syncer-mangled host object (no fromHost mirror → no
       # vcluster-0.23.0 deadlock, no missing GF_DATABASE_* env). Lockstep with
       # 16a/16d. Refs #3876 #3374 #3737.
-      version: 0.2.7
+      # 0.2.8 (#4460, Refs #4439 #4436 #4275): shared-pg-b's `-mesh`/`-mesh-rw`
+      # global Service aliases decoupled from the cnpg-pair flip → render on the
+      # multi-region signal so cross-region grafana/powerdns/pda hosts resolve the
+      # moment the mesh peers. Lockstep with 16a/16d.
+      version: 0.2.8
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
+++ b/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
@@ -75,7 +75,11 @@ spec:
       # the 4 vc-mgmt-homed deadlock apps; newapi keeps its `newapi/*` fromHost
       # wildcard per #3876), so this slot renders byte-identical to 0.2.2 on the
       # additive chart. Lockstep with 16a/16c. Refs #3876 #3374 #3737.
-      version: 0.2.7
+      # 0.2.8 (#4460, Refs #4439 #4436 #4275): shared-pg-c's `-mesh`/`-mesh-rw`
+      # global Service aliases decoupled from the cnpg-pair flip → render on the
+      # multi-region signal so the cross-region Organization-mesh / newapi /
+      # openova-flow hosts resolve the moment the mesh peers. Lockstep 16a/16c.
+      version: 0.2.8
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/platform/postgres/blueprint.yaml
+++ b/platform/postgres/blueprint.yaml
@@ -6,7 +6,9 @@ metadata:
     catalyst.openova.io/section: pts-4-1-data-services
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.2.7
+  # 0.2.8 (#4460): -mesh/-mesh-rw global Service aliases decoupled from the
+  # cnpg-pair flip (render on the multi-region signal; region-B NXDOMAIN fix).
+  version: 0.2.8
   card:
     title: PostgreSQL
     summary: |

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -123,7 +123,29 @@ name: bp-postgres
 #   the singleton analogue of the 0.2.1/#3577 active-hot-standby consumer-allow).
 #   Adds topology.networkPolicy.sharedConsumers (default false → per-Org byte-identical);
 #   slots 16a/16c/16d set it true → the probe NP also opens 5432 namespaceSelector:{}.
-version: 0.2.7
+# 0.2.8 (#4460, Refs #4439 #4436 #4275): DECOUPLE the ClusterMesh-global
+#   `-mesh`/`-mesh-rw` Service aliases from the cnpg-pair replication flip. The
+#   secondary region's keycloak/gitea/harbor consumer host is baked to
+#   `<instance>-mesh-rw.shared-data…` at cloud-init (cloudinit-control-plane.tftpl)
+#   + #4439's patchSecondaryCrossRegionPGHosts re-stamps it — REGARDLESS of the
+#   cnpg-pair flip. But the aliases used to render ONLY under $ahs
+#   (crossRegion=true), which flips LATE (after full ClusterMesh convergence +
+#   the SOVEREIGN_ENABLE_CNPG_PAIR patch). So on a fresh 2-region prov whose mesh
+#   shows `0 remote clusters ready`, the baked `-mesh-rw` host NXDOMAIN'd → region-B
+#   keycloak/gitea/harbor CrashLoop (the §2/§6 UAT walkers' symptom; also gates the
+#   #4275 region-kill walk). Host RESOLUTION is a mesh property; WAL REPLICATION is
+#   a cnpg-pair property. New helper `meshGlobalServices` gates the aliases on
+#   `clusterMesh.enabled` + a MULTI-REGION signal (both primary.region AND
+#   replica.region stamped — cloud-init sets both on EVERY region at boot, so a
+#   true single-region singleton is byte-identical, NO aliases). Primary side
+#   renders the managed `-mesh`/`-mesh-rw` Services (real backends); secondary side
+#   renders the zero-backend stub so writes cross the mesh to region-A — never to
+#   its own pre-flip singleton DB. The cross-mesh consumer-5432 path is already
+#   opened by 0.2.7's networkPolicy.sharedConsumers (#4442). The cnpg-pair-specific
+#   carve-outs (sync GUCs, replica-Pod cross-cluster allow, own-cluster
+#   pg_basebackup join, replica-side policy) stay $ahs-gated. Post-flip render is
+#   byte-identical to 0.2.7's $ahs shape.
+version: 0.2.8
 appVersion: "0.1.2"
 description: |
   Catalyst-authored data-instance Blueprint for a shareable, reusable

--- a/platform/postgres/chart/templates/_helpers.tpl
+++ b/platform/postgres/chart/templates/_helpers.tpl
@@ -83,6 +83,57 @@ replica side renders ONLY the follower Cluster + its mesh stub + netpol.
 {{- end -}}
 
 {{/*
+Whether this install publishes the ClusterMesh-global `-mesh` (read) +
+`-mesh-rw` (write) Service aliases — gated on `topology.clusterMesh.enabled`
++ a MULTI-REGION signal, deliberately DECOUPLED from `activeHotStandby` (#4460).
+
+WHY decoupled (the #4460 root cause): the secondary region's consumer host
+(keycloak/gitea/harbor `externalDatabase.host`) is baked to
+`<instance>-mesh-rw.shared-data…` UNCONDITIONALLY at cloud-init boot whenever
+`enable_shared_pg=true` (cloudinit-control-plane.tftpl), AND #4439's
+patchSecondaryCrossRegionPGHosts re-stamps the same. But the `-mesh-rw` global
+Service used to render ONLY under `$ahs` (`crossRegion=true`), which flips true
+LATE — after full ClusterMesh convergence AND the cnpg-pair replication flip
+(`SOVEREIGN_ENABLE_CNPG_PAIR=true`, catalyst-api enableCNPGPairAfterFullMesh).
+So during the entire pre-flip window — and PERMANENTLY if the mesh never
+converges (`0 remote clusters ready`) — the baked host had no backing Service
+→ NXDOMAIN → region-B CrashLoop (the §2/§6 UAT walkers' symptom; also gates the
+#4275 region-kill walk).
+
+Host RESOLUTION is a mesh property; WAL REPLICATION is a cnpg-pair property.
+Publishing these `service.cilium.io/global` aliases the moment ClusterMesh is
+enabled (not when replication flips) lets the secondary's host resolve
+cross-mesh to the primary's `-rw`/`-r` endpoint as soon as the mesh peers.
+
+MULTI-REGION SIGNAL (not just clusterMesh.enabled): a TRUE singleton
+(single-region prov) must stay byte-identical — NO mesh aliases, NO
+`service.cilium.io/global` annotation. The signal that distinguishes a pre-flip
+SECONDARY-of-a-2-region-prov from a true singleton is that BOTH
+`topology.primary.region` AND `topology.replica.region` are non-empty:
+cloud-init stamps SOVEREIGN_PRIMARY_REGION + SOVEREIGN_REPLICA_REGION onto EVERY
+region's bootstrap-kit substitute at boot (cloudinit-control-plane.tftpl,
+unconditional), so both are populated on a 2-region prov from the very first
+reconcile — BEFORE and independent of the cnpg-pair flip. A single-region prov
+leaves replica.region empty, so the aliases never render there. This is the
+exact same precondition the cnpg-pair flip itself `required`s (distinct
+non-empty primary/replica regions), so the two gates can never disagree.
+
+nil-safe: clusterMesh / primary / replica may be absent on a direct chart
+consumer that --sets only `mode`. The values.yaml defaults them, but dig keeps
+the helper panic-free even when an overlay nulls the sub-map. Sprig-safe
+`ne (toString …) "false"` so a literal clusterMesh.enabled=false (operator
+opt-out) is honoured.
+*/}}
+{{- define "bp-postgres.meshGlobalServices" -}}
+{{- $topology := .Values.topology | default dict -}}
+{{- $cmOn := ne (toString (dig "clusterMesh" "enabled" true $topology)) "false" -}}
+{{- $primaryRegion := dig "primary" "region" "" $topology -}}
+{{- $replicaRegion := dig "replica" "region" "" $topology -}}
+{{- $multiRegion := and (ne (trim (toString $primaryRegion)) "") (ne (trim (toString $replicaRegion)) "") -}}
+{{- if and $cmOn $multiRegion -}}true{{- end -}}
+{{- end -}}
+
+{{/*
 The follower Cluster CR name on the replica side. Distinct from the
 primary instance name (which the consumer host `<instance>-rw` resolves
 to) so the two Cluster CRs never collide and bp-continuum's switchover

--- a/platform/postgres/chart/templates/cluster.yaml
+++ b/platform/postgres/chart/templates/cluster.yaml
@@ -92,17 +92,30 @@ spec:
   which is N Database CRs on ONE role. The passwordSecret is taken from
   the FIRST binding declaring the owner, matching role-secrets.yaml.
 
-  managed.services (active-hot-standby only): the ClusterMesh-global
-  `-mesh` Service the replica region streams WAL from. Declared via CNPG's
+  managed.services (clusterMesh.enabled, primary side — #4460): the
+  ClusterMesh-global `-mesh` (read) + `-mesh-rw` (write) Service aliases the
+  secondary region resolves cross-mesh. Declared via CNPG's
   `spec.managed.services.additional[]` (CNPG ≥1.22) so CNPG owns the
   Service and applies the `service.cilium.io/global` annotation to the
   right object (the bp-cnpg-pair 0.1.1 fix for "refusing to reconcile
   service: <name>-r, not owned by the cluster"). selectorType: r =
-  read-replica endpoint; the replica region has zero local backends
+  read-replica endpoint; the secondary region has zero local backends
   matching it, so Cilium's local-affinity routing falls through to this
-  primary region.
+  primary region. Previously gated on $ahs (crossRegion=true), which made the
+  alias appear only after the LATE cnpg-pair flip — but the secondary's
+  consumer host is baked to `-mesh-rw` at cloud-init regardless, so the alias
+  must exist the moment the mesh peers (#4460). Now gated on the multi-region
+  meshGlobalServices signal + side=primary; post-flip render is byte-identical.
+
+  PRIMARY-SIDE ONLY: these managed Services carry REAL local backends (this
+  named Cluster's `-rw`/`-r` selectors), so they may render only where the
+  authoritative primary lives. On the SECONDARY side (side=secondary, which in
+  the pre-flip singleton window still renders THIS singleton Cluster) the
+  same-named aliases must be the zero-backend STUB (replica-mesh-service.yaml)
+  so the secondary's reads/writes cross the mesh to region-A — never to its own
+  local pre-flip singleton DB.
   */ -}}
-  {{- $meshSvc := and $ahs .Values.topology.clusterMesh.enabled }}
+  {{- $meshSvc := and (eq (include "bp-postgres.meshGlobalServices" .) "true") (eq (include "bp-postgres.side" .) "primary") }}
   {{- if or .Values.databases $meshSvc }}
   managed:
     {{- if .Values.databases }}

--- a/platform/postgres/chart/templates/replica-mesh-service.yaml
+++ b/platform/postgres/chart/templates/replica-mesh-service.yaml
@@ -31,7 +31,17 @@ This stub:
 This is the bp-cnpg-pair replica-mesh-service.yaml shape, with the names
 keyed off the data instance (`<instance>`) instead of `<fullname>-primary`.
 */ -}}
-{{- if and (ne (toString .Values.enabled) "false") .Values.topology.clusterMesh.enabled (include "bp-postgres.renderReplicaHalf" .) }}
+{{- /* #4460: the secondary-side stub renders whenever the multi-region
+   meshGlobalServices signal is set AND this is the SECONDARY side — DECOUPLED
+   from $ahs/renderReplicaHalf. In the PRE-FLIP singleton window region-B is
+   side=secondary but $ahs=false, so it renders the singleton primary Cluster
+   (cluster.yaml) — whose local managed Services are #4460-suppressed on the
+   secondary side precisely so this zero-backend stub owns the `-mesh`/`-mesh-rw`
+   names instead. That makes the secondary's baked `-mesh-rw` host route
+   cross-mesh to region-A's primary the moment the mesh peers, NOT to region-B's
+   own pre-flip singleton DB. Post-flip (renderReplicaHalf=true) the render is
+   byte-identical to the prior gate. */ -}}
+{{- if and (ne (toString .Values.enabled) "false") (eq (include "bp-postgres.meshGlobalServices" .) "true") (ne (include "bp-postgres.side" .) "primary") }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/platform/postgres/chart/tests/postgres-render.sh
+++ b/platform/postgres/chart/tests/postgres-render.sh
@@ -274,6 +274,64 @@ helm template shared-pg . -f "$TMP/xr.values.yaml" --namespace shared-data \
   --api-versions postgresql.cnpg.io/v1 > "$TMP/xr-replica.yaml" 2>&1 || fail "crossRegion replica render errored"
 grep -qE '^  name: shared-pg-replica$' "$TMP/xr-replica.yaml" || fail "crossRegion=true + side=secondary did NOT render the follower Cluster"
 
+# ── Case 4d: #4460 — PRE-FLIP multi-region → mesh aliases DECOUPLED from $ahs ──
+# A 2-region prov bakes the secondary's keycloak/gitea/harbor host to
+# `shared-pg-mesh-rw` at cloud-init (cloudinit-control-plane.tftpl) + #4439
+# re-stamps it — REGARDLESS of the cnpg-pair flip. But the cnpg-pair flip
+# (crossRegion=true → $ahs) lands LATE (post-mesh-convergence). So the
+# `-mesh`/`-mesh-rw` global Service aliases MUST render the moment the mesh is
+# enabled + the prov is multi-region (both primary/replica regions stamped),
+# NOT only after crossRegion flips. The pre-flip topology is mode=singleton,
+# crossRegion=false (NOT yet flipped), but BOTH regions ARE stamped.
+#
+# Multi-region signal = primary.region AND replica.region both non-empty
+# (cloud-init stamps both on every region at boot). A TRUE singleton leaves
+# replica.region empty → no aliases (Case 5 lock).
+echo "[render] Case 4d: #4460 PRE-FLIP multi-region (singleton + regions stamped) → -mesh/-mesh-rw aliases render WITHOUT the cnpg-pair flip"
+cat > "$TMP/preflip.values.yaml" <<'YAML'
+instance: { name: shared-pg }
+topology:
+  mode: singleton
+  crossRegion: false
+  side: primary
+  instances: 1
+  primary: { region: hz-fsn-rtz-prod }
+  replica: { region: hz-hel-rtz-prod }
+databases:
+  - { name: registry, owner: harbor, reflect: { secretName: harbor-database-secret, namespaces: [harbor] } }
+YAML
+# Primary side (pre-flip): the singleton Cluster (instances:1, NO $ahs sync
+# block) PLUS the -mesh/-mesh-rw managed Service aliases (real local backends).
+helm template shared-pg . -f "$TMP/preflip.values.yaml" --namespace shared-data \
+  --api-versions postgresql.cnpg.io/v1 > "$TMP/preflip-primary.yaml" 2>&1 || fail "#4460 pre-flip primary render errored"
+grep -qE '^  instances: 1$' "$TMP/preflip-primary.yaml" || fail "#4460 pre-flip primary expected the SINGLETON Cluster (instances: 1), not the \$ahs 3-instance"
+if grep -qE '^    synchronous:$' "$TMP/preflip-primary.yaml"; then
+  fail "#4460 pre-flip primary leaked the \$ahs synchronous block (crossRegion is still false — replication must NOT be active pre-flip)"
+fi
+grep -q 'name: shared-pg-mesh-rw' "$TMP/preflip-primary.yaml" \
+  || fail "#4460 pre-flip primary MISSING the -mesh-rw WRITE alias (the secondary's baked host would NXDOMAIN)"
+grep -q 'name: shared-pg-mesh' "$TMP/preflip-primary.yaml" || fail "#4460 pre-flip primary missing the -mesh read alias"
+grep -q 'service.cilium.io/global: "true"' "$TMP/preflip-primary.yaml" || fail "#4460 pre-flip primary -mesh alias missing the global annotation"
+grep -qE '^        - selectorType: rw$' "$TMP/preflip-primary.yaml" || fail "#4460 pre-flip primary -mesh-rw not selectorType rw (real backends)"
+# Secondary side (pre-flip): renders the singleton Cluster locally (side gate is
+# $ahs-false → not the replica follower) BUT the -mesh/-mesh-rw STUB owns the
+# global names (zero-backend cross-mesh), NOT the local managed Services — so the
+# secondary's writes cross the mesh to region-A, never to its own pre-flip DB.
+helm template shared-pg . -f "$TMP/preflip.values.yaml" --namespace shared-data \
+  --set topology.side=secondary \
+  --api-versions postgresql.cnpg.io/v1 > "$TMP/preflip-secondary.yaml" 2>&1 || fail "#4460 pre-flip secondary render errored"
+grep -q 'name: shared-pg-mesh-rw' "$TMP/preflip-secondary.yaml" \
+  || fail "#4460 pre-flip SECONDARY MISSING the -mesh-rw stub (root-cause NXDOMAIN: keycloak/gitea/harbor host baked to -mesh-rw resolves nothing)"
+grep -q 'name: shared-pg-mesh' "$TMP/preflip-secondary.yaml" || fail "#4460 pre-flip secondary missing the -mesh stub"
+grep -q 'catalyst.openova.io/role: write-endpoint' "$TMP/preflip-secondary.yaml" || fail "#4460 pre-flip secondary -mesh-rw stub missing write-endpoint label"
+# The secondary's -mesh-rw must be the zero-backend STUB, NOT a managed Service
+# under the local Cluster's managed.services.additional (which would bind local
+# backends and shadow region-A).
+if grep -qE '^      additional:$' "$TMP/preflip-secondary.yaml"; then
+  fail "#4460 pre-flip secondary leaked the managed.services.additional aliases (local backends would shadow region-A — must be the zero-backend stub)"
+fi
+grep -q 'cnpg.io/instanceRole: primary' "$TMP/preflip-secondary.yaml" || fail "#4460 pre-flip secondary -mesh-rw stub missing primary-role selector"
+
 # ── Case 5: singleton → byte-identical (NO sync, NO mesh, NO netpol) ──────
 echo "[render] Case 5: singleton → no synchronous block, no -mesh Service, only the CNPG-operator status-probe NetworkPolicy (no AHS replication carve-out)"
 if grep -q 'synchronous_commit' "$TMP/shared.yaml"; then

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -3934,7 +3934,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.6",
+      "version": "0.2.8",
       "section": "pts-4-1-data-services",
       "depends": [
         "bp-cnpg",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4069,7 +4069,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.2.5",
+    "version": "0.2.8",
     "section": "pts-4-1-data-services",
     "depends": [
       "bp-cnpg",

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5800,7 +5800,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.2.6"
+  # 0.2.8 (#4460): -mesh/-mesh-rw global Service aliases decoupled from the
+  # cnpg-pair flip (region-B cross-region consumer DB host NXDOMAIN fix).
+  version: "0.2.8"
   visibility: listed
   # Shareability + Contexts (#3370) — seeded verbatim from
   # platform/postgres/blueprint.yaml (lockstep-guarded). One instance
@@ -5893,7 +5895,10 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-postgres
-    version: 0.2.6
+    # 0.2.8 (#4460): -mesh/-mesh-rw global Service aliases decoupled from the
+    # cnpg-pair flip (render on the multi-region signal so cross-region consumer
+    # DB hosts resolve the moment the mesh peers; region-B NXDOMAIN fix).
+    version: 0.2.8
   # Seeded verbatim from platform/postgres/blueprint.yaml spec.topology.
   # singleton = single-instance Cluster; active-hot-standby = sync
   # replication across regions (ADR-0004 Pillar-3 zero-tx-loss) via the


### PR DESCRIPTION
## Problem
On a fresh 2-region prov, region-B keycloak/gitea/harbor CrashLoop because their DB write host `shared-pg-mesh-rw.shared-data.svc.cluster.local` NXDOMAINs. Found by UAT walkers (§2, §6); also gates the region-kill failover walk (#4275).

## Root cause (verified)
The ClusterMesh-global `-mesh`/`-mesh-rw` Service aliases were gated on `$ahs` (`topology.crossRegion=true`), which only flips true AFTER full ClusterMesh convergence + the cnpg-pair flip (`SOVEREIGN_ENABLE_CNPG_PAIR=true`). But the secondary's consumer host is baked to `shared-pg-mesh-rw` unconditionally at cloud-init boot (`cloudinit-control-plane.tftpl`) + #4439 re-stamps it. So pre-flip — and PERMANENTLY when the mesh shows `0 remote clusters ready` — the baked host had no backing Service.

## Fix (chart 0.2.7 -> 0.2.8)
Host RESOLUTION is a mesh property; WAL REPLICATION is a cnpg-pair property. New helper `meshGlobalServices` gates the aliases on `clusterMesh.enabled` + a MULTI-REGION signal (both primary.region AND replica.region stamped — cloud-init sets both on every region at boot; a true single-region singleton stays byte-identical, NO aliases). Primary side renders the managed `-mesh`/`-mesh-rw` Services; secondary side renders the zero-backend stub so writes cross the mesh to region-A. The cross-mesh consumer-5432 path is already opened by 0.2.7's `networkPolicy.sharedConsumers` (#4442). cnpg-pair-specific carve-outs stay `$ahs`-gated; post-flip render is byte-identical to 0.2.7. Helper is nil-safe via `dig`.

## Mesh-convergence note (point #2 — post-re-prov walk)
`0 remote clusters ready` is an orchestrator-timing property of catalyst-api `AutoEstablishClusterMesh`, NOT a missing enablement (apiserver/LB/`useAPIServer:true`/`cluster.name`/`id` all wired at prov time in `01-cilium.yaml`). This fix removes bp-postgres from the critical path. If region-B is still down post-re-prov, diagnose the mesh (`clustermesh.go`): `cilium clustermesh status` -> apiserver LB-IP / node-EIP-NodePort allocation -> the `<peer>.mesh.cilium.io` `hostAliases` TLS path (`patchCiliumHostAliases`).

## Tests
14/14 render cases (new Case 4d), helm lint clean, catalog-seed lockstep green, pin-sync-audit green, go catalog package builds. Pin lockstep: 16a/16c/16d + catalog-seed source.version & card spec.version + blueprint.yaml + generated blueprints.json/catalog.generated.ts -> 0.2.8.

Refs #4460 #4439 #4436 #4275

Generated with Claude Code