### PR TITLE
fix(org-controller): unblock fresh-prov Org reconcile — RBAC update/patch + CRD clientSecretRef trap (#4471, Refs #4290 #4293)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1165,7 +1165,15 @@ spec:
       #   delete-cascade (both already merged). 89993b2 descends from b23af68 → it
       #   keeps the #4393 Guaranteed-QoS vcluster fix too. Lockstep w/ Chart.yaml.
       #   Refs #4464 #4455 #4462 #4393.
-      version: 1.4.895
+      # 1.4.896 — #4471/#4462: org-controller ClusterRole gains update + patch on the
+      #   MAIN `organizations` resource. The #4462 delete-cascade added finalizer
+      #   add/remove via client.Update on the parent Org object, but the ClusterRole
+      #   granted update/patch only on /status + /finalizers SUBRESOURCES — so every
+      #   reconcile 403'd on the first finalizer-add (`cannot update resource
+      #   "organizations"`), producing NO tenant-networking finalizer, per-Org cert,
+      #   console-https-<slug> listener, or pool DNS on a fresh prov. Additive RBAC
+      #   widening. Lockstep w/ Chart.yaml. Refs #4471 #4462 #4290.
+      version: 1.4.896
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/core/controllers/organization/config/rbac/role.yaml
+++ b/core/controllers/organization/config/rbac/role.yaml
@@ -23,9 +23,15 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/managed-by: catalyst
 rules:
+  # #4471/#4462: the reconciler adds/removes finalizers via client.Update on
+  # the MAIN Organization object, which requires update/patch on the
+  # `organizations` resource — the `organizations/finalizers` subresource
+  # grant alone is NOT sufficient (client.Update writes the parent, not the
+  # /finalizers subresource). Without this every reconcile 403s on the first
+  # finalizer-add and no per-Org boundary is produced.
   - apiGroups: ["orgs.openova.io"]
     resources: ["organizations"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["orgs.openova.io"]
     resources: ["organizations/status"]
     verbs: ["get", "update", "patch"]

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3254,12 +3254,25 @@ name: bp-catalyst-platform
 #   preserved verbatim. The #4452 guard chart/tests/gitea-flux-auth-sync-rbac-
 #   order.sh is extended with parallel gate-3/gate-4 cases for this second job.
 #   Lockstep w/ bootstrap-kit slot 13 pin. Refs #4447 #3763 #3781.
+# 1.4.896 — #4471/#4462: organization-controller ClusterRole was missing update +
+#   patch on the MAIN `organizations` resource — it granted only get/list/watch
+#   there + update/patch on the /status + /finalizers SUBRESOURCES. The #4462
+#   delete-cascade added finalizer add/remove via client.Update on the parent
+#   Organization object (organization_controller.go finalizer ensure/remove), and
+#   k8s only routes to the /finalizers subresource when the request explicitly
+#   targets it — so client.Update on the parent 403'd `cannot update resource
+#   "organizations"`. EVERY Org reconcile bailed on the first finalizer-add: no
+#   tenant-networking finalizer, no per-Org Certificate, no console-https-<slug>
+#   Gateway listener, no pool DNS — keystone gates 4-5 blocked on a fresh prov.
+#   FIX: add update + patch to the `organizations` resource rule (additive,
+#   least-privilege — the /status + /finalizers grants stay). Lockstep w/
+#   bootstrap-kit slot 13 pin. Refs #4471 #4462 #4290.
 # 1.4.894 — #4464: re-pin organization-controller image b23af68 -> 89993b2 (the
 #   deploy-bump #2584 whole-file snapshot re-apply clobbered the per-controller
 #   bump back to b23af68, shipping org-controller WITHOUT #4455 tenant-dns +
 #   #4462 delete-cascade on every fresh prov). 89993b2 is a descendant of b23af68
 #   so it retains #4393 Guaranteed-QoS. Lockstep w/ bootstrap-kit slot 13 pin.
-version: 1.4.895
+version: 1.4.896
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/
 #   platform/crossplane chart + blueprint.yaml + bootstrap-kit slot 04). crossplane-core
 #   was still OOMKilled (CrashLoopBackOff, 55 restarts, exit 137, killed ~90s after start)

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3272,7 +3272,7 @@ name: bp-catalyst-platform
 #   bump back to b23af68, shipping org-controller WITHOUT #4455 tenant-dns +
 #   #4462 delete-cascade on every fresh prov). 89993b2 is a descendant of b23af68
 #   so it retains #4393 Guaranteed-QoS. Lockstep w/ bootstrap-kit slot 13 pin.
-version: 1.4.896
+version: 1.4.897
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/
 #   platform/crossplane chart + blueprint.yaml + bootstrap-kit slot 04). crossplane-core
 #   was still OOMKilled (CrashLoopBackOff, 55 restarts, exit 137, killed ~90s after start)

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3272,7 +3272,7 @@ name: bp-catalyst-platform
 #   bump back to b23af68, shipping org-controller WITHOUT #4455 tenant-dns +
 #   #4462 delete-cascade on every fresh prov). 89993b2 is a descendant of b23af68
 #   so it retains #4393 Guaranteed-QoS. Lockstep w/ bootstrap-kit slot 13 pin.
-version: 1.4.897
+version: 1.4.898
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/
 #   platform/crossplane chart + blueprint.yaml + bootstrap-kit slot 04). crossplane-core
 #   was still OOMKilled (CrashLoopBackOff, 55 restarts, exit 137, killed ~90s after start)

--- a/products/catalyst/chart/crds/organization.yaml
+++ b/products/catalyst/chart/crds/organization.yaml
@@ -210,16 +210,34 @@ spec:
                           type: string
                         clientSecretRef:
                           type: object
-                          required: [name, key]
                           description: |
                             Reference to a SealedSecret that holds the OIDC
                             client secret. Plaintext NEVER on the CR.
+
+                            #4471: `required: [name, key]` and `key.default`
+                            were REMOVED. `identity.federationConfig` is an
+                            OPTIONAL block ("empty means use the Sovereign's
+                            own realm"), but the controller's Go types model it
+                            as a VALUE struct (orgapi.OrganizationIdentity,
+                            not a pointer) — `,omitempty` is a no-op on a
+                            struct, so on EVERY `client.Update` (e.g. the
+                            tenant-networking finalizer add) the apiserver
+                            receives `clientSecretRef: {}`. With `required`
+                            present + `key` defaulted-in, that empty object
+                            failed validation (`clientSecretRef.name: Required
+                            value`) and wedged ALL reconciles before any
+                            per-Org boundary was produced. Dropping the
+                            required-enforcement here lets an absent federation
+                            round-trip; a configured federation still needs
+                            both name+key, which the controller validates at
+                            readClientSecret() time (organization_controller.go
+                            ~L1118) and surfaces on the IdentityProviderConfigured
+                            condition.
                           properties:
                             name:
                               type: string
                             key:
                               type: string
-                              default: client-secret
                           x-kubernetes-preserve-unknown-fields: true
                         tenantId:
                           type: string

--- a/products/catalyst/chart/templates/controllers/organization-controller-clusterrole.yaml
+++ b/products/catalyst/chart/templates/controllers/organization-controller-clusterrole.yaml
@@ -60,9 +60,16 @@ rules:
   # through to the Sovereign-wide tenant-wildcard / connection-refused).
   # The Flux GitRepository + Kustomization grants below (per_org_flux.go)
   # were already present; the HTTPRoute grant was the missing peer.
+  #
+  # #4471/#4462: `delete` added — teardownTenantNetworking
+  # (tenant_networking_teardown.go:127) DELETEs the per-Org console
+  # HTTPRoute on Org deletion. Without it the tenant-networking finalizer
+  # teardown 403s (`cannot delete resource "httproutes"`), the finalizer
+  # never drops, and the Org CR is stuck Terminating forever (orphaning
+  # its console route + wildcard cert).
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["httproutes"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   # #4075: a customer Org that picks a free-subdomain hostname under a
   # pool parent zone (e.g. console.<slug>.omani.homes) needs a
   # `*.<parentDomain>` TLS listener appended to the dedicated console
@@ -77,9 +84,15 @@ rules:
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["gateways"]
     verbs: ["get", "list", "watch", "update", "patch"]
+  # #4471/#4462: `delete` added — teardownTenantNetworking
+  # (tenant_networking_teardown.go:122) DELETEs the per-Org wildcard
+  # Certificate (org-wildcard-tls-<slug>-<pool>) in kube-system on Org
+  # deletion. Without it the tenant-networking finalizer teardown 403s
+  # (`cannot delete resource "certificates"`), the finalizer never drops,
+  # and the Org CR is stuck Terminating forever.
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/products/catalyst/chart/templates/controllers/organization-controller-clusterrole.yaml
+++ b/products/catalyst/chart/templates/controllers/organization-controller-clusterrole.yaml
@@ -27,9 +27,20 @@ metadata:
   labels:
     {{- include "controllers.labels" (dict "name" "organization" "root" .) | nindent 4 }}
 rules:
+  # #4471/#4462: the controller adds + removes the tenant-networking,
+  # iac-bootstrap, and per-org-realm finalizers via client.Update on the
+  # MAIN Organization object (organization_controller.go ~L455/469/484 add,
+  # ~L399/413/431 remove). controller-runtime's client.Update writes the
+  # parent resource — k8s only routes to the `organizations/finalizers`
+  # subresource when the request explicitly targets `.../finalizers`, which
+  # it does not here. So `organizations/finalizers:update` is NOT sufficient;
+  # the controller needs `update` (and `patch` for any SSA path) on the
+  # `organizations` resource itself, otherwise EVERY reconcile bails on the
+  # first finalizer-add with `cannot update resource "organizations"` and no
+  # per-Org boundary is ever produced (#4462 delete-cascade regression).
   - apiGroups: ["orgs.openova.io"]
     resources: ["organizations"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["orgs.openova.io"]
     resources: ["organizations/status"]
     verbs: ["get", "update", "patch"]


### PR DESCRIPTION
## Problem (live, fresh prov `91dc05917e44d1c1` / omantel.biz)

On a fresh Sovereign, EVERY Organization CR reconcile bailed on the first `tenant-networking` finalizer add, and NO per-Org boundary (namespace / quota / LimitRange / NetworkPolicy / vcluster / pool DNS) was ever produced. This blocked #4290/#4293 gates 3–6 entirely. Two layered root causes:

### 1. ClusterRole missing update/patch on `organizations` (commit 572d78ea2, already on this branch)
```
cannot update resource "organizations" in API group "orgs.openova.io" at the cluster scope
```
The controller adds finalizers via `client.Update` on the MAIN resource; `organizations/finalizers:update` does NOT cover that. Granted `update`,`patch`.

### 2. CRD clientSecretRef required-trap (this commit, 1.4.897)
After the RBAC grant, reconcile failed at the SAME line with:
```
Organization ... is invalid: spec.identity.federationConfig.clientSecretRef.name: Required value
```
`spec.identity` is OPTIONAL and minted absent, but the controller models it as VALUE structs (`,omitempty` is a no-op on a struct) → every `client.Update` serializes `clientSecretRef: {}` → the CRD's `required:[name,key]` + `key.default` rejects it. Dropped both; a configured federation is still validated at runtime in `readClientSecret()`.

## Verification — live on `91dc05917e44d1c1` (both fixes live-patched, then reconcile observed)

| Gate | Result |
|---|---|
| Single org-controller reconciles BSS + funnel | PASS — uata1(BSS) + uatb1(funnel) both `openova.io/source: tenant-created-event`, one producer |
| No `org-<uuid>`/`tenant-<slug>` strays | PASS — only `<slug>` namespaces |
| One Org CR + one vcluster HR per Org; S-tier no vcluster | PASS — uatb1(M)→vcluster-0 1/1 Running; uata1/uatwalk91(S)→host-ns, no vcluster |
| Plan-accurate quota+LimitRange+NetworkPolicy | PASS (S: cpu2/mem4Gi; M: cpu4/mem8Gi) |
| `console.<slug>.<pool>` → console-ELB EIP + LE TLS | PASS — all 3 dig→212.72.24.1, HTTPS 200, LE cert |
| Handover JWT sign-in (no 401) | PASS — 302→/dashboard, session cookie, whoami 200 |

Refs #4290 #4293 #4471

🤖 Generated with [Claude Code](https://claude.com/claude-code)