### PR TITLE
feat(application-controller): #3969 §13 — arm the Continuum lease-witness off the desired-state targets[]

### DIFF
--- a/core/controllers/application/internal/controller/application_controller.go
+++ b/core/controllers/application/internal/controller/application_controller.go
@@ -816,7 +816,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 			// gate already ran above (step 5.1); here we only map the
 			// targets onto the renderer's (choice, variant) inputs.
 			capability := blueprintPlacementCapability(bp)
-			choice, variant = placementVariantFromTargets(spec.PlacementTargets, capability)
+			// §13 — pass the Blueprint's declared topology so the synthetic
+			// variant can carry the right replication backend forward into the
+			// Continuum lease-witness arming (cnpg-pair vs stateless). bpTopo is
+			// nil for the pure-#3969 placement-only path → stateless Promoter.
+			choice, variant = placementVariantFromTargets(spec.PlacementTargets, capability, bpTopo)
 			r.Log.Info("placement targets resolved (desired-state fan-out)",
 				"app", app.GetName(),
 				"blueprint", spec.BlueprintName,
@@ -1527,8 +1531,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 	// PhaseDegraded/PhaseFailed ⇒ degraded; otherwise ⇒ reconciling). When
 	// desired-state targets are declared we carry their richer
 	// Primary|Standby role + Hot|Cold type onto the rollup, region-matched.
+	// §13 — a non-empty continuumRef means the per-app Continuum lease-witness
+	// DR contract was minted, so every Hot standby target is ARMED for
+	// promotion. This is the desired-state arming signal surfaced on
+	// status.targets[].armed; the runtime lease-held state stays on the
+	// Continuum CR (continuum-controller-owned) and only the fresh-multi-region
+	// walk proves which region currently holds it.
 	readyByRegion := readbackByRegion(plan, finalPhase)
-	observed := observedTargetsFromPlan(plan, effectiveTargets, readyByRegion)
+	observed := observedTargetsFromPlan(plan, effectiveTargets, readyByRegion, continuumRef != "")
 	su.PlacementRecon, su.PlacementReason, su.ObservedTargets = reconStatusBlock(observed)
 
 	// #4416 — write the Continuum back-pointer the producer minted above so

--- a/core/controllers/application/internal/controller/placement_continuum_armed_test.go
+++ b/core/controllers/application/internal/controller/placement_continuum_armed_test.go
@@ -1,0 +1,174 @@
+// placement_continuum_arm_test.go — #3969 §13.
+//
+// The §13 seam this exercises: the per-app Continuum lease-witness DR contract
+// must be ARMED off the canonical desired-state placement (spec.placement.
+// targets[]), NOT only off the deprecated Blueprint.spec.topology posture. The
+// synthetic fan-out variant (placementVariantFromTargets) carries a synthesized
+// Switchover block when — and only when — the targets describe a DR-capable
+// placement (Primary + ≥1 Standby), so the SAME producer (buildContinuumPlan)
+// mints the DR contract that makes a Hot standby armed for promotion.
+//
+// What we assert:
+//
+//  1. A {Primary + Hot Standby} placement synthesizes a Switchover block and
+//     feeds buildContinuumPlan a DR contract (the §13 arming).
+//  2. The Blueprint's declared replication backend (cnpg-pair) is carried
+//     forward into the synthesized mechanism; absent ⇒ the generic stateless
+//     Promoter.
+//  3. A singleton (lone Primary) and an active-active (2 Primary) placement
+//     synthesize NO Switchover — the producer skips them (no DR to arm).
+//  4. A {Primary + Cold Standby} placement (active-passive) still arms a
+//     contract (the standby region exists) but resolves to stateless when the
+//     Blueprint declares no streaming backend.
+package controller
+
+import (
+	"testing"
+
+	"github.com/openova-io/openova/core/controllers/internal/placement"
+	bpv1alpha1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
+)
+
+// twoRegionPlanAB is the resolved plan the producer reads (primary region-a,
+// standby region-b) — the producer keys hotStandbyRegions off it.
+func twoRegionPlanAB() placement.Plan {
+	return placement.Plan{
+		PrimaryRegion: "hetzner-fsn-rtz-prod",
+		Regions: []placement.RegionPlan{
+			{Name: "hetzner-fsn-rtz-prod", Role: placement.RolePrimary},
+			{Name: "hetzner-nbg-rtz-prod", Role: placement.RoleStandby, Standby: true},
+		},
+	}
+}
+
+func hotStandbyTargets() []bpv1alpha1.PlacementTarget {
+	return []bpv1alpha1.PlacementTarget{
+		{Region: "hetzner-fsn-rtz-prod", Cluster: "mgmt-A", VCluster: "mgmt", Role: bpv1alpha1.DataRolePrimary},
+		{Region: "hetzner-nbg-rtz-prod", Cluster: "mgmt-B", VCluster: "mgmt", Role: bpv1alpha1.DataRoleStandby, StandbyType: bpv1alpha1.StandbyHot},
+	}
+}
+
+// TestPlacementVariantFromTargets_ArmsContinuum_HotStandby — the central §13
+// acceptance: a desired-state Hot-standby placement synthesizes a Switchover
+// block so buildContinuumPlan mints a DR contract.
+func TestPlacementVariantFromTargets_ArmsContinuum_HotStandby(t *testing.T) {
+	choice, variant := placementVariantFromTargets(
+		hotStandbyTargets(), bpv1alpha1.CapabilityPrimaryStandby, nil)
+
+	if choice != bpv1alpha1.BcpActiveHotStandby {
+		t.Fatalf("choice = %q, want active-hot-standby", choice)
+	}
+	if variant.Switchover == nil || variant.Switchover.Mechanism == "" {
+		t.Fatalf("Hot-standby placement must synthesize a Switchover block, got %+v", variant.Switchover)
+	}
+
+	// The producer must now mint a DR contract off the synthetic variant.
+	cp, ok := buildContinuumPlan("acme/obs", choice, variant, twoRegionPlanAB(), nil)
+	if !ok {
+		t.Fatal("buildContinuumPlan skipped a Hot-standby placement — the §13 arming did not reach the producer")
+	}
+	if cp.PrimaryRegion != "hetzner-fsn-rtz-prod" {
+		t.Errorf("primaryRegion = %q, want hetzner-fsn-rtz-prod", cp.PrimaryRegion)
+	}
+	if len(cp.StandbyRegions) != 1 || cp.StandbyRegions[0] != "hetzner-nbg-rtz-prod" {
+		t.Errorf("standbyRegions = %v, want [hetzner-nbg-rtz-prod]", cp.StandbyRegions)
+	}
+	// No Blueprint replication backend declared ⇒ generic stateless Promoter.
+	if cp.Mechanism != "stateless" {
+		t.Errorf("mechanism = %q, want stateless (no declared backend)", cp.Mechanism)
+	}
+}
+
+// TestPlacementVariantFromTargets_CarriesCNPGBackend — when the Blueprint
+// still declares a cnpg-pair replication backend for this pattern, the
+// synthesized switchover resolves to cnpg-pair (the CNPG primary streaming
+// flip), not the generic stateless Promoter.
+func TestPlacementVariantFromTargets_CarriesCNPGBackend(t *testing.T) {
+	bpTopo := &bpv1alpha1.Topology{
+		Supported: []bpv1alpha1.BcpTopology{bpv1alpha1.BcpActiveHotStandby},
+		PerTopology: map[bpv1alpha1.BcpTopology]bpv1alpha1.TopologyVariant{
+			bpv1alpha1.BcpActiveHotStandby: {
+				Replication: &bpv1alpha1.ReplicationSpec{Backend: "cnpg-pair", Mode: "sync"},
+			},
+		},
+	}
+	choice, variant := placementVariantFromTargets(
+		hotStandbyTargets(), bpv1alpha1.CapabilityPrimaryStandby, bpTopo)
+
+	cp, ok := buildContinuumPlan("acme/obs", choice, variant, twoRegionPlanAB(), nil)
+	if !ok {
+		t.Fatal("buildContinuumPlan skipped a cnpg-pair Hot-standby placement")
+	}
+	if cp.Mechanism != "cnpg-pair" {
+		t.Errorf("mechanism = %q, want cnpg-pair (carried from the Blueprint backend)", cp.Mechanism)
+	}
+}
+
+// TestPlacementVariantFromTargets_SingletonNotArmed — a lone Primary is a
+// singleton: NO Switchover synthesized, the producer skips it.
+func TestPlacementVariantFromTargets_SingletonNotArmed(t *testing.T) {
+	targets := []bpv1alpha1.PlacementTarget{
+		{Region: "hetzner-fsn-rtz-prod", Cluster: "mgmt-A", VCluster: "mgmt", Role: bpv1alpha1.DataRolePrimary},
+	}
+	choice, variant := placementVariantFromTargets(
+		targets, bpv1alpha1.CapabilityPrimaryStandby, nil)
+
+	if choice != bpv1alpha1.BcpSingleton {
+		t.Fatalf("choice = %q, want singleton", choice)
+	}
+	if variant.Switchover != nil {
+		t.Errorf("singleton must NOT synthesize a Switchover, got %+v", variant.Switchover)
+	}
+
+	singletonPlan := placement.Plan{
+		PrimaryRegion: "hetzner-fsn-rtz-prod",
+		Regions:       []placement.RegionPlan{{Name: "hetzner-fsn-rtz-prod", Role: placement.RolePrimary}},
+	}
+	if _, ok := buildContinuumPlan("acme/obs", choice, variant, singletonPlan, nil); ok {
+		t.Error("buildContinuumPlan must skip a singleton placement (no DR to arm)")
+	}
+}
+
+// TestPlacementVariantFromTargets_ActiveActiveNotArmed — two Primary targets
+// is active-active (multi-master): no primary/standby flip, NO Switchover.
+func TestPlacementVariantFromTargets_ActiveActiveNotArmed(t *testing.T) {
+	targets := []bpv1alpha1.PlacementTarget{
+		{Region: "hetzner-fsn-rtz-prod", Cluster: "mgmt-A", VCluster: "mgmt", Role: bpv1alpha1.DataRolePrimary},
+		{Region: "hetzner-nbg-rtz-prod", Cluster: "mgmt-B", VCluster: "mgmt", Role: bpv1alpha1.DataRolePrimary},
+	}
+	choice, variant := placementVariantFromTargets(
+		targets, bpv1alpha1.CapabilityMultiPrimary, nil)
+
+	if choice != bpv1alpha1.BcpActiveActive {
+		t.Fatalf("choice = %q, want active-active", choice)
+	}
+	if variant.Switchover != nil {
+		t.Errorf("active-active must NOT synthesize a Switchover, got %+v", variant.Switchover)
+	}
+}
+
+// TestPlacementVariantFromTargets_ColdStandbyArmsStateless — a Cold standby
+// (active-passive) still arms a DR contract (the standby region exists), but
+// with no streaming backend resolves to the stateless Promoter.
+func TestPlacementVariantFromTargets_ColdStandbyArmsStateless(t *testing.T) {
+	targets := []bpv1alpha1.PlacementTarget{
+		{Region: "hetzner-fsn-rtz-prod", Cluster: "mgmt-A", VCluster: "mgmt", Role: bpv1alpha1.DataRolePrimary},
+		{Region: "hetzner-nbg-rtz-prod", Cluster: "mgmt-B", VCluster: "mgmt", Role: bpv1alpha1.DataRoleStandby, StandbyType: bpv1alpha1.StandbyCold},
+	}
+	choice, variant := placementVariantFromTargets(
+		targets, bpv1alpha1.CapabilityPrimaryStandby, nil)
+
+	if choice != bpv1alpha1.BcpActivePassive {
+		t.Fatalf("choice = %q, want active-passive", choice)
+	}
+	if variant.Switchover == nil {
+		t.Fatalf("active-passive (Cold standby) must synthesize a Switchover so the standby region has a DR contract")
+	}
+	cp, ok := buildContinuumPlan("acme/obs", choice, variant, twoRegionPlanAB(), nil)
+	if !ok {
+		t.Fatal("buildContinuumPlan skipped an active-passive placement")
+	}
+	if cp.Mechanism != "stateless" {
+		t.Errorf("mechanism = %q, want stateless (Cold standby, no streaming backend)", cp.Mechanism)
+	}
+}

--- a/core/controllers/application/internal/controller/placement_fanout.go
+++ b/core/controllers/application/internal/controller/placement_fanout.go
@@ -69,11 +69,32 @@ import (
 //     the BcpTopology enum, for the LabelTopology label + observability only
 //     (it never gates the render — the per-target roles do).
 //
+// # §13 — arming the Continuum lease-witness off the desired-state targets
+//
+// The per-app Continuum CR producer (continuum.go buildContinuumPlan) is the
+// thing that makes a Hot standby ARMED for promotion (§13): it mints a
+// Continuum.dr.openova.io/v1 CR whose leaseClient the continuum-controller
+// drives so exactly one region holds the write-lease at a time. That producer
+// gates on `variant.Switchover.Mechanism != ""`. Before this change the
+// synthetic variant carried ONLY a Placement block (no Switchover), so a
+// `targets[]`-declared {Primary + Hot Standby} placement produced NO Continuum
+// CR — the new desired-state model could declare a Hot standby but never arm
+// it. synthesizeSwitchover closes that: when the targets describe a DR-capable
+// placement (≥2 targets with ≥1 Standby), it stamps a Switchover block on the
+// synthetic variant so the SAME producer mints the DR contract off the new
+// model — keyed off the targets' roles, NOT the deprecated Blueprint.spec.
+// topology posture. The mechanism resolves from the Blueprint's declared
+// replication backend (when it still declares one) so a cnpg-pair app arms a
+// cnpg-pair switchover and a stateless app arms the generic DNS-flip Promoter.
+//
 // Returns (choice, variant). variant is always non-nil with a non-empty
-// Clusters slice when targets is non-empty (the caller guards len>0).
+// Clusters slice when targets is non-empty (the caller guards len>0). When the
+// placement is DR-capable the variant additionally carries a synthesized
+// Switchover (+ Replication) block so the Continuum producer arms it.
 func placementVariantFromTargets(
 	targets []bpv1alpha1.PlacementTarget,
 	capability bpv1alpha1.PlacementCapability,
+	bpTopo *bpv1alpha1.Topology,
 ) (bpv1alpha1.BcpTopology, *bpv1alpha1.TopologyVariant) {
 	clusters := make([]string, 0, len(targets))
 	roles := make(map[string]string, len(targets))
@@ -123,7 +144,106 @@ func placementVariantFromTargets(
 	}
 
 	choice := patternToBcpTopology(bpv1alpha1.DerivePattern(targets, capability))
+
+	// §13 — arm the Continuum lease-witness off the desired-state targets.
+	// A DR-capable placement (≥2 targets, ≥1 Standby) gets a synthesized
+	// Switchover (+ Replication) block so the per-app Continuum CR producer
+	// (buildContinuumPlan) mints the DR contract. A singleton / active-active
+	// placement gets no Switchover (the producer skips it — nothing to fail
+	// over to / no primary-standby flip to drive).
+	if sw, repl := synthesizeSwitchover(targets, choice, bpTopo); sw != nil {
+		variant.Switchover = sw
+		variant.Replication = repl
+	}
+
 	return choice, variant
+}
+
+// synthesizeSwitchover builds the Switchover (+ Replication) block that ARMS
+// the per-app Continuum lease-witness for a DR-capable desired-state placement
+// (§13). It returns (nil, nil) when the placement is NOT DR-capable — a
+// singleton (one Primary, no Standby) or active-active (multi-master, no
+// primary/standby flip to orchestrate) — so the Continuum producer skips it,
+// preserving the existing "no CR for non-DR apps" invariant.
+//
+// DR-capable = a single-primary topology with ≥1 Standby target:
+// active-hot-standby (Hot standby — a live, lease-armed replica) or
+// active-passive (Cold standby — rebuild-on-failover). Both flow to the
+// producer; the standby TYPE (Hot|Cold) is what the Continuum lease-witness
+// uses to decide whether the standby is a live promotion target vs a
+// rebuild-from-bucket follower.
+//
+// Mechanism resolution carries the Blueprint's DECLARED replication backend
+// forward (when it still declares one for this pattern) so the synthesized
+// switchover resolves to the right concrete mechanism:
+//   - a cnpg-pair backend → cnpg-pair switchover (CNPG primary streaming flip);
+//   - a raft backend       → raft-transition;
+//   - any other / none     → stateless (the generic DNS-flip-only Promoter).
+//
+// When the Blueprint declares NO topology block at all (the pure-#3969 path —
+// the placement is the SOLE source of truth), the mechanism defaults to
+// `bp-continuum`, the authoring alias resolveSwitchoverMechanism maps onto the
+// concrete mechanism by replication backend (stateless when none). This keeps
+// the arming keyed off the targets' roles, never the deprecated posture enum.
+func synthesizeSwitchover(
+	targets []bpv1alpha1.PlacementTarget,
+	choice bpv1alpha1.BcpTopology,
+	bpTopo *bpv1alpha1.Topology,
+) (*bpv1alpha1.SwitchoverSpec, *bpv1alpha1.ReplicationSpec) {
+	// Only the two single-primary DR topologies have a switchover to arm.
+	if choice != bpv1alpha1.BcpActiveHotStandby && choice != bpv1alpha1.BcpActivePassive {
+		return nil, nil
+	}
+	// Defensive: a DR topology must carry ≥2 targets with ≥1 Standby. (The
+	// pattern derivation already guarantees this for the two choices above,
+	// but we re-check so a malformed target list can never arm an empty
+	// hot-standby contract.)
+	var primaries, standbys int
+	for _, t := range targets {
+		switch t.Role {
+		case bpv1alpha1.DataRolePrimary:
+			primaries++
+		case bpv1alpha1.DataRoleStandby:
+			standbys++
+		}
+	}
+	if primaries == 0 || standbys == 0 {
+		return nil, nil
+	}
+
+	// Carry forward the Blueprint's declared replication block for this
+	// pattern, when it still declares one — that backend drives the concrete
+	// mechanism. Absent ⇒ nil, and the bp-continuum alias resolves to
+	// stateless (the generic DNS-flip Promoter).
+	repl := blueprintReplicationFor(choice, bpTopo)
+
+	mechanism := "bp-continuum" // authoring alias — resolved by backend below.
+	if repl != nil {
+		switch repl.Backend {
+		case "cnpg-pair":
+			mechanism = "cnpg-pair"
+		case "raft", "openbao-raft", "raft-transition":
+			mechanism = "raft-transition"
+		}
+	}
+	return &bpv1alpha1.SwitchoverSpec{Mechanism: mechanism}, repl
+}
+
+// blueprintReplicationFor returns the Blueprint's declared replication block
+// for the resolved pattern, when the Blueprint still carries a
+// `spec.topology.perTopology[<choice>].replication` block. Returns nil when
+// the Blueprint declares no topology (the pure-#3969 placement-only path) or
+// no replication for this pattern — in which case the synthesized switchover
+// arms the generic stateless Promoter. Read-only; never mutates bpTopo.
+func blueprintReplicationFor(choice bpv1alpha1.BcpTopology, bpTopo *bpv1alpha1.Topology) *bpv1alpha1.ReplicationSpec {
+	if bpTopo == nil || bpTopo.PerTopology == nil {
+		return nil
+	}
+	v, ok := bpTopo.PerTopology[choice]
+	if !ok {
+		return nil
+	}
+	return v.Replication
 }
 
 // patternToBcpTopology maps the #3969 DERIVED pattern label onto the legacy

--- a/core/controllers/application/internal/controller/placement_recon.go
+++ b/core/controllers/application/internal/controller/placement_recon.go
@@ -189,10 +189,20 @@ func resolveBackingPlacement(
 // readyByRegion maps a region name → its observed readiness; a region
 // absent from the map (HR not yet present) is treated as not-ready
 // (Reconciling), never degraded.
+// The `drArmed` flag (#3969 §13) is true when the controller minted a
+// per-app Continuum lease-witness DR contract for this Application (a
+// non-empty continuumRef). When set, every Hot standby target is marked
+// Armed — the DESIRED-STATE arming signal (a DR contract exists, the standby
+// is governed for promotion). A Cold standby is never armed (rebuild-on-
+// failover); a Primary is never armed (it is the write target, not a
+// promotion candidate). The RUNTIME lease-held state stays on the Continuum
+// CR's status, owned by the continuum-controller — only the fresh-multi-
+// region walk proves which region holds the lease.
 func observedTargetsFromPlan(
 	plan placement.Plan,
 	targets []bpv1alpha1.PlacementTarget,
 	readyByRegion map[string]regionReadback,
+	drArmed bool,
 ) []bpv1alpha1.ObservedTarget {
 	// Index the desired targets by region for the richer role/standbyType.
 	byRegion := map[string]bpv1alpha1.PlacementTarget{}
@@ -217,6 +227,11 @@ func observedTargetsFromPlan(
 			} else {
 				ot.Role = bpv1alpha1.DataRolePrimary
 			}
+		}
+
+		// §13 — a Hot standby in a DR-armed placement is ARMED for promotion.
+		if drArmed && ot.Role == bpv1alpha1.DataRoleStandby && ot.StandbyType == bpv1alpha1.StandbyHot {
+			ot.Armed = true
 		}
 
 		if rb, ok := readyByRegion[rp.Name]; ok {
@@ -300,6 +315,12 @@ func reconStatusBlock(observed []bpv1alpha1.ObservedTarget) (status, reason stri
 		}
 		if t.Degraded {
 			row["degraded"] = true
+		}
+		if t.Armed {
+			// §13 — the Hot standby is armed for promotion (a Continuum
+			// lease-witness DR contract was minted). The Topology tab's
+			// standby card reads this to render "Hot · armed".
+			row["armed"] = true
 		}
 		targets = append(targets, row)
 	}

--- a/core/controllers/application/internal/controller/placement_recon_test.go
+++ b/core/controllers/application/internal/controller/placement_recon_test.go
@@ -209,7 +209,7 @@ func TestObservedTargetsFromPlan_PrefersDesiredRoles(t *testing.T) {
 		{Region: "region-b", Cluster: "mgmt-B", Role: bpv1alpha1.DataRoleStandby, StandbyType: bpv1alpha1.StandbyHot},
 	}
 	ready := readbackByRegion(plan, PhaseReady)
-	obs := observedTargetsFromPlan(plan, targets, ready)
+	obs := observedTargetsFromPlan(plan, targets, ready, false)
 	if len(obs) != 2 {
 		t.Fatalf("observed len = %d, want 2", len(obs))
 	}
@@ -218,6 +218,53 @@ func TestObservedTargetsFromPlan_PrefersDesiredRoles(t *testing.T) {
 	}
 	if !obs[0].Ready || !obs[1].Ready {
 		t.Errorf("PhaseReady must mark every region ready, got %+v", obs)
+	}
+	// drArmed=false ⇒ no target armed (no Continuum DR contract minted).
+	for i, ot := range obs {
+		if ot.Armed {
+			t.Errorf("obs[%d].Armed = true with drArmed=false; want false", i)
+		}
+	}
+}
+
+// TestObservedTargetsFromPlan_ArmsHotStandbyWhenDRContract — §13: with a
+// minted Continuum DR contract (drArmed=true) the Hot standby target is
+// ARMED for promotion; the Primary and any Cold standby never are.
+func TestObservedTargetsFromPlan_ArmsHotStandbyWhenDRContract(t *testing.T) {
+	plan := placement.Plan{
+		PrimaryRegion: "region-a",
+		Regions: []placement.RegionPlan{
+			{Name: "region-a", Role: placement.RolePrimary},
+			{Name: "region-b", Role: placement.RoleStandby, Standby: true},
+			{Name: "region-c", Role: placement.RoleStandby, Standby: true},
+		},
+	}
+	targets := []bpv1alpha1.PlacementTarget{
+		{Region: "region-a", Cluster: "mgmt-A", Role: bpv1alpha1.DataRolePrimary},
+		{Region: "region-b", Cluster: "mgmt-B", Role: bpv1alpha1.DataRoleStandby, StandbyType: bpv1alpha1.StandbyHot},
+		{Region: "region-c", Cluster: "mgmt-C", Role: bpv1alpha1.DataRoleStandby, StandbyType: bpv1alpha1.StandbyCold},
+	}
+	obs := observedTargetsFromPlan(plan, targets, readbackByRegion(plan, PhaseReady), true)
+	if obs[0].Armed {
+		t.Errorf("Primary must never be Armed, got %+v", obs[0])
+	}
+	if !obs[1].Armed {
+		t.Errorf("Hot standby must be Armed when a DR contract is minted, got %+v", obs[1])
+	}
+	if obs[2].Armed {
+		t.Errorf("Cold standby must never be Armed (rebuild-on-failover), got %+v", obs[2])
+	}
+
+	// The wire row carries armed:true ONLY for the Hot standby.
+	_, _, rows := reconStatusBlock(obs)
+	if rows[0].(map[string]interface{})["armed"] != nil {
+		t.Errorf("Primary wire row must omit armed, got %+v", rows[0])
+	}
+	if rows[1].(map[string]interface{})["armed"] != true {
+		t.Errorf("Hot standby wire row must carry armed:true, got %+v", rows[1])
+	}
+	if rows[2].(map[string]interface{})["armed"] != nil {
+		t.Errorf("Cold standby wire row must omit armed, got %+v", rows[2])
 	}
 }
 
@@ -229,7 +276,7 @@ func TestObservedTargetsFromPlan_LegacyPlanWithoutTargets(t *testing.T) {
 		},
 	}
 	// No desired targets ⇒ map the legacy plan roles.
-	obs := observedTargetsFromPlan(plan, nil, readbackByRegion(plan, PhaseProvisioning))
+	obs := observedTargetsFromPlan(plan, nil, readbackByRegion(plan, PhaseProvisioning), false)
 	if obs[0].Role != bpv1alpha1.DataRolePrimary || obs[1].Role != bpv1alpha1.DataRoleStandby {
 		t.Errorf("legacy plan roles = %q/%q, want Primary/Standby", obs[0].Role, obs[1].Role)
 	}

--- a/core/controllers/pkg/apis/blueprint/v1alpha1/recon_status.go
+++ b/core/controllers/pkg/apis/blueprint/v1alpha1/recon_status.go
@@ -34,6 +34,17 @@ type ObservedTarget struct {
 	// Degraded — the target's HR reported a hard failure (Ready=False with
 	// a terminal reason, or past its reconcile budget).
 	Degraded bool `json:"degraded,omitempty"`
+	// Armed — #3969 §13: this is a Hot standby in a DR-capable placement
+	// for which a Continuum lease-witness DR contract was minted, i.e. the
+	// standby is ARMED for promotion (a live replica governed by the
+	// continuum-controller's lease). This is the DESIRED-STATE arming
+	// signal (a DR contract exists) — distinct from the RUNTIME lease-held
+	// state (which region currently holds the write-lease), which the
+	// continuum-controller owns on the Continuum CR's status and which only
+	// the fresh-multi-region walk can prove. A Cold standby is never armed
+	// (rebuild-on-failover, runs no process); a singleton / active-active
+	// placement has no standby to arm.
+	Armed bool `json:"armed,omitempty"`
 }
 
 // PlacementStatus is the §7.4 status block: ONE status value, an optional

--- a/core/controllers/pkg/apis/blueprint/v1alpha1/recon_status_test.go
+++ b/core/controllers/pkg/apis/blueprint/v1alpha1/recon_status_test.go
@@ -41,4 +41,20 @@ func TestDeriveReconStatus(t *testing.T) {
 			t.Fatalf("placement = %q, want Reconciling", s.Placement)
 		}
 	})
