### PR TITLE
fix(crossplane): route provider-opentofu xpkg pull off the poisoned-EIP path on Huawei — light the #4002/#4018 adoption seam at runtime

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -587,7 +587,12 @@ spec:
       # carve-out emits per-plane-ns allow-ingress NetworkPolicies (gitea/harbor/
       # openbao) instead of one dead `catalyst -> mgmt` policy — unwedges step-01/
       # 02/03/09 on a de-vclustered Sovereign whose planes are host namespaces.
-      version: 0.1.80
+      # 0.1.81 (#4488): step-11 crossplane-provider-pivot also pivots a Provider
+      # already on the mothership proxy-xpkg prefix (harbor.openova.io/proxy-xpkg)
+      # → harbor.<fqdn>/proxy-xpkg, so the Huawei fresh-prov provider-opentofu
+      # package (routed off the poisoned xpkg.upbound.io NAT) leaves no
+      # harbor.openova.io tether at cutover (Principle #11).
+      version: 0.1.81
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/infrastructure/base/provider-opentofu.yaml
+++ b/clusters/_template/infrastructure/base/provider-opentofu.yaml
@@ -27,7 +27,29 @@ spec:
   # unlike provider-terraform which is frozen at Terraform 1.5.7 / BSL).
   # Catalyst is an OpenTofu shop (required_version >= 1.6.0) so this is
   # the native fit. Pinned digest-pinnable tag.
-  package: xpkg.upbound.io/upbound/provider-opentofu:v1.1.3
+  #
+  # #4488 — the registry HOST is a Flux postBuild substitution var
+  # (set by the infrastructure-config Kustomization in cloud-init,
+  # cloud-conditional):
+  #   - Hetzner → `xpkg.upbound.io` (the upstream default — Hetzner's NAT
+  #     to xpkg is clean, the package pulls direct).
+  #   - Huawei  → `harbor.openova.io/proxy-xpkg` (the upstream pull-through
+  #     project on the mothership Harbor). On kom4dc the Crossplane xpkg
+  #     fetcher uses go-containerregistry DIRECTLY (it does NOT honour the
+  #     node containerd registries.yaml mirror — verified against the
+  #     crossplane v1.18 K8sFetcher), so the `xpkg.upbound.io` route in
+  #     registry_mirror_yaml_huawei is INERT for provider packages and the
+  #     fetcher would otherwise dial xpkg.upbound.io over the reputation-
+  #     blocklisted ("poisoned") kom4dc NAT EIP and stall → provider-
+  #     opentofu never reaches INSTALLED=True → no workspaces.tf.upbound.io
+  #     CRD → every CloudAdoption composite Ready=False (the #4002/#4018
+  #     adoption seam stays inert at runtime). proxy-xpkg is TLS-valid and
+  #     reachable over NAT; this install is `wait:false` / OFF the Phase-1
+  #     critical path, so its day-2 slowness is tolerable. Same host shape
+  #     the self-sovereign-cutover step-11 (#2034) pivots to post-handover
+  #     (harbor.<SOVEREIGN_FQDN>/proxy-xpkg/...). The `:=` default keeps a
+  #     raw `kustomize build` (CI / no-substitution) on the upstream coords.
+  package: ${XPKG_REGISTRY:=xpkg.upbound.io}/upbound/provider-opentofu:v1.1.3
   # Inherit the cluster's image-pull behaviour from the runtime config
   # below (so post-cutover the Sovereign's own Harbor can proxy it).
   runtimeConfigRef:

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -956,6 +956,16 @@ write_files:
             SOVEREIGN_FQDN_DASHED: ${sovereign_fqdn_slug}
             SOVEREIGN_LB_IP: ${load_balancer_ipv4}
             MARKETPLACE_ENABLED: "${marketplace_enabled}"
+            # #4488 — provider-opentofu package-pull host, cloud-conditional.
+            # The Crossplane xpkg fetcher (go-containerregistry, K8sFetcher)
+            # bypasses the node containerd registries.yaml mirror, so on
+            # Huawei (kom4dc) a raw `xpkg.upbound.io` package dials the
+            # poisoned NAT EIP and stalls → the adoption seam stays inert.
+            # Route Huawei through the mothership Harbor's TLS-valid
+            # proxy-xpkg pull-through (off the wait:false critical path);
+            # Hetzner keeps the direct upstream (clean NAT). See
+            # base/provider-opentofu.yaml for the full rationale.
+            XPKG_REGISTRY: "%{ if provider == "huawei" }harbor.openova.io/proxy-xpkg%{ else }xpkg.upbound.io%{ endif ~}"
 
 runcmd:
   - swapoff -a

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.80
+  version: 0.1.81
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1004,7 +1004,19 @@ name: bp-self-sovereign-cutover
 # plane HRs/slots no-op without tripping the residual-tether FATAL. Chart-only +
 # additive; render byte-identical on a pre-#4325 Sovereign that sets mgmtNamespace.
 # Lockstep: 06a pin + blueprint.yaml bumped in step.
