### PR TITLE
fix(#4885): 4 charts honour global.imageRegistry for step-07 cutover pivot

### DIFF
--- a/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
+++ b/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
@@ -186,7 +186,7 @@ spec:
       # enum) + non-empty metrics hostnameTemplate; matches catalog-seed.
       # 0.3.11 (#4375): topology placement.tier rtz → '' (host-native)
       # post-#4325 de-vcluster — lockstep with the chart + blueprint bump.
-      version: 0.3.11
+      version: 0.3.12
       sourceRef:
         kind: HelmRepository
         name: bp-sandbox

--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -183,7 +183,7 @@ spec:
       # chart renders the canonical apps.openova.io/v1 Application CR for
       # this slot's HelmRelease so the console /apps list, per-app Topology
       # tab + showback resolve guacamole (no more "no Application CR").
-      version: 0.2.27
+      version: 0.2.28
       sourceRef:
         kind: HelmRepository
         name: bp-guacamole

--- a/clusters/_template/bootstrap-kit/55b-bp-huawei-evs-csi.yaml
+++ b/clusters/_template/bootstrap-kit/55b-bp-huawei-evs-csi.yaml
@@ -186,7 +186,7 @@ spec:
       # the same `managed-by: flux` label so the kyverno policy admits BOTH the
       # pre- and post- hooks — without it the 1.0.6 upgrade rolled back on the
       # post-upgrade phase and the HR stayed Stalled.
-      version: 1.0.7
+      version: 1.0.8
       sourceRef:
         kind: HelmRepository
         name: bp-huawei-evs-csi

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -305,7 +305,7 @@ spec:
       #   remoteRef.key → catalyst/newapi/admin-token (the path catalyst-api's
       #   seedNewapiAdminToken seam writes); fixes the SecretSyncedError that
       #   left unified-rbac's admin-API calls 401'd on a fresh prov.
-      version: 1.4.137
+      version: 1.4.138
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/guacamole/blueprint.yaml
+++ b/platform/guacamole/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/category: platform
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.27
+  version: 0.2.28
   card:
     title: Apache Guacamole
     summary: Clientless HTML5 remote-desktop gateway. Browser-based RDP / VNC / SSH and kubectl-exec into Pods, with Keycloak SSO and full session recording to SeaweedFS. One Guacamole per Sovereign per ADR-0001 §11.

--- a/platform/guacamole/chart/Chart.yaml
+++ b/platform/guacamole/chart/Chart.yaml
@@ -1,5 +1,13 @@
 apiVersion: v2
 name: bp-guacamole
+# 0.2.28 (#4885): honour global.imageRegistry for the guacd + webapp openova-io
+# images so the self-sovereign-cutover step-07 image pivot reaches these Pods.
+# _helpers.tpl guacdImage/webappImage now route through a new registryImage
+# helper (host-swap on the leading registry segment when global.imageRegistry is
+# set; verbatim ghcr.io otherwise — default byte-identical pre-cutover). New
+# `global.imageRegistry: ""` seam in values.yaml. The 3rd-party sidecar/curl
+# images carry their own registry and are untouched. Lockstep: 52-bp-guacamole.yaml
+# pin + blueprint.yaml + catalog-seed source.version → 0.2.28. Refs #4885.
 # 0.2.17 (#3374, 2026-06-14): admin group-enrollment fix. After 0.2.16 landed
 # the JDBC permission store (sovereign-admins USER_GROUP with ADMINISTER + the
 # scheduling/POSTGRESQL_USER fixes), the owner STILL got no admin menu —
@@ -198,7 +206,7 @@ name: bp-guacamole
 # Instances-table chip, so the legacy spelling leaked the banned word to the
 # operator (hw159 #3375).
 # 0.2.26 (#3971): CNPG storageClass empty ⇒ cluster-default durable cloud CSI; local-path FORBIDDEN.
-version: 0.2.27
+version: 0.2.28
 appVersion: "1.5.5"
 description: |
   Catalyst-authored Blueprint chart for Apache Guacamole — a clientless

--- a/platform/guacamole/chart/templates/_helpers.tpl
+++ b/platform/guacamole/chart/templates/_helpers.tpl
@@ -84,12 +84,31 @@ Image-tag fail-fast helpers. Per docs/INVIOLABLE-PRINCIPLES.md #4a
 empty `:tag` MUST fail the helm template render — we never want
 floating `:latest` shipping into production.
 */}}
