### PR TITLE
fix(#4620): adoption consolidated — k8s backend + anchor + full policy + 3 static layers

### DIFF
--- a/clusters/_template/bootstrap-kit/14-crossplane-claims.yaml
+++ b/clusters/_template/bootstrap-kit/14-crossplane-claims.yaml
@@ -70,7 +70,7 @@ spec:
       # is replaced by a plain namespaced CRD reconciled by the
       # catalyst-useraccess-controller. Removes the retired legacy
       # Composition + the `userAccess.compositionEnabled` toggle.
-      version: 1.3.2
+      version: 1.3.3
       sourceRef:
         kind: HelmRepository
         name: bp-crossplane-claims

--- a/clusters/_template/infrastructure/base/provider-config-opentofu.yaml
+++ b/clusters/_template/infrastructure/base/provider-config-opentofu.yaml
@@ -38,7 +38,26 @@ spec:
   configuration: |
     // Catalyst-default OpenTofu provider configuration for adoption
     // Workspaces. Per-Workspace inline modules override/extend this.
-    // Empty by default — the adoption module carries its own provider{}
-    // block keyed to the cloud being adopted, because the on-prem HCS
-    // endpoints + insecure flag must be set per-cloud and cannot be a
-    // single global default.
+    // The adoption module carries its own provider{} block keyed to the
+    // cloud being adopted, because the on-prem HCS endpoints + insecure
+    // flag must be set per-cloud and cannot be a single global default.
+    //
+    // #4620: the kubernetes backend is MANDATORY, not an optimization.
+    // provider-opentofu's Observe runs `tofu state list` UNCONDITIONALLY
+    // (workspace.go Observe -> tofu.Resources) BEFORE Create can ever
+    // fire. With the default LOCAL backend a fresh Workspace has no state
+    // file, so `state list` hard-errors ("No state file was found") ->
+    // Observe errors -> Create/apply never runs -> permanent
+    // Synced=False deadlock (live-proven on hw225, 24/24 Workspaces).
+    // The kubernetes backend returns an EMPTY state gracefully (state
+    // list exit 0, live-verified in the provider pod), so the first
+    // Observe succeeds with exists=false, Create fires the one-shot
+    // apply, and the state Secret (tfstate-<workspace>-adoption in
+    // crossplane-system) survives provider-pod restarts.
+    terraform {
+      backend "kubernetes" {
+        secret_suffix     = "adoption"
+        namespace         = "crossplane-system"
+        in_cluster_config = true
+      }
+    }

--- a/clusters/_template/infrastructure/providers/base/provider-opentofu.yaml
+++ b/clusters/_template/infrastructure/providers/base/provider-opentofu.yaml
@@ -106,3 +106,18 @@ spec:
                 - secretRef:
                     name: cloud-credentials
                     optional: true
+              # #4739: resources.requests are MANDATORY. The host-ns Kyverno
+              # `resource-requests` + `resource-limits` Enforce policies DENY any
+              # pod that omits both cpu+memory requests. Without this the
+              # provider-opentofu pod is admission-denied on EVERY restart /
+              # fresh-prov ("Every container must declare resources.requests.cpu
+              # and resources.requests.memory") → deployment 0/1,
+              # UnhealthyPackageRevision → ALL crossplane CloudAdoptions stuck
+              # non-Ready (rows 206/207/239, live-observed hw225 2026-07-05).
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 256Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi

--- a/platform/crossplane-claims/blueprint.yaml
+++ b/platform/crossplane-claims/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-2-gitops-and-iac
 spec:
-  version: 1.3.2
+  version: 1.3.3
   card:
     title: crossplane-claims
     summary: |

--- a/platform/crossplane-claims/chart/Chart.yaml
+++ b/platform/crossplane-claims/chart/Chart.yaml
@@ -23,7 +23,7 @@ name: bp-crossplane-claims
 # CloudAdoption CRs at Ready=False. The `userAccess.compositionEnabled`
 # value is removed (no Composition remains to enable).
 # 1.3.1 (#4739): cloudadoption Composition Workspace GVK tf.upbound.io -> opentofu.upbound.io (matches the installed provider-opentofu; tf.upbound.io is the terraform provider group, unregistered here). Fixes CloudAdoption never-Ready + empty `kubectl get managed` (UAT 206/207/239).
-version: 1.3.2
+version: 1.3.3
 description: |
   Catalyst Crossplane XRDs + Compositions Blueprint. Carries ONLY the
   apiextensions.crossplane.io/v1 CompositeResourceDefinition and

--- a/platform/crossplane-claims/chart/templates/compositions/cloudadoption.yaml
+++ b/platform/crossplane-claims/chart/templates/compositions/cloudadoption.yaml
@@ -46,9 +46,17 @@ spec:
           annotations:
             crossplane.io/external-name: ""
         spec:
-          # OBSERVE-ONLY by default. Adoption must never re-provision the
-          # live platform. The `manage` flag flips this to full-manage.
-          managementPolicies: ["Observe"]
+          # #4620: FULL lifecycle, deliberately NOT ["Observe"]. The safety
+          # guarantee "adoption must never re-provision the live platform"
+          # comes from the MODULE (data sources + one inert terraform_data —
+          # apply/destroy structurally cannot mutate the cloud), not from the
+          # management policy. Observe-only was a deadlock: provider-opentofu's
+          # Observe runs `tofu state list` unconditionally, a never-applied
+          # workspace has no state, so Observe hard-errored forever and the
+          # state-writing apply could never run (live-proven hw225, 24/24
+          # Workspaces stuck Synced=False for 5h+). Full policy lets the
+          # one-shot Create/apply write the state; every later Observe reads it.
+          managementPolicies: ["*"]
           providerConfigRef:
             name: default
           forProvider:
@@ -182,7 +190,12 @@ spec:
               }
 
               # hcloud reads HCLOUD_TOKEN env when token is null.
