### PR TITLE
fix(agenity): per-Org MCP OPENOVA_MCP_TENANT_HOST must be the Org console host, not the Sovereign — create_application 404 on every fresh Org

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/application_parameters.go
+++ b/products/catalyst/bootstrap/api/internal/handler/application_parameters.go
@@ -1,6 +1,10 @@
 package handler
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
 
 // agenityMCPBearerSecretName is the in-namespace K8s Secret the agenity
 // chart's externalsecret-mcp-bearer.yaml materialises and the StatefulSet
@@ -94,13 +98,32 @@ const agenityMCPBearerRemoteKeyPrefix = "catalyst/agenity/"
 // caller's Org ref (the path is secret/catalyst/agenity/<slug>/mcp-bearer);
 // empty orgSlug ⇒ skip the mcpBearer stamp (we can't scope the path).
 //
+// For bp-agenity we ALSO stamp `openovaMCP.tenantHost` with the ORG's public
+// console host (#4624, live-proven on hw220 2026-07-04). The openova-MCP
+// forwards this value as `X-Tenant-Host` on the org-scoped install path
+// (POST /api/v1/org/applications); catalyst-api resolves the caller's Org
+// namespace from it via the tenant registry. The catalyst-api base URL is the
+// SOVEREIGN console host (console.<sovereignFqdn>) — which is NOT a registered
+// tenant — so when tenantHost is unset the chart's fallback derivation
+// (agenity.mcpTenantHost helper: httpRoute.hostnames empty → gate host
+// agenity.<sovereignFqdn> → console.<sovereignFqdn>) emits the Sovereign host
+// and EVERY agent create_application call 404s `tenant-not-registered`
+// (`MCP error -32010: upstream error`). The BSS-door GitOps overlay
+// (orgTenantBPAgenity) already resolves correctly (its httpRoute.hostnames[0]
+// = agenity.<slug>.<pool> derives console.<slug>.<pool>); this stamp closes
+// the Application-CR install door. orgConsoleHost is resolved from the tenant
+// registry (h.orgConsoleHostFor); empty ⇒ no stamp (mothership /
+// Catalyst-Zero / unresolvable — fail-closed, the chart's existing behaviour
+// applies), and an explicit caller value is never clobbered (same deference
+// as stampAgenitySovereignFqdn).
+//
 // blueprint may carry the `bp-` prefix or not; topology is the canonical
 // (or legacy-dialect) placement token already chosen by the caller.
 // sovereignFQDN is the Sovereign's own FQDN (e.g. "omantel.biz"); empty on
 // the mothership / Catalyst-Zero, where the agenity install is not a
 // production path — leaving sovereignFqdn unset keeps the chart's existing
 // fail-closed default behaviour.
