### PR TITLE
fix(bp-agenity): oidc-gate companion resources requests==limits so the gate pod is plan-LimitRange-admissible (0.5.16)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1208,7 +1208,10 @@ spec:
       #   gate + spaTokenSeed no-paste) in front of every per-Org agenity host
       #   (oidcGate.enabled default true), replacing the agnstar walk's
       #   hand-created live instance. Lockstep w/ Chart.yaml + products/agenity.
-      version: 1.4.932
+      # 1.4.933 — #4553: catalog-seed bp-agenity 0.5.15 -> 0.5.16 — oidc-gate
+      #   companion resources requests == limits so the gate pod is admissible
+      #   under the per-Org plan-limits LimitRange. Lockstep w/ products/agenity.
+      version: 1.4.933
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/agenity/blueprint.yaml
+++ b/products/agenity/blueprint.yaml
@@ -6,12 +6,16 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
+  # 0.5.16 (#4553): the oidc-gate companion's default resources are now
+  # requests == limits (Guaranteed QoS) so the gate pod is admissible under the
+  # per-Org plan-limits LimitRange (cpu:1/mem:1 ratio) — the prior Burstable
+  # spec was rejected, no gate pod, no SSO (live on agnstar). Lockstep with
+  # products/agenity/chart/Chart.yaml + the catalog-seed pin.
   # 0.5.15 (#4553/#4556): the chart now renders a bp-oidc-gate companion in
   # front of every per-Org agenity host (oidcGate.enabled default true) — the
   # durable zero-click SSO gate + spaTokenSeed no-paste landing, chart-managed
-  # rather than the agnstar walk's hand-created live instance. Lockstep with
-  # products/agenity/chart/Chart.yaml + the catalog-seed pin.
-  version: 0.5.15
+  # rather than the agnstar walk's hand-created live instance.
+  version: 0.5.16
   card:
     title: Agenity
     summary: |

--- a/products/agenity/chart/Chart.yaml
+++ b/products/agenity/chart/Chart.yaml
@@ -124,6 +124,16 @@ type: application
 # `ingress` entity that no K8s NetworkPolicy can admit — without the CNP every
 # external hit to agenity.<slug>.<pool> returned envoy 503 "upstream connect
 # error". appVersion (dashboard image) stays 0.9.6 — image bytes unchanged.
+# 0.5.16 (#4553, gate LimitRange fix): the oidc-gate companion's default
+# resources are now requests == limits (Guaranteed QoS, 1:1 ratio). The per-Org
+# namespace's plan `plan-limits` LimitRange (maxLimitRequestRatio cpu:1/mem:1 —
+# the Sovereign sells Guaranteed quota) REJECTED the prior Burstable gate spec
+# (cpu 10m->100m = 10:1) at pod admission: `max limit to request ratio per
+# Container is 1, but provided ratio is 10` → the gate Deployment's ReplicaSet
+# FailedCreate, no gate pod, no SSO (live root-cause on the agnstar Org
+# 2026-06-27 — the exact trap the agenity StatefulSet hit in #4362). cpu 50m /
+# mem 64Mi 1:1 keeps the oauth2-proxy admissible. Values-only; appVersion
+# (image) UNCHANGED.
 # 0.5.15 (#4553/#4556, durable zero-click SSO gate): render a bp-oidc-gate
 # COMPANION (templates/oidc-gate.yaml) in front of EVERY per-Org agenity host,
 # gated behind oidcGate.enabled (default true). The agnstar North-Star walk
@@ -149,7 +159,7 @@ type: application
 # same gateway bp-wordpress-tenant + the org console route attach to, #4054).
 # The old default rendered Accepted=False/InvalidHTTPRoute and the host 404'd
 # until the parentRef was hand-overridden. appVersion (image) unchanged.
-version: 0.5.15
+version: 0.5.16
 # Bumped appVersion 0.9.6 -> 0.9.7 (#4180): 0.9.7 is the FIRST image whose
 # /app/ mounts the WORKSPACES dashboard (Dashboardws bundle) rather than the
 # archaic single-column Dashboard.svelte. It is built from agenity#752

--- a/products/agenity/chart/values.yaml
+++ b/products/agenity/chart/values.yaml
@@ -325,12 +325,21 @@ oidcGate:
     dashboardPath: /app/
     value: sso
     port: 443
