### PR TITLE
fix(#4854): cross-region DB egress carve-out in plane-isolation (row 67 L1)

### DIFF
--- a/clusters/_template/bootstrap-kit/26b-bp-plane-isolation.yaml
+++ b/clusters/_template/bootstrap-kit/26b-bp-plane-isolation.yaml
@@ -145,7 +145,7 @@ spec:
       #   Live-proven dep 00720a7a9c72364d (kom4dc, 2026-06-27). Additive (admits
       #   ONLY the apiserver on :9443, scoped to the operator pods); default-deny
       #   intact. Only the opentelemetry entry sets apiserverWebhookPorts today.
-      version: 0.1.11
+      version: 0.1.12
       sourceRef:
         kind: HelmRepository
         name: bp-plane-isolation

--- a/platform/plane-isolation/blueprint.yaml
+++ b/platform/plane-isolation/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 0.1.11  # lockstep with chart/Chart.yaml (#4579 — apiserver-webhook-ingress CNP for the OTel-operator :9443 webhook)
+  version: 0.1.12  # lockstep with chart/Chart.yaml (#4579 — apiserver-webhook-ingress CNP for the OTel-operator :9443 webhook)
   card:
     title: Plane isolation (per-component default-deny)
     summary: |

--- a/platform/plane-isolation/chart/Chart.yaml
+++ b/platform/plane-isolation/chart/Chart.yaml
@@ -176,7 +176,23 @@ name: bp-plane-isolation
 #   (admits ONLY the apiserver on :9443, scoped to the operator pods);
 #   default-deny posture intact. New per-component `apiserverWebhookPorts` +
 #   `apiserverWebhookSelector` values; only the opentelemetry entry sets them.
-version: 0.1.11
+#
+# 0.1.12 (#4854 / #4846, UAT row 67): cross-region DB egress. A region-B DB
+#   consumer (grafana, gitea, …) dialling its cross-region CNPG GLOBAL service
+#   (`shared-pg-*-mesh-rw`, primary in the peer region) is silently dropped:
+#   with socketLB.hostNamespaceOnly=true the pod egresses to the service
+#   ClusterIP, which resolves to a REMOTE-CLUSTER identity that neither the
+#   default-deny namespaceSelector:{} (local pods) nor ipBlock 0.0.0.0/0
+#   (world) matches — the same reserved/foreign-identity class as the
+#   apiserver-egress carve-out, one layer out. New crossregion-db-egress-cnp.yaml
+#   renders a per-component CNP allowing `toCIDR: [serviceCIDR]` on 5432/TCP
+#   (new `serviceCIDR` value, default 10.96.0.0/12). Live-proven on hw228
+#   (dep ac35eda8561b7922, 2026-07-09): `toCIDR 10.96.0.0/12:5432` cleared the
+#   grafana→shared-pg-b-mesh-rw egress DROP (hubble FORWARDED). Additive; inert
+#   single-region (no peer → no global service resolves remote). NOTE: the
+#   region-A INGRESS realization (#4811 family — the #4846 CNP is Valid but the
+#   datapath is stale) is a separate layer that resolves on a clean converge.
+version: 0.1.12
 description: |
   Per-component default-deny + explicit-allow micro-segmentation for the
   de-vclustered platform planes (#4291 Workstream C). For each platform

--- a/platform/plane-isolation/chart/templates/crossregion-db-egress-cnp.yaml
+++ b/platform/plane-isolation/chart/templates/crossregion-db-egress-cnp.yaml
@@ -1,0 +1,81 @@
+{{- /*
+Per-component cross-region DB-egress CiliumNetworkPolicy (#4854 / #4846, UAT row 67).
+
+THE service-CIDR sibling of apiserver-egress-cnp.yaml. Same failure shape as
+the reserved kube-apiserver identity, one layer out: a ClusterMesh GLOBAL
+service whose backend primary lives in the PEER region.
+
+The companion default-deny NetworkPolicy allows egress to (a)
+namespaceSelector:{} → every in-cluster pod identity (the #4360 fix) and (b)
+ipBlock 0.0.0.0/0 → the Cilium `world` entity. For a LOCAL service ClusterIP
+that is enough — with socketLB.hostNamespaceOnly=true the pod egresses to the
+ClusterIP and the backend resolves to a LOCAL pod identity, which
+namespaceSelector:{} matches. But for a cross-region CNPG GLOBAL service
+(`service.cilium.io/global=true`, e.g. `shared-pg-b-mesh-rw` whose `-rw`
+primary sits in the peer region), the ClusterIP resolves to a REMOTE-CLUSTER
+identity: NOT a local pod (namespaceSelector:{} misses it) and NOT `world`
+(ipBlock 0.0.0.0/0 misses it). Result: a region-B DB consumer's SYN to its
+cross-region Postgres primary is silently dropped.
+
+Proven live on hw228 (dep ac35eda8561b7922, 2 VPC, 2026-07-09): region-B
+grafana → `shared-pg-b-mesh-rw:5432` and gitea → `shared-pg-1:5432` both
+`Policy denied DROPPED (SYN)` in hubble even though the datapath ROUTE was
+fixed (#4861). A CNP egress `toEndpoints io.cilium.k8s.policy.cluster In
+[<peer>]` and a `toCIDR <peer-pod-range>` BOTH failed to match (the policy is
+evaluated against the ClusterIP, not the resolved backend). `toCIDR:
+[10.96.0.0/12]` (the SERVICE CIDR) on 5432 CLEARED the egress drop — grafana's
+egress bpf policy then showed Allow with non-zero packet counts and the SYN
+reached the peer region. This is the INVERSE of the #4846 INGRESS carve-out
+(fromEndpoints cluster identity) — the ingress source arrives with its
+ClusterMesh identity intact, but the egress destination is a bare ClusterIP.
+
+A vanilla K8s NetworkPolicy ipBlock cannot express this (it matches `world`,
+not a resolved remote-cluster ClusterIP), so — exactly like the apiserver
+carve-out — the allow lives in a CiliumNetworkPolicy. Cilium computes the
+UNION of every policy selecting an endpoint, so this is purely additive to the
+default-deny: it grants cross-region Postgres reachability without weakening
+isolation (no `world`, only the service CIDR on the Postgres port).
+
+Scoped to 5432/TCP (Postgres) and the service CIDR — the minimal surface that
+carries all CNPG `-rw`/`-r`/`-mesh-rw` global-service DBs. Rendered for EVERY
+component (like apiserver-egress): a component whose DB is LOCAL gets a
+redundant-but-harmless allow (its local ClusterIP is already covered by
+namespaceSelector:{}), and a component placed cross-region gets the carve-out
+it needs. On a single-region prov this is inert (no peer region → no global
+service resolves remote).
+
+Gated on the cilium.io/v2 Capabilities check (the #2988/#3102 idiom) so the
+chart still installs on CRD-less clusters (kind CI), and on the SAME
+namespace-present defer guard as apiserver-egress-cnp.yaml / the default-deny
+(#4442/#4445/#4456 deadlock-guard parity).
+*/ -}}
+{{- if and .Values.enabled (.Capabilities.APIVersions.Has "cilium.io/v2") -}}
+{{- range .Values.components }}
+{{- $ns := .namespace }}
+{{- $guardNamespace := not (eq (toString .ensureNamespacePresent) "false") }}
+{{- if and $guardNamespace (not $.Values.renderUnconditional) (not (lookup "v1" "Namespace" "" $ns)) }}
+{{- /* namespace not present yet — defer this component's CNP to a later reconcile */ -}}
+{{- else }}
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ $ns }}-allow-crossregion-db-egress
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-plane-isolation.labels" $ | nindent 4 }}
+    catalyst.openova.io/component: {{ $ns }}-crossregion-db-netpol
+spec:
+  # endpointSelector {} = every endpoint in this namespace, matching the
+  # default-deny policy's scope.
+  endpointSelector: {}
+  egress:
+    - toCIDR:
+        - {{ $.Values.serviceCIDR | quote }}
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+{{- end }}{{/* end namespace-present guard */}}
+{{- end }}
+{{- end -}}

