### PR TITLE
fix(mimir): make-buckets Job survives slow kom4dc MinIO first-boot (row 172 Failed job root cause)

### DIFF
--- a/platform/mimir/chart/Chart.yaml
+++ b/platform/mimir/chart/Chart.yaml
@@ -31,7 +31,7 @@ type: application
 # every container satisfies the cluster-wide Kyverno `resource-requests`
 # Enforce policy. Post-#4325 this chart installs into the native host namespace
 # (not a vCluster) where the policy applies.
-version: 1.0.7
+version: 1.0.8
 appVersion: "3.0.4"
 keywords: [catalyst, blueprint, mimir, observability, metrics, prometheus]
 maintainers:

--- a/platform/mimir/chart/templates/devcluster-workloads.yaml
+++ b/platform/mimir/chart/templates/devcluster-workloads.yaml
@@ -559,7 +559,13 @@ data:
     MC_CONFIG_DIR="/tmp/minio/mc/"
     MC="/usr/bin/mc --insecure --config-dir ${MC_CONFIG_DIR}"
     connectToMinio() {
-      ATTEMPTS=0 ; LIMIT=29
+      # LIMIT bumped 29→150 (#4739): on kom4dc the Catalyst-owned MinIO
+      # Deployment pulls its server image through the Harbor pull-through proxy
+      # and can take several minutes to become Ready. At LIMIT=29 (58s/attempt)
+      # the make-buckets Job exhausted backoffLimit 6 (~6min total) before MinIO
+      # answered → Job Failed → mimir-ingester CrashLoop (no tsdb bucket).
+      # 150×2s = 5min/attempt ×6 = ~30min tolerance for slow first-boot.
+      ATTEMPTS=0 ; LIMIT=150
       ACCESS=$(cat /config/rootUser) ; SECRET=$(cat /config/rootPassword)
       set +e
       MC_COMMAND="${MC} alias set myminio http://$MINIO_ENDPOINT:$MINIO_PORT $ACCESS $SECRET"


### PR DESCRIPTION
make-minio-buckets exhausted backoffLimit before the Harbor-proxied MinIO image finished pulling on kom4dc → mimir-ingester CrashLoop. Bump connectToMinio wait 58s→5min/attempt. Live-observed hw225. Refs #4739