+{{/*
+Registry-rewrite helper (#4885). Given an openova-io "<host>/<path>" image
+repository + a validated tag, prepend .Values.global.imageRegistry in place of
+the leading registry host when it is set (self-sovereign-cutover step-07 pivot),
+else emit the ghcr.io ref verbatim. Mirrors the continuum.image pattern so the
+default byte-identically stays on ghcr.io pre-cutover.
+Usage: {{ include "bp-guacamole.registryImage" (dict "repo" <repo> "tag" <tag> "root" $) }}
+*/}}
+{{- define "bp-guacamole.registryImage" -}}
+{{- $repo := .repo -}}
+{{- $tag := .tag -}}
+{{- $globalRegistry := .root.Values.global.imageRegistry | default "" -}}
+{{- if ne $globalRegistry "" -}}
+{{- printf "%s/%s:%s" $globalRegistry (join "/" (slice (splitList "/" $repo) 1)) $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end }}
+
 {{- define "bp-guacamole.guacdImage" -}}
 {{- $tag := .Values.guacamole.guacd.image.tag -}}
 {{- if not $tag -}}
 {{- fail "bp-guacamole: .Values.guacamole.guacd.image.tag is empty — SHA-pinned image required (CI populates this)" -}}
 {{- end -}}
-{{- printf "%s:%s" .Values.guacamole.guacd.image.repository $tag -}}
+{{- include "bp-guacamole.registryImage" (dict "repo" .Values.guacamole.guacd.image.repository "tag" $tag "root" $) -}}
 {{- end }}
 
 {{- define "bp-guacamole.webappImage" -}}
@@ -97,7 +116,7 @@ floating `:latest` shipping into production.
 {{- if not $tag -}}
 {{- fail "bp-guacamole: .Values.guacamole.webapp.image.tag is empty — SHA-pinned image required (CI populates this)" -}}
 {{- end -}}
