### PR TITLE
fix(org): deprovision per-Org DNS on delete — stale records → Console 000 on re-prov (Refs #4459)

### DIFF
--- a/core/controllers/organization/internal/controller/tenant_dns.go
+++ b/core/controllers/organization/internal/controller/tenant_dns.go
@@ -223,11 +223,21 @@ func (r *Reconciler) teardownTenantDNS(ctx context.Context, org *orgapi.Organiza
 		subdomain = org.Spec.Slug
 	}
 	baseURL := strings.TrimSpace(r.PoolPowerDNSURL)
-	apiKey := strings.TrimSpace(r.PoolPowerDNSAPIKey)
+	// #4459 self-heal parity: resolve the key the SAME way the write path
+	// (reconcileTenantDNS) does — prefer the env-frozen value but fall back to a
+	// LIVE read of the bridged Secret (resolvePoolPowerDNSAPIKey, #4290/#4179).
+	// Previously teardown used the FROZEN r.PoolPowerDNSAPIKey only, so on a
+	// Sovereign where the key lives ONLY in the reflected Secret (env empty) the
+	// up-path wrote the per-Org pool A-records but the down-path skipped —
+	// leaving stale console.<slug>.<pool> / *.<slug>.<pool> records that survive
+	// the Org and point a later same-slug re-prov at a DEAD console-ELB IP (the
+	// exact #4459 poisoning this teardown exists to prevent). Now teardown
+	// works whenever the write path worked.
+	apiKey := r.resolvePoolPowerDNSAPIKey(ctx)
 	if baseURL == "" || apiKey == "" {
 		// No central-pdns writer wired — nothing this controller can delete.
-		r.Log.Info("tenant-dns teardown: skipped — central pool PowerDNS not wired",
-			"organization", org.Name)
+		r.Log.Info("tenant-dns teardown: skipped — central pool PowerDNS not wired (or key not yet reflected)",
+			"organization", org.Name, "have_url", baseURL != "", "have_key", apiKey != "")
 		return false, nil
 	}
 

--- a/products/catalyst/bootstrap/api/internal/handler/organization_dns.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_dns.go
@@ -195,7 +195,7 @@ func (p DefaultOrganizationDNSProvisioner) ProvisionFreeSubdomain(ctx context.Co
 	// ChangeType=REPLACE makes every write an unconditional upsert, so a
 	// stale same-name record (if one ever existed) is overwritten rather
 	// than skipped.
-	for _, prefix := range []string{"*", "console", "wordpress", "openclaw", "mail", "keycloak"} {
+	for _, prefix := range theFreeSubdomainPrefixes {
 		fqdn := fmt.Sprintf("%s.%s.%s.", prefix, subdomain, parentZone)
 		rrsets = append(rrsets, pdnsRRSet{
 			Name:       fqdn,
@@ -208,6 +208,42 @@ func (p DefaultOrganizationDNSProvisioner) ProvisionFreeSubdomain(ctx context.Co
 		})
 	}
 	return writer.PatchRRSets(ctx, zone, rrsets)
+}
+
+// theFreeSubdomainPrefixes is the per-Org host prefix set ProvisionFreeSubdomain
+// writes and DeprovisionFreeSubdomain deletes — kept in ONE place so the write
+// and delete paths can never drift (the #4459 leak class: write N, delete <N,
+// the surplus records survive the Org and shadow a re-prov's wildcard with a
+// dead IP).
+var theFreeSubdomainPrefixes = []string{"*", "console", "wordpress", "openclaw", "mail", "keycloak"}
+
+// DeprovisionFreeSubdomain implements OrganizationDNSProvisioner. DELETEs the
+// per-Org pool A-records ProvisionFreeSubdomain wrote (#4459 — a stale record
+// surviving an Org delete poisons a later same-slug re-prov with a dead
+// console IP → Console 000). No ingress IP is needed: PowerDNS
+// changetype=DELETE removes the whole rrset by name+type. Idempotent (deleting
+// an absent rrset is a 2xx no-op), so it is safe on an Org that never
+// provisioned DNS.
+func (p DefaultOrganizationDNSProvisioner) DeprovisionFreeSubdomain(ctx context.Context, subdomain, parentZone string) error {
+	writer := p.Writer
+	if p.PoolWriter != nil {
+		writer = p.PoolWriter
+	}
+	if writer == nil {
+		return errors.New("powerdns writer not wired")
+	}
+	if strings.TrimSpace(parentZone) == "" {
+		return errors.New("parent zone unconfigured")
+	}
+	rrsets := make([]pdnsRRSet, 0, len(theFreeSubdomainPrefixes))
+	for _, prefix := range theFreeSubdomainPrefixes {
+		rrsets = append(rrsets, pdnsRRSet{
+			Name:       fmt.Sprintf("%s.%s.%s.", prefix, subdomain, parentZone),
+			Type:       "A",
+			ChangeType: "DELETE",
+		})
+	}
+	return writer.PatchRRSets(ctx, parentZone, rrsets)
 }
 
 // ValidateBYOCNAME implements OrganizationDNSProvisioner. Resolves
@@ -261,6 +297,11 @@ type NoopOrganizationDNSProvisioner struct{}
 
 // ProvisionFreeSubdomain is a no-op.
 func (NoopOrganizationDNSProvisioner) ProvisionFreeSubdomain(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
+// DeprovisionFreeSubdomain is a no-op.
+func (NoopOrganizationDNSProvisioner) DeprovisionFreeSubdomain(_ context.Context, _, _ string) error {
 	return nil
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
@@ -103,6 +103,14 @@ type OrganizationDNSProvisioner interface {
 	// hostnames. Idempotent; returns nil on "record already exists
 	// with the same RDATA" outcomes.
 	ProvisionFreeSubdomain(ctx context.Context, subdomain, parentZone, ingressIPv4 string) error
+	// DeprovisionFreeSubdomain removes the per-Org pool A-records that
+	// ProvisionFreeSubdomain wrote (console + app sister hosts under
+	// <subdomain>.<parentZone>). Called on Organization delete so a stale
+	// record does not survive the Org and point a later same-slug re-prov at
+	// a DEAD console-ELB IP — the #4459 Console-000 poisoning. Idempotent:
+	// deleting an already-absent rrset is a 2xx no-op on PowerDNS, so this is
+	// safe to call even when the Org never provisioned DNS.
+	DeprovisionFreeSubdomain(ctx context.Context, subdomain, parentZone string) error
 	// ValidateBYOCNAME resolves `console.<byo_domain>` and confirms
 	// it CNAMEs to one of acceptedTargets (or, when nil/empty, to
 	// the supplied legacyTarget). Returns a structured error when the
@@ -885,6 +893,20 @@ func (h *Handler) HandleDeleteOrganization(w http.ResponseWriter, r *http.Reques
 			if err := deps.TenantRegistry.Delete(host); err != nil {
 				h.log.Warn("org-tenant: registry delete best-effort failed", "err", err)
 			}
+		}
+	}
+	// #4459 — remove the per-Org pool DNS records so a later same-slug re-prov
+	// does not inherit a stale console/app A-record pointing at a DEAD ELB IP
+	// (Console 000). Best-effort + idempotent (delete of an absent rrset is a
+	// 2xx no-op), mirroring the overlay/registry teardowns above. Free-subdomain
+	// mode only: a BYO-domain Org's records live in the customer's own zone.
+	if deps.DNS != nil && rec.DomainMode == store.OrganizationDomainFreeSubdomain {
+		parentZone := strings.TrimSpace(rec.ParentDomain)
+		if parentZone == "" {
+			parentZone = rec.OTECHFQDN
+		}
+		if err := deps.DNS.DeprovisionFreeSubdomain(r.Context(), rec.Subdomain, parentZone); err != nil {
+			h.log.Warn("org-tenant: DNS deprovision best-effort failed", "err", err, "subdomain", rec.Subdomain)
 		}
 	}
 

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
@@ -53,8 +53,10 @@ func (f *fakeGitOps) DeleteTenantOverlay(_ context.Context, rec store.Organizati
 type fakeDNS struct {
 	mu             sync.Mutex
 	provisionCalls []string
+	deproviCalls   []string
 	cnameCalls     []string
 	provisionErr   error
+	deprovisionErr error
 	cnameErr       error
 }
 
@@ -63,6 +65,13 @@ func (f *fakeDNS) ProvisionFreeSubdomain(_ context.Context, sub, parent, ip stri
 	defer f.mu.Unlock()
 	f.provisionCalls = append(f.provisionCalls, sub+":"+parent+":"+ip)
 	return f.provisionErr
+}
+
+func (f *fakeDNS) DeprovisionFreeSubdomain(_ context.Context, sub, parent string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deproviCalls = append(f.deproviCalls, sub+":"+parent)
+	return f.deprovisionErr
 }
 
 func (f *fakeDNS) ValidateBYOCNAME(_ context.Context, byo, legacy string, accepted ...string) error {
@@ -1761,5 +1770,37 @@ func TestLoadOrganizationParentDomainsFromEnv_Custom(t *testing.T) {
 		if p.Role != "org-pool" {
 			t.Errorf("non-primary entry should be org-pool: %+v", p)
 		}
+	}
+}
+
+// TestDeleteOrganization_DeprovisionsDNS (#4459) — an Org delete must remove
+// the per-Org pool DNS records the provision path wrote, so a later same-slug
+// re-prov does not inherit a stale console/app A-record → Console 000.
+func TestDeleteOrganization_DeprovisionsDNS(t *testing.T) {
+	h, _, dns, _, _, _ := newTestHandlerWithOrganizationDeps(t)
+
+	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/organizations",
+		bytes.NewReader([]byte(`{"subdomain":"acme","admin_email":"a@b.test"}`)))
+	createReq.Header.Set("Content-Type", "application/json")
+	createW := httptest.NewRecorder()
+	h.HandleCreateOrganization(createW, createReq)
+	var created orgTenantResponse
+	_ = json.Unmarshal(createW.Body.Bytes(), &created)
+
+	delReq := httptest.NewRequest(http.MethodDelete,
+		"/api/v1/organizations/"+created.OrganizationID, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", created.OrganizationID)
+	delReq = delReq.WithContext(context.WithValue(delReq.Context(), chi.RouteCtxKey, rctx))
+	delW := httptest.NewRecorder()
+	h.HandleDeleteOrganization(delW, delReq)
+
+	dns.mu.Lock()
+	defer dns.mu.Unlock()
+	if len(dns.deproviCalls) != 1 {
+		t.Fatalf("delete must call DeprovisionFreeSubdomain exactly once (#4459 — stale DNS poisons re-prov); got %d: %v", len(dns.deproviCalls), dns.deproviCalls)
+	}
+	if !strings.HasPrefix(dns.deproviCalls[0], "acme:") {
+		t.Errorf("deprovision must target the Org subdomain 'acme'; got %q", dns.deproviCalls[0])
 	}
 }


### PR DESCRIPTION
Found by reading the delete path: `ProvisionFreeSubdomain` writes 6 per-Org pool A-records but the DNS interface had no delete method and `HandleDeleteOrganization` never removed them → a same-slug re-prov inherits stale records pointing at a dead ELB IP = **Console 000**. Added `DeprovisionFreeSubdomain` (DELETEs the shared prefix set, idempotent), wired into delete best-effort, + test. Companion to #4719 on the other DNS write path. build/vet/tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)