### PR TITLE
fix(bp-self-sovereign-cutover): step-06 source-controller TLS-trust certSecretRef — last cert-tail x509 leg (Refs #3379)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -637,7 +637,18 @@ spec:
       # via the bp-catalyst-platform chart 1.4.927) — kills the step-08 fresh-
       # pull FATAL on the two residual ghcr.io tethers.
       # 0.1.87 (#4581 Refs #3379): step-03 Phase-A2 chart mirror wraps each skopeo copy in an outer attempt loop (PREWARM_COPY_ATTEMPTS) — a transient in-cluster-Harbor DEST 504 (not caught by skopeo --retry-times) no longer FATAL-s the whole cutover on one chart (live: bp-alloy 504 on prov 00720a7a, chart_ok=61/62).
-      version: 0.1.87
+      # 0.1.88 (#3379): the LAST leg of the cutover cert-tail — source-controller
+      # OCI-pull TLS-trust. Step-06 reads the in-cluster Harbor wildcard CA
+      # (sovereign-wildcard-tls-<fqdn-dashed>, kube-system) into a ca.crt-only
+      # Secret cutover-harbor-ca (flux-system) and patches every pivoted
+      # HelmRepository's spec.certSecretRef to it (live HR patch + durable Gitea
+      # inject), so source-controller TRUSTS the LE-staging in-cluster registry
+      # instead of `tls: x509: certificate signed by unknown authority` on every
+      # pivoted pull (live wedge dep 00720a7a). Flux OCI HRs have no
+      # insecureSkipVerify — certSecretRef is the only trust mechanism (mirrors
+      # skopeo #4529 / helm #4557 / containerd step-04 / OBS #4573 F2). Fail-OPEN
+      # when the CA is unreadable. Lockstep w/ Chart.yaml + blueprint.yaml.
+      version: 0.1.88
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.87
+  version: 0.1.88
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,48 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.88 (#3379, the LAST leg of the cutover cert-tail — source-controller
+# OCI-pull TLS-trust, live wedge on dep 00720a7a, 2026-06-28): step-06 now
+# gives the Flux SOURCE-CONTROLLER a trust path to the in-cluster Harbor.
+#
+# THE WEDGE. Step-06 Phase-1 pivots every openova-io HelmRepository's spec.url
+# from oci://ghcr.io/openova-io to oci://registry.<sov-fqdn>/openova-io. The
+# source-controller then pulls those OCI charts from the in-cluster Harbor —
+# whose wildcard `*.<sov-fqdn>` cert is served by the bootstrap LE-STAGING
+# issuer on a fresh / qaTestEnabled prov. source-controller carries only the
+# public CA bundle, so EVERY pivoted pull fails `tls: x509: certificate signed
+# by unknown authority` → the pivot never reconciles → Phase-3a's strip-
+# readiness gate never converges → the cutover never reaches the 600s deny-
+# egress hold → cutoverComplete never set (live dep 00720a7a). This is the
+# SAME LE-staging-in-cluster-Harbor cert pattern already closed at every OTHER
+# layer that talks to the registry — skopeo (#4529 --dest-tls-verify=false),
+# the helm CLI (#4557 --insecure-skip-tls-verify), containerd (step-04
+# skip_verify), and the OBS blob-redirect (#4573 F2 disableRedirect) — but the
+# source-controller leg had NO trust path until now.
+#
+# THE FIX (per-leg certSecretRef, consistent with #4529/#4557/#4573). Unlike
+# skopeo / helm / containerd, the Flux OCI HelmRepository API has NO
+# insecureSkipVerify field for spec.type=oci — the ONLY trust mechanism
+# source-controller honors is `spec.certSecretRef` → a Secret whose `ca.crt`
+# verifies the registry cert. Step-06 gains:
+#   - Phase-0.5: read the in-cluster Harbor serving cert's CA from the wildcard
+#     TLS Secret `sovereign-wildcard-tls-<fqdn-dashed>` in kube-system (prefer
+#     `ca.crt`, fall back to `tls.crt`) and create a ca.crt-only Secret
+#     `cutover-harbor-ca` in flux-system (Opaque — never copies the private key).
+#   - Phase-1: patch each pivoted HelmRepository's spec.certSecretRef to it in
+#     the SAME merge-patch as the URL pivot (so a pivoted url never lands
+#     trust-less even for one reconcile tick); already-URL-pivoted HRs get the
+#     ref back-filled on re-run.
+#   - Phase-2: inject `certSecretRef:` into each pivoted HelmRepository YAML in
+#     the local-Gitea bootstrap-kit slots (same indent as `url:`), so the
+#     bootstrap-kit Kustomization reconcile keeps the trust ref instead of
+#     reverting it ~1 min later and re-x509-failing every pull.
+# Fail-OPEN: helmRepositoryTrust.enabled=false, or an unreadable wildcard
+# Secret/CA, pivots the URL WITHOUT a certSecretRef (prior behaviour for a
+# public-CA-trusted Harbor) rather than wedging the cutover on the trust seam.
+# It does NOT widen source-controller's trust for any external host (the CA
+# bundle verifies ONLY the cluster's own registry cert chain). RBAC already
+# covers the cross-namespace Secret read + create/patch (cluster-scoped secrets
+# get/create/patch). New values block: .Values.helmRepositoryTrust.
 # 0.1.86 (#4573 Refs #3379, the two GENUINE clean-fresh-prov cutover faults —
 # the ones a version-frozen cutover hits, separate from the F1/F3/F5 re-drive
 # contamination that only bites driving NEW chart/image versions onto an
@@ -1225,7 +1268,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.87
+version: 0.1.88
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
@@ -163,6 +163,22 @@ data:
           # cluster's own registry.
           - name: HELM_IN_CLUSTER_TLS_VERIFY
             value: {{ .Values.helmReadinessProbe.inClusterTLSVerify | default false | quote }}
+          # Refs #3379 — source-controller TLS-trust for the pivoted
+          # HelmRepositories. Phase-0.5 extracts the in-cluster Harbor
+          # serving cert's CA from the wildcard TLS Secret and creates a
+          # ca.crt-only Secret in HELMREPO_NAMESPACE; Phase-1 patches every
+          # pivoted HelmRepository's spec.certSecretRef to it so
+          # source-controller trusts the LE-staging in-cluster registry.
+          # Flux OCI HelmRepository has NO insecureSkipVerify — certSecretRef
+          # is the only mechanism (see .Values.helmRepositoryTrust).
+          - name: HELMREPO_TRUST_ENABLED
+            value: {{ .Values.helmRepositoryTrust.enabled | default false | quote }}
+          - name: HELMREPO_TRUST_SRC_NAMESPACE
+            value: {{ .Values.helmRepositoryTrust.sourceSecretNamespace | quote }}
+          - name: HELMREPO_TRUST_SRC_NAME_PREFIX
+            value: {{ .Values.helmRepositoryTrust.sourceSecretNamePrefix | quote }}
+          - name: HELMREPO_TRUST_DEST_SECRET
+            value: {{ .Values.helmRepositoryTrust.destSecretName | quote }}
         volumeMounts:
           - name: helmrepository-list
             mountPath: /work
@@ -412,6 +428,69 @@ data:
               done || true
             fi
 
+            # ---- Phase 0.5: build the source-controller TLS-trust Secret (Refs #3379) ----
+            #
+            # THE LAST LEG OF THE CUTOVER CERT-TAIL. After Phase-1 pivots each
+            # HelmRepository URL to oci://${harbor_host}/openova-io, the Flux
+            # SOURCE-CONTROLLER pulls those OCI charts from the in-cluster
+            # Harbor — whose wildcard `*.${SOVEREIGN_FQDN}` cert is served by
+            # the bootstrap LE-STAGING issuer on a fresh / qaTestEnabled prov.
+            # source-controller carries only the public CA bundle → every
+            # pivoted pull fails `tls: x509: certificate signed by unknown
+            # authority` → the pivot never reconciles → Phase-3a's strip-
+            # readiness gate never converges → the cutover never reaches the
+            # 600s deny-egress hold → cutoverComplete never set (live dep
+            # 00720a7a). Flux OCI HelmRepository has NO insecureSkipVerify; the
+            # ONLY trust mechanism is spec.certSecretRef → a Secret whose
+            # `ca.crt` verifies the registry cert. This phase materialises that
+            # Secret in ${HELMREPO_NAMESPACE}; Phase-1 wires each pivoted HR's
+            # certSecretRef to it; Phase-2 makes both durable in Gitea.
+            #
+            # Fail-OPEN: if trust is disabled, or the wildcard Secret / CA
+            # cannot be read, we log and continue WITHOUT a certSecretRef
+            # (preserving the prior behaviour for a public-CA-trusted Harbor)
+            # rather than wedging the whole cutover on the trust seam.
+            trust_secret=""
+            case "${HELMREPO_TRUST_ENABLED:-false}" in
+              true|True|TRUE|1|yes)
+                # Wildcard TLS Secret name = <prefix><fqdn with '.'->'-'>.
+                fqdn_dashed=$(printf '%s' "${SOVEREIGN_FQDN}" | tr '.' '-')
+                wc_secret="${HELMREPO_TRUST_SRC_NAME_PREFIX}${fqdn_dashed}"
+                echo "[helmrepository-patches] Phase-0.5: building source-controller trust Secret from ${HELMREPO_TRUST_SRC_NAMESPACE}/${wc_secret}"
+                # Prefer the issuing CA (`ca.crt`); fall back to the served
+                # leaf+chain (`tls.crt`) used as a self-trust bundle when the
+                # issuer did not populate ca.crt. Read via `-o json | jq` to
+                # dodge the jsonpath dotted-key ambiguity (Fix #77 shape).
+                ca_b64=$(kubectl get secret "${wc_secret}" -n "${HELMREPO_TRUST_SRC_NAMESPACE}" -o json 2>/dev/null \
+                  | jq -r '.data["ca.crt"] // empty')
+                if [ -z "${ca_b64}" ]; then
+                  echo "[helmrepository-patches] Phase-0.5: ${wc_secret} has no ca.crt; falling back to tls.crt as the trust bundle"
+                  ca_b64=$(kubectl get secret "${wc_secret}" -n "${HELMREPO_TRUST_SRC_NAMESPACE}" -o json 2>/dev/null \
+                    | jq -r '.data["tls.crt"] // empty')
+                fi
+                if [ -z "${ca_b64}" ]; then
+                  echo "[helmrepository-patches] Phase-0.5 WARN: could not read ca.crt or tls.crt from ${HELMREPO_TRUST_SRC_NAMESPACE}/${wc_secret} — pivoting HelmRepository URLs WITHOUT a certSecretRef (source-controller will need a public-CA-trusted Harbor cert)"
+                else
+                  # Create/replace the ca.crt-only Secret in the HelmRepository
+                  # namespace. Opaque (not kubernetes.io/tls): source-controller
+                  # reads only the `ca.crt` key for certSecretRef; the private
+                  # key is deliberately NEVER copied. `kubectl apply` is
+                  # idempotent (re-runs converge; a CA rotation re-applies).
+                  trust_manifest=$(printf 'apiVersion: v1\nkind: Secret\nmetadata:\n  name: %s\n  namespace: %s\n  labels:\n    app.kubernetes.io/managed-by: self-sovereign-cutover\n    bp.openova.io/cutover-step: helmrepository-patches\ntype: Opaque\ndata:\n  ca.crt: %s\n' \
+                    "${HELMREPO_TRUST_DEST_SECRET}" "${HELMREPO_NAMESPACE}" "${ca_b64}")
+                  if printf '%s' "${trust_manifest}" | kubectl apply -f - >/dev/null 2>&1; then
+                    trust_secret="${HELMREPO_TRUST_DEST_SECRET}"
+                    echo "[helmrepository-patches] Phase-0.5 OK: ${HELMREPO_NAMESPACE}/${HELMREPO_TRUST_DEST_SECRET} carries the in-cluster Harbor CA — pivoted HelmRepositories will reference it via certSecretRef"
+                  else
+                    echo "[helmrepository-patches] Phase-0.5 WARN: kubectl apply of ${HELMREPO_NAMESPACE}/${HELMREPO_TRUST_DEST_SECRET} failed — pivoting WITHOUT a certSecretRef"
+                  fi
+                fi
+                ;;
+              *)
+                echo "[helmrepository-patches] Phase-0.5 skip: helmRepositoryTrust.enabled=false — pivoting HelmRepository URLs WITHOUT a certSecretRef"
+                ;;
+            esac
+
             # ---- Phase 1: live K8s patches (immediate) ----
             ok=0
             skip=0
