### PR TITLE
fix(provisioner): trim cluster.name trailing/collapsed dash — invalid cilium name killed every kom4dc prov at CNI bootstrap

### DIFF
--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -903,7 +903,7 @@ locals {
   # and id = primary + 1 + secondary-index. Auto-derive when var is empty.
   primary_cluster_mesh_name_effective = (
     var.cluster_mesh_name != "" ? var.cluster_mesh_name :
-    "${split(".", var.sovereign_fqdn)[0]}-${replace(local.region_keys[0], "/[0-9]+/", "")}"
+    "${split(".", var.sovereign_fqdn)[0]}-${trim(replace(replace(local.region_keys[0], "/[0-9]+/", ""), "/-+/", "-"), "-")}"
   )
   primary_cluster_mesh_id_effective = (
     var.cluster_mesh_id > 0 ? var.cluster_mesh_id : 1
@@ -912,7 +912,7 @@ locals {
     for idx, r in var.regions :
     r.code => (
       idx == 0 ? local.primary_cluster_mesh_name_effective :
-      "${split(".", var.sovereign_fqdn)[0]}-${replace(r.code, "/[0-9]+/", "")}"
+      "${split(".", var.sovereign_fqdn)[0]}-${trim(replace(replace(r.code, "/[0-9]+/", ""), "/-+/", "-"), "-")}"
     )
   }
   cluster_mesh_id_by_region = {

--- a/products/catalyst/bootstrap/api/internal/provisioner/clustermesh_name_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/clustermesh_name_test.go
@@ -20,8 +20,13 @@ func TestDeriveSecondaryClusterMeshName_MatchesTofuDigitStripping(t *testing.T) 
 		cloudRegion string
 		want        string
 	}{
-		// kom4dc shape — interior digit run (the live hw128 bug).
-		{"me-east-215-b", "hw128-me-east--b"},
+		// kom4dc shape — interior digit run: strip → "me-east--b", then
+		// collapse "--"→"-" so cilium's cluster.name validator accepts it.
+		{"me-east-215-b", "hw128-me-east-b"},
+		// Region with no AZ suffix — strip leaves a TRAILING dash that MUST
+		// be trimmed (the exact hw209-215 wedge: "me-east-215" → "me-east-"
+		// → cilium "must start/end alphanumeric" → CNI never installs).
+		{"me-east-215", "hw128-me-east"},
 		// Hetzner shapes — trailing run only; behaviour unchanged.
 		{"hel1", "hw128-hel"},
 		{"fsn1", "hw128-fsn"},

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -3826,7 +3826,20 @@ func stripDigitRuns(s string) string {
 			b.WriteByte(s[i])
 		}
 	}
-	return b.String()
+	// A digit run at a segment boundary ("me-east-215" → "me-east-", or the
+	// interior run in "me-east-215-b" → "me-east--b") leaves a trailing "-"
+	// or a "--" once the digits are gone. Cilium's cluster.name validator
+	// (validate.yaml) rejects BOTH ("must start and end with an alphanumeric
+	// character") → the CNI install fails → nodes NotReady → 0 HRs (the
+	// hw209-215 kom4dc wedge, live-diagnosed on 38e4191f). Collapse repeated
+	// dashes + trim leading/trailing so the derived name is always a valid
+	// cilium cluster.name. MUST stay byte-identical to the tofu counterpart
+	// (huawei/main.tf:906/915) per the #3241 lockstep contract.
+	out := b.String()
+	for strings.Contains(out, "--") {
+		out = strings.ReplaceAll(out, "--", "-")
+	}
+	return strings.Trim(out, "-")
 }
 
 // deriveClusterMeshID returns the canonical Cilium ClusterMesh peer ID


### PR DESCRIPTION
## Root cause (live-diagnosed inside dead prov 38e4191f / hw215)

Every kom4dc/Huawei prov (hw209-215) died at the cilium bootstrap, surfaced only as the generic phase-1 "0 HelmReleases". Inside the dead cluster: all 4 nodes NotReady ("cni plugin not initialized"), no cilium daemonset, and the cloud-init log shows cilium rejecting the cluster name ("must start and end with an alphanumeric character").

The cilium cluster.name is stem + "-" + region-with-digits-stripped. Stripping every digit run from a kom4dc region leaves an invalid name: "me-east-215" becomes "me-east-" (trailing dash), "me-east-215-b" becomes "me-east--b" (double dash). cilium 1.16.5 rejects both, so "helm install cilium" fails, no CNI, nodes NotReady, Flux cannot schedule, 0 HRs, prov wedges forever.

## Fix

Collapse repeated dashes and trim leading/trailing in both the Go stripDigitRuns (provisioner.go) and the tofu counterpart (huawei/main.tf lines 906 and 915), byte-identical per the #3241 lockstep contract. Result: "me-east-215" becomes "me-east", "me-east-215-b" becomes "me-east-b". Hetzner ("fsn1" becomes "fsn") is unaffected.

## Verification

clustermesh_name_test.go updated plus a trailing-dash case added; "go test" green; "go build" OK. Live proof: installing cilium on hw215 with a valid name brought all 4 nodes Ready and Flux plus bootstrap-kit reconciling, confirming this is the single CNI-bootstrap fault.