### PR TITLE
fix(#4879): openbao snapshot-fetch treats missing bucket as skip, not hard failure

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -148,7 +148,12 @@ spec:
       #   client scope; otherwise a silent claim-drop re-opens the admin UI 403.
       #   Live-verified on 91dc0591: fresh sovereign-admins login lands
       #   /ui/vault/secrets with [default,sso-operator-admin,sso-operator-read].
-      version: 1.2.59
+      # 1.2.60 — #4879: snapshot-FETCH robustness. The secondary's
+      #   openbao-snapshot-fetch CronJob ran list-objects-v2 under `set -eu`, so
+      #   a NoSuchBucket (local seaweedfs `openbao-snapshots` bucket not yet
+      #   created) aborted the Job every tick. Now a missing bucket is treated
+      #   like the empty-bucket case: WARN + exit 0 (skipped tick, not failure).
+      version: 1.2.60
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.59  # lockstep with chart/Chart.yaml (#4519 OIDC role oidc_scopes=groups — harden external-group resolution)
+  version: 1.2.60  # lockstep with chart/Chart.yaml (#4879 snapshot-fetch: NoSuchBucket → graceful skip, not hard Job failure)
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -1,5 +1,14 @@
 apiVersion: v2
 name: bp-openbao
+# 1.2.60 (#4879, 2026-07-09): snapshot-FETCH robustness — the secondary's
+# openbao-snapshot-fetch CronJob ran `s3api list-objects-v2` under `set -eu`,
+# so a NoSuchBucket error (the local seaweedfs `openbao-snapshots` bucket not
+# yet created — the primary creates it on its first successful ship) aborted
+# the whole Job every tick (hard CronJob failure). Now a missing bucket is
+# caught and treated like the already-handled EMPTY-bucket case: WARN + exit 0
+# (a skipped tick, not a failure). Real list errors still abort loudly. The
+# cross-region-replication half (seeding the bucket from region-A) is a larger
+# separate change, deferred.
 # 1.2.53 (#4343, 2026-06-25): set `injector.resources.requests` (cpu/memory)
 # so the agent-injector Deployment satisfies the cluster-wide Kyverno
 # `resource-requests` Enforce policy. Post-#4325 this chart installs into the
@@ -219,7 +228,7 @@ name: bp-openbao
 #   entity joined the sovereign-admins external group (direct_group_ids). Only
 #   the sso-configure reconcile.sh ROLE_PAYLOAD changes (+ the chart bump that
 #   rolls the Deployment per the #3374 checksum); no other template moves.
-version: 1.2.59
+version: 1.2.60
 # 1.2.51 (#3888, Refs #3847): prov-time openbao KV-seed mechanism — the
 # auth-bootstrap Job reads a one-shot cloud-init `openbao-bootstrap-seed`
 # Secret + writes its keys into KV at secret/<prefix>/* with the still-valid

--- a/platform/openbao/chart/templates/snapshot-replication.yaml
+++ b/platform/openbao/chart/templates/snapshot-replication.yaml
@@ -464,10 +464,33 @@ spec:
                   # uninterrupted. The restore + peers.json recovery is a
                   # bp-continuum step; this only stages the data.
                   log "fetching latest snapshot from s3://${S3_BUCKET} to ${STAGING_PATH}"
-                  LATEST="$(aws --endpoint-url "${S3_ENDPOINT}" s3api list-objects-v2 \
+                  # #4879: on a freshly-provisioned secondary the local seaweedfs
+                  # `openbao-snapshots` bucket may not exist yet — the primary's
+                  # save Job creates it on its FIRST successful ship. Under
+                  # `set -eu` a NoSuchBucket error from list-objects-v2 aborts the
+                  # whole Job (hard CronJob failure) instead of taking the graceful
+                  # empty-bucket skip below. Capture stderr and treat a
+                  # not-yet-present bucket EXACTLY like an empty one: WARN + exit 0
+                  # (a not-yet-created bucket is a skipped tick, not a failure).
+                  # Any OTHER list error still aborts, re-raising its exit code so
+                  # real faults stay loud.
+                  LIST_ERR=/tmp/openbao-snapshot-list.err
+                  if LATEST="$(aws --endpoint-url "${S3_ENDPOINT}" s3api list-objects-v2 \
                     --bucket "${S3_BUCKET}" \
                     --query 'sort_by(Contents,&LastModified)[-1].Key' \
-                    --output text)"
+                    --output text 2>"${LIST_ERR}")"; then
+                    rm -f "${LIST_ERR}"
+                  else
+                    rc=$?
+                    if grep -q 'NoSuchBucket' "${LIST_ERR}"; then
+                      log "WARN: bucket s3://${S3_BUCKET} not yet present on local S3 — skipping this tick (#4879)"
+                      rm -f "${LIST_ERR}"
+                      exit 0
+                    fi
+                    log "FATAL: list-objects-v2 on s3://${S3_BUCKET} failed (rc=${rc}): $(cat "${LIST_ERR}" 2>/dev/null)"
+                    rm -f "${LIST_ERR}"
+                    exit "${rc}"
+                  fi
                   if [ -z "${LATEST}" ] || [ "${LATEST}" = "None" ]; then
                     log "WARN: no snapshot objects in s3://${S3_BUCKET} yet — nothing to stage this tick"
                     exit 0

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -3395,7 +3395,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.2.59"
+  version: "1.2.60"
   visibility: unlisted
   card:
     title: "OpenBao"
