### PR TITLE
fix(bp-self-sovereign-cutover): harbor-prewarm skopeo no longer public-CA-verifies the in-cluster Harbor dest — unwedge cutover step-03 on LE-STAGING cert (0.1.82)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -592,7 +592,17 @@ spec:
       # → harbor.<fqdn>/proxy-xpkg, so the Huawei fresh-prov provider-opentofu
       # package (routed off the poisoned xpkg.upbound.io NAT) leaves no
       # harbor.openova.io tether at cutover (Principle #11).
-      version: 0.1.81
+      # 0.1.82 (#4529, Refs #3379): step-03 harbor-prewarm skopeo copies to the
+      # IN-CLUSTER Harbor (registry.<sov-fqdn>) now drive --dest-tls-verify from
+      # prewarm.destTLSVerify (DEFAULT false) instead of a hardcoded true. The
+      # in-cluster Harbor's wildcard cert is LE-STAGING on a fresh prov (and a
+      # Job-Pod skopeo has no node trust store even with prod LE) → the old true
+      # x509-failed every push (push_ok=0 push_fail=30 → step-03 FATAL → cutover
+      # never reached the 600s deny-egress hold; live keystone 25aadcfc). Trust is
+      # the cluster network, not a public CA (same as registries.yaml v1's bastion
+      # insecure_skip_verify). --src-tls-verify (external ghcr.io) stays true; the
+      # step-08 deny-egress security gate is untouched.
+      version: 0.1.82
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.81
+  version: 0.1.82
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1016,7 +1016,41 @@ name: bp-self-sovereign-cutover
 # MOTHERSHIP_PROXY_PREFIX env; Hetzner ships the upstream host so the new prefix
 # simply never matches there (render-additive, behaviour-identical on Hetzner).
 # Lockstep: 06a pin bumped in step.
-version: 0.1.81
+# 0.1.82 (#4529, Refs #3379): step-03 harbor-prewarm skopeo-copied the openova-io
+# container images + helm chart OCI artifacts INTO the in-cluster Harbor
+# (`registry.<sov-fqdn>` = HARBOR_PUBLIC_URL → HARBOR_HOST) with a HARDCODED
+# `--dest-tls-verify=true`. On a fresh prov that Harbor's wildcard `*.<sov-fqdn>`
+# cert is served by the BOOTSTRAP issuer `letsencrypt-dns01-staging-powerdns`
+# (LE-STAGING, untrusted by the public CA bundle), and a Job-Pod skopeo carries
+# no node trust store even with production LE — so `x509: certificate signed by
+# unknown authority` FAILED every push: `push_ok=0 push_fail=30` → step-03 FATAL
+# → the cutover never reached the 600s deny-egress hold → cutoverComplete never
+# set. Live on keystone prov 25aadcfc (registry.kv160729.omani.works), wedging
+# Pillar 5 at step 2/11 whenever LE-rate-limited onto the staging issuer.
+#
+# THE FIX (chart-only, template 03-harbor-prewarm-job.yaml + values.yaml): both
+# the Phase A (container image) and Phase A2 (helm chart OCI) skopeo copies now
+# drive `--dest-tls-verify` from a new env `PREWARM_DEST_TLS_VERIFY`
+# (.Values.prewarm.destTLSVerify, DEFAULT false). The copy DESTINATION is the
+# Sovereign's OWN in-cluster Harbor over the pod network — trust is the cluster
+# network, NOT a public CA — exactly the rationale the cold-start registries.yaml
+# v1 already uses `tls.insecure_skip_verify: true` for the bastion Harbor mirror
+# (04-registry-pivot-daemonset.yaml). `--src-tls-verify` STAYS `true`
+# unconditionally: the ghcr.io SOURCE is an external public-CA host that MUST be
+# authenticated. This does NOT weaken the cutover's security intent — that intent
+# is severing EXTERNAL tethers + pivoting to the LOCAL registry, and the witnessed
+# 600s deny-egress hold (step-08) remains the real security gate, entirely
+# untouched (step-08 unchanged; the egressDeny CCNP + call-home assertion stay
+# intact). Operators with a public-CA-trusted internal cert AND a skopeo trust
+# store may set prewarm.destTLSVerify=true via overlay.
+#
+# No step-count / RBAC / deadline change (still 11 steps). New contract Case 30
+# locks the wiring: no hardcoded --dest-tls-verify=true survives, both copies
+# drive it from the env (default false), src stays true, and an overlay can flip
+# it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
+# fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
+# the permanent env).
+version: 0.1.82
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -130,6 +130,19 @@ data:
           # infinite hang into a bounded, retryable failure.
           - name: PREWARM_SKOPEO_TIMEOUT
             value: {{ .Values.prewarm.skopeoCommandTimeout | default "1200s" | quote }}
