### PR TITLE
fix(cutover): gitea-admin-secret bridge materializes at runtime not render-time — kill step-06/09 CreateContainerConfigError wedge

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -702,7 +702,20 @@ spec:
       # (registry.<fqdn> -> gateway ClusterIP, no fallthrough) + materialises the
       # dragonfly-harbor-ca Secret + sets dfdaemon registryMirror.cert — the last
       # dfdaemon->Harbor leg. Pairs with bp-dragonfly >= 0.1.1 (optional cert mount).
-      version: 0.1.94
+      # 0.1.95 (#4660 Refs #4557 #3811): the gitea-admin-secret bridge now
+      # materialises at RUNTIME (new regular Job 00-gitea-admin-secret-bridge-job
+      # .yaml) instead of only at Helm RENDER time. The render-time lookup bridge
+      # (00-gitea-admin-secret-bridge.yaml) returns nil on a fresh prov because
+      # slot 06a renders BEFORE bp-gitea (slot ~14) exists, so the bridge Secret
+      # was never emitted and step-06 (helmrepository-patches) / step-09
+      # (gitea-token-mint) hit CreateContainerConfigError "secret gitea-admin-
+      # secret not found" → the cutover wedged at step-06 (live prov 17c2e8b2).
+      # The new Job polls (30 min default budget, values-overridable) for the
+      # source secret to appear and copies it into the `catalyst` release ns —
+      # event-driven, not render-time-bound. NOT a Helm hook (converges async
+      # behind disableWait:true). No step-count change; the Job carries
+      # component=gitea-admin-secret-bridge, not the cutover-step label.
+      version: 0.1.95
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.94
+  version: 0.1.95
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,44 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.95 (#4660 Refs #4557 #3811 #3379, the gitea-admin-secret bridge is
+# render-time-fragile and wedges the cutover at step-06): the companion
+# 00-gitea-admin-secret-bridge.yaml Helm-`lookup`s `gitea/gitea-admin-secret`
+# at RENDER time and re-emits it into the cutover release namespace (`catalyst`)
+# so the step Jobs' `secretKeyRef` (06-helmrepository-patches /
+# 09-gitea-token-mint, resolvable ONLY in the Pod's own namespace) finds it.
+# But bp-self-sovereign-cutover installs DORMANT at bootstrap-kit slot 06a,
+# which renders BEFORE bp-gitea (slot ~14) exists → the lookup returns nil →
+# the bridge Secret is NEVER emitted. Once the cutover HR reaches Ready (no
+# drift) helm-controller does NOT re-render, so the bridge stays absent
+# indefinitely and step-06/09 fail `CreateContainerConfigError: secret
+# "gitea-admin-secret" not found` → the cutover wedges at step-06 (failedStep
+# pct=45, live on prov 17c2e8b2 / kom4dc).
+#
+# THE FIX (new template 00-gitea-admin-secret-bridge-job.yaml): a REGULAR
+# (non-hook) Job ships with the chart and runs at install. It WAITS at RUNTIME
+# (poll loop, 30s × 60 = 30 min default budget, values-overridable) for the
+# source `gitea/gitea-admin-secret` to exist, then copies it into the release
+# namespace as `destSecretName`. Runtime copy is EVENT-DRIVEN, not render-time-
+# bound, so a late-arriving secret is materialised regardless of when bp-gitea
+# converges relative to slot 06a. NOT a Helm hook (a 30-min hook poll would
+# block the HR install/upgrade; this Job converges asynchronously behind the
+# 06a HR's disableWait:true, like the dormant registry-pivot DaemonSet). The
+# render-time lookup Secret is KEPT as the zero-cost fast path. Scoped by a
+# dedicated SA + a same-ns Role (create + name-scoped get/patch on the dest
+# Secret) + a `gitea`-ns Role granting get scoped via resourceNames to ONLY
+# `gitea-admin-secret` (cannot read any other cluster Secret). Container carries
+# resources.requests cpu 25m/mem 32Mi (the resource-requests Enforce policy),
+# pulls images.kubectl (alpine/k8s) via the harbor-proxy path (the harbor-proxy-
+# pull + image-tag-pinned Enforce policies), and streams the password bytes
+# kubectl→jq→kubectl in-pod, never echoed (#10). New values block
+# .Values.giteaAdminSecretBridge.runtimeJob.{enabled,pollIntervalSeconds,
+# pollMaxAttempts,activeDeadlineSeconds,ttlSecondsAfterFinished}. NO step-count
+# / job-mode / cutover-step-label change — the Job carries
+# catalyst.openova.io/component=gitea-admin-secret-bridge, so catalyst-api step
+# discovery + the contract test's exact-step-count assertion (11 steps / 10
+# job-mode) are unaffected. RBAC of the cutover-runner SA is untouched (the
+# bridge Job uses its OWN narrowly-scoped SA). Lockstep w/ blueprint.yaml +
+# 06a slot pin. Refs #4660 #4557 #3811 #3379.
 # 0.1.94 (#4652 Refs #4641 #4637, the LAST registry-pivot leg — dfdaemon ->
 # Harbor): step-04 (registry-pivot) now ALSO closes the two coupled faults that
 # wedged step-07 on kom4dc. (DNS) The pod hostAlias is insufficient for the Rust
@@ -1386,7 +1425,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.94
+version: 0.1.95
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/00-gitea-admin-secret-bridge-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/00-gitea-admin-secret-bridge-job.yaml
@@ -1,0 +1,317 @@
+{{- /*
+RUNTIME bridge of `gitea-admin-secret` into the cutover RELEASE namespace
+(#4660, Refs #4557 #3811 #3379 #3642).
+
+WHY THIS FILE EXISTS (the durable fix for the render-time-fragile lookup)
+=========================================================================
+The companion 00-gitea-admin-secret-bridge.yaml Helm-`lookup`s the source
+secret (`gitea/gitea-admin-secret`) at RENDER time and re-emits a copy into
+this chart's release namespace (`catalyst`). But bp-self-sovereign-cutover
+installs DORMANT at bootstrap-kit slot 06a, which renders BEFORE bp-gitea
+(slot ~14) exists → the render-time lookup returns nil → the bridge Secret is
+never emitted. Once the cutover HR reaches Ready (no drift) helm-controller
+does NOT re-render, so the bridge stays absent indefinitely. The first cutover
+step Job that references `gitea-admin-secret` (06-helmrepository-patches and
+09-gitea-token-mint read it via a Kubernetes `secretKeyRef`, which resolves
+ONLY in the Pod's OWN namespace — there is no cross-namespace secretKeyRef)
+then fails `CreateContainerConfigError: secret "gitea-admin-secret" not found`
+→ the cutover wedges at step-06 (live on prov 17c2e8b2, kom4dc).
+
+THE FIX (runtime copy — event-driven, not render-time-bound)
+============================================================
+This Job ships with the chart and runs at install. It WAITS at RUNTIME (a
+poll loop, ~30 min default budget, values-overridable) for the source secret
+`gitea/gitea-admin-secret` to exist, then copies it into the release namespace
+as `destSecretName`. Because the wait happens at runtime — not at template
+render — a late-arriving secret is materialised regardless of when bp-gitea
+converges relative to slot 06a. The render-time lookup Secret is KEPT as the
+zero-cost fast path for re-installs/upgrades where gitea already exists; this
+Job is the GUARANTEE of eventual materialisation.
+
+NOT A HELM HOOK
+===============
+A `post-install` hook with a 30-min poll would BLOCK the cutover HR's
+install/upgrade (Helm waits on hook completion), and on a fresh prov gitea is
+not up at slot-06a time so the hook would burn its whole budget every install.
+This is a REGULAR Job; the 06a HelmRelease sets `disableWait: true`, so the HR
+reaches Ready immediately and the Job converges asynchronously in the
+background (exactly like the dormant registry-pivot DaemonSet that also ships
+as a regular workload in this chart).
+
+NO cutover-step labels
+======================
+This Job carries `catalyst.openova.io/component: gitea-admin-secret-bridge`
+(matching the lookup Secret), NEITHER the ConfigMap kind NOR the
+`app.kubernetes.io/component: cutover-step` label — so catalyst-api's step
+discovery (it selects step ConfigMaps by that label) and the contract test's
+exact-step-count assertion (11 steps / 10 job-mode) are unaffected.
+
+CREDENTIAL HYGIENE (docs/INVIOLABLE-PRINCIPLES.md #10)
+=====================================================
+The admin-password bytes are streamed kubectl→kubectl IN-POD (a `kubectl get
+secret -o json` of the source piped straight into a `kubectl apply` of the
+destination) and are NEVER echoed/printed. Per #4 (never hardcode): the
+source/destination namespace + secret name + poll budget all flow through
+.Values.giteaAdminSecretBridge.* with the observed defaults.
+
+RBAC SCOPING (feedback_rbac_create_no_resourcenames.md)
+=======================================================
+A dedicated ServiceAccount with TWO Roles:
+  - a same-namespace Role granting create (NO resourceNames) + get/patch
+    (resourceNames-scoped to the destination secret) on Secrets, so the copy
+    can land in the release namespace;
+  - a Role in the SOURCE namespace (`gitea`) granting get on Secrets scoped via
+    resourceNames to ONLY `gitea-admin-secret` — the Job cannot read any other
+    Secret in `gitea` or anywhere else on the cluster.
+`create` is in its OWN rule WITHOUT resourceNames (the apiserver authz layer
+403s a create rule that carries resourceNames — the bp-openbao 6+ loop root).
+*/}}
+{{- if and .Values.giteaAdminSecretBridge.enabled .Values.giteaAdminSecretBridge.runtimeJob.enabled -}}
+{{- $srcNs := .Values.giteaAdminSecretBridge.sourceNamespace | default "gitea" -}}
+{{- $srcName := .Values.giteaAdminSecretBridge.sourceSecretName | default "gitea-admin-secret" -}}
+{{- $destName := .Values.giteaAdminSecretBridge.destSecretName | default "gitea-admin-secret" -}}
+{{- $destNs := .Release.Namespace -}}
+{{- $saName := printf "%s-gitea-secret-bridge" (include "bp-self-sovereign-cutover.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- $interval := .Values.giteaAdminSecretBridge.runtimeJob.pollIntervalSeconds | default 30 -}}
+{{- $attempts := .Values.giteaAdminSecretBridge.runtimeJob.pollMaxAttempts | default 60 -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $saName }}
+  namespace: {{ $destNs }}
+  labels:
+    {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}
+    catalyst.openova.io/component: gitea-admin-secret-bridge
+---
+# Same-namespace Role: create (NO resourceNames per RBAC authz) + get/patch
+# (name-scoped) on Secrets, so the Job can write the destination Secret.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $saName }}
+  namespace: {{ $destNs }}
+  labels:
+    {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}
+    catalyst.openova.io/component: gitea-admin-secret-bridge
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: [{{ $destName | quote }}]
+    verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $saName }}
+  namespace: {{ $destNs }}
+  labels:
+    {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}
+    catalyst.openova.io/component: gitea-admin-secret-bridge
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $saName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $saName }}
+    namespace: {{ $destNs }}
+---
+# Source-namespace Role: get on Secrets scoped via resourceNames to ONLY
+# `gitea-admin-secret` — the Job cannot read any other Secret in `gitea`.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $saName }}-src
+  namespace: {{ $srcNs }}
+  labels:
+    {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}
+    catalyst.openova.io/component: gitea-admin-secret-bridge
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: [{{ $srcName | quote }}]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $saName }}-src
+  namespace: {{ $srcNs }}
+  labels:
+    {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}
+    catalyst.openova.io/component: gitea-admin-secret-bridge
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $saName }}-src
+subjects:
+  - kind: ServiceAccount
+    name: {{ $saName }}
+    namespace: {{ $destNs }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $saName }}
+  namespace: {{ $destNs }}
+  labels:
+    {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}
+    catalyst.openova.io/component: gitea-admin-secret-bridge
+spec:
+  backoffLimit: 6
+  ttlSecondsAfterFinished: {{ .Values.giteaAdminSecretBridge.runtimeJob.ttlSecondsAfterFinished | default 86400 }}
+  activeDeadlineSeconds: {{ .Values.giteaAdminSecretBridge.runtimeJob.activeDeadlineSeconds | default 2000 }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "bp-self-sovereign-cutover.name" . }}
+        catalyst.openova.io/blueprint: bp-self-sovereign-cutover
+        catalyst.openova.io/component: gitea-admin-secret-bridge
+    spec:
+      serviceAccountName: {{ $saName }}
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: gitea-secret-bridge
+          # alpine/k8s is the canonical kubectl image already used by every
+          # other cutover step Job (images.kubectl). cutoverPhase: pre — this
+          # Job runs at install time, long before the step-04 registry pivot,
+          # so it must pull from the bootstrap-configured proxy host, not the
+          # post-pivot local-Harbor global.imageRegistry.
+          image: {{ include "bp-self-sovereign-cutover.image" (dict "repository" .Values.images.kubectl.repository "tag" .Values.images.kubectl.tag "cutoverPhase" "pre" "Values" .Values) }}
+          imagePullPolicy: IfNotPresent
+          env:
+            # kubectl writes its discovery/http cache under $HOME/.kube — point
+            # HOME at the writable emptyDir since readOnlyRootFilesystem:true.
+            - name: HOME
+              value: /tmp
+            - name: SRC_NAMESPACE
+              value: {{ $srcNs | quote }}
+            - name: SRC_SECRET_NAME
+              value: {{ $srcName | quote }}
+            - name: DEST_NAMESPACE
+              value: {{ $destNs | quote }}
+            - name: DEST_SECRET_NAME
+              value: {{ $destName | quote }}
+            - name: POLL_INTERVAL_SECONDS
+              value: {{ $interval | quote }}
+            - name: POLL_MAX_ATTEMPTS
+              value: {{ $attempts | quote }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+
+              echo "[gitea-secret-bridge] source = ${SRC_NAMESPACE}/${SRC_SECRET_NAME}"
+              echo "[gitea-secret-bridge] dest   = ${DEST_NAMESPACE}/${DEST_SECRET_NAME}"
+              echo "[gitea-secret-bridge] poll   = ${POLL_INTERVAL_SECONDS}s x ${POLL_MAX_ATTEMPTS} attempts"
+
+              # ── 1. Fast path — destination already carries a usable secret ──
+              # If the render-time lookup bridge (00-gitea-admin-secret-bridge
+              # .yaml) already emitted the secret (gitea was up at render
+              # time), this Job is a no-op. We still RE-COPY below if the source
+              # is present, so a Gitea admin-password rotation propagates — but
+              # if the source is not yet up AND the dest already exists we exit
+              # 0 immediately rather than burning the poll budget.
+              dest_present="false"
+              if kubectl -n "${DEST_NAMESPACE}" get secret "${DEST_SECRET_NAME}" >/dev/null 2>&1; then
+                dest_present="true"
+                echo "[gitea-secret-bridge] destination secret already present (render-time bridge or prior run)"
+              fi
+
+              # ── 2. Wait at RUNTIME for the source secret to materialise ─────
+              # This is the whole point: bp-gitea (slot ~14) converges AFTER
+              # this chart (slot 06a), so on a fresh prov the source is absent
+              # at install. Poll until it appears (event-driven), bounded by the
+              # values-overridable budget.
+              attempt=0
+              src_ready="false"
+              while [ "${attempt}" -lt "${POLL_MAX_ATTEMPTS}" ]; do
+                attempt=$((attempt + 1))
+                if kubectl -n "${SRC_NAMESPACE}" get secret "${SRC_SECRET_NAME}" >/dev/null 2>&1; then
+                  echo "[gitea-secret-bridge] source secret found (attempt ${attempt}/${POLL_MAX_ATTEMPTS})"
+                  src_ready="true"
+                  break
+                fi
+                echo "[gitea-secret-bridge] source not yet present (attempt ${attempt}/${POLL_MAX_ATTEMPTS}) — sleeping ${POLL_INTERVAL_SECONDS}s"
+                sleep "${POLL_INTERVAL_SECONDS}"
+              done
+
+              if [ "${src_ready}" != "true" ]; then
+                if [ "${dest_present}" = "true" ]; then
+                  echo "[gitea-secret-bridge] source never appeared within budget, but destination already exists — leaving it untouched, exit 0"
+                  exit 0
+                fi
+                echo "[gitea-secret-bridge] FATAL: source ${SRC_NAMESPACE}/${SRC_SECRET_NAME} did not materialise within the poll budget and no destination secret exists" >&2
+                exit 1
+              fi
+
+              # ── 3. Copy source → destination (stream in-pod, never echo) ────
+              # kubectl get -o json of the source, jq-rewrite metadata (strip
+              # the source-bound resourceVersion / uid / managedFields /
+              # creationTimestamp / ownerReferences, re-target the namespace +
+              # name, stamp provenance annotations + labels), then apply into
+              # the destination. The .data (base64 password bytes) flows
+              # kubectl→jq→kubectl and is NEVER printed. `kubectl apply`
+              # create-or-updates, so a password rotation on the source
+              # propagates on a re-run.
+              echo "[gitea-secret-bridge] copying ${SRC_NAMESPACE}/${SRC_SECRET_NAME} -> ${DEST_NAMESPACE}/${DEST_SECRET_NAME}"
+              kubectl -n "${SRC_NAMESPACE}" get secret "${SRC_SECRET_NAME}" -o json \
+                | jq \
+                    --arg ns "${DEST_NAMESPACE}" \
+                    --arg name "${DEST_SECRET_NAME}" \
+                    --arg src "${SRC_NAMESPACE}/${SRC_SECRET_NAME}" \
+                    '{apiVersion, kind, type,
+                      metadata: {
+                        name: $name,
+                        namespace: $ns,
+                        labels: {
+                          "catalyst.openova.io/blueprint": "bp-self-sovereign-cutover",
+                          "catalyst.openova.io/component": "gitea-admin-secret-bridge",
+                          "app.kubernetes.io/part-of": "catalyst",
+                          "app.kubernetes.io/managed-by": "Helm"
+                        },
+                        annotations: {
+                          "catalyst.openova.io/mirrored-from": $src,
+                          "catalyst.openova.io/bridge": "gitea-admin-secret-cutover-ns-runtime-4660"
+                        }
+                      },
+                      data: (.data // {})}' \
+                | kubectl -n "${DEST_NAMESPACE}" apply -f - >/dev/null
+
+              # ── 4. Verify the destination now exists with the password key ──
+              if ! kubectl -n "${DEST_NAMESPACE}" get secret "${DEST_SECRET_NAME}" \
+                   -o jsonpath='{.data.password}' 2>/dev/null | grep -q .; then
+                echo "[gitea-secret-bridge] FATAL: destination secret missing the password key after copy" >&2
+                exit 1
+              fi
+              echo "[gitea-secret-bridge] destination ${DEST_NAMESPACE}/${DEST_SECRET_NAME} materialised — cutover step Jobs' secretKeyRef will now resolve"
+              echo "[gitea-secret-bridge] step complete"
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 16Mi
+{{- end }}

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -199,6 +199,50 @@ giteaAdminSecretBridge:
   destSecretName: "gitea-admin-secret"
   usernameKey: "username"
   passwordKey: "password"
+  # #4660 — RUNTIME materialisation Job (the durable fix for the render-time
+  # fragility of the Helm-lookup bridge above).
+  #
+  # WHY. The lookup-and-mirror Secret above reads the source at HELM RENDER
+  # time. But this chart installs DORMANT at bootstrap-kit slot 06a, which
+  # renders BEFORE bp-gitea (slot ~14) exists → the lookup returns nil → the
+  # bridge Secret is never emitted into the release namespace. Once the cutover
+  # HR reaches Ready (no drift) helm-controller does NOT re-render, so the
+  # render-time bridge stays absent indefinitely and the first cutover step Job
+  # that references `gitea-admin-secret` (06-helmrepository-patches /
+  # 09-gitea-token-mint, secretKeyRef in the Pod's OWN namespace) fails
+  # `CreateContainerConfigError: secret "gitea-admin-secret" not found` → the
+  # cutover wedges at step-06 (live on prov 17c2e8b2).
+  #
+  # THE FIX. A regular (non-hook) Job ships with the chart and runs at install.
+  # It WAITS at RUNTIME (poll loop) for the source `gitea/gitea-admin-secret`
+  # to exist, then copies it into the release namespace as `destSecretName`.
+  # Runtime copy is EVENT-DRIVEN (it watches the source appear) rather than
+  # render-time-bound, so a late-arriving secret is materialised regardless of
+  # when bp-gitea converges relative to slot 06a. The lookup Secret above is
+  # kept as the no-cost fast path for re-installs/upgrades where gitea already
+  # exists; this Job is the guarantee of eventual materialisation.
+  #
+  # The Job is scoped by a dedicated ServiceAccount + a same-namespace Role
+  # (create/get/patch the destination Secret) + a `gitea`-namespace Role
+  # scoped via resourceNames to read ONLY `gitea-admin-secret` — it cannot read
+  # any other Secret on the cluster. Per docs/INVIOLABLE-PRINCIPLES.md #10 the
+  # admin-password bytes are streamed kubectl→kubectl in-pod and never echoed.
+  runtimeJob:
+    # Flip false to ship ONLY the render-time lookup Secret (e.g. an env where
+    # gitea is guaranteed up before slot 06a renders). Default true.
+    enabled: true
+    # Poll budget — total wait = pollIntervalSeconds * pollMaxAttempts. Defaults
+    # 30s * 60 = 1800s (30 min), comfortably inside the HR install/upgrade 40m
+    # timeout and long enough to span the slot-06a → bp-gitea (slot ~14) gap on
+    # a cold fresh prov. Both values-overridable (Principle #4: no hardcoding).
+    pollIntervalSeconds: 30
+    pollMaxAttempts: 60
+    # Job-level activeDeadlineSeconds — must exceed pollIntervalSeconds *
+    # pollMaxAttempts plus a copy-and-verify margin. Default 2000s (~33 min).
+    activeDeadlineSeconds: 2000
+    # ttlSecondsAfterFinished — keep the completed Job around for operator
+    # forensics for a day by default, then auto-GC.
+    ttlSecondsAfterFinished: 86400
 
 # GitRepository pivot credential — step 05 (flux-gitrepository-patch). #3536.
 #

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5036,7 +5036,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.94"
+    version: "0.1.95"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Root cause (Refs #4660, root-caused live on prov 17c2e8b2 / kom4dc)

`platform/self-sovereign-cutover/chart/manifest/00-gitea-admin-secret-bridge.yaml`
bridges `gitea/gitea-admin-secret` into the cutover release namespace
(`catalyst`) using a Helm `lookup` that reads the source at **RENDER time** and
re-emits it. The cutover step Jobs (06-helmrepository-patches,
09-gitea-token-mint) read `gitea-admin-secret` via a Kubernetes `secretKeyRef`,
which resolves **only in the Pod's own namespace** (no cross-namespace form).

But bp-self-sovereign-cutover installs **dormant at bootstrap-kit slot 06a**,
which renders **before** bp-gitea (slot ~14) exists → the `lookup` returns nil →
the bridge Secret is never emitted into `catalyst`. Once the cutover HR reaches
Ready (no drift) helm-controller does **not** re-render, so the bridge stays
absent indefinitely → step-06/09 fail
`CreateContainerConfigError: secret "gitea-admin-secret" not found` → the
cutover wedges at step-06 (`failedStep=helmrepository-patches`, pct=45).

## Fix — Option A: runtime bridge Job (event-driven, not render-time-bound)

New regular (non-hook) Job `manifest/00-gitea-admin-secret-bridge-job.yaml`
ships with the chart and runs at install. It **waits at RUNTIME** (poll loop,
30s × 60 = 30 min default budget, values-overridable) for
`gitea/gitea-admin-secret` to exist, then copies it into the release namespace
as `destSecretName`. Because the wait is at runtime — not at manifest render —
a late-arriving secret is materialised regardless of when bp-gitea converges
relative to slot 06a.

**Why a regular Job, not a Helm hook:** a 30-min hook poll would block the
cutover HR's install/upgrade (Helm waits on hook completion), and on a fresh
prov gitea is not up at slot-06a time. As a regular workload it converges
asynchronously behind the 06a HR's `disableWait: true` — exactly like the
dormant registry-pivot DaemonSet this chart already ships. The render-time
`lookup` Secret is **kept** as the zero-cost fast path for re-installs/upgrades
where gitea already exists.

### Inviolable-principle compliance
- **#4 (no hardcoding):** source/dest namespace + secret name + poll
  poll-rounds + deadlines all flow through
  `.Values.giteaAdminSecretBridge.runtimeJob.*` + the existing
  `giteaAdminSecretBridge.{sourceNamespace,sourceSecretName,destSecretName}`.
- **#10 (credential hygiene):** the admin-password bytes stream
  kubectl→jq→kubectl in-pod, never echoed/printed.
- **resource-requests Enforce:** `cpu 25m / memory 32Mi` requests declared.
- **harbor-proxy-pull + image-tag-pinned Enforce:** pinned
  `harbor.openova.io/proxy-dockerhub/alpine/k8s:1.31.4` (the chart's existing
  `images.kubectl`, cutoverPhase=pre so it pulls from the bootstrap proxy host).
- **RBAC (feedback_rbac_create_no_resourcenames):** dedicated SA + same-ns Role
  (`create` in its own rule with NO resourceNames; `get/patch` name-scoped to
  the dest Secret) + a `gitea`-ns Role granting `get` scoped via `resourceNames`
  to **only** `gitea-admin-secret`. The cutover-runner SA RBAC is untouched.

## Verification
- `helm manifest . --api-versions v2 --set global.sovereignFQDN=t.omani.works` → exit 0.
- `helm lint .` → 0 failed.
- New SA + 2 Roles (dest-ns + `gitea`-ns resourceNames-scoped) + 2 RoleBindings + Job all render.
- Cutover contract test (`tests/cutover-contract.sh`) → **35/35 gates green**; step ConfigMap count still **11** (the Job carries `component=gitea-admin-secret-bridge`, not the cutover-step label).
- Job script passes `dash -n`, `busybox ash -n`, `sh -n` (no bashisms — the step-08 trap).
- jq transform simulated: produces a clean namespace-retargeted Secret with source-bound metadata stripped, data + provenance preserved.

## Lockstep version bump 0.1.94 → 0.1.95
- `platform/self-sovereign-cutover/chart/Chart.yaml`
- `platform/self-sovereign-cutover/blueprint.yaml`
- `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml` (slot pin)
- `products/catalyst/chart/manifest/catalog-seed/blueprints.yaml` (catalog seed)

## Note on coverage
This fix guarantees the secret lands in `catalyst` regardless of how the stamped
step Jobs reference it (the consuming Jobs use `secretKeyRef` in their own
namespace, the standard path). If a future cutover step were to read
`gitea-admin-secret` from a *different* namespace, that namespace would need its
own bridge — not covered here; all current consumers (06/07/09/10/11) run in
the `catalyst` release ns.

Refs #4660 #4557 #3811 #3379

🤖 Generated with [Claude Code](https://claude.com/claude-code)