### PR TITLE
fix(#4563): pivot catalyst-ui + openova-flow-server off the residual ghcr.io tether under cutover deny-egress

### DIFF
--- a/.github/workflows/catalyst-build.yaml
+++ b/.github/workflows/catalyst-build.yaml
@@ -608,9 +608,15 @@ jobs:
           # green. Caught live hw86 walk 2026-05-31: catalyst-api stuck at
           # fd378e3 while ui rolled to 8a6536c. Now sed both files.
           API_KUST_TPL="products/catalyst/chart/templates/api-deployment-kustomize.yaml"
-          UI_TPL="products/catalyst/chart/templates/ui-deployment.yaml"
+          # #4563: catalyst-ui got the same dual-file split as catalyst-api —
+          # ui-deployment.yaml is now Helm-templated ({{ .Values.global.
+          # imageRegistry }}, no sed-matchable literal) and the contabo-mkt
+          # Kustomize path consumes ui-deployment-kustomize.yaml (literal).
+          # Sed the kustomize sibling so contabo rolls; Sovereigns roll via
+          # the values.yaml catalystUi.tag awk-bump above.
+          UI_KUST_TPL="products/catalyst/chart/templates/ui-deployment-kustomize.yaml"
           sed -i -E "s|(image: \"ghcr\.io/openova-io/openova/catalyst-api:)[^\"]*\"|\1${SHA_SHORT}\"|" "${API_TPL}" "${API_KUST_TPL}"
-          sed -i -E "s|(image: \"ghcr\.io/openova-io/openova/catalyst-ui:)[^\"]*\"|\1${SHA_SHORT}\"|"  "${UI_TPL}"
+          sed -i -E "s|(image: \"ghcr\.io/openova-io/openova/catalyst-ui:)[^\"]*\"|\1${SHA_SHORT}\"|"  "${UI_KUST_TPL}"
           # qa-loop iter-3 Fix #18 — also bump the CATALYST_BUILD_SHA env
           # literal in the api-deployment so /api/v1/version returns the
           # SHA the Pod is actually running. Without this, the env stays
@@ -622,7 +628,7 @@ jobs:
           # + newline + `              value:`.
           sed -i -E "/name: CATALYST_BUILD_SHA/{n;s|(value: )\"[a-f0-9]+\"|\1\"${SHA_SHORT}\"|;}" "${API_TPL}"
           echo "templates after update:"
-          grep -E "image: \".*catalyst-(api|ui):" "${API_TPL}" "${UI_TPL}"
+          grep -E "image: \".*catalyst-(api|ui):" "${API_KUST_TPL}" "${UI_KUST_TPL}"
           grep -A1 "CATALYST_BUILD_SHA" "${API_TPL}" | head -2
 
           # Wave 5.48 (#2272) — bump bp-catalyst-platform Chart.yaml patch
@@ -772,8 +778,9 @@ jobs:
           done
           echo "#2851 sweep: bumped ${bumped}/5 controller pin(s) to latest GHCR."
 
-      # values.yaml + the two literal-image templates (api-deployment,
-      # ui-deployment) are bumped together so:
+      # values.yaml + the literal-image Kustomize-sibling templates
+      # (api-deployment-kustomize, ui-deployment-kustomize) are bumped
+      # together so:
       #   - Sovereigns get the new SHA via the next OCI chart publish
       #     (blueprint-release fires below).
       #   - contabo's Kustomize-path Flux reconciles the bumped literal
@@ -797,6 +804,7 @@ jobs:
             products/catalyst/chart/templates/api-deployment.yaml
             products/catalyst/chart/templates/api-deployment-kustomize.yaml
             products/catalyst/chart/templates/ui-deployment.yaml
+            products/catalyst/chart/templates/ui-deployment-kustomize.yaml
             products/catalyst/chart/Chart.yaml
           commit-message: "deploy: update catalyst images to ${{ needs.build-ui.outputs.sha_short }} (+ #2851 controller sweep)"
 

--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -626,7 +626,11 @@ spec:
       # (`catalyst`) so the step Jobs' secretKeyRef resolves natively — no more
       # hand-bridged `kubectl apply`. No step-count / job-mode change (the
       # bridge is a Secret without the cutover-step label).
-      version: 0.1.84
+      # 0.1.85 (#4563 Refs #3379): step-07 also pivots the bp-openova-flow-
+      # server HR's global.imageRegistry to local Harbor (catalyst-ui pivots
+      # via the bp-catalyst-platform chart 1.4.927) — kills the step-08 fresh-
+      # pull FATAL on the two residual ghcr.io tethers. Lockstep w/ Chart.yaml.
+      version: 0.1.85
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover
@@ -727,6 +731,17 @@ spec:
     # a tether the preceding steps 01-07 already pivoted off.
     egressTest:
       enforceCIDRBlock: true
+      # #4563 (Refs #3379): the Sovereign-local registry host is
+      # `registry.${SOVEREIGN_FQDN}` (bp-harbor's HTTPRoute, see
+      # 19-harbor.yaml + harborPublicURL above), NOT `harbor.<fqdn>`.
+      # The step-08 #3695 fresh-pull proof classifies a workload as
+      # "already local" when its image host contains this substring —
+      # with the chart default `harbor.` the post-pivot catalyst-ui /
+      # openova-flow-server images (registry.<fqdn>/openova-io/...) were
+      # mis-classified as external and needlessly bounced. Override to
+      # `registry.` so pivoted workloads are correctly recognised as
+      # local and the proof PASSes on the first scan.
+      localRegistryHostSubstr: "registry."
     # Wave 5.110 (#2462): bastion mirror endpoint for harbor.openova.io,
     # substituted from cloudinit's flux-system/bastion-mirror Secret
     # (Huawei provider only; Hetzner leaves the var empty → chart skips

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1200,7 +1200,10 @@ spec:
       # 1.4.919 — #4525: catalog reads configuredRegions from same-namespace
       #   org-services-config (not cross-namespace sovereign-fqdn) so
       #   GET /catalog/regions returns the Sovereign's real region set.
-      version: 1.4.927
+      # 1.4.928 — #4563: catalyst-ui image templated via global.imageRegistry
+      #   so cutover step-07 pivots it to local Harbor (kills step-08 fresh-
+      #   pull FATAL on the residual ghcr.io tether). Lockstep w/ Chart.yaml.
+      version: 1.4.928
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/56-bp-openova-flow-server.yaml
+++ b/clusters/_template/bootstrap-kit/56-bp-openova-flow-server.yaml
@@ -71,7 +71,11 @@ spec:
   chart:
     spec:
       chart: bp-openova-flow-server
-      version: 0.2.4
+      # 0.2.5 (#4563 Refs #3379): image helper honours global.imageRegistry so
+      # cutover step-07 pivots openova-flow-server to local Harbor (kills the
+      # step-08 fresh-pull FATAL on the residual ghcr.io tether). Lockstep w/
+      # Chart.yaml + the global.imageRegistry:'' seam added to values above.
+      version: 0.2.5
       sourceRef:
         kind: HelmRepository
         name: bp-openova-flow-server
@@ -97,6 +101,18 @@ spec:
   # with the concrete sovereign FQDN before the HR bytes land in the
   # cluster.
   values:
+    # #4563 (Refs #3379): imageRegistry override seam — same pattern as
+    # slot 13 bp-catalyst-platform. Empty literal default at Phase 1
+    # (pre-cutover) → the chart helper's `{{ if .Values.global.imageRegistry }}`
+    # falls back to the literal ghcr.io repository. Cutover Step 07 patches
+    # this HR's spec.values.global.imageRegistry live AND durably edits this
+    # file in local Gitea, replacing the empty string with the local Harbor
+    # host so openova-flow-server pulls registry.<sov-fqdn>/openova-io/openova/
+    # openova-flow-server under the deny-egress hold (image native-pushed by
+    # cutover step-03). Without it the literal ghcr.io ref 401s under
+    # deny-egress → step-08 fresh-pull FATALs.
+    global:
+      imageRegistry: ''
     # G87 #2634: multi-region CNPG instances default (1 single-region, 2 multi).
     postgres:
       cluster:

--- a/platform/openova-flow-server/chart/Chart.yaml
+++ b/platform/openova-flow-server/chart/Chart.yaml
@@ -6,7 +6,12 @@ name: bp-openova-flow-server
 annotations:
   catalyst.openova.io/no-upstream: "true"
 # 0.2.4 (#3971): CNPG storageClass empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN.
-version: 0.2.4
+# 0.2.5 (#4563 Refs #3379): image helper honours global.imageRegistry — the
+#   post-cutover registry pivot (step-07 patches this HR too) swaps the ghcr.io
+#   prefix for registry.<sov-fqdn> so openova-flow-server pulls from the local
+#   Harbor under the 600s deny-egress hold instead of 401'ing → step-08 fresh-
+#   pull proof PASSes. No-op when global.imageRegistry is unset (pre-cutover).
+version: 0.2.5
 appVersion: "0.2.0"
 description: |
   Catalyst Blueprint chart for the openova-flow-server — the

--- a/platform/openova-flow-server/chart/templates/_helpers.tpl
+++ b/platform/openova-flow-server/chart/templates/_helpers.tpl
@@ -40,11 +40,40 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{/*
 Image-tag fail-fast — INVIOLABLE-PRINCIPLES #4a.
+
+#4563 (Refs #3379): honour `global.imageRegistry`. The repository is the
+full ghcr.io path (ghcr.io/openova-io/openova/openova-flow-server). When
+the post-cutover registry pivot sets global.imageRegistry =
+registry.<sovereign-fqdn>, swap ONLY the leading registry host so the
+image resolves to registry.<fqdn>/openova-io/openova/openova-flow-server
+— the path the cutover step-03 harbor-prewarm natively pushes the image
+to. Without the override the literal ghcr.io ref is unreachable under the
+600s deny-egress hold (anonymous-token fetch blocked → 401 ImagePullBackOff)
+and the step-08 fresh-pull proof FATALs. Mirrors the catalyst chart's
+api-deployment.yaml / ui-deployment.yaml `global.imageRegistry` wrapper.
 */}}
 {{- define "bp-openova-flow-server.image" -}}
 {{- $tag := .Values.flowServer.image.tag -}}
 {{- if not $tag -}}
 {{- fail "bp-openova-flow-server: .Values.flowServer.image.tag is empty — SHA-pinned image required (CI populates this)" -}}
 {{- end -}}
