### PR TITLE
fix(catalyst-api): per-Org console front door — self-healing TLS trio, apex-derived listener ports, console DNS → console ELB EIP (Refs #4732)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/org_console_tls.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_console_tls.go
@@ -117,20 +117,31 @@ const orgConsoleTLSIssuer = "letsencrypt-dns01-prod-powerdns"
 // canonical Sovereign install: the dedicated console Gateway lives as
 // `cilium-gateway-console` in kube-system (#4053,
 // clusters/_template/sovereign-tls/cilium-gateway-console.yaml) and the
-// catalyst-ui + catalyst-api Services live in catalyst-system. The listeners
-// bind the console gateway's own host ports (31443 / 31080) — distinct from
-// the shared gateway's 30443 / 30080 so both coexist in hostNetwork mode.
+// catalyst-ui + catalyst-api Services live in catalyst-system.
+//
+// #4732(2): the per-Org listener PORTS are no longer hardcoded — they are
+// read from the console gateway's own apex `console-https`/`console-http`
+// listeners at apply time (consoleApexListenerPorts). The console ELB
+// forwards 443/80 to exactly those node ports (#4718 hostNetwork scheme:
+// 8443/8080), so a per-Org listener on any OTHER port receives no traffic
+// — the prior 31443/31080 constants were the pre-#4718 scheme and left
+// every per-Org console dead (the nstar failure). SNI differentiates the
+// per-Org wildcard hosts from the apex host on the shared port pair. The
+// constants below remain only as the fallback when the apex pair cannot
+// be read.
 const (
-	consoleGatewayName       = "cilium-gateway-console"
-	consoleGatewayNamespace  = "kube-system"
-	consoleCertNamespace     = "kube-system"
-	catalystConsoleNamespace = "catalyst-system"
-	consoleListenerHTTPSPort = int64(31443)
-	consoleListenerHTTPPort  = int64(31080)
-	catalystUIServiceName    = "catalyst-ui"
-	catalystUIServicePort    = int64(80)
-	catalystAPIServiceName   = "catalyst-api"
-	catalystAPIServicePort   = int64(8080)
+	consoleGatewayName               = "cilium-gateway-console"
+	consoleGatewayNamespace          = "kube-system"
+	consoleCertNamespace             = "kube-system"
+	catalystConsoleNamespace         = "catalyst-system"
+	consoleApexListenerHTTPSName     = "console-https"
+	consoleApexListenerHTTPName      = "console-http"
+	consoleListenerHTTPSPortFallback = int64(8443)
+	consoleListenerHTTPPortFallback  = int64(8080)
+	catalystUIServiceName            = "catalyst-ui"
+	catalystUIServicePort            = int64(80)
+	catalystAPIServiceName           = "catalyst-api"
+	catalystAPIServicePort           = int64(8080)
 )
 
 // consoleGatewayGVR — Gateway API v1 Gateway (for the per-Org listener SSA
@@ -298,6 +309,44 @@ func ensureOrgConsoleCertificate(ctx context.Context, dyn dynamic.Interface, nam
 	return nil
 }
 
+// consoleApexListenerPorts reads the console gateway's live apex
+// `console-https`/`console-http` listeners and returns their ports —
+// the ONLY ports the console ELB actually forwards to (#4732 item 2).
+// Falls back to the #4718 canonical 8443/8080 pair when the gateway or
+// the apex listeners cannot be read (fresh install race, RBAC), so the
+// apply still lands on the current canonical scheme rather than failing.
+func consoleApexListenerPorts(ctx context.Context, dyn dynamic.Interface) (httpsPort, httpPort int64) {
+	httpsPort = consoleListenerHTTPSPortFallback
+	httpPort = consoleListenerHTTPPortFallback
+	gw, err := dyn.Resource(consoleGatewayGVR).Namespace(consoleGatewayNamespace).
+		Get(ctx, consoleGatewayName, metav1.GetOptions{})
+	if err != nil {
+		return httpsPort, httpPort
+	}
+	listeners, found, err := unstructured.NestedSlice(gw.Object, "spec", "listeners")
+	if err != nil || !found {
+		return httpsPort, httpPort
+	}
+	for _, l := range listeners {
+		lm, ok := l.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _, _ := unstructured.NestedString(lm, "name")
+		port, foundPort, _ := unstructured.NestedInt64(lm, "port")
+		if !foundPort {
+			continue
+		}
+		switch name {
+		case consoleApexListenerHTTPSName:
+			httpsPort = port
+		case consoleApexListenerHTTPName:
+			httpPort = port
+		}
+	}
+	return httpsPort, httpPort
+}
+
 // ensureOrgConsoleListener server-side-applies the per-Org HTTPS + HTTP
 // listener pair onto cilium-gateway-console. SSA with our dedicated field
 // manager merges by listener name (the Gateway listeners list is keyed on
@@ -309,6 +358,10 @@ func ensureOrgConsoleCertificate(ctx context.Context, dyn dynamic.Interface, nam
 // force claims ownership for our manager so the codified path heals the
 // hand-fix in place rather than erroring forever.
 func ensureOrgConsoleListener(ctx context.Context, dyn dynamic.Interface, names orgConsoleTLSNames, rec store.OrganizationProvisionRecord) error {
+	// #4732(2): ride the SAME ports as the apex pair — SNI separates the
+	// per-Org wildcard from the apex host. Any other port pair is dead
+	// (the ELB only forwards to the apex ports).
+	httpsPort, httpPort := consoleApexListenerPorts(ctx, dyn)
 	// Apply object carries ONLY the two per-Org listeners. SSA's name-keyed
 	// merge adds them to the existing listener set without touching the apex
 	// console-https/console-http pair owned by kustomize-controller.
@@ -324,7 +377,7 @@ func ensureOrgConsoleListener(ctx context.Context, dyn dynamic.Interface, names 
 				"listeners": []any{
 					map[string]any{
 						"name":     names.HTTPSName,
-						"port":     consoleListenerHTTPSPort,
+						"port":     httpsPort,
 						"protocol": "HTTPS",
 						"hostname": names.WildcardHost,
 						"tls": map[string]any{
@@ -339,7 +392,7 @@ func ensureOrgConsoleListener(ctx context.Context, dyn dynamic.Interface, names 
 					},
 					map[string]any{
 						"name":     names.HTTPName,
-						"port":     consoleListenerHTTPPort,
+						"port":     httpPort,
 						"protocol": "HTTP",
 						"hostname": names.WildcardHost,
 						"allowedRoutes": map[string]any{

--- a/products/catalyst/bootstrap/api/internal/handler/org_console_tls_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_console_tls_test.go
@@ -123,8 +123,8 @@ func fakeDynForConsoleTLS(t *testing.T) *dynamicfake.FakeDynamicClient {
 		"spec": map[string]any{
 			"gatewayClassName": "cilium",
 			"listeners": []any{
-				map[string]any{"name": "console-https", "port": int64(31443), "protocol": "HTTPS", "hostname": "*.omantel.biz"},
-				map[string]any{"name": "console-http", "port": int64(31080), "protocol": "HTTP", "hostname": "*.omantel.biz"},
+				map[string]any{"name": "console-https", "port": int64(8443), "protocol": "HTTPS", "hostname": "*.omantel.biz"},
+				map[string]any{"name": "console-http", "port": int64(8080), "protocol": "HTTP", "hostname": "*.omantel.biz"},
 			},
 		},
 	}}
@@ -268,4 +268,72 @@ func sliceContains(ss []string, want string) bool {
 		}
 	}
 	return false
+}
+
+// TestConsoleApexListenerPorts_DerivesFromApex locks #4732 item 2: the
+// per-Org listener pair must ride the SAME ports as the live apex
+// console-https/console-http listeners (the only ports the console ELB
+// forwards to), never a hardcoded pair from an older port scheme.
+func TestConsoleApexListenerPorts_DerivesFromApex(t *testing.T) {
+	dyn := fakeDynForConsoleTLS(t)
+	httpsPort, httpPort := consoleApexListenerPorts(context.Background(), dyn)
+	// fakeDynForConsoleTLS seeds the apex pair on 8443/8080 (#4718 scheme).
+	if httpsPort != 8443 || httpPort != 8080 {
+		t.Errorf("apex-derived ports = %d/%d, want 8443/8080 from the seeded apex", httpsPort, httpPort)
+	}
+}
+
+// TestConsoleApexListenerPorts_FallbackWhenGatewayMissing locks the
+// degraded path: no gateway readable → the #4718 canonical fallback pair.
+func TestConsoleApexListenerPorts_FallbackWhenGatewayMissing(t *testing.T) {
+	scheme := runtime.NewScheme()
+	gvrToList := map[schema.GroupVersionResource]string{
+		certificateGVR:    "CertificateList",
+		consoleGatewayGVR: "GatewayList",
+		httpRouteGVR:      "HTTPRouteList",
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToList)
+	httpsPort, httpPort := consoleApexListenerPorts(context.Background(), dyn)
+	if httpsPort != consoleListenerHTTPSPortFallback || httpPort != consoleListenerHTTPPortFallback {
+		t.Errorf("fallback ports = %d/%d, want %d/%d", httpsPort, httpPort,
+			consoleListenerHTTPSPortFallback, consoleListenerHTTPPortFallback)
+	}
+}
+
+// TestEnsureOrgConsoleListener_RidesApexPorts is the end-to-end lock for
+// #4732 item 2 through the SSA apply body: the per-Org listener pair in the
+// patch must carry the apex ports.
+func TestEnsureOrgConsoleListener_RidesApexPorts(t *testing.T) {
+	dyn := fakeDynForConsoleTLS(t)
+	names, ok := resolveOrgConsoleTLSNames(store.OrganizationProvisionRecord{
+		Subdomain:    "nstar",
+		DomainMode:   store.OrganizationDomainFreeSubdomain,
+		ParentDomain: "omani.homes",
+	})
+	if !ok {
+		t.Fatal("resolveOrgConsoleTLSNames returned !ok")
+	}
+	// The fake dynamic client does not implement server-side-apply merge
+	// (same limitation TestProvisionOrgConsoleTLS_AppliesTrio documents) —
+	// a returned error is tolerated; the assertion target is the recorded
+	// patch BODY.
+	_ = ensureOrgConsoleListener(context.Background(), dyn, names, store.OrganizationProvisionRecord{})
+	var patched []byte
+	for _, a := range dyn.Actions() {
+		if a.GetResource() == consoleGatewayGVR && a.GetVerb() == "patch" {
+			if pa, ok := a.(interface{ GetPatch() []byte }); ok {
+				patched = pa.GetPatch()
+			}
+		}
+	}
+	if len(patched) == 0 {
+		t.Fatal("no SSA patch recorded against the console gateway")
+	}
+	body := string(patched)
+	if !strings.Contains(body, `"port":8443`) || !strings.Contains(body, `"port":8080`) {
+		t.Errorf("per-Org listeners not on the apex 8443/8080 ports\npatch: %s", body)
+	}
+	if strings.Contains(body, `"port":31443`) || strings.Contains(body, `"port":31080`) {
+		t.Errorf("per-Org listeners still carry the dead pre-#4718 31443/31080 ports\npatch: %s", body)
+	}
 }

--- a/products/catalyst/bootstrap/api/internal/handler/organization_dns.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_dns.go
@@ -160,7 +160,18 @@ type Resolver interface {
 // resolve as soon as Flux finishes reconciling. Per epic #825 the
 // parentZone is operator-supplied (one of the Sovereign's
 // role:org-pool entries) — never inferred from a hardcoded OTECHFQDN.
-func (p DefaultOrganizationDNSProvisioner) ProvisionFreeSubdomain(ctx context.Context, subdomain, parentZone, ingressIPv4 string) error {
+//
+// #4732(3): the `console` record and the app records target DIFFERENT
+// front doors. App hosts (wordpress/openclaw/mail/keycloak + the per-Org
+// wildcard) ride the SHARED gateway (ingressIPv4). The Org console rides
+// the DEDICATED console gateway/ELB (#4053/#4718) — the same door
+// `console.<sovereign-fqdn>` serves — so its record must carry
+// consoleIPv4. Writing the console record with the shared-gateway IP is
+// exactly the nstar failure: the shared gateway has no console listener
+// for the Org zone, so the browser got the pool `*.<parent>` cert + 404.
+// consoleIPv4 == "" falls back to ingressIPv4 (single-gateway Sovereigns
+// and older callers keep their prior behaviour).
+func (p DefaultOrganizationDNSProvisioner) ProvisionFreeSubdomain(ctx context.Context, subdomain, parentZone, ingressIPv4, consoleIPv4 string) error {
 	// #4218: pool-domain console A-records (omani.*) live on the CENTRAL
 	// authoritative PowerDNS (pdns.openova.io), not the Sovereign-local
 	// one. Prefer PoolWriter when wired; fall back to the local Writer for
@@ -195,15 +206,23 @@ func (p DefaultOrganizationDNSProvisioner) ProvisionFreeSubdomain(ctx context.Co
 	// ChangeType=REPLACE makes every write an unconditional upsert, so a
 	// stale same-name record (if one ever existed) is overwritten rather
 	// than skipped.
+	consoleIP := strings.TrimSpace(consoleIPv4)
+	if consoleIP == "" {
+		consoleIP = ingressIPv4
+	}
 	for _, prefix := range theFreeSubdomainPrefixes {
 		fqdn := fmt.Sprintf("%s.%s.%s.", prefix, subdomain, parentZone)
+		content := ingressIPv4
+		if prefix == "console" {
+			content = consoleIP
+		}
 		rrsets = append(rrsets, pdnsRRSet{
 			Name:       fqdn,
 			Type:       "A",
 			TTL:        300,
 			ChangeType: "REPLACE",
 			Records: []pdnsRecord{
-				{Content: ingressIPv4, Disabled: false},
+				{Content: content, Disabled: false},
 			},
 		})
 	}
@@ -216,6 +235,40 @@ func (p DefaultOrganizationDNSProvisioner) ProvisionFreeSubdomain(ctx context.Co
 // the surplus records survive the Org and shadow a re-prov's wildcard with a
 // dead IP).
 var theFreeSubdomainPrefixes = []string{"*", "console", "wordpress", "openclaw", "mail", "keycloak"}
+
+// lookupHostFn is the seam tests stub to avoid live DNS. Production uses
+// net.DefaultResolver.
+var lookupHostFn = func(ctx context.Context, host string) ([]string, error) {
+	return net.DefaultResolver.LookupHost(ctx, host)
+}
+
+// resolveSovereignConsoleIPv4 resolves the Sovereign's own console
+// A-record (`console.<sovereignFQDN>`) to discover the DEDICATED console
+// gateway/ELB EIP (#4732 item 3). That record is written at prov time on
+// every Sovereign and always targets the console front door, so it is the
+// zero-config source of truth for where per-Org `console.<slug>.<pool>`
+// records must point. Returns "" on any failure (empty FQDN, lookup error,
+// no IPv4) — the caller then falls back to the shared ingress IP, which is
+// the pre-#4732 behaviour.
+func resolveSovereignConsoleIPv4(ctx context.Context, sovereignFQDN string) string {
+	fqdn := strings.Trim(strings.TrimSpace(sovereignFQDN), ".")
+	if fqdn == "" {
+		return ""
+	}
+	lctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	addrs, err := lookupHostFn(lctx, "console."+fqdn)
+	if err != nil {
+		return ""
+	}
+	for _, a := range addrs {
+		ip := net.ParseIP(a)
+		if ip != nil && ip.To4() != nil {
+			return ip.String()
+		}
+	}
+	return ""
+}
 
 // DeprovisionFreeSubdomain implements OrganizationDNSProvisioner. DELETEs the
 // per-Org pool A-records ProvisionFreeSubdomain wrote (#4459 — a stale record
@@ -296,7 +349,7 @@ func (p DefaultOrganizationDNSProvisioner) ValidateBYOCNAME(ctx context.Context,
 type NoopOrganizationDNSProvisioner struct{}
 
 // ProvisionFreeSubdomain is a no-op.
-func (NoopOrganizationDNSProvisioner) ProvisionFreeSubdomain(_ context.Context, _, _, _ string) error {
+func (NoopOrganizationDNSProvisioner) ProvisionFreeSubdomain(_ context.Context, _, _, _, _ string) error {
 	return nil
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
@@ -102,7 +102,13 @@ type OrganizationDNSProvisioner interface {
 	// `console.<subdomain>.<parentZone>` plus the per-app sister
 	// hostnames. Idempotent; returns nil on "record already exists
 	// with the same RDATA" outcomes.
-	ProvisionFreeSubdomain(ctx context.Context, subdomain, parentZone, ingressIPv4 string) error
+	//
+	// #4732(3): consoleIPv4 targets the Org console record at the
+	// DEDICATED console gateway/ELB front door (#4053/#4718) — the same
+	// door `console.<sovereign-fqdn>` serves; the app hosts + per-Org
+	// wildcard stay on ingressIPv4 (the shared gateway). Empty
+	// consoleIPv4 falls back to ingressIPv4.
+	ProvisionFreeSubdomain(ctx context.Context, subdomain, parentZone, ingressIPv4, consoleIPv4 string) error
 	// DeprovisionFreeSubdomain removes the per-Org pool A-records that
 	// ProvisionFreeSubdomain wrote (console + app sister hosts under
 	// <subdomain>.<parentZone>). Called on Organization delete so a stale
@@ -853,6 +859,18 @@ func (h *Handler) HandleReconcileOrganization(w http.ResponseWriter, r *http.Req
 		rec.State = deriveResumeState(rec)
 	}
 	final := h.runOrganizationPipeline(r.Context(), rec)
+	// #4732(1): the step-7 finalisation pair (Organization CR + console
+	// TLS trio) is best-effort and non-gating, so it can fail silently
+	// while the record still reaches done — and the pipeline never
+	// revisits a done record, leaving the Org permanently without a
+	// console front door (the nstar failure: no cert, no listener, no
+	// route → pool-wildcard cert + 404). Re-ensure both on EVERY
+	// operator-triggered reconcile; each is idempotent (AlreadyExists /
+	// SSA-merge = no-op), so a healthy Org is untouched.
+	if final.State == store.STSDone {
+		h.createOrgOrganizationCR(r.Context(), final)
+		h.provisionOrgConsoleTLS(r.Context(), final)
+	}
 	writeJSON(w, http.StatusOK, orgTenantRecordToResponse(final))
 }
 
@@ -1079,7 +1097,17 @@ func (h *Handler) runOrganizationPipeline(ctx context.Context, rec store.Organiz
 				if parentZone == "" {
 					parentZone = rec.OTECHFQDN
 				}
-				if err := deps.DNS.ProvisionFreeSubdomain(ctx, rec.Subdomain, parentZone, deps.OTECHIngressIPv4); err != nil {
+				// #4732(3): the Org console record must target the
+				// DEDICATED console gateway/ELB, not the shared
+				// gateway. The authoritative source that exists on
+				// EVERY Sovereign with zero extra config is the
+				// Sovereign's own console A-record
+				// (`console.<OTECHFQDN>` → console ELB EIP, written
+				// at prov time). Resolve it here; empty on failure
+				// falls back to the shared ingress IP inside
+				// ProvisionFreeSubdomain (prior behaviour).
+				consoleIPv4 := resolveSovereignConsoleIPv4(ctx, rec.OTECHFQDN)
+				if err := deps.DNS.ProvisionFreeSubdomain(ctx, rec.Subdomain, parentZone, deps.OTECHIngressIPv4, consoleIPv4); err != nil {
 					return failTransient(rec, "dns", err)
 				}
 			case store.OrganizationDomainBYO:

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
@@ -60,7 +60,7 @@ type fakeDNS struct {
 	cnameErr       error
 }
 
-func (f *fakeDNS) ProvisionFreeSubdomain(_ context.Context, sub, parent, ip string) error {
+func (f *fakeDNS) ProvisionFreeSubdomain(_ context.Context, sub, parent, ip, _ string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.provisionCalls = append(f.provisionCalls, sub+":"+parent+":"+ip)
@@ -1470,7 +1470,7 @@ func TestProvisionFreeSubdomain_WritesWildcardREPLACE(t *testing.T) {
 	defer srv.Close()
 
 	p := DefaultOrganizationDNSProvisioner{Writer: NewPowerDNSWriter(srv.URL, "key")}
-	if err := p.ProvisionFreeSubdomain(context.Background(), "demo", "omani.homes", "212.72.24.33"); err != nil {
+	if err := p.ProvisionFreeSubdomain(context.Background(), "demo", "omani.homes", "212.72.24.33", ""); err != nil {
 		t.Fatalf("ProvisionFreeSubdomain: %v", err)
 	}
 
@@ -1517,7 +1517,7 @@ func TestProvisionFreeSubdomain_PrefersPoolWriter(t *testing.T) {
 		Writer:     NewPowerDNSWriter(localSrv.URL, "local-key"),
 		PoolWriter: NewPowerDNSWriter(poolSrv.URL, "central-key"),
 	}
-	if err := p.ProvisionFreeSubdomain(context.Background(), "f4179close", "omani.works", "212.72.24.33"); err != nil {
+	if err := p.ProvisionFreeSubdomain(context.Background(), "f4179close", "omani.works", "212.72.24.33", ""); err != nil {
 		t.Fatalf("ProvisionFreeSubdomain: %v", err)
 	}
 	if poolHits != 1 {
@@ -1543,7 +1543,7 @@ func TestProvisionFreeSubdomain_FallsBackToLocalWriter(t *testing.T) {
 	defer localSrv.Close()
 
 	p := DefaultOrganizationDNSProvisioner{Writer: NewPowerDNSWriter(localSrv.URL, "local-key")}
-	if err := p.ProvisionFreeSubdomain(context.Background(), "demo", "t01.omani.works", "212.72.24.33"); err != nil {
+	if err := p.ProvisionFreeSubdomain(context.Background(), "demo", "t01.omani.works", "212.72.24.33", ""); err != nil {
 		t.Fatalf("ProvisionFreeSubdomain: %v", err)
 	}
 	if localHits != 1 {
@@ -1806,5 +1806,103 @@ func TestDeleteOrganization_DeprovisionsDNS(t *testing.T) {
 	}
 	if !strings.HasPrefix(dns.deproviCalls[0], "acme:") {
 		t.Errorf("deprovision must target the Org subdomain 'acme'; got %q", dns.deproviCalls[0])
+	}
+}
+
+// TestProvisionFreeSubdomain_ConsoleTargetsConsoleIPv4 locks #4732 item 3:
+// the `console.<slug>.<parent>` record must target the DEDICATED console
+// gateway/ELB EIP (consoleIPv4) while the per-Org wildcard + app hosts stay
+// on the shared-gateway ingress IP. Writing the console record with the
+// shared IP is the nstar failure (pool-wildcard cert + 404 — the shared
+// gateway has no console listener for the Org zone).
+func TestProvisionFreeSubdomain_ConsoleTargetsConsoleIPv4(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody = readAll(r.Body)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	p := DefaultOrganizationDNSProvisioner{Writer: NewPowerDNSWriter(srv.URL, "key")}
+	if err := p.ProvisionFreeSubdomain(context.Background(), "nstar", "omani.homes", "212.72.24.14", "212.72.24.33"); err != nil {
+		t.Fatalf("ProvisionFreeSubdomain: %v", err)
+	}
+
+	// Decode the rrsets and assert per-record targeting.
+	var body struct {
+		RRSets []struct {
+			Name    string `json:"name"`
+			Records []struct {
+				Content string `json:"content"`
+			} `json:"records"`
+		} `json:"rrsets"`
+	}
+	if err := json.Unmarshal([]byte(gotBody), &body); err != nil {
+		t.Fatalf("unmarshal PATCH body: %v\nbody: %s", err, gotBody)
+	}
+	byName := map[string]string{}
+	for _, rr := range body.RRSets {
+		if len(rr.Records) > 0 {
+			byName[rr.Name] = rr.Records[0].Content
+		}
+	}
+	if got := byName["console.nstar.omani.homes."]; got != "212.72.24.33" {
+		t.Errorf("console record = %q, want console ELB EIP 212.72.24.33", got)
+	}
+	for _, appHost := range []string{"*.nstar.omani.homes.", "wordpress.nstar.omani.homes.", "keycloak.nstar.omani.homes."} {
+		if got := byName[appHost]; got != "212.72.24.14" {
+			t.Errorf("%s = %q, want shared ingress 212.72.24.14", appHost, got)
+		}
+	}
+}
+
+// TestProvisionFreeSubdomain_EmptyConsoleIPFallsBack locks the back-compat
+// contract: consoleIPv4=="" keeps the pre-#4732 single-IP behaviour.
+func TestProvisionFreeSubdomain_EmptyConsoleIPFallsBack(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody = readAll(r.Body)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	p := DefaultOrganizationDNSProvisioner{Writer: NewPowerDNSWriter(srv.URL, "key")}
+	if err := p.ProvisionFreeSubdomain(context.Background(), "demo", "omani.rest", "212.72.24.14", ""); err != nil {
+		t.Fatalf("ProvisionFreeSubdomain: %v", err)
+	}
+	if strings.Contains(gotBody, `"content":"212.72.24.33"`) {
+		t.Errorf("unexpected console IP with empty consoleIPv4\nbody: %s", gotBody)
+	}
+	if c := strings.Count(gotBody, `"content":"212.72.24.14"`); c != len(theFreeSubdomainPrefixes) {
+		t.Errorf("expected every rrset on the ingress IP (%d), got %d\nbody: %s", len(theFreeSubdomainPrefixes), c, gotBody)
+	}
+}
+
+// TestResolveSovereignConsoleIPv4 locks the console-EIP discovery seam: the
+// Sovereign's own `console.<fqdn>` A record is the zero-config source of
+// truth for the console front door; failures degrade to "" (caller falls
+// back to the shared ingress IP).
+func TestResolveSovereignConsoleIPv4(t *testing.T) {
+	orig := lookupHostFn
+	defer func() { lookupHostFn = orig }()
+
+	lookupHostFn = func(_ context.Context, host string) ([]string, error) {
+		if host != "console.hw220.omani.works" {
+			t.Errorf("lookup host = %q, want console.hw220.omani.works", host)
+		}
+		return []string{"2a01:db8::1", "212.72.24.33"}, nil
+	}
+	if got := resolveSovereignConsoleIPv4(context.Background(), "hw220.omani.works."); got != "212.72.24.33" {
+		t.Errorf("resolve = %q, want first IPv4 212.72.24.33", got)
+	}
+
+	lookupHostFn = func(_ context.Context, _ string) ([]string, error) {
+		return nil, errors.New("nx")
+	}
+	if got := resolveSovereignConsoleIPv4(context.Background(), "hw220.omani.works"); got != "" {
+		t.Errorf("resolve on lookup error = %q, want empty", got)
+	}
+	if got := resolveSovereignConsoleIPv4(context.Background(), "  "); got != "" {
+		t.Errorf("resolve on blank fqdn = %q, want empty", got)
 	}
 }


### PR DESCRIPTION
Durable twins of the nstar live fixes on hw220 (`console.nstar.omani.homes` served the pool `*.omani.homes` cert + 404 — full root-cause chain on #4732).

## Changes

1. **Self-healing console-TLS trio (#4732 item 1)** — `HandleReconcileOrganization` now re-ensures the Organization CR + the #4075 console TLS trio (Certificate + gateway listener pair + HTTPRoute) for `STSDone` records. Before: the step-7 pair is best-effort/non-gating, so a silent failure (nstar's, mid-cutover) left the Org permanently without a front door — the pipeline never revisits `done` records, making the in-code claim "a later reconcile pass re-applies the trio" false.
2. **Apex-derived listener ports (#4732 item 2)** — `ensureOrgConsoleListener` reads the console gateway's live apex `console-https`/`console-http` ports and rides them (SNI-differentiated) instead of the hardcoded pre-#4718 `31443/31080`, which the console ELB never forwards to (verified dead on hw220; re-applying on 8443/8080 brought the console up). Fallback pair updated to the #4718 canonical 8443/8080.
3. **Console DNS record targets the console ELB EIP (#4732 item 3)** — `ProvisionFreeSubdomain` gains a `consoleIPv4` parameter: `console.<slug>.<parent>` now points at the dedicated console front door while the per-Org wildcard + app hosts stay on the shared gateway. The pipeline resolves the console EIP from the Sovereign's own `console.<fqdn>` A record — a zero-config source present on every env (empty resolution falls back to prior single-IP behaviour).

## Verification

- `go build ./...` + `go vet` clean; **full `internal/handler` suite green** (151s).
- New tests: console-record IP split + empty-consoleIP fallback + resolver seam (`organization_provisioning_test.go`), apex-port derivation + missing-gateway fallback + SSA patch body asserts 8443/8080 and rejects 31443/31080 (`org_console_tls_test.go`).
- Live proof of the fix class: hw220 nstar trio hand-applied with these exact shapes → `https://console.nstar.omani.homes/` now 200 with valid `*.nstar.omani.homes` LE cert (strict validation, no -k).

Refs #4732, #4075, #4718, #4053.

🤖 Generated with [Claude Code](https://claude.com/claude-code)