### PR TITLE
fix(#4818): cloud-view LB front door — hostPort datapath, not '(NodePort)'

### DIFF
--- a/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader.go
+++ b/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader.go
@@ -698,7 +698,8 @@ func buildLBs(in LoaderInput, rs provisioner.RegionSpec) []LoadBalancer {
 // DEPLOYMENT RECORD (Result.LoadBalancerIP) — the source of truth that is
 // always populated post-Phase-0 — rather than the empty Crossplane XRC
 // layer (Refs #3998). On Hetzner the IP is a real `hcloud_load_balancer`;
-// on Huawei kom4dc it is the EIP DNAT'd to the Cilium Gateway NodePort
+// on Huawei it is an EIP whose ELB targets node:443/:80 — the cilium-envoy
+// hostNetwork host port (§854 / #4765, NOT a nodePort)
 // (FrontDoorKind distinguishes them so the UI can explain the datapath).
 //
 // Both the declared (mothership) path and the live chroot path call this,
@@ -722,9 +723,10 @@ func frontDoorLBs(in LoaderInput, region string) []LoadBalancer {
 		{Port: 443, Protocol: "tcp"},
 		{Port: 6443, Protocol: "tcp"},
 	}
-	// FrontDoorKind: Huawei has no day-2 ELB instantiated (the EIP DNATs
-	// straight to the Gateway NodePort), so model it as gateway-eip;
-	// every other provider provisions a real cloud LB.
+	// FrontDoorKind: on Huawei the gateway ELB targets node:443/:80 — the
+	// cilium-envoy hostNetwork host port (§854 / #4765, NOT a nodePort) —
+	// so model it as gateway-eip; every other provider provisions a real
+	// cloud LB.
 	frontDoor := "cloud-lb"
 	if strings.EqualFold(in.Provider, "huawei") {
 		frontDoor = "gateway-eip"

--- a/products/catalyst/bootstrap/api/internal/infrastructure/types.go
+++ b/products/catalyst/bootstrap/api/internal/infrastructure/types.go
@@ -141,9 +141,9 @@ type VCluster struct {
 
 // LoadBalancer — the cloud front door fronting the cluster's ingress.
 // Provider-agnostic (Refs #3998): on Hetzner this is a real
-// `hcloud_load_balancer`; on Huawei kom4dc (no day-2 ELB instantiated)
-// it is the EIP DNAT'd to the Cilium-Gateway NodePort. Either way the
-// PublicIP + listeners are sourced from the deployment record
+// `hcloud_load_balancer`; on Huawei the gateway ELB targets node:443/:80,
+// the cilium-envoy hostNetwork host port (§854 / #4765 — NOT a nodePort).
+// Either way the PublicIP + listeners are sourced from the deployment record
 // (`Result.LoadBalancerIP`) — NOT the empty Crossplane XRC layer — so
 // the page answers "how is the platform fronted" on every Sovereign.
 type LoadBalancer struct {
@@ -166,7 +166,8 @@ type LoadBalancer struct {
 
 	// FrontDoorKind — provider-agnostic descriptor of HOW the cluster is
 	// fronted: "cloud-lb" (a real provider LB, e.g. Hetzner hcloud LB) or
-	// "gateway-eip" (Huawei EIP DNAT'd to the Cilium Gateway NodePort).
+	// "gateway-eip" (Huawei EIP whose ELB targets node:443/:80 — the
+	// cilium-envoy hostNetwork host port, §854 / #4765, NOT a nodePort).
 	// Lets the UI explain the EIP+Gateway datapath when no cloud LB exists
 	// (Refs #3998). Empty when unknown.
 	FrontDoorKind string `json:"frontDoorKind,omitempty"`

--- a/products/catalyst/bootstrap/ui/src/lib/infrastructure.types.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/infrastructure.types.ts
@@ -137,8 +137,9 @@ export interface LoadBalancerSpec {
   /**
    * Provider-agnostic descriptor of HOW the cluster is fronted (Refs #3998):
    * - 'cloud-lb'    — a real provider load balancer (e.g. Hetzner hcloud LB).
-   * - 'gateway-eip' — a cloud EIP DNAT'd to the Cilium Gateway NodePort
-   *                   (Huawei kom4dc, where no day-2 ELB is instantiated).
+   * - 'gateway-eip' — a cloud EIP whose ELB targets node:443/:80, the
+   *                   cilium-envoy hostNetwork host port (§854 / #4765 / #4706
+   *                   — NOT a nodePort; the gateway is served DIRECT).
    * Lets the LB view explain the EIP+Gateway datapath. Optional —
    * absent on older API builds.
    */

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-network/LoadBalancersPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-network/LoadBalancersPage.test.tsx
@@ -15,7 +15,7 @@ import {
 } from '@tanstack/react-router'
 
 import { CloudPage } from '../CloudPage'
-import { LoadBalancersPage } from './LoadBalancersPage'
+import { LoadBalancersPage, formatFrontDoor } from './LoadBalancersPage'
 import { infrastructureTopologyFixture } from '@/test/fixtures/infrastructure-topology.fixture'
 import { useWizardStore } from '@/entities/deployment/store'
 import { INITIAL_WIZARD_STATE } from '@/entities/deployment/model'
@@ -82,5 +82,21 @@ describe('LoadBalancersPage', () => {
     expect(body.textContent).toContain('116.203.42.1')
     expect(body.textContent).toContain('tcp:80')
     expect(body.textContent).toContain('tcp:443')
+  })
+
+  // #4818 — the Huawei gateway front door is served DIRECT via the cilium-envoy
+  // hostNetwork host port node:443/:80 (§854 / #4765 / #4706), NOT a nodePort.
+  // The label must never print "NodePort" — that falsely advertises the exact
+  // datapath the founder's absolute hard rule forbids.
+  describe('formatFrontDoor', () => {
+    it('gateway-eip renders the hostPort datapath, never "NodePort"', () => {
+      const label = formatFrontDoor({ frontDoorKind: 'gateway-eip' } as never)
+      expect(label).not.toContain('NodePort')
+      expect(label).toContain('hostPort')
+      expect(label).toContain('node:443/:80')
+    })
+    it('cloud-lb renders a real provider load balancer', () => {
+      expect(formatFrontDoor({ frontDoorKind: 'cloud-lb' } as never)).toBe('Cloud load balancer')
+    })
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-network/LoadBalancersPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-network/LoadBalancersPage.tsx
@@ -81,13 +81,15 @@ function formatListeners(lb: LoadBalancerSpec): string {
 }
 
 // formatFrontDoor explains the real ingress datapath (Refs #3998): a real
-// cloud LB vs an EIP DNAT'd to the Cilium Gateway NodePort (Huawei).
-function formatFrontDoor(lb: LoadBalancerSpec): string {
+// cloud LB vs an EIP whose ELB targets node:443/:80 — the cilium-envoy
+// hostNetwork host port (§854 / #4765 / #4706), NOT a nodePort. The gateway
+// is served DIRECT; there is no nodePort anywhere in the datapath.
+export function formatFrontDoor(lb: LoadBalancerSpec): string {
   switch (lb.frontDoorKind) {
     case 'cloud-lb':
       return 'Cloud load balancer'
     case 'gateway-eip':
-      return 'EIP → Cilium Gateway (NodePort)'
+      return 'EIP → Cilium Gateway (hostPort node:443/:80)'
     default:
       return '—'
   }


### PR DESCRIPTION
## What

The Cloud → Load Balancers **Front door** detail rendered `EIP → Cilium Gateway (NodePort)` for every Huawei `gateway-eip` front door. That is **factually wrong** and prints the exact term the founder's absolute §854 hard rule forbids.

The authoritative terraform (`infra/providers/huawei/main.tf` — `huaweicloud_elb_pool.https/.http` + listeners, tagged §854 / #4765 / #4706) targets the ELB at **node:443/:80 = the cilium-envoy hostNetwork HOST PORT, explicitly "NOT a nodePort"**. cilium-envoy is a hostNetwork DaemonSet (gateway-api hostNetwork mode #4706) binding node:443/:80 on every node. So the live datapath is `EIP/ELB → node:443/:80 (hostPort)` — §854-**compliant**, no nodePort. The label misrepresented a compliant datapath as a hard-rule violation.

## Changes
- `LoadBalancersPage.formatFrontDoor`: `gateway-eip` → **`EIP → Cilium Gateway (hostPort node:443/:80)`**; exported + regression test asserting the label never contains `NodePort` and does contain `hostPort` / `node:443/:80`.
- Corrected the stale `DNAT'd to the Cilium Gateway NodePort` comments in `infrastructure.types.ts`, backend `types.go`, and `topology_loader.go` (the `FrontDoorKind` model feeding the label).

## Verification
- Surfaced live on hw228 (dep `ac35eda8561b7922`): `/cloud?view=list&kind=load-balancers` → LB `hw228.omantel.biz` → Front door "(NodePort)", Public IP `212.72.24.43`.
- Root cause confirmed against IaC: pool/listener descriptions say node:443/:80 hostPort, "NOT a nodePort (§854 / #4765)".
- Gate: `npx vitest run LoadBalancersPage.test.tsx` → 4 passed; `tsc -b` clean; `go build ./...` + `go vet` + `go test ./internal/infrastructure/...` all pass.

Follow-up (not in this PR): `infra/providers/huawei/main.tf:~913` prose comment still says `node:<gateway-Service-nodePort>` — contradicts the authoritative resource descriptions 40 lines below; worth a doc-only cleanup.

Refs #4818 #4765 #4706 #3998

🤖 Generated with [Claude Code](https://claude.com/claude-code)