### PR TITLE
fix(org-controller): render gateway/apiserver CNP host-side for vcluster-tier Orgs + reflector-source pool-DNS fallback (Refs #4475)

### DIFF
--- a/core/controllers/organization/cmd/main.go
+++ b/core/controllers/organization/cmd/main.go
@@ -175,6 +175,18 @@ func main() {
 			poolPowerDNSSecretNS = "catalyst-system"
 		}
 	}
+	// #4475 §2 SELF-HEAL — the reflector SOURCE secret the bridged destination
+	// above is filled FROM. bp-reflector only re-emits into the destination on a
+	// reconcile cycle AFTER the source exists; on a fresh prov the source is
+	// created LATE (cert-manager DNS-01 solver) and the reflector can fail to
+	// re-scan after the late source-create, leaving the bridged destination empty
+	// INDEFINITELY. These two name the SOURCE so the reconciler can read the key
+	// DIRECTLY from it as a last-resort fallback — sidestepping a stuck reflector.
+	// Defaults match the #4218 chart PULL-stub source
+	// (`cert-manager/powerdns-api-credentials`). Per Inviolable Principle #4, both
+	// env-overridable.
+	poolPowerDNSSourceSecretName := envOr("CATALYST_POOL_POWERDNS_SOURCE_SECRET_NAME", "powerdns-api-credentials")
+	poolPowerDNSSourceSecretNS := envOr("CATALYST_POOL_POWERDNS_SOURCE_SECRET_NAMESPACE", "cert-manager")
 	// tenantConsoleLBIPv4 — the dedicated console-ELB EIP (#4053) the per-Org
 	// console host resolves to. tenantPrimaryLBIPv4 — the primary/shared LB IP
 	// fallback for a single-LB / pre-#4053 Sovereign. Both empty → the write is
