### PR TITLE
fix(cilium): clustermesh-proxy — cross-region ClusterMesh dies because CP-EIP :2379 lands on k3s etcd, not cilium (Refs #4784 #4656)

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -141,7 +141,7 @@ spec:
       # 1370 → 1420 (WG-only). Layers on the 1.4.9/1.4.10 zero-nodeport +
       # authMode=legacy work. Cross-region ClusterMesh pod path needs a fresh
       # 2-region prov to verify (datapath change). Refs #4656.
-      version: 1.4.11
+      version: 1.4.12
       sourceRef:
         kind: HelmRepository
         name: bp-cilium
@@ -319,6 +319,19 @@ spec:
         enabled: ${CILIUM_LB_IPAM_ENABLED:=false}
         cidrs:
           - ${CILIUM_LB_IPAM_CIDRS:=0.0.0.0/32}
+
+      # #4784 — clustermesh-proxy: hostNetwork TCP-passthrough shim so
+      # cross-region peers reach the clustermesh-apiserver etcd on a DEDICATED
+      # non-2379 host port. REQUIRED on no-CCM Huawei: the shared Sovereign
+      # EIP is the CP-node IP (1:1 NAT) AND the CP node runs k3s' own etcd on
+      # host :2379 → <EIP>:2379 lands on k3s etcd, never Cilium's
+      # clustermesh-apiserver (proven live hw225, #4784). hostPort MUST equal
+      # catalyst-api CLUSTERMESH_APISERVER_DIAL_PORT + infra
+      # clustermesh_proxy_port (SG rule). Hetzner leaves it disabled
+      # (hcloud-ccm LB IP has no k3s-etcd host collision → canonical :2379).
+      clustermeshProxy:
+        enabled: ${CILIUM_CLUSTERMESH_PROXY_ENABLED:=false}
+        hostPort: ${CILIUM_CLUSTERMESH_PROXY_PORT:=12379}
 
       # ── Cilium ClusterMesh — multi-region peering ──────────────────
       #

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1559,6 +1559,14 @@ spec:
     # browser-trusted Sovereign reaches cutoverComplete with ZERO manual steps.
     catalystApi:
       fireCutoverOnHandover: ${FIRE_CUTOVER_ON_HANDOVER:-false}
+      # #4784 — the etcd port catalyst-api dials for a peer's
+      # clustermesh-apiserver (CLUSTERMESH_APISERVER_DIAL_PORT env →
+      # clustermesh.go clusterMeshDialPort). Default 2379 (Hetzner hcloud-ccm
+      # path). no-CCM Huawei cloud-init sets CLUSTERMESH_APISERVER_DIAL_PORT to
+      # the bp-cilium clustermesh-proxy hostPort (dodges the CP-node k3s-etcd
+      # :2379 host collision — proven live hw225). MUST equal
+      # cilium.clustermeshProxy.hostPort + infra clustermesh_proxy_port.
+      clusterMeshDialPort: "${CLUSTERMESH_APISERVER_DIAL_PORT:-2379}"
     # ─── Sovereign-side region seeding (DoD D5) ─────────────────────
     # regionsJson — JSON-array literal of the canonical multi-region
     # RegionSpec[] this Sovereign was provisioned with. Threaded

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -830,6 +830,22 @@ write_files:
             # gateway_member_port_*). Left UNSET on Hetzner (hcloud-ccm path).
             CILIUM_LB_IPAM_ENABLED: "true"
             CILIUM_LB_IPAM_CIDRS: "${node_external_ip_value}/32"
+            # #4784 — clustermesh-proxy: the shared Sovereign EIP is the
+            # CP-node IP (1:1 NAT) AND the CP node runs k3s' own etcd on host
+            # :2379, so a peer dialing <EIP>:2379 lands on k3s etcd, not the
+            # Cilium clustermesh-apiserver (proven live hw225, #4784). Enable
+            # the bp-cilium clustermesh-proxy DaemonSet (hostNetwork socket on
+            # a dedicated non-2379 port → TCP-passthrough to the
+            # clustermesh-apiserver etcd) and point peers at it. The port MUST
+            # match infra/providers/huawei clustermesh_proxy_port (SG rule) +
+            # the catalyst-api CLUSTERMESH_APISERVER_DIAL_PORT env. Left UNSET
+            # on Hetzner (hcloud-ccm LB IP has no k3s-etcd host collision).
+            CILIUM_CLUSTERMESH_PROXY_ENABLED: "true"
+            CILIUM_CLUSTERMESH_PROXY_PORT: "${clustermesh_proxy_port}"
+            # catalyst-api dials peers on this port instead of 2379 (#4784).
+            # Consumed by the catalyst-api Deployment env (products/catalyst
+            # chart) — see clustermesh.go clusterMeshDialPort().
+            CLUSTERMESH_APISERVER_DIAL_PORT: "${clustermesh_proxy_port}"
             # #4706 — lockstep w/ the cilium-values hostNetwork block above.
             CILIUM_GATEWAY_HOSTNETWORK_ENABLED: "true"
             # #4706 — console gateway binds 8443/8080 under hostNetwork (two

--- a/infra/providers/_shared/tests/render.tf
+++ b/infra/providers/_shared/tests/render.tf
@@ -71,6 +71,7 @@ locals {
     node_ip_cmd                       = "echo 10.0.1.2"
     node_external_ip_cmd              = "echo 203.0.113.10"
     node_external_ip_value            = "203.0.113.10"
+    clustermesh_proxy_port            = 12379
     k3s_extra_args                    = ""
     registry_mirror_yaml              = "mirrors: {}"
     catalyst_api_url                  = "https://console.example.test"

--- a/infra/providers/hetzner/main.tf
+++ b/infra/providers/hetzner/main.tf
@@ -963,6 +963,7 @@ locals {
     pdns_api_host          = ""
     sovereign_region_role  = "primary"
     node_external_ip_value = ""
+    clustermesh_proxy_port = 12379 # #4784 — inert on Hetzner (clustermesh-proxy off; hcloud-ccm LB IP has no k3s-etcd :2379 host collision)
 
     # ── Provider-injected strings (the §5 hard-dependency exceptions) ──
     registry_mirror_yaml          = local.registry_mirror_yaml_hetzner
@@ -1506,6 +1507,7 @@ locals {
       pdns_api_host          = ""
       sovereign_region_role  = "secondary"
       node_external_ip_value = ""
+      clustermesh_proxy_port = 12379 # #4784 — inert on Hetzner (clustermesh-proxy off)
 
       # ── Provider-injected strings (the §5 hard-dependency exceptions) ──
       registry_mirror_yaml     = local.registry_mirror_yaml_hetzner

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -358,6 +358,27 @@ resource "huaweicloud_networking_secgroup_rule" "ingress_clustermesh_2379" {
   description      = "Cilium clustermesh-apiserver VIP dial :2379 (mTLS-protected; #4765 — replaces the forbidden NodePort range)"
 }
 
+# #4784 — clustermesh-proxy host-socket dial port. On no-CCM Huawei the shared
+# Sovereign EIP is the CP-node IP, a 1:1 NAT whose host :2379 is ALREADY bound
+# by k3s' own embedded etcd — so peers dialing <EIP>:2379 hit k3s etcd, never
+# the Cilium clustermesh-apiserver (proven live hw225, #4784). The bp-cilium
+# clustermesh-proxy DaemonSet binds a hostNetwork socket on this dedicated
+# non-2379 port and TCP-passthroughs to the clustermesh-apiserver etcd;
+# catalyst-api points peers here via CLUSTERMESH_APISERVER_DIAL_PORT. This is
+# a hostNetwork bind, NOT a NodePort (the port is well outside the forbidden
+# 30000-32767 range). etcd mTLS remains the security boundary.
+resource "huaweicloud_networking_secgroup_rule" "ingress_clustermesh_proxy" {
+  for_each          = { for r in var.regions : r.code => r }
+  security_group_id = huaweicloud_networking_secgroup.region[each.key].id
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = var.clustermesh_proxy_port
+  port_range_max    = var.clustermesh_proxy_port
+  remote_ip_prefix  = "0.0.0.0/0"
+  description       = "Cilium clustermesh-proxy host-socket dial (mTLS-protected; #4784 — non-2379 to dodge the CP-node k3s-etcd host collision)"
+}
+
 resource "huaweicloud_networking_secgroup_rule" "ingress_icmp" {
   for_each          = { for r in var.regions : r.code => r }
   security_group_id = huaweicloud_networking_secgroup.region[each.key].id
@@ -1102,6 +1123,11 @@ locals {
       # region's tofu-known CP EIP (printf, NOT curl). Hard dependency (plan §5).
       node_external_ip_cmd   = "printf '%s' '${huaweicloud_vpc_eip.cp[r.code].publicip.0.ip_address}'"
       node_external_ip_value = huaweicloud_vpc_eip.cp[r.code].publicip.0.ip_address
+      # #4784 — clustermesh-proxy host-socket dial port (non-2379; dodges the
+      # CP-node k3s-etcd :2379 collision). Drives CILIUM_CLUSTERMESH_PROXY_PORT
+      # + CLUSTERMESH_APISERVER_DIAL_PORT; matches the ingress_clustermesh_proxy
+      # SG rule + the bp-cilium clustermeshProxy.hostPort value.
+      clustermesh_proxy_port = var.clustermesh_proxy_port
       # node PRIVATE IP — HCS DHCP is non-deterministic (Wave 5.29 #2163:
       # cidrhost(subnet,2) is wrong), so detect the real eth0 address at
       # runtime. Used for k3s --node-ip + cilium k8sServiceHost substitution.

--- a/infra/providers/huawei/variables.tf
+++ b/infra/providers/huawei/variables.tf
@@ -638,3 +638,21 @@ variable "gateway_member_port_http" {
     error_message = "gateway_member_port_http must be a host port below the k8s NodePort range (30000-32767) — nodePorts are forbidden (§854)."
   }
 }
+
+# #4784 — clustermesh-proxy host-socket dial port. The bp-cilium
+# clustermesh-proxy DaemonSet (hostNetwork) binds this port on every node and
+# TCP-passthroughs to the clustermesh-apiserver etcd; catalyst-api points
+# cross-region peers here via CLUSTERMESH_APISERVER_DIAL_PORT. MUST NOT be
+# 2379/2380 (k3s' own embedded etcd on the CP-node host) nor in the forbidden
+# 30000-32767 NodePort range. Default 12379 (proven free on hw225 kom4dc CP
+# nodes). MUST equal the chart value cilium.clustermeshProxy.hostPort AND the
+# catalyst-api CLUSTERMESH_APISERVER_DIAL_PORT env.
+variable "clustermesh_proxy_port" {
+  type        = number
+  description = "Cilium clustermesh-proxy host-socket dial port (non-2379, host bind; NOT a NodePort). Peers dial <CP-EIP>:<this> → hostNetwork socat → clustermesh-apiserver etcd. Dodges the CP-node k3s-etcd :2379 collision (#4784)."
+  default     = 12379
+  validation {
+    condition     = var.clustermesh_proxy_port >= 1 && var.clustermesh_proxy_port <= 32767 && !(var.clustermesh_proxy_port >= 30000) && var.clustermesh_proxy_port != 2379 && var.clustermesh_proxy_port != 2380
+    error_message = "clustermesh_proxy_port must be a host port below the k8s NodePort range (30000-32767; §854) and NOT 2379/2380 (k3s embedded etcd on the CP-node host)."
+  }
+}

--- a/platform/cilium/blueprint.yaml
+++ b/platform/cilium/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 1.4.11
+  version: 1.4.12
   card:
     title: Cilium
     summary: Unified CNI + Service Mesh (eBPF). mTLS via WireGuard, Hubble observability, Gateway API.

--- a/platform/cilium/chart/Chart.yaml
+++ b/platform/cilium/chart/Chart.yaml
@@ -1,5 +1,31 @@
 apiVersion: v2
 name: bp-cilium
+# 1.4.12 (#4784, 2026-07-05): clustermesh-proxy — fix cross-region ClusterMesh
+# on no-CCM Huawei. #4765 had peers dial the clustermesh-apiserver VIP on the
+# shared Sovereign EIP :2379, but that EIP IS the CP-node IP: a Huawei 1:1 NAT
+# whose host :2379 is bound by k3s' OWN embedded etcd. So an off-cluster peer
+# dialing <EIP>:2379 is DNAT'd to <CP-private>:2379 and answered by K3S ETCD
+# (CN=etcd-server, k3s CA) — NEVER by Cilium's clustermesh-apiserver
+# (CN=clustermesh-apiserver.cilium.io, Cilium CA). The peer's etcd client
+# hangs → 0 remote clusters ready → cross-region global-service backend sync
+# dead → CNPG shared-pg replicas can't bootstrap. PROVEN LIVE hw225 with
+# openssl: <EIP>:2379 → etcd-server cert (Verify 19); the SAME mesh certs
+# against a host-socket on a NON-2379 port → clustermesh-apiserver.cilium.io
+# (Verify 0), mesh flips 0/1 → 1/1 ready, 13 region-A backends sync. FIX
+# (mirrors the gateway's proven host-socket model): a hostNetwork
+# clustermesh-proxy DaemonSet (templates/clustermesh-proxy-daemonset.yaml,
+# gated cilium.clustermeshProxy.enabled) binds a dedicated non-2379 host port
+# and TCP-passthroughs to the clustermesh-apiserver etcd; catalyst-api points
+# peers at it via CLUSTERMESH_APISERVER_DIAL_PORT (clustermesh.go). NOT a
+# NodePort — a hostNetwork bind (§854-clean, same as the gateway envoy).
+# Lockstep: blueprint.yaml 1.4.12 + 01-cilium.yaml slot pin 1.4.12 + catalog-
+# seed + values-clustermesh.yaml clustermeshProxy + infra/providers/huawei
+# (clustermesh_proxy_port var + ingress_clustermesh_proxy SG rule) +
+# cloudinit-control-plane.tftpl (CILIUM_CLUSTERMESH_PROXY_* +
+# CLUSTERMESH_APISERVER_DIAL_PORT) + products/catalyst chart (catalystApi.
+# clusterMeshDialPort → api-deployment env) + catalyst-api image rebuild.
+# DRAFT: needs a fresh 2-region Huawei prov cross-region walk (datapath
+# activation) to flip 1/1 ready on a clean prov. Refs #4784 #4656.
 # 1.4.9 (#4765, 2026-07-05): ZERO NODEPORTS. Merge the two overlapping
 # CiliumLoadBalancerIPPool templates (clustermesh-apiserver + sovereign-
 # gateway, both claiming the SAME CP-node /32 → the second pool went
@@ -235,7 +261,7 @@ name: bp-cilium
 #   Layers ON TOP of the 1.4.9/1.4.10 zero-nodeport + authMode=legacy work.
 #   Needs a fresh 2-region prov to verify the cross-region ClusterMesh pod
 #   path end-to-end (datapath change, not CI-provable). Refs #4656.
-version: 1.4.11
+version: 1.4.12
 description: |
   Catalyst-curated Blueprint umbrella chart for Cilium. Depends on the
   upstream `cilium` chart as a Helm subchart so `helm dependency build`

--- a/platform/cilium/chart/templates/clustermesh-proxy-daemonset.yaml
+++ b/platform/cilium/chart/templates/clustermesh-proxy-daemonset.yaml
@@ -1,0 +1,115 @@
+{{/*
+#4784 — clustermesh-proxy: a hostNetwork TCP-passthrough shim that makes the
+Cilium clustermesh-apiserver etcd reachable by cross-region peers on a
+DEDICATED non-2379 host port on the no-CCM Huawei 1:1-NAT'd EIP.
+
+ROOT CAUSE this template fixes (proven LIVE on hw225, dep 26df2f30b065e857):
+  #4765 gave the clustermesh-apiserver Service a real VIP on the shared
+  Sovereign EIP (the CP-node public IPv4) and had peers dial <EIP>:2379. But
+  on no-CCM Huawei that EIP is a Huawei-fabric 1:1 NAT to the CP node's
+  PRIVATE IP, AND the CP node runs k3s' OWN embedded etcd bound on the host
+  :2379. So an off-cluster peer dialing <EIP>:2379 is DNAT'd to
+  <CP-private>:2379 and is answered by K3S ETCD (a dst-IP-agnostic host
+  socket; server cert CN=etcd-server, k3s CA) — NEVER by Cilium's LB-VIP
+  datapath (keyed on the public EIP, which never sees the post-NAT packet).
+  The peer's etcd client presents a Cilium-CA client cert that k3s etcd
+  rejects and receives a k3s server cert the peer does not trust → the etcd
+  session never establishes → "context canceled" / heartbeat-watcher timeout
+  → 0 remote clusters ready → cross-region global-service backend sync dead
+  → CNPG shared-pg replicas cannot bootstrap.
+
+  openssl from region-B (issue #4784): <EIP>:2379 → CN=etcd-server (Verify
+  19); the SAME mesh certs against a host-socket on a NON-2379 port →
+  CN=clustermesh-apiserver.cilium.io (Cilium CA, Verify 0).
+
+THE FIX (mirrors the gateway's proven no-CCM-Huawei host-socket model):
+  Bind a hostNetwork socket on a dedicated non-2379 port and TCP-passthrough
+  (L4, TLS/mTLS preserved end-to-end) to the in-cluster clustermesh-apiserver
+  Service. Off-cluster <EIP>:<proxyPort> → post-NAT <CP-private>:<proxyPort>
+  → this host socket → clustermesh-apiserver etcd (real Cilium cert). k3s
+  etcd on :2379 is untouched. catalyst-api points peers at <proxyPort> via
+  CLUSTERMESH_APISERVER_DIAL_PORT (clustermesh.go). This is NOT a NodePort —
+  it is a hostNetwork bind, the same §854-clean mechanism the Sovereign
+  gateway uses (cilium-envoy hostNetwork node:443/:80).
+
+OPERATOR GATE (per docs/PRINCIPLES.md #4 — the chart never auto-enables):
+  Enabled per-provider via the HelmRelease overlay substitute
+  CILIUM_CLUSTERMESH_PROXY_ENABLED (true on no-CCM Huawei, unset/false on
+  Hetzner where hcloud-ccm materialises a real cloud LB whose IP has NO
+  k3s-etcd host collision, so the canonical :2379 dial stays correct).
+
+  The proxy hostPort MUST equal CLUSTERMESH_APISERVER_DIAL_PORT (catalyst-api)
+  AND be opened in the Sovereign security group (infra/providers/huawei
+  ingress_clustermesh_proxy). Default 12379 (proven free of k3s' etcd
+  2379/2380/2382 + the kubelet/supervisor ports on hw225 kom4dc CP nodes;
+  well outside the forbidden 30000-32767 NodePort range).
+*/}}
+{{- $cm := dig "clustermeshProxy" (dict) (.Values.cilium | default dict) }}
+{{- if $cm.enabled }}
+{{- $port := (int (default 12379 $cm.hostPort)) }}
+{{- $image := (default "alpine/socat:1.8.0.0" $cm.image) }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: clustermesh-proxy
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: bp-cilium
+    app.kubernetes.io/component: clustermesh-proxy
+    k8s-app: clustermesh-proxy
+    catalyst.openova.io/blueprint: bp-cilium
+    catalyst.openova.io/blueprint-version: {{ .Chart.Version | quote }}
+spec:
+  selector:
+    matchLabels:
+      k8s-app: clustermesh-proxy
+  template:
+    metadata:
+      labels:
+        k8s-app: clustermesh-proxy
+        app.kubernetes.io/name: bp-cilium
+        app.kubernetes.io/component: clustermesh-proxy
+    spec:
+      # hostNetwork + cluster DNS so socat binds the NODE's :<port> directly
+      # (post-NAT EIP ingress lands on it) and can still resolve the
+      # clustermesh-apiserver ClusterIP via cluster DNS.
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      priorityClassName: system-node-critical
+      # Run on EVERY node (incl. the CP node that owns the shared EIP). The
+      # CP-node instance is the one that receives the post-NAT EIP ingress;
+      # the others make the internal (VPC-peered) node-IP:<port> dial work too.
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: socat
+          image: {{ $image | quote }}
+          # L4 TCP passthrough — the clustermesh-apiserver's own TLS/mTLS is
+          # terminated by etcd, NOT here, so the peer validates the real
+          # CN=clustermesh-apiserver.cilium.io cert end-to-end.
+          args:
+            - "-d"
+            - "TCP-LISTEN:{{ $port }},fork,reuseaddr"
+            - "TCP:clustermesh-apiserver.kube-system.svc.cluster.local:2379"
+          ports:
+            - name: cm-etcd
+              containerPort: {{ $port }}
+              hostPort: {{ $port }}
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: false
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              memory: 64Mi
+          readinessProbe:
+            tcpSocket:
+              port: {{ $port }}
+            initialDelaySeconds: 3
+            periodSeconds: 10
+{{- end }}

--- a/platform/cilium/chart/values-clustermesh.yaml
+++ b/platform/cilium/chart/values-clustermesh.yaml
@@ -44,6 +44,22 @@ cilium:
     enabled: false
     cidrs: []
 
+  # #4784 — clustermesh-proxy: hostNetwork TCP-passthrough shim so
+  # cross-region peers reach the clustermesh-apiserver etcd on a DEDICATED
+  # non-2379 host port (templates/clustermesh-proxy-daemonset.yaml). REQUIRED
+  # on no-CCM Huawei: the shared Sovereign EIP is the CP-node IP, which is a
+  # 1:1 NAT AND runs k3s' own etcd on host :2379 — so <EIP>:2379 lands on
+  # k3s etcd, not Cilium's clustermesh-apiserver (proven live hw225, #4784).
+  # hostPort MUST equal catalyst-api's CLUSTERMESH_APISERVER_DIAL_PORT and be
+  # opened in the Sovereign SG (infra ingress_clustermesh_proxy). Disabled by
+  # default (Hetzner hcloud-ccm LB IP has no k3s-etcd host collision → the
+  # canonical :2379 dial stays correct). no-CCM Huawei cloudinit flips
+  # CILIUM_CLUSTERMESH_PROXY_ENABLED=true.
+  clustermeshProxy:
+    enabled: false
+    hostPort: 12379
+    image: alpine/socat:1.8.0.0
+
   # Per-Sovereign anchors — ALWAYS overridden by the Sovereign's
   # bootstrap-kit overlay. The empty-string + zero defaults here are
   # intentionally invalid — Cilium chart fails-fast at install time when

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -102,6 +102,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -166,7 +167,23 @@ const (
 	clusterMeshCASecretName     = "cilium-ca"
 	clusterMeshApiserverService = "clustermesh-apiserver"
 	clusterMeshNamespace        = "kube-system"
+	// clusterMeshAPIServerPort — the DEFAULT etcd port a peer dials
+	// (2379). Overridable at runtime via CLUSTERMESH_APISERVER_DIAL_PORT
+	// (see clusterMeshDialPort). On no-CCM Huawei the CP-node public EIP is
+	// a Huawei-fabric 1:1 NAT AND the CP node runs k3s' own embedded etcd on
+	// the host :2379 — so an off-cluster peer dialing <CP-EIP>:2379 is
+	// DNAT'd to <CP-private-IP>:2379 and lands on K3S ETCD (server cert
+	// CN=etcd-server, k3s CA), NEVER the Cilium clustermesh-apiserver
+	// (CN=clustermesh-apiserver.cilium.io, Cilium CA). The peer's etcd
+	// client then hangs on "Connecting to etcd server…" → "context
+	// canceled" → heartbeat-watcher timeout (issue #4784, proven live on
+	// hw225 with openssl: <EIP>:2379 → etcd-server cert; a host-socket on a
+	// NON-2379 port → clustermesh-apiserver.cilium.io cert, Verify OK). The
+	// durable fix routes peers to the clustermesh-proxy host-socket on a
+	// dedicated non-2379 port (bp-cilium clustermesh-proxy DaemonSet) via
+	// this override; Hetzner keeps the default 2379 behind hcloud-ccm.
 	clusterMeshAPIServerPort    = 2379
+	clusterMeshDialPortEnvVar   = "CLUSTERMESH_APISERVER_DIAL_PORT"
 	clusterMeshLBLookupTimeout  = 5 * time.Minute
 	clusterMeshLBLookupInterval = 10 * time.Second
 	clusterMeshCallTimeout      = 30 * time.Second
@@ -2290,6 +2307,23 @@ func regionKeyFromSpec(rs provisioner.RegionSpec, idx int) string {
 // type MUST be LoadBalancer; a typed-mismatch is a hard failure rather
 // than retried. A missing ingress after the timeout is likewise a hard
 // failure — the slot never silently falls back to a NodePort.
+// clusterMeshDialPort returns the etcd port a peer dials for the
+// clustermesh-apiserver endpoint. Default is clusterMeshAPIServerPort
+// (2379, the canonical Hetzner-hcloud-ccm path). On no-CCM Huawei the
+// cloud-init/deploy sets CLUSTERMESH_APISERVER_DIAL_PORT to the
+// clustermesh-proxy host-socket port (a dedicated non-2379 port that does
+// NOT collide with k3s' embedded etcd on the CP-node host :2379) — see
+// clusterMeshAPIServerPort's doc + issue #4784. A NodePort value here is
+// still forbidden; the proxy binds a hostNetwork socket, not a NodePort.
+func clusterMeshDialPort() int {
+	if v := strings.TrimSpace(os.Getenv(clusterMeshDialPortEnvVar)); v != "" {
+		if p, err := strconv.Atoi(v); err == nil && p > 0 && p <= 65535 {
+			return p
+		}
+	}
+	return clusterMeshAPIServerPort
+}
+
 func (h *Handler) waitForClusterMeshLB(ctx context.Context, client kubernetes.Interface) (string, int, error) {
 	timeout := clusterMeshLBLookupTimeout
 	if clusterMeshTestOverrideLBTimeout > 0 {
@@ -2332,16 +2366,30 @@ func (h *Handler) waitForClusterMeshLB(ctx context.Context, client kubernetes.In
 				continue
 			}
 			// #4765 (founder 2026-07-03, "FUCK THE NODEPORTS!!!") — peers
-			// ALWAYS dial the clustermesh VIP on :2379. NodePort is
-			// ABSOLUTELY FORBIDDEN. The single sovereign-vip LB-IPAM pool
-			// (bp-cilium 1.4.9) gives this Service a real VIP — no
-			// Conflicting=True, no starved ingress — so 2379 is served by
-			// Cilium's kube-proxy-replacement LB frontend on the ingress IP
-			// (reached over the WG-encrypted node path on the no-CCM Huawei
-			// 1:1-NAT'd EIP). There is NO node-owned-EIP NodePort fallback:
-			// if the VIP is unreachable the etcd connect step surfaces it
-			// with full peer context rather than silently dialing a NodePort.
-			return ip, clusterMeshAPIServerPort, nil
+			// dial the clustermesh endpoint on clusterMeshDialPort(); a
+			// NodePort is ABSOLUTELY FORBIDDEN and there is no node-owned-EIP
+			// NodePort fallback (if the endpoint is unreachable the etcd
+			// connect step surfaces it with full peer context).
+			//
+			// #4784 CORRECTION (proven live on hw225): the pre-#4784 belief
+			// that ":2379 is served by Cilium's LB frontend on the ingress
+			// IP, reached over the WG node path on the no-CCM Huawei
+			// 1:1-NAT'd EIP" is FALSE. The ingress IP IS the CP node's public
+			// EIP, the EIP is a 1:1 NAT to the CP node's PRIVATE IP, and the
+			// CP node runs k3s' OWN embedded etcd on the host :2379 — so the
+			// post-NAT packet (dst=<CP-private>:2379) is answered by k3s etcd
+			// (host socket, dst-IP-agnostic), never by Cilium's LB-VIP
+			// datapath (which is keyed on the public EIP and never sees the
+			// post-NAT packet). openssl from region-B: <EIP>:2379 →
+			// CN=etcd-server (k3s CA, Verify 19); the SAME certs against a
+			// host-socket on a NON-2379 port → CN=clustermesh-apiserver.
+			// cilium.io (Cilium CA, Verify 0). The durable fix therefore
+			// serves the clustermesh etcd on a dedicated non-2379 host socket
+			// (clustermesh-proxy DaemonSet) and points peers at it via
+			// CLUSTERMESH_APISERVER_DIAL_PORT — still NO NodePort. Hetzner
+			// keeps the default 2379 (hcloud-ccm real LB, no k3s-etcd host
+			// collision on the LB IP).
+			return ip, clusterMeshDialPort(), nil
 		}
 		if time.Now().After(deadline) {
 			return "", 0, fmt.Errorf("Service %s/%s has no LoadBalancer ingress after %s",

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -486,6 +486,17 @@ spec:
               # post-G92.2 nats-jetstream runs INSIDE the mgmt vCluster
               # and the host's `nats-system` namespace no longer exists.
               value: '{{ .Values.catalystApi.natsURL | default "nats://nats-jetstream.nats-system.svc.cluster.local:4222" }}'
+            # CLUSTERMESH_APISERVER_DIAL_PORT — #4784. The etcd port a peer
+            # dials for the clustermesh-apiserver endpoint (clustermesh.go
+            # clusterMeshDialPort). Default 2379 (Hetzner hcloud-ccm LB IP —
+            # no k3s-etcd host collision). On no-CCM Huawei the CP-node EIP is
+            # a 1:1 NAT whose host :2379 is bound by k3s' OWN etcd, so peers
+            # dialing <EIP>:2379 hit k3s etcd, not Cilium (proven live hw225);
+            # the catalyst bootstrap-kit slot sets catalystApi.clusterMeshDialPort
+            # to the clustermesh-proxy hostPort (matches
+            # cilium.clustermeshProxy.hostPort + infra clustermesh_proxy_port).
+            - name: CLUSTERMESH_APISERVER_DIAL_PORT
+              value: '{{ .Values.catalystApi.clusterMeshDialPort | default "2379" }}'
             # CATALYST_K8SCACHE_KUBECONFIGS_DIR — issue #321. Directory
             # the k8scache.Factory reads kubeconfigs from at startup.
             # The data-plane SharedInformerFactory opens one informer

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -3768,7 +3768,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.4.7"
+  version: "1.4.12"
   visibility: unlisted
   card:
     title: "Cilium"
@@ -3785,7 +3785,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-cilium
-    version: "1.4.9"
+    version: "1.4.12"
   topology:
     supported:
       - singleton

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -1323,6 +1323,13 @@ catalystApi:
   # (uncommon; the bp-nats-jetstream Blueprint deploys an in-cluster
   # broker by default).
   natsURL: ""
+  # #4784 — the etcd port catalyst-api dials for a peer's clustermesh-apiserver
+  # endpoint (CLUSTERMESH_APISERVER_DIAL_PORT). Empty → clustermesh.go defaults
+  # to 2379 (canonical Hetzner hcloud-ccm path). no-CCM Huawei sets this to the
+  # bp-cilium clustermesh-proxy hostPort (dodges the CP-node k3s-etcd :2379
+  # host collision — proven live hw225). MUST equal cilium.clustermeshProxy.
+  # hostPort + infra clustermesh_proxy_port. A NodePort value is forbidden.
+  clusterMeshDialPort: ""
   # Whether the child catalyst-api auto-fires the self-sovereignty cutover
   # engine the instant the mothership completes handover (#4061). Wires
   # CATALYST_FIRE_CUTOVER_ON_HANDOVER on Sovereign installs only (gated on

--- a/scripts/cloudinit-size-check.sh
+++ b/scripts/cloudinit-size-check.sh
@@ -150,6 +150,11 @@ fixture_cp_common() {
     pdns_api_host                     = "pdns.openova.io"
     sovereign_region_role             = "primary"
     node_external_ip_value            = "203.0.113.10"
+    # #4784 — clustermesh-proxy host port. The real templatefile() maps in
+    # infra/providers/*/main.tf supply this on every control-plane surface
+    # (primary + secondary-region); keep the size-check fixture in lockstep
+    # or tofu errors "vars map does not contain key clustermesh_proxy_port".
+    clustermesh_proxy_port            = 12379
 HCL
 }
 

--- a/scripts/lint-cloudinit.sh
+++ b/scripts/lint-cloudinit.sh
@@ -134,6 +134,11 @@ fixture_common() {
     pdns_api_host                     = "pdns.openova.io"
     sovereign_region_role             = "primary"
     node_external_ip_value            = "203.0.113.10"
+    # #4784 — clustermesh-proxy host port (below k8s NodePort range, not
+    # 2379/2380). The real templatefile() maps in infra/providers/*/main.tf
+    # supply this; keep the lint fixture in lockstep or tofu errors
+    # "vars map does not contain key clustermesh_proxy_port".
+    clustermesh_proxy_port            = 12379
 HCL
 }
 


### PR DESCRIPTION
## Root cause — PROVEN LIVE on hw225 (dep `26df2f30b065e857`, 2-region kom4dc, native-routing)

#4765 made cross-region ClusterMesh peers dial the clustermesh-apiserver VIP on the shared Sovereign EIP `:2379`, believing it is *"served by Cilium's LB frontend on the ingress IP, reached over the WG node path on the no-CCM Huawei 1:1-NAT'd EIP."* **hw225 disproves that.**

That EIP **is the CP node's own public IP** (only CP nodes get an EIP). It is a Huawei-fabric **1:1 NAT** to the CP node's private IP, and the CP node runs **k3s' OWN embedded etcd bound on the host `:2379`**. So an off-cluster peer dialing `<EIP>:2379` is DNAT'd to `<CP-private>:2379` and is answered by **k3s etcd** (a dst-IP-agnostic host socket) — **never** by Cilium's LB-VIP datapath (keyed on the public EIP, which never sees the post-NAT packet). The peer presents a Cilium-CA client cert k3s etcd rejects, and receives a k3s server cert the peer does not trust → the etcd session never establishes → `context canceled` / heartbeat-watcher timeout → `0 remote clusters ready` → cross-region global-service backend sync dead → CNPG shared-pg replicas can't bootstrap → region-B grafana/mimir/powerdns-admin CrashLoop.

### Evidence (region-B `cilium-agent` openssl, using the EXACT mesh CA + client cert cilium uses)

| region-B → region-A path | server cert | verify |
|---|---|---|
| `212.72.24.22:2379` (current) | `CN=etcd-server` / `etcd-server-ca` (k3s) | `Verify return code: 19` |
| host-socket on a **non-2379** port | `CN=clustermesh-apiserver.cilium.io` / `Cilium CA` | **`Verify return code: 0 (ok)`** |

`212.72.24.22` was confirmed to be the region-A CP node's `EXTERNAL-IP`; the same EIP's `:443` correctly reaches the gateway envoy (host-socket) while `:2379` reaches k3s etcd. This is the documented Huawei-NAT'd-EIP-breaks-Cilium-LB-VIP class, made terminal by a **port-2379 collision** with k3s etcd.

### Live-patch proof (the fix works)
socat host-socket on a non-2379 port on the CP node + SG open + repoint region-B's endpoint →
```
ClusterMesh: 1/1 remote clusters ready
  hw225-mesh: ready, 6 nodes, 181 endpoints, 376 identities, 8 services
  synchronization status: nodes=true endpoints=true identities=true services=true
```
13 region-A backends appeared in region-B; `shared-pg-b-mesh` (`10.97.8.30:5432`) populated with the region-A primary (`10.42.1.210`). **hw225 was restored to its pre-patch state after the proof** (reconciler resumed, temp proxy + SG rule removed).

## Fix (this PR) — mirrors the gateway's proven no-CCM-Huawei host-socket model
A hostNetwork bind, **NOT a NodePort** (§854-clean, same mechanism as the gateway envoy):

- **`platform/cilium/chart`**: new `clustermesh-proxy-daemonset.yaml` — a gated hostNetwork DaemonSet that binds a dedicated **non-2379** host port and TCP-passthroughs (TLS/mTLS preserved end-to-end) to the clustermesh-apiserver etcd. Default **OFF** (Hetzner hcloud-ccm LB IP has no k3s-etcd host collision). `values-clustermesh.yaml` `clustermeshProxy` knob.
- **`catalyst-api` `clustermesh.go`**: dial port is now env-overridable (`CLUSTERMESH_APISERVER_DIAL_PORT`, default `2379`); corrected the disproven comments with the hw225 evidence.
- **`infra/providers/huawei`**: `clustermesh_proxy_port` var (NodePort-range + 2379/2380 guarded) + `ingress_clustermesh_proxy` SG rule + cloud-init substitutes (`CILIUM_CLUSTERMESH_PROXY_{ENABLED,PORT}`, `CLUSTERMESH_APISERVER_DIAL_PORT`). Inert on Hetzner.
- **`products/catalyst` chart**: `catalystApi.clusterMeshDialPort` → api-deployment `CLUSTERMESH_APISERVER_DIAL_PORT` env (default 2379).
- **slots**: `01-cilium` (`clustermeshProxy.*`), `13-bp-catalyst-platform` (`catalystApi.clusterMeshDialPort`).
- **Lockstep**: bp-cilium `1.4.11 → 1.4.12` (Chart.yaml + blueprint.yaml + slot pin + catalog-seed; catalog-seed was stale at 1.4.7/1.4.9).

Everything is **default-off / default-2379** → zero Hetzner or existing-prov regression.

### Vetted
- `go build ./...` + `go test ./internal/handler` — OK
- `helm template` / `helm lint` — proxy renders **absent by default**, correct when enabled; catalyst api-deployment renders `2379` default / `12379` override
- `tofu fmt` + `validate` + full render — Huawei substitutes emit `CILIUM_CLUSTERMESH_PROXY_ENABLED/PORT` + `CLUSTERMESH_APISERVER_DIAL_PORT`
- `scripts/check-no-nodeports.sh` — **GREEN** (hostPort, not NodePort)

## 🚧 DRAFT — needs before merge/close
1. **Fresh 2-region Huawei prov cross-region walk** to activate + flip `1/1 ready` on a clean prov (datapath change — live gate, not CI).
2. **catalyst-api image rebuild** (clustermesh.go is baked into the image; merged ≠ delivered).
3. **DISTINCT downstream fault** that also gates the end-user symptom (replica bootstrap + observability recovery): after the mesh flips `1/1`, cross-region **data plane** was `6/12 reachable` — cilium-health `:4240` SG rule is scoped to each region's **own** node subnet (`10.92.1.0/24` / `10.102.1.0/24`), and cross-region pod path needs verification. This is native-routing datapath (#4656 / hw128-layer-6), **not** the clustermesh-sync issue #4784 — tracked separately.

Refs #4784 #4656

