### PR TITLE
fix(bp-catalyst-platform #4482): reflect catalyst-gitea-token into 'sandbox' ns — clear sandbox-controller CrashLoop, unblock openova-sandbox-mcp (1.4.901)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1183,7 +1183,12 @@ spec:
       #   httproutes + certificates → teardownTenantNetworking 403'd → deleted Orgs
       #   stuck Terminating (delete added). Lockstep w/ Chart.yaml.
       #   Refs #4471 #4462 #4290 #4293.
-      version: 1.4.900
+      # 1.4.901 — #4482 (Refs #3642): annotate the catalyst-gitea-token Secret
+      #   for emberstack reflection into the `sandbox` host ns so bp-sandbox's
+      #   sandbox-controller can read CATALYST_GITEA_TOKEN (was CrashLoopBackOff
+      #   on every Sovereign → 0 Sandboxes → no openova-sandbox-mcp). Lockstep
+      #   w/ Chart.yaml + templates/catalyst-gitea-token-secret.yaml.
+      version: 1.4.901
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,25 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.901 — #4482 (Refs #3642, 2026-06-26): unblock the Pillar-4 agentic
+# Sandbox+MCP journey. bp-sandbox's sandbox-controller CrashLoopBackOff'd on
+# every Sovereign — main.go calls mustEnv("CATALYST_GITEA_TOKEN") (hard
+# os.Exit(2) on empty) and sources the env from `catalyst-gitea-token` via an
+# `optional: true` secretKeyRef, but this template minted that Secret ONLY in
+# catalyst-system with NO reflector annotations, so it never reached the
+# `sandbox` host ns (split out by the #4325 de-vcluster). Empty env →
+# CrashLoop → 0 Sandboxes reconcile → no openova-sandbox-mcp process anywhere
+# (the bp-sandbox HR Ready=True masked the dead workload). Same de-vcluster
+# reflector-allowlist class as #4382/#4361/#4448. FIX: add emberstack
+# reflector annotations (reflection-allowed + reflection-auto, comma-free
+# `catalyst-system,sandbox` literals to dodge the comma-quantifier split trap)
+# to the catalyst-gitea-token Secret so it mirrors into `sandbox` and stays in
+# sync on PAT rotation. Live-proven on prov 91dc05917e44d1c1 (omantel.biz):
+# annotating the source reflected into `sandbox` within one reflector tick →
+# sandbox-controller 1/1 Running (0 restarts) → reconciled a Sandbox CR (12
+# files pushed to catalyst-tenant Gitea, status Ready=True/GitopsReconciled).
+# Additive-only (annotations on an existing Secret); no data/render change for
+# any other consumer; on contabo where gitea is host-side the gate is
+# unchanged. Bootstrap-kit slot-13 pin 1.4.900 → 1.4.901 lockstep.
 # 1.4.761 — #4061 (2026-06-22): stop a PERMANENT Sovereign from auto-firing the
 # self-sovereignty cutover the moment the mothership completes handover. The
 # child catalyst-api's ReceiveTofuArchive (handover.go) seals the
@@ -3290,7 +3310,7 @@ name: bp-catalyst-platform
 #   bump back to b23af68, shipping org-controller WITHOUT #4455 tenant-dns +
 #   #4462 delete-cascade on every fresh prov). 89993b2 is a descendant of b23af68
 #   so it retains #4393 Guaranteed-QoS. Lockstep w/ bootstrap-kit slot 13 pin.
-version: 1.4.900
+version: 1.4.901
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/
 #   platform/crossplane chart + blueprint.yaml + bootstrap-kit slot 04). crossplane-core
 #   was still OOMKilled (CrashLoopBackOff, 55 restarts, exit 137, killed ~90s after start)

--- a/products/catalyst/chart/templates/catalyst-gitea-token-secret.yaml
+++ b/products/catalyst/chart/templates/catalyst-gitea-token-secret.yaml
@@ -173,6 +173,33 @@ metadata:
     # subsequent helm install picks up the bytes via lookup against the
     # source Secrets.
     helm.sh/resource-policy: keep
+    # #4482 (Refs #3642) — mirror this PAT into the `sandbox` host ns so
+    # bp-sandbox's sandbox-controller can read CATALYST_GITEA_TOKEN.
+    # sandbox-controller's main.go calls mustEnv("CATALYST_GITEA_TOKEN")
+    # (hard os.Exit(2) on empty) and its Deployment sources the env from
+    # `catalyst-gitea-token` via an `optional: true` secretKeyRef. Pre-fix
+    # the Secret was minted ONLY in catalyst-system (no reflector
+    # annotations) and never reached `sandbox` (a host ns split out by the
+    # #4325 de-vcluster), so the env was empty → CrashLoopBackOff → 0
+    # Sandboxes reconcile → no openova-sandbox-mcp anywhere (Pillar-4
+    # journey dead; the bp-sandbox HR Ready=True masked it). Same
+    # de-vcluster reflector-allowlist class as #4382/#4361/#4448. The
+    # emberstack reflector mirrors the live token bytes (which the
+    # token-mint Job patches in below) into every listed namespace and
+    # keeps the mirror in sync on rotation. Namespace lists are
+    # COMMA-FREE literals — emberstack splits each *-namespaces annotation
+    # on commas BEFORE compiling each entry as a regex, so a `{m,n}`
+    # quantifier would be shattered by the split (see
+    # reference_ghcr_pull_reflector_misses_org_namespaces). Live-proven on
+    # prov 91dc05917e44d1c1 (omantel.biz): annotating the source Secret
+    # reflected into `sandbox` within one reflector tick →
+    # sandbox-controller went 1/1 Running (0 restarts) → reconciled a
+    # Sandbox CR (11-12 files pushed to catalyst-tenant Gitea, status
+    # Ready=True/GitopsReconciled).
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "catalyst-system,sandbox"
+    reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+    reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "catalyst-system,sandbox"
 type: Opaque
 data:
   # `url` carries the in-cluster Gitea endpoint so consumers don't need


### PR DESCRIPTION
## Fault (live on prov 91dc05917e44d1c1, omantel.biz)

`bp-sandbox`'s **sandbox-controller was in CrashLoopBackOff (22+ restarts)** on the Sovereign. Log:

```
{"level":"error","msg":"required env var unset","key":"CATALYST_GITEA_TOKEN"}
```

`core/controllers/sandbox/cmd/sandbox-controller/main.go:60` calls `mustEnv("CATALYST_GITEA_TOKEN")` → hard `os.Exit(2)` when empty. The Deployment sources that env from `secretKeyRef{name: catalyst-gitea-token, optional: true}`, but `products/catalyst/chart/templates/catalyst-gitea-token-secret.yaml` minted the Secret **only in `catalyst-system`** with **no reflector annotations** — so it never reached the `sandbox` host ns (split out by the #4325 de-vcluster). Verified live: `catalyst-system/catalyst-gitea-token` present (helm-hook annotations only); `sandbox/catalyst-gitea-token` → NotFound.

Consequence: empty env → CrashLoop → 0 `sandboxes.sandbox.openova.io` reconcile → **no `openova-sandbox-mcp` process anywhere** → the agentic Sandbox+MCP journey (Pillar-4) is dead. The `bp-sandbox` HR `Ready=True` masked it. Same de-vcluster reflector-allowlist class as #4382 / #4361 / #4448.

## Fix

Add emberstack-reflector annotations to the source `catalyst-gitea-token` Secret so it mirrors `catalyst-system → sandbox` and stays in sync on PAT rotation. Comma-free `catalyst-system,sandbox` literals to dodge the comma-quantifier split trap (memory `reference_ghcr_pull_reflector_misses_org_namespaces`). Additive-only — annotations on an existing Secret; no data/render change for any other consumer; contabo gate unchanged.

Chart `1.4.900 → 1.4.901` + bootstrap-kit slot-13 pin lockstep.

## Live evidence (prov 91dc05917e44d1c1, omantel.biz)

1. Annotated the source Secret → reflector mirrored into `sandbox` within one tick (`reflects: catalyst-system/catalyst-gitea-token`, non-empty token).
2. `sandbox-controller` → **`1/1 Running`, 0 restarts**; logs show `starting manager` (`newapi_wired:true`, `sovereign_fqdn:omantel.biz`) + leader lease acquired (passed the `mustEnv` exit).
3. Created a `Sandbox` CR (`uatwalk91`) → controller `reconcile ok`, **rendered 12 files** + pushed to `uatwalk91/catalyst-tenant@main:sandbox/...`; status `Ready=True` / reason `GitopsReconciled` / phase `Provisioning`. The rendered pty-server StatefulSet bundles `/usr/local/bin/openova-sandbox-mcp` + injects `mcp.json` for agent auto-discovery. (Test CR cleaned up.)

Unblocks UAT rows 218-223 (agentic Sandbox+MCP journey).

Refs #3642
Refs #4482

🤖 Generated with [Claude Code](https://claude.com/claude-code)