### PR TITLE
fix(marketplace #4564): returning-user redirect lands on the Org's pool-TLD console, not a marketplace-domain dead host

### DIFF
--- a/core/marketplace/src/layouts/Layout.astro
+++ b/core/marketplace/src/layouts/Layout.astro
@@ -93,7 +93,13 @@ const { title, step = 0 } = Astro.props;
         var cached = null;
         try { cached = JSON.parse(sessionStorage.getItem(CACHE_KEY) || 'null'); } catch (e) {}
         if (cached && cached.has && Date.now() - cached.ts < TTL_MS) {
-          redirect();
+          // #4564: pass the stamped slug on the cache fast-path too, so the
+          // per-tenant branch fires and `redirect()` prefers the stamped
+          // server console host (correct pool TLD) instead of the operator
+          // fallback `console.<sovFqdn>`.
+          var cachedSlug = '';
+          try { cachedSlug = localStorage.getItem('org-active-org-slug') || ''; } catch (_) {}
+          redirect(cachedSlug);
           return;
         }
         fetch('/api/tenant/orgs', { headers: { Authorization: 'Bearer ' + token } })
@@ -115,6 +121,25 @@ const { title, step = 0 } = Astro.props;
               var pick = (activeId && live.find(function (o) { return o.id === activeId; })) || live[0];
               if (pick && pick.slug) {
                 try { localStorage.setItem('org-active-org-slug', pick.slug); } catch (_) {}
+              }
+              // #4564: the picked org carries its SERVER-AUTHORITATIVE console
+              // host + pool TLD from /api/tenant/orgs (console_host /
+              // parent_domain). A funnel Org lives on the pool TLD
+              // (omani.homes / omani.rest / omani.trade), NOT the marketplace
+              // host domain — so deriving `console.<slug>.<marketplace-domain>`
+              // bounces a cleared-storage / cross-device returning user to a
+              // DEAD host (stale apex wildcard). Stamp the server host so
+              // `redirect()` (and future loads) land on the LIVE console.
+              if (pick) {
+                var srvHost = pick.console_host ||
+                  (pick.subdomain && pick.parent_domain
+                    ? 'console.' + pick.subdomain + '.' + pick.parent_domain
+                    : (pick.slug && pick.parent_domain
+                        ? 'console.' + pick.slug + '.' + pick.parent_domain
+                        : ''));
+                if (srvHost) {
+                  try { localStorage.setItem('org-active-console-host', String(srvHost).toLowerCase()); } catch (_) {}
+                }
               }
               redirect(pick && pick.slug ? String(pick.slug) : '');
             }
@@ -153,7 +178,22 @@ const { title, step = 0 } = Astro.props;
           if (sovFqdn) {
             var s = (slug || '').toLowerCase().trim();
             if (s) {
-              base = 'https://console.' + s + '.' + sovFqdn;
+              // #4564: a funnel Org lives on its chosen POOL TLD
+              // (omani.homes / omani.rest / omani.trade), which is NOT the
+              // marketplace host domain (sovFqdn). Deriving
+              // `console.<slug>.<sovFqdn>` lands on a DEAD apex-wildcard host.
+              // Prefer the SERVER-AUTHORITATIVE console host stamped above
+              // (org-active-console-host, #4176) — it carries the correct pool
+              // TLD. Guard: trust the stamp only if it names THIS slug, so a
+              // stale stamp from another Org can't misroute. Fall back to the
+              // sovFqdn derivation when no matching server host is known.
+              var srvConsoleHost = '';
+              try { srvConsoleHost = (localStorage.getItem('org-active-console-host') || '').trim().toLowerCase(); } catch (_) {}
+              if (srvConsoleHost && srvConsoleHost.indexOf('.' + s + '.') !== -1) {
+                base = 'https://' + srvConsoleHost;
+              } else {
+                base = 'https://console.' + s + '.' + sovFqdn;
+              }
               perTenant = true;
             } else {
               base = 'https://console.' + sovFqdn;


### PR DESCRIPTION
## Fault (live, dep 91dc05917e44d1c1, UAT funnel row 91 walk 2026-06-27)

The marketplace returning-user redirect (inline `is:inline` script in `core/marketplace/src/layouts/Layout.astro`) sent a signed-in returning visitor to their own Org console **but derived the console host from the MARKETPLACE host domain**, not the Org's chosen pool TLD.

For `marketplace.omantel.biz` it composed `console.<slug>.omantel.biz`. Every funnel Org is provisioned on the **pool TLD** (`omani.homes` / `omani.rest` / `omani.trade`), so:

- Org `walk-stranger-one` provisioned on `omani.homes` → real console `console.walk-stranger-one.omani.homes` (resolves 212.72.24.33, console-ELB).
- Redirect derived `console.walk-stranger-one.omantel.biz` → resolves `49.12.16.160` (stale apex wildcard, **dead**) → `/launching` polls `/healthz` → **ERR_CONNECTION_REFUSED forever**.

Same pool-TLD-vs-Sovereign-domain split #4421 / #4176 already closed on the org-controller + Svelte-config side; the inline redirect was never updated.

### Why it bites real users
The inline script read only `org-token` / `org-active-org` / `org-refresh-token` / `org-theme` — it never read the server-authoritative `org-active-console-host` (#4176) nor the `console_host` / `parent_domain` already present in the `/api/tenant/orgs` response. A returning user whose stamp is absent — **new device, cleared storage, fresh browser** — got bounced to a dead host.

## Fix
- `.then()` block now stamps `org-active-console-host` from the picked org's `console_host` (fallback `console.<sub>.<parent_domain>`), using the data the API already returns.
- `redirect()` prefers that server stamp (slug-guarded so a stale cross-Org stamp can't misroute) over the `sovFqdn` derivation; falls back to the old derivation only when no matching server host is known.
- Cache fast-path passes the stamped slug so the per-tenant branch fires there too.

Row-91's 'never the mothership' contract is preserved (target is still a Sovereign per-Org host, never `console.openova.io`); this closes the wrong-TLD-within-the-Sovereign edge.

## Validation
- `npm run build` green; `check-served-domain-hygiene` green (zero banned mothership literals).
- Live-observed on dep 91dc05917e44d1c1: the funnel Org `walk-stranger-one` provisioned on `omani.homes` (CR `spec.tenantPublic.parentDomain=omani.homes`); `console.<slug>.omani.homes` → 212.72.24.33 live, `console.<slug>.omantel.biz` → 49.12.16.160 dead. `/api/tenant/orgs` already returns `console_host` + `parent_domain` per org.

Refs #4564, Refs #3376.

🤖 Generated with [Claude Code](https://claude.com/claude-code)