-              provider "hcloud" { token = var.hcloud_token != "" ? var.hcloud_token : null }
+              # #4739: hcloud requires a syntactically-valid token at plan time
+              # even when count=0 gates every hz data source off (Huawei
+              # Sovereigns carry an empty hcloud-token key) — null token fails
+              # provider init with "Missing Hetzner token". A 64-hex dummy
+              # satisfies validation; no hz lookup ever runs when cloud!=hetzner.
+              provider "hcloud" { token = var.hcloud_token != "" ? var.hcloud_token : "0000000000000000000000000000000000000000000000000000000000000000" }
 
               # ── Huawei data lookups (read-only) ──────────────────────
               data "huaweicloud_elb_loadbalancers" "hw" {
@@ -229,13 +242,32 @@ spec:
                   try(data.hcloud_network.hz[0].id, ""),
                   var.resource_id,
                 )
-                observed_address = coalesce(
-                  try(data.huaweicloud_elb_loadbalancers.hw[0].loadbalancers[0].vip_address, ""),
+                # #4739: coalesce ERRORS when every argument is empty (needs a
+                # non-null/non-empty result) — happens on an adoption whose
+                # data lookups all resolve empty on the non-active cloud
+                # (count=0), aborting the whole tofu plan with "Error in
+                # function call". Wrap in try() so an all-empty set yields "".
+                # Also ipv4_address (not vip_address) is the huaweicloud
+                # plural-ELB attribute.
+                observed_address = try(coalesce(
+                  try(data.huaweicloud_elb_loadbalancers.hw[0].loadbalancers[0].ipv4_address, ""),
                   try(data.huaweicloud_compute_instance.hw[0].public_ip, ""),
                   try(data.hcloud_load_balancer.hz[0].ipv4, ""),
                   try(data.hcloud_server.hz[0].ipv4_address, ""),
-                  "",
-                )
+                ), "")
+              }
+
+              # #4620 anchor: a data-only module NEVER produces tracked
+              # resources, so ResourceExists stays false and the state stays
+              # output-only. This managed-but-inert resource (terraform_data
+              # touches NOTHING in the cloud) forces the first plan to diff ->
+              # the one-shot Create/apply runs -> the state file exists ->
+              # provider-opentofu's unconditional `tofu state list` in Observe
+              # succeeds forever after (live-proven hw225: manual apply of
+              # exactly this flipped `state list` from hard-error to listing
+              # the anchor + the resolved data source, with adopted=true).
+              resource "terraform_data" "adoption_anchor" {
+                input = local.observed_id
               }
 
               output "observed_id"      { value = local.observed_id }


### PR DESCRIPTION
Kills the #4620 adoption deadlock with the design fix, live-proven on hw225 first (24/24 manual applies clean, adopted=true, state list green). Legs: (1) kubernetes backend in ProviderConfig — empty-state list exits 0, verified in provider pod; (2) terraform_data anchor — forces the state-writing first apply; (3) managementPolicies [*] — safety is the data-only module, Observe-only structurally can't write state; (4) folds in the static layers from #4796/#4797/#4799/#4802 (supersedes all four). Chart 1.3.3 3-way lockstep. Refs #4620 #4739

🤖 Generated with [Claude Code](https://claude.com/claude-code)