### PR TITLE
fix(#3379): cutover registry-pivot ack-gate tolerates a laggard control-plane node (kom4dc cp1)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1232,7 +1232,7 @@ spec:
       #   stamp spec.parameters.sovereignFqdn so the openova-MCP URL points at
       #   this Sovereign, not the mothership. catalyst-api + application-controller
       #   image fixes (deploy-bot pins on next build). Lockstep w/ Chart.yaml.
-      version: 1.4.1036
+      version: 1.4.1037
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3408,7 +3408,7 @@ name: bp-catalyst-platform
 #   sovereign-fqdn) so GET /catalog/regions returns the Sovereign's REAL
 #   regions instead of [] — the marketplace BCP picker stops falling back to
 #   the hardcoded Hetzner list.
-version: 1.4.1036
+version: 1.4.1037
 # 1.4.980 — #4696: SMTP host default mail.openova.io -> stalwart-web.stalwart.svc.cluster.local
 #           (in-cluster svc, matches auth.go code default) — kill flaky-upstream-DNS PIN-delivery 502s.
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -1058,6 +1058,24 @@ spec:
               # zero-touch walk — handover auto-fires the cutover. Customer provs
               # (qaFixtures.enabled=false, fireCutoverOnHandover=false) stay gated.
               value: '{{ if .Values.global.sovereignFQDN }}{{ if or .Values.catalystApi.fireCutoverOnHandover .Values.qaFixtures.enabled }}true{{ else }}false{{ end }}{{ end }}'
+            # CATALYST_CUTOVER_ACK_TOLERANCE (#3379 / #4674) — how many
+            # registry-pivot (step-04) nodes may miss their v2 local-Harbor
+            # ack before the ack-gate (cutover.go waitForRegistryPivotNodeAcks)
+            # still proceeds. A control-plane node whose dragonfly dfdaemon is
+            # dead (the known kom4dc cp1 fault) never writes its v2 ack, and the
+            # in-code strict default (0) wedged the ENTIRE sovereignty cutover on
+            # that one node for the full 10-min timeout — observed live on hw228
+            # (5/6 workers acked, cp1 control-plane laggard → registry-pivot
+            # Failed). A control-plane node runs NO harbor-pulling workloads so
+            # its pivot is immaterial; the true local-only proof is the step-08
+            # deny-egress hold, which still fails fast if a real WORKER can't
+            # pull. Default 1 tolerates a single laggard (the #4635 reconciler +
+            # un-acked-node Warn log keep it visible); a genuine multi-node
+            # outage exceeds 1 and fails. Rendered directly (no `default` — the
+            # sprig int-default gotcha maps an explicit 0 back to the default).
+            # Sovereign-only; empty on the mothership (never a cutover subject).
+            - name: CATALYST_CUTOVER_ACK_TOLERANCE
+              value: '{{ if .Values.global.sovereignFQDN }}{{ .Values.catalystApi.cutoverAckTolerance }}{{ end }}'
             # SOVEREIGN_FQDN — Sovereign's public FQDN. The /auth/handover
             # validator (auth_handover.go) reads this to compute the expected
             # JWT audience claim ("https://console." + SOVEREIGN_FQDN). When

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -1348,6 +1348,18 @@ catalystApi:
   # cutover walk end-to-end with no operator click. Flipping this to true
   # does NOT change the operator/BSS CTA path — that always fires.
   fireCutoverOnHandover: false
+  # #3379 / #4674 — registry-pivot (cutover step-04) ack-gate laggard tolerance,
+  # wired to CATALYST_CUTOVER_ACK_TOLERANCE (Sovereign-only). A control-plane
+  # node whose dragonfly dfdaemon is dead (the known kom4dc cp1 fault) never
+  # writes its v2 local-Harbor ack; the in-code strict default (0) wedges the
+  # WHOLE sovereignty cutover on that one immaterial node for the full 10-min
+  # timeout (observed live hw228: 5/6 workers acked, cp1 control-plane laggard →
+  # registry-pivot Failed). A control-plane node runs no harbor-pulling
+  # workloads, so tolerating it is safe — the true local-only proof is the
+  # step-08 deny-egress hold, which still fails fast if a real WORKER can't pull.
+  # Default 1 tolerates a single laggard; a genuine multi-node outage exceeds it
+  # and fails. Set 0 to restore the strict all-nodes invariant.
+  cutoverAckTolerance: 1
 
 # ─── #4053 — Dedicated console Gateway (poison-proof blast-radius isolation) ──
 # Cilium Gateway API compiles every HTTPRoute + backend of a Gateway into ONE


### PR DESCRIPTION
## Live-surfaced on hw228 (dep ac35eda8561b7922) — Pillar-5 cutover fired this session

Fired the sovereignty cutover `POST /cutover/start`. Steps 1-3 (gitea-mirror, harbor-projects, harbor-prewarm) **succeeded**; **registry-pivot (step 04) FAILED**:
```
registry-pivot DaemonSet ready but not all nodes acked v2 registries.yaml in 10m0s:
get DaemonSet: client rate limiter Wait returned an error: context deadline exceeded
```
Live diagnosis: `registriesYamlActive=v2`, `dragonflyUpstream=local` (the pivot content applied), and **5 of 6 nodes acked v2** — the lone laggard is **`a-cp1-634324`, the region-a control-plane node**, whose dragonfly dfdaemon is the known-dead kom4dc cp1 fault, so it never writes its v2 ack. `cutover.go` `waitForRegistryPivotNodeAcks` gates on `desired-acks <= cutoverAckTolerance()`, default **0** (strict all-nodes) — so one immaterial control-plane node wedged the entire cutover for the full 10-min timeout (the trailing rate-limiter error is just the poll loop hitting the deadline).

## Fix
The tolerance mechanism already exists (`CATALYST_CUTOVER_ACK_TOLERANCE`, #4674) but was never wired into the deployment, so it defaulted to 0. This wires it from a new `catalystApi.cutoverAckTolerance` value **defaulted to 1**:
- A single laggard (typically a control-plane node with a flaky dfdaemon) no longer wedges the cutover.
- A genuine multi-node outage still exceeds 1 and fails fast; the #4635 reconciler + the un-acked-node `Warn` log keep the laggard visible.
- Correctness is still enforced by the **step-08 deny-egress hold** (cutoverComplete=true only if the cluster reconciles green with egress blocked) — a real worker that couldn't pull from local Harbor fails there.
- Rendered directly (no sprig `default` — the int-default gotcha maps an explicit 0 back to 1). Sovereign-only. Chart 1.4.1036→**1.4.1037**.

Flips the cutover-to-green (`cutoverComplete=true`) on the next fresh 2-region kom4dc prov. Refs #3379 #4674.

🤖 Generated with [Claude Code](https://claude.com/claude-code)