### PR TITLE
fix(cloud-init): retry the /etc/hosts pin resolve — kom4dc cilium-bootstrap DNS-wedge (#4692)

### DIFF
--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -1182,7 +1182,21 @@ runcmd:
      python3 -c 'import socket,sys;print(socket.getaddrinfo(sys.argv[1],443,2)[0][4][0])' "$1" 2>/dev/null
     }
     for h in github.com raw.githubusercontent.com codeload.github.com objects.githubusercontent.com helm.cilium.io get.helm.sh%{ if provider == "huawei" } api.github.com registry.${sovereign_fqdn}%{ endif ~}; do
-     a=$(r4 "$h"); [ -n "$a" ] && echo "$a $h" >>/etc/hosts || true
+     # #4692: retry the resolve. r4() runs once per host, but on a first-boot
+     # VPC where external DNS egress (1.1.1.1 / 8.8.8.8) or the local resolver
+     # is not yet ready, that single attempt leaves the host UNPINNED and the
+     # later helm-repo-add of https://helm.cilium.io/ then fails with no
+     # /etc/hosts fallback, so CNI never installs, the node stays NotReady, and
+     # 0 HRs reconcile (the #3829 kom4dc wedge that killed hw209/hw210/hw211).
+     # Bounded 5x3s max per host; additive — worst case is the prior single-shot
+     # no-pin behaviour, never a boot hang. Once pinned, /etc/hosts serves the
+     # resolve durably regardless of later live-DNS flakiness.
+     a=""
+     for attempt in 1 2 3 4 5; do
+      a=$(r4 "$h"); [ -n "$a" ] && break
+      [ "$attempt" = 5 ] || sleep 3
+     done
+     [ -n "$a" ] && echo "$a $h" >>/etc/hosts || true
 %{ if provider == "huawei" ~}
      [ -n "$a" ] && echo "$a $h" >>/var/lib/catalyst/github-ipv4-hosts
 %{ endif ~}


### PR DESCRIPTION
## Problem (#4692 / #3829)
`r4()` in the control-plane cloud-init resolves each bootstrap host (github.com, helm.cilium.io, get.helm.sh, …) exactly once and pins it into /etc/hosts. On a first-boot kom4dc VPC where external DNS egress (1.1.1.1/8.8.8.8) or the local resolver isn't ready yet, that single shot returns empty → `helm.cilium.io` is left **UNPINNED** → the later `helm repo add cilium https://helm.cilium.io/` fails with no /etc/hosts fallback → CNI never installs → node stays NotReady → 0 HelmReleases reconcile. This is the #3829 wedge that killed 3 consecutive provs (hw209/hw210/hw211) this session.

## Fix
Wrap the per-host resolve in a **bounded 5×3s retry** (≤15s/host). Additive — worst case is the prior single-shot no-pin behaviour, never a boot hang. Once a host is pinned, /etc/hosts serves it durably regardless of later live-DNS flakiness.

## Validation
- provisioner Go tests pass (the render gate) on current main
- `bash -n` on the rendered shell OK
- `%{if}`/`%{endif}` balanced 24/24; **zero new `${}` tftpl interpolation** (no render trap)

## Delivery + remaining proof
This tftpl is baked into the catalyst-api image, so it rolls on the next catalyst-api build (merged ≠ delivered until then). The end-to-end 'a fresh prov converges past the cilium bootstrap' proof is gated on that roll + one live prov — the durable fix is here; the live gate follows the image roll.

Refs #4692 #3829