### PR TITLE
fix(bp-cilium): pin MTU=1370 for wireguard+vxlan datapath — kill cross-node pod TCP timeouts on Huawei fresh prov (1.4.4)

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -99,7 +99,13 @@ spec:
       # AppRegistration client — oauth2-proxy callback was 500ing on hw133
       # (aud=[realm-management account], never hubble-ui). Same fix class as
       # the bp-oidc-gate openova-flow audience-mapper (#3447).
-      version: 1.4.3
+      # 1.4.4 (#4467, Huawei kom4dc fresh prov): pin cilium.MTU=1370 so the
+      # VXLAN-tunnel + WireGuard-node-encryption combined overhead is
+      # subtracted from the pod-facing devices (cilium_vxlan/cilium_host/
+      # lxc*). Auto-MTU left them at 1500 → oversized frames DF-dropped at
+      # the 1420 WireGuard MTU → all cross-node pod TCP to large payloads
+      # timed out → Phase-1 convergence deadlock. See the MTU value above.
+      version: 1.4.4
       sourceRef:
         kind: HelmRepository
         name: bp-cilium
@@ -133,6 +139,20 @@ spec:
       # The :=10.0.1.2 fallback preserves single-region (primary-only)
       # provisions where the substitute var would be empty/absent.
       k8sServiceHost: ${CILIUM_K8S_SERVICE_HOST:=10.0.1.2}
+      # 1.4.4 (#4467, Huawei kom4dc fresh prov): pin the datapath MTU to
+      # account for the COMBINED VXLAN-tunnel(+50) + WireGuard-node-
+      # encryption(+80) overhead. Cilium auto-MTU read eth0=1500 and
+      # programmed cilium_wg0=1420 but left cilium_vxlan/cilium_host/lxc*
+      # at 1500 → full-size pod frames overflow the WireGuard MTU and are
+      # silently DF-dropped → ALL cross-node pod TCP to non-trivial payloads
+      # times out (curl 28) → Phase-1 convergence deadlock (gitea-token-mint
+      # → gitea-http.gitea.svc:3000 cross-node). 1500−50−80 = 1370; a 1370B
+      # pod payload + 50B VXLAN = 1420 = the cilium_wg0 MTU exactly. The
+      # chart default (platform/cilium/chart/values.yaml `cilium.MTU: 1370`)
+      # already carries this; pinned here too so the load-bearing value is
+      # visible at the slot. Jumbo-frame / non-1500-eth0 Sovereigns override
+      # via ${CILIUM_MTU:=1370} in their per-Sovereign overlay (eth0−130).
+      MTU: ${CILIUM_MTU:=1370}
       # Phase-8a bug #15 (otech8 deployment 1bfc46347564467b 2026-05-01):
       # cilium-agent waits forever for the operator to register
       # ciliumenvoyconfigs + ciliumclusterwideenvoyconfigs CRDs.

--- a/platform/cilium/blueprint.yaml
+++ b/platform/cilium/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 1.4.3
+  version: 1.4.4
   card:
     title: Cilium
     summary: Unified CNI + Service Mesh (eBPF). mTLS via WireGuard, Hubble observability, Gateway API.

--- a/platform/cilium/chart/Chart.yaml
+++ b/platform/cilium/chart/Chart.yaml
@@ -1,5 +1,24 @@
 apiVersion: v2
 name: bp-cilium
