### PR TITLE
fix(#4836): accept #3969 placement targets[] in HandleApplicationUpdate (UAT G10) [re-open]

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications.go
@@ -72,6 +72,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/dynamic"
 
+	bpv1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
 	"github.com/openova-io/openova/core/controllers/pkg/validate"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
 )
@@ -126,6 +127,17 @@ type applicationPlacement struct {
 	// Clusters — canonical cluster IDs narrowing the topology
 	// fan-out for THIS instance.
 	Clusters []string `json:"clusters,omitempty"`
+
+	// Targets — the #3969 per-region placement model the console
+	// PlacementEditor sends: [{region, role:Primary|Standby,
+	// standbyType:Hot|Cold}]. When present with an empty Mode (the
+	// switchover / add-target flows, UAT row G10), the update handler folds
+	// it onto the canonical mode+regions the CR stores — Mode via
+	// bpv1.DerivePattern (the single source of pattern truth) and Regions
+	// Primary-first so regions[0] is the primary (placement_projection.go
+	// keys primaryRegion off regions[0]). Legacy {mode,regions} callers are
+	// unaffected. Refs #3969 #3375.
+	Targets []bpv1.PlacementTarget `json:"targets,omitempty"`
 }
 
 // validVClusterTier — accepted spec.placement.vcluster values

--- a/products/catalyst/bootstrap/api/internal/handler/applications_update.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_update.go
@@ -39,6 +39,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	bpv1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
 	"github.com/openova-io/openova/core/controllers/pkg/validate"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
 )
@@ -122,7 +123,45 @@ func applicationUpdateRequestNormalize(b applicationUpdateRequest) applicationUp
 	if strings.TrimSpace(b.DisplayName) == "" && strings.TrimSpace(b.TitleShort) != "" {
 		b.DisplayName = strings.TrimSpace(b.TitleShort)
 	}
+	// #3969 / row G10: the console PlacementEditor PUTs the per-region
+	// targets model — {placement:{targets:[{region,role,standbyType}]}} —
+	// with no mode/regions, so the legacy validator (placement.mode is
+	// required) 400'd the switchover / add-target flows. Fold targets onto
+	// the canonical mode+regions the Application CR stores: Mode via
+	// bpv1.DerivePattern (the ONLY place patterns come from, #3969 §7.3) and
+	// Regions Primary-first (regions[0] == primary, per placement_projection).
+	// Only fires when Mode is empty, so an explicit {mode,regions} caller (or
+	// a body that sets both) is byte-unchanged.
+	if b.Placement != nil && len(b.Placement.Targets) > 0 && strings.TrimSpace(b.Placement.Mode) == "" {
+		b.Placement.Mode = string(bpv1.DerivePattern(b.Placement.Targets, ""))
+		if len(b.Placement.Regions) == 0 {
+			b.Placement.Regions = regionsFromPlacementTargets(b.Placement.Targets)
+		}
+	}
 	return b
+}
+
+// regionsFromPlacementTargets flattens the #3969 targets model into the
+// legacy spec.regions list, Primary target(s) first so regions[0] is the
+// primary region (placement_projection.go derives status.placement.
+// primaryRegion from regions[0] for the single-primary modes). Duplicate
+// regions are dropped; relative order is otherwise preserved.
+func regionsFromPlacementTargets(targets []bpv1.PlacementTarget) []string {
+	seen := map[string]bool{}
+	var primaries, rest []string
+	for _, t := range targets {
+		r := strings.TrimSpace(t.Region)
+		if r == "" || seen[r] {
+			continue
+		}
+		seen[r] = true
+		if t.Role == bpv1.DataRolePrimary {
+			primaries = append(primaries, r)
+		} else {
+			rest = append(rest, r)
+		}
+	}
+	return append(primaries, rest...)
 }
 
 // applicationUpdateResponse mirrors applicationStatusResponse — the UI

--- a/products/catalyst/bootstrap/api/internal/handler/applications_update_placement_targets_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_update_placement_targets_test.go
@@ -97,3 +97,5 @@ func TestApplicationUpdateNormalize_ExplicitModeWins(t *testing.T) {
 		t.Errorf("explicit regions overwritten: got %v", got.Placement.Regions)
 	}
 }
+
+// (ci: retrigger test workflow after rebase onto flake fix #4839 — path-filtered job needs a Go-file change)

