### PR TITLE
fix(bp-dragonfly): Kyverno readOnlyRootFilesystem compliance — unblock dfdaemon DaemonSet + the self-sovereign cutover (0.1.1)

### DIFF
--- a/clusters/_template/bootstrap-kit/06-bp-dragonfly.yaml
+++ b/clusters/_template/bootstrap-kit/06-bp-dragonfly.yaml
@@ -85,7 +85,12 @@ spec:
       # 127.0.0.1:4001; upstream registry = ghcr (ghcr-pull auth). Every
       # workload + initContainer carries non-zero resources.requests for the
       # host-ns Kyverno resource-requests Enforce policy.
-      version: 0.1.0
+      # 0.1.1 (#4649): Kyverno readOnlyRootFilesystem compliance — emptyDir
+      # extraVolumes for every dfdaemon-writable path + OTel annotation in the
+      # chart; the securityContext is injected by the postRenderers below
+      # (upstream chart has no securityContext knob). Lockstep with the slot's
+      # postRenderers block at the bottom of this file.
+      version: 0.1.1
       sourceRef:
         kind: HelmRepository
         name: bp-dragonfly
@@ -138,3 +143,84 @@ spec:
               # (harbor-core.harbor.svc) in a single line — a separate, later-
               # validated step (platform/self-sovereign-cutover/), NOT here.
               addr: ${SOVEREIGN_DRAGONFLY_UPSTREAM_REGISTRY:=https://ghcr.io}
+  # ── Kyverno readOnlyRootFilesystem compliance (#4649) ─────────────────────
+  # The cluster `runasnonroot-readonlyrootfs` ClusterPolicy (Enforce on a
+  # cutover-stage prov) DENIES any container without
+  # securityContext.readOnlyRootFilesystem=true. On kom4dc fbf043d2 it blocked
+  # the dfdaemon DaemonSet (DESIRED=4 CURRENT=0) → no node containerd mirror at
+  # 127.0.0.1:4001 → the cutover's catalyst-api re-pull `connection refused` →
+  # ImagePullBackOff → cutover wedged at step-07 (sibling of #4637).
+  #
+  # The upstream dragonflyoss/dragonfly 1.7.0 chart exposes NO securityContext
+  # value knob for any component, so the field is injected here via the
+  # canonical Catalyst Flux postRenderers Kustomize patch (cf. 03-flux.yaml).
+  # Targets use the release-name-INDEPENDENT `component` label, NOT the
+  # release-prefixed object name. The emptyDir mounts for every path the
+  # read-only root then requires are baked into the chart values.yaml (#4649).
+  #
+  # The bundled mysql + redis bitnami subcharts already set
+  # readOnlyRootFilesystem=true themselves — they are NOT patched here.
+  #
+  # SCOPE: only readOnlyRootFilesystem (the live-enforced rule) + drop-ALL caps
+  # + no-privilege-escalation are applied — uniformly to all 4 dragonflyoss
+  # containers. The policy's runAsNonRoot rule defaults to Audit (anyPattern:
+  # Pod-level OR every-container) and was NOT in the live denial; the
+  # dragonflyoss images run as root (User:'' in the image config) and the
+  # dfdaemon `client` STRUCTURALLY needs root (hostNetwork/hostPID/hostIPC +
+  # the /var/run/dragonfly hostPath socket dir). Forcing runAsUser on the
+  # currently-running manager/scheduler/seed risks a crashloop that cannot be
+  # live-verified from here, so it is intentionally NOT applied. If a Sovereign
+  # flips the runAsNonRoot rule to Enforce, exclude the `dragonfly` namespace
+  # (same tier as the host-ns control planes already excluded) rather than
+  # re-image the upstream binaries.
+  postRenderers:
+    - kustomize:
+        patches:
+          # dfdaemon (client DaemonSet) — the live-denied workload.
+          - target:
+              kind: DaemonSet
+              labelSelector: component=client
+            patch: |
+              - op: add
+                path: /spec/template/spec/containers/0/securityContext
+                value:
+                  readOnlyRootFilesystem: true
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop: [ALL]
+          # manager (Deployment)
+          - target:
+              kind: Deployment
+              labelSelector: component=manager
+            patch: |
+              - op: add
+                path: /spec/template/spec/containers/0/securityContext
+                value:
+                  readOnlyRootFilesystem: true
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop: [ALL]
+          # scheduler (StatefulSet)
+          - target:
+              kind: StatefulSet
+              labelSelector: component=scheduler
+            patch: |
+              - op: add
+                path: /spec/template/spec/containers/0/securityContext
+                value:
+                  readOnlyRootFilesystem: true
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop: [ALL]
+          # seed-client (StatefulSet)
+          - target:
+              kind: StatefulSet
+              labelSelector: component=seed-client
+            patch: |
+              - op: add
+                path: /spec/template/spec/containers/0/securityContext
+                value:
+                  readOnlyRootFilesystem: true
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop: [ALL]

--- a/platform/dragonfly/blueprint.yaml
+++ b/platform/dragonfly/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-5-storage-and-data
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.0  # lockstep with chart/Chart.yaml (#4639 initial bp-dragonfly)
+  version: 0.1.1  # lockstep with chart/Chart.yaml (#4649 Kyverno readonlyrootfs compliance)
   card:
     title: Dragonfly
     family: foundation

--- a/platform/dragonfly/chart/Chart.yaml
+++ b/platform/dragonfly/chart/Chart.yaml
@@ -40,7 +40,15 @@ keywords: [catalyst, blueprint, dragonfly, p2p, registry, oci, image, distributi
 # scheduler + seedClient replicas 1, bundled mysql + redis enabled, every
 # workload + initContainer carries non-zero resources.requests so the
 # cluster Kyverno `resource-requests` Enforce policy admits it.
-version: 0.1.0
+# 0.1.1 (#4649): Kyverno `runasnonroot-readonlyrootfs` compliance. The
+# upstream chart has NO securityContext knob, so readOnlyRootFilesystem=true
+# is injected on all 4 dragonflyoss workloads via the bootstrap-kit slot's
+# Flux postRenderers; this chart adds the emptyDir extraVolumes/Mounts for
+# every dfdaemon-writable path (/var/lib/dragonfly, log dir, /var/run/
+# dragonfly socket, /tmp) so the read-only root does not crashloop, plus the
+# OTel inject-go annotation. Fixes the dfdaemon DaemonSet DESIRED=4 CURRENT=0
+# denial that wedged the self-sovereign cutover at the catalyst-api re-pull.
+version: 0.1.1
 appVersion: "2.5.0"
 maintainers:
   - name: OpenOva Catalyst

--- a/platform/dragonfly/chart/values.yaml
+++ b/platform/dragonfly/chart/values.yaml
@@ -69,6 +69,41 @@ dragonfly:
         limits:
           cpu: 500m
           memory: 512Mi
+    # ── Kyverno readOnlyRootFilesystem compliance (#4649) ──────────────────
+    # The cluster `runasnonroot-readonlyrootfs` Enforce ClusterPolicy DENIES
+    # any container without securityContext.readOnlyRootFilesystem=true. The
+    # upstream chart exposes NO securityContext knob, so the bootstrap-kit
+    # slot injects it via Flux postRenderers — but readOnlyRootFilesystem=true
+    # makes `/` read-only, so EVERY path the manager writes must be a mounted
+    # volume. The upstream default already mounts `logs`→/var/log/dragonfly/
+    # manager; add a writable work/cache home (workHome/cacheDir default to a
+    # path under the binary home) plus /tmp. The OTel annotation satisfies the
+    # `workload-must-be-otel-instrumented` Audit finding (manager is Go).
+    podAnnotations:
+      instrumentation.opentelemetry.io/inject-go: "true"
+    extraVolumes:
+      - name: logs
+        emptyDir: {}
+      - name: work
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+    extraVolumeMounts:
+      - name: logs
+        mountPath: /var/log/dragonfly/manager
+      - name: work
+        mountPath: /var/lib/dragonfly
+      - name: tmp
+        mountPath: /tmp
+    # Pin every writable dir under a MOUNTED path. Upstream leaves these empty
+    # ⇒ the binary defaults to $HOME/.dragonfly (/root/.dragonfly, read-only
+    # once readOnlyRootFilesystem=true). Explicit paths land on the `work`
+    # (/var/lib/dragonfly) + `logs` emptyDirs above.
+    config:
+      server:
+        workHome: /var/lib/dragonfly
+        logDir: /var/log/dragonfly/manager
+        cacheDir: /var/lib/dragonfly/cache
 
   # ── Scheduler (decides which peer serves which piece) ──────────────────
   scheduler:
@@ -89,6 +124,29 @@ dragonfly:
         limits:
           cpu: 500m
           memory: 512Mi
+    # ── Kyverno readOnlyRootFilesystem compliance (#4649) — see manager note ─
+    podAnnotations:
+      instrumentation.opentelemetry.io/inject-go: "true"
+    extraVolumes:
+      - name: logs
+        emptyDir: {}
+      - name: work
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+    extraVolumeMounts:
+      - name: logs
+        mountPath: /var/log/dragonfly/scheduler
+      - name: work
+        mountPath: /var/lib/dragonfly
+      - name: tmp
+        mountPath: /tmp
+    config:
+      server:
+        workHome: /var/lib/dragonfly
+        logDir: /var/log/dragonfly/scheduler
+        cacheDir: /var/lib/dragonfly/cache
+        dataDir: /var/lib/dragonfly/data
 
   # ── Seed Peer (seedClient) — does the per-cluster upstream fetch ───────
   # 1-2 seed nodes fetch each blob from ghcr ONCE, then the dfdaemon mesh
@@ -121,6 +179,31 @@ dragonfly:
       # Per #3971 a classless PVC is FORBIDDEN; the per-Sovereign overlay sets
       # SOVEREIGN_DRAGONFLY_SEED_STORAGE_CLASS to the provider's durable class.
       storageClass: ""
+    # ── Kyverno readOnlyRootFilesystem compliance (#4649) ──────────────────
+    # The seed peer is a dfdaemon (Rust). Its data dir /var/lib/dragonfly is
+    # the persistence PVC (already mounted) and its log dir /var/log/dragonfly/
+    # dfdaemon/ is the upstream `logs` emptyDir (re-declared below since setting
+    # extraVolumes OVERRIDES the upstream default). What the upstream seed-client
+    # StatefulSet does NOT mount — but the dfdaemon writes — is the unix-socket
+    # dir /var/run/dragonfly (download.server.socketPath) — on a read-only root
+    # the socket create would EACCES. Mount it (emptyDir; seed is NOT
+    # hostNetwork) plus /tmp. OTel annotation = Go/Rust dfdaemon (Audit finding).
+    podAnnotations:
+      instrumentation.opentelemetry.io/inject-go: "true"
+    extraVolumes:
+      - name: logs
+        emptyDir: {}
+      - name: socket-dir
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+    extraVolumeMounts:
+      - name: logs
+        mountPath: /var/log/dragonfly/dfdaemon/
+      - name: socket-dir
+        mountPath: /var/run/dragonfly
+      - name: tmp
+        mountPath: /tmp
     config:
       seedPeer:
         enable: true
@@ -154,6 +237,39 @@ dragonfly:
         limits:
           cpu: "1"
           memory: 1Gi
+    # ── Kyverno readOnlyRootFilesystem compliance (#4649) — the live denial ─
+    # The cluster `runasnonroot-readonlyrootfs` Enforce policy DENIED this
+    # DaemonSet (DESIRED=4 CURRENT=0) on kom4dc fbf043d2; zero dfdaemon pods →
+    # the cutover's catalyst-api re-pull hits `dial tcp 127.0.0.1:4001:
+    # connection refused` → ImagePullBackOff → cutover wedges at step-07. The
+    # securityContext (readOnlyRootFilesystem:true) is injected by the slot's
+    # Flux postRenderers (the upstream chart has no securityContext knob). With
+    # `/` read-only, every dfdaemon-writable path must be a mounted volume:
+    #   - /var/lib/dragonfly/          (storage.dir)  → `storage` emptyDir
+    #   - /var/log/dragonfly/dfdaemon/ (log dir)      → `logs` emptyDir
+    #   - /var/run/dragonfly           (socketPath)   → `socket-dir` hostPath
+    #                                     (template-managed; left as upstream)
+    #   - /tmp                                          → `tmp` emptyDir (added)
+    # Setting extraVolumes OVERRIDES the upstream `storage`+`logs` default, so
+    # both are re-declared here alongside the new `tmp`. The dfdaemon keeps
+    # running as root (hostNetwork/hostPID/hostIPC + the hostPath socket dir
+    # require it) — runAsNonRoot is NOT forced on it.
+    podAnnotations:
+      instrumentation.opentelemetry.io/inject-go: "true"
+    extraVolumes:
+      - name: storage
+        emptyDir: {}
+      - name: logs
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+    extraVolumeMounts:
+      - name: storage
+        mountPath: /var/lib/dragonfly/
+      - name: logs
+        mountPath: /var/log/dragonfly/dfdaemon/
+      - name: tmp
+        mountPath: /tmp
     config:
       # ── dfdaemon proxy = the node's containerd registry mirror ──────────
       # containerd on every node is configured (by dfinit below — or by


### PR DESCRIPTION
## Problem (verified live on kom4dc prov `fbf043d2`)

The cluster `runasnonroot-readonlyrootfs` ClusterPolicy (Enforce on a cutover-stage prov) DENIED the `dragonfly-client` (dfdaemon) DaemonSet:

```
policy runasnonroot-readonlyrootfs/container-readonlyrootfilesystem fail:
Every container in DaemonSet/dragonfly-client must set securityContext.readOnlyRootFilesystem=true
```

Result: DaemonSet `DESIRED=4 CURRENT=0` (zero pods admitted). The dfdaemon IS the node's containerd registry mirror at `127.0.0.1:4001`, so zero dfdaemon pods → the cutover's catalyst-api re-pull gets `dial tcp 127.0.0.1:4001: connect: connection refused` → ImagePullBackOff → cutover wedges at step-07 (sibling of #4637).

## Root cause

Upstream `dragonflyoss/dragonfly` 1.7.0 exposes **NO securityContext value knob** for any component (manager/scheduler/seedClient/client) — the workload templates never emit a per-container securityContext. The bundled mysql + redis bitnami subcharts already set `readOnlyRootFilesystem=true` themselves and are compliant.

## Fix

**Slot postRenderers** (the canonical Catalyst patch idiom for an upstream chart that lacks a knob, cf. `03-flux.yaml`) inject `readOnlyRootFilesystem: true` + `allowPrivilegeEscalation: false` + `capabilities.drop: [ALL]` onto all 4 dragonflyoss workload containers, targeting the release-name-independent `component` label.

**Chart `values.yaml`** adds emptyDir `extraVolumes`/`extraVolumeMounts` for every path the read-only root makes unwritable, so the workloads do not crashloop:

| workload | mounted writable paths |
|---|---|
| client (dfdaemon DaemonSet) | `/var/lib/dragonfly/` (storage.dir), `/var/log/dragonfly/dfdaemon/` (log), `/var/run/dragonfly` (socket, template hostPath), `/tmp` |
| seed-client (StatefulSet) | `/var/lib/dragonfly/` (PVC), `/var/log/dragonfly/dfdaemon/`, `/var/run/dragonfly` (socket — upstream does NOT mount it; EACCES on read-only root without this), `/tmp` |
| manager (Deployment) | `/var/lib/dragonfly` (workHome/cacheDir repinned off the read-only `$HOME` default), `/var/log/dragonfly/manager`, `/tmp` |
| scheduler (StatefulSet) | `/var/lib/dragonfly` (workHome/cacheDir/dataDir repinned), `/var/log/dragonfly/scheduler`, `/tmp` |

Also adds the `instrumentation.opentelemetry.io/inject-go: "true"` pod annotation (the `workload-must-be-otel-instrumented` Audit finding).

**Scope note on runAsNonRoot:** only the live-enforced `readOnlyRootFilesystem` rule is patched. The `runAsNonRoot` rule defaults to Audit and was not in the live denial; the dragonflyoss images run as root (`User:''`) and the dfdaemon `client` structurally needs root (hostNetwork/hostPID/hostIPC + the hostPath socket dir), so forcing `runAsUser` on the currently-running manager/scheduler/seed — a change that cannot be live-verified from here — is intentionally not applied.

## Lockstep

`0.1.0 → 0.1.1` across `chart/Chart.yaml` + `blueprint.yaml` + the bootstrap-kit slot pin. bp-dragonfly is a bootstrap-kit infra component (not a marketplace card), so it is not in the catalog-seed.

## Static verification (no cluster)

- `helm dependency build && helm template . --api-versions v2` renders clean (exit 0, no stderr).
- Applying the slot's postRenderers patches to the chart render via `kubectl kustomize` confirms all 4 dragonflyoss containers (incl. `DaemonSet/dragonfly-client`) gain `readOnlyRootFilesystem: true`.
- Every dfdaemon-writable path has a corresponding mount in the rendered output (verified per-component).
- `helm lint` passes; catalog-seed lockstep guard passes (69 checked, 0 fail); no banned words.

The Harbor-proxy-pull image-source Audit finding (dragonflyoss/* + bitnamilegacy/* from docker.io) is noted but left for the separate post-cutover registry-pivot — it is not the load-bearing denial.

Refs #4640 #4637 #4649

🤖 Generated with [Claude Code](https://claude.com/claude-code)