### PR TITLE
fix(infra): thread QA_FIXTURES_ENABLED into the cloud-init substitute — kill the always-false cutover auto-fire gate

### DIFF
--- a/docs/sessions/2026-06-30/STATUS-dragonfly-zero-touch-cutover.md
+++ b/docs/sessions/2026-06-30/STATUS-dragonfly-zero-touch-cutover.md
@@ -1,0 +1,68 @@
+# STATUS — Dragonfly zero-touch cutover (omantel.biz / kom4dc)
+
+**As of 2026-06-30, live-validated on prov `fbf043d2` (no fresh prov burned).**
+
+## Goal
+Drive the Sovereign to a **deterministic zero-touch cutover** (Pillar 5): provision →
+converge → handover → **auto-cutover** → `cutoverComplete`, 100% no manual touch, on the
+no-hairpin kom4dc cloud. The blocker was the cutover registry-pivot wedging because kom4dc
+nodes can't hairpin to their own public EIP. Fix = **Dragonfly** P2P (per-node dfdaemon
+mirror at `127.0.0.1`), per founder direction.
+
+## THE breakthrough (this session)
+**The Dragonfly registry-pivot WORKS on kom4dc — the hairpin is dead.** Manual-triggered
+cutover on the live converged env walked steps 1–6 green:
+`registry-pivot` ✅ → `registriesYaml` flipped **v1→v2**, dfdaemon upstream flipped
+**ghcr→local**. This is what NEVER worked with the hand-rolled hairpin for ~200 provs.
+
+## WBS / Gantt
+
+```
+            ◀──────────────── COMPLETE ────────────────▶│◀ now ▶│
+0  Design (cloud-agnostic/DR/isolation/blast-radius)      ████████        ✅
+1  bp-dragonfly chart (slot 06)                               ████████    ✅ #4640 merged
+2  Validate Dragonfly DEPLOYS on kom4dc                          ██████   ✅ #4639
+2b Defuse 5/5 VPC quota landmine                                  ████    ✅ 1/5
+3  Cutover registry-pivot → dfdaemon mirror + hostAlias            █████   ✅ #4641 merged
+4a Live-prove the Dragonfly registry-pivot (steps 1–6, regYaml v2) ████   ✅ PROVEN
+4b ADR-0012 + DoD Sandbox→Agenity correction                       ████   ✅ #4643 #4647
+─────────────────────────────────────────────────────────────────────────────────────
+5a Auto-fire gate root-cause (QA_FIXTURES_ENABLED never wired)      🔄 #4648 (CI green-verified local)
+5b dfdaemon Kyverno readOnlyRootFilesystem DENY → DS=0 pods         🔄 fix in progress (#4640 follow-up)
+6  Re-prov clean kom4dc qaTestEnabled → AUTO-cutover → COMPLETE     ⏭️  ◀ final acceptance
+```
+
+## Two remaining bugs (both caught by live validation, no wasted prov)
+
+**5a — auto-fire gate (FIXED, statically verified):** `QA_FIXTURES_ENABLED` was a
+*documented but never-assigned* postBuild-substitute var → `qaFixtures.enabled` (and thus
+`CATALYST_FIRE_CUTOVER_ON_HANDOVER`, #4642) always rendered `false` on **every** cloud →
+the cutover never auto-fired anywhere. Fix #4648: declare the var on Huawei + thread it
+through all `templatefile()` callers + add the substitute key. Proven with `tofu validate`
++ a render test (emits `QA_FIXTURES_ENABLED: "true"`) + both CI render gates run locally
+(exit 0). **Baked cloud-init → inert until catalyst-api image rebuilds.**
+
+**5b — dfdaemon Kyverno DENY (fix in progress):** the `dragonfly-client` DaemonSet is
+DENIED by the cluster's `readOnlyRootFilesystem=true` ENFORCE policy → DESIRED=4 CURRENT=0.
+With zero dfdaemon pods, the node's `127.0.0.1:4001` mirror is dead → catalyst-api re-pull
+(cutover step-07) gets `connection refused` → ImagePullBackOff → wedge at 54%. Fix:
+bp-dragonfly chart sets `readOnlyRootFilesystem=true` + emptyDir mounts for dfdaemon's
+writable paths (socket/cache/log) + OTel annotation. (Also Audit-flagged: dfdaemon images
+come from docker.io, not the local Harbor — `harbor-proxy-pull` will matter post-cutover.)
+
+## Pillar 4 correction (founder, 2026-06-30)
+**Sandbox is dead — replaced by Agenity.** Per-Org Agenity workspace + `bp-openova-mcp`
+(SSO/RBAC-scoped `agenity-mcp-bearer`). Canonical DoD doc swept (#4647); Sandbox menu to be
+removed.
+
+## What's left for the deterministic zero-touch proof
+1. Land 5a (#4648) + 5b (dfdaemon Kyverno fix) → catalyst-api + bp-dragonfly images rebuild.
+2. **One** clean kom4dc `qaTestEnabled` prov on the full train → converge → handover →
+   **auto**-cutover (5a opens the gate) → registry-pivot (proven) → catalyst-api re-pull via
+   a now-Kyverno-compliant dfdaemon (5b) → `cutoverComplete` through the 600s egress hold.
+
+## Process change (founder demand: "verify basics before the cycle")
+- Trace the full chain statically + render-prove the expected value **before** any prov.
+- Validate mechanisms on an already-converged live env (manual trigger) before re-proving.
+- Run the actual CI gates locally before pushing (caught the missing-var render-harness gap
+  before merge, not after a wasted walk).

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -553,6 +553,7 @@ write_files:
             # per-provider templates.
             SOVEREIGN_REGION_KEY: ${sovereign_region_key}
             MARKETPLACE_ENABLED: "${marketplace_enabled}"
+            QA_FIXTURES_ENABLED: "${qa_fixtures_enabled}"
             PARENT_DOMAINS_YAML: '${parent_domains_yaml}'
             # PARENT_DOMAINS_FILTER (#3376) — the external-dns domainFilters
             # list (bootstrap-kit slot 12, clusters/_template/bootstrap-kit/
@@ -844,6 +845,7 @@ write_files:
             SOVEREIGN_FQDN_DASHED: ${sovereign_fqdn_slug}
             SOVEREIGN_LB_IP: ${load_balancer_ipv4}
             MARKETPLACE_ENABLED: "${marketplace_enabled}"
+            QA_FIXTURES_ENABLED: "${qa_fixtures_enabled}"
             PARENT_DOMAINS_YAML: '${parent_domains_yaml}'
             WILDCARD_CERT_ISSUER: "${wildcard_cert_issuer}"
             SOVEREIGN_FQDN_SLUG: "${sovereign_fqdn_slug}"

--- a/infra/providers/_shared/tests/render.tf
+++ b/infra/providers/_shared/tests/render.tf
@@ -40,6 +40,7 @@ locals {
     gitops_repo_url                   = "https://github.com/openova-io/openova"
     gitops_branch                     = "main"
     marketplace_enabled               = "true"
+    qa_fixtures_enabled               = "true"
     console_isolation_enabled         = "true"
     wildcard_cert_issuer              = "wildcard-issuer"
     bcp_topology                      = "single-region"

--- a/infra/providers/hetzner/main.tf
+++ b/infra/providers/hetzner/main.tf
@@ -880,6 +880,7 @@ locals {
     gitops_repo_url     = var.gitops_repo_url
     gitops_branch       = var.gitops_branch
     marketplace_enabled = var.marketplace_enabled
+    qa_fixtures_enabled = var.qa_fixtures_enabled
     # #4053 console-isolation toggle (Refs #4431 #4212) → shared template's
     # SOVEREIGN_CONSOLE_GATEWAY substitute → slot-13 ingress.gateway.parentRef.name.
     console_isolation_enabled = var.console_isolation_enabled
@@ -1421,6 +1422,7 @@ locals {
       gitops_repo_url     = var.gitops_repo_url
       gitops_branch       = var.gitops_branch
       marketplace_enabled = var.marketplace_enabled
+      qa_fixtures_enabled = var.qa_fixtures_enabled
       # #4053 console-isolation toggle (Refs #4431 #4212) → shared template's
       # SOVEREIGN_CONSOLE_GATEWAY substitute → slot-13 ingress.gateway.parentRef.name.
       console_isolation_enabled = var.console_isolation_enabled

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -993,6 +993,7 @@ locals {
       sovereign_cnpg_instances = length(var.regions) > 1 ? "2" : "1"
       continuum_enabled        = length(var.regions) > 1 ? "true" : "false"
       marketplace_enabled      = var.marketplace_enabled
+      qa_fixtures_enabled      = var.qa_fixtures_enabled
       # #4053 console-isolation toggle (Refs #4431 #4212). Threads into the
       # shared template's SOVEREIGN_CONSOLE_GATEWAY substitute → slot-13
       # ingress.gateway.parentRef.name. "true" → cilium-gateway-console

--- a/infra/providers/huawei/variables.tf
+++ b/infra/providers/huawei/variables.tf
@@ -563,3 +563,18 @@ variable "cluster_mesh_id" {
     error_message = "cluster_mesh_id must be 0 (auto-allocate) or 1-255 (peer id)."
   }
 }
+
+# qa_fixtures_enabled — ported from the Hetzner provider (was MISSING on Huawei,
+# the root cause of the kom4dc cutover never auto-firing: catalyst-api passes
+# this tfvar from QATestEnabled, but without a declaration + a templatefile pass
+# + the QA_FIXTURES_ENABLED substitute key, slot-13's `qaFixtures.enabled`
+# (and thus CATALYST_FIRE_CUTOVER_ON_HANDOVER) always rendered false). Refs #4061.
+variable "qa_fixtures_enabled" {
+  type        = string
+  description = "When 'true', the Sovereign provisions with the bp-catalyst-platform qaFixtures stack rendered (qa-loop matrix consumers) AND auto-fires the self-sovereign cutover on handover. Default 'false' for customer Sovereigns. Set 'true' only on QA Sovereigns."
+  default     = "false"
+  validation {
+    condition     = contains(["true", "false"], var.qa_fixtures_enabled)
+    error_message = "qa_fixtures_enabled must be the string 'true' or 'false'."
+  }
+}

--- a/scripts/cloudinit-size-check.sh
+++ b/scripts/cloudinit-size-check.sh
@@ -127,6 +127,7 @@ fixture_cp_common() {
     enable_unattended_upgrades        = true
     enable_fail2ban                   = true
     marketplace_enabled               = "false"
+    qa_fixtures_enabled               = "false"
     console_isolation_enabled         = "true"
     continuum_enabled                 = "false"
     bcp_topology                      = "single-region"

--- a/scripts/lint-cloudinit.sh
+++ b/scripts/lint-cloudinit.sh
@@ -108,6 +108,7 @@ fixture_common() {
     enable_unattended_upgrades        = true
     enable_fail2ban                   = true
     marketplace_enabled               = "false"
+    qa_fixtures_enabled               = "false"
     console_isolation_enabled         = "true"
     continuum_enabled                 = "false"
     bcp_topology                      = "single-region"


### PR DESCRIPTION
## Root cause
The kom4dc cutover never auto-fired because `QA_FIXTURES_ENABLED` was a **documented but never-assigned** postBuild-substitute var. catalyst-api passes `qa_fixtures_enabled` as a tfvar (from `QATestEnabled`), but Huawei never declared the var and **neither provider threaded it into the templatefile() var map or the substitute block**. So slot-13 `qaFixtures.enabled` (and thus `CATALYST_FIRE_CUTOVER_ON_HANDOVER`, #4642) always rendered `false` on every cloud → the cutover always needed a manual trigger.

## Fix (mirrors `marketplace_enabled` exactly)
- declare `var.qa_fixtures_enabled` on Huawei (was missing);
- thread `qa_fixtures_enabled` into all 4 `templatefile()` callers (huawei, hetzner x2, _shared/tests);
- add `QA_FIXTURES_ENABLED` to both substitute blocks in the shared cloud-init.

## Static proof (no prov burned)
- `tofu validate` huawei + hetzner → **Success! The configuration is valid.**
- the `_shared/tests` render emits `QA_FIXTURES_ENABLED: "true"` in **both** substitute blocks when passed `qa_fixtures_enabled=true`.

## Note
Baked cloud-init → inert until the catalyst-api image rebuilds with this. Gated behind the live Dragonfly-cutover mechanism proof before any re-prov.

Refs #4061 #4637

🤖 Generated with [Claude Code](https://claude.com/claude-code)