### PR TITLE
fix(catalyst-api): gate "ready" on external console reachability — no more false-green (Refs #4706)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,24 @@ Test provs and tenant Organizations use the domains listed in
 The legacy `admin.<sovereign-fqdn>` subdomain for voucher operations is dead —
 voucher and billing operations live in the operator console's **BSS menu**.
 
+### 🛑 NodePorts are ABSOLUTELY FORBIDDEN — always, including for testing/debugging/proof
+
+Founder, 2026-07-03 (verbatim): *"YOU CAN NEVER EVER USE NODEPORT EVEN FOR TESTING
+PURPOSE!!! ... FUCK THE NODEPORTS!!!"*
+
+**Never create or rely on a NodePort — not in a chart, not live, not for a one-off
+test or root-cause proof.** Forbidden: `Service type=NodePort`; targeting the
+auto-allocated nodePorts of a `type=LoadBalancer` Svc; an ELB/LB pool member
+pointing at `node-IP:nodePort`; any "just to test" nodePort wiring. **If a fix
+appears to need a nodePort, it is the wrong fix — find the no-nodePort path first.**
+
+The gateway is served **DIRECT** (§854): cilium LB-IPAM VIP / shared-EIP
+(`lbipam.cilium.io/sharing-key`), OR Local-ETP + **hostPort** on the hostNetwork
+`cilium-envoy` pods (podIP == node IP → envoy listens on `node:443/:80` directly),
+with any Huawei ELB targeting `node-IP:443/:80` — never a nodePort. The #4691
+ELB→nodePort fallback is itself a §854 violation (removal tracked in #4706). See
+memory `feedback_nodeports_absolutely_forbidden.md`.
+
 ### Anti-theater discipline during PR review
 
 Per [`docs/PRINCIPLES.md`](docs/PRINCIPLES.md) §Anti-pattern-catalog, defensive-coding

--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -111,6 +111,12 @@ func main() {
 
 	h := handler.New(log)
 
+	// #4706 — turn on the external console-reachability gate: markPhase1Done
+	// will not flip a converged deployment to "ready" until its console URL
+	// actually answers, so the operator is never redirected to a TCP-dead
+	// console under a false-green "ready" pill.
+	h.EnableConsoleReachabilityGate()
+
 	// OpenBao client — wired whenever CATALYST_OPENBAO_ADDR is set.
 	//
 	// #3374: the client serves TWO consumers with different credential

--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -124,6 +124,14 @@ type Handler struct {
 	phase1MinBootstrapKitHRs int
 	phase1FirstSeenTimeout   time.Duration
 
+	// consoleProbe is the external console-reachability gate applied before
+	// markPhase1Done flips a converged deployment to "ready" (#4706). NIL =
+	// gate OFF (the pre-#4706 behaviour): production turns it on by calling
+	// EnableConsoleReachabilityGate() at startup; unit tests leave it nil so
+	// they never touch the network, and set a stub here directly when they
+	// want to assert the gate (reachable → ready, down → failed).
+	consoleProbe func(fqdn string) error
+
 	// phase1LatePollTimeout / phase1LatePollInterval — test-only
 	// overrides for the eventual-consistency late-poll window
 	// (issue #910). Zero means "fall back to env var →

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_console_gate_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_console_gate_test.go
@@ -1,0 +1,73 @@
+package handler
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// TestMarkPhase1DoneConsoleGate locks in #4706: a Phase-1 OutcomeReady is
+// promoted to Status="ready" ONLY when the external console-reachability probe
+// succeeds. A converged-but-unreachable console (the console-000 symptom that
+// killed hw217 while the mothership still claimed "ready") must be classified
+// "failed" — never a false-green "ready" that redirects the operator to a dead
+// URL. The consoleProbe seam lets us assert both arms without a network.
+func TestMarkPhase1DoneConsoleGate(t *testing.T) {
+	mkDep := func() *Deployment {
+		return &Deployment{
+			ID:     "console-gate",
+			Status: "phase1-watching",
+			Request: provisioner.Request{
+				SovereignFQDN: "hw999.omani.works",
+				Regions:       []provisioner.RegionSpec{{Provider: "huawei"}},
+			},
+			Result: &provisioner.Result{},
+		}
+	}
+	finalStates := map[string]string{"cilium": helmwatch.StateInstalled}
+
+	t.Run("console reachable -> ready", func(t *testing.T) {
+		h := NewWithPDM(silentLogger(), &fakePDM{})
+		h.consoleProbe = func(fqdn string) error { return nil }
+		dep := mkDep()
+		h.markPhase1Done(dep, finalStates, helmwatch.OutcomeReady)
+		if dep.Status != "ready" {
+			t.Fatalf("reachable console must flip ready: got Status=%q (err=%q)", dep.Status, dep.Error)
+		}
+	})
+
+	t.Run("console unreachable -> failed, not false-ready", func(t *testing.T) {
+		h := NewWithPDM(silentLogger(), &fakePDM{})
+		h.consoleProbe = func(fqdn string) error { return fmt.Errorf("connection refused") }
+		dep := mkDep()
+		h.markPhase1Done(dep, finalStates, helmwatch.OutcomeReady)
+		if dep.Status == "ready" {
+			t.Fatalf("unreachable console must NOT flip ready (false-green) — got Status=ready")
+		}
+		if dep.Status != "failed" {
+			t.Fatalf("unreachable console: got Status=%q, want failed", dep.Status)
+		}
+		if !strings.Contains(dep.Error, "externally reachable") {
+			t.Fatalf("failed error must explain the console is unreachable, got %q", dep.Error)
+		}
+	})
+
+	// The probe is skipped for non-Ready outcomes — a genuine hard failure
+	// upstream must stay failed regardless of console state.
+	t.Run("non-ready outcome is untouched by the gate", func(t *testing.T) {
+		h := NewWithPDM(silentLogger(), &fakePDM{})
+		called := false
+		h.consoleProbe = func(fqdn string) error { called = true; return nil }
+		dep := mkDep()
+		h.markPhase1Done(dep, finalStates, helmwatch.OutcomeFluxNotReconciling)
+		if called {
+			t.Fatalf("console probe must not run for a non-Ready outcome")
+		}
+		if dep.Status != "failed" {
+			t.Fatalf("OutcomeFluxNotReconciling must stay failed, got %q", dep.Status)
+		}
+	})
+}

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -29,8 +29,10 @@ package handler
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -608,8 +610,89 @@ func (h *Handler) spawnSecondaryRegionWatchers(dep *Deployment) func() {
 // "flux-not-reconciling" tells the operator to inspect the
 // bootstrap-kit Kustomization on the new cluster instead of
 // retrying provisioning.
+// consoleProbeBudget / consoleProbeInterval bound the external console-
+// reachability gate (#4706). A converged Sovereign whose gateway is not yet
+// serving (LB/ELB just being wired) may need a few seconds; a Sovereign whose
+// gateway is genuinely broken (e.g. an unwired Huawei ELB) never comes up and
+// must be classified failed rather than left probing forever. The budget is
+// deliberately short — Phase-1 convergence already took the long path, and the
+// gateway is either up within seconds of it or structurally broken.
+const (
+	consoleProbeBudget   = 90 * time.Second
+	consoleProbeInterval = 10 * time.Second
+)
+
+// defaultConsoleReachable is the production external-reachability probe for
+// #4706: it repeatedly GETs https://console.<fqdn>/ until it gets any HTTP
+// response with status < 500 (the gateway + console app are serving) or the
+// budget expires. It returns nil on reachable, a descriptive error otherwise.
+//
+// TLS verification is skipped on purpose — this proves the gateway ANSWERS
+// (TCP + TLS + HTTP), not that the cert chains to a public root (a fresh
+// Sovereign may still be on an LE-staging/in-cluster wildcard). A 4xx counts
+// as reachable (the gateway routed to a backend that replied); only a 5xx or a
+// transport error (connection refused / timeout / NXDOMAIN) counts as down —
+// which is exactly the console-000 symptom we must stop mislabelling "ready".
+func defaultConsoleReachable(fqdn string) error {
+	fqdn = strings.TrimSpace(fqdn)
+	if fqdn == "" {
+		return fmt.Errorf("empty sovereign FQDN — cannot probe console reachability")
+	}
+	target := "https://console." + fqdn + "/"
+	client := &http.Client{
+		Timeout:   8 * time.Second,
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}, // reachability, not trust
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), consoleProbeBudget)
+	defer cancel()
+	var last error
+	for {
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+		resp, err := client.Do(req)
+		if err == nil {
+			code := resp.StatusCode
+			resp.Body.Close()
+			if code < 500 {
+				return nil
+			}
+			last = fmt.Errorf("%s returned HTTP %d", target, code)
+		} else {
+			last = err
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("console %s not externally reachable within %s: %v", target, consoleProbeBudget, last)
+		case <-time.After(consoleProbeInterval):
+		}
+	}
+}
+
+// EnableConsoleReachabilityGate wires the production external console-
+// reachability probe (#4706). Once called, markPhase1Done refuses to flip a
+// converged deployment to "ready" until https://console.<fqdn>/ actually
+// answers — closing the false-green where the mothership claimed "ready" while
+// the console was TCP-dead (hw217). Call once from main; unit tests leave the
+// gate off and inject a stub via h.consoleProbe when they need to exercise it.
+func (h *Handler) EnableConsoleReachabilityGate() {
+	h.consoleProbe = defaultConsoleReachable
+}
+
 func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string, outcome string) {
 	now := time.Now().UTC()
+
+	// #4706 — external console-reachability gate. "ready" must mean the
+	// operator can actually open the console, not merely that Flux
+	// converged in-cluster. We probe BEFORE taking dep.mu so a slow or
+	// failing probe never blocks State() readers holding the same lock.
+	// dep.Request is immutable after creation, so reading SovereignFQDN
+	// lock-free is safe. The gate is OFF unless h.consoleProbe is wired:
+	// production calls EnableConsoleReachabilityGate() at startup; unit
+	// tests leave it nil (so they never touch the network) and set a stub
+	// directly when they want to exercise it.
+	var consoleReachErr error
+	if outcome == helmwatch.OutcomeReady && h.consoleProbe != nil {
+		consoleReachErr = h.consoleProbe(dep.Request.SovereignFQDN)
+	}
 
 	dep.mu.Lock()
 	if dep.Result == nil {
@@ -720,6 +803,15 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 		dep.Status = "failed"
 		dep.Error = fmt.Sprintf("Phase 1 watch timed out before convergence: %d component(s) observed, none hard-failed, but not all reached installed within the watch budget. The Sovereign's Flux keeps retrying cluster-side; re-attach the watch (retry) to re-evaluate. The deployment is NOT ready until every component is installed.", len(finalStates))
 	case outcome == helmwatch.OutcomeReady:
+		if consoleReachErr != nil {
+			// #4706 — Flux converged (every HelmRelease installed) but the
+			// operator-facing console is NOT externally reachable. A "ready"
+			// pill here redirects the operator to a dead URL — the exact
+			// false-green the readiness gate must refuse. Classify honestly.
+			dep.Status = "failed"
+			dep.Error = fmt.Sprintf("Phase 1 converged (all HelmReleases installed) but the console is NOT externally reachable: %v. The Sovereign's internals are up, but its gateway is not serving the public console URL, so the operator cannot use it — this is NOT ready. Investigate the gateway / load-balancer wiring (#4706) then retry.", consoleReachErr)
+			break
+		}
 		dep.Status = "ready"
 	default:
 		// Issue #3018 hardening: "ready" is granted ONLY by an


### PR DESCRIPTION
## Problem (Refs #4706)

`markPhase1Done` flipped a converged deployment to `Status="ready"` the instant Flux reported every HelmRelease installed — **without ever checking that the public console URL answers**. On hw217 the mothership showed a green `ready` pill while `https://console.<fqdn>/` was TCP-dead (the gateway load-balancer had zero pool members), so the console user was redirected to a 000 page under a false-green status. Internal Flux convergence is not the same as externally usable.

## Fix

- **`phase1_watch.go`** — a bounded external probe `defaultConsoleReachable(fqdn)`: `GET https://console.<fqdn>/`, 90s budget, any `<500` response counts as up (TLS verification skipped on purpose — this proves the gateway ANSWERS at TCP+TLS+HTTP, not that the cert chains to a public root, since a fresh Sovereign may still be on an in-cluster/staging wildcard). At the `OutcomeReady` case, promote to `ready` only if the probe succeeds; otherwise classify honestly as `failed` with a message pointing at the gateway / load-balancer wiring. The probe runs **before** `dep.mu` is taken so a slow/failing probe never blocks `State()` readers.
- **`handler.go` + `cmd/api/main.go`** — a `consoleProbe` seam. **Nil = gate OFF** (the pre-#4706 behaviour), so unit tests never touch the network; production turns it on via `EnableConsoleReachabilityGate()` at startup.
- **`phase1_console_gate_test.go`** — locks in both arms (reachable→ready, unreachable→failed-not-false-ready) plus that non-Ready outcomes bypass the gate, all offline via a stubbed probe.
- **`CLAUDE.md`** — records the founder's hard rule: NodePorts are absolutely forbidden, even for testing (§854).

## Tests

- New `TestMarkPhase1DoneConsoleGate` (3 subtests) — green.
- Full `internal/handler` package: my change adds zero new failures. `go build ./...` + `go vet` clean. The one red test (`TestRegistryPivotV2MirrorFallsBackToPublicHostWhenClusterIPUnresolved`) is a pre-existing cutover registry-pivot failure unrelated to these files (it was red before this branch).

## Note

This closes the false-green half of #4706 (readiness lies). The other half — making the Huawei console actually reachable without a nodePort (§854: envoy hostPort, since `node:443` does not route on a no-CCM Huawei node) — remains tracked on #4706; until it lands, Huawei provs will now honestly report `failed` instead of a lying `ready`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
