### PR TITLE
fix(dashboard): mothership /jobs re-seeds install+reconcile leaves from the live sovereign cluster (Refs #4731)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/infrastructure.go
+++ b/products/catalyst/bootstrap/api/internal/handler/infrastructure.go
@@ -1583,6 +1583,23 @@ func (h *Handler) sovereignDynamicClient(dep *Deployment) (dynamic.Interface, er
 		return dynamic.NewForConfig(cfg)
 	}
 
+	// #3153 conventional-path fallback — Result.KubeconfigPath carries json
+	// `omitempty` and is LOST when a mothership Pod roll persists a
+	// rehydrated deployment record before PutKubeconfig re-stamps it, even
+	// though the kubeconfig FILE itself survives on the PVC at
+	// <kubeconfigsDir>/<id>.yaml. Without this, a converged Sovereign's
+	// mother-side catalyst-api can't build a client (record field null) and
+	// the /jobs install+reconcile re-seed (#4731), retry, and reconciler
+	// projections all silently no-op even though the cluster is fully
+	// reachable. resolvePrimaryKubeconfigPath stat-guards the file, so a
+	// record whose kubeconfig was genuinely never posted (provisioning in
+	// flight) still returns the honest "not yet posted back" error below.
+	if kubeconfigPath == "" {
+		if resolved, ok := h.resolvePrimaryKubeconfigPath(dep); ok {
+			kubeconfigPath = resolved
+		}
+	}
+
 	if kubeconfigPath == "" {
 		return nil, errors.New("sovereign cluster kubeconfig not yet posted back — cloud-init in flight or PUT /kubeconfig missed; retry once the wizard's success screen reaches Phase-1 ready")
 	}

--- a/products/catalyst/bootstrap/api/internal/handler/jobs.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs.go
@@ -242,14 +242,16 @@ func envTruthy(name string) bool {
 //   - chroot in-cluster: SOVEREIGN_FQDN set AND matches this deployment
 //     (the in-cluster ServiceAccount is the client), preserved exactly
 //     as before; OR
-//   - mother mode: the deployment's kubeconfig has been posted back
-//     (dep.Result.KubeconfigPath set) so sovereignDynamicClient can
-//     build a client from it.
+//   - mother mode: the deployment's kubeconfig is resolvable via
+//     resolvePrimaryKubeconfigPath — either dep.Result.KubeconfigPath OR,
+//     when that omitempty field was dropped by a Pod-roll rehydrate, the
+//     surviving file at <kubeconfigsDir>/<id>.yaml (#3153) — so
+//     sovereignDynamicClient can build a client from it.
 //
 // No-op (Debug log, never an error — a /jobs read must not fail because
 // the cluster isn't reachable yet) when:
 //   - h.jobs is nil (persistence disabled)
-//   - mother mode AND no kubeconfig posted back yet (provisioning in
+//   - mother mode AND no kubeconfig resolvable yet (provisioning in
 //     flight — the next poll retries once cloud-init PUTs it)
 //   - jobs.Store already has the install group (hasBootstrapKit) — the
 //     expensive live HR-LIST is skipped; the always-idempotent
@@ -261,18 +263,20 @@ func (h *Handler) chrootSeedJobsStoreIfEmpty(ctx context.Context, dep *Deploymen
 	}
 	// The seed can only reach the Sovereign cluster via the chroot
 	// in-cluster client (SOVEREIGN_FQDN set + matches this dep) OR the
-	// mother's posted-back per-deployment kubeconfig. When NEITHER holds
-	// (mother mode, kubeconfig not yet posted — provisioning in flight)
-	// keep the historical no-op so the /jobs read never errors; the next
-	// poll retries once the kubeconfig lands.
+	// mother's posted-back per-deployment kubeconfig. resolvePrimaryKubeconfigPath
+	// resolves the latter with the #3153 conventional-path fallback — a
+	// converged Sovereign's record often has a NULL Result.KubeconfigPath
+	// (the omitempty field is dropped when a mothership Pod roll rehydrates
+	// the record before PutKubeconfig re-stamps it) even though the
+	// kubeconfig FILE still lives on the PVC at <kubeconfigsDir>/<id>.yaml.
+	// When NEITHER resolves (mother mode, kubeconfig genuinely not posted —
+	// provisioning in flight) keep the historical no-op so the /jobs read
+	// never errors; the next poll retries once the kubeconfig lands.
 	selfFQDN := strings.TrimSpace(os.Getenv("SOVEREIGN_FQDN"))
 	chrootInCluster := selfFQDN != "" && strings.EqualFold(selfFQDN, dep.Request.SovereignFQDN)
 	if !chrootInCluster {
-		dep.mu.Lock()
-		hasKubeconfig := dep.Result != nil && strings.TrimSpace(dep.Result.KubeconfigPath) != ""
-		dep.mu.Unlock()
-		if !hasKubeconfig {
-			h.log.Debug("jobs seed: sovereign cluster unreachable — no kubeconfig posted back yet; skipping install/reconcile re-seed",
+		if _, ok := h.resolvePrimaryKubeconfigPath(dep); !ok {
+			h.log.Debug("jobs seed: sovereign cluster unreachable — no kubeconfig resolvable yet; skipping install/reconcile re-seed",
 				"depId", dep.ID)
 			return
 		}

--- a/products/catalyst/bootstrap/api/internal/handler/jobs.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs.go
@@ -216,30 +216,66 @@ func envTruthy(name string) bool {
 	}
 }
 
-// chrootSeedJobsStoreIfEmpty — when the chroot Sovereign-side
-// catalyst-api gets a /jobs read for an imported deployment whose
-// per-deployment jobs.Store has no records, lazily seed the store
-// from a one-shot live-cluster HelmRelease list. Same shape as the
-// mother's Phase-1 informer initial-list seed (snapshotsToSeeds +
-// Bridge.SeedJobsFromInformerList) so the read returns byte-identical
-// rich Job records (deps + parent + status) just like the mother.
+// chrootSeedJobsStoreIfEmpty — when a /jobs read arrives for a
+// deployment whose per-deployment jobs.Store is missing the live
+// install/reconcile leaves, lazily re-seed the store from a one-shot
+// live-cluster HelmRelease list (+ reconciler / secondary-region /
+// cutover projections). Same shape as the mother's Phase-1 informer
+// initial-list seed (snapshotsToSeeds + Bridge.SeedJobsFromInformerList)
+// so the read returns byte-identical rich Job records (deps + parent +
+// status).
 //
-// No-op when:
-//   - SOVEREIGN_FQDN env is unset (mother mode)
-//   - dep.Request.SovereignFQDN doesn't match SOVEREIGN_FQDN
-//   - jobs.Store already has records for this deployment
-//   - sovereignDynamicClient errors (handler returns the existing
-//     empty list — caller already handles that case)
+// Despite the historical "chroot" name this now serves BOTH modes
+// (#4731): the mothership's per-deployment jobs.Store loses the
+// install-* / reconcile-* leaves whenever the catalyst-api Pod rolls
+// (they were only ever held in the Phase-1 helmwatch.Watcher's
+// in-memory store), leaving a converged Sovereign's Dashboard treemap
+// with only the statically-seeded lifecycle/cron/task/step kinds. The
+// mother is fully capable of re-listing the Sovereign's HelmReleases —
+// h.sovereignDynamicClient(dep) already works in mother mode by reading
+// the deployment's posted-back kubeconfig off the catalyst-api-
+// deployments PVC — so the re-seed simply runs wherever that client can
+// be built.
+//
+// Reachability gate — the seed lists the SOVEREIGN cluster's live
+// objects, so it runs only where catalyst-api can reach that cluster:
+//   - chroot in-cluster: SOVEREIGN_FQDN set AND matches this deployment
+//     (the in-cluster ServiceAccount is the client), preserved exactly
+//     as before; OR
+//   - mother mode: the deployment's kubeconfig has been posted back
+//     (dep.Result.KubeconfigPath set) so sovereignDynamicClient can
+//     build a client from it.
+//
+// No-op (Debug log, never an error — a /jobs read must not fail because
+// the cluster isn't reachable yet) when:
+//   - h.jobs is nil (persistence disabled)
+//   - mother mode AND no kubeconfig posted back yet (provisioning in
+//     flight — the next poll retries once cloud-init PUTs it)
+//   - jobs.Store already has the install group (hasBootstrapKit) — the
+//     expensive live HR-LIST is skipped; the always-idempotent
+//     reconciler / secondary / cutover projections still run
+//   - sovereignDynamicClient errors (handler returns the existing rows)
 func (h *Handler) chrootSeedJobsStoreIfEmpty(ctx context.Context, dep *Deployment) {
 	if h.jobs == nil {
 		return
 	}
+	// The seed can only reach the Sovereign cluster via the chroot
+	// in-cluster client (SOVEREIGN_FQDN set + matches this dep) OR the
+	// mother's posted-back per-deployment kubeconfig. When NEITHER holds
+	// (mother mode, kubeconfig not yet posted — provisioning in flight)
+	// keep the historical no-op so the /jobs read never errors; the next
+	// poll retries once the kubeconfig lands.
 	selfFQDN := strings.TrimSpace(os.Getenv("SOVEREIGN_FQDN"))
-	if selfFQDN == "" {
-		return
-	}
-	if !strings.EqualFold(selfFQDN, dep.Request.SovereignFQDN) {
-		return
+	chrootInCluster := selfFQDN != "" && strings.EqualFold(selfFQDN, dep.Request.SovereignFQDN)
+	if !chrootInCluster {
+		dep.mu.Lock()
+		hasKubeconfig := dep.Result != nil && strings.TrimSpace(dep.Result.KubeconfigPath) != ""
+		dep.mu.Unlock()
+		if !hasKubeconfig {
+			h.log.Debug("jobs seed: sovereign cluster unreachable — no kubeconfig posted back yet; skipping install/reconcile re-seed",
+				"depId", dep.ID)
+			return
+		}
 	}
 	existing, _ := h.jobs.ListJobs(dep.ID)
 	hasBootstrapKit := false

--- a/products/catalyst/bootstrap/api/internal/handler/jobs_mother_reseed_4731_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_mother_reseed_4731_test.go
@@ -1,0 +1,225 @@
+// jobs_mother_reseed_4731_test.go — coverage for the mother-mode
+// install/reconcile re-seed (Refs #4731).
+//
+// Symptom: on the mothership console, a CONVERGED Sovereign's deployment-
+// detail treemap showed ONLY task/step/lifecycle/cron kinds — the
+// install (HelmRelease) and reconcile (Flux Kustomization) leaves were
+// MISSING. Root cause: chrootSeedJobsStoreIfEmpty bailed at the top with
+// `if SOVEREIGN_FQDN == "" { return }`, so on the mother (env unset) the
+// live-cluster HR seed never ran. It was only ever populated in-memory by
+// the Phase-1 helmwatch.Watcher; the catalyst-api Pod roll wiped that, and
+// mother mode had no rebuild path.
+//
+// Fix: gate the seed on REACHABILITY (chroot in-cluster OR mother-with-
+// kubeconfig) instead of on SOVEREIGN_FQDN being set. h.sovereignDynamicClient
+// already reads the posted-back per-deployment kubeconfig in mother mode, so
+// the mother can re-list the Sovereign's HelmReleases on demand.
+//
+// These tests prove:
+//   - a mother-mode Handler (SOVEREIGN_FQDN unset) + a deployment WITH a
+//     Result.KubeconfigPath + a fake dynamicFactory serving N HelmReleases
+//     seeds N `install` leaves into jobs.Store; and
+//   - a mother-mode deployment WITHOUT a posted-back kubeconfig is a
+//     graceful no-op (provisioning in flight), never an error.
+package handler
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// fakeReseedDynamicClient serves the given bp-* HelmReleases (Ready=True)
+// AND registers the four §5a reconciler List kinds so the reconciler-
+// observation leg (chrootSeedReconcilerObservations) — which runs right
+// after the HR seed once the reachability gate is relaxed — Lists cleanly
+// (empty) instead of panicking the fake on an unregistered List kind. No
+// reconciler objects are served, so that leg no-ops; the test focuses on
+// the primary install seed.
+func fakeReseedDynamicClient(t *testing.T, hrNames ...string) *dynamicfake.FakeDynamicClient {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	for _, lk := range []schema.GroupVersionKind{
+		{Group: "helm.toolkit.fluxcd.io", Version: "v2", Kind: "HelmReleaseList"},
+		{Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Kind: "KustomizationList"},
+		{Group: "batch", Version: "v1", Kind: "CronJobList"},
+		{Group: "batch", Version: "v1", Kind: "JobList"},
+		{Group: "apps", Version: "v1", Kind: "DeploymentList"},
+	} {
+		scheme.AddKnownTypeWithName(lk, &unstructured.UnstructuredList{})
+	}
+	objs := make([]runtime.Object, 0, len(hrNames))
+	for _, name := range hrNames {
+		u := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "helm.toolkit.fluxcd.io/v2",
+				"kind":       "HelmRelease",
+				"metadata": map[string]any{
+					"name":      name,
+					"namespace": helmwatch.FluxNamespace,
+				},
+				"status": map[string]any{
+					"conditions": []any{
+						map[string]any{
+							"type":               "Ready",
+							"status":             string(metav1.ConditionTrue),
+							"reason":             "ReconciliationSucceeded",
+							"message":            "Helm install succeeded",
+							"lastTransitionTime": time.Now().UTC().Format(time.RFC3339),
+						},
+					},
+				},
+			},
+		}
+		u.SetGroupVersionKind(schema.GroupVersionKind{
+			Group: "helm.toolkit.fluxcd.io", Version: "v2", Kind: "HelmRelease",
+		})
+		objs = append(objs, u)
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{
+			helmwatch.HelmReleaseGVR:   "HelmReleaseList",
+			helmwatch.KustomizationGVR: "KustomizationList",
+			helmwatch.CronJobGVR:       "CronJobList",
+			helmwatch.JobGVR:           "JobList",
+			helmwatch.DeploymentGVR:    "DeploymentList",
+		},
+		objs...,
+	)
+}
+
+// TestChrootSeedJobsStoreIfEmpty_MotherReseedsInstalls is the end-to-end
+// proof for #4731: on the MOTHER (SOVEREIGN_FQDN unset) a deployment that
+// already has its kubeconfig posted back must re-seed the live-cluster
+// HelmReleases as `install` leaves — the leaves that were missing from a
+// converged Sovereign's Dashboard treemap after a catalyst-api Pod roll.
+func TestChrootSeedJobsStoreIfEmpty_MotherReseedsInstalls(t *testing.T) {
+	// Mother mode — explicitly unset so a polluted env never flips us to the
+	// chroot in-cluster path (which would try rest.InClusterConfig()).
+	t.Setenv("SOVEREIGN_FQDN", "")
+
+	const depID = "dep4731"
+	st, err := jobs.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	hrNames := []string{"bp-cilium", "bp-keycloak", "bp-cnpg", "bp-openbao"}
+	fake := fakeReseedDynamicClient(t, hrNames...)
+	h := &Handler{
+		jobs: st,
+		log:  slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		dynamicFactory: func(string) (dynamic.Interface, error) {
+			return fake, nil
+		},
+	}
+	dep := &Deployment{
+		ID:     depID,
+		Status: "ready",
+		Request: provisioner.Request{
+			SovereignFQDN: "hw224.omani.works",
+			Regions:       []provisioner.RegionSpec{{Provider: "huawei"}},
+		},
+		// Kubeconfig posted back at handover — the converged-Sovereign case.
+		Result: &provisioner.Result{KubeconfigPath: writeTempKubeconfig(t)},
+	}
+
+	h.chrootSeedJobsStoreIfEmpty(context.Background(), dep)
+
+	got, err := st.ListJobs(depID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+
+	// Every HelmRelease must have surfaced as an `install-<chart>` leaf with
+	// the KindInstall / JobTypeInstall tags under the bootstrap-kit group.
+	wantInstall := map[string]bool{
+		"install-cilium":   false,
+		"install-keycloak": false,
+		"install-cnpg":     false,
+		"install-openbao":  false,
+	}
+	installCount := 0
+	sawBootstrapKit := false
+	for _, j := range got {
+		if j.JobName == jobs.GroupBootstrapKit {
+			sawBootstrapKit = true
+		}
+		if j.Kind == jobs.KindInstall && j.Type == jobs.JobTypeInstall {
+			installCount++
+		}
+		if _, tracked := wantInstall[j.JobName]; tracked {
+			wantInstall[j.JobName] = true
+			if j.Kind != jobs.KindInstall {
+				t.Errorf("install leaf %q kind = %q, want %q", j.JobName, j.Kind, jobs.KindInstall)
+			}
+		}
+	}
+	for name, seen := range wantInstall {
+		if !seen {
+			t.Errorf("HelmRelease %q never surfaced as an install leaf on the mother", name)
+		}
+	}
+	if installCount != len(hrNames) {
+		t.Errorf("install leaf count = %d, want %d (one per HelmRelease)", installCount, len(hrNames))
+	}
+	if !sawBootstrapKit {
+		t.Errorf("the bootstrap-kit parent group was never materialised on the mother")
+	}
+}
+
+// TestChrootSeedJobsStoreIfEmpty_MotherNoKubeconfigIsNoOp proves the early
+// phase1-watching window (kubeconfig not posted back yet) stays a graceful
+// no-op on the mother — the reachability gate returns without touching the
+// store and without invoking the dynamicFactory, so a /jobs read never
+// errors and the next poll simply retries.
+func TestChrootSeedJobsStoreIfEmpty_MotherNoKubeconfigIsNoOp(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "")
+
+	const depID = "dep4731nk"
+	st, err := jobs.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	factoryCalled := false
+	h := &Handler{
+		jobs: st,
+		log:  slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		dynamicFactory: func(string) (dynamic.Interface, error) {
+			factoryCalled = true
+			return fakeReseedDynamicClient(t, "should-not-surface"), nil
+		},
+	}
+	dep := &Deployment{
+		ID:      depID,
+		Request: provisioner.Request{SovereignFQDN: "hw224.omani.works"},
+		// No Result/KubeconfigPath — cloud-init still in flight.
+	}
+
+	// Must not panic; store stays empty; the factory is never reached.
+	h.chrootSeedJobsStoreIfEmpty(context.Background(), dep)
+
+	if factoryCalled {
+		t.Fatalf("no-kubeconfig mother path must short-circuit before building a client")
+	}
+	got, err := st.ListJobs(depID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty store when kubeconfig unreachable, got %d jobs", len(got))
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/jobs_mother_reseed_4731_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_mother_reseed_4731_test.go
@@ -27,6 +27,8 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -221,5 +223,70 @@ func TestChrootSeedJobsStoreIfEmpty_MotherNoKubeconfigIsNoOp(t *testing.T) {
 	}
 	if len(got) != 0 {
 		t.Fatalf("expected empty store when kubeconfig unreachable, got %d jobs", len(got))
+	}
+}
+
+// TestChrootSeedJobsStoreIfEmpty_MotherReseedsViaConventionalPath is the
+// live-verified hw224 case: a CONVERGED Sovereign's mother-side record has a
+// NULL Result.KubeconfigPath (the omitempty field was dropped when a
+// mothership Pod roll rehydrated the record before PutKubeconfig re-stamped
+// it), yet the kubeconfig FILE still lives on the PVC at
+// <kubeconfigsDir>/<id>.yaml. The reachability gate + sovereignDynamicClient
+// must fall back to that conventional path (#3153) so the install re-seed
+// still fires — otherwise the treemap shows zero install leaves despite a
+// fully reachable cluster.
+func TestChrootSeedJobsStoreIfEmpty_MotherReseedsViaConventionalPath(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "")
+
+	const depID = "dep4731conv"
+	st, err := jobs.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	// The kubeconfig FILE survives on the PVC at the conventional path even
+	// though the record's KubeconfigPath field is null.
+	kubeDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(kubeDir, depID+".yaml"),
+		[]byte("apiVersion: v1\nkind: Config\n"), 0o600); err != nil {
+		t.Fatalf("write conventional kubeconfig: %v", err)
+	}
+
+	hrNames := []string{"bp-cilium", "bp-flux", "bp-cnpg"}
+	fake := fakeReseedDynamicClient(t, hrNames...)
+	h := &Handler{
+		jobs:           st,
+		log:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		kubeconfigsDir: kubeDir,
+		dynamicFactory: func(string) (dynamic.Interface, error) {
+			return fake, nil
+		},
+	}
+	dep := &Deployment{
+		ID:     depID,
+		Status: "ready",
+		Request: provisioner.Request{
+			SovereignFQDN: "hw224.omani.works",
+			Regions:       []provisioner.RegionSpec{{Provider: "huawei"}},
+		},
+		// Result present but KubeconfigPath EMPTY — the null-field record.
+		Result: &provisioner.Result{KubeconfigPath: ""},
+	}
+
+	h.chrootSeedJobsStoreIfEmpty(context.Background(), dep)
+
+	got, err := st.ListJobs(depID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	installCount := 0
+	for _, j := range got {
+		if j.Kind == jobs.KindInstall && j.Type == jobs.JobTypeInstall {
+			installCount++
+		}
+	}
+	if installCount != len(hrNames) {
+		t.Fatalf("conventional-path fallback: install leaf count = %d, want %d — the null-KubeconfigPath record did not resolve to the on-PVC file",
+			installCount, len(hrNames))
 	}
 }

--- a/products/catalyst/bootstrap/api/internal/handler/jobs_retry.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_retry.go
@@ -109,11 +109,19 @@ func (h *Handler) RetryJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Make sure the store is seeded (chroot lazy seed) so GetJob resolves
-	// the leaf even on the first hit after a Pod restart.
-	h.chrootSeedJobsStoreIfEmpty(r.Context(), dep)
-
 	job, _, err := st.GetJob(depID, jobID)
+	if errors.Is(err, jobs.ErrNotFound) {
+		// Cold store (e.g. first hit after a Pod restart) — lazily seed the
+		// per-deployment store from the live cluster, then resolve again.
+		// Seeding ONLY when the leaf is missing is deliberate (#4731): the
+		// re-seed refreshes every leaf's status from the live cluster, and
+		// the retry path must NOT let that flip the status of the very leaf
+		// the operator is retrying (e.g. a Failed leaf whose stale completed
+		// Job object still lingers in-cluster). The /jobs read paths own the
+		// live-status refresh; here we only need the leaf to exist.
+		h.chrootSeedJobsStoreIfEmpty(r.Context(), dep)
+		job, _, err = st.GetJob(depID, jobID)
+	}
 	if err != nil {
 		if errors.Is(err, jobs.ErrNotFound) {
 			writeJSON(w, http.StatusNotFound, map[string]string{"error": "job-not-found"})


### PR DESCRIPTION
## Founder symptom (verified live, 2026-07-05)

On the mothership console (console.openova.io) deployment-detail treemap for the **converged Sovereign hw224** (`964e9ca501951f54`), the progress/kind treemap showed ONLY `task`/`step`/`lifecycle`/`cron` kinds. The `install` (~65 HelmReleases) and `reconcile` (~14 Flux Kustomizations) leaves — the components the operator actually wants — were MISSING.

## Root cause (two independent defects, both proven on live hw224)

**1. Mother-mode gate.** `chrootSeedJobsStoreIfEmpty` (re-seeds install/reconcile leaves from the live cluster) bailed at the top with `if SOVEREIGN_FQDN == "" { return }`, so on the mothership (`SOVEREIGN_FQDN` unset) the live HelmRelease + reconciler seed never ran.

**2. Null `Result.KubeconfigPath` on a converged record (the deeper defect).** Even with the gate relaxed, the mother could not reach the Sovereign cluster: the live hw224 record has `Result.KubeconfigPath = null`. That field carries json `omitempty` and is dropped when a mothership Pod roll rehydrates the record before `PutKubeconfig` re-stamps it — **but the kubeconfig FILE survives on the PVC** at `/var/lib/catalyst/kubeconfigs/964e9ca501951f54.yaml` (verified: it lists all 65 `bp-*` HelmReleases in flux-system + 14 Kustomizations). Because `sovereignDynamicClient` read the raw record field, it errored with "kubeconfig not yet posted back", so BOTH the install re-seed AND the pre-existing `motherSeedInClusterReconcilers` silently no-oped.

## The fix

**Gate → reachability.** `chrootSeedJobsStoreIfEmpty` now runs wherever catalyst-api can reach the Sovereign cluster: chroot in-cluster (`SOVEREIGN_FQDN` set + matches this dep, **preserved exactly**) OR mother mode with a resolvable kubeconfig. The `!hasBootstrapKit` guard and the idempotent reconciler / secondary-region / cutover projections are all preserved.

**Client → #3153 conventional-path fallback.** `sovereignDynamicClient` now falls back to `resolvePrimaryKubeconfigPath` (the established `#3153` helper) when `Result.KubeconfigPath` is empty — resolving the surviving `<kubeconfigsDir>/<id>.yaml` file and stat-guarding it, so a record whose kubeconfig was genuinely never posted (provisioning in flight) still returns the honest not-yet-posted error. This single change unblocks BOTH the install seed AND `motherSeedInClusterReconcilers` (which also uses `sovereignDynamicClient`) → 65 install + 14 reconcile leaves on the mother. The gate uses the same resolver so the fallback path counts as reachable.

**Retry path.** `RetryJob` also calls the seed (to resolve the target leaf on a cold store). Reordered to seed **only when `GetJob` misses**, so the re-seed's live-status refresh can never flip the status of the leaf the operator is actively retrying (e.g. a Failed leaf whose stale completed Job object still lingers in-cluster).

## Live verification (mothership catalyst-api, dep 964e9ca501951f54)

- `SOVEREIGN_FQDN=` (empty) → mother mode confirmed.
- Record `Result.KubeconfigPath = null`; file present at `/var/lib/catalyst/kubeconfigs/964e9ca501951f54.yaml`.
- Via that file: **65 `bp-*` HelmReleases in flux-system** (all `bp-`-prefixed, exactly what `ListAndSnapshotHelmReleases` matches) + **14 Kustomizations**.
- Post-fix: `resolvePrimaryKubeconfigPath` resolves the file → client builds → install seed yields 65 leaves, reconciler seed yields 14 reconcile leaves.

## Tests (`internal/handler/jobs_mother_reseed_4731_test.go`)

- `TestChrootSeedJobsStoreIfEmpty_MotherReseedsInstalls` — mother-mode dep + fake `dynamicFactory` serving N HelmReleases seeds N `install` leaves via the real `ListAndSnapshotHelmReleases` path.
- `TestChrootSeedJobsStoreIfEmpty_MotherReseedsViaConventionalPath` — the hw224 case: NULL `Result.KubeconfigPath` + file at `<kubeconfigsDir>/<id>.yaml` still seeds N install leaves.
- `TestChrootSeedJobsStoreIfEmpty_MotherNoKubeconfigIsNoOp` — no resolvable kubeconfig → graceful no-op, factory never invoked.

Existing chroot seed tests + full RetryJob suite stay green. `go build`, `go test ./...`, `go vet ./...`, `gofmt` clean across the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
