### PR TITLE
fix(#4846): cnpg-pair cross-region netpol — ipBlock allow for ClusterMesh remote sources (DR-pair half)

### DIFF
--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -197,7 +197,7 @@ spec:
       # 0.2.6 (#3740): replication-source mesh Service flipped
       # selectorType r→rw so the cross-region replica streams from the
       # PRIMARY's walsender (not a cascaded local standby) → sync_state=sync.
-      version: 0.2.7
+      version: 0.2.8
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg-pair
@@ -277,6 +277,16 @@ spec:
         region: '${SOVEREIGN_PRIMARY_REGION:-}'
       replica:
         region: '${SOVEREIGN_REPLICA_REGION:-}'
+      networkPolicy:
+        # crossRegionPodCIDRs (#4846) — admit the PEER region's Pods to the
+        # pair's 5432 by RAW IP (ipBlock), bypassing the io.cilium.k8s.policy.
+        # cluster local-cluster scoping that drops ClusterMesh remote-cluster
+        # label-selector matches (region-b replica pg_basebackup/streaming was
+        # default-denied → "Creating a new replica" wedge). 10.42.0.0/15 is the
+        # deterministic pod supernet spanning both regions (01-cilium
+        # ipv4NativeRoutingCIDR). Only consumed when cnpgPair.enabled (AHS);
+        # a single-region prov (gate OFF) renders NO ipBlock (byte-identical).
+        crossRegionPodCIDRs: ['${SOVEREIGN_POD_SUPERNET_CIDR:-10.42.0.0/15}']
       # ── Continuum DR contract seed (#3195 G6, flipped 2026-06-12) ──
       # Renders the production Continuum CR so continuum-controller has
       # a real DR contract to reconcile (it was idle on every prov —

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-9-disaster-recovery
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.2.7
+  version: 0.2.8
   card:
     title: CNPG Cluster-Pair (Active-Hotstandby DR)
     summary: |

--- a/platform/cnpg-pair/chart/Chart.yaml
+++ b/platform/cnpg-pair/chart/Chart.yaml
@@ -9,7 +9,7 @@ name: bp-cnpg-pair
 # and the console Topology tab fell back to "singleton"). The template
 # gains an optional leaseClient.namespace passthrough. Slot-16b pin moves
 # to 0.2.7 in lockstep (Inviolable Principle #13).
-version: 0.2.7
+version: 0.2.8
 appVersion: "0.2.1"
 description: |
   Catalyst-curated Blueprint for an active-hotstandby CNPG cluster-pair

--- a/platform/cnpg-pair/chart/templates/networkpolicy.yaml
+++ b/platform/cnpg-pair/chart/templates/networkpolicy.yaml
@@ -89,6 +89,20 @@ spec:
           protocol: TCP
         - port: {{ .Values.cnpgPair.networkPolicy.operatorMetricsPort }}
           protocol: TCP
+    # CROSS-REGION pod CIDRs (#4846): the REPLICA region's Pods (streaming +
+    # pg_basebackup) reach the primary's 5432 by RAW SOURCE IP. The
+    # podSelector `cnpg.io/cluster=<replica>` rule above is implicitly
+    # local-cluster-scoped (Cilium ANDs io.cilium.k8s.policy.cluster=<local>),
+    # so the ClusterMesh remote-cluster replica Pods are NOT matched by it and
+    # get default-denied. ipBlock matches by IP, not identity — NOT scoped.
+    {{- range .Values.cnpgPair.networkPolicy.crossRegionPodCIDRs }}
+    - from:
+        - ipBlock:
+            cidr: {{ . | quote }}
+      ports:
+        - port: 5432
+          protocol: TCP
+    {{- end }}
 {{- end }}
 {{- if (include "cnpg-pair.isReplicaSide" .) }}
 ---
@@ -143,6 +157,18 @@ spec:
           protocol: TCP
         - port: {{ .Values.cnpgPair.networkPolicy.operatorMetricsPort }}
           protocol: TCP
+    # CROSS-REGION pod CIDRs (#4846): the PRIMARY region's Pods (streaming to
+    # this replica + any consumer reading the replica's -r) reach the replica's
+    # 5432 by RAW SOURCE IP — same local-cluster-scope bypass as the primary
+    # side above (k8s netpol label selectors don't match ClusterMesh remote).
+    {{- range .Values.cnpgPair.networkPolicy.crossRegionPodCIDRs }}
+    - from:
+        - ipBlock:
+            cidr: {{ . | quote }}
+      ports:
+        - port: 5432
+          protocol: TCP
+    {{- end }}
 ---
 # Egress carve-out for the probe Pod — must resolve DNS and reach
 # the replica's `-r` Service on 5432.

--- a/platform/cnpg-pair/chart/values.yaml
+++ b/platform/cnpg-pair/chart/values.yaml
@@ -237,6 +237,20 @@ cnpgPair:
     # cnpg-system (or the operator's own metrics collection) is not
     # default-denied once the gate flips ON.
     operatorMetricsPort: 9187
+    # crossRegionPodCIDRs (#4846) — pod CIDRs of the PEER region('s) cluster,
+    # allowed to reach the pair's 5432 for cross-region replication. REQUIRED:
+    # the podSelector `cnpg.io/cluster=<replica>` rule above claims to match
+    # "regardless of source cluster", but k8s NetworkPolicy pod/namespace
+    # selectors are implicitly scoped to the LOCAL cluster (Cilium ANDs
+    # io.cilium.k8s.policy.cluster=<local>), so ClusterMesh REMOTE-cluster Pods
+    # (the region-b replica streaming from + pg_basebackup'ing the region-a
+    # primary) are NEVER matched → default-denied → the replica wedges "Creating
+    # a new replica" (hw130 24h wedge; hw128's region-kill "PASS" missed it —
+    # its writes ran via kubectl-exec unix socket, never crossing the wire). An
+    # ipBlock matches by RAW source IP, not endpoint identity, so it is NOT
+    # subject to that scope. Wired to the deterministic pod supernet 10.42.0.0/15
+    # (spans both regions, 01-cilium ipv4NativeRoutingCIDR). EMPTY → no ipBlock.
+    crossRegionPodCIDRs: []
 
   # ── Continuum DR contract seed (#3195, Refs #3189) ────────────────
   # When `continuum.enabled: true` AND `cnpgPair.enabled: true`, the


### PR DESCRIPTION
## What
The DR-pair half of the #4846 fix (PR #4847 did the shared-pg half). The `cnpg-pair` chart's `allow-replication-to-primary` / `allow-probe-to-replica` NetworkPolicies have the identical Cilium ClusterMesh gap: their `podSelector: cnpg.io/cluster=<replica>` rule is implicitly scoped to the local cluster (`io.cilium.k8s.policy.cluster=<local>`), so the region-b replica's cross-region streaming + `pg_basebackup` are default-denied → the replica wedges "Creating a new replica" (hw128's region-kill "PASS" missed it — those writes ran via kubectl-exec unix socket, never crossing the wire).

## Fix
`cnpgPair.networkPolicy.crossRegionPodCIDRs` (list) → `ipBlock` ingress on 5432 (primary + replica sides). ipBlock matches by raw source IP, not endpoint identity, so it bypasses the local-cluster scope. Wired in bootstrap-kit slot 16b to the deterministic `10.42.0.0/15` pod supernet, overridable via `SOVEREIGN_POD_SUPERNET_CIDR`. Gate OFF (single-region) renders NO ipBlock (byte-identical).

## Tests (render)
- cnpgPair off → 0 ipBlock (byte-identical)
- on primary side + CIDR → 1; replica side → 1; render valid YAML

Chart 0.2.8 + blueprint + slot-16b pin lockstep.

Refs #4846 · UAT G12/R12 (Pillar-3 region-kill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)