### PR TITLE
fix(gateway): wire console-port substitute into slot-13 — #4715 shipped it inert (Refs #4706)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1317,6 +1317,21 @@ spec:
   # for console/admin/api. All chart-level Catalyst service config (image refs,
   # OTel endpoints, NATS subjects) lives in products/catalyst/chart/values.yaml.
   values:
+    # #4706 — console gateway listener host-ports, per-provider. This wires the
+    # CONSOLE_GATEWAY_{HTTPS,HTTP}_PORT cloud-init substitutes into the chart's
+    # consoleGateway values so the sovereign-tls-vars CM (CONSOLE_LISTENERS_YAML)
+    # renders the console Gateway on the right ports. Under the huawei
+    # hostNetwork gateway (cilium 1.19.3) TWO Gateways cannot both bind
+    # node:443, so huawei cloud-init sets 8443/8080 (unprivileged host ports,
+    # NOT nodePorts); the console ELB forwards public :443/:80 → node:8443/:8080.
+    # Hetzner leaves the substitutes unset → 443/80 (hostNetwork off — the
+    # hcloud-ccm LB Service shape has no bind collision). WITHOUT this wiring the
+    # chart default (443/80) always wins and the console Gateway collides with
+    # the PRIMARY gateway's node:443 → 404 on every console host (hw218, #4715
+    # regression: the substitute was emitted but never consumed here).
+    consoleGateway:
+      httpsPort: ${CONSOLE_GATEWAY_HTTPS_PORT:=443}
+      httpPort: ${CONSOLE_GATEWAY_HTTP_PORT:=80}
     # G91.catalyst-console-admin-self-grant (#2659): the Sovereign operator
     # (deployment.OrgEmail; from the sovereign-fqdn ConfigMap orgEmail key)
     # is auto-granted the realm-role `catalyst-admin` (composite over

--- a/products/catalyst/bootstrap/api/internal/provisioner/cilium_values_parity_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/cilium_values_parity_test.go
@@ -30,15 +30,15 @@
 // Coverage strategy: substring-presence checks on canonical YAML lines.
 // We deliberately avoid YAML unmarshalling + structural equality for
 // two reasons:
-//   1. The cloud-init `cilium-values.yaml` is INSIDE a tftpl `content: |`
-//      block with OpenTofu interpolations adjacent in the same file —
-//      unmarshalling the surrounding tftpl is non-trivial and adds a
-//      Terraform-specific test dep.
-//   2. The chart values.yaml carries `cilium:` as the umbrella subchart
-//      key while the bootstrap install consumes the upstream cilium/cilium
-//      chart directly (values must be at TOP LEVEL). Structural equality
-//      across a renaming boundary requires a sub-tree slice, which is
-//      more code to maintain than the focused presence checks below.
+//  1. The cloud-init `cilium-values.yaml` is INSIDE a tftpl `content: |`
+//     block with OpenTofu interpolations adjacent in the same file —
+//     unmarshalling the surrounding tftpl is non-trivial and adds a
+//     Terraform-specific test dep.
+//  2. The chart values.yaml carries `cilium:` as the umbrella subchart
+//     key while the bootstrap install consumes the upstream cilium/cilium
+//     chart directly (values must be at TOP LEVEL). Structural equality
+//     across a renaming boundary requires a sub-tree slice, which is
+//     more code to maintain than the focused presence checks below.
 //
 // The presence checks lock down the load-bearing keys identified by
 // the otech8 incident postmortem. New operator-curated values added
@@ -228,12 +228,13 @@ func TestCiliumValuesParity_BootstrapMatchesOverlayKeys(t *testing.T) {
 
 // TestCiliumValuesParity_GatewayHostNetworkLockstep (#4706) locks the
 // three-way gateway-api hostNetwork agreement:
-//   1. the cloud-init cilium-values.yaml block carries a huawei-conditional
-//      `hostNetwork:` + `enabled: true` (bootstrap install binds node:443/:80),
-//   2. the bootstrap-kit slot-01 HR wires
-//      `${CILIUM_GATEWAY_HOSTNETWORK_ENABLED...}` (the HR upgrade agrees),
-//   3. cloud-init's flux-bootstrap substitutes set
-//      CILIUM_GATEWAY_HOSTNETWORK_ENABLED: "true" on huawei.
+//  1. the cloud-init cilium-values.yaml block carries a huawei-conditional
+//     `hostNetwork:` + `enabled: true` (bootstrap install binds node:443/:80),
+//  2. the bootstrap-kit slot-01 HR wires
+//     `${CILIUM_GATEWAY_HOSTNETWORK_ENABLED...}` (the HR upgrade agrees),
+//  3. cloud-init's flux-bootstrap substitutes set
+//     CILIUM_GATEWAY_HOSTNETWORK_ENABLED: "true" on huawei.
+//
 // Drift between (1) and (2)+(3) is the #491 class: the bootstrap install and
 // the slot-01 upgrade disagree mid-Phase-1 and the gateway flaps between a
 // host bind and a Service-only shape. The ELB targets node:443/:80, so a
@@ -320,6 +321,33 @@ func TestCiliumValuesParity_ConsolePortNoCollision(t *testing.T) {
 		t.Errorf("CONSOLE_GATEWAY_HTTP_PORT must NOT be 80 — collides with the PRIMARY gateway's node:80 host bind (#4706)")
 	}
 }
+
+// TestConsoleGatewaySlot13ConsumesPortSubstitute (#4706, #4715 regression) —
+// the cloud-init emits CONSOLE_GATEWAY_HTTPS_PORT, but that is INERT unless
+// slot-13's bp-catalyst-platform HR values consume it into consoleGateway.
+// httpsPort (the chart's sovereign-tls-vars CM reads .Values.consoleGateway).
+// #4715 shipped the substitute WITHOUT this slot-13 wiring — the console
+// Gateway defaulted to 443 and collided even on fresh provs. This locks the
+// wiring so it cannot be dropped again silently.
+func TestConsoleGatewaySlot13ConsumesPortSubstitute(t *testing.T) {
+	cwd, _ := os.Getwd()
+	root := filepath.Clean(filepath.Join(cwd, "..", "..", "..", "..", "..", ".."))
+	raw, err := os.ReadFile(filepath.Join(root, "clusters", "_template", "bootstrap-kit", "13-bp-catalyst-platform.yaml"))
+	if err != nil {
+		t.Fatalf("read slot-13: %v", err)
+	}
+	slot := string(raw)
+	for _, want := range []string{
+		"consoleGateway:",
+		"httpsPort: ${CONSOLE_GATEWAY_HTTPS_PORT",
+		"httpPort: ${CONSOLE_GATEWAY_HTTP_PORT",
+	} {
+		if !strings.Contains(slot, want) {
+			t.Errorf("slot-13 must wire the console port substitute into HR values — missing %q (#4715 regression: substitute emitted but never consumed → console 443 collision)", want)
+		}
+	}
+}
+
 func TestCiliumValuesParity_BootstrapHelmVersionMatchesChartPin(t *testing.T) {
 	tpl := readCloudInit(t)
 


### PR DESCRIPTION
Self-caught repairing hw218: #4715 emitted `CONSOLE_GATEWAY_HTTPS_PORT` + taught the CM to read it, but slot-13 never passed it into `consoleGateway.httpsPort` — so the console Gateway defaulted to 443 and collided on node:443 under hostNetwork **even on fresh provs**. #4715 validated with `--set`, masking the gap. Now wired + validated end-to-end without `--set`; parity test locks it (companion to #4717).

🤖 Generated with [Claude Code](https://claude.com/claude-code)