### PR TITLE
fix(#4853): retry finalizer add/remove on 409 Conflict — fix the 32h Uninstalling wedge

### DIFF
--- a/core/controllers/application/internal/controller/application_controller.go
+++ b/core/controllers/application/internal/controller/application_controller.go
@@ -2134,17 +2134,39 @@ func (r *Reconciler) ensureFinalizer(ctx context.Context, app *unstructured.Unst
 	if hasFinalizer(app, FinalizerName) {
 		return nil
 	}
-	finalizers := app.GetFinalizers()
-	finalizers = append(finalizers, FinalizerName)
-	app.SetFinalizers(finalizers)
-	_, err := r.Dynamic.Resource(ApplicationGVR).Namespace(app.GetNamespace()).Update(ctx, app, metav1.UpdateOptions{})
+	// #4853 — the finalizer add is a read-modify-write on the Application, so
+	// (like updateStatus) it races the second reconcile goroutine / org-
+	// controller on resourceVersion. A bare Update on the stale `app` 409s and
+	// the reconcile errors + requeues. Mirror the updateStatus fix: re-GET the
+	// latest object each attempt under RetryOnConflict so the loser self-heals.
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest, err := r.Dynamic.Resource(ApplicationGVR).Namespace(app.GetNamespace()).
+			Get(ctx, app.GetName(), metav1.GetOptions{})
+		if err != nil {
+			// Gone between List and Update — nothing to finalize.
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return fmt.Errorf("re-fetch application for finalizer add: %w", err)
+		}
+		if hasFinalizer(latest, FinalizerName) {
+			return nil
+		}
+		latest.SetFinalizers(append(latest.GetFinalizers(), FinalizerName))
+		// Return the RAW api error so RetryOnConflict's IsConflict check fires
+		// (a %w-wrapped error would not be recognised).
+		_, uErr := r.Dynamic.Resource(ApplicationGVR).Namespace(latest.GetNamespace()).
+			Update(ctx, latest, metav1.UpdateOptions{})
+		if apierrors.IsNotFound(uErr) {
+			return nil
+		}
+		return uErr
+	})
 	if err != nil {
-		// Tolerate "not found" — the resource may have been deleted
-		// between our List and the Update.
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
-		return err
+		return fmt.Errorf("ensure finalizer: %w", err)
 	}
 	return nil
 }
@@ -2155,17 +2177,48 @@ func (r *Reconciler) removeFinalizer(ctx context.Context, app *unstructured.Unst
 	if !hasFinalizer(app, FinalizerName) {
 		return nil
 	}
-	out := make([]string, 0, len(app.GetFinalizers()))
-	for _, f := range app.GetFinalizers() {
-		if f == FinalizerName {
-			continue
+	// #4853 — THE ORIGINAL wedge: uat-openclaw stuck phase=Uninstalling for 32h
+	// with every managed resource already gone, because this strip did a bare
+	// Update on the stale reconcile object. A persistent concurrent writer bumps
+	// resourceVersion → every Update 409-conflicts → the finalizer never comes
+	// off → the CR never deletes → the reconcile loops forever (~3s, 32h). #4856
+	// fixed only updateStatus; the finalizer path had the same bug. Re-GET the
+	// latest object each attempt under RetryOnConflict so the strip applies
+	// against the fresh resourceVersion and the finalizer actually releases.
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest, err := r.Dynamic.Resource(ApplicationGVR).Namespace(app.GetNamespace()).
+			Get(ctx, app.GetName(), metav1.GetOptions{})
+		if err != nil {
+			// Already GC'd — the finalizer is gone, done.
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return fmt.Errorf("re-fetch application for finalizer removal: %w", err)
 		}
-		out = append(out, f)
-	}
-	app.SetFinalizers(out)
-	_, err := r.Dynamic.Resource(ApplicationGVR).Namespace(app.GetNamespace()).Update(ctx, app, metav1.UpdateOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return err
+		if !hasFinalizer(latest, FinalizerName) {
+			return nil
+		}
+		out := make([]string, 0, len(latest.GetFinalizers()))
+		for _, f := range latest.GetFinalizers() {
+			if f == FinalizerName {
+				continue
+			}
+			out = append(out, f)
+		}
+		latest.SetFinalizers(out)
+		// Raw api error so RetryOnConflict's IsConflict check fires.
+		_, uErr := r.Dynamic.Resource(ApplicationGVR).Namespace(latest.GetNamespace()).
+			Update(ctx, latest, metav1.UpdateOptions{})
+		if apierrors.IsNotFound(uErr) {
+			return nil
+		}
+		return uErr
+	})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("remove finalizer: %w", err)
 	}
 	return nil
 }

