### PR TITLE
fix(bp-cilium): hubble-ui oauth2-proxy --api-route so flow-stream XHR returns 401 not a 302-to-KC-login (flows never render) — 1.4.5

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -105,7 +105,12 @@ spec:
       # lxc*). Auto-MTU left them at 1500 → oversized frames DF-dropped at
       # the 1420 WireGuard MTU → all cross-node pod TCP to large payloads
       # timed out → Phase-1 convergence deadlock. See the MTU value above.
-      version: 1.4.4
+      # 1.4.5 (#4507, omantel.biz UAT row 39): add oauth2-proxy
+      # --api-route=^/api/ on the hubble-ui gate so the Hubble UI flow-stream
+      # XHR (gRPC-Web /api/v1/...) gets a 401 (not a 302-to-KC-login-HTML the
+      # gRPC-Web client can't follow) on a missing/expired session — fixes
+      # flows never rendering.
+      version: 1.4.5
       sourceRef:
         kind: HelmRepository
         name: bp-cilium

--- a/platform/cilium/blueprint.yaml
+++ b/platform/cilium/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 1.4.4
+  version: 1.4.5
   card:
     title: Cilium
     summary: Unified CNI + Service Mesh (eBPF). mTLS via WireGuard, Hubble observability, Gateway API.

--- a/platform/cilium/chart/Chart.yaml
+++ b/platform/cilium/chart/Chart.yaml
@@ -1,5 +1,16 @@
 apiVersion: v2
 name: bp-cilium
+# 1.4.5 (#4507, 2026-06-27): add oauth2-proxy --api-route=^/api/ to the
+# hubble-ui oauth2-proxy so the Hubble UI flow-stream XHR (a gRPC-Web/Connect
+# server-stream to /api/v1/...) gets a clean HTTP 401 on a missing/expired
+# session instead of a 302 to the Keycloak login HTML page. Root-caused live
+# on omantel.biz (dep 91dc05917e44d1c1, UAT row 39): a gRPC-Web client cannot
+# follow a cross-origin 302-to-login, so the default 302 silently wedges the
+# flow stream and flows never render. --api-route still AUTHs the path (unlike
+# --skip-auth-route) so there is no unauthenticated-exposure regression. New
+# values knob catalystOverlay.hubbleUI.oauth2Proxy.apiRoutes (default
+# ["^/api/"]). Lockstep: blueprint.yaml 1.4.5 + 01-cilium.yaml slot pin 1.4.5.
+# tests/g117-hubble-oauth2-proxy-enforcement.sh Case 5 asserts the flag.
 # 1.4.4 (#4467, 2026-06-26): pin cilium.MTU=1370 for the WireGuard+VXLAN
 # datapath. Root-caused live on a Huawei me-east-215 (kom4dc) fresh prov:
 # the chart runs routingMode=tunnel/tunnelProtocol=vxlan (upstream defaults
@@ -146,7 +157,7 @@ name: bp-cilium
 # the netbird realm-config idiom, identical to the bp-oidc-gate openova-flow
 # fix (#3447). bp-sso-bridge PUTs client.json template-wins every tick, so the
 # mapper lands on the live hubble-ui client zero-touch.
-version: 1.4.4
+version: 1.4.5
 description: |
   Catalyst-curated Blueprint umbrella chart for Cilium. Depends on the
   upstream `cilium` chart as a Helm subchart so `helm dependency build`

--- a/platform/cilium/chart/templates/hubble-ui-oauth2-proxy-deployment.yaml
+++ b/platform/cilium/chart/templates/hubble-ui-oauth2-proxy-deployment.yaml
@@ -90,6 +90,18 @@ spec:
             - --set-xauthrequest=true
             - --reverse-proxy=true
             - --whitelist-domain={{ $hostname }}
