### PR TITLE
fix(catalyst): agenity one-HR-per-install + openova-MCP URL targets the Sovereign not the mothership (1.4.936)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1211,7 +1211,11 @@ spec:
       # 1.4.933 — #4553: catalog-seed bp-agenity 0.5.15 -> 0.5.16 — oidc-gate
       #   companion resources requests == limits so the gate pod is admissible
       #   under the per-Org plan-limits LimitRange. Lockstep w/ products/agenity.
-      version: 1.4.935
+      # 1.4.936 — #4556: kill the agenity dual-render duplicate HR (quota) +
+      #   stamp spec.parameters.sovereignFqdn so the openova-MCP URL points at
+      #   this Sovereign, not the mothership. catalyst-api + application-controller
+      #   image fixes (deploy-bot pins on next build). Lockstep w/ Chart.yaml.
+      version: 1.4.936
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/core/controllers/application/internal/controller/application_controller.go
+++ b/core/controllers/application/internal/controller/application_controller.go
@@ -1122,6 +1122,25 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 	}
 	_ = perClusterFanout // status writer reads perClusterStatus; this var is the typed-shape audit trail
 
+	// #4556 Item 1 — when the topology fan-out produced HRs, those HRs ARE
+	// the install (exactly one for a singleton, N for an active-hot-standby
+	// cnpg-pair) and the reconciler already upserted them host-side above.
+	// The legacy per-region render+commit path below ALSO renders the same
+	// logical install under the bare `<app>` name and delivers it via a
+	// GitRepository + per-region Kustomization — so a topology/targets-driven
+	// Application was getting BOTH `<app>` AND `<app>-<cluster>` HelmReleases,
+	// double-consuming the Org plan quota (live: `agenity` + `agenity-rtz-a`
+	// both 1/1 on the agnstar Org). Honour the line-783 contract — "when the
+	// fan-out runs, the per-region path must NOT also own the install" — by
+	// suppressing the per-region render+commit + the host Flux bootstrap that
+	// delivers the duplicate. Status observation already targets the fan-out
+	// HRs via fanoutHRRefs (built from perClusterStatus), so nothing else
+	// changes. The predicate never touches the fan-out loop itself, so the
+	// cnpg-pair N>1 fan-out is unaffected; legacy / substrate / no-topology
+	// Applications (perClusterFanout empty) keep the per-region path as their
+	// SOLE install path, byte-identical to before.
+	fanoutOwnsInstall := len(perClusterFanout) > 0
+
 	// 7. Resolve placement → per-region work plan.
 	plan, err := placement.Resolve(spec.Placement, spec.Regions)
 	if err != nil {
@@ -1225,6 +1244,21 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 	regionStatuses := make([]map[string]interface{}, 0, len(plan.Regions))
 	allCommitted := true
 	for _, rp := range plan.Regions {
+		// #4556 Item 1 — the fan-out already owns the install (its `<app>-<cluster>`
+		// HRs were upserted host-side above). Skip the redundant per-region
+		// render+commit of the bare `<app>` HR so the Org plan quota is not
+		// double-consumed. Keep the regionStatuses skeleton row so
+		// status.regions[] + mergeRegionReadiness stay populated for the UI.
+		if fanoutOwnsInstall {
+			regionStatuses = append(regionStatuses, map[string]interface{}{
+				"name":               rp.Name,
+				"role":               rp.Role,
+				"replicas":           int64(replicasFor(rp.Standby, spec.Parameters)),
+				"ready":              int64(0),
+				"lastTransitionTime": time.Now().UTC().Format(time.RFC3339),
+			})
+			continue
+		}
 		merged := mergeMaps(bpManifestsValues, spec.Parameters)
 		out, err := render.Render(render.Inputs{
 			AppName: app.GetName(),
@@ -1327,13 +1361,23 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 	//     resolves the kubeConfig.secretRef). The IN-vCluster install
 	//     target stays the Application's namespace (rendered HR's
 	//     spec.targetNamespace).
-	hostHRNamespace := app.GetNamespace()
-	if bpVCluster != "" {
-		hostHRNamespace = vcPlacement.HostNamespace
-	}
-	if err := r.ensureHostFluxBootstrap(ctx, app, envSpec, plan, hostHRNamespace); err != nil {
-		return r.markDegraded(ctx, app, ReasonGiteaError,
-			fmt.Sprintf("ensure host Flux bootstrap: %v", err))
+	//
+	//     #4556 Item 1 — SKIP this when the fan-out owns the install: the
+	//     GitRepository + per-region Kustomization here are what deliver the
+	//     duplicate bare `<app>` HR (the fan-out `<app>-<cluster>` HRs were
+	//     already upserted host-side above). Bootstrapping them would
+	//     re-create the second HR every reconcile and double-consume the Org
+	//     plan quota. Legacy / non-fan-out Applications still bootstrap their
+	//     SOLE per-region delivery here, unchanged.
+	if !fanoutOwnsInstall {
+		hostHRNamespace := app.GetNamespace()
+		if bpVCluster != "" {
+			hostHRNamespace = vcPlacement.HostNamespace
+		}
+		if err := r.ensureHostFluxBootstrap(ctx, app, envSpec, plan, hostHRNamespace); err != nil {
+			return r.markDegraded(ctx, app, ReasonGiteaError,
+				fmt.Sprintf("ensure host Flux bootstrap: %v", err))
+		}
 	}
 
 	// 10. Observe the downstream HelmRelease so the Application's

--- a/core/controllers/application/internal/controller/application_controller_placement_fanout_test.go
+++ b/core/controllers/application/internal/controller/application_controller_placement_fanout_test.go
@@ -199,6 +199,67 @@ func TestReconcile_TargetsDriveFanout_SingletonSingleTarget(t *testing.T) {
 	}
 }
 
+// TestReconcile_SingletonFanout_OneHR_NoPerRegionGitRepository — #4556 Item 1.
+// A singleton target produces EXACTLY ONE HelmRelease total and NO per-region
+// GitRepository/Kustomization: the fan-out `<app>-<cluster>` HR is the SOLE
+// install, and the legacy per-region path (which would deliver a duplicate
+// bare `<app>` HR via a GitRepository + Kustomization, double-consuming the
+// Org plan quota — the live `agenity` + `agenity-rtz-a` fault) is suppressed.
+func TestReconcile_SingletonFanout_OneHR_NoPerRegionGitRepository(t *testing.T) {
+	bp := makeBlueprintNoTopology("bp-grafana", "1.0.6", "primary+standby")
+	env := makeMultiRegionEnv("acme-prod", "acme", "prod")
+	org := makeOrg("acme")
+	app := makeAppWithTargets("acme", "obs", "acme-prod", "bp-grafana", "1.0.6",
+		"singleton",
+		[]string{"hetzner-fsn-rtz-prod"},
+		[]map[string]interface{}{
+			{"region": "fsn", "cluster": "mgmt-A", "vcluster": "mgmt", "role": "Primary"},
+		},
+	)
+	fg := newFakeGitea()
+	fg.orgsExist["acme"] = true
+	r := newReconciler(t, fg, app, env, org, bp)
+
+	reconcileFromCluster(t, r, "acme", "obs")
+
+	got := readApp(t, r, "acme", "obs")
+	if phase, reason, msg := readPhaseAndReason(t, got); phase == PhaseFailed {
+		t.Fatalf("unexpected Failed phase: reason=%q msg=%q", reason, msg)
+	}
+
+	// EXACTLY ONE HR across every host namespace — no duplicate bare `<app>`
+	// HR rendered by the (now-suppressed) per-region path.
+	total := 0
+	for _, ns := range []string{"mgmt", "dmz", "rtz", "acme"} {
+		hrList, err := r.Dynamic.Resource(FluxHelmReleaseGVR).
+			Namespace(ns).List(context.Background(), metav1.ListOptions{})
+		if err != nil {
+			t.Fatalf("list HRs in %s: %v", ns, err)
+		}
+		total += len(hrList.Items)
+		for _, hr := range hrList.Items {
+			// The surviving HR is the fan-out `<app>-<cluster>` name, NOT the
+			// bare `<app>` the per-region path would have committed.
+			if hr.GetName() == "obs" {
+				t.Errorf("found the duplicate bare `<app>` HR %q in %s — the per-region path must be suppressed when the fan-out owns the install", hr.GetName(), ns)
+			}
+		}
+	}
+	if total != 1 {
+		t.Fatalf("want EXACTLY 1 HR for a singleton fan-out (one render path), got %d", total)
+	}
+
+	// The per-region delivery infra (GitRepository catalyst-app-{org}-{app})
+	// must NOT exist — bootstrapping it is what re-creates the duplicate HR
+	// every reconcile.
+	_, err := r.Dynamic.Resource(FluxGitRepositoryGVR).
+		Namespace("flux-system").
+		Get(context.Background(), "catalyst-app-acme-obs", metav1.GetOptions{})
+	if err == nil {
+		t.Fatalf("per-region GitRepository catalyst-app-acme-obs must NOT be bootstrapped for a fan-out-owned install (it delivers the duplicate HR)")
+	}
+}
+
 // TestReconcile_NoTargets_NoBlueprintTopology_NoFanout — the additive
 // invariant: with NO desired-state targets AND NO Blueprint topology, the
 // targets path is dormant and produces zero fan-out HRs (the legacy

--- a/products/catalyst/bootstrap/api/internal/handler/application_parameters.go
+++ b/products/catalyst/bootstrap/api/internal/handler/application_parameters.go
@@ -40,24 +40,69 @@ import "strings"
 //     posture) → active-hot-standby (the only HA mode the engine renders)
 //   - singleton / single-region / empty / unknown → singleton
 //
+// For bp-agenity specifically we additionally stamp `sovereignFqdn` from the
+// Sovereign's own FQDN (#4556 Item 2). The agenity chart derives the
+// openova-MCP catalyst-api URL as `https://console.<.Values.sovereignFqdn>`,
+// falling back to `console.openova.io` (the OpenOva MOTHERSHIP) when
+// sovereignFqdn is empty (chart statefulset.yaml:230-231). The BSS-door
+// GitOps overlay (organization_gitops.go orgTenantBPAgenity) already stamps
+// sovereignFqdn, but the Application-CR install path here did NOT — so a
+// per-Org agenity installed via POST /applications (or the create-instance
+// seed path) left it empty and every spawned agent's MCP forwarded
+// create_application calls to the MOTHERSHIP instead of this Sovereign.
+// We stamp it whether or not the caller supplied other parameters (the User
+// never sets it themselves); a caller that DID pin it wins (we never
+// overwrite a non-empty explicit value).
+//
 // blueprint may carry the `bp-` prefix or not; topology is the canonical
 // (or legacy-dialect) placement token already chosen by the caller.
-func defaultedParameters(blueprint, topology string, explicit map[string]interface{}) map[string]interface{} {
-	if len(explicit) > 0 {
-		out := make(map[string]interface{}, len(explicit))
-		for k, v := range explicit {
-			out[k] = v
-		}
+// sovereignFQDN is the Sovereign's own FQDN (e.g. "omantel.biz"); empty on
+// the mothership / Catalyst-Zero, where the agenity install is not a
+// production path — leaving sovereignFqdn unset keeps the chart's existing
+// fail-closed default behaviour.
+func defaultedParameters(blueprint, topology, sovereignFQDN string, explicit map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(explicit)+1)
+	for k, v := range explicit {
+		out[k] = v
+	}
+
+	if isAgenityBlueprint(blueprint) {
+		stampAgenitySovereignFqdn(out, sovereignFQDN)
+	}
+
+	if len(out) > 0 {
 		return out
 	}
 
-	params := map[string]interface{}{}
 	if isPostgresBlueprint(blueprint) {
-		params["topology"] = map[string]interface{}{
+		out["topology"] = map[string]interface{}{
 			"mode": postgresConfigSchemaMode(topology),
 		}
 	}
-	return params
+	return out
+}
+
+// stampAgenitySovereignFqdn sets `parameters.sovereignFqdn` to the Sovereign's
+// own FQDN (#4556 Item 2) unless the caller already pinned a non-empty value.
+// No-op when sovereignFQDN is empty (the mothership case) so the chart keeps
+// its existing fail-closed default rather than rendering a bogus host.
+func stampAgenitySovereignFqdn(params map[string]interface{}, sovereignFQDN string) {
+	fqdn := strings.TrimSpace(sovereignFQDN)
+	if fqdn == "" {
+		return
+	}
+	if existing, ok := params["sovereignFqdn"].(string); ok && strings.TrimSpace(existing) != "" {
+		return
+	}
+	params["sovereignFqdn"] = fqdn
+}
+
+// isAgenityBlueprint reports whether the blueprint id refers to bp-agenity
+// (with or without the `bp-` prefix).
+func isAgenityBlueprint(blueprint string) bool {
+	b := strings.TrimSpace(strings.ToLower(blueprint))
+	b = strings.TrimPrefix(b, "bp-")
+	return b == "agenity"
 }
 
 // isPostgresBlueprint reports whether the blueprint id refers to

--- a/products/catalyst/bootstrap/api/internal/handler/application_parameters_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/application_parameters_test.go
@@ -63,7 +63,7 @@ func bpPostgresConfigSchema() map[string]interface{} {
 // ── defaultedParameters unit table ──────────────────────────────────────
 
 func TestDefaultedParameters_PostgresNoValues_SeedsSingletonMode(t *testing.T) {
-	got := defaultedParameters("bp-postgres", "singleton", nil)
+	got := defaultedParameters("bp-postgres", "singleton", "", nil)
 	if got == nil {
 		t.Fatal("defaultedParameters returned nil — must always be a non-null object")
 	}
@@ -78,7 +78,7 @@ func TestDefaultedParameters_PostgresNoValues_SeedsSingletonMode(t *testing.T) {
 
 func TestDefaultedParameters_PostgresActiveHotStandby(t *testing.T) {
 	for _, topo := range []string{"active-hot-standby", "active-hotstandby", "active-active", "active-passive"} {
-		got := defaultedParameters("postgres", topo, nil)
+		got := defaultedParameters("postgres", topo, "", nil)
 		tm := got["topology"].(map[string]interface{})["mode"]
 		if tm != "active-hot-standby" {
 			t.Fatalf("topology %q → topology.mode = %v, want active-hot-standby", topo, tm)
@@ -87,7 +87,7 @@ func TestDefaultedParameters_PostgresActiveHotStandby(t *testing.T) {
 }
 
 func TestDefaultedParameters_NonPostgresNoValues_EmptyObjectNotNil(t *testing.T) {
-	got := defaultedParameters("bp-grafana", "singleton", nil)
+	got := defaultedParameters("bp-grafana", "singleton", "", nil)
 	if got == nil {
 		t.Fatal("non-postgres parameters returned nil — must be at least an empty object")
 	}
@@ -101,12 +101,89 @@ func TestDefaultedParameters_ExplicitValuesPreservedVerbatim(t *testing.T) {
 		"topology":  map[string]interface{}{"mode": "active-hot-standby"},
 		"databases": []interface{}{map[string]interface{}{"name": "wp", "owner": "wp"}},
 	}
-	got := defaultedParameters("bp-postgres", "singleton", explicit)
+	got := defaultedParameters("bp-postgres", "singleton", "", explicit)
 	if got["topology"].(map[string]interface{})["mode"] != "active-hot-standby" {
 		t.Fatalf("explicit topology.mode must be preserved (not overwritten by chosen topology), got %#v", got)
 	}
 	if _, ok := got["databases"]; !ok {
 		t.Fatalf("explicit databases must be preserved, got %#v", got)
+	}
+}
+
+// ── #4556 Item 2: bp-agenity stamps sovereignFqdn so the openova-MCP URL
+//    derives https://console.<sovereign-fqdn>, NOT the mothership
+//    console.openova.io. ───────────────────────────────────────────────────
+
+func TestDefaultedParameters_AgenityNoValues_StampsSovereignFqdn(t *testing.T) {
+	got := defaultedParameters("bp-agenity", "singleton", "omantel.biz", nil)
+	if got["sovereignFqdn"] != "omantel.biz" {
+		t.Fatalf("agenity parameters must stamp sovereignFqdn=omantel.biz, got %#v", got)
+	}
+}
+
+func TestDefaultedParameters_AgenityWithExplicitValues_StampsSovereignFqdn(t *testing.T) {
+	explicit := map[string]interface{}{
+		"agent": map[string]interface{}{"model": "claude-opus-4-8"},
+	}
+	got := defaultedParameters("agenity", "singleton", "t99.omani.works", explicit)
+	if got["sovereignFqdn"] != "t99.omani.works" {
+		t.Fatalf("agenity sovereignFqdn must be stamped even with explicit params, got %#v", got)
+	}
+	if _, ok := got["agent"]; !ok {
+		t.Fatalf("explicit agent params must be preserved alongside the stamped sovereignFqdn, got %#v", got)
+	}
+}
+
+func TestDefaultedParameters_AgenityExplicitSovereignFqdnWins(t *testing.T) {
+	explicit := map[string]interface{}{"sovereignFqdn": "pinned.example"}
+	got := defaultedParameters("bp-agenity", "singleton", "omantel.biz", explicit)
+	if got["sovereignFqdn"] != "pinned.example" {
+		t.Fatalf("a caller-pinned sovereignFqdn must NOT be overwritten, got %#v", got)
+	}
+}
+
+func TestDefaultedParameters_AgenityEmptyFQDN_NoStamp(t *testing.T) {
+	// Mothership / Catalyst-Zero: empty FQDN → leave sovereignFqdn unset so
+	// the chart's fail-closed default applies (no bogus console host).
+	got := defaultedParameters("bp-agenity", "singleton", "", nil)
+	if _, ok := got["sovereignFqdn"]; ok {
+		t.Fatalf("empty FQDN must NOT stamp sovereignFqdn, got %#v", got)
+	}
+}
+
+func TestNewApplicationUnstructured_Agenity_StampsSovereignFqdn(t *testing.T) {
+	req := applicationInstallRequest{
+		BlueprintRef:    applicationBlueprintRef{Name: "bp-agenity", Version: "0.5.16"},
+		Name:            "agenity",
+		OrganizationRef: "agnstar.omani.homes",
+		EnvironmentRef:  "agnstar-prod",
+		Placement:       applicationPlacement{Mode: "singleton", Regions: []string{"primary"}},
+	}
+	obj := newApplicationUnstructured(req, "omantel.biz")
+	params, found, _ := unstructured.NestedMap(obj.Object, "spec", "parameters")
+	if !found || params == nil {
+		t.Fatalf("spec.parameters absent/nil for agenity install")
+	}
+	if params["sovereignFqdn"] != "omantel.biz" {
+		t.Fatalf("agenity Application CR must carry spec.parameters.sovereignFqdn=omantel.biz (else the openova-MCP URL falls back to the mothership console.openova.io), got %#v", params)
+	}
+}
+
+func TestNewApplicationCRFromSeed_Agenity_StampsSovereignFqdn(t *testing.T) {
+	seed := instances.ApplicationSeed{
+		Name:          "agenity",
+		Namespace:     "agnstar.omani.homes",
+		Blueprint:     "bp-agenity",
+		Topology:      "singleton",
+		SovereignFQDN: "omantel.biz",
+	}
+	obj := newApplicationCRFromSeed(seed)
+	params, found, _ := unstructured.NestedMap(obj.Object, "spec", "parameters")
+	if !found || params == nil {
+		t.Fatalf("spec.parameters absent/nil for agenity seed")
+	}
+	if params["sovereignFqdn"] != "omantel.biz" {
+		t.Fatalf("agenity seed CR must carry spec.parameters.sovereignFqdn=omantel.biz, got %#v", params)
 	}
 }
 
@@ -182,7 +259,7 @@ func TestNewApplicationUnstructured_PostgresNoParams_ValidatesConfigSchema(t *te
 		EnvironmentRef:  "omantel-biz-prod",
 		Placement:       applicationPlacement{Mode: "singleton", Regions: []string{"primary"}},
 	}
-	obj := newApplicationUnstructured(req)
+	obj := newApplicationUnstructured(req, "")
 	params, found, _ := unstructured.NestedMap(obj.Object, "spec", "parameters")
 	if !found || params == nil {
 		t.Fatalf("spec.parameters absent/nil — newApplicationUnstructured must always stamp a non-null object")

--- a/products/catalyst/bootstrap/api/internal/handler/applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications.go
@@ -488,7 +488,18 @@ func (h *Handler) installApplicationCore(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	obj := newApplicationUnstructured(body)
+	// #4556 Item 2 — resolve the Sovereign's own FQDN so the agenity install
+	// stamps spec.parameters.sovereignFqdn (the chart derives the openova-MCP
+	// catalyst-api URL from it; empty → console.openova.io, the mothership).
+	// Prefer the deployment record's FQDN; fall back to this catalyst-api's
+	// own SOVEREIGN_FQDN env. Empty on the mothership/Catalyst-Zero is fine —
+	// agenity-on-mothership is not a production path and the chart's
+	// fail-closed default then applies.
+	sovereignFQDN := strings.TrimSpace(dep.Request.SovereignFQDN)
+	if sovereignFQDN == "" {
+		sovereignFQDN = h.sovereignFQDN()
+	}
+	obj := newApplicationUnstructured(body, sovereignFQDN)
 	created, err := client.Resource(ApplicationGVR()).Namespace(appNS).Create(
 		r.Context(), obj, metav1.CreateOptions{})
 	if err != nil {
@@ -960,7 +971,7 @@ func isSovereignOperatorClaim(claims *auth.Claims) bool {
 // install request. Sets the spec to mirror the API surface exactly so a
 // downstream Get returns the same shape the caller posted (modulo
 // metadata + status).
-func newApplicationUnstructured(req applicationInstallRequest) *unstructured.Unstructured {
+func newApplicationUnstructured(req applicationInstallRequest, sovereignFQDN string) *unstructured.Unstructured {
 	obj := &unstructured.Unstructured{}
 	obj.SetAPIVersion(ApplicationGVR().Group + "/" + ApplicationGVR().Version)
 	obj.SetKind("Application")
@@ -1041,7 +1052,7 @@ func newApplicationUnstructured(req applicationInstallRequest) *unstructured.Uns
 	// tree valid; the controller's admission webhook + this handler's
 	// validate.Parameters call have already gated explicit params against
 	// configSchema.
-	spec["parameters"] = defaultedParameters(req.BlueprintRef.Name, canonMode, req.Parameters)
+	spec["parameters"] = defaultedParameters(req.BlueprintRef.Name, canonMode, sovereignFQDN, req.Parameters)
 	_ = unstructured.SetNestedMap(obj.Object, spec, "spec")
 	return obj
 }

--- a/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
@@ -855,6 +855,11 @@ func (h *Handler) HandleCreateInstance(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
+	// #4556 Item 2 — stamp the Sovereign's own FQDN so a bp-agenity instance
+	// created via this path gets spec.parameters.sovereignFqdn (the chart
+	// derives the openova-MCP catalyst-api URL from it; empty → the mothership
+	// console.openova.io). No-op for non-agenity Blueprints.
+	seed.SovereignFQDN = h.sovereignFQDN()
 
 	// #3598 (EPIC #3597) — ensure the Org/Environment namespace exists
 	// BEFORE creating any Application CR. Without this the create races the
@@ -2189,7 +2194,7 @@ func newApplicationCRFromSeed(seed instances.ApplicationSeed) *unstructured.Unst
 	// reconciled (phase=Failed). Now seed.Values (when present) is used
 	// verbatim; otherwise we emit at least `{}` plus a configSchema-valid
 	// topology.mode for bp-postgres.
-	spec["parameters"] = defaultedParameters(seed.Blueprint, seed.Topology, seed.Values)
+	spec["parameters"] = defaultedParameters(seed.Blueprint, seed.Topology, seed.SovereignFQDN, seed.Values)
 	_ = unstructured.SetNestedMap(obj.Object, spec, "spec")
 	return obj
 }

--- a/products/catalyst/bootstrap/api/internal/handler/placement_3373_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/placement_3373_test.go
@@ -20,7 +20,7 @@ func TestNewApplicationUnstructured_StringForm_StoresCanonical(t *testing.T) {
 		// Legacy editor dialect on the wire …
 		Placement: applicationPlacement{Mode: "single-region", Regions: []string{"fsn"}},
 	}
-	obj := newApplicationUnstructured(req)
+	obj := newApplicationUnstructured(req, "")
 	pl, ok, err := unstructured.NestedString(obj.Object, "spec", "placement")
 	// One vocabulary (#3375 DoD-1): the CR STORES the canonical token —
 	// the legacy "single-region" is folded to "singleton" so every CR
@@ -44,7 +44,7 @@ func TestNewApplicationUnstructured_ObjectFormWhenVClusterSet(t *testing.T) {
 			Clusters: []string{"mgmt-A"},
 		},
 	}
-	obj := newApplicationUnstructured(req)
+	obj := newApplicationUnstructured(req, "")
 	vc, _, _ := unstructured.NestedString(obj.Object, "spec", "placement", "vcluster")
 	if vc != "rtz" {
 		t.Fatalf("spec.placement.vcluster = %q, want rtz", vc)
@@ -198,7 +198,7 @@ func TestNewApplicationUnstructured_DottedOrgSlugsNamespace(t *testing.T) {
 		EnvironmentRef:  "hw165.omani.works-prod",
 		Placement:       applicationPlacement{Mode: "singleton", Regions: []string{"fsn"}},
 	}
-	obj := newApplicationUnstructured(req)
+	obj := newApplicationUnstructured(req, "")
 	if ns := obj.GetNamespace(); ns != "hw165-omani-works" {
 		t.Fatalf("metadata.namespace = %q, want slugged hw165-omani-works", ns)
 	}

--- a/products/catalyst/bootstrap/api/internal/instances/create.go
+++ b/products/catalyst/bootstrap/api/internal/instances/create.go
@@ -189,6 +189,13 @@ type ApplicationSeed struct {
 	// defaults; the controller derives). Passed through verbatim to
 	// the OBJECT form of `spec.placement` on the Application CR.
 	Placement *InstancePlacementRequest
+
+	// SovereignFQDN — the Sovereign's own FQDN (e.g. "omantel.biz"), stamped
+	// by the create-instance handler so the bp-agenity install gets
+	// spec.parameters.sovereignFqdn (#4556 Item 2). Empty on the
+	// mothership/Catalyst-Zero. Consumed by newApplicationCRFromSeed via
+	// defaultedParameters; ignored for non-agenity Blueprints.
+	SovereignFQDN string
 }
 
 // Build constructs the ApplicationSeed from a sanitised+validated

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,17 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.936 — #4556 (agenity North-Star residual faults, items 1+2): (1) the
+#   application-controller no longer DUAL-RENDERS a topology/targets-driven
+#   Application — the fan-out `<app>-<cluster>` HR is now the sole install and
+#   the redundant per-region bare-`<app>` render+commit + host Flux bootstrap
+#   are suppressed when the fan-out owns the install, so a per-Org agenity stops
+#   consuming the Org plan quota twice (live `agenity` + `agenity-rtz-a`).
+#   (2) the catalyst-api Application-CR install path (POST /applications + the
+#   create-instance seed path) now stamps spec.parameters.sovereignFqdn for
+#   bp-agenity from the Sovereign's own FQDN, so the openova-MCP catalyst-api
+#   URL derives https://console.<sovereign-fqdn> instead of falling back to the
+#   mothership console.openova.io. Ships in the catalyst-api +
+#   application-controller images (deploy-bot bumps the pins on the next build).
 # 1.4.933 — #4553 (gate LimitRange fix): catalog-seed bp-agenity 0.5.15 ->
 #   0.5.16 — the oidc-gate companion's resources are now requests == limits so
 #   the gate pod is admissible under the per-Org plan-limits LimitRange (the
@@ -3364,7 +3376,7 @@ name: bp-catalyst-platform
 #   sovereign-fqdn) so GET /catalog/regions returns the Sovereign's REAL
 #   regions instead of [] — the marketplace BCP picker stops falling back to
 #   the hardcoded Hetzner list.
-version: 1.4.935
+version: 1.4.936
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/
 #   platform/crossplane chart + blueprint.yaml + bootstrap-kit slot 04). crossplane-core
 #   was still OOMKilled (CrashLoopBackOff, 55 restarts, exit 137, killed ~90s after start)


### PR DESCRIPTION
Refs #4556 — fixes the two genuinely-open agenity North-Star residual faults (item 3, the SPA token-paste gate, already shipped via #4560).

## Item 1 — dual-render duplicate HelmRelease (eats Org quota)

A topology / placement-targets-driven `Application` ran BOTH render paths every reconcile:
- the fan-out path upserted `<app>-<cluster>` host-side (e.g. `agenity-rtz-a`), AND
- the legacy per-region path committed + delivered a duplicate bare `<app>` HR (`agenity`) via a GitRepository + Kustomization.

So one singleton agenity install consumed the per-Org plan quota **twice** (live: `agenity` + `agenity-rtz-a`, both 1/1). `core/controllers/application/internal/controller/application_controller.go` now honours the long-standing "when the fan-out runs the per-region path must NOT also own the install" contract: when the fan-out produced HRs (`len(perClusterFanout) > 0`), the per-region render+commit + the `ensureHostFluxBootstrap` that delivers the duplicate are suppressed. The predicate never touches the fan-out loop itself, so the cnpg-pair N>1 fan-out and legacy / no-topology Applications are byte-unchanged. Status observation already targets the fan-out HRs via `fanoutHRRefs`. New regression test: a singleton fan-out = exactly ONE HR + NO per-region GitRepository.

## Item 2 — openova-MCP catalyst-api URL resolved to the mothership

The bp-agenity chart derives `https://console.<.Values.sovereignFqdn>`, falling back to `console.openova.io` (the OpenOva **mothership**) when `sovereignFqdn` is empty (`statefulset.yaml:230-231`). The BSS-door GitOps overlay already stamps it, but the **Application-CR install path** (`POST /applications` + the create-instance seed path) did NOT — so every spawned agent's MCP forwarded `create_application` calls to the wrong Sovereign. The catalyst-api now stamps `spec.parameters.sovereignFqdn` for bp-agenity from the Sovereign's own FQDN (mirroring the established bp-postgres `topology.mode` seam in `defaultedParameters`), preferring the deployment record's FQDN and falling back to the `SOVEREIGN_FQDN` env. Empty on the mothership keeps the chart's fail-closed default.

`helm template` proof (no chart change needed — the chart already derives correctly once the value is set):
```
--set sovereignFqdn=omantel.biz  ->  "OPENOVA_MCP_CATALYST_API_URL":"https://console.omantel.biz"   (zero console.openova.io)
default (empty)                  ->  "OPENOVA_MCP_CATALYST_API_URL":"https://console.openova.io"     (the fault, reproduced)
```

## Delivery

Both fixes ship in the **catalyst-api + application-controller** images (deploy-bot bumps the image pins on the next build). `bp-catalyst-platform` 1.4.935 -> 1.4.936 + bootstrap-kit slot-13 pin in lockstep so Flux re-rolls the seed.

## Verification
- `core/controllers` builds + full application-controller test suite green (incl. new `TestReconcile_SingletonFanout_OneHR_NoPerRegionGitRepository`; cnpg-hostside / vcluster-rollup / multi-cluster fan-out tests unchanged + green).
- bootstrap-api builds + handler tests green (incl. new agenity `defaultedParameters` / `newApplicationUnstructured` / `newApplicationCRFromSeed` stamping tests).
- `helm lint products/catalyst/chart` clean; agenity oidc-gate render test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)