--- a/products/catalyst/bootstrap/api/internal/handler/applications_update_placement_targets_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_update_placement_targets_test.go
@@ -1,0 +1,99 @@
+package handler
+
+import (
+	"reflect"
+	"testing"
+
+	bpv1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
+)
+
+// TestApplicationUpdateNormalize_TargetsDeriveModeAndRegions (#3969 / row G10):
+// the console PlacementEditor PUTs the per-region targets model with no
+// mode/regions. applicationUpdateRequestNormalize must fold it onto the
+// canonical spec.placement(mode)+spec.regions the CR stores — Mode via
+// bpv1.DerivePattern, Regions Primary-first (regions[0]==primary) — so the
+// switchover / add-target flows stop 400'ing on "placement.mode is required".
+func TestApplicationUpdateNormalize_TargetsDeriveModeAndRegions(t *testing.T) {
+	cases := []struct {
+		name        string
+		targets     []bpv1.PlacementTarget
+		wantMode    string
+		wantRegions []string
+	}{
+		{
+			name:        "singleton (1 primary)",
+			targets:     []bpv1.PlacementTarget{{Region: "me-east-215-a", Role: bpv1.DataRolePrimary}},
+			wantMode:    "singleton",
+			wantRegions: []string{"me-east-215-a"},
+		},
+		{
+			name: "add-target: singleton -> active-hot-standby",
+			targets: []bpv1.PlacementTarget{
+				{Region: "me-east-215-a", Role: bpv1.DataRolePrimary},
+				{Region: "me-east-215-b", Role: bpv1.DataRoleStandby, StandbyType: bpv1.StandbyHot},
+			},
+			wantMode:    "active-hot-standby",
+			wantRegions: []string{"me-east-215-a", "me-east-215-b"},
+		},
+		{
+			name: "switchover: primary flips to region-b (regions[0]==primary)",
+			targets: []bpv1.PlacementTarget{
+				{Region: "me-east-215-b", Role: bpv1.DataRolePrimary},
+				{Region: "me-east-215-a", Role: bpv1.DataRoleStandby, StandbyType: bpv1.StandbyHot},
+			},
+			wantMode:    "active-hot-standby",
+			wantRegions: []string{"me-east-215-b", "me-east-215-a"},
+		},
+		{
+			name: "active-passive (cold standby)",
+			targets: []bpv1.PlacementTarget{
+				{Region: "me-east-215-a", Role: bpv1.DataRolePrimary},
+				{Region: "me-east-215-b", Role: bpv1.DataRoleStandby, StandbyType: bpv1.StandbyCold},
+			},
+			wantMode:    "active-passive",
+			wantRegions: []string{"me-east-215-a", "me-east-215-b"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := applicationUpdateRequestNormalize(applicationUpdateRequest{
+				Placement: &applicationPlacement{Targets: tc.targets},
+			})
+			if got.Placement == nil {
+				t.Fatalf("placement dropped")
+			}
+			if got.Placement.Mode != tc.wantMode {
+				t.Errorf("mode = %q, want %q", got.Placement.Mode, tc.wantMode)
+			}
+			if !reflect.DeepEqual(got.Placement.Regions, tc.wantRegions) {
+				t.Errorf("regions = %v, want %v", got.Placement.Regions, tc.wantRegions)
+			}
+			// The whole point: validation must now PASS (previously 400'd
+			// "placement.mode is required when placement is set").
+			if msg, ok := validateApplicationUpdateRequest(got); !ok {
+				t.Errorf("validation failed after targets fold: %s", msg)
+			}
+		})
+	}
+}
+
+// TestApplicationUpdateNormalize_ExplicitModeWins: a legacy {mode,regions}
+// caller (or one that sets both) is byte-unchanged — the targets fold only
+// fires when Mode is empty.
+func TestApplicationUpdateNormalize_ExplicitModeWins(t *testing.T) {
+	got := applicationUpdateRequestNormalize(applicationUpdateRequest{
+		Placement: &applicationPlacement{
+			Mode:    "singleton",
+			Regions: []string{"me-east-215-a"},
+			Targets: []bpv1.PlacementTarget{
+				{Region: "me-east-215-b", Role: bpv1.DataRolePrimary},
+			},
+		},
+	})
+	if got.Placement.Mode != "singleton" {
+		t.Errorf("explicit mode overwritten: got %q", got.Placement.Mode)
+	}
+	if !reflect.DeepEqual(got.Placement.Regions, []string{"me-east-215-a"}) {
+		t.Errorf("explicit regions overwritten: got %v", got.Placement.Regions)
+	}
+}


### PR DESCRIPTION
Recovery of the placement-contract change (the prior PR #4837 was accidentally retired during a CI-retrigger; GitHub blocked its re-open due to a rebased head SHA). Same verified change.

## What
HandleApplicationUpdate now accepts the console's #3969 targets[] placement model — it folds the targets into canonical mode+regions via bpv1.DerivePattern (Primary-first so regions[0] is the primary). Unblocks console switchover + add-target (UAT G10), which returned 400 placement.mode is required.

## Tests
TestApplicationUpdateNormalize_TargetsDeriveModeAndRegions (singleton / add-target / switchover / active-passive) + _ExplicitModeWins — all pass locally; build clean. Rebased onto main, which already includes the k8scache flake remediation from #4839.

Refs #4836 #3969 #3375

<!-- refs-only; no auto-close keywords -->