### PR TITLE
fix(#4814): count live WorkerNodes not declared in cloud-graph merge

### DIFF
--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/k8sAdapter.test.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/k8sAdapter.test.ts
@@ -13,6 +13,7 @@
 import { describe, expect, it } from 'vitest'
 import { k8sToGraph, mergeGraphs } from './k8sAdapter'
 import type { K8sObject, K8sSnapshot } from './useK8sCacheStream'
+import type { GraphEdge, GraphNode } from './types'
 
 function snap(...entries: Array<[string, K8sObject]>): K8sSnapshot {
   const m = new Map<string, K8sObject>()
@@ -486,6 +487,121 @@ describe('mergeGraphs', () => {
     }
     const merged = mergeGraphs(cloud, k8s)
     expect(merged.nodes.filter((n) => n.type === 'WorkerNode')).toHaveLength(2)
+  })
+
+  // ── #4814: declared-vs-live WorkerNode over-count ─────────────────
+  // Builds the exact hw232 shape: the declared side (topology_loader
+  // buildNodes) emits synthetic ids + EMPTY worker IPs, so neither the
+  // id match nor the #4732 IP-collapse can fold a declared leaf onto its
+  // live twin. Without rule 3 the graph doubles (declared + live).
+  function declaredRegion(region: string, workers: number, cpEip: string) {
+    const clusterId = `Cluster:cl-${region}`
+    const nodes = [
+      { id: clusterId, type: 'Cluster' as const, label: `cl-${region}`, status: 'healthy' as const },
+      {
+        id: `WorkerNode:node-cp-${region}`,
+        type: 'WorkerNode' as const,
+        label: `node-cp-${region}`,
+        status: 'unknown' as const,
+        // Declared CP carries the public EIP — NOT the live InternalIP.
+        metadata: { sku: 's3.large', role: 'control-plane', ip: cpEip },
+      },
+    ]
+    const edges = [
+      { id: `e:${nodes[1]!.id}->${clusterId}`, source: nodes[1]!.id, target: clusterId, type: 'runs-on' as const },
+    ]
+    for (let i = 0; i < workers; i++) {
+      const id = `WorkerNode:node-w-${i}-${region}`
+      nodes.push({
+        id,
+        type: 'WorkerNode' as const,
+        label: `node-w-${i}-${region}`,
+        status: 'unknown' as const,
+        // Declared WORKER ip is EMPTY (topology_loader buildNodes).
+        metadata: { sku: 's3.large', role: 'worker', ip: '' } as Record<string, string>,
+      } as (typeof nodes)[number])
+      edges.push({ id: `e:${id}->${clusterId}`, source: id, target: clusterId, type: 'runs-on' as const })
+    }
+    return { nodes, edges }
+  }
+
+  function liveRegion(region: string, workers: number, ipBase: string) {
+    const nodes = [
+      {
+        id: `WorkerNode:catalyst-hw232-${region}-cp1`,
+        type: 'WorkerNode' as const,
+        label: `catalyst-hw232-${region}-cp1`,
+        status: 'healthy' as const,
+        metadata: { ip: `${ipBase}.10`, kubeletVersion: 'v1.31.4+k3s1' } as Record<string, string>,
+      },
+    ]
+    for (let i = 0; i < workers; i++) {
+      nodes.push({
+        id: `WorkerNode:catalyst-hw232-${region}-w${i}abc`,
+        type: 'WorkerNode' as const,
+        label: `catalyst-hw232-${region}-w${i}abc`,
+        status: 'healthy' as const,
+        metadata: { ip: `${ipBase}.${20 + i}`, kubeletVersion: 'v1.31.4+k3s1' } as Record<string, string>,
+      })
+    }
+    return { nodes, edges: [] as GraphEdge[] }
+  }
+
+  function concat(...gs: Array<{ nodes: GraphNode[]; edges: GraphEdge[] }>) {
+    return { nodes: gs.flatMap((g) => g.nodes), edges: gs.flatMap((g) => g.edges) }
+  }
+
+  it('#4814: two live regions ×(1 cp + 5 workers) collapse 24→12 (count live, not declared)', () => {
+    // hw232: BOTH regions fully live. 12 declared (synthetic id, empty
+    // worker IP) + 12 live (real name + IP) → must render 12, not 24.
+    const cloud = concat(
+      declaredRegion('me-east-215-a', 5, '203.0.113.1'),
+      declaredRegion('me-east-215-b', 5, '203.0.113.2'),
+    )
+    const k8s = concat(
+      liveRegion('me-east-215-a', 5, '10.209.1'),
+      liveRegion('me-east-215-b', 5, '10.219.1'),
+    )
+    // Before the fix: 12 + 12 = 24.
+    expect(cloud.nodes.filter((n) => n.type === 'WorkerNode')).toHaveLength(12)
+    expect(k8s.nodes.filter((n) => n.type === 'WorkerNode')).toHaveLength(12)
+
+    const merged = mergeGraphs(cloud, k8s)
+    const workers = merged.nodes.filter((n) => n.type === 'WorkerNode')
+    expect(workers).toHaveLength(12)
+    // Every surviving WorkerNode is a live leaf (real name), carrying
+    // the live Ready status — no synthetic declared placeholder remains.
+    expect(workers.every((n) => n.id.startsWith('WorkerNode:catalyst-hw232-'))).toBe(true)
+    expect(workers.every((n) => n.status === 'healthy')).toBe(true)
+    // The declared Cluster structural layer is preserved.
+    expect(merged.nodes.filter((n) => n.type === 'Cluster')).toHaveLength(2)
+  })
+
+  it('#4814: declared-only preview (no live nodes) keeps every declared WorkerNode leaf', () => {
+    // Pre-convergence: the k8s stream is empty. Nothing is suppressed —
+    // the declared topology still renders in full.
+    const cloud = concat(declaredRegion('me-east-215-a', 5, '203.0.113.1'))
+    const merged = mergeGraphs(cloud, { nodes: [], edges: [] })
+    // 1 cp + 5 workers = 6 declared leaves, all kept.
+    expect(merged.nodes.filter((n) => n.type === 'WorkerNode')).toHaveLength(6)
+    // Their runs-on → Cluster edges survive too.
+    expect(merged.edges.filter((e) => e.type === 'runs-on')).toHaveLength(6)
+  })
+
+  it('#4814: a live-absent secondary region is counted by its live nodes only (no fabricated leaves)', () => {
+    // region-a live (1 cp + 5 workers = 6 real), region-b declared but
+    // NOT provisioned (0 live). The over-count fix reports the 6 live
+    // nodes — region-b contributes no fabricated WorkerNode leaves.
+    const cloud = concat(
+      declaredRegion('me-east-215-a', 5, '203.0.113.1'),
+      declaredRegion('me-east-215-b', 5, '203.0.113.2'),
+    )
+    const k8s = concat(liveRegion('me-east-215-a', 5, '10.209.1'))
+    const merged = mergeGraphs(cloud, k8s)
+    expect(merged.nodes.filter((n) => n.type === 'WorkerNode')).toHaveLength(6)
+    // Both declared Clusters remain so region-b's declared capacity is
+    // still structurally visible (degraded, live-empty).
+    expect(merged.nodes.filter((n) => n.type === 'Cluster')).toHaveLength(2)
   })
 
   it('deduplicates edges that appear in both adapters with the same (source,target,type)', () => {

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/k8sAdapter.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/k8sAdapter.ts
@@ -531,6 +531,26 @@ function kindToArchType(kind: 'deployment' | 'statefulset' | 'daemonset'): ArchN
  *      fleet, so IP equality IS node identity. Without this rule every
  *      node rendered twice (12 real nodes → "24/24" on the graph while
  *      the list view showed the true 12).
+ *   3. #4814: rules 1 + 2 both FAIL when the declared side carries no
+ *      identity that can match a live node. The topology_loader's
+ *      declared `buildNodes` emits synthetic ids
+ *      (`node-w-<i>-<region>` / `node-cp-<region>`) AND leaves worker
+ *      `ip` EMPTY (only the control-plane gets an EIP, which is not the
+ *      live InternalIP). So neither the id match nor the IP-keyed
+ *      collapse fires, and a 2-region ×(1 cp + 5 worker) prov renders
+ *      12 declared + 12 live = "24/24" — an exact 2× over-count of the
+ *      12 physical nodes. There is no per-node key that can ever fold
+ *      the declared placeholders onto their live twins (the live node
+ *      name is a random hash, not the declared ordinal), so we count
+ *      LIVE, not declared: when confirmed-live WorkerNodes are present
+ *      (a standalone k8s Node WITH a non-empty InternalIP), the
+ *      remaining declared WorkerNode leaves that did NOT collapse onto
+ *      a live node are dropped — the live nodes are the leaves. The
+ *      declared Region / Cluster / NodePool structural layer stays, so
+ *      declared capacity is still visible (and a live-absent region
+ *      still shows its NodePool). Pre-convergence, when no live Node
+ *      has streamed yet, every declared placeholder is kept so the
+ *      declared-only preview still renders.
  *
  * Edges referencing a collapsed k8s id are rewritten to the surviving
  * cloud id so neighbour lookups (Pod runs-on, Volume attached-to) stay
@@ -552,6 +572,14 @@ export function mergeGraphs(cloud: AdaptResult, k8s: AdaptResult): AdaptResult {
   }
   // k8s id → surviving cloud id, for edge rewriting.
   const aliasedTo = new Map<string, string>()
+  // #4814: cloud-side WorkerNode ids that DID absorb a live payload
+  // (via rule 1 id-match or rule 2 IP-collapse). These represent a
+  // confirmed physical node and must never be dropped by rule 3.
+  const declaredWorkersMergedWithLive = new Set<string>()
+  // #4814: k8s WorkerNodes that rendered standalone (no declared twin).
+  // A non-empty InternalIP marks a CONFIRMED live node — the signal
+  // that the declared placeholders for that fleet are now redundant.
+  let confirmedLiveWorkerPresent = false
 
   // Emit cloud nodes first (provenance). When a k8s node has the same
   // id, fold the k8s payload onto the cloud node.
@@ -565,6 +593,7 @@ export function mergeGraphs(cloud: AdaptResult, k8s: AdaptResult): AdaptResult {
       if (idx >= 0) {
         merged[idx] = mergeNodePayloads(merged[idx]!, kn)
       }
+      if (kn.type === 'WorkerNode') declaredWorkersMergedWithLive.add(kn.id)
       continue
     }
     // Rule 2 — IP-keyed WorkerNode collapse.
@@ -576,13 +605,34 @@ export function mergeGraphs(cloud: AdaptResult, k8s: AdaptResult): AdaptResult {
         if (idx >= 0) {
           merged[idx] = mergeNodePayloads(merged[idx]!, kn)
         }
+        declaredWorkersMergedWithLive.add(cloudId)
         aliasedTo.set(kn.id, cloudId)
         continue
       }
+      // Standalone live WorkerNode — a real node with no declared twin.
+      if (ip) confirmedLiveWorkerPresent = true
     }
     seen.add(kn.id)
     merged.push(kn)
   }
+
+  // #4814 (rule 3) — count LIVE, not declared. When at least one
+  // confirmed live WorkerNode is present, the declared WorkerNode
+  // leaves that never collapsed onto a live node are the un-matchable
+  // duplicates the topology_loader emitted (synthetic id + empty
+  // worker IP); drop them so each physical node is counted ONCE. The
+  // declared Cluster / NodePool structural layer is untouched, so
+  // declared capacity stays visible. With no live node yet (declared-
+  // only preview) nothing is dropped.
+  let survivingNodes = merged
+  if (confirmedLiveWorkerPresent) {
+    survivingNodes = merged.filter((n) => {
+      if (n.type !== 'WorkerNode') return true
+      if (!cloudNodesById.has(n.id)) return true // live-originated leaf — keep
+      return declaredWorkersMergedWithLive.has(n.id) // declared: keep only if it has a live twin
+    })
+  }
+  const survivingIds = new Set(survivingNodes.map((n) => n.id))
 
   // Rewrite edges that referenced a collapsed k8s WorkerNode id to the
   // surviving cloud id, so Pod runs-on / Volume attached-to edges land
@@ -604,13 +654,12 @@ export function mergeGraphs(cloud: AdaptResult, k8s: AdaptResult): AdaptResult {
     seenEdges.add(k)
     dedupedEdges.push(e)
   }
-  // Drop edges whose endpoints aren't in the merged node set.
+  // Drop edges whose endpoints aren't in the surviving node set (this
+  // also sheds the runs-on edges of any #4814-dropped declared leaf).
   const merge: AdaptResult = {
-    nodes: merged,
-    edges: dedupedEdges.filter((e) => seen.has(e.source) && seen.has(e.target)),
+    nodes: survivingNodes,
+    edges: dedupedEdges.filter((e) => survivingIds.has(e.source) && survivingIds.has(e.target)),
   }
-  // unused but keeps the variable referenced under strict TS noUnusedLocals
-  void cloudNodesById
   return merge
 }
 


