### PR TITLE
fix(#4854): row-67 cross-region CNP namespace-scoping (L1 egress + L2 ingress)

### DIFF
--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -155,7 +155,7 @@ spec:
       # (#4442). Lockstep with 16c/16d.
       # 0.2.10 (#4846): identity-based cross-region DR CiliumNetworkPolicy
       # (crossRegionPeerClusters) replaces the inert ipBlock. Lockstep 16c/16d.
-      version: 0.2.10
+      version: 0.2.11
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -199,7 +199,7 @@ spec:
       # PRIMARY's walsender (not a cascaded local standby) → sync_state=sync.
       # 0.2.9 (#4846): identity-based cross-region DR CiliumNetworkPolicy
       # (crossRegionPeerClusters) replaces the inert ipBlock.
-      version: 0.2.9
+      version: 0.2.10
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg-pair

--- a/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
+++ b/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
@@ -93,7 +93,7 @@ spec:
       # moment the mesh peers. Lockstep with 16a/16d.
       # 0.2.10 (#4846): identity-based cross-region DR CiliumNetworkPolicy
       # (crossRegionPeerClusters) replaces the inert ipBlock. Lockstep 16a/16d.
-      version: 0.2.10
+      version: 0.2.11
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
+++ b/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
@@ -81,7 +81,7 @@ spec:
       # openova-flow hosts resolve the moment the mesh peers. Lockstep 16a/16c.
       # 0.2.10 (#4846): identity-based cross-region DR CiliumNetworkPolicy
       # (crossRegionPeerClusters) replaces the inert ipBlock. Lockstep 16a/16c.
-      version: 0.2.10
+      version: 0.2.11
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/26b-bp-plane-isolation.yaml
+++ b/clusters/_template/bootstrap-kit/26b-bp-plane-isolation.yaml
@@ -145,7 +145,7 @@ spec:
       #   Live-proven dep 00720a7a9c72364d (kom4dc, 2026-06-27). Additive (admits
       #   ONLY the apiserver on :9443, scoped to the operator pods); default-deny
       #   intact. Only the opentelemetry entry sets apiserverWebhookPorts today.
-      version: 0.1.12
+      version: 0.1.13
       sourceRef:
         kind: HelmRepository
         name: bp-plane-isolation

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -9,7 +9,7 @@ spec:
   # 0.2.9 (#4846): cross-region DR admission is an identity-based
   # CiliumNetworkPolicy (io.cilium.k8s.policy.cluster) — the 0.2.8 ipBlock was
   # inert for ClusterMesh remote endpoints. values crossRegionPeerClusters.
-  version: 0.2.9
+  version: 0.2.10
   card:
     title: CNPG Cluster-Pair (Active-Hotstandby DR)
     summary: |

--- a/platform/cnpg-pair/chart/Chart.yaml
+++ b/platform/cnpg-pair/chart/Chart.yaml
@@ -28,7 +28,7 @@ name: bp-cnpg-pair
 # the post-mesh flip. Default-OFF contract UNCHANGED: cnpgPair.enabled=false OR
 # empty crossRegionPeerClusters renders ZERO CiliumNetworkPolicy — resource
 # counts unchanged from 0.2.8. Lockstep slot 16b pin → 0.2.9.
-version: 0.2.9
+version: 0.2.10
 appVersion: "0.2.1"
 description: |
   Catalyst-curated Blueprint for an active-hotstandby CNPG cluster-pair

--- a/platform/cnpg-pair/chart/templates/networkpolicy.yaml
+++ b/platform/cnpg-pair/chart/templates/networkpolicy.yaml
@@ -123,6 +123,14 @@ spec:
                 {{- range .Values.cnpgPair.networkPolicy.crossRegionPeerClusters }}
                 - {{ . | quote }}
                 {{- end }}
+            # ANY-NAMESPACE (#4854 row 67 L2): a namespaced CNP's fromEndpoints
+            # is implicitly ANDed with `k8s:io.kubernetes.pod.namespace=<this
+            # policy's namespace>`, so without this Exists expression the rule
+            # admits ONLY peer-region Pods in this namespace and silently denies
+            # cross-region consumers in other namespaces. Referencing the
+            # namespace label suppresses the implicit same-namespace AND.
+            - key: k8s:io.kubernetes.pod.namespace
+              operator: Exists
       toPorts:
         - ports:
             - port: "5432"
@@ -210,6 +218,14 @@ spec:
                 {{- range .Values.cnpgPair.networkPolicy.crossRegionPeerClusters }}
                 - {{ . | quote }}
                 {{- end }}
+            # ANY-NAMESPACE (#4854 row 67 L2): a namespaced CNP's fromEndpoints
+            # is implicitly ANDed with `k8s:io.kubernetes.pod.namespace=<this
+            # policy's namespace>`, so without this Exists expression the rule
+            # admits ONLY peer-region Pods in this namespace and silently denies
+            # cross-region consumers in other namespaces. Referencing the
+            # namespace label suppresses the implicit same-namespace AND.
+            - key: k8s:io.kubernetes.pod.namespace
+              operator: Exists
       toPorts:
         - ports:
             - port: "5432"

--- a/platform/plane-isolation/blueprint.yaml
+++ b/platform/plane-isolation/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 0.1.12  # lockstep with chart/Chart.yaml (#4579 — apiserver-webhook-ingress CNP for the OTel-operator :9443 webhook)
+  version: 0.1.13  # lockstep with chart/Chart.yaml (#4579 — apiserver-webhook-ingress CNP for the OTel-operator :9443 webhook)
   card:
     title: Plane isolation (per-component default-deny)
     summary: |

--- a/platform/plane-isolation/chart/Chart.yaml
+++ b/platform/plane-isolation/chart/Chart.yaml
@@ -192,7 +192,7 @@ name: bp-plane-isolation
 #   single-region (no peer → no global service resolves remote). NOTE: the
 #   region-A INGRESS realization (#4811 family — the #4846 CNP is Valid but the
 #   datapath is stale) is a separate layer that resolves on a clean converge.
-version: 0.1.12
+version: 0.1.13
 description: |
   Per-component default-deny + explicit-allow micro-segmentation for the
   de-vclustered platform planes (#4291 Workstream C). For each platform

--- a/platform/plane-isolation/chart/templates/crossregion-db-egress-cnp.yaml
+++ b/platform/plane-isolation/chart/templates/crossregion-db-egress-cnp.yaml
@@ -76,6 +76,32 @@ spec:
         - ports:
             - port: "5432"
               protocol: TCP
+    # REMOTE-BACKEND carve-out (#4854 row 67 L1, corrected 2026-07-09). With
+    # socketLB `bpf-lb-sock=false` + `bpf-lb-sock-hostns-only=true`, a POD's
+    # connection to a global-service ClusterIP is DNAT'd to the backend Pod IP
+    # by bpf_lxc BEFORE the egress policy verdict — so the egress is evaluated
+    # against the RESOLVED peer-region backend endpoint (e.g. shared-pg-b-2
+    # 10.42.1.162, identity cluster=<peer>), NOT the ClusterIP. Proven live on
+    # hw228 (dep ac35eda8561b7922): the drop was `egress deny match none ->
+    # 10.42.1.162:5432` at bpf_lxc.c:1651 and `toCIDR: [serviceCIDR]` did NOT
+    # clear it (the earlier claim it did was measured before the DNAT-order
+    # behaviour above). The backend arrives as a KNOWN remote endpoint, so — like
+    # the #4846 ingress carve-out — it needs an identity `toEndpoints`, not a
+    # CIDR. A bare `toEndpoints` is implicitly ANDed with BOTH `cluster=<local>`
+    # and `namespace=<this ns>`; referencing each key with Exists suppresses both
+    # AND-injections so the rule matches any Postgres backend Pod in ANY peer
+    # cluster / ANY namespace on 5432 (empty MatchLabels in the derived selector,
+    # verified live: grafana ns=grafana → shared-pg-b ns=shared-data succeeded).
+    - toEndpoints:
+        - matchExpressions:
+            - key: io.cilium.k8s.policy.cluster
+              operator: Exists
+            - key: k8s:io.kubernetes.pod.namespace
+              operator: Exists
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
 {{- end }}{{/* end namespace-present guard */}}
 {{- end }}
 {{- end -}}

--- a/platform/postgres/blueprint.yaml
+++ b/platform/postgres/blueprint.yaml
@@ -11,7 +11,7 @@ spec:
   # 0.2.10 (#4846): cross-region DR admission is an identity-based
   # CiliumNetworkPolicy (io.cilium.k8s.policy.cluster) — the 0.2.9 ipBlock was
   # inert for ClusterMesh remote endpoints. values crossRegionPeerClusters.
-  version: 0.2.10
+  version: 0.2.11
   card:
     title: PostgreSQL
     summary: |

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -167,7 +167,7 @@ name: bp-postgres
 #   the singleton render is byte-identical to 0.2.9 (the ipBlock only rendered
 #   under crossRegion, which singletons never set). Lockstep slot pins 16a/16c/
 #   16d → 0.2.10. tests/postgres-render.sh Case 4e/4f added.
-version: 0.2.10
+version: 0.2.11
 appVersion: "0.1.2"
 description: |
   Catalyst-authored data-instance Blueprint for a shareable, reusable

--- a/platform/postgres/chart/templates/networkpolicy.yaml
+++ b/platform/postgres/chart/templates/networkpolicy.yaml
@@ -129,6 +129,19 @@ spec:
                 {{- range .Values.topology.networkPolicy.crossRegionPeerClusters }}
                 - {{ . | quote }}
                 {{- end }}
+            # ANY-NAMESPACE (#4854 row 67 L2): a namespaced CNP's fromEndpoints
+            # is implicitly ANDed with `k8s:io.kubernetes.pod.namespace=<this
+            # policy's namespace>` (proven live on hw228 — the derived selector
+            # carried `namespace=shared-data`). Without this Exists expression the
+            # rule admits ONLY peer-region Pods in shared-data (the DR replica),
+            # silently denying every cross-region SHARED-PG CONSUMER in another
+            # namespace (grafana ns=grafana, keycloak, gitea, harbor, powerdns …)
+            # → `Policy denied` DROP at the primary's bpf_lxc. Referencing the
+            # namespace label here suppresses the implicit same-namespace AND, so
+            # the rule matches consumers in EVERY peer-region namespace — the
+            # cross-cluster mirror of the in-region `namespaceSelector:{}` above.
+            - key: k8s:io.kubernetes.pod.namespace
+              operator: Exists
       toPorts:
         - ports:
             - port: "5432"
@@ -206,6 +219,19 @@ spec:
                 {{- range .Values.topology.networkPolicy.crossRegionPeerClusters }}
                 - {{ . | quote }}
                 {{- end }}
+            # ANY-NAMESPACE (#4854 row 67 L2): a namespaced CNP's fromEndpoints
+            # is implicitly ANDed with `k8s:io.kubernetes.pod.namespace=<this
+            # policy's namespace>` (proven live on hw228 — the derived selector
+            # carried `namespace=shared-data`). Without this Exists expression the
+            # rule admits ONLY peer-region Pods in shared-data (the DR replica),
+            # silently denying every cross-region SHARED-PG CONSUMER in another
+            # namespace (grafana ns=grafana, keycloak, gitea, harbor, powerdns …)
+            # → `Policy denied` DROP at the primary's bpf_lxc. Referencing the
+            # namespace label here suppresses the implicit same-namespace AND, so
+            # the rule matches consumers in EVERY peer-region namespace — the
+            # cross-cluster mirror of the in-region `namespaceSelector:{}` above.
+            - key: k8s:io.kubernetes.pod.namespace
+              operator: Exists
       toPorts:
         - ports:
             - port: "5432"

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -419,7 +419,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-cnpg-pair
-    version: "0.2.9"
+    version: "0.2.10"
   # G117.1+G117.4+G117.5 #2744-followup (2026-06-03): cluster-pair IS
   # active-hot-standby by construction. Only one topology variant —
   # active-passive — because the chart renders 2 Cluster CRs (primary +
@@ -5906,7 +5906,7 @@ spec:
     # 0.2.8 (#4460): -mesh/-mesh-rw global Service aliases decoupled from the
     # cnpg-pair flip (render on the multi-region signal so cross-region consumer
     # DB hosts resolve the moment the mesh peers; region-B NXDOMAIN fix).
-    version: "0.2.10"
+    version: "0.2.11"
   # Seeded verbatim from platform/postgres/blueprint.yaml spec.topology.
   # singleton = single-instance Cluster; active-hot-standby = sync
   # replication across regions (ADR-0004 Pillar-3 zero-tx-loss) via the


### PR DESCRIPTION
## Root cause (proven live on hw228, dep ac35eda8561b7922)

The row-67 asymmetry — cnpg-pair's cross-region DR replica streams fine while grafana→shared-pg-b black-holes — is **NOT** datapath/WireGuard/VPC/#4811-staleness. Both are region-B pod → region-A global-service:5432 over the same healthy ClusterMesh. It's a **two-layer Cilium implicit-selector-scoping defect**; cnpg-pair only avoids it by coincidence (its consumer is same-namespace with no restrictive egress CNP).

### L2 — ingress (bp-postgres + bp-cnpg-pair)
A namespaced `CiliumNetworkPolicy`'s `fromEndpoints:[cluster In [peer]]` is silently ANDed with `k8s:io.kubernetes.pod.namespace=<policy-ns>` (confirmed in the derived selector cache). So the cross-region ingress admitted **only** peer-region Pods in the DR-replica's own namespace (`shared-data`/`cnpg`), and **denied every cross-region consumer in another namespace** (grafana ns=`grafana`, keycloak, gitea, harbor, powerdns…). Live proof: drop `identity …→…, action deny, match none` at `bpf_lxc.c:2381` on shared-pg-b-2's node; control test — a `shared-data`-ns region-B pod reached the same primary from the same node fine.
**Fix:** add `k8s:io.kubernetes.pod.namespace Exists` to the `fromEndpoints` matchExpressions → suppresses the implicit same-namespace AND (the cross-cluster mirror of the in-region `namespaceSelector:{}`).

### L1 — egress (bp-plane-isolation)
With socketLB `bpf-lb-sock=false` + `bpf-lb-sock-hostns-only=true`, a pod→ClusterIP is DNAT'd to the **backend pod IP before** the egress verdict, so egress is evaluated against the resolved remote backend (e.g. `10.42.1.162`), **not** the service CIDR. `toCIDR: [serviceCIDR]` therefore never matches (this **corrects** the earlier #4865 claim — measured before this DNAT-order behaviour was isolated). Live proof: drop `egress deny match none -> 10.42.1.162:5432` at `bpf_lxc.c:1651` on grafana's node.
**Fix:** add a `toEndpoints:[cluster Exists, namespace Exists]` rule on 5432 → matches the resolved remote backend by identity (the egress mirror of the #4846 ingress carve-out). Rendered per-component, so it also covers keycloak/gitea/harbor/openbao/powerdns cross-region DB egress.

## Live recovery proof
After both fixes applied live: grafana region-b **3/3 Running, 0 restarts** (was CrashLoopBackOff/24+); log `Connecting to DB → Starting DB migrations → migrations completed`; shared-pg-b-2 primary shows live connections from the grafana pod IP; powerdns-admin (another cross-namespace region-B consumer) also connects.

## Changes
- `platform/postgres/chart/templates/networkpolicy.yaml` — namespace Exists on both crossregion-dr-{primary,replica} ingress blocks. Chart 0.2.10→**0.2.11**.
- `platform/cnpg-pair/chart/templates/networkpolicy.yaml` — same, twin. Chart 0.2.9→**0.2.10**.
- `platform/plane-isolation/chart/templates/crossregion-db-egress-cnp.yaml` — toEndpoints egress rule. Chart 0.1.12→**0.1.13**.
- blueprint.yaml + bootstrap-kit slot pins (16a/16c/16d/16b/26b) bumped in lockstep. `helm template` renders clean on all three.

Flips row 67 on the next fresh 2-region prov (or the mothership roll). Refs #4854 #4846.

🤖 Generated with [Claude Code](https://claude.com/claude-code)