### PR TITLE
fix(provisioning): pin per-Org HR-app chart versions — no floating version:"*" (Refs #4706)

### DIFF
--- a/core/services/provisioning/gitops/gitops.go
+++ b/core/services/provisioning/gitops/gitops.go
@@ -142,6 +142,14 @@ type ManifestGenerator struct {
 	// harbor.<sovereign-fqdn> post-handover.
 	RegistryMirror string
 
+	// HelmReleaseAppVersions pins the per-Org HelmRelease-shaped catalog
+	// apps' chart versions by app slug (e.g. {"openclaw": "0.2.13",
+	// "stalwart-mail": "0.1.12"}) — #4706. A missing entry falls back to
+	// the floating `version: "*"` (see pinHRChartVersion for why floating
+	// is a hazard worth pinning away). Wired from
+	// CATALYST_HR_APP_CHART_VERSIONS in services/provisioning/main.go.
+	HelmReleaseAppVersions map[string]string
+
 	// CloudProvider is the IaC cloud provider this Sovereign runs on —
 	// "hetzner" or "huawei". It selects the block-storage StorageClass
 	// the per-tenant CNPG pair PVCs bind to, because the StorageClass
@@ -687,6 +695,8 @@ func (g *ManifestGenerator) GenerateAllWithAppConfigs(slug, planSlug string, app
 			slug:         slug,
 			parentDomain: g.parentDomain(),
 			kubeSecret:   hrKubeSecret,
+			// #4706 — pin the chart version (empty → floating "*").
+			chartVersion: g.HelmReleaseAppVersions[a],
 			// #4272: the resolvable SHARED-realm OIDC issuer
 			// (auth.<fqdn>/realms/sovereign) when this Sovereign runs no
 			// per-Org realm. Empty falls the HR templates back to the per-Org

--- a/core/services/provisioning/gitops/helmrelease_apps.go
+++ b/core/services/provisioning/gitops/helmrelease_apps.go
@@ -88,6 +88,10 @@ type helmReleaseAppOpts struct {
 	slug         string // Org subdomain == host namespace
 	parentDomain string // org-pool parent zone (e.g. omani.homes)
 	adminEmail   string // operator/admin email for stalwart
+	// chartVersion, when non-empty, pins the HR's chart version instead of
+	// the floating `version: "*"` (#4706 — see pinHRChartVersion). Populated
+	// per-app from ManifestGenerator.HelmReleaseAppVersions.
+	chartVersion string
 	// kubeSecret, when non-empty, is the flux-system Secret holding the Org
 	// vCluster kubeconfig (`tenant-<slug>-kubeconfig`). Set on the vcluster
 	// tier so the host helm-controller installs the chart INTO the vcluster;
@@ -110,14 +114,34 @@ type helmReleaseAppOpts struct {
 // HelmRelease-shaped catalog app. Returns "" for a slug that is not a
 // HelmRelease app (defence in depth — callers gate on isHelmReleaseApp first).
 func generateHelmReleaseApp(appSlug string, opt helmReleaseAppOpts) string {
+	var out string
 	switch appSlug {
 	case "openclaw":
-		return generateOpenClawHR(opt)
+		out = generateOpenClawHR(opt)
 	case "stalwart-mail":
-		return generateStalwartHR(opt)
+		out = generateStalwartHR(opt)
 	default:
 		return ""
 	}
+	return pinHRChartVersion(out, opt.chartVersion)
+}
+
+// pinHRChartVersion replaces the HR template's floating `version: "*"` with
+// the pinned chart version when one is configured (#4706). A floating "*"
+// resolves to the HIGHEST semver tag on the OCI repo — which is how ONE
+// mis-tagged artifact (the bp-agenity container image pushed to the CHART
+// repo as :0.9.7) broke every Org install at once, and how an org app could
+// silently jump a major. Empty version keeps "*" (the historical behaviour)
+// so a missing pin degrades to today's shape, never to a broken render —
+// the pin is a hardening, not a new hard dependency. Single choke-point on
+// the rendered YAML so every current and future HR-shaped app template is
+// covered without per-template printf surgery.
+func pinHRChartVersion(yaml, version string) string {
+	v := strings.TrimSpace(version)
+	if v == "" {
+		return yaml
+	}
+	return strings.Replace(yaml, `version: "*"`, fmt.Sprintf("version: %q", v), 1)
 }
 
 // kubeConfigBlock renders the HR-level spec.kubeConfig the host helm-controller
@@ -366,5 +390,23 @@ func sortedHelmReleaseApps(appSlugs []string) []string {
 		}
 	}
 	sort.Strings(out)
+	return out
+}
+
+
+// ParseHRAppVersions parses the CATALYST_HR_APP_CHART_VERSIONS wire format
+// ("slug=version,slug=version") into the HelmReleaseAppVersions map (#4706).
+// Malformed entries are skipped rather than fatal — a typo in one pin must
+// not take the provisioning service down; the affected app just falls back
+// to the floating "*" it always had.
+func ParseHRAppVersions(raw string) map[string]string {
+	out := map[string]string{}
+	for _, kv := range strings.Split(raw, ",") {
+		k, v, ok := strings.Cut(strings.TrimSpace(kv), "=")
+		k, v = strings.TrimSpace(k), strings.TrimSpace(v)
+		if ok && k != "" && v != "" {
+			out[k] = v
+		}
+	}
 	return out
 }

--- a/core/services/provisioning/gitops/helmrelease_apps_test.go
+++ b/core/services/provisioning/gitops/helmrelease_apps_test.go
@@ -336,3 +336,36 @@ func TestParentDomain_DefaultFallback(t *testing.T) {
 		t.Errorf("default parent-domain host wrong:\n%s", openclaw)
 	}
 }
+
+// TestGenerateHelmReleaseApp_PinsChartVersion (#4706): a configured pin
+// replaces the floating `version: "*"` in the rendered HR; an absent pin
+// keeps "*" (degrade-to-historical, never break the render).
+func TestGenerateHelmReleaseApp_PinsChartVersion(t *testing.T) {
+	pinned := generateHelmReleaseApp("openclaw", helmReleaseAppOpts{
+		slug: "acme", parentDomain: "omani.homes", chartVersion: "0.2.13",
+	})
+	if !strings.Contains(pinned, `version: "0.2.13"`) {
+		t.Fatalf("pinned render must carry version: \"0.2.13\"; got:\n%s", pinned)
+	}
+	if strings.Contains(pinned, `version: "*"`) {
+		t.Fatalf("pinned render must not retain the floating version: \"*\"")
+	}
+
+	floating := generateHelmReleaseApp("stalwart-mail", helmReleaseAppOpts{
+		slug: "acme", parentDomain: "omani.homes",
+	})
+	if !strings.Contains(floating, `version: "*"`) {
+		t.Fatalf("absent pin must fall back to the historical floating \"*\"; got:\n%s", floating)
+	}
+}
+
+// TestParseHRAppVersions (#4706): wire-format parse + malformed-entry skip.
+func TestParseHRAppVersions(t *testing.T) {
+	m := ParseHRAppVersions(" openclaw=0.2.13, stalwart-mail = 0.1.12 ,broken,=x,y= ")
+	if m["openclaw"] != "0.2.13" || m["stalwart-mail"] != "0.1.12" {
+		t.Fatalf("parse failed: %#v", m)
+	}
+	if len(m) != 2 {
+		t.Fatalf("malformed entries must be skipped, got %#v", m)
+	}
+}

--- a/core/services/provisioning/main.go
+++ b/core/services/provisioning/main.go
@@ -180,6 +180,14 @@ func main() {
 	// defaults to the Hetzner class inside gitops.cnpgStorageClass().
 	generator.CloudProvider = getEnv("CLOUD_PROVIDER", "hetzner")
 
+	// #4706 — pin the per-Org HelmRelease-shaped apps' chart versions so a
+	// funnel Org never installs off a floating `version: "*"` (one mis-tagged
+	// ghcr artifact broke every Org install; majors could jump ungated).
+	// Defaults = the current catalog-seed pins; operators override via env.
+	// A missing/malformed entry falls back to "*" (never fatal).
+	generator.HelmReleaseAppVersions = gitops.ParseHRAppVersions(getEnv(
+		"CATALYST_HR_APP_CHART_VERSIONS", "openclaw=0.2.13,stalwart-mail=0.1.12"))
+
 	// #4282/#4275 CROSS-REGION STANDBY: the flux-system Secret name holding
 	// region-B's (the STANDBY region's) host-cluster kubeconfig. The per-Org
 	// active-hot-standby bp-cnpg-pair is now split-side — the primary HR lands


### PR DESCRIPTION
The org-tenants generator floated every per-Org HR at `version: "*"` (highest semver on the repo) — one mis-tagged ghcr artifact broke every Org install (#4710), and majors could jump ungated. Pin at the dispatcher choke-point from `CATALYST_HR_APP_CHART_VERSIONS` (defaults = current catalog pins); empty pin degrades to the historical `"*"`, never a broken render. Tests + build/vet green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)