### PR TITLE
feat(console): per-app Topology tab surfaces read-only DR state — standby region + live replication lag (#4551)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/lib/continuum.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/continuum.api.ts
@@ -148,10 +148,66 @@ export interface ContinuumFleetResponse {
   total: number
 }
 
+/**
+ * ContinuumReplicaInfo — one per-region replica row of the replication
+ * status. Mirrors the catalyst-api `continuumReplicaInfo` shape
+ * (continuum_dr_extras.go). The fields are best-effort: a synthesized
+ * fallback shape (source !== "live") may leave some empty.
+ */
+export interface ContinuumReplicaInfo {
+  region?: string
+  cluster?: string
+  role?: string // "primary" | "replica"
+  state?: string // streaming/connection state
+  lagSeconds?: number
+  lagBytes?: number
+}
+
+/**
+ * ContinuumReplicationStatus — body of
+ * GET /api/v1/sovereigns/{id}/continuum/{name}/replication-status
+ * (continuum_dr_extras.go::HandleContinuumReplicationStatus).
+ *
+ * This is the LIVE DR telemetry the per-app Topology tab renders for a
+ * cross-region (cnpg-pair / Continuum-backed) component: the current
+ * primary, the WAL replication lag in seconds, and the streaming/sync
+ * state. `source` is the honesty flag — "live" means it was read off the
+ * real Continuum + CNPGPair CR status; "synthesized" means the in-cluster
+ * client was bootstrapping or the CRs were missing and the backend
+ * returned a realistic-but-not-live shape. The UI MUST surface this so a
+ * fallback is never passed off as live.
+ */
+export interface ContinuumReplicationStatus {
+  continuum: string
+  namespace: string
+  primaryRegion: string
+  currentPrimary: string
+  walLagSeconds: number
+  walLagBytes?: number
+  replicaPromotable?: boolean
+  streamingState?: string
+  syncState?: string
+  lastHeartbeat?: string
+  replicas?: ContinuumReplicaInfo[]
+  observedAt?: string
+  source: string // "live" | "synthesized"
+}
+
 /* ── Endpoint helpers ────────────────────────────────────────────── */
 
 function continuumsBase(sovereignId: string): string {
   return `${API_BASE}/v1/sovereigns/${encodeURIComponent(sovereignId)}/continuums`
+}
+
+/**
+ * continuumSingularBase — the SINGULAR `/continuum/` path the EPIC-6
+ * iter-6 target-state endpoints live under (replication-status,
+ * switchover/history, settings). Distinct from continuumsBase (plural
+ * `/continuums/`, the older CRUD surface) — both are live for
+ * back-compat; the replication-status route is singular only.
+ */
+function continuumSingularBase(sovereignId: string): string {
+  return `${API_BASE}/v1/sovereigns/${encodeURIComponent(sovereignId)}/continuum`
 }
 
 function auditBase(sovereignId: string): string {
@@ -172,6 +228,30 @@ export async function getContinuum(
   const res = await authedFetch(url, { headers: { Accept: 'application/json' } })
   if (!res.ok) {
     throw new Error(`continuum get: HTTP ${res.status}`)
+  }
+  return res.json()
+}
+
+/**
+ * getContinuumReplicationStatus — fetch the live DR replication telemetry
+ * for a Continuum CR (GET .../continuum/{name}/replication-status). The
+ * per-app Topology tab calls this for cross-region components (continuum
+ * name = `dr-<app>`) to render the standby region + live WAL lag. A 404
+ * (no DR pair for this app) throws so the caller can render the calm
+ * singleton/no-DR state — NOT a fabricated lag.
+ */
+export async function getContinuumReplicationStatus(
+  sovereignId: string,
+  name: string,
+  opts: { namespace?: string } = {},
+): Promise<ContinuumReplicationStatus> {
+  const params = new URLSearchParams()
+  if (opts.namespace) params.set('namespace', opts.namespace)
+  const qs = params.toString()
+  const url = `${continuumSingularBase(sovereignId)}/${encodeURIComponent(name)}/replication-status${qs ? '?' + qs : ''}`
+  const res = await authedFetch(url, { headers: { Accept: 'application/json' } })
+  if (!res.ok) {
+    throw new Error(`continuum replication-status: HTTP ${res.status}`)
   }
   return res.json()
 }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.test.tsx
@@ -19,12 +19,24 @@ const getApplicationStatus = vi.fn()
 const getCatalogItem = vi.fn()
 const getApplicationPlacement = vi.fn()
 const getHierarchicalInfrastructure = vi.fn()
+const getContinuumReplicationStatus = vi.fn()
 
 vi.mock('@/lib/catalog.api', () => ({
   getApplicationStatus: (...a: unknown[]) => getApplicationStatus(...a),
   getCatalogItem: (...a: unknown[]) => getCatalogItem(...a),
   getApplicationPlacement: (...a: unknown[]) => getApplicationPlacement(...a),
 }))
+
+// The DR section (#3375 rows 51/52/56/57) reads live replication telemetry
+// off the Continuum CR via this client. Re-export the real lagBucket so the
+// component's bucket→colour mapping is exercised, not stubbed.
+vi.mock('@/lib/continuum.api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/continuum.api')>()
+  return {
+    ...actual,
+    getContinuumReplicationStatus: (...a: unknown[]) => getContinuumReplicationStatus(...a),
+  }
+})
 
 vi.mock('@/lib/infrastructure.types', () => ({
   getHierarchicalInfrastructure: (...a: unknown[]) => getHierarchicalInfrastructure(...a),
@@ -48,6 +60,10 @@ beforeEach(() => {
   // so the legacy spec/status projection still drives the existing asserts.
   // Tests that exercise the runtime path override this per-case.
   getApplicationPlacement.mockResolvedValue({ targets: [], derivedFromRuntime: true })
+  // DR replication-status default: 404 (no Continuum CR backs this app), so
+  // the DR section renders the calm "no cross-region replica" note unless a
+  // case overrides it. Mirrors the endpoint's real not-found behaviour.
+  getContinuumReplicationStatus.mockRejectedValue(new Error('continuum replication-status: HTTP 404'))
 })
 
 afterEach(() => {
@@ -290,5 +306,115 @@ describe('TopologyTab — #3982 runtime-derived placement', () => {
       expect(screen.getByTestId('topology-tab-target-card-1')).toBeTruthy()
     })
     expect(screen.getByTestId('topology-tab-pattern').textContent).toBe('active-hot-standby')
+  })
+})
+
+describe('TopologyTab — DR / replication surface (#3375 rows 51/52/56/57)', () => {
+  const standbyPlacement = {
+    targets: [
+      { region: 'me-east-215-a', cluster: 'c', vcluster: 'host', role: 'Primary' },
+      { region: 'me-east-215-b', cluster: 'c-b', vcluster: 'host', role: 'Standby', standbyType: 'Hot' },
+    ],
+    derivedFromRuntime: true,
+  }
+
+  it('renders the standby region + LIVE replication lag in seconds for a cross-region app (rows 51/52/56)', async () => {
+    getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
+    getApplicationStatus.mockResolvedValue({
+      name: 'shared-pg',
+      namespace: 'shared-data',
+      spec: {},
+      status: { placement: 'Reconciled' },
+    })
+    getApplicationPlacement.mockResolvedValue(standbyPlacement)
+    getContinuumReplicationStatus.mockResolvedValue({
+      continuum: 'dr-shared-pg',
+      namespace: 'shared-data',
+      primaryRegion: 'me-east-215-a',
+      currentPrimary: 'me-east-215-a',
+      walLagSeconds: 1.7,
+      streamingState: 'streaming',
+      syncState: 'async',
+      source: 'live',
+    })
+
+    render(withProviders(<TopologyTab sovereignId="dep-z" applicationName="shared-pg" namespace="shared-data" />))
+
+    // The continuum name is derived as dr-<app>.
+    await waitFor(() => {
+      expect(getContinuumReplicationStatus).toHaveBeenCalledWith('dep-z', 'dr-shared-pg', { namespace: 'shared-data' })
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-dr-panel')).toBeTruthy()
+    })
+    // Primary + standby region cards.
+    expect(screen.getByTestId('topology-tab-dr-primary').textContent).toContain('me-east-215-a')
+    expect(screen.getByTestId('topology-tab-dr-standby-me-east-215-b').textContent).toContain('me-east-215-b')
+    // LIVE lag in seconds — not a hardcoded dash.
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-dr-lag-value').textContent).toContain('1.7 s')
+    })
+    // Honest "live" source badge.
+    expect(screen.getByTestId('topology-tab-dr-source').textContent).toContain('live')
+  })
+
+  it('Switchover affordance is present but DISABLED (deferred, row 57)', async () => {
+    getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
+    getApplicationPlacement.mockResolvedValue(standbyPlacement)
+    getContinuumReplicationStatus.mockResolvedValue({
+      continuum: 'dr-shared-pg',
+      namespace: 'shared-data',
+      primaryRegion: 'me-east-215-a',
+      currentPrimary: 'me-east-215-a',
+      walLagSeconds: 0.4,
+      source: 'live',
+    })
+    getApplicationStatus.mockResolvedValue({ name: 'shared-pg', namespace: 'shared-data', spec: {}, status: {} })
+
+    render(withProviders(<TopologyTab sovereignId="dep-z" applicationName="shared-pg" namespace="shared-data" />))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-dr-switchover')).toBeTruthy()
+    })
+    const btn = screen.getByTestId('topology-tab-dr-switchover').querySelector('button')
+    expect(btn).toBeTruthy()
+    expect(btn?.disabled).toBe(true)
+  })
+
+  it('a SINGLETON app shows NO DR panel + NO Switchover (honestly hidden, row 58)', async () => {
+    getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
+    const initialApp = {
+      name: 'grafana',
+      namespace: 'grafana',
+      spec: { placement: { targets: [{ region: 'region-a', cluster: 'mgmt-A', vcluster: 'mgmt', role: 'Primary' }] } },
+      status: { placement: 'Reconciled' },
+    }
+    render(
+      withProviders(
+        <TopologyTab sovereignId="test-sov" applicationName="grafana" initialApp={initialApp as never} disableNetwork />,
+      ),
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-pattern').textContent).toBe('singleton')
+    })
+    expect(screen.queryByTestId('topology-tab-dr-panel')).toBeNull()
+    expect(screen.queryByTestId('topology-tab-dr-switchover')).toBeNull()
+    // The DR endpoint is never polled for a singleton.
+    expect(getContinuumReplicationStatus).not.toHaveBeenCalled()
+  })
+
+  it('a cross-region app with NO Continuum CR (404) shows the calm no-replica note, never a fabricated lag', async () => {
+    getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
+    getApplicationStatus.mockResolvedValue({ name: 'sso-bridge', namespace: 'sso-bridge', spec: {}, status: {} })
+    getApplicationPlacement.mockResolvedValue(standbyPlacement)
+    // Default beforeEach mock = 404.
+
+    render(withProviders(<TopologyTab sovereignId="dep-z" applicationName="sso-bridge" namespace="sso-bridge" />))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-dr-none')).toBeTruthy()
+    })
+    // No live lag value rendered (the section short-circuits on error).
+    expect(screen.queryByTestId('topology-tab-dr-lag-value')).toBeNull()
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
@@ -29,6 +29,11 @@ import {
   getCatalogItem,
   type CatalogItem,
 } from '@/lib/catalog.api'
