### PR TITLE
fix(bp-catalyst-platform): catalog reads configuredRegions from same-ns org-services-config — /catalog/regions returns REAL regions

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1197,7 +1197,10 @@ spec:
       #   but LEFT spec.source.version 0.5.12; Flux resolves from source.version
       #   so Sovereigns still pulled the OLD 0.5.12 chart -> per-Org agenity pod
       #   Init:ImagePullBackOff. Lockstep w/ Chart.yaml. Refs #4111 #4494 #4417.
-      version: 1.4.918
+      # 1.4.919 — #4525: catalog reads configuredRegions from same-namespace
+      #   org-services-config (not cross-namespace sovereign-fqdn) so
+      #   GET /catalog/regions returns the Sovereign's real region set.
+      version: 1.4.919
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3329,7 +3329,12 @@ name: bp-catalyst-platform
 #   source.version reaches the LIVE Blueprint CR zero-touch. Chart 0.5.13 is a
 #   published OCI artifact. Bump bp-catalyst-platform chart + bootstrap-kit
 #   slot 13 pin in lockstep so Flux re-rolls the seed. Refs #4111 #4494 #4417.
-version: 1.4.918
+# 1.4.919 — #4525: org-services catalog reads configuredRegions from the
+#   SAME-NAMESPACE org-services-config ConfigMap (not cross-namespace
+#   sovereign-fqdn) so GET /catalog/regions returns the Sovereign's REAL
+#   regions instead of [] — the marketplace BCP picker stops falling back to
+#   the hardcoded Hetzner list.
+version: 1.4.919
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/
 #   platform/crossplane chart + blueprint.yaml + bootstrap-kit slot 04). crossplane-core
 #   was still OOMKilled (CrashLoopBackOff, 55 restarts, exit 137, killed ~90s after start)

--- a/products/catalyst/chart/templates/org-services/catalog.yaml
+++ b/products/catalyst/chart/templates/org-services/catalog.yaml
@@ -51,16 +51,24 @@ spec:
             # #4525 — the Sovereign's configured regions (comma-separated)
             # so GET /catalog/regions returns the REAL region set the
             # marketplace BCP picker must offer (not hardcoded Hetzner
-            # names). Same source the fleet handler trusts — the
-            # `sovereign-fqdn` ConfigMap's `configuredRegions` key, written
-            # at provision time. optional=true so Sovereigns without the
-            # key (legacy / Catalyst-Zero) start cleanly with the env
-            # empty; /catalog/regions then returns [] and the frontend
-            # keeps its static fallback.
+            # names). Read from the SAME-NAMESPACE `org-services-config`
+            # ConfigMap (the central source of truth every org-services
+            # Deployment already mounts) — NOT the `sovereign-fqdn`
+            # ConfigMap, which lives in catalyst-system. A configMapKeyRef
+            # resolves only within the Pod's own namespace, so the
+            # cross-namespace `sovereign-fqdn` reference silently resolved
+            # to "" with optional=true → endpoint returned `[]` and the
+            # picker fell back to the hardcoded Hetzner list (the #4525
+            # fault). `org-services-config` carries `configuredRegions`
+            # from the SAME provision-time source (sovereign.configuredRegions
+            # / qaFixtures.configuredRegions). optional=true so legacy /
+            # Catalyst-Zero installs that pre-date the key start cleanly
+            # with the env empty; /catalog/regions then returns [] and the
+            # frontend keeps its static fallback.
             - name: CATALYST_CONFIGURED_REGIONS
               valueFrom:
                 configMapKeyRef:
-                  name: sovereign-fqdn
+                  name: org-services-config
                   key: configuredRegions
                   optional: true
           resources:

--- a/products/catalyst/chart/templates/org-services/configmap.yaml
+++ b/products/catalyst/chart/templates/org-services/configmap.yaml
@@ -145,6 +145,30 @@ keys). No other CORS rule lives off these prefixes today.
 {{- $adminOrigin := printf "https://admin.%s" $platformZone -}}
 {{- $consoleOrigin := printf "https://console.%s" $platformZone -}}
 {{- $portalOrigin := printf "https://portal.%s" $platformZone -}}
