### PR TITLE
fix(bp-openclaw): controller CPU 500m->250m so the S-plan plan-quota admits it (chart 0.2.16)

### DIFF
--- a/platform/openclaw/blueprint.yaml
+++ b/platform/openclaw/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-7-agentic-workspace
 spec:
-  version: 0.2.15
+  version: 0.2.16
   card:
     title: OpenClaw
     summary: |

--- a/platform/openclaw/chart/Chart.yaml
+++ b/platform/openclaw/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-openclaw
-version: 0.2.15
+version: 0.2.16
 appVersion: "0.2.0"
 description: |
   Catalyst Blueprint chart for the OpenClaw workspace controller pattern

--- a/platform/openclaw/chart/values.yaml
+++ b/platform/openclaw/chart/values.yaml
@@ -70,12 +70,18 @@ controller:
   # #4389/#4292: per-Org LimitRange maxLimitRequestRatio {cpu:1,memory:1}
   # rejects Burstable pods (a funnel Org's boundary forces Guaranteed QoS).
   # Render requests==limits so the controller pod is admitted.
+  # #4272: CPU must fit the S-plan ResourceQuota (plan-quota, 2 CPU per Org
+  # namespace). The rest of the funnel bundle already holds ~1600m
+  # (stalwart-tenant 1000m legacy / 500m current + mysql 250m + wordpress
+  # 100m + webmail 100m), so a 500m controller is FORBIDDEN by quota and the
+  # HR install deadlocks ("context deadline exceeded", ReplicaSet
+  # FailedCreate: exceeded quota). 250m fits beside even the legacy bundle.
   resources:
     requests:
-      cpu: 500m
+      cpu: 250m
       memory: 512Mi
     limits:
-      cpu: 500m
+      cpu: 250m
       memory: 512Mi
   securityContext:
     runAsNonRoot: true


### PR DESCRIPTION
## Problem

On an S-plan customer Org (2-CPU `plan-quota`), the `bp-openclaw` HelmRelease never converges: the funnel bundle already consumes ~1600m (legacy stalwart-tenant 1000m + mysql 250m + wordpress 100m + webmail 100m), so the controller's 500m Guaranteed pod is FORBIDDEN by quota:

```
ReplicaFailure FailedCreate - pods "openclaw-bp-openclaw-controller-..." is forbidden:
exceeded quota: plan-quota, requested: limits.cpu=500m,requests.cpu=500m,
used: limits.cpu=1600m,requests.cpu=1600m, limited: limits.cpu=2,requests.cpu=2
```

The HR install times out (`context deadline exceeded`), Stalls after 4 retries, and `openclaw.<org>.omani.homes/readyz` serves `503 no healthy upstream` — UAT row 232.

## Fix

`controller.resources` 500m→**250m** (requests==limits preserved — the per-Org LimitRange forces Guaranteed QoS per #4389/#4292). 250m fits beside even the legacy 1000m stalwart sizing (1600m+250m ≤ 2000m). Chart `0.2.16`, blueprint pin bumped in lockstep.

## Live proof (hw228, Org walk-stranger)

Applied as HR values override before codifying:
- pod `openclaw-bp-openclaw-controller-765678d76d-wf8c9` **1/1 Running** (was: unschedulable 34h)
- Service endpoints `10.42.3.47:8080` (was: `<none>`)
- `https://openclaw.walk-stranger.omani.homes/readyz` → **HTTP 200 `ready`** (was: 503)

## Notes

- The live env's stalwart-tenant still runs the pre-#4834 1000m sizing (no in-place StatefulSet upgrade); fresh provs get 500m — either way 250m openclaw fits.
- Follow-on (same quota math, separate surface): `perUserPod` remains 1 CPU Guaranteed — an agent session on a busy S-plan Org can still hit the quota ceiling; noted on #4272 rather than widened here.

Refs #4272

🤖 Generated with [Claude Code](https://claude.com/claude-code)