### PR TITLE
fix(#4877): self-heal reconciler for catalyst-api OpenBao seed seams

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -1069,6 +1069,21 @@ func main() {
 	// on a ticker, and a no-op when the registry/dynamic-client isn't wired.
 	go h.ReconcileTenantRegistryFromOrgCRs(context.Background())
 
+	// #4877 — level-triggered self-heal for the three OpenBao seed seams
+	// (newapi-admin-token / anthropic / per-Org mcp-bearer). Those seeds fire
+	// from EXACTLY ONE place (runOrganizationPipeline, once per HTTP Org-create,
+	// no retry). If that single write misses — catalyst-api OOM mid-pipeline
+	// (#4811) or a prereq not yet reflected — the OpenBao paths are never
+	// written and the ExternalSecrets reading them stay SecretSyncedError
+	// forever (unified-rbac 401s; agenity's agent gets no Anthropic cred / no
+	// Catalyst MCP bearer). This reconciler re-runs the seeds on startup + a
+	// periodic tick, seeding ONLY paths that are absent/empty (read-before-write
+	// → zero churn on healthy paths). Idempotent + non-fatal; dormant on the
+	// orchestrator (nil OpenBao) and behind CATALYST_SEED_RECONCILER_ENABLED.
+	// Wired here, after SetOpenBao (#189) + SetHandoverSigner (#233) +
+	// SetOrganizationDeps (all seed prerequisites) are in place.
+	h.StartSovereignSeedReconciler(context.Background())
+
 	// Unauthenticated cloud-init postback (issue #183, Option D + #634).
 	// The new Sovereign's control plane PUTs its rewritten kubeconfig
 	// here with `Authorization: Bearer <postback-token>`. PutKubeconfig

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_seed_reconciler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_seed_reconciler.go
@@ -1,0 +1,277 @@
+// sovereign_seed_reconciler.go — #4877. LEVEL-TRIGGERED self-heal for the
+// three OpenBao seed seams (newapi-admin-token / anthropic / mcp-bearer).
+//
+// THE GAP this file closes:
+//
+//	seedNewapiAdminToken, seedAnthropicToken and seedMCPBearer are each fired
+//	from EXACTLY ONE place — runOrganizationPipeline
+//	(organization_provisioning.go, Step 1) — once per HTTP Org-create, with NO
+//	retry and NO reconcile. If that single write misses (catalyst-api OOM
+//	mid-pipeline #4811, or a prereq — the NewAPI bridge Secret, the Anthropic
+//	env cred, the handover signer — not yet reflected at that instant), the
+//	OpenBao paths
+//	  - secret/catalyst/newapi/admin-token
+//	  - secret/catalyst/anthropic/token
+//	  - secret/catalyst/agenity/<slug>/mcp-bearer
+//	are NEVER written. The ExternalSecrets that read them then stay
+//	READY=False / SecretSyncedError FOREVER (unified-rbac 401s; the agenity
+//	agent never gets its Anthropic cred or its Catalyst MCP bearer), because
+//	nothing re-fires the producer — the Org is already "created".
+//
+// THE FIX (this file):
+//
+//	Re-run the seeds on catalyst-api STARTUP and on a periodic reconcile so a
+//	missed write self-heals. The seeds are already idempotent (PutKVv2
+//	overwrites) and non-fatal (a missing prereq is a logged skip, never an
+//	error), so a reconcile loop is safe. STARTUP is the primary recovery path:
+//	after the OOM that dropped the write, the catalyst-api Pod restarts and the
+//	startup pass immediately re-seeds every absent path. The periodic loop is
+//	the secondary safety net for a prereq that lands after startup (e.g. NewAPI
+//	finishing its install).
+//
+// READ-BEFORE-WRITE (why we don't blindly re-PutKVv2 every pass):
+//
+//	seedMCPBearer MINTS A FRESH bearer (new jti + new exp) on every call, so a
+//	blind re-seed every interval would churn the OpenBao value → ExternalSecret
+//	→ per-Org agenity-mcp-bearer Secret on every tick, growing KV version
+//	history and re-writing a healthy Secret needlessly. So each pass first
+//	READS the target path (GetKVv2) and seeds ONLY when it is absent or its
+//	expected property is empty — i.e. exactly the #4877 gap ("never written").
+//	A path that already holds a valid value is a true no-op (zero writes, zero
+//	log noise). The mcp-bearer's own doc comment frames periodic re-mint as an
+//	expiry-refresh feature, but the minted bearer is 1-year TTL and env-
+//	projected into the agenity StatefulSet (no hot-reload, no reloader on the
+//	chart), so a healthy bearer never needs refreshing between reconciles —
+//	self-heal of an ABSENT path is the whole job here.
+//
+// Global vs per-Org scope:
+//
+//	newapi-admin-token + anthropic are Sovereign-GLOBAL (one cluster-shared
+//	path each) → checked/seeded unconditionally once per pass. mcp-bearer is
+//	PER-ORG (the path carries the Org slug) → we enumerate the Organizations
+//	the Sovereign knows about the SAME way the console directory + the
+//	tenant-registry reconcile do (orgResponsesFromCRs → list every
+//	orgs.openova.io CR via the in-cluster dynamic client) and check/seed each.
+//	Out-of-cluster / CI (no dynamic client) yields zero Orgs and the per-Org
+//	leg is a no-op, matching every other dynamic-client path in this package.
+//
+// Per docs/PRINCIPLES.md #10 (credential hygiene): this never logs any token,
+// bearer, key or PEM — only outcome classes + byte-free identifiers.
+
+package handler
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/openbao"
+)
+
+const (
+	// defaultSeedReconcileInterval — steady-state cadence of the self-heal
+	// loop. Generous (10m): the #4877 fault is a PERSISTENT SecretSyncedError,
+	// not a fast-moving one, and the startup pass already heals the common
+	// post-OOM case immediately; the periodic loop only needs to catch a
+	// prereq that lands after startup. Overridable per docs/PRINCIPLES.md #4.
+	defaultSeedReconcileInterval = 10 * time.Minute
+	// seedReconcileWarmup delays the first pass so the Org-create pipeline +
+	// the OpenBao/handover-signer/org-deps wiring settle first — a redundant
+	// early pass is harmless (read-before-write no-ops), this just keeps the
+	// startup logs clean.
+	seedReconcileWarmup = 45 * time.Second
+)
+
+// StartSovereignSeedReconciler launches the #4877 seed self-heal loop in a
+// background goroutine. Returns immediately; ctx cancellation stops the loop.
+// Run from main.go AFTER the OpenBao client, handover signer and Organization
+// deps are wired (all three are seed prerequisites).
+//
+// Dormant (returns without spawning) when:
+//   - CATALYST_SEED_RECONCILER_ENABLED=false (kill switch), or
+//   - h.openbao is nil — the Catalyst-Zero orchestrator has no in-cluster
+//     OpenBao client and never hosts these secrets, so there is nothing to
+//     self-heal (mirrors every seed's own nil-OpenBao skip).
+func (h *Handler) StartSovereignSeedReconciler(ctx context.Context) {
+	if h == nil {
+		return
+	}
+	if os.Getenv("CATALYST_SEED_RECONCILER_ENABLED") == "false" {
+		if h.log != nil {
+			h.log.Info("[SEED-RECONCILE] disabled via CATALYST_SEED_RECONCILER_ENABLED=false")
+		}
+		return
+	}
+	if h.openbao == nil {
+		if h.log != nil {
+			h.log.Info("[SEED-RECONCILE] dormant: no OpenBao client (orchestrator / Catalyst-Zero) — nothing to self-heal")
+		}
+		return
+	}
+
+	interval := durationEnv("CATALYST_SEED_RECONCILE_INTERVAL", defaultSeedReconcileInterval)
+	if h.log != nil {
+		h.log.Info("[SEED-RECONCILE] starting (self-heal for newapi-admin-token / anthropic / per-Org mcp-bearer seeds, #4877)",
+			"intervalSec", int(interval.Seconds()),
+			"warmupSec", int(seedReconcileWarmup.Seconds()),
+		)
+	}
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(seedReconcileWarmup):
+		}
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			h.runSeedReconcilePass(ctx)
+			select {
+			case <-ctx.Done():
+				if h.log != nil {
+					h.log.Info("[SEED-RECONCILE] stopped")
+				}
+				return
+			case <-t.C:
+			}
+		}
+	}()
+}
+
+// runSeedReconcilePass performs one idempotent, best-effort self-heal pass:
+// for each of the three OpenBao seed paths it READS the current value and
+// re-runs the producing seed ONLY when the path is absent / empty (the #4877
+// gap). Exposed (unexported-but-package-visible) for the reconciler test.
+//
+// Never fatal: every seed already folds its own failures to a logged skip, and
+// a panic anywhere in the pass is recovered so a self-heal attempt can NEVER
+// crash catalyst-api. A read/list error skips just that leg and retries next
+// tick.
+func (h *Handler) runSeedReconcilePass(ctx context.Context) {
+	if h == nil || h.openbao == nil {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil && h.log != nil {
+			h.log.Error("[SEED-RECONCILE] pass panicked; recovered — catalyst-api unaffected, retry next tick",
+				"panic", r)
+		}
+	}()
+
+	// (1) newapi admin-token — Sovereign-GLOBAL. Seed only when the path lacks
+	// a non-empty ADMIN_API_TOKEN. seedNewapiAdminToken itself no-ops (loud
+	// skip) if NewAPI's bridge Secret hasn't rendered yet, so a still-absent
+	// path simply retries next tick once the chart lands.
+	h.reconcileGlobalSeed(ctx,
+		"newapi-admin-token",
+		newapiAdminTokenSeedMountPath, newapiAdminTokenSeedSecretPath,
+		[]string{newapiAdminTokenSeedKVProperty},
+		func() { _ = h.seedNewapiAdminToken(ctx) },
+	)
+
+	// (2) anthropic token — Sovereign-GLOBAL. Seed only when the path lacks a
+	// non-empty apiKey AND credentialsJson. seedAnthropicToken loud-skips when
+	// the founder cred env is unset, so on a credless Sovereign the path stays
+	// absent and the loop keeps (usefully) surfacing that gap.
+	h.reconcileGlobalSeed(ctx,
+		"anthropic",
+		anthropicSeedMountPath, anthropicSeedSecretPath,
+		[]string{"apiKey", "credentialsJson"},
+		func() { _ = h.seedAnthropicToken(ctx) },
+	)
+
+	// (3) per-Org mcp-bearer. Enumerate every Organization CR (the single
+	// source of truth both the BSS door and the marketplace funnel write) and
+	// self-heal each Org's per-slug bearer path. Global seeds above already
+	// ran, so a list failure here never starves them.
+	orgs, err := h.orgResponsesFromCRs(ctx)
+	if err != nil {
+		if h.log != nil {
+			h.log.Warn("[SEED-RECONCILE] list Organizations failed; per-Org mcp-bearer self-heal skipped this pass — retry next tick",
+				"err", err)
+		}
+		return
+	}
+	healed := 0
+	for i := range orgs {
+		slug := strings.TrimSpace(orgs[i].Subdomain)
+		if slug == "" {
+			continue
+		}
+		present, perr := h.openbaoPathHasProperty(ctx,
+			mcpBearerMountPath, mcpBearerSecretPath(slug), mcpBearerKVBearerProperty)
+		if perr != nil {
+			if h.log != nil {
+				h.log.Warn("[SEED-RECONCILE] mcp-bearer presence check failed; skipping Org this pass",
+					"slug", slug, "err", perr)
+			}
+			continue
+		}
+		if present {
+			continue // healthy — no churn.
+		}
+		if h.log != nil {
+			h.log.Info("[SEED-RECONCILE] mcp-bearer OpenBao path absent for Org — self-healing (#4877)",
+				"slug", slug)
+		}
+		if out := h.seedMCPBearer(ctx, slug, orgs[i].AdminEmail); out == MCPBearerSeedOutcomeSeeded {
+			healed++
+		}
+	}
+	if healed > 0 && h.log != nil {
+		h.log.Info("[SEED-RECONCILE] per-Org mcp-bearer self-heal complete",
+			"orgs", len(orgs), "healed", healed)
+	}
+}
+
+// reconcileGlobalSeed checks one Sovereign-global OpenBao path and invokes its
+// producing seed only when the path is absent / its expected property empty.
+// A transport error on the read is logged and the seed is skipped this pass (an
+// OpenBao blip would fail the write too) — the next tick retries.
+func (h *Handler) reconcileGlobalSeed(ctx context.Context, label, mount, path string, props []string, seed func()) {
+	present, err := h.openbaoPathHasProperty(ctx, mount, path, props...)
+	if err != nil {
+		if h.log != nil {
+			h.log.Warn("[SEED-RECONCILE] presence check failed; skipping this pass — retry next tick",
+				"seed", label, "err", err)
+		}
+		return
+	}
+	if present {
+		return // healthy — no churn.
+	}
+	if h.log != nil {
+		h.log.Info("[SEED-RECONCILE] OpenBao path absent — self-healing (#4877)",
+			"seed", label, "openbaoPath", mount+"/"+path)
+	}
+	seed()
+}
+
+// openbaoPathHasProperty reports whether the KV-v2 path exists AND at least one
+// of the named properties holds a non-empty string.
+//
+//   - NotFound / empty body  → (false, nil): the #4877 gap ("never written") —
+//     the caller seeds.
+//   - present, a prop non-empty → (true, nil): healthy — the caller no-ops.
+//   - present, all props empty  → (false, nil): a hollow / empty-seeded path —
+//     the caller re-seeds to fill it.
+//   - transport error           → (false, err): the caller skips this pass and
+//     retries next tick (a write would fail against the same blip).
+func (h *Handler) openbaoPathHasProperty(ctx context.Context, mount, path string, props ...string) (bool, error) {
+	data, err := h.openbao.GetKVv2(ctx, mount, path)
+	if err != nil {
+		if errors.Is(err, openbao.ErrSecretNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	for _, p := range props {
+		if s, ok := data[p].(string); ok && strings.TrimSpace(s) != "" {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_seed_reconciler_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_seed_reconciler_test.go
@@ -1,0 +1,216 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/openbao"
+)
+
+// rwKVServer is a fake OpenBao KV-v2 backend that answers BOTH the GET
+// (read-before-write existence check) and the PUT (seed write) the #4877
+// reconciler issues. GETs resolve from a canned map keyed by KV data-path
+// ("catalyst/anthropic/token", …); an absent key returns 404 so
+// openbaoPathHasProperty reports the #4877 gap. Every PUT is recorded so a test
+// can assert exactly which paths the reconciler (re)seeded — and, crucially,
+// that a healthy path is NEVER re-written (no churn).
+type rwKVServer struct {
+	mu       sync.Mutex
+	present  map[string]map[string]any // data-path → KV data (what a GET returns)
+	putPaths []string                  // KV data-paths that received a PUT
+	srv      *httptest.Server
+}
+
+func newRWKVServer(t *testing.T) *rwKVServer {
+	t.Helper()
+	s := &rwKVServer{present: map[string]map[string]any{}}
+	s.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// KV-v2 data URL: /v1/<mount>/data/<secretPath>.
+		const marker = "/data/"
+		idx := strings.Index(r.URL.Path, marker)
+		dataPath := ""
+		if idx >= 0 {
+			dataPath = r.URL.Path[idx+len(marker):]
+		}
+		switch r.Method {
+		case http.MethodGet:
+			s.mu.Lock()
+			data, ok := s.present[dataPath]
+			s.mu.Unlock()
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"errors":[]}`))
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"data": data}})
+		case http.MethodPut, http.MethodPost:
+			body, _ := io.ReadAll(r.Body)
+			var parsed struct {
+				Data map[string]any `json:"data"`
+			}
+			_ = json.Unmarshal(body, &parsed)
+			s.mu.Lock()
+			s.putPaths = append(s.putPaths, dataPath)
+			// A written path becomes present for any subsequent GET.
+			s.present[dataPath] = parsed.Data
+			s.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{"version":1}}`))
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	t.Cleanup(s.srv.Close)
+	return s
+}
+
+func (s *rwKVServer) seedPresent(dataPath string, data map[string]any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.present[dataPath] = data
+}
+
+func (s *rwKVServer) writes() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.putPaths))
+	copy(out, s.putPaths)
+	return out
+}
+
+func (s *rwKVServer) client() *openbao.Client {
+	return &openbao.Client{Addr: s.srv.URL, Token: "test-token", HTTP: s.srv.Client()}
+}
+
+// Test_openbaoPathHasProperty covers the read-before-write existence check:
+// absent path → false, present-with-value → true, present-but-empty → false.
+func Test_openbaoPathHasProperty(t *testing.T) {
+	srv := newRWKVServer(t)
+	srv.seedPresent("catalyst/anthropic/token", map[string]any{"apiKey": "sk-ant-x", "credentialsJson": ""})
+	srv.seedPresent("catalyst/agenity/hollow/mcp-bearer", map[string]any{"bearer": "  "})
+
+	h := &Handler{log: silentLogger()}
+	h.openbao = srv.client()
+	ctx := context.Background()
+
+	// Present with a non-empty property.
+	if ok, err := h.openbaoPathHasProperty(ctx, "secret", "catalyst/anthropic/token", "apiKey", "credentialsJson"); err != nil || !ok {
+		t.Errorf("anthropic present: got (%v,%v), want (true,nil)", ok, err)
+	}
+	// Absent path.
+	if ok, err := h.openbaoPathHasProperty(ctx, "secret", "catalyst/newapi/admin-token", "ADMIN_API_TOKEN"); err != nil || ok {
+		t.Errorf("newapi absent: got (%v,%v), want (false,nil)", ok, err)
+	}
+	// Present but the only property is whitespace → treated as empty (re-seed).
+	if ok, err := h.openbaoPathHasProperty(ctx, "secret", "catalyst/agenity/hollow/mcp-bearer", "bearer"); err != nil || ok {
+		t.Errorf("hollow bearer: got (%v,%v), want (false,nil)", ok, err)
+	}
+}
+
+// Test_runSeedReconcilePass_NoChurnWhenAllPresent is the safety guarantee: when
+// every global path already holds a valid value, the pass issues ZERO PUTs — a
+// healthy Sovereign is never re-written (no OpenBao version churn, no downstream
+// Secret/pod churn). The per-Org leg is a no-op here (no dynamic client → zero
+// Orgs), which is asserted implicitly by the total write count being 0.
+func Test_runSeedReconcilePass_NoChurnWhenAllPresent(t *testing.T) {
+	srv := newRWKVServer(t)
+	srv.seedPresent("catalyst/newapi/admin-token", map[string]any{"ADMIN_API_TOKEN": "bridge-secret"})
+	srv.seedPresent("catalyst/anthropic/token", map[string]any{"apiKey": "sk-ant-x", "credentialsJson": ""})
+
+	h := &Handler{log: silentLogger()}
+	h.openbao = srv.client()
+
+	h.runSeedReconcilePass(context.Background())
+
+	if got := srv.writes(); len(got) != 0 {
+		t.Fatalf("expected ZERO writes on an all-present pass (no churn), got %v", got)
+	}
+}
+
+// Test_runSeedReconcilePass_SelfHealsAbsentGlobalSeed proves the #4877 fix: an
+// absent global path IS re-seeded. Anthropic is the cleanly-unit-testable
+// global seed (its value is env-sourced, no in-cluster Secret read), so we
+// assert it gets written exactly once when its path is absent.
+func Test_runSeedReconcilePass_SelfHealsAbsentGlobalSeed(t *testing.T) {
+	srv := newRWKVServer(t)
+	// newapi path present (so that seed no-ops and can't reach rest.InClusterConfig);
+	// anthropic path deliberately ABSENT → must self-heal.
+	srv.seedPresent("catalyst/newapi/admin-token", map[string]any{"ADMIN_API_TOKEN": "bridge-secret"})
+
+	h := &Handler{log: silentLogger()}
+	h.openbao = srv.client()
+	t.Setenv(anthropicSeedAPIKeyEnv, "sk-ant-selfheal")
+	t.Setenv(anthropicSeedCredentialsJSONEnv, "")
+
+	h.runSeedReconcilePass(context.Background())
+
+	writes := srv.writes()
+	found := false
+	for _, p := range writes {
+		if p == "catalyst/anthropic/token" {
+			found = true
+		}
+		if p == "catalyst/newapi/admin-token" {
+			t.Errorf("newapi path was present but got re-written (churn): %v", writes)
+		}
+	}
+	if !found {
+		t.Fatalf("expected a self-heal write to catalyst/anthropic/token, got writes=%v", writes)
+	}
+}
+
+// Test_runSeedReconcilePass_PerOrgMCPBearerSelfHeal proves the per-Org
+// enumeration: the reconciler lists every Organization CR (orgResponsesFromCRs)
+// and self-heals the absent per-slug mcp-bearer path for each — while leaving an
+// Org whose bearer already exists untouched (no churn).
+func Test_runSeedReconcilePass_PerOrgMCPBearerSelfHeal(t *testing.T) {
+	// Two funnel Orgs (parentDomain set → both carry a pool console host).
+	h, _ := newOrgHandlerWithSeededCRs(t,
+		orgReadyCR("acme", "Acme", "omani.homes", "owner@acme.omani.homes", "Ready"),
+		orgReadyCR("globex", "Globex", "omani.homes", "owner@globex.omani.homes", "Ready"),
+	)
+	srv := newRWKVServer(t)
+	h.openbao = srv.client()
+	h.handoverSigner = newTestSigner(t)
+	// Make the two GLOBAL paths present so this test isolates the per-Org leg.
+	srv.seedPresent("catalyst/newapi/admin-token", map[string]any{"ADMIN_API_TOKEN": "bridge-secret"})
+	srv.seedPresent("catalyst/anthropic/token", map[string]any{"apiKey": "sk-ant-x"})
+	// globex ALREADY has a healthy bearer → must NOT be re-written; acme is absent.
+	srv.seedPresent("catalyst/agenity/globex/mcp-bearer", map[string]any{"bearer": "existing-bearer"})
+
+	h.runSeedReconcilePass(context.Background())
+
+	writes := srv.writes()
+	wantAcme := "catalyst/agenity/acme/mcp-bearer"
+	dontWantGlobex := "catalyst/agenity/globex/mcp-bearer"
+	sawAcme := false
+	for _, p := range writes {
+		if p == wantAcme {
+			sawAcme = true
+		}
+		if p == dontWantGlobex {
+			t.Errorf("globex bearer was present but got re-written (churn): %v", writes)
+		}
+	}
+	if !sawAcme {
+		t.Fatalf("expected a self-heal write to %s, got writes=%v", wantAcme, writes)
+	}
+}
+
+// Test_StartSovereignSeedReconciler_DormantWhenNoOpenBao verifies the
+// orchestrator guard: nil OpenBao client ⇒ the reconciler stays dormant and
+// runSeedReconcilePass is a no-op (no panic, no write attempt).
+func Test_StartSovereignSeedReconciler_DormantWhenNoOpenBao(t *testing.T) {
+	h := &Handler{log: silentLogger()}
+	// h.openbao deliberately nil.
+	h.StartSovereignSeedReconciler(context.Background()) // must return immediately, no panic.
+	h.runSeedReconcilePass(context.Background())          // must no-op, no panic.
+}


