### PR TITLE
fix(#4875): vpc-podcidr-route-reconciler ensures openssl (image lacks the CLI its HMAC signer needs)

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -141,7 +141,7 @@ spec:
       # 1370 → 1420 (WG-only). Layers on the 1.4.9/1.4.10 zero-nodeport +
       # authMode=legacy work. Cross-region ClusterMesh pod path needs a fresh
       # 2-region prov to verify (datapath change). Refs #4656.
-      version: 1.4.13
+      version: 1.4.14
       sourceRef:
         kind: HelmRepository
         name: bp-cilium

--- a/platform/cilium/blueprint.yaml
+++ b/platform/cilium/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 1.4.13
+  version: 1.4.14
   card:
     title: Cilium
     summary: Unified CNI + Service Mesh (eBPF). mTLS via WireGuard, Hubble observability, Gateway API.

--- a/platform/cilium/chart/Chart.yaml
+++ b/platform/cilium/chart/Chart.yaml
@@ -279,7 +279,7 @@ name: bp-cilium
 #   Layers ON TOP of the 1.4.9/1.4.10 zero-nodeport + authMode=legacy work.
 #   Needs a fresh 2-region prov to verify the cross-region ClusterMesh pod
 #   path end-to-end (datapath change, not CI-provable). Refs #4656.
-version: 1.4.13
+version: 1.4.14
 description: |
   Catalyst-curated Blueprint umbrella chart for Cilium. Depends on the
   upstream `cilium` chart as a Helm subchart so `helm dependency build`

--- a/platform/cilium/chart/templates/vpc-podcidr-route-reconciler.yaml
+++ b/platform/cilium/chart/templates/vpc-podcidr-route-reconciler.yaml
@@ -123,6 +123,17 @@ data:
     # "#4656" are ever modified or deleted; everything else is foreign.
     set -euo pipefail
     : "${HW_AK:?}" "${HW_SK:?}" "${HW_PROJECT_ID:?}" "${HW_REGION:?}" "${HW_CLOUD:?}"
+    # #4875 — the alpine/k8s image does NOT ship the openssl CLI, but the Huawei
+    # SDK-HMAC-SHA256 signer below (sha256hex/hmachex, lines ~139-140) hard-depends
+    # on `openssl dgst`. Without this ensure, every run died with
+    # "openssl: command not found" at the first api() call → the reconciler never
+    # wrote a single per-node route (live: 6/6 pods, both regions, zero successful
+    # runs). Guard → apk-add → clear-fail so a genuine signing-tool gap surfaces
+    # loudly instead of aborting cryptically before any route is reconciled.
+    command -v openssl >/dev/null 2>&1 || apk add --no-cache openssl >/dev/null 2>&1 || {
+      echo "FATAL: openssl CLI unavailable (image lacks it AND apk add failed); Huawei AK/SK SDK-HMAC-SHA256 signing requires it — per-node cross-region pod-CIDR routes cannot be reconciled. See #4875." >&2
+      exit 1
+    }
     MARKER_PREFIX="#4656"
     MARKER="#4656 podcidr-route-reconciler"
     VPC_HOST="vpc.${HW_REGION}.${HW_CLOUD}"
@@ -236,7 +247,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: reconcile
-              # alpine/k8s toolbox (bash + kubectl + jq + curl + openssl),
+              # alpine/k8s toolbox (bash + kubectl + jq + curl; openssl apk-added at runtime #4875),
               # dockerhub-proxied per MIRROR-EVERYTHING.
               image: {{ (default "harbor.openova.io/proxy-dockerhub/alpine/k8s:1.30.0" $rr.image) | quote }}
               command: ["bash", "/opt/reconciler/reconcile.sh"]

--- a/platform/cilium/chart/values.yaml
+++ b/platform/cilium/chart/values.yaml
@@ -499,7 +499,9 @@ catalystOverlay:
   vpcPodcidrRouteReconciler:
     enabled: false
     schedule: "*/5 * * * *"
-    # alpine/k8s toolbox (bash + kubectl + jq + curl + openssl), proxied.
+    # alpine/k8s toolbox (bash + kubectl + jq + curl), proxied. NOTE (#4875):
+    # this image does NOT ship the openssl CLI — the reconcile script apk-adds it
+    # at start (the Huawei SDK-HMAC-SHA256 signer needs `openssl dgst`).
     image: "harbor.openova.io/proxy-dockerhub/alpine/k8s:1.30.0"
     # HCS endpoint domain — service endpoints derive as
     # https://vpc.<huaweiRegion>.<cloud>/ (same derivation as

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -3785,7 +3785,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-cilium
-    version: "1.4.13"
+    version: "1.4.14"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
Fixes #4875 — the `vpc-podcidr-route-reconciler` CronJob (#4861/#4656 per-node cross-region pod-CIDR VPC routes) has **never succeeded** on any Huawei Sovereign: the `alpine/k8s:1.30.0` image ships **no `openssl` CLI**, but the Huawei SDK-HMAC-SHA256 request signer (`sha256hex`/`hmachex`) hard-depends on `openssl dgst`. Every run aborts `openssl: command not found` at the first `api()` call under `set -euo pipefail`, before any route is read/written. Live-verified on hw231: 6/6 pods, both regions, zero successful runs ever.

**Fix:** `command -v openssl || apk add --no-cache openssl || <clear FATAL>` before the signer runs, and correct the two `values.yaml`/template comments that wrongly claimed the image includes openssl. cilium chart 1.4.13→1.4.14 + bootstrap-kit / blueprint / catalog-seed locksteps.

**Impact:** latent, not an active outage — current cross-region traffic rides the base /16 VPC peering routes from #4656's tofu IaC. But the per-node `type=ecs` routes are never maintained, so a node scale-up / replacement / **region-kill failover node** black-holes cross-region (the #4656/#4854 per-node symptom). Directly relevant to the 2-region BCP / region-kill DoD.

`helm template` renders clean. Low blast radius (reconciler is `enabled:false` by default + currently 100% non-functional — this can only improve it).

Refs #4875 #4861 #4656 #4854