### PR TITLE
fix(bp-self-sovereign-cutover): step-06 Phase-3a pivots HelmRepository url + pull-probe to gateway HTTPS endpoint :30443 — kill local-Harbor connection-timeout wedge at pct=45 (Refs #4666)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -715,7 +715,7 @@ spec:
       # event-driven, not render-time-bound. NOT a Helm hook (converges async
       # behind disableWait:true). No step-count change; the Job carries
       # component=gitea-admin-secret-bridge, not the cutover-step label.
-      version: 0.1.95
+      version: 0.1.96
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover
@@ -763,6 +763,18 @@ spec:
       # never Ready → bootstrap-kit Ks stuck (chicken-and-egg). See
       # t20 debug matrix.
       harborPublicURL: https://registry.${SOVEREIGN_FQDN}
+      # #4666 (Refs #3379 #4652) — the in-cluster cilium-gateway HTTPS NodePort.
+      # Post-#4652 CoreDNS resolves registry.${SOVEREIGN_FQDN} cluster-internally
+      # to the cilium-gateway Service ClusterIP, which listens on 30443 (cilium-
+      # envoy can't bind 443; the public 443->30443 translation is the EXTERNAL
+      # LB / NodePort, invisible in-cluster). Step-06 appends `:30443` to the
+      # pivoted HelmRepository host so BOTH the Flux source-controller pull AND
+      # the Phase-3a `helm pull` probe land on the LISTENING port — without it
+      # the bare-host (:443) pull connect-timed-out and the cutover wedged at
+      # step-06 pct=45 forever (live hw201, dep 413ef5f88eb63b2b). Matches the
+      # registryPivot.dragonfly.gatewayHTTPSPort the containerd/dfdaemon path
+      # already used.
+      gatewayHTTPSPort: "30443"
       giteaInternalURL: http://gitea-http.gitea.svc.cluster.local:3000
       giteaPublicURL: https://gitea.${SOVEREIGN_FQDN}
       # G... (#2989, 2026-06-04): Step 07 (catalyst-api-env-patch, Phase 3

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.95
+  version: 0.1.96
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,40 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.96 (#4666 Refs #3379 #4652, the step-06 Phase-3a LOCAL-HARBOR-PULL wedge —
+# the pivoted HelmRepository url + the pull probe targeted the implicit :443):
+# Post-#4652 the cutover rewrites CoreDNS so registry.<sov-fqdn> resolves cluster-
+# INTERNALLY to the cilium-gateway Service ClusterIP. But cilium-envoy cannot bind
+# privileged ports (cilium-agent gates the bind), so the gateway's HTTPS listener
+# is the high NodePort 30443 — the public 443->30443 translation is the EXTERNAL
+# Hetzner LB / Huawei NodePort, INVISIBLE to in-cluster clients. So step-06
+# Phase-1 pivoted every HelmRepository url to oci://registry.<fqdn>/openova-io
+# (bare host -> implicit :443) and Phase-3a probed `helm pull oci://registry.
+# <fqdn>/...` — both resolve to the gateway ClusterIP but connect to :443 on which
+# NOTHING listens -> `dial tcp <gw-clusterip>:443: connect: connection timed out`.
+# The Flux SOURCE-CONTROLLER hit the IDENTICAL timeout for every pivoted chart
+# (`failed to login to OCI registry: Get "https://registry.<fqdn>/v2/": ...
+# Client.Timeout`), so the pivot never reconciled, Phase-3a's strip-readiness gate
+# never converged, and the cutover wedged at step-06 failedStep=helmrepository-
+# patches pct=45 forever — on a PROD-cert env, so NOT the #3379/#4557 TLS leg
+# (cert trust was fine; x509-fail=0). Live root-cause on hw201 (dep
+# 413ef5f88eb63b2b, kom4dc): the step-03 prewarm pushed all 63 charts OK and a
+# `helm pull oci://registry.hw201.omani.works:30443/openova-io/bp-cilium`
+# SUCCEEDED while the same pull to the bare host (:443) timed out.
+# THE FIX: step-06 builds harbor_endpoint = harbor_host[:GATEWAY_HTTPS_PORT]
+# (30443, mirroring registryPivot.dragonfly.gatewayHTTPSPort which the
+# containerd/dfdaemon path already used) and uses it for (1) the Phase-1 url pivot
+# (local_prefix = oci://host:30443/openova-io — so source-controller lands on the
+# listening port and the durable Gitea YAML carries the port), (2) the Phase-3a
+# `helm registry login` + `helm pull` probe, and (3) the Phase-0 ghcr-pull auth
+# entry. (3) is load-bearing: docker/OCI auth is keyed on the EXACT host[:port]
+# string (proven live — auth under bare host -> pull from host:30443 401s `no
+# basic auth credentials`; auth under host:30443 -> pull OK), so Phase-0 now
+# writes the local-Harbor auth under BOTH the endpoint AND the bare host, and the
+# Phase-3b strip guard protects both. New value sovereign.gatewayHTTPSPort (default
+# "30443"; "" = legacy host-only pivot). New GATEWAY_HTTPS_PORT env on step-06.
+# Contract test Case asserts harbor_endpoint=host:GATEWAY_HTTPS_PORT + the
+# login/pull target it. NO step-count / job-mode change. Lockstep w/ 06a slot pin.
+# Refs #4666 #3379 #4652.
 # 0.1.95 (#4660 Refs #4557 #3811 #3379, the gitea-admin-secret bridge is
 # render-time-fragile and wedges the cutover at step-06): the companion
 # 00-gitea-admin-secret-bridge.yaml Helm-`lookup`s `gitea/gitea-admin-secret`
@@ -1425,7 +1460,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.95
+version: 0.1.96
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
@@ -76,6 +76,17 @@ data:
             value: {{ .Values.helmRepositories.upstreamPrefix | quote }}
           - name: HARBOR_PUBLIC_URL
             value: {{ .Values.sovereign.harborPublicURL | quote }}
+          # #4666 (Refs #3379 #4652): the in-cluster cilium-gateway HTTPS
+          # listener port. Post-#4652 CoreDNS resolves registry.<fqdn> to the
+          # gateway ClusterIP, which listens on this NodePort (30443) — NOT 443
+          # (cilium-envoy can't bind privileged ports; the public 443→30443
+          # translation is the EXTERNAL LB, invisible in-cluster). Step-06
+          # appends `:<this>` to the pivoted HelmRepository host so BOTH the
+          # source-controller pull (live URL) AND the Phase-3a probe target the
+          # listening port. Empty = legacy host-only pivot (registry.<fqdn> must
+          # genuinely answer on 443 in-cluster). See sovereign.gatewayHTTPSPort.
+          - name: GATEWAY_HTTPS_PORT
+            value: {{ .Values.sovereign.gatewayHTTPSPort | default "" | quote }}
           - name: SOVEREIGN_FQDN
             value: {{ .Values.sovereign.fqdn | quote }}
           - name: GITEA_INTERNAL_URL
@@ -190,9 +201,30 @@ data:
           - |
             set -eu
             harbor_host=$(printf '%s' "${HARBOR_PUBLIC_URL}" | sed -E 's,^https?://,,; s,/$,,')
-            local_prefix="oci://${harbor_host}/openova-io"
 
-            echo "[helmrepository-patches] upstream=${UPSTREAM_PREFIX} -> local=${local_prefix}"
+            # #4666 (Refs #3379 #4652) — the in-cluster pull ENDPOINT carries the
+            # gateway HTTPS port. CoreDNS (post-#4652) resolves registry.<fqdn>
+            # to the cilium-gateway ClusterIP, which listens on the high NodePort
+            # (GATEWAY_HTTPS_PORT, 30443) because cilium-envoy can't bind 443 —
+            # the public 443→30443 translation is the EXTERNAL LB and is INVISIBLE
+            # in-cluster. So a HelmRepository url of oci://registry.<fqdn>/...
+            # resolves to the gateway ClusterIP but connects to the implicit :443
+            # (nothing listening) → connect timeout for BOTH the Flux source-
+            # controller pull AND the Phase-3a probe (live wedge hw201). Pivoting
+            # to oci://registry.<fqdn>:30443/... lands the pull on the listening
+            # port. `harbor_host` stays the bare host (used by `helm registry
+            # login` + the Phase-3b strip-host comparison — the docker-config auth
+            # key + the gateway TLS SNI are host-only, NO port). `harbor_endpoint`
+            # = host[:port] is what every OCI URL (pivot + probe) uses. Empty
+            # GATEWAY_HTTPS_PORT → endpoint == host (legacy host-only behaviour).
+            if [ -n "${GATEWAY_HTTPS_PORT:-}" ]; then
+              harbor_endpoint="${harbor_host}:${GATEWAY_HTTPS_PORT}"
+            else
+              harbor_endpoint="${harbor_host}"
+            fi
+            local_prefix="oci://${harbor_endpoint}/openova-io"
+
+            echo "[helmrepository-patches] upstream=${UPSTREAM_PREFIX} -> local=${local_prefix} (harbor_host=${harbor_host}, endpoint=${harbor_endpoint})"
 
             # ---- Phase -1: wait for Cilium Gateway Programmed=True (issue #1871) ----
             #
@@ -375,30 +407,45 @@ data:
             # the idempotency check here is the simple "is the Harbor auth
             # already present" test; the strip's own idempotency lives in
             # Phase 3.
-            already=$(printf '%s' "${existing_json}" | jq -r --arg h "${harbor_host}" \
+            # #4666 (Refs #3379 #4652): the auth entry MUST be keyed on the
+            # HOST:PORT endpoint the pivoted HelmRepository urls carry
+            # (registry.<fqdn>:30443), NOT the bare host. Docker/OCI auth lookup
+            # is EXACT host[:port] string match — a pull from
+            # oci://registry.<fqdn>:30443/... finds NO credential under a bare-
+            # host `registry.<fqdn>` key and 401s `no basic auth credentials`
+            # (PROVEN live hw201: auth keyed on bare host → pull from host:30443
+            # FAILS; auth keyed on host:30443 → pull OK). source-controller reads
+            # THIS ghcr-pull dockerconfigjson for the pivoted pull, so the
+            # endpoint key is load-bearing. We write BOTH keys: the endpoint
+            # (host:port — the one source-controller + the Phase-3a probe use)
+            # AND the bare host (harmless belt-and-suspenders / legacy host-only
+            # consumers; identical when GATEWAY_HTTPS_PORT is empty).
+            already=$(printf '%s' "${existing_json}" | jq -r --arg h "${harbor_endpoint}" \
               '.auths[$h].auth // empty')
             harbor_auth=$(printf '%s:%s' "${HARBOR_USERNAME}" "${HARBOR_PASSWORD}" | base64 -w0)
 
             if [ -n "${already}" ] && [ "${already}" = "${harbor_auth}" ]; then
-              echo "[helmrepository-patches] Phase-0 skip: ghcr-pull already carries auth for ${harbor_host} (strip deferred to Phase 3)"
+              echo "[helmrepository-patches] Phase-0 skip: ghcr-pull already carries auth for ${harbor_endpoint} (strip deferred to Phase 3)"
             else
-              # Single jq pass: ADD harbor.<sov-fqdn> auth. This is the
-              # PURELY ADDITIVE half of the old combined pipeline — the
-              # destructive `del(.auths[...])` arms were moved to Phase 3
-              # (see the strip-before-pivot fix). Adding Harbor auth early
-              # is the precondition that lets Phase-1's pivoted
-              # HelmRepositories pull from local Harbor; it leaves the
-              # ghcr.io fallback intact so a wedge before Phase 3 is
-              # recoverable.
+              # Single jq pass: ADD harbor.<sov-fqdn> auth under BOTH the endpoint
+              # (host:port) and the bare host. This is the PURELY ADDITIVE half of
+              # the old combined pipeline — the destructive `del(.auths[...])`
+              # arms were moved to Phase 3 (see the strip-before-pivot fix).
+              # Adding Harbor auth early is the precondition that lets Phase-1's
+              # pivoted HelmRepositories pull from local Harbor; it leaves the
+              # ghcr.io fallback intact so a wedge before Phase 3 is recoverable.
               #
               # `--arg` ALWAYS treats its value as a string (no shell
               # interpolation), so the Harbor password is never re-parsed
-              # by the shell.
+              # by the shell. When harbor_endpoint==harbor_host (no port) the two
+              # assignments collapse to one key (idempotent).
               new_json=$(printf '%s' "${existing_json}" | jq \
+                --arg ep "${harbor_endpoint}" \
                 --arg h "${harbor_host}" \
                 --arg user "${HARBOR_USERNAME}" \
                 --arg auth "${harbor_auth}" \
-                '.auths[$h] = {"username":$user,"auth":$auth}')
+                '.auths[$ep] = {"username":$user,"auth":$auth}
+                 | .auths[$h]  = {"username":$user,"auth":$auth}')
               new_b64=$(printf '%s' "${new_json}" | base64 -w0)
               # Merge-patch the data field. Quoting note: ${GHCR_PULL_SECRET_KEY}
               # is `.dockerconfigjson` which is a literal key (the leading
@@ -408,7 +455,7 @@ data:
               if kubectl patch secret "${GHCR_PULL_SECRET_NAME}" \
                   -n "${GHCR_PULL_SECRET_NAMESPACE}" \
                   --type=merge --patch "${patch_payload}" >/dev/null; then
-                echo "[helmrepository-patches] Phase-0 OK: added ${harbor_host} auth to ${GHCR_PULL_SECRET_NAMESPACE}/${GHCR_PULL_SECRET_NAME} (ghcr.io fallback retained until Phase 3)"
+                echo "[helmrepository-patches] Phase-0 OK: added ${harbor_endpoint}${harbor_endpoint:+ + }${harbor_host} auth to ${GHCR_PULL_SECRET_NAMESPACE}/${GHCR_PULL_SECRET_NAME} (ghcr.io fallback retained until Phase 3)"
               else
                 echo "[helmrepository-patches] FATAL: kubectl patch ${GHCR_PULL_SECRET_NAME} failed" >&2
                 exit 1
@@ -1003,7 +1050,7 @@ data:
               2>/dev/null | while read -r hrname hrurl; do
                 [ -z "${hrname}" ] && continue
                 case "${hrurl}" in
-                  *"//${harbor_host}/"*|*"//${harbor_host}") printf '%s\n' "${hrname}" ;;
+                  *"//${harbor_endpoint}/"*|*"//${harbor_endpoint}") printf '%s\n' "${hrname}" ;;
                   *) : ;;
                 esac
               done | sort -u > "${local_hr_file}" || : > "${local_hr_file}"
