### PR TITLE
fix(#4833): right-size bp-stalwart-tenant CPU 1→500m so openclaw fits the S-plan quota

### DIFF
--- a/platform/stalwart-tenant/blueprint.yaml
+++ b/platform/stalwart-tenant/blueprint.yaml
@@ -56,7 +56,7 @@ spec:
   # webadmin stays in-cluster on `-web` with an optional default-off
   # `mailadmin.<slug>` HTTPRoute.
   # Per #817 Chart.yaml version MUST equal blueprint.yaml spec.version.
-  version: 0.1.12
+  version: 0.1.13
   card:
     title: Stalwart (per-Organization)
     summary: |

--- a/platform/stalwart-tenant/chart/Chart.yaml
+++ b/platform/stalwart-tenant/chart/Chart.yaml
@@ -166,7 +166,16 @@ name: bp-stalwart-tenant
 #   100m/64Mi — overridable) and wired it onto the Job container. The
 #   StatefulSet already declared resources (stalwart.resources); only the
 #   hook Job was missing them. Mirrors the bp-newapi hook-Job convention.
-version: 0.1.12
+#
+# 0.1.13 (#4272/#4307/#4292, 2026-07-07): right-size stalwart.resources CPU
+#   1 -> 500m (requests==limits, Guaranteed QoS preserved). A guaranteed FULL
+#   core for an idle per-Org mailserver consumed 50% of the S-plan's 2-vCPU
+#   plan-quota, so on a co-tenant S funnel Org (wordpress+mysql+stalwart+openclaw)
+#   bp-openclaw's controller (requests 500m) was quota-DENIED and UAT rows
+#   224/232 stayed red. Live-root-caused on hw228 walk-stranger: used 1600m/2000m
+#   with stalwart at 1000m. 500m is ample for an idle demo mailserver and frees
+#   the headroom openclaw needs to schedule. Refs #4272 #4307 #4292.
+version: 0.1.13
 appVersion: "0.15.5"
 description: |
   Catalyst Blueprint scratch chart for a per-Org (per-vcluster) dedicated

--- a/platform/stalwart-tenant/chart/values.yaml
+++ b/platform/stalwart-tenant/chart/values.yaml
@@ -99,12 +99,23 @@ stalwart:
   # #4389/#4292: per-Org LimitRange maxLimitRequestRatio {cpu:1,memory:1}
   # forces Guaranteed QoS — render requests==limits or the StatefulSet pod is
   # 'forbidden: limit to request ratio is 1'.
+  #
+  # CPU right-sized 1 -> 500m (2026-07-07): a guaranteed FULL core for an idle
+  # per-Org mailserver was 50% of the entire S-plan quota (plan-quota caps
+  # requests.cpu at 2). Live on hw228 walk-stranger (S-plan): stalwart-0 at 1000m
+  # + mysql 250m + wordpress 100m + webmail 250m = 1600m used, leaving only 400m
+  # — so bp-openclaw's controller (requests 500m) was quota-DENIED
+  # ('exceeded quota: plan-quota, requested cpu=500m, used=1600m, limited=2') and
+  # UAT rows 224/232 (#4272 openclaw Ready + /readyz) stayed red. openclaw and
+  # stalwart-tenant co-default on the S funnel bundle but were never co-sized to
+  # fit 2 vCPU. 500m guaranteed is ample for an idle demo mailserver and frees the
+  # headroom openclaw needs. Refs #4272 #4307 #4292.
   resources:
     requests:
-      cpu: "1"
+      cpu: "500m"
       memory: 1Gi
     limits:
-      cpu: "1"
+      cpu: "500m"
       memory: 1Gi
 
   # SecurityContext — non-root + NET_BIND_SERVICE (issue #898).


### PR DESCRIPTION
## What
Right-size `bp-stalwart-tenant` `stalwart.resources` CPU **1 → 500m** (requests==limits, Guaranteed QoS preserved). Chart 0.1.12 → 0.1.13.

## Why (live root-caused on hw228, Org `walk-stranger`, S-plan)
The S-plan `ResourceQuota plan-quota` caps `requests.cpu` at 2 cores. stalwart-tenant's main container requested a **guaranteed full core** — 50% of the whole Org budget for an idle mailserver. Live usage was **1600m/2000m** (stalwart 1000m + mysql 250m + wordpress 100m + webmail 250m), so `bp-openclaw`'s controller (requests 500m) was quota-DENIED:

```
exceeded quota: plan-quota, requested cpu=500m, used=1600m, limited=2
```

→ UAT rows **224** (#4272 openclaw Ready 1/1) and **232** (#4272 openclaw /readyz 200) stayed red. openclaw + stalwart-tenant co-default on the S funnel bundle but were never co-sized to fit 2 vCPU.

## Verification
- On the same walk, rows **93 / 94 / 95 / 234** are ✅ live (2nd voucher `VCH-96N4EYYN6YDJ`, console.walk-stranger 200 signed-in, wordpress.walk-stranger serving, mail.walk-stranger 200 SnappyMail).
- **224/232** flip once the 0.1.13 chart rolls: stalwart drops to 500m → used 1100m → openclaw (500m) schedules within the 2-core cap.
- 500m guaranteed is ample for an idle demo mailserver.

Refs #4833 #4272 #4307 #4292

🤖 Generated with [Claude Code](https://claude.com/claude-code)