### PR TITLE
fix(#4811): retriable startup ClusterMesh reconcile on transient kubeconfig miss

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -224,6 +224,18 @@ const (
 	// on the next pass. The Handler field clusterMeshSteadyStateInterval
 	// overrides this for tests; zero falls back to the default below.
 	clusterMeshSteadyStateIntervalDefault = 5 * time.Minute
+
+	// #4811 — startup mesh-reconcile retry cadence + budget. When
+	// restoreFromStore finds a ready multi-region deployment whose primary
+	// kubeconfig is unresolved (the k8scache dir-load race — the file is on the
+	// PVC but os.Stat missed it by a few ms), retryStartupClusterMeshReconcile
+	// re-evaluates shouldStartupClusterMeshReconcile on this interval and
+	// launches the establish the first time it resolves, giving up after the
+	// budget so a genuinely-lost kubeconfig stops instead of spinning forever.
+	// The Handler fields clusterMeshStartupRetry* override these for tests;
+	// zero falls back to the defaults below.
+	clusterMeshStartupRetryIntervalDefault = 5 * time.Second
+	clusterMeshStartupRetryBudgetDefault   = 3 * time.Minute
 )
 
 // ClusterMesh-gated cnpg-pair enable (#3236) — names of the Flux
@@ -2842,6 +2854,39 @@ func (h *Handler) resolvePrimaryKubeconfigPath(dep *Deployment) (string, bool) {
 // loop's first attempt is a cheap idempotent re-run that confirms full
 // mesh and exits.
 func (h *Handler) shouldStartupClusterMeshReconcile(dep *Deployment) bool {
+	if !h.clusterMeshReconcileStatusGate(dep) {
+		return false
+	}
+	if _, ok := h.resolvePrimaryKubeconfigPath(dep); !ok {
+		dep.mu.Lock()
+		regionCount := len(dep.Request.Regions)
+		dep.mu.Unlock()
+		h.log.Warn("clustermesh: startup reconcile skipped — primary kubeconfig unresolved on ready multi-region deployment",
+			"id", dep.ID,
+			"regions", regionCount,
+		)
+		return false
+	}
+	return true
+}
+
+// clusterMeshReconcileStatusGate reports whether a rehydrated deployment's
+// status + region count make it a candidate for the startup ClusterMesh
+// reconcile — the STATUS/REGION half of shouldStartupClusterMeshReconcile,
+// factored out for #4811 so restoreFromStore can tell "not a mesh candidate at
+// all" (single-region, hard-failed) apart from "mesh candidate whose primary
+// kubeconfig was merely UNRESOLVED at restore". The latter is a TRANSIENT
+// condition — the kubeconfig FILE is on the PVC but the k8scache dir-load had
+// not finished when restoreFromStore ran, so os.Stat missed it — and must be
+// RETRIED (retryStartupClusterMeshReconcile) rather than skipped forever, which
+// is exactly the bug that left region-b ClusterMesh 0/1 across every OOM
+// restart.
+//
+// ready, OR failed-by-TIMEOUT (#3285/hw130): a timeout record's cluster keeps
+// converging under Flux — abandoning its mesh forever contradicted the
+// never-wipe-a-timeout doctrine. Hard failures (OutcomeFailed /
+// flux-not-reconciling) stay excluded.
+func (h *Handler) clusterMeshReconcileStatusGate(dep *Deployment) bool {
 	dep.mu.Lock()
 	status := dep.Status
 	regionCount := len(dep.Request.Regions)
@@ -2850,22 +2895,88 @@ func (h *Handler) shouldStartupClusterMeshReconcile(dep *Deployment) bool {
 		outcome = dep.Result.Phase1Outcome
 	}
 	dep.mu.Unlock()
-	// ready, OR failed-by-TIMEOUT (#3285/hw130): a timeout record's
-	// cluster keeps converging under Flux — abandoning its mesh forever
-	// contradicted the never-wipe-a-timeout doctrine. Hard failures
-	// (OutcomeFailed / flux-not-reconciling) stay excluded.
 	rescuableTimeout := status == "failed" && outcome == helmwatch.OutcomeTimeout
 	if (status != "ready" && !rescuableTimeout) || regionCount < 2 {
 		return false
 	}
-	if _, ok := h.resolvePrimaryKubeconfigPath(dep); !ok {
-		h.log.Warn("clustermesh: startup reconcile skipped — primary kubeconfig unresolved on ready multi-region deployment",
-			"id", dep.ID,
-			"regions", regionCount,
-		)
-		return false
-	}
 	return true
+}
+
+// retryStartupClusterMeshReconcile is the #4811 bounded self-heal for the
+// TRANSIENT "primary kubeconfig unresolved at restore" race. restoreFromStore
+// runs inside New(), sometimes milliseconds BEFORE the k8scache "loaded cluster
+// from kubeconfigs dir" step writes the primary kubeconfig file to the PVC — so
+// shouldStartupClusterMeshReconcile's resolvePrimaryKubeconfigPath os.Stat
+// misses the file and the gate returns false. The old code dropped the mesh
+// reconcile on the floor (a one-shot else-if), so the establish loop — which
+// carries the steady-state heal that REGENERATES a stale cilium-clustermesh
+// endpoint (the live #4811 symptom: the mesh endpoint stuck at the :2379 KINE
+// port instead of the :12379 proxy dial port → ClusterMesh 0/1 forever) — never
+// started, and every OOM restart re-lost the same race.
+//
+// This goroutine re-evaluates shouldStartupClusterMeshReconcile(dep) on
+// clusterMeshStartupRetryInterval and launches runAutoEstablishClusterMesh the
+// FIRST time it passes, then returns (the establish loop owns convergence +
+// steady-state from there; its own clusterMeshLoopActive guard makes any
+// double-start a no-op). It stops early when the deployment leaves the
+// ready/rescuable-timeout status gate (a wipe landed mid-wait — the kubeconfigs
+// are gone) and gives up after clusterMeshStartupRetryBudget so a genuinely-lost
+// kubeconfig (PVC unmount / wipe race) does NOT spin forever.
+func (h *Handler) retryStartupClusterMeshReconcile(dep *Deployment) {
+	defer func() {
+		if r := recover(); r != nil {
+			h.log.Error("clustermesh: startup reconcile retry panic recovered",
+				"id", dep.ID,
+				"panic", r,
+			)
+		}
+	}()
+
+	interval := h.clusterMeshStartupRetryInterval
+	if interval <= 0 {
+		interval = clusterMeshStartupRetryIntervalDefault
+	}
+	budget := h.clusterMeshStartupRetryBudget
+	if budget <= 0 {
+		budget = clusterMeshStartupRetryBudgetDefault
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), budget)
+	defer cancel()
+
+	h.log.Info("clustermesh: startup reconcile deferred — primary kubeconfig unresolved at restore; retrying until it lands on the PVC",
+		"id", dep.ID,
+		"interval", interval,
+		"budget", budget,
+	)
+
+	for attempt := 1; ; attempt++ {
+		// Stop the moment the deployment stops being a mesh candidate — a wipe
+		// mid-wait removes the kubeconfigs, so there is nothing left to mesh.
+		if !h.clusterMeshReconcileStatusGate(dep) {
+			h.log.Info("clustermesh: startup reconcile retry stopped — deployment no longer a ready multi-region mesh candidate",
+				"id", dep.ID,
+				"attempt", attempt,
+			)
+			return
+		}
+		if h.shouldStartupClusterMeshReconcile(dep) {
+			h.log.Info("clustermesh: startup reconcile primary kubeconfig resolved — launching establish loop",
+				"id", dep.ID,
+				"attempt", attempt,
+			)
+			go h.runAutoEstablishClusterMesh(dep)
+			return
+		}
+		if sleepErr := sleepCtx(ctx, interval); sleepErr != nil {
+			h.log.Warn("clustermesh: startup reconcile retry budget exhausted — primary kubeconfig never resolved; next trigger is a catalyst-api restart",
+				"id", dep.ID,
+				"attempts", attempt,
+				"err", sleepErr,
+			)
+			return
+		}
+	}
 }
 
 // emitClusterMeshProgress pushes a typed SSE event onto the deployment

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
@@ -1142,6 +1142,79 @@ func TestShouldStartupClusterMeshReconcile_ConventionalFallback(t *testing.T) {
 	})
 }
 