@@ -1033,12 +1080,19 @@ data:
               | head -n "${HELM_PROBE_SAMPLE_SIZE}" >> "${sample_file}" || true
             sort -u "${sample_file}" -o "${sample_file}"
             sample_total=$(grep -c . "${sample_file}" || true)
-            echo "[helmrepository-patches] Phase-3a: ${probe_total} pivoted chart(s) on ${harbor_host}; probing a sample of ${sample_total}"
+            echo "[helmrepository-patches] Phase-3a: ${probe_total} pivoted chart(s) on ${harbor_endpoint}; probing a sample of ${sample_total}"
 
-            helm registry login "${harbor_host}" ${HELM_LOGIN_INSECURE_FLAG} \
+            # #4666: login to the gateway HTTPS ENDPOINT (host:30443), the same
+            # host:port the pivoted OCI urls carry — `helm registry login` keys
+            # its stored auth on the registry host[:port] string, so logging in
+            # to the bare host while pulling from host:30443 leaves the pull
+            # UNAUTHENTICATED (it then 401s "no basic auth credentials"). On a
+            # host-only pivot (GATEWAY_HTTPS_PORT empty) harbor_endpoint==host so
+            # this is unchanged.
+            helm registry login "${harbor_endpoint}" ${HELM_LOGIN_INSECURE_FLAG} \
               -u "${HARBOR_USERNAME:-admin}" -p "${HARBOR_PASSWORD}" >/dev/null 2>&1 \
