### PR TITLE
fix(wipe): drain-before-destroy — stop leaking CSI volumes + LBs on every wipe (#4677 root cause)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/wipe.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe.go
@@ -542,6 +542,22 @@ func (h *Handler) WipeDeployment(w http.ResponseWriter, r *http.Request) {
 			report.TofuDestroyed = true
 		}
 	} else {
+		// #4677 — DRAIN-BEFORE-DESTROY. Before tofu destroy tears down the nodes,
+		// delete the cluster's LoadBalancer Services + PVCs so the in-cluster
+		// CCM/CSI controllers release their cloud resources (LBs, EIPs, EVS
+		// volumes). Without this, `tofu destroy` orphans every CSI `pvc-<uuid>`
+		// volume (they are not in tofu state) — the ~5.8TB-leak root cause.
+		// Best-effort: an unreachable (already-dead) cluster no-ops and the wipe
+		// proceeds; the post-destroy cloud-GC backstops by detached-status.
+		if h.kubeconfigsDir != "" {
+			if kcRaw, rerr := os.ReadFile(filepath.Join(h.kubeconfigsDir, id+".yaml")); rerr == nil {
+				emit("wipe", "info", "drain-before-destroy: releasing CSI volumes + LoadBalancers before tofu destroy (#4677)")
+				_ = drainClusterCloudResources(tofuCtx, kcRaw, func(msg string) {
+					emit("wipe", "info", msg)
+				})
+			}
+		}
+
 		credsRaw := buildWipeCredsRaw(providerName, body, dep.Request)
 		wipeSpec := providers.WipeSpec{
 			DeploymentID:  dep.ID,

--- a/products/catalyst/bootstrap/api/internal/handler/wipe_drain.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe_drain.go
@@ -1,0 +1,189 @@
+package handler
+
+// wipe_drain.go — #4677 drain-before-destroy.
+//
+// THE ROOT CAUSE this fixes
+// ─────────────────────────
+// The canonical wipe runs `tofu destroy`, which deletes ONLY the
+// Terraform-managed infra (VPC / ECS / EIPs / NAT / the tofu-declared ELB).
+// But a running Sovereign creates cloud resources at RUNTIME, OUTSIDE tofu
+// state, via the in-cluster controllers:
+//
+//   - the CSI driver (huawei-evs-csi / hcloud-csi) provisions one cloud VOLUME
+//     per PVC (postgres, gitea, harbor, openbao, loki, mimir, tempo, …), named
+//     `pvc-<uuid>` — no deployment identity;
+//   - the cloud-controller-manager provisions one LOAD BALANCER (+ its EIP) per
+//     `Service type=LoadBalancer`.
+//
+// `tofu destroy` tears down the nodes/VPC before the in-cluster CSI/CCM
+// controllers can delete those resources, so EVERY wipe orphans all of them
+// (detached volumes, dangling LBs) — billed forever, and invisible to the
+// name-prefix janitor because `pvc-<uuid>` carries no dep name to match.
+//
+// THE FIX
+// ───────
+// Before `tofu destroy`, while the cluster is still reachable, DRAIN the K8s
+// objects that own cloud resources so the in-cluster controllers release them:
+//   1. delete every `Service type=LoadBalancer` → CCM releases the LB + EIP;
+//   2. for every PVC, force its PV reclaim policy to Delete, then delete the
+//      PVC → CSI deletes the backing cloud volume;
+//   3. bounded wait for the PVs to disappear (best-effort).
+//
+// Best-effort by design: on a wipe of an ALREADY-DEAD env (apiserver
+// unreachable) the drain no-ops and the wipe proceeds to tofu destroy — the
+// post-destroy cloud-GC (swept by detached-status, not name) is the backstop
+// for that case.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// drainPVSettleTimeout bounds the post-delete wait for CSI to remove the PVs
+// (cloud volumes). Package var so tests can shorten it; the wipe never stalls
+// past it (the cloud-GC backstops any still-settling deletes).
+var drainPVSettleTimeout = 90 * time.Second
+
+// drainClusterCloudResources deletes the LoadBalancer Services + PVCs of the
+// cluster addressed by kcRaw so the in-cluster CCM/CSI controllers release
+// their cloud resources (LBs, EIPs, EVS volumes) BEFORE tofu destroys the
+// nodes. Returns nil (best-effort) when the cluster is unreachable — the
+// caller proceeds to tofu destroy regardless. progress may be nil.
+func drainClusterCloudResources(ctx context.Context, kcRaw []byte, progress func(string)) error {
+	if progress == nil {
+		progress = func(string) {}
+	}
+	if len(kcRaw) == 0 {
+		return nil // no kubeconfig on the PVC → nothing to drain (already gone)
+	}
+	restCfg, err := clientcmd.RESTConfigFromKubeConfig(kcRaw)
+	if err != nil {
+		progress("drain: skipped — bad kubeconfig: " + err.Error())
+		return nil
+	}
+	// A tight timeout so a dead apiserver never stalls the wipe.
+	restCfg.Timeout = 20 * time.Second
+	cs, err := kubernetes.NewForConfig(restCfg)
+	if err != nil {
+		progress("drain: skipped — client build failed: " + err.Error())
+		return nil
+	}
+
+	// Reachability probe: one cheap list. If the apiserver is gone (already-dead
+	// env), skip the drain entirely and let tofu destroy + the cloud-GC handle it.
+	probeCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+	if _, err := cs.CoreV1().Namespaces().List(probeCtx, metav1.ListOptions{Limit: 1}); err != nil {
+		progress("drain: cluster unreachable — skipping drain, relying on tofu destroy + cloud-GC (" + err.Error() + ")")
+		return nil
+	}
+
+	drainLoadBalancerServices(ctx, cs, progress)
+	drainPVCs(ctx, cs, progress)
+	return nil
+}
+
+// drainLoadBalancerServices deletes every Service of type LoadBalancer so the
+// cloud-controller-manager releases the backing LB + its EIP.
+func drainLoadBalancerServices(ctx context.Context, cs kubernetes.Interface, progress func(string)) {
+	if progress == nil {
+		progress = func(string) {}
+	}
+	lctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	svcs, err := cs.CoreV1().Services("").List(lctx, metav1.ListOptions{})
+	if err != nil {
+		progress("drain: list services failed: " + err.Error())
+		return
+	}
+	deleted := 0
+	for i := range svcs.Items {
+		s := &svcs.Items[i]
+		if s.Spec.Type != corev1.ServiceTypeLoadBalancer {
+			continue
+		}
+		dctx, dcancel := context.WithTimeout(ctx, 15*time.Second)
+		err := cs.CoreV1().Services(s.Namespace).Delete(dctx, s.Name, metav1.DeleteOptions{})
+		dcancel()
+		if err != nil {
+			progress(fmt.Sprintf("drain: delete svc %s/%s failed: %s", s.Namespace, s.Name, err.Error()))
+			continue
+		}
+		deleted++
+	}
+	progress(fmt.Sprintf("drain: deleted %d LoadBalancer Service(s) → CCM releasing LB(s)+EIP(s)", deleted))
+}
+
+// drainPVCs forces each PV's reclaim policy to Delete then deletes the PVC so
+// the CSI driver deletes the backing cloud volume (works even when the
+// StorageClass default was Retain — the whole env is being destroyed).
+func drainPVCs(ctx context.Context, cs kubernetes.Interface, progress func(string)) {
+	if progress == nil {
+		progress = func(string) {}
+	}
+	lctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	pvcs, err := cs.CoreV1().PersistentVolumeClaims("").List(lctx, metav1.ListOptions{})
+	if err != nil {
+		progress("drain: list pvcs failed: " + err.Error())
+		return
+	}
+	deleted := 0
+	pvNames := make([]string, 0, len(pvcs.Items))
+	for i := range pvcs.Items {
+		p := &pvcs.Items[i]
+		// Force the bound PV to Delete so releasing the PVC deletes the cloud
+		// volume regardless of the StorageClass's default reclaim policy.
+		if p.Spec.VolumeName != "" {
+			patch := []byte(`{"spec":{"persistentVolumeReclaimPolicy":"Delete"}}`)
+			pctx, pcancel := context.WithTimeout(ctx, 15*time.Second)
+			_, perr := cs.CoreV1().PersistentVolumes().Patch(pctx, p.Spec.VolumeName, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
+			pcancel()
+			if perr != nil {
+				progress(fmt.Sprintf("drain: patch pv %s reclaim=Delete failed: %s", p.Spec.VolumeName, perr.Error()))
+			} else {
+				pvNames = append(pvNames, p.Spec.VolumeName)
+			}
+		}
+		dctx, dcancel := context.WithTimeout(ctx, 15*time.Second)
+		err := cs.CoreV1().PersistentVolumeClaims(p.Namespace).Delete(dctx, p.Name, metav1.DeleteOptions{})
+		dcancel()
+		if err != nil {
+			progress(fmt.Sprintf("drain: delete pvc %s/%s failed: %s", p.Namespace, p.Name, err.Error()))
+			continue
+		}
+		deleted++
+	}
+	progress(fmt.Sprintf("drain: deleted %d PVC(s) (reclaim→Delete on %d PV) → CSI deleting cloud volume(s)", deleted, len(pvNames)))
+
+	// Bounded wait for the PVs to disappear (CSI delete completed). Best-effort:
+	// a slow CSI never stalls the wipe past the deadline; the cloud-GC backstops.
+	deadline := time.Now().Add(drainPVSettleTimeout)
+	for time.Now().Before(deadline) {
+		remaining := 0
+		wctx, wcancel := context.WithTimeout(ctx, 15*time.Second)
+		for _, n := range pvNames {
+			if _, err := cs.CoreV1().PersistentVolumes().Get(wctx, n, metav1.GetOptions{}); err == nil {
+				remaining++
+			}
+		}
+		wcancel()
+		if remaining == 0 {
+			progress("drain: all CSI volumes released (PVs gone)")
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(6 * time.Second):
+		}
+	}
+	progress("drain: proceeding to tofu destroy (some CSI deletes still settling — cloud-GC will backstop)")
+}

--- a/products/catalyst/bootstrap/api/internal/handler/wipe_drain_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe_drain_test.go
@@ -1,0 +1,72 @@
+package handler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// Test_drain_ReleasesLoadBalancersAndCSIVolumes proves the #4677 drain deletes
+// the LoadBalancer Services (so CCM releases the LB+EIP) and the PVCs (so CSI
+// deletes the cloud volume) — the runtime-provisioned resources tofu destroy
+// cannot see. A ClusterIP Service is left untouched.
+func Test_drain_ReleasesLoadBalancersAndCSIVolumes(t *testing.T) {
+	cs := fake.NewSimpleClientset(
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "gateway", Namespace: "kube-system"},
+			Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "internal", Namespace: "default"},
+			Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeClusterIP},
+		},
+		&corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{Name: "pvc-abc"},
+			Spec:       corev1.PersistentVolumeSpec{PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimRetain},
+		},
+		&corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "data-postgres-0", Namespace: "cnpg-system"},
+			Spec:       corev1.PersistentVolumeClaimSpec{VolumeName: "pvc-abc"},
+		},
+	)
+
+	drainPVSettleTimeout = 200 * time.Millisecond // keep CI fast
+	drainLoadBalancerServices(context.Background(), cs, nil)
+	drainPVCs(context.Background(), cs, nil)
+
+	// LoadBalancer Service deleted, ClusterIP Service kept.
+	if _, err := cs.CoreV1().Services("kube-system").Get(context.Background(), "gateway", metav1.GetOptions{}); err == nil {
+		t.Error("LoadBalancer Service 'gateway' should have been deleted (CCM must release the LB+EIP)")
+	}
+	if _, err := cs.CoreV1().Services("default").Get(context.Background(), "internal", metav1.GetOptions{}); err != nil {
+		t.Error("ClusterIP Service 'internal' must NOT be touched by the drain")
+	}
+
+	// PVC deleted → CSI releases the cloud volume.
+	if _, err := cs.CoreV1().PersistentVolumeClaims("cnpg-system").Get(context.Background(), "data-postgres-0", metav1.GetOptions{}); err == nil {
+		t.Error("PVC 'data-postgres-0' should have been deleted (CSI must release the EVS volume)")
+	}
+
+	// The bound PV's reclaim policy was forced to Delete so the volume is
+	// actually removed even though the StorageClass default was Retain.
+	pv, err := cs.CoreV1().PersistentVolumes().Get(context.Background(), "pvc-abc", metav1.GetOptions{})
+	if err == nil && pv.Spec.PersistentVolumeReclaimPolicy != corev1.PersistentVolumeReclaimDelete {
+		t.Errorf("PV reclaim policy = %q, want Delete (else Retain orphans the volume)", pv.Spec.PersistentVolumeReclaimPolicy)
+	}
+}
+
+// Test_drain_EmptyKubeconfigNoOp proves a wipe of an already-dead env (no
+// kubeconfig) no-ops cleanly rather than erroring — the wipe proceeds to tofu
+// destroy + the cloud-GC backstop.
+func Test_drain_EmptyKubeconfigNoOp(t *testing.T) {
+	if err := drainClusterCloudResources(context.Background(), nil, nil); err != nil {
+		t.Fatalf("empty kubeconfig should no-op, got %v", err)
+	}
+	if err := drainClusterCloudResources(context.Background(), []byte("not-a-kubeconfig"), nil); err != nil {
+		t.Fatalf("bad kubeconfig should no-op (best-effort), got %v", err)
+	}
+}


### PR DESCRIPTION
The ~5.8TB orphan-storage **root cause**: the wipe runs `tofu destroy` (only Terraform-managed infra), but a Sovereign creates cloud resources at **runtime outside tofu** — one CSI EVS per PVC (`pvc-<uuid>`, no dep name) + one CCM ELB+EIP per LoadBalancer Service. `tofu destroy` kills the nodes before the in-cluster controllers can delete them → every wipe orphans all CSI volumes, and name-prefix janitors can never catch `pvc-<uuid>`. **Fix**: before tofu destroy, while the cluster is reachable, delete all LoadBalancer Services + all PVCs (PV reclaim forced to Delete), bounded-wait for the PVs to vanish. Best-effort — an already-dead cluster no-ops. Fake-clientset test proves it. Refs #4677 #4636 #4614