### PR TITLE
docs: janitor self-reap post-mortem (VPC guard-chain) + sovereign-prov pre-flight checklist

### DIFF
--- a/docs/runbooks/preflight-sovereign-provision.md
+++ b/docs/runbooks/preflight-sovereign-provision.md
@@ -1,0 +1,39 @@
+# Pre-flight checklist — fresh Sovereign provisioning (kom4dc / Huawei)
+
+**Purpose:** a GO/NO-GO gate run BEFORE firing `POST /sovereign/api/v1/deployments`, so a fresh prov never hits the kom4dc VPC/EIP bottleneck and never lands on an unsafe substrate. This complements the *code-level* pre-flight already in `products/catalyst/bootstrap/api/internal/provisioner/provisioner.go:1841` (#4435, VPC-quota count) — this runbook is the operator's manual confirmation + the substrate-safety checks that code does not cover.
+
+> Born from the 2026-06-26 P0 (`docs/sessions/2026-06-26/postmortem-janitor-self-reap.md`): a VPC-cleanup janitor reaped the live env. The checks below are the guard chain that incident defines.
+
+## GO/NO-GO checklist
+
+| # | Check | How | GO criteria |
+|---|---|---|---|
+| 1 | **VPC quota headroom** | Huawei API `GET /v1/{project}/vpcs` (me-east-215) — count `vpc`s | count < 5 (the hard project limit); after a clean wipe expect **1** (bastion) |
+| 2 | **EIP pool headroom** | `GET /v1/{project}/publicips` — count allocated | free ≥ the prov's needs (apiserver ×2 + ELB ×2 + NAT ×1 per 2-region) |
+| 3 | **No leaked orphans** | query VPCs / ELBs / detached `pvc-*` EVS / EIPs for `catalyst-…-<prefix>-*` names whose dep prefix matches NO live (non-wiped) deployment record | zero orphans (the wipe API's `tofuDestroyed` flag LIES — verify by direct API, see #4454 / a20803b8) |
+| 4 | **Janitor is protect-by-default** | mothership `kubectl get deploy -n catalyst catalyst-api -o jsonpath='{...image}'` | image ≥ `fcb305f` (#4457 inversion) — confirm a `[JANITOR] … skipped (active deployment)` log on the new dep, NOT a reap (#4454) |
+| 5 | **Chart delivers the fixes** | `git show origin/main:products/catalyst/chart/values.yaml \| grep -A2 organization-controller` then check the pinned SHA's source for the expected fix markers | org-ctrl image SHA contains the merged fixes (e.g. `resolvePoolPowerDNSAPIKey`, `TenantNetworkingFinalizer`) — guards the #4465 deploy-bump clobber class |
+| 6 | **LE rate-limit headroom** | count distinct certs issued for the sovereign FQDN's registered domain in the last 7 days | < 50/week; else flip TLD `omantel.biz` ↔ `omani.works` (per L3 rotation) |
+
+**NO-GO on any red** → remediate (canonical wipe of orphans via `POST /deployments/{id}/wipe`, EIP cooldown wait, roll the mothership, TLD flip) before firing.
+
+## Wipe-confirmation evidence — 2026-06-26 (pre-re-prov, dep `b9f9590b558262b6` wiped)
+Verified by direct Huawei AK/SK SigV3 query (NOT the lying wipe flag), both AZs me-east-215 a+b. After wiping the reaped dep + force-deleting 283 stranded detached `pvc-*` EVS volumes, the project held **only the bastion**:
+
+| Resource | Count | Remaining |
+|---|---|---|
+| VPC | 1 | `bastion-openova-vpc` only |
+| EIP/publicips | 1 | bastion `212.72.24.20` only (4 freed: `.14`/`.39`/`.30`/`.31`, in TTL cooldown) |
+| ECS | 1 | `bastion-openova` only |
+| EVS volumes | 2 | both bastion-attached |
+| ELB loadbalancers | 0 | empty |
+| NAT gateways | 0 | empty |
+| VPC peerings | 0 | empty |
+
+⇒ Checks 1-3 GREEN → the re-prov (`91dc05917e44d1c1`) fired with full VPC/EIP headroom.
+
+## References
+- Janitor self-reap P0: #4454 (fix #4457 protect-by-default inversion)
+- Janitor hardening (log-only + active-dep allowlist + EVS-orphan sweep + cred-source): #4466
+- Deploy-bump clobber (stale chart pins): #4465 (#4464)
+- Post-mortem: `docs/sessions/2026-06-26/postmortem-janitor-self-reap.md`

--- a/docs/sessions/2026-06-26/postmortem-janitor-self-reap.md
+++ b/docs/sessions/2026-06-26/postmortem-janitor-self-reap.md
@@ -1,0 +1,52 @@
+# Post-mortem — orphan-sweep janitor self-reaped every fresh Sovereign (2026-06-26)
+
+**Severity:** P0 — every fresh kom4dc Sovereign self-destructed ~2.5 min after convergence; ~5 hours lost; 0 UAT walkthroughs in that window.
+**Owner:** platform (self-inflicted regression introduced earlier the same session).
+**Status:** root-caused, fixed (#4457), durable deploy-pipeline fix (#4465), clean slate verified, re-prov in flight.
+
+## Impact
+- Fresh prov `b9f9590b558262b6` (omantel.biz) reached `status: ready` at 10:45:37Z, then went fully unreachable ~10:48 (console/api/region apiservers → HTTP 000).
+- Misdiagnosed initially (by sub-agents) as a kom4dc EIP-poison blip → wasted cycles chasing EIP rotation.
+- Net: a full fix-cycle (11 PRs) consumed ~5 hours; **zero** UAT rows walked.
+
+## Timeline (UTC)
+- 10:45:37 — dep `ready`, all pillars green, console/api/marketplace 200 + valid LE TLS.
+- 10:47:34–36 — catalyst-api logs `[JANITOR] sweep orphan keypair … deleted` → `sweep orphan VPC: deleted peering …`.
+- 10:48:03–04 — all 12 ECS nodes `DELETED` in a ~1-second window (Huawei-API by-ID probe); apiserver EIPs (bound to the control-plane ECS) released; ELBs `ACTIVE` but all backends `OFFLINE`.
+- ~11:00–14:00 — diagnosis (Huawei-API forensic pinned the janitor), fix train, perfect-wipe verification, deploy-pipeline clobber fix, re-prov staged.
+
+## Root cause
+`products/catalyst/bootstrap/api/internal/handler/janitor.go` — the three cloud-resource sweeps (EIPs/keypairs/VPCs) built their protected `activePrefixes` set from an **allowlist** of states `{pending, provisioning, tofu-applying, flux-bootstrapping, phase1-watching, wiping}` that **omitted `ready`**. The instant a deployment flipped to `ready`, its 8-char prefix dropped out of protection and its `catalyst-…-<prefix>-*` keypair/VPC-peering/VPC/EIPs were reaped as "orphans," cascading the node deletion. The VPC sweep was added by #4435 (the "max-5-VPC" mitigation) — turning a latent gap into node-killing.
+
+## Why it shipped (three contributing failures)
+1. **Highest-risk change, lowest-risk treatment.** A janitor that *deletes cloud infrastructure* was merged on green CI with no live gate. CI passes; runtime self-destructs. This directly violated an existing written lesson (live-convergence gate for stateful/lifecycle changes).
+2. **Fragile-by-construction.** An allowlist of "active" states will always miss one (`ready`/`adopted`/`cutover`). Deletion logic must be **protect-by-default** (denylist of genuinely-dead states), failing safe.
+3. **Plumbing perfectionism over the goal.** After the janitor fix rolled, ~2 more hours went to serializing 11 PRs through deploy-bot version races and image-pin clobbers, instead of re-proving immediately and walking incrementally.
+
+## VPC-quota guard chain — where each check should fire (and where it failed)
+The founder warned about the kom4dc max-5-VPC bottleneck. Note the prov did NOT fail on the quota — it converged. The failure was the cleanup automation built to manage the quota. The defense-in-depth, layer by layer:
+
+| # | Guard | Where | This incident |
+|---|---|---|---|
+| 1 | **Pre-flight VPC-quota count** before provisioning | `provisioner.go:1841` (#4435) — counts project VPCs, fails fast if over limit | FIRED correctly; the prov had headroom and started cleanly |
+| 2 | **Orphan-VPC sweep** reclaims leaked VPCs from prior wipes | `janitor.go` SweepOrphanVPCs (#4435) | **FAILED — root cause.** Allowlist of "active" states omitted `ready` → swept the LIVE dep's VPC/peering/EIPs → node cascade-delete |
+| 3 | **Protect-by-default** (never reap a non-wiped dep) | `buildActivePrefixes()` denylist (#4457) | NOW HOLDS — live-proven (`skipped (active deployment)` in logs on the re-prov) |
+| 4 | **Active-dep do-not-touch allowlist** (status-independent) | tracked #4466 | follow-up hardening (belt-and-suspenders on top of #4457) |
+| 5 | **Log-only / dry-run before any real delete** | tracked #4466 | follow-up — would have caught #2 before it deleted anything |
+| 6 | **Post-wipe orphan verification** via direct cloud API | a20803b8 (this session) | FIRED — confirmed zero orphans (283 stranded EVS force-deleted), project = 1 VPC (bastion) |
+
+The single point of failure was layer 2 using an enumerate-the-safe-states allowlist. Layer 3 (#4457) converts it to protect-by-default; layers 4-5 (#4466) add log-only + an explicit active-dep exclusion so an inference bug can never again reach a live env.
+
+## Fixes
+- **#4457 (janitor, fail-safe inversion):** single `buildActivePrefixes()` helper used by all three sweeps — `case "wiped"` → eligible, `default` → protected. Any non-wiped status (incl. `ready`/`failed`/`adopted`/`cutover`) is protected; future statuses fail safe. Verified in code + rolled live on the mothership (`fcb305f`).
+- **#4465 (deploy-bump clobber):** the `deploy-bump` action's whole-file-snapshot re-apply was reverting concurrent pin bumps (it had silently staled the org-controller image to a pre-fix commit). Replaced with per-line `git cherry-pick -X theirs`.
+- **Perfect wipe verified:** dead dep wiped; Huawei-API confirmed zero orphans (283 stranded EVS force-deleted); project now holds one VPC (bastion only). Clean slate.
+
+## Prevention (enforced going forward)
+1. **Never merge infra-deleting / lifecycle (wipe/sweep/reclaim/scale-0) automation on CI-green.** Required: protect-by-default design; **log-only/dry-run** for a full live cycle before it is ever allowed to delete; live-convergence gate before AND after merge.
+2. **Goal-first:** re-prov on the env-survival fix and walk **incrementally**; never land-everything-first.
+3. **The single live Sovereign is precious:** never run cleanup automation against its Huawei project without an explicit do-not-touch allowlist for the active deployment.
+
+## Follow-ups
+- Harden the janitor beyond the inversion: log-only-until-proven mode + an explicit active-deployment do-not-touch allowlist (tracked separately).
+- Janitor cred-source gap (can't sweep after a wipe deletes the tfvars) + a standalone detached-EVS-orphan sweep (283 stranded here) — quota-hygiene hardening.


### PR DESCRIPTION
The P0 RCA (VPC-cleanup janitor reaped the live env via an allowlist that omitted 'ready') with the 6-layer VPC-quota guard chain, plus the GO/NO-GO operator pre-flight checklist carrying the 2026-06-26 Huawei SigV3 clean-slate evidence (project = 1 VPC, bastion only). Refs #4454 #4466 #4465.