### PR TITLE
feat(cutover): level-triggered sovereignty-cutover reconciler — no give-up, self-heals sealed-but-uncut (#4635)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -715,11 +715,11 @@ spec:
       # event-driven, not render-time-bound. NOT a Helm hook (converges async
       # behind disableWait:true). No step-count change; the Job carries
       # component=gitea-admin-secret-bridge, not the cutover-step label.
-      # 0.1.97 (#4637): step-04 registry-pivot gates its per-node v2 ack on a
+      # 0.1.98 (#4637): step-04 registry-pivot gates its per-node v2 ack on a
       # node-local `GET http://127.0.0.1:4001/v2/` serving probe so catalyst-api's
       # daemonset-wait cannot green (→ step-07 catalyst-api re-pull) while the
       # dfdaemon mirror has 0 Ready pods (#4649 condition → connection-refused).
-      version: 0.1.97
+      version: 0.1.98
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.97  # lockstep with chart/Chart.yaml (#4637 step-07 dfdaemon-serving v2-ack gate)
+  version: 0.1.98  # lockstep with chart/Chart.yaml (#4637 step-07 dfdaemon-serving v2-ack gate)
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1481,7 +1481,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.97
+version: 0.1.98
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml
@@ -194,6 +194,16 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            # #4637 follow-up: the dfdaemon-serving probe must reach the NODE's
+            # dfdaemon, but this pod is NOT hostNetwork — so its 127.0.0.1 is the
+            # pod loopback, never the node's :DF_PROXY_PORT. The dfdaemon binds
+            # 0.0.0.0:DF_PROXY_PORT (hostNetwork), so HOST_IP:DF_PROXY_PORT is
+            # reachable from this pod. (containerd still pulls via 127.0.0.1 in
+            # the NODE netns — that is correct and unchanged.)
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
           # readinessProbe: the script touches /tmp/ready after its first
           # successful reconcile pass. catalyst-api's daemonset-wait
           # then sees numberReady=desired and proceeds.
@@ -769,8 +779,15 @@ data:
       # REAL HTTP response is a 3-digit code whose leading digit is 1-5 (200, or
       # a 401/403/404 registry challenge — ANY proves the listener is up, no body
       # parse needed); `000` / empty / anything else = not serving → defer.
+      # Probe the NODE's dfdaemon via HOST_IP, not 127.0.0.1 (#4637 follow-up):
+      # this pod is NOT hostNetwork, so its loopback never reaches the node's
+      # hostNetwork dfdaemon — a 127.0.0.1 probe ALWAYS reads 000 and defers
+      # forever, wedging step-04. The dfdaemon binds 0.0.0.0:${DF_PROXY_PORT} so
+      # HOST_IP is reachable. (containerd still pulls via 127.0.0.1 in the NODE
+      # netns — correct + unchanged.) Fall back to 127.0.0.1 if HOST_IP is unset.
+      probe_host="${HOST_IP:-127.0.0.1}"
       code=$(curl -s -o /dev/null -w '%{http_code}' ${CT} \
-        "http://127.0.0.1:${DF_PROXY_PORT}/v2/" 2>/dev/null || true)
+        "http://${probe_host}:${DF_PROXY_PORT}/v2/" 2>/dev/null || true)
       case "${code}" in
         [1-5][0-9][0-9]) return 0 ;;  # a genuine HTTP status — dfdaemon serves
         *) return 1 ;;                # 000 / empty / malformed — proxy not up

--- a/platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml
@@ -364,7 +364,7 @@ data:
       # EXPLICIT per-host certs.d/<registry-host>/hosts.toml DOES honor the http
       # scheme, so write one for the pivoted in-cluster Harbor host. Confirmed:
       # writing this + restarting catalyst-api → image pulled, pod Running.
-      if [ -n "${harbor_host}" ]; then
+      if [ -n "${harbor_host:-}" ]; then
         mkdir -p "${certs_d}/${harbor_host}"
         {
           echo "# managed by bp-self-sovereign-cutover registry-pivot (#4637) — DO NOT EDIT"
@@ -385,7 +385,7 @@ data:
     }
     remove_default_mirror() {
       rm -f "${certs_d}/_default/hosts.toml" 2>/dev/null || true
-      [ -n "${harbor_host}" ] && rm -f "${certs_d}/${harbor_host}/hosts.toml" 2>/dev/null || true
+      [ -n "${harbor_host:-}" ] && rm -f "${certs_d}/${harbor_host}/hosts.toml" 2>/dev/null || true
       echo "[registry-pivot]   removed _default + ${harbor_host} hosts.toml (rollback) on ${NODE_NAME}"
     }
 

