### PR TITLE
fix(powerdns): hook-Job labels spelled out — managed-by=flux actually renders (Refs #4765)

### DIFF
--- a/clusters/_template/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/_template/bootstrap-kit/11-powerdns.yaml
@@ -150,7 +150,7 @@ spec:
       # chart renders the canonical apps.openova.io/v1 Application CR for
       # this slot's HelmRelease so the console /apps list, per-app Topology
       # tab + showback resolve powerdns (no more "no Application CR").
-      version: 1.2.19
+      version: 1.2.20
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns

--- a/platform/powerdns/blueprint.yaml
+++ b/platform/powerdns/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-2-gitops-and-iac
 spec:
-  version: 1.2.19
+  version: 1.2.20
   card:
     title: PowerDNS
     summary: |

--- a/platform/powerdns/chart/Chart.yaml
+++ b/platform/powerdns/chart/Chart.yaml
@@ -54,7 +54,9 @@ name: bp-powerdns
 #   app.kubernetes.io/managed-by: flux — kyverno `flux-managed` policy denied
 #   the hook on upgrade (hw224), rolling back 1.2.18 and stranding the anycast
 #   Service as the forbidden NodePort.
-version: 1.2.19
+# 1.2.20 (#4765): hook-Job labels spelled out so managed-by=flux actually
+#   renders — the 1.2.19 duplicate-key override was inert (first key wins).
+version: 1.2.20
 description: |
   Catalyst-curated Blueprint wrapper for PowerDNS Authoritative.
   Carries Catalyst-specific values.yaml + templates (CNPG cluster, dnsdist

--- a/platform/powerdns/chart/templates/zone-bootstrap-job.yaml
+++ b/platform/powerdns/chart/templates/zone-bootstrap-job.yaml
@@ -136,12 +136,16 @@ metadata:
   name: powerdns-zone-bootstrap
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "bp-powerdns.labels" . | nindent 4 }}
-    catalyst.openova.io/component: zone-bootstrap
-    # #4765 live-strike: kyverno ClusterPolicy `flux-managed` denies hook Jobs
-    # without this label (blocked the 1.2.18 upgrade on hw224). The hook IS
-    # created by a Flux-driven Helm upgrade; label satisfies the policy.
+    # #4765: labels spelled out (NOT the bp-powerdns.labels include) because
+    # managed-by MUST be flux here — kyverno ClusterPolicy `flux-managed`
+    # denies hook Jobs labeled managed-by: Helm (blocked 1.2.18 AND the
+    # 1.2.19 duplicate-key attempt on hw224: Helm's YAML decode keeps the
+    # FIRST duplicate key, so an override line after the include is inert).
+    app.kubernetes.io/name: {{ include "bp-powerdns.fullname" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: flux
+    catalyst.openova.io/blueprint: bp-powerdns
+    catalyst.openova.io/component: zone-bootstrap
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "10"


### PR DESCRIPTION
The 1.2.19 fix appended `app.kubernetes.io/managed-by: flux` after the labels include, but Helm's YAML decode keeps the FIRST duplicate key (`Helm`), so kyverno `flux-managed` kept denying the zone-bootstrap hook on hw224 region-a and the release kept rolling back to 1.2.17 — leaving the anycast Service as the forbidden NodePort.

Fix: the hook Job's labels are spelled out explicitly (no include) with `managed-by: flux`. Render-proof: exactly one managed-by label on the Job, value `flux`. bp-powerdns 1.2.19→1.2.20 + blueprint + slot pin lockstep.

Refs #4765

🤖 Generated with [Claude Code](https://claude.com/claude-code)