### PR TITLE
fix(#4464): deploy-bump per-line cherry-pick stops whole-file clobber + re-pin org-controller 89993b2 (1.4.894)

### DIFF
--- a/.github/actions/deploy-bump/action.yaml
+++ b/.github/actions/deploy-bump/action.yaml
@@ -137,27 +137,40 @@ runs:
         # fix. Lead had to manually `workflow_dispatch` Build & Deploy
         # to recover.
         #
-        # Fix: instead of trying to rebase our commit across a race,
-        # we (a) snapshot the intended file contents up-front, then
-        # (b) on every push retry, hard-reset to the latest origin/main
-        # AND re-apply the snapshot. The action becomes
-        # state-machine-shaped: "make origin/main have these file
-        # contents, with this commit message." Conflicts can't drop
-        # the bump because there IS no rebase — every retry starts
-        # fresh from origin/main and re-applies the intent on top.
-        INTENT_DIR="${RUNNER_TEMP:-/tmp}/deploy-bump-intent-$$"
-        mkdir -p "${INTENT_DIR}"
-        SNAPSHOTTED_PATHS=()
-        # shellcheck disable=SC2086
-        for p in $(echo "${DEPLOY_BUMP_PATHS}"); do
-          if [ -e "${p}" ]; then
-            mkdir -p "${INTENT_DIR}/$(dirname "${p}")"
-            cp "${p}" "${INTENT_DIR}/${p}"
-            SNAPSHOTTED_PATHS+=("${p}")
-          fi
-        done
-        echo "deploy-bump: snapshotted ${#SNAPSHOTTED_PATHS[@]} path(s) into ${INTENT_DIR}"
-
+        # Fix v1 (#2584, 2026-06-01): instead of trying to rebase our
+        # commit across a race, we snapshot the intended file contents
+        # up-front, then on every push retry hard-reset to the latest
+        # origin/main AND re-apply the snapshot. State-machine-shaped:
+        # "make origin/main have these file contents."
+        #
+        # Fix v2 (#4464, 2026-06-26) — the v1 WHOLE-FILE snapshot was
+        # itself a clobber. It re-applied the ENTIRE file content this
+        # job rendered, so any OTHER line a concurrent deploy job
+        # changed in the same file got reverted to THIS job's stale
+        # snapshot. Concrete damage: build-organization-controller
+        # bumped controllers.organization.image.tag b23af68 -> 89993b2
+        # (committed 69d5d3af4), then catalyst-build's deploy-bump
+        # re-applied its whole values.yaml snapshot (which still carried
+        # b23af68 because its checkout predated the per-controller bump)
+        # and clobbered org-ctrl back to b23af68 in 04bff9030 — a
+        # fast-forward CHILD of 69d5d3af4 that STILL reverted the line.
+        # Result: every fresh prov shipped org-controller WITHOUT #4455
+        # tenant-dns + #4462 delete-cascade. Same delivery-gap class as
+        # #4409/#4411/#4415.
+        #
+        # v2 fix: commit this job's change as a normal commit, then on
+        # each push retry reset to fresh origin/main and CHERRY-PICK that
+        # commit back on. cherry-pick is a per-hunk three-way merge, so
+        # it re-applies ONLY this job's hunks onto whatever a concurrent
+        # job already pushed: lines another job changed are PRESERVED,
+        # only lines THIS job intended to change are touched. When two
+        # jobs changed the EXACT same field (e.g. both bumped
+        # catalystApi.tag — a legitimate last-writer-wins case), `-X
+        # theirs` favours our deploy commit so the newer build still
+        # wins (matches the v1 behaviour for that field). A structural
+        # conflict git cannot auto-resolve fails loudly rather than
+        # pushing a half-merged tree.
+        #
         # Initial check — if nothing actually changed vs HEAD, exit
         # early with pushed=false (idempotent re-runs).
         # shellcheck disable=SC2086
@@ -166,7 +179,6 @@ runs:
           echo "deploy-bump: no staged changes — skipping commit/push."
           echo "pushed=false"   >> "$GITHUB_OUTPUT"
           echo "commit_sha="   >> "$GITHUB_OUTPUT"
-          rm -rf "${INTENT_DIR}"
           exit 0
         fi
 
@@ -181,7 +193,7 @@ runs:
             pushed=true
             break
           fi
-          echo "deploy-bump: push attempt ${i}/${MAX} failed — refetching + re-applying snapshot."
+          echo "deploy-bump: push attempt ${i}/${MAX} failed — refetching + re-applying intent commit (per-line cherry-pick)."
 
           # Recover from any prior iteration that may have left a
           # rebase / cherry-pick / merge in progress. Best-effort: if
@@ -192,38 +204,67 @@ runs:
           git merge --abort 2>/dev/null || true
 
           # Fetch latest origin/main and hard-reset HEAD onto it. This
-          # discards our local deploy commit; we re-create it from the
-          # snapshot below, which guarantees the values.yaml /
-          # template / Chart.yaml content we intended is what reaches
-          # main (regardless of what the racing deploy committed).
+          # discards our local deploy commit; we RE-CREATE it by
+          # cherry-picking our intent commit (#4464), which is a
+          # per-hunk three-way merge — a concurrent job's edits to
+          # OTHER lines of the same file survive (unlike the v1
+          # whole-file snapshot re-apply that reverted them).
           git fetch origin main
           git reset --hard origin/main
 
-          # Re-apply the snapshotted intent.
-          for p in "${SNAPSHOTTED_PATHS[@]}"; do
-            src="${INTENT_DIR}/${p}"
-            if [ -f "${src}" ]; then
-              mkdir -p "$(dirname "${p}")"
-              cp "${src}" "${p}"
+          # cherry-pick replays ONLY our hunks onto fresh origin/main.
+          # Conflict-resolution policy (#4464): when a concurrent deploy
+          # changed the SAME field this job owns (e.g. both bumped
+          # catalystApi.tag), take OURS — last-writer-wins for the field
+          # this job is the authoritative builder of, while still
+          # PRESERVING every line neither job's hunk touched. Lines only
+          # the OTHER job changed never conflict (different hunk) and are
+          # carried through untouched — that's the v1 clobber this fixes.
+          if git cherry-pick --keep-redundant-commits -X theirs "${COMMIT_SHA}" 2>/tmp/deploy-bump-cp-err; then
+            # Clean replay (possibly redundant if origin/main already
+            # has our change — --keep-redundant-commits makes that an
+            # empty commit whose TREE equals origin/main). Detect that
+            # and accept as no-op success, resetting HEAD back to the
+            # remote tip so the post-push verification (FINAL_SHA must
+            # be an ancestor of origin/main) holds.
+            #
+            # NOTE: `-X theirs` here means "favour the side being
+            # PICKED" (our deploy commit) on conflict — cherry-pick
+            # inverts the ours/theirs sense vs merge, so `theirs` ==
+            # our intent. See the -X-theirs test in test-clobber.sh.
+            if git diff --quiet "origin/main" HEAD; then
+              echo "deploy-bump: intent already present on origin/main after refetch on attempt ${i} — accepting as no-op success."
+              git reset --hard origin/main
+              pushed=true
+              break
             fi
-          done
-
-          # shellcheck disable=SC2086
-          echo "${DEPLOY_BUMP_PATHS}" | xargs git add --
-          if git diff --staged --quiet; then
-            # The racing deploy already pushed identical content (rare
-            # but possible — both jobs computed the same SHA short for
-            # the same git tree). Accept as no-op success.
-            echo "deploy-bump: intent matches origin/main after refetch on attempt ${i} — accepting as no-op success."
-            pushed=true
-            break
+          else
+            # cherry-pick stopped. With -X theirs the only way here is an
+            # add/add or delete/modify edge git can't auto-resolve, or an
+            # empty pick. If nothing is staged/changed, the intent was
+            # already on main — no-op success. Otherwise fail loudly
+            # rather than push a half-merged tree.
+            if git diff --quiet && git diff --staged --quiet; then
+              echo "deploy-bump: cherry-pick empty (intent already on origin/main) on attempt ${i} — accepting as no-op success."
+              git cherry-pick --abort 2>/dev/null || true
+              git reset --hard origin/main
+              pushed=true
+              break
+            fi
+            echo "deploy-bump: ERROR — intent commit ${COMMIT_SHA} could not be cherry-picked onto fresh origin/main even with -X theirs (structural conflict). Failing loudly rather than pushing a half-merged tree (#4464)." >&2
+            cat /tmp/deploy-bump-cp-err >&2 || true
+            git status --porcelain || true
+            git cherry-pick --abort 2>/dev/null || true
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            echo "commit_sha=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
+            exit 1
           fi
 
-          git commit -m "${DEPLOY_BUMP_MESSAGE}"
+          # The cherry-pick recreated the commit; refresh COMMIT_SHA so
+          # the post-push verification checks the SHA we actually pushed.
+          COMMIT_SHA="$(git rev-parse HEAD)"
           sleep "$((i * 2))"
         done
-
-        rm -rf "${INTENT_DIR}"
 
         if [ "${pushed}" != "true" ]; then
           echo "deploy-bump: all ${MAX} push attempts failed." >&2

--- a/.github/actions/deploy-bump/test-clobber.sh
+++ b/.github/actions/deploy-bump/test-clobber.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# #4464 verification — the deploy-bump v1 whole-file-snapshot clobber.
+#
+# Reproduces the live damage on origin/main (commit 04bff9030,
+# 2026-06-26): two deploy jobs touched DIFFERENT fields of the same
+# values.yaml, and the v1 action's whole-file snapshot re-apply on
+# push-retry REVERTED the field the OTHER job had just bumped.
+#
+# Concrete shape:
+#   1. build-organization-controller pushes a commit that bumps
+#      controllers.organization.image.tag  b23af68 -> 89993b2
+#      (the field carrying #4455 tenant-dns + #4462 delete-cascade).
+#   2. catalyst-build's deploy-bump was triggered off an EARLIER SHA
+#      where org-ctrl was still b23af68; it bumps a DIFFERENT field
+#      images.catalystApi.tag fcb305f -> 89993b2 and tries to push.
+#   3. origin/main has advanced (the org-ctrl bump landed first), so
+#      the push is rejected and deploy-bump refetches + re-applies.
+#
+# v1 BUG: the re-apply copied catalyst-build's WHOLE values.yaml
+# snapshot (org-ctrl still b23af68 in it) over fresh origin/main →
+# clobbered org-ctrl 89993b2 -> b23af68. Every fresh prov then shipped
+# org-controller WITHOUT both merged fixes.
+#
+# v2 fix (#4464): deploy-bump re-applies ONLY its OWN hunk
+# (catalystApi.tag) via a per-line cherry-pick, so the org-ctrl field
+# the other job bumped is PRESERVED.
+#
+# This test asserts the POST-fix action leaves BOTH bumps on main.
+#
+# Run: bash .github/actions/deploy-bump/test-clobber.sh
+# Exit 0: clobber-safety verified. Exit 1: org-ctrl field was reverted.
+
+set -euo pipefail
+
+WORK="${TMPDIR:-/tmp}/deploy-bump-clobber-test-$$"
+trap 'rm -rf "${WORK}"' EXIT
+mkdir -p "${WORK}"
+
+( cd "${WORK}" && git init -b main --bare upstream.git >/dev/null )
+
+# -- Seed: a values.yaml with TWO independent fields (mirrors the real
+#    products/catalyst/chart/values.yaml structure: an images block and
+#    a controllers block).
+SEED="${WORK}/seed"
+git clone -b main "${WORK}/upstream.git" "${SEED}" >/dev/null 2>&1 || git clone "${WORK}/upstream.git" "${SEED}" >/dev/null 2>&1
+cat > "${SEED}/values.yaml" <<'YAML'
+images:
+  catalystApi:
+    tag: "fcb305f"
+  catalystUi:
+    tag: "fcb305f"
+controllers:
+  organization:
+    image:
+      repository: "ghcr.io/openova-io/openova/organization-controller"
+      tag: "b23af68"
+      pullPolicy: IfNotPresent
+YAML
+( cd "${SEED}"
+  git config user.name  "seed"; git config user.email "seed@test.local"
+  git checkout -b main 2>/dev/null || true
+  git add values.yaml
+  git commit -m "seed: catalystApi=fcb305f org-ctrl=b23af68" >/dev/null
+  git push -u origin main >/dev/null 2>&1
+)
+
+# -- Workflow A (build-organization-controller, the racing winner):
+#    bumps ONLY the org-ctrl field b23af68 -> 89993b2 and pushes first.
+WORK_A="${WORK}/wf-a"
+git clone -b main "${WORK}/upstream.git" "${WORK_A}" >/dev/null 2>&1
+sed -i 's/tag: "b23af68"/tag: "89993b2"/' "${WORK_A}/values.yaml"
+( cd "${WORK_A}"
+  git config user.name  "wf-a"; git config user.email "wf-a@test.local"
+  git add values.yaml
+  git commit -m "deploy: bump organization-controller image to 89993b2" >/dev/null
+  git push origin HEAD:main >/dev/null
+)
+
+# -- Workflow B (catalyst-build's deploy-bump): checkout predates wf-a,
+#    so its tree still has org-ctrl=b23af68. It bumps ONLY catalystApi
+#    (a DIFFERENT field) fcb305f -> 89993b2, then invokes deploy-bump.
+#    By push time origin/main carries wf-a's org-ctrl bump.
+WORK_B="${WORK}/wf-b"
+git clone -b main "${WORK}/upstream.git" "${WORK_B}" >/dev/null 2>&1
+( cd "${WORK_B}" && git reset --hard HEAD~1 >/dev/null 2>&1 )  # back to seed (pre wf-a)
+sed -i 's/    tag: "fcb305f"/    tag: "89993b2"/g' "${WORK_B}/values.yaml"
+
+export DEPLOY_BUMP_PATHS="values.yaml"
+export DEPLOY_BUMP_MESSAGE="deploy: update catalyst images to 89993b2"
+export DEPLOY_BUMP_MAX_ATTEMPTS="5"
+export DEPLOY_BUMP_USER_NAME="wf-b"
+export DEPLOY_BUMP_USER_EMAIL="wf-b@test.local"
+export RUNNER_TEMP="${WORK}/runner-temp"; mkdir -p "${RUNNER_TEMP}"
+
+ACTION_BODY="$(awk '/^      run: \|$/{flag=1; next} flag' "$(dirname "$0")/action.yaml")"
+GITHUB_OUTPUT="${WORK}/gh-output"; export GITHUB_OUTPUT; touch "${GITHUB_OUTPUT}"
+
+( cd "${WORK_B}" && eval "${ACTION_BODY}" ) || {
+  echo "TEST FAIL: deploy-bump action body exited non-zero" >&2
+  exit 1
+}
+
+# -- Verify BOTH fields are 89993b2 on main: catalystApi (wf-b's intent)
+#    AND org-ctrl (wf-a's bump that v1 silently reverted to b23af68).
+CHECK="${WORK}/check"
+git clone "${WORK}/upstream.git" "${CHECK}" >/dev/null 2>&1
+API_TAG="$(awk '/catalystApi:/{f=1} f&&/tag:/{match($0,/"[^"]*"/); print substr($0,RSTART+1,RLENGTH-2); exit}' "${CHECK}/values.yaml")"
+ORG_TAG="$(awk '/organization:/{f=1} f&&/^      tag:/{match($0,/"[^"]*"/); print substr($0,RSTART+1,RLENGTH-2); exit}' "${CHECK}/values.yaml")"
+
+rc=0
+if [ "${API_TAG}" != "89993b2" ]; then
+  echo "TEST FAIL: catalystApi.tag = ${API_TAG} (expected 89993b2 — wf-b's own bump was lost)" >&2
+  rc=1
+fi
+if [ "${ORG_TAG}" != "89993b2" ]; then
+  echo "TEST FAIL (#4464 CLOBBER): controllers.organization.image.tag = ${ORG_TAG} (expected 89993b2)." >&2
+  echo "  wf-b's whole-file re-apply REVERTED the org-ctrl field wf-a bumped." >&2
+  echo "  This is exactly the live 04bff9030 regression that shipped org-controller" >&2
+  echo "  WITHOUT #4455 tenant-dns + #4462 delete-cascade on every fresh prov." >&2
+  rc=1
+fi
+
+if [ "${rc}" -ne 0 ]; then
+  echo "--- final values.yaml on main ---" >&2
+  cat "${CHECK}/values.yaml" >&2
+  exit 1
+fi
+
+if ! grep -q '^pushed=true$' "${GITHUB_OUTPUT}"; then
+  echo "TEST FAIL: action did not report pushed=true" >&2
+  cat "${GITHUB_OUTPUT}" >&2
+  exit 1
+fi
+
+echo "PASS: clobber-safety verified — wf-b's catalystApi bump landed AND wf-a's"
+echo "      org-controller bump (89993b2) survived. No #4464 whole-file revert."

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1158,7 +1158,14 @@ spec:
       #   bp-reflector lands the key) + loud-fails instead of silently skipping →
       #   per-Org console.<slug>.<pool> A-record is written on a fresh prov (was
       #   NXDOMAIN). Lockstep w/ Chart.yaml. Refs #4290 #4179.
