### PR TITLE
fix(sovereign-smtp): operator PIN-login 502 on every Sovereign — seed omits smtp-host (Refs #4748)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_smtp_seed.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_smtp_seed.go
@@ -191,6 +191,33 @@ func (h *Handler) seedSovereignSMTPCredentials(ctx context.Context, dep *Deploym
 		return SovereignSMTPSeedOutcomeSkippedNoEnv
 	}
 
+	// #4748 — the Phase-1 relay host/port/from must be the mothership's
+	// PUBLIC SMTP endpoint (mail.openova.io:587), NOT the mothership's own
+	// CATALYST_SMTP_HOST — that is the in-cluster `stalwart-web.stalwart.svc.
+	// cluster.local` Service (#4696), which does NOT exist on a customer
+	// Sovereign (Sovereigns run no Stalwart). Seeding ONLY smtp-user/smtp-pass
+	// (the original bug) left the chart's `catalyst-openova-kc-credentials`
+	// contract Secret with no source `smtp-host` to win precedence over, so it
+	// fell back to the `.Values.sovereign.smtp.host` in-cluster-Stalwart default
+	// → `no such host` → operator PIN-login 502 on EVERY fresh Sovereign
+	// (hw221 evidence). Seed the reachable public relay so the source-wins
+	// precedence in catalyst-openova-kc-credentials-secret.yaml repoints the
+	// contract Secret to a host that actually answers. Env-overridable so a
+	// bespoke relay can be pinned without a rebuild; defaults match the seed's
+	// stated intent (mail.openova.io:587).
+	relayHost := os.Getenv("CATALYST_SOVEREIGN_SMTP_RELAY_HOST")
+	if relayHost == "" {
+		relayHost = "mail.openova.io"
+	}
+	relayPort := os.Getenv("CATALYST_SOVEREIGN_SMTP_RELAY_PORT")
+	if relayPort == "" {
+		relayPort = "587"
+	}
+	relayFrom := os.Getenv("CATALYST_SOVEREIGN_SMTP_RELAY_FROM")
+	if relayFrom == "" {
+		relayFrom = smtpUser
+	}
+
 	factory := h.sovereignSMTPSeedClientFactory
 	if factory == nil {
 		factory = helmwatch.NewKubernetesClientFromKubeconfig
@@ -276,6 +303,13 @@ func (h *Handler) seedSovereignSMTPCredentials(ctx context.Context, dep *Deploym
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
+			// #4748 — host/port/from are the PUBLIC relay endpoint, not the
+			// mothership's in-cluster Stalwart. Without these three keys the
+			// chart's contract Secret has nothing to win precedence over and
+			// falls back to the unreachable in-cluster-Stalwart default.
+			"smtp-host": []byte(relayHost),
+			"smtp-port": []byte(relayPort),
+			"smtp-from": []byte(relayFrom),
 			"smtp-user": []byte(smtpUser),
 			"smtp-pass": []byte(smtpPass),
 		},
@@ -307,6 +341,8 @@ func (h *Handler) seedSovereignSMTPCredentials(ctx context.Context, dep *Deploym
 		"deploymentID", dep.ID,
 		"namespace", sovereignSMTPSeedNamespace,
 		"name", sovereignSMTPSeedSecretName,
+		"smtpRelayHost", relayHost, // #4748 — not a secret; the reachable public relay
+		"smtpRelayPort", relayPort,
 		"smtpUserBytes", len(smtpUser),
 		"smtpPassBytes", len(smtpPass),
 	)

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_smtp_seed_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_smtp_seed_test.go
@@ -121,6 +121,18 @@ func TestSeedSovereignSMTPCredentials_HappyPath(t *testing.T) {
 		// comparison is enough to flag a regression without leaking.
 		t.Errorf("smtp-pass data length = %d, want %d", len(got.Data["smtp-pass"]), len("p455w0rd-bytes-here-not-real"))
 	}
+	// #4748 — the seed MUST also write the public relay host/port/from, else
+	// the chart contract Secret falls back to the unreachable in-cluster
+	// Stalwart and operator PIN-login 502s on every Sovereign.
+	if string(got.Data["smtp-host"]) != "mail.openova.io" {
+		t.Errorf("smtp-host = %q, want mail.openova.io (public relay, NOT in-cluster stalwart)", got.Data["smtp-host"])
+	}
+	if string(got.Data["smtp-port"]) != "587" {
+		t.Errorf("smtp-port = %q, want 587", got.Data["smtp-port"])
+	}
+	if string(got.Data["smtp-from"]) != "noreply@openova.io" {
+		t.Errorf("smtp-from = %q, want noreply@openova.io (defaults to smtp-user)", got.Data["smtp-from"])
+	}
 	if got.Type != corev1.SecretTypeOpaque {
 		t.Errorf("Secret type = %q, want %q", got.Type, corev1.SecretTypeOpaque)
 	}


### PR DESCRIPTION
The single highest-impact bug from the hw221 fresh-prov walk: **no operator can log into any customer Sovereign console.** `pin/issue` → 502 because catalyst-api SMTP dials `stalwart-web.stalwart.svc.cluster.local` (the mothership-only in-cluster Stalwart; Sovereigns run none) → `no such host`.

**Root cause**: `sovereign_smtp_seed.go` seeded `sovereign-smtp-credentials` with only `smtp-user`/`smtp-pass`, never `smtp-host`/`smtp-port`/`smtp-from`. The chart contract secret's source-wins precedence then had no source host and fell back to the in-cluster-Stalwart `.Values.sovereign.smtp.host` default (#4696 — correct for the mothership, unreachable on a Sovereign). Live-confirmed on hw221: the seed secret has exactly 2 keys.

**Fix**: seed `smtp-host`/`smtp-port`/`smtp-from` = the reachable PUBLIC relay (`mail.openova.io`/`587`/smtp-user), env-overridable. Uses the public endpoint, NOT the mothership's in-cluster `CATALYST_SMTP_HOST`. Mothership untouched. HappyPath test asserts all three keys; `go build` + seed suite green. Unblocks the entire authenticated UAT walk. Refs #4748, #4696, #4739.