### PR TITLE
fix(bp-agenity): move the dashboard image off the chart OCI repo — ghcr chart/image collision (Refs #4706)

### DIFF
--- a/.github/workflows/agenity-build.yaml
+++ b/.github/workflows/agenity-build.yaml
@@ -22,7 +22,13 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE: ghcr.io/openova-io/bp-agenity
+  # #4706-family (chart-repo collision): the image moved OFF the chart's OCI
+  # repo. Pushing the dashboard image to ghcr.io/openova-io/bp-agenity (tag =
+  # appVersion 0.9.7) squatted the bp-agenity CHART repo — any HelmRelease
+  # resolving `version: "*"` picked the IMAGE manifest (highest semver) and
+  # died with "manifest does not contain minimum number of descriptors".
+  # Chart repos carry ONLY charts; images live at their own plain name.
+  IMAGE: ghcr.io/openova-io/agenity
   # Pin the PUBLIC agenity (chepherd daemon) SOURCE ref the Containerfile
   # builds from. Never floating main: pinned to a COMMIT SHA on agenity main.
   # Pinned to the agenity-org/agenity#752 merge COMMIT (main HEAD as of

--- a/products/agenity/blueprint.yaml
+++ b/products/agenity/blueprint.yaml
@@ -14,7 +14,7 @@ spec:
   # 0.5.17 (#4604): chart adds a default-on external-HTTPS egress CNP +
   # seeds the openova MCP into ~/.claude.json for a standalone claude (durable
   # Pillar-4 North-Star wiring). Lockstep with products/agenity/chart.
-  version: 0.5.19
+  version: 0.5.20
   card:
     title: Agenity
     summary: |

--- a/products/agenity/chart/Chart.yaml
+++ b/products/agenity/chart/Chart.yaml
@@ -1,5 +1,14 @@
 apiVersion: v2
 name: bp-agenity
+# 0.5.20 (#4706-family, 2026-07-03): image repo moved ghcr.io/openova-io/
+# bp-agenity → ghcr.io/openova-io/agenity. The dashboard image (tag =
+# appVersion 0.9.7) squatted the bp-agenity CHART OCI repo, so any
+# HelmRelease resolving `version: "*"` picked the IMAGE manifest (0.9.7 >
+# 0.5.x) and failed with "manifest does not contain minimum number of
+# descriptors (2)" — live-caught on hw217 Org northstar. Chart repos carry
+# ONLY charts. Lockstep: blueprint.yaml 0.5.20 + catalog-seed 0.5.20 +
+# agenity-build.yaml IMAGE. The squatting tags (0.9.7/latest on bp-agenity)
+# are deleted from ghcr after this lands.
 description: |
   Agenity — multi-agent runtime + dashboard, packaged as an installable
   OpenOva Application Blueprint. A User installs Agenity into their own
@@ -179,7 +188,7 @@ type: application
 # same gateway bp-wordpress-tenant + the org console route attach to, #4054).
 # The old default rendered Accepted=False/InvalidHTTPRoute and the host 404'd
 # until the parentRef was hand-overridden. appVersion (image) unchanged.
-version: 0.5.19
+version: 0.5.20
 # 0.5.19 (#4624): the StatefulSet SELF-WIRES the OPENOVA_MCP_BEARER + RS256
 # verify-pubkey projection from the enabled per-Org mcpBearer ExternalSecret
 # (agenity.mcpBearerSecretName / agenity.mcpPubkeySecretName helpers) — an

--- a/products/agenity/chart/values.yaml
+++ b/products/agenity/chart/values.yaml
@@ -20,12 +20,12 @@ sovereignFqdn: ""
 
 # ── Agenity runtime image (upstream chepherd daemon + openova-mcp) ─────────
 image:
-  repository: ghcr.io/openova-io/bp-agenity
+  repository: ghcr.io/openova-io/agenity
   tag: ""                 # defaults to .Chart.AppVersion
   pullPolicy: IfNotPresent
 
 # ── Private-registry pull secret (#4111) ──────────────────────────────────
-# The agenity image (`ghcr.io/openova-io/bp-agenity`) is a PRIVATE
+# The agenity image (`ghcr.io/openova-io/agenity`) is a PRIVATE
 # ghcr.io/openova-io/* package, so both the seed-claude-creds init container
 # and the chepherd main container must pull it WITH credentials. The Sovereign
 # emberstack-reflector reflects a `ghcr-pull` dockerconfigjson Secret into

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5992,7 +5992,7 @@ spec:
   # projection from the enabled per-Org mcpBearer ExternalSecret (no door has to
   # hand-couple bearerSecret.name) so a fresh Org's agenity MCP tools/list
   # surfaces create_application. Lockstep with products/agenity/chart.
-  version: "0.5.19"
+  version: "0.5.20"
   visibility: listed
   card:
     title: "Agenity"
@@ -6022,7 +6022,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-agenity
-    version: 0.5.19
+    version: 0.5.20
   topology:
     supported:
       - singleton


### PR DESCRIPTION
The agenity dashboard image was pushed to the **chart's** ghcr repo (`bp-agenity:0.9.7` = an image manifest) — so `version: "*"` HRs resolve the image and fail (`manifest does not contain minimum number of descriptors`). Live-caught on hw217 Org `northstar` (Pillar-4 walk). Image → `ghcr.io/openova-io/agenity`; chart 0.5.20 + lockstep. Post-merge: delete the squatting tags; follow-up: pin the org-tenants generator version (no more `*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)