### PR TITLE
fix(#4886): surface live Continuum DR state on Topology tab for bootstrap-HR apps

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras.go
@@ -889,10 +889,27 @@ func enrichReplicationStatus(cr *unstructured.Unstructured) continuumReplication
 	}
 	out.PrimaryRegion, _, _ = unstructured.NestedString(cr.Object, "spec", "primaryRegion")
 	out.CurrentPrimary, _, _ = unstructured.NestedString(cr.Object, "status", "currentPrimary")
+	// #4886 — the Continuum controller records the ACTIVE region as the
+	// witness-lease holder in `status.leaseHolder`, NOT `status.currentPrimary`
+	// (that field is CNPGPair-derived and only present when a cnpg pair backs
+	// the app). Prefer leaseHolder so the DR panel's active region is correct
+	// for the spine continuums (openbao raft, keycloak/gitea/harbor) and stays
+	// correct after a switchover flips the lease off the original primaryRegion.
+	if leaseHolder, _, _ := unstructured.NestedString(cr.Object, "status", "leaseHolder"); leaseHolder != "" {
+		out.CurrentPrimary = leaseHolder
+	}
 	if out.CurrentPrimary == "" {
 		out.CurrentPrimary = out.PrimaryRegion
 	}
 	out.WALLagSeconds = readNumericNested(cr.Object, "status", "walLagSeconds")
+	// #4886 — the Continuum controller writes the numeric lag as
+	// `status.replicationLagSeconds` (int64); `walLagSeconds` is the
+	// CNPGPair-only spelling. Fall back to replicationLagSeconds so the spine
+	// continuums surface their real lag instead of a hardcoded 0. (A linked
+	// CNPGPair reading, when present, still overrides this in the caller.)
+	if out.WALLagSeconds == 0 {
+		out.WALLagSeconds = readNumericNested(cr.Object, "status", "replicationLagSeconds")
+	}
 	out.WALLagBytes = int64(readNumericNested(cr.Object, "status", "walLagBytes"))
 	if streaming, _, _ := unstructured.NestedString(cr.Object, "status", "streamingState"); streaming != "" {
 		out.StreamingState = streaming

--- a/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras_4551_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras_4551_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	bpv1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
 )
@@ -145,6 +146,67 @@ func TestReplicationStatus_NoLivePairSingleRegionFallsBack(t *testing.T) {
 	// "live").
 	if resp.Source != "synthesized" {
 		t.Errorf("source: got %q want synthesized (no real cross-region pair)", resp.Source)
+	}
+}
+
+// #4886 — the Continuum controller records the ACTIVE region as
+// `status.leaseHolder` and the lag as `status.replicationLagSeconds` (NOT the
+// CNPGPair-only `status.currentPrimary` / `status.walLagSeconds`). The spine
+// continuums (openbao raft, keycloak/gitea/harbor) carry no cnpgPair link, so
+// the replication-status endpoint must read those continuum-level fields
+// directly — otherwise the panel shows the wrong active region (after a
+// switchover) and a hardcoded 0 lag. Fixture: a spine Continuum whose lease has
+// flipped to region-b (leaseHolder != spec.primaryRegion) with a 7s lag.
+func TestReplicationStatus_ReadsLeaseHolderAndReplicationLagSeconds(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured(
+		"dr-spine-openbao", "openbao", "openbao",
+		"me-east-215-a", []string{"me-east-215-b"})
+	// Lease has flipped to region-b (a switchover); the numeric lag lives in
+	// status.replicationLagSeconds (int64), the continuum-controller spelling.
+	_ = unstructured.SetNestedField(cr.Object, "me-east-215-b", "status", "leaseHolder")
+	_ = unstructured.SetNestedField(cr.Object, int64(7), "status", "replicationLagSeconds")
+	factory, _ := fakeContinuumDynamicFactory(cr)
+	h.dynamicFactory = factory
+	fixed := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	h.SetContinuumClock(func() time.Time { return fixed })
+	dep := installUserAccessDeployment(t, h, "dep-repl-leaseholder")
+
+	r := chi.NewRouter()
+	registerReplicationStatusRoute(r, h)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/continuum/dr-spine-openbao/replication-status?namespace=openbao", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp continuumReplicationStatus
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Source != "live" {
+		t.Errorf("source: got %q want live", resp.Source)
+	}
+	// Active region = leaseHolder (region-b after the switchover), NOT the
+	// static spec.primaryRegion.
+	if resp.CurrentPrimary != "me-east-215-b" {
+		t.Errorf("currentPrimary: got %q want me-east-215-b (=status.leaseHolder)", resp.CurrentPrimary)
+	}
+	// Numeric lag from status.replicationLagSeconds.
+	if resp.WALLagSeconds != 7 {
+		t.Errorf("walLagSeconds: got %v want 7 (=status.replicationLagSeconds)", resp.WALLagSeconds)
+	}
+	// The standby region surfaces so the panel can render the standby card.
+	foundStandby := false
+	for _, rep := range resp.Replicas {
+		if rep.Region == "me-east-215-b" {
+			foundStandby = true
+		}
+	}
+	if !foundStandby {
+		t.Errorf("replicas: missing standby me-east-215-b; got %+v", resp.Replicas)
 	}
 }
 

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.test.tsx
@@ -418,3 +418,104 @@ describe('TopologyTab — DR / replication surface (#3375 rows 51/52/56/57)', ()
     expect(screen.queryByTestId('topology-tab-dr-lag-value')).toBeNull()
   })
 })