+          # #4529 (Refs #3379): TLS-verify on the skopeo copy DESTINATION (the
+          # in-cluster Harbor `registry.<sov-fqdn>` = HARBOR_HOST). DEFAULT
+          # false — the copy target is the Sovereign's OWN registry over the
+          # cluster pod network whose wildcard cert is LE-STAGING/untrusted on a
+          # fresh prov (and a Job-Pod skopeo has no node trust store even with
+          # production LE), so verifying the dest against the public CA x509-fails
+          # every push (live keystone 25aadcfc: push_ok=0 push_fail=30 → step-03 FATAL →
+          # cutover never reaches the deny-egress hold). Trust here is the
+          # cluster network, not a public CA — same rationale as
+          # registries.yaml v1's insecure_skip_verify for the bastion mirror.
+          # The SRC (ghcr.io) verification is ALWAYS true (external public host).
+          - name: PREWARM_DEST_TLS_VERIFY
+            value: {{ .Values.prewarm.destTLSVerify | default false | quote }}
         volumeMounts:
           - name: prewarm
             mountPath: /work
@@ -371,12 +384,17 @@ data:
                 # #3944: `--command-timeout` is a skopeo GLOBAL flag (must
                 # precede the `copy` subcommand) — it bounds the whole copy so a
                 # silently-stalled connection can't hang the worker forever.