-{{- printf "%s:%s" .Values.guacamole.webapp.image.repository $tag -}}
+{{- include "bp-guacamole.registryImage" (dict "repo" .Values.guacamole.webapp.image.repository "tag" $tag "root" $) -}}
 {{- end }}
 
 {{/*

--- a/platform/guacamole/chart/values.yaml
+++ b/platform/guacamole/chart/values.yaml
@@ -18,6 +18,20 @@ catalystBlueprint:
     chart: "" # scratch chart — no upstream Helm chart
     version: ""
     repo: ""
+
+# ─── Global registry rewrite (matches catalyst / continuum chart pattern) ──
+# When set, every openova-io image pull (guacd + webapp) routes through this
+# registry instead of ghcr.io. Per-Sovereign overlays leave this empty; the
+# self-sovereign-cutover step-07 image pivot (#4885) sets it to
+# registry.<sovereign-fqdn> so post-cutover pulls hit the Sovereign's own
+# Harbor rather than ghcr.io (which the step-08 deny-egress hold blocks).
+# Empty = no rewrite → the default ghcr.io refs below are used verbatim.
+# The image helpers in templates/_helpers.tpl apply the rewrite (host-swap
+# on the leading registry segment); the sidecar/3rd-party images are never
+# openova-io so they carry their own registry and are untouched.
+global:
+  imageRegistry: ""
+
 # Top-level enable gate. When false, NO resources render. Verified by
 # `helm template` test in tests/.
 guacamole:

--- a/platform/huawei-evs-csi/blueprint.yaml
+++ b/platform/huawei-evs-csi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     catalyst.openova.io/provider: huawei
 spec:
-  version: 1.0.7
+  version: 1.0.8
   card:
     title: Huawei EVS CSI
     summary: |

--- a/platform/huawei-evs-csi/chart/Chart.yaml
+++ b/platform/huawei-evs-csi/chart/Chart.yaml
@@ -89,7 +89,14 @@ name: bp-huawei-evs-csi
 # ownerReference. Stamp `app.kubernetes.io/managed-by: flux` on it too so the
 # 1.0.6 upgrade no longer rolls back on the post-upgrade phase. Completes the
 # hook-label sweep for this chart (both pre- and post- hooks now admitted).
-version: 1.0.7
+# 1.0.8 (#4885): honour global.imageRegistry for the openova-io EVS driver image
+# so the self-sovereign-cutover step-07 image pivot reaches the controller +
+# node driver Pods. New templates/_helpers.tpl driverImage helper (host-swap on
+# the leading registry segment when global.imageRegistry set; verbatim ghcr.io
+# otherwise). New global.imageRegistry:"" seam. The six CSI sidecar images are
+# public harbor.openova.io proxy-k8s mirrors (3rd-party) and are NOT rewritten.
+# Lockstep: 55b-bp-huawei-evs-csi.yaml pin + blueprint.yaml → 1.0.8. Refs #4885.
+version: 1.0.8
 description: |
   Catalyst-curated Blueprint for the open-source huaweicloud-csi-driver EVS
   block-storage plugin (evs.csi.huaweicloud.com). Provides the durable

--- a/platform/huawei-evs-csi/chart/templates/_helpers.tpl
+++ b/platform/huawei-evs-csi/chart/templates/_helpers.tpl
@@ -1,0 +1,27 @@
+{{/*
+bp-huawei-evs-csi template helpers.
+*/}}
+
+{{/*
+Driver image ref with global.imageRegistry rewrite (#4885).
+
+The EVS driver image (image.driver) is the only openova-io first-party image in
+this chart — the six CSI sidecars are public harbor.openova.io proxy-k8s mirrors
+and MUST NOT be rewritten. When .Values.global.imageRegistry is set (the
+self-sovereign-cutover step-07 pivot), the leading registry host of the driver
+repository is swapped for the override (so ghcr.io/openova-io/openova/evs-csi-plugin
+→ registry.<sovereign-fqdn>/openova-io/openova/evs-csi-plugin); when empty the
+ghcr.io ref is emitted verbatim (default byte-identical pre-cutover).
+
+Usage: {{ include "bp-huawei-evs-csi.driverImage" . }}
+*/}}
+{{- define "bp-huawei-evs-csi.driverImage" -}}
+{{- $repo := .Values.image.driver.repository -}}
+{{- $tag := .Values.image.driver.tag -}}
+{{- $globalRegistry := .Values.global.imageRegistry | default "" -}}
+{{- if ne $globalRegistry "" -}}
+{{- printf "%s/%s:%s" $globalRegistry (join "/" (slice (splitList "/" $repo) 1)) $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end -}}

--- a/platform/huawei-evs-csi/chart/templates/controller-deployment.yaml
+++ b/platform/huawei-evs-csi/chart/templates/controller-deployment.yaml
@@ -188,7 +188,9 @@ spec:
             capabilities: { drop: [ALL] }
             seccompProfile: { type: RuntimeDefault }
         - name: evs-csi-plugin
-          image: "{{ $img.driver.repository }}:{{ $img.driver.tag }}"
+          # #4885: honour global.imageRegistry so step-07 cutover pivot reaches
+          # the driver Pod (sidecars stay on their harbor.openova.io mirrors).
+          image: "{{ include "bp-huawei-evs-csi.driverImage" . }}"
           imagePullPolicy: {{ $img.driver.pullPolicy | default "IfNotPresent" }}
           args:
             - "/bin/evs-csi-plugin"

--- a/platform/huawei-evs-csi/chart/templates/node-daemonset.yaml
+++ b/platform/huawei-evs-csi/chart/templates/node-daemonset.yaml
@@ -100,7 +100,9 @@ spec:
             capabilities: { drop: [ALL] }
             seccompProfile: { type: RuntimeDefault }
         - name: evs-csi-plugin
-          image: "{{ $img.driver.repository }}:{{ $img.driver.tag }}"
+          # #4885: honour global.imageRegistry so step-07 cutover pivot reaches
+          # the driver Pod (sidecars stay on their harbor.openova.io mirrors).
+          image: "{{ include "bp-huawei-evs-csi.driverImage" . }}"
           imagePullPolicy: {{ $img.driver.pullPolicy | default "IfNotPresent" }}
           args:
             - "/bin/evs-csi-plugin"