+# 1.4.4 (#4467, 2026-06-26): pin cilium.MTU=1370 for the WireGuard+VXLAN
+# datapath. Root-caused live on a Huawei me-east-215 (kom4dc) fresh prov:
+# the chart runs routingMode=tunnel/tunnelProtocol=vxlan (upstream defaults
+# — neither key is set here) WITH encryption.type=wireguard +
+# nodeEncryption=true. Cilium's auto-MTU read eth0=1500 and correctly
+# programmed cilium_wg0=1420 (eth0−80 WG) but did NOT compound the VXLAN
+# (+50) overhead onto the pod-facing devices — cilium_vxlan / cilium_host /
+# pod lxc* veths were left at 1500. A full-size 1500-byte pod frame then
+# becomes a 1550-byte VXLAN packet that overflows the 1420 WireGuard MTU
+# and is silently DF-dropped. Small packets (health probes, request lines)
+# pass; large ones (TCP data, HTTP bodies, TLS handshakes) drop → EVERY
+# cross-node pod-to-pod TCP to a non-trivial payload times out (curl 28).
+# Phase-1 convergence deadlocks (catalyst-gitea-token-mint can't reach
+# gitea-http.gitea.svc:3000 on another node → bp-catalyst-platform never
+# finishes). Correct pod MTU = 1500 − 50 (VXLAN) − 80 (WireGuard) = 1370;
+# 1370 + 50 VXLAN = 1420 = the cilium_wg0 MTU exactly. WireGuard is
+# always-on for every Catalyst Sovereign so a static 1370 default never
+# regresses a non-WG path. Lockstep: blueprint.yaml 1.4.4 + 01-cilium.yaml
+# slot pin 1.4.4. New tests/mtu-wireguard-vxlan.sh render gate.
 # 1.4.2 (#3374, 2026-06-14): hubble-ui oauth2-proxy client-secret is now
 # delivered by bp-sso-bridge (which APPLIES the ExternalSecret from its own
 # post-ESO reconciler), NOT by a chart-rendered ExternalSecret here. ROOT
@@ -127,7 +146,7 @@ name: bp-cilium
 # the netbird realm-config idiom, identical to the bp-oidc-gate openova-flow
 # fix (#3447). bp-sso-bridge PUTs client.json template-wins every tick, so the
 # mapper lands on the live hubble-ui client zero-touch.
-version: 1.4.3
+version: 1.4.4
 description: |
   Catalyst-curated Blueprint umbrella chart for Cilium. Depends on the
   upstream `cilium` chart as a Helm subchart so `helm dependency build`

