### PR TITLE
feat(application-controller): project status.placement DR primary↔standby split from Continuum (Refs #3986 #3375)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1211,11 +1211,17 @@ spec:
       # 1.4.933 — #4553: catalog-seed bp-agenity 0.5.15 -> 0.5.16 — oidc-gate
       #   companion resources requests == limits so the gate pod is admissible
       #   under the per-Org plan-limits LimitRange. Lockstep w/ products/agenity.
+      # 1.4.943 — #4601 (Refs #3986 #3375): application-controller projects the
+      #   effective per-region DR placement (mode/primaryRegion/standbyRegions/
+      #   replicationLagSeconds/leaseHeld, primary = live Continuum leaseHolder)
+      #   onto Application.status.placement so the per-app Topology DR strip can
+      #   render primary↔standby for the bootstrap-owned DR spine apps. CRD
+      #   status.placement gains the DR sub-fields. Lockstep w/ Chart.yaml.
       # 1.4.936 — #4556: kill the agenity dual-render duplicate HR (quota) +
       #   stamp spec.parameters.sovereignFqdn so the openova-MCP URL points at
       #   this Sovereign, not the mothership. catalyst-api + application-controller
       #   image fixes (deploy-bot pins on next build). Lockstep w/ Chart.yaml.
-      version: 1.4.941
+      version: 1.4.943
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/core/controllers/application/internal/controller/application_controller.go
+++ b/core/controllers/application/internal/controller/application_controller.go
@@ -1537,6 +1537,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 		su.Placement["clusters"] = clusters
 	}
 
+	// #4601 — fold the EFFECTIVE per-region DR placement projection onto the
+	// #3373 status.placement object so the per-app Topology DR strip can
+	// render the primary↔standby split (UAT rows 51/52/55/56/57). The
+	// resolved plan already carries the static primary + standbys; when this
+	// app minted a per-app Continuum (continuumRef non-empty) we read its
+	// live status to override the primary with the lease holder + surface
+	// replicationLagSeconds/leaseHeld. The DR keys are ADDITIVE — they never
+	// overwrite the {vcluster,source,regions,clusters} keys above. Read-only:
+	// this REPORTS placement, it never changes which region is primary.
+	if dr := r.placementProjectionForPlan(ctx, plan, continuumRef); dr != nil {
+		su.Placement = mergePlacementProjection(su.Placement, dr)
+	}
+
 	// #3969 §8a/§8b/§8e — run the owned-dependency cascade + the shared-dep
 	// recommendation closure for this Application's declared backing
 	// services. Owned (private) instances follow the consumer's resolved
@@ -2474,6 +2487,19 @@ func (r *Reconciler) reconcileBootstrapOwned(ctx context.Context, app *unstructu
 			fmt.Sprintf("adopted spine Continuum DR contract: %v", cerr))
 	}
 
+	// #4601 — project the EFFECTIVE per-region DR placement onto
+	// status.placement so the per-app Topology DR strip can render the
+	// primary↔standby split for this adopted spine app. The bootstrap-owned
+	// path NEVER wrote status.placement before, so every DR spine app
+	// (spine-gitea/harbor/keycloak/openbao) had an empty status.placement
+	// despite a live Continuum lease. We resolve the static plan from the
+	// app's own spec, then override the primary with the live Continuum
+	// leaseHolder + surface lag/leaseHeld. A non-DR bootstrap app (singleton
+	// shared-pg, single-region, no Continuum) projects the static singleton
+	// plan (primary + empty standbys) with no lag/leaseHeld. Read-only — this
+	// never changes which region is primary, only REPORTS it.
+	placementProjection := r.bootstrapPlacementProjection(ctx, app, continuumRef)
+
 	// Churn guard: a status write bumps resourceVersion → MODIFIED
 	// watch event → another reconcile. The normal path's Gitea
 	// byte-equality short-circuit naturally dampens that loop; this
