### PR TITLE
fix(provisioning): kill WordPress per-Org double-reconcile churn — initial funnel workflow no longer authors apps into the global org-tenants tree on a Sovereign (Refs #4827)

### DIFF
--- a/core/services/provisioning/handlers/consumer.go
+++ b/core/services/provisioning/handlers/consumer.go
@@ -1381,66 +1381,106 @@ func (h *Handler) runProvisioningWorkflow(provisionID, tenantID, subdomain, plan
 
 	// --- Step: Generate manifests ---
 	h.markStep(ctx, provisionID, stepIdx, prov.Steps[stepIdx].Name, "running")
-	manifests := h.Generator.GenerateAllWithAppConfigs(subdomain, planSlug, appSlugs, "", appConfigs)
-	if len(manifests) == 0 {
-		h.failProvision(ctx, provisionID, tenantID, stepIdx, "failed to generate manifests")
-		return
-	}
-	slog.Info("generated manifests",
-		"provision_id", provisionID,
-		"tenant", subdomain,
-		"files", len(manifests),
-	)
-	h.completeStep(ctx, provisionID, tenantID, stepIdx, prov.Steps[stepIdx].Name, totalSteps)
-	stepIdx++
 
-	// --- Step: Commit to Git ---
-	h.markStep(ctx, provisionID, stepIdx, prov.Steps[stepIdx].Name, "running")
+	// #4827 — On a Sovereign (PerOrgGitops) the customer's Applications are
+	// authored ONLY into the per-Org `<slug>/catalyst-tenant` repo: the
+	// org-controller bootstraps that repo's `vcluster/apps` tree + its
+	// `catalyst-tenant-<slug>-apps` Flux Kustomization, and each cart app's
+	// tenant.app_install_requested event drives applyTenantChangePerOrg to
+	// commit there (branch `main`, DB password read-preserved from that same
+	// tree). Authoring the SAME apps ALSO into the global `org-tenants` catalog
+	// tree here (the legacy contabo path) mints a SECOND, divergent apps tree
+	// with an independently-generated random DB password; that tree's
+	// `tenant-<slug>-apps` Kustomization AND the per-Org
+	// `catalyst-tenant-<slug>-apps` Kustomization then both reconcile the SAME
+	// WordPress Deployment INTO the vCluster (identical name/namespace, both
+	// prune=true) with two different *plaintext* WORDPRESS_DB_PASSWORD values,
+	// so the WordPress pod template flip-flops on every reconcile → endless
+	// rollout churn → intermittent HTTP 500. (The MySQL pod is immune: it
+	// consumes creds via `envFrom secretRef: mysql-credentials`, a
+	// template-stable reference by NAME, so its template is byte-identical
+	// across both trees and it never rolls.) The PerOrgGitops contract is
+	// explicit — "the global repo is the WRONG target for per-Org apps on a
+	// Sovereign" — and everything the org-tenants overlay carried lives in the
+	// per-Org tree (the #4785 in-vCluster HTTPRoute datapath, the networkpolicy
+	// baseline, the vCluster CR; the org-tenants overlay's only extras were a
+	// legacy `kind: Ingress` + per-tenant RBAC, both inert on a Gateway-API
+	// Sovereign). So on a Sovereign this legacy monolithic workflow authors
+	// NOTHING to git — it completes the generate + commit timeline steps as a
+	// no-op and proceeds to OBSERVE the per-Org-delivered vCluster pods for the
+	// funnel progress UI.
+	if h.PerOrgGitops {
+		h.completeStepWithMessage(ctx, provisionID, tenantID, stepIdx, prov.Steps[stepIdx].Name, totalSteps,
+			"per-Org Sovereign — Applications authored in the Org's catalyst-tenant repo (not the global org-tenants tree)")
+		stepIdx++
 
-	if h.GitHubClient == nil {
-		h.failProvision(ctx, provisionID, tenantID, stepIdx, "GitHub client not configured")
-		return
-	}
+		// --- Step: Commit to Git (owned by the per-Org app-install path) ---
+		h.markStep(ctx, provisionID, stepIdx, prov.Steps[stepIdx].Name, "running")
+		h.completeStepWithMessage(ctx, provisionID, tenantID, stepIdx, prov.Steps[stepIdx].Name, totalSteps,
+			"per-Org Sovereign — manifests committed to the Org's catalyst-tenant repo by the app-install path")
+		stepIdx++
+	} else {
+		manifests := h.Generator.GenerateAllWithAppConfigs(subdomain, planSlug, appSlugs, "", appConfigs)
+		if len(manifests) == 0 {
+			h.failProvision(ctx, provisionID, tenantID, stepIdx, "failed to generate manifests")
+			return
+		}
+		slog.Info("generated manifests",
+			"provision_id", provisionID,
+			"tenant", subdomain,
+			"files", len(manifests),
+		)
+		h.completeStep(ctx, provisionID, tenantID, stepIdx, prov.Steps[stepIdx].Name, totalSteps)
+		stepIdx++
 
-	parentKustomPath := h.Generator.BasePath + "/kustomization.yaml"
+		// --- Step: Commit to Git ---
+		h.markStep(ctx, provisionID, stepIdx, prov.Steps[stepIdx].Name, "running")
 
-	// Issue #944 cross-cluster pollution guard. Validate the parent
-	// kustomization path AND the per-tenant subdir live under the
-	// configured GIT_BASE_PATH before any commit lands.
-	if err := h.VerifyCommitTargetSafe(parentKustomPath); err != nil {
-		slog.Error("commit guard rejected provision target", "provision_id", provisionID, "path", parentKustomPath, "error", err)
-		h.failProvision(ctx, provisionID, tenantID, stepIdx, fmt.Sprintf("commit guard: %s", err))
-		return
-	}
-	if err := h.VerifyCommitTargetSafe(h.Generator.TenantDir(subdomain) + "/"); err != nil {
-		slog.Error("commit guard rejected tenant target", "provision_id", provisionID, "tenant", subdomain, "error", err)
-		h.failProvision(ctx, provisionID, tenantID, stepIdx, fmt.Sprintf("commit guard: %s", err))
-		return
-	}
+		if h.GitHubClient == nil {
+			h.failProvision(ctx, provisionID, tenantID, stepIdx, "GitHub client not configured")
+			return
+		}
 
-	branch := h.GitBranch
-	if branch == "" {
-		branch = "main"
-	}
+		parentKustomPath := h.Generator.BasePath + "/kustomization.yaml"
 
-	// Re-read the parent kustomization on EACH commit attempt so a concurrent
-	// teardown's removal of another slug doesn't get reverted by our retry
-	// replaying a stale files map (live race observed 2026-05-06: multitest
-	// provision's retry resurrected the just-deleted bookcheck slug). The
-	// #4250 sibling-prune guard lives in provisionParentRebuild.
-	rebuild := func(ctx context.Context) (map[string]string, error) {
-		return h.provisionParentRebuild(ctx, branch, parentKustomPath, subdomain, manifests)
-	}
+		// Issue #944 cross-cluster pollution guard. Validate the parent
+		// kustomization path AND the per-tenant subdir live under the
+		// configured GIT_BASE_PATH before any commit lands.
+		if err := h.VerifyCommitTargetSafe(parentKustomPath); err != nil {
+			slog.Error("commit guard rejected provision target", "provision_id", provisionID, "path", parentKustomPath, "error", err)
+			h.failProvision(ctx, provisionID, tenantID, stepIdx, fmt.Sprintf("commit guard: %s", err))
+			return
+		}
+		if err := h.VerifyCommitTargetSafe(h.Generator.TenantDir(subdomain) + "/"); err != nil {
+			slog.Error("commit guard rejected tenant target", "provision_id", provisionID, "tenant", subdomain, "error", err)
+			h.failProvision(ctx, provisionID, tenantID, stepIdx, fmt.Sprintf("commit guard: %s", err))
+			return
+		}
 
-	commitMsg := fmt.Sprintf("provision: deploy tenant %s (plan: %s, apps: %d)", subdomain, planSlug, len(appSlugs))
-	if err := h.GitHubClient.CommitFilesWithPruneAndRebuild(ctx, branch, commitMsg, nil, nil, rebuild); err != nil {
-		slog.Error("failed to commit manifests", "provision_id", provisionID, "error", err)
-		h.failProvision(ctx, provisionID, tenantID, stepIdx, fmt.Sprintf("git commit failed: %s", err))
-		return
+		branch := h.GitBranch
+		if branch == "" {
+			branch = "main"
+		}
+
+		// Re-read the parent kustomization on EACH commit attempt so a concurrent
+		// teardown's removal of another slug doesn't get reverted by our retry
+		// replaying a stale files map (live race observed 2026-05-06: multitest
+		// provision's retry resurrected the just-deleted bookcheck slug). The
+		// #4250 sibling-prune guard lives in provisionParentRebuild.
+		rebuild := func(ctx context.Context) (map[string]string, error) {
+			return h.provisionParentRebuild(ctx, branch, parentKustomPath, subdomain, manifests)
+		}
+
+		commitMsg := fmt.Sprintf("provision: deploy tenant %s (plan: %s, apps: %d)", subdomain, planSlug, len(appSlugs))
+		if err := h.GitHubClient.CommitFilesWithPruneAndRebuild(ctx, branch, commitMsg, nil, nil, rebuild); err != nil {
+			slog.Error("failed to commit manifests", "provision_id", provisionID, "error", err)
+			h.failProvision(ctx, provisionID, tenantID, stepIdx, fmt.Sprintf("git commit failed: %s", err))
+			return
+		}
+		slog.Info("committed manifests to GitHub", "provision_id", provisionID, "tenant", subdomain)
+		h.completeStep(ctx, provisionID, tenantID, stepIdx, prov.Steps[stepIdx].Name, totalSteps)
+		stepIdx++
 	}
-	slog.Info("committed manifests to GitHub", "provision_id", provisionID, "tenant", subdomain)
-	h.completeStep(ctx, provisionID, tenantID, stepIdx, prov.Steps[stepIdx].Name, totalSteps)
-	stepIdx++
 
 	// --- Step: Wait for vCluster HelmRelease Ready ---
 	// #4297 TIER GATE — vcluster-only. The "Provisioning vCluster" step stays in


### PR DESCRIPTION
## Root cause (live-confirmed on hw228, acme vCluster, 2026-07-07)

The funnel Org **acme**'s WordPress pod churns every ~1 min → intermittent HTTP 000/500. The in-vCluster `Deployment/wordpress` reached **generation 34 in ~87 min**, its ReplicaSet hash alternating `5975dc645f` ↔ `68d478cfbf`.

**Two Flux Kustomizations reconcile the SAME `wordpress` Deployment into the acme vCluster:**

| Kustomization | Source | DB password | Correct? |
|---|---|---|---|
| `catalyst-tenant-acme-apps` | per-Org gitea `acme/catalyst-tenant` `vcluster/apps` | `811a2f…` | ✅ matches live MySQL init (`mysqli_connect` OK) |
| `tenant-acme-apps` | global `openova-org-tenants` `clusters/hw228.omantel.biz/org-tenants/acme/apps` | `0d3557…` | ❌ stale/wrong |

Both target the same vCluster (same `tenant-acme-kubeconfig`), same ns, both `prune: true`. The **only** diff between the two ReplicaSet pod-templates is the plaintext `WORDPRESS_DB_PASSWORD` / `MYSQL_PASSWORD` env value (`811a2f…` vs `0d3557…`). Because WordPress embeds the password as a **plaintext env value**, the two Kustomizations fight over the pod template → rollout on every reconcile → the fresh pod that lands on `0d3557…` fails MySQL auth → HTTP 500.

**MySQL never churns** because its Deployment consumes creds via `envFrom: secretRef: mysql-credentials` — a template-stable reference *by name* → byte-identical template across both trees.

### Why two trees exist

- `runProvisioningWorkflow` (event `order.placed`) commits the apps into the **global** `org-tenants` catalog tree with a **freshly-minted random** password — unconditionally, with no `PerOrgGitops` gate.
- `applyTenantChangePerOrg` (event `tenant.app_install_requested`) already **honors `PerOrgGitops`** and commits the apps into the **per-Org** `catalyst-tenant` repo.

On a Sovereign both fire for the same cart → two divergent trees → double-reconcile. The `PerOrgGitops` doc is explicit: *"the global repo is the WRONG target for per-Org apps on a Sovereign."* The initial path simply never got the gate the day-2 path has.

## Fix

Gate the initial workflow's manifest-generate + git-commit on `PerOrgGitops` (mirroring the day-2 handler's existing `if h.PerOrgGitops { … }`). On a Sovereign the initial workflow now authors **nothing** to git — it completes the generate + commit timeline steps as a no-op and proceeds to **observe** the per-Org-delivered vCluster pods for the funnel progress UI. The per-Org `catalyst-tenant` repo (org-controller + app-install path) is the single source of truth.

**Nothing lost:** the #4785 in-vCluster HTTPRoute datapath (`httproute/app-wordpress` → `wordpress.acme.omani.homes`), the networkpolicy baseline, and the vCluster CR all live in the per-Org tree. The org-tenants overlay's only extras were a legacy `kind: Ingress` + per-tenant RBAC — both inert on a Gateway-API Sovereign.

**Non-Sovereign (contabo, `PerOrgGitops=false`) path unchanged.**

## MUST-PRESERVE

- ✅ #4785 datapath (in-vCluster HTTPRoute) — lives in the per-Org tree, untouched.
- ✅ WP↔MySQL creds that currently match (`811a2f…`) — the per-Org tree (the matching one) becomes the *sole* reconciler; the divergent `0d3557…` tree stops being authored.

## Tests

`go build ./...`, `go vet ./handlers/`, and the full provisioning module suite (`handlers` / `gitops` / `github` / `store` / `gitguard`) all pass. The gate lives inside `runProvisioningWorkflow`'s in-cluster-only goroutine (k8s-API + Gitea side effects, no injectable seam — the codebase intentionally integration-verifies this body, not unit-tests it), so behavioral proof is the fresh-prov funnel walk.

### Live cleanup for the already-provisioned hw228 acme
This PR prevents recurrence on any fresh Org. The existing stale `clusters/hw228.omantel.biz/org-tenants/acme/` overlay in gitea must be removed once (the parent `org-tenants` Kustomization's prune then GCs `tenant-acme-apps`) to stop the *current* live churn.

Refs #4827 #4785 #4384