--- a/platform/cilium/chart/tests/mtu-wireguard-vxlan.sh
+++ b/platform/cilium/chart/tests/mtu-wireguard-vxlan.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# bp-cilium MTU wireguard+vxlan render test (issue #4467).
+#
+# Regression guard for the live Huawei me-east-215 (kom4dc) fresh-prov bug:
+# the chart runs the datapath in VXLAN-tunnel mode (routingMode=tunnel +
+# tunnelProtocol=vxlan — upstream cilium defaults, the chart sets neither)
+# WITH WireGuard node-encryption (encryption.type=wireguard +
+# nodeEncryption=true). Cilium's AUTO-MTU detection read eth0=1500 and
+# programmed cilium_wg0=1420 (eth0 − 80 WG) but left cilium_vxlan /
+# cilium_host / pod lxc* veths at 1500. A full-size 1500-byte pod frame +
+# 50-byte VXLAN header = 1550 bytes, which overflows the 1420 WireGuard MTU
+# and is silently DF-dropped → ALL cross-node pod-to-pod TCP to non-trivial
+# payloads times out (curl 28) → Phase-1 convergence deadlock (e.g. the
+# catalyst-gitea-token-mint Job can't reach gitea-http.gitea.svc:3000 on
+# another node, so bp-catalyst-platform never finishes installing).
+#
+# The fix pins the upstream chart's top-level `MTU` helm value to 1370
+# (= 1500 eth0 − 50 VXLAN − 80 WireGuard), which renders cilium-config
+# `mtu: "1370"` and sets exactly the cilium_net / cilium_host / cilium_vxlan
+# / lxc device MTUs (per the upstream values.yaml comment). A 1370-byte pod
+# payload + 50-byte VXLAN = 1420 = the cilium_wg0 MTU exactly.
+#
+# This test asserts:
+#   1. default render emits cilium-config `mtu: "1370"` (the bug-fix value),
+#      AND WireGuard encryption is on AND the datapath is NOT forced into
+#      native routing (so the +50 VXLAN overhead the 1370 accounts for is
+#      genuinely present).
+#   2. setting cilium.MTU=0 (the upstream auto-detect default that REPRODUCES
+#      the bug) emits NO `mtu:` key — proving 1370 is a deliberate override
+#      and a future values.yaml regression to 0 would be caught.
+#   3. an operator overlay (cilium.MTU=1450, e.g. a WG-off Sovereign) renders
+#      that value verbatim — the knob is overridable per-Sovereign.
+#
+# Auto-discovered + run by .github/workflows/blueprint-release.yaml's
+# "Run chart integration tests (chart/tests/*.sh)" gate.
+#
+# Usage: bash tests/mtu-wireguard-vxlan.sh [CHART_DIR]
+#   CHART_DIR defaults to the parent directory of this script.
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+
+# Resolve subcharts only if not already vendored (same guard as
+# observability-toggle.sh — CI's `helm dependency build` step pre-populates
+# chart/charts/; a fresh local worktree resolves on demand).
+if [ ! -d charts ] || [ -z "$(ls -A charts 2>/dev/null)" ]; then
+  helm dependency build >/dev/null
+fi
+
+# ── Case 1: default render pins mtu: "1370" with WireGuard on + vxlan ────
+echo "[mtu-wireguard-vxlan] Case 1: default render emits cilium-config mtu: \"1370\""
+helm template smoke-cilium . > "$TMP/default.yaml"
+
+# The upstream cilium-configmap renders `mtu: "1370"` only when .Values.MTU
+# is truthy. Grep the cilium ConfigMap data key.
+if ! grep -qE '^\s*mtu:\s*"1370"\s*$' "$TMP/default.yaml"; then
+  echo "FAIL: default render does NOT pin cilium-config mtu: \"1370\"." >&2
+  echo "      The WireGuard+VXLAN datapath needs MTU = 1500 - 50 (vxlan) - 80 (wg) = 1370," >&2
+  echo "      else cilium auto-MTU leaves pod lxc*/cilium_vxlan at 1500 and oversized" >&2
+  echo "      frames are DF-dropped at the 1420 WireGuard MTU (issue #4467)." >&2
+  echo "      cilium-config mtu line(s) found:" >&2
+  grep -nE '^\s*mtu:' "$TMP/default.yaml" >&2 || echo "      (no mtu key rendered at all)" >&2
+  exit 1
+fi
+
+# Guard the PREMISE: the 1370 only makes sense if WireGuard encryption is on
+# (the +80 overhead) AND the datapath is not forced into native routing (so
+# the +50 VXLAN overhead is genuinely present). If a future edit turns
+# WireGuard off OR sets routing-mode=native, 1370 would be wrong and this
+# test must flag the mismatch.
+if ! grep -qE '^\s*enable-wireguard:\s*"true"\s*$' "$TMP/default.yaml"; then
+  echo "FAIL: default render does NOT enable WireGuard, but MTU is pinned to the" >&2
+  echo "      WireGuard-overhead value 1370. Either re-enable encryption.type=wireguard" >&2
+  echo "      or recompute the MTU (issue #4467)." >&2
+  grep -nE 'enable-wireguard|encryption' "$TMP/default.yaml" >&2 || true
+  exit 1
+fi
+# routing-mode native is the ONE mode where the +50 VXLAN overhead vanishes.
+# The chart must NOT be in native routing while pinning 1370.
+if grep -qE '^\s*routing-mode:\s*"native"\s*$' "$TMP/default.yaml"; then
+  echo "FAIL: default render forces routing-mode=native, but MTU 1370 budgets for the" >&2
+  echo "      +50 VXLAN tunnel overhead. Native routing has no VXLAN header — recompute" >&2
+  echo "      the MTU (eth0 - 80 WG only) if native routing is intended (issue #4467)." >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 2: MTU=0 (auto-detect, the bug) emits NO mtu key ───────────────
+echo "[mtu-wireguard-vxlan] Case 2: MTU=0 (auto-detect) emits no mtu key — proves 1370 is deliberate"
+if ! helm template smoke-cilium . --set cilium.MTU=0 \
+     > "$TMP/auto.yaml" 2> "$TMP/auto.err"; then
+  echo "FAIL: MTU=0 render failed:" >&2
+  cat "$TMP/auto.err" >&2
+  exit 1
+fi
+if grep -qE '^\s*mtu:\s*"' "$TMP/auto.yaml"; then
+  echo "FAIL: MTU=0 still rendered an mtu key — the upstream chart should OMIT mtu when" >&2
+  echo "      MTU is falsy (auto-detect). If this assertion changed, re-verify the upstream" >&2
+  echo "      cilium-configmap.yaml MTU gate (issue #4467)." >&2
+  grep -nE '^\s*mtu:' "$TMP/auto.yaml" >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 3: operator overlay overrides the MTU verbatim ─────────────────
+echo "[mtu-wireguard-vxlan] Case 3: cilium.MTU=1450 overlay renders mtu: \"1450\""
+if ! helm template smoke-cilium . --set cilium.MTU=1450 \
+     > "$TMP/override.yaml" 2> "$TMP/override.err"; then
+  echo "FAIL: MTU=1450 override render failed:" >&2
+  cat "$TMP/override.err" >&2
+  exit 1
+fi
+if ! grep -qE '^\s*mtu:\s*"1450"\s*$' "$TMP/override.yaml"; then
+  echo "FAIL: cilium.MTU=1450 overlay did not render mtu: \"1450\" — the per-Sovereign" >&2
+  echo "      MTU override knob is broken (issue #4467)." >&2
+  grep -nE '^\s*mtu:' "$TMP/override.yaml" >&2 || true
+  exit 1
+fi
+echo "  PASS"
+
+echo "[mtu-wireguard-vxlan] All bp-cilium MTU wireguard+vxlan gates green."

