### PR TITLE
fix(#4896): reconcile bp- prefix in Blueprint Edit-IaC dry-run/apply

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/k8s_resource_actions.go
+++ b/products/catalyst/bootstrap/api/internal/handler/k8s_resource_actions.go
@@ -31,8 +31,8 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/yaml"
@@ -305,7 +305,7 @@ func (h *Handler) handleApplyOrDryRun(w http.ResponseWriter, r *http.Request, dr
 		writeBadRequest(w, "missing-metadata-name", "metadata.name is required")
 		return
 	}
-	if parsed.GetName() != name {
+	if parsed.GetName() != name && !reconcileBlueprintBareName(parsed, kindName, name) {
 		writeBadRequest(w, "name-mismatch", fmt.Sprintf(
 			"yaml metadata.name=%q does not match URL name=%q", parsed.GetName(), name))
 		return
@@ -414,6 +414,41 @@ func (h *Handler) handleApplyOrDryRun(w http.ResponseWriter, r *http.Request, dr
 		"resourceVersion": updated.GetResourceVersion(),
 	}
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// reconcileBlueprintBareName bridges the Blueprint `bp-` prefix convention in
+// the catalog Edit-IaC (YamlEditor) dry-run/apply path (#4896).
+//
+// The catalog IaC editor seeds itself from the AUTHORED `blueprint.yaml`, whose
+// `metadata.name` is the BARE slug (e.g. "alloy"), while the in-cluster
+// Blueprint CR — and therefore the request URL — use the canonical `bp-` prefix
+// (e.g. "bp-alloy") per docs/ARCHITECTURE §4 (Naming) + the chart's
+// catalog-seed. A dry-run/apply of the UNCHANGED blueprint.yaml would otherwise
+// fail the name-match guard with
+//
+//	400 "yaml metadata.name='alloy' does not match URL name='bp-alloy'"
+//
+// even though it names the very same CR, blocking every full-CR IaC commit for
+// bp-prefixed blueprints (hw232, UAT rows 145/148/154).
+//
+// When (and only when) the resource is a Blueprint AND the URL name is exactly
+// "bp-"+parsed.name, the two are the SAME identity: we stamp the URL form onto
+// the parsed object so the downstream k8s Update targets the real `bp-<slug>`
+// CR, and report the match as reconciled. Every other case — a different kind,
+// or a genuine rename (bare `alloy`→`loki`, or prefixed `bp-alloy`→`bp-loki`) —
+// still fails the guard, so its protective purpose (rejecting a mis-targeted /
+// renamed CR) is preserved.
+func reconcileBlueprintBareName(parsed *unstructured.Unstructured, kindName, urlName string) bool {
+	// kindName is the canonical registry Kind.Name (see parseResourceParams);
+	// the Blueprint CRD registers as "blueprint".
+	if kindName != "blueprint" {
+		return false
+	}
+	if urlName == "bp-"+parsed.GetName() {
+		parsed.SetName(urlName)
+		return true
+	}
+	return false
 }
 
 // ── Internal helpers ────────────────────────────────────────────────

--- a/products/catalyst/bootstrap/api/internal/handler/k8s_resource_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/k8s_resource_test.go
@@ -61,11 +61,17 @@ func newResourceRig(t *testing.T, objs ...runtime.Object) *k8sResourceTestRig {
 	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}, &unstructured.Unstructured{})
 	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSetList"}, &unstructured.UnstructuredList{})
 	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"}, &unstructured.Unstructured{})
+	// Blueprint is a CLUSTER-scoped catalyst CRD (products/catalyst/chart/crds
+	// /blueprint.yaml: scope: Cluster). Registered here so the #4896 Edit-IaC
+	// dry-run test can route through the real handler against a seeded CR.
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "catalyst.openova.io", Version: "v1", Kind: "BlueprintList"}, &unstructured.UnstructuredList{})
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "catalyst.openova.io", Version: "v1", Kind: "Blueprint"}, &unstructured.Unstructured{})
 	gvrToListKind := map[schema.GroupVersionResource]string{
-		{Version: "v1", Resource: "pods"}:                        "PodList",
-		{Version: "v1", Resource: "configmaps"}:                  "ConfigMapList",
-		{Group: "apps", Version: "v1", Resource: "deployments"}:  "DeploymentList",
-		{Group: "apps", Version: "v1", Resource: "replicasets"}:  "ReplicaSetList",
+		{Version: "v1", Resource: "pods"}:                                     "PodList",
+		{Version: "v1", Resource: "configmaps"}:                               "ConfigMapList",
+		{Group: "apps", Version: "v1", Resource: "deployments"}:               "DeploymentList",
+		{Group: "apps", Version: "v1", Resource: "replicasets"}:               "ReplicaSetList",
+		{Group: "catalyst.openova.io", Version: "v1", Resource: "blueprints"}: "BlueprintList",
 	}
 	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, objs...)
 	core := kfake.NewSimpleClientset()
