### PR TITLE
fix(janitor): log-only-until-proven + active-dep allowlist + cred fallback + EVS-orphan sweep (#4466)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/janitor.go
+++ b/products/catalyst/bootstrap/api/internal/handler/janitor.go
@@ -67,6 +67,18 @@
 //     during a controlled debug session where the operator is mid-RCA
 //     on a failed deployment and doesn't want the record wiped out
 //     from under them).
+//   - CATALYST_JANITOR_DESTRUCTIVE: "true" arms the cloud-resource sweeps
+//     (EIPs/keypairs/VPCs/EVS) to ACTUALLY delete. Default FALSE → the
+//     sweeps run LOG-ONLY: each pass logs exactly what it WOULD reap
+//     (prefix, resource, reason) but deletes nothing. #4466 — makes
+//     "deletes prod infra" opt-in, not default. The b9f9590b node
+//     self-reap would have surfaced in this log-only window first.
+//   - CATALYST_JANITOR_ACTIVE_DEPLOYMENT_IDS: comma/space-separated
+//     deployment id(s) (or 8-char prefixes) hard-excluded from EVERY
+//     delete path, independent of status inference. #4466 belt-and-
+//     suspenders over the buildActivePrefixes denylist — set this to the
+//     live Sovereign's dep id so cleanup can never reach it even if status
+//     inference regresses.
 
 package handler
 
@@ -97,6 +109,40 @@ const (
 	defaultJanitorWipedMaxAge  = 1 * time.Hour
 )
 
+// janitorDestructive reports whether the cloud-resource sweeps (EIPs /
+// keypairs / VPCs / EVS) are permitted to ACTUALLY delete. #4466 makes
+// "deletes prod infra" opt-in: until CATALYST_JANITOR_DESTRUCTIVE=true is
+// explicitly set the sweeps run in LOG-ONLY mode — every pass logs exactly
+// the resource it WOULD reap (prefix, resource, reason) but deletes
+// nothing. The b9f9590b self-reap (all 12 ECS nodes deleted ~2.5 min after
+// convergence) would have surfaced in this log-only window before any node
+// died. Default FALSE — fail safe.
+func janitorDestructive() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("CATALYST_JANITOR_DESTRUCTIVE")), "true")
+}
+
+// janitorExtraProtectedPrefixes returns the explicit, status-independent
+// do-not-touch deployment-ID prefixes from CATALYST_JANITOR_ACTIVE_DEPLOYMENT_IDS
+// (comma/space-separated full IDs or 8-char prefixes). #4466 belt-and-
+// suspenders: even if status inference (buildActivePrefixes) ever regresses
+// again, the CURRENTLY-active deployment id(s) named here are hard-excluded
+// from every delete path. Operators set this to the live Sovereign's dep id
+// so cleanup automation can never reach it regardless of any status bug.
+func janitorExtraProtectedPrefixes() map[string]struct{} {
+	out := map[string]struct{}{}
+	raw := os.Getenv("CATALYST_JANITOR_ACTIVE_DEPLOYMENT_IDS")
+	if raw == "" {
+		return out
+	}
+	for _, f := range strings.FieldsFunc(raw, func(r rune) bool { return r == ',' || r == ' ' || r == '\n' || r == '\t' }) {
+		f = strings.TrimSpace(f)
+		if len(f) >= 8 {
+			out[f[:8]] = struct{}{}
+		}
+	}
+	return out
+}
+
 // StartJanitor launches the periodic janitor in a background goroutine.
 // Returns immediately. Run from main.go after the handler + store are
 // wired. ctx cancellation stops the loop.
@@ -116,6 +162,9 @@ func (h *Handler) StartJanitor(ctx context.Context, tofuWorkDir string) {
 		"wipedMaxAgeSec", int(wipedMaxAge.Seconds()),
 		"kubeconfigsDir", h.kubeconfigsDir,
 		"tofuWorkDir", tofuWorkDir,
+		// #4466: cloud-resource sweeps are LOG-ONLY until this is true.
+		"cloudSweepDestructive", janitorDestructive(),
+		"explicitProtectedPrefixes", len(janitorExtraProtectedPrefixes()),
 	)
 
 	go func() {
@@ -243,8 +292,17 @@ func (h *Handler) runJanitorPass(tofuWorkDir string, failedMaxAge, wipedMaxAge t
 	// bastion / non-catalyst VPCs hard-protected.
 	stats.OrphanVPCs = h.cleanOrphanVPCsHuawei(tofuWorkDir, activeIDs)
 
+	// Step 6: #4466 — standalone detached-EVS-orphan sweep. A node
+	// self-reap BEFORE a wipe strands CSI `pvc-*` volumes (283 on
+	// b9f9590b) as pure quota debt with no controller left to detach +
+	// delete them. EIPs/keypairs/VPCs each had a reclaim sweep; detached
+	// volumes did not. Only status=available, zero-attachment pvc-* volumes
+	// owned by no live dep are eligible (same protect-by-default guard).
+	stats.OrphanEVS = h.cleanOrphanEVSHuawei(tofuWorkDir, activeIDs)
+
 	h.log.Info("[JANITOR] pass complete",
 		"durationMs", int(time.Since(startedAt).Milliseconds()),
+		"destructive", janitorDestructive(),
 		"reaped", stats.Reaped,
 		"reapErrors", stats.ReapErrors,
 		"orphanKubeconfigsDeleted", stats.OrphanKubeconfigs,
@@ -252,6 +310,7 @@ func (h *Handler) runJanitorPass(tofuWorkDir string, failedMaxAge, wipedMaxAge t
 		"orphanEIPsDeleted", stats.OrphanEIPs,
 		"orphanKeypairsDeleted", stats.OrphanKeypairs,
 		"orphanVPCsDeleted", stats.OrphanVPCs,
+		"orphanEVSDeleted", stats.OrphanEVS,
 	)
 }
 
@@ -269,6 +328,7 @@ type janitorStats struct {
 	OrphanEIPs         int
 	OrphanKeypairs     int
 	OrphanVPCs         int
+	OrphanEVS          int
 }
 
 // reapDeployment is the cleanup primitive used by the janitor. It
@@ -435,7 +495,82 @@ func (h *Handler) buildActivePrefixes() map[string]struct{} {
 		}
 		return true
 	})
+	// #4466 belt-and-suspenders: merge the explicit, status-INDEPENDENT
+	// active-deployment do-not-touch allowlist. Even if the status-inference
+	// loop above ever regresses (the exact b9f9590b class of fault), the
+	// operator-named live deployment id(s) stay hard-protected.
+	for p := range janitorExtraProtectedPrefixes() {
+		activePrefixes[p] = struct{}{}
+	}
 	return activePrefixes