@@ -236,43 +248,45 @@ func main() {
 	}
 
 	r := &controller.Reconciler{
-		Client:                      mgr.GetClient(),
-		Log:                         log.WithName("reconciler"),
-		Keycloak:                    controller.NewLiveKeycloak(kcAddr, kcRealm, kcSAID, kcSASecret),
-		PerOrgRealmEnabled:          perOrgRealmEnabled,
-		GiteaClient:                 giteaClient,
-		HostCluster:                 hostCluster,
-		EnvRegionProvider:           envRegionProvider,
-		EnvRegionCode:               envRegionCode,
-		EnvRegionBuildingBlock:      envRegionBuildingBlock,
-		VClusterChartVersion:        chartVer,
-		VClusterHelmRepoName:        helmRepoName,
-		VClusterHelmRepoNamespace:   helmRepoNs,
-		VClusterImageRegistry:       vclusterImageRegistry,
-		Branch:                      branch,
-		GiteaInClusterURL:           giteaInClusterURL,
-		FluxNamespace:               fluxNamespace,
-		FluxIntervalSeconds:         fluxIntervalSeconds,
-		FluxGiteaSecretRef:          fluxGiteaSecretRef,
-		FederationSecretNamespace:   fedSecretNs,
-		UserAccessNamespace:         uaNs,
-		IacBootstrapGitea:           iacGitea,
-		IacBootstrapTokens:          iacTokens,
-		ConsoleGatewayName:          consoleGatewayName,
-		ConsoleGatewayNamespace:     consoleGatewayNs,
-		ConsoleTLSClusterIssuer:     consoleTLSIssuer,
-		ConsoleTLSCertNamespace:     consoleTLSCertNs,
-		ConsoleRouteNamespace:       consoleRouteNs,
-		ConsoleAPIService:           consoleAPISvc,
-		ConsoleUIService:            consoleUISvc,
-		ConsoleAPIPort:              consoleAPIPort,
-		ConsoleUIPort:               consoleUIPort,
-		PoolPowerDNSURL:             poolPowerDNSURL,
-		PoolPowerDNSAPIKey:          poolPowerDNSAPIKey,
-		PoolPowerDNSSecretName:      poolPowerDNSSecretName,
-		PoolPowerDNSSecretNamespace: poolPowerDNSSecretNS,
-		TenantConsoleLBIPv4:         tenantConsoleLBIPv4,
-		TenantPrimaryLBIPv4:         tenantPrimaryLBIPv4,
+		Client:                            mgr.GetClient(),
+		Log:                               log.WithName("reconciler"),
+		Keycloak:                          controller.NewLiveKeycloak(kcAddr, kcRealm, kcSAID, kcSASecret),
+		PerOrgRealmEnabled:                perOrgRealmEnabled,
+		GiteaClient:                       giteaClient,
+		HostCluster:                       hostCluster,
+		EnvRegionProvider:                 envRegionProvider,
+		EnvRegionCode:                     envRegionCode,
+		EnvRegionBuildingBlock:            envRegionBuildingBlock,
+		VClusterChartVersion:              chartVer,
+		VClusterHelmRepoName:              helmRepoName,
+		VClusterHelmRepoNamespace:         helmRepoNs,
+		VClusterImageRegistry:             vclusterImageRegistry,
+		Branch:                            branch,
+		GiteaInClusterURL:                 giteaInClusterURL,
+		FluxNamespace:                     fluxNamespace,
+		FluxIntervalSeconds:               fluxIntervalSeconds,
+		FluxGiteaSecretRef:                fluxGiteaSecretRef,
+		FederationSecretNamespace:         fedSecretNs,
+		UserAccessNamespace:               uaNs,
+		IacBootstrapGitea:                 iacGitea,
+		IacBootstrapTokens:                iacTokens,
+		ConsoleGatewayName:                consoleGatewayName,
+		ConsoleGatewayNamespace:           consoleGatewayNs,
+		ConsoleTLSClusterIssuer:           consoleTLSIssuer,
+		ConsoleTLSCertNamespace:           consoleTLSCertNs,
+		ConsoleRouteNamespace:             consoleRouteNs,
+		ConsoleAPIService:                 consoleAPISvc,
+		ConsoleUIService:                  consoleUISvc,
+		ConsoleAPIPort:                    consoleAPIPort,
+		ConsoleUIPort:                     consoleUIPort,
+		PoolPowerDNSURL:                   poolPowerDNSURL,
+		PoolPowerDNSAPIKey:                poolPowerDNSAPIKey,
+		PoolPowerDNSSecretName:            poolPowerDNSSecretName,
+		PoolPowerDNSSecretNamespace:       poolPowerDNSSecretNS,
+		PoolPowerDNSSourceSecretName:      poolPowerDNSSourceSecretName,
+		PoolPowerDNSSourceSecretNamespace: poolPowerDNSSourceSecretNS,
+		TenantConsoleLBIPv4:               tenantConsoleLBIPv4,
+		TenantPrimaryLBIPv4:               tenantPrimaryLBIPv4,
 	}
 	if err := r.SetupWithManager(mgr); err != nil {
 		log.Error(err, "setup reconciler")

--- a/core/controllers/organization/internal/controller/organization_controller.go
+++ b/core/controllers/organization/internal/controller/organization_controller.go
@@ -305,6 +305,26 @@ type Reconciler struct {
 	PoolPowerDNSSecretName      string
 	PoolPowerDNSSecretNamespace string
 
+	// PoolPowerDNSSourceSecretName / PoolPowerDNSSourceSecretNamespace name the
+	// reflector SOURCE secret the bridged `pool-powerdns-api-credentials`
+	// destination is filled FROM (`cert-manager/powerdns-api-credentials`, the
+	// ${POWERDNS_API_KEY} central key bp-cert-manager-powerdns-webhook uses for
+	// DNS-01). #4475 §2 — the LAST-RESORT self-heal: bp-reflector only re-emits
+	// into the destination ON a reconcile cycle AFTER the source exists, and on a
+	// fresh prov the source is created LATE (cert-manager DNS-01 solver) — the
+	// reflector logged `Source could not be found` on its first pass and then
+	// never re-scanned the target after the source appeared, so the bridged
+	// DESTINATION stays empty and `console.<slug>.<pool>` stays NXDOMAIN even
+	// though the SOURCE key is sitting in cert-manager. Reading the SOURCE secret
+	// directly when the destination is empty sidesteps the reflector entirely:
+	// the moment cert-manager creates the source, the very next Org reconcile
+	// resolves the key and writes the A-records — zero-touch, no reflector re-emit
+	// and no Pod roll. Env: CATALYST_POOL_POWERDNS_SOURCE_SECRET_NAME (default
+	// `powerdns-api-credentials`) / CATALYST_POOL_POWERDNS_SOURCE_SECRET_NAMESPACE
+	// (default `cert-manager`). The Secret's `api-key` key carries the value.
+	PoolPowerDNSSourceSecretName      string
+	PoolPowerDNSSourceSecretNamespace string
+
 	// PoolPowerDNSHTTPClient overrides the HTTP client used for the central-pdns
 	// PATCH (tests inject a client pointed at an httptest server). Nil → a 30s
 	// default client.
@@ -556,17 +576,20 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		// #4384 — the funnel/day-2 cart install commits the customer's
 		// purchased Applications into THIS repo's `vcluster/apps/` tree and
 		// read-modify-writes `vcluster/apps/kustomization.yaml` to enumerate
-		// them (alongside the NP/CNP boundary baseline). If the controller
+		// them (alongside the NP boundary baseline). If the controller
 		// kept overwriting that index with its baseline-only list on every
 		// reconcile, it would CLOBBER the funnel's app entries → Flux's
 		// `kustomize build ./vcluster/apps` would drop the customer's apps and
 		// the wordpress HelmRelease would never land. So the apps
 		// kustomization is SEED-ONLY here: the controller creates it once (so a
 		// fresh Org has a valid index before any cart install) and never
-		// overwrites it thereafter. The boundary docs it references
-		// (networkpolicy.yaml / ciliumnetworkpolicy.yaml) are still authored +
-		// kept current via their own PutFile entries above/below, and the
-		// funnel's merge always re-includes them, so the baseline stays live.
+		// overwrites it thereafter. The K8s NetworkPolicy doc it references
+		// (networkpolicy.yaml) is still authored + kept current via its own
+		// PutFile entry, and the funnel's merge always re-includes it, so the
+		// baseline stays live. (#4475 §1: the CNP no longer lives in apps/ — it
+		// moved to the host-applied `vcluster/host-apps/` tree, whose
+		// kustomization index the controller keeps current since the funnel does
+		// NOT merge into it.)
 		if path == "vcluster/apps/kustomization.yaml" {
 			if _, gerr := r.GiteaClient.GetFile(ctx, gOrg.Username, repoName, branch, path); gerr == nil {
 				// Already present (seeded earlier, possibly funnel-merged) —

--- a/core/controllers/organization/internal/controller/organization_controller_test.go
+++ b/core/controllers/organization/internal/controller/organization_controller_test.go
@@ -506,8 +506,8 @@ func TestReconcile_HappyPath(t *testing.T) {
 	if gs.createRepos != 1 {
 		t.Errorf("expected 1 gitea repo create, got %d", gs.createRepos)
 	}
-	if gs.createFiles != 8 {
-		t.Errorf("expected 8 gitea file creates (namespace, vcluster, resourcequota, limitrange, kustomization, apps/networkpolicy, apps/ciliumnetworkpolicy, apps/kustomization), got %d", gs.createFiles)
+	if gs.createFiles != 9 {
+		t.Errorf("expected 9 gitea file creates (namespace, vcluster, resourcequota, limitrange, kustomization, apps/networkpolicy, apps/kustomization, host-apps/ciliumnetworkpolicy, host-apps/kustomization), got %d", gs.createFiles)
 	}
 	if gs.updateFiles != 0 {
 		t.Errorf("expected 0 file updates on first reconcile, got %d", gs.updateFiles)
@@ -726,8 +726,8 @@ func TestReconcile_GiteaOrgAlreadyExists(t *testing.T) {
 	if gs.createRepos != 1 {
 		t.Errorf("expected 1 repo create even with pre-existing org, got %d", gs.createRepos)
 	}
-	if gs.createFiles != 8 {
-		t.Errorf("expected 8 file creates even with pre-existing org, got %d", gs.createFiles)
+	if gs.createFiles != 9 {
+		t.Errorf("expected 9 file creates even with pre-existing org, got %d", gs.createFiles)
 	}
 }
 

--- a/core/controllers/organization/internal/controller/per_org_flux.go
+++ b/core/controllers/organization/internal/controller/per_org_flux.go
@@ -125,6 +125,18 @@ func perOrgAppsKustomizationName(slug string) string {
 	return fmt.Sprintf("catalyst-tenant-%s-apps", slug)
 }
 
+// perOrgHostAppsKustomizationName is the #4475 §1 THIRD Kustomization that
+// reconciles the per-Org Gitea repo's `./vcluster/host-apps` tree (today: the
+// reserved-entity CiliumNetworkPolicy) ALWAYS host-side onto the `<slug>` ns.
+// Unlike the `-apps` Kustomization above it NEVER carries spec.kubeConfig: a
+// CiliumNetworkPolicy cannot be applied into a vanilla vcluster apiserver (no
+// cilium.io/v2 CRD → kustomize dry-run rejection wedges the whole tree). It must
+// land on the HOST `<slug>` ns where Cilium's CRD lives, the syncer reflects the
+// Org's vcluster pods, and the host-tier Org's own pods already run.
+func perOrgHostAppsKustomizationName(slug string) string {
+	return fmt.Sprintf("catalyst-tenant-%s-host-apps", slug)
+}
+
 // perOrgKubeconfigSecretName is the flux-system Secret the provisioning workflow
 // mirrors the per-Org vcluster's exported kubeconfig into (after the vcluster HR
 // goes Ready). The apps Kustomization references it via spec.kubeConfig for the
@@ -310,11 +322,59 @@ func (r *Reconciler) reconcilePerOrgFlux(ctx context.Context, org *orgapi.Organi
 		return fmt.Errorf("upsert per-Org apps Kustomization %s/%s: %w", ns, appsKustomizationName, err)
 	}
 
+	// --- Host-apps Kustomization (./vcluster/host-apps → the HOST `<slug>` ns) ---
+	// #4475 §1. The reserved-entity CiliumNetworkPolicy (gateway ingress +
+	// apiserver egress) renders into ./vcluster/host-apps, a tree DISTINCT from
+	// ./vcluster/apps. The `-apps` Kustomization routes its tree THROUGH the
+	// vcluster apiserver (spec.kubeConfig) for the vcluster tier — but a CNP
+	// CANNOT apply there: a vanilla vcluster has no cilium.io/v2 CRD, so the
+	// kustomize-controller dry-run rejects it ("no matches for kind
+	// CiliumNetworkPolicy") and WEDGES the entire apps tree for an M+ tier Org
+	// (the K8s NPs and every day-2 Application install go down with it). A CNP is
+	// also not a syncable workload object. This THIRD Kustomization reconciles the
+	// host-apps tree ALWAYS host-side (NO kubeConfig, for EVERY tier) onto the
+	// `<slug>` ns — where Cilium's CRD lives, where the syncer reflects the Org's
+	// vcluster pods (so endpointSelector:{} binds the reflected endpoints), and
+	// where the host-tier Org's own pods already run. targetNamespace rewrites the
+	// CNP's authored `apps` ns → `<slug>` on apply, matching the org-controller
+	// boundary ns.
+	hostAppsKustomizationName := perOrgHostAppsKustomizationName(slug)
+	hostAppsKS := &unstructured.Unstructured{}
+	hostAppsKS.SetGroupVersionKind(fluxKustomizationGVK)
+	hostAppsKS.SetNamespace(ns)
+	hostAppsKS.SetName(hostAppsKustomizationName)
+	hostAppsLabels := copyLabels(labels)
+	hostAppsLabels["catalyst.openova.io/component"] = "per-org-host-apps-reconciler"
+	if err := unstructured.SetNestedMap(hostAppsKS.Object, hostAppsLabels, "metadata", "labels"); err != nil {
+		return fmt.Errorf("set host-apps Kustomization labels: %w", err)
+	}
+	hostAppsKSSpec := map[string]any{
+		"interval":        fmt.Sprintf("%ds", interval),
+		"retryInterval":   fmt.Sprintf("%ds", interval),
+		"path":            "./vcluster/host-apps",
+		"prune":           true,
+		"targetNamespace": slug,
+		// NO kubeConfig — host-side for EVERY tier (the CNP can only apply where
+		// Cilium's CRD lives, #4475 §1). Deliberately tier-INDEPENDENT.
+		"sourceRef": map[string]any{
+			"kind":      "GitRepository",
+			"name":      gitRepoName,
+			"namespace": ns,
+		},
+	}
+	if err := unstructured.SetNestedMap(hostAppsKS.Object, hostAppsKSSpec, "spec"); err != nil {
+		return fmt.Errorf("set host-apps Kustomization spec: %w", err)
+	}
+	if err := r.upsertFluxResource(ctx, ns, hostAppsKustomizationName, hostAppsKS); err != nil {
+		return fmt.Errorf("upsert per-Org host-apps Kustomization %s/%s: %w", ns, hostAppsKustomizationName, err)
+	}
+
 	r.Log.Info("reconciled per-Org vCluster Flux loop",
 		"organization", slug,
 		"git_repository", fmt.Sprintf("%s/%s", ns, gitRepoName),
 		"kustomization", fmt.Sprintf("%s/%s", ns, kustomizationName),
 		"apps_kustomization", fmt.Sprintf("%s/%s", ns, appsKustomizationName),
+		"host_apps_kustomization", fmt.Sprintf("%s/%s", ns, hostAppsKustomizationName),
 		"apps_boundary_vcluster", gitops.BoundaryIsVcluster(org.Spec.PlanSlug),
 		"url", repoURL,
 		"branch", branch)
@@ -340,17 +400,19 @@ func (r *Reconciler) teardownPerOrgFlux(ctx context.Context, org *orgapi.Organiz
 	}
 	gitRepoName, kustomizationName := perOrgFluxNames(slug)
 	appsKustomizationName := perOrgAppsKustomizationName(slug)
+	hostAppsKustomizationName := perOrgHostAppsKustomizationName(slug)
 
 	// Delete the Kustomizations first so Flux stops reconciling the trees
 	// before the source disappears (avoids a transient source-not-found
 	// error on the Kustomization's last reconcile). prune:true means the
-	// vCluster Namespace + HR (and the apps NP) are GC'd by Flux as the
-	// Kustomizations are removed. The apps Kustomization is removed before the
-	// vcluster one + the source (#4293 MAJOR-2).
+	// vCluster Namespace + HR (and the apps NP + host-apps CNP) are GC'd by Flux
+	// as the Kustomizations are removed. The apps + host-apps Kustomizations are
+	// removed before the vcluster one + the source (#4293 MAJOR-2 / #4475 §1).
 	for _, target := range []struct {
 		gvk  schema.GroupVersionKind
 		name string
 	}{
+		{fluxKustomizationGVK, hostAppsKustomizationName},
 		{fluxKustomizationGVK, appsKustomizationName},
 		{fluxKustomizationGVK, kustomizationName},
 		{fluxGitRepositoryGVK, gitRepoName},

--- a/core/controllers/organization/internal/controller/per_org_flux_test.go
+++ b/core/controllers/organization/internal/controller/per_org_flux_test.go
@@ -384,6 +384,84 @@ func TestReconcilePerOrgFlux_AppsKustomization_HostTier(t *testing.T) {
 	}
 }
 
+// TestReconcilePerOrgFlux_HostAppsKustomization_AlwaysHostSide is the #4475 §1
+// lock. The reserved-entity CiliumNetworkPolicy (vcluster/host-apps/) CANNOT
+// apply into a CRD-less vcluster apiserver — so the org-controller authors a
+// THIRD Kustomization `catalyst-tenant-<slug>-host-apps` over ./vcluster/host-apps
+// that ALWAYS applies host-side (NO kubeConfig) for EVERY tier, targeting the
+// host `<slug>` ns. For the vcluster tier this is the fix: without it the CNP in
+// the kubeConfig-targeted apps tree wedged the whole tree.
+func TestReconcilePerOrgFlux_HostAppsKustomization_AlwaysHostSide(t *testing.T) {
+	// Both a paid (vcluster) tier and a free/host tier must get the host-apps
+	// Kustomization, and NEITHER may carry a kubeConfig.
+	for _, plan := range []string{"m", "s", "free", ""} {
+		t.Run("plan="+plan, func(t *testing.T) {
+			const slug = "acme"
+			cl := fake.NewClientBuilder().WithScheme(fluxScheme(t)).Build()
+			r := &Reconciler{
+				Log:                logr.Discard(),
+				GiteaInClusterURL:  "http://gitea-http.gitea.svc.cluster.local:3000",
+				FluxGiteaSecretRef: "openova-org-tenants-git-auth",
+			}
+			r.Client = cl
+			if err := r.reconcilePerOrgFlux(context.Background(), newTestOrgPlan(slug, plan)); err != nil {
+				t.Fatalf("reconcilePerOrgFlux: %v", err)
+			}
+			ks := getFlux(t, cl, fluxKustomizationGVK, "flux-system", perOrgHostAppsKustomizationName(slug))
+
+			if path, _, _ := unstructured.NestedString(ks.Object, "spec", "path"); path != "./vcluster/host-apps" {
+				t.Errorf("host-apps Kustomization spec.path = %q, want ./vcluster/host-apps", path)
+			}
+			if tns, _, _ := unstructured.NestedString(ks.Object, "spec", "targetNamespace"); tns != slug {
+				t.Errorf("host-apps Kustomization spec.targetNamespace = %q, want %q", tns, slug)
+			}
+			// CRITICAL (#4475 §1): the host-apps Kustomization must NEVER carry a
+			// kubeConfig — the CNP can only apply where Cilium's CRD lives (the
+			// host), regardless of tier. A kubeConfig would route it into the
+			// CRD-less vcluster apiserver and wedge.
+			if _, found, _ := unstructured.NestedMap(ks.Object, "spec", "kubeConfig"); found {
+				t.Errorf("host-apps Kustomization (plan=%q) MUST NOT carry kubeConfig — the CNP must apply host-side where Cilium's CRD lives", plan)
+			}
+			if prune, _, _ := unstructured.NestedBool(ks.Object, "spec", "prune"); !prune {
+				t.Errorf("host-apps Kustomization spec.prune must be true")
+			}
+		})
+	}
+}
+
+// TestReconcilePerOrgFlux_AppsKustomization_NoCNPInVclusterTree is the companion
+// #4475 §1 guard: the vcluster-tier apps Kustomization (kubeConfig-targeted into
+// the vcluster apiserver) reconciles ./vcluster/apps — which must carry ONLY the
+// syncable K8s NetworkPolicy, NOT the CNP. (Path-level separation; the gitops
+// render test proves the CNP file lives under host-apps/.)
+func TestReconcilePerOrgFlux_AppsKustomization_NoCNPInVclusterTree(t *testing.T) {
+	const slug = "acme"
+	cl := fake.NewClientBuilder().WithScheme(fluxScheme(t)).Build()
+	r := &Reconciler{
+		Log:                logr.Discard(),
+		GiteaInClusterURL:  "http://gitea-http.gitea.svc.cluster.local:3000",
+		FluxGiteaSecretRef: "openova-org-tenants-git-auth",
+	}
+	r.Client = cl
+	if err := r.reconcilePerOrgFlux(context.Background(), newTestOrgPlan(slug, "m")); err != nil {
+		t.Fatalf("reconcilePerOrgFlux: %v", err)
+	}
+	// The vcluster-tier apps Kustomization (kubeConfig) reconciles ./vcluster/apps.
+	apps := getFlux(t, cl, fluxKustomizationGVK, "flux-system", perOrgAppsKustomizationName(slug))
+	if path, _, _ := unstructured.NestedString(apps.Object, "spec", "path"); path != "./vcluster/apps" {
+		t.Errorf("apps Kustomization spec.path = %q, want ./vcluster/apps", path)
+	}
+	if _, found, _ := unstructured.NestedMap(apps.Object, "spec", "kubeConfig"); !found {
+		t.Errorf("vcluster-tier apps Kustomization MUST carry kubeConfig (syncs the K8s NP through the vcluster apiserver)")
+	}
+	// The host-apps Kustomization (./vcluster/host-apps) is the distinct host-side
+	// reconciler for the CNP.
+	host := getFlux(t, cl, fluxKustomizationGVK, "flux-system", perOrgHostAppsKustomizationName(slug))
+	if path, _, _ := unstructured.NestedString(host.Object, "spec", "path"); path != "./vcluster/host-apps" {
+		t.Errorf("host-apps Kustomization spec.path = %q, want ./vcluster/host-apps", path)
+	}
+}
+
 // TestTeardownPerOrgFlux_DeletesAppsKustomization — the apps Kustomization must
 // be torn down with the rest of the per-Org Flux loop (#4293 MAJOR-2).
 func TestTeardownPerOrgFlux_DeletesAppsKustomization(t *testing.T) {
@@ -411,5 +489,11 @@ func TestTeardownPerOrgFlux_DeletesAppsKustomization(t *testing.T) {
 	ks.SetGroupVersionKind(fluxKustomizationGVK)
 	if err := cl.Get(ctx, client.ObjectKey{Namespace: "flux-system", Name: perOrgAppsKustomizationName(slug)}, ks); err == nil {
 		t.Errorf("apps Kustomization must be deleted after teardown")
+	}
+	// #4475 §1: the host-apps Kustomization must also be torn down.
+	hostKS := &unstructured.Unstructured{}
+	hostKS.SetGroupVersionKind(fluxKustomizationGVK)
+	if err := cl.Get(ctx, client.ObjectKey{Namespace: "flux-system", Name: perOrgHostAppsKustomizationName(slug)}, hostKS); err == nil {
+		t.Errorf("host-apps Kustomization must be deleted after teardown")
 	}
 }

--- a/core/controllers/organization/internal/controller/perorg_apps_kustomization_seed_only_4384_test.go
+++ b/core/controllers/organization/internal/controller/perorg_apps_kustomization_seed_only_4384_test.go
@@ -13,11 +13,12 @@ import (
 
 // #4384 — the org-controller must NOT clobber `vcluster/apps/kustomization.yaml`
 // once it exists. The funnel/day-2 cart install read-modify-writes that index
-// to enumerate the customer's purchased Applications (alongside the NP/CNP
-// boundary baseline). If a subsequent org reconcile overwrote it with its
-// baseline-only list, Flux's `kustomize build ./vcluster/apps` would drop the
-// customer's apps and the wordpress HelmRelease would never land. So the
-// controller SEEDS the index once and never overwrites it.
+// to enumerate the customer's purchased Applications (alongside the K8s NP
+// boundary baseline; the CNP lives in the separate host-apps/ tree per #4475 §1).
+// If a subsequent org reconcile overwrote it with its baseline-only list, Flux's
+// `kustomize build ./vcluster/apps` would drop the customer's apps and the
+// wordpress HelmRelease would never land. So the controller SEEDS the index once
+// and never overwrites it.
 func TestReconcile_AppsKustomization_SeedOnly_NotClobbered_4384(t *testing.T) {
 	t.Parallel()
 	org := sampleOrg()
@@ -41,11 +42,12 @@ func TestReconcile_AppsKustomization_SeedOnly_NotClobbered_4384(t *testing.T) {
 
 	// Simulate the funnel cart install merging the customer's wordpress app
 	// into the index (the read-modify-write the provisioning service does).
+	// The CNP is NOT in this tree (#4475 §1 — it lives in host-apps/); the funnel
+	// merges app manifests alongside the K8s NP baseline only.
 	merged := `apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - app-wordpress.yaml
-  - ciliumnetworkpolicy.yaml
   - db-mysql.yaml
   - networkpolicy.yaml
 `
@@ -63,7 +65,7 @@ resources:
 	if !strings.Contains(after, "app-wordpress.yaml") {
 		t.Errorf("regression: org-controller CLOBBERED the funnel-merged apps kustomization — wordpress dropped:\n%s", after)
 	}
-	for _, want := range []string{"networkpolicy.yaml", "ciliumnetworkpolicy.yaml", "db-mysql.yaml"} {
+	for _, want := range []string{"networkpolicy.yaml", "db-mysql.yaml"} {
 		if !strings.Contains(after, want) {
 			t.Errorf("apps kustomization lost %q after reconcile:\n%s", want, after)
 		}

--- a/core/controllers/organization/internal/controller/tenant_dns.go
+++ b/core/controllers/organization/internal/controller/tenant_dns.go
@@ -281,22 +281,57 @@ func (r *Reconciler) poolPowerDNSSecretNamespace() string {
 	return "catalyst-system"
 }
 
-// resolvePoolPowerDNSAPIKey returns the central pool PowerDNS API key, preferring
-// the env-frozen value (CATALYST_POOL_POWERDNS_API_KEY, bound once at Pod start)
-// and FALLING BACK to a live read of the bridged Secret's `api-key` key when the
-// env is empty.
+// poolPowerDNSSourceSecretName / poolPowerDNSSourceSecretNamespace name the
+// reflector SOURCE secret the bridged destination is filled from (#4475 §2).
+// Defaults match the chart's #4218 reflector PULL-stub source: Secret
+// `powerdns-api-credentials` in `cert-manager`. Both are env-overridable per
+// Inviolable Principle #4.
+func (r *Reconciler) poolPowerDNSSourceSecretName() string {
+	if v := strings.TrimSpace(r.PoolPowerDNSSourceSecretName); v != "" {
+		return v
+	}
+	return "powerdns-api-credentials"
+}
+
+func (r *Reconciler) poolPowerDNSSourceSecretNamespace() string {
+	if v := strings.TrimSpace(r.PoolPowerDNSSourceSecretNamespace); v != "" {
+		return v
+	}
+	return "cert-manager"
+}
+
+// resolvePoolPowerDNSAPIKey returns the central pool PowerDNS API key, resolving
+// it from the first of three sources that carries a non-empty value:
 //
-// THE #4290/#4179 SELF-HEAL: the env var is a `secretKeyRef ... optional:true`
-// the kubelet resolves ONLY at Pod start. On a fresh prov the org-controller Pod
-// reliably starts before bp-reflector has copied
-// `cert-manager/powerdns-api-credentials` → `catalyst-system/pool-powerdns-api-credentials`
-// (the reflector itself depends on the sovereign-tls Kustomization seeding the
-// source first). With the env frozen empty and no checksum-annotation rolling the
-// Pod when the Secret later fills, the writer would log `have_key:false` and
-// silently skip the per-Org pool A-record FOREVER — leaving console.<slug>.<pool>
-// NXDOMAIN even after the key is sitting in the Secret. Reading the Secret live
-// each reconcile closes that race: the moment reflection completes, the very next
-// Org reconcile picks the key up and writes the record — zero-touch, no Pod roll.
+//  1. the env-frozen value (CATALYST_POOL_POWERDNS_API_KEY, bound once at Pod
+//     start);
+//  2. a live read of the bridged DESTINATION Secret's `api-key` key
+//     (`catalyst-system/pool-powerdns-api-credentials`) — the #4290/#4179
+//     self-heal;
+//  3. a live read of the reflector SOURCE Secret's `api-key` key
+//     (`cert-manager/powerdns-api-credentials`) — the #4475 §2 self-heal.
+//
+// THE #4290/#4179 SELF-HEAL (source 2): the env var is a `secretKeyRef ...
+// optional:true` the kubelet resolves ONLY at Pod start. On a fresh prov the
+// org-controller Pod reliably starts before bp-reflector has copied
+// `cert-manager/powerdns-api-credentials` → `catalyst-system/pool-powerdns-api-credentials`.
+// With the env frozen empty and no checksum-annotation rolling the Pod when the
+// Secret later fills, the writer would log `have_key:false` and silently skip the
+// per-Org pool A-record FOREVER. Reading the bridged DESTINATION live each
+// reconcile closes that race once reflection completes.
+//
+// THE #4475 §2 SELF-HEAL (source 3): bp-reflector only re-emits into the
+// destination on a reconcile cycle AFTER the source exists. On a fresh prov the
+// SOURCE (`cert-manager/powerdns-api-credentials`) is created LATE (cert-manager's
+// DNS-01 solver) — the reflector logged `Source could not be found` on its first
+// pass and then never re-scanned the target after the source appeared, so the
+// bridged DESTINATION can stay empty INDEFINITELY even though the SOURCE key is
+// present. Reading the SOURCE Secret directly when the destination is still empty
+// sidesteps the reflector entirely: the moment cert-manager creates the source,
+// the very next Org reconcile resolves the key and writes the A-records —
+// zero-touch, no reflector re-emit and no Pod roll. Source 2 (the bridged
+// destination) stays preferred so steady-state reads hit the controller's own
+// namespace; the SOURCE read is a fallback only.
 //
 // A read miss/error is non-fatal here (returns ""); the caller's loud-fail guard
 // decides whether an empty key is an error (pool URL configured) or a no-op
@@ -312,23 +347,44 @@ func (r *Reconciler) resolvePoolPowerDNSAPIKey(ctx context.Context) string {
 	if r.Client == nil {
 		return ""
 	}
-	var sec corev1.Secret
-	key := client.ObjectKey{
-		Namespace: r.poolPowerDNSSecretNamespace(),
-		Name:      r.poolPowerDNSSecretName(),
+	// Source 2: the bridged DESTINATION (controller-own-namespace) — preferred.
+	if v := r.readPoolKeyFromSecret(ctx,
+		r.poolPowerDNSSecretNamespace(), r.poolPowerDNSSecretName(),
+		"reflector landed it post-start"); v != "" {
+		return v
 	}
+	// Source 3 (#4475 §2): the reflector SOURCE — last-resort fallback that
+	// sidesteps a stuck reflector that never re-emitted after a late source-create.
+	if v := r.readPoolKeyFromSecret(ctx,
+		r.poolPowerDNSSourceSecretNamespace(), r.poolPowerDNSSourceSecretName(),
+		"read directly from the reflector SOURCE — bridged destination still empty (reflector did not re-emit after late source-create)"); v != "" {
+		return v
+	}
+	return ""
+}
+
+// readPoolKeyFromSecret reads the `api-key` key of the named Secret and returns
+// its trimmed value, or "" on NotFound / read error / empty value. NotFound is
+// the expected pre-reflection / pre-source-create state, so it is quiet; a
+// non-NotFound error is logged. A successful read logs at Info with the supplied
+// reason so the resolution path (bridged destination vs reflector source) is
+// observable. Shared by the #4290/#4179 (destination) and #4475 §2 (source)
+// self-heal reads in resolvePoolPowerDNSAPIKey.
+func (r *Reconciler) readPoolKeyFromSecret(ctx context.Context, namespace, name, reason string) string {
+	var sec corev1.Secret
+	key := client.ObjectKey{Namespace: namespace, Name: name}
 	if err := r.Get(ctx, key, &sec); err != nil {
 		if !apierrors.IsNotFound(err) {
 			r.Log.Error(err, "tenant-dns: live read of pool PowerDNS Secret failed",
 				"secret", key.Name, "namespace", key.Namespace)
 		}
-		// NotFound is the expected pre-reflection state — quiet; the caller's
-		// guard requeues so we retry once the Secret exists.
+		// NotFound is the expected pre-reflection / pre-source state — quiet; the
+		// caller's guard requeues so we retry once the Secret exists.
 		return ""
 	}
 	if v := strings.TrimSpace(string(sec.Data["api-key"])); v != "" {
-		r.Log.Info("tenant-dns: pool PowerDNS key resolved via LIVE Secret read (env was empty — reflector landed it post-start)",
-			"secret", key.Name, "namespace", key.Namespace)
+		r.Log.Info("tenant-dns: pool PowerDNS key resolved via LIVE Secret read (env was empty)",
+			"secret", key.Name, "namespace", key.Namespace, "reason", reason)
 		return v
 	}
 	return ""

--- a/core/controllers/organization/internal/controller/tenant_dns_test.go
+++ b/core/controllers/organization/internal/controller/tenant_dns_test.go
@@ -264,6 +264,93 @@ func TestReconcileTenantDNS_SelfHealsViaLiveSecretRead(t *testing.T) {
 	}
 }
 
+// TestReconcileTenantDNS_SelfHealsViaSourceSecretRead is the #4475 §2 regression
+// lock: when the env-frozen pool key is EMPTY and the bridged DESTINATION Secret
+// (`catalyst-system/pool-powerdns-api-credentials`) is STILL ABSENT (bp-reflector
+// never re-emitted after the late source-create), but the reflector SOURCE Secret
+// (`cert-manager/powerdns-api-credentials`) now carries the key, the reconciler
+// must FALL BACK to reading the SOURCE directly and write the per-Org A-records —
+// sidestepping the stuck reflector entirely. Without this, console.<slug>.<pool>
+// stays NXDOMAIN forever even though the central key is present in cert-manager.
+func TestReconcileTenantDNS_SelfHealsViaSourceSecretRead(t *testing.T) {
+	t.Parallel()
+	var cap capturedPatch
+	srv := newPDNSStub(t, &cap)
+	defer srv.Close()
+
+	// ONLY the reflector SOURCE exists (cert-manager). The bridged destination
+	// (catalyst-system/pool-powerdns-api-credentials) is deliberately absent —
+	// the reflector never re-emitted.
+	src := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "powerdns-api-credentials",
+			Namespace: "cert-manager",
+		},
+		Data: map[string][]byte{"api-key": []byte("source-pool-key")},
+	}
+	cl := fake.NewClientBuilder().WithScheme(secretScheme(t)).WithObjects(src).Build()
+
+	r := &Reconciler{
+		Client:              cl,
+		Log:                 logr.Discard(),
+		PoolPowerDNSURL:     srv.URL,
+		PoolPowerDNSAPIKey:  "", // env frozen EMPTY (pre-reflection Pod start)
+		TenantConsoleLBIPv4: "212.72.24.33",
+		// Destination + source secret name/namespace default to the #4218 chart
+		// PULL-stub values — match the fixture above without setting them.
+	}
+
+	changed, err := r.reconcileTenantDNS(context.Background(), orgWithTenantPublic("omani.works", "f4475done"))
+	if err != nil {
+		t.Fatalf("reconcileTenantDNS: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected changed=true — SOURCE Secret read should have supplied the key when the bridged destination was absent")
+	}
+	if cap.apiKey != "source-pool-key" {
+		t.Errorf("X-API-Key: got %q, want source-pool-key (proves the SOURCE-secret fallback was used, not the missing destination)", cap.apiKey)
+	}
+	rrsets, _ := cap.body["rrsets"].([]any)
+	if len(rrsets) != 2 {
+		t.Fatalf("rrsets: got %d, want 2 (console + wildcard)", len(rrsets))
+	}
+}
+
+// TestReconcileTenantDNS_PrefersDestinationOverSource locks the source ordering:
+// when BOTH the bridged destination AND the reflector source carry a key, the
+// reconciler must use the DESTINATION (the controller's own namespace, the
+// steady-state path) — the source read is a fallback only.
+func TestReconcileTenantDNS_PrefersDestinationOverSource(t *testing.T) {
+	t.Parallel()
+	var cap capturedPatch
+	srv := newPDNSStub(t, &cap)
+	defer srv.Close()
+
+	dst := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "pool-powerdns-api-credentials", Namespace: "catalyst-system"},
+		Data:       map[string][]byte{"api-key": []byte("destination-key")},
+	}
+	src := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "powerdns-api-credentials", Namespace: "cert-manager"},
+		Data:       map[string][]byte{"api-key": []byte("source-key")},
+	}
+	cl := fake.NewClientBuilder().WithScheme(secretScheme(t)).WithObjects(dst, src).Build()
+
+	r := &Reconciler{
+		Client:              cl,
+		Log:                 logr.Discard(),
+		PoolPowerDNSURL:     srv.URL,
+		PoolPowerDNSAPIKey:  "",
+		TenantConsoleLBIPv4: "212.72.24.33",
+	}
+	if _, err := r.reconcileTenantDNS(context.Background(), orgWithTenantPublic("omani.works", "f4475pref")); err != nil {
+		t.Fatalf("reconcileTenantDNS: %v", err)
+	}
+	if cap.apiKey != "destination-key" {
+		t.Errorf("X-API-Key: got %q, want destination-key (the bridged destination must be preferred over the source)", cap.apiKey)
+	}
+}
+
 // TestReconcileTenantDNS_LoudFailWhenKeyMissing locks the loud-fail guard: when
 // the pool URL is configured (this Sovereign EXPECTS a central pool write) but
 // the key is absent from both env AND the live Secret, the reconciler must return

--- a/core/controllers/organization/internal/gitops/manifests.go
+++ b/core/controllers/organization/internal/gitops/manifests.go
@@ -452,17 +452,32 @@ spec:
 // Cilium computes the UNION of every policy selecting an endpoint, so this CNP
 // is PURELY ADDITIVE to the K8s default-deny: it grants gateway reachability +
 // apiserver egress without weakening the cross-Org/cross-Environment denial
-// (note: NO `world` — only the gateway, never direct public ingress). It is
-// co-located with the K8s NP in the SAME apps tree, so it lands wherever the
-// real Org workloads do — INSIDE the vcluster for the paid tier (the keystone
-// #4299 redirects app HelmReleases there via spec.kubeConfig), on the host
-// `<slug>` ns for free/S — binding the actual pods, never an empty host shell.
+// (note: NO `world` — only the gateway, never direct public ingress).
+//
+// HOST-SIDE, NOT IN-VCLUSTER (#4475)
+// ----------------------------------
+// CRITICAL: this CNP renders into the HOST-applied `vcluster/host-apps` tree,
+// NOT the `vcluster/apps` tree the syncer reflects from the vcluster apiserver.
+// A vanilla vcluster has NO `cilium.io/v2` CRD — a CiliumNetworkPolicy applied
+// INTO the vcluster apiserver fails the kustomize-controller dry-run
+// (`no matches for kind "CiliumNetworkPolicy" in version "cilium.io/v2"`) and
+// WEDGES the entire kubeConfig-targeted apps Kustomization for a vcluster-tier
+// Org — taking the K8s NPs AND every day-2 Application install down with it
+// (#4475 §1). A CNP is also NOT a syncable workload object (sync.toHost only
+// reflects the K8s `networkPolicies` kind), so routing it through the vcluster
+// at all is wrong. Instead it applies DIRECTLY to the host `<slug>` namespace,
+// where Cilium's CRD lives AND where the syncer reflects the Org's vcluster
+// pods — so `endpointSelector: {}` binds the actual reflected endpoints, the
+// same de-vcluster host-ns enforcement pattern other host-enforced policies
+// follow. For the host tier (free/S) the Org's workloads already run in the
+// host `<slug>` ns, so the same host-applied CNP binds them there too.
 //
 // endpointSelector {} = every endpoint in the namespace (matching the K8s
-// default-deny's podSelector {} scope). Gated by the consumer on the cilium.io/v2
-// Capabilities check (the #2988/#3102 idiom) so kind CI (CRD-less) still applies
-// the K8s NP without this file — there the identity-aware agent isn't enforcing
-// anyway. On a real Sovereign the org-controller always emits it.
+// default-deny's podSelector {} scope). On a CRD-less cluster (kind CI) the
+// host-apps tree is simply not exercised by an enforcing agent — the K8s NP
+// path in apps/ still applies; there the identity-aware datapath isn't
+// enforcing anyway. On a real Sovereign the org-controller always emits it
+// host-side.
 const ciliumNetworkPolicyTemplate = `apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -502,11 +517,13 @@ spec:
 // ns. It is NOT listed in the boundary kustomization (a different path).
 const networkPolicyDoc = "networkpolicy.yaml"
 
-// ciliumNetworkPolicyDoc is the apps-tree filename for the reserved-entity CNP
-// companion (gateway ingress + apiserver egress). Co-located with
-// networkPolicyDoc under vcluster/apps/ so it lands on the SAME boundary the
-// real Org workloads run on (inside the vcluster for paid tiers; host `<slug>`
-// ns for free/S).
+// ciliumNetworkPolicyDoc is the host-apps-tree filename for the reserved-entity
+// CNP companion (gateway ingress + apiserver egress). It lives under
+// vcluster/host-apps/ — a SEPARATE tree from the syncer-reflected apps/ — because
+// a CiliumNetworkPolicy CANNOT be applied into a vanilla vcluster apiserver (no
+// cilium.io/v2 CRD → kustomize dry-run rejection wedges the whole tree, #4475 §1).
+// The host-apps tree is ALWAYS applied host-side to the `<slug>` ns where Cilium
+// enforces and the syncer reflects the Org's vcluster pods.
 const ciliumNetworkPolicyDoc = "ciliumnetworkpolicy.yaml"
 
 const kustomizationTemplate = `apiVersion: kustomize.config.k8s.io/v1beta1
@@ -518,14 +535,33 @@ resources:
 `
 
 // appsKustomizationTemplate is the kustomize index for the apps/ tree the
-// per-Org apps Flux Kustomization reconciles (#4293 MAJOR-2). Today it lists
-// only the default-deny NetworkPolicy baseline; the funnel's app-install tree
-// (a DIFFERENT repo) carries the customer's purchased Applications. Keeping an
-// explicit index here makes `kustomize build ./vcluster/apps` deterministic.
+// per-Org apps Flux Kustomization reconciles (#4293 MAJOR-2). It lists ONLY the
+// default-deny K8s NetworkPolicy baseline — a SYNCABLE object: for the vcluster
+// tier the apps Kustomization carries spec.kubeConfig so this lands in the
+// vcluster apiserver and the syncer reflects it to the host `<slug>` ns; for the
+// host tier it applies straight to the host ns. The CNP is DELIBERATELY NOT here
+// (#4475 §1): a CiliumNetworkPolicy cannot apply into the CRD-less vcluster
+// apiserver — it lives in the host-apps/ tree instead. The funnel's app-install
+// tree (a DIFFERENT repo) carries the customer's purchased Applications. Keeping
+// an explicit index here makes `kustomize build ./vcluster/apps` deterministic.
 const appsKustomizationTemplate = `apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ` + networkPolicyDoc + `
+`
+
+// hostAppsKustomizationTemplate is the kustomize index for the host-apps/ tree —
+// the per-Org HOST-applied apps Flux Kustomization (catalyst-tenant-<slug>-host-apps,
+// per_org_flux.go) reconciles it ALWAYS host-side (never via kubeConfig). It
+// carries the reserved-entity CiliumNetworkPolicy, which cannot apply into a
+// vanilla vcluster apiserver (no cilium.io/v2 CRD, #4475 §1) and is not a
+// syncable workload object. Applied to the host `<slug>` ns, the CNP binds the
+// Org's pods directly (host tier) or the syncer-reflected vcluster pods (vcluster
+// tier). Keeping an explicit index makes `kustomize build ./vcluster/host-apps`
+// deterministic.
+const hostAppsKustomizationTemplate = `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
   - ` + ciliumNetworkPolicyDoc + `
 `
 
@@ -582,10 +618,12 @@ func limitRangeDefaults(q PlanQuota) (cpu, mem string) {
 //     plan (skipped ResourceQuota for soft-cap Flexi; LimitRange always).
 //   - apps/networkpolicy.yaml seeds the default-deny + same-Org-allow baseline
 //     the syncer reflects to the host (sync.toHost.networkPolicies.enabled).
-//   - apps/ciliumnetworkpolicy.yaml is the MANDATORY companion that admits the
-//     Cilium Gateway `ingress` entity (else the Org's app behind its HTTPRoute
-//     503s) + egress to the `kube-apiserver` entity (else in-vcluster pods can't
-//     reach the cluster API) — reserved entities no K8s NetworkPolicy can match.
+//   - host-apps/ciliumnetworkpolicy.yaml is the MANDATORY companion that admits
+//     the Cilium Gateway `ingress` entity (else the Org's app behind its
+//     HTTPRoute 503s) + egress to the `kube-apiserver` entity (else in-vcluster
+//     pods can't reach the cluster API) — reserved entities no K8s NetworkPolicy
+//     can match. It lives in a SEPARATE host-applied tree (#4475 §1): a
+//     CiliumNetworkPolicy cannot be applied into the CRD-less vcluster apiserver.
 func Render(in Inputs) (map[string][]byte, error) {
 	if in.VClusterHelmRepoName == "" {
 		in.VClusterHelmRepoName = "loft"
@@ -642,20 +680,28 @@ func Render(in Inputs) (map[string][]byte, error) {
 	// (the boundary kustomization omits apps/, and the funnel apps-sync reads a
 	// DIFFERENT repo) → intra-Org isolation stayed inert.
 	files["vcluster/apps/"+networkPolicyDoc] = networkPolicyTemplate
-	// The reserved-entity CNP companion (gateway ingress + apiserver egress).
-	// Co-located with the K8s NP so it lands on the SAME boundary the keystone
-	// (#4299) installs the Org's real app workloads onto — inside the vcluster for
-	// the paid tier, the host `<slug>` ns for free/S. Without it the K8s
-	// default-deny silently 503s the Org's Application behind the Cilium Gateway
-	// and blocks egress to the cluster API (neither reachable via any K8s NP
-	// selector). Kustomize applies a CRD-less cluster's CNP as a no-op object;
-	// it has no effect there (kind CI isn't identity-enforcing), so it is safe to
-	// always render — on a real Sovereign cilium.io/v2 is present and enforces it.
-	files["vcluster/apps/"+ciliumNetworkPolicyDoc] = ciliumNetworkPolicyTemplate
+	// The reserved-entity CNP companion (gateway ingress + apiserver egress) lives
+	// in a SEPARATE host-applied tree (#4475 §1). A CiliumNetworkPolicy CANNOT be
+	// applied into the CRD-less vcluster apiserver — the kustomize-controller
+	// dry-run rejects `cilium.io/v2` ("no matches for kind CiliumNetworkPolicy")
+	// and WEDGES the whole kubeConfig-targeted apps Kustomization (taking the K8s
+	// NPs and every day-2 Application install down) for a vcluster-tier Org. It is
+	// also NOT a syncable workload object. So the org-controller's host-apps Flux
+	// Kustomization (catalyst-tenant-<slug>-host-apps, per_org_flux.go) reconciles
+	// this tree ALWAYS host-side onto the `<slug>` ns — where Cilium's CRD lives,
+	// where the syncer reflects the Org's vcluster pods, and where the host-tier
+	// Org's own pods already run. Without the CNP the K8s default-deny silently
+	// 503s the Org's Application behind the Cilium Gateway and blocks egress to the
+	// cluster API (neither reachable via any K8s NP selector).
+	files["vcluster/host-apps/"+ciliumNetworkPolicyDoc] = ciliumNetworkPolicyTemplate
 	// Explicit apps/kustomization.yaml so the per-Org apps Flux Kustomization's
-	// `kustomize build ./vcluster/apps` enumerates the NP + CNP deterministically
+	// `kustomize build ./vcluster/apps` enumerates the K8s NP deterministically
 	// (mirrors the funnel apps-tree, which also ships its own kustomization.yaml).
 	files["vcluster/apps/kustomization.yaml"] = appsKustomizationTemplate
+	// Explicit host-apps/kustomization.yaml so the per-Org host-apps Flux
+	// Kustomization's `kustomize build ./vcluster/host-apps` enumerates the CNP
+	// deterministically.
+	files["vcluster/host-apps/kustomization.yaml"] = hostAppsKustomizationTemplate
 
 	// Stable order for the kustomization resource list (map iteration above
 	// is randomized — keep the rendered kustomization byte-stable).

--- a/core/controllers/organization/internal/gitops/manifests_test.go
+++ b/core/controllers/organization/internal/gitops/manifests_test.go
@@ -24,7 +24,8 @@ func TestRender_AllPathsAndStructuralYAML(t *testing.T) {
 	}
 	// #4292: the paid-tier set is namespace + vcluster + resourcequota +
 	// limitrange + kustomization + the apps-tree networkpolicy baseline +
-	// (#4293 MAJOR-2) the apps-tree kustomization index.
+	// (#4293 MAJOR-2) the apps-tree kustomization index + (#4475 §1) the
+	// host-apps-tree CNP + its kustomization index.
 	wantPaths := []string{
 		"vcluster/namespace.yaml",
 		"vcluster/vcluster.yaml",
@@ -33,6 +34,8 @@ func TestRender_AllPathsAndStructuralYAML(t *testing.T) {
 		"vcluster/kustomization.yaml",
 		"vcluster/apps/networkpolicy.yaml",
 		"vcluster/apps/kustomization.yaml",
+		"vcluster/host-apps/ciliumnetworkpolicy.yaml",
+		"vcluster/host-apps/kustomization.yaml",
 	}
 	for _, p := range wantPaths {
 		if _, ok := out[p]; !ok {
@@ -299,36 +302,38 @@ func TestRender_NetworkPolicyBaselineInAppsTree(t *testing.T) {
 }
 
 // TestRender_CiliumNetworkPolicyReservedEntities proves the MANDATORY CNP
-// companion renders into the SAME apps tree as the K8s NP (so it lands on the
-// boundary the keystone #4299 installs the Org's real workloads onto — INSIDE
-// the vcluster for the paid tier, the host `<slug>` ns for free/S — never an
-// empty host shell), and that it admits the reserved entities a plain K8s
-// NetworkPolicy cannot express: `ingress`/`host`/`remote-node` (so the Org's
+// companion renders into the HOST-applied host-apps/ tree (#4475 §1) — NOT the
+// syncer-reflected apps/ tree, because a CiliumNetworkPolicy cannot apply into a
+// CRD-less vcluster apiserver — and that it admits the reserved entities a plain
+// K8s NetworkPolicy cannot express: `ingress`/`host`/`remote-node` (so the Org's
 // Application behind its Cilium-Gateway HTTPRoute is reachable, not 503) and
 // `kube-apiserver` egress (so an in-vcluster Org pod can reach the cluster API).
 func TestRender_CiliumNetworkPolicyReservedEntities(t *testing.T) {
 	t.Parallel()
 	// Both a paid (vcluster) tier and the free/host tier must carry the CNP in
-	// the apps tree — it must bind the real workloads wherever they land.
+	// the host-apps tree — it binds the host `<slug>` ns endpoints (the Org's own
+	// pods for the host tier; the syncer-reflected vcluster pods for the paid
+	// tier) for every tier identically.
 	for _, slug := range []string{"m", "s"} {
 		out, err := Render(Inputs{Slug: "acme", DisplayName: "Acme", Tier: "org",
 			PlanSlug: slug, SovereignFQDN: "x.example", HostCluster: "hz", VClusterChartVersion: "0.33.*"})
 		if err != nil {
 			t.Fatalf("Render(%s): %v", slug, err)
 		}
-		// It must live in the apps/ tree — the path the per-Org apps Flux
-		// Kustomization (per_org_flux.go) reconciles INTO the vcluster (paid
-		// tier, via spec.kubeConfig) / the host `<slug>` ns (free tier). It must
-		// NOT be in the boundary kustomization (./vcluster, host-applied).
-		cnp, ok := out["vcluster/apps/ciliumnetworkpolicy.yaml"]
+		// It must live in the host-apps/ tree — the path the per-Org host-apps
+		// Flux Kustomization (per_org_flux.go) reconciles ALWAYS host-side onto the
+		// `<slug>` ns. It must NOT be in the apps/ tree (which the vcluster tier
+		// routes through the CRD-less vcluster apiserver via kubeConfig), nor in
+		// the boundary kustomization (./vcluster, host-applied empty shell).
+		cnp, ok := out["vcluster/host-apps/ciliumnetworkpolicy.yaml"]
 		if !ok {
-			t.Fatalf("plan %s: missing vcluster/apps/ciliumnetworkpolicy.yaml — the K8s default-deny would silently 503 the Org's app behind the Cilium Gateway", slug)
+			t.Fatalf("plan %s: missing vcluster/host-apps/ciliumnetworkpolicy.yaml — the K8s default-deny would silently 503 the Org's app behind the Cilium Gateway", slug)
 		}
 		s := string(cnp)
 		for _, want := range []string{
 			"kind: CiliumNetworkPolicy",
 			"apiVersion: cilium.io/v2",
-			"namespace: apps", // the apps NS the syncer rewrites → host <slug> ns
+			"namespace: apps", // the apps NS the host-apps Kustomization rewrites → host <slug> ns
 			"endpointSelector: {}",
 			"fromEntities:",
 			"- ingress",
@@ -352,20 +357,30 @@ func TestRender_CiliumNetworkPolicyReservedEntities(t *testing.T) {
 		if err := yaml.Unmarshal(cnp, &v); err != nil {
 			t.Errorf("plan %s ciliumnetworkpolicy.yaml invalid YAML: %v\n%s", slug, err, s)
 		}
-		// The apps kustomization index must enumerate the CNP so
-		// `kustomize build ./vcluster/apps` applies it deterministically.
+		// #4475 §1: the CNP must NOT be in the apps/ tree (it would be routed into
+		// the CRD-less vcluster apiserver for the paid tier and wedge the tree).
+		if _, leaked := out["vcluster/apps/ciliumnetworkpolicy.yaml"]; leaked {
+			t.Errorf("plan %s: CNP leaked into vcluster/apps/ — for the vcluster tier that wedges the kubeConfig-targeted Kustomization (no cilium.io/v2 CRD in the vcluster). It must live in host-apps/", slug)
+		}
 		appsKz := string(out["vcluster/apps/kustomization.yaml"])
-		for _, want := range []string{"- networkpolicy.yaml", "- ciliumnetworkpolicy.yaml"} {
-			if !strings.Contains(appsKz, want) {
-				t.Errorf("plan %s apps/kustomization.yaml missing %q\n%s", slug, want, appsKz)
-			}
+		if strings.Contains(appsKz, "ciliumnetworkpolicy.yaml") {
+			t.Errorf("plan %s: apps/kustomization.yaml must NOT enumerate the CNP — it lives in host-apps/\n%s", slug, appsKz)
+		}
+		if !strings.Contains(appsKz, "- networkpolicy.yaml") {
+			t.Errorf("plan %s apps/kustomization.yaml missing the K8s NetworkPolicy\n%s", slug, appsKz)
+		}
+		// The host-apps kustomization index must enumerate the CNP so
+		// `kustomize build ./vcluster/host-apps` applies it deterministically.
+		hostAppsKz := string(out["vcluster/host-apps/kustomization.yaml"])
+		if !strings.Contains(hostAppsKz, "- ciliumnetworkpolicy.yaml") {
+			t.Errorf("plan %s host-apps/kustomization.yaml missing the CNP\n%s", slug, hostAppsKz)
 		}
 		// Anti-theater guard: the CNP must NOT be in the host-applied boundary
 		// kustomization (./vcluster) — that would apply it to the empty host
 		// shell, not the workload boundary.
 		boundaryKz := string(out["vcluster/kustomization.yaml"])
 		if strings.Contains(boundaryKz, "ciliumnetworkpolicy.yaml") {
-			t.Errorf("plan %s: CNP leaked into the boundary kustomization (host shell) — it must live in the apps tree (workload boundary)\n%s", slug, boundaryKz)
+			t.Errorf("plan %s: CNP leaked into the boundary kustomization (host shell) — it must live in the host-apps tree (workload boundary)\n%s", slug, boundaryKz)
 		}
 	}
 }


### PR DESCRIPTION
## Problem (UAT #4290/#4293 tail, fresh prov `91dc05917e44d1c1`)

Two convergence-tail faults from #4475, downstream of the now-fixed reconcile keystone.

### §1 — CiliumNetworkPolicy can't apply inside a vanilla vcluster (vcluster-tier only)

For M+ tier Orgs the per-Org apps Kustomization (`catalyst-tenant-<slug>-apps`) carries `spec.kubeConfig` and applies `./vcluster/apps` (default-deny NP + allow-same-org NP + CNP `allow-gateway-and-apiserver`) INTO the Org vcluster apiserver. But a vanilla vcluster has NO Cilium CRDs:

```
catalyst-tenant-uatb1-apps  Ready=False
  CiliumNetworkPolicy/uatb1/allow-gateway-and-apiserver dry-run failed:
  no matches for kind "CiliumNetworkPolicy" in version "cilium.io/v2"
```

That dry-run rejection wedges the ENTIRE apps tree — taking the K8s NetworkPolicies AND every day-2 Application install down with it. A CNP is also not a syncable workload object (`sync.toHost` only reflects the K8s `networkPolicies` kind), so routing it through the vcluster at all is wrong.

### §2 — pool-DNS reflector re-emit gap

On a fresh prov the reflector SOURCE `cert-manager/powerdns-api-credentials` is created LATE (cert-manager DNS-01 solver). bp-reflector logged `Source could not be found` on its first pass and never re-scanned the target after the source appeared, so the bridged destination `catalyst-system/pool-powerdns-api-credentials` stays empty INDEFINITELY → `console.<slug>.<pool>` NXDOMAIN. The #4455 controller-side live-read of the *destination* works only once that destination is populated; the reflector re-emit gap leaves it empty.

## Fix

### §1 — CNP host-side via a dedicated tree + third Kustomization
- `gitops/manifests.go`: the CNP now renders into `vcluster/host-apps/` (own kustomization index), out of the syncer-reflected `vcluster/apps/` tree. The K8s NetworkPolicies stay in `vcluster/apps/` (syncable).
- `per_org_flux.go`: a THIRD per-Org Flux Kustomization `catalyst-tenant-<slug>-host-apps` reconciles `./vcluster/host-apps` **ALWAYS host-side** (NO `kubeConfig`, every tier) with `targetNamespace: <slug>`. The CNP lands on the host `<slug>` ns — where Cilium's CRD lives, where the syncer reflects the Org's vcluster pods (`endpointSelector:{}` binds the reflected endpoints), and where host-tier Orgs' own pods already run. Matches the de-vcluster host-ns enforcement pattern. Teardown removes it with the rest of the per-Org Flux loop.

### §2 — controller source-secret fallback
- `tenant_dns.go`: when the bridged destination is still empty, `resolvePoolPowerDNSAPIKey` falls back to reading the SOURCE `cert-manager/powerdns-api-credentials` directly — sidestepping the stuck reflector. Destination stays preferred (steady-state); source read is fallback only. New env knobs `CATALYST_POOL_POWERDNS_SOURCE_SECRET_NAME/NAMESPACE`. Cluster-wide `secrets:get` RBAC the controller already holds covers the cross-namespace read — no RBAC change.

## Tests
- gitops render: CNP lives in `host-apps/` (not `apps/`) for both M and S tiers; apps kustomization no longer lists it; host-apps kustomization does.
- per_org_flux: host-apps Kustomization is host-side (never `kubeConfig`) for `m/s/free/""`; apps Kustomization keeps its kubeConfig; both torn down.
- tenant_dns: source-secret fallback fires when destination absent; destination preferred when both present.
- `go build ./...`, `go vet ./...`, full org-controller suite green.

## Verification status
Roll-gated for LIVE verification — no M-tier (vcluster-backed) Org is live to walk against right now. Shipping correct, tested code; live verify needs a fresh prov with an M-tier Org so the apps tree converges (CNP applies host-side, a day-2 postgres install into the vcluster reaches Ready) and `console.<slug>.<pool>` resolves zero-touch.

Refs #4475 #4290 #4293

🤖 Generated with [Claude Code](https://claude.com/claude-code)