@@ -76,6 +82,9 @@ func newResourceRig(t *testing.T, objs ...runtime.Object) *k8sResourceTestRig {
 		{Name: "configmap", GVR: schema.GroupVersionResource{Version: "v1", Resource: "configmaps"}, Namespaced: true, Sensitive: true},
 		{Name: "deployment", GVR: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}, Namespaced: true},
 		{Name: "replicaset", GVR: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "replicasets"}, Namespaced: true},
+		// Mirrors products/catalyst/bootstrap/api/internal/k8scache/kinds.go
+		// so the #4896 Edit-IaC dry-run routes resolve the Blueprint kind.
+		{Name: "blueprint", GVR: schema.GroupVersionResource{Group: "catalyst.openova.io", Version: "v1", Resource: "blueprints"}, Namespaced: true},
 	} {
 		_ = r.Add(k)
 	}
@@ -165,6 +174,25 @@ func newDeploymentObj(ns, name string, replicas int64) *unstructured.Unstructure
 					"labels": map[string]any{"app": "wp"},
 				},
 			},
+		},
+	}}
+}
+
+// newBlueprintObj builds a cluster-scoped Blueprint CR named with the
+// canonical `bp-` prefix (e.g. "bp-alloy"), as the chart's catalog-seed
+// ships it. No metadata.namespace — the CRD is cluster-scoped.
+func newBlueprintObj(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "catalyst.openova.io/v1",
+		"kind":       "Blueprint",
+		"metadata": map[string]any{
+			"name":            name,
+			"uid":             "uid-bp-" + name,
+			"resourceVersion": "7",
+		},
+		"spec": map[string]any{
+			"version": "1.0.2",
+			"card":    map[string]any{"title": "Alloy"},
 		},
 	}}
 }
