### PR TITLE
feat(catalog): GET /catalog/regions — marketplace BCP picker fetches the Sovereign's REAL regions

### DIFF
--- a/core/marketplace/src/components/BCPStep.svelte
+++ b/core/marketplace/src/components/BCPStep.svelte
@@ -27,26 +27,62 @@
   // and logs a Warn — symmetric with the operator-opt-in InvalidRegionPair
   // test in appconfigs_test.go.
   //
-  // Regions list — TODO follow-up: when the catalog service exposes
-  // GET /v1/catalog/regions returning the Sovereign's primary +
-  // secondary regions, swap REGIONS to a fetched list. For now the
-  // canonical t-N defaults are hardcoded; smaller blast radius than
-  // shipping a stub endpoint that would itself be theatre.
+  // Regions list — #4525: fetched from the catalog service's
+  // GET /api/catalog/regions (the Sovereign's REAL configured regions,
+  // sourced from CATALYST_CONFIGURED_REGIONS). The hardcoded list below
+  // is the loading/offline FALLBACK only — on a Huawei Sovereign running
+  // me-east-215-a/b the fetched set replaces it so the picker never
+  // offers a region the Sovereign cannot honor (which would route the
+  // customer's choice into the gitops InvalidRegionPair single-cluster
+  // fallback silently).
+  import { onMount } from 'svelte';
   import { readCart, setAppConfig } from '../lib/cart';
 
-  // Canonical Sovereign region keys — matches the values gitops
+  // Fallback Sovereign region keys — matches the values gitops
   // appconfigs_test.go::TestPostgres_AppConfigs_ActiveHotStandby_GenericApp
