### PR TITLE
fix(cloud-init): retry + fail-fast the Cilium CNI install — kill the silent-no-CNI fresh-prov wedge (Refs #4503 #1934)

### DIFF
--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -1157,32 +1157,42 @@ runcmd:
   # asserting/defaulting local-path is exactly the anti-pattern #3971 forbids.
 
 %{ if deployment_id != "" && kubeconfig_bearer_token != "" && catalyst_api_url != "" ~}
-  # ══════════════════════════════════════════════════════════════════════
   # KUBECONFIG PUT-BACK — STRUCTURAL INVARIANT (#3129): runs HERE, right
   # after apiserver /healthz and BEFORE gateway-api/cilium/flux. Nothing
-  # downstream can block it. The PUT block is provider-injected because the
-  # public-IP source + multi-region gating differ (hard dependency), but
-  # the ORDERING is identical and fixed for every cloud.
-  # ══════════════════════════════════════════════════════════════════════
+  # downstream can block it. The PUT block is provider-injected (the public-IP
+  # source + multi-region gating differ — a hard dependency), but the ORDERING
+  # is identical and fixed for every cloud.
   ${indent(2, kubeconfig_put_block)}
 %{ endif ~}
 
-  # ── gateway-api CRDs: ONE official bundle apply (lean Hetzner pattern) ─
-  # Flux's bp-gateway-api re-applies post-bootstrap; this single apply just
-  # unblocks the Cilium operator's gateway-controller at its OWN boot.
+  # ── gateway-api CRDs: ONE official bundle apply (Flux's bp-gateway-api
+  # re-applies post-bootstrap; this just unblocks the Cilium gateway-controller).
   - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.1.0/experimental-install.yaml'
   - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml wait --for=condition=Established crd/tlsroutes.gateway.networking.k8s.io --timeout=60s'
 
-  # ── Cilium CNI: single helm install from the structured values file ───
-  - 'curl -sSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash'
-  - 'helm repo add cilium https://helm.cilium.io/'
-  - 'helm repo update'
+  # ── Cilium CNI: helm install + retry/fail-fast (#4503; rationale below) ─
   - |
-    KUBECONFIG=/etc/rancher/k3s/k3s.yaml helm install cilium cilium/cilium \
-      --version 1.16.5 \
-      --namespace kube-system \
-      -f /var/lib/catalyst/cilium-values.yaml
-  - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml -n kube-system rollout status ds/cilium --timeout=240s'
+    set -e
+    rt() { n=0; until "$@"; do n=$((n+1)); [ "$n" -ge 5 ] && return 1; sleep 10; done; }
+    rt sh -c 'curl -sSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash'
+    rt helm repo add cilium https://helm.cilium.io/
+    rt helm repo update
+    rt sh -c 'KUBECONFIG=/etc/rancher/k3s/k3s.yaml helm install cilium cilium/cilium --version 1.16.5 --namespace kube-system -f /var/lib/catalyst/cilium-values.yaml'
+    if ! kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml -n kube-system rollout status ds/cilium --timeout=240s; then
+      echo "[cilium] FATAL: CNI never rolled out (#4503)" >/var/lib/catalyst/cilium-bootstrap-FAILED
+      exit 91
+    fi
+%{ if provider == "huawei" ~}
+  # #4503 root cause (Huawei-gated note; the byte budget is Hetzner-only): on
+  # the IPv4-only kom4dc path a single transient failure of get-helm-3 /
+  # helm.cilium.io / the chart pull used to be SILENT (cloud-init runcmd is
+  # non-fatal) → 0 Cilium objects → nodes NotReady ("cni plugin not
+  # initialized") forever → Flux controllers can't schedule → permanent
+  # deadlock whose only recorded symptom was the phase-1 watcher's generic
+  # "0 HelmReleases" (the WRONG layer; recurrence of #1934, hit on
+  # d692b5ed547596cf 2026-06-26). The retry+fail-fast block above makes "no
+  # CNI" its own loud fault instead of a masqueraded Flux/ghcr-blob wedge.
+%{ endif ~}
 %{ if provider == "huawei" ~}
   # ── In-cluster github→IPv4 for the Flux source-controller (#3714) ──────
   # The DEEPER half of the #3232/#3714 fix, restored after the #3721 revert

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -1170,18 +1170,21 @@ runcmd:
   - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.1.0/experimental-install.yaml'
   - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml wait --for=condition=Established crd/tlsroutes.gateway.networking.k8s.io --timeout=60s'
 
-  # ── Cilium CNI: helm install + retry/fail-fast (#4503; rationale below) ─
+  # ── Cilium CNI: helm upgrade --install + retry/fail-fast (#4503) ───────
+  # rt() retries each network step 5x/10s; `helm upgrade --install` is
+  # idempotent so a retry after a partial register actually recovers
+  # (`helm install` would die "cannot re-use a name"). set -e exits on any
+  # exhausted retry; a rollout-status failure writes the sentinel + exit 91
+  # so "no CNI" is its own loud fault, never a masqueraded Flux wedge.
   - |
     set -e
-    rt() { n=0; until "$@"; do n=$((n+1)); [ "$n" -ge 5 ] && return 1; sleep 10; done; }
-    rt sh -c 'curl -sSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash'
+    export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+    rt(){ for i in 1 2 3 4 5;do "$@"&&return;sleep 10;done;return 1;}
+    rt sh -c 'curl -sSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3|bash'
     rt helm repo add cilium https://helm.cilium.io/
     rt helm repo update
-    rt sh -c 'KUBECONFIG=/etc/rancher/k3s/k3s.yaml helm install cilium cilium/cilium --version 1.16.5 --namespace kube-system -f /var/lib/catalyst/cilium-values.yaml'
-    if ! kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml -n kube-system rollout status ds/cilium --timeout=240s; then
-      echo "[cilium] FATAL: CNI never rolled out (#4503)" >/var/lib/catalyst/cilium-bootstrap-FAILED
-      exit 91
-    fi
+    rt helm upgrade --install cilium cilium/cilium --version 1.16.5 -n kube-system -f /var/lib/catalyst/cilium-values.yaml
+    kubectl -n kube-system rollout status ds/cilium --timeout=240s || { echo no-cni >/var/lib/catalyst/cilium-bootstrap-FAILED;exit 91;}
 %{ if provider == "huawei" ~}
   # #4503 root cause (Huawei-gated note; the byte budget is Hetzner-only): on
   # the IPv4-only kom4dc path a single transient failure of get-helm-3 /
@@ -1470,4 +1473,4 @@ runcmd:
   - mkdir -p /var/lib/catalyst
   - touch /var/lib/catalyst/cloud-init-complete
 
-final_message: "Catalyst control-plane bootstrap complete after $UPTIME seconds — Flux is now reconciling clusters/_template/ for ${sovereign_fqdn} (provider=${provider})"
+final_message: "Catalyst CP bootstrap done; Flux reconciling ${sovereign_fqdn}"


### PR DESCRIPTION
## What

Makes the cloud-init Cilium CNI install **retry** and **fail-fast** instead of failing silently in a non-fatal `runcmd`.

`Refs #4503` (the durable-fix issue), `Refs #1934` (the historical "single-region cloud-init never installs Cilium" shape this recurs).

## Why — live forensic on d692b5ed547596cf (kom4dc validation Sovereign)

The dep was recorded `failed` with the generic *"Phase 1 watch saw zero HelmReleases"* — which points the operator at Flux (the #3829 ghcr-blob family). Live inspection of the still-reachable cluster proved the real cause is **one layer below** that:

- All 4 nodes `NotReady`: `cni plugin not initialized`.
- **Zero Cilium artifacts** — no `cilium-config` CM, no `sh.helm.release.v1.cilium` secret, no DaemonSet ⇒ `helm install cilium` never created a single object (the helm command itself failed).
- gateway-api CRDs (the step *immediately before* Cilium, a GitHub release-artifact apply) **succeeded** ⇒ github reachability was fine; the failure is specifically the `helm.cilium.io` / `get-helm-3` fetch.
- `coredns-custom` CM (the step *after* the failed `rollout status ds/cilium`) **is present** ⇒ cloud-init's non-fatal `runcmd` sailed past the Cilium failure and bootstrapped CoreDNS + Flux onto a CNI-less cluster.
- All 8 pods `Pending` (`untolerated taint node.kubernetes.io/not-ready`); Flux `GitRepository` has empty status — source-controller never even pulled, so the #3714/#3829 in-cluster-DNS wedge is moot here.

Permanent deadlock: nodes NotReady → CNI installed by cloud-init (failed) AND by Flux bp-cilium → Flux controllers can't schedule → can't install Cilium → nodes never Ready. Cannot self-heal; more phase-1 watch time would NOT have helped.

## Change

- `rt()` retries each network-dependent Cilium step (get-helm-3, repo add/update, helm install) 5× with 10s backoff — the IPv4-only kom4dc path is intermittent and single-shot is fragile.
- **Idempotency:** `helm install cilium` → `helm upgrade --install cilium …`. Under the retry, a partially-registered release on the first attempt would make a plain `helm install` retry die *"cannot re-use a name"*; `upgrade --install` recovers cleanly.
- HARD-FAIL: if `rollout status ds/cilium` still fails, write `/var/lib/catalyst/cilium-bootstrap-FAILED` and `exit 91` so "no CNI" is its own loud fault, not a masqueraded Flux wedge.
- `export KUBECONFIG` once at the top of the block (drops the per-command `--kubeconfig=` long-form + the inline-env `sh -c` wrapper) so the Hetzner render stays under cap.

## Byte budget — the real numbers (corrects the prior "+10B" claim)

The 32256B guardrail is enforced on the **Hetzner render only** (`infra/providers/hetzner/main.tf:985` + `:1571`). The shared template's full-line comments are **stripped from the Hetzner render** by the `replace(…,"/(?m)^[ ]*#( |$).*\n/","")` at the call site — so the earlier banner/prose trims reclaimed **zero** Hetzner bytes, and the "+10B" estimate was wrong by ~164B.

Measured with `tofu test` (mock_provider, real `templatefile()` render):

| render | before (over cap) | after (under cap) | margin |
|---|---|---|---|
| primary control-plane | **32410 B** (154 over) | **31846 B** | 410 B |
| secondary control-plane (worst-case fixture) | **32428 B** (172 over) | **32221 B** | 35 B |

Recovered the bytes WITHOUT weakening the fix: compacted `rt()` to a 5×/10s for-loop, `export KUBECONFIG` once, and trimmed the cosmetic `final_message` (a genuinely-rendered shared line). The retry, the fail-fast sentinel + `exit 91`, and `helm upgrade --install` idempotency are all intact.

## Verification

- `tofu validate` + `tofu fmt -check` on the hetzner module: **green**.
- `tofu test` (hetzner): **12/12** — both control-plane preconditions pass (31846 B / 32221 B < 32256).
- `tofu test` (huawei): **7/7** (no byte cap there; render + retry/fail-fast block correct).
- `scripts/lint-cloudinit.sh both` (`dash -n` POSIX): **PASS** — the new for-loop / `export` / `|| { … }` syntax is dash-clean on all 32 runcmd items.
- `scripts/cloudinit-size-check.sh both`: **PASS** for both providers.

## Follow-ups (left on #4503, not in this PR)
- Phase-1 watcher diagnostic: surface "CNI not initialized" distinctly from "0 HelmReleases".
- Revisit the 15m phase-1 watch budget for kom4dc cold-pull (secondary — would not have fixed THIS permanent deadlock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
