### PR TITLE
fix(cloud-init #4513): split two-NAME create-namespace + drop endif tilde — fresh prov no longer wedges at 0 HelmReleases

### DIFF
--- a/docs/sessions/2026-06-27/eip-quota-bump-request.md
+++ b/docs/sessions/2026-06-27/eip-quota-bump-request.md
@@ -1,0 +1,100 @@
+# Huawei National Cloud (Omantel) — Elastic IP quota-bump request
+
+**Status:** ready to send · **Audience:** Omantel National Cloud account team → Huawei Cloud quota approval
+**Region:** `me-east-215` (kom4dc) · **Project ID:** `f27698137bdc4b00ad509cf27f1e5547`
+**Resource type:** `publicip` (Elastic IP / EIP) · **Requested by:** OpenOva platform engineering
+
+---
+
+## One-line ask
+
+Raise the **`publicip` (EIP) quota** on project `f27698137bdc4b00ad509cf27f1e5547`, region `me-east-215`, from **10 → ≥ 16**.
+
+---
+
+## Why (business justification)
+
+The permanent production Sovereign (`omantel.biz`) is a 2-region high-availability deployment on kom4dc. Its disaster-recovery / region-kill failover capability (the load-bearing Pillar-3 proof of the platform) has live, healthy plumbing — two independent CNPG clusters streaming RPO=0, a held witness lease, ClusterMesh 2/2 — but the **destructive validation drill** (kill region-a, prove region-b promotes with zero committed-transaction loss) has never been executed against a disposable environment.
+
+We will not run a destructive failover drill against the permanent serving production environment except under a tightly-controlled low-traffic window with an operator present. The correct way to validate the DR/region-kill pillar repeatably is to stand up a **second, concurrent 2-region validation deployment** alongside the permanent one, run the drill there, capture the evidence, and tear it down — without ever touching production.
+
+That second concurrent 2-region deployment needs **6 EIPs**. The current quota leaves only **3** free. So the validation is hard-capacity-gated on the EIP quota, not on engineering readiness. Raising the quota to **≥ 16** clears the gate and lets us validate region-kill, the DR backbone, and multi-region facets in one disposable prov, leaving the permanent `omantel.biz` env untouched.
+
+---
+
+## Current state (verified, read-only, 2026-06-27)
+
+| Item | Value |
+|---|---|
+| Region | `me-east-215` (kom4dc) |
+| Project ID | `f27698137bdc4b00ad509cf27f1e5547` |
+| Current `publicip` quota | **10** |
+| Currently used | **7** |
+| Currently free | **3** |
+
+### The 7 EIPs in use — itemized
+
+| # | EIP role | Belongs to | Notes |
+|---|---|---|---|
+| 1 | **Bastion** EIP | Shared management infra (`bastion-openova`) | Permanent operations bastion — never wiped, not part of any Sovereign deployment. |
+| 2 | region-a control-plane / apiserver EIP | Permanent `omantel.biz` Sovereign (region-a, `hw-me-east-215-a-rtz-prod`) | apiserver `212.72.24.12:6443`. |
+| 3 | region-a NAT EIP | Permanent `omantel.biz` Sovereign (region-a) | Outbound egress for region-a workers. |
+| 4 | region-b control-plane / apiserver EIP | Permanent `omantel.biz` Sovereign (region-b, `hw-me-east-215-b-rtz-prod`) | apiserver `212.72.24.26:6443`. |
+| 5 | region-b NAT EIP | Permanent `omantel.biz` Sovereign (region-b) | Outbound egress for region-b workers. |
+| 6 | primary ELB EIP | Permanent `omantel.biz` Sovereign | Customer/application traffic load balancer. |
+| 7 | console ELB EIP | Permanent `omantel.biz` Sovereign | Dedicated console/api/marketplace load balancer (console-isolation). |
+
+> Items 2–7 are the **6 EIPs** consumed by the single permanent 2-region production Sovereign; item 1 is the shared bastion. 10 − 7 = **3 free**.
+
+---
+
+## Why a 2-region validation prov needs 6 EIPs
+
+A standard 2-region Catalyst deployment allocates EIPs as follows:
+
+| EIP | Count | Per region |
+|---|---|---|
+| Control-plane / apiserver | 2 | 1 × region-a + 1 × region-b |
+| NAT (egress) | 2 | 1 × region-a + 1 × region-b |
+| Primary ELB (application traffic) | 1 | shared |
+| Console ELB (console/api/marketplace) | 1 | shared |
+| **Total** | **6** | |
+
+Even with the console-isolation collapse (folding the console ELB into the primary ELB), a 2-region prov still needs **5** EIPs — which still exceeds the **3** currently free. So neither the full 6-EIP nor the collapsed 5-EIP form can fire today.
+
+**3 free < 5 (collapsed) < 6 (standard)** ⇒ a second concurrent 2-region validation prov cannot be created at the current quota.
+
+---
+
+## The exact ask
+
+| Field | Value |
+|---|---|
+| Quota name | `publicip` (Elastic IP) |
+| Region | `me-east-215` |
+| Project ID | `f27698137bdc4b00ad509cf27f1e5547` |
+| Current limit | 10 |
+| **Requested limit** | **≥ 16** |
+| Headroom rationale | 7 (current usage) + 6 (one concurrent 2-region validation prov) = 13; request 16 to leave a small margin for transient EIP allocation during prov/teardown and for the console-isolation variant without re-requesting. |
+
+A bump to **16** lets one full 2-region validation deployment run concurrently with the permanent production env, with margin. If Huawei caps the increase, **13** is the strict floor (7 + 6) that just barely admits one concurrent 2-region validation prov with zero headroom.
+
+---
+
+## What this unblocks once granted
+
+A single quota approval clears the hard-capacity gate on three tickets at once, all of which are otherwise engineering-ready:
+
+- **#4275** — Pillar-3 region-kill failover counter-test (kill region-a, prove region-b promotes RTO ≤ 30s, RPO = 0).
+- **#4212** — DR object-model backbone (spine Application→Continuum producer + Crossplane Observe-first adoption runtime proof).
+- **#4293 / #3969** — multi-region / application-centric placement facets that need a 2-region substrate to walk.
+
+No code change is required to consume the new quota — the platform's standard 2-region prov path allocates the 6 EIPs automatically once the headroom exists.
+
+---
+
+## Submission notes (for the operator)
+
+- This is a **quota increase request**, not a resource creation — it does not allocate any EIP by itself.
+- Route via the Omantel National Cloud account team or the Huawei Cloud console **Quotas → publicip → request increase** for project `f27698137bdc4b00ad509cf27f1e5547`, region `me-east-215`.
+- No production change occurs on approval; the new headroom simply makes a second concurrent 2-region validation prov possible. The permanent `omantel.biz` env is untouched throughout.

--- a/docs/sessions/2026-06-27/region-kill-drill-4275.md
+++ b/docs/sessions/2026-06-27/region-kill-drill-4275.md
@@ -1,0 +1,201 @@
+# Region-kill failover drill — Pillar-3 (D31) acceptance · #4275
+
+**Status:** finalized, executable · **DO NOT RUN without (1) a 2-region env AND (2) explicit founder GO.**
+**Refs:** #4275 (region-kill counter-test) · #4212 (DR backbone) · ADR-0004 (RPO=0 sync standby) · DoD §Pillar-3
+
+---
+
+## What this drill proves
+
+Pillar-3's load-bearing counter-test: on a 2-region Sovereign, hard-kill region-a's data tier and prove that the region-b synchronous standby promotes to primary **with zero committed-transaction loss (RPO=0) and RTO ≤ 30s**. Green plumbing is NOT acceptance — only a destructive kill + clean promotion + intact tx-counter + clean restore earns the ✅.
+
+---
+
+## Hard preconditions (all required before execution)
+
+1. **A 2-region converged env.** Either the permanent `omantel.biz` Sovereign (with the caveats in §Permanent-env safety below) OR a fresh disposable 2-region prov. A fresh disposable 2-region prov is itself gated on the kom4dc EIP quota bump (10 → ≥16) — see `eip-quota-bump-request.md`. There is no other 2-region capacity today.
+2. **Explicit founder GO.** This is a destructive drill. Per the autonomy mandate, destructive failover against the permanent serving env requires founder say-so and a low-traffic window with an operator present for the §(d) restore.
+3. **Read-only prerequisite verification green** (the §0 checks below): cnpg-pair primary + region-b sync standby streaming, lag=0, Continuum Healthy with a held lease, ClusterMesh 2/2.
+
+If any precondition is unmet, this runbook stays unexecuted. The single capacity gate for a disposable env is the EIP quota bump.
+
+---
+
+## Topology (the env this drill targets)
+
+Two **independent** k3s clusters (not a stretched control plane), confirmed live 2026-06-27 on dep `91dc05917e44d1c1`:
+
+| | region-a (primary) | region-b (standby) |
+|---|---|---|
+| cluster | `hw-me-east-215-a-rtz-prod` | `hw-me-east-215-b-rtz-prod` |
+| apiserver | `212.72.24.12:6443` | `212.72.24.26:6443` |
+| cnpg-pair | `cnpg-pair-bp-cnpg-pair-primary` 3/3, primary `…-primary-1` | `cnpg-pair-bp-cnpg-pair-replica` 3/3, `replica.enabled=true`, `pg_is_in_recovery=t` |
+| nodes | 1 cp + 5 workers | 1 cp + 5 workers |
+
+**Architectural fact that shapes the drill:** `continuum-controller` and `catalyst-api` run **only on region-a nodes**, and the arbitration Leases live in region-a's apiserver. On a *full* region-a kill the controller dies with the region, so promotion of region-b is necessarily **operator-driven** (`kubectl patch replica.enabled=false`). `spec.autoFailover=false` is locked (ADR contract) — the controller surfaces the alarm, it does not self-promote. Controller auto-promote applies only to a *partial* fault where region-a's apiserver survives. **This drill targets the faithful full-region-data-tier case → operator promotion.**
+
+### Kubeconfig handles (set before running)
+
+```bash
+# region-a + region-b kubeconfigs — adjust paths to the env under test.
+# On the permanent env (dep 91dc05917e44d1c1) these were:
+KA=/home/openova/.kube/91dc/91dc05917e44d1c1.yaml        # region-a
+KB=/home/openova/.kube/91dc/...-me-east-215-b-1.yaml     # region-b
+# For a fresh disposable prov, use that dep's region-a / region-b kubeconfigs.
+```
+
+---
+
+## 0. Pre-kill verification (READ-ONLY — confirm RPO=0 before touching anything)
+
+```bash
+# Primary sees region-b as the SYNC standby, lag = 0
+kubectl --kubeconfig=$KA exec -n cnpg cnpg-pair-bp-cnpg-pair-primary-1 -c postgres -- \
+  psql -U postgres -x -c "SELECT application_name,sync_state,sync_priority,replay_lsn FROM pg_stat_replication;"
+# Expect: application_name=cnpg-pair-bp-cnpg-pair-replica, sync_state=sync, sync_priority=1
+
+kubectl --kubeconfig=$KA exec -n cnpg cnpg-pair-bp-cnpg-pair-primary-1 -c postgres -- \
+  psql -U postgres -c "SHOW synchronous_standby_names; SHOW synchronous_commit;"
+# Expect: FIRST 1 ("cnpg-pair-bp-cnpg-pair-replica") ; remote_apply   (every COMMIT blocks on region-b ack ⇒ RPO=0)
+
+# Continuum healthy + lease held by region-a
+kubectl --kubeconfig=$KA get continuum -n cnpg cnpg-pair-bp-cnpg-pair-continuum \
+  -o jsonpath='{.status.phase} lease={.status.leaseHolder} held={.status.leaseHeld} lag={.status.replicationLagSeconds}{"\n"}'
+# Expect: Healthy lease=hw-me-east-215-a-rtz-prod held=true lag=0
+
+# ClusterMesh 2/2 (run from each region's cilium pod)
+kubectl --kubeconfig=$KA -n kube-system exec ds/cilium -- cilium-dbg troubleshoot clustermesh
+kubectl --kubeconfig=$KB -n kube-system exec ds/cilium -- cilium-dbg troubleshoot clustermesh
+# Expect: both peers resolve, TCP+TLS+etcd OK
+```
+
+**Gate:** do not proceed unless `sync_state=sync`, lag=0, Continuum `Healthy` + lease held, ClusterMesh both-ways OK.
+
+---
+
+## (a) Seed the monotonic tx-counter + confirm region-b is caught up
+
+```bash
+# seed 1000 rows — each COMMIT is sync-acked by region-b BEFORE returning
+kubectl --kubeconfig=$KA exec -n cnpg cnpg-pair-bp-cnpg-pair-primary-1 -c postgres -- psql -U postgres -d app -c \
+ "CREATE TABLE IF NOT EXISTS d31_counter(n bigint PRIMARY KEY, ts timestamptz DEFAULT now());
+  INSERT INTO d31_counter(n) SELECT g FROM generate_series(1,1000) g;"
+
+# primary count == 1000
+kubectl --kubeconfig=$KA exec -n cnpg cnpg-pair-bp-cnpg-pair-primary-1 -c postgres -- \
+  psql -U postgres -d app -tAc "SELECT max(n) FROM d31_counter;"   # expect 1000
+
+# region-b ALREADY has all 1000 (sync) BEFORE the kill — the RPO=0 pre-proof
+kubectl --kubeconfig=$KB exec -n cnpg cnpg-pair-bp-cnpg-pair-replica-1 -c postgres -- \
+  psql -U postgres -d app -tAc "SELECT max(n) FROM d31_counter;"   # expect 1000
+
+date -u +%FT%T.%3NZ   # T0 marker — record it
+```
+
+---
+
+## (b) Kill region-a (least-destructive faithful — data-tier kill)
+
+The faithful counter-test severs region-a's data plane so the region-b sync standby MUST promote. The least-destructive faithful form is **cordon region-a nodes + force-delete the 3 region-a cnpg primary pods** — a real kill of the data tier (not a pod restart / scale-down), and cleanly restorable on the permanent env. A full node-poweroff is more faithful but NOT cleanly restorable on a serving env → use a disposable env for that variant only.
+
+```bash
+# cordon every region-a node so cnpg cannot reschedule the primary inside region-a
+for n in $(kubectl --kubeconfig=$KA get nodes -o name); do
+  kubectl --kubeconfig=$KA cordon "${n#node/}"
+done
+
+# sever the data tier: force-delete the region-a cnpg-pair primary pods
+kubectl --kubeconfig=$KA delete pod -n cnpg \
+  -l cnpg.io/cluster=cnpg-pair-bp-cnpg-pair-primary --grace-period=0 --force
+
+date -u +%FT%T.%3NZ   # T-kill marker — record it
+```
+
+---
+
+## (c) Failover proof — operator-promote region-b + measure RTO/RPO
+
+```bash
+# operator promotion (continuum-controller is dead with region-a; autoFailover=false)
+kubectl --kubeconfig=$KB patch cluster.postgresql.cnpg.io cnpg-pair-bp-cnpg-pair-replica -n cnpg \
+  --type merge -p '{"spec":{"replica":{"enabled":false}}}'
+
+# watch pg_is_in_recovery flip t -> f  (RTO = delta from the patch to this flip)
+while true; do
+  R=$(kubectl --kubeconfig=$KB exec -n cnpg cnpg-pair-bp-cnpg-pair-replica-1 -c postgres -- \
+        psql -U postgres -tAc "SELECT pg_is_in_recovery();" 2>/dev/null)
+  echo "$(date -u +%FT%T.%3NZ) in_recovery=$R"
+  [ "$R" = "f" ] && break
+  sleep 0.2
+done
+
+# RPO proof: all 1000 rows survived on the NEW primary
+kubectl --kubeconfig=$KB exec -n cnpg cnpg-pair-bp-cnpg-pair-replica-1 -c postgres -- \
+  psql -U postgres -d app -tAc "SELECT count(*),max(n) FROM d31_counter;"   # expect 1000 | 1000  -> RPO=0
+
+# new primary accepts a fresh write
+kubectl --kubeconfig=$KB exec -n cnpg cnpg-pair-bp-cnpg-pair-replica-1 -c postgres -- \
+  psql -U postgres -d app -c "INSERT INTO d31_counter(n) VALUES (1001);"
+```
+
+**Pass bar:** RTO ≤ 30s (prior hw158 walk measured ~1.4s) · `count=1000` (zero committed-tx loss → RPO=0) · post-kill write accepted on the new primary.
+
+---
+
+## (d) Restore region-a → steady state (split-brain guard)
+
+**Order matters: demote region-a to standby BEFORE uncordoning, or you risk two primaries.**
+
+```bash
+# 1) re-home region-a as a STANDBY of the new (region-b) primary FIRST
+kubectl --kubeconfig=$KA patch cluster.postgresql.cnpg.io cnpg-pair-bp-cnpg-pair-primary -n cnpg \
+  --type merge -p '{"spec":{"replica":{"enabled":true}}}'
+
+# 2) only now uncordon — region-a pods reschedule and re-stream from region-b primary-mesh
+for n in $(kubectl --kubeconfig=$KA get nodes -o name); do
+  kubectl --kubeconfig=$KA uncordon "${n#node/}"
+done
+
+# 3) verify region-a is now a streaming standby (in recovery) and caught up
+kubectl --kubeconfig=$KA exec -n cnpg cnpg-pair-bp-cnpg-pair-primary-1 -c postgres -- \
+  psql -U postgres -tAc "SELECT pg_is_in_recovery();"   # expect t
+
+# 4) SPLIT-BRAIN GUARD — if any old-primary region-a pod came up writable, demote it immediately
+#    (a region-a pod returning pg_is_in_recovery=f after step 1 is the danger signal)
+```
+
+### Optional fail-back (return primary to region-a for steady state)
+
+Reverse (c)/(d): patch region-b `replica.enabled=true`, region-a `replica.enabled=false`, re-confirm sync standby + lease pinned to region-a. Optional — region-b can remain primary.
+
+### Steady-state re-confirmation (after restore)
+
+```bash
+kubectl --kubeconfig=$KA get continuum -n cnpg cnpg-pair-bp-cnpg-pair-continuum \
+  -o jsonpath='{.status.phase} lease={.status.leaseHolder} held={.status.leaseHeld}{"\n"}'
+# Expect: Healthy + lease re-pinned + cross-region standby back to sync_state=sync
+```
+
+---
+
+## Permanent-env safety (if running on `omantel.biz` instead of a disposable env)
+
+The cordon+force-delete data-tier form above is **permanent-env-safe** with two honest caveats — neither corrupts data:
+
+1. **Write-availability pause during the kill window.** With `synchronous_commit=remote_apply` and region-b as the only sync standby, while region-a primary is down and before region-b is promoted, any in-flight COMMIT on the old primary blocks. This is the by-design durability-over-availability contract (ADR-0004); the old primary is being killed anyway. Region-b is writable the instant it promotes.
+2. **Day-2 rejoin / split-brain on fail-back.** Bringing region-a back is the delicate step — §(d) avoids it by patching region-a to `replica.enabled=true` BEFORE uncordoning, so it rejoins strictly as a follower.
+
+The spine apps (gitea/harbor/keycloak/openbao) each carry their own Continuum already lease-held by region-a, so they ride the same arbitration. Running on the permanent env requires founder GO during a low-traffic window with an operator present to confirm §(d) reaches steady state before walking away. **A full node-poweroff variant is NOT recommended on the permanent env — it is not cleanly restorable; use a disposable 2-region prov for that.**
+
+---
+
+## Evidence to capture (for the #4275 acceptance comment)
+
+- §0 pre-kill `pg_stat_replication` showing `sync_state=sync`, lag=0 + Continuum `Healthy` lease-held.
+- §(a) T0 marker + region-b `max(n)=1000` pre-kill.
+- §(b) T-kill marker + the cordon/force-delete output.
+- §(c) the `in_recovery t→f` timeline (RTO delta) + `count=1000,max=1000` (RPO=0) + accepted post-kill write.
+- §(d) region-a back to `pg_is_in_recovery=t` + Continuum re-Healthy + lease re-pinned.
+- A wire/log capture or screenshot timeline showing RTO ≤ 30s.
+
+Acceptance = a destructive kill walked end-to-end with the counter intact (RPO=0), RTO ≤ 30s, and a clean restore. Post the timeline + evidence as a comment on #4275 — close only after that operator-walk lands on the issue.

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -948,7 +948,11 @@ write_files:
         namespace: flux-system
       spec:
         interval: 5m
-        path: ./clusters/_template/infrastructure%{ if provider == "hetzner" }/hetzner%{ endif ~}
+        # #4513: the endif directive below must NOT carry a trailing tilde — a
+        # tilde-close strips the following newline, collapsing `prune: true`
+        # onto this `path:` line ("yaml: mapping values are not allowed in this
+        # context") and wedging the infrastructure-config Kustomization.
+        path: ./clusters/_template/infrastructure%{ if provider == "hetzner" }/hetzner%{ endif }
         prune: true
         sourceRef:
           kind: GitRepository
@@ -1425,21 +1429,23 @@ runcmd:
   # Apply the bootstrap secrets BEFORE Flux reconciles bootstrap-kit (each
   # is an idempotent `kubectl apply`; re-running cloud-init rewrites bytes).
   #
-  # #3804 (Refs #3642) — create the three CRD-independent bootstrap namespaces
-  # (cert-manager, catalyst-system, openbao) in ONE idempotent apply FIRST so
-  # the namespaced secrets below land in an existing namespace. `kubectl create
-  # namespace` takes N positional names and emits N `---`-joined docs, so this
-  # is byte-identical in effect to three separate creates. The secret applies
-  # are then folded into a single multi-`-f` `kubectl apply` (each file is an
-  # independent Secret manifest; apply order among them is irrelevant), which
-  # drops ~6 repetitions of the `kubectl --kubeconfig=…` long-form and keeps the
-  # rendered cloud-init under Hetzner's 32256B cap. handover-jwt→catalyst-system
-  # and recovery-seed→openbao resolve here. (powerdns-api-credentials no longer
-  # needs the `cert-manager` ns created here — #3888 evicted it to the Flux
-  # sovereign-tls Kustomization, which lands it in `cert-manager` after
-  # bp-cert-manager.)
-  - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml create namespace catalyst-system openbao --dry-run=client -o yaml | kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml apply -f -'
-  - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml apply -f /var/lib/catalyst/ghcr-pull-secret.yaml -f /var/lib/catalyst/harbor-robot-token-secret.yaml -f /var/lib/catalyst/pdm-basicauth-secret.yaml -f /var/lib/catalyst/handover-jwt-public-secret.yaml -f /var/lib/catalyst/object-storage-secret.yaml -f /var/lib/catalyst/cloud-credentials-secret.yaml'
+  # #3804 (Refs #3642) — create the CRD-independent bootstrap namespaces
+  # (catalyst-system, openbao) idempotently FIRST so the namespaced secrets
+  # below land in an existing namespace. #4513: `kubectl create namespace`
+  # accepts EXACTLY ONE positional name ("error: exactly one NAME is required,
+  # got 2") — the prior two-name `create namespace catalyst-system openbao`
+  # died on this FIRST runcmd item, and because cloud-init halts runcmd on a
+  # non-zero exit the WHOLE remainder (bootstrap secrets, openbao seed,
+  # flux-bootstrap apply, cloud-init-complete marker) never ran → permanent
+  # 0-HR fresh-prov wedge. Loop one `create namespace` per name through the
+  # idempotent dry-run|apply idiom. handover-jwt→catalyst-system and
+  # recovery-seed→openbao resolve here. The secret applies below run from
+  # `cd /var/lib/catalyst` so the 6 `-f` paths drop their dir prefix, keeping
+  # the render under Hetzner's 32256B cap. (powerdns-api-credentials no longer
+  # needs `cert-manager` created here — #3888 evicted it to the Flux
+  # sovereign-tls Kustomization.)
+  - 'export KUBECONFIG=/etc/rancher/k3s/k3s.yaml; for ns in catalyst-system openbao; do kubectl create namespace "$ns" --dry-run=client -o yaml | kubectl apply -f -; done'
+  - 'cd /var/lib/catalyst; kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml apply -f ghcr-pull-secret.yaml -f harbor-robot-token-secret.yaml -f pdm-basicauth-secret.yaml -f handover-jwt-public-secret.yaml -f object-storage-secret.yaml -f cloud-credentials-secret.yaml'
 
   # openbao-recovery-seed: one-shot 32-byte seed the bp-openbao init Job
   # consumes + deletes on first success. Never in tfstate; node-local only.
@@ -1463,8 +1469,12 @@ runcmd:
 %{ endif ~}
 
   # Hand the cluster to Flux. From here it pulls clusters/_template/ and
-  # installs bp-cilium, bp-cert-manager, …, bp-catalyst-platform.
-  - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml apply -f /var/lib/catalyst/flux-bootstrap.yaml'
+  # installs bp-cilium, bp-cert-manager, …, bp-catalyst-platform. #4513: this
+  # is THE critical handoff — a silent failure here leaves the cluster at
+  # 0 GitRepository/0 HR forever with no recorded symptom. Fail-fast with a
+  # sentinel (mirrors the #4503 cilium block) so an apply failure is its OWN
+  # loud fault, not a masqueraded "0 HelmReleases" phase-1-watcher timeout.
+  - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml apply -f /var/lib/catalyst/flux-bootstrap.yaml || { touch /var/lib/catalyst/flux-bootstrap-FAILED; exit 92; }'
 %{ if crossplane_provider_yaml != "" ~}
   - 'nohup bash -c "deadline=\$((SECONDS+1800)); while [ \$SECONDS -lt \$deadline ]; do kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml apply -f /var/lib/catalyst/crossplane-provider.yaml >/dev/null 2>&1 && break; sleep 30; done" >/dev/null 2>&1 &'
 %{ endif ~}

--- a/infra/providers/_shared/tests/cloudinit_render.tftest.hcl
+++ b/infra/providers/_shared/tests/cloudinit_render.tftest.hcl
@@ -1,0 +1,65 @@
+# Regression tests for cloudinit-control-plane.tftpl render integrity (#4513).
+#
+# Two bugs wedged the keystone fresh prov 25aadcfc at 0 HelmReleases:
+#   1. `kubectl create namespace catalyst-system openbao` (two NAMEs) — kubectl
+#      accepts exactly one — died on the first runcmd item, halting the whole
+#      runcmd block (no bootstrap secrets, no flux-bootstrap apply).
+#   2. `%{ endif ~}` on the infrastructure-config `path:` stripped the trailing
+#      newline → `prune: true` jammed onto the path line → invalid YAML.
+#
+# These tests render the template (no apply, no creds) for both cloud branches
+# and assert neither defect re-appears.
+
+run "hetzner_render_is_valid" {
+  command = plan
+
+  variables {
+    provider_name = "hetzner"
+  }
+
+  assert {
+    condition     = output.path_line_jammed == false
+    error_message = "#4513 regression: infrastructure-config `path:` and `prune:` are on the same line (an endif tilde newline-strip bug) — invalid YAML."
+  }
+
+  assert {
+    condition     = output.prune_on_own_line == true
+    error_message = "#4513: `prune: true` must render on its own line."
+  }
+
+  assert {
+    condition     = output.multi_name_create == false
+    error_message = "#4513 regression: `kubectl create namespace catalyst-system openbao` passes two NAMEs — kubectl accepts exactly one; the runcmd block will die on the first item."
+  }
+
+  # Hetzner has a hard 32256B user-data cap; the production module enforces this
+  # via a precondition. Keep the standalone render comfortably under it so this
+  # harness fails fast if the template balloons.
+  assert {
+    condition     = output.rendered_bytes < 32256
+    error_message = "Rendered cloud-init exceeds the Hetzner 32256B guardrail."
+  }
+}
+
+run "huawei_render_is_valid" {
+  command = plan
+
+  variables {
+    provider_name = "huawei"
+  }
+
+  assert {
+    condition     = output.path_line_jammed == false
+    error_message = "#4513 regression (huawei branch): infrastructure-config `path:`/`prune:` jammed onto one line."
+  }
+
+  assert {
+    condition     = output.prune_on_own_line == true
+    error_message = "#4513 (huawei branch): `prune: true` must render on its own line."
+  }
+
+  assert {
+    condition     = output.multi_name_create == false
+    error_message = "#4513 regression (huawei branch): two-NAME `create namespace` will die on the first runcmd item."
+  }
+}

--- a/infra/providers/_shared/tests/render.tf
+++ b/infra/providers/_shared/tests/render.tf
@@ -1,0 +1,126 @@
+# Standalone render harness for cloudinit-control-plane.tftpl (#4513).
+#
+# This module exists ONLY to render the shared cloud-init template with a
+# complete dummy var map so a tofu test can assert the rendered YAML is
+# structurally valid — without standing up a full provider module and without
+# exposing the production (secret-bearing) render. Every value here is a
+# throwaway literal; nothing is applied.
+#
+# The render is exposed as a NON-sensitive output deliberately: all inputs are
+# dummies, so there is no secret to leak. Production renders keep the cloud-init
+# inside a `local` (never an output) — see hetzner/main.tf:853.
+
+variable "provider_name" {
+  description = "Which cloud branch to exercise (hetzner | huawei)."
+  type        = string
+  default     = "hetzner"
+}
+
+locals {
+  rendered_raw = templatefile("${path.module}/../cloudinit-control-plane.tftpl", {
+    provider                          = var.provider_name
+    cp_private_ip                     = "10.0.1.2"
+    cluster_cidr                      = "10.42.0.0/16"
+    service_cidr                      = "10.43.0.0/16"
+    sovereign_fqdn                    = "render-test.example.test"
+    sovereign_fqdn_slug               = "render-test-example-test"
+    deployment_id                     = "deadbeefdeadbeef"
+    org_name                          = "Render-Test"
+    org_email                         = "render-test@example.test"
+    region                            = var.provider_name == "huawei" ? "me-east-215-a" : "fsn1"
+    sovereign_region_key              = var.provider_name == "huawei" ? "me-east-215-a" : "fsn1"
+    sovereign_region_role             = "primary"
+    region_canonical_label            = "primary"
+    primary_region_canonical_label    = "primary"
+    replica_region_canonical_label    = ""
+    cluster_mesh_name                 = "render-test"
+    cluster_mesh_id                   = "1"
+    k3s_version                       = "v1.31.4+k3s1"
+    k3s_token                         = "render-test-token"
+    gitops_repo_url                   = "https://github.com/openova-io/openova"
+    gitops_branch                     = "main"
+    marketplace_enabled               = "true"
+    console_isolation_enabled         = "true"
+    wildcard_cert_issuer              = "wildcard-issuer"
+    bcp_topology                      = "single-region"
+    enable_hot_standby                = "false"
+    enable_shared_pg                  = "true"
+    default_storage_class             = var.provider_name == "huawei" ? "evs-ssd" : "hcloud-volumes"
+    sovereign_cnpg_instances          = "1"
+    continuum_enabled                 = "false"
+    parent_domains_yaml               = "[{name: \"example.test\", role: \"primary\"}]"
+    sovereign_regions_json            = jsonencode([{ region = "fsn1", primary = true }])
+    sovereign_configured_regions_yaml = jsonencode(["fsn1"])
+    enable_unattended_upgrades        = "true"
+    enable_fail2ban                   = "true"
+    distro_id                         = "ubuntu"
+    distro_codename                   = "jammy"
+    load_balancer_ipv4                = "203.0.113.10"
+    console_load_balancer_ipv4        = ""
+    handover_jwt_public_key           = "RENDER_TEST_JWK"
+    ghcr_pull_username                = "render-test"
+    ghcr_pull_token                   = "render-test-token"
+    object_storage_access_key         = "render-test-ak"
+    object_storage_secret_key         = "render-test-sk"
+    object_storage_bucket_name        = "render-test-bucket"
+    object_storage_endpoint           = "https://s3.example.test"
+    object_storage_region             = "us-east-1"
+    pdns_api_host                     = "powerdns.example.test"
+    node_ip_cmd                       = "echo 10.0.1.2"
+    node_external_ip_cmd              = "echo 203.0.113.10"
+    node_external_ip_value            = "203.0.113.10"
+    k3s_extra_args       = ""
+    registry_mirror_yaml = "mirrors: {}"
+    catalyst_api_url     = "https://console.example.test"
+    ghcr_pull_auth_b64   = "cmVuZGVyLXRlc3Q6cmVuZGVyLXRlc3Q="
+    harbor_robot_token   = "render-test-harbor-token"
+    kubeconfig_bearer_token       = "render-test-bearer"
+    pdm_basic_auth_user           = "render-test"
+    pdm_basic_auth_pass           = "render-test-pass"
+    powerdns_api_key              = "render-test-pdns-key"
+    cloud_credentials_secret_yaml = "apiVersion: v1\nkind: Secret\nmetadata:\n  name: cloud-credentials\n  namespace: flux-system\ndata: {}"
+    # Provider-injected runcmd/file blocks: empty on this render branch (the
+    # conditional if-not-empty guards short-circuit them), which is enough to
+    # exercise the infrastructure-config + namespace-create + flux-bootstrap
+    # sites this regression targets.
+    provider_prelude    = ""
+    kubeconfig_put_block = ""
+    provider_id_cmd          = ""
+    crossplane_provider_yaml = ""
+  })
+
+  # Mirror the production comment-strip (hetzner/main.tf:853 — `^[ ]*#( |$).*`)
+  # so the regexes + byte budget below run against what actually boots, not the
+  # ~44 KB of doc prose the template ships for human readers.
+  rendered_cloud_init = replace(local.rendered_raw, "/(?m)^[ ]*#( |$).*\n/", "")
+
+  # The infrastructure-config Kustomization spec: `path:` and `prune:` MUST be
+  # on separate lines (#4513 regression — an endif tilde collapsed them).
+  path_line_jammed  = length(regexall("infrastructure(/hetzner)?[ ]+prune:", local.rendered_cloud_init)) > 0
+  prune_on_own_line = length(regexall("(?m)^[ ]+prune: true$", local.rendered_cloud_init)) > 0
+
+  # The namespace-create loop must NOT pass two NAMEs to a single
+  # `create namespace` (#4513 — "exactly one NAME is required, got 2").
+  multi_name_create = length(regexall("create namespace catalyst-system openbao", local.rendered_cloud_init)) > 0
+}
+
+output "rendered_cloud_init" {
+  value     = local.rendered_cloud_init
+  sensitive = false
+}
+
+output "path_line_jammed" {
+  value = local.path_line_jammed
+}
+
+output "prune_on_own_line" {
+  value = local.prune_on_own_line
+}
+
+output "multi_name_create" {
+  value = local.multi_name_create
+}
+
+output "rendered_bytes" {
+  value = length(local.rendered_cloud_init)
+}

--- a/products/catalyst/bootstrap/api/internal/provisioner/cilium_values_parity_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/cilium_values_parity_test.go
@@ -236,13 +236,22 @@ func TestCiliumValuesParity_BootstrapHelmInstallReadsValuesFile(t *testing.T) {
 	tpl := readCloudInit(t)
 
 	// The helm install is in runcmd: as a multi-line block. The
-	// canonical form is:
-	//   helm install cilium cilium/cilium \
+	// canonical form is (post-#4504 retry-wrapper + idempotent install):
+	//   rt helm upgrade --install cilium cilium/cilium \
 	//     --version 1.16.5 \
 	//     --namespace kube-system \
 	//     -f /var/lib/catalyst/cilium-values.yaml
-	if !strings.Contains(tpl, "helm install cilium cilium/cilium") {
-		t.Fatalf("cloud-init must run `helm install cilium cilium/cilium` (this is the bootstrap exception; issue #491 didn't change that)")
+	//
+	// #4504 switched the bare `helm install` to a retried, idempotent
+	// `helm upgrade --install` so a transient get-helm/repo-update
+	// failure no longer leaves the node with no CNI. Both forms invoke
+	// the `cilium/cilium` chart; the contract this test guards is that
+	// the install reads the curated values FILE (`-f`), not a minimal
+	// `--set` list. Match on the chart invocation regardless of the
+	// install/upgrade verb.
+	if !strings.Contains(tpl, "helm install cilium cilium/cilium") &&
+		!strings.Contains(tpl, "helm upgrade --install cilium cilium/cilium") {
+		t.Fatalf("cloud-init must run `helm (install|upgrade --install) cilium cilium/cilium` (this is the bootstrap exception; issue #491 didn't change that, #4504 made it idempotent)")
 	}
 	if !strings.Contains(tpl, "-f /var/lib/catalyst/cilium-values.yaml") {
 		t.Errorf("bootstrap helm install must read values via `-f /var/lib/catalyst/cilium-values.yaml` (issue #491). Without this, the values file is never consumed and we regress to the pre-#491 minimal install which crash-loops cilium-agent.")


### PR DESCRIPTION
## Fault (verified on keystone validation Sovereign `25aadcfc437aa3e9` / kv160729.omani.works)

Fresh prov reached `status:phase1-watching` with **0 GitRepository / 0 Kustomization / 0 HelmRelease**. Nodes Ready, Cilium 4/4 (the #4503 fix worked), all 6 flux controllers Running, flux CRDs registered — yet the root source + bootstrap-kit Kustomization were never created, so Flux had nothing to reconcile. The cloud-init-complete marker was ABSENT on-node; flux-system bootstrap secrets ABSENT; `openbao` ns ABSENT.

## Root cause (cloud-init-output.log, definitive)

The `runcmd` block in `infra/providers/_shared/cloudinit-control-plane.tftpl` died at the namespace-create step:

```
kubectl create namespace catalyst-system openbao --dry-run=client -o yaml | kubectl apply -f -
  → error: exactly one NAME is required, got 2
  → error: no objects passed to apply
  → util.py[WARNING]: Failed running .../scripts/runcmd [1]
```

`kubectl create namespace` accepts **exactly ONE** positional name. Because cloud-init halts runcmd on the first non-zero exit, **everything after that item never ran** — the 6 bootstrap secrets, the openbao ns + recovery-seed, the crossplane provider, the `flux-bootstrap.yaml` apply (GitRepository + bootstrap-kit/sovereign-tls/bootstrap-kit-crs/infrastructure-config Kustomizations), and the completion marker.

### Second bug (latent)

The `infrastructure-config` Kustomization `path:` used `%{ endif ~}` — the tilde-close strips the trailing newline, collapsing `prune: true` onto the `path:` line → `error converting YAML to JSON: yaml: mapping values are not allowed in this context`. Bites on BOTH provider branches.

## Fix

1. Loop one `create namespace` per name through the idempotent dry-run|apply idiom; correct the false "takes N names" comment.
2. Drop the `~` from the `endif` on the infrastructure-config `path:`.
3. Fail-fast sentinel on the flux-bootstrap apply (mirrors #4503's pattern) so the critical handoff failing is its OWN loud fault, not a masqueraded 0-HR timeout.
4. Fold the secret-apply under `cd /var/lib/catalyst` to keep the render under the Hetzner 32256B cap (verified — primary + both secondary regions).

## Tests

- New `infra/providers/_shared/tests/` renders the shared template for provider ∈ {hetzner, huawei} and asserts path/prune on separate lines + no two-NAME create + byte budget. **Verified FAILS with either bug present** (negative control run).
- Existing hetzner (12/12) + huawei (7/7) module tests stay green.

## Recovery

Re-applied the missing bootstrap secrets + openbao ns/seed + corrected flux-bootstrap to the throwaway `25aadcfc` — GitRepository `openova` READY=True (artifact main@…), 64 HRs now materialized + climbing the dependency cascade (bp-cilium → bp-cert-manager → … → bp-catalyst-platform 1.4.913 Ready). One unrelated `bp-opentelemetry-operator` webhook-timing transient remains (retry-able, not the bootstrap fault).

Refs #4503 #3829 #4212

🤖 Generated with [Claude Code](https://claude.com/claude-code)