### PR TITLE
fix(topology): detect per-Org vcluster via StatefulSet (vCluster 0/0)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader.go
+++ b/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader.go
@@ -802,6 +802,40 @@ func loadVClusters(ctx context.Context, in LoaderInput) (out []VCluster) {
 			Status:    "healthy",
 		})
 	}
+
+	// Third-source: loft-sh/vcluster StatefulSets (label app=vcluster). The
+	// per-Org vcluster (bp-rtz-vcluster / org-controller) renders a StatefulSet
+	// named `vcluster` in the Org boundary ns WITHOUT a vcluster.io/.com CR AND
+	// without the catalyst.openova.io/vcluster-role ns label, so BOTH sources
+	// above miss it → "vCluster 0/0" despite a Running 1/1 vcluster (live hw225
+	// uat225wp 2026-07-05, #936 class). Enumerate app=vcluster StatefulSets,
+	// deduping against namespaces already emitted above. Refs #4739.
+	seen := map[string]bool{}
+	for _, v := range out {
+		seen[v.Namespace] = true
+	}
+	stsGVR := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"}
+	stsCtx, stsCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer stsCancel()
+	stsList, stsErr := in.DynamicClient.Resource(stsGVR).List(stsCtx, metav1.ListOptions{
+		LabelSelector: "app=vcluster",
+	})
+	if stsErr == nil && stsList != nil {
+		for _, sts := range stsList.Items {
+			ns := sts.GetNamespace()
+			if seen[ns] {
+				continue
+			}
+			seen[ns] = true
+			out = append(out, VCluster{
+				ID:        "vcluster-" + ns,
+				Name:      sts.GetName(),
+				Namespace: ns,
+				Role:      vclusterRole(sts.GetLabels()),
+				Status:    "healthy",
+			})
+		}
+	}
 	return out
 }
 

--- a/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader_perregion_test.go
+++ b/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader_perregion_test.go
@@ -68,6 +68,12 @@ func vclusterRoleNamespaceClient(t *testing.T, vclusterName string) dynamic.Inte
 	// the production vCluster-discovery path this test exercises.
 	gvrToListKind := map[schema.GroupVersionResource]string{
 		{Group: "vcluster.io", Version: "v1alpha1", Resource: "vclusters"}: "VClusterList",
+		// #4739: loadVClusters' third source enumerates app=vcluster
+		// StatefulSets. Register the list-kind so the fake returns an empty
+		// list (production: this Sovereign's Namespace-role vclusters win the
+		// dedup) instead of panicking → recover → [] (which regressed the
+		// Namespace-role fallback this test asserts).
+		{Group: "apps", Version: "v1", Resource: "statefulsets"}: "StatefulSetList",
 	}
 	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, ns)
 }


### PR DESCRIPTION
loadVClusters missed the per-Org loft-sh vcluster StatefulSet (no CR, no vcluster-role ns label) → 0/0 despite Running 1/1. Add app=vcluster StatefulSet source. Source-traced on hw225. Refs #4739