### PR TITLE
fix(bp-self-sovereign-cutover): auto-trigger retries on HTTP 425 so cutover auto-fires post-handover (0.1.91)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -648,19 +648,34 @@ spec:
       # insecureSkipVerify — certSecretRef is the only trust mechanism (mirrors
       # skopeo #4529 / helm #4557 / containerd step-04 / OBS #4573 F2). Fail-OPEN
       # when the CA is unreadable. Lockstep w/ Chart.yaml + blueprint.yaml.
-      version: 0.1.90
+      # 0.1.91 (#4632 Refs #3379): the auto-trigger 425-NO-RETRY race — the
+      # post-install hook Job POSTed /internal/cutover/trigger ONCE, got HTTP 425
+      # (handover not yet sealed at slot-06a install time), did `exit 0` and was
+      # then deleted (hook-succeeded) → nothing ever re-POSTed → the cutover
+      # NEVER auto-fired post-handover (live dep 8fd457a8: seal 13:56:41 vs lone
+      # POST 13:54:48). FIX (template 10): retry the POST every 15s on 425 (and
+      # transient 000/502) until a non-425 result or autoHandoverWaitSeconds
+      # (1500s). New trigger.autoHandoverWaitSeconds; autoTimeoutSeconds 1740→2100;
+      # HR install/upgrade timeout 30m→40m (above) so the hook unblocks in time.
+      version: 0.1.91
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover
         namespace: flux-system
   install:
+    # #4632 (chart 0.1.91): raised 30m → 40m so the auto-trigger Job's
+    # activeDeadlineSeconds (2100s / 35m — /healthz wait + the new 425
+    # handover-retry window) stays comfortably below the HR
+    # install/upgrade timeout and the post-install hook unblocks before
+    # Helm gives up. disableWait keeps the chart itself dormant; this
+    # timeout governs the hook Job's completion window.
     disableWait: true
-    timeout: 30m
+    timeout: 40m
     remediation:
       retries: -1
   upgrade:
     disableWait: true
