### PR TITLE
fix(cilium): native routing (drop VXLAN) to end the unfixable-by-MTU cross-node DF-drop (Refs #4656)

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -134,7 +134,14 @@ spec:
       # the 1.19.3 default (migration) mounts a helm-managed users CM that the
       # externally-established Catalyst mesh never renders (both hw224 regions
       # wedged Init:0/1 FailedMount on the 1.4.9 roll).
-      version: 1.4.10
+      # 1.4.11 (#4656, 2026-07-05): NATIVE routing (drop VXLAN). VXLAN-over-
+      # WireGuard stacked two headers per cross-node pod packet → DF-drops
+      # unfixable by any MTU. Chart switches routingMode: native +
+      # ipv4NativeRoutingCIDR + autoDirectNodeRoutes; MTU pin above moves
+      # 1370 → 1420 (WG-only). Layers on the 1.4.9/1.4.10 zero-nodeport +
+      # authMode=legacy work. Cross-region ClusterMesh pod path needs a fresh
+      # 2-region prov to verify (datapath change). Refs #4656.
+      version: 1.4.11
       sourceRef:
         kind: HelmRepository
         name: bp-cilium
@@ -191,20 +198,22 @@ spec:
       # The :=10.0.1.2 fallback preserves single-region (primary-only)
       # provisions where the substitute var would be empty/absent.
       k8sServiceHost: ${CILIUM_K8S_SERVICE_HOST:=10.0.1.2}
-      # 1.4.4 (#4467, Huawei kom4dc fresh prov): pin the datapath MTU to
-      # account for the COMBINED VXLAN-tunnel(+50) + WireGuard-node-
-      # encryption(+80) overhead. Cilium auto-MTU read eth0=1500 and
-      # programmed cilium_wg0=1420 but left cilium_vxlan/cilium_host/lxc*
-      # at 1500 → full-size pod frames overflow the WireGuard MTU and are
-      # silently DF-dropped → ALL cross-node pod TCP to non-trivial payloads
-      # times out (curl 28) → Phase-1 convergence deadlock (gitea-token-mint
-      # → gitea-http.gitea.svc:3000 cross-node). 1500−50−80 = 1370; a 1370B
-      # pod payload + 50B VXLAN = 1420 = the cilium_wg0 MTU exactly. The
-      # chart default (platform/cilium/chart/values.yaml `cilium.MTU: 1370`)
-      # already carries this; pinned here too so the load-bearing value is
-      # visible at the slot. Jumbo-frame / non-1500-eth0 Sovereigns override
-      # via ${CILIUM_MTU:=1370} in their per-Sovereign overlay (eth0−130).
-      MTU: ${CILIUM_MTU:=1370}
+      # 1.4.11 (#4656, 2026-07-05): NATIVE routing (drop VXLAN) — the datapath
+      # MTU is now WG-only. The old VXLAN-tunnel + WireGuard stack was
+      # UNFIXABLE by any MTU (cilium derived cilium_wg0 = MTU−80, so a pod
+      # packet + 50B VXLAN header ALWAYS exceeded wg0 → full-size cross-node
+      # pod TCP DF-dropped → Phase-1 convergence deadlock; #4467's MTU=1370
+      # pin disproven live on hw224). With routingMode: native (chart
+      # values.yaml) there is no VXLAN header to stack — WireGuard
+      # encapsulates ONCE, so the correct pod MTU is eth0(1500)−80 = 1420.
+      # The chart default (platform/cilium/chart/values.yaml `cilium.MTU:
+      # 1420`) already carries this; pinned here too so the load-bearing value
+      # is visible at the slot. Jumbo-frame / non-1500-eth0 Sovereigns override
+      # via ${CILIUM_MTU:=1420} in their per-Sovereign overlay (eth0−80).
+      # routingMode: native + ipv4NativeRoutingCIDR (10.42.0.0/15, spanning
+      # both per-region k3s pod CIDRs) + autoDirectNodeRoutes live in the chart
+      # values.yaml; the slot inherits them (no override needed here).
+      MTU: ${CILIUM_MTU:=1420}
       # Phase-8a bug #15 (otech8 deployment 1bfc46347564467b 2026-05-01):
       # cilium-agent waits forever for the operator to register
       # ciliumenvoyconfigs + ciliumclusterwideenvoyconfigs CRDs.

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -401,7 +401,16 @@ write_files:
       kubeProxyReplacement: true
       k8sServiceHost: NODE_IP_PLACEHOLDER
       k8sServicePort: 6443
-      tunnelProtocol: vxlan
+      # #4656: NATIVE routing (not vxlan) so WireGuard node-encryption does not
+      # double-encapsulate. VXLAN-inside-WireGuard is unfixable by any MTU —
+      # pinning MTU makes cilium derive wg0 = MTU-80, so pod(MTU)+50(VXLAN)
+      # always exceeds wg0 (proven live on hw224: host 1370 + 50 > wg0 1290).
+      # Nodes are L2-adjacent within a region so autoDirectNodeRoutes installs
+      # cross-node pod routes with no tunnel; the native CIDR is the per-region
+      # k3s cluster CIDR; cross-region reach stays ClusterMesh's job.
+      routingMode: native
+      ipv4NativeRoutingCIDR: "${cluster_cidr}"
+      autoDirectNodeRoutes: true
       bpf:
         masquerade: true
       ipam:

--- a/platform/cilium/blueprint.yaml
+++ b/platform/cilium/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 1.4.10
+  version: 1.4.11
   card:
     title: Cilium
     summary: Unified CNI + Service Mesh (eBPF). mTLS via WireGuard, Hubble observability, Gateway API.

--- a/platform/cilium/chart/Chart.yaml
+++ b/platform/cilium/chart/Chart.yaml
@@ -223,7 +223,19 @@ name: bp-cilium
 # 1.4.10 (#4765 follow-up): docs-only bump in lockstep with slot 01
 #   clustermesh.apiserver.tls.authMode=legacy (values live in the slot; the
 #   1.19.3 migration default mounts a users CM external establish never makes).
-version: 1.4.10
+# 1.4.11 (#4656, 2026-07-05): NATIVE routing (drop VXLAN). VXLAN-tunnel over
+#   WireGuard node-encryption stacks two headers on every cross-node pod
+#   packet (pod-MTU + 50B VXLAN > wg0), DF-dropping full-size cross-node pod
+#   TCP — UNFIXABLE by any MTU pin (cilium derives wg0 = MTU−80, so
+#   pod(MTU)+50 always exceeds wg0; #4467's MTU=1370 disproven live on hw224).
+#   Fix: routingMode: native + ipv4NativeRoutingCIDR + autoDirectNodeRoutes so
+#   WireGuard encapsulates ONCE and no VXLAN header stacks. MTU 1370 → 1420
+#   (WG-only = eth0−80). ipv4NativeRoutingCIDR 10.42.0.0/15 spans both
+#   per-region k3s pod CIDRs (region-a 10.42.0.0/16 + region-b 10.43.0.0/16).
+#   Layers ON TOP of the 1.4.9/1.4.10 zero-nodeport + authMode=legacy work.
+#   Needs a fresh 2-region prov to verify the cross-region ClusterMesh pod
+#   path end-to-end (datapath change, not CI-provable). Refs #4656.
+version: 1.4.11
 description: |
   Catalyst-curated Blueprint umbrella chart for Cilium. Depends on the
   upstream `cilium` chart as a Helm subchart so `helm dependency build`

--- a/platform/cilium/chart/tests/mtu-wireguard-vxlan.sh
+++ b/platform/cilium/chart/tests/mtu-wireguard-vxlan.sh
@@ -1,35 +1,39 @@
 #!/usr/bin/env bash
-# bp-cilium MTU wireguard+vxlan render test (issue #4467).
+# bp-cilium native-routing + WireGuard MTU render test (issue #4656,
+# supersedes the #4467 vxlan-tunnel MTU guard).
 #
-# Regression guard for the live Huawei me-east-215 (kom4dc) fresh-prov bug:
-# the chart runs the datapath in VXLAN-tunnel mode (routingMode=tunnel +
-# tunnelProtocol=vxlan — upstream cilium defaults, the chart sets neither)
-# WITH WireGuard node-encryption (encryption.type=wireguard +
-# nodeEncryption=true). Cilium's AUTO-MTU detection read eth0=1500 and
-# programmed cilium_wg0=1420 (eth0 − 80 WG) but left cilium_vxlan /
-# cilium_host / pod lxc* veths at 1500. A full-size 1500-byte pod frame +
-# 50-byte VXLAN header = 1550 bytes, which overflows the 1420 WireGuard MTU
-# and is silently DF-dropped → ALL cross-node pod-to-pod TCP to non-trivial
-# payloads times out (curl 28) → Phase-1 convergence deadlock (e.g. the
-# catalyst-gitea-token-mint Job can't reach gitea-http.gitea.svc:3000 on
-# another node, so bp-catalyst-platform never finishes installing).
+# HISTORY (#4467): the chart originally ran the datapath in VXLAN-tunnel mode
+# (routingMode=tunnel + tunnelProtocol=vxlan) WITH WireGuard node-encryption.
+# On a live Huawei me-east-215 (kom4dc) fresh prov this stacked TWO
+# encapsulations on every cross-node pod packet: pod-MTU + 50B VXLAN header,
+# carried over cilium_wg0 = eth0−80. A full-size pod frame + 50B VXLAN always
+# overflowed cilium_wg0 and was silently DF-dropped → ALL cross-node pod-to-pod
+# TCP to non-trivial payloads timed out (curl 28) → Phase-1 convergence
+# deadlock. #4467 pinned cilium.MTU=1370 (1500−50−80) as a mitigation, but that
+# was DISPROVEN: pinning the MTU makes cilium derive cilium_wg0 = MTU−80, so
+# pod(MTU) + 50 (VXLAN) ALWAYS exceeds cilium_wg0 for EVERY MTU value — the bug
+# is mathematically unfixable while both VXLAN and WireGuard node-encryption are
+# on (live-measured on hw224: host 1370 + 50 > wg0 1290).
 #
-# The fix pins the upstream chart's top-level `MTU` helm value to 1370
-# (= 1500 eth0 − 50 VXLAN − 80 WireGuard), which renders cilium-config
-# `mtu: "1370"` and sets exactly the cilium_net / cilium_host / cilium_vxlan
-# / lxc device MTUs (per the upstream values.yaml comment). A 1370-byte pod
-# payload + 50-byte VXLAN = 1420 = the cilium_wg0 MTU exactly.
+# FIX (#4656): DROP the VXLAN layer entirely — routingMode: native +
+# ipv4NativeRoutingCIDR + autoDirectNodeRoutes. WireGuard then encapsulates the
+# cross-node pod path ONCE (no VXLAN header to stack), so the correct pod MTU is
+# eth0(1500) − 80 (WireGuard only) = 1420. Nodes are L2-adjacent within a region
+# (same VPC subnet) so autoDirectNodeRoutes installs direct cross-node pod
+# routes with no tunnel; cross-region reach stays ClusterMesh's job.
 #
 # This test asserts:
-#   1. default render emits cilium-config `mtu: "1370"` (the bug-fix value),
-#      AND WireGuard encryption is on AND the datapath is NOT forced into
-#      native routing (so the +50 VXLAN overhead the 1370 accounts for is
-#      genuinely present).
-#   2. setting cilium.MTU=0 (the upstream auto-detect default that REPRODUCES
-#      the bug) emits NO `mtu:` key — proving 1370 is a deliberate override
-#      and a future values.yaml regression to 0 would be caught.
-#   3. an operator overlay (cilium.MTU=1450, e.g. a WG-off Sovereign) renders
-#      that value verbatim — the knob is overridable per-Sovereign.
+#   1. default render emits cilium-config `mtu: "1420"` (the WG-only value)
+#      AND WireGuard encryption is on (the +80 overhead the 1420 accounts for)
+#      AND the datapath IS in native routing (routing-mode: native) with
+#      ipv4-native-routing-cidr set + auto-direct-node-routes on — so the
+#      NO-VXLAN premise the 1420 depends on genuinely holds. If a future edit
+#      reverts to vxlan-tunnel routing while keeping 1420, this flags it.
+#   2. setting cilium.MTU=0 (the upstream auto-detect default) emits NO `mtu:`
+#      key — proving 1420 is a deliberate override and a regression to 0 is
+#      caught.
+#   3. an operator overlay (cilium.MTU=1450, e.g. a jumbo-frame Sovereign)
+#      renders that value verbatim — the knob is overridable per-Sovereign.
 #
 # Auto-discovered + run by .github/workflows/blueprint-release.yaml's
 # "Run chart integration tests (chart/tests/*.sh)" gate.
@@ -52,46 +56,60 @@ if [ ! -d charts ] || [ -z "$(ls -A charts 2>/dev/null)" ]; then
   helm dependency build >/dev/null
 fi
 
-# ── Case 1: default render pins mtu: "1370" with WireGuard on + vxlan ────
-echo "[mtu-wireguard-vxlan] Case 1: default render emits cilium-config mtu: \"1370\""
+# ── Case 1: default render pins mtu: "1420" with WireGuard on + native ───
+echo "[mtu-wireguard-vxlan] Case 1: default render emits cilium-config mtu: \"1420\" (native routing)"
 helm template smoke-cilium . > "$TMP/default.yaml"
 
-# The upstream cilium-configmap renders `mtu: "1370"` only when .Values.MTU
+# The upstream cilium-configmap renders `mtu: "1420"` only when .Values.MTU
 # is truthy. Grep the cilium ConfigMap data key.
-if ! grep -qE '^\s*mtu:\s*"1370"\s*$' "$TMP/default.yaml"; then
-  echo "FAIL: default render does NOT pin cilium-config mtu: \"1370\"." >&2
-  echo "      The WireGuard+VXLAN datapath needs MTU = 1500 - 50 (vxlan) - 80 (wg) = 1370," >&2
-  echo "      else cilium auto-MTU leaves pod lxc*/cilium_vxlan at 1500 and oversized" >&2
-  echo "      frames are DF-dropped at the 1420 WireGuard MTU (issue #4467)." >&2
+if ! grep -qE '^\s*mtu:\s*"1420"\s*$' "$TMP/default.yaml"; then
+  echo "FAIL: default render does NOT pin cilium-config mtu: \"1420\"." >&2
+  echo "      Native routing (no VXLAN) needs MTU = 1500 - 80 (wireguard) = 1420," >&2
+  echo "      else cilium auto-MTU mis-sizes the pod-facing devices (issue #4656)." >&2
   echo "      cilium-config mtu line(s) found:" >&2
   grep -nE '^\s*mtu:' "$TMP/default.yaml" >&2 || echo "      (no mtu key rendered at all)" >&2
   exit 1
 fi
 
-# Guard the PREMISE: the 1370 only makes sense if WireGuard encryption is on
-# (the +80 overhead) AND the datapath is not forced into native routing (so
-# the +50 VXLAN overhead is genuinely present). If a future edit turns
-# WireGuard off OR sets routing-mode=native, 1370 would be wrong and this
-# test must flag the mismatch.
+# Guard the PREMISE: 1420 (WG-only) is correct ONLY when WireGuard encryption
+# is on (the +80 overhead) AND the datapath is in NATIVE routing (no +50 VXLAN
+# header to stack). If a future edit turns WireGuard off OR reverts to
+# vxlan-tunnel routing, 1420 would be wrong and this test must flag it.
 if ! grep -qE '^\s*enable-wireguard:\s*"true"\s*$' "$TMP/default.yaml"; then
   echo "FAIL: default render does NOT enable WireGuard, but MTU is pinned to the" >&2
-  echo "      WireGuard-overhead value 1370. Either re-enable encryption.type=wireguard" >&2
-  echo "      or recompute the MTU (issue #4467)." >&2
+  echo "      WireGuard-overhead value 1420. Either re-enable encryption.type=wireguard" >&2
+  echo "      or recompute the MTU (issue #4656)." >&2
   grep -nE 'enable-wireguard|encryption' "$TMP/default.yaml" >&2 || true
   exit 1
 fi
-# routing-mode native is the ONE mode where the +50 VXLAN overhead vanishes.
-# The chart must NOT be in native routing while pinning 1370.
-if grep -qE '^\s*routing-mode:\s*"native"\s*$' "$TMP/default.yaml"; then
-  echo "FAIL: default render forces routing-mode=native, but MTU 1370 budgets for the" >&2
-  echo "      +50 VXLAN tunnel overhead. Native routing has no VXLAN header — recompute" >&2
-  echo "      the MTU (eth0 - 80 WG only) if native routing is intended (issue #4467)." >&2
+# routing-mode MUST be native — the #4656 fix that removes the +50 VXLAN header
+# so a single WireGuard encapsulation (MTU−80 = 1420) fits. A revert to
+# vxlan-tunnel routing re-introduces the unfixable-by-MTU DF-drop bug.
+if ! grep -qE '^\s*routing-mode:\s*"native"\s*$' "$TMP/default.yaml"; then
+  echo "FAIL: default render is NOT in native routing, but MTU 1420 budgets for a" >&2
+  echo "      WireGuard-only (no VXLAN) datapath. VXLAN-over-WireGuard stacks a +50" >&2
+  echo "      header that no MTU escapes (#4467 disproven) — keep routing-mode: native" >&2
+  echo "      (issue #4656)." >&2
+  grep -nE '^\s*routing-mode:' "$TMP/default.yaml" >&2 || echo "      (no routing-mode key)" >&2
+  exit 1
+fi
+# native routing REQUIRES ipv4-native-routing-cidr (upstream chart fails to
+# template without it) + autoDirectNodeRoutes for the tunnel-free cross-node
+# pod path. Assert both landed.
+if ! grep -qE '^\s*ipv4-native-routing-cidr:\s*\S' "$TMP/default.yaml"; then
+  echo "FAIL: routing-mode is native but ipv4-native-routing-cidr is absent — cilium" >&2
+  echo "      cannot decide which pod traffic is natively routable (issue #4656)." >&2
+  exit 1
+fi
+if ! grep -qE '^\s*auto-direct-node-routes:\s*"true"\s*$' "$TMP/default.yaml"; then
+  echo "FAIL: native routing without auto-direct-node-routes — same-region nodes will" >&2
+  echo "      not install direct cross-node pod routes (issue #4656)." >&2
   exit 1
 fi
 echo "  PASS"
 
 # ── Case 2: MTU=0 (auto-detect, the bug) emits NO mtu key ───────────────
-echo "[mtu-wireguard-vxlan] Case 2: MTU=0 (auto-detect) emits no mtu key — proves 1370 is deliberate"
+echo "[mtu-wireguard-vxlan] Case 2: MTU=0 (auto-detect) emits no mtu key — proves 1420 is deliberate"
 if ! helm template smoke-cilium . --set cilium.MTU=0 \
      > "$TMP/auto.yaml" 2> "$TMP/auto.err"; then
   echo "FAIL: MTU=0 render failed:" >&2
@@ -101,7 +119,7 @@ fi
 if grep -qE '^\s*mtu:\s*"' "$TMP/auto.yaml"; then
   echo "FAIL: MTU=0 still rendered an mtu key — the upstream chart should OMIT mtu when" >&2
   echo "      MTU is falsy (auto-detect). If this assertion changed, re-verify the upstream" >&2
-  echo "      cilium-configmap.yaml MTU gate (issue #4467)." >&2
+  echo "      cilium-configmap.yaml MTU gate (issue #4656)." >&2
   grep -nE '^\s*mtu:' "$TMP/auto.yaml" >&2
   exit 1
 fi
@@ -117,10 +135,10 @@ if ! helm template smoke-cilium . --set cilium.MTU=1450 \
 fi
 if ! grep -qE '^\s*mtu:\s*"1450"\s*$' "$TMP/override.yaml"; then
   echo "FAIL: cilium.MTU=1450 overlay did not render mtu: \"1450\" — the per-Sovereign" >&2
-  echo "      MTU override knob is broken (issue #4467)." >&2
+  echo "      MTU override knob is broken (issue #4656)." >&2
   grep -nE '^\s*mtu:' "$TMP/override.yaml" >&2 || true
   exit 1
 fi
 echo "  PASS"
 
-echo "[mtu-wireguard-vxlan] All bp-cilium MTU wireguard+vxlan gates green."
+echo "[mtu-wireguard-vxlan] All bp-cilium native-routing + WireGuard MTU gates green."

--- a/platform/cilium/chart/values.yaml
+++ b/platform/cilium/chart/values.yaml
@@ -159,10 +159,33 @@ cilium:
   # default) means auto-detect and reproduces the bug.
   #
   # Air-gapped / jumbo-frame (eth0 MTU != 1500) Sovereigns recompute as
-  # `<eth0-mtu> − 130` in their per-Sovereign overlay at clusters/<sov>/
-  # bootstrap-kit/01-cilium.yaml. Native-routing (non-vxlan) Sovereigns,
-  # if ever shipped, override to `<eth0-mtu> − 80` (WG-only) there too.
-  MTU: 1370
+  # `<eth0-mtu> − 80` (WG-only, native routing) in their per-Sovereign overlay
+  # at clusters/<sov>/bootstrap-kit/01-cilium.yaml.
+  #
+  # #4656 (2026-07-04): switched to NATIVE routing (routingMode below) so
+  # WireGuard encapsulates ONCE. VXLAN-inside-WireGuard was UNFIXABLE by any
+  # MTU: pinning MTU makes cilium derive wg0 = MTU−80, so pod(MTU)+50(VXLAN)
+  # ALWAYS exceeds wg0 (proven live hw224: host 1370 + 50 > wg0 1290). With
+  # no VXLAN the WG-only MTU is eth0(1500)−80 = 1420.
+  MTU: 1420
+
+  # #4656: native routing (NOT the upstream vxlan-tunnel default). WireGuard
+  # node-encryption then encapsulates cross-node pod traffic ONCE. Nodes are
+  # L2-adjacent within a region (same VPC subnet) so autoDirectNodeRoutes
+  # installs direct cross-node pod routes with no tunnel.
+  #
+  # ipv4NativeRoutingCIDR spans BOTH per-region k3s pod CIDRs — region-a
+  # 10.42.0.0/16 + region-b 10.43.0.0/16 collapse to the /15 10.42.0.0/15 —
+  # so a single chart value is correct for every region AND for single-region
+  # Sovereigns (whose pod CIDR is a subset). Traffic to pod IPs inside this
+  # CIDR is routed natively (never masqueraded); everything else egresses
+  # NAT'd. The bootstrap cloud-init pins the tighter per-region cluster_cidr
+  # explicitly; this chart overlay widens it to cover cross-region ClusterMesh.
+  # ⚠️ 2-region ClusterMesh cross-region pod reach MUST be fresh-prov-verified
+  # before merge (see #4656 spec) — this is the reviewable starting point.
+  routingMode: native
+  ipv4NativeRoutingCIDR: "10.42.0.0/15"
+  autoDirectNodeRoutes: true
 
   # Hubble — network observability (L3/L4/L7 flows, DNS, drop, http metrics).
   #


### PR DESCRIPTION
## Root cause (verified, not re-litigated)

On Huawei/kom4dc Sovereigns Cilium runs **VXLAN tunnel encapsulation OVER WireGuard node-encryption**. The two headers **STACK** on every cross-node pod packet: `pod-MTU + 50B VXLAN` header, carried over `cilium_wg0 = eth0 − 80`. A full-size pod frame + VXLAN always overflows `cilium_wg0` and is silently **DF-dropped**, so ALL cross-node pod TCP to non-trivial payloads times out → vcluster apiserver i/o-timeout, WordPress-in-vcluster never runs, region-b `clustermesh-apiserver` `Init:0/1`, region-kill failover + sovereignty cutover blocked. This is the largest single block of red UAT rows.

**Mathematically unfixable by any MTU pin.** Pinning `cilium.MTU` makes cilium derive `cilium_wg0 = MTU − 80`, so `pod(MTU) + 50 (VXLAN)` **always** exceeds `cilium_wg0` for every MTU value. #4467's `MTU=1370` was **disproven live on hw224** (host 1370 + 50 > wg0 1290, see commit `937c63d6b`). The only fix is to drop the VXLAN layer.

## Fix

`routingMode: native` + `ipv4NativeRoutingCIDR` + `autoDirectNodeRoutes` so **WireGuard encapsulates ONCE** and there is no VXLAN header to stack. Nodes are L2-adjacent within a region (same VPC subnet) → `autoDirectNodeRoutes` installs direct cross-node pod routes with no tunnel; cross-region reach stays ClusterMesh's job over the WireGuard node path.

- **cloud-init** (`infra/providers/_shared/cloudinit-control-plane.tftpl`): `tunnelProtocol: vxlan` → `routingMode: native` + `ipv4NativeRoutingCIDR: ${cluster_cidr}` (per-region-correct) + `autoDirectNodeRoutes: true`.
- **bp-cilium chart** (`platform/cilium/chart/values.yaml`): MTU `1370 → 1420` (WG-only = eth0−80), `routingMode: native`, `ipv4NativeRoutingCIDR: 10.42.0.0/15` (spans both per-region k3s pod CIDRs — region-a `10.42.0.0/16` + region-b `10.43.0.0/16`), `autoDirectNodeRoutes: true`. The upstream 1.19.3 subchart **fails to template** under native routing without an explicit `ipv4NativeRoutingCIDR`, so it is set here, not left to auto-derive.
- **slot overlay** (`clusters/_template/bootstrap-kit/01-cilium.yaml`): `MTU: ${CILIUM_MTU:=1370}` → `1420` so the slot no longer overrides the chart back to the vxlan value.
- **regression test** (`platform/cilium/chart/tests/mtu-wireguard-vxlan.sh`): the old #4467 test asserted the superseded vxlan/1370 contract; rewritten to guard the NEW native-routing contract (`mtu 1420`, `routing-mode native`, `ipv4-native-routing-cidr` + `auto-direct-node-routes` present, WireGuard on).

## Layers on top of the zero-nodeport work

This change is applied fresh on `main` (bp-cilium **1.4.10**), **preserving all of** the 1.4.9/1.4.10 work — single `sovereign-vip` LB-IPAM pool, `clustermesh` `authMode=legacy`, and the clustermesh Service NodePort suppression. `scripts/check-no-nodeports.sh` stays green (cilium renders **zero** NodePort Services). bp-cilium `1.4.10 → 1.4.11`, lockstep across `Chart.yaml` + `blueprint.yaml` + slot pin.

## Verification status (honest)

Local gates green:
- `helm template platform/cilium/chart` renders clean: `routing-mode: native`, `ipv4-native-routing-cidr: 10.42.0.0/15`, `auto-direct-node-routes: true`, `mtu: 1420`, **zero NodePorts**.
- All **5** bp-cilium chart tests pass.
- `check-bootstrap-kit-pin-sync.sh`: `bp-cilium chart=1.4.11 pin=1.4.11` OK.
- `cloudinit-size-check.sh` + `lint-cloudinit.sh` green for both providers (Huawei CP 82.4% of cap).

**This is a datapath change — it is NOT CI-provable.** It needs a fresh **2-region** prov to verify the cross-region ClusterMesh pod path end-to-end (coredns Ready, WordPress `200` in-vcluster, region-b converges, cross-region pod reach) before the surface is called shipped. `ipv4NativeRoutingCIDR: 10.42.0.0/15` covers up to 2 regions (10.42/10.43); a 3+-region Sovereign would need the CIDR widened (per-Sovereign overlay).

Refs #4656

🤖 Generated with [Claude Code](https://claude.com/claude-code)