-  // exercises ("hz-fsn-rtz-prod" / "hz-hel-rtz-prod") + adds nbg as the
-  // third region the t-N fresh-prov topology bring up. If a Sovereign
-  // wants a different set, the catalog/regions endpoint is the right
-  // injection point (see TODO above). hz-fsn = Falkenstein, hz-hel =
-  // Helsinki, hz-nbg = Nuremberg — all Hetzner BBs the canonical
-  // multi-region prov uses.
-  const REGIONS: { key: string; label: string }[] = [
+  // exercises ("hz-fsn-rtz-prod" / "hz-hel-rtz-prod") + nbg as a third.
+  // These are ONLY used while the /api/catalog/regions fetch is in flight
+  // or when it fails (offline / older Sovereign without the endpoint).
+  // hz-fsn = Falkenstein, hz-hel = Helsinki, hz-nbg = Nuremberg.
+  const FALLBACK_REGIONS: { key: string; label: string }[] = [
     { key: 'hz-fsn-rtz-prod', label: 'Falkenstein (hz-fsn)' },
     { key: 'hz-hel-rtz-prod', label: 'Helsinki (hz-hel)' },
     { key: 'hz-nbg-rtz-prod', label: 'Nuremberg (hz-nbg)' },
   ];
+
+  // The live region list shown in the <select>s. Starts as the fallback
+  // so the form is fully populated on first paint; replaced on mount by
+  // the Sovereign's real regions when the fetch succeeds with a non-empty
+  // set. A failed fetch or empty response leaves the fallback in place.
+  let REGIONS = $state<{ key: string; label: string }[]>(FALLBACK_REGIONS);
+
+  onMount(async () => {
+    try {
+      const res = await fetch('/api/catalog/regions', {
+        headers: { Accept: 'application/json' },
+      });
+      if (!res.ok) return; // keep fallback
+      const data = (await res.json()) as { key?: string; label?: string }[];
+      if (!Array.isArray(data) || data.length === 0) return; // keep fallback
+      const fetched = data
+        .filter((r) => typeof r.key === 'string' && r.key !== '')
+        .map((r) => ({ key: r.key as string, label: (r.label as string) || (r.key as string) }));
+      if (fetched.length === 0) return; // keep fallback
+      REGIONS = fetched;
+      // Re-anchor the picks onto the fetched set so a stale cart default
+      // (e.g. a hardcoded hz-* key from a prior session) can't survive as
+      // a region the Sovereign can't honor. Only nudge when the current
+      // pick isn't in the fetched set.
+      const keys = new Set(fetched.map((r) => r.key));
+      if (!keys.has(primaryRegion)) primaryRegion = fetched[0].key;
+      if (!keys.has(replicaRegion)) {
+        replicaRegion = fetched[1]?.key ?? fetched[0].key;
+      }
+    } catch {
+      // Network error — keep the static fallback so the picker is never
+      // blocked. The region-pair "must differ" validation still applies.
+    }
+  });
 
   // Helper: pull the current postgres slot from cart.appConfigs and
   // apply defaults so the form is always populated even on first

--- a/core/services/catalog/handlers/regions.go
+++ b/core/services/catalog/handlers/regions.go
@@ -1,0 +1,114 @@
+// Package handlers — regions.go: the public GET /catalog/regions endpoint
+// (#4525). The marketplace funnel BCP topology picker (BCPStep.svelte)
+// needs the Sovereign's REAL configured regions so the active-hot-standby
+// region <select>s never offer a region the Sovereign cannot honor.
+//
+// Before this endpoint the picker hardcoded Hetzner BB names
+// (Falkenstein/Helsinki/Nuremberg) — wrong on a Huawei Sovereign running
+// me-east-215-a/b. A customer who picked Falkenstein sent
+// primary_region=hz-fsn-rtz-prod into cart.appConfigs.postgres, which the
+// provisioning gitops generator (core/services/provisioning/gitops/
+// gitops.go) cannot map to a live cluster → silent single-cluster
+// fallback. This endpoint closes that gap.
+//
+// Source of truth: CATALYST_CONFIGURED_REGIONS — the SAME comma-separated
+// env the fleet handler trusts (products/catalyst/bootstrap/api/internal/
+// handler/fleet.go::regionsFromEnv). The value is already in the exact
+// region-key format the gitops layer consumes (e.g. `me-east-215-a` on
+// Huawei, `hz-fsn-rtz-prod` on Hetzner), so there is no per-provider
+// branching here and no risk of emitting a key the provisioner can't map.
+//
+// On a Sovereign where the env is unset the endpoint returns an empty
+// list; the frontend then keeps its static hardcoded fallback (the picker
+// is never blocked). Mirrors fleet.go's "empty env → empty slice, never
+// nil so JSON renders []" contract.
+
+package handlers
+
+import (
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/openova-io/openova/core/services/shared/respond"
+)
+
+// Region is the wire shape of one entry in GET /catalog/regions.
+//
+//	key   — the canonical region key the gitops layer consumes verbatim
+//	        (e.g. "me-east-215-a"). This is the value the BCPStep picker
+//	        writes into cart.appConfigs.postgres.{primary,replica}_region.
+//	label — a human-readable label for the <option>. Derived from the key
+//	        unless the env carried an explicit "key=label" pair.
+type Region struct {
+	Key   string `json:"key"`
+	Label string `json:"label"`
+}
+
+// ListRegions returns the Sovereign's configured regions from the
+// CATALYST_CONFIGURED_REGIONS env (comma-separated). Public + read-only —
+// same tier as /catalog/plans. Empty env → empty list (the frontend keeps
+// its static fallback). Cache-friendly (5 min) like the other public
+// catalog reads.
+func (h *Handler) ListRegions(w http.ResponseWriter, r *http.Request) {
+	regions := parseConfiguredRegions(os.Getenv("CATALYST_CONFIGURED_REGIONS"))
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	respond.OK(w, regions)
+}
+
+// parseConfiguredRegions splits the comma-separated CATALYST_CONFIGURED_REGIONS
+// value into a clean []Region. Mirrors fleet.go::regionsFromEnv: whitespace
+// and empty entries (trailing commas in the ConfigMap value) are skipped so
+// no ghost regions appear in the picker. Duplicate keys collapse to the
+// first occurrence.
+//
+// Each entry is either a bare key (`me-east-215-a`) or an explicit
+// `key=Human Label` pair. A bare key derives its label from the key
+// (humanizeRegionKey); an explicit pair takes the right-hand side as the
+// label verbatim.
+//
+// ALWAYS returns a non-nil slice so the JSON renders `[]` not `null` on an
+// empty/unset env — the frontend treats `[]` as "fall back to the static
+// list" exactly like a failed fetch.
+func parseConfiguredRegions(raw string) []Region {
+	out := make([]Region, 0)
+	seen := make(map[string]struct{})
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		key, label := part, ""
+		if i := strings.Index(part, "="); i >= 0 {
+			key = strings.TrimSpace(part[:i])
+			label = strings.TrimSpace(part[i+1:])
+		}
+		if key == "" {
+			continue
+		}
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		if label == "" {
+			label = humanizeRegionKey(key)
+		}
+		out = append(out, Region{Key: key, Label: label})
+	}
+	return out
+}
+
+// humanizeRegionKey turns a raw region key into a readable label when the
+// env carried no explicit "key=label" pair. Deliberately minimal — it
+// strips the trailing `-rtz-prod` Catalyst cluster suffix when present and
+// shows the remaining key verbatim (the keys are already short and
+// operator-meaningful, e.g. `me-east-215-a`). Per the #4525 design,
+// showing the key verbatim is acceptable v1; an operator who wants a
+// prettier label supplies a `key=Label` pair in the env.
+func humanizeRegionKey(key string) string {
+	trimmed := strings.TrimSuffix(key, "-rtz-prod")
+	if trimmed == "" {
+		return key
+	}
+	return trimmed
+}

