### PR TITLE
fix(cutover): step-08 egress-test tolerates leader-elected singleton rollout (source-controller) (#4674)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -715,11 +715,11 @@ spec:
       # event-driven, not render-time-bound. NOT a Helm hook (converges async
       # behind disableWait:true). No step-count change; the Job carries
       # component=gitea-admin-secret-bridge, not the cutover-step label.
-      # 0.1.98 (#4637): step-04 registry-pivot gates its per-node v2 ack on a
+      # 0.1.99 (#4637): step-04 registry-pivot gates its per-node v2 ack on a
       # node-local `GET http://127.0.0.1:4001/v2/` serving probe so catalyst-api's
       # daemonset-wait cannot green (→ step-07 catalyst-api re-pull) while the
       # dfdaemon mirror has 0 Ready pods (#4649 condition → connection-refused).
-      version: 0.1.98
+      version: 0.1.99
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.98  # lockstep with chart/Chart.yaml (#4637 step-07 dfdaemon-serving v2-ack gate)
+  version: 0.1.99  # lockstep with chart/Chart.yaml (#4637 step-07 dfdaemon-serving v2-ack gate)
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1481,7 +1481,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.98
+version: 0.1.99
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
@@ -541,6 +541,25 @@ data:
                   echo "    FAIL — ${kind}/${name} has a Pod in image-pull error under deny-egress (${reasons}); residual external-registry tether or inert mirror (#3695)"
                   return 1 ;;
               esac
+              # #4674 — rollout status timed out but NO image-pull error (checked
+              # above). The ACTUAL sovereignty proof is "pulled a fresh image from
+              # the LOCAL registry under deny-egress", NOT "rollout fully completed".
+              # A LEADER-ELECTED SINGLETON (Flux source-controller) whose readiness
+              # probe is gated on acquiring the leader lease, under maxUnavailable=0,
+              # DEADLOCKS a rollout-restart: the new Pod pulls its image from the
+              # local registry (no tether) but can't pass readiness until the old
+              # Pod releases the lease, and the old Pod won't terminate until the new
+              # one is Ready. That is a rollout artifact, NOT an egress failure. If
+              # the new-template Pod exists (updatedReplicas>=1) and the workload is
+              # still serving (readyReplicas>=1) with no pull error, the fresh-pull
+              # proof PASSED. (updatedReplicas/readyReplicas are empty on a DaemonSet
+              # → falls through to the strict FAIL, unchanged for those.)
+              updated=$(kubectl get "${kind}" "${name}" -n "${ns}" -o jsonpath='{.status.updatedReplicas}' 2>/dev/null || echo 0)
+              ready=$(kubectl get "${kind}" "${name}" -n "${ns}" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo 0)
+              if [ "${updated:-0}" -ge 1 ] && [ "${ready:-0}" -ge 1 ]; then
+                echo "    PASS — ${kind}/${name} pulled a fresh image from the local registry under deny-egress (rollout status incomplete = leader-election readiness artifact under maxUnavailable=0; workload still serving) (#4674)"
+                return 0
+              fi
               echo "    FAIL — ${kind}/${name} did not roll out within ${FRESH_PULL_TIMEOUT}s under deny-egress (reasons:${reasons:-<none>})"
               return 1
             }

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5036,7 +5036,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.98"
+    version: "0.1.99"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
LIVE on hw205 — the FIRST prov to reach step-08 (600s deny-egress hold). The #3695 fresh-pull proof rolls every external-registry workload + waits for `rollout status`. Flux **source-controller pulled its image from the local Harbor under deny-egress in 1s** (the actual sovereignty proof ✅) but its readiness probe is gated on acquiring the leader lease; under `maxUnavailable=0` the rollout-restart **deadlocks** → false FAIL → cutover wedged at pct=63. Fix: after ruling out image-pull errors, PASS if the new-template Pod exists (`updatedReplicas>=1`) and the workload still serves (`readyReplicas>=1`) — a leader-election readiness artifact, not a tether. DaemonSets keep the strict FAIL. Refs #4674 #3695 #3379