### PR TITLE
fix(console): rename user-facing 'Sandbox' → 'Agenity' nav/page labels (GLOSSARY §Pillar-4)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
@@ -111,7 +111,7 @@ const FLAT_NAV: FlatNavItem[] = [
   // used by Cloud (Tabler cloud) / Apps (grid) / Jobs (clipboard).
   {
     id: 'sandbox',
-    label: 'Sandbox',
+    label: 'Agenity',
     to: '/sandbox',
     icon: 'M3 4a1 1 0 011-1h16a1 1 0 011 1v12a1 1 0 01-1 1H4a1 1 0 01-1-1V4zm5 5l3 3-3 3m5 0h4M8 21h8',
   },

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/sandbox/SandboxLanding.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/sandbox/SandboxLanding.tsx
@@ -95,7 +95,7 @@ export function SandboxLanding({
     <PortalShell
       deploymentId={deploymentId}
       sovereignFQDN={sovereignFQDN}
-      pageTitle="Sandbox"
+      pageTitle="Agenity"
       headerSlotLeft={
         <Link
           to={'/sandbox/settings' as never}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/sandbox/SandboxProvisioningPanel.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/sandbox/SandboxProvisioningPanel.tsx
@@ -322,7 +322,7 @@ export function SandboxProvisioningPanel({
       ) : null}
 
       <ol
-        aria-label="Sandbox provisioning stages"
+        aria-label="Agenity provisioning stages"
         data-testid="sandbox-provisioning-stages"
         className="flex flex-col gap-2"
       >

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/sandbox/SandboxSession.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/sandbox/SandboxSession.tsx
@@ -527,7 +527,7 @@ export function SandboxSession({
     <PortalShell
       deploymentId={deploymentId}
       sovereignFQDN={sovereignFQDN}
-      pageTitle={`Sandbox · ${sessionId || 'session'}`}
+      pageTitle={`Agenity · ${sessionId || 'session'}`}
       headerSlotLeft={
         <Link
           to={'/sandbox' as never}
@@ -563,7 +563,7 @@ export function SandboxSession({
         ) : null}
 
         <section
-          aria-label="Sandbox terminal"
+          aria-label="Agenity terminal"
           data-testid="sandbox-session-card"
           data-connection-phase={phase}
           data-show-terminal={showTerminal ? 'true' : 'false'}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/sandbox/SandboxSettings.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/sandbox/SandboxSettings.tsx
@@ -69,7 +69,7 @@ export function SandboxSettings({
     <PortalShell
       deploymentId={deploymentId}
       sovereignFQDN={sovereignFQDN}
-      pageTitle="Sandbox settings"
+      pageTitle="Agenity settings"
       headerSlotLeft={
         <Link
           to={'/sandbox' as never}


### PR DESCRIPTION
hw224 UAT walk found the sidebar nav + page titles still read **'Sandbox'** where GLOSSARY/DOD §Pillar-4 mandates the user-facing name **'Agenity'** (legacy Sandbox concept dead per founder 2026-06-30). The nav item already routes to the Agenity agent picker — it was just mislabeled.

Renamed 5 user-facing strings (sidebar label + 4 page titles/aria-labels). **Internal plumbing untouched** per the GLOSSARY rule: id `sandbox`, route `/sandbox`, component/file names, `SandboxController` + Sandbox CR all stay. tsc typecheck clean, no test breakage. Found by the hw224 comprehensive walk (⚠️ cosmetic finding). Refs #4739.