+import {
+  getContinuumReplicationStatus,
+  lagBucket,
+  type LagBucket,
+} from '@/lib/continuum.api'
 import { getHierarchicalInfrastructure } from '@/lib/infrastructure.types'
 import { PlacementEditor, type OwnedDependencyInfo } from '@/widgets/topology/PlacementEditor'
 import {
@@ -203,6 +208,68 @@ export function TopologyTab({
   }, [app, runtimeTargets])
 
   const pattern = useMemo(() => derivePattern(targets), [targets])
+
+  // ── DR / replication telemetry (#3375 rows 51/52/56) ──────────────
+  //
+  // A component is DR-capable (has a cross-region replica) when its
+  // placement carries at least one Standby target alongside a Primary —
+  // i.e. it is NOT a singleton. For those, the live DR telemetry lives on
+  // the per-app Continuum CR (`dr-<app>` by the application-controller's
+  // convention, core/controllers/application/.../continuum.go
+  // ContinuumNameFor) and is surfaced by catalyst-api's
+  // /continuum/{name}/replication-status. We render it READ-ONLY: standby
+  // region(s) + the live WAL replication lag in seconds. Honestly hidden
+  // for singletons (no DR block against a phantom region — row 58).
+  const hasStandby = useMemo(
+    () => targets.some((t) => t.role === 'Standby'),
+    [targets],
+  )
+  const continuumName = useMemo(() => `dr-${applicationName}`, [applicationName])
+
+  // Only poll the DR endpoint for genuinely multi-region apps. A 404 (no
+  // Continuum CR for this app) does NOT retry and leaves drStatus
+  // undefined → the section renders the calm "no cross-region replica"
+  // note rather than a fabricated lag.
+  const drQ = useQuery({
+    queryKey: ['continuum-replication-status', sovereignId, continuumName, namespace, refreshTick],
+    queryFn: () => getContinuumReplicationStatus(sovereignId, continuumName, { namespace }),
+    enabled: !disableNetwork && hasStandby && !!sovereignId && !!applicationName,
+    refetchInterval: 30_000,
+    retry: false,
+  })
+  const drStatus = drQ.data
+
+  // The primary + standby regions for the DR cards. Prefer the live
+  // replication-status (authoritative current primary after a switchover);
+  // fall back to the placement targets when the endpoint is unavailable.
+  const drPrimaryRegion = useMemo(
+    () =>
+      drStatus?.currentPrimary ||
+      drStatus?.primaryRegion ||
+      targets.find((t) => t.role === 'Primary')?.region ||
+      '',
+    [drStatus, targets],
+  )
+  const drStandbyRegions = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          targets
+            .filter((t) => t.role === 'Standby' && t.region && t.region !== drPrimaryRegion)
+            .map((t) => t.region),
+        ),
+      ),
+    [targets, drPrimaryRegion],
+  )
+
+  // Live WAL replication lag in seconds (row 56). Undefined when the DR
+  // endpoint hasn't resolved yet — rendered as "—" with a "measuring…"
+  // hint, NEVER a hardcoded zero passed off as a real reading.
+  const lagSeconds: number | null = useMemo(
+    () => (typeof drStatus?.walLagSeconds === 'number' ? drStatus.walLagSeconds : null),
+    [drStatus],
+  )
+  const lagColor: LagBucket = useMemo(() => lagBucket(lagSeconds), [lagSeconds])
 
   // Owned dependencies that cascade — read from spec.placement.ownedDependencies
   // when present (override state); the names also come from the blueprint's
