### PR TITLE
fix(application-controller): resolve status.placement for CNPG / non-spine bootstrap apps from the cnpg-pair Continuum (Refs #3375 #3986 #4601)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1217,11 +1217,22 @@ spec:
       #   onto Application.status.placement so the per-app Topology DR strip can
       #   render primary↔standby for the bootstrap-owned DR spine apps. CRD
       #   status.placement gains the DR sub-fields. Lockstep w/ Chart.yaml.
+      # 1.4.948 — #4605 follow-up (Refs #3375 #3986 #4601): fix the
+      #   status.placement DR projection for CNPG-backed / non-spine bootstrap
+      #   apps. shared-pg/-b/-c are active-hot-standby but carry the
+      #   `platform-bootstrap-owned-host` placeholder + no continuumRef + no
+      #   per-app dr-<app> CR — governed by the platform-scope cnpg-pair
+      #   Continuum. The projection now falls back to it (DR-mode only),
+      #   normalizes the full cluster-name leaseHolder/hotStandbyRegions
+      #   (hw-me-east-215-a-rtz-prod -> me-east-215-a), and derives standbys from
+      #   it. Singleton shared apps keep the static projection. Spine unchanged.
+      #   application-controller image fix (deploy-bot pins on next build).
+      #   Lockstep w/ Chart.yaml.
       # 1.4.936 — #4556: kill the agenity dual-render duplicate HR (quota) +
       #   stamp spec.parameters.sovereignFqdn so the openova-MCP URL points at
       #   this Sovereign, not the mothership. catalyst-api + application-controller
       #   image fixes (deploy-bot pins on next build). Lockstep w/ Chart.yaml.
-      version: 1.4.947
+      version: 1.4.948
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/core/controllers/application/internal/controller/application_controller.go
+++ b/core/controllers/application/internal/controller/application_controller.go
@@ -2587,7 +2587,58 @@ func (r *Reconciler) bootstrapPlacementProjection(
 			"app", app.GetName(), "continuumRef", ref, "err", cerr)
 		cs = nil
 	}
+
+	// #4605 follow-up — CNPG-backed / non-spine fallback. A shared-data
+	// bootstrap app (shared-pg / shared-pg-b / shared-pg-c) carries NO
+	// back-referenced continuumRef and has NO per-app `dr-<app>` CR: its DR is
+	// governed by the platform-scope cnpg-pair Continuum, not a per-app one.
+	// AND its spec.regions is the `platform-bootstrap-owned-host` placeholder,
+	// so the static plan has no real primary/standby to project. When we found
+	// no per-app Continuum, the plan has no real regions, AND the app declares a
+	// DR posture (active-hot-standby / active-passive), resolve the
+	// platform-scope cnpg-pair Continuum so the live region-a→region-b
+	// WAL-streaming truth (normalized leaseHolder + hotStandbyRegions + lag +
+	// LeaseHeld) drives the projection.
+	//
+	// The DR-mode gate is load-bearing: a SINGLETON shared bootstrap app
+	// (harbor / openbao / newapi on a single-region data plane) must NOT inherit
+	// the cnpg-pair's hot-standby region split — it is a single-cluster app, not
+	// a DR contract. Singletons keep their static (placeholder) projection here;
+	// correcting the singleton placeholder is out of scope for this DR fix.
+	if cs == nil && !planHasRealRegions(plan) && isDRPlacementMode(plan.Mode) {
+		pcs, perr := r.resolvePlatformScopeContinuumStatus(ctx)
+		if perr != nil {
+			r.Log.Warn("bootstrap-owned: platform-scope Continuum read failed; static placement projection",
+				"app", app.GetName(), "err", perr)
+		} else if pcs != nil {
+			cs = pcs
+		}
+	}
+
 	return buildPlacementProjection(plan, cs)
+}
+
+// isDRPlacementMode reports whether the resolved placement mode is one of the
+// two single-primary DR postures (active-hot-standby / active-passive) that
+// have a primary↔standby flip a Continuum drives. A singleton / active-active
+// mode is NOT a DR contract — it must not resolve a cnpg-pair Continuum's
+// region split. (#4605 follow-up.)
+func isDRPlacementMode(mode string) bool {
+	return mode == placement.ModeActiveHotStandby || mode == placement.ModeActivePassive
+}
+
+// planHasRealRegions reports whether the resolved placement plan carries any
+// host-cluster region other than the `platform-bootstrap-owned-host`
+// placeholder literal (#4605 follow-up). A bootstrap app whose spec.regions is
+// only the placeholder resolves to a plan with no real region — its DR truth
+// must come from the governing Continuum, not the placeholder plan.
+func planHasRealRegions(plan placement.Plan) bool {
+	for _, rp := range plan.Regions {
+		if rp.Name != platformBootstrapOwnedHostRegion {
+			return true
+		}
+	}
+	return false
 }
 
 // reconcileBootstrapContinuum mints the per-app Continuum DR contract for a

