### PR TITLE
fix(org-provisioning): agenity per-Org gate host — MCP-installed agenity unreachable on the Org domain (Refs #4739)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/application_parameters.go
+++ b/products/catalyst/bootstrap/api/internal/handler/application_parameters.go
@@ -133,6 +133,7 @@ func defaultedParameters(blueprint, topology, sovereignFQDN, orgSlug, orgConsole
 		stampAgenitySovereignFqdn(out, sovereignFQDN)
 		stampAgenityMCPBearer(out, orgSlug)
 		stampAgenityMCPTenantHost(out, orgConsoleHost)
+		stampAgenityGateHost(out, orgConsoleHost)
 	}
 
 	if len(out) > 0 {
@@ -258,6 +259,51 @@ func stampAgenityMCPTenantHost(params map[string]interface{}, orgConsoleHost str
 	}
 	mcp["tenantHost"] = host
 	params["openovaMCP"] = mcp
+}
+
+// stampAgenityGateHost sets `parameters.httpRoute.hostnames[0]` to the Org's
+// public agenity app host (agenity.<slug>.<poolParentDomain>, e.g.
+// agenity.nstar.omani.homes) so the chart's `agenity.gateHostname` helper
+// resolves to the ORG host instead of falling back to `agenity.<sovereignFqdn>`
+// (#4739 W-3). Live-confirmed on hw220: the MCP `create_application` door never
+// sets httpRoute.hostnames, so the gate/oidc-gate HTTPRoute rendered on
+// `agenity.hw220.omani.works` — a host with NO DNS record — while the resolvable
+// Org host `agenity.nstar.omani.homes` had no route → agenity unreachable
+// externally (the API-side North Star still passed; only the human front door
+// was split-brained).
+//
+// The Org host is the exact inverse of the mcpTenantHost derivation: swap the
+// leading label of orgConsoleHost (console.<slug>.<pool>) for `agenity` →
+// agenity.<slug>.<pool>. This also keeps the chart's mcpTenantHost helper's
+// fallback derivation (agenity.<zone> → console.<zone>) self-consistent.
+//
+// No-op when:
+//   - orgConsoleHost is empty (mothership / Catalyst-Zero — the chart's
+//     fail-closed `agenity.<sovereignFqdn>` default holds), or
+//   - the caller already pinned a non-empty httpRoute.hostnames (deference —
+//     an explicit host wins, same as the sibling stamps).
+func stampAgenityGateHost(params map[string]interface{}, orgConsoleHost string) {
+	host := strings.ToLower(strings.TrimSpace(orgConsoleHost))
+	if host == "" {
+		return
+	}
+	// console.<slug>.<pool> → <slug>.<pool>; require a dotted host so a bare
+	// label can't produce a zone-less "agenity." host.
+	parts := strings.SplitN(host, ".", 2)
+	if len(parts) != 2 || parts[1] == "" {
+		return
+	}
+	gateHost := "agenity." + parts[1]
+
+	hr, _ := params["httpRoute"].(map[string]interface{})
+	if hr == nil {
+		hr = map[string]interface{}{}
+	}
+	if existing, ok := hr["hostnames"].([]interface{}); ok && len(existing) > 0 {
+		return
+	}
+	hr["hostnames"] = []interface{}{gateHost}
+	params["httpRoute"] = hr
 }
 
 // orgConsoleHostFor resolves the Org's public console host

--- a/products/catalyst/bootstrap/api/internal/handler/application_parameters_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/application_parameters_test.go
@@ -489,3 +489,42 @@ func TestConfigSchema_RejectsExplicitNull_AcceptsEmptyObject(t *testing.T) {
 		t.Fatalf("empty object {} must validate against bp-postgres configSchema, got: %v", repEmpty.Errors)
 	}
 }
+
+// TestDefaultedParameters_AgenityStampsGateHost locks #4739 W-3: the MCP
+// install path must stamp httpRoute.hostnames = [agenity.<slug>.<pool>] from
+// the Org console host, so the chart's gateHostname resolves to the RESOLVABLE
+// Org host instead of falling back to agenity.<sovereignFqdn> (no DNS).
+func TestDefaultedParameters_AgenityStampsGateHost(t *testing.T) {
+	got := defaultedParameters("bp-agenity", "singleton", "hw220.omani.works", "nstar", "console.nstar.omani.homes", nil)
+	hr, ok := got["httpRoute"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected httpRoute block, got %#v", got["httpRoute"])
+	}
+	hosts, ok := hr["hostnames"].([]interface{})
+	if !ok || len(hosts) != 1 || hosts[0] != "agenity.nstar.omani.homes" {
+		t.Fatalf("gate host = %#v, want [agenity.nstar.omani.homes] (Org host, not agenity.hw220.omani.works)", hr["hostnames"])
+	}
+}
+
+// TestDefaultedParameters_AgenityGateHostEmptyOrgConsole_NoStamp: mothership /
+// no-registry-row case → leave the chart's fail-closed sovereignFqdn default.
+func TestDefaultedParameters_AgenityGateHostEmptyOrgConsole_NoStamp(t *testing.T) {
+	got := defaultedParameters("bp-agenity", "singleton", "hw220.omani.works", "nstar", "", nil)
+	if _, present := got["httpRoute"]; present {
+		t.Fatalf("no gate host must be stamped when orgConsoleHost is empty, got %#v", got["httpRoute"])
+	}
+}
+
+// TestDefaultedParameters_AgenityExplicitGateHostWins: an explicit
+// httpRoute.hostnames the caller supplied is never clobbered.
+func TestDefaultedParameters_AgenityExplicitGateHostWins(t *testing.T) {
+	explicit := map[string]interface{}{
+		"httpRoute": map[string]interface{}{"hostnames": []interface{}{"agenity.custom.example"}},
+	}
+	got := defaultedParameters("bp-agenity", "singleton", "hw220.omani.works", "nstar", "console.nstar.omani.homes", explicit)
+	hr := got["httpRoute"].(map[string]interface{})
+	hosts := hr["hostnames"].([]interface{})
+	if hosts[0] != "agenity.custom.example" {
+		t.Fatalf("explicit gate host must win, got %#v", hosts)
+	}
+}


### PR DESCRIPTION
W-3 of #4739, live-confirmed on hw220 (wire evidence in the issue). The MCP `create_application` install path never sets `httpRoute.hostnames`, so `bp-agenity`'s `agenity.gateHostname` helper falls back to `agenity.<sovereignFqdn>` and renders the oidc-gate HTTPRoute on `agenity.hw220.omani.works` (NXDOMAIN), while the resolvable Org host `agenity.nstar.omani.homes` has no route — agenity's human front door is split-brained.

`defaultedParameters` now stamps `httpRoute.hostnames=[agenity.<slug>.<pool>]` from the same `orgConsoleHost` it already resolves for `openovaMCP.tenantHost` (#4624) — swapping the leading `console.` label for `agenity.`, the exact inverse of the chart's `mcpTenantHost` derivation so the two stay self-consistent. No-op on mothership (empty orgConsoleHost) and defers to an explicit host. Build+vet clean, 3 new tests + full handler suite green. This clears the last remaining fault on the Pillar-4 human-facing agentic surface (the MCP/API North Star already passed).

Refs #4739, #4624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)