+}
+
+// huaweiSweepCreds is a discovered set of project-wide Huawei creds the
+// orphan sweeps run under. All catalyst-huawei deployments in one
+// mothership share the same HCS project, so any one set drives the
+// project-wide sweep.
+type huaweiSweepCreds struct {
+	AK        string
+	SK        string
+	ProjectID string
+	Region    string
+}
+
+// discoverHuaweiCreds finds a working set of Huawei creds for the
+// project-wide orphan sweep. It first walks the per-deployment tfvars on
+// the PVC (the historical source). #4466 cred-source fallback: when the
+// LAST wipe has deleted its own `tofu.auto.tfvars.json` (the only cred
+// source the tfvars-walk knows), the walk short-circuits to "no huawei
+// deployments" and the post-wipe orphan sweep never runs — leaving the
+// very orphans the wipe failed to delete (283 stranded EVS on b9f9590b).
+// So when the tfvars walk comes up empty we fall back to the
+// `huawei-operator-creds` Secret, projected into the catalyst-api Pod as
+// CATALYST_HUAWEI_ACCESS_KEY / _SECRET_KEY / _PROJECT_ID / _REGION — the
+// same env the provisioner reads. Returns ok=false only when BOTH sources
+// are empty (genuinely no Huawei on this mothership).
+func discoverHuaweiCreds(tofuWorkDir string) (huaweiSweepCreds, bool) {
+	var c huaweiSweepCreds
+	if tofuWorkDir != "" {
+		if entries, err := os.ReadDir(tofuWorkDir); err == nil {
+			for _, e := range entries {
+				if !e.IsDir() {
+					continue
+				}
+				data, err := os.ReadFile(filepath.Join(tofuWorkDir, e.Name(), "tofu.auto.tfvars.json"))
+				if err != nil {
+					continue
+				}
+				var tv map[string]any
+				if err := json.Unmarshal(data, &tv); err != nil {
+					continue
+				}
+				akV, _ := tv["huawei_access_key"].(string)
+				skV, _ := tv["huawei_secret_key"].(string)
+				pidV, _ := tv["huawei_project_id"].(string)
+				regV, _ := tv["huawei_region"].(string)
+				if akV != "" && skV != "" && pidV != "" {
+					c.AK, c.SK, c.ProjectID, c.Region = akV, skV, pidV, regV
+					if c.Region == "" {
+						c.Region = "me-east-215"
+					}
+					return c, true
+				}
+			}
+		}
+	}
+	// Fallback: the huawei-operator-creds Secret env. This is what keeps a
+	// post-wipe sweep alive after the wipe deletes the dep's tfvars.
+	c.AK = os.Getenv("CATALYST_HUAWEI_ACCESS_KEY")
+	c.SK = os.Getenv("CATALYST_HUAWEI_SECRET_KEY")
+	c.ProjectID = os.Getenv("CATALYST_HUAWEI_PROJECT_ID")
+	c.Region = os.Getenv("CATALYST_HUAWEI_REGION")
+	if c.AK != "" && c.SK != "" && c.ProjectID != "" {
+		if c.Region == "" {
+			c.Region = "me-east-215"
+		}
+		return c, true
+	}
+	return huaweiSweepCreds{}, false
 }
 
 // cleanOrphanEIPsHuawei walks the per-deployment tfvars files on the