@@ -3420,7 +3420,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-openbao
-    version: "1.2.59"
+    version: "1.2.60"
   topology:
     supported:
     - active-passive


### PR DESCRIPTION
## Problem (root-caused live on hw231)

The `openbao-snapshot-fetch` CronJob on the **secondary** (region-b, label `snapshot-role: secondary`) fails **every run** with:

```
An error occurred (NoSuchBucket) when calling the ListObjectsV2 operation
```

The fetch script runs `aws s3api list-objects-v2` under `set -eu`. On a freshly-provisioned secondary the local seaweedfs `openbao-snapshots` bucket does **not exist yet** — the **primary's** save Job creates it on its first successful ship. Under `errexit`, the `NoSuchBucket` error aborts the whole Job → a hard CronJob failure on every tick.

The script already handles an **EMPTY** bucket gracefully (WARN + `exit 0`). A **not-yet-created** bucket should be treated identically — a skipped tick, not a failure.

## Fix (scoped — script-robustness half ONLY)

`platform/openbao/chart/templates/snapshot-replication.yaml` (secondary fetch branch): capture `list-objects-v2` stderr and, on `NoSuchBucket`, log a clear WARN and `exit 0`. Any **other** list error still aborts, re-raising its exit code so real faults stay loud. All existing behavior is preserved:

- empty-bucket skip → unchanged (WARN + exit 0)
- real list error → still hard-fails (re-raised rc)
- successful staging → unchanged

```sh
LIST_ERR=/tmp/openbao-snapshot-list.err
if LATEST="$(aws --endpoint-url "${S3_ENDPOINT}" s3api list-objects-v2 \
  --bucket "${S3_BUCKET}" \
  --query 'sort_by(Contents,&LastModified)[-1].Key' \
  --output text 2>"${LIST_ERR}")"; then
  rm -f "${LIST_ERR}"
else
  rc=$?
  if grep -q 'NoSuchBucket' "${LIST_ERR}"; then
    log "WARN: bucket s3://${S3_BUCKET} not yet present on local S3 — skipping this tick (#4879)"
    rm -f "${LIST_ERR}"
    exit 0
  fi
  log "FATAL: list-objects-v2 on s3://${S3_BUCKET} failed (rc=${rc}): $(cat "${LIST_ERR}" 2>/dev/null)"
  rm -f "${LIST_ERR}"
  exit "${rc}"
fi
```

## Deferred (NOT in this PR)

The **cross-region-replication half** — actually seeding the `openbao-snapshots` bucket on region-b (from region-A) so the fetch has objects to stage — is a larger, separate change and is intentionally deferred. This PR only stops the fetch Job from hard-failing when the bucket isn't present yet.

## Version lockstep

Chart `bp-openbao` **1.2.59 → 1.2.60**, bumped in lockstep across the four enforced pins:

- `platform/openbao/chart/Chart.yaml`
- `clusters/_template/bootstrap-kit/08-openbao.yaml` (slot pin)
- `platform/openbao/blueprint.yaml` (spec.version)
- `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` (bp-openbao spec.version + source.version)

## Validation

- `helm template test platform/openbao/chart` → renders clean
- `helm template test products/catalyst/chart` → renders clean
- rendered fetch script passes `sh -n`
- `scripts/check-bootstrap-kit-pin-sync.sh` → PASS
- `scripts/check-catalog-seed-lockstep.sh` → PASS

Refs #4879

🤖 Generated with [Claude Code](https://claude.com/claude-code)