### PR TITLE
test(#4811): pin clustermesh endpoint dial-port authoritative-overwrite invariant

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -104,6 +104,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -596,30 +597,89 @@ var clusterMeshRolloutTargets = []struct {
 	{"deployment", clusterMeshApiserverService},
 }
 
-// clusterMeshTestClientFactory — test-only hook. When non-nil,
+// clusterMeshTestClientFactory — test-only hook. When set,
 // buildRegionSlots routes its kubeconfig → clientset construction
 // through this function instead of the production helmwatch parser.
-// Tests inject fakes; production leaves this nil.
+// Tests inject fakes; production leaves it unset.
 //
 // Returning (nil, false) means "no override for this path, fall
 // through to production". Returning (client, true) injects the fake.
-var clusterMeshTestClientFactory func(kubeconfigPath string) (kubernetes.Interface, bool)
+//
+// #4811 part-b: stored behind an atomic.Pointer rather than a bare
+// package var. The establish reconcile loop (runAutoEstablishClusterMesh)
+// READS this hook from a background goroutine that a prior test may leak
+// past its own boundary (e.g. the bounded-retry self-heal test); the NEXT
+// test's install/restore WRITES it. Under `go test -race` that unsynchronized
+// read/write on a plain var is a reported data race that crashes the whole
+// package binary (seen only in CI, where scheduling differs). The atomic
+// load/store makes the seam race-free without any production lock on the hot
+// path (production leaves the pointer nil → a single atomic load returning nil).
+type clusterMeshClientFactory func(kubeconfigPath string) (kubernetes.Interface, bool)
+
+var clusterMeshTestClientFactoryPtr atomic.Pointer[clusterMeshClientFactory]
+
+func loadClusterMeshTestClientFactory() clusterMeshClientFactory {
+	if p := clusterMeshTestClientFactoryPtr.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
+func setClusterMeshTestClientFactory(fn clusterMeshClientFactory) {
+	if fn == nil {
+		clusterMeshTestClientFactoryPtr.Store(nil)
+		return
+	}
+	clusterMeshTestClientFactoryPtr.Store(&fn)
+}
 
 // clusterMeshTestDynamicClientFactory — test-only hook mirroring
 // clusterMeshTestClientFactory for the DYNAMIC client the cnpg-pair
 // gate flip (#3236) uses to patch the bootstrap-kit Flux Kustomization.
-// Same contract: (nil, false) falls through to production; production
-// leaves this nil.
-var clusterMeshTestDynamicClientFactory func(kubeconfigPath string) (dynamic.Interface, bool)
+// Same contract + same atomic-pointer race-safety rationale as above.
+type clusterMeshDynamicClientFactory func(kubeconfigPath string) (dynamic.Interface, bool)
+
+var clusterMeshTestDynamicClientFactoryPtr atomic.Pointer[clusterMeshDynamicClientFactory]
+
+func loadClusterMeshTestDynamicClientFactory() clusterMeshDynamicClientFactory {
+	if p := clusterMeshTestDynamicClientFactoryPtr.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
+func setClusterMeshTestDynamicClientFactory(fn clusterMeshDynamicClientFactory) {
+	if fn == nil {
+		clusterMeshTestDynamicClientFactoryPtr.Store(nil)
+		return
+	}
+	clusterMeshTestDynamicClientFactoryPtr.Store(&fn)
+}
 
 // clusterMeshTestOverrideLBTimeout / clusterMeshTestOverrideLBInterval
 // — test-only override knobs for the LB-discovery poll loop. Zero
 // falls back to the production constants. Tests set these to
 // sub-second values so the LB-absent path runs in milliseconds.
+//
+// #4811 part-b: stored as atomic.Int64 nanoseconds for the same reason
+// the factory hooks above are atomic — waitForClusterMeshLB READS them
+// from the long-lived steady-state heal goroutine, which some tests leave
+// running past their own boundary (status never leaves "ready"), while a
+// LATER test WRITES them. A plain time.Duration var makes that a `-race`
+// data race that crashes the package test binary in CI. Production never
+// sets them (both stay 0 → the load returns 0 → production constants win).
 var (
-	clusterMeshTestOverrideLBTimeout  time.Duration
-	clusterMeshTestOverrideLBInterval time.Duration
+	clusterMeshTestOverrideLBTimeoutNanos  atomic.Int64
+	clusterMeshTestOverrideLBIntervalNanos atomic.Int64
 )
+
+func clusterMeshTestOverrideLBTimeout() time.Duration {
+	return time.Duration(clusterMeshTestOverrideLBTimeoutNanos.Load())
+}
+
+func clusterMeshTestOverrideLBInterval() time.Duration {
+	return time.Duration(clusterMeshTestOverrideLBIntervalNanos.Load())
+}
 
 // AutoEstablishClusterMesh wires every region's clustermesh-apiserver
 // into a fully-connected peer mesh. Called from deployments.go AFTER
@@ -2114,8 +2174,8 @@ func (h *Handler) updateCopiedSecret(ctx context.Context, desired *corev1.Secret
 // behind the given kubeconfig path, honouring the test-only factory
 // override the same way buildRegionSlots does for typed clients.
 func (h *Handler) clusterMeshDynamicClient(kubeconfigPath string) (dynamic.Interface, error) {
-	if clusterMeshTestDynamicClientFactory != nil {
-		if d, ok := clusterMeshTestDynamicClientFactory(kubeconfigPath); ok {
+	if factory := loadClusterMeshTestDynamicClientFactory(); factory != nil {
+		if d, ok := factory(kubeconfigPath); ok {
 			return d, nil
 		}
 	}
@@ -2263,8 +2323,8 @@ func (h *Handler) buildRegionSlots(
 		// Test-only short-circuit: if a factory override is wired,
 		// route the path through it. Production override is nil; the
 		// fall-through reads the file and calls helmwatch.
-		if clusterMeshTestClientFactory != nil {
-			if c, ok := clusterMeshTestClientFactory(kc); ok {
+		if factory := loadClusterMeshTestClientFactory(); factory != nil {
+			if c, ok := factory(kc); ok {
 				slot.clientset = c
 				out = append(out, slot)
 				continue
@@ -2338,12 +2398,12 @@ func clusterMeshDialPort() int {
 
 func (h *Handler) waitForClusterMeshLB(ctx context.Context, client kubernetes.Interface) (string, int, error) {
 	timeout := clusterMeshLBLookupTimeout
-	if clusterMeshTestOverrideLBTimeout > 0 {
-		timeout = clusterMeshTestOverrideLBTimeout
+	if v := clusterMeshTestOverrideLBTimeout(); v > 0 {
+		timeout = v
 	}
 	interval := clusterMeshLBLookupInterval
-	if clusterMeshTestOverrideLBInterval > 0 {
-		interval = clusterMeshTestOverrideLBInterval
+	if v := clusterMeshTestOverrideLBInterval(); v > 0 {
+		interval = v
 	}
 	deadline := time.Now().Add(timeout)
 	for {

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -2589,6 +2589,18 @@ func peerMeshHostname(peerClusterName string) string {
 // mesh-component crash-cycle (clustermesh-apiserver Deployment hit
 // generation 35 on hw128) that never left the agents a stable window to
 // finish the remote-config sync.
+//
+// #4811 part-b INVARIANT (relied on by the establish path + pinned by
+// TestAutoEstablishClusterMesh_RewritesStaleDialPortOnReEstablish): the
+// per-peer ENDPOINT config-blob key (`<peer>` → buildPeerConfigBlob output)
+// is a MANAGED key, so it is ALWAYS overwritten — never merged-and-kept —
+// with the freshly-built blob. That blob carries the current
+// clusterMeshDialPort(), so an env whose peer endpoint was written in a
+// pre-12379 window (stale `:2379`) is authoritatively corrected to
+// `:12379` on the next establish pass rather than preserved. A future
+// refactor that turns this into skip-if-key-exists semantics would
+// silently reintroduce the stuck-`:2379` / ClusterMesh 0/1 symptom proven
+// live on hw228 — keep managed keys authoritative.
 func (h *Handler) applyClusterMeshSecret(ctx context.Context, client kubernetes.Interface, entries map[string][]byte) (bool, error) {
 	if len(entries) == 0 {
 		return false, nil

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
@@ -318,12 +318,12 @@ type testFixture struct {
 // clustermesh.go that defaults to nil; tests set it to a map keyed by
 // kubeconfig path. Production never touches this variable.
 func installClusterMeshClientFactory(clients map[string]kubernetes.Interface) func() {
-	prev := clusterMeshTestClientFactory
-	clusterMeshTestClientFactory = func(kcPath string) (kubernetes.Interface, bool) {
+	prev := loadClusterMeshTestClientFactory()
+	setClusterMeshTestClientFactory(func(kcPath string) (kubernetes.Interface, bool) {
 		c, ok := clients[kcPath]
 		return c, ok
-	}
-	return func() { clusterMeshTestClientFactory = prev }
+	})
+	return func() { setClusterMeshTestClientFactory(prev) }
 }
 
 func newTestFixture(t *testing.T, lbIPs []string) *testFixture {
@@ -505,12 +505,29 @@ func newFakeKustomizationDynClient(t *testing.T, objs ...runtime.Object) dynamic
 // installClusterMeshClientFactory for the dynamic-client path used by
 // the cnpg-pair gate flip. Returns a restore func.
 func installClusterMeshDynamicClientFactory(clients map[string]dynamic.Interface) func() {
-	prev := clusterMeshTestDynamicClientFactory
-	clusterMeshTestDynamicClientFactory = func(kcPath string) (dynamic.Interface, bool) {
+	prev := loadClusterMeshTestDynamicClientFactory()
+	setClusterMeshTestDynamicClientFactory(func(kcPath string) (dynamic.Interface, bool) {
 		c, ok := clients[kcPath]
 		return c, ok
-	}
-	return func() { clusterMeshTestDynamicClientFactory = prev }
+	})
+	return func() { setClusterMeshTestDynamicClientFactory(prev) }
+}
+
+// setClusterMeshLBOverrides sets the atomic LB-discovery poll overrides for
+// the duration of the test and restores them on cleanup. Atomic-backed so a
+// steady-state heal goroutine leaked by an earlier test (status never leaves
+// "ready") reading these in waitForClusterMeshLB cannot data-race this write
+// under `go test -race` (#4811 part-b).
+func setClusterMeshLBOverrides(t *testing.T, timeout, interval time.Duration) {
+	t.Helper()
+	prevTimeout := clusterMeshTestOverrideLBTimeoutNanos.Load()
+	prevInterval := clusterMeshTestOverrideLBIntervalNanos.Load()
+	clusterMeshTestOverrideLBTimeoutNanos.Store(int64(timeout))
+	clusterMeshTestOverrideLBIntervalNanos.Store(int64(interval))
+	t.Cleanup(func() {
+		clusterMeshTestOverrideLBTimeoutNanos.Store(prevTimeout)
+		clusterMeshTestOverrideLBIntervalNanos.Store(prevInterval)
+	})
 }
 
 // getBootstrapKitKustomization re-reads the Kustomization from the fake
@@ -591,14 +608,7 @@ func TestAutoEstablishClusterMesh_LBAbsentInOneRegion(t *testing.T) {
 	restoreDyn := installClusterMeshDynamicClientFactory(fx.dynClients)
 	defer restoreDyn()
 	// Shrink the LB lookup timeout so the test isn't slow.
-	// (We reach into the package-level const indirectly via a test
-	// hook below.)
-	prev := clusterMeshTestOverrideLBTimeout
-	clusterMeshTestOverrideLBTimeout = 200 * time.Millisecond
-	defer func() { clusterMeshTestOverrideLBTimeout = prev }()
-	prevInt := clusterMeshTestOverrideLBInterval
-	clusterMeshTestOverrideLBInterval = 25 * time.Millisecond
-	defer func() { clusterMeshTestOverrideLBInterval = prevInt }()
+	setClusterMeshLBOverrides(t, 200*time.Millisecond, 25*time.Millisecond)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -795,12 +805,7 @@ func TestRunAutoEstablishClusterMesh_RetryConvergesAfterLBAppears(t *testing.T) 
 
 	// Fast knobs: sub-second LB poll + retry backoff so the loop
 	// converges in milliseconds.
-	prev := clusterMeshTestOverrideLBTimeout
-	clusterMeshTestOverrideLBTimeout = 150 * time.Millisecond
-	defer func() { clusterMeshTestOverrideLBTimeout = prev }()
-	prevInt := clusterMeshTestOverrideLBInterval
-	clusterMeshTestOverrideLBInterval = 25 * time.Millisecond
-	defer func() { clusterMeshTestOverrideLBInterval = prevInt }()
+	setClusterMeshLBOverrides(t, 150*time.Millisecond, 25*time.Millisecond)
 	fx.handler.clusterMeshRetryInitialBackoff = 20 * time.Millisecond
 	fx.handler.clusterMeshRetryMaxBackoff = 60 * time.Millisecond
 	fx.handler.clusterMeshRetryBudget = 20 * time.Second
@@ -1646,12 +1651,7 @@ func TestAutoEstablishClusterMesh_PartialMeshDoesNotFlipCNPGPairGate(t *testing.
 	defer restore()
 	restoreDyn := installClusterMeshDynamicClientFactory(fx.dynClients)
 	defer restoreDyn()
-	prev := clusterMeshTestOverrideLBTimeout
-	clusterMeshTestOverrideLBTimeout = 200 * time.Millisecond
-	defer func() { clusterMeshTestOverrideLBTimeout = prev }()
-	prevInt := clusterMeshTestOverrideLBInterval
-	clusterMeshTestOverrideLBInterval = 25 * time.Millisecond
-	defer func() { clusterMeshTestOverrideLBInterval = prevInt }()
+	setClusterMeshLBOverrides(t, 200*time.Millisecond, 25*time.Millisecond)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
@@ -1378,6 +1378,122 @@ func TestAutoEstablishClusterMesh_Idempotent(t *testing.T) {
 	}
 }
 
+// peerEndpointBlob returns the single cilium-clustermesh peer config-blob
+// entry (the key whose value carries `endpoints:`) from a region's Secret,
+// together with its key. Fails the test if zero or more than one such entry
+// exists — the 2-region fixture has exactly one peer per region.
+func peerEndpointBlob(t *testing.T, client kubernetes.Interface) (peerKey string, blob []byte) {
+	t.Helper()
+	secret, err := client.CoreV1().Secrets(clusterMeshNamespace).Get(context.Background(), clusterMeshSecretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get cilium-clustermesh: %v", err)
+	}
+	for k, v := range secret.Data {
+		if bytes.Contains(v, []byte("endpoints:")) {
+			if peerKey != "" {
+				t.Fatalf("expected exactly one endpoint config-blob entry, found >1 (%q and %q)", peerKey, k)
+			}
+			peerKey, blob = k, append([]byte(nil), v...)
+		}
+	}
+	if peerKey == "" {
+		t.Fatalf("no endpoint config-blob entry in Secret (keys %v)", secretKeys(secret))
+	}
+	return peerKey, blob
+}
+
+// TestAutoEstablishClusterMesh_RewritesStaleDialPortOnReEstablish pins the
+// #4811 part-b migration invariant: an env whose cilium-clustermesh peer
+// endpoint was written in a PRE-12379 window (endpoint carries the stale
+// KINE `:2379` port) has that endpoint AUTHORITATIVELY corrected to the
+// current clusterMeshDialPort() (`:12379`) on the next establish pass —
+// the merge in applyClusterMeshSecret overwrites the managed endpoint key
+// rather than preserving the stale one. The per-peer cert/key/CA material
+// is preserved byte-for-byte across the port-only rewrite.
+//
+// Live proof this matters: on hw228 the mesh stayed ClusterMesh 0/1 until
+// the secret endpoint was patched `:2379`→`:12379` and cilium rolled. No
+// prior test asserted the endpoint PORT at all (they only checked the
+// 4-key entry COUNT), so a buildPeerConfigBlob regression that hardcoded
+// `:2379` would have shipped green — this test closes that gap.
+func TestAutoEstablishClusterMesh_RewritesStaleDialPortOnReEstablish(t *testing.T) {
+	fx := newTestFixture(t, []string{"203.0.113.10", "203.0.113.20"})
+	restore := installClusterMeshClientFactory(fx.clients)
+	defer restore()
+	restoreDyn := installClusterMeshDynamicClientFactory(fx.dynClients)
+	defer restoreDyn()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Pass 1 — no dial-port override, so clusterMeshDialPort() == the
+	// default 2379. This seeds each region's Secret with a peer endpoint
+	// carrying the stale KINE port, exactly the pre-12379-window shape.
+	if _, err := fx.handler.AutoEstablishClusterMesh(ctx, fx.dep); err != nil {
+		t.Fatalf("pass 1 (default port): %v", err)
+	}
+	primary := fx.clients[fx.primaryKubeconfigPath]
+	stalePeerKey, staleBlob := peerEndpointBlob(t, primary)
+	staleEndpoint := fmt.Sprintf("https://%s:%d", peerMeshHostname(stalePeerKey), clusterMeshAPIServerPort)
+	if !bytes.Contains(staleBlob, []byte(staleEndpoint)) {
+		t.Fatalf("pass 1 endpoint blob does not carry default port %d:\n%s",
+			clusterMeshAPIServerPort, staleBlob)
+	}
+	// Snapshot the peer cert/key/CA bytes so we can prove they survive the
+	// port-only rewrite untouched.
+	staleSecret, err := primary.CoreV1().Secrets(clusterMeshNamespace).Get(ctx, clusterMeshSecretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get stale secret: %v", err)
+	}
+	certMaterial := map[string][]byte{}
+	for _, suffix := range []string{"-ca.crt", ".crt", ".key"} {
+		k := stalePeerKey + suffix
+		v, ok := staleSecret.Data[k]
+		if !ok {
+			t.Fatalf("expected cert material key %q in seeded secret (keys %v)", k, secretKeys(staleSecret))
+		}
+		certMaterial[k] = append([]byte(nil), v...)
+	}
+
+	// Pass 2 — env now sets the clustermesh-proxy dial port (12379), the
+	// no-CCM Huawei value. The establish must REWRITE the stale endpoint.
+	t.Setenv(clusterMeshDialPortEnvVar, "12379")
+	if got := clusterMeshDialPort(); got != 12379 {
+		t.Fatalf("clusterMeshDialPort() = %d after env set, want 12379", got)
+	}
+	if _, err := fx.handler.AutoEstablishClusterMesh(ctx, fx.dep); err != nil {
+		t.Fatalf("pass 2 (12379 override): %v", err)
+	}
+
+	freshPeerKey, freshBlob := peerEndpointBlob(t, primary)
+	if freshPeerKey != stalePeerKey {
+		t.Fatalf("peer key changed across passes: %q -> %q", stalePeerKey, freshPeerKey)
+	}
+	wantEndpoint := fmt.Sprintf("https://%s:12379", peerMeshHostname(freshPeerKey))
+	if !bytes.Contains(freshBlob, []byte(wantEndpoint)) {
+		t.Errorf("endpoint NOT corrected to :12379 after re-establish; blob:\n%s", freshBlob)
+	}
+	if bytes.Contains(freshBlob, []byte(staleEndpoint)) {
+		t.Errorf("stale :2379 endpoint PRESERVED after re-establish (merge kept it instead of overwriting):\n%s", freshBlob)
+	}
+
+	// Cert/key/CA material preserved byte-for-byte — only the port moved.
+	freshSecret, err := primary.CoreV1().Secrets(clusterMeshNamespace).Get(ctx, clusterMeshSecretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get fresh secret: %v", err)
+	}
+	for k, want := range certMaterial {
+		got, ok := freshSecret.Data[k]
+		if !ok {
+			t.Errorf("cert material key %q dropped by re-establish", k)
+			continue
+		}
+		if !bytes.Equal(got, want) {
+			t.Errorf("cert material key %q mutated by the port-only rewrite", k)
+		}
+	}
+}
+
 // TestAutoEstablishClusterMesh_SingleRegionSkips — len(Regions) < 2
 // returns (nil, nil) immediately.
 func TestAutoEstablishClusterMesh_SingleRegionSkips(t *testing.T) {


### PR DESCRIPTION
## Summary — #4811 part-b (part-a was #4829, already merged)

The cross-region ClusterMesh peer endpoint the Sovereign writes into `kube-system/cilium-clustermesh` must dial the clustermesh-proxy port (`clusterMeshDialPort()`, `CLUSTERMESH_APISERVER_DIAL_PORT`, `12379` on no-CCM Huawei) — not bare `:2379`, which lands on k3s KINE and fails TLS. Proven live on hw228: patching the secret endpoint `:2379`→`:12379` + rolling cilium → `ClusterMesh: 1/1 remote clusters ready`.

### Investigation finding

The part-b concern — "on a pre-12379 env the establish re-runs but does NOT overwrite the stale `:2379` port" — **does not hold against current `main`**. The establish path is already authoritative:

- `buildPeerConfigBlob(peer, apiPort)` always (re)builds the endpoint with `apiPort == clusterMeshDialPort()` (via `waitForClusterMeshLB`), every establish pass.
- `applyClusterMeshSecret` **merges by overwriting managed keys** (`clustermesh.go` ~L2633): the per-peer config-blob key (`<peer>`) is overwritten with the fresh blob; only OTHER peers' entries are preserved.

Verified empirically: seed a `:2379` endpoint, re-establish with `CLUSTERMESH_APISERVER_DIAL_PORT=12379` → endpoint becomes `:12379`, cert/key/CA bytes unchanged.

So the live heal is delivered by **part-a (#4829)** — which restarts the establish loop on the transient-kubeconfig-miss race — plus this existing authoritative merge.

### The real gap this PR closes

**Zero test coverage of the endpoint port.** Existing clustermesh tests only assert the 4-key entry *count*, never the endpoint URL. A `buildPeerConfigBlob` regression that hardcoded `:2379` would ship green and silently reintroduce the hw228 `ClusterMesh 0/1` symptom.

- **`TestAutoEstablishClusterMesh_RewritesStaleDialPortOnReEstablish`** — seeds a stale `:2379` endpoint (default-port establish pass), re-establishes with `12379`, and asserts: endpoint rewritten `:2379`→`:12379`, stale entry NOT preserved, cert/key/CA preserved byte-for-byte. **Mutation-verified**: hardcoding `:2379` in `buildPeerConfigBlob` makes this test fail with exactly the "endpoint NOT corrected / stale preserved" errors.
- Documented the #4811 part-b managed-key overwrite invariant on `applyClusterMeshSecret` so a future skip-if-key-exists refactor can't silently break it.

**No production behavior change** — this is a durable regression guard for a live-proven, silent-if-broken behavior.

### Checks
- `go build ./...` — pass
- `go vet ./internal/handler/` — pass
- `go test ./internal/handler/` (full package, `-race`) — pass (150s)

Refs #4811

🤖 Generated with [Claude Code](https://claude.com/claude-code)