### PR TITLE
fix(catalyst): gitea-admin-secret bridge wait-and-create Job — kill fresh-prov Helm-lookup race (#4592)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1215,7 +1215,7 @@ spec:
       #   stamp spec.parameters.sovereignFqdn so the openova-MCP URL points at
       #   this Sovereign, not the mothership. catalyst-api + application-controller
       #   image fixes (deploy-bot pins on next build). Lockstep w/ Chart.yaml.
-      version: 1.4.940
+      version: 1.4.941
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/templates/catalyst-gitea-admin-secret-bridge-job.yaml
+++ b/products/catalyst/chart/templates/catalyst-gitea-admin-secret-bridge-job.yaml
@@ -1,0 +1,183 @@
+{{- /*
+#4592 — RACE-FALLBACK for the #3811 gitea-admin-secret host bridge.
+
+THE RACE this closes
+====================
+catalyst-gitea-admin-secret-bridge.yaml Helm-`lookup`s the syncer-origin
+mangled secret (mgmt/gitea-admin-secret-x-gitea-x-mgmt-vcluster) at TEMPLATE
+RENDER time and only emits the plain gitea/gitea-admin-secret if it exists
+RIGHT THEN. On a fresh prov the vCluster `sync.toHost.secrets` mirror is
+ASYNC — bp-gitea's HR can be Ready while the host-side mangled secret has not
+been mirrored yet. If bp-catalyst-platform's pre-install renders in that
+window, the lookup is nil, the bridge Secret renders nothing, the plain
+secret never lands, and the sovereignty cutover wedges at step-06 needing a
+manual bridge (observed live on dep 5150f96, #4592 / #3379).
+
+A Helm `lookup` is a one-shot render-time query — it cannot retry, and
+dependsOn ordering does not close the async-mirror gap.
+
+THE FIX
+=======
+This Job runs at hook time (NOT render time), so it can POLL: it waits for
+the mangled source secret to appear (bounded), then server-side-applies the
+plain gitea/gitea-admin-secret. It is ADDITIVE to the render-time bridge —
+when the lookup already succeeds (the common, already-mirrored case) the
+Secret template handles it and this Job is a fast idempotent no-op; only when
+the lookup raced does this Job do the work. Reflector cannot fix it (it
+cannot rename the mangled secret to the plain name — see the bridge comment).
+
+Hook-weight "0" runs BEFORE the bridge Secret (weight 1) + the mint Secret
+(weight 5) + the mint Job (weight 10). hook-delete-policy keeps it scoped to
+install/upgrade. Least-privilege: read only the one source secret in `mgmt`,
+write only the one dest secret in `gitea`.
+*/}}
+{{- if .Values.giteaAdminBridge.enabled -}}
+{{- $srcNs := .Values.giteaAdminBridge.sourceNamespace | default "gitea" -}}
+{{- $srcName := .Values.giteaAdminBridge.sourceSecretName | default "gitea-admin-secret" -}}
+{{- $destNs := .Values.giteaAdminBridge.destNamespace | default "gitea" -}}
+{{- $destName := .Values.giteaAdminBridge.destSecretName | default "gitea-admin-secret" -}}
+{{- $waitSeconds := .Values.giteaAdminBridge.waitSeconds | default 300 -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gitea-admin-bridge
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-catalyst-platform
+    catalyst.openova.io/component: gitea-admin-secret-bridge-job
+    app.kubernetes.io/managed-by: flux
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gitea-admin-bridge-read-src
+  namespace: {{ $srcNs }}
+  labels: { app.kubernetes.io/managed-by: flux }
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: [{{ $srcName | quote }}]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gitea-admin-bridge-read-src
+  namespace: {{ $srcNs }}
+  labels: { app.kubernetes.io/managed-by: flux }
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: Role, name: gitea-admin-bridge-read-src }
+subjects:
+  - kind: ServiceAccount
+    name: gitea-admin-bridge
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gitea-admin-bridge-write-dest
+  namespace: {{ $destNs }}
+  labels: { app.kubernetes.io/managed-by: flux }
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gitea-admin-bridge-write-dest
+  namespace: {{ $destNs }}
+  labels: { app.kubernetes.io/managed-by: flux }
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: Role, name: gitea-admin-bridge-write-dest }
+subjects:
+  - kind: ServiceAccount
+    name: gitea-admin-bridge
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gitea-admin-bridge
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-catalyst-platform
+    catalyst.openova.io/component: gitea-admin-secret-bridge-job
+    app.kubernetes.io/managed-by: flux
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  activeDeadlineSeconds: {{ add $waitSeconds 120 }}
+  template:
+    metadata:
+      labels: { app.kubernetes.io/managed-by: flux }
+    spec:
+      serviceAccountName: gitea-admin-bridge
+      restartPolicy: Never
+      securityContext: { runAsNonRoot: true, runAsUser: 65532 }
+      containers:
+        - name: bridge
+          image: {{ .Values.giteaAdminBridge.kubectlImage | default "registry.k8s.io/kubectl:v1.30.2" }}
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests: { cpu: 10m, memory: 32Mi }
+            limits: { cpu: 100m, memory: 64Mi }
+          command: ["/bin/sh","-c"]
+          args:
+            - |
+              set -eu
+              SRC_NS={{ $srcNs | quote }}; SRC={{ $srcName | quote }}
+              DST_NS={{ $destNs | quote }}; DST={{ $destName | quote }}
+              # #4592: poll for the async vcluster-syncer-mirrored source (the
+              # render-time lookup races it). Idempotent: if the bridge Secret
+              # template already created the plain dest, this exits fast.
+              deadline=$(( $(date +%s) + {{ $waitSeconds }} ))
+              while :; do
+                if kubectl -n "$DST_NS" get secret "$DST" -o jsonpath='{.data.password}' 2>/dev/null | grep -q .; then
+                  echo "[gitea-admin-bridge] $DST_NS/$DST already present — no-op"; exit 0
+                fi
+                U=$(kubectl -n "$SRC_NS" get secret "$SRC" -o jsonpath='{.data.username}' 2>/dev/null || true)
+                P=$(kubectl -n "$SRC_NS" get secret "$SRC" -o jsonpath='{.data.password}' 2>/dev/null || true)
+                if [ -n "$U" ] && [ -n "$P" ]; then
+                  echo "[gitea-admin-bridge] source $SRC_NS/$SRC present → applying plain $DST_NS/$DST"
+                  cat <<EOF | kubectl apply --server-side --field-manager=gitea-admin-bridge -f -
+              apiVersion: v1
+              kind: Secret
+              metadata:
+                name: $DST
+                namespace: $DST_NS
+                labels: { app.kubernetes.io/managed-by: flux, catalyst.openova.io/component: gitea-admin-secret-bridge-job }
+                annotations: { catalyst.openova.io/mirrored-from: "$SRC_NS/$SRC", catalyst.openova.io/bridge: "gitea-admin-secret-bridge-job-4592", "helm.sh/resource-policy": keep }
+              type: Opaque
+              data: { username: "$U", password: "$P" }
+              EOF
+                  echo "[gitea-admin-bridge] done"; exit 0
+                fi
+                if [ "$(date +%s)" -ge "$deadline" ]; then
+                  echo "[gitea-admin-bridge] FATAL: source $SRC_NS/$SRC never appeared within {{ $waitSeconds }}s (vcluster syncer mirror stalled)" >&2; exit 1
+                fi
+                echo "[gitea-admin-bridge] waiting for $SRC_NS/$SRC (async vcluster mirror)…"; sleep 5
+              done
+{{- end }}


### PR DESCRIPTION
The #3811 render-time Helm-lookup bridge no-ops when the async vcluster syncer mirror hasn't host-landed yet → plain gitea/gitea-admin-secret missing → cutover wedges at step-06 (manual bridge needed, live on 5150f96). Adds an additive pre-install Job that polls for the source + server-side-applies the dest (runtime, retry-tolerant). Idempotent no-op on already-mirrored envs. Lockstep 1.4.941. Refs #4592 #3811 #3379