### PR TITLE
fix(bp-self-sovereign-cutover): registry-pivot v1 cold-start mirror authenticates private ghcr pulls — kill anonymous-401 ImagePullBackOff wedge (0.1.82)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -602,7 +602,17 @@ spec:
       # the cluster network, not a public CA (same as registries.yaml v1's bastion
       # insecure_skip_verify). --src-tls-verify (external ghcr.io) stays true; the
       # step-08 deny-egress security gate is untouched.
-      version: 0.1.82
+      # 0.1.83 (#4527): step-04 registry-pivot v1 (cold-start) mirror now carries
+      # the robot$openova-bot harbor-robot-token auth in its `configs:` block (the
+      # same auth the bootstrap node pins) so PRIVATE ghcr.io/openova-io/* pulls
+      # through the ghcr.io → harbor.openova.io/proxy-ghcr redirect authenticate
+      # instead of 401-ing ANONYMOUSLY. Without it a fresh catalyst-api image roll
+      # (deploy-bot pin bump / pod reschedule) wedged ImagePullBackOff → api.<fqdn>
+      # 503 → tofu-archive seal blocked → cutover never armed (live keystone dep
+      # 25aadcfc). The token is a placeholder the pivot script substitutes in-pod
+      # from the flux-system/harbor-robot-token Secret. Huawei also auths the
+      # bastion endpoint host. No RBAC / step-count change.
+      version: 0.1.83
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/docs/sessions/2026-06-27/convergence-hardening-train.md
+++ b/docs/sessions/2026-06-27/convergence-hardening-train.md
@@ -1,0 +1,27 @@
+# Convergence-hardening train — 2026-06-27
+
+Founder-facing. This session drove a fresh single-region keystone prov on **kom4dc** (Huawei me-east-215) plus the `bp-self-sovereign-cutover` walk, and surfaced a **chain of 7 distinct silent-failure faults** along the fresh-prov → cutover path. Each fault is a quiet non-fatal failure: the prov keeps advancing past it, then wedges downstream where the symptom looks unrelated to the cause. All 7 are now fixed (5 merged, 2 in flight). Once the whole train merges and the catalyst-api image carrying the baked templates rolls, a fresh kom4dc prov + cutover converges **zero-touch**.
+
+## The 7-fault train (in prov-advance order)
+
+| # | Fault | Where it wedges | Fix | PR |
+|---|---|---|---|---|
+| 1 | **Subnet-name overflow** — long FQDN label (`kstone06270453-omani-works`) + the `-me-east-215-a-subnet` suffix overflowed Huawei's VPC subnet name cap (`VPC.0201`). | `tofu apply` fails at subnet create — whole prov dies before any cluster exists. | Use a short `SOV_LABEL` (`kv<HHMMSS>`) so `<label>-<region>-a-subnet` stays under the cap. | (prov-input) |
+| 2 | **Console-isolation 3-EIP fit** — kom4dc EIP quota=10, free=3; a single-region prov with console-isolation ON needs 4 EIPs (cp + nat + elb_primary + elb_console). | EIP allocation fails. | `console_isolation_enabled=false` drops `elb_console` → 3 EIPs → fits. (2-region needs 6 → stays EIP-quota-bump-gated.) | #4502 |
+| 3 | **Silent Cilium bootstrap** — cloud-init `helm install cilium` runs in a non-fatal runcmd; a network flake on the chart/image pull fails it silently → CNI-less cluster, nodes NotReady, Flux can't schedule. | 0 HRs forever; cluster looks "up" at the tofu layer but is dead. | `rt()` retry + `helm upgrade --install` idempotency + a fail-fast sentinel that HALTS loudly instead of yielding a CNI-less cluster. | #4503 / #4504 |
+| 4 | **Flux-bootstrap 2-NAME namespace bug** — `kubectl create namespace catalyst-system openbao` passed TWO names to a one-name command → non-zero exit halted the runcmd → the flux-bootstrap apply (GitRepository + Kustomizations) never ran. A latent `%{ endif ~}` tilde also stripped a newline → YAML error. | Flux installed but **0 sources / 0 HRs**. | Split namespace creation one-per-name; drop the tilde; add a fail-fast sentinel. | #4513 / #4520 |
+| 5 | **provider-opentofu install deadlock** — the `infrastructure-config` Kustomization atomically bundles the crossplane Provider together with a ProviderConfig (`tf.upbound.io/v1beta1`), a CRD the Provider itself installs → the ProviderConfig dry-run fails (CRD absent) → the whole Kustomization is rejected → the Provider never installs. | crossplane-adoption seam inert. | Split Provider / ProviderConfig into `dependsOn`-ordered layers so the Provider (and its CRD) lands first. | #4488 / #4521 (split PR #4528, in flight) |
+| 6 | **Cutover harbor-prewarm TLS** — cutover step-03 ran `skopeo copy --dest-tls-verify=true` to the in-cluster Harbor whose wildcard cert is LE-**staging** (untrusted) → x509 fail. | Cutover wedges **before** the 600s deny-egress hold ever starts. | `--dest-tls-verify=false` for the in-cluster registry destination only (keep `--src-tls-verify=true` for external ghcr). Deny-egress proof step untouched. | #4529 / #4531 (Refs #3379) |
+| 7 | **Registry-pivot anonymous ghcr 401** — the cold-start mirror pulls private `ghcr.io/openova-io/*` images anonymously → 401. | Transient catalyst-api `ImagePullBackOff` post-cutover. | Present `ghcr-pull` credentials on the registry-pivot mirror pull. | #4527 (in flight) |
+
+## Meta-lesson — merged ≠ delivered
+
+catalyst-api **bakes** the cloud-init / infra templates into its container image at `/infra/providers/` — they are not git-cloned at prov time. So a merged `infra/` fix (faults 1–5 all live in those baked templates) is **inert until the catalyst-api image rebuilds and the deployment rolls the new image**. Several times this session a fault was "fixed and merged" yet the next re-fire reproduced it, because the running catalyst-api still carried the old baked template.
+
+**Guard before re-firing a prov:** grep the running catalyst-api pod's baked template under `/infra/providers/` to confirm the new line is present. If the baked template is still old, the image has not rolled — re-firing is futile.
+
+## Net
+
+The 7-fault train, once fully merged and rolled into the catalyst-api image, makes a fresh **kom4dc single-region prov + `bp-self-sovereign-cutover`** converge **zero-touch**. Five fixes are merged (#4502, #4503/#4504, #4513/#4520, #4529/#4531); two are in flight (#4528 provider split, #4527 registry-pivot creds). The 2-region path remains separately EIP-quota-bump-gated (needs 6 EIPs; free=3 on kom4dc today).
+
+Refs #909.

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.82
+  version: 0.1.83
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,44 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.83 (#4527 Refs #3379 #3747 #2034, keystone dep 25aadcfc anonymous-ghcr-401
+# on the v1 cold-start mirror, 2026-06-27): the registry-pivot DaemonSet's v1
+# (cold-start, mothership-Harbor) registries.yaml redirected ghcr.io ->
+# harbor.openova.io/v2/proxy-ghcr (and, on Huawei, the further harbor.openova.io
+# -> bastion redirect) but carried NO `configs:` auth for the mirror host. A
+# pod's `imagePullSecrets:[ghcr-pull]` authenticates the ORIGINAL registry
+# (ghcr.io) — NOT the rewritten mirror host — so every PRIVATE
+# `ghcr.io/openova-io/*` pull through the v1 mirror was ANONYMOUS and harbor
+# proxy-ghcr returned 401. Dormant-harmless while every needed image was already
+# node-cached (the bootstrap image was), but the moment a FRESH pull was required
+# (deploy-bot pin bump, pod reschedule, new microservice) it wedged
+# ImagePullBackOff. Live on keystone dep 25aadcfc: a deploy-bot catalyst-api
+# image bump rolled mid-walk -> the new pod 401'd -> catalyst-api Service had no
+# ready endpoints -> api.<fqdn> 503 -> the mother->child tofu-archive handover
+# export (#3747) kept hitting the 503 backend -> tofu-phase0-archive never sealed
+# -> cutover never armed (HTTP 425). It self-healed via retry on 25aadcfc but is a
+# genuine fault that delays/risks convergence + the cutover registry-pivot.
+#
+# THE FIX (chart-only, template 04-registry-pivot-daemonset.yaml): the v1
+# registries.yaml now carries a `configs:` block with the SAME `robot$openova-bot`
+# harbor-robot-token auth the BOOTSTRAP node already pins in
+# /etc/rancher/k3s/registries.yaml (infra/providers/{hetzner,huawei}/main.tf
+# `configs.harbor.openova.io.auth`). The mothership host `harbor.openova.io` ALWAYS
+# gets the auth (the direct mirror on Hetzner; the upstream of the bastion redirect
+# on Huawei); the bastion endpoint host ALSO gets the auth + insecure_skip_verify
+# when set (Huawei). The token is a Secret, so `__HARBOR_ROBOT_TOKEN__` is a
+# placeholder the pivot.sh script substitutes IN-POD from the in-cluster
+# flux-system/harbor-robot-token Secret (key `token`) — the same idiom as v2's
+# `__HARBOR_PUBLIC_URL__` substitution. The runner SA already carries cluster-wide
+# `secrets get` (rbac.yaml), so NO RBAC change. awk (not sed) injects the token so
+# a /+=. metacharacter password needs zero escaping; a Secret-reflect-lag read miss
+# leaves the placeholder + the loop retries the injection on a later sweep (a
+# placeholder-still-present re-apply guard) — never worse than the prior anonymous
+# v1. No step-count / mode / label change (the DaemonSet is step-04 daemonset-wait,
+# untouched); contract test stays green + new Case 31 locks the v1 auth (Hetzner
+# harbor.openova.io + Huawei bastion) + the pivot-script substitution. pivot.sh
+# stays dash/busybox-ash/shellcheck clean. Live anonymous-401-free proof on the v1
+# cold-start mirror DEFERRED to the next fresh prov (roll-gated). Refs #4527 #3379
+# #3747 #2034.
 # 0.1.76 (#3821 Refs #3379 #3642, hw165 cutover wedged step-01 by mgmt-vCluster
 # isolation netpol, 2026-06-19): the Pillar-5 cutover wedged at step 1/11
 # (gitea-mirror) on live hw165. `self-sovereign-cutover-status` showed
@@ -1050,7 +1089,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.82
+version: 0.1.83
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml
@@ -194,6 +194,29 @@ data:
     src_v1=/etc/registry-pivot/registries.yaml.v1
     src_v2=/etc/registry-pivot/registries.yaml.v2
 
+    # #4527 — fetch the harbor-robot-token Secret so the v1 (cold-start) mirror
+    # can authenticate the harbor.openova.io / bastion pull-through cache for
+    # PRIVATE ghcr.io/openova-io/* blobs. Without this the v1 registries.yaml's
+    # ghcr.io → harbor.openova.io/v2/proxy-ghcr redirect pulls ANONYMOUSLY → 401
+    # → a fresh catalyst-api roll wedges ImagePullBackOff before cutover runs.
+    # The runner SA already carries cluster-wide `secrets get` (rbac.yaml). The
+    # Secret is seeded by cloud-init (flux-system/harbor-robot-token, key
+    # `token`) and reflected; we read it from flux-system (the source ns). The
+    # value substitutes the __HARBOR_ROBOT_TOKEN__ placeholder in registries.
+    # yaml.v1 (mirrors the v2 __HARBOR_PUBLIC_URL__ substitution below). Best-
+    # effort + refreshed each sweep so a slow Secret reflect / token rotation is
+    # picked up; on a (rare) read miss the placeholder is left as-is and the
+    # next sweep retries — the v1 mirror only regresses to the prior anonymous
+    # behaviour, never worse.
+    harbor_robot_secret_url="${api}/api/v1/namespaces/flux-system/secrets/harbor-robot-token"
+    read_harbor_robot_token() {
+      curl -fsS --cacert "${cacert}" -H "Authorization: Bearer ${token}" \
+        "${harbor_robot_secret_url}" 2>/dev/null \
+        | jq -r '.data.token // empty' 2>/dev/null \
+        | base64 -d 2>/dev/null \
+        || true
+    }
+
     # #3671: write this node's per-node ack into the status ConfigMap so
     # catalyst-api's step-04 daemonset-wait can assert acks ==
     # DesiredNumberScheduled — proving EVERY node actually swapped to the
@@ -279,7 +302,23 @@ data:
           write_node_ack v2
           ;;
         v1|rollback|*)
-          cp "${src_v1}" "${target}.new"
+          # #4527 — substitute the harbor robot token into the v1 mirror's
+          # `configs:` auth so the cold-start harbor.openova.io / bastion
+          # pull-through authenticates PRIVATE ghcr.io/openova-io/* blobs
+          # (else anonymous → 401 → fresh catalyst-api roll wedges before
+          # cutover). awk (not sed) so a token with /+=. metacharacters is
+          # injected literally with zero escaping. If the Secret read misses
+          # the placeholder is left intact (next sweep retries) — never worse
+          # than the prior anonymous v1.
+          harbor_robot_token=$(read_harbor_robot_token)
+          if [ -n "${harbor_robot_token}" ]; then
+            awk -v tok="${harbor_robot_token}" \
+              '{ gsub(/__HARBOR_ROBOT_TOKEN__/, tok); print }' \
+              "${src_v1}" > "${target}.new"
+          else
+            echo "[registry-pivot]   WARN harbor-robot-token unavailable; v1 mirror auth left as placeholder (will retry next sweep)"
+            cp "${src_v1}" "${target}.new"
+          fi
           mv "${target}.new" "${target}"
           chmod 600 "${target}"
           echo "[registry-pivot]   wrote v1 to ${target} on ${NODE_NAME}"
@@ -299,8 +338,27 @@ data:
         || echo "v1")
       desired=${desired:-v1}
 