@@ -2481,9 +2507,13 @@ func (r *Reconciler) reconcileBootstrapOwned(ctx context.Context, app *unstructu
 	// nothing meaningful changed (proven hot-looping at ~600ms/CR on
 	// the envtest adoption walk without this). The continuumRef is part
 	// of the changed-set: an adoption that just minted its Continuum must
-	// write the back-ref even when the HR phase is unchanged.
+	// write the back-ref even when the HR phase is unchanged. The
+	// placement projection is part of the changed-set too: a freshly-flipped
+	// lease (primary moved region) must re-write status.placement even when
+	// the adopted HR's phase is unchanged.
 	if bootstrapStatusUnchanged(app, phase, message, ready) &&
-		bootstrapContinuumRefUnchanged(app, continuumRef) {
+		bootstrapContinuumRefUnchanged(app, continuumRef) &&
+		bootstrapPlacementUnchanged(app, placementProjection) {
 		return nil
 	}
 
@@ -2501,7 +2531,63 @@ func (r *Reconciler) reconcileBootstrapOwned(ctx context.Context, app *unstructu
 		Ready:            ready,
 		LastReconciledAt: now,
 		ContinuumRef:     continuumRef,
+		Placement:        placementProjection,
 	})
+}
+
+// bootstrapPlacementProjection resolves the effective per-region DR placement
+// projection for an adopted (bootstrap-owned) Application and folds in the
+// live Continuum status (#4601). The adoption path is status-only — it never
+// resolves a fan-out render — so we resolve the placement plan directly from
+// the Application's own spec.placement + spec.regions (the same inputs
+// reconcileBootstrapContinuum uses), then read the per-app Continuum CR named
+// by continuumRef (falling back to the deterministic `dr-<app>` name) to
+// override the primary with the live leaseHolder + surface
+// replicationLagSeconds/leaseHeld.
+//
+// Returns nil (status.placement untouched) only when the spec has no
+// resolvable placement plan (no regions / unparseable spec) — never an error,
+// because a placement PROJECTION must never fail an adoption reconcile (the
+// HR observation is the load-bearing signal).
+func (r *Reconciler) bootstrapPlacementProjection(
+	ctx context.Context,
+	app *unstructured.Unstructured,
+	continuumRef string,
+) map[string]interface{} {
+	spec, err := parseSpec(app)
+	if err != nil {
+		return nil
+	}
+	if spec.Placement == "" || len(spec.Regions) == 0 {
+		return nil
+	}
+	plan, perr := placement.Resolve(spec.Placement, spec.Regions)
+	if perr != nil {
+		// Unresolvable placement (e.g. singleton with >1 region) — do not
+		// fabricate a projection; leave status.placement untouched.
+		r.Log.Warn("bootstrap-owned: placement resolve failed; no status.placement projection",
+			"app", app.GetName(), "placement", spec.Placement, "err", perr)
+		return nil
+	}
+	// Read the live Continuum status (if a CR exists for this app). Prefer the
+	// back-ref the producer just minted; when that is empty (e.g. the Blueprint
+	// is not yet in the catalog so reconcileBootstrapContinuum deferred the
+	// mint, but a CR from a prior reconcile already exists) fall back to the
+	// deterministic `dr-<app>` name in the app's namespace so the live lease
+	// still drives the projection. A read error degrades to the static-plan
+	// projection rather than failing the reconcile — the static plan still
+	// gives the UI a primary/standby split.
+	ref := continuumRef
+	if ref == "" {
+		ref = app.GetNamespace() + "/" + ContinuumNameFor(app.GetName())
+	}
+	cs, cerr := r.readContinuumDRStatus(ctx, ref)
+	if cerr != nil {
+		r.Log.Warn("bootstrap-owned: Continuum status read failed; static placement projection",
+			"app", app.GetName(), "continuumRef", ref, "err", cerr)
+		cs = nil
+	}
+	return buildPlacementProjection(plan, cs)
 }
 
 // reconcileBootstrapContinuum mints the per-app Continuum DR contract for a
@@ -2611,6 +2697,65 @@ func bootstrapContinuumRefUnchanged(app *unstructured.Unstructured, continuumRef
 	}
 	cur, _, _ := unstructured.NestedString(app.Object, "status", "continuumRef")
 	return cur == continuumRef
+}
+
+// bootstrapPlacementUnchanged reports whether the Application's current
+// status.placement already carries the DR projection keys (#4601) the next
+// reconcile would write. Part of the adoption-path churn guard: a freshly
+// flipped lease (primaryRegion moved) must re-write status.placement even
+// when the adopted HR phase is unchanged, but a steady-state reconcile must
+// NOT churn. A nil projection (no resolvable plan) is treated as "unchanged"
+// so it never forces an extra write on the non-DR adoption path.
+//
+// We compare only the DR-projection keys (mode / primaryRegion /
+// standbyRegions / replicationLagSeconds / leaseHeld), not the whole
+// status.placement object — the #3373 {vcluster,source,regions,clusters}
+// keys are not written on the bootstrap path, so comparing them would always
+// report "changed".
+func bootstrapPlacementUnchanged(app *unstructured.Unstructured, projection map[string]interface{}) bool {
+	if projection == nil {
+		return true
+	}
+	cur, _, _ := unstructured.NestedMap(app.Object, "status", "placement")
+	if cur == nil {
+		return false
+	}
+	for _, k := range []string{"mode", "primaryRegion", "standbyRegions", "replicationLagSeconds", "leaseHeld"} {
+		want, wantSet := projection[k]
+		got, gotSet := cur[k]
+		if wantSet != gotSet {
+			return false
+		}
+		if !wantSet {
+			continue
+		}
+		if !placementValueEqual(want, got) {
+			return false
+		}
+	}
+	return true
+}
+
+// placementValueEqual compares two status.placement values for churn-guard
+// equality, normalising the slice case (the projection writes
+// []interface{} for standbyRegions; the re-fetched status carries the same
+// shape, but a defensive element-wise compare keeps the guard robust to
+// client round-trip typing).
+func placementValueEqual(want, got interface{}) bool {
+	ws, wOK := want.([]interface{})
+	gs, gOK := got.([]interface{})
+	if wOK || gOK {
+		if !wOK || !gOK || len(ws) != len(gs) {
+			return false
+		}
+		for i := range ws {
+			if fmt.Sprintf("%v", ws[i]) != fmt.Sprintf("%v", gs[i]) {
+				return false
+			}
+		}
+		return true
+	}
+	return fmt.Sprintf("%v", want) == fmt.Sprintf("%v", got)
 }
 
 // bootstrapStatusUnchanged reports whether the Application's current

