### PR TITLE
feat(bp-dragonfly): per-cluster P2P image distribution layer

### DIFF
--- a/clusters/_template/bootstrap-kit/06-bp-dragonfly.yaml
+++ b/clusters/_template/bootstrap-kit/06-bp-dragonfly.yaml
@@ -1,0 +1,140 @@
+# bp-dragonfly — Catalyst bootstrap-kit Blueprint, slot 06.
+#
+# Per-cluster P2P container-image distribution. A per-node dfdaemon serves
+# every node's containerd registry-mirror (127.0.0.1:4001); each blob is
+# fetched from the upstream registry ONCE per cluster (ghcr.io pre-cutover)
+# and then distributed peer-to-peer over the LAN. Replaces the centralized
+# bastion proxy-cache + the per-cloud hairpin registry-pivot (#4639).
+#
+# Wrapper chart: platform/dragonfly/chart/ (umbrella over the upstream
+# dragonflyoss/dragonfly chart, Catalyst-curated values under the
+# `dragonfly:` key).
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# SLOT ORDER (design §6.1: "a bootstrap-kit slot, early order"). Sorted EARLY
+# — right after bp-cilium [CNI, slot 01] + bp-flux [GitOps, slot 03] +
+# crossplane/reflector, and BEFORE the image-heavy components (nats 07,
+# openbao 08, keycloak 09, gitea 10, harbor 19). Flux respects the dependsOn
+# edge below for actual install order; the numeric prefix only sets the
+# kustomization list position. Once dfdaemon is serving, every later HR's
+# image pull can flow node→127.0.0.1 dfdaemon→ghcr (once-per-blob)→P2P.
+#
+# SELF-CONTAINED PER CLUSTER (operator decision (A), design §8a): this slot
+# installs on EVERY cluster (every region, every plane) and each cluster runs
+# its OWN mesh + self-seeds from ghcr. No cross-plane/cross-region image path.
+#
+# CHICKEN-AND-EGG NOTE: on a fresh prov dfdaemon itself must be pulled before
+# it can serve P2P. The design pre-bakes dfdaemon + Cilium into the node image
+# (k3s airgap tar) + sets the containerd 127.0.0.1:4001 mirror at boot — that
+# cloud-init wiring is a SEPARATE change (#4639 defers it). For v1 dfdaemon
+# pulls itself from ghcr via ghcr-pull on first install; everything ELSE comes
+# up through dfdaemon. The post-handover registry-pivot (ghcr → local Harbor)
+# is ALSO a separate, later-validated cutover step — NOT wired here.
+
+---
+# Host namespace for the Dragonfly mesh. Flux applies Namespace kinds before
+# namespaced resources, so declaring it here guarantees it exists in the first
+# pass (mirrors the gitea/harbor/newapi slot convention — an absent namespace
+# fails the namespaced-resource dry-run and wedges the whole bootstrap-kit
+# reconcile).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dragonfly
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-dragonfly
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-dragonfly
+  namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+  labels:
+    catalyst.openova.io/slot: "06"
+spec:
+  # interval 1m so install remediation retries fire within ~5min total
+  # (mirrors the slot-19 harbor cadence). Dragonfly's manager waits on its
+  # bundled mysql + redis init, which can legitimately take a few minutes on
+  # cold k3s — the explicit timeout below covers that.
+  interval: 1m
+  releaseName: dragonfly
+  targetNamespace: dragonfly
+  dependsOn:
+    # CNI must be Ready: dfdaemon is hostNetwork and the per-cluster P2P mesh
+    # rides the pod network. bp-cilium (slot 01) provides both.
+    - name: bp-cilium
+      namespace: flux-system
+  chart:
+    spec:
+      chart: bp-dragonfly
+      # 0.1.0 (#4639): initial bp-dragonfly. Wraps upstream dragonfly 1.7.0
+      # (appVersion 2.5.0 / client v1.4.0). Manager + Scheduler + Seed Peer +
+      # per-node dfdaemon DaemonSet; dfdaemon proxy = node containerd mirror at
+      # 127.0.0.1:4001; upstream registry = ghcr (ghcr-pull auth). Every
+      # workload + initContainer carries non-zero resources.requests for the
+      # host-ns Kyverno resource-requests Enforce policy.
+      version: 0.1.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-dragonfly
+        namespace: flux-system
+  # Event-driven install per docs/PRINCIPLES.md #3. timeout 15m — the manager's
+  # bundled mysql + redis init + the scheduler/seed wait-for chains legitimately
+  # need >5m on cold k3s (same canonical-seam pattern as harbor slot 19).
+  install:
+    createNamespace: true
+    timeout: 15m
+    disableWait: true
+    remediation:
+      retries: 5
+      remediateLastFailure: true
+  upgrade:
+    timeout: 15m
+    disableWait: true
+    remediation:
+      retries: 5
+      remediateLastFailure: true
+  values:
+    dragonfly:
+      # G87 #2634 idiom: single-region default 1, multi-region bump via the
+      # cloud-init substitute. Dragonfly's mesh is self-contained per cluster
+      # so this is per-cluster replica sizing, not cross-region replication.
+      manager:
+        replicas: ${SOVEREIGN_DRAGONFLY_MANAGER_REPLICAS:=1}
+      scheduler:
+        replicas: ${SOVEREIGN_DRAGONFLY_SCHEDULER_REPLICAS:=1}
+      seedClient:
+        replicas: ${SOVEREIGN_DRAGONFLY_SEED_REPLICAS:=1}
+        persistence:
+          # #3971 — name the per-provider durable CSI class explicitly so the
+          # seed cache PVC is NEVER created classless (an unset class freezes to
+          # "" before a default StorageClass exists, permanently stranding it
+          # Pending). Sourced from cloud-init per-provider env (hcloud-volumes
+          # on Hetzner, evs-ssd on Huawei); empty default preserves the legacy
+          # omit-when-empty CI `helm template` path.
+          storageClass: ${SOVEREIGN_DRAGONFLY_SEED_STORAGE_CLASS:=}
+        config:
+          proxy:
+            registryMirror:
+              addr: ${SOVEREIGN_DRAGONFLY_UPSTREAM_REGISTRY:=https://ghcr.io}
+      client:
+        config:
+          proxy:
+            registryMirror:
+              # Pre-cutover upstream registry. The post-handover self-sovereign
+              # cutover flips this to the cluster-LOCAL Harbor
+              # (harbor-core.harbor.svc) in a single line — a separate, later-
+              # validated step (platform/self-sovereign-cutover/), NOT here.
+              addr: ${SOVEREIGN_DRAGONFLY_UPSTREAM_REGISTRY:=https://ghcr.io}

--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -27,6 +27,18 @@ resources:
   - 04-crossplane.yaml
   - 05-sealed-secrets.yaml
   - 05a-reflector.yaml
+  # bp-dragonfly (slot 06, #4639) — per-cluster P2P container-image
+  # distribution (Manager + Scheduler + Seed Peer + per-node dfdaemon
+  # DaemonSet). dfdaemon serves each node's containerd registry-mirror at
+  # 127.0.0.1:4001; each blob is fetched from ghcr ONCE per cluster then
+  # distributed P2P over the LAN. Replaces the centralized bastion proxy-cache
+  # + the per-cloud hairpin registry-pivot. Ordered EARLY (after CNI/flux,
+  # before the image-heavy components) so later HRs' pulls flow through the
+  # mesh. Self-contained per cluster — no cross-plane image path. dependsOn
+  # bp-cilium (CNI). MUST be registered here or Flux never creates the HR (the
+  # #3191 forgotten-slot wedge class). The post-cutover registry-pivot
+  # (ghcr → local Harbor) is a SEPARATE later step.
+  - 06-bp-dragonfly.yaml
   - 07-nats-jetstream.yaml
   - 08-openbao.yaml
   - 09-keycloak.yaml

--- a/clusters/_template/bootstrap-kit/placement.yaml
+++ b/clusters/_template/bootstrap-kit/placement.yaml
@@ -82,6 +82,8 @@ spec:
        namespace: kube-system, justification: "HOST-MINIMUM §4 — secret decryption substrate"}
     - {file: 05a-reflector.yaml, hr: bp-reflector, vcluster: host, target: host,
        namespace: reflector, justification: "HOST-MINIMUM §4 — canonical cross-namespace Secret mirror"}
+    - {file: 06-bp-dragonfly.yaml, hr: bp-dragonfly, vcluster: host, target: host,
+       namespace: dragonfly, justification: "HOST-MINIMUM §4 — per-node dfdaemon DaemonSet serves the host kubelet's containerd registry-mirror (127.0.0.1:4001); the P2P image-distribution substrate is a CNI sibling and cannot live in a vCluster (#4639)"}
     - {file: 06a-bp-self-sovereign-cutover.yaml, hr: bp-self-sovereign-cutover, vcluster: host, target: host,
        namespace: catalyst, justification: "HOST-MINIMUM §4 — host-credential surgery by design (8-tether pivot, ADR-0002)"}
     - {file: 11-powerdns.yaml, hr: bp-powerdns, vcluster: host, target: host,

--- a/platform/dragonfly/README.md
+++ b/platform/dragonfly/README.md
@@ -1,0 +1,150 @@
+# Dragonfly
+
+Per-cluster **P2P container-image distribution**. A per-node `dfdaemon` serves
+every node's containerd registry-mirror; each image blob is fetched from the
+upstream registry **once per cluster** and then distributed **peer-to-peer over
+the LAN** — the node IS the cache.
+
+**Role in Catalyst:** control-plane infrastructure (the per-cluster image
+distribution layer). It replaces two pieces of the legacy image path:
+
+1. the centralized **bastion proxy-cache** (`harbor.openova.io`, a SPOF that
+   pulled anonymously → 401s, and caused live `ImagePullBackOff` outages), and
+2. the **per-cloud hairpin registry-pivot** that wedges the self-sovereign
+   cutover on no-hairpin clouds (kom4dc/Huawei) — the `node → 127.0.0.1
+   dfdaemon` path is identical on every cloud, so the cutover becomes a
+   one-line upstream flip with zero per-cloud branches.
+
+Canonical design (operator-reviewed):
+[`docs/ideation/dragonfly-p2p-registry-cutover-redesign.md`](../../docs/ideation/dragonfly-p2p-registry-cutover-redesign.md).
+Tracked by **#4639**.
+
+This Blueprint wraps the **upstream `dragonfly` Helm chart**
+(`dragonflyoss/helm-charts`, `dragonfly@1.7.0`, appVersion 2.5.0 / client
+v1.4.0) as a Helm subchart via `chart/Chart.yaml` `dependencies:`. Catalyst-
+curated values flow into the subchart under the `dragonfly:` key in
+`chart/values.yaml`.
+
+> See [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md) §3.5 for where this
+> sits in the Catalyst control plane, and the `bp-harbor` README for the
+> companion local-registry component Dragonfly distributes from post-cutover.
+
+---
+
+## Components deployed
+
+| Component | Kind | Role |
+|---|---|---|
+| **Manager** | Deployment | Control plane: scheduler registry, seed-peer registry, console (internal). Backed by MySQL + Redis. |
+| **Scheduler** | StatefulSet | Decides which peer serves which piece of a blob. |
+| **Seed Peer** (`seedClient`) | StatefulSet | Does the per-cluster upstream fetch — pulls each blob from the upstream registry once, then the mesh distributes it. Has a local cache PVC. |
+| **dfdaemon** (`client`) | **DaemonSet** | The per-node peer + HTTP proxy. containerd on every node mirrors through its **local** dfdaemon at `127.0.0.1:4001`. |
+| MySQL + Redis | StatefulSet | Bundled (Bitnami subcharts) manager backing store. A production overlay can point at external CNPG/Valkey. |
+
+---
+
+## How the containerd mirror works
+
+```
+  node containerd ──mirror──▶ 127.0.0.1:4001 (local dfdaemon proxy)
+                                   │  cache miss
+                                   ▼
+                          upstream registry  (ghcr.io pre-cutover)
+                                   │  once per blob per cluster
+                                   ▼
+                          P2P mesh: node1 ◀─LAN─▶ node2 ◀─LAN─▶ node3
+```
+
+- **dfdaemon proxy port:** `127.0.0.1:4001` (`client.config.proxy.server.port`).
+  The design doc names `65001` — that is the **Dragonfly 1.x `dfget`** proxy
+  port; the modern 2.x client (the version this Blueprint wraps) listens on
+  `4001`. Override `proxyPort` + the dfinit `proxy.addr` in lockstep to keep a
+  legacy `65001` endpoint.
+- **Upstream registry (pre-cutover):** `https://ghcr.io`
+  (`client.config.proxy.registryMirror.addr` + the same on `seedClient`). The
+  Dragonfly **component images** themselves pull from ghcr via the `ghcr-pull`
+  Secret (`global.imagePullSecrets`).
+- **Post-cutover:** the self-sovereign cutover flips `registryMirror.addr` to
+  the cluster-local Harbor (`harbor-core.harbor.svc`) — a **single line**, no
+  node surgery. That pivot lives in `platform/self-sovereign-cutover/` and is a
+  **separate, later-validated step** (NOT wired here).
+
+### Who writes the containerd config?
+
+Two options, gated by `client.dfinit.enable` (default **`false`**):
+
+- **Default (v1, #4639):** the **node image / cloud-init** owns the
+  containerd-mirror wiring (the k3s airgap-bundle change — pre-bakes dfdaemon +
+  Cilium and sets the `127.0.0.1:4001` mirror at boot). That cloud-init change
+  is **deferred** and not part of this Blueprint. `dfinit` stays off so two
+  writers never fight over `config.toml` and `restartContainerRuntime` (which
+  bounces containerd) stays out of the default path.
+- **Opt-in:** a per-Sovereign overlay that is NOT pre-baking the mirror sets
+  `dragonfly.client.dfinit.enable: true`, letting Dragonfly itself install the
+  containerd `hosts.toml` (with `proxyAllRegistries: true` + an explicit
+  `ghcr.io`/`docker.io` registry list) at install time.
+
+---
+
+## Self-contained per cluster (no cross-plane image path)
+
+Per the operator decision (design §8a, option **(A)**): every cluster — each
+region, each plane (mgmt/dmz/rtz) — runs its **own** Dragonfly mesh and
+**self-seeds from ghcr** through its **own** additively-allow-listed egress.
+There is **no cross-plane or cross-region image path**, so a DMZ compromise
+cannot traverse to mgmt via images; **blast radius = one cluster**. Cross-cluster
+P2P (a peer borrowing blobs from another cluster's peers) is an **optimization
+only, never a hard dependency**. Per-plane/per-region deployment is a
+bootstrap-kit slot concern, not chart internals.
+
+---
+
+## Configuration knobs
+
+Catalyst-curated values under `dragonfly:` in `chart/values.yaml`:
+
+| Value | Default | Notes |
+|---|---|---|
+| `dragonfly.global.imagePullSecrets` | `[{name: ghcr-pull}]` | Pulls the Dragonfly component images from ghcr. |
+| `dragonfly.manager.replicas` | `1` | HA overlay → 3. |
+| `dragonfly.scheduler.replicas` | `1` | HA overlay → 3. |
+| `dragonfly.seedClient.replicas` | `1` | Seed peers. |
+| `dragonfly.seedClient.persistence.size` | `20Gi` | Per-seed cache. |
+| `dragonfly.seedClient.persistence.storageClass` | `""` | Empty ⇒ cluster-default **durable** cloud CSI. local-path is FORBIDDEN (#3971). |
+| `dragonfly.client.config.proxy.server.port` | `4001` | Node containerd mirror endpoint. |
+| `dragonfly.client.config.proxy.registryMirror.addr` | `https://ghcr.io` | Upstream registry; the cutover step flips this to local Harbor. |
+| `dragonfly.client.dfinit.enable` | `false` | See "Who writes the containerd config?" above. |
+| `dragonfly.mysql.enable` / `dragonfly.redis.enable` | `true` | Bundled manager backing store. |
+| `dragonfly.injector.enable` | `false` | Pod-mutation path OFF — Catalyst uses the containerd-mirror path. |
+
+### Kyverno compliance
+
+Every workload's **primary container** declares `resources.requests` (cpu +
+memory) and `livenessProbe` + `readinessProbe`, so the cluster Kyverno
+`resource-requests` and `probes-present` **Enforce** ClusterPolicies admit it.
+The upstream chart defaults requests to `'0'` (would be denied) — this Blueprint
+sets non-zero requests on manager / scheduler / seedClient / dfdaemon and their
+init containers. (Note: the upstream `wait-for-scheduler` init container exposes
+no values hook for resources; the policies validate primary `containers` only,
+not init containers, so this is admitted.)
+
+---
+
+## Operational notes
+
+- **Backups:** the mesh is effectively **stateless** — each seed's cache PVC is
+  a regenerable read-through cache (re-fetched from upstream on a miss). The
+  manager's MySQL holds only ephemeral peer/seed registry state. Nothing here is
+  in the Velero must-backup set.
+- **Scaling:** dfdaemon is a DaemonSet — it scales with the node count
+  automatically. Bump `seedClient.replicas` to widen the upstream-fetch fan-out.
+- **Multi-region / DR:** install **per cluster** (both regions, all planes).
+  Each cluster is independent; region-B survives region-A loss because it runs
+  its own mesh + self-seeds. There is no replication/switchover primitive — the
+  mesh is reconstituted from upstream, not from a peer cluster.
+- **Air-gap:** post-cutover each cluster serves entirely from its local Harbor
+  via dfdaemon — no ghcr, no bastion, no mothership in the image path.
+
+---
+
+*Part of [OpenOva](https://openova.io)*

--- a/platform/dragonfly/blueprint.yaml
+++ b/platform/dragonfly/blueprint.yaml
@@ -1,0 +1,139 @@
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: dragonfly
+  labels:
+    catalyst.openova.io/section: pts-3-5-storage-and-data
+    catalyst.openova.io/tier: catalyst-cp
+spec:
+  version: 0.1.0  # lockstep with chart/Chart.yaml (#4639 initial bp-dragonfly)
+  card:
+    title: Dragonfly
+    family: foundation
+    description: >-
+      Per-cluster P2P container-image distribution. A per-node dfdaemon serves
+      every node's containerd registry-mirror; each image blob is fetched from
+      the upstream registry ONCE per cluster (ghcr.io pre-cutover, the local
+      Harbor post-cutover) and then distributed peer-to-peer over the LAN — the
+      node IS the cache. Replaces the centralized bastion proxy-cache (SPOF,
+      anon-401s) and the per-cloud hairpin registry-pivot that wedges the
+      self-sovereign cutover on no-hairpin clouds. Deploys Manager + Scheduler +
+      Seed Peer + a per-node dfdaemon DaemonSet. Self-contained per cluster — no
+      cross-plane/cross-region image path.
+    docs: https://d7y.io/docs/
+  visibility: unlisted              # mandatory infra, auto-installed by bootstrap kit
+  configSchema:
+    type: object
+    properties:
+      upstreamRegistry:
+        type: string
+        default: "https://ghcr.io"
+        description: >-
+          Upstream registry the seed peer + dfdaemon back-to-source on a cache
+          miss. Pre-cutover this is ghcr.io (authenticated via the ghcr-pull
+          Secret). The self-sovereign cutover flips it to the cluster-local
+          Harbor (harbor-core.harbor.svc) in a single line — that pivot is a
+          SEPARATE, later-validated step and is not driven from this card.
+      proxyPort:
+        type: integer
+        default: 4001
+        minimum: 1
+        maximum: 65535
+        description: >-
+          Node-local dfdaemon HTTP proxy port that containerd mirrors through
+          (127.0.0.1:<proxyPort>). 4001 is the modern Dragonfly 2.x client
+          port; the legacy 1.x dfget port was 65001.
+      seedReplicas:
+        type: integer
+        default: 1
+        minimum: 1
+        maximum: 5
+        description: Seed-peer replicas. 1 for a single-cluster default; bump alongside an HA overlay.
+      managerReplicas:
+        type: integer
+        default: 1
+        minimum: 1
+        maximum: 3
+      schedulerReplicas:
+        type: integer
+        default: 1
+        minimum: 1
+        maximum: 3
+      seedStorageSize:
+        type: string
+        default: "20Gi"
+        description: Per-seed-peer cache PVC size. Bound to a durable cloud StorageClass (local-path FORBIDDEN, #3971).
+
+  placementSchema:
+    # bp-dragonfly is a per-CLUSTER singleton mesh with NO cross-cluster shared
+    # state — each cluster (every region, every plane) runs its own independent
+    # Dragonfly + self-seeds from ghcr (design §8/§8a). There is no replication
+    # or switchover primitive, so the only honest topology is `singleton`
+    # (replicated per cluster by the bootstrap-kit, not by a DR mechanism). A
+    # DR variant (active-hot-standby/active-passive) would require a
+    # replication+switchover declaration the mesh simply does not have.
+    modes: [singleton]
+    default: singleton
+    defaultOnMultiRegion: singleton
+    minRegions: 1
+    maxRegions: 2
+
+  # ── Class-level placement: HOST. dfdaemon is a per-node DaemonSet on the
+  # host kubelet's containerd — it CANNOT live in a vCluster. The whole mesh
+  # (manager/scheduler/seed/dfdaemon) is a host-substrate registry-distribution
+  # layer, sibling to the CNI. Self-contained PER CLUSTER (#4639 design §8a).
+  defaultPlacement:
+    vcluster: host
+  allowedPlacements: [host]
+
+  manifests:
+    chart: ./chart
+  depends:
+    # CNI must exist first — dfdaemon is hostNetwork + the proxy serves the
+    # node's containerd; the per-cluster P2P mesh rides the pod network.
+    - blueprint: bp-cilium
+      version: ^1
+  upgrades:
+    from: []
+
+  # ── Topology ─────────────────────────────────────────────────────────────
+  # Per the design §8/§8a: bp-dragonfly installs PER CLUSTER (every region,
+  # every plane), each cluster fully independent + self-seeded from ghcr. There
+  # is NO cross-cluster image dependency — cross-cluster P2P is an optimization
+  # only, never a hard dependency, and the mesh is stateless beyond each seed's
+  # regenerable local cache. So the ONLY honest topology is `singleton` (the
+  # bootstrap-kit replicates this same singleton mesh per cluster). A DR variant
+  # (active-hot-standby/active-passive) is intentionally NOT declared: it would
+  # require a replication+switchover primitive the mesh does not have — a
+  # region-B cluster survives a region-A loss because it runs its OWN mesh and
+  # re-seeds from upstream, NOT because state is replicated from region-A.
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        placement:
+          tier: ''
+          clusters: [mgmt-A]
+          roles:
+            mgmt-A: singleton
+
+  # ── Endpoints ──────────────────────────────────────────────────────────
+  # Dragonfly has no operator-facing public endpoint by default. The Manager
+  # ships a console (port 8080) but it is an internal control surface, not a
+  # per-Sovereign published host — kept ClusterIP-only. No HTTPRoute in v1.
+  endpoints: []
+
+  # ── SSO ──────────────────────────────────────────────────────────────────
+  # No SSO surface in v1 — there is no published operator console endpoint.
+  # If the Manager console is later exposed it opts into bp-sso-bridge like
+  # harbor/grafana; not in scope for #4639.
+
+  # ── Multi-instance ─────────────────────────────────────────────────────
+  # ONE Dragonfly mesh per cluster (the per-node dfdaemon DaemonSet is
+  # cluster-singleton by construction).
+  multiInstance:
+    enabled: false

--- a/platform/dragonfly/chart/Chart.yaml
+++ b/platform/dragonfly/chart/Chart.yaml
@@ -1,0 +1,58 @@
+apiVersion: v2
+name: bp-dragonfly
+description: |
+  Catalyst Blueprint umbrella chart for Dragonfly. Depends on the upstream
+  `dragonfly` chart (dragonflyoss/helm-charts) as a Helm subchart so
+  `helm dependency build` pulls the upstream payload into this artifact.
+  Catalyst-curated values flow into the upstream subchart under the
+  `dragonfly:` key in values.yaml.
+
+  Dragonfly is the per-cluster P2P container-image distribution layer
+  (design: docs/ideation/dragonfly-p2p-registry-cutover-redesign.md). It
+  deploys Manager + Scheduler + Seed Peer (seedClient) + a per-node
+  `dfdaemon` (the upstream `client` DaemonSet). Each node's containerd is
+  pointed at its LOCAL dfdaemon proxy; dfdaemon fetches each blob from the
+  upstream registry ONCE per cluster and distributes it peer-to-peer over
+  the LAN. The node IS the cache.
+
+  This replaces (a) the centralized bastion proxy-cache
+  (harbor.openova.io — SPOF, anon-401s, hw159 ImagePullBackOff) and
+  (b) the per-cloud hairpin registry-pivot that wedges the self-sovereign
+  cutover on no-hairpin clouds (kom4dc/Huawei). The node→127.0.0.1
+  dfdaemon path is identical on every cloud (zero per-cloud branches).
+
+  Pre-cutover the upstream registry is ghcr.io (authenticated via the
+  `ghcr-pull` Secret). Post-cutover a one-line dfdaemon upstream flip
+  points it at the cluster-LOCAL Harbor (harbor-core.harbor.svc) — that
+  pivot is a SEPARATE, later-validated step (platform/self-sovereign-
+  cutover/) and is NOT wired here.
+
+  Design = self-contained PER CLUSTER (operator decision (A), §8a of the
+  design doc): each cluster runs its OWN Dragonfly mesh and self-seeds
+  from ghcr through its own additively-allow-listed egress. There is NO
+  cross-plane / cross-region image path — blast radius is one cluster.
+  Per-plane / per-region deployment is a bootstrap-kit slot concern, not
+  chart internals.
+type: application
+keywords: [catalyst, blueprint, dragonfly, p2p, registry, oci, image, distribution]
+# 0.1.0 (#4639): initial bp-dragonfly. Wraps upstream dragonfly 1.7.0
+# (appVersion 2.5.0 / client v1.4.0). Single-cluster defaults: manager +
+# scheduler + seedClient replicas 1, bundled mysql + redis enabled, every
+# workload + initContainer carries non-zero resources.requests so the
+# cluster Kyverno `resource-requests` Enforce policy admits it.
+version: 0.1.0
+appVersion: "2.5.0"
+maintainers:
+  - name: OpenOva Catalyst
+    email: catalyst@openova.io
+
+# Pinned to dragonflyoss/dragonfly 1.7.0 (appVersion 2.5.0) — current
+# stable on 2026-06-29. Per docs/PRINCIPLES.md #4 (never hardcode) the
+# version is operator-bumpable via PR + Blueprint release. The upstream
+# chart bundles its own mysql + redis subcharts inside the tgz, so
+# `helm dependency build` of THIS umbrella pulls them transitively (no
+# extra repo wiring needed).
+dependencies:
+  - name: dragonfly
+    version: "1.7.0"
+    repository: "https://dragonflyoss.github.io/helm-charts/"

--- a/platform/dragonfly/chart/values.yaml
+++ b/platform/dragonfly/chart/values.yaml
@@ -1,0 +1,258 @@
+# Catalyst Blueprint umbrella metadata — the upstream chart is resolved as
+# a Helm subchart via Chart.yaml `dependencies:`. Catalyst-curated values
+# under the `dragonfly:` key flow into the upstream subchart unchanged.
+#
+# Per docs/PRINCIPLES.md #4 (never hardcode), every operationally-meaningful
+# value is configurable; cluster overlays in clusters/<sovereign>/ may
+# override any of these without rebuilding the Blueprint OCI artifact.
+#
+# Design: docs/ideation/dragonfly-p2p-registry-cutover-redesign.md
+#   - Manager + Scheduler + Seed Peer (seedClient) + per-node dfdaemon
+#     (upstream `client` DaemonSet).
+#   - containerd on every node is pointed at the LOCAL dfdaemon proxy; the
+#     dfdaemon fetches each blob from the upstream registry ONCE per cluster
+#     and distributes it P2P over the LAN.
+#   - Pre-cutover upstream = ghcr.io (component images pull via ghcr-pull).
+#     Post-cutover a one-line `registryMirror.addr` flip points it at the
+#     cluster-LOCAL Harbor — NOT wired here (separate cutover step).
+#   - Self-contained PER CLUSTER (operator decision (A)): no cross-plane /
+#     cross-region image path.
+
+catalystBlueprint:
+  upstream:
+    chart: dragonfly
+    version: "1.7.0"
+    repo: "https://dragonflyoss.github.io/helm-charts/"
+
+# ─── Upstream chart values (subchart key: dragonfly) ──────────────────────
+dragonfly:
+  # ── Global image-pull auth ─────────────────────────────────────────────
+  # The Dragonfly component images (manager/scheduler/client/dfinit) live on
+  # docker.io upstream. On a Catalyst Sovereign every Dragonfly image is
+  # mirrored under ghcr.io/openova-io and pulled with the `ghcr-pull` Secret
+  # (cloud-init seeds it in every namespace via the reflector). global.*
+  # cascades to every sub-component's pod spec.
+  #
+  # NOTE on the chicken-and-egg (design §3): on a fresh prov dfdaemon itself
+  # must be pulled BEFORE it can serve P2P. The design pre-bakes dfdaemon +
+  # Cilium into the node image (k3s airgap tar) — that cloud-init wiring is a
+  # SEPARATE change (#4639 explicitly defers it). For v1 the dfdaemon image
+  # pulls itself from ghcr via ghcr-pull on first install; everything ELSE
+  # comes up through dfdaemon once it is serving.
+  global:
+    imageRegistry: ""
+    imagePullSecrets:
+      - name: ghcr-pull
+
+  # ── Manager (control plane: scheduler registry + Org/SeedPeer DB) ───────
+  # Single-cluster default: 1 replica (HA overlay bumps to 3). The bundled
+  # mysql + redis subcharts back it (see mysql: / redis: below). EVERY
+  # workload + initContainer carries non-zero resources.requests because the
+  # cluster Kyverno `resource-requests` Enforce ClusterPolicy DENIES any pod
+  # with a zero/absent request — the upstream chart defaults requests to '0'.
+  manager:
+    enable: true
+    replicas: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: "2"
+        memory: 2Gi
+    # initContainer waits for mysql/redis readiness.
+    initContainer:
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+
+  # ── Scheduler (decides which peer serves which piece) ──────────────────
+  scheduler:
+    enable: true
+    replicas: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: "2"
+        memory: 2Gi
+    initContainer:
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+
+  # ── Seed Peer (seedClient) — does the per-cluster upstream fetch ───────
+  # 1-2 seed nodes fetch each blob from ghcr ONCE, then the dfdaemon mesh
+  # distributes it P2P. Single-cluster default: 1 replica. Persistence is a
+  # small per-seed cache (default 100Gi upstream → trimmed to a modest
+  # bootstrap default; the per-Sovereign overlay sizes it and names a
+  # durable cloud StorageClass — local-path is FORBIDDEN per #3971).
+  seedClient:
+    enable: true
+    replicas: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: "2"
+        memory: 4Gi
+    initContainer:
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+    persistence:
+      enable: true
+      size: 20Gi
+      # Empty ⇒ cluster-default durable cloud CSI (hcloud-volumes / evs-ssd).
+      # Per #3971 a classless PVC is FORBIDDEN; the per-Sovereign overlay sets
+      # SOVEREIGN_DRAGONFLY_SEED_STORAGE_CLASS to the provider's durable class.
+      storageClass: ""
+    config:
+      seedPeer:
+        enable: true
+      # The seed peer's own proxy carries the SAME ghcr upstream default as
+      # the per-node dfdaemon so a seed-side miss back-to-sources to ghcr.
+      proxy:
+        registryMirror:
+          # Pre-cutover upstream registry. Post-cutover the cutover step
+          # flips this to the cluster-local Harbor (harbor-core.harbor.svc).
+          addr: https://ghcr.io
+
+  # ── dfdaemon (per-node peer; upstream `client` DaemonSet) ──────────────
+  # hostNetwork/hostPID/hostIPC are upstream defaults (the proxy must be
+  # reachable on the node's 127.0.0.1 and the dfinit must edit the host
+  # containerd config). Requests are modest; the per-node proxy is mostly
+  # network + disk bound.
+  client:
+    enable: true
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: "2"
+        memory: 4Gi
+    initContainer:
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: "1"
+          memory: 1Gi
+    config:
+      # ── dfdaemon proxy = the node's containerd registry mirror ──────────
+      # containerd on every node is configured (by dfinit below — or by
+      # cloud-init in the airgap-bundle change) to mirror EVERY registry
+      # through this local proxy. dfdaemon then fetches each blob once per
+      # cluster and serves the rest P2P.
+      #
+      # PORT NOTE: the design doc names `127.0.0.1:65001` — that is the
+      # Dragonfly 1.x `dfget` HTTP-proxy port. The modern client (2.x /
+      # appVersion 2.5.0, the version this Blueprint wraps) listens on
+      # 127.0.0.1:4001. The containerd mirror endpoint dfinit writes is
+      # http://127.0.0.1:4001 accordingly. Operators who must keep the
+      # legacy 65001 endpoint override proxy.server.port + the dfinit
+      # proxy.addr in lockstep.
+      proxy:
+        server:
+          port: 4001
+        registryMirror:
+          # Pre-cutover upstream registry = ghcr. The proxy starts a
+          # registry-mirror service the node's containerd points at; on a
+          # cache miss dfdaemon back-to-sources to this addr (once per blob
+          # per cluster), then P2P-distributes. Post-cutover the cutover
+          # step flips this single line to harbor-core.harbor.svc.
+          addr: https://ghcr.io
+
+    # ── dfinit — write the host containerd registry-mirror config ──────────
+    # dfinit edits the node's /etc/containerd/config.toml hosts.d so every
+    # registry namespace mirrors through the local dfdaemon proxy
+    # (http://127.0.0.1:4001). `proxyAllRegistries: true` installs a
+    # catch-all _default/hosts.toml so ANY registry (incl. ghcr.io and
+    # docker.io) is proxied; the explicit `registries` list pins ghcr.io +
+    # docker.io with pull/resolve.
+    #
+    # DEFAULT OFF: in the v1 design (#4639) the node image / cloud-init owns
+    # the containerd-mirror wiring (the airgap-bundle change), so dfinit is
+    # disabled by default to avoid two writers fighting over config.toml and
+    # to keep `restartContainerRuntime` (which bounces containerd) out of the
+    # default path. A per-Sovereign overlay that is NOT pre-baking the mirror
+    # into the node image flips `dfinit.enable: true` to let Dragonfly itself
+    # install the containerd mirror at install time.
+    dfinit:
+      enable: false
+      restartContainerRuntime: true
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+      config:
+        proxy:
+          # Must match client.config.proxy.server.port above.
+          addr: http://127.0.0.1:4001
+        containerRuntime:
+          containerd:
+            configPath: /etc/containerd/config.toml
+            proxyAllRegistries: true
+            registries:
+              - hostNamespace: ghcr.io
+                serverAddr: https://ghcr.io
+                capabilities: ['pull', 'resolve']
+                skipVerify: true
+              - hostNamespace: docker.io
+                serverAddr: https://index.docker.io
+                capabilities: ['pull', 'resolve']
+                skipVerify: true
+
+  # ── Injector (mutating webhook that injects a dfget initContainer) ─────
+  # OFF: Catalyst uses the containerd-mirror path (every node's containerd →
+  # local dfdaemon), NOT pod mutation. Keeping the injector off also avoids a
+  # cert-manager-backed webhook in the image path (one fewer bootstrap dep).
+  injector:
+    enable: false
+
+  # ── Bundled MySQL (manager metadata DB) ────────────────────────────────
+  # Single-cluster default: the chart's bundled bitnami mysql subchart backs
+  # the manager. A production overlay may point the manager at an external
+  # CNPG/MySQL via dragonfly.externalMysql + dragonfly.mysql.enable=false.
+  # The bitnami subchart already sets its own resources; nothing to add here.
+  mysql:
+    enable: true
+    primary:
+      persistence:
+        size: 8Gi
+
+  # ── Bundled Redis (manager cache / scheduler coordination) ─────────────
+  redis:
+    enable: true
+    master:
+      persistence:
+        size: 8Gi
+
+# ─── Catalyst overlay values (reserved) ───────────────────────────────────
+# Reserved for Catalyst-side overlays added once bp-dragonfly is consumed in
+# clusters/_template/ (per-component NetworkPolicy / CNP allow-list for the
+# additive egress to ghcr; ExternalSecret projecting any future registry
+# credential; the post-cutover registryMirror.addr flip seam). v1 keeps this
+# empty so `helm template` renders cleanly with no extra CRDs.
+dragonflyOverlay:
+  networkPolicy:
+    enabled: false

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -86,6 +86,20 @@ slots:
     # Used by bp-gitea + bp-harbor to propagate CNPG-generated pg-app Secrets.
     depends_on: [bp-cert-manager]
     wave: present
+  - slot: 6
+    name: bp-dragonfly
+    # bp-dragonfly (#4639) — per-cluster P2P container-image distribution
+    # (Manager + Scheduler + Seed Peer + per-node dfdaemon DaemonSet). dfdaemon
+    # serves each node's containerd registry-mirror at 127.0.0.1:4001; each blob
+    # is fetched from ghcr ONCE per cluster then distributed P2P over the LAN.
+    # Replaces the centralized bastion proxy-cache + per-cloud hairpin registry-
+    # pivot. Ordered EARLY (after CNI + flux, before the image-heavy components)
+    # so later HRs' pulls flow through the mesh. dependsOn bp-cilium — dfdaemon
+    # is hostNetwork and the P2P mesh rides the pod network (CNI must be Ready).
+    # Self-contained per cluster — no cross-plane/cross-region image path. The
+    # post-cutover registry-pivot (ghcr → local Harbor) is a SEPARATE later step.
+    depends_on: [bp-cilium]
+    wave: present
   - slot: 7
     name: bp-nats-jetstream
     # G92.2 #2661 (2026-06-01): MGMT vCluster placement. HR carries


### PR DESCRIPTION
## What

New platform Blueprint **`bp-dragonfly`** — the per-cluster P2P container-image distribution layer from the operator-reviewed design (`docs/ideation/dragonfly-p2p-registry-cutover-redesign.md`).

Wraps the upstream **`dragonflyoss/dragonfly` Helm chart `1.7.0`** (appVersion 2.5.0 / client v1.4.0) as a Helm subchart. Deploys **Manager + Scheduler + Seed Peer + a per-node `dfdaemon` DaemonSet**. dfdaemon serves each node's containerd registry-mirror at `127.0.0.1:4001`; each blob is fetched from the upstream registry **once per cluster** then distributed **peer-to-peer over the LAN** — the node IS the cache.

Replaces (a) the centralized **bastion proxy-cache** (`harbor.openova.io` — SPOF, anon-401s, hw159 `ImagePullBackOff`) and (b) the **per-cloud hairpin registry-pivot** that wedges the self-sovereign cutover on no-hairpin clouds (kom4dc/Huawei). The `node → 127.0.0.1 dfdaemon` path is identical on every cloud.

**Self-contained per cluster** (operator decision (A), design §8a): each cluster (every region, every plane) runs its own Dragonfly mesh and self-seeds from ghcr. No cross-plane / cross-region image path — blast radius = one cluster.

## Files

| File | What |
|---|---|
| `platform/dragonfly/chart/Chart.yaml` | umbrella; `dependencies:` → `dragonfly@1.7.0` from `https://dragonflyoss.github.io/helm-charts/` |
| `platform/dragonfly/chart/values.yaml` | manager/scheduler/seedClient replicas 1; bundled mysql+redis; **non-zero `resources.requests` on every workload + initContainer**; dfdaemon `proxy.registryMirror.addr = ghcr` + proxy port 4001; `ghcr-pull` imagePullSecret; `dfinit` (containerd-mirror writer) default OFF |
| `platform/dragonfly/blueprint.yaml` | card + **singleton** topology + host placement; dependsOn `bp-cilium` |
| `platform/dragonfly/README.md` | component doc (role, mirror mechanism, knobs, ops) |
| `clusters/_template/bootstrap-kit/06-bp-dragonfly.yaml` | **slot 06** — early (after CNI/flux, before image-heavy components) |
| `kustomization.yaml` / `placement.yaml` / `scripts/expected-bootstrap-deps.yaml` | slot registration |

## Design notes

- **Proxy port:** the design names `127.0.0.1:65001` — that's the Dragonfly **1.x** `dfget` port. The modern **2.x** client (the version wrapped here) listens on **`4001`**; the containerd mirror endpoint is set accordingly (overridable to keep legacy 65001).
- **Topology = `singleton` only:** the mesh has no shared cross-cluster state to replicate (each seed's cache is regenerable; each cluster self-seeds), so declaring a DR `active-hot-standby` variant — which the admission schema requires to carry a `replication`+`switchover` primitive — would be dishonest. Region-B survives a region-A loss by running its **own** mesh, not by replication.

## Deferred (separate, later-validated steps)

- The cutover **registry-pivot** (ghcr → cluster-local Harbor, a one-line `registryMirror.addr` flip in `platform/self-sovereign-cutover/`) — **not touched**.
- The **airgap-bundle / cloud-init** containerd-mirror wiring — v1 dfdaemon pulls its own image from ghcr.

## Validation

- `helm lint` clean (only the cosmetic icon INFO).
- `helm dependency build && helm template . --api-versions v2` → **clean** (exit 0, no stderr).
- Every primary container carries `resources.requests` + liveness/readiness probes → admitted by the host-ns Kyverno `resource-requests` + `probes-present` Enforce policies.
- `tests/e2e/bootstrap-kit` Go suite **PASS** (incl. dragonfly version-lockstep + template-parse).
- `scripts/check-bootstrap-deps.sh` **PASS** (Drift 0, Cycles 0).
- `scripts/render-slot-placement.py check` **PASS**.
- Blueprint admission jsonschema (`platform/_schemas/blueprint-topology.json`) **clean** for dragonfly.

Refs #4639

🤖 Generated with [Claude Code](https://claude.com/claude-code)
