### PR TITLE
fix(#4885): wire 4 imageRegistry-honouring charts into cutover step-07 pivot

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -727,10 +727,15 @@ spec:
       # hook is now gated on trigger.fireCutoverOnHandover (wired from
       # ${FIRE_CUTOVER_ON_HANDOVER:-false} below) so an operator's
       # fireCutoverOnHandover=false suppresses the auto-fire, consistent with the
-      # catalyst-api reconciler (#4061). Charts that don't honour
-      # global.imageRegistry (bp-guacamole/bp-huawei-evs-csi/bp-newapi/bp-sandbox/
-      # org-services) are excluded pending a per-chart templating fix (#4885).
-      version: 0.1.106
+      # catalyst-api reconciler (#4061).
+      # 0.1.107 (#4885 Refs #4888 #4892): bp-guacamole / bp-huawei-evs-csi /
+      # bp-newapi / bp-sandbox now honour global.imageRegistry (#4892 per-chart
+      # image-helper fix), so they are ADDED to imageRegistryPivot.additionalHRs
+      # and step-07 pivots them to the local Harbor at cutover; each slot file
+      # gains the 6-space `global.imageRegistry: ''` seam so the durable Gitea
+      # edit persists. Only org-services (marketplace/auth concrete deploybot-
+      # bumped ghcr.io refs) stays excluded — the #4885 residual.
+      version: 0.1.107
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
+++ b/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
@@ -237,6 +237,13 @@ spec:
   # the canonical path is bumping chart values.yaml + bootstrap-kit
   # pin (single source of truth, INVIOLABLE-PRINCIPLES.md #4a).
   values:
+    # #4885 / #4892: global.imageRegistry override seam for the step-07 cutover
+    # image-registry pivot (imageRegistryPivot.additionalHRs). step-07 patches
+    # this HR's spec.values.global.imageRegistry live AND durably sed-edits THIS
+    # file — the sed matches `^      imageRegistry:`, so the 6-space indent is
+    # REQUIRED. Empty default = verbatim ghcr.io (byte-identical pre-cutover).
+    global:
+      imageRegistry: ''
     enabled: ${SANDBOX_ENABLED:-true}
     # G91.sandbox (#2657) — wire bp-sso-bridge framework. The chart-side
     # SANDBOX_SSO_* env-vars on the sandbox-controller Pod are sourced

--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -206,6 +206,13 @@ spec:
   # below is replaced with the concrete sovereign FQDN before the HR
   # bytes land in the cluster.
   values:
+    # #4885 / #4892: global.imageRegistry override seam for the step-07 cutover
+    # image-registry pivot (imageRegistryPivot.additionalHRs). step-07 patches
+    # this HR's spec.values.global.imageRegistry live AND durably sed-edits THIS
+    # file — the sed matches `^      imageRegistry:`, so the 6-space indent is
+    # REQUIRED. Empty default = verbatim ghcr.io (byte-identical pre-cutover).
+    global:
+      imageRegistry: ''
     # ── Bootstrap self-registration (#3687, extends #3370) ──────────────
     # The chart self-registers the Application CR for guacamole (the
     # canonical instance representation every console surface reads),

--- a/clusters/_template/bootstrap-kit/55b-bp-huawei-evs-csi.yaml
+++ b/clusters/_template/bootstrap-kit/55b-bp-huawei-evs-csi.yaml
@@ -225,6 +225,13 @@ spec:
   # storage-durability gate fails it (local-path is FORBIDDEN, never a silent
   # fallback). See #3971 #892.
   values:
+    # #4885 / #4892: global.imageRegistry override seam for the step-07 cutover
+    # image-registry pivot (imageRegistryPivot.additionalHRs). step-07 patches
+    # this HR's spec.values.global.imageRegistry live AND durably sed-edits THIS
+    # file — the sed matches `^      imageRegistry:`, so the 6-space indent is
+    # REQUIRED. Empty default = verbatim ghcr.io (byte-identical pre-cutover).
+    global:
+      imageRegistry: ''
     enabled: ${EVS_CSI_ENABLED:=true}
     defaultStorageClass: ${EVS_CSI_ENABLED:=true}
     # idc=true (chart default) engages the no-Keystone AK/SK bypass — REQUIRED

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -346,6 +346,13 @@ spec:
   # family model, `qwen3-coder`); the operator overlay overrides any of
   # these by setting them in this HelmRelease's spec.values.
   values:
+    # #4885 / #4892: global.imageRegistry override seam for the step-07 cutover
+    # image-registry pivot (imageRegistryPivot.additionalHRs). step-07 patches
+    # this HR's spec.values.global.imageRegistry live AND durably sed-edits THIS
+    # file — the sed matches `^      imageRegistry:`, so the 6-space indent is
+    # REQUIRED. Empty default = verbatim ghcr.io (byte-identical pre-cutover).
+    global:
+      imageRegistry: ''
     database:
       # #4291 DE-VCLUSTER — newapi OWNS its CNPG natively in host ns `newapi`
       # (cnpg.enabled below), and the chart's own DSN-sync Job writes exactly

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.106
+  version: 0.1.107
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,22 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.107 (#4885 Refs #4888 #4892, wire the four newly-honouring charts into the
+# step-07 image-registry pivot): #4888 introduced
+# .Values.imageRegistryPivot.additionalHRs + the pivot_extra_hr() mechanism
+# (seeded [bp-continuum]); #4892 then made bp-guacamole / bp-huawei-evs-csi /
+# bp-newapi / bp-sandbox honour global.imageRegistry (each per-chart image helper
+# now host-swaps the leading registry segment when set, verbatim ghcr.io when
+# empty). This bump ADDS those four HRs to additionalHRs so step-07 pivots them to
+# the local Harbor at cutover with the IDENTICAL live-HR-patch + durable-Gitea-edit
+# pattern already used for bp-catalyst-platform / bp-openova-flow-server /
+# bp-continuum. Each of the four bootstrap-kit slot files (19a-bp-sandbox /
+# 52-bp-guacamole / 55b-bp-huawei-evs-csi / 80-newapi) gains the required 6-space
+# `global.imageRegistry: ''` seam so the durable Gitea edit persists (the
+# 62-bp-continuum.yaml precedent from #4888). Only org-services (marketplace/auth
+# concrete deploybot-bumped ghcr.io refs) stays excluded — the #4885 residual. NO
+# step-count / job-mode / RBAC change (still 11 steps; the pivot is additive shell
+# in step-07). Lockstep w/ blueprint.yaml + 06a slot pin + catalog seed.
+# Refs #4885 #4888 #4892.
 # 0.1.106 (#4885 Refs #3379 #4563 #4061, hw232 live-walk: cutover wedged at
 # step-08 deny-egress hold because step-07 pivoted only 2 HRs + the auto-trigger
 # ignored the operator flag): TWO chart fixes.
@@ -1539,7 +1556,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.106
+version: 0.1.107
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -680,26 +680,49 @@ catalystAPI:
 # ⚠️ ONLY list charts VERIFIED to template their images through
 # global.imageRegistry. Patching an HR whose chart does NOT read the value is a
 # SILENT NO-OP — the workload stays on ghcr.io and step-08 still FATALs, but the
-# cutover log falsely reports the pivot "OK". The following #4885 offenders were
-# verified to NOT honour global.imageRegistry and are DELIBERATELY EXCLUDED —
-# each needs a SEPARATE per-chart templating fix (make its image helper honour
-# global.imageRegistry + add a slot seam) before it can be added here:
-#   - bp-guacamole        (platform/guacamole:  guacd/webapp images are literal
-#                          .Values.guacamole.*.image.repository = ghcr.io/...)
-#   - bp-huawei-evs-csi   (platform/huawei-evs-csi: driver image is literal
-#                          $img.driver.repository = ghcr.io/...)
-#   - bp-newapi           (platform/newapi: newapi/sandboxBridge/meteringSidecar
-#                          images are literal .Values.*.image.repository)
-#   - bp-sandbox          (platform/sandbox: controller/pty/mcp images literal)
+# cutover log falsely reports the pivot "OK".
+#
+# #4892 (Refs #4885): bp-guacamole / bp-huawei-evs-csi / bp-newapi / bp-sandbox
+# were FORMERLY excluded (their openova-io images were literal ghcr.io refs). The
+# per-chart templating fix landed in #4892 — each image helper now host-swaps the
+# leading registry segment when global.imageRegistry is set (verbatim ghcr.io when
+# empty, byte-identical pre-cutover) — so they are now VERIFIED to honour the value
+# and are listed below. Their bootstrap-kit slot files each carry a
+# `global.imageRegistry: ''` seam at 6-space indent (added in lockstep with this
+# chart bump) so the durable Gitea edit sticks.
+#
+# STILL DELIBERATELY EXCLUDED — the residual offender a plain global.imageRegistry
+# prefix cannot fix (needs a SEPARATE change before it can be added here):
 #   - org-services        (products/catalyst/chart/templates/org-services:
-#                          marketplace.yaml + auth.yaml hardcode ghcr.io — the
-#                          rest already pivot via the bp-catalyst-platform HR)
-# Tracked in #4885 as the residual cutover blocker.
+#                          marketplace.yaml + auth.yaml carry concrete
+#                          `image: ghcr.io/...:tag` strings the marketplace-build /
+#                          services-build deploybots sed-bump — templating them
+#                          would break those image-pin bumps. The 7 sibling
+#                          org-services templates already honour global.imageRegistry
+#                          and pivot via the bp-catalyst-platform HR patch. Needs a
+#                          coordinated deploybot change; tracked in #4885 as the
+#                          residual cutover blocker.)
 imageRegistryPivot:
   additionalHRs:
     - name: bp-continuum
       namespace: flux-system
       slotFile: clusters/_template/bootstrap-kit/62-bp-continuum.yaml
+    # #4892 (Refs #4885): the four charts formerly excluded above now honour
+    # global.imageRegistry, so their HRs pivot cleanly (no longer silent no-ops).
+    # Each metadata.name matches the live HelmRelease the cutover patches, and
+    # each slotFile carries the 6-space `global.imageRegistry: ''` seam.
+    - name: bp-guacamole
+      namespace: flux-system
+      slotFile: clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+    - name: bp-huawei-evs-csi
+      namespace: flux-system
+      slotFile: clusters/_template/bootstrap-kit/55b-bp-huawei-evs-csi.yaml
+    - name: bp-newapi
+      namespace: flux-system
+      slotFile: clusters/_template/bootstrap-kit/80-newapi.yaml
+    - name: bp-sandbox
+      namespace: flux-system
+      slotFile: clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
 
 # Step container images. The first three steps (01..03) + the
 # registry-pivot DaemonSet use upstream-public images because they run

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5036,7 +5036,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.106"
+    version: "0.1.107"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
`Refs #4885 #4888 #4892` — the small follow-up that completes the #4885 cutover image-registry pivot: wire the four charts that #4892 taught to honour `global.imageRegistry` into the cutover's curated pivot list so step-07 actually patches them at cutover. Chart-only; no live-cluster changes.

## Context
- **#4888 (merged)** introduced `.Values.imageRegistryPivot.additionalHRs` + the `pivot_extra_hr()` mechanism in `platform/self-sovereign-cutover/chart/`, seeded `[bp-continuum]`. It listed `bp-guacamole` / `bp-huawei-evs-csi` / `bp-newapi` / `bp-sandbox` as **deliberately excluded** because patching an HR whose chart ignores `global.imageRegistry` is a silent no-op.
- **#4892 (open, the hard prerequisite)** makes those four charts honour `global.imageRegistry` (each per-chart image helper host-swaps the leading registry segment when set, verbatim `ghcr.io` when empty). Its own follow-up note asks for exactly this wiring, kept out of #4892 to avoid a conflict with #4888's `imageRegistryPivot` block.

## The change
1. Add the four HRs to `imageRegistryPivot.additionalHRs` (alongside `bp-continuum`) in `platform/self-sovereign-cutover/chart/values.yaml`. Each `metadata.name` was verified against the live HelmRelease the cutover targets in the bootstrap-kit slot file (`bp-guacamole` / `bp-huawei-evs-csi` / `bp-newapi` / `bp-sandbox`, all in `flux-system`).
2. Add the required 6-space `global.imageRegistry: ''` seam to each of the four bootstrap-kit slot files (`19a-bp-sandbox` / `52-bp-guacamole` / `55b-bp-huawei-evs-csi` / `80-newapi`) so step-07's durable Gitea sed-edit persists the live HR patch — the same `62-bp-continuum.yaml` precedent #4888 established. Without the seam the durable edit silently no-ops and Flux reverts the pivot to `ghcr.io`.
3. Refresh the excluded-set docs: only `org-services` (marketplace/auth carry concrete `image: ghcr.io/...:tag` strings the deploybots sed-bump) stays excluded — the #4885 residual.

Cutover chart `0.1.106 -> 0.1.107`; lockstep `blueprint.yaml` + slot-06a pin + catalog-seed `source.version`.

## helm-template proof — step-07 pivots all 7 HRs
`helm template` of `templates/07-catalyst-api-env-patch-job.yaml` renders:
```
pivot_extra_hr "bp-continuum"        "flux-system" "clusters/_template/bootstrap-kit/62-bp-continuum.yaml"
pivot_extra_hr "bp-guacamole"        "flux-system" "clusters/_template/bootstrap-kit/52-bp-guacamole.yaml"
pivot_extra_hr "bp-huawei-evs-csi"   "flux-system" "clusters/_template/bootstrap-kit/55b-bp-huawei-evs-csi.yaml"
pivot_extra_hr "bp-newapi"           "flux-system" "clusters/_template/bootstrap-kit/80-newapi.yaml"
pivot_extra_hr "bp-sandbox"          "flux-system" "clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml"
```
plus the two hardcoded pivots (`HR_NAME=bp-catalyst-platform`, `FLOW_HR_NAME=bp-openova-flow-server`). The step-07 durable-edit sed substitutes the `''` seam to `'registry.<fqdn>'` correctly on all five slot files (simulated).

## Gates
- `helm lint` clean; `helm template` exit 0.
- Cutover contract test (`tests/cutover-contract.sh`) — all 35 cases green (step count / job-mode unchanged; the pivot is additive shell in step-07).
- `check-bootstrap-kit-pin-sync.sh --changed-only --base origin/main` — PASS (chart 0.1.107 == pin 0.1.107).
- `check-catalog-seed-lockstep.sh` — PASS (69 checked, 0 fail).
- All four edited slot files parse (`yq`).

## Coordination with #4892
#4892 owns the per-chart templating + its own pins; this PR owns the pivot wiring + the four slot seams. The seam additions sit 22–50 lines from #4892's pin bumps in each slot file (different hunks), so whichever merges second auto-merges cleanly. Both must land before a cutover runs for the four pivots to be durable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
