### PR TITLE
fix(org-controller): per-Org vcluster CNP bootstrap deadlock (rows 90/224/226)

### DIFF
--- a/core/controllers/organization/internal/gitops/manifests.go
+++ b/core/controllers/organization/internal/gitops/manifests.go
@@ -507,6 +507,28 @@ spec:
         - ingress
         - host
         - remote-node
+    # SAME-ORG (same-namespace) intra-Org allow. WITHOUT this the vcluster's own
+    # synced coredns (host ns pod) is denied reaching the vcluster apiserver pod
+    # (vcluster-0 :8443 — a regular pod, NOT the reserved kube-apiserver entity),
+    # so coredns never becomes ready and the vcluster never functions. The #4475
+    # host-apps move left the same-Org-allow baseline stranded in the
+    # vcluster/apps/ tree, which can ONLY apply AFTER the vcluster is functional →
+    # chicken-and-egg deadlock (proven live hw225: coredns 0/1 forever, no app
+    # ever deploys). endpointSelector {} default-denies every ns pod, so the
+    # same-Org allow MUST be host-side + unconditional here. Same-namespace only
+    # ⇒ cross-Org / cross-Environment denial is preserved.
+    - fromEndpoints:
+        - {}
+    # PLATFORM GITOPS reach: the flux kustomize-controller (flux-system) applies
+    # the Org's day-2 apps INTO the vcluster + mints the tenant-<slug>-kubeconfig
+    # secret — it must reach the vcluster apiserver pod :8443. Cross-namespace, so
+    # neither fromEntities nor the same-Org fromEndpoints covers it (proven live:
+    # flux 10.42.x → vcluster-0:8443 tcp SYN dropped "Policy denied" → apps
+    # Kustomization wedged "kubeConfig secret not found" forever). Scoped to the
+    # trusted flux-system ns only.
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: flux-system
   egress:
     # Admit egress to the cluster API (the reserved kube-apiserver entity) so an
     # in-vcluster Org app pod / in-cluster client can reach :443/:6443.
@@ -518,6 +540,11 @@ spec:
               protocol: TCP
             - port: "6443"
               protocol: TCP
+    # SAME-ORG egress: coredns / app pods → the vcluster apiserver pod + each
+    # other. Same-namespace only ⇒ no cross-Org weakening. Completes the bootstrap
+    # path that the vcluster-gated baseline could never deliver in time.
+    - toEndpoints:
+        - {}
 `
 
 // networkPolicyDoc is the apps-tree filename for the default-deny +

--- a/core/controllers/organization/internal/gitops/manifests_test.go
+++ b/core/controllers/organization/internal/gitops/manifests_test.go
@@ -349,6 +349,14 @@ func TestRender_CiliumNetworkPolicyReservedEntities(t *testing.T) {
 			`port: "443"`,
 			`port: "6443"`,
 			"openova.io/organization: acme",
+			// vcluster bootstrap-deadlock fix (proven live hw225): the same-Org
+			// (same-ns) allow lets the synced coredns reach vcluster-0:8443, and
+			// the flux-system allow lets the kustomize-controller mint the
+			// kubeconfig + apply apps. Without BOTH, the vcluster never functions
+			// and no customer app ever deploys.
+			"fromEndpoints:",
+			"k8s:io.kubernetes.pod.namespace: flux-system",
+			"toEndpoints:",
 		} {
 			if !strings.Contains(s, want) {
 				t.Errorf("plan %s ciliumnetworkpolicy.yaml missing %q\n%s", slug, want, s)


### PR DESCRIPTION
Fixes the per-Org vcluster CNP deadlock root-caused + PROVEN live on hw225. Adds same-Org (same-ns) + flux-system allow to the host-side `allow-gateway-and-apiserver` CNP so the vcluster's coredns + the flux kustomize-controller can reach `vcluster-0:8443` — breaking the chicken-and-egg that left coredns 0/1 forever + no app deploying. Live-patch proof: coredns 0/1→1/1, apps Kustomization wedged→Progressing. Test extended to lock both allows. Refs #4785 #4739 #4475