### PR TITLE
fix(#4846): cross-region shared-pg netpol — ipBlock allow for ClusterMesh remote-cluster sources

### DIFF
--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -236,6 +236,15 @@ spec:
       # active-hot-standby consumer-allow. Live regression on b9f9590b.
       networkPolicy:
         sharedConsumers: true
+        # crossRegionPodCIDRs (#4846) — admit the PEER region's pods to 5432 so
+        # region-b consumers (keycloak/grafana/…) + the region-b replica's
+        # pg_basebackup reach the primary. k8s netpol label rules are implicitly
+        # local-cluster-scoped (Cilium ANDs io.cilium.k8s.policy.cluster=<local>),
+        # so remote-cluster sources are dropped; an ipBlock matches by raw IP and
+        # is NOT scoped. 10.42.0.0/15 is the deterministic pod supernet spanning
+        # BOTH regions (01-cilium ipv4NativeRoutingCIDR). Only consumed in
+        # active-hot-standby; singleton ignores it (byte-identical default).
+        crossRegionPodCIDRs: ['${SOVEREIGN_POD_SUPERNET_CIDR:-10.42.0.0/15}']
     # The three bindings — the reuse proof. Three isolated databases +
     # three roles on ONE Cluster; each reflected into its consumer's
     # namespace.

--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -153,7 +153,7 @@ spec:
       # harbor NXDOMAIN'd on a fresh 2-region prov (0 remote clusters ready). The
       # cross-mesh consumer-5432 path is already opened by 0.2.7's sharedConsumers
       # (#4442). Lockstep with 16c/16d.
-      version: 0.2.8
+      version: 0.2.9
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
+++ b/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
@@ -138,6 +138,15 @@ spec:
       # them). See slot 16a for the full rationale.
       networkPolicy:
         sharedConsumers: true
+        # crossRegionPodCIDRs (#4846) — admit the PEER region's pods to 5432 so
+        # region-b consumers (keycloak/grafana/…) + the region-b replica's
+        # pg_basebackup reach the primary. k8s netpol label rules are implicitly
+        # local-cluster-scoped (Cilium ANDs io.cilium.k8s.policy.cluster=<local>),
+        # so remote-cluster sources are dropped; an ipBlock matches by raw IP and
+        # is NOT scoped. 10.42.0.0/15 is the deterministic pod supernet spanning
+        # BOTH regions (01-cilium ipv4NativeRoutingCIDR). Only consumed in
+        # active-hot-standby; singleton ignores it (byte-identical default).
+        crossRegionPodCIDRs: ['${SOVEREIGN_POD_SUPERNET_CIDR:-10.42.0.0/15}']
     databases:
       # grafana — FLIPPED (see header). The extraData keys are grafana's
       # native GF_DATABASE_* env contract; GF_DATABASE_HOST carries

--- a/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
+++ b/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
@@ -91,7 +91,7 @@ spec:
       # global Service aliases decoupled from the cnpg-pair flip → render on the
       # multi-region signal so cross-region grafana/powerdns/pda hosts resolve the
       # moment the mesh peers. Lockstep with 16a/16d.
-      version: 0.2.8
+      version: 0.2.9
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
+++ b/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
@@ -126,6 +126,15 @@ spec:
       # them). See slot 16a for the full rationale.
       networkPolicy:
         sharedConsumers: true
+        # crossRegionPodCIDRs (#4846) — admit the PEER region's pods to 5432 so
+        # region-b consumers (keycloak/grafana/…) + the region-b replica's
+        # pg_basebackup reach the primary. k8s netpol label rules are implicitly
+        # local-cluster-scoped (Cilium ANDs io.cilium.k8s.policy.cluster=<local>),
+        # so remote-cluster sources are dropped; an ipBlock matches by raw IP and
+        # is NOT scoped. 10.42.0.0/15 is the deterministic pod supernet spanning
+        # BOTH regions (01-cilium ipv4NativeRoutingCIDR). Only consumed in
+        # active-hot-standby; singleton ignores it (byte-identical default).
+        crossRegionPodCIDRs: ['${SOVEREIGN_POD_SUPERNET_CIDR:-10.42.0.0/15}']
     # The Organization-mesh bindings: three isolated databases, ONE role `org`
     # (chart 0.1.5 dedupes the role + password Secret across same-owner
     # bindings). Database names mirror orgPostgres.cluster.database +

--- a/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
+++ b/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
@@ -79,7 +79,7 @@ spec:
       # global Service aliases decoupled from the cnpg-pair flip → render on the
       # multi-region signal so the cross-region Organization-mesh / newapi /
       # openova-flow hosts resolve the moment the mesh peers. Lockstep 16a/16c.
-      version: 0.2.8
+      version: 0.2.9
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/platform/postgres/blueprint.yaml
+++ b/platform/postgres/blueprint.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   # 0.2.8 (#4460): -mesh/-mesh-rw global Service aliases decoupled from the
   # cnpg-pair flip (render on the multi-region signal; region-B NXDOMAIN fix).
-  version: 0.2.8
+  version: 0.2.9
   card:
     title: PostgreSQL
     summary: |

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -145,7 +145,7 @@ name: bp-postgres
 #   carve-outs (sync GUCs, replica-Pod cross-cluster allow, own-cluster
 #   pg_basebackup join, replica-side policy) stay $ahs-gated. Post-flip render is
 #   byte-identical to 0.2.7's $ahs shape.
-version: 0.2.8
+version: 0.2.9
 appVersion: "0.1.2"
 description: |
   Catalyst-authored data-instance Blueprint for a shareable, reusable

--- a/platform/postgres/chart/templates/networkpolicy.yaml
+++ b/platform/postgres/chart/templates/networkpolicy.yaml
@@ -91,6 +91,22 @@ spec:
           protocol: TCP
         - port: {{ .Values.topology.networkPolicy.operatorMetricsPort }}
           protocol: TCP
+    # CROSS-REGION pod CIDRs (#4846): the REPLICA region's Pods (consumers +
+    # the replica Cluster's pg_basebackup / streaming) reach the primary's 5432
+    # by RAW SOURCE IP via ipBlock. k8s NetworkPolicy namespaceSelector/
+    # podSelector are implicitly scoped to the LOCAL cluster (Cilium ANDs
+    # `io.cilium.k8s.policy.cluster=<local>`), so the region-b (remote-cluster)
+    # sources above are NOT matched and get default-denied → timeout (region-b
+    # grafana CrashLoop + replica stuck "Setting up primary" on hw228). ipBlock
+    # matches by IP, not endpoint identity, so it is NOT subject to that scope.
+    {{- range .Values.topology.networkPolicy.crossRegionPodCIDRs }}
+    - from:
+        - ipBlock:
+            cidr: {{ . | quote }}
+      ports:
+        - port: 5432
+          protocol: TCP
+    {{- end }}
 {{- end }}
 {{- if $isReplica }}
 ---
@@ -134,5 +150,17 @@ spec:
           protocol: TCP
         - port: {{ .Values.topology.networkPolicy.operatorMetricsPort }}
           protocol: TCP
+    # CROSS-REGION pod CIDRs (#4846): the PRIMARY region's Pods (the primary
+    # Cluster streaming to this replica + consumers reading the replica's
+    # -mesh-rw) reach the replica's 5432 by RAW SOURCE IP via ipBlock — same
+    # local-cluster-scope bypass as the primary side above.
+    {{- range .Values.topology.networkPolicy.crossRegionPodCIDRs }}
+    - from:
+        - ipBlock:
+            cidr: {{ . | quote }}
+      ports:
+        - port: 5432
+          protocol: TCP
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/platform/postgres/chart/values.yaml
+++ b/platform/postgres/chart/values.yaml
@@ -199,6 +199,22 @@ topology:
     # consumers are same-Org, covered by allow-same-org — no broad open). The
     # host shared-data slots set it true.
     sharedConsumers: false
+    # crossRegionPodCIDRs (#4846) — pod CIDRs of the OTHER region('s) cluster,
+    # allowed to reach this instance's 5432 for cross-region replication +
+    # shared-consumer reach. REQUIRED in a 2-region (active-hot-standby)
+    # Sovereign: k8s NetworkPolicy namespaceSelector/podSelector are implicitly
+    # scoped to the LOCAL cluster (Cilium ANDs `io.cilium.k8s.policy.cluster=
+    # <local>`), so ClusterMesh REMOTE-cluster sources (region-b keycloak/
+    # grafana consumers + the region-b replica's pg_basebackup) are NEVER
+    # matched by the label rules above and get default-denied → timeout (region-b
+    # grafana CrashLoop, replica stuck "Setting up primary" 30h, keycloak JGroups
+    # JDBC timeout — all on hw228). An `ipBlock` rule matches by raw source IP,
+    # NOT endpoint identity, so it is NOT subject to that local-cluster scoping
+    # and admits the remote region's pods. The bootstrap-kit wires this to the
+    # secondary region's pod CIDR(s) (SOVEREIGN_REPLICA_POD_CIDR / the peer
+    # region's cluster-pool CIDR) in active-hot-standby mode. EMPTY (default) →
+    # singleton renders NO ipBlock rule (byte-identical single-region default).
+    crossRegionPodCIDRs: []
 
 # ── Bindings (the shareable part) ───────────────────────────────────────
 # Each entry binds ONE consumer to this instance. The chart renders a


### PR DESCRIPTION
## What
Fixes the region-b DR failure (#4846): on a 2-region Sovereign, region-b pods cannot reach region-a-hosted shared-pg → the region-b replica sits at "Setting up primary" for 30h (ready count 0), grafana CrashLoop, keycloak JGroups timeout, and G12 region-kill / Pillar-3 is stalled.

## Root cause (cilium-dbg verified on the live env)
k8s NetworkPolicy `namespaceSelector: {}` / `podSelector` are implicitly scoped to the local cluster — Cilium ANDs `io.cilium.k8s.policy.cluster=<local>`. Region-b endpoints carry `…cluster=<secondary>` (remote), so the shared-pg policy label rules never match them → default-deny → timeout. Identity propagation works (region-a sees the region-b pod's full labels); the issue is the implicit local-cluster scope. Direct node datapath works (native routing #4807) — this is the policy layer, not #4656/MTU.

## Fix
`topology.networkPolicy.crossRegionPodCIDRs` (list) → rendered as an `ipBlock` ingress on 5432 (primary + replica sides). ipBlock matches by raw source IP, not endpoint identity, so it bypasses the local-cluster scope and admits the remote region's pods. Wired in bootstrap-kit slots 16a/16c/16d to the deterministic pod supernet `10.42.0.0/15` (spans both regions per 01-cilium ipv4NativeRoutingCIDR), overridable via `SOVEREIGN_POD_SUPERNET_CIDR`. Singleton renders NO ipBlock (byte-identical single-region default).

## Tests (render)
- singleton → 0 ipBlock (byte-identical default)
- active-hot-standby + 1 CIDR → primary side 1, replica side 1
- multi-CIDR → 2; full render is valid YAML

## Required follow-up (separate PR)
Mirror the same shape into `platform/cnpg-pair/chart` NetworkPolicy, and verify on a fresh 2-region prov: region-b replica bootstraps (ready count > 0) + region-b grafana/keycloak reach the write host.

Refs #4846 · UAT G12/R12/236/67/51-64

🤖 Generated with [Claude Code](https://claude.com/claude-code)
