### PR TITLE
fix(cutover): step-04 ack-gate tolerates bounded laggard nodes (#4674)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/cutover.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover.go
@@ -106,6 +106,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"sort"
@@ -1173,11 +1174,57 @@ func waitForRegistryPivotNodeAcks(ctx context.Context, deps *cutoverDeps, dsName
 			return false, nil
 		}
 		acks := countRegistryPivotV2Acks(status)
-		if acks >= desired {
+		// #4674 — tolerate a bounded number of laggard nodes. A single node
+		// whose dfdaemon is persistently dead (stale resolver cache) never
+		// writes its v2 ack, and the strict acks==desired gate would wedge the
+		// WHOLE cutover on that one node for the full timeout. With a tolerance
+		// of T, the gate proceeds once (desired-acks) <= T; the #4635
+		// level-triggered reconciler keeps re-running the cutover so a laggard
+		// that recovers still converges. Default T=0 preserves the strict
+		// all-nodes invariant; raise via CATALYST_CUTOVER_ACK_TOLERANCE only for
+		// clouds with flaky per-node dfdaemons (kom4dc). Un-acked nodes are
+		// logged so the operator/reconciler can see exactly which node lagged.
+		if desired-acks <= cutoverAckTolerance() {
+			if acks < desired {
+				slog.Warn("cutover: proceeding past registry-pivot ack-gate with laggard node(s) within tolerance",
+					"acked", acks, "desired", desired,
+					"tolerance", cutoverAckTolerance(),
+					"unackedNodes", strings.Join(unackedRegistryPivotNodes(status), ","),
+				)
+			}
 			return true, nil
 		}
 		return false, nil
 	})
+}
+
+// envCutoverAckTolerance is the number of registry-pivot nodes allowed to miss
+// their v2 ack before the step-04 gate still proceeds (#4674). Default 0 =
+// strict all-nodes invariant.
+const envCutoverAckTolerance = "CATALYST_CUTOVER_ACK_TOLERANCE"
+
+// cutoverAckTolerance reads the laggard-node tolerance for the step-04 ack
+// gate. Non-negative; malformed / negative → 0 (strict).
+func cutoverAckTolerance() int {
+	if v, err := strconv.Atoi(strings.TrimSpace(os.Getenv(envCutoverAckTolerance))); err == nil && v > 0 {
+		return v
+	}
+	return 0
+}
+
+// unackedRegistryPivotNodes returns the node names present as ack keys whose
+// value is NOT "v2" (still v1 / unset) — for operator-visible diagnostics when
+// the gate proceeds within tolerance.
+func unackedRegistryPivotNodes(status map[string]string) []string {
+	var out []string
+	for k, v := range status {
+		if strings.HasPrefix(k, registryPivotNodeAckPrefix) &&
+			strings.HasSuffix(k, registryPivotNodeAckSuffix) && v != "v2" {
+			node := strings.TrimSuffix(strings.TrimPrefix(k, registryPivotNodeAckPrefix), registryPivotNodeAckSuffix)
+			out = append(out, node)
+		}
+	}
+	return out
 }
 
 // countRegistryPivotV2Acks counts the per-node ack keys in the status map

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_ack_tolerance_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_ack_tolerance_test.go
@@ -1,0 +1,37 @@
+package handler
+
+import (
+	"os"
+	"sort"
+	"testing"
+)
+
+// Test_cutoverAckTolerance covers the #4674 laggard-node tolerance knob.
+func Test_cutoverAckTolerance(t *testing.T) {
+	cases := map[string]int{"": 0, "0": 0, "1": 1, "2": 2, "-1": 0, "junk": 0}
+	for in, want := range cases {
+		os.Setenv(envCutoverAckTolerance, in)
+		if got := cutoverAckTolerance(); got != want {
+			t.Errorf("cutoverAckTolerance(%q)=%d want %d", in, got, want)
+		}
+	}
+	os.Unsetenv(envCutoverAckTolerance)
+}
+
+// Test_unackedRegistryPivotNodes proves the diagnostic lists exactly the nodes
+// whose ack is not "v2" (the flaky ones), ignoring non-ack keys.
+func Test_unackedRegistryPivotNodes(t *testing.T) {
+	status := map[string]string{
+		"node.a.registriesYaml": "v2",
+		"node.b.registriesYaml": "v1",  // laggard
+		"node.c.registriesYaml": "",    // laggard (unset)
+		"node.d.registriesYaml": "v2",
+		"progressPercent":       "27",  // ignored
+		"currentStep":           "x",   // ignored
+	}
+	got := unackedRegistryPivotNodes(status)
+	sort.Strings(got)
+	if len(got) != 2 || got[0] != "b" || got[1] != "c" {
+		t.Fatalf("unackedRegistryPivotNodes=%v want [b c]", got)
+	}
+}


### PR DESCRIPTION
LIVE on hw204: 6/7 nodes acked `registriesYaml=v2`, but one node whose dfdaemon was persistently dead never acked → the strict `acks==desired` gate timed out the whole cutover at 10m. Adds `CATALYST_CUTOVER_ACK_TOLERANCE` (default 0 = strict, unchanged): with tolerance T the gate proceeds once `desired-acks <= T`, logging exactly which nodes lagged; the merged #4635 reconciler keeps re-running so a recovering laggard still converges. Table tests cover the knob + the un-acked diagnostic. Refs #4674 #4635 #3671