### PR TITLE
fix(cutover): hostNetwork-era wedges — registry-TLS gate for step-06 + step-08 budget 3600s (0.1.103) (Refs #4727)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -719,7 +719,7 @@ spec:
       # node-local `GET http://127.0.0.1:4001/v2/` serving probe so catalyst-api's
       # daemonset-wait cannot green (→ step-07 catalyst-api re-pull) while the
       # dfdaemon mirror has 0 Ready pods (#4649 condition → connection-refused).
-      version: 0.1.102
+      version: 0.1.103
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.102  # lockstep with chart/Chart.yaml (#4637 step-07 dfdaemon-serving v2-ack gate)
+  version: 0.1.103  # lockstep with chart/Chart.yaml (#4637 step-07 dfdaemon-serving v2-ack gate)
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1509,7 +1509,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.102
+version: 0.1.103
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
@@ -263,7 +263,21 @@ data:
                   echo "[helmrepository-patches] Phase -1 OK: Gateway ${GATEWAY_NAMESPACE}/${GATEWAY_NAME} Programmed=True"
                   break
                 fi
-                echo "[helmrepository-patches] Phase -1: Gateway exists but Programmed=${programmed:-<unset>}; retrying in 15s"
+                # hostNetwork gateway mode (#4708): cilium assigns NO LB
+                # address, so Programmed stays False FOREVER while envoy
+                # serves node:443 directly (live: hw220 both Gateways
+                # AddressNotAssigned with console answering 200). Probe the
+                # ACTUAL invariant the rewrite depends on instead:
+                # registry.<fqdn> answering TLS. Any HTTP code (401/200/404)
+                # proves TCP+TLS+HTTP through the gateway; only a transport
+                # failure (000) keeps waiting.
+                reg_code=$(curl -sk -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 15 "https://registry.${SOVEREIGN_FQDN}/v2/" 2>/dev/null || echo "000")
+                if [ "${reg_code}" != "000" ]; then
+                  gw_ready="true"
+                  echo "[helmrepository-patches] Phase -1 OK: Programmed=${programmed:-False} but https://registry.${SOVEREIGN_FQDN}/v2/ answers TLS (HTTP ${reg_code}) — hostNetwork gateway serves without an assigned address (#4708)"
+                  break
+                fi
+                echo "[helmrepository-patches] Phase -1: Gateway exists but Programmed=${programmed:-<unset>} and registry probe=${reg_code}; retrying in 15s"
               else
                 echo "[helmrepository-patches] Phase -1: Gateway ${GATEWAY_NAMESPACE}/${GATEWAY_NAME} not yet present; retrying in 15s"
               fi

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -1132,10 +1132,13 @@ stepTimeouts:
   # (force-reconcile GitRepository + bootstrap-kit Kustomization and wait
   # for Step-06's durable git-push to converge BEFORE the window opens)
   # + buffer for the assert sweep / policy teardown. Was 900s before
-  # #3526 added the pivot-poll; bumped to 1200s so the worst-case
-  # 300s-poll-then-600s-window run still has headroom under the Job's
-  # activeDeadlineSeconds.
-  egressBlockTestSeconds: 1200
+  # #3526 added the pivot-poll (-> 1200s). #4723-family (2026-07-03,
+  # live hw220): the fresh-pull rollout proof over EVERY external-registry
+  # workload on a 2-region 12-node prov needs >1200s — the Job hit
+  # DeadlineExceeded at exactly +1200s mid-proof (NOT an egress failure)
+  # and the engine looped 20-minute failures. 3600s gives the proof room;
+  # the deny-egress window itself stays 600s.
+  egressBlockTestSeconds: 3600
   # Step 09 (gitea-token-mint, TBD-C18) — short-lived: a single
   # Gitea API mint + validate + Secret patch + best-effort rollout.
   # 600s leaves generous headroom for the provisioning Deployment


### PR DESCRIPTION
Durable twins of the two live patches that unwedged hw220's first zero-touch cutover attempt today. Both changes are byte-mirrors of the CM patches proven live (step-06 completed in ~25s after 30+ min of deadlock; step-08 re-running with room).

- **step-06 Phase -1 gate**: in #4708 hostNetwork gateway mode, Gateways stay `Programmed=False / AddressNotAssigned` forever while envoy serves node:443 directly — the gate could NEVER pass. Added the honest fallback: `https://registry.<fqdn>/v2/` answering TLS (any HTTP code) satisfies the gate's actual invariant.
- **step-08 budget**: `egressBlockTestSeconds` 1200 → 3600 — the fresh-pull rollout proof over every workload on a 2-region 12-node prov was killed by DeadlineExceeded at exactly +1200s (not an egress failure). Deny-egress window itself unchanged (600s).
- Lockstep: chart 0.1.103 + blueprint.yaml + bootstrap-kit slot 06a.

Gates: helm lint 0 failed; rendered manifests carry the probe text + `activeDeadlineSeconds: 3600`.

Refs #4727 #3379 #4708 #4723

🤖 Generated with [Claude Code](https://claude.com/claude-code)