### PR TITLE
fix(catalyst): seed newapi admin-token into OpenBao so catalyst-newapi-admin-token ExternalSecret resolves on fresh prov

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1188,7 +1188,10 @@ spec:
       #   sandbox-controller can read CATALYST_GITEA_TOKEN (was CrashLoopBackOff
       #   on every Sovereign → 0 Sandboxes → no openova-sandbox-mcp). Lockstep
       #   w/ Chart.yaml + templates/catalyst-gitea-token-secret.yaml.
-      version: 1.4.905
+      # 1.4.906 — #4477 secondary: doc-only — CATALYST_NEWAPI_ADMIN_TOKEN env
+      #   comment cites the canonical `catalyst/newapi/admin-token` OpenBao path
+      #   (written by catalyst-api's seedNewapiAdminToken seam).
+      version: 1.4.906
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -301,7 +301,11 @@ spec:
       # 1.4.134 — #4477: admin-promote CronJob self-heals a stale OIDC provider
       #   client_secret (resync_provider_secret) so a KC client-secret rotation
       #   no longer wedges newapi token-exchange ("Failed to get token").
-      version: 1.4.135
+      # 1.4.136 — #4477 secondary: catalyst-newapi-admin-token ExternalSecret
+      #   remoteRef.key → catalyst/newapi/admin-token (the path catalyst-api's
+      #   seedNewapiAdminToken seam writes); fixes the SecretSyncedError that
+      #   left unified-rbac's admin-API calls 401'd on a fresh prov.
+      version: 1.4.136
       sourceRef:
         kind: HelmRepository
         name: bp-newapi
@@ -330,7 +334,9 @@ spec:
   #   - credentials.existingSecret   = SESSION_SECRET + CRYPTO_SECRET
   #                                    (rotated via OpenBao)
   #   - catalystIntegration.externalSecret.remoteRef.key
-  #                                  = sovereign/${SOVEREIGN_FQDN}/newapi/admin-token
+  #                                  = catalyst/newapi/admin-token
+  #     (cluster-shared; written by catalyst-api's seedNewapiAdminToken
+  #      seam under the writable `secret/catalyst/*` subtree — #4477)
   #   - defaultChannels.vllm.enabled = true (first-otech)
   #   - defaultChannels.vllm.endpoint
   #     + defaultChannels.vllm.attestation.owner
@@ -428,10 +434,20 @@ spec:
           kind: ClusterSecretStore
           name: vault-region1
         remoteRef:
-          # Canonical OpenBao path per docs/INVIOLABLE-PRINCIPLES.md #4.
-          # Under the `vault-region1` store's `secret/` mount the full
-          # path is `secret/sovereign/<fqdn>/newapi/admin-token`.
-          key: sovereign/${SOVEREIGN_FQDN}/newapi/admin-token
+          # OpenBao path WRITTEN by catalyst-api's seedNewapiAdminToken seam
+          # (#4477). Under the `vault-region1` store's `secret/` mount the
+          # full path is `secret/catalyst/newapi/admin-token`. The
+          # `catalyst/` prefix is the ONLY sub-tree a Sovereign's
+          # catalyst-api can write (its `catalyst-api-write` OpenBao role is
+          # scoped to `secret/{data,metadata}/catalyst/*`; a write to
+          # `secret/sovereign/*` 403s), so the producer + read-path share
+          # this prefix in lock-step — identical pattern to the anthropic /
+          # mcp-bearer seeds. The seed propagates NewAPI's bridge
+          # ADMIN_SECRET verbatim so this token MATCHES what the
+          # sandbox-bridge validates. Cluster-shared (one path serves the
+          # whole Sovereign's unified-rbac), so ${SOVEREIGN_FQDN} is no
+          # longer in the path.
+          key: catalyst/newapi/admin-token
           property: ADMIN_API_TOKEN
     # Default channels — chart-side composition (channel #1 first).
     #

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.135 # lockstep with chart/Chart.yaml (#4477 self-heal stale OIDC provider client_secret via promote CronJob resync)
+  version: 1.4.136 # lockstep with chart/Chart.yaml (#4477 secondary: catalyst-newapi-admin-token ExternalSecret read-path → catalyst/newapi/admin-token, written by catalyst-api seedNewapiAdminToken)
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -1,5 +1,24 @@
 apiVersion: v2
 name: bp-newapi
+# 1.4.136 (#4477 secondary, 2026-06-27): the `catalyst-newapi-admin-token`
+# ExternalSecret's canonical OpenBao read-path moves from the
+# never-written `sovereign/<fqdn>/newapi/admin-token` to the cluster-shared
+# `catalyst/newapi/admin-token` — the path catalyst-api's new
+# seedNewapiAdminToken seam (products/catalyst/bootstrap/api/internal/
+# handler/sovereign_newapi_admin_token_seed.go) WRITES. Pre-fix nothing
+# wrote the sovereign-prefixed path, so on every fresh prov the
+# ExternalSecret stayed SecretSyncedError (live-observed on 91dc05917e44d1c1,
+# omantel.biz) and unified-rbac's admin-API per-user-key issuance 401'd. The
+# producer can only write under `secret/{data,metadata}/catalyst/*` (its
+# `catalyst-api-write` OpenBao role), so producer + read-path share the
+# `catalyst/` prefix in lock-step — identical resolution to the anthropic /
+# mcp-bearer seeds. The seam propagates NewAPI's bridge ADMIN_SECRET verbatim
+# (the value the sandbox-bridge validates), so the distributed token matches.
+# Chart change is doc/default-comment only; the functional fix lives in
+# catalyst-api + the bootstrap-kit overlay remoteRef.key. Lockstep:
+# blueprint.yaml spec.version + clusters/_template/bootstrap-kit/80-newapi.yaml
+# chart pin bumped to 1.4.136 in the same PR (Inviolable Principle #14).
+#
 # 1.4.126 (#4278, 2026-06-25): admin-promote CronJob no longer loops forever
 # on a missing ServiceAccount → bp-newapi HR can reach Ready on a fresh Org.
 #
