### PR TITLE
fix(#4845): Jobs Re-run returns graceful 422 for aggregate reconcilers, not 502

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/jobs_retry.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_retry.go
@@ -159,6 +159,19 @@ func (h *Handler) RetryJob(w http.ResponseWriter, r *http.Request) {
 	now := time.Now().UTC()
 	action, rerr := h.dispatchRetry(r.Context(), dyn, job, now)
 	if rerr != nil {
+		// #4845: a leaf with no directly-retryable backing (aggregate
+		// trivy-operator scan, mutation-bridge, unsupported kind) is a
+		// client-side condition, not a server fault — return a graceful 422
+		// with an actionable message instead of a raw 502 so the operator
+		// sees "not directly retryable" rather than a gateway error.
+		if errors.Is(rerr, errNotDirectlyRetryable) {
+			h.log.Info("RetryJob: leaf not directly retryable", "depId", depID, "jobId", jobID, "kind", job.Kind, "detail", rerr.Error())
+			writeJSON(w, http.StatusUnprocessableEntity, map[string]string{
+				"error":  "not-directly-retryable",
+				"detail": rerr.Error(),
+			})
+			return
+		}
 		h.log.Warn("RetryJob: remediation failed", "depId", depID, "jobId", jobID, "kind", job.Kind, "err", rerr)
 		writeJSON(w, http.StatusBadGateway, map[string]string{
 			"error":  "remediation-failed",
@@ -247,7 +260,7 @@ func (h *Handler) dispatchRetry(ctx context.Context, dyn dynamic.Interface, job 
 		// on the stored claim. Best-effort: the claim GVR is not always
 		// resolvable from the leaf alone, so we re-drive via the HR fallback
 		// when the mutation maps to a bp-* release.
-		return "", fmt.Errorf("mutation re-submit is driven by the mutation bridge; retry via the originating Day-2 action")
+		return "", fmt.Errorf("mutation re-submit is driven by the mutation bridge; retry via the originating Day-2 action: %w", errNotDirectlyRetryable)
 
 	case jobs.KindTask:
 		// Standalone batch Job. A finished Job is TERMINAL — its
@@ -279,9 +292,17 @@ func (h *Handler) dispatchRetry(ctx context.Context, dyn dynamic.Interface, job 
 		return "deleted + recreated Job " + name + " for a fresh run", nil
 
 	default:
-		return "", fmt.Errorf("kind %q does not support retry", job.Kind)
+		return "", fmt.Errorf("kind %q does not support retry: %w", job.Kind, errNotDirectlyRetryable)
 	}
 }
+
+// errNotDirectlyRetryable marks a retry request against a leaf that has no
+// directly-retryable backing resource — an aggregate/operator-managed
+// reconciler (trivy-operator scan aggregate, a mutation bridged via a Day-2
+// action, or a kind with no retry mechanism). It is a client-side condition
+// (nothing to re-run here), NOT a server fault, so RetryJob maps it to a
+// graceful 422 with an actionable message instead of a raw 502. #4845.
+var errNotDirectlyRetryable = errors.New("reconciler is aggregate or operator-managed; not directly retryable")
 
 // retryTargetName derives the underlying object's name from a leaf Job by
 // stripping its kind prefix. The install leaf carries the bare chart in
@@ -527,7 +548,13 @@ func resolveObjectNamespace(ctx context.Context, dyn dynamic.Interface, gvr sche
 		}
 	}
 	if ns == "" {
-		return "", fmt.Errorf("%s %q not found in any namespace", gvr.Resource, name)
+		// #4845: a synthetic AGGREGATE reconciler (e.g. the "Trivy Security
+		// Scan" row aggregating trivy-operator's scan-vulnerabilityreport-*
+		// Jobs) has no standalone Job named after the reconciler, so the
+		// resolve fails. That is NOT a server fault — the row simply has no
+		// directly-retryable backing. Wrap with errNotDirectlyRetryable so
+		// the HTTP handler returns a graceful 422 instead of a raw 502.
+		return "", fmt.Errorf("%s %q not found in any namespace: %w", gvr.Resource, name, errNotDirectlyRetryable)
 	}
 	return ns, nil
 }

--- a/products/catalyst/bootstrap/api/internal/handler/jobs_retry_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_retry_test.go
@@ -348,6 +348,28 @@ func TestRetryJob_Task_CompletedJob_DeleteAndRecreate(t *testing.T) {
 	}
 }
 
+// #4845: an AGGREGATE task reconciler (e.g. the "Trivy Security Scan" row
+// aggregating trivy-operator's scan-vulnerabilityreport-* Jobs) has NO
+// standalone Job named after the reconciler, so resolveObjectNamespace can't
+// find a retry target. The reported defect was a raw 502
+// (remediation-failed). The contract now: a graceful 422 with a
+// "not-directly-retryable" code, never a 5xx — the row simply has no
+// directly-retryable backing.
+func TestRetryJob_Task_AggregateNoBackingJob_422(t *testing.T) {
+	// No backing Job seeded — mirrors the trivy scan aggregate.
+	r, _, depID := installRetryHarness(t, "owner@t99.omani.works",
+		"task-trivy-security-scan", jobs.StatusFailed)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, retryReq(depID, "task-trivy-security-scan",
+		&auth.Claims{Email: "owner@t99.omani.works", Tier: "operator"}))
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("want 422 (graceful not-directly-retryable), got %d; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "not-directly-retryable") {
+		t.Fatalf("body missing the not-directly-retryable code: %s", rec.Body.String())
+	}
+}
+
 // A task leaf whose Job is OWNED by a CronJob re-drives through the CronJob
 // ("Run now"), never a standalone recreate (which would orphan it).
 func TestRetryJob_Task_CronJobOwned_RunsViaCronJob(t *testing.T) {


### PR DESCRIPTION
## Problem (UAT row 176, hw228 real-PIN walk)
Clicking **Re-run** on the Failed "Trivy Security Scan (task)" row fired `POST /api/v1/deployments/{id}/jobs/task-trivy-security-scan/retry` and returned a raw:
```
502 remediation-failed: jobs "trivy-security-scan" not found in any namespace
```

## Root cause
`dispatchRetry` (KindTask branch, `jobs_retry.go`) resolves the retry target via `resolveObjectNamespace(JobGVR, name)` — it assumes a **standalone Job named identically to the reconciler**. The "Trivy Security Scan" row is a synthetic **aggregate** over trivy-operator's `scan-vulnerabilityreport-*` Jobs; there is no Job named `trivy-security-scan`, so the resolve returns not-found and **any** `dispatchRetry` error was mapped to a raw 502. Same shape for the mutation-bridge and unsupported-kind branches.

## Fix
Introduce `errNotDirectlyRetryable` and wrap the three not-directly-retryable branches (aggregate/no-backing-Job, mutation-bridge, unsupported-kind) with it. `RetryJob` maps `errors.Is(rerr, errNotDirectlyRetryable)` to a graceful **422 `not-directly-retryable`** with an actionable detail, instead of a 5xx gateway error. New unit test asserts the aggregate case → 422 (not 502). `go test ./internal/handler/ -run TestRetryJob` green; build + vet clean.

Follow-up (noted on #4845, not in this PR): a `retryable` flag on the reconciler model to suppress the Re-run affordance entirely for aggregate rows (FE change) — this PR makes the endpoint fail gracefully as the defense-in-depth half.

Refs #4845

🤖 Generated with [Claude Code](https://claude.com/claude-code)