### PR TITLE
fix(bp-cilium): 1.19.3 + gatewayAPI hostNetwork — §854-clean no-nodePort gateway (Refs #4706) [DRAFT: needs fresh-prov validation]

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -402,6 +402,23 @@ spec:
           cidrs:
             - ${CILIUM_GATEWAY_LB_IPAM_CIDRS:=0.0.0.0/32}
 
+      # ── #4706 — gateway-api hostNetwork, PER-PROVIDER ──────────────────
+      # cilium 1.19.3 (bp-cilium 1.4.8) fixed the 1.16.x hostNetwork bind
+      # bug, so cilium-envoy (already a hostNetwork DaemonSet) binds
+      # node:443/:80 directly.
+      #   Huawei (no-CCM): cloud-init sets CILIUM_GATEWAY_HOSTNETWORK_
+      #     ENABLED="true" — the ONLY §854-clean front door there (the LB
+      #     VIP dies at the 1:1-NAT'd EIP, nodePorts are forbidden). The
+      #     gateway ELB (infra/providers/huawei/main.tf elb_primary)
+      #     targets node:443/:80 — durable ports known at tofu time, so
+      #     members are correct from Phase-0 apply.
+      #   Hetzner: unset → false — the hcloud-ccm-materialised
+      #     LoadBalancer Service stays the front door (hostNetwork ON would
+      #     drop the CCM LB and break it).
+      gatewayAPI:
+        hostNetwork:
+          enabled: ${CILIUM_GATEWAY_HOSTNETWORK_ENABLED:=false}
+
     # ── Catalyst overlay templates (chart/templates/) ────────────────────
     # qa-loop iter-16 Fix #70: Hubble UI HTTPRoute now defaults ON for
     # every Sovereign. The chart auto-derives hostname `hubble.${SOVEREIGN_FQDN}`

--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -120,7 +120,7 @@ spec:
       # gateway Service's auto-allocated nodePort (discovered + reconciled
       # post-convergence by catalyst-api). The sharing-key annotation is dropped
       # from the clustermesh Service; the two Services no longer share an EIP.
-      version: 1.4.7
+      version: 1.4.8
       sourceRef:
         kind: HelmRepository
         name: bp-cilium

--- a/clusters/_template/bootstrap-kit/01a-gateway-api.yaml
+++ b/clusters/_template/bootstrap-kit/01a-gateway-api.yaml
@@ -82,7 +82,7 @@ spec:
   chart:
     spec:
       chart: bp-gateway-api
-      version: 1.1.0
+      version: 1.3.0
       sourceRef:
         kind: HelmRepository
         name: bp-gateway-api

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -430,6 +430,18 @@ write_files:
 %{ endif ~}
       envoy:
         enabled: true
+        # #4706 — required for the hostNetwork gateway's privileged host bind
+        # (node:443/:80): NET_BIND_SERVICE added to the envoy caps (list
+        # REPLACES the [NET_ADMIN, SYS_ADMIN] default — keep them) AND
+        # keepCapNetBindService=true (cilium-envoy-starter drops ambient caps
+        # at exec otherwise; live-proven on hw217). Inert on Hetzner.
+        securityContext:
+          capabilities:
+            envoy:
+              - NET_ADMIN
+              - SYS_ADMIN
+              - NET_BIND_SERVICE
+            keepCapNetBindService: true
       # envoyConfig.enabled (issue #491): without it the chart skips the
       # CiliumEnvoyConfig CRD registrations and cilium-agent waits forever.
       envoyConfig:

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -416,6 +416,18 @@ write_files:
           # render time (cilium-gateway-race #503). "auto" skips creation
           # when the gateway.networking.k8s.io CRDs are not yet present.
           create: "true"
+%{ if provider == "huawei" ~}
+        # #4706 — no-CCM Huawei: gateway-api hostNetwork ON. cilium 1.19.3
+        # fixed the 1.16.x host-bind bug, so cilium-envoy (hostNetwork
+        # DaemonSet) binds node:443/:80 directly and the gateway ELB
+        # (elb_primary) targets node:443/:80 — the only §854-clean front
+        # door here (the LB VIP dies at the 1:1-NAT'd EIP; nodePorts are
+        # forbidden). Must match slot-01's CILIUM_GATEWAY_HOSTNETWORK_ENABLED
+        # substitute below so the bootstrap install and the bp-cilium HR
+        # upgrade agree (cilium_values_parity_test.go class of drift).
+        hostNetwork:
+          enabled: true
+%{ endif ~}
       envoy:
         enabled: true
       # envoyConfig.enabled (issue #491): without it the chart skips the
@@ -825,6 +837,11 @@ write_files:
             # hcloud-ccm materialises the Service LB directly.
             CILIUM_GATEWAY_LB_IPAM_ENABLED: "true"
             CILIUM_GATEWAY_LB_IPAM_CIDRS: "${node_external_ip_value}/32"
+            # #4706 — gateway-api hostNetwork ON (cilium 1.19.3): envoy binds
+            # node:443/:80 directly; the gateway ELB targets those durable
+            # ports. Keep in lockstep with the cilium-values.yaml hostNetwork
+            # block above (bootstrap install) — drift here = the #491 class.
+            CILIUM_GATEWAY_HOSTNETWORK_ENABLED: "true"
             SOVEREIGN_GATEWAY_HTTPS_PORT: "443"
             SOVEREIGN_GATEWAY_HTTP_PORT: "80"
             HARBOR_PROXY_MIRROR_ENDPOINT: "http://212.72.24.20:5000"
@@ -1287,7 +1304,7 @@ runcmd:
     rt sh -c 'curl -sSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3|bash'
     rt helm repo add cilium https://helm.cilium.io/
     rt helm repo update
-    rt helm upgrade --install cilium cilium/cilium --version 1.16.5 -n kube-system -f /var/lib/catalyst/cilium-values.yaml
+    rt helm upgrade --install cilium cilium/cilium --version 1.19.3 -n kube-system -f /var/lib/catalyst/cilium-values.yaml
     kubectl -n kube-system rollout status ds/cilium --timeout=240s || { echo no-cni >/var/lib/catalyst/cilium-bootstrap-FAILED;exit 91;}
 %{ if provider == "huawei" ~}
   # #4503 root cause (Huawei-gated note; the byte budget is Hetzner-only): on

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -417,33 +417,14 @@ write_files:
           # when the gateway.networking.k8s.io CRDs are not yet present.
           create: "true"
 %{ if provider == "huawei" ~}
-        # #4706 — no-CCM Huawei: gateway-api hostNetwork ON. cilium 1.19.3
-        # fixed the 1.16.x host-bind bug, so cilium-envoy (hostNetwork
-        # DaemonSet) binds node:443/:80 directly and the gateway ELB
-        # (elb_primary) targets node:443/:80 — the only §854-clean front
-        # door here (the LB VIP dies at the 1:1-NAT'd EIP; nodePorts are
-        # forbidden). Must match slot-01's CILIUM_GATEWAY_HOSTNETWORK_ENABLED
-        # substitute below so the bootstrap install and the bp-cilium HR
-        # upgrade agree (cilium_values_parity_test.go class of drift).
+        # #4706 no-CCM Huawei: envoy binds node:443/:80; ELB targets them.
+        # Lockstep w/ CILIUM_GATEWAY_HOSTNETWORK_ENABLED (parity test).
         hostNetwork:
           enabled: true
 %{ endif ~}
       envoy:
         enabled: true
-        # #4706 — required for the hostNetwork gateway's privileged host bind
-        # (node:443/:80): NET_BIND_SERVICE added to the envoy caps (list
-        # REPLACES the [NET_ADMIN, SYS_ADMIN] default — keep them) AND
-        # keepCapNetBindService=true (cilium-envoy-starter drops ambient caps
-        # at exec otherwise; live-proven on hw217). Inert on Hetzner.
-        securityContext:
-          capabilities:
-            envoy:
-              - NET_ADMIN
-              - SYS_ADMIN
-              - NET_BIND_SERVICE
-            keepCapNetBindService: true
-      # envoyConfig.enabled (issue #491): without it the chart skips the
-      # CiliumEnvoyConfig CRD registrations and cilium-agent waits forever.
+
       envoyConfig:
         enabled: true
       l7Proxy: true
@@ -849,10 +830,7 @@ write_files:
             # hcloud-ccm materialises the Service LB directly.
             CILIUM_GATEWAY_LB_IPAM_ENABLED: "true"
             CILIUM_GATEWAY_LB_IPAM_CIDRS: "${node_external_ip_value}/32"
-            # #4706 — gateway-api hostNetwork ON (cilium 1.19.3): envoy binds
-            # node:443/:80 directly; the gateway ELB targets those durable
-            # ports. Keep in lockstep with the cilium-values.yaml hostNetwork
-            # block above (bootstrap install) — drift here = the #491 class.
+            # #4706 — lockstep w/ the cilium-values hostNetwork block above.
             CILIUM_GATEWAY_HOSTNETWORK_ENABLED: "true"
             SOVEREIGN_GATEWAY_HTTPS_PORT: "443"
             SOVEREIGN_GATEWAY_HTTP_PORT: "80"

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -239,16 +239,14 @@ resource "huaweicloud_vpc_subnet" "region" {
 #   - TCP 6443 — k3s apiserver from 0/0 (fail-closed by k8s RBAC,
 #                not by firewall — same shape Hetzner module ships)
 #   - UDP 51820 — Cilium WireGuard inter-region (DMZ-WG)
-#   - TCP 30000-32767 — k8s NodePort range. Covers BOTH the Cilium
-#                clustermesh-apiserver NodePort (mTLS LB, cross-region)
-#                AND the Sovereign Gateway LoadBalancer Service's
-#                auto-allocated nodePort, which the RESTORED gateway ELB
-#                (elb_primary) forwards public :443/:80 → node:<nodePort>
-#                to (#4690 / #4686 foundation-fix). #4682 had narrowed this
-#                to just :32379 on the (false) premise that the gateway
-#                would serve on node:443 directly — but node:443 does NOT
-#                route on a no-CCM Huawei node (only node:<nodePort> does,
-#                verified hw208), so the full range is restored. Same shape
+#   - TCP 30000-32767 — k8s NodePort range. Retained for the Cilium
+#                clustermesh-apiserver NodePort (mTLS LB, cross-region).
+#                NOTE (#4706): the Sovereign Gateway NO LONGER uses this
+#                range — with cilium 1.19.3's gateway-api hostNetwork mode,
+#                cilium-envoy binds node:443/:80 directly and the gateway
+#                ELB (elb_primary) targets those host ports (covered by the
+#                TCP 443/80 rules above). The 1.16.5-era ELB→node:<nodePort>
+#                forwarding (#4690/#4691) is retired. Same range shape
 #                Hetzner ships (firewall opens 30000-32767, PR #1538).
 #   - TCP 22  — only when ssh_allowed_cidrs is non-empty
 #   - ICMP    — for path-MTU + ping diagnostics
@@ -1309,25 +1307,20 @@ resource "huaweicloud_obs_bucket" "main" {
 # because clustermesh peers reach the CP EIP over the WG-encrypted node path,
 # not through the NAT.)
 #
-# Correct shape (this file): a dedicated public Huawei ELB v3 with its OWN
-# routable EIP does TCP passthrough public :443 → member:<gw-nodePort-https>
-# and :80 → member:<gw-nodePort-http>. The gateway keeps the #4682
-# type=LoadBalancer shape (hostNetwork off); Cilium's kube-proxy replacement
-# programs the Service's auto-allocated nodePort on every node, and
-# ELB→node:<nodePort> is the path that actually routes on a no-CCM Huawei node
-# (node:443 does NOT — only the nodePort does; verified hw208 `nc
-# 127.0.0.1:<nodePort>` OPEN, TLS serves). This is the identical cloud-LB →
-# Service-nodePort pattern hcloud-ccm runs on Hetzner; the Service TYPE stays
-# LoadBalancer (NOT type=NodePort — §854 is honored) and there is NO :30443
-# host-port / iptables-DNAT / hostNetwork.
+# Correct shape (this file, #4706 final form): a dedicated public Huawei ELB
+# v3 with its OWN routable EIP does TCP passthrough public :443/:80 →
+# member node:443/:80. With cilium 1.19.3's gateway-api hostNetwork mode
+# (bp-cilium 1.4.8; the 1.16.x host-bind bug that forced the interim
+# ELB→node:<nodePort> shape of #4690/#4691 is fixed), cilium-envoy — a
+# hostNetwork DaemonSet — binds node:443/:80 DIRECTLY on every node. The
+# member ports are durable and known at Phase-0 apply, so the front door is
+# correct from first apply: no placeholder, no post-convergence nodePort
+# discovery, no nodePort anywhere (§854 honored literally).
 #
-# nodePort is auto-allocated by Cilium and unknown at Phase-0 apply time, so
-# the members start at the placeholder var.gateway_service_nodeport_{https,http}
-# and are reconciled to the live per-port nodePort post-convergence by
-# catalyst-api (bootstrap/api post_handover_gateway_elb.go), reading the live
-# Service via client-go and PUT/POST-ing the ELB pool members via the existing
-# AK/SK client. The wildcard *.<fqdn> A-record points at THIS ELB's EIP
-# (load_balancer_ip output + load_balancer_ipv4 cloud-init render var).
+# catalyst-api (bootstrap/api post_handover_gateway_elb.go) only heals
+# member-SET drift (node churn) at these same ports. The wildcard *.<fqdn>
+# A-record points at THIS ELB's EIP (load_balancer_ip output +
+# load_balancer_ipv4 cloud-init render var).
 #
 # The dedicated CONSOLE ELB (elb_console, #4053) below is unchanged.
 
@@ -1404,8 +1397,8 @@ resource "huaweicloud_elb_listener" "http" {
 
 # Primary-region node private IPs — consumed by BOTH the gateway ELB
 # (elb_primary) members here and the CONSOLE ELB (elb_console) members below.
-# The cilium Gateway LoadBalancer Service's nodePort is reachable on every node
-# (kube-proxy-free Cilium socket-LB), so every node is a valid member.
+# cilium-envoy (hostNetwork DaemonSet, gateway-api hostNetwork mode #4706)
+# binds node:443/:80 on every node, so every node is a valid member.
 locals {
   # CPs are `count`-based — index by tofu's list-indexed array.
   # Workers are `for_each`-based on local.worker_map (key=<region>-<index>).
@@ -1429,67 +1422,45 @@ locals {
   console_member_count = local.console_isolation_on ? length(local.primary_lb_node_ips) : 0
 }
 
-# Gateway ELB members: primary-region nodes (CPs + workers). The cilium Gateway
-# LoadBalancer Service's nodePort is served on every node (kube-proxy-free
-# Cilium socket-LB), so every node is a valid member. protocol_port is the
-# PLACEHOLDER gateway nodePort at Phase-0 apply (var default 31443/31080);
-# catalyst-api reconciles it to the live per-port nodePort post-convergence
-# (post_handover_gateway_elb.go). The listeners stay at public 443/80.
+# Gateway ELB members: primary-region nodes (CPs + workers). With cilium
+# 1.19.3's gateway-api hostNetwork mode (#4706), cilium-envoy (a hostNetwork
+# DaemonSet) binds node:443/:80 on EVERY node, so every node is a valid member
+# at the DURABLE host ports — correct from Phase-0 apply, no placeholder, no
+# post-convergence nodePort discovery, no nodePort anywhere (§854).
+# catalyst-api (post_handover_gateway_elb.go) only heals member-SET drift
+# (node churn from the autoscaler) at these same ports.
 resource "huaweicloud_elb_member" "https" {
   count         = length(local.primary_lb_node_ips)
   pool_id       = huaweicloud_elb_pool.https.id
   address       = local.primary_lb_node_ips[count.index]
-  protocol_port = var.gateway_service_nodeport_https
+  protocol_port = var.gateway_member_port_https
   subnet_id     = huaweicloud_vpc_subnet.region[local.region_keys[0]].ipv4_subnet_id
-
-  # catalyst-api (post_handover_gateway_elb.go) rewrites the member port to the
-  # live gateway-Service nodePort post-convergence via the Huawei ELB API
-  # (member DELETE+POST). Ignore protocol_port drift so a later `tofu apply`
-  # (e.g. an idempotent re-prov) does not clobber the reconciled port back to
-  # the placeholder. address/subnet_id remain tofu-owned.
-  lifecycle {
-    ignore_changes = [protocol_port]
-  }
 }
 
 resource "huaweicloud_elb_member" "http" {
   count         = length(local.primary_lb_node_ips)
   pool_id       = huaweicloud_elb_pool.http.id
   address       = local.primary_lb_node_ips[count.index]
-  protocol_port = var.gateway_service_nodeport_http
+  protocol_port = var.gateway_member_port_http
   subnet_id     = huaweicloud_vpc_subnet.region[local.region_keys[0]].ipv4_subnet_id
-
-  lifecycle {
-    ignore_changes = [protocol_port]
-  }
 }
 
 resource "huaweicloud_elb_monitor" "https" {
   pool_id     = huaweicloud_elb_pool.https.id
   protocol    = "TCP"
-  port        = var.gateway_service_nodeport_https
+  port        = var.gateway_member_port_https
   interval    = 10
   timeout     = 5
   max_retries = 3
-
-  # Same reconcile-drift guard as the members: catalyst-api repoints the
-  # health-check port to the live nodePort alongside the members.
-  lifecycle {
-    ignore_changes = [port]
-  }
 }
 
 resource "huaweicloud_elb_monitor" "http" {
   pool_id     = huaweicloud_elb_pool.http.id
   protocol    = "TCP"
-  port        = var.gateway_service_nodeport_http
+  port        = var.gateway_member_port_http
   interval    = 10
   timeout     = 5
   max_retries = 3
-
-  lifecycle {
-    ignore_changes = [port]
-  }
 }
 
 # ── #4053 — Dedicated CONSOLE ELB (poison-proof gateway isolation) ───────────

--- a/infra/providers/huawei/variables.tf
+++ b/infra/providers/huawei/variables.tf
@@ -602,44 +602,39 @@ variable "fire_cutover_on_handover" {
   }
 }
 
-# ── #4690 / #4686 foundation-fix — Sovereign Gateway ELB member nodePorts ────
+# ── #4706 — Sovereign Gateway ELB member host ports (cilium 1.19.3) ──────────
 #
-# The restored gateway ELB (huaweicloud_elb_*.primary in main.tf) forwards
-# public :443/:80 → node:<gateway-Service-nodePort>. The gateway Service is
-# `cilium-gateway-cilium-gateway` (type=LoadBalancer, kube-system, #4682); its
-# per-port nodePort is AUTO-ALLOCATED by Cilium in the 30000-32767 range and is
-# NOT known at tofu-apply time (tofu runs at Phase-0, before the cluster — and
-# thus the Service — exists). Cilium 1.16.5 exposes NO durable pin for the
-# gateway Service's nodePort (the Gateway CRD `spec.infrastructure` has no
-# nodePort field; the `gatewayAPI` chart values have no nodePort/service knob;
-# a Kustomize/SSA patch on the operator-owned Service is contended). So these
-# two vars carry only a PLACEHOLDER port for the initial apply; catalyst-api
-# DISCOVERS the real per-port nodePort post-convergence (reading the live
-# Service via client-go) and reconciles the ELB pool members to it (Huawei ELB
-# member DELETE+POST via the existing AK/SK client — see
-# products/catalyst/bootstrap/api/internal/handler/post_handover_gateway_elb.go).
-# This mirrors exactly what hcloud-ccm does on Hetzner (it reads the Service and
-# programs the LB), just done explicitly because Huawei has no CCM.
+# The gateway ELB (huaweicloud_elb_*.primary in main.tf) forwards public
+# :443/:80 → node:443/:80. With cilium 1.19.3's gateway-api hostNetwork mode
+# (bp-cilium 1.4.8, gatewayAPI.hostNetwork.enabled=true on huawei — see
+# cloudinit-control-plane.tftpl), cilium-envoy (a hostNetwork DaemonSet) binds
+# node:443/:80 DIRECTLY on every node. The member port is therefore DURABLE
+# and known at tofu-apply time — no placeholder, no post-convergence nodePort
+# discovery, no nodePort anywhere (§854).
 #
-# Placeholders are valid in-range ports distinct from the clustermesh :32379.
-# They MUST NOT be 30443/30080 (that is the FORBIDDEN legacy hostNetwork
-# host-port pair, not a real gateway nodePort).
-variable "gateway_service_nodeport_https" {
+# History: pre-1.19 (cilium 1.16.5) the gateway was a type=LoadBalancer
+# Service whose auto-allocated nodePort was unknown at Phase-0, so these vars
+# were 31443/31080 placeholders that catalyst-api repointed post-convergence
+# (#4690/#4691). 1.16.x's hostNetwork bind bug (envoy NACK'd privileged host
+# binds) is fixed in 1.19, which removes the nodePort from the path entirely.
+# catalyst-api's post_handover_gateway_elb.go now only heals member-set drift
+# (node churn), always at these same ports.
+variable "gateway_member_port_https" {
   type        = number
-  description = "Placeholder nodePort for the gateway ELB HTTPS pool member at Phase-0 apply. catalyst-api reconciles this to the gateway LoadBalancer Service's real auto-allocated :443 nodePort post-convergence (post_handover_gateway_elb.go). Not a durable pin — the Service TYPE stays LoadBalancer, never NodePort."
-  default     = 31443
+  description = "Gateway ELB HTTPS pool member port — the host port cilium-envoy binds on every node via gateway-api hostNetwork (cilium 1.19.3). Durable; matches the Gateway listener port."
+  default     = 443
   validation {
-    condition     = var.gateway_service_nodeport_https >= 30000 && var.gateway_service_nodeport_https <= 32767
-    error_message = "gateway_service_nodeport_https must be in the k8s NodePort range 30000-32767."
+    condition     = var.gateway_member_port_https >= 1 && var.gateway_member_port_https <= 32767 && !(var.gateway_member_port_https >= 30000)
+    error_message = "gateway_member_port_https must be a host port below the k8s NodePort range (30000-32767) — nodePorts are forbidden (§854)."
   }
 }
 
-variable "gateway_service_nodeport_http" {
+variable "gateway_member_port_http" {
   type        = number
-  description = "Placeholder nodePort for the gateway ELB HTTP pool member at Phase-0 apply. catalyst-api reconciles this to the gateway LoadBalancer Service's real auto-allocated :80 nodePort post-convergence (post_handover_gateway_elb.go). Not a durable pin — the Service TYPE stays LoadBalancer, never NodePort."
-  default     = 31080
+  description = "Gateway ELB HTTP pool member port — the host port cilium-envoy binds on every node via gateway-api hostNetwork (cilium 1.19.3). Durable; matches the Gateway listener port."
+  default     = 80
   validation {
-    condition     = var.gateway_service_nodeport_http >= 30000 && var.gateway_service_nodeport_http <= 32767
-    error_message = "gateway_service_nodeport_http must be in the k8s NodePort range 30000-32767."
+    condition     = var.gateway_member_port_http >= 1 && var.gateway_member_port_http <= 32767 && !(var.gateway_member_port_http >= 30000)
+    error_message = "gateway_member_port_http must be a host port below the k8s NodePort range (30000-32767) — nodePorts are forbidden (§854)."
   }
 }

--- a/platform/cilium/blueprint.yaml
+++ b/platform/cilium/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 1.4.7
+  version: 1.4.8
   card:
     title: Cilium
     summary: Unified CNI + Service Mesh (eBPF). mTLS via WireGuard, Hubble observability, Gateway API.

--- a/platform/cilium/chart/Chart.yaml
+++ b/platform/cilium/chart/Chart.yaml
@@ -1,5 +1,22 @@
 apiVersion: v2
 name: bp-cilium
+# 1.4.8 (#4706, 2026-07-03): cilium 1.16.5 → 1.19.3 + gateway-api hostNetwork
+# per-provider — the PERMANENT §854-clean no-nodePort gateway on no-CCM Huawei.
+# 1.16.5 blocked BOTH clean paths: the LB VIP dies at Huawei's 1:1-NAT'd EIP
+# (hw208) and 1.16.x's gateway-api hostNetwork bind bug NACK'd envoy's
+# privileged host bind (otech45-47) — forcing the interim ELB→node:<nodePort>
+# shape (#4690/#4691), whose port-discovery reconciler failed on hw217
+# (memberless pools → console 000). 1.19 graduated hostNetwork out of beta:
+# cilium-envoy (hostNetwork DaemonSet) binds node:443/:80 DIRECTLY, the tofu
+# ELB members target those DURABLE ports from Phase-0 apply, and catalyst-api
+# only heals member-set drift (node churn). hostNetwork default stays FALSE
+# (Hetzner front door = hcloud-ccm LB Service); huawei flips it via the new
+# CILIUM_GATEWAY_HOSTNETWORK_ENABLED substitute. Guards: parity tests lock the
+# 3-way hostNetwork agreement + the bootstrap-helm-vs-chart version pin
+# (drift = unsupported in-place multi-minor CNI upgrade mid-Phase-1).
+# Lockstep: blueprint.yaml 1.4.8 + 01-cilium.yaml slot pin 1.4.8 + catalog-seed
+# 1.4.8 + cloudinit-control-plane.tftpl (helm --version 1.19.3 + hostNetwork
+# block + substitute) + infra/providers/huawei (member/monitor ports 443/80).
 # 1.4.7 (#4690 / #4686 foundation-fix, 2026-07-02): REVERT the 1.4.6 "option-B"
 # (gateway VIP sharing the clustermesh CP-node EIP via a Cilium LB-IPAM
 # `sharing-key`). That EIP is a Huawei 1:1 NAT — externally UNREACHABLE

--- a/platform/cilium/chart/Chart.yaml
+++ b/platform/cilium/chart/Chart.yaml
@@ -188,7 +188,7 @@ name: bp-cilium
 # the netbird realm-config idiom, identical to the bp-oidc-gate openova-flow
 # fix (#3447). bp-sso-bridge PUTs client.json template-wins every tick, so the
 # mapper lands on the live hubble-ui client zero-touch.
-version: 1.4.7
+version: 1.4.8
 description: |
   Catalyst-curated Blueprint umbrella chart for Cilium. Depends on the
   upstream `cilium` chart as a Helm subchart so `helm dependency build`
@@ -226,5 +226,5 @@ dependencies:
     # constraint with the locked version eliminates the lie. Bumping to a
     # newer Cilium minor is a separate slice that needs real upgrade
     # testing on a live data-plane cluster.
-    version: "1.16.5"
+    version: "1.19.3"
     repository: "https://helm.cilium.io"

--- a/platform/cilium/chart/values.yaml
+++ b/platform/cilium/chart/values.yaml
@@ -234,8 +234,20 @@ cilium:
     # through the LoadBalancer Service, identically inside and outside the
     # cluster (which is required for the segregated DMZ/RTZ multi-cluster
     # topology, where in-cluster ClusterIPs do not route across clusters).
+    #
+    # #4706 — RE-ENABLED with the cilium 1.16.5 → 1.19.3 bump. The bind
+    # rejection above was a 1.16.x gateway-api-hostNetwork bug (cilium-envoy
+    # NACK'd "cannot bind 0.0.0.0:80"); 1.19 graduated hostNetwork out of beta
+    # and fixes it, so envoy now binds node:443/:80 directly. This is the
+    # §854-CLEAN gateway path on no-CCM Huawei: the LoadBalancer VIP can't
+    # route through Huawei's 1:1-NAT'd EIP, and nodePorts are forbidden — so a
+    # direct host bind is the only compliant option. The Huawei ELB then
+    # targets node-IP:443/:80 (a hostPort, NOT a nodePort). Companion: the
+    # gateway-elb reconciler retargets :443/:80 instead of the Service
+    # nodePort. MUST be validated on a fresh prov (incl. 2-region cross-cluster
+    # reachability) before it is trusted — see #4706.
     hostNetwork:
-      enabled: false
+      enabled: true
 
   # L7 proxy via Envoy — for HTTPRoute, gRPCRoute, L7 NetworkPolicy
   envoy:

--- a/platform/cilium/chart/values.yaml
+++ b/platform/cilium/chart/values.yaml
@@ -257,6 +257,23 @@ cilium:
   # L7 proxy via Envoy — for HTTPRoute, gRPCRoute, L7 NetworkPolicy
   envoy:
     enabled: true
+    # #4706 — REQUIRED for the gateway-api hostNetwork host bind on
+    # privileged ports (node:443/:80). Two knobs, both live-proven on hw217:
+    #   1. NET_BIND_SERVICE must be ADDED to the envoy container caps (the
+    #      list REPLACES the chart default [NET_ADMIN, SYS_ADMIN] — keep
+    #      those two or the datapath breaks);
+    #   2. keepCapNetBindService=true — cilium-envoy-starter DROPS ambient
+    #      caps at exec unless told to keep NET_BIND_SERVICE; without it the
+    #      container cap alone still yields "cannot bind '0.0.0.0:80':
+    #      Permission denied" (observed live).
+    # Inert on Hetzner (hostNetwork off → no privileged host bind attempted).
+    securityContext:
+      capabilities:
+        envoy:
+          - NET_ADMIN
+          - SYS_ADMIN
+          - NET_BIND_SERVICE
+        keepCapNetBindService: true
 
   # L2 LoadBalancer announcements (alternative to MetalLB for bare-metal)
   l2announcements:

--- a/platform/cilium/chart/values.yaml
+++ b/platform/cilium/chart/values.yaml
@@ -235,19 +235,24 @@ cilium:
     # cluster (which is required for the segregated DMZ/RTZ multi-cluster
     # topology, where in-cluster ClusterIPs do not route across clusters).
     #
-    # #4706 — RE-ENABLED with the cilium 1.16.5 → 1.19.3 bump. The bind
+    # #4706 — PER-PROVIDER with the cilium 1.16.5 → 1.19.3 bump. The bind
     # rejection above was a 1.16.x gateway-api-hostNetwork bug (cilium-envoy
-    # NACK'd "cannot bind 0.0.0.0:80"); 1.19 graduated hostNetwork out of beta
-    # and fixes it, so envoy now binds node:443/:80 directly. This is the
-    # §854-CLEAN gateway path on no-CCM Huawei: the LoadBalancer VIP can't
-    # route through Huawei's 1:1-NAT'd EIP, and nodePorts are forbidden — so a
-    # direct host bind is the only compliant option. The Huawei ELB then
-    # targets node-IP:443/:80 (a hostPort, NOT a nodePort). Companion: the
-    # gateway-elb reconciler retargets :443/:80 instead of the Service
-    # nodePort. MUST be validated on a fresh prov (incl. 2-region cross-cluster
-    # reachability) before it is trusted — see #4706.
+    # NACK'd "cannot bind 0.0.0.0:80"); 1.19 graduated hostNetwork out of
+    # beta and fixes it, so envoy CAN bind node:443/:80 directly. On the
+    # no-CCM Huawei provider this is the ONLY §854-clean gateway path: the
+    # LoadBalancer VIP can't route through Huawei's 1:1-NAT'd EIP (hw208)
+    # and nodePorts are forbidden — so the Huawei ELB targets
+    # node-IP:443/:80 (a direct host bind, NOT a nodePort). Companion: the
+    # gateway-elb member reconciler + tofu members target :443/:80.
+    #
+    # DEFAULT stays FALSE: on Hetzner the front door IS the hcloud-ccm-
+    # materialised LoadBalancer Service — flipping hostNetwork there would
+    # drop the CCM LB and break the Hetzner gateway. The bootstrap-kit
+    # slot-01 HR wires this per-provider via the
+    # CILIUM_GATEWAY_HOSTNETWORK_ENABLED substitute (huawei cloud-init sets
+    # "true"; hetzner leaves it unset → default false).
     hostNetwork:
-      enabled: true
+      enabled: false
 
   # L7 proxy via Envoy — for HTTPRoute, gRPCRoute, L7 NetworkPolicy
   envoy:

--- a/platform/gateway-api/blueprint.yaml
+++ b/platform/gateway-api/blueprint.yaml
@@ -6,11 +6,11 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 1.1.0
+  version: 1.3.0
   card:
     title: Gateway API
     summary: |
-      Upstream Kubernetes Gateway API CRDs (Experimental channel, v1.1.0) — the
+      Upstream Kubernetes Gateway API CRDs (Experimental channel, v1.3.0) — the
       gateway.networking.k8s.io/v1 family that every HTTPRoute/Gateway/
       GatewayClass-using Blueprint depends on. Cilium 1.16's `gatewayAPI.
       enabled=true` flag wires up the cilium controller but does NOT

--- a/platform/gateway-api/chart/Chart.yaml
+++ b/platform/gateway-api/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-gateway-api
-version: 1.1.0
+version: 1.3.0
 description: |
   Catalyst Blueprint installing the upstream Kubernetes Gateway API
   CustomResourceDefinitions (Standard channel — gatewayclasses, gateways,
@@ -43,13 +43,17 @@ maintainers:
 # the Blueprint version metadata + a single annotation that the templates
 # read via .Chart.Annotations).
 #
-# Version v1.1.0 (NOT v1.2.0): Gateway API v1.2.0 changed
-# status.supportedFeatures from string[] to object[]; Cilium 1.16.5
-# still writes the old string format. The v1.2.0 CRD rejects the
-# status patch with "must be of type object: string", leaving
-# GatewayClass/cilium permanently Unknown/Pending. v1.1.0 retains the
-# string schema. Bump in lock-step with Cilium when 1.17+ (which
-# writes the v1.2.0 object format) is adopted. See issue #503.
+# Version v1.3.0 (#4706, 2026-07-03) — LOCKSTEP with cilium 1.19.3
+# (bp-cilium 1.4.8). Gateway API v1.2+ changed status.supportedFeatures
+# from string[] to object[]; cilium 1.17+ writes the object format. With
+# the old v1.1.0 CRDs installed, cilium 1.19.3's GatewayClass status
+# update is REJECTED ("supportedFeatures in body must be of type string:
+# object") and every Gateway stays Programmed=False / AddressNotAssigned
+# — no gateway, console 000. LIVE-PROVEN on hw217: applying the v1.3.0
+# experimental bundle un-wedged the GatewayClass immediately.
+# (History: v1.1.0 was itself pinned for the mirror-image reason — cilium
+# 1.16.5 wrote the old string format that v1.2.0 CRDs rejected, #503.
+# These two charts MUST move together.)
 #
 # experimental-install.yaml (NOT standard-install.yaml): Cilium 1.16.x
 # checks for tlsroutes.gateway.networking.k8s.io at operator startup.
@@ -58,4 +62,4 @@ maintainers:
 # includes TLSRoute, TCPRoute, UDPRoute, BackendLBPolicy, BackendTLSPolicy.
 annotations:
   catalyst.openova.io/no-upstream: "true"
-  catalyst.openova.io/upstream-gateway-api-version: "v1.1.0"
+  catalyst.openova.io/upstream-gateway-api-version: "v1.3.0"

--- a/platform/gateway-api/chart/scripts/regenerate.sh
+++ b/platform/gateway-api/chart/scripts/regenerate.sh
@@ -36,7 +36,7 @@ if [ -z "$upstream_ver" ]; then
   exit 1
 fi
 
-url="https://github.com/kubernetes-sigs/gateway-api/releases/download/${upstream_ver}/standard-install.yaml"
+url="https://github.com/kubernetes-sigs/gateway-api/releases/download/${upstream_ver}/experimental-install.yaml"
 echo "Pulling $url"
 tmp=$(mktemp)
 curl -sLf "$url" -o "$tmp"
@@ -48,17 +48,14 @@ src_path, out_dir = sys.argv[1], sys.argv[2]
 src = open(src_path).read()
 docs = re.split(r'\n---\n', src)
 
-fname_map = {
-    'gatewayclasses':  'gatewayclasses.yaml',
-    'gateways':        'gateways.yaml',
-    'grpcroutes':      'grpcroutes.yaml',
-    'httproutes':      'httproutes.yaml',
-    'referencegrants': 'referencegrants.yaml',
-}
+# Dynamic per-CRD file naming: every CRD in the experimental bundle lands
+# as <plural>.yaml. The EXPERIMENTAL channel is REQUIRED (not standard):
+# cilium checks for tlsroutes.gateway.networking.k8s.io at operator
+# startup and disables its gateway controller when absent.
 
 header = '''{{/*
   Vendored from kubernetes-sigs/gateway-api {{ index .Chart.Annotations "catalyst.openova.io/upstream-gateway-api-version" }}
-  standard-install.yaml. Do NOT hand-edit annotations / spec — re-vendor
+  experimental-install.yaml. Do NOT hand-edit annotations / spec — re-vendor
   via the script in tests/regenerate.sh when bumping the upstream version
   (also bump catalyst.openova.io/upstream-gateway-api-version in Chart.yaml).
 
@@ -78,14 +75,12 @@ for d in docs:
         continue
     name = m.group(1)
     suffix = name.split('.', 1)[0]
-    if suffix not in fname_map:
-        sys.exit(f"unexpected CRD {name}")
     out = re.sub(
         r'^(  annotations:\n)',
         r'\1    helm.sh/resource-policy: keep\n',
         d, count=1, flags=re.MULTILINE,
     ).strip() + '\n'
-    target = f"{out_dir}/{fname_map[suffix]}"
+    target = f"{out_dir}/{suffix}.yaml"
     with open(target, 'w') as f:
         f.write(header)
         f.write(out)

--- a/platform/gateway-api/chart/templates/backendtlspolicies.yaml
+++ b/platform/gateway-api/chart/templates/backendtlspolicies.yaml
@@ -9,7 +9,6 @@
   cluster-scoped infrastructure; deleting them on uninstall would break
   every HTTPRoute on the cluster simultaneously.
 */}}
-
 #
 # config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
 #
@@ -18,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
-    gateway.networking.k8s.io/bundle-version: v1.1.0
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.3.0
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   labels:
@@ -69,6 +68,29 @@ spec:
           spec:
             description: Spec defines the desired state of BackendTLSPolicy.
             properties:
+              options:
+                additionalProperties:
+                  description: |-
+                    AnnotationValue is the value of an annotation in Gateway API. This is used
+                    for validation of maps such as TLS options. This roughly matches Kubernetes
+                    annotation validation, although the length validation in that case is based
+                    on the entire size of the annotations struct.
+                  maxLength: 4096
+                  minLength: 0
+                  type: string
+                description: |-
+                  Options are a list of key/value pairs to enable extended TLS
+                  configuration for each implementation. For example, configuring the
+                  minimum TLS version or supported cipher suites.
+
+                  A set of common keys MAY be defined by the API in the future. To avoid
+                  any ambiguity, implementation-specific definitions MUST use
+                  domain-prefixed names, such as `example.com/my-custom-option`.
+                  Un-prefixed names are reserved for key names defined by Gateway API.
+
+                  Support: Implementation-specific
+                maxProperties: 16
+                type: object
               targetRefs:
                 description: |-
                   TargetRefs identifies an API object to apply the policy to.
@@ -78,9 +100,15 @@ spec:
                   by default, but this default may change in the future to provide
                   a more granular application of the policy.
 
+                  TargetRefs must be _distinct_. This means either that:
+
+                  * They select different targets. If this is the case, then targetRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, and `name` must
+                    be unique across all targetRef entries in the BackendTLSPolicy.
+                  * They select different sectionNames in the same target.
 
                   Support: Extended for Kubernetes Service
-
 
                   Support: Implementation-specific for any other resource
                 items:
@@ -90,7 +118,6 @@ spec:
                     target single resources. For more information on how this policy attachment
                     mode works, and a sample Policy resource, refer to the policy attachment
                     documentation for Gateway API.
-
 
                     Note: This should only be used for direct policy attachment when references
                     to SectionName are actually needed. In all other cases,
@@ -118,11 +145,9 @@ spec:
                         unspecified, this targetRef targets the entire resource. In the following
                         resources, SectionName is interpreted as the following:
 
-
                         * Gateway: Listener name
                         * HTTPRoute: HTTPRouteRule name
                         * Service: Port name
-
 
                         If a SectionName is specified, but does not exist on the targeted object,
                         the Policy must fail to attach, and the policy implementation should record
@@ -139,6 +164,20 @@ spec:
                 maxItems: 16
                 minItems: 1
                 type: array
+                x-kubernetes-validations:
+                - message: sectionName must be specified when targetRefs includes
+                    2 or more references to the same target
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name ? ((!has(p1.sectionName) || p1.sectionName
+                    == '''') == (!has(p2.sectionName) || p2.sectionName == ''''))
+                    : true))'
+                - message: sectionName must be unique when targetRefs includes 2 or
+                    more references to the same target
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.sectionName) ||
+                    p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName))))
               validation:
                 description: Validation contains backend TLS validation configuration.
                 properties:
@@ -148,25 +187,20 @@ spec:
                       contain a PEM-encoded TLS CA certificate bundle, which is used to
                       validate a TLS handshake between the Gateway and backend Pod.
 
-
                       If CACertificateRefs is empty or unspecified, then WellKnownCACertificates must be
                       specified. Only one of CACertificateRefs or WellKnownCACertificates may be specified,
-                      not both. If CACertifcateRefs is empty or unspecified, the configuration for
+                      not both. If CACertificateRefs is empty or unspecified, the configuration for
                       WellKnownCACertificates MUST be honored instead if supported by the implementation.
-
 
                       References to a resource in a different namespace are invalid for the
                       moment, although we will revisit this in the future.
-
 
                       A single CACertificateRef to a Kubernetes ConfigMap kind has "Core" support.
                       Implementations MAY choose to support attaching multiple certificates to
                       a backend, but this behavior is implementation-specific.
 
-
                       Support: Core - An optional single reference to a Kubernetes ConfigMap,
                       with the CA certificate in a key named `ca.crt`.
-
 
                       Support: Implementation-specific (More than one reference, or other kinds
                       of resources).
@@ -176,7 +210,6 @@ spec:
                         referrer.
                         The API object must be valid in the cluster; the Group and Kind must
                         be registered in the cluster for this reference to be valid.
-
 
                         References to objects with invalid Group and Kind are not valid, and must
                         be rejected by the implementation, with appropriate Conditions set
@@ -213,22 +246,83 @@ spec:
                       Hostname is used for two purposes in the connection between Gateways and
                       backends:
 
-
                       1. Hostname MUST be used as the SNI to connect to the backend (RFC 6066).
-                      2. Hostname MUST be used for authentication and MUST match the certificate
-                         served by the matching backend.
-
+                      2. Hostname MUST be used for authentication and MUST match the certificate served by the matching backend, unless SubjectAltNames is specified.
+                         authentication and MUST match the certificate served by the matching
+                         backend.
 
                       Support: Core
                     maxLength: 253
                     minLength: 1
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
+                  subjectAltNames:
+                    description: |-
+                      SubjectAltNames contains one or more Subject Alternative Names.
+                      When specified the certificate served from the backend MUST
+                      have at least one Subject Alternate Name matching one of the specified SubjectAltNames.
+
+                      Support: Extended
+                    items:
+                      description: SubjectAltName represents Subject Alternative Name.
+                      properties:
+                        hostname:
+                          description: |-
+                            Hostname contains Subject Alternative Name specified in DNS name format.
+                            Required when Type is set to Hostname, ignored otherwise.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        type:
+                          description: |-
+                            Type determines the format of the Subject Alternative Name. Always required.
+
+                            Support: Core
+                          enum:
+                          - Hostname
+                          - URI
+                          type: string
+                        uri:
+                          description: |-
+                            URI contains Subject Alternative Name specified in a full URI format.
+                            It MUST include both a scheme (e.g., "http" or "ftp") and a scheme-specific-part.
+                            Common values include SPIFFE IDs like "spiffe://mycluster.example.com/ns/myns/sa/svc1sa".
+                            Required when Type is set to URI, ignored otherwise.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^(([^:/?#]+):)(//([^/?#]*))([^?#]*)(\?([^#]*))?(#(.*))?
+                          type: string
+                      required:
+                      - type
+                      type: object
+                      x-kubernetes-validations:
+                      - message: SubjectAltName element must contain Hostname, if
+                          Type is set to Hostname
+                        rule: '!(self.type == "Hostname" && (!has(self.hostname) ||
+                          self.hostname == ""))'
+                      - message: SubjectAltName element must not contain Hostname,
+                          if Type is not set to Hostname
+                        rule: '!(self.type != "Hostname" && has(self.hostname) &&
+                          self.hostname != "")'
+                      - message: SubjectAltName element must contain URI, if Type
+                          is set to URI
+                        rule: '!(self.type == "URI" && (!has(self.uri) || self.uri
+                          == ""))'
+                      - message: SubjectAltName element must not contain URI, if Type
+                          is not set to URI
+                        rule: '!(self.type != "URI" && has(self.uri) && self.uri !=
+                          "")'
+                    maxItems: 5
+                    type: array
                   wellKnownCACertificates:
                     description: |-
                       WellKnownCACertificates specifies whether system CA certificates may be used in
                       the TLS handshake between the gateway and backend pod.
-
 
                       If WellKnownCACertificates is unspecified or empty (""), then CACertificateRefs
                       must be specified with at least one entry for a valid configuration. Only one of
@@ -236,7 +330,6 @@ spec:
                       implementation does not support the WellKnownCACertificates field or the value
                       supplied is not supported, the Status Conditions on the Policy MUST be
                       updated to include an Accepted: False Condition with Reason: Invalid.
-
 
                       Support: Implementation-specific
                     enum:
@@ -270,26 +363,21 @@ spec:
                   the controller first sees the policy and SHOULD update the entry as
                   appropriate when the relevant ancestor is modified.
 
-
                   Note that choosing the relevant ancestor is left to the Policy designers;
                   an important part of Policy design is designing the right object level at
                   which to namespace this status.
-
 
                   Note also that implementations MUST ONLY populate ancestor status for
                   the Ancestor resources they are responsible for. Implementations MUST
                   use the ControllerName field to uniquely identify the entries in this list
                   that they are responsible for.
 
-
                   Note that to achieve this, the list of PolicyAncestorStatus structs
                   MUST be treated as a map with a composite key, made up of the AncestorRef
                   and ControllerName fields combined.
 
-
                   A maximum of 16 ancestors will be represented in this list. An empty list
                   means the Policy is not relevant for any ancestors.
-
 
                   If this slice is full, implementations MUST NOT add further entries.
                   Instead they MUST consider the policy unimplementable and signal that
@@ -302,7 +390,6 @@ spec:
                     PolicyAncestorStatus describes the status of a route with respect to an
                     associated Ancestor.
 
-
                     Ancestors refer to objects that are either the Target of a policy or above it
                     in terms of object hierarchy. For example, if a policy targets a Service, the
                     Policy's Ancestors are, in order, the Service, the HTTPRoute, the Gateway, and
@@ -311,27 +398,22 @@ spec:
                     SHOULD use Gateway as the PolicyAncestorStatus object unless the designers
                     have a _very_ good reason otherwise.
 
-
                     In the context of policy attachment, the Ancestor is used to distinguish which
                     resource results in a distinct application of this policy. For example, if a policy
                     targets a Service, it may have a distinct result per attached Gateway.
-
 
                     Policies targeting the same resource may have different effects depending on the
                     ancestors of those resources. For example, different Gateways targeting the same
                     Service may have different capabilities, especially if they have different underlying
                     implementations.
 
-
                     For example, in BackendTLSPolicy, the Policy attaches to a Service that is
                     used as a backend in a HTTPRoute that is itself attached to a Gateway.
                     In this case, the relevant object for status is the Gateway, and that is the
                     ancestor object referred to in this status.
 
-
                     Note that a parent is also an ancestor, so for objects where the parent is the
                     relevant object for status, this struct SHOULD still be used.
-
 
                     This struct is intended to be used in a slice that's effectively a map,
                     with a composite key made up of the AncestorRef and the ControllerName.
@@ -349,7 +431,6 @@ spec:
                             To set the core API group (such as for a "Service" kind referent),
                             Group must be explicitly set to "" (empty string).
 
-
                             Support: Core
                           maxLength: 253
                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -359,13 +440,10 @@ spec:
                           description: |-
                             Kind is kind of the referent.
 
-
                             There are two kinds of parent resources with "Core" support:
-
 
                             * Gateway (Gateway conformance profile)
                             * Service (Mesh conformance profile, ClusterIP Services only)
-
 
                             Support for other resources is Implementation-Specific.
                           maxLength: 63
@@ -376,7 +454,6 @@ spec:
                           description: |-
                             Name is the name of the referent.
 
-
                             Support: Core
                           maxLength: 253
                           minLength: 1
@@ -386,7 +463,6 @@ spec:
                             Namespace is the namespace of the referent. When unspecified, this refers
                             to the local namespace of the Route.
 
-
                             Note that there are specific rules for ParentRefs which cross namespace
                             boundaries. Cross-namespace references are only valid if they are explicitly
                             allowed by something in the namespace they are referring to. For example:
@@ -394,18 +470,15 @@ spec:
                             generic way to enable any other kind of cross-namespace reference.
 
 
-
                             ParentRefs from a Route to a Service in the same namespace are "producer"
                             routes, which apply default routing rules to inbound connections from
                             any namespace to the Service.
-
 
                             ParentRefs from a Route to a Service in a different namespace are
                             "consumer" routes, and these routing rules are only applied to outbound
                             connections originating from the same namespace as the Route, for which
                             the intended destination of the connections are a Service targeted as a
                             ParentRef of the Route.
-
 
 
                             Support: Core
@@ -418,7 +491,6 @@ spec:
                             Port is the network port this Route targets. It can be interpreted
                             differently based on the type of parent resource.
 
-
                             When the parent resource is a Gateway, this targets all listeners
                             listening on the specified port that also support this kind of Route(and
                             select this Route). It's not recommended to set `Port` unless the
@@ -428,17 +500,14 @@ spec:
                             must match both specified values.
 
 
-
                             When the parent resource is a Service, this targets a specific port in the
                             Service spec. When both Port (experimental) and SectionName are specified,
                             the name and port of the selected port must match both specified values.
 
 
-
                             Implementations MAY choose to support other parent resources.
                             Implementations supporting other types of parent resources MUST clearly
                             document how/if Port is interpreted.
-
 
                             For the purpose of status, an attachment is considered successful as
                             long as the parent resource accepts it partially. For example, Gateway
@@ -447,7 +516,6 @@ spec:
                             from the referencing Route, the Route MUST be considered successfully
                             attached. If no Gateway listeners accept attachment from this Route,
                             the Route MUST be considered detached from the Gateway.
-
 
                             Support: Extended
                           format: int32
@@ -459,7 +527,6 @@ spec:
                             SectionName is the name of a section within the target resource. In the
                             following resources, SectionName is interpreted as the following:
 
-
                             * Gateway: Listener name. When both Port (experimental) and SectionName
                             are specified, the name and port of the selected listener must match
                             both specified values.
@@ -467,11 +534,9 @@ spec:
                             are specified, the name and port of the selected listener must match
                             both specified values.
 
-
                             Implementations MAY choose to support attaching Routes to other resources.
                             If that is the case, they MUST clearly document how SectionName is
                             interpreted.
-
 
                             When unspecified (empty string), this will reference the entire resource.
                             For the purpose of status, an attachment is considered successful if at
@@ -481,7 +546,6 @@ spec:
                             the referencing Route, the Route MUST be considered successfully
                             attached. If no Gateway listeners accept attachment from this Route, the
                             Route MUST be considered detached from the Gateway.
-
 
                             Support: Core
                           maxLength: 253
@@ -495,18 +559,8 @@ spec:
                       description: Conditions describes the status of the Policy with
                         respect to the given Ancestor.
                       items:
-                        description: "Condition contains details for one aspect of
-                          the current state of this API Resource.\n---\nThis struct
-                          is intended for direct use as an array at the field path
-                          .status.conditions.  For example,\n\n\n\ttype FooStatus
-                          struct{\n\t    // Represents the observations of a foo's
-                          current state.\n\t    // Known .status.conditions.type are:
-                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
-                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
-                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
-                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                          \   // other fields\n\t}"
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
                         properties:
                           lastTransitionTime:
                             description: |-
@@ -548,12 +602,7 @@ spec:
                             - Unknown
                             type: string
                           type:
-                            description: |-
-                              type of condition in CamelCase or in foo.example.com/CamelCase.
-                              ---
-                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                              useful (see .node.status.conditions), the ability to deconflict is important.
-                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
                             maxLength: 316
                             pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                             type: string
@@ -576,14 +625,11 @@ spec:
                         controller that wrote this status. This corresponds with the
                         controllerName field on GatewayClass.
 
-
                         Example: "example.net/gateway-controller".
-
 
                         The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
                         valid Kubernetes names
                         (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
-
 
                         Controllers MUST populate this field when writing status. Controllers should ensure that
                         entries to status populated with their ControllerName are cleaned up when they are no

--- a/platform/gateway-api/chart/templates/gatewayclasses.yaml
+++ b/platform/gateway-api/chart/templates/gatewayclasses.yaml
@@ -9,7 +9,6 @@
   cluster-scoped infrastructure; deleting them on uninstall would break
   every HTTPRoute on the cluster simultaneously.
 */}}
-
 #
 # config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
 #
@@ -18,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
-    gateway.networking.k8s.io/bundle-version: v1.1.0
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.3.0
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: gatewayclasses.gateway.networking.k8s.io
@@ -57,7 +56,6 @@ spec:
           GatewayClass describes a class of Gateways available to the user for creating
           Gateway resources.
 
-
           It is recommended that this resource be used as a template for Gateways. This
           means that a Gateway is based on the state of the GatewayClass at the time it
           was created and changes to the GatewayClass or associated parameters are not
@@ -66,12 +64,10 @@ spec:
           If implementations choose to propagate GatewayClass changes to existing
           Gateways, that MUST be clearly documented by the implementation.
 
-
           Whenever one or more Gateways are using a GatewayClass, implementations SHOULD
           add the `gateway-exists-finalizer.gateway.networking.k8s.io` finalizer on the
           associated GatewayClass. This ensures that a GatewayClass associated with a
           Gateway is not deleted while in use.
-
 
           GatewayClass is a Cluster level resource.
         properties:
@@ -100,12 +96,9 @@ spec:
                   ControllerName is the name of the controller that is managing Gateways of
                   this class. The value of this field MUST be a domain prefixed path.
 
-
                   Example: "example.net/gateway-controller".
 
-
                   This field is not mutable and cannot be empty.
-
 
                   Support: Core
                 maxLength: 253
@@ -125,20 +118,18 @@ spec:
                   parameters corresponding to the GatewayClass. This is optional if the
                   controller does not require any additional configuration.
 
-
                   ParametersRef can reference a standard Kubernetes resource, i.e. ConfigMap,
                   or an implementation-specific custom resource. The resource can be
                   cluster-scoped or namespace-scoped.
 
-
-                  If the referent cannot be found, the GatewayClass's "InvalidParameters"
-                  status condition will be true.
-
+                  If the referent cannot be found, refers to an unsupported kind, or when
+                  the data within that resource is malformed, the GatewayClass SHOULD be
+                  rejected with the "Accepted" status condition set to "False" and an
+                  "InvalidParameters" reason.
 
                   A Gateway for this GatewayClass may provide its own `parametersRef`. When both are specified,
                   the merging behavior is implementation specific.
                   It is generally recommended that GatewayClass provides defaults that can be overridden by a Gateway.
-
 
                   Support: Implementation-specific
                 properties:
@@ -180,12 +171,11 @@ spec:
               conditions:
               - lastTransitionTime: "1970-01-01T00:00:00Z"
                 message: Waiting for controller
-                reason: Waiting
+                reason: Pending
                 status: Unknown
                 type: Accepted
             description: |-
               Status defines the current state of GatewayClass.
-
 
               Implementations MUST populate status on all GatewayClass resources which
               specify their controller name.
@@ -201,20 +191,11 @@ spec:
                   Conditions is the current status from the controller for
                   this GatewayClass.
 
-
                   Controllers should prefer to publish conditions using values
                   of GatewayClassConditionType for the type of each Condition.
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -255,12 +236,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -277,17 +253,24 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               supportedFeatures:
-                description: |
+                description: |-
                   SupportedFeatures is the set of features the GatewayClass support.
-                  It MUST be sorted in ascending alphabetical order.
+                  It MUST be sorted in ascending alphabetical order by the Name key.
                 items:
-                  description: |-
-                    SupportedFeature is used to describe distinct features that are covered by
-                    conformance tests.
-                  type: string
+                  properties:
+                    name:
+                      description: |-
+                        FeatureName is used to describe distinct features that are covered by
+                        conformance tests.
+                      type: string
+                  required:
+                  - name
+                  type: object
                 maxItems: 64
                 type: array
-                x-kubernetes-list-type: set
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
             type: object
         required:
         - spec
@@ -317,7 +300,6 @@ spec:
           GatewayClass describes a class of Gateways available to the user for creating
           Gateway resources.
 
-
           It is recommended that this resource be used as a template for Gateways. This
           means that a Gateway is based on the state of the GatewayClass at the time it
           was created and changes to the GatewayClass or associated parameters are not
@@ -326,12 +308,10 @@ spec:
           If implementations choose to propagate GatewayClass changes to existing
           Gateways, that MUST be clearly documented by the implementation.
 
-
           Whenever one or more Gateways are using a GatewayClass, implementations SHOULD
           add the `gateway-exists-finalizer.gateway.networking.k8s.io` finalizer on the
           associated GatewayClass. This ensures that a GatewayClass associated with a
           Gateway is not deleted while in use.
-
 
           GatewayClass is a Cluster level resource.
         properties:
@@ -360,12 +340,9 @@ spec:
                   ControllerName is the name of the controller that is managing Gateways of
                   this class. The value of this field MUST be a domain prefixed path.
 
-
                   Example: "example.net/gateway-controller".
 
-
                   This field is not mutable and cannot be empty.
-
 
                   Support: Core
                 maxLength: 253
@@ -385,20 +362,18 @@ spec:
                   parameters corresponding to the GatewayClass. This is optional if the
                   controller does not require any additional configuration.
 
-
                   ParametersRef can reference a standard Kubernetes resource, i.e. ConfigMap,
                   or an implementation-specific custom resource. The resource can be
                   cluster-scoped or namespace-scoped.
 
-
-                  If the referent cannot be found, the GatewayClass's "InvalidParameters"
-                  status condition will be true.
-
+                  If the referent cannot be found, refers to an unsupported kind, or when
+                  the data within that resource is malformed, the GatewayClass SHOULD be
+                  rejected with the "Accepted" status condition set to "False" and an
+                  "InvalidParameters" reason.
 
                   A Gateway for this GatewayClass may provide its own `parametersRef`. When both are specified,
                   the merging behavior is implementation specific.
                   It is generally recommended that GatewayClass provides defaults that can be overridden by a Gateway.
-
 
                   Support: Implementation-specific
                 properties:
@@ -440,12 +415,11 @@ spec:
               conditions:
               - lastTransitionTime: "1970-01-01T00:00:00Z"
                 message: Waiting for controller
-                reason: Waiting
+                reason: Pending
                 status: Unknown
                 type: Accepted
             description: |-
               Status defines the current state of GatewayClass.
-
 
               Implementations MUST populate status on all GatewayClass resources which
               specify their controller name.
@@ -461,20 +435,11 @@ spec:
                   Conditions is the current status from the controller for
                   this GatewayClass.
 
-
                   Controllers should prefer to publish conditions using values
                   of GatewayClassConditionType for the type of each Condition.
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -515,12 +480,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -537,17 +497,24 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               supportedFeatures:
-                description: |
+                description: |-
                   SupportedFeatures is the set of features the GatewayClass support.
-                  It MUST be sorted in ascending alphabetical order.
+                  It MUST be sorted in ascending alphabetical order by the Name key.
                 items:
-                  description: |-
-                    SupportedFeature is used to describe distinct features that are covered by
-                    conformance tests.
-                  type: string
+                  properties:
+                    name:
+                      description: |-
+                        FeatureName is used to describe distinct features that are covered by
+                        conformance tests.
+                      type: string
+                  required:
+                  - name
+                  type: object
                 maxItems: 64
                 type: array
-                x-kubernetes-list-type: set
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
             type: object
         required:
         - spec

--- a/platform/gateway-api/chart/templates/gateways.yaml
+++ b/platform/gateway-api/chart/templates/gateways.yaml
@@ -9,7 +9,6 @@
   cluster-scoped infrastructure; deleting them on uninstall would break
   every HTTPRoute on the cluster simultaneously.
 */}}
-
 #
 # config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
 #
@@ -18,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
-    gateway.networking.k8s.io/bundle-version: v1.1.0
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.3.0
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: gateways.gateway.networking.k8s.io
@@ -77,12 +76,11 @@ spec:
             description: Spec defines the desired state of Gateway.
             properties:
               addresses:
-                description: |+
+                description: |-
                   Addresses requested for this Gateway. This is optional and behavior can
                   depend on the implementation. If a value is set in the spec and the
                   requested address is invalid or unavailable, the implementation MUST
                   indicate this in the associated entry in GatewayStatus.Addresses.
-
 
                   The Addresses field represents a request for the address(es) on the
                   "outside of the Gateway", that traffic bound for this Gateway will use.
@@ -90,23 +88,18 @@ spec:
                   other networking infrastructure, or some other address that traffic will
                   be sent to.
 
-
                   If no Addresses are specified, the implementation MAY schedule the
                   Gateway in an implementation-specific manner, assigning an appropriate
                   set of Addresses.
-
 
                   The implementation MUST bind all Listeners to every GatewayAddress that
                   it assigns to the Gateway and add a corresponding entry in
                   GatewayStatus.Addresses.
 
-
                   Support: Extended
-
-
                 items:
-                  description: GatewayAddress describes an address that can be bound
-                    to a Gateway.
+                  description: GatewaySpecAddress describes an address that can be
+                    bound to a Gateway.
                   oneOf:
                   - properties:
                       type:
@@ -131,16 +124,15 @@ spec:
                       type: string
                     value:
                       description: |-
-                        Value of the address. The validity of the values will depend
-                        on the type and support by the controller.
+                        When a value is unspecified, an implementation SHOULD automatically
+                        assign an address matching the requested type if possible.
 
+                        If an implementation does not support an empty value, they MUST set the
+                        "Programmed" condition in status to False with a reason of "AddressNotAssigned".
 
                         Examples: `1.2.3.4`, `128::1`, `my-ip-address`.
                       maxLength: 253
-                      minLength: 1
                       type: string
-                  required:
-                  - value
                   type: object
                   x-kubernetes-validations:
                   - message: Hostname value must only contain valid characters (matching
@@ -156,6 +148,151 @@ spec:
                 - message: Hostname values must be unique
                   rule: 'self.all(a1, a1.type == ''Hostname'' ? self.exists_one(a2,
                     a2.type == a1.type && a2.value == a1.value) : true )'
+              allowedListeners:
+                description: |-
+                  AllowedListeners defines which ListenerSets can be attached to this Gateway.
+                  While this feature is experimental, the default value is to allow no ListenerSets.
+                properties:
+                  namespaces:
+                    default:
+                      from: None
+                    description: |-
+                      Namespaces defines which namespaces ListenerSets can be attached to this Gateway.
+                      While this feature is experimental, the default value is to allow no ListenerSets.
+                    properties:
+                      from:
+                        default: None
+                        description: |-
+                          From indicates where ListenerSets can attach to this Gateway. Possible
+                          values are:
+
+                          * Same: Only ListenerSets in the same namespace may be attached to this Gateway.
+                          * Selector: ListenerSets in namespaces selected by the selector may be attached to this Gateway.
+                          * All: ListenerSets in all namespaces may be attached to this Gateway.
+                          * None: Only listeners defined in the Gateway's spec are allowed
+
+                          While this feature is experimental, the default value None
+                        enum:
+                        - All
+                        - Selector
+                        - Same
+                        - None
+                        type: string
+                      selector:
+                        description: |-
+                          Selector must be specified when From is set to "Selector". In that case,
+                          only ListenerSets in Namespaces matching this Selector will be selected by this
+                          Gateway. This field is ignored for other values of "From".
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                type: object
+              backendTLS:
+                description: |-
+                  BackendTLS configures TLS settings for when this Gateway is connecting to
+                  backends with TLS.
+
+                  Support: Core
+                properties:
+                  clientCertificateRef:
+                    description: |-
+                      ClientCertificateRef is a reference to an object that contains a Client
+                      Certificate and the associated private key.
+
+                      References to a resource in different namespace are invalid UNLESS there
+                      is a ReferenceGrant in the target namespace that allows the certificate
+                      to be attached. If a ReferenceGrant does not allow this reference, the
+                      "ResolvedRefs" condition MUST be set to False for this listener with the
+                      "RefNotPermitted" reason.
+
+                      ClientCertificateRef can reference to standard Kubernetes resources, i.e.
+                      Secret, or implementation-specific custom resources.
+
+                      This setting can be overridden on the service level by use of BackendTLSPolicy.
+
+                      Support: Core
+                    properties:
+                      group:
+                        default: ""
+                        description: |-
+                          Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                          When unspecified or empty string, core API group is inferred.
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        default: Secret
+                        description: Kind is kind of the referent. For example "Secret".
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: Name is the name of the referent.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace of the referenced object. When unspecified, the local
+                          namespace is inferred.
+
+                          Note that when a namespace different than the local namespace is specified,
+                          a ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+                          Support: Core
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                        type: string
+                    required:
+                    - name
+                    type: object
+                type: object
               gatewayClassName:
                 description: |-
                   GatewayClassName used for this Gateway. This is the name of a
@@ -164,13 +301,10 @@ spec:
                 minLength: 1
                 type: string
               infrastructure:
-                description: |+
+                description: |-
                   Infrastructure defines infrastructure level attributes about this Gateway instance.
 
-
-                  Support: Core
-
-
+                  Support: Extended
                 properties:
                   annotations:
                     additionalProperties:
@@ -185,55 +319,78 @@ spec:
                     description: |-
                       Annotations that SHOULD be applied to any resources created in response to this Gateway.
 
-
                       For implementations creating other Kubernetes objects, this should be the `metadata.annotations` field on resources.
                       For other implementations, this refers to any relevant (implementation specific) "annotations" concepts.
 
-
                       An implementation may chose to add additional implementation-specific annotations as they see fit.
-
 
                       Support: Extended
                     maxProperties: 8
                     type: object
+                    x-kubernetes-validations:
+                    - message: Annotation keys must be in the form of an optional
+                        DNS subdomain prefix followed by a required name segment of
+                        up to 63 characters.
+                      rule: self.all(key, key.matches(r"""^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]$"""))
+                    - message: If specified, the annotation key's prefix must be a
+                        DNS subdomain not longer than 253 characters in total.
+                      rule: self.all(key, key.split("/")[0].size() < 253)
                   labels:
                     additionalProperties:
                       description: |-
-                        AnnotationValue is the value of an annotation in Gateway API. This is used
-                        for validation of maps such as TLS options. This roughly matches Kubernetes
-                        annotation validation, although the length validation in that case is based
-                        on the entire size of the annotations struct.
-                      maxLength: 4096
+                        LabelValue is the value of a label in the Gateway API. This is used for validation
+                        of maps such as Gateway infrastructure labels. This matches the Kubernetes
+                        label validation rules:
+                        * must be 63 characters or less (can be empty),
+                        * unless empty, must begin and end with an alphanumeric character ([a-z0-9A-Z]),
+                        * could contain dashes (-), underscores (_), dots (.), and alphanumerics between.
+
+                        Valid values include:
+
+                        * MyValue
+                        * my.name
+                        * 123-my-value
+                      maxLength: 63
                       minLength: 0
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
                       type: string
                     description: |-
                       Labels that SHOULD be applied to any resources created in response to this Gateway.
 
-
                       For implementations creating other Kubernetes objects, this should be the `metadata.labels` field on resources.
                       For other implementations, this refers to any relevant (implementation specific) "labels" concepts.
 
-
                       An implementation may chose to add additional implementation-specific labels as they see fit.
 
+                      If an implementation maps these labels to Pods, or any other resource that would need to be recreated when labels
+                      change, it SHOULD clearly warn about this behavior in documentation.
 
                       Support: Extended
                     maxProperties: 8
                     type: object
+                    x-kubernetes-validations:
+                    - message: Label keys must be in the form of an optional DNS subdomain
+                        prefix followed by a required name segment of up to 63 characters.
+                      rule: self.all(key, key.matches(r"""^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]$"""))
+                    - message: If specified, the label key's prefix must be a DNS
+                        subdomain not longer than 253 characters in total.
+                      rule: self.all(key, key.split("/")[0].size() < 253)
                   parametersRef:
                     description: |-
                       ParametersRef is a reference to a resource that contains the configuration
                       parameters corresponding to the Gateway. This is optional if the
                       controller does not require any additional configuration.
 
-
                       This follows the same semantics as GatewayClass's `parametersRef`, but on a per-Gateway basis
-
 
                       The Gateway's GatewayClass may provide its own `parametersRef`. When both are specified,
                       the merging behavior is implementation specific.
                       It is generally recommended that GatewayClass provides defaults that can be overridden by a Gateway.
 
+                      If the referent cannot be found, refers to an unsupported kind, or when
+                      the data within that resource is malformed, the Gateway SHOULD be
+                      rejected with the "Accepted" status condition set to "False" and an
+                      "InvalidParameters" reason.
 
                       Support: Implementation-specific
                     properties:
@@ -265,6 +422,7 @@ spec:
                   logical endpoints that are bound on this Gateway's addresses.
                   At least one Listener MUST be specified.
 
+                  ## Distinct Listeners
 
                   Each Listener in a set of Listeners (for example, in a single Gateway)
                   MUST be _distinct_, in that a traffic flow MUST be able to be assigned to
@@ -273,97 +431,107 @@ spec:
                   from multiple Gateways onto a single data plane, and these rules _also_
                   apply in that case).
 
-
                   Practically, this means that each listener in a set MUST have a unique
                   combination of Port, Protocol, and, if supported by the protocol, Hostname.
 
-
                   Some combinations of port, protocol, and TLS settings are considered
-                  Core support and MUST be supported by implementations based on their
-                  targeted conformance profile:
+                  Core support and MUST be supported by implementations based on the objects
+                  they support:
 
-
-                  HTTP Profile
-
+                  HTTPRoute
 
                   1. HTTPRoute, Port: 80, Protocol: HTTP
                   2. HTTPRoute, Port: 443, Protocol: HTTPS, TLS Mode: Terminate, TLS keypair provided
 
-
-                  TLS Profile
-
+                  TLSRoute
 
                   1. TLSRoute, Port: 443, Protocol: TLS, TLS Mode: Passthrough
 
-
                   "Distinct" Listeners have the following property:
 
+                  **The implementation can match inbound requests to a single distinct
+                  Listener**.
 
-                  The implementation can match inbound requests to a single distinct
-                  Listener. When multiple Listeners share values for fields (for
+                  When multiple Listeners share values for fields (for
                   example, two Listeners with the same Port value), the implementation
                   can match requests to only one of the Listeners using other
                   Listener fields.
 
+                  When multiple listeners have the same value for the Protocol field, then
+                  each of the Listeners with matching Protocol values MUST have different
+                  values for other fields.
 
-                  For example, the following Listener scenarios are distinct:
+                  The set of fields that MUST be different for a Listener differs per protocol.
+                  The following rules define the rules for what fields MUST be considered for
+                  Listeners to be distinct with each protocol currently defined in the
+                  Gateway API spec.
 
+                  The set of listeners that all share a protocol value MUST have _different_
+                  values for _at least one_ of these fields to be distinct:
 
-                  1. Multiple Listeners with the same Port that all use the "HTTP"
-                     Protocol that all have unique Hostname values.
-                  2. Multiple Listeners with the same Port that use either the "HTTPS" or
-                     "TLS" Protocol that all have unique Hostname values.
-                  3. A mixture of "TCP" and "UDP" Protocol Listeners, where no Listener
-                     with the same Protocol has the same Port value.
+                  * **HTTP, HTTPS, TLS**: Port, Hostname
+                  * **TCP, UDP**: Port
 
+                  One **very** important rule to call out involves what happens when an
+                  implementation:
 
-                  Some fields in the Listener struct have possible values that affect
-                  whether the Listener is distinct. Hostname is particularly relevant
-                  for HTTP or HTTPS protocols.
+                  * Supports TCP protocol Listeners, as well as HTTP, HTTPS, or TLS protocol
+                    Listeners, and
+                  * sees HTTP, HTTPS, or TLS protocols with the same `port` as one with TCP
+                    Protocol.
 
+                  In this case all the Listeners that share a port with the
+                  TCP Listener are not distinct and so MUST NOT be accepted.
 
-                  When using the Hostname value to select between same-Port, same-Protocol
-                  Listeners, the Hostname value must be different on each Listener for the
-                  Listener to be distinct.
+                  If an implementation does not support TCP Protocol Listeners, then the
+                  previous rule does not apply, and the TCP Listeners SHOULD NOT be
+                  accepted.
 
+                  Note that the `tls` field is not used for determining if a listener is distinct, because
+                  Listeners that _only_ differ on TLS config will still conflict in all cases.
 
-                  When the Listeners are distinct based on Hostname, inbound request
+                  ### Listeners that are distinct only by Hostname
+
+                  When the Listeners are distinct based only on Hostname, inbound request
                   hostnames MUST match from the most specific to least specific Hostname
                   values to choose the correct Listener and its associated set of Routes.
 
-
-                  Exact matches must be processed before wildcard matches, and wildcard
-                  matches must be processed before fallback (empty Hostname value)
+                  Exact matches MUST be processed before wildcard matches, and wildcard
+                  matches MUST be processed before fallback (empty Hostname value)
                   matches. For example, `"foo.example.com"` takes precedence over
                   `"*.example.com"`, and `"*.example.com"` takes precedence over `""`.
-
 
                   Additionally, if there are multiple wildcard entries, more specific
                   wildcard entries must be processed before less specific wildcard entries.
                   For example, `"*.foo.example.com"` takes precedence over `"*.example.com"`.
+
                   The precise definition here is that the higher the number of dots in the
                   hostname to the right of the wildcard character, the higher the precedence.
-
 
                   The wildcard character will match any number of characters _and dots_ to
                   the left, however, so `"*.example.com"` will match both
                   `"foo.bar.example.com"` _and_ `"bar.example.com"`.
 
+                  ## Handling indistinct Listeners
 
                   If a set of Listeners contains Listeners that are not distinct, then those
-                  Listeners are Conflicted, and the implementation MUST set the "Conflicted"
+                  Listeners are _Conflicted_, and the implementation MUST set the "Conflicted"
                   condition in the Listener Status to "True".
 
+                  The words "indistinct" and "conflicted" are considered equivalent for the
+                  purpose of this documentation.
 
                   Implementations MAY choose to accept a Gateway with some Conflicted
                   Listeners only if they only accept the partial Listener set that contains
-                  no Conflicted Listeners. To put this another way, implementations may
-                  accept a partial Listener set only if they throw out *all* the conflicting
-                  Listeners. No picking one of the conflicting listeners as the winner.
-                  This also means that the Gateway must have at least one non-conflicting
-                  Listener in this case, otherwise it violates the requirement that at
-                  least one Listener must be present.
+                  no Conflicted Listeners.
 
+                  Specifically, an implementation MAY accept a partial Listener set subject to
+                  the following rules:
+
+                  * The implementation MUST NOT pick one conflicting Listener as the winner.
+                    ALL indistinct Listeners must not be accepted for processing.
+                  * At least one distinct Listener MUST be present, or else the Gateway effectively
+                    contains _no_ Listeners, and must be rejected from processing as a whole.
 
                   The implementation MUST set a "ListenersNotValid" condition on the
                   Gateway Status when the Gateway contains Conflicted Listeners whether or
@@ -372,37 +540,43 @@ spec:
                   Accepted. Additionally, the Listener status for those listeners SHOULD
                   indicate which Listeners are conflicted and not Accepted.
 
+                  ## General Listener behavior
 
-                  A Gateway's Listeners are considered "compatible" if:
+                  Note that, for all distinct Listeners, requests SHOULD match at most one Listener.
+                  For example, if Listeners are defined for "foo.example.com" and "*.example.com", a
+                  request to "foo.example.com" SHOULD only be routed using routes attached
+                  to the "foo.example.com" Listener (and not the "*.example.com" Listener).
 
+                  This concept is known as "Listener Isolation", and it is an Extended feature
+                  of Gateway API. Implementations that do not support Listener Isolation MUST
+                  clearly document this, and MUST NOT claim support for the
+                  `GatewayHTTPListenerIsolation` feature.
+
+                  Implementations that _do_ support Listener Isolation SHOULD claim support
+                  for the Extended `GatewayHTTPListenerIsolation` feature and pass the associated
+                  conformance tests.
+
+                  ## Compatible Listeners
+
+                  A Gateway's Listeners are considered _compatible_ if:
 
                   1. They are distinct.
                   2. The implementation can serve them in compliance with the Addresses
                      requirement that all Listeners are available on all assigned
                      addresses.
 
-
                   Compatible combinations in Extended support are expected to vary across
                   implementations. A combination that is compatible for one implementation
                   may not be compatible for another.
-
 
                   For example, an implementation that cannot serve both TCP and UDP listeners
                   on the same address, or cannot mix HTTPS and generic TLS listens on the same port
                   would not consider those cases compatible, even though they are distinct.
 
-
-                  Note that requests SHOULD match at most one Listener. For example, if
-                  Listeners are defined for "foo.example.com" and "*.example.com", a
-                  request to "foo.example.com" SHOULD only be routed using routes attached
-                  to the "foo.example.com" Listener (and not the "*.example.com" Listener).
-                  This concept is known as "Listener Isolation". Implementations that do
-                  not support Listener Isolation MUST clearly document this.
-
-
                   Implementations MAY merge separate Gateways onto a single set of
                   Addresses if all Listeners across all Gateways are compatible.
 
+                  In a future release the MinItems=1 requirement MAY be dropped.
 
                   Support: Core
                 items:
@@ -419,11 +593,9 @@ spec:
                         Listener and the trusted namespaces where those Route resources MAY be
                         present.
 
-
                         Although a client request may match multiple route rules, only one rule
                         may ultimately receive the request. Matching precedence MUST be
                         determined in order of the following criteria:
-
 
                         * The most specific match as defined by the Route type.
                         * The oldest Route based on creation timestamp. For example, a Route with
@@ -433,14 +605,12 @@ spec:
                           alphabetical order (namespace/name) should be given precedence. For
                           example, foo/bar is given precedence over foo/baz.
 
-
                         All valid rules within a Route attached to this Listener should be
                         implemented. Invalid Route rules can be ignored (sometimes that will mean
                         the full Route). If a Route rule transitions from valid to invalid,
                         support for that Route rule should be dropped to ensure consistency. For
                         example, even if a filter specified by a Route rule is invalid, the rest
                         of the rules within that Route should still be supported.
-
 
                         Support: Core
                       properties:
@@ -450,13 +620,11 @@ spec:
                             to this Gateway Listener. When unspecified or empty, the kinds of Routes
                             selected are determined using the Listener protocol.
 
-
                             A RouteGroupKind MUST correspond to kinds of Routes that are compatible
                             with the application protocol specified in the Listener's Protocol field.
                             If an implementation does not support or recognize this resource type, it
                             MUST set the "ResolvedRefs" condition to False for this Listener with the
                             "InvalidRouteKinds" reason.
-
 
                             Support: Core
                           items:
@@ -487,7 +655,6 @@ spec:
                             Namespaces indicates namespaces from which Routes may be attached to this
                             Listener. This is restricted to the namespace of this Gateway by default.
 
-
                             Support: Core
                           properties:
                             from:
@@ -496,12 +663,10 @@ spec:
                                 From indicates where Routes will be selected for this Gateway. Possible
                                 values are:
 
-
                                 * All: Routes in all namespaces may be used by this Gateway.
                                 * Selector: Routes in namespaces selected by the selector may be used by
                                   this Gateway.
                                 * Same: Only Routes in the same namespace may be used by this Gateway.
-
 
                                 Support: Core
                               enum:
@@ -514,7 +679,6 @@ spec:
                                 Selector must be specified when From is set to "Selector". In that case,
                                 only Routes in Namespaces matching this Selector will be selected by this
                                 Gateway. This field is ignored for other values of "From".
-
 
                                 Support: Core
                               properties:
@@ -570,18 +734,36 @@ spec:
                         field is ignored for protocols that don't require hostname based
                         matching.
 
-
                         Implementations MUST apply Hostname matching appropriately for each of
                         the following protocols:
 
-
                         * TLS: The Listener Hostname MUST match the SNI.
                         * HTTP: The Listener Hostname MUST match the Host header of the request.
-                        * HTTPS: The Listener Hostname SHOULD match at both the TLS and HTTP
-                          protocol layers as described above. If an implementation does not
-                          ensure that both the SNI and Host header match the Listener hostname,
-                          it MUST clearly document that.
+                        * HTTPS: The Listener Hostname SHOULD match both the SNI and Host header.
+                          Note that this does not require the SNI and Host header to be the same.
+                          The semantics of this are described in more detail below.
 
+                        To ensure security, Section 11.1 of RFC-6066 emphasizes that server
+                        implementations that rely on SNI hostname matching MUST also verify
+                        hostnames within the application protocol.
+
+                        Section 9.1.2 of RFC-7540 provides a mechanism for servers to reject the
+                        reuse of a connection by responding with the HTTP 421 Misdirected Request
+                        status code. This indicates that the origin server has rejected the
+                        request because it appears to have been misdirected.
+
+                        To detect misdirected requests, Gateways SHOULD match the authority of
+                        the requests with all the SNI hostname(s) configured across all the
+                        Gateway Listeners on the same port and protocol:
+
+                        * If another Listener has an exact match or more specific wildcard entry,
+                          the Gateway SHOULD return a 421.
+                        * If the current Listener (selected by SNI matching during ClientHello)
+                          does not match the Host:
+                            * If another Listener does match the Host the Gateway SHOULD return a
+                              421.
+                            * If no other Listener matches the Host, the Gateway MUST return a
+                              404.
 
                         For HTTPRoute and TLSRoute resources, there is an interaction with the
                         `spec.hostnames` array. When both listener and route specify hostnames,
@@ -589,11 +771,9 @@ spec:
                         accepted. For more information, refer to the Route specific Hostnames
                         documentation.
 
-
                         Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
                         as a suffix match. That means that a match for `*.example.com` would match
                         both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
-
 
                         Support: Core
                       maxLength: 253
@@ -605,7 +785,6 @@ spec:
                         Name is the name of the Listener. This name MUST be unique within a
                         Gateway.
 
-
                         Support: Core
                       maxLength: 253
                       minLength: 1
@@ -616,7 +795,6 @@ spec:
                         Port is the network port. Multiple listeners may use the
                         same port, subject to the Listener compatibility rules.
 
-
                         Support: Core
                       format: int32
                       maximum: 65535
@@ -626,11 +804,10 @@ spec:
                       description: |-
                         Protocol specifies the network protocol this listener expects to receive.
 
-
                         Support: Core
                       maxLength: 255
                       minLength: 1
-                      pattern: ^[a-zA-Z0-9]([-a-zSA-Z0-9]*[a-zA-Z0-9])?$|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9]+$
+                      pattern: ^[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?$|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9]+$
                       type: string
                     tls:
                       description: |-
@@ -638,14 +815,11 @@ spec:
                         the Protocol field is "HTTPS" or "TLS". It is invalid to set this field
                         if the Protocol field is "HTTP", "TCP", or "UDP".
 
-
                         The association of SNIs to Certificate defined in GatewayTLSConfig is
                         defined based on the Hostname field for this listener.
 
-
                         The GatewayClass MUST use the longest matching SNI out of all
                         available certificates for any TLS handshake.
-
 
                         Support: Core
                       properties:
@@ -656,11 +830,9 @@ spec:
                             establish a TLS handshake for requests that match the hostname of the
                             associated listener.
 
-
                             A single CertificateRef to a Kubernetes Secret has "Core" support.
                             Implementations MAY choose to support attaching multiple certificates to
                             a Listener, but this behavior is implementation-specific.
-
 
                             References to a resource in different namespace are invalid UNLESS there
                             is a ReferenceGrant in the target namespace that allows the certificate
@@ -668,17 +840,13 @@ spec:
                             "ResolvedRefs" condition MUST be set to False for this listener with the
                             "RefNotPermitted" reason.
 
-
                             This field is required to have at least one element when the mode is set
                             to "Terminate" (default) and is optional otherwise.
-
 
                             CertificateRefs can reference to standard Kubernetes resources, i.e.
                             Secret, or implementation-specific custom resources.
 
-
                             Support: Core - A single reference to a Kubernetes Secret of type kubernetes.io/tls
-
 
                             Support: Implementation-specific (More than one reference or other resource types)
                           items:
@@ -686,10 +854,8 @@ spec:
                               SecretObjectReference identifies an API object including its namespace,
                               defaulting to Secret.
 
-
                               The API object must be valid in the cluster; the Group and Kind must
                               be registered in the cluster for this reference to be valid.
-
 
                               References to objects with invalid Group and Kind are not valid, and must
                               be rejected by the implementation, with appropriate Conditions set
@@ -721,12 +887,10 @@ spec:
                                   Namespace is the namespace of the referenced object. When unspecified, the local
                                   namespace is inferred.
 
-
                                   Note that when a namespace different than the local namespace is specified,
                                   a ReferenceGrant object is required in the referent namespace to allow that
                                   namespace's owner to accept the reference. See the ReferenceGrant
                                   documentation for details.
-
 
                                   Support: Core
                                 maxLength: 63
@@ -739,17 +903,14 @@ spec:
                           maxItems: 64
                           type: array
                         frontendValidation:
-                          description: |+
+                          description: |-
                             FrontendValidation holds configuration information for validating the frontend (client).
                             Setting this field will require clients to send a client certificate
                             required for validation during the TLS handshake. In browsers this may result in a dialog appearing
                             that requests a user to specify the client certificate.
                             The maximum depth of a certificate chain accepted in verification is Implementation specific.
 
-
                             Support: Extended
-
-
                           properties:
                             caCertificateRefs:
                               description: |-
@@ -758,20 +919,16 @@ spec:
                                 the Certificate Authorities that can be used
                                 as a trust anchor to validate the certificates presented by the client.
 
-
                                 A single CA certificate reference to a Kubernetes ConfigMap
                                 has "Core" support.
                                 Implementations MAY choose to support attaching multiple CA certificates to
                                 a Listener, but this behavior is implementation-specific.
 
-
                                 Support: Core - A single reference to a Kubernetes ConfigMap
                                 with the CA certificate in a key named `ca.crt`.
 
-
                                 Support: Implementation-specific (More than one reference, or other kinds
                                 of resources).
-
 
                                 References to a resource in a different namespace are invalid UNLESS there
                                 is a ReferenceGrant in the target namespace that allows the certificate
@@ -782,10 +939,8 @@ spec:
                                 description: |-
                                   ObjectReference identifies an API object including its namespace.
 
-
                                   The API object must be valid in the cluster; the Group and Kind must
                                   be registered in the cluster for this reference to be valid.
-
 
                                   References to objects with invalid Group and Kind are not valid, and must
                                   be rejected by the implementation, with appropriate Conditions set
@@ -794,7 +949,7 @@ spec:
                                   group:
                                     description: |-
                                       Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                      When unspecified or empty string, core API group is inferred.
+                                      When set to the empty string, core API group is inferred.
                                     maxLength: 253
                                     pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                     type: string
@@ -815,12 +970,10 @@ spec:
                                       Namespace is the namespace of the referenced object. When unspecified, the local
                                       namespace is inferred.
 
-
                                       Note that when a namespace different than the local namespace is specified,
                                       a ReferenceGrant object is required in the referent namespace to allow that
                                       namespace's owner to accept the reference. See the ReferenceGrant
                                       documentation for details.
-
 
                                       Support: Core
                                     maxLength: 63
@@ -842,7 +995,6 @@ spec:
                             Mode defines the TLS behavior for the TLS session initiated by the client.
                             There are two possible modes:
 
-
                             - Terminate: The TLS session between the downstream client and the
                               Gateway is terminated at the Gateway. This mode requires certificates
                               to be specified in some way, such as populating the certificateRefs
@@ -851,7 +1003,6 @@ spec:
                               implies that the Gateway can't decipher the TLS stream except for
                               the ClientHello message of the TLS protocol. The certificateRefs field
                               is ignored in this mode.
-
 
                             Support: Core
                           enum:
@@ -873,12 +1024,10 @@ spec:
                             configuration for each implementation. For example, configuring the
                             minimum TLS version or supported cipher suites.
 
-
                             A set of common keys MAY be defined by the API in the future. To avoid
                             any ambiguity, implementation-specific definitions MUST use
                             domain-prefixed names, such as `example.com/my-custom-option`.
                             Un-prefixed names are reserved for key names defined by Gateway API.
-
 
                             Support: Implementation-specific
                           maxProperties: 16
@@ -938,20 +1087,16 @@ spec:
             description: Status defines the current state of Gateway.
             properties:
               addresses:
-                description: |+
+                description: |-
                   Addresses lists the network addresses that have been bound to the
                   Gateway.
-
 
                   This list may differ from the addresses provided in the spec under some
                   conditions:
 
-
                     * no addresses are specified, all addresses are dynamically assigned
                     * a combination of specified and dynamic addresses are assigned
                     * a specified address was unusable (e.g. already in use)
-
-
                 items:
                   description: GatewayStatusAddress describes a network address that
                     is bound to a Gateway.
@@ -982,7 +1127,6 @@ spec:
                         Value of the address. The validity of the values will depend
                         on the type and support by the controller.
 
-
                         Examples: `1.2.3.4`, `128::1`, `my-ip-address`.
                       maxLength: 253
                       minLength: 1
@@ -1012,30 +1156,19 @@ spec:
                 description: |-
                   Conditions describe the current conditions of the Gateway.
 
-
                   Implementations should prefer to express Gateway conditions
                   using the `GatewayConditionType` and `GatewayConditionReason`
                   constants so that operators and tools can converge on a common
                   vocabulary to describe Gateway state.
 
-
                   Known condition types are:
-
 
                   * "Accepted"
                   * "Programmed"
                   * "Ready"
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -1076,12 +1209,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -1108,7 +1236,6 @@ spec:
                         AttachedRoutes represents the total number of Routes that have been
                         successfully attached to this Listener.
 
-
                         Successful attachment of a Route to a Listener is based solely on the
                         combination of the AllowedRoutes field on the corresponding Listener
                         and the Route's ParentRefs field. A Route is successfully attached to
@@ -1121,7 +1248,6 @@ spec:
                         for Listeners with condition Accepted: false and MUST count successfully
                         attached Routes that may themselves have Accepted: false conditions.
 
-
                         Uses for this field include troubleshooting Route attachment and
                         measuring blast radius/impact of changes to a Listener.
                       format: int32
@@ -1130,18 +1256,8 @@ spec:
                       description: Conditions describe the current condition of this
                         listener.
                       items:
-                        description: "Condition contains details for one aspect of
-                          the current state of this API Resource.\n---\nThis struct
-                          is intended for direct use as an array at the field path
-                          .status.conditions.  For example,\n\n\n\ttype FooStatus
-                          struct{\n\t    // Represents the observations of a foo's
-                          current state.\n\t    // Known .status.conditions.type are:
-                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
-                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
-                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
-                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                          \   // other fields\n\t}"
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
                         properties:
                           lastTransitionTime:
                             description: |-
@@ -1183,12 +1299,7 @@ spec:
                             - Unknown
                             type: string
                           type:
-                            description: |-
-                              type of condition in CamelCase or in foo.example.com/CamelCase.
-                              ---
-                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                              useful (see .node.status.conditions), the ability to deconflict is important.
-                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
                             maxLength: 316
                             pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                             type: string
@@ -1216,7 +1327,6 @@ spec:
                         SupportedKinds is the list indicating the Kinds supported by this
                         listener. This MUST represent the kinds an implementation supports for
                         that Listener configuration.
-
 
                         If kinds are specified in Spec that are not supported, they MUST NOT
                         appear in this list and an implementation MUST set the "ResolvedRefs"
@@ -1304,12 +1414,11 @@ spec:
             description: Spec defines the desired state of Gateway.
             properties:
               addresses:
-                description: |+
+                description: |-
                   Addresses requested for this Gateway. This is optional and behavior can
                   depend on the implementation. If a value is set in the spec and the
                   requested address is invalid or unavailable, the implementation MUST
                   indicate this in the associated entry in GatewayStatus.Addresses.
-
 
                   The Addresses field represents a request for the address(es) on the
                   "outside of the Gateway", that traffic bound for this Gateway will use.
@@ -1317,23 +1426,18 @@ spec:
                   other networking infrastructure, or some other address that traffic will
                   be sent to.
 
-
                   If no Addresses are specified, the implementation MAY schedule the
                   Gateway in an implementation-specific manner, assigning an appropriate
                   set of Addresses.
-
 
                   The implementation MUST bind all Listeners to every GatewayAddress that
                   it assigns to the Gateway and add a corresponding entry in
                   GatewayStatus.Addresses.
 
-
                   Support: Extended
-
-
                 items:
-                  description: GatewayAddress describes an address that can be bound
-                    to a Gateway.
+                  description: GatewaySpecAddress describes an address that can be
+                    bound to a Gateway.
                   oneOf:
                   - properties:
                       type:
@@ -1358,16 +1462,15 @@ spec:
                       type: string
                     value:
                       description: |-
-                        Value of the address. The validity of the values will depend
-                        on the type and support by the controller.
+                        When a value is unspecified, an implementation SHOULD automatically
+                        assign an address matching the requested type if possible.
 
+                        If an implementation does not support an empty value, they MUST set the
+                        "Programmed" condition in status to False with a reason of "AddressNotAssigned".
 
                         Examples: `1.2.3.4`, `128::1`, `my-ip-address`.
                       maxLength: 253
-                      minLength: 1
                       type: string
-                  required:
-                  - value
                   type: object
                   x-kubernetes-validations:
                   - message: Hostname value must only contain valid characters (matching
@@ -1383,6 +1486,151 @@ spec:
                 - message: Hostname values must be unique
                   rule: 'self.all(a1, a1.type == ''Hostname'' ? self.exists_one(a2,
                     a2.type == a1.type && a2.value == a1.value) : true )'
+              allowedListeners:
+                description: |-
+                  AllowedListeners defines which ListenerSets can be attached to this Gateway.
+                  While this feature is experimental, the default value is to allow no ListenerSets.
+                properties:
+                  namespaces:
+                    default:
+                      from: None
+                    description: |-
+                      Namespaces defines which namespaces ListenerSets can be attached to this Gateway.
+                      While this feature is experimental, the default value is to allow no ListenerSets.
+                    properties:
+                      from:
+                        default: None
+                        description: |-
+                          From indicates where ListenerSets can attach to this Gateway. Possible
+                          values are:
+
+                          * Same: Only ListenerSets in the same namespace may be attached to this Gateway.
+                          * Selector: ListenerSets in namespaces selected by the selector may be attached to this Gateway.
+                          * All: ListenerSets in all namespaces may be attached to this Gateway.
+                          * None: Only listeners defined in the Gateway's spec are allowed
+
+                          While this feature is experimental, the default value None
+                        enum:
+                        - All
+                        - Selector
+                        - Same
+                        - None
+                        type: string
+                      selector:
+                        description: |-
+                          Selector must be specified when From is set to "Selector". In that case,
+                          only ListenerSets in Namespaces matching this Selector will be selected by this
+                          Gateway. This field is ignored for other values of "From".
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                type: object
+              backendTLS:
+                description: |-
+                  BackendTLS configures TLS settings for when this Gateway is connecting to
+                  backends with TLS.
+
+                  Support: Core
+                properties:
+                  clientCertificateRef:
+                    description: |-
+                      ClientCertificateRef is a reference to an object that contains a Client
+                      Certificate and the associated private key.
+
+                      References to a resource in different namespace are invalid UNLESS there
+                      is a ReferenceGrant in the target namespace that allows the certificate
+                      to be attached. If a ReferenceGrant does not allow this reference, the
+                      "ResolvedRefs" condition MUST be set to False for this listener with the
+                      "RefNotPermitted" reason.
+
+                      ClientCertificateRef can reference to standard Kubernetes resources, i.e.
+                      Secret, or implementation-specific custom resources.
+
+                      This setting can be overridden on the service level by use of BackendTLSPolicy.
+
+                      Support: Core
+                    properties:
+                      group:
+                        default: ""
+                        description: |-
+                          Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                          When unspecified or empty string, core API group is inferred.
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        default: Secret
+                        description: Kind is kind of the referent. For example "Secret".
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: Name is the name of the referent.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace of the referenced object. When unspecified, the local
+                          namespace is inferred.
+
+                          Note that when a namespace different than the local namespace is specified,
+                          a ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+                          Support: Core
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                        type: string
+                    required:
+                    - name
+                    type: object
+                type: object
               gatewayClassName:
                 description: |-
                   GatewayClassName used for this Gateway. This is the name of a
@@ -1391,13 +1639,10 @@ spec:
                 minLength: 1
                 type: string
               infrastructure:
-                description: |+
+                description: |-
                   Infrastructure defines infrastructure level attributes about this Gateway instance.
 
-
-                  Support: Core
-
-
+                  Support: Extended
                 properties:
                   annotations:
                     additionalProperties:
@@ -1412,55 +1657,78 @@ spec:
                     description: |-
                       Annotations that SHOULD be applied to any resources created in response to this Gateway.
 
-
                       For implementations creating other Kubernetes objects, this should be the `metadata.annotations` field on resources.
                       For other implementations, this refers to any relevant (implementation specific) "annotations" concepts.
 
-
                       An implementation may chose to add additional implementation-specific annotations as they see fit.
-
 
                       Support: Extended
                     maxProperties: 8
                     type: object
+                    x-kubernetes-validations:
+                    - message: Annotation keys must be in the form of an optional
+                        DNS subdomain prefix followed by a required name segment of
+                        up to 63 characters.
+                      rule: self.all(key, key.matches(r"""^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]$"""))
+                    - message: If specified, the annotation key's prefix must be a
+                        DNS subdomain not longer than 253 characters in total.
+                      rule: self.all(key, key.split("/")[0].size() < 253)
                   labels:
                     additionalProperties:
                       description: |-
-                        AnnotationValue is the value of an annotation in Gateway API. This is used
-                        for validation of maps such as TLS options. This roughly matches Kubernetes
-                        annotation validation, although the length validation in that case is based
-                        on the entire size of the annotations struct.
-                      maxLength: 4096
+                        LabelValue is the value of a label in the Gateway API. This is used for validation
+                        of maps such as Gateway infrastructure labels. This matches the Kubernetes
+                        label validation rules:
+                        * must be 63 characters or less (can be empty),
+                        * unless empty, must begin and end with an alphanumeric character ([a-z0-9A-Z]),
+                        * could contain dashes (-), underscores (_), dots (.), and alphanumerics between.
+
+                        Valid values include:
+
+                        * MyValue
+                        * my.name
+                        * 123-my-value
+                      maxLength: 63
                       minLength: 0
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
                       type: string
                     description: |-
                       Labels that SHOULD be applied to any resources created in response to this Gateway.
 
-
                       For implementations creating other Kubernetes objects, this should be the `metadata.labels` field on resources.
                       For other implementations, this refers to any relevant (implementation specific) "labels" concepts.
 
-
                       An implementation may chose to add additional implementation-specific labels as they see fit.
 
+                      If an implementation maps these labels to Pods, or any other resource that would need to be recreated when labels
+                      change, it SHOULD clearly warn about this behavior in documentation.
 
                       Support: Extended
                     maxProperties: 8
                     type: object
+                    x-kubernetes-validations:
+                    - message: Label keys must be in the form of an optional DNS subdomain
+                        prefix followed by a required name segment of up to 63 characters.
+                      rule: self.all(key, key.matches(r"""^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]$"""))
+                    - message: If specified, the label key's prefix must be a DNS
+                        subdomain not longer than 253 characters in total.
+                      rule: self.all(key, key.split("/")[0].size() < 253)
                   parametersRef:
                     description: |-
                       ParametersRef is a reference to a resource that contains the configuration
                       parameters corresponding to the Gateway. This is optional if the
                       controller does not require any additional configuration.
 
-
                       This follows the same semantics as GatewayClass's `parametersRef`, but on a per-Gateway basis
-
 
                       The Gateway's GatewayClass may provide its own `parametersRef`. When both are specified,
                       the merging behavior is implementation specific.
                       It is generally recommended that GatewayClass provides defaults that can be overridden by a Gateway.
 
+                      If the referent cannot be found, refers to an unsupported kind, or when
+                      the data within that resource is malformed, the Gateway SHOULD be
+                      rejected with the "Accepted" status condition set to "False" and an
+                      "InvalidParameters" reason.
 
                       Support: Implementation-specific
                     properties:
@@ -1492,6 +1760,7 @@ spec:
                   logical endpoints that are bound on this Gateway's addresses.
                   At least one Listener MUST be specified.
 
+                  ## Distinct Listeners
 
                   Each Listener in a set of Listeners (for example, in a single Gateway)
                   MUST be _distinct_, in that a traffic flow MUST be able to be assigned to
@@ -1500,97 +1769,107 @@ spec:
                   from multiple Gateways onto a single data plane, and these rules _also_
                   apply in that case).
 
-
                   Practically, this means that each listener in a set MUST have a unique
                   combination of Port, Protocol, and, if supported by the protocol, Hostname.
 
-
                   Some combinations of port, protocol, and TLS settings are considered
-                  Core support and MUST be supported by implementations based on their
-                  targeted conformance profile:
+                  Core support and MUST be supported by implementations based on the objects
+                  they support:
 
-
-                  HTTP Profile
-
+                  HTTPRoute
 
                   1. HTTPRoute, Port: 80, Protocol: HTTP
                   2. HTTPRoute, Port: 443, Protocol: HTTPS, TLS Mode: Terminate, TLS keypair provided
 
-
-                  TLS Profile
-
+                  TLSRoute
 
                   1. TLSRoute, Port: 443, Protocol: TLS, TLS Mode: Passthrough
 
-
                   "Distinct" Listeners have the following property:
 
+                  **The implementation can match inbound requests to a single distinct
+                  Listener**.
 
-                  The implementation can match inbound requests to a single distinct
-                  Listener. When multiple Listeners share values for fields (for
+                  When multiple Listeners share values for fields (for
                   example, two Listeners with the same Port value), the implementation
                   can match requests to only one of the Listeners using other
                   Listener fields.
 
+                  When multiple listeners have the same value for the Protocol field, then
+                  each of the Listeners with matching Protocol values MUST have different
+                  values for other fields.
 
-                  For example, the following Listener scenarios are distinct:
+                  The set of fields that MUST be different for a Listener differs per protocol.
+                  The following rules define the rules for what fields MUST be considered for
+                  Listeners to be distinct with each protocol currently defined in the
+                  Gateway API spec.
 
+                  The set of listeners that all share a protocol value MUST have _different_
+                  values for _at least one_ of these fields to be distinct:
 
-                  1. Multiple Listeners with the same Port that all use the "HTTP"
-                     Protocol that all have unique Hostname values.
-                  2. Multiple Listeners with the same Port that use either the "HTTPS" or
-                     "TLS" Protocol that all have unique Hostname values.
-                  3. A mixture of "TCP" and "UDP" Protocol Listeners, where no Listener
-                     with the same Protocol has the same Port value.
+                  * **HTTP, HTTPS, TLS**: Port, Hostname
+                  * **TCP, UDP**: Port
 
+                  One **very** important rule to call out involves what happens when an
+                  implementation:
 
-                  Some fields in the Listener struct have possible values that affect
-                  whether the Listener is distinct. Hostname is particularly relevant
-                  for HTTP or HTTPS protocols.
+                  * Supports TCP protocol Listeners, as well as HTTP, HTTPS, or TLS protocol
+                    Listeners, and
+                  * sees HTTP, HTTPS, or TLS protocols with the same `port` as one with TCP
+                    Protocol.
 
+                  In this case all the Listeners that share a port with the
+                  TCP Listener are not distinct and so MUST NOT be accepted.
 
-                  When using the Hostname value to select between same-Port, same-Protocol
-                  Listeners, the Hostname value must be different on each Listener for the
-                  Listener to be distinct.
+                  If an implementation does not support TCP Protocol Listeners, then the
+                  previous rule does not apply, and the TCP Listeners SHOULD NOT be
+                  accepted.
 
+                  Note that the `tls` field is not used for determining if a listener is distinct, because
+                  Listeners that _only_ differ on TLS config will still conflict in all cases.
 
-                  When the Listeners are distinct based on Hostname, inbound request
+                  ### Listeners that are distinct only by Hostname
+
+                  When the Listeners are distinct based only on Hostname, inbound request
                   hostnames MUST match from the most specific to least specific Hostname
                   values to choose the correct Listener and its associated set of Routes.
 
-
-                  Exact matches must be processed before wildcard matches, and wildcard
-                  matches must be processed before fallback (empty Hostname value)
+                  Exact matches MUST be processed before wildcard matches, and wildcard
+                  matches MUST be processed before fallback (empty Hostname value)
                   matches. For example, `"foo.example.com"` takes precedence over
                   `"*.example.com"`, and `"*.example.com"` takes precedence over `""`.
-
 
                   Additionally, if there are multiple wildcard entries, more specific
                   wildcard entries must be processed before less specific wildcard entries.
                   For example, `"*.foo.example.com"` takes precedence over `"*.example.com"`.
+
                   The precise definition here is that the higher the number of dots in the
                   hostname to the right of the wildcard character, the higher the precedence.
-
 
                   The wildcard character will match any number of characters _and dots_ to
                   the left, however, so `"*.example.com"` will match both
                   `"foo.bar.example.com"` _and_ `"bar.example.com"`.
 
+                  ## Handling indistinct Listeners
 
                   If a set of Listeners contains Listeners that are not distinct, then those
-                  Listeners are Conflicted, and the implementation MUST set the "Conflicted"
+                  Listeners are _Conflicted_, and the implementation MUST set the "Conflicted"
                   condition in the Listener Status to "True".
 
+                  The words "indistinct" and "conflicted" are considered equivalent for the
+                  purpose of this documentation.
 
                   Implementations MAY choose to accept a Gateway with some Conflicted
                   Listeners only if they only accept the partial Listener set that contains
-                  no Conflicted Listeners. To put this another way, implementations may
-                  accept a partial Listener set only if they throw out *all* the conflicting
-                  Listeners. No picking one of the conflicting listeners as the winner.
-                  This also means that the Gateway must have at least one non-conflicting
-                  Listener in this case, otherwise it violates the requirement that at
-                  least one Listener must be present.
+                  no Conflicted Listeners.
 
+                  Specifically, an implementation MAY accept a partial Listener set subject to
+                  the following rules:
+
+                  * The implementation MUST NOT pick one conflicting Listener as the winner.
+                    ALL indistinct Listeners must not be accepted for processing.
+                  * At least one distinct Listener MUST be present, or else the Gateway effectively
+                    contains _no_ Listeners, and must be rejected from processing as a whole.
 
                   The implementation MUST set a "ListenersNotValid" condition on the
                   Gateway Status when the Gateway contains Conflicted Listeners whether or
@@ -1599,37 +1878,43 @@ spec:
                   Accepted. Additionally, the Listener status for those listeners SHOULD
                   indicate which Listeners are conflicted and not Accepted.
 
+                  ## General Listener behavior
 
-                  A Gateway's Listeners are considered "compatible" if:
+                  Note that, for all distinct Listeners, requests SHOULD match at most one Listener.
+                  For example, if Listeners are defined for "foo.example.com" and "*.example.com", a
+                  request to "foo.example.com" SHOULD only be routed using routes attached
+                  to the "foo.example.com" Listener (and not the "*.example.com" Listener).
 
+                  This concept is known as "Listener Isolation", and it is an Extended feature
+                  of Gateway API. Implementations that do not support Listener Isolation MUST
+                  clearly document this, and MUST NOT claim support for the
+                  `GatewayHTTPListenerIsolation` feature.
+
+                  Implementations that _do_ support Listener Isolation SHOULD claim support
+                  for the Extended `GatewayHTTPListenerIsolation` feature and pass the associated
+                  conformance tests.
+
+                  ## Compatible Listeners
+
+                  A Gateway's Listeners are considered _compatible_ if:
 
                   1. They are distinct.
                   2. The implementation can serve them in compliance with the Addresses
                      requirement that all Listeners are available on all assigned
                      addresses.
 
-
                   Compatible combinations in Extended support are expected to vary across
                   implementations. A combination that is compatible for one implementation
                   may not be compatible for another.
-
 
                   For example, an implementation that cannot serve both TCP and UDP listeners
                   on the same address, or cannot mix HTTPS and generic TLS listens on the same port
                   would not consider those cases compatible, even though they are distinct.
 
-
-                  Note that requests SHOULD match at most one Listener. For example, if
-                  Listeners are defined for "foo.example.com" and "*.example.com", a
-                  request to "foo.example.com" SHOULD only be routed using routes attached
-                  to the "foo.example.com" Listener (and not the "*.example.com" Listener).
-                  This concept is known as "Listener Isolation". Implementations that do
-                  not support Listener Isolation MUST clearly document this.
-
-
                   Implementations MAY merge separate Gateways onto a single set of
                   Addresses if all Listeners across all Gateways are compatible.
 
+                  In a future release the MinItems=1 requirement MAY be dropped.
 
                   Support: Core
                 items:
@@ -1646,11 +1931,9 @@ spec:
                         Listener and the trusted namespaces where those Route resources MAY be
                         present.
 
-
                         Although a client request may match multiple route rules, only one rule
                         may ultimately receive the request. Matching precedence MUST be
                         determined in order of the following criteria:
-
 
                         * The most specific match as defined by the Route type.
                         * The oldest Route based on creation timestamp. For example, a Route with
@@ -1660,14 +1943,12 @@ spec:
                           alphabetical order (namespace/name) should be given precedence. For
                           example, foo/bar is given precedence over foo/baz.
 
-
                         All valid rules within a Route attached to this Listener should be
                         implemented. Invalid Route rules can be ignored (sometimes that will mean
                         the full Route). If a Route rule transitions from valid to invalid,
                         support for that Route rule should be dropped to ensure consistency. For
                         example, even if a filter specified by a Route rule is invalid, the rest
                         of the rules within that Route should still be supported.
-
 
                         Support: Core
                       properties:
@@ -1677,13 +1958,11 @@ spec:
                             to this Gateway Listener. When unspecified or empty, the kinds of Routes
                             selected are determined using the Listener protocol.
 
-
                             A RouteGroupKind MUST correspond to kinds of Routes that are compatible
                             with the application protocol specified in the Listener's Protocol field.
                             If an implementation does not support or recognize this resource type, it
                             MUST set the "ResolvedRefs" condition to False for this Listener with the
                             "InvalidRouteKinds" reason.
-
 
                             Support: Core
                           items:
@@ -1714,7 +1993,6 @@ spec:
                             Namespaces indicates namespaces from which Routes may be attached to this
                             Listener. This is restricted to the namespace of this Gateway by default.
 
-
                             Support: Core
                           properties:
                             from:
@@ -1723,12 +2001,10 @@ spec:
                                 From indicates where Routes will be selected for this Gateway. Possible
                                 values are:
 
-
                                 * All: Routes in all namespaces may be used by this Gateway.
                                 * Selector: Routes in namespaces selected by the selector may be used by
                                   this Gateway.
                                 * Same: Only Routes in the same namespace may be used by this Gateway.
-
 
                                 Support: Core
                               enum:
@@ -1741,7 +2017,6 @@ spec:
                                 Selector must be specified when From is set to "Selector". In that case,
                                 only Routes in Namespaces matching this Selector will be selected by this
                                 Gateway. This field is ignored for other values of "From".
-
 
                                 Support: Core
                               properties:
@@ -1797,18 +2072,36 @@ spec:
                         field is ignored for protocols that don't require hostname based
                         matching.
 
-
                         Implementations MUST apply Hostname matching appropriately for each of
                         the following protocols:
 
-
                         * TLS: The Listener Hostname MUST match the SNI.
                         * HTTP: The Listener Hostname MUST match the Host header of the request.
-                        * HTTPS: The Listener Hostname SHOULD match at both the TLS and HTTP
-                          protocol layers as described above. If an implementation does not
-                          ensure that both the SNI and Host header match the Listener hostname,
-                          it MUST clearly document that.
+                        * HTTPS: The Listener Hostname SHOULD match both the SNI and Host header.
+                          Note that this does not require the SNI and Host header to be the same.
+                          The semantics of this are described in more detail below.
 
+                        To ensure security, Section 11.1 of RFC-6066 emphasizes that server
+                        implementations that rely on SNI hostname matching MUST also verify
+                        hostnames within the application protocol.
+
+                        Section 9.1.2 of RFC-7540 provides a mechanism for servers to reject the
+                        reuse of a connection by responding with the HTTP 421 Misdirected Request
+                        status code. This indicates that the origin server has rejected the
+                        request because it appears to have been misdirected.
+
+                        To detect misdirected requests, Gateways SHOULD match the authority of
+                        the requests with all the SNI hostname(s) configured across all the
+                        Gateway Listeners on the same port and protocol:
+
+                        * If another Listener has an exact match or more specific wildcard entry,
+                          the Gateway SHOULD return a 421.
+                        * If the current Listener (selected by SNI matching during ClientHello)
+                          does not match the Host:
+                            * If another Listener does match the Host the Gateway SHOULD return a
+                              421.
+                            * If no other Listener matches the Host, the Gateway MUST return a
+                              404.
 
                         For HTTPRoute and TLSRoute resources, there is an interaction with the
                         `spec.hostnames` array. When both listener and route specify hostnames,
@@ -1816,11 +2109,9 @@ spec:
                         accepted. For more information, refer to the Route specific Hostnames
                         documentation.
 
-
                         Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
                         as a suffix match. That means that a match for `*.example.com` would match
                         both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
-
 
                         Support: Core
                       maxLength: 253
@@ -1832,7 +2123,6 @@ spec:
                         Name is the name of the Listener. This name MUST be unique within a
                         Gateway.
 
-
                         Support: Core
                       maxLength: 253
                       minLength: 1
@@ -1843,7 +2133,6 @@ spec:
                         Port is the network port. Multiple listeners may use the
                         same port, subject to the Listener compatibility rules.
 
-
                         Support: Core
                       format: int32
                       maximum: 65535
@@ -1853,11 +2142,10 @@ spec:
                       description: |-
                         Protocol specifies the network protocol this listener expects to receive.
 
-
                         Support: Core
                       maxLength: 255
                       minLength: 1
-                      pattern: ^[a-zA-Z0-9]([-a-zSA-Z0-9]*[a-zA-Z0-9])?$|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9]+$
+                      pattern: ^[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?$|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9]+$
                       type: string
                     tls:
                       description: |-
@@ -1865,14 +2153,11 @@ spec:
                         the Protocol field is "HTTPS" or "TLS". It is invalid to set this field
                         if the Protocol field is "HTTP", "TCP", or "UDP".
 
-
                         The association of SNIs to Certificate defined in GatewayTLSConfig is
                         defined based on the Hostname field for this listener.
 
-
                         The GatewayClass MUST use the longest matching SNI out of all
                         available certificates for any TLS handshake.
-
 
                         Support: Core
                       properties:
@@ -1883,11 +2168,9 @@ spec:
                             establish a TLS handshake for requests that match the hostname of the
                             associated listener.
 
-
                             A single CertificateRef to a Kubernetes Secret has "Core" support.
                             Implementations MAY choose to support attaching multiple certificates to
                             a Listener, but this behavior is implementation-specific.
-
 
                             References to a resource in different namespace are invalid UNLESS there
                             is a ReferenceGrant in the target namespace that allows the certificate
@@ -1895,17 +2178,13 @@ spec:
                             "ResolvedRefs" condition MUST be set to False for this listener with the
                             "RefNotPermitted" reason.
 
-
                             This field is required to have at least one element when the mode is set
                             to "Terminate" (default) and is optional otherwise.
-
 
                             CertificateRefs can reference to standard Kubernetes resources, i.e.
                             Secret, or implementation-specific custom resources.
 
-
                             Support: Core - A single reference to a Kubernetes Secret of type kubernetes.io/tls
-
 
                             Support: Implementation-specific (More than one reference or other resource types)
                           items:
@@ -1913,10 +2192,8 @@ spec:
                               SecretObjectReference identifies an API object including its namespace,
                               defaulting to Secret.
 
-
                               The API object must be valid in the cluster; the Group and Kind must
                               be registered in the cluster for this reference to be valid.
-
 
                               References to objects with invalid Group and Kind are not valid, and must
                               be rejected by the implementation, with appropriate Conditions set
@@ -1948,12 +2225,10 @@ spec:
                                   Namespace is the namespace of the referenced object. When unspecified, the local
                                   namespace is inferred.
 
-
                                   Note that when a namespace different than the local namespace is specified,
                                   a ReferenceGrant object is required in the referent namespace to allow that
                                   namespace's owner to accept the reference. See the ReferenceGrant
                                   documentation for details.
-
 
                                   Support: Core
                                 maxLength: 63
@@ -1966,17 +2241,14 @@ spec:
                           maxItems: 64
                           type: array
                         frontendValidation:
-                          description: |+
+                          description: |-
                             FrontendValidation holds configuration information for validating the frontend (client).
                             Setting this field will require clients to send a client certificate
                             required for validation during the TLS handshake. In browsers this may result in a dialog appearing
                             that requests a user to specify the client certificate.
                             The maximum depth of a certificate chain accepted in verification is Implementation specific.
 
-
                             Support: Extended
-
-
                           properties:
                             caCertificateRefs:
                               description: |-
@@ -1985,20 +2257,16 @@ spec:
                                 the Certificate Authorities that can be used
                                 as a trust anchor to validate the certificates presented by the client.
 
-
                                 A single CA certificate reference to a Kubernetes ConfigMap
                                 has "Core" support.
                                 Implementations MAY choose to support attaching multiple CA certificates to
                                 a Listener, but this behavior is implementation-specific.
 
-
                                 Support: Core - A single reference to a Kubernetes ConfigMap
                                 with the CA certificate in a key named `ca.crt`.
 
-
                                 Support: Implementation-specific (More than one reference, or other kinds
                                 of resources).
-
 
                                 References to a resource in a different namespace are invalid UNLESS there
                                 is a ReferenceGrant in the target namespace that allows the certificate
@@ -2009,10 +2277,8 @@ spec:
                                 description: |-
                                   ObjectReference identifies an API object including its namespace.
 
-
                                   The API object must be valid in the cluster; the Group and Kind must
                                   be registered in the cluster for this reference to be valid.
-
 
                                   References to objects with invalid Group and Kind are not valid, and must
                                   be rejected by the implementation, with appropriate Conditions set
@@ -2021,7 +2287,7 @@ spec:
                                   group:
                                     description: |-
                                       Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                      When unspecified or empty string, core API group is inferred.
+                                      When set to the empty string, core API group is inferred.
                                     maxLength: 253
                                     pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                     type: string
@@ -2042,12 +2308,10 @@ spec:
                                       Namespace is the namespace of the referenced object. When unspecified, the local
                                       namespace is inferred.
 
-
                                       Note that when a namespace different than the local namespace is specified,
                                       a ReferenceGrant object is required in the referent namespace to allow that
                                       namespace's owner to accept the reference. See the ReferenceGrant
                                       documentation for details.
-
 
                                       Support: Core
                                     maxLength: 63
@@ -2069,7 +2333,6 @@ spec:
                             Mode defines the TLS behavior for the TLS session initiated by the client.
                             There are two possible modes:
 
-
                             - Terminate: The TLS session between the downstream client and the
                               Gateway is terminated at the Gateway. This mode requires certificates
                               to be specified in some way, such as populating the certificateRefs
@@ -2078,7 +2341,6 @@ spec:
                               implies that the Gateway can't decipher the TLS stream except for
                               the ClientHello message of the TLS protocol. The certificateRefs field
                               is ignored in this mode.
-
 
                             Support: Core
                           enum:
@@ -2100,12 +2362,10 @@ spec:
                             configuration for each implementation. For example, configuring the
                             minimum TLS version or supported cipher suites.
 
-
                             A set of common keys MAY be defined by the API in the future. To avoid
                             any ambiguity, implementation-specific definitions MUST use
                             domain-prefixed names, such as `example.com/my-custom-option`.
                             Un-prefixed names are reserved for key names defined by Gateway API.
-
 
                             Support: Implementation-specific
                           maxProperties: 16
@@ -2165,20 +2425,16 @@ spec:
             description: Status defines the current state of Gateway.
             properties:
               addresses:
-                description: |+
+                description: |-
                   Addresses lists the network addresses that have been bound to the
                   Gateway.
-
 
                   This list may differ from the addresses provided in the spec under some
                   conditions:
 
-
                     * no addresses are specified, all addresses are dynamically assigned
                     * a combination of specified and dynamic addresses are assigned
                     * a specified address was unusable (e.g. already in use)
-
-
                 items:
                   description: GatewayStatusAddress describes a network address that
                     is bound to a Gateway.
@@ -2209,7 +2465,6 @@ spec:
                         Value of the address. The validity of the values will depend
                         on the type and support by the controller.
 
-
                         Examples: `1.2.3.4`, `128::1`, `my-ip-address`.
                       maxLength: 253
                       minLength: 1
@@ -2239,30 +2494,19 @@ spec:
                 description: |-
                   Conditions describe the current conditions of the Gateway.
 
-
                   Implementations should prefer to express Gateway conditions
                   using the `GatewayConditionType` and `GatewayConditionReason`
                   constants so that operators and tools can converge on a common
                   vocabulary to describe Gateway state.
 
-
                   Known condition types are:
-
 
                   * "Accepted"
                   * "Programmed"
                   * "Ready"
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -2303,12 +2547,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -2335,7 +2574,6 @@ spec:
                         AttachedRoutes represents the total number of Routes that have been
                         successfully attached to this Listener.
 
-
                         Successful attachment of a Route to a Listener is based solely on the
                         combination of the AllowedRoutes field on the corresponding Listener
                         and the Route's ParentRefs field. A Route is successfully attached to
@@ -2348,7 +2586,6 @@ spec:
                         for Listeners with condition Accepted: false and MUST count successfully
                         attached Routes that may themselves have Accepted: false conditions.
 
-
                         Uses for this field include troubleshooting Route attachment and
                         measuring blast radius/impact of changes to a Listener.
                       format: int32
@@ -2357,18 +2594,8 @@ spec:
                       description: Conditions describe the current condition of this
                         listener.
                       items:
-                        description: "Condition contains details for one aspect of
-                          the current state of this API Resource.\n---\nThis struct
-                          is intended for direct use as an array at the field path
-                          .status.conditions.  For example,\n\n\n\ttype FooStatus
-                          struct{\n\t    // Represents the observations of a foo's
-                          current state.\n\t    // Known .status.conditions.type are:
-                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
-                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
-                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
-                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                          \   // other fields\n\t}"
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
                         properties:
                           lastTransitionTime:
                             description: |-
@@ -2410,12 +2637,7 @@ spec:
                             - Unknown
                             type: string
                           type:
-                            description: |-
-                              type of condition in CamelCase or in foo.example.com/CamelCase.
-                              ---
-                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                              useful (see .node.status.conditions), the ability to deconflict is important.
-                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
                             maxLength: 316
                             pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                             type: string
@@ -2443,7 +2665,6 @@ spec:
                         SupportedKinds is the list indicating the Kinds supported by this
                         listener. This MUST represent the kinds an implementation supports for
                         that Listener configuration.
-
 
                         If kinds are specified in Spec that are not supported, they MUST NOT
                         appear in this list and an implementation MUST set the "ResolvedRefs"

--- a/platform/gateway-api/chart/templates/grpcroutes.yaml
+++ b/platform/gateway-api/chart/templates/grpcroutes.yaml
@@ -9,7 +9,6 @@
   cluster-scoped infrastructure; deleting them on uninstall would break
   every HTTPRoute on the cluster simultaneously.
 */}}
-
 #
 # config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
 #
@@ -18,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
-    gateway.networking.k8s.io/bundle-version: v1.1.0
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.3.0
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: grpcroutes.gateway.networking.k8s.io
@@ -50,13 +49,11 @@ spec:
           Filters can be used to specify additional processing steps. Backends specify
           where matching requests will be routed.
 
-
           GRPCRoute falls under extended support within the Gateway API. Within the
           following specification, the word "MUST" indicates that an implementation
           supporting GRPCRoute must conform to the indicated requirement, but an
           implementation not supporting this route type need not follow the requirement
           unless explicitly indicated.
-
 
           Implementations supporting `GRPCRoute` with the `HTTPS` `ProtocolType` MUST
           accept HTTP/2 connections without an initial upgrade from HTTP/1.1, i.e. via
@@ -64,7 +61,6 @@ spec:
           "Accepted" condition to "False" for the affected listener with a reason of
           "UnsupportedProtocol".  Implementations MAY also accept HTTP/2 connections
           with an upgrade from HTTP/1.
-
 
           Implementations supporting `GRPCRoute` with the `HTTP` `ProtocolType` MUST
           support HTTP/2 over cleartext TCP (h2c,
@@ -102,16 +98,13 @@ spec:
                   Host header to select a GRPCRoute to process the request. This matches
                   the RFC 1123 definition of a hostname with 2 notable exceptions:
 
-
                   1. IPs are not allowed.
                   2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
                      label MUST appear by itself as the first label.
 
-
                   If a hostname is specified by both the Listener and GRPCRoute, there
                   MUST be at least one intersecting hostname for the GRPCRoute to be
                   attached to the Listener. For example:
-
 
                   * A Listener with `test.example.com` as the hostname matches GRPCRoutes
                     that have either not specified any hostnames, or have specified at
@@ -122,11 +115,9 @@ spec:
                     `test.example.com` and `*.example.com` would both match. On the other
                     hand, `example.com` and `test.example.net` would not match.
 
-
                   Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
                   as a suffix match. That means that a match for `*.example.com` would match
                   both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
-
 
                   If both the Listener and GRPCRoute have specified hostnames, any
                   GRPCRoute hostnames that do not match the Listener hostname MUST be
@@ -134,12 +125,10 @@ spec:
                   GRPCRoute specified `test.example.com` and `test.example.net`,
                   `test.example.net` MUST NOT be considered for a match.
 
-
                   If both the Listener and GRPCRoute have specified hostnames, and none
                   match with the criteria above, then the GRPCRoute MUST NOT be accepted by
                   the implementation. The implementation MUST raise an 'Accepted' Condition
                   with a status of `False` in the corresponding RouteParentStatus.
-
 
                   If a Route (A) of type HTTPRoute or GRPCRoute is attached to a
                   Listener and that listener already has another Route (B) of the other
@@ -147,15 +136,12 @@ spec:
                   non-empty, then the implementation MUST accept exactly one of these two
                   routes, determined by the following criteria, in order:
 
-
                   * The oldest Route based on creation timestamp.
                   * The Route appearing first in alphabetical order by
                     "{namespace}/{name}".
 
-
                   The rejected Route MUST raise an 'Accepted' condition with a status of
                   'False' in the corresponding RouteParentStatus.
-
 
                   Support: Core
                 items:
@@ -163,16 +149,13 @@ spec:
                     Hostname is the fully qualified domain name of a network host. This matches
                     the RFC 1123 definition of a hostname with 2 notable exceptions:
 
-
                      1. IPs are not allowed.
                      2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
                         label must appear by itself as the first label.
 
-
                     Hostname can be "precise" which is a domain name without the terminating
                     dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
                     domain name prefixed with a single wildcard label (e.g. `*.example.com`).
-
 
                     Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
                     alphanumeric characters or '-', and must start and end with an alphanumeric
@@ -184,7 +167,7 @@ spec:
                 maxItems: 16
                 type: array
               parentRefs:
-                description: |+
+                description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants
                   to be attached to. Note that the referenced parent resource needs to
                   allow this for the attachment to be complete. For Gateways, that means
@@ -196,20 +179,15 @@ spec:
                   create a "producer" route for a Service in a different namespace from the
                   Route.
 
-
                   There are two kinds of parent resources with "Core" support:
-
 
                   * Gateway (Gateway conformance profile)
                   * Service (Mesh conformance profile, ClusterIP Services only)
 
-
                   This API may be extended in the future to support additional kinds of parent
                   resources.
 
-
                   ParentRefs must be _distinct_. This means either that:
-
 
                   * They select different objects.  If this is the case, then parentRef
                     entries are distinct. In terms of fields, this means that the
@@ -220,9 +198,7 @@ spec:
                     optional fields to different values. If one ParentRef sets a
                     combination of optional fields, all must set the same combination.
 
-
                   Some examples:
-
 
                   * If one ParentRef sets `sectionName`, all ParentRefs referencing the
                     same object must also set `sectionName`.
@@ -231,13 +207,11 @@ spec:
                   * If one ParentRef sets `sectionName` and `port`, all ParentRefs
                     referencing the same object must also set `sectionName` and `port`.
 
-
                   It is possible to separately reference multiple distinct objects that may
                   be collapsed by an implementation. For example, some implementations may
                   choose to merge compatible Gateway Listeners together. If that is the
                   case, the list of routes attached to those resources should also be
                   merged.
-
 
                   Note that for ParentRefs that cross namespace boundaries, there are specific
                   rules. Cross-namespace references are only valid if they are explicitly
@@ -246,37 +220,26 @@ spec:
                   generic way to enable other kinds of cross-namespace reference.
 
 
-
                   ParentRefs from a Route to a Service in the same namespace are "producer"
                   routes, which apply default routing rules to inbound connections from
                   any namespace to the Service.
-
 
                   ParentRefs from a Route to a Service in a different namespace are
                   "consumer" routes, and these routing rules are only applied to outbound
                   connections originating from the same namespace as the Route, for which
                   the intended destination of the connections are a Service targeted as a
                   ParentRef of the Route.
-
-
-
-
-
-
                 items:
                   description: |-
                     ParentReference identifies an API object (usually a Gateway) that can be considered
                     a parent of this resource (usually a route). There are two kinds of parent resources
                     with "Core" support:
 
-
                     * Gateway (Gateway conformance profile)
                     * Service (Mesh conformance profile, ClusterIP Services only)
 
-
                     This API may be extended in the future to support additional kinds of parent
                     resources.
-
 
                     The API object must be valid in the cluster; the Group and Kind must
                     be registered in the cluster for this reference to be valid.
@@ -289,7 +252,6 @@ spec:
                         To set the core API group (such as for a "Service" kind referent),
                         Group must be explicitly set to "" (empty string).
 
-
                         Support: Core
                       maxLength: 253
                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -299,13 +261,10 @@ spec:
                       description: |-
                         Kind is kind of the referent.
 
-
                         There are two kinds of parent resources with "Core" support:
-
 
                         * Gateway (Gateway conformance profile)
                         * Service (Mesh conformance profile, ClusterIP Services only)
-
 
                         Support for other resources is Implementation-Specific.
                       maxLength: 63
@@ -316,7 +275,6 @@ spec:
                       description: |-
                         Name is the name of the referent.
 
-
                         Support: Core
                       maxLength: 253
                       minLength: 1
@@ -326,7 +284,6 @@ spec:
                         Namespace is the namespace of the referent. When unspecified, this refers
                         to the local namespace of the Route.
 
-
                         Note that there are specific rules for ParentRefs which cross namespace
                         boundaries. Cross-namespace references are only valid if they are explicitly
                         allowed by something in the namespace they are referring to. For example:
@@ -334,18 +291,15 @@ spec:
                         generic way to enable any other kind of cross-namespace reference.
 
 
-
                         ParentRefs from a Route to a Service in the same namespace are "producer"
                         routes, which apply default routing rules to inbound connections from
                         any namespace to the Service.
-
 
                         ParentRefs from a Route to a Service in a different namespace are
                         "consumer" routes, and these routing rules are only applied to outbound
                         connections originating from the same namespace as the Route, for which
                         the intended destination of the connections are a Service targeted as a
                         ParentRef of the Route.
-
 
 
                         Support: Core
@@ -358,7 +312,6 @@ spec:
                         Port is the network port this Route targets. It can be interpreted
                         differently based on the type of parent resource.
 
-
                         When the parent resource is a Gateway, this targets all listeners
                         listening on the specified port that also support this kind of Route(and
                         select this Route). It's not recommended to set `Port` unless the
@@ -368,17 +321,14 @@ spec:
                         must match both specified values.
 
 
-
                         When the parent resource is a Service, this targets a specific port in the
                         Service spec. When both Port (experimental) and SectionName are specified,
                         the name and port of the selected port must match both specified values.
 
 
-
                         Implementations MAY choose to support other parent resources.
                         Implementations supporting other types of parent resources MUST clearly
                         document how/if Port is interpreted.
-
 
                         For the purpose of status, an attachment is considered successful as
                         long as the parent resource accepts it partially. For example, Gateway
@@ -387,7 +337,6 @@ spec:
                         from the referencing Route, the Route MUST be considered successfully
                         attached. If no Gateway listeners accept attachment from this Route,
                         the Route MUST be considered detached from the Gateway.
-
 
                         Support: Extended
                       format: int32
@@ -399,7 +348,6 @@ spec:
                         SectionName is the name of a section within the target resource. In the
                         following resources, SectionName is interpreted as the following:
 
-
                         * Gateway: Listener name. When both Port (experimental) and SectionName
                         are specified, the name and port of the selected listener must match
                         both specified values.
@@ -407,11 +355,9 @@ spec:
                         are specified, the name and port of the selected listener must match
                         both specified values.
 
-
                         Implementations MAY choose to support attaching Routes to other resources.
                         If that is the case, they MUST clearly document how SectionName is
                         interpreted.
-
 
                         When unspecified (empty string), this will reference the entire resource.
                         For the purpose of status, an attachment is considered successful if at
@@ -421,7 +367,6 @@ spec:
                         the referencing Route, the Route MUST be considered successfully
                         attached. If no Gateway listeners accept attachment from this Route, the
                         Route MUST be considered detached from the Gateway.
-
 
                         Support: Core
                       maxLength: 253
@@ -469,19 +414,15 @@ spec:
                         BackendRefs defines the backend(s) where matching requests should be
                         sent.
 
-
                         Failure behavior here depends on how many BackendRefs are specified and
                         how many are invalid.
-
 
                         If *all* entries in BackendRefs are invalid, and there are also no filters
                         specified in this route rule, *all* traffic which matches this rule MUST
                         receive an `UNAVAILABLE` status.
 
-
                         See the GRPCBackendRef definition for the rules about what makes a single
                         GRPCBackendRef invalid.
-
 
                         When a GRPCBackendRef is invalid, `UNAVAILABLE` statuses MUST be returned for
                         requests that would have otherwise been routed to an invalid backend. If
@@ -489,23 +430,18 @@ spec:
                         requests that would otherwise have been routed to an invalid backend
                         MUST receive an `UNAVAILABLE` status.
 
-
                         For example, if two backends are specified with equal weights, and one is
                         invalid, 50 percent of traffic MUST receive an `UNAVAILABLE` status.
                         Implementations may choose how that 50 percent is determined.
 
-
                         Support: Core for Kubernetes Service
 
-
                         Support: Implementation-specific for any other resource
-
 
                         Support for weight: Core
                       items:
                         description: |-
                           GRPCBackendRef defines how a GRPCRoute forwards a gRPC request.
-
 
                           Note that when a namespace different than the local namespace is specified, a
                           ReferenceGrant object is required in the referent namespace to allow that
@@ -513,34 +449,24 @@ spec:
                           documentation for details.
 
 
-                          <gateway:experimental:description>
-
-
                           When the BackendRef points to a Kubernetes Service, implementations SHOULD
                           honor the appProtocol field if it is set for the target Service Port.
 
-
                           Implementations supporting appProtocol SHOULD recognize the Kubernetes
                           Standard Application Protocols defined in KEP-3726.
-
 
                           If a Service appProtocol isn't specified, an implementation MAY infer the
                           backend protocol through its own means. Implementations MAY infer the
                           protocol from the Route type referring to the backend Service.
 
-
                           If a Route is not able to send traffic to the backend using the specified
                           protocol then the backend is considered invalid. Implementations MUST set the
                           "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
-
-
-                          </gateway:experimental:description>
                         properties:
                           filters:
                             description: |-
                               Filters defined at this level MUST be executed if and only if the
                               request is being forwarded to the backend defined here.
-
 
                               Support: Implementation-specific (For broader support of filters, use the
                               Filters field in GRPCRouteRule.)
@@ -560,9 +486,7 @@ spec:
                                     "networking.example.net"). ExtensionRef MUST NOT be used for core and
                                     extended filters.
 
-
                                     Support: Implementation-specific
-
 
                                     This filter can be used multiple times within the same rule.
                                   properties:
@@ -595,7 +519,6 @@ spec:
                                     RequestHeaderModifier defines a schema for a filter that modifies request
                                     headers.
 
-
                                     Support: Core
                                   properties:
                                     add:
@@ -604,17 +527,14 @@ spec:
                                         before the action. It appends to any existing values associated
                                         with the header name.
 
-
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header: foo
-
 
                                         Config:
                                           add:
                                           - name: "my-header"
                                             value: "bar,baz"
-
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -627,8 +547,7 @@ spec:
                                           name:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -661,17 +580,14 @@ spec:
                                         names are case-insensitive (see
                                         https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
 
-
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header1: foo
                                           my-header2: bar
                                           my-header3: baz
 
-
                                         Config:
                                           remove: ["my-header1", "my-header3"]
-
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -686,17 +602,14 @@ spec:
                                         Set overwrites the request with the given header (name, value)
                                         before the action.
 
-
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header: foo
-
 
                                         Config:
                                           set:
                                           - name: "my-header"
                                             value: "bar"
-
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -709,8 +622,7 @@ spec:
                                           name:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -743,11 +655,9 @@ spec:
                                     Requests are sent to the specified destination, but responses from
                                     that destination are ignored.
 
-
                                     This filter can be used multiple times within the same rule. Note that
                                     not all implementations will be able to support mirroring to multiple
                                     backends.
-
 
                                     Support: Extended
                                   properties:
@@ -755,17 +665,14 @@ spec:
                                       description: |-
                                         BackendRef references a resource where mirrored requests are sent.
 
-
                                         Mirrored requests must be sent only to a single destination endpoint
                                         within this BackendRef, irrespective of how many endpoints are present
                                         within this BackendRef.
-
 
                                         If the referent cannot be found, this BackendRef is invalid and must be
                                         dropped from the Gateway. The controller must ensure the "ResolvedRefs"
                                         condition on the Route status is set to `status: False` and not configure
                                         this backend in the underlying implementation.
-
 
                                         If there is a cross-namespace reference to an *existing* object
                                         that is not allowed by a ReferenceGrant, the controller must ensure the
@@ -773,13 +680,10 @@ spec:
                                         with the "RefNotPermitted" reason and not configure this backend in the
                                         underlying implementation.
 
-
                                         In either error case, the Message of the `ResolvedRefs` Condition
                                         should be used to provide more detail about the problem.
 
-
                                         Support: Extended for Kubernetes Service
-
 
                                         Support: Implementation-specific for any other resource
                                       properties:
@@ -797,9 +701,7 @@ spec:
                                             Kind is the Kubernetes resource kind of the referent. For example
                                             "Service".
 
-
                                             Defaults to "Service" when not specified.
-
 
                                             ExternalName services can refer to CNAME DNS records that may live
                                             outside of the cluster and as such are difficult to reason about in
@@ -807,9 +709,7 @@ spec:
                                             CVE-2021-25740 for more information). Implementations SHOULD NOT
                                             support ExternalName Services.
 
-
                                             Support: Core (Services with a type other than ExternalName)
-
 
                                             Support: Implementation-specific (Services with type ExternalName)
                                           maxLength: 63
@@ -826,12 +726,10 @@ spec:
                                             Namespace is the namespace of the backend. When unspecified, the local
                                             namespace is inferred.
 
-
                                             Note that when a namespace different than the local namespace is specified,
                                             a ReferenceGrant object is required in the referent namespace to allow that
                                             namespace's owner to accept the reference. See the ReferenceGrant
                                             documentation for details.
-
 
                                             Support: Core
                                           maxLength: 63
@@ -856,14 +754,53 @@ spec:
                                       - message: Must have port for Service reference
                                         rule: '(size(self.group) == 0 && self.kind
                                           == ''Service'') ? has(self.port) : true'
+                                    fraction:
+                                      description: |-
+                                        Fraction represents the fraction of requests that should be
+                                        mirrored to BackendRef.
+
+                                        Only one of Fraction or Percent may be specified. If neither field
+                                        is specified, 100% of requests will be mirrored.
+                                      properties:
+                                        denominator:
+                                          default: 100
+                                          format: int32
+                                          minimum: 1
+                                          type: integer
+                                        numerator:
+                                          format: int32
+                                          minimum: 0
+                                          type: integer
+                                      required:
+                                      - numerator
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: numerator must be less than or equal
+                                          to denominator
+                                        rule: self.numerator <= self.denominator
+                                    percent:
+                                      description: |-
+                                        Percent represents the percentage of requests that should be
+                                        mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
+                                        requests) and its maximum value is 100 (indicating 100% of requests).
+
+                                        Only one of Fraction or Percent may be specified. If neither field
+                                        is specified, 100% of requests will be mirrored.
+                                      format: int32
+                                      maximum: 100
+                                      minimum: 0
+                                      type: integer
                                   required:
                                   - backendRef
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: Only one of percent or fraction may be
+                                      specified in HTTPRequestMirrorFilter
+                                    rule: '!(has(self.percent) && has(self.fraction))'
                                 responseHeaderModifier:
                                   description: |-
                                     ResponseHeaderModifier defines a schema for a filter that modifies response
                                     headers.
-
 
                                     Support: Extended
                                   properties:
@@ -873,17 +810,14 @@ spec:
                                         before the action. It appends to any existing values associated
                                         with the header name.
 
-
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header: foo
-
 
                                         Config:
                                           add:
                                           - name: "my-header"
                                             value: "bar,baz"
-
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -896,8 +830,7 @@ spec:
                                           name:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -930,17 +863,14 @@ spec:
                                         names are case-insensitive (see
                                         https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
 
-
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header1: foo
                                           my-header2: bar
                                           my-header3: baz
 
-
                                         Config:
                                           remove: ["my-header1", "my-header3"]
-
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -955,17 +885,14 @@ spec:
                                         Set overwrites the request with the given header (name, value)
                                         before the action.
 
-
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header: foo
-
 
                                         Config:
                                           set:
                                           - name: "my-header"
                                             value: "bar"
-
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -978,8 +905,7 @@ spec:
                                           name:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -1007,20 +933,17 @@ spec:
                                       x-kubernetes-list-type: map
                                   type: object
                                 type:
-                                  description: |+
+                                  description: |-
                                     Type identifies the type of filter to apply. As with other API fields,
                                     types are classified into three conformance levels:
-
 
                                     - Core: Filter types and their corresponding configuration defined by
                                       "Support: Core" in this package, e.g. "RequestHeaderModifier". All
                                       implementations supporting GRPCRoute MUST support core filters.
 
-
                                     - Extended: Filter types and their corresponding configuration defined by
                                       "Support: Extended" in this package, e.g. "RequestMirror". Implementers
                                       are encouraged to support extended filters.
-
 
                                     - Implementation-specific: Filters that are defined and supported by specific vendors.
                                       In the future, filters showing convergence in behavior across multiple
@@ -1029,16 +952,12 @@ spec:
                                       is specified using the ExtensionRef field. `Type` MUST be set to
                                       "ExtensionRef" for custom filters.
 
-
                                     Implementers are encouraged to define custom implementation types to
                                     extend the core API with implementation-specific behavior.
-
 
                                     If a reference to a custom filter type cannot be resolved, the filter
                                     MUST NOT be skipped. Instead, requests that would have been processed by
                                     that filter MUST receive a HTTP error response.
-
-
                                   enum:
                                   - ResponseHeaderModifier
                                   - RequestHeaderModifier
@@ -1101,9 +1020,7 @@ spec:
                               Kind is the Kubernetes resource kind of the referent. For example
                               "Service".
 
-
                               Defaults to "Service" when not specified.
-
 
                               ExternalName services can refer to CNAME DNS records that may live
                               outside of the cluster and as such are difficult to reason about in
@@ -1111,9 +1028,7 @@ spec:
                               CVE-2021-25740 for more information). Implementations SHOULD NOT
                               support ExternalName Services.
 
-
                               Support: Core (Services with a type other than ExternalName)
-
 
                               Support: Implementation-specific (Services with type ExternalName)
                             maxLength: 63
@@ -1130,12 +1045,10 @@ spec:
                               Namespace is the namespace of the backend. When unspecified, the local
                               namespace is inferred.
 
-
                               Note that when a namespace different than the local namespace is specified,
                               a ReferenceGrant object is required in the referent namespace to allow that
                               namespace's owner to accept the reference. See the ReferenceGrant
                               documentation for details.
-
 
                               Support: Core
                             maxLength: 63
@@ -1163,12 +1076,10 @@ spec:
                               implementation supports. Weight is not a percentage and the sum of
                               weights does not need to equal 100.
 
-
                               If only one backend is specified and it has a weight greater than 0, 100%
                               of the traffic is forwarded to that backend. If weight is set to 0, no
                               traffic should be forwarded for this entry. If unspecified, weight
                               defaults to 1.
-
 
                               Support for this field varies based on the context where used.
                             format: int32
@@ -1189,13 +1100,10 @@ spec:
                         Filters define the filters that are applied to requests that match
                         this rule.
 
-
                         The effects of ordering of multiple behaviors are currently unspecified.
                         This can change in the future based on feedback during the alpha stage.
 
-
                         Conformance-levels at this level are defined based on the type of filter:
-
 
                         - ALL core filters MUST be supported by all implementations that support
                           GRPCRoute.
@@ -1203,17 +1111,14 @@ spec:
                         - Implementation-specific custom filters have no API guarantees across
                           implementations.
 
-
                         Specifying the same filter multiple times is not supported unless explicitly
                         indicated in the filter.
 
-
-                        If an implementation can not support a combination of filters, it must clearly
+                        If an implementation cannot support a combination of filters, it must clearly
                         document that limitation. In cases where incompatible or unsupported
                         filters are specified and cause the `Accepted` condition to be set to status
                         `False`, implementations may use the `IncompatibleFilters` reason to specify
                         this configuration error.
-
 
                         Support: Core
                       items:
@@ -1232,9 +1137,7 @@ spec:
                               "networking.example.net"). ExtensionRef MUST NOT be used for core and
                               extended filters.
 
-
                               Support: Implementation-specific
-
 
                               This filter can be used multiple times within the same rule.
                             properties:
@@ -1267,7 +1170,6 @@ spec:
                               RequestHeaderModifier defines a schema for a filter that modifies request
                               headers.
 
-
                               Support: Core
                             properties:
                               add:
@@ -1276,17 +1178,14 @@ spec:
                                   before the action. It appends to any existing values associated
                                   with the header name.
 
-
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header: foo
-
 
                                   Config:
                                     add:
                                     - name: "my-header"
                                       value: "bar,baz"
-
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -1298,8 +1197,7 @@ spec:
                                     name:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -1332,17 +1230,14 @@ spec:
                                   names are case-insensitive (see
                                   https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
 
-
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header1: foo
                                     my-header2: bar
                                     my-header3: baz
 
-
                                   Config:
                                     remove: ["my-header1", "my-header3"]
-
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -1357,17 +1252,14 @@ spec:
                                   Set overwrites the request with the given header (name, value)
                                   before the action.
 
-
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header: foo
-
 
                                   Config:
                                     set:
                                     - name: "my-header"
                                       value: "bar"
-
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -1379,8 +1271,7 @@ spec:
                                     name:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -1413,11 +1304,9 @@ spec:
                               Requests are sent to the specified destination, but responses from
                               that destination are ignored.
 
-
                               This filter can be used multiple times within the same rule. Note that
                               not all implementations will be able to support mirroring to multiple
                               backends.
-
 
                               Support: Extended
                             properties:
@@ -1425,17 +1314,14 @@ spec:
                                 description: |-
                                   BackendRef references a resource where mirrored requests are sent.
 
-
                                   Mirrored requests must be sent only to a single destination endpoint
                                   within this BackendRef, irrespective of how many endpoints are present
                                   within this BackendRef.
-
 
                                   If the referent cannot be found, this BackendRef is invalid and must be
                                   dropped from the Gateway. The controller must ensure the "ResolvedRefs"
                                   condition on the Route status is set to `status: False` and not configure
                                   this backend in the underlying implementation.
-
 
                                   If there is a cross-namespace reference to an *existing* object
                                   that is not allowed by a ReferenceGrant, the controller must ensure the
@@ -1443,13 +1329,10 @@ spec:
                                   with the "RefNotPermitted" reason and not configure this backend in the
                                   underlying implementation.
 
-
                                   In either error case, the Message of the `ResolvedRefs` Condition
                                   should be used to provide more detail about the problem.
 
-
                                   Support: Extended for Kubernetes Service
-
 
                                   Support: Implementation-specific for any other resource
                                 properties:
@@ -1467,9 +1350,7 @@ spec:
                                       Kind is the Kubernetes resource kind of the referent. For example
                                       "Service".
 
-
                                       Defaults to "Service" when not specified.
-
 
                                       ExternalName services can refer to CNAME DNS records that may live
                                       outside of the cluster and as such are difficult to reason about in
@@ -1477,9 +1358,7 @@ spec:
                                       CVE-2021-25740 for more information). Implementations SHOULD NOT
                                       support ExternalName Services.
 
-
                                       Support: Core (Services with a type other than ExternalName)
-
 
                                       Support: Implementation-specific (Services with type ExternalName)
                                     maxLength: 63
@@ -1496,12 +1375,10 @@ spec:
                                       Namespace is the namespace of the backend. When unspecified, the local
                                       namespace is inferred.
 
-
                                       Note that when a namespace different than the local namespace is specified,
                                       a ReferenceGrant object is required in the referent namespace to allow that
                                       namespace's owner to accept the reference. See the ReferenceGrant
                                       documentation for details.
-
 
                                       Support: Core
                                     maxLength: 63
@@ -1526,14 +1403,53 @@ spec:
                                 - message: Must have port for Service reference
                                   rule: '(size(self.group) == 0 && self.kind == ''Service'')
                                     ? has(self.port) : true'
+                              fraction:
+                                description: |-
+                                  Fraction represents the fraction of requests that should be
+                                  mirrored to BackendRef.
+
+                                  Only one of Fraction or Percent may be specified. If neither field
+                                  is specified, 100% of requests will be mirrored.
+                                properties:
+                                  denominator:
+                                    default: 100
+                                    format: int32
+                                    minimum: 1
+                                    type: integer
+                                  numerator:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                - numerator
+                                type: object
+                                x-kubernetes-validations:
+                                - message: numerator must be less than or equal to
+                                    denominator
+                                  rule: self.numerator <= self.denominator
+                              percent:
+                                description: |-
+                                  Percent represents the percentage of requests that should be
+                                  mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
+                                  requests) and its maximum value is 100 (indicating 100% of requests).
+
+                                  Only one of Fraction or Percent may be specified. If neither field
+                                  is specified, 100% of requests will be mirrored.
+                                format: int32
+                                maximum: 100
+                                minimum: 0
+                                type: integer
                             required:
                             - backendRef
                             type: object
+                            x-kubernetes-validations:
+                            - message: Only one of percent or fraction may be specified
+                                in HTTPRequestMirrorFilter
+                              rule: '!(has(self.percent) && has(self.fraction))'
                           responseHeaderModifier:
                             description: |-
                               ResponseHeaderModifier defines a schema for a filter that modifies response
                               headers.
-
 
                               Support: Extended
                             properties:
@@ -1543,17 +1459,14 @@ spec:
                                   before the action. It appends to any existing values associated
                                   with the header name.
 
-
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header: foo
-
 
                                   Config:
                                     add:
                                     - name: "my-header"
                                       value: "bar,baz"
-
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -1565,8 +1478,7 @@ spec:
                                     name:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -1599,17 +1511,14 @@ spec:
                                   names are case-insensitive (see
                                   https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
 
-
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header1: foo
                                     my-header2: bar
                                     my-header3: baz
 
-
                                   Config:
                                     remove: ["my-header1", "my-header3"]
-
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -1624,17 +1533,14 @@ spec:
                                   Set overwrites the request with the given header (name, value)
                                   before the action.
 
-
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header: foo
-
 
                                   Config:
                                     set:
                                     - name: "my-header"
                                       value: "bar"
-
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -1646,8 +1552,7 @@ spec:
                                     name:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -1675,20 +1580,17 @@ spec:
                                 x-kubernetes-list-type: map
                             type: object
                           type:
-                            description: |+
+                            description: |-
                               Type identifies the type of filter to apply. As with other API fields,
                               types are classified into three conformance levels:
-
 
                               - Core: Filter types and their corresponding configuration defined by
                                 "Support: Core" in this package, e.g. "RequestHeaderModifier". All
                                 implementations supporting GRPCRoute MUST support core filters.
 
-
                               - Extended: Filter types and their corresponding configuration defined by
                                 "Support: Extended" in this package, e.g. "RequestMirror". Implementers
                                 are encouraged to support extended filters.
-
 
                               - Implementation-specific: Filters that are defined and supported by specific vendors.
                                 In the future, filters showing convergence in behavior across multiple
@@ -1697,16 +1599,12 @@ spec:
                                 is specified using the ExtensionRef field. `Type` MUST be set to
                                 "ExtensionRef" for custom filters.
 
-
                               Implementers are encouraged to define custom implementation types to
                               extend the core API with implementation-specific behavior.
-
 
                               If a reference to a custom filter type cannot be resolved, the filter
                               MUST NOT be skipped. Instead, requests that would have been processed by
                               that filter MUST receive a HTTP error response.
-
-
                             enum:
                             - ResponseHeaderModifier
                             - RequestHeaderModifier
@@ -1760,9 +1658,7 @@ spec:
                         gRPC requests. Each match is independent, i.e. this rule will be matched
                         if **any** one of the matches is satisfied.
 
-
                         For example, take the following matches configuration:
-
 
                         ```
                         matches:
@@ -1775,27 +1671,21 @@ spec:
                             service: foo.bar.v2
                         ```
 
-
                         For a request to match against this rule, it MUST satisfy
                         EITHER of the two conditions:
-
 
                         - service of foo.bar AND contains the header `version: 2`
                         - service of foo.bar.v2
 
-
                         See the documentation for GRPCRouteMatch on how to specify multiple
                         match conditions to be ANDed together.
 
-
                         If no matches are specified, the implementation MUST match every gRPC request.
-
 
                         Proxy or Load Balancer routing configuration generated from GRPCRoutes
                         MUST prioritize rules based on the following criteria, continuing on
                         ties. Merging MUST not be done between GRPCRoutes and HTTPRoutes.
                         Precedence MUST be given to the rule with the largest number of:
-
 
                         * Characters in a matching non-wildcard hostname.
                         * Characters in a matching hostname.
@@ -1803,15 +1693,12 @@ spec:
                         * Characters in a matching method.
                         * Header matches.
 
-
                         If ties still exist across multiple Routes, matching precedence MUST be
                         determined in order of the following criteria, continuing on ties:
-
 
                         * The oldest Route based on creation timestamp.
                         * The Route appearing first in alphabetical order by
                           "{namespace}/{name}".
-
 
                         If ties still exist within the Route that has been given precedence,
                         matching precedence MUST be granted to the first matching rule meeting
@@ -1822,10 +1709,8 @@ spec:
                           action. Multiple match types are ANDed together, i.e. the match will
                           evaluate to true only if all conditions are satisfied.
 
-
                           For example, the match below will match a gRPC request only if its service
                           is `foo` AND it contains the `version: v1` header:
-
 
                           ```
                           matches:
@@ -1835,7 +1720,6 @@ spec:
                               headers:
                             - name: "version"
                               value "v1"
-
 
                           ```
                         properties:
@@ -1852,7 +1736,6 @@ spec:
                                 name:
                                   description: |-
                                     Name is the name of the gRPC Header to be matched.
-
 
                                     If multiple entries specify equivalent header names, only the first
                                     entry with an equivalent name MUST be considered for a match. Subsequent
@@ -1896,7 +1779,6 @@ spec:
                                   Value of the method to match against. If left empty or omitted, will
                                   match all services.
 
-
                                   At least one of Service and Method MUST be a non-empty string.
                                 maxLength: 1024
                                 type: string
@@ -1904,7 +1786,6 @@ spec:
                                 description: |-
                                   Value of the service to match against. If left empty or omitted, will
                                   match any service.
-
 
                                   At least one of Service and Method MUST be a non-empty string.
                                 maxLength: 1024
@@ -1915,9 +1796,7 @@ spec:
                                   Type specifies how to match against the service and/or method.
                                   Support: Core (Exact with service and method specified)
 
-
                                   Support: Implementation-specific (Exact with method specified but no service specified)
-
 
                                   Support: Implementation-specific (RegularExpression)
                                 enum:
@@ -1941,24 +1820,29 @@ spec:
                                 has(self.method) ? self.method.matches(r"""^[A-Za-z_][A-Za-z_0-9]*$"""):
                                 true'
                         type: object
-                      maxItems: 8
+                      maxItems: 64
                       type: array
+                    name:
+                      description: |-
+                        Name is the name of the route rule. This name MUST be unique within a Route if it is set.
+
+                        Support: Extended
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
                     sessionPersistence:
-                      description: |+
+                      description: |-
                         SessionPersistence defines and configures session persistence
                         for the route rule.
 
-
                         Support: Extended
-
-
                       properties:
                         absoluteTimeout:
                           description: |-
                             AbsoluteTimeout defines the absolute timeout of the persistent
                             session. Once the AbsoluteTimeout duration has elapsed, the
                             session becomes invalid.
-
 
                             Support: Extended
                           pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
@@ -1967,7 +1851,6 @@ spec:
                           description: |-
                             CookieConfig provides configuration settings that are specific
                             to cookie-based session persistence.
-
 
                             Support: Core
                           properties:
@@ -1980,19 +1863,17 @@ spec:
                                 attributes, while a session cookie is deleted when the current
                                 session ends.
 
-
                                 When set to "Permanent", AbsoluteTimeout indicates the
                                 cookie's lifetime via the Expires or Max-Age cookie attributes
                                 and is required.
-
 
                                 When set to "Session", AbsoluteTimeout indicates the
                                 absolute lifetime of the cookie tracked by the gateway and
                                 is optional.
 
+                                Defaults to "Session".
 
                                 Support: Core for "Session" type
-
 
                                 Support: Extended for "Permanent" type
                               enum:
@@ -2006,7 +1887,6 @@ spec:
                             Once the session has been idle for more than the specified
                             IdleTimeout duration, the session becomes invalid.
 
-
                             Support: Extended
                           pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                           type: string
@@ -2016,7 +1896,6 @@ spec:
                             which may be reflected in the cookie or the header. Users
                             should avoid reusing session names to prevent unintended
                             consequences, such as rejection or unpredictable behavior.
-
 
                             Support: Implementation-specific
                           maxLength: 128
@@ -2028,9 +1907,7 @@ spec:
                             the use a header or cookie. Defaults to cookie based session
                             persistence.
 
-
                             Support: Core for "Cookie" type
-
 
                             Support: Extended for "Header" type
                           enum:
@@ -2041,11 +1918,35 @@ spec:
                       x-kubernetes-validations:
                       - message: AbsoluteTimeout must be specified when cookie lifetimeType
                           is Permanent
-                        rule: '!has(self.cookieConfig.lifetimeType) || self.cookieConfig.lifetimeType
-                          != ''Permanent'' || has(self.absoluteTimeout)'
+                        rule: '!has(self.cookieConfig) || !has(self.cookieConfig.lifetimeType)
+                          || self.cookieConfig.lifetimeType != ''Permanent'' || has(self.absoluteTimeout)'
                   type: object
                 maxItems: 16
                 type: array
+                x-kubernetes-validations:
+                - message: While 16 rules and 64 matches per rule are allowed, the
+                    total number of matches across all rules in a route must be less
+                    than 128
+                  rule: '(self.size() > 0 ? (has(self[0].matches) ? self[0].matches.size()
+                    : 0) : 0) + (self.size() > 1 ? (has(self[1].matches) ? self[1].matches.size()
+                    : 0) : 0) + (self.size() > 2 ? (has(self[2].matches) ? self[2].matches.size()
+                    : 0) : 0) + (self.size() > 3 ? (has(self[3].matches) ? self[3].matches.size()
+                    : 0) : 0) + (self.size() > 4 ? (has(self[4].matches) ? self[4].matches.size()
+                    : 0) : 0) + (self.size() > 5 ? (has(self[5].matches) ? self[5].matches.size()
+                    : 0) : 0) + (self.size() > 6 ? (has(self[6].matches) ? self[6].matches.size()
+                    : 0) : 0) + (self.size() > 7 ? (has(self[7].matches) ? self[7].matches.size()
+                    : 0) : 0) + (self.size() > 8 ? (has(self[8].matches) ? self[8].matches.size()
+                    : 0) : 0) + (self.size() > 9 ? (has(self[9].matches) ? self[9].matches.size()
+                    : 0) : 0) + (self.size() > 10 ? (has(self[10].matches) ? self[10].matches.size()
+                    : 0) : 0) + (self.size() > 11 ? (has(self[11].matches) ? self[11].matches.size()
+                    : 0) : 0) + (self.size() > 12 ? (has(self[12].matches) ? self[12].matches.size()
+                    : 0) : 0) + (self.size() > 13 ? (has(self[13].matches) ? self[13].matches.size()
+                    : 0) : 0) + (self.size() > 14 ? (has(self[14].matches) ? self[14].matches.size()
+                    : 0) : 0) + (self.size() > 15 ? (has(self[15].matches) ? self[15].matches.size()
+                    : 0) : 0) <= 128'
+                - message: Rule name must be unique within the route
+                  rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name)
+                    && l1.name == l2.name))
             type: object
           status:
             description: Status defines the current state of GRPCRoute.
@@ -2059,12 +1960,10 @@ spec:
                   first sees the route and should update the entry as appropriate when the
                   route or gateway is modified.
 
-
                   Note that parent references that cannot be resolved by an implementation
                   of this API will not be added to this list. Implementations of this API
                   can only populate Route status for the Gateways/parent resources they are
                   responsible for.
-
 
                   A maximum of 32 Gateways will be represented in this list. An empty list
                   means the route has not been attached to any Gateway.
@@ -2079,38 +1978,24 @@ spec:
                         Note that the route's availability is also subject to the Gateway's own
                         status conditions and listener status.
 
-
                         If the Route's ParentRef specifies an existing Gateway that supports
                         Routes of this kind AND that Gateway's controller has sufficient access,
                         then that Gateway's controller MUST set the "Accepted" condition on the
                         Route, to indicate whether the route has been accepted or rejected by the
                         Gateway, and why.
 
-
                         A Route MUST be considered "Accepted" if at least one of the Route's
                         rules is implemented by the Gateway.
-
 
                         There are a number of cases where the "Accepted" condition may not be set
                         due to lack of controller visibility, that includes when:
 
-
-                        * The Route refers to a non-existent parent.
+                        * The Route refers to a nonexistent parent.
                         * The Route is of a type that the controller does not support.
                         * The Route is in a namespace the controller does not have access to.
                       items:
-                        description: "Condition contains details for one aspect of
-                          the current state of this API Resource.\n---\nThis struct
-                          is intended for direct use as an array at the field path
-                          .status.conditions.  For example,\n\n\n\ttype FooStatus
-                          struct{\n\t    // Represents the observations of a foo's
-                          current state.\n\t    // Known .status.conditions.type are:
-                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
-                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
-                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
-                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                          \   // other fields\n\t}"
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
                         properties:
                           lastTransitionTime:
                             description: |-
@@ -2152,12 +2037,7 @@ spec:
                             - Unknown
                             type: string
                           type:
-                            description: |-
-                              type of condition in CamelCase or in foo.example.com/CamelCase.
-                              ---
-                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                              useful (see .node.status.conditions), the ability to deconflict is important.
-                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
                             maxLength: 316
                             pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                             type: string
@@ -2180,14 +2060,11 @@ spec:
                         controller that wrote this status. This corresponds with the
                         controllerName field on GatewayClass.
 
-
                         Example: "example.net/gateway-controller".
-
 
                         The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
                         valid Kubernetes names
                         (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
-
 
                         Controllers MUST populate this field when writing status. Controllers should ensure that
                         entries to status populated with their ControllerName are cleaned up when they are no
@@ -2209,7 +2086,6 @@ spec:
                             To set the core API group (such as for a "Service" kind referent),
                             Group must be explicitly set to "" (empty string).
 
-
                             Support: Core
                           maxLength: 253
                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -2219,13 +2095,10 @@ spec:
                           description: |-
                             Kind is kind of the referent.
 
-
                             There are two kinds of parent resources with "Core" support:
-
 
                             * Gateway (Gateway conformance profile)
                             * Service (Mesh conformance profile, ClusterIP Services only)
-
 
                             Support for other resources is Implementation-Specific.
                           maxLength: 63
@@ -2236,7 +2109,6 @@ spec:
                           description: |-
                             Name is the name of the referent.
 
-
                             Support: Core
                           maxLength: 253
                           minLength: 1
@@ -2246,7 +2118,6 @@ spec:
                             Namespace is the namespace of the referent. When unspecified, this refers
                             to the local namespace of the Route.
 
-
                             Note that there are specific rules for ParentRefs which cross namespace
                             boundaries. Cross-namespace references are only valid if they are explicitly
                             allowed by something in the namespace they are referring to. For example:
@@ -2254,18 +2125,15 @@ spec:
                             generic way to enable any other kind of cross-namespace reference.
 
 
-
                             ParentRefs from a Route to a Service in the same namespace are "producer"
                             routes, which apply default routing rules to inbound connections from
                             any namespace to the Service.
-
 
                             ParentRefs from a Route to a Service in a different namespace are
                             "consumer" routes, and these routing rules are only applied to outbound
                             connections originating from the same namespace as the Route, for which
                             the intended destination of the connections are a Service targeted as a
                             ParentRef of the Route.
-
 
 
                             Support: Core
@@ -2278,7 +2146,6 @@ spec:
                             Port is the network port this Route targets. It can be interpreted
                             differently based on the type of parent resource.
 
-
                             When the parent resource is a Gateway, this targets all listeners
                             listening on the specified port that also support this kind of Route(and
                             select this Route). It's not recommended to set `Port` unless the
@@ -2288,17 +2155,14 @@ spec:
                             must match both specified values.
 
 
-
                             When the parent resource is a Service, this targets a specific port in the
                             Service spec. When both Port (experimental) and SectionName are specified,
                             the name and port of the selected port must match both specified values.
 
 
-
                             Implementations MAY choose to support other parent resources.
                             Implementations supporting other types of parent resources MUST clearly
                             document how/if Port is interpreted.
-
 
                             For the purpose of status, an attachment is considered successful as
                             long as the parent resource accepts it partially. For example, Gateway
@@ -2307,7 +2171,6 @@ spec:
                             from the referencing Route, the Route MUST be considered successfully
                             attached. If no Gateway listeners accept attachment from this Route,
                             the Route MUST be considered detached from the Gateway.
-
 
                             Support: Extended
                           format: int32
@@ -2319,7 +2182,6 @@ spec:
                             SectionName is the name of a section within the target resource. In the
                             following resources, SectionName is interpreted as the following:
 
-
                             * Gateway: Listener name. When both Port (experimental) and SectionName
                             are specified, the name and port of the selected listener must match
                             both specified values.
@@ -2327,11 +2189,9 @@ spec:
                             are specified, the name and port of the selected listener must match
                             both specified values.
 
-
                             Implementations MAY choose to support attaching Routes to other resources.
                             If that is the case, they MUST clearly document how SectionName is
                             interpreted.
-
 
                             When unspecified (empty string), this will reference the entire resource.
                             For the purpose of status, an attachment is considered successful if at
@@ -2341,7 +2201,6 @@ spec:
                             the referencing Route, the Route MUST be considered successfully
                             attached. If no Gateway listeners accept attachment from this Route, the
                             Route MUST be considered detached from the Gateway.
-
 
                             Support: Core
                           maxLength: 253
@@ -2365,2331 +2224,6 @@ spec:
     storage: true
     subresources:
       status: {}
-  - deprecated: true
-    deprecationWarning: The v1alpha2 version of GRPCRoute has been deprecated and
-      will be removed in a future release of the API. Please upgrade to v1.
-    name: v1alpha2
-    schema:
-      openAPIV3Schema:
-        description: |-
-          GRPCRoute provides a way to route gRPC requests. This includes the capability
-          to match requests by hostname, gRPC service, gRPC method, or HTTP/2 header.
-          Filters can be used to specify additional processing steps. Backends specify
-          where matching requests will be routed.
-
-
-          GRPCRoute falls under extended support within the Gateway API. Within the
-          following specification, the word "MUST" indicates that an implementation
-          supporting GRPCRoute must conform to the indicated requirement, but an
-          implementation not supporting this route type need not follow the requirement
-          unless explicitly indicated.
-
-
-          Implementations supporting `GRPCRoute` with the `HTTPS` `ProtocolType` MUST
-          accept HTTP/2 connections without an initial upgrade from HTTP/1.1, i.e. via
-          ALPN. If the implementation does not support this, then it MUST set the
-          "Accepted" condition to "False" for the affected listener with a reason of
-          "UnsupportedProtocol".  Implementations MAY also accept HTTP/2 connections
-          with an upgrade from HTTP/1.
-
-
-          Implementations supporting `GRPCRoute` with the `HTTP` `ProtocolType` MUST
-          support HTTP/2 over cleartext TCP (h2c,
-          https://www.rfc-editor.org/rfc/rfc7540#section-3.1) without an initial
-          upgrade from HTTP/1.1, i.e. with prior knowledge
-          (https://www.rfc-editor.org/rfc/rfc7540#section-3.4). If the implementation
-          does not support this, then it MUST set the "Accepted" condition to "False"
-          for the affected listener with a reason of "UnsupportedProtocol".
-          Implementations MAY also accept HTTP/2 connections with an upgrade from
-          HTTP/1, i.e. without prior knowledge.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec defines the desired state of GRPCRoute.
-            properties:
-              hostnames:
-                description: |-
-                  Hostnames defines a set of hostnames to match against the GRPC
-                  Host header to select a GRPCRoute to process the request. This matches
-                  the RFC 1123 definition of a hostname with 2 notable exceptions:
-
-
-                  1. IPs are not allowed.
-                  2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
-                     label MUST appear by itself as the first label.
-
-
-                  If a hostname is specified by both the Listener and GRPCRoute, there
-                  MUST be at least one intersecting hostname for the GRPCRoute to be
-                  attached to the Listener. For example:
-
-
-                  * A Listener with `test.example.com` as the hostname matches GRPCRoutes
-                    that have either not specified any hostnames, or have specified at
-                    least one of `test.example.com` or `*.example.com`.
-                  * A Listener with `*.example.com` as the hostname matches GRPCRoutes
-                    that have either not specified any hostnames or have specified at least
-                    one hostname that matches the Listener hostname. For example,
-                    `test.example.com` and `*.example.com` would both match. On the other
-                    hand, `example.com` and `test.example.net` would not match.
-
-
-                  Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
-                  as a suffix match. That means that a match for `*.example.com` would match
-                  both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
-
-
-                  If both the Listener and GRPCRoute have specified hostnames, any
-                  GRPCRoute hostnames that do not match the Listener hostname MUST be
-                  ignored. For example, if a Listener specified `*.example.com`, and the
-                  GRPCRoute specified `test.example.com` and `test.example.net`,
-                  `test.example.net` MUST NOT be considered for a match.
-
-
-                  If both the Listener and GRPCRoute have specified hostnames, and none
-                  match with the criteria above, then the GRPCRoute MUST NOT be accepted by
-                  the implementation. The implementation MUST raise an 'Accepted' Condition
-                  with a status of `False` in the corresponding RouteParentStatus.
-
-
-                  If a Route (A) of type HTTPRoute or GRPCRoute is attached to a
-                  Listener and that listener already has another Route (B) of the other
-                  type attached and the intersection of the hostnames of A and B is
-                  non-empty, then the implementation MUST accept exactly one of these two
-                  routes, determined by the following criteria, in order:
-
-
-                  * The oldest Route based on creation timestamp.
-                  * The Route appearing first in alphabetical order by
-                    "{namespace}/{name}".
-
-
-                  The rejected Route MUST raise an 'Accepted' condition with a status of
-                  'False' in the corresponding RouteParentStatus.
-
-
-                  Support: Core
-                items:
-                  description: |-
-                    Hostname is the fully qualified domain name of a network host. This matches
-                    the RFC 1123 definition of a hostname with 2 notable exceptions:
-
-
-                     1. IPs are not allowed.
-                     2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
-                        label must appear by itself as the first label.
-
-
-                    Hostname can be "precise" which is a domain name without the terminating
-                    dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
-                    domain name prefixed with a single wildcard label (e.g. `*.example.com`).
-
-
-                    Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
-                    alphanumeric characters or '-', and must start and end with an alphanumeric
-                    character. No other punctuation is allowed.
-                  maxLength: 253
-                  minLength: 1
-                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                  type: string
-                maxItems: 16
-                type: array
-              parentRefs:
-                description: |+
-                  ParentRefs references the resources (usually Gateways) that a Route wants
-                  to be attached to. Note that the referenced parent resource needs to
-                  allow this for the attachment to be complete. For Gateways, that means
-                  the Gateway needs to allow attachment from Routes of this kind and
-                  namespace. For Services, that means the Service must either be in the same
-                  namespace for a "producer" route, or the mesh implementation must support
-                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
-                  not applicable for governing ParentRefs to Services - it is not possible to
-                  create a "producer" route for a Service in a different namespace from the
-                  Route.
-
-
-                  There are two kinds of parent resources with "Core" support:
-
-
-                  * Gateway (Gateway conformance profile)
-                  * Service (Mesh conformance profile, ClusterIP Services only)
-
-
-                  This API may be extended in the future to support additional kinds of parent
-                  resources.
-
-
-                  ParentRefs must be _distinct_. This means either that:
-
-
-                  * They select different objects.  If this is the case, then parentRef
-                    entries are distinct. In terms of fields, this means that the
-                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
-                    be unique across all parentRef entries in the Route.
-                  * They do not select different objects, but for each optional field used,
-                    each ParentRef that selects the same object must set the same set of
-                    optional fields to different values. If one ParentRef sets a
-                    combination of optional fields, all must set the same combination.
-
-
-                  Some examples:
-
-
-                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
-                    same object must also set `sectionName`.
-                  * If one ParentRef sets `port`, all ParentRefs referencing the same
-                    object must also set `port`.
-                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
-                    referencing the same object must also set `sectionName` and `port`.
-
-
-                  It is possible to separately reference multiple distinct objects that may
-                  be collapsed by an implementation. For example, some implementations may
-                  choose to merge compatible Gateway Listeners together. If that is the
-                  case, the list of routes attached to those resources should also be
-                  merged.
-
-
-                  Note that for ParentRefs that cross namespace boundaries, there are specific
-                  rules. Cross-namespace references are only valid if they are explicitly
-                  allowed by something in the namespace they are referring to. For example,
-                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
-                  generic way to enable other kinds of cross-namespace reference.
-
-
-
-                  ParentRefs from a Route to a Service in the same namespace are "producer"
-                  routes, which apply default routing rules to inbound connections from
-                  any namespace to the Service.
-
-
-                  ParentRefs from a Route to a Service in a different namespace are
-                  "consumer" routes, and these routing rules are only applied to outbound
-                  connections originating from the same namespace as the Route, for which
-                  the intended destination of the connections are a Service targeted as a
-                  ParentRef of the Route.
-
-
-
-
-
-
-                items:
-                  description: |-
-                    ParentReference identifies an API object (usually a Gateway) that can be considered
-                    a parent of this resource (usually a route). There are two kinds of parent resources
-                    with "Core" support:
-
-
-                    * Gateway (Gateway conformance profile)
-                    * Service (Mesh conformance profile, ClusterIP Services only)
-
-
-                    This API may be extended in the future to support additional kinds of parent
-                    resources.
-
-
-                    The API object must be valid in the cluster; the Group and Kind must
-                    be registered in the cluster for this reference to be valid.
-                  properties:
-                    group:
-                      default: gateway.networking.k8s.io
-                      description: |-
-                        Group is the group of the referent.
-                        When unspecified, "gateway.networking.k8s.io" is inferred.
-                        To set the core API group (such as for a "Service" kind referent),
-                        Group must be explicitly set to "" (empty string).
-
-
-                        Support: Core
-                      maxLength: 253
-                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                      type: string
-                    kind:
-                      default: Gateway
-                      description: |-
-                        Kind is kind of the referent.
-
-
-                        There are two kinds of parent resources with "Core" support:
-
-
-                        * Gateway (Gateway conformance profile)
-                        * Service (Mesh conformance profile, ClusterIP Services only)
-
-
-                        Support for other resources is Implementation-Specific.
-                      maxLength: 63
-                      minLength: 1
-                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                      type: string
-                    name:
-                      description: |-
-                        Name is the name of the referent.
-
-
-                        Support: Core
-                      maxLength: 253
-                      minLength: 1
-                      type: string
-                    namespace:
-                      description: |-
-                        Namespace is the namespace of the referent. When unspecified, this refers
-                        to the local namespace of the Route.
-
-
-                        Note that there are specific rules for ParentRefs which cross namespace
-                        boundaries. Cross-namespace references are only valid if they are explicitly
-                        allowed by something in the namespace they are referring to. For example:
-                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
-                        generic way to enable any other kind of cross-namespace reference.
-
-
-
-                        ParentRefs from a Route to a Service in the same namespace are "producer"
-                        routes, which apply default routing rules to inbound connections from
-                        any namespace to the Service.
-
-
-                        ParentRefs from a Route to a Service in a different namespace are
-                        "consumer" routes, and these routing rules are only applied to outbound
-                        connections originating from the same namespace as the Route, for which
-                        the intended destination of the connections are a Service targeted as a
-                        ParentRef of the Route.
-
-
-
-                        Support: Core
-                      maxLength: 63
-                      minLength: 1
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                      type: string
-                    port:
-                      description: |-
-                        Port is the network port this Route targets. It can be interpreted
-                        differently based on the type of parent resource.
-
-
-                        When the parent resource is a Gateway, this targets all listeners
-                        listening on the specified port that also support this kind of Route(and
-                        select this Route). It's not recommended to set `Port` unless the
-                        networking behaviors specified in a Route must apply to a specific port
-                        as opposed to a listener(s) whose port(s) may be changed. When both Port
-                        and SectionName are specified, the name and port of the selected listener
-                        must match both specified values.
-
-
-
-                        When the parent resource is a Service, this targets a specific port in the
-                        Service spec. When both Port (experimental) and SectionName are specified,
-                        the name and port of the selected port must match both specified values.
-
-
-
-                        Implementations MAY choose to support other parent resources.
-                        Implementations supporting other types of parent resources MUST clearly
-                        document how/if Port is interpreted.
-
-
-                        For the purpose of status, an attachment is considered successful as
-                        long as the parent resource accepts it partially. For example, Gateway
-                        listeners can restrict which Routes can attach to them by Route kind,
-                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
-                        from the referencing Route, the Route MUST be considered successfully
-                        attached. If no Gateway listeners accept attachment from this Route,
-                        the Route MUST be considered detached from the Gateway.
-
-
-                        Support: Extended
-                      format: int32
-                      maximum: 65535
-                      minimum: 1
-                      type: integer
-                    sectionName:
-                      description: |-
-                        SectionName is the name of a section within the target resource. In the
-                        following resources, SectionName is interpreted as the following:
-
-
-                        * Gateway: Listener name. When both Port (experimental) and SectionName
-                        are specified, the name and port of the selected listener must match
-                        both specified values.
-                        * Service: Port name. When both Port (experimental) and SectionName
-                        are specified, the name and port of the selected listener must match
-                        both specified values.
-
-
-                        Implementations MAY choose to support attaching Routes to other resources.
-                        If that is the case, they MUST clearly document how SectionName is
-                        interpreted.
-
-
-                        When unspecified (empty string), this will reference the entire resource.
-                        For the purpose of status, an attachment is considered successful if at
-                        least one section in the parent resource accepts it. For example, Gateway
-                        listeners can restrict which Routes can attach to them by Route kind,
-                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
-                        the referencing Route, the Route MUST be considered successfully
-                        attached. If no Gateway listeners accept attachment from this Route, the
-                        Route MUST be considered detached from the Gateway.
-
-
-                        Support: Core
-                      maxLength: 253
-                      minLength: 1
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                      type: string
-                  required:
-                  - name
-                  type: object
-                maxItems: 32
-                type: array
-                x-kubernetes-validations:
-                - message: sectionName or port must be specified when parentRefs includes
-                    2 or more references to the same parent
-                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
-                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
-                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
-                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
-                    p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName)
-                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
-                    == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port)
-                    || p2.port == 0)): true))'
-                - message: sectionName or port must be unique when parentRefs includes
-                    2 or more references to the same parent
-                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
-                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
-                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
-                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
-                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
-                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
-                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
-                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
-                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
-                    == p2.port))))
-              rules:
-                description: Rules are a list of GRPC matchers, filters and actions.
-                items:
-                  description: |-
-                    GRPCRouteRule defines the semantics for matching a gRPC request based on
-                    conditions (matches), processing it (filters), and forwarding the request to
-                    an API object (backendRefs).
-                  properties:
-                    backendRefs:
-                      description: |-
-                        BackendRefs defines the backend(s) where matching requests should be
-                        sent.
-
-
-                        Failure behavior here depends on how many BackendRefs are specified and
-                        how many are invalid.
-
-
-                        If *all* entries in BackendRefs are invalid, and there are also no filters
-                        specified in this route rule, *all* traffic which matches this rule MUST
-                        receive an `UNAVAILABLE` status.
-
-
-                        See the GRPCBackendRef definition for the rules about what makes a single
-                        GRPCBackendRef invalid.
-
-
-                        When a GRPCBackendRef is invalid, `UNAVAILABLE` statuses MUST be returned for
-                        requests that would have otherwise been routed to an invalid backend. If
-                        multiple backends are specified, and some are invalid, the proportion of
-                        requests that would otherwise have been routed to an invalid backend
-                        MUST receive an `UNAVAILABLE` status.
-
-
-                        For example, if two backends are specified with equal weights, and one is
-                        invalid, 50 percent of traffic MUST receive an `UNAVAILABLE` status.
-                        Implementations may choose how that 50 percent is determined.
-
-
-                        Support: Core for Kubernetes Service
-
-
-                        Support: Implementation-specific for any other resource
-
-
-                        Support for weight: Core
-                      items:
-                        description: |-
-                          GRPCBackendRef defines how a GRPCRoute forwards a gRPC request.
-
-
-                          Note that when a namespace different than the local namespace is specified, a
-                          ReferenceGrant object is required in the referent namespace to allow that
-                          namespace's owner to accept the reference. See the ReferenceGrant
-                          documentation for details.
-
-
-                          <gateway:experimental:description>
-
-
-                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
-                          honor the appProtocol field if it is set for the target Service Port.
-
-
-                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
-                          Standard Application Protocols defined in KEP-3726.
-
-
-                          If a Service appProtocol isn't specified, an implementation MAY infer the
-                          backend protocol through its own means. Implementations MAY infer the
-                          protocol from the Route type referring to the backend Service.
-
-
-                          If a Route is not able to send traffic to the backend using the specified
-                          protocol then the backend is considered invalid. Implementations MUST set the
-                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
-
-
-                          </gateway:experimental:description>
-                        properties:
-                          filters:
-                            description: |-
-                              Filters defined at this level MUST be executed if and only if the
-                              request is being forwarded to the backend defined here.
-
-
-                              Support: Implementation-specific (For broader support of filters, use the
-                              Filters field in GRPCRouteRule.)
-                            items:
-                              description: |-
-                                GRPCRouteFilter defines processing steps that must be completed during the
-                                request or response lifecycle. GRPCRouteFilters are meant as an extension
-                                point to express processing that may be done in Gateway implementations. Some
-                                examples include request or response modification, implementing
-                                authentication strategies, rate-limiting, and traffic shaping. API
-                                guarantee/conformance is defined based on the type of the filter.
-                              properties:
-                                extensionRef:
-                                  description: |-
-                                    ExtensionRef is an optional, implementation-specific extension to the
-                                    "filter" behavior.  For example, resource "myroutefilter" in group
-                                    "networking.example.net"). ExtensionRef MUST NOT be used for core and
-                                    extended filters.
-
-
-                                    Support: Implementation-specific
-
-
-                                    This filter can be used multiple times within the same rule.
-                                  properties:
-                                    group:
-                                      description: |-
-                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                        When unspecified or empty string, core API group is inferred.
-                                      maxLength: 253
-                                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                      type: string
-                                    kind:
-                                      description: Kind is kind of the referent. For
-                                        example "HTTPRoute" or "Service".
-                                      maxLength: 63
-                                      minLength: 1
-                                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                      type: string
-                                    name:
-                                      description: Name is the name of the referent.
-                                      maxLength: 253
-                                      minLength: 1
-                                      type: string
-                                  required:
-                                  - group
-                                  - kind
-                                  - name
-                                  type: object
-                                requestHeaderModifier:
-                                  description: |-
-                                    RequestHeaderModifier defines a schema for a filter that modifies request
-                                    headers.
-
-
-                                    Support: Core
-                                  properties:
-                                    add:
-                                      description: |-
-                                        Add adds the given header(s) (name, value) to the request
-                                        before the action. It appends to any existing values associated
-                                        with the header name.
-
-
-                                        Input:
-                                          GET /foo HTTP/1.1
-                                          my-header: foo
-
-
-                                        Config:
-                                          add:
-                                          - name: "my-header"
-                                            value: "bar,baz"
-
-
-                                        Output:
-                                          GET /foo HTTP/1.1
-                                          my-header: foo,bar,baz
-                                      items:
-                                        description: HTTPHeader represents an HTTP
-                                          Header name and value as defined by RFC
-                                          7230.
-                                        properties:
-                                          name:
-                                            description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
-
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
-                                            maxLength: 256
-                                            minLength: 1
-                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
-                                            type: string
-                                          value:
-                                            description: Value is the value of HTTP
-                                              Header to be matched.
-                                            maxLength: 4096
-                                            minLength: 1
-                                            type: string
-                                        required:
-                                        - name
-                                        - value
-                                        type: object
-                                      maxItems: 16
-                                      type: array
-                                      x-kubernetes-list-map-keys:
-                                      - name
-                                      x-kubernetes-list-type: map
-                                    remove:
-                                      description: |-
-                                        Remove the given header(s) from the HTTP request before the action. The
-                                        value of Remove is a list of HTTP header names. Note that the header
-                                        names are case-insensitive (see
-                                        https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
-
-
-                                        Input:
-                                          GET /foo HTTP/1.1
-                                          my-header1: foo
-                                          my-header2: bar
-                                          my-header3: baz
-
-
-                                        Config:
-                                          remove: ["my-header1", "my-header3"]
-
-
-                                        Output:
-                                          GET /foo HTTP/1.1
-                                          my-header2: bar
-                                      items:
-                                        type: string
-                                      maxItems: 16
-                                      type: array
-                                      x-kubernetes-list-type: set
-                                    set:
-                                      description: |-
-                                        Set overwrites the request with the given header (name, value)
-                                        before the action.
-
-
-                                        Input:
-                                          GET /foo HTTP/1.1
-                                          my-header: foo
-
-
-                                        Config:
-                                          set:
-                                          - name: "my-header"
-                                            value: "bar"
-
-
-                                        Output:
-                                          GET /foo HTTP/1.1
-                                          my-header: bar
-                                      items:
-                                        description: HTTPHeader represents an HTTP
-                                          Header name and value as defined by RFC
-                                          7230.
-                                        properties:
-                                          name:
-                                            description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
-
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
-                                            maxLength: 256
-                                            minLength: 1
-                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
-                                            type: string
-                                          value:
-                                            description: Value is the value of HTTP
-                                              Header to be matched.
-                                            maxLength: 4096
-                                            minLength: 1
-                                            type: string
-                                        required:
-                                        - name
-                                        - value
-                                        type: object
-                                      maxItems: 16
-                                      type: array
-                                      x-kubernetes-list-map-keys:
-                                      - name
-                                      x-kubernetes-list-type: map
-                                  type: object
-                                requestMirror:
-                                  description: |-
-                                    RequestMirror defines a schema for a filter that mirrors requests.
-                                    Requests are sent to the specified destination, but responses from
-                                    that destination are ignored.
-
-
-                                    This filter can be used multiple times within the same rule. Note that
-                                    not all implementations will be able to support mirroring to multiple
-                                    backends.
-
-
-                                    Support: Extended
-                                  properties:
-                                    backendRef:
-                                      description: |-
-                                        BackendRef references a resource where mirrored requests are sent.
-
-
-                                        Mirrored requests must be sent only to a single destination endpoint
-                                        within this BackendRef, irrespective of how many endpoints are present
-                                        within this BackendRef.
-
-
-                                        If the referent cannot be found, this BackendRef is invalid and must be
-                                        dropped from the Gateway. The controller must ensure the "ResolvedRefs"
-                                        condition on the Route status is set to `status: False` and not configure
-                                        this backend in the underlying implementation.
-
-
-                                        If there is a cross-namespace reference to an *existing* object
-                                        that is not allowed by a ReferenceGrant, the controller must ensure the
-                                        "ResolvedRefs"  condition on the Route is set to `status: False`,
-                                        with the "RefNotPermitted" reason and not configure this backend in the
-                                        underlying implementation.
-
-
-                                        In either error case, the Message of the `ResolvedRefs` Condition
-                                        should be used to provide more detail about the problem.
-
-
-                                        Support: Extended for Kubernetes Service
-
-
-                                        Support: Implementation-specific for any other resource
-                                      properties:
-                                        group:
-                                          default: ""
-                                          description: |-
-                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                            When unspecified or empty string, core API group is inferred.
-                                          maxLength: 253
-                                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                          type: string
-                                        kind:
-                                          default: Service
-                                          description: |-
-                                            Kind is the Kubernetes resource kind of the referent. For example
-                                            "Service".
-
-
-                                            Defaults to "Service" when not specified.
-
-
-                                            ExternalName services can refer to CNAME DNS records that may live
-                                            outside of the cluster and as such are difficult to reason about in
-                                            terms of conformance. They also may not be safe to forward to (see
-                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                            support ExternalName Services.
-
-
-                                            Support: Core (Services with a type other than ExternalName)
-
-
-                                            Support: Implementation-specific (Services with type ExternalName)
-                                          maxLength: 63
-                                          minLength: 1
-                                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                          type: string
-                                        name:
-                                          description: Name is the name of the referent.
-                                          maxLength: 253
-                                          minLength: 1
-                                          type: string
-                                        namespace:
-                                          description: |-
-                                            Namespace is the namespace of the backend. When unspecified, the local
-                                            namespace is inferred.
-
-
-                                            Note that when a namespace different than the local namespace is specified,
-                                            a ReferenceGrant object is required in the referent namespace to allow that
-                                            namespace's owner to accept the reference. See the ReferenceGrant
-                                            documentation for details.
-
-
-                                            Support: Core
-                                          maxLength: 63
-                                          minLength: 1
-                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                                          type: string
-                                        port:
-                                          description: |-
-                                            Port specifies the destination port number to use for this resource.
-                                            Port is required when the referent is a Kubernetes Service. In this
-                                            case, the port number is the service port number, not the target port.
-                                            For other resources, destination port might be derived from the referent
-                                            resource or this field.
-                                          format: int32
-                                          maximum: 65535
-                                          minimum: 1
-                                          type: integer
-                                      required:
-                                      - name
-                                      type: object
-                                      x-kubernetes-validations:
-                                      - message: Must have port for Service reference
-                                        rule: '(size(self.group) == 0 && self.kind
-                                          == ''Service'') ? has(self.port) : true'
-                                  required:
-                                  - backendRef
-                                  type: object
-                                responseHeaderModifier:
-                                  description: |-
-                                    ResponseHeaderModifier defines a schema for a filter that modifies response
-                                    headers.
-
-
-                                    Support: Extended
-                                  properties:
-                                    add:
-                                      description: |-
-                                        Add adds the given header(s) (name, value) to the request
-                                        before the action. It appends to any existing values associated
-                                        with the header name.
-
-
-                                        Input:
-                                          GET /foo HTTP/1.1
-                                          my-header: foo
-
-
-                                        Config:
-                                          add:
-                                          - name: "my-header"
-                                            value: "bar,baz"
-
-
-                                        Output:
-                                          GET /foo HTTP/1.1
-                                          my-header: foo,bar,baz
-                                      items:
-                                        description: HTTPHeader represents an HTTP
-                                          Header name and value as defined by RFC
-                                          7230.
-                                        properties:
-                                          name:
-                                            description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
-
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
-                                            maxLength: 256
-                                            minLength: 1
-                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
-                                            type: string
-                                          value:
-                                            description: Value is the value of HTTP
-                                              Header to be matched.
-                                            maxLength: 4096
-                                            minLength: 1
-                                            type: string
-                                        required:
-                                        - name
-                                        - value
-                                        type: object
-                                      maxItems: 16
-                                      type: array
-                                      x-kubernetes-list-map-keys:
-                                      - name
-                                      x-kubernetes-list-type: map
-                                    remove:
-                                      description: |-
-                                        Remove the given header(s) from the HTTP request before the action. The
-                                        value of Remove is a list of HTTP header names. Note that the header
-                                        names are case-insensitive (see
-                                        https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
-
-
-                                        Input:
-                                          GET /foo HTTP/1.1
-                                          my-header1: foo
-                                          my-header2: bar
-                                          my-header3: baz
-
-
-                                        Config:
-                                          remove: ["my-header1", "my-header3"]
-
-
-                                        Output:
-                                          GET /foo HTTP/1.1
-                                          my-header2: bar
-                                      items:
-                                        type: string
-                                      maxItems: 16
-                                      type: array
-                                      x-kubernetes-list-type: set
-                                    set:
-                                      description: |-
-                                        Set overwrites the request with the given header (name, value)
-                                        before the action.
-
-
-                                        Input:
-                                          GET /foo HTTP/1.1
-                                          my-header: foo
-
-
-                                        Config:
-                                          set:
-                                          - name: "my-header"
-                                            value: "bar"
-
-
-                                        Output:
-                                          GET /foo HTTP/1.1
-                                          my-header: bar
-                                      items:
-                                        description: HTTPHeader represents an HTTP
-                                          Header name and value as defined by RFC
-                                          7230.
-                                        properties:
-                                          name:
-                                            description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
-
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
-                                            maxLength: 256
-                                            minLength: 1
-                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
-                                            type: string
-                                          value:
-                                            description: Value is the value of HTTP
-                                              Header to be matched.
-                                            maxLength: 4096
-                                            minLength: 1
-                                            type: string
-                                        required:
-                                        - name
-                                        - value
-                                        type: object
-                                      maxItems: 16
-                                      type: array
-                                      x-kubernetes-list-map-keys:
-                                      - name
-                                      x-kubernetes-list-type: map
-                                  type: object
-                                type:
-                                  description: |+
-                                    Type identifies the type of filter to apply. As with other API fields,
-                                    types are classified into three conformance levels:
-
-
-                                    - Core: Filter types and their corresponding configuration defined by
-                                      "Support: Core" in this package, e.g. "RequestHeaderModifier". All
-                                      implementations supporting GRPCRoute MUST support core filters.
-
-
-                                    - Extended: Filter types and their corresponding configuration defined by
-                                      "Support: Extended" in this package, e.g. "RequestMirror". Implementers
-                                      are encouraged to support extended filters.
-
-
-                                    - Implementation-specific: Filters that are defined and supported by specific vendors.
-                                      In the future, filters showing convergence in behavior across multiple
-                                      implementations will be considered for inclusion in extended or core
-                                      conformance levels. Filter-specific configuration for such filters
-                                      is specified using the ExtensionRef field. `Type` MUST be set to
-                                      "ExtensionRef" for custom filters.
-
-
-                                    Implementers are encouraged to define custom implementation types to
-                                    extend the core API with implementation-specific behavior.
-
-
-                                    If a reference to a custom filter type cannot be resolved, the filter
-                                    MUST NOT be skipped. Instead, requests that would have been processed by
-                                    that filter MUST receive a HTTP error response.
-
-
-                                  enum:
-                                  - ResponseHeaderModifier
-                                  - RequestHeaderModifier
-                                  - RequestMirror
-                                  - ExtensionRef
-                                  type: string
-                              required:
-                              - type
-                              type: object
-                              x-kubernetes-validations:
-                              - message: filter.requestHeaderModifier must be nil
-                                  if the filter.type is not RequestHeaderModifier
-                                rule: '!(has(self.requestHeaderModifier) && self.type
-                                  != ''RequestHeaderModifier'')'
-                              - message: filter.requestHeaderModifier must be specified
-                                  for RequestHeaderModifier filter.type
-                                rule: '!(!has(self.requestHeaderModifier) && self.type
-                                  == ''RequestHeaderModifier'')'
-                              - message: filter.responseHeaderModifier must be nil
-                                  if the filter.type is not ResponseHeaderModifier
-                                rule: '!(has(self.responseHeaderModifier) && self.type
-                                  != ''ResponseHeaderModifier'')'
-                              - message: filter.responseHeaderModifier must be specified
-                                  for ResponseHeaderModifier filter.type
-                                rule: '!(!has(self.responseHeaderModifier) && self.type
-                                  == ''ResponseHeaderModifier'')'
-                              - message: filter.requestMirror must be nil if the filter.type
-                                  is not RequestMirror
-                                rule: '!(has(self.requestMirror) && self.type != ''RequestMirror'')'
-                              - message: filter.requestMirror must be specified for
-                                  RequestMirror filter.type
-                                rule: '!(!has(self.requestMirror) && self.type ==
-                                  ''RequestMirror'')'
-                              - message: filter.extensionRef must be nil if the filter.type
-                                  is not ExtensionRef
-                                rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
-                              - message: filter.extensionRef must be specified for
-                                  ExtensionRef filter.type
-                                rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
-                            maxItems: 16
-                            type: array
-                            x-kubernetes-validations:
-                            - message: RequestHeaderModifier filter cannot be repeated
-                              rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
-                                <= 1
-                            - message: ResponseHeaderModifier filter cannot be repeated
-                              rule: self.filter(f, f.type == 'ResponseHeaderModifier').size()
-                                <= 1
-                          group:
-                            default: ""
-                            description: |-
-                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                              When unspecified or empty string, core API group is inferred.
-                            maxLength: 253
-                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                            type: string
-                          kind:
-                            default: Service
-                            description: |-
-                              Kind is the Kubernetes resource kind of the referent. For example
-                              "Service".
-
-
-                              Defaults to "Service" when not specified.
-
-
-                              ExternalName services can refer to CNAME DNS records that may live
-                              outside of the cluster and as such are difficult to reason about in
-                              terms of conformance. They also may not be safe to forward to (see
-                              CVE-2021-25740 for more information). Implementations SHOULD NOT
-                              support ExternalName Services.
-
-
-                              Support: Core (Services with a type other than ExternalName)
-
-
-                              Support: Implementation-specific (Services with type ExternalName)
-                            maxLength: 63
-                            minLength: 1
-                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                            type: string
-                          name:
-                            description: Name is the name of the referent.
-                            maxLength: 253
-                            minLength: 1
-                            type: string
-                          namespace:
-                            description: |-
-                              Namespace is the namespace of the backend. When unspecified, the local
-                              namespace is inferred.
-
-
-                              Note that when a namespace different than the local namespace is specified,
-                              a ReferenceGrant object is required in the referent namespace to allow that
-                              namespace's owner to accept the reference. See the ReferenceGrant
-                              documentation for details.
-
-
-                              Support: Core
-                            maxLength: 63
-                            minLength: 1
-                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                            type: string
-                          port:
-                            description: |-
-                              Port specifies the destination port number to use for this resource.
-                              Port is required when the referent is a Kubernetes Service. In this
-                              case, the port number is the service port number, not the target port.
-                              For other resources, destination port might be derived from the referent
-                              resource or this field.
-                            format: int32
-                            maximum: 65535
-                            minimum: 1
-                            type: integer
-                          weight:
-                            default: 1
-                            description: |-
-                              Weight specifies the proportion of requests forwarded to the referenced
-                              backend. This is computed as weight/(sum of all weights in this
-                              BackendRefs list). For non-zero values, there may be some epsilon from
-                              the exact proportion defined here depending on the precision an
-                              implementation supports. Weight is not a percentage and the sum of
-                              weights does not need to equal 100.
-
-
-                              If only one backend is specified and it has a weight greater than 0, 100%
-                              of the traffic is forwarded to that backend. If weight is set to 0, no
-                              traffic should be forwarded for this entry. If unspecified, weight
-                              defaults to 1.
-
-
-                              Support for this field varies based on the context where used.
-                            format: int32
-                            maximum: 1000000
-                            minimum: 0
-                            type: integer
-                        required:
-                        - name
-                        type: object
-                        x-kubernetes-validations:
-                        - message: Must have port for Service reference
-                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
-                            ? has(self.port) : true'
-                      maxItems: 16
-                      type: array
-                    filters:
-                      description: |-
-                        Filters define the filters that are applied to requests that match
-                        this rule.
-
-
-                        The effects of ordering of multiple behaviors are currently unspecified.
-                        This can change in the future based on feedback during the alpha stage.
-
-
-                        Conformance-levels at this level are defined based on the type of filter:
-
-
-                        - ALL core filters MUST be supported by all implementations that support
-                          GRPCRoute.
-                        - Implementers are encouraged to support extended filters.
-                        - Implementation-specific custom filters have no API guarantees across
-                          implementations.
-
-
-                        Specifying the same filter multiple times is not supported unless explicitly
-                        indicated in the filter.
-
-
-                        If an implementation can not support a combination of filters, it must clearly
-                        document that limitation. In cases where incompatible or unsupported
-                        filters are specified and cause the `Accepted` condition to be set to status
-                        `False`, implementations may use the `IncompatibleFilters` reason to specify
-                        this configuration error.
-
-
-                        Support: Core
-                      items:
-                        description: |-
-                          GRPCRouteFilter defines processing steps that must be completed during the
-                          request or response lifecycle. GRPCRouteFilters are meant as an extension
-                          point to express processing that may be done in Gateway implementations. Some
-                          examples include request or response modification, implementing
-                          authentication strategies, rate-limiting, and traffic shaping. API
-                          guarantee/conformance is defined based on the type of the filter.
-                        properties:
-                          extensionRef:
-                            description: |-
-                              ExtensionRef is an optional, implementation-specific extension to the
-                              "filter" behavior.  For example, resource "myroutefilter" in group
-                              "networking.example.net"). ExtensionRef MUST NOT be used for core and
-                              extended filters.
-
-
-                              Support: Implementation-specific
-
-
-                              This filter can be used multiple times within the same rule.
-                            properties:
-                              group:
-                                description: |-
-                                  Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                  When unspecified or empty string, core API group is inferred.
-                                maxLength: 253
-                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                type: string
-                              kind:
-                                description: Kind is kind of the referent. For example
-                                  "HTTPRoute" or "Service".
-                                maxLength: 63
-                                minLength: 1
-                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                type: string
-                              name:
-                                description: Name is the name of the referent.
-                                maxLength: 253
-                                minLength: 1
-                                type: string
-                            required:
-                            - group
-                            - kind
-                            - name
-                            type: object
-                          requestHeaderModifier:
-                            description: |-
-                              RequestHeaderModifier defines a schema for a filter that modifies request
-                              headers.
-
-
-                              Support: Core
-                            properties:
-                              add:
-                                description: |-
-                                  Add adds the given header(s) (name, value) to the request
-                                  before the action. It appends to any existing values associated
-                                  with the header name.
-
-
-                                  Input:
-                                    GET /foo HTTP/1.1
-                                    my-header: foo
-
-
-                                  Config:
-                                    add:
-                                    - name: "my-header"
-                                      value: "bar,baz"
-
-
-                                  Output:
-                                    GET /foo HTTP/1.1
-                                    my-header: foo,bar,baz
-                                items:
-                                  description: HTTPHeader represents an HTTP Header
-                                    name and value as defined by RFC 7230.
-                                  properties:
-                                    name:
-                                      description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
-
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
-                                      maxLength: 256
-                                      minLength: 1
-                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
-                                      type: string
-                                    value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
-                                      maxLength: 4096
-                                      minLength: 1
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                maxItems: 16
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                - name
-                                x-kubernetes-list-type: map
-                              remove:
-                                description: |-
-                                  Remove the given header(s) from the HTTP request before the action. The
-                                  value of Remove is a list of HTTP header names. Note that the header
-                                  names are case-insensitive (see
-                                  https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
-
-
-                                  Input:
-                                    GET /foo HTTP/1.1
-                                    my-header1: foo
-                                    my-header2: bar
-                                    my-header3: baz
-
-
-                                  Config:
-                                    remove: ["my-header1", "my-header3"]
-
-
-                                  Output:
-                                    GET /foo HTTP/1.1
-                                    my-header2: bar
-                                items:
-                                  type: string
-                                maxItems: 16
-                                type: array
-                                x-kubernetes-list-type: set
-                              set:
-                                description: |-
-                                  Set overwrites the request with the given header (name, value)
-                                  before the action.
-
-
-                                  Input:
-                                    GET /foo HTTP/1.1
-                                    my-header: foo
-
-
-                                  Config:
-                                    set:
-                                    - name: "my-header"
-                                      value: "bar"
-
-
-                                  Output:
-                                    GET /foo HTTP/1.1
-                                    my-header: bar
-                                items:
-                                  description: HTTPHeader represents an HTTP Header
-                                    name and value as defined by RFC 7230.
-                                  properties:
-                                    name:
-                                      description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
-
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
-                                      maxLength: 256
-                                      minLength: 1
-                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
-                                      type: string
-                                    value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
-                                      maxLength: 4096
-                                      minLength: 1
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                maxItems: 16
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                - name
-                                x-kubernetes-list-type: map
-                            type: object
-                          requestMirror:
-                            description: |-
-                              RequestMirror defines a schema for a filter that mirrors requests.
-                              Requests are sent to the specified destination, but responses from
-                              that destination are ignored.
-
-
-                              This filter can be used multiple times within the same rule. Note that
-                              not all implementations will be able to support mirroring to multiple
-                              backends.
-
-
-                              Support: Extended
-                            properties:
-                              backendRef:
-                                description: |-
-                                  BackendRef references a resource where mirrored requests are sent.
-
-
-                                  Mirrored requests must be sent only to a single destination endpoint
-                                  within this BackendRef, irrespective of how many endpoints are present
-                                  within this BackendRef.
-
-
-                                  If the referent cannot be found, this BackendRef is invalid and must be
-                                  dropped from the Gateway. The controller must ensure the "ResolvedRefs"
-                                  condition on the Route status is set to `status: False` and not configure
-                                  this backend in the underlying implementation.
-
-
-                                  If there is a cross-namespace reference to an *existing* object
-                                  that is not allowed by a ReferenceGrant, the controller must ensure the
-                                  "ResolvedRefs"  condition on the Route is set to `status: False`,
-                                  with the "RefNotPermitted" reason and not configure this backend in the
-                                  underlying implementation.
-
-
-                                  In either error case, the Message of the `ResolvedRefs` Condition
-                                  should be used to provide more detail about the problem.
-
-
-                                  Support: Extended for Kubernetes Service
-
-
-                                  Support: Implementation-specific for any other resource
-                                properties:
-                                  group:
-                                    default: ""
-                                    description: |-
-                                      Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                      When unspecified or empty string, core API group is inferred.
-                                    maxLength: 253
-                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                    type: string
-                                  kind:
-                                    default: Service
-                                    description: |-
-                                      Kind is the Kubernetes resource kind of the referent. For example
-                                      "Service".
-
-
-                                      Defaults to "Service" when not specified.
-
-
-                                      ExternalName services can refer to CNAME DNS records that may live
-                                      outside of the cluster and as such are difficult to reason about in
-                                      terms of conformance. They also may not be safe to forward to (see
-                                      CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                      support ExternalName Services.
-
-
-                                      Support: Core (Services with a type other than ExternalName)
-
-
-                                      Support: Implementation-specific (Services with type ExternalName)
-                                    maxLength: 63
-                                    minLength: 1
-                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                    type: string
-                                  name:
-                                    description: Name is the name of the referent.
-                                    maxLength: 253
-                                    minLength: 1
-                                    type: string
-                                  namespace:
-                                    description: |-
-                                      Namespace is the namespace of the backend. When unspecified, the local
-                                      namespace is inferred.
-
-
-                                      Note that when a namespace different than the local namespace is specified,
-                                      a ReferenceGrant object is required in the referent namespace to allow that
-                                      namespace's owner to accept the reference. See the ReferenceGrant
-                                      documentation for details.
-
-
-                                      Support: Core
-                                    maxLength: 63
-                                    minLength: 1
-                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                                    type: string
-                                  port:
-                                    description: |-
-                                      Port specifies the destination port number to use for this resource.
-                                      Port is required when the referent is a Kubernetes Service. In this
-                                      case, the port number is the service port number, not the target port.
-                                      For other resources, destination port might be derived from the referent
-                                      resource or this field.
-                                    format: int32
-                                    maximum: 65535
-                                    minimum: 1
-                                    type: integer
-                                required:
-                                - name
-                                type: object
-                                x-kubernetes-validations:
-                                - message: Must have port for Service reference
-                                  rule: '(size(self.group) == 0 && self.kind == ''Service'')
-                                    ? has(self.port) : true'
-                            required:
-                            - backendRef
-                            type: object
-                          responseHeaderModifier:
-                            description: |-
-                              ResponseHeaderModifier defines a schema for a filter that modifies response
-                              headers.
-
-
-                              Support: Extended
-                            properties:
-                              add:
-                                description: |-
-                                  Add adds the given header(s) (name, value) to the request
-                                  before the action. It appends to any existing values associated
-                                  with the header name.
-
-
-                                  Input:
-                                    GET /foo HTTP/1.1
-                                    my-header: foo
-
-
-                                  Config:
-                                    add:
-                                    - name: "my-header"
-                                      value: "bar,baz"
-
-
-                                  Output:
-                                    GET /foo HTTP/1.1
-                                    my-header: foo,bar,baz
-                                items:
-                                  description: HTTPHeader represents an HTTP Header
-                                    name and value as defined by RFC 7230.
-                                  properties:
-                                    name:
-                                      description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
-
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
-                                      maxLength: 256
-                                      minLength: 1
-                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
-                                      type: string
-                                    value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
-                                      maxLength: 4096
-                                      minLength: 1
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                maxItems: 16
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                - name
-                                x-kubernetes-list-type: map
-                              remove:
-                                description: |-
-                                  Remove the given header(s) from the HTTP request before the action. The
-                                  value of Remove is a list of HTTP header names. Note that the header
-                                  names are case-insensitive (see
-                                  https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
-
-
-                                  Input:
-                                    GET /foo HTTP/1.1
-                                    my-header1: foo
-                                    my-header2: bar
-                                    my-header3: baz
-
-
-                                  Config:
-                                    remove: ["my-header1", "my-header3"]
-
-
-                                  Output:
-                                    GET /foo HTTP/1.1
-                                    my-header2: bar
-                                items:
-                                  type: string
-                                maxItems: 16
-                                type: array
-                                x-kubernetes-list-type: set
-                              set:
-                                description: |-
-                                  Set overwrites the request with the given header (name, value)
-                                  before the action.
-
-
-                                  Input:
-                                    GET /foo HTTP/1.1
-                                    my-header: foo
-
-
-                                  Config:
-                                    set:
-                                    - name: "my-header"
-                                      value: "bar"
-
-
-                                  Output:
-                                    GET /foo HTTP/1.1
-                                    my-header: bar
-                                items:
-                                  description: HTTPHeader represents an HTTP Header
-                                    name and value as defined by RFC 7230.
-                                  properties:
-                                    name:
-                                      description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
-
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
-                                      maxLength: 256
-                                      minLength: 1
-                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
-                                      type: string
-                                    value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
-                                      maxLength: 4096
-                                      minLength: 1
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                maxItems: 16
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                - name
-                                x-kubernetes-list-type: map
-                            type: object
-                          type:
-                            description: |+
-                              Type identifies the type of filter to apply. As with other API fields,
-                              types are classified into three conformance levels:
-
-
-                              - Core: Filter types and their corresponding configuration defined by
-                                "Support: Core" in this package, e.g. "RequestHeaderModifier". All
-                                implementations supporting GRPCRoute MUST support core filters.
-
-
-                              - Extended: Filter types and their corresponding configuration defined by
-                                "Support: Extended" in this package, e.g. "RequestMirror". Implementers
-                                are encouraged to support extended filters.
-
-
-                              - Implementation-specific: Filters that are defined and supported by specific vendors.
-                                In the future, filters showing convergence in behavior across multiple
-                                implementations will be considered for inclusion in extended or core
-                                conformance levels. Filter-specific configuration for such filters
-                                is specified using the ExtensionRef field. `Type` MUST be set to
-                                "ExtensionRef" for custom filters.
-
-
-                              Implementers are encouraged to define custom implementation types to
-                              extend the core API with implementation-specific behavior.
-
-
-                              If a reference to a custom filter type cannot be resolved, the filter
-                              MUST NOT be skipped. Instead, requests that would have been processed by
-                              that filter MUST receive a HTTP error response.
-
-
-                            enum:
-                            - ResponseHeaderModifier
-                            - RequestHeaderModifier
-                            - RequestMirror
-                            - ExtensionRef
-                            type: string
-                        required:
-                        - type
-                        type: object
-                        x-kubernetes-validations:
-                        - message: filter.requestHeaderModifier must be nil if the
-                            filter.type is not RequestHeaderModifier
-                          rule: '!(has(self.requestHeaderModifier) && self.type !=
-                            ''RequestHeaderModifier'')'
-                        - message: filter.requestHeaderModifier must be specified
-                            for RequestHeaderModifier filter.type
-                          rule: '!(!has(self.requestHeaderModifier) && self.type ==
-                            ''RequestHeaderModifier'')'
-                        - message: filter.responseHeaderModifier must be nil if the
-                            filter.type is not ResponseHeaderModifier
-                          rule: '!(has(self.responseHeaderModifier) && self.type !=
-                            ''ResponseHeaderModifier'')'
-                        - message: filter.responseHeaderModifier must be specified
-                            for ResponseHeaderModifier filter.type
-                          rule: '!(!has(self.responseHeaderModifier) && self.type
-                            == ''ResponseHeaderModifier'')'
-                        - message: filter.requestMirror must be nil if the filter.type
-                            is not RequestMirror
-                          rule: '!(has(self.requestMirror) && self.type != ''RequestMirror'')'
-                        - message: filter.requestMirror must be specified for RequestMirror
-                            filter.type
-                          rule: '!(!has(self.requestMirror) && self.type == ''RequestMirror'')'
-                        - message: filter.extensionRef must be nil if the filter.type
-                            is not ExtensionRef
-                          rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
-                        - message: filter.extensionRef must be specified for ExtensionRef
-                            filter.type
-                          rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
-                      maxItems: 16
-                      type: array
-                      x-kubernetes-validations:
-                      - message: RequestHeaderModifier filter cannot be repeated
-                        rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
-                          <= 1
-                      - message: ResponseHeaderModifier filter cannot be repeated
-                        rule: self.filter(f, f.type == 'ResponseHeaderModifier').size()
-                          <= 1
-                    matches:
-                      description: |-
-                        Matches define conditions used for matching the rule against incoming
-                        gRPC requests. Each match is independent, i.e. this rule will be matched
-                        if **any** one of the matches is satisfied.
-
-
-                        For example, take the following matches configuration:
-
-
-                        ```
-                        matches:
-                        - method:
-                            service: foo.bar
-                          headers:
-                            values:
-                              version: 2
-                        - method:
-                            service: foo.bar.v2
-                        ```
-
-
-                        For a request to match against this rule, it MUST satisfy
-                        EITHER of the two conditions:
-
-
-                        - service of foo.bar AND contains the header `version: 2`
-                        - service of foo.bar.v2
-
-
-                        See the documentation for GRPCRouteMatch on how to specify multiple
-                        match conditions to be ANDed together.
-
-
-                        If no matches are specified, the implementation MUST match every gRPC request.
-
-
-                        Proxy or Load Balancer routing configuration generated from GRPCRoutes
-                        MUST prioritize rules based on the following criteria, continuing on
-                        ties. Merging MUST not be done between GRPCRoutes and HTTPRoutes.
-                        Precedence MUST be given to the rule with the largest number of:
-
-
-                        * Characters in a matching non-wildcard hostname.
-                        * Characters in a matching hostname.
-                        * Characters in a matching service.
-                        * Characters in a matching method.
-                        * Header matches.
-
-
-                        If ties still exist across multiple Routes, matching precedence MUST be
-                        determined in order of the following criteria, continuing on ties:
-
-
-                        * The oldest Route based on creation timestamp.
-                        * The Route appearing first in alphabetical order by
-                          "{namespace}/{name}".
-
-
-                        If ties still exist within the Route that has been given precedence,
-                        matching precedence MUST be granted to the first matching rule meeting
-                        the above criteria.
-                      items:
-                        description: |-
-                          GRPCRouteMatch defines the predicate used to match requests to a given
-                          action. Multiple match types are ANDed together, i.e. the match will
-                          evaluate to true only if all conditions are satisfied.
-
-
-                          For example, the match below will match a gRPC request only if its service
-                          is `foo` AND it contains the `version: v1` header:
-
-
-                          ```
-                          matches:
-                            - method:
-                              type: Exact
-                              service: "foo"
-                              headers:
-                            - name: "version"
-                              value "v1"
-
-
-                          ```
-                        properties:
-                          headers:
-                            description: |-
-                              Headers specifies gRPC request header matchers. Multiple match values are
-                              ANDed together, meaning, a request MUST match all the specified headers
-                              to select the route.
-                            items:
-                              description: |-
-                                GRPCHeaderMatch describes how to select a gRPC route by matching gRPC request
-                                headers.
-                              properties:
-                                name:
-                                  description: |-
-                                    Name is the name of the gRPC Header to be matched.
-
-
-                                    If multiple entries specify equivalent header names, only the first
-                                    entry with an equivalent name MUST be considered for a match. Subsequent
-                                    entries with an equivalent header name MUST be ignored. Due to the
-                                    case-insensitivity of header names, "foo" and "Foo" are considered
-                                    equivalent.
-                                  maxLength: 256
-                                  minLength: 1
-                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
-                                  type: string
-                                type:
-                                  default: Exact
-                                  description: Type specifies how to match against
-                                    the value of the header.
-                                  enum:
-                                  - Exact
-                                  - RegularExpression
-                                  type: string
-                                value:
-                                  description: Value is the value of the gRPC Header
-                                    to be matched.
-                                  maxLength: 4096
-                                  minLength: 1
-                                  type: string
-                              required:
-                              - name
-                              - value
-                              type: object
-                            maxItems: 16
-                            type: array
-                            x-kubernetes-list-map-keys:
-                            - name
-                            x-kubernetes-list-type: map
-                          method:
-                            description: |-
-                              Method specifies a gRPC request service/method matcher. If this field is
-                              not specified, all services and methods will match.
-                            properties:
-                              method:
-                                description: |-
-                                  Value of the method to match against. If left empty or omitted, will
-                                  match all services.
-
-
-                                  At least one of Service and Method MUST be a non-empty string.
-                                maxLength: 1024
-                                type: string
-                              service:
-                                description: |-
-                                  Value of the service to match against. If left empty or omitted, will
-                                  match any service.
-
-
-                                  At least one of Service and Method MUST be a non-empty string.
-                                maxLength: 1024
-                                type: string
-                              type:
-                                default: Exact
-                                description: |-
-                                  Type specifies how to match against the service and/or method.
-                                  Support: Core (Exact with service and method specified)
-
-
-                                  Support: Implementation-specific (Exact with method specified but no service specified)
-
-
-                                  Support: Implementation-specific (RegularExpression)
-                                enum:
-                                - Exact
-                                - RegularExpression
-                                type: string
-                            type: object
-                            x-kubernetes-validations:
-                            - message: One or both of 'service' or 'method' must be
-                                specified
-                              rule: 'has(self.type) ? has(self.service) || has(self.method)
-                                : true'
-                            - message: service must only contain valid characters
-                                (matching ^(?i)\.?[a-z_][a-z_0-9]*(\.[a-z_][a-z_0-9]*)*$)
-                              rule: '(!has(self.type) || self.type == ''Exact'') &&
-                                has(self.service) ? self.service.matches(r"""^(?i)\.?[a-z_][a-z_0-9]*(\.[a-z_][a-z_0-9]*)*$"""):
-                                true'
-                            - message: method must only contain valid characters (matching
-                                ^[A-Za-z_][A-Za-z_0-9]*$)
-                              rule: '(!has(self.type) || self.type == ''Exact'') &&
-                                has(self.method) ? self.method.matches(r"""^[A-Za-z_][A-Za-z_0-9]*$"""):
-                                true'
-                        type: object
-                      maxItems: 8
-                      type: array
-                    sessionPersistence:
-                      description: |+
-                        SessionPersistence defines and configures session persistence
-                        for the route rule.
-
-
-                        Support: Extended
-
-
-                      properties:
-                        absoluteTimeout:
-                          description: |-
-                            AbsoluteTimeout defines the absolute timeout of the persistent
-                            session. Once the AbsoluteTimeout duration has elapsed, the
-                            session becomes invalid.
-
-
-                            Support: Extended
-                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
-                          type: string
-                        cookieConfig:
-                          description: |-
-                            CookieConfig provides configuration settings that are specific
-                            to cookie-based session persistence.
-
-
-                            Support: Core
-                          properties:
-                            lifetimeType:
-                              default: Session
-                              description: |-
-                                LifetimeType specifies whether the cookie has a permanent or
-                                session-based lifetime. A permanent cookie persists until its
-                                specified expiry time, defined by the Expires or Max-Age cookie
-                                attributes, while a session cookie is deleted when the current
-                                session ends.
-
-
-                                When set to "Permanent", AbsoluteTimeout indicates the
-                                cookie's lifetime via the Expires or Max-Age cookie attributes
-                                and is required.
-
-
-                                When set to "Session", AbsoluteTimeout indicates the
-                                absolute lifetime of the cookie tracked by the gateway and
-                                is optional.
-
-
-                                Support: Core for "Session" type
-
-
-                                Support: Extended for "Permanent" type
-                              enum:
-                              - Permanent
-                              - Session
-                              type: string
-                          type: object
-                        idleTimeout:
-                          description: |-
-                            IdleTimeout defines the idle timeout of the persistent session.
-                            Once the session has been idle for more than the specified
-                            IdleTimeout duration, the session becomes invalid.
-
-
-                            Support: Extended
-                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
-                          type: string
-                        sessionName:
-                          description: |-
-                            SessionName defines the name of the persistent session token
-                            which may be reflected in the cookie or the header. Users
-                            should avoid reusing session names to prevent unintended
-                            consequences, such as rejection or unpredictable behavior.
-
-
-                            Support: Implementation-specific
-                          maxLength: 128
-                          type: string
-                        type:
-                          default: Cookie
-                          description: |-
-                            Type defines the type of session persistence such as through
-                            the use a header or cookie. Defaults to cookie based session
-                            persistence.
-
-
-                            Support: Core for "Cookie" type
-
-
-                            Support: Extended for "Header" type
-                          enum:
-                          - Cookie
-                          - Header
-                          type: string
-                      type: object
-                      x-kubernetes-validations:
-                      - message: AbsoluteTimeout must be specified when cookie lifetimeType
-                          is Permanent
-                        rule: '!has(self.cookieConfig.lifetimeType) || self.cookieConfig.lifetimeType
-                          != ''Permanent'' || has(self.absoluteTimeout)'
-                  type: object
-                maxItems: 16
-                type: array
-            type: object
-          status:
-            description: Status defines the current state of GRPCRoute.
-            properties:
-              parents:
-                description: |-
-                  Parents is a list of parent resources (usually Gateways) that are
-                  associated with the route, and the status of the route with respect to
-                  each parent. When this route attaches to a parent, the controller that
-                  manages the parent must add an entry to this list when the controller
-                  first sees the route and should update the entry as appropriate when the
-                  route or gateway is modified.
-
-
-                  Note that parent references that cannot be resolved by an implementation
-                  of this API will not be added to this list. Implementations of this API
-                  can only populate Route status for the Gateways/parent resources they are
-                  responsible for.
-
-
-                  A maximum of 32 Gateways will be represented in this list. An empty list
-                  means the route has not been attached to any Gateway.
-                items:
-                  description: |-
-                    RouteParentStatus describes the status of a route with respect to an
-                    associated Parent.
-                  properties:
-                    conditions:
-                      description: |-
-                        Conditions describes the status of the route with respect to the Gateway.
-                        Note that the route's availability is also subject to the Gateway's own
-                        status conditions and listener status.
-
-
-                        If the Route's ParentRef specifies an existing Gateway that supports
-                        Routes of this kind AND that Gateway's controller has sufficient access,
-                        then that Gateway's controller MUST set the "Accepted" condition on the
-                        Route, to indicate whether the route has been accepted or rejected by the
-                        Gateway, and why.
-
-
-                        A Route MUST be considered "Accepted" if at least one of the Route's
-                        rules is implemented by the Gateway.
-
-
-                        There are a number of cases where the "Accepted" condition may not be set
-                        due to lack of controller visibility, that includes when:
-
-
-                        * The Route refers to a non-existent parent.
-                        * The Route is of a type that the controller does not support.
-                        * The Route is in a namespace the controller does not have access to.
-                      items:
-                        description: "Condition contains details for one aspect of
-                          the current state of this API Resource.\n---\nThis struct
-                          is intended for direct use as an array at the field path
-                          .status.conditions.  For example,\n\n\n\ttype FooStatus
-                          struct{\n\t    // Represents the observations of a foo's
-                          current state.\n\t    // Known .status.conditions.type are:
-                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
-                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
-                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
-                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                          \   // other fields\n\t}"
-                        properties:
-                          lastTransitionTime:
-                            description: |-
-                              lastTransitionTime is the last time the condition transitioned from one status to another.
-                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                            format: date-time
-                            type: string
-                          message:
-                            description: |-
-                              message is a human readable message indicating details about the transition.
-                              This may be an empty string.
-                            maxLength: 32768
-                            type: string
-                          observedGeneration:
-                            description: |-
-                              observedGeneration represents the .metadata.generation that the condition was set based upon.
-                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                              with respect to the current state of the instance.
-                            format: int64
-                            minimum: 0
-                            type: integer
-                          reason:
-                            description: |-
-                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                              Producers of specific condition types may define expected values and meanings for this field,
-                              and whether the values are considered a guaranteed API.
-                              The value should be a CamelCase string.
-                              This field may not be empty.
-                            maxLength: 1024
-                            minLength: 1
-                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                            type: string
-                          status:
-                            description: status of the condition, one of True, False,
-                              Unknown.
-                            enum:
-                            - "True"
-                            - "False"
-                            - Unknown
-                            type: string
-                          type:
-                            description: |-
-                              type of condition in CamelCase or in foo.example.com/CamelCase.
-                              ---
-                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                              useful (see .node.status.conditions), the ability to deconflict is important.
-                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                            maxLength: 316
-                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                            type: string
-                        required:
-                        - lastTransitionTime
-                        - message
-                        - reason
-                        - status
-                        - type
-                        type: object
-                      maxItems: 8
-                      minItems: 1
-                      type: array
-                      x-kubernetes-list-map-keys:
-                      - type
-                      x-kubernetes-list-type: map
-                    controllerName:
-                      description: |-
-                        ControllerName is a domain/path string that indicates the name of the
-                        controller that wrote this status. This corresponds with the
-                        controllerName field on GatewayClass.
-
-
-                        Example: "example.net/gateway-controller".
-
-
-                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
-                        valid Kubernetes names
-                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
-
-
-                        Controllers MUST populate this field when writing status. Controllers should ensure that
-                        entries to status populated with their ControllerName are cleaned up when they are no
-                        longer necessary.
-                      maxLength: 253
-                      minLength: 1
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
-                      type: string
-                    parentRef:
-                      description: |-
-                        ParentRef corresponds with a ParentRef in the spec that this
-                        RouteParentStatus struct describes the status of.
-                      properties:
-                        group:
-                          default: gateway.networking.k8s.io
-                          description: |-
-                            Group is the group of the referent.
-                            When unspecified, "gateway.networking.k8s.io" is inferred.
-                            To set the core API group (such as for a "Service" kind referent),
-                            Group must be explicitly set to "" (empty string).
-
-
-                            Support: Core
-                          maxLength: 253
-                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                          type: string
-                        kind:
-                          default: Gateway
-                          description: |-
-                            Kind is kind of the referent.
-
-
-                            There are two kinds of parent resources with "Core" support:
-
-
-                            * Gateway (Gateway conformance profile)
-                            * Service (Mesh conformance profile, ClusterIP Services only)
-
-
-                            Support for other resources is Implementation-Specific.
-                          maxLength: 63
-                          minLength: 1
-                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                          type: string
-                        name:
-                          description: |-
-                            Name is the name of the referent.
-
-
-                            Support: Core
-                          maxLength: 253
-                          minLength: 1
-                          type: string
-                        namespace:
-                          description: |-
-                            Namespace is the namespace of the referent. When unspecified, this refers
-                            to the local namespace of the Route.
-
-
-                            Note that there are specific rules for ParentRefs which cross namespace
-                            boundaries. Cross-namespace references are only valid if they are explicitly
-                            allowed by something in the namespace they are referring to. For example:
-                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
-                            generic way to enable any other kind of cross-namespace reference.
-
-
-
-                            ParentRefs from a Route to a Service in the same namespace are "producer"
-                            routes, which apply default routing rules to inbound connections from
-                            any namespace to the Service.
-
-
-                            ParentRefs from a Route to a Service in a different namespace are
-                            "consumer" routes, and these routing rules are only applied to outbound
-                            connections originating from the same namespace as the Route, for which
-                            the intended destination of the connections are a Service targeted as a
-                            ParentRef of the Route.
-
-
-
-                            Support: Core
-                          maxLength: 63
-                          minLength: 1
-                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                          type: string
-                        port:
-                          description: |-
-                            Port is the network port this Route targets. It can be interpreted
-                            differently based on the type of parent resource.
-
-
-                            When the parent resource is a Gateway, this targets all listeners
-                            listening on the specified port that also support this kind of Route(and
-                            select this Route). It's not recommended to set `Port` unless the
-                            networking behaviors specified in a Route must apply to a specific port
-                            as opposed to a listener(s) whose port(s) may be changed. When both Port
-                            and SectionName are specified, the name and port of the selected listener
-                            must match both specified values.
-
-
-
-                            When the parent resource is a Service, this targets a specific port in the
-                            Service spec. When both Port (experimental) and SectionName are specified,
-                            the name and port of the selected port must match both specified values.
-
-
-
-                            Implementations MAY choose to support other parent resources.
-                            Implementations supporting other types of parent resources MUST clearly
-                            document how/if Port is interpreted.
-
-
-                            For the purpose of status, an attachment is considered successful as
-                            long as the parent resource accepts it partially. For example, Gateway
-                            listeners can restrict which Routes can attach to them by Route kind,
-                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
-                            from the referencing Route, the Route MUST be considered successfully
-                            attached. If no Gateway listeners accept attachment from this Route,
-                            the Route MUST be considered detached from the Gateway.
-
-
-                            Support: Extended
-                          format: int32
-                          maximum: 65535
-                          minimum: 1
-                          type: integer
-                        sectionName:
-                          description: |-
-                            SectionName is the name of a section within the target resource. In the
-                            following resources, SectionName is interpreted as the following:
-
-
-                            * Gateway: Listener name. When both Port (experimental) and SectionName
-                            are specified, the name and port of the selected listener must match
-                            both specified values.
-                            * Service: Port name. When both Port (experimental) and SectionName
-                            are specified, the name and port of the selected listener must match
-                            both specified values.
-
-
-                            Implementations MAY choose to support attaching Routes to other resources.
-                            If that is the case, they MUST clearly document how SectionName is
-                            interpreted.
-
-
-                            When unspecified (empty string), this will reference the entire resource.
-                            For the purpose of status, an attachment is considered successful if at
-                            least one section in the parent resource accepts it. For example, Gateway
-                            listeners can restrict which Routes can attach to them by Route kind,
-                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
-                            the referencing Route, the Route MUST be considered successfully
-                            attached. If no Gateway listeners accept attachment from this Route, the
-                            Route MUST be considered detached from the Gateway.
-
-
-                            Support: Core
-                          maxLength: 253
-                          minLength: 1
-                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                          type: string
-                      required:
-                      - name
-                      type: object
-                  required:
-                  - controllerName
-                  - parentRef
-                  type: object
-                maxItems: 32
-                type: array
-            required:
-            - parents
-            type: object
-        type: object
-    served: true
-    storage: false
 status:
   acceptedNames:
     kind: ""

--- a/platform/gateway-api/chart/templates/httproutes.yaml
+++ b/platform/gateway-api/chart/templates/httproutes.yaml
@@ -9,7 +9,6 @@
   cluster-scoped infrastructure; deleting them on uninstall would break
   every HTTPRoute on the cluster simultaneously.
 */}}
-
 #
 # config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
 #
@@ -18,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
-    gateway.networking.k8s.io/bundle-version: v1.1.0
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.3.0
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: httproutes.gateway.networking.k8s.io
@@ -78,20 +77,16 @@ spec:
                   performing a match and (absent of any applicable header modification
                   configuration) MUST forward this header unmodified to the backend.
 
-
                   Valid values for Hostnames are determined by RFC 1123 definition of a
                   hostname with 2 notable exceptions:
-
 
                   1. IPs are not allowed.
                   2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
                      label must appear by itself as the first label.
 
-
                   If a hostname is specified by both the Listener and HTTPRoute, there
                   must be at least one intersecting hostname for the HTTPRoute to be
                   attached to the Listener. For example:
-
 
                   * A Listener with `test.example.com` as the hostname matches HTTPRoutes
                     that have either not specified any hostnames, or have specified at
@@ -103,11 +98,9 @@ spec:
                     all match. On the other hand, `example.com` and `test.example.net` would
                     not match.
 
-
                   Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
                   as a suffix match. That means that a match for `*.example.com` would match
                   both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
-
 
                   If both the Listener and HTTPRoute have specified hostnames, any
                   HTTPRoute hostnames that do not match the Listener hostname MUST be
@@ -115,25 +108,20 @@ spec:
                   HTTPRoute specified `test.example.com` and `test.example.net`,
                   `test.example.net` must not be considered for a match.
 
-
                   If both the Listener and HTTPRoute have specified hostnames, and none
                   match with the criteria above, then the HTTPRoute is not accepted. The
                   implementation must raise an 'Accepted' Condition with a status of
                   `False` in the corresponding RouteParentStatus.
 
-
                   In the event that multiple HTTPRoutes specify intersecting hostnames (e.g.
                   overlapping wildcard matching and exact matching hostnames), precedence must
                   be given to rules from the HTTPRoute with the largest number of:
 
-
                   * Characters in a matching non-wildcard hostname.
                   * Characters in a matching hostname.
 
-
                   If ties exist across multiple Routes, the matching precedence rules for
                   HTTPRouteMatches takes over.
-
 
                   Support: Core
                 items:
@@ -141,16 +129,13 @@ spec:
                     Hostname is the fully qualified domain name of a network host. This matches
                     the RFC 1123 definition of a hostname with 2 notable exceptions:
 
-
                      1. IPs are not allowed.
                      2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
                         label must appear by itself as the first label.
 
-
                     Hostname can be "precise" which is a domain name without the terminating
                     dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
                     domain name prefixed with a single wildcard label (e.g. `*.example.com`).
-
 
                     Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
                     alphanumeric characters or '-', and must start and end with an alphanumeric
@@ -162,7 +147,7 @@ spec:
                 maxItems: 16
                 type: array
               parentRefs:
-                description: |+
+                description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants
                   to be attached to. Note that the referenced parent resource needs to
                   allow this for the attachment to be complete. For Gateways, that means
@@ -174,20 +159,15 @@ spec:
                   create a "producer" route for a Service in a different namespace from the
                   Route.
 
-
                   There are two kinds of parent resources with "Core" support:
-
 
                   * Gateway (Gateway conformance profile)
                   * Service (Mesh conformance profile, ClusterIP Services only)
 
-
                   This API may be extended in the future to support additional kinds of parent
                   resources.
 
-
                   ParentRefs must be _distinct_. This means either that:
-
 
                   * They select different objects.  If this is the case, then parentRef
                     entries are distinct. In terms of fields, this means that the
@@ -198,9 +178,7 @@ spec:
                     optional fields to different values. If one ParentRef sets a
                     combination of optional fields, all must set the same combination.
 
-
                   Some examples:
-
 
                   * If one ParentRef sets `sectionName`, all ParentRefs referencing the
                     same object must also set `sectionName`.
@@ -209,13 +187,11 @@ spec:
                   * If one ParentRef sets `sectionName` and `port`, all ParentRefs
                     referencing the same object must also set `sectionName` and `port`.
 
-
                   It is possible to separately reference multiple distinct objects that may
                   be collapsed by an implementation. For example, some implementations may
                   choose to merge compatible Gateway Listeners together. If that is the
                   case, the list of routes attached to those resources should also be
                   merged.
-
 
                   Note that for ParentRefs that cross namespace boundaries, there are specific
                   rules. Cross-namespace references are only valid if they are explicitly
@@ -224,37 +200,26 @@ spec:
                   generic way to enable other kinds of cross-namespace reference.
 
 
-
                   ParentRefs from a Route to a Service in the same namespace are "producer"
                   routes, which apply default routing rules to inbound connections from
                   any namespace to the Service.
-
 
                   ParentRefs from a Route to a Service in a different namespace are
                   "consumer" routes, and these routing rules are only applied to outbound
                   connections originating from the same namespace as the Route, for which
                   the intended destination of the connections are a Service targeted as a
                   ParentRef of the Route.
-
-
-
-
-
-
                 items:
                   description: |-
                     ParentReference identifies an API object (usually a Gateway) that can be considered
                     a parent of this resource (usually a route). There are two kinds of parent resources
                     with "Core" support:
 
-
                     * Gateway (Gateway conformance profile)
                     * Service (Mesh conformance profile, ClusterIP Services only)
 
-
                     This API may be extended in the future to support additional kinds of parent
                     resources.
-
 
                     The API object must be valid in the cluster; the Group and Kind must
                     be registered in the cluster for this reference to be valid.
@@ -267,7 +232,6 @@ spec:
                         To set the core API group (such as for a "Service" kind referent),
                         Group must be explicitly set to "" (empty string).
 
-
                         Support: Core
                       maxLength: 253
                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -277,13 +241,10 @@ spec:
                       description: |-
                         Kind is kind of the referent.
 
-
                         There are two kinds of parent resources with "Core" support:
-
 
                         * Gateway (Gateway conformance profile)
                         * Service (Mesh conformance profile, ClusterIP Services only)
-
 
                         Support for other resources is Implementation-Specific.
                       maxLength: 63
@@ -294,7 +255,6 @@ spec:
                       description: |-
                         Name is the name of the referent.
 
-
                         Support: Core
                       maxLength: 253
                       minLength: 1
@@ -304,7 +264,6 @@ spec:
                         Namespace is the namespace of the referent. When unspecified, this refers
                         to the local namespace of the Route.
 
-
                         Note that there are specific rules for ParentRefs which cross namespace
                         boundaries. Cross-namespace references are only valid if they are explicitly
                         allowed by something in the namespace they are referring to. For example:
@@ -312,18 +271,15 @@ spec:
                         generic way to enable any other kind of cross-namespace reference.
 
 
-
                         ParentRefs from a Route to a Service in the same namespace are "producer"
                         routes, which apply default routing rules to inbound connections from
                         any namespace to the Service.
-
 
                         ParentRefs from a Route to a Service in a different namespace are
                         "consumer" routes, and these routing rules are only applied to outbound
                         connections originating from the same namespace as the Route, for which
                         the intended destination of the connections are a Service targeted as a
                         ParentRef of the Route.
-
 
 
                         Support: Core
@@ -336,7 +292,6 @@ spec:
                         Port is the network port this Route targets. It can be interpreted
                         differently based on the type of parent resource.
 
-
                         When the parent resource is a Gateway, this targets all listeners
                         listening on the specified port that also support this kind of Route(and
                         select this Route). It's not recommended to set `Port` unless the
@@ -346,17 +301,14 @@ spec:
                         must match both specified values.
 
 
-
                         When the parent resource is a Service, this targets a specific port in the
                         Service spec. When both Port (experimental) and SectionName are specified,
                         the name and port of the selected port must match both specified values.
 
 
-
                         Implementations MAY choose to support other parent resources.
                         Implementations supporting other types of parent resources MUST clearly
                         document how/if Port is interpreted.
-
 
                         For the purpose of status, an attachment is considered successful as
                         long as the parent resource accepts it partially. For example, Gateway
@@ -365,7 +317,6 @@ spec:
                         from the referencing Route, the Route MUST be considered successfully
                         attached. If no Gateway listeners accept attachment from this Route,
                         the Route MUST be considered detached from the Gateway.
-
 
                         Support: Extended
                       format: int32
@@ -377,7 +328,6 @@ spec:
                         SectionName is the name of a section within the target resource. In the
                         following resources, SectionName is interpreted as the following:
 
-
                         * Gateway: Listener name. When both Port (experimental) and SectionName
                         are specified, the name and port of the selected listener must match
                         both specified values.
@@ -385,11 +335,9 @@ spec:
                         are specified, the name and port of the selected listener must match
                         both specified values.
 
-
                         Implementations MAY choose to support attaching Routes to other resources.
                         If that is the case, they MUST clearly document how SectionName is
                         interpreted.
-
 
                         When unspecified (empty string), this will reference the entire resource.
                         For the purpose of status, an attachment is considered successful if at
@@ -399,7 +347,6 @@ spec:
                         the referencing Route, the Route MUST be considered successfully
                         attached. If no Gateway listeners accept attachment from this Route, the
                         Route MUST be considered detached from the Gateway.
-
 
                         Support: Core
                       maxLength: 253
@@ -452,19 +399,15 @@ spec:
                         BackendRefs defines the backend(s) where matching requests should be
                         sent.
 
-
                         Failure behavior here depends on how many BackendRefs are specified and
                         how many are invalid.
-
 
                         If *all* entries in BackendRefs are invalid, and there are also no filters
                         specified in this route rule, *all* traffic which matches this rule MUST
                         receive a 500 status code.
 
-
                         See the HTTPBackendRef definition for the rules about what makes a single
                         HTTPBackendRef invalid.
-
 
                         When a HTTPBackendRef is invalid, 500 status codes MUST be returned for
                         requests that would have otherwise been routed to an invalid backend. If
@@ -472,26 +415,25 @@ spec:
                         requests that would otherwise have been routed to an invalid backend
                         MUST receive a 500 status code.
 
-
                         For example, if two backends are specified with equal weights, and one is
                         invalid, 50 percent of traffic must receive a 500. Implementations may
                         choose how that 50 percent is determined.
 
+                        When a HTTPBackendRef refers to a Service that has no ready endpoints,
+                        implementations SHOULD return a 503 for requests to that backend instead.
+                        If an implementation chooses to do this, all of the above rules for 500 responses
+                        MUST also apply for responses that return a 503.
 
                         Support: Core for Kubernetes Service
 
-
                         Support: Extended for Kubernetes ServiceImport
 
-
                         Support: Implementation-specific for any other resource
-
 
                         Support for weight: Core
                       items:
                         description: |-
                           HTTPBackendRef defines how a HTTPRoute forwards a HTTP request.
-
 
                           Note that when a namespace different than the local namespace is specified, a
                           ReferenceGrant object is required in the referent namespace to allow that
@@ -499,34 +441,24 @@ spec:
                           documentation for details.
 
 
-                          <gateway:experimental:description>
-
-
                           When the BackendRef points to a Kubernetes Service, implementations SHOULD
                           honor the appProtocol field if it is set for the target Service Port.
 
-
                           Implementations supporting appProtocol SHOULD recognize the Kubernetes
                           Standard Application Protocols defined in KEP-3726.
-
 
                           If a Service appProtocol isn't specified, an implementation MAY infer the
                           backend protocol through its own means. Implementations MAY infer the
                           protocol from the Route type referring to the backend Service.
 
-
                           If a Route is not able to send traffic to the backend using the specified
                           protocol then the backend is considered invalid. Implementations MUST set the
                           "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
-
-
-                          </gateway:experimental:description>
                         properties:
                           filters:
                             description: |-
                               Filters defined at this level should be executed if and only if the
                               request is being forwarded to the backend defined here.
-
 
                               Support: Implementation-specific (For broader support of filters, use the
                               Filters field in HTTPRouteRule.)
@@ -539,6 +471,289 @@ spec:
                                 authentication strategies, rate-limiting, and traffic shaping. API
                                 guarantee/conformance is defined based on the type of the filter.
                               properties:
+                                cors:
+                                  description: |-
+                                    CORS defines a schema for a filter that responds to the
+                                    cross-origin request based on HTTP response header.
+
+                                    Support: Extended
+                                  properties:
+                                    allowCredentials:
+                                      description: |-
+                                        AllowCredentials indicates whether the actual cross-origin request allows
+                                        to include credentials.
+
+                                        The only valid value for the `Access-Control-Allow-Credentials` response
+                                        header is true (case-sensitive).
+
+                                        If the credentials are not allowed in cross-origin requests, the gateway
+                                        will omit the header `Access-Control-Allow-Credentials` entirely rather
+                                        than setting its value to false.
+
+                                        Support: Extended
+                                      enum:
+                                      - true
+                                      type: boolean
+                                    allowHeaders:
+                                      description: |-
+                                        AllowHeaders indicates which HTTP request headers are supported for
+                                        accessing the requested resource.
+
+                                        Header names are not case sensitive.
+
+                                        Multiple header names in the value of the `Access-Control-Allow-Headers`
+                                        response header are separated by a comma (",").
+
+                                        When the `AllowHeaders` field is configured with one or more headers, the
+                                        gateway must return the `Access-Control-Allow-Headers` response header
+                                        which value is present in the `AllowHeaders` field.
+
+                                        If any header name in the `Access-Control-Request-Headers` request header
+                                        is not included in the list of header names specified by the response
+                                        header `Access-Control-Allow-Headers`, it will present an error on the
+                                        client side.
+
+                                        If any header name in the `Access-Control-Allow-Headers` response header
+                                        does not recognize by the client, it will also occur an error on the
+                                        client side.
+
+                                        A wildcard indicates that the requests with all HTTP headers are allowed.
+                                        The `Access-Control-Allow-Headers` response header can only use `*`
+                                        wildcard as value when the `AllowCredentials` field is unspecified.
+
+                                        When the `AllowCredentials` field is specified and `AllowHeaders` field
+                                        specified with the `*` wildcard, the gateway must specify one or more
+                                        HTTP headers in the value of the `Access-Control-Allow-Headers` response
+                                        header. The value of the header `Access-Control-Allow-Headers` is same as
+                                        the `Access-Control-Request-Headers` header provided by the client. If
+                                        the header `Access-Control-Request-Headers` is not included in the
+                                        request, the gateway will omit the `Access-Control-Allow-Headers`
+                                        response header, instead of specifying the `*` wildcard. A Gateway
+                                        implementation may choose to add implementation-specific default headers.
+
+                                        Support: Extended
+                                      items:
+                                        description: |-
+                                          HTTPHeaderName is the name of an HTTP header.
+
+                                          Valid values include:
+
+                                          * "Authorization"
+                                          * "Set-Cookie"
+
+                                          Invalid values include:
+
+                                            - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
+                                              headers are not currently supported by this type.
+                                            - "/invalid" - "/ " is an invalid character
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      maxItems: 64
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    allowMethods:
+                                      description: |-
+                                        AllowMethods indicates which HTTP methods are supported for accessing the
+                                        requested resource.
+
+                                        Valid values are any method defined by RFC9110, along with the special
+                                        value `*`, which represents all HTTP methods are allowed.
+
+                                        Method names are case sensitive, so these values are also case-sensitive.
+                                        (See https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1)
+
+                                        Multiple method names in the value of the `Access-Control-Allow-Methods`
+                                        response header are separated by a comma (",").
+
+                                        A CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.
+                                        (See https://fetch.spec.whatwg.org/#cors-safelisted-method) The
+                                        CORS-safelisted methods are always allowed, regardless of whether they
+                                        are specified in the `AllowMethods` field.
+
+                                        When the `AllowMethods` field is configured with one or more methods, the
+                                        gateway must return the `Access-Control-Allow-Methods` response header
+                                        which value is present in the `AllowMethods` field.
+
+                                        If the HTTP method of the `Access-Control-Request-Method` request header
+                                        is not included in the list of methods specified by the response header
+                                        `Access-Control-Allow-Methods`, it will present an error on the client
+                                        side.
+
+                                        The `Access-Control-Allow-Methods` response header can only use `*`
+                                        wildcard as value when the `AllowCredentials` field is unspecified.
+
+                                        When the `AllowCredentials` field is specified and `AllowMethods` field
+                                        specified with the `*` wildcard, the gateway must specify one HTTP method
+                                        in the value of the Access-Control-Allow-Methods response header. The
+                                        value of the header `Access-Control-Allow-Methods` is same as the
+                                        `Access-Control-Request-Method` header provided by the client. If the
+                                        header `Access-Control-Request-Method` is not included in the request,
+                                        the gateway will omit the `Access-Control-Allow-Methods` response header,
+                                        instead of specifying the `*` wildcard. A Gateway implementation may
+                                        choose to add implementation-specific default methods.
+
+                                        Support: Extended
+                                      items:
+                                        enum:
+                                        - GET
+                                        - HEAD
+                                        - POST
+                                        - PUT
+                                        - DELETE
+                                        - CONNECT
+                                        - OPTIONS
+                                        - TRACE
+                                        - PATCH
+                                        - '*'
+                                        type: string
+                                      maxItems: 9
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                      x-kubernetes-validations:
+                                      - message: AllowMethods cannot contain '*' alongside
+                                          other methods
+                                        rule: '!(''*'' in self && self.size() > 1)'
+                                    allowOrigins:
+                                      description: |-
+                                        AllowOrigins indicates whether the response can be shared with requested
+                                        resource from the given `Origin`.
+
+                                        The `Origin` consists of a scheme and a host, with an optional port, and
+                                        takes the form `<scheme>://<host>(:<port>)`.
+
+                                        Valid values for scheme are: `http` and `https`.
+
+                                        Valid values for port are any integer between 1 and 65535 (the list of
+                                        available TCP/UDP ports). Note that, if not included, port `80` is
+                                        assumed for `http` scheme origins, and port `443` is assumed for `https`
+                                        origins. This may affect origin matching.
+
+                                        The host part of the origin may contain the wildcard character `*`. These
+                                        wildcard characters behave as follows:
+
+                                        * `*` is a greedy match to the _left_, including any number of
+                                          DNS labels to the left of its position. This also means that
+                                          `*` will include any number of period `.` characters to the
+                                          left of its position.
+                                        * A wildcard by itself matches all hosts.
+
+                                        An origin value that includes _only_ the `*` character indicates requests
+                                        from all `Origin`s are allowed.
+
+                                        When the `AllowOrigins` field is configured with multiple origins, it
+                                        means the server supports clients from multiple origins. If the request
+                                        `Origin` matches the configured allowed origins, the gateway must return
+                                        the given `Origin` and sets value of the header
+                                        `Access-Control-Allow-Origin` same as the `Origin` header provided by the
+                                        client.
+
+                                        The status code of a successful response to a "preflight" request is
+                                        always an OK status (i.e., 204 or 200).
+
+                                        If the request `Origin` does not match the configured allowed origins,
+                                        the gateway returns 204/200 response but doesn't set the relevant
+                                        cross-origin response headers. Alternatively, the gateway responds with
+                                        403 status to the "preflight" request is denied, coupled with omitting
+                                        the CORS headers. The cross-origin request fails on the client side.
+                                        Therefore, the client doesn't attempt the actual cross-origin request.
+
+                                        The `Access-Control-Allow-Origin` response header can only use `*`
+                                        wildcard as value when the `AllowCredentials` field is unspecified.
+
+                                        When the `AllowCredentials` field is specified and `AllowOrigins` field
+                                        specified with the `*` wildcard, the gateway must return a single origin
+                                        in the value of the `Access-Control-Allow-Origin` response header,
+                                        instead of specifying the `*` wildcard. The value of the header
+                                        `Access-Control-Allow-Origin` is same as the `Origin` header provided by
+                                        the client.
+
+                                        Support: Extended
+                                      items:
+                                        description: |-
+                                          The AbsoluteURI MUST NOT be a relative URI, and it MUST follow the URI syntax and
+                                          encoding rules specified in RFC3986.  The AbsoluteURI MUST include both a
+                                          scheme (e.g., "http" or "spiffe") and a scheme-specific-part.  URIs that
+                                          include an authority MUST include a fully qualified domain name or
+                                          IP address as the host.
+                                        maxLength: 253
+                                        minLength: 1
+                                        pattern: ^(([^:/?#]+):)(//([^/?#]*))([^?#]*)(\?([^#]*))?(#(.*))?
+                                        type: string
+                                      maxItems: 64
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    exposeHeaders:
+                                      description: |-
+                                        ExposeHeaders indicates which HTTP response headers can be exposed
+                                        to client-side scripts in response to a cross-origin request.
+
+                                        A CORS-safelisted response header is an HTTP header in a CORS response
+                                        that it is considered safe to expose to the client scripts.
+                                        The CORS-safelisted response headers include the following headers:
+                                        `Cache-Control`
+                                        `Content-Language`
+                                        `Content-Length`
+                                        `Content-Type`
+                                        `Expires`
+                                        `Last-Modified`
+                                        `Pragma`
+                                        (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
+                                        The CORS-safelisted response headers are exposed to client by default.
+
+                                        When an HTTP header name is specified using the `ExposeHeaders` field,
+                                        this additional header will be exposed as part of the response to the
+                                        client.
+
+                                        Header names are not case sensitive.
+
+                                        Multiple header names in the value of the `Access-Control-Expose-Headers`
+                                        response header are separated by a comma (",").
+
+                                        A wildcard indicates that the responses with all HTTP headers are exposed
+                                        to clients. The `Access-Control-Expose-Headers` response header can only
+                                        use `*` wildcard as value when the `AllowCredentials` field is
+                                        unspecified.
+
+                                        Support: Extended
+                                      items:
+                                        description: |-
+                                          HTTPHeaderName is the name of an HTTP header.
+
+                                          Valid values include:
+
+                                          * "Authorization"
+                                          * "Set-Cookie"
+
+                                          Invalid values include:
+
+                                            - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
+                                              headers are not currently supported by this type.
+                                            - "/invalid" - "/ " is an invalid character
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      maxItems: 64
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    maxAge:
+                                      default: 5
+                                      description: |-
+                                        MaxAge indicates the duration (in seconds) for the client to cache the
+                                        results of a "preflight" request.
+
+                                        The information provided by the `Access-Control-Allow-Methods` and
+                                        `Access-Control-Allow-Headers` response headers can be cached by the
+                                        client until the time specified by `Access-Control-Max-Age` elapses.
+
+                                        The default value of `Access-Control-Max-Age` response header is 5
+                                        (seconds).
+                                      format: int32
+                                      minimum: 1
+                                      type: integer
+                                  type: object
                                 extensionRef:
                                   description: |-
                                     ExtensionRef is an optional, implementation-specific extension to the
@@ -546,9 +761,7 @@ spec:
                                     "networking.example.net"). ExtensionRef MUST NOT be used for core and
                                     extended filters.
 
-
                                     This filter can be used multiple times within the same rule.
-
 
                                     Support: Implementation-specific
                                   properties:
@@ -581,7 +794,6 @@ spec:
                                     RequestHeaderModifier defines a schema for a filter that modifies request
                                     headers.
 
-
                                     Support: Core
                                   properties:
                                     add:
@@ -590,17 +802,14 @@ spec:
                                         before the action. It appends to any existing values associated
                                         with the header name.
 
-
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header: foo
-
 
                                         Config:
                                           add:
                                           - name: "my-header"
                                             value: "bar,baz"
-
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -613,8 +822,7 @@ spec:
                                           name:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -647,17 +855,14 @@ spec:
                                         names are case-insensitive (see
                                         https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
 
-
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header1: foo
                                           my-header2: bar
                                           my-header3: baz
 
-
                                         Config:
                                           remove: ["my-header1", "my-header3"]
-
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -672,17 +877,14 @@ spec:
                                         Set overwrites the request with the given header (name, value)
                                         before the action.
 
-
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header: foo
-
 
                                         Config:
                                           set:
                                           - name: "my-header"
                                             value: "bar"
-
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -695,8 +897,7 @@ spec:
                                           name:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -729,11 +930,9 @@ spec:
                                     Requests are sent to the specified destination, but responses from
                                     that destination are ignored.
 
-
                                     This filter can be used multiple times within the same rule. Note that
                                     not all implementations will be able to support mirroring to multiple
                                     backends.
-
 
                                     Support: Extended
                                   properties:
@@ -741,17 +940,14 @@ spec:
                                       description: |-
                                         BackendRef references a resource where mirrored requests are sent.
 
-
                                         Mirrored requests must be sent only to a single destination endpoint
                                         within this BackendRef, irrespective of how many endpoints are present
                                         within this BackendRef.
-
 
                                         If the referent cannot be found, this BackendRef is invalid and must be
                                         dropped from the Gateway. The controller must ensure the "ResolvedRefs"
                                         condition on the Route status is set to `status: False` and not configure
                                         this backend in the underlying implementation.
-
 
                                         If there is a cross-namespace reference to an *existing* object
                                         that is not allowed by a ReferenceGrant, the controller must ensure the
@@ -759,13 +955,10 @@ spec:
                                         with the "RefNotPermitted" reason and not configure this backend in the
                                         underlying implementation.
 
-
                                         In either error case, the Message of the `ResolvedRefs` Condition
                                         should be used to provide more detail about the problem.
 
-
                                         Support: Extended for Kubernetes Service
-
 
                                         Support: Implementation-specific for any other resource
                                       properties:
@@ -783,9 +976,7 @@ spec:
                                             Kind is the Kubernetes resource kind of the referent. For example
                                             "Service".
 
-
                                             Defaults to "Service" when not specified.
-
 
                                             ExternalName services can refer to CNAME DNS records that may live
                                             outside of the cluster and as such are difficult to reason about in
@@ -793,9 +984,7 @@ spec:
                                             CVE-2021-25740 for more information). Implementations SHOULD NOT
                                             support ExternalName Services.
 
-
                                             Support: Core (Services with a type other than ExternalName)
-
 
                                             Support: Implementation-specific (Services with type ExternalName)
                                           maxLength: 63
@@ -812,12 +1001,10 @@ spec:
                                             Namespace is the namespace of the backend. When unspecified, the local
                                             namespace is inferred.
 
-
                                             Note that when a namespace different than the local namespace is specified,
                                             a ReferenceGrant object is required in the referent namespace to allow that
                                             namespace's owner to accept the reference. See the ReferenceGrant
                                             documentation for details.
-
 
                                             Support: Core
                                           maxLength: 63
@@ -842,14 +1029,53 @@ spec:
                                       - message: Must have port for Service reference
                                         rule: '(size(self.group) == 0 && self.kind
                                           == ''Service'') ? has(self.port) : true'
+                                    fraction:
+                                      description: |-
+                                        Fraction represents the fraction of requests that should be
+                                        mirrored to BackendRef.
+
+                                        Only one of Fraction or Percent may be specified. If neither field
+                                        is specified, 100% of requests will be mirrored.
+                                      properties:
+                                        denominator:
+                                          default: 100
+                                          format: int32
+                                          minimum: 1
+                                          type: integer
+                                        numerator:
+                                          format: int32
+                                          minimum: 0
+                                          type: integer
+                                      required:
+                                      - numerator
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: numerator must be less than or equal
+                                          to denominator
+                                        rule: self.numerator <= self.denominator
+                                    percent:
+                                      description: |-
+                                        Percent represents the percentage of requests that should be
+                                        mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
+                                        requests) and its maximum value is 100 (indicating 100% of requests).
+
+                                        Only one of Fraction or Percent may be specified. If neither field
+                                        is specified, 100% of requests will be mirrored.
+                                      format: int32
+                                      maximum: 100
+                                      minimum: 0
+                                      type: integer
                                   required:
                                   - backendRef
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: Only one of percent or fraction may be
+                                      specified in HTTPRequestMirrorFilter
+                                    rule: '!(has(self.percent) && has(self.fraction))'
                                 requestRedirect:
                                   description: |-
                                     RequestRedirect defines a schema for a filter that responds to the
                                     request with an HTTP redirection.
-
 
                                     Support: Core
                                   properties:
@@ -858,7 +1084,6 @@ spec:
                                         Hostname is the hostname to be used in the value of the `Location`
                                         header in the response.
                                         When empty, the hostname in the `Host` header of the request is used.
-
 
                                         Support: Core
                                       maxLength: 253
@@ -870,7 +1095,6 @@ spec:
                                         Path defines parameters used to modify the path of the incoming request.
                                         The modified path is then used to construct the `Location` header. When
                                         empty, the request path is used as-is.
-
 
                                         Support: Extended
                                       properties:
@@ -887,32 +1111,17 @@ spec:
                                             to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
                                             of "/xyz" would be modified to "/xyz/bar".
 
-
                                             Note that this matches the behavior of the PathPrefix match type. This
                                             matches full path elements. A path element refers to the list of labels
                                             in the path split by the `/` separator. When specified, a trailing `/` is
                                             ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
                                             match the prefix `/abc`, but the path `/abcd` would not.
 
-
                                             ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
                                             Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
                                             the implementation setting the Accepted Condition for the Route to `status: False`.
 
-
                                             Request Path | Prefix Match | Replace Prefix | Modified Path
-                                            -------------|--------------|----------------|----------
-                                            /foo/bar     | /foo         | /xyz           | /xyz/bar
-                                            /foo/bar     | /foo         | /xyz/          | /xyz/bar
-                                            /foo/bar     | /foo/        | /xyz           | /xyz/bar
-                                            /foo/bar     | /foo/        | /xyz/          | /xyz/bar
-                                            /foo         | /foo         | /xyz           | /xyz
-                                            /foo/        | /foo         | /xyz           | /xyz/
-                                            /foo/bar     | /foo         | <empty string> | /bar
-                                            /foo/        | /foo         | <empty string> | /
-                                            /foo         | /foo         | <empty string> | /
-                                            /foo/        | /foo         | /              | /
-                                            /foo         | /foo         | /              | /
                                           maxLength: 1024
                                           type: string
                                         type:
@@ -920,10 +1129,8 @@ spec:
                                             Type defines the type of path modifier. Additional types may be
                                             added in a future release of the API.
 
-
                                             Note that values may be added to this enum, implementations
                                             must ensure that unknown values will not cause a crash.
-
 
                                             Unknown values here must result in the implementation setting the
                                             Accepted Condition for the Route to `status: False`, with a
@@ -957,10 +1164,8 @@ spec:
                                         Port is the port to be used in the value of the `Location`
                                         header in the response.
 
-
                                         If no port is specified, the redirect port MUST be derived using the
                                         following rules:
-
 
                                         * If redirect scheme is not-empty, the redirect port MUST be the well-known
                                           port associated with the redirect scheme. Specifically "http" to port 80
@@ -969,16 +1174,13 @@ spec:
                                         * If redirect scheme is empty, the redirect port MUST be the Gateway
                                           Listener port.
 
-
                                         Implementations SHOULD NOT add the port number in the 'Location'
                                         header in the following cases:
-
 
                                         * A Location header that will use HTTP (whether that is determined via
                                           the Listener protocol or the Scheme field) _and_ use port 80.
                                         * A Location header that will use HTTPS (whether that is determined via
                                           the Listener protocol or the Scheme field) _and_ use port 443.
-
 
                                         Support: Extended
                                       format: int32
@@ -990,19 +1192,15 @@ spec:
                                         Scheme is the scheme to be used in the value of the `Location` header in
                                         the response. When empty, the scheme of the request is used.
 
-
                                         Scheme redirects can affect the port of the redirect, for more information,
                                         refer to the documentation for the port field of this filter.
-
 
                                         Note that values may be added to this enum, implementations
                                         must ensure that unknown values will not cause a crash.
 
-
                                         Unknown values here must result in the implementation setting the
                                         Accepted Condition for the Route to `status: False`, with a
                                         Reason of `UnsupportedValue`.
-
 
                                         Support: Extended
                                       enum:
@@ -1014,15 +1212,12 @@ spec:
                                       description: |-
                                         StatusCode is the HTTP status code to be used in response.
 
-
                                         Note that values may be added to this enum, implementations
                                         must ensure that unknown values will not cause a crash.
-
 
                                         Unknown values here must result in the implementation setting the
                                         Accepted Condition for the Route to `status: False`, with a
                                         Reason of `UnsupportedValue`.
-
 
                                         Support: Core
                                       enum:
@@ -1035,7 +1230,6 @@ spec:
                                     ResponseHeaderModifier defines a schema for a filter that modifies response
                                     headers.
 
-
                                     Support: Extended
                                   properties:
                                     add:
@@ -1044,17 +1238,14 @@ spec:
                                         before the action. It appends to any existing values associated
                                         with the header name.
 
-
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header: foo
-
 
                                         Config:
                                           add:
                                           - name: "my-header"
                                             value: "bar,baz"
-
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -1067,8 +1258,7 @@ spec:
                                           name:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -1101,17 +1291,14 @@ spec:
                                         names are case-insensitive (see
                                         https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
 
-
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header1: foo
                                           my-header2: bar
                                           my-header3: baz
 
-
                                         Config:
                                           remove: ["my-header1", "my-header3"]
-
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -1126,17 +1313,14 @@ spec:
                                         Set overwrites the request with the given header (name, value)
                                         before the action.
 
-
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header: foo
-
 
                                         Config:
                                           set:
                                           - name: "my-header"
                                             value: "bar"
-
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -1149,8 +1333,7 @@ spec:
                                           name:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -1182,16 +1365,13 @@ spec:
                                     Type identifies the type of filter to apply. As with other API fields,
                                     types are classified into three conformance levels:
 
-
                                     - Core: Filter types and their corresponding configuration defined by
                                       "Support: Core" in this package, e.g. "RequestHeaderModifier". All
                                       implementations must support core filters.
 
-
                                     - Extended: Filter types and their corresponding configuration defined by
                                       "Support: Extended" in this package, e.g. "RequestMirror". Implementers
                                       are encouraged to support extended filters.
-
 
                                     - Implementation-specific: Filters that are defined and supported by
                                       specific vendors.
@@ -1201,19 +1381,15 @@ spec:
                                       is specified using the ExtensionRef field. `Type` should be set to
                                       "ExtensionRef" for custom filters.
 
-
                                     Implementers are encouraged to define custom implementation types to
                                     extend the core API with implementation-specific behavior.
-
 
                                     If a reference to a custom filter type cannot be resolved, the filter
                                     MUST NOT be skipped. Instead, requests that would have been processed by
                                     that filter MUST receive a HTTP error response.
 
-
                                     Note that values may be added to this enum, implementations
                                     must ensure that unknown values will not cause a crash.
-
 
                                     Unknown values here must result in the implementation setting the
                                     Accepted Condition for the Route to `status: False`, with a
@@ -1225,11 +1401,11 @@ spec:
                                   - RequestRedirect
                                   - URLRewrite
                                   - ExtensionRef
+                                  - CORS
                                   type: string
                                 urlRewrite:
                                   description: |-
                                     URLRewrite defines a schema for a filter that modifies a request during forwarding.
-
 
                                     Support: Extended
                                   properties:
@@ -1237,7 +1413,6 @@ spec:
                                       description: |-
                                         Hostname is the value to be used to replace the Host header value during
                                         forwarding.
-
 
                                         Support: Extended
                                       maxLength: 253
@@ -1247,7 +1422,6 @@ spec:
                                     path:
                                       description: |-
                                         Path defines a path rewrite.
-
 
                                         Support: Extended
                                       properties:
@@ -1264,32 +1438,17 @@ spec:
                                             to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
                                             of "/xyz" would be modified to "/xyz/bar".
 
-
                                             Note that this matches the behavior of the PathPrefix match type. This
                                             matches full path elements. A path element refers to the list of labels
                                             in the path split by the `/` separator. When specified, a trailing `/` is
                                             ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
                                             match the prefix `/abc`, but the path `/abcd` would not.
 
-
                                             ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
                                             Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
                                             the implementation setting the Accepted Condition for the Route to `status: False`.
 
-
                                             Request Path | Prefix Match | Replace Prefix | Modified Path
-                                            -------------|--------------|----------------|----------
-                                            /foo/bar     | /foo         | /xyz           | /xyz/bar
-                                            /foo/bar     | /foo         | /xyz/          | /xyz/bar
-                                            /foo/bar     | /foo/        | /xyz           | /xyz/bar
-                                            /foo/bar     | /foo/        | /xyz/          | /xyz/bar
-                                            /foo         | /foo         | /xyz           | /xyz
-                                            /foo/        | /foo         | /xyz           | /xyz/
-                                            /foo/bar     | /foo         | <empty string> | /bar
-                                            /foo/        | /foo         | <empty string> | /
-                                            /foo         | /foo         | <empty string> | /
-                                            /foo/        | /foo         | /              | /
-                                            /foo         | /foo         | /              | /
                                           maxLength: 1024
                                           type: string
                                         type:
@@ -1297,10 +1456,8 @@ spec:
                                             Type defines the type of path modifier. Additional types may be
                                             added in a future release of the API.
 
-
                                             Note that values may be added to this enum, implementations
                                             must ensure that unknown values will not cause a crash.
-
 
                                             Unknown values here must result in the implementation setting the
                                             Accepted Condition for the Route to `status: False`, with a
@@ -1377,6 +1534,11 @@ spec:
                               - message: filter.extensionRef must be specified for
                                   ExtensionRef filter.type
                                 rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                              - message: filter.cors must be nil if the filter.type
+                                  is not CORS
+                                rule: '!(has(self.cors) && self.type != ''CORS'')'
+                              - message: filter.cors must be specified for CORS filter.type
+                                rule: '!(!has(self.cors) && self.type == ''CORS'')'
                             maxItems: 16
                             type: array
                             x-kubernetes-validations:
@@ -1414,9 +1576,7 @@ spec:
                               Kind is the Kubernetes resource kind of the referent. For example
                               "Service".
 
-
                               Defaults to "Service" when not specified.
-
 
                               ExternalName services can refer to CNAME DNS records that may live
                               outside of the cluster and as such are difficult to reason about in
@@ -1424,9 +1584,7 @@ spec:
                               CVE-2021-25740 for more information). Implementations SHOULD NOT
                               support ExternalName Services.
 
-
                               Support: Core (Services with a type other than ExternalName)
-
 
                               Support: Implementation-specific (Services with type ExternalName)
                             maxLength: 63
@@ -1443,12 +1601,10 @@ spec:
                               Namespace is the namespace of the backend. When unspecified, the local
                               namespace is inferred.
 
-
                               Note that when a namespace different than the local namespace is specified,
                               a ReferenceGrant object is required in the referent namespace to allow that
                               namespace's owner to accept the reference. See the ReferenceGrant
                               documentation for details.
-
 
                               Support: Core
                             maxLength: 63
@@ -1476,12 +1632,10 @@ spec:
                               implementation supports. Weight is not a percentage and the sum of
                               weights does not need to equal 100.
 
-
                               If only one backend is specified and it has a weight greater than 0, 100%
                               of the traffic is forwarded to that backend. If weight is set to 0, no
                               traffic should be forwarded for this entry. If unspecified, weight
                               defaults to 1.
-
 
                               Support for this field varies based on the context where used.
                             format: int32
@@ -1502,16 +1656,13 @@ spec:
                         Filters define the filters that are applied to requests that match
                         this rule.
 
-
                         Wherever possible, implementations SHOULD implement filters in the order
                         they are specified.
 
-
                         Implementations MAY choose to implement this ordering strictly, rejecting
-                        any combination or order of filters that can not be supported. If implementations
+                        any combination or order of filters that cannot be supported. If implementations
                         choose a strict interpretation of filter ordering, they MUST clearly document
                         that behavior.
-
 
                         To reject an invalid combination or order of filters, implementations SHOULD
                         consider the Route Rules with this configuration invalid. If all Route Rules
@@ -1519,28 +1670,23 @@ spec:
                         a portion of Route Rules are invalid, implementations MUST set the
                         "PartiallyInvalid" condition for the Route.
 
-
                         Conformance-levels at this level are defined based on the type of filter:
-
 
                         - ALL core filters MUST be supported by all implementations.
                         - Implementers are encouraged to support extended filters.
                         - Implementation-specific custom filters have no API guarantees across
                           implementations.
 
-
                         Specifying the same filter multiple times is not supported unless explicitly
                         indicated in the filter.
 
-
                         All filters are expected to be compatible with each other except for the
                         URLRewrite and RequestRedirect filters, which may not be combined. If an
-                        implementation can not support other combinations of filters, they must clearly
+                        implementation cannot support other combinations of filters, they must clearly
                         document that limitation. In cases where incompatible or unsupported
                         filters are specified and cause the `Accepted` condition to be set to status
                         `False`, implementations may use the `IncompatibleFilters` reason to specify
                         this configuration error.
-
 
                         Support: Core
                       items:
@@ -1552,6 +1698,289 @@ spec:
                           authentication strategies, rate-limiting, and traffic shaping. API
                           guarantee/conformance is defined based on the type of the filter.
                         properties:
+                          cors:
+                            description: |-
+                              CORS defines a schema for a filter that responds to the
+                              cross-origin request based on HTTP response header.
+
+                              Support: Extended
+                            properties:
+                              allowCredentials:
+                                description: |-
+                                  AllowCredentials indicates whether the actual cross-origin request allows
+                                  to include credentials.
+
+                                  The only valid value for the `Access-Control-Allow-Credentials` response
+                                  header is true (case-sensitive).
+
+                                  If the credentials are not allowed in cross-origin requests, the gateway
+                                  will omit the header `Access-Control-Allow-Credentials` entirely rather
+                                  than setting its value to false.
+
+                                  Support: Extended
+                                enum:
+                                - true
+                                type: boolean
+                              allowHeaders:
+                                description: |-
+                                  AllowHeaders indicates which HTTP request headers are supported for
+                                  accessing the requested resource.
+
+                                  Header names are not case sensitive.
+
+                                  Multiple header names in the value of the `Access-Control-Allow-Headers`
+                                  response header are separated by a comma (",").
+
+                                  When the `AllowHeaders` field is configured with one or more headers, the
+                                  gateway must return the `Access-Control-Allow-Headers` response header
+                                  which value is present in the `AllowHeaders` field.
+
+                                  If any header name in the `Access-Control-Request-Headers` request header
+                                  is not included in the list of header names specified by the response
+                                  header `Access-Control-Allow-Headers`, it will present an error on the
+                                  client side.
+
+                                  If any header name in the `Access-Control-Allow-Headers` response header
+                                  does not recognize by the client, it will also occur an error on the
+                                  client side.
+
+                                  A wildcard indicates that the requests with all HTTP headers are allowed.
+                                  The `Access-Control-Allow-Headers` response header can only use `*`
+                                  wildcard as value when the `AllowCredentials` field is unspecified.
+
+                                  When the `AllowCredentials` field is specified and `AllowHeaders` field
+                                  specified with the `*` wildcard, the gateway must specify one or more
+                                  HTTP headers in the value of the `Access-Control-Allow-Headers` response
+                                  header. The value of the header `Access-Control-Allow-Headers` is same as
+                                  the `Access-Control-Request-Headers` header provided by the client. If
+                                  the header `Access-Control-Request-Headers` is not included in the
+                                  request, the gateway will omit the `Access-Control-Allow-Headers`
+                                  response header, instead of specifying the `*` wildcard. A Gateway
+                                  implementation may choose to add implementation-specific default headers.
+
+                                  Support: Extended
+                                items:
+                                  description: |-
+                                    HTTPHeaderName is the name of an HTTP header.
+
+                                    Valid values include:
+
+                                    * "Authorization"
+                                    * "Set-Cookie"
+
+                                    Invalid values include:
+
+                                      - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
+                                        headers are not currently supported by this type.
+                                      - "/invalid" - "/ " is an invalid character
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                maxItems: 64
+                                type: array
+                                x-kubernetes-list-type: set
+                              allowMethods:
+                                description: |-
+                                  AllowMethods indicates which HTTP methods are supported for accessing the
+                                  requested resource.
+
+                                  Valid values are any method defined by RFC9110, along with the special
+                                  value `*`, which represents all HTTP methods are allowed.
+
+                                  Method names are case sensitive, so these values are also case-sensitive.
+                                  (See https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1)
+
+                                  Multiple method names in the value of the `Access-Control-Allow-Methods`
+                                  response header are separated by a comma (",").
+
+                                  A CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.
+                                  (See https://fetch.spec.whatwg.org/#cors-safelisted-method) The
+                                  CORS-safelisted methods are always allowed, regardless of whether they
+                                  are specified in the `AllowMethods` field.
+
+                                  When the `AllowMethods` field is configured with one or more methods, the
+                                  gateway must return the `Access-Control-Allow-Methods` response header
+                                  which value is present in the `AllowMethods` field.
+
+                                  If the HTTP method of the `Access-Control-Request-Method` request header
+                                  is not included in the list of methods specified by the response header
+                                  `Access-Control-Allow-Methods`, it will present an error on the client
+                                  side.
+
+                                  The `Access-Control-Allow-Methods` response header can only use `*`
+                                  wildcard as value when the `AllowCredentials` field is unspecified.
+
+                                  When the `AllowCredentials` field is specified and `AllowMethods` field
+                                  specified with the `*` wildcard, the gateway must specify one HTTP method
+                                  in the value of the Access-Control-Allow-Methods response header. The
+                                  value of the header `Access-Control-Allow-Methods` is same as the
+                                  `Access-Control-Request-Method` header provided by the client. If the
+                                  header `Access-Control-Request-Method` is not included in the request,
+                                  the gateway will omit the `Access-Control-Allow-Methods` response header,
+                                  instead of specifying the `*` wildcard. A Gateway implementation may
+                                  choose to add implementation-specific default methods.
+
+                                  Support: Extended
+                                items:
+                                  enum:
+                                  - GET
+                                  - HEAD
+                                  - POST
+                                  - PUT
+                                  - DELETE
+                                  - CONNECT
+                                  - OPTIONS
+                                  - TRACE
+                                  - PATCH
+                                  - '*'
+                                  type: string
+                                maxItems: 9
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: AllowMethods cannot contain '*' alongside
+                                    other methods
+                                  rule: '!(''*'' in self && self.size() > 1)'
+                              allowOrigins:
+                                description: |-
+                                  AllowOrigins indicates whether the response can be shared with requested
+                                  resource from the given `Origin`.
+
+                                  The `Origin` consists of a scheme and a host, with an optional port, and
+                                  takes the form `<scheme>://<host>(:<port>)`.
+
+                                  Valid values for scheme are: `http` and `https`.
+
+                                  Valid values for port are any integer between 1 and 65535 (the list of
+                                  available TCP/UDP ports). Note that, if not included, port `80` is
+                                  assumed for `http` scheme origins, and port `443` is assumed for `https`
+                                  origins. This may affect origin matching.
+
+                                  The host part of the origin may contain the wildcard character `*`. These
+                                  wildcard characters behave as follows:
+
+                                  * `*` is a greedy match to the _left_, including any number of
+                                    DNS labels to the left of its position. This also means that
+                                    `*` will include any number of period `.` characters to the
+                                    left of its position.
+                                  * A wildcard by itself matches all hosts.
+
+                                  An origin value that includes _only_ the `*` character indicates requests
+                                  from all `Origin`s are allowed.
+
+                                  When the `AllowOrigins` field is configured with multiple origins, it
+                                  means the server supports clients from multiple origins. If the request
+                                  `Origin` matches the configured allowed origins, the gateway must return
+                                  the given `Origin` and sets value of the header
+                                  `Access-Control-Allow-Origin` same as the `Origin` header provided by the
+                                  client.
+
+                                  The status code of a successful response to a "preflight" request is
+                                  always an OK status (i.e., 204 or 200).
+
+                                  If the request `Origin` does not match the configured allowed origins,
+                                  the gateway returns 204/200 response but doesn't set the relevant
+                                  cross-origin response headers. Alternatively, the gateway responds with
+                                  403 status to the "preflight" request is denied, coupled with omitting
+                                  the CORS headers. The cross-origin request fails on the client side.
+                                  Therefore, the client doesn't attempt the actual cross-origin request.
+
+                                  The `Access-Control-Allow-Origin` response header can only use `*`
+                                  wildcard as value when the `AllowCredentials` field is unspecified.
+
+                                  When the `AllowCredentials` field is specified and `AllowOrigins` field
+                                  specified with the `*` wildcard, the gateway must return a single origin
+                                  in the value of the `Access-Control-Allow-Origin` response header,
+                                  instead of specifying the `*` wildcard. The value of the header
+                                  `Access-Control-Allow-Origin` is same as the `Origin` header provided by
+                                  the client.
+
+                                  Support: Extended
+                                items:
+                                  description: |-
+                                    The AbsoluteURI MUST NOT be a relative URI, and it MUST follow the URI syntax and
+                                    encoding rules specified in RFC3986.  The AbsoluteURI MUST include both a
+                                    scheme (e.g., "http" or "spiffe") and a scheme-specific-part.  URIs that
+                                    include an authority MUST include a fully qualified domain name or
+                                    IP address as the host.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^(([^:/?#]+):)(//([^/?#]*))([^?#]*)(\?([^#]*))?(#(.*))?
+                                  type: string
+                                maxItems: 64
+                                type: array
+                                x-kubernetes-list-type: set
+                              exposeHeaders:
+                                description: |-
+                                  ExposeHeaders indicates which HTTP response headers can be exposed
+                                  to client-side scripts in response to a cross-origin request.
+
+                                  A CORS-safelisted response header is an HTTP header in a CORS response
+                                  that it is considered safe to expose to the client scripts.
+                                  The CORS-safelisted response headers include the following headers:
+                                  `Cache-Control`
+                                  `Content-Language`
+                                  `Content-Length`
+                                  `Content-Type`
+                                  `Expires`
+                                  `Last-Modified`
+                                  `Pragma`
+                                  (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
+                                  The CORS-safelisted response headers are exposed to client by default.
+
+                                  When an HTTP header name is specified using the `ExposeHeaders` field,
+                                  this additional header will be exposed as part of the response to the
+                                  client.
+
+                                  Header names are not case sensitive.
+
+                                  Multiple header names in the value of the `Access-Control-Expose-Headers`
+                                  response header are separated by a comma (",").
+
+                                  A wildcard indicates that the responses with all HTTP headers are exposed
+                                  to clients. The `Access-Control-Expose-Headers` response header can only
+                                  use `*` wildcard as value when the `AllowCredentials` field is
+                                  unspecified.
+
+                                  Support: Extended
+                                items:
+                                  description: |-
+                                    HTTPHeaderName is the name of an HTTP header.
+
+                                    Valid values include:
+
+                                    * "Authorization"
+                                    * "Set-Cookie"
+
+                                    Invalid values include:
+
+                                      - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
+                                        headers are not currently supported by this type.
+                                      - "/invalid" - "/ " is an invalid character
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                maxItems: 64
+                                type: array
+                                x-kubernetes-list-type: set
+                              maxAge:
+                                default: 5
+                                description: |-
+                                  MaxAge indicates the duration (in seconds) for the client to cache the
+                                  results of a "preflight" request.
+
+                                  The information provided by the `Access-Control-Allow-Methods` and
+                                  `Access-Control-Allow-Headers` response headers can be cached by the
+                                  client until the time specified by `Access-Control-Max-Age` elapses.
+
+                                  The default value of `Access-Control-Max-Age` response header is 5
+                                  (seconds).
+                                format: int32
+                                minimum: 1
+                                type: integer
+                            type: object
                           extensionRef:
                             description: |-
                               ExtensionRef is an optional, implementation-specific extension to the
@@ -1559,9 +1988,7 @@ spec:
                               "networking.example.net"). ExtensionRef MUST NOT be used for core and
                               extended filters.
 
-
                               This filter can be used multiple times within the same rule.
-
 
                               Support: Implementation-specific
                             properties:
@@ -1594,7 +2021,6 @@ spec:
                               RequestHeaderModifier defines a schema for a filter that modifies request
                               headers.
 
-
                               Support: Core
                             properties:
                               add:
@@ -1603,17 +2029,14 @@ spec:
                                   before the action. It appends to any existing values associated
                                   with the header name.
 
-
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header: foo
-
 
                                   Config:
                                     add:
                                     - name: "my-header"
                                       value: "bar,baz"
-
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -1625,8 +2048,7 @@ spec:
                                     name:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -1659,17 +2081,14 @@ spec:
                                   names are case-insensitive (see
                                   https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
 
-
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header1: foo
                                     my-header2: bar
                                     my-header3: baz
 
-
                                   Config:
                                     remove: ["my-header1", "my-header3"]
-
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -1684,17 +2103,14 @@ spec:
                                   Set overwrites the request with the given header (name, value)
                                   before the action.
 
-
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header: foo
-
 
                                   Config:
                                     set:
                                     - name: "my-header"
                                       value: "bar"
-
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -1706,8 +2122,7 @@ spec:
                                     name:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -1740,11 +2155,9 @@ spec:
                               Requests are sent to the specified destination, but responses from
                               that destination are ignored.
 
-
                               This filter can be used multiple times within the same rule. Note that
                               not all implementations will be able to support mirroring to multiple
                               backends.
-
 
                               Support: Extended
                             properties:
@@ -1752,17 +2165,14 @@ spec:
                                 description: |-
                                   BackendRef references a resource where mirrored requests are sent.
 
-
                                   Mirrored requests must be sent only to a single destination endpoint
                                   within this BackendRef, irrespective of how many endpoints are present
                                   within this BackendRef.
-
 
                                   If the referent cannot be found, this BackendRef is invalid and must be
                                   dropped from the Gateway. The controller must ensure the "ResolvedRefs"
                                   condition on the Route status is set to `status: False` and not configure
                                   this backend in the underlying implementation.
-
 
                                   If there is a cross-namespace reference to an *existing* object
                                   that is not allowed by a ReferenceGrant, the controller must ensure the
@@ -1770,13 +2180,10 @@ spec:
                                   with the "RefNotPermitted" reason and not configure this backend in the
                                   underlying implementation.
 
-
                                   In either error case, the Message of the `ResolvedRefs` Condition
                                   should be used to provide more detail about the problem.
 
-
                                   Support: Extended for Kubernetes Service
-
 
                                   Support: Implementation-specific for any other resource
                                 properties:
@@ -1794,9 +2201,7 @@ spec:
                                       Kind is the Kubernetes resource kind of the referent. For example
                                       "Service".
 
-
                                       Defaults to "Service" when not specified.
-
 
                                       ExternalName services can refer to CNAME DNS records that may live
                                       outside of the cluster and as such are difficult to reason about in
@@ -1804,9 +2209,7 @@ spec:
                                       CVE-2021-25740 for more information). Implementations SHOULD NOT
                                       support ExternalName Services.
 
-
                                       Support: Core (Services with a type other than ExternalName)
-
 
                                       Support: Implementation-specific (Services with type ExternalName)
                                     maxLength: 63
@@ -1823,12 +2226,10 @@ spec:
                                       Namespace is the namespace of the backend. When unspecified, the local
                                       namespace is inferred.
 
-
                                       Note that when a namespace different than the local namespace is specified,
                                       a ReferenceGrant object is required in the referent namespace to allow that
                                       namespace's owner to accept the reference. See the ReferenceGrant
                                       documentation for details.
-
 
                                       Support: Core
                                     maxLength: 63
@@ -1853,14 +2254,53 @@ spec:
                                 - message: Must have port for Service reference
                                   rule: '(size(self.group) == 0 && self.kind == ''Service'')
                                     ? has(self.port) : true'
+                              fraction:
+                                description: |-
+                                  Fraction represents the fraction of requests that should be
+                                  mirrored to BackendRef.
+
+                                  Only one of Fraction or Percent may be specified. If neither field
+                                  is specified, 100% of requests will be mirrored.
+                                properties:
+                                  denominator:
+                                    default: 100
+                                    format: int32
+                                    minimum: 1
+                                    type: integer
+                                  numerator:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                - numerator
+                                type: object
+                                x-kubernetes-validations:
+                                - message: numerator must be less than or equal to
+                                    denominator
+                                  rule: self.numerator <= self.denominator
+                              percent:
+                                description: |-
+                                  Percent represents the percentage of requests that should be
+                                  mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
+                                  requests) and its maximum value is 100 (indicating 100% of requests).
+
+                                  Only one of Fraction or Percent may be specified. If neither field
+                                  is specified, 100% of requests will be mirrored.
+                                format: int32
+                                maximum: 100
+                                minimum: 0
+                                type: integer
                             required:
                             - backendRef
                             type: object
+                            x-kubernetes-validations:
+                            - message: Only one of percent or fraction may be specified
+                                in HTTPRequestMirrorFilter
+                              rule: '!(has(self.percent) && has(self.fraction))'
                           requestRedirect:
                             description: |-
                               RequestRedirect defines a schema for a filter that responds to the
                               request with an HTTP redirection.
-
 
                               Support: Core
                             properties:
@@ -1869,7 +2309,6 @@ spec:
                                   Hostname is the hostname to be used in the value of the `Location`
                                   header in the response.
                                   When empty, the hostname in the `Host` header of the request is used.
-
 
                                   Support: Core
                                 maxLength: 253
@@ -1881,7 +2320,6 @@ spec:
                                   Path defines parameters used to modify the path of the incoming request.
                                   The modified path is then used to construct the `Location` header. When
                                   empty, the request path is used as-is.
-
 
                                   Support: Extended
                                 properties:
@@ -1898,32 +2336,17 @@ spec:
                                       to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
                                       of "/xyz" would be modified to "/xyz/bar".
 
-
                                       Note that this matches the behavior of the PathPrefix match type. This
                                       matches full path elements. A path element refers to the list of labels
                                       in the path split by the `/` separator. When specified, a trailing `/` is
                                       ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
                                       match the prefix `/abc`, but the path `/abcd` would not.
 
-
                                       ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
                                       Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
                                       the implementation setting the Accepted Condition for the Route to `status: False`.
 
-
                                       Request Path | Prefix Match | Replace Prefix | Modified Path
-                                      -------------|--------------|----------------|----------
-                                      /foo/bar     | /foo         | /xyz           | /xyz/bar
-                                      /foo/bar     | /foo         | /xyz/          | /xyz/bar
-                                      /foo/bar     | /foo/        | /xyz           | /xyz/bar
-                                      /foo/bar     | /foo/        | /xyz/          | /xyz/bar
-                                      /foo         | /foo         | /xyz           | /xyz
-                                      /foo/        | /foo         | /xyz           | /xyz/
-                                      /foo/bar     | /foo         | <empty string> | /bar
-                                      /foo/        | /foo         | <empty string> | /
-                                      /foo         | /foo         | <empty string> | /
-                                      /foo/        | /foo         | /              | /
-                                      /foo         | /foo         | /              | /
                                     maxLength: 1024
                                     type: string
                                   type:
@@ -1931,10 +2354,8 @@ spec:
                                       Type defines the type of path modifier. Additional types may be
                                       added in a future release of the API.
 
-
                                       Note that values may be added to this enum, implementations
                                       must ensure that unknown values will not cause a crash.
-
 
                                       Unknown values here must result in the implementation setting the
                                       Accepted Condition for the Route to `status: False`, with a
@@ -1968,10 +2389,8 @@ spec:
                                   Port is the port to be used in the value of the `Location`
                                   header in the response.
 
-
                                   If no port is specified, the redirect port MUST be derived using the
                                   following rules:
-
 
                                   * If redirect scheme is not-empty, the redirect port MUST be the well-known
                                     port associated with the redirect scheme. Specifically "http" to port 80
@@ -1980,16 +2399,13 @@ spec:
                                   * If redirect scheme is empty, the redirect port MUST be the Gateway
                                     Listener port.
 
-
                                   Implementations SHOULD NOT add the port number in the 'Location'
                                   header in the following cases:
-
 
                                   * A Location header that will use HTTP (whether that is determined via
                                     the Listener protocol or the Scheme field) _and_ use port 80.
                                   * A Location header that will use HTTPS (whether that is determined via
                                     the Listener protocol or the Scheme field) _and_ use port 443.
-
 
                                   Support: Extended
                                 format: int32
@@ -2001,19 +2417,15 @@ spec:
                                   Scheme is the scheme to be used in the value of the `Location` header in
                                   the response. When empty, the scheme of the request is used.
 
-
                                   Scheme redirects can affect the port of the redirect, for more information,
                                   refer to the documentation for the port field of this filter.
-
 
                                   Note that values may be added to this enum, implementations
                                   must ensure that unknown values will not cause a crash.
 
-
                                   Unknown values here must result in the implementation setting the
                                   Accepted Condition for the Route to `status: False`, with a
                                   Reason of `UnsupportedValue`.
-
 
                                   Support: Extended
                                 enum:
@@ -2025,15 +2437,12 @@ spec:
                                 description: |-
                                   StatusCode is the HTTP status code to be used in response.
 
-
                                   Note that values may be added to this enum, implementations
                                   must ensure that unknown values will not cause a crash.
-
 
                                   Unknown values here must result in the implementation setting the
                                   Accepted Condition for the Route to `status: False`, with a
                                   Reason of `UnsupportedValue`.
-
 
                                   Support: Core
                                 enum:
@@ -2046,7 +2455,6 @@ spec:
                               ResponseHeaderModifier defines a schema for a filter that modifies response
                               headers.
 
-
                               Support: Extended
                             properties:
                               add:
@@ -2055,17 +2463,14 @@ spec:
                                   before the action. It appends to any existing values associated
                                   with the header name.
 
-
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header: foo
-
 
                                   Config:
                                     add:
                                     - name: "my-header"
                                       value: "bar,baz"
-
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -2077,8 +2482,7 @@ spec:
                                     name:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -2111,17 +2515,14 @@ spec:
                                   names are case-insensitive (see
                                   https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
 
-
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header1: foo
                                     my-header2: bar
                                     my-header3: baz
 
-
                                   Config:
                                     remove: ["my-header1", "my-header3"]
-
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -2136,17 +2537,14 @@ spec:
                                   Set overwrites the request with the given header (name, value)
                                   before the action.
 
-
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header: foo
-
 
                                   Config:
                                     set:
                                     - name: "my-header"
                                       value: "bar"
-
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -2158,8 +2556,7 @@ spec:
                                     name:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -2191,16 +2588,13 @@ spec:
                               Type identifies the type of filter to apply. As with other API fields,
                               types are classified into three conformance levels:
 
-
                               - Core: Filter types and their corresponding configuration defined by
                                 "Support: Core" in this package, e.g. "RequestHeaderModifier". All
                                 implementations must support core filters.
 
-
                               - Extended: Filter types and their corresponding configuration defined by
                                 "Support: Extended" in this package, e.g. "RequestMirror". Implementers
                                 are encouraged to support extended filters.
-
 
                               - Implementation-specific: Filters that are defined and supported by
                                 specific vendors.
@@ -2210,19 +2604,15 @@ spec:
                                 is specified using the ExtensionRef field. `Type` should be set to
                                 "ExtensionRef" for custom filters.
 
-
                               Implementers are encouraged to define custom implementation types to
                               extend the core API with implementation-specific behavior.
-
 
                               If a reference to a custom filter type cannot be resolved, the filter
                               MUST NOT be skipped. Instead, requests that would have been processed by
                               that filter MUST receive a HTTP error response.
 
-
                               Note that values may be added to this enum, implementations
                               must ensure that unknown values will not cause a crash.
-
 
                               Unknown values here must result in the implementation setting the
                               Accepted Condition for the Route to `status: False`, with a
@@ -2234,11 +2624,11 @@ spec:
                             - RequestRedirect
                             - URLRewrite
                             - ExtensionRef
+                            - CORS
                             type: string
                           urlRewrite:
                             description: |-
                               URLRewrite defines a schema for a filter that modifies a request during forwarding.
-
 
                               Support: Extended
                             properties:
@@ -2246,7 +2636,6 @@ spec:
                                 description: |-
                                   Hostname is the value to be used to replace the Host header value during
                                   forwarding.
-
 
                                   Support: Extended
                                 maxLength: 253
@@ -2256,7 +2645,6 @@ spec:
                               path:
                                 description: |-
                                   Path defines a path rewrite.
-
 
                                   Support: Extended
                                 properties:
@@ -2273,32 +2661,17 @@ spec:
                                       to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
                                       of "/xyz" would be modified to "/xyz/bar".
 
-
                                       Note that this matches the behavior of the PathPrefix match type. This
                                       matches full path elements. A path element refers to the list of labels
                                       in the path split by the `/` separator. When specified, a trailing `/` is
                                       ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
                                       match the prefix `/abc`, but the path `/abcd` would not.
 
-
                                       ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
                                       Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
                                       the implementation setting the Accepted Condition for the Route to `status: False`.
 
-
                                       Request Path | Prefix Match | Replace Prefix | Modified Path
-                                      -------------|--------------|----------------|----------
-                                      /foo/bar     | /foo         | /xyz           | /xyz/bar
-                                      /foo/bar     | /foo         | /xyz/          | /xyz/bar
-                                      /foo/bar     | /foo/        | /xyz           | /xyz/bar
-                                      /foo/bar     | /foo/        | /xyz/          | /xyz/bar
-                                      /foo         | /foo         | /xyz           | /xyz
-                                      /foo/        | /foo         | /xyz           | /xyz/
-                                      /foo/bar     | /foo         | <empty string> | /bar
-                                      /foo/        | /foo         | <empty string> | /
-                                      /foo         | /foo         | <empty string> | /
-                                      /foo/        | /foo         | /              | /
-                                      /foo         | /foo         | /              | /
                                     maxLength: 1024
                                     type: string
                                   type:
@@ -2306,10 +2679,8 @@ spec:
                                       Type defines the type of path modifier. Additional types may be
                                       added in a future release of the API.
 
-
                                       Note that values may be added to this enum, implementations
                                       must ensure that unknown values will not cause a crash.
-
 
                                       Unknown values here must result in the implementation setting the
                                       Accepted Condition for the Route to `status: False`, with a
@@ -2383,6 +2754,11 @@ spec:
                         - message: filter.extensionRef must be specified for ExtensionRef
                             filter.type
                           rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                        - message: filter.cors must be nil if the filter.type is not
+                            CORS
+                          rule: '!(has(self.cors) && self.type != ''CORS'')'
+                        - message: filter.cors must be specified for CORS filter.type
+                          rule: '!(!has(self.cors) && self.type == ''CORS'')'
                       maxItems: 16
                       type: array
                       x-kubernetes-validations:
@@ -2411,9 +2787,7 @@ spec:
                         HTTP requests. Each match is independent, i.e. this rule will be matched
                         if **any** one of the matches is satisfied.
 
-
                         For example, take the following matches configuration:
-
 
                         ```
                         matches:
@@ -2426,29 +2800,23 @@ spec:
                             value: "/v2/foo"
                         ```
 
-
                         For a request to match against this rule, a request must satisfy
                         EITHER of the two conditions:
-
 
                         - path prefixed with `/foo` AND contains the header `version: v2`
                         - path prefix of `/v2/foo`
 
-
                         See the documentation for HTTPRouteMatch on how to specify multiple
                         match conditions that should be ANDed together.
-
 
                         If no matches are specified, the default is a prefix
                         path match on "/", which has the effect of matching every
                         HTTP request.
 
-
                         Proxy or Load Balancer routing configuration generated from HTTPRoutes
                         MUST prioritize matches based on the following criteria, continuing on
                         ties. Across all rules specified on applicable Routes, precedence must be
                         given to the match having:
-
 
                         * "Exact" path match.
                         * "Prefix" path match with largest number of characters.
@@ -2456,23 +2824,18 @@ spec:
                         * Largest number of header matches.
                         * Largest number of query param matches.
 
-
                         Note: The precedence of RegularExpression path matches are implementation-specific.
-
 
                         If ties still exist across multiple Routes, matching precedence MUST be
                         determined in order of the following criteria, continuing on ties:
-
 
                         * The oldest Route based on creation timestamp.
                         * The Route appearing first in alphabetical order by
                           "{namespace}/{name}".
 
-
                         If ties still exist within an HTTPRoute, matching precedence MUST be granted
                         to the FIRST matching rule (in list order) with a match meeting the above
                         criteria.
-
 
                         When no rules matching a request have been successfully attached to the
                         parent a request is coming from, a HTTP 404 status code MUST be returned.
@@ -2480,11 +2843,11 @@ spec:
                         description: "HTTPRouteMatch defines the predicate used to
                           match requests to a given\naction. Multiple match types
                           are ANDed together, i.e. the match will\nevaluate to true
-                          only if all conditions are satisfied.\n\n\nFor example,
-                          the match below will match a HTTP request only if its path\nstarts
-                          with `/foo` AND it contains the `version: v1` header:\n\n\n```\nmatch:\n\n\n\tpath:\n\t
+                          only if all conditions are satisfied.\n\nFor example, the
+                          match below will match a HTTP request only if its path\nstarts
+                          with `/foo` AND it contains the `version: v1` header:\n\n```\nmatch:\n\n\tpath:\n\t
                           \ value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t
-                          \ value \"v1\"\n\n\n```"
+                          \ value \"v1\"\n\n```"
                         properties:
                           headers:
                             description: |-
@@ -2499,15 +2862,13 @@ spec:
                                 name:
                                   description: |-
                                     Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                    case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
+                                    case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                     If multiple entries specify equivalent header names, only the first
                                     entry with an equivalent name MUST be considered for a match. Subsequent
                                     entries with an equivalent header name MUST be ignored. Due to the
                                     case-insensitivity of header names, "foo" and "Foo" are considered
                                     equivalent.
-
 
                                     When a header is repeated in an HTTP request, it is
                                     implementation-specific behavior as to how this is represented.
@@ -2523,12 +2884,9 @@ spec:
                                   description: |-
                                     Type specifies how to match against the value of the header.
 
-
                                     Support: Core (Exact)
 
-
                                     Support: Implementation-specific (RegularExpression)
-
 
                                     Since RegularExpression HeaderMatchType has implementation-specific
                                     conformance, implementations can support POSIX, PCRE or any other dialects
@@ -2559,7 +2917,6 @@ spec:
                               When specified, this route will be matched only if the request has the
                               specified method.
 
-
                               Support: Extended
                             enum:
                             - GET
@@ -2585,9 +2942,7 @@ spec:
                                 description: |-
                                   Type specifies how to match against the path Value.
 
-
                                   Support: Core (Exact, PathPrefix)
-
 
                                   Support: Implementation-specific (RegularExpression)
                                 enum:
@@ -2653,7 +3008,6 @@ spec:
                               values are ANDed together, meaning, a request must match all the
                               specified query parameters to select the route.
 
-
                               Support: Extended
                             items:
                               description: |-
@@ -2666,11 +3020,9 @@ spec:
                                     exact string match. (See
                                     https://tools.ietf.org/html/rfc7230#section-2.7.3).
 
-
                                     If multiple entries specify equivalent query param names, only the first
                                     entry with an equivalent name MUST be considered for a match. Subsequent
                                     entries with an equivalent query param name MUST be ignored.
-
 
                                     If a query param is repeated in an HTTP request, the behavior is
                                     purposely left undefined, since different data planes have different
@@ -2678,7 +3030,6 @@ spec:
                                     match against the first value of the param if the data plane supports it,
                                     as this behavior is expected in other load balancing contexts outside of
                                     the Gateway API.
-
 
                                     Users SHOULD NOT route traffic based on repeated query params to guard
                                     themselves against potential differences in the implementations.
@@ -2691,12 +3042,9 @@ spec:
                                   description: |-
                                     Type specifies how to match against the value of the query parameter.
 
-
                                     Support: Extended (Exact)
 
-
                                     Support: Implementation-specific (RegularExpression)
-
 
                                     Since RegularExpression QueryParamMatchType has Implementation-specific
                                     conformance, implementations can support POSIX, PCRE or any other
@@ -2722,24 +3070,116 @@ spec:
                             - name
                             x-kubernetes-list-type: map
                         type: object
-                      maxItems: 8
+                      maxItems: 64
                       type: array
+                    name:
+                      description: |-
+                        Name is the name of the route rule. This name MUST be unique within a Route if it is set.
+
+                        Support: Extended
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    retry:
+                      description: |-
+                        Retry defines the configuration for when to retry an HTTP request.
+
+                        Support: Extended
+                      properties:
+                        attempts:
+                          description: |-
+                            Attempts specifies the maximum number of times an individual request
+                            from the gateway to a backend should be retried.
+
+                            If the maximum number of retries has been attempted without a successful
+                            response from the backend, the Gateway MUST return an error.
+
+                            When this field is unspecified, the number of times to attempt to retry
+                            a backend request is implementation-specific.
+
+                            Support: Extended
+                          type: integer
+                        backoff:
+                          description: |-
+                            Backoff specifies the minimum duration a Gateway should wait between
+                            retry attempts and is represented in Gateway API Duration formatting.
+
+                            For example, setting the `rules[].retry.backoff` field to the value
+                            `100ms` will cause a backend request to first be retried approximately
+                            100 milliseconds after timing out or receiving a response code configured
+                            to be retryable.
+
+                            An implementation MAY use an exponential or alternative backoff strategy
+                            for subsequent retry attempts, MAY cap the maximum backoff duration to
+                            some amount greater than the specified minimum, and MAY add arbitrary
+                            jitter to stagger requests, as long as unsuccessful backend requests are
+                            not retried before the configured minimum duration.
+
+                            If a Request timeout (`rules[].timeouts.request`) is configured on the
+                            route, the entire duration of the initial request and any retry attempts
+                            MUST not exceed the Request timeout duration. If any retry attempts are
+                            still in progress when the Request timeout duration has been reached,
+                            these SHOULD be canceled if possible and the Gateway MUST immediately
+                            return a timeout error.
+
+                            If a BackendRequest timeout (`rules[].timeouts.backendRequest`) is
+                            configured on the route, any retry attempts which reach the configured
+                            BackendRequest timeout duration without a response SHOULD be canceled if
+                            possible and the Gateway should wait for at least the specified backoff
+                            duration before attempting to retry the backend request again.
+
+                            If a BackendRequest timeout is _not_ configured on the route, retry
+                            attempts MAY time out after an implementation default duration, or MAY
+                            remain pending until a configured Request timeout or implementation
+                            default duration for total request time is reached.
+
+                            When this field is unspecified, the time to wait between retry attempts
+                            is implementation-specific.
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        codes:
+                          description: |-
+                            Codes defines the HTTP response status codes for which a backend request
+                            should be retried.
+
+                            Support: Extended
+                          items:
+                            description: |-
+                              HTTPRouteRetryStatusCode defines an HTTP response status code for
+                              which a backend request should be retried.
+
+                              Implementations MUST support the following status codes as retryable:
+
+                              * 500
+                              * 502
+                              * 503
+                              * 504
+
+                              Implementations MAY support specifying additional discrete values in the
+                              500-599 range.
+
+                              Implementations MAY support specifying discrete values in the 400-499 range,
+                              which are often inadvisable to retry.
+                            maximum: 599
+                            minimum: 400
+                            type: integer
+                          type: array
+                      type: object
                     sessionPersistence:
-                      description: |+
+                      description: |-
                         SessionPersistence defines and configures session persistence
                         for the route rule.
 
-
                         Support: Extended
-
-
                       properties:
                         absoluteTimeout:
                           description: |-
                             AbsoluteTimeout defines the absolute timeout of the persistent
                             session. Once the AbsoluteTimeout duration has elapsed, the
                             session becomes invalid.
-
 
                             Support: Extended
                           pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
@@ -2748,7 +3188,6 @@ spec:
                           description: |-
                             CookieConfig provides configuration settings that are specific
                             to cookie-based session persistence.
-
 
                             Support: Core
                           properties:
@@ -2761,19 +3200,17 @@ spec:
                                 attributes, while a session cookie is deleted when the current
                                 session ends.
 
-
                                 When set to "Permanent", AbsoluteTimeout indicates the
                                 cookie's lifetime via the Expires or Max-Age cookie attributes
                                 and is required.
-
 
                                 When set to "Session", AbsoluteTimeout indicates the
                                 absolute lifetime of the cookie tracked by the gateway and
                                 is optional.
 
+                                Defaults to "Session".
 
                                 Support: Core for "Session" type
-
 
                                 Support: Extended for "Permanent" type
                               enum:
@@ -2787,7 +3224,6 @@ spec:
                             Once the session has been idle for more than the specified
                             IdleTimeout duration, the session becomes invalid.
 
-
                             Support: Extended
                           pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                           type: string
@@ -2797,7 +3233,6 @@ spec:
                             which may be reflected in the cookie or the header. Users
                             should avoid reusing session names to prevent unintended
                             consequences, such as rejection or unpredictable behavior.
-
 
                             Support: Implementation-specific
                           maxLength: 128
@@ -2809,9 +3244,7 @@ spec:
                             the use a header or cookie. Defaults to cookie based session
                             persistence.
 
-
                             Support: Core for "Cookie" type
-
 
                             Support: Extended for "Header" type
                           enum:
@@ -2822,16 +3255,13 @@ spec:
                       x-kubernetes-validations:
                       - message: AbsoluteTimeout must be specified when cookie lifetimeType
                           is Permanent
-                        rule: '!has(self.cookieConfig.lifetimeType) || self.cookieConfig.lifetimeType
-                          != ''Permanent'' || has(self.absoluteTimeout)'
+                        rule: '!has(self.cookieConfig) || !has(self.cookieConfig.lifetimeType)
+                          || self.cookieConfig.lifetimeType != ''Permanent'' || has(self.absoluteTimeout)'
                     timeouts:
-                      description: |+
+                      description: |-
                         Timeouts defines the timeouts that can be configured for an HTTP request.
 
-
                         Support: Extended
-
-
                       properties:
                         backendRequest:
                           description: |-
@@ -2839,21 +3269,19 @@ spec:
                             to a backend. This covers the time from when the request first starts being
                             sent from the gateway to when the full response has been received from the backend.
 
-
                             Setting a timeout to the zero duration (e.g. "0s") SHOULD disable the timeout
                             completely. Implementations that cannot completely disable the timeout MUST
                             instead interpret the zero duration as the longest possible value to which
                             the timeout can be set.
 
-
                             An entire client HTTP transaction with a gateway, covered by the Request timeout,
                             may result in more than one call from the gateway to the destination backend,
                             for example, if automatic retries are supported.
 
-
-                            Because the Request timeout encompasses the BackendRequest timeout, the value of
-                            BackendRequest must be <= the value of Request timeout.
-
+                            The value of BackendRequest must be a Gateway API Duration string as defined by
+                            GEP-2257.  When this field is unspecified, its behavior is implementation-specific;
+                            when specified, the value of BackendRequest must be no more than the value of the
+                            Request timeout (since the Request timeout encompasses the BackendRequest timeout).
 
                             Support: Extended
                           pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
@@ -2864,26 +3292,22 @@ spec:
                             If the gateway has not been able to respond before this deadline is met, the gateway
                             MUST return a timeout error.
 
-
                             For example, setting the `rules.timeouts.request` field to the value `10s` in an
                             `HTTPRoute` will cause a timeout if a client request is taking longer than 10 seconds
                             to complete.
-
 
                             Setting a timeout to the zero duration (e.g. "0s") SHOULD disable the timeout
                             completely. Implementations that cannot completely disable the timeout MUST
                             instead interpret the zero duration as the longest possible value to which
                             the timeout can be set.
 
-
                             This timeout is intended to cover as close to the whole request-response transaction
                             as possible although an implementation MAY choose to start the timeout after the entire
                             request stream has been received instead of immediately after the transaction is
                             initiated by the client.
 
-
-                            When this field is unspecified, request timeout behavior is implementation-specific.
-
+                            The value of Request is a Gateway API Duration string as defined by GEP-2257. When this
+                            field is unspecified, request timeout behavior is implementation-specific.
 
                             Support: Extended
                           pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
@@ -2938,6 +3362,24 @@ spec:
                       != ''PathPrefix'') ? false : true) : true'
                 maxItems: 16
                 type: array
+                x-kubernetes-validations:
+                - message: While 16 rules and 64 matches per rule are allowed, the
+                    total number of matches across all rules in a route must be less
+                    than 128
+                  rule: '(self.size() > 0 ? self[0].matches.size() : 0) + (self.size()
+                    > 1 ? self[1].matches.size() : 0) + (self.size() > 2 ? self[2].matches.size()
+                    : 0) + (self.size() > 3 ? self[3].matches.size() : 0) + (self.size()
+                    > 4 ? self[4].matches.size() : 0) + (self.size() > 5 ? self[5].matches.size()
+                    : 0) + (self.size() > 6 ? self[6].matches.size() : 0) + (self.size()
+                    > 7 ? self[7].matches.size() : 0) + (self.size() > 8 ? self[8].matches.size()
+                    : 0) + (self.size() > 9 ? self[9].matches.size() : 0) + (self.size()
+                    > 10 ? self[10].matches.size() : 0) + (self.size() > 11 ? self[11].matches.size()
+                    : 0) + (self.size() > 12 ? self[12].matches.size() : 0) + (self.size()
+                    > 13 ? self[13].matches.size() : 0) + (self.size() > 14 ? self[14].matches.size()
+                    : 0) + (self.size() > 15 ? self[15].matches.size() : 0) <= 128'
+                - message: Rule name must be unique within the route
+                  rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name)
+                    && l1.name == l2.name))
             type: object
           status:
             description: Status defines the current state of HTTPRoute.
@@ -2951,12 +3393,10 @@ spec:
                   first sees the route and should update the entry as appropriate when the
                   route or gateway is modified.
 
-
                   Note that parent references that cannot be resolved by an implementation
                   of this API will not be added to this list. Implementations of this API
                   can only populate Route status for the Gateways/parent resources they are
                   responsible for.
-
 
                   A maximum of 32 Gateways will be represented in this list. An empty list
                   means the route has not been attached to any Gateway.
@@ -2971,38 +3411,24 @@ spec:
                         Note that the route's availability is also subject to the Gateway's own
                         status conditions and listener status.
 
-
                         If the Route's ParentRef specifies an existing Gateway that supports
                         Routes of this kind AND that Gateway's controller has sufficient access,
                         then that Gateway's controller MUST set the "Accepted" condition on the
                         Route, to indicate whether the route has been accepted or rejected by the
                         Gateway, and why.
 
-
                         A Route MUST be considered "Accepted" if at least one of the Route's
                         rules is implemented by the Gateway.
-
 
                         There are a number of cases where the "Accepted" condition may not be set
                         due to lack of controller visibility, that includes when:
 
-
-                        * The Route refers to a non-existent parent.
+                        * The Route refers to a nonexistent parent.
                         * The Route is of a type that the controller does not support.
                         * The Route is in a namespace the controller does not have access to.
                       items:
-                        description: "Condition contains details for one aspect of
-                          the current state of this API Resource.\n---\nThis struct
-                          is intended for direct use as an array at the field path
-                          .status.conditions.  For example,\n\n\n\ttype FooStatus
-                          struct{\n\t    // Represents the observations of a foo's
-                          current state.\n\t    // Known .status.conditions.type are:
-                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
-                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
-                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
-                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                          \   // other fields\n\t}"
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
                         properties:
                           lastTransitionTime:
                             description: |-
@@ -3044,12 +3470,7 @@ spec:
                             - Unknown
                             type: string
                           type:
-                            description: |-
-                              type of condition in CamelCase or in foo.example.com/CamelCase.
-                              ---
-                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                              useful (see .node.status.conditions), the ability to deconflict is important.
-                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
                             maxLength: 316
                             pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                             type: string
@@ -3072,14 +3493,11 @@ spec:
                         controller that wrote this status. This corresponds with the
                         controllerName field on GatewayClass.
 
-
                         Example: "example.net/gateway-controller".
-
 
                         The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
                         valid Kubernetes names
                         (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
-
 
                         Controllers MUST populate this field when writing status. Controllers should ensure that
                         entries to status populated with their ControllerName are cleaned up when they are no
@@ -3101,7 +3519,6 @@ spec:
                             To set the core API group (such as for a "Service" kind referent),
                             Group must be explicitly set to "" (empty string).
 
-
                             Support: Core
                           maxLength: 253
                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -3111,13 +3528,10 @@ spec:
                           description: |-
                             Kind is kind of the referent.
 
-
                             There are two kinds of parent resources with "Core" support:
-
 
                             * Gateway (Gateway conformance profile)
                             * Service (Mesh conformance profile, ClusterIP Services only)
-
 
                             Support for other resources is Implementation-Specific.
                           maxLength: 63
@@ -3128,7 +3542,6 @@ spec:
                           description: |-
                             Name is the name of the referent.
 
-
                             Support: Core
                           maxLength: 253
                           minLength: 1
@@ -3138,7 +3551,6 @@ spec:
                             Namespace is the namespace of the referent. When unspecified, this refers
                             to the local namespace of the Route.
 
-
                             Note that there are specific rules for ParentRefs which cross namespace
                             boundaries. Cross-namespace references are only valid if they are explicitly
                             allowed by something in the namespace they are referring to. For example:
@@ -3146,18 +3558,15 @@ spec:
                             generic way to enable any other kind of cross-namespace reference.
 
 
-
                             ParentRefs from a Route to a Service in the same namespace are "producer"
                             routes, which apply default routing rules to inbound connections from
                             any namespace to the Service.
-
 
                             ParentRefs from a Route to a Service in a different namespace are
                             "consumer" routes, and these routing rules are only applied to outbound
                             connections originating from the same namespace as the Route, for which
                             the intended destination of the connections are a Service targeted as a
                             ParentRef of the Route.
-
 
 
                             Support: Core
@@ -3170,7 +3579,6 @@ spec:
                             Port is the network port this Route targets. It can be interpreted
                             differently based on the type of parent resource.
 
-
                             When the parent resource is a Gateway, this targets all listeners
                             listening on the specified port that also support this kind of Route(and
                             select this Route). It's not recommended to set `Port` unless the
@@ -3180,17 +3588,14 @@ spec:
                             must match both specified values.
 
 
-
                             When the parent resource is a Service, this targets a specific port in the
                             Service spec. When both Port (experimental) and SectionName are specified,
                             the name and port of the selected port must match both specified values.
 
 
-
                             Implementations MAY choose to support other parent resources.
                             Implementations supporting other types of parent resources MUST clearly
                             document how/if Port is interpreted.
-
 
                             For the purpose of status, an attachment is considered successful as
                             long as the parent resource accepts it partially. For example, Gateway
@@ -3199,7 +3604,6 @@ spec:
                             from the referencing Route, the Route MUST be considered successfully
                             attached. If no Gateway listeners accept attachment from this Route,
                             the Route MUST be considered detached from the Gateway.
-
 
                             Support: Extended
                           format: int32
@@ -3211,7 +3615,6 @@ spec:
                             SectionName is the name of a section within the target resource. In the
                             following resources, SectionName is interpreted as the following:
 
-
                             * Gateway: Listener name. When both Port (experimental) and SectionName
                             are specified, the name and port of the selected listener must match
                             both specified values.
@@ -3219,11 +3622,9 @@ spec:
                             are specified, the name and port of the selected listener must match
                             both specified values.
 
-
                             Implementations MAY choose to support attaching Routes to other resources.
                             If that is the case, they MUST clearly document how SectionName is
                             interpreted.
-
 
                             When unspecified (empty string), this will reference the entire resource.
                             For the purpose of status, an attachment is considered successful if at
@@ -3233,7 +3634,6 @@ spec:
                             the referencing Route, the Route MUST be considered successfully
                             attached. If no Gateway listeners accept attachment from this Route, the
                             Route MUST be considered detached from the Gateway.
-
 
                             Support: Core
                           maxLength: 253
@@ -3303,20 +3703,16 @@ spec:
                   performing a match and (absent of any applicable header modification
                   configuration) MUST forward this header unmodified to the backend.
 
-
                   Valid values for Hostnames are determined by RFC 1123 definition of a
                   hostname with 2 notable exceptions:
-
 
                   1. IPs are not allowed.
                   2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
                      label must appear by itself as the first label.
 
-
                   If a hostname is specified by both the Listener and HTTPRoute, there
                   must be at least one intersecting hostname for the HTTPRoute to be
                   attached to the Listener. For example:
-
 
                   * A Listener with `test.example.com` as the hostname matches HTTPRoutes
                     that have either not specified any hostnames, or have specified at
@@ -3328,11 +3724,9 @@ spec:
                     all match. On the other hand, `example.com` and `test.example.net` would
                     not match.
 
-
                   Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
                   as a suffix match. That means that a match for `*.example.com` would match
                   both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
-
 
                   If both the Listener and HTTPRoute have specified hostnames, any
                   HTTPRoute hostnames that do not match the Listener hostname MUST be
@@ -3340,25 +3734,20 @@ spec:
                   HTTPRoute specified `test.example.com` and `test.example.net`,
                   `test.example.net` must not be considered for a match.
 
-
                   If both the Listener and HTTPRoute have specified hostnames, and none
                   match with the criteria above, then the HTTPRoute is not accepted. The
                   implementation must raise an 'Accepted' Condition with a status of
                   `False` in the corresponding RouteParentStatus.
 
-
                   In the event that multiple HTTPRoutes specify intersecting hostnames (e.g.
                   overlapping wildcard matching and exact matching hostnames), precedence must
                   be given to rules from the HTTPRoute with the largest number of:
 
-
                   * Characters in a matching non-wildcard hostname.
                   * Characters in a matching hostname.
 
-
                   If ties exist across multiple Routes, the matching precedence rules for
                   HTTPRouteMatches takes over.
-
 
                   Support: Core
                 items:
@@ -3366,16 +3755,13 @@ spec:
                     Hostname is the fully qualified domain name of a network host. This matches
                     the RFC 1123 definition of a hostname with 2 notable exceptions:
 
-
                      1. IPs are not allowed.
                      2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
                         label must appear by itself as the first label.
 
-
                     Hostname can be "precise" which is a domain name without the terminating
                     dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
                     domain name prefixed with a single wildcard label (e.g. `*.example.com`).
-
 
                     Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
                     alphanumeric characters or '-', and must start and end with an alphanumeric
@@ -3387,7 +3773,7 @@ spec:
                 maxItems: 16
                 type: array
               parentRefs:
-                description: |+
+                description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants
                   to be attached to. Note that the referenced parent resource needs to
                   allow this for the attachment to be complete. For Gateways, that means
@@ -3399,20 +3785,15 @@ spec:
                   create a "producer" route for a Service in a different namespace from the
                   Route.
 
-
                   There are two kinds of parent resources with "Core" support:
-
 
                   * Gateway (Gateway conformance profile)
                   * Service (Mesh conformance profile, ClusterIP Services only)
 
-
                   This API may be extended in the future to support additional kinds of parent
                   resources.
 
-
                   ParentRefs must be _distinct_. This means either that:
-
 
                   * They select different objects.  If this is the case, then parentRef
                     entries are distinct. In terms of fields, this means that the
@@ -3423,9 +3804,7 @@ spec:
                     optional fields to different values. If one ParentRef sets a
                     combination of optional fields, all must set the same combination.
 
-
                   Some examples:
-
 
                   * If one ParentRef sets `sectionName`, all ParentRefs referencing the
                     same object must also set `sectionName`.
@@ -3434,13 +3813,11 @@ spec:
                   * If one ParentRef sets `sectionName` and `port`, all ParentRefs
                     referencing the same object must also set `sectionName` and `port`.
 
-
                   It is possible to separately reference multiple distinct objects that may
                   be collapsed by an implementation. For example, some implementations may
                   choose to merge compatible Gateway Listeners together. If that is the
                   case, the list of routes attached to those resources should also be
                   merged.
-
 
                   Note that for ParentRefs that cross namespace boundaries, there are specific
                   rules. Cross-namespace references are only valid if they are explicitly
@@ -3449,37 +3826,26 @@ spec:
                   generic way to enable other kinds of cross-namespace reference.
 
 
-
                   ParentRefs from a Route to a Service in the same namespace are "producer"
                   routes, which apply default routing rules to inbound connections from
                   any namespace to the Service.
-
 
                   ParentRefs from a Route to a Service in a different namespace are
                   "consumer" routes, and these routing rules are only applied to outbound
                   connections originating from the same namespace as the Route, for which
                   the intended destination of the connections are a Service targeted as a
                   ParentRef of the Route.
-
-
-
-
-
-
                 items:
                   description: |-
                     ParentReference identifies an API object (usually a Gateway) that can be considered
                     a parent of this resource (usually a route). There are two kinds of parent resources
                     with "Core" support:
 
-
                     * Gateway (Gateway conformance profile)
                     * Service (Mesh conformance profile, ClusterIP Services only)
 
-
                     This API may be extended in the future to support additional kinds of parent
                     resources.
-
 
                     The API object must be valid in the cluster; the Group and Kind must
                     be registered in the cluster for this reference to be valid.
@@ -3492,7 +3858,6 @@ spec:
                         To set the core API group (such as for a "Service" kind referent),
                         Group must be explicitly set to "" (empty string).
 
-
                         Support: Core
                       maxLength: 253
                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -3502,13 +3867,10 @@ spec:
                       description: |-
                         Kind is kind of the referent.
 
-
                         There are two kinds of parent resources with "Core" support:
-
 
                         * Gateway (Gateway conformance profile)
                         * Service (Mesh conformance profile, ClusterIP Services only)
-
 
                         Support for other resources is Implementation-Specific.
                       maxLength: 63
@@ -3519,7 +3881,6 @@ spec:
                       description: |-
                         Name is the name of the referent.
 
-
                         Support: Core
                       maxLength: 253
                       minLength: 1
@@ -3529,7 +3890,6 @@ spec:
                         Namespace is the namespace of the referent. When unspecified, this refers
                         to the local namespace of the Route.
 
-
                         Note that there are specific rules for ParentRefs which cross namespace
                         boundaries. Cross-namespace references are only valid if they are explicitly
                         allowed by something in the namespace they are referring to. For example:
@@ -3537,18 +3897,15 @@ spec:
                         generic way to enable any other kind of cross-namespace reference.
 
 
-
                         ParentRefs from a Route to a Service in the same namespace are "producer"
                         routes, which apply default routing rules to inbound connections from
                         any namespace to the Service.
-
 
                         ParentRefs from a Route to a Service in a different namespace are
                         "consumer" routes, and these routing rules are only applied to outbound
                         connections originating from the same namespace as the Route, for which
                         the intended destination of the connections are a Service targeted as a
                         ParentRef of the Route.
-
 
 
                         Support: Core
@@ -3561,7 +3918,6 @@ spec:
                         Port is the network port this Route targets. It can be interpreted
                         differently based on the type of parent resource.
 
-
                         When the parent resource is a Gateway, this targets all listeners
                         listening on the specified port that also support this kind of Route(and
                         select this Route). It's not recommended to set `Port` unless the
@@ -3571,17 +3927,14 @@ spec:
                         must match both specified values.
 
 
-
                         When the parent resource is a Service, this targets a specific port in the
                         Service spec. When both Port (experimental) and SectionName are specified,
                         the name and port of the selected port must match both specified values.
 
 
-
                         Implementations MAY choose to support other parent resources.
                         Implementations supporting other types of parent resources MUST clearly
                         document how/if Port is interpreted.
-
 
                         For the purpose of status, an attachment is considered successful as
                         long as the parent resource accepts it partially. For example, Gateway
@@ -3590,7 +3943,6 @@ spec:
                         from the referencing Route, the Route MUST be considered successfully
                         attached. If no Gateway listeners accept attachment from this Route,
                         the Route MUST be considered detached from the Gateway.
-
 
                         Support: Extended
                       format: int32
@@ -3602,7 +3954,6 @@ spec:
                         SectionName is the name of a section within the target resource. In the
                         following resources, SectionName is interpreted as the following:
 
-
                         * Gateway: Listener name. When both Port (experimental) and SectionName
                         are specified, the name and port of the selected listener must match
                         both specified values.
@@ -3610,11 +3961,9 @@ spec:
                         are specified, the name and port of the selected listener must match
                         both specified values.
 
-
                         Implementations MAY choose to support attaching Routes to other resources.
                         If that is the case, they MUST clearly document how SectionName is
                         interpreted.
-
 
                         When unspecified (empty string), this will reference the entire resource.
                         For the purpose of status, an attachment is considered successful if at
@@ -3624,7 +3973,6 @@ spec:
                         the referencing Route, the Route MUST be considered successfully
                         attached. If no Gateway listeners accept attachment from this Route, the
                         Route MUST be considered detached from the Gateway.
-
 
                         Support: Core
                       maxLength: 253
@@ -3677,19 +4025,15 @@ spec:
                         BackendRefs defines the backend(s) where matching requests should be
                         sent.
 
-
                         Failure behavior here depends on how many BackendRefs are specified and
                         how many are invalid.
-
 
                         If *all* entries in BackendRefs are invalid, and there are also no filters
                         specified in this route rule, *all* traffic which matches this rule MUST
                         receive a 500 status code.
 
-
                         See the HTTPBackendRef definition for the rules about what makes a single
                         HTTPBackendRef invalid.
-
 
                         When a HTTPBackendRef is invalid, 500 status codes MUST be returned for
                         requests that would have otherwise been routed to an invalid backend. If
@@ -3697,26 +4041,25 @@ spec:
                         requests that would otherwise have been routed to an invalid backend
                         MUST receive a 500 status code.
 
-
                         For example, if two backends are specified with equal weights, and one is
                         invalid, 50 percent of traffic must receive a 500. Implementations may
                         choose how that 50 percent is determined.
 
+                        When a HTTPBackendRef refers to a Service that has no ready endpoints,
+                        implementations SHOULD return a 503 for requests to that backend instead.
+                        If an implementation chooses to do this, all of the above rules for 500 responses
+                        MUST also apply for responses that return a 503.
 
                         Support: Core for Kubernetes Service
 
-
                         Support: Extended for Kubernetes ServiceImport
 
-
                         Support: Implementation-specific for any other resource
-
 
                         Support for weight: Core
                       items:
                         description: |-
                           HTTPBackendRef defines how a HTTPRoute forwards a HTTP request.
-
 
                           Note that when a namespace different than the local namespace is specified, a
                           ReferenceGrant object is required in the referent namespace to allow that
@@ -3724,34 +4067,24 @@ spec:
                           documentation for details.
 
 
-                          <gateway:experimental:description>
-
-
                           When the BackendRef points to a Kubernetes Service, implementations SHOULD
                           honor the appProtocol field if it is set for the target Service Port.
 
-
                           Implementations supporting appProtocol SHOULD recognize the Kubernetes
                           Standard Application Protocols defined in KEP-3726.
-
 
                           If a Service appProtocol isn't specified, an implementation MAY infer the
                           backend protocol through its own means. Implementations MAY infer the
                           protocol from the Route type referring to the backend Service.
 
-
                           If a Route is not able to send traffic to the backend using the specified
                           protocol then the backend is considered invalid. Implementations MUST set the
                           "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
-
-
-                          </gateway:experimental:description>
                         properties:
                           filters:
                             description: |-
                               Filters defined at this level should be executed if and only if the
                               request is being forwarded to the backend defined here.
-
 
                               Support: Implementation-specific (For broader support of filters, use the
                               Filters field in HTTPRouteRule.)
@@ -3764,6 +4097,289 @@ spec:
                                 authentication strategies, rate-limiting, and traffic shaping. API
                                 guarantee/conformance is defined based on the type of the filter.
                               properties:
+                                cors:
+                                  description: |-
+                                    CORS defines a schema for a filter that responds to the
+                                    cross-origin request based on HTTP response header.
+
+                                    Support: Extended
+                                  properties:
+                                    allowCredentials:
+                                      description: |-
+                                        AllowCredentials indicates whether the actual cross-origin request allows
+                                        to include credentials.
+
+                                        The only valid value for the `Access-Control-Allow-Credentials` response
+                                        header is true (case-sensitive).
+
+                                        If the credentials are not allowed in cross-origin requests, the gateway
+                                        will omit the header `Access-Control-Allow-Credentials` entirely rather
+                                        than setting its value to false.
+
+                                        Support: Extended
+                                      enum:
+                                      - true
+                                      type: boolean
+                                    allowHeaders:
+                                      description: |-
+                                        AllowHeaders indicates which HTTP request headers are supported for
+                                        accessing the requested resource.
+
+                                        Header names are not case sensitive.
+
+                                        Multiple header names in the value of the `Access-Control-Allow-Headers`
+                                        response header are separated by a comma (",").
+
+                                        When the `AllowHeaders` field is configured with one or more headers, the
+                                        gateway must return the `Access-Control-Allow-Headers` response header
+                                        which value is present in the `AllowHeaders` field.
+
+                                        If any header name in the `Access-Control-Request-Headers` request header
+                                        is not included in the list of header names specified by the response
+                                        header `Access-Control-Allow-Headers`, it will present an error on the
+                                        client side.
+
+                                        If any header name in the `Access-Control-Allow-Headers` response header
+                                        does not recognize by the client, it will also occur an error on the
+                                        client side.
+
+                                        A wildcard indicates that the requests with all HTTP headers are allowed.
+                                        The `Access-Control-Allow-Headers` response header can only use `*`
+                                        wildcard as value when the `AllowCredentials` field is unspecified.
+
+                                        When the `AllowCredentials` field is specified and `AllowHeaders` field
+                                        specified with the `*` wildcard, the gateway must specify one or more
+                                        HTTP headers in the value of the `Access-Control-Allow-Headers` response
+                                        header. The value of the header `Access-Control-Allow-Headers` is same as
+                                        the `Access-Control-Request-Headers` header provided by the client. If
+                                        the header `Access-Control-Request-Headers` is not included in the
+                                        request, the gateway will omit the `Access-Control-Allow-Headers`
+                                        response header, instead of specifying the `*` wildcard. A Gateway
+                                        implementation may choose to add implementation-specific default headers.
+
+                                        Support: Extended
+                                      items:
+                                        description: |-
+                                          HTTPHeaderName is the name of an HTTP header.
+
+                                          Valid values include:
+
+                                          * "Authorization"
+                                          * "Set-Cookie"
+
+                                          Invalid values include:
+
+                                            - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
+                                              headers are not currently supported by this type.
+                                            - "/invalid" - "/ " is an invalid character
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      maxItems: 64
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    allowMethods:
+                                      description: |-
+                                        AllowMethods indicates which HTTP methods are supported for accessing the
+                                        requested resource.
+
+                                        Valid values are any method defined by RFC9110, along with the special
+                                        value `*`, which represents all HTTP methods are allowed.
+
+                                        Method names are case sensitive, so these values are also case-sensitive.
+                                        (See https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1)
+
+                                        Multiple method names in the value of the `Access-Control-Allow-Methods`
+                                        response header are separated by a comma (",").
+
+                                        A CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.
+                                        (See https://fetch.spec.whatwg.org/#cors-safelisted-method) The
+                                        CORS-safelisted methods are always allowed, regardless of whether they
+                                        are specified in the `AllowMethods` field.
+
+                                        When the `AllowMethods` field is configured with one or more methods, the
+                                        gateway must return the `Access-Control-Allow-Methods` response header
+                                        which value is present in the `AllowMethods` field.
+
+                                        If the HTTP method of the `Access-Control-Request-Method` request header
+                                        is not included in the list of methods specified by the response header
+                                        `Access-Control-Allow-Methods`, it will present an error on the client
+                                        side.
+
+                                        The `Access-Control-Allow-Methods` response header can only use `*`
+                                        wildcard as value when the `AllowCredentials` field is unspecified.
+
+                                        When the `AllowCredentials` field is specified and `AllowMethods` field
+                                        specified with the `*` wildcard, the gateway must specify one HTTP method
+                                        in the value of the Access-Control-Allow-Methods response header. The
+                                        value of the header `Access-Control-Allow-Methods` is same as the
+                                        `Access-Control-Request-Method` header provided by the client. If the
+                                        header `Access-Control-Request-Method` is not included in the request,
+                                        the gateway will omit the `Access-Control-Allow-Methods` response header,
+                                        instead of specifying the `*` wildcard. A Gateway implementation may
+                                        choose to add implementation-specific default methods.
+
+                                        Support: Extended
+                                      items:
+                                        enum:
+                                        - GET
+                                        - HEAD
+                                        - POST
+                                        - PUT
+                                        - DELETE
+                                        - CONNECT
+                                        - OPTIONS
+                                        - TRACE
+                                        - PATCH
+                                        - '*'
+                                        type: string
+                                      maxItems: 9
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                      x-kubernetes-validations:
+                                      - message: AllowMethods cannot contain '*' alongside
+                                          other methods
+                                        rule: '!(''*'' in self && self.size() > 1)'
+                                    allowOrigins:
+                                      description: |-
+                                        AllowOrigins indicates whether the response can be shared with requested
+                                        resource from the given `Origin`.
+
+                                        The `Origin` consists of a scheme and a host, with an optional port, and
+                                        takes the form `<scheme>://<host>(:<port>)`.
+
+                                        Valid values for scheme are: `http` and `https`.
+
+                                        Valid values for port are any integer between 1 and 65535 (the list of
+                                        available TCP/UDP ports). Note that, if not included, port `80` is
+                                        assumed for `http` scheme origins, and port `443` is assumed for `https`
+                                        origins. This may affect origin matching.
+
+                                        The host part of the origin may contain the wildcard character `*`. These
+                                        wildcard characters behave as follows:
+
+                                        * `*` is a greedy match to the _left_, including any number of
+                                          DNS labels to the left of its position. This also means that
+                                          `*` will include any number of period `.` characters to the
+                                          left of its position.
+                                        * A wildcard by itself matches all hosts.
+
+                                        An origin value that includes _only_ the `*` character indicates requests
+                                        from all `Origin`s are allowed.
+
+                                        When the `AllowOrigins` field is configured with multiple origins, it
+                                        means the server supports clients from multiple origins. If the request
+                                        `Origin` matches the configured allowed origins, the gateway must return
+                                        the given `Origin` and sets value of the header
+                                        `Access-Control-Allow-Origin` same as the `Origin` header provided by the
+                                        client.
+
+                                        The status code of a successful response to a "preflight" request is
+                                        always an OK status (i.e., 204 or 200).
+
+                                        If the request `Origin` does not match the configured allowed origins,
+                                        the gateway returns 204/200 response but doesn't set the relevant
+                                        cross-origin response headers. Alternatively, the gateway responds with
+                                        403 status to the "preflight" request is denied, coupled with omitting
+                                        the CORS headers. The cross-origin request fails on the client side.
+                                        Therefore, the client doesn't attempt the actual cross-origin request.
+
+                                        The `Access-Control-Allow-Origin` response header can only use `*`
+                                        wildcard as value when the `AllowCredentials` field is unspecified.
+
+                                        When the `AllowCredentials` field is specified and `AllowOrigins` field
+                                        specified with the `*` wildcard, the gateway must return a single origin
+                                        in the value of the `Access-Control-Allow-Origin` response header,
+                                        instead of specifying the `*` wildcard. The value of the header
+                                        `Access-Control-Allow-Origin` is same as the `Origin` header provided by
+                                        the client.
+
+                                        Support: Extended
+                                      items:
+                                        description: |-
+                                          The AbsoluteURI MUST NOT be a relative URI, and it MUST follow the URI syntax and
+                                          encoding rules specified in RFC3986.  The AbsoluteURI MUST include both a
+                                          scheme (e.g., "http" or "spiffe") and a scheme-specific-part.  URIs that
+                                          include an authority MUST include a fully qualified domain name or
+                                          IP address as the host.
+                                        maxLength: 253
+                                        minLength: 1
+                                        pattern: ^(([^:/?#]+):)(//([^/?#]*))([^?#]*)(\?([^#]*))?(#(.*))?
+                                        type: string
+                                      maxItems: 64
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    exposeHeaders:
+                                      description: |-
+                                        ExposeHeaders indicates which HTTP response headers can be exposed
+                                        to client-side scripts in response to a cross-origin request.
+
+                                        A CORS-safelisted response header is an HTTP header in a CORS response
+                                        that it is considered safe to expose to the client scripts.
+                                        The CORS-safelisted response headers include the following headers:
+                                        `Cache-Control`
+                                        `Content-Language`
+                                        `Content-Length`
+                                        `Content-Type`
+                                        `Expires`
+                                        `Last-Modified`
+                                        `Pragma`
+                                        (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
+                                        The CORS-safelisted response headers are exposed to client by default.
+
+                                        When an HTTP header name is specified using the `ExposeHeaders` field,
+                                        this additional header will be exposed as part of the response to the
+                                        client.
+
+                                        Header names are not case sensitive.
+
+                                        Multiple header names in the value of the `Access-Control-Expose-Headers`
+                                        response header are separated by a comma (",").
+
+                                        A wildcard indicates that the responses with all HTTP headers are exposed
+                                        to clients. The `Access-Control-Expose-Headers` response header can only
+                                        use `*` wildcard as value when the `AllowCredentials` field is
+                                        unspecified.
+
+                                        Support: Extended
+                                      items:
+                                        description: |-
+                                          HTTPHeaderName is the name of an HTTP header.
+
+                                          Valid values include:
+
+                                          * "Authorization"
+                                          * "Set-Cookie"
+
+                                          Invalid values include:
+
+                                            - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
+                                              headers are not currently supported by this type.
+                                            - "/invalid" - "/ " is an invalid character
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      maxItems: 64
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    maxAge:
+                                      default: 5
+                                      description: |-
+                                        MaxAge indicates the duration (in seconds) for the client to cache the
+                                        results of a "preflight" request.
+
+                                        The information provided by the `Access-Control-Allow-Methods` and
+                                        `Access-Control-Allow-Headers` response headers can be cached by the
+                                        client until the time specified by `Access-Control-Max-Age` elapses.
+
+                                        The default value of `Access-Control-Max-Age` response header is 5
+                                        (seconds).
+                                      format: int32
+                                      minimum: 1
+                                      type: integer
+                                  type: object
                                 extensionRef:
                                   description: |-
                                     ExtensionRef is an optional, implementation-specific extension to the
@@ -3771,9 +4387,7 @@ spec:
                                     "networking.example.net"). ExtensionRef MUST NOT be used for core and
                                     extended filters.
 
-
                                     This filter can be used multiple times within the same rule.
-
 
                                     Support: Implementation-specific
                                   properties:
@@ -3806,7 +4420,6 @@ spec:
                                     RequestHeaderModifier defines a schema for a filter that modifies request
                                     headers.
 
-
                                     Support: Core
                                   properties:
                                     add:
@@ -3815,17 +4428,14 @@ spec:
                                         before the action. It appends to any existing values associated
                                         with the header name.
 
-
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header: foo
-
 
                                         Config:
                                           add:
                                           - name: "my-header"
                                             value: "bar,baz"
-
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -3838,8 +4448,7 @@ spec:
                                           name:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -3872,17 +4481,14 @@ spec:
                                         names are case-insensitive (see
                                         https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
 
-
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header1: foo
                                           my-header2: bar
                                           my-header3: baz
 
-
                                         Config:
                                           remove: ["my-header1", "my-header3"]
-
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -3897,17 +4503,14 @@ spec:
                                         Set overwrites the request with the given header (name, value)
                                         before the action.
 
-
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header: foo
-
 
                                         Config:
                                           set:
                                           - name: "my-header"
                                             value: "bar"
-
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -3920,8 +4523,7 @@ spec:
                                           name:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -3954,11 +4556,9 @@ spec:
                                     Requests are sent to the specified destination, but responses from
                                     that destination are ignored.
 
-
                                     This filter can be used multiple times within the same rule. Note that
                                     not all implementations will be able to support mirroring to multiple
                                     backends.
-
 
                                     Support: Extended
                                   properties:
@@ -3966,17 +4566,14 @@ spec:
                                       description: |-
                                         BackendRef references a resource where mirrored requests are sent.
 
-
                                         Mirrored requests must be sent only to a single destination endpoint
                                         within this BackendRef, irrespective of how many endpoints are present
                                         within this BackendRef.
-
 
                                         If the referent cannot be found, this BackendRef is invalid and must be
                                         dropped from the Gateway. The controller must ensure the "ResolvedRefs"
                                         condition on the Route status is set to `status: False` and not configure
                                         this backend in the underlying implementation.
-
 
                                         If there is a cross-namespace reference to an *existing* object
                                         that is not allowed by a ReferenceGrant, the controller must ensure the
@@ -3984,13 +4581,10 @@ spec:
                                         with the "RefNotPermitted" reason and not configure this backend in the
                                         underlying implementation.
 
-
                                         In either error case, the Message of the `ResolvedRefs` Condition
                                         should be used to provide more detail about the problem.
 
-
                                         Support: Extended for Kubernetes Service
-
 
                                         Support: Implementation-specific for any other resource
                                       properties:
@@ -4008,9 +4602,7 @@ spec:
                                             Kind is the Kubernetes resource kind of the referent. For example
                                             "Service".
 
-
                                             Defaults to "Service" when not specified.
-
 
                                             ExternalName services can refer to CNAME DNS records that may live
                                             outside of the cluster and as such are difficult to reason about in
@@ -4018,9 +4610,7 @@ spec:
                                             CVE-2021-25740 for more information). Implementations SHOULD NOT
                                             support ExternalName Services.
 
-
                                             Support: Core (Services with a type other than ExternalName)
-
 
                                             Support: Implementation-specific (Services with type ExternalName)
                                           maxLength: 63
@@ -4037,12 +4627,10 @@ spec:
                                             Namespace is the namespace of the backend. When unspecified, the local
                                             namespace is inferred.
 
-
                                             Note that when a namespace different than the local namespace is specified,
                                             a ReferenceGrant object is required in the referent namespace to allow that
                                             namespace's owner to accept the reference. See the ReferenceGrant
                                             documentation for details.
-
 
                                             Support: Core
                                           maxLength: 63
@@ -4067,14 +4655,53 @@ spec:
                                       - message: Must have port for Service reference
                                         rule: '(size(self.group) == 0 && self.kind
                                           == ''Service'') ? has(self.port) : true'
+                                    fraction:
+                                      description: |-
+                                        Fraction represents the fraction of requests that should be
+                                        mirrored to BackendRef.
+
+                                        Only one of Fraction or Percent may be specified. If neither field
+                                        is specified, 100% of requests will be mirrored.
+                                      properties:
+                                        denominator:
+                                          default: 100
+                                          format: int32
+                                          minimum: 1
+                                          type: integer
+                                        numerator:
+                                          format: int32
+                                          minimum: 0
+                                          type: integer
+                                      required:
+                                      - numerator
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: numerator must be less than or equal
+                                          to denominator
+                                        rule: self.numerator <= self.denominator
+                                    percent:
+                                      description: |-
+                                        Percent represents the percentage of requests that should be
+                                        mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
+                                        requests) and its maximum value is 100 (indicating 100% of requests).
+
+                                        Only one of Fraction or Percent may be specified. If neither field
+                                        is specified, 100% of requests will be mirrored.
+                                      format: int32
+                                      maximum: 100
+                                      minimum: 0
+                                      type: integer
                                   required:
                                   - backendRef
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: Only one of percent or fraction may be
+                                      specified in HTTPRequestMirrorFilter
+                                    rule: '!(has(self.percent) && has(self.fraction))'
                                 requestRedirect:
                                   description: |-
                                     RequestRedirect defines a schema for a filter that responds to the
                                     request with an HTTP redirection.
-
 
                                     Support: Core
                                   properties:
@@ -4083,7 +4710,6 @@ spec:
                                         Hostname is the hostname to be used in the value of the `Location`
                                         header in the response.
                                         When empty, the hostname in the `Host` header of the request is used.
-
 
                                         Support: Core
                                       maxLength: 253
@@ -4095,7 +4721,6 @@ spec:
                                         Path defines parameters used to modify the path of the incoming request.
                                         The modified path is then used to construct the `Location` header. When
                                         empty, the request path is used as-is.
-
 
                                         Support: Extended
                                       properties:
@@ -4112,32 +4737,17 @@ spec:
                                             to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
                                             of "/xyz" would be modified to "/xyz/bar".
 
-
                                             Note that this matches the behavior of the PathPrefix match type. This
                                             matches full path elements. A path element refers to the list of labels
                                             in the path split by the `/` separator. When specified, a trailing `/` is
                                             ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
                                             match the prefix `/abc`, but the path `/abcd` would not.
 
-
                                             ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
                                             Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
                                             the implementation setting the Accepted Condition for the Route to `status: False`.
 
-
                                             Request Path | Prefix Match | Replace Prefix | Modified Path
-                                            -------------|--------------|----------------|----------
-                                            /foo/bar     | /foo         | /xyz           | /xyz/bar
-                                            /foo/bar     | /foo         | /xyz/          | /xyz/bar
-                                            /foo/bar     | /foo/        | /xyz           | /xyz/bar
-                                            /foo/bar     | /foo/        | /xyz/          | /xyz/bar
-                                            /foo         | /foo         | /xyz           | /xyz
-                                            /foo/        | /foo         | /xyz           | /xyz/
-                                            /foo/bar     | /foo         | <empty string> | /bar
-                                            /foo/        | /foo         | <empty string> | /
-                                            /foo         | /foo         | <empty string> | /
-                                            /foo/        | /foo         | /              | /
-                                            /foo         | /foo         | /              | /
                                           maxLength: 1024
                                           type: string
                                         type:
@@ -4145,10 +4755,8 @@ spec:
                                             Type defines the type of path modifier. Additional types may be
                                             added in a future release of the API.
 
-
                                             Note that values may be added to this enum, implementations
                                             must ensure that unknown values will not cause a crash.
-
 
                                             Unknown values here must result in the implementation setting the
                                             Accepted Condition for the Route to `status: False`, with a
@@ -4182,10 +4790,8 @@ spec:
                                         Port is the port to be used in the value of the `Location`
                                         header in the response.
 
-
                                         If no port is specified, the redirect port MUST be derived using the
                                         following rules:
-
 
                                         * If redirect scheme is not-empty, the redirect port MUST be the well-known
                                           port associated with the redirect scheme. Specifically "http" to port 80
@@ -4194,16 +4800,13 @@ spec:
                                         * If redirect scheme is empty, the redirect port MUST be the Gateway
                                           Listener port.
 
-
                                         Implementations SHOULD NOT add the port number in the 'Location'
                                         header in the following cases:
-
 
                                         * A Location header that will use HTTP (whether that is determined via
                                           the Listener protocol or the Scheme field) _and_ use port 80.
                                         * A Location header that will use HTTPS (whether that is determined via
                                           the Listener protocol or the Scheme field) _and_ use port 443.
-
 
                                         Support: Extended
                                       format: int32
@@ -4215,19 +4818,15 @@ spec:
                                         Scheme is the scheme to be used in the value of the `Location` header in
                                         the response. When empty, the scheme of the request is used.
 
-
                                         Scheme redirects can affect the port of the redirect, for more information,
                                         refer to the documentation for the port field of this filter.
-
 
                                         Note that values may be added to this enum, implementations
                                         must ensure that unknown values will not cause a crash.
 
-
                                         Unknown values here must result in the implementation setting the
                                         Accepted Condition for the Route to `status: False`, with a
                                         Reason of `UnsupportedValue`.
-
 
                                         Support: Extended
                                       enum:
@@ -4239,15 +4838,12 @@ spec:
                                       description: |-
                                         StatusCode is the HTTP status code to be used in response.
 
-
                                         Note that values may be added to this enum, implementations
                                         must ensure that unknown values will not cause a crash.
-
 
                                         Unknown values here must result in the implementation setting the
                                         Accepted Condition for the Route to `status: False`, with a
                                         Reason of `UnsupportedValue`.
-
 
                                         Support: Core
                                       enum:
@@ -4260,7 +4856,6 @@ spec:
                                     ResponseHeaderModifier defines a schema for a filter that modifies response
                                     headers.
 
-
                                     Support: Extended
                                   properties:
                                     add:
@@ -4269,17 +4864,14 @@ spec:
                                         before the action. It appends to any existing values associated
                                         with the header name.
 
-
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header: foo
-
 
                                         Config:
                                           add:
                                           - name: "my-header"
                                             value: "bar,baz"
-
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -4292,8 +4884,7 @@ spec:
                                           name:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -4326,17 +4917,14 @@ spec:
                                         names are case-insensitive (see
                                         https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
 
-
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header1: foo
                                           my-header2: bar
                                           my-header3: baz
 
-
                                         Config:
                                           remove: ["my-header1", "my-header3"]
-
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -4351,17 +4939,14 @@ spec:
                                         Set overwrites the request with the given header (name, value)
                                         before the action.
 
-
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header: foo
-
 
                                         Config:
                                           set:
                                           - name: "my-header"
                                             value: "bar"
-
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -4374,8 +4959,7 @@ spec:
                                           name:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -4407,16 +4991,13 @@ spec:
                                     Type identifies the type of filter to apply. As with other API fields,
                                     types are classified into three conformance levels:
 
-
                                     - Core: Filter types and their corresponding configuration defined by
                                       "Support: Core" in this package, e.g. "RequestHeaderModifier". All
                                       implementations must support core filters.
 
-
                                     - Extended: Filter types and their corresponding configuration defined by
                                       "Support: Extended" in this package, e.g. "RequestMirror". Implementers
                                       are encouraged to support extended filters.
-
 
                                     - Implementation-specific: Filters that are defined and supported by
                                       specific vendors.
@@ -4426,19 +5007,15 @@ spec:
                                       is specified using the ExtensionRef field. `Type` should be set to
                                       "ExtensionRef" for custom filters.
 
-
                                     Implementers are encouraged to define custom implementation types to
                                     extend the core API with implementation-specific behavior.
-
 
                                     If a reference to a custom filter type cannot be resolved, the filter
                                     MUST NOT be skipped. Instead, requests that would have been processed by
                                     that filter MUST receive a HTTP error response.
 
-
                                     Note that values may be added to this enum, implementations
                                     must ensure that unknown values will not cause a crash.
-
 
                                     Unknown values here must result in the implementation setting the
                                     Accepted Condition for the Route to `status: False`, with a
@@ -4450,11 +5027,11 @@ spec:
                                   - RequestRedirect
                                   - URLRewrite
                                   - ExtensionRef
+                                  - CORS
                                   type: string
                                 urlRewrite:
                                   description: |-
                                     URLRewrite defines a schema for a filter that modifies a request during forwarding.
-
 
                                     Support: Extended
                                   properties:
@@ -4462,7 +5039,6 @@ spec:
                                       description: |-
                                         Hostname is the value to be used to replace the Host header value during
                                         forwarding.
-
 
                                         Support: Extended
                                       maxLength: 253
@@ -4472,7 +5048,6 @@ spec:
                                     path:
                                       description: |-
                                         Path defines a path rewrite.
-
 
                                         Support: Extended
                                       properties:
@@ -4489,32 +5064,17 @@ spec:
                                             to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
                                             of "/xyz" would be modified to "/xyz/bar".
 
-
                                             Note that this matches the behavior of the PathPrefix match type. This
                                             matches full path elements. A path element refers to the list of labels
                                             in the path split by the `/` separator. When specified, a trailing `/` is
                                             ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
                                             match the prefix `/abc`, but the path `/abcd` would not.
 
-
                                             ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
                                             Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
                                             the implementation setting the Accepted Condition for the Route to `status: False`.
 
-
                                             Request Path | Prefix Match | Replace Prefix | Modified Path
-                                            -------------|--------------|----------------|----------
-                                            /foo/bar     | /foo         | /xyz           | /xyz/bar
-                                            /foo/bar     | /foo         | /xyz/          | /xyz/bar
-                                            /foo/bar     | /foo/        | /xyz           | /xyz/bar
-                                            /foo/bar     | /foo/        | /xyz/          | /xyz/bar
-                                            /foo         | /foo         | /xyz           | /xyz
-                                            /foo/        | /foo         | /xyz           | /xyz/
-                                            /foo/bar     | /foo         | <empty string> | /bar
-                                            /foo/        | /foo         | <empty string> | /
-                                            /foo         | /foo         | <empty string> | /
-                                            /foo/        | /foo         | /              | /
-                                            /foo         | /foo         | /              | /
                                           maxLength: 1024
                                           type: string
                                         type:
@@ -4522,10 +5082,8 @@ spec:
                                             Type defines the type of path modifier. Additional types may be
                                             added in a future release of the API.
 
-
                                             Note that values may be added to this enum, implementations
                                             must ensure that unknown values will not cause a crash.
-
 
                                             Unknown values here must result in the implementation setting the
                                             Accepted Condition for the Route to `status: False`, with a
@@ -4602,6 +5160,11 @@ spec:
                               - message: filter.extensionRef must be specified for
                                   ExtensionRef filter.type
                                 rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                              - message: filter.cors must be nil if the filter.type
+                                  is not CORS
+                                rule: '!(has(self.cors) && self.type != ''CORS'')'
+                              - message: filter.cors must be specified for CORS filter.type
+                                rule: '!(!has(self.cors) && self.type == ''CORS'')'
                             maxItems: 16
                             type: array
                             x-kubernetes-validations:
@@ -4639,9 +5202,7 @@ spec:
                               Kind is the Kubernetes resource kind of the referent. For example
                               "Service".
 
-
                               Defaults to "Service" when not specified.
-
 
                               ExternalName services can refer to CNAME DNS records that may live
                               outside of the cluster and as such are difficult to reason about in
@@ -4649,9 +5210,7 @@ spec:
                               CVE-2021-25740 for more information). Implementations SHOULD NOT
                               support ExternalName Services.
 
-
                               Support: Core (Services with a type other than ExternalName)
-
 
                               Support: Implementation-specific (Services with type ExternalName)
                             maxLength: 63
@@ -4668,12 +5227,10 @@ spec:
                               Namespace is the namespace of the backend. When unspecified, the local
                               namespace is inferred.
 
-
                               Note that when a namespace different than the local namespace is specified,
                               a ReferenceGrant object is required in the referent namespace to allow that
                               namespace's owner to accept the reference. See the ReferenceGrant
                               documentation for details.
-
 
                               Support: Core
                             maxLength: 63
@@ -4701,12 +5258,10 @@ spec:
                               implementation supports. Weight is not a percentage and the sum of
                               weights does not need to equal 100.
 
-
                               If only one backend is specified and it has a weight greater than 0, 100%
                               of the traffic is forwarded to that backend. If weight is set to 0, no
                               traffic should be forwarded for this entry. If unspecified, weight
                               defaults to 1.
-
 
                               Support for this field varies based on the context where used.
                             format: int32
@@ -4727,16 +5282,13 @@ spec:
                         Filters define the filters that are applied to requests that match
                         this rule.
 
-
                         Wherever possible, implementations SHOULD implement filters in the order
                         they are specified.
 
-
                         Implementations MAY choose to implement this ordering strictly, rejecting
-                        any combination or order of filters that can not be supported. If implementations
+                        any combination or order of filters that cannot be supported. If implementations
                         choose a strict interpretation of filter ordering, they MUST clearly document
                         that behavior.
-
 
                         To reject an invalid combination or order of filters, implementations SHOULD
                         consider the Route Rules with this configuration invalid. If all Route Rules
@@ -4744,28 +5296,23 @@ spec:
                         a portion of Route Rules are invalid, implementations MUST set the
                         "PartiallyInvalid" condition for the Route.
 
-
                         Conformance-levels at this level are defined based on the type of filter:
-
 
                         - ALL core filters MUST be supported by all implementations.
                         - Implementers are encouraged to support extended filters.
                         - Implementation-specific custom filters have no API guarantees across
                           implementations.
 
-
                         Specifying the same filter multiple times is not supported unless explicitly
                         indicated in the filter.
 
-
                         All filters are expected to be compatible with each other except for the
                         URLRewrite and RequestRedirect filters, which may not be combined. If an
-                        implementation can not support other combinations of filters, they must clearly
+                        implementation cannot support other combinations of filters, they must clearly
                         document that limitation. In cases where incompatible or unsupported
                         filters are specified and cause the `Accepted` condition to be set to status
                         `False`, implementations may use the `IncompatibleFilters` reason to specify
                         this configuration error.
-
 
                         Support: Core
                       items:
@@ -4777,6 +5324,289 @@ spec:
                           authentication strategies, rate-limiting, and traffic shaping. API
                           guarantee/conformance is defined based on the type of the filter.
                         properties:
+                          cors:
+                            description: |-
+                              CORS defines a schema for a filter that responds to the
+                              cross-origin request based on HTTP response header.
+
+                              Support: Extended
+                            properties:
+                              allowCredentials:
+                                description: |-
+                                  AllowCredentials indicates whether the actual cross-origin request allows
+                                  to include credentials.
+
+                                  The only valid value for the `Access-Control-Allow-Credentials` response
+                                  header is true (case-sensitive).
+
+                                  If the credentials are not allowed in cross-origin requests, the gateway
+                                  will omit the header `Access-Control-Allow-Credentials` entirely rather
+                                  than setting its value to false.
+
+                                  Support: Extended
+                                enum:
+                                - true
+                                type: boolean
+                              allowHeaders:
+                                description: |-
+                                  AllowHeaders indicates which HTTP request headers are supported for
+                                  accessing the requested resource.
+
+                                  Header names are not case sensitive.
+
+                                  Multiple header names in the value of the `Access-Control-Allow-Headers`
+                                  response header are separated by a comma (",").
+
+                                  When the `AllowHeaders` field is configured with one or more headers, the
+                                  gateway must return the `Access-Control-Allow-Headers` response header
+                                  which value is present in the `AllowHeaders` field.
+
+                                  If any header name in the `Access-Control-Request-Headers` request header
+                                  is not included in the list of header names specified by the response
+                                  header `Access-Control-Allow-Headers`, it will present an error on the
+                                  client side.
+
+                                  If any header name in the `Access-Control-Allow-Headers` response header
+                                  does not recognize by the client, it will also occur an error on the
+                                  client side.
+
+                                  A wildcard indicates that the requests with all HTTP headers are allowed.
+                                  The `Access-Control-Allow-Headers` response header can only use `*`
+                                  wildcard as value when the `AllowCredentials` field is unspecified.
+
+                                  When the `AllowCredentials` field is specified and `AllowHeaders` field
+                                  specified with the `*` wildcard, the gateway must specify one or more
+                                  HTTP headers in the value of the `Access-Control-Allow-Headers` response
+                                  header. The value of the header `Access-Control-Allow-Headers` is same as
+                                  the `Access-Control-Request-Headers` header provided by the client. If
+                                  the header `Access-Control-Request-Headers` is not included in the
+                                  request, the gateway will omit the `Access-Control-Allow-Headers`
+                                  response header, instead of specifying the `*` wildcard. A Gateway
+                                  implementation may choose to add implementation-specific default headers.
+
+                                  Support: Extended
+                                items:
+                                  description: |-
+                                    HTTPHeaderName is the name of an HTTP header.
+
+                                    Valid values include:
+
+                                    * "Authorization"
+                                    * "Set-Cookie"
+
+                                    Invalid values include:
+
+                                      - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
+                                        headers are not currently supported by this type.
+                                      - "/invalid" - "/ " is an invalid character
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                maxItems: 64
+                                type: array
+                                x-kubernetes-list-type: set
+                              allowMethods:
+                                description: |-
+                                  AllowMethods indicates which HTTP methods are supported for accessing the
+                                  requested resource.
+
+                                  Valid values are any method defined by RFC9110, along with the special
+                                  value `*`, which represents all HTTP methods are allowed.
+
+                                  Method names are case sensitive, so these values are also case-sensitive.
+                                  (See https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1)
+
+                                  Multiple method names in the value of the `Access-Control-Allow-Methods`
+                                  response header are separated by a comma (",").
+
+                                  A CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.
+                                  (See https://fetch.spec.whatwg.org/#cors-safelisted-method) The
+                                  CORS-safelisted methods are always allowed, regardless of whether they
+                                  are specified in the `AllowMethods` field.
+
+                                  When the `AllowMethods` field is configured with one or more methods, the
+                                  gateway must return the `Access-Control-Allow-Methods` response header
+                                  which value is present in the `AllowMethods` field.
+
+                                  If the HTTP method of the `Access-Control-Request-Method` request header
+                                  is not included in the list of methods specified by the response header
+                                  `Access-Control-Allow-Methods`, it will present an error on the client
+                                  side.
+
+                                  The `Access-Control-Allow-Methods` response header can only use `*`
+                                  wildcard as value when the `AllowCredentials` field is unspecified.
+
+                                  When the `AllowCredentials` field is specified and `AllowMethods` field
+                                  specified with the `*` wildcard, the gateway must specify one HTTP method
+                                  in the value of the Access-Control-Allow-Methods response header. The
+                                  value of the header `Access-Control-Allow-Methods` is same as the
+                                  `Access-Control-Request-Method` header provided by the client. If the
+                                  header `Access-Control-Request-Method` is not included in the request,
+                                  the gateway will omit the `Access-Control-Allow-Methods` response header,
+                                  instead of specifying the `*` wildcard. A Gateway implementation may
+                                  choose to add implementation-specific default methods.
+
+                                  Support: Extended
+                                items:
+                                  enum:
+                                  - GET
+                                  - HEAD
+                                  - POST
+                                  - PUT
+                                  - DELETE
+                                  - CONNECT
+                                  - OPTIONS
+                                  - TRACE
+                                  - PATCH
+                                  - '*'
+                                  type: string
+                                maxItems: 9
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: AllowMethods cannot contain '*' alongside
+                                    other methods
+                                  rule: '!(''*'' in self && self.size() > 1)'
+                              allowOrigins:
+                                description: |-
+                                  AllowOrigins indicates whether the response can be shared with requested
+                                  resource from the given `Origin`.
+
+                                  The `Origin` consists of a scheme and a host, with an optional port, and
+                                  takes the form `<scheme>://<host>(:<port>)`.
+
+                                  Valid values for scheme are: `http` and `https`.
+
+                                  Valid values for port are any integer between 1 and 65535 (the list of
+                                  available TCP/UDP ports). Note that, if not included, port `80` is
+                                  assumed for `http` scheme origins, and port `443` is assumed for `https`
+                                  origins. This may affect origin matching.
+
+                                  The host part of the origin may contain the wildcard character `*`. These
+                                  wildcard characters behave as follows:
+
+                                  * `*` is a greedy match to the _left_, including any number of
+                                    DNS labels to the left of its position. This also means that
+                                    `*` will include any number of period `.` characters to the
+                                    left of its position.
+                                  * A wildcard by itself matches all hosts.
+
+                                  An origin value that includes _only_ the `*` character indicates requests
+                                  from all `Origin`s are allowed.
+
+                                  When the `AllowOrigins` field is configured with multiple origins, it
+                                  means the server supports clients from multiple origins. If the request
+                                  `Origin` matches the configured allowed origins, the gateway must return
+                                  the given `Origin` and sets value of the header
+                                  `Access-Control-Allow-Origin` same as the `Origin` header provided by the
+                                  client.
+
+                                  The status code of a successful response to a "preflight" request is
+                                  always an OK status (i.e., 204 or 200).
+
+                                  If the request `Origin` does not match the configured allowed origins,
+                                  the gateway returns 204/200 response but doesn't set the relevant
+                                  cross-origin response headers. Alternatively, the gateway responds with
+                                  403 status to the "preflight" request is denied, coupled with omitting
+                                  the CORS headers. The cross-origin request fails on the client side.
+                                  Therefore, the client doesn't attempt the actual cross-origin request.
+
+                                  The `Access-Control-Allow-Origin` response header can only use `*`
+                                  wildcard as value when the `AllowCredentials` field is unspecified.
+
+                                  When the `AllowCredentials` field is specified and `AllowOrigins` field
+                                  specified with the `*` wildcard, the gateway must return a single origin
+                                  in the value of the `Access-Control-Allow-Origin` response header,
+                                  instead of specifying the `*` wildcard. The value of the header
+                                  `Access-Control-Allow-Origin` is same as the `Origin` header provided by
+                                  the client.
+
+                                  Support: Extended
+                                items:
+                                  description: |-
+                                    The AbsoluteURI MUST NOT be a relative URI, and it MUST follow the URI syntax and
+                                    encoding rules specified in RFC3986.  The AbsoluteURI MUST include both a
+                                    scheme (e.g., "http" or "spiffe") and a scheme-specific-part.  URIs that
+                                    include an authority MUST include a fully qualified domain name or
+                                    IP address as the host.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^(([^:/?#]+):)(//([^/?#]*))([^?#]*)(\?([^#]*))?(#(.*))?
+                                  type: string
+                                maxItems: 64
+                                type: array
+                                x-kubernetes-list-type: set
+                              exposeHeaders:
+                                description: |-
+                                  ExposeHeaders indicates which HTTP response headers can be exposed
+                                  to client-side scripts in response to a cross-origin request.
+
+                                  A CORS-safelisted response header is an HTTP header in a CORS response
+                                  that it is considered safe to expose to the client scripts.
+                                  The CORS-safelisted response headers include the following headers:
+                                  `Cache-Control`
+                                  `Content-Language`
+                                  `Content-Length`
+                                  `Content-Type`
+                                  `Expires`
+                                  `Last-Modified`
+                                  `Pragma`
+                                  (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
+                                  The CORS-safelisted response headers are exposed to client by default.
+
+                                  When an HTTP header name is specified using the `ExposeHeaders` field,
+                                  this additional header will be exposed as part of the response to the
+                                  client.
+
+                                  Header names are not case sensitive.
+
+                                  Multiple header names in the value of the `Access-Control-Expose-Headers`
+                                  response header are separated by a comma (",").
+
+                                  A wildcard indicates that the responses with all HTTP headers are exposed
+                                  to clients. The `Access-Control-Expose-Headers` response header can only
+                                  use `*` wildcard as value when the `AllowCredentials` field is
+                                  unspecified.
+
+                                  Support: Extended
+                                items:
+                                  description: |-
+                                    HTTPHeaderName is the name of an HTTP header.
+
+                                    Valid values include:
+
+                                    * "Authorization"
+                                    * "Set-Cookie"
+
+                                    Invalid values include:
+
+                                      - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
+                                        headers are not currently supported by this type.
+                                      - "/invalid" - "/ " is an invalid character
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                maxItems: 64
+                                type: array
+                                x-kubernetes-list-type: set
+                              maxAge:
+                                default: 5
+                                description: |-
+                                  MaxAge indicates the duration (in seconds) for the client to cache the
+                                  results of a "preflight" request.
+
+                                  The information provided by the `Access-Control-Allow-Methods` and
+                                  `Access-Control-Allow-Headers` response headers can be cached by the
+                                  client until the time specified by `Access-Control-Max-Age` elapses.
+
+                                  The default value of `Access-Control-Max-Age` response header is 5
+                                  (seconds).
+                                format: int32
+                                minimum: 1
+                                type: integer
+                            type: object
                           extensionRef:
                             description: |-
                               ExtensionRef is an optional, implementation-specific extension to the
@@ -4784,9 +5614,7 @@ spec:
                               "networking.example.net"). ExtensionRef MUST NOT be used for core and
                               extended filters.
 
-
                               This filter can be used multiple times within the same rule.
-
 
                               Support: Implementation-specific
                             properties:
@@ -4819,7 +5647,6 @@ spec:
                               RequestHeaderModifier defines a schema for a filter that modifies request
                               headers.
 
-
                               Support: Core
                             properties:
                               add:
@@ -4828,17 +5655,14 @@ spec:
                                   before the action. It appends to any existing values associated
                                   with the header name.
 
-
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header: foo
-
 
                                   Config:
                                     add:
                                     - name: "my-header"
                                       value: "bar,baz"
-
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -4850,8 +5674,7 @@ spec:
                                     name:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -4884,17 +5707,14 @@ spec:
                                   names are case-insensitive (see
                                   https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
 
-
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header1: foo
                                     my-header2: bar
                                     my-header3: baz
 
-
                                   Config:
                                     remove: ["my-header1", "my-header3"]
-
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -4909,17 +5729,14 @@ spec:
                                   Set overwrites the request with the given header (name, value)
                                   before the action.
 
-
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header: foo
-
 
                                   Config:
                                     set:
                                     - name: "my-header"
                                       value: "bar"
-
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -4931,8 +5748,7 @@ spec:
                                     name:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -4965,11 +5781,9 @@ spec:
                               Requests are sent to the specified destination, but responses from
                               that destination are ignored.
 
-
                               This filter can be used multiple times within the same rule. Note that
                               not all implementations will be able to support mirroring to multiple
                               backends.
-
 
                               Support: Extended
                             properties:
@@ -4977,17 +5791,14 @@ spec:
                                 description: |-
                                   BackendRef references a resource where mirrored requests are sent.
 
-
                                   Mirrored requests must be sent only to a single destination endpoint
                                   within this BackendRef, irrespective of how many endpoints are present
                                   within this BackendRef.
-
 
                                   If the referent cannot be found, this BackendRef is invalid and must be
                                   dropped from the Gateway. The controller must ensure the "ResolvedRefs"
                                   condition on the Route status is set to `status: False` and not configure
                                   this backend in the underlying implementation.
-
 
                                   If there is a cross-namespace reference to an *existing* object
                                   that is not allowed by a ReferenceGrant, the controller must ensure the
@@ -4995,13 +5806,10 @@ spec:
                                   with the "RefNotPermitted" reason and not configure this backend in the
                                   underlying implementation.
 
-
                                   In either error case, the Message of the `ResolvedRefs` Condition
                                   should be used to provide more detail about the problem.
 
-
                                   Support: Extended for Kubernetes Service
-
 
                                   Support: Implementation-specific for any other resource
                                 properties:
@@ -5019,9 +5827,7 @@ spec:
                                       Kind is the Kubernetes resource kind of the referent. For example
                                       "Service".
 
-
                                       Defaults to "Service" when not specified.
-
 
                                       ExternalName services can refer to CNAME DNS records that may live
                                       outside of the cluster and as such are difficult to reason about in
@@ -5029,9 +5835,7 @@ spec:
                                       CVE-2021-25740 for more information). Implementations SHOULD NOT
                                       support ExternalName Services.
 
-
                                       Support: Core (Services with a type other than ExternalName)
-
 
                                       Support: Implementation-specific (Services with type ExternalName)
                                     maxLength: 63
@@ -5048,12 +5852,10 @@ spec:
                                       Namespace is the namespace of the backend. When unspecified, the local
                                       namespace is inferred.
 
-
                                       Note that when a namespace different than the local namespace is specified,
                                       a ReferenceGrant object is required in the referent namespace to allow that
                                       namespace's owner to accept the reference. See the ReferenceGrant
                                       documentation for details.
-
 
                                       Support: Core
                                     maxLength: 63
@@ -5078,14 +5880,53 @@ spec:
                                 - message: Must have port for Service reference
                                   rule: '(size(self.group) == 0 && self.kind == ''Service'')
                                     ? has(self.port) : true'
+                              fraction:
+                                description: |-
+                                  Fraction represents the fraction of requests that should be
+                                  mirrored to BackendRef.
+
+                                  Only one of Fraction or Percent may be specified. If neither field
+                                  is specified, 100% of requests will be mirrored.
+                                properties:
+                                  denominator:
+                                    default: 100
+                                    format: int32
+                                    minimum: 1
+                                    type: integer
+                                  numerator:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                - numerator
+                                type: object
+                                x-kubernetes-validations:
+                                - message: numerator must be less than or equal to
+                                    denominator
+                                  rule: self.numerator <= self.denominator
+                              percent:
+                                description: |-
+                                  Percent represents the percentage of requests that should be
+                                  mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
+                                  requests) and its maximum value is 100 (indicating 100% of requests).
+
+                                  Only one of Fraction or Percent may be specified. If neither field
+                                  is specified, 100% of requests will be mirrored.
+                                format: int32
+                                maximum: 100
+                                minimum: 0
+                                type: integer
                             required:
                             - backendRef
                             type: object
+                            x-kubernetes-validations:
+                            - message: Only one of percent or fraction may be specified
+                                in HTTPRequestMirrorFilter
+                              rule: '!(has(self.percent) && has(self.fraction))'
                           requestRedirect:
                             description: |-
                               RequestRedirect defines a schema for a filter that responds to the
                               request with an HTTP redirection.
-
 
                               Support: Core
                             properties:
@@ -5094,7 +5935,6 @@ spec:
                                   Hostname is the hostname to be used in the value of the `Location`
                                   header in the response.
                                   When empty, the hostname in the `Host` header of the request is used.
-
 
                                   Support: Core
                                 maxLength: 253
@@ -5106,7 +5946,6 @@ spec:
                                   Path defines parameters used to modify the path of the incoming request.
                                   The modified path is then used to construct the `Location` header. When
                                   empty, the request path is used as-is.
-
 
                                   Support: Extended
                                 properties:
@@ -5123,32 +5962,17 @@ spec:
                                       to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
                                       of "/xyz" would be modified to "/xyz/bar".
 
-
                                       Note that this matches the behavior of the PathPrefix match type. This
                                       matches full path elements. A path element refers to the list of labels
                                       in the path split by the `/` separator. When specified, a trailing `/` is
                                       ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
                                       match the prefix `/abc`, but the path `/abcd` would not.
 
-
                                       ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
                                       Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
                                       the implementation setting the Accepted Condition for the Route to `status: False`.
 
-
                                       Request Path | Prefix Match | Replace Prefix | Modified Path
-                                      -------------|--------------|----------------|----------
-                                      /foo/bar     | /foo         | /xyz           | /xyz/bar
-                                      /foo/bar     | /foo         | /xyz/          | /xyz/bar
-                                      /foo/bar     | /foo/        | /xyz           | /xyz/bar
-                                      /foo/bar     | /foo/        | /xyz/          | /xyz/bar
-                                      /foo         | /foo         | /xyz           | /xyz
-                                      /foo/        | /foo         | /xyz           | /xyz/
-                                      /foo/bar     | /foo         | <empty string> | /bar
-                                      /foo/        | /foo         | <empty string> | /
-                                      /foo         | /foo         | <empty string> | /
-                                      /foo/        | /foo         | /              | /
-                                      /foo         | /foo         | /              | /
                                     maxLength: 1024
                                     type: string
                                   type:
@@ -5156,10 +5980,8 @@ spec:
                                       Type defines the type of path modifier. Additional types may be
                                       added in a future release of the API.
 
-
                                       Note that values may be added to this enum, implementations
                                       must ensure that unknown values will not cause a crash.
-
 
                                       Unknown values here must result in the implementation setting the
                                       Accepted Condition for the Route to `status: False`, with a
@@ -5193,10 +6015,8 @@ spec:
                                   Port is the port to be used in the value of the `Location`
                                   header in the response.
 
-
                                   If no port is specified, the redirect port MUST be derived using the
                                   following rules:
-
 
                                   * If redirect scheme is not-empty, the redirect port MUST be the well-known
                                     port associated with the redirect scheme. Specifically "http" to port 80
@@ -5205,16 +6025,13 @@ spec:
                                   * If redirect scheme is empty, the redirect port MUST be the Gateway
                                     Listener port.
 
-
                                   Implementations SHOULD NOT add the port number in the 'Location'
                                   header in the following cases:
-
 
                                   * A Location header that will use HTTP (whether that is determined via
                                     the Listener protocol or the Scheme field) _and_ use port 80.
                                   * A Location header that will use HTTPS (whether that is determined via
                                     the Listener protocol or the Scheme field) _and_ use port 443.
-
 
                                   Support: Extended
                                 format: int32
@@ -5226,19 +6043,15 @@ spec:
                                   Scheme is the scheme to be used in the value of the `Location` header in
                                   the response. When empty, the scheme of the request is used.
 
-
                                   Scheme redirects can affect the port of the redirect, for more information,
                                   refer to the documentation for the port field of this filter.
-
 
                                   Note that values may be added to this enum, implementations
                                   must ensure that unknown values will not cause a crash.
 
-
                                   Unknown values here must result in the implementation setting the
                                   Accepted Condition for the Route to `status: False`, with a
                                   Reason of `UnsupportedValue`.
-
 
                                   Support: Extended
                                 enum:
@@ -5250,15 +6063,12 @@ spec:
                                 description: |-
                                   StatusCode is the HTTP status code to be used in response.
 
-
                                   Note that values may be added to this enum, implementations
                                   must ensure that unknown values will not cause a crash.
-
 
                                   Unknown values here must result in the implementation setting the
                                   Accepted Condition for the Route to `status: False`, with a
                                   Reason of `UnsupportedValue`.
-
 
                                   Support: Core
                                 enum:
@@ -5271,7 +6081,6 @@ spec:
                               ResponseHeaderModifier defines a schema for a filter that modifies response
                               headers.
 
-
                               Support: Extended
                             properties:
                               add:
@@ -5280,17 +6089,14 @@ spec:
                                   before the action. It appends to any existing values associated
                                   with the header name.
 
-
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header: foo
-
 
                                   Config:
                                     add:
                                     - name: "my-header"
                                       value: "bar,baz"
-
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -5302,8 +6108,7 @@ spec:
                                     name:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -5336,17 +6141,14 @@ spec:
                                   names are case-insensitive (see
                                   https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
 
-
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header1: foo
                                     my-header2: bar
                                     my-header3: baz
 
-
                                   Config:
                                     remove: ["my-header1", "my-header3"]
-
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -5361,17 +6163,14 @@ spec:
                                   Set overwrites the request with the given header (name, value)
                                   before the action.
 
-
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header: foo
-
 
                                   Config:
                                     set:
                                     - name: "my-header"
                                       value: "bar"
-
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -5383,8 +6182,7 @@ spec:
                                     name:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -5416,16 +6214,13 @@ spec:
                               Type identifies the type of filter to apply. As with other API fields,
                               types are classified into three conformance levels:
 
-
                               - Core: Filter types and their corresponding configuration defined by
                                 "Support: Core" in this package, e.g. "RequestHeaderModifier". All
                                 implementations must support core filters.
 
-
                               - Extended: Filter types and their corresponding configuration defined by
                                 "Support: Extended" in this package, e.g. "RequestMirror". Implementers
                                 are encouraged to support extended filters.
-
 
                               - Implementation-specific: Filters that are defined and supported by
                                 specific vendors.
@@ -5435,19 +6230,15 @@ spec:
                                 is specified using the ExtensionRef field. `Type` should be set to
                                 "ExtensionRef" for custom filters.
 
-
                               Implementers are encouraged to define custom implementation types to
                               extend the core API with implementation-specific behavior.
-
 
                               If a reference to a custom filter type cannot be resolved, the filter
                               MUST NOT be skipped. Instead, requests that would have been processed by
                               that filter MUST receive a HTTP error response.
 
-
                               Note that values may be added to this enum, implementations
                               must ensure that unknown values will not cause a crash.
-
 
                               Unknown values here must result in the implementation setting the
                               Accepted Condition for the Route to `status: False`, with a
@@ -5459,11 +6250,11 @@ spec:
                             - RequestRedirect
                             - URLRewrite
                             - ExtensionRef
+                            - CORS
                             type: string
                           urlRewrite:
                             description: |-
                               URLRewrite defines a schema for a filter that modifies a request during forwarding.
-
 
                               Support: Extended
                             properties:
@@ -5471,7 +6262,6 @@ spec:
                                 description: |-
                                   Hostname is the value to be used to replace the Host header value during
                                   forwarding.
-
 
                                   Support: Extended
                                 maxLength: 253
@@ -5481,7 +6271,6 @@ spec:
                               path:
                                 description: |-
                                   Path defines a path rewrite.
-
 
                                   Support: Extended
                                 properties:
@@ -5498,32 +6287,17 @@ spec:
                                       to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
                                       of "/xyz" would be modified to "/xyz/bar".
 
-
                                       Note that this matches the behavior of the PathPrefix match type. This
                                       matches full path elements. A path element refers to the list of labels
                                       in the path split by the `/` separator. When specified, a trailing `/` is
                                       ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
                                       match the prefix `/abc`, but the path `/abcd` would not.
 
-
                                       ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
                                       Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
                                       the implementation setting the Accepted Condition for the Route to `status: False`.
 
-
                                       Request Path | Prefix Match | Replace Prefix | Modified Path
-                                      -------------|--------------|----------------|----------
-                                      /foo/bar     | /foo         | /xyz           | /xyz/bar
-                                      /foo/bar     | /foo         | /xyz/          | /xyz/bar
-                                      /foo/bar     | /foo/        | /xyz           | /xyz/bar
-                                      /foo/bar     | /foo/        | /xyz/          | /xyz/bar
-                                      /foo         | /foo         | /xyz           | /xyz
-                                      /foo/        | /foo         | /xyz           | /xyz/
-                                      /foo/bar     | /foo         | <empty string> | /bar
-                                      /foo/        | /foo         | <empty string> | /
-                                      /foo         | /foo         | <empty string> | /
-                                      /foo/        | /foo         | /              | /
-                                      /foo         | /foo         | /              | /
                                     maxLength: 1024
                                     type: string
                                   type:
@@ -5531,10 +6305,8 @@ spec:
                                       Type defines the type of path modifier. Additional types may be
                                       added in a future release of the API.
 
-
                                       Note that values may be added to this enum, implementations
                                       must ensure that unknown values will not cause a crash.
-
 
                                       Unknown values here must result in the implementation setting the
                                       Accepted Condition for the Route to `status: False`, with a
@@ -5608,6 +6380,11 @@ spec:
                         - message: filter.extensionRef must be specified for ExtensionRef
                             filter.type
                           rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                        - message: filter.cors must be nil if the filter.type is not
+                            CORS
+                          rule: '!(has(self.cors) && self.type != ''CORS'')'
+                        - message: filter.cors must be specified for CORS filter.type
+                          rule: '!(!has(self.cors) && self.type == ''CORS'')'
                       maxItems: 16
                       type: array
                       x-kubernetes-validations:
@@ -5636,9 +6413,7 @@ spec:
                         HTTP requests. Each match is independent, i.e. this rule will be matched
                         if **any** one of the matches is satisfied.
 
-
                         For example, take the following matches configuration:
-
 
                         ```
                         matches:
@@ -5651,29 +6426,23 @@ spec:
                             value: "/v2/foo"
                         ```
 
-
                         For a request to match against this rule, a request must satisfy
                         EITHER of the two conditions:
-
 
                         - path prefixed with `/foo` AND contains the header `version: v2`
                         - path prefix of `/v2/foo`
 
-
                         See the documentation for HTTPRouteMatch on how to specify multiple
                         match conditions that should be ANDed together.
-
 
                         If no matches are specified, the default is a prefix
                         path match on "/", which has the effect of matching every
                         HTTP request.
 
-
                         Proxy or Load Balancer routing configuration generated from HTTPRoutes
                         MUST prioritize matches based on the following criteria, continuing on
                         ties. Across all rules specified on applicable Routes, precedence must be
                         given to the match having:
-
 
                         * "Exact" path match.
                         * "Prefix" path match with largest number of characters.
@@ -5681,23 +6450,18 @@ spec:
                         * Largest number of header matches.
                         * Largest number of query param matches.
 
-
                         Note: The precedence of RegularExpression path matches are implementation-specific.
-
 
                         If ties still exist across multiple Routes, matching precedence MUST be
                         determined in order of the following criteria, continuing on ties:
-
 
                         * The oldest Route based on creation timestamp.
                         * The Route appearing first in alphabetical order by
                           "{namespace}/{name}".
 
-
                         If ties still exist within an HTTPRoute, matching precedence MUST be granted
                         to the FIRST matching rule (in list order) with a match meeting the above
                         criteria.
-
 
                         When no rules matching a request have been successfully attached to the
                         parent a request is coming from, a HTTP 404 status code MUST be returned.
@@ -5705,11 +6469,11 @@ spec:
                         description: "HTTPRouteMatch defines the predicate used to
                           match requests to a given\naction. Multiple match types
                           are ANDed together, i.e. the match will\nevaluate to true
-                          only if all conditions are satisfied.\n\n\nFor example,
-                          the match below will match a HTTP request only if its path\nstarts
-                          with `/foo` AND it contains the `version: v1` header:\n\n\n```\nmatch:\n\n\n\tpath:\n\t
+                          only if all conditions are satisfied.\n\nFor example, the
+                          match below will match a HTTP request only if its path\nstarts
+                          with `/foo` AND it contains the `version: v1` header:\n\n```\nmatch:\n\n\tpath:\n\t
                           \ value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t
-                          \ value \"v1\"\n\n\n```"
+                          \ value \"v1\"\n\n```"
                         properties:
                           headers:
                             description: |-
@@ -5724,15 +6488,13 @@ spec:
                                 name:
                                   description: |-
                                     Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                    case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
+                                    case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
                                     If multiple entries specify equivalent header names, only the first
                                     entry with an equivalent name MUST be considered for a match. Subsequent
                                     entries with an equivalent header name MUST be ignored. Due to the
                                     case-insensitivity of header names, "foo" and "Foo" are considered
                                     equivalent.
-
 
                                     When a header is repeated in an HTTP request, it is
                                     implementation-specific behavior as to how this is represented.
@@ -5748,12 +6510,9 @@ spec:
                                   description: |-
                                     Type specifies how to match against the value of the header.
 
-
                                     Support: Core (Exact)
 
-
                                     Support: Implementation-specific (RegularExpression)
-
 
                                     Since RegularExpression HeaderMatchType has implementation-specific
                                     conformance, implementations can support POSIX, PCRE or any other dialects
@@ -5784,7 +6543,6 @@ spec:
                               When specified, this route will be matched only if the request has the
                               specified method.
 
-
                               Support: Extended
                             enum:
                             - GET
@@ -5810,9 +6568,7 @@ spec:
                                 description: |-
                                   Type specifies how to match against the path Value.
 
-
                                   Support: Core (Exact, PathPrefix)
-
 
                                   Support: Implementation-specific (RegularExpression)
                                 enum:
@@ -5878,7 +6634,6 @@ spec:
                               values are ANDed together, meaning, a request must match all the
                               specified query parameters to select the route.
 
-
                               Support: Extended
                             items:
                               description: |-
@@ -5891,11 +6646,9 @@ spec:
                                     exact string match. (See
                                     https://tools.ietf.org/html/rfc7230#section-2.7.3).
 
-
                                     If multiple entries specify equivalent query param names, only the first
                                     entry with an equivalent name MUST be considered for a match. Subsequent
                                     entries with an equivalent query param name MUST be ignored.
-
 
                                     If a query param is repeated in an HTTP request, the behavior is
                                     purposely left undefined, since different data planes have different
@@ -5903,7 +6656,6 @@ spec:
                                     match against the first value of the param if the data plane supports it,
                                     as this behavior is expected in other load balancing contexts outside of
                                     the Gateway API.
-
 
                                     Users SHOULD NOT route traffic based on repeated query params to guard
                                     themselves against potential differences in the implementations.
@@ -5916,12 +6668,9 @@ spec:
                                   description: |-
                                     Type specifies how to match against the value of the query parameter.
 
-
                                     Support: Extended (Exact)
 
-
                                     Support: Implementation-specific (RegularExpression)
-
 
                                     Since RegularExpression QueryParamMatchType has Implementation-specific
                                     conformance, implementations can support POSIX, PCRE or any other
@@ -5947,24 +6696,116 @@ spec:
                             - name
                             x-kubernetes-list-type: map
                         type: object
-                      maxItems: 8
+                      maxItems: 64
                       type: array
+                    name:
+                      description: |-
+                        Name is the name of the route rule. This name MUST be unique within a Route if it is set.
+
+                        Support: Extended
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    retry:
+                      description: |-
+                        Retry defines the configuration for when to retry an HTTP request.
+
+                        Support: Extended
+                      properties:
+                        attempts:
+                          description: |-
+                            Attempts specifies the maximum number of times an individual request
+                            from the gateway to a backend should be retried.
+
+                            If the maximum number of retries has been attempted without a successful
+                            response from the backend, the Gateway MUST return an error.
+
+                            When this field is unspecified, the number of times to attempt to retry
+                            a backend request is implementation-specific.
+
+                            Support: Extended
+                          type: integer
+                        backoff:
+                          description: |-
+                            Backoff specifies the minimum duration a Gateway should wait between
+                            retry attempts and is represented in Gateway API Duration formatting.
+
+                            For example, setting the `rules[].retry.backoff` field to the value
+                            `100ms` will cause a backend request to first be retried approximately
+                            100 milliseconds after timing out or receiving a response code configured
+                            to be retryable.
+
+                            An implementation MAY use an exponential or alternative backoff strategy
+                            for subsequent retry attempts, MAY cap the maximum backoff duration to
+                            some amount greater than the specified minimum, and MAY add arbitrary
+                            jitter to stagger requests, as long as unsuccessful backend requests are
+                            not retried before the configured minimum duration.
+
+                            If a Request timeout (`rules[].timeouts.request`) is configured on the
+                            route, the entire duration of the initial request and any retry attempts
+                            MUST not exceed the Request timeout duration. If any retry attempts are
+                            still in progress when the Request timeout duration has been reached,
+                            these SHOULD be canceled if possible and the Gateway MUST immediately
+                            return a timeout error.
+
+                            If a BackendRequest timeout (`rules[].timeouts.backendRequest`) is
+                            configured on the route, any retry attempts which reach the configured
+                            BackendRequest timeout duration without a response SHOULD be canceled if
+                            possible and the Gateway should wait for at least the specified backoff
+                            duration before attempting to retry the backend request again.
+
+                            If a BackendRequest timeout is _not_ configured on the route, retry
+                            attempts MAY time out after an implementation default duration, or MAY
+                            remain pending until a configured Request timeout or implementation
+                            default duration for total request time is reached.
+
+                            When this field is unspecified, the time to wait between retry attempts
+                            is implementation-specific.
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        codes:
+                          description: |-
+                            Codes defines the HTTP response status codes for which a backend request
+                            should be retried.
+
+                            Support: Extended
+                          items:
+                            description: |-
+                              HTTPRouteRetryStatusCode defines an HTTP response status code for
+                              which a backend request should be retried.
+
+                              Implementations MUST support the following status codes as retryable:
+
+                              * 500
+                              * 502
+                              * 503
+                              * 504
+
+                              Implementations MAY support specifying additional discrete values in the
+                              500-599 range.
+
+                              Implementations MAY support specifying discrete values in the 400-499 range,
+                              which are often inadvisable to retry.
+                            maximum: 599
+                            minimum: 400
+                            type: integer
+                          type: array
+                      type: object
                     sessionPersistence:
-                      description: |+
+                      description: |-
                         SessionPersistence defines and configures session persistence
                         for the route rule.
 
-
                         Support: Extended
-
-
                       properties:
                         absoluteTimeout:
                           description: |-
                             AbsoluteTimeout defines the absolute timeout of the persistent
                             session. Once the AbsoluteTimeout duration has elapsed, the
                             session becomes invalid.
-
 
                             Support: Extended
                           pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
@@ -5973,7 +6814,6 @@ spec:
                           description: |-
                             CookieConfig provides configuration settings that are specific
                             to cookie-based session persistence.
-
 
                             Support: Core
                           properties:
@@ -5986,19 +6826,17 @@ spec:
                                 attributes, while a session cookie is deleted when the current
                                 session ends.
 
-
                                 When set to "Permanent", AbsoluteTimeout indicates the
                                 cookie's lifetime via the Expires or Max-Age cookie attributes
                                 and is required.
-
 
                                 When set to "Session", AbsoluteTimeout indicates the
                                 absolute lifetime of the cookie tracked by the gateway and
                                 is optional.
 
+                                Defaults to "Session".
 
                                 Support: Core for "Session" type
-
 
                                 Support: Extended for "Permanent" type
                               enum:
@@ -6012,7 +6850,6 @@ spec:
                             Once the session has been idle for more than the specified
                             IdleTimeout duration, the session becomes invalid.
 
-
                             Support: Extended
                           pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                           type: string
@@ -6022,7 +6859,6 @@ spec:
                             which may be reflected in the cookie or the header. Users
                             should avoid reusing session names to prevent unintended
                             consequences, such as rejection or unpredictable behavior.
-
 
                             Support: Implementation-specific
                           maxLength: 128
@@ -6034,9 +6870,7 @@ spec:
                             the use a header or cookie. Defaults to cookie based session
                             persistence.
 
-
                             Support: Core for "Cookie" type
-
 
                             Support: Extended for "Header" type
                           enum:
@@ -6047,16 +6881,13 @@ spec:
                       x-kubernetes-validations:
                       - message: AbsoluteTimeout must be specified when cookie lifetimeType
                           is Permanent
-                        rule: '!has(self.cookieConfig.lifetimeType) || self.cookieConfig.lifetimeType
-                          != ''Permanent'' || has(self.absoluteTimeout)'
+                        rule: '!has(self.cookieConfig) || !has(self.cookieConfig.lifetimeType)
+                          || self.cookieConfig.lifetimeType != ''Permanent'' || has(self.absoluteTimeout)'
                     timeouts:
-                      description: |+
+                      description: |-
                         Timeouts defines the timeouts that can be configured for an HTTP request.
 
-
                         Support: Extended
-
-
                       properties:
                         backendRequest:
                           description: |-
@@ -6064,21 +6895,19 @@ spec:
                             to a backend. This covers the time from when the request first starts being
                             sent from the gateway to when the full response has been received from the backend.
 
-
                             Setting a timeout to the zero duration (e.g. "0s") SHOULD disable the timeout
                             completely. Implementations that cannot completely disable the timeout MUST
                             instead interpret the zero duration as the longest possible value to which
                             the timeout can be set.
 
-
                             An entire client HTTP transaction with a gateway, covered by the Request timeout,
                             may result in more than one call from the gateway to the destination backend,
                             for example, if automatic retries are supported.
 
-
-                            Because the Request timeout encompasses the BackendRequest timeout, the value of
-                            BackendRequest must be <= the value of Request timeout.
-
+                            The value of BackendRequest must be a Gateway API Duration string as defined by
+                            GEP-2257.  When this field is unspecified, its behavior is implementation-specific;
+                            when specified, the value of BackendRequest must be no more than the value of the
+                            Request timeout (since the Request timeout encompasses the BackendRequest timeout).
 
                             Support: Extended
                           pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
@@ -6089,26 +6918,22 @@ spec:
                             If the gateway has not been able to respond before this deadline is met, the gateway
                             MUST return a timeout error.
 
-
                             For example, setting the `rules.timeouts.request` field to the value `10s` in an
                             `HTTPRoute` will cause a timeout if a client request is taking longer than 10 seconds
                             to complete.
-
 
                             Setting a timeout to the zero duration (e.g. "0s") SHOULD disable the timeout
                             completely. Implementations that cannot completely disable the timeout MUST
                             instead interpret the zero duration as the longest possible value to which
                             the timeout can be set.
 
-
                             This timeout is intended to cover as close to the whole request-response transaction
                             as possible although an implementation MAY choose to start the timeout after the entire
                             request stream has been received instead of immediately after the transaction is
                             initiated by the client.
 
-
-                            When this field is unspecified, request timeout behavior is implementation-specific.
-
+                            The value of Request is a Gateway API Duration string as defined by GEP-2257. When this
+                            field is unspecified, request timeout behavior is implementation-specific.
 
                             Support: Extended
                           pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
@@ -6163,6 +6988,24 @@ spec:
                       != ''PathPrefix'') ? false : true) : true'
                 maxItems: 16
                 type: array
+                x-kubernetes-validations:
+                - message: While 16 rules and 64 matches per rule are allowed, the
+                    total number of matches across all rules in a route must be less
+                    than 128
+                  rule: '(self.size() > 0 ? self[0].matches.size() : 0) + (self.size()
+                    > 1 ? self[1].matches.size() : 0) + (self.size() > 2 ? self[2].matches.size()
+                    : 0) + (self.size() > 3 ? self[3].matches.size() : 0) + (self.size()
+                    > 4 ? self[4].matches.size() : 0) + (self.size() > 5 ? self[5].matches.size()
+                    : 0) + (self.size() > 6 ? self[6].matches.size() : 0) + (self.size()
+                    > 7 ? self[7].matches.size() : 0) + (self.size() > 8 ? self[8].matches.size()
+                    : 0) + (self.size() > 9 ? self[9].matches.size() : 0) + (self.size()
+                    > 10 ? self[10].matches.size() : 0) + (self.size() > 11 ? self[11].matches.size()
+                    : 0) + (self.size() > 12 ? self[12].matches.size() : 0) + (self.size()
+                    > 13 ? self[13].matches.size() : 0) + (self.size() > 14 ? self[14].matches.size()
+                    : 0) + (self.size() > 15 ? self[15].matches.size() : 0) <= 128'
+                - message: Rule name must be unique within the route
+                  rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name)
+                    && l1.name == l2.name))
             type: object
           status:
             description: Status defines the current state of HTTPRoute.
@@ -6176,12 +7019,10 @@ spec:
                   first sees the route and should update the entry as appropriate when the
                   route or gateway is modified.
 
-
                   Note that parent references that cannot be resolved by an implementation
                   of this API will not be added to this list. Implementations of this API
                   can only populate Route status for the Gateways/parent resources they are
                   responsible for.
-
 
                   A maximum of 32 Gateways will be represented in this list. An empty list
                   means the route has not been attached to any Gateway.
@@ -6196,38 +7037,24 @@ spec:
                         Note that the route's availability is also subject to the Gateway's own
                         status conditions and listener status.
 
-
                         If the Route's ParentRef specifies an existing Gateway that supports
                         Routes of this kind AND that Gateway's controller has sufficient access,
                         then that Gateway's controller MUST set the "Accepted" condition on the
                         Route, to indicate whether the route has been accepted or rejected by the
                         Gateway, and why.
 
-
                         A Route MUST be considered "Accepted" if at least one of the Route's
                         rules is implemented by the Gateway.
-
 
                         There are a number of cases where the "Accepted" condition may not be set
                         due to lack of controller visibility, that includes when:
 
-
-                        * The Route refers to a non-existent parent.
+                        * The Route refers to a nonexistent parent.
                         * The Route is of a type that the controller does not support.
                         * The Route is in a namespace the controller does not have access to.
                       items:
-                        description: "Condition contains details for one aspect of
-                          the current state of this API Resource.\n---\nThis struct
-                          is intended for direct use as an array at the field path
-                          .status.conditions.  For example,\n\n\n\ttype FooStatus
-                          struct{\n\t    // Represents the observations of a foo's
-                          current state.\n\t    // Known .status.conditions.type are:
-                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
-                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
-                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
-                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                          \   // other fields\n\t}"
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
                         properties:
                           lastTransitionTime:
                             description: |-
@@ -6269,12 +7096,7 @@ spec:
                             - Unknown
                             type: string
                           type:
-                            description: |-
-                              type of condition in CamelCase or in foo.example.com/CamelCase.
-                              ---
-                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                              useful (see .node.status.conditions), the ability to deconflict is important.
-                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
                             maxLength: 316
                             pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                             type: string
@@ -6297,14 +7119,11 @@ spec:
                         controller that wrote this status. This corresponds with the
                         controllerName field on GatewayClass.
 
-
                         Example: "example.net/gateway-controller".
-
 
                         The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
                         valid Kubernetes names
                         (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
-
 
                         Controllers MUST populate this field when writing status. Controllers should ensure that
                         entries to status populated with their ControllerName are cleaned up when they are no
@@ -6326,7 +7145,6 @@ spec:
                             To set the core API group (such as for a "Service" kind referent),
                             Group must be explicitly set to "" (empty string).
 
-
                             Support: Core
                           maxLength: 253
                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -6336,13 +7154,10 @@ spec:
                           description: |-
                             Kind is kind of the referent.
 
-
                             There are two kinds of parent resources with "Core" support:
-
 
                             * Gateway (Gateway conformance profile)
                             * Service (Mesh conformance profile, ClusterIP Services only)
-
 
                             Support for other resources is Implementation-Specific.
                           maxLength: 63
@@ -6353,7 +7168,6 @@ spec:
                           description: |-
                             Name is the name of the referent.
 
-
                             Support: Core
                           maxLength: 253
                           minLength: 1
@@ -6363,7 +7177,6 @@ spec:
                             Namespace is the namespace of the referent. When unspecified, this refers
                             to the local namespace of the Route.
 
-
                             Note that there are specific rules for ParentRefs which cross namespace
                             boundaries. Cross-namespace references are only valid if they are explicitly
                             allowed by something in the namespace they are referring to. For example:
@@ -6371,18 +7184,15 @@ spec:
                             generic way to enable any other kind of cross-namespace reference.
 
 
-
                             ParentRefs from a Route to a Service in the same namespace are "producer"
                             routes, which apply default routing rules to inbound connections from
                             any namespace to the Service.
-
 
                             ParentRefs from a Route to a Service in a different namespace are
                             "consumer" routes, and these routing rules are only applied to outbound
                             connections originating from the same namespace as the Route, for which
                             the intended destination of the connections are a Service targeted as a
                             ParentRef of the Route.
-
 
 
                             Support: Core
@@ -6395,7 +7205,6 @@ spec:
                             Port is the network port this Route targets. It can be interpreted
                             differently based on the type of parent resource.
 
-
                             When the parent resource is a Gateway, this targets all listeners
                             listening on the specified port that also support this kind of Route(and
                             select this Route). It's not recommended to set `Port` unless the
@@ -6405,17 +7214,14 @@ spec:
                             must match both specified values.
 
 
-
                             When the parent resource is a Service, this targets a specific port in the
                             Service spec. When both Port (experimental) and SectionName are specified,
                             the name and port of the selected port must match both specified values.
 
 
-
                             Implementations MAY choose to support other parent resources.
                             Implementations supporting other types of parent resources MUST clearly
                             document how/if Port is interpreted.
-
 
                             For the purpose of status, an attachment is considered successful as
                             long as the parent resource accepts it partially. For example, Gateway
@@ -6424,7 +7230,6 @@ spec:
                             from the referencing Route, the Route MUST be considered successfully
                             attached. If no Gateway listeners accept attachment from this Route,
                             the Route MUST be considered detached from the Gateway.
-
 
                             Support: Extended
                           format: int32
@@ -6436,7 +7241,6 @@ spec:
                             SectionName is the name of a section within the target resource. In the
                             following resources, SectionName is interpreted as the following:
 
-
                             * Gateway: Listener name. When both Port (experimental) and SectionName
                             are specified, the name and port of the selected listener must match
                             both specified values.
@@ -6444,11 +7248,9 @@ spec:
                             are specified, the name and port of the selected listener must match
                             both specified values.
 
-
                             Implementations MAY choose to support attaching Routes to other resources.
                             If that is the case, they MUST clearly document how SectionName is
                             interpreted.
-
 
                             When unspecified (empty string), this will reference the entire resource.
                             For the purpose of status, an attachment is considered successful if at
@@ -6458,7 +7260,6 @@ spec:
                             the referencing Route, the Route MUST be considered successfully
                             attached. If no Gateway listeners accept attachment from this Route, the
                             Route MUST be considered detached from the Gateway.
-
 
                             Support: Core
                           maxLength: 253

--- a/platform/gateway-api/chart/templates/referencegrants.yaml
+++ b/platform/gateway-api/chart/templates/referencegrants.yaml
@@ -9,7 +9,6 @@
   cluster-scoped infrastructure; deleting them on uninstall would break
   every HTTPRoute on the cluster simultaneously.
 */}}
-
 #
 # config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
 #
@@ -18,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
-    gateway.networking.k8s.io/bundle-version: v1.1.0
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.3.0
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: referencegrants.gateway.networking.k8s.io
@@ -40,187 +39,6 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    deprecated: true
-    deprecationWarning: The v1alpha2 version of ReferenceGrant has been deprecated
-      and will be removed in a future release of the API. Please upgrade to v1beta1.
-    name: v1alpha2
-    schema:
-      openAPIV3Schema:
-        description: |-
-          ReferenceGrant identifies kinds of resources in other namespaces that are
-          trusted to reference the specified kinds of resources in the same namespace
-          as the policy.
-
-
-          Each ReferenceGrant can be used to represent a unique trust relationship.
-          Additional Reference Grants can be used to add to the set of trusted
-          sources of inbound references for the namespace they are defined within.
-
-
-          A ReferenceGrant is required for all cross-namespace references in Gateway API
-          (with the exception of cross-namespace Route-Gateway attachment, which is
-          governed by the AllowedRoutes configuration on the Gateway, and cross-namespace
-          Service ParentRefs on a "consumer" mesh Route, which defines routing rules
-          applicable only to workloads in the Route namespace). ReferenceGrants allowing
-          a reference from a Route to a Service are only applicable to BackendRefs.
-
-
-          ReferenceGrant is a form of runtime verification allowing users to assert
-          which cross-namespace object references are permitted. Implementations that
-          support ReferenceGrant MUST NOT permit cross-namespace references which have
-          no grant, and MUST respond to the removal of a grant by revoking the access
-          that the grant allowed.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec defines the desired state of ReferenceGrant.
-            properties:
-              from:
-                description: |-
-                  From describes the trusted namespaces and kinds that can reference the
-                  resources described in "To". Each entry in this list MUST be considered
-                  to be an additional place that references can be valid from, or to put
-                  this another way, entries MUST be combined using OR.
-
-
-                  Support: Core
-                items:
-                  description: ReferenceGrantFrom describes trusted namespaces and
-                    kinds.
-                  properties:
-                    group:
-                      description: |-
-                        Group is the group of the referent.
-                        When empty, the Kubernetes core API group is inferred.
-
-
-                        Support: Core
-                      maxLength: 253
-                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                      type: string
-                    kind:
-                      description: |-
-                        Kind is the kind of the referent. Although implementations may support
-                        additional resources, the following types are part of the "Core"
-                        support level for this field.
-
-
-                        When used to permit a SecretObjectReference:
-
-
-                        * Gateway
-
-
-                        When used to permit a BackendObjectReference:
-
-
-                        * GRPCRoute
-                        * HTTPRoute
-                        * TCPRoute
-                        * TLSRoute
-                        * UDPRoute
-                      maxLength: 63
-                      minLength: 1
-                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                      type: string
-                    namespace:
-                      description: |-
-                        Namespace is the namespace of the referent.
-
-
-                        Support: Core
-                      maxLength: 63
-                      minLength: 1
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                      type: string
-                  required:
-                  - group
-                  - kind
-                  - namespace
-                  type: object
-                maxItems: 16
-                minItems: 1
-                type: array
-              to:
-                description: |-
-                  To describes the resources that may be referenced by the resources
-                  described in "From". Each entry in this list MUST be considered to be an
-                  additional place that references can be valid to, or to put this another
-                  way, entries MUST be combined using OR.
-
-
-                  Support: Core
-                items:
-                  description: |-
-                    ReferenceGrantTo describes what Kinds are allowed as targets of the
-                    references.
-                  properties:
-                    group:
-                      description: |-
-                        Group is the group of the referent.
-                        When empty, the Kubernetes core API group is inferred.
-
-
-                        Support: Core
-                      maxLength: 253
-                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                      type: string
-                    kind:
-                      description: |-
-                        Kind is the kind of the referent. Although implementations may support
-                        additional resources, the following types are part of the "Core"
-                        support level for this field:
-
-
-                        * Secret when used to permit a SecretObjectReference
-                        * Service when used to permit a BackendObjectReference
-                      maxLength: 63
-                      minLength: 1
-                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                      type: string
-                    name:
-                      description: |-
-                        Name is the name of the referent. When unspecified, this policy
-                        refers to all resources of the specified Group and Kind in the local
-                        namespace.
-                      maxLength: 253
-                      minLength: 1
-                      type: string
-                  required:
-                  - group
-                  - kind
-                  type: object
-                maxItems: 16
-                minItems: 1
-                type: array
-            required:
-            - from
-            - to
-            type: object
-        type: object
-    served: true
-    storage: false
-    subresources: {}
-  - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -229,15 +47,12 @@ spec:
           trusted to reference the specified kinds of resources in the same namespace
           as the policy.
 
-
           Each ReferenceGrant can be used to represent a unique trust relationship.
           Additional Reference Grants can be used to add to the set of trusted
           sources of inbound references for the namespace they are defined within.
 
-
           All cross-namespace references in Gateway API (with the exception of cross-namespace
           Gateway-route attachment) require a ReferenceGrant.
-
 
           ReferenceGrant is a form of runtime verification allowing users to assert
           which cross-namespace object references are permitted. Implementations that
@@ -272,7 +87,6 @@ spec:
                   to be an additional place that references can be valid from, or to put
                   this another way, entries MUST be combined using OR.
 
-
                   Support: Core
                 items:
                   description: ReferenceGrantFrom describes trusted namespaces and
@@ -282,7 +96,6 @@ spec:
                       description: |-
                         Group is the group of the referent.
                         When empty, the Kubernetes core API group is inferred.
-
 
                         Support: Core
                       maxLength: 253
@@ -294,15 +107,11 @@ spec:
                         additional resources, the following types are part of the "Core"
                         support level for this field.
 
-
                         When used to permit a SecretObjectReference:
-
 
                         * Gateway
 
-
                         When used to permit a BackendObjectReference:
-
 
                         * GRPCRoute
                         * HTTPRoute
@@ -316,7 +125,6 @@ spec:
                     namespace:
                       description: |-
                         Namespace is the namespace of the referent.
-
 
                         Support: Core
                       maxLength: 63
@@ -338,7 +146,6 @@ spec:
                   additional place that references can be valid to, or to put this another
                   way, entries MUST be combined using OR.
 
-
                   Support: Core
                 items:
                   description: |-
@@ -350,7 +157,6 @@ spec:
                         Group is the group of the referent.
                         When empty, the Kubernetes core API group is inferred.
 
-
                         Support: Core
                       maxLength: 253
                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -360,7 +166,6 @@ spec:
                         Kind is the kind of the referent. Although implementations may support
                         additional resources, the following types are part of the "Core"
                         support level for this field:
-
 
                         * Secret when used to permit a SecretObjectReference
                         * Service when used to permit a BackendObjectReference

--- a/platform/gateway-api/chart/templates/tcproutes.yaml
+++ b/platform/gateway-api/chart/templates/tcproutes.yaml
@@ -9,7 +9,6 @@
   cluster-scoped infrastructure; deleting them on uninstall would break
   every HTTPRoute on the cluster simultaneously.
 */}}
-
 #
 # config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
 #
@@ -18,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
-    gateway.networking.k8s.io/bundle-version: v1.1.0
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.3.0
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: tcproutes.gateway.networking.k8s.io
@@ -67,7 +66,7 @@ spec:
             description: Spec defines the desired state of TCPRoute.
             properties:
               parentRefs:
-                description: |+
+                description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants
                   to be attached to. Note that the referenced parent resource needs to
                   allow this for the attachment to be complete. For Gateways, that means
@@ -79,20 +78,15 @@ spec:
                   create a "producer" route for a Service in a different namespace from the
                   Route.
 
-
                   There are two kinds of parent resources with "Core" support:
-
 
                   * Gateway (Gateway conformance profile)
                   * Service (Mesh conformance profile, ClusterIP Services only)
 
-
                   This API may be extended in the future to support additional kinds of parent
                   resources.
 
-
                   ParentRefs must be _distinct_. This means either that:
-
 
                   * They select different objects.  If this is the case, then parentRef
                     entries are distinct. In terms of fields, this means that the
@@ -103,9 +97,7 @@ spec:
                     optional fields to different values. If one ParentRef sets a
                     combination of optional fields, all must set the same combination.
 
-
                   Some examples:
-
 
                   * If one ParentRef sets `sectionName`, all ParentRefs referencing the
                     same object must also set `sectionName`.
@@ -114,13 +106,11 @@ spec:
                   * If one ParentRef sets `sectionName` and `port`, all ParentRefs
                     referencing the same object must also set `sectionName` and `port`.
 
-
                   It is possible to separately reference multiple distinct objects that may
                   be collapsed by an implementation. For example, some implementations may
                   choose to merge compatible Gateway Listeners together. If that is the
                   case, the list of routes attached to those resources should also be
                   merged.
-
 
                   Note that for ParentRefs that cross namespace boundaries, there are specific
                   rules. Cross-namespace references are only valid if they are explicitly
@@ -129,37 +119,26 @@ spec:
                   generic way to enable other kinds of cross-namespace reference.
 
 
-
                   ParentRefs from a Route to a Service in the same namespace are "producer"
                   routes, which apply default routing rules to inbound connections from
                   any namespace to the Service.
-
 
                   ParentRefs from a Route to a Service in a different namespace are
                   "consumer" routes, and these routing rules are only applied to outbound
                   connections originating from the same namespace as the Route, for which
                   the intended destination of the connections are a Service targeted as a
                   ParentRef of the Route.
-
-
-
-
-
-
                 items:
                   description: |-
                     ParentReference identifies an API object (usually a Gateway) that can be considered
                     a parent of this resource (usually a route). There are two kinds of parent resources
                     with "Core" support:
 
-
                     * Gateway (Gateway conformance profile)
                     * Service (Mesh conformance profile, ClusterIP Services only)
 
-
                     This API may be extended in the future to support additional kinds of parent
                     resources.
-
 
                     The API object must be valid in the cluster; the Group and Kind must
                     be registered in the cluster for this reference to be valid.
@@ -172,7 +151,6 @@ spec:
                         To set the core API group (such as for a "Service" kind referent),
                         Group must be explicitly set to "" (empty string).
 
-
                         Support: Core
                       maxLength: 253
                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -182,13 +160,10 @@ spec:
                       description: |-
                         Kind is kind of the referent.
 
-
                         There are two kinds of parent resources with "Core" support:
-
 
                         * Gateway (Gateway conformance profile)
                         * Service (Mesh conformance profile, ClusterIP Services only)
-
 
                         Support for other resources is Implementation-Specific.
                       maxLength: 63
@@ -199,7 +174,6 @@ spec:
                       description: |-
                         Name is the name of the referent.
 
-
                         Support: Core
                       maxLength: 253
                       minLength: 1
@@ -209,7 +183,6 @@ spec:
                         Namespace is the namespace of the referent. When unspecified, this refers
                         to the local namespace of the Route.
 
-
                         Note that there are specific rules for ParentRefs which cross namespace
                         boundaries. Cross-namespace references are only valid if they are explicitly
                         allowed by something in the namespace they are referring to. For example:
@@ -217,18 +190,15 @@ spec:
                         generic way to enable any other kind of cross-namespace reference.
 
 
-
                         ParentRefs from a Route to a Service in the same namespace are "producer"
                         routes, which apply default routing rules to inbound connections from
                         any namespace to the Service.
-
 
                         ParentRefs from a Route to a Service in a different namespace are
                         "consumer" routes, and these routing rules are only applied to outbound
                         connections originating from the same namespace as the Route, for which
                         the intended destination of the connections are a Service targeted as a
                         ParentRef of the Route.
-
 
 
                         Support: Core
@@ -241,7 +211,6 @@ spec:
                         Port is the network port this Route targets. It can be interpreted
                         differently based on the type of parent resource.
 
-
                         When the parent resource is a Gateway, this targets all listeners
                         listening on the specified port that also support this kind of Route(and
                         select this Route). It's not recommended to set `Port` unless the
@@ -251,17 +220,14 @@ spec:
                         must match both specified values.
 
 
-
                         When the parent resource is a Service, this targets a specific port in the
                         Service spec. When both Port (experimental) and SectionName are specified,
                         the name and port of the selected port must match both specified values.
 
 
-
                         Implementations MAY choose to support other parent resources.
                         Implementations supporting other types of parent resources MUST clearly
                         document how/if Port is interpreted.
-
 
                         For the purpose of status, an attachment is considered successful as
                         long as the parent resource accepts it partially. For example, Gateway
@@ -270,7 +236,6 @@ spec:
                         from the referencing Route, the Route MUST be considered successfully
                         attached. If no Gateway listeners accept attachment from this Route,
                         the Route MUST be considered detached from the Gateway.
-
 
                         Support: Extended
                       format: int32
@@ -282,7 +247,6 @@ spec:
                         SectionName is the name of a section within the target resource. In the
                         following resources, SectionName is interpreted as the following:
 
-
                         * Gateway: Listener name. When both Port (experimental) and SectionName
                         are specified, the name and port of the selected listener must match
                         both specified values.
@@ -290,11 +254,9 @@ spec:
                         are specified, the name and port of the selected listener must match
                         both specified values.
 
-
                         Implementations MAY choose to support attaching Routes to other resources.
                         If that is the case, they MUST clearly document how SectionName is
                         interpreted.
-
 
                         When unspecified (empty string), this will reference the entire resource.
                         For the purpose of status, an attachment is considered successful if at
@@ -304,7 +266,6 @@ spec:
                         the referencing Route, the Route MUST be considered successfully
                         attached. If no Gateway listeners accept attachment from this Route, the
                         Route MUST be considered detached from the Gateway.
-
 
                         Support: Core
                       maxLength: 253
@@ -347,21 +308,17 @@ spec:
                     backendRefs:
                       description: |-
                         BackendRefs defines the backend(s) where matching requests should be
-                        sent. If unspecified or invalid (refers to a non-existent resource or a
+                        sent. If unspecified or invalid (refers to a nonexistent resource or a
                         Service with no endpoints), the underlying implementation MUST actively
                         reject connection attempts to this backend. Connection rejections must
                         respect weight; if an invalid backend is requested to have 80% of
                         connections, then 80% of connections must be rejected instead.
 
-
                         Support: Core for Kubernetes Service
-
 
                         Support: Extended for Kubernetes ServiceImport
 
-
                         Support: Implementation-specific for any other resource
-
 
                         Support for weight: Extended
                       items:
@@ -369,35 +326,25 @@ spec:
                           BackendRef defines how a Route should forward a request to a Kubernetes
                           resource.
 
-
                           Note that when a namespace different than the local namespace is specified, a
                           ReferenceGrant object is required in the referent namespace to allow that
                           namespace's owner to accept the reference. See the ReferenceGrant
                           documentation for details.
 
 
-                          <gateway:experimental:description>
-
-
                           When the BackendRef points to a Kubernetes Service, implementations SHOULD
                           honor the appProtocol field if it is set for the target Service Port.
 
-
                           Implementations supporting appProtocol SHOULD recognize the Kubernetes
                           Standard Application Protocols defined in KEP-3726.
-
 
                           If a Service appProtocol isn't specified, an implementation MAY infer the
                           backend protocol through its own means. Implementations MAY infer the
                           protocol from the Route type referring to the backend Service.
 
-
                           If a Route is not able to send traffic to the backend using the specified
                           protocol then the backend is considered invalid. Implementations MUST set the
                           "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
-
-
-                          </gateway:experimental:description>
 
 
                           Note that when the BackendTLSPolicy object is enabled by the implementation,
@@ -418,9 +365,7 @@ spec:
                               Kind is the Kubernetes resource kind of the referent. For example
                               "Service".
 
-
                               Defaults to "Service" when not specified.
-
 
                               ExternalName services can refer to CNAME DNS records that may live
                               outside of the cluster and as such are difficult to reason about in
@@ -428,9 +373,7 @@ spec:
                               CVE-2021-25740 for more information). Implementations SHOULD NOT
                               support ExternalName Services.
 
-
                               Support: Core (Services with a type other than ExternalName)
-
 
                               Support: Implementation-specific (Services with type ExternalName)
                             maxLength: 63
@@ -447,12 +390,10 @@ spec:
                               Namespace is the namespace of the backend. When unspecified, the local
                               namespace is inferred.
 
-
                               Note that when a namespace different than the local namespace is specified,
                               a ReferenceGrant object is required in the referent namespace to allow that
                               namespace's owner to accept the reference. See the ReferenceGrant
                               documentation for details.
-
 
                               Support: Core
                             maxLength: 63
@@ -480,12 +421,10 @@ spec:
                               implementation supports. Weight is not a percentage and the sum of
                               weights does not need to equal 100.
 
-
                               If only one backend is specified and it has a weight greater than 0, 100%
                               of the traffic is forwarded to that backend. If weight is set to 0, no
                               traffic should be forwarded for this entry. If unspecified, weight
                               defaults to 1.
-
 
                               Support for this field varies based on the context where used.
                             format: int32
@@ -502,10 +441,23 @@ spec:
                       maxItems: 16
                       minItems: 1
                       type: array
+                    name:
+                      description: |-
+                        Name is the name of the route rule. This name MUST be unique within a Route if it is set.
+
+                        Support: Extended
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
                   type: object
                 maxItems: 16
                 minItems: 1
                 type: array
+                x-kubernetes-validations:
+                - message: Rule name must be unique within the route
+                  rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name)
+                    && l1.name == l2.name))
             required:
             - rules
             type: object
@@ -521,12 +473,10 @@ spec:
                   first sees the route and should update the entry as appropriate when the
                   route or gateway is modified.
 
-
                   Note that parent references that cannot be resolved by an implementation
                   of this API will not be added to this list. Implementations of this API
                   can only populate Route status for the Gateways/parent resources they are
                   responsible for.
-
 
                   A maximum of 32 Gateways will be represented in this list. An empty list
                   means the route has not been attached to any Gateway.
@@ -541,38 +491,24 @@ spec:
                         Note that the route's availability is also subject to the Gateway's own
                         status conditions and listener status.
 
-
                         If the Route's ParentRef specifies an existing Gateway that supports
                         Routes of this kind AND that Gateway's controller has sufficient access,
                         then that Gateway's controller MUST set the "Accepted" condition on the
                         Route, to indicate whether the route has been accepted or rejected by the
                         Gateway, and why.
 
-
                         A Route MUST be considered "Accepted" if at least one of the Route's
                         rules is implemented by the Gateway.
-
 
                         There are a number of cases where the "Accepted" condition may not be set
                         due to lack of controller visibility, that includes when:
 
-
-                        * The Route refers to a non-existent parent.
+                        * The Route refers to a nonexistent parent.
                         * The Route is of a type that the controller does not support.
                         * The Route is in a namespace the controller does not have access to.
                       items:
-                        description: "Condition contains details for one aspect of
-                          the current state of this API Resource.\n---\nThis struct
-                          is intended for direct use as an array at the field path
-                          .status.conditions.  For example,\n\n\n\ttype FooStatus
-                          struct{\n\t    // Represents the observations of a foo's
-                          current state.\n\t    // Known .status.conditions.type are:
-                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
-                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
-                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
-                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                          \   // other fields\n\t}"
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
                         properties:
                           lastTransitionTime:
                             description: |-
@@ -614,12 +550,7 @@ spec:
                             - Unknown
                             type: string
                           type:
-                            description: |-
-                              type of condition in CamelCase or in foo.example.com/CamelCase.
-                              ---
-                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                              useful (see .node.status.conditions), the ability to deconflict is important.
-                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
                             maxLength: 316
                             pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                             type: string
@@ -642,14 +573,11 @@ spec:
                         controller that wrote this status. This corresponds with the
                         controllerName field on GatewayClass.
 
-
                         Example: "example.net/gateway-controller".
-
 
                         The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
                         valid Kubernetes names
                         (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
-
 
                         Controllers MUST populate this field when writing status. Controllers should ensure that
                         entries to status populated with their ControllerName are cleaned up when they are no
@@ -671,7 +599,6 @@ spec:
                             To set the core API group (such as for a "Service" kind referent),
                             Group must be explicitly set to "" (empty string).
 
-
                             Support: Core
                           maxLength: 253
                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -681,13 +608,10 @@ spec:
                           description: |-
                             Kind is kind of the referent.
 
-
                             There are two kinds of parent resources with "Core" support:
-
 
                             * Gateway (Gateway conformance profile)
                             * Service (Mesh conformance profile, ClusterIP Services only)
-
 
                             Support for other resources is Implementation-Specific.
                           maxLength: 63
@@ -698,7 +622,6 @@ spec:
                           description: |-
                             Name is the name of the referent.
 
-
                             Support: Core
                           maxLength: 253
                           minLength: 1
@@ -708,7 +631,6 @@ spec:
                             Namespace is the namespace of the referent. When unspecified, this refers
                             to the local namespace of the Route.
 
-
                             Note that there are specific rules for ParentRefs which cross namespace
                             boundaries. Cross-namespace references are only valid if they are explicitly
                             allowed by something in the namespace they are referring to. For example:
@@ -716,18 +638,15 @@ spec:
                             generic way to enable any other kind of cross-namespace reference.
 
 
-
                             ParentRefs from a Route to a Service in the same namespace are "producer"
                             routes, which apply default routing rules to inbound connections from
                             any namespace to the Service.
-
 
                             ParentRefs from a Route to a Service in a different namespace are
                             "consumer" routes, and these routing rules are only applied to outbound
                             connections originating from the same namespace as the Route, for which
                             the intended destination of the connections are a Service targeted as a
                             ParentRef of the Route.
-
 
 
                             Support: Core
@@ -740,7 +659,6 @@ spec:
                             Port is the network port this Route targets. It can be interpreted
                             differently based on the type of parent resource.
 
-
                             When the parent resource is a Gateway, this targets all listeners
                             listening on the specified port that also support this kind of Route(and
                             select this Route). It's not recommended to set `Port` unless the
@@ -750,17 +668,14 @@ spec:
                             must match both specified values.
 
 
-
                             When the parent resource is a Service, this targets a specific port in the
                             Service spec. When both Port (experimental) and SectionName are specified,
                             the name and port of the selected port must match both specified values.
 
 
-
                             Implementations MAY choose to support other parent resources.
                             Implementations supporting other types of parent resources MUST clearly
                             document how/if Port is interpreted.
-
 
                             For the purpose of status, an attachment is considered successful as
                             long as the parent resource accepts it partially. For example, Gateway
@@ -769,7 +684,6 @@ spec:
                             from the referencing Route, the Route MUST be considered successfully
                             attached. If no Gateway listeners accept attachment from this Route,
                             the Route MUST be considered detached from the Gateway.
-
 
                             Support: Extended
                           format: int32
@@ -781,7 +695,6 @@ spec:
                             SectionName is the name of a section within the target resource. In the
                             following resources, SectionName is interpreted as the following:
 
-
                             * Gateway: Listener name. When both Port (experimental) and SectionName
                             are specified, the name and port of the selected listener must match
                             both specified values.
@@ -789,11 +702,9 @@ spec:
                             are specified, the name and port of the selected listener must match
                             both specified values.
 
-
                             Implementations MAY choose to support attaching Routes to other resources.
                             If that is the case, they MUST clearly document how SectionName is
                             interpreted.
-
 
                             When unspecified (empty string), this will reference the entire resource.
                             For the purpose of status, an attachment is considered successful if at
@@ -803,7 +714,6 @@ spec:
                             the referencing Route, the Route MUST be considered successfully
                             attached. If no Gateway listeners accept attachment from this Route, the
                             Route MUST be considered detached from the Gateway.
-
 
                             Support: Core
                           maxLength: 253

--- a/platform/gateway-api/chart/templates/tlsroutes.yaml
+++ b/platform/gateway-api/chart/templates/tlsroutes.yaml
@@ -9,7 +9,6 @@
   cluster-scoped infrastructure; deleting them on uninstall would break
   every HTTPRoute on the cluster simultaneously.
 */}}
-
 #
 # config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
 #
@@ -18,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
-    gateway.networking.k8s.io/bundle-version: v1.1.0
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.3.0
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: tlsroutes.gateway.networking.k8s.io
@@ -45,7 +44,6 @@ spec:
           The TLSRoute resource is similar to TCPRoute, but can be configured
           to match against TLS-specific metadata. This allows more flexibility
           in matching streams for a given TLS listener.
-
 
           If you need to forward traffic to a single target for a TLS listener, you
           could choose to use a TCPRoute with a TLS listener.
@@ -76,16 +74,13 @@ spec:
                   SNI attribute of TLS ClientHello message in TLS handshake. This matches
                   the RFC 1123 definition of a hostname with 2 notable exceptions:
 
-
                   1. IPs are not allowed in SNI names per RFC 6066.
                   2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
                      label must appear by itself as the first label.
 
-
                   If a hostname is specified by both the Listener and TLSRoute, there
                   must be at least one intersecting hostname for the TLSRoute to be
                   attached to the Listener. For example:
-
 
                   * A Listener with `test.example.com` as the hostname matches TLSRoutes
                     that have either not specified any hostnames, or have specified at
@@ -96,19 +91,16 @@ spec:
                     `test.example.com` and `*.example.com` would both match. On the other
                     hand, `example.com` and `test.example.net` would not match.
 
-
                   If both the Listener and TLSRoute have specified hostnames, any
                   TLSRoute hostnames that do not match the Listener hostname MUST be
                   ignored. For example, if a Listener specified `*.example.com`, and the
                   TLSRoute specified `test.example.com` and `test.example.net`,
                   `test.example.net` must not be considered for a match.
 
-
                   If both the Listener and TLSRoute have specified hostnames, and none
                   match with the criteria above, then the TLSRoute is not accepted. The
                   implementation must raise an 'Accepted' Condition with a status of
                   `False` in the corresponding RouteParentStatus.
-
 
                   Support: Core
                 items:
@@ -116,16 +108,13 @@ spec:
                     Hostname is the fully qualified domain name of a network host. This matches
                     the RFC 1123 definition of a hostname with 2 notable exceptions:
 
-
                      1. IPs are not allowed.
                      2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
                         label must appear by itself as the first label.
 
-
                     Hostname can be "precise" which is a domain name without the terminating
                     dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
                     domain name prefixed with a single wildcard label (e.g. `*.example.com`).
-
 
                     Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
                     alphanumeric characters or '-', and must start and end with an alphanumeric
@@ -137,7 +126,7 @@ spec:
                 maxItems: 16
                 type: array
               parentRefs:
-                description: |+
+                description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants
                   to be attached to. Note that the referenced parent resource needs to
                   allow this for the attachment to be complete. For Gateways, that means
@@ -149,20 +138,15 @@ spec:
                   create a "producer" route for a Service in a different namespace from the
                   Route.
 
-
                   There are two kinds of parent resources with "Core" support:
-
 
                   * Gateway (Gateway conformance profile)
                   * Service (Mesh conformance profile, ClusterIP Services only)
 
-
                   This API may be extended in the future to support additional kinds of parent
                   resources.
 
-
                   ParentRefs must be _distinct_. This means either that:
-
 
                   * They select different objects.  If this is the case, then parentRef
                     entries are distinct. In terms of fields, this means that the
@@ -173,9 +157,7 @@ spec:
                     optional fields to different values. If one ParentRef sets a
                     combination of optional fields, all must set the same combination.
 
-
                   Some examples:
-
 
                   * If one ParentRef sets `sectionName`, all ParentRefs referencing the
                     same object must also set `sectionName`.
@@ -184,13 +166,11 @@ spec:
                   * If one ParentRef sets `sectionName` and `port`, all ParentRefs
                     referencing the same object must also set `sectionName` and `port`.
 
-
                   It is possible to separately reference multiple distinct objects that may
                   be collapsed by an implementation. For example, some implementations may
                   choose to merge compatible Gateway Listeners together. If that is the
                   case, the list of routes attached to those resources should also be
                   merged.
-
 
                   Note that for ParentRefs that cross namespace boundaries, there are specific
                   rules. Cross-namespace references are only valid if they are explicitly
@@ -199,37 +179,26 @@ spec:
                   generic way to enable other kinds of cross-namespace reference.
 
 
-
                   ParentRefs from a Route to a Service in the same namespace are "producer"
                   routes, which apply default routing rules to inbound connections from
                   any namespace to the Service.
-
 
                   ParentRefs from a Route to a Service in a different namespace are
                   "consumer" routes, and these routing rules are only applied to outbound
                   connections originating from the same namespace as the Route, for which
                   the intended destination of the connections are a Service targeted as a
                   ParentRef of the Route.
-
-
-
-
-
-
                 items:
                   description: |-
                     ParentReference identifies an API object (usually a Gateway) that can be considered
                     a parent of this resource (usually a route). There are two kinds of parent resources
                     with "Core" support:
 
-
                     * Gateway (Gateway conformance profile)
                     * Service (Mesh conformance profile, ClusterIP Services only)
 
-
                     This API may be extended in the future to support additional kinds of parent
                     resources.
-
 
                     The API object must be valid in the cluster; the Group and Kind must
                     be registered in the cluster for this reference to be valid.
@@ -242,7 +211,6 @@ spec:
                         To set the core API group (such as for a "Service" kind referent),
                         Group must be explicitly set to "" (empty string).
 
-
                         Support: Core
                       maxLength: 253
                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -252,13 +220,10 @@ spec:
                       description: |-
                         Kind is kind of the referent.
 
-
                         There are two kinds of parent resources with "Core" support:
-
 
                         * Gateway (Gateway conformance profile)
                         * Service (Mesh conformance profile, ClusterIP Services only)
-
 
                         Support for other resources is Implementation-Specific.
                       maxLength: 63
@@ -269,7 +234,6 @@ spec:
                       description: |-
                         Name is the name of the referent.
 
-
                         Support: Core
                       maxLength: 253
                       minLength: 1
@@ -279,7 +243,6 @@ spec:
                         Namespace is the namespace of the referent. When unspecified, this refers
                         to the local namespace of the Route.
 
-
                         Note that there are specific rules for ParentRefs which cross namespace
                         boundaries. Cross-namespace references are only valid if they are explicitly
                         allowed by something in the namespace they are referring to. For example:
@@ -287,18 +250,15 @@ spec:
                         generic way to enable any other kind of cross-namespace reference.
 
 
-
                         ParentRefs from a Route to a Service in the same namespace are "producer"
                         routes, which apply default routing rules to inbound connections from
                         any namespace to the Service.
-
 
                         ParentRefs from a Route to a Service in a different namespace are
                         "consumer" routes, and these routing rules are only applied to outbound
                         connections originating from the same namespace as the Route, for which
                         the intended destination of the connections are a Service targeted as a
                         ParentRef of the Route.
-
 
 
                         Support: Core
@@ -311,7 +271,6 @@ spec:
                         Port is the network port this Route targets. It can be interpreted
                         differently based on the type of parent resource.
 
-
                         When the parent resource is a Gateway, this targets all listeners
                         listening on the specified port that also support this kind of Route(and
                         select this Route). It's not recommended to set `Port` unless the
@@ -321,17 +280,14 @@ spec:
                         must match both specified values.
 
 
-
                         When the parent resource is a Service, this targets a specific port in the
                         Service spec. When both Port (experimental) and SectionName are specified,
                         the name and port of the selected port must match both specified values.
 
 
-
                         Implementations MAY choose to support other parent resources.
                         Implementations supporting other types of parent resources MUST clearly
                         document how/if Port is interpreted.
-
 
                         For the purpose of status, an attachment is considered successful as
                         long as the parent resource accepts it partially. For example, Gateway
@@ -340,7 +296,6 @@ spec:
                         from the referencing Route, the Route MUST be considered successfully
                         attached. If no Gateway listeners accept attachment from this Route,
                         the Route MUST be considered detached from the Gateway.
-
 
                         Support: Extended
                       format: int32
@@ -352,7 +307,6 @@ spec:
                         SectionName is the name of a section within the target resource. In the
                         following resources, SectionName is interpreted as the following:
 
-
                         * Gateway: Listener name. When both Port (experimental) and SectionName
                         are specified, the name and port of the selected listener must match
                         both specified values.
@@ -360,11 +314,9 @@ spec:
                         are specified, the name and port of the selected listener must match
                         both specified values.
 
-
                         Implementations MAY choose to support attaching Routes to other resources.
                         If that is the case, they MUST clearly document how SectionName is
                         interpreted.
-
 
                         When unspecified (empty string), this will reference the entire resource.
                         For the purpose of status, an attachment is considered successful if at
@@ -374,7 +326,6 @@ spec:
                         the referencing Route, the Route MUST be considered successfully
                         attached. If no Gateway listeners accept attachment from this Route, the
                         Route MUST be considered detached from the Gateway.
-
 
                         Support: Core
                       maxLength: 253
@@ -417,7 +368,7 @@ spec:
                     backendRefs:
                       description: |-
                         BackendRefs defines the backend(s) where matching requests should be
-                        sent. If unspecified or invalid (refers to a non-existent resource or
+                        sent. If unspecified or invalid (refers to a nonexistent resource or
                         a Service with no endpoints), the rule performs no forwarding; if no
                         filters are specified that would result in a response being sent, the
                         underlying implementation must actively reject request attempts to this
@@ -426,15 +377,11 @@ spec:
                         requested to have 80% of requests, then 80% of requests must be rejected
                         instead.
 
-
                         Support: Core for Kubernetes Service
-
 
                         Support: Extended for Kubernetes ServiceImport
 
-
                         Support: Implementation-specific for any other resource
-
 
                         Support for weight: Extended
                       items:
@@ -442,35 +389,25 @@ spec:
                           BackendRef defines how a Route should forward a request to a Kubernetes
                           resource.
 
-
                           Note that when a namespace different than the local namespace is specified, a
                           ReferenceGrant object is required in the referent namespace to allow that
                           namespace's owner to accept the reference. See the ReferenceGrant
                           documentation for details.
 
 
-                          <gateway:experimental:description>
-
-
                           When the BackendRef points to a Kubernetes Service, implementations SHOULD
                           honor the appProtocol field if it is set for the target Service Port.
 
-
                           Implementations supporting appProtocol SHOULD recognize the Kubernetes
                           Standard Application Protocols defined in KEP-3726.
-
 
                           If a Service appProtocol isn't specified, an implementation MAY infer the
                           backend protocol through its own means. Implementations MAY infer the
                           protocol from the Route type referring to the backend Service.
 
-
                           If a Route is not able to send traffic to the backend using the specified
                           protocol then the backend is considered invalid. Implementations MUST set the
                           "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
-
-
-                          </gateway:experimental:description>
 
 
                           Note that when the BackendTLSPolicy object is enabled by the implementation,
@@ -491,9 +428,7 @@ spec:
                               Kind is the Kubernetes resource kind of the referent. For example
                               "Service".
 
-
                               Defaults to "Service" when not specified.
-
 
                               ExternalName services can refer to CNAME DNS records that may live
                               outside of the cluster and as such are difficult to reason about in
@@ -501,9 +436,7 @@ spec:
                               CVE-2021-25740 for more information). Implementations SHOULD NOT
                               support ExternalName Services.
 
-
                               Support: Core (Services with a type other than ExternalName)
-
 
                               Support: Implementation-specific (Services with type ExternalName)
                             maxLength: 63
@@ -520,12 +453,10 @@ spec:
                               Namespace is the namespace of the backend. When unspecified, the local
                               namespace is inferred.
 
-
                               Note that when a namespace different than the local namespace is specified,
                               a ReferenceGrant object is required in the referent namespace to allow that
                               namespace's owner to accept the reference. See the ReferenceGrant
                               documentation for details.
-
 
                               Support: Core
                             maxLength: 63
@@ -553,12 +484,10 @@ spec:
                               implementation supports. Weight is not a percentage and the sum of
                               weights does not need to equal 100.
 
-
                               If only one backend is specified and it has a weight greater than 0, 100%
                               of the traffic is forwarded to that backend. If weight is set to 0, no
                               traffic should be forwarded for this entry. If unspecified, weight
                               defaults to 1.
-
 
                               Support for this field varies based on the context where used.
                             format: int32
@@ -575,10 +504,23 @@ spec:
                       maxItems: 16
                       minItems: 1
                       type: array
+                    name:
+                      description: |-
+                        Name is the name of the route rule. This name MUST be unique within a Route if it is set.
+
+                        Support: Extended
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
                   type: object
                 maxItems: 16
                 minItems: 1
                 type: array
+                x-kubernetes-validations:
+                - message: Rule name must be unique within the route
+                  rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name)
+                    && l1.name == l2.name))
             required:
             - rules
             type: object
@@ -594,12 +536,10 @@ spec:
                   first sees the route and should update the entry as appropriate when the
                   route or gateway is modified.
 
-
                   Note that parent references that cannot be resolved by an implementation
                   of this API will not be added to this list. Implementations of this API
                   can only populate Route status for the Gateways/parent resources they are
                   responsible for.
-
 
                   A maximum of 32 Gateways will be represented in this list. An empty list
                   means the route has not been attached to any Gateway.
@@ -614,38 +554,24 @@ spec:
                         Note that the route's availability is also subject to the Gateway's own
                         status conditions and listener status.
 
-
                         If the Route's ParentRef specifies an existing Gateway that supports
                         Routes of this kind AND that Gateway's controller has sufficient access,
                         then that Gateway's controller MUST set the "Accepted" condition on the
                         Route, to indicate whether the route has been accepted or rejected by the
                         Gateway, and why.
 
-
                         A Route MUST be considered "Accepted" if at least one of the Route's
                         rules is implemented by the Gateway.
-
 
                         There are a number of cases where the "Accepted" condition may not be set
                         due to lack of controller visibility, that includes when:
 
-
-                        * The Route refers to a non-existent parent.
+                        * The Route refers to a nonexistent parent.
                         * The Route is of a type that the controller does not support.
                         * The Route is in a namespace the controller does not have access to.
                       items:
-                        description: "Condition contains details for one aspect of
-                          the current state of this API Resource.\n---\nThis struct
-                          is intended for direct use as an array at the field path
-                          .status.conditions.  For example,\n\n\n\ttype FooStatus
-                          struct{\n\t    // Represents the observations of a foo's
-                          current state.\n\t    // Known .status.conditions.type are:
-                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
-                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
-                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
-                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                          \   // other fields\n\t}"
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
                         properties:
                           lastTransitionTime:
                             description: |-
@@ -687,12 +613,7 @@ spec:
                             - Unknown
                             type: string
                           type:
-                            description: |-
-                              type of condition in CamelCase or in foo.example.com/CamelCase.
-                              ---
-                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                              useful (see .node.status.conditions), the ability to deconflict is important.
-                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
                             maxLength: 316
                             pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                             type: string
@@ -715,14 +636,11 @@ spec:
                         controller that wrote this status. This corresponds with the
                         controllerName field on GatewayClass.
 
-
                         Example: "example.net/gateway-controller".
-
 
                         The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
                         valid Kubernetes names
                         (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
-
 
                         Controllers MUST populate this field when writing status. Controllers should ensure that
                         entries to status populated with their ControllerName are cleaned up when they are no
@@ -744,7 +662,6 @@ spec:
                             To set the core API group (such as for a "Service" kind referent),
                             Group must be explicitly set to "" (empty string).
 
-
                             Support: Core
                           maxLength: 253
                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -754,13 +671,10 @@ spec:
                           description: |-
                             Kind is kind of the referent.
 
-
                             There are two kinds of parent resources with "Core" support:
-
 
                             * Gateway (Gateway conformance profile)
                             * Service (Mesh conformance profile, ClusterIP Services only)
-
 
                             Support for other resources is Implementation-Specific.
                           maxLength: 63
@@ -771,7 +685,6 @@ spec:
                           description: |-
                             Name is the name of the referent.
 
-
                             Support: Core
                           maxLength: 253
                           minLength: 1
@@ -781,7 +694,6 @@ spec:
                             Namespace is the namespace of the referent. When unspecified, this refers
                             to the local namespace of the Route.
 
-
                             Note that there are specific rules for ParentRefs which cross namespace
                             boundaries. Cross-namespace references are only valid if they are explicitly
                             allowed by something in the namespace they are referring to. For example:
@@ -789,18 +701,15 @@ spec:
                             generic way to enable any other kind of cross-namespace reference.
 
 
-
                             ParentRefs from a Route to a Service in the same namespace are "producer"
                             routes, which apply default routing rules to inbound connections from
                             any namespace to the Service.
-
 
                             ParentRefs from a Route to a Service in a different namespace are
                             "consumer" routes, and these routing rules are only applied to outbound
                             connections originating from the same namespace as the Route, for which
                             the intended destination of the connections are a Service targeted as a
                             ParentRef of the Route.
-
 
 
                             Support: Core
@@ -813,7 +722,6 @@ spec:
                             Port is the network port this Route targets. It can be interpreted
                             differently based on the type of parent resource.
 
-
                             When the parent resource is a Gateway, this targets all listeners
                             listening on the specified port that also support this kind of Route(and
                             select this Route). It's not recommended to set `Port` unless the
@@ -823,17 +731,14 @@ spec:
                             must match both specified values.
 
 
-
                             When the parent resource is a Service, this targets a specific port in the
                             Service spec. When both Port (experimental) and SectionName are specified,
                             the name and port of the selected port must match both specified values.
 
 
-
                             Implementations MAY choose to support other parent resources.
                             Implementations supporting other types of parent resources MUST clearly
                             document how/if Port is interpreted.
-
 
                             For the purpose of status, an attachment is considered successful as
                             long as the parent resource accepts it partially. For example, Gateway
@@ -842,7 +747,6 @@ spec:
                             from the referencing Route, the Route MUST be considered successfully
                             attached. If no Gateway listeners accept attachment from this Route,
                             the Route MUST be considered detached from the Gateway.
-
 
                             Support: Extended
                           format: int32
@@ -854,7 +758,6 @@ spec:
                             SectionName is the name of a section within the target resource. In the
                             following resources, SectionName is interpreted as the following:
 
-
                             * Gateway: Listener name. When both Port (experimental) and SectionName
                             are specified, the name and port of the selected listener must match
                             both specified values.
@@ -862,11 +765,9 @@ spec:
                             are specified, the name and port of the selected listener must match
                             both specified values.
 
-
                             Implementations MAY choose to support attaching Routes to other resources.
                             If that is the case, they MUST clearly document how SectionName is
                             interpreted.
-
 
                             When unspecified (empty string), this will reference the entire resource.
                             For the purpose of status, an attachment is considered successful if at
@@ -876,7 +777,6 @@ spec:
                             the referencing Route, the Route MUST be considered successfully
                             attached. If no Gateway listeners accept attachment from this Route, the
                             Route MUST be considered detached from the Gateway.
-
 
                             Support: Core
                           maxLength: 253

--- a/platform/gateway-api/chart/templates/udproutes.yaml
+++ b/platform/gateway-api/chart/templates/udproutes.yaml
@@ -9,7 +9,6 @@
   cluster-scoped infrastructure; deleting them on uninstall would break
   every HTTPRoute on the cluster simultaneously.
 */}}
-
 #
 # config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
 #
@@ -18,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
-    gateway.networking.k8s.io/bundle-version: v1.1.0
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.3.0
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: udproutes.gateway.networking.k8s.io
@@ -67,7 +66,7 @@ spec:
             description: Spec defines the desired state of UDPRoute.
             properties:
               parentRefs:
-                description: |+
+                description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants
                   to be attached to. Note that the referenced parent resource needs to
                   allow this for the attachment to be complete. For Gateways, that means
@@ -79,20 +78,15 @@ spec:
                   create a "producer" route for a Service in a different namespace from the
                   Route.
 
-
                   There are two kinds of parent resources with "Core" support:
-
 
                   * Gateway (Gateway conformance profile)
                   * Service (Mesh conformance profile, ClusterIP Services only)
 
-
                   This API may be extended in the future to support additional kinds of parent
                   resources.
 
-
                   ParentRefs must be _distinct_. This means either that:
-
 
                   * They select different objects.  If this is the case, then parentRef
                     entries are distinct. In terms of fields, this means that the
@@ -103,9 +97,7 @@ spec:
                     optional fields to different values. If one ParentRef sets a
                     combination of optional fields, all must set the same combination.
 
-
                   Some examples:
-
 
                   * If one ParentRef sets `sectionName`, all ParentRefs referencing the
                     same object must also set `sectionName`.
@@ -114,13 +106,11 @@ spec:
                   * If one ParentRef sets `sectionName` and `port`, all ParentRefs
                     referencing the same object must also set `sectionName` and `port`.
 
-
                   It is possible to separately reference multiple distinct objects that may
                   be collapsed by an implementation. For example, some implementations may
                   choose to merge compatible Gateway Listeners together. If that is the
                   case, the list of routes attached to those resources should also be
                   merged.
-
 
                   Note that for ParentRefs that cross namespace boundaries, there are specific
                   rules. Cross-namespace references are only valid if they are explicitly
@@ -129,37 +119,26 @@ spec:
                   generic way to enable other kinds of cross-namespace reference.
 
 
-
                   ParentRefs from a Route to a Service in the same namespace are "producer"
                   routes, which apply default routing rules to inbound connections from
                   any namespace to the Service.
-
 
                   ParentRefs from a Route to a Service in a different namespace are
                   "consumer" routes, and these routing rules are only applied to outbound
                   connections originating from the same namespace as the Route, for which
                   the intended destination of the connections are a Service targeted as a
                   ParentRef of the Route.
-
-
-
-
-
-
                 items:
                   description: |-
                     ParentReference identifies an API object (usually a Gateway) that can be considered
                     a parent of this resource (usually a route). There are two kinds of parent resources
                     with "Core" support:
 
-
                     * Gateway (Gateway conformance profile)
                     * Service (Mesh conformance profile, ClusterIP Services only)
 
-
                     This API may be extended in the future to support additional kinds of parent
                     resources.
-
 
                     The API object must be valid in the cluster; the Group and Kind must
                     be registered in the cluster for this reference to be valid.
@@ -172,7 +151,6 @@ spec:
                         To set the core API group (such as for a "Service" kind referent),
                         Group must be explicitly set to "" (empty string).
 
-
                         Support: Core
                       maxLength: 253
                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -182,13 +160,10 @@ spec:
                       description: |-
                         Kind is kind of the referent.
 
-
                         There are two kinds of parent resources with "Core" support:
-
 
                         * Gateway (Gateway conformance profile)
                         * Service (Mesh conformance profile, ClusterIP Services only)
-
 
                         Support for other resources is Implementation-Specific.
                       maxLength: 63
@@ -199,7 +174,6 @@ spec:
                       description: |-
                         Name is the name of the referent.
 
-
                         Support: Core
                       maxLength: 253
                       minLength: 1
@@ -209,7 +183,6 @@ spec:
                         Namespace is the namespace of the referent. When unspecified, this refers
                         to the local namespace of the Route.
 
-
                         Note that there are specific rules for ParentRefs which cross namespace
                         boundaries. Cross-namespace references are only valid if they are explicitly
                         allowed by something in the namespace they are referring to. For example:
@@ -217,18 +190,15 @@ spec:
                         generic way to enable any other kind of cross-namespace reference.
 
 
-
                         ParentRefs from a Route to a Service in the same namespace are "producer"
                         routes, which apply default routing rules to inbound connections from
                         any namespace to the Service.
-
 
                         ParentRefs from a Route to a Service in a different namespace are
                         "consumer" routes, and these routing rules are only applied to outbound
                         connections originating from the same namespace as the Route, for which
                         the intended destination of the connections are a Service targeted as a
                         ParentRef of the Route.
-
 
 
                         Support: Core
@@ -241,7 +211,6 @@ spec:
                         Port is the network port this Route targets. It can be interpreted
                         differently based on the type of parent resource.
 
-
                         When the parent resource is a Gateway, this targets all listeners
                         listening on the specified port that also support this kind of Route(and
                         select this Route). It's not recommended to set `Port` unless the
@@ -251,17 +220,14 @@ spec:
                         must match both specified values.
 
 
-
                         When the parent resource is a Service, this targets a specific port in the
                         Service spec. When both Port (experimental) and SectionName are specified,
                         the name and port of the selected port must match both specified values.
 
 
-
                         Implementations MAY choose to support other parent resources.
                         Implementations supporting other types of parent resources MUST clearly
                         document how/if Port is interpreted.
-
 
                         For the purpose of status, an attachment is considered successful as
                         long as the parent resource accepts it partially. For example, Gateway
@@ -270,7 +236,6 @@ spec:
                         from the referencing Route, the Route MUST be considered successfully
                         attached. If no Gateway listeners accept attachment from this Route,
                         the Route MUST be considered detached from the Gateway.
-
 
                         Support: Extended
                       format: int32
@@ -282,7 +247,6 @@ spec:
                         SectionName is the name of a section within the target resource. In the
                         following resources, SectionName is interpreted as the following:
 
-
                         * Gateway: Listener name. When both Port (experimental) and SectionName
                         are specified, the name and port of the selected listener must match
                         both specified values.
@@ -290,11 +254,9 @@ spec:
                         are specified, the name and port of the selected listener must match
                         both specified values.
 
-
                         Implementations MAY choose to support attaching Routes to other resources.
                         If that is the case, they MUST clearly document how SectionName is
                         interpreted.
-
 
                         When unspecified (empty string), this will reference the entire resource.
                         For the purpose of status, an attachment is considered successful if at
@@ -304,7 +266,6 @@ spec:
                         the referencing Route, the Route MUST be considered successfully
                         attached. If no Gateway listeners accept attachment from this Route, the
                         Route MUST be considered detached from the Gateway.
-
 
                         Support: Core
                       maxLength: 253
@@ -347,21 +308,17 @@ spec:
                     backendRefs:
                       description: |-
                         BackendRefs defines the backend(s) where matching requests should be
-                        sent. If unspecified or invalid (refers to a non-existent resource or a
+                        sent. If unspecified or invalid (refers to a nonexistent resource or a
                         Service with no endpoints), the underlying implementation MUST actively
                         reject connection attempts to this backend. Packet drops must
                         respect weight; if an invalid backend is requested to have 80% of
                         the packets, then 80% of packets must be dropped instead.
 
-
                         Support: Core for Kubernetes Service
-
 
                         Support: Extended for Kubernetes ServiceImport
 
-
                         Support: Implementation-specific for any other resource
-
 
                         Support for weight: Extended
                       items:
@@ -369,35 +326,25 @@ spec:
                           BackendRef defines how a Route should forward a request to a Kubernetes
                           resource.
 
-
                           Note that when a namespace different than the local namespace is specified, a
                           ReferenceGrant object is required in the referent namespace to allow that
                           namespace's owner to accept the reference. See the ReferenceGrant
                           documentation for details.
 
 
-                          <gateway:experimental:description>
-
-
                           When the BackendRef points to a Kubernetes Service, implementations SHOULD
                           honor the appProtocol field if it is set for the target Service Port.
 
-
                           Implementations supporting appProtocol SHOULD recognize the Kubernetes
                           Standard Application Protocols defined in KEP-3726.
-
 
                           If a Service appProtocol isn't specified, an implementation MAY infer the
                           backend protocol through its own means. Implementations MAY infer the
                           protocol from the Route type referring to the backend Service.
 
-
                           If a Route is not able to send traffic to the backend using the specified
                           protocol then the backend is considered invalid. Implementations MUST set the
                           "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
-
-
-                          </gateway:experimental:description>
 
 
                           Note that when the BackendTLSPolicy object is enabled by the implementation,
@@ -418,9 +365,7 @@ spec:
                               Kind is the Kubernetes resource kind of the referent. For example
                               "Service".
 
-
                               Defaults to "Service" when not specified.
-
 
                               ExternalName services can refer to CNAME DNS records that may live
                               outside of the cluster and as such are difficult to reason about in
@@ -428,9 +373,7 @@ spec:
                               CVE-2021-25740 for more information). Implementations SHOULD NOT
                               support ExternalName Services.
 
-
                               Support: Core (Services with a type other than ExternalName)
-
 
                               Support: Implementation-specific (Services with type ExternalName)
                             maxLength: 63
@@ -447,12 +390,10 @@ spec:
                               Namespace is the namespace of the backend. When unspecified, the local
                               namespace is inferred.
 
-
                               Note that when a namespace different than the local namespace is specified,
                               a ReferenceGrant object is required in the referent namespace to allow that
                               namespace's owner to accept the reference. See the ReferenceGrant
                               documentation for details.
-
 
                               Support: Core
                             maxLength: 63
@@ -480,12 +421,10 @@ spec:
                               implementation supports. Weight is not a percentage and the sum of
                               weights does not need to equal 100.
 
-
                               If only one backend is specified and it has a weight greater than 0, 100%
                               of the traffic is forwarded to that backend. If weight is set to 0, no
                               traffic should be forwarded for this entry. If unspecified, weight
                               defaults to 1.
-
 
                               Support for this field varies based on the context where used.
                             format: int32
@@ -502,10 +441,23 @@ spec:
                       maxItems: 16
                       minItems: 1
                       type: array
+                    name:
+                      description: |-
+                        Name is the name of the route rule. This name MUST be unique within a Route if it is set.
+
+                        Support: Extended
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
                   type: object
                 maxItems: 16
                 minItems: 1
                 type: array
+                x-kubernetes-validations:
+                - message: Rule name must be unique within the route
+                  rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name)
+                    && l1.name == l2.name))
             required:
             - rules
             type: object
@@ -521,12 +473,10 @@ spec:
                   first sees the route and should update the entry as appropriate when the
                   route or gateway is modified.
 
-
                   Note that parent references that cannot be resolved by an implementation
                   of this API will not be added to this list. Implementations of this API
                   can only populate Route status for the Gateways/parent resources they are
                   responsible for.
-
 
                   A maximum of 32 Gateways will be represented in this list. An empty list
                   means the route has not been attached to any Gateway.
@@ -541,38 +491,24 @@ spec:
                         Note that the route's availability is also subject to the Gateway's own
                         status conditions and listener status.
 
-
                         If the Route's ParentRef specifies an existing Gateway that supports
                         Routes of this kind AND that Gateway's controller has sufficient access,
                         then that Gateway's controller MUST set the "Accepted" condition on the
                         Route, to indicate whether the route has been accepted or rejected by the
                         Gateway, and why.
 
-
                         A Route MUST be considered "Accepted" if at least one of the Route's
                         rules is implemented by the Gateway.
-
 
                         There are a number of cases where the "Accepted" condition may not be set
                         due to lack of controller visibility, that includes when:
 
-
-                        * The Route refers to a non-existent parent.
+                        * The Route refers to a nonexistent parent.
                         * The Route is of a type that the controller does not support.
                         * The Route is in a namespace the controller does not have access to.
                       items:
-                        description: "Condition contains details for one aspect of
-                          the current state of this API Resource.\n---\nThis struct
-                          is intended for direct use as an array at the field path
-                          .status.conditions.  For example,\n\n\n\ttype FooStatus
-                          struct{\n\t    // Represents the observations of a foo's
-                          current state.\n\t    // Known .status.conditions.type are:
-                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
-                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
-                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
-                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                          \   // other fields\n\t}"
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
                         properties:
                           lastTransitionTime:
                             description: |-
@@ -614,12 +550,7 @@ spec:
                             - Unknown
                             type: string
                           type:
-                            description: |-
-                              type of condition in CamelCase or in foo.example.com/CamelCase.
-                              ---
-                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                              useful (see .node.status.conditions), the ability to deconflict is important.
-                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
                             maxLength: 316
                             pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                             type: string
@@ -642,14 +573,11 @@ spec:
                         controller that wrote this status. This corresponds with the
                         controllerName field on GatewayClass.
 
-
                         Example: "example.net/gateway-controller".
-
 
                         The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
                         valid Kubernetes names
                         (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
-
 
                         Controllers MUST populate this field when writing status. Controllers should ensure that
                         entries to status populated with their ControllerName are cleaned up when they are no
@@ -671,7 +599,6 @@ spec:
                             To set the core API group (such as for a "Service" kind referent),
                             Group must be explicitly set to "" (empty string).
 
-
                             Support: Core
                           maxLength: 253
                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -681,13 +608,10 @@ spec:
                           description: |-
                             Kind is kind of the referent.
 
-
                             There are two kinds of parent resources with "Core" support:
-
 
                             * Gateway (Gateway conformance profile)
                             * Service (Mesh conformance profile, ClusterIP Services only)
-
 
                             Support for other resources is Implementation-Specific.
                           maxLength: 63
@@ -698,7 +622,6 @@ spec:
                           description: |-
                             Name is the name of the referent.
 
-
                             Support: Core
                           maxLength: 253
                           minLength: 1
@@ -708,7 +631,6 @@ spec:
                             Namespace is the namespace of the referent. When unspecified, this refers
                             to the local namespace of the Route.
 
-
                             Note that there are specific rules for ParentRefs which cross namespace
                             boundaries. Cross-namespace references are only valid if they are explicitly
                             allowed by something in the namespace they are referring to. For example:
@@ -716,18 +638,15 @@ spec:
                             generic way to enable any other kind of cross-namespace reference.
 
 
-
                             ParentRefs from a Route to a Service in the same namespace are "producer"
                             routes, which apply default routing rules to inbound connections from
                             any namespace to the Service.
-
 
                             ParentRefs from a Route to a Service in a different namespace are
                             "consumer" routes, and these routing rules are only applied to outbound
                             connections originating from the same namespace as the Route, for which
                             the intended destination of the connections are a Service targeted as a
                             ParentRef of the Route.
-
 
 
                             Support: Core
@@ -740,7 +659,6 @@ spec:
                             Port is the network port this Route targets. It can be interpreted
                             differently based on the type of parent resource.
 
-
                             When the parent resource is a Gateway, this targets all listeners
                             listening on the specified port that also support this kind of Route(and
                             select this Route). It's not recommended to set `Port` unless the
@@ -750,17 +668,14 @@ spec:
                             must match both specified values.
 
 
-
                             When the parent resource is a Service, this targets a specific port in the
                             Service spec. When both Port (experimental) and SectionName are specified,
                             the name and port of the selected port must match both specified values.
 
 
-
                             Implementations MAY choose to support other parent resources.
                             Implementations supporting other types of parent resources MUST clearly
                             document how/if Port is interpreted.
-
 
                             For the purpose of status, an attachment is considered successful as
                             long as the parent resource accepts it partially. For example, Gateway
@@ -769,7 +684,6 @@ spec:
                             from the referencing Route, the Route MUST be considered successfully
                             attached. If no Gateway listeners accept attachment from this Route,
                             the Route MUST be considered detached from the Gateway.
-
 
                             Support: Extended
                           format: int32
@@ -781,7 +695,6 @@ spec:
                             SectionName is the name of a section within the target resource. In the
                             following resources, SectionName is interpreted as the following:
 
-
                             * Gateway: Listener name. When both Port (experimental) and SectionName
                             are specified, the name and port of the selected listener must match
                             both specified values.
@@ -789,11 +702,9 @@ spec:
                             are specified, the name and port of the selected listener must match
                             both specified values.
 
-
                             Implementations MAY choose to support attaching Routes to other resources.
                             If that is the case, they MUST clearly document how SectionName is
                             interpreted.
-
 
                             When unspecified (empty string), this will reference the entire resource.
                             For the purpose of status, an attachment is considered successful if at
@@ -803,7 +714,6 @@ spec:
                             the referencing Route, the Route MUST be considered successfully
                             attached. If no Gateway listeners accept attachment from this Route, the
                             Route MUST be considered detached from the Gateway.
-
 
                             Support: Core
                           maxLength: 253

--- a/platform/gateway-api/chart/templates/xbackendtrafficpolicies.yaml
+++ b/platform/gateway-api/chart/templates/xbackendtrafficpolicies.yaml
@@ -9,43 +9,44 @@
   cluster-scoped infrastructure; deleting them on uninstall would break
   every HTTPRoute on the cluster simultaneously.
 */}}
-
 #
-# config/crd/experimental/gateway.networking.k8s.io_backendlbpolicies.yaml
+# config/crd/experimental/gateway.networking.x-k8s.io_xbackendtrafficpolicies.yaml
 #
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
-    gateway.networking.k8s.io/bundle-version: v1.1.0
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.3.0
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
-  name: backendlbpolicies.gateway.networking.k8s.io
+  labels:
+    gateway.networking.k8s.io/policy: Direct
+  name: xbackendtrafficpolicies.gateway.networking.x-k8s.io
 spec:
-  group: gateway.networking.k8s.io
+  group: gateway.networking.x-k8s.io
   names:
     categories:
     - gateway-api
-    kind: BackendLBPolicy
-    listKind: BackendLBPolicyList
-    plural: backendlbpolicies
+    kind: XBackendTrafficPolicy
+    listKind: XBackendTrafficPolicyList
+    plural: xbackendtrafficpolicies
     shortNames:
-    - blbpolicy
-    singular: backendlbpolicy
+    - xbtrafficpolicy
+    singular: xbackendtrafficpolicy
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    name: v1alpha2
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-
-          BackendLBPolicy provides a way to define load balancing rules
-          for a backend.
+          XBackendTrafficPolicy defines the configuration for how traffic to a
+          target backend should be handled.
         properties:
           apiVersion:
             description: |-
@@ -65,13 +66,115 @@ spec:
           metadata:
             type: object
           spec:
-            description: Spec defines the desired state of BackendLBPolicy.
+            description: Spec defines the desired state of BackendTrafficPolicy.
             properties:
+              retryConstraint:
+                description: |-
+                  RetryConstraint defines the configuration for when to allow or prevent
+                  further retries to a target backend, by dynamically calculating a 'retry
+                  budget'. This budget is calculated based on the percentage of incoming
+                  traffic composed of retries over a given time interval. Once the budget
+                  is exceeded, additional retries will be rejected.
+
+                  For example, if the retry budget interval is 10 seconds, there have been
+                  1000 active requests in the past 10 seconds, and the allowed percentage
+                  of requests that can be retried is 20% (the default), then 200 of those
+                  requests may be composed of retries. Active requests will only be
+                  considered for the duration of the interval when calculating the retry
+                  budget. Retrying the same original request multiple times within the
+                  retry budget interval will lead to each retry being counted towards
+                  calculating the budget.
+
+                  Configuring a RetryConstraint in BackendTrafficPolicy is compatible with
+                  HTTPRoute Retry settings for each HTTPRouteRule that targets the same
+                  backend. While the HTTPRouteRule Retry stanza can specify whether a
+                  request will be retried, and the number of retry attempts each client
+                  may perform, RetryConstraint helps prevent cascading failures such as
+                  retry storms during periods of consistent failures.
+
+                  After the retry budget has been exceeded, additional retries to the
+                  backend MUST return a 503 response to the client.
+
+                  Additional configurations for defining a constraint on retries MAY be
+                  defined in the future.
+
+                  Support: Extended
+                properties:
+                  budget:
+                    default:
+                      interval: 10s
+                      percent: 20
+                    description: Budget holds the details of the retry budget configuration.
+                    properties:
+                      interval:
+                        default: 10s
+                        description: |-
+                          Interval defines the duration in which requests will be considered
+                          for calculating the budget for retries.
+
+                          Support: Extended
+                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                        type: string
+                        x-kubernetes-validations:
+                        - message: interval can not be greater than one hour or less
+                            than one second
+                          rule: '!(duration(self) < duration(''1s'') || duration(self)
+                            > duration(''1h''))'
+                      percent:
+                        default: 20
+                        description: |-
+                          Percent defines the maximum percentage of active requests that may
+                          be made up of retries.
+
+                          Support: Extended
+                        maximum: 100
+                        minimum: 0
+                        type: integer
+                    type: object
+                  minRetryRate:
+                    default:
+                      count: 10
+                      interval: 1s
+                    description: |-
+                      MinRetryRate defines the minimum rate of retries that will be allowable
+                      over a specified duration of time.
+
+                      The effective overall minimum rate of retries targeting the backend
+                      service may be much higher, as there can be any number of clients which
+                      are applying this setting locally.
+
+                      This ensures that requests can still be retried during periods of low
+                      traffic, where the budget for retries may be calculated as a very low
+                      value.
+
+                      Support: Extended
+                    properties:
+                      count:
+                        description: |-
+                          Count specifies the number of requests per time interval.
+
+                          Support: Extended
+                        maximum: 1000000
+                        minimum: 1
+                        type: integer
+                      interval:
+                        description: |-
+                          Interval specifies the divisor of the rate of requests, the amount of
+                          time during which the given count of requests occur.
+
+                          Support: Extended
+                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                        type: string
+                        x-kubernetes-validations:
+                        - message: interval can not be greater than one hour
+                          rule: '!(duration(self) == duration(''0s'') || duration(self)
+                            > duration(''1h''))'
+                    type: object
+                type: object
               sessionPersistence:
                 description: |-
                   SessionPersistence defines and configures session persistence
                   for the backend.
-
 
                   Support: Extended
                 properties:
@@ -81,7 +184,6 @@ spec:
                       session. Once the AbsoluteTimeout duration has elapsed, the
                       session becomes invalid.
 
-
                       Support: Extended
                     pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                     type: string
@@ -89,7 +191,6 @@ spec:
                     description: |-
                       CookieConfig provides configuration settings that are specific
                       to cookie-based session persistence.
-
 
                       Support: Core
                     properties:
@@ -102,19 +203,17 @@ spec:
                           attributes, while a session cookie is deleted when the current
                           session ends.
 
-
                           When set to "Permanent", AbsoluteTimeout indicates the
                           cookie's lifetime via the Expires or Max-Age cookie attributes
                           and is required.
-
 
                           When set to "Session", AbsoluteTimeout indicates the
                           absolute lifetime of the cookie tracked by the gateway and
                           is optional.
 
+                          Defaults to "Session".
 
                           Support: Core for "Session" type
-
 
                           Support: Extended for "Permanent" type
                         enum:
@@ -128,7 +227,6 @@ spec:
                       Once the session has been idle for more than the specified
                       IdleTimeout duration, the session becomes invalid.
 
-
                       Support: Extended
                     pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                     type: string
@@ -138,7 +236,6 @@ spec:
                       which may be reflected in the cookie or the header. Users
                       should avoid reusing session names to prevent unintended
                       consequences, such as rejection or unpredictable behavior.
-
 
                       Support: Implementation-specific
                     maxLength: 128
@@ -150,9 +247,7 @@ spec:
                       the use a header or cookie. Defaults to cookie based session
                       persistence.
 
-
                       Support: Core for "Cookie" type
-
 
                       Support: Extended for "Header" type
                     enum:
@@ -163,14 +258,17 @@ spec:
                 x-kubernetes-validations:
                 - message: AbsoluteTimeout must be specified when cookie lifetimeType
                     is Permanent
-                  rule: '!has(self.cookieConfig.lifetimeType) || self.cookieConfig.lifetimeType
-                    != ''Permanent'' || has(self.absoluteTimeout)'
+                  rule: '!has(self.cookieConfig) || !has(self.cookieConfig.lifetimeType)
+                    || self.cookieConfig.lifetimeType != ''Permanent'' || has(self.absoluteTimeout)'
               targetRefs:
                 description: |-
-                  TargetRef identifies an API object to apply policy to.
-                  Currently, Backends (i.e. Service, ServiceImport, or any
-                  implementation-specific backendRef) are the only valid API
-                  target references.
+                  TargetRefs identifies API object(s) to apply this policy to.
+                  Currently, Backends (A grouping of like endpoints such as Service,
+                  ServiceImport, or any implementation-specific backendRef) are the only
+                  valid API target references.
+
+                  Currently, a TargetRef can not be scoped to a specific port on a
+                  Service.
                 items:
                   description: |-
                     LocalPolicyTargetReference identifies an API object to apply a direct or
@@ -212,7 +310,7 @@ spec:
             - targetRefs
             type: object
           status:
-            description: Status defines the current state of BackendLBPolicy.
+            description: Status defines the current state of BackendTrafficPolicy.
             properties:
               ancestors:
                 description: |-
@@ -223,26 +321,21 @@ spec:
                   the controller first sees the policy and SHOULD update the entry as
                   appropriate when the relevant ancestor is modified.
 
-
                   Note that choosing the relevant ancestor is left to the Policy designers;
                   an important part of Policy design is designing the right object level at
                   which to namespace this status.
-
 
                   Note also that implementations MUST ONLY populate ancestor status for
                   the Ancestor resources they are responsible for. Implementations MUST
                   use the ControllerName field to uniquely identify the entries in this list
                   that they are responsible for.
 
-
                   Note that to achieve this, the list of PolicyAncestorStatus structs
                   MUST be treated as a map with a composite key, made up of the AncestorRef
                   and ControllerName fields combined.
 
-
                   A maximum of 16 ancestors will be represented in this list. An empty list
                   means the Policy is not relevant for any ancestors.
-
 
                   If this slice is full, implementations MUST NOT add further entries.
                   Instead they MUST consider the policy unimplementable and signal that
@@ -255,7 +348,6 @@ spec:
                     PolicyAncestorStatus describes the status of a route with respect to an
                     associated Ancestor.
 
-
                     Ancestors refer to objects that are either the Target of a policy or above it
                     in terms of object hierarchy. For example, if a policy targets a Service, the
                     Policy's Ancestors are, in order, the Service, the HTTPRoute, the Gateway, and
@@ -264,27 +356,22 @@ spec:
                     SHOULD use Gateway as the PolicyAncestorStatus object unless the designers
                     have a _very_ good reason otherwise.
 
-
                     In the context of policy attachment, the Ancestor is used to distinguish which
                     resource results in a distinct application of this policy. For example, if a policy
                     targets a Service, it may have a distinct result per attached Gateway.
-
 
                     Policies targeting the same resource may have different effects depending on the
                     ancestors of those resources. For example, different Gateways targeting the same
                     Service may have different capabilities, especially if they have different underlying
                     implementations.
 
-
                     For example, in BackendTLSPolicy, the Policy attaches to a Service that is
                     used as a backend in a HTTPRoute that is itself attached to a Gateway.
                     In this case, the relevant object for status is the Gateway, and that is the
                     ancestor object referred to in this status.
 
-
                     Note that a parent is also an ancestor, so for objects where the parent is the
                     relevant object for status, this struct SHOULD still be used.
-
 
                     This struct is intended to be used in a slice that's effectively a map,
                     with a composite key made up of the AncestorRef and the ControllerName.
@@ -302,7 +389,6 @@ spec:
                             To set the core API group (such as for a "Service" kind referent),
                             Group must be explicitly set to "" (empty string).
 
-
                             Support: Core
                           maxLength: 253
                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -312,13 +398,10 @@ spec:
                           description: |-
                             Kind is kind of the referent.
 
-
                             There are two kinds of parent resources with "Core" support:
-
 
                             * Gateway (Gateway conformance profile)
                             * Service (Mesh conformance profile, ClusterIP Services only)
-
 
                             Support for other resources is Implementation-Specific.
                           maxLength: 63
@@ -329,7 +412,6 @@ spec:
                           description: |-
                             Name is the name of the referent.
 
-
                             Support: Core
                           maxLength: 253
                           minLength: 1
@@ -339,7 +421,6 @@ spec:
                             Namespace is the namespace of the referent. When unspecified, this refers
                             to the local namespace of the Route.
 
-
                             Note that there are specific rules for ParentRefs which cross namespace
                             boundaries. Cross-namespace references are only valid if they are explicitly
                             allowed by something in the namespace they are referring to. For example:
@@ -347,18 +428,15 @@ spec:
                             generic way to enable any other kind of cross-namespace reference.
 
 
-
                             ParentRefs from a Route to a Service in the same namespace are "producer"
                             routes, which apply default routing rules to inbound connections from
                             any namespace to the Service.
-
 
                             ParentRefs from a Route to a Service in a different namespace are
                             "consumer" routes, and these routing rules are only applied to outbound
                             connections originating from the same namespace as the Route, for which
                             the intended destination of the connections are a Service targeted as a
                             ParentRef of the Route.
-
 
 
                             Support: Core
@@ -371,7 +449,6 @@ spec:
                             Port is the network port this Route targets. It can be interpreted
                             differently based on the type of parent resource.
 
-
                             When the parent resource is a Gateway, this targets all listeners
                             listening on the specified port that also support this kind of Route(and
                             select this Route). It's not recommended to set `Port` unless the
@@ -381,17 +458,14 @@ spec:
                             must match both specified values.
 
 
-
                             When the parent resource is a Service, this targets a specific port in the
                             Service spec. When both Port (experimental) and SectionName are specified,
                             the name and port of the selected port must match both specified values.
 
 
-
                             Implementations MAY choose to support other parent resources.
                             Implementations supporting other types of parent resources MUST clearly
                             document how/if Port is interpreted.
-
 
                             For the purpose of status, an attachment is considered successful as
                             long as the parent resource accepts it partially. For example, Gateway
@@ -400,7 +474,6 @@ spec:
                             from the referencing Route, the Route MUST be considered successfully
                             attached. If no Gateway listeners accept attachment from this Route,
                             the Route MUST be considered detached from the Gateway.
-
 
                             Support: Extended
                           format: int32
@@ -412,7 +485,6 @@ spec:
                             SectionName is the name of a section within the target resource. In the
                             following resources, SectionName is interpreted as the following:
 
-
                             * Gateway: Listener name. When both Port (experimental) and SectionName
                             are specified, the name and port of the selected listener must match
                             both specified values.
@@ -420,11 +492,9 @@ spec:
                             are specified, the name and port of the selected listener must match
                             both specified values.
 
-
                             Implementations MAY choose to support attaching Routes to other resources.
                             If that is the case, they MUST clearly document how SectionName is
                             interpreted.
-
 
                             When unspecified (empty string), this will reference the entire resource.
                             For the purpose of status, an attachment is considered successful if at
@@ -434,7 +504,6 @@ spec:
                             the referencing Route, the Route MUST be considered successfully
                             attached. If no Gateway listeners accept attachment from this Route, the
                             Route MUST be considered detached from the Gateway.
-
 
                             Support: Core
                           maxLength: 253
@@ -448,18 +517,8 @@ spec:
                       description: Conditions describes the status of the Policy with
                         respect to the given Ancestor.
                       items:
-                        description: "Condition contains details for one aspect of
-                          the current state of this API Resource.\n---\nThis struct
-                          is intended for direct use as an array at the field path
-                          .status.conditions.  For example,\n\n\n\ttype FooStatus
-                          struct{\n\t    // Represents the observations of a foo's
-                          current state.\n\t    // Known .status.conditions.type are:
-                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
-                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
-                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
-                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                          \   // other fields\n\t}"
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
                         properties:
                           lastTransitionTime:
                             description: |-
@@ -501,12 +560,7 @@ spec:
                             - Unknown
                             type: string
                           type:
-                            description: |-
-                              type of condition in CamelCase or in foo.example.com/CamelCase.
-                              ---
-                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                              useful (see .node.status.conditions), the ability to deconflict is important.
-                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
                             maxLength: 316
                             pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                             type: string
@@ -529,14 +583,11 @@ spec:
                         controller that wrote this status. This corresponds with the
                         controllerName field on GatewayClass.
 
-
                         Example: "example.net/gateway-controller".
-
 
                         The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
                         valid Kubernetes names
                         (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
-
 
                         Controllers MUST populate this field when writing status. Controllers should ensure that
                         entries to status populated with their ControllerName are cleaned up when they are no

--- a/platform/gateway-api/chart/templates/xlistenersets.yaml
+++ b/platform/gateway-api/chart/templates/xlistenersets.yaml
@@ -1,0 +1,857 @@
+{{/*
+  Vendored from kubernetes-sigs/gateway-api {{ index .Chart.Annotations "catalyst.openova.io/upstream-gateway-api-version" }}
+  experimental-install.yaml. Do NOT hand-edit annotations / spec — re-vendor
+  via the script in tests/regenerate.sh when bumping the upstream version
+  (also bump catalyst.openova.io/upstream-gateway-api-version in Chart.yaml).
+
+  helm.sh/resource-policy: keep is added under metadata.annotations so a
+  Helm uninstall does NOT delete the CRD. Gateway API CRDs are foundational
+  cluster-scoped infrastructure; deleting them on uninstall would break
+  every HTTPRoute on the cluster simultaneously.
+*/}}
+#
+# config/crd/experimental/gateway.networking.x-k8s.io_xlistenersets.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.3.0
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  name: xlistenersets.gateway.networking.x-k8s.io
+spec:
+  group: gateway.networking.x-k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: XListenerSet
+    listKind: XListenerSetList
+    plural: xlistenersets
+    shortNames:
+    - lset
+    singular: xlistenerset
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          XListenerSet defines a set of additional listeners
+          to attach to an existing Gateway.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of ListenerSet.
+            properties:
+              listeners:
+                description: |-
+                  Listeners associated with this ListenerSet. Listeners define
+                  logical endpoints that are bound on this referenced parent Gateway's addresses.
+
+                  Listeners in a `Gateway` and their attached `ListenerSets` are concatenated
+                  as a list when programming the underlying infrastructure. Each listener
+                  name does not need to be unique across the Gateway and ListenerSets.
+                  See ListenerEntry.Name for more details.
+
+                  Implementations MUST treat the parent Gateway as having the merged
+                  list of all listeners from itself and attached ListenerSets using
+                  the following precedence:
+
+                  1. "parent" Gateway
+                  2. ListenerSet ordered by creation time (oldest first)
+                  3. ListenerSet ordered alphabetically by “{namespace}/{name}”.
+
+                  An implementation MAY reject listeners by setting the ListenerEntryStatus
+                  `Accepted`` condition to False with the Reason `TooManyListeners`
+
+                  If a listener has a conflict, this will be reported in the
+                  Status.ListenerEntryStatus setting the `Conflicted` condition to True.
+
+                  Implementations SHOULD be cautious about what information from the
+                  parent or siblings are reported to avoid accidentally leaking
+                  sensitive information that the child would not otherwise have access
+                  to. This can include contents of secrets etc.
+                items:
+                  properties:
+                    allowedRoutes:
+                      default:
+                        namespaces:
+                          from: Same
+                      description: |-
+                        AllowedRoutes defines the types of routes that MAY be attached to a
+                        Listener and the trusted namespaces where those Route resources MAY be
+                        present.
+
+                        Although a client request may match multiple route rules, only one rule
+                        may ultimately receive the request. Matching precedence MUST be
+                        determined in order of the following criteria:
+
+                        * The most specific match as defined by the Route type.
+                        * The oldest Route based on creation timestamp. For example, a Route with
+                          a creation timestamp of "2020-09-08 01:02:03" is given precedence over
+                          a Route with a creation timestamp of "2020-09-08 01:02:04".
+                        * If everything else is equivalent, the Route appearing first in
+                          alphabetical order (namespace/name) should be given precedence. For
+                          example, foo/bar is given precedence over foo/baz.
+
+                        All valid rules within a Route attached to this Listener should be
+                        implemented. Invalid Route rules can be ignored (sometimes that will mean
+                        the full Route). If a Route rule transitions from valid to invalid,
+                        support for that Route rule should be dropped to ensure consistency. For
+                        example, even if a filter specified by a Route rule is invalid, the rest
+                        of the rules within that Route should still be supported.
+                      properties:
+                        kinds:
+                          description: |-
+                            Kinds specifies the groups and kinds of Routes that are allowed to bind
+                            to this Gateway Listener. When unspecified or empty, the kinds of Routes
+                            selected are determined using the Listener protocol.
+
+                            A RouteGroupKind MUST correspond to kinds of Routes that are compatible
+                            with the application protocol specified in the Listener's Protocol field.
+                            If an implementation does not support or recognize this resource type, it
+                            MUST set the "ResolvedRefs" condition to False for this Listener with the
+                            "InvalidRouteKinds" reason.
+
+                            Support: Core
+                          items:
+                            description: RouteGroupKind indicates the group and kind
+                              of a Route resource.
+                            properties:
+                              group:
+                                default: gateway.networking.k8s.io
+                                description: Group is the group of the Route.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                description: Kind is the kind of the Route.
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                            required:
+                            - kind
+                            type: object
+                          maxItems: 8
+                          type: array
+                        namespaces:
+                          default:
+                            from: Same
+                          description: |-
+                            Namespaces indicates namespaces from which Routes may be attached to this
+                            Listener. This is restricted to the namespace of this Gateway by default.
+
+                            Support: Core
+                          properties:
+                            from:
+                              default: Same
+                              description: |-
+                                From indicates where Routes will be selected for this Gateway. Possible
+                                values are:
+
+                                * All: Routes in all namespaces may be used by this Gateway.
+                                * Selector: Routes in namespaces selected by the selector may be used by
+                                  this Gateway.
+                                * Same: Only Routes in the same namespace may be used by this Gateway.
+
+                                Support: Core
+                              enum:
+                              - All
+                              - Selector
+                              - Same
+                              type: string
+                            selector:
+                              description: |-
+                                Selector must be specified when From is set to "Selector". In that case,
+                                only Routes in Namespaces matching this Selector will be selected by this
+                                Gateway. This field is ignored for other values of "From".
+
+                                Support: Core
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      type: object
+                    hostname:
+                      description: |-
+                        Hostname specifies the virtual hostname to match for protocol types that
+                        define this concept. When unspecified, all hostnames are matched. This
+                        field is ignored for protocols that don't require hostname based
+                        matching.
+
+                        Implementations MUST apply Hostname matching appropriately for each of
+                        the following protocols:
+
+                        * TLS: The Listener Hostname MUST match the SNI.
+                        * HTTP: The Listener Hostname MUST match the Host header of the request.
+                        * HTTPS: The Listener Hostname SHOULD match at both the TLS and HTTP
+                          protocol layers as described above. If an implementation does not
+                          ensure that both the SNI and Host header match the Listener hostname,
+                          it MUST clearly document that.
+
+                        For HTTPRoute and TLSRoute resources, there is an interaction with the
+                        `spec.hostnames` array. When both listener and route specify hostnames,
+                        there MUST be an intersection between the values for a Route to be
+                        accepted. For more information, refer to the Route specific Hostnames
+                        documentation.
+
+                        Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
+                        as a suffix match. That means that a match for `*.example.com` would match
+                        both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the Listener. This name MUST be unique within a
+                        ListenerSet.
+
+                        Name is not required to be unique across a Gateway and ListenerSets.
+                        Routes can attach to a Listener by having a ListenerSet as a parentRef
+                        and setting the SectionName
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port. Multiple listeners may use the
+                        same port, subject to the Listener compatibility rules.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    protocol:
+                      description: Protocol specifies the network protocol this listener
+                        expects to receive.
+                      maxLength: 255
+                      minLength: 1
+                      pattern: ^[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?$|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9]+$
+                      type: string
+                    tls:
+                      description: |-
+                        TLS is the TLS configuration for the Listener. This field is required if
+                        the Protocol field is "HTTPS" or "TLS". It is invalid to set this field
+                        if the Protocol field is "HTTP", "TCP", or "UDP".
+
+                        The association of SNIs to Certificate defined in GatewayTLSConfig is
+                        defined based on the Hostname field for this listener.
+
+                        The GatewayClass MUST use the longest matching SNI out of all
+                        available certificates for any TLS handshake.
+                      properties:
+                        certificateRefs:
+                          description: |-
+                            CertificateRefs contains a series of references to Kubernetes objects that
+                            contains TLS certificates and private keys. These certificates are used to
+                            establish a TLS handshake for requests that match the hostname of the
+                            associated listener.
+
+                            A single CertificateRef to a Kubernetes Secret has "Core" support.
+                            Implementations MAY choose to support attaching multiple certificates to
+                            a Listener, but this behavior is implementation-specific.
+
+                            References to a resource in different namespace are invalid UNLESS there
+                            is a ReferenceGrant in the target namespace that allows the certificate
+                            to be attached. If a ReferenceGrant does not allow this reference, the
+                            "ResolvedRefs" condition MUST be set to False for this listener with the
+                            "RefNotPermitted" reason.
+
+                            This field is required to have at least one element when the mode is set
+                            to "Terminate" (default) and is optional otherwise.
+
+                            CertificateRefs can reference to standard Kubernetes resources, i.e.
+                            Secret, or implementation-specific custom resources.
+
+                            Support: Core - A single reference to a Kubernetes Secret of type kubernetes.io/tls
+
+                            Support: Implementation-specific (More than one reference or other resource types)
+                          items:
+                            description: |-
+                              SecretObjectReference identifies an API object including its namespace,
+                              defaulting to Secret.
+
+                              The API object must be valid in the cluster; the Group and Kind must
+                              be registered in the cluster for this reference to be valid.
+
+                              References to objects with invalid Group and Kind are not valid, and must
+                              be rejected by the implementation, with appropriate Conditions set
+                              on the containing object.
+                            properties:
+                              group:
+                                default: ""
+                                description: |-
+                                  Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                  When unspecified or empty string, core API group is inferred.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                default: Secret
+                                description: Kind is kind of the referent. For example
+                                  "Secret".
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace is the namespace of the referenced object. When unspecified, the local
+                                  namespace is inferred.
+
+                                  Note that when a namespace different than the local namespace is specified,
+                                  a ReferenceGrant object is required in the referent namespace to allow that
+                                  namespace's owner to accept the reference. See the ReferenceGrant
+                                  documentation for details.
+
+                                  Support: Core
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          maxItems: 64
+                          type: array
+                        frontendValidation:
+                          description: |-
+                            FrontendValidation holds configuration information for validating the frontend (client).
+                            Setting this field will require clients to send a client certificate
+                            required for validation during the TLS handshake. In browsers this may result in a dialog appearing
+                            that requests a user to specify the client certificate.
+                            The maximum depth of a certificate chain accepted in verification is Implementation specific.
+
+                            Support: Extended
+                          properties:
+                            caCertificateRefs:
+                              description: |-
+                                CACertificateRefs contains one or more references to
+                                Kubernetes objects that contain TLS certificates of
+                                the Certificate Authorities that can be used
+                                as a trust anchor to validate the certificates presented by the client.
+
+                                A single CA certificate reference to a Kubernetes ConfigMap
+                                has "Core" support.
+                                Implementations MAY choose to support attaching multiple CA certificates to
+                                a Listener, but this behavior is implementation-specific.
+
+                                Support: Core - A single reference to a Kubernetes ConfigMap
+                                with the CA certificate in a key named `ca.crt`.
+
+                                Support: Implementation-specific (More than one reference, or other kinds
+                                of resources).
+
+                                References to a resource in a different namespace are invalid UNLESS there
+                                is a ReferenceGrant in the target namespace that allows the certificate
+                                to be attached. If a ReferenceGrant does not allow this reference, the
+                                "ResolvedRefs" condition MUST be set to False for this listener with the
+                                "RefNotPermitted" reason.
+                              items:
+                                description: |-
+                                  ObjectReference identifies an API object including its namespace.
+
+                                  The API object must be valid in the cluster; the Group and Kind must
+                                  be registered in the cluster for this reference to be valid.
+
+                                  References to objects with invalid Group and Kind are not valid, and must
+                                  be rejected by the implementation, with appropriate Conditions set
+                                  on the containing object.
+                                properties:
+                                  group:
+                                    description: |-
+                                      Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                      When set to the empty string, core API group is inferred.
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  kind:
+                                    description: Kind is kind of the referent. For
+                                      example "ConfigMap" or "Service".
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
+                                  name:
+                                    description: Name is the name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace is the namespace of the referenced object. When unspecified, the local
+                                      namespace is inferred.
+
+                                      Note that when a namespace different than the local namespace is specified,
+                                      a ReferenceGrant object is required in the referent namespace to allow that
+                                      namespace's owner to accept the reference. See the ReferenceGrant
+                                      documentation for details.
+
+                                      Support: Core
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                required:
+                                - group
+                                - kind
+                                - name
+                                type: object
+                              maxItems: 8
+                              minItems: 1
+                              type: array
+                          type: object
+                        mode:
+                          default: Terminate
+                          description: |-
+                            Mode defines the TLS behavior for the TLS session initiated by the client.
+                            There are two possible modes:
+
+                            - Terminate: The TLS session between the downstream client and the
+                              Gateway is terminated at the Gateway. This mode requires certificates
+                              to be specified in some way, such as populating the certificateRefs
+                              field.
+                            - Passthrough: The TLS session is NOT terminated by the Gateway. This
+                              implies that the Gateway can't decipher the TLS stream except for
+                              the ClientHello message of the TLS protocol. The certificateRefs field
+                              is ignored in this mode.
+
+                            Support: Core
+                          enum:
+                          - Terminate
+                          - Passthrough
+                          type: string
+                        options:
+                          additionalProperties:
+                            description: |-
+                              AnnotationValue is the value of an annotation in Gateway API. This is used
+                              for validation of maps such as TLS options. This roughly matches Kubernetes
+                              annotation validation, although the length validation in that case is based
+                              on the entire size of the annotations struct.
+                            maxLength: 4096
+                            minLength: 0
+                            type: string
+                          description: |-
+                            Options are a list of key/value pairs to enable extended TLS
+                            configuration for each implementation. For example, configuring the
+                            minimum TLS version or supported cipher suites.
+
+                            A set of common keys MAY be defined by the API in the future. To avoid
+                            any ambiguity, implementation-specific definitions MUST use
+                            domain-prefixed names, such as `example.com/my-custom-option`.
+                            Un-prefixed names are reserved for key names defined by Gateway API.
+
+                            Support: Implementation-specific
+                          maxProperties: 16
+                          type: object
+                      type: object
+                      x-kubernetes-validations:
+                      - message: certificateRefs or options must be specified when
+                          mode is Terminate
+                        rule: 'self.mode == ''Terminate'' ? size(self.certificateRefs)
+                          > 0 || size(self.options) > 0 : true'
+                  required:
+                  - name
+                  - port
+                  - protocol
+                  type: object
+                maxItems: 64
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+                x-kubernetes-validations:
+                - message: tls must not be specified for protocols ['HTTP', 'TCP',
+                    'UDP']
+                  rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?
+                    !has(l.tls) : true)'
+                - message: tls mode must be Terminate for protocol HTTPS
+                  rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode
+                    == '''' || l.tls.mode == ''Terminate'') : true)'
+                - message: hostname must not be specified for protocols ['TCP', 'UDP']
+                  rule: 'self.all(l, l.protocol in [''TCP'', ''UDP'']  ? (!has(l.hostname)
+                    || l.hostname == '''') : true)'
+                - message: Listener name must be unique within the Gateway
+                  rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
+                - message: Combination of port, protocol and hostname must be unique
+                    for each listener
+                  rule: 'self.all(l1, !has(l1.port) || self.exists_one(l2, has(l2.port)
+                    && l1.port == l2.port && l1.protocol == l2.protocol && (has(l1.hostname)
+                    && has(l2.hostname) ? l1.hostname == l2.hostname : !has(l1.hostname)
+                    && !has(l2.hostname))))'
+              parentRef:
+                description: ParentRef references the Gateway that the listeners are
+                  attached to.
+                properties:
+                  group:
+                    default: gateway.networking.k8s.io
+                    description: Group is the group of the referent.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    default: Gateway
+                    description: Kind is kind of the referent. For example "Gateway".
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the referent.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace is the namespace of the referent.  If not present,
+                      the namespace of the referent is assumed to be the same as
+                      the namespace of the referring object.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - listeners
+            - parentRef
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Accepted
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+            description: Status defines the current state of ListenerSet.
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: |-
+                  Conditions describe the current conditions of the ListenerSet.
+
+                  Implementations MUST express ListenerSet conditions using the
+                  `ListenerSetConditionType` and `ListenerSetConditionReason`
+                  constants so that operators and tools can converge on a common
+                  vocabulary to describe ListenerSet state.
+
+                  Known condition types are:
+
+                  * "Accepted"
+                  * "Programmed"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              listeners:
+                description: Listeners provide status for each unique listener port
+                  defined in the Spec.
+                items:
+                  description: ListenerStatus is the status associated with a Listener.
+                  properties:
+                    attachedRoutes:
+                      description: |-
+                        AttachedRoutes represents the total number of Routes that have been
+                        successfully attached to this Listener.
+
+                        Successful attachment of a Route to a Listener is based solely on the
+                        combination of the AllowedRoutes field on the corresponding Listener
+                        and the Route's ParentRefs field. A Route is successfully attached to
+                        a Listener when it is selected by the Listener's AllowedRoutes field
+                        AND the Route has a valid ParentRef selecting the whole Gateway
+                        resource or a specific Listener as a parent resource (more detail on
+                        attachment semantics can be found in the documentation on the various
+                        Route kinds ParentRefs fields). Listener or Route status does not impact
+                        successful attachment, i.e. the AttachedRoutes field count MUST be set
+                        for Listeners with condition Accepted: false and MUST count successfully
+                        attached Routes that may themselves have Accepted: false conditions.
+
+                        Uses for this field include troubleshooting Route attachment and
+                        measuring blast radius/impact of changes to a Listener.
+                      format: int32
+                      type: integer
+                    conditions:
+                      description: Conditions describe the current condition of this
+                        listener.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    name:
+                      description: Name is the name of the Listener that this status
+                        corresponds to.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    port:
+                      description: Port is the network port the listener is configured
+                        to listen on.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    supportedKinds:
+                      description: |-
+                        SupportedKinds is the list indicating the Kinds supported by this
+                        listener. This MUST represent the kinds an implementation supports for
+                        that Listener configuration.
+
+                        If kinds are specified in Spec that are not supported, they MUST NOT
+                        appear in this list and an implementation MUST set the "ResolvedRefs"
+                        condition to "False" with the "InvalidRouteKinds" reason. If both valid
+                        and invalid Route kinds are specified, the implementation MUST
+                        reference the valid Route kinds that have been specified.
+                      items:
+                        description: RouteGroupKind indicates the group and kind of
+                          a Route resource.
+                        properties:
+                          group:
+                            default: gateway.networking.k8s.io
+                            description: Group is the group of the Route.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            description: Kind is the kind of the Route.
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                        required:
+                        - kind
+                        type: object
+                      maxItems: 8
+                      type: array
+                  required:
+                  - attachedRoutes
+                  - conditions
+                  - name
+                  - port
+                  - supportedKinds
+                  type: object
+                maxItems: 64
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/platform/gateway-api/chart/tests/crd-render.sh
+++ b/platform/gateway-api/chart/tests/crd-render.sh
@@ -62,15 +62,16 @@ if [ ! -s "$render_file" ]; then
   exit 1
 fi
 
-# (2) exactly 10 CRDs (experimental channel — includes TLSRoute/TCPRoute/UDPRoute/
-# BackendLBPolicy/BackendTLSPolicy required for Cilium 1.16.x gateway controller).
+# (2) exactly 11 CRDs (v1.3.0 experimental channel — includes TLSRoute/TCPRoute/
+# UDPRoute/BackendTLSPolicy required for the Cilium gateway controller, plus the
+# x-k8s XBackendTrafficPolicy/XListenerSet that replaced BackendLBPolicy in v1.3).
 crd_count="$(grep -c '^kind: CustomResourceDefinition$' "$render_file" || true)"
-if [ "$crd_count" -ne 10 ]; then
-  echo "::error::expected exactly 10 CRDs (experimental channel), got $crd_count"
+if [ "$crd_count" -ne 11 ]; then
+  echo "::error::expected exactly 11 CRDs (v1.3.0 experimental channel), got $crd_count"
   grep -A 3 '^kind: CustomResourceDefinition$' "$render_file" | head -60
   exit 1
 fi
-echo "  ✓ 10 CRDs rendered (experimental channel)"
+echo "  ✓ 11 CRDs rendered (experimental channel)"
 
 # (3) each CRD has helm.sh/resource-policy: keep
 for name in \
@@ -78,8 +79,9 @@ for name in \
     gateways.gateway.networking.k8s.io \
     grpcroutes.gateway.networking.k8s.io \
     httproutes.gateway.networking.k8s.io \
-    backendlbpolicies.gateway.networking.k8s.io \
     backendtlspolicies.gateway.networking.k8s.io \
+    xbackendtrafficpolicies.gateway.networking.x-k8s.io \
+    xlistenersets.gateway.networking.x-k8s.io \
     tcproutes.gateway.networking.k8s.io \
     tlsroutes.gateway.networking.k8s.io \
     udproutes.gateway.networking.k8s.io \
@@ -92,11 +94,11 @@ for name in \
 done
 
 keep_count="$(grep -c '^    helm.sh/resource-policy: keep$' "$render_file" || true)"
-if [ "$keep_count" -ne 10 ]; then
-  echo "::error::expected 10 helm.sh/resource-policy: keep annotations, got $keep_count"
+if [ "$keep_count" -ne 11 ]; then
+  echo "::error::expected 11 helm.sh/resource-policy: keep annotations, got $keep_count"
   exit 1
 fi
-echo "  ✓ all 10 CRDs annotated helm.sh/resource-policy: keep"
+echo "  ✓ all 11 CRDs annotated helm.sh/resource-policy: keep"
 
 # (4) bundle-version annotation matches Chart.yaml pin
 bundle_ver_lines="$(grep '^    gateway.networking.k8s.io/bundle-version:' "$render_file" || true)"

--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -1303,6 +1303,23 @@ func (h *Handler) CreateDeployment(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// #4706 (founder 2026-07-03: "the fundamental requirement of 2 region
+	// mimicking agreement") — the BCP agreement default is MULTI-REGION.
+	// A POST with <2 regions and no explicit bcpTopology is rejected at
+	// ADMISSION: a single-region prov must be a DELIBERATE act (the payload
+	// says bcpTopology="single-region" in so many words — the
+	// quota-constrained validation shape). This floor deliberately lives
+	// HERE and not in Request.Validate(): Validate doubles as the store's
+	// legacy-record rehydration/migration path, where pre-floor
+	// single-region records must keep loading.
+	if strings.TrimSpace(req.BcpTopology) == "" && len(req.Regions) < 2 {
+		http.Error(w,
+			fmt.Sprintf("deployment has %d region(s) and no explicit bcpTopology — the BCP agreement default is multi-region (>=2 regions, Pillar 2). Add a second region, or set bcpTopology=%q explicitly for a deliberate single-region validation prov",
+				len(req.Regions), provisioner.BcpTopologySingleRegion),
+			http.StatusBadRequest)
+		return
+	}
+
 	if err := req.Validate(); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return

--- a/products/catalyst/bootstrap/api/internal/handler/deployments_huawei_dispatch_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments_huawei_dispatch_test.go
@@ -69,6 +69,7 @@ func TestCreateDeployment_Huawei_DispatchesToHuaweiAdapter(t *testing.T) {
 		// frontend should not send them either.
 		"region":       "me-east-215",
 		"orgName":      "Example HCS Customer",
+		"bcpTopology": "single-region", // #4706 — implicit 1-region is rejected
 		"orgEmail":     "ops@example.om",
 		"sshPublicKey": "ssh-ed25519 AAAA test",
 		// Object Storage credentials — Huawei OBS uses S3-compatible
@@ -164,6 +165,7 @@ func TestCreateDeployment_Huawei_EnforcesResourceFloor(t *testing.T) {
 		"sovereignSubdomain":     "hcs",
 		"region":                 "me-east-215",
 		"orgName":                "Example HCS Customer",
+		"bcpTopology": "single-region", // #4706 — implicit 1-region is rejected
 		"orgEmail":               "ops@example.om",
 		"sshPublicKey":           "ssh-ed25519 AAAA test",
 		"controlPlaneSize":       "m7n.large.8",

--- a/products/catalyst/bootstrap/api/internal/handler/deployments_huawei_dispatch_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments_huawei_dispatch_test.go
@@ -230,6 +230,7 @@ func TestCreateDeployment_Huawei_MissingAccessKey_Rejected(t *testing.T) {
 		"sovereignSubdomain":     "hcs",
 		"region":                 "me-east-215",
 		"orgName":                "Example",
+		"bcpTopology": "single-region", // #4706 — implicit 1-region is rejected at admission
 		"orgEmail":               "ops@example.om",
 		"sshPublicKey":           "ssh-ed25519 AAAA test",
 		"objectStorageRegion":    "me-east-215",
@@ -266,6 +267,7 @@ func TestCreateDeployment_Huawei_UnknownProviderRejected(t *testing.T) {
 		"sovereignDomainMode":    "byo",
 		"region":                 "me-east-215",
 		"orgName":                "Example",
+		"bcpTopology": "single-region", // #4706 — implicit 1-region is rejected at admission
 		"orgEmail":               "ops@example.om",
 		"sshPublicKey":           "ssh-ed25519 AAAA test",
 		"objectStorageRegion":    "fsn1",

--- a/products/catalyst/bootstrap/api/internal/handler/deployments_persist_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments_persist_test.go
@@ -82,6 +82,7 @@ func TestPersistence_CreateDeploymentWritesRowImmediately(t *testing.T) {
 
 	body, _ := json.Marshal(map[string]any{
 		"orgName":                "Acme",
+		"bcpTopology": "single-region", // #4706 — implicit 1-region is rejected
 		"orgEmail":               "ops@acme.io",
 		"sovereignFQDN":          "k8s.acme.io",
 		"sovereignDomainMode":    "byo",
@@ -333,6 +334,7 @@ func TestPersistence_OnDiskJSONIsRedacted(t *testing.T) {
 
 	body, _ := json.Marshal(map[string]any{
 		"orgName":                "Omantel",
+		"bcpTopology": "single-region", // #4706 — implicit 1-region is rejected
 		"orgEmail":               "ops@omantel.om",
 		"sovereignFQDN":          "omantel.omani.works",
 		"sovereignDomainMode":    "pool",
@@ -482,6 +484,7 @@ func TestPersistence_DockerStyleRoundTrip(t *testing.T) {
 
 	body, _ := json.Marshal(map[string]any{
 		"orgName":                "RestartTest",
+		"bcpTopology": "single-region", // #4706 — implicit 1-region is rejected
 		"orgEmail":               "ops@example.io",
 		"sovereignFQDN":          "k8s.example.io",
 		"sovereignDomainMode":    "byo",

--- a/products/catalyst/bootstrap/api/internal/handler/deployments_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments_test.go
@@ -47,6 +47,7 @@ func TestCreateDeployment_ManagedPoolReservesViaPDM(t *testing.T) {
 		"hetznerProjectID":       "proj",
 		"region":                 "fsn1",
 		"orgName":                "Omantel",
+		"bcpTopology": "single-region", // #4706 — implicit 1-region is rejected
 		"orgEmail":               "ops@omantel.om",
 		"sshPublicKey":           "ssh-ed25519 AAAA test",
 		"objectStorageRegion":    "fsn1",
@@ -95,6 +96,7 @@ func TestCreateDeployment_PDMConflictBlocksDeployment(t *testing.T) {
 		"hetznerProjectID":       "proj",
 		"region":                 "fsn1",
 		"orgName":                "Omantel",
+		"bcpTopology": "single-region", // #4706 — implicit 1-region is rejected
 		"orgEmail":               "ops@omantel.om",
 		"sshPublicKey":           "ssh-ed25519 AAAA test",
 		"objectStorageRegion":    "fsn1",
@@ -128,6 +130,7 @@ func TestCreateDeployment_BYODoesNotReserve(t *testing.T) {
 		"hetznerProjectID":       "proj",
 		"region":                 "fsn1",
 		"orgName":                "Acme",
+		"bcpTopology": "single-region", // #4706 — implicit 1-region is rejected
 		"orgEmail":               "ops@acme.io",
 		"sshPublicKey":           "ssh-ed25519 AAAA test",
 		"objectStorageRegion":    "fsn1",
@@ -174,6 +177,7 @@ func TestCreateDeployment_DerivesObjectStorageBucketFromFQDN(t *testing.T) {
 		"hetznerProjectID":       "proj",
 		"region":                 "fsn1",
 		"orgName":                "Acme",
+		"bcpTopology": "single-region", // #4706 — implicit 1-region is rejected
 		"orgEmail":               "ops@acme.io",
 		"sshPublicKey":           "ssh-ed25519 AAAA test",
 		"objectStorageRegion":    "fsn1",
@@ -251,6 +255,7 @@ func TestCreateDeployment_MarketplaceEnabledDefaultsTrue(t *testing.T) {
 				"hetznerProjectID":       "proj",
 				"region":                 "fsn1",
 				"orgName":                "Acme",
+				"bcpTopology": "single-region", // #4706 — implicit 1-region is rejected
 				"orgEmail":               "ops@acme.io",
 				"sshPublicKey":           "ssh-ed25519 AAAA test",
 				"objectStorageRegion":    "fsn1",
@@ -325,6 +330,7 @@ func TestCreateDeployment_EnableSharedPostgresDefaultsTrue(t *testing.T) {
 				"hetznerProjectID":       "proj",
 				"region":                 "fsn1",
 				"orgName":                "Acme",
+				"bcpTopology": "single-region", // #4706 — implicit 1-region is rejected
 				"orgEmail":               "ops@acme.io",
 				"sshPublicKey":           "ssh-ed25519 AAAA test",
 				"objectStorageRegion":    "fsn1",
@@ -434,6 +440,7 @@ func TestCreateDeployment_AcceptsMatchingOrgEmail(t *testing.T) {
 		"hetznerProjectID":       "proj",
 		"region":                 "fsn1",
 		"orgName":                "Omantel",
+		"bcpTopology": "single-region", // #4706 — implicit 1-region is rejected
 		"orgEmail":               "Me@Example.com", // mixed-case match
 		"sshPublicKey":           "ssh-ed25519 AAAA test",
 		"objectStorageRegion":    "fsn1",

--- a/products/catalyst/bootstrap/api/internal/handler/deployments_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments_test.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -572,5 +573,30 @@ func TestListDeployments_OwnerQueryParam(t *testing.T) {
 	}
 	if len(resp.Deployments) != 0 {
 		t.Fatalf("got %d deployments, want 0 (cross-tenant ?owner must never leak)", len(resp.Deployments))
+	}
+}
+
+// TestCreateDeployment_RejectsImplicitSingleRegion (#4706, founder
+// 2026-07-03: "the fundamental requirement of 2 region mimicking
+// agreement") — a POST with <2 regions and NO explicit bcpTopology is a
+// 400 at admission. The floor lives HERE (not in Request.Validate) because
+// Validate doubles as the store's legacy-record rehydration path.
+func TestCreateDeployment_RejectsImplicitSingleRegion(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	body := map[string]any{
+		"orgName":       "Implicit SR",
+		"orgEmail":      "ops@implicit.test",
+		"sovereignFQDN": "implicit.omani.works",
+		"region":        "fsn1",
+	}
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/deployments", bytes.NewReader(b))
+	w := httptest.NewRecorder()
+	h.CreateDeployment(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("implicit single-region POST must 400 at admission, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "multi-region") {
+		t.Fatalf("rejection must explain the multi-region BCP default, got: %s", w.Body.String())
 	}
 }

--- a/products/catalyst/bootstrap/api/internal/handler/load_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/load_test.go
@@ -82,6 +82,7 @@ func newLoadTestServer(t *testing.T) (*httptest.Server, *Handler) {
 func validRequest(idx int) map[string]any {
 	return map[string]any{
 		"orgName":                fmt.Sprintf("Load Test Org %d", idx),
+		"bcpTopology":            "single-region", // #4706 — implicit 1-region is rejected
 		"orgEmail":               fmt.Sprintf("load+%d@openova.io", idx),
 		"sovereignFQDN":          fmt.Sprintf("loadtest-%d.openova.io", idx),
 		"sovereignDomainMode":    "byo",
@@ -366,7 +367,9 @@ func TestLoad_RejectsInvalidInputUnderConcurrency(t *testing.T) {
 func TestLoad_DeploymentValidationContractKeepsLoadTestFromHangingForever(t *testing.T) {
 	body := validRequest(0)
 	r := provisioner.Request{
-		OrgName:                body["orgName"].(string),
+		OrgName:     body["orgName"].(string),
+		BcpTopology: body["bcpTopology"].(string), // #4706 — explicit single-region
+
 		OrgEmail:               body["orgEmail"].(string),
 		SovereignFQDN:          body["sovereignFQDN"].(string),
 		SovereignDomainMode:    body["sovereignDomainMode"].(string),

--- a/products/catalyst/bootstrap/api/internal/handler/post_handover_gateway_elb.go
+++ b/products/catalyst/bootstrap/api/internal/handler/post_handover_gateway_elb.go
@@ -1,26 +1,26 @@
-// post_handover_gateway_elb.go — #4690 / #4686 foundation-fix: after Phase-1
-// converges, discover the Sovereign gateway LoadBalancer Service's live,
-// auto-allocated nodePort and reconcile the Huawei gateway ELB's pool members
-// to it.
+// post_handover_gateway_elb.go — #4706: after Phase-1 converges, converge the
+// Huawei gateway ELB's pool member SET to the live cluster's nodes at the
+// durable gateway host ports (:443/:80).
 //
-// THE BREAK THIS CLOSES. On the CCM-less Huawei provider the Sovereign Gateway
-// is a `Service type=LoadBalancer` (cilium-gateway-cilium-gateway, kube-system,
-// #4682) fronted publicly by a dedicated Huawei ELB (infra/providers/huawei/
-// main.tf huaweicloud_elb_*.primary). That ELB forwards public :443/:80 →
-// node:<gateway-Service-nodePort> — the only path that routes on a no-CCM
-// Huawei node (node:443 does NOT, verified hw208). The nodePort is
-// auto-allocated by Cilium and unknown at tofu-apply time, so the tofu ELB
-// members start at a placeholder port (var.gateway_service_nodeport_*) and this
-// hook repoints them at the live nodePort post-convergence.
+// THE SHAPE. On the CCM-less Huawei provider the Sovereign Gateway is served
+// by cilium-envoy in gateway-api hostNetwork mode (cilium 1.19.3, bp-cilium
+// 1.4.8): envoy — a hostNetwork DaemonSet — binds node:443/:80 directly on
+// every node, and the dedicated public gateway ELB (infra/providers/huawei/
+// main.tf huaweicloud_elb_*.primary) does TCP passthrough public :443/:80 →
+// node:443/:80. tofu seeds correct members at Phase-0 (the ports are durable
+// and known at apply time — no nodePort anywhere, §854). What this hook heals
+// is member-set DRIFT: autoscaler-added nodes missing from the pools and
+// replaced/removed nodes leaving stale members — the job hcloud-ccm does
+// continuously on Hetzner, done explicitly here because Huawei has no CCM.
 //
-// This is exactly what hcloud-ccm does on Hetzner (reads the Service, programs
-// the LB); Huawei has no CCM so catalyst-api does it explicitly. Hetzner
-// deployments skip this hook entirely (the tofu LB already targets node:443).
+// History: on cilium 1.16.5 (hostNetwork bind bug) this hook discovered the
+// gateway Service's auto-allocated nodePort and repointed member PORTS
+// (#4690/#4691). That shape is retired by the 1.19.3 bump.
 //
 // Runs as a background goroutine from the OutcomeReady terminal block, next to
 // runPostHandoverAdoptionApply / runPostHandoverSpineApplications. Best-effort:
 // failures log + emit an SSE warn but never fail the handover. Idempotent — a
-// re-run against already-reconciled members is a no-op.
+// re-run against already-converged members is a no-op.
 package handler
 
 import (
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -38,23 +39,23 @@ import (
 )
 
 const (
-	// gatewayServiceNamespace / gatewayServiceName — the Service Cilium's
-	// gateway-controller auto-creates for the `cilium-gateway` Gateway
-	// (kube-system). Name = cilium-gateway-<gateway-name> (see
-	// clusters/_template/sovereign-tls/cilium-gateway.yaml).
-	gatewayServiceNamespace = "kube-system"
-	gatewayServiceName      = "cilium-gateway-cilium-gateway"
+	// gatewayHostPortHTTPS / gatewayHostPortHTTP — the durable host ports
+	// cilium-envoy binds on every node in gateway-api hostNetwork mode.
+	// Must match the Gateway listener ports (clusters/_template/sovereign-tls/
+	// cilium-gateway.yaml) and the tofu member ports
+	// (var.gateway_member_port_{https,http}).
+	gatewayHostPortHTTPS = 443
+	gatewayHostPortHTTP  = 80
 
-	// gatewayELBReconcileMaxWait — budget waiting for the gateway Service to
-	// exist + get its nodePort allocated. The Service lands only after
-	// bp-cilium reconciles the Gateway, which may still be settling at first
-	// OutcomeReady. Fully off the bootstrap critical path.
+	// gatewayELBReconcileMaxWait — budget waiting for the primary cluster to
+	// report ≥1 node InternalIP. Nodes exist long before OutcomeReady, so this
+	// is defensive only. Fully off the bootstrap critical path.
 	gatewayELBReconcileMaxWait = 15 * time.Minute
 	gatewayELBReconcilePoll    = 30 * time.Second
 )
 
-// runPostHandoverGatewayELB reconciles the Huawei gateway ELB members to the
-// live gateway-Service nodePort. See file header. Huawei-only.
+// runPostHandoverGatewayELB converges the Huawei gateway ELB member set to the
+// live node IPs at the gateway host ports. See file header. Huawei-only.
 func (h *Handler) runPostHandoverGatewayELB(dep *Deployment) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -63,7 +64,7 @@ func (h *Handler) runPostHandoverGatewayELB(dep *Deployment) {
 	}()
 
 	// Hetzner (and any non-Huawei) path: hcloud-ccm programs the gateway LB
-	// against node:443 automatically — nothing to reconcile here.
+	// against the live nodes automatically — nothing to reconcile here.
 	if strings.ToLower(strings.TrimSpace(dep.Request.Provider)) != "huawei" {
 		return
 	}
@@ -104,20 +105,17 @@ func (h *Handler) runPostHandoverGatewayELB(dep *Deployment) {
 	}
 	fqdn := strings.TrimSpace(dep.Request.SovereignFQDN)
 
-	// Poll for the gateway Service's per-port nodePorts, then reconcile the ELB.
-	// Require BOTH the :443 and :80 nodePorts before reconciling — a
-	// type=LoadBalancer Service is assigned nodePorts for all its ports
-	// atomically, so a partial read means the Service is still being programmed;
-	// reconciling on a partial read would strand the un-read pool's members on
-	// the placeholder port.
+	// Poll for the primary cluster's node InternalIPs (the primary kubeconfig
+	// scopes this to primary-region nodes — each region is its own cluster),
+	// then converge the ELB member set to them at the gateway host ports.
 	deadline := time.Now().Add(gatewayELBReconcileMaxWait)
 	for {
-		httpsNP, httpNP, perr := h.discoverGatewayNodePorts(cs)
-		if perr == nil && httpsNP > 0 && httpNP > 0 {
+		nodeIPs, perr := h.discoverNodeInternalIPs(cs)
+		if perr == nil && len(nodeIPs) > 0 {
 			changed, rerr := hp.ReconcileGatewayELBMembers(
 				context.Background(),
 				dep.Request.HuaweiAccessKey, dep.Request.HuaweiSecretKey, dep.Request.HuaweiProjectID,
-				region, fqdn, httpsNP, httpNP,
+				region, fqdn, nodeIPs, gatewayHostPortHTTPS, gatewayHostPortHTTP,
 				func(msg string) { h.log.Info("gateway-elb: " + msg) },
 			)
 			if rerr != nil {
@@ -131,23 +129,23 @@ func (h *Handler) runPostHandoverGatewayELB(dep *Deployment) {
 				return
 			}
 			h.log.Info("gateway-elb: reconcile complete",
-				"id", dep.ID, "httpsNodePort", httpsNP, "httpNodePort", httpNP, "membersChanged", changed)
+				"id", dep.ID, "nodes", len(nodeIPs), "membersChanged", changed)
 			dep.recordEvent(provisioner.Event{
 				Time:    time.Now().UTC().Format(time.RFC3339),
 				Phase:   "post-handover",
 				Level:   "info",
-				Message: "Gateway ELB reconciled to the live gateway-Service nodePort (https→node:" + strconv.Itoa(httpsNP) + ", http→node:" + strconv.Itoa(httpNP) + "); public :443/:80 front door is wired.",
+				Message: "Gateway ELB member set converged to " + strconv.Itoa(len(nodeIPs)) + " live nodes at node:" + strconv.Itoa(gatewayHostPortHTTPS) + "/:" + strconv.Itoa(gatewayHostPortHTTP) + " (" + strconv.Itoa(changed) + " changed); public :443/:80 front door is wired.",
 			})
 			return
 		}
 		if time.Now().After(deadline) {
-			h.log.Warn("gateway-elb: budget exhausted waiting for the gateway Service nodePort; ELB members left at the placeholder port",
-				"id", dep.ID, "service", gatewayServiceNamespace+"/"+gatewayServiceName)
+			h.log.Warn("gateway-elb: budget exhausted waiting for node InternalIPs; ELB members left as tofu seeded them",
+				"id", dep.ID)
 			dep.recordEvent(provisioner.Event{
 				Time:    time.Now().UTC().Format(time.RFC3339),
 				Phase:   "post-handover",
 				Level:   "warn",
-				Message: "Gateway Service " + gatewayServiceNamespace + "/" + gatewayServiceName + " never exposed a nodePort within budget; the gateway ELB members stay at the tofu placeholder port and the *." + fqdn + " front door will not serve until reconciled.",
+				Message: "Could not list the primary cluster's node IPs within budget; the gateway ELB members stay as tofu seeded them (correct for the boot-time node set; autoscaler drift unhealed this cycle).",
 			})
 			return
 		}
@@ -155,26 +153,24 @@ func (h *Handler) runPostHandoverGatewayELB(dep *Deployment) {
 	}
 }
 
-// discoverGatewayNodePorts reads the gateway LoadBalancer Service and returns
-// its per-port (443/80) auto-allocated nodePorts. Returns (0,0,nil) when the
-// Service exists but has not been assigned nodePorts yet (caller retries).
-func (h *Handler) discoverGatewayNodePorts(cs kubernetes.Interface) (httpsNodePort, httpNodePort int, err error) {
+// discoverNodeInternalIPs lists the cluster's nodes and returns their
+// InternalIP addresses — the gateway ELB pool member addresses. Every node
+// runs cilium-envoy (hostNetwork DaemonSet) with the gateway listeners bound
+// on node:443/:80, so every node is a valid member.
+func (h *Handler) discoverNodeInternalIPs(cs kubernetes.Interface) ([]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
-	svc, gerr := cs.CoreV1().Services(gatewayServiceNamespace).Get(ctx, gatewayServiceName, metav1.GetOptions{})
-	if gerr != nil {
-		return 0, 0, gerr
+	nodes, err := cs.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
 	}
-	for _, p := range svc.Spec.Ports {
-		if p.NodePort <= 0 {
-			continue
-		}
-		switch p.Port {
-		case 443:
-			httpsNodePort = int(p.NodePort)
-		case 80:
-			httpNodePort = int(p.NodePort)
+	var ips []string
+	for _, n := range nodes.Items {
+		for _, addr := range n.Status.Addresses {
+			if addr.Type == corev1.NodeInternalIP && strings.TrimSpace(addr.Address) != "" {
+				ips = append(ips, addr.Address)
+			}
 		}
 	}
-	return httpsNodePort, httpNodePort, nil
+	return ips, nil
 }

--- a/products/catalyst/bootstrap/api/internal/providers/huawei/gateway_elb.go
+++ b/products/catalyst/bootstrap/api/internal/providers/huawei/gateway_elb.go
@@ -1,25 +1,29 @@
-// gateway_elb.go — #4690 / #4686 foundation-fix: reconcile the Sovereign
-// gateway ELB's pool members to the gateway LoadBalancer Service's live,
-// auto-allocated nodePort.
+// gateway_elb.go — #4706: reconcile the Sovereign gateway ELB's pool members
+// to the live node set at the DURABLE gateway host ports (:443/:80).
 //
-// WHY THIS EXISTS. On the CCM-less Huawei provider the Sovereign Gateway is a
-// `Service type=LoadBalancer` (cilium-gateway-cilium-gateway, kube-system,
-// #4682) fronted publicly by a dedicated Huawei ELB (infra/providers/huawei/
-// main.tf huaweicloud_elb_*.primary). The ELB forwards public :443/:80 →
-// node:<gateway-Service-nodePort> — that is the only path that routes on a
-// no-CCM Huawei node (node:443 does NOT, verified live on hw208). The nodePort
-// is AUTO-ALLOCATED by Cilium in the 30000-32767 range and is unknown at
-// tofu-apply time (tofu runs at Phase-0, before the cluster — and thus the
-// Service — exists), and Cilium 1.16.5 exposes no durable pin for it. So the
-// tofu ELB members start at a PLACEHOLDER port (var.gateway_service_nodeport_*)
-// and catalyst-api rewrites them to the live nodePort here, post-convergence.
+// WHY THIS EXISTS. On the CCM-less Huawei provider the Sovereign Gateway is
+// served by cilium-envoy in gateway-api hostNetwork mode (cilium 1.19.3,
+// bp-cilium 1.4.8): envoy — a hostNetwork DaemonSet — binds node:443/:80
+// directly on every node, and a dedicated public Huawei ELB
+// (infra/providers/huawei/main.tf huaweicloud_elb_*.primary) does TCP
+// passthrough public :443/:80 → node:443/:80. The member ports are durable
+// and known at tofu-apply time, so tofu seeds correct members at Phase-0 —
+// no nodePort anywhere (§854), no placeholder, no port discovery.
 //
-// This is exactly what hcloud-ccm does on Hetzner (it reads the Service and
-// programs the LB); Huawei has no CCM, so catalyst-api does it explicitly. The
-// gateway Service TYPE stays LoadBalancer (never type=NodePort — §854).
+// What is left for catalyst-api is MEMBER-SET drift: nodes added by the
+// autoscaler are missing from the pools, and replaced/removed nodes leave
+// stale members behind. This reconciler converges each gateway pool's member
+// set to the live cluster's node IPs at the fixed port — the same job
+// hcloud-ccm does continuously on Hetzner, done explicitly here because
+// Huawei has no CCM.
 //
-// Idempotent by construction: a member already on the desired port is left
-// untouched; only mismatched members are DELETE+POST-recreated. Safe to re-run.
+// History: on cilium 1.16.5 (hostNetwork bind bug) the gateway was an
+// ELB→node:<auto-allocated nodePort> forward and this file repointed member
+// PORTS post-convergence (#4690/#4691). That shape — and its failure mode
+// (empty pools = console 000, hw217) — is retired by the 1.19.3 bump.
+//
+// Idempotent by construction: a member already at (nodeIP, port) is left
+// untouched; only missing members are added and stale ones removed.
 package huawei
 
 import (
@@ -46,24 +50,35 @@ const (
 	gatewayPoolHTTPSuffix  = "-elb-pool-http"
 )
 
-// ReconcileGatewayELBMembers repoints the gateway ELB's HTTPS/HTTP pool members
-// (and their health monitors) at the live gateway-Service nodePorts.
+// ReconcileGatewayELBMembers converges the gateway ELB's HTTPS/HTTP pool
+// member sets to nodeIPs at the fixed gateway host ports, and points each
+// pool's health monitor at the same port.
 //
 // It is an exported method on *Provider (mirrors SweepOrphanEIPs) so the
-// handler reaches it via h.huaweiProvider("gateway-elb"). httpsNodePort /
-// httpNodePort are the LoadBalancer Service's real per-port nodePorts, which
-// the caller discovers from the live cluster.
+// handler reaches it via h.huaweiProvider("gateway-elb"). nodeIPs are the
+// live cluster's node InternalIPs (primary region — each region is its own
+// cluster); httpsPort/httpPort are the durable gateway host ports (443/80),
+// bound on every node by cilium-envoy's gateway-api hostNetwork mode.
 //
-// Returns the number of members changed (0 == already converged / nothing to
-// do) and an error only on a hard API failure. Per-member failures are logged
-// via progress and do NOT abort the whole reconcile (best-effort, like the
-// day-2 post-handover hooks).
-func (p *Provider) ReconcileGatewayELBMembers(ctx context.Context, ak, sk, projectID, region, sovereignFQDN string, httpsNodePort, httpNodePort int, progress func(msg string)) (int, error) {
+// Returns the number of members changed (adds + removals; 0 == already
+// converged) and an error only on a hard API failure. Per-member failures are
+// logged via progress and do NOT abort the whole reconcile (best-effort, like
+// the day-2 post-handover hooks).
+func (p *Provider) ReconcileGatewayELBMembers(ctx context.Context, ak, sk, projectID, region, sovereignFQDN string, nodeIPs []string, httpsPort, httpPort int, progress func(msg string)) (int, error) {
 	if progress == nil {
 		progress = func(string) {}
 	}
-	if httpsNodePort <= 0 && httpNodePort <= 0 {
-		return 0, fmt.Errorf("gateway-elb: no valid nodePort supplied (https=%d http=%d)", httpsNodePort, httpNodePort)
+	if httpsPort <= 0 && httpPort <= 0 {
+		return 0, fmt.Errorf("gateway-elb: no valid gateway host port supplied (https=%d http=%d)", httpsPort, httpPort)
+	}
+	desiredIPs := make(map[string]bool, len(nodeIPs))
+	for _, ip := range nodeIPs {
+		if ip = strings.TrimSpace(ip); ip != "" {
+			desiredIPs[ip] = true
+		}
+	}
+	if len(desiredIPs) == 0 {
+		return 0, fmt.Errorf("gateway-elb: no node IPs supplied — refusing to empty the pools")
 	}
 	hw := hwCreds{AccessKey: ak, SecretKey: sk, ProjectID: projectID}
 	client := httpClientFor(providers.ProviderCreds{Raw: map[string]string{"region": region}})
@@ -85,7 +100,9 @@ func (p *Provider) ReconcileGatewayELBMembers(ctx context.Context, ak, sk, proje
 		return 0, fmt.Errorf("gateway-elb: no ELB named *%s found for %s (elbs=%d)", gatewayELBNameSuffix, sovereignFQDN, len(elbs))
 	}
 
-	// 2. Resolve the ELB's pools; classify each as https/http by name suffix.
+	// 2. Resolve the ELB's pools + its VIP subnet (the fallback subnet for
+	//    member creates when a pool has no existing member to inherit from —
+	//    nodes and the ELB share the region subnet by construction).
 	lbResp, status, err := doSignedRequest(client, hw, http.MethodGet, base+"/loadbalancers/"+gwELBID, nil)
 	if err != nil {
 		return 0, fmt.Errorf("gateway-elb: get LB %s: %w", gwELBID, err)
@@ -95,7 +112,8 @@ func (p *Provider) ReconcileGatewayELBMembers(ctx context.Context, ak, sk, proje
 	}
 	var lb struct {
 		LoadBalancer struct {
-			Pools []struct {
+			VipSubnetCidrID string `json:"vip_subnet_cidr_id"`
+			Pools           []struct {
 				ID string `json:"id"`
 			} `json:"pools"`
 		} `json:"loadbalancer"`
@@ -132,9 +150,9 @@ func (p *Provider) ReconcileGatewayELBMembers(ctx context.Context, ak, sk, proje
 		desired := 0
 		switch {
 		case strings.HasSuffix(pool.Pool.Name, gatewayPoolHTTPSSuffix):
-			desired = httpsNodePort
+			desired = httpsPort
 		case strings.HasSuffix(pool.Pool.Name, gatewayPoolHTTPSuffix):
-			desired = httpNodePort
+			desired = httpPort
 		default:
 			// Not a gateway pool (shouldn't happen — the gateway ELB owns only
 			// these two — but skip defensively rather than mis-port a member).
@@ -144,30 +162,43 @@ func (p *Provider) ReconcileGatewayELBMembers(ctx context.Context, ak, sk, proje
 			continue
 		}
 
-		// 3. DELETE+POST each member whose port != desired. A member already on
-		//    the desired port is left untouched (idempotent re-run).
+		// 3. Converge the member set: keep members already at (nodeIP, desired),
+		//    delete everything else (stale nodes, wrong ports, empty addresses),
+		//    then add the missing nodes. Track a subnet to inherit for creates.
+		subnetForCreate := lb.LoadBalancer.VipSubnetCidrID
+		present := make(map[string]bool, len(pool.Pool.Members))
 		for _, m := range pool.Pool.Members {
-			if m.ProtocolPort == desired {
+			if m.SubnetID != "" {
+				subnetForCreate = m.SubnetID
+			}
+			if desiredIPs[m.Address] && m.ProtocolPort == desired {
+				present[m.Address] = true
 				continue
 			}
-			// Delete the stale-port member.
+			// Stale member (node gone, wrong port, or empty address).
 			_, dStat, dErr := doSignedRequest(client, hw, http.MethodDelete, base+"/pools/"+pl.ID+"/members/"+m.ID, nil)
 			if dErr != nil || (dStat >= 400 && dStat != http.StatusNotFound) {
-				progress(fmt.Sprintf("gateway-elb: pool %s: delete member %s (%s:%d) failed (status %d): %v", pool.Pool.Name, m.ID, m.Address, m.ProtocolPort, dStat, dErr))
+				progress(fmt.Sprintf("gateway-elb: pool %s: delete stale member %s (%q:%d) failed (status %d): %v", pool.Pool.Name, m.ID, m.Address, m.ProtocolPort, dStat, dErr))
 				continue
 			}
-			// Recreate at the live nodePort (same address + subnet).
-			body := gatewayMemberCreateBody(m.Address, desired, m.SubnetID)
+			progress(fmt.Sprintf("gateway-elb: pool %s: stale member %q:%d removed", pool.Pool.Name, m.Address, m.ProtocolPort))
+			changed++
+		}
+		for ip := range desiredIPs {
+			if present[ip] {
+				continue
+			}
+			body := gatewayMemberCreateBody(ip, desired, subnetForCreate)
 			cResp, cStat, cErr := doSignedRequest(client, hw, http.MethodPost, base+"/pools/"+pl.ID+"/members", body)
 			if cErr != nil || cStat >= 400 {
-				progress(fmt.Sprintf("gateway-elb: pool %s: recreate member %s:%d failed (status %d): %s", pool.Pool.Name, m.Address, desired, cStat, snippet(cResp, 200)))
+				progress(fmt.Sprintf("gateway-elb: pool %s: add member %s:%d failed (status %d): %s", pool.Pool.Name, ip, desired, cStat, snippet(cResp, 200)))
 				continue
 			}
-			progress(fmt.Sprintf("gateway-elb: pool %s: member %s repointed %d→%d", pool.Pool.Name, m.Address, m.ProtocolPort, desired))
+			progress(fmt.Sprintf("gateway-elb: pool %s: member %s:%d added", pool.Pool.Name, ip, desired))
 			changed++
 		}
 
-		// 4. Repoint the pool's health monitor at the live nodePort too, so the
+		// 4. Point the pool's health monitor at the gateway host port, so the
 		//    ELB marks the members healthy against the port it actually forwards.
 		if pool.Pool.HealthMonitorID != "" {
 			hmBody := []byte(fmt.Sprintf(`{"healthmonitor":{"monitor_port":%d}}`, desired))
@@ -175,7 +206,7 @@ func (p *Provider) ReconcileGatewayELBMembers(ctx context.Context, ak, sk, proje
 			if hErr != nil || hStat >= 400 {
 				progress(fmt.Sprintf("gateway-elb: pool %s: monitor repoint→%d failed (status %d): %s", pool.Pool.Name, desired, hStat, snippet(hResp, 200)))
 			} else {
-				progress(fmt.Sprintf("gateway-elb: pool %s: monitor repointed →%d", pool.Pool.Name, desired))
+				progress(fmt.Sprintf("gateway-elb: pool %s: monitor →%d", pool.Pool.Name, desired))
 			}
 		}
 	}
@@ -184,9 +215,10 @@ func (p *Provider) ReconcileGatewayELBMembers(ctx context.Context, ak, sk, proje
 }
 
 // gatewayMemberCreateBody builds the ELB v3 member-create payload. subnet_cidr_id
-// is the member's IPv4 subnet (echoed back from the existing member so the new
-// member lands on the same subnet tofu placed it in). When empty it is omitted
-// (cross-VPC member — not our case, but keep the encoder honest).
+// is the member's IPv4 subnet (inherited from an existing member, or the ELB's
+// own VIP subnet — nodes and the ELB share the region subnet by construction).
+// When empty it is omitted (cross-VPC member — not our case, but keep the
+// encoder honest).
 func gatewayMemberCreateBody(address string, port int, subnetCIDRID string) []byte {
 	member := map[string]any{
 		"address":       address,

--- a/products/catalyst/bootstrap/api/internal/providers/huawei/gateway_elb_test.go
+++ b/products/catalyst/bootstrap/api/internal/providers/huawei/gateway_elb_test.go
@@ -20,31 +20,36 @@ type memberOp struct {
 }
 
 // fakeHCSGatewayELB mimics the ELB v3 endpoints ReconcileGatewayELBMembers
-// walks: list LBs, get LB (pools), get pool (members + healthmonitor), member
-// POST/DELETE, and healthmonitor PUT. It records every member op + monitor PUT
-// port so the test asserts the reconcile touched ONLY the mismatched members.
+// walks: list LBs, get LB (pools + vip subnet), get pool (members +
+// healthmonitor), member POST/DELETE, and healthmonitor PUT. It records every
+// member op + monitor PUT port so the test asserts the reconcile converged the
+// member SET correctly.
+//
+// Fixture shape (#4706 contract):
+//   - live nodes: 10.42.0.10 / .11 / .12 (passed by the test)
+//   - https pool: one member at a STALE 1.16.5-era nodePort (m-https-1,
+//     .10:31443 → delete, re-add at :443), one member with an EMPTY address
+//     (m-https-empty — the exact hw217 memberless-pool bug shape → delete),
+//     one member already correct (m-https-ok, .12:443 → untouched). Node .11
+//     and .10 are missing at :443 → added.
+//   - http pool: one stale member (.10:31080 → delete); all 3 nodes added at :80.
+//   - a console ELB that must never be touched.
 func fakeHCSGatewayELB(t *testing.T, ops *[]memberOp, monitorPorts *[]int) func() {
 	t.Helper()
 	var mu sync.Mutex
 
-	// One gateway ELB ("...-elb-primary") + one console ELB ("...-elb-console").
-	// The console ELB MUST be ignored (name suffix mismatch).
 	const lbList = `{"loadbalancers":[
 	  {"id":"lb-gw","name":"catalyst-hw9-omani-works-5b413990-elb-primary"},
 	  {"id":"lb-console","name":"catalyst-hw9-omani-works-5b413990-elb-console"}
 	]}`
-	// The gateway LB has two pools: https + http.
-	const lbGetGW = `{"loadbalancer":{"pools":[{"id":"pool-https"},{"id":"pool-http"}]}}`
-	// https pool: two members on the placeholder port 31443 (need repoint→30111);
-	//             one member ALREADY on 30111 (must be left untouched).
+	const lbGetGW = `{"loadbalancer":{"vip_subnet_cidr_id":"subnet-vip","pools":[{"id":"pool-https"},{"id":"pool-http"}]}}`
 	const poolHTTPS = `{"pool":{"name":"catalyst-hw9-omani-works-5b413990-elb-pool-https",
 	  "healthmonitor_id":"hm-https",
 	  "members":[
 	    {"id":"m-https-1","address":"10.42.0.10","protocol_port":31443,"subnet_cidr_id":"subnet-1"},
-	    {"id":"m-https-2","address":"10.42.0.11","protocol_port":31443,"subnet_cidr_id":"subnet-1"},
-	    {"id":"m-https-ok","address":"10.42.0.12","protocol_port":30111,"subnet_cidr_id":"subnet-1"}
+	    {"id":"m-https-empty","address":"","protocol_port":443,"subnet_cidr_id":""},
+	    {"id":"m-https-ok","address":"10.42.0.12","protocol_port":443,"subnet_cidr_id":"subnet-1"}
 	  ]}}`
-	// http pool: one member on placeholder 31080 (need repoint→30222).
 	const poolHTTP = `{"pool":{"name":"catalyst-hw9-omani-works-5b413990-elb-pool-http",
 	  "healthmonitor_id":"hm-http",
 	  "members":[
@@ -74,6 +79,7 @@ func fakeHCSGatewayELB(t *testing.T, ops *[]memberOp, monitorPorts *[]int) func(
 				Member struct {
 					Address      string `json:"address"`
 					ProtocolPort int    `json:"protocol_port"`
+					SubnetCidrID string `json:"subnet_cidr_id"`
 				} `json:"member"`
 			}
 			_ = json.NewDecoder(r.Body).Decode(&body)
@@ -110,33 +116,28 @@ func fakeHCSGatewayELB(t *testing.T, ops *[]memberOp, monitorPorts *[]int) func(
 	}
 }
 
-// TestReconcileGatewayELBMembers_RepointsMismatchedOnly is the core contract:
-// members on the placeholder port are DELETE+POST-recreated at the live
-// nodePort; a member already on the live port is left untouched; the console
-// ELB is never touched; and both pools' health monitors are repointed.
-func TestReconcileGatewayELBMembers_RepointsMismatchedOnly(t *testing.T) {
+// TestReconcileGatewayELBMembers_ConvergesSetAtHostPorts is the core #4706
+// contract: the member set converges to the live node IPs at the fixed
+// gateway host ports (443/80); stale members (wrong port, gone node, EMPTY
+// address — the hw217 memberless-pool bug shape) are removed; a member
+// already correct is untouched; the console ELB is never touched; both
+// pools' health monitors point at the gateway host port.
+func TestReconcileGatewayELBMembers_ConvergesSetAtHostPorts(t *testing.T) {
 	var ops []memberOp
 	var monitorPorts []int
 	restore := fakeHCSGatewayELB(t, &ops, &monitorPorts)
 	defer restore()
 
+	nodes := []string{"10.42.0.10", "10.42.0.11", "10.42.0.12"}
 	p := New()
 	changed, err := p.ReconcileGatewayELBMembers(context.Background(),
 		"ak", "sk", "proj", "me-east-215", "hw9.omani.works",
-		30111 /*https nodePort*/, 30222 /*http nodePort*/, nil)
+		nodes, 443, 80, nil)
 	if err != nil {
 		t.Fatalf("ReconcileGatewayELBMembers: %v", err)
 	}
 
-	// 2 https placeholder members + 1 http placeholder member = 3 repoints.
-	// The already-on-30111 https member is NOT touched.
-	if changed != 3 {
-		t.Fatalf("changed = %d, want 3 (2 https + 1 http mismatched members)", changed)
-	}
-
-	// Every DELETE must be paired with a POST at the desired port.
-	var posts []memberOp
-	var deletes []memberOp
+	var posts, deletes []memberOp
 	for _, o := range ops {
 		switch o.verb {
 		case "POST":
@@ -145,56 +146,68 @@ func TestReconcileGatewayELBMembers_RepointsMismatchedOnly(t *testing.T) {
 			deletes = append(deletes, o)
 		}
 	}
+
+	// https pool: delete m-https-1 (stale port 31443) + m-https-empty (empty
+	// address). http pool: delete m-http-1 (stale port 31080). Total 3.
 	if len(deletes) != 3 {
-		t.Fatalf("DELETEs = %d (%v), want 3", len(deletes), deletes)
+		t.Fatalf("DELETEs = %d (%v), want 3 (stale-port ×2 + empty-address ×1)", len(deletes), deletes)
 	}
-	if len(posts) != 3 {
-		t.Fatalf("POSTs = %d (%v), want 3", len(posts), posts)
-	}
-	// The already-correct member (id m-https-ok, address .12) must NOT be deleted.
 	for _, d := range deletes {
 		if d.id == "m-https-ok" {
 			t.Fatalf("deleted the already-correct member m-https-ok — must be left untouched")
 		}
 	}
-	// POST ports must be the live nodePorts (443→30111, 80→30222).
+	// https pool: add .10 + .11 at :443 (.12 already present). http pool: add
+	// all 3 at :80. Total 5.
+	if len(posts) != 5 {
+		t.Fatalf("POSTs = %d (%v), want 5 (2 https + 3 http adds)", len(posts), posts)
+	}
 	for _, po := range posts {
-		if po.poolID == "pool-https" && po.port != 30111 {
-			t.Fatalf("https POST for %s got port %d, want 30111", po.address, po.port)
+		if po.address == "" {
+			t.Fatalf("POSTed a member with an EMPTY address — the hw217 bug shape must be impossible")
 		}
-		if po.poolID == "pool-http" && po.port != 30222 {
-			t.Fatalf("http POST for %s got port %d, want 30222", po.address, po.port)
+		if po.poolID == "pool-https" && po.port != 443 {
+			t.Fatalf("https POST for %s got port %d, want 443", po.address, po.port)
+		}
+		if po.poolID == "pool-http" && po.port != 80 {
+			t.Fatalf("http POST for %s got port %d, want 80", po.address, po.port)
+		}
+		if po.port >= 30000 {
+			t.Fatalf("POSTed member port %d is in the NodePort range — nodePorts are FORBIDDEN (§854)", po.port)
 		}
 	}
-	// Both health monitors repointed (30111 for https pool, 30222 for http pool).
+	if changed != len(posts)+len(deletes) {
+		t.Fatalf("changed = %d, want %d (adds + removals)", changed, len(posts)+len(deletes))
+	}
+	// Both health monitors point at the gateway host ports.
 	if len(monitorPorts) != 2 {
 		t.Fatalf("monitor PUTs = %d (%v), want 2", len(monitorPorts), monitorPorts)
 	}
 	sawHTTPS, sawHTTP := false, false
 	for _, mp := range monitorPorts {
-		if mp == 30111 {
+		if mp == 443 {
 			sawHTTPS = true
 		}
-		if mp == 30222 {
+		if mp == 80 {
 			sawHTTP = true
 		}
 	}
 	if !sawHTTPS || !sawHTTP {
-		t.Fatalf("monitor ports = %v, want to include both 30111 and 30222", monitorPorts)
+		t.Fatalf("monitor ports = %v, want to include both 443 and 80", monitorPorts)
 	}
 }
 
-// TestReconcileGatewayELBMembers_Idempotent — a second run when all members are
-// already on the live port is a no-op (0 changes, 0 DELETE/POST).
+// TestReconcileGatewayELBMembers_Idempotent — a re-run when the member set
+// already equals the live nodes at the host port is a no-op (0 changes,
+// 0 DELETE/POST).
 func TestReconcileGatewayELBMembers_Idempotent(t *testing.T) {
-	// Fake HCS whose members are ALREADY on the live ports.
 	var mu sync.Mutex
 	var ops []memberOp
 	const lbList = `{"loadbalancers":[{"id":"lb-gw","name":"catalyst-hw9-omani-works-5b413990-elb-primary"}]}`
-	const lbGet = `{"loadbalancer":{"pools":[{"id":"pool-https"}]}}`
+	const lbGet = `{"loadbalancer":{"vip_subnet_cidr_id":"subnet-vip","pools":[{"id":"pool-https"}]}}`
 	const poolHTTPS = `{"pool":{"name":"catalyst-hw9-omani-works-5b413990-elb-pool-https",
 	  "healthmonitor_id":"hm-https",
-	  "members":[{"id":"m1","address":"10.42.0.10","protocol_port":30111,"subnet_cidr_id":"subnet-1"}]}}`
+	  "members":[{"id":"m1","address":"10.42.0.10","protocol_port":443,"subnet_cidr_id":"subnet-1"}]}}`
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.HasSuffix(r.URL.Path, "/elb/loadbalancers"):
@@ -221,12 +234,13 @@ func TestReconcileGatewayELBMembers_Idempotent(t *testing.T) {
 
 	p := New()
 	changed, err := p.ReconcileGatewayELBMembers(context.Background(),
-		"ak", "sk", "proj", "me-east-215", "hw9.omani.works", 30111, 30222, nil)
+		"ak", "sk", "proj", "me-east-215", "hw9.omani.works",
+		[]string{"10.42.0.10"}, 443, 80, nil)
 	if err != nil {
 		t.Fatalf("ReconcileGatewayELBMembers: %v", err)
 	}
 	if changed != 0 {
-		t.Fatalf("changed = %d, want 0 (all members already on the live port)", changed)
+		t.Fatalf("changed = %d, want 0 (member set already converged)", changed)
 	}
 	for _, o := range ops {
 		if o.verb == http.MethodDelete || o.verb == http.MethodPost {
@@ -250,11 +264,28 @@ func TestReconcileGatewayELBMembers_NoGatewayELB(t *testing.T) {
 
 	p := New()
 	_, err := p.ReconcileGatewayELBMembers(context.Background(),
-		"ak", "sk", "proj", "me-east-215", "hw9.omani.works", 30111, 30222, nil)
+		"ak", "sk", "proj", "me-east-215", "hw9.omani.works",
+		[]string{"10.42.0.10"}, 443, 80, nil)
 	if err == nil {
 		t.Fatalf("expected an error when no -elb-primary ELB exists, got nil")
 	}
 	if !strings.Contains(err.Error(), "-elb-primary") {
 		t.Fatalf("error %q should mention the missing -elb-primary ELB", err.Error())
+	}
+}
+
+// TestReconcileGatewayELBMembers_RefusesEmptyNodeSet — an empty node list must
+// error out, never empty the pools (an empty pool = console 000, the exact
+// hw217 failure).
+func TestReconcileGatewayELBMembers_RefusesEmptyNodeSet(t *testing.T) {
+	p := New()
+	_, err := p.ReconcileGatewayELBMembers(context.Background(),
+		"ak", "sk", "proj", "me-east-215", "hw9.omani.works",
+		nil, 443, 80, nil)
+	if err == nil {
+		t.Fatalf("expected an error on an empty node set, got nil")
+	}
+	if !strings.Contains(err.Error(), "no node IPs") {
+		t.Fatalf("error %q should say no node IPs were supplied", err.Error())
 	}
 }

--- a/products/catalyst/bootstrap/api/internal/provisioner/cilium_values_parity_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/cilium_values_parity_test.go
@@ -256,6 +256,23 @@ func TestCiliumValuesParity_GatewayHostNetworkLockstep(t *testing.T) {
 		t.Errorf("bootstrap cilium-values.yaml must carry the huawei-conditional gatewayAPI hostNetwork block (#4706) — without it the bootstrap install serves no host bind and the gateway ELB (node:443/:80) has nothing to forward to")
 	}
 
+	// (1b) the envoy NET_BIND_SERVICE cap pair — without BOTH knobs envoy
+	// cannot bind the privileged host ports ("cannot bind '0.0.0.0:80':
+	// Permission denied", live-proven hw217): the cap in the container list
+	// AND keepCapNetBindService (cilium-envoy-starter drops ambient caps at
+	// exec otherwise).
+	for _, tok := range []string{"NET_BIND_SERVICE", "keepCapNetBindService: true"} {
+		if !strings.Contains(bootstrapBlock, tok) {
+			t.Errorf("bootstrap cilium-values.yaml must carry %q (#4706) — without it envoy cannot bind node:443/:80 and the gateway ELB has nothing to forward to", tok)
+		}
+	}
+	chart := readChartValues(t)
+	for _, tok := range []string{"NET_BIND_SERVICE", "keepCapNetBindService: true"} {
+		if !strings.Contains(chart, tok) {
+			t.Errorf("platform/cilium/chart/values.yaml must carry %q (#4706) — the slot-01 HR upgrade would strip the envoy bind capability mid-bootstrap", tok)
+		}
+	}
+
 	// (2) slot-01 HR wiring.
 	if !strings.Contains(overlay, "CILIUM_GATEWAY_HOSTNETWORK_ENABLED") {
 		t.Errorf("clusters/_template/bootstrap-kit/01-cilium.yaml must wire gatewayAPI.hostNetwork.enabled from CILIUM_GATEWAY_HOSTNETWORK_ENABLED (#4706)")

--- a/products/catalyst/bootstrap/api/internal/provisioner/cilium_values_parity_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/cilium_values_parity_test.go
@@ -226,6 +226,87 @@ func TestCiliumValuesParity_BootstrapMatchesOverlayKeys(t *testing.T) {
 	}
 }
 
+// TestCiliumValuesParity_GatewayHostNetworkLockstep (#4706) locks the
+// three-way gateway-api hostNetwork agreement:
+//   1. the cloud-init cilium-values.yaml block carries a huawei-conditional
+//      `hostNetwork:` + `enabled: true` (bootstrap install binds node:443/:80),
+//   2. the bootstrap-kit slot-01 HR wires
+//      `${CILIUM_GATEWAY_HOSTNETWORK_ENABLED...}` (the HR upgrade agrees),
+//   3. cloud-init's flux-bootstrap substitutes set
+//      CILIUM_GATEWAY_HOSTNETWORK_ENABLED: "true" on huawei.
+// Drift between (1) and (2)+(3) is the #491 class: the bootstrap install and
+// the slot-01 upgrade disagree mid-Phase-1 and the gateway flaps between a
+// host bind and a Service-only shape. The ELB targets node:443/:80, so a
+// regression here = console 000 (the hw217 shape).
+func TestCiliumValuesParity_GatewayHostNetworkLockstep(t *testing.T) {
+	tpl := readCloudInit(t)
+	overlay := readBootstrapKitOverlay(t)
+
+	// (1) bootstrap cilium-values block: hostNetwork enabled inside the
+	// huawei conditional.
+	startMarker := "- path: /var/lib/catalyst/cilium-values.yaml"
+	endMarker := "- path: /var/lib/catalyst/flux-bootstrap.yaml"
+	si := strings.Index(tpl, startMarker)
+	ei := strings.Index(tpl, endMarker)
+	if si < 0 || ei < 0 || ei <= si {
+		t.Fatalf("could not locate cilium-values.yaml block in cloud-init template (start=%d, end=%d)", si, ei)
+	}
+	bootstrapBlock := tpl[si:ei]
+	if !strings.Contains(bootstrapBlock, "hostNetwork:") {
+		t.Errorf("bootstrap cilium-values.yaml must carry the huawei-conditional gatewayAPI hostNetwork block (#4706) — without it the bootstrap install serves no host bind and the gateway ELB (node:443/:80) has nothing to forward to")
+	}
+
+	// (2) slot-01 HR wiring.
+	if !strings.Contains(overlay, "CILIUM_GATEWAY_HOSTNETWORK_ENABLED") {
+		t.Errorf("clusters/_template/bootstrap-kit/01-cilium.yaml must wire gatewayAPI.hostNetwork.enabled from CILIUM_GATEWAY_HOSTNETWORK_ENABLED (#4706)")
+	}
+
+	// (3) huawei substitute set to "true".
+	if !strings.Contains(tpl, `CILIUM_GATEWAY_HOSTNETWORK_ENABLED: "true"`) {
+		t.Errorf(`cloud-init flux-bootstrap substitutes must set CILIUM_GATEWAY_HOSTNETWORK_ENABLED: "true" on huawei (#4706)`)
+	}
+}
+
+// TestCiliumValuesParity_BootstrapHelmVersionMatchesChartPin (#4706) locks the
+// bootstrap `helm upgrade --install cilium --version X` against the bp-cilium
+// Chart.yaml dependency pin. If they drift, every fresh prov does an
+// unsupported multi-minor in-place CNI upgrade mid-Phase-1 (cloud-init
+// installs one cilium, the slot-01 HR immediately upgrades to another) — the
+// exact trap the 1.16.5→1.19.3 bump would have created without this guard.
+func TestCiliumValuesParity_BootstrapHelmVersionMatchesChartPin(t *testing.T) {
+	tpl := readCloudInit(t)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot := filepath.Clean(filepath.Join(cwd, "..", "..", "..", "..", "..", ".."))
+	raw, err := os.ReadFile(filepath.Join(repoRoot, "platform", "cilium", "chart", "Chart.yaml"))
+	if err != nil {
+		t.Fatalf("read Chart.yaml: %v", err)
+	}
+	chartYAML := string(raw)
+
+	// Extract the dependency pin: the `version: "X.Y.Z"` line inside the
+	// dependencies block (the only double-quoted version in the file).
+	var pin string
+	for _, line := range strings.Split(chartYAML, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, `version: "`) {
+			pin = strings.Trim(strings.TrimPrefix(trimmed, "version:"), ` "`)
+			break
+		}
+	}
+	if pin == "" {
+		t.Fatalf("could not extract the cilium dependency version pin from platform/cilium/chart/Chart.yaml")
+	}
+
+	want := "helm upgrade --install cilium cilium/cilium --version " + pin
+	if !strings.Contains(tpl, want) {
+		t.Errorf("cloud-init bootstrap install must pin the SAME cilium version as the bp-cilium chart dependency (%q). Drift = an unsupported in-place multi-minor CNI upgrade mid-Phase-1 on every fresh prov (#4706).", pin)
+	}
+}
+
 // TestCiliumValuesParity_BootstrapHelmInstallReadsValuesFile verifies
 // the bootstrap helm install command in cloud-init reads the values
 // file via `-f /var/lib/catalyst/cilium-values.yaml` rather than relying

--- a/products/catalyst/bootstrap/api/internal/provisioner/cilium_values_parity_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/cilium_values_parity_test.go
@@ -260,12 +260,13 @@ func TestCiliumValuesParity_GatewayHostNetworkLockstep(t *testing.T) {
 	// cannot bind the privileged host ports ("cannot bind '0.0.0.0:80':
 	// Permission denied", live-proven hw217): the cap in the container list
 	// AND keepCapNetBindService (cilium-envoy-starter drops ambient caps at
-	// exec otherwise).
-	for _, tok := range []string{"NET_BIND_SERVICE", "keepCapNetBindService: true"} {
-		if !strings.Contains(bootstrapBlock, tok) {
-			t.Errorf("bootstrap cilium-values.yaml must carry %q (#4706) — without it envoy cannot bind node:443/:80 and the gateway ELB has nothing to forward to", tok)
-		}
-	}
+	// exec otherwise). DELIBERATELY asserted on the CHART values ONLY, not
+	// the bootstrap heredoc: gateway listeners exist only after Flux applies
+	// the Gateway CR (sovereign-tls, post-bootstrap), and slot-01's bp-cilium
+	// HR upgrade delivers the caps before any bind attempt — so carrying
+	// them in cloud-init buys nothing and costs bytes against Hetzner's
+	// 32 KiB user_data cap (#966: the 3-region CP render sits within ~30 B
+	// of it). This is NOT the #491 drift class (nothing crashes pre-Gateway).
 	chart := readChartValues(t)
 	for _, tok := range []string{"NET_BIND_SERVICE", "keepCapNetBindService: true"} {
 		if !strings.Contains(chart, tok) {

--- a/products/catalyst/bootstrap/api/internal/provisioner/parent_domains_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/parent_domains_test.go
@@ -40,6 +40,9 @@ import (
 // Validate() also requires.
 func validBaseWithSecrets() Request {
 	return Request{
+		// #4706 — deliberate single-region validation shape (the BCP
+		// default is multi-region; implicit 1-region is rejected).
+		BcpTopology:            BcpTopologySingleRegion,
 		OrgName:                "ACME",
 		OrgEmail:               "ops@acme.io",
 		SovereignFQDN:          "acme.openova.io",

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -1052,21 +1052,15 @@ func (r *Request) Validate() error {
 		}
 		r.BcpTopology = explicit
 	} else {
-		// #4706 (hw217 lesson, founder 2026-07-03: "the fundamental
-		// requirement of 2 region mimicking agreement") — the BCP
-		// agreement default is MULTI-REGION. An absent bcpTopology + a
-		// single region used to silently derive "single-region" and sail
-		// through, which is exactly how an absent-minded 1-region prov
-		// (hw217) got accepted. A single-region prov is now a DELIBERATE
-		// act: the payload must say bcpTopology="single-region" in so
-		// many words (the quota-constrained validation shape); an absent
-		// topology with <2 regions is a 400.
-		if len(r.Regions) < 2 {
-			return fmt.Errorf(
-				"deployment has %d region(s) and no explicit bcpTopology — the BCP agreement default is multi-region (>=2 regions, Pillar 2). Add a second region, or set bcpTopology=%q explicitly for a deliberate single-region validation prov",
-				len(r.Regions), BcpTopologySingleRegion,
-			)
-		}
+		// NOTE (#4706): the multi-region POST floor ("no implicit
+		// single-region provs") lives in the HANDLER admission path
+		// (CreateDeployment, deployments.go), NOT here — Validate() is
+		// ALSO the on-restart legacy-record migration path (the store
+		// rehydrates pre-floor single-region records through it, see
+		// TestLegacyRecord_NoParentDomainsKey_LoadsCleanly), and a
+		// policy floor here would brick existing deployments on the
+		// next catalyst-api roll. Rehydrated legacy records keep the
+		// historical auto-derivation.
 		r.BcpTopology = deriveBcpTopology(*r)
 	}
 	// Mirror invariant: an EXPLICIT single-region declaration with >=2

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -1052,7 +1052,31 @@ func (r *Request) Validate() error {
 		}
 		r.BcpTopology = explicit
 	} else {
+		// #4706 (hw217 lesson, founder 2026-07-03: "the fundamental
+		// requirement of 2 region mimicking agreement") — the BCP
+		// agreement default is MULTI-REGION. An absent bcpTopology + a
+		// single region used to silently derive "single-region" and sail
+		// through, which is exactly how an absent-minded 1-region prov
+		// (hw217) got accepted. A single-region prov is now a DELIBERATE
+		// act: the payload must say bcpTopology="single-region" in so
+		// many words (the quota-constrained validation shape); an absent
+		// topology with <2 regions is a 400.
+		if len(r.Regions) < 2 {
+			return fmt.Errorf(
+				"deployment has %d region(s) and no explicit bcpTopology — the BCP agreement default is multi-region (>=2 regions, Pillar 2). Add a second region, or set bcpTopology=%q explicitly for a deliberate single-region validation prov",
+				len(r.Regions), BcpTopologySingleRegion,
+			)
+		}
 		r.BcpTopology = deriveBcpTopology(*r)
+	}
+	// Mirror invariant: an EXPLICIT single-region declaration with >=2
+	// regions is contradictory — reject rather than guess which half the
+	// operator meant.
+	if r.BcpTopology == BcpTopologySingleRegion && len(r.Regions) >= 2 {
+		return fmt.Errorf(
+			"bcpTopology=%q contradicts len(regions)=%d — drop the extra regions or choose a multi-region topology",
+			BcpTopologySingleRegion, len(r.Regions),
+		)
 	}
 	// Cross-field invariant: active-hotstandby and active-active both
 	// require >=2 regions on the wire — a single-region prov cannot

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner_bcp_topology_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner_bcp_topology_test.go
@@ -179,24 +179,20 @@ func TestValidate_AutoDerivesOnMultiRegionEmpty(t *testing.T) {
 }
 
 func TestValidate_AutoDerivesOnSingleRegionEmpty(t *testing.T) {
-	// CONTRACT INVERTED by #4706 (founder 2026-07-03: "the fundamental
-	// requirement of 2 region mimicking agreement"): empty topology +
-	// 1 region used to silently auto-derive "single-region" — that
-	// silent derivation is exactly how the absent-minded 1-region hw217
-	// prov got accepted. It is now a Validate-time REJECTION; a
-	// single-region prov must declare bcpTopology="single-region"
-	// explicitly.
+	// #4706 NOTE: Validate() keeps the historical auto-derivation because
+	// it is ALSO the store's legacy-record rehydration path. The
+	// multi-region POST floor lives at HANDLER admission
+	// (TestCreateDeployment_RejectsImplicitSingleRegion).
 	req := baseValidateRequest(t)
 	req.BcpTopology = ""
 	req.Regions = []RegionSpec{
 		{Provider: "hetzner", CloudRegion: "fsn1", ControlPlaneSize: "cpx32"},
 	}
-	err := req.Validate()
-	if err == nil {
-		t.Fatalf("Validate(): empty topology + 1 region must now be REJECTED (BCP default = multi-region, #4706)")
+	if err := req.Validate(); err != nil {
+		t.Fatalf("Validate(): %v", err)
 	}
-	if !strings.Contains(err.Error(), "multi-region") {
-		t.Fatalf("rejection must explain the multi-region BCP default, got: %v", err)
+	if req.BcpTopology != BcpTopologySingleRegion {
+		t.Fatalf("Validate(): empty topology + 1 region should auto-derive single-region, got %q", req.BcpTopology)
 	}
 }
 
@@ -309,24 +305,6 @@ func tfvarsRequest(t *testing.T) Request {
 	t.Helper()
 	r := baseValidateRequest(t)
 	return *r
-}
-
-// TestValidate_RejectsImplicitSingleRegion (#4706, founder 2026-07-03: "the
-// fundamental requirement of 2 region mimicking agreement") — the BCP
-// agreement default is MULTI-REGION. A request with <2 regions and NO
-// explicit bcpTopology must 400 at Validate time; silently deriving
-// "single-region" is exactly how the absent-minded 1-region hw217 prov got
-// accepted.
-func TestValidate_RejectsImplicitSingleRegion(t *testing.T) {
-	req := validBaseWithSecrets()
-	req.BcpTopology = ""
-	err := req.Validate()
-	if err == nil {
-		t.Fatalf("a 1-region request with no explicit bcpTopology must be rejected (BCP default = multi-region)")
-	}
-	if !strings.Contains(err.Error(), "multi-region") {
-		t.Fatalf("rejection must explain the multi-region BCP default, got: %v", err)
-	}
 }
 
 // TestValidate_AllowsExplicitSingleRegion — the deliberate opt-out: saying

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner_bcp_topology_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner_bcp_topology_test.go
@@ -179,16 +179,24 @@ func TestValidate_AutoDerivesOnMultiRegionEmpty(t *testing.T) {
 }
 
 func TestValidate_AutoDerivesOnSingleRegionEmpty(t *testing.T) {
+	// CONTRACT INVERTED by #4706 (founder 2026-07-03: "the fundamental
+	// requirement of 2 region mimicking agreement"): empty topology +
+	// 1 region used to silently auto-derive "single-region" — that
+	// silent derivation is exactly how the absent-minded 1-region hw217
+	// prov got accepted. It is now a Validate-time REJECTION; a
+	// single-region prov must declare bcpTopology="single-region"
+	// explicitly.
 	req := baseValidateRequest(t)
 	req.BcpTopology = ""
 	req.Regions = []RegionSpec{
 		{Provider: "hetzner", CloudRegion: "fsn1", ControlPlaneSize: "cpx32"},
 	}
-	if err := req.Validate(); err != nil {
-		t.Fatalf("Validate(): %v", err)
+	err := req.Validate()
+	if err == nil {
+		t.Fatalf("Validate(): empty topology + 1 region must now be REJECTED (BCP default = multi-region, #4706)")
 	}
-	if req.BcpTopology != BcpTopologySingleRegion {
-		t.Fatalf("Validate(): empty topology + 1 region should auto-derive single-region, got %q", req.BcpTopology)
+	if !strings.Contains(err.Error(), "multi-region") {
+		t.Fatalf("rejection must explain the multi-region BCP default, got: %v", err)
 	}
 }
 
@@ -239,7 +247,9 @@ func TestWriteTfvars_EmitsSingleRegionForLegacyPath(t *testing.T) {
 	req := tfvarsRequest(t)
 	// Legacy single-region payload (no Regions[] supplied) — exercises
 	// the back-compat path the wizard used pre-multi-region work.
+	// #4706 — legacy payloads must ALSO declare single-region explicitly.
 	req.Regions = nil
+	req.BcpTopology = BcpTopologySingleRegion
 	if err := req.Validate(); err != nil {
 		t.Fatalf("Validate(): %v", err)
 	}
@@ -299,4 +309,48 @@ func tfvarsRequest(t *testing.T) Request {
 	t.Helper()
 	r := baseValidateRequest(t)
 	return *r
+}
+
+// TestValidate_RejectsImplicitSingleRegion (#4706, founder 2026-07-03: "the
+// fundamental requirement of 2 region mimicking agreement") — the BCP
+// agreement default is MULTI-REGION. A request with <2 regions and NO
+// explicit bcpTopology must 400 at Validate time; silently deriving
+// "single-region" is exactly how the absent-minded 1-region hw217 prov got
+// accepted.
+func TestValidate_RejectsImplicitSingleRegion(t *testing.T) {
+	req := validBaseWithSecrets()
+	req.BcpTopology = ""
+	err := req.Validate()
+	if err == nil {
+		t.Fatalf("a 1-region request with no explicit bcpTopology must be rejected (BCP default = multi-region)")
+	}
+	if !strings.Contains(err.Error(), "multi-region") {
+		t.Fatalf("rejection must explain the multi-region BCP default, got: %v", err)
+	}
+}
+
+// TestValidate_AllowsExplicitSingleRegion — the deliberate opt-out: saying
+// bcpTopology="single-region" in so many words keeps the quota-constrained
+// validation shape available.
+func TestValidate_AllowsExplicitSingleRegion(t *testing.T) {
+	req := validBaseWithSecrets()
+	req.BcpTopology = BcpTopologySingleRegion
+	if err := req.Validate(); err != nil {
+		t.Fatalf("an EXPLICIT single-region declaration must validate, got: %v", err)
+	}
+}
+
+// TestValidate_RejectsContradictorySingleRegion — an explicit single-region
+// declaration with >=2 regions is contradictory; reject rather than guess.
+func TestValidate_RejectsContradictorySingleRegion(t *testing.T) {
+	req := validBaseWithSecrets()
+	req.Regions = []RegionSpec{
+		{Provider: "hetzner", CloudRegion: "fsn1"},
+		{Provider: "hetzner", CloudRegion: "nbg1"},
+	}
+	req.BcpTopology = BcpTopologySingleRegion
+	err := req.Validate()
+	if err == nil {
+		t.Fatalf("bcpTopology=single-region with >=2 regions must be rejected as contradictory")
+	}
 }

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner_console_isolation_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner_console_isolation_test.go
@@ -22,6 +22,8 @@ func boolPtr(b bool) *bool { return &b }
 // 1. Omitted (nil pointer) → default TRUE — production posture preserved.
 func TestWriteTfvars_ConsoleIsolation_DefaultResolvesTrue(t *testing.T) {
 	req := tfvarsRequest(t)
+	// #4706 — deliberate single-region shape (implicit 1-region is rejected).
+	req.BcpTopology = BcpTopologySingleRegion
 	// ConsoleIsolationEnabled left nil (the omit-from-POST default).
 
 	out := writeTfvarsSharedPG(t, req)
@@ -34,6 +36,8 @@ func TestWriteTfvars_ConsoleIsolation_DefaultResolvesTrue(t *testing.T) {
 // 2. Explicit true → TRUE.
 func TestWriteTfvars_ConsoleIsolation_ExplicitTrueResolvesTrue(t *testing.T) {
 	req := tfvarsRequest(t)
+	// #4706 — deliberate single-region shape (implicit 1-region is rejected).
+	req.BcpTopology = BcpTopologySingleRegion
 	req.ConsoleIsolationEnabled = boolPtr(true)
 
 	out := writeTfvarsSharedPG(t, req)
@@ -47,6 +51,8 @@ func TestWriteTfvars_ConsoleIsolation_ExplicitTrueResolvesTrue(t *testing.T) {
 //    console re-parents onto the shared cilium-gateway).
 func TestWriteTfvars_ConsoleIsolation_ExplicitFalseResolvesFalse(t *testing.T) {
 	req := tfvarsRequest(t)
+	// #4706 — deliberate single-region shape (implicit 1-region is rejected).
+	req.BcpTopology = BcpTopologySingleRegion
 	req.ConsoleIsolationEnabled = boolPtr(false)
 
 	out := writeTfvarsSharedPG(t, req)

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner_shared_pg_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner_shared_pg_test.go
@@ -53,6 +53,8 @@ func writeTfvarsSharedPG(t *testing.T, req Request) map[string]any {
 // 1. The fire-body opt-in flips the substitution var to "true".
 func TestWriteTfvars_EnableSharedPostgres_OptInResolvesTrue(t *testing.T) {
 	req := tfvarsRequest(t)
+	// #4706 — deliberate single-region shape (implicit 1-region is rejected).
+	req.BcpTopology = BcpTopologySingleRegion
 	req.EnableSharedPostgres = true
 
 	out := writeTfvarsSharedPG(t, req)
@@ -65,6 +67,8 @@ func TestWriteTfvars_EnableSharedPostgres_OptInResolvesTrue(t *testing.T) {
 // 2. Absent (the default) keeps the gate OFF — safe-by-default preserved.
 func TestWriteTfvars_EnableSharedPostgres_DefaultResolvesFalse(t *testing.T) {
 	req := tfvarsRequest(t)
+	// #4706 — deliberate single-region shape (implicit 1-region is rejected).
+	req.BcpTopology = BcpTopologySingleRegion
 	// EnableSharedPostgres left at its zero value (false) — this is now the
 	// EXPLICIT opt-out shape (an operator who sets `"enableSharedPostgres":
 	// false` in the body for the byte-identical dedicated-cluster path).

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner_storage_class_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner_storage_class_test.go
@@ -42,6 +42,8 @@ func huaweiTfvarsRequest(t *testing.T) Request {
 //    default — never empty, never local-path.
 func TestWriteTfvars_StorageClass_HetznerDefault(t *testing.T) {
 	req := tfvarsRequest(t) // Hetzner base; StorageClass left empty.
+	// #4706 — deliberate single-region shape (implicit 1-region is rejected).
+	req.BcpTopology = BcpTopologySingleRegion
 
 	out := writeTfvarsSharedPG(t, req)
 
@@ -54,6 +56,8 @@ func TestWriteTfvars_StorageClass_HetznerDefault(t *testing.T) {
 //    default (evs-ssd) — the bp-huawei-evs-csi slot-55b default class.
 func TestWriteTfvars_StorageClass_HuaweiDefault(t *testing.T) {
 	req := huaweiTfvarsRequest(t) // StorageClass left empty.
+	// #4706 — deliberate single-region shape (implicit 1-region is rejected).
+	req.BcpTopology = BcpTopologySingleRegion
 
 	out := writeTfvarsSharedPG(t, req)
 
@@ -66,6 +70,8 @@ func TestWriteTfvars_StorageClass_HuaweiDefault(t *testing.T) {
 //    chosen by the user" requirement). Surrounding whitespace is trimmed.
 func TestWriteTfvars_StorageClass_ExplicitHonored(t *testing.T) {
 	req := tfvarsRequest(t)
+	// #4706 — deliberate single-region shape (implicit 1-region is rejected).
+	req.BcpTopology = BcpTopologySingleRegion
 	req.StorageClass = "  hcloud-volumes-xfs  " // operator chose a non-default class.
 
 	out := writeTfvarsSharedPG(t, req)
@@ -80,6 +86,8 @@ func TestWriteTfvars_StorageClass_ExplicitHonored(t *testing.T) {
 //    derivation), so a Regions-only payload still surfaces a class to tofu.
 func TestWriteTfvars_StorageClass_PerRegionFoldsToUmbrella(t *testing.T) {
 	req := tfvarsRequest(t)
+	// #4706 — deliberate single-region shape (implicit 1-region is rejected).
+	req.BcpTopology = BcpTopologySingleRegion
 	req.StorageClass = "" // umbrella empty.
 	req.Regions = []RegionSpec{
 		{
@@ -102,6 +110,8 @@ func TestWriteTfvars_StorageClass_PerRegionFoldsToUmbrella(t *testing.T) {
 //    shape sets the class at the top level).
 func TestWriteTfvars_StorageClass_UmbrellaWinsOverRegion(t *testing.T) {
 	req := tfvarsRequest(t)
+	// #4706 — deliberate single-region shape (implicit 1-region is rejected).
+	req.BcpTopology = BcpTopologySingleRegion
 	req.StorageClass = "hcloud-volumes" // umbrella set.
 	req.Regions = []RegionSpec{
 		{

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner_test.go
@@ -43,6 +43,9 @@ func jsonMarshal(v any) (string, error) {
 // provisioner-layer tests don't depend on handler-layer logic.
 func validBase() Request {
 	return Request{
+		// #4706 — deliberate single-region validation shape (the BCP
+		// default is multi-region; implicit 1-region is rejected).
+		BcpTopology:            BcpTopologySingleRegion,
 		OrgName:                "ACME",
 		OrgEmail:               "ops@acme.io",
 		SovereignFQDN:          "acme.openova.io",
@@ -92,6 +95,9 @@ func TestValidate_NonEmptyRegions_MirrorsIndex0ToSingularFields(t *testing.T) {
 		{Provider: "hetzner", CloudRegion: "fsn1", ControlPlaneSize: "cx42", WorkerSize: "cx32", WorkerCount: 2},
 		{Provider: "aws", CloudRegion: "eu-west-1", ControlPlaneSize: "m6i.xlarge", WorkerSize: "m6i.xlarge", WorkerCount: 0},
 	}
+	// validBase() declares single-region (#4706); this test is 2-region —
+	// clear it so Validate auto-derives active-hotstandby.
+	r.BcpTopology = ""
 
 	if err := r.Validate(); err != nil {
 		t.Fatalf("valid Regions should pass: %v", err)

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -4260,7 +4260,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.1.0"
+  version: "1.3.0"
   visibility: unlisted
   card:
     title: "Gateway API"
@@ -4277,7 +4277,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-gateway-api
-    version: "1.1.0"
+    version: "1.3.0"
   topology:
     supported:
       - singleton

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -3785,7 +3785,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-cilium
-    version: "1.4.7"
+    version: "1.4.8"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Problem (Refs #4706)

On a no-CCM Huawei node the gateway's only external path is the Huawei ELB → `node:<nodePort>` forward (#4690/#4691) — which §854 forbids. Both §854-clean alternatives are blocked on **cilium 1.16.5**:
- the `type=LoadBalancer` VIP can't route through Huawei's 1:1-NAT'd CP EIP (externally unreachable);
- envoy's privileged `:443` host bind is NACK'd by cilium 1.16.x's buggy gateway-api hostNetwork ("cannot bind 0.0.0.0:80", live-verified otech45-47) → it falls back to the `:30443` nodePort range.

## Fix

cilium 1.19 graduated gateway-api hostNetwork out of beta and fixes that bind. So the §854-clean permanent path is: **bump the CNI to 1.19.3 + enable `gatewayAPI.hostNetwork`** — cilium-envoy (already hostNetwork, podIP==nodeIP) then binds `node:443/:80` directly, and the Huawei ELB targets `node-IP:443/:80` (a hostPort, **not** a nodePort).

- `Chart.yaml`: cilium dependency `1.16.5 → 1.19.3`; bp-cilium `1.4.7 → 1.4.8`.
- `values.yaml`: `gatewayAPI.hostNetwork.enabled: true` (re-enabled — 1.19 fixes the 1.16.x bind bug).
- Lockstep → 1.4.8: `blueprint.yaml` + `01-cilium.yaml` slot pin + catalog-seed.

## Validation status — DRAFT, do NOT merge without a fresh-prov gate

- ✅ Render-validated: `helm template` with 1.19.3 + `hostNetwork=true` → clean, 1947 lines, no values-shape errors.
- ❌ NOT runtime-validated. This is a **major CNI bump** that reverses the #4690 (2026-07-02) ELB→nodePort design and has multi-cluster (DMZ/RTZ) reachability implications. cilium is the exact bootstrap layer whose fragility killed hw209–215, so this must be validated on a **fresh 2-region prov** — CNI installs, gateway binds `node:443`, console returns 200 off-cluster, cross-cluster reachability holds — before merge.

## Companion follow-up

Retarget the `gateway-elb` reconciler (`internal/providers/huawei/gateway_elb.go`) at `node:443/:80` (+ fix the empty-address member bug) once the 1.19 hostNetwork gateway shape is observed on a live cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