--- a/core/controllers/application/internal/controller/placement_projection.go
+++ b/core/controllers/application/internal/controller/placement_projection.go
@@ -38,12 +38,41 @@ package controller
 
 import (
 	"context"
+	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/openova-io/openova/core/controllers/internal/placement"
+)
+
+// platformBootstrapOwnedHostRegion is the placeholder region literal every
+// bootstrap-owned Application CR carries in spec.regions
+// (`platform/<x>/chart/templates/application-cr.yaml`). It is NOT a real
+// host-cluster region — it exists only to satisfy the pre-#3370 CRD's
+// region-pattern requirement (4 letter-only dash tokens) for OLD-CRD
+// compatibility. A CNPG-backed / shared-data bootstrap app (shared-pg) carries
+// EXACTLY this single placeholder, so its resolved placement plan has no real
+// primary/standby regions — the live DR truth must come from the governing
+// Continuum, not from this literal. (#4605 follow-up.)
+const platformBootstrapOwnedHostRegion = "platform-bootstrap-owned-host"
+
+// clusterNameProviders / clusterNameBuildingBlocks / clusterNameEnvTypes are
+// the closed token sets a host-cluster name (`{prov}-{reg}-{bb}-{env_type}`,
+// docs/ARCHITECTURE.md §4 Naming) is built from. normalizeRegion uses the
+// `-{bb}-{env_type}` TAIL + a leading {prov} segment to recognise a FULL
+// cluster name (e.g. hw-me-east-215-a-rtz-prod, hz-fsn-rtz-prod) and strip it
+// to the bare region — WITHOUT mis-firing on an already-bare region label
+// (me-east-215-a), which carries no provider prefix and no bb token. Anchoring
+// on the known token sets (rather than raw segment count) is what disambiguates
+// the two 4-segment shapes me-east-215-a (region) and hz-fsn-rtz-prod
+// (cluster). Mirrors the openova.io/{building-block,environment-type} label
+// vocabulary.
+var (
+	clusterNameProviders      = map[string]bool{"hw": true, "hz": true, "aws": true, "gcp": true, "azure": true}
+	clusterNameBuildingBlocks = map[string]bool{"rtz": true, "dmz": true, "mgt": true, "mgmt": true}
+	clusterNameEnvTypes       = map[string]bool{"prod": true, "stg": true, "staging": true, "dev": true, "uat": true}
 )
 
 // placementProjectionForPlan resolves the DR placement projection for an
