### PR TITLE
fix(cutover): steps 02/03 reach Harbor via external host registry.<fqdn>, not internal svc harbor-core.harbor.svc (#4688)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -715,11 +715,11 @@ spec:
       # event-driven, not render-time-bound. NOT a Helm hook (converges async
       # behind disableWait:true). No step-count change; the Job carries
       # component=gitea-admin-secret-bridge, not the cutover-step label.
-      # 0.1.100 (#4637): step-04 registry-pivot gates its per-node v2 ack on a
+      # 0.1.101 (#4637): step-04 registry-pivot gates its per-node v2 ack on a
       # node-local `GET http://127.0.0.1:4001/v2/` serving probe so catalyst-api's
       # daemonset-wait cannot green (→ step-07 catalyst-api re-pull) while the
       # dfdaemon mirror has 0 Ready pods (#4649 condition → connection-refused).
-      version: 0.1.100
+      version: 0.1.101
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.100  # lockstep with chart/Chart.yaml (#4637 step-07 dfdaemon-serving v2-ack gate)
+  version: 0.1.101  # lockstep with chart/Chart.yaml (#4637 step-07 dfdaemon-serving v2-ack gate)
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1509,7 +1509,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.100
+version: 0.1.101
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/02-harbor-projects-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/02-harbor-projects-job.yaml
@@ -33,6 +33,15 @@ data:
         env:
           - name: HARBOR_INTERNAL_URL
             value: {{ .Values.sovereign.harborInternalURL | quote }}
+          # #4688 — reach the local Harbor via its EXTERNAL host registry.<fqdn>
+          # (NOT the internal svc name harbor-core.harbor.svc) so cutover steps work
+          # under DMZ/RTZ multi-cluster segregation, where an in-cluster ClusterIP
+          # does not route across clusters. In-cluster-reachable via the gateway
+          # hairpin (verified 401 from a harbor pod on hw208). The `-k` on the curls
+          # below tolerates the local Harbor's LE-STAGING wildcard on qaTest provs
+          # (in-cluster access to the LOCAL Harbor's own cert; not MITM-exposed).
+          - name: HARBOR_PUBLIC_URL
+            value: {{ .Values.sovereign.harborPublicURL | quote }}
           - name: HARBOR_USERNAME
             valueFrom:
               secretKeyRef:
@@ -58,7 +67,7 @@ data:
           - |
             set -eu
             : "${HARBOR_USERNAME:=admin}"
-            base="${HARBOR_INTERNAL_URL}/api/v2.0"
+            base="${HARBOR_PUBLIC_URL}/api/v2.0"  # #4688 external host, not harbor-core.harbor.svc
 
             # 1. Decode GHCR creds (used by proxy-ghcr registry, authMode=credential).
             if [ -n "${GHCR_DOCKERCONFIG:-}" ]; then
@@ -92,7 +101,7 @@ data:
                 reg_payload="${reg_payload},\"credential\":{\"type\":\"basic\",\"access_key\":\"${ghcr_user}\",\"access_secret\":\"${ghcr_pass}\"}"
               fi
               reg_payload="${reg_payload}}"
-              code=$(curl -s -o /tmp/reg.out -w "%{http_code}" -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" -X POST \
+              code=$(curl -sk -o /tmp/reg.out -w "%{http_code}" -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" -X POST \
                 -H "Content-Type: application/json" \
                 "${base}/registries" --data "${reg_payload}")
               case "${code}" in
@@ -100,14 +109,14 @@ data:
                 *)       echo "[harbor-projects]   registry ${name}-upstream FAILED (${code})"; cat /tmp/reg.out; exit 1 ;;
               esac
 