### PR DESCRIPTION
## Defect (#4877)

catalyst-api's three OpenBao seed seams — `seedNewapiAdminToken`, `seedAnthropicToken`, `seedMCPBearer` — are each called from **exactly one place**: `runOrganizationPipeline` (`organization_provisioning.go`, Step 1), **once per HTTP Org-create, with no retry and no reconcile**.

If that single write misses — catalyst-api OOM mid-pipeline (#4811), or a prereq (NewAPI bridge Secret / Anthropic env cred / handover signer) not yet reflected at that instant — the OpenBao paths

- `secret/catalyst/newapi/admin-token`
- `secret/catalyst/anthropic/token`
- `secret/catalyst/agenity/<slug>/mcp-bearer`

are **never written**, and the ExternalSecrets that read them stay `READY=False` / `SecretSyncedError` **forever** (unified-RBAC 401s; the agenity agent never receives its Anthropic cred or its Catalyst MCP bearer). Nothing re-fires the producer because the Org is already "created".

## Fix

New `StartSovereignSeedReconciler` (`internal/handler/sovereign_seed_reconciler.go`), wired from `main.go` after `SetOpenBao` / `SetHandoverSigner` / `SetOrganizationDeps`:

- **Re-runs the seeds on catalyst-api startup + a periodic tick** so a missed write self-heals. Startup is the primary recovery path (after the OOM that dropped the write, the Pod restarts and the startup pass immediately re-seeds every absent path); the periodic loop (default 10m, env-overridable) catches a prereq that lands later.
- **Read-before-write** (`GetKVv2`): a path is (re)seeded **only when it is absent or its expected property is empty** — i.e. exactly the #4877 gap. A healthy path is a true no-op (zero writes, zero log noise). This matters because `seedMCPBearer` mints a fresh bearer (new `jti`/`exp`) on every call — a blind re-seed would churn the OpenBao value → ExternalSecret → per-Org agenity Secret every tick. The minted bearer is 1-year TTL and env-projected into the agenity StatefulSet (no hot-reload, no reloader on the chart), so a healthy bearer never needs refreshing between reconciles.
- **Global vs per-Org scope**: `newapi-admin-token` + `anthropic` are Sovereign-global (one path each) → checked once per pass. `mcp-bearer` is per-Org → the reconciler enumerates Organizations via the **existing `orgResponsesFromCRs`** (list every `orgs.openova.io` CR — the single source of truth both the BSS door and the marketplace funnel write, same enumeration the console directory + tenant-registry reconcile use) and self-heals each Org's per-slug path.
- **Idempotent + non-fatal**: every seed already folds its own failures to a logged skip; the pass is additionally `recover`-guarded so a self-heal attempt can never crash catalyst-api. **Dormant** on the orchestrator (nil OpenBao) and behind the `CATALYST_SEED_RECONCILER_ENABLED=false` kill switch.

## Tests

`sovereign_seed_reconciler_test.go`:
- `Test_openbaoPathHasProperty` — absent → seed, present-with-value → skip, present-but-whitespace → re-seed.
- `Test_runSeedReconcilePass_NoChurnWhenAllPresent` — all paths present ⇒ **zero PUTs** (the no-churn safety guarantee).
- `Test_runSeedReconcilePass_SelfHealsAbsentGlobalSeed` — absent anthropic path ⇒ one self-heal write; present newapi path untouched.
- `Test_runSeedReconcilePass_PerOrgMCPBearerSelfHeal` — two Org CRs: the Org with an absent bearer is seeded, the Org with an existing bearer is left untouched.
- `Test_StartSovereignSeedReconciler_DormantWhenNoOpenBao` — nil OpenBao ⇒ dormant, no panic.

`go build ./...` + `go vet ./...` clean; full `go test ./internal/handler/` green (151s). No chart bump — deploybot's "Build & Deploy Catalyst" builds catalyst-api from `products/catalyst/bootstrap/api` on merge (consistent with recent catalyst-api-only PRs #4866/#4862/#4839/#4831, none of which bumped a chart).

Refs #4877

🤖 Generated with [Claude Code](https://claude.com/claude-code)