@@ -454,58 +589,13 @@ func (h *Handler) buildActivePrefixes() map[string]struct{} {
 // Returns the number of EIPs deleted. Returns 0 + logs on any error.
 // Safe to call even when no huawei deployment exists (no-op).
 func (h *Handler) cleanOrphanEIPsHuawei(tofuWorkDir string, activeIDs map[string]struct{}) int {
-	if tofuWorkDir == "" {
-		return 0
-	}
-	entries, err := os.ReadDir(tofuWorkDir)
-	if err != nil {
-		return 0
-	}
-	// Find the first deployment with valid huawei creds in its tfvars.
-	// All catalyst-huawei deployments in a single mothership share the
-	// same HCS project so any one set of creds works for the project-
-	// wide sweep.
-	var ak, sk, projectID, region string
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		tfvarsPath := filepath.Join(tofuWorkDir, e.Name(), "tofu.auto.tfvars.json")
-		data, err := os.ReadFile(tfvarsPath)
-		if err != nil {
-			continue
-		}
-		var tv map[string]any
-		if err := json.Unmarshal(data, &tv); err != nil {
-			continue
-		}
-		akV, _ := tv["huawei_access_key"].(string)
-		skV, _ := tv["huawei_secret_key"].(string)
-		pidV, _ := tv["huawei_project_id"].(string)
-		regV, _ := tv["huawei_region"].(string)
-		if akV != "" && skV != "" && pidV != "" {
-			ak = akV
-			sk = skV
-			projectID = pidV
-			region = regV
-			if region == "" {
-				region = "me-east-215"
-			}
-			break
-		}
-	}
-	if ak == "" {
+	creds, ok := discoverHuaweiCreds(tofuWorkDir)
+	if !ok {
 		// No huawei deployments on this mothership — nothing to sweep.
 		return 0
 	}
-	cp, perr := providers.Get("huawei")
-	if perr != nil || cp == nil {
-		h.log.Warn("[JANITOR] huawei provider not wired — skipping orphan-EIP sweep", "err", perr)
-		return 0
-	}
-	hp, ok := cp.(*huaweiprovider.Provider)
-	if !ok || hp == nil {
-		h.log.Warn("[JANITOR] huawei provider type assertion failed — skipping orphan-EIP sweep")
+	hp := h.huaweiProvider("orphan-EIP")
+	if hp == nil {
 		return 0
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
@@ -514,7 +604,7 @@ func (h *Handler) cleanOrphanEIPsHuawei(tofuWorkDir string, activeIDs map[string
 	// genuinely-wiped records' leaked infra. See buildActivePrefixes for
 	// the fail-safe-inversion rationale (the b9f9590b self-destruct).
 	activePrefixes := h.buildActivePrefixes()
-	deleted, err := hp.SweepOrphanEIPs(ctx, ak, sk, projectID, region, activePrefixes, func(msg string) {
+	deleted, err := hp.SweepOrphanEIPs(ctx, creds.AK, creds.SK, creds.ProjectID, creds.Region, activePrefixes, janitorDestructive(), func(msg string) {
 		h.log.Info("[JANITOR] " + msg)
 	})
 	if err != nil {
@@ -522,6 +612,23 @@ func (h *Handler) cleanOrphanEIPsHuawei(tofuWorkDir string, activeIDs map[string
 		return deleted
 	}
 	return deleted
+}
+
+// huaweiProvider resolves the wired Huawei provider, logging + returning
+// nil when it is unavailable. Shared by every orphan sweep. `what`
+// labels the log line (e.g. "orphan-EVS").
+func (h *Handler) huaweiProvider(what string) *huaweiprovider.Provider {
+	cp, perr := providers.Get("huawei")
+	if perr != nil || cp == nil {
+		h.log.Warn("[JANITOR] huawei provider not wired — skipping "+what+" sweep", "err", perr)
+		return nil
+	}
+	hp, ok := cp.(*huaweiprovider.Provider)
+	if !ok || hp == nil {
+		h.log.Warn("[JANITOR] huawei provider type assertion failed — skipping " + what + " sweep")
+		return nil
+	}
+	return hp
 }
 
 // cleanOrphanKeypairsHuawei mirrors cleanOrphanEIPsHuawei but for SSH
@@ -539,53 +646,12 @@ func (h *Handler) cleanOrphanEIPsHuawei(tofuWorkDir string, activeIDs map[string
 // prefix. Only a `wiped` record (which SHOULD have no cloud infra) leaves
 // its keypairs reclaimable.
 func (h *Handler) cleanOrphanKeypairsHuawei(tofuWorkDir string, activeIDs map[string]struct{}) int {
-	if tofuWorkDir == "" {
+	creds, ok := discoverHuaweiCreds(tofuWorkDir)
+	if !ok {
 		return 0
 	}
-	entries, err := os.ReadDir(tofuWorkDir)
-	if err != nil {
-		return 0
-	}
-	var ak, sk, projectID, region string
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		tfvarsPath := filepath.Join(tofuWorkDir, e.Name(), "tofu.auto.tfvars.json")
-		data, err := os.ReadFile(tfvarsPath)
-		if err != nil {
-			continue
-		}
-		var tv map[string]any
-		if err := json.Unmarshal(data, &tv); err != nil {
-			continue
-		}
-		akV, _ := tv["huawei_access_key"].(string)
-		skV, _ := tv["huawei_secret_key"].(string)
-		pidV, _ := tv["huawei_project_id"].(string)
-		regV, _ := tv["huawei_region"].(string)
-		if akV != "" && skV != "" && pidV != "" {
-			ak = akV
-			sk = skV
-			projectID = pidV
-			region = regV
-			if region == "" {
-				region = "me-east-215"
-			}
-			break
-		}
-	}
-	if ak == "" {
-		return 0
-	}
-	cp, perr := providers.Get("huawei")
-	if perr != nil || cp == nil {
-		h.log.Warn("[JANITOR] huawei provider not wired — skipping orphan-keypair sweep", "err", perr)
-		return 0
-	}
-	hp, ok := cp.(*huaweiprovider.Provider)
-	if !ok || hp == nil {
-		h.log.Warn("[JANITOR] huawei provider type assertion failed — skipping orphan-keypair sweep")
+	hp := h.huaweiProvider("orphan-keypair")
+	if hp == nil {
 		return 0
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
@@ -593,7 +659,7 @@ func (h *Handler) cleanOrphanKeypairsHuawei(tofuWorkDir string, activeIDs map[st
 	// #4454: protect by DEFAULT (every non-wiped record). See
 	// buildActivePrefixes for the fail-safe-inversion rationale.
 	activePrefixes := h.buildActivePrefixes()
-	deleted, err := hp.SweepOrphanKeypairs(ctx, ak, sk, projectID, region, activePrefixes, func(msg string) {
+	deleted, err := hp.SweepOrphanKeypairs(ctx, creds.AK, creds.SK, creds.ProjectID, creds.Region, activePrefixes, janitorDestructive(), func(msg string) {
 		h.log.Info("[JANITOR] " + msg)
 	})
 	if err != nil {
@@ -618,53 +684,12 @@ func (h *Handler) cleanOrphanKeypairsHuawei(tofuWorkDir string, activeIDs map[st
 // prefix; only a `wiped` record leaves its VPCs reclaimable. Bastion /
 // non-catalyst VPCs are hard-protected in SweepOrphanVPCs itself.
 func (h *Handler) cleanOrphanVPCsHuawei(tofuWorkDir string, activeIDs map[string]struct{}) int {
-	if tofuWorkDir == "" {
+	creds, ok := discoverHuaweiCreds(tofuWorkDir)
+	if !ok {
 		return 0
 	}
-	entries, err := os.ReadDir(tofuWorkDir)
-	if err != nil {
-		return 0
-	}
-	var ak, sk, projectID, region string
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		tfvarsPath := filepath.Join(tofuWorkDir, e.Name(), "tofu.auto.tfvars.json")
-		data, err := os.ReadFile(tfvarsPath)
-		if err != nil {
-			continue
-		}
-		var tv map[string]any
-		if err := json.Unmarshal(data, &tv); err != nil {
-			continue
-		}
-		akV, _ := tv["huawei_access_key"].(string)
-		skV, _ := tv["huawei_secret_key"].(string)
-		pidV, _ := tv["huawei_project_id"].(string)
-		regV, _ := tv["huawei_region"].(string)
-		if akV != "" && skV != "" && pidV != "" {
-			ak = akV
-			sk = skV
-			projectID = pidV
-			region = regV
-			if region == "" {
-				region = "me-east-215"
-			}
-			break
-		}
-	}
-	if ak == "" {
-		return 0
-	}
-	cp, perr := providers.Get("huawei")
-	if perr != nil || cp == nil {
-		h.log.Warn("[JANITOR] huawei provider not wired — skipping orphan-VPC sweep", "err", perr)
-		return 0
-	}
-	hp, ok := cp.(*huaweiprovider.Provider)
-	if !ok || hp == nil {
-		h.log.Warn("[JANITOR] huawei provider type assertion failed — skipping orphan-VPC sweep")
+	hp := h.huaweiProvider("orphan-VPC")
+	if hp == nil {
 		return 0
 	}
 	// VPC cascade teardown (peerings → floating-IPs → subnets → ports →
@@ -675,11 +700,41 @@ func (h *Handler) cleanOrphanVPCsHuawei(tofuWorkDir string, activeIDs map[string
 	// #4454: protect by DEFAULT (every non-wiped record). See
 	// buildActivePrefixes for the fail-safe-inversion rationale.
 	activePrefixes := h.buildActivePrefixes()
-	deleted, err := hp.SweepOrphanVPCs(ctx, ak, sk, projectID, region, activePrefixes, func(msg string) {
+	deleted, err := hp.SweepOrphanVPCs(ctx, creds.AK, creds.SK, creds.ProjectID, creds.Region, activePrefixes, janitorDestructive(), func(msg string) {
 		h.log.Info("[JANITOR] " + msg)
 	})
 	if err != nil {
 		h.log.Warn("[JANITOR] orphan-VPC sweep error", "err", err.Error())
+		return deleted
+	}
+	return deleted
+}
+
+// cleanOrphanEVSHuawei is the detached-EVS-orphan sweep (#4466). A node
+// self-reap BEFORE a wipe strands CSI `pvc-*` volumes — 283 were stranded
+// on b9f9590b as pure quota debt because nothing was left to detach +
+// delete them. EIPs / keypairs / VPCs each already had a project-wide
+// reclaim sweep; detached volumes did not. Same protect-by-default guard
+// (buildActivePrefixes) + same log-only gate (janitorDestructive) as its
+// siblings. Only `status:available`, zero-attachment `pvc-*` volumes that
+// belong to no live dep are eligible.
+func (h *Handler) cleanOrphanEVSHuawei(tofuWorkDir string, activeIDs map[string]struct{}) int {
+	creds, ok := discoverHuaweiCreds(tofuWorkDir)
+	if !ok {
+		return 0
+	}
+	hp := h.huaweiProvider("orphan-EVS")
+	if hp == nil {
+		return 0
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	activePrefixes := h.buildActivePrefixes()
+	deleted, err := hp.SweepOrphanEVS(ctx, creds.AK, creds.SK, creds.ProjectID, creds.Region, activePrefixes, janitorDestructive(), func(msg string) {
+		h.log.Info("[JANITOR] " + msg)
+	})
+	if err != nil {
+		h.log.Warn("[JANITOR] orphan-EVS sweep error", "err", err.Error())
 		return deleted
 	}
 	return deleted

--- a/products/catalyst/bootstrap/api/internal/handler/janitor_reap_protection_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/janitor_reap_protection_test.go
@@ -3,6 +3,8 @@ package handler
 import (
 	"io"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -93,5 +95,108 @@ func TestBuildActivePrefixes_UnknownFutureStatusFailsSafe(t *testing.T) {
 	got := h.buildActivePrefixes()
 	if _, ok := got["deadbeef"]; !ok {
 		t.Fatalf("an unrecognised future status was NOT protected — the inversion must fail SAFE so a new lifecycle state can't reintroduce the b9f9590b self-destruct")
+	}
+}
+
+// TestJanitorDestructive_DefaultsFalse — #4466. The cloud-resource sweeps
+// must default to LOG-ONLY. "deletes prod infra" is opt-in.
+func TestJanitorDestructive_DefaultsFalse(t *testing.T) {
+	t.Setenv("CATALYST_JANITOR_DESTRUCTIVE", "")
+	if janitorDestructive() {
+		t.Fatal("janitorDestructive() must default FALSE (log-only) when the env is unset")
+	}
+	t.Setenv("CATALYST_JANITOR_DESTRUCTIVE", "false")
+	if janitorDestructive() {
+		t.Fatal("janitorDestructive() must be FALSE for explicit =false")
+	}
+	t.Setenv("CATALYST_JANITOR_DESTRUCTIVE", "TRUE")
+	if !janitorDestructive() {
+		t.Fatal("janitorDestructive() must be TRUE for =TRUE (case-insensitive opt-in)")
+	}
+}
+
+// TestJanitorExtraProtectedPrefixes — #4466 explicit active-dep allowlist.
+// Full IDs and 8-char prefixes both collapse to the 8-char protected key.
+func TestJanitorExtraProtectedPrefixes(t *testing.T) {
+	t.Setenv("CATALYST_JANITOR_ACTIVE_DEPLOYMENT_IDS", "b9f9590b558262b6, deadbeef ffffffffaaaa")
+	got := janitorExtraProtectedPrefixes()
+	for _, want := range []string{"b9f9590b", "deadbeef", "ffffffff"} {
+		if _, ok := got[want]; !ok {
+			t.Fatalf("prefix %q missing from explicit allowlist %v", want, got)
+		}
+	}
+	t.Setenv("CATALYST_JANITOR_ACTIVE_DEPLOYMENT_IDS", "")
+	if len(janitorExtraProtectedPrefixes()) != 0 {
+		t.Fatal("empty env must yield no explicit prefixes")
+	}
+}
+
+// TestBuildActivePrefixes_MergesExplicitAllowlist — #4466 belt-and-
+// suspenders. Even when NO in-memory deployment carries a prefix (the worst
+// case: status inference fully regressed / records lost), the explicitly-
+// named live deployment id is still hard-protected.
+func TestBuildActivePrefixes_MergesExplicitAllowlist(t *testing.T) {
+	t.Setenv("CATALYST_JANITOR_ACTIVE_DEPLOYMENT_IDS", "b9f9590b558262b6")
+	h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	// No deployments stored at all — only the explicit allowlist should
+	// drive protection.
+	got := h.buildActivePrefixes()
+	if _, ok := got["b9f9590b"]; !ok {
+		t.Fatal("explicit active-deployment id was NOT protected — the belt-and-suspenders allowlist must hold even with zero in-memory records")
+	}
+}
+
+// TestDiscoverHuaweiCreds_EnvFallback — #4466 cred-source gap. After the
+// last wipe deletes its own tofu.auto.tfvars.json the tfvars walk finds
+// nothing; the sweep must still run by falling back to the
+// huawei-operator-creds Secret env. With an EMPTY tofu dir + the env set,
+// discovery must succeed.
+func TestDiscoverHuaweiCreds_EnvFallback(t *testing.T) {
+	emptyTofu := t.TempDir() // no per-deployment tfvars at all (post-wipe)
+	t.Setenv("CATALYST_HUAWEI_ACCESS_KEY", "ak-env")
+	t.Setenv("CATALYST_HUAWEI_SECRET_KEY", "sk-env")
+	t.Setenv("CATALYST_HUAWEI_PROJECT_ID", "proj-env")
+	t.Setenv("CATALYST_HUAWEI_REGION", "")
+
+	c, ok := discoverHuaweiCreds(emptyTofu)
+	if !ok {
+		t.Fatal("post-wipe sweep must fall back to huawei-operator-creds env when no tfvars survive — got ok=false (the 'no huawei deployments' short-circuit that strands orphans)")
+	}
+	if c.AK != "ak-env" || c.SK != "sk-env" || c.ProjectID != "proj-env" {
+		t.Fatalf("env-fallback creds wrong: %+v", c)
+	}
+	if c.Region != "me-east-215" {
+		t.Fatalf("empty region must default to me-east-215, got %q", c.Region)
+	}
+}
+
+// TestDiscoverHuaweiCreds_TfvarsWins — when a per-deployment tfvars DOES
+// carry creds it is used in preference to the env (the normal path).
+func TestDiscoverHuaweiCreds_TfvarsWins(t *testing.T) {
+	dir := t.TempDir()
+	depDir := filepath.Join(dir, "dep1")
+	if err := os.MkdirAll(depDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	tf := `{"huawei_access_key":"ak-tfvars","huawei_secret_key":"sk-tfvars","huawei_project_id":"proj-tfvars","huawei_region":"me-east-215"}`
+	if err := os.WriteFile(filepath.Join(depDir, "tofu.auto.tfvars.json"), []byte(tf), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CATALYST_HUAWEI_ACCESS_KEY", "ak-env-should-not-win")
+
+	c, ok := discoverHuaweiCreds(dir)
+	if !ok || c.AK != "ak-tfvars" {
+		t.Fatalf("tfvars creds must win over env: ok=%v ak=%q", ok, c.AK)
+	}
+}
+
+// TestDiscoverHuaweiCreds_NoneAvailable — both sources empty → ok=false (a
+// genuine no-Huawei mothership; the sweep correctly no-ops).
+func TestDiscoverHuaweiCreds_NoneAvailable(t *testing.T) {
+	t.Setenv("CATALYST_HUAWEI_ACCESS_KEY", "")
+	t.Setenv("CATALYST_HUAWEI_SECRET_KEY", "")
+	t.Setenv("CATALYST_HUAWEI_PROJECT_ID", "")
+	if _, ok := discoverHuaweiCreds(t.TempDir()); ok {
+		t.Fatal("with neither tfvars nor env creds, discovery must report ok=false")
 	}
 }

--- a/products/catalyst/bootstrap/api/internal/providers/huawei/provider.go
+++ b/products/catalyst/bootstrap/api/internal/providers/huawei/provider.go
@@ -94,8 +94,15 @@ func VPCQuotaPreflight(ctx context.Context, accessKey, secretKey, projectID, reg
 // provisioner.VPCReclaimHook by init() (#4431). Same free-function
 // shape as VPCQuotaPreflight so the provisioner can reclaim leaked VPC
 // quota in-band without importing huawei. Delegates to SweepOrphanVPCs.
+//
+// This is the in-band, provision-time quota-reclaim path (NOT the
+// background janitor), so it passes destructive=true: a fresh prov that
+// hit the VPC cap genuinely needs the leaked orphans gone to make room.
+// The #4466 log-only gate is the background janitor's default; it does not
+// apply to this explicit on-demand reclaim. Protect-by-default
+// (activeDepIDPrefixes) still hard-protects every in-flight dep's VPC.
 func VPCReclaimPreflight(ctx context.Context, accessKey, secretKey, projectID, region string, activeDepIDPrefixes map[string]struct{}, progress func(msg string)) (int, error) {
-	return New().SweepOrphanVPCs(ctx, accessKey, secretKey, projectID, region, activeDepIDPrefixes, progress)
+	return New().SweepOrphanVPCs(ctx, accessKey, secretKey, projectID, region, activeDepIDPrefixes, true, progress)
 }
 
 // Name returns the canonical provider name.
@@ -113,7 +120,12 @@ func regionFromCreds(creds providers.ProviderCreds) string {
 
 // endpointFor returns the per-service endpoint for one call.
 // Pattern: `https://<service>.<region>.kom4dc.nationalcloud.om`.
-func endpointFor(service, region string) string {
+//
+// It is a package var (not a plain func) ONLY so tests can point the HCS
+// service endpoints at a httptest server — production never reassigns it.
+// (#4466: the orphan-sweep log-only/destructive contract is asserted
+// end-to-end against a fake HCS by overriding this.)
+var endpointFor = func(service, region string) string {
 	return fmt.Sprintf("https://%s.%s.kom4dc.nationalcloud.om", service, region)
 }
 
@@ -1768,7 +1780,15 @@ func deleteEIP(ctx context.Context, client *http.Client, hw hwCreds, region, id 
 // Intended caller: the periodic janitor (handler/janitor.go). Idempotent
 // + safe to run during active provisioning: bound EIPs (port_id set)
 // AND active EIPs (status=ACTIVE/BOUND) are never touched.
-func (p *Provider) SweepOrphanEIPs(ctx context.Context, ak, sk, projectID, region string, activeDepIDPrefixes map[string]struct{}, progress func(msg string)) (int, error) {
+//
+// #4466 — LOG-ONLY GATE. `destructive` defaults FALSE (the janitor only
+// flips it true when CATALYST_JANITOR_DESTRUCTIVE=true). While false the
+// sweep LOGS exactly the EIP it WOULD reap (`would-reap (log-only)`) but
+// performs NO delete — so "deletes prod infra" is opt-in, not the default.
+// The b9f9590b self-reap would have been caught in this log-only window
+// before any node died. The return value is the count of would-reap (or
+// actually-reaped, when destructive) EIPs.
+func (p *Provider) SweepOrphanEIPs(ctx context.Context, ak, sk, projectID, region string, activeDepIDPrefixes map[string]struct{}, destructive bool, progress func(msg string)) (int, error) {
 	if progress == nil {
 		progress = func(string) {}
 	}
@@ -1825,6 +1845,13 @@ func (p *Provider) SweepOrphanEIPs(ctx context.Context, ak, sk, projectID, regio
 				continue
 			}
 		}
+		if !destructive {
+			// #4466 log-only: count it so the operator sees the volume the
+			// destructive pass WOULD reclaim, but delete nothing.
+			progress(fmt.Sprintf("sweep orphan EIP %s (bw=%s): would-reap (log-only; set CATALYST_JANITOR_DESTRUCTIVE=true to act)", e.Address, e.BandwidthName))
+			deleted++
+			continue
+		}
 		if err := deleteEIP(ctx, client, hw, region, e.ID); err != nil {
 			progress(fmt.Sprintf("sweep orphan EIP %s (bw=%s): DELETE failed: %v", e.Address, e.BandwidthName, err))
 			continue
@@ -1854,7 +1881,10 @@ func (p *Provider) SweepOrphanEIPs(ctx context.Context, ak, sk, projectID, regio
 // of 8-char prefixes of in-flight deployment IDs (status one of
 // pending / provisioning / tofu-applying / flux-bootstrapping /
 // phase1-watching / wiping). Empty = no protection (post-wipe sweep).
-func (p *Provider) SweepOrphanKeypairs(ctx context.Context, ak, sk, projectID, region string, activeDepIDPrefixes map[string]struct{}, progress func(msg string)) (int, error) {
+//
+// #4466: `destructive` gates the real delete (default false → log-only
+// `would-reap`). See SweepOrphanEIPs for the rationale.
+func (p *Provider) SweepOrphanKeypairs(ctx context.Context, ak, sk, projectID, region string, activeDepIDPrefixes map[string]struct{}, destructive bool, progress func(msg string)) (int, error) {
 	if progress == nil {
 		progress = func(string) {}
 	}
@@ -1912,6 +1942,11 @@ func (p *Provider) SweepOrphanKeypairs(ctx context.Context, ak, sk, projectID, r
 				continue
 			}
 		}
+		if !destructive {
+			progress(fmt.Sprintf("sweep orphan keypair %s: would-reap (log-only; set CATALYST_JANITOR_DESTRUCTIVE=true to act)", name))
+			deleted++
+			continue
+		}
 		delURL := fmt.Sprintf("%s/%s", listURL, name)
 		_, dstatus, derr := doSignedRequest(client, hw, http.MethodDelete, delURL, nil)
 		if derr != nil {
@@ -1967,7 +2002,12 @@ func (p *Provider) SweepOrphanKeypairs(ctx context.Context, ak, sk, projectID, r
 // during active provisioning.
 //
 // Returns the count of VPCs deleted.
-func (p *Provider) SweepOrphanVPCs(ctx context.Context, ak, sk, projectID, region string, activeDepIDPrefixes map[string]struct{}, progress func(msg string)) (int, error) {
+//
+// #4466: `destructive` gates the cascade teardown (default false →
+// log-only `would-reap`). VPC reaping cascade-deleted the live dep's
+// peering/EIPs on b9f9590b, so the log-only window matters most here. See
+// SweepOrphanEIPs for the rationale.
+func (p *Provider) SweepOrphanVPCs(ctx context.Context, ak, sk, projectID, region string, activeDepIDPrefixes map[string]struct{}, destructive bool, progress func(msg string)) (int, error) {
 	if progress == nil {
 		progress = func(string) {}
 	}
@@ -1997,6 +2037,11 @@ func (p *Provider) SweepOrphanVPCs(ctx context.Context, ak, sk, projectID, regio
 			if v.Name != "" && strings.HasPrefix(v.Name, "catalyst-") {
 				progress(fmt.Sprintf("sweep orphan VPC %s: skipped (active deployment)", v.Name))
 			}
+			continue
+		}
+		if !destructive {
+			progress(fmt.Sprintf("sweep orphan VPC %s: would-reap (log-only; set CATALYST_JANITOR_DESTRUCTIVE=true to act)", v.Name))
+			deleted++
 			continue
 		}
 		// Delete any peering pinning this VPC before the cascade, else
@@ -2037,6 +2082,134 @@ func isReclaimableOrphanVPC(name string, activeDepIDPrefixes map[string]struct{}
 		}
 	}
 	return true
+}
+
+// hwEVSVolume is the subset of the EVS list response the orphan sweep
+// reads. `Attachments` carries the server bindings (empty when detached);
+// `Metadata` is the free-form map the CSI driver stamps (it carries the
+// owning cluster ID under keys like `cluster_id` / the PV's namespace).
+type hwEVSVolume struct {
+	ID          string            `json:"id"`
+	Name        string            `json:"name"`
+	Status      string            `json:"status"`
+	Attachments []map[string]any  `json:"attachments"`
+	Metadata    map[string]string `json:"metadata"`
+}
+
+// isReclaimableOrphanEVS is the pure match/protection predicate for the
+// detached-EVS-orphan sweep (#4466). Node self-reap BEFORE a wipe (the
+// b9f9590b incident) strands CSI `pvc-*` volumes — 283 were stranded as
+// pure quota debt because nothing detaches+deletes them once the node is
+// gone. The provider had EIP/keypair/VPC reclaim sweeps but no
+// detached-volume sweep; this closes the last quota-debt fault.
+//
+// A volume is reclaimable when ALL of:
+//   - name carries the CSI `pvc-` prefix (so we ONLY ever touch
+//     Kubernetes-provisioned PV volumes, never a bastion / operator-owned
+//     system disk),
+//   - it is genuinely detached: status=="available" AND zero attachments
+//     (an in-use / attaching / creating volume is NEVER swept — same
+//     protect-the-live-resource posture as the bound-EIP guard),
+//   - its owning-cluster metadata carries NONE of the in-flight
+//     deployment-ID 8-char prefixes (so a live cluster's PVCs are never
+//     reaped; protect-by-default — a volume whose metadata matches an
+//     active dep is protected even though it is momentarily detached).
+//
+// Bastion volumes never carry the `pvc-` prefix, so the prefix filter
+// alone hard-protects them; the explicit bastion substring guard is a
+// belt-and-suspenders second layer.
+func isReclaimableOrphanEVS(name, status string, attachmentCount int, metadata map[string]string, activeDepIDPrefixes map[string]struct{}) bool {
+	if name == "" {
+		return false
+	}
+	// Hard-protect anything that is not a CSI-provisioned PV, and any
+	// bastion-named volume (defence-in-depth — a `pvc-`-named volume can't
+	// be the bastion, but the check costs nothing).
+	if strings.Contains(name, "bastion") || !strings.HasPrefix(name, "pvc-") {
+		return false
+	}
+	// Only sweep genuinely-detached volumes. An attached / attaching /
+	// creating / deleting volume is live and must never be reaped.
+	if status != "available" || attachmentCount > 0 {
+		return false
+	}
+	// Protect-by-default: if the volume's owning-cluster metadata carries
+	// any in-flight deployment-ID prefix, it belongs to a live env (its
+	// node may merely be momentarily detached during a roll) — protect it.
+	for _, v := range metadata {
+		for prefix := range activeDepIDPrefixes {
+			if v != "" && strings.Contains(v, prefix) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// SweepOrphanEVS lists every EVS volume in the HCS project and reclaims
+// detached CSI `pvc-*` volumes that belong to no in-flight deployment
+// (#4466). It is the volume-tier sibling of SweepOrphanEIPs / Keypairs /
+// VPCs: the per-deployment Wipe tears down volumes via the cluster's CSI
+// controller, but a node self-reap BEFORE the wipe leaves the volumes
+// orphaned with no controller left to detach+delete them — 283 piled up
+// on b9f9590b as pure quota debt.
+//
+// Match + protection live in isReclaimableOrphanEVS (pure, unit-testable).
+// `destructive` gates the real delete (default false → log-only
+// `would-reap`), identical to the sibling sweeps. activeDepIDPrefixes is
+// the protect-by-default set of in-flight deployment-ID 8-char prefixes.
+// Returns the count of volumes reaped (or would-reap, in log-only mode).
+// Idempotent + safe to run during active provisioning.
+func (p *Provider) SweepOrphanEVS(ctx context.Context, ak, sk, projectID, region string, activeDepIDPrefixes map[string]struct{}, destructive bool, progress func(msg string)) (int, error) {
+	if progress == nil {
+		progress = func(string) {}
+	}
+	hw := hwCreds{AccessKey: ak, SecretKey: sk, ProjectID: projectID}
+	client := httpClientFor(providers.ProviderCreds{Raw: map[string]string{"region": region}})
+
+	// EVS detail list — /v2/{project}/cloudvolumes/detail returns name,
+	// status, attachments and metadata in one call.
+	listURL := fmt.Sprintf("%s/v2/%s/cloudvolumes/detail", endpointFor("evs", region), projectID)
+	resp, status, err := doSignedRequest(client, hw, http.MethodGet, listURL, nil)
+	if err != nil {
+		return 0, fmt.Errorf("list volumes: %w", err)
+	}
+	if status >= 400 {
+		return 0, fmt.Errorf("list volumes: status %d: %s", status, snippet(resp, 240))
+	}
+	var decoded struct {
+		Volumes []hwEVSVolume `json:"volumes"`
+	}
+	if err := json.Unmarshal(resp, &decoded); err != nil {
+		return 0, fmt.Errorf("decode volumes: %w", err)
+	}
+	deleted := 0
+	for _, v := range decoded.Volumes {
+		if !isReclaimableOrphanEVS(v.Name, v.Status, len(v.Attachments), v.Metadata, activeDepIDPrefixes) {
+			if strings.HasPrefix(v.Name, "pvc-") {
+				progress(fmt.Sprintf("sweep orphan EVS %s (status=%s, attachments=%d): skipped (in-use or active deployment)", v.Name, v.Status, len(v.Attachments)))
+			}
+			continue
+		}
+		if !destructive {
+			progress(fmt.Sprintf("sweep orphan EVS %s (status=%s): would-reap (log-only; set CATALYST_JANITOR_DESTRUCTIVE=true to act)", v.Name, v.Status))
+			deleted++
+			continue
+		}
+		delURL := fmt.Sprintf("%s/v2/%s/cloudvolumes/%s", endpointFor("evs", region), projectID, v.ID)
+		_, dstatus, derr := doSignedRequest(client, hw, http.MethodDelete, delURL, nil)
+		if derr != nil {
+			progress(fmt.Sprintf("sweep orphan EVS %s: DELETE failed: %v", v.Name, derr))
+			continue
+		}
+		if dstatus >= 400 && dstatus != http.StatusNotFound {
+			progress(fmt.Sprintf("sweep orphan EVS %s: DELETE status %d", v.Name, dstatus))
+			continue
+		}
+		progress(fmt.Sprintf("sweep orphan EVS %s: deleted", v.Name))
+		deleted++
+	}
+	return deleted, nil
 }
 
 // deleteVPCPeeringsTouching removes every VPC peering whose requester or

--- a/products/catalyst/bootstrap/api/internal/providers/huawei/sweep_orphan_evs_test.go
+++ b/products/catalyst/bootstrap/api/internal/providers/huawei/sweep_orphan_evs_test.go
@@ -1,0 +1,245 @@
+package huawei
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// fakeHCSEVS stands up a httptest server that mimics the EVS detail-list +
+// per-volume DELETE endpoints, overrides the package `endpointFor` to route
+// at it, and records every DELETE'd volume ID. Returns a restore func.
+func fakeHCSEVS(t *testing.T, listBody string, deleted *[]string) func() {
+	t.Helper()
+	var mu sync.Mutex
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/cloudvolumes/detail"):
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(listBody))
+		case r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/cloudvolumes/"):
+			mu.Lock()
+			parts := strings.Split(strings.TrimRight(r.URL.Path, "/"), "/")
+			*deleted = append(*deleted, parts[len(parts)-1])
+			mu.Unlock()
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	host := strings.TrimPrefix(srv.URL, "https://")
+	orig := endpointFor
+	endpointFor = func(service, region string) string { return "https://" + host }
+	return func() {
+		endpointFor = orig
+		srv.Close()
+	}
+}
+
+// evsListFixture: one stranded orphan + one in-use + one bastion disk.
+const evsListFixture = `{"volumes":[
+  {"id":"vol-orphan-1","name":"pvc-aaaa-orphan","status":"available","attachments":[],"metadata":{}},
+  {"id":"vol-inuse-2","name":"pvc-bbbb-inuse","status":"in-use","attachments":[{"server_id":"s1"}],"metadata":{}},
+  {"id":"vol-bastion-3","name":"bastion-openova-root","status":"available","attachments":[],"metadata":{}}
+]}`
+
+// TestSweepOrphanEVS_LogOnlyReapsNothing — #4466 key contract. With
+// destructive=false the sweep must issue ZERO deletes (log-only) even
+// though one volume is a genuine orphan. The returned count reflects the
+// would-reap so an operator sees what the destructive pass would do.
+func TestSweepOrphanEVS_LogOnlyReapsNothing(t *testing.T) {
+	var deleted []string
+	restore := fakeHCSEVS(t, evsListFixture, &deleted)
+	defer restore()
+
+	p := New()
+	n, err := p.SweepOrphanEVS(context.Background(), "ak", "sk", "proj", "me-east-215",
+		map[string]struct{}{}, false /*destructive*/, nil)
+	if err != nil {
+		t.Fatalf("SweepOrphanEVS: %v", err)
+	}
+	if len(deleted) != 0 {
+		t.Fatalf("log-only mode issued %d DELETE(s) (%v) — must delete NOTHING", len(deleted), deleted)
+	}
+	if n != 1 {
+		t.Fatalf("would-reap count = %d, want 1 (the single genuine orphan)", n)
+	}
+}
+
+// TestSweepOrphanEVS_DestructiveReapsOrphanOnly — with the flag armed the
+// sweep deletes ONLY the genuine orphan; the in-use + bastion volumes are
+// never touched.
+func TestSweepOrphanEVS_DestructiveReapsOrphanOnly(t *testing.T) {
+	var deleted []string
+	restore := fakeHCSEVS(t, evsListFixture, &deleted)
+	defer restore()
+
+	p := New()
+	n, err := p.SweepOrphanEVS(context.Background(), "ak", "sk", "proj", "me-east-215",
+		map[string]struct{}{}, true /*destructive*/, nil)
+	if err != nil {
+		t.Fatalf("SweepOrphanEVS: %v", err)
+	}
+	if n != 1 || len(deleted) != 1 || deleted[0] != "vol-orphan-1" {
+		t.Fatalf("destructive sweep deleted=%v (n=%d), want exactly [vol-orphan-1]", deleted, n)
+	}
+}
+
+// TestSweepOrphanEVS_ActiveDepNeverReaped — a detached orphan whose
+// metadata carries an in-flight deployment-ID prefix is protected EVEN with
+// the destructive flag set.
+func TestSweepOrphanEVS_ActiveDepNeverReaped(t *testing.T) {
+	listBody := fmt.Sprintf(`{"volumes":[
+	  {"id":"vol-live-1","name":"pvc-live","status":"available","attachments":[],"metadata":{"cluster_id":"catalyst-x-%s-cluster"}}
+	]}`, "5b413990")
+	var deleted []string
+	restore := fakeHCSEVS(t, listBody, &deleted)
+	defer restore()
+
+	p := New()
+	n, err := p.SweepOrphanEVS(context.Background(), "ak", "sk", "proj", "me-east-215",
+		map[string]struct{}{"5b413990": {}}, true /*destructive*/, nil)
+	if err != nil {
+		t.Fatalf("SweepOrphanEVS: %v", err)
+	}
+	if n != 0 || len(deleted) != 0 {
+		t.Fatalf("active-dep volume was reaped (deleted=%v, n=%d) — must be protected regardless of flag", deleted, n)
+	}
+}
+
+// TestIsReclaimableOrphanEVS locks the #4466 detached-EVS-orphan
+// match/protection contract:
+//   - only CSI `pvc-*` volumes are ever in scope (system / bastion disks
+//     never carry that prefix → hard-protected),
+//   - only genuinely-detached volumes (status=available + zero
+//     attachments) are eligible (an in-use / attaching volume is live),
+//   - protect-by-default: a volume whose owning-cluster metadata carries an
+//     in-flight deployment-ID prefix is protected even when momentarily
+//     detached.
+func TestIsReclaimableOrphanEVS(t *testing.T) {
+	// One in-flight deployment protected by its 8-char ID prefix.
+	active := map[string]struct{}{
+		"5b413990": {},
+	}
+
+	cases := []struct {
+		name        string
+		vol         string
+		status      string
+		attachments int
+		metadata    map[string]string
+		want        bool
+	}{
+		// Reclaimable: detached CSI volume, no active-dep metadata.
+		{
+			name:        "stranded detached pvc from a self-reaped node",
+			vol:         "pvc-aaaaaaaa-1111-2222-3333-444444444444",
+			status:      "available",
+			attachments: 0,
+			metadata:    map[string]string{"cluster_id": "wiped-cluster-aabbccdd"},
+			want:        true,
+		},
+		{
+			name:        "detached pvc with no metadata at all",
+			vol:         "pvc-bbbbbbbb-1111-2222-3333-444444444444",
+			status:      "available",
+			attachments: 0,
+			metadata:    nil,
+			want:        true,
+		},
+
+		// Protected: in-use / non-detached volume must never be swept.
+		{
+			name:        "in-use attached pvc",
+			vol:         "pvc-cccccccc-1111-2222-3333-444444444444",
+			status:      "in-use",
+			attachments: 1,
+			metadata:    nil,
+			want:        false,
+		},
+		{
+			name:        "available status but still carries an attachment",
+			vol:         "pvc-dddddddd-1111-2222-3333-444444444444",
+			status:      "available",
+			attachments: 1,
+			metadata:    nil,
+			want:        false,
+		},
+		{
+			name:        "mid-attach (creating) volume",
+			vol:         "pvc-eeeeeeee-1111-2222-3333-444444444444",
+			status:      "creating",
+			attachments: 0,
+			metadata:    nil,
+			want:        false,
+		},
+
+		// Protected: belongs to a live deployment (metadata prefix match).
+		{
+			name:        "detached but owned by an in-flight dep (node mid-roll)",
+			vol:         "pvc-ffffffff-1111-2222-3333-444444444444",
+			status:      "available",
+			attachments: 0,
+			metadata:    map[string]string{"cluster_id": "catalyst-omantel-biz-5b413990-cluster"},
+			want:        false,
+		},
+
+		// Hard-protected: not a CSI volume / bastion.
+		{
+			name:        "bastion system disk",
+			vol:         "bastion-openova-root",
+			status:      "available",
+			attachments: 0,
+			metadata:    nil,
+			want:        false,
+		},
+		{
+			name:        "catalyst control-plane root disk (not a pvc-)",
+			vol:         "catalyst-omantel-biz-aabbccdd-cp-root",
+			status:      "available",
+			attachments: 0,
+			metadata:    nil,
+			want:        false,
+		},
+		{
+			name:        "empty name",
+			vol:         "",
+			status:      "available",
+			attachments: 0,
+			metadata:    nil,
+			want:        false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isReclaimableOrphanEVS(tc.vol, tc.status, tc.attachments, tc.metadata, active)
+			if got != tc.want {
+				t.Fatalf("isReclaimableOrphanEVS(%q, %q, %d) = %v, want %v",
+					tc.vol, tc.status, tc.attachments, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsReclaimableOrphanEVS_NoActiveProvs proves the post-wipe sweep
+// (empty active set) reclaims every detached pvc-* while still hard-
+// protecting in-use volumes and non-CSI / bastion disks.
+func TestIsReclaimableOrphanEVS_NoActiveProvs(t *testing.T) {
+	empty := map[string]struct{}{}
+	if !isReclaimableOrphanEVS("pvc-stranded-vol", "available", 0, nil, empty) {
+		t.Fatal("with no in-flight provs every detached pvc- volume must be reclaimable")
+	}
+	if isReclaimableOrphanEVS("pvc-stranded-vol", "in-use", 1, nil, empty) {
+		t.Fatal("an in-use volume must stay protected even with an empty active set")
+	}
+	if isReclaimableOrphanEVS("bastion-openova-root", "available", 0, nil, empty) {
+		t.Fatal("a bastion disk must stay protected even with an empty active set")
+	}
+}


### PR DESCRIPTION
## Durable janitor hardening — #4466 follow-up to the self-reap P0

Implements the defense-in-depth committed in the post-mortem
(`docs/sessions/2026-06-26/postmortem-janitor-self-reap.md`). #4457 already
fixed the immediate fault (allowlist→denylist inversion so non-wiped deps
are protected). This adds the layers that make it structurally impossible
for an infra-deleting janitor to reap a live env again.

The b9f9590b incident: all 12 ECS nodes DELETED ~2.5 min after convergence,
because the cloud-resource sweeps actually delete on every pass with no
opt-in gate and only status-inference protection.

### Seams added (in `janitor.go` + `huawei/provider.go`)

1. **Log-only / dry-run gate (the key one)** — the three cloud sweeps
   (EIPs/keypairs/VPCs) + the new EVS sweep default to LOG-ONLY: each pass
   logs exactly what it WOULD reap (`would-reap (log-only)`) but deletes
   nothing until `CATALYST_JANITOR_DESTRUCTIVE=true` is explicitly set.
   "Deletes prod infra" is now opt-in. The in-band provision-time VPC
   reclaim hook keeps `destructive=true` (it is the explicit on-demand
   quota-reclaim path, not the background janitor).

2. **Explicit active-deployment do-not-touch allowlist** —
   `CATALYST_JANITOR_ACTIVE_DEPLOYMENT_IDS` hard-excludes the named live
   deployment id(s) from every delete path, merged into
   `buildActivePrefixes`. Belt-and-suspenders over the status denylist:
   holds even if status inference fully regresses.

3. **Cred-source fallback** — the post-wipe sweep short-circuited to "no
   huawei deployments" because the wipe deletes the dep's
   `tofu.auto.tfvars.json` (the only cred source the tfvars-walk knew).
   `discoverHuaweiCreds` now falls back to the `huawei-operator-creds`
   Secret env, so the sweep still runs after the last wipe and reclaims the
   stranded orphans.

4. **Standalone detached-EVS-orphan sweep** — node self-reap before a wipe
   strands CSI `pvc-*` volumes (283 on b9f9590b) as quota debt with no
   controller left to detach+delete them. `SweepOrphanEVS` reclaims only
   `status=available`, zero-attachment `pvc-*` volumes owned by no live dep
   (same protect-by-default guard + same log-only gate).

### Tests

`endpointFor` made an overridable package var so the log-only/destructive
contract runs end-to-end against a fake HCS server. Coverage:

- log-only mode reaps nothing (zero DELETEs, only logs);
- destructive flag + a genuine (wiped-prefix) orphan → eligible;
- active-dep prefix → never eligible regardless of the flag;
- EVS sweep skips bastion / attached / non-orphan volumes;
- cred env-fallback after the tfvars vanish; tfvars-wins; none-available no-op;
- explicit-allowlist merge holds with zero in-memory records.

`go build ./...` + `go vet` + the huawei + handler suites green.

### Verification posture

This is mothership-image code; live-verify is deferred to the next
prov-lifecycle (founder direction). The durable merge ships now; the new
default is FAIL-SAFE (log-only), so even unverified it cannot delete infra.

Refs #4466 #4454

🤖 Generated with [Claude Code](https://claude.com/claude-code)