### PR TITLE
fix(bp-openbao): snapshot BAO_ADDR -> real openbao Service (#4623)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -148,7 +148,7 @@ spec:
       #   client scope; otherwise a silent claim-drop re-opens the admin UI 403.
       #   Live-verified on 91dc0591: fresh sovereign-admins login lands
       #   /ui/vault/secrets with [default,sso-operator-admin,sso-operator-read].
-      version: 1.2.58
+      version: 1.2.59
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.58  # lockstep with chart/Chart.yaml (#4519 OIDC role oidc_scopes=groups — harden external-group resolution)
+  version: 1.2.59  # lockstep with chart/Chart.yaml (#4519 OIDC role oidc_scopes=groups — harden external-group resolution)
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -195,6 +195,7 @@ name: bp-openbao
 #   new `exact_id` helper extracts the group id (last exact "id") + alias id
 #   (first exact "id", only when a canonical_id is present). Live-verified on
 #   91dc0591/omantel.biz: both groups now bind sso-operator-admin on tick-1.
+# 1.2.59 — #4623: snapshot-replication BAO_ADDR -> the real openbao Service (was openbao-openbao -> NXDOMAIN -> backup CronJob never ran).
 # 1.2.58 — #4519 (Refs #3374 #4477): HARDEN the OIDC role's group resolution by
 #   EXPLICITLY requesting the `groups` scope (oidc_scopes=["groups"]). The whole
 #   sovereign-admins → sso-operator-admin uplift hinges on the `groups` claim
@@ -218,7 +219,7 @@ name: bp-openbao
 #   entity joined the sovereign-admins external group (direct_group_ids). Only
 #   the sso-configure reconcile.sh ROLE_PAYLOAD changes (+ the chart bump that
 #   rolls the Deployment per the #3374 checksum); no other template moves.
-version: 1.2.58
+version: 1.2.59
 # 1.2.51 (#3888, Refs #3847): prov-time openbao KV-seed mechanism — the
 # auth-bootstrap Job reads a one-shot cloud-init `openbao-bootstrap-seed`
 # Secret + writes its keys into KV at secret/<prefix>/* with the still-valid

--- a/platform/openbao/chart/templates/snapshot-replication.yaml
+++ b/platform/openbao/chart/templates/snapshot-replication.yaml
@@ -59,7 +59,13 @@ objects). The primary vs secondary CronJob is selected by
 {{- if $registry }}{{- $repo = printf "%s/%s" $registry $repo -}}{{- end -}}
 {{- $tag := $img.tag | default "2.17.0" -}}
 {{- $pullPolicy := $img.pullPolicy | default "IfNotPresent" -}}
-{{- $baoAddr := $sr.baoAddress | default (printf "http://%s-openbao.%s.svc.cluster.local:8200" .Release.Name .Release.Namespace) -}}
+{{- /* #4623 — the live OpenBao Service is `openbao` (fullnameOverride), NOT
+       `<release>-openbao`. The old `%s-openbao` default resolved to
+       `openbao-openbao.<ns>.svc` → NXDOMAIN → snapshot `bao login` "Could not
+       resolve host" → no client_token → the backup CronJob never runs (the exact
+       bug sso-configure-deployment.yaml already documents at its $baoAddrSSO).
+       Match the real Service so the default works without a baoAddress override. */}}
+{{- $baoAddr := $sr.baoAddress | default (printf "http://openbao.%s.svc.cluster.local:8200" .Release.Namespace) -}}
 {{- $schedule := $sr.schedule | default "*/10 * * * *" -}}
 {{- $deadline := $sr.activeDeadlineSeconds | default 600 -}}
 {{- $backoff := $sr.backoffLimit | default 3 -}}


### PR DESCRIPTION
Zero-touch convergence audit of 8fd457a8 found the openbao-snapshot CronJob erroring: BAO_ADDR=`openbao-openbao.<ns>.svc` (doubled name) -> NXDOMAIN -> backup never runs. Fixed to the real `openbao` Service (the bug sso-configure-deployment.yaml already documents). Chart 1.2.58->1.2.59 + blueprint + slot 08 lockstep. Refs #4623