-              && echo "[helmrepository-patches] Phase-3a: helm registry login ${harbor_host} OK" \
-              || echo "[helmrepository-patches] Phase-3a WARN: helm registry login ${harbor_host} returned non-zero (will retry inside the pull loop)"
+              && echo "[helmrepository-patches] Phase-3a: helm registry login ${harbor_endpoint} OK" \
+              || echo "[helmrepository-patches] Phase-3a WARN: helm registry login ${harbor_endpoint} returned non-zero (will retry inside the pull loop)"
 
             while [ "$(date +%s)" -lt "${strip_wait_deadline}" ]; do
               if [ "${sample_total}" -eq 0 ]; then
@@ -1060,7 +1114,7 @@ data:
                   | while read -r hrname hrurl; do
                       [ -z "${hrname}" ] && continue
                       case "${hrurl}" in
-                        *"//${harbor_host}/"*|*"//${harbor_host}") printf '%s\n' "${hrname}" ;;
+                        *"//${harbor_endpoint}/"*|*"//${harbor_endpoint}") printf '%s\n' "${hrname}" ;;
                         *) : ;;
                       esac
                     done | sort -u > "${local_hr_file}" || : > "${local_hr_file}"
@@ -1089,7 +1143,12 @@ data:
               pull_fail_names=""
               while IFS="$(printf '\t')" read -r p_chart p_ver; do
                 [ -z "${p_chart}" ] && continue
