### PR TITLE
fix(cutover): auto-trigger Job budgets overran activeDeadline — DeadlineExceeded on every cold-pull fresh prov (0.1.102) (Refs #4723)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -719,7 +719,7 @@ spec:
       # node-local `GET http://127.0.0.1:4001/v2/` serving probe so catalyst-api's
       # daemonset-wait cannot green (→ step-07 catalyst-api re-pull) while the
       # dfdaemon mirror has 0 Ready pods (#4649 condition → connection-refused).
-      version: 0.1.101
+      version: 0.1.102
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.101  # lockstep with chart/Chart.yaml (#4637 step-07 dfdaemon-serving v2-ack gate)
+  version: 0.1.102  # lockstep with chart/Chart.yaml (#4637 step-07 dfdaemon-serving v2-ack gate)
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1509,7 +1509,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.101
+version: 0.1.102
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -1289,7 +1289,7 @@ trigger:
   # the 30m HR cap. Bumped from 720s (12m) on Fix #152 (chart 0.1.27)
   # after prov #23 hit the 14m Job deadline before catalyst-api came
   # up — cold-start budget needs ~2× headroom on slow Sovereigns.
-  autoWaitForAPISeconds: 1500
+  autoWaitForAPISeconds: 600
   # #4632 (chart 0.1.91): how long the trigger POST RETRIES on HTTP 425
   # (handover-completion gate) before giving up (exit 0; operator can fire
   # via CTA). On a FRESH prov this hook fires at slot-06a install time —
@@ -1301,24 +1301,33 @@ trigger:
   # at 13:56:41 but the lone POST 425'd at 13:54:48, ~2 min too early →
   # cutover stuck progressPercent=0). The Job now polls every 15s within
   # this budget so the trigger re-fires the moment handover seals the
-  # archive — zero-touch, no CTA click (founder rule #933). 1500s (25m)
-  # comfortably covers a slow Hetzner/Huawei handover post-the-/healthz-wait.
-  autoHandoverWaitSeconds: 1500
+  # archive — zero-touch, no CTA click (founder rule #933). #4723 (chart
+  # 0.1.102): 1500s -> 900s. The long wait only needs to cover the #4632
+  # race class (~2min between chart-install and seal on
+  # fireCutoverOnHandover provs). On a PERMANENT Sovereign the seal lands
+  # only after full phase-1 convergence (45min after hook start on hw220)
+  # — no in-Job wait can bridge that, and it does not need to: the #4669
+  # level-triggered reconciler self-heals sealed-but-uncut after this Job
+  # exits 0. Shrinking the wait restores real pod-start margin under the
+  # activeDeadline (see autoTimeoutSeconds below).
+  autoHandoverWaitSeconds: 900
   # Overall cap on the auto-trigger Job runtime. activeDeadlineSeconds
   # on the Job spec — anything longer means catalyst-api is sick and
   # the operator should investigate. The Job exiting at this deadline
   # is non-fatal for the chart install (the cutover engine already
   # runs detached inside catalyst-api once /start returns 200).
-  # Must stay below the HelmRelease install/upgrade timeout (30m =
-  # 1800s post-Fix-#152) so the Job ends and the hook unblocks before
-  # Helm gives up. Bumped from 840s (14m) on Fix #152 (chart 0.1.27)
-  # after prov #23 wedged at 3 consecutive DeadlineExceeded — 29m
-  # leaves a 1m buffer below the 30m HR cap. #4632 (chart 0.1.91): raised
-  # 1740 → 2100 (35m) so the deadline covers the /healthz reachability wait
-  # (autoWaitForAPISeconds, ≤300s effective once the API is up) PLUS the
-  # full autoHandoverWaitSeconds 425-retry window (1500s) PLUS a ~5m buffer.
-  # The HelmRelease install/upgrade timeout is also raised to 40m in the
-  # 06a slot overlay lockstep so the hook still unblocks before Helm gives up.
+  # Must stay below the HelmRelease install/upgrade timeout (40m per the
+  # 06a slot overlay) so the Job ends and the hook unblocks before Helm
+  # gives up. History: 840s (Fix #152) -> 1740 -> 2100 (#4632). #4723
+  # (chart 0.1.102): the #4632 arithmetic was broken — worst-case script
+  # time was autoWaitForAPISeconds(1500) + autoHandoverWaitSeconds(1500)
+  # = 3000s INSIDE this 2100s deadline, and even the happy path (API up)
+  # left ~600s for pod scheduling + a COLD image pull (~10min on a fresh
+  # prov, no warm registry pre-cutover) → the pod was killed mid-retry
+  # before its own graceful exit-0 (live: hw220 attempt 1 DeadlineExceeded
+  # at exactly +2100s, a wasted 26-min Helm remediate/reinstall cycle).
+  # Now: 600 + 900 = 1500s worst-case script time under the unchanged
+  # 2100s deadline = a real 600s pod-start margin on EVERY path.
   autoTimeoutSeconds: 2100
   # TTL on the completed Job — kept for audit so operators can read
   # the trigger Pod logs if something looks wrong.


### PR DESCRIPTION
## Live evidence (hw220 / 907629bc3577355b, 2026-07-03)

bp-self-sovereign-cutover@0.1.101 install attempt 1 failed `job bp-self-sovereign-cutover-auto-trigger failed: DeadlineExceeded` at exactly Job-creation +2100s → Helm uninstall-remediated → a wasted 26-minute reinstall cycle while phase-1 sat at 62/63. Attempt 2 survived only because the image was cached.

## Root cause

`autoWaitForAPISeconds: 1500` + `autoHandoverWaitSeconds: 1500` = 3000s worst-case script time inside `autoTimeoutSeconds: 2100` (the Job's activeDeadlineSeconds). Happy path left ~600s for pod scheduling + a COLD image pull (~10 min on a fresh prov — no warm local registry pre-cutover), so the pod was killed before its own graceful exit-0.

## Fix (values only, no template change)

- `autoWaitForAPISeconds` 1500 → 600
- `autoHandoverWaitSeconds` 1500 → 900 — post-#4669 the level-triggered reconciler self-heals sealed-but-uncut, so the in-Job retry only needs to cover the #4632 ~2min race class, not convergence-length gaps (hw220's seal landed 45min after hook start; no in-Job budget can bridge that by design)
- `autoTimeoutSeconds` 2100 unchanged → every path now has ≥600s pod-start margin
- lockstep: Chart.yaml + blueprint.yaml + bootstrap-kit slot 06a → 0.1.102

## Gates

- `helm lint`: 0 failed
- rendered Job asserts: `activeDeadlineSeconds: 2100`, `WAIT_TIMEOUT_SECONDS=600`, `HANDOVER_WAIT_SECONDS=900`

Refs #4723 #3379 #4632 #4669

🤖 Generated with [Claude Code](https://claude.com/claude-code)