### PR TITLE
fix(marketplace): banned 'tenant' → Organization on customer surfaces (Refs #4739)

### DIFF
--- a/core/marketplace/playwright/customer-journey.spec.ts
+++ b/core/marketplace/playwright/customer-journey.spec.ts
@@ -308,7 +308,7 @@ test.describe('marketplace customer-journey (17-step regression gate)', () => {
     const res = await page.goto('/')
     expect(res, 'navigation response').not.toBeNull()
     expect(res!.status()).toBeLessThan(400)
-    await expect(page.getByRole('heading', { name: /Build your cloud tenant/i })).toBeVisible()
+    await expect(page.getByRole('heading', { name: /Build your cloud Organization/i })).toBeVisible()
     await expect(page.getByRole('link', { name: /Get Started/i })).toBeVisible()
   })
 

--- a/core/marketplace/src/components/CheckoutStep.svelte
+++ b/core/marketplace/src/components/CheckoutStep.svelte
@@ -342,7 +342,7 @@
         const baseSlug = derivedSlug();
         tenant = await createTenantWithRetry(
           baseSlug,
-          orgName || user.email.split('@')[0] + "'s tenant",
+          orgName || user.email.split('@')[0] + "'s Organization",
         );
         localStorage.setItem(cartKey, tenant.id);
       }
@@ -481,7 +481,7 @@
                 <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
               </svg>
             </div>
-            <h2 class="text-xl font-bold text-[var(--color-text-strong)]">Your tenant is ready!</h2>
+            <h2 class="text-xl font-bold text-[var(--color-text-strong)]">Your Organization is ready!</h2>
             <p class="mt-1 text-sm text-[var(--color-text-dim)]">You'll receive a welcome email shortly.</p>
           {:else if provision.status === 'failed'}
             <div class="mx-auto mb-3 flex h-16 w-16 items-center justify-center rounded-full bg-[var(--color-danger)]/20">
@@ -493,7 +493,7 @@
             <p class="mt-1 text-sm text-[var(--color-text-dim)]">Please contact support.</p>
           {:else}
             <div class="mx-auto mb-3 h-12 w-12 animate-spin rounded-full border-3 border-[var(--color-accent)] border-t-transparent"></div>
-            <h2 class="text-lg font-semibold text-[var(--color-text-strong)]">Setting up your tenant</h2>
+            <h2 class="text-lg font-semibold text-[var(--color-text-strong)]">Setting up your Organization</h2>
           {/if}
         </div>
         <div class="flex flex-col gap-3">
@@ -623,7 +623,7 @@
              already validated in AddonsStep. -->
         <div class="mb-4 space-y-3">
           <div>
-            <label class="text-xs font-medium text-[var(--color-text-dim)]">Tenant name</label>
+            <label class="text-xs font-medium text-[var(--color-text-dim)]">Organization name</label>
             <input
               bind:value={orgName}
               placeholder="My Company"
@@ -664,7 +664,7 @@
                 {:else if slugStatus === 'invalid'}
                   <span class="text-[var(--color-danger)]">Subdomain must be at least 3 characters</span>
                 {:else}
-                  <span class="text-[var(--color-text-dimmer)]">Auto-synced from tenant name — edit to override</span>
+                  <span class="text-[var(--color-text-dimmer)]">Auto-synced from Organization name — edit to override</span>
                 {/if}
               </div>
             </div>

--- a/core/marketplace/src/pages/index.astro
+++ b/core/marketplace/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from '../layouts/Layout.astro';
 ---
-<Layout title="Build Your Tenant">
+<Layout title="Build Your Organization">
   <div class="flex flex-col items-center gap-8 py-16 text-center">
     <div class="flex h-16 w-16 items-center justify-center rounded-2xl bg-[var(--color-accent)]">
       <svg viewBox="0 0 28 28" class="h-10 w-10" fill="none">
@@ -11,7 +11,7 @@ import Layout from '../layouts/Layout.astro';
       </svg>
     </div>
     <h1 class="text-4xl font-bold text-[var(--color-text-strong)]">
-      Build your cloud tenant<br/>in under 5 minutes
+      Build your cloud Organization<br/>in under 5 minutes
     </h1>
     <p class="max-w-lg text-lg text-[var(--color-text-dim)]">
       Choose a plan, pick your apps, set up your domain, and launch.
@@ -29,7 +29,7 @@ import Layout from '../layouts/Layout.astro';
     <div class="mt-8 grid max-w-3xl grid-cols-2 gap-4 text-left sm:grid-cols-4">
       {[
         { icon: '∞', label: 'Unlimited apps' },
-        { icon: '🔒', label: 'Isolated tenant' },
+        { icon: '🔒', label: 'Isolated Organization' },
         { icon: '🌐', label: 'Free subdomains' },
         { icon: '⚡', label: 'One-click deploy' },
       ].map(f => (


### PR DESCRIPTION
W-12 of #4739. The marketplace storefront hero + checkout flow still rendered the banned term **tenant** on customer-visible surfaces (GLOSSARY: `tenant → Organization`): the `<title>`, hero `h1`, an 'Isolated tenant' feature chip, and five checkout strings (progress heading, success heading, form label, helper text, default org-name fallback). All mapped to **Organization** per the canonical correction. The one coupled Playwright assertion (`customer-journey.spec.ts:311`) is updated to the new hero copy. Internal identifiers and API route paths (`tenantId`, `/tenant/orgs`, `tenantHost`) are wire contracts and left unchanged.

Marketplace `astro build` green (11 pages), domain-hygiene gate green.

Refs #4739.