--- a/platform/cilium/chart/values.yaml
+++ b/platform/cilium/chart/values.yaml
@@ -120,6 +120,50 @@ cilium:
     type: wireguard
     nodeEncryption: true
 
+  # Pod/datapath MTU — explicitly pinned to account for the COMBINED
+  # VXLAN tunnel + WireGuard node-encryption overhead. DO NOT remove or set
+  # to 0 (auto) on this platform.
+  #
+  # The Catalyst datapath stacks two encapsulations on every cross-node
+  # pod packet:
+  #   1. routingMode=tunnel + tunnelProtocol=vxlan  → +50 bytes (VXLAN hdr).
+  #      Both are upstream defaults (this chart sets neither key), so the
+  #      datapath IS in VXLAN-tunnel mode unless an overlay overrides it.
+  #   2. encryption.type=wireguard + nodeEncryption=true (above) → ~80 bytes
+  #      (WireGuard transport overhead on cilium_wg0).
+  #
+  # Root-caused live on a Huawei me-east-215 (kom4dc) fresh prov (#4467):
+  # cilium's AUTO-MTU detection read eth0=1500 and correctly programmed
+  # cilium_wg0=1420 (eth0 − 80 WG), BUT left cilium_vxlan / cilium_host /
+  # pod lxc* veths at 1500 — it did NOT compound the VXLAN overhead onto
+  # the pod-facing devices when BOTH vxlan-tunnel AND wireguard were on.
+  # Net: a pod emitting a full 1500-byte frame produces a 1550-byte VXLAN
+  # packet that overflows the 1420 WireGuard MTU and is silently dropped
+  # (DF set). Small packets (health probes, HTTP request lines) pass; large
+  # ones (TCP data, HTTP response bodies, TLS handshakes) drop → ALL
+  # cross-node pod-to-pod TCP to non-trivial payloads times out
+  # (`curl: (28)`). Phase-1 convergence deadlocks (e.g. the
+  # catalyst-gitea-token-mint Job can't reach gitea-http.gitea.svc:3000 on
+  # another node → bp-catalyst-platform never finishes installing).
+  #
+  # Correct pod MTU = 1500 (eth0) − 50 (VXLAN) − 80 (WireGuard) = 1370.
+  # A 1370-byte pod payload + 50 VXLAN = 1420 = exactly the cilium_wg0 MTU.
+  # WireGuard node-encryption is ALWAYS-ON for every Catalyst Sovereign
+  # (the canonical east-west mTLS layer — see the encryption block above),
+  # so 1370 is a safe static default that never regresses a non-WG path.
+  #
+  # The upstream cilium chart's top-level `MTU` key renders cilium-config
+  # `mtu: "1370"`, which sets the device MTU for exactly cilium_net /
+  # cilium_host / cilium_vxlan / lxc (per the upstream values.yaml comment)
+  # — the very devices left mis-sized by the auto path. `MTU: 0` (upstream
+  # default) means auto-detect and reproduces the bug.
+  #
+  # Air-gapped / jumbo-frame (eth0 MTU != 1500) Sovereigns recompute as
+  # `<eth0-mtu> − 130` in their per-Sovereign overlay at clusters/<sov>/
+  # bootstrap-kit/01-cilium.yaml. Native-routing (non-vxlan) Sovereigns,
+  # if ever shipped, override to `<eth0-mtu> − 80` (WG-only) there too.
+  MTU: 1370
+
   # Hubble — network observability (L3/L4/L7 flows, DNS, drop, http metrics).
   #
   # DEFAULT OFF per docs/BLUEPRINT-AUTHORING.md §11.2 (Observability toggles