-func defaultedParameters(blueprint, topology, sovereignFQDN, orgSlug string, explicit map[string]interface{}) map[string]interface{} {
+func defaultedParameters(blueprint, topology, sovereignFQDN, orgSlug, orgConsoleHost string, explicit map[string]interface{}) map[string]interface{} {
 	out := make(map[string]interface{}, len(explicit)+1)
 	for k, v := range explicit {
 		out[k] = v
@@ -109,6 +132,7 @@ func defaultedParameters(blueprint, topology, sovereignFQDN, orgSlug string, exp
 	if isAgenityBlueprint(blueprint) {
 		stampAgenitySovereignFqdn(out, sovereignFQDN)
 		stampAgenityMCPBearer(out, orgSlug)
+		stampAgenityMCPTenantHost(out, orgConsoleHost)
 	}
 
 	if len(out) > 0 {
@@ -197,6 +221,107 @@ func stampAgenityMCPBearer(params map[string]interface{}, orgSlug string) {
 	mcp["mcpBearer"] = mcpBearer
 
 	params["openovaMCP"] = mcp
+}
+
+// stampAgenityMCPTenantHost sets `parameters.openovaMCP.tenantHost` to the
+// Org's public console host (console.<slug>.<poolParentDomain>, e.g.
+// console.nstar.omani.homes) so the chart's OPENOVA_MCP_TENANT_HOST env — the
+// X-Tenant-Host the MCP forwards on org-scoped calls — targets the ORG host,
+// not the Sovereign console host (#4624, live-proven on hw220: with
+// TENANT_HOST=console.hw220.omani.works every create_application 404'd; the
+// moment it was set to console.nstar.omani.homes the same call returned 201).
+// The chart's `agenity.mcpTenantHost` helper prefers an explicit
+// openovaMCP.tenantHost over any derivation, so this value flows straight to
+// the env. OPENOVA_MCP_CATALYST_API_URL is untouched — it keeps deriving
+// https://console.<sovereignFqdn> from the separately-stamped sovereignFqdn.
+//
+// No-op when:
+//   - orgConsoleHost is empty (mothership / Catalyst-Zero / registry has no
+//     row for this Org — fail-closed, the chart's existing behaviour holds), or
+//   - the caller already pinned a non-empty openovaMCP.tenantHost (we never
+//     clobber an explicit value — same deference as stampAgenitySovereignFqdn).
+//
+// The merge is additive on the openovaMCP block, preserving any other
+// sub-keys (bearerSecret / mcpBearer / …) a caller or sibling stamp supplied.
+func stampAgenityMCPTenantHost(params map[string]interface{}, orgConsoleHost string) {
+	host := strings.ToLower(strings.TrimSpace(orgConsoleHost))
+	if host == "" {
+		return
+	}
+
+	mcp, _ := params["openovaMCP"].(map[string]interface{})
+	if mcp == nil {
+		mcp = map[string]interface{}{}
+	}
+	if existing, ok := mcp["tenantHost"].(string); ok && strings.TrimSpace(existing) != "" {
+		return
+	}
+	mcp["tenantHost"] = host
+	params["openovaMCP"] = mcp
+}
+
+// orgConsoleHostFor resolves the Org's public console host
+// (console.<slug>.<poolParentDomain>) for an Org ref from the tenant
+// registry — the SAME table the org-scoped install path resolves
+// X-Tenant-Host against, so the stamped tenantHost is by construction a
+// registered tenant. Returns "" when the registry is unwired (mothership /
+// CI) or holds no row for this Org (fail-closed — the caller skips the
+// stamp).
+func (h *Handler) orgConsoleHostFor(orgRef string) string {
+	if h == nil || h.tenantRegistry == nil {
+		return ""
+	}
+	return orgConsoleHostFromRegistrations(h.tenantRegistry.List(), orgRef)
+}
+
+// orgConsoleHostFromRegistrations is the pure resolver behind
+// orgConsoleHostFor. The Org ref arrives in several dialects depending on
+// the door: the real Org namespace (`org-<uuid>` or the slug — the org-scoped
+// install door forces this), a bare slug ("nstar"), or the dotted Org zone
+// ("nstar.omani.homes"). Matching, in preference order:
+//
+//  1. registration.OrganizationNamespace == orgNamespace(ref) — the exact
+//     namespace binding (covers the org-door's forced namespace and a
+//     slug-named namespace);
+//  2. the Org slug of the registration's Host (console.<slug>.<pool> →
+//     <slug>, via orgSlugFromHost) == the ref's leading DNS label (covers
+//     the sovereign-admin door's dotted Org-zone refs).
+//
+// Only tenant_kind=org rows participate. Ties resolve to the
+// lexicographically-smallest host so the result is deterministic regardless
+// of registry iteration order.
+func orgConsoleHostFromRegistrations(regs []store.TenantRegistration, orgRef string) string {
+	ref := strings.TrimSpace(orgRef)
+	if ref == "" {
+		return ""
+	}
+	ns := orgNamespace(ref)
+	slug := leadingDNSLabel(ref)
+	nsMatch, slugMatch := "", ""
+	for _, reg := range regs {
+		if reg.TenantKind != store.TenantKindOrg {
+			continue
+		}
+		host := strings.ToLower(strings.TrimSpace(reg.Host))
+		if host == "" {
+			continue
+		}
+		if regNS := strings.ToLower(strings.TrimSpace(reg.OrganizationNamespace)); regNS != "" && regNS == ns {
+			if nsMatch == "" || host < nsMatch {
+				nsMatch = host
+			}
+			continue
+		}
+		if slug != "" && orgSlugFromHost(host) == slug {
+			if slugMatch == "" || host < slugMatch {
+				slugMatch = host
+			}
+		}
+	}
+	if nsMatch != "" {
+		return nsMatch
+	}
+	return slugMatch
 }
 
 // setIfAbsentMap sets key=val only when the destination has no non-empty

--- a/products/catalyst/bootstrap/api/internal/handler/application_parameters_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/application_parameters_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/openova-io/openova/core/controllers/pkg/validate"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/instances"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
 )
 
 // bpPostgresConfigSchema mirrors platform/postgres/blueprint.yaml
@@ -63,7 +64,7 @@ func bpPostgresConfigSchema() map[string]interface{} {
 // ── defaultedParameters unit table ──────────────────────────────────────
 
 func TestDefaultedParameters_PostgresNoValues_SeedsSingletonMode(t *testing.T) {
-	got := defaultedParameters("bp-postgres", "singleton", "", "", nil)
+	got := defaultedParameters("bp-postgres", "singleton", "", "", "", nil)
 	if got == nil {
 		t.Fatal("defaultedParameters returned nil — must always be a non-null object")
 	}
@@ -78,7 +79,7 @@ func TestDefaultedParameters_PostgresNoValues_SeedsSingletonMode(t *testing.T) {
 
 func TestDefaultedParameters_PostgresActiveHotStandby(t *testing.T) {
 	for _, topo := range []string{"active-hot-standby", "active-hotstandby", "active-active", "active-passive"} {
-		got := defaultedParameters("postgres", topo, "", "", nil)
+		got := defaultedParameters("postgres", topo, "", "", "", nil)
 		tm := got["topology"].(map[string]interface{})["mode"]
 		if tm != "active-hot-standby" {
 			t.Fatalf("topology %q → topology.mode = %v, want active-hot-standby", topo, tm)
@@ -87,7 +88,7 @@ func TestDefaultedParameters_PostgresActiveHotStandby(t *testing.T) {
 }
 
 func TestDefaultedParameters_NonPostgresNoValues_EmptyObjectNotNil(t *testing.T) {
-	got := defaultedParameters("bp-grafana", "singleton", "", "", nil)
+	got := defaultedParameters("bp-grafana", "singleton", "", "", "", nil)
 	if got == nil {
 		t.Fatal("non-postgres parameters returned nil — must be at least an empty object")
 	}
@@ -101,7 +102,7 @@ func TestDefaultedParameters_ExplicitValuesPreservedVerbatim(t *testing.T) {
 		"topology":  map[string]interface{}{"mode": "active-hot-standby"},
 		"databases": []interface{}{map[string]interface{}{"name": "wp", "owner": "wp"}},
 	}
-	got := defaultedParameters("bp-postgres", "singleton", "", "", explicit)
+	got := defaultedParameters("bp-postgres", "singleton", "", "", "", explicit)
 	if got["topology"].(map[string]interface{})["mode"] != "active-hot-standby" {
 		t.Fatalf("explicit topology.mode must be preserved (not overwritten by chosen topology), got %#v", got)
 	}
@@ -115,7 +116,7 @@ func TestDefaultedParameters_ExplicitValuesPreservedVerbatim(t *testing.T) {
 //    console.openova.io. ───────────────────────────────────────────────────
 
 func TestDefaultedParameters_AgenityNoValues_StampsSovereignFqdn(t *testing.T) {
-	got := defaultedParameters("bp-agenity", "singleton", "omantel.biz", "nstar2", nil)
+	got := defaultedParameters("bp-agenity", "singleton", "omantel.biz", "nstar2", "", nil)
 	if got["sovereignFqdn"] != "omantel.biz" {
 		t.Fatalf("agenity parameters must stamp sovereignFqdn=omantel.biz, got %#v", got)
 	}
@@ -125,7 +126,7 @@ func TestDefaultedParameters_AgenityWithExplicitValues_StampsSovereignFqdn(t *te
 	explicit := map[string]interface{}{
 		"agent": map[string]interface{}{"model": "claude-opus-4-8"},
 	}
-	got := defaultedParameters("agenity", "singleton", "t99.omani.works", "t99org.omani.homes", explicit)
+	got := defaultedParameters("agenity", "singleton", "t99.omani.works", "t99org.omani.homes", "", explicit)
 	if got["sovereignFqdn"] != "t99.omani.works" {
 		t.Fatalf("agenity sovereignFqdn must be stamped even with explicit params, got %#v", got)
 	}
@@ -136,7 +137,7 @@ func TestDefaultedParameters_AgenityWithExplicitValues_StampsSovereignFqdn(t *te
 
 func TestDefaultedParameters_AgenityExplicitSovereignFqdnWins(t *testing.T) {
 	explicit := map[string]interface{}{"sovereignFqdn": "pinned.example"}
-	got := defaultedParameters("bp-agenity", "singleton", "omantel.biz", "nstar2", explicit)
+	got := defaultedParameters("bp-agenity", "singleton", "omantel.biz", "nstar2", "", explicit)
 	if got["sovereignFqdn"] != "pinned.example" {
 		t.Fatalf("a caller-pinned sovereignFqdn must NOT be overwritten, got %#v", got)
 	}
@@ -145,7 +146,7 @@ func TestDefaultedParameters_AgenityExplicitSovereignFqdnWins(t *testing.T) {
 func TestDefaultedParameters_AgenityEmptyFQDN_NoStamp(t *testing.T) {
 	// Mothership / Catalyst-Zero: empty FQDN → leave sovereignFqdn unset so
 	// the chart's fail-closed default applies (no bogus console host).
-	got := defaultedParameters("bp-agenity", "singleton", "", "", nil)
+	got := defaultedParameters("bp-agenity", "singleton", "", "", "", nil)
 	if _, ok := got["sovereignFqdn"]; ok {
 		t.Fatalf("empty FQDN must NOT stamp sovereignFqdn, got %#v", got)
 	}
@@ -195,7 +196,7 @@ func assertAgenityMCPBearerWiring(t *testing.T, params map[string]interface{}, w
 
 func TestDefaultedParameters_AgenityNoValues_StampsMCPBearerWiring(t *testing.T) {
 	// FQDN-form org ref must collapse to the leading DNS label for the path.
-	got := defaultedParameters("bp-agenity", "singleton", "omantel.biz", "nstar2.omani.homes", nil)
+	got := defaultedParameters("bp-agenity", "singleton", "omantel.biz", "nstar2.omani.homes", "", nil)
 	assertAgenityMCPBearerWiring(t, got, "nstar2")
 }
 
@@ -203,7 +204,7 @@ func TestDefaultedParameters_AgenityEmptyOrgSlug_NoMCPBearerStamp(t *testing.T) 
 	// No Org slug ⇒ we cannot scope the per-Org OpenBao path; skip the stamp
 	// (a path with an empty/cross-Org slug would defeat seedMCPBearer's
 	// own-Org guarantee). sovereignFqdn still stamps independently.
-	got := defaultedParameters("bp-agenity", "singleton", "omantel.biz", "", nil)
+	got := defaultedParameters("bp-agenity", "singleton", "omantel.biz", "", "", nil)
 	if _, ok := got["openovaMCP"]; ok {
 		t.Fatalf("empty org slug must NOT stamp openovaMCP wiring, got %#v", got)
 	}
@@ -213,7 +214,7 @@ func TestDefaultedParameters_AgenityEmptyOrgSlug_NoMCPBearerStamp(t *testing.T) 
 }
 
 func TestDefaultedParameters_NonAgenity_NoMCPBearerStamp(t *testing.T) {
-	got := defaultedParameters("bp-postgres", "singleton", "omantel.biz", "nstar2", nil)
+	got := defaultedParameters("bp-postgres", "singleton", "omantel.biz", "nstar2", "", nil)
 	if _, ok := got["openovaMCP"]; ok {
 		t.Fatalf("non-agenity Blueprint must NOT get openovaMCP wiring, got %#v", got)
 	}
@@ -225,7 +226,7 @@ func TestDefaultedParameters_AgenityExplicitMCPBearerWins(t *testing.T) {
 			"bearerSecret": map[string]interface{}{"name": "pinned-secret", "key": "bearer"},
 		},
 	}
-	got := defaultedParameters("bp-agenity", "singleton", "omantel.biz", "nstar2", explicit)
+	got := defaultedParameters("bp-agenity", "singleton", "omantel.biz", "nstar2", "", explicit)
 	mcp := got["openovaMCP"].(map[string]interface{})
 	bs := mcp["bearerSecret"].(map[string]interface{})
 	if bs["name"] != "pinned-secret" {
@@ -245,7 +246,7 @@ func TestNewApplicationUnstructured_Agenity_StampsSovereignFqdn(t *testing.T) {
 		EnvironmentRef:  "agnstar-prod",
 		Placement:       applicationPlacement{Mode: "singleton", Regions: []string{"primary"}},
 	}
-	obj := newApplicationUnstructured(req, "omantel.biz")
+	obj := newApplicationUnstructured(req, "omantel.biz", "console.agnstar.omani.homes")
 	params, found, _ := unstructured.NestedMap(obj.Object, "spec", "parameters")
 	if !found || params == nil {
 		t.Fatalf("spec.parameters absent/nil for agenity install")
@@ -255,15 +256,23 @@ func TestNewApplicationUnstructured_Agenity_StampsSovereignFqdn(t *testing.T) {
 	}
 	// #4610 — the install-door CR must ALSO wire the per-Org MCP bearer.
 	assertAgenityMCPBearerWiring(t, params, "agnstar")
+	// #4624 — the install-door CR must ALSO pin the ORG console host as the
+	// MCP tenant host (X-Tenant-Host), while sovereignFqdn (above) keeps the
+	// catalyst-api URL on the SOVEREIGN console host.
+	mcp := params["openovaMCP"].(map[string]interface{})
+	if mcp["tenantHost"] != "console.agnstar.omani.homes" {
+		t.Fatalf("openovaMCP.tenantHost = %v, want console.agnstar.omani.homes", mcp["tenantHost"])
+	}
 }
 
 func TestNewApplicationCRFromSeed_Agenity_StampsSovereignFqdn(t *testing.T) {
 	seed := instances.ApplicationSeed{
-		Name:          "agenity",
-		Namespace:     "agnstar.omani.homes",
-		Blueprint:     "bp-agenity",
-		Topology:      "singleton",
-		SovereignFQDN: "omantel.biz",
+		Name:           "agenity",
+		Namespace:      "agnstar.omani.homes",
+		Blueprint:      "bp-agenity",
+		Topology:       "singleton",
+		SovereignFQDN:  "omantel.biz",
+		OrgConsoleHost: "console.agnstar.omani.homes",
 	}
 	obj := newApplicationCRFromSeed(seed)
 	params, found, _ := unstructured.NestedMap(obj.Object, "spec", "parameters")
@@ -275,6 +284,102 @@ func TestNewApplicationCRFromSeed_Agenity_StampsSovereignFqdn(t *testing.T) {
 	}
 	// #4610 — the create-instance seed door must ALSO wire the per-Org MCP bearer.
 	assertAgenityMCPBearerWiring(t, params, "agnstar")
+	// #4624 — the seed door must ALSO pin the ORG console host as the MCP
+	// tenant host.
+	mcp := params["openovaMCP"].(map[string]interface{})
+	if mcp["tenantHost"] != "console.agnstar.omani.homes" {
+		t.Fatalf("openovaMCP.tenantHost = %v, want console.agnstar.omani.homes", mcp["tenantHost"])
+	}
+}
+
+// ── #4624: bp-agenity stamps openovaMCP.tenantHost = the ORG console host so
+//    OPENOVA_MCP_TENANT_HOST (the X-Tenant-Host the MCP forwards on the
+//    org-scoped install path) targets the Org, NOT the Sovereign console
+//    host. Live-proven on hw220 2026-07-04: with
+//    TENANT_HOST=console.hw220.omani.works every create_application returned
+//    404 tenant-not-registered (MCP error -32010); setting it to
+//    console.nstar.omani.homes made the same call return 201. ──────────────
+
+func TestDefaultedParameters_AgenityStampsOrgConsoleTenantHost(t *testing.T) {
+	// The decisive #4624 case: orgSlug=nstar + pool domain omani.homes ⇒ the
+	// stamped TENANT_HOST is console.nstar.omani.homes while the catalyst-api
+	// URL derivation input (sovereignFqdn) stays the SOVEREIGN fqdn.
+	got := defaultedParameters("bp-agenity", "singleton", "hw220.omani.works", "nstar", "console.nstar.omani.homes", nil)
+	if got["sovereignFqdn"] != "hw220.omani.works" {
+		t.Fatalf("sovereignFqdn must stay the SOVEREIGN fqdn (the catalyst-api URL derives https://console.<sovereignFqdn> from it), got %#v", got)
+	}
+	mcp, ok := got["openovaMCP"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("agenity parameters missing openovaMCP block: %#v", got)
+	}
+	if mcp["tenantHost"] != "console.nstar.omani.homes" {
+		t.Fatalf("openovaMCP.tenantHost = %v, want console.nstar.omani.homes (the ORG console host — a Sovereign-host X-Tenant-Host 404s tenant-not-registered)", mcp["tenantHost"])
+	}
+}
+
+func TestDefaultedParameters_AgenityExplicitTenantHostWins(t *testing.T) {
+	explicit := map[string]interface{}{
+		"openovaMCP": map[string]interface{}{"tenantHost": "console.pinned.example"},
+	}
+	got := defaultedParameters("bp-agenity", "singleton", "hw220.omani.works", "nstar", "console.nstar.omani.homes", explicit)
+	mcp := got["openovaMCP"].(map[string]interface{})
+	if mcp["tenantHost"] != "console.pinned.example" {
+		t.Fatalf("a caller-pinned openovaMCP.tenantHost must NOT be overwritten, got %#v", mcp["tenantHost"])
+	}
+	// The additive sibling stamp (#4610 mcpBearer wiring) must still land.
+	assertAgenityMCPBearerWiring(t, got, "nstar")
+}
+
+func TestDefaultedParameters_AgenityEmptyOrgConsoleHost_NoTenantHostStamp(t *testing.T) {
+	// Mothership / Catalyst-Zero / registry-miss: empty orgConsoleHost ⇒ no
+	// tenantHost stamp (fail-closed — the chart keeps its existing
+	// behaviour); the sibling stamps are unaffected.
+	got := defaultedParameters("bp-agenity", "singleton", "hw220.omani.works", "nstar", "", nil)
+	mcp, ok := got["openovaMCP"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("agenity parameters missing openovaMCP block (the #4610 bearer stamp): %#v", got)
+	}
+	if _, present := mcp["tenantHost"]; present {
+		t.Fatalf("empty orgConsoleHost must NOT stamp openovaMCP.tenantHost, got %#v", mcp["tenantHost"])
+	}
+}
+
+func TestDefaultedParameters_NonAgenity_NoTenantHostStamp(t *testing.T) {
+	got := defaultedParameters("bp-postgres", "singleton", "hw220.omani.works", "nstar", "console.nstar.omani.homes", nil)
+	if _, ok := got["openovaMCP"]; ok {
+		t.Fatalf("non-agenity Blueprint must NOT get openovaMCP wiring, got %#v", got)
+	}
+}
+
+// orgConsoleHostFromRegistrations — the tenant-registry resolver behind the
+// #4624 stamp. Must resolve every Org-ref dialect the two install doors
+// carry (real namespace / bare slug / dotted Org zone), ignore non-org rows,
+// and fail closed on a miss.
+func TestOrgConsoleHostFromRegistrations(t *testing.T) {
+	regs := []store.TenantRegistration{
+		// The Sovereign's own console row (tenant_kind=otech) must NEVER win.
+		{Host: "console.hw220.omani.works", TenantID: "self", TenantKind: store.TenantKindOTECH},
+		// Funnel/reconcile-shaped org row: OrganizationNamespace = slug.
+		{Host: "console.nstar.omani.homes", TenantID: "t-nstar", TenantKind: store.TenantKindOrg, OrganizationNamespace: "nstar"},
+		// BSS-shaped org row: OrganizationNamespace = org-<uuid>.
+		{Host: "console.acme.omani.rest", TenantID: "t-acme", TenantKind: store.TenantKindOrg, OrganizationNamespace: "org-t-acme"},
+	}
+	cases := []struct {
+		ref, want string
+	}{
+		{"nstar", "console.nstar.omani.homes"},             // bare slug → ns match
+		{"nstar.omani.homes", "console.nstar.omani.homes"}, // dotted Org zone → slug-of-host match
+		{"org-t-acme", "console.acme.omani.rest"},          // forced real namespace (org door) → ns match
+		{"acme.omani.rest", "console.acme.omani.rest"},     // dotted zone for the BSS-shaped row
+		{"hw220.omani.works", ""},                          // the Sovereign itself is NOT an Org — fail closed
+		{"unknown", ""},                                    // registry miss — fail closed
+		{"", ""},                                           // empty ref — fail closed
+	}
+	for _, c := range cases {
+		if got := orgConsoleHostFromRegistrations(regs, c.ref); got != c.want {
+			t.Errorf("orgConsoleHostFromRegistrations(%q) = %q, want %q", c.ref, got, c.want)
+		}
+	}
 }
 
 // ── configSchema round-trip: producers emit validating parameters ───────
@@ -349,7 +454,7 @@ func TestNewApplicationUnstructured_PostgresNoParams_ValidatesConfigSchema(t *te
 		EnvironmentRef:  "omantel-biz-prod",
 		Placement:       applicationPlacement{Mode: "singleton", Regions: []string{"primary"}},
 	}
-	obj := newApplicationUnstructured(req, "")
+	obj := newApplicationUnstructured(req, "", "")
 	params, found, _ := unstructured.NestedMap(obj.Object, "spec", "parameters")
 	if !found || params == nil {
 		t.Fatalf("spec.parameters absent/nil — newApplicationUnstructured must always stamp a non-null object")

--- a/products/catalyst/bootstrap/api/internal/handler/applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications.go
@@ -499,7 +499,16 @@ func (h *Handler) installApplicationCore(w http.ResponseWriter, r *http.Request,
 	if sovereignFQDN == "" {
 		sovereignFQDN = h.sovereignFQDN()
 	}
-	obj := newApplicationUnstructured(body, sovereignFQDN)
+	// #4624 — resolve the ORG's public console host (console.<slug>.<pool>)
+	// from the tenant registry so the agenity install stamps
+	// spec.parameters.openovaMCP.tenantHost. Without it the chart falls back
+	// to console.<sovereignFqdn> for OPENOVA_MCP_TENANT_HOST — the Sovereign
+	// host is NOT a registered tenant, so every agent create_application
+	// 404'd `tenant-not-registered` (live-proven on hw220 2026-07-04: 404
+	// with the Sovereign host, 201 the moment the env was set to the Org
+	// host). Empty (mothership / no registry row) ⇒ no stamp, fail-closed.
+	orgConsoleHost := h.orgConsoleHostFor(body.OrganizationRef)
+	obj := newApplicationUnstructured(body, sovereignFQDN, orgConsoleHost)
 	created, err := client.Resource(ApplicationGVR()).Namespace(appNS).Create(
 		r.Context(), obj, metav1.CreateOptions{})
 	if err != nil {
@@ -971,7 +980,13 @@ func isSovereignOperatorClaim(claims *auth.Claims) bool {
 // install request. Sets the spec to mirror the API surface exactly so a
 // downstream Get returns the same shape the caller posted (modulo
 // metadata + status).
-func newApplicationUnstructured(req applicationInstallRequest, sovereignFQDN string) *unstructured.Unstructured {
+//
+// orgConsoleHost — the Org's public console host (console.<slug>.<pool>),
+// resolved by the caller from the tenant registry (h.orgConsoleHostFor).
+// Stamped as spec.parameters.openovaMCP.tenantHost for bp-agenity (#4624)
+// so the agent-side MCP's X-Tenant-Host targets the ORG, not the Sovereign
+// console host. Empty ⇒ no stamp (fail-closed).
+func newApplicationUnstructured(req applicationInstallRequest, sovereignFQDN, orgConsoleHost string) *unstructured.Unstructured {
 	obj := &unstructured.Unstructured{}
 	obj.SetAPIVersion(ApplicationGVR().Group + "/" + ApplicationGVR().Version)
 	obj.SetKind("Application")
@@ -1052,7 +1067,7 @@ func newApplicationUnstructured(req applicationInstallRequest, sovereignFQDN str
 	// tree valid; the controller's admission webhook + this handler's
 	// validate.Parameters call have already gated explicit params against
 	// configSchema.
-	spec["parameters"] = defaultedParameters(req.BlueprintRef.Name, canonMode, sovereignFQDN, req.OrganizationRef, req.Parameters)
+	spec["parameters"] = defaultedParameters(req.BlueprintRef.Name, canonMode, sovereignFQDN, req.OrganizationRef, orgConsoleHost, req.Parameters)
 	_ = unstructured.SetNestedMap(obj.Object, spec, "spec")
 	return obj
 }

--- a/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
@@ -860,6 +860,15 @@ func (h *Handler) HandleCreateInstance(w http.ResponseWriter, r *http.Request) {
 	// derives the openova-MCP catalyst-api URL from it; empty → the mothership
 	// console.openova.io). No-op for non-agenity Blueprints.
 	seed.SovereignFQDN = h.sovereignFQDN()
+	// #4624 — stamp the ORG's public console host (console.<slug>.<pool>,
+	// from the tenant registry) so a bp-agenity instance gets
+	// spec.parameters.openovaMCP.tenantHost: the OPENOVA_MCP_TENANT_HOST the
+	// agent's MCP forwards as X-Tenant-Host must be the Org host, NOT the
+	// Sovereign console host derived from sovereignFqdn (that host is not a
+	// registered tenant → every agent create_application 404'd, live-proven
+	// on hw220 2026-07-04). Empty (mothership / no registry row) ⇒ no stamp,
+	// fail-closed. No-op for non-agenity Blueprints.
+	seed.OrgConsoleHost = h.orgConsoleHostFor(seed.Namespace)
 
 	// #3598 (EPIC #3597) — ensure the Org/Environment namespace exists
 	// BEFORE creating any Application CR. Without this the create races the
@@ -2194,7 +2203,7 @@ func newApplicationCRFromSeed(seed instances.ApplicationSeed) *unstructured.Unst
 	// reconciled (phase=Failed). Now seed.Values (when present) is used
 	// verbatim; otherwise we emit at least `{}` plus a configSchema-valid
 	// topology.mode for bp-postgres.
-	spec["parameters"] = defaultedParameters(seed.Blueprint, seed.Topology, seed.SovereignFQDN, seed.Namespace, seed.Values)
+	spec["parameters"] = defaultedParameters(seed.Blueprint, seed.Topology, seed.SovereignFQDN, seed.Namespace, seed.OrgConsoleHost, seed.Values)
 	_ = unstructured.SetNestedMap(obj.Object, spec, "spec")
 	return obj
 }

--- a/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
@@ -1746,6 +1746,16 @@ spec:
     # under catalyst/ (the only KV sub-tree a Sovereign can WRITE via the
     # catalyst-api-write policy; vault-region1's role is read-only).
     openovaMCP:
+      # #4624 — the ORG console host the openova-MCP forwards as
+      # X-Tenant-Host on the org-scoped install path. The chart would derive
+      # the same value from httpRoute.hostnames[0] ({{.AgenityHost}} →
+      # console.<slug>.<pool>), but pinning it makes the contract explicit
+      # and byte-identical with the Application-CR install door's
+      # defaultedParameters stamp. It MUST be the Org host — the catalyst-api
+      # URL host (console.<sovereignFqdn>) is NOT a registered tenant, so a
+      # Sovereign-host X-Tenant-Host 404s tenant-not-registered on every
+      # agent create_application (live-proven on hw220 2026-07-04).
+      tenantHost: {{.ConsoleHost}}
       bearerSecret:
         name: agenity-mcp-bearer
         key: bearer

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
@@ -459,6 +459,10 @@ func TestRenderOrganizationOverlay_AgenityMCPBearerWiring(t *testing.T) {
 	}
 	for _, want := range []string{
 		"openovaMCP:",
+		// #4624 — the ORG console host pinned as the MCP tenant host
+		// (X-Tenant-Host). MUST be the Org host, never the Sovereign console
+		// host (which is not a registered tenant → create_application 404s).
+		"tenantHost: console.acme.omani.homes",
 		"bearerSecret:",
 		"name: agenity-mcp-bearer",
 		"key: bearer",

--- a/products/catalyst/bootstrap/api/internal/handler/placement_3373_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/placement_3373_test.go
@@ -20,7 +20,7 @@ func TestNewApplicationUnstructured_StringForm_StoresCanonical(t *testing.T) {
 		// Legacy editor dialect on the wire …
 		Placement: applicationPlacement{Mode: "single-region", Regions: []string{"fsn"}},
 	}
-	obj := newApplicationUnstructured(req, "")
+	obj := newApplicationUnstructured(req, "", "")
 	pl, ok, err := unstructured.NestedString(obj.Object, "spec", "placement")
 	// One vocabulary (#3375 DoD-1): the CR STORES the canonical token —
 	// the legacy "single-region" is folded to "singleton" so every CR
@@ -44,7 +44,7 @@ func TestNewApplicationUnstructured_ObjectFormWhenVClusterSet(t *testing.T) {
 			Clusters: []string{"mgmt-A"},
 		},
 	}
-	obj := newApplicationUnstructured(req, "")
+	obj := newApplicationUnstructured(req, "", "")
 	vc, _, _ := unstructured.NestedString(obj.Object, "spec", "placement", "vcluster")
 	if vc != "rtz" {
 		t.Fatalf("spec.placement.vcluster = %q, want rtz", vc)
@@ -198,7 +198,7 @@ func TestNewApplicationUnstructured_DottedOrgSlugsNamespace(t *testing.T) {
 		EnvironmentRef:  "hw165.omani.works-prod",
 		Placement:       applicationPlacement{Mode: "singleton", Regions: []string{"fsn"}},
 	}
-	obj := newApplicationUnstructured(req, "")
+	obj := newApplicationUnstructured(req, "", "")
 	if ns := obj.GetNamespace(); ns != "hw165-omani-works" {
 		t.Fatalf("metadata.namespace = %q, want slugged hw165-omani-works", ns)
 	}

--- a/products/catalyst/bootstrap/api/internal/instances/create.go
+++ b/products/catalyst/bootstrap/api/internal/instances/create.go
@@ -196,6 +196,20 @@ type ApplicationSeed struct {
 	// mothership/Catalyst-Zero. Consumed by newApplicationCRFromSeed via
 	// defaultedParameters; ignored for non-agenity Blueprints.
 	SovereignFQDN string
+
+	// OrgConsoleHost — the Org's public console host
+	// (console.<slug>.<poolParentDomain>, e.g. console.nstar.omani.homes),
+	// stamped by the create-instance handler from the tenant registry so the
+	// bp-agenity install gets spec.parameters.openovaMCP.tenantHost (#4624):
+	// the OPENOVA_MCP_TENANT_HOST the agent-side MCP forwards as
+	// X-Tenant-Host MUST be the ORG console host — the Sovereign console
+	// host (console.<sovereignFqdn>, where the catalyst-api URL correctly
+	// points) is NOT a registered tenant, so without this every agent
+	// create_application 404s `tenant-not-registered`. Empty on the
+	// mothership / when the registry has no row for the Org (no stamp,
+	// fail-closed). Consumed by newApplicationCRFromSeed via
+	// defaultedParameters; ignored for non-agenity Blueprints.
+	OrgConsoleHost string
 }
 
 // Build constructs the ApplicationSeed from a sanitised+validated


### PR DESCRIPTION
## The bug (live-proven on hw220, 2026-07-04)

A per-Org **bp-agenity** installed on a Sovereign via the **Application-CR door** rendered its openova-MCP env as:

```
OPENOVA_MCP_CATALYST_API_URL = https://console.hw220.omani.works   ← correct (Sovereign)
OPENOVA_MCP_TENANT_HOST      = console.hw220.omani.works           ← WRONG (Sovereign, must be Org)
```

The MCP forwards `TENANT_HOST` as `X-Tenant-Host` on `POST /api/v1/org/applications`. The Sovereign console host is **not a registered tenant**, so catalyst-api answered **404 `tenant-not-registered`** and every agent `mcp__openova__create_application` failed (`MCP error -32010: upstream error`).

**Live fix that proved the diagnosis:** `kubectl set env statefulset/agenity-rtz-a-bp-agenity -n nstar OPENOVA_MCP_TENANT_HOST=console.nstar.omani.homes` → next `create_application` returned **HTTP 201** and the Application CR landed.

## Root cause

`defaultedParameters` (the Application-CR install/seed doors) stamped only `sovereignFqdn`. With `openovaMCP.tenantHost` and `httpRoute.hostnames` both empty, the chart's `agenity.mcpTenantHost` helper (`products/agenity/chart/templates/_helpers.tpl:63`) fell back to the synthetic gate host `agenity.<sovereignFqdn>` and derived `console.<sovereignFqdn>` — the Sovereign host. The BSS GitOps door was already correct (its `httpRoute.hostnames[0] = agenity.<slug>.<pool>` derives `console.<slug>.<pool>`), which is why only Application-CR-installed agenities hit this.

## The fix (derive, no hardcode; chart untouched)

The chart's explicit-value seam from #4610 (`openovaMCP.tenantHost` wins over any derivation → `OPENOVA_MCP_TENANT_HOST` env) already exists — the missing half was the **producer stamp**:

- **`internal/handler/application_parameters.go`** — new `stampAgenityMCPTenantHost`: stamps `parameters.openovaMCP.tenantHost` with the Org's console host (`console.<slug>.<poolParentDomain>`) resolved from the **tenant registry** (`orgConsoleHostFor` / `orgConsoleHostFromRegistrations` — the same table the org-scoped path resolves `X-Tenant-Host` against, so the stamped host is by construction a registered tenant). Empty ⇒ **no stamp** (mothership/Catalyst-Zero fail-closed); an explicit caller value is **never clobbered** (same deference pattern as `stampAgenitySovereignFqdn`). `sovereignFqdn` is untouched, so `OPENOVA_MCP_CATALYST_API_URL` keeps deriving `https://console.<sovereignFqdn>` (Sovereign).
- **`internal/handler/applications.go`** — `installApplicationCore` resolves the Org console host from the registry and threads it through `newApplicationUnstructured`.
- **`internal/instances/create.go` + `internal/handler/endpoint_handler.go`** — `ApplicationSeed.OrgConsoleHost` stamped by the create-instance handler; consumed by `newApplicationCRFromSeed`.
- **`internal/handler/organization_gitops.go`** (`orgTenantBPAgenity`) — pins `openovaMCP.tenantHost: {{.ConsoleHost}}` explicitly so both doors emit byte-consistent wiring (derivation was already correct there; the pin makes the contract explicit).

### Tests

- `TestDefaultedParameters_AgenityStampsOrgConsoleTenantHost` — the decisive case: orgSlug=`nstar` + pool `omani.homes` ⇒ stamped `tenantHost=console.nstar.omani.homes` while `sovereignFqdn` stays `hw220.omani.works`.
- Explicit-`tenantHost` deference, empty-host fail-closed, non-agenity no-stamp, registry-resolver dialect table (slug / dotted zone / forced org-namespace / otech-row exclusion), both CR-producer doors, BSS overlay render pin.

### Gates

```
cd products/catalyst/bootstrap/api && go build ./...   → clean
go test ./internal/handler/... ./internal/instances/... → ok (handler 106s, instances 0.004s)
helm lint products/agenity/chart                        → rc=0 (chart NOT modified — no version bump needed)
```

`helm template` proof (chart consuming the stamped parameter):

- **Before-fix param shape** (`sovereignFqdn` only): `OPENOVA_MCP_TENANT_HOST: "console.hw220.omani.works"` — reproduces the live bug.
- **After-fix param shape** (`sovereignFqdn` + stamped `openovaMCP.tenantHost`): `OPENOVA_MCP_TENANT_HOST: "console.nstar.omani.homes"`, `OPENOVA_MCP_CATALYST_API_URL: "https://console.hw220.omani.works"`.

### Deployment note

`spec.parameters` is stamped at CR **create** — already-installed agenity Applications keep their old parameters; re-render/re-create (or the live `kubectl set env` already applied on hw220/nstar) covers existing installs.

## Sibling gaps found in the same walk (NOT fixed here — follow-up)

1. **anthropic ExternalSecret hard-fails on missing `apiKey`**: the ExternalSecret references properties `apiKey` AND `credentialsJson`; if `apiKey` is absent in OpenBao it wedges `SecretSyncedError`. The #4303 producer should always write both properties.
2. **`create_application` 400 on version-less requests**: `blueprintRef.version is required` — the tool/handler should resolve the catalog's latest pinned version when omitted.
3. **Admin `POST /api/v1/organizations` creates a bare Org shell with no default Environment** — agenity then sits Pending on `Environment <slug>-prod not found`; a default Environment should be ensured at Org create.

Refs #4624 #4277

🤖 Generated with [Claude Code](https://claude.com/claude-code)