-                if helm pull "oci://${harbor_host}/openova-io/${p_chart}" ${HELM_PULL_INSECURE_FLAG} \
+                # #4666: pull from the gateway HTTPS ENDPOINT (host:30443) — the
+                # in-cluster CoreDNS resolves registry.<fqdn> to the gateway
+                # ClusterIP whose listener is 30443, so a bare-host (implicit
+                # :443) pull connect-times-out (the hw201 wedge). harbor_endpoint
+                # == host on a host-only pivot.
+                if helm pull "oci://${harbor_endpoint}/openova-io/${p_chart}" ${HELM_PULL_INSECURE_FLAG} \
                      --version "${p_ver}" -d /tmp/helm-pull >/tmp/.helm-pull.log 2>&1; then
                   pull_ok=$((pull_ok+1))
                 else
@@ -1099,10 +1158,10 @@ data:
               done < "${sample_file}"
               if [ "${pull_ok}" -gt 0 ] && [ "${pull_fail}" -eq 0 ]; then
                 ready_ok="true"
-                echo "[helmrepository-patches] Phase-3a OK: all ${pull_ok} sampled chart(s) pulled from ${harbor_host}/openova-io — local Harbor serves the charts + auth works"
+                echo "[helmrepository-patches] Phase-3a OK: all ${pull_ok} sampled chart(s) pulled from ${harbor_endpoint}/openova-io — local Harbor serves the charts + auth works"
                 break
               fi
