### PR TITLE
fix(#4885): roll gitea on admin-secret change so keepUpdated re-syncs DB password

### DIFF
--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -174,7 +174,12 @@ spec:
       #   at admission → pre-upgrade gate failed → bp-gitea HR rollback-looped and
       #   stranded bp-catalyst-platform / bp-continuum / bp-sandbox. Fix: default the
       #   guard image to the harbor-proxy form. Refs #4369 #4367 #4354.
-      version: 1.2.46
+      # 1.2.47 — #4885: reloader annotation on the gitea Deployment metadata
+      #   (secret.reloader.stakater.com/reload: gitea-admin-secret) so bp-reloader
+      #   (slot 28) rolls gitea on any admin-secret change and keepUpdated re-syncs
+      #   the DB password — closes the Pillar-5 cutover step-06 demirror 401 gap
+      #   (live hw232). Refs #4885 #3379 #830.
+      version: 1.2.47
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.46 # lockstep with chart/Chart.yaml (#4402 spine topology tier:mgmt → '' host-native, #4325 de-vcluster fallout)
+  version: 1.2.47 # lockstep with chart/Chart.yaml (#4885 admin-secret reloader annotation; #4402 spine topology tier:mgmt → '' host-native, #4325 de-vcluster fallout)
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -192,7 +192,21 @@ name: bp-gitea
 #   `seaweedfs-s3.seaweedfs.svc` / `seaweedfs-filer.seaweedfs.svc` (bp-seaweedfs
 #   re-homed to host ns by #4325). objectStorage/mirror are default-OFF. Test
 #   assertion updated in lockstep. Refs #4388 #4325.
-version: 1.2.46
+# 1.2.47 (#4885, Refs #3379 #830, 2026-07-09): Pillar-5 cutover hardening —
+#   gitea admin-secret reload gap. Live on hw232 the cutover step-06 demirror
+#   got 401 `user's password is invalid [uid:1 gitea_admin]` because
+#   GITEA_ADMIN_PASSWORD_MODE=keepUpdated re-syncs the DB password to
+#   gitea-admin-secret ONLY on pod restart, and gitea never restarts — so once
+#   the Secret changed the live DB kept the old password while the Secret held
+#   the new one. templates/admin-secret.yaml's Helm `lookup` already pins the
+#   password against regeneration (issue #830); this bump adds the belt-and-braces
+#   companion: a `secret.reloader.stakater.com/reload: gitea-admin-secret`
+#   annotation on the gitea Deployment metadata (via the upstream chart's
+#   `deployment.annotations`) so bp-reloader (slot 28) rolls the Deployment on any
+#   admin-secret change and keepUpdated re-syncs the DB password immediately. The
+#   Recreate strategy keeps the roll RWO/LevelDB-safe. Non-cutover render unchanged
+#   except the new (always-present) Deployment annotation.
+version: 1.2.47
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/values.yaml
+++ b/platform/gitea/chart/values.yaml
@@ -216,6 +216,33 @@ gitea:
   # no HA during a roll, so Recreate costs nothing it didn't already lack.
   strategy:
     type: Recreate
+  # ─── #4885: roll gitea when gitea-admin-secret changes (Stakater Reloader) ─
+  # Root cause (hw232 live, Pillar-5 cutover step-06 demirror 401): the Gitea
+  # admin user's password is seeded into the live DB by the init container from
+  # `gitea-admin-secret`, and GITEA_ADMIN_PASSWORD_MODE=keepUpdated re-syncs the
+  # DB password to the Secret ONLY ON POD RESTART. Gitea never restarts on its
+  # own, so if `gitea-admin-secret` ever changes (rotation, a re-render, an
+  # operator reset) the live DB keeps the OLD password while the Secret holds
+  # the NEW one — every admin-API auth (including bp-self-sovereign-cutover
+  # step-06 demirror) then 401s `user's password is invalid [uid:1 gitea_admin]`.
+  #
+  # templates/admin-secret.yaml's Helm `lookup` guard already pins the password
+  # so it does NOT regenerate on normal reconciles (issue #830 Bug 2). This
+  # annotation is the belt-and-braces companion the #4885 root-cause calls for:
+  # bp-reloader (bootstrap-kit slot 28, --reload-strategy=annotations) watches
+  # `gitea-admin-secret` and triggers a rolling restart of THIS Deployment on
+  # any change, so the init container re-runs and keepUpdated re-syncs the DB
+  # password immediately instead of waiting for an unrelated restart. The
+  # annotation lives on the Deployment's OWN metadata (upstream
+  # `deployment.annotations` → templates/gitea/deployment.yaml metadata.annotations)
+  # which is exactly where Reloader reads (same idiom as bp-powerdns-admin's
+  # `secret.reloader.stakater.com/reload: pda-sso-oidc-credentials`). The
+  # Recreate strategy above makes the roll RWO-PVC / LevelDB-lock-safe. The
+  # admin-secret always exists (chart-core), so the annotation is unconditional.
+  # Refs #4885 #3379 #830.
+  deployment:
+    annotations:
+      secret.reloader.stakater.com/reload: "gitea-admin-secret"
   # Upstream chart Ingress — DISABLED. Catalyst routes via Cilium Gateway
   # API (see top-level `gateway:` block below). Issue #387.
   ingress:

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -4311,7 +4311,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.2.46"
+  version: "1.2.47"
   visibility: unlisted
   card:
     title: "Gitea"
@@ -4334,7 +4334,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-gitea
-    version: "1.2.46"
+    version: "1.2.47"
   topology:
     supported:
       - active-hot-standby


### PR DESCRIPTION
## What

Pillar-5 cutover hardening — the gitea `gitea-admin-secret` reload gap (defect-2 of #4885, found live on hw232).

## Root cause (confirmed live, hw232)

The Gitea admin user's password is seeded into the live DB by the init container from `gitea-admin-secret`. `GITEA_ADMIN_PASSWORD_MODE=keepUpdated` re-syncs the DB password to the Secret **only on pod restart**, and gitea never restarts on its own. So once `gitea-admin-secret` changed, the live DB kept the old password while the Secret held the new one — the cutover step-06 demirror then hit `401 "user's password is invalid [uid:1 gitea_admin]"`, and so would any gitea admin-API auth.

## Fix

`templates/admin-secret.yaml` already carries a Helm `lookup` guard (issue #830) that pins the password so it does not regenerate on normal reconciles. This PR adds the belt-and-braces companion the root cause calls for:

- A `secret.reloader.stakater.com/reload: gitea-admin-secret` annotation on the **gitea Deployment metadata**, injected via the upstream chart's `deployment.annotations` value (`values.yaml`). `bp-reloader` (bootstrap-kit slot 28, `--reload-strategy=annotations`) watches the Secret and rolls the Deployment on any change, so the init container re-runs and `keepUpdated` re-syncs the live DB password immediately instead of waiting for an unrelated restart.
- Same idiom already used by `bp-powerdns-admin` (`secret.reloader.stakater.com/reload: pda-sso-oidc-credentials`). The annotation lands on Deployment `metadata.annotations` — exactly where Reloader reads.
- The existing `strategy.type: Recreate` keeps the roll RWO-PVC / LevelDB-lock safe. The admin-secret is chart-core, so the annotation is unconditional.

## Version + locksteps

Chart `1.2.46 -> 1.2.47`, with the three locksteps bumped in the same change so the pin-sync gates stay green:

- `platform/gitea/chart/Chart.yaml`
- `clusters/_template/bootstrap-kit/10-gitea.yaml` (slot version)
- `platform/gitea/blueprint.yaml`
- `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` (spec.version + source.version)

## Verification

- `helm lint` clean; `helm template` renders the reloader annotation on the gitea Deployment `metadata.annotations` (and nowhere else).
- Lookup persistence proven with `helm install --dry-run=server` run twice against a namespace pre-seeded with a fixed-password `gitea-admin-secret` — both renders preserved the password verbatim; a namespace with no secret produced a fresh 32-char random per render (the first-install branch).
- `scripts/check-catalog-seed-lockstep.sh` PASS (69 checked, 0 fail).
- `tests/kyverno-probes-present.sh` + `tests/kyverno-harbor-proxy-images.sh` PASS.

No live-cluster deploy — chart change only.

Refs #4885 #3379 #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)