### PR TITLE
fix(crossplane): adoption ELB observed_address vip_address→ipv4_address (Unsupported attribute)

### DIFF
--- a/platform/crossplane-claims/chart/Chart.yaml
+++ b/platform/crossplane-claims/chart/Chart.yaml
@@ -23,7 +23,7 @@ name: bp-crossplane-claims
 # CloudAdoption CRs at Ready=False. The `userAccess.compositionEnabled`
 # value is removed (no Composition remains to enable).
 # 1.3.1 (#4739): cloudadoption Composition Workspace GVK tf.upbound.io -> opentofu.upbound.io (matches the installed provider-opentofu; tf.upbound.io is the terraform provider group, unregistered here). Fixes CloudAdoption never-Ready + empty `kubectl get managed` (UAT 206/207/239).
-version: 1.3.2
+version: 1.3.3
 description: |
   Catalyst Crossplane XRDs + Compositions Blueprint. Carries ONLY the
   apiextensions.crossplane.io/v1 CompositeResourceDefinition and

--- a/platform/crossplane-claims/chart/templates/compositions/cloudadoption.yaml
+++ b/platform/crossplane-claims/chart/templates/compositions/cloudadoption.yaml
@@ -230,7 +230,7 @@ spec:
                   var.resource_id,
                 )
                 observed_address = coalesce(
-                  try(data.huaweicloud_elb_loadbalancers.hw[0].loadbalancers[0].vip_address, ""),
+                  try(data.huaweicloud_elb_loadbalancers.hw[0].loadbalancers[0].ipv4_address, ""),
                   try(data.huaweicloud_compute_instance.hw[0].public_ip, ""),
                   try(data.hcloud_load_balancer.hz[0].ipv4, ""),
                   try(data.hcloud_server.hz[0].ipv4_address, ""),


### PR DESCRIPTION
Layer-6 of the adoption fix chain: huaweicloud plural ELB data source has no vip_address (it's ipv4_address); try() can't catch the static schema error. Live-observed hw225. Refs #4739