### PR TITLE
fix(provisioning): gitea-token init reads live secret FILE not stale env — kills 30-min fresh-prov outage (Refs #4756)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1232,7 +1232,7 @@ spec:
       #   stamp spec.parameters.sovereignFqdn so the openova-MCP URL points at
       #   this Sovereign, not the mothership. catalyst-api + application-controller
       #   image fixes (deploy-bot pins on next build). Lockstep w/ Chart.yaml.
-      version: 1.4.1006
+      version: 1.4.1007
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3408,7 +3408,7 @@ name: bp-catalyst-platform
 #   sovereign-fqdn) so GET /catalog/regions returns the Sovereign's REAL
 #   regions instead of [] — the marketplace BCP picker stops falling back to
 #   the hardcoded Hetzner list.
-version: 1.4.1006
+version: 1.4.1007
 # 1.4.980 — #4696: SMTP host default mail.openova.io -> stalwart-web.stalwart.svc.cluster.local
 #           (in-cluster svc, matches auth.go code default) — kill flaky-upstream-DNS PIN-delivery 502s.
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/

--- a/products/catalyst/chart/templates/org-services/provisioning.yaml
+++ b/products/catalyst/chart/templates/org-services/provisioning.yaml
@@ -228,17 +228,16 @@ spec:
             # SAME Secret/key via secretKeyRef so the probe validates exactly
             # what the workload runs with (no kubectl get of the Secret, so
             # no extra RBAC; the kubelet resolves it same-namespace).
-            - name: GITHUB_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.orgServices.provisioning.githubToken.secretName | default "provisioning-github-token" | quote }}
-                  key: {{ .Values.orgServices.provisioning.githubToken.secretKey | default "GITHUB_TOKEN" | quote }}
-                  # optional:true — on the very first reconcile the Secret may
-                  # not exist yet (provisioning-github-token.yaml renders it
-                  # only once the bootstrap PAT is populated). An absent token
-                  # reads as empty and the probe keeps waiting rather than
-                  # crash-looping the init on a missing key.
-                  optional: true
+            # #4756 — read the token from a MOUNTED SECRET FILE (below), not a
+            # secretKeyRef env. A secret-env is resolved ONCE at container start
+            # (empty on first boot) and NEVER updates when the cutover bridge
+            # later mints the real token — so the old env probe waited the full
+            # TIMEOUT_SECONDS (1800s) then exit-1-restarted to re-resolve: a
+            # ~30-min customer-provisioning outage on every fresh prov. A secret
+            # VOLUME file is kubelet-synced live (~60s), and the loop re-reads it
+            # each iteration, so the token is picked up the instant it is minted.
+            - name: GITHUB_TOKEN_FILE
+              value: /var/run/provisioning-github-token/GITHUB_TOKEN
             - name: GITEA_INTERNAL_URL
               value: {{ .Values.orgServices.provisioning.waitForCutoverToken.giteaInternalURL | default "http://gitea-http.gitea.svc.cluster.local:3000" | quote }}
             - name: INTERVAL_SECONDS
@@ -252,6 +251,10 @@ spec:
               echo "[wait-for-gitea-token] gating on a Gitea token Gitea accepts (GET ${GITEA_INTERNAL_URL}/api/v1/user → 200)"
               deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
               while [ "$(date +%s)" -lt "${deadline}" ]; do
+                # #4756 — re-read the token from the kubelet-synced Secret FILE
+                # each iteration; a late-minted token is then picked up live
+                # (a secret ENV would be a stale start-time snapshot forever).
+                GITHUB_TOKEN="$(cat "${GITHUB_TOKEN_FILE}" 2>/dev/null || true)"
                 if [ -z "${GITHUB_TOKEN:-}" ]; then
                   echo "[wait-for-gitea-token] GITHUB_TOKEN not yet populated (Secret absent/empty); retrying in ${INTERVAL_SECONDS}s"
                   sleep "${INTERVAL_SECONDS}"
@@ -287,6 +290,13 @@ spec:
             readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
+          volumeMounts:
+            # #4756 — the kubelet-synced token Secret (live-updating, unlike
+            # a secretKeyRef env). optional:true on the volume so first-boot
+            # (Secret absent) reads as an empty file, not a mount failure.
+            - name: provisioning-github-token
+              mountPath: /var/run/provisioning-github-token
+              readOnly: true
       {{- end }}
       containers:
         - name: provisioning
@@ -556,6 +566,16 @@ spec:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
             runAsUser: 65534
+      volumes:
+        # #4756 — the provisioning-github-token Secret mounted as a
+        # live-synced FILE for the wait-for-gitea-token init probe (which
+        # re-reads it each loop iteration, so a late-minted token is picked up
+        # in ~60s instead of the 1800s init-timeout restart). optional:true so
+        # first-boot (Secret absent) mounts an empty dir, not a mount failure.
+        - name: provisioning-github-token
+          secret:
+            secretName: {{ .Values.orgServices.provisioning.githubToken.secretName | default "provisioning-github-token" | quote }}
+            optional: true
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
The `wait-for-gitea-token` init read GITHUB_TOKEN via a **secretKeyRef env** — resolved once at container start (empty on first boot) and never updated when the cutover bridge mints the real token ~9 min later. So the loop polled its stale empty env for the full 1800s timeout → exit 1 → restart re-resolved → Ready. **~30-min window on every fresh prov where customer-Org provisioning cannot run** (live-confirmed hw223, #4758). Fix: mount the Secret as a volume + re-read the token from the kubelet-synced FILE on each poll (files sync live ~60s, env does not). Main container untouched. helm template renders clean, YAML parse OK. Refs #4756, #4758.