### PR TITLE
fix(#4843): Edit-IaC editor seeds committable YAML (inline empty maps + strip server fields)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/widgets/cloud-list/YamlEditor.iac.test.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/cloud-list/YamlEditor.iac.test.ts
@@ -1,0 +1,92 @@
+/**
+ * YamlEditor.iac.test.ts — #4843 regression: the "Edit IaC" editor must seed
+ * COMMITTABLE YAML from a live Blueprint CR.
+ *
+ * Root cause (UAT hw228 rows 148/154): the live CR carries
+ * `metadata.managedFields` whose entries hold empty `fieldsV1: {}` maps.
+ * objectToYAML() rendered an empty MAP as a bare `{}` pushed onto its own
+ * UNINDENTED line, producing invalid YAML — `PUT /catalog/{bp}/iac` then 400'd
+ * (`yaml: line N: could not find expected ':'`). Two fixes, both asserted here:
+ *   1. objectToYAML inlines empty objects (`k: {}`) like it already did empty
+ *      arrays (`k: []`).
+ *   2. stripServerFields removes managedFields/status/runtime metadata from the
+ *      seed (matching the server-side application_iac_git.go sanitiser).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { load as parseYAML } from 'js-yaml'
+
+import { objectToYAML, stripServerFields } from './YamlEditor'
+import type { K8sObject } from '@/widgets/architecture-graph/useK8sCacheStream'
+
+describe('#4843 objectToYAML empty-container handling', () => {
+  it('inlines an empty object as `k: {}` (not a bare {} on its own line)', () => {
+    const out = objectToYAML({ metadata: { fieldsV1: {} } })
+    // The empty map must be inline; a bare `{}` at column 0 is the bug.
+    expect(out).not.toMatch(/^\{\}$/m)
+    expect(out).toContain('fieldsV1: {}')
+    // …and the whole thing must be valid YAML that round-trips.
+    expect(() => parseYAML(out)).not.toThrow()
+  })
+
+  it('still inlines an empty array as `k: []`', () => {
+    expect(objectToYAML({ items: [] })).toContain('items: []')
+  })
+
+  it('keeps non-empty nested objects on indented lines', () => {
+    const out = objectToYAML({ spec: { version: '1.2.3' } })
+    expect(out).toContain('spec:\n  version: 1.2.3')
+    expect(() => parseYAML(out)).not.toThrow()
+  })
+})
+
+describe('#4843 stripServerFields', () => {
+  const liveCR: K8sObject = {
+    apiVersion: 'catalog.openova.io/v1alpha1',
+    kind: 'Blueprint',
+    metadata: {
+      name: 'bp-wordpress',
+      resourceVersion: '918273',
+      uid: 'abc-123',
+      generation: 4,
+      creationTimestamp: '2026-07-06T00:00:00Z',
+      managedFields: [
+        { manager: 'flux', operation: 'Apply', fieldsType: 'FieldsV1', fieldsV1: {} },
+      ],
+    },
+    spec: { version: '0.4.12', manifests: { chart: 'bp-wordpress-tenant' } },
+    status: { phase: 'Ready' },
+  } as unknown as K8sObject
+
+  it('drops managedFields/status/runtime metadata but keeps the authored contract', () => {
+    const clean = stripServerFields(liveCR) as Record<string, unknown>
+    const meta = clean.metadata as Record<string, unknown>
+    expect(meta.managedFields).toBeUndefined()
+    expect(meta.resourceVersion).toBeUndefined()
+    expect(meta.uid).toBeUndefined()
+    expect(meta.generation).toBeUndefined()
+    expect(meta.creationTimestamp).toBeUndefined()
+    expect(clean.status).toBeUndefined()
+    // User-authored fields survive.
+    expect(meta.name).toBe('bp-wordpress')
+    expect(clean.spec).toEqual({ version: '0.4.12', manifests: { chart: 'bp-wordpress-tenant' } })
+  })
+
+  it('does not mutate the source object (live query cache safety)', () => {
+    stripServerFields(liveCR)
+    expect((liveCR.metadata as Record<string, unknown>).managedFields).toBeDefined()
+    expect((liveCR as Record<string, unknown>).status).toBeDefined()
+  })
+
+  it('end-to-end: a live CR with managedFields seeds COMMITTABLE YAML', () => {
+    // This is the exact hw228 148/154 failure path: seed the editor the way
+    // YamlEditor does (stripServerFields → objectToYAML) and prove it parses.
+    const seed = objectToYAML(stripServerFields(liveCR))
+    expect(seed).not.toMatch(/^\{\}$/m)
+    const parsed = parseYAML(seed) as Record<string, unknown>
+    expect(parsed.kind).toBe('Blueprint')
+    expect((parsed.metadata as Record<string, unknown>).name).toBe('bp-wordpress')
+    expect((parsed.spec as Record<string, unknown>).version).toBe('0.4.12')
+    expect((parsed.metadata as Record<string, unknown>).managedFields).toBeUndefined()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/widgets/cloud-list/YamlEditor.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/cloud-list/YamlEditor.tsx
@@ -72,7 +72,7 @@ export interface YamlEditorProps {
  *  js-yaml; for the editor's seed-text use we keep the dependency
  *  surface minimal by stringifying via JSON.stringify + a YAML adapter
  *  that's good enough for `kubectl apply -f` round-trip. */
-function objectToYAML(obj: unknown, indent = 0): string {
+export function objectToYAML(obj: unknown, indent = 0): string {
   const pad = '  '.repeat(indent)
   if (obj === null || obj === undefined) return 'null'
   if (typeof obj === 'string') {
@@ -99,7 +99,16 @@ function objectToYAML(obj: unknown, indent = 0): string {
     if (entries.length === 0) return '{}'
     return entries
       .map(([k, v]) => {
-        if (v && typeof v === 'object' && (!Array.isArray(v) || v.length > 0)) {
+        // Newline+indent ONLY for a NON-EMPTY container. An empty object or
+        // empty array is a scalar-like leaf and MUST stay inline (`k: {}` /
+        // `k: []`). The old test (`!Array.isArray(v) || v.length > 0`) newlined
+        // an empty MAP, and objectToYAML({}) returns a bare `{}` with NO
+        // indent — so an empty map like a k8s `fieldsV1: {}` landed as `{}` at
+        // column 0, invalid YAML that made "Edit IaC" uncommittable (#4843).
+        const nonEmptyContainer =
+          !!v && typeof v === 'object' &&
+          (Array.isArray(v) ? v.length > 0 : Object.keys(v).length > 0)
+        if (nonEmptyContainer) {
           return `${pad}${k}:\n${objectToYAML(v, indent + 1)}`
         }
         return `${pad}${k}: ${objectToYAML(v, indent)}`
@@ -107,6 +116,34 @@ function objectToYAML(obj: unknown, indent = 0): string {
       .join('\n')
   }
   return String(obj)
+}
+
+/** Strip server-populated / runtime fields that are NOT part of the
+ *  user-authored IaC contract before seeding the editor — mirrors the
+ *  server-side sanitiser in application_iac_git.go (`status`,
+ *  `metadata.managedFields`, …). Presenting them is noise, and
+ *  `metadata.managedFields` in particular carries empty `fieldsV1: {}` maps
+ *  that historically serialised to uncommittable YAML (#4843). Shallow-clones
+ *  so the live query object is never mutated. */
+export function stripServerFields(obj: K8sObject): K8sObject {
+  const clone: Record<string, unknown> = { ...(obj as Record<string, unknown>) }
+  delete clone.status
+  const meta = clone.metadata
+  if (meta && typeof meta === 'object' && !Array.isArray(meta)) {
+    const m: Record<string, unknown> = { ...(meta as Record<string, unknown>) }
+    for (const k of [
+      'managedFields',
+      'resourceVersion',
+      'uid',
+      'generation',
+      'creationTimestamp',
+      'selfLink',
+    ]) {
+      delete m[k]
+    }
+    clone.metadata = m
+  }
+  return clone as K8sObject
 }
 
 interface DiffLine {
@@ -134,7 +171,7 @@ function computeDiff(left: string, right: string): DiffLine[] {
 }
 
 export function YamlEditor({ deploymentId, kind, ns, name, obj, fluxOverride, onCommit, commitLabel, onCreateEditor }: YamlEditorProps) {
-  const initial = useMemo(() => (obj ? objectToYAML(obj) : ''), [obj])
+  const initial = useMemo(() => (obj ? objectToYAML(stripServerFields(obj)) : ''), [obj])
   const [yaml, setYaml] = useState<string>(initial)
   const [showDiff, setShowDiff] = useState(false)
   const [validateMsg, setValidateMsg] = useState<string | null>(null)


### PR DESCRIPTION
## What
Fixes the console **Edit IaC** editor presenting **un-committable YAML** for any Blueprint whose live CR carries `metadata.managedFields` (UAT hw228 rows 148/154).

## Root cause
`YamlEditor.objectToYAML()` inlined empty **arrays** (`k: []`) but newlined empty **objects**, and `objectToYAML({})` returns a bare `{}` with no indent → a managedFields `fieldsV1: {}` landed as `{}` at column 0 → invalid YAML → `PUT /catalog/{bp}/iac` **400** (`yaml: line N: could not find expected ':'`). Isolated live: managedFields-stripped PUT → 200.

## Fix
1. `objectToYAML` inlines empty objects (`k: {}`) like empty arrays.
2. `stripServerFields` drops `status` + `metadata.{managedFields,resourceVersion,uid,generation,creationTimestamp,selfLink}` from the editor seed — mirrors the server-side `application_iac_git.go` sanitiser.

## Tests
`YamlEditor.iac.test.ts` (6 cases): empty-map inlining, empty-array still inlined, non-empty nesting preserved, strip drops runtime fields but keeps the authored contract, no source mutation, and an **end-to-end round-trip** proving a live CR with managedFields seeds YAML that parses. Existing `YamlEditor.test.tsx` still green (7/7).

Refs #4843 · UAT 148/154

🤖 Generated with [Claude Code](https://claude.com/claude-code)