### PR TITLE
fix(catalyst-api): derive Org isolation label from the #4292 tier gate (S-plan → host-ns, not vcluster)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/org_list_from_cr.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_list_from_cr.go
@@ -120,12 +120,16 @@ func orgCRToResponse(obj *unstructured.Unstructured, otechFQDN string) orgTenant
 	if billingMode == "" {
 		billingMode = "real"
 	}
-	// Isolation is derived (not a spec field) — mirror resolveOrgShape:
-	// internal → namespace, customer → vcluster.
-	isolation := "vcluster"
-	if kind == "internal" {
-		isolation = "namespace"
-	}
+	// planSlug drives the #4292 tier gate below — read it up front so the
+	// derived isolation label reflects the actual backing.
+	planSlug := strings.ToLower(getSpec("planSlug"))
+	// Isolation is derived (not a spec field) from the SAME #4292 tier gate the
+	// org-controller uses to author the backing (isolationForTier mirrors
+	// gitops.boundaryIsVcluster): internal → namespace; customer free/S →
+	// namespace (host-ns); customer M+/flexi → vcluster. Deriving from kind
+	// ALONE (the pre-#4539 behavior) mislabeled an S-plan Org "vcluster" while
+	// it correctly backs a host namespace (UAT rows 9-12, dep 91dc05917e44d1c1).
+	isolation := isolationForTier(kind, planSlug)
 
 	// tenantPublic.parentDomain carries the org-pool apex; subdomain
 	// defaults to the slug. Empty parent → single-domain back-compat
@@ -190,7 +194,7 @@ func orgCRToResponse(obj *unstructured.Unstructured, otechFQDN string) orgTenant
 		Tier:            tier,
 		BillingMode:     billingMode,
 		Isolation:       isolation,
-		PlanSlug:        strings.ToLower(getSpec("planSlug")),
+		PlanSlug:        planSlug,
 		CreatedAt:       obj.GetCreationTimestamp().Time,
 		UpdatedAt:       obj.GetCreationTimestamp().Time,
 	}

--- a/products/catalyst/bootstrap/api/internal/handler/organization_orgshape_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_orgshape_test.go
@@ -1,9 +1,10 @@
 // organization_orgshape_test.go — coverage for resolveOrgShape, the
-// Organizations internal-door defaulting (issue #3378 B1). Locks the
-// §2.1/§2.3 model: kind defaults to customer (the funnel door); kind-
-// derived billingMode + isolation defaults; the advanced override; and
-// the malformed-enum fallback that keeps a bad body from stamping a
-// nonsense shape.
+// Organizations internal-door defaulting (issue #3378 B1) + the #4539
+// isolation-label-from-tier-gate fix. Locks the §2.1/§2.3 model: kind defaults
+// to customer (the funnel door); kind-derived billingMode default; the #4292
+// TIER GATE deriving the isolation label (free/S → namespace host-ns, M+ →
+// vcluster; internal always namespace); the advanced override; and the
+// malformed-enum fallback that keeps a bad body from stamping a nonsense shape.
 package handler
 
 import "testing"
