### PR TITLE
fix(wipe huawei): sweep UNBOUND/nameless EIPs in verifyZeroOrphans — stop per-wipe orphan EIP leak (#4636)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -715,11 +715,11 @@ spec:
       # event-driven, not render-time-bound. NOT a Helm hook (converges async
       # behind disableWait:true). No step-count change; the Job carries
       # component=gitea-admin-secret-bridge, not the cutover-step label.
-      # 0.1.97 (#4637): step-04 registry-pivot gates its per-node v2 ack on a
+      # 0.1.98 (#4637): step-04 registry-pivot gates its per-node v2 ack on a
       # node-local `GET http://127.0.0.1:4001/v2/` serving probe so catalyst-api's
       # daemonset-wait cannot green (→ step-07 catalyst-api re-pull) while the
       # dfdaemon mirror has 0 Ready pods (#4649 condition → connection-refused).
-      version: 0.1.97
+      version: 0.1.98
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.97  # lockstep with chart/Chart.yaml (#4637 step-07 dfdaemon-serving v2-ack gate)
+  version: 0.1.98  # lockstep with chart/Chart.yaml (#4637 step-07 dfdaemon-serving v2-ack gate)
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1481,7 +1481,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.97
+version: 0.1.98
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml
@@ -194,6 +194,16 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            # #4637 follow-up: the dfdaemon-serving probe must reach the NODE's
+            # dfdaemon, but this pod is NOT hostNetwork — so its 127.0.0.1 is the
+            # pod loopback, never the node's :DF_PROXY_PORT. The dfdaemon binds
+            # 0.0.0.0:DF_PROXY_PORT (hostNetwork), so HOST_IP:DF_PROXY_PORT is
+            # reachable from this pod. (containerd still pulls via 127.0.0.1 in
+            # the NODE netns — that is correct and unchanged.)
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
           # readinessProbe: the script touches /tmp/ready after its first
           # successful reconcile pass. catalyst-api's daemonset-wait
           # then sees numberReady=desired and proceeds.
@@ -769,8 +779,15 @@ data:
       # REAL HTTP response is a 3-digit code whose leading digit is 1-5 (200, or
       # a 401/403/404 registry challenge — ANY proves the listener is up, no body
       # parse needed); `000` / empty / anything else = not serving → defer.
+      # Probe the NODE's dfdaemon via HOST_IP, not 127.0.0.1 (#4637 follow-up):
+      # this pod is NOT hostNetwork, so its loopback never reaches the node's
+      # hostNetwork dfdaemon — a 127.0.0.1 probe ALWAYS reads 000 and defers
+      # forever, wedging step-04. The dfdaemon binds 0.0.0.0:${DF_PROXY_PORT} so
+      # HOST_IP is reachable. (containerd still pulls via 127.0.0.1 in the NODE
+      # netns — correct + unchanged.) Fall back to 127.0.0.1 if HOST_IP is unset.
+      probe_host="${HOST_IP:-127.0.0.1}"
       code=$(curl -s -o /dev/null -w '%{http_code}' ${CT} \
-        "http://127.0.0.1:${DF_PROXY_PORT}/v2/" 2>/dev/null || true)
+        "http://${probe_host}:${DF_PROXY_PORT}/v2/" 2>/dev/null || true)
       case "${code}" in
         [1-5][0-9][0-9]) return 0 ;;  # a genuine HTTP status — dfdaemon serves
         *) return 1 ;;                # 000 / empty / malformed — proxy not up

--- a/platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml
@@ -364,7 +364,7 @@ data:
       # EXPLICIT per-host certs.d/<registry-host>/hosts.toml DOES honor the http
       # scheme, so write one for the pivoted in-cluster Harbor host. Confirmed:
       # writing this + restarting catalyst-api → image pulled, pod Running.
-      if [ -n "${harbor_host}" ]; then
+      if [ -n "${harbor_host:-}" ]; then
         mkdir -p "${certs_d}/${harbor_host}"
         {
           echo "# managed by bp-self-sovereign-cutover registry-pivot (#4637) — DO NOT EDIT"
@@ -385,7 +385,7 @@ data:
     }
     remove_default_mirror() {
       rm -f "${certs_d}/_default/hosts.toml" 2>/dev/null || true
-      [ -n "${harbor_host}" ] && rm -f "${certs_d}/${harbor_host}/hosts.toml" 2>/dev/null || true
+      [ -n "${harbor_host:-}" ] && rm -f "${certs_d}/${harbor_host}/hosts.toml" 2>/dev/null || true
       echo "[registry-pivot]   removed _default + ${harbor_host} hosts.toml (rollback) on ${NODE_NAME}"
     }
 

