### PR TITLE
fix(gateway): console gateway → 8443/8080 host ports — no node:443 collision under hostNetwork (Refs #4706)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1232,7 +1232,7 @@ spec:
       #   stamp spec.parameters.sovereignFqdn so the openova-MCP URL points at
       #   this Sovereign, not the mothership. catalyst-api + application-controller
       #   image fixes (deploy-bot pins on next build). Lockstep w/ Chart.yaml.
-      version: 1.4.986
+      version: 1.4.987
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -832,6 +832,12 @@ write_files:
             CILIUM_GATEWAY_LB_IPAM_CIDRS: "${node_external_ip_value}/32"
             # #4706 — lockstep w/ the cilium-values hostNetwork block above.
             CILIUM_GATEWAY_HOSTNETWORK_ENABLED: "true"
+            # #4706 — console gateway binds 8443/8080 under hostNetwork (two
+            # Gateways cannot both bind node:443); the console ELB keeps public
+            # :443/:80 and forwards to node:8443/:8080. Lockstep: slot-13
+            # consoleGateway ports + main.tf console member/monitor ports.
+            CONSOLE_GATEWAY_HTTPS_PORT: "8443"
+            CONSOLE_GATEWAY_HTTP_PORT: "8080"
             SOVEREIGN_GATEWAY_HTTPS_PORT: "443"
             SOVEREIGN_GATEWAY_HTTP_PORT: "80"
             HARBOR_PROXY_MIRROR_ENDPOINT: "http://212.72.24.20:5000"

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -273,6 +273,35 @@ resource "huaweicloud_networking_secgroup_rule" "ingress_443" {
   description       = "Cilium Gateway HTTPS"
 }
 
+# #4706 — console gateway hostNetwork ports (8443/8080): the console ELB
+# forwards public :443/:80 to these node host ports. Same 0/0 shape as the
+# 443 rule above (traffic still fronts through the console ELB EIP).
+resource "huaweicloud_networking_secgroup_rule" "ingress_8443" {
+  for_each          = { for r in var.regions : r.code => r }
+  security_group_id = huaweicloud_networking_secgroup.region[each.key].id
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 8443
+  port_range_max    = 8443
+  remote_ip_prefix  = "0.0.0.0/0"
+  description       = "Cilium Gateway HTTPS"
+}
+
+
+resource "huaweicloud_networking_secgroup_rule" "ingress_8080" {
+  for_each          = { for r in var.regions : r.code => r }
+  security_group_id = huaweicloud_networking_secgroup.region[each.key].id
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 8080
+  port_range_max    = 8080
+  remote_ip_prefix  = "0.0.0.0/0"
+  description       = "Cilium Gateway HTTPS"
+}
+
+
 resource "huaweicloud_networking_secgroup_rule" "ingress_80" {
   for_each          = { for r in var.regions : r.code => r }
   security_group_id = huaweicloud_networking_secgroup.region[each.key].id
@@ -1576,7 +1605,7 @@ resource "huaweicloud_elb_member" "console_https" {
   count         = local.console_member_count
   pool_id       = huaweicloud_elb_pool.console_https[0].id
   address       = local.primary_lb_node_ips[count.index]
-  protocol_port = 443
+  protocol_port = 8443
   subnet_id     = huaweicloud_vpc_subnet.region[local.region_keys[0]].ipv4_subnet_id
 }
 
@@ -1584,7 +1613,7 @@ resource "huaweicloud_elb_member" "console_http" {
   count         = local.console_member_count
   pool_id       = huaweicloud_elb_pool.console_http[0].id
   address       = local.primary_lb_node_ips[count.index]
-  protocol_port = 80
+  protocol_port = 8080
   subnet_id     = huaweicloud_vpc_subnet.region[local.region_keys[0]].ipv4_subnet_id
 }
 
@@ -1592,7 +1621,7 @@ resource "huaweicloud_elb_monitor" "console_https" {
   count       = local.console_isolation_on ? 1 : 0
   pool_id     = huaweicloud_elb_pool.console_https[0].id
   protocol    = "TCP"
-  port        = 443
+  port        = 8443
   interval    = 10
   timeout     = 5
   max_retries = 3
@@ -1602,7 +1631,7 @@ resource "huaweicloud_elb_monitor" "console_http" {
   count       = local.console_isolation_on ? 1 : 0
   pool_id     = huaweicloud_elb_pool.console_http[0].id
   protocol    = "TCP"
-  port        = 80
+  port        = 8080
   interval    = 10
   timeout     = 5
   max_retries = 3

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3408,7 +3408,7 @@ name: bp-catalyst-platform
 #   sovereign-fqdn) so GET /catalog/regions returns the Sovereign's REAL
 #   regions instead of [] — the marketplace BCP picker stops falling back to
 #   the hardcoded Hetzner list.
-version: 1.4.986
+version: 1.4.987
 # 1.4.980 — #4696: SMTP host default mail.openova.io -> stalwart-web.stalwart.svc.cluster.local
 #           (in-cluster svc, matches auth.go code default) — kill flaky-upstream-DNS PIN-delivery 502s.
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/


### PR DESCRIPTION
hw218 live-caught: two Gateways cannot both bind node:443 under the hostNetwork gateway — console ELB landed on the PRIMARY listener → 404 on every console host. Console gateway now binds unprivileged 8443/8080 (host ports, NOT nodePorts) on huawei via new substitutes; console ELB keeps public :443/:80; Hetzner untouched (defaults). tofu 12/12+7/7 PASS, CM renders port 8443, isolation preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)