### PR TITLE
fix(bp-agenity): default httpRoute.parentRef to the real Sovereign console gateway (0.5.14)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1200,7 +1200,7 @@ spec:
       # 1.4.919 — #4525: catalog reads configuredRegions from same-namespace
       #   org-services-config (not cross-namespace sovereign-fqdn) so
       #   GET /catalog/regions returns the Sovereign's real region set.
-      version: 1.4.924
+      version: 1.4.925
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/agenity/blueprint.yaml
+++ b/products/agenity/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.5.13
+  version: 0.5.14
   card:
     title: Agenity
     summary: |

--- a/products/agenity/chart/Chart.yaml
+++ b/products/agenity/chart/Chart.yaml
@@ -124,7 +124,15 @@ type: application
 # `ingress` entity that no K8s NetworkPolicy can admit — without the CNP every
 # external hit to agenity.<slug>.<pool> returned envoy 503 "upstream connect
 # error". appVersion (dashboard image) stays 0.9.6 — image bytes unchanged.
-version: 0.5.13
+# 0.5.14 (#4553, Pillar-4 North-Star walk on omantel.biz dep 91dc05917e44d1c1):
+# httpRoute.parentRef default catalyst-gateway/catalyst-system -> the REAL
+# Sovereign console gateway cilium-gateway-console/kube-system. There is NO
+# `catalyst-gateway` on a Catalyst Sovereign — the per-Org agenity host
+# (agenity.<slug>.<pool>) is a customer host on the console-ELB gateway (the
+# same gateway bp-wordpress-tenant + the org console route attach to, #4054).
+# The old default rendered Accepted=False/InvalidHTTPRoute and the host 404'd
+# until the parentRef was hand-overridden. appVersion (image) unchanged.
+version: 0.5.14
 # Bumped appVersion 0.9.6 -> 0.9.7 (#4180): 0.9.7 is the FIRST image whose
 # /app/ mounts the WORKSPACES dashboard (Dashboardws bundle) rather than the
 # archaic single-column Dashboard.svelte. It is built from agenity#752

--- a/products/agenity/chart/values.yaml
+++ b/products/agenity/chart/values.yaml
@@ -259,9 +259,21 @@ service:
 httpRoute:
   enabled: true
   hostnames: []         # default: discovered from the Org/Sovereign FQDN
+  # The per-Org agenity host (agenity.<slug>.<pool>) is a CUSTOMER host, so it
+  # lands on the Sovereign's CONSOLE gateway (cilium-gateway-console in
+  # kube-system) — the dedicated console-ELB EIP that owns every *.{<pool>}
+  # listener (#4054 console-isolation; the same gateway bp-wordpress-tenant /
+  # the org console route attach to). The cilium-ingress-networkpolicy.yaml
+  # CNP comment in this chart already names cilium-gateway-console as the
+  # attach point; this default now matches it. There is NO `catalyst-gateway`
+  # on a Catalyst Sovereign — the old default attached to a non-existent
+  # Gateway, so the route was Accepted=False/InvalidHTTPRoute and the host
+  # 404'd until the parentRef was hand-overridden (agnstar North-Star walk,
+  # #4553). Override per-install only for a non-isolated single-gateway test
+  # cluster.
   parentRef:
-    name: catalyst-gateway
-    namespace: catalyst-system
+    name: cilium-gateway-console
+    namespace: kube-system
   # Stamp Cache-Control: no-cache on the SPA HTML entry points (/app/, /,
   # index.html) so a browser ALWAYS revalidates the document and picks up
   # newly-rolled content-hashed assets. Without it the daemon sets no

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,12 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.925 — #4553 (Pillar-4 North-Star walk, 2026-06-27): catalog-seed
+#   bp-agenity spec.version + source.version 0.5.13 -> 0.5.14 (lockstep with
+#   products/agenity/chart 0.5.14) — the agenity httpRoute.parentRef default now
+#   targets the REAL Sovereign console gateway cilium-gateway-console/kube-system
+#   instead of the non-existent catalyst-gateway/catalyst-system, so a fresh
+#   Org's agenity host serves instead of 404'ing on InvalidHTTPRoute. Bootstrap-
+#   kit slot-13 pin bumps lockstep.
 # 1.4.906 — #4477 secondary (2026-06-27): doc-only — the CATALYST_NEWAPI_ADMIN_TOKEN
 # env comment in api-deployment{,-kustomize}.yaml now cites the canonical
 # OpenBao path `catalyst/newapi/admin-token` (written by catalyst-api's
@@ -3334,7 +3341,7 @@ name: bp-catalyst-platform
 #   sovereign-fqdn) so GET /catalog/regions returns the Sovereign's REAL
 #   regions instead of [] — the marketplace BCP picker stops falling back to
 #   the hardcoded Hetzner list.
-version: 1.4.924
+version: 1.4.925
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/
 #   platform/crossplane chart + blueprint.yaml + bootstrap-kit slot 04). crossplane-core
 #   was still OOMKilled (CrashLoopBackOff, 55 restarts, exit 137, killed ~90s after start)

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5980,7 +5980,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.5.13"
+  version: "0.5.14"
   visibility: listed
   card:
     title: "Agenity"
@@ -6010,7 +6010,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-agenity
-    version: 0.5.13
+    version: 0.5.14
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## What

`products/agenity/chart/values.yaml` defaulted `httpRoute.parentRef` to `catalyst-gateway/catalyst-system` — a Gateway that **does not exist** on a Catalyst Sovereign. The per-Org agenity host (`agenity.<slug>.<pool>`) is a customer host that lands on the **console-ELB gateway `cilium-gateway-console/kube-system`** (the dedicated console EIP that owns every `*.<pool>` listener, #4054 console-isolation — the same gateway bp-wordpress-tenant + the org console route attach to). The chart's own `cilium-ingress-networkpolicy.yaml` comment already names `cilium-gateway-console` as the attach point; this default now matches it.

## Live find (Pillar-4 North-Star walk, omantel.biz dep 91dc05917e44d1c1)

Fresh Org `agnstar` (plan `s` → host-ns singleton). The agenity pod ran `1/1` and served `/healthz 200` in-cluster, but the public host **404'd** (`HTTPRoute Accepted=False/InvalidHTTPRoute`) until `parentRef` was repointed to `cilium-gateway-console`. After the repoint: bare host `/ -> 302`, `/app/ -> 200`.

## Lockstep version bumps
- `products/agenity/chart/Chart.yaml` 0.5.13 -> 0.5.14
- `products/agenity/blueprint.yaml` 0.5.13 -> 0.5.14
- catalog-seed `spec.version` + `source.version` 0.5.13 -> 0.5.14
- `bp-catalyst-platform` 1.4.924 -> 1.4.925 + slot-13 pin

Refs #4553

🤖 Generated with [Claude Code](https://claude.com/claude-code)