### PR TITLE
fix(#4813): per-Org cnpg operator read-only webhook RBAC so ensurePKI startup succeeds

### DIFF
--- a/platform/cnpg/chart/Chart.yaml
+++ b/platform/cnpg/chart/Chart.yaml
@@ -101,7 +101,25 @@ name: bp-cnpg
 #       4635277cae4ffed9). FIX: switch both to `command: ["/bin/bash", ...]`
 #       (the image carries /bin/bash + /usr/bin/openssl; webhook-gate-hook.yaml
 #       already uses bash). Refs #4322 #4143 #4201 #4326.
-version: 1.0.14
+#
+# 1.0.15 (#4813, 2026-07-07): the G65/1.0.14 fix (A) removed ALL
+#       *webhookconfigurations verbs from the per-Org operator's minimal
+#       ClusterRole to kill the caBundle hijack — but cnpg 1.29's operator
+#       startup ALWAYS calls controller.ensurePKI(), which does a cluster-scoped
+#       GET on the webhook configs to verify the caBundle, even for a
+#       namespace-scoped per-Org operator. So the RBAC removal broke operator
+#       STARTUP: "cannot get resource mutatingwebhookconfigurations at the
+#       cluster scope" → CrashLoopBackOff → bp-cnpg InstallFailed → every
+#       DB-backed per-Org app (wordpress/newapi/openclaw) DependencyNotReady on
+#       an S-plan namespace-isolated Org (live-found hw228 walkstrangertwo, an
+#       S-plan Org lands namespace per the #4292 tier gate). FIX: grant the
+#       per-Org operator READ-ONLY get/list/watch on mutating/validating
+#       webhookconfigurations — NO patch/update — so ensurePKI's GET succeeds
+#       but the operator is STILL structurally incapable of PATCHing (hijacking)
+#       the cluster-singleton caBundle (the hijack was the PATCH verb, not GET).
+#       Needs a fresh S-plan (namespace) Org convergence to fully verify.
+#       Refs #4813 #4322 #4293.
+version: 1.0.15
 description: |
   Catalyst-curated Blueprint umbrella chart for CloudNativePG. Depends on
   the upstream `cloudnative-pg` chart as a Helm subchart so

--- a/platform/cnpg/chart/templates/per-org-operator-rbac.yaml
+++ b/platform/cnpg/chart/templates/per-org-operator-rbac.yaml
@@ -192,6 +192,22 @@ rules:
   - apiGroups: ["postgresql.cnpg.io"]
     resources: ["clusterimagecatalogs"]
     verbs: ["get", "list", "watch"]
+  # #4813 (2026-07-07): cnpg 1.29's operator startup ALWAYS runs
+  # controller.ensurePKI(), which does a cluster-scoped GET on the
+  # mutating/validating webhook configs to verify the caBundle — even for a
+  # namespace-scoped (clusterWide=false) per-Org operator. The G65 fix above
+  # omitted ALL webhookconfigurations verbs to kill the #4322 caBundle-hijack,
+  # but that also removed the GET ensurePKI needs → "cannot get resource
+  # mutatingwebhookconfigurations at the cluster scope" → operator
+  # CrashLoopBackOff → bp-cnpg InstallFailed → every DB-backed per-Org app
+  # (wordpress/newapi/openclaw) DependencyNotReady (live: hw228 walkstrangertwo,
+  # an S-plan namespace Org). FIX: grant READ-ONLY get/list/watch ONLY — NO
+  # patch/update/create/delete — so ensurePKI can verify the caBundle but the
+  # per-Org operator remains STRUCTURALLY INCAPABLE of PATCHing (hijacking) the
+  # cluster-singleton webhook. The hijack vector was the PATCH verb, not GET.
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Summary

Fixes a per-Org cnpg-operator CrashLoop that stalls the whole DB-backed app stack on **namespace-isolated (S-plan) Orgs** — found live by driving the funnel on hw228.

## Root cause (a post-1.0.14 regression)

The G65/1.0.14 fix (`per-org-operator-rbac.yaml`) deliberately stripped **all** `*webhookconfigurations` verbs from the per-Org operator's minimal ClusterRole to kill the #4322 caBundle-hijack. But cnpg 1.29's operator startup **always** runs `controller.ensurePKI()`, which does a cluster-scoped **GET** on the mutating/validating webhook configs to verify the caBundle — even for a namespace-scoped (`clusterWide=false`) per-Org operator. So the RBAC removal broke operator **startup**:

```
setup: unable to setup PKI infrastructure: mutatingwebhookconfigurations "cnpg-mutating-webhook-configuration"
is forbidden: User "system:serviceaccount:<org>:bp-cnpg-cloudnative-pg" cannot get resource
"mutatingwebhookconfigurations" at the cluster scope
```
→ CrashLoopBackOff → `bp-cnpg InstallFailed` → `bp-wordpress-tenant`/`bp-newapi` DependencyNotReady, `bp-openclaw` InstallFailed.

## Live evidence

Created an S-plan Org (`walkstrangertwo`) via the console; per the #4292 tier gate an S-plan Org lands **namespace-isolated** → its cnpg operator CrashLooped (restart 9) on exactly this GET → the app stack stalled at 2/7 HRs for 20+ min. M-plan+ Orgs (vcluster isolation) run cnpg **inside** the vcluster and are unaffected.

## Fix

Grant the per-Org operator **read-only `get`/`list`/`watch`** on `mutating/validatingwebhookconfigurations` — **no** `patch`/`update`/`create`/`delete`. `ensurePKI`'s GET now succeeds, but the operator remains **structurally incapable of PATCHing (hijacking)** the cluster-singleton caBundle — the #4322 hijack vector was the PATCH verb, not GET. Render-verified: the rule emits `get/list/watch` only. Chart `1.0.14 → 1.0.15`.

## Verification

`helm template` render confirms the new rule is read-only and only emits in webhook-less (per-Org) mode. **Datapath verification needs a fresh S-plan (namespace) Org convergence** — the fix lands the RBAC a namespace-isolated cnpg operator needs to start.

Refs #4813 #4322 #4293
