### PR TITLE
fix(bp-oidc-gate #4556): spaTokenSeed — TRUE zero-click for agenity, kill the bootstrap-token paste prompt after SSO

### DIFF
--- a/clusters/_template/bootstrap-kit/13c-bp-oidc-gate.yaml
+++ b/clusters/_template/bootstrap-kit/13c-bp-oidc-gate.yaml
@@ -79,7 +79,15 @@ spec:
       # initialised, hw167 UAT rows 3374-36/37/38). keycloakInternalURL below
       # points the backchannel (discovery-skip + redeem/jwks/userinfo) at the
       # in-cluster keycloak Service; the browser leg stays public.
-      version: 0.1.5
+      # 0.1.6 (#4556, 2026-06-27): spaTokenSeed — TRUE zero-click for a
+      # token-paste SPA. The agenity oidc-gate instance below does the FULL KC
+      # SSO, but the upstream agenity `/app/` SPA then demands a pasted
+      # localStorage bootstrap token even though the daemon runs authMode=none
+      # (open API). spaTokenSeed 302s the bare root, post-SSO, to
+      # `/app/?token=<sentinel>` so the SPA seeds the token and lands
+      # authenticated with NO paste (the durable path — the daemon's `oidc`
+      # authMode is a non-functional upstream scaffold, #128).
+      version: 0.1.6
       sourceRef:
         kind: HelmRepository
         name: bp-oidc-gate

--- a/platform/oidc-gate/blueprint.yaml
+++ b/platform/oidc-gate/blueprint.yaml
@@ -6,7 +6,10 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.5
+  # 0.1.6 (#4556): spaTokenSeed — TRUE zero-click for a token-paste SPA
+  # (agenity/chepherd). 302s the bare root, post-SSO, to /app/?token=<sentinel>
+  # so the SPA seeds localStorage and lands authenticated with NO paste.
+  version: 0.1.6
   card:
     title: oidc-gate
     summary: |

--- a/platform/oidc-gate/chart/Chart.yaml
+++ b/platform/oidc-gate/chart/Chart.yaml
@@ -90,7 +90,32 @@ name: bp-oidc-gate
 # exact frontchannel-public/backchannel-internal split keycloak-frontend-env.yaml
 # already establishes. Set empty to restore the pre-#3844 public-discovery
 # path (clusters where the public issuer DOES hairpin).
-version: 0.1.5
+# 0.1.6 (#4556, 2026-06-27): spaTokenSeed — TRUE zero-click for a token-paste
+# SPA. The agnstar North-Star walk (#4553, dep 91dc05917e44d1c1) proved the
+# agenity oidc-gate instance does the FULL Keycloak SSO, yet the User then
+# hit a "Welcome back / Paste the bootstrap token chepherd printed at startup"
+# screen — the upstream agenity-org/agenity `/app/` SPA
+# (web/src/components/ws/Dashboardws.svelte) gates purely on
+# localStorage['chepherd-token'] being present (`if (getToken()) ...; else
+# needLogin = true;`) and NEVER probes the daemon's auth mode, even though the
+# daemon runs CHEPHERD_AUTH_MODE=none (open API, authMiddleware a no-op). The
+# SPA DOES ingest a `?token=` URL param on mount (Dashboardws L1144-1152), and
+# because the daemon is unauthenticated any token value is accepted. New
+# per-instance `spaTokenSeed{dashboardPath,value,port}`: 302 the bare root
+# (Exact `/`), AFTER the gate's SSO, to `<dashboardPath>?token=<value>` so the
+# SPA seeds localStorage and lands authenticated with ZERO paste. value is a
+# sentinel (never verified — the daemon auth is off). Mutually exclusive with
+# rootRedirectPath (an app is EITHER native-OIDC needing a login redirect OR a
+# token-paste SPA needing a seed). Verified live on agnstar: Cilium
+# ReplaceFullPath carries the `?token=` query verbatim in the Location header
+# and oauth2-proxy preserves path+query through the KC round-trip. This is the
+# durable path because the upstream daemon's `oidc` authMode is a
+# non-functional scaffold (internal/auth/auth.go OIDCProvider.Validate returns
+# ErrNotSupported "oidc validation not yet wired, #128") — authMode=oidc would
+# leave the API open yet still demand a localStorage token. Default unset → no
+# rule (byte-identical to a login-less gated app). Slot 13c sets spaTokenSeed
+# on the agenity-agnstar instance.
+version: 0.1.6
 appVersion: "7.6.0"
 description: |
   Catalyst generic OIDC gate — a per-app oauth2-proxy instance set that

--- a/platform/oidc-gate/chart/templates/instances.yaml
+++ b/platform/oidc-gate/chart/templates/instances.yaml
@@ -305,7 +305,64 @@ spec:
   hostnames:
     - {{ $hostname | quote }}
   rules:
-{{- if $inst.rootRedirectPath }}
+{{- if hasKey $inst "spaTokenSeed" }}
+{{- /*
+#4556 — SPA bootstrap-token SEED (zero-click for a token-paste SPA).
+
+WHY THIS IS NEEDED for an app whose SPA gates on a CLIENT-SIDE token even
+when its daemon API is unauthenticated (agenity/chepherd: the daemon runs
+CHEPHERD_AUTH_MODE=none so authMiddleware is a no-op and every /api/v1/*
+request passes, but the `/app/` SPA — web/src/components/ws/Dashboardws.svelte
+in the upstream agenity-org/agenity build — shows "Welcome back / Paste the
+bootstrap token chepherd printed at startup" purely because
+`localStorage['chepherd-token']` is empty: its mount logic is
+`if (getToken()) startLiveLoop(); else needLogin = true;`, with NO probe of
+the daemon's auth mode). So even after the gate has done the FULL Keycloak
+SSO and the API is open, the User is stuck at a token-paste screen — the
+exact #4556 item-3 fault on the agnstar North-Star walk.
+
+The SPA ingests a `?token=` URL query param on mount (Dashboardws L1144-1152:
+`new URL(location.href).searchParams.get('token')` → localStorage → strip),
+and because the daemon is unauthenticated ANY non-empty token value is
+accepted. So the durable zero-click seam is: 302 the bare root to
+`<dashboardPath>?token=<value>` AFTER the gate's SSO. Cilium Gateway API
+ReplaceFullPath carries the query verbatim (verified live: Location =
+`https://<host>/app/?token=<value>`), and oauth2-proxy preserves the
+path+query through the KC round-trip in its `state` param, so the User lands
+on `/app/?token=<value>`, the SPA seeds localStorage, strips the param, and
+renders the workspace authenticated — NO paste.
+
+WHY NOT daemon CHEPHERD_AUTH_MODE=oidc: the upstream OIDCProvider.Validate
+(internal/auth/auth.go) is a non-functional scaffold that returns
+ErrNotSupported ("oidc validation not yet wired, #128"), AND rs.AuthToken is
+set ONLY in local mode (cmd/run.go) — so oidc mode would leave the API open
+yet still demand a localStorage token, and 401 if Validate is ever reached.
+The token-seed is the only path that works against the shipped upstream
+without forking the SPA.
+
+The `value` is a SENTINEL — it is never verified (auth is off on the daemon),
+it exists only to make the SPA's presence-check pass. Loop-safe exactly like
+rootRedirectPath: only the Exact bare root is redirected; /app/, /_astro/*,
+/api/*, /healthz, the WS all fall through to the catch-all backend untouched,
+and the post-seed SPA lives at /app/ which never revisits `/`. Mutually
+exclusive with rootRedirectPath (an app is EITHER native-OIDC needing a login
+redirect OR a token-paste SPA needing a seed). Default unset → no rule
+(byte-identical to a login-less gated app).
+*/}}
+    - matches:
+        - path:
+            type: Exact
+            value: /
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            port: {{ $inst.spaTokenSeed.port | default 443 }}
+            statusCode: 302
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: {{ printf "%s?token=%s" ($inst.spaTokenSeed.dashboardPath | default "/app/") ($inst.spaTokenSeed.value | default "sso") | quote }}
+{{- else if $inst.rootRedirectPath }}
 {{- /*
 #3374 Layer-A (powerdns-admin) — bare-root → app-native OIDC login path.
 

--- a/platform/oidc-gate/chart/tests/spa-token-seed-render.sh
+++ b/platform/oidc-gate/chart/tests/spa-token-seed-render.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# bp-oidc-gate — #4556 spaTokenSeed render audit.
+#
+# An app whose SPA gates on a CLIENT-SIDE bootstrap token (localStorage),
+# even when its daemon API is unauthenticated, cannot be made zero-click by
+# the gate's SSO alone: agenity/chepherd runs CHEPHERD_AUTH_MODE=none (open
+# API) yet the `/app/` SPA shows "Paste the bootstrap token" purely because
+# localStorage['chepherd-token'] is empty (it never probes the daemon auth
+# mode). The SPA DOES ingest a `?token=` URL param on mount, and any value is
+# accepted because the daemon is unauthenticated. The per-instance
+# `spaTokenSeed` makes the gate 302 ONLY the bare root (Exact `/`), AFTER the
+# gate's SSO, to `<dashboardPath>?token=<value>` so the SPA seeds localStorage
+# and lands authenticated with NO paste.
+#
+# This test asserts:
+#   1. an instance WITH spaTokenSeed renders an Exact `/` RequestRedirect to
+#      `<dashboardPath>?token=<value>` (the query carried in replaceFullPath)
+#      AHEAD of the PathPrefix `/` backend;
+#   2. an instance WITHOUT it renders NO redirect (only the PathPrefix
+#      backend);
+#   3. spaTokenSeed.port overrides the redirect port, and dashboardPath/value
+#      defaults are /app/ and sso;
+#   4. spaTokenSeed takes precedence over rootRedirectPath (mutual exclusivity:
+#      the seed wins, no double Exact-/ rule).
+
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
+helm="${HELM_BIN:-helm}"
+
+vals="$(mktemp)"
+trap 'rm -f "$vals"' EXIT
+cat >"$vals" <<'YAML'
+sovereignFQDN: smoke.example.com
+realm: sovereign
+instances:
+  # token-paste SPA — spaTokenSeed set (explicit path/value/port)
+  - name: agenity-org1
+    enabled: true
+    clientId: agenity-org1
+    hostname: agenity.org1.smoke.example.com
+    upstream: http://agenity.org1.svc.cluster.local:8080
+    spaTokenSeed:
+      dashboardPath: /app/
+      value: sso
+      port: 443
+  # token-paste SPA — spaTokenSeed defaults (no path/value/port)
+  - name: agenity-defaults
+    enabled: true
+    clientId: agenity-defaults
+    hostname: agenity.defaults.smoke.example.com
+    upstream: http://agenity.defaults.svc.cluster.local:8080
+    spaTokenSeed: {}
+  # custom dashboard path + value + port
+  - name: agenity-custom
+    enabled: true
+    clientId: agenity-custom
+    hostname: agenity.custom.smoke.example.com
+    upstream: http://agenity.custom.svc.cluster.local:8080
+    spaTokenSeed:
+      dashboardPath: /dashboard/
+      value: seed42
+      port: 8443
+  # login-less app — NO spaTokenSeed (control)
+  - name: flowless
+    enabled: true
+    clientId: flowless
+    upstream: http://flowless.default.svc.cluster.local:80
+  # spaTokenSeed precedence over rootRedirectPath
+  - name: agenity-precedence
+    enabled: true
+    clientId: agenity-precedence
+    hostname: agenity.prec.smoke.example.com
+    upstream: http://agenity.prec.svc.cluster.local:8080
+    rootRedirectPath: /oidc/login
+    spaTokenSeed:
+      value: sso
+YAML
+
+out="$("$helm" template oidc-gate "$chart_dir" -f "$vals" 2>/dev/null)"
+
+route_doc() {
+  echo "$out" | awk -v want="oidc-gate-$1" '
+    BEGIN{RS="\n---\n"}
+    /kind: HTTPRoute/ && $0 ~ ("name: \"?" want "\"?") {print}'
+}
+
+# ── Case 1: explicit spaTokenSeed → Exact / -> /app/?token=sso ──────────────
+echo "[spa-token-seed] Case 1: agenity-org1 renders Exact / RequestRedirect to /app/?token=sso"
+a1="$(route_doc agenity-org1)"
+if [ -z "$a1" ]; then echo "FAIL: no HTTPRoute oidc-gate-agenity-org1 rendered" >&2; echo "$out" >&2; exit 1; fi
+echo "$a1" | grep -qE 'type:\s*Exact'                                  || { echo "FAIL: missing Exact path match" >&2; echo "$a1" >&2; exit 1; }
+echo "$a1" | grep -qE 'type:\s*RequestRedirect'                        || { echo "FAIL: missing RequestRedirect filter" >&2; echo "$a1" >&2; exit 1; }
+echo "$a1" | grep -qE 'replaceFullPath:\s*"?/app/\?token=sso"?'        || { echo "FAIL: redirect not to /app/?token=sso" >&2; echo "$a1" >&2; exit 1; }
+echo "$a1" | grep -qE 'port:\s*443'                                    || { echo "FAIL: redirect not on port 443" >&2; echo "$a1" >&2; exit 1; }
+echo "$a1" | grep -qE 'statusCode:\s*302'                              || { echo "FAIL: redirect not 302" >&2; echo "$a1" >&2; exit 1; }
+echo "  PASS"
+
+# ── Case 2: defaults → /app/?token=sso on port 443 ─────────────────────────
+echo "[spa-token-seed] Case 2: agenity-defaults uses dashboardPath=/app/ value=sso port=443 defaults"
+a2="$(route_doc agenity-defaults)"
+echo "$a2" | grep -qE 'replaceFullPath:\s*"?/app/\?token=sso"?' || { echo "FAIL: defaults not /app/?token=sso" >&2; echo "$a2" >&2; exit 1; }
+echo "$a2" | grep -qE 'port:\s*443'                            || { echo "FAIL: default port not 443" >&2; echo "$a2" >&2; exit 1; }
+echo "  PASS"
+
+# ── Case 3: custom path/value/port honoured ────────────────────────────────
+echo "[spa-token-seed] Case 3: agenity-custom honours /dashboard/?token=seed42 on 8443"
+a3="$(route_doc agenity-custom)"
+echo "$a3" | grep -qE 'replaceFullPath:\s*"?/dashboard/\?token=seed42"?' || { echo "FAIL: custom path/value wrong" >&2; echo "$a3" >&2; exit 1; }
+echo "$a3" | grep -qE 'port:\s*8443'                                    || { echo "FAIL: custom port 8443 not honoured" >&2; echo "$a3" >&2; exit 1; }
+echo "  PASS"
+
+# ── Case 4: control (no spaTokenSeed) renders NO redirect ──────────────────
+echo "[spa-token-seed] Case 4: flowless (no spaTokenSeed) renders NO redirect"
+fl="$(route_doc flowless)"
+if echo "$fl" | grep -qE 'RequestRedirect|type:\s*Exact'; then
+  echo "FAIL: flowless should NOT render a redirect" >&2; echo "$fl" >&2; exit 1
+fi
+echo "$fl" | grep -qE 'type:\s*PathPrefix' || { echo "FAIL: flowless missing PathPrefix backend" >&2; exit 1; }
+echo "  PASS"
+
+# ── Case 5: spaTokenSeed precedence over rootRedirectPath ──────────────────
+echo "[spa-token-seed] Case 5: spaTokenSeed wins over rootRedirectPath (no /oidc/login redirect)"
+ap="$(route_doc agenity-precedence)"
+echo "$ap" | grep -qE 'replaceFullPath:\s*"?/app/\?token=sso"?' || { echo "FAIL: precedence instance did not render the seed redirect" >&2; echo "$ap" >&2; exit 1; }
+if echo "$ap" | grep -qE 'replaceFullPath:\s*"?/oidc/login"?'; then
+  echo "FAIL: rootRedirectPath rule rendered alongside spaTokenSeed (must be mutually exclusive)" >&2; echo "$ap" >&2; exit 1
+fi
+# exactly ONE Exact-/ match in this route (no double redirect rule)
+n_exact="$(echo "$ap" | grep -cE 'type:\s*Exact' || true)"
+[ "$n_exact" -eq 1 ] || { echo "FAIL: expected exactly 1 Exact-/ rule, got $n_exact" >&2; echo "$ap" >&2; exit 1; }
+echo "  PASS"
+
+echo "[bp-oidc-gate #4556 spaTokenSeed] All cases PASS"

--- a/platform/oidc-gate/chart/values.yaml
+++ b/platform/oidc-gate/chart/values.yaml
@@ -106,4 +106,22 @@ resources:
 #     # Login-less gated apps (openova-flow) leave this unset → only
 #     # /oauth2/callback registers (byte-identical to the pre-#3741 shape).
 #     appNativeCallbackPath: ""     # e.g. "/oidc/authorized"
+#     # spaTokenSeed (#4556): for an app whose SPA gates on a CLIENT-SIDE
+#     # bootstrap token EVEN when its daemon API is unauthenticated. The
+#     # agenity/chepherd `/app/` SPA shows "Paste the bootstrap token" purely
+#     # because localStorage['chepherd-token'] is empty — it never probes the
+#     # daemon's auth mode (which runs CHEPHERD_AUTH_MODE=none, so the API is
+#     # actually open). The SPA ingests a `?token=` URL param on mount, and
+#     # because the daemon is unauthenticated any value is accepted. Setting
+#     # this 302s the bare root (Exact `/`), AFTER the gate's full KC SSO, to
+#     # `<dashboardPath>?token=<value>` so the SPA seeds localStorage and lands
+#     # authenticated with NO paste. value is a SENTINEL (never verified — the
+#     # daemon auth is off; it only satisfies the SPA presence-check). Mutually
+#     # exclusive with rootRedirectPath. Default unset → no redirect rule. This
+#     # is the durable path because the upstream daemon's oidc authMode is a
+#     # non-functional scaffold (OIDCProvider.Validate → ErrNotSupported, #128).
+#     spaTokenSeed:
+#       dashboardPath: "/app/"      # the SPA route that ingests ?token=
+#       value: "sso"                # sentinel token (daemon auth is off)
+#       port: 443                   # external HTTPS port for the Location header
 instances: []


### PR DESCRIPTION
## Problem (#4556 item 3)
On the agnstar North-Star walk (#4553, dep `91dc05917e44d1c1`), `https://agenity.agnstar.omani.homes/` does the FULL Keycloak SSO via the agenity oidc-gate instance — then dead-ends on a **"Welcome back — Paste the bootstrap token chepherd printed at startup"** prompt. Violates founder requirement #4 (*"access agenity in SSO way without requiring additional token copy paste"*).

## Root cause (verified against the EXACT built upstream ref `5620ad668197f146dc529c4f18f932371249cb72`, the AGENITY_REF in agenity-build.yaml)
- The `/app/` SPA `web/src/components/ws/Dashboardws.svelte` gates **purely** on `localStorage['chepherd-token']` presence: `if (getToken()) startLiveLoop(); else needLogin = true;` (L1199-1200). It NEVER probes the daemon's auth mode — so even with `CHEPHERD_AUTH_MODE=none` (open API: `authMiddleware` no-op when `s.AuthToken==""`, server.go L504-507) it shows the paste prompt when localStorage is empty.
- **`authMode=oidc` is a dead end** (rules out #4556 option b): upstream `OIDCProvider.Validate` (`internal/auth/auth.go:241-246`) is a non-functional scaffold returning `ErrNotSupported` ("oidc validation not yet wired, #128"), and `rs.AuthToken` is set ONLY in local mode (`cmd/run.go`). So oidc mode would leave the API open yet STILL demand a localStorage token, and 401 if `Validate` ran.

## Fix (durable, no upstream fork)
The SPA **ingests a `?token=` URL query param on mount** (Dashboardws L1144-1152) into localStorage, then strips it. Because the daemon is unauthenticated, **any** value is accepted. New per-instance `spaTokenSeed{dashboardPath,value,port}` on **bp-oidc-gate** 302s the bare root (Exact `/`), AFTER its SSO, to `<dashboardPath>?token=<value>` so the SPA seeds the token and lands authenticated with ZERO paste. value is a sentinel (never verified — daemon auth is off). Mutually exclusive with `rootRedirectPath`.

## VERIFIED LIVE on agnstar (3 screenshots on the issue)
1. BEFORE: `/app/` empty localStorage → token-paste prompt (the fault).
2. AFTER (deterministic, direct daemon): `/app/?token=sso` → SPA ingests token, strips param, renders the authenticated workspace; probe `{token_in_localStorage:'sso', has_paste_prompt:false, has_workspace_tabs:true}`.
3. AFTER (full live public URL through the gate): `agenity.agnstar.omani.homes/` → gateway 302 → `/app/?token=sso` → oauth2-proxy session → authenticated workspace, NO paste.
Each leg verified: Cilium `ReplaceFullPath` carries `?token=` verbatim in the Location header; oauth2-proxy preserves path+query through the KC round-trip in `state`.

## Changes
- `platform/oidc-gate/chart`: `spaTokenSeed` instance knob + render rule (`hasKey` guard); values + Chart + blueprint **0.1.5 → 0.1.6**.
- `clusters/_template/bootstrap-kit/13c`: slot pin **0.1.5 → 0.1.6**.
- new `tests/spa-token-seed-render.sh` (5 cases incl. defaults + precedence over `rootRedirectPath`); existing render tests stay green.

Refs #4556 #4553

🤖 Generated with [Claude Code](https://claude.com/claude-code)