### PR TITLE
P0: gateway sharing-key empty default renders YAML null → Gateway CRD rejects → sovereign-tls wedged → console dead on EVERY fresh prov (fix #4687 regression)

### DIFF
--- a/clusters/_template/sovereign-tls/cilium-gateway.yaml
+++ b/clusters/_template/sovereign-tls/cilium-gateway.yaml
@@ -210,11 +210,19 @@ spec:
       # CP-node EIP via Cilium LB-IPAM (different ports :443/:80 vs :2379), serving
       # DIRECTLY as a type=LoadBalancer with NO ELB and NO NodePort (§854). Cilium
       # propagates this annotation onto the generated cilium-gateway-<name> Service.
-      # Empty default → Hetzner (hcloud-ccm provisions the real LB; sharing-key
-      # irrelevant, empty is ignored). Huawei cloud-init sets it to the shared key.
+      # #4689 P0 — the default MUST be NON-EMPTY. An empty `:=` default renders the
+      # annotation value to YAML *null*, which the Gateway CRD REJECTS
+      # (`spec.infrastructure.annotations.lbipam.cilium.io/sharing-key ... must be of
+      # type string: "null"`) → the sovereign-tls Kustomization dry-run FAILS → the
+      # gateway never applies → console never serves (broke EVERY fresh prov post-#4687).
+      # The sovereign-tls Kustomization's substituteFrom (sovereign-tls-vars CM) does NOT
+      # provide CILIUM_GATEWAY_SHARING_KEY, so this default is what actually renders — it
+      # MUST equal the clustermesh Service's key (cloud-init CILIUM_GATEWAY_SHARING_KEY,
+      # slot-01) so both co-locate on the CP-node EIP. Harmless on Hetzner (no LB-IPAM
+      # pool → inert; hcloud-ccm gives the ExternalIP).
       # health-check-retries dropped (hcloud default is 3 — no-op) to stay within the
       # Gateway-API CRD 8-annotation cap (#1896).
-      lbipam.cilium.io/sharing-key: "${CILIUM_GATEWAY_SHARING_KEY:=}"
+      lbipam.cilium.io/sharing-key: "${CILIUM_GATEWAY_SHARING_KEY:=sovereign-gw-cm}"
     # #4686 — shared LB-IPAM selector labels. Cilium 1.16+ propagates
     # spec.infrastructure.labels onto the generated cilium-gateway-<name>
     # Service.


### PR DESCRIPTION
## P0 — #4687 broke the gateway on every fresh prov
`clusters/_template/sovereign-tls/cilium-gateway.yaml` set `lbipam.cilium.io/sharing-key: "${CILIUM_GATEWAY_SHARING_KEY:=}"`. The **sovereign-tls** Kustomization's `postBuild.substituteFrom` is the `sovereign-tls-vars` ConfigMap, which does NOT provide `CILIUM_GATEWAY_SHARING_KEY` → the empty `:=` default renders the annotation value to **YAML null** → the Gateway CRD rejects it:
```
Gateway "cilium-gateway" is invalid: spec.infrastructure.annotations.lbipam.cilium.io/sharing-key: Invalid value: "null": ... must be of type string: "null"
```
→ sovereign-tls Kustomization dry-run FAILS → the gateway never applies → **console never serves on any fresh prov** (Hetzner + Huawei). Live-diagnosed on hw208 (`cdf4c53b`).

**Why CI missed it:** the "Phase-8a preflight C — Cilium Gateway HTTPRoute admission" job (which server-dry-runs the Gateway) flaked on Kind-cluster setup on the #4687 merge and never ran. The gateway YAML is Kustomize-managed, so `helm template`/`tofu validate` didn't cover it.

## Fix
Non-empty default: `"${CILIUM_GATEWAY_SHARING_KEY:=sovereign-gw-cm}"` — always a valid string, and equals the clustermesh Service's key (cloud-init `CILIUM_GATEWAY_SHARING_KEY="sovereign-gw-cm"`, slot-01) so both co-locate on the CP-node EIP. Harmless on Hetzner (no LB-IPAM pool → inert; hcloud-ccm gives the ExternalIP).

## Validated LIVE on hw208 (fresh 2-region prov)
- Patched the Gateway with the string value → **CRD accepts** (was rejecting null).
- Gateway + clustermesh both → ExternalIP `212.72.24.31` shared via `sharing-key=sovereign-gw-cm` (option-B proven end-to-end on a fresh prov).
- clustermesh side is correct (cloud-init substitute provides the key); only the gateway's empty default was broken.

Delivery: `clusters/_template/` is Flux-git-delivered → reaches every prov (incl. hw208) on next reconcile, no image rebuild.

Follow-up (separate): the LB-IPAM race (clustermesh assigned its IP before its sharing-key registered → needed a one-shot `cilium-operator` restart) — a durable guard so fresh provs co-locate zero-touch.

Refs #4687 #4686