+// TestStartupClusterMeshRetry_SelfHealsTransientKubeconfigMiss is the #4811
+// regression: on a fresh 2-region Sovereign restore, restoreFromStore runs
+// inside New() sometimes MILLISECONDS before the k8scache dir-load writes the
+// primary kubeconfig file to the PVC. The record's omitempty
+// Result.KubeconfigPath is empty and the conventional file is not yet on disk,
+// so shouldStartupClusterMeshReconcile's os.Stat misses it and the one-shot
+// gate returns false. The OLD code dropped the mesh reconcile forever, so the
+// establish loop (and its steady-state heal that regenerates a stale
+// clustermesh endpoint) never started and region-b stayed ClusterMesh 0/1
+// across every OOM restart. The FIX starts a bounded retry that re-checks the
+// gate and launches the establish the moment the kubeconfig lands.
+func TestStartupClusterMeshRetry_SelfHealsTransientKubeconfigMiss(t *testing.T) {
+	fx := newTestFixture(t, []string{"203.0.113.10", "203.0.113.20"})
+	restore := installClusterMeshClientFactory(fx.clients)
+	defer restore()
+	restoreDyn := installClusterMeshDynamicClientFactory(fx.dynClients)
+	defer restoreDyn()
+
+	// Simulate the transient miss: the record lost its omitempty
+	// Result.KubeconfigPath AND the conventional primary file is not yet on the
+	// PVC when the reconcile is first evaluated.
+	fx.dep.mu.Lock()
+	fx.dep.Result.KubeconfigPath = ""
+	fx.dep.mu.Unlock()
+	if err := os.Remove(fx.primaryKubeconfigPath); err != nil {
+		t.Fatalf("remove primary kubeconfig to simulate transient miss: %v", err)
+	}
+
+	// Precondition: the one-shot gate skips right now (the bug), but the dep IS
+	// a ready multi-region mesh candidate — so the retry SHOULD arm.
+	if fx.handler.shouldStartupClusterMeshReconcile(fx.dep) {
+		t.Fatalf("precondition: gate must skip while the primary kubeconfig is absent")
+	}
+	if !fx.handler.clusterMeshReconcileStatusGate(fx.dep) {
+		t.Fatalf("precondition: a ready 2-region dep must pass the status gate so the retry arms")
+	}
+
+	// Sub-second knobs so the retry re-checks and the establish converges in ms.
+	fx.handler.clusterMeshStartupRetryInterval = 10 * time.Millisecond
+	fx.handler.clusterMeshStartupRetryBudget = 10 * time.Second
+	fx.handler.clusterMeshRetryInitialBackoff = 20 * time.Millisecond
+	fx.handler.clusterMeshRetryMaxBackoff = 60 * time.Millisecond
+	fx.handler.clusterMeshRetryBudget = 10 * time.Second
+	fx.handler.clusterMeshAttemptTimeout = 5 * time.Second
+	fx.handler.clusterMeshSteadyStateInterval = 20 * time.Millisecond
+
+	// Release the (blocking) steady-state heal once convergence lands so the
+	// establish goroutine returns cleanly.
+	stopSteady := watchAndStopSteadyStateOnConverged(fx)
+	defer stopSteady()
+
+	// Arm the bounded retry — it must NOT establish yet (file still absent).
+	go fx.handler.retryStartupClusterMeshReconcile(fx.dep)
+
+	// The kubeconfig FILE lands on the PVC shortly after (k8scache dir-load
+	// finishes). The retry's next poll now resolves it, passes the gate, and
+	// launches the establish → the mesh converges.
+	time.Sleep(40 * time.Millisecond)
+	if hasClusterMeshEvent(fx.dep, "info", "reconcile loop complete") {
+		t.Fatalf("establish fired before the kubeconfig landed — retry must not launch while the primary is unresolved")
+	}
+	writeFakeKubeconfig(t, fx.dir, fx.dep.ID, "") // re-creates <dir>/<id>.yaml (== fx.primaryKubeconfigPath)
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if hasClusterMeshEvent(fx.dep, "info", "reconcile loop complete") {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("startup mesh reconcile never fired after the transient kubeconfig miss self-healed; events:\n%s", dumpClusterMeshEvents(fx.dep))
+}
+
 // TestBuildRegionSlots_SecondaryConventionalFallback documents + locks in
 // the part-2 finding: secondary region kubeconfigs are resolved from the
 // conventional `<kubeconfigsDir>/<id>-<region>-<idx>.yaml` filesystem path

--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -527,6 +527,7 @@ func (h *Handler) restoreFromStore() {
 
 	resumed := 0
 	meshReconciles := 0
+	meshRetries := 0
 	spineReconciles := 0
 	for _, rec := range records {
 		dep := fromRecord(rec)
@@ -599,6 +600,22 @@ func (h *Handler) restoreFromStore() {
 			// kubeconfigs are warn-and-skipped inside the should-helper.
 			meshReconciles++
 			go h.runAutoEstablishClusterMesh(dep)
+		} else if h.clusterMeshReconcileStatusGate(dep) {
+			// #4811 — the deployment IS a ready multi-region mesh candidate but
+			// shouldStartupClusterMeshReconcile returned false ONLY because the
+			// primary kubeconfig was unresolved at restore (the k8scache
+			// dir-load race: restoreFromStore runs during New(), sometimes
+			// milliseconds before the kubeconfig file lands on the PVC, so the
+			// resolvePrimaryKubeconfigPath os.Stat misses it). The old one-shot
+			// dropped the reconcile forever, so the stale cilium-clustermesh
+			// endpoint (:2379 KINE port instead of the :12379 proxy dial port) —
+			// regenerated only by the establish loop's steady-state heal — never
+			// healed and region-b's mesh stayed 0/1 across every OOM restart.
+			// Start a bounded background retry that re-checks and fires the
+			// establish the moment the kubeconfig resolves; it self-bounds so a
+			// genuinely-lost kubeconfig still stops.
+			meshRetries++
+			go h.retryStartupClusterMeshReconcile(dep)
 		}
 		// #3319 (founder, 2026-06-12) — converged-late handover. MUST be
 		// an INDEPENDENT hook, not the else-arm above: #3317 made the
@@ -641,6 +658,7 @@ func (h *Handler) restoreFromStore() {
 		"count", len(records),
 		"resumed", resumed,
 		"clusterMeshReconciles", meshReconciles,
+		"clusterMeshRetries", meshRetries,
 		"spineReconciles", spineReconciles,
 		"dir", h.store.Dir(),
 	)

--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -56,6 +56,16 @@ type Handler struct {
 	dynadotAPIKey    string
 	dynadotAPISecret string
 
+	// clusterMeshLoopActive guards against double-starting the establish +
+	// steady-state loop for the same deployment (#4811). runAutoEstablishClusterMesh
+	// LoadOrStores the dep ID on entry and Deletes it on return, so a second
+	// concurrent trigger — the startup retry racing markPhase1Done /
+	// converged-late, or two restore passes — becomes a cheap no-op instead of
+	// two competing loops thrashing the same idempotent Secret writes. Cleared
+	// on return so a later legitimate re-trigger (next catalyst-api roll) still
+	// runs. map[string]struct{}.
+	clusterMeshLoopActive sync.Map
+
 	// pdm — pool-domain-manager client. Required in production; tests can
 	// inject a fake via NewWithPDM. The default URL points at the in-cluster
 	// service FQDN so a stock Catalyst-Zero deployment "just works" without
@@ -209,6 +219,22 @@ type Handler struct {
 	// value so the steady-state pass is exercised in milliseconds;
 	// production leaves it at zero.
 	clusterMeshSteadyStateInterval time.Duration
+
+	// clusterMeshStartupRetry* (#4811) — bounded retry for the STARTUP
+	// ClusterMesh reconcile when restoreFromStore finds a ready multi-region
+	// deployment whose primary kubeconfig was merely UNRESOLVED at restore.
+	// restoreFromStore runs inside New(), sometimes milliseconds BEFORE the
+	// k8scache dir-load writes the primary kubeconfig file to the PVC, so the
+	// resolvePrimaryKubeconfigPath os.Stat misses it and
+	// shouldStartupClusterMeshReconcile returns false. The old one-shot dropped
+	// the reconcile forever; retryStartupClusterMeshReconcile instead re-checks
+	// on Interval and launches runAutoEstablishClusterMesh the first time it
+	// passes, giving up after Budget so a genuinely-lost kubeconfig still stops.
+	// Zero falls back to the clusterMeshStartupRetry*Default constants in
+	// clustermesh.go. Tests inject sub-second values so the self-heal is
+	// exercised in milliseconds; production leaves both at zero.
+	clusterMeshStartupRetryInterval time.Duration
+	clusterMeshStartupRetryBudget   time.Duration
 
 	// handoverCertWaitTimeout / handoverCertPollInterval — runtime knobs
 	// for the loop that waits for the sovereign-wildcard-tls Certificate

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -1470,6 +1470,20 @@ func (h *Handler) runHandoverJobSweep(dep *Deployment) {
 // convergence success event still fires exactly once (operator signal);
 // the status!=ready check ends the goroutine on wipe.
 func (h *Handler) runAutoEstablishClusterMesh(dep *Deployment) {
+	// #4811 — one establish+heal loop per deployment. A second concurrent
+	// trigger (the startup retry racing markPhase1Done / converged-late, or two
+	// restore passes) LoadOrStores the same dep ID and becomes a no-op instead
+	// of spinning a competing loop that thrashes the same idempotent Secret
+	// writes. Cleared on return so a later legitimate re-trigger (the next
+	// catalyst-api roll) still runs.
+	if _, active := h.clusterMeshLoopActive.LoadOrStore(dep.ID, struct{}{}); active {
+		h.log.Info("clustermesh: establish loop already active for deployment — skipping duplicate start",
+			"id", dep.ID,
+		)
+		return
+	}
+	defer h.clusterMeshLoopActive.Delete(dep.ID)
+
 	defer func() {
 		if r := recover(); r != nil {
 			h.log.Error("clustermesh: orchestrator panic recovered",


### PR DESCRIPTION
## Problem — Refs #4811

On a 2-region Sovereign, region-b federates via Cilium ClusterMesh. `cilium-dbg status` shows `ClusterMesh: 0/1 remote clusters ready` because the mesh endpoint stays stale (`:2379` KINE port instead of the `:12379` proxy dial port). That endpoint is regenerated only by the establish loop's **steady-state heal** — but the establish loop **never started**.

### Root cause (fully diagnosed on the issue)
`restoreFromStore()` armed the startup ClusterMesh reconcile as a **one-shot else-if**:

```go
} else if h.shouldStartupClusterMeshReconcile(dep) { go h.runAutoEstablishClusterMesh(dep) }
```

`shouldStartupClusterMeshReconcile` returns `false` when `resolvePrimaryKubeconfigPath` can't `os.Stat` the primary kubeconfig. `restoreFromStore` runs inside `New()`, and live logs show the skip firing **~19 ms BEFORE** k8scache logs `loaded cluster from kubeconfigs dir` — a **transient** resolve-failure (the file is on the PVC, just not visible yet; `Result.KubeconfigPath` is `omitempty` and empty post-restore). Because the check was one-shot, `runAutoEstablishClusterMesh` never started, its steady-state heal never ran, and the stale `:2379` endpoint persisted forever. OOM restarts re-lose the race each time.

## Fix — make the startup reconcile RETRIABLE (mechanism-agnostic)

- Extract the status/region half of `shouldStartupClusterMeshReconcile` into **`clusterMeshReconcileStatusGate`** so `restoreFromStore` can tell *"not a mesh candidate at all"* (single-region / hard-failed) apart from *"mesh candidate whose primary kubeconfig was merely unresolved at restore"*.
- In `restoreFromStore`, when the direct gate is false but the **status gate** still passes, start **`retryStartupClusterMeshReconcile`** — a bounded background loop that re-evaluates `shouldStartupClusterMeshReconcile(dep)` on `clusterMeshStartupRetryInterval` and launches `runAutoEstablishClusterMesh` the first time it passes. Bounded by `clusterMeshStartupRetryBudget` (default 3 min) so a genuinely-lost kubeconfig still stops. Happy path (resolves immediately → start now) is unchanged.
- **Double-start guard:** a `clusterMeshLoopActive sync.Map` `LoadOrStore` at the top of `runAutoEstablishClusterMesh` makes any second concurrent trigger a no-op instead of two competing establish loops.
- New Handler knobs `clusterMeshStartupRetry{Interval,Budget}` (+ `*Default` constants) mirror the existing `clusterMeshRetry*` / `clusterMeshSteadyStateInterval` test-override pattern so tests drive it in milliseconds.

## Test

`TestStartupClusterMeshRetry_SelfHealsTransientKubeconfigMiss` — a ready 2-region dep whose `resolvePrimaryKubeconfigPath` fails on the first check but succeeds after the kubeconfig file lands DOES eventually launch the establish and converge (asserts the `reconcile loop complete` event; also asserts it does NOT fire while the file is still absent).

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./internal/handler/ -race -count=1` — PASS (full package, 159s)

## Follow-up (not in this PR)
The catalyst-api OOM (>4Gi) is aggravated by a reflector storm — informers started for CRDs ABSENT on the env (`hcloud.crossplane.io/*` on a Huawei Sovereign; `dr/orgs/sandbox.openova.io` when uninstalled) spin `Failed to watch … could not find the requested resource` in a tight loop. Gating those informers on API-discovery CRD presence is a separate, cleanly-scoped commit — noted here as follow-up rather than forced into this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)