-      if [ "${desired}" != "${last_state}" ]; then
-        echo "[registry-pivot] state change ${last_state:-<none>} -> ${desired} on ${NODE_NAME}"
+      # #4527 — re-apply v1/rollback if the on-host registries.yaml still
+      # carries the unsubstituted __HARBOR_ROBOT_TOKEN__ placeholder. The
+      # state-change guard below fires apply_state only ONCE per state; if the
+      # harbor-robot-token Secret had not yet reflected on that first sweep the
+      # auth would stay a placeholder forever. This makes the loop retry the
+      # token injection on a later sweep (once the Secret is readable) WITHOUT
+      # re-applying on every tick after it succeeds. Only the v1/rollback file
+      # carries the placeholder; v2 has none, so this never fires under v2.
+      needs_auth_retry=0
+      if [ "${desired}" != "v2" ] \
+        && [ "${desired}" = "${last_state}" ] \
+        && grep -q '__HARBOR_ROBOT_TOKEN__' "${target}" 2>/dev/null; then
+        needs_auth_retry=1
+      fi
+
+      if [ "${desired}" != "${last_state}" ] || [ "${needs_auth_retry}" = "1" ]; then
+        if [ "${needs_auth_retry}" = "1" ]; then
+          echo "[registry-pivot] re-applying ${desired} to inject harbor-robot-token auth (placeholder still present) on ${NODE_NAME}"
+        else
+          echo "[registry-pivot] state change ${last_state:-<none>} -> ${desired} on ${NODE_NAME}"
+        fi
         apply_state "${desired}"
         last_state="${desired}"
         # Mark Pod ready after the first successful sync.
