### PR TITLE
fix(qa-fixtures): default-deny CCNP exempt huawei-evs-csi + dragonfly + org-services — the REAL cutover-validation wedge

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1232,7 +1232,7 @@ spec:
       #   stamp spec.parameters.sovereignFqdn so the openova-MCP URL points at
       #   this Sovereign, not the mothership. catalyst-api + application-controller
       #   image fixes (deploy-bot pins on next build). Lockstep w/ Chart.yaml.
-      version: 1.4.958
+      version: 1.4.959
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/templates/qa-fixtures/cilium-network-policies.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/cilium-network-policies.yaml
@@ -31,7 +31,17 @@
   auto-trigger Job stuck 20m on "catalyst-api not ready HTTP 000000" (DNS+egress denied).
   newapi — bp-newapi ships an Application namespace whose pods need DNS/apiserver.
 */ -}}
-{{- $excludedNamespaces := list "kube-system" "cilium" "flux-system" "catalyst-system" "catalyst" "newapi" "kyverno" "openbao" "keycloak" "gitea" "powerdns" "external-dns" "external-secrets-system" "cert-manager" "harbor" "grafana" "loki" "mimir" "tempo" "alloy" "opentelemetry" "trivy-system" "syft-grype" "sigstore-system" "falco" "vpa" "cluster-autoscaler" "cnpg-system" "valkey" "nats-system" "velero" "guacamole" "coraza" "crossplane-system" }}
+{{- /*
+  #4657 (2026-06-30): huawei-evs-csi + dragonfly + org-services were MISSING — on a
+  qaTestEnabled prov this default-deny denied the EVS CSI provisioner egress to the
+  apiserver → catalyst-api PVCs never bind → catalyst-api Pending → handover/cutover
+  never fire (the exact wedge on cutover-validation provs; NOT a Cilium MTU bug — this
+  policy only exists on qaFixtures provs, which is why production never hit it). Storage
+  CSI drivers + the Dragonfly registry layer + the org-services provisioning plane are
+  platform infra that legitimately need apiserver/DNS egress. (hcloud-csi / other-provider
+  CSI namespaces belong here too if a provider runs its CSI in a dedicated ns.)
+*/ -}}
+{{- $excludedNamespaces := list "kube-system" "cilium" "flux-system" "catalyst-system" "catalyst" "newapi" "kyverno" "openbao" "keycloak" "gitea" "powerdns" "external-dns" "external-secrets-system" "cert-manager" "harbor" "grafana" "loki" "mimir" "tempo" "alloy" "opentelemetry" "trivy-system" "syft-grype" "sigstore-system" "falco" "vpa" "cluster-autoscaler" "cnpg-system" "valkey" "nats-system" "velero" "guacamole" "coraza" "crossplane-system" "huawei-evs-csi" "dragonfly" "org-services" }}
 {{- $qaNs := .Values.qaFixtures.namespace | default "qa-omantel" }}
 {{- if .Values.qaFixtures.networkPolicies.enabled | default true }}
 ---


### PR DESCRIPTION
## Root cause (live-proven, answers "why only today")
The qa-fixtures cluster-wide `default-deny` CCNP exempts 34 platform namespaces but **omitted `huawei-evs-csi`**. This policy is `managed-by: qa-fixtures` → it renders **only on qaTestEnabled provs** (exactly what the cutover auto-fire gate #4648 requires). On those provs it default-denied the EVS CSI provisioner egress to the apiserver → catalyst-api PVCs never bound (`VolumeBinding deadline`) → catalyst-api Pending → handover/cutover never fired. **Production provs (qaFixtures off) never get this policy — which is why it never bit before.**

This supersedes the earlier Cilium-MTU diagnosis (#4656), which was wrong: MTU=1370 was stable across green provs, so it could not be the differentiator. The differentiator was qaFixtures.

## Live proof
Added `huawei-evs-csi` to the live CCNP exemption → **PVCs bound 2/2 + catalyst-api Running within 20s.** Also add `dragonfly` (registry layer) + `org-services` (provisioning plane) — both default-denied + crashlooping (dfdaemon could not reach its scheduler) for the same reason. `helm template` confirms all three exempted. Chart 1.4.958→1.4.959 + slot lockstep.

Refs #4657 #4637 #4656

🤖 Generated with [Claude Code](https://claude.com/claude-code)