+            # #4507 — The Hubble UI flow stream is a gRPC-Web/Connect
+            # server-streaming XHR to /api/v1/... A gRPC-Web client cannot
+            # follow a 302 to the Keycloak login HTML page, so when the
+            # oauth2-proxy session is missing/expired the default 302-to-login
+            # silently wedges the flow stream — flows never render (UAT row
+            # 39). --api-route makes oauth2-proxy return HTTP 401 (not 302)
+            # for these paths, so the SPA observes the auth failure cleanly
+            # and a top-level reload re-runs silent SSO. This still AUTHs the
+            # path (unlike --skip-auth-route) — no unauthenticated exposure.
+            {{- range $route := ($proxy.apiRoutes | default (list "^/api/")) }}
+            - --api-route={{ $route }}
+            {{- end }}
           env:
             # #3374: with ssoBridgeSync the client-secret comes from the
             # bp-sso-bridge-published ExternalSecret (the LIVE Keycloak

--- a/platform/cilium/chart/tests/g117-hubble-oauth2-proxy-enforcement.sh
+++ b/platform/cilium/chart/tests/g117-hubble-oauth2-proxy-enforcement.sh
@@ -99,4 +99,27 @@ grep -q "kind: Deployment" <<<"$dep_byo" || { echo "FAIL: Deployment missing und
 grep -q "hubble-ui-oauth2-proxy-sso" <<<"$dep_byo" || { echo "FAIL: Deployment does not reference existingSecret" >&2; exit 1; }
 echo "  PASS (Secret suppressed; Deployment references existingSecret)"
 
+# ── Case 5: #4507 — /api XHR returns 401 not 302 (gRPC-Web flow stream) ────
+# The Hubble UI flow stream is a gRPC-Web/Connect server-streaming XHR to
+# /api/v1/...; a gRPC-Web client cannot follow a 302 to the Keycloak login
+# HTML page, so on a missing/expired session the default 302-to-login
+# silently wedges the stream and flows never render (UAT row 39). --api-route
+# makes oauth2-proxy return HTTP 401 for these paths. It still AUTHs the path
+# (unlike --skip-auth-route) — no unauthenticated-exposure regression.
+echo "[g117-hubble-oauth2-proxy] Case 5: --api-route=^/api/ on flow-stream path"
+grep -qF -- "--api-route=^/api/" <<<"$dep_oidc" || {
+  echo "FAIL: oauth2-proxy missing --api-route=^/api/ — flow XHR would 302-to-KC-login (flows never render, #4507)" >&2; exit 1
+}
+# Guard against a regression to --skip-auth-route on the API path (that would
+# expose the flow stream UNAUTHENTICATED).
+if grep -qF -- "--skip-auth-route=^/api/" <<<"$dep_oidc"; then
+  echo "FAIL: flow API path is on --skip-auth-route (unauthenticated exposure) — must be --api-route" >&2; exit 1
+fi
+# Custom apiRoutes override is honored.
+dep_custom="$(show hubble-ui-oauth2-proxy-deployment.yaml --set catalystOverlay.hubbleUI.auth=oidc --set 'catalystOverlay.hubbleUI.oauth2Proxy.apiRoutes={^/api/,^/v1/grpc/}')"
+grep -qF -- "--api-route=^/v1/grpc/" <<<"$dep_custom" || {
+  echo "FAIL: custom oauth2Proxy.apiRoutes not honored" >&2; exit 1
+}
+echo "  PASS (--api-route=^/api/ present; not skip-auth; override honored)"
+
 echo "[bp-cilium G117.5 #2744 hubble oauth2-proxy enforcement] All cases PASS"

--- a/platform/cilium/chart/values.yaml
+++ b/platform/cilium/chart/values.yaml
@@ -416,6 +416,16 @@ catalystOverlay:
         enabled: true
         externalSecretStoreName: vault-region1
         refreshInterval: 1h
+      # #4507 — oauth2-proxy --api-route regexes. The Hubble UI flow stream
+      # is a gRPC-Web/Connect server-streaming XHR to /api/v1/...; a gRPC-Web
+      # client cannot follow a 302 to the Keycloak login HTML page, so a
+      # missing/expired session silently wedges the stream and flows never
+      # render (UAT row 39). Listing the /api prefix here makes oauth2-proxy
+      # return HTTP 401 (not 302-to-login) for these paths, so the SPA sees
+      # the auth failure cleanly. These paths are STILL authenticated (unlike
+      # skipAuthRoutes) — no unauthenticated-exposure regression.
+      apiRoutes:
+        - "^/api/"
       replicas: 1
       image:
         repository: quay.io/oauth2-proxy/oauth2-proxy


### PR DESCRIPTION
## Fault (UAT row 39, omantel.biz dep `91dc05917e44d1c1`)

The Hubble UI loads but its flow-stream XHR is **302-redirected to the Keycloak login HTML page** by `hubble-ui-oauth2-proxy` instead of returning data — so flows never render.

## Root cause

The Hubble UI flow stream is a **gRPC-Web/Connect server-streaming** XHR to `/api/v1/...` (nginx in the `frontend` container proxies `/api` → the `backend` gRPC server → hubble-relay). A gRPC-Web client **cannot follow a 302 to a cross-origin HTML login page** — it just consumes the redirect as an opaque/failed response and the stream silently dies.

`platform/cilium/chart/templates/hubble-ui-oauth2-proxy-deployment.yaml` configured oauth2-proxy (v7.6.0) with **no `--api-route`** flag, so oauth2-proxy's default for any missing/expired session is a **302 to the OIDC login URL** — correct for the UI root (the browser navigates and silent-SSO re-auths), wrong for the `/api` XHR.

Reproduced live:

```
$ curl -s -o /dev/null -w '%{http_code} %{redirect_url}' -XPOST https://hubble.omantel.biz/api/v1/flows
302 https://auth.omantel.biz/realms/sovereign/protocol/openid-connect/auth?...client_id=hubble-ui...
# oauth2-proxy log: [oauthproxy.go:1017] No valid authentication in request. Initiating login.
#                   POST "/api/v1/flows" ... 302
```

## Fix

Add `--api-route=^/api/` to the oauth2-proxy args (new values knob `catalystOverlay.hubbleUI.oauth2Proxy.apiRoutes`, default `["^/api/"]`). oauth2-proxy then returns **HTTP 401 instead of 302** for the flow path, so the SPA observes the auth failure cleanly and a top-level reload re-runs silent SSO.

Crucially this uses `--api-route` (still authenticates the path) **not** `--skip-auth-route` (which would expose the flow stream unauthenticated and regress the #2744 enforcement). Confirmed `--api-route` is supported by the live oauth2-proxy v7.6.0: *"return HTTP 401 instead of redirecting to authentication server if token is not valid."*

## Lockstep + tests

- chart `1.4.4` → `1.4.5`, `blueprint.yaml` `1.4.5`, bootstrap-kit slot `01-cilium.yaml` pin `1.4.5`.
- `tests/g117-hubble-oauth2-proxy-enforcement.sh` **Case 5**: asserts `--api-route=^/api/` renders, is NOT on `--skip-auth-route`, and honors a custom `apiRoutes` override. All 5 cases PASS locally.

## Roll-to-live

Chart-level. **Roll-gated** behind the standard delivery chain (chart publish → bootstrap-kit pin → the live `Blueprint`/`HelmRelease` on omantel.biz reconciling the new pin). Note the live Blueprint CR keeps its old `spec.version` until the catalog roll reaches it (MEMORY: `resource-policy: keep` makes bumps inert until #4417 lands or a manual `kubectl patch`).

## Live verification status

The 302-to-KC-login on the unauthenticated `/api/v1/flows` XHR is reproduced live (above) — that IS the row-39 fault. **Full post-fix proof** (authenticated session → flow XHR returns data / 401-not-302 on expiry) requires the chart to roll to the live oauth2-proxy Deployment AND an interactive silent-SSO browser session (catalyst-pin). Until the roll + an interactive walk, row 39 is **VERIFIED-PARTIAL**: root cause proven + fix rendered green, live re-walk pending the catalog roll.

Refs #4507
Refs #3374

🤖 Generated with [Claude Code](https://claude.com/claude-code)