-              reg_id=$(curl -s -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" "${base}/registries?name=${name}-upstream" | tr ',' '\n' | grep -o '"id":[0-9]*' | head -1 | awk -F: '{print $2}')
+              reg_id=$(curl -sk -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" "${base}/registries?name=${name}-upstream" | tr ',' '\n' | grep -o '"id":[0-9]*' | head -1 | awk -F: '{print $2}')
               if [ -z "${reg_id}" ]; then
                 echo "[harbor-projects]   could not resolve registry id for ${name}-upstream"
                 exit 1
               fi
 
               proj_payload="{\"project_name\":\"${name}\",\"public\":true,\"registry_id\":${reg_id},\"metadata\":{\"public\":\"true\"}}"
-              code=$(curl -s -o /tmp/proj.out -w "%{http_code}" -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" -X POST \
+              code=$(curl -sk -o /tmp/proj.out -w "%{http_code}" -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" -X POST \
                 -H "Content-Type: application/json" \
                 "${base}/projects" --data "${proj_payload}")
               case "${code}" in
@@ -130,7 +139,7 @@ data:
             for push_proj in {{ join " " .Values.harbor.pushProjects }}; do
               echo "[harbor-projects] ensuring push-mode project ${push_proj}"
               proj_payload="{\"project_name\":\"${push_proj}\",\"public\":false,\"metadata\":{\"public\":\"false\"}}"
-              code=$(curl -s -o /tmp/proj.out -w "%{http_code}" -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" -X POST \
+              code=$(curl -sk -o /tmp/proj.out -w "%{http_code}" -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" -X POST \
                 -H "Content-Type: application/json" \
                 "${base}/projects" --data "${proj_payload}")
               case "${code}" in

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -704,7 +704,7 @@ data:
 
             # ─── Phase B (legacy): HEAD against proxy-cache for non-openova-io ─
             echo "[harbor-prewarm] Phase B: HEAD against proxy-cache for upstream images"
-            base="${HARBOR_INTERNAL_URL}/v2"
+            base="${HARBOR_PUBLIC_URL}/v2"  # #4688 external host, not harbor-core.harbor.svc
             ok=0
             fail=0
             while IFS= read -r line; do
@@ -712,7 +712,7 @@ data:
               [ -z "${ref}" ] && continue
               path=${ref%:*}
               tag=${ref##*:}
-              code=$(curl -s -o /dev/null -w "%{http_code}" \
+              code=$(curl -sk -o /dev/null -w "%{http_code}" \
                 -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
                 -H "Accept: application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json" \
                 -I "${base}/${path}/manifests/${tag}")

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5036,7 +5036,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.100"
+    version: "0.1.101"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Founder directive: "fix the stupid mistake of using internal service name for harbor" — for DMZ/RTZ multi-cluster
The dragonfly flip (step 04) already uses the external host (#4682). This completes it for the remaining cutover steps that reached Harbor by the **internal k8s service name** `harbor-core.harbor.svc.cluster.local`:
- **Step 02** (`02-harbor-projects-job.yaml`): `base` `${HARBOR_INTERNAL_URL}/api/v2.0` → `${HARBOR_PUBLIC_URL}/api/v2.0`; added the `HARBOR_PUBLIC_URL` env; 4 Harbor-API curls → `-sk`.
- **Step 03** (`03-harbor-prewarm-job.yaml`): `base` `${HARBOR_INTERNAL_URL}/v2` → `${HARBOR_PUBLIC_URL}/v2`; the Harbor HEAD curl → `-sk`. (`HARBOR_PUBLIC_URL` env already present.) The skopeo GHCR download curl is untouched (keeps verification).

Under DMZ/RTZ cluster segregation an in-cluster ClusterIP does NOT route across clusters, so the external routable host `registry.<fqdn>` is the only correct target — matching the dragonfly + source-controller + step-06 targets.

## Reachability PROVEN (not assumed)
From a harbor pod on the live hw208 fresh-prov: `curl https://registry.hw208.omani.works/v2/` → **401** (Harbor responds — reachable in-cluster via the gateway hairpin), identical to the internal svc. The NAT'd-EIP gap (#4686) only blocks EXTERNAL access; steps 02/03 run in-cluster.

## `-k` rationale
Steps 02/03 run PRE-registry-pivot, before the harborCA secret exists, so the #4652 CA-mount pattern isn't available yet. These are in-cluster admin calls to the LOCAL Harbor's own cert (LE-STAGING on qaTest provs) — not MITM-exposed. `-k` tolerates the local staging wildcard.

## Validation
`helm template` clean; no remaining `${HARBOR_INTERNAL_URL}` consumption in the script bodies; chart 0.1.100→0.1.101 + blueprint/slot-06a/catalog-seed lockstepped.

**Needs a LIVE cutover gate** on a fresh prov (steps 02/03 → registry.<fqdn> → local Harbor → 201/409) before it's proven end-to-end — the cutover is fragile; this is a code-review + static-validation ship, not yet a live-walked one.

Refs #4688 #4682