### PR DESCRIPTION
## What

The operator-console **Cloud graph** (`/cloud?view=graph`) rendered the `WorkerNode` count chip as **24/24** on a 2-region ×(1 control-plane + 5 worker) prov whose real fleet is **12 physical nodes** (hw232, 2026-07-09) — an exact 2× over-count.

## Root cause (proven on hw232)

The chip counts `WorkerNode`-type composites in the UI-side merge of two adapters:

1. **Declared adapter** (`adapter.ts`) — one `WorkerNode` per node from the topology_loader's declared build. Ids are **synthetic** (`node-w-<i>-<region>` / `node-cp-<region>`) and declared **workers carry an empty `ip`** (only the control-plane gets an EIP, which is not the live InternalIP).
2. **Live k8s adapter** (`k8sAdapter.ts`) — one `WorkerNode` per live Node, with real names + InternalIPs.
3. **`mergeGraphs`** collapses a declared/live pair only by (a) exact id match or (b) the #4732 InternalIP-keyed collapse. On the declared path **both fail** — synthetic id ≠ live name, and the empty worker `ip` is skipped by the IP collapse. Result: `12 declared + 12 live = 24`.

There is no per-node key that can ever fold a declared placeholder onto its live twin (the live node name is a random hash, not the declared ordinal).