+                # #4529: --dest-tls-verify is PREWARM_DEST_TLS_VERIFY (default
+                # false) — the dest is the in-cluster Harbor over the pod
+                # network (LE-STAGING/untrusted cert on a fresh prov, no node
+                # trust store in a Job Pod). --src-tls-verify stays true (ghcr.io
+                # is an external public-CA host that MUST be authenticated).
                 if skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT}" copy \
                   --insecure-policy \
                   --retry-times 5 \
                   --src-creds="${ghcr_user}:${ghcr_pat}" \
                   --dest-creds="${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
-                  --dest-tls-verify=true \
+                  --dest-tls-verify="${PREWARM_DEST_TLS_VERIFY}" \
                   --src-tls-verify=true \
                   "docker://${up}" "docker://${lref}" >>"${cpdir}/${slug}.log" 2>&1; then
                   rc=0
@@ -550,12 +568,15 @@ data:
               cslug=$(printf '%s_%s' "${cchart}" "${cver}" | tr -c 'A-Za-z0-9._-' '_')
               # #3944: bound the chart-OCI copy too (skopeo GLOBAL flag before
               # the `copy` subcommand) so a stalled connection fails fast.
+              # #4529: same dest-TLS treatment as Phase A — the chart OCI dest
+              # is the in-cluster Harbor (PREWARM_DEST_TLS_VERIFY, default
+              # false); src stays verified (external ghcr.io).
               if skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT}" copy \
                 --insecure-policy \
                 --retry-times 3 \
                 --src-creds="${ghcr_user}:${ghcr_pat}" \
                 --dest-creds="${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
-                --dest-tls-verify=true \
+                --dest-tls-verify="${PREWARM_DEST_TLS_VERIFY}" \
                 --src-tls-verify=true \
                 "${csrc}" "${cdst}" >"${chart_cpdir}/${cslug}.log" 2>&1; then
                 printf '%s:%s' "${cchart}" "${cver}" >"${chart_cpdir}/${cslug}.ok"

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -952,4 +952,50 @@ if ! grep -q "name: bp-self-sovereign-cutover-allow-cutover-to-mgmt$" "$TMP/rend
 fi
 echo "  PASS (carve-out opens catalyst -> {gitea,harbor,openbao} host namespaces by default; legacy mgmtNamespace=mgmt still works; no dead mgmt policy by default)"
 
+echo "[cutover-contract] Case 30: Step-03 harbor-prewarm skopeo copies do NOT public-CA-verify the IN-CLUSTER Harbor DESTINATION (#4529, Refs #3379)"
+# keystone prov 25aadcfc: step-03 skopeo-copied openova-io images to the in-
+# cluster Harbor `registry.<sov-fqdn>` (HARBOR_PUBLIC_URL → HARBOR_HOST) with
+# --dest-tls-verify=true. That Harbor's wildcard cert is LE-STAGING (the
+# bootstrap default issuer, untrusted by the public CA bundle) on a fresh prov,
+# and a Job-Pod skopeo carries no node trust store even with production LE — so
+# x509 unknown-authority FAILED every push (push_ok=0 push_fail=30) → step-03
+# FATAL → the 600s deny-egress hold never ran → cutoverComplete never set. The
+# dest is the cluster's OWN registry; trust is the cluster network, not a public
+# CA. The default render MUST drive --dest-tls-verify from PREWARM_DEST_TLS_VERIFY
+# (default false) so neither copy public-CA-verifies the in-cluster destination.
+# A hardcoded `--dest-tls-verify=true` MUST NOT remain in the step.
+if grep -q -- '--dest-tls-verify=true' "$TMP/render.yaml"; then
+  echo "FAIL: Step-03 still hardcodes --dest-tls-verify=true on a skopeo copy to the in-cluster Harbor — x509 unknown-authority fails every push on an LE-STAGING-cert Sovereign (#4529)" >&2
+  exit 1
+fi
+# Both copy loops (Phase A images + Phase A2 charts) MUST drive dest-TLS from the env var.
+dest_var_copies=$(grep -c -- '--dest-tls-verify="${PREWARM_DEST_TLS_VERIFY}"' "$TMP/render.yaml" || true)
+if [ "${dest_var_copies}" -lt 2 ]; then
+  echo "FAIL: Step-03 has < 2 skopeo copies driving --dest-tls-verify from PREWARM_DEST_TLS_VERIFY (found ${dest_var_copies}); a Phase A or A2 copy still public-CA-verifies the in-cluster dest (#4529)" >&2
+  exit 1
+fi
+# The env var MUST be projected from .Values.prewarm.destTLSVerify and DEFAULT false.
+if ! grep -q 'name: PREWARM_DEST_TLS_VERIFY' "$TMP/render.yaml"; then
+  echo "FAIL: Step-03 does not project the PREWARM_DEST_TLS_VERIFY env (from .Values.prewarm.destTLSVerify) (#4529)" >&2
+  exit 1
+fi
+if ! grep -A1 'name: PREWARM_DEST_TLS_VERIFY' "$TMP/render.yaml" | grep -q 'value: "false"'; then
+  echo "FAIL: PREWARM_DEST_TLS_VERIFY does not default to \"false\" — the in-cluster Harbor copy would still public-CA-verify on a fresh prov (#4529)" >&2
+  exit 1
+fi
+# The SOURCE (external ghcr.io) verification MUST stay TRUE — never weakened.
+src_verify_copies=$(grep -c -- '--src-tls-verify=true' "$TMP/render.yaml" || true)
+if [ "${src_verify_copies}" -lt 2 ]; then
+  echo "FAIL: Step-03 weakened --src-tls-verify — the external ghcr.io SOURCE must stay public-CA-verified (found ${src_verify_copies}; expected >=2) (#4529)" >&2
+  exit 1
+fi
+# Operator overlay MUST be able to re-enable dest verification (true) when the
+# internal cert is public-CA-trusted.
+helm template smoke-desttls . --set 'prewarm.destTLSVerify=true' > "$TMP/render-desttls.yaml"
+if ! grep -A1 'name: PREWARM_DEST_TLS_VERIFY' "$TMP/render-desttls.yaml" | grep -q 'value: "true"'; then
+  echo "FAIL: prewarm.destTLSVerify=true overlay does not flip PREWARM_DEST_TLS_VERIFY to \"true\" — operators cannot opt into dest verification (#4529)" >&2
+  exit 1
+fi
+echo "  PASS (Step-03 drives in-cluster-Harbor dest-TLS from PREWARM_DEST_TLS_VERIFY, default false; src ghcr.io stays verified; overlay can re-enable dest verify)"
+
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -338,6 +338,35 @@ prewarm:
   # stepTimeouts.harborPrewarmSeconds (5400s) so at least 2-3 copies can run
   # serially within one Job's deadline even in the worst case.
   skopeoCommandTimeout: "1200s"
+  # #4529 (Refs #3379): TLS verification on the skopeo copy DESTINATION — the
+  # IN-CLUSTER Harbor reached as `registry.<sov-fqdn>` (HARBOR_PUBLIC_URL →
+  # HARBOR_HOST). DEFAULT false.
+  #
+  # WHY false is correct (NOT a security regression). Step-03 copies the
+  # openova-io container images + helm chart OCI artifacts INTO the Sovereign's
+  # OWN in-cluster Harbor over the cluster pod network. On a fresh prov that
+  # Harbor's wildcard `*.<sov-fqdn>` cert is served by the BOOTSTRAP issuer
+  # `letsencrypt-dns01-staging-powerdns` (LE-STAGING, untrusted by the public
+  # CA bundle) until production LE certs rotate in — and even with production
+  # LE certs a skopeo binary running in a Job Pod carries no node trust store,
+  # so `--dest-tls-verify=true` raises `x509: certificate signed by unknown
+  # authority` and EVERY push fails (`push_ok=0 push_fail=30` → step-03 FATAL →
+  # the cutover never reaches the 600s deny-egress hold → cutoverComplete never
+  # set; live keystone prov 25aadcfc on registry.kv160729.omani.works). The
+  # destination is the cluster's OWN registry — trust is established by the
+  # cluster network, NOT a public CA — exactly the same rationale the cold-start
+  # registries.yaml v1 uses `tls.insecure_skip_verify: true` for the bastion
+  # Harbor mirror (04-registry-pivot-daemonset.yaml). The cutover's SECURITY
+  # intent is severing EXTERNAL tethers + pivoting to the LOCAL registry; the
+  # witnessed 600s deny-egress hold (step-08) is the real security gate and is
+  # wholly untouched by this flag. SRC verification stays true unconditionally
+  # (the ghcr.io SOURCE is a public CA-signed external host that MUST be
+  # authenticated).
+  #
+  # Operators with a public-CA-trusted internal registry cert AND a skopeo
+  # trust store may set this true via overlay; default false is the correct
+  # fresh-prov behaviour.
+  destTLSVerify: false
   images:
     - "proxy-docker/library/redis:7"
     - "proxy-docker/library/postgres:16"


### PR DESCRIPTION
## Fault

The Pillar-5 cutover (`bp-self-sovereign-cutover`, #3379) wedges at **step 2/11 (harbor-prewarm)** on a fresh prov.

Live evidence (keystone prov `25aadcfc`): step-03 runs `skopeo copy --dest-tls-verify=true` to the **IN-CLUSTER** registry `registry.kv160729.omani.works`, which fails `x509: certificate signed by unknown authority` → `push_ok=0 push_fail=30` FATAL → the cutover never reaches the 600s deny-egress hold → `cutoverComplete` never set.

Root: the in-cluster Harbor's wildcard cert is served by the bootstrap default issuer `letsencrypt-dns01-staging-powerdns` (LE-STAGING, untrusted by the public CA bundle). And even with production LE certs, a skopeo binary running in a Job Pod carries **no node trust store** — so verifying the in-cluster Harbor against the public CA can never succeed from the pod.

## Fix

`platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml` — both the **Phase A** (openova-io container image) and **Phase A2** (openova-io helm chart OCI) skopeo copies now drive `--dest-tls-verify` from a new env `PREWARM_DEST_TLS_VERIFY` (`.Values.prewarm.destTLSVerify`, **default `false`**).

The copy **destination** is the Sovereign's OWN in-cluster Harbor over the pod network — trust is the cluster network, **not** a public CA. This is exactly the rationale the cold-start `registries.yaml` v1 already uses `tls.insecure_skip_verify: true` for the bastion Harbor mirror (`04-registry-pivot-daemonset.yaml`).

`--src-tls-verify` **stays `true` unconditionally** — the `ghcr.io` SOURCE is an external public-CA host that MUST be authenticated.

## Security intent preserved

The cutover's security intent is **severing EXTERNAL tethers + pivoting to the LOCAL registry** — trusting the local registry over the cluster network is correct. The real security gate is the **witnessed 600s deny-egress hold (step-08)**, which is **entirely untouched** by this PR (no change to `08-egress-block-test-job.yaml`; the egressDeny CCNP + call-home assertion stay intact). `git diff` touches step-03 + values + chart + test + the two pins only.

## Lockstep + tests

- chart `0.1.81 → 0.1.82`; `blueprint.yaml` + bootstrap-kit `slot-06a` pins bumped in lockstep.
- New contract **Case 30** locks the wiring: no hardcoded `--dest-tls-verify=true` survives; both copies drive it from the env (default `false`); `--src-tls-verify=true` stays; an overlay (`prewarm.destTLSVerify=true`) can re-enable dest verification.
- All **30** contract cases green; `helm lint` clean.

## Roll-gated

Live `11-step → cutoverComplete=true` validation needs a fresh prov whose cutover reaches the 600s egress hold. **NOT** live-verified here; **NOT** run on the permanent env.

Refs #4529 #3379

🤖 Generated with [Claude Code](https://claude.com/claude-code)