--- a/platform/huawei-evs-csi/chart/values.yaml
+++ b/platform/huawei-evs-csi/chart/values.yaml
@@ -147,6 +147,19 @@ volumeSnapshotClass:
 imagePullSecrets:
   - name: ghcr-pull
 
+# ─── Global registry rewrite (matches catalyst / continuum chart pattern) ──
+# When set, the openova-io DRIVER image (image.driver, below) routes through
+# this registry instead of ghcr.io. Per-Sovereign overlays leave this empty;
+# the self-sovereign-cutover step-07 image pivot (#4885) sets it to
+# registry.<sovereign-fqdn> so the driver pulls from the Sovereign's own Harbor
+# post-cutover (the step-08 deny-egress hold blocks ghcr.io). Empty = no rewrite.
+# The six sidecar images (image.sidecars.*) are PUBLIC harbor.openova.io proxy-k8s
+# mirrors — 3rd-party, NOT openova-io — so they carry their own registry and are
+# deliberately NOT rewritten by this seam. The driverImage helper in
+# templates/_helpers.tpl performs the host-swap.
+global:
+  imageRegistry: ""
+
 image:
   driver:
     repository: ghcr.io/openova-io/openova/evs-csi-plugin

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.137 # lockstep with chart/Chart.yaml (#4477 secondary: catalyst-newapi-admin-token ExternalSecret read-path → catalyst/newapi/admin-token, written by catalyst-api seedNewapiAdminToken)
+  version: 1.4.138 # lockstep with chart/Chart.yaml (#4885: global.imageRegistry seam for openova-io images)
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -1,5 +1,14 @@
 apiVersion: v2
 name: bp-newapi
+# 1.4.138 (#4885): honour global.imageRegistry for the openova-io images
+# (newapi-mirror, newapi-sandbox-bridge, services-metering-sidecar) so the
+# self-sovereign-cutover step-07 image pivot reaches those Pods. New
+# templates/_helpers.tpl `bp-newapi.image` helper (host-swap on the leading
+# registry segment when global.imageRegistry set; verbatim ghcr.io otherwise —
+# default byte-identical pre-cutover). New global.imageRegistry:"" seam. The
+# 3rd-party helper images (harbor.openova.io proxy-* curl / postgres client) are
+# NOT rewritten. Lockstep: 80-newapi.yaml pin + blueprint.yaml + catalog-seed
+# source.version → 1.4.138. Refs #4885.
 # 1.4.136 (#4477 secondary, 2026-06-27): the `catalyst-newapi-admin-token`
 # ExternalSecret's canonical OpenBao read-path moves from the
 # never-written `sovereign/<fqdn>/newapi/admin-token` to the cluster-shared
@@ -928,7 +937,7 @@ name: bp-newapi
 #   drift, then hash-gated reload), mounts the OIDC secret, and its Role reads
 #   it. Live-verified on 91dc0591/omantel.biz: DB secret resynced, pod reloaded
 #   "Loaded 1 custom OAuth providers", KC authenticates the corrected secret.
-version: 1.4.137
+version: 1.4.138
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/_helpers.tpl
+++ b/platform/newapi/chart/templates/_helpers.tpl
@@ -313,3 +313,24 @@ the EFFECTIVE channel list (`.Values.channels` + composed defaults).
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Registry-rewrite image helper (#4885). Given an openova-io "<host>/<path>"
+repository + tag, prepend .Values.global.imageRegistry in place of the leading
+registry host when it is set (self-sovereign-cutover step-07 pivot), else emit
+the ghcr.io ref verbatim (default byte-identical pre-cutover). Mirrors the
+continuum.image pattern. Apply ONLY to openova-io first-party images — the
+3rd-party helper images (harbor.openova.io proxy-* curl / postgres) carry their
+own registry and must NOT be routed through this.
+Usage: {{ include "bp-newapi.image" (dict "repo" <repo> "tag" <tag> "root" $) }}
+*/}}
+{{- define "bp-newapi.image" -}}
+{{- $repo := .repo -}}
+{{- $tag := .tag -}}
+{{- $globalRegistry := .root.Values.global.imageRegistry | default "" -}}
+{{- if ne $globalRegistry "" -}}
+{{- printf "%s/%s:%s" $globalRegistry (join "/" (slice (splitList "/" $repo) 1)) $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end -}}