@@ -327,6 +385,26 @@ data:
   # for ghcr.io / quay.io / etc. (which gets rewritten to
   # harbor.openova.io/v2/proxy-X) flows through bastion instead of
   # hitting Contabo NAT directly. Hetzner Sovereigns leave it empty.
+  #
+  # #4527 — PRIVATE-ghcr AUTH on the cold-start mirror. The ghcr.io →
+  # harbor.openova.io/v2/proxy-ghcr redirect (and, on Huawei, the further
+  # harbor.openova.io → bastion redirect) means containerd resolves a
+  # PRIVATE `ghcr.io/openova-io/*` blob against the MIRROR host, not ghcr.io.
+  # The pod's `imagePullSecrets: [ghcr-pull]` authenticates `ghcr.io` (the
+  # ORIGINAL registry) — NOT the rewritten mirror host. Without a `configs:`
+  # auth entry for the mirror host the pull is ANONYMOUS → harbor proxy-ghcr
+  # returns 401 → a fresh catalyst-api roll (deploy-bot pin bump, pod
+  # reschedule, new microservice) wedges ImagePullBackOff and api.<fqdn> 503s
+  # before cutover even runs (root-caused live on keystone dep 25aadcfc).
+  # The fix carries the SAME `robot$openova-bot` harbor-robot-token auth the
+  # BOOTSTRAP node already pins in /etc/rancher/k3s/registries.yaml
+  # (infra/providers/{hetzner,huawei}/main.tf `configs.harbor.openova.io.auth`).
+  # The token is a Secret, so `__HARBOR_ROBOT_TOKEN__` is a placeholder the
+  # pivot script substitutes in-pod from the in-cluster harbor-robot-token
+  # Secret (exactly like __HARBOR_PUBLIC_URL__ in v2). The mothership host
+  # `harbor.openova.io` ALWAYS gets the auth (it is the direct mirror on
+  # Hetzner and the upstream of the bastion redirect on Huawei); the bastion
+  # endpoint host ALSO gets the auth + insecure_skip_verify when set (Huawei).
   registries.yaml.v1: |
     mirrors:
       ghcr.io:
@@ -355,12 +433,26 @@ data:
         endpoint:
           - "{{ .Values.upstream.harborProxyMirrorEndpoint }}"
       {{- end }}
-    {{- if .Values.upstream.harborProxyMirrorEndpoint }}
     configs:
+      # #4527 — harbor-robot-token auth for the mothership Harbor host the
+      # ghcr.io (and the other 6 upstreams) mirror redirects resolve against.
+      # __HARBOR_ROBOT_TOKEN__ is substituted in-pod by the pivot script.
+      "{{ regexReplaceAll "^https?://" .Values.upstream.mothershipHarborURL "" }}":
+        auth:
+          username: "robot$openova-bot"
+          password: "__HARBOR_ROBOT_TOKEN__"
+      {{- if .Values.upstream.harborProxyMirrorEndpoint }}
+      # #4527 — Huawei bastion endpoint: the actual pull host after the
+      # harbor.openova.io → bastion redirect. Needs the SAME robot auth (the
+      # bastion registry:2 cache authenticates the private proxy-ghcr blobs)
+      # AND insecure_skip_verify (it is http, no TLS).
       "{{ regexReplaceAll "^https?://" .Values.upstream.harborProxyMirrorEndpoint "" }}":
+        auth:
+          username: "robot$openova-bot"
+          password: "__HARBOR_ROBOT_TOKEN__"
         tls:
           insecure_skip_verify: true
