### PR TITLE
fix(catalyst-api): console org-list/detail read from orgs.openova.io CRs — funnel Orgs (+ parent) now render (Refs #4179 #4290 #3687)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/org_list_from_cr.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_list_from_cr.go
@@ -1,0 +1,262 @@
+// org_list_from_cr.go — #4479 (Refs #4179 #4290 #3687). The console
+// org-list + org-detail read path used to source ONLY from the local
+// directory-backed OrganizationProvisionStore (deps.Store) — the
+// provision-record store written by THIS catalyst-api's own create
+// pipeline (the BSS door, HandleCreateOrganization). A funnel-created
+// Organization (core/services/provisioning consumer → createOrganizationCR)
+// mints the canonical orgs.openova.io CR directly but never writes a
+// local provision record, so it was invisible: GET /api/v1/organizations
+// returned {"items":[]} and GET /api/v1/organizations/{slug} 404'd
+// org-tenant-not-found — for every funnel Org AND the parent Sovereign Org.
+//
+// This file aligns the read path with the #4290 single-producer model:
+// every Organization — funnel OR BSS — is an orgs.openova.io CR the
+// org-controller reconciles, so the console reads from THAT source of
+// truth. The local store is still consulted (and wins on collision) so
+// in-flight provisioning detail (the 7-step timeline, last_error,
+// commit_sha) keeps rendering for rows the BSS door authored before the
+// CR lands. The merge is deduped by slug.
+//
+// CR-read is nil-tolerant by construction: out-of-cluster / CI (no
+// in-cluster dynamic client) leaves orgResponsesFromCRs returning
+// (nil, nil) and the handlers fall back to the local store unchanged —
+// preserving the existing store-only unit tests.
+
+package handler
+
+import (
+	"context"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+// orgResponsesFromCRs lists every orgs.openova.io Organization CR via the
+// in-cluster dynamic client and maps each to an orgTenantResponse. Returns
+// (nil, nil) when no in-cluster dynamic client is available (CI /
+// out-of-cluster catalyst-api) so callers transparently fall back to the
+// local store. A list error is surfaced so the caller can decide whether to
+// degrade to store-only (it does) rather than 5xx the whole console.
+func (h *Handler) orgResponsesFromCRs(ctx context.Context) ([]orgTenantResponse, error) {
+	deps, err := h.sovereignDepsFor()
+	if err != nil || deps == nil || deps.dyn == nil {
+		// Out-of-cluster / CI: no apiserver to read CRs from. The caller
+		// falls back to the local provision store.
+		return nil, nil
+	}
+	list, err := deps.dyn.Resource(organizationGVR()).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		// CRD not installed on an older Sovereign, transient apiserver
+		// blip, RBAC gap — degrade to store-only rather than erroring the
+		// directory. The caller logs + falls back.
+		return nil, err
+	}
+	out := make([]orgTenantResponse, 0, len(list.Items))
+	for i := range list.Items {
+		out = append(out, orgCRToResponse(&list.Items[i], h.orgTenantDeps.OTECHFQDN))
+	}
+	return out, nil
+}
+
+// orgCRFromSlug fetches a single Organization CR by name (the slug). Returns
+// (nil, false) when no dynamic client is available or the CR is absent — the
+// caller then falls back to the local store / 404.
+func (h *Handler) orgCRFromSlug(ctx context.Context, slug string) (*orgTenantResponse, bool) {
+	slug = strings.ToLower(strings.TrimSpace(slug))
+	if slug == "" {
+		return nil, false
+	}
+	deps, err := h.sovereignDepsFor()
+	if err != nil || deps == nil || deps.dyn == nil {
+		return nil, false
+	}
+	obj, err := deps.dyn.Resource(organizationGVR()).Get(ctx, slug, metav1.GetOptions{})
+	if err != nil || obj == nil {
+		return nil, false
+	}
+	resp := orgCRToResponse(obj, h.orgTenantDeps.OTECHFQDN)
+	return &resp, true
+}
+
+// orgCRToResponse maps an Organization CR (orgs.openova.io/v1) onto the
+// console's orgTenantResponse wire shape. The CR is the canonical desired-
+// state both doors write (org_tenant_org_cr.go ensureOrganizationCR +
+// core/services/provisioning createOrganizationCR), so the mapping mirrors
+// that spec shape. Provisioning-timeline detail (steps/last_error/commit_sha)
+// is NOT on the CR — those stay zero-valued here and are filled from the
+// local store on the merge when a record exists; for a pure funnel Org the
+// timeline is derived from the CR phase (Ready→done) so the directory still
+// renders a sane status.
+func orgCRToResponse(obj *unstructured.Unstructured, otechFQDN string) orgTenantResponse {
+	spec, _, _ := unstructured.NestedMap(obj.Object, "spec")
+	getSpec := func(key string) string {
+		if spec == nil {
+			return ""
+		}
+		if v, ok := spec[key].(string); ok {
+			return strings.TrimSpace(v)
+		}
+		return ""
+	}
+
+	slug := getSpec("slug")
+	if slug == "" {
+		slug = strings.TrimSpace(obj.GetName())
+	}
+	displayName := getSpec("displayName")
+
+	kind := strings.ToLower(getSpec("kind"))
+	if kind != "internal" && kind != "customer" {
+		kind = "customer"
+	}
+	tier := strings.ToLower(getSpec("tier"))
+	if tier == "" {
+		tier = "org"
+	}
+	billingMode := strings.ToLower(getSpec("billingMode"))
+	if billingMode == "" {
+		billingMode = "real"
+	}
+	// Isolation is derived (not a spec field) — mirror resolveOrgShape:
+	// internal → namespace, customer → vcluster.
+	isolation := "vcluster"
+	if kind == "internal" {
+		isolation = "namespace"
+	}
+
+	// tenantPublic.parentDomain carries the org-pool apex; subdomain
+	// defaults to the slug. Empty parent → single-domain back-compat
+	// (deriveConsoleHost falls back to OTECHFQDN).
+	parentDomain := ""
+	if tp, ok := spec["tenantPublic"].(map[string]any); ok {
+		if pd, ok := tp["parentDomain"].(string); ok {
+			parentDomain = strings.ToLower(strings.TrimSpace(pd))
+		}
+	}
+
+	adminEmail := ""
+	if owners, ok := spec["owners"].([]any); ok {
+		for _, o := range owners {
+			om, ok := o.(map[string]any)
+			if !ok {
+				continue
+			}
+			if e, ok := om["email"].(string); ok && strings.TrimSpace(e) != "" {
+				adminEmail = strings.TrimSpace(e)
+				// Prefer the owner role when present; otherwise first email.
+				if r, _ := om["role"].(string); strings.EqualFold(r, "owner") {
+					break
+				}
+			}
+		}
+	}
+
+	// tenant-id label is stamped by both CR emitters (ensureOrganizationCR:
+	// openova.io/tenant-id; provisioning createOrganizationCR: same). Fall
+	// back to the slug so org-detail is still addressable on legacy CRs.
+	tenantID := ""
+	if labels := obj.GetLabels(); labels != nil {
+		tenantID = strings.TrimSpace(labels["openova.io/tenant-id"])
+	}
+	if tenantID == "" {
+		tenantID = slug
+	}
+
+	// Derive the provisioning state from the CR status. The org-controller
+	// stamps status.vcluster.phase (Pending|Provisioning|Ready|Failed) and a
+	// top-level Ready condition. A Ready Org reads as STSDone so the console
+	// timeline shows green; anything else maps to a best-effort in-flight /
+	// failed state so the directory badge is honest.
+	state := orgStateFromCR(obj)
+
+	// Synthesize a provision record so we reuse deriveConsoleHost + the
+	// existing record→response mapper for hostname/steps derivation. This
+	// keeps the CR row byte-shaped identically to a store-backed row.
+	rec := store.OrganizationProvisionRecord{
+		OrganizationID:  tenantID,
+		State:           state,
+		Subdomain:       slug,
+		DomainMode:      store.OrganizationDomainFreeSubdomain,
+		ParentDomain:    parentDomain,
+		AdminEmail:      adminEmail,
+		CompanyName:     displayName,
+		OTECHFQDN:       strings.TrimSpace(otechFQDN),
+		VClusterName:    "vc-" + slug,
+		TenantNamespace: slug,
+		Kind:            kind,
+		Tier:            tier,
+		BillingMode:     billingMode,
+		Isolation:       isolation,
+		PlanSlug:        strings.ToLower(getSpec("planSlug")),
+		CreatedAt:       obj.GetCreationTimestamp().Time,
+		UpdatedAt:       obj.GetCreationTimestamp().Time,
+	}
+	return orgTenantRecordToResponse(rec)
+}
+
+// orgStateFromCR maps the Organization CR status to a provision state for the
+// console timeline. Ready (vcluster phase Ready OR a Ready=True condition) →
+// STSDone; an explicit Failed phase → STSFailed; everything else (Pending /
+// Provisioning / no status yet) → STSBPChartsInstalled so the directory shows
+// "provisioning" rather than a misleading "pending" for an Org whose substrate
+// is already coming up.
+func orgStateFromCR(obj *unstructured.Unstructured) store.OrganizationProvisionState {
+	phase, _, _ := unstructured.NestedString(obj.Object, "status", "vcluster", "phase")
+	switch strings.ToLower(strings.TrimSpace(phase)) {
+	case "ready":
+		return store.STSDone
+	case "failed":
+		return store.STSFailed
+	}
+	// Top-level Ready condition as a secondary signal.
+	conds, _, _ := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	for _, c := range conds {
+		cm, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		ctype, _ := cm["type"].(string)
+		cstatus, _ := cm["status"].(string)
+		if strings.EqualFold(ctype, "Ready") && strings.EqualFold(cstatus, "True") {
+			return store.STSDone
+		}
+	}
+	if strings.TrimSpace(phase) == "" {
+		// No status block yet — substrate is being created.
+		return store.STSBPChartsInstalled
+	}
+	return store.STSBPChartsInstalled
+}
+
+// mergeOrgResponses unions the local store-backed rows with the CR-derived
+// rows, deduped by slug. Local rows win on collision: the BSS door authored
+// them and they carry the richer provisioning timeline (steps/last_error/
+// commit_sha) the CR lacks. CR-only rows (every funnel Org + the parent
+// Sovereign Org) are appended so the directory shows every real Organization.
+// Order: local rows first (newest-first as the store returns them), then the
+// CR-only remainder.
+func mergeOrgResponses(local, fromCR []orgTenantResponse) []orgTenantResponse {
+	bySlug := make(map[string]struct{}, len(local))
+	out := make([]orgTenantResponse, 0, len(local)+len(fromCR))
+	for _, r := range local {
+		key := strings.ToLower(strings.TrimSpace(r.Subdomain))
+		if key != "" {
+			bySlug[key] = struct{}{}
+		}
+		out = append(out, r)
+	}
+	for _, r := range fromCR {
+		key := strings.ToLower(strings.TrimSpace(r.Subdomain))
+		if key != "" {
+			if _, seen := bySlug[key]; seen {
+				continue
+			}
+			bySlug[key] = struct{}{}
+		}
+		out = append(out, r)
+	}
+	return out
+}

--- a/products/catalyst/bootstrap/api/internal/handler/org_list_from_cr_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_list_from_cr_test.go
@@ -1,0 +1,228 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+// newOrgHandlerWithSeededCRs wires the Organization deps with a local store
+// AND a fake dynamic client pre-seeded with the supplied Organization CRs, so
+// the #4479 list/detail read path can be exercised against canonical CRs that
+// the local provision store never saw (the funnel-Org case).
+func newOrgHandlerWithSeededCRs(t *testing.T, crs ...*unstructured.Unstructured) (*Handler, *store.OrganizationProvisionStore) {
+	t.Helper()
+	dir := t.TempDir()
+	tenantStore, err := store.NewOrganizationProvisionStore(dir)
+	if err != nil {
+		t.Fatalf("tenant store: %v", err)
+	}
+	h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	h.SetOrganizationDeps(OrganizationDeps{
+		Store:     tenantStore,
+		OTECHFQDN: "otech.example",
+	})
+
+	scheme := runtime.NewScheme()
+	gvrToList := map[schema.GroupVersionResource]string{
+		organizationGVR(): "OrganizationList",
+	}
+	objs := make([]runtime.Object, 0, len(crs))
+	for _, c := range crs {
+		objs = append(objs, c)
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToList, objs...)
+	h.SetSovereignDepsFactory(func() (*sovereignDeps, error) {
+		return &sovereignDeps{core: nil, dyn: dyn}, nil
+	})
+	return h, tenantStore
+}
+
+// orgCR builds a minimal Ready Organization CR (orgs.openova.io/v1) shaped
+// like the one both doors mint.
+func orgReadyCR(slug, displayName, parentDomain, ownerEmail, phase string) *unstructured.Unstructured {
+	spec := map[string]any{
+		"slug":         slug,
+		"displayName":  displayName,
+		"kind":         "customer",
+		"tier":         "org",
+		"planSlug":     "s",
+		"billingMode":  "real",
+		"sovereignRef": "otech.example",
+		"owners": []any{
+			map[string]any{"email": ownerEmail, "role": "owner"},
+		},
+	}
+	if parentDomain != "" {
+		spec["tenantPublic"] = map[string]any{
+			"parentDomain": parentDomain,
+			"subdomain":    slug,
+		}
+	}
+	obj := map[string]any{
+		"apiVersion": "orgs.openova.io/v1",
+		"kind":       "Organization",
+		"metadata": map[string]any{
+			"name": slug,
+			"labels": map[string]any{
+				"openova.io/tenant-id": "tid-" + slug,
+			},
+		},
+		"spec": spec,
+	}
+	if phase != "" {
+		obj["status"] = map[string]any{
+			"vcluster": map[string]any{"phase": phase},
+		}
+	}
+	return &unstructured.Unstructured{Object: obj}
+}
+
+// TestListOrganizations_IncludesFunnelCRs is the #4479 DoD: a funnel-created
+// Org (CR only, no local provision record) appears in GET /api/v1/organizations
+// alongside the parent Sovereign Org. Before the fix the directory returned
+// only the local store rows (empty for funnel Orgs) → {"items":[]}.
+func TestListOrganizations_IncludesFunnelCRs(t *testing.T) {
+	h, _ := newOrgHandlerWithSeededCRs(t,
+		orgReadyCR("uatwalk91", "UAT Walk 91", "omani.homes", "owner@uatwalk91.test", "Ready"),
+		orgReadyCR("omantel", "Omantel", "", "admin@omantel.biz", "Ready"),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/organizations", nil)
+	w := httptest.NewRecorder()
+	h.HandleListOrganizations(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: want 200 got %d body=%s", w.Code, w.Body.String())
+	}
+	var got struct {
+		Items []orgTenantResponse `json:"items"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Items) != 2 {
+		t.Fatalf("items: want 2 (funnel Org + parent) got %d: %s", len(got.Items), w.Body.String())
+	}
+	bySlug := map[string]orgTenantResponse{}
+	for _, it := range got.Items {
+		bySlug[it.Subdomain] = it
+	}
+	uat, ok := bySlug["uatwalk91"]
+	if !ok {
+		t.Fatalf("funnel Org uatwalk91 missing from directory")
+	}
+	if uat.State != store.STSDone {
+		t.Errorf("uatwalk91 state: want done (Ready phase) got %s", uat.State)
+	}
+	if uat.ConsoleHost != "console.uatwalk91.omani.homes" {
+		t.Errorf("uatwalk91 console_host: want console.uatwalk91.omani.homes got %q", uat.ConsoleHost)
+	}
+	if _, ok := bySlug["omantel"]; !ok {
+		t.Errorf("parent Org omantel missing from directory")
+	}
+}
+
+// TestListOrganizations_LocalWinsOnCollision proves the merge dedupes by slug
+// and the local store row (richer in-flight timeline) wins over the CR row.
+func TestListOrganizations_LocalWinsOnCollision(t *testing.T) {
+	h, st := newOrgHandlerWithSeededCRs(t,
+		orgReadyCR("acme", "ACME from CR", "omani.homes", "cr@acme.test", "Ready"),
+	)
+	// Local store row for the SAME slug with a distinct company name +
+	// in-flight (not done) state.
+	if err := st.Put(store.OrganizationProvisionRecord{
+		OrganizationID: "uuid-acme",
+		State:          store.STSBPChartsInstalled,
+		Subdomain:      "acme",
+		DomainMode:     store.OrganizationDomainFreeSubdomain,
+		ParentDomain:   "omani.homes",
+		AdminEmail:     "local@acme.test",
+		CompanyName:    "ACME from local store",
+		OTECHFQDN:      "otech.example",
+	}); err != nil {
+		t.Fatalf("seed local: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/organizations", nil)
+	w := httptest.NewRecorder()
+	h.HandleListOrganizations(w, req)
+
+	var got struct {
+		Items []orgTenantResponse `json:"items"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &got)
+	if len(got.Items) != 1 {
+		t.Fatalf("items: want 1 (deduped) got %d", len(got.Items))
+	}
+	if got.Items[0].CompanyName != "ACME from local store" {
+		t.Errorf("collision: local row should win, got company %q", got.Items[0].CompanyName)
+	}
+}
+
+// TestGetOrganization_FunnelCRBySlug is the org-detail half: a slug-addressed
+// GET resolves the Organization CR when the local store has no matching
+// record. Before the fix this 404'd org-tenant-not-found.
+func TestGetOrganization_FunnelCRBySlug(t *testing.T) {
+	h, _ := newOrgHandlerWithSeededCRs(t,
+		orgReadyCR("uatwalk91", "UAT Walk 91", "omani.homes", "owner@uatwalk91.test", "Ready"),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/organizations/uatwalk91", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "uatwalk91")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	w := httptest.NewRecorder()
+	h.HandleGetOrganization(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: want 200 got %d body=%s", w.Code, w.Body.String())
+	}
+	var got orgTenantResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Subdomain != "uatwalk91" {
+		t.Errorf("subdomain: want uatwalk91 got %q", got.Subdomain)
+	}
+	if got.AdminEmail != "owner@uatwalk91.test" {
+		t.Errorf("admin_email: want owner@uatwalk91.test got %q", got.AdminEmail)
+	}
+	if got.State != store.STSDone {
+		t.Errorf("state: want done got %s", got.State)
+	}
+}
+
+// TestGetOrganization_StillMissesUnknown confirms a slug with neither a local
+// record nor a CR still 404s org-tenant-not-found.
+func TestGetOrganization_StillMissesUnknown(t *testing.T) {
+	h, _ := newOrgHandlerWithSeededCRs(t,
+		orgReadyCR("acme", "ACME", "omani.homes", "a@b.test", "Ready"),
+	)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/organizations/nope", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "nope")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	w := httptest.NewRecorder()
+	h.HandleGetOrganization(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status: want 404 got %d", w.Code)
+	}
+	var got map[string]string
+	_ = json.Unmarshal(w.Body.Bytes(), &got)
+	if got["error"] != "org-tenant-not-found" {
+		t.Errorf("error: want org-tenant-not-found got %q", got["error"])
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
@@ -703,38 +703,70 @@ func (h *Handler) HandleCreateOrganization(w http.ResponseWriter, r *http.Reques
 }
 
 // HandleListOrganizations — GET /api/v1/org/tenants.
+//
+// #4479 (Refs #4179 #4290 #3687): the directory unions the local
+// provision-record store (the BSS door's in-flight timeline detail) with
+// the canonical orgs.openova.io Organization CRs (the truth BOTH doors
+// write). Without the CR read every funnel-created Org — and the parent
+// Sovereign Org — was invisible because the funnel never writes a local
+// record. The CR read is nil-tolerant (orgResponsesFromCRs returns
+// (nil,nil) out-of-cluster/CI), so the store-only path is preserved when
+// no in-cluster dynamic client exists. Local rows win on slug collision
+// (richer provisioning timeline); CR-only rows are appended.
 func (h *Handler) HandleListOrganizations(w http.ResponseWriter, r *http.Request) {
 	deps := h.orgTenantDeps
-	if deps.Store == nil {
-		writeJSON(w, http.StatusOK, map[string]any{"items": []orgTenantResponse{}})
-		return
+	local := make([]orgTenantResponse, 0)
+	if deps.Store != nil {
+		for _, rec := range deps.Store.List() {
+			local = append(local, orgTenantRecordToResponse(rec))
+		}
 	}
-	rows := deps.Store.List()
-	out := make([]orgTenantResponse, 0, len(rows))
-	for _, rec := range rows {
-		out = append(out, orgTenantRecordToResponse(rec))
+
+	fromCR, err := h.orgResponsesFromCRs(r.Context())
+	if err != nil {
+		// CRD absent / apiserver blip / RBAC gap — degrade to store-only
+		// rather than 5xx-ing the directory. Loud log, soft fall-through.
+		h.log.Warn("org-tenant: list Organization CRs failed — directory degrades to local store only", "err", err)
 	}
+
+	out := mergeOrgResponses(local, fromCR)
 	writeJSON(w, http.StatusOK, map[string]any{"items": out})
 }
 
 // HandleGetOrganization — GET /api/v1/org/tenants/{id}.
+//
+// #4479 (Refs #4179 #4290 #3687): org-detail resolves the path param
+// against the local provision store FIRST (the param is the BSS door's
+// UUID), then falls back to an orgs.openova.io Organization CR lookup by
+// slug. The console + openova-MCP address org-detail by slug
+// (console.<slug>...), and a funnel-created Org has no local record — only
+// the CR — so without the CR fallback BOTH the customer Org and the parent
+// Sovereign Org 404'd org-tenant-not-found. The CR read is nil-tolerant
+// (no dynamic client → fall through to 404), preserving the store-only
+// path in CI / out-of-cluster.
 func (h *Handler) HandleGetOrganization(w http.ResponseWriter, r *http.Request) {
 	deps := h.orgTenantDeps
-	if deps.Store == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
-			"error": "org-tenant-store-unavailable",
-		})
-		return
-	}
 	id := chi.URLParam(r, "id")
-	rec, ok := deps.Store.Get(id)
-	if !ok {
-		writeJSON(w, http.StatusNotFound, map[string]string{
-			"error": "org-tenant-not-found",
-		})
+
+	// 1) Local provision store keyed by the BSS-door UUID.
+	if deps.Store != nil {
+		if rec, ok := deps.Store.Get(id); ok {
+			writeJSON(w, http.StatusOK, orgTenantRecordToResponse(rec))
+			return
+		}
+	}
+
+	// 2) Canonical Organization CR keyed by slug (the funnel-Org path + the
+	//    parent Sovereign Org). `id` doubles as the slug for slug-addressed
+	//    callers (console / openova-MCP).
+	if resp, ok := h.orgCRFromSlug(r.Context(), id); ok {
+		writeJSON(w, http.StatusOK, *resp)
 		return
 	}
-	writeJSON(w, http.StatusOK, orgTenantRecordToResponse(rec))
+
+	writeJSON(w, http.StatusNotFound, map[string]string{
+		"error": "org-tenant-not-found",
+	})
 }
 
 // HandleReconcileOrganization — POST /api/v1/org/tenants/{id}/reconcile.


### PR DESCRIPTION
## Problem (§G walker, live on prov `91dc05917e44d1c1`)
A funnel-created Organization is **invisible in the operator console** even though its `orgs.openova.io` CR is fully `Ready`. `uatwalk91` exists with `vcluster.phase=Ready` (WordPress+MySQL running, Keycloak group + Gitea org reconciled via #4471), yet:

- `GET /api/v1/organizations` returns `{"items":[]}`
- `GET /api/v1/organizations/{slug}` 404s `org-tenant-not-found` for BOTH the customer Org AND the parent `omantel.biz`

So the directory, org-detail, showback, and the Layer1=Organization treemap omit every real Org (§G rows 5/6/7/9/10/11/12/20/21/23/25 FAIL).

## Root cause
`HandleListOrganizations` + `HandleGetOrganization`
(`products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go`)
read **only** from `deps.Store` — the `OrganizationProvisionStore`, a
directory-backed (PVC-local) provision-record store written ONLY by THIS
catalyst-api's create pipeline (the **BSS door**, `HandleCreateOrganization`).

The **funnel door** (`core/services/provisioning` consumer → `createOrganizationCR`)
mints the canonical `orgs.openova.io` CR directly but never writes a local
record. So `Store.List()` is empty and `Store.Get(slug)` 404s for funnel Orgs.
The parent `omantel.biz` also 404s because the read path never consults the CRs
at all — empty for everyone whose record this Pod did not author. This is the
registration-store half of the funnel-vs-BSS door divergence (#4179).

## Fix (consolidation per #4290 single-producer)
Read the org-list + org-detail path from the **Organization CRs** (the truth
BOTH doors write) via the catalyst-api's existing in-cluster dynamic client
(`sovereignDepsFor()` + `organizationGVR()`), merged with local provision
records for in-flight timeline detail.

- **`org_list_from_cr.go`** (new):
  - `orgResponsesFromCRs` lists Organization CRs → `[]orgTenantResponse`
  - `orgCRFromSlug` fetches one CR by slug (org-detail fallback)
  - `orgCRToResponse` maps spec/status → wire shape (slug/displayName/kind/tier/billingMode/planSlug; `status.vcluster.phase` Ready→done, Failed→failed, else provisioning; owner email from `spec.owners`; console host via existing `deriveConsoleHost`)
  - `mergeOrgResponses` unions store + CR rows deduped by slug (local wins — richer timeline)
- **`HandleListOrganizations`**: union local store + CR rows.
- **`HandleGetOrganization`**: store lookup by UUID first, then CR fallback by slug (console / openova-MCP address detail by slug).
- **Nil-tolerant**: no in-cluster dynamic client (CI / out-of-cluster) → falls back to store-only, preserving prior behaviour + existing `TestListOrganizations`.

## Tests
`go test ./internal/handler/` green (full suite). New cases:
- `TestListOrganizations_IncludesFunnelCRs` — funnel Org (CR-only) + parent both render; phase Ready→done; console host derived
- `TestListOrganizations_LocalWinsOnCollision` — slug dedupe, local row wins
- `TestGetOrganization_FunnelCRBySlug` — slug-addressed detail resolves the CR
- `TestGetOrganization_StillMissesUnknown` — unknown slug still 404s `org-tenant-not-found`

## Delivery
catalyst-api is a microservice image (`ghcr.io/openova-io/openova/catalyst-api`).
`.github/workflows/catalyst-build.yaml` on merge auto-builds the image at the
merge SHA, seds the image pin into the api-deployment templates, bumps
`CATALYST_BUILD_SHA`, and bumps `products/catalyst/chart/Chart.yaml` so Blueprint
Release re-publishes — so the live roll on 91dc0591 follows merge + image build
(no manual lockstep needed).

Refs #4179 #4290 #3687

🤖 Generated with [Claude Code](https://claude.com/claude-code)
