### PR TITLE
fix(application-controller): singleton fan-out carries per-Org spec.parameters into HR values (#4589)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -648,7 +648,7 @@ spec:
       # insecureSkipVerify — certSecretRef is the only trust mechanism (mirrors
       # skopeo #4529 / helm #4557 / containerd step-04 / OBS #4573 F2). Fail-OPEN
       # when the CA is unreadable. Lockstep w/ Chart.yaml + blueprint.yaml.
-      version: 0.1.88
+      version: 0.1.89
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/core/controllers/application/internal/controller/application_controller.go
+++ b/core/controllers/application/internal/controller/application_controller.go
@@ -1027,6 +1027,20 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 			// #3375 DoD-3 — same owner labels on the per-app Continuum CR.
 			continuumOwnerLabels = fanoutOwnerLabels(envSpec, app)
 
+			// #4589 — the topology fan-out path must carry the SAME merged
+			// values as the non-fanout per-region path below
+			// (mergeMaps(bpManifestsValues, spec.Parameters)): the Blueprint's
+			// manifests.values overlaid with the per-Org spec.Parameters.
+			// Without this, singleton/active fan-out HRs render with chart
+			// defaults ONLY — httpRoute.hostnames + sovereignFqdn drop, the
+			// bp-oidc-gate companion fails closed, and zero-click SSO never
+			// lands on a fresh Org. (agnstar only appeared to work because its
+			// stale pre-#4556 non-fanout HR still carried these values; a fresh
+			// Org exposed the gap — see #4589 / deeper cause of #4556 item-1.)
+			// bpManifestsValues is declared later (non-fanout scope), so the
+			// fan-out path reads it from the Blueprint object directly here.
+			fanoutManifestsValues, _, _ := unstructured.NestedMap(bp.Object, "spec", "manifests", "values")
+
 			hrs, ferr := topo.FanoutHRs(topo.FanoutInputs{
 				AppName:        app.GetName(),
 				AppNamespace:   app.GetNamespace(),
@@ -1050,6 +1064,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 				DependsOnFor:        fanoutDependsOnFor,
 				IntervalSeconds:     r.Cfg.HelmReleaseIntervalSeconds,
 				OwnerLabels:         fanoutOwnerLabels(envSpec, app),
+				// #4589 — per-Org params (httpRoute.hostnames, sovereignFqdn,
+				// oidcGate, …) merged OVER the Blueprint manifests.values,
+				// mirroring the non-fanout path so the fan-out HR is
+				// parameter-complete and the SSO gate renders.
+				Values: mergeMaps(fanoutManifestsValues, spec.Parameters),
 			})
 			if ferr != nil {
 				// Render-error path — surface as Degraded so the

--- a/core/controllers/application/internal/controller/application_controller_placement_fanout_test.go
+++ b/core/controllers/application/internal/controller/application_controller_placement_fanout_test.go
@@ -199,6 +199,59 @@ func TestReconcile_TargetsDriveFanout_SingletonSingleTarget(t *testing.T) {
 	}
 }
 
+// TestReconcile_SingletonFanout_CarriesParameters_4589 — regression for #4589.
+// The singleton/active topology fan-out path must pass the Application's
+// per-Org spec.parameters THROUGH into the rendered HelmRelease spec.values
+// (merged over the Blueprint manifests.values), exactly as the non-fanout
+// per-region path does (mergeMaps(bpManifestsValues, spec.Parameters)). Before
+// the fix the FanoutInputs literal omitted Values:, so the fan-out HR rendered
+// with chart DEFAULTS only — per-Org httpRoute.hostnames + sovereignFqdn
+// dropped and the bp-oidc-gate SSO companion failed closed on a fresh Org (the
+// deeper cause under #4556 item-1; agnstar only worked off its stale HR).
+func TestReconcile_SingletonFanout_CarriesParameters_4589(t *testing.T) {
+	bp := makeBlueprintNoTopology("bp-agenity", "0.5.16", "primary+standby")
+	env := makeMultiRegionEnv("acme-prod", "acme", "prod")
+	org := makeOrg("acme")
+	app := makeApp("acme", "agenity", "acme-prod", "bp-agenity", "0.5.16",
+		"single-region", []string{"hetzner-fsn-rtz-prod"},
+		map[string]interface{}{
+			"sovereignFqdn": "t99.omani.works",
+			"marker4589":    "present",
+		})
+	// Overlay the #3969 targets placement (singleton) — the fan-out driver.
+	spec := app.Object["spec"].(map[string]interface{})
+	spec["placement"] = map[string]interface{}{
+		"mode": "singleton",
+		"targets": []interface{}{
+			map[string]interface{}{"region": "fsn", "cluster": "mgmt-A", "vcluster": "mgmt", "role": "Primary"},
+		},
+	}
+	fg := newFakeGitea()
+	fg.orgsExist["acme"] = true
+	r := newReconciler(t, fg, app, env, org, bp)
+
+	reconcileFromCluster(t, r, "acme", "agenity")
+
+	hrList, err := r.Dynamic.Resource(FluxHelmReleaseGVR).
+		Namespace("mgmt").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list HRs in mgmt: %v", err)
+	}
+	if got := len(hrList.Items); got != 1 {
+		t.Fatalf("want 1 singleton fan-out HR, got %d", got)
+	}
+	vals, found, _ := unstructured.NestedMap(hrList.Items[0].Object, "spec", "values")
+	if !found {
+		t.Fatalf("#4589: fan-out HR has NO spec.values — per-Org parameters dropped entirely")
+	}
+	if vals["marker4589"] != "present" {
+		t.Errorf("#4589: fan-out HR spec.values missing per-Org parameter marker4589; got %v", vals)
+	}
+	if vals["sovereignFqdn"] != "t99.omani.works" {
+		t.Errorf("#4589: fan-out HR spec.values missing sovereignFqdn; got %v", vals)
+	}
+}
+
 // TestReconcile_SingletonFanout_OneHR_NoPerRegionGitRepository — #4556 Item 1.
 // A singleton target produces EXACTLY ONE HelmRelease total and NO per-region
 // GitRepository/Kustomization: the fan-out `<app>-<cluster>` HR is the SOLE

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.88
+  version: 0.1.89
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1268,7 +1268,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.88
+version: 0.1.89
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -1164,18 +1164,22 @@ for tok in \
   'HELMREPO_TRUST_SRC_NAMESPACE' \
   'HELMREPO_TRUST_SRC_NAME_PREFIX' \
   'HELMREPO_TRUST_DEST_SECRET'; do
