### PR TITLE
fix(#4846): identity-based CiliumNetworkPolicy for cross-region DR (ipBlock was inert for ClusterMesh)

### DIFF
--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -153,7 +153,9 @@ spec:
       # harbor NXDOMAIN'd on a fresh 2-region prov (0 remote clusters ready). The
       # cross-mesh consumer-5432 path is already opened by 0.2.7's sharedConsumers
       # (#4442). Lockstep with 16c/16d.
-      version: 0.2.9
+      # 0.2.10 (#4846): identity-based cross-region DR CiliumNetworkPolicy
+      # (crossRegionPeerClusters) replaces the inert ipBlock. Lockstep 16c/16d.
+      version: 0.2.10
       sourceRef:
         kind: HelmRepository
         name: bp-postgres
@@ -236,15 +238,19 @@ spec:
       # active-hot-standby consumer-allow. Live regression on b9f9590b.
       networkPolicy:
         sharedConsumers: true
-        # crossRegionPodCIDRs (#4846) — admit the PEER region's pods to 5432 so
-        # region-b consumers (keycloak/grafana/…) + the region-b replica's
-        # pg_basebackup reach the primary. k8s netpol label rules are implicitly
-        # local-cluster-scoped (Cilium ANDs io.cilium.k8s.policy.cluster=<local>),
-        # so remote-cluster sources are dropped; an ipBlock matches by raw IP and
-        # is NOT scoped. 10.42.0.0/15 is the deterministic pod supernet spanning
-        # BOTH regions (01-cilium ipv4NativeRoutingCIDR). Only consumed in
-        # active-hot-standby; singleton ignores it (byte-identical default).
-        crossRegionPodCIDRs: ['${SOVEREIGN_POD_SUPERNET_CIDR:-10.42.0.0/15}']
+        # crossRegionPeerClusters (#4846) — admit the PEER region's pods to 5432
+        # by CLUSTER IDENTITY so region-b consumers (keycloak/grafana/…) + the
+        # region-b replica's pg_basebackup reach the primary. k8s-netpol label
+        # rules are implicitly local-cluster-scoped, and a k8s `ipBlock` never
+        # matches a ClusterMesh remote endpoint (it matches only a CIDR identity,
+        # which Cilium assigns solely to NON-endpoint IPs) — so the chart renders
+        # an identity-based CiliumNetworkPolicy selecting io.cilium.k8s.policy.
+        # cluster instead. SOVEREIGN_PEER_CLUSTERMESH_NAMES is stamped by
+        # catalyst-api (enableCNPGPairAfterFullMesh) with the peer region's mesh
+        # name(s) at the post-mesh cnpg-pair flip, as a YAML flow-sequence e.g.
+        # [hw228-me-east-b]. Only consumed in active-hot-standby; DEFAULT [] →
+        # singleton renders NO CiliumNetworkPolicy (byte-identical default).
+        crossRegionPeerClusters: ${SOVEREIGN_PEER_CLUSTERMESH_NAMES:-[]}
     # The three bindings — the reuse proof. Three isolated databases +
     # three roles on ONE Cluster; each reflected into its consumer's
     # namespace.

--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -197,7 +197,9 @@ spec:
       # 0.2.6 (#3740): replication-source mesh Service flipped
       # selectorType r→rw so the cross-region replica streams from the
       # PRIMARY's walsender (not a cascaded local standby) → sync_state=sync.
-      version: 0.2.8
+      # 0.2.9 (#4846): identity-based cross-region DR CiliumNetworkPolicy
+      # (crossRegionPeerClusters) replaces the inert ipBlock.
+      version: 0.2.9
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg-pair
@@ -278,15 +280,19 @@ spec:
       replica:
         region: '${SOVEREIGN_REPLICA_REGION:-}'
       networkPolicy:
-        # crossRegionPodCIDRs (#4846) — admit the PEER region's Pods to the
-        # pair's 5432 by RAW IP (ipBlock), bypassing the io.cilium.k8s.policy.
-        # cluster local-cluster scoping that drops ClusterMesh remote-cluster
-        # label-selector matches (region-b replica pg_basebackup/streaming was
-        # default-denied → "Creating a new replica" wedge). 10.42.0.0/15 is the
-        # deterministic pod supernet spanning both regions (01-cilium
-        # ipv4NativeRoutingCIDR). Only consumed when cnpgPair.enabled (AHS);
-        # a single-region prov (gate OFF) renders NO ipBlock (byte-identical).
-        crossRegionPodCIDRs: ['${SOVEREIGN_POD_SUPERNET_CIDR:-10.42.0.0/15}']
+        # crossRegionPeerClusters (#4846) — admit the PEER region's Pods to the
+        # pair's 5432 by CLUSTER IDENTITY. A k8s `ipBlock` (the reverted #4846
+        # first attempt) is INERT for ClusterMesh traffic: it matches only a CIDR
+        # identity, which Cilium assigns solely to NON-endpoint IPs, so the
+        # region-b replica (a known remote endpoint) is `match none` → deny →
+        # "Creating a new replica" wedge (proven hw228). The chart renders an
+        # identity-based CiliumNetworkPolicy selecting io.cilium.k8s.policy.cluster
+        # instead. SOVEREIGN_PEER_CLUSTERMESH_NAMES is stamped by catalyst-api
+        # (enableCNPGPairAfterFullMesh) with the peer region's mesh name(s) at the
+        # post-mesh flip, as a YAML flow-sequence e.g. [hw228-mesh]. Only consumed
+        # when cnpgPair.enabled (AHS); a single-region prov (gate OFF) + the
+        # DEFAULT [] render NO CiliumNetworkPolicy (byte-identical).
+        crossRegionPeerClusters: ${SOVEREIGN_PEER_CLUSTERMESH_NAMES:-[]}
       # ── Continuum DR contract seed (#3195 G6, flipped 2026-06-12) ──
       # Renders the production Continuum CR so continuum-controller has
       # a real DR contract to reconcile (it was idle on every prov —

--- a/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
+++ b/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
@@ -91,7 +91,9 @@ spec:
       # global Service aliases decoupled from the cnpg-pair flip → render on the
       # multi-region signal so cross-region grafana/powerdns/pda hosts resolve the
       # moment the mesh peers. Lockstep with 16a/16d.
-      version: 0.2.9
+      # 0.2.10 (#4846): identity-based cross-region DR CiliumNetworkPolicy
+      # (crossRegionPeerClusters) replaces the inert ipBlock. Lockstep 16a/16d.
+      version: 0.2.10
       sourceRef:
         kind: HelmRepository
         name: bp-postgres
@@ -138,15 +140,19 @@ spec:
       # them). See slot 16a for the full rationale.
       networkPolicy:
         sharedConsumers: true
-        # crossRegionPodCIDRs (#4846) — admit the PEER region's pods to 5432 so
-        # region-b consumers (keycloak/grafana/…) + the region-b replica's
-        # pg_basebackup reach the primary. k8s netpol label rules are implicitly
-        # local-cluster-scoped (Cilium ANDs io.cilium.k8s.policy.cluster=<local>),
-        # so remote-cluster sources are dropped; an ipBlock matches by raw IP and
-        # is NOT scoped. 10.42.0.0/15 is the deterministic pod supernet spanning
-        # BOTH regions (01-cilium ipv4NativeRoutingCIDR). Only consumed in
-        # active-hot-standby; singleton ignores it (byte-identical default).
-        crossRegionPodCIDRs: ['${SOVEREIGN_POD_SUPERNET_CIDR:-10.42.0.0/15}']
+        # crossRegionPeerClusters (#4846) — admit the PEER region's pods to 5432
+        # by CLUSTER IDENTITY so region-b consumers (keycloak/grafana/…) + the
+        # region-b replica's pg_basebackup reach the primary. k8s-netpol label
+        # rules are implicitly local-cluster-scoped, and a k8s `ipBlock` never
+        # matches a ClusterMesh remote endpoint (it matches only a CIDR identity,
+        # which Cilium assigns solely to NON-endpoint IPs) — so the chart renders
+        # an identity-based CiliumNetworkPolicy selecting io.cilium.k8s.policy.
+        # cluster instead. SOVEREIGN_PEER_CLUSTERMESH_NAMES is stamped by
+        # catalyst-api (enableCNPGPairAfterFullMesh) with the peer region's mesh
+        # name(s) at the post-mesh cnpg-pair flip, as a YAML flow-sequence e.g.
+        # [hw228-me-east-b]. Only consumed in active-hot-standby; DEFAULT [] →
+        # singleton renders NO CiliumNetworkPolicy (byte-identical default).
+        crossRegionPeerClusters: ${SOVEREIGN_PEER_CLUSTERMESH_NAMES:-[]}
     databases:
       # grafana — FLIPPED (see header). The extraData keys are grafana's
       # native GF_DATABASE_* env contract; GF_DATABASE_HOST carries

--- a/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
+++ b/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
@@ -79,7 +79,9 @@ spec:
       # global Service aliases decoupled from the cnpg-pair flip → render on the
       # multi-region signal so the cross-region Organization-mesh / newapi /
       # openova-flow hosts resolve the moment the mesh peers. Lockstep 16a/16c.
-      version: 0.2.9
+      # 0.2.10 (#4846): identity-based cross-region DR CiliumNetworkPolicy
+      # (crossRegionPeerClusters) replaces the inert ipBlock. Lockstep 16a/16c.
+      version: 0.2.10
       sourceRef:
         kind: HelmRepository
         name: bp-postgres
@@ -126,15 +128,19 @@ spec:
       # them). See slot 16a for the full rationale.
       networkPolicy:
         sharedConsumers: true
-        # crossRegionPodCIDRs (#4846) — admit the PEER region's pods to 5432 so
-        # region-b consumers (keycloak/grafana/…) + the region-b replica's
-        # pg_basebackup reach the primary. k8s netpol label rules are implicitly
-        # local-cluster-scoped (Cilium ANDs io.cilium.k8s.policy.cluster=<local>),
-        # so remote-cluster sources are dropped; an ipBlock matches by raw IP and
-        # is NOT scoped. 10.42.0.0/15 is the deterministic pod supernet spanning
-        # BOTH regions (01-cilium ipv4NativeRoutingCIDR). Only consumed in
-        # active-hot-standby; singleton ignores it (byte-identical default).
-        crossRegionPodCIDRs: ['${SOVEREIGN_POD_SUPERNET_CIDR:-10.42.0.0/15}']
+        # crossRegionPeerClusters (#4846) — admit the PEER region's pods to 5432
+        # by CLUSTER IDENTITY so region-b consumers (keycloak/grafana/…) + the
+        # region-b replica's pg_basebackup reach the primary. k8s-netpol label
+        # rules are implicitly local-cluster-scoped, and a k8s `ipBlock` never
+        # matches a ClusterMesh remote endpoint (it matches only a CIDR identity,
+        # which Cilium assigns solely to NON-endpoint IPs) — so the chart renders
+        # an identity-based CiliumNetworkPolicy selecting io.cilium.k8s.policy.
+        # cluster instead. SOVEREIGN_PEER_CLUSTERMESH_NAMES is stamped by
+        # catalyst-api (enableCNPGPairAfterFullMesh) with the peer region's mesh
+        # name(s) at the post-mesh cnpg-pair flip, as a YAML flow-sequence e.g.
+        # [hw228-me-east-b]. Only consumed in active-hot-standby; DEFAULT [] →
+        # singleton renders NO CiliumNetworkPolicy (byte-identical default).
+        crossRegionPeerClusters: ${SOVEREIGN_PEER_CLUSTERMESH_NAMES:-[]}
     # The Organization-mesh bindings: three isolated databases, ONE role `org`
     # (chart 0.1.5 dedupes the role + password Secret across same-owner
     # bindings). Database names mirror orgPostgres.cluster.database +

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -6,7 +6,10 @@ metadata:
     catalyst.openova.io/section: pts-9-disaster-recovery
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.2.8
+  # 0.2.9 (#4846): cross-region DR admission is an identity-based
+  # CiliumNetworkPolicy (io.cilium.k8s.policy.cluster) — the 0.2.8 ipBlock was
+  # inert for ClusterMesh remote endpoints. values crossRegionPeerClusters.
+  version: 0.2.9
   card:
     title: CNPG Cluster-Pair (Active-Hotstandby DR)
     summary: |

--- a/platform/cnpg-pair/chart/Chart.yaml
+++ b/platform/cnpg-pair/chart/Chart.yaml
@@ -9,7 +9,26 @@ name: bp-cnpg-pair
 # and the console Topology tab fell back to "singleton"). The template
 # gains an optional leaseClient.namespace passthrough. Slot-16b pin moves
 # to 0.2.7 in lockstep (Inviolable Principle #13).
-version: 0.2.8
+# 0.2.9 (#4846, Refs #4656 #4275): REPLACE the inert cross-region ipBlock with
+# an identity-based CiliumNetworkPolicy. 0.2.8 added a k8s-NetworkPolicy
+# `ipBlock: {cidr: crossRegionPodCIDRs}` on 5432 to admit the ClusterMesh remote
+# replica, but that ipBlock is INERT for ClusterMesh traffic: a k8s `ipBlock`
+# matches only a CIDR identity, which Cilium assigns SOLELY to IPs that are NOT
+# known endpoints. A ClusterMesh remote-cluster pod IS a known endpoint carrying
+# its own pod security identity → the ipBlock is `match none` → deny (confirmed
+# with cilium-dbg on hw228). networkpolicy.yaml now REMOVES both ipBlock blocks
+# (primary allow-replication-to-primary + replica allow-probe-to-replica) and,
+# gated on the new `cnpgPair.networkPolicy.crossRegionPeerClusters` (peer
+# ClusterMesh name(s)), renders a per-side CiliumNetworkPolicy (cilium.io/v2)
+# selecting THIS side's Cluster Pods (primaryName / replicaName) and admitting
+# ingress fromEndpoints matching `io.cilium.k8s.policy.cluster In [<peers>]` on
+# 5432/TCP — the shape that made region-b→region-a pg_isready + DR basebackup
+# succeed LIVE on hw228. values `crossRegionPodCIDRs` → `crossRegionPeerClusters`;
+# catalyst-api stamps the peer name(s) via SOVEREIGN_PEER_CLUSTERMESH_NAMES at
+# the post-mesh flip. Default-OFF contract UNCHANGED: cnpgPair.enabled=false OR
+# empty crossRegionPeerClusters renders ZERO CiliumNetworkPolicy — resource
+# counts unchanged from 0.2.8. Lockstep slot 16b pin → 0.2.9.
+version: 0.2.9
 appVersion: "0.2.1"
 description: |
   Catalyst-curated Blueprint for an active-hotstandby CNPG cluster-pair

--- a/platform/cnpg-pair/chart/templates/networkpolicy.yaml
+++ b/platform/cnpg-pair/chart/templates/networkpolicy.yaml
@@ -89,20 +89,45 @@ spec:
           protocol: TCP
         - port: {{ .Values.cnpgPair.networkPolicy.operatorMetricsPort }}
           protocol: TCP
-    # CROSS-REGION pod CIDRs (#4846): the REPLICA region's Pods (streaming +
-    # pg_basebackup) reach the primary's 5432 by RAW SOURCE IP. The
-    # podSelector `cnpg.io/cluster=<replica>` rule above is implicitly
-    # local-cluster-scoped (Cilium ANDs io.cilium.k8s.policy.cluster=<local>),
-    # so the ClusterMesh remote-cluster replica Pods are NOT matched by it and
-    # get default-denied. ipBlock matches by IP, not identity — NOT scoped.
-    {{- range .Values.cnpgPair.networkPolicy.crossRegionPodCIDRs }}
-    - from:
-        - ipBlock:
-            cidr: {{ . | quote }}
-      ports:
-        - port: 5432
-          protocol: TCP
-    {{- end }}
+{{- if gt (len .Values.cnpgPair.networkPolicy.crossRegionPeerClusters) 0 }}
+---
+# CROSS-REGION DR (#4846): the REPLICA region's Pods (streaming + pg_basebackup)
+# reach the primary's 5432 over ClusterMesh as KNOWN endpoints carrying their
+# OWN pod security identity. The podSelector `cnpg.io/cluster=<replica>` rule
+# above is implicitly local-cluster-scoped (Cilium ANDs io.cilium.k8s.policy.
+# cluster=<local>) so it never matches the remote replica; and a k8s-netpol
+# `ipBlock` matches ONLY a CIDR identity (assigned SOLELY to IPs that are NOT
+# known endpoints) so it is `match none` for the remote replica → deny (the
+# #4846 ipBlock shipped INERT; proven with cilium-dbg on hw228 — "Creating a
+# new replica" wedge). Admit the peer cluster(s) by IDENTITY via a
+# CiliumNetworkPolicy selecting `io.cilium.k8s.policy.cluster`; this exact shape
+# made region-b→region-a pg_isready + the DR basebackup succeed on hw228.
+# EMPTY (single-region) → NO CiliumNetworkPolicy (byte-identical default).
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "cnpg-pair.fullname" . }}-crossregion-dr-primary
+  labels:
+    {{- include "cnpg-pair.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . | quote }}
+spec:
+  endpointSelector:
+    matchLabels:
+      cnpg.io/cluster: {{ include "cnpg-pair.primaryName" . }}
+  ingress:
+    - fromEndpoints:
+        - matchExpressions:
+            - key: io.cilium.k8s.policy.cluster
+              operator: In
+              values:
+                {{- range .Values.cnpgPair.networkPolicy.crossRegionPeerClusters }}
+                - {{ . | quote }}
+                {{- end }}
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+{{- end }}
 {{- end }}
 {{- if (include "cnpg-pair.isReplicaSide" .) }}
 ---
@@ -157,18 +182,39 @@ spec:
           protocol: TCP
         - port: {{ .Values.cnpgPair.networkPolicy.operatorMetricsPort }}
           protocol: TCP
-    # CROSS-REGION pod CIDRs (#4846): the PRIMARY region's Pods (streaming to
-    # this replica + any consumer reading the replica's -r) reach the replica's
-    # 5432 by RAW SOURCE IP — same local-cluster-scope bypass as the primary
-    # side above (k8s netpol label selectors don't match ClusterMesh remote).
-    {{- range .Values.cnpgPair.networkPolicy.crossRegionPodCIDRs }}
-    - from:
-        - ipBlock:
-            cidr: {{ . | quote }}
-      ports:
-        - port: 5432
-          protocol: TCP
-    {{- end }}
+{{- if gt (len .Values.cnpgPair.networkPolicy.crossRegionPeerClusters) 0 }}
+---
+# CROSS-REGION DR (#4846): the PRIMARY region's Pods (streaming to this replica
+# + any consumer reading the replica's -r) reach the replica's 5432 over
+# ClusterMesh as KNOWN endpoints with their OWN pod identity — an `ipBlock`
+# never matches them (same inert-ipBlock root cause as the primary side above,
+# proven hw228). Admit them by cluster identity via a CiliumNetworkPolicy
+# selecting the peer ClusterMesh name(s). EMPTY (single-region) → no CNP.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "cnpg-pair.fullname" . }}-crossregion-dr-replica
+  labels:
+    {{- include "cnpg-pair.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . | quote }}
+spec:
+  endpointSelector:
+    matchLabels:
+      cnpg.io/cluster: {{ include "cnpg-pair.replicaName" . }}
+  ingress:
+    - fromEndpoints:
+        - matchExpressions:
+            - key: io.cilium.k8s.policy.cluster
+              operator: In
+              values:
+                {{- range .Values.cnpgPair.networkPolicy.crossRegionPeerClusters }}
+                - {{ . | quote }}
+                {{- end }}
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+{{- end }}
 ---
 # Egress carve-out for the probe Pod — must resolve DNS and reach
 # the replica's `-r` Service on 5432.

--- a/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
+++ b/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
@@ -547,4 +547,62 @@ if [ "$PAIROFF" -ne 0 ]; then
 fi
 echo "  PASS"
 
+# ── Case 12: #4846 — crossRegionPeerClusters → identity-based CNP, NO ipBlock ─
+# Cross-region DR admission is an identity-based CiliumNetworkPolicy selecting
+# the peer cluster(s) by io.cilium.k8s.policy.cluster. A k8s-netpol ipBlock (the
+# reverted #4846 first attempt) is INERT for ClusterMesh remote endpoints (proven
+# hw228) and MUST NOT render. Assert one CNP per side + zero ipBlock; and that
+# empty crossRegionPeerClusters (Case 2/3 default) renders ZERO CNP.
+echo "[render] Case 12: #4846 crossRegionPeerClusters → per-side CiliumNetworkPolicy (identity In-list), NO ipBlock"
+helm template smoke-cnpg-pair . \
+  --set cnpgPair.enabled=true \
+  --set cnpgPair.primary.region=hz-fsn-rtz-prod \
+  --set cnpgPair.replica.region=hz-hel-rtz-prod \
+  --set cnpgPair.image.tag=16.3-23 \
+  --set 'cnpgPair.networkPolicy.crossRegionPeerClusters={hw228-me-east-b}' \
+  > "$TMP/cnp-primary.yaml" 2> "$TMP/cnp-primary.err" || {
+  echo "FAIL: #4846 side=primary CNP render errored:" >&2; cat "$TMP/cnp-primary.err" >&2; exit 1; }
+if [ "$(grep -cE '^kind: CiliumNetworkPolicy$' "$TMP/cnp-primary.yaml")" != "1" ]; then
+  echo "FAIL: #4846 side=primary expected exactly 1 CiliumNetworkPolicy." >&2; exit 1; fi
+grep -qE '^  name: smoke-cnpg-pair-bp-cnpg-pair-crossregion-dr-primary$' "$TMP/cnp-primary.yaml" || {
+  echo "FAIL: #4846 primary CNP name != smoke-cnpg-pair-bp-cnpg-pair-crossregion-dr-primary." >&2; exit 1; }
+grep -qE '^      cnpg.io/cluster: smoke-cnpg-pair-bp-cnpg-pair-primary$' "$TMP/cnp-primary.yaml" || {
+  echo "FAIL: #4846 primary CNP endpointSelector must select the primary Cluster Pods." >&2; exit 1; }
+grep -q 'key: io.cilium.k8s.policy.cluster' "$TMP/cnp-primary.yaml" || {
+  echo "FAIL: #4846 primary CNP missing io.cilium.k8s.policy.cluster identity match." >&2; exit 1; }
+grep -q 'operator: In' "$TMP/cnp-primary.yaml" || {
+  echo "FAIL: #4846 primary CNP not using an In-list of peer clusters." >&2; exit 1; }
+grep -q '"hw228-me-east-b"' "$TMP/cnp-primary.yaml" || {
+  echo "FAIL: #4846 primary CNP missing the peer cluster name in the In-list." >&2; exit 1; }
+if grep -qE '^[[:space:]]*-?[[:space:]]*ipBlock:' "$TMP/cnp-primary.yaml"; then
+  echo "FAIL: #4846 primary render leaked an ipBlock rule (inert for ClusterMesh)." >&2; exit 1; fi
+grep -q 'allow-replication-to-primary' "$TMP/cnp-primary.yaml" || {
+  echo "FAIL: #4846 primary render dropped the k8s allow-replication-to-primary NetworkPolicy." >&2; exit 1; }
+# Replica side.
+helm template smoke-cnpg-pair . \
+  --set cnpgPair.enabled=true \
+  --set cnpgPair.side=replica \
+  --set cnpgPair.primary.region=hz-fsn-rtz-prod \
+  --set cnpgPair.replica.region=hz-hel-rtz-prod \
+  --set cnpgPair.image.tag=16.3-23 \
+  --set 'cnpgPair.networkPolicy.crossRegionPeerClusters={hw228-mesh}' \
+  > "$TMP/cnp-replica.yaml" 2> "$TMP/cnp-replica.err" || {
+  echo "FAIL: #4846 side=replica CNP render errored:" >&2; cat "$TMP/cnp-replica.err" >&2; exit 1; }
+if [ "$(grep -cE '^kind: CiliumNetworkPolicy$' "$TMP/cnp-replica.yaml")" != "1" ]; then
+  echo "FAIL: #4846 side=replica expected exactly 1 CiliumNetworkPolicy." >&2; exit 1; fi
+grep -qE '^  name: smoke-cnpg-pair-bp-cnpg-pair-crossregion-dr-replica$' "$TMP/cnp-replica.yaml" || {
+  echo "FAIL: #4846 replica CNP name != smoke-cnpg-pair-bp-cnpg-pair-crossregion-dr-replica." >&2; exit 1; }
+grep -qE '^      cnpg.io/cluster: smoke-cnpg-pair-bp-cnpg-pair-replica$' "$TMP/cnp-replica.yaml" || {
+  echo "FAIL: #4846 replica CNP endpointSelector must select the replica Cluster Pods." >&2; exit 1; }
+grep -q '"hw228-mesh"' "$TMP/cnp-replica.yaml" || {
+  echo "FAIL: #4846 replica CNP missing the primary mesh name in the In-list." >&2; exit 1; }
+if grep -qE '^[[:space:]]*-?[[:space:]]*ipBlock:' "$TMP/cnp-replica.yaml"; then
+  echo "FAIL: #4846 replica render leaked an ipBlock rule." >&2; exit 1; fi
+# Empty crossRegionPeerClusters (Case 2 default primary render) → ZERO CNP.
+if grep -q 'CiliumNetworkPolicy' "$TMP/primary.yaml"; then
+  echo "FAIL: #4846 primary render WITHOUT crossRegionPeerClusters must emit ZERO CiliumNetworkPolicy." >&2; exit 1; fi
+if grep -q 'CiliumNetworkPolicy' "$TMP/replica.yaml"; then
+  echo "FAIL: #4846 replica render WITHOUT crossRegionPeerClusters must emit ZERO CiliumNetworkPolicy." >&2; exit 1; fi
+echo "  PASS (1 CNP per side, identity In-list, no ipBlock; empty peers → zero CNP)"
+
 echo "[render] All bp-cnpg-pair render gates green."

--- a/platform/cnpg-pair/chart/values.yaml
+++ b/platform/cnpg-pair/chart/values.yaml
@@ -237,20 +237,29 @@ cnpgPair:
     # cnpg-system (or the operator's own metrics collection) is not
     # default-denied once the gate flips ON.
     operatorMetricsPort: 9187
-    # crossRegionPodCIDRs (#4846) — pod CIDRs of the PEER region('s) cluster,
-    # allowed to reach the pair's 5432 for cross-region replication. REQUIRED:
-    # the podSelector `cnpg.io/cluster=<replica>` rule above claims to match
-    # "regardless of source cluster", but k8s NetworkPolicy pod/namespace
-    # selectors are implicitly scoped to the LOCAL cluster (Cilium ANDs
-    # io.cilium.k8s.policy.cluster=<local>), so ClusterMesh REMOTE-cluster Pods
-    # (the region-b replica streaming from + pg_basebackup'ing the region-a
-    # primary) are NEVER matched → default-denied → the replica wedges "Creating
-    # a new replica" (hw130 24h wedge; hw128's region-kill "PASS" missed it —
-    # its writes ran via kubectl-exec unix socket, never crossing the wire). An
-    # ipBlock matches by RAW source IP, not endpoint identity, so it is NOT
-    # subject to that scope. Wired to the deterministic pod supernet 10.42.0.0/15
-    # (spans both regions, 01-cilium ipv4NativeRoutingCIDR). EMPTY → no ipBlock.
-    crossRegionPodCIDRs: []
+    # crossRegionPeerClusters (#4846) — the Cilium ClusterMesh cluster.name(s)
+    # of the PEER region('s) cluster, allowed to reach the pair's 5432 for
+    # cross-region replication. REQUIRED: the podSelector `cnpg.io/cluster=
+    # <replica>` rule above claims to match "regardless of source cluster", but
+    # k8s NetworkPolicy pod/namespace selectors are implicitly local-cluster-
+    # scoped (Cilium ANDs io.cilium.k8s.policy.cluster=<local>), so ClusterMesh
+    # REMOTE-cluster Pods (the region-b replica streaming from + pg_basebackup'
+    # ing the region-a primary) are NEVER matched → default-denied → the replica
+    # wedges "Creating a new replica" (hw130 24h wedge).
+    #
+    # The #4846 fix FIRST tried an `ipBlock: {cidr}` here, but that is INERT for
+    # ClusterMesh traffic: a k8s-netpol `ipBlock` matches ONLY a CIDR identity,
+    # which Cilium assigns SOLELY to IPs that are NOT known endpoints. A
+    # ClusterMesh remote pod IS a known endpoint carrying its own pod security
+    # identity, so the ipBlock is never consulted → `match none` → deny (proven
+    # with cilium-dbg on hw228). The CORRECT admission is an identity-based
+    # CiliumNetworkPolicy whose `fromEndpoints` selects the peer cluster(s) by
+    # the `io.cilium.k8s.policy.cluster` label — this exact shape made region-b→
+    # region-a pg_isready + the DR basebackup succeed on hw228. The bootstrap-kit
+    # wires this to the peer region's ClusterMesh name(s)
+    # (SOVEREIGN_PEER_CLUSTERMESH_NAMES, stamped by catalyst-api at the post-mesh
+    # cnpg-pair flip). EMPTY → no CiliumNetworkPolicy.
+    crossRegionPeerClusters: []
 
   # ── Continuum DR contract seed (#3195, Refs #3189) ────────────────
   # When `continuum.enabled: true` AND `cnpgPair.enabled: true`, the

--- a/platform/postgres/blueprint.yaml
+++ b/platform/postgres/blueprint.yaml
@@ -8,7 +8,10 @@ metadata:
 spec:
   # 0.2.8 (#4460): -mesh/-mesh-rw global Service aliases decoupled from the
   # cnpg-pair flip (render on the multi-region signal; region-B NXDOMAIN fix).
-  version: 0.2.9
+  # 0.2.10 (#4846): cross-region DR admission is an identity-based
+  # CiliumNetworkPolicy (io.cilium.k8s.policy.cluster) — the 0.2.9 ipBlock was
+  # inert for ClusterMesh remote endpoints. values crossRegionPeerClusters.
+  version: 0.2.10
   card:
     title: PostgreSQL
     summary: |

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -145,7 +145,29 @@ name: bp-postgres
 #   carve-outs (sync GUCs, replica-Pod cross-cluster allow, own-cluster
 #   pg_basebackup join, replica-side policy) stay $ahs-gated. Post-flip render is
 #   byte-identical to 0.2.7's $ahs shape.
-version: 0.2.9
+# 0.2.10 (#4846, Refs #4656 #4275): REPLACE the inert cross-region ipBlock with
+#   an identity-based CiliumNetworkPolicy. 0.2.9 added a k8s-NetworkPolicy
+#   `ipBlock: {cidr: crossRegionPodCIDRs}` on 5432 to admit the ClusterMesh
+#   remote replica, but that ipBlock is INERT for ClusterMesh traffic: a k8s
+#   `ipBlock` matches only a CIDR identity, which Cilium assigns SOLELY to IPs
+#   that are NOT known endpoints. A ClusterMesh remote-cluster pod IS a known
+#   endpoint carrying its own pod security identity, so the ipBlock rule is
+#   never consulted → `match none` → deny (confirmed with cilium-dbg on hw228,
+#   region-b→region-a pg_isready failed, DR replica stuck "Setting up primary").
+#   networkpolicy.yaml now REMOVES both ipBlock blocks and, gated on the new
+#   `topology.networkPolicy.crossRegionPeerClusters` (peer ClusterMesh name(s)),
+#   renders a per-side CiliumNetworkPolicy (cilium.io/v2) selecting THIS side's
+#   Cluster Pods (primaryName on primary, replicaName on replica) and admitting
+#   ingress `fromEndpoints` matching `io.cilium.k8s.policy.cluster In
+#   [<peers>]` on 5432/TCP — the exact shape that made region-b→region-a
+#   pg_isready succeed + the DR replica basebackup complete LIVE on hw228.
+#   values `crossRegionPodCIDRs` → `crossRegionPeerClusters`; catalyst-api
+#   stamps the peer name(s) via SOVEREIGN_PEER_CLUSTERMESH_NAMES at the
+#   post-mesh cnpg-pair flip. EMPTY (singleton / single-region) → NO CNP, so
+#   the singleton render is byte-identical to 0.2.9 (the ipBlock only rendered
+#   under crossRegion, which singletons never set). Lockstep slot pins 16a/16c/
+#   16d → 0.2.10. tests/postgres-render.sh Case 4e/4f added.
+version: 0.2.10
 appVersion: "0.1.2"
 description: |
   Catalyst-authored data-instance Blueprint for a shareable, reusable

--- a/platform/postgres/chart/templates/networkpolicy.yaml
+++ b/platform/postgres/chart/templates/networkpolicy.yaml
@@ -91,22 +91,49 @@ spec:
           protocol: TCP
         - port: {{ .Values.topology.networkPolicy.operatorMetricsPort }}
           protocol: TCP
-    # CROSS-REGION pod CIDRs (#4846): the REPLICA region's Pods (consumers +
-    # the replica Cluster's pg_basebackup / streaming) reach the primary's 5432
-    # by RAW SOURCE IP via ipBlock. k8s NetworkPolicy namespaceSelector/
-    # podSelector are implicitly scoped to the LOCAL cluster (Cilium ANDs
-    # `io.cilium.k8s.policy.cluster=<local>`), so the region-b (remote-cluster)
-    # sources above are NOT matched and get default-denied → timeout (region-b
-    # grafana CrashLoop + replica stuck "Setting up primary" on hw228). ipBlock
-    # matches by IP, not endpoint identity, so it is NOT subject to that scope.
-    {{- range .Values.topology.networkPolicy.crossRegionPodCIDRs }}
-    - from:
-        - ipBlock:
-            cidr: {{ . | quote }}
-      ports:
-        - port: 5432
-          protocol: TCP
-    {{- end }}
+{{- if gt (len .Values.topology.networkPolicy.crossRegionPeerClusters) 0 }}
+---
+# CROSS-REGION DR (#4846): the REPLICA region's Pods (consumers + the replica
+# Cluster's pg_basebackup / WAL streaming) reach the primary's 5432 over Cilium
+# ClusterMesh. They arrive as KNOWN Cilium endpoints carrying their OWN pod
+# security identity — NOT a CIDR identity — so a k8s-NetworkPolicy `ipBlock`
+# rule NEVER admits them: Cilium assigns a CIDR identity ONLY to IPs that are
+# NOT known endpoints, so a ClusterMesh remote pod is `match none` → deny (the
+# #4847 ipBlock shipped inert; proven on hw228). A k8s-netpol label selector is
+# ALSO implicitly local-cluster-scoped (Cilium ANDs `io.cilium.k8s.policy.
+# cluster=<local>`), so it can't match a remote endpoint either. The CORRECT
+# admission is an identity-based CiliumNetworkPolicy selecting the peer
+# cluster(s) by the `io.cilium.k8s.policy.cluster` label — this exact shape made
+# region-b→region-a pg_isready succeed + the DR replica basebackup complete on
+# hw228. Gated on crossRegionPeerClusters (the peer ClusterMesh name(s), stamped
+# by catalyst-api at the post-mesh cnpg-pair flip); EMPTY (singleton /
+# single-region) → NO CNP → byte-identical default render.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "bp-postgres.instanceName" . }}-crossregion-dr-primary
+  namespace: {{ include "bp-postgres.namespace" . }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+spec:
+  endpointSelector:
+    matchLabels:
+      cnpg.io/cluster: {{ include "bp-postgres.instanceName" . }}
+  ingress:
+    - fromEndpoints:
+        - matchExpressions:
+            - key: io.cilium.k8s.policy.cluster
+              operator: In
+              values:
+                {{- range .Values.topology.networkPolicy.crossRegionPeerClusters }}
+                - {{ . | quote }}
+                {{- end }}
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+{{- end }}
 {{- end }}
 {{- if $isReplica }}
 ---
@@ -150,17 +177,39 @@ spec:
           protocol: TCP
         - port: {{ .Values.topology.networkPolicy.operatorMetricsPort }}
           protocol: TCP
-    # CROSS-REGION pod CIDRs (#4846): the PRIMARY region's Pods (the primary
-    # Cluster streaming to this replica + consumers reading the replica's
-    # -mesh-rw) reach the replica's 5432 by RAW SOURCE IP via ipBlock — same
-    # local-cluster-scope bypass as the primary side above.
-    {{- range .Values.topology.networkPolicy.crossRegionPodCIDRs }}
-    - from:
-        - ipBlock:
-            cidr: {{ . | quote }}
-      ports:
-        - port: 5432
-          protocol: TCP
-    {{- end }}
+{{- if gt (len .Values.topology.networkPolicy.crossRegionPeerClusters) 0 }}
+---
+# CROSS-REGION DR (#4846): the PRIMARY region's Pods (the primary Cluster
+# streaming to this replica + consumers reading the replica's -mesh-rw) reach
+# the replica's 5432 over ClusterMesh as KNOWN endpoints with their OWN pod
+# identity — an `ipBlock` never matches them (same inert-ipBlock root cause as
+# the primary side above). Admit them by cluster identity via a
+# CiliumNetworkPolicy selecting the peer ClusterMesh name(s). EMPTY → no CNP.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "bp-postgres.instanceName" . }}-crossregion-dr-replica
+  namespace: {{ include "bp-postgres.namespace" . }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+spec:
+  endpointSelector:
+    matchLabels:
+      cnpg.io/cluster: {{ include "bp-postgres.replicaName" . }}
+  ingress:
+    - fromEndpoints:
+        - matchExpressions:
+            - key: io.cilium.k8s.policy.cluster
+              operator: In
+              values:
+                {{- range .Values.topology.networkPolicy.crossRegionPeerClusters }}
+                - {{ . | quote }}
+                {{- end }}
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+{{- end }}
 {{- end }}
 {{- end }}

--- a/platform/postgres/chart/tests/postgres-render.sh
+++ b/platform/postgres/chart/tests/postgres-render.sh
@@ -332,6 +332,91 @@ if grep -qE '^      additional:$' "$TMP/preflip-secondary.yaml"; then
 fi
 grep -q 'cnpg.io/instanceRole: primary' "$TMP/preflip-secondary.yaml" || fail "#4460 pre-flip secondary -mesh-rw stub missing primary-role selector"
 
+# ── Case 4e: #4846 — crossRegionPeerClusters → identity-based CNP, NO ipBlock ─
+# The cross-region DR admission is an identity-based CiliumNetworkPolicy that
+# selects the peer cluster(s) by io.cilium.k8s.policy.cluster. A k8s-netpol
+# ipBlock (the reverted #4846 first attempt) is INERT for ClusterMesh remote
+# endpoints (proven hw228) and MUST NOT render. Assert one CNP per side that
+# selects THIS side's Cluster Pods and lists the peer cluster name(s) in the
+# io.cilium.k8s.policy.cluster In-set — and that ZERO ipBlock rules remain.
+echo "[render] Case 4e: #4846 crossRegionPeerClusters → per-side CiliumNetworkPolicy (identity In-list), NO ipBlock"
+cat > "$TMP/cnp.values.yaml" <<'YAML'
+instance: { name: shared-pg }
+topology:
+  mode: active-hot-standby
+  side: primary
+  instances: 3
+  primary: { region: hz-fsn-rtz-prod }
+  replica: { region: hz-hel-rtz-prod }
+  networkPolicy:
+    crossRegionPeerClusters: [hw228-me-east-b]
+databases:
+  - name: registry
+    owner: harbor
+    reflect: { secretName: harbor-database-secret, namespaces: [harbor] }
+YAML
+helm template shared-pg . -f "$TMP/cnp.values.yaml" --namespace shared-data \
+  --api-versions postgresql.cnpg.io/v1 > "$TMP/cnp-primary.yaml" 2>&1 || fail "#4846 CNP primary render errored"
+# Exactly ONE CiliumNetworkPolicy on the primary side, named -crossregion-dr-primary.
+[ "$(grep -cE '^kind: CiliumNetworkPolicy$' "$TMP/cnp-primary.yaml")" = "1" ] \
+  || fail "#4846 primary side expected exactly 1 CiliumNetworkPolicy"
+grep -qE '^  name: shared-pg-crossregion-dr-primary$' "$TMP/cnp-primary.yaml" \
+  || fail "#4846 primary CNP name != shared-pg-crossregion-dr-primary"
+# It selects the PRIMARY Cluster's Pods (endpointSelector), never the replica.
+grep -qE '^      cnpg.io/cluster: shared-pg$' "$TMP/cnp-primary.yaml" \
+  || fail "#4846 primary CNP endpointSelector must select cnpg.io/cluster: shared-pg (the primary Cluster)"
+# It admits the peer cluster by IDENTITY (io.cilium.k8s.policy.cluster In-list).
+grep -q 'key: io.cilium.k8s.policy.cluster' "$TMP/cnp-primary.yaml" \
+  || fail "#4846 primary CNP missing io.cilium.k8s.policy.cluster identity match"
+grep -q 'operator: In' "$TMP/cnp-primary.yaml" || fail "#4846 primary CNP not using an In-list of peer clusters"
+grep -q '"hw228-me-east-b"' "$TMP/cnp-primary.yaml" || fail "#4846 primary CNP missing the peer cluster name in the In-list"
+# NO ipBlock rule anywhere (the inert #4846 first attempt is gone). Match only a
+# real `ipBlock:` YAML key, not the prose comment that names it.
+if grep -qE '^[[:space:]]*-?[[:space:]]*ipBlock:' "$TMP/cnp-primary.yaml"; then
+  fail "#4846 primary render leaked an ipBlock rule (inert for ClusterMesh — must be an identity CNP)"
+fi
+# The k8s-NetworkPolicy carve-outs (consumer / own-cluster / operator) are intact.
+grep -q 'allow-replication-to-primary' "$TMP/cnp-primary.yaml" \
+  || fail "#4846 primary render dropped the k8s allow-replication-to-primary NetworkPolicy"
+# Replica side: the CNP selects the REPLICA Cluster's Pods + lists the primary mesh.
+cat > "$TMP/cnp-replica.values.yaml" <<'YAML'
+instance: { name: shared-pg }
+topology:
+  mode: active-hot-standby
+  side: replica
+  instances: 3
+  primary: { region: hz-fsn-rtz-prod }
+  replica: { region: hz-hel-rtz-prod }
+  networkPolicy:
+    crossRegionPeerClusters: [hw228-mesh]
+databases:
+  - name: registry
+    owner: harbor
+    reflect: { secretName: harbor-database-secret, namespaces: [harbor] }
+YAML
+helm template shared-pg . -f "$TMP/cnp-replica.values.yaml" --namespace shared-data \
+  --api-versions postgresql.cnpg.io/v1 > "$TMP/cnp-replica.yaml" 2>&1 || fail "#4846 CNP replica render errored"
+[ "$(grep -cE '^kind: CiliumNetworkPolicy$' "$TMP/cnp-replica.yaml")" = "1" ] \
+  || fail "#4846 replica side expected exactly 1 CiliumNetworkPolicy"
+grep -qE '^  name: shared-pg-crossregion-dr-replica$' "$TMP/cnp-replica.yaml" \
+  || fail "#4846 replica CNP name != shared-pg-crossregion-dr-replica"
+grep -qE '^      cnpg.io/cluster: shared-pg-replica$' "$TMP/cnp-replica.yaml" \
+  || fail "#4846 replica CNP endpointSelector must select cnpg.io/cluster: shared-pg-replica"
+grep -q '"hw228-mesh"' "$TMP/cnp-replica.yaml" || fail "#4846 replica CNP missing the primary mesh name in the In-list"
+if grep -qE '^[[:space:]]*-?[[:space:]]*ipBlock:' "$TMP/cnp-replica.yaml"; then
+  fail "#4846 replica render leaked an ipBlock rule"
+fi
+
+# ── Case 4f: #4846 — EMPTY crossRegionPeerClusters → ZERO CNP (default) ──────
+# The default (single-region / singleton, and every AHS render before the
+# post-mesh peer-name stamp) carries an empty crossRegionPeerClusters, which
+# MUST render NO CiliumNetworkPolicy while the k8s-netpol carve-outs stay.
+echo "[render] Case 4f: #4846 empty crossRegionPeerClusters → ZERO CiliumNetworkPolicy, k8s netpol intact"
+grep -q 'CiliumNetworkPolicy' "$TMP/ahs.yaml" \
+  && fail "#4846 AHS render WITHOUT crossRegionPeerClusters must emit ZERO CiliumNetworkPolicy" || true
+grep -q 'allow-replication-to-primary' "$TMP/ahs.yaml" \
+  || fail "#4846 AHS render lost the k8s allow-replication-to-primary NetworkPolicy"
+
 # ── Case 5: singleton → byte-identical (NO sync, NO mesh, NO netpol) ──────
 echo "[render] Case 5: singleton → no synchronous block, no -mesh Service, only the CNPG-operator status-probe NetworkPolicy (no AHS replication carve-out)"
 if grep -q 'synchronous_commit' "$TMP/shared.yaml"; then
@@ -364,6 +449,10 @@ fi
 # Cluster stalls Ready=False at "Instance Status Extraction Error").
 if grep -qE 'allow-replication-to-(primary|replica)' "$TMP/shared.yaml"; then
   fail "singleton render leaked an AHS replication NetworkPolicy (active-hot-standby only)"
+fi
+# #4846: singleton must NOT leak the cross-region DR CiliumNetworkPolicy.
+if grep -q 'CiliumNetworkPolicy' "$TMP/shared.yaml"; then
+  fail "#4846: singleton render leaked a cross-region DR CiliumNetworkPolicy (active-hot-standby only)"
 fi
 grep -qE '^  name: shared-pg-allow-cnpg-operator-probe$' "$TMP/shared.yaml" \
   || fail "#4282: singleton render missing the CNPG-operator status-probe NetworkPolicy"

--- a/platform/postgres/chart/values.yaml
+++ b/platform/postgres/chart/values.yaml
@@ -199,22 +199,30 @@ topology:
     # consumers are same-Org, covered by allow-same-org — no broad open). The
     # host shared-data slots set it true.
     sharedConsumers: false
-    # crossRegionPodCIDRs (#4846) — pod CIDRs of the OTHER region('s) cluster,
-    # allowed to reach this instance's 5432 for cross-region replication +
-    # shared-consumer reach. REQUIRED in a 2-region (active-hot-standby)
-    # Sovereign: k8s NetworkPolicy namespaceSelector/podSelector are implicitly
-    # scoped to the LOCAL cluster (Cilium ANDs `io.cilium.k8s.policy.cluster=
-    # <local>`), so ClusterMesh REMOTE-cluster sources (region-b keycloak/
-    # grafana consumers + the region-b replica's pg_basebackup) are NEVER
-    # matched by the label rules above and get default-denied → timeout (region-b
-    # grafana CrashLoop, replica stuck "Setting up primary" 30h, keycloak JGroups
-    # JDBC timeout — all on hw228). An `ipBlock` rule matches by raw source IP,
-    # NOT endpoint identity, so it is NOT subject to that local-cluster scoping
-    # and admits the remote region's pods. The bootstrap-kit wires this to the
-    # secondary region's pod CIDR(s) (SOVEREIGN_REPLICA_POD_CIDR / the peer
-    # region's cluster-pool CIDR) in active-hot-standby mode. EMPTY (default) →
-    # singleton renders NO ipBlock rule (byte-identical single-region default).
-    crossRegionPodCIDRs: []
+    # crossRegionPeerClusters (#4846) — the Cilium ClusterMesh cluster.name(s)
+    # of the OTHER region('s) cluster, allowed to reach this instance's 5432 for
+    # cross-region replication + shared-consumer reach. REQUIRED in a 2-region
+    # (active-hot-standby) Sovereign.
+    #
+    # WHY an identity-based CiliumNetworkPolicy, NOT a k8s-NetworkPolicy ipBlock
+    # (the #4847/#4848 inert-fix correction): the region-b sources (keycloak/
+    # grafana consumers + the region-b replica's pg_basebackup/WAL streaming)
+    # arrive over ClusterMesh as KNOWN Cilium endpoints carrying their OWN pod
+    # security identity. A k8s-netpol `ipBlock` matches ONLY a CIDR identity,
+    # which Cilium assigns SOLELY to IPs that are NOT known endpoints — so a
+    # ClusterMesh remote pod is never a CIDR-identity match → `match none` →
+    # deny. (The #4846 ipBlock shipped INERT; proven with cilium-dbg on hw228.)
+    # A k8s-netpol label selector is ALSO implicitly local-cluster-scoped
+    # (Cilium ANDs `io.cilium.k8s.policy.cluster=<local>`), so it can't match a
+    # remote endpoint either. The CORRECT admission is a CiliumNetworkPolicy
+    # whose `fromEndpoints` selects the peer cluster(s) by the
+    # `io.cilium.k8s.policy.cluster` label — this exact shape made region-b→
+    # region-a pg_isready succeed and the DR replica basebackup complete on
+    # hw228. The bootstrap-kit wires this to the peer region's ClusterMesh
+    # name(s) (SOVEREIGN_PEER_CLUSTERMESH_NAMES, stamped by catalyst-api at the
+    # post-mesh cnpg-pair flip). EMPTY (default) → singleton renders NO
+    # CiliumNetworkPolicy (byte-identical single-region default).
+    crossRegionPeerClusters: []
 
 # ── Bindings (the shareable part) ───────────────────────────────────────
 # Each entry binds ONE consumer to this instance. The chart renders a

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -271,6 +271,25 @@ const (
 	clusterMeshRegionRoleSubstituteKey = "SOVEREIGN_REGION_ROLE"
 	fluxReconcileRequestedAtAnnotation = "reconcile.fluxcd.io/requestedAt"
 
+	// clusterMeshPeerClusterMeshNamesSubstituteKey (#4846, Refs #4656 #4275)
+	// carries the Cilium ClusterMesh cluster.name(s) of the OTHER region(s)
+	// for the region whose bootstrap-kit Kustomization it is stamped onto,
+	// as a YAML flow-sequence string (e.g. `[hw228-me-east-b]` on region-A;
+	// `[hw228-mesh]` on region-B). bp-postgres (16a/16c/16d) + bp-cnpg-pair
+	// (16b) consume it as `crossRegionPeerClusters:
+	// ${SOVEREIGN_PEER_CLUSTERMESH_NAMES:-[]}` to render the cross-region DR
+	// CiliumNetworkPolicy that admits the ClusterMesh remote replica by
+	// `io.cilium.k8s.policy.cluster` identity. This REPLACES the inert #4846
+	// ipBlock: a k8s-NetworkPolicy ipBlock matches only a CIDR identity
+	// (assigned solely to NON-endpoint IPs), so a ClusterMesh remote pod — a
+	// KNOWN endpoint with its own pod identity — is `match none` → deny
+	// (proven with cilium-dbg on hw228). It is stamped alongside the
+	// SOVEREIGN_ENABLE_CNPG_PAIR flip below (the crossRegion netpol half only
+	// renders once that gate is on), so the CNP appears exactly when the
+	// cross-region datapath activates; single-region provs never reach this
+	// flip → the slot default `[]` → no CNP (byte-identical).
+	clusterMeshPeerClusterMeshNamesSubstituteKey = "SOVEREIGN_PEER_CLUSTERMESH_NAMES"
+
 	// Cross-region shared-pg WRITE-host substitute keys (#4436, Refs
 	// #4159). On a 2-region shared-pg Sovereign the CNPG primary (the
 	// region-local `shared-pg-rw` Service) lives ONLY in region-A; the
@@ -1142,6 +1161,35 @@ func (h *Handler) autoEstablishClusterMesh(ctx context.Context, dep *Deployment)
 	return statuses, cnpgPairConverged, nil
 }
 
+// buildPeerClusterMeshNamesValue returns the SOVEREIGN_PEER_CLUSTERMESH_NAMES
+// substitute value for the region at slots[idx] — a YAML flow-sequence string
+// listing EVERY OTHER region's Cilium cluster.name (the identity the
+// cross-region DR CiliumNetworkPolicy matches via io.cilium.k8s.policy.cluster,
+// #4846). Each slot's clusterName was already derived (buildRegionSlots) via
+// provisioner.DeriveClusterMeshName (primary = `<label>-mesh`) /
+// DeriveSecondaryClusterMeshName (`<stem>-<region-no-digits>`), so this reuses
+// the SAME strings cilium-config carries on each cluster — the identity the
+// remote pods actually present.
+//
+// Returns "[]" when there is no peer (single-region, or every other slot's
+// clusterName is empty), so the chart renders NO CiliumNetworkPolicy. Emitted
+// as a flow sequence (e.g. "[hw228-me-east-b]") so the slot's
+// `crossRegionPeerClusters: ${SOVEREIGN_PEER_CLUSTERMESH_NAMES:-[]}` substitutes
+// to a valid YAML list.
+func buildPeerClusterMeshNamesValue(slots []regionSlot, idx int) string {
+	peers := make([]string, 0, len(slots))
+	for j := range slots {
+		if j == idx {
+			continue
+		}
+		name := strings.TrimSpace(slots[j].clusterName)
+		if name != "" {
+			peers = append(peers, name)
+		}
+	}
+	return "[" + strings.Join(peers, ",") + "]"
+}
+
 // enableCNPGPairAfterFullMesh flips the slot-16b gate on EVERY
 // region's bootstrap-kit Flux Kustomization (the one cloud-init applies
 // — infra/providers/_shared/cloudinit-control-plane.tftpl) by merging
@@ -1227,6 +1275,13 @@ func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployme
 		// this crossRegion flip, so their `<instance>-replication`/`-ca`
 		// Secrets must be synced primary → replica alongside bp-cnpg-pair's.
 		sharedPGEnabled bool
+		// peerClusterMeshNames (#4846) — the OTHER region(s)' Cilium
+		// cluster.name(s) as a YAML flow-sequence string, stamped onto THIS
+		// region's SOVEREIGN_PEER_CLUSTERMESH_NAMES substitute so the
+		// bp-postgres / bp-cnpg-pair cross-region DR CiliumNetworkPolicy
+		// admits the ClusterMesh remote replica by identity. Derived from the
+		// slots' already-computed clusterName (buildPeerClusterMeshNamesValue).
+		peerClusterMeshNames string
 	}
 	targets := make([]flipTarget, 0, len(slots))
 	for i := range slots {
@@ -1300,7 +1355,13 @@ func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployme
 			}
 		}
 		sharedPGEnabled := strings.EqualFold(strings.TrimSpace(substitute[clusterMeshSharedPGSubstituteKey]), "true")
-		targets = append(targets, flipTarget{regionKey: regionLabel, dyn: dyn, primarySide: role == "primary", sharedPGEnabled: sharedPGEnabled})
+		targets = append(targets, flipTarget{
+			regionKey:            regionLabel,
+			dyn:                  dyn,
+			primarySide:          role == "primary",
+			sharedPGEnabled:      sharedPGEnabled,
+			peerClusterMeshNames: buildPeerClusterMeshNamesValue(slots, i),
+		})
 	}
 
 	// ── Patch phase: TWO-STAGE (#3241 first-flip deadlock) ──────────
@@ -1325,27 +1386,39 @@ func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployme
 	// sibling substitute keys + existing annotations are preserved —
 	// only the gate key and the reconcile-request stamp change.
 	stamp := time.Now().UTC().Format(time.RFC3339Nano)
-	patch := map[string]any{
-		"metadata": map[string]any{
-			"annotations": map[string]any{
-				fluxReconcileRequestedAtAnnotation: stamp,
-			},
-		},
-		"spec": map[string]any{
-			"postBuild": map[string]any{
-				"substitute": map[string]any{
-					clusterMeshCNPGPairSubstituteKey: "true",
+	// Per-region patch: SOVEREIGN_ENABLE_CNPG_PAIR is identical for every
+	// region, but SOVEREIGN_PEER_CLUSTERMESH_NAMES (#4846) differs — each
+	// region's substitute must carry the OTHER region(s)' Cilium cluster.name,
+	// so the cross-region DR CiliumNetworkPolicy admits the correct remote
+	// peer by identity. Both keys land in ONE merge patch so the CNP appears
+	// atomically with the crossRegion netpol half it gates. The JSON merge
+	// patch (RFC 7386) merges nested objects key-by-key, so sibling substitute
+	// keys + existing annotations are preserved.
+	patchOne := func(t flipTarget) bool {
+		substitute := map[string]any{
+			clusterMeshCNPGPairSubstituteKey: "true",
+		}
+		if t.peerClusterMeshNames != "" {
+			substitute[clusterMeshPeerClusterMeshNamesSubstituteKey] = t.peerClusterMeshNames
+		}
+		patch := map[string]any{
+			"metadata": map[string]any{
+				"annotations": map[string]any{
+					fluxReconcileRequestedAtAnnotation: stamp,
 				},
 			},
-		},
-	}
-	patchBytes, err := json.Marshal(patch)
-	if err != nil {
-		h.log.Warn("clustermesh: cnpg-pair gate: marshal merge patch failed",
-			"id", dep.ID, "err", err)
-		return false
-	}
-	patchOne := func(t flipTarget) bool {
+			"spec": map[string]any{
+				"postBuild": map[string]any{
+					"substitute": substitute,
+				},
+			},
+		}
+		patchBytes, err := json.Marshal(patch)
+		if err != nil {
+			h.log.Warn("clustermesh: cnpg-pair gate: marshal merge patch failed",
+				"id", dep.ID, "region", t.regionKey, "err", err)
+			return false
+		}
 		patchCtx, cancelPatch := context.WithTimeout(ctx, clusterMeshCallTimeout)
 		_, patchErr := t.dyn.Resource(fluxKustomizationGVR).Namespace(fluxSystemNamespace).
 			Patch(patchCtx, bootstrapKitKustomizationName, types.MergePatchType, patchBytes, metav1.PatchOptions{})

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_peer_names_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_peer_names_test.go
@@ -1,0 +1,66 @@
+package handler
+
+// #4846 (Refs #4656 #4275) — the SOVEREIGN_PEER_CLUSTERMESH_NAMES substitute
+// that catalyst-api stamps onto each region's bootstrap-kit Kustomization at the
+// post-mesh cnpg-pair flip. The bp-postgres / bp-cnpg-pair charts consume it as
+// `crossRegionPeerClusters` to render the identity-based cross-region DR
+// CiliumNetworkPolicy (admits the ClusterMesh remote replica by
+// io.cilium.k8s.policy.cluster — the k8s-netpol ipBlock it replaces was inert
+// for ClusterMesh endpoints, proven on hw228).
+//
+// Invariant under test: each region's value carries the cluster.name(s) of the
+// OTHER region(s) — NOT its own — as a YAML flow-sequence string; a single
+// region yields "[]" so the chart renders NO CNP (byte-identical default).
+
+import "testing"
+
+func TestBuildPeerClusterMeshNamesValue(t *testing.T) {
+	t.Run("two regions — each carries the OTHER's cluster name", func(t *testing.T) {
+		// slots[0] = primary (DeriveClusterMeshName → <label>-mesh),
+		// slots[1] = secondary (DeriveSecondaryClusterMeshName → <stem>-<region>).
+		slots := []regionSlot{
+			{key: "", clusterName: "hw228-mesh"},
+			{key: "me-east-215-b", clusterName: "hw228-me-east-b"},
+		}
+		if got := buildPeerClusterMeshNamesValue(slots, 0); got != "[hw228-me-east-b]" {
+			t.Fatalf("region-a (primary) peer names = %q, want [hw228-me-east-b] (the secondary's mesh name)", got)
+		}
+		if got := buildPeerClusterMeshNamesValue(slots, 1); got != "[hw228-mesh]" {
+			t.Fatalf("region-b (secondary) peer names = %q, want [hw228-mesh] (the primary's mesh name)", got)
+		}
+	})
+
+	t.Run("single region — empty flow sequence (no CNP)", func(t *testing.T) {
+		slots := []regionSlot{{key: "", clusterName: "solo-mesh"}}
+		if got := buildPeerClusterMeshNamesValue(slots, 0); got != "[]" {
+			t.Fatalf("single-region peer names = %q, want [] (chart must render NO CiliumNetworkPolicy)", got)
+		}
+	})
+
+	t.Run("three regions — each carries the two OTHER names, order preserved", func(t *testing.T) {
+		slots := []regionSlot{
+			{key: "", clusterName: "t129-mesh"},
+			{key: "nbg1", clusterName: "t129-nbg"},
+			{key: "hel1", clusterName: "t129-hel"},
+		}
+		if got := buildPeerClusterMeshNamesValue(slots, 0); got != "[t129-nbg,t129-hel]" {
+			t.Fatalf("region-0 peer names = %q, want [t129-nbg,t129-hel]", got)
+		}
+		if got := buildPeerClusterMeshNamesValue(slots, 1); got != "[t129-mesh,t129-hel]" {
+			t.Fatalf("region-1 peer names = %q, want [t129-mesh,t129-hel]", got)
+		}
+		if got := buildPeerClusterMeshNamesValue(slots, 2); got != "[t129-mesh,t129-nbg]" {
+			t.Fatalf("region-2 peer names = %q, want [t129-mesh,t129-nbg]", got)
+		}
+	})
+
+	t.Run("blank peer cluster name is skipped (never emits an empty list element)", func(t *testing.T) {
+		slots := []regionSlot{
+			{key: "", clusterName: "hw228-mesh"},
+			{key: "b", clusterName: "  "}, // whitespace-only → skipped
+		}
+		if got := buildPeerClusterMeshNamesValue(slots, 0); got != "[]" {
+			t.Fatalf("peer with blank clusterName must be skipped: got %q, want []", got)
+		}
+	})
+}


### PR DESCRIPTION
## Problem (proven live on hw228)

The shipped #4846 fix (#4847 platform/postgres 0.2.9 + #4848 platform/cnpg-pair 0.2.8) added a k8s-NetworkPolicy `ipBlock: {cidr: crossRegionPodCIDRs}` on 5432 to admit the cross-region ClusterMesh replica. **That ipBlock is inert for ClusterMesh traffic.** A k8s-netpol `ipBlock` matches only a *CIDR identity*, which Cilium assigns solely to IPs that are **not** known endpoints. A ClusterMesh remote-cluster pod *is* a known endpoint carrying its own pod security identity, so the ipBlock rule is never consulted → `match none` → deny (confirmed with `cilium-dbg` on hw228: region-b→region-a `pg_isready` failed, DR replica stuck "Setting up primary").

## Fix

Replace both charts' ipBlock blocks with a per-side, **identity-based** `CiliumNetworkPolicy` (cilium.io/v2) that selects THIS side's Cluster Pods (`primaryName` on primary, `replicaName` on replica) and admits ingress `fromEndpoints` matching `io.cilium.k8s.policy.cluster In [<peers>]` on 5432/TCP — the exact shape that made region-b→region-a `pg_isready` succeed and the DR replica basebackup complete **live on hw228**.

### Changes
- **platform/postgres** 0.2.9 → 0.2.10, **platform/cnpg-pair** 0.2.8 → 0.2.9. `networkpolicy.yaml` removes both ipBlock blocks per side and renders the CNP gated on the new `…networkPolicy.crossRegionPeerClusters` (peer ClusterMesh name(s)). `values` `crossRegionPodCIDRs` → `crossRegionPeerClusters`; `blueprint.yaml` lockstep. **Singleton / empty-peers render is byte-identical (zero CNP objects).**
- **bootstrap-kit** slots 16a/16b/16c/16d: `crossRegionPeerClusters: ${SOVEREIGN_PEER_CLUSTERMESH_NAMES:-[]}`; chart pins bumped in lockstep.
- **catalyst-api** `handler/clustermesh.go`: `enableCNPGPairAfterFullMesh` now stamps `SOVEREIGN_PEER_CLUSTERMESH_NAMES` (the peer region's ClusterMesh name(s), from the slots' `DeriveClusterMeshName`-derived `clusterName`) onto each region's bootstrap-kit substitute, atomically with the crossRegion flip. Focused unit test: 2-region → each region carries the OTHER's name; single-region → `[]`.

### Deviation from brief
The brief located the per-region substitute plumbing in `provisioner/provisioner.go`. It is not there — the `SOVEREIGN_*` substitutes are stamped at boot by the cloud-init tftpl and **runtime-patched by `handler/clustermesh.go`** at the post-mesh cnpg-pair flip (using the exact `DeriveClusterMeshName`/`DeriveSecondaryClusterMeshName` functions the brief named, via the pre-computed `slot.clusterName`). The peer-name stamp lands in that same flip, so the CNP appears exactly when the crossRegion netpol half it gates renders.

### Gates (all green)
- `helm template` postgres + cnpg-pair, both sides: CNP present with `io.cilium.k8s.policy.cluster In [<peer>]` and **zero** `ipBlock`; empty peers → **zero** CNP, k8s-netpol carve-outs intact.
- `postgres-render.sh` Case 4e/4f + Case 5 guard, `cnpg-pair-render.sh` Case 12.
- `go build ./...`, `go vet`, full `go test ./internal/handler/`, `go test ./internal/provisioner/...`.
- `check-bootstrap-kit-pin-sync.sh`, `check-bootstrap-deps.sh`.

Refs #4846 #4656 #4275