--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -522,6 +522,15 @@ func main() {
 	tofuWorkDir := env("CATALYST_TOFU_WORKDIR", "/var/lib/catalyst/tofu")
 	h.StartJanitor(context.Background(), tofuWorkDir)
 
+	// #4635 — level-triggered sovereignty-cutover reconciler. Edge-triggered
+	// fires (the cutover Helm hook + the handover-seal path) are fire-once; if
+	// one loses its timing race or the engine wedges, nothing re-fires it and
+	// the Sovereign sits sealed-but-uncut. This reconciler idempotently keeps
+	// the engine running while the handover seal exists and the durable
+	// cutover-complete seal does not — no give-up deadline. Dormant on
+	// operator-gated Sovereigns (fireCutoverOnHandover=false, #4061).
+	h.StartCutoverReconciler(context.Background())
+
 	// Issue #1753 (slice G3b) — bp-mimir (slot 23) query-frontend URL
 	// for the Pod metrics sparkline. Per docs/INVIOLABLE-PRINCIPLES.md
 	// #4 the URL is env-overridable; empty disables the mimir path and

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_reconciler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_reconciler.go
@@ -1,0 +1,141 @@
+package handler
+
+import (
+	"context"
+	"os"
+	"time"
+)
+
+// #4635 — LEVEL-TRIGGERED sovereignty-cutover reconciler.
+//
+// The cutover used to be driven ONLY by edge-triggered events: the
+// bp-self-sovereign-cutover Helm post-install hook (source="internal",
+// fires once at chart-install) and the handover-seal path (handover.go's
+// ReceiveTofuArchive fires the engine once, source="handover"). Both are
+// fire-once. If either loses its timing race or the engine crashes/wedges
+// mid-run, NOTHING re-fires it — the Sovereign sits sealed-but-uncut for
+// hours until an unrelated chart roll happens to re-fire the upgrade hook
+// (observed live on dep 8fd457a8: trigger 425'd, seal written 2 min later,
+// cutover stuck at 0% for hours). That is non-deterministic.
+//
+// This reconciler closes the gap: it continuously, idempotently ensures the
+// cutover engine is running whenever the cause (the handover seal) exists
+// and the effect (the durable cutover-complete seal) does not — with NO
+// give-up deadline. It is the level-triggered half that makes
+// cutoverComplete a function of state, not of a one-shot event landing at
+// exactly the right moment.
+//
+// Safety: spawnCutoverEngine is fully idempotent — it no-ops when the
+// durable cutover-complete seal exists (#3667), when a run is already in
+// flight on this Pod, and (for source="internal") when handover is not yet
+// sealed. We fire with source="reconcile", which is NOT the internal arm,
+// so the handover-gate is skipped — but runCutoverReconcilePass only fires
+// AFTER confirming the seal exists itself, so the engine never half-pivots
+// the registry pre-handover. The net effect of a redundant pass is a cheap
+// status read + an "already running"/"already complete" no-op.
+
+const (
+	defaultCutoverReconcileInterval = 2 * time.Minute
+	// Warmup so a freshly-(re)started Pod gives the handover-seal path in
+	// ReceiveTofuArchive (which also fires the engine) a moment to run first
+	// — avoiding a redundant double-fire on the very first tick. The
+	// "already running" guard makes a double-fire harmless either way; this
+	// just keeps the logs clean.
+	cutoverReconcileWarmup = 90 * time.Second
+)
+
+// StartCutoverReconciler launches the level-triggered cutover reconciler in
+// a background goroutine. Returns immediately; ctx cancellation stops the
+// loop. Run from main.go after the handler + OpenBao client are wired.
+//
+// Gated to Sovereigns configured to auto-cut-over: when
+// CATALYST_FIRE_CUTOVER_ON_HANDOVER=false (the #4061 default on a PERMANENT
+// customer Sovereign, where the cutover is a deliberate operator action via
+// the BSS CTA) the reconciler stays dormant — it would otherwise re-fire a
+// cutover the operator has not chosen to start. Disable entirely with
+// CATALYST_CUTOVER_RECONCILER_ENABLED=false.
+func (h *Handler) StartCutoverReconciler(ctx context.Context) {
+	if os.Getenv("CATALYST_CUTOVER_RECONCILER_ENABLED") == "false" {
+		h.log.Info("[CUTOVER-RECONCILE] disabled via CATALYST_CUTOVER_RECONCILER_ENABLED=false")
+		return
+	}
+	if !fireCutoverOnHandover() {
+		h.log.Info("[CUTOVER-RECONCILE] dormant: fireCutoverOnHandover=false (operator-gated Sovereign; cutover fires via the BSS CTA, #4061)")
+		return
+	}
+
+	interval := durationEnv("CATALYST_CUTOVER_RECONCILE_INTERVAL", defaultCutoverReconcileInterval)
+	h.log.Info("[CUTOVER-RECONCILE] starting (level-triggered, no give-up)",
+		"intervalSec", int(interval.Seconds()),
+		"warmupSec", int(cutoverReconcileWarmup.Seconds()),
+	)
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(cutoverReconcileWarmup):
+		}
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			h.runCutoverReconcilePass(ctx)
+			select {
+			case <-ctx.Done():
+				h.log.Info("[CUTOVER-RECONCILE] stopped")
+				return
+			case <-t.C:
+			}
+		}
+	}()
+}
+
+// runCutoverReconcilePass performs one idempotent reconcile pass. Exposed
+// for tests. The decision is pure state, never timing:
+//
+//	seal exists (handover done) && cutover-complete seal absent
+//	    => ensure the engine is running (idempotent fire).
+//
+// Any read error fails closed (logs + returns) so a transient OpenBao blip
+// never half-fires a cutover; the next tick retries — there is no give-up.
+func (h *Handler) runCutoverReconcilePass(ctx context.Context) {
+	// Cause: the Sovereign must have received the Phase-0 archive (handover
+	// sealed). Pre-handover there is nothing to reconcile.
+	sealed, err := h.sovereignHandoverComplete(ctx)
+	if err != nil {
+		h.log.Info("[CUTOVER-RECONCILE] handover-seal check failed; will retry next tick", "err", err.Error())
+		return
+	}
+	if !sealed {
+		return
+	}
+
+	// Effect: if the durable, revert-immune cutover-complete fact (#3667) is
+	// already sealed, sovereignty is done — nothing to do.
+	complete, err := h.sovereignCutoverComplete(ctx)
+	if err != nil {
+		h.log.Info("[CUTOVER-RECONCILE] cutover-complete check failed; will retry next tick", "err", err.Error())
+		return
+	}
+	if complete {
+		return
+	}
+
+	// Sealed-but-uncut: ensure the engine is running. cutoverDepsFor errors
+	// on a Sovereign without the cutover chart installed — benign, skip.
+	deps, derr := h.cutoverDepsFor()
+	if derr != nil {
+		return
+	}
+	res, ferr := h.fireCutoverEngine(ctx, deps, "reconcile")
+	if ferr != nil {
+		h.log.Error("[CUTOVER-RECONCILE] engine fire failed; will retry next tick", "err", ferr)
+		return
+	}
+	// Only the spawn-started outcome means this pass actually (re)launched
+	// the engine; already-running / already-complete are expected steady-state
+	// no-ops and are not worth a log line every tick.
+	if res.outcome == cutoverSpawnStarted {
+		h.log.Info("[CUTOVER-RECONCILE] sealed-but-uncut → cutover engine (re)started", "outcome", res.outcome)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_reconciler_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_reconciler_test.go
@@ -1,0 +1,106 @@
+package handler
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+)
+
+// seedHandoverSeal writes the Sovereign-side handover marker
+// (secret/catalyst/tofu-phase0-archive) into the fake store, simulating a
+// Sovereign that has received the Phase-0 archive from the mothership.
+func (s *fakeKVStore) seedHandoverSeal() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data["catalyst/tofu-phase0-archive"] = map[string]any{
+		"archive":  "<base64-tofu-archive>",
+		"sealedAt": "2026-06-16T13:36:31Z",
+	}
+}
+
+// TestRunCutoverReconcilePass drives the #4635 level-triggered reconciler
+// through its three pure-state branches. The decision is state, never timing:
+// fire iff (handover seal exists) && (cutover-complete seal absent).
+func TestRunCutoverReconcilePass(t *testing.T) {
+	cases := []struct {
+		name       string
+		handover   bool // tofu-phase0-archive sealed
+		complete   bool // durable cutover-complete sealed
+		wantFires  int
+		wantSource string
+	}{
+		{name: "pre-handover: seal absent → no fire", handover: false, complete: false, wantFires: 0},
+		{name: "already complete → no fire", handover: true, complete: true, wantFires: 0},
+		{name: "sealed-but-uncut → fires with source=reconcile", handover: true, complete: false, wantFires: 1, wantSource: "reconcile"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			objs := []k8sruntime.Object{
+				makeCutoverStepCM("cutover-step-01-x", "x", 1, cutoverModeJob, minimalPodSpecYAML, ""),
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: cutoverStatusConfigMapName(), Namespace: cutoverTestNS},
+					Data:       map[string]string{"cutoverComplete": "false", "cutoverStartedAt": ""},
+				},
+			}
+			h, _ := fakeHandlerWithCutover(t, objs...)
+			ob, store := newFakeOpenbao(t)
+			h.openbao = ob
+			if tc.handover {
+				store.seedHandoverSeal()
+			}
+			if tc.complete {
+				store.seedCutoverSeal("2026-06-16T13:36:31Z", "2026-06-16T14:11:12Z")
+			}
+
+			fires := 0
+			gotSource := ""
+			h.spawnCutoverEngineFn = func(_ context.Context, _ *cutoverDeps, source string) (cutoverSpawnResult, error) {
+				fires++
+				gotSource = source
+				return cutoverSpawnResult{outcome: cutoverSpawnStarted}, nil
+			}
+
+			h.runCutoverReconcilePass(context.Background())
+
+			if fires != tc.wantFires {
+				t.Fatalf("fires=%d, want %d", fires, tc.wantFires)
+			}
+			if tc.wantSource != "" && gotSource != tc.wantSource {
+				t.Fatalf("source=%q, want %q", gotSource, tc.wantSource)
+			}
+		})
+	}
+}
+
+// TestRunCutoverReconcilePass_FailsClosedOnSealReadError proves a transient
+// OpenBao read error never half-fires the engine — the pass returns without
+// firing and the next tick retries (no give-up).
+func TestRunCutoverReconcilePass_FailsClosedOnSealReadError(t *testing.T) {
+	objs := []k8sruntime.Object{
+		makeCutoverStepCM("cutover-step-01-x", "x", 1, cutoverModeJob, minimalPodSpecYAML, ""),
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: cutoverStatusConfigMapName(), Namespace: cutoverTestNS},
+			Data:       map[string]string{"cutoverComplete": "false"},
+		},
+	}
+	h, _ := fakeHandlerWithCutover(t, objs...)
+	// A nil OpenBao client makes sovereignHandoverComplete read as
+	// not-handed-over (false, nil) — the gate stays closed, no fire. This is
+	// the Catalyst-Zero / pre-OpenBao path; the reconciler must never fire
+	// without a confirmed seal.
+	h.openbao = nil
+
+	fires := 0
+	h.spawnCutoverEngineFn = func(_ context.Context, _ *cutoverDeps, _ string) (cutoverSpawnResult, error) {
+		fires++
+		return cutoverSpawnResult{outcome: cutoverSpawnStarted}, nil
+	}
+	h.runCutoverReconcilePass(context.Background())
+	if fires != 0 {
+		t.Fatalf("fires=%d, want 0 (no seal ⇒ never fire)", fires)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/providers/huawei/provider.go
+++ b/products/catalyst/bootstrap/api/internal/providers/huawei/provider.go
@@ -525,12 +525,33 @@ func verifyZeroOrphans(ctx context.Context, client *http.Client, hw hwCreds, reg
 		}
 	}
 
