### PR TITLE
fix(phase1): console gate 90s→35m — stop false 'failed' on healthy slow provs (Refs #4746)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -614,12 +614,26 @@ func (h *Handler) spawnSecondaryRegionWatchers(dep *Deployment) func() {
 // reachability gate (#4706). A converged Sovereign whose gateway is not yet
 // serving (LB/ELB just being wired) may need a few seconds; a Sovereign whose
 // gateway is genuinely broken (e.g. an unwired Huawei ELB) never comes up and
-// must be classified failed rather than left probing forever. The budget is
-// deliberately short — Phase-1 convergence already took the long path, and the
-// gateway is either up within seconds of it or structurally broken.
+// must be classified failed rather than left probing forever.
+//
+// #4746 — the budget was 90s on the false premise that "the console is up
+// within seconds of OutcomeReady or structurally broken." That is WRONG on a
+// slow 2-region prov: the phase1 watch's ready-census is narrow, so OutcomeReady
+// fires while the console's own server chain (bp-catalyst-platform → bp-gitea →
+// bp-keycloak, whose HR alone has a 30m install budget) is still installing.
+// Live evidence: hw221 fired OutcomeReady at T+24m but the console only answered
+// at T+48m — a 23-MINUTE gap during which the 90s gate falsely stamped a
+// perfectly healthy prov `status=failed` (hw222 repro'd identically). A false
+// "failed" is not cosmetic: it invites a wrong wipe of a converging env.
+// The budget now covers keycloak's full install budget + the downstream
+// gitea/catalyst-platform/cert chain with margin. The gate stays HARD (a
+// genuinely dead console still fails — just after a realistic wait, not 90s),
+// so the hw217/hw218 false-GREEN this probe exists to kill is unaffected. The
+// probe holds no lock while waiting (see markPhase1Done), so a long wait never
+// blocks State() readers.
 const (
-	consoleProbeBudget   = 90 * time.Second
-	consoleProbeInterval = 10 * time.Second
+	consoleProbeBudget   = 35 * time.Minute
+	consoleProbeInterval = 15 * time.Second
 )
 
 // defaultConsoleReachable is the production external-reachability probe for


### PR DESCRIPTION
The #4706 console-reachability gate uses a 90s budget on the false premise that the console is up within seconds of `OutcomeReady`. On a slow 2-region prov the phase1 ready-census is narrow, so `OutcomeReady` fires while the console's server chain (`bp-catalyst-platform → bp-gitea → bp-keycloak`, 30m HR budget) is still installing. **Live evidence (twice): hw221 fired OutcomeReady at T+24m but the console answered at T+48m — a 23-minute gap during which the 90s gate stamped a fully-healthy prov `status=failed`; hw222 repro'd identically.** A false `failed` isn't cosmetic — it invites a wrong wipe of a converging env.

Budget → 35m (covers keycloak's full install budget + downstream chain with margin). The gate stays **HARD** — a genuinely-dead console still fails, just after a realistic wait, so the hw217/hw218 false-GREEN this probe exists to kill is unaffected. Probe holds no lock while waiting. Gate tests use the injected `consoleProbe` seam (timing-independent) — build + Console/Phase1 suite green. Refs #4746.