### PR TITLE
fix(#4873): cutover prewarm+probe read DEPLOYED chart version (not mutable desired)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -719,7 +719,7 @@ spec:
       # node-local `GET http://127.0.0.1:4001/v2/` serving probe so catalyst-api's
       # daemonset-wait cannot green (→ step-07 catalyst-api re-pull) while the
       # dfdaemon mirror has 0 Ready pods (#4649 condition → connection-refused).
-      version: 0.1.103
+      version: 0.1.104
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.103  # lockstep with chart/Chart.yaml (#4637 step-07 dfdaemon-serving v2-ack gate)
+  version: 0.1.104
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1509,7 +1509,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.103
+version: 0.1.104
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -576,10 +576,22 @@ data:
             # Enumerate (chart, version, sourceRef.kind, sourceRef.name) from
             # every HelmRelease cluster-wide. Tab-separated; a HR with no
             # explicit chart.spec is skipped (empty fields).
+            # #4870-followup: mirror the DEPLOYED chart version
+            # (.status.history[0].chartVersion), NOT the mutable desired
+            # .spec.chart.spec.version. During a cutover the gitea-mirror step
+            # can pull a deploybot-bumped catalog pin into the env, so
+            # .spec.chart.spec.version can transiently oscillate (e.g. an env
+            # DEPLOYED on 1.4.1038 briefly shows spec 1.4.1039 then settles
+            # back). If prewarm mirrors the transient desired (1.4.1039) but
+            # step-06 later checks the settled deployed (1.4.1038), the pivot
+            # wedges forever ("chart not yet pullable"). The deployed version
+            # is immutable for the running release — mirror THAT so the release
+            # keeps reconciling from local Harbor post-pivot.
             chart_tuples=$(kubectl get helmreleases -A -o json | \
-              jq -r '.items[].spec.chart.spec
-                | select(.chart != null and .sourceRef != null)
-                | [ .chart, (.version // ""), (.sourceRef.kind // ""), (.sourceRef.name // "") ]
+              jq -r '.items[]
+                | .spec.chart.spec as $cs
+                | select($cs.chart != null and $cs.sourceRef != null)
+                | [ $cs.chart, ((.status.history[0].chartVersion) // $cs.version // ""), ($cs.sourceRef.kind // ""), ($cs.sourceRef.name // "") ]
                 | @tsv' 2>/dev/null | sort -u || true)
 
             # Resolve the UPSTREAM chart-OCI host/project prefix from the same

--- a/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
@@ -1043,10 +1043,16 @@ data:
               done | sort -u > "${local_hr_file}" || : > "${local_hr_file}"
 
             probe_file=/tmp/.chart-probe.txt
+            # #4870-followup: probe the DEPLOYED chart version
+            # (.status.history[0].chartVersion), matching what step-03
+            # harbor-prewarm mirrors. Reading the mutable desired
+            # .spec.chart.spec.version here races the deploybot catalog bump
+            # and wedges the pivot when prewarm mirrored a different version.
             kubectl get helmreleases -A -o json 2>/dev/null | \
-              jq -r '.items[].spec.chart.spec
-                | select(.chart != null and .sourceRef != null and (.sourceRef.kind // "") == "HelmRepository")
-                | [ (.sourceRef.name // ""), .chart, (.version // "") ]
+              jq -r '.items[]
+                | .spec.chart.spec as $cs
+                | select($cs.chart != null and $cs.sourceRef != null and ($cs.sourceRef.kind // "") == "HelmRepository")
+                | [ ($cs.sourceRef.name // ""), $cs.chart, ((.status.history[0].chartVersion) // $cs.version // "") ]
                 | @tsv' 2>/dev/null | \
               while IFS="$(printf '\t')" read -r src chart ver; do
                 [ -z "${chart}" ] && continue
@@ -1104,9 +1110,10 @@ data:
                       esac
                     done | sort -u > "${local_hr_file}" || : > "${local_hr_file}"
                 kubectl get helmreleases -A -o json 2>/dev/null | \
-                  jq -r '.items[].spec.chart.spec
-                    | select(.chart != null and .sourceRef != null and (.sourceRef.kind // "") == "HelmRepository")
-                    | [ (.sourceRef.name // ""), .chart, (.version // "") ]
+                  jq -r '.items[]
+                    | .spec.chart.spec as $cs
+                    | select($cs.chart != null and $cs.sourceRef != null and ($cs.sourceRef.kind // "") == "HelmRepository")
+                    | [ ($cs.sourceRef.name // ""), $cs.chart, ((.status.history[0].chartVersion) // $cs.version // "") ]
                     | @tsv' 2>/dev/null | \
                   while IFS="$(printf '\t')" read -r src chart ver; do
                     [ -z "${chart}" ] && continue

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5036,7 +5036,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.103"
+    version: "0.1.104"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
Fixes the cutover wedge at helmrepository-patches when a deploybot chart bump races the pivot.

**Root cause:** step-03 harbor-prewarm + step-06 helmrepository-patches both read `.spec.chart.spec.version` (mutable desired). The gitea-mirror step pulls `main` (possibly a deploybot-bumped catalog pin) into the env mid-cutover, so that field oscillates — prewarm mirrored `bp-catalyst-platform:1.4.1039` while step-06 later checked the settled `1.4.1038` → pivot retry-loops forever.

**Fix:** both steps now read the immutable **deployed** version `.status.history[0].chartVersion` (fallback `.spec.chart.spec.version`), so prewarm mirrors exactly what step-06 verifies — the version the running release needs to keep reconciling from local Harbor post-pivot.

Verified live on hw231 (dep ab1355c25f9798c3): registry-pivot (#4870 ack-gate) passed 6/6; the wedge was purely this skew. `helm template` renders clean; chart 0.1.103→0.1.104.

Refs #4873 #3379 #4870