### PR TITLE
fix(#4811): cloud-aware ClusterMesh dial port (mothership serves both clouds)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -151,9 +151,10 @@ type regionSlot struct {
 	kubeconfigPath string               // on-disk path to the region's kubeconfig YAML
 	clusterName    string               // Cilium cluster.name for this region
 	clusterID      int                  // Cilium cluster.id (1..255)
+	provider       string               // cloud provider of THIS region ("huawei"/"hetzner"/…) — selects the dial port (#4811)
 	clientset      kubernetes.Interface // typed client built from kubeconfig
 	lbIP           string               // public LB IP of clustermesh-apiserver Service
-	apiPort        int                  // port peers DIAL on lbIP — 2379 on a real cloud LB; the Service NodePort when lbIP is a node-owned EIP (Cilium nodeIPAM, kom4dc shape)
+	apiPort        int                  // port peers DIAL on lbIP — 2379 on a real cloud LB (Hetzner hcloud-ccm); the clustermesh-proxy hostPort (12379) on a no-CCM cloud (Huawei/kom4dc, CP-EIP ingress collides with k3s-etcd :2379). Never a NodePort (#4765).
 	caCert         []byte               // cilium-ca tls.crt bytes
 	caKey          []byte               // cilium-ca tls.key bytes
 	err            error                // non-nil if LB lookup / CA snapshot failed
@@ -184,6 +185,15 @@ const (
 	// dedicated non-2379 port (bp-cilium clustermesh-proxy DaemonSet) via
 	// this override; Hetzner keeps the default 2379 behind hcloud-ccm.
 	clusterMeshAPIServerPort    = 2379
+	// clusterMeshProxyDialPort — the bp-cilium clustermesh-proxy DaemonSet
+	// hostPort (#4784). On a no-CCM cloud (Huawei/kom4dc) there is no real
+	// LoadBalancer: the clustermesh-apiserver Service's ingress IP is the
+	// CP-node's public EIP (1:1 NAT to the CP private IP), and that host's
+	// :2379 is answered by k3s' OWN embedded etcd — so peers MUST dial the
+	// dedicated proxy host-socket instead. This value MUST match infra
+	// `clustermesh_proxy_port` + bp-cilium `clustermeshProxy.hostPort`
+	// (both 12379). NOT a NodePort — the proxy binds a hostNetwork socket.
+	clusterMeshProxyDialPort    = 12379
 	clusterMeshDialPortEnvVar   = "CLUSTERMESH_APISERVER_DIAL_PORT"
 	clusterMeshLBLookupTimeout  = 5 * time.Minute
 	clusterMeshLBLookupInterval = 10 * time.Second
@@ -807,7 +817,7 @@ func (h *Handler) autoEstablishClusterMesh(ctx context.Context, dep *Deployment)
 		if s.err != nil {
 			continue
 		}
-		lbIP, apiPort, err := h.waitForClusterMeshLB(ctx, s.clientset)
+		lbIP, apiPort, err := h.waitForClusterMeshLB(ctx, s.clientset, s.provider)
 		if err != nil {
 			s.err = fmt.Errorf("lb-discovery: %w", err)
 			h.log.Warn("clustermesh: LB lookup failed for region",
@@ -2303,10 +2313,19 @@ func (h *Handler) buildRegionSlots(
 			}
 		}
 
+		// #4811 — the dial port keys on THIS region's cloud. Prefer the
+		// per-region Provider; fall back to the deployment-level Provider
+		// (single-cloud provs often set only the top-level field).
+		regionProvider := strings.TrimSpace(rs.Provider)
+		if regionProvider == "" {
+			regionProvider = strings.TrimSpace(dep.Request.Provider)
+		}
+
 		slot := regionSlot{
 			key:            key,
 			kubeconfigPath: kc,
 			clusterName:    clusterName,
+			provider:       regionProvider,
 		}
 		if isPrimary {
 			slot.clusterID = primaryID
@@ -2387,16 +2406,47 @@ func regionKeyFromSpec(rs provisioner.RegionSpec, idx int) string {
 // NOT collide with k3s' embedded etcd on the CP-node host :2379) — see
 // clusterMeshAPIServerPort's doc + issue #4784. A NodePort value here is
 // still forbidden; the proxy binds a hostNetwork socket, not a NodePort.
-func clusterMeshDialPort() int {
+//
+// #4811 — the port MUST key on the DIALED region's cloud, not on a single
+// static env. The mothership catalyst-api establishes meshes for BOTH
+// Hetzner and Huawei Sovereigns from ONE (env-unset) deployment, so a static
+// CLUSTERMESH_APISERVER_DIAL_PORT env can never be right for a multi-cloud
+// mothership: with the env unset it defaulted to 2379 and wrote every Huawei
+// Sovereign's peer endpoint as `:2379` (→ k3s KINE, ClusterMesh 0/1). The
+// env is retained as an explicit single-cloud override (highest precedence),
+// but when it is unset the default is resolved from `provider`: a no-CCM
+// cloud (Huawei/kom4dc) dials the clustermesh-proxy hostPort (12379); a CCM
+// cloud (Hetzner, real hcloud-ccm LB IP with no k3s-etcd host collision)
+// dials the canonical etcd :2379.
+func clusterMeshDialPort(provider string) int {
 	if v := strings.TrimSpace(os.Getenv(clusterMeshDialPortEnvVar)); v != "" {
 		if p, err := strconv.Atoi(v); err == nil && p > 0 && p <= 65535 {
 			return p
 		}
 	}
+	if isNoCCMCloud(provider) {
+		return clusterMeshProxyDialPort
+	}
 	return clusterMeshAPIServerPort
 }
 
-func (h *Handler) waitForClusterMeshLB(ctx context.Context, client kubernetes.Interface) (string, int, error) {
+// isNoCCMCloud reports whether the given deployment/region provider runs
+// WITHOUT a cloud-controller-manager LoadBalancer — i.e. the
+// clustermesh-apiserver Service has no real LB IP and the CP-node public EIP
+// (which serves the ingress) collides with k3s' embedded etcd on host :2379,
+// so peers must dial the clustermesh-proxy hostPort (clusterMeshProxyDialPort)
+// instead of :2379. Hetzner (hcloud-ccm) returns false. Matches the provider
+// strings validated in deployments.go (req.Provider / Regions[i].Provider).
+func isNoCCMCloud(provider string) bool {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "huawei", "hcs", "kom4dc":
+		return true
+	default:
+		return false
+	}
+}
+
+func (h *Handler) waitForClusterMeshLB(ctx context.Context, client kubernetes.Interface, provider string) (string, int, error) {
 	timeout := clusterMeshLBLookupTimeout
 	if v := clusterMeshTestOverrideLBTimeout(); v > 0 {
 		timeout = v
@@ -2461,7 +2511,7 @@ func (h *Handler) waitForClusterMeshLB(ctx context.Context, client kubernetes.In
 			// CLUSTERMESH_APISERVER_DIAL_PORT — still NO NodePort. Hetzner
 			// keeps the default 2379 (hcloud-ccm real LB, no k3s-etcd host
 			// collision on the LB IP).
-			return ip, clusterMeshDialPort(), nil
+			return ip, clusterMeshDialPort(provider), nil
 		}
 		if time.Now().After(deadline) {
 			return "", 0, fmt.Errorf("Service %s/%s has no LoadBalancer ingress after %s",

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
@@ -1463,7 +1463,7 @@ func TestAutoEstablishClusterMesh_RewritesStaleDialPortOnReEstablish(t *testing.
 	// Pass 2 — env now sets the clustermesh-proxy dial port (12379), the
 	// no-CCM Huawei value. The establish must REWRITE the stale endpoint.
 	t.Setenv(clusterMeshDialPortEnvVar, "12379")
-	if got := clusterMeshDialPort(); got != 12379 {
+	if got := clusterMeshDialPort(""); got != 12379 {
 		t.Fatalf("clusterMeshDialPort() = %d after env set, want 12379", got)
 	}
 	if _, err := fx.handler.AutoEstablishClusterMesh(ctx, fx.dep); err != nil {
@@ -1496,6 +1496,47 @@ func TestAutoEstablishClusterMesh_RewritesStaleDialPortOnReEstablish(t *testing.
 		if !bytes.Equal(got, want) {
 			t.Errorf("cert material key %q mutated by the port-only rewrite", k)
 		}
+	}
+}
+
+// TestClusterMeshDialPort_CloudAware — #4811. The dial port must be resolved
+// from the DIALED region's cloud when the env is unset, because the mothership
+// catalyst-api establishes meshes for BOTH clouds from ONE env-unset
+// deployment. A no-CCM cloud (Huawei/kom4dc) dials the clustermesh-proxy
+// hostPort (12379); a CCM cloud (Hetzner) dials the canonical etcd :2379. An
+// explicit env override still wins over the cloud default (single-cloud escape
+// hatch). Regression guard: env-unset + provider=huawei previously returned
+// 2379 (KINE) and wedged every Huawei Sovereign at ClusterMesh 0/1.
+func TestClusterMeshDialPort_CloudAware(t *testing.T) {
+	// Ensure no ambient override leaks in from the environment.
+	t.Setenv(clusterMeshDialPortEnvVar, "")
+
+	cases := []struct {
+		provider string
+		want     int
+	}{
+		{"huawei", clusterMeshProxyDialPort}, // no-CCM → proxy hostPort 12379
+		{"hcs", clusterMeshProxyDialPort},
+		{"kom4dc", clusterMeshProxyDialPort},
+		{"HUAWEI", clusterMeshProxyDialPort}, // case-insensitive
+		{"hetzner", clusterMeshAPIServerPort}, // CCM real LB → 2379
+		{"", clusterMeshAPIServerPort},        // unknown → safe 2379 default
+		{"aws", clusterMeshAPIServerPort},
+	}
+	for _, c := range cases {
+		if got := clusterMeshDialPort(c.provider); got != c.want {
+			t.Errorf("clusterMeshDialPort(%q) = %d, want %d", c.provider, got, c.want)
+		}
+	}
+
+	// Explicit env override wins over the cloud-aware default, for either cloud.
+	t.Setenv(clusterMeshDialPortEnvVar, "12379")
+	if got := clusterMeshDialPort("hetzner"); got != 12379 {
+		t.Errorf("env override ignored for hetzner: got %d, want 12379", got)
+	}
+	t.Setenv(clusterMeshDialPortEnvVar, "2379")
+	if got := clusterMeshDialPort("huawei"); got != 2379 {
+		t.Errorf("env override ignored for huawei: got %d, want 2379", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Makes the ClusterMesh peer **dial port** resolve from the **dialed region's cloud** instead of a single static `CLUSTERMESH_APISERVER_DIAL_PORT` env. This is the real root cause of the 44-row BCP (multi-region) gate on Huawei/kom4dc Sovereigns (#4811) — deeper than the earlier retriable-reconcile / endpoint-overwrite hardening (#4829/#4830), which hardened the Sovereign-side establish that legitimately never runs (it doesn't own the primary kubeconfig).

## Root cause (traced live on hw228, 2026-07-07)

The **mothership** catalyst-api owns the Phase-1 clustermesh establish — it's the process with both region kubeconfigs, and its logs actively reconcile the deployment's mesh. Its `CLUSTERMESH_APISERVER_DIAL_PORT` env is **UNSET** (the chart only sets it via the *Sovereign's* bootstrap-kit slot, never on the mothership's own deployment) → `clusterMeshDialPort()` returned the default `2379`.

But the mothership establishes meshes for **both** clouds from one env-unset deployment:
- **Hetzner** (hcloud-ccm real LB IP, no k3s-etcd host collision) → correct at `:2379`.
- **Huawei/kom4dc** (no CCM; the clustermesh-apiserver Service ingress IP is the CP-node public EIP, whose host `:2379` is answered by k3s' embedded etcd/KINE) → **wrong** at `:2379`. Peers hit KINE (cert `kine.sock`, not `mesh.cilium.io`) → `ClusterMesh 0/1`.

A static mothership env can never be right for a multi-cloud mothership. Proven live: patching the peer endpoint `:2379`→`:12379` (the clustermesh-proxy hostPort) + `rollout restart ds/cilium` → `ClusterMesh 1/1`.

## Fix

`clusterMeshDialPort(provider string)` now:
1. honors an explicit `CLUSTERMESH_APISERVER_DIAL_PORT` env override (highest precedence — single-cloud escape hatch), else
2. resolves by the dialed region's cloud: no-CCM cloud (Huawei/hcs/kom4dc) → `clusterMeshProxyDialPort` (12379, matches infra `clustermesh_proxy_port` + bp-cilium `clustermeshProxy.hostPort`); CCM cloud (Hetzner) / unknown → `clusterMeshAPIServerPort` (2379).

The port keys on the **dialed** region because it's what *other* peers dial to reach that region. `regionSlot` gains a `provider` field (per-region `Provider`, falling back to the deployment-level `Provider`); `waitForClusterMeshLB` takes and forwards it. `buildPeerConfigBlob` / the #4830 stale-endpoint overwrite already consume `slot.apiPort`, so the whole write path is corrected with no further change. No NodePort anywhere (proxy binds a hostNetwork socket — §854 / #4765).

## Impact

- **Fresh 2-region Huawei provs** now get `:12379` peer endpoints from Phase-1 (zero-touch mesh) once the mothership rolls this image.
- **hw228** (already converged) meshes durably on the mothership's next establish pass — no manual secret patch.
- Hetzner multi-region unchanged (`:2379`).

## Tests

- New `TestClusterMeshDialPort_CloudAware` — table-driven: huawei/hcs/kom4dc → 12379, hetzner/unknown → 2379, case-insensitive, env override wins for either cloud.
- `TestAutoEstablishClusterMesh_RewritesStaleDialPortOnReEstablish` updated to the new signature (env-override path unchanged).
- `go build ./...`, `go vet`, full `internal/handler` suite green under `-race`.

Refs #4811 #4784 #4829 #4830 #4275
