### PR TITLE
fix(#4785): register Gateway-API HTTPRoute CRD in per-Org vcluster

### DIFF
--- a/core/controllers/organization/internal/gitops/manifests.go
+++ b/core/controllers/organization/internal/gitops/manifests.go
@@ -350,6 +350,55 @@ spec:
         fromHost:
           - from: keycloak/keycloak
             to: keycloak/keycloak
+    # #4785: REGISTER the Gateway-API HTTPRoute CRD inside the per-Org vcluster so
+    # a customer app's chart (bp-wordpress etc.) can CREATE its ingress HTTPRoute.
+    # A vanilla vcluster has NO gateway.networking.k8s.io CRD, and vcluster 0.33.4
+    # sync.toHost.customResources (above) does NOT register the CRD in the vcluster
+    # apiserver — it only reflects instances host-ward — so the kubeConfig-targeted
+    # tenant-<slug>-apps Kustomization dry-run fails 'no matches for kind HTTPRoute
+    # in gateway.networking.k8s.io/v1' and wedges the ENTIRE app tree (no customer
+    # app ever serves). VALIDATED live on hw228 acme 2026-07-06: the moment this
+    # CRD was registered the apps Kustomization flipped False->Ready/Applied and
+    # WordPress+MySQL reached 1/1 Running. A STRUCTURAL stub
+    # (x-kubernetes-preserve-unknown-fields) is sufficient — the vcluster only needs
+    # to ACCEPT the create; the HOST Cilium Gateway-API operator holds the
+    # authoritative full schema + does the real validation when toHost reflects the
+    # route. Same mechanism bp-mgmt-vcluster uses (values.yaml experimental.deploy,
+    # proven hw130) — see #4785 conclusive diagnosis.
+    experimental:
+      deploy:
+        vcluster:
+          manifests: |
+            apiVersion: apiextensions.k8s.io/v1
+            kind: CustomResourceDefinition
+            metadata:
+              name: httproutes.gateway.networking.k8s.io
+              annotations:
+                api-approved.kubernetes.io: "https://github.com/kubernetes-sigs/gateway-api/pull/1111"
+                catalyst.openova.io/managed-by: org-controller
+            spec:
+              group: gateway.networking.k8s.io
+              scope: Namespaced
+              names:
+                kind: HTTPRoute
+                listKind: HTTPRouteList
+                plural: httproutes
+                singular: httproute
+              versions:
+                - name: v1
+                  served: true
+                  storage: true
+                  schema:
+                    openAPIV3Schema:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                - name: v1beta1
+                  served: true
+                  storage: false
+                  schema:
+                    openAPIV3Schema:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
 `
 
 // resourceQuotaTemplate caps the Org boundary host namespace at the plan the

--- a/core/controllers/organization/internal/gitops/manifests_test.go
+++ b/core/controllers/organization/internal/gitops/manifests_test.go
@@ -266,6 +266,40 @@ func TestRender_LimitRangeNoRatioForVclusterOrg(t *testing.T) {
 	}
 }
 
+// TestRender_VclusterRegistersHTTPRouteCRD_4785 locks in the #4785 fix: the per-Org
+// vcluster HR must register the Gateway-API HTTPRoute CRD via
+// experimental.deploy.vcluster.manifests so a customer app's chart (bp-wordpress)
+// can CREATE its ingress HTTPRoute. vcluster 0.33.4 sync.toHost.customResources does
+// NOT register the CRD (only reflects instances host-ward), so without this the
+// tenant-<slug>-apps Kustomization dry-run fails "no matches for kind HTTPRoute" and
+// wedges every customer app. Validated live on hw228 acme 2026-07-06 — WordPress+MySQL
+// reached 1/1 Running the moment this CRD was registered.
+func TestRender_VclusterRegistersHTTPRouteCRD_4785(t *testing.T) {
+	t.Parallel()
+	out, err := Render(Inputs{Slug: "acme", DisplayName: "Acme", Tier: "org",
+		PlanSlug: "m", SovereignFQDN: "x.example", HostCluster: "hz", VClusterChartVersion: "0.33.*"})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	vc := string(out["vcluster/vcluster.yaml"])
+	for _, want := range []string{
+		"experimental:",
+		"deploy:",
+		"manifests: |",
+		"httproutes.gateway.networking.k8s.io",
+		"kind: HTTPRoute",
+		"x-kubernetes-preserve-unknown-fields: true",
+	} {
+		if !strings.Contains(vc, want) {
+			t.Errorf("#4785: vcluster.yaml must register the HTTPRoute CRD in the per-Org vcluster, missing %q", want)
+		}
+	}
+	var v any
+	if err := yaml.Unmarshal([]byte(vc), &v); err != nil {
+		t.Errorf("#4785: vcluster.yaml invalid YAML after the CRD-register block: %v", err)
+	}
+}
+
 // TestRender_NetworkPolicyBaselineInAppsTree proves the default-deny +
 // same-Org-allow baseline renders in the apps tree (so the syncer reflects it
 // to the host). The np-sync flag itself is asserted in TestRender_AllPaths.


### PR DESCRIPTION
## Problem
The first real vcluster-tier customer Org (hw228 `acme`) surfaced that **no purchased app can serve** in a per-Org vcluster. The app's `HTTPRoute` is applied into the Org-vcluster, but vcluster 0.33.4 `sync.toHost.customResources` (the #4792 4th layer) does **not register the CRD** in the vcluster apiserver — it only reflects instances host-ward. So `tenant-<slug>-apps` dry-runs against a vcluster with no `gateway.networking.k8s.io` kind → `no matches for kind "HTTPRoute"` → the whole app tree wedges.

Diagnosis chain (config present in the live syncer, RBAC OK, host CRD present, CRD still absent in vcluster) is on #4785.

## Fix
Register a **structural HTTPRoute CRD stub** (`x-kubernetes-preserve-unknown-fields: true`) via `experimental.deploy.vcluster.manifests` in the per-Org vcluster HR. The vcluster only needs to *accept* the create; the host Cilium Gateway-API operator holds the authoritative schema and validates when `sync.toHost` reflects the route. This mirrors the proven `bp-mgmt-vcluster` pattern (values.yaml, hw130).

## Validation
**Live on hw228 acme (2026-07-06):** manually registering this exact CRD into the acme vcluster flipped `catalyst-tenant-acme-apps` **False → Ready/Applied** and **WordPress + MySQL reached 1/1 Running**. This PR makes it zero-touch on every per-Org vcluster prov.

- `go build` / `go vet` / `go test ./organization/...` green
- new test `TestRender_VclusterRegistersHTTPRouteCRD_4785` locks the CRD into the rendered vcluster HR

Unblocks UAT rows 89/90/226 + convergence 224 once a fresh Plan-M+ prov runs on this image.

Refs #4785 #4292

🤖 Generated with [Claude Code](https://claude.com/claude-code)