@@ -392,6 +459,151 @@ export function TopologyTab({
           />
         )}
       </section>
+
+      {/* ── DR / replication (#3375 rows 51/52/56/57) ────────────────────
+          READ-ONLY cross-region DR telemetry. Rendered ONLY for apps whose
+          placement carries a Standby target (a live cross-region replica);
+          honestly absent for singletons so we never arm a DR block against
+          a phantom region (row 58). */}
+      {hasStandby ? (
+        <section
+          className="mt-4 rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] p-4"
+          data-testid="topology-tab-dr-panel"
+        >
+          <div className="mb-3 flex items-baseline justify-between">
+            <h3 className="text-sm font-semibold text-[var(--color-text-strong)]">
+              Disaster recovery
+            </h3>
+            {drStatus ? (
+              <span
+                className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
+                  drStatus.source === 'live'
+                    ? 'bg-green-500/10 text-green-400'
+                    : 'bg-yellow-500/10 text-yellow-400'
+                }`}
+                data-testid="topology-tab-dr-source"
+                title={
+                  drStatus.source === 'live'
+                    ? 'Read live off the Continuum + CNPGPair CR status.'
+                    : 'Fallback shape — the in-cluster client was bootstrapping or the DR CRs were not found. Not a live reading.'
+                }
+              >
+                {drStatus.source === 'live' ? '● live' : '○ not live'}
+              </span>
+            ) : null}
+          </div>
+
+          {drQ.isError ? (
+            // The replication-status endpoint 404s when no Continuum CR
+            // backs this app — a calm "no DR pair yet" note, NOT an error.
+            <p className="text-xs text-[var(--color-text-dim)]" data-testid="topology-tab-dr-none">
+              No cross-region replica reporting yet for this component.
+            </p>
+          ) : (
+            <>
+              <div
+                className="flex flex-wrap items-stretch gap-2"
+                data-testid="topology-tab-dr-regions"
+              >
+                <div
+                  className="min-w-[11rem] rounded-md border border-green-500/40 bg-green-500/10 px-3 py-2"
+                  data-testid="topology-tab-dr-primary"
+                >
+                  <div className="text-[10px] uppercase tracking-wide text-[var(--color-text-dim)]">
+                    Primary region
+                  </div>
+                  <div className="mt-0.5 font-mono text-xs font-semibold text-green-400">
+                    {drPrimaryRegion || '—'}
+                  </div>
+                  <div className="text-[10px] text-[var(--color-text-dim)]">serves writes</div>
+                </div>
+                {drStandbyRegions.length > 0 ? (
+                  drStandbyRegions.map((region) => (
+                    <div
+                      key={region}
+                      className="min-w-[11rem] rounded-md border border-yellow-500/40 bg-yellow-500/10 px-3 py-2"
+                      data-testid={`topology-tab-dr-standby-${region}`}
+                    >
+                      <div className="text-[10px] uppercase tracking-wide text-[var(--color-text-dim)]">
+                        Standby region
+                      </div>
+                      <div className="mt-0.5 font-mono text-xs font-semibold text-yellow-400">
+                        {region}
+                      </div>
+                      <div className="text-[10px] text-[var(--color-text-dim)]">
+                        {drStatus?.streamingState
+                          ? drStatus.streamingState
+                          : 'hot replica (follows WAL)'}
+                      </div>
+                    </div>
+                  ))
+                ) : (
+                  <div
+                    className="min-w-[11rem] rounded-md border border-yellow-500/40 bg-yellow-500/10 px-3 py-2"
+                    data-testid="topology-tab-dr-standby"
+                  >
+                    <div className="text-[10px] uppercase tracking-wide text-[var(--color-text-dim)]">
+                      Standby region
+                    </div>
+                    <div className="mt-0.5 font-mono text-xs font-semibold text-yellow-400">
+                      {drStatus?.replicas?.find((rep) => rep.role !== 'primary')?.region || '—'}
+                    </div>
+                    <div className="text-[10px] text-[var(--color-text-dim)]">
+                      {drStatus?.streamingState || 'hot replica (follows WAL)'}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {/* Live replication lag in seconds (row 56) — never a hardcoded —. */}
+              <div className="mt-3 flex items-center gap-2 text-xs" data-testid="topology-tab-dr-lag">
+                <span className="text-[var(--color-text-dim)]">Replication lag</span>
+                <span
+                  className={`inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 font-semibold tabular-nums ${
+                    lagColor === 'green'
+                      ? 'bg-green-500/10 text-green-400'
+                      : lagColor === 'yellow'
+                        ? 'bg-yellow-500/10 text-yellow-400'
+                        : lagColor === 'red'
+                          ? 'bg-red-500/10 text-red-400'
+                          : 'bg-[var(--color-bg)] text-[var(--color-text-dim)]'
+                  }`}
+                  data-testid="topology-tab-dr-lag-value"
+                >
+                  {lagSeconds == null ? '—' : `${lagSeconds.toFixed(1)} s`}
+                </span>
+                {lagSeconds == null && drQ.isLoading ? (
+                  <span className="text-[10px] text-[var(--color-text-dim)]">measuring…</span>
+                ) : null}
+                {drStatus?.syncState ? (
+                  <span className="text-[10px] text-[var(--color-text-dim)]">
+                    · {drStatus.syncState}
+                  </span>
+                ) : null}
+              </div>
+
+              {/* Destructive Switchover is DEFERRED (#4552 — needs careful
+                  safety UX: confirm + RPO/health preflight). Surfaced as a
+                  disabled affordance so the surface is discoverable without
+                  arming a one-click region flip. */}
+              <div className="mt-4 flex items-center gap-2" data-testid="topology-tab-dr-switchover">
+                <button
+                  type="button"
+                  className="cursor-not-allowed rounded-md border border-[var(--color-border)] px-3 py-1.5 text-xs text-[var(--color-text-dim)] opacity-60"
+                  disabled
+                  aria-disabled="true"
+                  title="Manual switchover ships next — it needs a confirm + preflight safety flow (Refs #4552)."
+                >
+                  Switch over…
+                </button>
+                <span className="text-[10px] text-[var(--color-text-dim)]">
+                  manual switchover ships next (Refs #4552)
+                </span>
+              </div>
+            </>
+          )}
+        </section>
+      ) : null}
 
       {/* ── Panel 2: Status ──────────────────────────────────────────── */}
       <section


### PR DESCRIPTION
## What
The per-app **Topology tab** (operator console, `AppDetail/TopologyTab.tsx`) now renders a **read-only Disaster-recovery section** for cross-region components: standby region(s) + the **live WAL replication lag in seconds**, sourced from the Continuum CR the platform already exposes. Closes the gap behind UAT rows 51/52/56/57 (#3375 / #3986) — the tab previously showed only the runtime Placement panel + a recon Status chip and NO DR state.

## Why it was a thin change
The DR data plane was already healthy and already exposed — catalyst-api serves `GET /api/v1/sovereigns/{id}/continuum/{name}/replication-status` (`continuum_dr_extras.go::HandleContinuumReplicationStatus`) returning `primaryRegion / currentPrimary / walLagSeconds / streamingState / syncState / replicas[] / source`. The TopologyTab simply never called it. This PR wires the existing endpoint into the existing tab — no new backend, no cluster mutation.

## Changes
- **`continuum.api.ts`** — `ContinuumReplicationStatus` type + `getContinuumReplicationStatus()` client (singular `/continuum/` path, distinct from the plural CRUD base).
- **`TopologyTab.tsx`** — a READ-ONLY "Disaster recovery" `<section>` rendered ONLY when the placement carries a `Standby` target (a live cross-region replica). Shows:
  - Primary region + standby region card(s).
  - **Live WAL replication lag in seconds** (lag-bucket coloured green/yellow/red; `—` + "measuring…" while loading — never a hardcoded zero).
  - Streaming/sync state.
  - A **live vs. not-live source badge** so a synthesized fallback shape is never passed off as live telemetry.
  - Continuum name derived as `dr-<app>` (the application-controller's `ContinuumNameFor` convention).
  - **Honestly hidden for singletons** (no DR block against a phantom region — row 58); the endpoint isn't even polled.
  - **Switchover button DEFERRED** — rendered as a disabled affordance pointing at #4552 (the destructive one-click region-flip needs a confirm + RPO/health preflight safety flow; deliberately deferred here).
- **`TopologyTab.test.tsx`** — 4 new cases: live-lag render, deferred-disabled switchover, singleton-hidden + not-polled, 404-no-CR calm note.

## Deferred (exemplary follow-up ticket)
- **#4552** — arm the manual Switchover with a confirm + RPO/health preflight (reuse the existing `SwitchoverDialog` + `requestSwitchover` + `/switchover/preview`). Best verified alongside the region-kill counter-test #4275.

## Gates
- `tsc -b --noEmit` ✅
- `eslint` (changed files) ✅
- `vite build` ✅
- `vitest` — 68 pass across continuum + AppDetail + topology widget suites (incl. the 4 new DR cases) ✅

Not yet live-walked — no fresh-prov provider capacity in this session; the surface is unit-gated and reads an already-live endpoint. Live walk lands on the next 2-region prov (shared-pg / cnpg-pair) per #3375 rows 51/52/56.

Refs #3375 #3986 #4551 #4552

🤖 Generated with [Claude Code](https://claude.com/claude-code)
