### PR TITLE
fix(bp-loki): disable loki-sc-rules sidecar — kill CrashLoop from /proc/1/cmdline probe (1.0.3)

### DIFF
--- a/clusters/_template/bootstrap-kit/22-loki.yaml
+++ b/clusters/_template/bootstrap-kit/22-loki.yaml
@@ -114,7 +114,10 @@ spec:
       # 1.0.2 — #4347: loki livenessProbe + sidecar exec probes + harbor-proxy
       #   images so it clears the host-ns Kyverno probes-present + harbor-proxy-pull
       #   Enforce policies (post-#4325). Refs #4347 #4325.
-      version: 1.0.2
+      # 1.0.3 — #4623a: DISABLE the loki-sc-rules sidecar (no loki_rule objects
+      #   ship + its /proc/1/cmdline EXEC probe CrashLoops on upstream image
+      #   entrypoint drift). Drops the container entirely. Refs #4623.
+      version: 1.0.3
       sourceRef:
         kind: HelmRepository
         name: bp-loki

--- a/platform/loki/blueprint.yaml
+++ b/platform/loki/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.0.2  # lockstep with chart/Chart.yaml (#4347 probes-present + harbor-proxy images for host-ns Kyverno Enforce)
+  version: 1.0.3  # lockstep with chart/Chart.yaml (#4623a disable loki-sc-rules sidecar — no rules ship + CrashLoop hazard from /proc/1/cmdline probe)
   card:
     title: Loki
     family: insights

--- a/platform/loki/chart/Chart.yaml
+++ b/platform/loki/chart/Chart.yaml
@@ -25,7 +25,17 @@ type: application
 #   (probes-present Enforce); (b) proxy both images (grafana/loki +
 #   kiwigrid/k8s-sidecar) through harbor.openova.io (harbor-proxy-pull Enforce).
 #   Adds tests/kyverno-probes-present.sh. Refs #4347 #4325.
-version: 1.0.2
+# 1.0.3 (#4623a): DISABLE the loki-sc-rules sidecar (loki.sidecar.rules.enabled
+#   = false). This Sovereign ships ZERO loki_rule ConfigMaps/Secrets, so the
+#   sidecar watched an empty set forever AND was a recurring CrashLoop hazard —
+#   its EXEC liveness/readiness probe grepped /proc/1/cmdline for python/sidecar,
+#   coupling the probe to the upstream image's PID-1 entrypoint which the mutable
+#   kiwigrid/k8s-sidecar:2.5.0 tag can change on any rebuild. Disabling drops the
+#   container entirely (nothing for probes-present/resource-requests Enforce to
+#   reject, no functional loss). Probes retained but switched to the image's
+#   built-in /healthz HTTP endpoint for overlays that re-enable the sidecar.
+#   Refs #4623.
+version: 1.0.3
 appVersion: "3.6.7"
 keywords: [catalyst, blueprint, loki, observability, logs]
 maintainers:

--- a/platform/loki/chart/values.yaml
+++ b/platform/loki/chart/values.yaml
@@ -97,10 +97,35 @@ loki:
   # de-vcluster migration it installs into the native host namespace and the
   # StatefulSet admission is DENIED. Modest request for the light k8s watcher.
   sidecar:
+    # #4623a — DISABLE the loki-sc-rules sidecar on a solo Sovereign. The
+    # sidecar (kiwigrid/k8s-sidecar) exists only to ingest Loki ruler
+    # ConfigMaps/Secrets labelled `loki_rule` into the StatefulSet. This
+    # Sovereign ships ZERO such rule objects (no alerting/recording rules in
+    # the catalog), so the sidecar watches an empty set forever — pure dead
+    # weight in the SingleBinary pod.
+    #
+    # It is ALSO a recurring CrashLoop hazard: its only health signal is an
+    # EXEC probe that greps `/proc/1/cmdline` for `python`/`sidecar` (#4347).
+    # That couples the probe to the upstream image's PID-1 entrypoint string,
+    # which the mutable `kiwigrid/k8s-sidecar:2.5.0` tag is free to change on
+    # any rebuild — when it does, the probe fails, the container CrashLoops,
+    # and (because it shares the SingleBinary pod) it can disrupt the Loki
+    # StatefulSet's readiness even though Loki itself is healthy.
+    #
+    # Disabling the sidecar removes the container entirely: no probe to fail,
+    # nothing for the host-ns Kyverno `probes-present` / `resource-requests`
+    # Enforce policies to reject, and no functional loss (no rules to load).
+    # Per-Sovereign overlays that DO ship Loki rules re-enable this with
+    # `loki.sidecar.rules.enabled: true` AND should switch the probes below to
+    # the image's built-in `/healthz` HTTP endpoint (HEALTH_PORT, default 8080)
+    # rather than the brittle /proc/1/cmdline grep.
+    rules:
+      enabled: false
     # #4347 — proxy the kiwigrid/k8s-sidecar image through the Sovereign-local
     # Harbor so the host-ns `harbor-proxy-pull` Enforce policy admits it
     # (`docker.io/kiwigrid/k8s-sidecar` matches no allowed glob). Mirror the
-    # grafana sidecar's proxy-dockerhub convention.
+    # grafana sidecar's proxy-dockerhub convention. (Retained so overlays that
+    # re-enable the sidecar still pull through Harbor.)
     image:
       registry: harbor.openova.io
       repository: proxy-dockerhub/kiwigrid/k8s-sidecar
@@ -111,28 +136,38 @@ loki:
       limits:
         cpu: 50m
         memory: 64Mi
