### PR TITLE
fix(catalyst-api): DR backbone self-fires for a converged primary when the declared standby is absent (Refs #3375 #4212)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/phase1_dr_integrity_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_dr_integrity_test.go
@@ -1,14 +1,22 @@
-// phase1_dr_integrity_test.go — #3375 DoD-7 wiring coverage. Proves the
-// DR-integrity gate in markPhase1Done downgrades an otherwise-ready
-// active-hot-standby deployment to `failed` (standby-region-absent) when
-// the standby region never came up — the hw150 lying-flag the issue
-// catalogues — and that the gate leaves single-region and genuinely
-// 2-region-healthy provs untouched.
+// phase1_dr_integrity_test.go — #3375 DoD-7 wiring coverage, updated for
+// the #4486 self-firing DR backbone (Refs #3375 #4212). Proves the
+// DR-integrity gate in markPhase1Done:
+//
+//   - when the PRIMARY region converged (OutcomeReady) but the declared
+//     standby is absent, keeps the deployment `ready`, FIRES the handover
+//     (so the post-handover spine producer chain runs for the degraded
+//     single-region primary), and records the standby absence as the
+//     non-fatal SecondaryDegraded + standby-region-absent Phase1Outcome —
+//     NOT a `failed` latch that would freeze the whole post-handover chain
+//     off forever (the original architectural fault #4486 fixes);
+//   - when the PRIMARY did NOT converge (a hard-failed component →
+//     finalStatus already `failed`), stays `failed` and fires NO handover
+//     (genuine-failure path preserved);
+//   - leaves single-region provs untouched (no standby to assert).
 
 package handler
 
 import (
-	"strings"
 	"testing"
 	"time"
 
@@ -16,11 +24,14 @@ import (
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
 )
 
-// active-hot-standby requested, 2 regions declared, but the Phase-1 watch
-// observed ONLY the primary (no secondary control-plane ever PUT its
-// kubeconfig). Even with OutcomeReady, the deployment must be `failed`
-// with the standby-region-absent reason — and NO handover token minted.
-func TestMarkPhase1Done_ActiveHotStandby_AbsentStandby_NotReady(t *testing.T) {
+// #4486 — active-hot-standby requested, 2 regions declared, primary
+// converged (OutcomeReady) but the Phase-1 watch observed ONLY the primary
+// (no secondary control-plane ever PUT its kubeconfig). The deployment must
+// stay `ready`, FIRE the handover (HandoverFiredAt set), and flag the
+// standby absence as SecondaryDegraded + standby-region-absent — so the
+// converged primary's post-handover spine producer chain runs instead of
+// being latched permanently inert.
+func TestMarkPhase1Done_ActiveHotStandby_AbsentStandby_PrimaryReady_FiresHandover(t *testing.T) {
 	h := NewWithPDM(silentLogger(), &fakePDM{})
 	h.SetHandoverSigner(loadTestSigner(t))
 
@@ -60,21 +71,85 @@ func TestMarkPhase1Done_ActiveHotStandby_AbsentStandby_NotReady(t *testing.T) {
 	dep.mu.Lock()
 	defer dep.mu.Unlock()
 
-	if dep.Status != "failed" {
-		t.Fatalf("Status = %q, want failed (active-hot-standby with absent standby region)", dep.Status)
+	// #4486: a converged primary stays ready (degraded single-region spine).
+	if dep.Status != "ready" {
+		t.Fatalf("Status = %q, want ready (converged primary must hand over even with an absent standby, #4486)", dep.Status)
 	}
-	if !strings.Contains(dep.Error, "standby") {
-		t.Errorf("Error must explain the absent standby region; got %q", dep.Error)
+	// The standby absence is recorded non-fatally.
+	if !dep.Result.SecondaryDegraded {
+		t.Errorf("SecondaryDegraded = false, want true (absent standby must surface as degraded)")
 	}
 	if dep.Result.Phase1Outcome != provisioner.ReasonStandbyRegionAbsent {
 		t.Errorf("Phase1Outcome = %q, want %q", dep.Result.Phase1Outcome, provisioner.ReasonStandbyRegionAbsent)
 	}
-	// No handover token on a failed DR-integrity outcome.
+	// Must NOT latch a hard Error onto a ready deployment (the wizard's
+	// FailureCard would render it as a failure).
+	if dep.Error != "" {
+		t.Errorf("Error unexpectedly set on a ready (degraded) deployment: %q", dep.Error)
+	}
+	// The whole point of #4486: the handover MUST fire so the post-handover
+	// producer chain (spine apps, adoption, policy-flip) is reachable.
+	if dep.Result.HandoverFiredAt == nil {
+		t.Errorf("HandoverFiredAt was NOT set — the post-handover chain is latched inert (the #4486 fault)")
+	}
+	if dep.Result.HandoverURL == "" {
+		t.Errorf("HandoverURL was NOT set on the degraded-but-ready primary")
+	}
+}
+
+// #4486 genuine-failure path: active-hot-standby requested, standby absent,
+// AND the primary itself hard-FAILED a component (so finalStatus is already
+// `failed` before the DR gate). The deployment must stay `failed` and fire
+// NO handover — nothing converged to hand over. Guards against the self-fire
+// fix over-reaching into the real-failure case.
+func TestMarkPhase1Done_ActiveHotStandby_AbsentStandby_PrimaryFailed_StaysFailed(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.SetHandoverSigner(loadTestSigner(t))
+
+	dep := &Deployment{
+		ID:        "phase1-ahs-primary-failed",
+		Status:    "phase1-watching",
+		StartedAt: time.Now(),
+		eventsCh:  make(chan provisioner.Event, 256),
+		done:      make(chan struct{}),
+		Request: provisioner.Request{
+			SovereignFQDN: "otech-ahs-fail.example.com",
+			OrgEmail:      "operator@ahs.example.com",
+			BcpTopology:   provisioner.BcpTopologyActiveHotStandby,
+			Regions: []provisioner.RegionSpec{
+				{Provider: "huawei", CloudRegion: "me-east-215-a"},
+				{Provider: "huawei", CloudRegion: "me-east-215-b"},
+			},
+		},
+		Result: &provisioner.Result{
+			SovereignFQDN: "otech-ahs-fail.example.com",
+		},
+		OwnerEmail: "operator@ahs.example.com",
+	}
+	h.deployments.Store(dep.ID, dep)
+
+	// A hard-FAILED primary component → markPhase1Done's `failed > 0` branch
+	// stamps Status=failed BEFORE the DR gate. The DR gate (which only
+	// re-evaluates a `ready` dep) never runs; the deployment is a genuine
+	// failure, not a degraded-but-functional spine.
+	finalStates := map[string]string{
+		"cilium":            helmwatch.StateInstalled,
+		"catalyst-platform": helmwatch.StateFailed,
+	}
+	h.markPhase1Done(dep, finalStates, helmwatch.OutcomeReady)
+
+	dep.mu.Lock()
+	defer dep.mu.Unlock()
+
+	if dep.Status != "failed" {
+		t.Fatalf("Status = %q, want failed (a hard-failed primary is a genuine failure)", dep.Status)
+	}
+	// No handover on a genuine failure — nothing converged.
 	if dep.Result.HandoverFiredAt != nil {
-		t.Errorf("HandoverFiredAt unexpectedly set on standby-absent failure")
+		t.Errorf("HandoverFiredAt unexpectedly set on a genuinely failed primary")
 	}
 	if dep.Result.HandoverURL != "" {
-		t.Errorf("HandoverURL unexpectedly set on standby-absent failure: %q", dep.Result.HandoverURL)
+		t.Errorf("HandoverURL unexpectedly set on a genuinely failed primary: %q", dep.Result.HandoverURL)
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -731,20 +731,44 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 		dep.Error = fmt.Sprintf("Phase 1 watch terminated with unhandled outcome %q — catalyst-api is missing a status mapping for it. The deployment is NOT marked ready; please file an issue with the deployment ID and the catalyst-api logs from this run.", outcome)
 	}
 
-	// #3375 DoD-7 — DR INTEGRITY GATE. An otherwise-ready deployment that
-	// REQUESTED active-hot-standby (or active-active) but whose standby
-	// region never came up must NOT claim the topology. The honest
-	// outcome is `failed` with the canonical standby-region-absent reason
-	// — the DR sibling of the "did not PUT kubeconfig" primary failure.
+	// #3375 DoD-7 — DR INTEGRITY GATE, made SELF-FIRING for a converged
+	// primary (#4486, Refs #3375 #4212). A deployment that REQUESTED
+	// active-hot-standby (or active-active) but whose standby region never
+	// came up cannot HONESTLY claim the topology — but the corrective
+	// action depends entirely on whether the PRIMARY converged:
 	//
-	// This re-evaluates ONLY an already-ready deployment (it never
-	// upgrades a failed one) and keys on the OBSERVED secondary-region
-	// count (non-primary entries in the #3611 census). A SLOW-but-present
-	// secondary HAS an observed watcher → it is counted → it does NOT
-	// trip this gate (the surface-not-gate design for slow secondaries is
-	// preserved). Only a GENUINELY-ABSENT region (no cluster, no
-	// kubeconfig, zero observed secondary — the hw150 shape) trips it.
-	// Generic: keys on Request.BcpTopology + region counts, no app name.
+	//   (a) Primary NOT ready (outcome != OutcomeReady — kubeconfig-missing,
+	//       flux-not-reconciling, a hard-FAILED component, timeout): this is
+	//       a GENUINE failure. Keep `failed` + the standby-region-absent
+	//       reason. Nothing converged; there is nothing to hand over.
+	//
+	//   (b) Primary IS ready (outcome == OutcomeReady) but the standby is
+	//       absent: the primary region is a DEGRADED-BUT-FUNCTIONAL
+	//       single-region spine. Latching this to `failed` was an
+	//       ARCHITECTURAL FAULT — `finalStatus=="failed"` makes the
+	//       OutcomeReady terminal block below skip `fireHandover`, so
+	//       `HandoverFiredAt` stays nil and the ENTIRE post-handover
+	//       producer chain (spine Applications, adoption-apply, policy-flip,
+	//       ClusterMesh) is permanently inert, with NO level-triggered heal
+	//       (`runConvergedLateRescue` + `shouldStartupSpineReconcile` both
+	//       gate on `HandoverFiredAt != nil`). A single-region-up
+	//       multi-region prov could never enroll even its degraded spine.
+	//       The honest, self-healing outcome is to STAY `ready`, fire the
+	//       handover for the converged primary, run the spine producer, and
+	//       record the standby absence as a NON-FATAL `SecondaryDegraded`
+	//       condition (the same surface-not-gate idiom #3611 uses for a
+	//       slow-but-present secondary) plus the `standby-region-absent`
+	//       Phase1Outcome so the operator console + logs stay honest.
+	//
+	// This re-evaluates ONLY an already-ready deployment (it never upgrades
+	// a failed one) and keys on the OBSERVED secondary-region count
+	// (non-primary entries in the #3611 census). A SLOW-but-present
+	// secondary HAS an observed watcher → it is counted → it does NOT trip
+	// this gate at all (its slowness rides the #3611 SecondaryDegraded
+	// surface independently). Only a GENUINELY-ABSENT region (no cluster, no
+	// kubeconfig, zero observed secondary — the hw150 shape) reaches the
+	// branch here. Generic: keys on Request.BcpTopology + region counts, no
+	// app name.
 	if dep.Status == "ready" {
 		observedSecondary := 0
 		for _, rh := range dep.Result.Regions {
@@ -755,9 +779,28 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 		if ok, reason := provisioner.DeclaredDRStandbyIntegrity(
 			dep.Request.BcpTopology, len(dep.Request.Regions), observedSecondary,
 		); !ok {
-			dep.Status = "failed"
-			dep.Error = reason
+			// The primary converged (dep.Status=="ready" is only reached on
+			// outcome==OutcomeReady; the storage/kubeconfig/timeout/failed
+			// branches above all set "failed"). So this is case (b): keep
+			// the converged primary HANDED-OVER as a degraded single-region
+			// spine instead of latching the whole chain off.
+			//
+			// NB: do NOT set dep.Error here — the deployment is `ready`, and
+			// /deployments/{id} surfaces a non-empty Error as a top-level
+			// `error` field that the wizard's FailureCard renders as a hard
+			// failure. The standby absence rides the honest, non-fatal
+			// channels instead: SecondaryDegraded (the #3611 surface-not-gate
+			// badge), the standby-region-absent Phase1Outcome, and the loud
+			// warn below. `reason` is logged, not stamped as a failure.
+			dep.Result.SecondaryDegraded = true
 			dep.Result.Phase1Outcome = provisioner.ReasonStandbyRegionAbsent
+			h.log.Warn("phase 1 ready on the PRIMARY but the declared DR STANDBY region is ABSENT — handing over the converged primary as a DEGRADED single-region spine (NOT latching failed); DR is INACTIVE until the standby provisions (#4486, Refs #3375)",
+				"id", dep.ID,
+				"bcpTopology", dep.Request.BcpTopology,
+				"declaredRegions", len(dep.Request.Regions),
+				"observedSecondary", observedSecondary,
+				"reason", reason,
+			)
 		}
 	}
 


### PR DESCRIPTION
## Fault

On a multi-region active-hot-standby prov whose standby region's census is empty at Phase-1 watch-termination, the **#3375 DR-integrity gate** downgraded the dep `ready→failed` (`ReasonStandbyRegionAbsent`). Because `finalStatus=="failed"`, the `OutcomeReady` terminal block in `markPhase1Done` (`products/catalyst/bootstrap/api/internal/handler/phase1_watch.go`) skipped `fireHandover` → `HandoverFiredAt` stayed nil → the **ENTIRE post-handover producer chain** (spine Applications, adoption-apply, policy-flip, ClusterMesh) was permanently inert.

No level-triggered heal exists: every heal path (`runConvergedLateRescue`, `shouldStartupSpineReconcile`) itself requires `HandoverFiredAt != nil`. So a single-region-up multi-region prov could never enroll even its degraded spine.

## Fix

Split the DR-integrity gate by whether the **PRIMARY** converged:

- **Primary not ready** (`outcome != OutcomeReady` — kubeconfig-missing, flux-not-reconciling, a hard-FAILED component, timeout): genuine failure. Stays `failed` (nothing converged to hand over). The `failed > 0` and outcome branches in `markPhase1Done` set `failed` *before* the DR gate, so the gate (which only re-evaluates a `ready` dep) never runs.
- **Primary ready but standby absent**: the primary is a degraded-but-functional single-region spine. Now **stays `ready`**, fires the handover so the post-handover spine producer chain runs, and records the standby absence as the non-fatal `SecondaryDegraded` (#3611 surface-not-gate idiom) + `standby-region-absent` `Phase1Outcome`. No hard `Error` is stamped on the `ready` deployment (the wizard's `FailureCard` renders a non-empty `error` field as a failure).

## Tests

- `TestMarkPhase1Done_ActiveHotStandby_AbsentStandby_PrimaryReady_FiresHandover`: converged primary + absent standby → `ready` + `HandoverFiredAt` set + `HandoverURL` set + `SecondaryDegraded=true` + `Phase1Outcome=standby-region-absent` + no `Error`.
- `TestMarkPhase1Done_ActiveHotStandby_AbsentStandby_PrimaryFailed_StaysFailed`: hard-failed primary → stays `failed`, no handover (genuine-failure path preserved).
- Existing single-region, storage-gate, timeout, and handover-idempotency guards unchanged and green.

`go build ./...` + `go vet` clean; handler + provisioner suites green.

## Verification note

Live verification is blocked by the mothership outage — shipping the durable merge; verify on the next 2-region prov (primary-up / standby-absent → handover fires + degraded spine enrolls).

Refs #3375 #4212 #4486

🤖 Generated with [Claude Code](https://claude.com/claude-code)