--- a/core/services/catalog/handlers/regions_test.go
+++ b/core/services/catalog/handlers/regions_test.go
@@ -1,0 +1,112 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestParseConfiguredRegions guards the CATALYST_CONFIGURED_REGIONS parse
+// that powers GET /catalog/regions (#4525). The keys MUST pass through
+// verbatim (the gitops layer consumes them as-is, e.g. `me-east-215-a`),
+// trailing-comma / whitespace ghosts must be skipped (mirrors fleet.go::
+// regionsFromEnv), duplicates collapse, and an empty/unset env yields a
+// non-nil empty slice so the JSON renders `[]` not `null` (the frontend
+// treats `[]` as "keep the static fallback").
+func TestParseConfiguredRegions(t *testing.T) {
+	t.Run("empty env yields empty non-nil slice", func(t *testing.T) {
+		got := parseConfiguredRegions("")
+		if got == nil {
+			t.Fatal("got nil, want non-nil empty slice (JSON must render [] not null)")
+		}
+		if len(got) != 0 {
+			t.Fatalf("len = %d, want 0", len(got))
+		}
+	})
+
+	t.Run("huawei keys pass through verbatim", func(t *testing.T) {
+		got := parseConfiguredRegions("me-east-215-a,me-east-215-b")
+		if len(got) != 2 {
+			t.Fatalf("len = %d, want 2 (%+v)", len(got), got)
+		}
+		if got[0].Key != "me-east-215-a" || got[1].Key != "me-east-215-b" {
+			t.Fatalf("keys = %q,%q, want me-east-215-a,me-east-215-b", got[0].Key, got[1].Key)
+		}
+		// A bare key with no -rtz-prod suffix labels verbatim.
+		if got[0].Label != "me-east-215-a" {
+			t.Fatalf("label = %q, want me-east-215-a", got[0].Label)
+		}
+	})
+
+	t.Run("whitespace and trailing-comma ghosts are skipped", func(t *testing.T) {
+		got := parseConfiguredRegions("fsn1, hz-hel-rtz-prod ,")
+		if len(got) != 2 {
+			t.Fatalf("len = %d, want 2 (%+v)", len(got), got)
+		}
+		if got[0].Key != "fsn1" || got[1].Key != "hz-hel-rtz-prod" {
+			t.Fatalf("keys = %q,%q, want fsn1,hz-hel-rtz-prod", got[0].Key, got[1].Key)
+		}
+		// The -rtz-prod Catalyst cluster suffix is stripped for the label.
+		if got[1].Label != "hz-hel" {
+			t.Fatalf("label = %q, want hz-hel", got[1].Label)
+		}
+	})
+
+	t.Run("explicit key=label pair is honored", func(t *testing.T) {
+		got := parseConfiguredRegions("me-east-215-a=Muscat A,me-east-215-b=Muscat B")
+		if len(got) != 2 {
+			t.Fatalf("len = %d, want 2 (%+v)", len(got), got)
+		}
+		if got[0].Key != "me-east-215-a" || got[0].Label != "Muscat A" {
+			t.Fatalf("entry[0] = %+v, want {me-east-215-a, Muscat A}", got[0])
+		}
+	})
+
+	t.Run("duplicate keys collapse to first", func(t *testing.T) {
+		got := parseConfiguredRegions("me-east-215-a,me-east-215-a=Ignored")
+		if len(got) != 1 {
+			t.Fatalf("len = %d, want 1 (dedup)", len(got))
+		}
+		if got[0].Label != "me-east-215-a" {
+			t.Fatalf("label = %q, want first occurrence's derived label", got[0].Label)
+		}
+	})
+}
+
+// TestListRegionsHandler exercises the HTTP surface end-to-end: the env
+// is read, the response is the [{key,label}] array, and the cache header
+// is set. Empty env must still return `[]` with HTTP 200 (never null,
+// never an error) so the picker degrades to its static fallback cleanly.
+func TestListRegionsHandler(t *testing.T) {
+	t.Setenv("CATALYST_CONFIGURED_REGIONS", "me-east-215-a,me-east-215-b")
+	h := &Handler{}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/catalog/regions", nil)
+	h.ListRegions(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "public, max-age=300" {
+		t.Fatalf("Cache-Control = %q, want public, max-age=300", cc)
+	}
+	var regions []Region
+	if err := json.Unmarshal(rec.Body.Bytes(), &regions); err != nil {
+		t.Fatalf("decode body: %v (%s)", err, rec.Body.String())
+	}
+	if len(regions) != 2 || regions[0].Key != "me-east-215-a" || regions[1].Key != "me-east-215-b" {
+		t.Fatalf("regions = %+v, want me-east-215-a + me-east-215-b", regions)
+	}
+
+	// Empty env → [] with 200, never null/500.
+	t.Setenv("CATALYST_CONFIGURED_REGIONS", "")
+	rec2 := httptest.NewRecorder()
+	h.ListRegions(rec2, httptest.NewRequest(http.MethodGet, "/catalog/regions", nil))
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("empty-env status = %d, want 200", rec2.Code)
+	}
+	if body := rec2.Body.String(); body != "[]\n" && body != "[]" {
+		t.Fatalf("empty-env body = %q, want []", body)
+	}
+}

