### PR TITLE
fix(catalyst): SMTP host mail.openova.io → in-cluster stalwart-web svc — kill flaky-DNS PIN-login 502 (#4696)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1232,7 +1232,7 @@ spec:
       #   stamp spec.parameters.sovereignFqdn so the openova-MCP URL points at
       #   this Sovereign, not the mothership. catalyst-api + application-controller
       #   image fixes (deploy-bot pins on next build). Lockstep w/ Chart.yaml.
-      version: 1.4.979
+      version: 1.4.980
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3408,7 +3408,9 @@ name: bp-catalyst-platform
 #   sovereign-fqdn) so GET /catalog/regions returns the Sovereign's REAL
 #   regions instead of [] — the marketplace BCP picker stops falling back to
 #   the hardcoded Hetzner list.
-version: 1.4.979
+version: 1.4.980
+# 1.4.980 — #4696: SMTP host default mail.openova.io -> stalwart-web.stalwart.svc.cluster.local
+#           (in-cluster svc, matches auth.go code default) — kill flaky-upstream-DNS PIN-delivery 502s.
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/
 #   platform/crossplane chart + blueprint.yaml + bootstrap-kit slot 04). crossplane-core
 #   was still OOMKilled (CrashLoopBackOff, 55 restarts, exit 137, killed ~90s after start)

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -89,7 +89,13 @@ sovereign:
   # `catalyst-system/sovereign-smtp-credentials` Secret seam (issue
   # #883, agent A5).
   smtp:
-    host: mail.openova.io
+    # #4696: in-cluster Stalwart Service (matches the catalyst-api
+    # CATALYST_SMTP_HOST code default in auth.go). mail.openova.io resolves via
+    # FLAKY upstream DNS ("server misbehaving") and intermittently 502s the PIN
+    # send (operator console PIN-login "could not deliver code"); the in-cluster
+    # svc resolves reliably with no external hairpin. Per-Sovereign overlays may
+    # still repoint via the sovereign-smtp-credentials Secret (source-wins).
+    host: stalwart-web.stalwart.svc.cluster.local
     port: "587"
     from: noreply@openova.io
   # ── Anthropic credential for the per-Org agentic agent (#4277) ──
@@ -1855,7 +1861,7 @@ orgSecrets:
     # these fallbacks. Until A5 ships full host/port/from coverage
     # the chart-level fallback keeps gate 2 (PIN delivery) working.
     # Issue #934 follow-up.
-    host: "mail.openova.io"
+    host: "stalwart-web.stalwart.svc.cluster.local"   # #4696: reliable in-cluster Stalwart svc (matches auth.go default); not flaky-DNS mail.openova.io
     port: "587"
     from: "noreply@openova.io"
     user: "noreply@openova.io"                # SMTP submission username (often == from)


### PR DESCRIPTION
## Problem
Operator console PIN-login intermittently returns `could not deliver code` (screenshots in #4696). catalyst-api's `/api/v1/auth/pin/issue` SMTP-sends via `mail.openova.io`, which resolves through **flaky upstream DNS**: `dial tcp: lookup mail.openova.io on 10.43.0.10:53: server misbehaving` → 502.

## Root cause + fix
catalyst-api and Stalwart are co-located in-cluster. `auth.go:212` already defaults `CATALYST_SMTP_HOST` to `stalwart-web.stalwart.svc.cluster.local`, but the bp-catalyst-platform chart **overrode** it with the external `mail.openova.io`. Aligned both chart occurrences (`sovereign.smtp.host` + the PIN-delivery fallback at values.yaml:98/1864) to the in-cluster svc — resolves reliably, no external hairpin. Chart 1.4.978 → 1.4.979.

## Live validation
From the running catalyst-api pod: `stalwart-web.stalwart.svc.cluster.local` → `10.43.241.231` (reliable in-cluster), while `mail.openova.io` returned `server misbehaving` at issue time. Fixes the mothership **and every Sovereign** (each resolves the svc to its own local Stalwart; per-Sovereign secret overlay still wins via source-wins precedence).

Refs #4696