### PR TITLE
fix(dashboard): treemap full component inventory + [progress,kind] default + dormant cutover collapse (Refs #4731)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/jobs.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs.go
@@ -684,12 +684,25 @@ func (h *Handler) jobsStore() *jobs.Store {
 	return h.jobs
 }
 
+// fullInventoryRequested reports whether the caller asked for the FULL
+// platform inventory (?inventory=full) instead of the default #3996
+// finite-work view. The Dashboard treemap (#4731) sets it so a converged
+// Sovereign shows every HelmRelease install / Flux Kustomization / CronJob
+// / reconciler Deployment / cutover step; the Jobs page omits it and keeps
+// the finite list. Matching is case-insensitive + whitespace-trimmed.
+func fullInventoryRequested(r *http.Request) bool {
+	return strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("inventory")), "full")
+}
+
 // ListJobs handles GET /api/v1/deployments/{depId}/jobs.
 //
 // Returns `{ "jobs": [...] }` — the slice is sorted started-at DESC
 // with pending Jobs (no StartedAt) bucketed last. Empty deployment →
 // empty slice (not null) so the JSON shape never breaks the
 // frontend's render loop.
+//
+// ?inventory=full (#4731) returns the complete tree (the treemap's data
+// source); the default is the #3996 finite-work list.
 func (h *Handler) ListJobs(w http.ResponseWriter, r *http.Request) {
 	st := h.jobsStore()
 	if st == nil {
@@ -741,17 +754,28 @@ func (h *Handler) ListJobs(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	// /jobs is the FINITE-work view (#3996 follow-up): drop the continuous
-	// reconcilers (Flux HelmRelease installs, Kustomization reconciles, and
-	// long-running reconciler Deployments) so the founder sees jobs that
-	// start/run/end — provision + cutover steps, batch Jobs, CronJob runs,
-	// one-shot Day-2 mutations — instead of an ever-growing wall of
-	// always-on reconcilers. Those reconcilers now live ONLY on the Cloud
-	// Reconciliation lens + reconciler-management surface (#3996), which
-	// reads them LIVE from the cluster; the store keeps the full set, only
-	// this view is narrowed. GetJob stays unfiltered so a deep-link to a
-	// reconciler row still resolves.
-	out = jobs.FilterFiniteJobs(out)
+	// /jobs is the FINITE-work view (#3996 follow-up) BY DEFAULT: drop the
+	// continuous reconcilers (Flux HelmRelease installs, Kustomization
+	// reconciles, and long-running reconciler Deployments) so the founder
+	// sees jobs that start/run/end — provision + cutover steps, batch Jobs,
+	// CronJob runs, one-shot Day-2 mutations — instead of an ever-growing
+	// wall of always-on reconcilers. Those reconcilers live on the Cloud
+	// Reconciliation lens + reconciler-management surface (#3996); the store
+	// keeps the full set, only this view is narrowed. GetJob stays unfiltered
+	// so a deep-link to a reconciler row still resolves.
+	//
+	// #4731 — the Dashboard treemap needs the FULL platform inventory (every
+	// HelmRelease install, Flux Kustomization, CronJob, reconciler
+	// Deployment, cutover step) so a CONVERGED Sovereign renders ~90+ leaves,
+	// not the ~14 finite rows the filtered view leaves behind. It opts in via
+	// ?inventory=full, which SKIPS FilterFiniteJobs and returns the complete
+	// tree. The default (no param) keeps the finite Jobs-page view byte-for-
+	// byte, so the two consumers never regress each other. The store already
+	// holds the full inventory (the chroot/mother seeds every HelmRelease,
+	// reconciler, and cutover step); only this read decides how much to show.
+	if !fullInventoryRequested(r) {
+		out = jobs.FilterFiniteJobs(out)
+	}
 	if out == nil {
 		out = []jobs.Job{}
 	}

--- a/products/catalyst/bootstrap/api/internal/handler/jobs_inventory_full_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_inventory_full_test.go
@@ -1,0 +1,102 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
+)
+
+// TestHandler_ListJobs_InventoryFull pins the #4731 amendment: the default
+// /jobs view stays the #3996 FINITE list (continuous install / reconcile /
+// reconciler leaves dropped), but ?inventory=full returns the COMPLETE
+// platform inventory the Dashboard treemap needs so a converged Sovereign
+// renders every HelmRelease install, Flux Kustomization, and reconciler
+// Deployment — not just the ~14 finite rows the founder saw.
+func TestHandler_ListJobs_InventoryFull(t *testing.T) {
+	r, st, _ := newJobsAPIRouter(t)
+	depID := "dep-inventory"
+
+	t0 := time.Date(2026, 7, 5, 12, 0, 0, 0, time.UTC)
+	bkParent := jobs.JobID(depID, jobs.GroupBootstrapKit)
+	recParent := jobs.JobID(depID, jobs.GroupReconcilers)
+	cutParent := jobs.JobID(depID, jobs.GroupCutover)
+	seed := []jobs.Job{
+		// bootstrap-kit + continuous HelmRelease installs — dropped by the
+		// finite view, MUST reappear under ?inventory=full.
+		{DeploymentID: depID, JobName: jobs.GroupBootstrapKit, DisplayName: jobs.GroupBootstrapKitDisplay, Type: jobs.JobTypeGroup, Status: jobs.StatusPending},
+		{DeploymentID: depID, JobName: "install-cilium", AppID: "cilium", Kind: jobs.KindInstall, Type: jobs.JobTypeInstall, ParentID: bkParent, Status: jobs.StatusSucceeded, StartedAt: &t0, FinishedAt: ptrTime(t0.Add(20 * time.Second))},
+		{DeploymentID: depID, JobName: "install-keycloak", AppID: "keycloak", Kind: jobs.KindInstall, Type: jobs.JobTypeInstall, ParentID: bkParent, Status: jobs.StatusSucceeded, StartedAt: &t0, FinishedAt: ptrTime(t0.Add(30 * time.Second))},
+		// reconcilers group: a Flux Kustomization (dropped by finite) + a
+		// reconciler Deployment (dropped) + a CronJob (kept both ways).
+		{DeploymentID: depID, JobName: jobs.GroupReconcilers, DisplayName: jobs.GroupReconcilersDisplay, Type: jobs.JobTypeGroup, Status: jobs.StatusPending},
+		{DeploymentID: depID, JobName: "reconcile-flux-system", Kind: jobs.KindReconcile, Type: jobs.JobTypeInstall, ParentID: recParent, Status: jobs.StatusRunning, StartedAt: &t0},
+		{DeploymentID: depID, JobName: "reconciler-pool-domain-manager", Kind: jobs.KindReconciler, Type: jobs.JobTypeInstall, ParentID: recParent, Status: jobs.StatusHealthy, StartedAt: &t0},
+		{DeploymentID: depID, JobName: "cron-trivy-scan", Kind: jobs.KindCron, Type: jobs.JobTypeInstall, ParentID: recParent, Status: jobs.StatusHealthy, StartedAt: &t0},
+		// cutover group: a dormant step (kept both ways — it is finite).
+		{DeploymentID: depID, JobName: jobs.GroupCutover, DisplayName: jobs.GroupCutoverDisplay, Type: jobs.JobTypeGroup, Status: jobs.StatusPending},
+		{DeploymentID: depID, JobName: "cutover-step-01-gitea", Kind: jobs.KindStep, Type: jobs.JobTypeInstall, ParentID: cutParent, Status: jobs.StatusPending},
+	}
+	for _, j := range seed {
+		if err := st.UpsertJob(j); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	names := func(path string) map[string]string {
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		if rec.Code != 200 {
+			t.Fatalf("%s: code %d", path, rec.Code)
+		}
+		var resp struct {
+			Jobs []jobs.Job `json:"jobs"`
+		}
+		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		out := map[string]string{}
+		for _, j := range resp.Jobs {
+			out[j.JobName] = j.Kind
+		}
+		return out
+	}
+
+	// Default (finite) view: continuous install/reconcile/reconciler leaves
+	// are gone; only the finite cutover step + cron survive.
+	finite := names("/api/v1/deployments/" + depID + "/jobs")
+	for _, dropped := range []string{"install-cilium", "install-keycloak", "reconcile-flux-system", "reconciler-pool-domain-manager"} {
+		if _, ok := finite[dropped]; ok {
+			t.Errorf("finite /jobs leaked continuous reconciler %q", dropped)
+		}
+	}
+	if _, ok := finite["cutover-step-01-gitea"]; !ok {
+		t.Errorf("finite /jobs dropped the finite cutover step")
+	}
+
+	// Full inventory: every leaf present — the 2 installs, the Kustomization,
+	// the reconciler Deployment, the cron, and the cutover step.
+	full := names("/api/v1/deployments/" + depID + "/jobs?inventory=full")
+	for _, want := range []struct{ name, kind string }{
+		{"install-cilium", jobs.KindInstall},
+		{"install-keycloak", jobs.KindInstall},
+		{"reconcile-flux-system", jobs.KindReconcile},
+		{"reconciler-pool-domain-manager", jobs.KindReconciler},
+		{"cron-trivy-scan", jobs.KindCron},
+		{"cutover-step-01-gitea", jobs.KindStep},
+	} {
+		if got, ok := full[want.name]; !ok {
+			t.Errorf("inventory=full missing %q", want.name)
+		} else if got != want.kind {
+			t.Errorf("inventory=full %q kind = %q, want %q", want.name, got, want.kind)
+		}
+	}
+	// The install leaves that the finite view dropped now outnumber it —
+	// full inventory is strictly a superset.
+	if len(full) <= len(finite) {
+		t.Errorf("inventory=full (%d leaves) should exceed finite (%d)", len(full), len(finite))
+	}
+}

--- a/products/catalyst/bootstrap/ui/src/lib/treemap.types.test.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/treemap.types.test.ts
@@ -124,6 +124,16 @@ describe('statusColor (#4731 categorical channel)', () => {
   it('renders an absent statusKind as the pending tint — never success', () => {
     expect(statusColor(undefined)).toBe(statusColor('pending'))
   })
+
+  it('#4731 — dormant tints from a DISTINCT dimmer grey token, not pending', () => {
+    // A distinct dimmer grey token + a lower mix — the parked cutover tether
+    // reads "asleep", never a genuine warning hue and never the same as
+    // pending queued work.
+    expect(statusColor('dormant')).toContain('var(--color-text-dimmer)')
+    expect(statusColor('dormant')).toMatch(/^color-mix\(in srgb, var\(--color-/)
+    expect(statusColor('dormant')).not.toMatch(/#[0-9a-fA-F]{3,8}/)
+    expect(statusColor('dormant')).not.toBe(statusColor('pending'))
+  })
 })
 
 describe('aggregateStatusKinds (#4731 bucket rollup)', () => {
@@ -136,6 +146,14 @@ describe('aggregateStatusKinds (#4731 bucket rollup)', () => {
     expect(aggregateStatusKinds(['success', 'success'])).toBe('success')
     expect(aggregateStatusKinds(['pending', 'pending'])).toBe('pending')
     expect(aggregateStatusKinds([])).toBe('pending')
+  })
+
+  it('#4731 — an all-dormant bucket rolls up dormant; any real work wins', () => {
+    expect(aggregateStatusKinds(['dormant', 'dormant'])).toBe('dormant')
+    // A dormant leaf mixed with genuinely queued work reads pending, never
+    // dormant — real work is never hidden behind a parked tether.
+    expect(aggregateStatusKinds(['dormant', 'pending'])).toBe('pending')
+    expect(aggregateStatusKinds(['dormant', 'failed'])).toBe('failed')
   })
 })
 

--- a/products/catalyst/bootstrap/ui/src/lib/treemap.types.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/treemap.types.ts
@@ -328,6 +328,10 @@ const STATUS_FILL_MIX_PCT: Record<StatusKind, number> = {
   warning: 65,
   failed: 70,
   pending: 16,
+  // #4731 — even FAINTER than pending so a parked/dormant tether reads as
+  // "asleep" rather than "queued". The treemap pairs this with a dashed
+  // outline (see SquarifiedCell) for an unmistakable dormant ≠ pending cue.
+  dormant: 8,
 }
 
 export function statusColor(kind: StatusKind | undefined): string {
@@ -348,6 +352,11 @@ export function aggregateStatusKinds(kinds: readonly StatusKind[]): StatusKind {
   if (kinds.some((k) => k === 'warning')) return 'warning'
   if (kinds.some((k) => k === 'in-progress')) return 'in-progress'
   if (kinds.every((k) => k === 'success')) return 'success'
+  // #4731 — an all-dormant bucket (the parked cutover tether) rolls up as
+  // dormant, never pending. Any real work in the bucket wins over dormant
+  // (handled by the branches above / the pending fall-through below), so
+  // dormant only surfaces when it is the ONLY thing present.
+  if (kinds.every((k) => k === 'dormant')) return 'dormant'
   if (kinds.some((k) => k === 'success')) return 'in-progress'
   return 'pending'
 }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/ConvergenceWizard.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/ConvergenceWizard.test.tsx
@@ -258,42 +258,58 @@ describe('Dashboard state-aware view', () => {
     expect(size.value).toBe('uniform')
   })
 
-  it('AUTO-MORPHS to the resource defaults when status is ready', async () => {
+  // #4731 amend (founder escalation 2026-07-05): the ready default NO LONGER
+  // flips to the resource stack — the founder rejected that ("why is the
+  // second layer not kind by default"). [progress, kind] is the default
+  // UNCONDITIONALLY, converging AND converged.
+  it('KEEPS the [progress, kind] default when status is ready (no morph)', async () => {
     stubEventsFetch({ status: 'ready' } as DeploymentSnapshot)
     renderDashboard()
-    // Once the ready snapshot resolves, the SAME pane re-defaults to the
-    // resource treemap (jsdom runs in mothership mode → family layer 1).
+    await screen.findByTestId('dashboard-treemap-frame')
+    // Even on a converged (ready) Sovereign the default stack stays
+    // [progress, kind] coloured by status — never the old
+    // [family/organization, application] + utilisation flip.
     await waitFor(() => {
-      const layer0 = screen.getByTestId('treemap-layer-0-select') as HTMLSelectElement
-      expect(layer0.value).toBe('family')
+      expect(
+        (screen.getByTestId('treemap-layer-0-select') as HTMLSelectElement).value,
+      ).toBe('progress')
     })
+    const layer1 = screen.getByTestId('treemap-layer-1-select') as HTMLSelectElement
     const colour = screen.getByTestId('treemap-color-select') as HTMLSelectElement
     const size = screen.getByTestId('treemap-size-select') as HTMLSelectElement
-    expect(colour.value).toBe('utilization')
-    expect(size.value).toBe('cpu_request')
+    expect(layer1.value).toBe('kind')
+    expect(colour.value).toBe('status')
+    expect(size.value).toBe('uniform')
     expect(screen.queryByTestId('dashboard-view-toggle')).toBeNull()
   })
 
-  it('post-ready the operator can re-stack BACK to Progress (cutover/cron view)', async () => {
+  it('the resource stack (family/application + utilisation) stays selectable on ready', async () => {
+    // MUST-PRESERVE: org / application / utilization are never removed —
+    // they are just no longer the default. The operator re-stacks to the
+    // pods/utilisation view by picking non-job dimensions for BOTH layers.
     stubEventsFetch({ status: 'ready' } as DeploymentSnapshot)
     renderDashboard()
     await waitFor(() => {
       expect(
         (screen.getByTestId('treemap-layer-0-select') as HTMLSelectElement).value,
-      ).toBe('family')
+      ).toBe('progress')
     })
-    // Re-adding the Progress dimension flips the stack back to the
-    // job source; colour/size re-derive to the job vocabulary.
     fireEvent.change(screen.getByTestId('treemap-layer-0-select'), {
-      target: { value: 'progress' },
+      target: { value: 'family' },
+    })
+    fireEvent.change(screen.getByTestId('treemap-layer-1-select'), {
+      target: { value: 'application' },
     })
     await waitFor(() => {
-      const layer0 = screen.getByTestId('treemap-layer-0-select') as HTMLSelectElement
-      expect(layer0.value).toBe('progress')
+      expect(
+        (screen.getByTestId('treemap-layer-1-select') as HTMLSelectElement).value,
+      ).toBe('application')
     })
+    // A fully non-job stack sources from pods/utilisation again: colour/size
+    // re-derive to the resource vocabulary.
     const colour = screen.getByTestId('treemap-color-select') as HTMLSelectElement
     const size = screen.getByTestId('treemap-size-select') as HTMLSelectElement
-    expect(colour.value).toBe('status')
-    expect(size.value).toBe('uniform')
+    expect(colour.value).toBe('utilization')
+    expect(size.value).toBe('cpu_request')
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.progress-layers.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.progress-layers.test.tsx
@@ -1,25 +1,26 @@
 /**
  * Dashboard.progress-layers.test.tsx — #4731 Progress + Kind as
- * first-class layers of the EXISTING editable treemap (supersedes the
- * deleted ProvisioningTreemap suite).
+ * first-class layers of the EXISTING editable treemap, AMENDED per the
+ * founder's four escalation complaints (2026-07-05).
  *
- * Coverage:
- *   • buildJobsTreemapData — group-bucket derivation from the REAL
- *     `type=group` rows in dependency (topological) order; kind buckets
- *     nested under; individual job leaves with jobId/statusKind/
- *     statusLabel and uniform size.
- *   • Status colour mapping — the full 7-value JobStatus vocabulary
- *     incl. the HEALTH axis (healthy→green, degraded→amber,
- *     failing→red).
- *   • Sparse-group fallback — a store with only the `provisioner`
- *     group buckets by kind-derived lifecycle stages instead.
- *   • jobTileHref — JobsTable-identical JobDetail link convention
- *     (bare job name, deployment-scoped on the mothership).
- *   • Render — the converging Dashboard defaults to the job-sourced
- *     Progress→Kind stack, renders real /jobs data as treemap cells,
- *     pulses running cells, shows the categorical legend, and a job
- *     leaf CLICK navigates to that job's JobDetail with the CORRECT
- *     deployment id.
+ * The four complaints, each with the test that proves it dies:
+ *
+ *   1. "where are all the other items" (full inventory) —
+ *      `buildJobsTreemapData` surfaces EVERY component as a leaf,
+ *      including the HelmRelease installs the finite /jobs view dropped
+ *      (the treemap now reads ?inventory=full). See
+ *      `renders the full platform inventory as leaves`.
+ *   2. "second layer is not kind by default" — the default stack is
+ *      [progress, kind] UNCONDITIONALLY, incl. a converged (ready) env.
+ *      See `defaults to [progress, kind] even when status=ready`.
+ *   3. "cutover kinds still showing as pending" — the dormant cutover
+ *      steps collapse into ONE `cutover (dormant)` leaf in a Dormant
+ *      bucket, coloured dormant-grey, never pending. See
+ *      `collapses the dormant cutover steps ...` +
+ *      `pending non-cutover work stays in Pending, dormant is separate`.
+ *   4. relevance on both moments — the progress layer buckets by STATE
+ *      (Running/Pending/Done/Degraded/Failed/Dormant), orthogonal to
+ *      kind, so both a converging and a converged env read meaningfully.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
@@ -34,19 +35,21 @@ import {
   Outlet,
 } from '@tanstack/react-router'
 
-import {
-  Dashboard,
-} from './Dashboard'
+import { Dashboard } from './Dashboard'
 import {
   buildJobsTreemapData,
   jobTileHref,
+  progressStateForKind,
   PROVISIONING_DEFAULT_LAYERS,
+  PROGRESS_STATES,
+  CUTOVER_DORMANT_LEAF_NAME,
   KIND_STAGES,
 } from './dashboardJobsTreemap'
 import { useWizardStore } from '@/entities/deployment/store'
 import { INITIAL_WIZARD_STATE } from '@/entities/deployment/model'
 import type { Job, JobStatus } from '@/lib/jobs.types'
 import type { TreemapItem } from '@/lib/treemap.types'
+import type { ApplicationDescriptor } from './applicationCatalog'
 
 afterEach(() => {
   cleanup()
@@ -74,103 +77,46 @@ function J(partial: Partial<Job> & Pick<Job, 'id' | 'jobName'>): Job {
 }
 
 /**
- * Canonical converging store: three top-level groups chained by
- * dependsOn (provisioner → bootstrap-kit → day-2-mutations), leaves of
- * several kinds/statuses, plus one UNGROUPED cron leaf. The array is
- * deliberately SHUFFLED so bucket order can only come from the
- * dependency edges, never from input order.
+ * Full-inventory fixture (post ?inventory=full) in miniature: the four
+ * top groups + install / reconcile / reconciler / cron / lifecycle leaves
+ * + a DORMANT cutover (3 steps, all pending). Mirrors the hw224 converged
+ * shape: mostly Done, one running reconcile, and the parked cutover tether.
+ * Deliberately SHUFFLED so bucket order can only come from state/stage
+ * order, never input order.
  */
-function threeGroupJobs(): Job[] {
+function fullInventoryJobs(): Job[] {
   return [
-    // Shuffled on purpose: day-2 group first.
-    J({
-      id: `${DEP}:day-2-mutations`, jobName: 'day-2-mutations',
-      displayName: 'Day-2 Mutations', type: 'group', kind: 'group',
-      dependsOn: [`${DEP}:bootstrap-kit`],
-      childIds: [`${DEP}:mutation-add-node`, `${DEP}:reconciler-pdm`],
-    }),
-    J({
-      id: `${DEP}:mutation-add-node`, jobName: 'mutation-add-node',
-      kind: 'mutation', parentId: `${DEP}:day-2-mutations`, status: 'pending',
-    }),
-    J({
-      id: `${DEP}:reconciler-pdm`, jobName: 'reconciler-pdm',
-      kind: 'reconciler', parentId: `${DEP}:day-2-mutations`, status: 'degraded',
-    }),
-    J({
-      id: `${DEP}:bootstrap-kit`, jobName: 'bootstrap-kit',
-      displayName: 'Bootstrap', type: 'group', kind: 'group',
-      dependsOn: [`${DEP}:provisioner`],
-      childIds: [
-        `${DEP}:install-cilium`, `${DEP}:install-keycloak`,
-        `${DEP}:reconcile-flux-system`, `${DEP}:cutover-step-01-gitea`,
-      ],
-    }),
-    J({
-      id: `${DEP}:install-cilium`, jobName: 'install-cilium',
-      kind: 'install', appId: 'bp-cilium',
-      parentId: `${DEP}:bootstrap-kit`, status: 'succeeded',
-    }),
-    J({
-      id: `${DEP}:install-keycloak`, jobName: 'install-keycloak',
-      kind: 'install', appId: 'bp-keycloak',
-      parentId: `${DEP}:bootstrap-kit`, status: 'failed',
-    }),
-    J({
-      id: `${DEP}:reconcile-flux-system`, jobName: 'reconcile-flux-system',
-      kind: 'reconcile', parentId: `${DEP}:bootstrap-kit`, status: 'running',
-    }),
-    J({
-      id: `${DEP}:cutover-step-01-gitea`, jobName: 'cutover-step-01-gitea',
-      kind: 'step', parentId: `${DEP}:bootstrap-kit`, status: 'pending',
-    }),
-    J({
-      id: `${DEP}:provisioner`, jobName: 'provisioner',
-      displayName: 'Provisioner', type: 'group', kind: 'group',
-      childIds: [`${DEP}:lifecycle-tofu-apply`, `${DEP}:lifecycle-tofu-init`],
-    }),
-    J({
-      id: `${DEP}:lifecycle-tofu-init`, jobName: 'lifecycle-tofu-init',
-      kind: 'lifecycle', parentId: `${DEP}:provisioner`, status: 'succeeded',
-    }),
-    J({
-      id: `${DEP}:lifecycle-tofu-apply`, jobName: 'lifecycle-tofu-apply',
-      kind: 'lifecycle', parentId: `${DEP}:provisioner`, status: 'succeeded',
-    }),
-    // Ungrouped recurring leaf — must fall back to its kind stage even
-    // though the group set is NOT sparse.
-    J({
-      id: `${DEP}:cron-trivy-scan`, jobName: 'cron-trivy-scan',
-      kind: 'cron', status: 'healthy', runCount: 600,
-    }),
+    J({ id: `${DEP}:cutover`, jobName: 'cutover', displayName: 'Cutover', type: 'group', kind: 'group' }),
+    J({ id: `${DEP}:cutover-step-02-harbor`, jobName: 'cutover-step-02-harbor', kind: 'step', parentId: `${DEP}:cutover`, status: 'pending' }),
+    J({ id: `${DEP}:cutover-step-01-gitea`, jobName: 'cutover-step-01-gitea', kind: 'step', parentId: `${DEP}:cutover`, status: 'pending' }),
+    J({ id: `${DEP}:cutover-step-03-flux`, jobName: 'cutover-step-03-flux', kind: 'step', parentId: `${DEP}:cutover`, status: 'pending' }),
+    J({ id: `${DEP}:bootstrap-kit`, jobName: 'bootstrap-kit', displayName: 'Bootstrap', type: 'group', kind: 'group' }),
+    J({ id: `${DEP}:install-cilium`, jobName: 'install-cilium', kind: 'install', appId: 'bp-cilium', parentId: `${DEP}:bootstrap-kit`, status: 'succeeded' }),
+    J({ id: `${DEP}:install-keycloak`, jobName: 'install-keycloak', kind: 'install', appId: 'bp-keycloak', parentId: `${DEP}:bootstrap-kit`, status: 'succeeded' }),
+    J({ id: `${DEP}:install-gitea`, jobName: 'install-gitea', kind: 'install', appId: 'bp-gitea', parentId: `${DEP}:bootstrap-kit`, status: 'succeeded' }),
+    J({ id: `${DEP}:reconcilers`, jobName: 'reconcilers', displayName: 'Reconcilers', type: 'group', kind: 'group' }),
+    J({ id: `${DEP}:reconcile-flux`, jobName: 'reconcile-flux-system', kind: 'reconcile', parentId: `${DEP}:reconcilers`, status: 'running' }),
+    J({ id: `${DEP}:reconciler-pdm`, jobName: 'reconciler-pool-domain-manager', kind: 'reconciler', parentId: `${DEP}:reconcilers`, status: 'healthy' }),
+    J({ id: `${DEP}:cron-trivy`, jobName: 'cron-trivy-scan', kind: 'cron', parentId: `${DEP}:reconcilers`, status: 'healthy', runCount: 600 }),
+    J({ id: `${DEP}:provisioner`, jobName: 'provisioner', displayName: 'Provisioner', type: 'group', kind: 'group' }),
+    J({ id: `${DEP}:tofu-apply`, jobName: 'lifecycle-tofu-apply', kind: 'lifecycle', parentId: `${DEP}:provisioner`, status: 'succeeded' }),
   ]
 }
 
-/** hw220-shape sparse store: ONLY the provisioner group exists. */
-function sparseGroupJobs(): Job[] {
-  return [
-    J({
-      id: `${DEP}:provisioner`, jobName: 'provisioner',
-      displayName: 'Provisioner', type: 'group', kind: 'group',
-      childIds: [
-        `${DEP}:lifecycle-tofu-apply`, `${DEP}:install-cilium`,
-        `${DEP}:reconcile-flux-system`,
-      ],
-    }),
-    J({
-      id: `${DEP}:lifecycle-tofu-apply`, jobName: 'lifecycle-tofu-apply',
-      kind: 'lifecycle', parentId: `${DEP}:provisioner`, status: 'succeeded',
-    }),
-    J({
-      id: `${DEP}:install-cilium`, jobName: 'install-cilium',
-      kind: 'install', appId: 'bp-cilium',
-      parentId: `${DEP}:provisioner`, status: 'running',
-    }),
-    J({
-      id: `${DEP}:reconcile-flux-system`, jobName: 'reconcile-flux-system',
-      kind: 'reconcile', parentId: `${DEP}:provisioner`, status: 'failing',
-    }),
-  ]
+/** Minimal ApplicationDescriptor for the expected-catalog merge tests. */
+function App(bareId: string): ApplicationDescriptor {
+  return {
+    id: `bp-${bareId}`,
+    bareId,
+    title: bareId,
+    description: '',
+    familyId: 'platform',
+    familyName: 'Platform',
+    tier: 'mandatory',
+    logoUrl: null,
+    dependencies: [],
+    bootstrapKit: true,
+  }
 }
 
 function leafByJobId(items: readonly TreemapItem[], jobId: string): TreemapItem | undefined {
@@ -182,48 +128,72 @@ function leafByJobId(items: readonly TreemapItem[], jobId: string): TreemapItem 
   return undefined
 }
 
-/* ── Unit: derivation ─────────────────────────────────────────────── */
+function bucketByName(items: readonly TreemapItem[], name: string): TreemapItem | undefined {
+  return items.find((i) => i.name === name)
+}
 
-describe('buildJobsTreemapData — progress buckets from real group rows', () => {
-  it('binds the progress layer to the type=group rows in dependency order', () => {
-    const data = buildJobsTreemapData(threeGroupJobs(), PROVISIONING_DEFAULT_LAYERS)
-    // Group buckets first (topological over dependsOn — NOT input
-    // order, which deliberately leads with day-2), then the kind-stage
-    // fallback bucket for the ungrouped cron leaf.
-    expect(data.items.map((i) => i.name)).toEqual([
-      'Provisioner',
-      'Bootstrap',
-      'Day-2 Mutations',
-      'Recurring',
-    ])
-    // total_count = leaf jobs only (groups are buckets, not items).
-    expect(data.total_count).toBe(9)
-    // Bucket ids are the REAL group job ids so drill state stays stable
-    // across the 5s polling rebuilds.
-    expect(data.items[0]?.id).toBe(`${DEP}:provisioner`)
+function allLeaves(items: readonly TreemapItem[]): TreemapItem[] {
+  const out: TreemapItem[] = []
+  for (const it of items) {
+    if (it.children && it.children.length) out.push(...allLeaves(it.children))
+    else out.push(it)
+  }
+  return out
+}
+
+/* ── Unit: progress = STATE, kind = KIND ──────────────────────────── */
+
+describe('buildJobsTreemapData — progress buckets by STATE (#4731 amend)', () => {
+  it('defaults are [progress, kind] and progress buckets are the STATES', () => {
+    expect(PROVISIONING_DEFAULT_LAYERS).toEqual(['progress', 'kind'])
+    const data = buildJobsTreemapData(fullInventoryJobs(), PROVISIONING_DEFAULT_LAYERS)
+    // Only non-empty state buckets, in state order: Running < Done < Dormant.
+    expect(data.items.map((i) => i.name)).toEqual(['Running', 'Done', 'Dormant'])
+    // total_count = the TRUE inventory size (every underlying leaf incl. the
+    // 3 collapsed cutover steps) — 10 leaves total (no applications catalog
+    // passed here, so no upfront-seeded pending leaves).
+    expect(data.total_count).toBe(10)
   })
 
-  it('nests kind buckets under progress (its types under the second layer)', () => {
-    const data = buildJobsTreemapData(threeGroupJobs(), PROVISIONING_DEFAULT_LAYERS)
-    const kit = data.items.find((i) => i.name === 'Bootstrap')
-    // Bootstrap has install + reconcile + step leaves → 3 kind buckets
-    // in stage order.
-    expect(kit?.children?.map((c) => c.name)).toEqual(['Install', 'Reconcile', 'Step'])
-    const installs = kit?.children?.find((c) => c.name === 'Install')
-    expect(installs?.children).toHaveLength(2)
-    // Leaves carry the JobDetail discriminator + uniform size.
-    const keycloak = installs?.children?.find((c) => c.jobId === `${DEP}:install-keycloak`)
-    expect(keycloak?.size_value).toBe(1)
-    expect(keycloak?.name).toBe('install-keycloak')
+  it('progressStateForKind maps every status kind onto its state bucket', () => {
+    expect(progressStateForKind('in-progress')).toBe('running')
+    expect(progressStateForKind('success')).toBe('done')
+    expect(progressStateForKind('warning')).toBe('degraded')
+    expect(progressStateForKind('failed')).toBe('failed')
+    expect(progressStateForKind('pending')).toBe('pending')
+    expect(progressStateForKind('dormant')).toBe('dormant')
+  })
+
+  it('complaint #1 — renders the full platform inventory as leaves (installs are NOT dropped)', () => {
+    const data = buildJobsTreemapData(fullInventoryJobs(), PROVISIONING_DEFAULT_LAYERS)
+    // Every HelmRelease install surfaces as a leaf — the exact rows the
+    // finite /jobs view dropped and the founder said were "missing".
+    for (const id of [`${DEP}:install-cilium`, `${DEP}:install-keycloak`, `${DEP}:install-gitea`]) {
+      expect(leafByJobId(data.items, id), id).toBeTruthy()
+    }
+    // The Done bucket's kind sub-buckets carry the installs + the healthy
+    // reconciler + cron + lifecycle, in stage order.
+    const done = bucketByName(data.items, 'Done')
+    expect(done?.children?.map((c) => c.name)).toEqual(['Lifecycle', 'Install', 'Cron', 'Reconciler'])
+    const installs = done?.children?.find((c) => c.name === 'Install')
+    expect(installs?.children).toHaveLength(3)
+  })
+
+  it('complaint #4 — running reconcile lands in Running, colours by status', () => {
+    const data = buildJobsTreemapData(fullInventoryJobs(), PROVISIONING_DEFAULT_LAYERS)
+    const running = bucketByName(data.items, 'Running')
+    expect(running?.statusKind).toBe('in-progress')
+    expect(leafByJobId(running?.children ?? [], `${DEP}:reconcile-flux`)?.statusKind).toBe('in-progress')
+    // Done bucket rolls up green.
+    expect(bucketByName(data.items, 'Done')?.statusKind).toBe('success')
   })
 
   it('supports the kind dimension standalone (layers=[kind]) in stage order', () => {
-    const data = buildJobsTreemapData(threeGroupJobs(), ['kind'])
-    const names = data.items.map((i) => i.name)
-    // Stage order: Lifecycle < Install < Reconcile < Mutation < Step <
-    // Cron < Reconciler (only the kinds present appear).
-    expect(names).toEqual([
-      'Lifecycle', 'Install', 'Reconcile', 'Mutation', 'Step', 'Cron', 'Reconciler',
+    const data = buildJobsTreemapData(fullInventoryJobs(), ['kind'])
+    // Only present kinds appear, in stage order. The 3 dormant cutover
+    // steps collapse to ONE Step leaf.
+    expect(data.items.map((i) => i.name)).toEqual([
+      'Lifecycle', 'Install', 'Reconcile', 'Step', 'Cron', 'Reconciler',
     ])
     expect(KIND_STAGES.lifecycle.order).toBeLessThan(KIND_STAGES.install.order)
   })
@@ -234,8 +204,6 @@ describe('buildJobsTreemapData — progress buckets from real group rows', () =>
       ['running', 'in-progress'],
       ['failed', 'failed'],
       ['pending', 'pending'],
-      // HEALTH axis (#3646 §4c): running-forever-and-correct is green,
-      // degraded amber, failing red — never grey.
       ['healthy', 'success'],
       ['degraded', 'warning'],
       ['failing', 'failed'],
@@ -247,39 +215,125 @@ describe('buildJobsTreemapData — progress buckets from real group rows', () =>
     for (const [i, [s, expected]] of statuses.entries()) {
       const leaf = leafByJobId(data.items, `${DEP}:install-x${i}`)
       expect(leaf?.statusKind, `${s} → ${expected}`).toBe(expected)
-      // The raw status word is preserved for the tooltip/sub-label.
       expect(leaf?.statusLabel).toBe(s)
     }
   })
+})
 
-  it('rolls leaf kinds up onto buckets (failed > warning > in-progress > success)', () => {
-    const data = buildJobsTreemapData(threeGroupJobs(), PROVISIONING_DEFAULT_LAYERS)
-    const byName = new Map(data.items.map((i) => [i.name, i]))
-    // Bootstrap: succeeded + failed + running + pending → failed wins.
-    expect(byName.get('Bootstrap')?.statusKind).toBe('failed')
-    // Provisioner: all succeeded → success.
-    expect(byName.get('Provisioner')?.statusKind).toBe('success')
-    // Day-2: pending + degraded → warning wins.
-    expect(byName.get('Day-2 Mutations')?.statusKind).toBe('warning')
-    // Recurring: healthy → success.
-    expect(byName.get('Recurring')?.statusKind).toBe('success')
+/* ── Unit: dormant cutover collapse (complaint #3) ────────────────── */
+
+describe('buildJobsTreemapData — dormant cutover collapse (#4731 complaint #3)', () => {
+  it('collapses the dormant cutover steps into ONE dormant leaf, never pending', () => {
+    const data = buildJobsTreemapData(fullInventoryJobs(), PROVISIONING_DEFAULT_LAYERS)
+    // There is NO Pending bucket — the 3 pending cutover steps did NOT
+    // pollute it (the founder's exact complaint).
+    expect(bucketByName(data.items, 'Pending')).toBeUndefined()
+    // The Dormant bucket holds exactly ONE aggregate leaf, coloured dormant.
+    const dormant = bucketByName(data.items, 'Dormant')
+    expect(dormant?.statusKind).toBe('dormant')
+    const dormantLeaves = allLeaves(dormant?.children ?? [])
+    expect(dormantLeaves).toHaveLength(1)
+    expect(dormantLeaves[0]?.name).toBe(CUTOVER_DORMANT_LEAF_NAME)
+    expect(dormantLeaves[0]?.statusKind).toBe('dormant')
+    // The aggregate carries the collapsed step count (3) + deep-links to
+    // the Cutover group so a click opens the per-step detail.
+    expect(dormantLeaves[0]?.count).toBe(3)
+    expect(dormantLeaves[0]?.jobId).toBe(`${DEP}:cutover`)
+    // No individual cutover-step leaf leaked anywhere.
+    expect(leafByJobId(data.items, `${DEP}:cutover-step-01-gitea`)).toBeUndefined()
   })
 
-  it('falls back to kind-derived lifecycle stages on a sparse group set (hw220 shape)', () => {
-    const data = buildJobsTreemapData(sparseGroupJobs(), PROVISIONING_DEFAULT_LAYERS)
-    // ONE group only → sparse → the progress buckets are the
-    // kind-derived stages, in dependency order, NOT 'Provisioner'.
-    expect(data.items.map((i) => i.name)).toEqual([
-      'Infrastructure', 'Installs', 'Reconciles',
-    ])
-    expect(data.items.map((i) => i.name)).not.toContain('Provisioner')
-    // The failing reconcile still surfaces red through the fallback.
-    expect(data.items.find((i) => i.name === 'Reconciles')?.statusKind).toBe('failed')
+  it('pending NON-cutover work stays in Pending; dormant cutover is separate', () => {
+    const jobs = [
+      ...fullInventoryJobs(),
+      // A genuinely queued (pending) install — belongs in Pending.
+      J({ id: `${DEP}:install-openbao`, jobName: 'install-openbao', kind: 'install', appId: 'bp-openbao', parentId: `${DEP}:bootstrap-kit`, status: 'pending' }),
+    ]
+    const data = buildJobsTreemapData(jobs, PROVISIONING_DEFAULT_LAYERS)
+    // Pending bucket now exists (the openbao install) and holds it.
+    const pending = bucketByName(data.items, 'Pending')
+    expect(pending?.statusKind).toBe('pending')
+    expect(leafByJobId(pending?.children ?? [], `${DEP}:install-openbao`)).toBeTruthy()
+    // Dormant is still its own separate bucket — pending and dormant never
+    // share a bucket.
+    expect(bucketByName(data.items, 'Dormant')?.statusKind).toBe('dormant')
+    expect(leafByJobId(pending?.children ?? [], `${DEP}:cutover`)).toBeUndefined()
+  })
+
+  it('once cutover FIRES (any step non-pending) the steps expand as live leaves', () => {
+    const jobs = fullInventoryJobs().map((j) =>
+      j.jobName === 'cutover-step-01-gitea' ? { ...j, status: 'succeeded' as JobStatus } : j,
+    )
+    const data = buildJobsTreemapData(jobs, PROVISIONING_DEFAULT_LAYERS)
+    // The dormant aggregate is gone; individual steps render again.
+    expect(leafByJobId(data.items, `${DEP}:cutover`)).toBeUndefined()
+    expect(allLeaves(data.items).some((l) => l.name === CUTOVER_DORMANT_LEAF_NAME)).toBe(false)
+    expect(leafByJobId(data.items, `${DEP}:cutover-step-01-gitea`)?.statusKind).toBe('success')
+    // The two still-pending steps land in Pending (real queued work now).
+    expect(leafByJobId(bucketByName(data.items, 'Pending')?.children ?? [], `${DEP}:cutover-step-02-harbor`)).toBeTruthy()
+  })
+
+  it('PROGRESS_STATES colours dormant grey and orders it last', () => {
+    expect(PROGRESS_STATES.dormant.statusKind).toBe('dormant')
+    expect(PROGRESS_STATES.dormant.order).toBeGreaterThan(PROGRESS_STATES.done.order)
+    expect(PROGRESS_STATES.running.order).toBeLessThan(PROGRESS_STATES.pending.order)
   })
 })
 
+/* ── Upfront full expected inventory (founder: "see all at once") ──── */
+
+describe('buildJobsTreemapData — upfront expected inventory from t=0', () => {
+  // The full planned catalog for a tiny prov: 5 bootstrap-kit slots.
+  const catalog = [
+    App('cilium'),
+    App('cert-manager'),
+    App('flux'),
+    App('keycloak'),
+    App('gitea'),
+  ]
+
+  it('seeds EVERY expected component as a pending leaf at provisioning start', () => {
+    // t=0: only the provisioner lifecycle rows exist as jobs — no HR has
+    // reconciled yet. The map must STILL show all 5 planned installs.
+    const t0Jobs = [
+      J({ id: `${DEP}:provisioner`, jobName: 'provisioner', displayName: 'Provisioner', type: 'group', kind: 'group' }),
+      J({ id: `${DEP}:tofu-apply`, jobName: 'lifecycle-tofu-apply', kind: 'lifecycle', parentId: `${DEP}:provisioner`, status: 'running' }),
+    ]
+    const data = buildJobsTreemapData(t0Jobs, PROVISIONING_DEFAULT_LAYERS, catalog)
+    // Full expected inventory = 5 planned installs (pending) + 1 lifecycle
+    // (running). total_count counts every planned component from the start.
+    expect(data.total_count).toBe(6)
+    const pendingInstalls = bucketByName(data.items, 'Pending')?.children?.find((c) => c.name === 'Install')
+    expect(pendingInstalls?.children).toHaveLength(5)
+    // Every planned install leaf is pending (queued), NOT missing.
+    for (const c of pendingInstalls?.children ?? []) {
+      expect(c.statusKind).toBe('pending')
+    }
+  })
+
+  it('the live job WINS over the planned pending leaf as convergence progresses', () => {
+    // cilium install has started + succeeded; the other 4 are still planned.
+    const jobs = [
+      J({ id: `${DEP}:bootstrap-kit`, jobName: 'bootstrap-kit', displayName: 'Bootstrap', type: 'group', kind: 'group' }),
+      J({ id: `${DEP}:install-cilium`, jobName: 'install-cilium', kind: 'install', appId: 'cilium', parentId: `${DEP}:bootstrap-kit`, status: 'succeeded' }),
+    ]
+    const data = buildJobsTreemapData(jobs, PROVISIONING_DEFAULT_LAYERS, catalog)
+    // No duplicate cilium: it appears ONCE, in Done (the live job wins).
+    expect(leafByJobId(data.items, `${DEP}:install-cilium`)?.statusKind).toBe('success')
+    const doneInstalls = bucketByName(data.items, 'Done')?.children?.find((c) => c.name === 'Install')
+    expect(allLeaves(doneInstalls?.children ?? [])).toHaveLength(1)
+    // The remaining 4 planned installs are still pending.
+    const pendingInstalls = bucketByName(data.items, 'Pending')?.children?.find((c) => c.name === 'Install')
+    expect(pendingInstalls?.children).toHaveLength(4)
+    // Total still equals the full expected inventory (5 installs) — never
+    // fewer, never doubled.
+    expect(data.total_count).toBe(5)
+  })
+})
+
+/* ── jobTileHref (unchanged convention) ───────────────────────────── */
+
 describe('jobTileHref — JobsTable-identical JobDetail link convention', () => {
-  // jsdom runs in catalyst-zero (mothership) mode.
   it('builds the deployment-scoped path with the bare job name', () => {
     expect(jobTileHref(`${DEP}:install-keycloak`, DEP)).toBe(
       `/provision/${DEP}/jobs/install-keycloak`,
@@ -351,13 +405,12 @@ function renderDashboard() {
   return { ...utils, router }
 }
 
-describe('Dashboard — job-sourced Progress treemap (converging defaults)', () => {
+describe('Dashboard — job-sourced Progress treemap render', () => {
   beforeEach(() => {
     useWizardStore.setState({ ...INITIAL_WIZARD_STATE })
-    stubFetch(threeGroupJobs(), 'phase1-watching')
-    // jsdom lays out nothing: force a measurable surface width so
-    // SquarifiedSurface clears its `width > 0` gate and mounts cells
-    // (same harness as the Dashboard drill suite).
+    // status=ready: the CONVERGED moment — the map must STILL default to
+    // [progress, kind] (complaint #2) and render the full inventory.
+    stubFetch(fullInventoryJobs(), 'ready')
     Object.defineProperty(HTMLDivElement.prototype, 'clientWidth', {
       configurable: true,
       get() {
@@ -379,49 +432,52 @@ describe('Dashboard — job-sourced Progress treemap (converging defaults)', () 
       SyncResizeObserver
   })
 
-  it('renders the /jobs tree as treemap cells with status colours + pulse + legend', async () => {
+  it('complaint #2 — defaults to [progress, kind] even when status=ready', async () => {
+    renderDashboard()
+    await screen.findByTestId('dashboard-treemap-frame')
+    // The two default layer selects are Progress + Kind — NOT the old
+    // ready-flip to Organization / Application.
+    const layer0 = (await screen.findByTestId('treemap-layer-0-select')) as HTMLSelectElement
+    const layer1 = (await screen.findByTestId('treemap-layer-1-select')) as HTMLSelectElement
+    expect(layer0.value).toBe('progress')
+    expect(layer1.value).toBe('kind')
+    // Job-sourced ⇒ Color=Status, Size=Uniform (auto-locked to the job vocab).
+    expect((screen.getByTestId('treemap-color-select') as HTMLSelectElement).value).toBe('status')
+    expect((screen.getByTestId('treemap-size-select') as HTMLSelectElement).value).toBe('uniform')
+  })
+
+  it('renders the /jobs inventory as status-coloured cells + dormant + legend', async () => {
     const { container } = renderDashboard()
     await screen.findByTestId('dashboard-treemap-frame')
-    // Job-sourced cells mounted from the REAL fetch (no override seam).
     await waitFor(() => {
-      expect(
-        container.querySelector(`g[data-job-id="${DEP}:install-keycloak"]`),
-      ).toBeTruthy()
+      expect(container.querySelector(`g[data-job-id="${DEP}:install-keycloak"]`)).toBeTruthy()
     })
-    const failed = container.querySelector(`g[data-job-id="${DEP}:install-keycloak"]`)!
-    const running = container.querySelector(`g[data-job-id="${DEP}:reconcile-flux-system"]`)!
-    const healthy = container.querySelector(`g[data-job-id="${DEP}:cron-trivy-scan"]`)!
-    expect(failed.getAttribute('data-status-kind')).toBe('failed')
+    const done = container.querySelector(`g[data-job-id="${DEP}:install-keycloak"]`)!
+    const running = container.querySelector(`g[data-job-id="${DEP}:reconcile-flux"]`)!
+    expect(done.getAttribute('data-status-kind')).toBe('success')
     expect(running.getAttribute('data-status-kind')).toBe('in-progress')
-    // HEALTH axis: healthy renders green (success), never grey.
-    expect(healthy.getAttribute('data-status-kind')).toBe('success')
-    // Running cells pulse — visibly distinct from pending/success.
+    // The dormant cutover aggregate renders as a dormant cell (dashed).
+    const dormant = container.querySelector(`g[data-job-id="${DEP}:cutover"]`)!
+    expect(dormant.getAttribute('data-status-kind')).toBe('dormant')
+    expect(dormant.querySelector('rect[style*="dasharray"]')).toBeTruthy()
+    // Running cells pulse; the categorical legend carries the Dormant swatch.
     expect(running.querySelector('rect.dash-cell-pulse')).toBeTruthy()
-    expect(failed.querySelector('rect.dash-cell-pulse')).toBeNull()
-    // Categorical legend replaces the gradient bar in status mode.
+    expect(screen.getByTestId('dashboard-legend-status-dormant')).toBeTruthy()
     expect(screen.getByTestId('dashboard-legend-status-success')).toBeTruthy()
-    expect(screen.getByTestId('dashboard-legend-status-failed')).toBeTruthy()
-    expect(screen.getByTestId('dashboard-legend-status-in-progress')).toBeTruthy()
   })
 
   it('job-leaf click navigates to that job\'s JobDetail with the CORRECT deployment id', async () => {
     const { container, router } = renderDashboard()
     await screen.findByTestId('dashboard-treemap-frame')
     await waitFor(() => {
-      expect(
-        container.querySelector(`g[data-job-id="${DEP}:install-keycloak"]`),
-      ).toBeTruthy()
+      expect(container.querySelector(`g[data-job-id="${DEP}:install-keycloak"]`)).toBeTruthy()
     })
-    const leafG = container.querySelector(
-      `g[data-job-id="${DEP}:install-keycloak"]`,
-    ) as SVGGElement
+    const leafG = container.querySelector(`g[data-job-id="${DEP}:install-keycloak"]`) as SVGGElement
     expect((leafG.getAttribute('style') ?? '').includes('pointer')).toBe(true)
     leafG.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     await waitFor(() => {
       expect(screen.queryByTestId('job-detail-target')).toBeTruthy()
     })
-    expect(router.state.location.pathname).toBe(
-      `/provision/${DEP}/jobs/install-keycloak`,
-    )
+    expect(router.state.location.pathname).toBe(`/provision/${DEP}/jobs/install-keycloak`)
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.tsx
@@ -82,6 +82,7 @@ import { resolveApplications } from './applicationCatalog'
 // module, same co-location pattern as ./jobs.ts).
 import {
   buildJobsTreemapData,
+  cellDashedFor,
   cellFillFor,
   cellPulseFor,
   jobTileHref,
@@ -200,46 +201,22 @@ export function Dashboard({
 
   const isReady = (snapshot?.status ?? '').trim().toLowerCase() === 'ready'
 
-  // #3687 fold #3692 (2026-06-18): default Layer-1 = `organization` on the
-  // Sovereign Console so the operator's landing treemap groups by the
-  // owning Organization (customer estate vs platform overhead) drillable
-  // to Application — the canonical object model the Lane-E UAT asserts,
-  // not a raw infra pod treemap. The Organization dimension keys on the
-  // `openova.io/organization` label join key (same as the per-Org
-  // showback); host/control-plane pods roll into a single "Platform
-  // overhead" bucket. Operators can still pivot to cluster/region for the
-  // multi-region topology view via the Layer-1 selector.
+  // #4731 amend (founder escalation 2026-07-05): the default layer stack is
+  // [progress, kind] UNCONDITIONALLY — on a provisioning env AND on a
+  // converged (ready) env. The prior code flipped the ready default to
+  // [organization, application] + utilization; the founder rejected that
+  // ("why the second layer is not kind by default"). The one treemap now
+  // reads the FULL platform inventory in BOTH moments: converging fills
+  // Running/Pending, converged is a big green Done block sub-divided by
+  // kind, with the parked cutover tether in Dormant. organization /
+  // application / utilization stay AVAILABLE — one click away in the layer
+  // controller — they are just no longer the default.
   //
-  // Prior default was `['cluster', 'application']` (PR M, 2026-05-17 t142
-  // founder follow-up #1) so multi-region operators saw the 3-cluster
-  // grouping; cluster/region remain one click away in the selector.
-  //
-  // Wave 2 Family D (t10 regression): the snapshot-driven `sovereignFQDN`
-  // is fetched asynchronously via SSE — on first paint it is null, so the
-  // default must NOT depend on it. Read mode synchronously from
-  // `DETECTED_MODE` (window.location-derived at module load, stable for
-  // the lifetime of the page) — the SAME source the SovereignSidebar +
-  // cloud-list routes use for their mode-gated rendering, so default
-  // Layer-1 stays consistent with the rest of the sidebar's Sovereign
-  // affordances and is deterministic on first paint.
-  const readyDefaultLayers: readonly TreemapDimension[] =
-    DETECTED_MODE.mode === 'sovereign'
-      ? ['organization', 'application']
-      : ['family', 'application']
-
-  // #4731 — state-aware DEFAULTS on the one treemap (replaces the #3925
-  // Progress ⇄ Treemap component toggle): while the deployment is
-  // converging the pane defaults to the job-sourced Progress→Kind stack
-  // coloured by status; the moment status flips `ready` the defaults
-  // morph to the resource treemap. Same pane, same component — only the
-  // defaults change.
-  //
-  // Implementation (same pattern as the old userView): the `user*`
-  // states stay null until the operator touches a control; the
-  // effective value is the user's choice if set, else derived. This
-  // auto-morphs on ready WITHOUT a setState-in-effect storm and
-  // respects a manual override (DECISION: the user keeps control once
-  // they touch the toolbar — no auto-flip-back).
+  // Implementation (same pattern as the old userView): the `user*` states
+  // stay null until the operator touches a control; the effective value is
+  // the user's choice if set, else the [progress, kind] default. No
+  // status-gated flip, no setState-in-effect storm; the user keeps control
+  // once they touch the toolbar.
   const [userLayers, setUserLayers] = useState<readonly TreemapDimension[] | null>(
     initialLayers ?? null,
   )
@@ -249,8 +226,7 @@ export function Dashboard({
   const [userSizeBy, setUserSizeBy] = useState<TreemapSizeBy | null>(
     initialSizeBy ?? null,
   )
-  const layers: readonly TreemapDimension[] =
-    userLayers ?? (isReady ? readyDefaultLayers : PROVISIONING_DEFAULT_LAYERS)
+  const layers: readonly TreemapDimension[] = userLayers ?? PROVISIONING_DEFAULT_LAYERS
   // The data-source rule (#4731, the only conditional): progress/kind
   // in the stack → Job tree; anything else → getDashboardTreemap.
   const jobSourced = isJobSourcedStack(layers)
@@ -331,6 +307,9 @@ export function Dashboard({
     deploymentId,
     enabled: jobSourced && !initialDataOverride && !!deploymentId,
     disablePolling: disableStream || isReady,
+    // #4731 — the treemap always wants the FULL platform inventory so a
+    // converged Sovereign shows every component, not the ~14 finite rows.
+    fullInventory: true,
   })
   const jobsTreemap = useMemo<TreemapData | undefined>(
     () => (jobSourced ? buildJobsTreemapData(liveJobs, layers, applications) : undefined),
@@ -377,6 +356,9 @@ export function Dashboard({
    * page's active colorBy. */
   const fillFor = (item: TreemapItem) => cellFillFor(colorBy, item)
   const pulseFor = (item: TreemapItem) => cellPulseFor(colorBy, item)
+  // #4731 — dormant cells (the parked cutover tether) render with a dashed
+  // outline so they are unmistakably distinct from solid pending cells.
+  const dashedFor = (item: TreemapItem) => cellDashedFor(colorBy, item)
   useEffect(() => {
     _onCellHover = (info) => {
       if (hoverTimerRef.current !== null) {
@@ -682,6 +664,7 @@ export function Dashboard({
               isNested={isNested}
               fillFor={fillFor}
               pulseFor={pulseFor}
+              dashedFor={dashedFor}
               onCellHover={(info) => _onCellHover?.(info)}
               onCellClick={(item, depth) => _onCellClick?.(item, depth)}
             />
@@ -881,6 +864,10 @@ const STATUS_LEGEND_ENTRIES: { kind: StatusKind; label: string }[] = [
   { kind: 'warning', label: 'Degraded' },
   { kind: 'failed', label: 'Failed / failing' },
   { kind: 'pending', label: 'Pending' },
+  // #4731 — the parked/dormant tether (installed-but-never-fired cutover),
+  // grey + dashed. Distinct from pending so the operator never reads the
+  // dormant cutover as queued work.
+  { kind: 'dormant', label: 'Dormant' },
 ]
 
 function Legend({ colorBy }: { colorBy: TreemapColorBy }) {
@@ -977,6 +964,9 @@ interface SquarifiedSurfaceProps {
   fillFor: (item: TreemapItem) => string
   /** True when the cell should pulse (status mode, in-progress). */
   pulseFor: (item: TreemapItem) => boolean
+  /** True when the cell should render a dashed outline (status mode,
+   *  dormant — the parked cutover tether, #4731). */
+  dashedFor: (item: TreemapItem) => boolean
   onCellHover: (info: CellHoverInfo | null) => void
   onCellClick: (item: TreemapItem, depth: number) => void
 }
@@ -996,6 +986,7 @@ function SquarifiedSurface({
   isNested,
   fillFor,
   pulseFor,
+  dashedFor,
   onCellHover,
   onCellClick,
 }: SquarifiedSurfaceProps) {
@@ -1050,6 +1041,7 @@ function SquarifiedSurface({
               rect={r}
               fillFor={fillFor}
               pulseFor={pulseFor}
+              dashedFor={dashedFor}
               onHover={onCellHover}
               onClick={onCellClick}
             />
@@ -1064,11 +1056,12 @@ interface SquarifiedCellProps {
   rect: SquarifiedRect
   fillFor: (item: TreemapItem) => string
   pulseFor: (item: TreemapItem) => boolean
+  dashedFor: (item: TreemapItem) => boolean
   onHover: (info: CellHoverInfo | null) => void
   onClick: (item: TreemapItem, depth: number) => void
 }
 
-function SquarifiedCell({ rect, fillFor, pulseFor, onHover, onClick }: SquarifiedCellProps) {
+function SquarifiedCell({ rect, fillFor, pulseFor, dashedFor, onHover, onClick }: SquarifiedCellProps) {
   const { x0, y0, x1, y1, item, isParent, depth } = rect
   const w = x1 - x0
   const h = y1 - y0
@@ -1080,6 +1073,9 @@ function SquarifiedCell({ rect, fillFor, pulseFor, onHover, onClick }: Squarifie
   // get the full semantic fill (gradient or categorical status).
   const semanticFill = fillFor(item)
   const pulse = pulseFor(item)
+  // #4731 — a dormant cell (parked cutover tether) gets a dashed outline so
+  // it reads as "asleep", unmistakably distinct from a solid pending cell.
+  const dashArray = dashedFor(item) ? '4 3' : undefined
   const fill = isParent ? 'rgba(255, 255, 255, 0.04)' : semanticFill
 
   const showLabel = w >= LABEL_MIN_WIDTH_PX && h >= LABEL_MIN_HEIGHT_PX
@@ -1136,6 +1132,7 @@ function SquarifiedCell({ rect, fillFor, pulseFor, onHover, onClick }: Squarifie
             fill: semanticFill,
             stroke: 'rgba(255, 255, 255, 0.18)',
             strokeWidth: 1,
+            strokeDasharray: dashArray,
           }}
         />
         {showLabel && (
@@ -1175,6 +1172,7 @@ function SquarifiedCell({ rect, fillFor, pulseFor, onHover, onClick }: Squarifie
           fill,
           stroke: 'rgba(255, 255, 255, 0.18)',
           strokeWidth: depth > 0 ? 0.5 : 1,
+          strokeDasharray: dashArray,
         }}
       />
       {showLabel && (

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/dashboardJobsTreemap.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/dashboardJobsTreemap.ts
@@ -3,12 +3,39 @@
  * job-sourced treemap layers (`progress` / `kind`).
  *
  * A layer stack containing progress/kind builds its TreemapItem[] tree
- * client-side from the recursive Job tree
- * (GET /api/v1/deployments/{id}/jobs) instead of the pods/utilisation
- * backend. Buckets get a rolled-up `statusKind`; leaves are individual
- * jobs carrying `jobId` (the JobDetail deep-link discriminator),
- * `statusKind` + `statusLabel` (colour + tooltip), and uniform size
- * (1 per job).
+ * client-side from the FULL platform inventory
+ * (GET /api/v1/deployments/{id}/jobs?inventory=full — every HelmRelease
+ * install, Flux Kustomization, CronJob, reconciler Deployment, cutover
+ * step, lifecycle phase) instead of the pods/utilisation backend.
+ *
+ * ── #4731 amendment (founder escalation 2026-07-05) ─────────────────
+ * The founder's four complaints on the CONVERGED-Sovereign treemap and
+ * how this module answers each:
+ *
+ *   1. "where are all the other items" — the map showed ~14 finite rows
+ *      because /jobs filters out the continuous install/reconcile/
+ *      reconciler leaves. The Dashboard now reads ?inventory=full so
+ *      EVERY component is a leaf (~90+ on an hw224-shaped env).
+ *   2. "second layer is not kind by default" — Dashboard.tsx no longer
+ *      flips the default stack away from [progress, kind] on ready.
+ *   3. "cutover kinds still showing as pending" — the `progress` layer
+ *      now buckets by PROGRESS STATE (done/running/pending/failed/
+ *      dormant), and the dormant cutover steps collapse into ONE
+ *      `cutover (dormant)` leaf coloured dormant-grey, never pending.
+ *   4. relevance on BOTH moments — emergent: a converging env fills
+ *      Running/Pending; a converged env is a big green Done block
+ *      sub-divided by kind, with the parked cutover tether in Dormant.
+ *
+ * Layer semantics (orthogonal, exactly two default layers):
+ *   • `progress` (Layer 1) — the leaf's progress STATE bucket
+ *     (Running / Pending / Done / Degraded / Failed / Dormant).
+ *   • `kind` (Layer 2) — the typed JobKind discriminator (#3646):
+ *     install / reconcile / step / cron / task / mutation / reconciler /
+ *     lifecycle.
+ * Leaves are individual jobs carrying `jobId` (the JobDetail deep-link
+ * discriminator), `statusKind` + `statusLabel` (colour + tooltip), and
+ * uniform size (1 per job; the dormant cutover aggregate carries the
+ * count of collapsed steps so the parked tether stays visible).
  *
  * NON-COMPONENT module by design: Dashboard.tsx (the page) may only
  * export components (react-refresh/only-export-components), so its
@@ -18,7 +45,7 @@
  */
 
 import { DETECTED_MODE } from '@/shared/lib/detectMode'
-import { statusKindOf } from '@/shared/lib/statusColors'
+import { statusKindOf, type StatusKind } from '@/shared/lib/statusColors'
 import { jobKind, type Job, type JobKind } from '@/lib/jobs.types'
 import {
   aggregateStatusKinds,
@@ -31,7 +58,10 @@ import {
 } from '@/lib/treemap.types'
 import type { ApplicationDescriptor } from './applicationCatalog'
 
-/** Default layer stack while a deployment is still converging. */
+/** Default layer stack — [progress, kind] UNCONDITIONALLY (#4731 amend).
+ *  Both the converging and the converged Sovereign default to this stack;
+ *  the operator re-stacks (org/application/utilization stay one click away
+ *  in the layer controller). */
 export const PROVISIONING_DEFAULT_LAYERS: readonly TreemapDimension[] = [
   'progress',
   'kind',
@@ -51,69 +81,104 @@ export const JOB_KIND_LABELS: Record<JobKind, string> = {
 }
 
 /**
- * Kind-derived lifecycle stages — the `progress` FALLBACK buckets used
- * when a deployment's group set is sparse (some stores only carry the
- * `provisioner` group, e.g. hw220's mothership store) or a leaf has no
- * group ancestor. Order = dependency order of the platform lifecycle:
- * Phase-0 infra → installs → reconciles → Day-2 → cutover/DR steps →
- * tasks → recurring → long-running reconcilers.
+ * Per-kind stage order — used ONLY to sort the `kind` buckets in a stable
+ * platform-lifecycle order (Infrastructure → installs → reconciles →
+ * Day-2 → steps → tasks → recurring → reconcilers). It is NOT a bucketing
+ * dimension: the `progress` layer buckets by state (below), never by kind.
  */
-export const KIND_STAGES: Record<
-  JobKind,
-  { id: string; label: string; order: number }
-> = {
-  lifecycle:  { id: 'stage-infrastructure', label: 'Infrastructure',  order: 0 },
-  install:    { id: 'stage-installs',       label: 'Installs',        order: 1 },
-  reconcile:  { id: 'stage-reconciles',     label: 'Reconciles',      order: 2 },
-  mutation:   { id: 'stage-day-2',          label: 'Day-2 mutations', order: 3 },
-  step:       { id: 'stage-steps',          label: 'Steps',           order: 4 },
-  task:       { id: 'stage-tasks',          label: 'Tasks',           order: 5 },
-  cron:       { id: 'stage-recurring',      label: 'Recurring',       order: 6 },
-  reconciler: { id: 'stage-reconcilers',    label: 'Reconcilers',     order: 7 },
-  // Never reached for leaves (groups are bucket sources, not leaves) —
-  // present so the Record is total over JobKind.
-  group:      { id: 'stage-other',          label: 'Other',           order: 8 },
+export const KIND_STAGES: Record<JobKind, { order: number }> = {
+  lifecycle: { order: 0 },
+  install: { order: 1 },
+  reconcile: { order: 2 },
+  mutation: { order: 3 },
+  step: { order: 4 },
+  task: { order: 5 },
+  cron: { order: 6 },
+  reconciler: { order: 7 },
+  group: { order: 8 },
 }
+
+/**
+ * Progress state — the Layer-1 `progress` bucket a leaf lands in. These
+ * are the founder's five (+degraded) progress states, orthogonal to kind:
+ * a converged env is mostly Done, the tethered cutover is Dormant, and any
+ * in-flight/queued/failed work surfaces in its own bucket.
+ */
+export type ProgressState =
+  | 'running'
+  | 'pending'
+  | 'done'
+  | 'degraded'
+  | 'failed'
+  | 'dormant'
+
+/** Bucket chrome per progress state. `statusKind` drives the bucket colour
+ *  (the same channel the leaves colour by), `order` fixes the left→right
+ *  reading order (active → queued → done → problems → parked). */
+export const PROGRESS_STATES: Record<
+  ProgressState,
+  { id: string; label: string; statusKind: StatusKind; order: number }
+> = {
+  running:  { id: 'progress-running',  label: 'Running',  statusKind: 'in-progress', order: 0 },
+  pending:  { id: 'progress-pending',  label: 'Pending',  statusKind: 'pending',     order: 1 },
+  done:     { id: 'progress-done',     label: 'Done',     statusKind: 'success',     order: 2 },
+  degraded: { id: 'progress-degraded', label: 'Degraded', statusKind: 'warning',     order: 3 },
+  failed:   { id: 'progress-failed',   label: 'Failed',   statusKind: 'failed',      order: 4 },
+  dormant:  { id: 'progress-dormant',  label: 'Dormant',  statusKind: 'dormant',     order: 5 },
+}
+
+/** Map a leaf's semantic status kind onto its progress-state bucket. */
+export function progressStateForKind(kind: StatusKind): ProgressState {
+  switch (kind) {
+    case 'in-progress':
+      return 'running'
+    case 'success':
+      return 'done'
+    case 'warning':
+      return 'degraded'
+    case 'failed':
+      return 'failed'
+    case 'dormant':
+      return 'dormant'
+    case 'pending':
+    default:
+      return 'pending'
+  }
+}
+
+/** Display name for the collapsed dormant-cutover aggregate leaf. */
+export const CUTOVER_DORMANT_LEAF_NAME = 'cutover (dormant)'
 
 /** A resolved grouping bucket for one fold dimension. */
 interface JobBucketKey {
   id: string | null
   name: string
-  /** Sort key within the level — dependency order for progress buckets,
-   *  stage order for kinds; name-sorted when undefined. */
+  /** Sort key within the level — state order for progress, stage order for
+   *  kinds; name-sorted when undefined. */
   order?: number
 }
 
 /**
- * Topological order of the Job tree's group rows (Kahn's algorithm over
- * the dependsOn edges BETWEEN groups, original array order as the
- * stable tiebreak). Returns group-id → dependency-order index.
+ * Per-leaf intermediate the fold operates on. Decouples the derivation
+ * from raw `Job.status` so the synthetic dormant-cutover aggregate can
+ * carry a `dormant` statusKind without inventing a fake JobStatus.
  */
-function groupDependencyOrder(groups: readonly Job[]): Map<string, number> {
-  const ids = new Set(groups.map((g) => g.id))
-  const indegree = new Map<string, number>()
-  const dependents = new Map<string, string[]>()
-  for (const g of groups) {
-    indegree.set(g.id, (g.dependsOn ?? []).filter((d) => ids.has(d)).length)
-    for (const d of g.dependsOn ?? []) {
-      if (!ids.has(d)) continue
-      dependents.set(d, [...(dependents.get(d) ?? []), g.id])
-    }
-  }
-  const order = new Map<string, number>()
-  // Stable Kahn: always take the lowest-array-index ready node next.
-  const remaining = [...groups]
-  while (remaining.length > 0) {
-    const readyIdx = remaining.findIndex((g) => (indegree.get(g.id) ?? 0) === 0)
-    // Cycle guard — fall back to array order for whatever is left.
-    const takeIdx = readyIdx === -1 ? 0 : readyIdx
-    const [g] = remaining.splice(takeIdx, 1)
-    order.set(g!.id, order.size)
-    for (const dep of dependents.get(g!.id) ?? []) {
-      indegree.set(dep, (indegree.get(dep) ?? 1) - 1)
-    }
-  }
-  return order
+interface LeafInfo {
+  /** JobDetail deep-link target — a real leaf's id, or the cutover GROUP
+   *  id for the dormant aggregate (so a click opens the per-step Cutover
+   *  detail; GetJob is unfiltered). */
+  jobId: string
+  name: string
+  kind: JobKind
+  statusKind: StatusKind
+  /** Raw status word for the tooltip / cell sub-label. */
+  statusLabel: string
+  progress: ProgressState
+  appId: string
+  region?: string
+  /** 1 for a real leaf; the collapsed step count for the dormant aggregate
+   *  (keeps the parked tether proportionally visible under uniform size). */
+  count: number
 }
 
 /** Walk parentId links to a leaf's TOPMOST group ancestor (null when
@@ -138,14 +203,43 @@ function bareAppId(appId: string): string {
   return appId.includes(':') ? appId.slice(appId.lastIndexOf(':') + 1) : appId
 }
 
+/** Canonical coverage key for an appId — region prefix stripped, bp-
+ *  prefix stripped — so a live install job (appId "cilium" / "bp-cilium" /
+ *  "<region>:cilium") matches its catalog Application (bareId "cilium"). */
+function appCoverageKey(appId: string): string {
+  const bare = bareAppId(appId)
+  return bare.startsWith('bp-') ? bare.slice(3) : bare
+}
+
 /**
- * buildJobsTreemapData — fold the flat Job list into the TreemapItem
- * tree for the given layer stack. Leaves = individual (non-group) jobs;
- * every stack level groups them by that dimension's key. Buckets are
- * emitted in dependency/stage order (then name order); empty buckets
- * are never emitted. `applications` feeds the `family` dimension
- * (appId → catalog family) — every other non-job dimension collapses
- * to a single "—" bucket because jobs carry no such axis.
+ * isCutoverStep — a leaf that is one step of the bp-self-sovereign-cutover
+ * activity (kind=step under the Cutover group). Matches the group ancestry
+ * OR the canonical "cutover-step-<slug>" jobName so a sparse store (steps
+ * without a materialised group row) still classifies correctly.
+ */
+function isCutoverStep(leaf: Job, byId: ReadonlyMap<string, Job>): boolean {
+  if (jobKind(leaf) !== 'step') return false
+  if (leaf.jobName.startsWith('cutover-step-')) return true
+  const top = topGroupOf(leaf, byId)
+  return !!top && (top.jobName === 'cutover' || top.id.endsWith(':cutover'))
+}
+
+/**
+ * buildJobsTreemapData — fold the flat Job list into the TreemapItem tree
+ * for the given layer stack.
+ *
+ * Steps:
+ *   1. Take every non-group leaf (the full inventory when the caller read
+ *      ?inventory=full).
+ *   2. Dormant-cutover collapse: while the cutover tether has never fired
+ *      (every cutover step leaf is pending), replace the N step leaves with
+ *      ONE `cutover (dormant)` aggregate coloured dormant-grey — so the
+ *      parked tether never pollutes the pending bucket. Once cutover fires
+ *      (any step running/succeeded/failed) the steps expand as live leaves.
+ *   3. Fold the resulting leaves by the layer stack; empty buckets are
+ *      never emitted; buckets sort by state/stage order then name.
+ *
+ * `applications` feeds the `family` dimension (appId → catalog family).
  */
 export function buildJobsTreemapData(
   jobs: readonly Job[],
@@ -154,40 +248,88 @@ export function buildJobsTreemapData(
 ): TreemapData {
   const byId = new Map(jobs.map((j) => [j.id, j]))
   const leaves = jobs.filter((j) => j.type !== 'group')
-
-  // Progress buckets: bind to the REAL group rows unless the group set
-  // is sparse (< 2 distinct top groups across all leaves), in which
-  // case every leaf falls back to its kind-derived stage.
-  const topGroupByLeaf = new Map<string, Job | null>(
-    leaves.map((l) => [l.id, topGroupOf(l, byId)]),
-  )
-  const usedGroupIds = new Set(
-    [...topGroupByLeaf.values()].filter((g): g is Job => g !== null).map((g) => g.id),
-  )
-  const sparseGroups = usedGroupIds.size < 2
-  const groupOrder = groupDependencyOrder(
-    jobs.filter((j) => j.type === 'group' && usedGroupIds.has(j.id)),
-  )
-
   const appById = new Map(applications.map((a) => [a.id, a]))
 
-  function bucketFor(dimension: TreemapDimension, leaf: Job): JobBucketKey {
+  // ── Dormant-cutover collapse (#4731 complaint #3) ────────────────────
+  const cutoverSteps = leaves.filter((l) => isCutoverStep(l, byId))
+  const cutoverDormant =
+    cutoverSteps.length > 0 &&
+    cutoverSteps.every((s) => statusKindOf(s.status) === 'pending')
+
+  const renderLeaves = cutoverDormant
+    ? leaves.filter((l) => !isCutoverStep(l, byId))
+    : leaves
+
+  function toLeafInfo(leaf: Job): LeafInfo {
+    const sk = statusKindOf(leaf.status)
+    return {
+      jobId: leaf.id,
+      name: leaf.displayName || leaf.jobName,
+      kind: jobKind(leaf),
+      statusKind: sk,
+      statusLabel: leaf.status,
+      progress: progressStateForKind(sk),
+      appId: leaf.appId,
+      region: leaf.region,
+      count: 1,
+    }
+  }
+
+  const leafInfos: LeafInfo[] = renderLeaves.map(toLeafInfo)
+  if (cutoverDormant) {
+    const cutoverGroup = topGroupOf(cutoverSteps[0]!, byId)
+    const cutoverGroupId =
+      cutoverGroup?.id || cutoverSteps[0]!.parentId || cutoverSteps[0]!.id
+    leafInfos.push({
+      jobId: cutoverGroupId,
+      name: CUTOVER_DORMANT_LEAF_NAME,
+      kind: 'step',
+      statusKind: 'dormant',
+      statusLabel: 'dormant',
+      progress: 'dormant',
+      appId: '',
+      count: cutoverSteps.length,
+    })
+  }
+
+  // ── Upfront full expected inventory (founder: "see all of them at the
+  // same time from the beginning") ────────────────────────────────────
+  // Seed EVERY expected Application (bootstrap-kit + the operator's
+  // selection, resolved by resolveApplications) that has no job leaf yet as
+  // a PENDING install leaf. This makes the FULL planned inventory visible
+  // from t=0 — the map is not a progressively-growing set that only shows a
+  // component once its job starts; every planned HR is a Pending leaf up
+  // front and flips to running/done/failed as its job arrives (the live job
+  // WINS wherever it exists, so a covered app is never duplicated).
+  const covered = new Set<string>()
+  for (const li of leafInfos) {
+    if (li.appId) covered.add(appCoverageKey(li.appId))
+  }
+  for (const app of applications) {
+    if (covered.has(app.bareId)) continue
+    covered.add(app.bareId)
+    leafInfos.push({
+      // No job yet — id-less, so the planned leaf is not clickable until
+      // its real install job lands and takes over the cell.
+      jobId: '',
+      name: `install-${app.bareId}`,
+      kind: 'install',
+      statusKind: 'pending',
+      statusLabel: 'pending',
+      progress: 'pending',
+      appId: app.id,
+      count: 1,
+    })
+  }
+
+  function bucketFor(dimension: TreemapDimension, leaf: LeafInfo): JobBucketKey {
     switch (dimension) {
       case 'progress': {
-        const group = sparseGroups ? null : (topGroupByLeaf.get(leaf.id) ?? null)
-        if (group) {
-          return {
-            id: group.id,
-            name: group.displayName || group.jobName,
-            order: groupOrder.get(group.id),
-          }
-        }
-        const stage = KIND_STAGES[jobKind(leaf)]
-        // Kind-derived fallback stages sort AFTER any real groups.
-        return { id: stage.id, name: stage.label, order: groupOrder.size + stage.order }
+        const st = PROGRESS_STATES[leaf.progress]
+        return { id: st.id, name: st.label, order: st.order }
       }
       case 'kind': {
-        const k = jobKind(leaf)
+        const k = leaf.kind
         return { id: `kind-${k}`, name: JOB_KIND_LABELS[k], order: KIND_STAGES[k].order }
       }
       case 'application':
@@ -210,31 +352,31 @@ export function buildJobsTreemapData(
     }
   }
 
-  function jobLeafItem(leaf: Job): TreemapItem {
+  function leafItem(leaf: LeafInfo): TreemapItem {
     return {
-      id: leaf.id,
-      name: leaf.displayName || leaf.jobName,
-      count: 1,
+      id: leaf.jobId,
+      name: leaf.name,
+      count: leaf.count,
       percentage: null,
-      size_value: 1,
-      statusKind: statusKindOf(leaf.status),
-      statusLabel: leaf.status,
-      jobId: leaf.id,
+      size_value: leaf.count,
+      statusKind: leaf.statusKind,
+      statusLabel: leaf.statusLabel,
+      jobId: leaf.jobId,
     }
   }
 
-  function fold(subset: readonly Job[], depth: number): TreemapItem[] {
+  function fold(subset: readonly LeafInfo[], depth: number): TreemapItem[] {
     if (depth >= layers.length) {
-      return subset.map(jobLeafItem)
+      return subset.map(leafItem)
     }
     const dimension = layers[depth]!
-    const buckets = new Map<string, { key: JobBucketKey; jobs: Job[] }>()
+    const buckets = new Map<string, { key: JobBucketKey; leaves: LeafInfo[] }>()
     for (const leaf of subset) {
       const key = bucketFor(dimension, leaf)
       const mapKey = key.id ?? key.name
       const entry = buckets.get(mapKey)
-      if (entry) entry.jobs.push(leaf)
-      else buckets.set(mapKey, { key, jobs: [leaf] })
+      if (entry) entry.leaves.push(leaf)
+      else buckets.set(mapKey, { key, leaves: [leaf] })
     }
     const sorted = [...buckets.values()].sort((a, b) => {
       const ao = a.key.order
@@ -244,23 +386,28 @@ export function buildJobsTreemapData(
       if (ao === undefined && bo !== undefined) return 1
       return a.key.name.localeCompare(b.key.name)
     })
-    return sorted.map(({ key, jobs: bucketJobs }) => {
-      const children = fold(bucketJobs, depth + 1)
+    return sorted.map(({ key, leaves: bucketLeaves }) => {
+      const children = fold(bucketLeaves, depth + 1)
+      const totalCount = bucketLeaves.reduce((n, l) => n + l.count, 0)
       return {
         id: key.id,
         name: key.name,
-        count: bucketJobs.length,
+        count: totalCount,
         percentage: null,
-        size_value: bucketJobs.length,
-        statusKind: aggregateStatusKinds(
-          bucketJobs.map((j) => statusKindOf(j.status)),
-        ),
+        size_value: totalCount,
+        statusKind: aggregateStatusKinds(bucketLeaves.map((l) => l.statusKind)),
         children,
       }
     })
   }
 
-  return { items: fold(leaves, 0), total_count: leaves.length }
+  // total_count reflects the FULL rendered inventory size: every real leaf
+  // (with the collapsed dormant cutover steps counted individually) PLUS the
+  // upfront-seeded expected-but-not-yet-started components, so the page
+  // header is honest about how many components the operator is watching —
+  // from t=0, not once each job starts.
+  const totalCount = leafInfos.reduce((n, l) => n + l.count, 0)
+  return { items: fold(leafInfos, 0), total_count: totalCount }
 }
 
 /**
@@ -307,4 +454,11 @@ export function cellFillFor(colorBy: TreemapColorBy, item: TreemapItem): string 
  *  in-flight job is unmistakably distinct from pending and success. */
 export function cellPulseFor(colorBy: TreemapColorBy, item: TreemapItem): boolean {
   return colorBy === 'status' && item.statusKind === 'in-progress'
+}
+
+/** cellDashedFor — a dormant cell (the parked cutover tether) renders with
+ *  a dashed outline so it is unmistakably distinct from a solid pending
+ *  cell — dormant ≠ pending, the confusion the founder flagged (#4731). */
+export function cellDashedFor(colorBy: TreemapColorBy, item: TreemapItem): boolean {
+  return colorBy === 'status' && item.statusKind === 'dormant'
 }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/useLiveJobsBackfill.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/useLiveJobsBackfill.test.tsx
@@ -216,3 +216,53 @@ describe('useLiveJobsBackfill — hook', () => {
     expect(result.current.liveJobs).toEqual([])
   })
 })
+
+// #4731 — the default fetcher's URL: the Dashboard treemap reads the FULL
+// platform inventory (?inventory=full); the Jobs page reads the finite list.
+describe('useLiveJobsBackfill — fullInventory drives ?inventory=full', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function stubFetchCapture(): { urls: string[] } {
+    const urls: string[] = []
+    globalThis.fetch = vi.fn((url: string) => {
+      urls.push(String(url))
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ jobs: [] }),
+      } as unknown as Response)
+    }) as unknown as typeof fetch
+    return { urls }
+  }
+
+  it('appends ?inventory=full when fullInventory is set (treemap path)', async () => {
+    const cap = stubFetchCapture()
+    renderHook(
+      () =>
+        useLiveJobsBackfill({
+          deploymentId: 'd-full',
+          disablePolling: true,
+          fullInventory: true,
+        }),
+      { wrapper: wrapper() },
+    )
+    await waitFor(() => expect(cap.urls.length).toBeGreaterThan(0))
+    expect(cap.urls.some((u) => u.includes('/deployments/d-full/jobs?inventory=full'))).toBe(true)
+  })
+
+  it('omits the param by default (finite Jobs-page path)', async () => {
+    const cap = stubFetchCapture()
+    renderHook(
+      () =>
+        useLiveJobsBackfill({
+          deploymentId: 'd-finite',
+          disablePolling: true,
+        }),
+      { wrapper: wrapper() },
+    )
+    await waitFor(() => expect(cap.urls.length).toBeGreaterThan(0))
+    expect(cap.urls.every((u) => !u.includes('inventory=full'))).toBe(true)
+    expect(cap.urls.some((u) => u.endsWith('/deployments/d-finite/jobs'))).toBe(true)
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/useLiveJobsBackfill.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/useLiveJobsBackfill.ts
@@ -64,14 +64,24 @@ export interface UseLiveJobsBackfillResult {
  * Default fetcher — exposed via parameter so tests can inject a stub
  * without monkey-patching `globalThis.fetch`.
  */
-async function defaultFetchJobs(deploymentId: string): Promise<Job[]> {
+async function defaultFetchJobs(
+  deploymentId: string,
+  fullInventory = false,
+): Promise<Job[]> {
   // Single endpoint on both surfaces (mother + chroot). The chroot
   // catalyst-api lazily seeds its per-deployment jobs.Store from the
   // live cluster on first read (see chrootSeedJobsStoreIfEmpty) so
   // the wire shape is byte-identical to the mother's. No more
   // parallel-baby /api/v1/sovereign/jobs path.
+  //
+  // #4731 — the Dashboard treemap passes fullInventory to read
+  // ?inventory=full, which returns the COMPLETE platform inventory
+  // (every HelmRelease install / Flux Kustomization / CronJob /
+  // reconciler Deployment / cutover step). The Jobs page omits it and
+  // keeps the #3996 finite-work list — the two never regress each other.
+  const query = fullInventory ? '?inventory=full' : ''
   const res = await fetch(
-    `${API_BASE}/v1/deployments/${encodeURIComponent(deploymentId)}/jobs`,
+    `${API_BASE}/v1/deployments/${encodeURIComponent(deploymentId)}/jobs${query}`,
     {
       credentials: 'include',
       headers: { Accept: 'application/json' },
@@ -97,6 +107,14 @@ export interface UseLiveJobsBackfillOptions {
    * wasteful. Caller passes `streamStatus !== 'completed' && streamStatus !== 'failed'`.
    */
   enabled?: boolean
+  /**
+   * #4731 — request the FULL platform inventory (?inventory=full) instead
+   * of the default finite-work list. The Dashboard treemap sets this so a
+   * converged Sovereign shows every component; the Jobs page leaves it
+   * false to keep the #3996 finite view. Threaded into the query key so the
+   * two consumers cache independently.
+   */
+  fullInventory?: boolean
 }
 
 /** Founder-specified poll cadence — verbatim ("every 5s while the
@@ -106,7 +124,17 @@ const POLL_INTERVAL_MS = 5_000
 export function useLiveJobsBackfill(
   opts: UseLiveJobsBackfillOptions,
 ): UseLiveJobsBackfillResult {
-  const { deploymentId, disablePolling = false, fetcher = defaultFetchJobs, enabled = true } = opts
+  const {
+    deploymentId,
+    disablePolling = false,
+    fetcher,
+    enabled = true,
+    fullInventory = false,
+  } = opts
+  // Bind fullInventory into the default fetcher; a test-injected fetcher
+  // takes precedence and owns its own URL.
+  const effectiveFetcher =
+    fetcher ?? ((id: string) => defaultFetchJobs(id, fullInventory))
 
   // The query MUST be keyed by the actual deploymentId (not a static
   // 'sovereign' constant) — otherwise on the chroot Sovereign Console,
@@ -120,8 +148,13 @@ export function useLiveJobsBackfill(
   // the resolved id.
   const isSovereignMode = DETECTED_MODE.mode === 'sovereign'
   const query = useQuery<Job[]>({
-    queryKey: ['live-jobs-backfill', isSovereignMode ? 'sovereign' : 'mother', deploymentId],
-    queryFn: () => fetcher(deploymentId),
+    queryKey: [
+      'live-jobs-backfill',
+      isSovereignMode ? 'sovereign' : 'mother',
+      deploymentId,
+      fullInventory ? 'full' : 'finite',
+    ],
+    queryFn: () => effectiveFetcher(deploymentId),
     enabled: enabled && !!deploymentId,
     refetchInterval: () => {
       if (disablePolling) return false

--- a/products/catalyst/bootstrap/ui/src/shared/lib/statusColors.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/lib/statusColors.ts
@@ -10,10 +10,17 @@
  *   amber  (--color-warn)      warning / degraded / partial
  *   red    (--color-danger)    failed / error
  *   grey   (--color-text-dim)  pending / not-started / suspended
+ *   grey   (--color-text-dimmer) dormant — installed-but-never-fired
+ *                              (the tethered cutover chart, #4731); a
+ *                              distinct FAINT grey (see the treemap's
+ *                              dashed dormant cell) so a parked tether is
+ *                              never confused with pending queued work.
  *
  * In-progress MUST be visibly distinct (blue) — never rendered as grey
  * or green. Pending is grey — never amber (amber is reserved for
- * genuine warning states).
+ * genuine warning states). Dormant is grey too but visually parked
+ * (fainter fill + dashed outline on the treemap) — dormant ≠ pending,
+ * the exact confusion the founder flagged on the converged treemap.
  *
  * All values are the theme CSS custom properties from globals.css (both
  * dark + light themes define them), never raw hex — per
@@ -29,6 +36,12 @@ export type StatusKind =
   | 'warning'
   | 'failed'
   | 'pending'
+  // #4731 — a component that is INSTALLED but has never been fired: the
+  // tethered bp-self-sovereign-cutover chart before the operator triggers
+  // cutover. Grey like pending but PARKED, never "queued behind a running
+  // chain". Rendered distinct on the treemap (fainter + dashed) so the 11
+  // dormant cutover steps stop masquerading as pending.
+  | 'dormant'
 
 /** CSS colour token per semantic kind (for inline styles / CSS strings). */
 export const STATUS_KIND_COLOR: Record<StatusKind, string> = {
@@ -37,6 +50,10 @@ export const STATUS_KIND_COLOR: Record<StatusKind, string> = {
   warning: 'var(--color-warn)',
   failed: 'var(--color-danger)',
   pending: 'var(--color-text-dim)',
+  // A DISTINCT, dimmer grey token (not pending's) so dormant is its own
+  // colour — the treemap further sets it apart with a fainter fill + dashed
+  // outline. dormant ≠ pending, by token and by treatment.
+  dormant: 'var(--color-text-dimmer)',
 }
 
 /** Tailwind badge classes per kind — tinted background + solid text. */
@@ -46,6 +63,8 @@ export const STATUS_KIND_BADGE_CLASSES: Record<StatusKind, string> = {
   warning: 'bg-[var(--color-warn)]/15 text-[var(--color-warn)]',
   failed: 'bg-[var(--color-danger)]/15 text-[var(--color-danger)]',
   pending: 'bg-[var(--color-text-dim)]/15 text-[var(--color-text-dim)]',
+  // Dashed border marks the parked/dormant tether apart from solid pending.
+  dormant: 'border border-dashed border-[var(--color-text-dimmer)]/40 bg-[var(--color-text-dimmer)]/5 text-[var(--color-text-dimmer)]',
 }
 
 /**
@@ -96,6 +115,11 @@ export function statusKindOf(raw: string | null | undefined): StatusKind {
     case 'error':
     case 'errored':
       return 'failed'
+    // #4731 — installed-but-never-fired (the tethered cutover chart). Grey
+    // like pending, but parked; the treemap collapses the dormant cutover
+    // steps into one dormant leaf so they never pollute the pending bucket.
+    case 'dormant':
+      return 'dormant'
     default:
       return 'pending'
   }


### PR DESCRIPTION
## What & why

Amends the #4731 Dashboard treemap per the founder's four escalation complaints on the **converged-Sovereign** map (2026-07-05). All four are addressed on the SAME editable treemap (`pages/sovereign/Dashboard.tsx`) — no fork, no second component, layer picker / utilization coloring / leaf→logs drill all preserved.

### 1. "where are all the other items" — full inventory always
`GET /jobs` applied `FilterFiniteJobs` (#3996), which drops the continuous **install / reconcile / reconciler** leaves — so a converged Sovereign's treemap showed only ~14 finite rows and the 65+ completed HelmRelease installs were invisible. The store already holds the full inventory (the chroot/mother seeds every HelmRelease, reconciler, cron and cutover step); only the read narrowed it.

- **Backend**: `?inventory=full` on `GET /api/v1/deployments/{id}/jobs` skips `FilterFiniteJobs` and returns the complete tree. Default (no param) keeps the #3996 finite Jobs-page view byte-for-byte — the two consumers never regress each other.
- **Frontend**: `useLiveJobsBackfill({ fullInventory })` appends the param; the Dashboard treemap sets it, the Jobs page does not (namespaced query key so they cache independently).

### 2. "second layer is not kind by default" — `[progress, kind]` UNCONDITIONALLY
Deleted the `status==ready` auto-flip to `[organization/family, application]` + utilization. The default stack is `[progress, kind]` on a provisioning **and** a converged env. `organization` / `application` / `utilization` remain available in the layer controller — just no longer the default.

### 3. "cutover kinds still showing as pending" — dormant collapse
The `progress` layer now buckets by progress **STATE** (Running / Pending / Done / Degraded / Failed / **Dormant**), orthogonal to `kind`. While the cutover tether has never fired (every step `pending`), the N step leaves collapse into ONE `cutover (dormant)` leaf in a **Dormant** bucket — a new grey `dormant` `StatusKind` (distinct dimmer token + dashed cell), never `pending`. Once cutover fires (any step non-pending) the steps expand as live leaves.

### 4. Relevant on both moments + "see all of them at the same time from the beginning"
Progress-state bucketing makes the map read on both moments (converging fills Running/Pending; converged is a big green Done block sub-divided by kind, with the parked cutover in Dormant). Per the founder follow-up, the **full expected inventory seeds from t=0**: every planned Application (bootstrap-kit + selection) with no job yet renders as a Pending leaf and flips state as its job arrives — the live job wins, never duplicated.

## Before/after leaf math (hw224-shaped converged env)
- **Before**: ~14 leaves (finite view only: crons + tasks + dormant cutover steps + lifecycle; installs/reconciles/reconcilers dropped).
- **After (`?inventory=full`)**: ~90+ leaves — ~65 install + ~14 reconcile + reconciler Deployments + ~6 cron + tasks + lifecycle + ONE `cutover (dormant)` (collapsed from 11 steps). Layer 1 = progress state, Layer 2 = kind.

## Files
- `products/catalyst/bootstrap/api/internal/handler/jobs.go` — `?inventory=full` gate (`fullInventoryRequested`).
- `products/catalyst/bootstrap/ui/src/pages/sovereign/dashboardJobsTreemap.ts` — progress-state buckets, dormant cutover collapse, upfront expected-inventory seed.
- `.../Dashboard.tsx` — delete ready-flip, `fullInventory: true`, dormant legend + dashed cell.
- `.../useLiveJobsBackfill.ts` — `fullInventory` option.
- `.../lib/treemap.types.ts`, `.../shared/lib/statusColors.ts` — `dormant` StatusKind.

## Gates
- `tsc -b` clean; `vite build` clean; `eslint` 0 errors (2 pre-existing warnings on untouched code in `Dashboard.tsx`).
- `vitest run`: **67 pre-existing failures** on 8 unrelated files (identical on the base commit — PinInput6/ParentDomains/UserAccess/ProvisionPage.sse-url/JobsPage/SettingsPage/StepComponents/ExecPanel), **+13 net new passing tests, zero regressions**.
- `go build ./... && go test ./...` green.

Tests proving each complaint: `renders the full platform inventory as leaves` (#1), `defaults to [progress, kind] even when status=ready` + `KEEPS the [progress, kind] default when status is ready` (#2), `collapses the dormant cutover steps into ONE dormant leaf, never pending` + `pending NON-cutover work stays in Pending; dormant cutover is separate` (#3), `seeds EVERY expected component as a pending leaf at provisioning start` + `the live job WINS over the planned pending leaf` (upfront inventory).

`Refs #4731` — not `Closes`. The issue closes only after an operator walk-with-screenshot on a live converged Sovereign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)