### PR TITLE
fix(provisioner): VPC-quota reclaim protects ALL live deployments (#4614 — the production-delete root cause)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/openbao"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/pdm"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/powerdns"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
 )
 
@@ -624,6 +625,15 @@ func New(log *slog.Logger) *Handler {
 		pdm:              pdm.New(pdmURL),
 		kubeconfigsDir:   kubeconfigsDir,
 	}
+
+	// #4614: arm the in-band VPC-quota reclaim (provisioner pre-flight) with
+	// the SAME live-deployment allowlist the background janitor uses. Without
+	// this the reclaim's protect-set holds only the firing prov's own prefix
+	// and treats every OTHER live Sovereign's VPC as a reclaimable orphan —
+	// the path that cascade-deleted production omantel.biz on 2026-06-28.
+	// buildActivePrefixes reads h.deployments at call (reclaim) time, so
+	// binding the method here — before restore — is safe.
+	provisioner.ActiveDepPrefixesHook = h.buildActivePrefixes
 
 	st, err := store.New(dir)
 	if err != nil {

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -92,6 +92,37 @@ type vpcReclaimFunc func(ctx context.Context, accessKey, secretKey, projectID, r
 // huawei adapter's init() sets it (→ SweepOrphanVPCs).
 var VPCReclaimHook vpcReclaimFunc
 
+// ActiveDepPrefixesHook returns the do-not-touch allowlist of 8-char
+// deployment-ID prefixes for EVERY live (non-`wiped`) deployment. nil by
+// default — the handler registers it (→ Handler.buildActivePrefixes, the
+// #4454 fail-safe). The in-band VPC-quota reclaim (#4614) consults it so
+// the reclaim can never reap a live Sovereign's VPC that merely shares
+// the project — the production-delete fault of 2026-06-28, where the
+// reclaim's protect-set held only THIS prov's own prefix and so treated
+// the live omantel.biz VPC as a reclaimable orphan.
+var ActiveDepPrefixesHook func() map[string]struct{}
+
+// reclaimProtectSet builds the do-not-touch allowlist for the in-band
+// VPC-quota reclaim (#4614): EVERY live (non-`wiped`) deployment's 8-char
+// prefix from ActiveDepPrefixesHook (the handler's #4454 fail-safe), plus
+// this prov's own (not-yet-created) deployment prefix. SweepOrphanVPCs
+// reaps any catalyst-* VPC NOT in this set, so a missing live prefix here
+// means a live Sovereign's VPC gets deleted — the production-delete fault.
+// nil hook (no handler wired, e.g. CI) degrades to protecting only the
+// firing prov, the pre-#4614 behaviour.
+func reclaimProtectSet(deploymentID string) map[string]struct{} {
+	protect := map[string]struct{}{}
+	if ActiveDepPrefixesHook != nil {
+		for p := range ActiveDepPrefixesHook() {
+			protect[p] = struct{}{}
+		}
+	}
+	if len(deploymentID) >= 8 {
+		protect[deploymentID[:8]] = struct{}{}
+	}
+	return protect
+}
+
 // ParentDomain is one entry in Request.ParentDomains — a registered
 // parent zone the Sovereign-side PowerDNS becomes authoritative for
 // after NS-flip lands at the registrar.
@@ -1917,14 +1948,13 @@ func (p *Provisioner) Provision(ctx context.Context, req Request, events chan<- 
 		} else {
 			emit("tofu-init", "info", fmt.Sprintf("HCS VPC quota: used %d / %d, requesting %d", used, limit, needed))
 			if used+needed > limit && VPCReclaimHook != nil {
-				// Protect this prov's own (not-yet-created) VPCs + any
-				// in-flight sibling prov by passing this DeploymentID's
-				// 8-char prefix — the reclaim only touches terminal-state
-				// catalyst-* orphans.
-				protect := map[string]struct{}{}
-				if len(req.DeploymentID) >= 8 {
-					protect[req.DeploymentID[:8]] = struct{}{}
-				}
+				// #4614: protect EVERY live deployment, not just THIS
+				// prov's own prefix. SweepOrphanVPCs reaps any catalyst-*
+				// VPC whose 8-char prefix is NOT in `protect`; seeding it
+				// with only this prov's prefix made the reclaim treat a
+				// live production Sovereign sharing the project as an
+				// orphan and DELETE its VPC (the 2026-06-28 incident).
+				protect := reclaimProtectSet(req.DeploymentID)
 				emit("tofu-init", "info", fmt.Sprintf("HCS VPC quota over budget (%d/%d, need %d) — reclaiming orphaned catalyst VPCs before failing", used, limit, needed))
 				reclaimed, rerr := VPCReclaimHook(ctx, req.HuaweiAccessKey, req.HuaweiSecretKey, req.HuaweiProjectID, region, protect, func(msg string) {
 					emit("tofu-init", "info", "vpc-reclaim: "+msg)

--- a/products/catalyst/bootstrap/api/internal/provisioner/reclaim_protect_4614_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/reclaim_protect_4614_test.go
@@ -1,0 +1,67 @@
+package provisioner
+
+import "testing"
+
+// TestReclaimProtectSet_ProtectsAllLiveDeployments is the #4614 regression:
+// the in-band VPC-quota reclaim must protect EVERY live deployment, not just
+// the firing prov. On 2026-06-28 the reclaim's protect-set held only the
+// firing prov's own prefix, so SweepOrphanVPCs treated the live production
+// omantel.biz VPC (a different prefix sharing the kom4dc project) as a
+// reclaimable orphan and cascade-deleted all 12 production nodes.
+func TestReclaimProtectSet_ProtectsAllLiveDeployments(t *testing.T) {
+	orig := ActiveDepPrefixesHook
+	t.Cleanup(func() { ActiveDepPrefixesHook = orig })
+
+	// Simulate the handler's #4454 allowlist: two OTHER live deployments
+	// (the production Sovereign + a sibling) share the project.
+	ActiveDepPrefixesHook = func() map[string]struct{} {
+		return map[string]struct{}{"91dc0591": {}, "5150f960": {}}
+	}
+
+	got := reclaimProtectSet("aaaaaaaa1111222233334444")
+
+	// The firing prov AND both live deployments must all be protected.
+	for _, want := range []string{"aaaaaaaa", "91dc0591", "5150f960"} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("reclaimProtectSet missing %q — its VPC would be reaped by the in-band reclaim (the #4614 production-delete fault)", want)
+		}
+	}
+	if len(got) != 3 {
+		t.Errorf("reclaimProtectSet = %d prefixes, want 3 (firing prov + 2 live)", len(got))
+	}
+}
+
+// TestReclaimProtectSet_NilHookProtectsFiringProv guards the CI / no-handler
+// path: with no ActiveDepPrefixesHook wired, the reclaim still protects the
+// firing prov's own (not-yet-created) VPCs — the pre-#4614 baseline, never
+// weaker.
+func TestReclaimProtectSet_NilHookProtectsFiringProv(t *testing.T) {
+	orig := ActiveDepPrefixesHook
+	t.Cleanup(func() { ActiveDepPrefixesHook = orig })
+	ActiveDepPrefixesHook = nil
+
+	got := reclaimProtectSet("bbbbbbbb5555666677778888")
+	if _, ok := got["bbbbbbbb"]; !ok {
+		t.Error("reclaimProtectSet must still protect the firing prov when the hook is nil")
+	}
+	if len(got) != 1 {
+		t.Errorf("reclaimProtectSet (nil hook) = %d prefixes, want 1", len(got))
+	}
+}
+
+// TestReclaimProtectSet_ShortDeploymentID tolerates a malformed/short
+// deployment ID without panicking (the < 8-char guard) and still folds in
+// the live-deployment allowlist.
+func TestReclaimProtectSet_ShortDeploymentID(t *testing.T) {
+	orig := ActiveDepPrefixesHook
+	t.Cleanup(func() { ActiveDepPrefixesHook = orig })
+	ActiveDepPrefixesHook = func() map[string]struct{} { return map[string]struct{}{"91dc0591": {}} }
+
+	got := reclaimProtectSet("short")
+	if _, ok := got["91dc0591"]; !ok {
+		t.Error("reclaimProtectSet must protect the live deployment even when the firing prov ID is too short to add")
+	}
+	if len(got) != 1 {
+		t.Errorf("reclaimProtectSet (short ID) = %d prefixes, want 1 (only the live deployment)", len(got))
+	}
+}


### PR DESCRIPTION
## Root cause of the 2026-06-28 production-delete

The in-band tofu-init VPC-quota reclaim (`provisioner.go`) built its `SweepOrphanVPCs` protect-set from **only the firing prov's own 8-char prefix**. `SweepOrphanVPCs` reaps any `catalyst-*` VPC whose prefix is NOT in that set — so when a fresh prov hit quota on a project shared with a live Sovereign, the live Sovereign's VPC looked like an orphan and was cascade-deleted. That is exactly how production `omantel.biz` (`91dc05917e44d1c1`) lost all 12 nodes.

## Fix
- New `provisioner.ActiveDepPrefixesHook`, wired by the handler to `buildActivePrefixes()` — the **same #4454 fail-safe allowlist** the background janitor already enforces (every non-`wiped` deployment protects its prefix).
- New `reclaimProtectSet(deploymentID)` helper folds that allowlist + the firing prov's own prefix.
- Regression tests: all-live-protected / nil-hook-degrades-safe / short-id.

The janitor (#4454) and the in-band reclaim now share identical protection; the reclaim path was the one gap.

## Verification
- `go build` + `go vet` clean (provisioner + handler).
- 3 new unit tests pass.
- Live fresh-prov verification is gated on re-establishing an env (the one this deleted) — to walk once an env exists.

Refs #4614