### PR TITLE
fix(bp-agenity): chart-managed bp-oidc-gate companion for every per-Org agenity host — durable zero-click SSO + no-paste (0.5.15)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1203,7 +1203,12 @@ spec:
       # 1.4.928 — #4563: catalyst-ui image templated via global.imageRegistry
       #   so cutover step-07 pivots it to local Harbor (kills step-08 fresh-
       #   pull FATAL on the residual ghcr.io tether). Lockstep w/ Chart.yaml.
-      version: 1.4.930
+      # 1.4.931 — #4553/#4556: catalog-seed bp-agenity 0.5.14 -> 0.5.15 — the
+      #   chart now renders a bp-oidc-gate companion (durable zero-click SSO
+      #   gate + spaTokenSeed no-paste) in front of every per-Org agenity host
+      #   (oidcGate.enabled default true), replacing the agnstar walk's
+      #   hand-created live instance. Lockstep w/ Chart.yaml + products/agenity.
+      version: 1.4.931
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/agenity/blueprint.yaml
+++ b/products/agenity/blueprint.yaml
@@ -6,7 +6,12 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.5.14
+  # 0.5.15 (#4553/#4556): the chart now renders a bp-oidc-gate companion in
+  # front of every per-Org agenity host (oidcGate.enabled default true) — the
+  # durable zero-click SSO gate + spaTokenSeed no-paste landing, chart-managed
+  # rather than the agnstar walk's hand-created live instance. Lockstep with
+  # products/agenity/chart/Chart.yaml + the catalog-seed pin.
+  version: 0.5.15
   card:
     title: Agenity
     summary: |

--- a/products/agenity/chart/Chart.yaml
+++ b/products/agenity/chart/Chart.yaml
@@ -124,6 +124,23 @@ type: application
 # `ingress` entity that no K8s NetworkPolicy can admit — without the CNP every
 # external hit to agenity.<slug>.<pool> returned envoy 503 "upstream connect
 # error". appVersion (dashboard image) stays 0.9.6 — image bytes unchanged.
+# 0.5.15 (#4553/#4556, durable zero-click SSO gate): render a bp-oidc-gate
+# COMPANION (templates/oidc-gate.yaml) in front of EVERY per-Org agenity host,
+# gated behind oidcGate.enabled (default true). The agnstar North-Star walk
+# hand-created a drift-disabled `oidc-gate-agenity-agnstar` HelmRelease, so a
+# fresh agenity Org / a re-prov got NO gate (the host served the dashboard
+# UN-gated). Templating the gate AS PART OF the agenity install makes the gate
+# arrive WITH agenity — chart-managed, drift-detected, zero hand-creation. The
+# companion renders the proven #3374 resource set (cookie Secret +
+# AppRegistration ConfigMap for bp-sso-bridge + client-secret ExternalSecret +
+# oauth2-proxy Deployment + Service + HTTPRoute owning the agenity host with the
+# #4556 spaTokenSeed bare-root -> /app/?token=sso redirect + a gateway-ingress
+# CNP). The gate's upstream is the agenity Service; when it renders, the chart's
+# OWN HTTPRoute (templates/httproute.yaml) is SUPPRESSED (two routes on one host
+# is undefined routing). Hostname + clientId derive from httpRoute.hostnames[0]
+# / sovereignFqdn (fail-closed per Inviolable #4 — no host -> no gate). The
+# org-gitops emitter pins oidcGate.clientId=agenity-<slug> per Org. Template +
+# values + helper change; appVersion (image) UNCHANGED.
 # 0.5.14 (#4553, Pillar-4 North-Star walk on omantel.biz dep 91dc05917e44d1c1):
 # httpRoute.parentRef default catalyst-gateway/catalyst-system -> the REAL
 # Sovereign console gateway cilium-gateway-console/kube-system. There is NO
@@ -132,7 +149,7 @@ type: application
 # same gateway bp-wordpress-tenant + the org console route attach to, #4054).
 # The old default rendered Accepted=False/InvalidHTTPRoute and the host 404'd
 # until the parentRef was hand-overridden. appVersion (image) unchanged.
-version: 0.5.14
+version: 0.5.15
 # Bumped appVersion 0.9.6 -> 0.9.7 (#4180): 0.9.7 is the FIRST image whose
 # /app/ mounts the WORKSPACES dashboard (Dashboardws bundle) rather than the
 # archaic single-column Dashboard.svelte. It is built from agenity#752

--- a/products/agenity/chart/templates/_helpers.tpl
+++ b/products/agenity/chart/templates/_helpers.tpl
@@ -32,3 +32,51 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "agenity.image" -}}
 {{- printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) -}}
 {{- end -}}
