### PR TITLE
fix(org-controller): sync gateway-api HTTPRoutes into per-Org vcluster (#4785 4th layer, rows 90/224/226/232)

### DIFF
--- a/core/controllers/organization/internal/gitops/manifests.go
+++ b/core/controllers/organization/internal/gitops/manifests.go
@@ -312,6 +312,20 @@ spec:
         # whole-ns NetworkPolicy -- a different mechanism.)
         networkPolicies:
           enabled: true
+        # #4785: sync gateway-api HTTPRoutes to the host <slug> ns. A customer
+        # app's Helm chart (e.g. bp-openclaw, bp-wordpress-tenant) renders an
+        # HTTPRoute for its external ingress and is installed INTO the
+        # Org-vcluster (apps tree, via kubeConfig). A vanilla vcluster has NO
+        # gateway.networking.k8s.io CRD, so the install fails with
+        # 'no matches for kind HTTPRoute in gateway.networking.k8s.io' and no
+        # customer app ever serves (proven live hw225 uat225wp). Enabling the
+        # custom-resource sync imports the HTTPRoute CRD (copied from host) so
+        # the app can create it, AND reflects it to the host <slug> ns where the
+        # Cilium Gateway routes external traffic to the app pod — the same
+        # host-reflection model as services/networkPolicies above.
+        customResources:
+          httproutes.gateway.networking.k8s.io:
+            enabled: true
       fromHost:
         ingressClasses:
           enabled: true


### PR DESCRIPTION
4th layer of the per-Org apps chain. Enable HTTPRoute custom-resource sync in the vcluster so customer app charts can create their HTTPRoute + reach the host Cilium Gateway. Live-patched hw225 uat225wp (vcluster rolling). Refs #4785 #4739