### PR TITLE
fix(prov): hardcode provider-opentofu host; revert #4620 cloud-init postBuild (#4620)

### DIFF
--- a/clusters/_template/infrastructure/providers/base/provider-opentofu.yaml
+++ b/clusters/_template/infrastructure/providers/base/provider-opentofu.yaml
@@ -31,9 +31,11 @@ spec:
   # Catalyst is an OpenTofu shop (required_version >= 1.6.0) so this is
   # the native fit. Pinned digest-pinnable tag.
   #
-  # #4600 — the package pulls DIRECTLY from xpkg.upbound.io on EVERY cloud
-  # (Hetzner AND Huawei). XPKG_REGISTRY carries no postBuild substitution
-  # anywhere, so Flux expands the `:=` default to the clean upstream coords.
+  # #4600/#4620 — the package pulls DIRECTLY from xpkg.upbound.io on EVERY
+  # cloud (Hetzner AND Huawei), HARDCODED on the package line below. There is
+  # no postBuild anywhere to resolve a VAR:=default placeholder, so the host
+  # MUST be a literal — a placeholder would ship un-substituted (the #4620 bug
+  # that left provider-opentofu Installed=False on the live 8fd457a8 prov).
   #
   # The former Huawei-only `harbor.openova.io/proxy-xpkg` substitution
   # (#4488/#4491/#4542) was an ARTIFICIAL dependency on the BASTION Harbor:
@@ -62,9 +64,13 @@ spec:
   # `xpkg.upbound.io/...` spec.package to `harbor.<SOVEREIGN_FQDN>/proxy-xpkg`
   # post-handover (the pivot job already matches the upstream-host shape — it
   # is the Hetzner shape it has always handled), so Principle #11 sovereignty
-  # is unaffected. The `:=` default keeps a raw `kustomize build`
-  # (CI / no-substitution) on the upstream coords.
-  package: ${XPKG_REGISTRY:=xpkg.upbound.io}/upbound/provider-opentofu:v1.1.3
+  # is unaffected. #4620 — the host is HARDCODED to xpkg.upbound.io rather
+  # than an XPKG_REGISTRY:=xpkg.upbound.io placeholder: Flux only resolves a
+  # VAR:=default placeholder when a Kustomization postBuild exists, and the
+  # inline infrastructure-providers Kustomization has NONE — so the raw
+  # placeholder shipped verbatim and provider-opentofu stayed Installed=False
+  # on the live 8fd457a8 prov. step-11 pivots this literal host post-handover.
+  package: xpkg.upbound.io/upbound/provider-opentofu:v1.1.3
   # Inherit the cluster's image-pull behaviour from the runtime config
   # below (so post-cutover the Sovereign's own Harbor can proxy it).
   runtimeConfigRef:

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -997,21 +997,18 @@ write_files:
           kind: GitRepository
           name: openova
         wait: false
-        # #4620 — provider-opentofu pulls from xpkg.upbound.io via the manifest's
-        # `${XPKG_REGISTRY:=xpkg.upbound.io}` default. A postBuild MUST be present
-        # for Flux to RESOLVE that `:=` default: #4600 deleted the ENTIRE postBuild
-        # assuming the bare default would apply, but Flux only runs `${VAR:=default}`
-        # resolution when spec.postBuild exists — with none, the literal
-        # `${XPKG_REGISTRY:=...}` shipped verbatim → provider-opentofu Installed=False
-        # → crossplane adoption inert (live on the 8fd457a8 re-prov). Re-add the
-        # postBuild (the SOVEREIGN_FQDN key keeps the substitution engine ON without
-        # re-introducing the artificial bastion-Harbor tether #4488/#4491/#4542 whose
-        # `harbor.openova.io/proxy-xpkg` project never existed → 401). Cutover step-11
-        # still pivots the RESOLVED `xpkg.upbound.io/...` spec.package to
-        # `harbor.<fqdn>/proxy-xpkg` post-handover, so Principle #11 is unaffected.
-        postBuild:
-          substitute:
-            SOVEREIGN_FQDN: ${sovereign_fqdn}
+        # #4600 — NO XPKG_REGISTRY postBuild substitution on ANY cloud.
+        # provider-opentofu pulls DIRECTLY from xpkg.upbound.io (the manifest's
+        # XPKG_REGISTRY := xpkg.upbound.io default) on Hetzner AND Huawei.
+        # The former Huawei-only `harbor.openova.io/proxy-xpkg` substitution
+        # (#4488/#4491/#4542) was an ARTIFICIAL bastion-Harbor tether whose
+        # `proxy-xpkg` project never existed → 401 → provider-opentofu
+        # Installed=False → adoption seam inert. Its "poisoned NAT" premise is
+        # FALSE: xpkg.upbound.io answers HTTP 401 (the anon-auth challenge) in
+        # 0.43s direct from the live Huawei Sovereign, and crossplane-system
+        # has no egress NetworkPolicy. Cutover step-11 already pivots the raw
+        # `xpkg.upbound.io/...` spec.package to `harbor.<fqdn>/proxy-xpkg`
+        # post-handover, so Principle #11 sovereignty is unaffected.
       # NOTE (#4521): LAYER 2 — the CRD-CONSUMING `infrastructure-config` Flux
       # Kustomization (ProviderConfig + the Observe-first CloudAdoption
       # placeholder) is NOT inlined here. It ships as a COMMITTED Flux


### PR DESCRIPTION
PR #4627 broke the catalyst-api image build (G36 render test) since 12:36 — a literal XPKG_REGISTRY interpolation placeholder in a cloud-init comment. Reverts the cloud-init byte-identical and hardcodes the provider-opentofu host instead (git-delivered, zero cloud-init footprint, no image rebuild; cutover step-11 still pivots it). Refs #4620