@@ -432,19 +511,59 @@ data:
 
               new_url=$(printf '%s' "${cur_url}" | sed -e "s,${UPSTREAM_PREFIX},${local_prefix},")
               if [ "${new_url}" = "${cur_url}" ]; then
+                # URL is already pivoted (or non-default). On a re-run the URL
+                # may already point at local Harbor while the certSecretRef is
+                # still absent — apply the trust ref so an already-pivoted HR
+                # is not left x509-failing source-controller (Refs #3379). Only
+                # acts when the URL is genuinely the local-Harbor host AND a
+                # trust secret was built AND the ref is not already present.
+                case "${cur_url}" in
+                  "${local_prefix}"|"${local_prefix}/"*)
+                    if [ -n "${trust_secret}" ]; then
+                      cur_ref=$(kubectl get helmrepository "${name}" \
+                        -n "${HELMREPO_NAMESPACE}" \
+                        -o jsonpath='{.spec.certSecretRef.name}' 2>/dev/null || echo "")
+                      if [ "${cur_ref}" != "${trust_secret}" ]; then
+                        ref_patch=$(printf '{"spec":{"certSecretRef":{"name":"%s"}}}' "${trust_secret}")
+                        if kubectl patch helmrepository "${name}" \
+                            -n "${HELMREPO_NAMESPACE}" \
+                            --type=merge --patch "${ref_patch}" >/dev/null 2>&1; then
+                          kubectl annotate --overwrite helmrepository "${name}" \
+                            -n "${HELMREPO_NAMESPACE}" \
+                            "reconcile.fluxcd.io/requestedAt=$(date +%s)" >/dev/null 2>&1 || true
+                          echo "[helmrepository-patches] OK ${name} (already URL-pivoted; added certSecretRef=${trust_secret})"
+                          ok=$((ok+1))
+                          continue
+                        fi
+                      fi
+                    fi
+                    ;;
+                  *) : ;;
+                esac
                 echo "[helmrepository-patches] SKIP ${name} (already pivoted or non-default URL)"
                 skip=$((skip+1))
                 continue
               fi
 
