### PR TITLE
fix(provisioning): funnel plan selection propagates to the Organization CR — slug-aware resolvePlanSlug (Refs #3376 #4293)

### DIFF
--- a/core/services/provisioning/handlers/handlers.go
+++ b/core/services/provisioning/handlers/handlers.go
@@ -393,9 +393,60 @@ func (h *Handler) resolveAppDependencies(ctx context.Context, appSlugs []string)
 	return deps
 }
 
-// resolvePlanSlug fetches the plan slug for a plan UUID from the catalog.
+// knownPlanSlugs is the canonical set of plan slugs the platform recognizes,
+// matching the boundary/QoS switches in gitops (BoundaryIsVcluster: ""/s/free
+// → host tier; m/l/xl/flexi → dedicated vcluster; qosResources: flexi vs the
+// rest). It is the single source of truth for "is this string already a slug?"
+// so resolvePlanSlug can short-circuit the catalog UUID lookup when the caller
+// (the marketplace funnel) already posts the slug directly.
+var knownPlanSlugs = map[string]struct{}{
+	"s":     {},
+	"m":     {},
+	"l":     {},
+	"xl":    {},
+	"flexi": {},
+	"free":  {},
+}
+
+// isKnownPlanSlug reports whether s is one of the canonical plan slugs
+// (case-insensitive, whitespace-trimmed) and, if so, returns its normalized
+// (lowercase) form.
+func isKnownPlanSlug(s string) (string, bool) {
+	norm := strings.ToLower(strings.TrimSpace(s))
+	if norm == "" {
+		return "", false
+	}
+	_, ok := knownPlanSlugs[norm]
+	return norm, ok
+}
+
+// resolvePlanSlug resolves the caller's plan identifier to a canonical plan
+// slug (s|m|l|xl|flexi). It accepts BOTH forms the two provisioning doors post:
+//
+//   - the marketplace FUNNEL door posts the plan SLUG directly ("m"/"l"/"xl"/…);
+//     that value is returned as-is (normalized) without a catalog round-trip.
+//   - the BSS door posts a plan UUID, which is looked up against /catalog/plans.
+//
+// Before #4473 this function treated EVERY input as a UUID, so a funnel-posted
+// slug matched no catalog row and silently fell through to the "s" default —
+// every funnel Org provisioned at the S boundary regardless of the chosen plan
+// (Pillar-1 billing/provisioning correctness fault, verified live on prov
+// 91dc05917e44d1c1: plan_id:"m" → Org CR spec.planSlug:"s"). The slug fast-path
+// closes that gap; the UUID lookup is preserved for the BSS door.
+//
+// When the input is neither a known slug nor a resolvable UUID, the historical
+// "s" default is returned — but now LOGGED, so a silent S-downgrade is never
+// invisible again.
 func (h *Handler) resolvePlanSlug(ctx context.Context, planID string) string {
+	// Fast-path: the funnel posts the slug directly. No catalog round-trip,
+	// no dependency on /catalog/plans being reachable at creation time.
+	if slug, ok := isKnownPlanSlug(planID); ok {
+		return slug
+	}
+
 	if h.CatalogURL == "" {
+		slog.Warn("resolvePlanSlug: no catalog URL and plan_id is not a known slug — defaulting to 's' (verify the Org is not being silently downgraded)",
+			"plan_id", planID)
 		return "s" // default
 	}
 	reqCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
@@ -403,15 +454,18 @@ func (h *Handler) resolvePlanSlug(ctx context.Context, planID string) string {
 
 	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, h.CatalogURL+"/catalog/plans", nil)
 	if err != nil {
+		slog.Warn("resolvePlanSlug: catalog request build failed — defaulting to 's'", "plan_id", planID, "err", err)
 		return "s"
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
+		slog.Warn("resolvePlanSlug: catalog unreachable — defaulting to 's'", "plan_id", planID, "err", err)
 		return "s"
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		io.Copy(io.Discard, resp.Body)
+		slog.Warn("resolvePlanSlug: catalog returned non-200 — defaulting to 's'", "plan_id", planID, "status", resp.StatusCode)
 		return "s"
 	}
 	var plans []struct {
@@ -419,6 +473,7 @@ func (h *Handler) resolvePlanSlug(ctx context.Context, planID string) string {
 		Slug string `json:"slug"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&plans); err != nil {
+		slog.Warn("resolvePlanSlug: catalog decode failed — defaulting to 's'", "plan_id", planID, "err", err)
 		return "s"
 	}
 	for _, p := range plans {
@@ -426,6 +481,8 @@ func (h *Handler) resolvePlanSlug(ctx context.Context, planID string) string {
 			return p.Slug
 		}
 	}
+	slog.Warn("resolvePlanSlug: plan_id matched neither a known slug nor a catalog plan UUID — defaulting to 's' (an Org may be silently downgraded to the S boundary)",
+		"plan_id", planID)
 	return "s"
 }
 
@@ -496,6 +553,11 @@ func (h *Handler) resolveTenantPlanSlug(ctx context.Context, tenantSlug, planID 
 // self-consistent because it resolves once); the day-2 path uses this richer
 // signal via resolveTenantPlanSlug.
 func (h *Handler) lookupPlanSlug(ctx context.Context, planID string) (slug string, reachable bool) {
+	// #4473: the funnel posts the slug directly; a known slug is an
+	// authoritative answer with no catalog dependency.
+	if s, ok := isKnownPlanSlug(planID); ok {
+		return s, true
+	}
 	if h.CatalogURL == "" {
 		return "s", false
 	}

--- a/core/services/provisioning/handlers/organization_create.go
+++ b/core/services/provisioning/handlers/organization_create.go
@@ -127,11 +127,14 @@ func (h *Handler) createOrganizationCR(ctx context.Context, data tenantCreatedPa
 	if tier == "" {
 		tier = "org"
 	}
-	// Resolve the purchased plan UUID → catalog slug (s|m|l|xl|flexi) so the
-	// Organization CR carries the SINGLE truth-source for the resource cap the
-	// org-controller materializes (Workstream B, #4292). resolvePlanSlug
-	// defaults to "s" on any catalog miss, so an empty PlanID still yields a
-	// valid cap rather than running uncapped.
+	// Resolve the purchased plan identifier → canonical slug (s|m|l|xl|flexi) so
+	// the Organization CR carries the SINGLE truth-source for the resource cap
+	// the org-controller materializes (Workstream B, #4292). The funnel posts
+	// the slug directly and the BSS door posts a plan UUID; resolvePlanSlug
+	// handles BOTH (#4473) — a known slug short-circuits, a UUID is looked up in
+	// the catalog, and only a genuinely-unknown value falls back to a LOGGED "s"
+	// default. Before #4473 the funnel slug fell through to "s" unconditionally,
+	// downgrading every paid funnel Org to the S boundary.
 	planSlug := h.resolvePlanSlug(ctx, data.PlanID)
 	billingMode := strings.TrimSpace(data.BillingMode)
 	if billingMode == "" {

--- a/core/services/provisioning/handlers/resolve_plan_slug_4473_test.go
+++ b/core/services/provisioning/handlers/resolve_plan_slug_4473_test.go
@@ -1,0 +1,97 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+// #4473 — the marketplace funnel posts the plan SLUG ("m"/"l"/"xl"/…) as
+// plan_id, but resolvePlanSlug treated EVERY input as a catalog UUID, so a
+// funnel-posted slug matched no catalog row and silently fell through to the
+// "s" default — every funnel Org provisioned at the S boundary regardless of
+// the chosen plan (verified live on prov 91dc05917e44d1c1: plan_id:"m" → Org CR
+// spec.planSlug:"s"). These tests lock the slug fast-path + the preserved
+// UUID-lookup fallback + the logged-default behavior.
+
+func TestResolvePlanSlug_SlugInReturnsThatSlug(t *testing.T) {
+	// A known slug must be returned as-is WITHOUT any catalog round-trip — even
+	// with no CatalogURL configured, so it can never silently downgrade.
+	h := &Handler{CatalogURL: ""}
+	cases := map[string]string{
+		"s":     "s",
+		"m":     "m",
+		"l":     "l",
+		"xl":    "xl",
+		"flexi": "flexi",
+		"free":  "free",
+		// case-insensitive + whitespace-tolerant.
+		"M":     "m",
+		" xl ":  "xl",
+		"Flexi": "flexi",
+	}
+	for in, want := range cases {
+		if got := h.resolvePlanSlug(context.Background(), in); got != want {
+			t.Errorf("resolvePlanSlug(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestResolvePlanSlug_UUIDInResolvesViaCatalog(t *testing.T) {
+	// The BSS door posts a plan UUID; it must still resolve via /catalog/plans.
+	url := catalogPlansStub(t, http.StatusOK, `[{"id":"plan-m-uuid","slug":"m"},{"id":"plan-l-uuid","slug":"l"}]`)
+	h := &Handler{CatalogURL: url}
+	if got := h.resolvePlanSlug(context.Background(), "plan-l-uuid"); got != "l" {
+		t.Errorf("resolvePlanSlug(plan-l-uuid) = %q, want l", got)
+	}
+}
+
+func TestResolvePlanSlug_UnknownInDefaultsToS(t *testing.T) {
+	// An input that is neither a known slug nor a resolvable catalog UUID falls
+	// back to the historical "s" default (now logged, but still "s").
+	url := catalogPlansStub(t, http.StatusOK, `[{"id":"plan-m-uuid","slug":"m"}]`)
+	h := &Handler{CatalogURL: url}
+	if got := h.resolvePlanSlug(context.Background(), "totally-unknown-uuid"); got != "s" {
+		t.Errorf("resolvePlanSlug(unknown) = %q, want s (default)", got)
+	}
+}
+
+func TestResolvePlanSlug_TransientCatalogStillDefaultsToS(t *testing.T) {
+	// A non-slug input + a transient catalog failure keeps the historical "s"
+	// default for the creation path (resolveTenantPlanSlug carries the richer
+	// fail-closed signal for the day-2 path; the creation path resolves once).
+	url := catalogPlansStub(t, http.StatusInternalServerError, `boom`)
+	h := &Handler{CatalogURL: url}
+	if got := h.resolvePlanSlug(context.Background(), "plan-m-uuid"); got != "s" {
+		t.Errorf("resolvePlanSlug(uuid, transient) = %q, want s", got)
+	}
+}
+
+func TestLookupPlanSlug_SlugInIsAuthoritative(t *testing.T) {
+	// #4473: a known slug passed to the day-2 resolver is authoritative with no
+	// catalog dependency (reachable=true), so a funnel slug is never mistaken
+	// for an unreachable-catalog guess.
+	h := &Handler{CatalogURL: ""}
+	slug, reachable := h.lookupPlanSlug(context.Background(), "xl")
+	if !reachable {
+		t.Fatalf("a known slug must be reachable=true (authoritative) even with no CatalogURL")
+	}
+	if slug != "xl" {
+		t.Errorf("slug = %q, want xl", slug)
+	}
+}
+
+func TestIsKnownPlanSlug(t *testing.T) {
+	known := []string{"s", "m", "l", "xl", "flexi", "free", "M", " L ", "XL"}
+	for _, k := range known {
+		if _, ok := isKnownPlanSlug(k); !ok {
+			t.Errorf("isKnownPlanSlug(%q) = false, want true", k)
+		}
+	}
+	unknown := []string{"", "  ", "plan-m-uuid", "xxl", "medium", "0", "tier-m"}
+	for _, u := range unknown {
+		if norm, ok := isKnownPlanSlug(u); ok {
+			t.Errorf("isKnownPlanSlug(%q) = true (norm=%q), want false", u, norm)
+		}
+	}
+}


### PR DESCRIPTION
## Fault (verified live on prov `91dc05917e44d1c1`)

The marketplace funnel posts the plan **slug** (`"s"`/`"m"`/`"l"`/`"xl"`/`"flexi"`) as `plan_id`, but `resolvePlanSlug(ctx, planID)` in `core/services/provisioning/handlers/handlers.go` treated **every** input as a plan UUID and looked it up against `/catalog/plans`. A slug matches no catalog UUID row, so the resolver fell through every branch to the hardcoded `return "s"` default.

Result: a customer who picks/pays for M/L/XL gets an Organization CR provisioned at the **S** boundary/quota. Pillar-1 billing/provisioning correctness fault.

**Live proof:** funnel posted `plan_id:"m"` → tenant-service stored `plan_id:"m"` ✓ but the Org CR `uatwalk91` had `spec.planSlug: "s"`. Owner email + apps propagated correctly; only the plan slug was wrong.

## Fix

`resolvePlanSlug` now accepts **both** doors' inputs:
- **Funnel door** posts the slug directly → a known slug (`s`/`m`/`l`/`xl`/`flexi`/`free`, case-insensitive, whitespace-tolerant) short-circuits with **no catalog round-trip**.
- **BSS door** posts a plan UUID → still resolved via `/catalog/plans` (unchanged, no regression).
- A genuinely-unknown value → the historical `"s"` default, but now **LOGGED** (`slog.Warn`) so a silent S-downgrade is never invisible again.

`lookupPlanSlug` (the #4293 day-2 resolver) gains the same slug fast-path, so a funnel slug is treated as authoritative rather than as an unreachable-catalog guess. The canonical slug set is centralized in `knownPlanSlugs` / `isKnownPlanSlug`, aligned with the `BoundaryIsVcluster` / `qosResources` switches in `gitops`.

## Test

`handlers/resolve_plan_slug_4473_test.go`:
- slug-in → that slug (incl. case/whitespace, with empty CatalogURL — never downgrades)
- UUID-in → catalog-resolved slug
- unknown-in → `"s"` default
- transient catalog + UUID → `"s"`
- `lookupPlanSlug` slug fast-path → authoritative
- `isKnownPlanSlug` known/unknown table

`go build ./...` + `go vet ./handlers/...` clean. New tests + the existing #4293 fail-closed tests all green.

## Ship + verify

This is the **provisioning** microservice — rolls via `services-provisioning:<sha>`, not catalyst-api. Live-verify pending the services-provisioning image roll: a fresh funnel M Org should then carry `spec.planSlug == "m"`.

Refs #3376 #4293
Refs #4473

🤖 Generated with [Claude Code](https://claude.com/claude-code)