+
+{{- /*
+agenity.gateHostname — the public hostname the oidc-gate companion (and the
+chart's own HTTPRoute) owns. The org-gitops emitter passes the per-Org host as
+httpRoute.hostnames[0] (agenity.<slug>.<pool>); else derive agenity.<fqdn> from
+sovereignFqdn; else "" (fail-closed — Inviolable Principle #4, the gate then
+renders nothing). Single source of truth shared by the gate + the suppression
+guard so both agree on the host.
+*/ -}}
+{{- define "agenity.gateHostname" -}}
+{{- if .Values.httpRoute.hostnames -}}
+{{- index .Values.httpRoute.hostnames 0 -}}
+{{- else if .Values.sovereignFqdn -}}
+{{- printf "agenity.%s" .Values.sovereignFqdn -}}
+{{- end -}}
+{{- end -}}
+
+{{- /*
+agenity.gateEnabled — "true" only when the SSO gate is requested AND a hostname
+resolves (no host → fail-closed, the gate would render nothing useful). Drives
+BOTH templates/oidc-gate.yaml (render the gate) AND templates/httproute.yaml
+(suppress the chart's own route so the gate owns the host).
+*/ -}}
+{{- define "agenity.gateEnabled" -}}
+{{- if and .Values.oidcGate.enabled (include "agenity.gateHostname" .) -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{- /*
+agenity.gateClientId — the KC client id the gate registers. Explicit
+oidcGate.clientId wins (the org-gitops emitter pins agenity-<slug>); else
+derive agenity-<firstLabel> from the gate hostname (agenity.<slug>.<pool> →
+agenity-<slug>); else "agenity-gate".
+*/ -}}
+{{- define "agenity.gateClientId" -}}
+{{- if .Values.oidcGate.clientId -}}
+{{- .Values.oidcGate.clientId -}}
+{{- else -}}
+{{- $host := include "agenity.gateHostname" . -}}
+{{- $labels := splitList "." $host -}}
+{{- if gt (len $labels) 1 -}}
+{{- printf "agenity-%s" (index $labels 1) -}}
+{{- else -}}
+agenity-gate
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/products/agenity/chart/templates/httproute.yaml
+++ b/products/agenity/chart/templates/httproute.yaml
@@ -1,4 +1,12 @@
-{{- if .Values.httpRoute.enabled }}
+{{- /*
+#4553 — when the oidc-gate companion is enabled (the default for a per-Org
+install) the gate (templates/oidc-gate.yaml) OWNS the agenity hostname and
+carries the bare-root → /app/?token=<sentinel> spaTokenSeed redirect. Two
+HTTPRoutes on one hostname is undefined routing, so suppress this route then.
+It renders ONLY for a non-gated test install (oidcGate.enabled=false), serving
+the host un-gated with the chart's own bare-root → /app/ redirect (pre-#4553).
+*/ -}}
+{{- if and .Values.httpRoute.enabled (not (include "agenity.gateEnabled" .)) }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/products/agenity/chart/templates/oidc-gate.yaml
+++ b/products/agenity/chart/templates/oidc-gate.yaml
@@ -1,0 +1,341 @@
+{{- /*
+bp-agenity — zero-click SSO gate companion (#4553/#4556).
+
+Renders a bp-oidc-gate-shaped oauth2-proxy IN FRONT OF the per-Org agenity
+host so EVERY agenity install automatically gets the Sovereign zero-click SSO
+contract (fresh browser → bare URL → Keycloak sovereign realm, silent via
+catalyst-pin → signed in) AND the spaTokenSeed no-paste landing.
+
+WHY HERE (not a hand-created live instance): the agnstar North-Star walk
+(#4553) hand-created a drift-disabled `oidc-gate-agenity-agnstar` HelmRelease,
+so a fresh agenity Org / a re-prov got NO gate (the host served the dashboard
+UN-gated). Templating the gate AS PART OF the bp-agenity chart makes the gate
+arrive WITH the agenity install — chart-managed, drift-detected, zero hand-
+creation. The resource set is byte-equivalent to a bp-oidc-gate instances[]
+entry (#3374): cookie Secret + AppRegistration ConfigMap (bp-sso-bridge mints
+the KC client) + ExternalSecret (client secret from OpenBao) + oauth2-proxy
+Deployment (the WALKED hubble-ui arg set, #2744) + Service + HTTPRoute that
+OWNS the agenity hostname with the spaTokenSeed redirect + a CNP admitting the
+gateway entity to the gate pod.
+
+Renders only when `oidcGate.enabled` AND a hostname resolves (agenity.gateEnabled,
+fail-closed per Inviolable Principle #4). When it renders, the chart's own
+HTTPRoute (templates/httproute.yaml) is suppressed (two routes on one host is
+undefined routing — the gate owns the host).
+*/ -}}
+{{- if include "agenity.gateEnabled" . }}
+{{- $hostname := include "agenity.gateHostname" . }}
+{{- $cid := include "agenity.gateClientId" . }}
+{{- $gateName := printf "oidc-gate-%s" $cid }}
+{{- $g := .Values.oidcGate }}
+{{- $issuer := printf "https://auth.%s/realms/%s" .Values.sovereignFqdn $g.realm }}
+{{- /*
+The agenity Service the gate proxies to (same chart release, this namespace).
+Upstream host = <fullname>.<namespace>.svc.cluster.local:<service.port>.
+*/ -}}
+{{- $upstream := printf "http://%s.%s.svc.cluster.local:%v" (include "agenity.fullname" .) .Release.Namespace .Values.service.port }}
+{{- /*
+#3844 — backchannel-via-internal-Service. When keycloakInternalURL is set the
+gate SKIPS discovery against the public issuer EIP (unhairpinnable inside the
+cluster on Huawei/kom4dc → CrashLoop) and dials the in-cluster keycloak Service
+for redeem/jwks/userinfo, keeping the browser legs public.
+*/ -}}
+{{- $kcInternal := trimSuffix "/" ($g.keycloakInternalURL | default "") }}
+{{- $internalRealm := "" }}
+{{- if $kcInternal }}{{- $internalRealm = printf "%s/realms/%s" $kcInternal $g.realm }}{{- end }}
+---
+# ── cookie secret (gate-local; lookup-or-generate, survives uninstall) ──
+{{- $existing := lookup "v1" "Secret" .Release.Namespace (printf "%s-cookie" $gateName) }}
+{{- $cookieSecret := "" }}
+{{- if $existing }}
+{{- $cookieSecret = index $existing.data "cookie-secret" | default "" | b64dec }}
+{{- end }}
+{{- if not $cookieSecret }}{{- $cookieSecret = randAlphaNum 32 }}{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-cookie" $gateName | quote }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    {{- include "agenity.labels" . | nindent 4 }}
+    catalyst.openova.io/component: {{ $gateName | quote }}
+type: Opaque
+stringData:
+  cookie-secret: {{ $cookieSecret | quote }}
+---
+# ── AppRegistration — bp-sso-bridge mints/adopts the KC client ─────────
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-sso-registration" $gateName | quote }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agenity.labels" . | nindent 4 }}
+    sso.openova.io/app-registration: {{ $cid | quote }}
+data:
+  realm: {{ $g.realm | quote }}
+  client.json: |
+    {
+      "clientId": {{ $cid | quote }},
+      "name": {{ printf "Agenity SSO gate — %s" $cid | quote }},
+      "enabled": true,
+      "publicClient": false,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "redirectUris": [
+        "https://{{ $hostname }}/oauth2/callback"
+      ],
+      "webOrigins": [
+        "https://{{ $hostname }}"
+      ],
+      "defaultClientScopes": ["web-origins", "acr", "profile", "roles", "email", "groups"],
+      "protocolMappers": [
+        {
+          "name": {{ printf "audience-%s" $cid | quote }},
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "config": {
+            "included.client.audience": {{ $cid | quote }},
+            "id.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ],
+      "attributes": {
+        "access.token.lifespan": "900"
+      }
+    }
+{{- if .Capabilities.APIVersions.Has "external-secrets.io/v1beta1" }}
+---
+# ── client secret — the LIVE KC value via bp-sso-bridge + OpenBao ──────
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ printf "%s-oidc" $gateName | quote }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agenity.labels" . | nindent 4 }}
+    bp-sso-bridge.openova.io/consumer: bp-oidc-gate
+spec:
+  refreshInterval: {{ $g.refreshInterval | default "1h" }}
+  secretStoreRef:
+    name: {{ $g.externalSecretStoreName | default "vault-region1" }}
+    kind: ClusterSecretStore
+  target:
+    name: {{ printf "%s-oidc" $gateName | quote }}
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        client-secret: "{{ "{{ .client_secret }}" }}"
+  data:
+    - secretKey: client_secret
+      remoteRef:
+        key: {{ printf "sso/%s/%s" $g.realm $cid | quote }}
+        property: client_secret
+{{- end }}
+---
+# ── oauth2-proxy Deployment ────────────────────────────────────────────
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $gateName | quote }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agenity.labels" . | nindent 4 }}
+    catalyst.openova.io/component: {{ $gateName | quote }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bp-oidc-gate
+      catalyst.openova.io/component: {{ $gateName | quote }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bp-oidc-gate
+        catalyst.openova.io/component: {{ $gateName | quote }}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
+        seccompProfile:
+          type: RuntimeDefault
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: oauth2-proxy
+          image: {{ printf "%s/%s:%s" $g.image.registryMirror $g.image.repository $g.image.tag | quote }}
+          imagePullPolicy: {{ $g.image.pullPolicy }}
+          args:
+            - --http-address=0.0.0.0:4180
+            - --provider=keycloak-oidc
+            # PUBLIC issuer — `iss`-claim validation (+ discovery when not
+            # skipped). KC_HOSTNAME is pinned public by bp-keycloak so tokens
+            # carry this `iss` even when the backchannel is dialed in-cluster.
+            - --oidc-issuer-url={{ $issuer }}
+            - --client-id={{ $cid }}
+            - --redirect-url=https://{{ $hostname }}/oauth2/callback
+            - --upstream={{ $upstream }}
+            - --email-domain=*
+            - --scope=openid profile email groups
+{{- if $internalRealm }}
+            # #3844 — skip discovery against the public EIP (unhairpinnable
+            # from inside the cluster on Huawei/kom4dc); dial the in-cluster
+            # keycloak Service for the backchannel legs.
+            - --skip-oidc-discovery=true
+            - --redeem-url={{ $internalRealm }}/protocol/openid-connect/token
+            - --oidc-jwks-url={{ $internalRealm }}/protocol/openid-connect/certs
+            - --profile-url={{ $internalRealm }}/protocol/openid-connect/userinfo
+{{- end }}
+            # Silent zero-click: the realm IDR defaultProvider plus the
+            # explicit kc_idp_hint cover both realm-config drift directions
+            # (G113 #2725 / G117.5 #2744).
+            - --login-url={{ $issuer }}/protocol/openid-connect/auth?kc_idp_hint=catalyst-pin
+            - --cookie-secure=true
+            - --cookie-name=_oidc_gate_{{ $cid | replace "-" "_" }}
+            - --skip-provider-button=true
+            - --set-xauthrequest=true
+            - --reverse-proxy=true
+            - --whitelist-domain={{ $hostname }}
+          env:
+            - name: OAUTH2_PROXY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ printf "%s-oidc" $gateName | quote }}
+                  key: client-secret
+            - name: OAUTH2_PROXY_COOKIE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ printf "%s-cookie" $gateName | quote }}
+                  key: cookie-secret
+          ports:
+            - name: http
+              containerPort: 4180
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: 4180
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: 4180
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            {{- toYaml $g.resources | nindent 12 }}
+---
+# ── Service ────────────────────────────────────────────────────────────
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $gateName | quote }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agenity.labels" . | nindent 4 }}
+    catalyst.openova.io/component: {{ $gateName | quote }}
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: bp-oidc-gate
+    catalyst.openova.io/component: {{ $gateName | quote }}
+  ports:
+    - name: http
+      port: 80
+      targetPort: 4180
+      protocol: TCP
+---
+# ── HTTPRoute — the gate OWNS the agenity hostname ─────────────────────
+# The agenity chart's own HTTPRoute is suppressed when the gate renders
+# (templates/httproute.yaml `and …enabled (not gateEnabled)`); two routes on
+# one host is undefined routing. The spaTokenSeed redirect below replaces the
+# chart's bare-root → /app/ redirect (it ADDS the ?token=<sentinel> seed so the
+# SPA lands authenticated with NO paste).
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $gateName | quote }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agenity.labels" . | nindent 4 }}
+    catalyst.openova.io/component: {{ $gateName | quote }}
+spec:
+  parentRefs:
+    - name: {{ .Values.httpRoute.parentRef.name | quote }}
+      namespace: {{ .Values.httpRoute.parentRef.namespace | quote }}
+  hostnames:
+    - {{ $hostname | quote }}
+  rules:
+{{- /*
+#4556 — SPA bootstrap-token SEED. 302 ONLY the bare root (Exact `/`), AFTER the
+gate's full KC SSO, to `<dashboardPath>?token=<value>`. The agenity `/app/` SPA
+ingests the `?token=` URL param on mount, seeds localStorage, strips the param,
+and renders the workspace authenticated — NO paste. value is a SENTINEL (the
+daemon runs authMode=none, so it is never verified). Loop-safe: only the Exact
+bare root is redirected; /app/, /_astro/*, /api/*, /healthz, the WS all fall
+through to the catch-all backend untouched. The port is the EXTERNAL HTTPS port
+(443), never the Gateway listener NodePort (a NodePort in Location hangs behind
+a cloud ELB). VERIFIED live on agnstar (#4556).
+*/}}
+    - matches:
+        - path:
+            type: Exact
+            value: /
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            port: {{ $g.spaTokenSeed.port | default 443 }}
+            statusCode: 302
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: {{ printf "%s?token=%s" ($g.spaTokenSeed.dashboardPath | default "/app/") ($g.spaTokenSeed.value | default "sso") | quote }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ $gateName | quote }}
+          port: 80
+{{- if and .Values.networkPolicy.enabled .Values.networkPolicy.ingress.allowGatewayEntity (.Capabilities.APIVersions.Has "cilium.io/v2") }}
+---
+# ── CiliumNetworkPolicy — admit the Cilium Gateway Envoy to the gate pod ──
+# The gate's HTTPRoute attaches the agenity hostname to cilium-gateway-console;
+# the gateway traffic carries the reserved `ingress` ENTITY identity no K8s
+# NetworkPolicy can match, so without this CNP the gateway→gate hop is
+# default-denied and the browser sees envoy 503 (the #4180/#3785/#3374 class).
+# ADDITIVE (unions with any K8s NetworkPolicy); gated on the cilium.io/v2
+# Capabilities check so the chart still renders on a CRD-less kind cluster.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ printf "%s-gateway-ingress" $gateName | quote }}
+  labels:
+    {{- include "agenity.labels" . | nindent 4 }}
+    catalyst.openova.io/component: {{ printf "%s-netpol" $gateName | quote }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: bp-oidc-gate
+      catalyst.openova.io/component: {{ $gateName }}
+  ingress:
+    - fromEntities:
+        - ingress
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP
+{{- end }}
+{{- end }}

--- a/products/agenity/chart/tests/oidc-gate-companion-render.sh
+++ b/products/agenity/chart/tests/oidc-gate-companion-render.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# bp-agenity — #4553/#4556 oidc-gate companion render audit.
+#
+# Every per-Org agenity install must AUTOMATICALLY get a chart-managed
+# bp-oidc-gate companion in front of its host (zero-click SSO + spaTokenSeed
+# no-paste landing) — NOT the agnstar walk's hand-created drift-disabled live
+# instance. This test asserts the durable contract:
+#
+#   1. GATED install (hostname set, oidcGate.enabled default true):
+#      - the gate's resource set renders (oauth2-proxy Deployment, Service,
+#        cookie Secret, AppRegistration ConfigMap, ExternalSecret, HTTPRoute);
+#      - the gate's HTTPRoute carries the #4556 spaTokenSeed Exact `/` ->
+#        /app/?token=sso 302 redirect;
+#      - the oauth2-proxy --upstream points at the agenity Service;
+#      - the client id derives `agenity-<slug>` from the host;
+#      - EXACTLY ONE HTTPRoute renders (the gate's) — the chart's OWN route is
+#        SUPPRESSED (two routes on one host is undefined routing);
+#      - a gateway-ingress CiliumNetworkPolicy admits the `ingress` entity.
+#   2. NON-gated install (oidcGate.enabled=false): NO gate resources; the
+#      chart's OWN HTTPRoute renders with the bare-root -> /app/ redirect.
+#   3. FAIL-CLOSED (no hostname, no sovereignFqdn): the gate renders nothing
+#      (Inviolable Principle #4) — no oidc-gate-* resources.
+#   4. clientId override is honoured.
+
+set -euo pipefail
+
+chart_dir="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+helm="${HELM_BIN:-helm}"
+
+HOST=agenity.agnstar.omani.homes
+FQDN=agnstar.omani.homes
+
+render_gated() {
+  "$helm" template agenity "$chart_dir" \
+    --set "sovereignFqdn=$FQDN" \
+    --set "httpRoute.hostnames[0]=$HOST" \
+    --api-versions "cilium.io/v2" \
+    --api-versions "external-secrets.io/v1beta1" \
+    "$@" 2>/dev/null
+}
+
+# ── Case 1: gated install renders the full companion + suppresses own route ──
+echo "[oidc-gate-companion] Case 1: gated per-Org install renders the gate + suppresses chart route"
+g="$(render_gated)"
+
+echo "$g" | grep -qE 'name: "oidc-gate-agenity-agnstar"'                  || { echo "FAIL: no gate Deployment/Service/HTTPRoute oidc-gate-agenity-agnstar" >&2; echo "$g" >&2; exit 1; }
+echo "$g" | grep -qE 'kind: Deployment'                                   || { echo "FAIL: no gate Deployment" >&2; exit 1; }
+echo "$g" | grep -qE 'name: "oidc-gate-agenity-agnstar-sso-registration"' || { echo "FAIL: no AppRegistration ConfigMap" >&2; exit 1; }
+echo "$g" | grep -qE 'sso.openova.io/app-registration: "agenity-agnstar"' || { echo "FAIL: AppRegistration not labelled for bp-sso-bridge" >&2; exit 1; }
+echo "$g" | grep -qE 'kind: ExternalSecret'                               || { echo "FAIL: no client-secret ExternalSecret (with external-secrets API)" >&2; exit 1; }
+echo "$g" | grep -qE 'key: "sso/sovereign/agenity-agnstar"'               || { echo "FAIL: ExternalSecret remoteRef not sso/sovereign/agenity-agnstar" >&2; exit 1; }
+echo "$g" | grep -qE 'name: "oidc-gate-agenity-agnstar-cookie"'           || { echo "FAIL: no gate cookie Secret" >&2; exit 1; }
+echo "$g" | grep -qE -- '--client-id=agenity-agnstar'                     || { echo "FAIL: oauth2-proxy --client-id not agenity-agnstar" >&2; exit 1; }
+echo "$g" | grep -qE -- '--upstream=http://agenity-bp-agenity\..*\.svc\.cluster\.local:8080' || { echo "FAIL: gate --upstream not the agenity Service" >&2; echo "$g" >&2; exit 1; }
+echo "$g" | grep -qE -- '--login-url=https://auth\.agnstar\.omani\.homes/realms/sovereign.*kc_idp_hint=catalyst-pin' || { echo "FAIL: silent SSO login-url/kc_idp_hint missing" >&2; exit 1; }
+echo "  PASS — gate resource set rendered"
+
+# spaTokenSeed redirect present (Exact / -> /app/?token=sso 302)
+echo "$g" | grep -qE 'replaceFullPath: "/app/\?token=sso"' || { echo "FAIL: missing spaTokenSeed /app/?token=sso redirect" >&2; echo "$g" >&2; exit 1; }
+echo "$g" | grep -qE 'statusCode: 302'                     || { echo "FAIL: spaTokenSeed redirect not 302" >&2; exit 1; }
+echo "  PASS — #4556 spaTokenSeed no-paste redirect present"
+
+# EXACTLY ONE HTTPRoute (the gate's) — chart's own route suppressed
+n_routes="$(echo "$g" | grep -c 'kind: HTTPRoute' || true)"
+[ "$n_routes" -eq 1 ] || { echo "FAIL: expected exactly 1 HTTPRoute (the gate's), got $n_routes — chart's own route not suppressed" >&2; echo "$g" >&2; exit 1; }
+# and that ONE route is the gate's, not the chart's
+if echo "$g" | awk 'BEGIN{RS="\n---\n"} /kind: HTTPRoute/ && /name: agenity-bp-agenity/{found=1} END{exit !found}'; then
+  echo "FAIL: the chart's own HTTPRoute (agenity-bp-agenity) rendered alongside the gate" >&2; echo "$g" >&2; exit 1
+fi
+echo "  PASS — chart's own HTTPRoute suppressed (gate owns the host)"
+
+# gateway-ingress CNP admits the ingress entity to the gate
+echo "$g" | grep -qE 'name: "oidc-gate-agenity-agnstar-gateway-ingress"' || { echo "FAIL: no gate gateway-ingress CiliumNetworkPolicy" >&2; exit 1; }
+echo "$g" | grep -qE 'kind: CiliumNetworkPolicy'                          || { echo "FAIL: no CiliumNetworkPolicy" >&2; exit 1; }
+echo "$g" | grep -qE 'port: "4180"'                                       || { echo "FAIL: gate CNP not admitting port 4180" >&2; exit 1; }
+echo "  PASS — gateway-entity CNP present"
+
+# ── Case 2: oidcGate.enabled=false → chart's own route, NO gate ──────────────
+echo "[oidc-gate-companion] Case 2: oidcGate.enabled=false renders the chart's own route, NO gate"
+ng="$("$helm" template agenity "$chart_dir" --set "sovereignFqdn=$FQDN" --set "httpRoute.hostnames[0]=$HOST" --set oidcGate.enabled=false 2>/dev/null)"
+if echo "$ng" | grep -qE 'oidc-gate-'; then echo "FAIL: gate resources rendered with oidcGate.enabled=false" >&2; echo "$ng" >&2; exit 1; fi
+n2="$(echo "$ng" | grep -c 'kind: HTTPRoute' || true)"
+[ "$n2" -eq 1 ] || { echo "FAIL: expected the chart's own HTTPRoute (1), got $n2" >&2; exit 1; }
+echo "$ng" | grep -qE 'replaceFullPath: "/app/"' || { echo "FAIL: chart's own bare-root -> /app/ redirect missing" >&2; exit 1; }
+echo "  PASS"
+
+# ── Case 3: fail-closed — no hostname, no fqdn → no gate ─────────────────────
+echo "[oidc-gate-companion] Case 3: fail-closed (no hostname, no sovereignFqdn) renders no gate"
+fc="$("$helm" template agenity "$chart_dir" --set 'httpRoute.hostnames={}' 2>/dev/null)"
+if echo "$fc" | grep -qE 'oidc-gate-'; then echo "FAIL: gate rendered with no hostname (must fail closed, Inviolable #4)" >&2; echo "$fc" >&2; exit 1; fi
+echo "  PASS"
+
+# ── Case 4: clientId override honoured ──────────────────────────────────────
+echo "[oidc-gate-companion] Case 4: oidcGate.clientId override honoured"
+co="$(render_gated --set oidcGate.clientId=agenity-custom)"
+echo "$co" | grep -qE -- '--client-id=agenity-custom'        || { echo "FAIL: clientId override not applied to --client-id" >&2; exit 1; }
+echo "$co" | grep -qE 'name: "oidc-gate-agenity-custom"'     || { echo "FAIL: gate name did not pick up clientId override" >&2; exit 1; }
+echo "$co" | grep -qE 'key: "sso/sovereign/agenity-custom"'  || { echo "FAIL: ExternalSecret key did not pick up clientId override" >&2; exit 1; }
+echo "  PASS"
+
+echo "[bp-agenity #4553/#4556 oidc-gate companion] All cases PASS"

--- a/products/agenity/chart/values.yaml
+++ b/products/agenity/chart/values.yaml
@@ -255,7 +255,89 @@ service:
   port: 8080            # Agenity web UI + dashboard WS + MCP HTTP
   metricsPort: 9090     # Prometheus scrape
 
+# ── Zero-click SSO gate (bp-oidc-gate companion, #4553/#4556) ─────────────
+# Every per-Org agenity install lands behind a bp-oidc-gate oauth2-proxy that
+# brings the agenity host under the Sovereign zero-click SSO contract (fresh
+# browser → bare URL → Keycloak sovereign realm, silent via catalyst-pin →
+# signed in) AND seeds the SPA bootstrap token so the User lands on the
+# workspace with NO paste prompt.
+#
+# WHY this lives in the bp-agenity chart (not a hand-created live instance):
+# the agnstar North-Star walk (#4553) hand-created a drift-disabled
+# `oidc-gate-agenity-agnstar` HelmRelease, so a fresh agenity Org or a re-prov
+# got NO gate (the host served the dashboard un-gated, anyone reaching it saw
+# it). Templating the gate AS PART OF the agenity install makes EVERY per-Org
+# agenity install automatically get its companion gate — chart-managed, drift
+# detected, zero hand-creation.
+#
+# The companion renders the SAME proven resource set as a bp-oidc-gate
+# instances[] entry (#3374): a gate-local cookie Secret, an AppRegistration
+# ConfigMap (bp-sso-bridge mints/adopts the KC client + publishes the live
+# secret to OpenBao sso/<realm>/<clientId>), an ExternalSecret pulling that
+# client secret, the oauth2-proxy Deployment (the WALKED hubble-ui arg set),
+# a Service, an HTTPRoute that OWNS the agenity hostname with the spaTokenSeed
+# bare-root redirect, and a CiliumNetworkPolicy admitting the gateway entity to
+# the gate pod. The gate's upstream is the agenity Service.
+#
+# When enabled, the agenity chart's OWN HTTPRoute (templates/httproute.yaml)
+# is SUPPRESSED — two HTTPRoutes on one hostname is undefined routing; the gate
+# owns the host and the spaTokenSeed redirect replaces the chart's bare-root →
+# /app/ redirect. The agenity pod stays reachable ONLY via the gate (its own
+# CNP still admits the gateway entity, but the gate proxies all traffic, so the
+# gate is the single ingress door).
+oidcGate:
+  # true (default) → render the oidc-gate companion in front of the agenity
+  # host and suppress the chart's own HTTPRoute. Set false for a non-SSO test
+  # install (the chart's own bare-root → /app/ HTTPRoute then serves the host
+  # un-gated, the pre-#4553 shape). Auto-no-ops on a clusterless render if
+  # neither hostnames nor sovereignFqdn is set (fail-closed, Inviolable #4).
+  enabled: true
+  # KC client id the gate registers (sovereign realm). Empty → derived
+  # `agenity-<orgSlug>` from the gate hostname's first label's parent, falling
+  # back to `agenity-gate`. The org-gitops emitter pins it explicitly to
+  # `agenity-<slug>` so each Org gets a distinct client (matches the live
+  # agnstar instance `agenity-agnstar`).
+  clientId: ""
+  # oauth2-proxy image (rendered <registryMirror>/<repository>:<tag>, matching
+  # the harbor-proxy-pull `*/proxy-*/*` glob — same as bp-oidc-gate).
+  image:
+    registryMirror: harbor.openova.io
+    repository: proxy-quay/oauth2-proxy/oauth2-proxy
+    tag: v7.6.0
+    pullPolicy: IfNotPresent
+  # Keycloak realm the gated client lives in (the Sovereign shared realm).
+  realm: sovereign
+  # In-cluster Keycloak base URL for the BACKCHANNEL OIDC legs (#3844): the
+  # gate SKIPS discovery against the public issuer EIP (unhairpinnable from
+  # inside the cluster on Huawei/kom4dc → CrashLoop) and dials the in-cluster
+  # keycloak Service for redeem/jwks/userinfo, keeping the browser-facing
+  # login/redirect URLs public. Empty → restore public-discovery behaviour.
+  keycloakInternalURL: "http://keycloak.keycloak.svc.cluster.local"
+  # ClusterSecretStore the gate's client-secret ExternalSecret resolves through.
+  externalSecretStoreName: vault-region1
+  refreshInterval: 1h
+  # The SPA bootstrap-token seed (#4556): 302 the bare root, AFTER the full KC
+  # SSO, to `<dashboardPath>?token=<value>` so the agenity `/app/` SPA seeds
+  # localStorage and lands authenticated with NO paste. value is a SENTINEL
+  # (the daemon runs authMode=none, so it is never verified — it only satisfies
+  # the SPA's localStorage presence-check). VERIFIED live on agnstar (#4556).
+  spaTokenSeed:
+    dashboardPath: /app/
+    value: sso
+    port: 443
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
+
 # ── HTTPRoute (Cilium Gateway) — the User reaches the Agenity console ──────
+# When oidcGate.enabled (the default), the bp-oidc-gate companion OWNS the
+# agenity hostname and this HTTPRoute is suppressed (two routes on one host is
+# undefined routing). It renders only for a non-gated test install
+# (oidcGate.enabled=false).
 httpRoute:
   enabled: true
   hostnames: []         # default: discovered from the Org/Sovereign FQDN

--- a/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
@@ -1674,8 +1674,22 @@ spec:
     # Per-Org identity zone — the openova-MCP derives
     # https://console.<sovereignFqdn> from this when catalystApiUrl is empty.
     sovereignFqdn: {{.Subdomain}}.{{.ParentDomain}}
-    # HTTPRoute exposure for the per-Org dashboard. Without a non-empty
-    # hostnames the chart's templates/httproute.yaml guard renders nothing.
+    # Zero-click SSO gate (#4553) — the bp-oidc-gate companion the chart
+    # renders IN FRONT OF this Org's agenity host, chart-managed (NOT a
+    # hand-created live instance). It owns {{.AgenityHost}}, runs the full
+    # Keycloak sovereign-realm SSO (silent via catalyst-pin), and seeds the
+    # SPA bootstrap token (spaTokenSeed -> /app/?token=sso) so the User lands
+    # on the workspace with NO paste. clientId is pinned per-Org so each Org
+    # registers a distinct KC client (matches the live agnstar
+    # agenity-agnstar). The chart derives the same agenity-<slug> from the
+    # hostname when clientId is empty; pinning it makes the contract explicit.
+    oidcGate:
+      enabled: true
+      clientId: agenity-{{.Subdomain}}
+    # HTTPRoute exposure for the per-Org dashboard. When oidcGate.enabled (the
+    # default), the gate OWNS {{.AgenityHost}} and the chart's own HTTPRoute is
+    # suppressed (two routes on one host is undefined routing); these
+    # hostnames + parentRef still drive the gate's HTTPRoute host + gateway.
     httpRoute:
       enabled: true
       hostnames:

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
@@ -468,6 +468,41 @@ func TestRenderOrganizationOverlay_AgenityMCPBearerWiring(t *testing.T) {
 	}
 }
 