+
+	// §13 — the Armed attribute is orthogonal to the recon status: an armed
+	// Hot standby that is still reconciling stays Reconciling (Armed is a
+	// display attribute of the standby, never a second status value), and an
+	// armed-and-ready placement is Reconciled. Armed never fabricates a class.
+	t.Run("Armed is orthogonal to recon status", func(t *testing.T) {
+		armedReady := ObservedTarget{Region: "region-b", Role: DataRoleStandby, StandbyType: StandbyHot, Ready: true, Armed: true}
+		armedNotReady := ObservedTarget{Region: "region-b", Role: DataRoleStandby, StandbyType: StandbyHot, Ready: false, Armed: true}
+
+		if s := DeriveReconStatus([]ObservedTarget{primary, armedReady}); s.Placement != ReconStatusReconciled {
+			t.Errorf("armed+ready ⇒ Reconciled, got %q", s.Placement)
+		}
+		if s := DeriveReconStatus([]ObservedTarget{primary, armedNotReady}); s.Placement != ReconStatusReconciling {
+			t.Errorf("armed+not-ready ⇒ Reconciling, got %q", s.Placement)
+		}
+	})
 }


### PR DESCRIPTION
## What

Closes the genuinely-remaining #3969 §13 seam: the per-app **Continuum lease-witness DR contract** — the thing that makes a **Hot standby armed for promotion** — was minted ONLY off the deprecated `Blueprint.spec.topology` posture, never off the canonical `spec.placement.targets[]` desired-state model.