-    # #4347 — the loki-sc-rules sidecar (kiwigrid/k8s-sidecar) had NO probes →
-    # the host-ns Kyverno `probes-present` Enforce policy denies the StatefulSet.
-    # The sidecar serves no HTTP health port, so both probes are EXEC checks
-    # confirming PID 1 is still the python sidecar process (a crashed/replaced
-    # PID 1 fails the grep). /proc/1/cmdline is null-separated; grep -q matches
-    # the `python` / `sidecar` substring on the python-slim base image.
+    # #4623a — Probes for when an overlay re-enables `sidecar.rules.enabled`.
+    # These satisfy the host-ns Kyverno `probes-present` Enforce policy
+    # (#4347) WITHOUT the brittle /proc/1/cmdline grep the chart used before.
+    # kiwigrid/k8s-sidecar 2.5.0 ships a built-in health HTTP server at
+    # `/healthz` on HEALTH_PORT (default 8080): 200 once the initial config
+    # sync is done + the k8s watch is alive, 503 before first sync / on lost
+    # k8s contact / dead watcher. This contract is stable across image
+    # rebuilds, unlike the PID-1 entrypoint string.
+    #
+    # `/healthz` returns 503 until first sync, so a startupProbe gates initial
+    # readiness (generous failureThreshold tolerates slow first list/watch),
+    # liveness uses a high failureThreshold so a transient k8s-contact blip
+    # doesn't needlessly restart the watcher.
+    startupProbe:
+      httpGet:
+        path: /healthz
+        port: 8080
+      periodSeconds: 5
+      timeoutSeconds: 5
+      failureThreshold: 30
     livenessProbe:
-      exec:
-        command:
-          - /bin/sh
-          - -c
-          - 'grep -aq -e python -e sidecar /proc/1/cmdline'
+      httpGet:
+        path: /healthz
+        port: 8080
       initialDelaySeconds: 15
       periodSeconds: 30
       timeoutSeconds: 5
-      failureThreshold: 3
+      failureThreshold: 6
     readinessProbe:
-      exec:
-        command:
-          - /bin/sh
-          - -c
-          - 'grep -aq -e python -e sidecar /proc/1/cmdline'
+      httpGet:
+        path: /healthz
+        port: 8080
       initialDelaySeconds: 5
       periodSeconds: 15
       timeoutSeconds: 5

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -859,7 +859,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-loki
-    version: 1.0.0
+    version: 1.0.3
   # G117.1+G117.4+G117.5 #2744-followup (2026-06-03): lockstep with
   # platform/loki/blueprint.yaml. active-passive via S3 bucket replication.
   # No user-facing endpoint (Loki is queried via Grafana datasource); sso


### PR DESCRIPTION
## BUG 1 (#4623a) — loki-sc-rules sidecar CrashLoop

### Root cause (confirmed)
The bp-loki SingleBinary pod co-runs a `loki-sc-rules` sidecar (`kiwigrid/k8s-sidecar`) whose only purpose is to ingest Loki **ruler** ConfigMaps/Secrets labelled `loki_rule`. This Sovereign ships **zero** such rule objects (no alerting/recording rules anywhere in the catalog — verified by `grep loki_rule` across the repo), so the sidecar watches an empty set forever.

It is also a recurring **CrashLoop hazard**: its only health signal was an EXEC liveness/readiness probe that greps `/proc/1/cmdline` for `python`/`sidecar` (added in #4347 to satisfy the host-ns Kyverno `probes-present` Enforce policy). That couples the probe to the upstream image's PID-1 entrypoint **string**, which the mutable `kiwigrid/k8s-sidecar:2.5.0` tag is free to change on any rebuild.

> Empirical note: I pulled the current `kiwigrid/k8s-sidecar:2.5.0` (rebuilt 2026-01-21, `Cmd: ["python","-u","/app/sidecar.py"]`, `Entrypoint: None`) and the existing probe `grep -aq -e python -e sidecar /proc/1/cmdline` **passes today** (PID-1 cmdline = `python -u /app/sidecar.py`). So the chart's probe is correct for the image as currently published — but the coupling is brittle and the team already burned itself on it. The fix removes the coupling entirely rather than re-tuning it.

### Fix
- `loki.sidecar.rules.enabled: false` → the sidecar container is **not rendered at all**. No probe to fail, nothing for the host-ns Kyverno `probes-present` / `resource-requests` Enforce policies to reject (verified: container count drops 2→1, both chart tests still PASS), and no functional loss (no rules to load).
- The retained sidecar probe block is switched from the `/proc/1/cmdline` grep to the image's **built-in `/healthz` HTTP endpoint** (`HEALTH_PORT` 8080), with a `startupProbe` to tolerate the pre-first-sync 503, so any per-Sovereign overlay that re-enables `sidecar.rules.enabled` when it actually ships Loki rules gets a durable, rebuild-proof probe.

### Lockstep version bumps
- `platform/loki/chart/Chart.yaml` 1.0.2 → **1.0.3**
- `platform/loki/blueprint.yaml`
- `clusters/_template/bootstrap-kit/22-loki.yaml`
- `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` (curation card)

### Validation
- `helm lint platform/loki/chart` → 0 failed
- `tests/kyverno-probes-present.sh` → PASS (1 container, both probes)
- `tests/kyverno-resource-requests.sh` → PASS
- `helm template products/catalyst/chart` → renders clean, bp-loki blueprint present

Refs #4623

🤖 Generated with [Claude Code](https://claude.com/claude-code)