--- a/platform/newapi/chart/templates/deployment.yaml
+++ b/platform/newapi/chart/templates/deployment.yaml
@@ -182,7 +182,7 @@ spec:
         # as the legacy plain-container bridge (kept identical so the only
         # behavioural change is WHEN it starts and HOW its endpoint publishes).
         - name: sandbox-bridge
-          image: "{{ .Values.sandboxBridge.image.repository }}:{{ .Values.sandboxBridge.image.tag }}"
+          image: {{ include "bp-newapi.image" (dict "repo" .Values.sandboxBridge.image.repository "tag" .Values.sandboxBridge.image.tag "root" $) | quote }}
           imagePullPolicy: {{ .Values.sandboxBridge.image.pullPolicy }}
           restartPolicy: Always
           ports:
@@ -235,7 +235,7 @@ spec:
         # databaseDsnGate.image with any image that also matches the glob +
         # carries the ghcr-pull secret.
         - name: wait-for-sql-dsn
-          image: {{ $dsnGate.image | default (printf "%s:%s" .Values.newapi.image.repository .Values.newapi.image.tag) | quote }}
+          image: {{ $dsnGate.image | default (include "bp-newapi.image" (dict "repo" .Values.newapi.image.repository "tag" .Values.newapi.image.tag "root" $)) | quote }}
           imagePullPolicy: {{ .Values.newapi.image.pullPolicy | default "IfNotPresent" }}
           env:
             - name: DSN_GATE_TIMEOUT_SECONDS
@@ -284,7 +284,7 @@ spec:
       {{- end }}
       containers:
         - name: newapi
-          image: "{{ .Values.newapi.image.repository }}:{{ .Values.newapi.image.tag }}"
+          image: {{ include "bp-newapi.image" (dict "repo" .Values.newapi.image.repository "tag" .Values.newapi.image.tag "root" $) | quote }}
           imagePullPolicy: {{ .Values.newapi.image.pullPolicy }}
           ports:
             - name: http
@@ -438,7 +438,7 @@ spec:
         # signing key + admin secret as the in-binary code path
         # would.
         - name: sandbox-bridge
-          image: "{{ .Values.sandboxBridge.image.repository }}:{{ .Values.sandboxBridge.image.tag }}"
+          image: {{ include "bp-newapi.image" (dict "repo" .Values.sandboxBridge.image.repository "tag" .Values.sandboxBridge.image.tag "root" $) | quote }}
           imagePullPolicy: {{ .Values.sandboxBridge.image.pullPolicy }}
           ports:
             - name: bridge
@@ -477,7 +477,7 @@ spec:
         # see values.yaml `meteringSidecar` for the architecture
         # rationale.
         - name: metering-sidecar
-          image: "{{ .Values.meteringSidecar.image.repository }}:{{ .Values.meteringSidecar.image.tag }}"
+          image: {{ include "bp-newapi.image" (dict "repo" .Values.meteringSidecar.image.repository "tag" .Values.meteringSidecar.image.tag "root" $) | quote }}
           imagePullPolicy: {{ .Values.meteringSidecar.image.pullPolicy }}
           ports:
             - name: metering

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -47,6 +47,20 @@ imagePullSecrets:
 #                sync.fromHost.secrets `newapi/*` mirror + replicateServices.
 placement:
   role: all
+
+# ─── Global registry rewrite (matches catalyst / continuum chart pattern) ──
+# When set, the openova-io images (newapi-mirror, newapi-sandbox-bridge,
+# services-metering-sidecar) route through this registry instead of ghcr.io.
+# Per-Sovereign overlays leave this empty; the self-sovereign-cutover step-07
+# image pivot (#4885) sets it to registry.<sovereign-fqdn> so those Pods pull
+# from the Sovereign's own Harbor post-cutover (the step-08 deny-egress hold
+# blocks ghcr.io). Empty = no rewrite. The 3rd-party helper images
+# (harbor.openova.io proxy-dockerhub curl, proxy-ghcr postgres client) carry
+# their own registry and are NOT rewritten. The bp-newapi.image helper in
+# templates/_helpers.tpl performs the host-swap.
+global:
+  imageRegistry: ""
+
 # ─── NewAPI application ──────────────────────────────────────────────────
 newapi:
   enabled: true

