### PR TITLE
fix(catalyst-api): tear down sovereign parent-zone DNS records on wipe (Refs #4732)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_dns_records.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_dns_records.go
@@ -335,3 +335,57 @@ func (h *Handler) upsertSovereignParentZoneRecordsFromResult(ctx context.Context
 		)
 	}
 }
+
+// deleteSovereignParentZoneRecords is the wipe-side twin of
+// upsertSovereignParentZoneRecords (#4732 item 7). It DELETEs the same
+// rrset names the upsert wrote — every CanonicalSovereignSubdomain plus
+// the bare apex — from the given parent zone, so a wiped Sovereign's
+// records do not linger and route third parties' traffic (or a later
+// same-name re-prov) at a released EIP. Verified live: a wiped env's
+// `console.<fqdn>` still resolved a full day after the wipe.
+//
+// Idempotent: PowerDNS changetype=DELETE on an absent rrset is a 2xx
+// no-op. Best-effort by design — the caller logs and continues so a DNS
+// hiccup never blocks the wipe's cloud purge or record cleanup.
+func (h *Handler) deleteSovereignParentZoneRecords(ctx context.Context, sovereignFQDN, parentZone string) error {
+	if h.powerdnsZoneClient == nil {
+		h.log.Info("sovereign-dns-records: delete skipped (no powerdns client wired)",
+			"sovereignFQDN", sovereignFQDN,
+		)
+		return nil
+	}
+	if sovereignFQDN == "" {
+		return fmt.Errorf("sovereign-dns-records: sovereignFQDN required for delete")
+	}
+	if parentZone == "" {
+		parts := strings.SplitN(sovereignFQDN, ".", 2)
+		if len(parts) == 2 {
+			parentZone = parts[1]
+		} else {
+			parentZone = sovereignFQDN
+		}
+	}
+	subdomains := CanonicalSovereignSubdomains
+	rrsets := make([]powerdns.RRSet, 0, len(subdomains)+1)
+	for _, sub := range subdomains {
+		rrsets = append(rrsets, powerdns.RRSet{
+			Name:       sub + "." + sovereignFQDN + ".",
+			Type:       "A",
+			ChangeType: "DELETE",
+		})
+	}
+	rrsets = append(rrsets, powerdns.RRSet{
+		Name:       sovereignFQDN + ".",
+		Type:       "A",
+		ChangeType: "DELETE",
+	})
+	if err := h.powerdnsZoneClient.PatchRRSets(ctx, parentZone, rrsets); err != nil {
+		return fmt.Errorf("sovereign-dns-records: delete from parent zone %q: %w", parentZone, err)
+	}
+	h.log.Info("sovereign-dns-records: parent zone records deleted for wiped Sovereign",
+		"sovereignFQDN", sovereignFQDN,
+		"parentZone", parentZone,
+		"recordCount", len(rrsets),
+	)
+	return nil
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_dns_records_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_dns_records_test.go
@@ -1,7 +1,12 @@
 package handler
 
 import (
+	"context"
+	"io"
+	"log/slog"
 	"testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/powerdns"
 )
 
 // TestCanonicalSovereignSubdomainsCoversBrowserFacingApps guards the parent-zone
@@ -147,5 +152,62 @@ func TestConsoleGatewaySubdomainSetOverride(t *testing.T) {
 	}
 	if got := recordTargetIP("marketplace", "1.1.1.1", "2.2.2.2", set); got != "1.1.1.1" {
 		t.Errorf("marketplace no longer in overridden set → should resolve to sharedLB; got %q", got)
+	}
+}
+
+// stubZoneClient records PatchRRSets calls for the delete-side test.
+type stubZoneClient struct {
+	zones  []string
+	rrsets [][]powerdns.RRSet
+	err    error
+}
+
+func (s *stubZoneClient) CreateZone(_ context.Context, _ powerdns.ZoneSpec) error { return nil }
+func (s *stubZoneClient) ZoneExists(_ context.Context, _ string) (bool, error)   { return true, nil }
+func (s *stubZoneClient) PatchRRSets(_ context.Context, zone string, rrsets []powerdns.RRSet) error {
+	s.zones = append(s.zones, zone)
+	s.rrsets = append(s.rrsets, rrsets)
+	return s.err
+}
+
+// TestDeleteSovereignParentZoneRecords locks #4732 item 7: the wipe-side
+// teardown DELETEs exactly the rrset names the upsert wrote — every
+// canonical subdomain plus the bare apex — so a wiped Sovereign's records
+// cannot linger and resolve a released EIP (the live console.hw217 case).
+func TestDeleteSovereignParentZoneRecords(t *testing.T) {
+	stub := &stubZoneClient{}
+	h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil)), powerdnsZoneClient: stub}
+
+	if err := h.deleteSovereignParentZoneRecords(context.Background(), "hw217.omani.works", ""); err != nil {
+		t.Fatalf("deleteSovereignParentZoneRecords: %v", err)
+	}
+	if len(stub.zones) != 1 || stub.zones[0] != "omani.works" {
+		t.Fatalf("zones patched = %v, want [omani.works] (derived from FQDN tail)", stub.zones)
+	}
+	got := stub.rrsets[0]
+	// Every canonical subdomain + the apex, all changetype=DELETE.
+	if want := len(CanonicalSovereignSubdomains) + 1; len(got) != want {
+		t.Fatalf("rrset count = %d, want %d (canonical set + apex)", len(got), want)
+	}
+	names := map[string]bool{}
+	for _, rr := range got {
+		if rr.ChangeType != "DELETE" {
+			t.Errorf("rrset %s changetype = %q, want DELETE", rr.Name, rr.ChangeType)
+		}
+		names[rr.Name] = true
+	}
+	for _, must := range []string{"console.hw217.omani.works.", "api.hw217.omani.works.", "hw217.omani.works."} {
+		if !names[must] {
+			t.Errorf("missing DELETE rrset for %s", must)
+		}
+	}
+}
+
+// TestDeleteSovereignParentZoneRecords_NilClientNoop locks the
+// best-effort contract: no powerdns client wired → nil error, no panic.
+func TestDeleteSovereignParentZoneRecords_NilClientNoop(t *testing.T) {
+	h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	if err := h.deleteSovereignParentZoneRecords(context.Background(), "hw217.omani.works", ""); err != nil {
+		t.Fatalf("expected nil error with no client, got %v", err)
 	}
 }

