### PR TITLE
fix(ui): OrgConsumption.isPlatform — unbreak catalyst-build

### DIFF
--- a/products/catalyst/bootstrap/ui/src/lib/organizations.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/organizations.api.ts
@@ -246,6 +246,9 @@ export interface AppConsumption {
 export interface OrgConsumption {
   org: string
   isParent: boolean
+  /** True on the single synthetic "Platform overhead" row the API folds
+   *  infra/Job usage into (org_consumption.go `json:"isPlatform"`). */
+  isPlatform?: boolean
   costUnits: number
   cpuMilli: number
   memoryGiB: number


### PR DESCRIPTION
catalyst-build has been red on main all day (TS2339/TS2353: isPlatform missing from OrgConsumption) — which blocks the catalyst-api image that bakes the #4807 pod-CIDR IaC fix. One-field TS interface fix, tsc clean. Refs #4656

🤖 Generated with [Claude Code](https://claude.com/claude-code)