### PR TITLE
chore(crossplane): republish bp-crossplane-claims with #4794 adoption HCL fix

### DIFF
--- a/platform/crossplane-claims/chart/Chart.yaml
+++ b/platform/crossplane-claims/chart/Chart.yaml
@@ -23,7 +23,7 @@ name: bp-crossplane-claims
 # CloudAdoption CRs at Ready=False. The `userAccess.compositionEnabled`
 # value is removed (no Composition remains to enable).
 # 1.3.1 (#4739): cloudadoption Composition Workspace GVK tf.upbound.io -> opentofu.upbound.io (matches the installed provider-opentofu; tf.upbound.io is the terraform provider group, unregistered here). Fixes CloudAdoption never-Ready + empty `kubectl get managed` (UAT 206/207/239).
-version: 1.3.1
+version: 1.3.2
 description: |
   Catalyst Crossplane XRDs + Compositions Blueprint. Carries ONLY the
   apiextensions.crossplane.io/v1 CompositeResourceDefinition and


### PR DESCRIPTION
#4794 merged the adoption Composition fix without a Chart.yaml bump → ghcr 1.3.1 predates it. Version bump so CI publishes a chart carrying the fix (else a fresh prov still hits the tofu HCL error). Refs #4739 #4794