### PR TITLE
fix(console): collapse cloud/k8s WorkerNodes by InternalIP — graph showed 24/24 for 12 real nodes (Refs #4732)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/k8sAdapter.test.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/k8sAdapter.test.ts
@@ -411,6 +411,83 @@ describe('mergeGraphs', () => {
     expect(merged.edges).toEqual([])
   })
 
+  it('#4732(4): collapses cloud/k8s WorkerNodes by InternalIP when ids differ (Huawei naming), rewriting edges', () => {
+    // Cloud side names nodes from the RegionSpec; k8s side uses the real
+    // Node name — ids NEVER match on Huawei. Same InternalIP = same node.
+    const cloud = {
+      nodes: [
+        { id: 'Cluster:c', type: 'Cluster' as const, label: 'c', status: 'healthy' as const },
+        {
+          id: 'WorkerNode:worker-1-me-east-215-a',
+          type: 'WorkerNode' as const,
+          label: 'worker-1-me-east-215-a',
+          status: 'unknown' as const,
+          metadata: { sku: 's3.large', ip: '192.168.0.44' },
+        },
+      ],
+      edges: [
+        {
+          id: 'e:Cluster:c->WorkerNode:worker-1-me-east-215-a',
+          source: 'Cluster:c',
+          target: 'WorkerNode:worker-1-me-east-215-a',
+          type: 'runs-on' as const,
+        },
+      ],
+    }
+    const k8s = {
+      nodes: [
+        {
+          id: 'WorkerNode:catalyst-hw220-907629bc-me-east-215-a-w1d535a',
+          type: 'WorkerNode' as const,
+          label: 'catalyst-hw220-907629bc-me-east-215-a-w1d535a',
+          status: 'healthy' as const,
+          metadata: { ip: '192.168.0.44', kubeletVersion: 'v1.31.4+k3s1' },
+        },
+        { id: 'Pod:foo/p', type: 'Pod' as const, label: 'p', status: 'healthy' as const },
+      ],
+      edges: [
+        {
+          id: 'e:Pod:foo/p->WorkerNode:catalyst',
+          source: 'Pod:foo/p',
+          target: 'WorkerNode:catalyst-hw220-907629bc-me-east-215-a-w1d535a',
+          type: 'runs-on' as const,
+        },
+      ],
+    }
+    const merged = mergeGraphs(cloud, k8s)
+    // ONE WorkerNode survives — the double-render (12 real → 24 shown) is dead.
+    const workers = merged.nodes.filter((n) => n.type === 'WorkerNode')
+    expect(workers).toHaveLength(1)
+    const node = workers[0]!
+    expect(node.id).toBe('WorkerNode:worker-1-me-east-215-a')
+    // K8s live status wins; cloud sku + k8s kubeletVersion both retained.
+    expect(node.status).toBe('healthy')
+    expect(node.metadata).toEqual(
+      expect.objectContaining({ sku: 's3.large', kubeletVersion: 'v1.31.4+k3s1' }),
+    )
+    // The Pod runs-on edge is REWRITTEN to the surviving cloud id, not dropped.
+    const podEdge = merged.edges.find((e) => e.source === 'Pod:foo/p')!
+    expect(podEdge.target).toBe('WorkerNode:worker-1-me-east-215-a')
+    expect(merged.edges.filter((e) => e.target === 'WorkerNode:worker-1-me-east-215-a')).toHaveLength(2)
+  })
+
+  it('#4732(4): WorkerNodes without an IP never collapse (no false identity)', () => {
+    const cloud = {
+      nodes: [
+        { id: 'WorkerNode:a', type: 'WorkerNode' as const, label: 'a', status: 'unknown' as const, metadata: {} },
+      ],
+      edges: [],
+    }
+    const k8s = {
+      nodes: [
+        { id: 'WorkerNode:b', type: 'WorkerNode' as const, label: 'b', status: 'healthy' as const, metadata: { ip: '' } },
+      ],
+      edges: [],
+    }
+    const merged = mergeGraphs(cloud, k8s)
+    expect(merged.nodes.filter((n) => n.type === 'WorkerNode')).toHaveLength(2)
+  })
+
   it('deduplicates edges that appear in both adapters with the same (source,target,type)', () => {
     const cloud = {
       nodes: [

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/k8sAdapter.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/k8sAdapter.ts
@@ -516,20 +516,42 @@ function kindToArchType(kind: 'deployment' | 'statefulset' | 'daemonset'): ArchN
 
 /**
  * mergeGraphs unions the cloud-side and K8s-side adapter outputs.
- * The collapse rule:
+ * The collapse rules:
  *
- *   Cloud-side WorkerNode + K8s-side WorkerNode (originating from a
- *   Node object) get folded into one node when their ids match. The
- *   K8s-side payload wins for live status (Ready condition) while
- *   the cloud-side payload contributes the SKU / role metadata.
+ *   1. Cloud-side WorkerNode + K8s-side WorkerNode (originating from a
+ *      Node object) get folded into one node when their ids match. The
+ *      K8s-side payload wins for live status (Ready condition) while
+ *      the cloud-side payload contributes the SKU / role metadata.
+ *   2. #4732(4): when the ids DON'T match — the normal case on Huawei,
+ *      where the cloud side names nodes from the RegionSpec
+ *      ("worker-1-me-east-215-a") and the k8s side uses the real Node
+ *      name ("catalyst-<fqdn>-...-w1d535a") — a WorkerNode pair is
+ *      collapsed by InternalIP instead. Both adapters stamp
+ *      `metadata.ip`, and a node's InternalIP is unique within the
+ *      fleet, so IP equality IS node identity. Without this rule every
+ *      node rendered twice (12 real nodes → "24/24" on the graph while
+ *      the list view showed the true 12).
  *
- * Edges referencing either id are rewritten to point at the merged
- * node so neighbour lookups stay correct.
+ * Edges referencing a collapsed k8s id are rewritten to the surviving
+ * cloud id so neighbour lookups (Pod runs-on, Volume attached-to) stay
+ * correct.
  */
 export function mergeGraphs(cloud: AdaptResult, k8s: AdaptResult): AdaptResult {
   const cloudNodesById = new Map(cloud.nodes.map((n) => [n.id, n] as const))
   const merged: GraphNode[] = []
   const seen = new Set<string>()
+
+  // #4732(4): index cloud-side WorkerNodes by InternalIP for the
+  // IP-keyed collapse (rule 2). Only non-empty IPs participate — a
+  // topology row without an IP can never falsely match.
+  const cloudWorkerByIP = new Map<string, string>()
+  for (const cn of cloud.nodes) {
+    if (cn.type !== 'WorkerNode') continue
+    const ip = String(cn.metadata?.['ip'] ?? '').trim()
+    if (ip && !cloudWorkerByIP.has(ip)) cloudWorkerByIP.set(ip, cn.id)
+  }
+  // k8s id → surviving cloud id, for edge rewriting.
+  const aliasedTo = new Map<string, string>()
 
   // Emit cloud nodes first (provenance). When a k8s node has the same
   // id, fold the k8s payload onto the cloud node.
@@ -545,11 +567,32 @@ export function mergeGraphs(cloud: AdaptResult, k8s: AdaptResult): AdaptResult {
       }
       continue
     }
+    // Rule 2 — IP-keyed WorkerNode collapse.
+    if (kn.type === 'WorkerNode') {
+      const ip = String(kn.metadata?.['ip'] ?? '').trim()
+      const cloudId = ip ? cloudWorkerByIP.get(ip) : undefined
+      if (cloudId) {
+        const idx = merged.findIndex((n) => n.id === cloudId)
+        if (idx >= 0) {
+          merged[idx] = mergeNodePayloads(merged[idx]!, kn)
+        }
+        aliasedTo.set(kn.id, cloudId)
+        continue
+      }
+    }
     seen.add(kn.id)
     merged.push(kn)
   }
 
-  const edges = [...cloud.edges, ...k8s.edges]
+  // Rewrite edges that referenced a collapsed k8s WorkerNode id to the
+  // surviving cloud id, so Pod runs-on / Volume attached-to edges land
+  // on the merged node instead of being dropped by the endpoint filter.
+  const rewrite = (id: string) => aliasedTo.get(id) ?? id
+  const edges = [...cloud.edges, ...k8s.edges].map((e) => {
+    const s = rewrite(e.source)
+    const t = rewrite(e.target)
+    return s === e.source && t === e.target ? e : { ...e, source: s, target: t }
+  })
   // De-duplicate edges by (source,target,type) so cloud + k8s emitters
   // don't produce parallel edges for the same relation.
   const edgeKey = (e: GraphEdge) => `${e.source}|${e.target}|${e.type}`


### PR DESCRIPTION
Item 4 of the #4732 defect chain, verified live on hw220: `/cloud?view=graph` rendered **24/24 worker nodes** while the list view (and `kubectl get nodes` across both regions) showed the true **12**.

## Root cause

`mergeGraphs` collapses cloud-side and k8s-side WorkerNodes only on composite-id equality. On Huawei the two naming schemes never match (`worker-1-me-east-215-a` from the RegionSpec vs `catalyst-<fqdn>-...-w1d535a` from the live Node), so every node rendered twice — the k8sAdapter header even documented the gap ("when they don't [match], the page renders both").

## Fix

Both adapters already stamp `metadata.ip` (topology `node.ip` / Node InternalIP), and InternalIP is unique per fleet — IP equality IS node identity. New rule 2 in `mergeGraphs`: an unmatched k8s WorkerNode whose IP matches a cloud WorkerNode collapses onto it (k8s live status wins, both metadata sets retained), and edges referencing the collapsed k8s id are rewritten to the survivor so Pod `runs-on` / Volume `attached-to` edges keep resolving instead of being dropped by the endpoint filter. Nodes without an IP never collapse.

## Verification

- New tests: Huawei-naming collapse (1 surviving node, edge rewrite, metadata union, status precedence) + no-IP never collapses.
- `npx tsc -b` clean; architecture-graph suite **80/80 green**.

Refs #4732.

🤖 Generated with [Claude Code](https://claude.com/claude-code)