-  if ! printf '%s' "$STEP06_BLOCK" | grep -q "$tok"; then
+  # here-string (not `printf | grep -q`): under `set -o pipefail`, grep -q
+  # closes the pipe on first match → printf takes SIGPIPE (141) → pipefail
+  # propagates 141 → `if !` flips it into a FALSE FAIL. Flaky by timing on the
+  # large STEP06_BLOCK (1222 lines); a here-string has no pipe, so no SIGPIPE.
+  if ! grep -q "$tok" <<<"$STEP06_BLOCK"; then
     echo "FAIL: step-06 podSpec missing trust env var ${tok} — source-controller has no certSecretRef trust path for the pivoted in-cluster-Harbor HelmRepositories (#3379)" >&2
     exit 1
   fi
 done
 # The pivot patch must carry certSecretRef alongside the url, and Phase-0.5 must
 # read the wildcard cert (ca.crt with tls.crt fallback) + create the dest Secret.
-if ! printf '%s' "$STEP06_BLOCK" | grep -q 'certSecretRef'; then
+if ! grep -q 'certSecretRef' <<<"$STEP06_BLOCK"; then
   echo "FAIL: step-06 podSpec never sets spec.certSecretRef on the pivoted HelmRepositories — source-controller will x509 on the LE-staging in-cluster Harbor (#3379)" >&2
   exit 1
 fi
-if ! printf '%s' "$STEP06_BLOCK" | grep -Eq 'ca\.crt'; then
+if ! grep -Eq 'ca\.crt' <<<"$STEP06_BLOCK"; then
   echo "FAIL: step-06 podSpec never reads ca.crt from the in-cluster Harbor wildcard Secret — no trust bundle for the certSecretRef (#3379)" >&2
   exit 1
 fi
@@ -1190,7 +1194,7 @@ fi
 # key) and assert enabled:true lives inside it — the block carries several
 # comment lines before `enabled:`, so a fixed -A window is too brittle.
 HRT_BLOCK=$(awk '/^helmRepositoryTrust:/{f=1; next} f&&/^[a-zA-Z]/{exit} f{print}' values.yaml)
-if ! printf '%s' "$HRT_BLOCK" | grep -Eq '^[[:space:]]+enabled:[[:space:]]*true'; then
+if ! grep -Eq '^[[:space:]]+enabled:[[:space:]]*true' <<<"$HRT_BLOCK"; then
   echo "FAIL: helmRepositoryTrust.enabled is not true by default — fresh/qaTestEnabled provs serve an LE-staging in-cluster Harbor and need the trust path on by default (#3379)" >&2
   exit 1
 fi


### PR DESCRIPTION
Fresh-Org North-Star walk (nstar2) exposed it: the topology fan-out `FanoutInputs` literal omitted `Values:`, so singleton/active fan-out HelmReleases rendered with chart defaults only — per-Org `spec.parameters` (httpRoute.hostnames, sovereignFqdn, oidcGate) dropped → bp-oidc-gate failed closed → zero-click SSO never landed on a fresh Org. Now mirrors the non-fanout path's `mergeMaps(bpManifestsValues, spec.Parameters)`. Deeper cause under #4556 item-1 (agnstar only worked off its stale HR). Regression test included (fails without the fix). Refs #4589 #4556 #3374