### PR TITLE
fix(#4821): customer-Org vcluster — replicateServices.fromHost, not sync.fromHost.services

### DIFF
--- a/core/controllers/organization/internal/gitops/manifests.go
+++ b/core/controllers/organization/internal/gitops/manifests.go
@@ -329,22 +329,27 @@ spec:
       fromHost:
         ingressClasses:
           enabled: true
-        # #4739/#4803: mirror the HOST keycloak Service INTO the vcluster so a
-        # vcluster-hosted app (bp-openclaw) resolves keycloak.keycloak.svc.
-        # cluster.local and fetches the realm JWKS IN-CLUSTER — dodging the
-        # kom4dc NAT-EIP hairpin that 503s /readyz when the JWKS is pulled from
-        # the public issuer's EXTERNAL jwks_uri (the gateway EIP, unreachable
-        # from a Pod on kom4dc). Pairs with openclaw's OIDC_INTERNAL_ISSUER_URL
-        # seam (#4803): the overlay sets it to
-        # http://keycloak.keycloak.svc.cluster.local/realms/<realm> and this
-        # mapping makes that name resolve inside the vcluster. vcluster 0.33
-        # config-v2 fromHost.services.mappings.byName ("host-ns/name":
-        # "virtual-ns/name").
-        services:
-          enabled: true
-          mappings:
-            byName:
-              "keycloak/keycloak": "keycloak/keycloak"
+    # #4739/#4803/#4821: mirror the HOST keycloak Service INTO the vcluster so a
+    # vcluster-hosted app (bp-openclaw) resolves keycloak.keycloak.svc.cluster.
+    # local and fetches the realm JWKS IN-CLUSTER — dodging the kom4dc NAT-EIP
+    # hairpin that 503s /readyz when the JWKS is pulled from the public issuer's
+    # EXTERNAL jwks_uri (the gateway EIP, unreachable from a Pod on kom4dc).
+    # Pairs with openclaw's OIDC_INTERNAL_ISSUER_URL seam (#4803).
+    #
+    # #4821: loft vcluster 0.33.4 has NO sync.fromHost.services key — its
+    # values.schema.json rejects it ("Additional property services is not
+    # allowed"), so the vcluster HelmRelease InstallFailed and the ENTIRE
+    # customer-Org provision stalled (dns/certs/keycloak/registry never ran;
+    # first surfaced on the first real customer-Org vcluster prov, hw228 acme).
+    # The correct vcluster config to import a host Service is
+    # networking.replicateServices.fromHost (a list of {from,to} — host-ns/svc
+    # to virtual-ns/svc) — the same key the platform's bp-mgmt-vcluster chart
+    # uses for shared-pg.
+    networking:
+      replicateServices:
+        fromHost:
+          - from: keycloak/keycloak
+            to: keycloak/keycloak
 `
 
 // resourceQuotaTemplate caps the Org boundary host namespace at the plan the


### PR DESCRIPTION
## What

The org-controller's per-Org vcluster HelmRelease (`core/controllers/organization/internal/gitops/manifests.go`) passed an **invalid vcluster config key**, stalling **every** customer-Org provision.

### Root cause (reproduced live on hw228 — first real customer-Org vcluster prov)
Drove the marketplace funnel E2E → customer Org **acme** (Plan-M → vcluster tier). The vcluster HelmRelease **InstallFailed**:
```
Helm install failed for release acme/vcluster with chart vcluster@0.33.4:
values don't meet the specifications of the schema(s):
- sync.fromHost: Additional property services is not allowed
```
`manifests.go` emitted (per #4804 — mirror host `keycloak/keycloak` Service into the vcluster for in-cluster JWKS, dodging the kom4dc NAT-EIP hairpin):
```yaml
sync:
  fromHost:
    services:
      enabled: true
      mappings: { byName: { "keycloak/keycloak": "keycloak/keycloak" } }
```
I pulled loft **vcluster 0.33.4** and confirmed its `values.schema.json` has **no `sync.fromHost.services`** key (fromHost supports events/configMaps/secrets/nodes/ingressClasses/csiDrivers/… only). The #4804 comment's assumption ("vcluster 0.33 config-v2 fromHost.services.mappings.byName") is false for the pinned chart. Result: vcluster HR never Ready → the whole org provision stalls at `dns:pending` (certs/keycloak/registry never run; WordPress day-2 also fails). Never caught before because hw227's acme was **namespace-tier** (#4813), so this vcluster path had never run on a real prov.

### Fix
Use the correct vcluster key **`networking.replicateServices.fromHost`** (a list of `{from,to}`) — verified against loft 0.33.4's schema (`FromHost defines the services that should get synced from the host to the virtual cluster`) AND identical to the key the platform's own `bp-mgmt-vcluster` chart uses for shared-pg. Same intent, valid schema, non-regressing to #4803/#4804.

## Verification
- `go build ./...` + `go vet` + `go test ./organization/internal/gitops/` all green (org-controller module).
- Schema-verified: `helm pull vcluster --repo https://charts.loft.sh --version 0.33.4` → `networking.replicateServices.fromHost` present; `sync.fromHost.services` absent.
- **Needs a fresh customer-Org vcluster prov to confirm end-to-end** (acme on hw228 won't retroactively fix — the org record is already stalled). UAT rows 86/88/89/226 + topology 13/46-49 unblock once a customer Org completes.

Refs #4821 #4804 #4803 #4292

🤖 Generated with [Claude Code](https://claude.com/claude-code)