### PR TITLE
fix(bp-agenity): durable external-HTTPS egress CNP + standalone-claude openova MCP discovery (0.5.17)

### DIFF
--- a/products/agenity/blueprint.yaml
+++ b/products/agenity/blueprint.yaml
@@ -11,11 +11,10 @@ spec:
   # per-Org plan-limits LimitRange (cpu:1/mem:1 ratio) — the prior Burstable
   # spec was rejected, no gate pod, no SSO (live on agnstar). Lockstep with
   # products/agenity/chart/Chart.yaml + the catalog-seed pin.
-  # 0.5.15 (#4553/#4556): the chart now renders a bp-oidc-gate companion in
-  # front of every per-Org agenity host (oidcGate.enabled default true) — the
-  # durable zero-click SSO gate + spaTokenSeed no-paste landing, chart-managed
-  # rather than the agnstar walk's hand-created live instance.
-  version: 0.5.16
+  # 0.5.17 (#4604): chart adds a default-on external-HTTPS egress CNP +
+  # seeds the openova MCP into ~/.claude.json for a standalone claude (durable
+  # Pillar-4 North-Star wiring). Lockstep with products/agenity/chart.
+  version: 0.5.17
   card:
     title: Agenity
     summary: |

--- a/products/agenity/chart/Chart.yaml
+++ b/products/agenity/chart/Chart.yaml
@@ -8,6 +8,26 @@ description: |
   (RBAC-scoped to the User's rights) to create more Applications in the
   User's own Organization — the north-star self-service journey.
 type: application
+# 0.5.16 -> 0.5.17 (#4604, Pillar-4 North Star — durable egress + standalone-
+# claude MCP discovery): two ADDITIVE chart changes, both proven gaps on the
+# nstar2 North-Star walk (dep 91dc05917e44d1c1, pod agenity-rtz-a-bp-agenity-0).
+# (1) templates/cilium-egress-networkpolicy.yaml — a default-on
+# CiliumNetworkPolicy granting the agenity pod external-HTTPS egress
+# (toEntities:[world]:443 + DNS preserved) so the solo agent reaches
+# api.anthropic.com and the openova-mcp child reaches https://console.<fqdn> to
+# drive create_application. The walk only made the chat reachable after a
+# HAND-APPLIED stopgap CNP (agenity-allow-external-https-egress); templating it
+# makes EVERY per-Org install / re-prov get egress by construction (mirrors
+# openclaw #4401). Gated on networkPolicy.egress.allowExternalHttps +
+# cilium.io/v2 Capabilities (kind CI still renders). (2) the seed-claude-creds
+# init container now seeds the `openova` mcpServers entry into the pod's
+# ~/.claude.json so a STANDALONE claude (`claude -p …`, the verifier path)
+# discovers the openova MCP — chepherd's CHEPHERD_EXTRA_MCP_JSON seam only
+# reaches chepherd-SPAWNED agents' per-session .mcp.json, while a bare claude
+# reads ~/.claude.json (mcpServers:[] live → "no MCP tools"). The bearer +
+# RS256 pubkey stay OUT of the JSON (the openova-mcp child inherits them from
+# the container env, same contract as CHEPHERD_EXTRA_MCP_JSON). Template +
+# values change; appVersion (image) UNCHANGED.
 # 0.5.12 -> 0.5.13 (#4111): default `imagePullSecrets` to `[{name: ghcr-pull}]`
 # so EVERY image-pulling Pod (the seed-claude-creds init container AND the
 # chepherd main container) references the reflected ghcr-pull dockerconfigjson
@@ -159,7 +179,7 @@ type: application
 # same gateway bp-wordpress-tenant + the org console route attach to, #4054).
 # The old default rendered Accepted=False/InvalidHTTPRoute and the host 404'd
 # until the parentRef was hand-overridden. appVersion (image) unchanged.
-version: 0.5.16
+version: 0.5.17
 # Bumped appVersion 0.9.6 -> 0.9.7 (#4180): 0.9.7 is the FIRST image whose
 # /app/ mounts the WORKSPACES dashboard (Dashboardws bundle) rather than the
 # archaic single-column Dashboard.svelte. It is built from agenity#752

--- a/products/agenity/chart/templates/cilium-egress-networkpolicy.yaml
+++ b/products/agenity/chart/templates/cilium-egress-networkpolicy.yaml
@@ -1,0 +1,80 @@
+{{- /*
+#4604 (Pillar-4 North Star): the agenity solo agent (claude-code) MUST reach
+api.anthropic.com over external HTTPS to answer chat AND the openova-mcp child
+MUST reach the public Sovereign console (https://console.<fqdn>) to drive
+create_application — BOTH are off-cluster :443 hops to an external EIP that no
+Pod/namespace/ipBlock K8s selector can name. On a Cilium Sovereign the canonical
+expression is a CiliumNetworkPolicy `toEntities: [world]` egress carve-out
+(mirrors openclaw #4401 + the cilium-ingress-networkpolicy.yaml `fromEntities`
+idiom in this same chart).
+
+WHY THIS IS DURABLE (not a live-patch): the North-Star walk on nstar2 (dep
+91dc05917e44d1c1) only made the chat reachable after a HAND-APPLIED CNP
+`agenity-allow-external-https-egress` (toEntities:[world]:443). That live patch
+is gone on the next reconcile / a fresh Org / a re-prov, so the agent silently
+loses Anthropic + catalyst-api reachability. Templating it here makes EVERY
+per-Org agenity install get external-HTTPS egress by construction.
+
+🛑 DNS IS LOAD-BEARING: a CiliumNetworkPolicy that specifies ANY egress rule
+flips the selected endpoint to default-deny egress for everything else — so
+without an explicit DNS allow the agent can no longer resolve
+api.anthropic.com / console.<fqdn> and every outbound call NXDOMAINs. We allow
+:53 UDP+TCP to the cluster's kube-dns (the `kube-system` namespace + the
+`kube-dns` k8s service entity) so name resolution keeps working under the new
+default-deny posture. We additionally allow egress to the in-cluster entities
+(cluster/host/remote-node) so the dashboard's own in-cluster legs (apiserver
+when the local spawner is NOT forced, metrics, the chepherd MCP HTTP listener)
+are not collaterally denied.
+
+Gated on the cilium.io/v2 Capabilities check (the #2988/#3102 idiom) so the
+chart still installs on CRD-less clusters (kind CI), and on
+networkPolicy.egress.allowExternalHttps so a non-Cilium overlay (or an
+air-gapped Sovereign that mirrors Anthropic + console behind an in-cluster
+proxy) can opt out.
+*/ -}}
+{{- if and .Values.networkPolicy.enabled .Values.networkPolicy.egress.allowExternalHttps (.Capabilities.APIVersions.Has "cilium.io/v2") }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "agenity.fullname" . }}-external-egress
+  labels:
+    {{- include "agenity.labels" . | nindent 4 }}
+    catalyst.openova.io/component: agenity-egress-netpol
+spec:
+  endpointSelector:
+    matchLabels:
+      {{- include "agenity.selectorLabels" . | nindent 6 }}
+  egress:
+    # ── External HTTPS — api.anthropic.com (the solo agent's model calls) +
+    # the public Sovereign console https://console.<fqdn> the openova-mcp
+    # child forwards create_application to (#4604). No Pod/ipBlock selector
+    # can name an external EIP, so `toEntities: [world]` :443 is the canonical
+    # carve-out. `cluster`/`host`/`remote-node` keep in-cluster legs alive
+    # under the new default-deny egress posture this rule introduces.
+    - toEntities:
+        - world
+        - cluster
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "{{ .Values.networkPolicy.egress.httpsPort }}"
+              protocol: TCP
+    # ── DNS — LOAD-BEARING (see header). Resolving api.anthropic.com /
+    # console.<fqdn> requires kube-dns reachability; the egress rule above
+    # would otherwise default-deny :53. Allow UDP+TCP :53 to the cluster
+    # kube-dns (kube-system) so name resolution survives the default-deny flip.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"
+{{- end }}

