### PR TITLE
fix(kyverno-policies): exempt dragonfly registry-layer ns from the compliance set — the real cutover step-07 wedge-cause

### DIFF
--- a/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
+++ b/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
@@ -150,7 +150,7 @@ spec:
       # that span unbounded org-<uuid> namespaces the excludeNamespaces list can't
       # enumerate; without this the WordPress mysql Deployment was admission-blocked
       # → 0 pods → WordPress had no DB. Refs #4422 #3376.
-      version: 1.0.43
+      version: 1.0.44
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno

--- a/platform/kyverno-policies/chart/Chart.yaml
+++ b/platform/kyverno-policies/chart/Chart.yaml
@@ -298,7 +298,7 @@ type: application
 # namespaces the excludeNamespaces list can't enumerate. Mirrors the cnpg.io/
 # cluster label-exempt on backup-configured (#3971). Template+values change.
 # Refs #4422 #3376.
-version: 1.0.43
+version: 1.0.44
 appVersion: "1.0.2"
 keywords: [catalyst, blueprint, kyverno, policy, compliance, audit]
 maintainers:

--- a/platform/kyverno-policies/chart/values.yaml
+++ b/platform/kyverno-policies/chart/values.yaml
@@ -81,6 +81,19 @@ compliancePolicies:
       - flux-system
       - cilium
       - cilium-gateway
+      # dragonfly (#4640/#4637, 2026-06-30): bp-dragonfly is the P2P
+      # registry-distribution layer — the per-node dfdaemon is containerd's
+      # 127.0.0.1 mirror, peer to cilium as core image-path plumbing. Its
+      # workloads run upstream third-party images (docker.io/dragonflyoss/* +
+      # a docker.io/busybox init) that, by construction, CANNOT be required to
+      # pull through the very registry they bootstrap (harbor-proxy-pull) and
+      # carry the upstream chart's `:latest` busybox init (image-tag-pinned).
+      # Post-cutover both Enforce policies denied the recycled dragonfly-client
+      # DaemonSet → DS to 0 → node mirror dead → cutover wedged at step-07.
+      # Same trust tier + same treatment as cilium/cert-manager/kyverno: exempt
+      # from the compliance set via this shared anchor. (probes-present +
+      # resource-requests are satisfied by the bp-dragonfly chart regardless.)
+      - dragonfly
       - cert-manager
       - openova-system
       - catalyst
@@ -299,6 +312,10 @@ compliancePolicies:
       # is already exempt via complianceDefaultExcludes); exempt it here for
       # the image-source glob only. It stays subject to every OTHER policy.
       - crossplane-system
+      # NOTE: `dragonfly` is NOT listed here — it is in the shared
+      # complianceDefaultExcludes anchor (top of this file), which this policy's
+      # excludeNamespaces references, so it is already covered for the
+      # image-source glob AND every other compliance policy (see the anchor).
 
   imageTagPinned:
     enabled: true


### PR DESCRIPTION
## Live root cause (kom4dc fbf043d2)
The bp-dragonfly `dragonfly-client` dfdaemon DaemonSet was DENIED at admission by two ENFORCE policies — `harbor-proxy-pull` (images are `docker.io/dragonflyoss/*`, not local-Harbor) and `image-tag-pinned` (upstream `busybox:latest` init). The dfdaemon IS the node mirror, so by construction it cannot be required to pull through the registry it bootstraps. When it recycled mid-cutover, Kyverno denied re-creation -> DaemonSet to 0 -> node mirror dead -> catalyst-api re-pull (cutover step-07) ImagePullBackOff -> cutover wedged at 54%.

## Fix
`dragonfly` is core registry-distribution plumbing, peer to `cilium`/`cert-manager`/`kyverno` which are ALL already in the shared `complianceDefaultExcludes` anchor — it was just missed (new component). Add it to the anchor: one consistent change, same treatment as the other core-plumbing namespaces.

## Live-proven
After applying the exemption to the live policies, all 4 dfdaemon pods ADMIT + run 1/1 (were 0/4). `helm template` renders clean; chart 1.0.43->1.0.44 + slot pin lockstep.

## Note
The `readOnlyRootFilesystem` policy (#4650 target) is **Audit**, not the wedge-cause — see #4649.

Refs #4640 #4637

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- ci-retrigger -->
