### PR TITLE
fix(org-controller): drop maxLimitRequestRatio on vcluster-Org host ns — unbricks every M+ customer Org (Refs #4758)

### DIFF
--- a/core/controllers/organization/internal/gitops/manifests.go
+++ b/core/controllers/organization/internal/gitops/manifests.go
@@ -370,11 +370,21 @@ spec:
       default:
         cpu: "{{ .DefaultCPU }}"
         memory: "{{ .DefaultMem }}"
-{{- if not .Quota.Burstable }}
-      maxLimitRequestRatio:
-        cpu: "1"
-        memory: "1"
-{{- end }}
+{{- /*
+  #4758 — NO maxLimitRequestRatio on the vcluster-Org host namespace. This
+  template renders the HOST ns of a per-Org vCluster, and the vcluster syncer
+  reflects the vcluster's pods INTO this ns — starting with the vcluster's own
+  bundled system pods (coredns, ratio 50:1 cpu / 2.66:1 mem) which can NEVER be
+  Guaranteed. A maxLimitRequestRatio cpu=1/memory=1 here therefore FORBIDS
+  every synced pod at admission → coredns Pending → the vcluster runs nothing →
+  the customer's first app (WordPress) 404s. Live-confirmed on hw223 uatwalk223
+  (syncer: "forbidden: cpu max limit to request ratio ... is 1, but provided
+  50"). The #4292/W-2 Guaranteed-QoS enforcement belongs on the HOST-namespace
+  Org path (non-vcluster tiers), NOT here — the vcluster boundary + the
+  vcluster's own resource caps provide isolation for vcluster-mode Orgs. The
+  defaultRequest/default above stay (they satisfy the ResourceQuota's
+  "limited resource must be set" admission rule without imposing a ratio).
+*/}}
 `
 
 // networkPolicyTemplate is the default-deny + same-Org-allow baseline rendered

--- a/core/controllers/organization/internal/gitops/manifests_test.go
+++ b/core/controllers/organization/internal/gitops/manifests_test.go
@@ -234,7 +234,12 @@ func TestRender_FlexiNoResourceQuota(t *testing.T) {
 
 // TestRender_LimitRangeGuaranteedRatio proves fixed tiers pin the
 // maxLimitRequestRatio {cpu:1,memory:1} + defaultRequest==default → Guaranteed.
-func TestRender_LimitRangeGuaranteedRatio(t *testing.T) {
+// #4758 — the vcluster-Org host-namespace LimitRange must NOT set
+// maxLimitRequestRatio: the vcluster syncer reflects the vcluster's own
+// (non-Guaranteed) system pods (coredns, ratio 50:1) into this ns, and a
+// ratio=1 forbids every synced pod at admission → vcluster runs nothing →
+// customer app 404. defaultRequest/default stay (quota admission), ratio goes.
+func TestRender_LimitRangeNoRatioForVclusterOrg(t *testing.T) {
 	t.Parallel()
 	out, err := Render(Inputs{Slug: "acme", DisplayName: "Acme", Tier: "org",
 		PlanSlug: "m", SovereignFQDN: "x.example", HostCluster: "hz", VClusterChartVersion: "0.33.*"})
@@ -244,9 +249,6 @@ func TestRender_LimitRangeGuaranteedRatio(t *testing.T) {
 	lr := string(out["vcluster/limitrange.yaml"])
 	for _, want := range []string{
 		"kind: LimitRange",
-		"maxLimitRequestRatio",
-		"cpu: \"1\"",
-		"memory: \"1\"",
 		"defaultRequest:",
 		"default:",
 		"namespace: acme",
@@ -254,6 +256,9 @@ func TestRender_LimitRangeGuaranteedRatio(t *testing.T) {
 		if !strings.Contains(lr, want) {
 			t.Errorf("M-tier limitrange.yaml missing %q\n%s", want, lr)
 		}
+	}
+	if strings.Contains(lr, "maxLimitRequestRatio") {
+		t.Errorf("#4758: vcluster-Org limitrange.yaml must NOT set maxLimitRequestRatio (breaks vcluster pod-sync)\n%s", lr)
 	}
 	var v any
 	if err := yaml.Unmarshal([]byte(lr), &v); err != nil {


### PR DESCRIPTION
Highest-impact bug from the hw223 walk: **every vcluster-mode (M+ plan) customer Org is a non-functional shell** — provisions Ready with a reachable console, but no customer app can run.

**Root cause (live, hw223 uatwalk223)**: the per-Org vcluster syncs its pods into the Org host namespace, starting with the vcluster's own coredns (ratio 50:1). The plan-limits LimitRange set maxLimitRequestRatio {cpu:1,memory:1} (Guaranteed-only, #4292) → admission FORBADE every synced pod → coredns Pending → vcluster runs nothing → WordPress 404. Syncer log: `forbidden: cpu max limit to request ratio is 1, but provided 50`.

**Fix**: this template renders the vcluster-Org host ns, so the ratio must not be set here (it's incompatible with vcluster pod-sync). defaultRequest/default stay for quota admission; Guaranteed-QoS enforcement belongs on the non-vcluster host-namespace Org path. Test asserts the ratio is now absent; go build + gitops suite green. Refs #4758, #4739.