### PR TITLE
fix(harbor): create the missing proxy-xpkg proxy-cache project on the bastion Harbor (Refs #4488 #4521 #4491)

### DIFF
--- a/.github/workflows/ensure-bastion-harbor-proxy-projects.yaml
+++ b/.github/workflows/ensure-bastion-harbor-proxy-projects.yaml
@@ -1,0 +1,152 @@
+name: Ensure Bastion Harbor proxy-cache projects (#4488)
+
+# #4488 — the MISSING `proxy-xpkg` proxy-cache project on the bastion/mothership
+# Harbor (harbor.openova.io, EIP 212.72.24.20).
+#
+# ROOT CAUSE (live evidence, definitive prov fbd5b9c644c1d5f2): on a fresh Huawei
+# (kom4dc) prov the Crossplane package manager pulls
+#   harbor.openova.io/v2/proxy-xpkg/upbound/provider-opentofu:v1.1.3
+# and gets `401 UNAUTHORIZED: project proxy-xpkg not found`. #4491 routed the
+# provider-opentofu xpkg package off the poisoned-EIP path to
+# `harbor.openova.io/proxy-xpkg/...` (XPKG_REGISTRY substitution in
+# infra/providers/_shared/cloudinit-control-plane.tftpl), but it points at a
+# proxy-cache project that was never created on the bastion Harbor. The
+# Crossplane xpkg fetcher (go-containerregistry K8sFetcher) dials that host
+# DIRECTLY (it does NOT honour the node containerd registries.yaml mirror — see
+# infra/providers/huawei/main.tf), so the missing project surfaces as the 401 →
+# provider-opentofu stays INSTALLED=False → workspaces.tf.upbound.io never
+# registers → all 24 CloudAdoption composites Ready=False → the #4002/#4018
+# adoption seam stays inert. (#4528's Provider/ProviderConfig ordering split is
+# the LAYER ABOVE this; this is the package SOURCE that 401s.)
+#
+# The SAME gap is documented for `proxy-ecr` in infra/providers/huawei/main.tf
+# (~L660: "the bastion :5000 has NO proxy-xpkg / proxy-ecr projects ... real
+# manifest pull -> HTTP 404") — both `xpkg.upbound.io` and `public.ecr.aws` are
+# routed at `https://harbor.openova.io/proxy-{xpkg,ecr}` by registries.yaml.
+# This workflow ensures BOTH proxy-cache projects exist so neither 401s/404s.
+#
+# WHY A DEDICATED WORKFLOW (not folded into warmup-bastion-harbor.yaml):
+# creating a proxy-cache project requires creating a Harbor registry ENDPOINT
+# first (`POST /api/v2.0/registries`), which is a Harbor SYSTEM-ADMIN operation.
+# The warmup workflow authenticates as the PROJECT-SCOPED `robot$openova-warmup`
+# (push+pull on openova-io/**) which cannot create registries. This workflow
+# uses a Harbor ADMIN credential (secret BASTION_HARBOR_ADMIN_TOKEN) — the same
+# class of admin the self-sovereign-cutover Step-02 (02-harbor-projects-job)
+# uses against the Sovereign-LOCAL Harbor. It mirrors that Job's create logic
+# (registry endpoint → proxy-cache project with registry_id), targeting the
+# bastion/mothership Harbor instead.
+#
+# IDEMPOTENT: 201 = created, 409 = already exists (both success). Safe to run on
+# every relevant change. Non-fatal if the admin secret is absent (forks /
+# unconfigured repos degrade to a ::warning, exactly like warmup-bastion-harbor).
+#
+# PREREQUISITE (orchestrator/founder): provision the CI secret
+# `BASTION_HARBOR_ADMIN_TOKEN` — a Harbor admin (or a system robot with the
+# `registry` create+list system permission). Without it the workflow no-ops with
+# a warning and the 401 persists (kom4dc fresh prov keeps failing
+# provider-opentofu install).
+
+on:
+  push:
+    paths:
+      # Re-run when the consumer side (the XPKG_REGISTRY route + provider
+      # package ref) or this workflow itself changes, so the bastion-side
+      # proxy-cache project stays in lockstep with what the cloud-init points at.
+      - 'infra/providers/_shared/cloudinit-control-plane.tftpl'
+      - 'infra/providers/huawei/main.tf'
+      - 'clusters/_template/infrastructure/base/provider-opentofu.yaml'
+      - '.github/workflows/ensure-bastion-harbor-proxy-projects.yaml'
+    branches: [main]
+  # Allow a manual ensure (e.g. after the bastion Harbor is rebuilt).
+  workflow_dispatch:
+
+jobs:
+  ensure-proxy-projects:
+    runs-on: ubuntu-latest
+    # Non-blocking: a failure here must never wedge the merge pipeline. The fix
+    # is delivered at prov/bootstrap time (the project just has to exist on the
+    # bastion Harbor before a kom4dc fresh prov pulls provider-opentofu).
+    continue-on-error: true
+    env:
+      # The bastion/mothership Harbor front door (harbor.openova.io → bastion
+      # EIP 212.72.24.20). The Crossplane xpkg fetcher + the registries.yaml
+      # xpkg/ecr routes both target this host.
+      HARBOR_HOST: harbor.openova.io
+      HARBOR_USERNAME: ${{ vars.BASTION_HARBOR_ADMIN_USERNAME || 'admin' }}
+      HARBOR_PASSWORD: ${{ secrets.BASTION_HARBOR_ADMIN_TOKEN }}
+    steps:
+      - name: Guard — admin secret present
+        run: |
+          if [ -z "${HARBOR_PASSWORD}" ]; then
+            echo "::warning title=#4488 proxy-cache ensure skipped::secrets.BASTION_HARBOR_ADMIN_TOKEN is not set — cannot create the bastion Harbor proxy-xpkg/proxy-ecr proxy-cache projects. Provision a Harbor admin (or a system robot with the 'registry' create+list permission). Skipping (non-fatal); the kom4dc fresh-prov provider-opentofu pull will keep 401ing 'project proxy-xpkg not found' until this lands."
+            echo "ENSURE_SKIP=1" >> "$GITHUB_ENV"
+          else
+            echo "ENSURE_SKIP=0" >> "$GITHUB_ENV"
+          fi
+
+      - name: Ensure proxy-cache projects on the bastion Harbor
+        if: env.ENSURE_SKIP == '0'
+        env:
+          # Data-driven list: `name|upstreamURL|registryType`. MUST stay in
+          # lockstep with the self-sovereign-cutover proxyProjects (Sovereign-
+          # local equivalent) in
+          # platform/self-sovereign-cutover/chart/values.yaml. Both are anonymous
+          # docker-registry pull-throughs (upbound + public ECR serve plain v2
+          # anonymously; no upstream credential needed — see the cutover values
+          # comment for the quay/xpkg/ecr "docker-registry adapter" rationale).
+          PROXY_PROJECTS: |
+            proxy-xpkg|https://xpkg.upbound.io|docker-registry
+            proxy-ecr|https://public.ecr.aws|docker-registry
+        run: |
+          set -eu
+          base="https://${HARBOR_HOST}/api/v2.0"
+          # `printf | while` runs the loop body in a PIPELINE SUBSHELL, so a plain
+          # rc=1 set inside would not survive to the final exit. Track failure via
+          # a marker file that the parent shell inspects after the loop.
+          fail_marker="$(mktemp)"; rm -f "${fail_marker}"
+
+          printf '%s\n' "${PROXY_PROJECTS}" | while IFS='|' read -r name upstream rtype; do
+            [ -z "${name}" ] && continue
+            echo "[ensure] proxy-cache project ${name} → ${upstream} (${rtype})"
+
+            # 1. Ensure the upstream registry endpoint (anonymous pull-through).
+            reg_payload="{\"name\":\"${name}-upstream\",\"type\":\"${rtype}\",\"url\":\"${upstream}\"}"
+            code=$(curl -s -o /tmp/reg.out -w '%{http_code}' \
+              -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" -X POST \
+              -H 'Content-Type: application/json' \
+              "${base}/registries" --data "${reg_payload}" || echo "000")
+            case "${code}" in
+              201|409) echo "[ensure]   registry ${name}-upstream OK (${code})" ;;
+              *)       echo "::warning::registry ${name}-upstream ensure returned HTTP ${code}"; cat /tmp/reg.out 2>/dev/null || true; : >"${fail_marker}" ;;
+            esac
+
+            # 2. Resolve the registry id (needed as the proxy-cache project's
+            #    registry_id — Harbor binds the proxy-cache project to it).
+            reg_id=$(curl -s -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
+              "${base}/registries?name=${name}-upstream" \
+              | tr ',' '\n' | grep -o '"id":[0-9]*' | head -1 | awk -F: '{print $2}')
+            if [ -z "${reg_id}" ]; then
+              echo "::warning::could not resolve registry id for ${name}-upstream; skipping project ${name}"
+              : >"${fail_marker}"
+              continue
+            fi
+
+            # 3. Ensure the proxy-cache project bound to that registry. public=true
+            #    so anonymous pulls (the Crossplane xpkg fetcher pulls cred-free)
+            #    succeed.
+            proj_payload="{\"project_name\":\"${name}\",\"public\":true,\"registry_id\":${reg_id},\"metadata\":{\"public\":\"true\"}}"
+            code=$(curl -s -o /tmp/proj.out -w '%{http_code}' \
+              -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" -X POST \
+              -H 'Content-Type: application/json' \
+              "${base}/projects" --data "${proj_payload}" || echo "000")
+            case "${code}" in
+              201|409) echo "[ensure]   project ${name} OK (${code})" ;;
+              *)       echo "::warning::project ${name} ensure returned HTTP ${code}"; cat /tmp/proj.out 2>/dev/null || true; : >"${fail_marker}" ;;
+            esac
+          done
+
+          echo "[ensure] proxy-cache project ensure complete"
+          # Surface a non-zero exit so an operator sees a real failure in the
+          # step log, but continue-on-error keeps the pipeline green (the fix is
+          # delivered at prov time, not by this CI run blocking a merge).
+          if [ -e "${fail_marker}" ]; then rm -f "${fail_marker}"; exit 1; fi

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -657,13 +657,18 @@ locals {
   # Route ghcr/quay/gcr/registry.k8s.io through the bastion :5000 with the SAME
   # proxy-* rewrites — zero NAT egress, exactly like harbor + docker.io already do.
   #
-  # xpkg.upbound.io / public.ecr.aws stay on https://harbor.openova.io: the
-  # bastion :5000 has NO proxy-xpkg / proxy-ecr projects (verified live: real
-  # manifest pull -> HTTP 404, vs proxy-gcr -> 200), so routing them to the
-  # bastion would 404. They are Crossplane-provider / ecr images that are NOT in
-  # the Phase-1 bootstrap critical path (Crossplane is idle on kom4dc — infra is
-  # 100% OpenTofu), so the external-harbor route for these two is harmless and
-  # strictly better than a 404. docker.io stays on the bastion :5002 cache.
+  # xpkg.upbound.io / public.ecr.aws stay on https://harbor.openova.io (NOT the
+  # bastion :5000 endpoint): the proxy-xpkg / proxy-ecr proxy-cache projects are
+  # served by the EXTERNAL Harbor front door, ensured by
+  # .github/workflows/ensure-bastion-harbor-proxy-projects.yaml (#4488). Historic
+  # note: these two projects did NOT exist on the bastion (manifest pull -> 404)
+  # while Crossplane was idle on kom4dc; #4263/#4491 made Crossplane NON-idle
+  # (provider-opentofu pulls xpkg.upbound.io/upbound/provider-opentofu through
+  # proxy-xpkg), so the project now MUST exist — hence the ensure workflow. The
+  # Crossplane xpkg fetcher (go-containerregistry K8sFetcher) bypasses THIS
+  # containerd mirror entirely and dials harbor.openova.io/proxy-xpkg directly,
+  # so this rewrite is belt-and-braces for node-level xpkg pulls. docker.io stays
+  # on the bastion :5002 cache.
   #
   # #4049 (2026-06-21) — every image Huawei→Huawei, INCLUDING PRIVATE catalyst.
   # The ghcr.io mirror now carries TWO ordered rewrite rules (k3s/containerd


### PR DESCRIPTION
## Root cause (live, definitive prov `fbd5b9c644c1d5f2`)

On a fresh Huawei (kom4dc) prov the Crossplane package manager pulls
`harbor.openova.io/v2/proxy-xpkg/upbound/provider-opentofu:v1.1.3` and gets
**`401 UNAUTHORIZED: project proxy-xpkg not found`**.

#4491 routed the provider-opentofu xpkg package off the poisoned NAT-EIP path to
`harbor.openova.io/proxy-xpkg/...` (the `XPKG_REGISTRY` substitution in
`infra/providers/_shared/cloudinit-control-plane.tftpl`) — but it points at a
proxy-cache project that **was never created on the bastion/mothership Harbor**.
The Crossplane xpkg fetcher (go-containerregistry `K8sFetcher`) dials that host
DIRECTLY (it bypasses the node containerd `registries.yaml` mirror), so the
missing project surfaces as the 401. The downstream cascade:

- `provider-opentofu` stays `INSTALLED=False`
- `workspaces.tf.upbound.io` CRD never registers
- all 24 `CloudAdoption` composites sit `Ready=False`
- the #4002/#4018 OpenTofu->Crossplane adoption seam is inert at runtime

(#4528's Provider/ProviderConfig ordering split is the layer ABOVE this and is
correct; this is the package SOURCE that 401s — the layer below it.)

The **same gap** is documented for `proxy-ecr` in `infra/providers/huawei/main.tf`
(~L660: "the bastion :5000 has NO proxy-xpkg / proxy-ecr projects ... real
manifest pull -> HTTP 404").

## Fix

New CI workflow `.github/workflows/ensure-bastion-harbor-proxy-projects.yaml`
idempotently ensures, via the Harbor API, that the **bastion/mothership Harbor**
has:

- the upbound upstream registry endpoint + the `proxy-xpkg` proxy-cache project
  (so `harbor.openova.io/proxy-xpkg/upbound/provider-opentofu` resolves through
  `xpkg.upbound.io`)
- `proxy-ecr` too (the identical missing-project gap on the same code path)

It mirrors the self-sovereign-cutover Step-02 (`02-harbor-projects-job`) create
logic that already does exactly this for the Sovereign-**local** Harbor (registry
endpoint -> proxy-cache project bound by `registry_id`), but targets the
bastion/mothership Harbor.

Why a dedicated workflow (not folded into `warmup-bastion-harbor.yaml`): creating
a registry endpoint is a Harbor **system-admin** operation. The warmup workflow
authenticates as the project-scoped `robot$openova-warmup` (push+pull on
`openova-io/**`) which cannot create registries. This workflow uses a Harbor admin
credential (secret `BASTION_HARBOR_ADMIN_TOKEN`).

- Idempotent: `201`=created, `409`=already exists, both success.
- Non-fatal if the admin secret is absent (forks / unconfigured repos degrade to
  a `::warning`, exactly like `warmup-bastion-harbor.yaml`).

Also refreshes the now-stale `huawei/main.tf` comment that claimed the bastion has
no `proxy-xpkg`/`proxy-ecr` projects (true only while Crossplane was idle on
kom4dc; #4263/#4491 made it non-idle, so the project now must exist).

## Operator precondition

Provision the CI secret `BASTION_HARBOR_ADMIN_TOKEN` (a Harbor admin, or a system
robot with the `registry` create+list system permission). Optionally set repo var
`BASTION_HARBOR_ADMIN_USERNAME` (defaults to `admin`).

## Roll-gated

On a fresh prov where `provider-opentofu` reaches `Installed+Healthy` and the
`CloudAdoptions` reconcile `Ready=True`, this lands #4488 and #4521 (per repo
discipline they close only after the operator walk lands as a comment, not on
merge). Not live-verified in this PR.

Refs #4488 #4521 #4491

🤖 Generated with [Claude Code](https://claude.com/claude-code)