+{{- /*
+#4525 — configuredRegions for the org-services catalog Deployment.
+
+The catalog pod's CATALYST_CONFIGURED_REGIONS env (catalog.yaml) reads
+this key so GET /catalog/regions returns the Sovereign's REAL configured
+region set (the marketplace BCP picker must offer these, not a hardcoded
+Hetzner list). The value is computed from the SAME provision-time source
+as the `sovereign-fqdn` ConfigMap (sovereign-fqdn-configmap.yaml) — the
+catalog pod lives in `org-services`, but `sovereign-fqdn` lives in
+`catalyst-system`, and a configMapKeyRef resolves only within the pod's
+own namespace; reading the cross-namespace key silently resolved to ""
+with optional=true → endpoint `[]`. Carrying the same value HERE (the
+ConfigMap the catalog pod already mounts same-namespace) closes that gap.
+
+Resolution order mirrors sovereign-fqdn-configmap.yaml exactly:
+  1. .Values.sovereign.configuredRegions (operator-set, canonical)
+  2. .Values.qaFixtures.configuredRegions WHEN qaFixtures.enabled
+  3. empty string — endpoint returns [] and the frontend keeps its
+     static fallback (Catalyst-Zero / legacy Sovereigns).
+*/ -}}
+{{- $cfgRegions := default (list) .Values.sovereign.configuredRegions -}}
+{{- if and (eq (len $cfgRegions) 0) (and .Values.qaFixtures .Values.qaFixtures.enabled) -}}
+{{-   $cfgRegions = default (list) .Values.qaFixtures.configuredRegions -}}
+{{- end -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -221,4 +245,15 @@ data:
   # ---- checkout redirect targets --------------------------------------------
   CHECKOUT_SUCCESS_URL: {{ printf "%s/checkout/success" $marketplaceOrigin | quote }}
   CHECKOUT_CANCEL_URL: {{ printf "%s/checkout/cancel" $marketplaceOrigin | quote }}
+
+  # ---- BCP region picker (#4525) --------------------------------------------
+  # configuredRegions — comma-separated region set this Sovereign was
+  # provisioned with. Consumed by the catalog Deployment's
+  # CATALYST_CONFIGURED_REGIONS env (catalog.yaml) so GET /catalog/regions
+  # returns the REAL regions the marketplace BCP picker must offer. See the
+  # resolution-order comment above the data block — same source as the
+  # `sovereign-fqdn` ConfigMap, but emitted in THIS namespace so the
+  # catalog pod's same-namespace configMapKeyRef actually resolves it
+  # (the GET /catalog/regions endpoint then returns the real region set).
+  configuredRegions: {{ join "," $cfgRegions | quote }}
 {{- end }}


### PR DESCRIPTION
## What

`GET /catalog/regions` (PR #4535, live) returned `200 []` because the org-services catalog Deployment's `CATALYST_CONFIGURED_REGIONS` env referenced `configMapKeyRef: sovereign-fqdn/configuredRegions`, but the `sovereign-fqdn` ConfigMap is emitted into **catalyst-system** (the bp-catalyst-platform release namespace) while the catalog pod runs in **org-services**.

A `configMapKeyRef` resolves only within the pod's own namespace, so with `optional: true` the env silently resolved empty, the endpoint returned `[]`, and the marketplace BCP region picker fell back to the hardcoded Hetzner list instead of the Sovereign's real regions.

## Fix (Option B — fold into the ConfigMap the catalog pod already mounts)

- Emit `configuredRegions` in **org-services-config** (org-services ns) using the **same resolution order** as `sovereign-fqdn-configmap.yaml`:
  1. `sovereign.configuredRegions` (operator-set, canonical)
  2. `qaFixtures.configuredRegions` when `qaFixtures.enabled`
  3. empty string, so the endpoint returns `[]` and the frontend keeps its static fallback
- Repoint the catalog Deployment env at `org-services-config` (same-namespace) so the `configMapKeyRef` actually reads it.

Both the catalog Deployment and `org-services-config` gate on the identical `ingress.marketplace.enabled` condition, so they are always emitted together — no dangling reference.

## End-to-end loop

provision `sovereign.configuredRegions` then `org-services-config.configuredRegions` (org-services ns) then catalog pod env `CATALYST_CONFIGURED_REGIONS` then handler `os.Getenv("CATALYST_CONFIGURED_REGIONS")` then `GET /catalog/regions` then marketplace BCP picker.

No Go change — PR #4535's handler already reads the right env var; only the wiring was wrong.

## Render proof

- Sovereign-set rendered `configuredRegions: "hw-me-east-215-a-rtz-prod,hw-me-east-215-b-rtz-prod"`
- qaFixtures fallback rendered `configuredRegions: "fsn1,hz-hel-rtz-prod"`
- empty default rendered `configuredRegions: ""`
- catalog env now points at `name: org-services-config`
- full chart renders clean on both Sovereign and Catalyst-Zero (191 docs, exit 0); `configmap.yaml` is Helm-only (not Kustomize-enumerated) so the contabo path is unaffected
- catalog regions handler tests pass

Chart `1.4.917` to `1.4.918` plus the bootstrap-kit slot 13 pin in lockstep so a fresh prov wires the value end-to-end.

Roll-gated against #4525 — the issue completes when the org-services catalog config rolls to the live env and `/api/catalog/regions` returns the 2 Huawei regions plus the BCP picker offers them. Not live-verified.

Refs #4525

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- re-validate -->
