### PR TITLE
fix(bp-plane-isolation): annotate smoke-render-mode=default-off so the OCI publish stops wedging (0.1.9)

### DIFF
--- a/clusters/_template/bootstrap-kit/26b-bp-plane-isolation.yaml
+++ b/clusters/_template/bootstrap-kit/26b-bp-plane-isolation.yaml
@@ -117,7 +117,11 @@ spec:
       #   circular deadlock 0.1.7 was meant to break. Live-caught on fresh re-prov
       #   91dc05917e44d1c1 (kom4dc, 2026-06-26): published 0.1.7 HR install STILL FAILED.
       #   All three per-component templates now carry the identical lookup-guard.
-      version: 0.1.8
+      # 0.1.9 (#4468): annotate smoke-render-mode=default-off so the blueprint-release
+      #   OCI publish stops wedging — the all-template lookup-guard renders ZERO
+      #   resources client-side by design (the gate's short-render trip). Annotation-
+      #   only; no policy/behaviour change vs 0.1.8.
+      version: 0.1.9
       sourceRef:
         kind: HelmRepository
         name: bp-plane-isolation

--- a/platform/plane-isolation/blueprint.yaml
+++ b/platform/plane-isolation/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 0.1.8  # lockstep with chart/Chart.yaml (#4468 — extend the #4445 defer-if-absent guard to apiserver-egress + gateway-ingress CNPs)
+  version: 0.1.9  # lockstep with chart/Chart.yaml (#4468 — smoke-render-mode=default-off so the OCI publish stops wedging on the empty client-side render)
   card:
     title: Plane isolation (per-component default-deny)
     summary: |

--- a/platform/plane-isolation/chart/Chart.yaml
+++ b/platform/plane-isolation/chart/Chart.yaml
@@ -134,7 +134,15 @@ name: bp-plane-isolation
 #   despite the changelog claiming the deadlock fixed. All three per-component
 #   templates now carry the identical lookup-guard so a deferred namespace lands on
 #   the next helm-controller reconcile once its consumer chart creates it.
-version: 0.1.8
+# 0.1.9 (#4468): annotate `catalyst.openova.io/smoke-render-mode: "default-off"` so
+#   the blueprint-release smoke-render gate stops wedging the OCI publish. With the
+#   0.1.8 lookup-guard on all three templates, a client-side default render (no live
+#   namespaces) emits ZERO resources by design → the gate's "suspiciously short
+#   render" check failed → helm push never ran → 0.1.7 + 0.1.8 had to be hand-
+#   published. The annotation tells the gate the short render is expected (full
+#   dial-graph covered by tests/e2e/bootstrap-kit renderUnconditional contract).
+#   No template/behaviour change — annotation + lockstep bump only.
+version: 0.1.9
 description: |
   Per-component default-deny + explicit-allow micro-segmentation for the
   de-vclustered platform planes (#4291 Workstream C). For each platform
@@ -157,5 +165,20 @@ maintainers:
 #   Catalyst-authored CRs (NetworkPolicy + CiliumNetworkPolicy targeting
 #   the cilium.io CRDs installed by bp-cilium). No upstream Helm subchart.
 #   Same shape as bp-network-policies / bp-kyverno-policies / bp-continuum.
+#
+# - catalyst.openova.io/smoke-render-mode: "default-off"
+#   The blueprint-release smoke-render gate runs `helm template` with DEFAULT
+#   values (client-side, no `cilium.io/v2` API, `lookup` always empty). Under
+#   that path EVERY per-component template now defers — the default-deny
+#   NetworkPolicy + apiserver-egress + gateway-ingress CNPs all carry the
+#   #4445/#4468 namespace-present lookup-guard, so a client-side render with no
+#   live namespaces emits ZERO resources by design. That tripped the gate's
+#   "suspiciously short render" check on every version bump (the reason 0.1.7
+#   and 0.1.8 had to be hand-published). Marking smoke-render-mode=default-off
+#   tells the gate the short default render is expected; the full dial-graph is
+#   covered by the tests/e2e/bootstrap-kit contract render
+#   (`--set renderUnconditional=true --api-versions cilium.io/v2`). Same shape
+#   as bp-cilium-policies / bp-network-policies / bp-sandbox.
 annotations:
   catalyst.openova.io/no-upstream: "true"
+  catalyst.openova.io/smoke-render-mode: "default-off"


### PR DESCRIPTION
## Fault

The 0.1.8 lookup-guard (PR #4470) now sits on all three per-component templates (default-deny NetworkPolicy + apiserver-egress CNP + gateway-ingress CNP). On the client-side default `helm template` the blueprint-release smoke-render gate runs (no live namespaces, no `cilium.io/v2` API), `lookup` returns empty, so EVERY component defers and the chart renders ZERO resources by design.

That trips the gate's "suspiciously short render (<5 lines)" check, so the `helm push` step never runs — which is exactly why `bp-plane-isolation:0.1.7` and `0.1.8` had to be hand-published to ghcr. Live evidence: blueprint-release run 28254780548 (the #4470 merge) failed at "Helm template smoke render (default values)" → 0.1.8 never reached ghcr.

## Fix (0.1.9)

Add `catalyst.openova.io/smoke-render-mode: "default-off"` to `platform/plane-isolation/chart/Chart.yaml`. The gate then treats the short default render as expected — the full 47-policy dial-graph is covered by the `tests/e2e/bootstrap-kit` contract render (`--set renderUnconditional=true --api-versions cilium.io/v2`). Same shape as bp-cilium-policies / bp-network-policies / bp-sandbox, which already carry it.

Annotation-only — no template or policy behaviour change vs 0.1.8.

Lockstep: chart `0.1.8 -> 0.1.9` + `blueprint.yaml` 0.1.9 + slot-26b pin 0.1.9.

### Verified
- reproduced the exact gate logic locally: 1-line default render + `default-off` annotation -> GATE PASS (publish unblocked)
- GUARD 1 (`no-upstream:true`) + GUARD 2 (`smoke-render-mode:default-off`) both satisfied
- pin-sync-audit green; helm lint clean; `tests/e2e/bootstrap-kit` all green

Refs #4468

🤖 Generated with [Claude Code](https://claude.com/claude-code)