### PR TITLE
fix(useraccess): cluster-scoped controller alignment so grants materialize — 0 RoleBindings → N (Refs #4773)

### DIFF
--- a/core/controllers/organization/internal/controller/organization_controller.go
+++ b/core/controllers/organization/internal/controller/organization_controller.go
@@ -50,21 +50,22 @@ import (
 	"github.com/openova-io/openova/core/controllers/pkg/gitea"
 )
 
-// userAccessGVR is the namespace-scoped UserAccess CR group/version/kind
+// userAccessGVR is the CLUSTER-scoped UserAccess CR group/version/kind
 // the reconciler writes per Org owner. Defined in
-// platform/crossplane-claims/chart/templates/xrds/useraccess.yaml as
+// platform/crossplane-claims/chart/templates/crds/useraccess.yaml as
 // access.openova.io/v1alpha1.
 //
-// NOTE on scope: Crossplane Claims are namespace-scoped by convention
-// (the underlying XR — XUserAccess — is cluster-scoped, but the *Claim*
-// the controller writes is namespaced). The runtime CRD on a live
-// Sovereign therefore reports `spec.scope: Namespaced`, and a Get/Create
-// without a namespace fails with `an empty namespace may not be set
-// when a resource name is provided`. Reconciler.UserAccessNamespace
-// (env CATALYST_USERACCESS_NAMESPACE, default `catalyst-system`)
-// matches the qa-fixtures convention at
-// products/catalyst/chart/templates/qa-fixtures/useraccess-qa-user1.yaml
-// — the Sovereign-wide namespace where every Sovereign-IAM CR lives.
+// NOTE on scope (Refs #4773): UserAccess is a plain CLUSTER-scoped CRD.
+// The former Crossplane-Claim coupling (which made the Claim namespaced)
+// is gone; more importantly the resource MUST be cluster-scoped because
+// the useraccess-controller materializes RoleBindings into the Org's own
+// namespace (≠ wherever the CR lives) and ClusterRoleBindings for
+// wildcard grants, owning each via an ownerReference — a namespaced
+// owner cannot own a cross-namespace RoleBinding (the GC would delete it)
+// nor a cluster-scoped ClusterRoleBinding (invalid ownerRef). So the CR
+// is written cluster-scoped: NO metadata.namespace, and Get/Create route
+// to the cluster path. This mirrors Organization itself being cluster-
+// scoped so it can own children across namespaces.
 var userAccessGVR = schema.GroupVersionResource{
 	Group:    "access.openova.io",
 	Version:  "v1alpha1",
@@ -948,31 +949,25 @@ func (r *Reconciler) patchStatus(ctx context.Context, org *orgapi.Organization, 
 	return r.Status().Update(ctx, updated)
 }
 
-// upsertUserAccess writes (or updates) a single-grant UserAccess Claim
-// CR scoped to the Organization. The CR shape mirrors
+// upsertUserAccess writes (or updates) a single-grant UserAccess CR
+// scoped to the Organization. The CR shape mirrors
 // platform/crossplane-claims/chart/tests/fixtures/useraccess-sample.yaml.
 //
-// The CR is written into r.UserAccessNamespace (default
-// `catalyst-system`) per the qa-fixtures convention at
-// products/catalyst/chart/templates/qa-fixtures/useraccess-qa-user1.yaml.
-// Crossplane Claims are namespace-scoped on the live API server (the
-// underlying XR is cluster-scoped) — Get/Create without a namespace
-// fails with `an empty namespace may not be set when a resource name is
-// provided`. See organization_controller.go top-of-file note on
-// userAccessGVR for the full rationale.
+// The CR is CLUSTER-scoped (Refs #4773) — no metadata.namespace — because
+// the useraccess-controller materializes the RoleBinding into the Org's
+// own namespace (≠ where the CR lives) and owns it via an ownerReference;
+// a namespaced owner cannot own a cross-namespace RoleBinding (the GC
+// would delete it). See the top-of-file note on userAccessGVR for the
+// full ownerRef rationale.
 //
-// Slice C5 (useraccess-controller) consumes the Claim and materialises
-// the RoleBindings.
+// Slice C5 (useraccess-controller) consumes the CR and materialises the
+// RoleBindings.
 func (r *Reconciler) upsertUserAccess(ctx context.Context, org *orgapi.Organization, owner orgapi.OrganizationOwner) error {
 	// Sanitize the email into a label-safe leaf: "ceo@acme.com" →
 	// "ceo-at-acme-com". Keeps the CR name deterministic + RFC 1123-
 	// compliant.
 	emailLeaf := sanitizeEmail(owner.Email)
 	name := fmt.Sprintf("%s-%s", org.Spec.Slug, emailLeaf)
-	ns := r.UserAccessNamespace
-	if ns == "" {
-		ns = "catalyst-system"
-	}
 
 	// Map Org owner role to UserAccess role. Per the unified design
 	// §6.2 "owner" is the highest tier; the existing XRD uses the
@@ -983,7 +978,7 @@ func (r *Reconciler) upsertUserAccess(ctx context.Context, org *orgapi.Organizat
 	desired := unstructured.Unstructured{}
 	desired.SetGroupVersionKind(userAccessGVK)
 	desired.SetName(name)
-	desired.SetNamespace(ns)
+	// No SetNamespace: UserAccess is cluster-scoped (Refs #4773).
 	desired.SetLabels(map[string]string{
 		"openova.io/organization":      org.Spec.Slug,
 		"openova.io/sovereign":         org.Spec.SovereignRef,
@@ -1023,16 +1018,16 @@ func (r *Reconciler) upsertUserAccess(ctx context.Context, org *orgapi.Organizat
 	// claims/ today).
 	current := unstructured.Unstructured{}
 	current.SetGroupVersionKind(userAccessGVK)
-	if err := r.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, &current); err != nil {
+	if err := r.Get(ctx, client.ObjectKey{Name: name}, &current); err != nil {
 		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("get UserAccess %s/%s: %w", ns, name, err)
+			return fmt.Errorf("get UserAccess %s: %w", name, err)
 		}
 		// Create.
 		if err := r.Create(ctx, &desired); err != nil {
 			if apierrors.IsAlreadyExists(err) {
 				return nil
 			}
-			return fmt.Errorf("create UserAccess %s/%s: %w", ns, name, err)
+			return fmt.Errorf("create UserAccess %s: %w", name, err)
 		}
 		return nil
 	}
@@ -1040,7 +1035,7 @@ func (r *Reconciler) upsertUserAccess(ctx context.Context, org *orgapi.Organizat
 	current.Object["spec"] = desired.Object["spec"]
 	current.SetLabels(desired.GetLabels())
 	if err := r.Update(ctx, &current); err != nil {
-		return fmt.Errorf("update UserAccess %s/%s: %w", ns, name, err)
+		return fmt.Errorf("update UserAccess %s: %w", name, err)
 	}
 	return nil
 }

--- a/core/controllers/organization/internal/controller/organization_controller_test.go
+++ b/core/controllers/organization/internal/controller/organization_controller_test.go
@@ -784,24 +784,20 @@ func TestReconcile_Missing_NoError(t *testing.T) {
 	}
 }
 
-// TestUpsertUserAccess_NamespaceScoped — qa-loop iter-8 Fix #42 regression.
+// TestUpsertUserAccess_ClusterScoped — Refs #4773.
 //
-// The Crossplane Claim CR (`useraccesses.access.openova.io`) is
-// namespace-scoped on the live API server. A previous code path called
-// r.Get / r.Create with `client.ObjectKey{Name: name}` (empty
-// namespace), which the apiserver rejects with `an empty namespace may
-// not be set when a resource name is provided`. That single error
-// blocked the entire downstream chain on omantel — Organization
-// transitioned to Failed/UserAccessFailed, Environment never created
-// the per-Org repo, Application never registered Flux GitRepository,
-// no Pod was ever scheduled.
+// UserAccess flipped from a namespaced Crossplane Claim to a plain
+// CLUSTER-scoped CRD (the useraccess-controller owns cross-namespace
+// RoleBindings + cluster-scoped ClusterRoleBindings via ownerRefs, which
+// a namespaced owner cannot do). The upsert path therefore writes the CR
+// with NO metadata.namespace and Get/Create route to the cluster path.
 //
 // This test asserts:
-//  1. Upsert writes the UserAccess CR into the configured
-//     r.UserAccessNamespace (default `catalyst-system`).
-//  2. The CR carries metadata.namespace == that namespace (NOT empty).
+//  1. Upsert writes the UserAccess CR cluster-scoped (Get with
+//     `client.ObjectKey{Name: name}`, no namespace).
+//  2. The CR carries an EMPTY metadata.namespace.
 //  3. The owner-per-CR mapping holds (1 owner = 1 CR).
-func TestUpsertUserAccess_NamespaceScoped(t *testing.T) {
+func TestUpsertUserAccess_ClusterScoped(t *testing.T) {
 	t.Parallel()
 	org := sampleOrg()
 	r, _, _ := makeReconciler(t, org)
@@ -810,17 +806,16 @@ func TestUpsertUserAccess_NamespaceScoped(t *testing.T) {
 		NamespacedName: types.NamespacedName{Name: "acme"},
 	})
 	if err != nil {
-		t.Fatalf("reconcile failed (regression — empty-namespace bug?): %v", err)
+		t.Fatalf("reconcile failed: %v", err)
 	}
 	// #3687 (fold #3669): the reconcile requeues while the vCluster HR is
 	// still provisioning (no HR/namespace seeded in this fake cluster).
 	// That is correct convergence behavior — the UserAccess writes below
-	// still happen on this pass; this test asserts their namespace, not
-	// the requeue cadence.
+	// still happen on this pass; this test asserts their scope, not the
+	// requeue cadence.
 	_ = res
 
-	// Assert every UserAccess CR carries metadata.namespace =
-	// r.UserAccessNamespace (catalyst-system).
+	// Assert every UserAccess CR is cluster-scoped (empty namespace).
 	uaList := unstructured.UnstructuredList{}
 	uaList.SetGroupVersionKind(schema.GroupVersionKind{
 		Group: "access.openova.io", Version: "v1alpha1", Kind: "UserAccessList",
@@ -832,9 +827,9 @@ func TestUpsertUserAccess_NamespaceScoped(t *testing.T) {
 		t.Fatalf("expected 2 UserAccess CRs (one per owner), got %d", len(uaList.Items))
 	}
 	for _, ua := range uaList.Items {
-		if ua.GetNamespace() != "catalyst-system" {
-			t.Errorf("UserAccess %s: namespace = %q, want %q (the apiserver rejects an empty namespace on namespaced CRs)",
-				ua.GetName(), ua.GetNamespace(), "catalyst-system")
+		if ua.GetNamespace() != "" {
+			t.Errorf("UserAccess %s: namespace = %q, want %q (cluster-scoped CR carries no namespace)",
+				ua.GetName(), ua.GetNamespace(), "")
 		}
 	}
 
@@ -861,20 +856,20 @@ func TestUpsertUserAccess_NamespaceScoped(t *testing.T) {
 	}
 }
 
-// TestUpsertUserAccess_DefaultsToCatalystSystem — when the Reconciler
-// is constructed with UserAccessNamespace=="" (e.g. main.go env var
-// missing), the upsert path must default to "catalyst-system" rather
-// than panic or write into the empty namespace.
-func TestUpsertUserAccess_DefaultsToCatalystSystem(t *testing.T) {
+// TestUpsertUserAccess_ClusterScopedRegardlessOfNamespaceField — Refs
+// #4773. UserAccess is cluster-scoped, so the upsert path writes the CR
+// with NO namespace regardless of the (now-vestigial) UserAccessNamespace
+// field. Setting it must not leak a namespace onto the cluster-scoped CR.
+func TestUpsertUserAccess_ClusterScopedRegardlessOfNamespaceField(t *testing.T) {
 	t.Parallel()
 	org := sampleOrg()
 	r, _, _ := makeReconciler(t, org)
-	r.UserAccessNamespace = "" // simulate unset env var
+	r.UserAccessNamespace = "catalyst-system" // vestigial; must be ignored
 
 	if _, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "acme"},
 	}); err != nil {
-		t.Fatalf("reconcile with empty UserAccessNamespace must default and succeed: %v", err)
+		t.Fatalf("reconcile must succeed: %v", err)
 	}
 	uaList := unstructured.UnstructuredList{}
 	uaList.SetGroupVersionKind(schema.GroupVersionKind{
@@ -884,9 +879,9 @@ func TestUpsertUserAccess_DefaultsToCatalystSystem(t *testing.T) {
 		t.Fatalf("list UserAccess: %v", err)
 	}
 	for _, ua := range uaList.Items {
-		if ua.GetNamespace() != "catalyst-system" {
-			t.Errorf("UserAccess %s: namespace = %q, want default %q",
-				ua.GetName(), ua.GetNamespace(), "catalyst-system")
+		if ua.GetNamespace() != "" {
+			t.Errorf("UserAccess %s: namespace = %q, want %q (cluster-scoped — the UserAccessNamespace field must not leak onto the CR)",
+				ua.GetName(), ua.GetNamespace(), "")
 		}
 	}
 }

--- a/core/controllers/useraccess/internal/controller/reconciler.go
+++ b/core/controllers/useraccess/internal/controller/reconciler.go
@@ -1,9 +1,21 @@
 // reconciler.go — UserAccessReconciler.Reconcile.
 //
+// Scope (Refs #4773): UserAccess is a CLUSTER-scoped CRD. A single grant
+// spans many namespaces and can emit cluster-scoped ClusterRoleBindings,
+// so the CR must be cluster-scoped for the ownerRef-based GC below to be
+// valid — a namespaced owner cannot own a ClusterRoleBinding (invalid
+// ownerRef) nor a RoleBinding in a different namespace (cross-namespace
+// ownerRef → the GC treats the owner as absent and deletes the binding).
+// The Fetch below uses req.NamespacedName, which for a cluster-scoped CR
+// carries an empty namespace; using it (rather than dropping the field)
+// keeps the reconciler correct even if a Request ever arrives carrying a
+// namespace (the historical namespaced-CR / cluster-scoped-Get mismatch
+// that produced 0 RoleBindings on hw224).
+//
 // Steady-state algorithm:
 //
-//   1. Fetch the UserAccess CR (cluster-scoped). Not-found → no-op
-//      (garbage-collected by ownerRef cascade).
+//   1. Fetch the UserAccess CR (cluster-scoped) via req.NamespacedName.
+//      Not-found → no-op (garbage-collected by ownerRef cascade).
 //   2. ParseSpec(). On invalid spec → status.phase=Failed + Condition
 //      Ready=False, Reason=Invalid, Message=<text>. Stop.
 //   3. Build the desired RoleBinding / ClusterRoleBinding set:
@@ -112,7 +124,11 @@ func (r *UserAccessReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	ua := &unstructured.Unstructured{}
 	ua.SetGroupVersionKind(UserAccessGVK())
-	if err := r.Client.Get(ctx, types.NamespacedName{Name: req.Name}, ua); err != nil {
+	// UserAccess is cluster-scoped (Refs #4773) so req.Namespace is empty;
+	// use req.NamespacedName verbatim so the Get honours whatever the
+	// enqueued Request carries (defends against the historical
+	// namespaced-CR mismatch that dropped req.Namespace → 0 bindings).
+	if err := r.Client.Get(ctx, req.NamespacedName, ua); err != nil {
 		if apierrors.IsNotFound(err) {
 			// UserAccess deleted — owner refs garbage-collect bindings.
 			return ctrl.Result{}, nil
@@ -148,7 +164,7 @@ func (r *UserAccessReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		// view.
 		fresh := &unstructured.Unstructured{}
 		fresh.SetGroupVersionKind(UserAccessGVK())
-		if getErr := r.Client.Get(ctx, types.NamespacedName{Name: req.Name}, fresh); getErr == nil {
+		if getErr := r.Client.Get(ctx, req.NamespacedName, fresh); getErr == nil {
 			ua = fresh
 			if reparsed, vmsg2 := ParseSpec(ua); vmsg2 == "" {
 				spec = reparsed

--- a/core/controllers/useraccess/internal/controller/reconciler_test.go
+++ b/core/controllers/useraccess/internal/controller/reconciler_test.go
@@ -448,6 +448,69 @@ func TestReconcile_NotFoundIsNoOp(t *testing.T) {
 	}
 }
 
+// T11 — regression for the hw224 0-RoleBindings bug (Refs #4773).
+//
+// Root cause of the production 0-bindings symptom: the reconcile Request
+// carried a namespace (the CR was a namespaced Crossplane Claim), but the
+// Get dropped it — `r.Client.Get(ctx, types.NamespacedName{Name: req.Name}, ua)`
+// looked up ("", name), got NotFound, and the controller treated EVERY
+// UserAccess as deleted → it never created a single RoleBinding.
+//
+// The fix flips UserAccess to a cluster-scoped CRD (so Requests carry no
+// namespace) AND makes the Get use `req.NamespacedName` verbatim, so the
+// reconciler stays correct even if a Request ever arrives carrying a
+// namespace (e.g. an Owns()-remapped enqueue). This test fires a Request
+// WITH a namespace against a CR stored under that namespace and asserts a
+// RoleBinding is ACTUALLY created — it fails against the pre-fix
+// `{Name: req.Name}` Get (0 bindings) and passes against `req.NamespacedName`.
+func TestReconcile_RequestCarriesNamespace_StillBinds(t *testing.T) {
+	ua := newUA("ns-carried-ua", 1, map[string]any{
+		"user":         map[string]any{"keycloakSubject": "sub-xyz"},
+		"sovereignRef": "omantel",
+		"applications": []any{
+			map[string]any{
+				"app":        "wordpress",
+				"role":       "editor",
+				"namespaces": []any{"acme-prod"},
+			},
+		},
+	})
+	// Store the CR under a namespace, as a namespaced producer would have.
+	ua.SetNamespace("catalyst-system")
+	r, c := newReconciler(t, ua)
+
+	// Fire the Request WITH the namespace — exactly what tripped the old
+	// namespace-dropping Get and produced 0 bindings.
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: "catalyst-system", Name: "ns-carried-ua"},
+	}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	var rbs rbacv1.RoleBindingList
+	if err := c.List(context.Background(), &rbs); err != nil {
+		t.Fatalf("list rbs: %v", err)
+	}
+	if len(rbs.Items) != 1 {
+		t.Fatalf("0-bindings regression (Refs #4773): expected 1 RoleBinding, got %d", len(rbs.Items))
+	}
+	rb := rbs.Items[0]
+	if rb.Namespace != "acme-prod" {
+		t.Fatalf("namespace: got %s want acme-prod", rb.Namespace)
+	}
+	if rb.RoleRef.Name != "openova:application-editor" {
+		t.Fatalf("roleRef: got %s want openova:application-editor", rb.RoleRef.Name)
+	}
+	if len(rb.Subjects) != 1 || rb.Subjects[0].Kind != SubjectKindUser || rb.Subjects[0].Name != "oidc:sub-xyz" {
+		t.Fatalf("subject: %+v", rb.Subjects)
+	}
+	// ownerRef pinned to the UA's UID — the cascade-delete linkage that a
+	// cluster-scoped owner can legally hold over a cross-namespace binding.
+	if len(rb.OwnerReferences) != 1 || rb.OwnerReferences[0].UID != ua.GetUID() {
+		t.Fatalf("ownerRef: %+v", rb.OwnerReferences)
+	}
+}
+
 // asMetaTime is a small helper so the test file doesn't drag a
 // metav1 import for the one place we want to compare timestamps.
 func asMetaTime(t apiextv1.Time) string { return t.Format("2006-01-02T15:04:05Z") }

--- a/platform/crossplane-claims/chart/templates/crds/useraccess.yaml
+++ b/platform/crossplane-claims/chart/templates/crds/useraccess.yaml
@@ -27,12 +27,34 @@
 # no longer part of this path, UserAccess is a PLAIN CRD. Nothing spawns
 # an XUserAccess XR, so the leak cannot recur.
 #
-# Scope: Namespaced — every existing producer writes the CR into the
-# Sovereign-wide `catalyst-system` namespace (organization-controller
-# `upsertUserAccess`, catalyst-api `user_access_owner_seed.go` /
-# `rbac_assign.go` / `user_access.go`, and the qa-fixtures). Keeping the
-# resource namespaced preserves those producers verbatim — the ONLY thing
-# this change removes is the redundant Crossplane XR-spawning layer.
+# Scope: Cluster (Refs #4773 follow-up) — a single UserAccess grant spans
+# MANY namespaces by design and can materialize CLUSTER-scoped bindings:
+#   • the useraccess-controller emits ClusterRoleBinding objects for
+#     wildcard / empty-scope grants (owner-seed, `namespaces: ["*"]`), and
+#   • it emits RoleBinding objects into the target application / org /
+#     env namespaces, which are DIFFERENT from wherever the CR itself
+#     would live (the org-controller writes the CR "centrally" but the
+#     RoleBinding lands in the Org's own namespace).
+# Every materialized binding carries an ownerReference back to this CR so
+# K8s garbage-collects them on delete (no finalizer). Kubernetes ownerRef
+# rules make that IMPOSSIBLE for a namespaced owner:
+#   • a cluster-scoped ClusterRoleBinding may only be owned by a
+#     cluster-scoped owner — a namespaced owner is an unresolvable
+#     ownerRef (OwnerRefInvalidNamespace), the binding is never GC'd, and
+#   • a RoleBinding in namespace M may only reference a namespaced owner
+#     in the SAME namespace M — an ownerRef to a UserAccess in a
+#     different namespace is treated as ABSENT and the GC DELETES the
+#     freshly-created RoleBinding within seconds.
+# So a namespaced UserAccess cannot own its bindings: grants either leak
+# (CRBs) or are immediately garbage-collected (cross-namespace RBs) — the
+# 0-RoleBindings symptom on hw224. A cluster-scoped UserAccess CAN own
+# both (namespaced dependents may name a cluster-scoped owner in ANY
+# namespace, and cluster-scoped dependents may name a cluster-scoped
+# owner) — exactly the reason Organization (the org-controller's own
+# parent CR) is cluster-scoped too. The producers are updated lockstep to
+# stop stamping a namespace (organization-controller `upsertUserAccess`,
+# catalyst-api `user_access_owner_seed.go` / `rbac_assign.go` /
+# `user_access.go`, and the qa-fixtures).
 #
 # The GVK (access.openova.io/v1alpha1, kind UserAccess) and GVR
 # (useraccesses) are UNCHANGED, so the catalyst-useraccess-controller,
@@ -56,7 +78,7 @@ metadata:
     catalyst.openova.io/iam-plane: "true"
 spec:
   group: access.openova.io
-  scope: Namespaced
+  scope: Cluster
   names:
     kind: UserAccess
     listKind: UserAccessList

--- a/products/catalyst/bootstrap/api/cmd/api/main_test.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main_test.go
@@ -69,7 +69,7 @@ func captureLogger() (*slog.Logger, *bytes.Buffer) {
 // TestRunBakeTimeOwnerSeed_SeedsWhenChrootEnvsSet proves the canonical
 // happy path: chroot mode (SOVEREIGN_FQDN set) + OPERATOR_EMAIL set +
 // in-cluster dynamic client present → an owner UserAccess CR is
-// created in catalyst-system within the first attempt.
+// created (cluster-scoped, Refs #4773) within the first attempt.
 func TestRunBakeTimeOwnerSeed_SeedsWhenChrootEnvsSet(t *testing.T) {
 	t.Setenv("SOVEREIGN_FQDN", "omantel.omani.works")
 	t.Setenv("OPERATOR_EMAIL", "emrah.baysal@openova.io")
@@ -79,13 +79,12 @@ func TestRunBakeTimeOwnerSeed_SeedsWhenChrootEnvsSet(t *testing.T) {
 
 	runBakeTimeOwnerSeed(context.Background(), log, client)
 
-	// Assert: a UserAccess CR exists in catalyst-system with the
-	// canonical owner-seed name. We re-use the same lookup path the
-	// handler tests do — the CR shape is covered exhaustively over
-	// there; this test only proves the boot wiring fires.
+	// Assert: a cluster-scoped UserAccess CR exists with the canonical
+	// owner-seed name. We re-use the same lookup path the handler tests
+	// do — the CR shape is covered exhaustively over there; this test
+	// only proves the boot wiring fires.
 	const wantName = "useraccess-owner-emrah-baysal-at-openova-io"
 	got, err := client.Resource(handler.UserAccessGVR()).
-		Namespace("catalyst-system").
 		Get(context.Background(), wantName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("expected owner UserAccess %q after bake-time seed; got err %v", wantName, err)

--- a/products/catalyst/bootstrap/api/internal/handler/rbac_assign.go
+++ b/products/catalyst/bootstrap/api/internal/handler/rbac_assign.go
@@ -165,12 +165,12 @@ type rbacAssignScopeBody struct {
 //
 //  1. Canonical (used by U1 multi-grant editor):
 //     {"user":{"email":"...","keycloakSubject":"..."},
-//      "tier":"developer",
-//      "scope":[{"key":"openova.io/application","value":"qa-wp"}]}
+//     "tier":"developer",
+//     "scope":[{"key":"openova.io/application","value":"qa-wp"}]}
 //
 //  2. Ergonomic top-level (used by CLI / scripts / qa-loop matrix):
 //     {"email":"qa-user1@openova.io","tier":"developer",
-//      "scopeType":"application","scopeName":"qa-wp"}
+//     "scopeType":"application","scopeName":"qa-wp"}
 //
 // The handler normalizes shape (2) into shape (1) before validation
 // + find-or-create. The top-level Email + KeycloakSubject collapse
@@ -668,29 +668,21 @@ const rbacAssignMaxRetries = 2
 
 // rbacAssignNamespace — namespace for UserAccess CRs.
 //
-// CRITICAL: useraccesses.access.openova.io is a Crossplane Claim
-// (claimNames in platform/crossplane-claims/chart/templates/xrds/
-// useraccess.yaml). Crossplane Claims are NAMESPACED by construction —
-// only the underlying XR (xuseraccesses) is cluster-scoped. The earlier
-// `const rbacAssignNamespace = ""` comment was wrong (mistook the
-// composition family for "cluster-scoped"). With an empty namespace,
-// the dynamic client routes Create to the apiserver's cluster-wide
-// path /apis/access.openova.io/v1alpha1/useraccesses, which is NOT
-// registered for a namespaced resource — the apiserver returns 404
-// with "the server could not find the requested resource". That's the
-// C6-006 / TBD-C6-006-followup symptom on t22 cov-bench: POST
-// /api/v1/sovereign/rbac/assign 500'd despite PR #1789's
-// CRD-NotFound→503 wrapper, because the IsNotFound branch never fired
-// (the 404 was for the route, not the resource — same wire shape, but
-// it's the namespace-stripping that fooled the apiserver into 404'ing).
+// EMPTY, and it must stay empty: useraccesses.access.openova.io is a
+// plain CLUSTER-scoped CRD (Refs #4773 — the former Crossplane-Claim
+// coupling is gone). It MUST be cluster-scoped because the
+// useraccess-controller materializes RoleBindings into the target
+// application/org/env namespaces and ClusterRoleBindings for
+// wildcard/empty-scope grants, owning each via an ownerReference — a
+// namespaced owner can own NEITHER a cross-namespace RoleBinding (the GC
+// deletes it) NOR a cluster-scoped ClusterRoleBinding (invalid ownerRef).
 //
-// Fix: stamp catalyst-system on every Create + use it on the Resource
-// client, mirroring user_access_owner_seed.go's t134 D21 fix
-// (userAccessOwnerNamespace = "catalyst-system"). The List path keeps
-// Namespace("") for cross-namespace listing (that IS valid against a
-// namespaced CRD — the apiserver routes /apis/<g>/<v>/<r> as
-// list-all-namespaces and returns the union).
-const rbacAssignNamespace = "catalyst-system"
+// Because the value is "", `obj.SetNamespace(rbacAssignNamespace)`
+// removes the namespace field (apimachinery SetNamespace("") deletes it)
+// and `client.Resource(gvr).Namespace(rbacAssignNamespace)` routes to the
+// cluster-scoped REST path /apis/access.openova.io/v1alpha1/useraccesses,
+// which is exactly what a cluster-scoped CRD serves.
+const rbacAssignNamespace = ""
 
 // rbacAssignFindOrCreate runs the 3-path logic:
 //
@@ -824,14 +816,14 @@ func rbacAssignCreate(
 	obj.SetAPIVersion(userAccessGroup + "/" + userAccessVersion)
 	obj.SetKind("UserAccess")
 	obj.SetName(name)
-	// Pin the namespace on the object so the apiserver routes the
-	// Create to the namespaced REST path (see rbacAssignNamespace doc
-	// for the t22 cov-bench symptom this fixes). Mirrors the
-	// owner-seed pattern in user_access_owner_seed.go.
+	// UserAccess is CLUSTER-scoped (Refs #4773): rbacAssignNamespace is
+	// "" so this removes any namespace field and the Create below routes
+	// to the cluster REST path. Kept as an explicit call so the intent
+	// (no namespace) is obvious next to SetName.
 	obj.SetNamespace(rbacAssignNamespace)
 	obj.SetLabels(map[string]string{
-		labelTier:                          wantTier,
-		"catalyst.openova.io/managed-by":   "rbac-assign",
+		labelTier:                        wantTier,
+		"catalyst.openova.io/managed-by": "rbac-assign",
 	})
 
 	user := map[string]any{}
@@ -892,17 +884,9 @@ func rbacAssignUpdateTier(
 		tierClusterRolePrefix+wantTier,
 		"spec", "tierRoleRef",
 	)
-	// Update uses the CR's own namespace (rbacAssignNamespace for new
-	// CRs we created; the apiserver also returns the canonical ns on
-	// every List item). Empty namespace would route to the cluster-
-	// scoped REST path which the apiserver doesn't serve for a
-	// namespaced CRD (404 "the server could not find the requested
-	// resource") — see rbacAssignNamespace doc.
-	ns := desired.GetNamespace()
-	if ns == "" {
-		ns = rbacAssignNamespace
-	}
-	return client.Resource(UserAccessGVR()).Namespace(ns).Update(ctx, desired, metav1.UpdateOptions{})
+	// UserAccess is CLUSTER-scoped (Refs #4773) — Update routes to the
+	// cluster REST path. The CR carries no namespace.
+	return client.Resource(UserAccessGVR()).Update(ctx, desired, metav1.UpdateOptions{})
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────

--- a/products/catalyst/bootstrap/api/internal/handler/rbac_assign_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/rbac_assign_test.go
@@ -601,15 +601,14 @@ func TestHandleRBACAssign_RejectsUnknownTierWith400(t *testing.T) {
 	}
 }
 
-// TestHandleRBACAssign_CreateStampsNamespace pins the rbacAssignNamespace
-// fix for TBD-C6-006-followup. The UserAccess Claim is namespaced (XRD
-// claimNames per platform/crossplane-claims/chart/templates/xrds/
-// useraccess.yaml); creating with an empty namespace routes to the
-// cluster-scoped REST path which the apiserver doesn't serve, returning
-// 404 "the server could not find the requested resource". The fix
-// stamps catalyst-system on every Create — this test asserts the stamp
-// is on the wire.
-func TestHandleRBACAssign_CreateStampsNamespace(t *testing.T) {
+// TestHandleRBACAssign_CreateIsClusterScoped pins the cluster-scoped
+// Create for UserAccess (Refs #4773). UserAccess is a plain CLUSTER-scoped
+// CRD — the Create must route to the cluster REST path (empty action
+// namespace) and the object must carry NO metadata.namespace, so the
+// useraccess-controller can own its cross-namespace RoleBindings +
+// ClusterRoleBindings via ownerRefs. This test asserts both are empty on
+// the wire — the inverse of the old namespaced-Claim assertion.
+func TestHandleRBACAssign_CreateIsClusterScoped(t *testing.T) {
 	h := NewWithPDM(silentLogger(), &fakePDM{})
 	factory, client := fakeUserAccessDynamicFactory()
 	h.dynamicFactory = factory
@@ -641,14 +640,14 @@ func TestHandleRBACAssign_CreateStampsNamespace(t *testing.T) {
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("status: got %d want 201; body=%s", rec.Code, rec.Body.String())
 	}
-	if got, want := createdNs.Load(), rbacAssignNamespace; got != want {
-		t.Errorf("Create action namespace: got %q want %q (regression: empty NS routes to cluster-scoped REST path, apiserver 404s — C6-006-followup symptom)", got, want)
+	if got := createdNs.Load(); got != "" {
+		t.Errorf("Create action namespace: got %q want \"\" (UserAccess is cluster-scoped — Create must route to the cluster REST path, Refs #4773)", got)
 	}
-	if got, want := objNs.Load(), rbacAssignNamespace; got != want {
-		t.Errorf("object metadata.namespace: got %q want %q (must be stamped on the unstructured so kubectl get -n <ns> finds it)", got, want)
+	if got := objNs.Load(); got != "" {
+		t.Errorf("object metadata.namespace: got %q want \"\" (cluster-scoped CR carries no namespace)", got)
 	}
-	if rbacAssignNamespace == "" {
-		t.Fatal("rbacAssignNamespace must be non-empty — UserAccess is a namespaced Crossplane Claim")
+	if rbacAssignNamespace != "" {
+		t.Fatal("rbacAssignNamespace must be empty — UserAccess is a cluster-scoped CRD (Refs #4773)")
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/user_access.go
+++ b/products/catalyst/bootstrap/api/internal/handler/user_access.go
@@ -130,10 +130,10 @@ type userAccessAppGrantBody struct {
 }
 
 type userAccessItem struct {
-	Name              string                  `json:"name"`
-	Spec              userAccessSpecBody      `json:"spec"`
-	Status            *userAccessStatusBody   `json:"status,omitempty"`
-	CreationTimestamp string                  `json:"creationTimestamp,omitempty"`
+	Name              string                `json:"name"`
+	Spec              userAccessSpecBody    `json:"spec"`
+	Status            *userAccessStatusBody `json:"status,omitempty"`
+	CreationTimestamp string                `json:"creationTimestamp,omitempty"`
 }
 
 type userAccessStatusBody struct {
@@ -202,14 +202,9 @@ func (h *Handler) serveUserAccessList(w http.ResponseWriter, r *http.Request, de
 		writeUserAccessUnavailable(w, err)
 		return
 	}
-	// UserAccess Claims are NAMESPACED per the XRD's claimNames block
-	// (Crossplane Claims are namespaced by construction — only the
-	// underlying XR xuseraccesses is cluster-scoped). Listing with
-	// Namespace("") asks the apiserver for all-namespaces and works
-	// against a namespaced CRD; metadata.namespace is preserved on
-	// every item for any caller that wants to filter. Refs t134 D21
-	// fix in user_access_owner_seed.go + TBD-C6-006-followup.
-	listIface, err := client.Resource(UserAccessGVR()).Namespace("").List(r.Context(), metav1.ListOptions{})
+	// UserAccess is a CLUSTER-scoped CRD (Refs #4773) — List routes to
+	// the cluster-scoped REST path and returns every CR on the Sovereign.
+	listIface, err := client.Resource(UserAccessGVR()).List(r.Context(), metav1.ListOptions{})
 	if err != nil {
 		// CRD not installed → return empty list, not 500. The
 		// access.openova.io UserAccess CRD ships via a separate
@@ -257,16 +252,12 @@ func (h *Handler) CreateUserAccess(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	obj := userAccessToUnstructured(body)
-	// Stamp the canonical namespace on the Claim — Crossplane Claims
-	// are namespaced; an empty namespace routes to the cluster-scoped
-	// REST path which the apiserver doesn't serve for a namespaced
-	// CRD (404 "the server could not find the requested resource").
-	// Mirrors rbacAssignNamespace + userAccessOwnerNamespace.
-	// Refs TBD-C6-006-followup.
-	if obj.GetNamespace() == "" {
-		obj.SetNamespace(rbacAssignNamespace)
-	}
-	created, err := client.Resource(UserAccessGVR()).Namespace(obj.GetNamespace()).Create(r.Context(), obj, metav1.CreateOptions{})
+	// UserAccess is a CLUSTER-scoped CRD (Refs #4773) — no namespace on
+	// the object, and Create routes to the cluster-scoped REST path. A
+	// cluster-scoped owner is REQUIRED for the useraccess-controller to
+	// own its cross-namespace RoleBindings + ClusterRoleBindings via
+	// ownerRefs (a namespaced owner cannot).
+	created, err := client.Resource(UserAccessGVR()).Create(r.Context(), obj, metav1.CreateOptions{})
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			writeJSON(w, http.StatusConflict, map[string]string{
@@ -317,11 +308,8 @@ func (h *Handler) UpdateUserAccess(w http.ResponseWriter, r *http.Request) {
 		writeUserAccessUnavailable(w, err)
 		return
 	}
-	// Find the existing Claim across all namespaces. UserAccess Claims
-	// are namespaced; we walk the all-namespaces list to discover the
-	// canonical namespace before issuing the Update against that exact
-	// REST path. Refs TBD-C6-006-followup.
-	current, currentNs, err := findUserAccessByName(r.Context(), client, name)
+	// Find the existing CR (cluster-scoped, Refs #4773).
+	current, _, err := findUserAccessByName(r.Context(), client, name)
 	if err != nil {
 		if errors.Is(err, errUserAccessNotFound) {
 			writeJSON(w, http.StatusNotFound, map[string]string{
@@ -339,8 +327,9 @@ func (h *Handler) UpdateUserAccess(w http.ResponseWriter, r *http.Request) {
 	desired := userAccessToUnstructured(body)
 	desired.SetResourceVersion(current.GetResourceVersion())
 	desired.SetUID(current.GetUID())
-	desired.SetNamespace(currentNs)
-	updated, err := client.Resource(UserAccessGVR()).Namespace(currentNs).Update(r.Context(), desired, metav1.UpdateOptions{})
+	// No namespace — UserAccess is cluster-scoped; Update routes to the
+	// cluster REST path.
+	updated, err := client.Resource(UserAccessGVR()).Update(r.Context(), desired, metav1.UpdateOptions{})
 	if err != nil {
 		if apierrors.IsConflict(err) {
 			writeJSON(w, http.StatusConflict, map[string]string{
@@ -398,19 +387,14 @@ func (h *Handler) DeleteUserAccess(w http.ResponseWriter, r *http.Request) {
 
 var errUserAccessNotFound = errors.New("user-access: not found")
 
-// findUserAccessByName walks the all-namespaces list and returns the
-// first UserAccess Claim whose metadata.name matches. Returns the
-// CR + its namespace, or errUserAccessNotFound on miss. Used by
-// UpdateUserAccess and tryDeleteUserAccess to discover the canonical
-// namespace before issuing a per-namespace REST call.
-//
-// UserAccess Claims are namespaced; an empty-namespace Get/Update/
-// Delete routes to the cluster-scoped REST path which the apiserver
-// returns 404 for ("the server could not find the requested
-// resource"). Walk the list once to discover the namespace, then
-// route the mutation to the canonical path. Refs TBD-C6-006-followup.
+// findUserAccessByName lists the cluster-scoped UserAccess CRs and
+// returns the first whose metadata.name matches. Returns the CR + its
+// namespace (empty — the resource is cluster-scoped, Refs #4773), or
+// errUserAccessNotFound on miss. A List by name (rather than a direct
+// Get) is retained so callers get the full object + resourceVersion in
+// one round trip.
 func findUserAccessByName(ctx context.Context, client dynamic.Interface, name string) (*unstructured.Unstructured, string, error) {
-	listIface, err := client.Resource(UserAccessGVR()).Namespace("").List(ctx, metav1.ListOptions{})
+	listIface, err := client.Resource(UserAccessGVR()).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, "", errUserAccessNotFound
@@ -426,20 +410,16 @@ func findUserAccessByName(ctx context.Context, client dynamic.Interface, name st
 	return nil, "", errUserAccessNotFound
 }
 
-// tryDeleteUserAccess deletes the named namespaced Claim. Walks the
-// all-namespaces list to discover the canonical namespace before
-// issuing the Delete (UserAccess Claims are namespaced per the XRD
-// claimNames block — an empty-namespace Delete routes to the
-// cluster-scoped REST path which the apiserver doesn't serve for a
-// namespaced CRD). Returns errUserAccessNotFound on miss so the
-// caller can map onto HTTP 404. Refs TBD-C6-006-followup.
+// tryDeleteUserAccess deletes the named cluster-scoped UserAccess CR
+// (Refs #4773). Returns errUserAccessNotFound on miss so the caller can
+// map onto HTTP 404. Deleting the CR cascades the useraccess-controller's
+// materialized RoleBindings / ClusterRoleBindings via ownerRef GC.
 func tryDeleteUserAccess(ctx context.Context, client dynamic.Interface, name string) error {
-	_, ns, err := findUserAccessByName(ctx, client, name)
-	if err != nil {
+	if _, _, err := findUserAccessByName(ctx, client, name); err != nil {
 		return err
 	}
 	policy := metav1.DeletePropagationForeground
-	err = client.Resource(UserAccessGVR()).Namespace(ns).Delete(ctx, name, metav1.DeleteOptions{
+	err := client.Resource(UserAccessGVR()).Delete(ctx, name, metav1.DeleteOptions{
 		PropagationPolicy: &policy,
 	})
 	if err != nil {

--- a/products/catalyst/bootstrap/api/internal/handler/user_access_owner_seed.go
+++ b/products/catalyst/bootstrap/api/internal/handler/user_access_owner_seed.go
@@ -75,15 +75,14 @@ const userAccessOwnerEmailAnnotation = "catalyst.openova.io/user-email"
 // limit (the apiserver rejects longer names with a 422).
 const userAccessOwnerNamePrefix = "useraccess-owner-"
 
-// userAccessOwnerNamespace is the namespace the auto-seeded owner CR
-// lives in. useraccesses.access.openova.io is a NAMESPACED Crossplane
-// Claim per platform/crossplane-claims/chart/templates/xrds/useraccess.yaml
-// (`claimNames` block). catalyst-system is canonical — every other
-// Catalyst-authored CR lives there too, and the listing/admin handler
-// at user_access.go::ListUserAccess uses `Namespace("")` which surfaces
-// CRs from every namespace, so the operator entry surfaces on /users
-// without per-namespace filtering. Caught on t134 2026-05-17.
-const userAccessOwnerNamespace = "catalyst-system"
+// userAccessOwnerNamespace — EMPTY. useraccesses.access.openova.io is a
+// plain CLUSTER-scoped CRD (Refs #4773). The owner CR carries no
+// namespace; SetNamespace("") removes the field and the Create routes to
+// the cluster REST path. Cluster scope is REQUIRED here: the owner CR
+// grants openova:tier-owner with empty scopes → the useraccess-controller
+// emits a cluster-scoped ClusterRoleBinding, which only a cluster-scoped
+// owner may own via an ownerRef.
+const userAccessOwnerNamespace = ""
 
 // EnsureOwnerUserAccess creates an owner-tier UserAccess CR for the
 // operator who just completed PIN-login + handover, if one does not
@@ -124,14 +123,12 @@ func EnsureOwnerUserAccess(ctx context.Context, client dynamic.Interface, email,
 	sovRef := rbacAssignSlug(sovereignFQDN)
 
 	obj := buildOwnerUserAccessUnstructured(name, email, sovRef)
-	// D21 fix on t134 2026-05-17: the prior Namespace("") call returned
-	// "the server could not find the requested resource" because
-	// useraccesses.access.openova.io is NAMESPACED (Claim semantics per
-	// the XRD's claimNames block). Pin to catalyst-system + stamp the
-	// namespace on the CR object so the apiserver routes the Create.
+	// UserAccess is CLUSTER-scoped (Refs #4773): userAccessOwnerNamespace
+	// is "" so this removes any namespace field and the Create routes to
+	// the cluster REST path — required so the owner-tier ClusterRoleBinding
+	// the controller emits can be owned by this CR via an ownerRef.
 	obj.SetNamespace(userAccessOwnerNamespace)
 	_, err := client.Resource(UserAccessGVR()).
-		Namespace(userAccessOwnerNamespace).
 		Create(ctx, obj, metav1.CreateOptions{})
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {

--- a/products/catalyst/bootstrap/api/internal/k8scache/kinds.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/kinds.go
@@ -190,8 +190,11 @@ var DefaultKinds = []Kind{
 	// platform-health view + the components page both consume this.
 	{Name: "helmrelease", GVR: schema.GroupVersionResource{Group: "helm.toolkit.fluxcd.io", Version: "v2", Resource: "helmreleases"}, Namespaced: true},
 	// access.openova.io/v1alpha1 UserAccess — RBAC binding CRD
-	// surfaced on the /users page.
-	{Name: "useraccess", GVR: schema.GroupVersionResource{Group: "access.openova.io", Version: "v1alpha1", Resource: "useraccesses"}, Namespaced: true},
+	// surfaced on the /users page. CLUSTER-scoped (Refs #4773): a single
+	// grant spans many namespaces and can emit ClusterRoleBindings, so
+	// the CR carries no namespace and the generic /k8s/{kind} + informer
+	// paths must treat it cluster-scoped.
+	{Name: "useraccess", GVR: schema.GroupVersionResource{Group: "access.openova.io", Version: "v1alpha1", Resource: "useraccesses"}, Namespaced: false},
 	// apps.openova.io/v1 Application — workload CRD owning the
 	// `/apps` and AppDetail pages (EPIC-2 slice T+O+P).
 	//

--- a/products/catalyst/chart/CRDS.md
+++ b/products/catalyst/chart/CRDS.md
@@ -30,7 +30,7 @@ controller-runtime.source.EventHandler   if kind is a CRD, it should be installe
 ## UserAccess (out-of-tree CRD)
 
 `useraccesses.access.openova.io` is **not** in this chart — it is a
-plain namespaced CustomResourceDefinition shipped from
+plain **cluster-scoped** CustomResourceDefinition shipped from
 `platform/crossplane-claims/chart/templates/crds/useraccess.yaml`.
 
 As of Refs #4773 it is **no longer** a Crossplane XRD/Claim: the old
@@ -40,6 +40,15 @@ Composition was retired by default) — an unbounded leak. The XRD +
 Composition are removed; the `catalyst-useraccess-controller`
 reconciles the plain CRD directly into RoleBinding / ClusterRoleBinding
 objects (no Crossplane, no provider-kubernetes).
+
+The CRD is **cluster-scoped** (not namespaced): a single UserAccess
+grant spans many namespaces and can emit cluster-scoped
+ClusterRoleBindings, each owned by the CR via an ownerReference — a
+namespaced owner could own neither a cross-namespace RoleBinding (the
+GC deletes it) nor a ClusterRoleBinding (invalid ownerRef), which was
+the 0-RoleBindings symptom. The producers (organization-controller,
+catalyst-api `rbac/assign` + owner-seed + admin CRUD, qa-fixtures)
+write the CR with no namespace.
 
 A Sovereign that runs `catalyst-useraccess-controller` therefore
 requires both this catalyst chart **and** the `crossplane-claims`

--- a/products/catalyst/chart/templates/qa-fixtures/useraccess-qa-test-tiers.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/useraccess-qa-test-tiers.yaml
@@ -19,7 +19,10 @@ render → no synthetic users in the cluster.
 
 Per qa-omantel naming conventions (see useraccess-qa-user1.yaml):
 - spec.sovereignRef MUST be the single-label form (TLD/SLD stripped).
-- All CRs land in catalyst-system (cluster-scoped logical principals).
+- UserAccess is a CLUSTER-scoped CRD (Refs #4773) — the CRs carry no
+  namespace (cluster-scoped logical principals); the useraccess-controller
+  owns the RoleBindings/ClusterRoleBindings it materializes across the
+  target namespaces via cluster-scoped ownerRefs.
 - Scopes mirror qa-user1 so the test users live in the same env-type/app
   space the matrix's resource fixtures (qa-omantel ns, qa-wp app) use.
 */ -}}
@@ -37,8 +40,9 @@ admission-rejection class of chart-roll wedges.
 apiVersion: access.openova.io/v1alpha1
 kind: UserAccess
 metadata:
+  # UserAccess is a CLUSTER-scoped CRD (Refs #4773) — no namespace here;
+  # the apiserver rejects a namespace on a cluster-scoped object.
   name: qa-test-{{ $tier }}
-  namespace: catalyst-system
   labels:
     catalyst.openova.io/managed-by: qa-fixtures
     catalyst.openova.io/tier: {{ $tier }}

--- a/products/catalyst/chart/templates/qa-fixtures/useraccess-qa-user1.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/useraccess-qa-user1.yaml
@@ -10,8 +10,9 @@ reconcile pass once the XRD is live will render and apply the CR.
 apiVersion: access.openova.io/v1alpha1
 kind: UserAccess
 metadata:
+  # UserAccess is a CLUSTER-scoped CRD (Refs #4773) — no namespace here;
+  # the apiserver rejects a namespace on a cluster-scoped object.
   name: qa-user1
-  namespace: catalyst-system
   labels:
     catalyst.openova.io/managed-by: qa-fixtures
     catalyst.openova.io/tier: developer


### PR DESCRIPTION
## Problem — UserAccess grants have NEVER materialized (0 RoleBindings)

On hw224, `kubectl get rolebindings,clusterrolebindings -A` filtered for
useraccess/application-role ownership returns **ZERO**. UserAccess grants
have never worked. Root cause is a **scope mismatch**:

- **Producers write the CRs; the controller reconciles them; both must
  agree on scope.** PR #4776 (stop the XUserAccess leak) made the CRD a
  plain **namespaced** resource. But the useraccess-controller's grant
  logic fundamentally requires **cluster** scope, and its `Get` reads the
  CR cluster-scoped (`types.NamespacedName{Name: req.Name}` — no
  namespace). On a namespaced CR the reconcile Request carries a
  namespace, the Get dropped it, looked in the empty namespace →
  `NotFound` → every UserAccess looked deleted → **the controller never
  created a single binding.**

## Direction chosen — CLUSTER-scoped (not "make the namespaced Get compile")

The brief allowed either direction; the correct one is dictated by what
`desired.go` / `tier_bindings.go` actually emit:

1. **`desired.go` `desiredClusterRoleBindings` + `tier_bindings.go`
   wildcard path emit cluster-scoped ClusterRoleBindings.** The
   owner-seed (`EnsureOwnerUserAccess`) grants `openova:tier-owner` with
   empty scopes → a **ClusterRoleBinding**. A cluster-scoped
   ClusterRoleBinding may only be owned by a **cluster-scoped** owner; a
   namespaced owner is an unresolvable ownerRef (`OwnerRefInvalidNamespace`)
   and is never GC'd.
2. **`desired.go` `desiredRoleBindings` + `tier_bindings.go`
   `resolveScopesToNamespaces` emit RoleBindings into the target
   application/org/env namespaces — DIFFERENT from where the CR lives.**
   The org-controller writes the CR "centrally" but the RoleBinding lands
   in the Org's OWN namespace (`applications[].namespaces=[org.Spec.Slug]`).
   Every binding carries an ownerReference back to the CR for GC. A
   RoleBinding in namespace `M` may only reference a namespaced owner in
   the **same** namespace `M`; an ownerRef to a UserAccess in a different
   namespace is treated as **absent** and the GC **deletes the
   freshly-created RoleBinding within seconds**.

So a **namespaced** UserAccess cannot own its bindings — grants either
flicker-delete (cross-namespace RBs) or leak (CRBs). A **cluster-scoped**
UserAccess can own **both** (a namespaced dependent may name a
cluster-scoped owner in ANY namespace; a cluster-scoped dependent may name
a cluster-scoped owner). This is exactly why **Organization** — the
org-controller's own parent CR — is cluster-scoped so it can own children
across namespaces.

"Just making the namespaced Get compile" would have left the 0-bindings
bug intact in a new form (bindings created then GC-deleted). The
cluster-scoped direction is what the grant logic needs.

### Binding-namespace vs owner-namespace analysis

A namespaced UserAccess in namespace `N` can own only RoleBindings in
namespace `N` — never a ClusterRoleBinding, never a RoleBinding in `M≠N`.
Because this design needs both, the owner **must** be cluster-scoped;
then ownerRef GC works for every binding and **no label-based finalizer
GC is needed** (the existing ownerRef cascade in `desired.go`/`reconciler.go`
stays valid).

## Changes (lockstep)

- **CRD** `platform/crossplane-claims/chart/templates/crds/useraccess.yaml`:
  `scope: Namespaced → Cluster` + rationale.
- **`reconciler.go`**: `Get` uses `req.NamespacedName` (empty ns for a
  cluster-scoped CR; robust if a Request ever carries a namespace — the
  historical mismatch). Same for the `fresh` re-Get.
  - before: `r.Client.Get(ctx, types.NamespacedName{Name: req.Name}, ua)`
  - after:  `r.Client.Get(ctx, req.NamespacedName, ua)`
- **Producers stop stamping a namespace:**
  - org-controller `upsertUserAccess`: drop `SetNamespace`, Get with
    `client.ObjectKey{Name: name}`.
  - catalyst-api `rbac_assign.go` (`rbacAssignNamespace=""`),
    `user_access_owner_seed.go` (`userAccessOwnerNamespace=""`),
    `user_access.go` Create/Update/Delete/List route cluster-scoped.
  - `k8scache/kinds.go`: useraccess `Namespaced:false` so the generic
    `/k8s/{kind}` + informer paths treat it cluster-scoped.
  - qa-fixtures `useraccess-qa-user1.yaml` / `-test-tiers.yaml`: drop
    `namespace: catalyst-system` (a cluster-scoped CR rejects a namespace).
- **Tests** flipped to assert cluster scope, plus a new reconciler
  regression **`TestReconcile_RequestCarriesNamespace_StillBinds`** that
  fires a Request carrying a namespace against a namespaced-stored CR and
  asserts a RoleBinding is **actually created** with the right ClusterRole
  + subject + ownerRef — the test that would have caught the 0-bindings
  bug (fails on the old `{Name: req.Name}` Get, passes on `req.NamespacedName`).

## Gates

- `cd core/controllers && go build ./... && go test ./...` — green.
- `cd products/catalyst/bootstrap/api && go build/test/vet ./...` — green.
- gofmt clean. No banned terms (docs/GLOSSARY.md).
- The useraccess-controller / organization-controller / catalyst-api
  images **auto-bump their `values.yaml` tags on merge-to-main** via their
  respective build workflows (`useraccess-controller-build.yaml`,
  `build-organization-controller.yaml`, `catalyst-build.yaml`) — the pins
  update lockstep so a fresh prov runs the fixed producers + controller.
  (Per Principle #4a, GitHub Actions is the only build path — no manual
  SHA pin.) The fresh prov must fire **after** those auto-bump commits land.

`Refs #4773` (not `Closes` — the issue closes on an operator-walk with a
non-empty `kubectl get rolebindings,clusterrolebindings` proof).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