--- a/platform/sandbox/blueprint.yaml
+++ b/platform/sandbox/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-sandbox
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.3.11
+  version: 0.3.12
   card:
     title: Sandbox
     summary: |

--- a/platform/sandbox/chart/Chart.yaml
+++ b/platform/sandbox/chart/Chart.yaml
@@ -119,7 +119,16 @@ annotations:
 # `helm template newapi platform/newapi/chart/ -s templates/service.yaml`
 # → metadata.name: newapi-bp-newapi. Walker on t38 (chart 1.4.216,
 # substrate be4f78bc872e2c56) caught the live regression.
-version: 0.3.11
+# 0.3.12 (#4885): honour global.imageRegistry for the three openova-io images —
+# the sandbox-controller (image) AND the runtime.ptyServerImage / runtime.mcpImage
+# env values the controller stamps into every per-Sandbox child workload. New
+# sandbox.rewriteImageRef helper (host-swap on the leading registry segment when
+# global.imageRegistry set; verbatim ghcr.io otherwise — default byte-identical
+# pre-cutover); sandbox.image now routes through it. New global.imageRegistry:""
+# seam. Ensures the self-sovereign-cutover step-07 pivot reaches both the
+# controller and every child pty/mcp Pod. Lockstep: 19a-bp-sandbox.yaml pin +
+# blueprint.yaml + catalog-seed source.version → 0.3.12. Refs #4885.
+version: 0.3.12
 appVersion: "0.3.7"
 keywords:
   - catalyst

--- a/platform/sandbox/chart/templates/_helpers.tpl
+++ b/platform/sandbox/chart/templates/_helpers.tpl
@@ -38,10 +38,30 @@ catalyst.openova.io/controller: sandbox
 {{/* Resolve the controller image reference. Fails-fast when tag is
      empty so the operator catches the misconfig at `helm template`
      time rather than from a CrashLoopBackoff. */}}
+{{/*
+sandbox.rewriteImageRef (#4885) — apply the global.imageRegistry host-swap to a
+full "<host>/<path>:<tag>" openova-io image ref. When .Values.global.imageRegistry
+is set (self-sovereign-cutover step-07 pivot) the leading registry host is
+replaced (ghcr.io/openova-io/openova/x:tag → registry.<fqdn>/openova-io/openova/x:tag);
+when empty (or the ref is empty) the ref is returned verbatim so the default stays
+byte-identical pre-cutover. Used for the pty-server / mcp env values the controller
+stamps into each per-Sandbox child workload.
+Usage: {{ include "sandbox.rewriteImageRef" (dict "ref" <fullref> "root" $) }}
+*/}}
+{{- define "sandbox.rewriteImageRef" -}}
+{{- $ref := .ref -}}
+{{- $globalRegistry := .root.Values.global.imageRegistry | default "" -}}
+{{- if and (ne $ref "") (ne $globalRegistry "") -}}
+{{- printf "%s/%s" $globalRegistry (join "/" (slice (splitList "/" $ref) 1)) -}}
+{{- else -}}
+{{- $ref -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "sandbox.image" -}}
 {{- $tag := .Values.image.tag | default "" -}}
 {{- if eq $tag "" -}}
 {{- fail "platform/sandbox/chart values.image.tag is empty — CI must stamp a SHA before render. Per docs/INVIOLABLE-PRINCIPLES.md #4a no :latest is permitted." -}}
 {{- end -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- include "sandbox.rewriteImageRef" (dict "ref" (printf "%s:%s" .Values.image.repository $tag) "root" $) -}}
 {{- end -}}

--- a/platform/sandbox/chart/templates/deployment.yaml
+++ b/platform/sandbox/chart/templates/deployment.yaml
@@ -67,7 +67,9 @@ spec:
             # render fast if the per-Sovereign overlay forgets to wire
             # them (Inviolable Principle #4a — no silent :latest).
             - name: SANDBOX_PTY_SERVER_IMAGE