--- a/platform/plane-isolation/chart/values.yaml
+++ b/platform/plane-isolation/chart/values.yaml
@@ -11,6 +11,17 @@ enabled: true
 # kube-system.
 dnsNamespace: kube-system
 
+# Service ClusterIP CIDR (k3s default 10.96.0.0/12). Used by the
+# crossregion-db-egress CNP (#4854/#4846 row 67). A cross-region ClusterMesh
+# GLOBAL-service DB (e.g. shared-pg-*-mesh-rw whose primary lives in the peer
+# region) is dialled via its ClusterIP; with socketLB.hostNamespaceOnly=true
+# the pod egresses to that ClusterIP and Cilium evaluates egress policy against
+# the SERVICE CIDR — a resolved remote-cluster identity that neither the
+# default-deny's namespaceSelector:{} (local pods) nor ipBlock 0.0.0.0/0
+# (world) matches. So DB egress to a cross-region global service is silently
+# dropped. This CIDR is the toCIDR target of the crossregion-db-egress CNP.
+serviceCIDR: 10.96.0.0/12
+
 # #4442 deferral escape hatch. The per-component default-deny is normally
 # DEFERRED for a component whose namespace does not yet exist (a `lookup` guard
 # that breaks the fresh-prov circular deadlock — see Chart.yaml 0.1.7). But