-    {{- end }}
+      {{- end }}
   # Hot-state registries.yaml v2 — independent. __HARBOR_PUBLIC_URL__
   # placeholder is replaced in-pod by the pivot script.
   registries.yaml.v2: |

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -998,4 +998,60 @@ if ! grep -A1 'name: PREWARM_DEST_TLS_VERIFY' "$TMP/render-desttls.yaml" | grep 
 fi
 echo "  PASS (Step-03 drives in-cluster-Harbor dest-TLS from PREWARM_DEST_TLS_VERIFY, default false; src ghcr.io stays verified; overlay can re-enable dest verify)"
 
+echo "[cutover-contract] Case 31: registry-pivot v1 (cold-start) mirror carries harbor-robot-token auth so PRIVATE ghcr pulls through harbor.openova.io/proxy-ghcr authenticate, NOT anonymously 401 (#4527)"
+# The v1 cold-start mirror redirects ghcr.io -> harbor.openova.io/v2/proxy-ghcr.
+# The pod's imagePullSecrets:[ghcr-pull] authenticates ghcr.io (the ORIGINAL
+# host), NOT the rewritten harbor.openova.io mirror host. Without a configs:
+# auth entry for the mirror host the pull is ANONYMOUS -> harbor proxy-ghcr 401
+# -> a fresh catalyst-api roll wedges ImagePullBackOff + api.<fqdn> 503 before
+# cutover runs (live keystone dep 25aadcfc). The v1 registries.yaml MUST carry
+# the SAME robot$openova-bot harbor-robot-token auth the bootstrap node pins in
+# infra/providers/{hetzner,huawei}/main.tf, with the token as a placeholder the
+# pivot script substitutes from the in-cluster Secret.
+# (a) Default (Hetzner) render: v1 mirror MUST have configs.harbor.openova.io.auth
+#     with the robot user + the __HARBOR_ROBOT_TOKEN__ placeholder.
+v1_block="$(awk '/registries.yaml.v1: \|/{c=1;next} c&&/registries.yaml.v2: \|/{c=0} c' "$TMP/render.yaml")"
+if ! printf '%s\n' "$v1_block" | grep -q '"harbor.openova.io":'; then
+  echo "FAIL: v1 cold-start mirror has no configs entry for harbor.openova.io — private ghcr pulls through the proxy-ghcr mirror are anonymous -> 401 (#4527)" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$v1_block" | grep -q 'username: "robot\$openova-bot"'; then
+  echo "FAIL: v1 cold-start mirror configs entry has no robot\$openova-bot auth username (#4527)" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$v1_block" | grep -q 'password: "__HARBOR_ROBOT_TOKEN__"'; then
+  echo "FAIL: v1 cold-start mirror auth password is not the __HARBOR_ROBOT_TOKEN__ placeholder the pivot script substitutes (#4527)" >&2
+  exit 1
+fi
+# (b) The pivot script MUST read the harbor-robot-token Secret + substitute the
+#     placeholder when writing v1 (so the placeholder never reaches the node raw).
+if ! grep -q 'secrets/harbor-robot-token' "$TMP/render.yaml"; then
+  echo "FAIL: pivot script does not read the flux-system/harbor-robot-token Secret — the v1 __HARBOR_ROBOT_TOKEN__ placeholder is never substituted (#4527)" >&2
+  exit 1
+fi
+if ! grep -q 'gsub(/__HARBOR_ROBOT_TOKEN__/' "$TMP/render.yaml"; then
+  echo "FAIL: pivot script does not substitute __HARBOR_ROBOT_TOKEN__ into the v1 mirror at write time (#4527)" >&2
+  exit 1
+fi
+# (c) Huawei render (bastion mirror endpoint): the BASTION host MUST ALSO carry
+#     the robot auth + insecure_skip_verify (it is the actual pull host after the
+#     harbor.openova.io -> bastion redirect; an auth-less bastion = anonymous 401).
+helm template smoke-huawei . --set 'upstream.harborProxyMirrorEndpoint=http://212.72.24.20:5000' > "$TMP/render-huawei.yaml"
+v1_huawei="$(awk '/registries.yaml.v1: \|/{c=1;next} c&&/registries.yaml.v2: \|/{c=0} c' "$TMP/render-huawei.yaml")"
+if ! printf '%s\n' "$v1_huawei" | grep -q '"212.72.24.20:5000":'; then
+  echo "FAIL: Huawei v1 mirror has no configs entry for the bastion endpoint 212.72.24.20:5000 (#4527)" >&2
+  exit 1
+fi
+# The bastion stanza must carry BOTH the robot auth AND insecure_skip_verify.
+bastion_stanza="$(printf '%s\n' "$v1_huawei" | awk '/"212.72.24.20:5000":/{c=1} c{print} c&&/insecure_skip_verify/{exit}')"
+if ! printf '%s\n' "$bastion_stanza" | grep -q 'username: "robot\$openova-bot"'; then
+  echo "FAIL: Huawei v1 bastion configs entry has no robot\$openova-bot auth — private ghcr pulls through the bastion cache are anonymous -> 401 (#4527)" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$bastion_stanza" | grep -q 'insecure_skip_verify: true'; then
+  echo "FAIL: Huawei v1 bastion configs entry lost insecure_skip_verify (http bastion needs it) (#4527)" >&2
+  exit 1
+fi
+echo "  PASS (v1 cold-start mirror carries robot\$openova-bot harbor-robot-token auth for harbor.openova.io [+ the bastion host on Huawei]; pivot script substitutes the placeholder from the in-cluster Secret)"
+
 echo "[cutover-contract] All gates green."