--- a/products/agenity/chart/templates/statefulset.yaml
+++ b/products/agenity/chart/templates/statefulset.yaml
@@ -128,7 +128,34 @@ spec:
               # with it the REPL boots to the prompt and stays alive to receive
               # the operator's chat message. The projects map marks the chepherd
               # agent/session working dirs trusted so no per-cwd dialog fires.
+              #
+              # ── openova MCP at USER level (#4604) ────────────────────────────
+              # chepherd's CHEPHERD_EXTRA_MCP_JSON seam (main container, below)
+              # merges the `openova` MCP server into each chepherd-SPAWNED
+              # agent's per-session .mcp.json. But a claude invoked STANDALONE in
+              # the pod (`claude -p "…"`, the North-Star verifier path) reads
+              # ~/.claude.json's `mcpServers` + a project ./.mcp.json — NEITHER
+              # of which carries the openova entry, so a bare claude reports "no
+              # MCP tools" (verified live on nstar2: ~/.claude.json mcpServers:[]
+              # + no .mcp.json). Seeding the `openova` mcpServers entry HERE, into
+              # the same ~/.claude.json the onboarding stub already writes, makes
+              # EVERY claude in the pod (spawned OR standalone) discover the
+              # openova MCP with zero per-session config. The bearer + RS256
+              # pubkey are deliberately OMITTED: the openova-mcp child is launched
+              # by claude inside the chepherd container and INHERITS
+              # OPENOVA_MCP_BEARER / OPENOVA_MCP_RS256_PUBKEY_PEM from the
+              # container env (set on the main container) — the same
+              # env-inheritance contract CHEPHERD_EXTRA_MCP_JSON relies on. Only
+              # the non-secret knobs (catalyst-api URL, context pin, verify mode)
+              # are pinned. Path + knobs mirror openovaMCP.* so the two discovery
+              # seams agree.
+              {{- if .Values.openovaMCP.enabled }}
+              {{- $apiURL := .Values.openovaMCP.catalystApiUrl }}
+              {{- if not $apiURL }}{{ $apiURL = printf "https://console.%s" (.Values.sovereignFqdn | default "openova.io") }}{{- end }}
+              printf '%s' '{"hasCompletedOnboarding":true,"bypassPermissionsModeAccepted":true,"autoPermissionsNotificationCount":99,"mcpServers":{"openova":{"command":{{ .Values.openovaMCP.binaryPath | quote }},"env":{"OPENOVA_MCP_CATALYST_API_URL":{{ $apiURL | quote }},"OPENOVA_MCP_CONTEXT":{{ .Values.openovaMCP.context | quote }},"OPENOVA_MCP_VERIFY":{{ .Values.openovaMCP.verify | quote }}}}},"projects":{"/var/chepherd/repo":{"hasTrustDialogAccepted":true,"hasCompletedProjectOnboarding":true},"/home/chepherd":{"hasTrustDialogAccepted":true,"hasCompletedProjectOnboarding":true}}}' > /claudehome/.claude.json
+              {{- else }}
               printf '%s' '{"hasCompletedOnboarding":true,"bypassPermissionsModeAccepted":true,"autoPermissionsNotificationCount":99,"projects":{"/var/chepherd/repo":{"hasTrustDialogAccepted":true,"hasCompletedProjectOnboarding":true},"/home/chepherd":{"hasTrustDialogAccepted":true,"hasCompletedProjectOnboarding":true}}}' > /claudehome/.claude.json
