### PR TITLE
fix(showback): directory panel renders every Org row, not just the parent (Refs #4739)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/ShowbackPanel.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/ShowbackPanel.test.tsx
@@ -56,6 +56,42 @@ describe('ShowbackPanel — parent self-showback (DoD 3)', () => {
     expect(screen.getByTestId('showback-no-apps')).toBeTruthy()
   })
 
+  it('directory view (no org prop) renders EVERY org — the customer Org row, not just the parent (#4739 row 23)', () => {
+    const multi: SovereignConsumption = {
+      totalCostUnits: 1425.5,
+      pending: false,
+      orgs: [
+        { org: 'sovereign', isParent: true, isPlatform: false, costUnits: 0, cpuMilli: 0, memoryGiB: 0, storageGiB: 0, apps: [] },
+        { org: 'uatwp4758', isParent: false, isPlatform: false, costUnits: 525.5, cpuMilli: 520, memoryGiB: 1.06, storageGiB: 5,
+          apps: [{ application: 'vcluster', namespace: 'uatwp4758', costUnits: 525.5, cpuMilli: 520, memoryGiB: 1.06, storageGiB: 5, percent: 100 }] },
+        { org: '__platform', isParent: false, isPlatform: true, costUnits: 900, cpuMilli: 750, memoryGiB: 2, storageGiB: 10, apps: [] },
+      ],
+    }
+    renderPanel(multi)
+    // The customer Org slice MUST render (the bug: it was dropped, only the parent showed).
+    expect(screen.getByTestId('showback-org-slice-uatwp4758')).toBeTruthy()
+    expect(screen.getByTestId('showback-app-vcluster')).toBeTruthy()
+    // All three orgs present + distinct (parent, customer, platform).
+    expect(screen.getByTestId('showback-org-slice-sovereign')).toBeTruthy()
+    expect(screen.getByTestId('showback-org-slice-__platform')).toBeTruthy()
+    // The customer Org's 525.5 units surface (not collapsed to the parent's 0).
+    expect(screen.getAllByTestId('showback-total').some((n) => n.textContent === '525.5')).toBe(true)
+  })
+
+  it('detail view (org prop) still renders only that one org', () => {
+    const multi: SovereignConsumption = {
+      totalCostUnits: 525.5, pending: false,
+      orgs: [
+        { org: 'sovereign', isParent: true, isPlatform: false, costUnits: 0, cpuMilli: 0, memoryGiB: 0, storageGiB: 0, apps: [] },
+        { org: 'uatwp4758', isParent: false, isPlatform: false, costUnits: 525.5, cpuMilli: 520, memoryGiB: 1.06, storageGiB: 5,
+          apps: [{ application: 'vcluster', namespace: 'uatwp4758', costUnits: 525.5, cpuMilli: 520, memoryGiB: 1.06, storageGiB: 5, percent: 100 }] },
+      ],
+    }
+    renderPanel(multi, 'uatwp4758')
+    expect(screen.getByTestId('showback-org-slice-uatwp4758')).toBeTruthy()
+    expect(screen.queryByTestId('showback-org-slice-sovereign')).toBeNull()
+  })
+
   it('never crashes on an empty feed', () => {
     renderPanel({ totalCostUnits: 0, pending: true, orgs: [] })
     expect(screen.getByTestId('showback-empty')).toBeTruthy()

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/ShowbackPanel.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/ShowbackPanel.tsx
@@ -20,11 +20,64 @@ import {
 } from '@/lib/organizations.api'
 
 export interface ShowbackPanelProps {
-  /** Render only this org's slice (e.g. the parent). When omitted the
-   *  panel shows the parent (first org) row. */
+  /** Render only this org's slice (e.g. the parent detail view). When
+   *  omitted the panel renders EVERY org's slice — the sovereign estate
+   *  PLUS each customer Organization row (#4739 row 23: a 2nd Org's own
+   *  consumption must show as its own row, distinct from Platform
+   *  overhead), not just the parent. */
   org?: string
   /** Test seam — bypass the fetch with a synthetic feed. */
   initialOverride?: SovereignConsumption
+}
+
+/** OrgShowbackSlice — one org's per-app consumption block. Rendered once
+ *  in the org-detail view and once per org in the directory view. */
+function OrgShowbackSlice({ target }: { target: OrgConsumption }) {
+  return (
+    <div data-testid={`showback-org-slice-${target.org}`} className="mb-4 last:mb-0">
+      <p className="mb-2 text-xs text-[var(--color-text-dim)]">
+        <span data-testid="showback-org" className="font-medium text-[var(--color-text)]">{target.org}</span>
+        {target.isParent
+          ? ' (parent — your own estate)'
+          : target.isPlatform
+            ? ' (platform overhead)'
+            : ' (Organization)'}{' '}
+        ·{' '}
+        <span data-testid="showback-total" className="font-mono">{target.costUnits}</span> units ·{' '}
+        {target.cpuMilli}m CPU · {target.memoryGiB} GiB mem · {target.storageGiB} GiB storage
+      </p>
+      {target.apps.length === 0 ? (
+        <div data-testid="showback-no-apps" className="text-sm text-[var(--color-text-dim)]">
+          No applications attributed yet.
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-[var(--color-border)]">
+          <table data-testid="showback-table" className="w-full border-collapse text-sm">
+            <thead>
+              <tr className="border-b border-[var(--color-border)] text-left text-[0.7rem] uppercase tracking-wide text-[var(--color-text-dim)]">
+                <th className="px-3 py-2 font-semibold">Application</th>
+                <th className="px-3 py-2 font-semibold">Namespace</th>
+                <th className="px-3 py-2 font-semibold text-right">CPU (m)</th>
+                <th className="px-3 py-2 font-semibold text-right">Mem (GiB)</th>
+                <th className="px-3 py-2 font-semibold text-right">Share</th>
+              </tr>
+            </thead>
+            <tbody>
+              {target.apps.map((a) => (
+                <tr key={`${a.namespace}/${a.application}`} data-testid={`showback-app-${a.application}`} className="border-b border-[var(--color-border)] last:border-b-0">
+                  <td className="px-3 py-2 text-[var(--color-text-strong)]">{a.application}</td>
+                  <td className="px-3 py-2 font-mono text-xs text-[var(--color-text-dim)]">{a.namespace}</td>
+                  <td className="px-3 py-2 text-right tabular-nums">{a.cpuMilli}</td>
+                  <td className="px-3 py-2 text-right tabular-nums">{a.memoryGiB}</td>
+                  <td className="px-3 py-2 text-right tabular-nums" data-testid={`showback-app-pct-${a.application}`}>{a.percent}%</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
 }
 
 export function ShowbackPanel({ org, initialOverride }: ShowbackPanelProps) {
@@ -38,11 +91,15 @@ export function ShowbackPanel({ org, initialOverride }: ShowbackPanelProps) {
   const feed = initialOverride ?? query.data
   const loading = !initialOverride && query.isLoading
 
-  const target: OrgConsumption | undefined = feed
+  // Detail view (`org` given) → that single org's slice. Directory view
+  // (no `org`) → EVERY org, parent first (#4739 row 23): the customer
+  // Organizations' own consumption must each render as their own row,
+  // not be collapsed to the parent-only view.
+  const slices: OrgConsumption[] = feed
     ? org
-      ? feed.orgs.find((o) => o.org === org)
-      : feed.orgs.find((o) => o.isParent) ?? feed.orgs[0]
-    : undefined
+      ? feed.orgs.filter((o) => o.org === org)
+      : feed.orgs
+    : []
 
   return (
     <section
@@ -65,48 +122,15 @@ export function ShowbackPanel({ org, initialOverride }: ShowbackPanelProps) {
 
       {loading ? (
         <div data-testid="showback-loading" className="text-sm text-[var(--color-text-dim)]">Loading…</div>
-      ) : !target ? (
+      ) : slices.length === 0 ? (
         <div data-testid="showback-empty" className="text-sm text-[var(--color-text-dim)]">
           No consumption attributed yet. Showback populates from running workloads.
         </div>
       ) : (
         <div>
-          <p className="mb-3 text-xs text-[var(--color-text-dim)]">
-            <span data-testid="showback-org" className="font-medium text-[var(--color-text)]">{target.org}</span>
-            {target.isParent ? ' (parent — your own estate)' : ''} ·{' '}
-            <span data-testid="showback-total" className="font-mono">{target.costUnits}</span> units ·{' '}
-            {target.cpuMilli}m CPU · {target.memoryGiB} GiB mem · {target.storageGiB} GiB storage
-          </p>
-          {target.apps.length === 0 ? (
-            <div data-testid="showback-no-apps" className="text-sm text-[var(--color-text-dim)]">
-              No applications attributed yet.
-            </div>
-          ) : (
-            <div className="overflow-x-auto rounded-lg border border-[var(--color-border)]">
-              <table data-testid="showback-table" className="w-full border-collapse text-sm">
-                <thead>
-                  <tr className="border-b border-[var(--color-border)] text-left text-[0.7rem] uppercase tracking-wide text-[var(--color-text-dim)]">
-                    <th className="px-3 py-2 font-semibold">Application</th>
-                    <th className="px-3 py-2 font-semibold">Namespace</th>
-                    <th className="px-3 py-2 font-semibold text-right">CPU (m)</th>
-                    <th className="px-3 py-2 font-semibold text-right">Mem (GiB)</th>
-                    <th className="px-3 py-2 font-semibold text-right">Share</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {target.apps.map((a) => (
-                    <tr key={`${a.namespace}/${a.application}`} data-testid={`showback-app-${a.application}`} className="border-b border-[var(--color-border)] last:border-b-0">
-                      <td className="px-3 py-2 text-[var(--color-text-strong)]">{a.application}</td>
-                      <td className="px-3 py-2 font-mono text-xs text-[var(--color-text-dim)]">{a.namespace}</td>
-                      <td className="px-3 py-2 text-right tabular-nums">{a.cpuMilli}</td>
-                      <td className="px-3 py-2 text-right tabular-nums">{a.memoryGiB}</td>
-                      <td className="px-3 py-2 text-right tabular-nums" data-testid={`showback-app-pct-${a.application}`}>{a.percent}%</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
+          {slices.map((o) => (
+            <OrgShowbackSlice key={o.org} target={o} />
+          ))}
         </div>
       )}
     </section>


### PR DESCRIPTION
## UAT row 23 ❌ → fixed
Live on hw224, `/org/consumption` returns correct per-Org attribution (`uatwp4758 = 525.5 units`, its `vcluster` app at 100%, distinct from `sovereign`=0 and `__platform`). But the directory-level Showback panel showed ONLY the parent at "0 units · No applications attributed yet" — the customer-Org row was dropped.

Root cause: `ShowbackPanel` selected a SINGLE `target` org (parent by default when no `org` prop). At the directory + BillingModeGate views (no prop) it only ever rendered the parent.

Fix: no `org` prop → render every `feed.orgs` slice (parent + each customer Org + platform, each labeled distinctly); `org` prop → unchanged single-org detail view. Two tests added: customer-Org row renders in directory view; detail view stays single-org. Existing 3 tests still green.

Verified live: the underlying data (525.5 units for uatwp4758) is real and already served — this is a pure render fix, no backend change.

Refs #4739 #3687

🤖 Generated with [Claude Code](https://claude.com/claude-code)