### PR TITLE
fix(bp-self-sovereign-cutover): contract-test SIGPIPE false-fail wedged 0.1.88 publish — re-cut 0.1.89 (#3379)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -648,7 +648,7 @@ spec:
       # insecureSkipVerify — certSecretRef is the only trust mechanism (mirrors
       # skopeo #4529 / helm #4557 / containerd step-04 / OBS #4573 F2). Fail-OPEN
       # when the CA is unreadable. Lockstep w/ Chart.yaml + blueprint.yaml.
-      version: 0.1.88
+      version: 0.1.89
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.88
+  version: 0.1.89
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1268,7 +1268,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.88
+version: 0.1.89
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -1164,18 +1164,22 @@ for tok in \
   'HELMREPO_TRUST_SRC_NAMESPACE' \
   'HELMREPO_TRUST_SRC_NAME_PREFIX' \
   'HELMREPO_TRUST_DEST_SECRET'; do
-  if ! printf '%s' "$STEP06_BLOCK" | grep -q "$tok"; then
+  # here-string (not `printf | grep -q`): under `set -o pipefail`, grep -q
+  # closes the pipe on first match → printf takes SIGPIPE (141) → pipefail
+  # propagates 141 → `if !` flips it into a FALSE FAIL. Flaky by timing on the
+  # large STEP06_BLOCK (1222 lines); a here-string has no pipe, so no SIGPIPE.
+  if ! grep -q "$tok" <<<"$STEP06_BLOCK"; then
     echo "FAIL: step-06 podSpec missing trust env var ${tok} — source-controller has no certSecretRef trust path for the pivoted in-cluster-Harbor HelmRepositories (#3379)" >&2
     exit 1
   fi
 done
 # The pivot patch must carry certSecretRef alongside the url, and Phase-0.5 must
 # read the wildcard cert (ca.crt with tls.crt fallback) + create the dest Secret.
-if ! printf '%s' "$STEP06_BLOCK" | grep -q 'certSecretRef'; then
+if ! grep -q 'certSecretRef' <<<"$STEP06_BLOCK"; then
   echo "FAIL: step-06 podSpec never sets spec.certSecretRef on the pivoted HelmRepositories — source-controller will x509 on the LE-staging in-cluster Harbor (#3379)" >&2
   exit 1
 fi
-if ! printf '%s' "$STEP06_BLOCK" | grep -Eq 'ca\.crt'; then
+if ! grep -Eq 'ca\.crt' <<<"$STEP06_BLOCK"; then
   echo "FAIL: step-06 podSpec never reads ca.crt from the in-cluster Harbor wildcard Secret — no trust bundle for the certSecretRef (#3379)" >&2
   exit 1
 fi
@@ -1190,7 +1194,7 @@ fi
 # key) and assert enabled:true lives inside it — the block carries several
 # comment lines before `enabled:`, so a fixed -A window is too brittle.
 HRT_BLOCK=$(awk '/^helmRepositoryTrust:/{f=1; next} f&&/^[a-zA-Z]/{exit} f{print}' values.yaml)
-if ! printf '%s' "$HRT_BLOCK" | grep -Eq '^[[:space:]]+enabled:[[:space:]]*true'; then
+if ! grep -Eq '^[[:space:]]+enabled:[[:space:]]*true' <<<"$HRT_BLOCK"; then
   echo "FAIL: helmRepositoryTrust.enabled is not true by default — fresh/qaTestEnabled provs serve an LE-staging in-cluster Harbor and need the trust path on by default (#3379)" >&2
   exit 1
 fi


### PR DESCRIPTION
The 0.1.88 Blueprint Release failed at `cutover-contract.sh` ('step-06 podSpec missing trust env var HELMREPO_TRUST_ENABLED') after a `printf: write error: Broken pipe`. The env var IS rendered (count=2); the false FAIL is `printf | grep -q` taking SIGPIPE under `set -o pipefail` on the 1222-line block. Fixed via bash here-strings (no pipe) at all 4 sites + bumped 0.1.89 lockstep so the merged cert-tail fix (#4586) actually publishes to ghcr. Refs #3379