### PR TITLE
fix(bp-plane-isolation): admit kube-apiserver into the OTel-operator :9443 webhook (Refs #4579 #3379)

### DIFF
--- a/clusters/_template/bootstrap-kit/26b-bp-plane-isolation.yaml
+++ b/clusters/_template/bootstrap-kit/26b-bp-plane-isolation.yaml
@@ -130,7 +130,22 @@ spec:
       #   SecretSyncedError → the seeds never landed. Same de-vcluster ingress-gap class
       #   as #4448 (sso-bridge→openbao). Network-only: catalyst-api's k8s-auth role is
       #   already bound.
-      version: 0.1.10
+      # 0.1.11 (#4579 / Refs #3379 #4401 #4428): add a per-component kube-apiserver
+      #   WEBHOOK-INGRESS CiliumNetworkPolicy (fromEntities:[kube-apiserver,host,
+      #   remote-node] on the declared port) — the INGRESS mirror of the 0.1.5/#4428
+      #   apiserver-egress CNP, for a component whose admission webhook the apiserver
+      #   calls BACK into. The opentelemetry default-deny ingress allow-list is
+      #   namespace-based (alloy + catalyst-system); the apiserver is host-network →
+      #   reserved `kube-apiserver` identity → no namespaceSelector admits it → the
+      #   apiserver's call into the OTel-operator `minstrumentation.kb.io` mutating
+      #   webhook (opentelemetry-operator-webhook:443 → pod :9443) was dropped → the
+      #   operator post-install hook `context deadline exceeded` → the
+      #   bp-opentelemetry-operator HR Stalled (MissingRollbackTarget) → the
+      #   all-terminal handover gate couldn't fire on a fresh prov (59/62 HRs).
+      #   Live-proven dep 00720a7a9c72364d (kom4dc, 2026-06-27). Additive (admits
+      #   ONLY the apiserver on :9443, scoped to the operator pods); default-deny
+      #   intact. Only the opentelemetry entry sets apiserverWebhookPorts today.
+      version: 0.1.11
       sourceRef:
         kind: HelmRepository
         name: bp-plane-isolation

--- a/platform/plane-isolation/blueprint.yaml
+++ b/platform/plane-isolation/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 0.1.10  # lockstep with chart/Chart.yaml (#4499 — add catalyst-system to openbao allowIngressFrom)
+  version: 0.1.11  # lockstep with chart/Chart.yaml (#4579 — apiserver-webhook-ingress CNP for the OTel-operator :9443 webhook)
   card:
     title: Plane isolation (per-component default-deny)
     summary: |
@@ -45,6 +45,16 @@ spec:
             allowIngressFrom:
               type: array
               items:
+                type: string
+            apiserverWebhookPorts:
+              type: array
+              description: TCP port(s) an admission/conversion webhook server listens on that the kube-apiserver calls back into. Renders a CiliumNetworkPolicy admitting the reserved kube-apiserver identity on these ports (#4579). Omit for components with no apiserver-called webhook.
+              items:
+                type: integer
+            apiserverWebhookSelector:
+              type: object
+              description: Optional matchLabels narrowing the apiserver-webhook-ingress CNP to just the webhook pods (default — every pod in the namespace on the named ports).
+              additionalProperties:
                 type: string
   placementSchema:
     modes: [single-region, active-active]

--- a/platform/plane-isolation/chart/Chart.yaml
+++ b/platform/plane-isolation/chart/Chart.yaml
@@ -154,7 +154,29 @@ name: bp-plane-isolation
 #   network-only de-vcluster ingress-gap class as #4448 (sso-bridge→openbao) and
 #   #4382 (org-services→gitea). The auth path is already wired (catalyst-api's
 #   k8s-auth role bound); this was purely the missing network ingress edge.
-version: 0.1.10
+# 0.1.11 (#4579 / Refs #3379 #4401 #4428): ADD a kube-apiserver-webhook-INGRESS
+#   CiliumNetworkPolicy (fromEntities:[kube-apiserver,host,remote-node] on the
+#   declared port) for a component that runs an admission/conversion webhook the
+#   kube-apiserver calls BACK into. The apiserver-egress CNP (0.1.5/#4428)
+#   admitted the apiserver as an egress TARGET (pod to VIP); this is its INGRESS
+#   mirror (apiserver to pod webhook). The opentelemetry default-deny INGRESS
+#   allow-list is namespace-based (alloy + catalyst-system) — but the apiserver
+#   is HOST-NETWORK, so it carries the reserved `kube-apiserver` identity that no
+#   namespaceSelector can match. So the apiserver call into the
+#   bp-opentelemetry-operator `minstrumentation.kb.io` mutating webhook (Service
+#   opentelemetry-operator-webhook:443 to pod :9443) was Cilium-dropped — the
+#   operator post-install hook (apply default Instrumentation CR, routed through
+#   that webhook) logged `context deadline exceeded`, the bp-opentelemetry-
+#   operator HR Stalled (MissingRollbackTarget), and on a fresh prov the
+#   all-terminal handover gate could not fire (stalled at 59/62 HRs). Live-proven
+#   on dep 00720a7a9c72364d (kom4dc, 2026-06-27). A K8s NetworkPolicy cannot
+#   express reserved:kube-apiserver, so the allow lives in a CiliumNetworkPolicy
+#   — same reserved-entity class as the gateway `ingress` CNP (#4401 added the
+#   analogous fromEntities pattern) and the apiserver-egress CNP. Additive
+#   (admits ONLY the apiserver on :9443, scoped to the operator pods);
+#   default-deny posture intact. New per-component `apiserverWebhookPorts` +
+#   `apiserverWebhookSelector` values; only the opentelemetry entry sets them.
+version: 0.1.11
 description: |
   Per-component default-deny + explicit-allow micro-segmentation for the
   de-vclustered platform planes (#4291 Workstream C). For each platform

--- a/platform/plane-isolation/chart/templates/apiserver-webhook-ingress-cnp.yaml
+++ b/platform/plane-isolation/chart/templates/apiserver-webhook-ingress-cnp.yaml
@@ -1,0 +1,92 @@
+{{- /*
+Per-component kube-apiserver-webhook-INGRESS CiliumNetworkPolicy (#4579).
+
+THE ingress mirror of apiserver-egress-cnp.yaml (#4428). That template admits
+the apiserver as an EGRESS target (a default-denied pod dialing the kube-API
+VIP 10.96.0.1:443). THIS template admits the apiserver as an INGRESS SOURCE —
+the reverse direction, for components that run an admission/conversion webhook
+the kube-apiserver itself calls back into.
+
+The companion default-deny NetworkPolicy is podSelector:{} Ingress whose
+allow-list is PURELY namespaceSelector rules (same-ns + flux-system + the
+explicit allowIngressFrom). The kube-apiserver is HOST-NETWORK, so it carries
+the reserved `kube-apiserver` security identity — which is NOT a pod (so a
+namespaceSelector can NEVER match it) and NOT `world`. Result: an apiserver→
+pod:<webhookPort> admission-webhook call is silently dropped → the webhook
+server is unreachable → every API write the webhook intercepts times out.
+
+Live proof (bp-opentelemetry-operator, kom4dc dep 00720a7a9c72364d, 2026-06-27):
+the operator's `minstrumentation.kb.io` MUTATING webhook is backed by Service
+`opentelemetry-operator-webhook.opentelemetry.svc:443` → pod port :9443. The
+operator's post-install Helm hook applies the default Instrumentation CR, which
+the apiserver routes through that webhook. With the `opentelemetry` default-deny
+in force the apiserver→operator:9443 call is dropped → the hook logs `context
+deadline exceeded` → the bp-opentelemetry-operator HelmRelease Stalls
+(MissingRollbackTarget) → on a fresh prov the all-terminal handover gate can't
+fire (stalls at 59/62 HRs).
+
+A vanilla K8s NetworkPolicy cannot express reserved:kube-apiserver, so — exactly
+like the gateway `ingress` entity (gateway-ingress-cnp.yaml) and the apiserver
+egress (apiserver-egress-cnp.yaml) — the allow lives in a CiliumNetworkPolicy.
+Cilium computes the UNION of every policy selecting an endpoint, so this is
+purely ADDITIVE to the default-deny: it admits ONLY the kube-apiserver (plus
+host / remote-node, since the apiserver runs in the host netns and may sit on a
+peer node) on ONLY the declared webhook port(s) — no `world`, no broad ingress.
+
+Rendered ONLY for a component that declares `apiserverWebhookPorts` (the set of
+TCP ports its admission/conversion webhook server listens on). Pure-backend and
+public-route components that run no apiserver-called webhook get NO extra admit.
+An optional per-component `apiserverWebhookSelector` (matchLabels) narrows the
+endpointSelector to just the webhook pods (mirrors the proven live recovery
+`app.kubernetes.io/name: opentelemetry-operator`); absent, it defaults to
+endpointSelector:{} (every pod in the namespace, matching the default-deny
+scope — still tight because only the named port(s) are admitted).
+
+Gated on the cilium.io/v2 Capabilities check (the #2988/#3102 idiom) so the
+chart still installs on CRD-less clusters (kind CI), and carries the #4456
+defer-if-absent namespace guard so the atomic Helm install can't fail on a
+not-yet-created namespace (parity with the other three per-component templates).
+*/ -}}
+{{- if and .Values.enabled (.Capabilities.APIVersions.Has "cilium.io/v2") -}}
+{{- range .Values.components }}
+{{- if .apiserverWebhookPorts }}
+{{- $ns := .namespace }}
+{{- $guardNamespace := not (eq (toString .ensureNamespacePresent) "false") }}
+{{- if and $guardNamespace (not $.Values.renderUnconditional) (not (lookup "v1" "Namespace" "" $ns)) }}
+{{- /* namespace not present yet — defer this component's CNP to a later reconcile */ -}}
+{{- else }}
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ $ns }}-allow-apiserver-webhook-ingress
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-plane-isolation.labels" $ | nindent 4 }}
+    catalyst.openova.io/component: {{ $ns }}-apiserver-webhook-netpol
+spec:
+  # endpointSelector narrows to the webhook pods when apiserverWebhookSelector is
+  # set (proven live recovery scoped to app.kubernetes.io/name); otherwise {} =
+  # every endpoint in this namespace, matching the default-deny policy's scope.
+  endpointSelector:
+    {{- if .apiserverWebhookSelector }}
+    matchLabels:
+      {{- toYaml .apiserverWebhookSelector | nindent 6 }}
+    {{- else }}
+    {}
+    {{- end }}
+  ingress:
+    - fromEntities:
+        - kube-apiserver
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+        {{- range .apiserverWebhookPorts }}
+            - port: {{ . | quote }}
+              protocol: TCP
+        {{- end }}
+{{- end }}{{/* end namespace-present guard */}}
+{{- end }}{{/* end apiserverWebhookPorts guard */}}
+{{- end }}
+{{- end -}}

--- a/platform/plane-isolation/chart/values.yaml
+++ b/platform/plane-isolation/chart/values.yaml
@@ -33,7 +33,15 @@ renderUnconditional: false
 #   * the gateway-ingress CiliumNetworkPolicy fromEntities:[ingress,host,
 #     remote-node] when `gatewayIngress: true` (every component fronted by a
 #     public HTTPRoute needs it; pure-backend components like loki/mimir/tempo/
-#     valkey/seaweedfs/vllm/nats/sandbox/coraza do NOT face the gateway).
+#     valkey/seaweedfs/vllm/nats/sandbox/coraza do NOT face the gateway), and
+#   * the kube-apiserver-webhook-ingress CiliumNetworkPolicy fromEntities:
+#     [kube-apiserver,host,remote-node] on the declared TCP port(s) when
+#     `apiserverWebhookPorts: [<port>...]` is set — for a component that runs an
+#     admission/conversion webhook the kube-apiserver calls back into (the
+#     reserved `kube-apiserver` identity is host-network → no namespaceSelector
+#     can admit it). Optional `apiserverWebhookSelector` (matchLabels) narrows
+#     the policy to just the webhook pods. Only bp-opentelemetry-operator needs
+#     it today (`minstrumentation.kb.io` on :9443, #4579).
 #
 # allowIngressFrom is the EXPLICIT cross-component call graph, derived from the
 # whole-plane bp-{mgmt,rtz,dmz}-vcluster allow-lists + each chart's own NP. It
@@ -159,8 +167,24 @@ components:
       - grafana                    # grafana queries tempo
       - alloy                      # alloy ships traces
       - opentelemetry              # otel collector ships traces
-  - namespace: opentelemetry       # OTLP collector (no public route)
+  - namespace: opentelemetry       # OTLP collector + OTel operator (no public route)
     gatewayIngress: false
+    # The bp-opentelemetry-operator admission webhook (`minstrumentation.kb.io`,
+    # Service opentelemetry-operator-webhook:443 → pod :9443) is called BACK by
+    # the kube-apiserver when the operator's post-install hook applies the
+    # default Instrumentation CR. The apiserver is host-network → reserved
+    # `kube-apiserver` identity → no namespaceSelector in the default-deny can
+    # admit it → the webhook call is dropped → the hook `context deadline
+    # exceeded` → the HR Stalls (MissingRollbackTarget) → the all-terminal
+    # handover gate can't fire on a fresh prov (stalls at 59/62 HRs). Renders a
+    # companion CiliumNetworkPolicy (apiserver-webhook-ingress-cnp.yaml) that
+    # admits ONLY the apiserver on :9443 — same reserved-entity class as the
+    # gateway `ingress` CNP + the apiserver-egress CNP, additive to the
+    # default-deny. Scoped to the operator pods via apiserverWebhookSelector
+    # (the proven live recovery on kom4dc 00720a7a9c72364d, Refs #4579 #4401).
+    apiserverWebhookPorts: [9443]
+    apiserverWebhookSelector:
+      app.kubernetes.io/name: opentelemetry-operator
     allowIngressFrom:
       - alloy                      # alloy forwards OTLP logs/metrics/traces to the collector
                                    # (slot 21-alloy → opentelemetry-collector:4317). The otel

--- a/tests/e2e/bootstrap-kit/main_test.go
+++ b/tests/e2e/bootstrap-kit/main_test.go
@@ -10,23 +10,23 @@
 //
 // The architecture (per docs/SOVEREIGN-PROVISIONING.md §3) is:
 //
-//   OpenTofu provisions Phase 0 → cloud-init starts k3s → cloud-init
-//   bootstraps Flux → Flux reconciles clusters/<sovereign-fqdn>/ from this
-//   monorepo → that subtree contains a Kustomization tree that installs the
-//   11-component bootstrap kit in dependency order.
+//	OpenTofu provisions Phase 0 → cloud-init starts k3s → cloud-init
+//	bootstraps Flux → Flux reconciles clusters/<sovereign-fqdn>/ from this
+//	monorepo → that subtree contains a Kustomization tree that installs the
+//	11-component bootstrap kit in dependency order.
 //
 // The "right Kustomizations" assertion is therefore:
-//   1. clusters/_template/ exists and renders to valid Flux Kustomization
-//      manifests after SOVEREIGN_FQDN_PLACEHOLDER substitution
-//   2. The dependency graph encoded by `dependsOn` matches the canonical
-//      11-phase order: cilium → cert-manager → flux → crossplane →
-//      sealed-secrets → spire → nats-jetstream → openbao → keycloak →
-//      gitea → bp-catalyst-platform
-//   3. Each referenced platform/<x>/blueprint.yaml + chart/Chart.yaml
-//      actually exists at the path the Kustomization claims
-//   4. On a kind cluster (CI): Flux CRDs install, the GitRepository points
-//      at the local checkout, and the Kustomization objects are accepted
-//      by the API server (their OpenAPI schema is satisfied)
+//  1. clusters/_template/ exists and renders to valid Flux Kustomization
+//     manifests after SOVEREIGN_FQDN_PLACEHOLDER substitution
+//  2. The dependency graph encoded by `dependsOn` matches the canonical
+//     11-phase order: cilium → cert-manager → flux → crossplane →
+//     sealed-secrets → spire → nats-jetstream → openbao → keycloak →
+//     gitea → bp-catalyst-platform
+//  3. Each referenced platform/<x>/blueprint.yaml + chart/Chart.yaml
+//     actually exists at the path the Kustomization claims
+//  4. On a kind cluster (CI): Flux CRDs install, the GitRepository points
+//     at the local checkout, and the Kustomization objects are accepted
+//     by the API server (their OpenAPI schema is satisfied)
 //
 // Note: the test deliberately does NOT wait for the kit to fully install
 // upstream charts — that is what #141 (real Hetzner end-to-end) covers.
@@ -424,22 +424,22 @@ func TestBootstrapKit_TemplateClusterParses(t *testing.T) {
 //
 // This test asserts the platform-plane invariants that must hold post-#4291:
 //
-//   1. NO bootstrap-kit HelmRelease carries a `kubeConfig.secretRef` pointing
-//      at a plane-vCluster mirror Secret (vc-mgmt / vc-rtz / vc-dmz) — that was
-//      the #3642 "vCluster pivot" render mechanism, now retired for platform
-//      planes. (Per-Org vClusters are NOT in clusters/_template/bootstrap-kit/;
-//      they are emitted per-Organization by the org-controller.)
-//   2. NO HelmRelease carries the stale `catalyst.openova.io/vcluster` label.
-//   3. The plane-vCluster runtime slots (54 bp-dmz-vcluster, 58 bp-mgmt-vcluster,
-//      59 bp-rtz-vcluster) and slot 00 (vcluster-host-namespaces) are RETIRED.
-//   4. The newapi render-split companion slot 80a (bp-newapi-host-seams) is
-//      RETIRED and its #4321/#4305/#4278 fixes are preserved in slot 80, which
-//      now renders host-native `placement.role: all` with `cnpg.enabled: true`
-//      (the app HR itself renders the CNPG Cluster + DSN-sync + admin-promote
-//      + AppRegistration + ExternalSecrets natively in host ns `newapi`).
-//   5. bp-plane-isolation (slot 26b) — the per-component default-deny
-//      micro-segmentation that replaces the coarse whole-plane vCluster
-//      boundary — IS present.
+//  1. NO bootstrap-kit HelmRelease carries a `kubeConfig.secretRef` pointing
+//     at a plane-vCluster mirror Secret (vc-mgmt / vc-rtz / vc-dmz) — that was
+//     the #3642 "vCluster pivot" render mechanism, now retired for platform
+//     planes. (Per-Org vClusters are NOT in clusters/_template/bootstrap-kit/;
+//     they are emitted per-Organization by the org-controller.)
+//  2. NO HelmRelease carries the stale `catalyst.openova.io/vcluster` label.
+//  3. The plane-vCluster runtime slots (54 bp-dmz-vcluster, 58 bp-mgmt-vcluster,
+//     59 bp-rtz-vcluster) and slot 00 (vcluster-host-namespaces) are RETIRED.
+//  4. The newapi render-split companion slot 80a (bp-newapi-host-seams) is
+//     RETIRED and its #4321/#4305/#4278 fixes are preserved in slot 80, which
+//     now renders host-native `placement.role: all` with `cnpg.enabled: true`
+//     (the app HR itself renders the CNPG Cluster + DSN-sync + admin-promote
+//     + AppRegistration + ExternalSecrets natively in host ns `newapi`).
+//  5. bp-plane-isolation (slot 26b) — the per-component default-deny
+//     micro-segmentation that replaces the coarse whole-plane vCluster
+//     boundary — IS present.
 func TestBootstrapKit_PlatformPlanesAreHostNative(t *testing.T) {
 	root := repoRoot(t)
 	kitDir := filepath.Join(root, "clusters", "_template", "bootstrap-kit")
@@ -1092,10 +1092,12 @@ func TestBootstrapKit_PlaneIsolationDialGraphIsCovered(t *testing.T) {
 			} `yaml:"ingress"`
 		} `yaml:"spec"`
 	}
-	ingressFrom := map[string]map[string]bool{} // targetNs -> set(sourceNs)
-	gatewayCNP := map[string]bool{}             // targetNs that have a gateway-ingress (`ingress` entity) CNP
-	apiserverCNP := map[string]bool{}           // targetNs that have a kube-apiserver-egress CNP (#4428)
-	allComponentNs := map[string]bool{}         // every ns that has a default-deny NetworkPolicy
+	ingressFrom := map[string]map[string]bool{}     // targetNs -> set(sourceNs)
+	gatewayCNP := map[string]bool{}                 // targetNs that have a gateway-ingress (`ingress` entity) CNP
+	apiserverCNP := map[string]bool{}               // targetNs that have a kube-apiserver-egress CNP (#4428)
+	apiserverWebhookCNP := map[string]bool{}        // targetNs that have a kube-apiserver-WEBHOOK-ingress CNP (#4579)
+	webhookCNPPorts := map[string]map[string]bool{} // targetNs -> set(port string) admitted on the webhook-ingress CNP (#4579)
+	allComponentNs := map[string]bool{}             // every ns that has a default-deny NetworkPolicy
 
 	dec := yaml.NewDecoder(strings.NewReader(string(out)))
 	for {
@@ -1136,10 +1138,39 @@ func TestBootstrapKit_PlaneIsolationDialGraphIsCovered(t *testing.T) {
 			if ns == "" {
 				continue
 			}
-			// Disambiguate the two CNP kinds this chart ships by name suffix:
-			// the gateway-ingress (`ingress` entity) CNP and the kube-apiserver
-			// egress CNP (#4428). Both select endpointSelector:{}.
+			// Disambiguate the CNP kinds this chart ships by name suffix:
+			// the gateway-ingress (`ingress` entity) CNP, the kube-apiserver
+			// egress CNP (#4428), and the kube-apiserver WEBHOOK-ingress CNP
+			// (#4579 — admits the apiserver INTO a component's webhook port).
+			// The webhook-ingress case is checked FIRST because its suffix
+			// (...-webhook-ingress) is the most specific.
 			switch {
+			case strings.HasSuffix(name, "-allow-apiserver-webhook-ingress"):
+				apiserverWebhookCNP[ns] = true
+				// Capture the admitted webhook port(s) so the test can assert
+				// the OTel-operator :9443 admit is present (not just any port).
+				if webhookCNPPorts[ns] == nil {
+					webhookCNPPorts[ns] = map[string]bool{}
+				}
+				spec, _ := raw["spec"].(map[string]any)
+				ingress, _ := spec["ingress"].([]any)
+				for _, ri := range ingress {
+					rule, _ := ri.(map[string]any)
+					toPorts, _ := rule["toPorts"].([]any)
+					for _, tpi := range toPorts {
+						tp, _ := tpi.(map[string]any)
+						ports, _ := tp["ports"].([]any)
+						for _, pi := range ports {
+							p, _ := pi.(map[string]any)
+							switch v := p["port"].(type) {
+							case string:
+								webhookCNPPorts[ns][v] = true
+							case int:
+								webhookCNPPorts[ns][fmt.Sprintf("%d", v)] = true
+							}
+						}
+					}
+				}
 			case strings.HasSuffix(name, "-allow-apiserver-egress"):
 				apiserverCNP[ns] = true
 			case strings.HasSuffix(name, "-allow-gateway-ingress"):
@@ -1217,6 +1248,32 @@ func TestBootstrapKit_PlaneIsolationDialGraphIsCovered(t *testing.T) {
 	for ns := range allComponentNs {
 		if !apiserverCNP[ns] {
 			t.Errorf("bp-plane-isolation: default-denied component %q is MISSING its allow-apiserver-egress CiliumNetworkPolicy — pods that dial the kube-API (e.g. the CNPG instance-manager) will time out on 10.96.0.1:443 → HR wedge (#4428 #4409). apiserver-egress-cnp.yaml renders for every component; this gap means a render regression", ns)
+		}
+	}
+
+	// A component that runs an admission/conversion webhook the kube-apiserver
+	// calls BACK into MUST carry the kube-apiserver-WEBHOOK-ingress CNP (#4579)
+	// on the webhook port. The default-deny's INGRESS allow-list is purely
+	// namespaceSelector — but the apiserver is host-network → reserved
+	// `kube-apiserver` identity → no namespaceSelector can admit it → the
+	// apiserver→webhook call is silently dropped → the operator post-install
+	// hook `context deadline exceeded` → the HR Stalls (MissingRollbackTarget)
+	// → the all-terminal handover gate can't fire. Today only
+	// bp-opentelemetry-operator needs it (`minstrumentation.kb.io` on :9443,
+	// Service opentelemetry-operator-webhook:443 → pod :9443). Live-proven dep
+	// 00720a7a9c72364d (kom4dc, 2026-06-27). This edge fails WITHOUT the
+	// apiserverWebhookPorts: [9443] value on the opentelemetry entry and PASSES
+	// with it — the same guard class that caught #4448/#4499/#4428.
+	wantWebhookCNP := map[string]string{
+		"opentelemetry": "9443",
+	}
+	for ns, port := range wantWebhookCNP {
+		if !apiserverWebhookCNP[ns] {
+			t.Errorf("bp-plane-isolation: webhook component %q is MISSING its allow-apiserver-webhook-ingress CiliumNetworkPolicy — the kube-apiserver→webhook call (reserved `kube-apiserver` identity, no namespaceSelector can admit it) will be DROPPED → the operator post-install hook `context deadline exceeded` → HR Stalls → handover gate can't fire (#4579). Set apiserverWebhookPorts: [%s] on the %q entry in platform/plane-isolation/chart/values.yaml", ns, port, ns)
+			continue
+		}
+		if !webhookCNPPorts[ns][port] {
+			t.Errorf("bp-plane-isolation: %q allow-apiserver-webhook-ingress CiliumNetworkPolicy does NOT admit the apiserver on port %s — the webhook server listens there; the call will be DROPPED (#4579). Ensure apiserverWebhookPorts on the %q entry contains %s", ns, port, ns, port)
 		}
 	}
 }


### PR DESCRIPTION
Refs #4579 #3379

## Problem

The bp-plane-isolation `opentelemetry-default-deny` NetworkPolicy ingress allow-list is namespace-based (alloy + catalyst-system). The kube-apiserver is **host-network**, so it carries the reserved `kube-apiserver` Cilium identity that **no `namespaceSelector` can ever match** — the same reserved-entity trap as #4401.

So the apiserver's callback into the bp-opentelemetry-operator `minstrumentation.kb.io` **mutating webhook** (Service `opentelemetry-operator-webhook.opentelemetry.svc:443` -> pod `:9443`) was Cilium-dropped. The operator's post-install Helm hook (which applies the default `Instrumentation` CR, routed through that webhook) then logged `context deadline exceeded`, the `bp-opentelemetry-operator` HR Stalled (`MissingRollbackTarget`), and on a fresh kom4dc prov the all-terminal handover gate could not fire (stalled at 59/62 HRs).

Live-proven on dep `00720a7a9c72364d`.

## Fix (durable, matches the proven live recovery)

A K8s `NetworkPolicy` cannot express `reserved:kube-apiserver`, so — exactly like the gateway `ingress` CNP and the #4428 apiserver-**egress** CNP — the allow lives in a `CiliumNetworkPolicy`. This is the **ingress mirror** of the existing apiserver-egress template.

- **New template** `apiserver-webhook-ingress-cnp.yaml` renders a per-component CNP `fromEntities:[kube-apiserver,host,remote-node]` on the declared TCP port(s) when a component sets `apiserverWebhookPorts`. Additive to the default-deny (admits **only** the apiserver on `:9443`, scoped to the operator pods via `apiserverWebhookSelector`) — default-deny posture intact. Carries the #4456 defer-if-absent namespace guard + the `cilium.io/v2` capability gate, in parity with the other three per-component templates.
- The `opentelemetry` entry sets `apiserverWebhookPorts: [9443]` + `apiserverWebhookSelector: {app.kubernetes.io/name: opentelemetry-operator}` (the proven live recovery endpointSelector).
- Chart `0.1.10` -> `0.1.11`; `blueprint.yaml` + slot-26b pin lockstep; `configSchema` documents the two new per-component fields.
- **Case-30 dial-graph contract test** (`tests/e2e/bootstrap-kit/main_test.go`) asserts the apiserver->`opentelemetry`:`9443` webhook-ingress CNP edge — verified it **fails without** the values change and **passes with** it (the same guard that caught #4448/#4499/#4428).

## Rendered CNP

```yaml
apiVersion: cilium.io/v2
kind: CiliumNetworkPolicy
metadata:
  name: opentelemetry-allow-apiserver-webhook-ingress
  namespace: opentelemetry
spec:
  endpointSelector:
    matchLabels:
      app.kubernetes.io/name: opentelemetry-operator
  ingress:
    - fromEntities: [kube-apiserver, host, remote-node]
      toPorts:
        - ports:
            - port: "9443"
              protocol: TCP
```

## Verification

- `helm lint` clean; `helm template --api-versions cilium.io/v2 --set renderUnconditional=true` renders exactly one webhook-ingress CNP (opentelemetry only), all docs parse.
- `go test ./tests/e2e/bootstrap-kit/...` green (Case-30 included); `go vet` + `gofmt` clean.

## Roll gate

**Roll-gated, not yet live-verified beyond the chart+test proof.** Clears #4579 (roll-gated) only when a fresh prov's `bp-opentelemetry-operator` reaches terminal-Ready (no webhook `context deadline exceeded`) and the all-terminal handover gate fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)