### PR TITLE
fix(wipe): sweep unbound/nameless orphan EIPs project-wide — verifyZeroOrphans missed them (#4636)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/providers/huawei/provider.go
+++ b/products/catalyst/bootstrap/api/internal/providers/huawei/provider.go
@@ -525,12 +525,33 @@ func verifyZeroOrphans(ctx context.Context, client *http.Client, hw hwCreds, reg
 		}
 	}
 
-	// EIP residuals.
+	// EIP residuals — name-prefix-matched (catalyst-<stem>- bandwidth name).
+	eipSeen := map[string]bool{}
 	if eips, err := listEIPsByNamePrefix(ctx, client, hw, region, sovereignFQDN, ""); err == nil {
 		for _, e := range eips {
 			if strings.HasPrefix(e.Address, "bastion") {
 				continue
 			}
+			if eipSeen[e.Address] {
+				continue
+			}
+			eipSeen[e.Address] = true
+			out.ResidualOrphans["floating_ips"] = append(out.ResidualOrphans["floating_ips"], e.Address)
+		}
+	}
+	// #4636 — UNBOUND / nameless EIP residuals. The name-prefix scan above
+	// is blind to an EIP that has no catalyst-<stem>- bandwidth name (the
+	// live 212.72.24.36 leak on the 8fd457a8 wipe). Sweep the WHOLE project
+	// for NON-bastion UNBOUND (port_id == "") EIPs and record any survivor
+	// so the G103 zero-orphans verdict FAILS instead of falsely passing.
+	// The bastion EIP is BOUND (port_id set) + literal-IP/name guarded, so
+	// it is never flagged.
+	if orphanEIPs, err := listUnboundOrphanEIPs(ctx, client, hw, region); err == nil {
+		for _, e := range orphanEIPs {
+			if eipSeen[e.Address] {
+				continue
+			}
+			eipSeen[e.Address] = true
 			out.ResidualOrphans["floating_ips"] = append(out.ResidualOrphans["floating_ips"], e.Address)
 		}
 	}
