### PR TITLE
fix(crossplane): adoption observed_address coalesce try-wrap (layer 10)

### DIFF
--- a/clusters/_template/bootstrap-kit/14-crossplane-claims.yaml
+++ b/clusters/_template/bootstrap-kit/14-crossplane-claims.yaml
@@ -70,7 +70,7 @@ spec:
       # is replaced by a plain namespaced CRD reconciled by the
       # catalyst-useraccess-controller. Removes the retired legacy
       # Composition + the `userAccess.compositionEnabled` toggle.
-      version: 1.3.2
+      version: 1.3.3
       sourceRef:
         kind: HelmRepository
         name: bp-crossplane-claims

--- a/platform/crossplane-claims/blueprint.yaml
+++ b/platform/crossplane-claims/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-2-gitops-and-iac
 spec:
-  version: 1.3.2
+  version: 1.3.3
   card:
     title: crossplane-claims
     summary: |

--- a/platform/crossplane-claims/chart/Chart.yaml
+++ b/platform/crossplane-claims/chart/Chart.yaml
@@ -23,7 +23,7 @@ name: bp-crossplane-claims
 # CloudAdoption CRs at Ready=False. The `userAccess.compositionEnabled`
 # value is removed (no Composition remains to enable).
 # 1.3.1 (#4739): cloudadoption Composition Workspace GVK tf.upbound.io -> opentofu.upbound.io (matches the installed provider-opentofu; tf.upbound.io is the terraform provider group, unregistered here). Fixes CloudAdoption never-Ready + empty `kubectl get managed` (UAT 206/207/239).
-version: 1.3.2
+version: 1.3.3
 description: |
   Catalyst Crossplane XRDs + Compositions Blueprint. Carries ONLY the
   apiextensions.crossplane.io/v1 CompositeResourceDefinition and

--- a/platform/crossplane-claims/chart/templates/compositions/cloudadoption.yaml
+++ b/platform/crossplane-claims/chart/templates/compositions/cloudadoption.yaml
@@ -229,13 +229,19 @@ spec:
                   try(data.hcloud_network.hz[0].id, ""),
                   var.resource_id,
                 )
-                observed_address = coalesce(
-                  try(data.huaweicloud_elb_loadbalancers.hw[0].loadbalancers[0].vip_address, ""),
+                # #4739: coalesce ERRORS when every argument is empty (needs a
+                # non-null/non-empty result) — happens on an Observe-only
+                # adoption whose data lookups all resolve empty on the
+                # non-active cloud (count=0), aborting the whole tofu plan with
+                # "Error in function call". Wrap in try() so an all-empty set
+                # yields "". Also ipv4_address (not vip_address) is the
+                # huaweicloud plural-ELB attribute.
+                observed_address = try(coalesce(
+                  try(data.huaweicloud_elb_loadbalancers.hw[0].loadbalancers[0].ipv4_address, ""),
                   try(data.huaweicloud_compute_instance.hw[0].public_ip, ""),
                   try(data.hcloud_load_balancer.hz[0].ipv4, ""),
                   try(data.hcloud_server.hz[0].ipv4_address, ""),
-                  "",
-                )
+                ), "")
               }
 
               output "observed_id"      { value = local.observed_id }


### PR DESCRIPTION
coalesce errors on all-empty (Observe-only). Wrap in try. Refs #4739 #4620