### PR TITLE
fix(handover): postTofuArchive skips public-CA verify on the mother→child archive hop — LE-staging child cert no longer x509-fails the seal that arms the cutover (Refs #4543 #3379)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/handover.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handover.go
@@ -69,6 +69,7 @@ package handler
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -478,7 +479,24 @@ func (h *Handler) postTofuArchive(ctx context.Context, sovereignFQDN, deployment
 
 	httpc := h.handoverHTTPClient
 	if httpc == nil {
-		httpc = &http.Client{Timeout: 60 * time.Second}
+		// #4543: the child Sovereign's wildcard cert is LE-STAGING on a
+		// fresh prov (the bootstrap default that dodges LE-prod rate
+		// limits). A default http.Client verifies api.<fqdn> against the
+		// public CA bundle → x509 unknown-authority → the archive POST
+		// fails → tofu-phase0-archive never seals → the cutover never
+		// arms. This is a mother→child internal hop to the deterministic
+		// api.<fqdn> the mothership just provisioned (and already trusts
+		// via the kubeconfig + handover keys it holds), so skip public-CA
+		// verification here — the SAME rationale and pattern the async
+		// export paths already use (exportTofuArchiveToChild /
+		// exportDeploymentToChild). External TLS (ghcr, public endpoints)
+		// is untouched; this is narrowly the handover-archive submit.
+		httpc = &http.Client{
+			Timeout: 60 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // child's LE-staging cert; mother→child internal hop, same rationale as exportTofuArchiveToChild (#4543)
+			},
+		}
 	}
 	resp, err := httpc.Do(req)
 	if err != nil {

--- a/products/catalyst/bootstrap/api/internal/handler/handover_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handover_test.go
@@ -314,6 +314,54 @@ func TestFinaliseHandover_NotFound(t *testing.T) {
 	}
 }
 
+// TestPostTofuArchive_DefaultClientToleratesUntrustedChildCert (#4543) is
+// the regression guard for the handover-submit TLS-verify fault: on a fresh
+// prov the child Sovereign's wildcard cert is LE-STAGING (untrusted by the
+// public CA bundle, the bootstrap default that dodges LE-prod rate limits).
+//
+// Before #4543, postTofuArchive's default http.Client (the production path,
+// used whenever no test client is injected via SetHandoverHTTPClient)
+// verified api.<fqdn> against the public CA bundle → x509 unknown-authority
+// → the archive POST failed → tofu-phase0-archive never sealed → the cutover
+// never armed. This test stands up an httptest.NewTLSServer (self-signed,
+// untrusted) and drives postTofuArchive with NO injected client, so the
+// PRODUCTION default client is exercised. It must reach the receiver and
+// return nil, proving the default client skips public-CA verification on the
+// mother→child internal hop.
+//
+// We point handoverTargetURL straight at the TLS server's URL (so the call
+// hits a real untrusted-cert endpoint) but deliberately leave
+// handoverHTTPClient nil. A regression (default client re-verifies against
+// the public bundle) makes httpc.Do fail with an x509 error and this fails.
+func TestPostTofuArchive_DefaultClientToleratesUntrustedChildCert(t *testing.T) {
+	recvr := &fakeReceiver{}
+	srv := httptest.NewTLSServer(recvr.handler())
+	defer srv.Close()
+
+	h := newTestHandler(t)
+	// Override the target URL so the call lands on the self-signed TLS
+	// server, but DO NOT call SetHandoverHTTPClient — that leaves
+	// handoverHTTPClient nil so postTofuArchive builds the production
+	// default client. If that default still verified against the public
+	// CA bundle (the pre-#4543 bug), this POST would x509-fail.
+	h.SetHandoverTargetURL(srv.URL)
+
+	err := h.postTofuArchive(context.Background(), "tenant-staging.omani.works", "dep-4543", map[string]string{
+		"terraform.tfstate": base64.StdEncoding.EncodeToString([]byte(`{"v":1}`)),
+	})
+	if err != nil {
+		t.Fatalf("postTofuArchive against an untrusted (LE-staging-class) child cert failed: %v — "+
+			"the production default client must skip public-CA verification on the mother→child "+
+			"handover-archive hop (#4543), else tofu-phase0-archive never seals and the cutover never arms", err)
+	}
+	if recvr.called != 1 {
+		t.Fatalf("receiver called %d times, want 1 (the archive POST never reached the child)", recvr.called)
+	}
+	if recvr.body.DeploymentID != "dep-4543" {
+		t.Errorf("body.deploymentId: %q", recvr.body.DeploymentID)
+	}
+}
+
 func TestReceiveTofuArchive_NoOpenBaoReturns503(t *testing.T) {
 	h := newTestHandler(t)
 	body, _ := json.Marshal(tofuArchiveRequest{


### PR DESCRIPTION
## Fault

On the definitive zero-touch validation prov `fbd5b9c644c1d5f2` / `kv184704.omani.works`, the platform converged zero-touch (64 HRs, dep `ready`) but the HANDOVER could not seal the OpenTofu archive into the child OpenBao, so the cutover stays unarmable:

```
"steps": { "tofuArchiveSubmitted": false, ... },
"errors": [
  "submit tofu archive: post: Post \"https://api.kv184704.omani.works/api/v1/handover/tofu-archive\": tls: failed to verify certificate: x509: certificate signed by unknown authority"
]
```

A manual cutover trigger then returns HTTP 425 `handover-incomplete: tofu-phase0-archive not present in OpenBao`.

## Root cause

`products/catalyst/bootstrap/api/internal/handler/handover.go::postTofuArchive` (the synchronous `FinaliseHandover` path) built its default HTTP client with **no** `TLSClientConfig`:

```go
httpc := h.handoverHTTPClient
if httpc == nil {
    httpc = &http.Client{Timeout: 60 * time.Second}   // verifies against the PUBLIC CA bundle
}
```

So the POST to `https://api.<fqdn>/api/v1/handover/tofu-archive` verified the child's cert against the public CA bundle. On a fresh prov the child's wildcard cert is **LE-STAGING** (the bootstrap default that dodges LE-prod rate limits) → `x509: certificate signed by unknown authority` → the archive POST fails → `tofu-phase0-archive` never seals into the child OpenBao → the Self-Sovereign cutover engine (`ReceiveTofuArchive` → fire) never runs → `cutoverComplete` stays false forever.

## Same class as #4529, one site over

#4529 fixed the `--dest-tls-verify` on the cutover step-03 harbor-prewarm skopeo copy (in-cluster Harbor on an LE-staging Sovereign). The identical "verify-against-public-CA fails on a deliberately-LE-staging Sovereign" failure existed on the handover tofu-archive submit path — a different code site #4529 did not touch. Notably, the **async** export paths (`exportTofuArchiveToChild`, `exportDeploymentToChild`) already skip public-CA verify on this mother→child internal hop with the canonical `Transport{TLSClientConfig:{InsecureSkipVerify:true}}` pattern; the synchronous finalise path was the lone outlier.

## Fix

`postTofuArchive`'s default client now mirrors the established mother→child pattern:

```go
httpc = &http.Client{
    Timeout: 60 * time.Second,
    Transport: &http.Transport{
        TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // child's LE-staging cert; mother→child internal hop
    },
}
```

- Narrowly the handover-archive submit — a platform-to-platform call to the deterministic `api.<fqdn>` the mothership just provisioned and already trusts via the kubeconfig + handover keys it holds.
- External TLS (ghcr, public endpoints) is **untouched**.
- Test clients injected via `SetHandoverHTTPClient` are unaffected.

## Regression guard

`TestPostTofuArchive_DefaultClientToleratesUntrustedChildCert` drives `postTofuArchive` against an `httptest.NewTLSServer` (self-signed, untrusted) with **no** injected client, exercising the production default path. Proven to reproduce the exact `x509: certificate signed by unknown authority` failure without the fix, and pass with it. Full `internal/handler` package suite green; `go build`/`gofmt`/`go vet` clean.

## Roll-gated

This is catalyst-api code (mothership-baked) → it needs the **catalyst-api image to rebuild + roll to the mothership** before it takes effect on a re-prov. It closes the cutover path (#3379 / #4527 / #4529) on a re-prov where the handover seals + the cutover completes through the 600s egress hold. **Not live-verified** — exercising it requires a fresh prov whose handover now seals.

Refs #4543 #3379

🤖 Generated with [Claude Code](https://claude.com/claude-code)