--- a/core/controllers/application/internal/controller/placement_projection.go
+++ b/core/controllers/application/internal/controller/placement_projection.go
@@ -1,0 +1,245 @@
+// placement_projection.go — #4601 (Refs #3986 #3375): project the
+// EFFECTIVE per-region DR placement onto Application.status.placement so the
+// per-app Topology DR strip (#932 / #3986 / #3375, UAT rows 51/52/55/56/57)
+// has a primary↔standby split to render for HelmRelease-backed apps.
+//
+// THE GAP this closes:
+//
+// An Application CR carries `spec.placement` (active-hot-standby /
+// active-passive / singleton) but, before this, `status.placement` carried
+// only the static {vcluster, source, regions, clusters} shape (#3373) — and
+// the bootstrap-owned path (the path EVERY DR spine app — spine-gitea,
+// spine-harbor, spine-keycloak, spine-openbao — traverses) never wrote even
+// that. So the Topology UI had nothing to derive primary/standby from.
+//
+// Meanwhile the per-app Continuum CR (`continuums.dr.openova.io`, minted by
+// continuum.go + back-referenced via `status.continuumRef`) carries the LIVE
+// truth: `status.leaseHolder` (= the region currently primary),
+// `status.replicationLagSeconds`, and the `LeaseHeld` condition. This
+// projection READS that Continuum status and folds it into
+// `status.placement` so the UI reads one place.
+//
+// Strictly OBSERVATIONAL: this code only REPORTS placement; it never changes
+// which region is primary, never touches an HR replica count, never writes
+// the Continuum. It derives:
+//
+//	status.placement.mode                  — the resolved placement mode
+//	status.placement.primaryRegion         — Continuum leaseHolder, else the
+//	                                          static plan primary
+//	status.placement.standbyRegions[]      — every plan region except primary
+//	status.placement.replicationLagSeconds — from the Continuum status (when present)
+//	status.placement.leaseHeld             — Continuum LeaseHeld condition (when present)
+//
+// When no Continuum exists (singleton, single-region, non-DR app) the
+// projection falls back to the static placement plan: primary = plan
+// primary, standbys = the plan's standby regions, lag/leaseHeld omitted.
+
+package controller
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/openova-io/openova/core/controllers/internal/placement"
+)
+
+// placementProjectionForPlan resolves the DR placement projection for an
+// already-resolved placement plan, folding in the live Continuum status read
+// from continuumRef (#4601). Used by the normal (non-bootstrap) reconcile
+// path, where the plan is resolved as part of the fan-out. A Continuum read
+// error degrades to the static-plan projection (still a valid primary/standby
+// split) rather than failing the reconcile. Returns nil when the plan has no
+// regions to project.
+func (r *Reconciler) placementProjectionForPlan(
+	ctx context.Context,
+	plan placement.Plan,
+	continuumRef string,
+) map[string]interface{} {
+	cs, err := r.readContinuumDRStatus(ctx, continuumRef)
+	if err != nil {
+		r.Log.Warn("Continuum status read failed; static placement projection",
+			"continuumRef", continuumRef, "err", err)
+		cs = nil
+	}
+	return buildPlacementProjection(plan, cs)
+}
+
+// continuumDRStatus is the minimal projection of a per-app Continuum CR's
+// status the placement projection consumes. A nil value means "no Continuum
+// for this app" — the projection then falls back to the static plan.
+type continuumDRStatus struct {
+	// LeaseHolder is the region currently holding the DR lease — i.e. the
+	// live primary. Authoritative over the static plan primary, which is
+	// only the *configured* (regions[0]) primary and goes stale the moment
+	// the continuum-controller flips the lease on failover.
+	LeaseHolder string
+
+	// ReplicationLagSeconds mirrors the Continuum status field. -1 means
+	// "the Continuum reported no lag value" (omit from the projection).
+	ReplicationLagSeconds int64
+
+	// HasLag reports whether ReplicationLagSeconds was present on the CR
+	// status (distinguishes a genuine 0 from an absent field).
+	HasLag bool
+
+	// LeaseHeld is the Continuum's `LeaseHeld` condition status == "True".
+	LeaseHeld bool
+
+	// HasLeaseHeld reports whether the LeaseHeld condition was present.
+	HasLeaseHeld bool
+}
+
+// readContinuumDRStatus fetches the per-app Continuum CR named by the
+// `<namespace>/<name>` continuumRef and extracts the DR status fields the
+// placement projection needs. Returns (nil, nil) when continuumRef is empty
+// or the CR is not found (a non-DR app, or the producer has not minted the CR
+// yet) — the caller then falls back to the static plan. A genuine read error
+// is returned so the caller can decide whether to surface it; the projection
+// itself never fails a reconcile over a missing Continuum.
+func (r *Reconciler) readContinuumDRStatus(ctx context.Context, continuumRef string) (*continuumDRStatus, error) {
+	ns, name, ok := splitNamespacedName(continuumRef)
+	if !ok {
+		return nil, nil
+	}
+	cr, err := r.Dynamic.Resource(ContinuumGVR).Namespace(ns).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return continuumDRStatusFromCR(cr), nil
+}
+
+// continuumDRStatusFromCR is the pure extraction of the DR status fields from
+// an already-fetched Continuum CR. Split out so unit tests can exercise the
+// projection against a constructed Unstructured without a client.
+func continuumDRStatusFromCR(cr *unstructured.Unstructured) *continuumDRStatus {
+	if cr == nil {
+		return nil
+	}
+	out := &continuumDRStatus{ReplicationLagSeconds: -1}
+	out.LeaseHolder, _, _ = unstructured.NestedString(cr.Object, "status", "leaseHolder")
+	if lag, found, _ := unstructured.NestedInt64(cr.Object, "status", "replicationLagSeconds"); found {
+		out.ReplicationLagSeconds = lag
+		out.HasLag = true
+	}
+	conds, _, _ := unstructured.NestedSlice(cr.Object, "status", "conditions")
+	for _, c := range conds {
+		cm, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if t, _ := cm["type"].(string); t == "LeaseHeld" {
+			s, _ := cm["status"].(string)
+			out.LeaseHeld = s == "True"
+			out.HasLeaseHeld = true
+			break
+		}
+	}
+	return out
+}
+
+// buildPlacementProjection projects the effective per-region DR placement
+// from the resolved placement plan, optionally overridden by the LIVE
+// Continuum status. PURE — no client calls — so the controller status writer
+// and the unit tests share one code path.
+//
+// Derivation:
+//
+//   - mode               — plan.Mode (the canonical placement token).
+//   - primaryRegion      — Continuum leaseHolder when present + non-empty
+//     (the live primary survives a failover flip); otherwise the static
+//     plan primary (regions[0] for the single-primary modes; empty for
+//     active-active, which has no primary concept).
+//   - standbyRegions[]   — every plan region that is NOT the effective
+//     primary, in plan (priority) order. This is recomputed against the
+//     effective (possibly failed-over) primary so a post-failover projection
+//     correctly lists the OLD primary as a standby.
+//   - replicationLagSeconds / leaseHeld — surfaced only when the Continuum
+//     status carried them (a non-DR/static projection omits both).
+//
+// Returns nil only when the plan has no regions at all (nothing to project) —
+// the caller then leaves status.placement untouched.
+func buildPlacementProjection(plan placement.Plan, cs *continuumDRStatus) map[string]interface{} {
+	if len(plan.Regions) == 0 {
+		return nil
+	}
+
+	// Effective primary: the live lease holder wins over the configured
+	// plan primary so the projection tracks failover, not just config.
+	primary := plan.PrimaryRegion
+	if cs != nil && cs.LeaseHolder != "" {
+		primary = cs.LeaseHolder
+	}
+
+	// Standbys: every plan region except the effective primary, in plan
+	// (priority) order. Recomputing against the EFFECTIVE primary (not the
+	// static plan.PrimaryRegion) means a failed-over deployment lists the
+	// old primary as a standby and the new primary is excluded.
+	standbys := make([]interface{}, 0, len(plan.Regions))
+	for _, rp := range plan.Regions {
+		if rp.Name == primary {
+			continue
+		}
+		standbys = append(standbys, rp.Name)
+	}
+
+	proj := map[string]interface{}{
+		"mode":           plan.Mode,
+		"primaryRegion":  primary,
+		"standbyRegions": standbys,
+	}
+	if cs != nil {
+		if cs.HasLag {
+			proj["replicationLagSeconds"] = cs.ReplicationLagSeconds
+		}
+		if cs.HasLeaseHeld {
+			proj["leaseHeld"] = cs.LeaseHeld
+		}
+	}
+	return proj
+}
+
+// mergePlacementProjection folds the DR projection (mode / primaryRegion /
+// standbyRegions / replicationLagSeconds / leaseHeld) onto an existing
+// status.placement object (the #3373 {vcluster, source, regions, clusters}
+// shape), or returns the projection alone when there is no base object. The
+// DR keys are additive — they never overwrite the #3373 keys. Returns nil
+// when there is nothing to write (no base + nil projection).
+func mergePlacementProjection(base, projection map[string]interface{}) map[string]interface{} {
+	if projection == nil {
+		return base
+	}
+	if base == nil {
+		return projection
+	}
+	for k, v := range projection {
+		base[k] = v
+	}
+	return base
+}
+
+// splitNamespacedName splits a `<namespace>/<name>` ref. Returns ok=false for
+// any input that is not exactly one `/`-separated namespace+name pair.
+func splitNamespacedName(ref string) (namespace, name string, ok bool) {
+	for i := 0; i < len(ref); i++ {
+		if ref[i] == '/' {
+			ns, nm := ref[:i], ref[i+1:]
+			if ns == "" || nm == "" {
+				return "", "", false
+			}
+			// Reject a second slash (not a simple ns/name).
+			for j := i + 1; j < len(ref); j++ {
+				if ref[j] == '/' {
+					return "", "", false
+				}
+			}
+			return ns, nm, true
+		}
+	}
+	return "", "", false
+}