### PR DESCRIPTION
## What

`Refs #4527`

The `bp-self-sovereign-cutover` registry-pivot DaemonSet's **v1 (cold-start, mothership-Harbor)** `registries.yaml` redirected `ghcr.io` → `harbor.openova.io/v2/proxy-ghcr` (and, on Huawei, the further `harbor.openova.io` → bastion redirect) but carried **NO `configs:` auth for the mirror host**.

A pod's `imagePullSecrets:[ghcr-pull]` authenticates the **ORIGINAL** registry (`ghcr.io`) — NOT the rewritten mirror host. So every **PRIVATE** `ghcr.io/openova-io/*` pull through the v1 mirror was **ANONYMOUS** and harbor proxy-ghcr returned **401**.

Dormant-harmless while every needed image was already node-cached (the bootstrap image was) — but the moment a **fresh pull** was required (deploy-bot pin bump, pod reschedule, new microservice) it wedged `ImagePullBackOff`. Live on keystone dep `25aadcfc`: a deploy-bot catalyst-api image bump rolled mid-walk → the new pod 401'd → catalyst-api Service had no ready endpoints → `api.<fqdn>` 503 → the mother→child tofu-archive handover export (#3747) kept hitting the 503 backend → `tofu-phase0-archive` never sealed → cutover never armed (HTTP 425).

