### PR TITLE
fix(#4814): cloud-graph counts honest for standby-absent secondary region

### DIFF
--- a/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader.go
+++ b/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader.go
@@ -118,7 +118,7 @@ func buildTopology(ctx context.Context, in LoaderInput) TopologyData {
 
 	regions := []Region{}
 	if len(in.Regions) > 0 {
-		for _, rs := range in.Regions {
+		for i, rs := range in.Regions {
 			// Multi-region live-source fix (fix/console-topology-both-
 			// regions): the mothership path (Request.Regions populated)
 			// previously read EVERY region's live data — vClusters,
@@ -138,6 +138,22 @@ func buildTopology(ctx context.Context, in LoaderInput) TopologyData {
 			perRegionIn := in
 			if dc := perRegionDynamicClient(in, rs); dc != nil {
 				perRegionIn.DynamicClient = dc
+			} else if i > 0 && in.K8sCache != nil && len(in.K8sCache.Clusters()) > 0 {
+				// Secondary declared region (Regions[0] is primary) with
+				// NO live kubeconfig registered in a POPULATED k8sCache =
+				// standby-region-absent (#4811). (When K8sCache is nil /
+				// empty — legacy single-cluster mode — the primary-client
+				// fallback below is still correct; only guard the
+				// multi-cluster case.) Falling back to the primary client
+				// here made
+				// buildRegion read the primary's Nodes and emit THIS
+				// region's DECLARED worker count as present — the #4814
+				// fabrication ("Region 2/2 · WorkerNode 24/24" on a
+				// region-b-absent 2-region prov, 6 live nodes). Emit a
+				// degraded, live-empty region so the console counts stay
+				// honest (0 live vs declared → renders as degraded/partial).
+				regions = append(regions, buildAbsentRegion(rs))
+				continue
 			}
 			regions = append(regions, buildRegion(ctx, perRegionIn, rs))
 		}
@@ -521,6 +537,31 @@ func derivePattern(in LoaderInput) string {
 		return "solo"
 	default:
 		return "unknown"
+	}
+}
+
+// buildAbsentRegion renders a DECLARED secondary region that has no live
+// kubeconfig registered in the k8sCache (standby-region-absent — the #4811
+// gap on a 2-region prov where region-b never converged). It emits a
+// degraded, live-empty Region (no Clusters → 0 live nodes) carrying only
+// the declared SKUs/WorkerCount, so the console counts reflect reality
+// (0 live vs declared) instead of falling back to the primary region's
+// client and rendering this region's declared worker count as present
+// (#4814). The frontend derives the live node count from
+// len(Clusters[*].Nodes), so an empty Clusters slice yields an honest
+// "0 live / N declared" and a degraded region badge.
+func buildAbsentRegion(rs provisioner.RegionSpec) Region {
+	return Region{
+		ID:             "region-" + rs.CloudRegion,
+		Name:           rs.CloudRegion,
+		Provider:       rs.Provider,
+		ProviderRegion: rs.CloudRegion,
+		SkuCP:          rs.ControlPlaneSize,
+		SkuWorker:      rs.WorkerSize,
+		WorkerCount:    rs.WorkerCount, // declared total; live=0 (empty Clusters)
+		Status:         "degraded",
+		Clusters:       nil,
+		Networks:       nil,
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader_perregion_test.go
+++ b/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader_perregion_test.go
@@ -171,6 +171,57 @@ func TestLoad_PerRegionFallsBackToPrimaryWhenCacheNil(t *testing.T) {
 	}
 }
 
+// TestLoad_SecondaryAbsentKubeconfigRendersDegraded proves the #4814 fix:
+// on a POPULATED k8sCache (multi-cluster mode) where a declared secondary
+// region's own kubeconfig never registered (standby-region-absent, #4811),
+// the loader must render that region DEGRADED + live-empty — NOT fall back
+// to the primary client and mirror its live contents, which rendered the
+// secondary's DECLARED worker count as present ("Region 2/2 · WorkerNode
+// 24/24" on a region-b-absent 2-region prov with 6 live nodes).
+func TestLoad_SecondaryAbsentKubeconfigRendersDegraded(t *testing.T) {
+	const depID = "depY"
+	primaryClient := vclusterRoleNamespaceClient(t, "only-primary")
+	in := LoaderInput{
+		DeploymentID:  depID,
+		Status:        "ready",
+		SovereignFQDN: "depy.omani.works",
+		Provider:      "huawei",
+		Region:        "reg-a",
+		Regions: []provisioner.RegionSpec{
+			{Provider: "huawei", CloudRegion: "reg-a", WorkerCount: 3},
+			{Provider: "huawei", CloudRegion: "reg-b", WorkerCount: 3},
+		},
+		DynamicClient: primaryClient,
+		// Populated cache with ONLY the primary cluster registered;
+		// reg-b's "<depID>-reg-b" kubeconfig is absent (never converged).
+		K8sCache: &fakeK8sCache{clients: map[string]dynamic.Interface{
+			depID: primaryClient,
+		}},
+	}
+	resp := Load(context.Background(), in)
+	if len(resp.Topology.Regions) != 2 {
+		t.Fatalf("expected 2 region rows, got %d", len(resp.Topology.Regions))
+	}
+	var regB *Region
+	for i := range resp.Topology.Regions {
+		if resp.Topology.Regions[i].Name == "reg-b" {
+			regB = &resp.Topology.Regions[i]
+		}
+	}
+	if regB == nil {
+		t.Fatalf("reg-b region row missing; got %v", regionNames(resp.Topology.Regions))
+	}
+	if regB.Status != "degraded" {
+		t.Errorf("reg-b (absent kubeconfig) should render degraded, got %q", regB.Status)
+	}
+	if len(regB.Clusters) != 0 {
+		t.Errorf("reg-b should have 0 live clusters (no primary fallback), got %d", len(regB.Clusters))
+	}
+	if contains(vclusterNames(*regB), "only-primary") {
+		t.Errorf("reg-b must NOT mirror the primary client's vclusters (#4814 fabrication), got %v", vclusterNames(*regB))
+	}
+}
+
 func regionNames(rs []Region) []string {
 	out := make([]string, 0, len(rs))
 	for _, r := range rs {


### PR DESCRIPTION
## Problem
On **hw227** (region-b standby-absent, #4811), the console cloud graph renders `Region 2/2 · Cluster 2/2 · WorkerNode 24/24` as fully-present while the cluster actually has **6 live nodes, all region-a** — a declared-not-live count fabrication (filed #4814).

## Root cause
`buildTopology` (products/catalyst/bootstrap/api/internal/infrastructure/topology_loader.go) resolves a per-region dynamic client via `perRegionDynamicClient`. For a declared secondary region whose own `<depID>-<region>` kubeconfig never registered in the k8sCache (standby-region-absent), that returns nil, and the loop **fell back to the primary region's client**. `buildRegion` then emitted the secondary's **declared** `WorkerCount` as present, mirroring the primary's live contents → the 24/24 fabrication.

## Fix
Guard the fallback to the **multi-cluster case only**: when the k8sCache is populated but this secondary's kubeconfig is absent, emit a **degraded, live-empty** `Region` (`buildAbsentRegion` — no Clusters → 0 live nodes, `Status: degraded`, declared `WorkerCount` retained as the total). The FE derives the live count from `len(Clusters[*].Nodes)`, so this yields an honest "0 live / N declared" and a degraded badge instead of `2/2`/`24/24`.

**K8sCache-nil legacy/single-cluster mode keeps the primary-client fallback unchanged** (that path has no multi-cluster data — the fallback is correct there).

## Tests
- Adds `TestLoad_SecondaryAbsentKubeconfigRendersDegraded` (populated cache, secondary kubeconfig absent → degraded + 0 clusters + no primary mirroring).
- Existing `TestLoad_PerRegionFallsBackToPrimaryWhenCacheNil` (legacy) and `TestLoad_PerRegionLiveClientFanOut` (present regions) still pass.
- `go build` + `go vet` + `go test ./internal/infrastructure/...` all green.

## Verify (post-roll)
On a region-b-absent 2-region prov, the cloud graph should render `Region 1/2` (or region-b degraded) + `WorkerNode <live>/<declared>`, not `2/2` / `24/24`. Closes UAT #4814 once the catalyst-api chart is bumped + rolled.

Refs #4814 #4811

🤖 Generated with [Claude Code](https://claude.com/claude-code)