### PR TITLE
fix(org-controller #4471): ClusterRole gains update+patch on organizations resource — unblock #4462 finalizer-add (1.4.896)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1165,7 +1165,15 @@ spec:
       #   delete-cascade (both already merged). 89993b2 descends from b23af68 → it
       #   keeps the #4393 Guaranteed-QoS vcluster fix too. Lockstep w/ Chart.yaml.
       #   Refs #4464 #4455 #4462 #4393.
-      version: 1.4.895
+      # 1.4.896 — #4471/#4462: org-controller ClusterRole gains update + patch on the
+      #   MAIN `organizations` resource. The #4462 delete-cascade added finalizer
+      #   add/remove via client.Update on the parent Org object, but the ClusterRole
+      #   granted update/patch only on /status + /finalizers SUBRESOURCES — so every
+      #   reconcile 403'd on the first finalizer-add (`cannot update resource
+      #   "organizations"`), producing NO tenant-networking finalizer, per-Org cert,
+      #   console-https-<slug> listener, or pool DNS on a fresh prov. Additive RBAC
+      #   widening. Lockstep w/ Chart.yaml. Refs #4471 #4462 #4290.
+      version: 1.4.896
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/core/controllers/organization/config/rbac/role.yaml
+++ b/core/controllers/organization/config/rbac/role.yaml
@@ -23,9 +23,15 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/managed-by: catalyst
 rules:
+  # #4471/#4462: the reconciler adds/removes finalizers via client.Update on
+  # the MAIN Organization object, which requires update/patch on the
+  # `organizations` resource — the `organizations/finalizers` subresource
+  # grant alone is NOT sufficient (client.Update writes the parent, not the
+  # /finalizers subresource). Without this every reconcile 403s on the first
+  # finalizer-add and no per-Org boundary is produced.
   - apiGroups: ["orgs.openova.io"]
     resources: ["organizations"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["orgs.openova.io"]
     resources: ["organizations/status"]
     verbs: ["get", "update", "patch"]

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3254,12 +3254,25 @@ name: bp-catalyst-platform
 #   preserved verbatim. The #4452 guard chart/tests/gitea-flux-auth-sync-rbac-
 #   order.sh is extended with parallel gate-3/gate-4 cases for this second job.
 #   Lockstep w/ bootstrap-kit slot 13 pin. Refs #4447 #3763 #3781.
+# 1.4.896 — #4471/#4462: organization-controller ClusterRole was missing update +
+#   patch on the MAIN `organizations` resource — it granted only get/list/watch
+#   there + update/patch on the /status + /finalizers SUBRESOURCES. The #4462
+#   delete-cascade added finalizer add/remove via client.Update on the parent
+#   Organization object (organization_controller.go finalizer ensure/remove), and
+#   k8s only routes to the /finalizers subresource when the request explicitly
+#   targets it — so client.Update on the parent 403'd `cannot update resource
+#   "organizations"`. EVERY Org reconcile bailed on the first finalizer-add: no
+#   tenant-networking finalizer, no per-Org Certificate, no console-https-<slug>
+#   Gateway listener, no pool DNS — keystone gates 4-5 blocked on a fresh prov.
+#   FIX: add update + patch to the `organizations` resource rule (additive,
+#   least-privilege — the /status + /finalizers grants stay). Lockstep w/
+#   bootstrap-kit slot 13 pin. Refs #4471 #4462 #4290.
 # 1.4.894 — #4464: re-pin organization-controller image b23af68 -> 89993b2 (the
 #   deploy-bump #2584 whole-file snapshot re-apply clobbered the per-controller
 #   bump back to b23af68, shipping org-controller WITHOUT #4455 tenant-dns +
 #   #4462 delete-cascade on every fresh prov). 89993b2 is a descendant of b23af68
 #   so it retains #4393 Guaranteed-QoS. Lockstep w/ bootstrap-kit slot 13 pin.
-version: 1.4.895
+version: 1.4.896
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/
 #   platform/crossplane chart + blueprint.yaml + bootstrap-kit slot 04). crossplane-core
 #   was still OOMKilled (CrashLoopBackOff, 55 restarts, exit 137, killed ~90s after start)

--- a/products/catalyst/chart/templates/controllers/organization-controller-clusterrole.yaml
+++ b/products/catalyst/chart/templates/controllers/organization-controller-clusterrole.yaml
@@ -27,9 +27,20 @@ metadata:
   labels:
     {{- include "controllers.labels" (dict "name" "organization" "root" .) | nindent 4 }}
 rules:
+  # #4471/#4462: the controller adds + removes the tenant-networking,
+  # iac-bootstrap, and per-org-realm finalizers via client.Update on the
+  # MAIN Organization object (organization_controller.go ~L455/469/484 add,
+  # ~L399/413/431 remove). controller-runtime's client.Update writes the
+  # parent resource — k8s only routes to the `organizations/finalizers`
+  # subresource when the request explicitly targets `.../finalizers`, which
+  # it does not here. So `organizations/finalizers:update` is NOT sufficient;
+  # the controller needs `update` (and `patch` for any SSA path) on the
+  # `organizations` resource itself, otherwise EVERY reconcile bails on the
+  # first finalizer-add with `cannot update resource "organizations"` and no
+  # per-Org boundary is ever produced (#4462 delete-cascade regression).
   - apiGroups: ["orgs.openova.io"]
     resources: ["organizations"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["orgs.openova.io"]
     resources: ["organizations/status"]
     verbs: ["get", "update", "patch"]


### PR DESCRIPTION
## Problem

The #4462 delete-cascade added the tenant-networking / iac-bootstrap / per-org-realm finalizer **add + remove** via `client.Update` on the **main** Organization object (`core/controllers/organization/internal/controller/organization_controller.go`). The `catalyst-organization-controller` ClusterRole, however, granted `update`/`patch` only on the `organizations/status` and `organizations/finalizers` **subresources** — and only `get`/`list`/`watch` on the `organizations` resource itself.

Kubernetes routes a write to the `/finalizers` subresource **only** when the request explicitly targets `.../finalizers`; controller-runtime's `client.Update` writes the **parent** object. So every reconcile 403'd on the very first finalizer-add:

```
organizations.orgs.openova.io "uata1" is forbidden:
User "system:serviceaccount:...:catalyst-organization-controller"
cannot update resource "organizations" in API group "orgs.openova.io" at the cluster scope
```

On fresh prov `91dc05917e44d1c1` (omantel.biz) all 3 Orgs (`uata1`/`uatb1`/`uatwalk91`) were stuck: no tenant-networking finalizer, no status advance, no per-Org Certificate, no `console-https-<slug>` Gateway listener, no pool DNS. **Keystone gates 4-5 blocked for every Org.**

## Fix

Add `update` + `patch` to the `organizations` resource rule (additive, least-privilege — the `/status` + `/finalizers` subresource grants are unchanged) in **both**:

- `products/catalyst/chart/templates/controllers/organization-controller-clusterrole.yaml` — the live-rendered `catalyst-organization-controller` ClusterRole.
- `core/controllers/organization/config/rbac/role.yaml` — the hand-maintained kubebuilder manifest (kept in sync).

Chart `1.4.895 -> 1.4.896` + bootstrap-kit slot-13 pin in lockstep. `helm lint` clean; pin-sync audit PASS; rendered ClusterRole verified `organizations -> [get,list,watch,update,patch]`.

## Live evidence (live-patched ahead of the chart roll on `91dc05917e44d1c1`)

A ClusterRole patch takes effect with no controller restart — the next reconcile re-authorizes. Within a couple of reconciles all 3 stuck Orgs converged:

| Org | finalizer | Ready | per-Org Certificate | console listener | pool DNS |
|---|---|---|---|---|---|
| uata1 | `orgs.openova.io/tenant-networking` ✅ | `True` Reconciled | `org-wildcard-tls-uata1-omani-homes` Ready ✅ | `console-https-uata1` (*.uata1.omani.homes) ✅ | `console.uata1.omani.homes -> 212.72.24.33` ✅ |
| uatb1 | ✅ | `True` Reconciled | `org-wildcard-tls-uatb1-omani-homes` Ready ✅ | `console-https-uatb1` ✅ | `console.uatb1.omani.homes -> 212.72.24.33` ✅ |
| uatwalk91 | ✅ | `True` Reconciled | `org-wildcard-tls-uatwalk91-omani-homes` Ready ✅ | `console-https-uatwalk91` ✅ | `console.uatwalk91.omani.homes -> 212.72.24.33` ✅ |

`212.72.24.33` is the console-ELB EIP (console-isolation, #4054). This is the keystone-gate-4 unblock.

Refs #4471 #4462 #4290

🤖 Generated with [Claude Code](https://claude.com/claude-code)