@@ -17,9 +18,12 @@ func TestResolveOrgShape(t *testing.T) {
 		{
 			// #4292: an omitted plan slug defaults to "s" (smallest paid cap),
 			// never empty — the org-controller must always materialize a quota.
-			name: "omitted kind defaults to the customer funnel shape (byte-unchanged)",
+			// #4539: an S-plan customer Org backs a HOST NAMESPACE per the tier
+			// gate, so the derived isolation is "namespace" (was wrongly
+			// "vcluster" pre-#4539).
+			name: "omitted kind defaults to the customer funnel shape — S → host-ns",
 			in:   orgTenantCreateRequest{},
-			want: orgShape{Kind: "customer", Tier: "org", BillingMode: "real", Isolation: "vcluster", PlanSlug: "s"},
+			want: orgShape{Kind: "customer", Tier: "org", BillingMode: "real", Isolation: "namespace", PlanSlug: "s"},
 		},
 		{
 			name: "internal door → showback + namespace (kind-derived defaults)",
@@ -27,8 +31,38 @@ func TestResolveOrgShape(t *testing.T) {
 			want: orgShape{Kind: "internal", Tier: "org", BillingMode: "showback", Isolation: "namespace", PlanSlug: "s"},
 		},
 		{
-			name: "explicit customer → real + vcluster",
+			// #4539: explicit customer at the default S plan still backs host-ns.
+			name: "explicit customer at default S plan → real + host-ns",
 			in:   orgTenantCreateRequest{Kind: "customer"},
+			want: orgShape{Kind: "customer", Tier: "org", BillingMode: "real", Isolation: "namespace", PlanSlug: "s"},
+		},
+		{
+			// #4539 core assertion: an M-plan customer Org gets a dedicated
+			// vCluster per the #4292 tier gate → isolation "vcluster".
+			name: "customer M plan → dedicated vcluster",
+			in:   orgTenantCreateRequest{Kind: "customer", PlanSlug: "m"},
+			want: orgShape{Kind: "customer", Tier: "org", BillingMode: "real", Isolation: "vcluster", PlanSlug: "m"},
+		},
+		{
+			// #4539: every paid M+ tier (l/xl/flexi) is vcluster.
+			name: "customer XL plan → dedicated vcluster",
+			in:   orgTenantCreateRequest{Kind: "customer", PlanSlug: "xl"},
+			want: orgShape{Kind: "customer", Tier: "org", BillingMode: "real", Isolation: "vcluster", PlanSlug: "xl"},
+		},
+		{
+			// #4539: an explicit "free" plan is a host-ns boundary like S.
+			name: "customer free plan → host-ns",
+			in:   orgTenantCreateRequest{Kind: "customer", PlanSlug: "free"},
+			// "free" is not a quota slug → planSlug falls back to "s", but the
+			// isolation derivation runs on the resolved slug → still namespace.
+			want: orgShape{Kind: "customer", Tier: "org", BillingMode: "real", Isolation: "namespace", PlanSlug: "s"},
+		},
+		{
+			// #4539: an explicit isolation in the request still overrides the
+			// derived value (the advanced operator view) — an S-plan Org can be
+			// force-put onto a vcluster.
+			name: "advanced override: S-plan customer forced onto vcluster",
+			in:   orgTenantCreateRequest{Kind: "customer", PlanSlug: "s", Isolation: "vcluster"},
 			want: orgShape{Kind: "customer", Tier: "org", BillingMode: "real", Isolation: "vcluster", PlanSlug: "s"},
 		},
 		{
@@ -42,32 +76,36 @@ func TestResolveOrgShape(t *testing.T) {
 			want: orgShape{Kind: "internal", Tier: "corporate", BillingMode: "showback", Isolation: "namespace", PlanSlug: "s"},
 		},
 		{
-			name: "case-insensitive enum normalization",
-			in:   orgTenantCreateRequest{Kind: "INTERNAL", Tier: "Corporate", BillingMode: "ShowBack", Isolation: "NameSpace", PlanSlug: "M"},
-			want: orgShape{Kind: "internal", Tier: "corporate", BillingMode: "showback", Isolation: "namespace", PlanSlug: "m"},
+			// #4539: case-insensitive — M plan customer derives vcluster.
+			name: "case-insensitive enum normalization (M plan → vcluster)",
+			in:   orgTenantCreateRequest{Kind: "CUSTOMER", Tier: "Corporate", BillingMode: "Real", PlanSlug: "M"},
+			want: orgShape{Kind: "customer", Tier: "corporate", BillingMode: "real", Isolation: "vcluster", PlanSlug: "m"},
 		},
 		{
-			name: "malformed kind falls back to customer default shape",
+			// #4539: malformed kind → customer + S default → host-ns.
+			name: "malformed kind falls back to customer S host-ns shape",
 			in:   orgTenantCreateRequest{Kind: "garbage"},
-			want: orgShape{Kind: "customer", Tier: "org", BillingMode: "real", Isolation: "vcluster", PlanSlug: "s"},
+			want: orgShape{Kind: "customer", Tier: "org", BillingMode: "real", Isolation: "namespace", PlanSlug: "s"},
 		},
 		{
-			name: "malformed billingMode/isolation fall back to the kind-derived default",
+			// #4539: malformed billingMode/isolation fall back to the
+			// kind+tier-derived default (internal S → showback + namespace).
+			name: "malformed billingMode/isolation fall back to the derived default",
 			in:   orgTenantCreateRequest{Kind: "internal", BillingMode: "bogus", Isolation: "bogus", Tier: "bogus"},
 			want: orgShape{Kind: "internal", Tier: "org", BillingMode: "showback", Isolation: "namespace", PlanSlug: "s"},
 		},
 		{
-			// #4292: an explicit valid plan slug passes through verbatim.
-			name: "explicit plan slug passes through",
-			in:   orgTenantCreateRequest{Kind: "customer", PlanSlug: "xl"},
-			want: orgShape{Kind: "customer", Tier: "org", BillingMode: "real", Isolation: "vcluster", PlanSlug: "xl"},
+			// #4539: malformed isolation on an M-plan customer → derived vcluster.
+			name: "malformed isolation on M-plan customer → derived vcluster",
+			in:   orgTenantCreateRequest{Kind: "customer", PlanSlug: "m", Isolation: "bogus"},
+			want: orgShape{Kind: "customer", Tier: "org", BillingMode: "real", Isolation: "vcluster", PlanSlug: "m"},
 		},
 		{
 			// #4292: a malformed plan slug falls back to "s" so a bad body can
-			// never mint an uncapped Org.
-			name: "malformed plan slug falls back to s",
+			// never mint an uncapped Org; #4539: the resolved S → host-ns.
+			name: "malformed plan slug falls back to s → host-ns",
 			in:   orgTenantCreateRequest{Kind: "customer", PlanSlug: "jumbo"},
-			want: orgShape{Kind: "customer", Tier: "org", BillingMode: "real", Isolation: "vcluster", PlanSlug: "s"},
+			want: orgShape{Kind: "customer", Tier: "org", BillingMode: "real", Isolation: "namespace", PlanSlug: "s"},
 		},
 	}
 
@@ -76,6 +114,37 @@ func TestResolveOrgShape(t *testing.T) {
 			got := resolveOrgShape(tc.in)
 			if got != tc.want {
 				t.Fatalf("resolveOrgShape(%+v) = %+v, want %+v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsolationForTier locks the #4539 tier-gate derivation directly — the
+// single helper both the BSS create path (resolveOrgShape) and the CR read path
+// (orgCRToResponse) call so the displayed isolation label always matches the
+// actual backing the org-controller authors (gitops.boundaryIsVcluster).
+func TestIsolationForTier(t *testing.T) {
+	tests := []struct {
+		name     string
+		kind     string
+		planSlug string
+		want     string
+	}{
+		{"customer empty plan → host-ns", "customer", "", "namespace"},
+		{"customer S → host-ns", "customer", "s", "namespace"},
+		{"customer free → host-ns", "customer", "free", "namespace"},
+		{"customer M → vcluster", "customer", "m", "vcluster"},
+		{"customer L → vcluster", "customer", "l", "vcluster"},
+		{"customer XL → vcluster", "customer", "xl", "vcluster"},
+		{"customer flexi → vcluster", "customer", "flexi", "vcluster"},
+		{"internal S → host-ns", "internal", "s", "namespace"},
+		{"internal M → host-ns (department never gets a vcluster)", "internal", "m", "namespace"},
+		{"case-insensitive customer M → vcluster", "Customer", "M", "vcluster"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isolationForTier(tc.kind, tc.planSlug); got != tc.want {
+				t.Fatalf("isolationForTier(%q, %q) = %q, want %q", tc.kind, tc.planSlug, got, tc.want)
 			}
 		})
 	}

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
@@ -279,22 +279,64 @@ type orgShape struct {
 	PlanSlug string
 }
 
+// allTiersVcluster mirrors the controller-side single switch (issue #4292
+// boundaryIsVcluster in core/controllers/organization/internal/gitops/
+// manifests.go): set it true to put EVERY tier (incl. free/S) on a dedicated
+// vCluster. It is duplicated here the same way gitops.BoundaryIsVcluster
+// duplicates the controller gate — the two MUST flip together so the displayed
+// `isolation` label never diverges from the actual backing.
+const allTiersVcluster = false
+
+// isolationForTier returns the Org's actual boundary primitive ("namespace"
+// for a host-ns Org, "vcluster" for a dedicated Org-vCluster), derived from the
+// SAME #4292 TIER GATE the org-controller uses to author the backing. Keeping
+// this in lockstep with that gate is what makes the displayed `isolation` value
+// ACCURATE rather than a static kind-derived guess:
+//
+//   - internal kind → always "namespace" (a department shares the host ns; no
+//     dedicated vCluster regardless of plan).
+//   - customer kind → the plan tier gate decides: free/S (or empty) share the
+//     host `<slug>` namespace → "namespace"; m/l/xl/flexi get a dedicated
+//     Org-vCluster → "vcluster".
+//
+// Before this fix the label was hardcoded customer→vcluster, so an S-plan Org
+// that correctly backs a host namespace was mislabeled "vcluster" (UAT rows
+// 9-12, dep 91dc05917e44d1c1). The BACKING was always right — only the label
+// ignored the tier.
+func isolationForTier(kind, planSlug string) string {
+	if strings.ToLower(strings.TrimSpace(kind)) == "internal" {
+		return "namespace"
+	}
+	if allTiersVcluster {
+		return "vcluster"
+	}
+	switch strings.ToLower(strings.TrimSpace(planSlug)) {
+	case "", "s", "free":
+		return "namespace"
+	default:
+		return "vcluster"
+	}
+}
+
 // resolveOrgShape applies the §2.1/§2.3 model: kind defaults to
-// "customer" (the marketplace door); kind-derived billingMode +
-// isolation defaults (internal → showback + namespace; customer → real +
-// vcluster) fill in when the advanced override didn't send them; tier
-// defaults to "org". Unknown enum values fall back to the kind default
-// so a malformed body can never stamp a nonsense shape.
+// "customer" (the marketplace door); billingMode defaults from kind
+// (internal → showback; customer → real); isolation is DERIVED from the
+// #4292 tier gate (isolationForTier) so the displayed boundary matches the
+// actual backing — free/S → namespace, M+ → vcluster — not a static
+// kind-only guess; tier defaults to "org". Unknown enum values fall back to
+// the derived default so a malformed body can never stamp a nonsense shape.
+// An explicit valid isolation in the request still overrides (the advanced
+// operator view).
 func resolveOrgShape(req orgTenantCreateRequest) orgShape {
 	kind := strings.ToLower(strings.TrimSpace(req.Kind))
 	if kind != "internal" && kind != "customer" {
 		kind = "customer"
 	}
 
-	// kind-derived defaults (§2.3).
-	defBilling, defIsolation := "real", "vcluster"
+	// kind-derived billing default (§2.3).
+	defBilling := "real"
 	if kind == "internal" {
-		defBilling, defIsolation = "showback", "namespace"
+		defBilling = "showback"
 	}
 
 	billing := strings.ToLower(strings.TrimSpace(req.BillingMode))
@@ -304,11 +346,21 @@ func resolveOrgShape(req orgTenantCreateRequest) orgShape {
 		billing = defBilling
 	}
 
+	planSlug := strings.ToLower(strings.TrimSpace(req.PlanSlug))
+	switch planSlug {
+	case "s", "m", "l", "xl", "flexi":
+	default:
+		planSlug = "s"
+	}
+
+	// Isolation is DERIVED from the #4292 tier gate (host-ns for free/S,
+	// vcluster for M+; internal is always host-ns) so the label reflects the
+	// real backing. An explicit valid request override still wins.
 	isolation := strings.ToLower(strings.TrimSpace(req.Isolation))
 	switch isolation {
 	case "namespace", "vcluster":
 	default:
-		isolation = defIsolation
+		isolation = isolationForTier(kind, planSlug)
 	}
 
 	tier := strings.ToLower(strings.TrimSpace(req.Tier))
@@ -316,13 +368,6 @@ func resolveOrgShape(req orgTenantCreateRequest) orgShape {
 	case "org", "corporate":
 	default:
 		tier = "org"
-	}
-
-	planSlug := strings.ToLower(strings.TrimSpace(req.PlanSlug))
-	switch planSlug {
-	case "s", "m", "l", "xl", "flexi":
-	default:
-		planSlug = "s"
 	}
 
 	return orgShape{Kind: kind, Tier: tier, BillingMode: billing, Isolation: isolation, PlanSlug: planSlug}
@@ -647,16 +692,16 @@ func (h *Handler) HandleCreateOrganization(w http.ResponseWriter, r *http.Reques
 
 	orgTenantID := uuid.New().String()
 	rec := store.OrganizationProvisionRecord{
-		OrganizationID:  orgTenantID,
-		State:           store.STSPending,
-		Subdomain:       subdomain,
-		DomainMode:      store.OrganizationDomainMode(mode),
-		BYODomain:       byo,
-		ParentDomain:    parent,
-		AdminEmail:      email,
-		CompanyName:     strings.TrimSpace(body.CompanyName),
-		OTECHFQDN:       otech,
-		VClusterName:    "vc-" + subdomain,
+		OrganizationID: orgTenantID,
+		State:          store.STSPending,
+		Subdomain:      subdomain,
+		DomainMode:     store.OrganizationDomainMode(mode),
+		BYODomain:      byo,
+		ParentDomain:   parent,
+		AdminEmail:     email,
+		CompanyName:    strings.TrimSpace(body.CompanyName),
+		OTECHFQDN:      otech,
+		VClusterName:   "vc-" + subdomain,
 		// Workstream A (#4290 / EPIC #4293) — the per-Organization host
 		// namespace is the org-controller-owned `<slug>`, NOT a stray
 		// `org-<uuid>`. The org-controller (core/controllers/organization/


### PR DESCRIPTION
## Fault

The Organization `isolation` value the console org-list/detail surfaces was derived from the Org **kind** only (`customer`→`vcluster`, `internal`→`namespace`) and IGNORED the plan tier. Per the #4292 TIER GATE a free/S-plan customer Org correctly backs a **host namespace** — only M+ tiers get a dedicated vCluster (`boundaryIsVcluster` in `core/controllers/organization/internal/gitops/manifests.go`). So a customer S-plan Org displayed `isolation=vcluster` while its actual backing is host-ns: a misleading label. Surfaced by the UAT reconciliation (rows 9-12, dep `91dc05917e44d1c1`). **The BACKING was always correct — only the label ignored the tier.**

## Source of the wrong value
- `products/catalyst/bootstrap/api/internal/handler/org_list_from_cr.go` (~L123-128) — the CR read path the console reads; derived `isolation` from kind alone even though it already reads `planSlug`.
- `products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go` (`resolveOrgShape`) — the BSS create-time default; `vcluster` for any customer regardless of plan.

## Fix
New shared helper `isolationForTier(kind, planSlug)` mirrors the controller-side `gitops.boundaryIsVcluster` gate (same lockstep duplication the funnel-side `gitops.BoundaryIsVcluster` already uses):
- `internal` → `namespace` (a department shares the host ns; no dedicated vCluster regardless of plan)
- `customer` free/S/empty → `namespace` (host-ns boundary)
- `customer` m/l/xl/flexi → `vcluster` (dedicated Org-vCluster)

Both the BSS create path (`resolveOrgShape`) and the CR read path (`orgCRToResponse`) derive the label from it, so the displayed value always matches the backing the org-controller authors. An explicit valid request `isolation` still overrides (advanced operator view). `allTiersVcluster` is duplicated as a const so the single Sovereign-level switch flips both sides together.

## Tests
- `TestIsolationForTier` — locks the gate directly across all tiers + internal kind.
- `TestResolveOrgShape` — updated so an **S-plan Org asserts `namespace` (host-ns)** and an **M-plan Org asserts `vcluster`**, plus the explicit-override and malformed-input fallbacks.
- `go build ./...`, `go vet`, and the full `internal/handler` package suite green.

## Roll-gated for live
Org-services / catalyst-api image rolls. UAT rows 9-12 flip ✅ when the corrected label rolls and the S-plan Org reports host-ns isolation.

Refs #4539 Refs #4292

🤖 Generated with [Claude Code](https://claude.com/claude-code)