-              value: {{ required "values.runtime.ptyServerImage MUST be set (SHA-pinned per docs/INVIOLABLE-PRINCIPLES.md #4a)" .Values.runtime.ptyServerImage | quote }}
+              # #4885: honour global.imageRegistry so the child pty-server Pods the
+              # controller stamps this into pivot to local Harbor post-cutover.
+              value: {{ include "sandbox.rewriteImageRef" (dict "ref" (required "values.runtime.ptyServerImage MUST be set (SHA-pinned per docs/INVIOLABLE-PRINCIPLES.md #4a)" .Values.runtime.ptyServerImage) "root" $) | quote }}
             # TBD-P4 B2 (#1986, 2026-05-20): SANDBOX_MCP_IMAGE is no
             # longer used by sandbox-controller — the per-Sandbox MCP
             # Deployment was removed (stdio binary cannot run as a Pod).
@@ -80,7 +82,8 @@ spec:
             # remove from values.yaml + bootstrap-kit overlays in a
             # later follow-up once all overlays drop the setting.
             - name: SANDBOX_MCP_IMAGE
-              value: {{ .Values.runtime.mcpImage | default "" | quote }}
+              # #4885: honour global.imageRegistry (empty default → unchanged).
+              value: {{ include "sandbox.rewriteImageRef" (dict "ref" (.Values.runtime.mcpImage | default "") "root" $) | quote }}
             - name: SANDBOX_NEWAPI_URL
               value: {{ required "values.runtime.newapiURL MUST be set (e.g. https://newapi.<sov-fqdn>/v1 - newapi-proxy-contract.md)" .Values.runtime.newapiURL | quote }}
             - name: SANDBOX_LLM_GATEWAY_TOKEN_SECRET

--- a/platform/sandbox/chart/values.yaml
+++ b/platform/sandbox/chart/values.yaml
@@ -10,6 +10,20 @@ enabled: false
 nameOverride: ""
 fullnameOverride: ""
 replicas: 1
+
+# ─── Global registry rewrite (matches catalyst / continuum chart pattern) ──
+# When set, the three openova-io images route through this registry instead of
+# ghcr.io: the sandbox-controller (image, below) AND the per-Sandbox pty-server
+# / mcp-server images (runtime.ptyServerImage / runtime.mcpImage), which the
+# controller reads as env values and stamps into each per-Sandbox workload.
+# Per-Sovereign overlays leave this empty; the self-sovereign-cutover step-07
+# image pivot (#4885) sets it to registry.<sovereign-fqdn> so both the
+# controller and every child pty/mcp Pod pull from the Sovereign's own Harbor
+# post-cutover (the step-08 deny-egress hold blocks ghcr.io). Empty = no rewrite.
+# The sandbox.image + sandbox.rewriteImageRef helpers in _helpers.tpl apply it.
+global:
+  imageRegistry: ""
+
 image:
   repository: ghcr.io/openova-io/openova/sandbox-controller
   tag: "0c717f6"

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -1717,7 +1717,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-guacamole
-    version: "0.2.27"
+    version: "0.2.28"
   topology:
     supported:
     - active-hot-standby
@@ -2340,7 +2340,7 @@ business model is reselling LLM access to its own customers; use
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-newapi
-    version: "1.4.137"
+    version: "1.4.138"
   topology:
     supported:
     - active-passive
@@ -5700,7 +5700,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: sandbox
-    version: "0.3.11"
+    version: "0.3.12"
   topology:
     supported:
       - active-hot-standby


### PR DESCRIPTION
`Refs #4885 #4888` — the residual #4885 cutover wedge: 4 charts that hardcoded `ghcr.io` on their openova-io images now honour `global.imageRegistry`, so the sovereignty-cutover step-07 image pivot reaches their Pods. Chart-only; no live-cluster changes.

