### PR TITLE
fix(catalog-seed #4111): bp-agenity seed source.version 0.5.12->0.5.13 lockstep — kill per-Org agenity Init:ImagePullBackOff (1.4.910)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1191,7 +1191,13 @@ spec:
       # 1.4.906 — #4477 secondary: doc-only — CATALYST_NEWAPI_ADMIN_TOKEN env
       #   comment cites the canonical `catalyst/newapi/admin-token` OpenBao path
       #   (written by catalyst-api's seedNewapiAdminToken seam).
-      version: 1.4.909
+      # 1.4.910 — #4111: catalog-seed bp-agenity spec.source.version 0.5.12 ->
+      #   0.5.13 lockstep follow-up to #4494. #4494 bumped the seed Blueprint's
+      #   spec.version to 0.5.13 (chart carrying imagePullSecrets:[ghcr-pull])
+      #   but LEFT spec.source.version 0.5.12; Flux resolves from source.version
+      #   so Sovereigns still pulled the OLD 0.5.12 chart -> per-Org agenity pod
+      #   Init:ImagePullBackOff. Lockstep w/ Chart.yaml. Refs #4111 #4494 #4417.
+      version: 1.4.910
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3318,7 +3318,18 @@ name: bp-catalyst-platform
 #   bump back to b23af68, shipping org-controller WITHOUT #4455 tenant-dns +
 #   #4462 delete-cascade on every fresh prov). 89993b2 is a descendant of b23af68
 #   so it retains #4393 Guaranteed-QoS. Lockstep w/ bootstrap-kit slot 13 pin.
-version: 1.4.909
+# 1.4.910 — #4111: catalog-seed bp-agenity spec.source.version 0.5.12 -> 0.5.13
+#   lockstep follow-up to #4494. #4494 bumped the seed Blueprint's spec.version
+#   to 0.5.13 (the chart carrying imagePullSecrets:[ghcr-pull], #4111 image-pull
+#   fix) but LEFT spec.source.version at 0.5.12. Flux resolves the chart from
+#   source.version, so every Sovereign still pulled bp-agenity@0.5.12 (the OLD
+#   chart WITHOUT imagePullSecrets) -> the per-Org agenity pod stayed
+#   Init:ImagePullBackOff (private ghcr.io/openova-io/agenity image, 401
+#   anonymous). Now that #4417 dropped resource-policy:keep, a matched
+#   source.version reaches the LIVE Blueprint CR zero-touch. Chart 0.5.13 is a
+#   published OCI artifact. Bump bp-catalyst-platform chart + bootstrap-kit
+#   slot 13 pin in lockstep so Flux re-rolls the seed. Refs #4111 #4494 #4417.
+version: 1.4.910
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/
 #   platform/crossplane chart + blueprint.yaml + bootstrap-kit slot 04). crossplane-core
 #   was still OOMKilled (CrashLoopBackOff, 55 restarts, exit 137, killed ~90s after start)

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -6010,7 +6010,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-agenity
-    version: 0.5.12
+    version: 0.5.13
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## The fault (verified)

PR #4494 bumped the catalog-seed `bp-agenity` Blueprint's `spec.version` to `0.5.13` (the chart carrying `imagePullSecrets: [ghcr-pull]`, the #4111 image-pull fix) but **left `spec.source.version` at `0.5.12`**. Flux resolves the chart from `source.version`, so every Sovereign still pulled `bp-agenity@0.5.12` (the OLD chart WITHOUT `imagePullSecrets`) — the per-Org agenity pod stayed `Init:ImagePullBackOff` on the private `ghcr.io/openova-io/agenity` image (401 anonymous).

## The fix (minimal, byte-clean)

- `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` — `bp-agenity` `spec.source.version` `0.5.12` → `0.5.13` (now matches `spec.version: "0.5.13"`).
- `products/catalyst/chart/Chart.yaml` — bp-catalyst-platform umbrella `1.4.909` → `1.4.910` so Flux re-rolls the catalog-seed (now that #4417 dropped `helm.sh/resource-policy:keep`, a matched `source.version` reaches the LIVE Blueprint CR zero-touch on the next helm upgrade).
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` — slot 13 pin `1.4.909` → `1.4.910` in lockstep.

Chart `0.5.13` is a published OCI artifact (`ghcr.io/openova-io/bp-agenity:0.5.13`, appVersion `0.9.7`).

## Local gates (all PASS)

- `check-bootstrap-kit-pin-sync.sh --changed-only` → `OK bp-catalyst-platform: chart=1.4.910 pin=1.4.910`.
- `check-catalog-seed-lockstep.sh` → `checked: 69  fail: 0`.
- `helm template … catalog-seed/blueprints.yaml` → `bp-agenity` renders `spec.version == source.version == 0.5.13`.

## Scope

This is the **image-pull half** of #4111. The **agentic-run half** (spawned claude-code agent has no OAuth credential) is unaddressed here and needs an Anthropic OAuth credential — #4111 stays open.

Refs #4111 #4494 #4417

🤖 Generated with [Claude Code](https://claude.com/claude-code)