+// TestRenderOrganizationOverlay_AgenityOIDCGateWiring is the #4553/#4556
+// durable-gate guard. The bp-agenity overlay MUST enable the chart's
+// bp-oidc-gate companion (oidcGate.enabled) and pin the per-Org clientId to
+// agenity-<slug>, so EVERY per-Org agenity install gets a chart-managed
+// zero-click SSO gate + spaTokenSeed no-paste landing — NOT the agnstar walk's
+// hand-created drift-disabled live instance. Without this a fresh agenity Org
+// or a re-prov serves the dashboard un-gated.
+func TestRenderOrganizationOverlay_AgenityOIDCGateWiring(t *testing.T) {
+	rec := store.OrganizationProvisionRecord{
+		OrganizationID:  "t-acme",
+		Subdomain:       "acme",
+		DomainMode:      store.OrganizationDomainFreeSubdomain,
+		AdminEmail:      "admin@acme.test",
+		OTECHFQDN:       "otech.example",
+		ParentDomain:    "omani.homes",
+		TenantNamespace: "org-t-acme",
+	}
+	files, err := renderOrganizationOverlay(rec, OrganizationChartVersions{})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body, ok := files["bp-agenity.yaml"]
+	if !ok {
+		t.Fatalf("bp-agenity.yaml missing")
+	}
+	for _, want := range []string{
+		"oidcGate:",
+		"clientId: agenity-acme",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("bp-agenity.yaml missing durable oidc-gate wiring %q\n---\n%s", want, body)
+		}
+	}
+}
+
 func TestRenderOrganizationOverlay_FreeSubdomain_AllChartsPresent(t *testing.T) {
 	rec := store.OrganizationProvisionRecord{
 		OrganizationID:  "t-acme",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,15 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.931 — #4553/#4556 (durable zero-click SSO gate): catalog-seed bp-agenity
+#   spec.version + source.version 0.5.14 -> 0.5.15 (lockstep with
+#   products/agenity/chart 0.5.15). The bp-agenity chart now renders a
+#   bp-oidc-gate COMPANION (oauth2-proxy + AppRegistration + ExternalSecret +
+#   HTTPRoute with the #4556 spaTokenSeed bare-root -> /app/?token=sso redirect)
+#   in front of every per-Org agenity host (oidcGate.enabled default true),
+#   replacing the agnstar walk's hand-created drift-disabled live instance — a
+#   fresh agenity Org / a re-prov now gets a chart-managed zero-click no-paste
+#   gate automatically. The org-gitops emitter (orgTenantBPAgenity) pins
+#   oidcGate.clientId=agenity-<slug>. Bootstrap-kit slot-13 pin bumps lockstep.
 # 1.4.928 — #4563 (Refs #3379, cutover step-08 fresh-pull, 2026-06-27):
 #   catalyst-ui Deployment image is now templated through
 #   global.imageRegistry (ui-deployment.yaml) exactly like catalyst-api —
@@ -3349,7 +3359,7 @@ name: bp-catalyst-platform
 #   sovereign-fqdn) so GET /catalog/regions returns the Sovereign's REAL
 #   regions instead of [] — the marketplace BCP picker stops falling back to
 #   the hardcoded Hetzner list.
-version: 1.4.930
+version: 1.4.931
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/
 #   platform/crossplane chart + blueprint.yaml + bootstrap-kit slot 04). crossplane-core
 #   was still OOMKilled (CrashLoopBackOff, 55 restarts, exit 137, killed ~90s after start)

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5980,7 +5980,10 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.5.14"
+  # 0.5.15 (#4553/#4556): chart renders a bp-oidc-gate companion in front of
+  # every per-Org agenity host (durable zero-click SSO gate + spaTokenSeed
+  # no-paste landing, chart-managed). Lockstep with products/agenity/chart.
+  version: "0.5.15"
   visibility: listed
   card:
     title: "Agenity"
@@ -6010,7 +6013,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-agenity
-    version: 0.5.14
+    version: 0.5.15
   topology:
     supported:
       - singleton


### PR DESCRIPTION
Refs #4553 #4556

## Problem

The agnstar North-Star walk hand-created a **drift-disabled** `oidc-gate-agenity-agnstar` HelmRelease, so the zero-click SSO gate was a live-only artifact. A fresh agenity Organization or a re-prov got **NO gate** — the host served the dashboard un-gated (anyone reaching it saw it, no Keycloak login) and landed on the SPA token-paste screen. Not durable.

## Fix — wire the gate INTO the bp-agenity chart

Every per-Org agenity install now AUTOMATICALLY renders its own `bp-oidc-gate` companion in front of the agenity host — chart-managed (the HR owns it, drift-detection on), zero hand-creation.

- **`templates/oidc-gate.yaml`** (new): the proven #3374 resource set — gate-local cookie Secret, AppRegistration ConfigMap (bp-sso-bridge mints/adopts the KC client + publishes the live secret to OpenBao), client-secret ExternalSecret, the oauth2-proxy Deployment (the WALKED hubble-ui arg set), a Service, an HTTPRoute that **owns the agenity hostname** with the #4556 `spaTokenSeed` bare-root → `/app/?token=sso` 302 redirect, and a gateway-ingress CiliumNetworkPolicy. Upstream is the agenity Service; silent SSO via `kc_idp_hint=catalyst-pin`; backchannel-via-internal-keycloak (#3844).
- **`templates/_helpers.tpl`**: `gateHostname` / `gateEnabled` / `gateClientId` helpers (host from `httpRoute.hostnames[0]` or `sovereignFqdn`; clientId derives `agenity-<slug>`; **fail-closed** per Inviolable #4 — no host, no gate).
- **`templates/httproute.yaml`**: SUPPRESS the chart's own route when the gate renders (two routes on one host is undefined routing — the gate owns the host; the spaTokenSeed redirect replaces the bare-root → `/app/` redirect).
- **`values.yaml`**: `oidcGate` block (`enabled` default true; image/realm/keycloakInternalURL/spaTokenSeed/resources).
- **`tests/oidc-gate-companion-render.sh`** (new): render audit — gated install renders the full companion + suppresses the chart route + the spaTokenSeed redirect + the CNP; `oidcGate.enabled=false` serves the chart's own route un-gated; fail-closed with no host; clientId override honoured.

The org-gitops emitter (`orgTenantBPAgenity`) sets `oidcGate.enabled` + pins `oidcGate.clientId=agenity-<slug>` so each Organization registers a distinct KC client (matches the live `agenity-agnstar`). New `TestRenderOrganizationOverlay_AgenityOIDCGateWiring` guard.

## Design

Templating the gate directly into bp-agenity (vs. a subchart) makes it compose automatically with both the BSS door and any future render path: when agenity installs in an Organization, the gate comes with it — deriving the host from the Organization's pool FQDN, registering the KC client via the same AppRegistration ConfigMap bp-sso-bridge consumes (catalyst-system → sso-bridge → KC mint path works for the Org-namespaced instance).

## Lockstep

- bp-agenity chart + blueprint + catalog-seed `0.5.14` → `0.5.15`
- bp-catalyst-platform chart + slot-13 pin `1.4.930` → `1.4.931`
- platform oidc-gate instances (grafana/hubble/etc.) **byte-identical** (additive)

## Verification

- `helm template` render tests (gated / non-gated / fail-closed / clientId-override) — all pass
- `helm lint` clean
- `go build ./...` + `go test ./internal/handler/... -run Agenity` — all pass (incl. the new wiring guard)
- platform oidc-gate chart untouched + its 3 render tests still pass

Live re-walk on agnstar (`https://agenity.agnstar.omani.homes/app/` → workspace, no paste) to follow on merge+roll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)