### PR TITLE
feat(infra+catalyst): console-isolation toggle to fit a 3-EIP single-region validation prov

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1403,6 +1403,20 @@ spec:
       # MUST persist to local Gitea source-of-truth).
       imageRegistry: ''
     ingress:
+      gateway:
+        parentRef:
+          # #4053 console-isolation toggle (Refs #4431 #4212). Threaded from
+          # cloud-init's SOVEREIGN_CONSOLE_GATEWAY postBuild substitute (fed by
+          # tofu var console_isolation_enabled). Default cilium-gateway-console
+          # (the chart's own default, #4053 poison-proof isolation). On a 3-EIP
+          # single-region validation prov where the dedicated console ELB is NOT
+          # created (console_isolation_enabled=false), this resolves to
+          # cilium-gateway so the catalyst-ui/catalyst-api HTTPRoutes re-parent
+          # onto the SHARED gateway and the console still resolves at the
+          # primary LB IP (no #4070-shape 404-with-TLS-green). When the
+          # substitute is absent (legacy contabo/Catalyst-Zero Kustomize build)
+          # the envsubst fallback keeps the chart default.
+          name: ${SOVEREIGN_CONSOLE_GATEWAY:-cilium-gateway-console}
       hosts:
         console:
           host: console.${SOVEREIGN_FQDN}

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -499,6 +499,14 @@ write_files:
             SOVEREIGN_DEPLOYMENT_ID: ${deployment_id}
             # #4236 console-ELB IPv4 → slot-13 sovereignConsoleLBIP (see that file).
             SOVEREIGN_CONSOLE_LB_IP: ${console_load_balancer_ipv4}
+            # #4053 console-isolation toggle (Refs #4431 #4212) → slot-13
+            # ingress.gateway.parentRef.name. When console_isolation_enabled is
+            # "true" (default) the console HTTPRoutes parent the DEDICATED
+            # cilium-gateway-console (poison-proof CEC isolation). When "false"
+            # (a 3-EIP single-region validation prov that drops the console ELB)
+            # they re-parent onto the SHARED cilium-gateway so the console still
+            # resolves at the primary LB IP (no #4070-shape 404-with-TLS-green).
+            SOVEREIGN_CONSOLE_GATEWAY: "${console_isolation_enabled == "true" ? "cilium-gateway-console" : "cilium-gateway"}"
             # #4236/#4179: primary LB IPv4 → slot-13 sovereignLBIP → ConfigMap lbIP
             # (was undeclared here → lbIP empty → org-controller pool-DNS skip).
             SOVEREIGN_LB_IP: ${load_balancer_ipv4}

