### PR TITLE
fix(#4885): step-07 multi-HR imageRegistry pivot + couple auto-trigger to fireCutoverOnHandover

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -719,7 +719,18 @@ spec:
       # node-local `GET http://127.0.0.1:4001/v2/` serving probe so catalyst-api's
       # daemonset-wait cannot green (→ step-07 catalyst-api re-pull) while the
       # dfdaemon mirror has 0 Ready pods (#4649 condition → connection-refused).
-      version: 0.1.105
+      # 0.1.106 (#4885 Refs #3379 #4061): (D3) step-07 now pivots a CURATED set of
+      # ADDITIONAL openova-io HRs (imageRegistryPivot.additionalHRs, default
+      # [bp-continuum]) whose chart honours global.imageRegistry — the 2-HR
+      # hard-code left ~6 workloads on ghcr.io that 401'd under the step-08
+      # deny-egress hold (cutoverComplete never set, hw232). (D1) the auto-trigger
+      # hook is now gated on trigger.fireCutoverOnHandover (wired from
+      # ${FIRE_CUTOVER_ON_HANDOVER:-false} below) so an operator's
+      # fireCutoverOnHandover=false suppresses the auto-fire, consistent with the
+      # catalyst-api reconciler (#4061). Charts that don't honour
+      # global.imageRegistry (bp-guacamole/bp-huawei-evs-csi/bp-newapi/bp-sandbox/
+      # org-services) are excluded pending a per-chart templating fix (#4885).
+      version: 0.1.106
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover
@@ -855,3 +866,19 @@ spec:
     # picks it up at HelmRelease apply time.
     upstream:
       harborProxyMirrorEndpoint: "${HARBOR_PROXY_MIRROR_ENDPOINT:=}"
+    # #4885 Defect 1 (Refs #3379 #4061): couple the chart's auto-trigger hook to
+    # the operator's fireCutoverOnHandover gate. Before this, the auto-trigger
+    # hook Job rendered whenever trigger.auto=true (chart default) and POSTed
+    # /api/v1/internal/cutover/trigger — a path gated ONLY by the handover-seal
+    # 425, NOT by the operator flag — so an operator setting
+    # fireCutoverOnHandover=false (honoured by the catalyst-api reconciler,
+    # `[CUTOVER-RECONCILE] dormant: fireCutoverOnHandover=false`, #4061) STILL
+    # got an auto-fired cutover. We wire trigger.fireCutoverOnHandover from the
+    # SAME ${FIRE_CUTOVER_ON_HANDOVER:-false} Flux postBuild substitution the
+    # catalyst-api reads (13-bp-catalyst-platform.yaml catalystApi.
+    # fireCutoverOnHandover ← cloud-init FIRE_CUTOVER_ON_HANDOVER), so the hook
+    # renders (auto-fires) ONLY on a Sovereign the operator opted in to
+    # fire-on-handover. Default false → the cutover fires via the BSS CTA (or the
+    # #4669 level-triggered reconciler once the operator flips the flag).
+    trigger:
+      fireCutoverOnHandover: ${FIRE_CUTOVER_ON_HANDOVER:-false}

--- a/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
+++ b/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
@@ -181,6 +181,22 @@ spec:
   # + nats.openova-system.svc.cluster.local respectively). Per-
   # Sovereign overlays may repoint at Sovereign-local instances.
   values:
+    # #4885 (Refs #3379): imageRegistry override seam — same pattern as
+    # slot 13 bp-catalyst-platform + slot 56 bp-openova-flow-server. Empty
+    # literal default at Phase 1 (pre-cutover) → the chart helper's
+    # `{{ if ne (.Values.global.imageRegistry | default "") "" }}` (continuum
+    # templates/_helpers.tpl `continuum.image`) falls back to the literal
+    # ghcr.io repository. Cutover step-07 (#4885, via
+    # .Values.imageRegistryPivot.additionalHRs) patches this HR's
+    # spec.values.global.imageRegistry live AND durably edits THIS file in
+    # local Gitea, replacing the empty string with the local Harbor host so
+    # continuum-controller pulls registry.<sov-fqdn>/openova-io/openova/
+    # continuum-controller under the deny-egress hold (image native-pushed by
+    # cutover step-03). Without this seam the live HR patch is reverted by the
+    # next Flux Kustomization reconcile. 6-space indent on `imageRegistry:` is
+    # REQUIRED — step-07's sed matches `^      imageRegistry:`.
+    global:
+      imageRegistry: ''
     continuum:
       enabled: ${CONTINUUM_ENABLED:-false}
       # ── harbor-proxy-pull compliance (#3195) ──────────────────────────

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.105
+  version: 0.1.106
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,35 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.106 (#4885 Refs #3379 #4563 #4061, hw232 live-walk: cutover wedged at
+# step-08 deny-egress hold because step-07 pivoted only 2 HRs + the auto-trigger
+# ignored the operator flag): TWO chart fixes.
+#   D3 (step-07 multi-HR image-registry pivot) — step-07 hard-coded the
+#     global.imageRegistry pivot to ONLY bp-catalyst-platform (~L71) +
+#     bp-openova-flow-server (#4563, ~L224). Every OTHER openova-io-image HR
+#     whose chart honours global.imageRegistry stayed on ghcr.io → under the
+#     step-08 deny-egress hold its image ref 401s → cutoverComplete never set.
+#     step-07 now ALSO iterates a CURATED list
+#     (.Values.imageRegistryPivot.additionalHRs, default [bp-continuum]) and
+#     pivots each such HR with the IDENTICAL live-HR-patch + durable-Gitea-edit
+#     pattern (new pivot_extra_hr() shell function + range). ONLY charts VERIFIED
+#     to template through global.imageRegistry are listed; the offenders that do
+#     NOT (bp-guacamole/bp-huawei-evs-csi/bp-newapi/bp-sandbox + the org-services
+#     marketplace/auth hardcoded refs) are DELIBERATELY EXCLUDED — each needs a
+#     separate per-chart templating fix (tracked in #4885) and patching their HR
+#     here would be a silent no-op. Added a `global.imageRegistry: ''` seam to
+#     slot 62-bp-continuum.yaml so the durable Gitea edit persists. The existing
+#     bp-catalyst-platform + bp-openova-flow-server pivots are UNCHANGED.
+#   D1 (auto-trigger vs fireCutoverOnHandover) — the 10-auto-trigger-job.yaml
+#     hook rendered whenever trigger.auto=true (default), independent of the
+#     operator's fireCutoverOnHandover gate → an operator setting
+#     fireCutoverOnHandover=false (honoured by the catalyst-api reconciler,
+#     #4061) STILL got an auto-fired cutover. The hook now renders only when
+#     BOTH trigger.auto AND trigger.fireCutoverOnHandover are true. New value
+#     trigger.fireCutoverOnHandover (default false, fail-closed) is wired on real
+#     Sovereigns from the SAME ${FIRE_CUTOVER_ON_HANDOVER:-false} postBuild
+#     substitution catalyst-api reads (06a slot overlay). NO step-count / job-
+#     mode / RBAC change (still 11 steps; the auto-trigger Job is not a cutover
+#     step). Lockstep w/ blueprint.yaml + 06a slot pin + catalog seed. Refs #4885.
 # 0.1.99 (#4682 Refs #3379 #4666 #4652 #4639, the registry-external-host + gateway
 # :443-LoadBalancer cutover: KILL every :30443 NodePort append + the CoreDNS
 # registry-local.server rewrite + the dfdaemon hostAlias→cilium-gateway-ClusterIP
@@ -1509,7 +1539,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.105
+version: 0.1.106
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/07-catalyst-api-env-patch-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/07-catalyst-api-env-patch-job.yaml
@@ -22,6 +22,17 @@ global.imageRegistry — this step now patches that HR too (live +
 durable Gitea edit) so both residual ghcr.io tethers pivot to the
 local Harbor before the step-08 fresh-pull-under-deny-egress proof.
 
+#4885 (Refs #3379): the bp-catalyst-platform + bp-openova-flow-server
+pivots above were the ONLY two HRs step-07 pivoted — every OTHER
+openova-io-image HR whose chart honours global.imageRegistry stayed on
+ghcr.io and 401'd under the step-08 deny-egress hold, so cutoverComplete
+never set (live wedge hw232). This step now ALSO iterates a CURATED list
+(.Values.imageRegistryPivot.additionalHRs, default [bp-continuum]) and
+pivots each such HR with the identical live-HR-patch + durable-Gitea-edit
+pattern. Charts that do NOT honour global.imageRegistry (bp-guacamole,
+bp-huawei-evs-csi, bp-newapi, bp-sandbox, org-services marketplace/auth)
+need a separate per-chart templating fix and are excluded (#4885 residual).
+
 Phase 2 (pre-G61): kubectl set env CATALYST_GITOPS_REPO_URL pointing
 catalyst-api at the local Gitea mirror. Triggers another rolling
 restart (likely already in-flight from Phase 1's HR upgrade, but
@@ -275,6 +286,80 @@ data:
             else
               echo "[catalyst-api-env-patch] #4563 SKIP: HR ${FLOW_HR_NAMESPACE}/${FLOW_HR_NAME} not present (flow-server not installed on this Sovereign)"
             fi
+
+            # ---- #4885 (Refs #3379): pivot the REMAINING openova-io HRs ----
+            # whose chart honours global.imageRegistry. bp-catalyst-platform
+            # (above) + bp-openova-flow-server (above) were the ONLY two HRs
+            # step-07 pivoted; every OTHER openova-io-image HR that honours
+            # global.imageRegistry stayed on ghcr.io and 401'd under the
+            # step-08 deny-egress hold → the hold never went green →
+            # cutoverComplete never set (live wedge hw232, dep d71ca7ee89fd4451).
+            # The curated set (.Values.imageRegistryPivot.additionalHRs) is
+            # pivoted here with the SAME live-HR-patch + durable-Gitea-edit
+            # pattern as the two blocks above. ONLY charts VERIFIED to template
+            # their images through global.imageRegistry are listed (values.yaml
+            # carries the excluded-offenders list + rationale) — patching an HR
+            # whose chart ignores the value is a SILENT NO-OP, so the offenders
+            # that need a separate per-chart templating fix (bp-guacamole,
+            # bp-huawei-evs-csi, bp-newapi, bp-sandbox, org-services marketplace/
+            # auth) are deliberately NOT in the default list (#4885 residual).
+            pivot_extra_hr() {
+              _hr_name="$1"; _hr_ns="$2"; _slot="$3"
+              if ! kubectl get hr "${_hr_name}" -n "${_hr_ns}" >/dev/null 2>&1; then
+                echo "[catalyst-api-env-patch] #4885 SKIP: HR ${_hr_ns}/${_hr_name} not present (not installed on this Sovereign)"
+                return 0
+              fi
+              echo "[catalyst-api-env-patch] #4885 HR patch ${_hr_ns}/${_hr_name} spec.values.global.imageRegistry=${REGISTRY}"
+              _patch=$(printf '{"spec":{"values":{"global":{"imageRegistry":"%s"}}}}' "${REGISTRY}")
+              kubectl patch hr "${_hr_name}" \
+                -n "${_hr_ns}" \
+                --type=merge \
+                -p "${_patch}" || echo "[catalyst-api-env-patch] #4885 ${_hr_name} HR patch failed (non-fatal; will retry on next cutover)"
+
+              # Durable Gitea edit of the slot file so Flux Kustomization
+              # doesn't revert the live patch (same #2613 rule as the two
+              # blocks above). The slot MUST carry `imageRegistry: ''` at
+              # 6-space indent under its values.global block.
+              cd /tmp
+              rm -rf xhrrepo
+              _push_url=$(printf '%s' "${GITEA_INTERNAL_URL}" | sed -E "s,^(https?://),\1${GITEA_USERNAME}:${GITEA_PASSWORD}@,")"/${GITEA_ORG}/${GITEA_REPO}.git"
+              if git clone --depth 1 --branch main "${_push_url}" xhrrepo >/dev/null 2>&1; then
+                cd xhrrepo
+                git config user.email "self-sovereign-cutover@${HARBOR_HOST}"
+                git config user.name  "self-sovereign-cutover (#4885 ${_hr_name} imageRegistry patch)"
+                if [ -f "${_slot}" ]; then
+                  if sed -i -E "s|^([[:space:]]{6}imageRegistry:[[:space:]]*)['\"]?[^'\"]*['\"]?[[:space:]]*\$|\1'${REGISTRY}'|" "${_slot}" 2>/dev/null; then
+                    if ! git diff --quiet "${_slot}"; then
+                      git add "${_slot}"
+                      git commit -m "cutover #4885: pivot ${_hr_name} global.imageRegistry to local Harbor (${REGISTRY})" >/dev/null
+                      if git push origin main >/dev/null 2>&1; then
+                        echo "[catalyst-api-env-patch] #4885 OK: Gitea-edit pushed ${_slot} global.imageRegistry='${REGISTRY}'"
+                      else
+                        echo "[catalyst-api-env-patch] #4885 WARN: git push failed for ${_hr_name} (live HR-patch non-durable; next reconcile may revert)" >&2
+                      fi
+                    else
+                      echo "[catalyst-api-env-patch] #4885 SKIP: ${_slot} already has imageRegistry=${REGISTRY} (idempotent re-run)"
+                    fi
+                  else
+                    echo "[catalyst-api-env-patch] #4885 WARN: sed match failed on ${_slot} (missing 6-space imageRegistry:'' seam?); ${_hr_name} pivot durability not guaranteed" >&2
+                  fi
+                else
+                  echo "[catalyst-api-env-patch] #4885 SKIP: ${_slot} not present in local mirror"
+                fi
+                cd /tmp
+                rm -rf xhrrepo
+              else
+                echo "[catalyst-api-env-patch] #4885 WARN: git clone of local Gitea failed; ${_hr_name} pivot durability not guaranteed" >&2
+              fi
+
+              kubectl annotate hr "${_hr_name}" \
+                -n "${_hr_ns}" \
+                "reconcile.fluxcd.io/requestedAt=$(date +%s)" \
+                --overwrite || true
+            }
+{{- range .Values.imageRegistryPivot.additionalHRs }}
+            pivot_extra_hr {{ .name | quote }} {{ .namespace | quote }} {{ .slotFile | quote }}
+{{- end }}
 
             # G61 Phase 2 (was Step 07 pre-G61): set env on the
             # catalyst-api Deployment so it routes GitOps queries to

--- a/platform/self-sovereign-cutover/chart/templates/10-auto-trigger-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/10-auto-trigger-job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.trigger.auto }}
+{{- if and .Values.trigger.auto .Values.trigger.fireCutoverOnHandover }}
 {{- /*
 Step 10 — auto-trigger Job (issue #933, refined per issue #935 Bug 2).
 
@@ -90,9 +90,23 @@ Re-trigger semantics:
     re-trigger idempotently (skips already-success steps via the
     durable status ConfigMap). Safe to fire repeatedly.
 
-Operator override:
-  - Set trigger.auto=false in the per-Sovereign overlay to disable the
-    auto-trigger and require the manual CTA. Default: true (founder rule).
+Operator override (#4885 Defect 1 — COUPLED gate):
+  - This hook now renders ONLY when BOTH trigger.auto AND
+    trigger.fireCutoverOnHandover are true (see the `{{ if and ... }}`
+    guard at the top of this template). Previously the render was gated on
+    trigger.auto ALONE, independent of the operator's fireCutoverOnHandover
+    flag — so an operator who set fireCutoverOnHandover=false (honoured by
+    the catalyst-api reconciler, #4061) STILL got an auto-fired cutover
+    because /internal/cutover/trigger is gated only by the handover-seal
+    425, not by the operator flag. The two gates were uncoupled.
+  - trigger.fireCutoverOnHandover defaults FALSE (fail-closed) and is wired
+    on real Sovereigns from the SAME ${FIRE_CUTOVER_ON_HANDOVER:-false}
+    postBuild substitution the catalyst-api reads (06a slot overlay), so
+    both gates always agree: a Sovereign auto-fires ONLY when the operator
+    opted in. When false the cutover fires via the operator's BSS CTA (or
+    the #4669 level-triggered reconciler once the operator flips the flag).
+  - trigger.auto=false STILL fully disables the auto-trigger regardless of
+    fireCutoverOnHandover (the sandboxed-test-Sovereign override).
 */ -}}
 apiVersion: batch/v1
 kind: Job

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -141,38 +141,61 @@ else
   exit 1
 fi
 
-echo "[cutover-contract] Case 8: auto-trigger Job renders by default (#933)"
-# Founder rule: handover is not done until cutover has run. The chart MUST
-# auto-fire by default. trigger.auto=false is the operator override, NOT
-# the default.
-if ! grep -q 'cutover-auto-trigger' "$TMP/render.yaml"; then
-  echo "FAIL: auto-trigger Job missing from default render — handover gate broken" >&2
-  exit 1
-fi
-# It MUST be a post-install + post-upgrade Helm hook so chart upgrades
-# also re-fire (catalyst-api handles idempotency).
-if ! grep -q '"helm.sh/hook": "post-install,post-upgrade"' "$TMP/render.yaml" ; then
-  echo "FAIL: auto-trigger Job missing post-install + post-upgrade hook annotations" >&2
-  exit 1
-fi
-echo "  PASS (auto-trigger Job present + hook-annotated)"
+# #4885 Defect 1 (Refs #4061): the auto-trigger hook is now COUPLED to the
+# operator's fireCutoverOnHandover gate — it renders only when BOTH
+# trigger.auto AND trigger.fireCutoverOnHandover are true. Render a "fire"
+# variant with fireCutoverOnHandover=true so the auto-trigger-internals cases
+# (8/10/11/13/14) can assert against a render where the hook is PRESENT.
+helm template smoke-fire . --set trigger.fireCutoverOnHandover=true > "$TMP/render-fire.yaml"
 
-echo "[cutover-contract] Case 9: auto-trigger absent when trigger.auto=false"
-# Operator override path — the chart MUST install dormant when an overlay
-# disables auto-trigger.
-helm template smoke-noauto . --set trigger.auto=false > "$TMP/render-noauto.yaml"
+echo "[cutover-contract] Case 8: auto-trigger Job renders when fireCutoverOnHandover=true; ABSENT by default (#4885 Defect 1, Refs #4061)"
+# BEFORE #4885 the founder-rule-#933 default was "auto-fire always" (gated on
+# trigger.auto alone). But /internal/cutover/trigger is gated only by the
+# handover-seal 425, NOT by the operator flag — so an operator who set
+# fireCutoverOnHandover=false (honoured by the catalyst-api reconciler, #4061
+# operator-gated Sovereign) STILL got an auto-fired cutover. #4061 already made
+# the cutover operator-gated-by-default; #4885 couples the hook to the SAME
+# flag. The hook now renders ONLY when trigger.auto AND
+# trigger.fireCutoverOnHandover are BOTH true, and is fail-closed by default
+# (fireCutoverOnHandover: false). On a real Sovereign the 06a overlay wires the
+# flag from ${FIRE_CUTOVER_ON_HANDOVER:-false} so both gates always agree.
+#
+# (a) with fireCutoverOnHandover=true the hook MUST render + be hook-annotated.
+if ! grep -q 'cutover-auto-trigger' "$TMP/render-fire.yaml"; then
+  echo "FAIL: auto-trigger Job missing when fireCutoverOnHandover=true — handover-fire path broken (#4885)" >&2
+  exit 1
+fi
+if ! grep -q '"helm.sh/hook": "post-install,post-upgrade"' "$TMP/render-fire.yaml" ; then
+  echo "FAIL: auto-trigger Job missing post-install + post-upgrade hook annotations (#4885)" >&2
+  exit 1
+fi
+# (b) THE DEFECT-1 GUARD: with the chart default (fireCutoverOnHandover=false)
+#     the hook MUST NOT render — else an operator's `false` is silently
+#     overridden (the exact hw232 bug).
+if grep -q 'cutover-auto-trigger' "$TMP/render.yaml"; then
+  echo "FAIL: auto-trigger Job rendered by default (fireCutoverOnHandover=false) — the operator gate is silently overridden (#4885 Defect 1)" >&2
+  exit 1
+fi
+echo "  PASS (auto-trigger renders iff fireCutoverOnHandover=true; suppressed by default)"
+
+echo "[cutover-contract] Case 9: auto-trigger absent when trigger.auto=false (even with fireCutoverOnHandover=true)"
+# Operator override path — trigger.auto=false MUST fully disable the auto-
+# trigger regardless of the fireCutoverOnHandover gate (the sandboxed-test-
+# Sovereign override). Set fireCutoverOnHandover=true to isolate the trigger.auto
+# gate (else the hook would be absent for the OTHER reason and prove nothing).
+helm template smoke-noauto . --set trigger.auto=false --set trigger.fireCutoverOnHandover=true > "$TMP/render-noauto.yaml"
 if grep -q 'cutover-auto-trigger' "$TMP/render-noauto.yaml"; then
   echo "FAIL: auto-trigger Job rendered despite trigger.auto=false" >&2
   exit 1
 fi
-echo "  PASS (auto-trigger gated on trigger.auto)"
+echo "  PASS (auto-trigger gated on trigger.auto independently of fireCutoverOnHandover)"
 
 echo "[cutover-contract] Case 10: auto-trigger uses /internal/cutover/trigger (#935 Bug 2)"
 # Chart 0.1.16 POSTed /api/v1/sovereign/cutover/start which sat behind
 # RequireSession middleware and 401'd forever on otech113 2026-05-05.
 # 0.1.17 must route through /api/v1/internal/cutover/trigger (lives
 # OUTSIDE RequireSession, validates the bearer SA token via TokenReview).
-if ! grep -q '/api/v1/internal/cutover/trigger' "$TMP/render.yaml"; then
+if ! grep -q '/api/v1/internal/cutover/trigger' "$TMP/render-fire.yaml"; then
   echo "FAIL: auto-trigger Job does NOT POST /api/v1/internal/cutover/trigger" >&2
   exit 1
 fi
@@ -182,11 +205,11 @@ echo "[cutover-contract] Case 11: auto-trigger sends SA bearer token (#935 Bug 2
 # The Job must mount its projected ServiceAccount token AND send it as
 # Authorization: Bearer. Without this the /internal/cutover/trigger
 # endpoint will reject the request with 401 missing-bearer.
-if ! grep -q '/var/run/secrets/kubernetes.io/serviceaccount/token' "$TMP/render.yaml"; then
+if ! grep -q '/var/run/secrets/kubernetes.io/serviceaccount/token' "$TMP/render-fire.yaml"; then
   echo "FAIL: auto-trigger Job does NOT read its projected SA token" >&2
   exit 1
 fi
-if ! grep -q 'Authorization: Bearer' "$TMP/render.yaml"; then
+if ! grep -q 'Authorization: Bearer' "$TMP/render-fire.yaml"; then
   echo "FAIL: auto-trigger Job does NOT send Authorization: Bearer header" >&2
   exit 1
 fi
@@ -220,11 +243,11 @@ echo "[cutover-contract] Case 13: readiness probe targets /healthz, NOT /soverei
 # 0.1.18 polls /healthz instead (unauthenticated, always 200 when
 # the process is up). This gate guards against future regressions
 # that re-introduce an auth-gated readiness probe.
-if ! grep -q 'healthz_url=' "$TMP/render.yaml"; then
+if ! grep -q 'healthz_url=' "$TMP/render-fire.yaml"; then
   echo "FAIL: auto-trigger Job missing healthz_url= readiness probe target" >&2
   exit 1
 fi
-if ! grep -q '/healthz' "$TMP/render.yaml"; then
+if ! grep -q '/healthz' "$TMP/render-fire.yaml"; then
   echo "FAIL: auto-trigger Job does NOT include the /healthz probe path" >&2
   exit 1
 fi
@@ -237,7 +260,7 @@ fi
 # appears in the rendered Job. The string itself is allowed in
 # documentation comments — that's why we anchor on `=` (assignment),
 # not just substring presence.
-if grep -E '^\s*[a-zA-Z_][a-zA-Z0-9_]*=.*/api/v1/sovereign/cutover/status' "$TMP/render.yaml" >/dev/null; then
+if grep -E '^\s*[a-zA-Z_][a-zA-Z0-9_]*=.*/api/v1/sovereign/cutover/status' "$TMP/render-fire.yaml" >/dev/null; then
   echo "FAIL: auto-trigger Job polls /sovereign/cutover/status as a readiness probe (auth-gated, 401-loops)" >&2
   exit 1
 fi
@@ -251,7 +274,7 @@ echo "[cutover-contract] Case 14: no early cutoverComplete short-circuit on auth
 # cutover/trigger endpoint is itself idempotent (returns 200 with the
 # existing snapshot when cutoverComplete=true; cutover_internal.go
 # line 279) so no separate pre-read is needed.
-if grep -E "grep.*cutoverComplete.*/tmp/status\.json" "$TMP/render.yaml" >/dev/null; then
+if grep -E "grep.*cutoverComplete.*/tmp/status\.json" "$TMP/render-fire.yaml" >/dev/null; then
   echo "FAIL: auto-trigger Job retains the 0.1.17 cutoverComplete pre-read off /tmp/status.json — that file no longer exists" >&2
   exit 1
 fi

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -655,6 +655,52 @@ catalystAPI:
   # The env var that catalyst-api reads for its GitOps source URL.
   envVar: "CATALYST_GITOPS_REPO_URL"
 
+# #4885 (Refs #3379 #4563): step-07 image-registry pivot — the CURATED set of
+# ADDITIONAL openova-io HelmReleases whose chart HONOURS global.imageRegistry
+# and must be pivoted to the local Harbor at cutover.
+#
+# THE BUG (#4885 Defect 3, live wedge hw232): step-07 hard-coded the
+# global.imageRegistry pivot to ONLY bp-catalyst-platform (~L71) +
+# bp-openova-flow-server (#4563, ~L224). Every OTHER openova-io-image HR whose
+# chart honours global.imageRegistry stayed on ghcr.io → under the step-08
+# deny-egress hold its image ref 401s → the hold never goes green →
+# cutoverComplete never set. bp-continuum is such a chart (its
+# templates/_helpers.tpl `continuum.image` honours global.imageRegistry, same
+# mechanism bp-catalyst-platform uses).
+#
+# Each entry is pivoted with the IDENTICAL live-HR-patch + durable-Gitea-edit
+# pattern step-07 already applies to bp-catalyst-platform / bp-openova-flow-
+# server: `kubectl patch hr <name> --type=merge -p
+# '{"spec":{"values":{"global":{"imageRegistry":"<registry.fqdn>"}}}}'` plus a
+# sed of the slot file's `imageRegistry: ''` seam (6-space indent) so Flux
+# Kustomization doesn't revert the live patch. So every slotFile below MUST
+# carry a `global.imageRegistry: ''` seam at 6-space indent (added to
+# 62-bp-continuum.yaml in lockstep with this chart bump).
+#
+# ⚠️ ONLY list charts VERIFIED to template their images through
+# global.imageRegistry. Patching an HR whose chart does NOT read the value is a
+# SILENT NO-OP — the workload stays on ghcr.io and step-08 still FATALs, but the
+# cutover log falsely reports the pivot "OK". The following #4885 offenders were
+# verified to NOT honour global.imageRegistry and are DELIBERATELY EXCLUDED —
+# each needs a SEPARATE per-chart templating fix (make its image helper honour
+# global.imageRegistry + add a slot seam) before it can be added here:
+#   - bp-guacamole        (platform/guacamole:  guacd/webapp images are literal
+#                          .Values.guacamole.*.image.repository = ghcr.io/...)
+#   - bp-huawei-evs-csi   (platform/huawei-evs-csi: driver image is literal
+#                          $img.driver.repository = ghcr.io/...)
+#   - bp-newapi           (platform/newapi: newapi/sandboxBridge/meteringSidecar
+#                          images are literal .Values.*.image.repository)
+#   - bp-sandbox          (platform/sandbox: controller/pty/mcp images literal)
+#   - org-services        (products/catalyst/chart/templates/org-services:
+#                          marketplace.yaml + auth.yaml hardcode ghcr.io — the
+#                          rest already pivot via the bp-catalyst-platform HR)
+# Tracked in #4885 as the residual cutover blocker.
+imageRegistryPivot:
+  additionalHRs:
+    - name: bp-continuum
+      namespace: flux-system
+      slotFile: clusters/_template/bootstrap-kit/62-bp-continuum.yaml
+
 # Step container images. The first three steps (01..03) + the
 # registry-pivot DaemonSet use upstream-public images because they run
 # BEFORE registries.yaml v2 takes effect on the node containerd.
@@ -1271,6 +1317,30 @@ trigger:
   # console.<sov-fqdn>/console/dashboard. Set to false in per-Sovereign
   # overlay if a sandboxed test Sovereign should stay tethered.
   auto: true
+  # #4885 (Refs #3379 #4061): COUPLE the auto-trigger hook to the operator's
+  # fireCutoverOnHandover gate. Before this, the auto-trigger hook Job
+  # rendered whenever trigger.auto=true (default) and POSTed
+  # /api/v1/internal/cutover/trigger — a path gated ONLY by the handover-seal
+  # 425, NOT by the operator flag. So an operator who set
+  # fireCutoverOnHandover=false (honoured by the catalyst-api reconciler:
+  # `[CUTOVER-RECONCILE] dormant: fireCutoverOnHandover=false`, #4061
+  # operator-gated Sovereign) STILL got an auto-fired cutover — the two gates
+  # were uncoupled. The hook now renders only when trigger.auto AND
+  # fireCutoverOnHandover are BOTH true (see templates/10-auto-trigger-job.yaml
+  # `{{ if and .Values.trigger.auto .Values.trigger.fireCutoverOnHandover }}`).
+  #
+  # DEFAULT false — fail-closed / operator-gated, CONSISTENT with the source
+  # catalyst-api reads: the catalyst chart plumbs
+  # CATALYST_FIRE_CUTOVER_ON_HANDOVER from catalystApi.fireCutoverOnHandover =
+  # ${FIRE_CUTOVER_ON_HANDOVER:-false} (13-bp-catalyst-platform.yaml), so a
+  # Sovereign auto-fires ONLY when the operator opted in (tofu var
+  # fire_cutover_on_handover=true → FIRE_CUTOVER_ON_HANDOVER=true). The 06a
+  # slot overlay (clusters/_template/bootstrap-kit/06a-bp-self-sovereign-
+  # cutover.yaml) wires this value from the SAME ${FIRE_CUTOVER_ON_HANDOVER:-
+  # false} postBuild substitution so both gates always agree. When false the
+  # cutover fires via the operator's BSS CTA (or the #4669 level-triggered
+  # reconciler once the operator flips the flag). Overlay always wins.
+  fireCutoverOnHandover: false
   # Optional pre-flight delay before the hook POSTs /start. 0 = fire
   # immediately. Useful for soak Sovereigns where the operator wants a
   # short window to inspect the freshly-handed-over dashboard before

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5036,7 +5036,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.105"
+    version: "0.1.106"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
`Refs #4885` — two of the three Pillar-5 cutover-hardening defects found on the hw232 live walk. Chart-only (`platform/self-sovereign-cutover/`); no live-cluster changes.

## Defect 3 — step-07 pivoted only 2 HRs (THE cutover wedge)

`07-catalyst-api-env-patch-job.yaml` hard-coded the `spec.values.global.imageRegistry` pivot to **bp-catalyst-platform** + **bp-openova-flow-server** only. Every other openova-io-image HR whose chart honours `global.imageRegistry` stayed on `ghcr.io/…` → under the step-08 deny-egress hold it 401s → the hold never goes green → `cutoverComplete` never set.

**Fix:** step-07 now ALSO iterates a **curated list** — `values.imageRegistryPivot.additionalHRs` (default `[bp-continuum]`) — and pivots each with the **identical** live-HR-patch + durable-Gitea-edit pattern (new `pivot_extra_hr()` shell function + `{{ range }}`). The existing bp-catalyst-platform + bp-openova-flow-server blocks are **unchanged** (Case 32 still green).

**Verification of target charts** (grepped `platform/` / `products/`):

| Chart | Honours `global.imageRegistry`? | Action |
|---|---|---|
| bp-catalyst-platform | ✅ (existing) | already pivoted |
| bp-openova-flow-server | ✅ (existing) | already pivoted |
| **bp-continuum** | ✅ `templates/_helpers.tpl` `continuum.image` | **added to pivot list** (+ `global.imageRegistry:''` seam added to `62-bp-continuum.yaml` so the durable Gitea edit persists) |

### ⚠️ Residual wedge — charts that do NOT honour `global.imageRegistry`

These build image refs from hardcoded `.Values.<x>.image.repository = ghcr.io/openova-io/…` and are **deliberately excluded** (patching their HR would be a silent no-op). Each needs a **separate per-chart templating fix** (make its image helper honour `global.imageRegistry` + add a slot seam) before it can be added to the list — tracked as the #4885 residual:

- **bp-guacamole** — `guacd`/`webapp` images literal `.Values.guacamole.*.image.repository`
- **bp-huawei-evs-csi** — driver image literal `$img.driver.repository`
- **bp-newapi** — `newapi`/`sandboxBridge`/`meteringSidecar` images literal `.Values.*.image.repository`
- **bp-sandbox** — controller/pty/mcp images literal `.Values.image.repository` / `ptyServerImage` / `mcpImage`
- **org-services** — part of the bp-catalyst-platform chart; most templates DO honour `global.imageRegistry` (pivoted by the existing bp-catalyst-platform HR patch), but `marketplace.yaml` + `auth.yaml` hardcode `ghcr.io/openova-io/…`

So this PR fixes the step-07 **mechanism** (maintainable curated list) + adds bp-continuum; a fully-clean `cutoverComplete` still requires the 5 per-chart templating fixes above.

## Defect 1 — `trigger.auto` overrode `fireCutoverOnHandover`

The `10-auto-trigger-job.yaml` hook rendered whenever `trigger.auto: true` (default), independent of the operator's `fireCutoverOnHandover` gate. Since `/internal/cutover/trigger` is gated only by the handover-seal 425 (not the operator flag), an operator setting `fireCutoverOnHandover=false` (honoured by the catalyst-api reconciler, #4061) still got an auto-fired cutover.

**Fix:** the hook now renders only when **both** `trigger.auto` **and** `trigger.fireCutoverOnHandover` are true. New value `trigger.fireCutoverOnHandover` (default **false**, fail-closed) is wired on real Sovereigns from the **same** `${FIRE_CUTOVER_ON_HANDOVER:-false}` Flux postBuild substitution catalyst-api reads (13-bp-catalyst-platform → `catalystApi.fireCutoverOnHandover`), via the 06a slot overlay — so both gates always agree. `trigger.auto=false` still fully disables the auto-trigger independently.

## Locksteps + validation

- Chart `0.1.105 → 0.1.106`; lockstep bumps: `blueprint.yaml`, `06a` slot pin, catalog-seed `source.version`.
- `helm lint` clean; `check-bootstrap-kit-pin-sync.sh` OK; `check-catalog-seed-lockstep.sh` PASS.
- Contract test **35/35 green** (Cases 8/9/10/11/13/14 updated for the coupled gate; Case 32 flow-server pivot preserved).
- Rendered step-07 script passes `sh -n`, `dash -n`, and `busybox ash -n` (no bashisms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)