-version: 0.1.80
+# 0.1.81 (#4488): step-11 crossplane-provider-pivot now ALSO pivots a Provider
+# whose spec.package is already on the mothership proxy-xpkg prefix
+# (`harbor.openova.io/proxy-xpkg/...`) → `harbor.<sov-fqdn>/proxy-xpkg/...`.
+# A Huawei fresh prov ships provider-opentofu pointed at the mothership Harbor's
+# proxy-xpkg (the Crossplane xpkg fetcher bypasses the node containerd mirror and
+# `xpkg.upbound.io` dials the poisoned kom4dc NAT EIP — see
+# clusters/_template/infrastructure/base/provider-opentofu.yaml), so without this
+# the harbor.openova.io host literal would survive the cutover (Principle #11
+# violation). New value crossplaneProviderPivot.mothershipProxyPrefix +
+# MOTHERSHIP_PROXY_PREFIX env; Hetzner ships the upstream host so the new prefix
+# simply never matches there (render-additive, behaviour-identical on Hetzner).
+# Lockstep: 06a pin bumped in step.
+version: 0.1.81
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/11-crossplane-provider-pivot-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/11-crossplane-provider-pivot-job.yaml
@@ -133,6 +133,12 @@ data:
             value: {{ .Values.crossplaneProviderPivot.upstreamHost | quote }}
           - name: REGISTRY_PATH
             value: {{ .Values.crossplaneProviderPivot.registryPath | quote }}
+          # #4488 — the mothership proxy-xpkg prefix a Huawei fresh prov
+          # already carries in provider-opentofu's spec.package. Pivoted to
+          # harbor.<fqdn>/proxy-xpkg too so no harbor.openova.io tether
+          # survives the cutover (Principle #11).
+          - name: MOTHERSHIP_PROXY_PREFIX
+            value: {{ .Values.crossplaneProviderPivot.mothershipProxyPrefix | quote }}
         volumeMounts:
           - name: tmp
             mountPath: /tmp
@@ -192,10 +198,23 @@ data:
                 printf '%s\n' "${providers_tsv}" | while IFS="$(printf '\t')" read -r name pkg; do
                   if [ -z "${name}" ]; then continue; fi
 
+                  # #4488 — match EITHER the raw upstream host
+                  # (xpkg.upbound.io/..., Hetzner) OR the mothership
+                  # proxy-xpkg prefix (harbor.openova.io/proxy-xpkg/...,
+                  # the Huawei fresh-prov shape). Both rewrite to the
+                  # Sovereign-local target_prefix, preserving the path+tag
+                  # after the matched prefix.
+                  matched_prefix=""
                   case "${pkg}" in
-                    "${upstream_prefix}/"*)
-                      # Compute new spec.package by replacing host prefix.
-                      pkg_suffix="${pkg#${upstream_prefix}/}"
+                    "${upstream_prefix}/"*)              matched_prefix="${upstream_prefix}" ;;
+                    "${MOTHERSHIP_PROXY_PREFIX}/"*)      matched_prefix="${MOTHERSHIP_PROXY_PREFIX}" ;;
+                  esac
+
+                  case "${pkg}" in
+                    "${upstream_prefix}/"* | "${MOTHERSHIP_PROXY_PREFIX}/"*)
+                      # Compute new spec.package by replacing the matched
+                      # host(+path) prefix with the Sovereign-local one.
+                      pkg_suffix="${pkg#${matched_prefix}/}"
                       new_pkg="${target_prefix}/${pkg_suffix}"
                       echo "[crossplane-provider-pivot] PATCH ${name} ${pkg} -> ${new_pkg}"
                       # Merge-patch only spec.package — preserves every
@@ -213,7 +232,7 @@ data:
                       echo "[crossplane-provider-pivot] SKIP ${name} (already pivoted: ${pkg})"
                       ;;
                     *)
-                      echo "[crossplane-provider-pivot] SKIP ${name} (package host not ${upstream_prefix} or ${target_host}: ${pkg})"
+                      echo "[crossplane-provider-pivot] SKIP ${name} (package prefix not ${upstream_prefix}, ${MOTHERSHIP_PROXY_PREFIX}, or ${target_prefix}: ${pkg})"
                       ;;
                   esac
                 done

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -885,6 +885,19 @@ crossplaneProviderPivot:
   # diverge from that project name unless the proxyProjects list is
   # updated in lockstep.
   registryPath: "proxy-xpkg"
+  # #4488 — the SECOND upstream prefix to pivot. On Huawei a fresh prov
+  # ships provider-opentofu's `spec.package` already pointed at the
+  # MOTHERSHIP Harbor's proxy-xpkg (`harbor.openova.io/proxy-xpkg/...`),
+  # because the Crossplane xpkg fetcher bypasses the node containerd
+  # mirror and `xpkg.upbound.io` dials the poisoned kom4dc NAT EIP (see
+  # clusters/_template/infrastructure/base/provider-opentofu.yaml +
+  # infra/providers/_shared/cloudinit-control-plane.tftpl XPKG_REGISTRY).
+  # That `harbor.openova.io` host is a mothership tether Principle #11
+  # forbids post-cutover, so the live-patch ALSO rewrites this prefix to
+  # `harbor.<sov-fqdn>/${registryPath}`. Must equal mothershipHarborURL's
+  # host + "/" + registryPath. Hetzner Sovereigns ship the upstream host
+  # so this prefix simply never matches there (harmless).
+  mothershipProxyPrefix: "harbor.openova.io/proxy-xpkg"
 
 # Step 09 (gitea-token-mint, TBD-C18) — bootstrap the Gitea API token
 # that the Organization provisioning service uses for tenant repo materialisation.


