### PR TITLE
docs(adr): ADR-0012 — Dragonfly P2P registry + cloud-agnostic cutover

### DIFF
--- a/docs/adr/0012-dragonfly-p2p-registry-cutover.md
+++ b/docs/adr/0012-dragonfly-p2p-registry-cutover.md
@@ -1,0 +1,68 @@
+# ADR-0012 — Dragonfly P2P registry distribution + cloud-agnostic cutover
+
+- **Status:** Accepted (2026-06-29)
+- **Shipped by:** #4640 (`bp-dragonfly`), #4641 (cutover registry-pivot rewrite), #4642 (auto-cutover wiring)
+- **Supersedes the registry-pivot mechanism in:** ADR-0002 (post-handover sovereignty cutover) — the cutover *contract* is unchanged; only the registry-repoint *mechanism* changes.
+- **Related:** ADR-0001 §9 (ClusterMesh is inter-region, same-plane), ADR-0011 (OpenTofu/Crossplane seam), `docs/ideation/dragonfly-p2p-registry-cutover-redesign.md` (full design + diagrams), issues #4637 / #4639.
+
+## Context
+
+The self-sovereignty cutover repoints every container-image source from the OpenOva
+mothership to the Sovereign's own registry. Its registry-pivot **wedged on kom4dc
+(Huawei)**: nodes were pointed at `registry.<fqdn>` → a public EIP → and kom4dc nodes
+**cannot hairpin** to their own cluster's EIP. It "worked" on Hetzner only because
+Hetzner allows the hairpin — an **implicit per-cloud assumption** (the registry-pivot
+literally branched `if Hetzner / Huawei / Contabo`), plus `/etc/hosts` pins, a
+non-standard `:30443` gateway port, and DNAT workarounds.
+
+Separately, image distribution relied on a **single centralized bastion proxy-cache**
+(`harbor.openova.io`, hardcoded in ~203 files) — a SPOF + bottleneck that caused real
+outages (`#3735` hw159 ImagePullBackOff, anonymous-pull 401s) and an "artificial"
+mothership tether the founder flagged for removal.
+
+## Decision
+
+Adopt **Dragonfly** (CNCF P2P image distribution) as the per-cluster registry layer,
+and rewrite the cutover registry-pivot around it. Generic, zero per-cloud branches:
+
+1. **Per-node `dfdaemon` as the containerd registry mirror** at `127.0.0.1:4001`
+   (`hostNetwork`, proxy port). containerd `certs.d/_default/hosts.toml` points at the
+   node-local dfdaemon — never the un-hairpinnable public EIP. Identical on every cloud.
+2. **Node-as-cache / P2P:** dfdaemon fetches each blob from the upstream **once per
+   cluster** (the seed peer) and distributes peer-to-peer over the LAN. The bastion
+   proxy-cache is **removed from the image path**; ghcr is hit minimally (rate-limit
+   resistant). The mothership remains the *provisioner only*, never in the image path.
+3. **Each plane / cluster is self-contained** (its own registry + Dragonfly mesh). There
+   is **NO cross-plane ClusterMesh** for images — that would breach the
+   `bp-plane-isolation` default-deny and raise the blast radius (a DMZ compromise reaching
+   mgmt). ClusterMesh stays **region-scoped, same-plane** per ADR-0001. Blast radius for
+   the image path = one cluster.
+4. **Cutover = a one-line `dfdaemon` upstream flip** (`registryMirror.addr`
+   ghcr → in-cluster Harbor) **plus a `hostAlias`** mapping `registry.<fqdn>` → harbor
+   ClusterIP. The hostAlias is essential: because dfdaemon is `hostNetwork` it inherits
+   the node's hairpin, so without it the Harbor `Www-Authenticate` token realm
+   (`https://registry.<fqdn>/service/token`) would hairpin — the actual #4637 root. No
+   `/etc/hosts` / `:30443` / DNAT node surgery remains.
+5. **Zero-touch cutover** (#4642): a qa/test prov (`qaFixtures.enabled`) auto-fires the
+   cutover on handover for the full unattended walk; **permanent customer Sovereigns stay
+   operator-gated** via the BSS "Achieve True Sovereignty" CTA, preserving #4061.
+
+## Consequences
+
+- **Cloud-agnostic:** the node→dfdaemon→registry path is byte-identical on Huawei and
+  Hetzner. No per-cloud branch survives in the image/cutover path.
+- **DR-correct:** each cluster self-seeds and survives loss of any other (region-kill).
+- **Isolation-correct:** no cross-plane reach; default-deny intact.
+- **Rate-limit-resistant:** once-per-blob-per-cluster upstream pulls + P2P fan-out.
+- **Cost / follow-ups:** per-cluster registry footprint (full Harbor vs a lightweight
+  per-plane registry is an open sizing choice); the dfdaemon "egg" should be pre-baked
+  into the node image (k3s airgap bundle) so bootstrap needs no upstream — tracked as a
+  follow-up, not blocking.
+
+## Alternatives rejected
+
+- **Keep the bastion proxy-cache:** SPOF, hardcoded ×203, recurring outages, artificial
+  mothership tether.
+- **Shared Harbor via the external endpoint** (`registry.<fqdn>` for dmz/rtz): reintroduces
+  the exact kom4dc hairpin and couples DR to one endpoint.
+- **Cross-plane ClusterMesh global service:** breaches plane isolation; blast-radius increase.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,6 +15,7 @@ Format: lightweight ADR (Status / Context / Decision / Consequences / Shipped-vi
 | [0009](0009-per-org-iac-repo-bootstrap.md) | Per-Organization IaC repo bootstrap on Org creation | Accepted |
 | [0010](0010-reusable-shareable-backing-services.md) | Reusable, shareable backing-services model (declarative, no controller/Crossplane) | Accepted |
 | [0011](0011-opentofu-crossplane-adoption-seam.md) | OpenTofu→Crossplane adoption seam (provider-opentofu Workspace, Observe-first) | Accepted |
+| [0012](0012-dragonfly-p2p-registry-cutover.md) | Dragonfly P2P registry distribution + cloud-agnostic cutover (kills the kom4dc hairpin + the bastion proxy-cache) | Accepted |
 
 > **Numbering note:** slots 0005–0008 are intentionally reserved for in-flight EPIC ADRs (G92/G105/G108/G112 candidates). ADR-0009 picked its slot deliberately so it could land without ordering coupling — see the ADR-0009 header. The 0005–0008 gap is by design, not a missing-file anomaly.
 

--- a/docs/sessions/2026-06-29/dragonfly-zero-touch-cutover.md
+++ b/docs/sessions/2026-06-29/dragonfly-zero-touch-cutover.md
@@ -1,0 +1,64 @@
+# Session 2026-06-29 — Dragonfly P2P registry → deterministic zero-touch cutover
+
+**Goal (founder):** drive omantel.biz (kom4dc Sovereign) to a **deterministic zero-touch
+state** — provision → converge → handover → **cutover** → `cutoverComplete` with **zero
+manual touch, including the cutover**. Root blocker: the cutover registry-pivot wedged on
+kom4dc (nodes cannot hairpin to their own public EIP). Solution: replace the
+bastion-proxy + per-cloud hairpin hacks with **Dragonfly P2P**.
+
+## Shipped
+
+| PR | What | Status |
+|---|---|---|
+| #4640 | `bp-dragonfly` — per-node dfdaemon P2P registry layer (slot 06) | ✅ merged |
+| #4641 | cutover registry-pivot → dfdaemon mirror + hostAlias (kills #4637 kom4dc hairpin) | ✅ merged |
+| #4642 | qaFixtures provs auto-fire cutover on handover (zero-touch incl. cutover, #4061-safe) | ✅ merged |
+| #4643 | ADR-0012 — Dragonfly registry architecture decision record | ✅ open |
+| — | `bp-catalyst-platform:1.4.955` published (auto-cutover wiring) | ✅ |
+
+Design: `docs/ideation/dragonfly-p2p-registry-cutover-redesign.md` · Decision: `docs/adr/0012-…`
+· Findings: issue #4639.
+
+## WBS / Gantt
+
+```
+            ◀──────────────── COMPLETE ────────────────▶│◀ now ▶│
+0   Design (stress-tested: cloud-agnostic/DR/isolation)   ████████          ✅
+1   bp-dragonfly (chart, slot 06)                             ████████      ✅ #4640
+2   Validate on live kom4dc (deploys+runs, dfdaemon :4001)        ████████  ✅ #4639
+2b  Defuse 5/5 VPC quota landmine                                  █████     ✅ 1/5
+3   Cutover-rewrite (dfdaemon mirror + upstream flip + hostAlias)    ██████  ✅ #4641
+4.2 Auto-cutover-on-handover wiring (qaFixtures, #4061-safe)          █████  ✅ #4642
+4.x ADR-0012 (decision record)                                        ███   ✅ #4643
+─────────────────────────────────────────────────────────────────────────────────
+4.3 fresh kom4dc qaTestEnabled e2e prov (fbf043d2)                       🔄  IN FLIGHT
+4.4 converge → handover → AUTO-cutover → cutoverComplete                 ⏭️  ◀ last gate
+```
+
+## Key decisions / findings
+
+- **dfdaemon = node-local containerd mirror** (`127.0.0.1:4001`, hostNetwork) — generic,
+  no per-cloud branch. Each plane/cluster **self-contained**; **no cross-plane mesh**
+  (preserves plane-isolation; blast radius = 1 cluster).
+- **The #4637 root is the token realm:** dfdaemon is hostNetwork → inherits the node
+  hairpin, so Harbor's `Www-Authenticate` realm (`https://registry.<fqdn>/service/token`)
+  hairpins. Fix = `hostAlias` `registry.<fqdn>` → harbor ClusterIP. (Captured in #4639.)
+- **Zero-touch scope:** qa/test provs auto-fire the cutover; **customer Sovereigns stay
+  operator-gated** (BSS CTA) per #4061.
+- **Operational traps captured to memory:** (1) catalyst-api in-memory store does not
+  reload on recycle → wipe via workdir `tofu destroy`; (2) merging a bp-catalyst-platform
+  change then firing a prov → the mothership catalyst-api rolls and abandons the prov →
+  pre-flight `rollout status` + no in-flight Build-&-Deploy CI before firing.
+
+## Follow-ups (non-blocking)
+
+- Pre-bake dfdaemon+Cilium into the node image (k3s airgap bundle) so bootstrap needs no
+  upstream (the dfdaemon "egg").
+- Per-plane registry footprint sizing (full Harbor vs lightweight per-plane registry).
+- Sweep leftover OBS buckets from wiped throwaway provs.
+
+## Acceptance (pending)
+
+The e2e prov `fbf043d226aca6f1` (single-region kom4dc, `qaTestEnabled`) must walk
+**converge → handover → auto-cutover → `cutoverComplete`** through the 600s deny-egress
+hold with no manual touch. That is the one outstanding gate; everything upstream is done.


### PR DESCRIPTION
Immutable decision record for the now-shipped Dragonfly registry architecture (#4640 bp-dragonfly, #4641 cutover-rewrite, #4642 auto-cutover wiring): per-node dfdaemon containerd mirror at 127.0.0.1, in-cluster Harbor upstream + P2P (no bastion), each plane self-contained (no cross-plane mesh), cutover = one-line upstream flip + hostAlias for the kom4dc token-realm hairpin. Generic across Huawei + Hetzner.

Refs #4637 #4639

🤖 Generated with [Claude Code](https://claude.com/claude-code)