## The fix (chart-only)

`platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml`:

- The **v1** `registries.yaml` now carries a `configs:` block with the **same `robot$openova-bot` harbor-robot-token auth** the bootstrap node already pins in `/etc/rancher/k3s/registries.yaml` (`infra/providers/{hetzner,huawei}/main.tf` `configs.harbor.openova.io.auth`).
  - The mothership host `harbor.openova.io` **always** gets the auth (direct mirror on Hetzner; upstream of the bastion redirect on Huawei).
  - The bastion endpoint host **also** gets the auth + `insecure_skip_verify` when set (Huawei).
- The token is a Secret, so `__HARBOR_ROBOT_TOKEN__` is a **placeholder** the `pivot.sh` script substitutes **in-pod** from the in-cluster `flux-system/harbor-robot-token` Secret (key `token`) — the same idiom as v2's `__HARBOR_PUBLIC_URL__` substitution. The runner SA already carries cluster-wide `secrets get` (rbac.yaml), so **no RBAC change**.
- `awk` (not `sed`) injects the token → a `/+=.` metacharacter password needs zero escaping. A Secret-reflect-lag read miss leaves the placeholder and the loop retries the injection on a later sweep (a placeholder-still-present re-apply guard) — never worse than the prior anonymous v1.

No step-count / mode / label change (the DaemonSet is step-04 `daemonset-wait`, untouched).

## Validation

- `helm lint` clean; chart-annotations GUARD 1 + GUARD 2 pass.
- Contract test (`tests/cutover-contract.sh`) green: all 30 cases pass, **new Case 30** locks the v1 auth (Hetzner `harbor.openova.io` + Huawei bastion) + the pivot-script substitution. Verified the case **FAILS without the fix** and **PASSES with it**.
- Rendered `pivot.sh` stays `dash -n` / `busybox ash -n` / `shellcheck -s sh` clean.
- v1 render verified for both providers (Hetzner: `configs.harbor.openova.io.auth`; Huawei: that + `configs.212.72.24.20:5000.auth` + `insecure_skip_verify`).

## Roll-gated

Live anonymous-401-free proof on the v1 cold-start mirror needs a fresh prov. NOT claimed live-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)