-    timeout: 30m
+    timeout: 40m
     remediation:
       retries: 3
   # Per-Sovereign overrides — the chart's values.yaml carries

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.90
+  version: 0.1.91
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,33 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.91 (#4632 Refs #3379, the auto-trigger 425-NO-RETRY race that means the
+# cutover NEVER auto-fires post-handover — verified live on dep 8fd457a8,
+# 2026-06-29): the post-install/post-upgrade auto-trigger hook Job
+# (10-auto-trigger-job.yaml, hook-delete-policy hook-succeeded) waits for
+# catalyst-api /healthz=200 then POSTs ONCE to /api/v1/internal/cutover/trigger.
+# On a FRESH prov it fires at slot-06a install time — BEFORE bp-catalyst-platform
+# reaches Ready and the handover post-install hook seals
+# secret/catalyst/tofu-phase0-archive — so the POST returns HTTP 425 ("handover
+# not complete"). The old 425 handler did a single `exit 0` and GAVE UP; because
+# the hook is then deleted, NOTHING ever re-POSTed the trigger → the cutover
+# never auto-fired (the case's own comment falsely claimed "the cutover
+# auto-fires when the same trigger is re-POSTed" — nothing re-POSTed it). Live
+# proof on 8fd457a8: handover seal written 13:56:41 but the lone POST 425'd at
+# 13:54:48 (~2 min too early) → cutover stuck progressPercent=0,
+# cutoverStartedAt="". FIX (chart-only, template 10): wrap the single POST +
+# `case "${code}"` block in a `while : ; do … done` loop — 200 breaks (success),
+# 409 breaks (already-running), 424 exits 1 (no-steps), 401|403 exits 0 (RBAC),
+# 425 retries every 15s until handover seals or autoHandoverWaitSeconds elapses
+# (then graceful exit 0; operator CTA still works), and transient 000/502 retry
+# in the same budget. New values trigger.autoHandoverWaitSeconds (default 1500)
+# + trigger.autoTimeoutSeconds default raised 1740 → 2100 (35m) so the Job
+# activeDeadlineSeconds covers the /healthz wait + the 425-retry window; the 06a
+# slot HR install/upgrade timeout raised 30m → 40m in lockstep so the hook
+# unblocks before Helm gives up. NO step-count / job-mode / RBAC change (the
+# auto-trigger Job is not a cutover step). The registry-half-pivot guard (hw93
+# 2026-06-04) is preserved — the engine still only starts once the archive is
+# sealed; the Job just keeps asking until it is. Lockstep w/ blueprint.yaml +
+# 06a slot pin + catalog seed.
 # 0.1.88 (#3379, the LAST leg of the cutover cert-tail — source-controller
 # OCI-pull TLS-trust, live wedge on dep 00720a7a, 2026-06-28): step-06 now
 # gives the Flux SOURCE-CONTROLLER a trust path to the in-cluster Harbor.
@@ -1268,7 +1296,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.90
+version: 0.1.91
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/10-auto-trigger-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/10-auto-trigger-job.yaml
@@ -109,7 +109,7 @@ metadata:
 spec:
   backoffLimit: 3
   ttlSecondsAfterFinished: {{ .Values.trigger.autoJobTTLSeconds | default 86400 }}
-  activeDeadlineSeconds: {{ .Values.trigger.autoTimeoutSeconds | default 600 }}
+  activeDeadlineSeconds: {{ .Values.trigger.autoTimeoutSeconds | default 2100 }}
   template:
     metadata:
       labels:
@@ -130,6 +130,8 @@ spec:
               value: {{ .Values.trigger.autoDelaySeconds | default 0 | quote }}
             - name: WAIT_TIMEOUT_SECONDS
               value: {{ .Values.trigger.autoWaitForAPISeconds | default 300 | quote }}
+            - name: HANDOVER_WAIT_SECONDS
+              value: {{ .Values.trigger.autoHandoverWaitSeconds | default 1500 | quote }}
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -208,71 +210,104 @@ spec:
               fi
 
               # 4. POST /api/v1/internal/cutover/trigger with the SA
-              #    token. catalyst-api validates the token via
-              #    TokenReview and runs the same engine path as
-              #    /sovereign/cutover/start.
+              #    token, RETRYING on the handover-completion gate. catalyst-
+              #    api validates the token via TokenReview and runs the same
+              #    engine path as /sovereign/cutover/start.
               #
               #    Idempotency contract:
               #    - cutoverComplete=true → 200 with the existing snapshot
               #    - cutover already running on this Pod → 409 (benign)
               #    - no steps found → 424 (chart not installed; impossible here)
               #    - success → 200 with the freshly-seeded snapshot
+              #    - handover not yet sealed → 425 (FailedDependency)
               #    - SA token rejected by apiserver → 502 (transient)
               #    - SA mismatch → 403 (chart RBAC misconfig)
-              echo "[auto-trigger] POSTing ${trigger_url}"
-              # Read the token at request time (not as an env var) so
-              # rotation during a long deadline still authenticates.
-              code=$(curl -s -o /tmp/trigger.json -w "%{http_code}" \
-                -X POST --connect-timeout 10 --max-time 60 \
-                -H "Authorization: Bearer $(cat ${sa_token_file})" \
-                -H "Content-Type: application/json" \
-                -d '{}' \
-                "${trigger_url}" 2>/dev/null || echo "000")
+              #
+              # THE 425-NO-RETRY RACE (#4632, verified live on dep 8fd457a8).
+              # This hook is a `post-install,post-upgrade` Job with
+              # hook-delete-policy `hook-succeeded`. On a FRESH prov it fires
+              # at slot-06a install time — BEFORE bp-catalyst-platform reaches
+              # Ready and the handover post-install hook seals
+              # secret/catalyst/tofu-phase0-archive — so catalyst-api correctly
+              # refuses with HTTP 425 ("handover not complete"). The previous
+              # 425 handler did a single `exit 0` and GAVE UP; the hook was then
+              # deleted, so NOTHING ever re-POSTed the trigger and the cutover
+              # NEVER auto-fired. Live proof: 8fd457a8's handover seal was
+              # written at 13:56:41 but the lone POST 425'd at 13:54:48 (~2 min
+              # too early) → cutover stuck progressPercent=0, cutoverStartedAt="".
+              # FIX: poll on 425 (and transient 000/502) until a non-425 result
+              # or a bounded handover-wait deadline. The retry runs INSIDE the
+              # Job's own lifetime, so the trigger is re-POSTed the moment the
+              # gate opens — no operator CTA click required (founder rule #933).
+              hdeadline=$(( $(date +%s) + HANDOVER_WAIT_SECONDS ))
+              echo "[auto-trigger] POSTing ${trigger_url} (will retry on HTTP 425 until handover seals, up to ${HANDOVER_WAIT_SECONDS}s)"
+              while : ; do
+                # Read the token at request time (not as an env var) so
+                # rotation during a long deadline still authenticates.
+                code=$(curl -s -o /tmp/trigger.json -w "%{http_code}" \
+                  -X POST --connect-timeout 10 --max-time 60 \
+                  -H "Authorization: Bearer $(cat ${sa_token_file})" \
+                  -H "Content-Type: application/json" \
+                  -d '{}' \
+                  "${trigger_url}" 2>/dev/null || echo "000")
 
-              case "${code}" in
-                200)
-                  echo "[auto-trigger] cutover started successfully"
-                  cat /tmp/trigger.json 2>/dev/null || true
-                  ;;
-                409)
-                  echo "[auto-trigger] cutover already in progress on the catalyst-api Pod — no-op"
-                  ;;
-                424)
-                  echo "[auto-trigger] catalyst-api reports no step ConfigMaps — chart install ordering bug"
-                  cat /tmp/trigger.json 2>/dev/null || true
-                  exit 1
-                  ;;
-                401|403)
-                  echo "[auto-trigger] catalyst-api rejected our SA token (HTTP ${code}); chart RBAC may be misconfigured"
-                  cat /tmp/trigger.json 2>/dev/null || true
-                  # Exit 0 — operator-actionable, not a chart-install
-                  # failure. CTA still works via the operator session.
-                  exit 0
-                  ;;
-                425)
-                  # Handover-completion gate (catalyst-api
-                  # cutover_internal.go). On a FRESH prov this hook fires
-                  # at bootstrap — long before handover — and catalyst-api
-                  # correctly refuses to start the cutover engine until the
-                  # tofu-phase0-archive is sealed at handover. This is the
-                  # EXPECTED, BENIGN path on every fresh prov: it prevents
-                  # the registry half-pivot that used to wedge bootstrap-kit
-                  # (hw93 2026-06-04). The cutover auto-fires post-handover
-                  # when the same trigger is re-POSTed and the gate is open.
-                  echo "[auto-trigger] cutover deferred: this Sovereign has not been handed over yet (HTTP 425). EXPECTED pre-handover — no engine started; the cutover auto-fires once handover seals the tofu archive."
-                  cat /tmp/trigger.json 2>/dev/null || true
-                  exit 0
-                  ;;
-                *)
-                  echo "[auto-trigger] unexpected status ${code}"
-                  cat /tmp/trigger.json 2>/dev/null || true
-                  # Do NOT fail the hook — the operator can still fire
-                  # the cutover manually via the CTA. Exit 0 so the
-                  # chart install completes and Flux marks the
-                  # HelmRelease Ready.
-                  exit 0
-                  ;;
-              esac
+                case "${code}" in
+                  200)
+                    echo "[auto-trigger] cutover started successfully"
+                    cat /tmp/trigger.json 2>/dev/null || true
+                    break
+                    ;;
+                  409)
+                    echo "[auto-trigger] cutover already in progress on the catalyst-api Pod — no-op"
+                    break
+                    ;;
+                  424)
+                    echo "[auto-trigger] catalyst-api reports no step ConfigMaps — chart install ordering bug"
+                    cat /tmp/trigger.json 2>/dev/null || true
+                    exit 1
+                    ;;
+                  401|403)
+                    echo "[auto-trigger] catalyst-api rejected our SA token (HTTP ${code}); chart RBAC may be misconfigured"
+                    cat /tmp/trigger.json 2>/dev/null || true
+                    # Exit 0 — operator-actionable, not a chart-install
+                    # failure. CTA still works via the operator session.
+                    exit 0
+                    ;;
+                  425)
+                    # Handover-completion gate (catalyst-api
+                    # cutover_internal.go). On a FRESH prov this hook fires
+                    # at bootstrap — long before handover — and catalyst-api
+                    # correctly refuses to start the cutover engine until the
+                    # tofu-phase0-archive is sealed at handover. RETRY until the
+                    # gate opens (#4632) instead of giving up: a single exit 0
+                    # here means nothing ever re-POSTs and the cutover never
+                    # auto-fires (the registry half-pivot guard from hw93
+                    # 2026-06-04 stays intact — the engine only starts once the
+                    # archive is sealed, we just keep asking until it is).
+                    if [ "$(date +%s)" -ge "${hdeadline}" ]; then
+                      echo "[auto-trigger] cutover still deferred after ${HANDOVER_WAIT_SECONDS}s handover wait (HTTP 425) — exiting 0; operator can fire manually via CTA once handover completes."
+                      cat /tmp/trigger.json 2>/dev/null || true
+                      exit 0
+                    fi
+                    echo "[auto-trigger] cutover deferred: this Sovereign has not been handed over yet (HTTP 425). Retrying in 15s until handover seals the tofu archive."
+                    sleep 15
+                    ;;
+                  *)
+                    # Transient (000 connect failure, 502 TokenReview blip,
+                    # etc.). Retry within the same handover-wait budget rather
+                    # than giving up on a momentary hiccup, then exit 0 so a
+                    # genuinely-sick API never fails the chart install.
+                    echo "[auto-trigger] transient/unexpected status ${code}"
+                    cat /tmp/trigger.json 2>/dev/null || true
+                    if [ "$(date +%s)" -ge "${hdeadline}" ]; then
+                      echo "[auto-trigger] gave up after ${HANDOVER_WAIT_SECONDS}s of transient failures — exiting 0; operator can fire manually via CTA."
+                      exit 0
+                    fi
+                    echo "[auto-trigger] retrying in 15s"
+                    sleep 15
+                    ;;
+                esac
+              done
 
               echo "[auto-trigger] complete"
           resources:

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -1164,6 +1164,20 @@ trigger:
   # after prov #23 hit the 14m Job deadline before catalyst-api came
   # up — cold-start budget needs ~2× headroom on slow Sovereigns.
   autoWaitForAPISeconds: 1500
