### PR TITLE
fix(provisioning): funnel-door apps sourceRef flux-system→openova-org-tenants (row 226)

### DIFF
--- a/core/services/provisioning/gitops/gitops.go
+++ b/core/services/provisioning/gitops/gitops.go
@@ -799,7 +799,7 @@ spec:
   targetNamespace: %s
   sourceRef:
     kind: GitRepository
-    name: flux-system
+    name: openova-org-tenants
     namespace: flux-system
   path: ./%s/%s/apps%s
 `, slug, ns, basePath, slug, kubeConfig)


### PR DESCRIPTION
generateAppsSyncKustomization hardcoded a nonexistent flux-system GitRepo. Correct repo is openova-org-tenants. Live-proven hw225. Refs #4739 #4785