### PR TITLE
fix(catalyst-api): install-door agenity CR wires the per-Org openova-MCP bearer — kill create_application 401 (Refs #4610 #4276 #4277 #3988)

### DIFF
--- a/products/agenity/blueprint.yaml
+++ b/products/agenity/blueprint.yaml
@@ -14,7 +14,7 @@ spec:
   # 0.5.17 (#4604): chart adds a default-on external-HTTPS egress CNP +
   # seeds the openova MCP into ~/.claude.json for a standalone claude (durable
   # Pillar-4 North-Star wiring). Lockstep with products/agenity/chart.
-  version: 0.5.17
+  version: 0.5.18
   card:
     title: Agenity
     summary: |

--- a/products/agenity/chart/Chart.yaml
+++ b/products/agenity/chart/Chart.yaml
@@ -179,7 +179,14 @@ type: application
 # same gateway bp-wordpress-tenant + the org console route attach to, #4054).
 # The old default rendered Accepted=False/InvalidHTTPRoute and the host 404'd
 # until the parentRef was hand-overridden. appVersion (image) unchanged.
-version: 0.5.17
+version: 0.5.18
+# 0.5.18 (#4610): OPENOVA_MCP_TENANT_HOST — the openova MCP now forwards the
+# Org console host (console.<slug>.<pool>) as X-Tenant-Host on the org-scoped
+# install path, so create_application resolves the caller's OWN Org instead of
+# 404ing `tenant-not-registered` against the Sovereign api-URL host. Derived
+# from the agenity gate host (agenity.<slug>.<pool> → console.<slug>.<pool>) or
+# pinned via openovaMCP.tenantHost. Wired in BOTH the CHEPHERD_EXTRA_MCP_JSON
+# (spawned agents) and as a container env (standalone claude inherits it).
 # Bumped appVersion 0.9.6 -> 0.9.7 (#4180): 0.9.7 is the FIRST image whose
 # /app/ mounts the WORKSPACES dashboard (Dashboardws bundle) rather than the
 # archaic single-column Dashboard.svelte. It is built from agenity#752

--- a/products/agenity/chart/templates/_helpers.tpl
+++ b/products/agenity/chart/templates/_helpers.tpl
@@ -50,6 +50,32 @@ guard so both agree on the host.
 {{- end -}}
 
 {{- /*
+agenity.mcpTenantHost — the Organization console host (console.<slug>.<pool>)
+the openova MCP forwards as X-Tenant-Host on the org-scoped install path
+(#4116). The catalyst-api base URL is the SOVEREIGN host (console.<sov-fqdn>)
+which is NOT a registered tenant, so X-Tenant-Host MUST be the Org host or the
+install 404s `tenant-not-registered` (#4610). Resolution:
+  1. explicit openovaMCP.tenantHost wins;
+  2. else derive from the agenity gate host (agenity.<slug>.<pool>): swap the
+     leading `agenity` label for `console` → console.<slug>.<pool>;
+  3. else empty (the MCP falls back to deriving from the api-URL host).
+*/ -}}
+{{- define "agenity.mcpTenantHost" -}}
+{{- if .Values.openovaMCP.tenantHost -}}
+{{- .Values.openovaMCP.tenantHost -}}
+{{- else -}}
+{{- $host := include "agenity.gateHostname" . -}}
+{{- if $host -}}
+{{- $rest := "" -}}
+{{- if contains "." $host -}}
+{{- $rest = (regexReplaceAll "^[^.]+\\." $host "") -}}
+{{- printf "console.%s" $rest -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- /*
 agenity.gateEnabled — "true" only when the SSO gate is requested AND a hostname
 resolves (no host → fail-closed, the gate would render nothing useful). Drives
 BOTH templates/oidc-gate.yaml (render the gate) AND templates/httproute.yaml

--- a/products/agenity/chart/templates/statefulset.yaml
+++ b/products/agenity/chart/templates/statefulset.yaml
@@ -268,16 +268,31 @@ spec:
             # natively (verified: `openova-mcp` logs `bearer_fallback=true` and
             # reads OPENOVA_MCP_* from its environment). Only the non-secret,
             # MCP-specific knobs are pinned in the JSON.
+            {{- $tenantHost := include "agenity.mcpTenantHost" . }}
             - name: CHEPHERD_EXTRA_MCP_JSON
               value: |-
                 {"mcpServers":{"openova":{
                   "command":{{ .Values.openovaMCP.binaryPath | quote }},
                   "env":{
                     "OPENOVA_MCP_CATALYST_API_URL":{{ $apiURL | quote }},
+                    {{- if $tenantHost }}
+                    "OPENOVA_MCP_TENANT_HOST":{{ $tenantHost | quote }},
+                    {{- end }}
                     "OPENOVA_MCP_CONTEXT":{{ .Values.openovaMCP.context | quote }},
                     "OPENOVA_MCP_VERIFY":{{ .Values.openovaMCP.verify | quote }}
                   }
                 }}}
+            {{- if $tenantHost }}
+            # OPENOVA_MCP_TENANT_HOST (#4610) — the Org console host the MCP
+            # forwards as X-Tenant-Host on the org-scoped install path. Set as a
+            # container env so a STANDALONE claude (whose ~/.claude.json carries
+            # only the non-secret MCP knobs) ALSO gets it via the same env
+            # inheritance the bearer/pubkey use. The api-URL host is the
+            # SOVEREIGN host and is NOT a registered tenant, so without this the
+            # org-scoped create 404s `tenant-not-registered`.
+            - name: OPENOVA_MCP_TENANT_HOST
+              value: {{ $tenantHost | quote }}
+            {{- end }}
             {{- if .Values.openovaMCP.bearerSecret.name }}
             # Interim per-call bearer (#4111) — an admin-tier, Org-pinned,
             # handover-RS256-signed session JWT the MCP forwards to the

--- a/products/agenity/chart/values.yaml
+++ b/products/agenity/chart/values.yaml
@@ -133,6 +133,21 @@ openovaMCP:
   # from the Sovereign FQDN. Override for a host-namespace (non-vCluster)
   # install where the in-cluster Service name resolves.
   catalystApiUrl: ""
+  # tenantHost — the Organization console host (console.<slug>.<pool>) the
+  # MCP forwards as X-Tenant-Host on the org-scoped install path
+  # (POST /api/v1/org/applications, #4116) so the catalyst-api resolves the
+  # caller's OWN Org namespace from the tenant registry. CRITICAL (#4610): the
+  # catalyst-api base URL (catalystApiUrl) is the SOVEREIGN host
+  # (console.<sovereign-fqdn>, e.g. console.omantel.biz) — the Cilium Gateway
+  # routes /api/v1/* there — but that host is NOT a registered TENANT, so if
+  # the MCP defaults X-Tenant-Host to the api-URL host the org-scoped install
+  # 404s `tenant-not-registered`. This value pins the Org console host
+  # instead. Empty → the chart derives it from httpRoute.hostnames[0] (the
+  # agenity.<slug>.<pool> host) by swapping the leading `agenity` label for
+  # `console`; a non-empty value wins. Falls back to OPENOVA_MCP_TENANT_HOST
+  # unset (the MCP then derives from the api-URL host) only when no Org host
+  # is resolvable.
+  tenantHost: ""
   # Pins the MCP to the Organization context so even a wider token cannot
   # widen the surface beyond the User's Org (defense in depth).
   context: organization

--- a/products/catalyst/bootstrap/api/internal/handler/application_parameters.go
+++ b/products/catalyst/bootstrap/api/internal/handler/application_parameters.go
@@ -2,6 +2,28 @@ package handler
 
 import "strings"
 
+// agenityMCPBearerSecretName is the in-namespace K8s Secret the agenity
+// chart's externalsecret-mcp-bearer.yaml materialises and the StatefulSet
+// projects as OPENOVA_MCP_BEARER + OPENOVA_MCP_RS256_PUBKEY_PEM. Fixed by
+// contract with products/agenity/chart/values.yaml (openovaMCP.mcpBearer
+// .secretName) AND the BSS-door GitOps overlay (orgTenantBPAgenity) so the
+// two create doors emit byte-identical wiring.
+const agenityMCPBearerSecretName = "agenity-mcp-bearer"
+
+// agenityMCPBearerStoreRef / Kind — the region-1 ClusterSecretStore the
+// agenity ExternalSecret authenticates to OpenBao through. Same store the
+// anthropic + mcp-bearer ExternalSecrets already use.
+const (
+	agenityMCPBearerStoreRef  = "vault-region1"
+	agenityMCPBearerStoreKind = "ClusterSecretStore"
+)
+
+// agenityMCPBearerRemoteKeyPrefix + the Org slug build the per-Org OpenBao
+// KV-v2 path the producer (seedMCPBearer) writes and the ExternalSecret
+// reads — secret/catalyst/agenity/<slug>/mcp-bearer (properties bearer +
+// pubkeyPem). MUST match mcpBearerSecretPath() in sovereign_mcp_bearer_seed.go.
+const agenityMCPBearerRemoteKeyPrefix = "catalyst/agenity/"
+
 // defaultedParameters returns the value to stamp into
 // `Application.spec.parameters` for a newly-created Application CR.
 //
@@ -54,13 +76,31 @@ import "strings"
 // never sets it themselves); a caller that DID pin it wins (we never
 // overwrite a non-empty explicit value).
 //
+// For bp-agenity we ALSO stamp the `openovaMCP` mcpBearer wiring (#4610). The
+// chart defaults leave the per-Org bearer ExternalSecret DISABLED
+// (mcpBearer.externalSecret.enabled=false, remoteKey="", and
+// rs256PubkeySecret pointed at the host `catalyst-handover-jwt` Secret which
+// is the MOTHERSHIP key — absent in the Org namespace anyway). So an agenity
+// installed via the Application-CR door projected NO OPENOVA_MCP_BEARER, and
+// the only bearer the MCP saw was a hand-injected MOTHERSHIP-signed token the
+// Sovereign's catalyst-api rejects on EVERY endpoint (whoami/organizations/
+// org/applications all 401 `unauthenticated`, because catalyst-api validates
+// against the Sovereign's LOCAL handover-signer key — NOT the mothership
+// key). The BSS-door overlay (orgTenantBPAgenity) wires this; the install
+// door did not. We mirror that overlay so BOTH doors point the chart at the
+// in-namespace `agenity-mcp-bearer` Secret — fed from the per-Org OpenBao
+// path the producer (seedMCPBearer) writes with a LOCAL-signer-signed bearer
+// + its matching verify pubkey. orgSlug is the leading DNS label of the
+// caller's Org ref (the path is secret/catalyst/agenity/<slug>/mcp-bearer);
+// empty orgSlug ⇒ skip the mcpBearer stamp (we can't scope the path).
+//
 // blueprint may carry the `bp-` prefix or not; topology is the canonical
 // (or legacy-dialect) placement token already chosen by the caller.
 // sovereignFQDN is the Sovereign's own FQDN (e.g. "omantel.biz"); empty on
 // the mothership / Catalyst-Zero, where the agenity install is not a
 // production path — leaving sovereignFqdn unset keeps the chart's existing
 // fail-closed default behaviour.
-func defaultedParameters(blueprint, topology, sovereignFQDN string, explicit map[string]interface{}) map[string]interface{} {
+func defaultedParameters(blueprint, topology, sovereignFQDN, orgSlug string, explicit map[string]interface{}) map[string]interface{} {
 	out := make(map[string]interface{}, len(explicit)+1)
 	for k, v := range explicit {
 		out[k] = v
@@ -68,6 +108,7 @@ func defaultedParameters(blueprint, topology, sovereignFQDN string, explicit map
 
 	if isAgenityBlueprint(blueprint) {
 		stampAgenitySovereignFqdn(out, sovereignFQDN)
+		stampAgenityMCPBearer(out, orgSlug)
 	}
 
 	if len(out) > 0 {
@@ -95,6 +136,89 @@ func stampAgenitySovereignFqdn(params map[string]interface{}, sovereignFQDN stri
 		return
 	}
 	params["sovereignFqdn"] = fqdn
+}
+
+// stampAgenityMCPBearer wires the chart's openova-MCP bearer ExternalSecret
+// (#4610) so the install-door agenity gets OPENOVA_MCP_BEARER +
+// OPENOVA_MCP_RS256_PUBKEY_PEM from the per-Org OpenBao path the producer
+// (seedMCPBearer) writes — secret/catalyst/agenity/<slug>/mcp-bearer. This is
+// the exact block the BSS-door GitOps overlay (orgTenantBPAgenity) emits, so
+// both doors deliver the same LOCAL-signer-signed bearer the Sovereign's
+// catalyst-api accepts. Without it the chart's `enabled:false` default leaves
+// the bearer undelivered and the MCP forwards an unaccepted token → 401.
+//
+// No-op when:
+//   - orgSlug is empty (we can't scope the OpenBao path / a forged cross-Org
+//     scope would defeat the seedMCPBearer own-Org guarantee), or
+//   - the caller already pinned a non-empty openovaMCP block (we never
+//     clobber an explicit value — same deference as sovereignFqdn).
+//
+// The merge is additive: we set ONLY the wiring keys the chart needs
+// (bearerSecret / rs256PubkeySecret / mcpBearer.externalSecret), preserving
+// any other openovaMCP sub-keys an explicit caller supplied.
+func stampAgenityMCPBearer(params map[string]interface{}, orgSlug string) {
+	// The OpenBao path the producer scopes per-Org is keyed by the Org SLUG
+	// (leading DNS label), matching mcpBearerSecretPath(). A dotted FQDN ref
+	// (e.g. "nstar2.omani.homes") must collapse to "nstar2".
+	slug := leadingDNSLabel(orgSlug)
+	if slug == "" {
+		return
+	}
+
+	mcp, _ := params["openovaMCP"].(map[string]interface{})
+	if mcp == nil {
+		mcp = map[string]interface{}{}
+	}
+
+	// bearerSecret + rs256PubkeySecret point the StatefulSet at the in-ns
+	// Secret the ExternalSecret materialises (both keys live in one Secret so
+	// the bearer travels with the pubkey that verifies it — #4228).
+	setIfAbsentMap(mcp, "bearerSecret", map[string]interface{}{
+		"name": agenityMCPBearerSecretName,
+		"key":  "bearer",
+	})
+	setIfAbsentMap(mcp, "rs256PubkeySecret", map[string]interface{}{
+		"name": agenityMCPBearerSecretName,
+		"key":  "pubkeyPem",
+	})
+
+	mcpBearer, _ := mcp["mcpBearer"].(map[string]interface{})
+	if mcpBearer == nil {
+		mcpBearer = map[string]interface{}{}
+	}
+	setIfAbsentMap(mcpBearer, "externalSecret", map[string]interface{}{
+		"enabled":              true,
+		"secretStoreRef":       agenityMCPBearerStoreRef,
+		"secretStoreKind":      agenityMCPBearerStoreKind,
+		"remoteKey":            agenityMCPBearerRemoteKeyPrefix + slug + "/mcp-bearer",
+		"remoteBearerProperty": "bearer",
+		"remotePubkeyProperty": "pubkeyPem",
+	})
+	mcp["mcpBearer"] = mcpBearer
+
+	params["openovaMCP"] = mcp
+}
+
+// setIfAbsentMap sets key=val only when the destination has no non-empty
+// value at key — so an explicit caller value is never clobbered. Treats an
+// existing non-empty map as authoritative.
+func setIfAbsentMap(dst map[string]interface{}, key string, val map[string]interface{}) {
+	if existing, ok := dst[key].(map[string]interface{}); ok && len(existing) > 0 {
+		return
+	}
+	dst[key] = val
+}
+
+// leadingDNSLabel returns the first DNS label (everything before the first
+// dot) of an Org ref, lower-cased + trimmed. "nstar2.omani.homes" → "nstar2";
+// "acme" → "acme"; "" → "". Matches the per-Org OpenBao path slug the
+// producer (seedMCPBearer / mcpBearerSecretPath) scopes by.
+func leadingDNSLabel(ref string) string {
+	r := strings.ToLower(strings.TrimSpace(ref))
+	if i := strings.IndexByte(r, '.'); i >= 0 {
+		r = r[:i]
+	}
+	return r
 }
 
 // isAgenityBlueprint reports whether the blueprint id refers to bp-agenity

--- a/products/catalyst/bootstrap/api/internal/handler/application_parameters_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/application_parameters_test.go
@@ -63,7 +63,7 @@ func bpPostgresConfigSchema() map[string]interface{} {
 // ── defaultedParameters unit table ──────────────────────────────────────
 
 func TestDefaultedParameters_PostgresNoValues_SeedsSingletonMode(t *testing.T) {
-	got := defaultedParameters("bp-postgres", "singleton", "", nil)
+	got := defaultedParameters("bp-postgres", "singleton", "", "", nil)
 	if got == nil {
 		t.Fatal("defaultedParameters returned nil — must always be a non-null object")
 	}
@@ -78,7 +78,7 @@ func TestDefaultedParameters_PostgresNoValues_SeedsSingletonMode(t *testing.T) {
 
 func TestDefaultedParameters_PostgresActiveHotStandby(t *testing.T) {
 	for _, topo := range []string{"active-hot-standby", "active-hotstandby", "active-active", "active-passive"} {
-		got := defaultedParameters("postgres", topo, "", nil)
+		got := defaultedParameters("postgres", topo, "", "", nil)
 		tm := got["topology"].(map[string]interface{})["mode"]
 		if tm != "active-hot-standby" {
 			t.Fatalf("topology %q → topology.mode = %v, want active-hot-standby", topo, tm)
@@ -87,7 +87,7 @@ func TestDefaultedParameters_PostgresActiveHotStandby(t *testing.T) {
 }
 
 func TestDefaultedParameters_NonPostgresNoValues_EmptyObjectNotNil(t *testing.T) {
-	got := defaultedParameters("bp-grafana", "singleton", "", nil)
+	got := defaultedParameters("bp-grafana", "singleton", "", "", nil)
 	if got == nil {
 		t.Fatal("non-postgres parameters returned nil — must be at least an empty object")
 	}
@@ -101,7 +101,7 @@ func TestDefaultedParameters_ExplicitValuesPreservedVerbatim(t *testing.T) {
 		"topology":  map[string]interface{}{"mode": "active-hot-standby"},
 		"databases": []interface{}{map[string]interface{}{"name": "wp", "owner": "wp"}},
 	}
-	got := defaultedParameters("bp-postgres", "singleton", "", explicit)
+	got := defaultedParameters("bp-postgres", "singleton", "", "", explicit)
 	if got["topology"].(map[string]interface{})["mode"] != "active-hot-standby" {
 		t.Fatalf("explicit topology.mode must be preserved (not overwritten by chosen topology), got %#v", got)
 	}
@@ -115,7 +115,7 @@ func TestDefaultedParameters_ExplicitValuesPreservedVerbatim(t *testing.T) {
 //    console.openova.io. ───────────────────────────────────────────────────
 
 func TestDefaultedParameters_AgenityNoValues_StampsSovereignFqdn(t *testing.T) {
-	got := defaultedParameters("bp-agenity", "singleton", "omantel.biz", nil)
+	got := defaultedParameters("bp-agenity", "singleton", "omantel.biz", "nstar2", nil)
 	if got["sovereignFqdn"] != "omantel.biz" {
 		t.Fatalf("agenity parameters must stamp sovereignFqdn=omantel.biz, got %#v", got)
 	}
@@ -125,7 +125,7 @@ func TestDefaultedParameters_AgenityWithExplicitValues_StampsSovereignFqdn(t *te
 	explicit := map[string]interface{}{
 		"agent": map[string]interface{}{"model": "claude-opus-4-8"},
 	}
-	got := defaultedParameters("agenity", "singleton", "t99.omani.works", explicit)
+	got := defaultedParameters("agenity", "singleton", "t99.omani.works", "t99org.omani.homes", explicit)
 	if got["sovereignFqdn"] != "t99.omani.works" {
 		t.Fatalf("agenity sovereignFqdn must be stamped even with explicit params, got %#v", got)
 	}
@@ -136,7 +136,7 @@ func TestDefaultedParameters_AgenityWithExplicitValues_StampsSovereignFqdn(t *te
 
 func TestDefaultedParameters_AgenityExplicitSovereignFqdnWins(t *testing.T) {
 	explicit := map[string]interface{}{"sovereignFqdn": "pinned.example"}
-	got := defaultedParameters("bp-agenity", "singleton", "omantel.biz", explicit)
+	got := defaultedParameters("bp-agenity", "singleton", "omantel.biz", "nstar2", explicit)
 	if got["sovereignFqdn"] != "pinned.example" {
 		t.Fatalf("a caller-pinned sovereignFqdn must NOT be overwritten, got %#v", got)
 	}
@@ -145,9 +145,95 @@ func TestDefaultedParameters_AgenityExplicitSovereignFqdnWins(t *testing.T) {
 func TestDefaultedParameters_AgenityEmptyFQDN_NoStamp(t *testing.T) {
 	// Mothership / Catalyst-Zero: empty FQDN → leave sovereignFqdn unset so
 	// the chart's fail-closed default applies (no bogus console host).
-	got := defaultedParameters("bp-agenity", "singleton", "", nil)
+	got := defaultedParameters("bp-agenity", "singleton", "", "", nil)
 	if _, ok := got["sovereignFqdn"]; ok {
 		t.Fatalf("empty FQDN must NOT stamp sovereignFqdn, got %#v", got)
+	}
+}
+
+// ── #4610: bp-agenity stamps the openova-MCP bearer ExternalSecret wiring so
+//    the install-door agenity gets OPENOVA_MCP_BEARER from the per-Org OpenBao
+//    path (LOCAL-signer-signed bearer the Sovereign's catalyst-api accepts),
+//    NOT the chart's `enabled:false` default that delivers nothing → 401. ───
+
+// assertAgenityMCPBearerWiring fails unless params carries the full openovaMCP
+// mcpBearer wiring the chart needs to project OPENOVA_MCP_BEARER +
+// OPENOVA_MCP_RS256_PUBKEY_PEM from secret/catalyst/agenity/<slug>/mcp-bearer.
+func assertAgenityMCPBearerWiring(t *testing.T, params map[string]interface{}, wantSlug string) {
+	t.Helper()
+	mcp, ok := params["openovaMCP"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("agenity parameters missing openovaMCP block: %#v", params)
+	}
+	bs, ok := mcp["bearerSecret"].(map[string]interface{})
+	if !ok || bs["name"] != agenityMCPBearerSecretName || bs["key"] != "bearer" {
+		t.Fatalf("openovaMCP.bearerSecret must point at %q/bearer, got %#v", agenityMCPBearerSecretName, mcp["bearerSecret"])
+	}
+	pk, ok := mcp["rs256PubkeySecret"].(map[string]interface{})
+	if !ok || pk["name"] != agenityMCPBearerSecretName || pk["key"] != "pubkeyPem" {
+		t.Fatalf("openovaMCP.rs256PubkeySecret must point at %q/pubkeyPem (the SEEDED local-signer pubkey, NOT the host catalyst-handover-jwt mothership key), got %#v", agenityMCPBearerSecretName, mcp["rs256PubkeySecret"])
+	}
+	mb, ok := mcp["mcpBearer"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("openovaMCP.mcpBearer missing: %#v", mcp)
+	}
+	es, ok := mb["externalSecret"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("openovaMCP.mcpBearer.externalSecret missing: %#v", mb)
+	}
+	if es["enabled"] != true {
+		t.Fatalf("openovaMCP.mcpBearer.externalSecret.enabled must be true (the chart default is false → bearer undelivered → 401), got %#v", es["enabled"])
+	}
+	wantKey := "catalyst/agenity/" + wantSlug + "/mcp-bearer"
+	if es["remoteKey"] != wantKey {
+		t.Fatalf("openovaMCP.mcpBearer.externalSecret.remoteKey = %v, want %q (must match the producer's mcpBearerSecretPath)", es["remoteKey"], wantKey)
+	}
+	if es["remoteBearerProperty"] != "bearer" || es["remotePubkeyProperty"] != "pubkeyPem" {
+		t.Fatalf("openovaMCP.mcpBearer.externalSecret property names must be bearer/pubkeyPem, got %#v", es)
+	}
+}
+
+func TestDefaultedParameters_AgenityNoValues_StampsMCPBearerWiring(t *testing.T) {
+	// FQDN-form org ref must collapse to the leading DNS label for the path.
+	got := defaultedParameters("bp-agenity", "singleton", "omantel.biz", "nstar2.omani.homes", nil)
+	assertAgenityMCPBearerWiring(t, got, "nstar2")
+}
+
+func TestDefaultedParameters_AgenityEmptyOrgSlug_NoMCPBearerStamp(t *testing.T) {
+	// No Org slug ⇒ we cannot scope the per-Org OpenBao path; skip the stamp
+	// (a path with an empty/cross-Org slug would defeat seedMCPBearer's
+	// own-Org guarantee). sovereignFqdn still stamps independently.
+	got := defaultedParameters("bp-agenity", "singleton", "omantel.biz", "", nil)
+	if _, ok := got["openovaMCP"]; ok {
+		t.Fatalf("empty org slug must NOT stamp openovaMCP wiring, got %#v", got)
+	}
+	if got["sovereignFqdn"] != "omantel.biz" {
+		t.Fatalf("sovereignFqdn must still stamp independently of the mcpBearer slug, got %#v", got)
+	}
+}
+
+func TestDefaultedParameters_NonAgenity_NoMCPBearerStamp(t *testing.T) {
+	got := defaultedParameters("bp-postgres", "singleton", "omantel.biz", "nstar2", nil)
+	if _, ok := got["openovaMCP"]; ok {
+		t.Fatalf("non-agenity Blueprint must NOT get openovaMCP wiring, got %#v", got)
+	}
+}
+
+func TestDefaultedParameters_AgenityExplicitMCPBearerWins(t *testing.T) {
+	explicit := map[string]interface{}{
+		"openovaMCP": map[string]interface{}{
+			"bearerSecret": map[string]interface{}{"name": "pinned-secret", "key": "bearer"},
+		},
+	}
+	got := defaultedParameters("bp-agenity", "singleton", "omantel.biz", "nstar2", explicit)
+	mcp := got["openovaMCP"].(map[string]interface{})
+	bs := mcp["bearerSecret"].(map[string]interface{})
+	if bs["name"] != "pinned-secret" {
+		t.Fatalf("a caller-pinned openovaMCP.bearerSecret must NOT be overwritten, got %#v", bs)
+	}
+	// The additive merge still wires the missing keys (rs256PubkeySecret, mcpBearer).
+	if _, ok := mcp["mcpBearer"]; !ok {
+		t.Fatalf("additive merge must still wire the absent mcpBearer key, got %#v", mcp)
 	}
 }
 
@@ -167,6 +253,8 @@ func TestNewApplicationUnstructured_Agenity_StampsSovereignFqdn(t *testing.T) {
 	if params["sovereignFqdn"] != "omantel.biz" {
 		t.Fatalf("agenity Application CR must carry spec.parameters.sovereignFqdn=omantel.biz (else the openova-MCP URL falls back to the mothership console.openova.io), got %#v", params)
 	}
+	// #4610 — the install-door CR must ALSO wire the per-Org MCP bearer.
+	assertAgenityMCPBearerWiring(t, params, "agnstar")
 }
 
 func TestNewApplicationCRFromSeed_Agenity_StampsSovereignFqdn(t *testing.T) {
@@ -185,6 +273,8 @@ func TestNewApplicationCRFromSeed_Agenity_StampsSovereignFqdn(t *testing.T) {
 	if params["sovereignFqdn"] != "omantel.biz" {
 		t.Fatalf("agenity seed CR must carry spec.parameters.sovereignFqdn=omantel.biz, got %#v", params)
 	}
+	// #4610 — the create-instance seed door must ALSO wire the per-Org MCP bearer.
+	assertAgenityMCPBearerWiring(t, params, "agnstar")
 }
 
 // ── configSchema round-trip: producers emit validating parameters ───────

--- a/products/catalyst/bootstrap/api/internal/handler/applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications.go
@@ -1052,7 +1052,7 @@ func newApplicationUnstructured(req applicationInstallRequest, sovereignFQDN str
 	// tree valid; the controller's admission webhook + this handler's
 	// validate.Parameters call have already gated explicit params against
 	// configSchema.
-	spec["parameters"] = defaultedParameters(req.BlueprintRef.Name, canonMode, sovereignFQDN, req.Parameters)
+	spec["parameters"] = defaultedParameters(req.BlueprintRef.Name, canonMode, sovereignFQDN, req.OrganizationRef, req.Parameters)
 	_ = unstructured.SetNestedMap(obj.Object, spec, "spec")
 	return obj
 }

--- a/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
@@ -2194,7 +2194,7 @@ func newApplicationCRFromSeed(seed instances.ApplicationSeed) *unstructured.Unst
 	// reconciled (phase=Failed). Now seed.Values (when present) is used
 	// verbatim; otherwise we emit at least `{}` plus a configSchema-valid
 	// topology.mode for bp-postgres.
-	spec["parameters"] = defaultedParameters(seed.Blueprint, seed.Topology, seed.SovereignFQDN, seed.Values)
+	spec["parameters"] = defaultedParameters(seed.Blueprint, seed.Topology, seed.SovereignFQDN, seed.Namespace, seed.Values)
 	_ = unstructured.SetNestedMap(obj.Object, spec, "spec")
 	return obj
 }

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5983,7 +5983,7 @@ spec:
   # 0.5.17 (#4604): chart adds a default-on external-HTTPS egress CNP +
   # seeds the openova MCP into ~/.claude.json for a standalone claude (durable
   # Pillar-4 North-Star wiring). Lockstep with products/agenity/chart.
-  version: "0.5.17"
+  version: "0.5.18"
   visibility: listed
   card:
     title: "Agenity"
@@ -6013,7 +6013,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-agenity
-    version: 0.5.17
+    version: 0.5.18
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## The North Star write gate (create_application) 401

`create_application` via the per-Org `openova` MCP returned `-32010 upstream error`; catalyst-api logged `POST /api/v1/org/applications status=401`.

## Root cause — verified live (omantel.biz / dep 91dc0591, Org nstar2)

The 401 is **NOT** a write-path authz divergence. Curling the live `.claude.json` bearer against the Sovereign's catalyst-api returns `401 {"error":"unauthenticated"}` on **every** endpoint — `GET /api/v1/whoami`, `GET /api/v1/organizations`, AND `POST /api/v1/org/applications`. The "whoami=200" evidence was a red herring: the MCP `handleWhoami` is LOCAL and never calls catalyst-api.

Signature-key mismatch:
- omantel.biz Sovereign local handover signer pubkey `065ecb51…` — catalyst-api `RequireSession.ValidateToken` validates session bearers against THIS `LocalPublicKey`.
- The bearer in agenity's `~/.claude.json` (`OPENOVA_MCP_BEARER`) is signed by the **MOTHERSHIP** key `3e232eb3…` (`iss=console.openova.io`). `rsa.VerifyPKCS1v15` fails → 401 everywhere.

Two delivery gaps put the wrong (mothership-signed) bearer there:
1. **Wiring gap (this PR)**: the agenity Application CR (created via the install door) had `spec.parameters.openovaMCP = {}`. The chart fell back to its `values.yaml` defaults — `mcpBearer.externalSecret.enabled=false`, `remoteKey=""`, `rs256PubkeySecret.name=catalyst-handover-jwt` (the host MOTHERSHIP key, absent in the Org ns). So the per-Org `OPENOVA_MCP_BEARER` ExternalSecret was never wired. `defaultedParameters` already stamps `sovereignFqdn` for agenity (#4556) but NOT the `openovaMCP` block. The BSS/GitOps door (`orgTenantBPAgenity`) DOES wire it; the install door did not.
2. **Seed delivery** (live backfill, tracked on #4610): `secret/catalyst/agenity/<slug>/mcp-bearer` must be populated by the producer `seedMCPBearer` (which already mints with the LOCAL signer — the key catalyst-api accepts).

So catalyst-api **already accepts** the correctly-signed org-scoped bearer (the producer mints it with `h.handoverSigner`); the bug is purely that the correctly-signed bearer was never DELIVERED to the MCP. This PR closes the install-door wiring gap.

## Fix

`defaultedParameters` now stamps the `openovaMCP` mcpBearer ExternalSecret wiring (+ the seeded `rs256PubkeySecret`) for agenity Application CRs — mirroring the `orgTenantBPAgenity` overlay and the existing `sovereignFqdn` precedent. Both create doors (`newApplicationUnstructured` install path + `newApplicationCRFromSeed` create-instance path) now point the chart at the in-namespace `agenity-mcp-bearer` Secret, fed from `secret/catalyst/agenity/<slug>/mcp-bearer`.

- Additive merge — never clobbers a caller-pinned `openovaMCP` value.
- Empty Org slug → skip the stamp (cannot scope the per-Org path without defeating seedMCPBearer's own-Org guarantee).
- FQDN org ref collapses to the leading DNS label for the path (matches `mcpBearerSecretPath`).
- `spec.parameters.openovaMCP` flows into the `bp-agenity` HelmRelease values via the application-controller's `mergeMaps(bpManifestsValues, spec.Parameters)`, so the chart's `externalsecret-mcp-bearer.yaml` renders.

## Tests
New unit coverage asserts both install doors emit the full mcpBearer wiring (FQDN→slug collapse, empty-slug skip, non-agenity skip, explicit-wins); the existing `sovereignFqdn` + postgres configSchema tests still pass. `go build ./... && go test ./internal/handler/` green.

## Verification
Live create_application walk on nstar2 after the catalyst-api image rolls + the agenity Application reconciles the new params (merged ≠ delivered until then).

Refs #4610 #4276 #4277 #3988 #4111 #4556

🤖 Generated with [Claude Code](https://claude.com/claude-code)