+              {{- end }}
               chmod 644 /claudehome/.claude.json
           securityContext:
             runAsUser: 1000

--- a/products/agenity/chart/values.yaml
+++ b/products/agenity/chart/values.yaml
@@ -407,6 +407,22 @@ networkPolicy:
     # reserved `ingress` entity (the Cilium Gateway Envoy) to service.port.
     # Disable only on a non-Cilium overlay that fronts agenity differently.
     allowGatewayEntity: true
+  # ── External-HTTPS egress (#4604) ────────────────────────────────────────
+  # The solo agent (claude-code) calls api.anthropic.com and the openova-mcp
+  # child forwards create_application to the public Sovereign console — both
+  # off-cluster :443 hops to an external EIP no K8s selector can name. On a
+  # Cilium Sovereign that needs a CiliumNetworkPolicy `toEntities:[world]:443`
+  # egress carve-out (templates/cilium-egress-networkpolicy.yaml). DEFAULT-ON
+  # for the agentic app: without it a fresh Org / re-prov silently loses
+  # Anthropic + catalyst-api reachability (the nstar2 North-Star walk only
+  # worked after a hand-applied stopgap CNP — this makes it chart-durable).
+  egress:
+    # allowExternalHttps → emit the egress CNP (world:443 + DNS preserved).
+    # Disable only on an air-gapped Sovereign that mirrors Anthropic + the
+    # console behind an in-cluster proxy the agent reaches without world egress.
+    allowExternalHttps: true
+    # External HTTPS port for both the Anthropic + console hops (443).
+    httpsPort: 443
 
 # ── Persistence — chepherd runtime state + per-agent repo/cache ───────────
 # CSI-backed PVCs. storageClass empty = the cluster's default CSI class.