+  # requests == limits (Guaranteed QoS, 1:1 ratio) — REQUIRED for a per-Org
+  # install. The per-Org namespace carries the plan `plan-limits` LimitRange
+  # with maxLimitRequestRatio cpu:1/memory:1 (the Sovereign sells Guaranteed
+  # quota), so a Burstable gate spec (e.g. cpu 10m->100m = 10:1) is REJECTED at
+  # pod admission: `max limit to request ratio per Container is 1, but provided
+  # ratio is N` → the gate Deployment's ReplicaSet FailedCreate and the gate
+  # never serves (live on the agnstar Org 2026-06-27, same trap the agenity
+  # StatefulSet hit in #4362). 1:1 keeps the oauth2-proxy admissible and is
+  # plenty for a single-Org auth proxy.
   resources:
     requests:
-      cpu: 10m
-      memory: 32Mi
+      cpu: 50m
+      memory: 64Mi
     limits:
-      cpu: 100m
+      cpu: 50m
       memory: 64Mi
 
 # ── HTTPRoute (Cilium Gateway) — the User reaches the Agenity console ──────

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,10 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.933 — #4553 (gate LimitRange fix): catalog-seed bp-agenity 0.5.15 ->
+#   0.5.16 — the oidc-gate companion's resources are now requests == limits so
+#   the gate pod is admissible under the per-Org plan-limits LimitRange (the
+#   Burstable spec was rejected, no gate pod, no SSO live on agnstar). Lockstep
+#   w/ products/agenity/chart 0.5.16. Bootstrap-kit slot-13 pin bumps lockstep.
 # 1.4.931 — #4553/#4556 (durable zero-click SSO gate): catalog-seed bp-agenity
 #   spec.version + source.version 0.5.14 -> 0.5.15 (lockstep with
 #   products/agenity/chart 0.5.15). The bp-agenity chart now renders a
@@ -3359,7 +3364,7 @@ name: bp-catalyst-platform
 #   sovereign-fqdn) so GET /catalog/regions returns the Sovereign's REAL
 #   regions instead of [] — the marketplace BCP picker stops falling back to
 #   the hardcoded Hetzner list.
-version: 1.4.932
+version: 1.4.933
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/
 #   platform/crossplane chart + blueprint.yaml + bootstrap-kit slot 04). crossplane-core
 #   was still OOMKilled (CrashLoopBackOff, 55 restarts, exit 137, killed ~90s after start)

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5983,7 +5983,7 @@ spec:
   # 0.5.15 (#4553/#4556): chart renders a bp-oidc-gate companion in front of
   # every per-Org agenity host (durable zero-click SSO gate + spaTokenSeed
   # no-paste landing, chart-managed). Lockstep with products/agenity/chart.
-  version: "0.5.15"
+  version: "0.5.16"
   visibility: listed
   card:
     title: "Agenity"
@@ -6013,7 +6013,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-agenity
-    version: 0.5.15
+    version: 0.5.16
   topology:
     supported:
       - singleton


### PR DESCRIPTION
Refs #4553

Follow-up to PR #4572. The #4553 oidc-gate companion shipped **Burstable** default resources (cpu `10m`→`100m` = 10:1, memory `32Mi`→`64Mi` = 2:1). The per-Org namespace carries the plan `plan-limits` LimitRange (`maxLimitRequestRatio cpu:1/memory:1` — the Sovereign sells Guaranteed quota), which **rejected the gate pod at admission**:

```
max limit to request ratio per Container is 1, but provided ratio is 10
```

→ the gate Deployment's ReplicaSet `FailedCreate`, no gate pod, no SSO (live root-cause on the agnstar Org — the exact trap the agenity StatefulSet hit in #4362).

## Fix

Pin the companion's default resources to `requests == limits` (cpu `50m` / mem `64Mi`, Guaranteed QoS) so the oauth2-proxy is admissible. Values-only; the image is unchanged.

## Lockstep

- bp-agenity chart + blueprint + catalog-seed `0.5.15` → `0.5.16`
- bp-catalyst-platform chart + slot-13 pin `1.4.932` → `1.4.933`

## Verification

`helm template` render tests + `helm lint` green. Live-confirmed on agnstar (gate pod admits + serves with 1:1 resources).

🤖 Generated with [Claude Code](https://claude.com/claude-code)