--- a/core/controllers/application/internal/controller/placement_projection_test.go
+++ b/core/controllers/application/internal/controller/placement_projection_test.go
@@ -1,0 +1,341 @@
+// placement_projection_test.go — #4601 (Refs #3986 #3375): coverage for the
+// status.placement DR projection.
+//
+// Two layers:
+//
+//  1. Pure-unit: buildPlacementProjection + continuumDRStatusFromCR — the
+//     primary/standby derivation, the live-Continuum override (leaseHolder
+//     wins over the static plan primary), and the lag/leaseHeld surfacing.
+//     Zero K8s.
+//
+//  2. Integration: drive a full reconcile of a bootstrap-owned (adopted)
+//     active-hot-standby spine Application that already has a per-app
+//     Continuum CR (leaseHolder=region-a, lag 0). Assert status.placement is
+//     populated with primaryRegion=region-a + standbyRegions=[region-b] + the
+//     mode. This is the regression gate for the live gap: before the
+//     projection, the bootstrap-owned path wrote NO status.placement, so this
+//     test would find an empty object and fail.
+
+package controller
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/openova-io/openova/core/controllers/internal/placement"
+)
+
+// ── Pure units ───────────────────────────────────────────────────────
+
+func TestBuildPlacementProjection(t *testing.T) {
+	// active-hot-standby across region-a (primary) + region-b (standby).
+	plan, err := placement.Resolve("active-hot-standby", []string{"region-a", "region-b"})
+	if err != nil {
+		t.Fatalf("resolve plan: %v", err)
+	}
+
+	t.Run("static plan, no Continuum", func(t *testing.T) {
+		got := buildPlacementProjection(plan, nil)
+		if got["mode"] != placement.ModeActiveHotStandby {
+			t.Errorf("mode = %v, want %s", got["mode"], placement.ModeActiveHotStandby)
+		}
+		if got["primaryRegion"] != "region-a" {
+			t.Errorf("primaryRegion = %v, want region-a", got["primaryRegion"])
+		}
+		standbys, _ := got["standbyRegions"].([]interface{})
+		if !reflect.DeepEqual(standbys, []interface{}{"region-b"}) {
+			t.Errorf("standbyRegions = %v, want [region-b]", standbys)
+		}
+		// No Continuum ⇒ no lag / leaseHeld keys.
+		if _, ok := got["replicationLagSeconds"]; ok {
+			t.Errorf("replicationLagSeconds present with no Continuum: %v", got["replicationLagSeconds"])
+		}
+		if _, ok := got["leaseHeld"]; ok {
+			t.Errorf("leaseHeld present with no Continuum: %v", got["leaseHeld"])
+		}
+	})
+
+	t.Run("live Continuum: leaseHolder=region-a, lag 0, leaseHeld", func(t *testing.T) {
+		cs := &continuumDRStatus{
+			LeaseHolder:           "region-a",
+			ReplicationLagSeconds: 0,
+			HasLag:                true,
+			LeaseHeld:             true,
+			HasLeaseHeld:          true,
+		}
+		got := buildPlacementProjection(plan, cs)
+		if got["primaryRegion"] != "region-a" {
+			t.Errorf("primaryRegion = %v, want region-a", got["primaryRegion"])
+		}
+		standbys, _ := got["standbyRegions"].([]interface{})
+		if !reflect.DeepEqual(standbys, []interface{}{"region-b"}) {
+			t.Errorf("standbyRegions = %v, want [region-b]", standbys)
+		}
+		if got["replicationLagSeconds"] != int64(0) {
+			t.Errorf("replicationLagSeconds = %v, want 0", got["replicationLagSeconds"])
+		}
+		if got["leaseHeld"] != true {
+			t.Errorf("leaseHeld = %v, want true", got["leaseHeld"])
+		}
+	})
+
+	t.Run("post-failover: leaseHolder=region-b overrides static primary", func(t *testing.T) {
+		// The configured plan primary is region-a, but the lease has flipped
+		// to region-b. The projection must follow the LIVE lease: primary
+		// region-b, and the OLD primary region-a now listed as a standby.
+		cs := &continuumDRStatus{
+			LeaseHolder:           "region-b",
+			ReplicationLagSeconds: 12,
+			HasLag:                true,
+			LeaseHeld:             true,
+			HasLeaseHeld:          true,
+		}
+		got := buildPlacementProjection(plan, cs)
+		if got["primaryRegion"] != "region-b" {
+			t.Errorf("primaryRegion = %v, want region-b (failed-over lease)", got["primaryRegion"])
+		}
+		standbys, _ := got["standbyRegions"].([]interface{})
+		if !reflect.DeepEqual(standbys, []interface{}{"region-a"}) {
+			t.Errorf("standbyRegions = %v, want [region-a] (old primary demoted)", standbys)
+		}
+		if got["replicationLagSeconds"] != int64(12) {
+			t.Errorf("replicationLagSeconds = %v, want 12", got["replicationLagSeconds"])
+		}
+	})
+
+	t.Run("singleton: primary + empty standbys, no Continuum", func(t *testing.T) {
+		sp, err := placement.Resolve("singleton", []string{"region-a"})
+		if err != nil {
+			t.Fatalf("resolve singleton: %v", err)
+		}
+		got := buildPlacementProjection(sp, nil)
+		if got["mode"] != placement.ModeSingleton {
+			t.Errorf("mode = %v, want singleton", got["mode"])
+		}
+		if got["primaryRegion"] != "region-a" {
+			t.Errorf("primaryRegion = %v, want region-a", got["primaryRegion"])
+		}
+		standbys, _ := got["standbyRegions"].([]interface{})
+		if len(standbys) != 0 {
+			t.Errorf("standbyRegions = %v, want empty", standbys)
+		}
+	})
+
+	t.Run("empty plan ⇒ nil projection", func(t *testing.T) {
+		if got := buildPlacementProjection(placement.Plan{}, nil); got != nil {
+			t.Errorf("expected nil projection for empty plan, got %v", got)
+		}
+	})
+}
+
+func TestContinuumDRStatusFromCR(t *testing.T) {
+	cr := &unstructured.Unstructured{Object: map[string]interface{}{
+		"status": map[string]interface{}{
+			"leaseHolder":           "me-east-215-a",
+			"replicationLagSeconds": int64(0),
+			"conditions": []interface{}{
+				map[string]interface{}{"type": "LeaseHeld", "status": "True"},
+				map[string]interface{}{"type": "Ready", "status": "True"},
+			},
+		},
+	}}
+	cs := continuumDRStatusFromCR(cr)
+	if cs == nil {
+		t.Fatal("nil status from a populated Continuum CR")
+	}
+	if cs.LeaseHolder != "me-east-215-a" {
+		t.Errorf("LeaseHolder = %q, want me-east-215-a", cs.LeaseHolder)
+	}
+	if !cs.HasLag || cs.ReplicationLagSeconds != 0 {
+		t.Errorf("lag = %d (has=%v), want 0 (has=true)", cs.ReplicationLagSeconds, cs.HasLag)
+	}
+	if !cs.HasLeaseHeld || !cs.LeaseHeld {
+		t.Errorf("leaseHeld = %v (has=%v), want true", cs.LeaseHeld, cs.HasLeaseHeld)
+	}
+}
+
+func TestMergePlacementProjection(t *testing.T) {
+	base := map[string]interface{}{"vcluster": "host", "source": "host-default"}
+	proj := map[string]interface{}{"mode": "active-hot-standby", "primaryRegion": "region-a"}
+	got := mergePlacementProjection(base, proj)
+	// DR keys folded in additively; #3373 keys preserved.
+	for k, want := range map[string]interface{}{
+		"vcluster": "host", "source": "host-default",
+		"mode": "active-hot-standby", "primaryRegion": "region-a",
+	} {
+		if got[k] != want {
+			t.Errorf("merged[%q] = %v, want %v", k, got[k], want)
+		}
+	}
+	// nil projection leaves the base untouched.
+	if g := mergePlacementProjection(base, nil); !reflect.DeepEqual(g, base) {
+		t.Errorf("nil projection mutated base: %v", g)
+	}
+	// nil base returns the projection alone.
+	if g := mergePlacementProjection(nil, proj); !reflect.DeepEqual(g, proj) {
+		t.Errorf("nil base lost projection: %v", g)
+	}
+}
+
+func TestSplitNamespacedName(t *testing.T) {
+	cases := []struct {
+		in       string
+		ns, name string
+		ok       bool
+	}{
+		{"catalyst/dr-spine-gitea", "catalyst", "dr-spine-gitea", true},
+		{"", "", "", false},
+		{"noslash", "", "", false},
+		{"/name", "", "", false},
+		{"ns/", "", "", false},
+		{"a/b/c", "", "", false},
+	}
+	for _, c := range cases {
+		ns, name, ok := splitNamespacedName(c.in)
+		if ns != c.ns || name != c.name || ok != c.ok {
+			t.Errorf("split(%q) = (%q,%q,%v), want (%q,%q,%v)", c.in, ns, name, ok, c.ns, c.name, c.ok)
+		}
+	}
+}
+
+// ── Integration ──────────────────────────────────────────────────────
+
+// makeContinuumCR builds a per-app Continuum CR with a populated status the
+// projection reads (leaseHolder / lag / LeaseHeld), mirroring the live shape
+// the continuum-controller stamps.
+func makeContinuumCR(namespace, name, appName, leaseHolder string, lag int64) *unstructured.Unstructured {
+	cr := &unstructured.Unstructured{}
+	cr.SetAPIVersion(ContinuumGroup + "/" + ContinuumVersion)
+	cr.SetKind(ContinuumKind)
+	cr.SetNamespace(namespace)
+	cr.SetName(name)
+	cr.SetLabels(map[string]string{"catalyst.openova.io/app": appName})
+	cr.Object["spec"] = map[string]interface{}{
+		"applicationRef":    namespace + "/" + appName,
+		"primaryRegion":     leaseHolder,
+		"hotStandbyRegions": []interface{}{"me-east-215-b"},
+		"leaseClient":       map[string]interface{}{"kind": "k8s-lease"},
+		"switchover":        map[string]interface{}{"mechanism": "cnpg-pair"},
+	}
+	cr.Object["status"] = map[string]interface{}{
+		"leaseHolder":           leaseHolder,
+		"primaryRegion":         leaseHolder,
+		"replicationLagSeconds": lag,
+		"phase":                 "Healthy",
+		"conditions": []interface{}{
+			map[string]interface{}{"type": "LeaseHeld", "status": "True"},
+			map[string]interface{}{"type": "Ready", "status": "True"},
+		},
+	}
+	return cr
+}
+
+// makeBootstrapDRSpineApp mirrors a bootstrap-owned spine Application
+// (spec.bootstrap=true) with an active-hot-standby DR posture across two real
+// regions — the shape of spine-gitea/harbor/keycloak on a 2-region Sovereign.
+func makeBootstrapDRSpineApp(namespace, name, hrName, hrNamespace string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("apps.openova.io/v1")
+	u.SetKind("Application")
+	u.SetNamespace(namespace)
+	u.SetName(name)
+	u.SetGeneration(1)
+	u.SetLabels(map[string]string{
+		"apps.openova.io/bootstrap-owned":  "true",
+		"catalyst.openova.io/organization": "omantel-biz",
+	})
+	u.Object["spec"] = map[string]interface{}{
+		"bootstrap":      true,
+		"environmentRef": "omantel-biz-cp",
+		"blueprintRef": map[string]interface{}{
+			"name":    "bp-gitea",
+			"version": "1.2.24",
+		},
+		"placement":       "active-hot-standby",
+		"regions":         []interface{}{"me-east-215-a", "me-east-215-b"},
+		"targetNamespace": namespace,
+		"releaseName":     name,
+		"helmRelease": map[string]interface{}{
+			"name":      hrName,
+			"namespace": hrNamespace,
+		},
+	}
+	return u
+}
+
+// TestReconcile_BootstrapOwned_PlacementProjectionFromContinuum is the
+// regression gate for the #4601 live gap: a bootstrap-owned DR spine app with
+// a live Continuum (leaseHolder=me-east-215-a) must project status.placement
+// with primaryRegion=me-east-215-a + standbyRegions=[me-east-215-b] + the
+// mode. Before the projection the bootstrap-owned path wrote NO
+// status.placement, so the assertions below would find an empty object.
+func TestReconcile_BootstrapOwned_PlacementProjectionFromContinuum(t *testing.T) {
+	app := makeBootstrapDRSpineApp("catalyst", "spine-gitea", "bp-gitea-spine", "flux-system")
+	hr := makeSlotHR("flux-system", "bp-gitea-spine", "True", "Helm install succeeded")
+	// The producer mints/back-refs `dr-<app>`; seed it with a live lease.
+	cont := makeContinuumCR("catalyst", ContinuumNameFor("spine-gitea"), "spine-gitea", "me-east-215-a", 0)
+
+	fg := newFakeGitea()
+	r := newReconciler(t, fg, app, hr, cont)
+
+	reconcileFromCluster(t, r, "catalyst", "spine-gitea")
+
+	got := readApp(t, r, "catalyst", "spine-gitea")
+	pl, found, _ := unstructured.NestedMap(got.Object, "status", "placement")
+	if !found || pl == nil {
+		t.Fatal("status.placement is empty — projection did not run (the #4601 gap)")
+	}
+	if pl["mode"] != placement.ModeActiveHotStandby {
+		t.Errorf("status.placement.mode = %v, want %s", pl["mode"], placement.ModeActiveHotStandby)
+	}
+	if pl["primaryRegion"] != "me-east-215-a" {
+		t.Errorf("status.placement.primaryRegion = %v, want me-east-215-a (live leaseHolder)", pl["primaryRegion"])
+	}
+	standbys, _, _ := unstructured.NestedSlice(got.Object, "status", "placement", "standbyRegions")
+	if len(standbys) != 1 || standbys[0] != "me-east-215-b" {
+		t.Errorf("status.placement.standbyRegions = %v, want [me-east-215-b]", standbys)
+	}
+	if pl["leaseHeld"] != true {
+		t.Errorf("status.placement.leaseHeld = %v, want true", pl["leaseHeld"])
+	}
+	lag, lagFound, _ := unstructured.NestedInt64(got.Object, "status", "placement", "replicationLagSeconds")
+	if !lagFound || lag != 0 {
+		t.Errorf("status.placement.replicationLagSeconds = %d (found=%v), want 0", lag, lagFound)
+	}
+}
+
+// TestReconcile_BootstrapOwned_SingletonNoContinuum_StaticProjection — a
+// bootstrap-owned single-region app (no Continuum) still projects a static
+// placement (primary + empty standbys) so the UI has a primary to show, but
+// no lag/leaseHeld.
+func TestReconcile_BootstrapOwned_SingletonNoContinuum_StaticProjection(t *testing.T) {
+	app := makeBootstrapDRSpineApp("shared-data", "shared-pg", "bp-postgres-shared", "flux-system")
+	// Override to a singleton single-region posture (the shared-pg shape).
+	spec, _, _ := unstructured.NestedMap(app.Object, "spec")
+	spec["placement"] = "singleton"
+	spec["regions"] = []interface{}{"me-east-215-a"}
+	app.Object["spec"] = spec
+	hr := makeSlotHR("flux-system", "bp-postgres-shared", "True", "Helm install succeeded")
+
+	fg := newFakeGitea()
+	r := newReconciler(t, fg, app, hr)
+
+	reconcileFromCluster(t, r, "shared-data", "shared-pg")
+
+	got := readApp(t, r, "shared-data", "shared-pg")
+	pl, found, _ := unstructured.NestedMap(got.Object, "status", "placement")
+	if !found || pl == nil {
+		t.Fatal("status.placement empty for a singleton bootstrap app")
+	}
+	if pl["mode"] != placement.ModeSingleton {
+		t.Errorf("mode = %v, want singleton", pl["mode"])
+	}
+	if pl["primaryRegion"] != "me-east-215-a" {
+		t.Errorf("primaryRegion = %v, want me-east-215-a", pl["primaryRegion"])
+	}
+	if _, ok := pl["leaseHeld"]; ok {
+		t.Errorf("leaseHeld present for a no-Continuum singleton: %v", pl["leaseHeld"])
+	}
+}

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,18 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.943 — #4601 (Refs #3986 #3375): the application-controller now projects
+#   the EFFECTIVE per-region DR placement onto Application.status.placement
+#   ({mode, primaryRegion, standbyRegions, replicationLagSeconds, leaseHeld})
+#   so the per-app Topology DR strip (UAT 51/52/55/56/57) can render the
+#   primary↔standby split for HelmRelease-backed apps. The primary is the LIVE
+#   Continuum leaseHolder when a per-app Continuum exists (tracks failover),
+#   else the configured plan primary (regions[0]). Wired into BOTH the
+#   bootstrap-owned adoption path (every DR spine app: spine-gitea/harbor/
+#   keycloak/openbao — which previously wrote NO status.placement) and the
+#   normal fan-out path. Read-only / observational — REPORTS placement, never
+#   changes it. CRD application.yaml status.placement gains the documented DR
+#   sub-fields (additive; the object already preserves-unknown-fields). Ships
+#   in the application-controller image (deploy-bot bumps the pin on next build).
 # 1.4.936 — #4556 (agenity North-Star residual faults, items 1+2): (1) the
 #   application-controller no longer DUAL-RENDERS a topology/targets-driven
 #   Application — the fan-out `<app>-<cluster>` HR is now the sole install and