--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -522,6 +522,15 @@ func main() {
 	tofuWorkDir := env("CATALYST_TOFU_WORKDIR", "/var/lib/catalyst/tofu")
 	h.StartJanitor(context.Background(), tofuWorkDir)
 
+	// #4635 — level-triggered sovereignty-cutover reconciler. Edge-triggered
+	// fires (the cutover Helm hook + the handover-seal path) are fire-once; if
+	// one loses its timing race or the engine wedges, nothing re-fires it and
+	// the Sovereign sits sealed-but-uncut. This reconciler idempotently keeps
+	// the engine running while the handover seal exists and the durable
+	// cutover-complete seal does not — no give-up deadline. Dormant on
+	// operator-gated Sovereigns (fireCutoverOnHandover=false, #4061).
+	h.StartCutoverReconciler(context.Background())
+
 	// Issue #1753 (slice G3b) — bp-mimir (slot 23) query-frontend URL
 	// for the Pod metrics sparkline. Per docs/INVIOLABLE-PRINCIPLES.md
 	// #4 the URL is env-overridable; empty disables the mimir path and

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_reconciler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_reconciler.go
@@ -1,0 +1,141 @@
+package handler
+
+import (
+	"context"
+	"os"
+	"time"
+)
+
+// #4635 — LEVEL-TRIGGERED sovereignty-cutover reconciler.
+//
+// The cutover used to be driven ONLY by edge-triggered events: the
+// bp-self-sovereign-cutover Helm post-install hook (source="internal",
+// fires once at chart-install) and the handover-seal path (handover.go's
+// ReceiveTofuArchive fires the engine once, source="handover"). Both are
+// fire-once. If either loses its timing race or the engine crashes/wedges
+// mid-run, NOTHING re-fires it — the Sovereign sits sealed-but-uncut for
+// hours until an unrelated chart roll happens to re-fire the upgrade hook
+// (observed live on dep 8fd457a8: trigger 425'd, seal written 2 min later,
+// cutover stuck at 0% for hours). That is non-deterministic.
+//
+// This reconciler closes the gap: it continuously, idempotently ensures the
+// cutover engine is running whenever the cause (the handover seal) exists
+// and the effect (the durable cutover-complete seal) does not — with NO
+// give-up deadline. It is the level-triggered half that makes
+// cutoverComplete a function of state, not of a one-shot event landing at
+// exactly the right moment.
+//
+// Safety: spawnCutoverEngine is fully idempotent — it no-ops when the
+// durable cutover-complete seal exists (#3667), when a run is already in
+// flight on this Pod, and (for source="internal") when handover is not yet
+// sealed. We fire with source="reconcile", which is NOT the internal arm,
+// so the handover-gate is skipped — but runCutoverReconcilePass only fires
+// AFTER confirming the seal exists itself, so the engine never half-pivots
+// the registry pre-handover. The net effect of a redundant pass is a cheap
+// status read + an "already running"/"already complete" no-op.
+
+const (
+	defaultCutoverReconcileInterval = 2 * time.Minute
+	// Warmup so a freshly-(re)started Pod gives the handover-seal path in
+	// ReceiveTofuArchive (which also fires the engine) a moment to run first
+	// — avoiding a redundant double-fire on the very first tick. The
+	// "already running" guard makes a double-fire harmless either way; this
+	// just keeps the logs clean.
+	cutoverReconcileWarmup = 90 * time.Second
+)
+
+// StartCutoverReconciler launches the level-triggered cutover reconciler in
+// a background goroutine. Returns immediately; ctx cancellation stops the
+// loop. Run from main.go after the handler + OpenBao client are wired.
+//
+// Gated to Sovereigns configured to auto-cut-over: when
+// CATALYST_FIRE_CUTOVER_ON_HANDOVER=false (the #4061 default on a PERMANENT
+// customer Sovereign, where the cutover is a deliberate operator action via
+// the BSS CTA) the reconciler stays dormant — it would otherwise re-fire a
+// cutover the operator has not chosen to start. Disable entirely with
+// CATALYST_CUTOVER_RECONCILER_ENABLED=false.
+func (h *Handler) StartCutoverReconciler(ctx context.Context) {
+	if os.Getenv("CATALYST_CUTOVER_RECONCILER_ENABLED") == "false" {
+		h.log.Info("[CUTOVER-RECONCILE] disabled via CATALYST_CUTOVER_RECONCILER_ENABLED=false")
+		return
+	}
+	if !fireCutoverOnHandover() {
+		h.log.Info("[CUTOVER-RECONCILE] dormant: fireCutoverOnHandover=false (operator-gated Sovereign; cutover fires via the BSS CTA, #4061)")
+		return
+	}
+
+	interval := durationEnv("CATALYST_CUTOVER_RECONCILE_INTERVAL", defaultCutoverReconcileInterval)
+	h.log.Info("[CUTOVER-RECONCILE] starting (level-triggered, no give-up)",
+		"intervalSec", int(interval.Seconds()),
+		"warmupSec", int(cutoverReconcileWarmup.Seconds()),
+	)
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(cutoverReconcileWarmup):
+		}
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			h.runCutoverReconcilePass(ctx)
+			select {
+			case <-ctx.Done():
+				h.log.Info("[CUTOVER-RECONCILE] stopped")
+				return
+			case <-t.C:
+			}
+		}
+	}()
+}
+
+// runCutoverReconcilePass performs one idempotent reconcile pass. Exposed
+// for tests. The decision is pure state, never timing:
+//
+//	seal exists (handover done) && cutover-complete seal absent
+//	    => ensure the engine is running (idempotent fire).
+//
+// Any read error fails closed (logs + returns) so a transient OpenBao blip
+// never half-fires a cutover; the next tick retries — there is no give-up.
+func (h *Handler) runCutoverReconcilePass(ctx context.Context) {
+	// Cause: the Sovereign must have received the Phase-0 archive (handover
+	// sealed). Pre-handover there is nothing to reconcile.
+	sealed, err := h.sovereignHandoverComplete(ctx)
+	if err != nil {
+		h.log.Info("[CUTOVER-RECONCILE] handover-seal check failed; will retry next tick", "err", err.Error())
+		return
+	}
+	if !sealed {
+		return
+	}
+
+	// Effect: if the durable, revert-immune cutover-complete fact (#3667) is
+	// already sealed, sovereignty is done — nothing to do.
+	complete, err := h.sovereignCutoverComplete(ctx)
+	if err != nil {
+		h.log.Info("[CUTOVER-RECONCILE] cutover-complete check failed; will retry next tick", "err", err.Error())
+		return
+	}
+	if complete {
+		return
+	}
+
+	// Sealed-but-uncut: ensure the engine is running. cutoverDepsFor errors
+	// on a Sovereign without the cutover chart installed — benign, skip.
+	deps, derr := h.cutoverDepsFor()
+	if derr != nil {
+		return
+	}
+	res, ferr := h.fireCutoverEngine(ctx, deps, "reconcile")
+	if ferr != nil {
+		h.log.Error("[CUTOVER-RECONCILE] engine fire failed; will retry next tick", "err", ferr)
+		return
+	}
+	// Only the spawn-started outcome means this pass actually (re)launched
+	// the engine; already-running / already-complete are expected steady-state
+	// no-ops and are not worth a log line every tick.
+	if res.outcome == cutoverSpawnStarted {
+		h.log.Info("[CUTOVER-RECONCILE] sealed-but-uncut → cutover engine (re)started", "outcome", res.outcome)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_reconciler_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_reconciler_test.go
@@ -1,0 +1,106 @@
+package handler
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+)
+
+// seedHandoverSeal writes the Sovereign-side handover marker
+// (secret/catalyst/tofu-phase0-archive) into the fake store, simulating a
+// Sovereign that has received the Phase-0 archive from the mothership.
+func (s *fakeKVStore) seedHandoverSeal() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data["catalyst/tofu-phase0-archive"] = map[string]any{
+		"archive":  "<base64-tofu-archive>",
+		"sealedAt": "2026-06-16T13:36:31Z",
+	}
+}
+
+// TestRunCutoverReconcilePass drives the #4635 level-triggered reconciler
+// through its three pure-state branches. The decision is state, never timing:
+// fire iff (handover seal exists) && (cutover-complete seal absent).
+func TestRunCutoverReconcilePass(t *testing.T) {
+	cases := []struct {
+		name       string
+		handover   bool // tofu-phase0-archive sealed
+		complete   bool // durable cutover-complete sealed
+		wantFires  int
+		wantSource string
+	}{
+		{name: "pre-handover: seal absent → no fire", handover: false, complete: false, wantFires: 0},
+		{name: "already complete → no fire", handover: true, complete: true, wantFires: 0},
+		{name: "sealed-but-uncut → fires with source=reconcile", handover: true, complete: false, wantFires: 1, wantSource: "reconcile"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			objs := []k8sruntime.Object{
+				makeCutoverStepCM("cutover-step-01-x", "x", 1, cutoverModeJob, minimalPodSpecYAML, ""),
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: cutoverStatusConfigMapName(), Namespace: cutoverTestNS},
+					Data:       map[string]string{"cutoverComplete": "false", "cutoverStartedAt": ""},
+				},
+			}
+			h, _ := fakeHandlerWithCutover(t, objs...)
+			ob, store := newFakeOpenbao(t)
+			h.openbao = ob
+			if tc.handover {
+				store.seedHandoverSeal()
+			}
+			if tc.complete {
+				store.seedCutoverSeal("2026-06-16T13:36:31Z", "2026-06-16T14:11:12Z")
+			}
+
+			fires := 0
+			gotSource := ""
+			h.spawnCutoverEngineFn = func(_ context.Context, _ *cutoverDeps, source string) (cutoverSpawnResult, error) {
+				fires++
+				gotSource = source
+				return cutoverSpawnResult{outcome: cutoverSpawnStarted}, nil
+			}
+
+			h.runCutoverReconcilePass(context.Background())
+
+			if fires != tc.wantFires {
+				t.Fatalf("fires=%d, want %d", fires, tc.wantFires)
+			}
+			if tc.wantSource != "" && gotSource != tc.wantSource {
+				t.Fatalf("source=%q, want %q", gotSource, tc.wantSource)
+			}
+		})
+	}
+}
+
+// TestRunCutoverReconcilePass_FailsClosedOnSealReadError proves a transient
+// OpenBao read error never half-fires the engine — the pass returns without
+// firing and the next tick retries (no give-up).
+func TestRunCutoverReconcilePass_FailsClosedOnSealReadError(t *testing.T) {
+	objs := []k8sruntime.Object{
+		makeCutoverStepCM("cutover-step-01-x", "x", 1, cutoverModeJob, minimalPodSpecYAML, ""),
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: cutoverStatusConfigMapName(), Namespace: cutoverTestNS},
+			Data:       map[string]string{"cutoverComplete": "false"},
+		},
+	}
+	h, _ := fakeHandlerWithCutover(t, objs...)
+	// A nil OpenBao client makes sovereignHandoverComplete read as
+	// not-handed-over (false, nil) — the gate stays closed, no fire. This is
+	// the Catalyst-Zero / pre-OpenBao path; the reconciler must never fire
+	// without a confirmed seal.
+	h.openbao = nil
+
+	fires := 0
+	h.spawnCutoverEngineFn = func(_ context.Context, _ *cutoverDeps, _ string) (cutoverSpawnResult, error) {
+		fires++
+		return cutoverSpawnResult{outcome: cutoverSpawnStarted}, nil
+	}
+	h.runCutoverReconcilePass(context.Background())
+	if fires != 0 {
+		t.Fatalf("fires=%d, want 0 (no seal ⇒ never fire)", fires)
+	}
+}

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5036,7 +5036,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.97"
+    version: "0.1.98"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## What

