### PR TITLE
fix(marketplace): authed owner on /redeem must not see the public funnel — owner-redirect contract (UAT row 3)

### DIFF
--- a/core/marketplace/playwright/customer-journey.spec.ts
+++ b/core/marketplace/playwright/customer-journey.spec.ts
@@ -362,6 +362,39 @@ test.describe('marketplace customer-journey (17-step regression gate)', () => {
     await expect(page.locator('#redeem-valid-code')).toContainText('OPENOVA-DEV-2026')
   })
 
+  test('05b authed owner on /redeem is NOT immediately shown the public funnel (owner-redirect contract, #4546 / UAT row 3)', async ({ page }) => {
+    // An authed owner landing on the public redeem funnel must never see the
+    // public funnel chrome ("Voucher not valid" / the signup CTA) while the
+    // Layout's returning-user redirect bounces them to their console. The redeem
+    // page must suppress its own funnel paint when a session token is present.
+    //
+    // We return [] for /tenant/orgs so the Layout cross-host redirect does NOT
+    // navigate away (keeping this test on-origin + deterministic) — the redeem
+    // guard's neutral "redirecting" shim is the surface under test. (A real
+    // owner WITH a live workspace is additionally bounced by the Layout; that
+    // cross-host nav is exercised by the live UAT walk, not this on-origin test.)
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem('org-token', 'mock-jwt-token')
+        localStorage.setItem('org-refresh-token', 'mock-refresh-token')
+      } catch (_) {}
+    })
+    await page.route('**/api/tenant/orgs', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+    )
+    // If the funnel ever ran, this resolves it to a definite "not valid" panel,
+    // making a wrong "funnel painted" outcome assertable rather than racy.
+    await page.route('**/api/billing/vouchers/redeem-preview', (route) =>
+      route.fulfill({ status: 404, contentType: 'application/json', body: '{}' }),
+    )
+    await page.goto('/redeem?code=DEMO123')
+    // The guard keeps the neutral redirecting shim and suppresses the public
+    // funnel — assert in the grace window BEFORE the safety fall-through fires.
+    await expect(page.getByText(/Taking you to your dashboard/i)).toBeVisible({ timeout: 5_000 })
+    await expect(page.locator('#redeem-not-valid')).toBeHidden()
+    await expect(page.locator('#redeem-valid')).toBeHidden()
+  })
+
   test('06 signup email input + button (checkout sign-in surface)', async ({ page }) => {
     // CheckoutStep renders the sign-in form when no `org-token` exists.
     await page.goto('/checkout')

--- a/core/marketplace/src/pages/redeem.astro
+++ b/core/marketplace/src/pages/redeem.astro
@@ -183,6 +183,37 @@ import Layout from '../layouts/Layout.astro';
     }
 
     function init() {
+      // #4546 (UAT row 3, Refs #3687): owner-redirect contract. An authed owner
+      // landing on the public redeem funnel must be bounced to their console —
+      // they must NEVER see the public funnel chrome ("Voucher not valid" / the
+      // signup CTA). The Layout's returning-user redirect script handles the
+      // actual bounce, but it runs asynchronously (it fetches /api/tenant/orgs
+      // before calling window.location.replace). If we paint the funnel here in
+      // the meantime, the owner sees the public chrome flash/stick — exactly the
+      // observed fault. So when a session token is present, suppress the funnel
+      // paint entirely: keep the neutral loading shim visible (it reads as a
+      // "redirecting…" state) and let the Layout redirect take over. Only the
+      // unauthenticated public flow falls through to the validate() funnel.
+      var hasToken = false;
+      try { hasToken = !!localStorage.getItem('org-token'); } catch (_) {}
+      if (hasToken) {
+        show('redeem-loading');
+        var loadingCopy = document.querySelector('#redeem-loading p');
+        if (loadingCopy) loadingCopy.textContent = 'Taking you to your dashboard…';
+        // Safety fall-through: the Layout redirect only fires for an authed
+        // user who actually has at least one live workspace. A signed-in user
+        // with NO workspace yet (e.g. a returning visitor mid-signup) is never
+        // bounced — so after a short grace window with no navigation, fall
+        // through to the public redeem flow so they can still redeem. The
+        // window.location.replace in the Layout redirect tears this timer down
+        // by unloading the page before it fires.
+        window.setTimeout(function () { runFunnel(); }, 2500);
+        return;
+      }
+      runFunnel();
+    }
+
+    function runFunnel() {
       const params = new URLSearchParams(window.location.search);
       const code = (params.get('code') || '').trim().toUpperCase();
       if (!code) {


### PR DESCRIPTION
## What

Fixes **UAT row 3** (`Refs #3687`): an authed owner hitting the public voucher-redeem
URL must be bounced to their console — they must never see the public funnel chrome.

Live evidence (omantel.biz, dep `91dc05917e44d1c1`): `marketplace.omantel.biz/redeem/?code=DEMO123`
on an authed owner session rendered the public funnel + **"Voucher not valid"** instead
of redirecting — owner-redirect contract unmet.

## Root cause

`core/marketplace/src/pages/redeem.astro` had **no owner-redirect guard of its own**. It
relied entirely on the Layout's returning-user redirect, but `init()` fired on
`DOMContentLoaded` and painted the funnel chrome immediately, **racing** the Layout's
async `/api/tenant/orgs` → `window.location.replace` redirect. The page's own comment
described a guard that did not exist.

## Fix

When an `org-token` is present, suppress the public funnel paint, keep a neutral
"Taking you to your dashboard…" shim, and let the Layout owner-redirect take over. A
signed-in user with **no** live workspace still falls through to the public redeem flow
after a short grace window so they can redeem. Unauthenticated visitors are unchanged.

Adds playwright regression `05b`. Existing redeem tests (04/05) unaffected — they run
without a token and fall through to the funnel exactly as before.

## Verification

- `npm run build` green (incl. served-domain-hygiene postbuild gate).
- `npx playwright test -g "voucher|owner-redirect"` → 3/3 pass (04, 05, **05b**).
- Full customer-journey suite: 19/19 of the journey rows pass (the one unrelated
  failure, "01 storefront loads", is a pre-existing `index.astro` heading drift on
  clean `main` — not touched here).

Roll-gated: the marketplace image rolls to the live env after merge.

Refs #4546
Refs #3687

🤖 Generated with [Claude Code](https://claude.com/claude-code)