## The wedge
The cutover step-07 pivot (PR #4888) rewrites `spec.values.global.imageRegistry` on a curated HR list so post-cutover image pulls hit the Sovereign's own Harbor instead of `ghcr.io`. Under the step-08 deny-egress hold (`github.com` / `ghcr.io` / `harbor.openova.io` blocked), any workload still on `ghcr.io` → 401 → the hold never goes green → `cutoverComplete` never seals. PR #4888 listed these charts as **deliberately excluded** because patching their HR would be a silent no-op until each chart's template honours `global.imageRegistry`. This PR ships that per-chart templating (the prerequisite).

## Fix pattern
Each openova-io image ref routes through a helper that **host-swaps the leading registry segment** when `global.imageRegistry` is set, and emits the **verbatim `ghcr.io` ref** when empty — default byte-identical pre-cutover. Mirrors the existing `bp-catalyst-platform` / `bp-continuum` `splitList`/`slice 1` pattern. A `global.imageRegistry: ""` seam is added to each `values.yaml`. **Registry prefix only** — no image path/tag changes.

| Chart | openova-io image seam changed | helper |
|---|---|---|
| bp-guacamole | `guacamole.guacd.image` + `guacamole.webapp.image` | `_helpers.tpl` `guacdImage`/`webappImage` → new `registryImage` |
| bp-huawei-evs-csi | `image.driver` (controller-deployment + node-daemonset) | new `_helpers.tpl` `driverImage` |
| bp-newapi | `newapi.image` + `sandboxBridge.image` + `meteringSidecar.image` (deployment.yaml x5 incl. dsn-gate default) | new `bp-newapi.image` |
| bp-sandbox | controller `image` **+** `runtime.ptyServerImage` / `runtime.mcpImage` env values the controller stamps into every child pty/mcp Pod | `sandbox.image` + new `sandbox.rewriteImageRef` |

### 3rd-party images left untouched (as required)
- **bp-huawei-evs-csi** — the six CSI sidecars are `harbor.openova.io/proxy-k8s/*` public mirrors.
- **bp-newapi** — the curl (`harbor.openova.io/proxy-dockerhub/curlimages/curl`) + postgres-client (`harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql`) helper images.

These carry their own registry and are not openova-io; `helm template … --set global.imageRegistry=…` confirmed they stay on `harbor.openova.io` under the set case.

## helm-template proof (per image, both modes)
- **empty** `global.imageRegistry` → `ghcr.io/openova-io/openova/<name>:<tag>` (unchanged)
- **set** `registry.t99.omani.works` → `registry.t99.omani.works/openova-io/openova/<name>:<tag>` (host swapped, path + tag preserved)

Verified for all: guacd, webapp, evs-csi-plugin, newapi-mirror, newapi-sandbox-bridge, services-metering-sidecar, sandbox-controller, sandbox-pty-server, sandbox-mcp-server. `helm lint` clean on all 4; full render exits 0 in both modes.

## Locksteps + gates
Per chart: Chart.yaml version bump + bootstrap-kit slot pin + blueprint.yaml + catalog-seed `source.version` (evs-csi has no catalog-seed entry). Versions: guacamole `0.2.27→0.2.28`, huawei-evs-csi `1.0.7→1.0.8`, newapi `1.4.137→1.4.138`, sandbox `0.3.11→0.3.12`.

- `check-bootstrap-kit-pin-sync.sh --changed-only --base origin/main` → **PASS** (4/4 pin==chart)
- `check-catalog-seed-lockstep.sh` → **PASS** (69 checked, 0 fail)

## Follow-ups (NOT in this PR)
1. **Wire into the pivot** — add `bp-guacamole`, `bp-huawei-evs-csi`, `bp-newapi`, `bp-sandbox` to `imageRegistryPivot.additionalHRs` in `platform/self-sovereign-cutover/chart/values.yaml`. That list + the `pivot_extra_hr` mechanism are introduced by PR #4888 (still open, owns chart 0.1.106), so this is a 1-commit follow-up onto #4888 once it merges (or a rebase) — kept out of this PR to avoid a conflict with #4888's `imageRegistryPivot` block. These chart fixes are the hard prerequisite.
2. **org-services (marketplace.yaml / auth.yaml)** — intentionally excluded. Both image lines are `sed`-bumped by the `marketplace-build.yaml` + `services-build.yaml` deploybots on a concrete `image: ghcr.io/…:tag` string; templating them would silently break those image-pin bumps (and the files carry a contabo-mkt raw-Kustomize concrete-string warning + a prior #580 `InvalidImageName` regression). The 7 sibling org-services templates already honour `global.imageRegistry` and are pivoted by the existing bp-catalyst-platform HR patch. Making marketplace/auth honour it needs a coordinated deploybot change (migrate the tag into a `values.yaml` field the deploybot bumps) — filed as the residual, not shippable as a simple prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)