### PR TITLE
fix(bp-plane-isolation #4499): add catalyst-system to openbao allowIngressFrom — catalyst-api k8s-auth to OpenBao Cilium-dropped → secret/catalyst/* ExternalSecrets SecretSyncedError (0.1.10)

### DIFF
--- a/clusters/_template/bootstrap-kit/26b-bp-plane-isolation.yaml
+++ b/clusters/_template/bootstrap-kit/26b-bp-plane-isolation.yaml
@@ -121,7 +121,16 @@ spec:
       #   OCI publish stops wedging — the all-template lookup-guard renders ZERO
       #   resources client-side by design (the gate's short-render trip). Annotation-
       #   only; no policy/behaviour change vs 0.1.8.
-      version: 0.1.9
+      # 0.1.10 (#4499 / Refs #4325 #4448 #4477 #4277): add catalyst-system to openbao's
+      #   INGRESS allowlist. The openbao default-deny covered external-secrets-system +
+      #   cnpg-system + sso-bridge (#4448) but OMITTED catalyst-system — so catalyst-api's
+      #   kubernetes-auth login to openbao.openbao.svc:8200 (read/write secret/catalyst/*
+      #   — newapi admin-token #4477, anthropic token #4277, mcp-bearer) was Cilium-
+      #   dropped → login timeout → every ExternalSecret on a secret/catalyst/* path went
+      #   SecretSyncedError → the seeds never landed. Same de-vcluster ingress-gap class
+      #   as #4448 (sso-bridge→openbao). Network-only: catalyst-api's k8s-auth role is
+      #   already bound.
+      version: 0.1.10
       sourceRef:
         kind: HelmRepository
         name: bp-plane-isolation

--- a/platform/plane-isolation/blueprint.yaml
+++ b/platform/plane-isolation/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 0.1.9  # lockstep with chart/Chart.yaml (#4468 — smoke-render-mode=default-off so the OCI publish stops wedging on the empty client-side render)
+  version: 0.1.10  # lockstep with chart/Chart.yaml (#4499 — add catalyst-system to openbao allowIngressFrom)
   card:
     title: Plane isolation (per-component default-deny)
     summary: |

--- a/platform/plane-isolation/chart/Chart.yaml
+++ b/platform/plane-isolation/chart/Chart.yaml
@@ -142,7 +142,19 @@ name: bp-plane-isolation
 #   published. The annotation tells the gate the short render is expected (full
 #   dial-graph covered by tests/e2e/bootstrap-kit renderUnconditional contract).
 #   No template/behaviour change — annotation + lockstep bump only.
-version: 0.1.9
+# 0.1.10 (#4499 / Refs #4325 #4448 #4477 #4277): ADD catalyst-system to openbao's
+#   allowIngressFrom. The openbao default-deny INGRESS allowlist covered
+#   external-secrets-system + cnpg-system + sso-bridge (#4448) but OMITTED
+#   catalyst-system — so catalyst-api's kubernetes-auth login to
+#   openbao.openbao.svc:8200 (to read/write secret/catalyst/* — newapi admin-token
+#   #4477, anthropic token #4277, mcp-bearer) was Cilium-dropped → login timeout →
+#   every ExternalSecret on a secret/catalyst/* path went SecretSyncedError → the
+#   seeds never landed. De-vcluster (#4325) split openbao into its own host ns, so
+#   the catalyst-system → openbao dial needs an explicit ingress carve-out. Same
+#   network-only de-vcluster ingress-gap class as #4448 (sso-bridge→openbao) and
+#   #4382 (org-services→gitea). The auth path is already wired (catalyst-api's
+#   k8s-auth role bound); this was purely the missing network ingress edge.
+version: 0.1.10
 description: |
   Per-component default-deny + explicit-allow micro-segmentation for the
   de-vclustered platform planes (#4291 Workstream C). For each platform

--- a/platform/plane-isolation/chart/values.yaml
+++ b/platform/plane-isolation/chart/values.yaml
@@ -101,6 +101,14 @@ components:
     allowIngressFrom:
       - external-secrets-system    # ESO authenticates to openbao:8200 (the vault-region1 store)
       - cnpg-system                # CNPG operator → openbao audit/storage adjuncts (when used)
+      - catalyst-system            # catalyst-api logs into openbao.openbao.svc:8200 via
+                                   # kubernetes-auth to read/write secret/catalyst/* (newapi
+                                   # admin-token #4477, anthropic token #4277, mcp-bearer). De-vcluster
+                                   # split openbao into its own host ns post-#4325 → without this
+                                   # carve-out Cilium drops the login dial → timeout → every
+                                   # ExternalSecret on a secret/catalyst/* path is SecretSyncedError.
+                                   # Network-only gap, same class as sso-bridge below (Refs #4325
+                                   # #4499 #4448 #4477 #4277).
       - sso-bridge                 # bp-sso-bridge (G91.1 #2652) logs into openbao.openbao.svc:8200
                                    # each reconciler tick (k8s-auth, SA sso-bridge-reconciler) to
                                    # fetch/store the per-app KC OIDC client_secret bundle under

--- a/tests/e2e/bootstrap-kit/main_test.go
+++ b/tests/e2e/bootstrap-kit/main_test.go
@@ -1158,12 +1158,15 @@ func TestBootstrapKit_PlaneIsolationDialGraphIsCovered(t *testing.T) {
 		"nats-system": {"org-services", "guacamole", "catalyst-system", "newapi"},
 		// Shared object store — its blob-storage consumers (default-off but legitimate).
 		"seaweedfs": {"gitea", "harbor", "loki", "mimir", "tempo", "velero", "guacamole", "catalyst-system", "sandbox"},
-		// Secrets engine — ESO reads it, CNPG operator manages adjuncts, and
+		// Secrets engine — ESO reads it, CNPG operator manages adjuncts,
 		// bp-sso-bridge logs in each reconciler tick (k8s-auth) to fetch/store
-		// the per-app KC OIDC client_secret bundle. Missing sso-bridge → the
-		// reconciler curl(28)-timeouts → no secret/sso/* → grafana/hubble/gitea
-		// SSO secrets never materialize → 503/503/500 (#4448, kom4dc b9f9590b).
-		"openbao": {"external-secrets-system", "cnpg-system", "sso-bridge"},
+		// the per-app KC OIDC client_secret bundle, and catalyst-api logs in via
+		// kubernetes-auth to read/write secret/catalyst/* (newapi admin-token,
+		// anthropic token, mcp-bearer). Missing sso-bridge → no secret/sso/* →
+		// grafana/hubble/gitea SSO 503/503/500 (#4448). Missing catalyst-system →
+		// catalyst-api login times out → every secret/catalyst/* ExternalSecret
+		// goes SecretSyncedError (#4499, Refs #4477 #4277). kom4dc b9f9590b.
+		"openbao": {"external-secrets-system", "cnpg-system", "sso-bridge", "catalyst-system"},
 		// Dashboards — SSO + ESO + its own Postgres backend.
 		"grafana": {"external-secrets-system", "cnpg-system"},
 		// Log/metric/trace stores — their queriers + shippers.


### PR DESCRIPTION
## Fault

The `openbao-default-deny` NetworkPolicy rendered by `platform/plane-isolation/chart` OMITS `catalyst-system` from its OpenBao ingress allow-list. The list covered `external-secrets-system` + `cnpg-system` + `sso-bridge` (#4448) but not `catalyst-system`.

After de-vcluster (#4325) split openbao into its own host namespace, catalyst-api's kubernetes-auth login to `openbao.openbao.svc:8200` is Cilium-dropped (timeout). Effect: every ExternalSecret reading a `secret/catalyst/*` path goes `SecretSyncedError` → the seeds never land:

- newapi admin-token (#4477 secondary)
- anthropic token write-path (#4277)
- mcp-bearer

Same de-vcluster ingress-gap class as #4448 (sso-bridge→openbao) and #4382 (org-services→gitea). Network-only: catalyst-api's k8s-auth role is already bound — purely the missing network ingress edge.

## Fix (mirrors #4448)

- `platform/plane-isolation/chart/values.yaml`: add `catalyst-system` to the openbao block's `allowIngressFrom`.
- Chart `0.1.9 → 0.1.10`; `platform/plane-isolation/blueprint.yaml` + bootstrap-kit slot `26b` pin lockstep.
- `tests/e2e/bootstrap-kit/main_test.go`: add `catalyst-system` to the Case-30 `wantEdges` openbao entry.

## Verification

- **Test FAILS without the values fix** — `TestBootstrapKit_PlaneIsolationDialGraphIsCovered` errors: `namespace "openbao" is dialed by "catalyst-system" ... but "catalyst-system" is MISSING from "openbao"'s allowIngressFrom`.
- **Test PASSES with the values fix.** Full bootstrap-kit suite green.
- `helm template --set renderUnconditional=true --api-versions cilium.io/v2` renders the openbao-default-deny ingress namespaceSelector list as `[external-secrets-system, cnpg-system, catalyst-system, sso-bridge]` (+ implicit flux-system / same-ns / kube-system).
- `helm lint` clean.

This is the root cause behind #4477 (secondary) + #4277 (anthropic write-path). It rolls on the next fresh prov and when plane-isolation re-rolls on the live env. Issues stay open: the seeds still need to fire + #4277 still needs a real Anthropic credential for the VALUE.

Refs #4499 #4477 #4277 #4448 #4325

🤖 Generated with [Claude Code](https://claude.com/claude-code)