### PR TITLE
feat(catalyst): qaFixtures provs auto-fire cutover on handover — zero-touch incl. cutover (1.4.955)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1232,7 +1232,7 @@ spec:
       #   stamp spec.parameters.sovereignFqdn so the openova-MCP URL points at
       #   this Sovereign, not the mothership. catalyst-api + application-controller
       #   image fixes (deploy-bot pins on next build). Lockstep w/ Chart.yaml.
-      version: 1.4.954
+      version: 1.4.955
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,9 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.955 — #4061 (zero-touch cutover): a qaFixtures-enabled prov (omantel.biz,
+#   qaTestEnabled=true) now auto-fires the cutover on handover for the full
+#   unattended zero-touch walk; permanent customer Sovereigns stay operator-gated
+#   (BSS "Achieve True Sovereignty" CTA) per #4061. Refs #4637 #4639.
 # 1.4.948 — #4605 follow-up (Refs #3375 #3986 #4601): fix the
 #   status.placement DR projection for CNPG-backed / non-spine bootstrap apps.
 #   shared-pg/-b/-c (ns shared-data) are active-hot-standby but carry the
@@ -3403,7 +3407,7 @@ name: bp-catalyst-platform
 #   sovereign-fqdn) so GET /catalog/regions returns the Sovereign's REAL
 #   regions instead of [] — the marketplace BCP picker stops falling back to
 #   the hardcoded Hetzner list.
-version: 1.4.954
+version: 1.4.955
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/
 #   platform/crossplane chart + blueprint.yaml + bootstrap-kit slot 04). crossplane-core
 #   was still OOMKilled (CrashLoopBackOff, 55 restarts, exit 137, killed ~90s after start)

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -1041,7 +1041,12 @@ spec:
             # Catalyst-Zero / the mothership, which is the handover SENDER, never
             # a cutover subject — fireCutoverOnHandover never runs there.
             - name: CATALYST_FIRE_CUTOVER_ON_HANDOVER
-              value: '{{ if .Values.global.sovereignFQDN }}{{ .Values.catalystApi.fireCutoverOnHandover | default false }}{{ end }}'
+              # #4061 keeps PERMANENT customer Sovereigns operator-gated (explicit
+              # BSS "Achieve True Sovereignty" CTA). A qa/test prov (qaFixtures.enabled,
+              # e.g. omantel.biz with qaTestEnabled=true) drives the FULL unattended
+              # zero-touch walk — handover auto-fires the cutover. Customer provs
+              # (qaFixtures.enabled=false, fireCutoverOnHandover=false) stay gated.
+              value: '{{ if .Values.global.sovereignFQDN }}{{ if or .Values.catalystApi.fireCutoverOnHandover .Values.qaFixtures.enabled }}true{{ else }}false{{ end }}{{ end }}'
             # SOVEREIGN_FQDN — Sovereign's public FQDN. The /auth/handover
             # validator (auth_handover.go) reads this to compute the expected
             # JWT audience claim ("https://console." + SOVEREIGN_FQDN). When


### PR DESCRIPTION
## What

Makes the cutover **auto-fire on handover for qa/test provs** (the zero-touch-incl-cutover requirement), while keeping permanent customer Sovereigns operator-gated per #4061.

`CATALYST_FIRE_CUTOVER_ON_HANDOVER` now renders `true` when `or .Values.catalystApi.fireCutoverOnHandover .Values.qaFixtures.enabled`. A qaTestEnabled prov sets `qaFixtures.enabled=true`, so handover seals the tofu-phase0-archive AND fires the Dragonfly cutover unattended -> cutoverComplete. Customer provs (both false) still require the BSS Achieve-True-Sovereignty CTA.

This is the last piece for the e2e zero-touch proof: a fresh kom4dc qaTestEnabled prov on this train converges -> handover -> AUTO-cutover (via the Dragonfly registry-pivot, #4641) -> cutoverComplete, with no manual touch.

Refs #4061 #4637 #4639

🤖 Generated with [Claude Code](https://claude.com/claude-code)