@@ -909,7 +928,7 @@ name: bp-newapi
 #   drift, then hash-gated reload), mounts the OIDC secret, and its Role reads
 #   it. Live-verified on 91dc0591/omantel.biz: DB secret resynced, pod reloaded
 #   "Loaded 1 custom OAuth providers", KC authenticates the corrected secret.
-version: 1.4.135
+version: 1.4.136
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/external-secret.yaml
+++ b/platform/newapi/chart/templates/external-secret.yaml
@@ -8,11 +8,16 @@ control plane reads this Secret's `ADMIN_API_TOKEN` key and uses it as
 during the Organization user-create flow. The Secret therefore MUST exist on the
 OTECH control plane before unified-rbac begins reconciliation.
 
-Sourced from the operator's OpenBao via a ClusterSecretStore (Catalyst
+Sourced from the Sovereign's OpenBao via a ClusterSecretStore (Catalyst
 default = `vault-region1`, shipped by bp-external-secrets-stores). The
-remote OpenBao path is operator-supplied at install time per the
-canonical convention `sovereign/<sovereign-fqdn>/newapi/admin-token`
-(under the store's `secret/` mount) with property `ADMIN_API_TOKEN`.
+remote OpenBao path is WRITTEN by catalyst-api's seedNewapiAdminToken seam
+(#4477) at the canonical, cluster-shared path `catalyst/newapi/admin-token`
+(under the store's `secret/` mount) with property `ADMIN_API_TOKEN`. The
+`catalyst/` prefix is the only sub-tree a Sovereign's catalyst-api can
+write (`catalyst-api-write` role scoped to `secret/{data,metadata}/
+catalyst/*`), so the producer + this read-path share the prefix in
+lock-step. The seam propagates NewAPI's bridge ADMIN_SECRET verbatim so
+the distributed token MATCHES what the sandbox-bridge validates.
 
 Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), every knob
 (refreshInterval, secretStoreRef.kind/name, remoteRef.key,
@@ -34,7 +39,7 @@ pattern the bp-external-dns chart uses (issue #190).
 {{- $secretName := $ci.existingSecret | default "catalyst-newapi-admin-token" -}}
 {{- $remoteKey := $remote.key | default "" -}}
 {{- if not $remoteKey -}}
-{{- fail "catalystIntegration.externalSecret.enabled=true but catalystIntegration.externalSecret.remoteRef.key is empty — supply the per-Sovereign OpenBao path in the bootstrap-kit overlay (canonical: sovereign/<sovereign-fqdn>/newapi/admin-token)" -}}
+{{- fail "catalystIntegration.externalSecret.enabled=true but catalystIntegration.externalSecret.remoteRef.key is empty — supply the OpenBao path in the bootstrap-kit overlay (canonical, cluster-shared: catalyst/newapi/admin-token — the path catalyst-api's seedNewapiAdminToken seam writes, #4477)" -}}
 {{- end -}}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -747,10 +747,13 @@ reseller:
 # the responsibility of the NewAPI admin API itself, not this chart.
 catalystIntegration:
   enabled: true
-  # ExternalSecret name carrying the admin API token NewAPI generates at
-  # bootstrap. Required key: ADMIN_API_TOKEN. The token is rotated by
-  # the operator on a schedule documented in
-  # docs/CATALYST-CLI-AGENT.md.
+  # ExternalSecret name carrying the admin API token. The token value is
+  # NewAPI's bridge ADMIN_SECRET (the bearer the sandbox-bridge validates),
+  # propagated into OpenBao by catalyst-api's seedNewapiAdminToken seam at
+  # provisioning time (#4477) and distributed back via this ExternalSecret.
+  # Required key: ADMIN_API_TOKEN. Rotation: re-running the seam (every Org
+  # reconcile) re-propagates the current bridge ADMIN_SECRET, so a manual
+  # rotation of the token-signing-key Secret self-heals on the next reconcile.
   existingSecret: "catalyst-newapi-admin-token"
   # Comma-separated list of namespaces emberstack/reflector mirrors the
   # rendered Secret into (TBD-V15 / #2021). Default `catalyst-system`
@@ -764,14 +767,18 @@ catalystIntegration:
   # controllers in other namespaces need the same bearer locally.
   reflectorNamespaces: "catalyst-system"
   # ExternalSecret render — gated, default true. Sources the admin token
-  # from the operator's OpenBao via a ClusterSecretStore (default
+  # from the Sovereign's OpenBao via a ClusterSecretStore (default
   # `vault-region1`, the bp-external-secrets-stores default). The remote
-  # path is operator-supplied; the canonical convention per
-  # docs/INVIOLABLE-PRINCIPLES.md #4 is
-  # `sovereign/<sovereign-fqdn>/newapi/admin-token` (under the store's
-  # `secret/` mount) with property `ADMIN_API_TOKEN`. The cluster overlay
-  # at `clusters/<sovereign>/bootstrap-kit/80-newapi.yaml` sets
-  # `externalSecret.remoteRef.key` per Sovereign.
+  # path is WRITTEN by catalyst-api's seedNewapiAdminToken seam (#4477):
+  # the canonical, cluster-shared path is `catalyst/newapi/admin-token`
+  # (under the store's `secret/` mount) with property `ADMIN_API_TOKEN`.
+  # The `catalyst/` prefix is the ONLY sub-tree a Sovereign's catalyst-api
+  # can write (its `catalyst-api-write` OpenBao role is scoped to
+  # `secret/{data,metadata}/catalyst/*`), so the producer + this read-path
+  # share the prefix in lock-step. The cluster overlay at
+  # `clusters/<sovereign>/bootstrap-kit/80-newapi.yaml` sets
+  # `externalSecret.remoteRef.key` (default template ships
+  # `catalyst/newapi/admin-token`).
   externalSecret:
     enabled: true
     refreshInterval: "1h"
@@ -786,9 +793,10 @@ catalystIntegration:
     # convention. Operator overlay supplies the per-Sovereign value.
     remoteRef:
       # `key` is the OpenBao path under the ClusterSecretStore's base
-      # path (`secret/` in the Catalyst default). Operator overlay
-      # supplies the per-Sovereign value, e.g.:
-      #   sovereign/omantel.omani.works/newapi/admin-token
+      # path (`secret/` in the Catalyst default). Written by catalyst-api's
+      # seedNewapiAdminToken seam (#4477); the cluster overlay ships the
+      # canonical cluster-shared value:
+      #   catalyst/newapi/admin-token
       key: ""
       # `property` is the JSON field inside the OpenBao secret holding
       # the bearer token used by the Catalyst signup hook (ADR-0003 §3.2).

--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -389,6 +389,16 @@ type Handler struct {
 	// exercised without standing up a real cluster.
 	sovereignSMTPSeedClientFactory SovereignSMTPSeedClientFactory
 
+	// ── NewAPI admin-token OpenBao seed (issue #4477 secondary; ADR-0003) ───
+	// newapiAdminTokenSecretReader — test-only override for reading the
+	// bridge ADMIN_SECRET from the in-cluster
+	// `newapi-bp-newapi-token-signing-key` Secret. Production leaves this
+	// nil and seedNewapiAdminToken falls back to
+	// inClusterNewapiBridgeAdminSecret (rest.InClusterConfig). Tests inject
+	// a closure returning a fixed value (or NotFound) so the OpenBao-write
+	// path is exercised without a real apiserver.
+	newapiAdminTokenSecretReader NewapiAdminTokenSecretReader
+
 	// ── Multi-zone PowerDNS (issue #827, parent epic #825) ──────────────────
 	// powerdnsZoneClient — narrow client for runtime parent-zone creation.
 	// The bootstrap-kit's bp-powerdns Helm hook Job creates the operator's

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
@@ -964,6 +964,21 @@ func (h *Handler) runOrganizationPipeline(ctx context.Context, rec store.Organiz
 		// the agenity dashboard still serves). rec.Subdomain is the Org slug
 		// the bearer is scoped to; rec.AdminEmail is the owner subject.
 		_ = h.seedMCPBearer(ctx, rec.Subdomain, rec.AdminEmail)
+
+		// #4477 (secondary; ADR-0003 §3.2/§6) — propagate NewAPI's bridge
+		// ADMIN_SECRET (the bearer the sandbox-bridge validates with
+		// subtle.ConstantTimeCompare) into the Sovereign's OpenBao
+		// `secret/catalyst/newapi/admin-token` so the cluster-shared
+		// `catalyst-newapi-admin-token` ExternalSecret resolves and
+		// unified-rbac's per-user-key issuance against NewAPI's admin API
+		// authenticates. Without it that ExternalSecret stays
+		// SecretSyncedError (the live fault on 91dc0591) and admin-API calls
+		// 401. The path is cluster-shared, so the FIRST Org-create converges
+		// the whole Sovereign. Same posture as the two seeds above:
+		// idempotent (PutKVv2 overwrites) and NEVER fails the pipeline (a
+		// missing bridge Secret only leaves unified-rbac's admin path
+		// unauthenticated until NewAPI's token-signing-key Secret renders).
+		_ = h.seedNewapiAdminToken(ctx)
 	}
 
 	// Step 2 — bp_charts_installed.

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_newapi_admin_token_seed.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_newapi_admin_token_seed.go
@@ -1,0 +1,297 @@
+// Sovereign-side NewAPI admin-token OpenBao seeding (issue #4477 secondary
+// item; ADR-0003 §3.2 + §6 — the unified-RBAC admin-API token seam; Refs #3374).
+//
+// Why this exists:
+//
+//	ADR-0003 wires Catalyst's per-user-key issuance through NewAPI's admin
+//	API: the unified-rbac path in the OTECH control plane reads the
+//	`catalyst-newapi-admin-token` Secret's `ADMIN_API_TOKEN` key and presents
+//	it as `Authorization: Bearer <token>` against NewAPI's admin endpoints
+//	(per-user-key create, sandbox-token mint) during the Organization
+//	user-create flow. That Secret is materialised by an ExternalSecret which
+//	reads the Sovereign's OpenBao via the `vault-region1` ClusterSecretStore
+//	at the canonical path `catalyst/newapi/admin-token` (under the store's
+//	`secret/` mount) with property `ADMIN_API_TOKEN`.
+//
+//	The READ side (chart ExternalSecret + reflector mirror into
+//	catalyst-system) is wired and shipped. The PRODUCER — the thing that
+//	WRITES that OpenBao path at provisioning time — did NOT exist. Result:
+//	on every fresh prov the `catalyst-newapi-admin-token` ExternalSecret
+//	stayed READY=False / SecretSyncedError (the live-observed fault on
+//	`91dc05917e44d1c1`, omantel.biz, recorded as #4477's secondary item),
+//	and no admin bearer reached unified-rbac, so per-user-key issuance
+//	against NewAPI's admin API 401'd. This file is that missing producer.
+//
+// Why the VALUE is the bridge's ADMIN_SECRET (NOT a fresh random token):
+//
+//	NewAPI's sandbox-bridge validates the inbound admin bearer with
+//	subtle.ConstantTimeCompare against its own NEWAPI_ADMIN_SECRET env,
+//	which is sourced from the chart-generated, lookup-persisted
+//	`newapi-bp-newapi-token-signing-key` Secret's `ADMIN_SECRET` key
+//	(platform/newapi/chart/templates/sandbox-token-signing-key-secret.yaml).
+//	A freshly-minted random token here would NOT match → every unified-rbac
+//	call 401s. So the producer reads that Secret's `ADMIN_SECRET` (the
+//	source-of-truth bearer the bridge accepts) and propagates it into
+//	OpenBao verbatim. The ExternalSecret then distributes the SAME bytes to
+//	the catalyst-system reflector mirror unified-rbac consumes — the bearer
+//	and the value that validates it are guaranteed identical.
+//
+// Why `secret/catalyst/newapi/admin-token` (NOT bare
+// `secret/sovereign/<fqdn>/newapi/admin-token`):
+//
+//	Identical reasoning to sovereign_anthropic_seed.go +
+//	sovereign_mcp_bearer_seed.go: the catalyst-api Pod holds the
+//	write-capable `catalyst-api-write` OpenBao role scoped to
+//	`secret/{data,metadata}/catalyst/*` (platform/openbao/chart/templates/
+//	auth-bootstrap-job.yaml #3376). It has NO write grant on
+//	`secret/sovereign/*`, so a write to the historical
+//	`sovereign/<fqdn>/newapi/admin-token` path would 403 permission-denied.
+//	We therefore write under the `catalyst/` prefix the platform can ALREADY
+//	write — zero new OpenBao policy/role — and the read-path (chart default
+//	+ the bootstrap-kit overlay `catalystIntegration.externalSecret
+//	.remoteRef.key`) is moved to `catalyst/newapi/admin-token` in lock-step.
+//
+// When this runs:
+//
+//	runOrganizationPipeline calls seedNewapiAdminToken right after Step 1
+//	(per-Org overlay committed), beside seedAnthropicToken / seedMCPBearer.
+//	The OpenBao path is cluster-shared (one `secret/catalyst/newapi/admin-
+//	token` serves the whole Sovereign's unified-rbac), so the FIRST
+//	Org-create makes the Sovereign converge; subsequent Org-creates re-seed
+//	harmlessly (idempotent — PutKVv2 overwrites). A nil `h.openbao` client
+//	(Catalyst-Zero orchestrator) is a non-fatal skip, as is a missing
+//	bridge Secret (NewAPI not yet installed on this Sovereign — the next
+//	reconcile re-seeds once the chart has rendered the token-signing-key
+//	Secret).
+//
+// Per docs/PRINCIPLES.md #10 (credential hygiene): never logs the token —
+// only byte lengths + outcome class.
+package handler
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// newapiAdminTokenSeedMountPath / newapiAdminTokenSeedSecretPath — the
+// OpenBao KV-v2 location the producer writes and the
+// `catalyst-newapi-admin-token` ExternalSecret reads. Fixed-by-contract
+// with the bp-newapi chart's catalystIntegration.externalSecret.remoteRef
+// .key (platform/newapi/chart/values.yaml) and the bootstrap-kit overlay
+// (clusters/_template/bootstrap-kit/80-newapi.yaml). The `catalyst/` prefix
+// is the ONLY sub-tree a Sovereign's catalyst-api can write (see the file
+// doc comment).
+const (
+	newapiAdminTokenSeedMountPath  = "secret"
+	newapiAdminTokenSeedSecretPath = "catalyst/newapi/admin-token"
+)
+
+// newapiAdminTokenSeedKVProperty — the KV-v2 field name the ExternalSecret
+// reads (data[0].remoteRef.property = ADMIN_API_TOKEN). Fixed-by-contract
+// with platform/newapi/chart/templates/external-secret.yaml.
+const newapiAdminTokenSeedKVProperty = "ADMIN_API_TOKEN"
+
+// newapiBridgeSecretNamespace / newapiBridgeSecretName / newapiBridgeSecretKey
+// — the in-cluster Secret + key the bp-newapi chart auto-provisions
+// (platform/newapi/chart/templates/sandbox-token-signing-key-secret.yaml).
+// `ADMIN_SECRET` is the bearer the sandbox-bridge validates with
+// subtle.ConstantTimeCompare, so it is the source-of-truth value the seed
+// MUST propagate (a mismatch 401s every unified-rbac call).
+//
+// We read the `catalyst-system` REFLECTOR MIRROR rather than the chart's
+// origin namespace (`newapi` on host installs, the mgmt vCluster on
+// placement.role=vcluster-app). The bp-newapi chart's
+// sandboxTokenSigningKey.reflectorNamespaces default
+// (`catalyst-system,sandbox,sandbox-.*`) emberstack-mirrors this Secret
+// into `catalyst-system` on EVERY placement role — the same namespace
+// catalyst-api itself runs in (openbao chart serviceAccountNamespace:
+// catalyst-system). Reading the mirror in catalyst-api's own namespace is
+// placement-role-agnostic AND needs no cross-namespace RBAC. Overridable
+// per principle #4 via the env vars below for overlays that re-home it.
+const (
+	newapiBridgeSecretNamespace = "catalyst-system"
+	newapiBridgeSecretName      = "newapi-bp-newapi-token-signing-key"
+	newapiBridgeSecretKey       = "ADMIN_SECRET"
+)
+
+// Env overrides (docs/PRINCIPLES.md #4 — runtime-configurable knobs). Empty
+// ⇒ the const defaults above. A per-Sovereign overlay that renames the
+// token-signing-key Secret or re-homes it sets these on the catalyst-api
+// Pod without rebuilding the image.
+const (
+	newapiAdminTokenSeedSecretNamespaceEnv = "CATALYST_NEWAPI_ADMIN_TOKEN_SECRET_NAMESPACE"
+	newapiAdminTokenSeedSecretNameEnv      = "CATALYST_NEWAPI_ADMIN_TOKEN_SECRET_NAME"
+	newapiAdminTokenSeedSecretKeyEnv       = "CATALYST_NEWAPI_ADMIN_TOKEN_SECRET_KEY"
+)
+
+// newapiAdminTokenSeedTimeout bounds the in-cluster Secret Get. Generous
+// for first-contact against the apiserver; overridable per principle #4.
+const newapiAdminTokenSeedTimeout = 15 * time.Second
+
+// NewapiAdminTokenSeedOutcome — terminal classification of one seed attempt.
+type NewapiAdminTokenSeedOutcome string
+
+const (
+	NewapiAdminTokenSeedOutcomeSeeded          NewapiAdminTokenSeedOutcome = "seeded"
+	NewapiAdminTokenSeedOutcomeSkippedNoBao    NewapiAdminTokenSeedOutcome = "skipped-no-openbao"
+	NewapiAdminTokenSeedOutcomeSkippedNoSecret NewapiAdminTokenSeedOutcome = "skipped-no-bridge-secret"
+	NewapiAdminTokenSeedOutcomeClientFailure   NewapiAdminTokenSeedOutcome = "client-failure"
+	NewapiAdminTokenSeedOutcomeWriteFailure    NewapiAdminTokenSeedOutcome = "write-failure"
+)
+
+// NewapiAdminTokenSecretReader returns the bridge ADMIN_SECRET bytes from the
+// in-cluster `newapi-bp-newapi-token-signing-key` Secret. The narrow seam
+// keeps the OpenBao-write path unit-testable without standing up a real
+// apiserver: production wires inClusterNewapiBridgeAdminSecret;
+// tests inject a closure returning a fixed value (or NotFound).
+type NewapiAdminTokenSecretReader func(ctx context.Context, namespace, name, key string) (string, bool, error)
+
+// SetNewapiAdminTokenSecretReader wires a test-only reader. Production leaves
+// this nil and the helper falls back to inClusterNewapiBridgeAdminSecret.
+func (h *Handler) SetNewapiAdminTokenSecretReader(r NewapiAdminTokenSecretReader) {
+	h.newapiAdminTokenSecretReader = r
+}
+
+// inClusterNewapiBridgeAdminSecret reads the bridge ADMIN_SECRET from the
+// in-cluster Secret via rest.InClusterConfig (catalyst-api always runs in
+// the Sovereign it serves). Returns (value, found, err): found=false +
+// nil err is the "Secret/key not present yet" branch (NewAPI not installed
+// or the chart hasn't rendered the token-signing-key Secret yet) — the
+// caller treats that as a non-fatal skip, not a failure.
+func inClusterNewapiBridgeAdminSecret(ctx context.Context, namespace, name, key string) (string, bool, error) {
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		return "", false, fmt.Errorf("in-cluster config unavailable: %w", err)
+	}
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return "", false, fmt.Errorf("build core client: %w", err)
+	}
+	return readNewapiBridgeAdminSecret(ctx, clientset, namespace, name, key)
+}
+
+// readNewapiBridgeAdminSecret is the clientset-bound core of the reader,
+// split out so a fake.NewSimpleClientset can exercise the Get + key-extract
+// logic directly. NotFound on the Secret ⇒ (",false,nil); a present Secret
+// missing the key ⇒ ("",false,nil) (chart drift / partial render — re-seed
+// next reconcile). Any other API error is a hard failure.
+func readNewapiBridgeAdminSecret(ctx context.Context, clientset kubernetes.Interface, namespace, name, key string) (string, bool, error) {
+	sec, err := clientset.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	raw, ok := sec.Data[key]
+	if !ok || len(raw) == 0 {
+		return "", false, nil
+	}
+	return string(raw), true, nil
+}
+
+// seedNewapiAdminToken propagates NewAPI's bridge ADMIN_SECRET (the bearer
+// the sandbox-bridge validates) into the Sovereign's OpenBao
+// `secret/catalyst/newapi/admin-token` path so the
+// `catalyst-newapi-admin-token` ExternalSecret resolves and unified-rbac's
+// admin-API calls authenticate (issue #4477 secondary item). Idempotent:
+// PutKVv2 overwrites, so repeated Org-creates re-seed harmlessly.
+//
+// Returns the terminal outcome so the caller can emit an SSE / log line
+// without coupling this helper to the emit machinery. NEVER returns an
+// error that fails the Org pipeline — a missing bridge Secret or a transient
+// OpenBao blip must not block the rest of the Org (unified-rbac's per-user-
+// key issuance stays offline only until the path is seeded). The outcome is
+// surfaced loudly instead.
+func (h *Handler) seedNewapiAdminToken(ctx context.Context) NewapiAdminTokenSeedOutcome {
+	// Catalyst-Zero (the orchestrator) has no in-cluster OpenBao client and
+	// never hosts NewAPI — skip without noise beyond a debug line.
+	// Production Sovereign catalyst-api always has h.openbao wired
+	// (SetOpenBao, main.go).
+	if h.openbao == nil {
+		if h.log != nil {
+			h.log.Debug("newapi admin-token seed: skipped — no OpenBao client (orchestrator / Catalyst-Zero)")
+		}
+		return NewapiAdminTokenSeedOutcomeSkippedNoBao
+	}
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	ns := envOr(newapiAdminTokenSeedSecretNamespaceEnv, newapiBridgeSecretNamespace)
+	name := envOr(newapiAdminTokenSeedSecretNameEnv, newapiBridgeSecretName)
+	key := envOr(newapiAdminTokenSeedSecretKeyEnv, newapiBridgeSecretKey)
+
+	reader := h.newapiAdminTokenSecretReader
+	if reader == nil {
+		reader = inClusterNewapiBridgeAdminSecret
+	}
+
+	rctx, cancel := context.WithTimeout(ctx, newapiAdminTokenSeedTimeout)
+	defer cancel()
+
+	token, found, err := reader(rctx, ns, name, key)
+	if err != nil {
+		// A real API error (RBAC drift, apiserver unreachable) — surface
+		// loud + skip; the pipeline must not fail on it.
+		if h.log != nil {
+			h.log.Error("newapi admin-token seed: read bridge admin secret failed",
+				"namespace", ns,
+				"name", name,
+				"key", key,
+				"err", err,
+			)
+		}
+		return NewapiAdminTokenSeedOutcomeClientFailure
+	}
+	if !found || strings.TrimSpace(token) == "" {
+		// NewAPI not yet installed on this Sovereign, or the chart has not
+		// rendered the token-signing-key Secret yet. Loud skip; the next
+		// Org reconcile re-seeds once the Secret exists. NOT a failure —
+		// seeding an empty path would pin the ESO/reflector empty-seed trap.
+		if h.log != nil {
+			h.log.Warn("newapi admin-token seed: SKIPPED — bridge admin secret not present yet; catalyst-newapi-admin-token ExternalSecret stays unresolved until NewAPI's token-signing-key Secret renders",
+				"namespace", ns,
+				"name", name,
+				"key", key,
+				"openbaoPath", newapiAdminTokenSeedMountPath+"/"+newapiAdminTokenSeedSecretPath,
+			)
+		}
+		return NewapiAdminTokenSeedOutcomeSkippedNoSecret
+	}
+
+	// KV-v2 payload. Field name MUST match the ExternalSecret's
+	// remoteRef.property value (ADMIN_API_TOKEN).
+	data := map[string]any{
+		newapiAdminTokenSeedKVProperty: token,
+	}
+
+	if err := h.openbao.PutKVv2(ctx, newapiAdminTokenSeedMountPath, newapiAdminTokenSeedSecretPath, data); err != nil {
+		if h.log != nil {
+			h.log.Error("newapi admin-token seed: OpenBao write failed",
+				"openbaoPath", newapiAdminTokenSeedMountPath+"/"+newapiAdminTokenSeedSecretPath,
+				"err", err,
+			)
+		}
+		return NewapiAdminTokenSeedOutcomeWriteFailure
+	}
+
+	if h.log != nil {
+		// Per docs/PRINCIPLES.md #10: byte length + outcome only, never the
+		// token plaintext.
+		h.log.Info("newapi admin-token seed: wrote OpenBao path so the catalyst-newapi-admin-token ExternalSecret resolves + unified-rbac's admin-API calls authenticate",
+			"openbaoPath", newapiAdminTokenSeedMountPath+"/"+newapiAdminTokenSeedSecretPath,
+			"sourceSecret", ns+"/"+name,
+			"adminTokenBytes", len(token),
+		)
+	}
+	return NewapiAdminTokenSeedOutcomeSeeded
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_newapi_admin_token_seed_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_newapi_admin_token_seed_test.go
@@ -1,0 +1,198 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/openbao"
+)
+
+// newapiCaptureKVServer is a fake OpenBao KV-v2 endpoint that records the
+// last PUT path + payload so the test can assert seedNewapiAdminToken wrote
+// the exact `secret/catalyst/newapi/admin-token` path with the
+// `ADMIN_API_TOKEN` field the catalyst-newapi-admin-token ExternalSecret
+// expects. Named distinctly from the anthropic seed test's captureKVServer
+// (same package).
+type newapiCaptureKVServer struct {
+	mu      sync.Mutex
+	lastURL string
+	lastReq map[string]any
+	srv     *httptest.Server
+}
+
+func newNewapiCaptureKVServer(t *testing.T) *newapiCaptureKVServer {
+	t.Helper()
+	c := &newapiCaptureKVServer{}
+	c.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var parsed map[string]any
+		_ = json.Unmarshal(body, &parsed)
+		c.mu.Lock()
+		c.lastURL = r.URL.Path
+		c.lastReq = parsed
+		c.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"version":1}}`))
+	}))
+	t.Cleanup(c.srv.Close)
+	return c
+}
+
+func (c *newapiCaptureKVServer) dataField(key string) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.lastReq == nil {
+		return "", false
+	}
+	data, ok := c.lastReq["data"].(map[string]any)
+	if !ok {
+		return "", false
+	}
+	v, ok := data[key].(string)
+	return v, ok
+}
+
+// Test_seedNewapiAdminToken_SeedsExpectedPathAndField verifies the producer
+// writes secret/catalyst/newapi/admin-token with ADMIN_API_TOKEN set to the
+// bridge ADMIN_SECRET it read from the in-cluster Secret (#4477). The path +
+// field name are the contract with platform/newapi/chart/templates/
+// external-secret.yaml — drift here re-breaks unified-rbac's admin auth.
+func Test_seedNewapiAdminToken_SeedsExpectedPathAndField(t *testing.T) {
+	srv := newNewapiCaptureKVServer(t)
+	h := &Handler{log: silentLogger()}
+	h.openbao = &openbao.Client{Addr: srv.srv.URL, Token: "test-token", HTTP: srv.srv.Client()}
+
+	const bridgeSecret = "bridge-admin-secret-64chars-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+	h.SetNewapiAdminTokenSecretReader(func(_ context.Context, ns, name, key string) (string, bool, error) {
+		// Confirm the seam reads the canonical bridge Secret coordinates.
+		if ns != newapiBridgeSecretNamespace || name != newapiBridgeSecretName || key != newapiBridgeSecretKey {
+			t.Errorf("reader called with (%q,%q,%q), want (%q,%q,%q)", ns, name, key,
+				newapiBridgeSecretNamespace, newapiBridgeSecretName, newapiBridgeSecretKey)
+		}
+		return bridgeSecret, true, nil
+	})
+
+	outcome := h.seedNewapiAdminToken(context.Background())
+	if outcome != NewapiAdminTokenSeedOutcomeSeeded {
+		t.Fatalf("outcome = %q, want %q", outcome, NewapiAdminTokenSeedOutcomeSeeded)
+	}
+
+	// KV-v2 PUT path is /v1/<mount>/data/<secretPath>.
+	wantPath := "/v1/secret/data/catalyst/newapi/admin-token"
+	srv.mu.Lock()
+	gotPath := srv.lastURL
+	srv.mu.Unlock()
+	if gotPath != wantPath {
+		t.Errorf("PUT path = %q, want %q", gotPath, wantPath)
+	}
+
+	// The seeded value MUST be the bridge ADMIN_SECRET verbatim — a mismatch
+	// here would 401 every unified-rbac call against the sandbox-bridge.
+	if v, ok := srv.dataField("ADMIN_API_TOKEN"); !ok || v != bridgeSecret {
+		t.Errorf("ADMIN_API_TOKEN field = %q (present=%v), want bridge ADMIN_SECRET verbatim", v, ok)
+	}
+}
+
+// Test_seedNewapiAdminToken_SkipNoBridgeSecret verifies the NewAPI-not-yet-
+// installed path: reader reports not-found ⇒ loud skip, NO OpenBao write
+// (an empty path would pin the ESO/reflector empty-seed trap).
+func Test_seedNewapiAdminToken_SkipNoBridgeSecret(t *testing.T) {
+	srv := newNewapiCaptureKVServer(t)
+	h := &Handler{log: silentLogger()}
+	h.openbao = &openbao.Client{Addr: srv.srv.URL, Token: "test-token", HTTP: srv.srv.Client()}
+
+	h.SetNewapiAdminTokenSecretReader(func(_ context.Context, _, _, _ string) (string, bool, error) {
+		return "", false, nil
+	})
+
+	if outcome := h.seedNewapiAdminToken(context.Background()); outcome != NewapiAdminTokenSeedOutcomeSkippedNoSecret {
+		t.Fatalf("outcome = %q, want %q", outcome, NewapiAdminTokenSeedOutcomeSkippedNoSecret)
+	}
+	srv.mu.Lock()
+	wrote := srv.lastURL != ""
+	srv.mu.Unlock()
+	if wrote {
+		t.Errorf("expected NO OpenBao write when bridge secret absent, but a write hit %q", srv.lastURL)
+	}
+}
+
+// Test_seedNewapiAdminToken_ClientFailure verifies a real API error from the
+// reader (RBAC drift, apiserver unreachable) ⇒ loud skip, NO OpenBao write,
+// and the pipeline is NOT failed (outcome is a classification, not an error).
+func Test_seedNewapiAdminToken_ClientFailure(t *testing.T) {
+	srv := newNewapiCaptureKVServer(t)
+	h := &Handler{log: silentLogger()}
+	h.openbao = &openbao.Client{Addr: srv.srv.URL, Token: "test-token", HTTP: srv.srv.Client()}
+
+	h.SetNewapiAdminTokenSecretReader(func(_ context.Context, _, _, _ string) (string, bool, error) {
+		return "", false, errors.New("forbidden: secrets is forbidden")
+	})
+
+	if outcome := h.seedNewapiAdminToken(context.Background()); outcome != NewapiAdminTokenSeedOutcomeClientFailure {
+		t.Fatalf("outcome = %q, want %q", outcome, NewapiAdminTokenSeedOutcomeClientFailure)
+	}
+	srv.mu.Lock()
+	wrote := srv.lastURL != ""
+	srv.mu.Unlock()
+	if wrote {
+		t.Errorf("expected NO OpenBao write on reader error, but a write hit %q", srv.lastURL)
+	}
+}
+
+// Test_seedNewapiAdminToken_SkipNoOpenBao verifies the Catalyst-Zero
+// orchestrator path: nil OpenBao client ⇒ non-fatal skip, no panic, reader
+// never consulted.
+func Test_seedNewapiAdminToken_SkipNoOpenBao(t *testing.T) {
+	h := &Handler{log: silentLogger()}
+	// h.openbao deliberately nil.
+	h.SetNewapiAdminTokenSecretReader(func(_ context.Context, _, _, _ string) (string, bool, error) {
+		t.Fatal("reader must not be consulted when OpenBao client is nil")
+		return "", false, nil
+	})
+	if outcome := h.seedNewapiAdminToken(context.Background()); outcome != NewapiAdminTokenSeedOutcomeSkippedNoBao {
+		t.Fatalf("outcome = %q, want %q", outcome, NewapiAdminTokenSeedOutcomeSkippedNoBao)
+	}
+}
+
+// Test_readNewapiBridgeAdminSecret exercises the clientset-bound reader core
+// against a fake clientset: present Secret returns the value; missing Secret
+// and missing key both return (",false,nil) (the non-fatal skip branch).
+func Test_readNewapiBridgeAdminSecret(t *testing.T) {
+	ctx := context.Background()
+
+	// (a) present Secret + key.
+	core := kfake.NewSimpleClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: newapiBridgeSecretName, Namespace: newapiBridgeSecretNamespace},
+		Data:       map[string][]byte{newapiBridgeSecretKey: []byte("the-admin-secret")},
+	})
+	v, found, err := readNewapiBridgeAdminSecret(ctx, core, newapiBridgeSecretNamespace, newapiBridgeSecretName, newapiBridgeSecretKey)
+	if err != nil || !found || v != "the-admin-secret" {
+		t.Fatalf("present: got (%q, found=%v, err=%v), want (\"the-admin-secret\", true, nil)", v, found, err)
+	}
+
+	// (b) Secret missing entirely ⇒ non-fatal skip.
+	empty := kfake.NewSimpleClientset()
+	if v, found, err := readNewapiBridgeAdminSecret(ctx, empty, newapiBridgeSecretNamespace, newapiBridgeSecretName, newapiBridgeSecretKey); err != nil || found || v != "" {
+		t.Fatalf("missing secret: got (%q, found=%v, err=%v), want (\"\", false, nil)", v, found, err)
+	}
+
+	// (c) Secret present but key absent ⇒ non-fatal skip (partial render).
+	noKey := kfake.NewSimpleClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: newapiBridgeSecretName, Namespace: newapiBridgeSecretNamespace},
+		Data:       map[string][]byte{"SIGNING_KEY": []byte("x")},
+	})
+	if v, found, err := readNewapiBridgeAdminSecret(ctx, noKey, newapiBridgeSecretNamespace, newapiBridgeSecretName, newapiBridgeSecretKey); err != nil || found || v != "" {
+		t.Fatalf("missing key: got (%q, found=%v, err=%v), want (\"\", false, nil)", v, found, err)
+	}
+}

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,13 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.906 — #4477 secondary (2026-06-27): doc-only — the CATALYST_NEWAPI_ADMIN_TOKEN
+# env comment in api-deployment{,-kustomize}.yaml now cites the canonical
+# OpenBao path `catalyst/newapi/admin-token` (written by catalyst-api's
+# seedNewapiAdminToken seam) instead of the never-written, sovereign-prefixed
+# path. No rendered-output change; version bump per Inviolable Principle #14
+# (chart-touch → version+pin lockstep). Pin in
+# clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml bumped in step.
+#
 # 1.4.901 — #4482 (Refs #3642, 2026-06-26): unblock the Pillar-4 agentic
 # Sandbox+MCP journey. bp-sandbox's sandbox-controller CrashLoopBackOff'd on
 # every Sovereign — main.go calls mustEnv("CATALYST_GITEA_TOKEN") (hard
@@ -3310,7 +3318,7 @@ name: bp-catalyst-platform
 #   bump back to b23af68, shipping org-controller WITHOUT #4455 tenant-dns +
 #   #4462 delete-cascade on every fresh prov). 89993b2 is a descendant of b23af68
 #   so it retains #4393 Guaranteed-QoS. Lockstep w/ bootstrap-kit slot 13 pin.
-version: 1.4.905
+version: 1.4.906
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/
 #   platform/crossplane chart + blueprint.yaml + bootstrap-kit slot 04). crossplane-core
 #   was still OOMKilled (CrashLoopBackOff, 55 restarts, exit 137, killed ~90s after start)

--- a/products/catalyst/chart/templates/api-deployment-kustomize.yaml
+++ b/products/catalyst/chart/templates/api-deployment-kustomize.yaml
@@ -774,7 +774,8 @@ spec:
             # `catalyst-newapi-admin-token` Secret rendered by the
             # bp-newapi chart's ExternalSecret (key ADMIN_API_TOKEN,
             # source ClusterSecretStore `vault-region1`, OpenBao path
-            # `sovereign/<sovereign-fqdn>/newapi/admin-token`).
+            # `catalyst/newapi/admin-token` — written by catalyst-api's
+            # seedNewapiAdminToken seam, #4477).
             #
             # Same cross-namespace pattern as `sme-secrets` above: the
             # ExternalSecret lands the Secret in the `newapi` namespace

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -911,7 +911,8 @@ spec:
             # `catalyst-newapi-admin-token` Secret rendered by the
             # bp-newapi chart's ExternalSecret (key ADMIN_API_TOKEN,
             # source ClusterSecretStore `vault-region1`, OpenBao path
-            # `sovereign/<sovereign-fqdn>/newapi/admin-token`).
+            # `catalyst/newapi/admin-token` — written by catalyst-api's
+            # seedNewapiAdminToken seam, #4477).
             #
             # Same cross-namespace pattern as `sme-secrets` above: the
             # ExternalSecret lands the Secret in the `newapi` namespace


### PR DESCRIPTION
Refs #4477 #3374

## Problem
The `catalyst-newapi-admin-token` ExternalSecret (ADR-0003 §3.2/§6 — the unified-RBAC admin-API bearer for per-user-key issuance) sat `SecretSyncedError` on every fresh prov because the OpenBao path it reads — `sovereign/<fqdn>/newapi/admin-token` — was **never written by any producer**. No code seeded it. Result: unified-RBAC's calls against NewAPI's admin API 401'd. Live-observed on `91dc05917e44d1c1` (omantel.biz); recorded as the **secondary** item in #4477 (the primary SSO FAIL 1 / FAIL 2 ship in a separate PR).

## Fix
Add a `seedNewapiAdminToken` seam in catalyst-api (`products/catalyst/bootstrap/api/internal/handler/sovereign_newapi_admin_token_seed.go`), mirroring the existing `seedAnthropicToken` / `seedMCPBearer` producers:

- It reads NewAPI's **bridge `ADMIN_SECRET`** — the `newapi-bp-newapi-token-signing-key` Secret key the sandbox-bridge validates with `subtle.ConstantTimeCompare` — and propagates it **verbatim** into the Sovereign's OpenBao. This guarantees the distributed token MATCHES what the bridge accepts. A freshly-minted random token would 401 on every unified-RBAC call.
- The producer can only write under `secret/{data,metadata}/catalyst/*` (its `catalyst-api-write` OpenBao role; a write to `secret/sovereign/*` 403s), so the canonical read-path moves to the cluster-shared **`catalyst/newapi/admin-token`** in lock-step — the identical resolution the anthropic / mcp-bearer seeds use.
- Wired into `runOrganizationPipeline` beside the other two seeds: idempotent (`PutKVv2` overwrites), cluster-shared (the first Org-create converges the whole Sovereign), and **never fails the pipeline** (a missing bridge Secret only leaves the admin path unauthenticated until NewAPI's token-signing-key Secret renders; loud-skip, no empty-seed).

## Read-path lockstep
- `clusters/_template/bootstrap-kit/80-newapi.yaml` — `catalystIntegration.externalSecret.remoteRef.key` → `catalyst/newapi/admin-token` + chart pin 1.4.135→1.4.136.
- `platform/newapi/chart/{Chart.yaml,values.yaml,templates/external-secret.yaml}` + `blueprint.yaml` — version + default-doc to the `catalyst/` path.

## Verification
- `go build ./...` + `go vet ./internal/handler/` clean.
- 5 new seed tests + full handler suite green.
- `helm template` renders the ExternalSecret reading **exactly** the seeded path (`key: catalyst/newapi/admin-token`, `property`/`secretKey: ADMIN_API_TOKEN`).
- Shipped `admin-promote-rbac-render.sh` (incl. Case 6 #4477) + `bridge-readiness-render.sh` pass.

Live verification (the ExternalSecret syncs on a prov) is blocked by the current mothership outage — this ships the durable merge; the sync verifies on the next reachable prov.

🤖 Generated with [Claude Code](https://claude.com/claude-code)