-              patch=$(printf '{"spec":{"url":"%s"}}' "${new_url}")
+              # Wire the source-controller TLS-trust certSecretRef alongside
+              # the URL pivot (Refs #3379). Without it, source-controller
+              # x509-fails the very first pull against the LE-staging
+              # in-cluster Harbor. The certSecretRef is added in the SAME
+              # merge-patch so the URL never lands trust-less even for a
+              # reconcile tick. When trust_secret is empty (disabled or the CA
+              # was unreadable) we pivot the URL only — prior behaviour.
+              if [ -n "${trust_secret}" ]; then
+                patch=$(printf '{"spec":{"url":"%s","certSecretRef":{"name":"%s"}}}' "${new_url}" "${trust_secret}")
+              else
+                patch=$(printf '{"spec":{"url":"%s"}}' "${new_url}")
+              fi
               if kubectl patch helmrepository "${name}" \
                   -n "${HELMREPO_NAMESPACE}" \
                   --type=merge --patch "${patch}" >/dev/null; then
                 kubectl annotate --overwrite helmrepository "${name}" \
                   -n "${HELMREPO_NAMESPACE}" \
                   "reconcile.fluxcd.io/requestedAt=$(date +%s)" >/dev/null
-                echo "[helmrepository-patches] OK ${name} -> ${new_url}"
+                echo "[helmrepository-patches] OK ${name} -> ${new_url}${trust_secret:+ (certSecretRef=${trust_secret})}"
                 ok=$((ok+1))
               else
                 echo "[helmrepository-patches] FAIL ${name}"