@@ -3376,7 +3389,7 @@ name: bp-catalyst-platform
 #   sovereign-fqdn) so GET /catalog/regions returns the Sovereign's REAL
 #   regions instead of [] — the marketplace BCP picker stops falling back to
 #   the hardcoded Hetzner list.
-version: 1.4.942
+version: 1.4.943
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/
 #   platform/crossplane chart + blueprint.yaml + bootstrap-kit slot 04). crossplane-core
 #   was still OOMKilled (CrashLoopBackOff, 55 restarts, exit 137, killed ~90s after start)

--- a/products/catalyst/chart/crds/application.yaml
+++ b/products/catalyst/chart/crds/application.yaml
@@ -430,6 +430,15 @@ spec:
                     resolved + rendered (instance > Blueprint default >
                     legacy seams). The console reflects this — it mirrors
                     the Git-committed truth, never fights it.
+
+                    #4601 — additionally carries the EFFECTIVE per-region DR
+                    split ({mode, primaryRegion, standbyRegions,
+                    replicationLagSeconds, leaseHeld}) so the per-app Topology
+                    DR strip can render primary↔standby. The primary is the
+                    LIVE Continuum leaseHolder when a per-app Continuum exists
+                    (so the projection tracks failover, not just config),
+                    else the configured plan primary (regions[0]). Read-only /
+                    observational — REPORTS placement, never changes it.
                   properties:
                     vcluster:
                       type: string