## The change

`mergeGraphs` now **counts live, not declared**. After the existing id-match + IP-collapse passes, when a **confirmed live** `WorkerNode` is present (a standalone k8s Node with a non-empty InternalIP), the declared `WorkerNode` leaves that never collapsed onto a live node are dropped so each physical node is counted **once**.

- The declared **Region / Cluster / NodePool** structural layer is untouched — declared capacity stays visible, and a live-absent region still shows its NodePool.
- **Pre-convergence** (no live Node streamed yet) every declared placeholder is kept, so the declared-only preview still renders in full.
- Gating suppression on a **non-empty** live InternalIP keeps the existing "no false identity" collapse test green (an unconfirmed empty-IP node never triggers suppression).

## Proof (before → after)

New `mergeGraphs` tests assert the exact hw232 numbers:

| Case | Declared | Live | Merged (was) | Merged (now) |
|---|---|---|---|---|
| Two live regions ×(1 cp + 5 w) | 12 | 12 | 24 | **12** |
| Declared-only preview (no live) | 6 | 0 | 6 | **6** (unchanged) |
| Live-absent secondary region | 12 | 6 | 18 | **6** |

`vitest run` on the architecture-graph widget: **83 passed**. Every surviving leaf in the two-live-region case is a live k8s node carrying the live Ready status; both declared Clusters are preserved.

Refs #4814

🤖 Generated with [Claude Code](https://claude.com/claude-code)