### PR TITLE
chore(catalyst): bump bp-catalyst-platform 1.4.940 to deliver application-controller b2f7449 (#4589/#4590)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1215,7 +1215,7 @@ spec:
       #   stamp spec.parameters.sovereignFqdn so the openova-MCP URL points at
       #   this Sovereign, not the mothership. catalyst-api + application-controller
       #   image fixes (deploy-bot pins on next build). Lockstep w/ Chart.yaml.
-      version: 1.4.939
+      version: 1.4.940
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3376,7 +3376,7 @@ name: bp-catalyst-platform
 #   sovereign-fqdn) so GET /catalog/regions returns the Sovereign's REAL
 #   regions instead of [] — the marketplace BCP picker stops falling back to
 #   the hardcoded Hetzner list.
-version: 1.4.939
+version: 1.4.940
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/
 #   platform/crossplane chart + blueprint.yaml + bootstrap-kit slot 04). crossplane-core
 #   was still OOMKilled (CrashLoopBackOff, 55 restarts, exit 137, killed ~90s after start)


### PR DESCRIPTION
merged≠delivered: the deploy-bot set the application-controller image tag to b2f7449 (#4590) in values.yaml but skipped the Chart.yaml bump, so the live HR never re-pulls. Bumps Chart.yaml + bootstrap-kit slot-13 lockstep 1.4.939→1.4.940 to republish WITH b2f7449 + re-pin the live HR. Delivers the #4589 fan-out-values fix → durable fresh-Org zero-click SSO. Refs #4589 #4590 #4556