### PR DESCRIPTION
## Problem (root-caused live on omantel.biz Huawei kom4dc fresh prov)

`bp-cilium` 1.4.3 runs the datapath in **VXLAN-tunnel mode** (`routing-mode=tunnel`, `tunnel-protocol=vxlan` — the upstream cilium 1.16.5 defaults; the chart sets neither key) **with WireGuard node-encryption** (`encryption.type=wireguard`, `nodeEncryption=true`). On a fresh Huawei me-east-215 Sovereign, cilium auto-MTU leaves the pod/datapath devices mis-sized:

| device | MTU | correct? |
|---|---|---|
| node `eth0` | 1500 | — |
| `cilium_wg0` (WireGuard) | 1420 | ✓ (eth0 − 80 WG) |
| `cilium_vxlan` | **1500** | ✗ should be ≤1370 |
| `cilium_host` | **1500** | ✗ |
| pod `lxc*` veth | **1500** | ✗ |

Cilium subtracted the WireGuard overhead onto `cilium_wg0` (→1420) but did **not** compound the +50 VXLAN overhead onto the pod-facing devices. A full-size 1500-byte pod frame → 1550-byte VXLAN packet → overflows the 1420 WireGuard MTU → silently DF-dropped. Small packets (probes, request lines) pass; large packets (TCP data, HTTP bodies, TLS handshakes) drop.

**Symptom:** every cross-node pod-to-pod TCP connection to a non-trivial payload times out (`curl: (28)`). Phase-1 convergence deadlocks — `catalyst-gitea-token-mint` can't reach `gitea-http.gitea.svc:3000` on another node, so bp-catalyst-platform never finishes installing.

## Fix

Pin the upstream chart's top-level `MTU` helm value to **1370**, which renders cilium-config `mtu: "1370"` and sets exactly the `cilium_net` / `cilium_host` / `cilium_vxlan` / `lxc` device MTUs (per the upstream values.yaml comment) — the devices the auto path mis-sized.

```
1500 (eth0) − 50 (VXLAN) − 80 (WireGuard) = 1370
1370 (pod payload) + 50 (VXLAN) = 1420 = cilium_wg0 MTU exactly
```

WireGuard node-encryption is **always-on** for every Catalyst Sovereign (canonical east-west mTLS layer), so a static 1370 default never regresses a non-WG path. Jumbo-frame / non-1500-eth0 Sovereigns override via `${CILIUM_MTU:=1370}` (eth0 − 130) in their per-Sovereign overlay.

## Files changed

- `platform/cilium/chart/values.yaml` — `cilium.MTU: 1370` default (with full root-cause comment).
- `clusters/_template/bootstrap-kit/01-cilium.yaml` — slot values overlay pins `MTU: ${CILIUM_MTU:=1370}` + version pin **1.4.3 → 1.4.4**.
- `platform/cilium/chart/Chart.yaml` — version **1.4.3 → 1.4.4** + changelog.
- `platform/cilium/blueprint.yaml` — `spec.version` **1.4.3 → 1.4.4** (lockstep).
- `platform/cilium/chart/tests/mtu-wireguard-vxlan.sh` — new render gate (3 cases).

## Verification

Rendered cilium-config from the changed chart:
```
mtu: "1370"
enable-wireguard: "true"
encrypt-node: "true"
routing-mode: "tunnel"
tunnel-protocol: "vxlan"
```
This is exactly the buggy datapath config from the live prov, with the MTU now correct — confirming the 1370 math against the real render.

- `tests/mtu-wireguard-vxlan.sh` — all 3 cases PASS (default pins 1370 + premise-guards WG-on/not-native; MTU=0 emits no key; override renders verbatim).
- `tests/observability-toggle.sh` — PASS (no regression).
- `scripts/check-bootstrap-kit-pin-sync.sh` — `bp-cilium: chart=1.4.4 pin=1.4.4` lockstep green.
- `helm lint` — 0 failures.

Code/chart fix only — no live cluster touched (the live prov is being live-patched separately by the parent).

Refs #4467

🤖 Generated with [Claude Code](https://claude.com/claude-code)