### PR TITLE
fix(self-sovereign-cutover): rewrite registry-pivot to the Dragonfly dfdaemon mirror — kill the kom4dc hairpin (0.1.93)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -86,6 +86,14 @@ spec:
       namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-harbor
       namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+    # #4639: the cutover registry-pivot (step-04) flips the bp-dragonfly dfdaemon
+    # mesh's upstream from ghcr to the local Harbor + adds the registry.<fqdn> ->
+    # cilium-gateway hostAlias. The dfdaemon DaemonSet + seed-peer + their
+    # ConfigMaps must exist before step-04 can patch them, so the cutover HR
+    # depends on bp-dragonfly (slot 06) being Ready. The chart itself is dormant,
+    # so an early apply is benign — this edge only orders the post-handover flip.
+    - name: bp-dragonfly
+      namespace: flux-system
     # NB on issue #1871 (TBD-A24 cutover↔gateway circular deadlock):
     # PR #1875 initially added `- name: sovereign-tls` to this list.
     # That fix was UNRESOLVABLE in Flux: HelmRelease.dependsOn can
@@ -648,6 +656,30 @@ spec:
       # insecureSkipVerify — certSecretRef is the only trust mechanism (mirrors
       # skopeo #4529 / helm #4557 / containerd step-04 / OBS #4573 F2). Fail-OPEN
       # when the CA is unreadable. Lockstep w/ Chart.yaml + blueprint.yaml.
+      # 0.1.93 (#4639 Refs #4637): the GENERIC registry-pivot — Dragonfly P2P
+      # replaces the hand-rolled per-cloud hairpin hack. step-04 (registry-pivot)
+      # no longer writes /etc/rancher/k3s/registries.yaml + per-upstream certs.d
+      # hosts.toml through the in-cluster Harbor's PUBLIC host. bp-dragonfly
+      # (slot 06) runs a per-node dfdaemon proxy at 127.0.0.1:4001 that every
+      # node's containerd mirrors through. On registriesYamlActive=v2 the step-04
+      # DaemonSet (1) writes the containerd `_default/hosts.toml` catch-all -> the
+      # node-local dfdaemon; (2) flips the dfdaemon (+ seed) registryMirror.addr
+      # ghcr -> the local Harbor (https://registry.<fqdn>:30443); (3) adds a
+      # `registry.<fqdn> -> cilium-gateway ClusterIP` hostAlias to the dfdaemon
+      # pod template (the #4637 token-realm hairpin kill — dfdaemon is hostNetwork
+      # so it inherits the node's public-EIP pin AND must reach the token realm).
+      # The node->127.0.0.1 dfdaemon path is IDENTICAL on Huawei + Hetzner — zero
+      # per-cloud `if` branches. LIVE-PROVEN on kom4dc omantel.biz (the cloud that
+      # breaks the legacy hairpin): public-host fetch i/o-timed-out (curl 28)
+      # while the gateway-ClusterIP resolve returned the registry 401 + 200 from
+      # /service/token. step-04 stays mode=daemonset-wait / 11 steps / per-node
+      # acks unchanged. New values block .Values.registryPivot.dragonfly (defaults
+      # match the bp-dragonfly releaseName `dragonfly` + cilium-gateway/30443
+      # layout — no overlay needed). The legacy registries.yaml v1/v2 mirror +
+      # the #4527/#4557/#4637-ClusterIP machinery is removed. Adds a dependsOn
+      # edge on bp-dragonfly (the dfdaemon mesh must be up before the flip).
+      # Lockstep w/ Chart.yaml + blueprint.yaml.
+      #
       # 0.1.92 (#4637): the KUBELET-HAIRPIN leg. step-04 (registry-pivot) now
       # resolves harbor-core's node-routable ClusterIP and points the v2
       # containerd mirror endpoints at http://<clusterip>:<port> instead of
@@ -655,10 +687,7 @@ spec:
       # gateway EIP). On a no-hairpin cloud (kom4dc) the kubelet could not dial
       # its own cluster's public EIP, so step-07 (catalyst-api-env-patch)
       # ErrImagePull'd `dial tcp <EIP>:443: i/o timeout` and the cutover wedged
-      # at 54% (live f7464ffc). Fail-OPEN to the public host on a resolve miss.
-      # New values block .Values.registryPivot.inClusterHarbor (defaults
-      # harbor-core/harbor/:80 match this Sovereign's bp-harbor layout — no
-      # overlay needed). Lockstep w/ Chart.yaml + blueprint.yaml.
+      # at 54% (live f7464ffc). Superseded by 0.1.93's Dragonfly rewrite.
       #
       # 0.1.91 (#4632 Refs #3379): the auto-trigger 425-NO-RETRY race — the
       # post-install hook Job POSTed /internal/cutover/trigger ONCE, got HTTP 425
@@ -669,7 +698,7 @@ spec:
       # transient 000/502) until a non-425 result or autoHandoverWaitSeconds
       # (1500s). New trigger.autoHandoverWaitSeconds; autoTimeoutSeconds 1740→2100;
       # HR install/upgrade timeout 30m→40m (above) so the hook unblocks in time.
-      version: 0.1.92
+      version: 0.1.93
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.92
+  version: 0.1.93
   card:
     title: self-sovereignty-cutover
     summary: |
@@ -26,6 +26,11 @@ spec:
   depends:
     - blueprint: bp-gitea
     - blueprint: bp-harbor
+    # #4639: step-04 (registry-pivot, the Dragonfly rewrite) flips the
+    # bp-dragonfly dfdaemon mesh upstream ghcr -> local Harbor + adds the
+    # registry.<fqdn> -> cilium-gateway hostAlias, so the dfdaemon mesh must
+    # be present before the post-handover cutover runs.
+    - blueprint: bp-dragonfly
 
   # ── G117.1: Topology declaration ────────────────────────────────────────
   # Per docs/sessions/2026-06-02-per-blueprint-topology-audit.md:

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,42 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.93 (#4639 Refs #4637, the GENERIC registry-pivot — Dragonfly P2P replaces
+# the hand-rolled per-cloud hairpin hack): step-04 (registry-pivot) no longer
+# writes /etc/rancher/k3s/registries.yaml + per-upstream certs.d hosts.toml
+# through the in-cluster Harbor's PUBLIC host (which the node /etc/hosts pins to
+# the un-hairpinnable public gateway EIP). bp-dragonfly (slot 06) now runs a
+# per-node dfdaemon proxy at 127.0.0.1:4001 that every node's containerd already
+# mirrors through. The cutover is now THREE generic moves the step-04 DaemonSet
+# performs on registriesYamlActive=v2 (no per-cloud `if Hetzner/Huawei` branch):
+#   1. write the containerd `_default/hosts.toml` catch-all -> the node-local
+#      dfdaemon proxy (effective on the running node, re-read per pull);
+#   2. flip the dfdaemon (+ seed-peer) proxy.registryMirror.addr from
+#      https://ghcr.io -> the cluster-LOCAL Harbor (https://registry.<fqdn>:30443,
+#      the canonical gateway HTTPS port) — the design's "one-line upstream flip";
+#   3. add a `registry.<fqdn> -> cilium-gateway ClusterIP` hostAlias to the
+#      dfdaemon (+ seed) pod template. THE #4637 ROOT KILL: dfdaemon is
+#      hostNetwork, so without the alias its Harbor pull AND the token-realm
+#      follow-up (`Www-Authenticate: Bearer realm="https://registry.<fqdn>:30443/
+#      service/token"`) both hairpin to the public EIP. The alias resolves the
+#      Harbor host to the node-routable Cilium-gateway ClusterIP (kube-proxy/
+#      cilium program it on the host net) — the gateway terminates the wildcard
+#      `*.<fqdn>` TLS and routes registry.<fqdn> to Harbor, token realm included.
+# Moves 2+3 are cluster-wide (one ConfigMap / one DaemonSet template), performed
+# ONCE by whichever node converges first (status guard dragonflyUpstream=local);
+# every node still independently performs move 1 + writes its per-node ack.
+# LIVE-PROVEN on the kom4dc omantel.biz env (the cloud that breaks the legacy
+# hairpin): from a hostNetwork context `curl https://registry.<fqdn>/v2/`
+# i/o-timed-out (curl 28) while the same fetch with the host resolved to the
+# cilium-gateway ClusterIP returned the registry 401 challenge AND a 200 from
+# `/service/token`. step-04 stays mode=daemonset-wait / 11 steps / per-node acks
+# unchanged. New values block .Values.registryPivot.dragonfly (defaults match
+# the bp-dragonfly releaseName `dragonfly` + the canonical cilium-gateway /
+# 30443 layout — no overlay needed). The legacy registries.yaml v1/v2 mirror +
+# the #4527 harbor-robot-token / #4557 / #4637-ClusterIP machinery is removed
+# (the cold-start ghcr upstream is now bp-dragonfly's concern, not the cutover).
+# RBAC unchanged (services get + daemonsets/statefulsets + configmaps patch were
+# already granted). Contract Case 31 rewritten to the Dragonfly invariants.
+# Lockstep w/ blueprint.yaml + 06a slot pin + catalog seed.
 # 0.1.92 (#4637, the KUBELET-HAIRPIN leg of the cutover — registry-pivot v2
 # mirror now points at a NODE-REACHABLE in-cluster Harbor, live wedge on
 # f7464ffc / omantel.biz kom4dc, 2026-06-29): step-04 (registry-pivot) no
@@ -1329,7 +1366,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.92
+version: 0.1.93
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/README.md
+++ b/platform/self-sovereign-cutover/chart/README.md
@@ -33,7 +33,7 @@ through `harbor.openova.io`) and becomes hard-independent only after the
 | 01 | `cutover-step-01-gitea-mirror` ConfigMap | pre-pivot | `git clone --mirror` upstream → `git push --mirror` to local Gitea |
 | 02 | `cutover-step-02-harbor-projects` ConfigMap | pre-pivot | Create 7 proxy_cache projects in local Harbor |
 | 03 | `cutover-step-03-harbor-prewarm` ConfigMap | pre-pivot | HEAD-pull every image referenced by bootstrap-kit through proxy-cache |
-| 04 | `registry-pivot` DaemonSet | pre-pivot | Always-on per-node reconcile loop for `/etc/rancher/k3s/registries.yaml` (v1 ↔ v2) |
+| 04 | `registry-pivot` DaemonSet | pre-pivot | Always-on per-node reconcile loop (Dragonfly, #4639): on `registriesYamlActive=v2` it writes the containerd `_default/hosts.toml` catch-all → the node-local dfdaemon proxy, flips the `bp-dragonfly` dfdaemon upstream ghcr → local Harbor, and adds a `registry.<fqdn>` → cilium-gateway ClusterIP hostAlias (the #4637 hairpin kill) |
 | 05 | `cutover-step-05-flux-gitrepository-patch` ConfigMap | post-pivot | Patch `flux-system/openova` GitRepository.url → local Gitea |
 | 06 | `cutover-step-06-helmrepository-patches` ConfigMap | post-pivot | Patch every OCI HelmRepository → `oci://harbor.<sov-fqdn>/openova-io` |
 | 07 | `cutover-step-07-catalyst-api-env-patch` ConfigMap | post-pivot | `kubectl set env deploy/catalyst-api CATALYST_GITOPS_REPO_URL=...` |
@@ -41,9 +41,10 @@ through `harbor.openova.io`) and becomes hard-independent only after the
 | 09 | `self-sovereign-cutover-status` ConfigMap | mutable state | Per-step state machine read+written by every step + the UI |
 
 The phase column controls image routing: `pre`-phase steps must use
-upstream-public images because they run BEFORE registries.yaml v2 takes
-effect on the node containerd. `post`-phase steps may pull through local
-Harbor when `.Values.global.imageRegistry` is set in the overlay.
+upstream-public images because they run BEFORE step-04 pivots the node
+containerd onto the local Dragonfly dfdaemon (whose upstream then flips to
+the local Harbor). `post`-phase steps may pull through local Harbor when
+`.Values.global.imageRegistry` is set in the overlay.
 
 ## Values
 
@@ -52,7 +53,7 @@ See [`values.yaml`](./values.yaml). The required overlay-supplied keys are:
 | Key | Purpose |
 |---|---|
 | `sovereign.fqdn` | The Sovereign's base FQDN (e.g. `otech.omani.works`). Drives every public URL in this chart. |