### PR DESCRIPTION
## Problem
On a Huawei (kom4dc) fresh prov the OpenTofu→Crossplane adoption seam (#4002 / #4018 / #4263) is **inert at runtime**: 24 `CloudAdoption` CRs apply `ADOPTED=True`/`SYNCED=True` but every claim is `READY=False` with `no matches for kind "Workspace" in version "tf.upbound.io/v1beta1"`. `provider-opentofu` never reaches `INSTALLED=True`, so `workspaces.tf.upbound.io` never registers and the composites can't observe the OpenTofu infra.

## Root cause (verified)
#4263 correctly **delivers** the `Provider/provider-opentofu` CR for all clouds (un-gated `infrastructure-config` Kustomization). Delivery, OOM (4Gi, #4430), and the Kyverno crossplane-system exemption (#4349) are all already merged. The remaining gap is the **package PULL on Huawei**:

- Crossplane's xpkg fetcher (`go-containerregistry` `K8sFetcher`) pulls provider packages **directly**, **bypassing** the node containerd `registries.yaml` mirror (verified against crossplane v1.18). So the `xpkg.upbound.io` mirror entry in `registry_mirror_yaml_huawei` is **inert** for provider packages.
- The fetcher dials `xpkg.upbound.io` over the reputation-blocklisted ("poisoned") kom4dc NAT EIP — the exact #4049 fresh-prov wedge — and stalls.
- `xpkg.upbound.io` was the *only* registry left on the external route, precisely because Crossplane "was idle on kom4dc" (`infra/providers/huawei/main.tf:660-666`). #4263 made it non-idle.

## Fix
Template `provider-opentofu`'s `spec.package` host as a Flux postBuild substitution var (`XPKG_REGISTRY`), set cloud-conditionally by the `infrastructure-config` Kustomization in cloud-init:
- **Hetzner** → `xpkg.upbound.io` (direct upstream; Hetzner NAT is clean)
- **Huawei** → `harbor.openova.io/proxy-xpkg` (the mothership Harbor's TLS-valid pull-through; reachable over NAT, off the `wait:false` Phase-1 critical path)

The `${XPKG_REGISTRY:=xpkg.upbound.io}` default keeps a raw `kustomize build` (CI) on the upstream coords.

### Self-sovereign-cutover lockstep (Principle #11)
Because the Huawei live package now carries `harbor.openova.io/proxy-xpkg/...`, step-11 `crossplane-provider-pivot` is extended to ALSO pivot that mothership-proxy prefix → `harbor.<sov-fqdn>/proxy-xpkg/...`, so no `harbor.openova.io` tether survives the cutover. New value `crossplaneProviderPivot.mothershipProxyPrefix` + `MOTHERSHIP_PROXY_PREFIX` env; Hetzner never matches it (render-additive, behaviour-identical on Hetzner). Cutover chart `0.1.80 → 0.1.81` with slot-06a pin + `blueprint.yaml` lockstep.

## Guards (all green locally)
`cloudinit-size` (Huawei 81.7% of cap), `lint-cloudinit`, `check-cloudinit-kustomization-deps`, `check-tofu-flux-envsubst`, `check-bootstrap-kit-pin-sync`, `kustomize build` (both clouds), `helm lint`, `cutover-contract` (Case 22), handler + provisioner Go tests. Real `tofu templatefile()` render confirmed Huawei → `XPKG_REGISTRY: "harbor.openova.io/proxy-xpkg"`.

## Verification
Live verification (CloudAdoptions reach `Ready` on a fresh Huawei prov) is blocked by the current mothership/omantel outage. Ships the durable merge; on the next reachable prov verify: `kubectl get providers.pkg.crossplane.io` → `provider-opentofu INSTALLED=True`, `kubectl get crd workspaces.tf.upbound.io` exists, `kubectl get cloudadoption -A` all `READY=True`.

### Known follow-up (tracked, not in this PR)
On a *cutover* Huawei Sovereign the live Provider patch (step-11) is reconciled back from Gitea, where `provider-opentofu.yaml` carries the templated `${XPKG_REGISTRY}` — so the post-cutover host is determined by the `infrastructure-config` Kustomization's `XPKG_REGISTRY` substitute (still `harbor.openova.io/proxy-xpkg`). Severing that final post-cutover substitute residual is a follow-up to the Pillar-5 cutover walk, not the fresh-prov runtime-Observe break this PR closes.

Refs #4488 #4002 #4018 #4212

🤖 Generated with [Claude Code](https://claude.com/claude-code)