### PR TITLE
fix(#4833): pin fresh funnel-Org stalwart-mail to 0.1.13 so openclaw fits S-plan quota

### DIFF
--- a/core/services/provisioning/main.go
+++ b/core/services/provisioning/main.go
@@ -185,8 +185,11 @@ func main() {
 	// ghcr artifact broke every Org install; majors could jump ungated).
 	// Defaults = the current catalog-seed pins; operators override via env.
 	// A missing/malformed entry falls back to "*" (never fatal).
+	// stalwart-mail 0.1.13 (#4833): CPU right-sized 1->500m so bp-openclaw's
+	// controller fits the S-plan 2-vCPU plan-quota on a co-tenant funnel Org
+	// (0.1.12's guaranteed full core starved openclaw → UAT 224/232 red).
 	generator.HelmReleaseAppVersions = gitops.ParseHRAppVersions(getEnv(
-		"CATALYST_HR_APP_CHART_VERSIONS", "openclaw=0.2.13,stalwart-mail=0.1.12"))
+		"CATALYST_HR_APP_CHART_VERSIONS", "openclaw=0.2.13,stalwart-mail=0.1.13"))
 
 	// #4282/#4275 CROSS-REGION STANDBY: the flux-system Secret name holding
 	// region-B's (the STANDBY region's) host-cluster kubeconfig. The per-Org


### PR DESCRIPTION
## What
Bump the provisioning service's `CATALYST_HR_APP_CHART_VERSIONS` default `stalwart-mail=0.1.12` → `0.1.13`.

## Why
#4834 (merged) right-sized `bp-stalwart-tenant` CPU 1→500m (chart 0.1.13, published to GHCR) so `bp-openclaw`'s controller fits the S-plan 2-vCPU `plan-quota`. But the funnel provisioning service still defaulted the per-Org stalwart pin to **0.1.12**, so a fresh funnel Org would re-install the guaranteed-full-core stalwart and re-starve openclaw → UAT **224/232** stay red.

`bp-stalwart-tenant` is a StatefulSet with `volumeClaimTemplates` and **cannot be helm-upgraded in place** (both upgrade and rollback fail `forbidden: updates to statefulset spec`), so a fresh-install pin is the only propagation path. This makes the next fresh prov install 0.1.13 → openclaw schedules → 224/232 flip.

## Verification
- Root-caused live on hw228 `walk-stranger`: `exceeded quota: plan-quota, requested cpu=500m, used=1600m, limited=2`.
- `TestParseHRAppVersions` unaffected (parser test with a literal input, not the default).

Refs #4833 #4834 #4272 #4307

🤖 Generated with [Claude Code](https://claude.com/claude-code)