### PR TITLE
fix(console): eradicate residual user-facing tenant leaks (row 214 — Tenant-App category + 2 strings)

### DIFF
--- a/platform/wordpress-tenant/blueprint.yaml
+++ b/platform/wordpress-tenant/blueprint.yaml
@@ -3,7 +3,7 @@ kind: Blueprint
 metadata:
   name: bp-wordpress-tenant
   labels:
-    catalyst.openova.io/category: tenant-app
+    catalyst.openova.io/category: organization-app
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
   version: 0.4.20
@@ -19,7 +19,7 @@ spec:
       time so the Organization admin's first browser hit lands on /wp-admin
       authenticated. No install wizard, no manual config.
     icon: wordpress.svg
-    category: tenant-app
+    category: organization-app
     tags: [wordpress, cms, organization, sso, keycloak, oidc, postgres]
     documentation: https://wordpress.org/documentation/
     license: GPL-2.0-or-later

--- a/products/catalyst/bootstrap/ui/src/components/CrudModals/AddRegionModal.tsx
+++ b/products/catalyst/bootstrap/ui/src/components/CrudModals/AddRegionModal.tsx
@@ -122,7 +122,7 @@ export function AddRegionModal({
               ))}
             </select>
           </FormRow>
-          <FormRow label="Region" hint="Provider tenant already credentialed during initial provisioning.">
+          <FormRow label="Region" hint="Provider account already credentialed during initial provisioning.">
             <select
               data-testid="add-region-modal-region"
               value={regionId}

--- a/products/catalyst/bootstrap/ui/src/entities/deployment/model.ts
+++ b/products/catalyst/bootstrap/ui/src/entities/deployment/model.ts
@@ -342,7 +342,7 @@ export const SOVEREIGN_POOL_DOMAINS: SovereignPoolDomain[] = [
   {
     id: 'omani-works',
     domain: 'omani.works',
-    description: 'OpenOva-provided pool — first franchised Sovereigns and Organization marketplace tenants. DNS managed via Dynadot.',
+    description: 'OpenOva-provided pool — first franchised Sovereigns and Organization marketplace customers. DNS managed via Dynadot.',
   },
 ]
 

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -5698,7 +5698,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "title": "WordPress (per-Organization)",
     "summary": "|",
     "icon": "wordpress.svg",
-    "category": "tenant-app",
+    "category": "organization-app",
     "tagline": null,
     "tags": [],
     "visibility": "listed",

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -38,7 +38,7 @@ metadata:
     catalyst.openova.io/managed-by: catalog-seed
     catalyst.openova.io/origin: openova-public
     catalyst.openova.io/curation: openova-public
-    catalyst.openova.io/category: tenant-app
+    catalyst.openova.io/category: organization-app
     catalyst.openova.io/section: pts-7-org-tenant
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
@@ -58,7 +58,7 @@ spec:
   visibility: listed
   card:
     title: "WordPress (per-Organization)"
-    category: tenant-app
+    category: organization-app
     family: cms
     summary: "Turnkey, SSO-pre-wired WordPress per Organization. Postgres + cert-manager TLS pre-wired."
     description: "Runs in the Organization's vcluster, namespace = Organization namespace. SSO via the Organization-vcluster Keycloak realm. Default theme + admin user pre-seeded at install time."
@@ -183,7 +183,7 @@ metadata:
     catalyst.openova.io/managed-by: catalog-seed
     catalyst.openova.io/origin: openova-public
     catalyst.openova.io/curation: openova-public
-    catalyst.openova.io/category: tenant-app
+    catalyst.openova.io/category: organization-app
     catalyst.openova.io/section: pts-7-org-tenant
     catalyst.openova.io/alias-of: bp-wordpress-tenant
     app.kubernetes.io/managed-by: {{ $managedBy }}
@@ -193,7 +193,7 @@ spec:
   visibility: listed
   card:
     title: "WordPress"
-    category: tenant-app
+    category: organization-app
     family: cms
     summary: "Turnkey, SSO-pre-wired WordPress. Postgres + cert-manager TLS pre-wired. The marketplace funnel's flagship CMS."
     description: "Runs in the Org's vcluster. SSO via the per-Org Keycloak realm (openid-connect-generic). Default theme + admin user pre-seeded at install time so the first browser hit lands on /wp-admin authenticated. Aliases the bp-wordpress-tenant chart."
@@ -372,7 +372,7 @@ spec:
 # though the chart is published and the wordpress-tenant chart's
 # `pg.activeHotStandby.enabled` knob already renders the same shape
 # inline (DoD D31). Seeding here lets operators install the pair
-# standalone (companion DB for any tenant-app) AND lets the install
+# standalone (companion DB for any organization-app) AND lets the install
 # flow render a stable reference target when wordpress-tenant.db.mode
 # = active-hot-standby. Refs TBD-E8b, TBD-B31.
 apiVersion: catalyst.openova.io/v1


### PR DESCRIPTION
Row 214 banned-term leak: walker-2 found user-facing 'Tenant-App' catalog category + 'Provider tenant already credentialed' + 'Organization marketplace tenants' on hw225. Renamed tenant-app→organization-app + fixed the 2 strings. Refs #4739 #3383