+  # #4632 (chart 0.1.91): how long the trigger POST RETRIES on HTTP 425
+  # (handover-completion gate) before giving up (exit 0; operator can fire
+  # via CTA). On a FRESH prov this hook fires at slot-06a install time —
+  # BEFORE bp-catalyst-platform reaches Ready and the handover post-install
+  # hook seals secret/catalyst/tofu-phase0-archive — so the first POST 425s.
+  # The prior single-POST 425 handler did `exit 0` and the hook-succeeded
+  # delete-policy then removed the Job, so NOTHING ever re-POSTed and the
+  # cutover never auto-fired (verified live on dep 8fd457a8: handover sealed
+  # at 13:56:41 but the lone POST 425'd at 13:54:48, ~2 min too early →
+  # cutover stuck progressPercent=0). The Job now polls every 15s within
+  # this budget so the trigger re-fires the moment handover seals the
+  # archive — zero-touch, no CTA click (founder rule #933). 1500s (25m)
+  # comfortably covers a slow Hetzner/Huawei handover post-the-/healthz-wait.
+  autoHandoverWaitSeconds: 1500
   # Overall cap on the auto-trigger Job runtime. activeDeadlineSeconds
   # on the Job spec — anything longer means catalyst-api is sick and
   # the operator should investigate. The Job exiting at this deadline