-              echo "[helmrepository-patches] Phase-3a: ${pull_fail}/${sample_total} sampled chart(s) not yet pullable from ${harbor_host}: ${pull_fail_names:-<none>} (last error below); retrying in 15s"
+              echo "[helmrepository-patches] Phase-3a: ${pull_fail}/${sample_total} sampled chart(s) not yet pullable from ${harbor_endpoint}: ${pull_fail_names:-<none>} (last error below); retrying in 15s"
               sed 's/^/    /' /tmp/.helm-pull.log 2>/dev/null | tail -5 || true
               sleep 15
             done
@@ -1135,8 +1194,11 @@ data:
               rem="${rem#*,}"
               strip_host=$(printf '%s' "${strip_host}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
               [ -z "${strip_host}" ] && continue
-              if [ "${strip_host}" = "${harbor_host}" ]; then
-                echo "[helmrepository-patches] Phase-3b WARN: refusing to strip ${strip_host} (matches local harbor host); check .Values.harbor.mothershipAuthsToStrip overlay"
+              # #4666: protect BOTH the bare host AND the host:port endpoint —
+              # Phase-0 now writes the local-Harbor auth under both keys, so an
+              # overlay that erroneously lists either must never strip it.
+              if [ "${strip_host}" = "${harbor_host}" ] || [ "${strip_host}" = "${harbor_endpoint}" ]; then
+                echo "[helmrepository-patches] Phase-3b WARN: refusing to strip ${strip_host} (matches local harbor host/endpoint); check .Values.harbor.mothershipAuthsToStrip overlay"
                 continue
               fi
               present=$(printf '%s' "${strip_json}" | jq -r --arg h "${strip_host}" '.auths | has($h)')
@@ -1160,7 +1222,8 @@ data:
               rem="${rem#*,}"
               strip_host=$(printf '%s' "${strip_host}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
               [ -z "${strip_host}" ] && continue
-              if [ "${strip_host}" = "${harbor_host}" ]; then
+              # #4666: never strip the local Harbor host OR its host:port endpoint.
+              if [ "${strip_host}" = "${harbor_host}" ] || [ "${strip_host}" = "${harbor_endpoint}" ]; then
                 continue
               fi
               jq_filter="${jq_filter} | del(.auths[\$s${strip_idx}])"

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -373,12 +373,31 @@ fi
 #     Ready read could never become True → the strip was FATAL-refused every
 #     run and the cutover wedged at step-06 (hw146; also the hw144 0/0 shape,
 #     #3588). Guard against a regression back to the status-Ready read.
-if ! grep -Eq 'helm pull "oci://\$\{harbor_host\}/openova-io/' "$TMP/render.yaml"; then
-  echo "FAIL: Step-06 Phase-3a does not prove pullability via 'helm pull oci://\${harbor_host}/openova-io/<chart>' — the strip readiness gate is not a real authenticated pull (Refs #3627)" >&2
+if ! grep -Eq 'helm pull "oci://\$\{harbor_endpoint\}/openova-io/' "$TMP/render.yaml"; then
+  echo "FAIL: Step-06 Phase-3a does not prove pullability via 'helm pull oci://\${harbor_endpoint}/openova-io/<chart>' — the strip readiness gate is not a real authenticated pull against the gateway HTTPS endpoint (Refs #3627 #4666)" >&2
   exit 1
 fi
 if ! grep -q 'helm registry login' "$TMP/render.yaml"; then
   echo "FAIL: Step-06 Phase-3a does not 'helm registry login' the local Harbor before the pull probe (Refs #3627)" >&2
+  exit 1
+fi
+# #4666: the pivoted HelmRepository url + the Phase-3a probe MUST target the
+# in-cluster gateway HTTPS ENDPOINT (host[:port]). Post-#4652 CoreDNS resolves
+# registry.<fqdn> to the cilium-gateway ClusterIP, which listens on the high
+# NodePort (30443) — a bare-host (implicit :443) OCI pull connect-times-out for
+# both the Flux source-controller AND the Phase-3a probe (the hw201 wedge). The
+# step builds harbor_endpoint = harbor_host[:GATEWAY_HTTPS_PORT] and uses it for
+# the local_prefix (URL pivot), the login, and the pull. Guard the wiring.
+if ! grep -q 'GATEWAY_HTTPS_PORT' "$TMP/render.yaml"; then
+  echo "FAIL: Step-06 does not carry GATEWAY_HTTPS_PORT — the pivoted HelmRepository url + Phase-3a probe would target the implicit :443 and connect-timeout against the cilium-gateway ClusterIP (the hw201 wedge, Refs #4666)" >&2
+  exit 1
+fi
+if ! grep -Eq 'harbor_endpoint="\$\{harbor_host\}:\$\{GATEWAY_HTTPS_PORT\}"' "$TMP/render.yaml"; then
+  echo "FAIL: Step-06 does not derive harbor_endpoint=host:GATEWAY_HTTPS_PORT — the local-Harbor pull endpoint must carry the gateway HTTPS port (Refs #4666)" >&2
+  exit 1
+fi
+if ! grep -Eq 'helm registry login "\$\{harbor_endpoint\}"' "$TMP/render.yaml"; then
+  echo "FAIL: Step-06 Phase-3a 'helm registry login' must target harbor_endpoint (host:port) — docker/OCI auth is keyed on the exact host[:port], so a bare-host login leaves the host:port pull unauthenticated (Refs #4666)" >&2
   exit 1
 fi
 # The probe MUST run from a writable helm home (the Pod is

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -46,6 +46,38 @@ sovereign:
   # ↓ overlay required for real cutover (uses ${SOVEREIGN_FQDN}).
   #    MUST be `registry.<sov-fqdn>` to match the bp-harbor HTTPRoute.
   harborPublicURL: "https://registry.example.local"
+  # ── #4666 (Refs #3379 #4652) — the in-cluster gateway HTTPS port ──────────
+  # THE STEP-06 PHASE-3a LOCAL-HARBOR-PULL WEDGE FIX. Post-#4652 CoreDNS
+  # resolves `registry.<sov-fqdn>` cluster-INTERNALLY to the cilium-gateway
+  # Service ClusterIP (a `coredns-custom` registry-local.server block with NO
+  # fallthrough — the public EIP is never returned in-cluster). But cilium-envoy
+  # CANNOT bind privileged ports (cilium-agent gates the bind), so the gateway's
+  # HTTPS listener is the high NodePort 30443, NOT 443 (see
+  # clusters/_template/sovereign-tls/cilium-gateway.yaml — the public 443→30443
+  # translation is done by the EXTERNAL Hetzner LB / Huawei NodePort, which is
+  # invisible to in-cluster clients). So an in-cluster OCI pull of
+  # `oci://registry.<fqdn>/openova-io/...` resolves to the gateway ClusterIP but
+  # connects to the implicit `:443` — on which NOTHING listens → `connect:
+  # connection timed out`. This is EXACTLY what the Flux SOURCE-CONTROLLER hits
+  # for every pivoted HelmRepository AND what step-06 Phase-3a's `helm pull`
+  # probe hits (live evidence hw201 / dep 413ef5f88eb63b2b: the prewarm pushed
+  # all 63 charts OK, but `Head "https://registry.hw201.omani.works/v2/openova-
+  # io/bp-cilium/manifests/1.4.5": dial tcp 10.96.2.39:443: connect: connection
+  # timed out` on the probe, and source-controller `failed to login to OCI
+  # registry: Get "https://registry.hw201.omani.works/v2/": ... Client.Timeout`
+  # on every chart — while the SAME pull to `registry.hw201.omani.works:30443`
+  # succeeds). The dfdaemon/containerd path (step-04) already dials the local
+  # Harbor on this port (registryPivot.dragonfly.gatewayHTTPSPort); the
+  # source-controller / Flux OCI path did NOT carry the port until this fix.
+  #
+  # Step-06 appends `:<gatewayHTTPSPort>` to the pivoted HelmRepository host so
+  # both the live URL pivot (source-controller pulls) and the Phase-3a probe
+  # (`helm registry login` + `helm pull`) target the LISTENING port. Set to ""
+  # to pivot host-only (legacy behaviour) on a Sovereign whose in-cluster
+  # `registry.<fqdn>` genuinely answers on 443 (e.g. an operator who fronted the
+  # gateway with an in-cluster :443 Service/LB). Default 30443 = the canonical
+  # Catalyst gateway HTTPS NodePort (matches registryPivot.dragonfly.gatewayHTTPSPort).
+  gatewayHTTPSPort: "30443"
   giteaInternalURL: "http://gitea-http.gitea.svc.cluster.local:3000"
   # ↓ overlay supplies https://gitea.${SOVEREIGN_FQDN} (informational; jobs use internal URL).
   giteaPublicURL: "https://gitea.example.local"

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5036,7 +5036,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.95"
+    version: "0.1.96"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Problem
The self-sovereign cutover wedges at **step-06 `helmrepository-patches`, failedStep, pct=45** indefinitely — on a **PROD-LE-cert** env, so NOT the #3379/#4557 staging-TLS leg. The step-06 Job loops:

```
Phase-3a WARN: helm registry login registry.<fqdn> returned non-zero
Phase-3a: 6/6 sampled chart(s) not yet pullable from registry.<fqdn>: ...
    Error: failed to do request: Head "https://registry.<fqdn>/v2/openova-io/bp-cilium/manifests/1.4.5": dial tcp <gw-clusterip>:443: connect: connection timed out
FATAL: local-Harbor HelmRepositories did not all reach Ready=True within 600s — REFUSING to strip ...
```

## Root cause (live evidence — hw201 / dep 413ef5f88eb63b2b, kom4dc)
Post-#4652 the cutover rewrites CoreDNS so `registry.<fqdn>` resolves cluster-INTERNALLY to the **cilium-gateway Service ClusterIP**. But cilium-envoy **cannot bind privileged ports** (cilium-agent gates the bind), so the gateway's HTTPS listener is the high NodePort **30443**, not 443 — the public `443→30443` translation is the **external** Hetzner LB / Huawei NodePort, **invisible to in-cluster clients** (see `clusters/_template/sovereign-tls/cilium-gateway.yaml`).

Step-06 Phase-1 pivoted every HelmRepository url to `oci://registry.<fqdn>/openova-io` (bare host → implicit **:443**) and Phase-3a probed `helm pull oci://registry.<fqdn>/...`. Both resolve to the gateway ClusterIP but connect to `:443`, on which **nothing listens** → connection timeout. The Flux **source-controller** hit the identical timeout for every pivoted chart (`failed to login to OCI registry: Get "https://registry.<fqdn>/v2/": ... Client.Timeout`), so the pivot never reconciled and Phase-3a's strip-readiness gate never converged.

**This is NOT a "prewarm didn't push the charts" problem** — step-03 reported `Phase A2 complete: chart_ok=63 chart_fail=0`. Decisive live proof:
- `helm pull oci://registry.hw201.omani.works:30443/openova-io/bp-cilium --version 1.4.5` → **Pulled OK** (232KB tgz)
- Same pull on the bare host (implicit :443) → **connection timeout**
- Docker/OCI auth is keyed on the EXACT host[:port]: auth under bare host → pull from host:30443 → **401 `no basic auth credentials`**; auth under host:30443 → **pull OK**

The containerd/dfdaemon path (step-04) already dials the local Harbor on `:30443` (`registryPivot.dragonfly.gatewayHTTPSPort`); the Flux OCI / source-controller path did NOT carry the port until this PR.

## Fix
Step-06 builds `harbor_endpoint = harbor_host[:GATEWAY_HTTPS_PORT]` (default `30443`) and uses it for:
1. **Phase-1 URL pivot** — `local_prefix = oci://host:30443/openova-io` so source-controller lands on the listening port; the durable Gitea YAML + certSecretRef injection carry the port.
2. **Phase-3a** `helm registry login` + `helm pull` probe.
3. **Phase-0** `ghcr-pull` auth entry — written under **both** the endpoint and the bare host. The endpoint key is load-bearing (OCI auth is exact host[:port] match; source-controller reads this secret for the pivoted pull).

Phase-3b strip guard now protects both the host and the endpoint key. New value `sovereign.gatewayHTTPSPort` (default `"30443"`; `""` = legacy host-only pivot for an operator whose in-cluster `registry.<fqdn>` genuinely answers on 443).

## Validation
- `helm template platform/self-sovereign-cutover/chart --api-versions v2 --set global.sovereignFQDN=t.omani.works` — **clean** (exit 0).
- Rendered step-06 script body passes `sh -n` syntax check.
- `tests/cutover-contract.sh` — **All gates green**, including new #4666 assertions (harbor_endpoint=host:GATEWAY_HTTPS_PORT, login + pull target the endpoint).
- Live-proven on hw201: the `:30443` pull succeeds end-to-end with the harbor-admin creds against the in-cluster Harbor that already holds all 63 prewarmed charts. (READ-ONLY investigation; no hand-patch of the throwaway env — the durable chart fix is shipped here.)

## Lockstep
chart `0.1.95`→`0.1.96` + `06a` slot pin + `blueprint.yaml` + catalog seed `blueprints.yaml`.

Refs #4666 #3379 #4652

🤖 Generated with [Claude Code](https://claude.com/claude-code)