-| `sovereign.harborPublicURL` | `https://registry.<sovereign.fqdn>`. The bp-harbor HTTPRoute publishes at `registry.<sov>`, NOT `harbor.<sov>` — see `clusters/_template/bootstrap-kit/19-harbor.yaml` `gateway.host`. Routed to by registries.yaml v2 + step 06. |
+| `sovereign.harborPublicURL` | `https://registry.<sovereign.fqdn>`. The bp-harbor HTTPRoute publishes at `registry.<sov>`, NOT `harbor.<sov>` — see `clusters/_template/bootstrap-kit/19-harbor.yaml` `gateway.host`. The step-04 Dragonfly upstream flip + step 06 repoint to this host. |
 | `sovereign.giteaPublicURL` | `https://gitea.<sovereign.fqdn>`. Informational; jobs reach Gitea via the in-cluster Service URL. |
 
 Per `docs/PRINCIPLES.md` #4 (never hardcode), the chart ships
@@ -64,9 +65,10 @@ overlay is non-functional by design.
 
 The HelmRelease that installs this chart is at
 `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml`.
-It depends on `bp-gitea` and `bp-harbor` (so the local Gitea + Harbor
-exist before the chart's step ConfigMaps reference them at trigger time)
-and uses `disableWait: true` because the chart is dormant (no Pods to
+It depends on `bp-gitea`, `bp-harbor`, and `bp-dragonfly` (the local Gitea +
+Harbor + the per-node dfdaemon mesh must exist before the chart's step
+ConfigMaps + step-04's Dragonfly upstream flip reference them at trigger
+time) and uses `disableWait: true` because the chart is dormant (no Pods to
 wait on except the registry-pivot DaemonSet, which is event-driven on
 the status ConfigMap).
 

--- a/platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml
@@ -1,48 +1,79 @@
 {{- /*
-Step 04 — registry-pivot.
+Step 04 — registry-pivot (Dragonfly rewrite, #4639 Refs #4637).
 
 This step is a DaemonSet, not a Job. The consumer (catalyst-api,
 issue #792) handles this via mode=daemonset-wait: when the cutover
 hits this step, it waits for the DaemonSet's
-`status.numberReady == status.desiredNumberScheduled` and treats that
-as step success. The DaemonSet is shipped HERE by the chart so it is
-already running by the time catalyst-api stamps the wait.
+`status.numberReady == status.desiredNumberScheduled` AND the per-node
+`node.<NODE>.registriesYaml=v2` acks (#3671) on the cutover-status
+ConfigMap, then treats that as step success. The DaemonSet is shipped
+HERE by the chart so it is already running by the time catalyst-api
+stamps the wait.
 
-What the DaemonSet actually does
-────────────────────────────────
-A reconcile loop on every node. Reads the `registriesYamlActive` key
-on the cutover-status ConfigMap via the in-cluster K8s API; when it
-sees "v2", atomically replaces /etc/rancher/k3s/registries.yaml with
-the v2 form (rewrites every upstream registry through harbor.<sov-fqdn>).
-"v1" or "rollback" restores the cold-start file (mothership Harbor).
-Idempotent across restarts.
+WHAT CHANGED (#4639) — Dragonfly, not the hand-rolled hairpin hack
+──────────────────────────────────────────────────────────────────
+The legacy step-04 wrote /etc/rancher/k3s/registries.yaml + regenerated
+the containerd certs.d/<host>/hosts.toml mirror dir to redirect the 7
+canonical upstreams through the in-cluster Harbor's PUBLIC host
+(registry.<fqdn>). That host DNS-resolves on the NODE to the cluster's
+PUBLIC gateway EIP (the cloudinit /etc/hosts pin). On a cloud whose nodes
+cannot hairpin to their own public EIP (Huawei kom4dc) the kubelet pull
+i/o-timed-out and the cutover wedged at step-07 (#4637). Every prior
+workaround (the ClusterIP rewrite, the `30443`/DNAT surgery, per-cloud
+`if Hetzner/Huawei` branches) was a symptom of that one bad assumption.
 
-🛑 #3647 (hw149 live repro) — registries.yaml ALONE is inert for new
-pulls. k3s reads /etc/rancher/k3s/registries.yaml ONLY at process
-startup, where it GENERATES the containerd host-mirror dir
-/var/lib/rancher/k3s/agent/etc/containerd/certs.d/<host>/hosts.toml and
-sets containerd's `config_path` to that dir. containerd then re-reads
-those hosts.toml files PER PULL REQUEST (the certs.d host-dir mechanism
-is dynamic — no containerd/k3s restart needed). So after cutover, just
-rewriting registries.yaml leaves the LIVE node still resolving ghcr.io:
-a fresh pod-roll 401s on ghcr (Init:ImagePullBackOff, reproduced on
-hw149). THE FIX: this loop now ALSO regenerates the certs.d/<host>/
-hosts.toml mirror files itself — exactly what k3s does at startup, but
-applied to the running node — so a pod rolled AFTER cutover pulls from
-local Harbor with NO node reboot. registries.yaml is still written (it
-keeps the node correct across a future genuine k3s restart); the
-hosts.toml write is what makes the pivot take effect immediately. The
-canonical certs.d path + the fact k3s materialises it from
-registries.yaml is documented in infra/providers/huawei/cloudinit-
-worker.tftpl (line ~74).
+Dragonfly (`bp-dragonfly`, slot 06) removes the assumption. Every node's
+containerd already mirrors through the LOCAL dfdaemon proxy on
+`127.0.0.1:{{ .Values.registryPivot.dragonfly.proxyPort }}` (a standard,
+documented containerd mirror — the node→127.0.0.1 path is IDENTICAL on
+every cloud, zero per-cloud branches). dfdaemon fetches each blob from
+its configured upstream ONCE per cluster and serves the rest P2P. So the
+cutover is now THREE generic moves, all of which this DaemonSet performs
+on the live node when it sees registriesYamlActive=v2:
 
-The daemonset-wait completion condition is "all node Pods Ready" — by
-the time every Pod is Running and reporting Ready, the reconcile loop
-has done its first sync. Because the chart ships registriesYamlActive=v1
-in the initial status ConfigMap, the FIRST sync writes v1 (no-op rollover).
-catalyst-api's runCutover sets registriesYamlActive=v2 BEFORE stamping
-step 05 — the next reconcile sweep then converges every node to v2
-within the 15s poll interval (well under the daemonset-wait timeout).
+  1. CONTAINERD → dfdaemon. Write a containerd certs.d `_default/hosts.toml`
+     catch-all that mirrors EVERY registry namespace through
+     `http://127.0.0.1:{{ .Values.registryPivot.dragonfly.proxyPort }}`
+     (the dfdaemon proxy). containerd re-reads certs.d PER PULL, so this
+     takes effect on the RUNNING node with NO k3s restart — the same
+     live-certs.d mechanism the legacy step relied on (#3647), but the
+     endpoint is the node-LOCAL dfdaemon, never the un-hairpinnable EIP.
+     (When bp-dragonfly's own `dfinit` is enabled the node already carries
+     this mirror at boot; this write is then a harmless idempotent re-state.)
+
+  2. dfdaemon UPSTREAM FLIP. Patch the `{{ .Values.registryPivot.dragonfly.clientConfigMap }}`
+     ConfigMap (and the seed-peer's) `proxy.registryMirror.addr` from
+     `https://ghcr.io` → the cluster-LOCAL Harbor public host
+     (`https://registry.<fqdn>:{{ .Values.registryPivot.dragonfly.gatewayHTTPSPort }}`).
+     This is the design's "one-line upstream flip": post-cutover dfdaemon
+     back-to-sources to the LOCAL Harbor, never ghcr.
+
+  3. HOSTALIAS (the #4637 root kill). dfdaemon is hostNetwork, so it
+     inherits the node's `registry.<fqdn> → public-EIP` pin and would
+     hairpin on the upstream fetch — AND on the token-realm follow-up
+     (Harbor answers `Www-Authenticate: Bearer realm="https://registry.
+     <fqdn>:{{ .Values.registryPivot.dragonfly.gatewayHTTPSPort }}/service/token"`,
+     which the client must also reach). Adding a Kubernetes `hostAliases`
+     entry `registry.<fqdn> → <cilium-gateway ClusterIP>` to the dfdaemon
+     (+ seed) pod template makes BOTH the `/v2/` fetch and the token-realm
+     fetch resolve to the cluster's node-routable Cilium-gateway ClusterIP
+     (kube-proxy/cilium program it on the host net) instead of the public
+     EIP. The gateway terminates the wildcard `*.<fqdn>` TLS and routes
+     `registry.<fqdn>` to Harbor — token realm included — so the whole
+     registry handshake stays in-cluster. PROVEN live on the kom4dc
+     `omantel.biz` env: from a hostNetwork context the public-host fetch
+     i/o-timed-out (curl 28) while the same fetch with `registry.<fqdn>`
+     resolved to the gateway ClusterIP returned the registry 401 challenge
+     + a 200 from `/service/token`.
+
+Moves 2 + 3 are CLUSTER-wide (one ConfigMap / one DaemonSet template), so
+the DaemonSet performs them ONCE, guarded by a status flag, on whichever
+node converges first; every node still independently performs move 1 on
+its own containerd and writes its own per-node ack.
+
+ROLLBACK (v1): remove the `_default/hosts.toml` catch-all (restore the
+node's pre-cutover containerd behaviour) and revert the dfdaemon upstream
++ hostAlias to ghcr. Idempotent across restarts.
 
 Image phase: pre.
 */ -}}
@@ -81,24 +112,40 @@ spec:
           env:
             - name: HARBOR_PUBLIC_URL
               value: {{ .Values.sovereign.harborPublicURL | quote }}
-            # #4637 — node-reachable in-cluster Harbor coordinates. The kubelet
-            # (node network) resolves registry.<sov-fqdn> → the cluster's PUBLIC
-            # gateway EIP (the cloudinit /etc/hosts pin) and on hairpin-incapable
-            # clouds (Huawei kom4dc) i/o-timeouts dialing its own public EIP. The
-            # pivot script resolves the harbor-core Service ClusterIP at runtime
-            # (node-routable via kube-proxy/cilium) and writes the direct
-            # registry.<sov-fqdn> hosts.toml endpoint at http://<clusterip>:<port>
-            # so the kubelet's post-pivot catalyst-api image pull stays in-cluster.
-            - name: HARBOR_SERVICE_NAME
-              value: {{ .Values.registryPivot.inClusterHarbor.serviceName | quote }}
-            - name: HARBOR_SERVICE_NAMESPACE
-              value: {{ .Values.registryPivot.inClusterHarbor.serviceNamespace | quote }}
-            - name: HARBOR_SERVICE_PORT
-              value: {{ .Values.registryPivot.inClusterHarbor.servicePort | quote }}
             - name: STATUS_CONFIGMAP_NAME
               value: {{ .Values.status.configMapName | quote }}
             - name: STATUS_CONFIGMAP_NAMESPACE
               value: {{ .Release.Namespace | quote }}
+            # ── Dragonfly coordinates (the #4639 rewrite) ──────────────────
+            # The dfdaemon proxy every node's containerd mirrors through.
+            - name: DF_PROXY_PORT
+              value: {{ .Values.registryPivot.dragonfly.proxyPort | quote }}
+            # The bp-dragonfly mesh namespace + the per-node dfdaemon
+            # DaemonSet + seed-peer + their config ConfigMaps the upstream
+            # flip + hostAlias patch target.
+            - name: DF_NAMESPACE
+              value: {{ .Values.registryPivot.dragonfly.namespace | quote }}
+            - name: DF_CLIENT_DAEMONSET
+              value: {{ .Values.registryPivot.dragonfly.clientDaemonSet | quote }}
+            - name: DF_CLIENT_CONFIGMAP
+              value: {{ .Values.registryPivot.dragonfly.clientConfigMap | quote }}
+            - name: DF_SEED_STATEFULSET
+              value: {{ .Values.registryPivot.dragonfly.seedStatefulSet | quote }}
+            - name: DF_SEED_CONFIGMAP
+              value: {{ .Values.registryPivot.dragonfly.seedConfigMap | quote }}
+            # The node-routable Cilium gateway Service whose ClusterIP serves
+            # registry.<fqdn> (wildcard TLS + token realm). The hostAlias maps
+            # registry.<fqdn> → this ClusterIP so dfdaemon's hostNetwork pull
+            # never hairpins to the public EIP. The gateway HTTPS listener port
+            # is the canonical Catalyst NodePort (SOVEREIGN_GATEWAY_HTTPS_PORT).
+            - name: GATEWAY_SERVICE_NAME
+              value: {{ .Values.registryPivot.dragonfly.gatewayServiceName | quote }}
+            - name: GATEWAY_SERVICE_NAMESPACE
+              value: {{ .Values.registryPivot.dragonfly.gatewayServiceNamespace | quote }}
+            - name: GATEWAY_HTTPS_PORT
+              value: {{ .Values.registryPivot.dragonfly.gatewayHTTPSPort | quote }}
+            - name: DF_RESTART_ON_FLIP
+              value: {{ .Values.registryPivot.dragonfly.restartOnFlip | quote }}
             - name: NODE_NAME
               valueFrom:
                 fieldRef:
@@ -112,40 +159,26 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
           volumeMounts:
-            - name: registries-d
-              mountPath: /host/etc/rancher/k3s
-            # #3647: the containerd certs.d host-mirror dir k3s generates
-            # from registries.yaml at startup. The pivot loop regenerates
-            # the per-host hosts.toml files here so NEW pulls on the
-            # running node hit local Harbor without a k3s restart.
+            # #3647/#4639: the containerd certs.d host-mirror dir. The pivot
+            # loop writes the `_default/hosts.toml` catch-all that points
+            # containerd at the node-local dfdaemon proxy; containerd re-reads
+            # it per-pull so the pivot is effective on the RUNNING node.
             - name: containerd-certs-d
               mountPath: /host/var/lib/rancher/k3s/agent/etc/containerd/certs.d
             - name: pivot-script
               mountPath: /usr/local/bin/pivot.sh
               subPath: pivot.sh
               readOnly: true
-            - name: registries-yaml-tpl
-              mountPath: /etc/registry-pivot/registries.yaml.v2
-              subPath: registries.yaml.v2
-              readOnly: true
-            - name: registries-yaml-tpl
-              mountPath: /etc/registry-pivot/registries.yaml.v1
-              subPath: registries.yaml.v1
-              readOnly: true
           command: ["/bin/sh", "/usr/local/bin/pivot.sh"]
           resources:
             requests: { cpu: 25m, memory: 32Mi }
             limits:   { memory: 128Mi }
       volumes:
-        - name: registries-d
-          hostPath:
-            path: /etc/rancher/k3s
-            type: DirectoryOrCreate
-        # #3647: containerd host-mirror dir (k3s default data-dir; no
+        # #3647/#4639: containerd host-mirror dir (k3s default data-dir; no
         # --data-dir override in cloudinit-control-plane.tftpl). containerd
-        # re-reads <host>/hosts.toml here on every pull, so writing it makes
-        # the registry pivot effective on a RUNNING node — the missing piece
-        # that left hw149 resolving ghcr.io after cutover.
+        # re-reads <ns>/hosts.toml here on every pull, so writing the
+        # `_default/hosts.toml` catch-all makes the dfdaemon mirror effective
+        # on a RUNNING node — no k3s restart, no node reboot.
         - name: containerd-certs-d
           hostPath:
             path: /var/lib/rancher/k3s/agent/etc/containerd/certs.d
@@ -154,9 +187,6 @@ spec:
           configMap:
             name: registry-pivot-script
             defaultMode: 0755
-        - name: registries-yaml-tpl
-          configMap:
-            name: registry-pivot-registries-yaml
 ---
 # Step ConfigMap for catalyst-api consumer (mode=daemonset-wait).
 # The handler resolves the DaemonSet name from the `bp.openova.io/cutover-daemonset`
@@ -189,13 +219,30 @@ metadata:
 data:
   pivot.sh: |
     #!/bin/sh
-    # registry-pivot reconcile loop. Reads registriesYamlActive from the
-    # cutover-status ConfigMap; when the value changes, atomically
-    # replaces the host registries.yaml with v1 or v2 AND regenerates the
-    # containerd certs.d/<host>/hosts.toml mirror files so the pivot takes
-    # effect on the RUNNING node (registries.yaml alone is read only at k3s
-    # startup — see header comment + #3647).
-    set -eu
+    # shellcheck disable=SC2086  # ${CT} (= "--max-time 20") is word-split ON PURPOSE so the two tokens become separate curl args; quoting it would pass a single bad arg.
+    # registry-pivot reconcile loop (Dragonfly rewrite, #4639 Refs #4637).
+    # Reads registriesYamlActive from the cutover-status ConfigMap; when the
+    # value changes:
+    #   v2 → (a) write the containerd `_default/hosts.toml` catch-all that
+    #            mirrors EVERY registry namespace through the node-local
+    #            dfdaemon proxy http://127.0.0.1:${DF_PROXY_PORT};
+    #        (b) ONCE (cluster-wide, guarded): flip the dfdaemon (+ seed)
+    #            registryMirror.addr ghcr → the local Harbor, add a
+    #            registry.<fqdn> → cilium-gateway ClusterIP hostAlias, and
+    #            bounce dfdaemon so it reloads.
+    #   v1/rollback → remove the catch-all + revert the dfdaemon upstream/alias.
+    #
+    # NB on `set -u` (NOT `set -eu`): this is a long-running best-effort
+    # RECONCILE LOOP — every apiserver call is already individually guarded
+    # (--max-time + `|| true` / `&& … || …` fallbacks) and a transient miss is
+    # MEANT to be retried on the next 15s sweep, never to abort the loop. Under
+    # `errexit` any guarded sub-command that legitimately exits non-zero (a
+    # best-effort ack that 409s, a `[ test ]` that is false at the tail of an
+    # `&&` chain) would kill the whole DaemonSet pod and the per-node pivot
+    # would silently stall. `set -u` keeps unset-variable protection (the real
+    # footgun) without the errexit fragility. The daemonset-wait + per-node ack
+    # contract is unchanged.
+    set -u
 
     apk add --no-cache curl jq >/dev/null 2>&1 || true
 
@@ -203,301 +250,256 @@ data:
     token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
     cacert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
     cm_url="${api}/api/v1/namespaces/${STATUS_CONFIGMAP_NAMESPACE}/configmaps/${STATUS_CONFIGMAP_NAME}"
+    # EVERY apiserver call carries --max-time so a kom4dc network blip FAIL-FASTs
+    # instead of wedging the reconcile loop forever (a stuck-but-alive connection
+    # never trips curl's -f). 20s is generous for an in-cluster apiserver call;
+    # the 15s sweep retries any miss. Word-split intentionally ($CT not quoted).
+    CT="--max-time 20"
 
-    target=/host/etc/rancher/k3s/registries.yaml
-    src_v1=/etc/registry-pivot/registries.yaml.v1
-    src_v2=/etc/registry-pivot/registries.yaml.v2
+    # containerd host-mirror dir, mounted from the host. containerd re-reads
+    # certs.d/<ns>/hosts.toml PER PULL, so writing the `_default` catch-all
+    # here makes new pulls hit the local dfdaemon immediately — no k3s restart.
+    certs_d=/host/var/lib/rancher/k3s/agent/etc/containerd/certs.d
+    df_proxy="http://127.0.0.1:${DF_PROXY_PORT}"
+    last_state=""
 
-    # #4527 — fetch the harbor-robot-token Secret so the v1 (cold-start) mirror
-    # can authenticate the harbor.openova.io / bastion pull-through cache for
-    # PRIVATE ghcr.io/openova-io/* blobs. Without this the v1 registries.yaml's
-    # ghcr.io → harbor.openova.io/v2/proxy-ghcr redirect pulls ANONYMOUSLY → 401
-    # → a fresh catalyst-api roll wedges ImagePullBackOff before cutover runs.
-    # The runner SA already carries cluster-wide `secrets get` (rbac.yaml). The
-    # Secret is seeded by cloud-init (flux-system/harbor-robot-token, key
-    # `token`) and reflected; we read it from flux-system (the source ns). The
-    # value substitutes the __HARBOR_ROBOT_TOKEN__ placeholder in registries.
-    # yaml.v1 (mirrors the v2 __HARBOR_PUBLIC_URL__ substitution below). Best-
-    # effort + refreshed each sweep so a slow Secret reflect / token rotation is
-    # picked up; on a (rare) read miss the placeholder is left as-is and the
-    # next sweep retries — the v1 mirror only regresses to the prior anonymous
-    # behaviour, never worse.
-    harbor_robot_secret_url="${api}/api/v1/namespaces/flux-system/secrets/harbor-robot-token"
-    read_harbor_robot_token() {
-      curl -fsS --cacert "${cacert}" -H "Authorization: Bearer ${token}" \
-        "${harbor_robot_secret_url}" 2>/dev/null \
-        | jq -r '.data.token // empty' 2>/dev/null \
-        | base64 -d 2>/dev/null \
-        || true
+    # ── helpers ────────────────────────────────────────────────────────────
+
+    # The dfdaemon upstream the cutover flips TO: the cluster-LOCAL Harbor's
+    # public host, on the canonical gateway HTTPS port. dfdaemon resolves this
+    # host via the hostAlias we add (→ cilium-gateway ClusterIP), so the
+    # `:PORT` here MUST match the realm Harbor reflects (EXT_ENDPOINT host +
+    # the port the request carries) — keeping the token-realm follow-up on the
+    # same node-routable endpoint.
+    harbor_host=$(printf '%s' "${HARBOR_PUBLIC_URL}" | sed -E 's,^https?://,,; s,/$,,')
+    local_upstream="https://${harbor_host}:${GATEWAY_HTTPS_PORT}"
+
+    # Write (v2) or remove (v1) the containerd `_default/hosts.toml` catch-all
+    # that mirrors every registry namespace through the node-local dfdaemon
+    # proxy. `_default` is the containerd wildcard host-config dir — it applies
+    # to ANY registry that has no explicit certs.d/<host> dir, so a single file
+    # routes ghcr.io / docker.io / registry.k8s.io / … all through dfdaemon.
+    # skip_verify is moot (the endpoint is plain-HTTP loopback) but harmless.
+    write_default_mirror() {
+      mkdir -p "${certs_d}/_default"
+      {
+        echo "# managed by bp-self-sovereign-cutover registry-pivot (#4639) — DO NOT EDIT"
+        echo "[host.\"${df_proxy}\"]"
+        echo "  capabilities = [\"pull\", \"resolve\"]"
+        echo "  skip_verify = true"
+      } > "${certs_d}/_default/hosts.toml.new"
+      mv "${certs_d}/_default/hosts.toml.new" "${certs_d}/_default/hosts.toml"
+      echo "[registry-pivot]   wrote _default/hosts.toml -> ${df_proxy} (dfdaemon) on ${NODE_NAME}"
+    }
+    remove_default_mirror() {
+      rm -f "${certs_d}/_default/hosts.toml" 2>/dev/null || true
+      echo "[registry-pivot]   removed _default/hosts.toml (rollback) on ${NODE_NAME}"
     }
 
-    # #4637 — resolve the harbor-core Service ClusterIP from the in-cluster K8s
-    # API. THE KUBELET-HAIRPIN FIX. registries.yaml v2 mirrors every upstream
-    # (and the direct registry.<sov-fqdn> host) through __HARBOR_PUBLIC_URL__ =
-    # registry.<sov-fqdn>, which the NODE resolver pins to the cluster's PUBLIC
-    # gateway EIP (infra/providers/*/cloudinit-worker.tftpl /etc/hosts pin). On
-    # a hairpin-incapable cloud (Huawei kom4dc) the kubelet cannot dial its own
-    # cluster's public EIP → step-07's catalyst-api image pull ErrImagePulls
-    # `dial tcp <EIP>:443: i/o timeout` and the cutover wedges at 54%
-    # (catalyst-api-env-patch). The pod-network path works only because pods use
-    # CoreDNS → harbor-core ClusterIP; the kubelet uses the node resolver, not
-    # CoreDNS, so it never sees the ClusterIP unless we hand it one. A Service
-    # ClusterIP IS node-routable (kube-proxy/cilium program it on the host net),
-    # so resolving it here and pointing the direct registry.<sov-fqdn> hosts.toml
-    # at http://<clusterip>:<port> keeps the kubelet pull in-cluster — never the
-    # un-hairpinnable public EIP. harbor-core serves PLAIN HTTP on its ClusterIP
-    # (platform/harbor expose.type=clusterIP, expose.tls.enabled=false; TLS
-    # terminates at the Gateway, NOT the Service), so the endpoint is http:// and
-    # carries NO cert to verify (trust is the cluster network — same rationale as
-    # the #4557 skip_verify). Best-effort: on a read miss the caller falls back to
-    # the public-host endpoint (prior behaviour) and the next sweep retries.
-    harbor_svc_url="${api}/api/v1/namespaces/${HARBOR_SERVICE_NAMESPACE}/services/${HARBOR_SERVICE_NAME}"
-    read_harbor_clusterip() {
-      curl -fsS --cacert "${cacert}" -H "Authorization: Bearer ${token}" \
-        "${harbor_svc_url}" 2>/dev/null \
+    # Resolve the cilium-gateway Service ClusterIP — node-routable (kube-proxy/
+    # cilium program it on the host net), serves registry.<fqdn> (wildcard TLS
+    # + token realm). The hostAlias maps registry.<fqdn> → this IP so dfdaemon's
+    # hostNetwork pull never hairpins to the public EIP. Best-effort: empty on a
+    # read miss → the flip is deferred to a later sweep (re-fires while the
+    # alias is still missing), never wedging on a transient API miss.
+    gw_svc_url="${api}/api/v1/namespaces/${GATEWAY_SERVICE_NAMESPACE}/services/${GATEWAY_SERVICE_NAME}"
+    read_gateway_clusterip() {
+      curl -fsS ${CT} --cacert "${cacert}" -H "Authorization: Bearer ${token}" \
+        "${gw_svc_url}" 2>/dev/null \
         | jq -r '.spec.clusterIP // empty' 2>/dev/null \
         || true
     }
 
-    # #3671: write this node's per-node ack into the status ConfigMap so
-    # catalyst-api's step-04 daemonset-wait can assert acks ==
-    # DesiredNumberScheduled — proving EVERY node actually swapped to the
-    # local-Harbor (v2) file, not merely that the DS Pods are Ready. The
-    # key is node.<NODE_NAME>.registriesYaml. Uses a JSON merge-patch (the
-    # SA already has configmaps patch RBAC via the chart's role). Dots in
-    # the node name are fine — they are part of the ConfigMap DATA KEY, not
-    # a JSONPath. Best-effort: a failed ack just means the wait keeps
-    # polling until the next sweep retries it.
+    # Patch a dfdaemon-family ConfigMap's dfdaemon.yaml registryMirror.addr to
+    # ${1}. The config is a single YAML string under data."dfdaemon.yaml"; we
+    # read it, rewrite ONLY the registryMirror.addr line, and merge-patch it
+    # back. Idempotent. SCOPING IS LOAD-BEARING: the dfdaemon.yaml carries
+    # MULTIPLE `addr:` keys — `manager.addr: http://dragonfly-manager…:65003`
+    # (the gRPC control-plane the dfdaemon health-checks at boot) AND
+    # `proxy.registryMirror.addr` (the registry upstream we flip). A blanket
+    # `sed s/addr: …/` would ALSO rewrite the manager addr → dfdaemon
+    # ConnectError on startup → CrashLoopBackOff (caught live on the kom4dc
+    # seed-client). So the awk rewrites the `addr:` ONLY while inside a
+    # `registryMirror:` block (set the in-block flag on a line ending in
+    # `registryMirror:`; clear it when indentation returns to <= the
+    # registryMirror key's indent). want_addr is passed via -v (no shell
+    # interpolation into the awk program → metacharacter-safe).
+    patch_df_configmap_addr() {
+      cm_name="$1"; want_addr="$2"
+      url="${api}/api/v1/namespaces/${DF_NAMESPACE}/configmaps/${cm_name}"
+      cur=$(curl -fsS ${CT} --cacert "${cacert}" -H "Authorization: Bearer ${token}" "${url}" 2>/dev/null \
+        | jq -r '.data["dfdaemon.yaml"] // empty' 2>/dev/null || true)
+      [ -z "${cur}" ] && { echo "[registry-pivot]   WARN ${cm_name} dfdaemon.yaml unreadable; deferring upstream flip"; return 1; }
+      new=$(printf '%s' "${cur}" | awk -v want="${want_addr}" '
+        # compute leading-space count of a line
+        function indent(s,   n){ n=0; while (substr(s,n+1,1)==" ") n++; return n }
+        {
+          if ($0 ~ /registryMirror:[[:space:]]*$/) { inblk=1; blkind=indent($0); print; next }
+          if (inblk) {
+            ci=indent($0)
+            # a non-blank line at indent <= the registryMirror key ends the block
+            if ($0 ~ /[^[:space:]]/ && ci <= blkind) inblk=0
+          }
+          if (inblk && $0 ~ /^[[:space:]]*addr:[[:space:]]*https?:\/\//) {
+            sub(/addr:[[:space:]]*https?:\/\/[^[:space:]]+/, "addr: " want)
+          }
+          print
+        }')
+      [ "${new}" = "${cur}" ] && { echo "[registry-pivot]   ${cm_name} upstream already ${want_addr}"; return 0; }
+      patch=$(jq -cn --arg v "${new}" '{data: {"dfdaemon.yaml": $v}}')
+      if curl -fsS ${CT} -X PATCH --cacert "${cacert}" -H "Authorization: Bearer ${token}" \
+        -H "Content-Type: application/merge-patch+json" --data "${patch}" "${url}" >/dev/null 2>&1; then
+        echo "[registry-pivot]   flipped ${cm_name} dfdaemon upstream -> ${want_addr}"
+        return 0
+      fi
+      echo "[registry-pivot]   WARN failed to patch ${cm_name} upstream (will retry next sweep)"
+      return 1
+    }
+
+    # Set (v2) / clear (v1) the registry.<fqdn> → gateway-ClusterIP hostAlias on
+    # a dfdaemon-family workload (DaemonSet or StatefulSet) pod template. Adding
+    # hostAliases switches the hostNetwork pod from the node's bind-mounted
+    # /etc/hosts (which carries the public-EIP pin) to a kubelet-managed hosts
+    # file that ALSO contains our alias → the gateway ClusterIP entry wins the
+    # connection (proven live: curl picks the routable address). A strategic-
+    # merge patch on spec.template.spec.hostAliases re-rolls the pods.
+    patch_workload_hostalias() {
+      kind="$1"; name="$2"; gwip="$3"   # kind ∈ daemonsets|statefulsets
+      url="${api}/apis/apps/v1/namespaces/${DF_NAMESPACE}/${kind}/${name}"
+      if [ -n "${gwip}" ]; then
+        patch=$(jq -cn --arg ip "${gwip}" --arg h "${harbor_host}" \
+          '{spec:{template:{spec:{hostAliases:[{ip:$ip,hostnames:[$h]}]}}}}')
+      else
+        patch='{"spec":{"template":{"spec":{"hostAliases":[]}}}}'
+      fi
+      if curl -fsS ${CT} -X PATCH --cacert "${cacert}" -H "Authorization: Bearer ${token}" \
+        -H "Content-Type: application/strategic-merge-patch+json" --data "${patch}" "${url}" >/dev/null 2>&1; then
+        echo "[registry-pivot]   patched ${kind}/${name} hostAliases (${harbor_host} -> ${gwip:-<cleared>})"
+        return 0
+      fi
+      echo "[registry-pivot]   WARN failed to patch ${kind}/${name} hostAliases (will retry next sweep)"
+      return 1
+    }
+
+    # Roll dfdaemon (+ seed) so they reload the flipped upstream. A hostAlias
+    # patch already re-rolls them; this is the explicit nudge for the addr-only
+    # change and is gated by DF_RESTART_ON_FLIP. Uses the restartedAt annotation
+    # (kubectl rollout restart equivalent) via a strategic-merge patch.
+    restart_workload() {
+      kind="$1"; name="$2"
+      [ "${DF_RESTART_ON_FLIP}" = "true" ] || return 0
+      url="${api}/apis/apps/v1/namespaces/${DF_NAMESPACE}/${kind}/${name}"
+      stamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+      patch=$(jq -cn --arg t "${stamp}" \
+        '{spec:{template:{metadata:{annotations:{"kubectl.kubernetes.io/restartedAt":$t}}}}}')
+      curl -fsS ${CT} -X PATCH --cacert "${cacert}" -H "Authorization: Bearer ${token}" \
+        -H "Content-Type: application/strategic-merge-patch+json" --data "${patch}" "${url}" >/dev/null 2>&1 \
+        && echo "[registry-pivot]   rolled ${kind}/${name}" \
+        || echo "[registry-pivot]   WARN failed to roll ${kind}/${name}"
+    }
+
+    # The cluster-wide dfdaemon flip (upstream + hostAlias) — performed ONCE.
+    # The status key dragonflyUpstream=local is the cluster-scope guard: the
+    # first node to converge sets it; the rest skip. Returns 0 only when the
+    # full flip (both ConfigMaps + both hostAliases) succeeded so the guard is
+    # set; a partial failure leaves the guard unset → a later sweep retries.
+    cm_patch_status() {
+      key="$1"; val="$2"
+      p=$(jq -cn --arg k "${key}" --arg v "${val}" '{data: {($k): $v}}')
+      curl -fsS ${CT} -X PATCH --cacert "${cacert}" -H "Authorization: Bearer ${token}" \
+        -H "Content-Type: application/merge-patch+json" --data "${p}" "${cm_url}" >/dev/null 2>&1 || true
+    }
+    df_flip_to_local() {
+      already=$(curl -fsS ${CT} --cacert "${cacert}" -H "Authorization: Bearer ${token}" "${cm_url}" 2>/dev/null \
+        | jq -r '.data.dragonflyUpstream // empty' 2>/dev/null || true)
+      if [ "${already}" = "local" ]; then
+        return 0
+      fi
+      gwip=$(read_gateway_clusterip)
+      if [ -z "${gwip}" ] || [ "${gwip}" = "None" ]; then
+        echo "[registry-pivot]   WARN cilium-gateway ClusterIP unresolved; deferring dfdaemon flip on ${NODE_NAME}"
+        return 1
+      fi
+      echo "[registry-pivot]   cilium-gateway ClusterIP ${gwip} -> hostAlias ${harbor_host} on ${NODE_NAME}"
+      ok=0
+      patch_df_configmap_addr "${DF_CLIENT_CONFIGMAP}" "${local_upstream}" || ok=1
+      [ -n "${DF_SEED_CONFIGMAP}" ] && { patch_df_configmap_addr "${DF_SEED_CONFIGMAP}" "${local_upstream}" || ok=1; }
+      patch_workload_hostalias daemonsets "${DF_CLIENT_DAEMONSET}" "${gwip}" || ok=1
+      [ -n "${DF_SEED_STATEFULSET}" ] && { patch_workload_hostalias statefulsets "${DF_SEED_STATEFULSET}" "${gwip}" || ok=1; }
+      restart_workload daemonsets "${DF_CLIENT_DAEMONSET}"
+      [ -n "${DF_SEED_STATEFULSET}" ] && restart_workload statefulsets "${DF_SEED_STATEFULSET}"
+      if [ "${ok}" = "0" ]; then
+        cm_patch_status dragonflyUpstream local
+        echo "[registry-pivot]   dfdaemon flipped to LOCAL Harbor ${local_upstream} (cluster-wide guard set)"
+        return 0
+      fi
+      echo "[registry-pivot]   dfdaemon flip incomplete; guard NOT set, will retry next sweep on ${NODE_NAME}"
+      return 1
+    }
+    df_revert_to_ghcr() {
+      patch_df_configmap_addr "${DF_CLIENT_CONFIGMAP}" "https://ghcr.io" || true
+      if [ -n "${DF_SEED_CONFIGMAP}" ]; then
+        patch_df_configmap_addr "${DF_SEED_CONFIGMAP}" "https://ghcr.io" || true
+      fi
+      patch_workload_hostalias daemonsets "${DF_CLIENT_DAEMONSET}" "" || true
+      if [ -n "${DF_SEED_STATEFULSET}" ]; then
+        patch_workload_hostalias statefulsets "${DF_SEED_STATEFULSET}" "" || true
+      fi
+      cm_patch_status dragonflyUpstream ghcr
+    }
+
+    # #3671: per-node ack the daemonset-wait counts (proves EVERY node swapped
+    # its containerd to the dfdaemon mirror, not merely that the DS Pods are
+    # Ready). Key node.<NODE>.registriesYaml. Best-effort; retried each sweep.
     write_node_ack() {
-      ack_val="$1"   # "v1" | "v2" | "rollback"
+      ack_val="$1"
       ack_key="node.${NODE_NAME}.registriesYaml"
       patch=$(jq -cn --arg k "${ack_key}" --arg v "${ack_val}" '{data: {($k): $v}}')
-      if curl -fsS -X PATCH \
-        --cacert "${cacert}" \
-        -H "Authorization: Bearer ${token}" \
-        -H "Content-Type: application/merge-patch+json" \
-        --data "${patch}" \
-        "${cm_url}" >/dev/null 2>&1; then
-        echo "[registry-pivot]   acked ${ack_key}=${ack_val}"
-      else
-        echo "[registry-pivot]   WARN failed to ack ${ack_key}=${ack_val} (will retry next sweep)"
-      fi
-    }
-    # #3647: the containerd host-mirror dir, mounted from the host. k3s
-    # generates these files from registries.yaml at startup and containerd
-    # re-reads them per pull, so writing them here makes new pulls hit the
-    # desired registry immediately — no k3s restart, no node reboot.
-    certs_d=/host/var/lib/rancher/k3s/agent/etc/containerd/certs.d
-    last_state=""
-
-    # The 7 canonical upstream hosts the pivot mirrors, kept in lockstep
-    # with registries.yaml.{v1,v2} below (and .Values.harbor.proxyProjects).
-    # "<upstream-host> <proxy-project>" — the proxy path under the mirror.
-    upstream_mirrors="ghcr.io proxy-ghcr
-    docker.io proxy-docker
-    registry.k8s.io proxy-k8s
-    gcr.io proxy-gcr
-    quay.io proxy-quay
-    xpkg.upbound.io proxy-xpkg
-    public.ecr.aws proxy-ecr"
-
-    # Regenerate certs.d/<host>/hosts.toml for every mirrored upstream,
-    # pointing each at https://<mirror_host>/v2/<proxy-project>. This is
-    # the containerd host-dir form k3s itself emits from registries.yaml;
-    # override_path=true makes containerd use the literal /v2/<proxy>/...
-    # path (matching the registries.yaml `endpoint` rewrite) instead of
-    # appending the image path to the host root. capabilities pull+resolve
-    # is all a proxy-cache mirror needs. Written atomically per file.
-    # #4557 (Refs #3379): when the mirror host is the cluster's OWN in-cluster
-    # Harbor (registry.<sov-fqdn>), its wildcard cert is served by the BOOTSTRAP
-    # issuer letsencrypt-dns01-staging-powerdns (LE-STAGING, untrusted) on a
-    # fresh prov, so containerd's pull HEAD x509-fails ("certificate signed by
-    # unknown authority") on BOTH the mirror-redirect entries AND any DIRECT
-    # `registry.<sov-fqdn>/...` reference. Step-07 pivots catalyst-api's image
-    # to global.imageRegistry=registry.<sov-fqdn>, so the rolled pod
-    # ImagePullBackOff'd at the containerd layer (live c39f0cd4455b7a46). Gate a
-    # `skip_verify = true` on the in-cluster-Harbor host hosts.toml exactly like
-    # the cold-start v1 mirror does for the bastion endpoint (registries.yaml v1
-    # tls.insecure_skip_verify). The MOTHERSHIP host (v1/rollback path) keeps
-    # verify — only the local LE-staging registry is skipped. Same #4557
-    # cutover-tail pattern as the step-06 helm-CLI flags, one layer lower
-    # (containerd, not a script). in_cluster_skip ($2) is "true" only on the v2
-    # (in-cluster Harbor) path.
-    #
-    # #4637 — node_endpoint ($3) is a NODE-REACHABLE scheme://host[:port] for the
-    # in-cluster Harbor (e.g. http://10.96.9.166:80, the harbor-core ClusterIP).
-    # When set (v2 path, ClusterIP resolved) the mirror-redirect entries AND the
-    # direct registry.<sov-fqdn> host entry point the containerd `[host]` block at
-    # THIS endpoint instead of https://<mirror_host>, so the kubelet's pull is
-    # routed to the node-routable ClusterIP rather than the un-hairpinnable public
-    # gateway EIP. The certs.d `server`/dir name stays the PUBLIC host so a pull of
-    # `registry.<sov-fqdn>/...` (the step-07 catalyst-api image pin) and the
-    # upstream-host dirs still MATCH containerd's host lookup — only the resolved
-    # endpoint is the in-cluster ClusterIP. Empty = fall back to the public host
-    # (prior #4557 behaviour). A ClusterIP endpoint is plain http with no cert, so
-    # skip_verify is moot there but harmless.
-    write_hosts_toml() {
-      mirror_host="$1"   # bare host[:port], no scheme — the PUBLIC registry host
-      in_cluster_skip="${2:-false}"
-      node_endpoint="${3:-}"   # #4637: node-reachable scheme://host[:port], or empty
-      # Endpoint the containerd [host] block dials. node_endpoint wins (#4637);
-      # else the historical https://<public-host> (kept for the rollback path and
-      # the fallback when the ClusterIP could not be resolved).
-      if [ -n "${node_endpoint}" ]; then
-        ep_base="${node_endpoint%/}"
-      else
-        ep_base="https://${mirror_host}"
-      fi
-      mkdir -p "${certs_d}"
-      printf '%s\n' "${upstream_mirrors}" | while read -r up proj; do
-        [ -z "${up}" ] && continue
-        d="${certs_d}/${up}"
-        mkdir -p "${d}"
-        {
-          echo "# managed by bp-self-sovereign-cutover registry-pivot (#3647 #4557 #4637) — DO NOT EDIT"
-          echo "server = \"https://${up}\""
-          echo ""
-          echo "[host.\"${ep_base}/v2/${proj}\"]"
-          echo "  capabilities = [\"pull\", \"resolve\"]"
-          echo "  override_path = true"
-          [ "${in_cluster_skip}" = "true" ] && echo "  skip_verify = true"
-        } > "${d}/hosts.toml.new"
-        mv "${d}/hosts.toml.new" "${d}/hosts.toml"
-      done
-      # #4557: a DIRECT host hosts.toml for the in-cluster Harbor itself so a
-      # `registry.<sov-fqdn>/openova-io/...` reference (NOT a mirror-rewritten
-      # upstream — e.g. the step-07 catalyst-api image pin) also skips the
-      # LE-staging cert. Only on the v2 (in-cluster) path; the mothership
-      # rollback path never writes a skip_verify direct host.
-      # #4637: the dir name + `server` stay the PUBLIC registry host (containerd
-      # keys the host-config dir off the image-ref host = registry.<sov-fqdn>),
-      # but the [host] ENDPOINT is the node-reachable ClusterIP so the kubelet
-      # never dials the public gateway EIP.
-      if [ "${in_cluster_skip}" = "true" ]; then
-        hd="${certs_d}/${mirror_host}"
-        mkdir -p "${hd}"
-        {
-          echo "# managed by bp-self-sovereign-cutover registry-pivot (#4557 #4637) — DO NOT EDIT"
-          echo "server = \"https://${mirror_host}/v2\""
-          echo ""
-          echo "[host.\"${ep_base}/v2\"]"
-          echo "  capabilities = [\"pull\", \"resolve\"]"
-          echo "  skip_verify = true"
-        } > "${hd}/hosts.toml.new"
-        mv "${hd}/hosts.toml.new" "${hd}/hosts.toml"
-        echo "[registry-pivot]   wrote direct ${mirror_host}/hosts.toml -> ${ep_base} (skip_verify) on ${NODE_NAME}"
-      fi
-      echo "[registry-pivot]   wrote certs.d hosts.toml for $(printf '%s\n' "${upstream_mirrors}" | grep -c .) upstreams -> ${ep_base} on ${NODE_NAME}"
+      curl -fsS ${CT} -X PATCH --cacert "${cacert}" -H "Authorization: Bearer ${token}" \
+        -H "Content-Type: application/merge-patch+json" --data "${patch}" "${cm_url}" >/dev/null 2>&1 \
+        && echo "[registry-pivot]   acked ${ack_key}=${ack_val}" \
+        || echo "[registry-pivot]   WARN failed to ack ${ack_key}=${ack_val} (will retry next sweep)"
     }
 
     apply_state() {
       desired="$1"
       case "${desired}" in
         v2)
-          harbor_host=$(printf '%s' "${HARBOR_PUBLIC_URL}" | sed -E 's,^https?://,,; s,/$,,')
-          sed -e "s,__HARBOR_PUBLIC_URL__,${harbor_host},g" "${src_v2}" > "${target}.new"
-          mv "${target}.new" "${target}"
-          chmod 600 "${target}"
-          echo "[registry-pivot]   wrote v2 to ${target} on ${NODE_NAME}"
-          # #3647: mirror the pivot into the live containerd host-dir so a
-          # pod rolled AFTER cutover pulls from local Harbor, not ghcr.io.
-          # #4557: in-cluster Harbor is LE-staging → skip_verify=true (2nd arg).
-          # #4637: resolve the harbor-core Service ClusterIP (node-routable via
-          # kube-proxy/cilium) and route the containerd [host] endpoints at it so
-          # the kubelet pull NEVER dials the un-hairpinnable public gateway EIP
-          # that registry.<sov-fqdn> resolves to on the node. harbor-core serves
-          # plain HTTP on its ClusterIP (expose.type=clusterIP, tls disabled) →
-          # the endpoint is http://<clusterip>:<port>. On a resolve miss the 3rd
-          # arg is empty and write_hosts_toml falls back to the public host (prior
-          # behaviour) — never worse than before, and the next sweep retries.
-          harbor_clusterip=$(read_harbor_clusterip)
-          node_endpoint=""
-          if [ -n "${harbor_clusterip}" ] && [ "${harbor_clusterip}" != "None" ]; then
-            node_endpoint="http://${harbor_clusterip}:${HARBOR_SERVICE_PORT}"
-            echo "[registry-pivot]   harbor-core ClusterIP ${harbor_clusterip}:${HARBOR_SERVICE_PORT} -> node-reachable mirror endpoint ${node_endpoint} on ${NODE_NAME}"
-          else
-            echo "[registry-pivot]   WARN harbor-core ClusterIP unresolved; v2 mirror falls back to public host ${harbor_host} (kubelet may hairpin-fail on no-hairpin clouds) on ${NODE_NAME}"
-          fi
-          write_hosts_toml "${harbor_host}" "true" "${node_endpoint}"
-          # #3671: ack this node's v2 swap so step-04 can count acks.
+          # Per-node: point this node's containerd at the local dfdaemon.
+          write_default_mirror
+          # Cluster-wide (guarded): flip the dfdaemon upstream + hostAlias.
+          df_flip_to_local || true
           write_node_ack v2
           ;;
         v1|rollback|*)
-          # #4527 — substitute the harbor robot token into the v1 mirror's
-          # `configs:` auth so the cold-start harbor.openova.io / bastion
-          # pull-through authenticates PRIVATE ghcr.io/openova-io/* blobs
-          # (else anonymous → 401 → fresh catalyst-api roll wedges before
-          # cutover). awk (not sed) so a token with /+=. metacharacters is
-          # injected literally with zero escaping. If the Secret read misses
-          # the placeholder is left intact (next sweep retries) — never worse
-          # than the prior anonymous v1.
-          harbor_robot_token=$(read_harbor_robot_token)
-          if [ -n "${harbor_robot_token}" ]; then
-            awk -v tok="${harbor_robot_token}" \
-              '{ gsub(/__HARBOR_ROBOT_TOKEN__/, tok); print }' \
-              "${src_v1}" > "${target}.new"
-          else
-            echo "[registry-pivot]   WARN harbor-robot-token unavailable; v1 mirror auth left as placeholder (will retry next sweep)"
-            cp "${src_v1}" "${target}.new"
-          fi
-          mv "${target}.new" "${target}"
-          chmod 600 "${target}"
-          echo "[registry-pivot]   wrote v1 to ${target} on ${NODE_NAME}"
-          # #3647: rollback must also be effective on the running node —
-          # point the live containerd host-dir back at mothership Harbor.
-          mothership_host=$(printf '%s' "{{ .Values.upstream.mothershipHarborURL }}" | sed -E 's,^https?://,,; s,/$,,')
-          write_hosts_toml "${mothership_host}"
-          # #3671: ack this node back to v1 so a rollback de-counts it.
+          remove_default_mirror
+          df_revert_to_ghcr || true
           write_node_ack v1
           ;;
       esac
     }
 
     while true; do
-      desired=$(curl -fsS --cacert "${cacert}" -H "Authorization: Bearer ${token}" "${cm_url}" 2>/dev/null \
+      desired=$(curl -fsS ${CT} --cacert "${cacert}" -H "Authorization: Bearer ${token}" "${cm_url}" 2>/dev/null \
         | jq -r '.data.registriesYamlActive // "v1"' 2>/dev/null \
         || echo "v1")
       desired=${desired:-v1}
 
-      # #4527 — re-apply v1/rollback if the on-host registries.yaml still
-      # carries the unsubstituted __HARBOR_ROBOT_TOKEN__ placeholder. The
-      # state-change guard below fires apply_state only ONCE per state; if the
-      # harbor-robot-token Secret had not yet reflected on that first sweep the
-      # auth would stay a placeholder forever. This makes the loop retry the
-      # token injection on a later sweep (once the Secret is readable) WITHOUT
-      # re-applying on every tick after it succeeds. Only the v1/rollback file
-      # carries the placeholder; v2 has none, so this never fires under v2.
-      needs_auth_retry=0
-      if [ "${desired}" != "v2" ] \
-        && [ "${desired}" = "${last_state}" ] \
-        && grep -q '__HARBOR_ROBOT_TOKEN__' "${target}" 2>/dev/null; then
-        needs_auth_retry=1
-      fi
-
-      # #4637 — re-apply v2 if the direct in-cluster Harbor hosts.toml still
-      # points its [host] endpoint at the PUBLIC registry host (https://<host>)
-      # instead of a node-reachable ClusterIP. apply_state fires only ONCE per
-      # state, so if the harbor-core Service was not yet resolvable (or its
-      # ClusterIP not yet assigned) on the first v2 sweep, the mirror would stay
-      # on the un-hairpinnable public-EIP endpoint forever and step-07's pull
-      # would keep i/o-timing-out. This retries the ClusterIP resolution on a
-      # later sweep (once the Service is readable) WITHOUT re-applying every tick
-      # after it converges. Only meaningful under v2; the direct host dir is
-      # certs_d/<public-host>, written only on the v2 path.
-      needs_node_endpoint_retry=0
+      # #4639 — re-apply v2 if the cluster-wide dfdaemon flip has not yet been
+      # confirmed (guard dragonflyUpstream != local). apply_state fires only
+      # ONCE per state, so if the cilium-gateway Service was not yet resolvable
+      # on the first v2 sweep the flip would be skipped forever. This retries
+      # the flip on a later sweep WITHOUT re-applying every tick once converged.
+      needs_flip_retry=0
       if [ "${desired}" = "v2" ] && [ "${desired}" = "${last_state}" ]; then
-        v2_host=$(printf '%s' "${HARBOR_PUBLIC_URL}" | sed -E 's,^https?://,,; s,/$,,')
-        v2_direct_toml="${certs_d}/${v2_host}/hosts.toml"
-        if grep -q "\[host.\"https://${v2_host}/v2\"\]" "${v2_direct_toml}" 2>/dev/null; then
-          needs_node_endpoint_retry=1
-        fi
+        cur_up=$(curl -fsS ${CT} --cacert "${cacert}" -H "Authorization: Bearer ${token}" "${cm_url}" 2>/dev/null \
+          | jq -r '.data.dragonflyUpstream // empty' 2>/dev/null || true)
+        [ "${cur_up}" != "local" ] && needs_flip_retry=1
       fi
 
-      if [ "${desired}" != "${last_state}" ] || [ "${needs_auth_retry}" = "1" ] || [ "${needs_node_endpoint_retry}" = "1" ]; then
-        if [ "${needs_auth_retry}" = "1" ]; then
-          echo "[registry-pivot] re-applying ${desired} to inject harbor-robot-token auth (placeholder still present) on ${NODE_NAME}"
-        elif [ "${needs_node_endpoint_retry}" = "1" ]; then
-          echo "[registry-pivot] re-applying ${desired} to resolve node-reachable harbor ClusterIP (direct hosts.toml still on public host) on ${NODE_NAME}"
+      if [ "${desired}" != "${last_state}" ] || [ "${needs_flip_retry}" = "1" ]; then
+        if [ "${needs_flip_retry}" = "1" ]; then
+          echo "[registry-pivot] re-applying ${desired} to complete the dfdaemon upstream flip (guard not yet local) on ${NODE_NAME}"
         else
           echo "[registry-pivot] state change ${last_state:-<none>} -> ${desired} on ${NODE_NAME}"
         fi
@@ -509,132 +511,4 @@ data:
 
       sleep 15
     done
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: registry-pivot-registries-yaml
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}
-    app.kubernetes.io/component: cutover-daemonset
-data:
-  # Cold-start registries.yaml v1 — soft-tethered to mothership Harbor.
-  # Wave 5.110 (#2462): include optional `harbor.openova.io → bastion`
-  # mirror when .Values.upstream.harborProxyMirrorEndpoint is set. On
-  # Huawei Sovereigns this MUST be set to http://212.72.24.20:5000 (the
-  # bastion-openova registry:2 cache) so containerd's resolution chain
-  # for ghcr.io / quay.io / etc. (which gets rewritten to
-  # harbor.openova.io/v2/proxy-X) flows through bastion instead of
-  # hitting Contabo NAT directly. Hetzner Sovereigns leave it empty.
-  #
-  # #4527 — PRIVATE-ghcr AUTH on the cold-start mirror. The ghcr.io →
-  # harbor.openova.io/v2/proxy-ghcr redirect (and, on Huawei, the further
-  # harbor.openova.io → bastion redirect) means containerd resolves a
-  # PRIVATE `ghcr.io/openova-io/*` blob against the MIRROR host, not ghcr.io.
-  # The pod's `imagePullSecrets: [ghcr-pull]` authenticates `ghcr.io` (the
-  # ORIGINAL registry) — NOT the rewritten mirror host. Without a `configs:`
-  # auth entry for the mirror host the pull is ANONYMOUS → harbor proxy-ghcr
-  # returns 401 → a fresh catalyst-api roll (deploy-bot pin bump, pod
-  # reschedule, new microservice) wedges ImagePullBackOff and api.<fqdn> 503s
-  # before cutover even runs (root-caused live on keystone dep 25aadcfc).
-  # The fix carries the SAME `robot$openova-bot` harbor-robot-token auth the
-  # BOOTSTRAP node already pins in /etc/rancher/k3s/registries.yaml
-  # (infra/providers/{hetzner,huawei}/main.tf `configs.harbor.openova.io.auth`).
-  # The token is a Secret, so `__HARBOR_ROBOT_TOKEN__` is a placeholder the
-  # pivot script substitutes in-pod from the in-cluster harbor-robot-token
-  # Secret (exactly like __HARBOR_PUBLIC_URL__ in v2). The mothership host
-  # `harbor.openova.io` ALWAYS gets the auth (it is the direct mirror on
-  # Hetzner and the upstream of the bastion redirect on Huawei); the bastion
-  # endpoint host ALSO gets the auth + insecure_skip_verify when set (Huawei).
-  registries.yaml.v1: |
-    mirrors:
-      ghcr.io:
-        endpoint:
-          - "{{ .Values.upstream.mothershipHarborURL }}/v2/proxy-ghcr"
-      docker.io:
-        endpoint:
-          - "{{ .Values.upstream.mothershipHarborURL }}/v2/proxy-docker"
-      registry.k8s.io:
-        endpoint:
-          - "{{ .Values.upstream.mothershipHarborURL }}/v2/proxy-k8s"
-      gcr.io:
-        endpoint:
-          - "{{ .Values.upstream.mothershipHarborURL }}/v2/proxy-gcr"
-      quay.io:
-        endpoint:
-          - "{{ .Values.upstream.mothershipHarborURL }}/v2/proxy-quay"
-      xpkg.upbound.io:
-        endpoint:
-          - "{{ .Values.upstream.mothershipHarborURL }}/v2/proxy-xpkg"
-      public.ecr.aws:
-        endpoint:
-          - "{{ .Values.upstream.mothershipHarborURL }}/v2/proxy-ecr"
-      {{- if .Values.upstream.harborProxyMirrorEndpoint }}
-      harbor.openova.io:
-        endpoint:
-          - "{{ .Values.upstream.harborProxyMirrorEndpoint }}"
-      {{- end }}
-    configs:
-      # #4527 — harbor-robot-token auth for the mothership Harbor host the
-      # ghcr.io (and the other 6 upstreams) mirror redirects resolve against.
-      # __HARBOR_ROBOT_TOKEN__ is substituted in-pod by the pivot script.
-      "{{ regexReplaceAll "^https?://" .Values.upstream.mothershipHarborURL "" }}":
-        auth:
-          username: "robot$openova-bot"
-          password: "__HARBOR_ROBOT_TOKEN__"
-      {{- if .Values.upstream.harborProxyMirrorEndpoint }}
-      # #4527 — Huawei bastion endpoint: the actual pull host after the
-      # harbor.openova.io → bastion redirect. Needs the SAME robot auth (the
-      # bastion registry:2 cache authenticates the private proxy-ghcr blobs)
-      # AND insecure_skip_verify (it is http, no TLS).
-      "{{ regexReplaceAll "^https?://" .Values.upstream.harborProxyMirrorEndpoint "" }}":
-        auth:
-          username: "robot$openova-bot"
-          password: "__HARBOR_ROBOT_TOKEN__"
-        tls:
-          insecure_skip_verify: true
-      {{- end }}
-  # Hot-state registries.yaml v2 — independent. __HARBOR_PUBLIC_URL__
-  # placeholder is replaced in-pod by the pivot script.
-  registries.yaml.v2: |
-    mirrors:
-      ghcr.io:
-        endpoint:
-          - "https://__HARBOR_PUBLIC_URL__/v2/proxy-ghcr"
-      docker.io:
-        endpoint:
-          - "https://__HARBOR_PUBLIC_URL__/v2/proxy-docker"
-      registry.k8s.io:
-        endpoint:
-          - "https://__HARBOR_PUBLIC_URL__/v2/proxy-k8s"
-      gcr.io:
-        endpoint:
-          - "https://__HARBOR_PUBLIC_URL__/v2/proxy-gcr"
-      quay.io:
-        endpoint:
-          - "https://__HARBOR_PUBLIC_URL__/v2/proxy-quay"
-      xpkg.upbound.io:
-        endpoint:
-          - "https://__HARBOR_PUBLIC_URL__/v2/proxy-xpkg"
-      public.ecr.aws:
-        endpoint:
-          - "https://__HARBOR_PUBLIC_URL__/v2/proxy-ecr"
-    # #4557 (Refs #3379): the in-cluster Harbor (registry.<sov-fqdn>) serves an
-    # LE-STAGING (untrusted) wildcard on a fresh prov. Without this `configs:`
-    # tls skip, a genuine k3s restart regenerates certs.d/<host>/hosts.toml from
-    # THIS file WITHOUT skip_verify → every mirror-redirect AND direct
-    # `registry.<sov-fqdn>/...` pull x509-fails ("certificate signed by unknown
-    # authority"). The pivot script's write_hosts_toml ALSO writes skip_verify
-    # live (containerd re-reads certs.d per-pull, no restart needed), but
-    # carrying it in registries.yaml keeps the node correct across a future
-    # restart — the same belt-and-suspenders as the v1 mirror. Trust is the
-    # cluster network, not a public CA (identical rationale to the v1 bastion
-    # mirror's tls.insecure_skip_verify above + step-03/step-06 in-cluster
-    # skips). EXTERNAL upstreams are reached via the mirror redirect, never
-    # directly, so this skip only ever relaxes the cluster's own registry.
-    configs:
-      "__HARBOR_PUBLIC_URL__":
-        tls:
-          insecure_skip_verify: true
 {{- end }}

--- a/platform/self-sovereign-cutover/chart/templates/rbac.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/rbac.yaml
@@ -40,9 +40,12 @@ The cutover runner needs cluster-scope reach because:
     under the deny-egress hold and watches its replacement reach Running
     to prove a FRESH image pull resolves through local Harbor — needs
     pods {delete} + replicasets {get,list} (pod→Deployment ownership map).
-  - Registry-pivot DaemonSet writes to /etc/rancher/k3s/registries.yaml
-    on the host filesystem (hostPath, no K8s API needed beyond status
-    update on the cutover-status ConfigMap).
+  - Registry-pivot DaemonSet (step 04, #4639 Dragonfly rewrite) writes the
+    containerd `_default/hosts.toml` catch-all on the host filesystem
+    (hostPath → the node-local dfdaemon proxy), patches the bp-dragonfly
+    dfdaemon ConfigMap upstream + DaemonSet/StatefulSet hostAliases, reads
+    the cilium-gateway Service ClusterIP, and writes per-node acks +
+    the cluster-wide flip guard on the cutover-status ConfigMap.
 
 We use ClusterRole + ClusterRoleBinding because the namespaces touched
 are heterogeneous and cluster-scoped resources (CiliumNetworkPolicy)
@@ -112,7 +115,7 @@ rules:
     resources: ["nodes"]   # registry-pivot DaemonSet reports node status into the status ConfigMap
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
-    resources: ["services"]   # #4637: registry-pivot DaemonSet resolves the harbor-core Service ClusterIP (node-reachable) for the v2 containerd mirror endpoint instead of the un-hairpinnable public gateway EIP
+    resources: ["services"]   # #4639 (Refs #4637): registry-pivot DaemonSet resolves the cilium-gateway Service ClusterIP (node-routable, serves registry.<fqdn> wildcard TLS + token realm) for the dfdaemon hostAlias instead of the un-hairpinnable public gateway EIP
     verbs: ["get", "list", "watch"]
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["gateways"]   # step 06 Phase -1 (#1871, chart 0.1.32): wait for cilium-gateway Programmed=True before URL rewrite
@@ -141,7 +144,7 @@ rules:
     verbs: ["update", "patch"]   # step 07 sets env on catalyst-api deployment
   - apiGroups: ["apps"]
     resources: ["daemonsets", "statefulsets"]
-    verbs: ["update", "patch"]   # step 08 (#3695) rolls EVERY external-registry workload under deny-egress to prove fresh-pullability — kubectl rollout restart patches the workload's pod template
+    verbs: ["update", "patch"]   # step 08 (#3695) rolls EVERY external-registry workload under deny-egress to prove fresh-pullability — kubectl rollout restart patches the workload's pod template; AND step 04 (#4639) patches the bp-dragonfly dfdaemon DaemonSet + seed-peer StatefulSet hostAliases (registry.<fqdn> -> cilium-gateway ClusterIP) + restartedAt for the Dragonfly upstream flip
   - apiGroups: ["source.toolkit.fluxcd.io"]
     resources: ["gitrepositories", "helmrepositories"]
     verbs: ["update", "patch"]   # steps 05 + 06

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -998,61 +998,62 @@ if ! grep -A1 'name: PREWARM_DEST_TLS_VERIFY' "$TMP/render-desttls.yaml" | grep 
 fi
 echo "  PASS (Step-03 drives in-cluster-Harbor dest-TLS from PREWARM_DEST_TLS_VERIFY, default false; src ghcr.io stays verified; overlay can re-enable dest verify)"
 
-echo "[cutover-contract] Case 31: registry-pivot v1 (cold-start) mirror carries harbor-robot-token auth so PRIVATE ghcr pulls through harbor.openova.io/proxy-ghcr authenticate, NOT anonymously 401 (#4527)"
-# The v1 cold-start mirror redirects ghcr.io -> harbor.openova.io/v2/proxy-ghcr.
-# The pod's imagePullSecrets:[ghcr-pull] authenticates ghcr.io (the ORIGINAL
-# host), NOT the rewritten harbor.openova.io mirror host. Without a configs:
-# auth entry for the mirror host the pull is ANONYMOUS -> harbor proxy-ghcr 401
-# -> a fresh catalyst-api roll wedges ImagePullBackOff + api.<fqdn> 503 before
-# cutover runs (live keystone dep 25aadcfc). The v1 registries.yaml MUST carry
-# the SAME robot$openova-bot harbor-robot-token auth the bootstrap node pins in
-# infra/providers/{hetzner,huawei}/main.tf, with the token as a placeholder the
-# pivot script substitutes from the in-cluster Secret.
-# (a) Default (Hetzner) render: v1 mirror MUST have configs.harbor.openova.io.auth
-#     with the robot user + the __HARBOR_ROBOT_TOKEN__ placeholder.
-v1_block="$(awk '/registries.yaml.v1: \|/{c=1;next} c&&/registries.yaml.v2: \|/{c=0} c' "$TMP/render.yaml")"
-if ! printf '%s\n' "$v1_block" | grep -q '"harbor.openova.io":'; then
-  echo "FAIL: v1 cold-start mirror has no configs entry for harbor.openova.io — private ghcr pulls through the proxy-ghcr mirror are anonymous -> 401 (#4527)" >&2
+echo "[cutover-contract] Case 31: step-04 registry-pivot uses the Dragonfly path — node containerd mirrors through the LOCAL dfdaemon, dfdaemon upstream flips to the local Harbor, and a registry.<fqdn> -> cilium-gateway hostAlias kills the kubelet/dfdaemon hairpin (#4639, Refs #4637)"
+# The Dragonfly rewrite REPLACES the per-cloud registries.yaml / hosts.toml /
+# 30443/DNAT hairpin surgery with three generic moves. The contract:
+#   (a) the pivot writes the containerd `_default/hosts.toml` catch-all pointing
+#       at the node-local dfdaemon proxy (http://127.0.0.1:<proxyPort>) — NOT the
+#       public registry host (which the node /etc/hosts pins to the un-hairpinnable
+#       public EIP);
+#   (b) the pivot flips the dfdaemon (+ seed) registryMirror.addr to the local
+#       Harbor on the gateway HTTPS port;
+#   (c) the pivot adds a registry.<fqdn> -> cilium-gateway ClusterIP hostAlias to
+#       the dfdaemon (+ seed) pod template (the #4637 token-realm hairpin kill);
+#   (d) the legacy registries.yaml / k3s registries.yaml machinery is GONE.
+pivot_block="$(awk '/name: registry-pivot-script/{c=1} c{print} c&&/^---/{if(seen)exit; seen=1}' "$TMP/render.yaml")"
+# (a) containerd _default catch-all -> the node-local dfdaemon proxy.
+if ! printf '%s\n' "$pivot_block" | grep -q '127.0.0.1:'; then
+  echo "FAIL: step-04 pivot script does not point containerd at the node-local dfdaemon proxy (127.0.0.1) — the #4639 generic mirror (#4639)" >&2
   exit 1
 fi
-if ! printf '%s\n' "$v1_block" | grep -q 'username: "robot\$openova-bot"'; then
-  echo "FAIL: v1 cold-start mirror configs entry has no robot\$openova-bot auth username (#4527)" >&2
+if ! printf '%s\n' "$pivot_block" | grep -q '_default/hosts.toml'; then
+  echo "FAIL: step-04 pivot script does not write the containerd _default/hosts.toml catch-all that mirrors every registry namespace through dfdaemon (#4639)" >&2
   exit 1
 fi
-if ! printf '%s\n' "$v1_block" | grep -q 'password: "__HARBOR_ROBOT_TOKEN__"'; then
-  echo "FAIL: v1 cold-start mirror auth password is not the __HARBOR_ROBOT_TOKEN__ placeholder the pivot script substitutes (#4527)" >&2
+# (b) dfdaemon upstream flip to the local Harbor on the gateway HTTPS port.
+if ! printf '%s\n' "$pivot_block" | grep -q 'registryMirror'; then
+  echo "FAIL: step-04 pivot script does not flip the dfdaemon registryMirror upstream to the local Harbor (#4639)" >&2
   exit 1
 fi
-# (b) The pivot script MUST read the harbor-robot-token Secret + substitute the
-#     placeholder when writing v1 (so the placeholder never reaches the node raw).
-if ! grep -q 'secrets/harbor-robot-token' "$TMP/render.yaml"; then
-  echo "FAIL: pivot script does not read the flux-system/harbor-robot-token Secret — the v1 __HARBOR_ROBOT_TOKEN__ placeholder is never substituted (#4527)" >&2
+if ! printf '%s\n' "$pivot_block" | grep -q 'GATEWAY_HTTPS_PORT'; then
+  echo "FAIL: step-04 pivot script does not target the gateway HTTPS port for the local-Harbor upstream (so the token realm stays node-routable) (#4639)" >&2
   exit 1
 fi
-if ! grep -q 'gsub(/__HARBOR_ROBOT_TOKEN__/' "$TMP/render.yaml"; then
-  echo "FAIL: pivot script does not substitute __HARBOR_ROBOT_TOKEN__ into the v1 mirror at write time (#4527)" >&2
+# (c) the registry.<fqdn> -> cilium-gateway ClusterIP hostAlias (the #4637 kill).
+if ! printf '%s\n' "$pivot_block" | grep -q 'hostAliases'; then
+  echo "FAIL: step-04 pivot script does not patch a registry.<fqdn> -> cilium-gateway ClusterIP hostAlias onto the dfdaemon pod template (the #4637 token-realm hairpin kill) (#4639)" >&2
   exit 1
 fi
-# (c) Huawei render (bastion mirror endpoint): the BASTION host MUST ALSO carry
-#     the robot auth + insecure_skip_verify (it is the actual pull host after the
-#     harbor.openova.io -> bastion redirect; an auth-less bastion = anonymous 401).
-helm template smoke-huawei . --set 'upstream.harborProxyMirrorEndpoint=http://212.72.24.20:5000' > "$TMP/render-huawei.yaml"
-v1_huawei="$(awk '/registries.yaml.v1: \|/{c=1;next} c&&/registries.yaml.v2: \|/{c=0} c' "$TMP/render-huawei.yaml")"
-if ! printf '%s\n' "$v1_huawei" | grep -q '"212.72.24.20:5000":'; then
-  echo "FAIL: Huawei v1 mirror has no configs entry for the bastion endpoint 212.72.24.20:5000 (#4527)" >&2
+if ! printf '%s\n' "$pivot_block" | grep -q 'GATEWAY_SERVICE_NAME'; then
+  echo "FAIL: step-04 pivot script does not resolve the cilium-gateway Service ClusterIP for the hostAlias (#4639)" >&2
   exit 1
 fi
-# The bastion stanza must carry BOTH the robot auth AND insecure_skip_verify.
-bastion_stanza="$(printf '%s\n' "$v1_huawei" | awk '/"212.72.24.20:5000":/{c=1} c{print} c&&/insecure_skip_verify/{exit}')"
-if ! printf '%s\n' "$bastion_stanza" | grep -q 'username: "robot\$openova-bot"'; then
-  echo "FAIL: Huawei v1 bastion configs entry has no robot\$openova-bot auth — private ghcr pulls through the bastion cache are anonymous -> 401 (#4527)" >&2
+# (d) the legacy k3s registries.yaml / per-upstream mirror machinery is GONE.
+# Fixed-string match on the distinctive data-key / placeholder / mount tokens the
+# removed ConfigMap + DaemonSet carried (so a passing-comment analogy like
+# "registries.yaml v1's insecure_skip_verify" in another step never false-trips).
+if grep -qF -e 'registries.yaml.v1:' -e 'registries.yaml.v2:' \
+   -e 'registry-pivot-registries-yaml' -e '/etc/rancher/k3s/registries.yaml' \
+   -e '__HARBOR_ROBOT_TOKEN__' "$TMP/render.yaml"; then
+  echo "FAIL: the legacy registries.yaml hairpin machinery (v1/v2 mirror, k3s registries.yaml, robot-token placeholder) still renders — the #4639 Dragonfly rewrite must remove it" >&2
   exit 1
 fi
-if ! printf '%s\n' "$bastion_stanza" | grep -q 'insecure_skip_verify: true'; then
-  echo "FAIL: Huawei v1 bastion configs entry lost insecure_skip_verify (http bastion needs it) (#4527)" >&2
+# step-04 MUST stay daemonset-wait with the per-node ack convention intact.
+if ! printf '%s\n' "$pivot_block" | grep -q 'node.${NODE_NAME}.registriesYaml'; then
+  echo "FAIL: step-04 pivot script no longer writes the per-node node.<NODE>.registriesYaml ack the daemonset-wait counts (#3671)" >&2
   exit 1
 fi
-echo "  PASS (v1 cold-start mirror carries robot\$openova-bot harbor-robot-token auth for harbor.openova.io [+ the bastion host on Huawei]; pivot script substitutes the placeholder from the in-cluster Secret)"
+echo "  PASS (step-04 is the Dragonfly path: containerd -> node-local dfdaemon, dfdaemon upstream -> local Harbor, registry.<fqdn> -> cilium-gateway hostAlias; legacy registries.yaml hairpin machinery removed; per-node acks preserved)"
 
 echo "[cutover-contract] Case 32: Step-07 ALSO pivots the bp-openova-flow-server HR global.imageRegistry to local Harbor (#4563, Refs #3379)"
 # openova-flow-server is a SEPARATE HelmRelease (slot 56) whose chart honours

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -633,50 +633,77 @@ images:
     repository: "harbor.openova.io/proxy-dockerhub/library/alpine"
     tag: "3.20"
 
-# registry-pivot DaemonSet — runs from chart install to converge
-# /etc/rancher/k3s/registries.yaml on every node. The DaemonSet starts
-# DORMANT (writes the v1 cold-start file) and only flips to v2 when
-# catalyst-api updates the cutover-status ConfigMap key
-# `registriesYamlActive` to "v2" — see template 04-registry-pivot-daemonset.yaml.
-# Operators can disable the always-on DaemonSet shape via overlay; in
-# that case catalyst-api stamps the DaemonSet on demand at trigger time.
+# registry-pivot DaemonSet — runs from chart install to converge each node's
+# containerd registry mirror onto the local Dragonfly dfdaemon (#4639). The
+# DaemonSet starts DORMANT and only acts when catalyst-api updates the
+# cutover-status ConfigMap key `registriesYamlActive` to "v2" — see template
+# 04-registry-pivot-daemonset.yaml. Operators can disable the always-on
+# DaemonSet shape via overlay; in that case catalyst-api stamps the DaemonSet
+# on demand at trigger time.
 registryPivot:
   enabled: true
-  # #4637 — node-reachable in-cluster Harbor Service for the v2 containerd
-  # mirror endpoint. THE KUBELET-HAIRPIN FIX.
+  # #4639 (Refs #4637) — Dragonfly P2P registry-pivot. THE GENERIC HAIRPIN KILL.
   #
-  # registries.yaml v2 (+ the regenerated certs.d/<host>/hosts.toml) mirrors
-  # every upstream AND the direct `registry.<sov-fqdn>` host through
-  # __HARBOR_PUBLIC_URL__ = registry.<sov-fqdn>. The NODE resolver pins that
-  # name to the cluster's PUBLIC gateway EIP (infra/providers/*/cloudinit-
-  # worker.tftpl `/etc/hosts` block). On a cloud whose nodes cannot hairpin to
-  # their own cluster's public EIP (Huawei kom4dc) the KUBELET's post-pivot
-  # catalyst-api image pull (step-07 catalyst-api-env-patch) ErrImagePulls
-  # `dial tcp <EIP>:443: i/o timeout` and the cutover wedges at 54%. The pod-
-  # network path works only because PODS resolve via CoreDNS → harbor-core
-  # ClusterIP; the kubelet uses the node resolver, not CoreDNS.
-  #
-  # A Service ClusterIP IS node-routable (kube-proxy/cilium program it on the
-  # host network), so the pivot DaemonSet resolves harbor-core's ClusterIP at
-  # runtime (via the in-cluster K8s API — needs services get/list, added to
-  # rbac.yaml) and points the containerd `[host]` mirror endpoints at
-  # http://<clusterip>:<port> instead of https://registry.<sov-fqdn>. The
-  # certs.d dir name + `server` stay the PUBLIC host (containerd keys the
-  # host-config off the image-ref host) — only the resolved endpoint is the
-  # in-cluster ClusterIP. harbor-core serves PLAIN HTTP on its ClusterIP
-  # (platform/harbor expose.type=clusterIP, expose.tls.enabled=false; TLS
-  # terminates at the Gateway), so the endpoint is http and carries no cert to
-  # verify. On a resolve miss the script falls back to the public host (prior
-  # #4557 behaviour) and retries the resolution on the next sweep.
-  inClusterHarbor:
-    # bp-harbor exposes the core registry Service as `harbor-core` in the
-    # `harbor` namespace (Catalyst standard, issue #387). Matches
-    # sovereign.harborInternalURL host.
-    serviceName: "harbor-core"
-    serviceNamespace: "harbor"
-    # harbor-core's ClusterIP plain-HTTP registry port (upstream Harbor core
-    # backendPort 80 when expose.tls.enabled=false).
-    servicePort: "80"
+  # Every node's containerd already mirrors through the node-LOCAL dfdaemon
+  # proxy on 127.0.0.1:<proxyPort> (bp-dragonfly, slot 06). The cutover does
+  # three generic moves (no per-cloud branches):
+  #   1. write the containerd `_default/hosts.toml` catch-all → the dfdaemon
+  #      proxy (effective on the running node, containerd re-reads per pull);
+  #   2. flip the dfdaemon (+ seed-peer) `proxy.registryMirror.addr` from
+  #      https://ghcr.io → the cluster-LOCAL Harbor public host on the gateway
+  #      HTTPS port;
+  #   3. add a `registry.<fqdn> → cilium-gateway ClusterIP` hostAlias to the
+  #      dfdaemon (+ seed) pod template so the hostNetwork dfdaemon resolves the
+  #      Harbor host (AND its token realm) to the node-routable Cilium-gateway
+  #      ClusterIP instead of the un-hairpinnable public EIP the node /etc/hosts
+  #      pins it to. PROVEN live on kom4dc omantel.biz (the cloud that breaks
+  #      the legacy hairpin): the public-host fetch i/o-times-out while the
+  #      gateway-ClusterIP resolve returns the registry 401 + a 200 from
+  #      /service/token.
+  # The node→127.0.0.1 dfdaemon path is identical on Huawei + Hetzner, so the
+  # per-cloud `/etc/hosts`/`30443`/DNAT surgery the old step carried is gone.
+  dragonfly:
+    # The dfdaemon proxy port every node's containerd mirrors through. Matches
+    # bp-dragonfly client.config.proxy.server.port (127.0.0.1:4001 on the 2.x
+    # client this Sovereign runs).
+    proxyPort: "4001"
+    # The bp-dragonfly mesh namespace + the per-node dfdaemon DaemonSet, the
+    # seed-peer StatefulSet, and their config ConfigMaps the cutover patches
+    # for the upstream flip + hostAlias. These are the upstream dragonfly chart
+    # resource names (releaseName `dragonfly`). Seed names empty-string-safe:
+    # a Sovereign without a seed peer leaves them blank and the cutover skips
+    # the seed patch.
+    namespace: "dragonfly"
+    clientDaemonSet: "dragonfly-client"
+    clientConfigMap: "dragonfly-client"
+    seedStatefulSet: "dragonfly-seed-client"
+    seedConfigMap: "dragonfly-seed-client"
+    # The node-routable Cilium gateway Service whose ClusterIP serves
+    # registry.<fqdn> (wildcard `*.<fqdn>` TLS + the Harbor token realm). Cilium
+    # creates `cilium-gateway-<gateway-name>` for the `cilium-gateway` Gateway
+    # in kube-system; its ClusterIP is programmed on the host net (kube-proxy/
+    # cilium), so it is reachable from the hostNetwork dfdaemon. The hostAlias
+    # maps registry.<fqdn> → this ClusterIP.
+    gatewayServiceName: "cilium-gateway-cilium-gateway"
+    gatewayServiceNamespace: "kube-system"
+    # The Cilium gateway HTTPS listener port — the canonical Catalyst gateway
+    # NodePort (infra/providers/_shared/cloudinit-control-plane.tftpl
+    # SOVEREIGN_GATEWAY_HTTPS_PORT, Hetzner LB 443→30443, Huawei NodePort
+    # 30443). The local-Harbor upstream is https://registry.<fqdn>:<this> so
+    # the realm Harbor reflects carries the SAME port — the token-realm
+    # follow-up stays on the node-routable gateway endpoint.
+    gatewayHTTPSPort: "30443"
+    # Bounce dfdaemon (+ seed) after the upstream flip so it reloads the new
+    # registryMirror.addr. DEFAULT false: the hostAlias patch (move 3) ALREADY
+    # re-rolls the dfdaemon (+ seed) pods — adding hostAliases mutates the pod
+    # template, which the DaemonSet/StatefulSet controller rolls on its own — so
+    # the addr-only ConfigMap change is picked up by that same roll without a
+    # second, redundant restartedAt bump. Keeping the explicit restart OFF also
+    # avoids re-rolling the seed-peer twice (a StatefulSet whose upstream
+    # securityContext may need a per-Sovereign Kyverno exemption — a bp-dragonfly
+    # chart concern, not the cutover's). Operators who pin the dfdaemon config
+    # via an immutable ConfigMap (no auto-reload) can flip this true via overlay.
+    restartOnFlip: false
 
 # CiliumNetworkPolicy for step 08 (egress-block-test). Operator
 # overrides duration via overlay if 10 min isn't enough.

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5011,7 +5011,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.91"
+  version: "0.1.93"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5028,7 +5028,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.91"
+    version: "0.1.93"
   topology:
     supported:
       - singleton

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -366,7 +366,14 @@ slots:
     # parked Stalled, handover never fired). The cross-kind ordering
     # is now enforced upstream by the cloud-init / Kustomization
     # graph rather than by an entry in this list.
-    depends_on: [bp-gitea, bp-harbor]
+    #
+    # #4639: + bp-dragonfly. The cutover registry-pivot (step-04, the
+    # Dragonfly rewrite) flips the bp-dragonfly dfdaemon mesh's upstream
+    # ghcr -> local Harbor + adds the registry.<fqdn> -> cilium-gateway
+    # hostAlias. The dfdaemon DaemonSet + seed-peer + their ConfigMaps
+    # (slot 06) must exist before step-04 can patch them, so the cutover
+    # HR depends on bp-dragonfly being Ready.
+    depends_on: [bp-gitea, bp-harbor, bp-dragonfly]
     wave: W2.K1
 
   # ---- Tier 6: observability (W2.K2, slots 19c, 20-26) ---------------------


### PR DESCRIPTION
## What

Rewrites the self-sovereign cutover's registry-pivot to use the **Dragonfly dfdaemon** (bp-dragonfly, #4640) instead of the hand-rolled per-cloud `hosts.toml`/EIP-hairpin surgery that wedges on kom4dc (no node hairpin).

The new pivot is three generic steps, zero per-cloud branches:
1. **containerd → node-local dfdaemon.** Write `certs.d/_default/hosts.toml` pointing at `127.0.0.1:4001` (the dfdaemon proxy). containerd re-reads certs.d per pull, so the mirror is always the node-LOCAL dfdaemon — never the un-hairpinnable public EIP.
2. **dfdaemon upstream flip.** Patch the dfdaemon client ConfigMap `registryMirror.addr` `ghcr.io → local Harbor` at cutover.
3. **`hostAlias` token-realm fix.** Map `registry.<fqdn>` → harbor ClusterIP on the dfdaemon, so the `Www-Authenticate` token realm resolves node-locally — the actual #4637 root (dfdaemon is hostNetwork, so it inherits the node hairpin without this).

## Evidence

- `helm template` renders clean (22 docs); version lockstep 0.1.93 across Chart/blueprint/slot/seed.
- bp-dragonfly is live-validated on kom4dc prov `7ae803f1` (deploys + runs, dfdaemon proxy serving on `:4001`); the upstream-flip + hostAlias mechanism was exercised there. Findings + spec on #4639.

## Not in this change

- The end-to-end zero-touch proof (fresh prov → handover → auto-cutover → cutoverComplete) and the `fireCutoverOnHandover` default flip ride a follow-up walk.

Refs #4637 #4639

🤖 Generated with [Claude Code](https://claude.com/claude-code)