### PR TITLE
fix(qa-fixtures): declare resources.requests on qa-cnpg-backup-s3-seed Job (resource-requests Enforce denial on upgrade/rollback)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1232,7 +1232,7 @@ spec:
       #   stamp spec.parameters.sovereignFqdn so the openova-MCP URL points at
       #   this Sovereign, not the mothership. catalyst-api + application-controller
       #   image fixes (deploy-bot pins on next build). Lockstep w/ Chart.yaml.
-      version: 1.4.960
+      version: 1.4.961
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3407,7 +3407,7 @@ name: bp-catalyst-platform
 #   sovereign-fqdn) so GET /catalog/regions returns the Sovereign's REAL
 #   regions instead of [] — the marketplace BCP picker stops falling back to
 #   the hardcoded Hetzner list.
-version: 1.4.960
+version: 1.4.961
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/
 #   platform/crossplane chart + blueprint.yaml + bootstrap-kit slot 04). crossplane-core
 #   was still OOMKilled (CrashLoopBackOff, 55 restarts, exit 137, killed ~90s after start)

--- a/products/catalyst/chart/templates/qa-fixtures/cnpg-clusters-qa.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/cnpg-clusters-qa.yaml
@@ -134,6 +134,14 @@ spec:
       containers:
         - name: seed
           image: harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.29.3
+          # #4658: declare resources.requests — the cluster-wide resource-requests
+          # Kyverno policy is Enforce and denies any container without them. Without
+          # this the Job is admitted only by install-timing luck and gets DENIED on
+          # any later Helm upgrade/rollback re-create (caught live on 4f8d845d).
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
           command: ["sh", "-c"]
           args:
             - |


### PR DESCRIPTION
The seed container had no `resources.requests`; the cluster-wide `resource-requests` Kyverno policy is **Enforce**. On fresh install it admits by timing luck, but on any later Helm upgrade/rollback re-create it is DENIED → bp-catalyst-platform stuck in a rollback loop (caught live on 4f8d845d during a version bump). Adds cpu 25m / memory 32Mi. Sibling qa-fixtures Jobs may share this — noted for follow-up.

Refs #4658

🤖 Generated with [Claude Code](https://claude.com/claude-code)