### PR TITLE
fix(cilium): native routing to end VXLAN-over-WireGuard MTU DF-drops (DRAFT — needs fresh-prov verify) (Refs #4656)

### DIFF
--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -401,7 +401,16 @@ write_files:
       kubeProxyReplacement: true
       k8sServiceHost: NODE_IP_PLACEHOLDER
       k8sServicePort: 6443
-      tunnelProtocol: vxlan
+      # #4656: NATIVE routing (not vxlan) so WireGuard node-encryption does not
+      # double-encapsulate. VXLAN-inside-WireGuard is unfixable by any MTU —
+      # pinning MTU makes cilium derive wg0 = MTU-80, so pod(MTU)+50(VXLAN)
+      # always exceeds wg0 (proven live on hw224: host 1370 + 50 > wg0 1290).
+      # Nodes are L2-adjacent within a region so autoDirectNodeRoutes installs
+      # cross-node pod routes with no tunnel; the native CIDR is the per-region
+      # k3s cluster CIDR; cross-region reach stays ClusterMesh's job.
+      routingMode: native
+      ipv4NativeRoutingCIDR: "${cluster_cidr}"
+      autoDirectNodeRoutes: true
       bpf:
         masquerade: true
       ipam:

--- a/platform/cilium/chart/Chart.yaml
+++ b/platform/cilium/chart/Chart.yaml
@@ -205,7 +205,7 @@ name: bp-cilium
 # the netbird realm-config idiom, identical to the bp-oidc-gate openova-flow
 # fix (#3447). bp-sso-bridge PUTs client.json template-wins every tick, so the
 # mapper lands on the live hubble-ui client zero-touch.
-version: 1.4.8
+version: 1.4.9
 description: |
   Catalyst-curated Blueprint umbrella chart for Cilium. Depends on the
   upstream `cilium` chart as a Helm subchart so `helm dependency build`

--- a/platform/cilium/chart/values.yaml
+++ b/platform/cilium/chart/values.yaml
@@ -159,10 +159,27 @@ cilium:
   # default) means auto-detect and reproduces the bug.
   #
   # Air-gapped / jumbo-frame (eth0 MTU != 1500) Sovereigns recompute as
-  # `<eth0-mtu> − 130` in their per-Sovereign overlay at clusters/<sov>/
-  # bootstrap-kit/01-cilium.yaml. Native-routing (non-vxlan) Sovereigns,
-  # if ever shipped, override to `<eth0-mtu> − 80` (WG-only) there too.
-  MTU: 1370
+  # `<eth0-mtu> − 80` (WG-only, native routing) in their per-Sovereign overlay
+  # at clusters/<sov>/bootstrap-kit/01-cilium.yaml.
+  #
+  # #4656 (2026-07-04): switched to NATIVE routing (routingMode below) so
+  # WireGuard encapsulates ONCE. VXLAN-inside-WireGuard was UNFIXABLE by any
+  # MTU: pinning MTU makes cilium derive wg0 = MTU−80, so pod(MTU)+50(VXLAN)
+  # ALWAYS exceeds wg0 (proven live hw224: host 1370 + 50 > wg0 1290). With
+  # no VXLAN the WG-only MTU is eth0(1500)−80 = 1420.
+  MTU: 1420
+
+  # #4656: native routing (NOT the upstream vxlan-tunnel default). WireGuard
+  # node-encryption then encapsulates cross-node pod traffic ONCE. Nodes are
+  # L2-adjacent within a region (same VPC subnet) so autoDirectNodeRoutes
+  # installs direct cross-node pod routes with no tunnel. ipv4NativeRoutingCIDR
+  # is auto-derived from ipam.mode=kubernetes node podCIDRs; the bootstrap
+  # cloud-init ALSO pins it explicitly per-region (cluster_cidr) — per-region
+  # CIDRs are 10.42.0.0/16 (region-a) / 10.43.0.0/16 (region-b).
+  # ⚠️ 2-region ClusterMesh cross-region pod reach MUST be fresh-prov-verified
+  # before merge (see #4656 spec) — this is the reviewable starting point.
+  routingMode: native
+  autoDirectNodeRoutes: true
 
   # Hubble — network observability (L3/L4/L7 flows, DNS, drop, http metrics).
   #


### PR DESCRIPTION
**Root cause PROVEN** (live hw224): VXLAN-inside-WireGuard is unfixable by any MTU — pinning `cilium.MTU=X` makes cilium derive `wg0=X-80`, so `pod(X)+50(VXLAN) > wg0` always. #4467's 1370 gave wg0=1290, pod+50=1420 > 1290 → cross-node DF-drop → vcluster apiserver i/o-timeout → customer WordPress never runs + region-b clustermesh Init:0/1.

**Fix**: `routingMode: native` (no VXLAN) so WireGuard encapsulates once; `autoDirectNodeRoutes` for the L2-adjacent region nodes; WG-only MTU = eth0-80 = 1420. Two sites: cloud-init (per-region `${cluster_cidr}`) + bp-cilium chart.

⚠️ **DRAFT — do not merge until fresh-prov-verified.** The 2-region ClusterMesh cross-region path + per-region `ipv4NativeRoutingCIDR` (10.42/10.43) must be proven on a clean 2-region prov (coredns Ready · WordPress 200 in-vcluster · region-b converges) before merge — SACRED cloud-init + stateful datapath = live-gate, not CI. Supersedes #4467. Unblocks the 7 WordPress ❌ + region-b ⚠️ rows in the hw224 full-table walk. Full proof + spec on #4656.