### PR TITLE
fix(#4849): source-controller OOM + unbounded emptyDir → node DiskPressure → GitRepo wedge (bp-flux postRenderer)

### DIFF
--- a/clusters/_template/bootstrap-kit/03-flux.yaml
+++ b/clusters/_template/bootstrap-kit/03-flux.yaml
@@ -155,3 +155,29 @@ spec:
                   rollingUpdate:
                     maxUnavailable: 0
                     maxSurge: 1
+                template:
+                  spec:
+                    containers:
+                      # #4849: source-controller default memLimit (384Mi) OOMs
+                      # (exit 137) cloning this repo -> each OOM leaves a ~500MB
+                      # partial clone in the UNBOUNDED /tmp emptyDir -> /tmp fills
+                      # the node disk (91% on hw228) -> node DiskPressure -> the
+                      # GitRepository wedges (14h stall, delivery dead). Bump mem
+                      # so a full clone fits, and cap the emptyDirs so a clone
+                      # loop can never again exhaust the node (it fails its own
+                      # pod, not every pod on the node). Patched via postRenderer
+                      # because helm-controller owns this Deployment and reverts
+                      # a raw kubectl patch.
+                      - name: manager
+                        resources:
+                          limits:
+                            memory: 1Gi
+                          requests:
+                            memory: 256Mi
+                    volumes:
+                      - name: tmp
+                        emptyDir:
+                          sizeLimit: 2Gi
+                      - name: data
+                        emptyDir:
+                          sizeLimit: 3Gi


### PR DESCRIPTION
## Problem (recurring, live on hw228)
Flux `source-controller` runs with the default **memLimit 384Mi**. Cloning this (large) repo **OOMKills** it (exit 137). Each OOM leaves a ~500MB partial clone in its **unbounded `/tmp` emptyDir**; over a crash-loop these accumulate until **`/tmp` fills the node disk** (observed 91%, 33.8G/39.1G) → node **DiskPressure=True** → the `openova` GitRepository can no longer clone (`no space left on device`) → **delivery wedges** (a 14h zero-touch stall this session — every merged fix blocked until the pod was manually deleted).

## Fix
Extend the existing bp-flux `postRenderers` kustomize patch for the `source-controller` Deployment (where the #3735 RollingUpdate patch already lives — patched there because helm-controller owns the Deployment and reverts raw `kubectl patch`):
- `resources.limits.memory: 1Gi` (+ `requests.memory: 256Mi`) so a full clone fits and doesn't OOM.
- `emptyDir.sizeLimit` on `tmp` (2Gi) and `data` (3Gi) — defense-in-depth so a clone loop can **never** exhaust the node again (it fails its own pod, not every pod on the node).

Validated: YAML parses; the patch carries mem + sizeLimit. Reconciles onto existing envs (bootstrap-kit tracks main) and every fresh prov. Refs #4849