### PR TITLE
fix(cutover): harbor-prewarm Phase-A2 chart mirror retries transient 504 (Refs #3379)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -636,7 +636,8 @@ spec:
       # server HR's global.imageRegistry to local Harbor (catalyst-ui pivots
       # via the bp-catalyst-platform chart 1.4.927) — kills the step-08 fresh-
       # pull FATAL on the two residual ghcr.io tethers.
-      version: 0.1.86
+      # 0.1.87 (#4581 Refs #3379): step-03 Phase-A2 chart mirror wraps each skopeo copy in an outer attempt loop (PREWARM_COPY_ATTEMPTS) — a transient in-cluster-Harbor DEST 504 (not caught by skopeo --retry-times) no longer FATAL-s the whole cutover on one chart (live: bp-alloy 504 on prov 00720a7a, chart_ok=61/62).
+      version: 0.1.87
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.86
+  version: 0.1.87
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1225,7 +1225,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.86
+version: 0.1.87
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -617,19 +617,41 @@ data:
               # #4529: same dest-TLS treatment as Phase A — the chart OCI dest
               # is the in-cluster Harbor (PREWARM_DEST_TLS_VERIFY, default
               # false); src stays verified (external ghcr.io).
-              if skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT}" copy \
-                --insecure-policy \
-                --retry-times 3 \
-                --src-creds="${ghcr_user}:${ghcr_pat}" \
-                --dest-creds="${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
-                --dest-tls-verify="${PREWARM_DEST_TLS_VERIFY}" \
-                --src-tls-verify=true \
-                "${csrc}" "${cdst}" >"${chart_cpdir}/${cslug}.log" 2>&1; then
-                printf '%s:%s' "${cchart}" "${cver}" >"${chart_cpdir}/${cslug}.ok"
-              else
+              #
+              # #4581 (Refs #3379): wrap the chart copy in an OUTER attempt loop
+              # with backoff. skopeo's `--retry-times` only re-tries SOURCE-pull
+              # errors; a TRANSIENT in-cluster-Harbor DEST 504 on blob-upload
+              # initiation (Harbor capacity/OBS flap) is NOT retried by it and
+              # FATAL-ed the whole step on ONE chart. Live evidence: prov
+              # 00720a7a, `bp-alloy:1.0.2` → "initiating layer upload ... 504
+              # Gateway Timeout" with chart_ok=61/62, so step-06 aborted the
+              # cutover over a single transient blip. The outer loop (same shape
+              # as the Phase-B PREWARM_COPY_ATTEMPTS image path) turns a
+              # transient dest 504 into a bounded retry instead of a cutover-
+              # killing FATAL.
+              cattempt=0
+              cmax="${PREWARM_COPY_ATTEMPTS:-4}"
+              while : ; do
+                cattempt=$((cattempt+1))
+                if skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT}" copy \
+                  --insecure-policy \
+                  --retry-times 3 \
+                  --src-creds="${ghcr_user}:${ghcr_pat}" \
+                  --dest-creds="${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
+                  --dest-tls-verify="${PREWARM_DEST_TLS_VERIFY}" \
+                  --src-tls-verify=true \
+                  "${csrc}" "${cdst}" >"${chart_cpdir}/${cslug}.log" 2>&1; then
+                  printf '%s:%s' "${cchart}" "${cver}" >"${chart_cpdir}/${cslug}.ok"
+                  return 0
+                fi
                 crc=$?
-                printf '%s:%s exit=%s' "${cchart}" "${cver}" "${crc}" >"${chart_cpdir}/${cslug}.fail"
-              fi
+                if [ "${cattempt}" -ge "${cmax}" ]; then
+                  printf '%s:%s exit=%s attempts=%s' "${cchart}" "${cver}" "${crc}" "${cattempt}" >"${chart_cpdir}/${cslug}.fail"
+                  return 0
+                fi
+                echo "[harbor-prewarm] chart ${cchart}:${cver} copy attempt ${cattempt}/${cmax} failed (rc=${crc}, transient e.g. 504) — retrying in $((cattempt*5))s" >>"${chart_cpdir}/${cslug}.log"
+                sleep "$((cattempt*5))"
+              done
             }
 
             chart_pids=""

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -4491,7 +4491,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.84",
+      "version": "0.1.87",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",


### PR DESCRIPTION
Wraps each Phase-A2 chart skopeo copy in an outer retry loop so a transient in-cluster-Harbor dest 504 (bp-alloy on prov 00720a7a, chart_ok=61/62) no longer FATAL-s the cutover. Refs #3379 #4573 #4581