### PR TITLE
fix(org-controller): CRD clientSecretRef value-struct trap + teardown RBAC delete on httproutes/certificates (1.4.899)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1173,7 +1173,17 @@ spec:
       #   "organizations"`), producing NO tenant-networking finalizer, per-Org cert,
       #   console-https-<slug> listener, or pool DNS on a fresh prov. Additive RBAC
       #   widening. Lockstep w/ Chart.yaml. Refs #4471 #4462 #4290.
-      version: 1.4.898
+      # 1.4.899 — #4471/#4462: two more org-controller reconcile faults (1.4.896's
+      #   `organizations` update/patch RBAC widening already landed via #4472).
+      #   (a) the CRD's clientSecretRef carried `required: [name, key]` + `key.default`,
+      #   but the controller models `spec.identity`/`clientSecretRef` as VALUE structs
+      #   so every client.Update serialized an empty `clientSecretRef: {}` → CRD
+      #   validation rejected ALL reconciles → no per-Org boundary (CRD relaxed,
+      #   absent-federation now round-trips). (b) the ClusterRole lacked `delete` on
+      #   httproutes + certificates → teardownTenantNetworking 403'd → deleted Orgs
+      #   stuck Terminating (delete added). Lockstep w/ Chart.yaml.
+      #   Refs #4471 #4462 #4290 #4293.
+      version: 1.4.899
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3254,6 +3254,24 @@ name: bp-catalyst-platform
 #   preserved verbatim. The #4452 guard chart/tests/gitea-flux-auth-sync-rbac-
 #   order.sh is extended with parallel gate-3/gate-4 cases for this second job.
 #   Lockstep w/ bootstrap-kit slot 13 pin. Refs #4447 #3763 #3781.
+# 1.4.899 — #4471/#4462: two more org-controller reconcile faults (the 1.4.896
+#   `organizations` update/patch RBAC widening already landed via #4472). (a) CRD
+#   clientSecretRef value-struct trap: the controller models `spec.identity`
+#   (and its `clientSecretRef`) as VALUE structs, so `,omitempty` is a no-op and
+#   EVERY `client.Update` (e.g. the finalizer-add) serializes an empty
+#   `clientSecretRef: {}`; with the CRD's `required: [name, key]` + `key.default`
+#   present, that empty object failed validation (`clientSecretRef.name: Required
+#   value`) and wedged ALL reconciles before any per-Org boundary was produced.
+#   FIX: drop `required`/`key.default` from the CRD so an absent federation
+#   round-trips; a configured federation still needs name+key, validated by the
+#   controller at readClientSecret() time. (b) teardown RBAC gap: the
+#   organization-controller ClusterRole lacked `delete` on `httproutes`
+#   (gateway.networking.k8s.io) + `certificates` (cert-manager.io), so
+#   teardownTenantNetworking 403'd on Org deletion (`cannot delete resource
+#   "httproutes"/"certificates"`) — the tenant-networking finalizer never dropped
+#   and deleted Orgs hung Terminating forever. FIX: add `delete` (additive,
+#   existing verbs kept). Lockstep w/ bootstrap-kit slot 13 pin.
+#   Refs #4471 #4462 #4290 #4293.
 # 1.4.896 — #4471/#4462: organization-controller ClusterRole was missing update +
 #   patch on the MAIN `organizations` resource — it granted only get/list/watch
 #   there + update/patch on the /status + /finalizers SUBRESOURCES. The #4462
@@ -3272,7 +3290,7 @@ name: bp-catalyst-platform
 #   bump back to b23af68, shipping org-controller WITHOUT #4455 tenant-dns +
 #   #4462 delete-cascade on every fresh prov). 89993b2 is a descendant of b23af68
 #   so it retains #4393 Guaranteed-QoS. Lockstep w/ bootstrap-kit slot 13 pin.
-version: 1.4.898
+version: 1.4.899
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/
 #   platform/crossplane chart + blueprint.yaml + bootstrap-kit slot 04). crossplane-core
 #   was still OOMKilled (CrashLoopBackOff, 55 restarts, exit 137, killed ~90s after start)

--- a/products/catalyst/chart/crds/organization.yaml
+++ b/products/catalyst/chart/crds/organization.yaml
@@ -210,16 +210,34 @@ spec:
                           type: string
                         clientSecretRef:
                           type: object
-                          required: [name, key]
                           description: |
                             Reference to a SealedSecret that holds the OIDC
                             client secret. Plaintext NEVER on the CR.
