### PR TITLE
fix(crossplane): adoption hcloud dummy token when unused (Missing Hetzner token on Huawei)

### DIFF
--- a/platform/crossplane-claims/chart/Chart.yaml
+++ b/platform/crossplane-claims/chart/Chart.yaml
@@ -23,7 +23,7 @@ name: bp-crossplane-claims
 # CloudAdoption CRs at Ready=False. The `userAccess.compositionEnabled`
 # value is removed (no Composition remains to enable).
 # 1.3.1 (#4739): cloudadoption Composition Workspace GVK tf.upbound.io -> opentofu.upbound.io (matches the installed provider-opentofu; tf.upbound.io is the terraform provider group, unregistered here). Fixes CloudAdoption never-Ready + empty `kubectl get managed` (UAT 206/207/239).
-version: 1.3.2
+version: 1.3.3
 description: |
   Catalyst Crossplane XRDs + Compositions Blueprint. Carries ONLY the
   apiextensions.crossplane.io/v1 CompositeResourceDefinition and

--- a/platform/crossplane-claims/chart/templates/compositions/cloudadoption.yaml
+++ b/platform/crossplane-claims/chart/templates/compositions/cloudadoption.yaml
@@ -182,7 +182,7 @@ spec:
               }
 
               # hcloud reads HCLOUD_TOKEN env when token is null.
-              provider "hcloud" { token = var.hcloud_token != "" ? var.hcloud_token : null }
+              provider "hcloud" { token = var.hcloud_token != "" ? var.hcloud_token : "unused-on-non-hetzner" }
 
               # ── Huawei data lookups (read-only) ──────────────────────
               data "huaweicloud_elb_loadbalancers" "hw" {

--- a/platform/crossplane-claims/chart/templates/compositions/cloudadoption.yaml
+++ b/platform/crossplane-claims/chart/templates/compositions/cloudadoption.yaml
@@ -182,7 +182,7 @@ spec:
               }
 
               # hcloud reads HCLOUD_TOKEN env when token is null.
-              provider "hcloud" { token = var.hcloud_token != "" ? var.hcloud_token : "unused-on-non-hetzner" }
+              provider "hcloud" { token = var.hcloud_token != "" ? var.hcloud_token : "0000000000000000000000000000000000000000000000000000000000000000" }
 
               # ── Huawei data lookups (read-only) ──────────────────────
               data "huaweicloud_elb_loadbalancers" "hw" {


### PR DESCRIPTION
Cloud-agnostic module: hcloud provider rejects null token at configure even when unused (count=0). Dummy fallback. Live-observed hw225. Refs #4739