### PR TITLE
fix(#4881): un-wedge Blueprint Release for bp-self-sovereign-cutover (stale cutover-contract Case 26 after #4874)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -719,7 +719,7 @@ spec:
       # node-local `GET http://127.0.0.1:4001/v2/` serving probe so catalyst-api's
       # daemonset-wait cannot green (→ step-07 catalyst-api re-pull) while the
       # dfdaemon mirror has 0 Ready pods (#4649 condition → connection-refused).
-      version: 0.1.104
+      version: 0.1.105
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.104
+  version: 0.1.105
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1509,7 +1509,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.104
+version: 0.1.105
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -847,10 +847,22 @@ if ! grep -q 'Phase A2: mirror openova-io helm charts into local Harbor' "$TMP/r
   echo "FAIL: Step-03 missing the Phase A2 helm-chart mirror — the charts never reach local Harbor; step-06's ghcr.io strip would 404 every (re)pull (Refs #3627)" >&2
   exit 1
 fi
-# The chart name+version MUST be read off the consuming HelmRelease's
-# spec.chart.spec (NOT the HelmRepository, whose spec.url is only the pointer).
-if ! grep -q '.items\[\].spec.chart.spec' "$TMP/render.yaml"; then
-  echo "FAIL: Step-03 Phase A2 does not enumerate chart+version from HelmRelease spec.chart.spec (Refs #3627)" >&2
+# The chart name MUST be read off the consuming HelmRelease's spec.chart.spec
+# (NOT the HelmRepository, whose spec.url is only the pointer). #4873/#4874:
+# Phase A2's jq now binds `.spec.chart.spec as $cs` for the chart name and reads
+# the DEPLOYED version from `.status.history[0].chartVersion` (falling back to
+# $cs.version). The mutable desired .spec.chart.spec.version oscillates
+# mid-cutover on a deploybot catalog bump, so mirroring the deployed version is
+# what keeps prewarm (step-03) and the pull-probe (step-06) in lockstep.
+if ! grep -q '.spec.chart.spec as \$cs' "$TMP/render.yaml"; then
+  echo "FAIL: Step-03 Phase A2 does not enumerate the chart off HelmRelease spec.chart.spec (Refs #3627 #4873)" >&2
+  exit 1
+fi
+# And it MUST mirror the DEPLOYED chart version, not the mutable desired
+# spec.chart.spec.version (which races the deploybot catalog bump and wedges
+# the pivot when prewarm mirrored a different version than step-06 probes).
+if ! grep -q 'status.history\[0\].chartVersion' "$TMP/render.yaml"; then
+  echo "FAIL: Step-03 Phase A2 does not mirror the DEPLOYED chart version (.status.history[0].chartVersion); reading the mutable desired spec.version wedges the pivot (Refs #4873)" >&2
   exit 1
 fi
 # It MUST select only sourceRef.kind=HelmRepository entries (skip OCIRepository/

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5036,7 +5036,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.104"
+    version: "0.1.105"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Problem

The **Blueprint Release** workflow fails deterministically at job `build (platform/self-sovereign-cutover)` for chart **bp-self-sovereign-cutover 0.1.104**, so `ghcr.io/openova-io/bp-self-sovereign-cutover:0.1.104` never publishes. `main` is currently inconsistent: all pins (bootstrap-kit slot 06a, blueprint.yaml, catalog-seed) reference 0.1.104 but no such artifact exists in GHCR, so a fresh Sovereign prov cannot seal the cutover (Pillar 5).

- Failing run: `28991861621`, job `86045855855` (re-run also failed).
- Failing step: **Run chart integration tests (chart/tests/\*.sh)**.
- Exact error:
  ```
  [cutover-contract] Case 26: Step-03 harbor-prewarm mirrors openova-io helm CHARTS into local Harbor (Refs #3627)
  FAIL: Step-03 Phase A2 does not enumerate chart+version from HelmRelease spec.chart.spec (Refs #3627)
  ```

## Root cause

PR #4874 (fix #4873, `98d567134`) refactored the Step-03 harbor-prewarm and Step-06 helmrepository-patches jq to read the **deployed** chart version `.status.history[0].chartVersion` instead of the mutable desired `.spec.chart.spec.version`. That changed the jq from `.items[].spec.chart.spec | ...` to `.items[] | .spec.chart.spec as $cs | ...`, so the contiguous substring `.items[].spec.chart.spec` no longer appears in the rendered Step-03 ConfigMap.

The chart's own gate `tests/cutover-contract.sh` **Case 26** (line 852) still `grep`s for that old literal, so the assertion fails and the job dies before the GHCR push. The test was simply not updated in lockstep with #4874's template change — this is a stale-test regression, **not** a CI-infra / registry-push / signing problem. (bp-cilium 1.4.14 / #4876 published fine precisely because it has no such stale render assertion.)

## Fix

- Refresh Case 26 to the #4874 intent — assert Phase A2 (a) binds `.spec.chart.spec as $cs` for the chart name and (b) mirrors the DEPLOYED version `.status.history[0].chartVersion` (this also guards against a regression back to the mutable-desired read that #4873 fixed).
- Bump chart `0.1.104 → 0.1.105` and lockstep the 3 pins: `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml`, `platform/self-sovereign-cutover/blueprint.yaml`, `products/catalyst/chart/templates/catalog-seed/blueprints.yaml`.

## Verification (local)

- `helm template` renders clean — 6698 lines, exit 0.
- `bash tests/cutover-contract.sh` — **all 35 cases green** (Case 26 now PASS).

On merge, Blueprint Release re-fires for the changed `platform/self-sovereign-cutover/chart/**`, the now-passing test lets the job publish `bp-self-sovereign-cutover:0.1.105`, and the auto-bump/lockstep steps no-op (pins already at 0.1.105).

Refs #4881 #4874 #4873 #3627

🤖 Generated with [Claude Code](https://claude.com/claude-code)