@@ -1173,8 +1187,13 @@ trigger:
   # 1800s post-Fix-#152) so the Job ends and the hook unblocks before
   # Helm gives up. Bumped from 840s (14m) on Fix #152 (chart 0.1.27)
   # after prov #23 wedged at 3 consecutive DeadlineExceeded — 29m
-  # leaves a 1m buffer below the 30m HR cap.
-  autoTimeoutSeconds: 1740
+  # leaves a 1m buffer below the 30m HR cap. #4632 (chart 0.1.91): raised
+  # 1740 → 2100 (35m) so the deadline covers the /healthz reachability wait
+  # (autoWaitForAPISeconds, ≤300s effective once the API is up) PLUS the
+  # full autoHandoverWaitSeconds 425-retry window (1500s) PLUS a ~5m buffer.
+  # The HelmRelease install/upgrade timeout is also raised to 40m in the
+  # 06a slot overlay lockstep so the hook still unblocks before Helm gives up.
+  autoTimeoutSeconds: 2100
   # TTL on the completed Job — kept for audit so operators can read
   # the trigger Pod logs if something looks wrong.
   autoJobTTLSeconds: 86400

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5011,7 +5011,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.56"
+  version: "0.1.91"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5028,7 +5028,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.56"
+    version: "0.1.91"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Problem (Refs #4632, verified live on dep 8fd457a8)

`bp-self-sovereign-cutover`'s auto-trigger is a Helm `post-install,post-upgrade` hook Job (`platform/self-sovereign-cutover/chart/templates/10-auto-trigger-job.yaml`) whose `hook-delete-policy` includes `hook-succeeded`. It waits for catalyst-api `/healthz=200`, then POSTs **once** to `/api/v1/internal/cutover/trigger`.

On a fresh prov the hook fires at **slot-06a install time** — BEFORE `bp-catalyst-platform` reaches Ready and the handover post-install hook seals `secret/catalyst/tofu-phase0-archive` — so the POST returns **HTTP 425** ("handover not complete"). The old `425)` case did `exit 0` and **gave up**; because the hook is then deleted, **nothing ever re-POSTed** the trigger → the cutover **never auto-fired**. The case's own comment falsely claimed "the cutover auto-fires when the same trigger is re-POSTed" — but nothing re-POSTed it.

**Live proof (dep 8fd457a8):** handover seal written `13:56:41`, but the lone POST 425'd at `13:54:48` (~2 min too early) → cutover stuck `progressPercent=0`, `cutoverStartedAt=""`.

## Fix (chart-only)

Wrap the single POST + `case "${code}"` block in a `while : ; do … done` loop:

- `200` → success, `break`
- `409` → already-running, `break`
- `424` → no-steps, `exit 1`
- `401|403` → RBAC-reject, `exit 0`
- `425` → retry every 15s until handover seals **or** `autoHandoverWaitSeconds` (1500s) elapses, then graceful `exit 0` (operator CTA still works)
- `*` (transient `000`/`502`) → retry in the same budget, then `exit 0`

The retry runs inside the Job's own lifetime, so the trigger re-fires the moment the gate opens — zero-touch, no CTA click (founder rule #933). The registry-half-pivot guard (hw93 2026-06-04) is preserved: the engine still only starts once the archive is sealed; the Job just keeps asking until it is.

### Lockstep
- New `trigger.autoHandoverWaitSeconds` (default 1500) → `HANDOVER_WAIT_SECONDS` env + `hdeadline`.
- `trigger.autoTimeoutSeconds` default `1740 → 2100` (35m) so the Job `activeDeadlineSeconds` covers the `/healthz` wait + the 425-retry window.
- 06a slot HR `install`/`upgrade` timeout `30m → 40m` so the hook unblocks before Helm gives up.
- Version bumps `0.1.90 → 0.1.91`: `Chart.yaml`, `blueprint.yaml`, bootstrap-kit slot 06a pin, catalog seed (`products/catalyst/chart/templates/catalog-seed/blueprints.yaml`, also corrects a stale `0.1.56` pin).

### Validation
- `helm lint platform/self-sovereign-cutover/chart` → passes (only the cosmetic icon INFO).
- Rendered auto-trigger script passes `dash -n`, `busybox ash -n`, and `sh -n` (POSIX-clean per chart discipline).
- `platform/self-sovereign-cutover/chart/tests/cutover-contract.sh` → **All gates green** (no step-count / job-mode / RBAC change; the auto-trigger Job is not a cutover step).

Live 11-step → `cutoverComplete=true` validation is roll-gated to the next fresh prov (not run on a permanent env).

Refs #4632 #3379

🤖 Generated with [Claude Code](https://claude.com/claude-code)
