### PR TITLE
fix(cutover): level-triggered reconciler must re-run a failed step — else a wedged cutover stays wedged (#4635 follow-up)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/cutover_internal.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_internal.go
@@ -451,6 +451,20 @@ type cutoverSpawnResult struct {
 // RequireSession) and source="handover" (ReceiveTofuArchive, where the
 // tofu-phase0-archive is sealed BY DEFINITION at the call site) are
 // deliberate post-handover actions and skip the gate.
+// cutoverSourceRetriesFailedStep reports whether a cutover spawned from this
+// source should RE-RUN a genuinely-failed step (the runCutover operatorRetry
+// flag). The one-shot edge triggers fail closed; the deliberate/level-triggered
+// drivers retry until the durable cutover-complete seal exists:
+//   - "internal" (Helm post-install hook) / "handover" (seal-fire) — FIRE-ONCE,
+//     unattended → fail closed (false).
+//   - "operator" (BSS CTA) — re-runs on the operator's deliberate click (true).
+//   - "reconcile" (#4635 level-triggered reconciler) — the no-give-up mechanism;
+//     MUST re-run a failed step every pass, else a cutover wedged at a failed
+//     step stays wedged forever and the reconciler is inert (true).
+func cutoverSourceRetriesFailedStep(source string) bool {
+	return source == "operator" || source == "reconcile"
+}
+
 func (h *Handler) spawnCutoverEngine(ctx context.Context, deps *cutoverDeps, source string) (cutoverSpawnResult, error) {
 	status, err := readCutoverStatus(ctx, deps)
 	if err != nil {
@@ -566,13 +580,21 @@ func (h *Handler) spawnCutoverEngine(ctx context.Context, deps *cutoverDeps, sou
 	// client disconnect doesn't cancel a multi-step cutover. The
 	// cutoverStepTimeout on each step bounds the overall runtime.
 	//
-	// operatorRetry=false (#3379): the in-cluster auto-trigger
-	// (source="internal") and the handover-seal path (source="handover") are
-	// unattended — a GENUINE prior step failure must fail-closed, not
-	// auto-loop. Only the operator-session CTA (HandleCutoverStart) sets
-	// operatorRetry=true to re-run a genuinely-failed step. Transient
-	// (DeadlineExceeded) failures still re-run via jobFailedTransiently.
-	go h.runCutover(context.Background(), deps, steps, false)
+	// operatorRetry semantics (#3379 + #4635):
+	//   - source="internal" (the one-shot Helm post-install hook) and
+	//     source="handover" (the one-shot seal-fire) are UNATTENDED, FIRE-ONCE
+	//     edges — a GENUINE prior step failure must fail-closed, not auto-loop,
+	//     so they keep operatorRetry=false.
+	//   - source="operator" (the BSS CTA, HandleCutoverStart) re-runs a
+	//     genuinely-failed step on the operator's deliberate click.
+	//   - source="reconcile" (#4635, the LEVEL-triggered reconciler) IS the
+	//     no-give-up mechanism: it must RE-RUN a genuinely-failed step every
+	//     pass until the durable cutover-complete seal exists — otherwise a
+	//     cutover wedged at a failed step (e.g. a stale Failed step Job carried
+	//     over on resume) stays wedged forever and the reconciler is inert. So
+	//     it retries like the operator CTA.
+	// Transient (DeadlineExceeded) failures always re-run via jobFailedTransiently.
+	go h.runCutover(context.Background(), deps, steps, cutoverSourceRetriesFailedStep(source))
 
 	freshStatus, _ := readCutoverStatus(ctx, deps)
 	stepNames := make([]string, 0, len(steps))

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_reconciler_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_reconciler_test.go
@@ -104,3 +104,22 @@ func TestRunCutoverReconcilePass_FailsClosedOnSealReadError(t *testing.T) {
 		t.Fatalf("fires=%d, want 0 (no seal ⇒ never fire)", fires)
 	}
 }
+
+// TestCutoverSourceRetriesFailedStep guards the #4635 gap: the level-triggered
+// reconciler (source="reconcile") MUST re-run a genuinely-failed step (else a
+// cutover wedged at a failed step stays wedged and the reconciler is inert),
+// while the one-shot edge triggers fail closed.
+func TestCutoverSourceRetriesFailedStep(t *testing.T) {
+	cases := map[string]bool{
+		"internal":  false, // one-shot Helm hook — fail closed
+		"handover":  false, // one-shot seal-fire — fail closed
+		"operator":  true,  // BSS CTA — deliberate retry
+		"reconcile": true,  // #4635 level-triggered — no-give-up retry
+		"":          false, // unknown — fail closed
+	}
+	for source, want := range cases {
+		if got := cutoverSourceRetriesFailedStep(source); got != want {
+			t.Errorf("cutoverSourceRetriesFailedStep(%q) = %v, want %v", source, got, want)
+		}
+	}
+}


### PR DESCRIPTION
The #4635 reconciler fired the engine via `spawnCutoverEngine`, which hardcoded `runCutover(operatorRetry=false)`. With operatorRetry=false a genuinely-failed step fails closed and is never re-run (cutover.go:1531 `if jobFailedTransiently(job) || operatorRetry`). So the reconciler was inert against the exact case it exists for: a cutover **wedged at a failed step** (e.g. a stale Failed step Job carried over on resume — the hw202 step-07 scenario). `source="reconcile"` now retries the failed step like the operator CTA, via the `cutoverSourceRetriesFailedStep` helper; the one-shot edge triggers (internal/handover) still fail closed by design. Table test guards the mapping. Refs #4635 #3379