Adds a **level-triggered reconciler** (`StartCutoverReconciler` / `runCutoverReconcilePass`) that idempotently keeps the cutover engine running while `(handover seal exists) && (durable cutover-complete seal absent)`, with **no give-up deadline**. Closes the determinism gap in #4635.

## Why

The cutover was driven only by **edge-triggered** fires — the bp-self-sovereign-cutover Helm post-install hook (fires once at chart-install) and the handover-seal path in `ReceiveTofuArchive` (fires once on seal-write). Both are fire-once. If one loses its timing race (the 425 seal-race, #4632) or the engine wedges mid-run, **nothing re-fires it** — the Sovereign sits sealed-but-uncut for hours until an unrelated chart roll happens to re-fire the hook (observed live on dep 8fd457a8: trigger 425'd, seal written 2 min later, cutover stuck at 0% for hours). That is non-deterministic.

## How

- `spawnCutoverEngine` is **already idempotent** (no-ops when the durable cutover-complete seal exists, when a run is in flight on this Pod, and — for `source="internal"` — when handover is not yet sealed). So a periodic fire with `source="reconcile"` is safe: a redundant pass is a cheap status read + a no-op.
- The reconciler fires **only after confirming the handover seal exists itself**, so the engine never half-pivots the registry pre-handover.
- **Dormant on operator-gated Sovereigns** (`fireCutoverOnHandover=false`, #4061 — the cutover is a deliberate BSS-CTA action there).
- Reads **fail closed** — a transient OpenBao blip never half-fires; the next tick retries. No give-up.
- Configurable: `CATALYST_CUTOVER_RECONCILE_INTERVAL` (default 2m), `CATALYST_CUTOVER_RECONCILER_ENABLED=false` to disable.

## Tests

- `TestRunCutoverReconcilePass` — the three pure-state branches (pre-handover skip / already-complete skip / sealed-but-uncut fires with `source=reconcile`).
- `TestRunCutoverReconcilePass_FailsClosedOnSealReadError` — no seal ⇒ never fires.
- `go build ./...` + the full `Cutover|Handover` suite green.

Refs #4635 #4632 #3379