+
+                            #4471: `required: [name, key]` and `key.default`
+                            were REMOVED. `identity.federationConfig` is an
+                            OPTIONAL block ("empty means use the Sovereign's
+                            own realm"), but the controller's Go types model it
+                            as a VALUE struct (orgapi.OrganizationIdentity,
+                            not a pointer) — `,omitempty` is a no-op on a
+                            struct, so on EVERY `client.Update` (e.g. the
+                            tenant-networking finalizer add) the apiserver
+                            receives `clientSecretRef: {}`. With `required`
+                            present + `key` defaulted-in, that empty object
+                            failed validation (`clientSecretRef.name: Required
+                            value`) and wedged ALL reconciles before any
+                            per-Org boundary was produced. Dropping the
+                            required-enforcement here lets an absent federation
+                            round-trip; a configured federation still needs
+                            both name+key, which the controller validates at
+                            readClientSecret() time (organization_controller.go
+                            ~L1118) and surfaces on the IdentityProviderConfigured
+                            condition.
                           properties:
                             name:
                               type: string
                             key:
                               type: string
-                              default: client-secret
                           x-kubernetes-preserve-unknown-fields: true
                         tenantId:
                           type: string

--- a/products/catalyst/chart/templates/controllers/organization-controller-clusterrole.yaml
+++ b/products/catalyst/chart/templates/controllers/organization-controller-clusterrole.yaml
@@ -60,9 +60,16 @@ rules:
   # through to the Sovereign-wide tenant-wildcard / connection-refused).
   # The Flux GitRepository + Kustomization grants below (per_org_flux.go)
   # were already present; the HTTPRoute grant was the missing peer.
+  #
+  # #4471/#4462: `delete` added — teardownTenantNetworking
+  # (tenant_networking_teardown.go:127) DELETEs the per-Org console
+  # HTTPRoute on Org deletion. Without it the tenant-networking finalizer
+  # teardown 403s (`cannot delete resource "httproutes"`), the finalizer
+  # never drops, and the Org CR is stuck Terminating forever (orphaning
+  # its console route + wildcard cert).
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["httproutes"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   # #4075: a customer Org that picks a free-subdomain hostname under a
   # pool parent zone (e.g. console.<slug>.omani.homes) needs a
   # `*.<parentDomain>` TLS listener appended to the dedicated console
@@ -77,9 +84,15 @@ rules:
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["gateways"]
     verbs: ["get", "list", "watch", "update", "patch"]
+  # #4471/#4462: `delete` added — teardownTenantNetworking
+  # (tenant_networking_teardown.go:122) DELETEs the per-Org wildcard
+  # Certificate (org-wildcard-tls-<slug>-<pool>) in kube-system on Org
+  # deletion. Without it the tenant-networking finalizer teardown 403s
+  # (`cannot delete resource "certificates"`), the finalizer never drops,
+  # and the Org CR is stuck Terminating forever.
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]


### PR DESCRIPTION
Lands the genuine NEW value of #4474 cleanly on top of main. #4474's layer-1 RBAC (`organizations` update/patch) already merged via #4472 (chart 1.4.896), so this PR carries only layers 2 + 3, rebased on the current main (1.4.898).

## Layer 2 — CRD clientSecretRef value-struct trap
The org-controller models optional `spec.identity` (and its `clientSecretRef`) as VALUE structs, so `,omitempty` is a no-op and every `client.Update` (e.g. the tenant-networking finalizer-add) serializes an empty `clientSecretRef: {}`. With the CRD's `required: [name, key]` + `key.default` present, that empty object failed validation (`clientSecretRef.name: Required value`) and wedged ALL reconciles before any per-Org boundary was produced.

**Fix:** drop `required: [name, key]` and `key.default` from the CRD so an absent federation round-trips. A configured federation still needs both `name`+`key`, validated by the controller at `readClientSecret()` time and surfaced on the `IdentityProviderConfigured` condition.

## Layer 3 — teardown RBAC fault
The organization-controller ClusterRole lacked `delete` on `httproutes` (gateway.networking.k8s.io) + `certificates` (cert-manager.io). `teardownTenantNetworking` (`tenant_networking_teardown.go`) DELETEs the per-Org console HTTPRoute (`teardownTenantRoute`) + per-Org wildcard Certificate (`teardownTenantConsoleTLS`) on Org deletion, so without `delete` the tenant-networking finalizer teardown 403'd, the finalizer never dropped, and deleted Orgs hung Terminating forever.

**Fix:** add `delete` to those two rules (additive — existing verbs kept).

## Delivery
- bp-catalyst-platform chart `1.4.898` -> `1.4.899` + bootstrap-kit slot-13 pin in lockstep.
- `scripts/check-bootstrap-kit-pin-sync.sh` PASS (chart=1.4.899 pin=1.4.899).
- `helm lint` clean, `helm template` renders clean (org-controller ClusterRole shows `delete` on httproutes+certificates).
- CRD valid: `kubectl apply --dry-run=client` accepts it; YAML round-trips with `clientSecretRef.required`/`key.default` removed.

Refs #4471 #4462 #4290 #4293