### PR TITLE
fix(#4838): Factory.Stop() waits for snapshot loop to drain (kills recurring TempDir flake)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/k8scache/factory.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/factory.go
@@ -240,6 +240,14 @@ type Factory struct {
 	stopOnce sync.Once
 	stop     chan struct{}
 
+	// loopWG tracks the Start-spawned background loops (snapshot writer +
+	// kubeconfigs rescan) so Stop() can WAIT for them to fully exit — draining
+	// any in-flight snapshot write — before returning. Without the wait,
+	// Stop() only closed `stop` and returned, so a test's t.TempDir() cleanup
+	// (RemoveAll) raced runSnapshotLoop's eager snapshotOnce write →
+	// "directory not empty" flake (TestSnapshot_HydrateStaleThenRelist).
+	loopWG sync.WaitGroup
+
 	// started + runCtx (#4000) — set once Start() has run. AddCluster
 	// consults these so a cluster registered AFTER the factory started
 	// (the rescan loop, the secondary-kubeconfig POST handler, the #4001
@@ -762,7 +770,8 @@ func (f *Factory) Start(ctx context.Context) error {
 	}
 
 	if f.cfg.SnapshotDir != "" {
-		go f.runSnapshotLoop(ctx)
+		f.loopWG.Add(1)
+		go func() { defer f.loopWG.Done(); f.runSnapshotLoop(ctx) }()
 	}
 
 	// Periodic kubeconfigs-dir rescan + chroot self-register recovery.
@@ -775,7 +784,8 @@ func (f *Factory) Start(ctx context.Context) error {
 	// treemap multi-region only showed 1 cluster). See Config.RescanInterval
 	// godoc for the full root-cause analysis.
 	if f.cfg.KubeconfigsDir != "" || f.cfg.HomeCoreClient != nil {
-		go f.runKubeconfigsRescanLoop(ctx)
+		f.loopWG.Add(1)
+		go func() { defer f.loopWG.Done(); f.runKubeconfigsRescanLoop(ctx) }()
 	}
 
 	return nil
@@ -973,9 +983,14 @@ func (f *Factory) readSovereignFQDNFromConfigMap(ctx context.Context) string {
 	return strings.TrimSpace(cm.Data["fqdn"])
 }
 
-// Stop signals every informer + the snapshot loop to exit. Idempotent.
+// Stop signals every informer + the snapshot loop to exit, then WAITS for
+// the Start-spawned background loops to fully drain (any in-flight snapshot
+// write completes) before returning. Idempotent. The wait is what makes
+// Stop() safe to pair with a test's t.TempDir() cleanup — without it the
+// RemoveAll raced runSnapshotLoop's write ("directory not empty").
 func (f *Factory) Stop() {
 	f.stopOnce.Do(func() { close(f.stop) })
+	f.loopWG.Wait()
 }
 
 // Synced returns true when at least one informer per cluster has


### PR DESCRIPTION
## What
`Factory.Stop()` now WAITs for the Start-spawned background loops to drain before returning.

## Why
`TestSnapshot_HydrateStaleThenRelist` recurringly flaked `directory not empty` on `t.TempDir()` cleanup — `Stop()` only `close(f.stop)` and returned, so `runSnapshotLoop`'s eager `snapshotOnce` write raced Go's `RemoveAll`. Blocks CI on every api-module PR (#4831, #4837).

## How
`loopWG sync.WaitGroup`; wrap `runSnapshotLoop` + `runKubeconfigsRescanLoop`; `Stop()` `f.loopWG.Wait()`. Both loops already `select` on `f.stop` → bounded wait, no hang.

## Verified
`go test -run TestSnapshot_HydrateStaleThenRelist -count=20 -race` → green (was flaky); full k8scache package green.

Refs #4838

🤖 Generated with [Claude Code](https://claude.com/claude-code)