--- a/core/controllers/application/internal/controller/application_controller_finalizer_conflict_4853_test.go
+++ b/core/controllers/application/internal/controller/application_controller_finalizer_conflict_4853_test.go
@@ -1,0 +1,113 @@
+// Tests for the #4853 FINALIZER-removal conflict loop — the original wedge
+// (uat-openclaw stuck phase=Uninstalling for 32h with all resources gone).
+// removeFinalizer / ensureFinalizer did a bare Update on the stale reconcile
+// object; a persistent concurrent writer 409'd every attempt so the finalizer
+// never came off and the reconcile looped forever. #4856 fixed only
+// updateStatus; these guard the finalizer paths, which now wrap the
+// read-modify-write in retry.RetryOnConflict with a re-GET.
+package controller
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// injectFinalizerUpdateConflicts prepends a reactor returning a 409 Conflict
+// for the first `n` MAIN-resource (non-status) updates on applications — i.e.
+// the finalizer write — then passes through.
+func injectFinalizerUpdateConflicts(t *testing.T, r *Reconciler, n int) *int {
+	t.Helper()
+	fake, ok := r.Dynamic.(*dynamicfake.FakeDynamicClient)
+	if !ok {
+		t.Fatalf("Dynamic is %T, want *dynamicfake.FakeDynamicClient", r.Dynamic)
+	}
+	fired := 0
+	fake.PrependReactor("update", "applications", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "" {
+			return false, nil, nil // only race the main-resource (finalizer) write
+		}
+		if fired < n {
+			fired++
+			return true, nil, apierrors.NewConflict(
+				schema.GroupResource{Group: "apps.openova.io", Resource: "applications"},
+				"uat-openclaw",
+				errors.New("the object has been modified; please apply your changes to the latest version and try again"),
+			)
+		}
+		return false, nil, nil
+	})
+	return &fired
+}
+
+// TestRemoveFinalizer_RetriesOnConflict is the #4853 original-symptom guard:
+// a single injected 409 on the finalizer strip must be transparently retried
+// and the finalizer must actually come off — not loop forever (32h wedge).
+func TestRemoveFinalizer_RetriesOnConflict(t *testing.T) {
+	app := makeApp("acme", "uat-openclaw", "acme-prod", "bp-openclaw", "0.2.16", "single-region",
+		[]string{"hetzner-fsn-rtz-prod"}, map[string]interface{}{})
+	app.SetFinalizers([]string{FinalizerName})
+	r := newReconciler(t, newFakeGitea(), app)
+	fired := injectFinalizerUpdateConflicts(t, r, 1)
+
+	if err := r.removeFinalizer(context.Background(), app); err != nil {
+		t.Fatalf("removeFinalizer errored on a single retryable conflict: %v", err)
+	}
+	if *fired != 1 {
+		t.Fatalf("expected exactly 1 injected conflict consumed, got %d", *fired)
+	}
+	got := readApp(t, r, "acme", "uat-openclaw")
+	if hasFinalizer(got, FinalizerName) {
+		t.Fatalf("finalizer %q still present after removeFinalizer — the CR would never delete (the 32h wedge)", FinalizerName)
+	}
+}
+
+// TestRemoveFinalizer_PersistentConflictSurfaces proves the retry does not
+// silently swallow a conflict that never clears: once the budget is exhausted
+// the error surfaces (wrapped "remove finalizer: ...") and stays a Conflict,
+// so a genuine wedge is LOUD instead of looking successful.
+func TestRemoveFinalizer_PersistentConflictSurfaces(t *testing.T) {
+	app := makeApp("acme", "uat-openclaw", "acme-prod", "bp-openclaw", "0.2.16", "single-region",
+		[]string{"hetzner-fsn-rtz-prod"}, map[string]interface{}{})
+	app.SetFinalizers([]string{FinalizerName})
+	r := newReconciler(t, newFakeGitea(), app)
+	injectFinalizerUpdateConflicts(t, r, 100) // > retry.DefaultRetry.Steps
+
+	err := r.removeFinalizer(context.Background(), app)
+	if err == nil {
+		t.Fatalf("removeFinalizer swallowed a persistent conflict; want a surfaced error")
+	}
+	if !strings.Contains(err.Error(), "remove finalizer") {
+		t.Errorf("error = %q, want it wrapped with %q", err.Error(), "remove finalizer")
+	}
+	if !apierrors.IsConflict(err) {
+		t.Errorf("error should still be a recognisable Conflict; got %v", err)
+	}
+}
+
+// TestEnsureFinalizer_RetriesOnConflict guards the add path with the same
+// contract — a single 409 heals and the finalizer lands.
+func TestEnsureFinalizer_RetriesOnConflict(t *testing.T) {
+	app := makeApp("acme", "uat-openclaw", "acme-prod", "bp-openclaw", "0.2.16", "single-region",
+		[]string{"hetzner-fsn-rtz-prod"}, map[string]interface{}{})
+	r := newReconciler(t, newFakeGitea(), app)
+	fired := injectFinalizerUpdateConflicts(t, r, 1)
+
+	if err := r.ensureFinalizer(context.Background(), app); err != nil {
+		t.Fatalf("ensureFinalizer errored on a single retryable conflict: %v", err)
+	}
+	if *fired != 1 {
+		t.Fatalf("expected exactly 1 injected conflict consumed, got %d", *fired)
+	}
+	got := readApp(t, r, "acme", "uat-openclaw")
+	if !hasFinalizer(got, FinalizerName) {
+		t.Fatalf("finalizer %q not present after ensureFinalizer heal", FinalizerName)
+	}
+}