--- a/core/services/catalog/handlers/routes.go
+++ b/core/services/catalog/handlers/routes.go
@@ -15,6 +15,10 @@ func (h *Handler) Routes() http.Handler {
 	mux.HandleFunc("GET /catalog/bundles/{slug}", h.GetBundle)
 	mux.HandleFunc("GET /catalog/plans", h.ListPlans)
 	mux.HandleFunc("GET /catalog/addons", h.ListAddOns)
+	// #4525 — the Sovereign's REAL configured regions (CATALYST_CONFIGURED_REGIONS)
+	// so the marketplace BCP picker never offers a region the Sovereign
+	// cannot honor. Public, read-only — same tier as /catalog/plans.
+	mux.HandleFunc("GET /catalog/regions", h.ListRegions)
 
 	// Admin — mutating operations (require superadmin JWT).
 	mux.HandleFunc("POST /catalog/admin/apps", h.CreateApp)

--- a/core/services/gateway/main.go
+++ b/core/services/gateway/main.go
@@ -57,6 +57,10 @@ func main() {
 		{PathPrefix: "/api/catalog/bundles", Upstream: catalogURL, StripPrefix: "/api", Public: true},
 		{PathPrefix: "/api/catalog/plans", Upstream: catalogURL, StripPrefix: "/api", Public: true},
 		{PathPrefix: "/api/catalog/addons", Upstream: catalogURL, StripPrefix: "/api", Public: true},
+		// #4525 — the Sovereign's REAL configured regions, so the marketplace
+		// funnel BCP picker fetches a live region set instead of hardcoded
+		// Hetzner names. Public (the picker renders pre-auth, like plans/addons).
+		{PathPrefix: "/api/catalog/regions", Upstream: catalogURL, StripPrefix: "/api", Public: true},
 		// Catalog admin (requires auth).
 		{PathPrefix: "/api/catalog/admin/", Upstream: catalogURL, StripPrefix: "/api", Public: false},
 		// Organization directory + CRUD (#3383: canonical `/api/organizations`,

--- a/products/catalyst/chart/templates/org-services/catalog.yaml
+++ b/products/catalyst/chart/templates/org-services/catalog.yaml
@@ -48,6 +48,21 @@ spec:
                 configMapKeyRef:
                   name: org-services-config
                   key: CORS_ORIGIN_PUBLIC
+            # #4525 — the Sovereign's configured regions (comma-separated)
+            # so GET /catalog/regions returns the REAL region set the
+            # marketplace BCP picker must offer (not hardcoded Hetzner
+            # names). Same source the fleet handler trusts — the
+            # `sovereign-fqdn` ConfigMap's `configuredRegions` key, written
+            # at provision time. optional=true so Sovereigns without the
+            # key (legacy / Catalyst-Zero) start cleanly with the env
+            # empty; /catalog/regions then returns [] and the frontend
+            # keeps its static fallback.
+            - name: CATALYST_CONFIGURED_REGIONS
+              valueFrom:
+                configMapKeyRef:
+                  name: sovereign-fqdn
+                  key: configuredRegions
+                  optional: true
           resources:
             requests:
               cpu: 25m

--- a/products/catalyst/chart/templates/services/catalog/deployment.yaml
+++ b/products/catalyst/chart/templates/services/catalog/deployment.yaml
@@ -85,6 +85,19 @@ spec:
                   name: sovereign-fqdn
                   key: fqdn
                   optional: true
+            # #4525 — the Sovereign's configured regions (comma-separated)
+            # so GET /catalog/regions returns the REAL region set the
+            # marketplace BCP picker must offer. Same `sovereign-fqdn`
+            # ConfigMap key the fleet handler + api-deployment read.
+            # optional=true so a Sovereign without the key starts cleanly
+            # with the env empty (endpoint returns [], frontend keeps its
+            # static fallback).
+            - name: CATALYST_CONFIGURED_REGIONS
+              valueFrom:
+                configMapKeyRef:
+                  name: sovereign-fqdn
+                  key: configuredRegions
+                  optional: true
             {{- range $k, $v := .Values.services.catalog.env }}
             - name: {{ $k | quote }}
               value: {{ $v | quote }}


### PR DESCRIPTION
## What

The marketplace funnel BCP topology picker (`core/marketplace/src/components/BCPStep.svelte`) hardcoded Hetzner BB names (Falkenstein/Helsinki/Nuremberg) while a Huawei Sovereign runs `me-east-215-a`/`me-east-215-b`. A customer who picked Falkenstein sent `primary_region=hz-fsn-rtz-prod` into `cart.appConfigs.postgres`, which the provisioning gitops generator cannot map to a live cluster → silent single-cluster fallback.

## Change

**Backend — new public endpoint `GET /catalog/regions`** (`core/services/catalog/handlers/regions.go` + `routes.go`):
- Read-only, no auth — same tier as `/catalog/plans`.
- Returns `[{key,label}]` from `CATALYST_CONFIGURED_REGIONS` — the **same** source `fleet.go::regionsFromEnv` trusts, already in the exact region-key format the gitops layer consumes (`me-east-215-a` on Huawei, `hz-fsn-rtz-prod` on Hetzner). No per-provider branching, no risk of emitting a key the provisioner can't map.
- Empty/unset env → `[]` (non-nil, JSON renders `[]` not `null`) so the frontend keeps its static fallback. Labels derive from the key (strips the `-rtz-prod` Catalyst suffix) or an explicit `key=Label` env pair.

**Gateway** (`core/services/gateway/main.go`): added the public `/api/catalog/regions` → `catalogURL` route alongside `/api/catalog/plans`+`/addons` (the marketplace funnel renders pre-auth).

**Deployment wiring**: both catalog Deployments (`templates/org-services/catalog.yaml` — the storefront path — and `templates/services/catalog/deployment.yaml` — host-install) now read `CATALYST_CONFIGURED_REGIONS` from the `sovereign-fqdn` ConfigMap's `configuredRegions` key (`optional: true`), mirroring `api-deployment.yaml`.

**Frontend** (`BCPStep.svelte`): fetches `/api/catalog/regions` on mount and replaces the region `<select>`s with the live set; the hardcoded list stays as the loading/offline fallback. The region-pair "must differ" validation is preserved, and stale cart picks outside the fetched set are re-anchored so the customer can't ship a region the Sovereign can't honor.

## Tests / build
- `core/services/catalog`: `go build ./...` + `go test ./...` green (new `regions_test.go` covers the env parse + the HTTP surface incl. empty-env `[]`).
- `core/services/gateway`: `go build`/`go vet`/`go test` green.
- `core/marketplace`: `npm run build` green (incl. `/bcp/` page + domain-hygiene postbuild gate).
- `helm template` renders both catalog Deployments with the new env, full chart renders error-free.

## Roll-gated for live
Provable by merged code + build; live-verify is the catalog + marketplace image roll to the live env (the Huawei Sovereign's picker then offers `me-east-215-a`/`-b`).

Refs #4525

🤖 Generated with [Claude Code](https://claude.com/claude-code)