--- a/infra/providers/hetzner/main.tf
+++ b/infra/providers/hetzner/main.tf
@@ -294,6 +294,14 @@ resource "hcloud_ssh_key" "main" {
 locals {
   control_plane_count = var.ha_enabled ? 3 : 1
 
+  # #4053 console-isolation gate (Refs #4431 #4212). When "true" (default) the
+  # dedicated console LB stack is created; "false" drops it (console front
+  # doors collapse onto hcloud_load_balancer.main). The console LB-target
+  # resources fan out per node, so their counts multiply by the gate.
+  console_isolation_on             = var.console_isolation_enabled == "true"
+  console_cp_target_count          = local.console_isolation_on ? local.control_plane_count : 0
+  console_worker_target_count      = local.console_isolation_on ? var.worker_count : 0
+
   # Wildcard cert ClusterIssuer selector (Fix #176 — qa-loop iter-1 LE
   # PROD rate-limit unblock for clusters/_template/sovereign-tls/cilium-
   # gateway-cert.yaml). The sovereign-tls Kustomization's
@@ -872,6 +880,9 @@ locals {
     gitops_repo_url          = var.gitops_repo_url
     gitops_branch            = var.gitops_branch
     marketplace_enabled      = var.marketplace_enabled
+    # #4053 console-isolation toggle (Refs #4431 #4212) → shared template's
+    # SOVEREIGN_CONSOLE_GATEWAY substitute → slot-13 ingress.gateway.parentRef.name.
+    console_isolation_enabled = var.console_isolation_enabled
     wildcard_cert_issuer     = local.wildcard_cert_issuer
     bcp_topology             = var.bcp_topology
     enable_hot_standby       = var.enable_hot_standby
@@ -909,7 +920,7 @@ locals {
     # cloud-init → bootstrap-kit slot 13 → sovereign-fqdn ConfigMap `consoleLBIP`
     # → organization-controller so the per-Org pool-DNS `console.<slug>.<pool>`
     # A-record targets the console front door (the #4179 final layer).
-    console_load_balancer_ipv4 = hcloud_load_balancer.console.ipv4
+    console_load_balancer_ipv4 = local.console_isolation_on ? hcloud_load_balancer.console[0].ipv4 : ""
 
     # Huawei-branch substitute vars — passed empty/placeholder on Hetzner so
     # the shared template's `provider == "huawei"` block parses (tofu
@@ -1168,6 +1179,7 @@ resource "hcloud_load_balancer_service" "dns" {
 # front gateway (TLSRoute is a startup CRD presence-check only on 1.16.x), which
 # rules out the single-IP front-gateway alternative.
 resource "hcloud_load_balancer" "console" {
+  count              = local.console_isolation_on ? 1 : 0
   name               = "catalyst-${replace(var.sovereign_fqdn, ".", "-")}-console-lb"
   load_balancer_type = "lb11"
   location           = var.region
@@ -1181,7 +1193,8 @@ resource "hcloud_load_balancer" "console" {
 }
 
 resource "hcloud_load_balancer_network" "console" {
-  load_balancer_id = hcloud_load_balancer.console.id
+  count            = local.console_isolation_on ? 1 : 0
+  load_balancer_id = hcloud_load_balancer.console[0].id
   network_id       = hcloud_network.region["primary"].id
   # .253 — one below the shared LB's .254 anchor (see hcloud_load_balancer_
   # network.main). Pins the console LB's private IP so it cannot race the CP /
@@ -1195,9 +1208,9 @@ resource "hcloud_load_balancer_network" "console" {
 # DaemonSet on every node and binds BOTH 30443 (shared) and 31443 (console), so
 # every node is a valid target for the console LB too.
 resource "hcloud_load_balancer_target" "console_control_plane" {
-  count            = local.control_plane_count
+  count            = local.console_cp_target_count
   type             = "server"
-  load_balancer_id = hcloud_load_balancer.console.id
+  load_balancer_id = hcloud_load_balancer.console[0].id
   server_id        = hcloud_server.control_plane[count.index].id
   use_private_ip   = true
 
@@ -1205,9 +1218,9 @@ resource "hcloud_load_balancer_target" "console_control_plane" {
 }
 
 resource "hcloud_load_balancer_target" "console_workers" {
-  count            = var.worker_count
+  count            = local.console_worker_target_count
   type             = "server"
-  load_balancer_id = hcloud_load_balancer.console.id
+  load_balancer_id = hcloud_load_balancer.console[0].id
   server_id        = hcloud_server.worker[count.index].id
   use_private_ip   = true
 
@@ -1218,7 +1231,8 @@ resource "hcloud_load_balancer_target" "console_workers" {
 }
 
 resource "hcloud_load_balancer_service" "console_http" {
-  load_balancer_id = hcloud_load_balancer.console.id
+  count            = local.console_isolation_on ? 1 : 0
+  load_balancer_id = hcloud_load_balancer.console[0].id
   protocol         = "tcp"
   listen_port      = 80
   # 31080 — the console gateway's HTTP host-port (cilium-gateway-console.yaml).
@@ -1226,7 +1240,8 @@ resource "hcloud_load_balancer_service" "console_http" {
 }
 
 resource "hcloud_load_balancer_service" "console_https" {
-  load_balancer_id = hcloud_load_balancer.console.id
+  count            = local.console_isolation_on ? 1 : 0
+  load_balancer_id = hcloud_load_balancer.console[0].id
   protocol         = "tcp"
   listen_port      = 443
   # 31443 — the console gateway's HTTPS host-port. TLS terminates at the
@@ -1406,6 +1421,9 @@ locals {
       gitops_repo_url          = var.gitops_repo_url
       gitops_branch            = var.gitops_branch
       marketplace_enabled      = var.marketplace_enabled
+      # #4053 console-isolation toggle (Refs #4431 #4212) → shared template's
+      # SOVEREIGN_CONSOLE_GATEWAY substitute → slot-13 ingress.gateway.parentRef.name.
+      console_isolation_enabled = var.console_isolation_enabled
       wildcard_cert_issuer     = local.wildcard_cert_issuer
       bcp_topology             = var.bcp_topology
       enable_hot_standby       = var.enable_hot_standby
@@ -1444,7 +1462,7 @@ locals {
       # ${console_load_balancer_ipv4} substitute resolves. The organization-
       # controller only runs in the primary region but the substitute must be
       # defined in both templatefile() calls.
-      console_load_balancer_ipv4 = hcloud_load_balancer.console.ipv4
+      console_load_balancer_ipv4 = local.console_isolation_on ? hcloud_load_balancer.console[0].ipv4 : ""
 
       # Huawei-branch substitute vars — inert on Hetzner (see primary call),
       # EXCEPT sovereign_region_role: live via the shared

--- a/infra/providers/hetzner/main.tf
+++ b/infra/providers/hetzner/main.tf
@@ -298,9 +298,9 @@ locals {
   # dedicated console LB stack is created; "false" drops it (console front
   # doors collapse onto hcloud_load_balancer.main). The console LB-target
   # resources fan out per node, so their counts multiply by the gate.
-  console_isolation_on             = var.console_isolation_enabled == "true"
-  console_cp_target_count          = local.console_isolation_on ? local.control_plane_count : 0
-  console_worker_target_count      = local.console_isolation_on ? var.worker_count : 0
+  console_isolation_on        = var.console_isolation_enabled == "true"
+  console_cp_target_count     = local.console_isolation_on ? local.control_plane_count : 0
+  console_worker_target_count = local.console_isolation_on ? var.worker_count : 0
 
   # Wildcard cert ClusterIssuer selector (Fix #176 — qa-loop iter-1 LE
   # PROD rate-limit unblock for clusters/_template/sovereign-tls/cilium-
@@ -873,23 +873,23 @@ locals {
     replica_region_canonical_label = length(local.secondary_regions) > 0 ? (
       local.region_canonical_label[keys(local.secondary_regions)[0]]
     ) : ""
-    cluster_mesh_name        = var.cluster_mesh_name
-    cluster_mesh_id          = var.cluster_mesh_id
-    k3s_version              = var.k3s_version
-    k3s_token                = local.k3s_token
-    gitops_repo_url          = var.gitops_repo_url
-    gitops_branch            = var.gitops_branch
-    marketplace_enabled      = var.marketplace_enabled
+    cluster_mesh_name   = var.cluster_mesh_name
+    cluster_mesh_id     = var.cluster_mesh_id
+    k3s_version         = var.k3s_version
+    k3s_token           = local.k3s_token
+    gitops_repo_url     = var.gitops_repo_url
+    gitops_branch       = var.gitops_branch
+    marketplace_enabled = var.marketplace_enabled
     # #4053 console-isolation toggle (Refs #4431 #4212) → shared template's
     # SOVEREIGN_CONSOLE_GATEWAY substitute → slot-13 ingress.gateway.parentRef.name.
     console_isolation_enabled = var.console_isolation_enabled
-    wildcard_cert_issuer     = local.wildcard_cert_issuer
-    bcp_topology             = var.bcp_topology
-    enable_hot_standby       = var.enable_hot_standby
-    enable_shared_pg         = var.enable_shared_pg
-    default_storage_class    = var.default_storage_class
-    sovereign_cnpg_instances = length(var.regions) > 1 ? "2" : "1"
-    continuum_enabled        = length(var.regions) > 1 ? "true" : "false"
+    wildcard_cert_issuer      = local.wildcard_cert_issuer
+    bcp_topology              = var.bcp_topology
+    enable_hot_standby        = var.enable_hot_standby
+    enable_shared_pg          = var.enable_shared_pg
+    default_storage_class     = var.default_storage_class
+    sovereign_cnpg_instances  = length(var.regions) > 1 ? "2" : "1"
+    continuum_enabled         = length(var.regions) > 1 ? "true" : "false"
     parent_domains_yaml = coalesce(
       var.parent_domains_yaml,
       format("[{name: \"%s\", role: \"primary\"}]", var.sovereign_fqdn)
@@ -1414,23 +1414,23 @@ locals {
       replica_region_canonical_label = length(local.secondary_regions) > 0 ? (
         local.region_canonical_label[keys(local.secondary_regions)[0]]
       ) : ""
-      cluster_mesh_name        = local.secondary_region_cluster_mesh_name[k]
-      cluster_mesh_id          = local.secondary_region_cluster_mesh_id[k]
-      k3s_version              = var.k3s_version
-      k3s_token                = local.k3s_token
-      gitops_repo_url          = var.gitops_repo_url
-      gitops_branch            = var.gitops_branch
-      marketplace_enabled      = var.marketplace_enabled
+      cluster_mesh_name   = local.secondary_region_cluster_mesh_name[k]
+      cluster_mesh_id     = local.secondary_region_cluster_mesh_id[k]
+      k3s_version         = var.k3s_version
+      k3s_token           = local.k3s_token
+      gitops_repo_url     = var.gitops_repo_url
+      gitops_branch       = var.gitops_branch
+      marketplace_enabled = var.marketplace_enabled
       # #4053 console-isolation toggle (Refs #4431 #4212) → shared template's
       # SOVEREIGN_CONSOLE_GATEWAY substitute → slot-13 ingress.gateway.parentRef.name.
       console_isolation_enabled = var.console_isolation_enabled
-      wildcard_cert_issuer     = local.wildcard_cert_issuer
-      bcp_topology             = var.bcp_topology
-      enable_hot_standby       = var.enable_hot_standby
-      enable_shared_pg         = var.enable_shared_pg
-      default_storage_class    = var.default_storage_class
-      sovereign_cnpg_instances = length(var.regions) > 1 ? "2" : "1"
-      continuum_enabled        = length(var.regions) > 1 ? "true" : "false"
+      wildcard_cert_issuer      = local.wildcard_cert_issuer
+      bcp_topology              = var.bcp_topology
+      enable_hot_standby        = var.enable_hot_standby
+      enable_shared_pg          = var.enable_shared_pg
+      default_storage_class     = var.default_storage_class
+      sovereign_cnpg_instances  = length(var.regions) > 1 ? "2" : "1"
+      continuum_enabled         = length(var.regions) > 1 ? "true" : "false"
       parent_domains_yaml = coalesce(
         var.parent_domains_yaml,
         format("[{name: \"%s\", role: \"primary\"}]", var.sovereign_fqdn)

--- a/infra/providers/hetzner/outputs.tf
+++ b/infra/providers/hetzner/outputs.tf
@@ -20,8 +20,8 @@ output "load_balancer_ip" {
 # that pre-dates #4053 ignores this output and PDM falls back to
 # load_balancer_ip for every record (byte-identical to pre-#4053 behaviour).
 output "console_load_balancer_ip" {
-  description = "Public IPv4 of the dedicated console load balancer (console./api.<fqdn> point here; #4053 gateway isolation)"
-  value       = hcloud_load_balancer.console.ipv4
+  description = "Public IPv4 of the dedicated console load balancer (console./api.<fqdn> point here; #4053 gateway isolation). EMPTY when console_isolation_enabled=false — the catalyst-api DNS-writer then collapses console/api/marketplace onto load_balancer_ip (sovereign_dns_records.go, test-covered)."
+  value       = length(hcloud_load_balancer.console) > 0 ? hcloud_load_balancer.console[0].ipv4 : ""
 }
 
 output "sovereign_fqdn" {

--- a/infra/providers/hetzner/variables.tf
+++ b/infra/providers/hetzner/variables.tf
@@ -46,6 +46,27 @@ variable "marketplace_enabled" {
   }
 }
 
+# ── #4053 console gateway isolation toggle (Refs #4431 #4212) ──────────────
+# Companion to the Huawei port's `console_isolation_enabled`. When 'true' (the
+# canonical default) the Sovereign provisions the dedicated console LB
+# (hcloud_load_balancer.console + its targets/services) so the console./api./
+# marketplace. front doors ride an isolated cilium-gateway-console whose CEC
+# can never be poisoned by a half-converged app on the shared gateway (#4053).
+# When 'false' the dedicated console LB stack is NOT created — the console
+# front doors collapse onto hcloud_load_balancer.main and bp-catalyst-platform
+# re-parents the catalyst-ui/catalyst-api HTTPRoutes onto the shared
+# cilium-gateway (SOVEREIGN_CONSOLE_GATEWAY substitute) so the console still
+# resolves. Set from catalyst-api Request.ConsoleIsolationEnabled.
+variable "console_isolation_enabled" {
+  type        = string
+  description = "When 'true' (canonical default) the Sovereign provisions the dedicated console LB (#4053 gateway isolation). 'false' drops the console LB stack (console front doors collapse onto the shared LB + cilium-gateway). Set from catalyst-api Request.ConsoleIsolationEnabled."
+  default     = "true"
+  validation {
+    condition     = contains(["true", "false"], var.console_isolation_enabled)
+    error_message = "console_isolation_enabled must be the string 'true' or 'false'."
+  }
+}
+
 # ── BCP topology (Refs #2666 G93.1) ──────────────────────────────────────
 # Business-Continuity-Planning topology the operator chose at provision
 # time. The canonical seam between the Catalyst console's wizard

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -990,7 +990,7 @@ locals {
       # (default isolation); "false" → cilium-gateway (shared) so the console
       # resolves even when no dedicated console ELB exists.
       console_isolation_enabled = var.console_isolation_enabled
-      wildcard_cert_issuer     = var.wildcard_cert_use_staging == "true" ? "letsencrypt-dns01-staging-powerdns" : "letsencrypt-dns01-prod-powerdns"
+      wildcard_cert_issuer      = var.wildcard_cert_use_staging == "true" ? "letsencrypt-dns01-staging-powerdns" : "letsencrypt-dns01-prod-powerdns"
 
       ghcr_pull_username = local.ghcr_pull_username
       ghcr_pull_token    = var.ghcr_pull_token
@@ -1378,8 +1378,8 @@ locals {
   # a 3-EIP single-region validation prov. The member resources fan out per
   # node, so their count is the node count multiplied by the gate (0 → no
   # members when isolation is off).
-  console_isolation_on  = var.console_isolation_enabled == "true"
-  console_member_count  = local.console_isolation_on ? length(local.primary_lb_node_ips) : 0
+  console_isolation_on = var.console_isolation_enabled == "true"
+  console_member_count = local.console_isolation_on ? length(local.primary_lb_node_ips) : 0
 }
 
 resource "huaweicloud_elb_member" "https" {

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -984,6 +984,12 @@ locals {
       sovereign_cnpg_instances = length(var.regions) > 1 ? "2" : "1"
       continuum_enabled        = length(var.regions) > 1 ? "true" : "false"
       marketplace_enabled      = var.marketplace_enabled
+      # #4053 console-isolation toggle (Refs #4431 #4212). Threads into the
+      # shared template's SOVEREIGN_CONSOLE_GATEWAY substitute → slot-13
+      # ingress.gateway.parentRef.name. "true" → cilium-gateway-console
+      # (default isolation); "false" → cilium-gateway (shared) so the console
+      # resolves even when no dedicated console ELB exists.
+      console_isolation_enabled = var.console_isolation_enabled
       wildcard_cert_issuer     = var.wildcard_cert_use_staging == "true" ? "letsencrypt-dns01-staging-powerdns" : "letsencrypt-dns01-prod-powerdns"
 
       ghcr_pull_username = local.ghcr_pull_username
@@ -1012,7 +1018,7 @@ locals {
       # cloud-init → bootstrap-kit slot 13 → sovereign-fqdn ConfigMap `consoleLBIP`
       # → organization-controller so the per-Org pool-DNS `console.<slug>.<pool>`
       # A-record targets the console front door (the #4179 final layer).
-      console_load_balancer_ipv4 = huaweicloud_vpc_eip.elb_console.publicip.0.ip_address
+      console_load_balancer_ipv4 = local.console_isolation_on ? huaweicloud_vpc_eip.elb_console[0].publicip.0.ip_address : ""
 
       # ── Provider-injected strings (the §5 hard-dependency exceptions) ──
       registry_mirror_yaml          = local.registry_mirror_yaml_huawei
@@ -1366,6 +1372,14 @@ locals {
       if w.region == local.region_keys[0]
     ],
   )
+
+  # #4053 console-isolation gate (Refs #4431 #4212). When "true" (default) the
+  # dedicated console ELB stack is created; "false" drops it to save one EIP on
+  # a 3-EIP single-region validation prov. The member resources fan out per
+  # node, so their count is the node count multiplied by the gate (0 → no
+  # members when isolation is off).
+  console_isolation_on  = var.console_isolation_enabled == "true"
+  console_member_count  = local.console_isolation_on ? length(local.primary_lb_node_ips) : 0
 }
 
 resource "huaweicloud_elb_member" "https" {
@@ -1428,6 +1442,7 @@ resource "huaweicloud_elb_monitor" "http" {
 # Byte-identical design to the Hetzner console LB (infra/providers/hetzner).
 
 resource "huaweicloud_vpc_eip" "elb_console" {
+  count = local.console_isolation_on ? 1 : 0
   publicip {
     type = "5_bgp"
   }
@@ -1440,10 +1455,11 @@ resource "huaweicloud_vpc_eip" "elb_console" {
 }
 
 resource "huaweicloud_elb_loadbalancer" "console" {
+  count             = local.console_isolation_on ? 1 : 0
   name              = "${local.name_prefix}-elb-console"
   vpc_id            = huaweicloud_vpc.region[local.region_keys[0]].id
   ipv4_subnet_id    = huaweicloud_vpc_subnet.region[local.region_keys[0]].ipv4_subnet_id
-  ipv4_eip_id       = huaweicloud_vpc_eip.elb_console.id
+  ipv4_eip_id       = huaweicloud_vpc_eip.elb_console[0].id
   availability_zone = [var.huawei_az]
   description       = "Catalyst Sovereign ${var.sovereign_fqdn} — #4053 dedicated CONSOLE gateway 443→31443 + 80→31080 routing"
 
@@ -1461,37 +1477,41 @@ resource "huaweicloud_elb_loadbalancer" "console" {
 }
 
 resource "huaweicloud_elb_pool" "console_https" {
+  count           = local.console_isolation_on ? 1 : 0
   name            = "${local.name_prefix}-elb-pool-console-https"
   protocol        = "TCP"
   lb_method       = "ROUND_ROBIN"
-  loadbalancer_id = huaweicloud_elb_loadbalancer.console.id
+  loadbalancer_id = huaweicloud_elb_loadbalancer.console[0].id
   description     = "cilium-gateway-console targets on port 31443"
 }
 
 resource "huaweicloud_elb_pool" "console_http" {
+  count           = local.console_isolation_on ? 1 : 0
   name            = "${local.name_prefix}-elb-pool-console-http"
   protocol        = "TCP"
   lb_method       = "ROUND_ROBIN"
-  loadbalancer_id = huaweicloud_elb_loadbalancer.console.id
+  loadbalancer_id = huaweicloud_elb_loadbalancer.console[0].id
   description     = "cilium-gateway-console targets on port 31080"
 }
 
 resource "huaweicloud_elb_listener" "console_https" {
-  loadbalancer_id = huaweicloud_elb_loadbalancer.console.id
+  count           = local.console_isolation_on ? 1 : 0
+  loadbalancer_id = huaweicloud_elb_loadbalancer.console[0].id
   name            = "${local.name_prefix}-elb-listener-console-https"
   protocol        = "TCP"
   protocol_port   = 443
-  default_pool_id = huaweicloud_elb_pool.console_https.id
+  default_pool_id = huaweicloud_elb_pool.console_https[0].id
   idle_timeout    = 60
   description     = "TCP passthrough — cilium-gateway-console terminates TLS at 31443"
 }
 
 resource "huaweicloud_elb_listener" "console_http" {
-  loadbalancer_id = huaweicloud_elb_loadbalancer.console.id
+  count           = local.console_isolation_on ? 1 : 0
+  loadbalancer_id = huaweicloud_elb_loadbalancer.console[0].id
   name            = "${local.name_prefix}-elb-listener-console-http"
   protocol        = "TCP"
   protocol_port   = 80
-  default_pool_id = huaweicloud_elb_pool.console_http.id
+  default_pool_id = huaweicloud_elb_pool.console_http[0].id
   idle_timeout    = 60
   description     = "TCP passthrough — console HTTP→HTTPS redirect"
 }
@@ -1500,23 +1520,24 @@ resource "huaweicloud_elb_listener" "console_http" {
 # cilium-envoy runs on every node and binds BOTH 30443 (shared) and 31443
 # (console), so every node is a valid console-ELB target on 31443/31080.
 resource "huaweicloud_elb_member" "console_https" {
-  count         = length(local.primary_lb_node_ips)
-  pool_id       = huaweicloud_elb_pool.console_https.id
+  count         = local.console_member_count
+  pool_id       = huaweicloud_elb_pool.console_https[0].id
   address       = local.primary_lb_node_ips[count.index]
   protocol_port = 31443
   subnet_id     = huaweicloud_vpc_subnet.region[local.region_keys[0]].ipv4_subnet_id
 }
 
 resource "huaweicloud_elb_member" "console_http" {
-  count         = length(local.primary_lb_node_ips)
-  pool_id       = huaweicloud_elb_pool.console_http.id
+  count         = local.console_member_count
+  pool_id       = huaweicloud_elb_pool.console_http[0].id
   address       = local.primary_lb_node_ips[count.index]
   protocol_port = 31080
   subnet_id     = huaweicloud_vpc_subnet.region[local.region_keys[0]].ipv4_subnet_id
 }
 
 resource "huaweicloud_elb_monitor" "console_https" {
-  pool_id     = huaweicloud_elb_pool.console_https.id
+  count       = local.console_isolation_on ? 1 : 0
+  pool_id     = huaweicloud_elb_pool.console_https[0].id
   protocol    = "TCP"
   port        = 31443
   interval    = 10
@@ -1525,7 +1546,8 @@ resource "huaweicloud_elb_monitor" "console_https" {
 }
 
 resource "huaweicloud_elb_monitor" "console_http" {
-  pool_id     = huaweicloud_elb_pool.console_http.id
+  count       = local.console_isolation_on ? 1 : 0
+  pool_id     = huaweicloud_elb_pool.console_http[0].id
   protocol    = "TCP"
   port        = 31080
   interval    = 10

--- a/infra/providers/huawei/outputs.tf
+++ b/infra/providers/huawei/outputs.tf
@@ -20,8 +20,8 @@ output "load_balancer_ip" {
 # consoleLoadBalancerIP. Empty-safe: a pre-#4053 consumer ignores it and PDM
 # falls back to load_balancer_ip for every record.
 output "console_load_balancer_ip" {
-  description = "Public EIP of the dedicated console ELB (console./api.<fqdn> point here; #4053 gateway isolation)."
-  value       = huaweicloud_vpc_eip.elb_console.publicip.0.ip_address
+  description = "Public EIP of the dedicated console ELB (console./api.<fqdn> point here; #4053 gateway isolation). EMPTY when console_isolation_enabled=false — the catalyst-api DNS-writer then collapses console/api/marketplace onto load_balancer_ip (sovereign_dns_records.go, test-covered)."
+  value       = length(huaweicloud_vpc_eip.elb_console) > 0 ? huaweicloud_vpc_eip.elb_console[0].publicip.0.ip_address : ""
 }
 
 output "sovereign_fqdn" {

--- a/infra/providers/huawei/variables.tf
+++ b/infra/providers/huawei/variables.tf
@@ -408,6 +408,33 @@ variable "marketplace_enabled" {
   EOT
 }
 
+# ── #4053 console gateway isolation toggle (Refs #4431 #4212) ──────────────
+# When true (the canonical default), the Sovereign provisions the DEDICATED
+# console ELB (huaweicloud_elb_loadbalancer.console + its own EIP/pools/
+# listeners/members/monitors) so the console./api./marketplace. front doors
+# ride an isolated cilium-gateway-console whose CEC can never be poisoned by a
+# half-converged app on the shared gateway (#4053).
+#
+# When false, the dedicated console ELB stack is NOT created → the Sovereign
+# consumes ONE FEWER public EIP (cp + nat + elb_primary = 3 instead of 4). The
+# console_load_balancer_ip output then resolves EMPTY, which the catalyst-api
+# DNS-writer (sovereign_dns_records.go recordTargetIP, test-covered) already
+# collapses onto elb_primary for every record — and bp-catalyst-platform
+# re-parents the catalyst-ui/catalyst-api HTTPRoutes onto the shared
+# cilium-gateway (SOVEREIGN_CONSOLE_GATEWAY substitute) so the console still
+# resolves (no #4070-shape 404). This is the seam that lets a single-region
+# validation prov fit a 3-free-EIP kom4dc pool. Set 'false' for those provs;
+# production stays byte-identical on the 'true' default.
+variable "console_isolation_enabled" {
+  type        = string
+  description = "When 'true' (canonical default) the Sovereign provisions the dedicated console ELB + EIP (#4053 gateway isolation). 'false' drops the console ELB stack (one fewer EIP; console front doors collapse onto elb_primary + the shared cilium-gateway) — used by 3-EIP single-region validation provs. Set from catalyst-api Request.ConsoleIsolationEnabled."
+  default     = "true"
+  validation {
+    condition     = contains(["true", "false"], var.console_isolation_enabled)
+    error_message = "console_isolation_enabled must be the string 'true' or 'false'."
+  }
+}
+
 # ── BCP topology (Refs #2666 G93.1) ────────────────────────────────────
 # Companion to the Hetzner port's `bcp_topology` + `enable_hot_standby`
 # vars. Pre-G93.1 the Huawei cloud-init template OMITTED the

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -253,6 +253,26 @@ func bcpTopologyEnableHotStandby(topology string) string {
 	}
 }
 
+// consoleIsolationEnabled resolves the #4053 console-isolation toggle (Refs
+// #4431 #4212) for a Request, applying the default-TRUE rule:
+//
+//   - Request.ConsoleIsolationEnabled == nil (the POST omitted the field — the
+//     common case + every legacy/automation payload) → true (the canonical
+//     production posture: dedicated console ELB + isolated cilium-gateway-
+//     console, byte-identical to pre-#4431 behaviour).
+//   - Request.ConsoleIsolationEnabled == &false → false (the 3-EIP single-
+//     region validation shape: no console ELB, console front doors collapse
+//     onto elb_primary + the shared cilium-gateway).
+//   - Request.ConsoleIsolationEnabled == &true → true (explicit production).
+//
+// One source of truth shared by writeTfvars() and the unit tests.
+func consoleIsolationEnabled(req Request) bool {
+	if req.ConsoleIsolationEnabled == nil {
+		return true
+	}
+	return *req.ConsoleIsolationEnabled
+}
+
 // Per-provider default StorageClass names — the durable cloud-block-storage
 // CSI class each provider's bootstrap-kit installs and flips to
 // cluster-default (#3971/#892). These are the FALLBACKS the operator gets
@@ -543,6 +563,35 @@ type Request struct {
 	// — operator opts in via wizard's "Enable Marketplace" component
 	// checkbox.
 	MarketplaceEnabled bool `json:"marketplaceEnabled"`
+
+	// ConsoleIsolationEnabled — #4053 dedicated-console-gateway toggle (Refs
+	// #4431 #4212). When true (the canonical default, set in NewRequest /
+	// applyDefaults below), the Sovereign provisions the dedicated console ELB
+	// + its own public EIP so the console./api./marketplace. front doors ride
+	// an isolated cilium-gateway-console whose CEC can never be poisoned by a
+	// half-converged app on the shared gateway (#4053). The catalyst-ui /
+	// catalyst-api HTTPRoutes parent that dedicated gateway.
+	//
+	// When false, the dedicated console ELB stack is NOT created — the
+	// Sovereign consumes ONE FEWER public EIP (cp + nat + elb_primary = 3
+	// instead of 4), the console_load_balancer_ip tofu output resolves EMPTY
+	// (the DNS-writer recordTargetIP collapses console/api/marketplace onto
+	// elb_primary, sovereign_dns_records.go, test-covered), and the
+	// SOVEREIGN_CONSOLE_GATEWAY cloud-init substitute re-parents the console
+	// HTTPRoutes onto the SHARED cilium-gateway so the console still resolves
+	// (no #4070-shape 404-with-TLS-green). This is the seam that lets a
+	// single-region validation prov fit a 3-free-EIP kom4dc pool.
+	//
+	// Threaded through the EXACT same seam as MarketplaceEnabled: this Request
+	// field → tofu var `console_isolation_enabled` (string "true"/"false") →
+	// the IaC console-ELB `count` gate + the cloud-init SOVEREIGN_CONSOLE_GATEWAY
+	// substitute → bootstrap-kit slot 13 ingress.gateway.parentRef.name.
+	//
+	// Default TRUE (production posture). A POST that omits this field lands the
+	// isolated-console production shape, byte-identical to today. A pointer so
+	// "omitted" (nil → defaulted true) is distinguishable from an explicit
+	// false; applyConsoleIsolationDefault() resolves it.
+	ConsoleIsolationEnabled *bool `json:"consoleIsolationEnabled,omitempty"`
 
 	// EnableSharedPostgres — opt-in switch for the ADR-0010 reusable,
 	// shareable backing-services model (#3188). When true, bootstrap-kit
@@ -2598,6 +2647,19 @@ func writeTfvars(deployDir string, req Request) error {
 		// Kustomization postBuild.substitute block at cloud-init render
 		// time without quoting surprises.
 		"marketplace_enabled": map[bool]string{true: "true", false: "false"}[req.MarketplaceEnabled],
+
+		// #4053 console-isolation toggle (Refs #4431 #4212). Stringified
+		// "true"/"false" for the same envsubst-passthrough reason as
+		// marketplace_enabled. true (the default, resolved by
+		// consoleIsolationEnabled when the field is omitted) → the IaC
+		// console-ELB `count` gate provisions the dedicated console ELB + EIP
+		// and the cloud-init SOVEREIGN_CONSOLE_GATEWAY substitute keeps the
+		// console HTTPRoutes on cilium-gateway-console (#4053 isolation).
+		// false → the console ELB stack is dropped (one fewer EIP) and the
+		// console re-parents onto the shared cilium-gateway. The matching
+		// infra/providers/{hetzner,huawei}/variables.tf carry the
+		// `["true","false"]` validation so a typo fails at `tofu plan`.
+		"console_isolation_enabled": map[bool]string{true: "true", false: "false"}[consoleIsolationEnabled(req)],
 
 		// QA fixtures auto-enable (Fix #73 — qa-loop bounded-cycle iter-16).
 		// Stringified for symmetric reasons as marketplace_enabled. When

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner_console_isolation_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner_console_isolation_test.go
@@ -1,0 +1,79 @@
+// provisioner_console_isolation_test.go — #4053 console-isolation toggle
+// coverage (Refs #4431 #4212).
+//
+// The boolean (pointer) Request.ConsoleIsolationEnabled field stringifies to
+// the `console_isolation_enabled` tofu var, which:
+//   - gates the dedicated console-ELB `count` in
+//     infra/providers/{hetzner,huawei}/main.tf, and
+//   - feeds the shared cloud-init template's SOVEREIGN_CONSOLE_GATEWAY
+//     substitute → bootstrap-kit slot 13 ingress.gateway.parentRef.name.
+//
+// Default-TRUE rule (the production posture): an OMITTED field (nil pointer)
+// resolves to "true" so a fresh prov is byte-identical to today (dedicated
+// console ELB + isolated cilium-gateway-console). An explicit false drops the
+// console ELB (one fewer EIP) and re-parents the console onto the shared
+// cilium-gateway — the 3-EIP single-region validation shape.
+package provisioner
+
+import "testing"
+
+func boolPtr(b bool) *bool { return &b }
+
+// 1. Omitted (nil pointer) → default TRUE — production posture preserved.
+func TestWriteTfvars_ConsoleIsolation_DefaultResolvesTrue(t *testing.T) {
+	req := tfvarsRequest(t)
+	// ConsoleIsolationEnabled left nil (the omit-from-POST default).
+
+	out := writeTfvarsSharedPG(t, req)
+
+	if got := out["console_isolation_enabled"]; got != "true" {
+		t.Errorf("console_isolation_enabled = %v, want %q (omitted → dedicated console ELB + isolated gateway, production-byte-identical)", got, "true")
+	}
+}
+
+// 2. Explicit true → TRUE.
+func TestWriteTfvars_ConsoleIsolation_ExplicitTrueResolvesTrue(t *testing.T) {
+	req := tfvarsRequest(t)
+	req.ConsoleIsolationEnabled = boolPtr(true)
+
+	out := writeTfvarsSharedPG(t, req)
+
+	if got := out["console_isolation_enabled"]; got != "true" {
+		t.Errorf("console_isolation_enabled = %v, want %q (explicit true)", got, "true")
+	}
+}
+
+// 3. Explicit false → FALSE — the 3-EIP validation shape (no console ELB,
+//    console re-parents onto the shared cilium-gateway).
+func TestWriteTfvars_ConsoleIsolation_ExplicitFalseResolvesFalse(t *testing.T) {
+	req := tfvarsRequest(t)
+	req.ConsoleIsolationEnabled = boolPtr(false)
+
+	out := writeTfvarsSharedPG(t, req)
+
+	if got := out["console_isolation_enabled"]; got != "false" {
+		t.Errorf("console_isolation_enabled = %v, want %q (explicit false → drop console ELB, shared gateway)", got, "false")
+	}
+}
+
+// consoleIsolationEnabled() helper — the single source of truth for the
+// default-TRUE resolution. Pin all three branches directly.
+func TestConsoleIsolationEnabled_Default(t *testing.T) {
+	cases := []struct {
+		name string
+		in   *bool
+		want bool
+	}{
+		{"nil-pointer-defaults-true", nil, true},
+		{"explicit-true", boolPtr(true), true},
+		{"explicit-false", boolPtr(false), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := Request{ConsoleIsolationEnabled: tc.in}
+			if got := consoleIsolationEnabled(req); got != tc.want {
+				t.Errorf("consoleIsolationEnabled(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/scripts/cloudinit-size-check.sh
+++ b/scripts/cloudinit-size-check.sh
@@ -127,6 +127,7 @@ fixture_cp_common() {
     enable_unattended_upgrades        = true
     enable_fail2ban                   = true
     marketplace_enabled               = "false"
+    console_isolation_enabled         = "true"
     continuum_enabled                 = "false"
     bcp_topology                      = "single-region"
     enable_hot_standby                = "false"

--- a/scripts/lint-cloudinit.sh
+++ b/scripts/lint-cloudinit.sh
@@ -108,6 +108,7 @@ fixture_common() {
     enable_unattended_upgrades        = true
     enable_fail2ban                   = true
     marketplace_enabled               = "false"
+    console_isolation_enabled         = "true"
     continuum_enabled                 = "false"
     bcp_topology                      = "single-region"
     enable_hot_standby                = "false"


### PR DESCRIPTION
## What

Add a `console_isolation_enabled` toggle (default **true** = production unchanged) that, when set false, drops the dedicated #4053 console ELB so a single-region Sovereign prov consumes **3 EIPs** (cp + nat + elb_primary) instead of 4 — fitting a 3-free-EIP kom4dc pool for a throwaway validation prov.

## GATE-A — IaC (`infra/providers/{huawei,hetzner}`)

- New `variable "console_isolation_enabled"` (default `"true"`, `["true","false"]` validation) in both providers.
- The console-ELB stack is `count`-gated to 0 when false:
  - **Huawei**: `elb_console` EIP + `console` loadbalancer + 2 pools + 2 listeners + 2 members + 2 monitors.
  - **Hetzner**: `console` LB + network + CP/worker targets + 2 services.
- `console_load_balancer_ip` output resolves **empty** when off (`length(...) > 0 ? ...[0] : ""`). The catalyst-api DNS-writer (`sovereign_dns_records.go` `recordTargetIP`) already collapses console/api/marketplace onto `elb_primary` when consoleLBIP is empty — the existing `sovereign_dns_records_test.go` regression test is untouched and passes.

## GATE-B — chart + cloud-init

- Shared `cloudinit-control-plane.tftpl` gains a `SOVEREIGN_CONSOLE_GATEWAY` postBuild substitute (`console_isolation_enabled == "true" ? "cilium-gateway-console" : "cilium-gateway"`).
- Bootstrap-kit slot-13 sets `ingress.gateway.parentRef.name: ${SOVEREIGN_CONSOLE_GATEWAY:-cilium-gateway-console}` so the catalyst-ui/catalyst-api/catalog/marketplace HTTPRoutes re-parent onto the **shared** `cilium-gateway` when isolation is off — the console resolves at the primary LB IP (no #4070-shape 404-with-TLS-green). Default keeps `cilium-gateway-console` (the chart's own default).

## GATE-B — provisioner

- `Request.ConsoleIsolationEnabled *bool` (nil → true via `consoleIsolationEnabled()`) → tofu var `console_isolation_enabled`. An omitted POST field lands the production isolated-console shape; an explicit `false` fires the 3-EIP validation shape. No deployments-handler change needed (pointer-based default).

## Default-safe

`console_isolation_enabled` defaults true in the variable, the provisioner helper, the cloud-init substitute fallback, and the chart value — **production is byte-identical**.

## Verification

- `tofu validate` clean on **both** modules (huawei + hetzner).
- `go build ./...` + `go vet` clean.
- New `provisioner_console_isolation_test.go` (default-true / explicit-true / explicit-false + helper branches) passes.
- Existing `sovereign_dns_records_test.go` regression test passes (empty consoleLBIP collapses onto lbIP).
- `helm template` confirms parentRef renders `cilium-gateway-console` by default and `cilium-gateway` under override, for both `httproute.yaml` and the catalog route.

Refs #4431 #4212

🤖 Generated with [Claude Code](https://claude.com/claude-code)