@@ -74,8 +103,20 @@ type continuumDRStatus struct {
 	// LeaseHolder is the region currently holding the DR lease — i.e. the
 	// live primary. Authoritative over the static plan primary, which is
 	// only the *configured* (regions[0]) primary and goes stale the moment
-	// the continuum-controller flips the lease on failover.
+	// the continuum-controller flips the lease on failover. Always a
+	// NORMALIZED region label (a cnpg-pair Continuum stamps the full cluster
+	// name `hw-me-east-215-a-rtz-prod`; continuumDRStatusFromCR folds it to
+	// the bare region `me-east-215-a` so the projection is consistent with
+	// the per-app `dr-<app>` Continuums, which already carry bare regions).
 	LeaseHolder string
+
+	// StandbyRegions are the NORMALIZED standby region labels read from the
+	// Continuum spec.hotStandbyRegions. Used to populate
+	// status.placement.standbyRegions when the static placement plan has no
+	// REAL standby regions to offer — i.e. a CNPG-backed bootstrap app whose
+	// spec.regions is the `platform-bootstrap-owned-host` placeholder, so the
+	// resolved plan carries no second region. (#4605 follow-up.)
+	StandbyRegions []string
 
 	// ReplicationLagSeconds mirrors the Continuum status field. -1 means
 	// "the Continuum reported no lag value" (omit from the projection).
@@ -122,7 +163,20 @@ func continuumDRStatusFromCR(cr *unstructured.Unstructured) *continuumDRStatus {
 		return nil
 	}
 	out := &continuumDRStatus{ReplicationLagSeconds: -1}
-	out.LeaseHolder, _, _ = unstructured.NestedString(cr.Object, "status", "leaseHolder")
+	rawHolder, _, _ := unstructured.NestedString(cr.Object, "status", "leaseHolder")
+	out.LeaseHolder = normalizeRegion(rawHolder)
+	// spec.hotStandbyRegions is the configured standby roster. Normalize each
+	// (the cnpg-pair Continuum stamps full cluster names) so a CNPG-backed app
+	// whose static plan has no real standby can still surface its standby
+	// region(s). Distinct from the live leaseHolder, which is what the standby
+	// roster is computed AGAINST in buildPlacementProjection.
+	if standbys, found, _ := unstructured.NestedStringSlice(cr.Object, "spec", "hotStandbyRegions"); found {
+		for _, s := range standbys {
+			if n := normalizeRegion(s); n != "" {
+				out.StandbyRegions = append(out.StandbyRegions, n)
+			}
+		}
+	}
 	if lag, found, _ := unstructured.NestedInt64(cr.Object, "status", "replicationLagSeconds"); found {
 		out.ReplicationLagSeconds = lag
 		out.HasLag = true
@@ -169,23 +223,55 @@ func buildPlacementProjection(plan placement.Plan, cs *continuumDRStatus) map[st
 		return nil
 	}
 
-	// Effective primary: the live lease holder wins over the configured
-	// plan primary so the projection tracks failover, not just config.
+	// Whether the static plan carries REAL host-cluster regions. A CNPG-backed
+	// bootstrap app (shared-pg) resolves its plan from the placeholder literal
+	// `platform-bootstrap-owned-host`, so plan.Regions holds no real region —
+	// the live DR truth (primary + standby roster) must come entirely from the
+	// governing Continuum. A spine app carries real spec.regions, so its plan
+	// IS the source of truth (the Continuum only overrides the primary on a
+	// failover flip).
+	planHasRealRegions := false
+	for _, rp := range plan.Regions {
+		if rp.Name != platformBootstrapOwnedHostRegion {
+			planHasRealRegions = true
+			break
+		}
+	}
+
+	// Effective primary: the live lease holder (normalized) wins over the
+	// configured plan primary so the projection tracks failover, not just
+	// config. For a placeholder-region plan it is the ONLY primary signal.
 	primary := plan.PrimaryRegion
 	if cs != nil && cs.LeaseHolder != "" {
 		primary = cs.LeaseHolder
 	}
 
-	// Standbys: every plan region except the effective primary, in plan
-	// (priority) order. Recomputing against the EFFECTIVE primary (not the
-	// static plan.PrimaryRegion) means a failed-over deployment lists the
-	// old primary as a standby and the new primary is excluded.
-	standbys := make([]interface{}, 0, len(plan.Regions))
-	for _, rp := range plan.Regions {
-		if rp.Name == primary {
+	// Standbys: every standby region except the effective primary, in priority
+	// order. Recomputing against the EFFECTIVE primary (not the static plan
+	// primary) means a failed-over deployment lists the OLD primary as a
+	// standby and the new primary is excluded.
+	//
+	// Source of the standby roster:
+	//   - a plan WITH real regions ⇒ the plan regions (the spine path; the
+	//     Continuum only flips which one is primary, never the membership).
+	//   - a plan WITHOUT real regions (placeholder) ⇒ the Continuum's
+	//     hotStandbyRegions (the CNPG-backed shared-data path). Without this a
+	//     CNPG-backed app would project an EMPTY standbyRegions even though the
+	//     Continuum knows the standby region (the #4605 follow-up gap).
+	standbyNames := make([]string, 0, len(plan.Regions))
+	if planHasRealRegions {
+		for _, rp := range plan.Regions {
+			standbyNames = append(standbyNames, rp.Name)
+		}
+	} else if cs != nil {
+		standbyNames = append(standbyNames, cs.StandbyRegions...)
+	}
+	standbys := make([]interface{}, 0, len(standbyNames))
+	for _, name := range standbyNames {
+		if name == primary || name == "" {
 			continue
 		}
-		standbys = append(standbys, rp.Name)
+		standbys = append(standbys, name)
 	}
 
 	proj := map[string]interface{}{
@@ -221,6 +307,78 @@ func mergePlacementProjection(base, projection map[string]interface{}) map[strin
 		base[k] = v
 	}
 	return base
+}
+
+// normalizeRegion folds a host-cluster name (`{prov}-{reg}-{bb}-{env_type}`,
+// e.g. hw-me-east-215-a-rtz-prod, hz-fsn-rtz-prod) down to its bare region
+// label (me-east-215-a, fsn) so the placement projection speaks ONE region
+// vocabulary regardless of which Continuum produced the value (the cnpg-pair
+// Continuum stamps full cluster names; the per-app `dr-<app>` Continuums stamp
+// bare regions). It is IDEMPOTENT: a value that is already a bare region is
+// returned unchanged.
+//
+// Detection anchors on the CLOSED token sets, NOT raw segment count — that is
+// what disambiguates the two 4-segment shapes me-east-215-a (region:
+// non-provider first segment, non-env last segment) and hz-fsn-rtz-prod
+// (cluster: provider `hz` first, building-block `rtz` second-last, env `prod`
+// last). A value is a full cluster name iff:
+//   - it has ≥4 dash segments, AND
+//   - the first segment is a known provider, AND
+//   - the second-to-last segment is a known building-block, AND
+//   - the last segment is a known env_type.
+//
+// When all hold, strip the leading provider + the trailing {bb}-{env_type},
+// leaving the region. Otherwise the value is returned verbatim (a bare region,
+// the `platform-bootstrap-owned-host` placeholder, or anything unexpected) —
+// deliberately conservative so an unrecognised value is surfaced visibly rather
+// than silently mangled.
+func normalizeRegion(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	parts := strings.Split(s, "-")
+	if len(parts) < 4 {
+		return s
+	}
+	prov := parts[0]
+	bb := parts[len(parts)-2]
+	env := parts[len(parts)-1]
+	if !clusterNameProviders[prov] || !clusterNameBuildingBlocks[bb] || !clusterNameEnvTypes[env] {
+		return s
+	}
+	region := strings.Join(parts[1:len(parts)-2], "-")
+	if region == "" {
+		return s
+	}
+	return region
+}
+
+// resolvePlatformScopeContinuumStatus reads the SINGLE platform-scope
+// Continuum (label `openova.io/scope=platform`) — the cnpg-pair DR contract
+// that governs the shared CNPG data plane backing the shared-data bootstrap
+// apps (shared-pg). It is the fallback the bootstrap projection uses when a
+// CNPG-backed app has NEITHER a back-referenced continuumRef NOR a per-app
+// `dr-<app>` CR: those apps are governed by the cnpg-pair Continuum, not a
+// per-app one. Returns (nil, nil) when no platform-scope Continuum exists (a
+// single-region or non-CNPG Sovereign) — the caller then keeps the static
+// projection. A genuine list error is returned so the caller can degrade
+// gracefully rather than fail the reconcile. (#4605 follow-up.)
+func (r *Reconciler) resolvePlatformScopeContinuumStatus(ctx context.Context) (*continuumDRStatus, error) {
+	list, err := r.Dynamic.Resource(ContinuumGVR).Namespace("").List(ctx, metav1.ListOptions{
+		LabelSelector: "openova.io/scope=platform",
+	})
+	if err != nil {
+		return nil, err
+	}
+	if list == nil || len(list.Items) == 0 {
+		return nil, nil
+	}
+	// Exactly one platform-scope Continuum is expected (the cnpg-pair). If a
+	// future Sovereign carries more, the first deterministically-ordered one
+	// is the shared data plane's contract — the List is name-ordered.
+	cr := list.Items[0]
+	return continuumDRStatusFromCR(&cr), nil
 }
 
 // splitNamespacedName splits a `<namespace>/<name>` ref. Returns ok=false for

--- a/core/controllers/application/internal/controller/placement_projection_test.go
+++ b/core/controllers/application/internal/controller/placement_projection_test.go
@@ -130,6 +130,124 @@ func TestBuildPlacementProjection(t *testing.T) {
 	})
 }
 
+// TestNormalizeRegion — the cluster-name → bare-region fold the projection
+// applies so a cnpg-pair Continuum's full cluster-name leaseHolder
+// (hw-me-east-215-a-rtz-prod) projects the SAME region label as a per-app
+// `dr-<app>` Continuum's already-bare region (me-east-215-a). Idempotent.
+func TestNormalizeRegion(t *testing.T) {
+	cases := []struct{ in, want string }{
+		// Full cluster names — strip provider + {bb}-{env_type}.
+		{"hw-me-east-215-a-rtz-prod", "me-east-215-a"},
+		{"hw-me-east-215-b-rtz-prod", "me-east-215-b"},
+		{"hz-fsn-rtz-prod", "fsn"},
+		{"hz-hel-rtz-prod", "hel"},
+		{"hz-fsn-rtz-stg", "fsn"},
+		// Already-bare regions — passed through unchanged (idempotent).
+		{"me-east-215-a", "me-east-215-a"},
+		{"me-east-215-b", "me-east-215-b"},
+		{"region-a", "region-a"},
+		{"region-b", "region-b"},
+		// Re-normalizing a bare region is a no-op.
+		{normalizeRegion("hw-me-east-215-a-rtz-prod"), "me-east-215-a"},
+		// Edge: empty / placeholder are returned verbatim (visible, not mangled).
+		{"", ""},
+		{"platform-bootstrap-owned-host", "platform-bootstrap-owned-host"},
+		// A value with an env-suffix but too few segments to be a cluster name
+		// is left alone (conservative).
+		{"x-rtz-prod", "x-rtz-prod"},
+	}
+	for _, c := range cases {
+		if got := normalizeRegion(c.in); got != c.want {
+			t.Errorf("normalizeRegion(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestBuildPlacementProjection_CNPGPlaceholderPlan is the pure-unit regression
+// for the #4605 follow-up: a CNPG-backed bootstrap app (shared-pg) whose static
+// plan resolved from the `platform-bootstrap-owned-host` placeholder must NOT
+// project the placeholder as primaryRegion. With the governing cnpg-pair
+// Continuum's status folded in, primaryRegion is the NORMALIZED leaseHolder and
+// standbyRegions comes from the Continuum's hotStandbyRegions.
+func TestBuildPlacementProjection_CNPGPlaceholderPlan(t *testing.T) {
+	// shared-pg's real shape: active-hot-standby over the single placeholder.
+	plan, err := placement.Resolve("active-hot-standby", []string{"platform-bootstrap-owned-host"})
+	if err != nil {
+		t.Fatalf("resolve placeholder plan: %v", err)
+	}
+	// Without a Continuum the placeholder leaks (the live BUG shape).
+	t.Run("no Continuum ⇒ placeholder leaks (documents the bug)", func(t *testing.T) {
+		got := buildPlacementProjection(plan, nil)
+		if got["primaryRegion"] != "platform-bootstrap-owned-host" {
+			t.Errorf("expected placeholder primary with no Continuum, got %v", got["primaryRegion"])
+		}
+	})
+	// With the cnpg-pair Continuum status (normalized at extraction) the
+	// projection resolves the real region-a primary + region-b standby.
+	t.Run("cnpg-pair Continuum ⇒ real region-a primary + region-b standby", func(t *testing.T) {
+		cs := &continuumDRStatus{
+			LeaseHolder:           "me-east-215-a", // already normalized at extraction
+			StandbyRegions:        []string{"me-east-215-b"},
+			ReplicationLagSeconds: 0,
+			HasLag:                true,
+			LeaseHeld:             true,
+			HasLeaseHeld:          true,
+		}
+		got := buildPlacementProjection(plan, cs)
+		if got["mode"] != placement.ModeActiveHotStandby {
+			t.Errorf("mode = %v, want %s", got["mode"], placement.ModeActiveHotStandby)
+		}
+		if got["primaryRegion"] != "me-east-215-a" {
+			t.Errorf("primaryRegion = %v, want me-east-215-a (NOT the placeholder)", got["primaryRegion"])
+		}
+		standbys, _ := got["standbyRegions"].([]interface{})
+		if !reflect.DeepEqual(standbys, []interface{}{"me-east-215-b"}) {
+			t.Errorf("standbyRegions = %v, want [me-east-215-b]", standbys)
+		}
+		if got["leaseHeld"] != true {
+			t.Errorf("leaseHeld = %v, want true", got["leaseHeld"])
+		}
+		if got["replicationLagSeconds"] != int64(0) {
+			t.Errorf("replicationLagSeconds = %v, want 0", got["replicationLagSeconds"])
+		}
+	})
+}
+
+// TestContinuumDRStatusFromCR_CNPGPairFullClusterNames asserts the extraction
+// normalizes a cnpg-pair Continuum's FULL cluster-name leaseHolder +
+// hotStandbyRegions down to bare region labels (so the projection speaks one
+// vocabulary). This is the cnpg/cnpg-pair-bp-cnpg-pair-continuum live shape.
+func TestContinuumDRStatusFromCR_CNPGPairFullClusterNames(t *testing.T) {
+	cr := &unstructured.Unstructured{Object: map[string]interface{}{
+		"spec": map[string]interface{}{
+			"applicationRef":    "catalyst-platform",
+			"primaryRegion":     "hw-me-east-215-a-rtz-prod",
+			"hotStandbyRegions": []interface{}{"hw-me-east-215-b-rtz-prod"},
+		},
+		"status": map[string]interface{}{
+			"leaseHolder":           "hw-me-east-215-a-rtz-prod",
+			"replicationLagSeconds": int64(0),
+			"conditions": []interface{}{
+				map[string]interface{}{"type": "LeaseHeld", "status": "True"},
+				map[string]interface{}{"type": "Ready", "status": "True"},
+			},
+		},
+	}}
+	cs := continuumDRStatusFromCR(cr)
+	if cs == nil {
+		t.Fatal("nil status from a populated cnpg-pair Continuum CR")
+	}
+	if cs.LeaseHolder != "me-east-215-a" {
+		t.Errorf("LeaseHolder = %q, want normalized me-east-215-a", cs.LeaseHolder)
+	}
+	if !reflect.DeepEqual(cs.StandbyRegions, []string{"me-east-215-b"}) {
+		t.Errorf("StandbyRegions = %v, want normalized [me-east-215-b]", cs.StandbyRegions)
+	}
+	if !cs.HasLeaseHeld || !cs.LeaseHeld {
+		t.Errorf("leaseHeld = %v (has=%v), want true", cs.LeaseHeld, cs.HasLeaseHeld)
+	}
+}
+
 func TestContinuumDRStatusFromCR(t *testing.T) {
 	cr := &unstructured.Unstructured{Object: map[string]interface{}{
 		"status": map[string]interface{}{
@@ -303,6 +421,146 @@ func TestReconcile_BootstrapOwned_PlacementProjectionFromContinuum(t *testing.T)
 	lag, lagFound, _ := unstructured.NestedInt64(got.Object, "status", "placement", "replicationLagSeconds")
 	if !lagFound || lag != 0 {
 		t.Errorf("status.placement.replicationLagSeconds = %d (found=%v), want 0", lag, lagFound)
+	}
+}
+
+// makeCNPGPairContinuumCR builds the platform-scope cnpg-pair Continuum CR —
+// the DR contract that governs the shared CNPG data plane backing the
+// shared-data bootstrap apps (shared-pg). It carries FULL cluster names
+// (hw-me-east-215-a-rtz-prod) in spec + status and the `openova.io/scope:
+// platform` label the resolver selects on, mirroring the live
+// cnpg/cnpg-pair-bp-cnpg-pair-continuum.
+func makeCNPGPairContinuumCR(namespace, name, primaryCluster, standbyCluster string, lag int64) *unstructured.Unstructured {
+	cr := &unstructured.Unstructured{}
+	cr.SetAPIVersion(ContinuumGroup + "/" + ContinuumVersion)
+	cr.SetKind(ContinuumKind)
+	cr.SetNamespace(namespace)
+	cr.SetName(name)
+	cr.SetLabels(map[string]string{"openova.io/scope": "platform"})
+	cr.Object["spec"] = map[string]interface{}{
+		"applicationRef":    "catalyst-platform",
+		"primaryRegion":     primaryCluster,
+		"hotStandbyRegions": []interface{}{standbyCluster},
+		"leaseClient":       map[string]interface{}{"kind": "k8s-lease"},
+		"switchover":        map[string]interface{}{"mechanism": "cnpg-pair"},
+	}
+	cr.Object["status"] = map[string]interface{}{
+		"leaseHolder":           primaryCluster,
+		"replicationLagSeconds": lag,
+		"phase":                 "Healthy",
+		"conditions": []interface{}{
+			map[string]interface{}{"type": "LeaseHeld", "status": "True"},
+			map[string]interface{}{"type": "Ready", "status": "True"},
+		},
+	}
+	return cr
+}
+
+// TestReconcile_BootstrapOwned_CNPGSharedPG_PlacementFromCNPGPairContinuum is
+// the regression gate for the #4605 follow-up live gap (dep 91dc05917e44d1c1):
+// `shared-pg` (ns shared-data) is a CNPG-backed bootstrap app with
+//   - spec.placement = active-hot-standby
+//   - spec.regions   = ["platform-bootstrap-owned-host"]  (the placeholder)
+//   - NO status.continuumRef + NO per-app `dr-shared-pg` Continuum
+//
+// Its DR is governed by the PLATFORM-SCOPE cnpg-pair Continuum
+// (leaseHolder=hw-me-east-215-a-rtz-prod, hotStandbyRegions=
+// [hw-me-east-215-b-rtz-prod]). BEFORE the fix the projection fell back to the
+// static placeholder plan and wrote
+//
+//	{primaryRegion: platform-bootstrap-owned-host, standbyRegions: []}
+//
+// — the exact wrong live value. AFTER the fix the projection resolves the
+// cnpg-pair Continuum and normalizes the cluster names to bare regions:
+//
+//	{mode: active-hot-standby, primaryRegion: me-east-215-a,
+//	 standbyRegions: [me-east-215-b], leaseHeld: true, replicationLagSeconds: 0}
+func TestReconcile_BootstrapOwned_CNPGSharedPG_PlacementFromCNPGPairContinuum(t *testing.T) {
+	// shared-pg's REAL live shape: placeholder region, no continuumRef.
+	app := makeBootstrapDRSpineApp("shared-data", "shared-pg", "bp-postgres-shared", "flux-system")
+	spec, _, _ := unstructured.NestedMap(app.Object, "spec")
+	spec["placement"] = "active-hot-standby"
+	spec["regions"] = []interface{}{"platform-bootstrap-owned-host"}
+	spec["blueprintRef"] = map[string]interface{}{"name": "bp-postgres", "version": "0.2.8"}
+	app.Object["spec"] = spec
+	hr := makeSlotHR("flux-system", "bp-postgres-shared", "True", "Helm install succeeded")
+	// The platform-scope cnpg-pair Continuum — full cluster names, scope label.
+	// NO per-app dr-shared-pg CR exists (the live gap).
+	cnpgPair := makeCNPGPairContinuumCR("cnpg", "cnpg-pair-bp-cnpg-pair-continuum",
+		"hw-me-east-215-a-rtz-prod", "hw-me-east-215-b-rtz-prod", 0)
+
+	fg := newFakeGitea()
+	r := newReconciler(t, fg, app, hr, cnpgPair)
+
+	reconcileFromCluster(t, r, "shared-data", "shared-pg")
+
+	got := readApp(t, r, "shared-data", "shared-pg")
+	pl, found, _ := unstructured.NestedMap(got.Object, "status", "placement")
+	if !found || pl == nil {
+		t.Fatal("status.placement is empty for shared-pg")
+	}
+	if pl["mode"] != placement.ModeActiveHotStandby {
+		t.Errorf("status.placement.mode = %v, want %s", pl["mode"], placement.ModeActiveHotStandby)
+	}
+	if pl["primaryRegion"] != "me-east-215-a" {
+		t.Errorf("status.placement.primaryRegion = %v, want me-east-215-a (NOT platform-bootstrap-owned-host)", pl["primaryRegion"])
+	}
+	if pl["primaryRegion"] == "platform-bootstrap-owned-host" {
+		t.Error("REGRESSION: primaryRegion is still the bootstrap placeholder — the #4605 follow-up fix did not fire")
+	}
+	standbys, _, _ := unstructured.NestedSlice(got.Object, "status", "placement", "standbyRegions")
+	if len(standbys) != 1 || standbys[0] != "me-east-215-b" {
+		t.Errorf("status.placement.standbyRegions = %v, want [me-east-215-b]", standbys)
+	}
+	if pl["leaseHeld"] != true {
+		t.Errorf("status.placement.leaseHeld = %v, want true", pl["leaseHeld"])
+	}
+	lag, lagFound, _ := unstructured.NestedInt64(got.Object, "status", "placement", "replicationLagSeconds")
+	if !lagFound || lag != 0 {
+		t.Errorf("status.placement.replicationLagSeconds = %d (found=%v), want 0", lag, lagFound)
+	}
+}
+
+// TestReconcile_BootstrapOwned_SingletonSharedApp_DoesNotInheritCNPGPair is
+// the negative guard for the #4605 follow-up DR-mode gate: a SINGLETON shared
+// bootstrap app (harbor / openbao / newapi — placeholder region, no
+// continuumRef) must NOT inherit the platform-scope cnpg-pair Continuum's
+// hot-standby region split even when one is present. It is a single-cluster
+// app, not a DR contract. Without the isDRPlacementMode gate it would wrongly
+// project primaryRegion=me-east-215-a + standbyRegions=[me-east-215-b].
+func TestReconcile_BootstrapOwned_SingletonSharedApp_DoesNotInheritCNPGPair(t *testing.T) {
+	app := makeBootstrapDRSpineApp("openbao", "openbao", "bp-openbao", "flux-system")
+	spec, _, _ := unstructured.NestedMap(app.Object, "spec")
+	spec["placement"] = "singleton"
+	spec["regions"] = []interface{}{"platform-bootstrap-owned-host"}
+	spec["blueprintRef"] = map[string]interface{}{"name": "bp-openbao", "version": "1.0.0"}
+	app.Object["spec"] = spec
+	hr := makeSlotHR("flux-system", "bp-openbao", "True", "Helm install succeeded")
+	// A platform-scope cnpg-pair Continuum IS present — but a singleton must
+	// ignore it.
+	cnpgPair := makeCNPGPairContinuumCR("cnpg", "cnpg-pair-bp-cnpg-pair-continuum",
+		"hw-me-east-215-a-rtz-prod", "hw-me-east-215-b-rtz-prod", 0)
+
+	fg := newFakeGitea()
+	r := newReconciler(t, fg, app, hr, cnpgPair)
+
+	reconcileFromCluster(t, r, "openbao", "openbao")
+
+	got := readApp(t, r, "openbao", "openbao")
+	pl, _, _ := unstructured.NestedMap(got.Object, "status", "placement")
+	if pl["mode"] != placement.ModeSingleton {
+		t.Errorf("mode = %v, want singleton", pl["mode"])
+	}
+	// A singleton must NOT borrow the cnpg-pair's region split.
+	if pl["primaryRegion"] == "me-east-215-a" {
+		t.Error("singleton wrongly inherited the cnpg-pair leaseHolder region — DR-mode gate failed")
+	}
+	standbys, _, _ := unstructured.NestedSlice(got.Object, "status", "placement", "standbyRegions")
+	if len(standbys) != 0 {
+		t.Errorf("singleton standbyRegions = %v, want empty (must not inherit cnpg-pair standbys)", standbys)
+	}
+	if _, ok := pl["leaseHeld"]; ok {
+		t.Errorf("singleton leaseHeld present (%v) — must not inherit the cnpg-pair lease", pl["leaseHeld"])
 	}
 }
 

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,19 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.948 — #4605 follow-up (Refs #3375 #3986 #4601): fix the
+#   status.placement DR projection for CNPG-backed / non-spine bootstrap apps.
+#   shared-pg/-b/-c (ns shared-data) are active-hot-standby but carry the
+#   `platform-bootstrap-owned-host` placeholder in spec.regions, NO continuumRef,
+#   and NO per-app `dr-<app>` CR — their DR is governed by the platform-scope
+#   cnpg-pair Continuum (cnpg/cnpg-pair-bp-cnpg-pair-continuum). The projection
+#   now (a) falls back to that platform-scope Continuum when a DR-mode bootstrap
+#   app has no per-app one + only placeholder regions, (b) normalizes the
+#   cnpg-pair full cluster-name leaseHolder/hotStandbyRegions
+#   (hw-me-east-215-a-rtz-prod -> me-east-215-a), and (c) derives standbyRegions
+#   from the Continuum when the static plan has no real regions. Singleton shared
+#   apps (harbor/openbao/newapi) keep their static projection (DR-mode gate).
+#   Spine apps unchanged. Read-only / observational. Ships in the
+#   application-controller image (deploy-bot bumps the pin on next build).
 # 1.4.943 — #4601 (Refs #3986 #3375): the application-controller now projects
 #   the EFFECTIVE per-region DR placement onto Application.status.placement
 #   ({mode, primaryRegion, standbyRegions, replicationLagSeconds, leaseHeld})
@@ -3389,7 +3403,7 @@ name: bp-catalyst-platform
 #   sovereign-fqdn) so GET /catalog/regions returns the Sovereign's REAL
 #   regions instead of [] — the marketplace BCP picker stops falling back to
 #   the hardcoded Hetzner list.
-version: 1.4.947
+version: 1.4.948
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/
 #   platform/crossplane chart + blueprint.yaml + bootstrap-kit slot 04). crossplane-core
 #   was still OOMKilled (CrashLoopBackOff, 55 restarts, exit 137, killed ~90s after start)


### PR DESCRIPTION
## Problem
#4605 projected `status.placement` correctly for the DR **spine** apps but MIS-projects the **CNPG-backed shared-data** apps.

**Live on dep `91dc05917e44d1c1` (2-region):**
- `spine-gitea` (ns catalyst) → `{leaseHeld:true, mode:active-hot-standby, primaryRegion:me-east-215-a, replicationLagSeconds:0, standbyRegions:[me-east-215-b]}` ✅
- `shared-pg` (ns shared-data) → `{primaryRegion:"platform-bootstrap-owned-host", standbyRegions:[]}` ❌ — despite live region-a→region-b WAL streaming.

`shared-pg-b` and `shared-pg-c` have the identical wrong shape.

## Root cause (3 compounding gaps)
1. `shared-pg.spec.regions` is the bootstrap placeholder `["platform-bootstrap-owned-host"]` (the OLD-CRD-compat literal from `platform/postgres/chart/templates/application-cr.yaml`), so `placement.Resolve` yields **no real region** → `primaryRegion` fell back to the placeholder. Spine apps differ: they carry **real** 2-region `spec.regions`.
2. `shared-pg.status.continuumRef` is **empty** AND no per-app `dr-shared-pg` CR exists. Its DR is governed by the **platform-scope cnpg-pair Continuum** (`cnpg/cnpg-pair-bp-cnpg-pair-continuum`, label `openova.io/scope=platform`), not a per-app one — so the `dr-<app>` deterministic-name read found nothing → no leaseHolder override.
3. The cnpg-pair Continuum stamps **full cluster names** (`hw-me-east-215-a-rtz-prod`) where spine per-app Continuums stamp **bare regions** (`me-east-215-a`) — un-normalized.

## Fix
`core/controllers/application/internal/controller/placement_projection.go` + `application_controller.go`:
- **`normalizeRegion`** — idempotent `{prov}-{reg}-{bb}-{env_type}` → `{reg}` fold, anchored on the closed provider / building-block / env-type token sets. Folds `hw-me-east-215-a-rtz-prod`→`me-east-215-a`, `hz-fsn-rtz-prod`→`fsn`; leaves bare regions (`me-east-215-a`) untouched.
- **`continuumDRStatus.StandbyRegions`** — read from `spec.hotStandbyRegions` (normalized); `leaseHolder` normalized at extraction.
- **`bootstrapPlacementProjection`** — when a **DR-mode** bootstrap app has no per-app Continuum and only placeholder regions, fall back to the single platform-scope cnpg-pair Continuum. The `isDRPlacementMode` gate keeps **singleton** shared apps (harbor / openbao / newapi) on their static projection — they must not inherit the hot-standby split.
- **`buildPlacementProjection`** — derives `standbyRegions` from the Continuum's `hotStandbyRegions` when the static plan has no real regions.

**Spine behavior unchanged** (real regions ⇒ the plan is the source of truth; the Continuum only flips the primary on failover). **Read-only / observational** — never changes which region is primary, never writes the Continuum.

## Tests
- `TestNormalizeRegion` — cluster-name → region table, idempotent.
- `TestContinuumDRStatusFromCR_CNPGPairFullClusterNames` — normalization at extraction.
- `TestBuildPlacementProjection_CNPGPlaceholderPlan` — placeholder-plan + cnpg-pair status → real region split.
- `TestReconcile_BootstrapOwned_CNPGSharedPG_PlacementFromCNPGPairContinuum` — the shared-pg live shape end-to-end → `primaryRegion me-east-215-a` + `standbyRegions [me-east-215-b]` + `leaseHeld`. **Verified FAILS without the fix** (projects the exact wrong placeholder) **and PASSES with it.**
- `TestReconcile_BootstrapOwned_SingletonSharedApp_DoesNotInheritCNPGPair` — DR-mode-gate negative guard.

## Gates
`cd core/controllers && go build ./... && go test ./application/...` → green. Full `go test ./...` green. `gofmt` clean.

## Delivery
Lockstep: `bp-catalyst-platform` chart `1.4.947 → 1.4.948` + bootstrap-kit slot-13 pin. The Go code is **baked into the application-controller image** — deploy-bot bumps the image pin on the next build (merged ≠ delivered until the image rolls).

Refs #3375 #3986 #4601

🤖 Generated with [Claude Code](https://claude.com/claude-code)