@@ -449,6 +477,110 @@ spec: {}
 	rig.router().ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status: got %d want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "name-mismatch") {
+		t.Fatalf("expected name-mismatch error, got %s", rec.Body.String())
+	}
+}
+
+// TestReconcileBlueprintBareName is the #4896 unit contract for the
+// bp-prefix name reconciliation used by the Edit-IaC dry-run/apply guard.
+func TestReconcileBlueprintBareName(t *testing.T) {
+	mk := func(name string) *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "catalyst.openova.io/v1",
+			"kind":       "Blueprint",
+			"metadata":   map[string]any{"name": name},
+		}}
+	}
+	// Authored bare slug vs canonical bp-prefixed URL → SAME identity:
+	// reconciled, and parsed.name stamped to the URL form so the k8s
+	// Update targets the real bp-<slug> CR.
+	p := mk("alloy")
+	if !reconcileBlueprintBareName(p, "blueprint", "bp-alloy") {
+		t.Fatalf("bare 'alloy' vs URL 'bp-alloy' should reconcile")
+	}
+	if p.GetName() != "bp-alloy" {
+		t.Fatalf("parsed name not stamped: got %q want %q", p.GetName(), "bp-alloy")
+	}
+	// A genuine rename (bare) must NOT reconcile — the guard still fires.
+	if reconcileBlueprintBareName(mk("loki"), "blueprint", "bp-alloy") {
+		t.Fatalf("genuine rename 'loki' vs 'bp-alloy' must not reconcile")
+	}
+	// A genuine rename between two prefixed names must NOT reconcile.
+	if reconcileBlueprintBareName(mk("bp-loki"), "blueprint", "bp-alloy") {
+		t.Fatalf("prefixed rename 'bp-loki' vs 'bp-alloy' must not reconcile")
+	}
+	// Non-Blueprint kinds are never bp-reconciled (guard fully preserved).
+	if reconcileBlueprintBareName(mk("alloy"), "configmap", "bp-alloy") {
+		t.Fatalf("non-blueprint kind must not reconcile")
+	}
+}
+
+// TestHandleK8sResourceDryRun_BlueprintBareNameAgainstBpPrefixedURL is the
+// #4896 regression: the catalog Edit-IaC editor seeds the AUTHORED
+// blueprint.yaml (metadata.name = bare "alloy", no resourceVersion) and
+// dry-runs it against the in-cluster CR "bp-alloy" (URL name). Before the
+// fix this 400'd with "metadata.name='alloy' does not match URL
+// name='bp-alloy'"; now the bp-prefix is reconciled and the dry-run
+// returns 200 against the seeded CR.
+func TestHandleK8sResourceDryRun_BlueprintBareNameAgainstBpPrefixedURL(t *testing.T) {
+	bp := newBlueprintObj("bp-alloy")
+	rig := newResourceRig(t, bp)
+	defer rig.stop()
+
+	// Exactly what the YamlEditor submits: the bare-named authored source.
+	yamlBody := `apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: alloy
+spec:
+  version: 1.0.2
+  card:
+    title: Alloy
+`
+	body, _ := json.Marshal(map[string]string{"yaml": yamlBody})
+	// URL kind segment is "Blueprint" (as the console sends it) → canonicalised
+	// to the registry "blueprint"; ns segment "_" → cluster-scoped.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sovereigns/alpha/k8s/Blueprint/_/bp-alloy/dry-run", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	rig.router().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("blueprint bare-name dry-run: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp["dryRun"] != true {
+		t.Fatalf("dryRun flag not echoed: %v", resp)
+	}
+	if resp["name"] != "bp-alloy" {
+		t.Fatalf("response name: got %v want bp-alloy (Update must target the prefixed CR)", resp["name"])
+	}
+}
+
+// TestHandleK8sResourceApply_BlueprintGenuineRenameStillRejected proves the
+// #4896 fix does NOT weaken the guard: renaming the Blueprint in the editor
+// (bp-alloy URL, but metadata.name = "loki") still 400s name-mismatch.
+func TestHandleK8sResourceApply_BlueprintGenuineRenameStillRejected(t *testing.T) {
+	bp := newBlueprintObj("bp-alloy")
+	rig := newResourceRig(t, bp)
+	defer rig.stop()
+
+	yamlBody := `apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: loki
+spec:
+  version: 1.0.2
+`
+	body, _ := json.Marshal(map[string]string{"yaml": yamlBody})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sovereigns/alpha/k8s/Blueprint/_/bp-alloy/apply", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	rig.router().ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("genuine blueprint rename: got %d want 400; body=%s", rec.Code, rec.Body.String())
 	}
 	if !strings.Contains(rec.Body.String(), "name-mismatch") {
 		t.Fatalf("expected name-mismatch error, got %s", rec.Body.String())


### PR DESCRIPTION
## What

The catalog **Edit-IaC YamlEditor** durable Commit failed at validation for every `bp-`-prefixed blueprint:

```
POST /api/v1/k8s/Blueprint/_/bp-alloy/dry-run
→ 400 "yaml metadata.name='alloy' does not match URL name='bp-alloy'"
```

(live-verified on hw232; UAT rows 145/148/154).

## Root cause (the seam)

- The catalog IaC editor (`CatalogDetail.tsx` → `YamlEditor`) seeds itself from the **authored `blueprint.yaml`**, whose `metadata.name` is the **bare slug** (`alloy`). The corpus authors blueprints bare (e.g. `platform/alloy/blueprint.yaml: name: alloy`).
- The **in-cluster Blueprint CR** — and therefore the request URL — use the canonical **`bp-` prefix** (`bp-alloy`), per the chart `catalog-seed` (`templates/catalog-seed/blueprints.yaml` names CRs `bp-wordpress`, `bp-cnpg`, …) and `catalog_client_cluster_fallback.go`.
- `handleApplyOrDryRun` (`k8s_resource_actions.go`) does a real k8s `Update(DryRun)` against the URL name and enforces `parsed.metadata.name == URLname`. Bare-vs-prefixed → 400 before any write.

The card-form path (`POST /api/v1/org/commerce/apps`) was unaffected; only this generic k8s dry-run/apply path.

## Fix (which side)

Server-side, in `handleApplyOrDryRun`. When the resource is a **Blueprint** and the URL name is exactly `bp-`+`parsed.name`, they name the **same CR**: stamp the URL form onto the parsed object so the downstream Update targets the real `bp-<slug>` CR, and accept the match. This keeps the round-trip consistent — the authored `blueprint.yaml` stays **bare**, so the Gitea commit (`saveCatalogBlueprintIaC`) is untouched; the editor never has to mangle its YAML.

The guard's protective purpose is preserved: a different kind, or a genuine rename (bare `alloy`→`loki`, or prefixed `bp-alloy`→`bp-loki`), still fails with `name-mismatch`.

## Dry-run before/after

| | metadata.name | URL name | result |
|---|---|---|---|
| before | `alloy` | `bp-alloy` | **400** name-mismatch |
| after | `alloy` | `bp-alloy` | **200** (reconciled → Update targets `bp-alloy`) |
| after (genuine rename) | `loki` | `bp-alloy` | **400** name-mismatch (guard intact) |

## Tests

- `TestReconcileBlueprintBareName` — pure-unit contract (reconcile + stamp; reject genuine renames; reject non-Blueprint kinds).
- `TestHandleK8sResourceDryRun_BlueprintBareNameAgainstBpPrefixedURL` — reproduces the live 400, now 200 against a seeded `bp-alloy` CR.
- `TestHandleK8sResourceApply_BlueprintGenuineRenameStillRejected` — guard still 400s a rename.

`go build ./...`, `go vet`, and the full `internal/handler` package suite pass.

Refs #4896

🤖 Generated with [Claude Code](https://claude.com/claude-code)