### PR TITLE
fix(#4834): align catalog seed bp-stalwart-tenant 0.1.8→0.1.13 (S-plan right-sizing reaches the marketplace)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -4760,7 +4760,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.1.8",
+      "version": "0.1.13",
       "section": "pts-4-5-communication",
       "depends": [
         "bp-keycloak",


### PR DESCRIPTION
## Problem
The catalog seed `blueprints.json` listed **bp-stalwart-tenant at 0.1.8** — 5 versions behind the published chart **0.1.13**. #4834/#4833 (commit cb8c17248) right-sized the stalwart-tenant CPU 1→500m (chart + blueprint.yaml bumped to 0.1.13) so a per-Org openclaw controller (requests 500m) fits the S-plan 2vCPU quota, but the **marketplace catalog seed was left at 0.1.8**, so the marketplace still offers the old 1000m build.

## Evidence (live, hw228 walk-stranger)
openclaw controller Deployment is 0/1 — ReplicaSet `FailedCreate: exceeded quota plan-quota, requested cpu=500m, used=1600m, limited=2`, because the live `bp-stalwart-tenant@0.1.12` requests **1000m** CPU. This blocks UAT rows 224 (openclaw controller Ready) + 232 (openclaw `/readyz` 200).

## Fix
Bump the `blueprints.json` seed entry to **0.1.13** (published on ghcr), matching the chart. One-line change; JSON validated (95 blueprints intact). Fresh provs already install 0.1.13 from Gitea; this aligns the mothership marketplace seed so no install path can offer the quota-starving 1000m build.

Refs #4834 #4833