@@ -582,6 +701,64 @@ data:
               echo "[helmrepository-patches] edited ${f}"
             done
             echo "[helmrepository-patches] sed edited ${edited} files"
+
+            # Phase-2 trust durability (Refs #3379): inject `certSecretRef:`
+            # into every HelmRepository spec whose url was just pivoted to the
+            # local Harbor, at the SAME indent as the `url:` line, so the
+            # bootstrap-kit Kustomization reconcile keeps the source-controller
+            # trust ref instead of reverting Phase-1's live certSecretRef patch
+            # (~1 min later) and re-x509-failing every pivoted pull. Idempotent:
+            # if a certSecretRef referencing trust_secret already sits in the
+            # same HelmRepository spec we leave it; awk only injects when the
+            # pivoted url line has no matching certSecretRef immediately after.
+            # Only runs when a trust secret was actually built (Phase-0.5).
+            if [ -n "${trust_secret}" ]; then
+              trust_edited=0
+              for f in $(grep -lE "^[[:space:]]*url:[[:space:]]*${local_prefix}([[:space:]]*|/.*)$" "${target_dir}"/*.yaml 2>/dev/null || true); do
+                awk -v ref="${trust_secret}" -v lp="${local_prefix}" '
+                  # Match a pivoted `url:` line (local Harbor prefix). Capture
+                  # its leading whitespace so the injected block aligns with the
+                  # sibling keys (type/interval/url/secretRef) under spec:.
+                  {
+                    line=$0
+                    if (match(line, /^[[:space:]]*url:[[:space:]]*/)) {
+                      val=line; sub(/^[[:space:]]*url:[[:space:]]*/, "", val)
+                      # Only the local-Harbor url lines (this file may also
+                      # carry an unrelated url: e.g. a GitRepository) — gate on
+                      # the value starting with the local prefix.
+                      if (index(val, lp) == 1) {
+                        indent=line; sub(/url:.*/, "", indent)
+                        print line
+                        print indent "certSecretRef:"
+                        print indent "  name: " ref
+                        injected_here=1
+                        next
+                      }
+                    }
+                    # Drop a pre-existing certSecretRef block that immediately
+                    # follows our just-printed url (avoids a duplicate on
+                    # re-run). A line at the url indent starting `certSecretRef:`
+                    # right after an injection is the stale one.
+                    if (injected_here==1 && match(line, /^[[:space:]]*certSecretRef:[[:space:]]*$/)) {
+                      injected_here=2   # swallow this line + its `name:` child
+                      next
+                    }
+                    if (injected_here==2 && match(line, /^[[:space:]]*name:[[:space:]]*/)) {
+                      injected_here=0   # swallow the child name line
+                      next
+                    }
+                    injected_here=0
+                    print line
+                  }
+                ' "${f}" > "${f}.trust" && mv "${f}.trust" "${f}"
+                trust_edited=$((trust_edited+1))
+                echo "[helmrepository-patches] trust-injected certSecretRef -> ${f}"
+              done
+              if [ "${trust_edited}" -gt 0 ]; then
+                edited=$((edited+trust_edited))
+                echo "[helmrepository-patches] Phase-2 trust: injected certSecretRef=${trust_secret} into ${trust_edited} pivoted HelmRepository YAML(s)"
+              fi
+            fi
 
             # Phase-2.5 (TBD-C19, 2026-05-18): inject openova-catalog URL
             # override into 13-bp-catalyst-platform.yaml's

