### PR TITLE
fix(kyverno): flux-managed carve-out for Helm hooks — unblocks powerdns NodePort→LB live upgrade (Refs #4765)

### DIFF
--- a/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
+++ b/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
@@ -150,7 +150,7 @@ spec:
       # that span unbounded org-<uuid> namespaces the excludeNamespaces list can't
       # enumerate; without this the WordPress mysql Deployment was admission-blocked
       # → 0 pods → WordPress had no DB. Refs #4422 #3376.
-      version: 1.0.44
+      version: 1.0.45
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno

--- a/platform/kyverno-policies/blueprint.yaml
+++ b/platform/kyverno-policies/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.44
+  version: 1.0.45
   card:
     title: Kyverno Policy Library
     family: guardian

--- a/platform/kyverno-policies/chart/Chart.yaml
+++ b/platform/kyverno-policies/chart/Chart.yaml
@@ -298,7 +298,11 @@ type: application
 # namespaces the excludeNamespaces list can't enumerate. Mirrors the cnpg.io/
 # cluster label-exempt on backup-configured (#3971). Template+values change.
 # Refs #4422 #3376.
-version: 1.0.44
+# 1.0.45 (#4765): flux-managed carve-out for Helm HOOK resources
+#   (helm.sh/hook annotation) — hooks get no Flux labels + Helm force-stamps
+#   managed-by:Helm, so a legit hook Job (bp-powerdns zone-bootstrap) was
+#   Enforce-denied on live upgrade, stranding the powerdns anycast NodePort.
+version: 1.0.45
 appVersion: "1.0.2"
 keywords: [catalyst, blueprint, kyverno, policy, compliance, audit]
 maintainers:

--- a/platform/kyverno-policies/chart/templates/baseline/10-flux-managed.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/10-flux-managed.yaml
@@ -151,6 +151,29 @@ spec:
                 - Service
               names:
                 - "test-service-delete-me-*"
+          {{- /*
+            #4765 (2026-07-05, proven live hw224 region-a): Helm HOOK resources
+            (carrying a `helm.sh/hook` annotation) are executed by Helm's action
+            engine DIRECTLY and are NOT part of the manifest Flux's helm-controller
+            post-renders — so they never receive the helm.toolkit.fluxcd.io/* labels.
+            Worse, Helm force-stamps `app.kubernetes.io/managed-by: Helm` on apply
+            (a template override of that label is silently dropped — Helm always
+            wins), so a hook can NEVER satisfy any of this rule's three conditions.
+            A hook Job is nonetheless legitimately managed (by Helm, driven by a
+            Flux HelmRelease). On a FRESH prov the hook slips through because it
+            runs at bootstrap before Enforce engages; on a LIVE UPGRADE of a
+            converged env kyverno denies it and Flux rolls the release back —
+            proven on hw224 region-a, where bp-powerdns' zone-bootstrap
+            post-upgrade hook kept being denied so the powerdns anycast Service was
+            stranded on the forbidden NodePort (the LoadBalancer upgrade could
+            never land). Carve out the definitionally-unmanageable Helm hook,
+            mirroring the CNPG-operator + vCluster-probe carve-outs above. Additive
+            (loosens only): a hook that should have been denied is at worst
+            admitted; nothing new is ever denied.
+          */}}
+          - resources:
+              annotations:
+                helm.sh/hook: "*"
       validate:
         message: >-
           {{ `{{request.object.kind}}/{{request.object.metadata.name}}` }} is

--- a/platform/kyverno-policies/chart/tests/helm-hook-admitted/kyverno-test.yaml
+++ b/platform/kyverno-policies/chart/tests/helm-hook-admitted/kyverno-test.yaml
@@ -1,0 +1,44 @@
+# #4765 — Kyverno conformance test for the flux-managed (10) carve-out that
+# admits legitimate Helm HOOK resources (helm.sh/hook annotation).
+#
+# Run with the Kyverno CLI:
+#   cd platform/kyverno-policies/chart
+#   # re-render the policy if the template/values changed:
+#   helm template . --set compliancePolicies.fluxManaged.action=Enforce \
+#     --show-only templates/baseline/10-flux-managed.yaml \
+#     | grep -v '^# Source:' | sed '/^---$/d' \
+#     > tests/helm-hook-admitted/policy.yaml
+#   kyverno test tests/helm-hook-admitted/
+#
+# LIVE shape: hw224 region-a, bp-powerdns zone-bootstrap post-upgrade hook
+# repeatedly Enforce-denied (Helm force-stamps managed-by: Helm; hooks get no
+# Flux labels), so the powerdns LoadBalancer upgrade kept rolling back and the
+# anycast Service was stranded on the forbidden NodePort.
+#
+# TWO cases prove the fix:
+#   1. Helm hook Job (helm.sh/hook annotation)            → ADMITTED (pass)
+#   2. plain kubectl Job, no hook annotation, no Flux lbl → DENIED  (fail)
+#      (proves the carve-out is annotation-scoped, not a blanket Job exemption)
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: helm-hook-admitted-test
+policies:
+  - policy.yaml
+resources:
+  - resources.yaml
+results:
+  # 1. Helm hook Job → admitted by the helm.sh/hook carve-out.
+  - policy: flux-managed
+    rule: workload-must-be-flux-managed
+    resources:
+      - powerdns/powerdns-zone-bootstrap
+    kind: Job
+    result: pass
+  # 2. Plain orphan Job, no hook annotation → DENIED (carve-out is narrow).
+  - policy: flux-managed
+    rule: workload-must-be-flux-managed
+    resources:
+      - default/rogue-adhoc-job
+    kind: Job
+    result: fail

--- a/platform/kyverno-policies/chart/tests/helm-hook-admitted/policy.yaml
+++ b/platform/kyverno-policies/chart/tests/helm-hook-admitted/policy.yaml
@@ -1,0 +1,101 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: flux-managed
+  labels:
+    app.kubernetes.io/name: bp-kyverno
+    app.kubernetes.io/component: compliance-policy
+    catalyst.openova.io/policy-tier: compliance
+    catalyst.openova.io/policy-domain: governance
+  annotations:
+    policies.kyverno.io/title: Workloads must be managed by Flux
+    policies.kyverno.io/category: catalyst-compliance
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/description: >-
+      Workload-rendering resources must carry
+      `app.kubernetes.io/managed-by: flux` (the upstream Flux label) OR
+      have an ownerReference pointing at a HelmRelease / Kustomization.
+      Direct kubectl apply is rejected — IaC-first per
+      docs/INVIOLABLE-PRINCIPLES.md #3.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: workload-must-be-flux-managed
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+                - DaemonSet
+                - Job
+                - CronJob
+                - Service
+                - Ingress
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - kube-system
+                - flux-system
+                - cilium
+                - cilium-gateway
+                - dragonfly
+                - cert-manager
+                - openova-system
+                - catalyst
+                - kyverno
+                - monitoring
+                - ingress
+                - dmz
+                - mgmt
+                - rtz
+                - sso-bridge
+                - cnpg
+                - shared-data
+                - powerdns-admin
+                - trivy-system
+          - resources:
+              selector:
+                matchLabels:
+                  app.kubernetes.io/managed-by: cloudnative-pg
+          - resources:
+              namespaceSelector:
+                matchExpressions:
+                  - key: openova.io/organization
+                    operator: Exists
+          - resources:
+              kinds:
+                - Service
+              names:
+                - "test-service-delete-me-*"
+          - resources:
+              annotations:
+                helm.sh/hook: "*"
+      validate:
+        message: >-
+          {{request.object.kind}}/{{request.object.metadata.name}} is
+          not Flux-managed. Add label
+          `app.kubernetes.io/managed-by: flux` on metadata.labels OR
+          attach an ownerReference to a HelmRelease / Kustomization.
+        deny:
+          conditions:
+            all:
+              - key: '{{ request.object.metadata.labels."app.kubernetes.io/managed-by" || '''' }}'
+                operator: NotEquals
+                value: flux
+              # Wave 5.97 nil-safety: check Flux-applied labels instead of
+              # ownerReferences. Flux sets BOTH helm.toolkit.fluxcd.io/name AND
+              # kustomize.toolkit.fluxcd.io/name on every resource it manages.
+              # The original JMESPath filter `ownerReferences[?kind==X]` errors
+              # when ownerReferences is nil (most kubectl-created Pods + debug
+              # pods + admission-time injected sidecars), and admission webhook
+              # failurePolicy=Fail blocks all pod creation cluster-wide.
+              # Label-based check is nil-safe via the `||` JMESPath fallback.
+              - key: '{{ request.object.metadata.labels."helm.toolkit.fluxcd.io/name" || '''' }}'
+                operator: Equals
+                value: ''
+              - key: '{{ request.object.metadata.labels."kustomize.toolkit.fluxcd.io/name" || '''' }}'
+                operator: Equals
+                value: ''

--- a/platform/kyverno-policies/chart/tests/helm-hook-admitted/resources.yaml
+++ b/platform/kyverno-policies/chart/tests/helm-hook-admitted/resources.yaml
@@ -1,0 +1,41 @@
+# #4765 — INPUT fixtures for the flux-managed (10) Helm-hook carve-out.
+# None carry a Flux label/ownerRef (no `app.kubernetes.io/managed-by: flux`, no
+# `helm.toolkit.fluxcd.io/name`, no `kustomize.toolkit.fluxcd.io/name`), so the
+# deny rule's conditions are all true UNLESS an exclude carve-out spares them.
+
+# 1. The bp-powerdns zone-bootstrap HOOK Job — a Helm post-upgrade hook.
+#    Helm force-stamps `managed-by: Helm` and it gets no Flux labels, so it can
+#    only pass via the new `helm.sh/hook` annotation carve-out. MUST be ADMITTED
+#    (else the powerdns LoadBalancer upgrade rolls back → stranded NodePort).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: powerdns-zone-bootstrap
+  namespace: powerdns
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: bootstrap
+          image: curlimages/curl:8.10.1
+---
+# 2. A plain kubectl-applied Job — NO Flux label, NO helm.sh/hook annotation.
+#    MUST stay DENIED: the carve-out is annotation-scoped, not a blanket Job
+#    exemption. Proves the loosening is narrow.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rogue-adhoc-job
+  namespace: default
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: x
+          image: busybox:1.36


### PR DESCRIPTION
## Root cause (the #4769 fix was ineffective)
#4769 added `app.kubernetes.io/managed-by: flux` to the bp-powerdns zone-bootstrap hook Job template — but **Helm force-overwrites that label to `Helm` at apply time** (a template value for `managed-by` is always dropped). Verified live on hw224 region-a: bp-powerdns kept failing the `flux-managed` ENFORCING policy on every upgrade attempt (1.2.18/1.2.19/1.2.20) → Flux rolled the release back to 1.2.17 → the anycast Service stayed the forbidden **NodePort** (the LoadBalancer upgrade could never land).

Region-b escaped because it's a secondary with no parent zones → the zone-bootstrap hook doesn't render → clean LoadBalancer upgrade. Fresh provs escape because powerdns installs at bootstrap before Enforce engages.

## Fix
A Helm **hook** resource is executed by Helm's action engine directly, is NOT in the manifest Flux post-renders (so no `helm.toolkit.fluxcd.io/*` labels), and carries Helm's forced `managed-by: Helm` — it can NEVER satisfy the policy, yet it IS legitimately managed (by Helm, driven by a Flux HelmRelease). Exclude `helm.sh/hook`-annotated resources from `flux-managed`, mirroring the existing CNPG-operator + vCluster-probe carve-outs. **Additive** — loosens only; nothing new is ever denied.

## Proof
`kyverno test tests/helm-hook-admitted/` → 2/2 pass: hook Job `Excluded` (admitted), plain orphan Job still **denied** (carve-out is annotation-scoped, not a blanket Job exemption). bp-kyverno-policies 1.0.44→1.0.45 + slot pin lockstep.

Refs #4765

🤖 Generated with [Claude Code](https://claude.com/claude-code)