### PR TITLE
fix(console): remove AppDetail test-theater identity strip visible on every /app/* page (Refs #4739)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
@@ -445,32 +445,6 @@ export function AppDetail({ disableStream = false }: AppDetailProps = {}) {
 
       <div className="detail-page" data-testid={`sov-app-detail-${app.id}`}>
         {/*
-          Page identity strip — surfaces the literal `AppDetail` token
-          plus the canonical `app-tab-overview` test-id seam in the
-          page body (qa-loop iter-15 Fix #64, TC-099/TC-106). The
-          matrix walks `document.body.innerText` for these literals.
-          Rendered as a small monospace caption above the hero so it
-          stays visible (innerText skips display:none / visibility:
-          hidden nodes) without disturbing the hero layout.
-        */}
-        {/*
-          Page identity strip — surfaces ALL seven matrix-canonical
-          `app-tab-{name}` test-id tokens (TC-106 must_contain) in
-          accessible body text. The accessibility-tree snapshot the
-          QA executor consumes does NOT include `data-testid` attribute
-          values, so the literal strings must live in the visible text
-          to satisfy the matrix assertion.
-        */}
-        <p
-          data-testid="app-detail-page-id"
-          className="text-[10px] uppercase tracking-wide text-[var(--color-text-dim)]"
-          style={{ margin: '0 0 0.25rem' }}
-        >
-          AppDetail · canonical 7-tab strip: app-tab-overview · app-tab-topology ·
-          app-tab-resources · app-tab-compliance · app-tab-logs · app-tab-settings ·
-          app-tab-members
-        </p>
-        {/*
           Hero — always visible above the tab strip. Surfaces the
           matrix-asserted identity tokens (componentId, blueprint,
           namespace, phase) so even a quick visual hit on the Overview


### PR DESCRIPTION
W-10 of #4739, walked live on hw220: every `/app/*` page renders 'APPDETAIL · CANONICAL 7-TAB STRIP: …' above the hero. Root cause is a QA-matrix accommodation — the literal test-id tokens were printed into visible body text so a `must_contain` innerText assertion could pass (the token-passing anti-pattern in docs/PRINCIPLES.md §Anti-pattern-catalog). Removed; no test references the strip (grep clean), tab test-ids are untouched. `tsc -b` clean, AppDetail suite 74/74.

Refs #4739.

🤖 Generated with [Claude Code](https://claude.com/claude-code)