### PR TITLE
fix(bp-openbao,bp-newapi): two fresh-prov SSO seeding faults — openbao external-group alias never binds (admin/ops 403) + newapi DB provider secret goes stale (Refs #4477 #3374)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -139,7 +139,10 @@ spec:
       #   readiness EXEC probes + server.livenessProbe ENABLED (sealed-tolerant)
       #   so the StatefulSet + sso-configure Deployment clear the host-ns Kyverno
       #   probes-present Enforce policy (post-#4325). Refs #4347 #4325.
-      version: 1.2.56
+      # 1.2.57 — #4477: sso-configure external-group→policy bind fix
+      #   (map_admin_group read canonical id from a nonexistent field on fresh
+      #   external groups → sovereign-admins/-ops never bound → openbao UI 403).
+      version: 1.2.57
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -298,7 +298,10 @@ spec:
       # 1.4.130 — #4347: channel-seed hook Job curl image harbor-proxied so it
       #   clears the host-ns Kyverno harbor-proxy-pull Enforce policy on every
       #   reconcile (post-#4325). Refs #4347 #4325.
-      version: 1.4.133
+      # 1.4.134 — #4477: admin-promote CronJob self-heals a stale OIDC provider
+      #   client_secret (resync_provider_secret) so a KC client-secret rotation
+      #   no longer wedges newapi token-exchange ("Failed to get token").
+      version: 1.4.134
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.133 # lockstep with chart/Chart.yaml (#4388 valkey.url + egress NP → host-ns valkey, #4325 fallout)
+  version: 1.4.134 # lockstep with chart/Chart.yaml (#4477 self-heal stale OIDC provider client_secret via promote CronJob resync)
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -899,7 +899,17 @@ name: bp-newapi
 #   `valkey-primary.valkey.svc` / ns `valkey` (bp-valkey re-homed to host ns by
 #   #4325; the old `rtz` namespace selector denied newapi→valkey:6379 egress).
 #   Config-default-only. Refs #4388 #4325 #4376.
-version: 1.4.133
+# 1.4.134 — #4477: SELF-HEAL a stale OIDC provider client_secret. The one-shot
+#   admin-seed upserts custom_oauth_providers.client_secret ONCE; when Keycloak
+#   rotates the newapi-admin client secret (or the seed ran before bp-sso-bridge
+#   published the final secret) the DB row goes stale → newapi token-exchange
+#   sends the old secret → KC `unauthorized_client` → in-app SSO errors "Failed
+#   to get token from OpenOva SSO". The per-minute admin-promote CronJob now runs
+#   resync_provider_secret (reads the live /oidc secret, UPDATEs the row only on
+#   drift, then hash-gated reload), mounts the OIDC secret, and its Role reads
+#   it. Live-verified on 91dc0591/omantel.biz: DB secret resynced, pod reloaded
+#   "Loaded 1 custom OAuth providers", KC authenticates the corrected secret.
+version: 1.4.134
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/admin-sso-seed-job.yaml
+++ b/platform/newapi/chart/templates/admin-sso-seed-job.yaml
@@ -272,6 +272,9 @@ rules:
     resources: ["secrets"]
     resourceNames:
       - {{ $cnpgSecretName | quote }}
+      # #4477 — promote.sh now also reads the OIDC secret to re-sync the
+      # provider's client_secret when KC rotates it (resync_provider_secret).
+      - {{ $oidcSecretName | quote }}
     verbs: ["get"]
   # promote.sh runs reload_newapi_provider → get+patch EXACTLY the NewAPI
   # Deployment (idempotent, hash-gated rollout-restart). Same scope as the
@@ -348,6 +351,43 @@ data:
       done
       echo "[admin-seed] FATAL: users table not present after 5min (newapi never migrated?)" >&2
       return 1
+    }
+    resync_provider_secret() {
+      # #4477 — keep the seeded custom_oauth_providers row's client_secret in
+      # sync with the LIVE KC `newapi-admin` client secret on EVERY promote
+      # tick, so a Keycloak client-secret ROTATION self-heals.
+      #
+      # ROOT CAUSE (measured live 91dc0591/omantel.biz 2026-06-26): the one-shot
+      # seed.sh upserts client_secret exactly once (post-install/upgrade hook).
+      # When KC later rotates the `newapi-admin` client secret — or the seed ran
+      # before bp-sso-bridge published the final secret — the DB row keeps the
+      # STALE secret forever; the per-minute promote CronJob only promoted users
+      # + reloaded, it NEVER re-upserted the provider secret. NewAPI's
+      # token-exchange then sends the old secret → Keycloak `unauthorized_client
+      # - Invalid client credentials` → the in-app SSO button errors "Failed to
+      # get token from OpenOva SSO" (live DB had pbzwee… while live KC + the
+      # synced newapi-oidc Secret had s9uH2s…).
+      #
+      # The mounted /oidc secret (the SAME ESO-synced `newapi-oidc` the seed
+      # reads) is the live source of truth — bp-sso-bridge publishes the LIVE KC
+      # client_secret to OpenBao and ESO syncs it here. Re-read it each tick and
+      # UPDATE the provider row when it drifts. Best-effort + idempotent: a no-op
+      # when the secret already matches (UPDATE … WHERE client_secret <> …), and
+      # when the secret/provider isn't present yet it simply skips. After a real
+      # update we trigger reload_newapi_provider (the hash changes → restart) so
+      # the running pod re-reads the corrected secret.
+      LIVE_CS="$(cat /oidc/client_secret 2>/dev/null || cat /oidc/OIDC_CLIENT_SECRET 2>/dev/null || echo '')"
+      if [ -z "${LIVE_CS}" ]; then
+        return 0
+      fi
+      changed="$($PSQL -c "UPDATE custom_oauth_providers
+              SET client_secret = '${LIVE_CS}', updated_at = now()
+              WHERE slug = '{{ $providerSlug }}'
+                AND client_secret IS DISTINCT FROM '${LIVE_CS}'
+            RETURNING id;" 2>/dev/null | wc -l | tr -d ' ')"
+      if [ "${changed:-0}" != "0" ]; then
+        echo "[admin-seed] provider {{ $providerSlug }} client_secret drifted from the live KC secret — resynced from /oidc"
+      fi
     }
     promote_oidc_users() {
       # Any SSO-authenticated, active user that is not yet root → root (100).
@@ -550,6 +590,10 @@ data:
   promote.sh: |
     . /scripts/common.sh
     wait_for_users_table
+    # #4477 — self-heal a stale provider client_secret BEFORE promote/reload, so a
+    # KC client-secret rotation never wedges token-exchange. Idempotent no-op when
+    # the DB already matches the live /oidc secret.
+    resync_provider_secret
     promote_oidc_users
     # (e') #3374/#3563 — SELF-HEALING provider reload. The one-shot seed.sh
     #      reload (step e) fires EXACTLY ONCE and is best-effort: if it is
@@ -807,6 +851,14 @@ spec:
             - name: cnpg
               secret:
                 secretName: {{ $cnpgSecretName | quote }}
+            # #4477 — promote.sh resync_provider_secret reads the live OIDC
+            # client_secret here to self-heal a drifted provider row. optional:
+            # true so a tick before bp-sso-bridge has published the secret still
+            # schedules (resync_provider_secret soft-skips when /oidc is empty).
+            - name: oidc
+              secret:
+                secretName: {{ $oidcSecretName | quote }}
+                optional: true
             - name: tmp
               emptyDir:
                 medium: Memory
@@ -827,6 +879,9 @@ spec:
                   mountPath: /scripts
                 - name: cnpg
                   mountPath: /cnpg
+                  readOnly: true
+                - name: oidc
+                  mountPath: /oidc
                   readOnly: true
                 - name: tmp
                   mountPath: /tmp

--- a/platform/newapi/chart/tests/admin-promote-rbac-render.sh
+++ b/platform/newapi/chart/tests/admin-promote-rbac-render.sh
@@ -174,4 +174,32 @@ if ! grep -q 'serviceAccountName: bp-newapi-admin-seed' "$seed_job_doc"; then
 fi
 echo "[bp-newapi] Case 5: PASS"
 
+# ── Case 6 (#4477): admin-promote CronJob re-syncs a drifted provider secret ─
+# REGRESSION GUARD for the live token-exchange fault (91dc0591/omantel.biz
+# 2026-06-26): the one-shot seed upserts the provider client_secret ONCE; when
+# KC rotates the newapi-admin client secret the DB row goes stale and the
+# per-minute promote CronJob never re-synced it → newapi token-exchange sent the
+# old secret → KC `unauthorized_client` → "Failed to get token from OpenOva SSO".
+# The fix mounts the OIDC secret into the CronJob + adds resync_provider_secret
+# to promote.sh + grants the promote Role read on the OIDC secret.
+echo "[bp-newapi] Case 6 (#4477): admin-promote re-syncs the provider client_secret"
+# 6a — promote Role reads the OIDC secret (default name bp-newapi-oidc).
+if ! grep -q 'bp-newapi-oidc' "$role_doc"; then
+  echo "FAIL: Role/bp-newapi-admin-promote does not grant read on the OIDC secret — resync_provider_secret cannot read /oidc (#4477)"
+  cat "$role_doc"
+  exit 1
+fi
+# 6b — CronJob mounts the OIDC secret at /oidc.
+if ! grep -q 'mountPath: /oidc' "$cron_doc"; then
+  echo "FAIL: CronJob/bp-newapi-admin-promote does not mount the OIDC secret at /oidc (#4477)"
+  exit 1
+fi
+# 6c — the scripts ConfigMap's promote.sh calls resync_provider_secret, and the
+#       function is defined in common.sh.
+if ! grep -q 'resync_provider_secret' "$cm_doc"; then
+  echo "FAIL: scripts ConfigMap does not define/call resync_provider_secret (#4477)"
+  exit 1
+fi
+echo "[bp-newapi] Case 6: PASS"
+
 echo "[bp-newapi] All admin-promote RBAC render cases PASS"

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.56  # lockstep with chart/Chart.yaml (#4402 spine topology tier:mgmt → '' host-native, #4325 de-vcluster fallout)
+  version: 1.2.57  # lockstep with chart/Chart.yaml (#4477 sso-configure external-group alias bind fix)
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -184,7 +184,18 @@ name: bp-openbao
 #   `seaweedfs-s3.seaweedfs.svc` / ns `seaweedfs` (bp-seaweedfs re-homed to host
 #   ns by #4325). snapshot-replication is default-OFF — applies only when an
 #   operator enables it. Test assertions updated in lockstep. Refs #4388 #4325.
-version: 1.2.56
+# 1.2.57 — #4477: FIX the sso-configure reconciler's external-group→policy
+#   binding for sovereign-admins + sovereign-ops. map_admin_group read the
+#   group's canonical id from a `canonical_id` field that DOES NOT EXIST on a
+#   fresh external group (it appears only inside the nested alias once an alias
+#   is bound) → _gid was empty on the first tick → the group-alias was never
+#   created → `WARN: mapping external group … failed` forever → the OIDC user's
+#   sovereign-admins group mapped to no policy → openbao UI 403 on
+#   /sys/internal/ui/mounts. The group's canonical id is its OWN top-level `id`;
+#   new `exact_id` helper extracts the group id (last exact "id") + alias id
+#   (first exact "id", only when a canonical_id is present). Live-verified on
+#   91dc0591/omantel.biz: both groups now bind sso-operator-admin on tick-1.
+version: 1.2.57
 # 1.2.51 (#3888, Refs #3847): prov-time openbao KV-seed mechanism — the
 # auth-bootstrap Job reads a one-shot cloud-init `openbao-bootstrap-seed`
 # Secret + writes its keys into KV at secret/<prefix>/* with the still-valid

--- a/platform/openbao/chart/templates/sso-configure-deployment.yaml
+++ b/platform/openbao/chart/templates/sso-configure-deployment.yaml
@@ -306,18 +306,32 @@ data:
       if [ -z "${OIDC_ACCESSOR}" ]; then
         log "WARN: could not resolve oidc auth mount accessor; admin-group mapping deferred to next tick"
       else
-        # group_field pulls the FIRST "<key>":"<value>" out of a
-        # `bao_get identity/group/name/<name>` body (one comma-joined line).
-        # The body nests an `alias` sub-object that ALSO carries `id` +
-        # `canonical_id`, so a greedy `.*"id":"…"` over the whole line is
-        # ambiguous. We split on commas first (tr , \n) and take head -1,
-        # which deterministically returns the EARLIEST key occurrence:
-        #   - `canonical_id` appears once (inside the alias) and its value
-        #     IS the canonical group id we must bind the alias to → _gid;
-        #   - `id` appears first as the alias's own id → _aid (the alias to
-        #     UPDATE on re-runs). $1=json body, $2=key name.
-        group_field() {
-          printf '%s' "$1" | tr ',' '\n' | sed -n "s/.*\"$2\":\"\([^\"]*\)\".*/\1/p" | head -1
+        # #4477 — robust id extraction from a `bao_get identity/group/name/<name>`
+        # body (one comma-joined JSON line). The PRIOR code read the group's
+        # canonical id from a `canonical_id` field and the alias id from the
+        # FIRST `id` — both WRONG, and the bug that made admin/ops never bind:
+        #
+        #   - A freshly-created EXTERNAL group has NO `canonical_id` anywhere in
+        #     its body — `canonical_id` appears ONLY inside the nested `alias`
+        #     sub-object, which is `{}` empty until an alias exists. So
+        #     `_gid="$(group_field … canonical_id)"` was EMPTY on the very first
+        #     tick → `[ -z "$_gid" ] && return 1` → the alias was NEVER created
+        #     → "mapping external group sovereign-admins/-ops failed" forever
+        #     (measured live 91dc0591/omantel.biz 2026-06-26 — sovereign-viewers
+        #     was unaffected only because the loop never maps viewers). The
+        #     group's canonical id is its OWN top-level `id`, ALWAYS present.
+        #   - The alias id (`_aid`, for the UPDATE path) is the alias
+        #     sub-object's `id`, present only once the alias exists.
+        #
+        # `exact_id` lists every EXACT `"id"` key value (not request_id /
+        # canonical_id / lease_id / *_id) in body order. The alias's `id`, when
+        # present, is nested first; the group's own `id` is last. So:
+        #   _gid = exact_id | tail -1   (group's canonical id — always present)
+        #   _aid = exact_id | head -1   (alias id — ONLY when an alias exists,
+        #                                gated on a `canonical_id` being present).
+        # $1 = json body.
+        exact_id() {
+          printf '%s' "$1" | tr ',{}' '\n\n\n' | grep -E '(^|[^A-Za-z_])"id":"' | sed -n 's/.*"id":"\([^"]*\)".*/\1/p'
         }
         map_admin_group() {
           # $1 = realm group name (claim value). Fully idempotent: creates
@@ -330,16 +344,24 @@ data:
           # id via identity/group-alias/id/<alias_id>.
           _grp="$1"
           _gjson="$(bao_get "identity/group/name/${_grp}")"
-          # The canonical group id == the alias.canonical_id in the body.
-          _gid="$(group_field "${_gjson}" canonical_id)"
-          # The existing group-alias id (absent until the first alias write).
-          _aid="$(group_field "${_gjson}" id)"
+          # The group's canonical id == its OWN top-level `id` (always present
+          # on any existing group). The nested alias.id (if any) sorts FIRST in
+          # the body, so the group id is the LAST exact-id occurrence (#4477).
+          _gid="$(exact_id "${_gjson}" | tail -1)"
+          # The existing group-alias id (absent until the first alias write) —
+          # the alias sub-object's `id`, present only when a `canonical_id`
+          # field exists in the body (i.e. the alias is non-empty).
+          if printf '%s' "${_gjson}" | grep -q '"canonical_id"'; then
+            _aid="$(exact_id "${_gjson}" | head -1)"
+          else
+            _aid=""
+          fi
           if [ -z "${_gid}" ]; then
             # Group does not exist yet — create it, then re-read its id.
             bao_write "identity/group" "$(printf '{"name":"%s","type":"external","policies":["sso-operator-admin"]}' "${_grp}")" || return 1
             _gjson="$(bao_get "identity/group/name/${_grp}")"
-            _gid="$(group_field "${_gjson}" canonical_id)"
-            _aid="$(group_field "${_gjson}" id)"
+            _gid="$(exact_id "${_gjson}" | tail -1)"
+            _aid=""
           else
             # Group exists — keep its policy current (last-write-wins).
             bao_write "identity/group/name/${_grp}" '{"type":"external","policies":["sso-operator-admin"]}' || return 1

--- a/platform/openbao/chart/tests/g117-5-sso-tier1.sh
+++ b/platform/openbao/chart/tests/g117-5-sso-tier1.sh
@@ -72,4 +72,23 @@ if ! grep -q "OpenBao's OIDC" "${chart_dir}/values.yaml" \
 fi
 echo "  PASS"
 
+echo "[g117-5-sso-tier1] Case 5 (#4477): sso-configure reads the group canonical id from the group's OWN top-level id, NOT a (nonexistent-on-fresh-group) canonical_id field"
+# REGRESSION GUARD: map_admin_group used to set _gid from `group_field … canonical_id`.
+# A fresh external group has NO canonical_id in its body until an alias is bound,
+# so _gid was empty on tick-1 and the group-alias was never created → admin/ops
+# never bound → openbao UI 403. The corrected loop derives _gid from the group's
+# own top-level id via `exact_id … | tail -1`. Assert the fix is present AND the
+# broken pattern is gone.
+recon="${tmpdir}/default.yaml"
+if ! grep -q 'exact_id()' "${recon}"; then
+  echo "FAIL: exact_id helper missing from reconcile.sh — #4477 fix regressed" >&2; exit 1
+fi
+if ! grep -q '_gid="$(exact_id ' "${recon}"; then
+  echo "FAIL: _gid no longer derived via exact_id (group top-level id) — #4477 fix regressed" >&2; exit 1
+fi
+if grep -q '_gid="$(group_field "${_gjson}" canonical_id)"' "${recon}"; then
+  echo "FAIL: _gid still read from a canonical_id field — the #4477 chicken-and-egg bug" >&2; exit 1
+fi
+echo "  PASS"
+
 echo "[bp-openbao G117.5 Tier-1 SSO] All cases PASS"


### PR DESCRIPTION
Two genuine SSO FAILs on the live fresh prov `91dc05917e44d1c1` (omantel.biz). Both are config-SEEDING faults (NOT the sso-bridge↔openbao netpol path, which is fixed). Refs #4477 #3374.

## FAIL 1 — openbao UI authz 403 (sovereign-admins/-ops never bind)
OIDC login lands but the UI 403s on `GET /v1/sys/internal/ui/mounts` — the user authed with only the `default` policy.

**Root cause:** `platform/openbao/chart/templates/sso-configure-deployment.yaml` `map_admin_group()` read the external group's canonical id from a `canonical_id` field that **does not exist on a fresh external group** — `canonical_id` appears only INSIDE the nested `alias` sub-object once an alias is bound. On tick-1 the body's `alias` is `{}` empty, so `_gid` was always empty → `[ -z "$_gid" ] && return 1` → the group-alias was never created → `WARN: mapping external group sovereign-admins/-ops failed` forever → the OIDC user's group mapped to no policy → 403. `sovereign-viewers` was unaffected only because the loop never maps viewers (their read-only baseline comes from the OIDC role's `token_policies`).

The group's canonical id is its **own top-level `id`**, always present. New `exact_id` helper extracts the group id (last exact `"id"`) and the alias id (first exact `"id"`, only when a `canonical_id` is present).

**Live-verified on 91dc0591:** the corrected `map_admin_group` ran against live openbao — both `sovereign-admins` + `sovereign-ops` now have aliases bound to the oidc mount accessor with `sso-operator-admin`.

bp-openbao **1.2.56 → 1.2.57** (chart + blueprint + slot-08 lockstep). `g117-5-sso-tier1.sh` Case 5 guards the corrected extraction.

## FAIL 2 — newapi token-exchange ("Failed to get token from OpenOva SSO")
**Root cause:** the `custom_oauth_providers` row IS seeded+enabled, but its `client_secret` goes STALE vs the rotating KC `newapi-admin` client secret. The one-shot admin-seed upserts the secret ONCE (post-install/upgrade hook); the per-minute admin-promote CronJob only promoted users + reloaded — it NEVER re-upserted the provider secret. When KC rotates (or the seed ran before bp-sso-bridge published the final secret) the DB row sends the old secret → KC `unauthorized_client` → in-app SSO errors. Live DB had `pbzwee…` while live KC + the synced `newapi-oidc` Secret had `s9uH2s…`.

**Fix:** `promote.sh` now runs `resync_provider_secret` (reads the live `/oidc` secret, `UPDATE`s the provider row only on drift, then hash-gated reload); the CronJob mounts the OIDC secret + its Role reads it.

**Live-verified on 91dc0591:** DB secret resynced; pod reloaded `Loaded 1 custom OAuth providers`; KC `invalid_grant`/`Code not valid` on a dummy code with the corrected secret (client authenticated) vs `unauthorized_client` with the stale secret.

bp-newapi **1.4.133 → 1.4.134** (chart + blueprint + slot-80 lockstep). `admin-promote-rbac-render.sh` Case 6 guards the resync seam.

## Follow-up PR (tracked on #4477)
The `catalyst-newapi-admin-token` ExternalSecret is `SecretSyncedError` (openbao path `sovereign/<fqdn>/newapi/admin-token` unwritten). This is the ADR-0003 unified-rbac admin **API token** (per-user-key issuance), orthogonal to the SSO browser login that is FAIL 2 — it needs a new openbao-writer seam for newapi and does not block the SSO login walk. A dedicated follow-up PR ships it; this PR keeps the SSO-login fix tight.

## Tests
- bp-openbao: g117-5-sso-tier1 (+ new Case 5), sso-landing-render, bootstrap-seed-toggle, httproute-render — all PASS; helm lint clean.
- bp-newapi: admin-promote-rbac-render (+ new Case 6), dsn-secret-preserve, httproute, imagepullsecrets, startup-probe, bridge-readiness — all PASS; helm lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
