### PR TITLE
fix(adoption): plant empty cross-cloud key so CloudAdoption Workspaces Sync (rows 206/207/239)

### DIFF
--- a/infra/providers/hetzner/main.tf
+++ b/infra/providers/hetzner/main.tf
@@ -831,6 +831,17 @@ locals {
       hcloud-network-name: ${hcloud_network.region["primary"].name}
       hcloud-firewall-name: ${hcloud_firewall.main.name}
       hcloud-ssh-key-name: ${hcloud_ssh_key.main.name}
+      # #4739: empty cross-cloud placeholders. The cloud-agnostic
+      # opentofu-cloud-adoption Composition wires HW_ACCESS_KEY / HW_SECRET_KEY /
+      # HW_PROJECT_ID / HW_REGION_NAME via REQUIRED secretKeyRefs (the
+      # provider-opentofu Workspace env schema has no `optional` field). Without
+      # these keys on a Hetzner Sovereign every adoption Workspace fails Sync
+      # "couldn't find key huawei-ak…". Empty values are inert (cloud==hetzner so
+      # the huaweicloud data lookups have count=0 and that provider is unused).
+      huawei-ak: ""
+      huawei-sk: ""
+      huawei-project-id: ""
+      huawei-region: ""
   EOT
 
   # ── Worker cloud-init computed BEFORE the control-plane cloud-init so it

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -837,6 +837,15 @@ locals {
       # The huaweicloud-csi-driver cloud-config reads this as `project-id`.
       huawei-project-id: "${var.huawei_project_id}"
       huawei-region: "${var.huawei_region}"
+      # #4739: empty cross-cloud placeholder. The cloud-agnostic
+      # opentofu-cloud-adoption Composition (platform/crossplane-claims) wires
+      # HCLOUD_TOKEN via a REQUIRED secretKeyRef on key `hcloud-token` (the
+      # provider-opentofu Workspace env schema has no `optional` field). Without
+      # this key present on a Huawei Sovereign every adoption Workspace fails
+      # Sync "couldn't find key hcloud-token in Secret cloud-credentials" → all
+      # CloudAdoptions stuck non-Ready. Empty value is inert (cloud==huawei so
+      # the hcloud data lookups have count=0 and the hcloud provider is unused).
+      hcloud-token: ""
   EOT
 
   # provider prelude — Huawei. Runs BEFORE k3s (runcmd 0-indent items; the

--- a/platform/crossplane-claims/chart/templates/compositions/cloudadoption.yaml
+++ b/platform/crossplane-claims/chart/templates/compositions/cloudadoption.yaml
@@ -120,15 +120,37 @@ spec:
               - key: hcloud_token
                 value: ""
             module: |
-              variable "cloud"             { type = string }
-              variable "resource_kind"     { type = string }
-              variable "resource_id"       { type = string }
-              variable "huawei_region"     { type = string  default = "me-east-215" }
-              variable "huawei_access_key" { type = string  default = "" }
-              variable "huawei_secret_key" { type = string  default = "" }
-              variable "huawei_project_id" { type = string  default = "" }
-              variable "huawei_insecure"   { type = string  default = "true" }
-              variable "hcloud_token"      { type = string  default = "" }
+              # #4739: OpenTofu (unlike Terraform) REJECTS a single-line block
+              # with more than one argument ("Invalid single-argument block
+              # definition"). The var blocks that carry BOTH `type` and
+              # `default` must be multi-line. Single-arg blocks stay inline.
+              variable "cloud"         { type = string }
+              variable "resource_kind" { type = string }
+              variable "resource_id"   { type = string }
+              variable "huawei_region" {
+                type    = string
+                default = "me-east-215"
+              }
+              variable "huawei_access_key" {
+                type    = string
+                default = ""
+              }
+              variable "huawei_secret_key" {
+                type    = string
+                default = ""
+              }
+              variable "huawei_project_id" {
+                type    = string
+                default = ""
+              }
+              variable "huawei_insecure" {
+                type    = string
+                default = "true"
+              }
+              variable "hcloud_token" {
+                type    = string
+                default = ""
+              }
 
               terraform {
                 required_providers {

--- a/platform/crossplane-claims/chart/templates/compositions/cloudadoption.yaml
+++ b/platform/crossplane-claims/chart/templates/compositions/cloudadoption.yaml
@@ -58,12 +58,17 @@ spec:
             # HW_ACCESS_KEY / HW_SECRET_KEY / HW_REGION_NAME / HW_PROJECT_ID
             # when its args are omitted; hcloud reads HCLOUD_TOKEN. Sourced
             # from the flux-system/cloud-credentials Secret the cloud-init
-            # plants (Hetzner: hcloud-token; Huawei: huawei-ak/-sk/-project-
-            # id/-region). Every secretKeyRef is `optional`-shaped by the
-            # provider — a Hetzner Sovereign (no huawei-* keys) leaves the
-            # HW_* vars empty, and the cloud var gates which data lookup runs,
-            # so the missing keys are inert. This is what lets the Observe
-            # data lookup actually AUTHENTICATE against the live cloud API —
+            # plants. #4739: the provider-opentofu Workspace env secretKeyRef
+            # schema has NO `optional` field (verified: only key/name/namespace),
+            # so a REQUIRED reference to a key that is absent hard-fails the
+            # Workspace Sync ("couldn't find key hcloud-token in Secret …"). The
+            # cloud-init on BOTH clouds therefore plants ALL 5 keys — the native
+            # ones populated + the cross-cloud ones as EMPTY placeholders
+            # (Huawei carries an empty hcloud-token; Hetzner empty huawei-*).
+            # Every secretKeyRef then resolves; the empty cross-cloud value is
+            # inert because the `cloud` var gates which data lookup runs (the
+            # unused provider's lookups have count=0). This is what lets the
+            # Observe data lookup AUTHENTICATE against the live cloud API —
             # without it the Workspace tofu run has no credentials and the
             # adoption never reaches Synced.
             env:


### PR DESCRIPTION
Live hw225: all 24 adoption Workspaces Synced=False 'couldnt find key hcloud-token in Secret cloud-credentials' — the required secretKeyRef references a Hetzner key on a Huawei env (Workspace env schema has no optional field). Cloud-init now plants all 5 keys w/ empty cross-cloud placeholders. Live-patched hw225 to prove. Refs #4739