--- a/platform/self-sovereign-cutover/chart/templates/rbac.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/rbac.yaml
@@ -21,7 +21,15 @@ The cutover runner needs cluster-scope reach because:
   - Step 06 patches HelmRepositories in `flux-system` namespace, AND
     (phase-0, #1184) merges harbor.<sov-fqdn> auth into the ghcr-pull
     Secret in `flux-system` so source-controller can pull from the
-    per-Sovereign Harbor mirror without manual kubectl patch.
+    per-Sovereign Harbor mirror without manual kubectl patch. It ALSO
+    (phase-0.5, #3379) READS the in-cluster Harbor wildcard TLS Secret in
+    `kube-system` and CREATES/patches a ca.crt-only Secret
+    (`cutover-harbor-ca`) in `flux-system`, then patches each pivoted
+    HelmRepository's spec.certSecretRef to it so source-controller TRUSTS
+    the LE-staging in-cluster registry (Flux OCI HRs have no
+    insecureSkipVerify — certSecretRef is the only trust mechanism). Both
+    the cross-namespace Secret read and the Secret create/patch are already
+    covered by the cluster-scoped secrets get/create/patch rules below.
   - Step 07 patches Deployment in `catalyst-platform` namespace.
   - Step 08 creates+deletes a CiliumNetworkPolicy cluster-wide, queries
     HelmRelease/Kustomization status across all namespaces, AND (#3526)

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -1144,4 +1144,56 @@ else
   echo "  SKIP (19-harbor.yaml not reachable from test cwd — chart consumed standalone)"
 fi
 
+echo "[cutover-contract] Case 35: step-06 wires a source-controller TLS-trust certSecretRef for the pivoted HelmRepositories (#3379, the last cert-tail leg)"
+# #3379: after step-06 pivots each openova-io HelmRepository to the in-cluster
+# Harbor (registry.<fqdn>), the Flux source-controller x509-fails the pull
+# because the LE-staging wildcard cert is not in its public CA bundle. Flux OCI
+# HelmRepository has NO insecureSkipVerify — the ONLY trust mechanism is
+# spec.certSecretRef -> a Secret whose ca.crt verifies the registry. Step-06
+# Phase-0.5 builds that Secret from the in-cluster Harbor wildcard cert and
+# Phase-1/Phase-2 wire each pivoted HR's certSecretRef to it. Assert the
+# rendered step-06 podSpec carries the trust env vars + the patch shape.
+STEP06_BLOCK=$(awk '/name: cutover-step-06-helmrepository-patches/,/^---$/' "$TMP/render.yaml")
+if [ -z "$STEP06_BLOCK" ]; then
+  # The ConfigMap name may render slightly differently across helm versions;
+  # fall back to the whole render so the substring asserts still fire.
+  STEP06_BLOCK=$(cat "$TMP/render.yaml")
+fi
+for tok in \
+  'HELMREPO_TRUST_ENABLED' \
+  'HELMREPO_TRUST_SRC_NAMESPACE' \
+  'HELMREPO_TRUST_SRC_NAME_PREFIX' \
+  'HELMREPO_TRUST_DEST_SECRET'; do
+  if ! printf '%s' "$STEP06_BLOCK" | grep -q "$tok"; then
+    echo "FAIL: step-06 podSpec missing trust env var ${tok} — source-controller has no certSecretRef trust path for the pivoted in-cluster-Harbor HelmRepositories (#3379)" >&2
+    exit 1
+  fi
+done
+# The pivot patch must carry certSecretRef alongside the url, and Phase-0.5 must
+# read the wildcard cert (ca.crt with tls.crt fallback) + create the dest Secret.
+if ! printf '%s' "$STEP06_BLOCK" | grep -q 'certSecretRef'; then
+  echo "FAIL: step-06 podSpec never sets spec.certSecretRef on the pivoted HelmRepositories — source-controller will x509 on the LE-staging in-cluster Harbor (#3379)" >&2
+  exit 1
+fi
+if ! printf '%s' "$STEP06_BLOCK" | grep -Eq 'ca\.crt'; then
+  echo "FAIL: step-06 podSpec never reads ca.crt from the in-cluster Harbor wildcard Secret — no trust bundle for the certSecretRef (#3379)" >&2
+  exit 1
+fi
+# Trust defaults must be present + sane in values.yaml (enabled true; the
+# wildcard-secret source in kube-system; the flux-system dest secret name).
+# cwd is $CHART_DIR (the script cd'd into it above), so values.yaml is local.
+if ! grep -Eq '^helmRepositoryTrust:' values.yaml; then
+  echo "FAIL: values.yaml has no helmRepositoryTrust block — the #3379 cert-tail fix is unconfigurable" >&2
+  exit 1
+fi
+# Extract the helmRepositoryTrust block (from its header to the next top-level
+# key) and assert enabled:true lives inside it — the block carries several
+# comment lines before `enabled:`, so a fixed -A window is too brittle.
+HRT_BLOCK=$(awk '/^helmRepositoryTrust:/{f=1; next} f&&/^[a-zA-Z]/{exit} f{print}' values.yaml)
+if ! printf '%s' "$HRT_BLOCK" | grep -Eq '^[[:space:]]+enabled:[[:space:]]*true'; then
+  echo "FAIL: helmRepositoryTrust.enabled is not true by default — fresh/qaTestEnabled provs serve an LE-staging in-cluster Harbor and need the trust path on by default (#3379)" >&2
+  exit 1
+fi
+echo "  PASS (step-06 builds a ca.crt trust Secret from the in-cluster Harbor wildcard cert + wires every pivoted HelmRepository's certSecretRef to it; helmRepositoryTrust.enabled defaults true)"
+
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -534,6 +534,60 @@ helmRepositories:
     # ghcr.io). Caught live on t22.omantel.biz 2026-05-18.
     - "openova-catalog"
 
+# ── HelmRepository TLS-trust for the in-cluster Harbor (Refs #3379) ──────
+#
+# THE LAST LEG OF THE CUTOVER CERT-TAIL. Step-06 Phase-1 pivots every
+# openova-io HelmRepository's spec.url from oci://ghcr.io/openova-io to
+# oci://registry.<sov-fqdn>/openova-io. The Flux SOURCE-CONTROLLER then
+# pulls those OCI charts from the in-cluster Harbor — whose wildcard
+# `*.<sov-fqdn>` cert is served by the BOOTSTRAP issuer
+# `letsencrypt-dns01-staging-powerdns` (LE-STAGING, untrusted by the public
+# CA bundle) on a fresh / qaTestEnabled prov. source-controller runs with
+# only the public CA bundle, so EVERY pivoted pull fails
+# `tls: x509: certificate signed by unknown authority` → the pivot never
+# reconciles → step-06 Phase-3a's strip-readiness gate never converges →
+# the cutover never reaches the 600s deny-egress hold → cutoverComplete
+# never set (live on dep 00720a7a).
+#
+# WHY certSecretRef (not a skip flag): unlike skopeo (#4529 --dest-tls-
+# verify=false), the helm CLI (#4557 --insecure-skip-tls-verify) and
+# containerd (step-04 skip_verify), the Flux OCI HelmRepository API has NO
+# `insecure`/`insecureSkipVerify` field for spec.type=oci — the ONLY trust
+# mechanism source-controller honors is `spec.certSecretRef` pointing at a
+# Secret whose `ca.crt` key holds the CA to verify the registry against
+# (host-scoped to registry.<sov-fqdn>, same scoping #4573 F2's
+# disableRedirect relies on). Step-06 extracts the in-cluster Harbor
+# serving cert's CA from the wildcard TLS Secret and patches every pivoted
+# HelmRepository's certSecretRef to it (live HR patch + durable Gitea edit),
+# so source-controller trusts the LE-staging registry over the cluster
+# network without trusting it publicly.
+#
+# This is a per-leg trust path consistent with the rest of the cert-tail;
+# it does NOT widen source-controller's trust for any external host (the
+# CA bundle here verifies ONLY the cluster's own registry cert chain).
+helmRepositoryTrust:
+  # Master switch. Default true — every fresh / qaTestEnabled prov serves
+  # the in-cluster Harbor on an LE-staging (or otherwise node-untrusted)
+  # wildcard, so source-controller needs the certSecretRef trust path. An
+  # operator whose in-cluster Harbor presents a public-CA-trusted cert AND
+  # whose source-controller already trusts it may set this false via
+  # overlay (then the pivoted HRs pull with the default public trust store).
+  enabled: true
+  # The cert-manager TLS Secret backing the in-cluster Harbor's wildcard
+  # serving cert. Lives in `kube-system` (clusters/_template/sovereign-tls/
+  # cilium-gateway-cert.yaml: secretName sovereign-wildcard-tls-<fqdn-
+  # dashed>). Step-06 reads its `ca.crt` (the issuing CA — LE-staging
+  # intermediate on a fresh prov) and, if absent, falls back to `tls.crt`
+  # (the served leaf+chain used as a self-trust bundle). The `<fqdn-dashed>`
+  # suffix is computed at runtime from sovereign.fqdn ('.'->'-').
+  sourceSecretNamespace: "kube-system"
+  sourceSecretNamePrefix: "sovereign-wildcard-tls-"
+  # Destination Secret created/updated by step-06 in the HelmRepository
+  # namespace (flux-system) carrying ONLY the `ca.crt` key. Every pivoted
+  # HelmRepository's spec.certSecretRef.name is patched to this. A
+  # source-controller-only object — never exposes the cert's private key.
+  destSecretName: "cutover-harbor-ca"
+
 # catalyst-api Deployment to patch in step 07 (catalyst-api-env-patch).
 # Sovereign-side namespace is `catalyst-system`, NOT `catalyst-platform`
 # — caught live on otech103 2026-05-04 (Step-7 'deployment catalyst-api


### PR DESCRIPTION
## What

Closes the **last leg of the cutover cert-tail** (#3379): the Flux **source-controller** OCI-pull `tls: x509: certificate signed by unknown authority` against the in-cluster Harbor after step-06 pivots the HelmRepository URLs (live wedge on dep `00720a7a`).

## Root

Step-06 Phase-1 repoints every openova-io HelmRepository's `spec.url` to `oci://registry.<sov-fqdn>/openova-io`. source-controller then pulls those OCI charts from the in-cluster Harbor — whose wildcard `*.<sov-fqdn>` cert is served by the bootstrap **LE-staging** issuer on a fresh / qaTestEnabled prov. source-controller carries only the public CA bundle, so every pivoted pull x509-fails → the pivot never reconciles → Phase-3a's strip-readiness gate never converges → the cutover never reaches the 600s deny-egress hold → `cutoverComplete` never set.

This is the **same LE-staging-in-cluster-Harbor cert pattern** already closed at every other layer that talks to the registry — skopeo (#4529), the helm CLI (#4557), containerd (step-04 `skip_verify`), the OBS blob-redirect (#4573 F2) — but the source-controller leg had **no trust path** until now.

## Fix (Option B — per-leg `certSecretRef`, consistent with #4529/#4557/#4573)

Flux OCI HelmRepository has **no** `insecureSkipVerify` for `spec.type=oci` — the only trust mechanism source-controller honors is `spec.certSecretRef` → a Secret whose `ca.crt` verifies the registry cert. Step-06 gains:

- **Phase-0.5** — read the in-cluster Harbor serving cert's CA from the wildcard TLS Secret `sovereign-wildcard-tls-<fqdn-dashed>` (kube-system; prefer `ca.crt`, fall back to `tls.crt`) and create a `ca.crt`-only **Opaque** Secret `cutover-harbor-ca` in flux-system (never copies the private key).
- **Phase-1** — patch each pivoted HelmRepository's `spec.certSecretRef` in the **same** merge-patch as the URL pivot (so a pivoted url never lands trust-less for even one reconcile tick); already-URL-pivoted HRs get the ref back-filled on re-run.
- **Phase-2** — inject `certSecretRef:` into each pivoted HelmRepository YAML in the local-Gitea bootstrap-kit slots (same indent as `url:`), so the bootstrap-kit Kustomization reconcile keeps the trust ref instead of reverting it ~1 min later.

**Fail-OPEN**: `helmRepositoryTrust.enabled=false`, or an unreadable wildcard Secret/CA, pivots the URL **without** a certSecretRef (prior behaviour for a public-CA-trusted Harbor) — never wedges the cutover on the trust seam. Does **not** widen source-controller's trust for any external host; the CA bundle verifies only the cluster's own registry cert chain. RBAC already covers the cross-namespace Secret read + create/patch.

## Tests

- `helm template` + `helm lint` clean; rendered step-06 shell passes `sh -n`.
- New **contract Case 35** asserts the trust env vars, the `certSecretRef` patch shape, the `ca.crt` read, and `helmRepositoryTrust.enabled` default true — all 35 gates green.
- awk Phase-2 injection verified functionally: correct `spec:`-indent placement, **idempotent** on re-run (no duplicate certSecretRef), YAML stays valid, `secretRef` (auth) + `certSecretRef` (trust) coexist.
- `render-slot-placement.py check` PASSED (no placement drift).

## Lockstep

`Chart.yaml` + `blueprint.yaml` + slot-06a pin → **0.1.88**.

Refs #3379

🤖 Generated with [Claude Code](https://claude.com/claude-code)