--- a/products/catalyst/bootstrap/api/internal/handler/application_parameters_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/application_parameters_test.go
@@ -153,7 +153,7 @@ func TestDefaultedParameters_AgenityEmptyFQDN_NoStamp(t *testing.T) {
 
 func TestNewApplicationUnstructured_Agenity_StampsSovereignFqdn(t *testing.T) {
 	req := applicationInstallRequest{
-		BlueprintRef:    applicationBlueprintRef{Name: "bp-agenity", Version: "0.5.16"},
+		BlueprintRef:    applicationBlueprintRef{Name: "bp-agenity", Version: "0.5.17"},
 		Name:            "agenity",
 		OrganizationRef: "agnstar.omani.homes",
 		EnvironmentRef:  "agnstar-prod",

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5980,10 +5980,10 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  # 0.5.15 (#4553/#4556): chart renders a bp-oidc-gate companion in front of
-  # every per-Org agenity host (durable zero-click SSO gate + spaTokenSeed
-  # no-paste landing, chart-managed). Lockstep with products/agenity/chart.
-  version: "0.5.16"
+  # 0.5.17 (#4604): chart adds a default-on external-HTTPS egress CNP +
+  # seeds the openova MCP into ~/.claude.json for a standalone claude (durable
+  # Pillar-4 North-Star wiring). Lockstep with products/agenity/chart.
+  version: "0.5.17"
   visibility: listed
   card:
     title: "Agenity"
@@ -6013,7 +6013,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-agenity
-    version: 0.5.16
+    version: 0.5.17
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## What
Closes the two remaining Pillar-4 North-Star wiring gaps proven on the live nstar2 agenity walk (dep `91dc05917e44d1c1`, pod `agenity-rtz-a-bp-agenity-0`), making both chart-durable.

### Gap 1 — external-HTTPS egress was a live-patch (not in the chart)
The agenity solo agent (claude-code) only reached `api.anthropic.com`, and its `openova-mcp` child only reached the public Sovereign console, after a **hand-applied** CNP `agenity-allow-external-https-egress` (`toEntities:[world]:443`) in the Org namespace. That live patch evaporates on the next reconcile / a fresh Org / a re-prov.

- New `templates/cilium-egress-networkpolicy.yaml`: a **default-on** `CiliumNetworkPolicy` granting the agenity pod external-HTTPS egress (`toEntities:[world,cluster,host,remote-node]:443`), mirrors openclaw #4401.
- **DNS preserved**: a CNP egress rule flips the selected pod to default-deny egress, so `:53` UDP+TCP to kube-dns (`kube-system`/`k8s-app=kube-dns`) is explicitly allowed — else name resolution NXDOMAINs under the new posture.
- Gated on `networkPolicy.egress.allowExternalHttps` (values, default `true`) + the `cilium.io/v2` Capabilities check so **kind CI still renders** (CNP absent on a CRD-less cluster).

### Gap 2 — a standalone `claude` saw "no MCP tools"
The chart already wires the openova MCP through chepherd's `CHEPHERD_EXTRA_MCP_JSON` seam — but that only merges into each chepherd-**spawned** agent's per-session `.mcp.json`. A `claude -p "…"` invoked **standalone** in the pod (the North-Star verifier path) reads `~/.claude.json`'s `mcpServers` + a project `./.mcp.json`, both empty live → zero discovery.

- The `seed-claude-creds` init container now seeds the `openova` `mcpServers` entry into the same `~/.claude.json` it already writes, so **every** claude in the pod (spawned OR standalone) discovers the openova MCP.
- The bearer + RS256 pubkey stay **out** of the JSON: the `openova-mcp` child is launched by claude inside the chepherd container and inherits `OPENOVA_MCP_BEARER` / `OPENOVA_MCP_RS256_PUBKEY_PEM` from the container env — the same env-inheritance contract `CHEPHERD_EXTRA_MCP_JSON` uses. Only the non-secret knobs (catalyst-api URL, context pin, verify mode) are pinned.

## Lockstep
- `products/agenity/chart/Chart.yaml` `0.5.16 -> 0.5.17`
- catalog-seed `blueprints.yaml` agenity pin (card + source) `0.5.16 -> 0.5.17`
- agenity param test pin `0.5.16 -> 0.5.17`
- appVersion (image) **UNCHANGED** — pure chart-template + values change.

## Validation
- `helm template` renders clean WITH cilium caps (egress CNP present, init `~/.claude.json` carries valid `mcpServers.openova`) AND WITHOUT (kind CI — CNP absent, no nil-pointer).
- `helm lint` clean; agenity param test green.
- Live evidence (claude lists `mcp__openova__*` + a safe `create_application` CR created then deleted) posted on #4604.

## How the Sandbox wires the MCP (reference)
`core/controllers/sandbox/internal/gitops/manifests.go` (`mcpConfigMapTemplate`) projects a `mcp.json` ConfigMap mounted at every agent-canonical path (`~/.claude.json`, `./.mcp.json`, `~/.qwen/settings.json`, `.cursor/mcp.json`) with the `openova-sandbox-mcp` binary baked into the pty-server image + `SANDBOX_*` env on the StatefulSet. bp-agenity is the chepherd analogue: binary at `/usr/local/bin/openova-mcp`, config injected via `CHEPHERD_EXTRA_MCP_JSON` (spawned) + now `~/.claude.json` (standalone).

Refs #4604
Refs #4277

🤖 Generated with [Claude Code](https://claude.com/claude-code)