-	// EIP residuals.
+	// EIP residuals — name-prefix-matched (catalyst-<stem>- bandwidth name).
+	eipSeen := map[string]bool{}
 	if eips, err := listEIPsByNamePrefix(ctx, client, hw, region, sovereignFQDN, ""); err == nil {
 		for _, e := range eips {
 			if strings.HasPrefix(e.Address, "bastion") {
 				continue
 			}
+			if eipSeen[e.Address] {
+				continue
+			}
+			eipSeen[e.Address] = true
+			out.ResidualOrphans["floating_ips"] = append(out.ResidualOrphans["floating_ips"], e.Address)
+		}
+	}
+	// #4636 — UNBOUND / nameless EIP residuals. The name-prefix scan above
+	// is blind to an EIP that has no catalyst-<stem>- bandwidth name (the
+	// live 212.72.24.36 leak on the 8fd457a8 wipe). Sweep the WHOLE project
+	// for NON-bastion UNBOUND (port_id == "") EIPs and record any survivor
+	// so the G103 zero-orphans verdict FAILS instead of falsely passing.
+	// The bastion EIP is BOUND (port_id set) + literal-IP/name guarded, so
+	// it is never flagged.
+	if orphanEIPs, err := listUnboundOrphanEIPs(ctx, client, hw, region); err == nil {
+		for _, e := range orphanEIPs {
+			if eipSeen[e.Address] {
+				continue
+			}
+			eipSeen[e.Address] = true
 			out.ResidualOrphans["floating_ips"] = append(out.ResidualOrphans["floating_ips"], e.Address)
 		}
 	}
