### PR TITLE
fix(cilium,powerdns): unwedge the #4765 live roll — authMode=legacy + kyverno label on the zone-bootstrap hook (Refs #4765)

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -130,7 +130,11 @@ spec:
       # needs no LB-IPAM pool — cilium.gateway.lbIpam + CILIUM_GATEWAY_LB_IPAM_*
       # are retired. Slot folds both gates into one cilium.lbIpam block +
       # postRenderer that suppresses the clustermesh Service NodePort.
-      version: 1.4.9
+      # 1.4.10 (#4765 follow-up): clustermesh apiserver tls.authMode=legacy —
+      # the 1.19.3 default (migration) mounts a helm-managed users CM that the
+      # externally-established Catalyst mesh never renders (both hw224 regions
+      # wedged Init:0/1 FailedMount on the 1.4.9 roll).
+      version: 1.4.10
       sourceRef:
         kind: HelmRepository
         name: bp-cilium
@@ -339,6 +343,18 @@ spec:
       clustermesh:
         useAPIServer: true
         apiserver:
+          # #4765 follow-up (hw224 live, 2026-07-05): cilium 1.19.3 defaults
+          # tls.authMode=migration, which mounts `etcd-users-config` from
+          # ConfigMap `clustermesh-remote-users` — a CM only rendered when
+          # helm itself manages the mesh peer list (clustermesh.config.enabled).
+          # Catalyst establishes the mesh EXTERNALLY (catalyst-api
+          # AutoEstablishClusterMesh distributes CA-signed client certs), so
+          # that CM never exists and the 1.4.9 roll wedged BOTH hw224 regions'
+          # apiserver pods Init:0/1 on FailedMount -> mesh down. legacy =
+          # plain CA-signed client-cert etcd auth, no users CM, matching the
+          # external establish flow exactly.
+          tls:
+            authMode: legacy
           service:
             # #4765 (founder 2026-07-03, "FUCK THE NODEPORTS!!!"): the
             # clustermesh-apiserver Service is LoadBalancer ALWAYS — NodePort

--- a/clusters/_template/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/_template/bootstrap-kit/11-powerdns.yaml
@@ -150,7 +150,7 @@ spec:
       # chart renders the canonical apps.openova.io/v1 Application CR for
       # this slot's HelmRelease so the console /apps list, per-app Topology
       # tab + showback resolve powerdns (no more "no Application CR").
-      version: 1.2.18
+      version: 1.2.19
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns

--- a/platform/cilium/blueprint.yaml
+++ b/platform/cilium/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 1.4.9
+  version: 1.4.10
   card:
     title: Cilium
     summary: Unified CNI + Service Mesh (eBPF). mTLS via WireGuard, Hubble observability, Gateway API.

--- a/platform/cilium/chart/Chart.yaml
+++ b/platform/cilium/chart/Chart.yaml
@@ -220,7 +220,10 @@ name: bp-cilium
 # the netbird realm-config idiom, identical to the bp-oidc-gate openova-flow
 # fix (#3447). bp-sso-bridge PUTs client.json template-wins every tick, so the
 # mapper lands on the live hubble-ui client zero-touch.
-version: 1.4.9
+# 1.4.10 (#4765 follow-up): docs-only bump in lockstep with slot 01
+#   clustermesh.apiserver.tls.authMode=legacy (values live in the slot; the
+#   1.19.3 migration default mounts a users CM external establish never makes).
+version: 1.4.10
 description: |
   Catalyst-curated Blueprint umbrella chart for Cilium. Depends on the
   upstream `cilium` chart as a Helm subchart so `helm dependency build`

--- a/platform/powerdns/blueprint.yaml
+++ b/platform/powerdns/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-2-gitops-and-iac
 spec:
-  version: 1.2.18
+  version: 1.2.19
   card:
     title: PowerDNS
     summary: |

--- a/platform/powerdns/chart/Chart.yaml
+++ b/platform/powerdns/chart/Chart.yaml
@@ -50,7 +50,11 @@ name: bp-powerdns
 # 1.2.17 (#3971): CNPG storageClass empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN.
 # 1.2.18 (#4765): anycast NodePort ERADICATED — serviceType=NodePort fails render;
 #   LoadBalancer renders allocateLoadBalancerNodePorts:false (Cilium LB-IPAM shared VIP).
-version: 1.2.18
+# 1.2.19 (#4765 live-strike): zone-bootstrap hook Job carries
+#   app.kubernetes.io/managed-by: flux — kyverno `flux-managed` policy denied
+#   the hook on upgrade (hw224), rolling back 1.2.18 and stranding the anycast
+#   Service as the forbidden NodePort.
+version: 1.2.19
 description: |
   Catalyst-curated Blueprint wrapper for PowerDNS Authoritative.
   Carries Catalyst-specific values.yaml + templates (CNPG cluster, dnsdist

--- a/platform/powerdns/chart/templates/zone-bootstrap-job.yaml
+++ b/platform/powerdns/chart/templates/zone-bootstrap-job.yaml
@@ -138,6 +138,10 @@ metadata:
   labels:
     {{- include "bp-powerdns.labels" . | nindent 4 }}
     catalyst.openova.io/component: zone-bootstrap
+    # #4765 live-strike: kyverno ClusterPolicy `flux-managed` denies hook Jobs
+    # without this label (blocked the 1.2.18 upgrade on hw224). The hook IS
+    # created by a Flux-driven Helm upgrade; label satisfies the policy.
+    app.kubernetes.io/managed-by: flux
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "10"


### PR DESCRIPTION
Two roll-out defects surfaced by the #4766 canon landing live on hw224:

1. **Clustermesh apiservers wedged Init:0/1 on BOTH regions** — cilium 1.19.3 defaults `clustermesh.apiserver.tls.authMode=migration`, which mounts `etcd-users-config` from ConfigMap `clustermesh-remote-users`. That CM is only rendered when helm itself manages the mesh peer list; Catalyst establishes the mesh externally (catalyst-api distributes CA-signed client certs), so the CM never exists → FailedMount → mesh down. Fix: `authMode: legacy` (plain CA-signed client-cert etcd auth, no users CM) in slot 01. bp-cilium 1.4.9→1.4.10 + pin lockstep.

2. **bp-powerdns 1.2.18 upgrade denied by kyverno `flux-managed` policy** on the zone-bootstrap post-upgrade hook Job (helm hooks carry no Flux ownerRef), rolling the release back and stranding the anycast Service as the forbidden NodePort. Fix: the hook Job carries `app.kubernetes.io/managed-by: flux` (it IS created by a Flux-driven Helm upgrade). bp-powerdns 1.2.18→1.2.19 + blueprint + pin lockstep.

Render proofs: zone-bootstrap Job renders with the flux label; zero nodePort fields; `scripts/check-no-nodeports.sh` green.

Refs #4765

🤖 Generated with [Claude Code](https://claude.com/claude-code)