-{{- printf "%s:%s" .Values.flowServer.image.repository $tag -}}
+{{- $repo := .Values.flowServer.image.repository -}}
+{{- $registry := "" -}}
+{{- if .Values.global -}}
+{{- $registry = .Values.global.imageRegistry | default "" -}}
+{{- end -}}
+{{- if $registry -}}
+{{/* Strip the leading registry host (first path segment, e.g. ghcr.io)
+     and re-prefix with the pivot registry. Splits on "/" and drops the
+     first segment; the remainder is rejoined with "/". A repository with
+     no "/" (bare image name) is kept whole under the new registry. */}}
+{{- $parts := splitList "/" $repo -}}
+{{- $rest := $repo -}}
+{{- if gt (len $parts) 1 -}}
+{{- $rest = rest $parts | join "/" -}}
+{{- end -}}
+{{- printf "%s/%s:%s" (trimSuffix "/" $registry) $rest $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
 {{- end -}}

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.84
+  version: 0.1.85
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,18 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.85 (#4563 Refs #3379, keystone re-prov c39f0cd4455b7a46 reached step-08
+# with the 600s deny-egress hold PASSING but the fresh-pull-under-deny-egress
+# proof FATALing on two residual ghcr.io tethers, 2026-06-27): step-07 now ALSO
+# pivots the bp-openova-flow-server HR's global.imageRegistry (live HR-patch +
+# durable Gitea edit of slot-56), mirroring the bp-catalyst-platform pivot —
+# openova-flow-server is a SEPARATE HR that step-07 previously left on its
+# literal ghcr.io image, so under the deny-egress hold its anonymous-token
+# fetch was blocked → 401 ImagePullBackOff → step-08 FATAL. catalyst-ui's pivot
+# is handled by the bp-catalyst-platform chart (ui-deployment.yaml templated
+# via global.imageRegistry, 1.4.927). Slot 06a also sets egressTest.
+# localRegistryHostSubstr='registry.' (the real Sovereign Harbor host is
+# registry.<fqdn>, not harbor.<fqdn>) so the #3695 proof classifies pivoted
+# workloads as local on the first scan instead of needlessly bouncing them.
 # 0.1.84 (#4557 Refs #3379, keystone re-prov c39f0cd4455b7a46 wedged step-06 on
 # the helm-CLI x509 vs the LE-staging in-cluster Harbor, 2026-06-27): FOUR
 # changes — the recurring cutover-tail cert-verify pattern closed at every
@@ -1186,7 +1199,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.84
+version: 0.1.85
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/07-catalyst-api-env-patch-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/07-catalyst-api-env-patch-job.yaml
@@ -14,6 +14,14 @@ pre-G61 catalyst-api Deployment image was hardcoded ghcr.io which
 the policy correctly denied after Kyverno bootstrapMode->Enforce
 flip).
 
+#4563 (Refs #3379): catalyst-ui's image is now templated through
+global.imageRegistry (ui-deployment.yaml), so the bp-catalyst-platform
+HR patch above pivots it automatically. openova-flow-server is a
+SEPARATE HR (slot 56) whose chart helper also honours
+global.imageRegistry — this step now patches that HR too (live +
+durable Gitea edit) so both residual ghcr.io tethers pivot to the
+local Harbor before the step-08 fresh-pull-under-deny-egress proof.
+
 Phase 2 (pre-G61): kubectl set env CATALYST_GITOPS_REPO_URL pointing
 catalyst-api at the local Gitea mirror. Triggers another rolling
 restart (likely already in-flight from Phase 1's HR upgrade, but
@@ -201,6 +209,72 @@ data:
               fi
               sleep 2
             done
+
+            # ---- #4563 (Refs #3379): pivot bp-openova-flow-server ----
+            # openova-flow-server is a SEPARATE HelmRelease (slot 56)
+            # whose chart helper honours global.imageRegistry the same
+            # way bp-catalyst-platform does, but step-07 above only
+            # patches the catalyst-platform HR. Without this block the
+            # flow-server Deployment keeps its literal ghcr.io image →
+            # under the 600s deny-egress hold the anonymous-token fetch
+            # to ghcr.io is blocked → 401 ImagePullBackOff → step-08
+            # fresh-pull proof FATALs. Mirror the catalyst-platform
+            # live-HR-patch + durable-Gitea-edit pattern above so the
+            # pivot survives Flux reconciles.
+            FLOW_HR_NAME="bp-openova-flow-server"
+            FLOW_HR_NAMESPACE="flux-system"
+            if kubectl get hr "${FLOW_HR_NAME}" -n "${FLOW_HR_NAMESPACE}" >/dev/null 2>&1; then
+              echo "[catalyst-api-env-patch] #4563 HR patch ${FLOW_HR_NAMESPACE}/${FLOW_HR_NAME} spec.values.global.imageRegistry=${REGISTRY}"
+              FLOW_PATCH=$(printf '{"spec":{"values":{"global":{"imageRegistry":"%s"}}}}' "${REGISTRY}")
+              kubectl patch hr "${FLOW_HR_NAME}" \
+                -n "${FLOW_HR_NAMESPACE}" \
+                --type=merge \
+                -p "${FLOW_PATCH}" || echo "[catalyst-api-env-patch] #4563 flow-server HR patch failed (non-fatal; will retry on next cutover)"
+
+              # Durable Gitea edit on the slot-56 source-of-truth so Flux
+              # Kustomization doesn't revert the live patch (same #2613 rule).
+              cd /tmp
+              rm -rf flowrepo
+              flow_push_url=$(printf '%s' "${GITEA_INTERNAL_URL}" | sed -E "s,^(https?://),\1${GITEA_USERNAME}:${GITEA_PASSWORD}@,")"/${GITEA_ORG}/${GITEA_REPO}.git"
+              if git clone --depth 1 --branch main "${flow_push_url}" flowrepo >/dev/null 2>&1; then
+                cd flowrepo
+                git config user.email "self-sovereign-cutover@${HARBOR_HOST}"
+                git config user.name  "self-sovereign-cutover (#4563 flow-server imageRegistry patch)"
+                flow_target="clusters/_template/bootstrap-kit/56-bp-openova-flow-server.yaml"
+                if [ -f "${flow_target}" ]; then
+                  # Match `imageRegistry: ''` at 6-space indent under the
+                  # global: block. Replace with the harbor host. Idempotent.
+                  if sed -i -E "s|^([[:space:]]{6}imageRegistry:[[:space:]]*)['\"]?[^'\"]*['\"]?[[:space:]]*\$|\1'${REGISTRY}'|" "${flow_target}" 2>/dev/null; then
+                    if ! git diff --quiet "${flow_target}"; then
+                      git add "${flow_target}"
+                      git commit -m "cutover #4563: pivot bp-openova-flow-server global.imageRegistry to local Harbor (${REGISTRY})" >/dev/null
+                      if git push origin main >/dev/null 2>&1; then
+                        echo "[catalyst-api-env-patch] #4563 OK: Gitea-edit pushed ${flow_target} global.imageRegistry='${REGISTRY}'"
+                      else
+                        echo "[catalyst-api-env-patch] #4563 WARN: git push failed (live HR-patch non-durable; next reconcile may revert)" >&2
+                      fi
+                    else
+                      echo "[catalyst-api-env-patch] #4563 SKIP: ${flow_target} already has imageRegistry=${REGISTRY} (idempotent re-run)"
+                    fi
+                  else
+                    echo "[catalyst-api-env-patch] #4563 WARN: sed match failed on ${flow_target}; flow-server pivot durability not guaranteed" >&2
+                  fi
+                else
+                  echo "[catalyst-api-env-patch] #4563 SKIP: ${flow_target} not present in local mirror"
+                fi
+                cd /tmp
+                rm -rf flowrepo
+              else
+                echo "[catalyst-api-env-patch] #4563 WARN: git clone of local Gitea failed; flow-server pivot durability not guaranteed" >&2
+              fi
+
+              kubectl annotate hr "${FLOW_HR_NAME}" \
+                -n "${FLOW_HR_NAMESPACE}" \
+                "reconcile.fluxcd.io/requestedAt=$(date +%s)" \
+                --overwrite || true
+            else
+              echo "[catalyst-api-env-patch] #4563 SKIP: HR ${FLOW_HR_NAMESPACE}/${FLOW_HR_NAME} not present (flow-server not installed on this Sovereign)"
+            fi
 
             # G61 Phase 2 (was Step 07 pre-G61): set env on the
             # catalyst-api Deployment so it routes GitOps queries to

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -1054,4 +1054,28 @@ if ! printf '%s\n' "$bastion_stanza" | grep -q 'insecure_skip_verify: true'; the
 fi
 echo "  PASS (v1 cold-start mirror carries robot\$openova-bot harbor-robot-token auth for harbor.openova.io [+ the bastion host on Huawei]; pivot script substitutes the placeholder from the in-cluster Secret)"
 
+echo "[cutover-contract] Case 32: Step-07 ALSO pivots the bp-openova-flow-server HR global.imageRegistry to local Harbor (#4563, Refs #3379)"
+# openova-flow-server is a SEPARATE HelmRelease (slot 56) whose chart honours
+# global.imageRegistry. Step-07 historically patched ONLY bp-catalyst-platform,
+# so openova-flow-server (and catalyst-ui, before its chart was templated) kept
+# the literal ghcr.io image — under the 600s deny-egress hold the anonymous-
+# token fetch to ghcr.io is blocked -> 401 ImagePullBackOff -> step-08 fresh-
+# pull proof FATALs. Step-07 MUST now patch the flow-server HR too (live HR
+# patch + durable Gitea edit) so the residual tether pivots to local Harbor.
+step07_block="$(awk '/cutover-step-07-catalyst-api-env-patch/{c=1} c{print} c&&/cutover-order: "8"/{exit}' "$TMP/render.yaml")"
+[ -n "$step07_block" ] || step07_block="$(cat "$TMP/render.yaml")"
+if ! printf '%s\n' "$step07_block" | grep -q 'FLOW_HR_NAME="bp-openova-flow-server"'; then
+  echo "FAIL: Step-07 does not define FLOW_HR_NAME=bp-openova-flow-server — the flow-server HR is never pivoted, its ghcr.io image 401s under deny-egress and step-08 fresh-pull FATALs (#4563)" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$step07_block" | grep -q 'kubectl patch hr "${FLOW_HR_NAME}"'; then
+  echo "FAIL: Step-07 does not kubectl-patch the flow-server HR spec.values.global.imageRegistry (#4563)" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$step07_block" | grep -q '56-bp-openova-flow-server.yaml'; then
+  echo "FAIL: Step-07 does not durably edit the slot-56 source-of-truth in local Gitea — the live HR patch is reverted on the next Flux reconcile (#4563)" >&2
+  exit 1
+fi
+echo "  PASS (Step-07 pivots bp-openova-flow-server HR global.imageRegistry live + durably edits slot-56; catalyst-ui pivots via bp-catalyst-platform's templated ui-deployment.yaml)"
+
 echo "[cutover-contract] All gates green."

--- a/products/catalyst/chart/.helmignore
+++ b/products/catalyst/chart/.helmignore
@@ -45,3 +45,7 @@ templates/api-deployment-kustomize.yaml
 # for the contabo-mkt raw-Kustomize path). Helm renders only the templated
 # api-priorityclass.yaml; Kustomize renders only this literal one.
 templates/api-priorityclass-kustomize.yaml
+# #4563: Kustomize-mode sibling of ui-deployment.yaml (literal catalyst-ui
+# image ref for the contabo-mkt raw-Kustomize path). Helm renders only the
+# templated ui-deployment.yaml; Kustomize renders only this literal one.
+templates/ui-deployment-kustomize.yaml

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,13 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.928 — #4563 (Refs #3379, cutover step-08 fresh-pull, 2026-06-27):
+#   catalyst-ui Deployment image is now templated through
+#   global.imageRegistry (ui-deployment.yaml) exactly like catalyst-api —
+#   so the cutover step-07 HR patch pivots catalyst-ui to the local Harbor
+#   and the 600s deny-egress fresh-pull proof stops FATALing on the
+#   residual ghcr.io tether. Literal Kustomize sibling ui-deployment-
+#   kustomize.yaml (contabo-mkt path) added + .helmignore + kustomization
+#   + deploy-bot sed updated in lockstep.
 # 1.4.925 — #4553 (Pillar-4 North-Star walk, 2026-06-27): catalog-seed
 #   bp-agenity spec.version + source.version 0.5.13 -> 0.5.14 (lockstep with
 #   products/agenity/chart 0.5.14) — the agenity httpRoute.parentRef default now
@@ -3341,7 +3349,7 @@ name: bp-catalyst-platform
 #   sovereign-fqdn) so GET /catalog/regions returns the Sovereign's REAL
 #   regions instead of [] — the marketplace BCP picker stops falling back to
 #   the hardcoded Hetzner list.
-version: 1.4.927
+version: 1.4.928
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/
 #   platform/crossplane chart + blueprint.yaml + bootstrap-kit slot 04). crossplane-core
 #   was still OOMKilled (CrashLoopBackOff, 55 restarts, exit 137, killed ~90s after start)

--- a/products/catalyst/chart/templates/kustomization.yaml
+++ b/products/catalyst/chart/templates/kustomization.yaml
@@ -7,7 +7,11 @@ resources:
   # dangles a non-existent class. Cluster-scoped; the namespace: catalyst
   # transformer above is a no-op on it.
   - api-priorityclass-kustomize.yaml
-  - ui-deployment.yaml
+  # #4563: ui-deployment-kustomize.yaml (literal image) is the Kustomize-
+  # mode sibling. ui-deployment.yaml is now the Helm-templated sibling
+  # ({{ .Values.global.imageRegistry }}) which kustomize-controller can't
+  # render — mirrors the api-deployment-kustomize.yaml split.
+  - ui-deployment-kustomize.yaml
   - ui-service.yaml
   - api-deployment-kustomize.yaml
   - api-deployments-pvc.yaml

--- a/products/catalyst/chart/templates/ui-deployment-kustomize.yaml
+++ b/products/catalyst/chart/templates/ui-deployment-kustomize.yaml
@@ -1,0 +1,70 @@
+# G61-followup #4563 (Refs #2612 #4563, 2026-06-27): Kustomize-mode
+# sibling of ui-deployment.yaml. Contabo-mkt applies this via raw
+# Kustomize (kustomize-controller does not render Helm templates). The
+# Helm sibling (ui-deployment.yaml) uses {{ .Values.global.imageRegistry }}
+# so Sovereign-Helm honours the post-cutover registry override.
+#
+# This file uses a literal `ghcr.io/...` image ref so Kustomize on
+# contabo applies it unchanged. CI auto-bumps the literal here AND the
+# values.yaml `images.catalystUi.tag` so contabo + Sovereigns roll to
+# the same SHA. Same Kustomize-vs-Helm split pattern as
+# api-deployment-kustomize.yaml (issue #2612).
+#
+# Kept out of the Helm-rendered bundle via .helmignore.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: catalyst-ui
+  labels:
+    app.kubernetes.io/name: catalyst-ui
+    app.kubernetes.io/component: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: catalyst-ui
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: catalyst-ui
+        policy.cilium.io/enforced: "true"  # Wave 5.121 #2466 — kyverno cilium-l7-mtls policy
+    spec:
+      imagePullSecrets:
+        - name: ghcr-pull
+      containers:
+        - name: catalyst-ui
+          # Literal image ref — required for the contabo-mkt Kustomize
+          # path (kustomize-controller doesn't render Helm templates).
+          # Auto-bumped by .github/workflows/catalyst-build.yaml's deploy
+          # step on every push to main, so contabo rolls to the latest
+          # catalyst-ui SHA. Sovereigns consume the Helm sibling.
+          image: "ghcr.io/openova-io/openova/catalyst-ui:7d35005"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 1001

--- a/products/catalyst/chart/templates/ui-deployment.yaml
+++ b/products/catalyst/chart/templates/ui-deployment.yaml
@@ -20,12 +20,25 @@ spec:
         - name: ghcr-pull
       containers:
         - name: catalyst-ui
-          # Literal image ref — required for the contabo-mkt Kustomize
-          # path (kustomize-controller doesn't render Helm templates).
-          # Auto-bumped by .github/workflows/catalyst-build.yaml's deploy
-          # step on every push to main, so Sovereigns AND contabo both
-          # roll to the latest catalyst-ui SHA.
-          image: "ghcr.io/openova-io/openova/catalyst-ui:7d35005"
+          # G61-followup #4563 (2026-06-27): templated image ref so
+          # Sovereign-Helm honours `global.imageRegistry` override.
+          # Post-cutover step-07 patches HelmRelease.spec.values.global.
+          # imageRegistry = registry.<sovereign-fqdn> on bp-catalyst-
+          # platform → this catalyst-ui Pod restarts pulling through the
+          # local Harbor (image natively pushed there by cutover step-03
+          # harbor-prewarm). Pre-#4563 the literal `ghcr.io/...` ref did
+          # NOT honour the pivot, so under the 600s deny-egress hold the
+          # ghcr.io ref's anonymous-token fetch was blocked → 401
+          # ImagePullBackOff → step-08 fresh-pull proof FATALed.
+          # Mirrors api-deployment.yaml L219.
+          #
+          # Contabo-mkt Kustomize path consumes ui-deployment-kustomize.
+          # yaml (literal ghcr.io ref, .helmignore'd from the Sovereign
+          # bundle) because kustomize-controller can't render Helm
+          # templates. CI auto-bumps both the literal in the kustomize
+          # file AND the values.yaml `images.catalystUi.tag` so contabo
+          # and Sovereigns roll together.
+          image: "{{ if .Values.global.imageRegistry }}{{ .Values.global.imageRegistry }}{{ else }}{{ .Values.images.registry }}{{ end }}/{{ .Values.images.organization }}/catalyst-ui:{{ .Values.images.catalystUi.tag }}"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080


### PR DESCRIPTION
## Summary

Closes the LAST identified fault blocking the Pillar-5 sovereignty cutover (#3379). The cutover on `c39f0cd4455b7a46` reached step-08 with the **600s deny-egress hold PASSING** (github/ghcr/harbor/console all unreachable=000, denied), but the #3695/#3647 **fresh-pull-under-deny-egress proof FATALed**: `catalyst-ui` and `openova-flow-server` Deployments hardcoded `ghcr.io/...` image literals that did **not** honour `global.imageRegistry`, so the step-07 registry pivot left them on ghcr.io → under deny-egress the anonymous-token fetch was blocked → 401 ImagePullBackOff → step-08 FATAL → `cutoverComplete` stays false.

## Fix

**catalyst-ui** (`products/catalyst/chart`, 1.4.926→1.4.927):
- `ui-deployment.yaml` image templated through `global.imageRegistry` (mirrors `api-deployment.yaml` L219) — the existing step-07 patch on the `bp-catalyst-platform` HR now pivots catalyst-ui to `registry.<sov-fqdn>` automatically.
- New `ui-deployment-kustomize.yaml` (literal image) for the contabo-mkt raw-Kustomize path (kustomize-controller can't render Helm templates). `.helmignore` excludes it from the Sovereign Helm bundle; `kustomization.yaml` references it instead of the templated file. Mirrors the `api-deployment` dual-file split.
- `catalyst-build.yaml` deploy-bot seds the kustomize sibling (the templated file has no sed-matchable literal); Sovereigns roll via the `values.yaml` `catalystUi.tag` awk-bump; deploy-bump paths updated.

**openova-flow-server** (`platform/openova-flow-server/chart`, 0.2.4→0.2.5):
- `_helpers.tpl` image helper honours `global.imageRegistry` (swaps the ghcr.io prefix for the pivot registry). slot-56 ships the `global.imageRegistry: ''` seam.
- It is a SEPARATE HR that step-07 never patched → cutover step-07 (bp-self-sovereign-cutover 0.1.84→0.1.85) now ALSO patches the `bp-openova-flow-server` HR (live patch + durable Gitea edit of slot-56), mirroring the bp-catalyst-platform pivot.

**step-08 correctness:** slot-06a sets `egressTest.localRegistryHostSubstr='registry.'` (the real Sovereign Harbor host is `registry.<fqdn>`, not `harbor.<fqdn>`) so the #3695 proof classifies the pivoted workloads as local on the first scan.

step-03 harbor-prewarm already native-pushes these images (running-pods ∪ declared-templates union grep `^ghcr.io/openova-io/`), so they exist in local Harbor for the fresh pull.

## Verification
- `helm template` renders catalyst-ui + flow-server correctly with AND without `global.imageRegistry` (ghcr.io fallback / registry.<fqdn> pivot). Kustomize build of the contabo path stays valid (one catalyst-ui Deployment, literal image).
- deploy-bot sed bumps the kustomize sibling, leaves the templated file untouched.
- `helm lint` green on all three charts; pin-sync audit PASS (all three pins lockstep).
- Cutover contract test green incl. new **Case 32** asserting the step-07 flow-server pivot (verified it FAILS without the fix).

Refs #4563 #3379