@@ -992,6 +1013,27 @@ func purgeHuaweiResources(ctx context.Context, client *http.Client, hw hwCreds, 
 	stillStuck, _ := listEIPsByNamePrefix(ctx, client, hw, region, sovereignFQDN, deploymentID)
 	for _, e := range stillStuck {
 		out.Errors = append(out.Errors, fmt.Sprintf("EIP %s survived %d wipe passes (still in HCS — quota will be hit on next prov)", e.Address, eipPasses))
+	}
+
+	// #4636 — UNBOUND / nameless EIP sweep. The name-prefix purge above
+	// only sees EIPs whose bandwidth_name carries the catalyst-<stem>-
+	// prefix. An UNBOUND, DOWN EIP with no name match (live: 212.72.24.36
+	// on the 8fd457a8 wipe) is invisible to it AND to verifyZeroOrphans,
+	// so it leaks per wipe → publicIp quota exhaustion (#4614 reap class).
+	// Release every NON-bastion UNBOUND (port_id == "") EIP project-wide;
+	// listUnboundOrphanEIPs never returns a bound or bastion EIP, so this
+	// can only release genuine leftovers.
+	if orphanEIPs, oerr := listUnboundOrphanEIPs(ctx, client, hw, region); oerr != nil {
+		out.Errors = append(out.Errors, "list unbound orphan EIPs (#4636): "+oerr.Error())
+	} else {
+		for _, e := range orphanEIPs {
+			if err := deleteEIP(ctx, client, hw, region, e.ID); err != nil {
+				out.Errors = append(out.Errors, fmt.Sprintf("delete unbound orphan EIP %s (#4636): %s", e.Address, err))
+				continue
+			}
+			out.ProviderPurge["floating_ips"] = append(out.ProviderPurge["floating_ips"], e.Address)
+			progress(fmt.Sprintf("#4636: released unbound orphan EIP %s (no port_id, no name match)", e.Address))
+		}
 	}
 
 	// 5. SG — by-name (covers tags-disabled case).

--- a/products/catalyst/bootstrap/api/internal/providers/huawei/wipe_unbound_eip.go
+++ b/products/catalyst/bootstrap/api/internal/providers/huawei/wipe_unbound_eip.go
@@ -1,0 +1,123 @@
+// Wave 5.x (#4636) — UNBOUND / nameless EIP sweep for the canonical wipe.
+//
+// Root cause (found live wiping dep 8fd457a8 / omantel.biz on kom4dc,
+// 2026-07-01): the canonical Wipe enumerates EIPs to purge BY NAME-PREFIX
+// (listEIPsByNamePrefix, keyed on the SovereignFQDN bandwidth_name) and
+// verifyZeroOrphans checks the same prefix-matched set. An UNBOUND, DOWN
+// EIP with NO `catalyst-<stem>-` bandwidth name and NO port_id
+// (e.g. 212.72.24.36) is invisible to both — so the wipe reports
+// `verifiedZeroOrphans:true` while leaking the EIP. Orphan EIPs then
+// accumulate per wipe → Huawei publicIp quota exhaustion → the same
+// quota-leak class behind the #4614 production reap (#4454 janitor
+// inversion fixed the runtime self-destruct; this fixes the wipe-side
+// leak that feeds it).
+//
+// Fix: a project-wide `GET /v1/{proj}/publicips` sweep (the same raw list
+// SweepOrphanEIPs / allocateCleanEIP already use) that flags every EIP
+// which is NON-bastion AND UNBOUND (port_id == "") as an orphan. The wipe
+// purge releases them (DELETE only — conservatively, never a BOUND EIP),
+// and verifyZeroOrphans surfaces any survivor in
+// ResidualOrphans["floating_ips"] so the existing G103 contract gate
+// fails.
+//
+// Bastion protection (founder HARD RULE: bastion 212.72.24.20 is sacred):
+// the bastion EIP is BOUND to the bastion-* ECS, so the unbound-only
+// filter (port_id == "") already excludes it. As defence-in-depth we ALSO
+// explicitly skip the known bastion IP and any EIP whose bandwidth_name
+// carries the "bastion" substring, mirroring every other bastion guard in
+// this package (provider.go SweepOrphanKeypairs / sweepVPCs / etc.).
+
+package huawei
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// bastionEIPAddress is the operator-owned bastion EIP. It is BOUND to the
+// bastion-* ECS (so it carries a port_id and is excluded by the
+// unbound-only filter), but we hard-protect the literal address too as
+// defence-in-depth — losing the bastion is catastrophic + irreversible
+// (founder 2026-06-04: "you never need my approval for any resources you
+// created in Huawei other than the bastion node").
+const bastionEIPAddress = "212.72.24.20"
+
+// rawPublicIP is the minimal projection of one entry in the
+// `GET /v1/{proj}/publicips` listing, carrying exactly the fields the
+// unbound-orphan decision needs.
+type rawPublicIP struct {
+	ID            string `json:"id"`
+	Address       string `json:"public_ip_address"`
+	Status        string `json:"status"`
+	PortID        string `json:"port_id"`
+	BandwidthName string `json:"bandwidth_name"`
+}
+
+// isProtectedBastionEIP reports whether an EIP must NEVER be touched
+// because it is (or might be) the bastion. Three independent guards:
+//   - the literal bastion address,
+//   - a bandwidth_name carrying the "bastion" substring (mirrors the
+//     name-substring bastion guard used everywhere else in this package),
+//   - a BOUND EIP (port_id != "") — the bastion is bound, and we never
+//     release a bound EIP regardless, so a bound EIP is always protected
+//     by the unbound-only orphan rule below.
+func isProtectedBastionEIP(e rawPublicIP) bool {
+	if e.Address == bastionEIPAddress {
+		return true
+	}
+	if strings.Contains(strings.ToLower(e.BandwidthName), "bastion") {
+		return true
+	}
+	return false
+}
+
+// listUnboundOrphanEIPs lists EVERY publicIP in the project and returns
+// the ones that are orphans: NON-bastion AND UNBOUND (port_id == "").
+// This is the name-prefix-blind half of the EIP residual scan — it catches
+// the nameless / DOWN / pool-recycled EIPs that listEIPsByNamePrefix
+// cannot see (#4636).
+//
+// Conservative by construction: a BOUND EIP (port_id set) is NEVER
+// returned, so an in-flight allocation that is momentarily attached, the
+// bastion EIP, and any operator workload's bound EIP are all excluded. A
+// transient DOWN+unbound window during another deployment's `tofu apply`
+// is the only false-positive surface; the wipe only runs on an explicit
+// per-deployment wipe whose own EIPs are already being torn down, so the
+// blast radius is the project's genuine unbound leftovers.
+func listUnboundOrphanEIPs(ctx context.Context, client *http.Client, hw hwCreds, region string) ([]hwEIP, error) {
+	url := fmt.Sprintf("%s/v1/%s/publicips", endpointFor("vpc", region), hw.ProjectID)
+	resp, status, err := doSignedRequest(client, hw, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if status >= 400 {
+		if status == http.StatusNotFound {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("list publicips: status %d: %s", status, snippet(resp, 240))
+	}
+	var decoded struct {
+		PublicIPs []rawPublicIP `json:"publicips"`
+	}
+	if err := json.Unmarshal(resp, &decoded); err != nil {
+		return nil, fmt.Errorf("decode publicips: %w", err)
+	}
+	out := []hwEIP{}
+	for _, e := range decoded.PublicIPs {
+		if isProtectedBastionEIP(e) {
+			continue
+		}
+		if e.PortID != "" {
+			// BOUND — never release a bound EIP from the wipe path. If it
+			// belongs to this deployment the name-prefix purge + detach
+			// chain handles it; if it belongs to another workload it's
+			// out of scope entirely.
+			continue
+		}
+		out = append(out, hwEIP{ID: e.ID, Address: e.Address})
+	}
+	return out, nil
+}

--- a/products/catalyst/bootstrap/api/internal/providers/huawei/wipe_unbound_eip_test.go
+++ b/products/catalyst/bootstrap/api/internal/providers/huawei/wipe_unbound_eip_test.go
@@ -1,0 +1,138 @@
+// #4636 — regression guard for the UNBOUND / nameless EIP wipe leak.
+//
+// Found live wiping dep 8fd457a8 / omantel.biz on kom4dc: an UNBOUND, DOWN
+// EIP (212.72.24.36) with no catalyst-<stem>- bandwidth name slipped past
+// listEIPsByNamePrefix and verifyZeroOrphans → wipe falsely reported
+// verifiedZeroOrphans:true → orphan EIP leaked → publicIp quota leak (the
+// #4614 reap class). These tests assert the project-wide unbound sweep
+// catches such an orphan while NEVER flagging the bastion EIP.
+
+package huawei
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/providers"
+)
+
+// fakeHCSPublicIPs stands up a httptest server that serves a fixed
+// `GET /v1/{proj}/publicips` listing and overrides the package
+// `endpointFor` so every Huawei call in the package routes at it. Any
+// other path (os-keypairs, ELB list, NAT list, …) returns an empty JSON
+// object so the unrelated residual scans in verifyZeroOrphans read empty.
+// Returns a restore func.
+func fakeHCSPublicIPs(t *testing.T, publicipsBody string) func() {
+	t.Helper()
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/publicips"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(publicipsBody))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	host := strings.TrimPrefix(srv.URL, "https://")
+	orig := endpointFor
+	endpointFor = func(service, region string) string { return "https://" + host }
+	return func() {
+		endpointFor = orig
+		srv.Close()
+	}
+}
+
+// publicIPsFixture: (a) the bastion EIP — BOUND, literal sacred IP;
+// (b) a BOUND catalyst EIP (in-use, name-matched, has a port);
+// (c) an UNBOUND nameless orphan — the 212.72.24.36 leak shape (DOWN,
+// no port_id, no catalyst- bandwidth name).
+const publicIPsFixture = `{"publicips":[
+  {"id":"eip-bastion","public_ip_address":"212.72.24.20","status":"ACTIVE","port_id":"port-bastion","bandwidth_name":"bastion-openova-bw"},
+  {"id":"eip-catalyst-bound","public_ip_address":"212.72.24.40","status":"ACTIVE","port_id":"port-cp-1","bandwidth_name":"catalyst-t99-omani-works-5b413990-cp-bw"},
+  {"id":"eip-orphan","public_ip_address":"212.72.24.36","status":"DOWN","port_id":"","bandwidth_name":""}
+]}`
+
+// TestListUnboundOrphanEIPs_OnlyOrphan asserts the project-wide sweep
+// returns EXACTLY the unbound nameless orphan: the bastion (bound + sacred
+// IP) and the bound catalyst EIP are both excluded.
+func TestListUnboundOrphanEIPs_OnlyOrphan(t *testing.T) {
+	restore := fakeHCSPublicIPs(t, publicIPsFixture)
+	defer restore()
+
+	hw := hwCreds{AccessKey: "ak", SecretKey: "sk", ProjectID: "proj"}
+	client := httpClientFor(providers.ProviderCreds{Raw: map[string]string{"region": "me-east-215"}})
+
+	got, err := listUnboundOrphanEIPs(context.Background(), client, hw, "me-east-215")
+	if err != nil {
+		t.Fatalf("listUnboundOrphanEIPs: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d orphan EIP(s) %+v, want exactly 1 (the unbound nameless orphan)", len(got), got)
+	}
+	if got[0].Address != "212.72.24.36" || got[0].ID != "eip-orphan" {
+		t.Fatalf("orphan = %+v, want {ID:eip-orphan Address:212.72.24.36}", got[0])
+	}
+	for _, e := range got {
+		if e.Address == bastionEIPAddress {
+			t.Fatalf("bastion EIP %s was flagged as an orphan — HARD bastion-protection violated", e.Address)
+		}
+	}
+}
+
+// TestVerifyZeroOrphans_FlagsUnboundEIP wires the sweep through the real
+// verifyZeroOrphans path: the unbound nameless orphan must land in
+// ResidualOrphans["floating_ips"] and flip VerifiedZeroOrphans=false,
+// while the bastion EIP is NEVER recorded.
+func TestVerifyZeroOrphans_FlagsUnboundEIP(t *testing.T) {
+	restore := fakeHCSPublicIPs(t, publicIPsFixture)
+	defer restore()
+
+	hw := hwCreds{AccessKey: "ak", SecretKey: "sk", ProjectID: "proj"}
+	client := httpClientFor(providers.ProviderCreds{Raw: map[string]string{"region": "me-east-215"}})
+	out := &providers.WipeResult{}
+
+	verifyZeroOrphans(context.Background(), client, hw, "me-east-215", "t99.omani.works", func(string) {}, out)
+
+	if out.VerifiedZeroOrphans {
+		t.Fatalf("VerifiedZeroOrphans=true, but an unbound orphan EIP (212.72.24.36) survived — the wipe-contract gate must FAIL")
+	}
+	fips := out.ResidualOrphans["floating_ips"]
+	found := false
+	for _, a := range fips {
+		if a == bastionEIPAddress {
+			t.Fatalf("bastion EIP %s recorded as a residual orphan — HARD bastion-protection violated", a)
+		}
+		if a == "212.72.24.36" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("residual floating_ips = %v, want it to include the unbound orphan 212.72.24.36", fips)
+	}
+}
+
+// TestVerifyZeroOrphans_CleanProjectPasses confirms NO false positive: a
+// project whose only EIP is the bastion (bound, sacred) reports zero
+// orphans — verifyZeroOrphans must NOT flag the bastion.
+func TestVerifyZeroOrphans_CleanProjectPasses(t *testing.T) {
+	const onlyBastion = `{"publicips":[
+      {"id":"eip-bastion","public_ip_address":"212.72.24.20","status":"ACTIVE","port_id":"port-bastion","bandwidth_name":"bastion-openova-bw"}
+    ]}`
+	restore := fakeHCSPublicIPs(t, onlyBastion)
+	defer restore()
+
+	hw := hwCreds{AccessKey: "ak", SecretKey: "sk", ProjectID: "proj"}
+	client := httpClientFor(providers.ProviderCreds{Raw: map[string]string{"region": "me-east-215"}})
+	out := &providers.WipeResult{}
+
+	verifyZeroOrphans(context.Background(), client, hw, "me-east-215", "t99.omani.works", func(string) {}, out)
+
+	if !out.VerifiedZeroOrphans {
+		t.Fatalf("VerifiedZeroOrphans=false on a clean (bastion-only) project; residuals=%v — bastion must never be flagged", out.ResidualOrphans)
+	}
+}


### PR DESCRIPTION
## What
The canonical wipe missed UNBOUND/nameless orphan EIPs → leak → Huawei `publicip` quota exhaustion (the #4614 reap class). Adds `listUnboundOrphanEIPs` (project-wide `GET /publicips`) + wires it into both the purge (DELETE-only, never a bound EIP) and `verifyZeroOrphans` (records survivors → G103 gate fails).

## Bastion protection (founder HARD rule: `212.72.24.20` is sacred)
Load-bearing guard = the **unbound-only filter** (`port_id == ""`): the bastion EIP is BOUND to the `bastion-*` ECS, so it is never returned. Literal-IP + `bastion` name-substring are defence-in-depth. The release path only ever touches fully-unbound EIPs.

## Tests
`wipe_unbound_eip_test.go`: fake `/publicips` with bastion (bound) + bound catalyst EIP + unbound nameless orphan → only the orphan is flagged, bastion never flagged, bastion-only project passes. Confirmed FAILS without the sweep, PASSES with it. `go build ./...` + huawei pkg green.

## Note
Branched clean off current main (the prior #4670 branch had inadvertently carried #4669's reconciler+chart commits). The same name-prefix-only assumption exists in the keypair/SG residual scans — noted for follow-up (EIP is the P0, the 10/project quota is the live leak).

Refs #4636 #4614 #4454