### PR TITLE
fix(crossplane): cloudadoption Workspace GVK -> opentofu.upbound.io — unblocks adoption Ready (Refs #4739)

### DIFF
--- a/clusters/_template/bootstrap-kit/14-crossplane-claims.yaml
+++ b/clusters/_template/bootstrap-kit/14-crossplane-claims.yaml
@@ -70,7 +70,7 @@ spec:
       # is replaced by a plain namespaced CRD reconciled by the
       # catalyst-useraccess-controller. Removes the retired legacy
       # Composition + the `userAccess.compositionEnabled` toggle.
-      version: 1.3.0
+      version: 1.3.1
       sourceRef:
         kind: HelmRepository
         name: bp-crossplane-claims

--- a/platform/crossplane-claims/blueprint.yaml
+++ b/platform/crossplane-claims/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-2-gitops-and-iac
 spec:
-  version: 1.3.0
+  version: 1.3.1
   card:
     title: crossplane-claims
     summary: |

--- a/platform/crossplane-claims/chart/Chart.yaml
+++ b/platform/crossplane-claims/chart/Chart.yaml
@@ -22,7 +22,8 @@ name: bp-crossplane-claims
 # starved the shared Crossplane reconcile queue and held crossplane-adoption
 # CloudAdoption CRs at Ready=False. The `userAccess.compositionEnabled`
 # value is removed (no Composition remains to enable).
-version: 1.3.0
+# 1.3.1 (#4739): cloudadoption Composition Workspace GVK tf.upbound.io -> opentofu.upbound.io (matches the installed provider-opentofu; tf.upbound.io is the terraform provider group, unregistered here). Fixes CloudAdoption never-Ready + empty `kubectl get managed` (UAT 206/207/239).
+version: 1.3.1
 description: |
   Catalyst Crossplane XRDs + Compositions Blueprint. Carries ONLY the
   apiextensions.crossplane.io/v1 CompositeResourceDefinition and

--- a/platform/crossplane-claims/chart/templates/compositions/cloudadoption.yaml
+++ b/platform/crossplane-claims/chart/templates/compositions/cloudadoption.yaml
@@ -38,7 +38,7 @@ spec:
   resources:
     - name: adoption-workspace
       base:
-        apiVersion: tf.upbound.io/v1beta1
+        apiVersion: opentofu.upbound.io/v1beta1
         kind: Workspace
         metadata:
           # external-name is patched to the real resource id below; it is


### PR DESCRIPTION
Live on hw224, every XCloudAdoption is stuck: 'no matches for kind Workspace in version tf.upbound.io/v1beta1'. tf.upbound.io is the upbound *terraform* provider group; hw224 runs **provider-opentofu**, which registers Workspace at **opentofu.upbound.io/v1beta1** (verified: kubectl get crds → workspaces.opentofu.upbound.io). The Composition pointed at the wrong group → composite never composes → CloudAdoption never Ready → kubectl get managed empty → UAT rows 206/207/239 ❌. Fix points the composed Workspace at the provider's real group. bp-crossplane-claims 1.3.0→1.3.1 + blueprint + slot-pin lockstep. helm render: zero tf.upbound.io refs remain.

Refs #4739 #4620

🤖 Generated with [Claude Code](https://claude.com/claude-code)