### PR DESCRIPTION
## Problem (row 67, layer 1 — proven live on hw228)

A region-B DB consumer (grafana, gitea, …) dialling its **cross-region** CNPG global service (`shared-pg-*-mesh-rw`, `-rw` primary in the peer region) is silently dropped. With `socketLB.hostNamespaceOnly=true` (a deliberate DNS-race fix on this platform), the pod egresses to the service ClusterIP, and Cilium evaluates egress policy against a **resolved remote-cluster identity** — which neither the default-deny's `namespaceSelector:{}` (local pods) nor `ipBlock 0.0.0.0/0` (world) matches. Same reserved/foreign-identity class as the existing `apiserver-egress` carve-out, one layer out.

Prior live proof (#4854 comments): a diagnostic CNP with `toCIDR: [10.96.0.0/12]` on 5432 cleared the egress drop.

## Fix

New `templates/crossregion-db-egress-cnp.yaml` — a per-component CNP (mirroring `apiserver-egress-cnp.yaml`: same namespace-present defer guard + cilium capability gate) allowing `toCIDR: [{{ serviceCIDR }}]` on `5432/TCP`. New `serviceCIDR` value (default `10.96.0.0/12`). Additive (union with default-deny; no `world`, only the service CIDR on the Postgres port); inert on single-region (no peer → no global service resolves remote). Chart `0.1.11 → 0.1.12` + slot-26b bootstrap-kit pin lockstep. `helm lint` clean; renders one CNP per component with `--api-versions cilium.io/v2`.

## Validation status — honest

- **L1 (egress content): durably fixed** by this PR.
- **L2 (region-A ingress realization, #4811 family): separate layer.** On the current degraded hw228 the applied CNPs are `Valid=True` but the datapath returns `policy-verdict:none TRAFFIC_DIRECTION_UNKNOWN DENIED` — a **policy-realization staleness** signature (the same reason the pre-existing #4846 ingress CNP is Valid-but-unrealized), not a policy-content gap. End-to-end validation (grafana/gitea reach their cross-region DB) is gated on a **fresh converge**, where realization is clean.

Row 67 stays ⚠️ until validated on a fresh prov. Diagnostic probe cleaned up; the two live CNPs remain as the durable twin (superseded by the chart roll).

Refs #4854 Refs #4846

🤖 Generated with [Claude Code](https://claude.com/claude-code)