-      version: 1.4.893
+      # 1.4.894 — #4464: re-pin organization-controller image b23af68 -> 89993b2.
+      #   The deploy-bump #2584 whole-file snapshot re-apply was clobbering the
+      #   per-controller bump back to b23af68 on every catalyst-build deploy run,
+      #   so a fresh prov shipped org-controller WITHOUT #4455 tenant-dns OR #4462
+      #   delete-cascade (both already merged). 89993b2 descends from b23af68 → it
+      #   keeps the #4393 Guaranteed-QoS vcluster fix too. Lockstep w/ Chart.yaml.
+      #   Refs #4464 #4455 #4462 #4393.
+      version: 1.4.894
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3254,7 +3254,12 @@ name: bp-catalyst-platform
 #   preserved verbatim. The #4452 guard chart/tests/gitea-flux-auth-sync-rbac-
 #   order.sh is extended with parallel gate-3/gate-4 cases for this second job.
 #   Lockstep w/ bootstrap-kit slot 13 pin. Refs #4447 #3763 #3781.
-version: 1.4.893
+# 1.4.894 — #4464: re-pin organization-controller image b23af68 -> 89993b2 (the
+#   deploy-bump #2584 whole-file snapshot re-apply clobbered the per-controller
+#   bump back to b23af68, shipping org-controller WITHOUT #4455 tenant-dns +
+#   #4462 delete-cascade on every fresh prov). 89993b2 is a descendant of b23af68
+#   so it retains #4393 Guaranteed-QoS. Lockstep w/ bootstrap-kit slot 13 pin.
+version: 1.4.894
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/
 #   platform/crossplane chart + blueprint.yaml + bootstrap-kit slot 04). crossplane-core
 #   was still OOMKilled (CrashLoopBackOff, 55 restarts, exit 137, killed ~90s after start)

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -715,9 +715,20 @@ controllers:
       # bumped this field to b23af68 in 3b9235c1f, then the #2851 controller sweep
       # (86c5a7cfd) REVERTED it back to 5cbfbd8 ~2min later — the exact deploy-bot
       # treadmill that left every m-tier funnel Org stuck at 'vcluster-0 forbidden:
-      # ratio 20' (verified live on g10vc). Re-pin to b23af68 (#4393) explicitly;
-      # without it the org-controller never renders the Guaranteed-QoS vcluster.
-      tag: "b23af68"
+      # ratio 20' (verified live on g10vc).
+      # 89993b2 (#4464, 2026-06-26) — b23af68 LACKS both #4455 tenant-dns self-heal
+      # (resolvePoolPowerDNSAPIKey → kills console.<slug>.<pool> NXDOMAIN, #4290/#4179)
+      # AND #4462 delete-cascade (TenantNetworkingFinalizer → kills Org-delete leak).
+      # Both merged on main (89993b2c2 / d864ce942); the build-organization-controller
+      # workflow bumped this field → 89993b2 in 69d5d3af4, then the catalyst-build
+      # deploy-bump (#2584 whole-file snapshot re-apply) REVERTED it → b23af68 in
+      # 04bff9030 — a fast-forward CHILD of the per-controller bump that still
+      # clobbered the line because its stale snapshot carried b23af68 (the #2851
+      # sweep that run logged '0/5 bumped', so the revert came from the snapshot
+      # re-apply, NOT the sweep). 89993b2 is a direct DESCENDANT of b23af68 so it
+      # CONTAINS the #4393 Guaranteed-QoS LimitRange fix AS WELL AS #4455 + #4462.
+      # Durable fix to the deploy-bump whole-file clobber tracked in #4464.
+      tag: "89993b2"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:


### PR DESCRIPTION
## Root cause — deploy-bump #2584 whole-file snapshot IS the clobber

The fresh-prov `bp-catalyst-platform` chart was shipping **org-controller pinned to `b23af68`**, which lacks BOTH:
- #4455 tenant-dns self-heal (`resolvePoolPowerDNSAPIKey`) → per-Org `console.<slug>.<pool>` NXDOMAIN (#4290/#4179) recurs.
- #4462 delete-cascade (`TenantNetworkingFinalizer`) → Org-delete tenant-networking leak recurs.

Both fixes are merged on `main`. The per-controller workflow correctly bumped `controllers.organization.image.tag` → `89993b2` (commit `69d5d3af4`). The very next `catalyst-build` deploy run reverted it back to `b23af68` (commit `04bff9030`):

```
-      tag: "89993b2"
+      tag: "b23af68"
```

It is **NOT the #2851 sweep** — that step logged `#2851 sweep: bumped 0/5` (its GHCR query returns no 7-hex tag and skips). The revert came from the **`deploy-bump` composite action's #2584 whole-file snapshot re-apply**:

> *v1 design: snapshot the intended file contents up-front; on every push retry `git reset --hard origin/main` and re-apply the whole snapshot.*

catalyst-build was triggered off `89993b2c2` where org-ctrl was still `b23af68` (the per-controller bump hadn't landed yet), so its snapshot carried `b23af68`. On push-retry it discarded the per-controller bump (`69d5d3af4`) and re-wrote the **entire** `values.yaml`, clobbering org-ctrl `89993b2 → b23af68`. Any field another concurrent deploy job changed gets reverted this way. Same delivery-gap class as #4409 / #4411 / #4415.

## Fixes

### Durable (the real bug) — `.github/actions/deploy-bump/action.yaml`
Replace the whole-file snapshot re-apply with a **per-line cherry-pick**. Commit the change normally; on each push retry reset to fresh origin/main and `git cherry-pick -X theirs` the intent commit. cherry-pick is a per-hunk three-way merge:
- Lines another concurrent job changed are **preserved** (different hunk, no conflict).
- Same-field two-job bumps (e.g. both bump `catalystApi.tag`) resolve last-writer-wins via `-X theirs` — matches v1 behaviour for that field.
- A structural conflict git can't auto-resolve **fails loudly** instead of pushing a half-merged tree.

New `test-clobber.sh` reproduces `04bff9030` (two jobs bump DIFFERENT fields) and asserts both survive. `test-race.sh` (same-field last-writer-wins) and `test-basic.sh` still pass — all three green.

### Immediate — re-pin org-controller
`controllers.organization.image.tag` `b23af68` → `89993b2`. `89993b2` is a direct **descendant** of `b23af68`, so it retains the #4393 Guaranteed-QoS LimitRange fix AS WELL AS #4455 + #4462. GHCR image `89993b2` confirmed present. Chart.yaml + bootstrap-kit slot-13 bumped lockstep `1.4.893` → `1.4.894`.

## Validation
- `bash test-basic.sh` / `test-race.sh` / `test-clobber.sh` → all PASS
- `shellcheck` on the embedded action body → clean
- `helm lint products/catalyst/chart` → 0 failed
- `helm template` → renders `organization-controller:89993b2`
- `scripts/check-bootstrap-kit-pin-sync.sh` → PASS (`bp-catalyst-platform: chart=1.4.894 pin=1.4.894`)

## Verify-don't-trust (post-merge)
```
git show origin/main:products/catalyst/chart/values.yaml | grep -A1 organization-controller   # -> tag: 89993b2
git show 89993b2:core/controllers/organization/internal/controller/tenant_dns.go | grep -c resolvePoolPowerDNSAPIKey  # -> 4
git show 89993b2:core/controllers/organization/internal/controller/organization_controller.go | grep -c TenantNetworkingFinalizer  # -> 3
```

Refs #4464 #4455 #4462 #4393 #2851 #2584 #4409 #4411 #4415 #4290 #4179

🤖 Generated with [Claude Code](https://claude.com/claude-code)