### PR TITLE
fix(bp-self-sovereign-cutover): the two GENUINE clean-fresh-prov cutover faults — F4 drift-proof chart-mirror set + F2 harbor blob-redirect off (0.1.86)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -626,11 +626,17 @@ spec:
       # (`catalyst`) so the step Jobs' secretKeyRef resolves natively — no more
       # hand-bridged `kubectl apply`. No step-count / job-mode change (the
       # bridge is a Secret without the cutover-step label).
+      # 0.1.86 (#4573 Refs #3379): the two GENUINE clean-fresh-prov faults —
+      # F4 step-03 Phase A2 chart-mirror set now drift-proof (UNION static
+      # names ∪ live openova-io HelmRepositories, not the stale static list
+      # that omitted ~22 charts) + F2 harbor blob-redirect disabled in slot
+      # 19-harbor (no OBS 302 that x509s in-cluster TLS-pinned clients).
+      # Lockstep w/ Chart.yaml + blueprint.yaml.
       # 0.1.85 (#4563 Refs #3379): step-07 also pivots the bp-openova-flow-
       # server HR's global.imageRegistry to local Harbor (catalyst-ui pivots
       # via the bp-catalyst-platform chart 1.4.927) — kills the step-08 fresh-
-      # pull FATAL on the two residual ghcr.io tethers. Lockstep w/ Chart.yaml.
-      version: 0.1.85
+      # pull FATAL on the two residual ghcr.io tethers.
+      version: 0.1.86
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -375,6 +375,26 @@ spec:
           host: ${SOVEREIGN_HARBOR_PG_HOST:=harbor-pg-rw.harbor.svc.cluster.local}
       persistence:
         imageChartStorage:
+          # #4573 F2 (Refs #3379): serve registry blobs DIRECTLY from the
+          # in-cluster Harbor host — do NOT 302-redirect blob GETs to a
+          # presigned cloud Object Storage URL. With redirect ENABLED (the
+          # upstream default), a `GET /v2/<repo>/blobs/<digest>` returns a
+          # 302 to `https://obs.<region>.<sov>.nationalcloud.om/...` (Huawei
+          # OBS) / the S3 endpoint, whose cert is a DIFFERENT host from
+          # `registry.<sov-fqdn>`. Every in-cluster TLS-pinned client trusts
+          # ONLY the registry host: containerd's certs.d skip_verify (#4557)
+          # is host-scoped to `registry.<sov-fqdn>`, skopeo's `--dest/--src-
+          # tls-verify` targets the registry host, and a HelmRepository
+          # certSecretRef scopes trust to the registry host — NONE trust the
+          # OBS host → `tls: failed to verify certificate ... valid for
+          # *.obs... not registry.<fqdn>` (live c39f0cd4455b7a46, #4573 F2).
+          # That x509 wedges the step-08 fresh-pull proof (containerd blob
+          # GET) and any in-cluster blob fetch under the deny-egress hold.
+          # `disableRedirect: true` makes harbor-registry stream the blob
+          # bytes itself over the already-trusted registry host — the OBS
+          # backend is still the durable store (Harbor reads/writes it
+          # server-side); only the CLIENT-facing 302 is suppressed.
+          disableRedirect: true
           type: s3
           s3:
             existingSecret: harbor-objectstorage-credentials

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.85
+  version: 0.1.86
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,31 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.86 (#4573 Refs #3379, the two GENUINE clean-fresh-prov cutover faults —
+# the ones a version-frozen cutover hits, separate from the F1/F3/F5 re-drive
+# contamination that only bites driving NEW chart/image versions onto an
+# already-pivoted cluster, 2026-06-28): TWO changes.
+#   F4 (prewarm completeness) — step-03 Phase A2 (openova-io helm-chart mirror)
+#     previously seeded its pivot set ONLY from the static
+#     .Values.helmRepositories.names list, which had DRIFTED and omitted ~22
+#     openova-io HelmRepositories the bootstrap-kit slots reference (bp-cnpg-pair,
+#     bp-network-policies, bp-postgres, bp-newapi, bp-oidc-gate, bp-sso-bridge,
+#     bp-sandbox, bp-vllm, bp-plane-isolation, bp-continuum, bp-guacamole,
+#     bp-k8s-ws-proxy, bp-powerdns-admin, bp-opentelemetry-operator,
+#     bp-openova-flow-{server,emitter}, the hcloud/evs CSI charts, …). Those
+#     charts never reached local Harbor → a post-strip HR source kick 404s
+#     `does not have an artifact` (live c39f0cd4455b7a46). Phase A2 now derives
+#     the pivot set DYNAMICALLY: UNION the static names with EVERY live Flux
+#     HelmRepository whose spec.url is the openova-io upstream OCI prefix — a
+#     drift-proof, strict superset (same live∪declared discipline Phase A's
+#     image enumeration already uses).
+#   F2 (Harbor OBS-redirect TLS) — bootstrap-kit slot 19-harbor now sets
+#     harbor.persistence.imageChartStorage.disableRedirect=true on the s3 store
+#     so blob GETs stream DIRECTLY from registry.<sov-fqdn> instead of 302-ing to
+#     a presigned obs.<region>.<sov>.nationalcloud.om URL whose cert no in-cluster
+#     TLS-pinned client (containerd certs.d skip_verify / skopeo / a HelmRepo
+#     certSecretRef are all host-scoped to the registry host) trusts → x509 that
+#     wedges the step-08 fresh-pull proof + any in-cluster blob fetch under the
+#     deny-egress hold.
 # 0.1.85 (#4563 Refs #3379, keystone re-prov c39f0cd4455b7a46 reached step-08
 # with the 600s deny-egress hold PASSING but the fresh-pull-under-deny-egress
 # proof FATALing on two residual ghcr.io tethers, 2026-06-27): step-07 now ALSO
@@ -1199,7 +1225,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.85
+version: 0.1.86
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -513,14 +513,60 @@ data:
             # by this one-shot cutover prewarm.
             echo "[harbor-prewarm] Phase A2: mirror openova-io helm charts into local Harbor"
 
-            # Build the pivot-set lookup (one HR name per line, mounted RO).
+            # Build the pivot-set lookup. #4573 F4 (Refs #3379): the prior
+            # implementation seeded the pivot set ONLY from the static
+            # .Values.helmRepositories.names list (mounted at
+            # /chart-mirror/chart-mirror-names.txt). That list is hand-
+            # maintained and DRIFTED — it omitted ~22 openova-io
+            # HelmRepositories the bootstrap-kit slots actually reference
+            # (bp-cnpg-pair, bp-network-policies, bp-postgres, bp-newapi,
+            # bp-oidc-gate, bp-sso-bridge, bp-sandbox, bp-vllm, bp-plane-
+            # isolation, bp-continuum, bp-guacamole, bp-k8s-ws-proxy,
+            # bp-powerdns-admin, bp-opentelemetry-operator, bp-openova-flow-
+            # {server,emitter}, the hcloud/evs CSI charts, …). Phase A2 then
+            # SKIPPED those charts → they never landed in local Harbor → a
+            # post-strip HR source kick 404s `does not have an artifact`
+            # (live c39f0cd4455b7a46). The COMPLETENESS of the mirror set
+            # must NOT depend on a static list staying in sync with the
+            # slot tree.
+            #
+            # Fix: derive the pivot set DYNAMICALLY from the LIVE cluster —
+            # every Flux HelmRepository whose spec.url is the upstream
+            # openova-io OCI prefix (oci://ghcr.io/openova-io) is in the set,
+            # regardless of whether it is named in the static list. UNION
+            # that live set with the static names file (belt-and-suspenders:
+            # a HR named in the list but momentarily absent from the live
+            # API read is still covered). The union can only WIDEN the set —
+            # every chart is still skopeo-copied idempotently — never narrow
+            # it, a strict superset of the prior behaviour. This is the same
+            # "union live ∪ declared, never depend on a static snapshot"
+            # discipline the container-image enumeration (Phase A) already
+            # uses above.
             pivot_set_file=/tmp/.chart-pivot-set.txt
             : > "${pivot_set_file}"
+            # (a) static names from the mounted list (legacy contract).
             while IFS= read -r pl; do
               pn=$(printf '%s' "${pl}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
               [ -z "${pn}" ] && continue
               printf '%s\n' "${pn}" >> "${pivot_set_file}"
             done < /chart-mirror/chart-mirror-names.txt
+            # (b) live HelmRepositories whose url is the openova-io upstream
+            # OCI prefix — the complete, drift-proof set. UPSTREAM_PREFIX is
+            # `oci://ghcr.io/openova-io`; a HR url may be exactly that prefix
+            # or a `<prefix>/<name>`-suffixed form, so match on the prefix.
+            up_prefix_match=$(printf '%s' "${UPSTREAM_PREFIX}" | sed -e 's,/$,,')
+            live_openova_hrs=$(kubectl get helmrepositories.source.toolkit.fluxcd.io -A -o json 2>/dev/null | \
+              jq -r --arg p "${up_prefix_match}" \
+                '.items[] | select((.spec.url // "") | startswith($p)) | .metadata.name' 2>/dev/null | \
+              sort -u || true)
+            printf '%s\n' "${live_openova_hrs}" >> "${pivot_set_file}"
+            # Dedupe + drop blanks so the lookup is clean.
+            sort -u "${pivot_set_file}" -o "${pivot_set_file}"
+            sed -i '/^[[:space:]]*$/d' "${pivot_set_file}" 2>/dev/null || true
+            static_n=$(grep -c . /chart-mirror/chart-mirror-names.txt 2>/dev/null || echo 0)
+            live_n=$(printf '%s\n' "${live_openova_hrs}" | grep -c . || true)
+            union_n=$(grep -c . "${pivot_set_file}" || true)
+            echo "[harbor-prewarm] Phase A2 pivot set: static-names=${static_n} ∪ live-openova-io-HelmRepositories=${live_n} → ${union_n} unique sourceRef name(s) (#4573 F4: drift-proof)"
 
             in_pivot_set() {
               # $1 = HelmRepository name; 0 if present in the pivot set.

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -1078,4 +1078,53 @@ if ! printf '%s\n' "$step07_block" | grep -q '56-bp-openova-flow-server.yaml'; t
 fi
 echo "  PASS (Step-07 pivots bp-openova-flow-server HR global.imageRegistry live + durably edits slot-56; catalyst-ui pivots via bp-catalyst-platform's templated ui-deployment.yaml)"
 
+echo "[cutover-contract] Case 33: Step-03 Phase A2 chart-mirror pivot set is DRIFT-PROOF — derived from LIVE openova-io HelmRepositories, not the static names list alone (#4573 F4, Refs #3379)"
+# #4573 F4: the prior Phase A2 seeded its pivot set ONLY from the static
+# .Values.helmRepositories.names list (mounted chart-mirror-names.txt). That
+# list had drifted and omitted ~22 openova-io HelmRepositories the bootstrap-
+# kit slots reference, so those charts were never skopeo-mirrored into local
+# Harbor and a post-strip HR source kick 404s `does not have an artifact`.
+# Phase A2 MUST union the static names with the LIVE HelmRepository set whose
+# spec.url is the openova-io upstream OCI prefix. Assert the dynamic-union
+# kubectl read + the startswith(UPSTREAM_PREFIX) selection are both present.
+prewarm_block="$(awk '/cutover-step-03-harbor-prewarm/{c=1} c{print} c&&/cutover-order: "4"/{exit}' "$TMP/render.yaml")"
+[ -n "$prewarm_block" ] || prewarm_block="$(cat "$TMP/render.yaml")"
+if ! printf '%s\n' "$prewarm_block" | grep -q 'kubectl get helmrepositories.source.toolkit.fluxcd.io -A'; then
+  echo "FAIL: Step-03 Phase A2 does not read the LIVE HelmRepository set — the chart-mirror pivot set stays bound to the static names list and drifts (#4573 F4)" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$prewarm_block" | grep -q 'startswith($p)'; then
+  echo "FAIL: Step-03 Phase A2 does not select HelmRepositories by spec.url startswith(UPSTREAM_PREFIX) — the openova-io chart set is not derived live (#4573 F4)" >&2
+  exit 1
+fi
+# The static names list must ALSO now carry the formerly-missing openova-io HRs
+# so step-06 Phase-1 REPOINTS them (else step-08 count_offenders catches the
+# stragglers still on oci://ghcr.io/openova-io and FAILs the proof).
+for must in bp-postgres bp-newapi bp-sso-bridge bp-oidc-gate bp-sandbox bp-vllm bp-plane-isolation bp-cnpg-pair; do
+  if ! printf '%s\n' "$prewarm_block" | grep -q "${must}"; then
+    echo "FAIL: openova-io HelmRepository ${must} missing from the helmRepositories.names pivot set — step-06 never repoints it, step-08 count_offenders FAILs (#4573 F4)" >&2
+    exit 1
+  fi
+done
+echo "  PASS (Step-03 Phase A2 unions static names ∪ live openova-io HelmRepositories; the formerly-missing ~22 charts are now in the repoint+mirror set — drift-proof)"
+
+echo "[cutover-contract] Case 34: bootstrap-kit slot 19-harbor disables the blob-redirect on the s3 store so in-cluster TLS-pinned clients never x509 on the OBS host (#4573 F2, Refs #3379)"
+# #4573 F2: with the upstream-default redirect ENABLED, a registry blob GET 302s
+# to a presigned obs.<region>.<sov>.nationalcloud.om URL whose cert is a
+# DIFFERENT host from registry.<sov-fqdn>; containerd's host-scoped skip_verify
+# (#4557), skopeo's dest/src-tls-verify, and a HelmRepo certSecretRef all trust
+# ONLY the registry host -> x509 wedges the step-08 fresh-pull proof + any
+# in-cluster blob fetch under the deny-egress hold. The Sovereign overlay MUST
+# set harbor.persistence.imageChartStorage.disableRedirect: true.
+HARBOR_SLOT="${HARBOR_SLOT:-../../../clusters/_template/bootstrap-kit/19-harbor.yaml}"
+if [ -f "$HARBOR_SLOT" ]; then
+  if ! grep -Eq 'disableRedirect:[[:space:]]*true' "$HARBOR_SLOT"; then
+    echo "FAIL: 19-harbor.yaml does not set imageChartStorage.disableRedirect: true — blob GETs 302 to the OBS host and x509 the in-cluster TLS-pinned cutover clients (#4573 F2)" >&2
+    exit 1
+  fi
+  echo "  PASS (19-harbor.yaml sets imageChartStorage.disableRedirect: true — registry streams blobs directly from registry.<fqdn>, no OBS 302)"
+else
+  echo "  SKIP (19-harbor.yaml not reachable from test cwd: $HARBOR_SLOT)"
+fi
+
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -484,6 +484,38 @@ helmRepositories:
     - "bp-coraza"
     - "bp-cert-manager-powerdns-webhook"
     - "bp-cluster-autoscaler-hcloud"
+    # #4573 F4 (Refs #3379): the ~22 openova-io HelmRepositories the
+    # bootstrap-kit slots reference that this hand-maintained list had
+    # DRIFTED past. Step-06 Phase-1 must repoint EVERY openova-io HR's
+    # spec.url to local Harbor or step-08's count_offenders catches the
+    # stragglers still on oci://ghcr.io/openova-io and FAILs the proof;
+    # step-03 Phase A2 ALSO unions this list with the live HelmRepository
+    # set (drift-proof) so both the repoint and the chart-mirror are
+    # complete. Every name below was confirmed to carry
+    # `url: oci://ghcr.io/openova-io` in clusters/_template/bootstrap-kit/.
+    - "bp-cert-manager-issuers"
+    - "bp-cnpg-pair"
+    - "bp-continuum"
+    - "bp-guacamole"
+    - "bp-hcloud-ccm"
+    - "bp-hcloud-csi"
+    - "bp-huawei-evs-csi"
+    - "bp-k8s-ws-proxy"
+    - "bp-kyverno-policies"
+    - "bp-network-policies"
+    - "bp-newapi"
+    - "bp-oidc-gate"
+    - "bp-openova-flow-emitter"
+    - "bp-openova-flow-server"
+    - "bp-opentelemetry-operator"
+    - "bp-plane-isolation"
+    - "bp-postgres"
+    - "bp-powerdns-admin"
+    - "bp-sandbox"
+    - "bp-sso-bridge"
+    - "bp-vcluster-helmrepo"
+    - "bp-velero-hcs"
+    - "bp-vllm"
     # openova-catalog (TBD-C19, 2026-05-18) — the named Flux v1
     # HelmRepository the application-controller renders every
     # per-Application HelmRelease against (catalogSourceRef default).


### PR DESCRIPTION
## Summary

Closes the two #4573 faults a CLEAN (version-frozen) fresh-prov sovereignty cutover actually hits. The other three #4573 faults (F1 source-controller x509, F3 kubelet skip_verify, F5 EVS-attach) are **re-drive contamination** — they only bite when driving NEW chart/image versions onto an ALREADY-pivoted cluster (the #4563 live re-drive on c39f0cd). A clean cutover freezes versions pre-pivot, so no chart/image re-pull happens and those three never fire. Confirmed by tracing the cutover step graph: OCI HelmRepositories are static pointers source-controller never reconciles; step-06 Phase-3a already carries `--insecure-skip-tls-verify` (#4557); step-08's fresh-pull proof rolls IMAGES via containerd (already skip_verify'd #4557), not charts.

## F4 — prewarm chart-mirror set completeness (drift-proof)

step-03 Phase A2 (the openova-io helm-CHART mirror, distinct from Phase A container images) seeded its pivot set ONLY from the static `.Values.helmRepositories.names` list. That hand-maintained list had **drifted** and omitted ~22 openova-io HelmRepositories the bootstrap-kit slots reference (bp-cnpg-pair, bp-network-policies, bp-postgres, bp-newapi, bp-oidc-gate, bp-sso-bridge, bp-sandbox, bp-vllm, bp-plane-isolation, bp-continuum, bp-guacamole, bp-k8s-ws-proxy, bp-powerdns-admin, bp-opentelemetry-operator, bp-openova-flow-{server,emitter}, the hcloud/evs CSI charts, …). Those charts never landed in local Harbor → a post-strip HR source kick 404s `does not have an artifact` (live c39f0cd4455b7a46).

Fix: Phase A2 now derives the pivot set **dynamically** — UNION the static names with EVERY live Flux HelmRepository whose `spec.url` is the openova-io upstream OCI prefix (`oci://ghcr.io/openova-io`). Drift-proof, strict superset, same live-union discipline Phase A's image enumeration already uses. The static names list is ALSO completed (the formerly-missing ~22 names added) so step-06 Phase-1 **repoints** every openova-io HR — else step-08's `count_offenders` catches the stragglers still on ghcr.io and FAILs the proof.

## F2 — Harbor OBS blob-redirect breaks in-cluster TLS-pinned clients

With the upstream-default `disableRedirect: false`, a registry blob `GET /v2/.../blobs/<digest>` 302s to a presigned `obs.<region>.<sov>.nationalcloud.om` URL whose cert is a DIFFERENT host from `registry.<sov-fqdn>`. Every in-cluster TLS-pinned cutover client trusts ONLY the registry host — containerd's certs.d skip_verify (#4557) is host-scoped, skopeo's dest/src-tls-verify targets the registry host, a HelmRepo certSecretRef scopes to the registry host — none trust the OBS host → `tls: failed to verify certificate ... valid for *.obs... not registry.<fqdn>`. That x509 wedges the step-08 fresh-pull proof + any in-cluster blob fetch under the deny-egress hold.

Fix: bootstrap-kit slot `19-harbor` sets `harbor.persistence.imageChartStorage.disableRedirect: true` so harbor-registry streams blob bytes itself over the already-trusted registry host. OBS stays the durable backend (server-side read/write); only the client-facing 302 is suppressed.

## Changes
- `platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml` — Phase A2 dynamic-union pivot set (F4)
- `platform/self-sovereign-cutover/chart/values.yaml` — complete the `helmRepositories.names` repoint list (F4)
- `clusters/_template/bootstrap-kit/19-harbor.yaml` — `disableRedirect: true` on the s3 store (F2)
- Chart.yaml 0.1.85→0.1.86 + blueprint.yaml + slot-06a pin (lockstep)
- `tests/cutover-contract.sh` — Case 33 (F4 drift-proof) + Case 34 (F2 redirect-off); all 34 gates green

## Test
- `bash platform/self-sovereign-cutover/chart/tests/cutover-contract.sh` → All gates green (34 cases)
- `go test ./tests/e2e/bootstrap-kit/...` → ok
- `helm template` renders clean; YAML parses; no banned words; names list deduped (62 entries)

Live cutoverComplete=true verification deferred to a clean fresh-prov cutover walk (next step in this session).

Refs #4573 #3379

🤖 Generated with [Claude Code](https://claude.com/claude-code)