### PR TITLE
fix(catalog-seed): gate bp-wordpress alias off on qaFixtures provs — kill the duplicate-Blueprint post-render wedge

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1232,7 +1232,7 @@ spec:
       #   stamp spec.parameters.sovereignFqdn so the openova-MCP URL points at
       #   this Sovereign, not the mothership. catalyst-api + application-controller
       #   image fixes (deploy-bot pins on next build). Lockstep w/ Chart.yaml.
-      version: 1.4.957
+      version: 1.4.958
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -1012,29 +1012,29 @@ echo "[cutover-contract] Case 31: step-04 registry-pivot uses the Dragonfly path
 #   (d) the legacy registries.yaml / k3s registries.yaml machinery is GONE.
 pivot_block="$(awk '/name: registry-pivot-script/{c=1} c{print} c&&/^---/{if(seen)exit; seen=1}' "$TMP/render.yaml")"
 # (a) containerd _default catch-all -> the node-local dfdaemon proxy.
-if ! printf '%s\n' "$pivot_block" | grep -q '127.0.0.1:'; then
+if ! grep -q '127.0.0.1:' <<<"$pivot_block"; then
   echo "FAIL: step-04 pivot script does not point containerd at the node-local dfdaemon proxy (127.0.0.1) — the #4639 generic mirror (#4639)" >&2
   exit 1
 fi
-if ! printf '%s\n' "$pivot_block" | grep -q '_default/hosts.toml'; then
+if ! grep -q '_default/hosts.toml' <<<"$pivot_block"; then
   echo "FAIL: step-04 pivot script does not write the containerd _default/hosts.toml catch-all that mirrors every registry namespace through dfdaemon (#4639)" >&2
   exit 1
 fi
 # (b) dfdaemon upstream flip to the local Harbor on the gateway HTTPS port.
-if ! printf '%s\n' "$pivot_block" | grep -q 'registryMirror'; then
+if ! grep -q 'registryMirror' <<<"$pivot_block"; then
   echo "FAIL: step-04 pivot script does not flip the dfdaemon registryMirror upstream to the local Harbor (#4639)" >&2
   exit 1
 fi
-if ! printf '%s\n' "$pivot_block" | grep -q 'GATEWAY_HTTPS_PORT'; then
+if ! grep -q 'GATEWAY_HTTPS_PORT' <<<"$pivot_block"; then
   echo "FAIL: step-04 pivot script does not target the gateway HTTPS port for the local-Harbor upstream (so the token realm stays node-routable) (#4639)" >&2
   exit 1
 fi
 # (c) the registry.<fqdn> -> cilium-gateway ClusterIP hostAlias (the #4637 kill).
-if ! printf '%s\n' "$pivot_block" | grep -q 'hostAliases'; then
+if ! grep -q 'hostAliases' <<<"$pivot_block"; then
   echo "FAIL: step-04 pivot script does not patch a registry.<fqdn> -> cilium-gateway ClusterIP hostAlias onto the dfdaemon pod template (the #4637 token-realm hairpin kill) (#4639)" >&2
   exit 1
 fi
-if ! printf '%s\n' "$pivot_block" | grep -q 'GATEWAY_SERVICE_NAME'; then
+if ! grep -q 'GATEWAY_SERVICE_NAME' <<<"$pivot_block"; then
   echo "FAIL: step-04 pivot script does not resolve the cilium-gateway Service ClusterIP for the hostAlias (#4639)" >&2
   exit 1
 fi
@@ -1049,7 +1049,7 @@ if grep -qF -e 'registries.yaml.v1:' -e 'registries.yaml.v2:' \
   exit 1
 fi
 # step-04 MUST stay daemonset-wait with the per-node ack convention intact.
-if ! printf '%s\n' "$pivot_block" | grep -q 'node.${NODE_NAME}.registriesYaml'; then
+if ! grep -q 'node.${NODE_NAME}.registriesYaml' <<<"$pivot_block"; then
   echo "FAIL: step-04 pivot script no longer writes the per-node node.<NODE>.registriesYaml ack the daemonset-wait counts (#3671)" >&2
   exit 1
 fi

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3407,7 +3407,7 @@ name: bp-catalyst-platform
 #   sovereign-fqdn) so GET /catalog/regions returns the Sovereign's REAL
 #   regions instead of [] — the marketplace BCP picker stops falling back to
 #   the hardcoded Hetzner list.
-version: 1.4.957
+version: 1.4.958
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/
 #   platform/crossplane chart + blueprint.yaml + bootstrap-kit slot 04). crossplane-core
 #   was still OOMKilled (CrashLoopBackOff, 55 restarts, exit 137, killed ~90s after start)

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -152,8 +152,15 @@ spec:
             type: string
             description: "Admin email (must match Keycloak realm email claim)."
 ---
+{{- if not $.Values.qaFixtures.enabled }}
 # bp-wordpress — production alias for the bare `wordpress` / `bp-wordpress`
 # slug (2026-06-19, #3870 / #3376). The customer-facing marketplace funnel
+# NOTE (2026-06-30, #4655): gated `not qaFixtures.enabled` — on a qaTestEnabled
+# prov the templates/qa-fixtures/blueprint-bp-wordpress.yaml fixture ALSO seeds a
+# `bp-wordpress` Blueprint, so rendering this alias too registers the id twice →
+# Helm post-render "may not add resource with an already registered id:
+# Blueprint/bp-wordpress" → bp-catalyst-platform install fails → fresh qa provs
+# wedge at ~59/65 HRs. Production (qaFixtures off) still gets this alias.
 # (core/marketplace AppsStep.svelte) sells WordPress under `slug: wordpress`,
 # and operator docs + the qa-loop matrix POST `"blueprint":"bp-wordpress"`.
 # The console resolves both via the catalog-client bare→`bp-` prefix retry
@@ -271,6 +278,7 @@ spec:
           email:
             type: string
             description: "Admin email (must match Keycloak realm email claim)."
+{{- end }}
 ---
 apiVersion: catalyst.openova.io/v1
 kind: Blueprint


### PR DESCRIPTION
## Problem (caught live on the cutover-validation prov 5d4935b9)
Fresh **qaTestEnabled** provs wedge at ~59/65 HRs: `bp-catalyst-platform` Helm install fails with `error while running post render: may not add resource with an already registered id: Blueprint/bp-wordpress`. So the prov never reaches `ready` → no handover → no cutover.

## Root cause (a #3870 regression, qa-only)
The #3870 catalog-seed `bp-wordpress` alias (alias-of `bp-wordpress-tenant`) renders always-on. On a qaTestEnabled prov, `templates/qa-fixtures/blueprint-bp-wordpress.yaml` ALSO seeds a `bp-wordpress` Blueprint → the id `Blueprint/bp-wordpress` is registered twice → post-render fails. Production provs (qaFixtures off) only render the alias, so it was never caught.

## Fix
Gate the alias `{{ if not qaFixtures.enabled }}`: qa provs use the qa-fixtures bp-wordpress; production uses the alias. `helm template` proves **exactly 1** bp-wordpress Blueprint in BOTH modes. Chart 1.4.957→1.4.958 + slot pin lockstep.

Refs #3870 #4655

🤖 Generated with [Claude Code](https://claude.com/claude-code)