### PR TITLE
fix(bp-agenity): default imagePullSecrets to ghcr-pull — kill per-Org Init:ImagePullBackOff (0.5.13)

### DIFF
--- a/products/agenity/blueprint.yaml
+++ b/products/agenity/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.5.12
+  version: 0.5.13
   card:
     title: Agenity
     summary: |

--- a/products/agenity/chart/Chart.yaml
+++ b/products/agenity/chart/Chart.yaml
@@ -8,6 +8,22 @@ description: |
   (RBAC-scoped to the User's rights) to create more Applications in the
   User's own Organization — the north-star self-service journey.
 type: application
+# 0.5.12 -> 0.5.13 (#4111): default `imagePullSecrets` to `[{name: ghcr-pull}]`
+# so EVERY image-pulling Pod (the seed-claude-creds init container AND the
+# chepherd main container) references the reflected ghcr-pull dockerconfigjson
+# Secret. The agenity image is a PRIVATE ghcr.io/openova-io/* package, so an
+# anonymous pull 401s. The Sovereign emberstack-reflector already reflects
+# `ghcr-pull` into every per-Org `org-*`/pool namespace, but a reflected Secret
+# is INERT unless the Pod spec references it — with the prior empty default the
+# StatefulSet rendered `imagePullSecrets: []` and the Pod wedged at
+# Init:ImagePullBackOff on a fresh Org (live root-cause on the omantel.biz demo
+# Org `uatwalk91` namespace 2026-06-27: pod agenity-rtz-a-bp-agenity-0 0/1
+# Init:ImagePullBackOff with ghcr-pull PRESENT in the ns — the missing piece was
+# the pod-spec reference, exactly the reflected-secret-is-inert trap). The
+# per-Org install pins `*` so this re-reconciles live via Flux; no fresh prov
+# needed for the chart-level half. Values-only change; chart templates already
+# render `{{- with .Values.imagePullSecrets }}` (no template edit). appVersion
+# (dashboard image) stays 0.9.7 — image bytes UNCHANGED.
 # 0.5.11 -> 0.5.12 (#4362, #4325 fallout): declare manifests.helmRelease.
 # disableWait=true so the application-controller stamps install.disableWait +
 # upgrade.disableWait on the rendered HR. The large agenity image (appVersion
@@ -108,7 +124,7 @@ type: application
 # `ingress` entity that no K8s NetworkPolicy can admit — without the CNP every
 # external hit to agenity.<slug>.<pool> returned envoy 503 "upstream connect
 # error". appVersion (dashboard image) stays 0.9.6 — image bytes unchanged.
-version: 0.5.12
+version: 0.5.13
 # Bumped appVersion 0.9.6 -> 0.9.7 (#4180): 0.9.7 is the FIRST image whose
 # /app/ mounts the WORKSPACES dashboard (Dashboardws bundle) rather than the
 # archaic single-column Dashboard.svelte. It is built from agenity#752

--- a/products/agenity/chart/values.yaml
+++ b/products/agenity/chart/values.yaml
@@ -24,7 +24,23 @@ image:
   tag: ""                 # defaults to .Chart.AppVersion
   pullPolicy: IfNotPresent
 
-imagePullSecrets: []
+# ── Private-registry pull secret (#4111) ──────────────────────────────────
+# The agenity image (`ghcr.io/openova-io/bp-agenity`) is a PRIVATE
+# ghcr.io/openova-io/* package, so both the seed-claude-creds init container
+# and the chepherd main container must pull it WITH credentials. The Sovereign
+# emberstack-reflector reflects a `ghcr-pull` dockerconfigjson Secret into
+# every per-Org `org-*` / pool namespace, but a reflected Secret is INERT
+# unless the Pod spec references it — without this default the StatefulSet
+# rendered `imagePullSecrets: []`, the Pod pulled anonymously, ghcr returned
+# 401, and the Pod wedged at Init:ImagePullBackOff on a fresh Org (live on the
+# omantel.biz demo Org `uatwalk91` namespace, 2026-06-27: pod
+# agenity-rtz-a-bp-agenity-0 0/1 Init:ImagePullBackOff while `ghcr-pull` WAS
+# reflected into the ns — the missing piece was the pod-spec reference).
+# Defaulting to `ghcr-pull` makes both containers reference the already-
+# reflected Secret so the private image pulls. An install into a Sovereign
+# that mirrors the image into a public/custom registry can override this list.
+imagePullSecrets:
+  - name: ghcr-pull
 
 # ── Solo-agent profile ────────────────────────────────────────────────────
 # chepherd boots with a single solo worker agent the User chats with. The

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5952,8 +5952,8 @@ spec:
 # with the built-in solo agent (Claude Opus 4.7, token pre-configured), and
 # the agent creates more Applications in the User's Org via the RBAC-scoped
 # openova MCP. The north-star self-service journey (UAT rows 218-223).
-# Lockstep with products/agenity/chart/Chart.yaml version 0.5.12 + the
-# published chart ghcr.io/openova-io/bp-agenity:0.5.12 (appVersion 0.9.7 — the
+# Lockstep with products/agenity/chart/Chart.yaml version 0.5.13 + the
+# published chart ghcr.io/openova-io/bp-agenity:0.5.13 (appVersion 0.9.7 — the
 # image whose /app mounts the WORKSPACES dashboard rather than the archaic
 # single-column one, built from agenity#752, #4180). 0.5.10 (#4362, #4325
 # fallout) flips the topology singleton placement.tier `rtz` -> '' (host-native)
@@ -5980,7 +5980,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.5.12"
+  version: "0.5.13"
   visibility: listed
   card:
     title: "Agenity"


### PR DESCRIPTION
## Problem (live, dep `91dc05917e44d1c1` / omantel.biz, Org `uatwalk91`)

The per-Org bp-agenity pod wedges at `Init:ImagePullBackOff` pulling the **private** `ghcr.io/openova-io/bp-agenity:0.9.7` image:

```
uatwalk91  agenity-rtz-a-bp-agenity-0  0/1  Init:ImagePullBackOff  (x565 over 134m)
```

## Root cause — reflected-secret-is-inert (pod-spec gap, NOT a reflection gap)

The chart's StatefulSet already renders `imagePullSecrets` via `{{- with .Values.imagePullSecrets }}`, but `values.yaml` defaulted it to `[]`. So both the `seed-claude-creds` init container and the `chepherd` main container pulled the **private** image **anonymously** → ghcr 401 → `ImagePullBackOff`.

The `ghcr-pull` dockerconfigjson Secret **IS reflected** into the Org namespace (verified present, 3h51m old) — the emberstack reflector works. The missing piece was the **pod-spec reference**: a reflected Secret is inert unless the Pod references it. Confirmed against a working ghcr-pulling pod in another ns:

```
newapi-bp-newapi-...  pullSecrets=[{"name":"ghcr-pull"}]   # works
agenity-rtz-a-...     pullSecrets=                          # empty → backoff
```

## Fix

Default `values.yaml` `imagePullSecrets` to `[{name: ghcr-pull}]`. One pod-level entry covers every container in the pod, so init + main both pull with credentials. `helm template` confirms it renders before both `initContainers` and `containers` (default + credentialsKey modes); `helm lint` clean.

## Rolls live vs roll-gated

**Rolls LIVE.** The per-Org install pins `*`, so once `bp-agenity:0.5.13` publishes the per-Org HelmRelease auto-resolves it and Flux re-reconciles the StatefulSet with the pull secret — no fresh prov needed. Chart `0.5.12`→`0.5.13` + `blueprint.yaml` + catalog-seed pins bumped in lockstep. appVersion (image) stays `0.9.7` — image bytes unchanged, no rebuild.

## What remains OPEN on #4111

The agentic-run half — supplying a real Anthropic OAuth `credentials.json` and proving a spawned claude-code agent authenticates end-to-end — is gated on a credential not available to this session and stays OPEN. This PR fixes ONLY the image-pull fault.

Refs #4111

🤖 Generated with [Claude Code](https://claude.com/claude-code)