### PR TITLE
fix(#4853): retry Application status writes on 409 Conflict

### DIFF
--- a/core/controllers/application/internal/controller/application_controller.go
+++ b/core/controllers/application/internal/controller/application_controller.go
@@ -59,6 +59,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/util/retry"
 
 	topo "github.com/openova-io/openova/core/controllers/application/internal/render"
 	"github.com/openova-io/openova/core/controllers/internal/clusterregistry"
@@ -2284,104 +2285,126 @@ type statusUpdate struct {
 // concurrent edits, then update with the desired status. The dynamic
 // client's UpdateStatus handles the /status subresource correctly.
 func (r *Reconciler) updateStatus(ctx context.Context, app *unstructured.Unstructured, su statusUpdate) error {
-	// Always re-fetch to avoid clobbering. If the object is gone, no-op.
-	latest, err := r.Dynamic.Resource(ApplicationGVR).Namespace(app.GetNamespace()).
-		Get(ctx, app.GetName(), metav1.GetOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return fmt.Errorf("re-fetch application for status: %w", err)
-	}
-
 	now := time.Now().UTC().Format(time.RFC3339)
-	currentStatus, _, _ := unstructured.NestedMap(latest.Object, "status")
-	if currentStatus == nil {
-		currentStatus = map[string]interface{}{}
-	}
-	currentStatus["observedGeneration"] = latest.GetGeneration()
-	if su.Phase != "" {
-		currentStatus["phase"] = su.Phase
-	}
-	if su.PrimaryRegion != "" {
-		currentStatus["primaryRegion"] = su.PrimaryRegion
-	}
-	if su.Regions != nil {
-		regions := make([]interface{}, len(su.Regions))
-		for i, r := range su.Regions {
-			regions[i] = r
-		}
-		currentStatus["regions"] = regions
-	}
-	if su.Placement != nil {
-		// #3373 — effective placement reflection.
-		currentStatus["placement"] = su.Placement
-	}
-	if su.PlacementRecon != "" {
-		// #3969 §7.4 — the ONE recon status value (string), distinct from
-		// the legacy `status.placement` object above. Reconciled /
-		// Reconciling / Degraded — never a second contradictory class.
-		currentStatus["placementRecon"] = su.PlacementRecon
-		// The plain reason is set (or cleared) alongside the status so a
-		// stale reason never lingers once the placement reconciles green.
-		currentStatus["placementReason"] = su.PlacementReason
-	}
-	if su.ObservedTargets != nil {
-		// #3969 §7.4 — the observed per-target rollup the Topology tab
-		// reads. One status value, never two.
-		currentStatus["targets"] = su.ObservedTargets
-	}
-	if su.ContinuumRef != "" {
-		// #4416 — the back-pointer to this Application's per-app Continuum DR
-		// contract, closing the #4212 spine→Continuum round-trip.
-		currentStatus["continuumRef"] = su.ContinuumRef
-	}
-	if su.GiteaRepo != "" {
-		currentStatus["giteaRepo"] = su.GiteaRepo
-	}
-	if su.Installed != nil {
-		currentStatus["installedBlueprint"] = su.Installed
-	}
-	if su.LastReconciledAt != "" {
-		currentStatus["lastReconciledAt"] = su.LastReconciledAt
-	}
-	if su.PerCluster != nil {
-		// G117.6 — slice of map[string]interface{} → []interface{} for
-		// the dynamic client's NestedSlice contract.
-		perCluster := make([]interface{}, len(su.PerCluster))
-		for i, c := range su.PerCluster {
-			perCluster[i] = c
-		}
-		currentStatus["perCluster"] = perCluster
-	}
 
-	// Replace Ready condition; preserve unrelated conditions.
-	conditions := []interface{}{}
-	if existing, ok := currentStatus["conditions"].([]interface{}); ok {
-		for _, c := range existing {
-			cm, ok := c.(map[string]interface{})
-			if !ok {
-				continue
+	// #4853 — the periodic re-list goroutine (runPeriodicRelist → initialList)
+	// and the watch goroutine (watchOnce) both call Reconcile → updateStatus on
+	// the SAME Application concurrently. A bare Get-then-UpdateStatus races on
+	// resourceVersion in the window between the read and the write: whichever
+	// writes second gets a 409 Conflict ("the object has been modified; please
+	// apply your latest changes to the latest version") and the reconcile logs
+	// `update status: Operation cannot be fulfilled ...` every ~30s. Wrapping
+	// the whole read-modify-write in RetryOnConflict re-runs it with the fresh
+	// resourceVersion so the loser self-heals instead of erroring + requeuing.
+	// The closure returns the RAW api error on the write so RetryOnConflict's
+	// IsConflict check fires (a %w-wrapped error would not be recognised).
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		// Always re-fetch to avoid clobbering. If the object is gone, no-op.
+		latest, err := r.Dynamic.Resource(ApplicationGVR).Namespace(app.GetNamespace()).
+			Get(ctx, app.GetName(), metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
 			}
-			if t, _ := cm["type"].(string); t == "Ready" {
-				continue
-			}
-			conditions = append(conditions, c)
+			return fmt.Errorf("re-fetch application for status: %w", err)
 		}
-	}
-	conditions = append(conditions, map[string]interface{}{
-		"type":               "Ready",
-		"status":             su.Ready,
-		"reason":             su.Reason,
-		"message":            su.Message,
-		"lastTransitionTime": now,
+
+		currentStatus, _, _ := unstructured.NestedMap(latest.Object, "status")
+		if currentStatus == nil {
+			currentStatus = map[string]interface{}{}
+		}
+		currentStatus["observedGeneration"] = latest.GetGeneration()
+		if su.Phase != "" {
+			currentStatus["phase"] = su.Phase
+		}
+		if su.PrimaryRegion != "" {
+			currentStatus["primaryRegion"] = su.PrimaryRegion
+		}
+		if su.Regions != nil {
+			regions := make([]interface{}, len(su.Regions))
+			for i, r := range su.Regions {
+				regions[i] = r
+			}
+			currentStatus["regions"] = regions
+		}
+		if su.Placement != nil {
+			// #3373 — effective placement reflection.
+			currentStatus["placement"] = su.Placement
+		}
+		if su.PlacementRecon != "" {
+			// #3969 §7.4 — the ONE recon status value (string), distinct from
+			// the legacy `status.placement` object above. Reconciled /
+			// Reconciling / Degraded — never a second contradictory class.
+			currentStatus["placementRecon"] = su.PlacementRecon
+			// The plain reason is set (or cleared) alongside the status so a
+			// stale reason never lingers once the placement reconciles green.
+			currentStatus["placementReason"] = su.PlacementReason
+		}
+		if su.ObservedTargets != nil {
+			// #3969 §7.4 — the observed per-target rollup the Topology tab
+			// reads. One status value, never two.
+			currentStatus["targets"] = su.ObservedTargets
+		}
+		if su.ContinuumRef != "" {
+			// #4416 — the back-pointer to this Application's per-app Continuum DR
+			// contract, closing the #4212 spine→Continuum round-trip.
+			currentStatus["continuumRef"] = su.ContinuumRef
+		}
+		if su.GiteaRepo != "" {
+			currentStatus["giteaRepo"] = su.GiteaRepo
+		}
+		if su.Installed != nil {
+			currentStatus["installedBlueprint"] = su.Installed
+		}
+		if su.LastReconciledAt != "" {
+			currentStatus["lastReconciledAt"] = su.LastReconciledAt
+		}
+		if su.PerCluster != nil {
+			// G117.6 — slice of map[string]interface{} → []interface{} for
+			// the dynamic client's NestedSlice contract.
+			perCluster := make([]interface{}, len(su.PerCluster))
+			for i, c := range su.PerCluster {
+				perCluster[i] = c
+			}
+			currentStatus["perCluster"] = perCluster
+		}
+
+		// Replace Ready condition; preserve unrelated conditions.
+		conditions := []interface{}{}
+		if existing, ok := currentStatus["conditions"].([]interface{}); ok {
+			for _, c := range existing {
+				cm, ok := c.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if t, _ := cm["type"].(string); t == "Ready" {
+					continue
+				}
+				conditions = append(conditions, c)
+			}
+		}
+		conditions = append(conditions, map[string]interface{}{
+			"type":               "Ready",
+			"status":             su.Ready,
+			"reason":             su.Reason,
+			"message":            su.Message,
+			"lastTransitionTime": now,
+		})
+		currentStatus["conditions"] = conditions
+
+		latest.Object["status"] = currentStatus
+
+		if _, err := r.Dynamic.Resource(ApplicationGVR).Namespace(latest.GetNamespace()).
+			UpdateStatus(ctx, latest, metav1.UpdateOptions{}); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			// Return the raw error so RetryOnConflict can recognise a 409
+			// Conflict and re-run the closure with the fresh resourceVersion.
+			return err
+		}
+		return nil
 	})
-	currentStatus["conditions"] = conditions
-
-	latest.Object["status"] = currentStatus
-
-	_, err = r.Dynamic.Resource(ApplicationGVR).Namespace(latest.GetNamespace()).
-		UpdateStatus(ctx, latest, metav1.UpdateOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil

--- a/core/controllers/application/internal/controller/application_controller_status_conflict_4853_test.go
+++ b/core/controllers/application/internal/controller/application_controller_status_conflict_4853_test.go
@@ -1,0 +1,119 @@
+// Tests for the #4853 status-update conflict race in the application
+// controller. The periodic re-list goroutine and the watch goroutine both
+// call Reconcile -> updateStatus on the same Application; a bare
+// Get-then-UpdateStatus loses a race on resourceVersion and logs
+// `update status: Operation cannot be fulfilled ... the object has been
+// modified` every ~30s. updateStatus now wraps the read-modify-write in
+// retry.RetryOnConflict so the loser self-heals instead of erroring.
+package controller
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// injectStatusConflicts prepends a reactor on the fake dynamic client that
+// returns a 409 Conflict for the first `n` status-subresource updates, then
+// passes through. Returns a pointer to the live counter of injected conflicts.
+func injectStatusConflicts(t *testing.T, r *Reconciler, n int) *int {
+	t.Helper()
+	fake, ok := r.Dynamic.(*dynamicfake.FakeDynamicClient)
+	if !ok {
+		t.Fatalf("Dynamic is %T, want *dynamicfake.FakeDynamicClient", r.Dynamic)
+	}
+	fired := 0
+	fake.PrependReactor("update", "applications", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "status" {
+			return false, nil, nil // only race the /status write
+		}
+		if fired < n {
+			fired++
+			return true, nil, apierrors.NewConflict(
+				schema.GroupResource{Group: "apps.openova.io", Resource: "applications"},
+				"uat-hw228-pg",
+				errors.New("the object has been modified; please apply your latest changes to the latest version and try again"),
+			)
+		}
+		return false, nil, nil // pass through to the tracker
+	})
+	return &fired
+}
+
+// TestUpdateStatus_RetriesOnConflict is the #4853 guard: a single injected
+// 409 Conflict on the status write must be transparently retried, and the
+// caller must see a nil error with the intended status applied.
+func TestUpdateStatus_RetriesOnConflict(t *testing.T) {
+	app := makeApp("acme", "uat-hw228-pg", "acme-prod", "bp-postgres", "0.2.10", "single-region",
+		[]string{"hetzner-fsn-rtz-prod"}, map[string]interface{}{})
+	r := newReconciler(t, newFakeGitea(), app)
+	fired := injectStatusConflicts(t, r, 1)
+
+	err := r.updateStatus(context.Background(), app, statusUpdate{
+		Phase:   PhaseReady,
+		Ready:   "True",
+		Reason:  "Healthy",
+		Message: "all regions ready",
+	})
+	if err != nil {
+		t.Fatalf("updateStatus returned error on a single retryable conflict: %v", err)
+	}
+	if *fired != 1 {
+		t.Fatalf("expected exactly 1 injected conflict to be consumed, got %d", *fired)
+	}
+
+	got := readApp(t, r, "acme", "uat-hw228-pg")
+	phase, _, _ := unstructured.NestedString(got.Object, "status", "phase")
+	if phase != PhaseReady {
+		t.Errorf("status.phase = %q after conflict-heal, want %q", phase, PhaseReady)
+	}
+	// The Ready condition must reflect the intended write, proving the retry
+	// re-applied the desired status (not a stale pre-conflict value).
+	conds, _, _ := unstructured.NestedSlice(got.Object, "status", "conditions")
+	var readyStatus string
+	for _, c := range conds {
+		if cm, ok := c.(map[string]interface{}); ok {
+			if t, _ := cm["type"].(string); t == "Ready" {
+				readyStatus, _ = cm["status"].(string)
+			}
+		}
+	}
+	if readyStatus != "True" {
+		t.Errorf("Ready condition status = %q after conflict-heal, want %q", readyStatus, "True")
+	}
+}
+
+// TestUpdateStatus_PersistentConflictSurfaces proves the retry does NOT
+// silently swallow a conflict that never clears: once RetryOnConflict
+// exhausts its budget the error must still surface (wrapped as
+// "update status: ..."), so a genuine wedge stays LOUD rather than looking
+// like a successful write.
+func TestUpdateStatus_PersistentConflictSurfaces(t *testing.T) {
+	app := makeApp("acme", "uat-hw228-pg", "acme-prod", "bp-postgres", "0.2.10", "single-region",
+		[]string{"hetzner-fsn-rtz-prod"}, map[string]interface{}{})
+	r := newReconciler(t, newFakeGitea(), app)
+	// More than retry.DefaultRetry.Steps (5) so the budget is exhausted.
+	injectStatusConflicts(t, r, 100)
+
+	err := r.updateStatus(context.Background(), app, statusUpdate{
+		Phase: PhaseReady,
+		Ready: "True",
+	})
+	if err == nil {
+		t.Fatalf("updateStatus swallowed a persistent conflict; want a surfaced error")
+	}
+	if !strings.Contains(err.Error(), "update status") {
+		t.Errorf("error = %q, want it wrapped with %q", err.Error(), "update status")
+	}
+	if !apierrors.IsConflict(err) {
+		t.Errorf("error should still be a recognisable Conflict; got %v", err)
+	}
+}


### PR DESCRIPTION
## Problem (confirmed live on hw228)

The application-controller runs **two** reconcile goroutines against the same `Application` CR:
- `runPeriodicRelist` → `initialList` → `Reconcile` (every ~30s), and
- `runWatch` → `watchOnce` → `Reconcile` (on watch events).

Both paths finish in `updateStatus`, which performed a bare `Get`-then-`UpdateStatus`. In the window between the read and the write the two goroutines race on `resourceVersion`, so whichever writes second gets a 409 Conflict. Live on hw228 (`acme/uat-hw228-pg`) the controller logged, every ~30s:

```
ERROR "initial reconcile failed" err="update status: Operation cannot be fulfilled on applications.apps.openova.io \"uat-hw228-pg\": the object has been modified; please apply your latest changes to the latest version and try again"
ERROR "reconcile failed" namespace=acme err="update status: Operation cannot be fulfilled ..."
```

The existing re-fetch narrows but cannot close the window under two concurrent writers.

## Fix

Wrap the whole read-modify-write in `retry.RetryOnConflict(retry.DefaultRetry, …)` — the canonical client-go remedy. On conflict the closure re-runs (re-`Get` → re-apply the desired status → re-`UpdateStatus`) with the fresh `resourceVersion`, so the loser self-heals instead of erroring + requeuing.

- The closure returns the **raw** api error on the write so `RetryOnConflict`'s `IsConflict` check fires (a `%w`-wrapped error would not be recognised).
- A conflict that never clears still surfaces after the retry budget, wrapped as `update status: …`, so a genuine wedge stays **loud** rather than looking like a successful write.

Read-only status write only — no change to what the controller writes, just how resiliently.

## Tests

- `TestUpdateStatus_RetriesOnConflict` — one injected 409 on the `/status` subresource is transparently retried; caller sees `nil` and the intended `phase=Ready` + `Ready=True` condition are applied.
- `TestUpdateStatus_PersistentConflictSurfaces` — conflicts on every attempt exhaust the budget and the error still surfaces (wrapped, and still `IsConflict`).

Full `application/internal/controller` suite green; `go build` + `go vet` clean.

Refs #4853

🤖 Generated with [Claude Code](https://claude.com/claude-code)