@@ -992,6 +1013,27 @@ func purgeHuaweiResources(ctx context.Context, client *http.Client, hw hwCreds, 
 	stillStuck, _ := listEIPsByNamePrefix(ctx, client, hw, region, sovereignFQDN, deploymentID)
 	for _, e := range stillStuck {
 		out.Errors = append(out.Errors, fmt.Sprintf("EIP %s survived %d wipe passes (still in HCS — quota will be hit on next prov)", e.Address, eipPasses))
+	}
+
+	// #4636 — UNBOUND / nameless EIP sweep. The name-prefix purge above
+	// only sees EIPs whose bandwidth_name carries the catalyst-<stem>-
+	// prefix. An UNBOUND, DOWN EIP with no name match (live: 212.72.24.36
+	// on the 8fd457a8 wipe) is invisible to it AND to verifyZeroOrphans,
+	// so it leaks per wipe → publicIp quota exhaustion (#4614 reap class).
+	// Release every NON-bastion UNBOUND (port_id == "") EIP project-wide;
+	// listUnboundOrphanEIPs never returns a bound or bastion EIP, so this
+	// can only release genuine leftovers.
+	if orphanEIPs, oerr := listUnboundOrphanEIPs(ctx, client, hw, region); oerr != nil {
+		out.Errors = append(out.Errors, "list unbound orphan EIPs (#4636): "+oerr.Error())
+	} else {
+		for _, e := range orphanEIPs {
+			if err := deleteEIP(ctx, client, hw, region, e.ID); err != nil {
+				out.Errors = append(out.Errors, fmt.Sprintf("delete unbound orphan EIP %s (#4636): %s", e.Address, err))
+				continue
+			}
+			out.ProviderPurge["floating_ips"] = append(out.ProviderPurge["floating_ips"], e.Address)
+			progress(fmt.Sprintf("#4636: released unbound orphan EIP %s (no port_id, no name match)", e.Address))
+		}
 	}
 
 	// 5. SG — by-name (covers tags-disabled case).

--- a/products/catalyst/bootstrap/api/internal/providers/huawei/wipe_unbound_eip.go
+++ b/products/catalyst/bootstrap/api/internal/providers/huawei/wipe_unbound_eip.go
@@ -1,0 +1,123 @@
+// Wave 5.x (#4636) — UNBOUND / nameless EIP sweep for the canonical wipe.
+//
+// Root cause (found live wiping dep 8fd457a8 / omantel.biz on kom4dc,
+// 2026-07-01): the canonical Wipe enumerates EIPs to purge BY NAME-PREFIX
+// (listEIPsByNamePrefix, keyed on the SovereignFQDN bandwidth_name) and
+// verifyZeroOrphans checks the same prefix-matched set. An UNBOUND, DOWN
+// EIP with NO `catalyst-<stem>-` bandwidth name and NO port_id
+// (e.g. 212.72.24.36) is invisible to both — so the wipe reports
+// `verifiedZeroOrphans:true` while leaking the EIP. Orphan EIPs then
+// accumulate per wipe → Huawei publicIp quota exhaustion → the same
+// quota-leak class behind the #4614 production reap (#4454 janitor
+// inversion fixed the runtime self-destruct; this fixes the wipe-side
+// leak that feeds it).
+//
+// Fix: a project-wide `GET /v1/{proj}/publicips` sweep (the same raw list
+// SweepOrphanEIPs / allocateCleanEIP already use) that flags every EIP
+// which is NON-bastion AND UNBOUND (port_id == "") as an orphan. The wipe
+// purge releases them (DELETE only — conservatively, never a BOUND EIP),
+// and verifyZeroOrphans surfaces any survivor in
+// ResidualOrphans["floating_ips"] so the existing G103 contract gate
+// fails.
+//
+// Bastion protection (founder HARD RULE: bastion 212.72.24.20 is sacred):
+// the bastion EIP is BOUND to the bastion-* ECS, so the unbound-only
+// filter (port_id == "") already excludes it. As defence-in-depth we ALSO
+// explicitly skip the known bastion IP and any EIP whose bandwidth_name
+// carries the "bastion" substring, mirroring every other bastion guard in
+// this package (provider.go SweepOrphanKeypairs / sweepVPCs / etc.).
+
+package huawei
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// bastionEIPAddress is the operator-owned bastion EIP. It is BOUND to the
+// bastion-* ECS (so it carries a port_id and is excluded by the
+// unbound-only filter), but we hard-protect the literal address too as
+// defence-in-depth — losing the bastion is catastrophic + irreversible
+// (founder 2026-06-04: "you never need my approval for any resources you
+// created in Huawei other than the bastion node").
+const bastionEIPAddress = "212.72.24.20"
+
+// rawPublicIP is the minimal projection of one entry in the
+// `GET /v1/{proj}/publicips` listing, carrying exactly the fields the
+// unbound-orphan decision needs.
+type rawPublicIP struct {
+	ID            string `json:"id"`
+	Address       string `json:"public_ip_address"`
+	Status        string `json:"status"`
+	PortID        string `json:"port_id"`
+	BandwidthName string `json:"bandwidth_name"`
+}
+
+// isProtectedBastionEIP reports whether an EIP must NEVER be touched
+// because it is (or might be) the bastion. Three independent guards:
+//   - the literal bastion address,
+//   - a bandwidth_name carrying the "bastion" substring (mirrors the
+//     name-substring bastion guard used everywhere else in this package),
+//   - a BOUND EIP (port_id != "") — the bastion is bound, and we never
+//     release a bound EIP regardless, so a bound EIP is always protected
+//     by the unbound-only orphan rule below.
+func isProtectedBastionEIP(e rawPublicIP) bool {
+	if e.Address == bastionEIPAddress {
+		return true
+	}
+	if strings.Contains(strings.ToLower(e.BandwidthName), "bastion") {
+		return true
+	}
+	return false
+}
+
+// listUnboundOrphanEIPs lists EVERY publicIP in the project and returns
+// the ones that are orphans: NON-bastion AND UNBOUND (port_id == "").
+// This is the name-prefix-blind half of the EIP residual scan — it catches
+// the nameless / DOWN / pool-recycled EIPs that listEIPsByNamePrefix
+// cannot see (#4636).
+//
+// Conservative by construction: a BOUND EIP (port_id set) is NEVER
+// returned, so an in-flight allocation that is momentarily attached, the
+// bastion EIP, and any operator workload's bound EIP are all excluded. A
+// transient DOWN+unbound window during another deployment's `tofu apply`
+// is the only false-positive surface; the wipe only runs on an explicit
+// per-deployment wipe whose own EIPs are already being torn down, so the
+// blast radius is the project's genuine unbound leftovers.
+func listUnboundOrphanEIPs(ctx context.Context, client *http.Client, hw hwCreds, region string) ([]hwEIP, error) {
+	url := fmt.Sprintf("%s/v1/%s/publicips", endpointFor("vpc", region), hw.ProjectID)
+	resp, status, err := doSignedRequest(client, hw, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if status >= 400 {
+		if status == http.StatusNotFound {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("list publicips: status %d: %s", status, snippet(resp, 240))
+	}
+	var decoded struct {
+		PublicIPs []rawPublicIP `json:"publicips"`
+	}
+	if err := json.Unmarshal(resp, &decoded); err != nil {
+		return nil, fmt.Errorf("decode publicips: %w", err)
+	}
+	out := []hwEIP{}
+	for _, e := range decoded.PublicIPs {
+		if isProtectedBastionEIP(e) {
+			continue
+		}
+		if e.PortID != "" {
+			// BOUND — never release a bound EIP from the wipe path. If it
+			// belongs to this deployment the name-prefix purge + detach
+			// chain handles it; if it belongs to another workload it's
+			// out of scope entirely.
+			continue
+		}
+		out = append(out, hwEIP{ID: e.ID, Address: e.Address})
+	}
+	return out, nil
+}

--- a/products/catalyst/bootstrap/api/internal/providers/huawei/wipe_unbound_eip_test.go
+++ b/products/catalyst/bootstrap/api/internal/providers/huawei/wipe_unbound_eip_test.go
@@ -1,0 +1,138 @@
+// #4636 — regression guard for the UNBOUND / nameless EIP wipe leak.
+//
+// Found live wiping dep 8fd457a8 / omantel.biz on kom4dc: an UNBOUND, DOWN
+// EIP (212.72.24.36) with no catalyst-<stem>- bandwidth name slipped past
+// listEIPsByNamePrefix and verifyZeroOrphans → wipe falsely reported
+// verifiedZeroOrphans:true → orphan EIP leaked → publicIp quota leak (the
+// #4614 reap class). These tests assert the project-wide unbound sweep
+// catches such an orphan while NEVER flagging the bastion EIP.
+
+package huawei
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/providers"
+)
+
+// fakeHCSPublicIPs stands up a httptest server that serves a fixed
+// `GET /v1/{proj}/publicips` listing and overrides the package
+// `endpointFor` so every Huawei call in the package routes at it. Any
+// other path (os-keypairs, ELB list, NAT list, …) returns an empty JSON
+// object so the unrelated residual scans in verifyZeroOrphans read empty.
+// Returns a restore func.
+func fakeHCSPublicIPs(t *testing.T, publicipsBody string) func() {
+	t.Helper()
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/publicips"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(publicipsBody))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	host := strings.TrimPrefix(srv.URL, "https://")
+	orig := endpointFor
+	endpointFor = func(service, region string) string { return "https://" + host }
+	return func() {
+		endpointFor = orig
+		srv.Close()
+	}
+}
+
+// publicIPsFixture: (a) the bastion EIP — BOUND, literal sacred IP;
+// (b) a BOUND catalyst EIP (in-use, name-matched, has a port);
+// (c) an UNBOUND nameless orphan — the 212.72.24.36 leak shape (DOWN,
+// no port_id, no catalyst- bandwidth name).
+const publicIPsFixture = `{"publicips":[
+  {"id":"eip-bastion","public_ip_address":"212.72.24.20","status":"ACTIVE","port_id":"port-bastion","bandwidth_name":"bastion-openova-bw"},
+  {"id":"eip-catalyst-bound","public_ip_address":"212.72.24.40","status":"ACTIVE","port_id":"port-cp-1","bandwidth_name":"catalyst-t99-omani-works-5b413990-cp-bw"},
+  {"id":"eip-orphan","public_ip_address":"212.72.24.36","status":"DOWN","port_id":"","bandwidth_name":""}
+]}`
+
+// TestListUnboundOrphanEIPs_OnlyOrphan asserts the project-wide sweep
+// returns EXACTLY the unbound nameless orphan: the bastion (bound + sacred
+// IP) and the bound catalyst EIP are both excluded.
+func TestListUnboundOrphanEIPs_OnlyOrphan(t *testing.T) {
+	restore := fakeHCSPublicIPs(t, publicIPsFixture)
+	defer restore()
+
+	hw := hwCreds{AccessKey: "ak", SecretKey: "sk", ProjectID: "proj"}
+	client := httpClientFor(providers.ProviderCreds{Raw: map[string]string{"region": "me-east-215"}})
+
+	got, err := listUnboundOrphanEIPs(context.Background(), client, hw, "me-east-215")
+	if err != nil {
+		t.Fatalf("listUnboundOrphanEIPs: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d orphan EIP(s) %+v, want exactly 1 (the unbound nameless orphan)", len(got), got)
+	}
+	if got[0].Address != "212.72.24.36" || got[0].ID != "eip-orphan" {
+		t.Fatalf("orphan = %+v, want {ID:eip-orphan Address:212.72.24.36}", got[0])
+	}
+	for _, e := range got {
+		if e.Address == bastionEIPAddress {
+			t.Fatalf("bastion EIP %s was flagged as an orphan — HARD bastion-protection violated", e.Address)
+		}
+	}
+}
+
+// TestVerifyZeroOrphans_FlagsUnboundEIP wires the sweep through the real
+// verifyZeroOrphans path: the unbound nameless orphan must land in
+// ResidualOrphans["floating_ips"] and flip VerifiedZeroOrphans=false,
+// while the bastion EIP is NEVER recorded.
+func TestVerifyZeroOrphans_FlagsUnboundEIP(t *testing.T) {
+	restore := fakeHCSPublicIPs(t, publicIPsFixture)
+	defer restore()
+
+	hw := hwCreds{AccessKey: "ak", SecretKey: "sk", ProjectID: "proj"}
+	client := httpClientFor(providers.ProviderCreds{Raw: map[string]string{"region": "me-east-215"}})
+	out := &providers.WipeResult{}
+
+	verifyZeroOrphans(context.Background(), client, hw, "me-east-215", "t99.omani.works", func(string) {}, out)
+
+	if out.VerifiedZeroOrphans {
+		t.Fatalf("VerifiedZeroOrphans=true, but an unbound orphan EIP (212.72.24.36) survived — the wipe-contract gate must FAIL")
+	}
+	fips := out.ResidualOrphans["floating_ips"]
+	found := false
+	for _, a := range fips {
+		if a == bastionEIPAddress {
+			t.Fatalf("bastion EIP %s recorded as a residual orphan — HARD bastion-protection violated", a)
+		}
+		if a == "212.72.24.36" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("residual floating_ips = %v, want it to include the unbound orphan 212.72.24.36", fips)
+	}
+}
+
+// TestVerifyZeroOrphans_CleanProjectPasses confirms NO false positive: a
+// project whose only EIP is the bastion (bound, sacred) reports zero
+// orphans — verifyZeroOrphans must NOT flag the bastion.
+func TestVerifyZeroOrphans_CleanProjectPasses(t *testing.T) {
+	const onlyBastion = `{"publicips":[
+      {"id":"eip-bastion","public_ip_address":"212.72.24.20","status":"ACTIVE","port_id":"port-bastion","bandwidth_name":"bastion-openova-bw"}
+    ]}`
+	restore := fakeHCSPublicIPs(t, onlyBastion)
+	defer restore()
+
+	hw := hwCreds{AccessKey: "ak", SecretKey: "sk", ProjectID: "proj"}
+	client := httpClientFor(providers.ProviderCreds{Raw: map[string]string{"region": "me-east-215"}})
+	out := &providers.WipeResult{}
+
+	verifyZeroOrphans(context.Background(), client, hw, "me-east-215", "t99.omani.works", func(string) {}, out)
+
+	if !out.VerifiedZeroOrphans {
+		t.Fatalf("VerifiedZeroOrphans=false on a clean (bastion-only) project; residuals=%v — bastion must never be flagged", out.ResidualOrphans)
+	}
+}

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5036,7 +5036,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.97"
+    version: "0.1.98"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Problem

Found live wiping dep `8fd457a8` / omantel.biz on kom4dc. The canonical wipe (`WipeDeployment` → `providers/huawei/provider.go`) enumerates EIPs to purge **by name-prefix** (`listEIPsByNamePrefix`, keyed on the SovereignFQDN `bandwidth_name`), and `verifyZeroOrphans` checks the same prefix-matched set. An **UNBOUND, DOWN EIP `212.72.24.36`** — no `port_id`, no `catalyst-<stem>-` name match — was invisible to both. The wipe reported `verifiedZeroOrphans:true` while the EIP stayed in the project; an independent `GET /v1/{proj}/publicips` sweep caught it and it was released by hand.

Orphan EIPs accumulate per wipe → Huawei `publicIp` quota exhaustion → the same quota-leak class behind the #4614 production reap. The wipe's own "verified zero orphans" was therefore not trustworthy.

## Fix

New helper `listUnboundOrphanEIPs` (`wipe_unbound_eip.go`) does a project-wide `GET /v1/{proj}/publicips` — the same raw listing `SweepOrphanEIPs` / `allocateCleanEIP` already use — and returns every EIP that is **NON-bastion AND UNBOUND (`port_id == ""`)**. It reuses `doSignedRequest`, `endpointFor`, the existing `hwEIP` projection, and `snippet` — no new signing path.

- **Purge path** (`provider.go`, step 4, after the name-prefix delete loop): release every non-bastion unbound EIP project-wide. Conservative — only unbound EIPs are deleted, never a bound one.
- **`verifyZeroOrphans`**: record any surviving non-bastion unbound EIP in `ResidualOrphans["floating_ips"]` so the existing G103 wipe-contract gate **fails** instead of falsely passing. Name-prefix + unbound matches are deduped.

## Bastion protection (HARD)

The bastion EIP `212.72.24.20` is **bound** to the `bastion-*` ECS, so the unbound-only filter (`port_id == ""`) already excludes it. As defence-in-depth `isProtectedBastionEIP` ALSO skips the literal bastion IP and any `bandwidth_name` carrying the `bastion` substring — mirroring every other bastion guard in this package. The bastion is never released and never flagged.

**Bastion identification — honest note:** the guard is primarily **port-binding** (a bound EIP is never released, which is what actually protects the live bastion) plus a literal-IP and name-substring belt-and-braces. I did not resolve the `port_id` back to the owning ECS name — the unbound-only rule makes that unnecessary for the release path (we only ever release EIPs with no binding at all), and the literal-IP guard covers the bastion's specific address.

## Test

`wipe_unbound_eip_test.go` stands up a fake `/publicips` listing with (a) the bastion EIP (bound, sacred IP), (b) a bound catalyst EIP, (c) an unbound nameless orphan (`212.72.24.36` shape):
- `listUnboundOrphanEIPs` returns **only** the orphan.
- `verifyZeroOrphans` lands the orphan in `ResidualOrphans["floating_ips"]`, flips `VerifiedZeroOrphans=false`, and **never** records the bastion.
- a bastion-only project still verifies zero orphans (no false positive).

Verified the `verifyZeroOrphans` test **FAILS** without the sweep and **PASSES** with it (real regression guard, not token-passing).

`go build ./...`, `go vet ./internal/providers/huawei/`, and the full huawei package tests are clean.

## Audit (the issue's "same gap elsewhere?")

The same **name-prefix-only** assumption applies to the **keypair** and **security-group** residual scans in `verifyZeroOrphans` (filter on `catalyst-<stem>-` / `listSGsByName`). A genuinely nameless keypair/SG would be missed too. EIP is the P0 here — tight 10/project quota and the actual live leak — so per the issue's guidance those are noted for a follow-up rather than expanded in this change.

Refs #4636 #4614 #4454

🤖 Generated with [Claude Code](https://claude.com/claude-code)