### PR TITLE
fix(#4889): HR-Ready overlay for adopted spine/bootstrap Application CRs (Apps grid + AppDetail status flap)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications.go
@@ -1487,7 +1487,21 @@ func (h *Handler) HandleApplicationGet(w http.ResponseWriter, r *http.Request) {
 	//
 	// Mirrors the C4-013 contract: surface the discrepancy when the
 	// CR phase disagrees with HR Ready, so the operator can see both.
-	if isHRReady := h.helmReleaseReadyByName(r.Context(), depID, resp.ReleaseName); isHRReady && resp.Phase != "Ready" {
+	//
+	// #4889 — resolve the HR-lookup identity from spec.helmRelease.name
+	// (the adopted HelmRelease) first. Spine/bootstrap Application CRs
+	// reference their HR there (e.g. spine-gitea → flux-system/bp-gitea)
+	// and carry NO spec.releaseName, so resp.ReleaseName fell back to the
+	// CR's OWN name ("spine-gitea") and helmReleaseReadyByName never
+	// matched the real HR ("bp-gitea") — the overlay was inert for exactly
+	// these apps and the operator saw FAILED/Provisioning (source:
+	// Application CR) while the HelmRelease was Ready. Fallback chain:
+	// spec.helmRelease.name → resp.ReleaseName.
+	hrLookupName := resp.ReleaseName
+	if hrn, ok, _ := unstructured.NestedString(obj.Object, "spec", "helmRelease", "name"); ok && hrn != "" {
+		hrLookupName = hrn
+	}
+	if isHRReady := h.helmReleaseReadyByName(r.Context(), depID, hrLookupName); isHRReady && resp.Phase != "Ready" {
 		resp.HRReady = true
 		resp.PhaseFromCR = resp.Phase
 		resp.Phase = "Ready"

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign.go
@@ -794,6 +794,17 @@ func (h *Handler) HandleSovereignApps(w http.ResponseWriter, r *http.Request) {
 			if hrName, _, _ := unstructured.NestedString(app.Object, "spec", "helmRelease", "name"); hrName != "" {
 				adoptedHRs[hrName] = true
 				externalURL = urlByHRName[hrName]
+				// #4889 — HR-Ready overlay for adopted spine/bootstrap CRs.
+				// The Application CR status.phase lags/flaps behind Flux (the
+				// app-controller can sit at Provisioning/Failed while the
+				// adopted HelmRelease is already Ready=True). When the adopted
+				// HR (installed map, built from helmReleaseReady above) is
+				// Ready, prefer it — mirrors the detail endpoint's C4-003 /
+				// #4889 overlay so the grid card doesn't render FAILED/
+				// installing while the HelmRelease is Ready.
+				if status != "installed" && installed[hrName] == "installed" {
+					status = "installed"
+				}
 			}
 			topology, _, _ := unstructured.NestedString(app.Object, "spec", "placement")
 			instanceRows = append(instanceRows, sovereignAppItem{


### PR DESCRIPTION
## What

Fixes the console-accuracy defect where the **Apps grid** and **AppDetail header** render spine/bootstrap platform apps (gitea, harbor, keycloak, cnpg, grafana, …) as **FAILED / installing** `source: Application CR` while their Flux HelmReleases are `Ready=True` and the Reconciliation lens + AppDetail→Topology show `Ready (source: HelmRelease)`.

Surfaced by the hw232 live UAT walk. Root-cause + live evidence in #4889.

## Root cause

The Application-CR `status.phase` lags/flaps behind Flux (app-controller readback lag). A "prefer HR Ready" overlay exists to mask this (C4-003) but did **not** reach adopted (spine/bootstrap) CRs:

- **detail** (`applications.go`): the overlay looked up the HR by `resp.ReleaseName`, which for spine CRs — no `spec.releaseName` — falls back to the CR's own name (`spine-gitea`) and never matched the real HR (`bp-gitea`, from `spec.helmRelease.name`). Overlay inert.
- **list** (`sovereign.go` `HandleSovereignApps`): the adopted-CR card status was a pure `status.phase` readout with **no** HR cross-check — even though the adopted HR's Ready state was already in the `installed` map.

## Fix (backend-only, reuses existing data)

- detail: resolve the HR-lookup identity from `spec.helmRelease.name` first (fallback `resp.ReleaseName`), so `helmReleaseReadyByName` matches the adopted HR.
- list: when the adopted-CR `phase != Ready` but the adopted HR (`installed[hrName]`) is Ready, promote the card to `installed` — mirrors the detail overlay.

The deeper app-controller readback (so the CR itself stops flapping) is the #856-class follow-up noted in #4889.

## Test

- `go build ./internal/handler/` ✅ · `go vet` ✅
- full `go test ./internal/handler/` ✅ (150s, all pass)

Not yet verified on a live prov (catalyst-api runs a pinned image on hw232). Merged ≠ delivered — needs a fresh-prov walk to confirm the grid/header no longer flap.

Refs #4889
Refs #856

🤖 Generated with [Claude Code](https://claude.com/claude-code)