--- a/products/catalyst/bootstrap/api/internal/handler/wipe.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe.go
@@ -600,6 +600,39 @@ func (h *Handler) WipeDeployment(w http.ResponseWriter, r *http.Request) {
 		emit("wipe", "error", providerName+" G103 verification: "+itoa(residualTotal)+" catalyst-* resource(s) survived wipe (bastion-* excluded): "+kindCountSummary(report.ResidualOrphans))
 	}
 
+	// Step 2b — sovereign DNS teardown (#4732 item 7). The prov wrote the
+	// canonical per-Sovereign A records (console/api/marketplace/… + apex)
+	// into EVERY parent zone via upsertSovereignParentZoneRecords; nothing
+	// deleted them on wipe, so a wiped env's `console.<fqdn>` kept
+	// resolving a released EIP (verified live: console.hw217.omani.works
+	// a full day post-wipe — the exact stale-record class #1505 was built
+	// to prevent on the WRITE side). Best-effort + idempotent: a DNS
+	// failure logs and never blocks the purge or record cleanup.
+	{
+		fqdn := dep.Request.SovereignFQDN
+		parents := make([]string, 0, len(dep.Request.ParentDomains))
+		for _, pd := range dep.Request.ParentDomains {
+			if pd.Name != "" {
+				parents = append(parents, pd.Name)
+			}
+		}
+		if len(parents) == 0 && fqdn != "" {
+			if idx := strings.IndexByte(fqdn, '.'); idx > 0 {
+				parents = append(parents, fqdn[idx+1:])
+			}
+		}
+		dnsCtx, dnsCancel := context.WithTimeout(context.Background(), 60*time.Second)
+		for _, parent := range parents {
+			if err := h.deleteSovereignParentZoneRecords(dnsCtx, fqdn, parent); err != nil {
+				report.Errors = append(report.Errors, "sovereign dns teardown ("+parent+"): "+err.Error())
+				emit("wipe", "warn", "sovereign DNS teardown failed for zone "+parent+" — stale records may linger: "+err.Error())
+			} else {
+				emit("wipe", "info", "sovereign DNS records deleted from parent zone "+parent)
+			}
+		}
+		dnsCancel()
+	}
+
 	// Step 3 — PDM release (pool-subdomain only). Resolve pool + subdomain
 	// from either the Deployment record (set during the reservation step)
 	// or from the FQDN as a fallback.


### PR DESCRIPTION
Item 7 of the #4732 defect chain.

**Bug**: the prov writes canonical per-Sovereign A records (`console.<fqdn>`, `api.<fqdn>`, … + apex) into every parent zone, but the wipe never deletes them. Verified live: `console.hw217.omani.works` → `212.72.24.35` a full day after hw217 was wiped — a released EIP that Huawei can reassign to a third party (the same traffic-to-stranger class that motivated #1505 on the write side).

**Fix**: new wipe step 2b calls `deleteSovereignParentZoneRecords` — the delete-side twin of `upsertSovereignParentZoneRecords` — DELETEing the identical rrset name set (canonical subdomains + apex) from every parent zone on the deployment record. Idempotent (PowerDNS DELETE of an absent rrset is a 2xx no-op), best-effort (a DNS failure logs into the wipe report and never blocks the cloud purge or record cleanup), background-context with a 60s budget so a client disconnect can't starve it.

**Verification**: `go build` + `go vet` clean; new tests lock the exact rrset name/changetype set (console/api/apex present, all `DELETE`), the FQDN-tail zone derivation, and the nil-client no-op.

Refs #4732, #1505, #4719.

🤖 Generated with [Claude Code](https://claude.com/claude-code)