### PR TITLE
fix(provisioning #4567): drop ciliumnetworkpolicy.yaml from the funnel apps kustomization (it lives in host-apps/) — unwedge purchased-app deploy

### DIFF
--- a/core/services/provisioning/gitops/perorg_apps_tree.go
+++ b/core/services/provisioning/gitops/perorg_apps_tree.go
@@ -21,9 +21,21 @@ const PerOrgAppsDir = "vcluster/apps"
 // preserve them in the apps kustomization (they enforce intra-Org isolation),
 // so MergePerOrgAppsKustomization keeps them in the resources list even though
 // the funnel does not own/regenerate them.
+//
+// #4567: ONLY `networkpolicy.yaml` lives in `vcluster/apps/`. The Cilium
+// `ciliumnetworkpolicy.yaml` lives in `vcluster/host-apps/` (NOT `apps/`) — the
+// #4292 split deliberately keeps the CNP out of the apps tree because a
+// `cilium.io/v2` doc in the kubeConfig-targeted `vcluster/apps` Kustomization
+// wedges the vcluster-tier reconcile (no Cilium CRD inside the vcluster). The
+// org-controller's own `vcluster/host-apps` Kustomization delivers the CNP.
+// Listing it here made the funnel emit a `vcluster/apps/kustomization.yaml`
+// that references a non-existent `vcluster/apps/ciliumnetworkpolicy.yaml` →
+// `kustomize build failed: …: no such file or directory` → the ENTIRE apps
+// Kustomization failed → the purchased app + its db dependency never deployed
+// (host-tier S/free funnel Orgs). The CNP must NOT be re-listed in the apps
+// tree by the funnel.
 var perOrgAppsBaselineDocs = []string{
 	"networkpolicy.yaml",
-	"ciliumnetworkpolicy.yaml",
 }
 
 // GeneratePerOrgAppsTree renders the customer's purchased Applications for a
@@ -107,8 +119,9 @@ func isHostHelmReleaseAppFile(path, hostPrefix string) bool {
 }
 
 // MergePerOrgAppsKustomization rebuilds the `vcluster/apps/kustomization.yaml`
-// resources list so it enumerates BOTH the org-controller boundary baseline
-// (networkpolicy.yaml + ciliumnetworkpolicy.yaml) AND the funnel's app docs.
+// resources list so it enumerates the org-controller boundary baseline
+// (networkpolicy.yaml — the ONLY baseline that lives in `vcluster/apps/`) AND
+// the funnel's app docs.
 //
 // `existing` is the current kustomization.yaml content read from the per-Org
 // repo (empty if absent). Any resource already listed there is preserved
@@ -116,7 +129,23 @@ func isHostHelmReleaseAppFile(path, hostPrefix string) bool {
 // are force-included, and the new appDocs are unioned in. The result is
 // deterministic (sorted) so a re-render is byte-stable and the PutFile/commit
 // short-circuits when nothing changed.
+//
+// #4567: `ciliumnetworkpolicy.yaml` is force-EXCLUDED here even if a prior
+// (buggy) commit listed it in `existing` — the CNP file only ever exists in
+// `vcluster/host-apps/`, so referencing it from the apps kustomization breaks
+// the kustomize build for the WHOLE apps tree (→ purchased app never deploys).
+// Stripping it on every merge self-heals an already-broken per-Org repo on the
+// next cart install / reconcile.
 func MergePerOrgAppsKustomization(existing string, appDocs []string) string {
+	// excludedFromAppsTree are docs that must NEVER appear in
+	// `vcluster/apps/kustomization.yaml` because their file does not live in
+	// `vcluster/apps/` (the org-controller authors them under
+	// `vcluster/host-apps/`). Listing one makes kustomize build fail with
+	// "no such file or directory" and wedges the entire apps Kustomization.
+	excludedFromAppsTree := map[string]struct{}{
+		"ciliumnetworkpolicy.yaml": {},
+	}
+
 	resources := map[string]struct{}{}
 	for _, d := range perOrgAppsBaselineDocs {
 		resources[d] = struct{}{}
@@ -130,10 +159,16 @@ func MergePerOrgAppsKustomization(existing string, appDocs []string) string {
 		if name == "" || name == "kustomization.yaml" {
 			continue
 		}
+		if _, bad := excludedFromAppsTree[name]; bad {
+			continue // #4567: drop a stale CNP entry from a prior bad commit
+		}
 		resources[name] = struct{}{}
 	}
 	for _, d := range appDocs {
 		if d == "kustomization.yaml" {
+			continue
+		}
+		if _, bad := excludedFromAppsTree[d]; bad {
 			continue
 		}
 		resources[d] = struct{}{}

--- a/core/services/provisioning/gitops/perorg_apps_tree_test.go
+++ b/core/services/provisioning/gitops/perorg_apps_tree_test.go
@@ -58,9 +58,13 @@ func TestGeneratePerOrgAppsTree_WordpressCart(t *testing.T) {
 	}
 }
 
-// TestMergePerOrgAppsKustomization preserves the org-controller's NP/CNP
-// baseline AND adds the funnel's app docs, deterministically + idempotently.
+// TestMergePerOrgAppsKustomization preserves the org-controller's NP baseline
+// AND adds the funnel's app docs, deterministically + idempotently — and
+// #4567 force-EXCLUDES ciliumnetworkpolicy.yaml (which lives in host-apps/, not
+// apps/, so listing it wedges the kustomize build → app never deploys).
 func TestMergePerOrgAppsKustomization(t *testing.T) {
+	// A stale/buggy repo that already listed the CNP in the apps tree — the
+	// merge must SELF-HEAL by dropping it (#4567).
 	existing := `apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -69,10 +73,15 @@ resources:
 `
 	out := MergePerOrgAppsKustomization(existing, []string{"app-wordpress.yaml", "db-mysql.yaml"})
 
-	for _, want := range []string{"networkpolicy.yaml", "ciliumnetworkpolicy.yaml", "app-wordpress.yaml", "db-mysql.yaml"} {
+	for _, want := range []string{"networkpolicy.yaml", "app-wordpress.yaml", "db-mysql.yaml"} {
 		if !strings.Contains(out, "- "+want) {
 			t.Errorf("merged kustomization missing %q:\n%s", want, out)
 		}
+	}
+	// #4567: the CNP must NOT survive into the apps tree, even when a prior bad
+	// commit listed it.
+	if strings.Contains(out, "- ciliumnetworkpolicy.yaml") {
+		t.Errorf("ciliumnetworkpolicy.yaml leaked into vcluster/apps/kustomization.yaml — it lives in host-apps/, so this breaks the kustomize build:\n%s", out)
 	}
 
 	// Idempotent: merging the same docs into the produced output is byte-stable.
@@ -81,10 +90,13 @@ resources:
 		t.Errorf("MergePerOrgAppsKustomization not idempotent:\n--- first ---\n%s\n--- second ---\n%s", out, out2)
 	}
 
-	// Empty existing seeds the baseline from scratch.
+	// Empty existing seeds the baseline from scratch — networkpolicy.yaml only.
 	fresh := MergePerOrgAppsKustomization("", []string{"app-wordpress.yaml"})
-	if !strings.Contains(fresh, "- networkpolicy.yaml") || !strings.Contains(fresh, "- ciliumnetworkpolicy.yaml") {
-		t.Errorf("empty-existing merge must seed the NP/CNP baseline:\n%s", fresh)
+	if !strings.Contains(fresh, "- networkpolicy.yaml") {
+		t.Errorf("empty-existing merge must seed the networkpolicy baseline:\n%s", fresh)
+	}
+	if strings.Contains(fresh, "- ciliumnetworkpolicy.yaml") {
+		t.Errorf("empty-existing merge must NOT seed the CNP into the apps tree (#4567):\n%s", fresh)
 	}
 	if !strings.Contains(fresh, "- app-wordpress.yaml") {
 		t.Errorf("empty-existing merge must include the new app doc:\n%s", fresh)

--- a/core/services/provisioning/handlers/perorg_cart_install_4384_test.go
+++ b/core/services/provisioning/handlers/perorg_cart_install_4384_test.go
@@ -164,12 +164,18 @@ func TestApplyTenantChangePerOrg_CommitsToPerOrgRepo_4384(t *testing.T) {
 		if f.Path == "vcluster/apps/kustomization.yaml" {
 			sawKust = true
 			dec, _ := base64.StdEncoding.DecodeString(f.Content)
-			// The merged kustomization preserves the org-controller NP/CNP
+			// The merged kustomization preserves the org-controller NP
 			// baseline AND lists the new app.
-			for _, want := range []string{"networkpolicy.yaml", "ciliumnetworkpolicy.yaml", "app-wordpress.yaml"} {
+			for _, want := range []string{"networkpolicy.yaml", "app-wordpress.yaml"} {
 				if !strings.Contains(string(dec), want) {
 					t.Errorf("merged kustomization missing %q:\n%s", want, dec)
 				}
+			}
+			// #4567: the CNP lives in vcluster/host-apps/, not apps/ — it must
+			// NOT be listed in the apps kustomization (else the kustomize build
+			// fails on the missing file and the purchased app never deploys).
+			if strings.Contains(string(dec), "ciliumnetworkpolicy.yaml") {
+				t.Errorf("apps kustomization wrongly lists ciliumnetworkpolicy.yaml (a host-apps/ file) — breaks the build:\n%s", dec)
 			}
 		}
 	}


### PR DESCRIPTION
## Fault (live, dep 91dc05917e44d1c1, UAT funnel rows 89/90/95 walk 2026-06-27)

The funnel/day-2 cart-install force-listed `ciliumnetworkpolicy.yaml` in `vcluster/apps/kustomization.yaml`, but the org-controller authors that file into `vcluster/host-apps/` (the #4292 split keeps the CNP out of the kubeConfig-targeted apps tree — a `cilium.io/v2` doc there has no CRD inside the vcluster). The apps Kustomization referenced a non-existent file:

```
catalyst-tenant-walk-stranger-one-apps   False
  kustomize build failed: accumulating resources from 'ciliumnetworkpolicy.yaml':
  open .../vcluster/apps/ciliumnetworkpolicy.yaml: no such file or directory
```

The whole apps Kustomization failed → the purchased WordPress + its mysql dependency never deployed:
```
ERROR step="Installing mysql (dependency)" error="app mysql not ready in walk-stranger-one after 10m0s"
ERROR day-2 install: pod not ready app=wordpress error="app wordpress not ready in walk-stranger-one after 10m0s"
```
Reproduced on BOTH fresh funnel Orgs this walk (S-plan host-tier).

## Root cause
`core/services/provisioning/gitops/perorg_apps_tree.go` — `perOrgAppsBaselineDocs` wrongly listed `ciliumnetworkpolicy.yaml`. Per the org-controller manifest set (#4292, asserted in `core/controllers/organization/internal/gitops/manifests_test.go`): `networkpolicy.yaml` → `vcluster/apps/`; `ciliumnetworkpolicy.yaml` → `vcluster/host-apps/` (and the test explicitly forbids the CNP from `vcluster/apps/kustomization.yaml`). The funnel's baseline-docs list was stale.

## Fix
- Drop `ciliumnetworkpolicy.yaml` from `perOrgAppsBaselineDocs` (keep `networkpolicy.yaml`).
- `MergePerOrgAppsKustomization` force-EXCLUDES the CNP even when a prior buggy commit listed it in `existing`, so the next cart-install / reconcile self-heals an already-broken per-Org repo.
- Update the two tests that encoded the bug.

## Validation
- `go build ./...`, `gitops` + `handlers` packages green.
- Live-confirmed root cause on dep 91dc0591 (kustomize build error verbatim; CNP present only in `vcluster/host-apps/`).

Terminal blocker for funnel rows 89/90 (app card Running + app serves at its FQDN) on host-tier funnel Orgs.

Refs #4567, Refs #3376, Refs #4384.

🤖 Generated with [Claude Code](https://claude.com/claude-code)