@@ -448,4 +457,37 @@ spec:
                       type: array
                       items:
                         type: string
+                    # #4601 — DR projection (additive; folded onto the #3373
+                    # object). Present for every app with a resolvable plan.
+                    mode:
+                      type: string
+                      description: |
+                        Resolved canonical placement mode (singleton |
+                        active-active | active-hot-standby | active-passive).
+                    primaryRegion:
+                      type: string
+                      description: |
+                        Effective primary region — the LIVE Continuum
+                        leaseHolder when a per-app Continuum exists, else the
+                        configured plan primary (regions[0]). Empty for
+                        active-active (no primary concept).
+                    standbyRegions:
+                      type: array
+                      description: |
+                        Every plan region except the effective primary, in
+                        plan (priority) order. After a failover the OLD
+                        primary appears here.
+                      items:
+                        type: string
+                    replicationLagSeconds:
+                      type: integer
+                      format: int64
+                      description: |
+                        Replication lag from the per-app Continuum status
+                        (omitted when no Continuum reported one).
+                    leaseHeld:
+                      type: boolean
+                      description: |
+                        The per-app Continuum's LeaseHeld condition (omitted
+                        when no Continuum exists).
               x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
## Problem
The per-app Topology DR surface (#932 / #3986 / #3375, UAT rows 51/52/55/56/57) had nothing to derive primary/standby from for HelmRelease-backed apps. Application CRs carry `spec.placement` (active-hot-standby / active-passive / singleton) but `status.placement` carried no DR projection.

**Confirmed live on dep 91dc05917e44d1c1 (2-region):** the DR spine apps (`spine-gitea`, `spine-harbor`, `spine-keycloak`, `spine-openbao` in ns `catalyst`) are **bootstrap-owned** with `spec.placement=active-hot-standby` + 2 regions and DO mint per-app Continuum CRs (`status.continuumRef=catalyst/dr-spine-gitea`). But `status.placement` is **EMPTY** on every one of them, because the bootstrap-owned reconcile path (`reconcileBootstrapOwned`) only wrote `Phase/Reason/Message/Ready/ContinuumRef` — it never built `su.Placement`, and DR spine apps never traverse the non-bootstrap path that does. The live DR truth (`leaseHolder` / `replicationLagSeconds` / `LeaseHeld`) sat only on the Continuum CR.

## Fix
Project the EFFECTIVE per-region DR placement onto `status.placement`:
```
{ mode, primaryRegion, standbyRegions[], replicationLagSeconds, leaseHeld }
```
- `primaryRegion` = LIVE Continuum **leaseHolder** when a per-app Continuum exists (so the projection follows a failover flip, not just config), else the configured plan primary (`regions[0]`); `standbyRegions` = every plan region except the effective primary (post-failover the old primary is correctly demoted to a standby).
- Continuum read by the minted `continuumRef`, with a deterministic `dr-<app>` fallback.
- **Read-only / observational** — REPORTS placement, never changes which region is primary, never writes the Continuum.
- Wired into **both** the bootstrap-owned adoption path and the normal fan-out path (additive merge onto the existing #3373 `{vcluster,source,regions,clusters}` object — DR keys never overwrite the #3373 keys).

## Files
- `core/controllers/application/internal/controller/placement_projection.go` — new: pure `buildPlacementProjection` + `continuumDRStatusFromCR` reader + merge/split helpers + the two path entrypoints.
- `core/controllers/application/internal/controller/application_controller.go` — wire into bootstrap-owned + normal paths; churn-guard helper `bootstrapPlacementUnchanged`.
- `core/controllers/application/internal/controller/placement_projection_test.go` — new tests (below).
- `products/catalyst/chart/crds/application.yaml` — document the DR sub-fields (additive; object already preserves-unknown-fields).
- `products/catalyst/chart/Chart.yaml` — bp-catalyst-platform 1.4.942 → 1.4.943.

## Tests
- Pure: `buildPlacementProjection` (static / live-lease / **post-failover override** / singleton / empty), `continuumDRStatusFromCR`, merge + split helpers.
- Integration: two bootstrap-owned reconciles — live Continuum (leaseHolder=me-east-215-a) → `primaryRegion=me-east-215-a` + `standbyRegions=[me-east-215-b]` + `leaseHeld=true` + `replicationLagSeconds=0`; singleton no-Continuum → static projection (primary + empty standbys, no lag/leaseHeld).
- **Proven to FAIL without the projection and PASS with it.** Full `core/controllers` module green; `go build ./...`, `go vet`, `gofmt` clean.

## Delivery note
The application-controller image tag is bumped by the deploy-bot on build-on-merge (not hand-edited). The CRD ships with the bp-catalyst-platform chart bump. **merged ≠ delivered** — live `status.placement` populates only after the rolled image reaches the env.

Refs #3986 #3375 #4601

🤖 Generated with [Claude Code](https://claude.com/claude-code)