### PR TITLE
fix(cloud-init): retry cilium rollout-status — stop intermittent 0-HR fresh-prov wedge (Refs #4752)

### DIFF
--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -1297,6 +1297,15 @@ runcmd:
   # (`helm install` would die "cannot re-use a name"). set -e exits on any
   # exhausted retry; a rollout-status failure writes the sentinel + exit 91
   # so "no CNI" is its own loud fault, never a masqueraded Flux wedge.
+  #
+  # #4752 — the cilium rollout-status wait MUST go through `rt` (the 5×/10s
+  # retry helper), like every helm step above it. A single-shot
+  # `rollout status --timeout=240s || exit 91` aborted the WHOLE bootstrap
+  # (Flux never installed → permanent 0-HR wedge) whenever one cilium pod was
+  # merely slow. Live evidence (hw222): the wait timed out at "4 of 5 pods
+  # available", exit 91 fired, and cilium finished healthy seconds later —
+  # too late. Wrapping in `rt` gives cilium up to 5×240s=20m (breaking early
+  # the instant it's Ready) while still failing loud on a genuinely dead CNI.
   - |
     set -e
     export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
@@ -1305,7 +1314,7 @@ runcmd:
     rt helm repo add cilium https://helm.cilium.io/
     rt helm repo update
     rt helm upgrade --install cilium cilium/cilium --version 1.19.3 -n kube-system -f /var/lib/catalyst/cilium-values.yaml
-    kubectl -n kube-system rollout status ds/cilium --timeout=240s || { echo no-cni >/var/lib/catalyst/cilium-bootstrap-FAILED;exit 91;}
+    rt kubectl -n kube-system rollout status ds/cilium --timeout=240s || { echo no-cni >/var/lib/catalyst/cilium-bootstrap-FAILED;exit 91;}
 %{ if provider == "huawei" ~}
   # #4503 root cause (Huawei-gated note; the byte budget is Hetzner-only): on
   # the IPv4-only kom4dc path a single transient failure of get-helm-3 /


### PR DESCRIPTION
Root cause of the long-standing intermittent 0-HR fresh-prov wedge, live-confirmed on hw222. The CP bootstrap's cilium `rollout status` was the **one** step in the `set -e` block NOT wrapped in the `rt()` 5×/10s retry helper (every helm step above it is). A single `rollout status --timeout=240s || exit 91` **aborted the entire bootstrap** — Flux never installed, 0 HelmReleases, no self-heal — whenever one cilium pod was slow.

**hw222 evidence** (cloud-init-output.log via `kubectl debug node`): `Waiting for daemon set cilium rollout to finish: 4 of 5 updated pods available` → `timed out waiting for the condition` → `Failed running runcmd [91]`. cilium finished healthy seconds later — too late.

**Fix**: prefix the wait with `rt` (one word). Gives cilium up to 5×240s=20m, breaks early the instant it's Ready, and still fails loud (sentinel + exit 91) on a genuinely dead CNI. No new `$`/`${` tokens → no tftpl-render risk. Cloud-init is SACRED/thin — this is a minimal, in-pattern change (reuses the existing helper). Validates on the next fresh prov (which should then converge reliably and let the auth-gated UAT walk complete). Refs #4752, #4739.