### PR TITLE
fix(bp-plane-isolation #4468): extend the #4445 defer-if-absent guard to apiserver-egress + gateway-ingress CNPs (0.1.8)

### DIFF
--- a/clusters/_template/bootstrap-kit/26b-bp-plane-isolation.yaml
+++ b/clusters/_template/bootstrap-kit/26b-bp-plane-isolation.yaml
@@ -109,7 +109,15 @@ spec:
       #   DEADLOCK (live b9f9590b, 2026-06-26). Cilium unions every policy +
       #   helm-controller reconciles on interval, so the deferred policy lands on the
       #   NEXT reconcile once the namespace exists.
-      version: 0.1.7
+      # 0.1.8 (#4468 / Refs #4456 #4445): EXTEND the 0.1.7 defer-if-absent guard to the
+      #   OTHER two per-component templates it missed — apiserver-egress-cnp.yaml
+      #   (added 0.1.5/#4428) and gateway-ingress-cnp.yaml ALSO render `namespace: <ns>`
+      #   CNPs per component, so the absent `sandbox` ns STILL atomic-failed the release
+      #   ("namespaces sandbox not found") via the apiserver-egress CNP → the SAME
+      #   circular deadlock 0.1.7 was meant to break. Live-caught on fresh re-prov
+      #   91dc05917e44d1c1 (kom4dc, 2026-06-26): published 0.1.7 HR install STILL FAILED.
+      #   All three per-component templates now carry the identical lookup-guard.
+      version: 0.1.8
       sourceRef:
         kind: HelmRepository
         name: bp-plane-isolation

--- a/platform/plane-isolation/blueprint.yaml
+++ b/platform/plane-isolation/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 0.1.7  # lockstep with chart/Chart.yaml (#4442 — defer per-component default-deny when its namespace is absent)
+  version: 0.1.8  # lockstep with chart/Chart.yaml (#4468 — extend the #4445 defer-if-absent guard to apiserver-egress + gateway-ingress CNPs)
   card:
     title: Plane isolation (per-component default-deny)
     summary: |

--- a/platform/plane-isolation/chart/Chart.yaml
+++ b/platform/plane-isolation/chart/Chart.yaml
@@ -120,7 +120,21 @@ name: bp-plane-isolation
 #   `ensureNamespacePresent: false` opts back into the old hard-require behavior;
 #   chart-level `renderUnconditional: true` forces all components to render regardless
 #   of lookup (the static dial-graph contract render / CI client-side template path).
-version: 0.1.7
+# 0.1.8 (#4456 / Refs #4442 #4445 #4428 #4325): EXTEND the #4445 defer-if-absent
+#   lookup-guard to the OTHER two per-component templates that #4445 missed. #4445
+#   guarded ONLY default-deny-networkpolicy.yaml, but apiserver-egress-cnp.yaml
+#   (added 0.1.5/#4428) and gateway-ingress-cnp.yaml ALSO render `namespace: <ns>`
+#   resources for every component — so the absent `sandbox` namespace STILL atomic-
+#   failed the whole release (`namespaces "sandbox" not found`) via the apiserver-
+#   egress CNP, leaving the EXACT same circular deadlock #4445 was meant to break:
+#   no plane-isolation policy lands → gitea default-deny + catalyst-system allow
+#   never apply → gitea-token-mint curl-28 timeout CrashLoop → bp-catalyst-platform
+#   install hangs 30m → bp-sandbox never creates `sandbox`. Live-caught on the fresh
+#   re-prov 91dc05917e44d1c1 (kom4dc, 2026-06-26): published 0.1.7 HR install FAILED
+#   despite the changelog claiming the deadlock fixed. All three per-component
+#   templates now carry the identical lookup-guard so a deferred namespace lands on
+#   the next helm-controller reconcile once its consumer chart creates it.
+version: 0.1.8
 description: |
   Per-component default-deny + explicit-allow micro-segmentation for the
   de-vclustered platform planes (#4291 Workstream C). For each platform

--- a/platform/plane-isolation/chart/templates/apiserver-egress-cnp.yaml
+++ b/platform/plane-isolation/chart/templates/apiserver-egress-cnp.yaml
@@ -46,10 +46,29 @@ radius.
 
 Gated on the cilium.io/v2 Capabilities check (the #2988/#3102 idiom) so the
 chart still installs on CRD-less clusters (kind CI).
+
+#4456 deadlock-guard parity: this CNP carries the SAME `namespace: <ns>` apply
+requirement as the default-deny NetworkPolicy, and Helm install is ATOMIC — so
+an absent namespace here (`sandbox`, created LATE by bp-sandbox behind
+bp-catalyst-platform) fails the WHOLE release exactly like #4442/#4445, with the
+same CIRCULAR DEADLOCK (gitea default-deny + catalyst-system allow never land →
+gitea-token-mint CrashLoops → bp-catalyst-platform hangs → bp-sandbox never
+creates `sandbox`). #4445 added the defer-if-absent guard to the default-deny
+template ONLY and missed this one (added in 0.1.5, #4428), so the published
+0.1.7 STILL atomic-failed `namespaces "sandbox" not found` on a fresh prov (live
+91dc05917e44d1c1, 2026-06-26). Mirror the guard here: skip a component whose
+namespace is absent and let helm-controller's next reconcile land it once the
+consumer chart creates the namespace (Cilium unions every policy selecting an
+endpoint). `ensureNamespacePresent: false` / chart-level `renderUnconditional:
+true` behave identically to the default-deny template.
 */ -}}
 {{- if and .Values.enabled (.Capabilities.APIVersions.Has "cilium.io/v2") -}}
 {{- range .Values.components }}
 {{- $ns := .namespace }}
+{{- $guardNamespace := not (eq (toString .ensureNamespacePresent) "false") }}
+{{- if and $guardNamespace (not $.Values.renderUnconditional) (not (lookup "v1" "Namespace" "" $ns)) }}
+{{- /* namespace not present yet — defer this component's CNP to a later reconcile */ -}}
+{{- else }}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -66,5 +85,6 @@ spec:
   egress:
     - toEntities:
         - kube-apiserver
+{{- end }}{{/* end namespace-present guard */}}
 {{- end }}
 {{- end -}}

--- a/platform/plane-isolation/chart/templates/gateway-ingress-cnp.yaml
+++ b/platform/plane-isolation/chart/templates/gateway-ingress-cnp.yaml
@@ -33,6 +33,16 @@ chart still installs on CRD-less clusters (kind CI).
 {{- range .Values.components }}
 {{- if .gatewayIngress }}
 {{- $ns := .namespace }}
+{{- /* #4456 deadlock-guard parity (see apiserver-egress-cnp.yaml / default-deny-
+       networkpolicy.yaml): skip a gatewayIngress component whose namespace is
+       absent so the atomic Helm install can't fail on a not-yet-created ns. No
+       current gatewayIngress component is created late, but the guard keeps all
+       three per-component templates uniform so a future late-created public
+       component can't re-introduce the fresh-prov deadlock. */ -}}
+{{- $guardNamespace := not (eq (toString .ensureNamespacePresent) "false") }}
+{{- if and $guardNamespace (not $.Values.renderUnconditional) (not (lookup "v1" "Namespace" "" $ns)) }}
+{{- /* namespace not present yet — defer this component's CNP to a later reconcile */ -}}
+{{- else }}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -51,6 +61,7 @@ spec:
         - ingress
         - host
         - remote-node
+{{- end }}{{/* end namespace-present guard */}}
 {{- end }}
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
## Fault

`bp-plane-isolation@0.1.7` HR install FAILS on a fresh prov with `namespaces "sandbox" not found` — re-introducing the exact circular deadlock #4445 was meant to break.

#4445 (0.1.7) added the defer-if-absent `lookup` guard to **only** `templates/default-deny-networkpolicy.yaml`. But the chart ships TWO more per-component templates that also render `namespace: <ns>` resources for **every** component:
- `templates/apiserver-egress-cnp.yaml` (added 0.1.5/#4428) — a CiliumNetworkPolicy per component, **unguarded**.
- `templates/gateway-ingress-cnp.yaml` — per gatewayIngress component, **unguarded**.

Helm install is ATOMIC, so the apiserver-egress CNP targeting the late-created `sandbox` namespace fails the WHOLE release → NONE of the plane-isolation policies land → the deadlock:

> no plane-isolation policy lands → gitea default-deny + catalyst-system allow never apply → gitea-token-mint `curl(28)` timeout CrashLoop → bp-catalyst-platform install hangs 30m → bp-sandbox never creates `sandbox`.

Live-caught on fresh re-prov `91dc05917e44d1c1` (kom4dc, omantel.biz, 2026-06-26) — BOTH regions (a + b). The published 0.1.7 HR install FAILED despite its changelog claiming the deadlock fixed.

## Fix (0.1.8)

Extend the identical `lookup`-guard to `apiserver-egress-cnp.yaml` and `gateway-ingress-cnp.yaml` so all three per-component templates defer a not-yet-existent namespace uniformly. A deferred namespace's policy lands on the next helm-controller reconcile once its consumer chart creates it (Cilium unions every policy selecting an endpoint).

### Verified
- client-side `helm template` → 0 policies (lookup empty, all deferred)
- `--set renderUnconditional=true` → full 45-policy dial-graph (Case-30 contract render path intact)
- `--set components[0].ensureNamespacePresent=false` escape hatch still renders
- `helm lint` clean

## Live unblock (already applied to 91dc05917e44d1c1)

The correct policy set (sandbox-stripped) was `kubectl apply`-ed directly to both regions to break the deadlock immediately: token-mint mints, sso-bridge reaches openbao (SSO secrets seed), harbor-core reaches harbor-redis, region-a catalyst-platform install completed + console/api/marketplace serve HTTP 200 with valid LE TLS. The durable fix rolls when 0.1.8 publishes + the bootstrap-kit pin bumps.

Refs #4468 #4445 #4442 #4428 #4325

🤖 Generated with [Claude Code](https://claude.com/claude-code)