### PR DESCRIPTION
## The original #4853 bug — distinct from what #4856 fixed

#4853 has **two** conflict paths. PR #4856 wrapped `updateStatus` in `RetryOnConflict` (the ~30s status-write ERROR churn). But the issue's headline symptom — **`Application/uat-openclaw` stuck `phase=Uninstalling` for 32h** with every managed resource already gone — is the **finalizer-removal** path, which #4856 did not touch.

`removeFinalizer` (and `ensureFinalizer`) did a bare `Update` on the **stale reconcile object**:
```go
app.SetFinalizers(out)
_, err := r.Dynamic.Resource(ApplicationGVR).Namespace(app.GetNamespace()).Update(ctx, app, metav1.UpdateOptions{})
```
A persistent concurrent writer bumps `resourceVersion` → every strip 409-conflicts (`the object has been modified`) → the finalizer never comes off → the CR never deletes → `handleDeletion` returns the error → requeue → loops forever (~3s, 32h live on hw228 acme).

## Fix

Mirror the #4856 `updateStatus` pattern in both finalizer paths: **re-GET the latest object each attempt under `retry.RetryOnConflict`**, return the raw api error so `IsConflict` fires, tolerate `NotFound` (already GC'd). A persistent conflict still surfaces (wrapped `remove finalizer: ...`) so a genuine wedge stays loud instead of looking successful.

## Tests
`application_controller_finalizer_conflict_4853_test.go` — a reactor injecting 409s on the **main-resource** (finalizer) update:
- `TestRemoveFinalizer_RetriesOnConflict` — one conflict heals, finalizer actually comes off.
- `TestRemoveFinalizer_PersistentConflictSurfaces` — 100 conflicts → surfaced, still `IsConflict`.
- `TestEnsureFinalizer_RetriesOnConflict` — add path heals too.

Full application-controller suite green. `go build` + `go vet` clean.

Refs #4853

🤖 Generated with [Claude Code](https://claude.com/claude-code)