+
+describe('TopologyTab — #4886 bootstrap-HR DR off the live Continuum CR', () => {
+  // spine-keycloak/gitea/harbor/openbao + cnpg-pair: Continuum-backed bootstrap
+  // HelmReleases with NO Application CR. Their Pods run active-active across
+  // both regions, so the placement projection labels BOTH regions Primary and
+  // hasStandby is false — yet the live continuum carries the real active
+  // (leaseHolder) + standby + replicationLagSeconds. The DR section must render
+  // off that live status instead of vanishing.
+  const activeActivePlacement = {
+    targets: [
+      { region: 'me-east-215-a', cluster: 'dep-x', vcluster: 'mgmt', role: 'Primary' },
+      { region: 'me-east-215-b', cluster: 'dep-x-b', vcluster: 'mgmt', role: 'Primary' },
+    ],
+    derivedFromRuntime: true,
+  }
+
+  it('renders the DR section for a bootstrap-HR app off the LIVE continuum (active region=leaseHolder, standby, numeric lag)', async () => {
+    getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
+    getApplicationPlacement.mockResolvedValue(activeActivePlacement)
+    getContinuumReplicationStatus.mockResolvedValue({
+      continuum: 'dr-spine-keycloak',
+      namespace: 'keycloak',
+      primaryRegion: 'me-east-215-a',
+      // active region = the witness-lease holder (surfaced as currentPrimary).
+      currentPrimary: 'me-east-215-a',
+      walLagSeconds: 0,
+      replicas: [{ region: 'me-east-215-b', role: 'replica', lagSeconds: 0 }],
+      streamingState: 'streaming',
+      source: 'live',
+    })
+
+    render(
+      withProviders(
+        <TopologyTab
+          sovereignId="dep-x"
+          applicationName="spine-keycloak"
+          namespace="flux-system"
+          isBootstrap
+        />,
+      ),
+    )
+
+    // Bootstrap components query with EMPTY namespace so the cluster-wide lookup
+    // finds the CR in the spine's namespace (not the flux-system HR ns).
+    await waitFor(() => {
+      expect(getContinuumReplicationStatus).toHaveBeenCalledWith('dep-x', 'dr-spine-keycloak', {
+        namespace: undefined,
+      })
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-dr-panel')).toBeTruthy()
+    })
+    // Active region = leaseHolder; standby is the OTHER region — NOT a second
+    // "PRIMARY / serves writes" card.
+    expect(screen.getByTestId('topology-tab-dr-primary').textContent).toContain('me-east-215-a')
+    expect(screen.getByTestId('topology-tab-dr-standby').textContent).toContain('me-east-215-b')
+    // Numeric replication lag in seconds (row 56/64) — never a bare dash.
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-dr-lag-value').textContent).toContain('0.0 s')
+    })
+    expect(screen.getByTestId('topology-tab-dr-source').textContent).toContain('live')
+    // The Status panel's honest "n/a — bootstrap component" note is unaffected.
+    expect(screen.getByTestId('topology-tab-status-bootstrap')).toBeTruthy()
+  })
+
+  it('does NOT render DR for a SINGLETON bootstrap app (synthesized fallback is never passed off as live)', async () => {
+    getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
+    getApplicationPlacement.mockResolvedValue({
+      targets: [{ region: 'me-east-215-a', cluster: 'dep-x', vcluster: 'mgmt', role: 'Primary' }],
+      derivedFromRuntime: true,
+    })
+    // The endpoint returns a synthesized shape (source:"synthesized") when no
+    // live Continuum/cnpg-pair backs the app — the DR section must stay hidden.
+    getContinuumReplicationStatus.mockResolvedValue({
+      continuum: 'dr-cert-manager',
+      namespace: 'cert-manager',
+      primaryRegion: 'hz-fsn-rtz-prod',
+      currentPrimary: 'hz-fsn-rtz-prod',
+      walLagSeconds: 2.0,
+      replicas: [{ region: 'hz-hel-rtz-prod', role: 'replica' }],
+      source: 'synthesized',
+    })
+
+    render(
+      withProviders(
+        <TopologyTab
+          sovereignId="dep-x"
+          applicationName="cert-manager"
+          namespace="flux-system"
+          isBootstrap
+        />,
+      ),
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-status-bootstrap')).toBeTruthy()
+    })
+    expect(screen.queryByTestId('topology-tab-dr-panel')).toBeNull()
+    expect(screen.queryByTestId('topology-tab-dr-switchover')).toBeNull()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
@@ -226,14 +226,25 @@ export function TopologyTab({
   )
   const continuumName = useMemo(() => `dr-${applicationName}`, [applicationName])
 
-  // Only poll the DR endpoint for genuinely multi-region apps. A 404 (no
-  // Continuum CR for this app) does NOT retry and leaves drStatus
-  // undefined → the section renders the calm "no cross-region replica"
-  // note rather than a fabricated lag.
+  // Poll the DR endpoint for genuinely multi-region apps. Two entry points:
+  //   • App-CR apps with a Standby placement target (hasStandby, the #3375 path).
+  //   • #4886 — Continuum-backed BOOTSTRAP-HR apps (spine-keycloak/gitea/harbor/
+  //     openbao, cnpg-pair). These have NO Application CR and their Pods run
+  //     active-active across both regions, so the placement projection can't
+  //     advertise a Standby target → hasStandby is false even though the live
+  //     `continuums.dr.openova.io` CR carries the real active/standby + lag.
+  //     We poll for them too and gate rendering on a live cross-region result
+  //     (source:"live" + a distinct standby region) so a singleton bootstrap
+  //     component never fabricates DR off the synthesized fallback.
+  // A 404 (no Continuum CR) does NOT retry and leaves drStatus undefined.
+  // Bootstrap components query with an EMPTY namespace so the cluster-wide
+  // lookup finds the CR in its own namespace (the HR lives in flux-system, the
+  // Continuum in the spine's namespace) — mirrors the #4000 placement rule.
+  const drNamespace = isBootstrap ? undefined : namespace
   const drQ = useQuery({
-    queryKey: ['continuum-replication-status', sovereignId, continuumName, namespace, refreshTick],
-    queryFn: () => getContinuumReplicationStatus(sovereignId, continuumName, { namespace }),
-    enabled: !disableNetwork && hasStandby && !!sovereignId && !!applicationName,
+    queryKey: ['continuum-replication-status', sovereignId, continuumName, drNamespace, refreshTick],
+    queryFn: () => getContinuumReplicationStatus(sovereignId, continuumName, { namespace: drNamespace }),
+    enabled: !disableNetwork && (hasStandby || isBootstrap) && !!sovereignId && !!applicationName,
     refetchInterval: 30_000,
     retry: false,
   })
@@ -270,6 +281,22 @@ export function TopologyTab({
     [drStatus],
   )
   const lagColor: LagBucket = useMemo(() => lagBucket(lagSeconds), [lagSeconds])
+
+  // #4886 — the DR section renders for App-CR apps with a Standby placement
+  // target (the existing #3375 hasStandby path) AND for bootstrap-HR apps whose
+  // LIVE continuum status confirms a genuine cross-region pair: source:"live"
+  // plus a standby region distinct from the active/lease-holder region. A
+  // singleton bootstrap component (no live continuum → synthesized fallback, or
+  // a same-region echo) never renders DR, so we never arm a phantom region.
+  const liveStandbyRegion = useMemo(
+    () =>
+      drStatus?.replicas?.find(
+        (rep) => rep.role !== 'primary' && !!rep.region && rep.region !== drPrimaryRegion,
+      )?.region || '',
+    [drStatus, drPrimaryRegion],
+  )
+  const bootstrapHasLiveDR = isBootstrap && drStatus?.source === 'live' && !!liveStandbyRegion
+  const showDR = hasStandby || bootstrapHasLiveDR
 
   // Owned dependencies that cascade — read from spec.placement.ownedDependencies
   // when present (override state); the names also come from the blueprint's
@@ -464,8 +491,9 @@ export function TopologyTab({
           READ-ONLY cross-region DR telemetry. Rendered ONLY for apps whose
           placement carries a Standby target (a live cross-region replica);
           honestly absent for singletons so we never arm a DR block against
-          a phantom region (row 58). */}
-      {hasStandby ? (
+          a phantom region (row 58). #4886 also renders it for Continuum-backed
+          bootstrap-HR apps off the live continuum status. */}
+      {showDR ? (
         <section
           className="mt-4 rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] p-4"
           data-testid="topology-tab-dr-panel"
@@ -546,7 +574,9 @@ export function TopologyTab({
                       Standby region
                     </div>
                     <div className="mt-0.5 font-mono text-xs font-semibold text-yellow-400">
-                      {drStatus?.replicas?.find((rep) => rep.role !== 'primary')?.region || '—'}
+                      {liveStandbyRegion ||
+                        drStatus?.replicas?.find((rep) => rep.role !== 'primary')?.region ||
+                        '—'}
                     </div>
                     <div className="text-[10px] text-[var(--color-text-dim)]">
                       {drStatus?.streamingState || 'hot replica (follows WAL)'}


### PR DESCRIPTION
## Problem (hw232 UAT rows 51/52/56/62/64)

The per-app **Topology tab DR section** never surfaced live Continuum DR state for Continuum-backed **bootstrap-HelmRelease** apps (`spine-keycloak/gitea/harbor/openbao`, `cnpg-pair`). For those apps it rendered both regions as `● PRIMARY / serves writes`, a bare `──▶ repl` arrow with no numeric lag, and DR Status `n/a — bootstrap component` — even though the live `continuums.dr.openova.io` CRs were all Healthy (`leaseHolder`, `replicationLagSeconds=0`, LeaseHeld/Ready) and the Reconciliation lens showed Continuum 5/5.

## Root cause

The DR section only rendered when the placement projection advertised a **Standby** target (`hasStandby`). These spine apps have **no Application CR** and run **active-active at the workload level**, so pod-occupancy labels **both** regions `Primary`. #4551's `continuumStandbyRegion` then suppresses the legitimate standby as a same-region echo → `hasStandby` stays false → the DR section vanishes. The authoritative active/standby + lag lived on the Continuum CR the whole time.

Two supporting gaps: the replication-status backend read the **CNPGPair-only** `status.currentPrimary` / `status.walLagSeconds`, but the Continuum controller writes the active region + lag as `status.leaseHolder` / `status.replicationLagSeconds` (the spine continuums carry no `cnpgPair` link) → even a resolved CR returned a fallback primary and a hardcoded 0 lag.

## Fix

**Frontend** (`TopologyTab.tsx`): poll the replication-status endpoint for bootstrap apps too (keyed `dr-<app>`, **empty namespace** so the cluster-wide lookup finds the CR in the spine's own namespace — mirrors the #4000 placement rule), and render the DR section when the result is **genuinely live** (`source:"live"` + a standby region distinct from the active/lease-holder region). A singleton bootstrap app (synthesized fallback) still honestly hides DR — no fabricated region. **The App-CR path is unchanged; singleton apps still hide DR.**

**Backend** (`enrichReplicationStatus`): prefer `status.leaseHolder` for the active region (so a switchover that flips the lease is reflected correctly) and fall back to `status.replicationLagSeconds` for the numeric lag when `walLagSeconds` is absent. A linked CNPGPair reading, when present, still overrides — no App-CR regression.

## Keying continuum → app

Unchanged from #4551's 3-tier resolution: CR name `dr-<app>` (direct — e.g. `spine-keycloak` → `dr-spine-keycloak`) → `spec.applicationRef` → live cnpg-pair derivation. The frontend just stops gating the render on the placement-derived `hasStandby` for bootstrap apps and trusts the authoritative continuum status instead.

## Tests

- **UI** (`TopologyTab.test.tsx`, +2): a bootstrap-HR app with a live continuum renders active(=leaseHolder)/standby/numeric-lag off `source:"live"`; a singleton bootstrap app (synthesized) renders **no** DR panel. `vitest` 15/15 green, `tsc -b --noEmit` clean.
- **API** (`continuum_dr_extras_4551_test.go`, +1): `replication-status` reads `status.leaseHolder` (active region after a switchover) + `status.replicationLagSeconds`. `go build ./...` + `go test ./internal/handler/` green.

Refs #4886 #4551 #932 #3986 #3375

🤖 Generated with [Claude Code](https://claude.com/claude-code)