`placementVariantFromTargets` synthesized a fan-out variant with ONLY a `Placement` block (no `Switchover`), so `buildContinuumPlan` (gates on `variant.Switchover.Mechanism != ""`) rejected it. Result: a `targets[]`-declared `{Primary + Hot Standby}` placement rendered its HelmReleases but produced **NO Continuum CR** → the standby was never armed.

## Changes (additive + backward-compatible)

- **`synthesizeSwitchover`** (`placement_fanout.go`): a DR-capable placement (Primary + ≥1 Standby) gets a synthesized `Switchover` (+ `Replication`) block so the **same** producer arms the DR contract. Singleton / active-active synthesize nothing (producer skips them — no DR to arm). Mechanism carries the Blueprint's declared replication backend forward: `cnpg-pair → cnpg-pair`, `raft → raft-transition`, else the generic `stateless` DNS-flip Promoter.
- **`ObservedTarget.Armed`** + `status.targets[].armed` wire field (`recon_status.go`, `placement_recon.go`): a Hot standby in a DR-armed placement (`continuumRef != ""`) is marked **armed** — the *desired-state* arming signal. A Cold standby and a Primary are never armed. The *runtime* lease-held state stays on the Continuum CR (continuum-controller-owned), provable only on the fresh-multi-region walk.

## Tests (all green)

- `TestPlacementVariantFromTargets_ArmsContinuum_HotStandby`
- `TestPlacementVariantFromTargets_CarriesCNPGBackend`
- `TestPlacementVariantFromTargets_SingletonNotArmed`
- `TestPlacementVariantFromTargets_ActiveActiveNotArmed`
- `TestPlacementVariantFromTargets_ColdStandbyArmsStateless`
- `TestObservedTargetsFromPlan_ArmsHotStandbyWhenDRContract`

`go build` / `go vet` / `go test` 0 across the controllers module (39 pkgs ok). Existing `continuum_test.go` + fan-out tests pass untouched; a placement with no `targets[]` still resolves via the legacy `ResolveTopology` fallback unchanged.

## What still needs the fresh-multi-region walk (provider-capacity gated)

The **runtime** half of §13 — that the armed Hot standby's witness lease is actually held by exactly one region, that a switchover flips the lease + promotes, and the DoD §10 items 1–9 (zero-contradiction Topology tab, provision-write, switchover, singleton→multi, capability-gate denial, owned-dep cascade, shared-dep recommendation) — is acceptance-gated on a fresh 2-region prov. No spare provider capacity right now.

Refs #3969