### PR TITLE
fix(#4897): render Apps-grid topology badge for object-form placement

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/fleet.go
+++ b/products/catalyst/bootstrap/api/internal/handler/fleet.go
@@ -664,6 +664,13 @@ func (h *Handler) collectApplicationsForSovereign(
 		app := &apps.Items[i]
 		topology, _, _ := unstructured.NestedString(app.Object, "spec", "placement")
 		if topology == "" {
+			// #4897 — object-form placement {mode, regions, …} carries the
+			// posture in .mode; a raw string read collapses it to "". Without
+			// this an active-hot-standby app (object placement) fell through to
+			// the single-region default in the Fleet table + DR-posture derive.
+			topology, _, _ = unstructured.NestedString(app.Object, "spec", "placement", "mode")
+		}
+		if topology == "" {
 			topology = topologySingleRegion
 		}
 		regions, _, _ := unstructured.NestedStringSlice(app.Object, "spec", "regions")

--- a/products/catalyst/bootstrap/api/internal/handler/org_applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_applications.go
@@ -316,7 +316,13 @@ func (h *Handler) HandleOrgApplications(w http.ResponseWriter, r *http.Request) 
 					externalURL = resolveOpenURL(hr.urlKeys)
 				}
 			}
-			topology, _, _ := unstructured.NestedString(app.Object, "spec", "placement")
+			// #4897 — spec.placement is dual-form (legacy posture STRING or the
+			// object {mode, regions, …}). readTopology reads .mode for the
+			// object form, so an active-hot-standby instance created via
+			// Catalog→New-instance renders its topology badge in the Org-scoped
+			// Apps grid too. A raw NestedString read collapsed the object to
+			// "" → the sov-app-topology-<name> badge was absent.
+			topology := readTopology(app)
 			rows = append(rows, sovereignAppItem{
 				ID:          app.GetName(),
 				Slug:        slug,

--- a/products/catalyst/bootstrap/api/internal/handler/org_applications_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_applications_test.go
@@ -244,6 +244,66 @@ func TestOrgApplications_ProjectsOwnNamespaceOnly(t *testing.T) {
 	}
 }
 
+// makeApplicationWithPlacement is makeApplicationFull plus a spec.placement of
+// an arbitrary shape (a legacy posture STRING, or the object {mode, regions})
+// so the projection's topology read can be exercised against BOTH forms.
+func makeApplicationWithPlacement(name, ns, bp, phase string, placement any) *unstructured.Unstructured {
+	u := makeApplicationFull(name, ns, bp, phase)
+	_ = unstructured.SetNestedField(u.Object, placement, "spec", "placement")
+	return u
+}
+
+// TestOrgApplications_TopologyBadge_ObjectAndStringPlacement — #4897. A New-
+// instance active-hot-standby create writes spec.placement as the OBJECT
+// {mode, regions}; a singleton / spine AHS create writes the legacy STRING.
+// The Org-scoped Apps-grid projection must surface the topology posture for
+// BOTH shapes (the raw NestedString read collapsed the object to "" → the
+// sov-app-topology-<name> badge was absent for object-placement AHS apps).
+func TestOrgApplications_TopologyBadge_ObjectAndStringPlacement(t *testing.T) {
+	dynObjs := []runtime.Object{
+		// New-instance AHS — placement is the OBJECT form (the #4897 defect).
+		makeApplicationWithPlacement("uatprobe-ahs", demoOrgNS, "bp-grafana", "Ready",
+			map[string]any{
+				"mode":    "active-hot-standby",
+				"regions": []any{"me-east-215-a", "me-east-215-b"},
+			}),
+		// Spine AHS — placement is the legacy STRING form (already rendered).
+		makeApplicationWithPlacement("spine-ahs", demoOrgNS, "bp-grafana", "Ready", "active-hot-standby"),
+		// Singleton — string form (already rendered).
+		makeApplicationWithPlacement("uatprobe-single", demoOrgNS, "bp-grafana", "Ready", "singleton"),
+	}
+	claims := &auth.Claims{Tier: orgScopedTier, Org: "demo"}
+	rec := orgAppsGet(t, "console.demo.omani.homes", claims, dynObjs)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Apps []struct {
+			ID       string `json:"id"`
+			Instance bool   `json:"instance"`
+			Topology string `json:"topology"`
+		} `json:"apps"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	topoByID := map[string]string{}
+	for _, a := range resp.Apps {
+		topoByID[a.ID] = a.Topology
+	}
+	// The object-placement AHS app is the regression under test: it must now
+	// carry the "active-hot-standby" posture, identical to the string-form one.
+	if got := topoByID["uatprobe-ahs"]; got != "active-hot-standby" {
+		t.Errorf("object-placement AHS topology = %q, want active-hot-standby (badge was absent before #4897)", got)
+	}
+	if got := topoByID["spine-ahs"]; got != "active-hot-standby" {
+		t.Errorf("string-placement AHS topology = %q, want active-hot-standby (must not regress)", got)
+	}
+	if got := topoByID["uatprobe-single"]; got != "singleton" {
+		t.Errorf("singleton topology = %q, want singleton (must not regress)", got)
+	}
+}
+
 // TestOrgApplications_CrossOrgForged — a demo session forging the acme host is
 // 403 org-scope-mismatch (the #4110 binding), never projecting acme's estate.
 func TestOrgApplications_CrossOrgForged(t *testing.T) {

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign.go
@@ -806,7 +806,13 @@ func (h *Handler) HandleSovereignApps(w http.ResponseWriter, r *http.Request) {
 					status = "installed"
 				}
 			}
-			topology, _, _ := unstructured.NestedString(app.Object, "spec", "placement")
+			// #4897 — spec.placement is dual-form: a legacy posture STRING or
+			// the object {mode, regions, …}. readTopology handles both (the
+			// object posture rides in .mode), so an active-hot-standby instance
+			// created via Catalog→New-instance (which writes the OBJECT form)
+			// gets its topology badge, same as string-form spine AHS apps. A
+			// raw NestedString read collapsed the object to "" → no badge.
+			topology := readTopology(app)
 			instanceRows = append(instanceRows, sovereignAppItem{
 				ID:           app.GetName(),
 				Slug:         slug,

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.topology.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.topology.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * AppsPage.topology.test.tsx — #4897.
+ *
+ * The Apps-grid topology badge (`sov-app-topology-<id>`) is driven by the
+ * `topology` value the BFF projects from the Application's `spec.placement`.
+ * That placement is DUAL-FORM: a legacy posture STRING, or the object
+ * `{ mode, regions }` a New-instance active-hot-standby create writes.
+ *
+ * `topologyLabel` normalises BOTH shapes so an active-hot-standby instance
+ * created via Catalog→New-instance renders its badge ("active-hot-standby"),
+ * exactly like a string-form spine AHS app — without regressing the singleton
+ * / string path or emitting a spurious badge for a missing placement.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { topologyLabel } from './AppsPage'
+
+describe('topologyLabel — #4897 dual-shape placement resilience', () => {
+  it('object-form active-hot-standby → reads .mode', () => {
+    expect(
+      topologyLabel({
+        mode: 'active-hot-standby',
+        regions: ['me-east-215-a', 'me-east-215-b'],
+      }),
+    ).toBe('active-hot-standby')
+  })
+
+  it('string-form posture → used as-is', () => {
+    expect(topologyLabel('active-hot-standby')).toBe('active-hot-standby')
+    expect(topologyLabel('singleton')).toBe('singleton')
+    expect(topologyLabel('active-active')).toBe('active-active')
+  })
+
+  it('object without a string mode → empty (no badge)', () => {
+    expect(topologyLabel({ regions: ['fsn'] })).toBe('')
+    expect(topologyLabel({ mode: 123 as unknown })).toBe('')
+    expect(topologyLabel({})).toBe('')
+  })
+
+  it('missing / non-object placement → empty (no badge)', () => {
+    expect(topologyLabel(undefined)).toBe('')
+    expect(topologyLabel(null)).toBe('')
+    expect(topologyLabel('')).toBe('')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
@@ -54,6 +54,32 @@ import { isDeploymentID } from '@/shared/types/deployment'
 import { useTheme } from '@/shared/lib/useTheme'
 import { resolveCatalogIcon } from '@/shared/lib/resolveCatalogIcon'
 
+/**
+ * topologyLabel — #4897. The apps-list `topology` field is normally the
+ * canonical placement-posture STRING (the BFF projects it via readTopology).
+ * The Application's `spec.placement` is dual-form, though: a legacy posture
+ * string OR an object `{ mode, regions }` — the shape a New-instance
+ * active-hot-standby create writes. This normaliser keeps the topology badge
+ * resilient to BOTH shapes reaching the grid:
+ *   • string  → used as-is (e.g. "active-hot-standby", "singleton")
+ *   • object  → read `.mode` (the posture)
+ *   • neither → '' (no badge)
+ * The load-bearing fix is server-side (the BFF now projects the object
+ * form's mode); this guard keeps the grid correct if the raw dual-form
+ * placement ever reaches the FE.
+ */
+export function topologyLabel(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (
+    value &&
+    typeof value === 'object' &&
+    typeof (value as { mode?: unknown }).mode === 'string'
+  ) {
+    return (value as { mode: string }).mode
+  }
+  return ''
+}
+
 interface AppsPageProps {
   /** Test seam — disables the live SSE EventSource attach. */
   disableStream?: boolean
@@ -184,7 +210,9 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
           externalURL?: string
           instance?: boolean
           blueprint?: string
-          topology?: string
+          // #4897 — normally the projected posture string; tolerate the raw
+          // dual-form placement object ({ mode, regions }) too (topologyLabel).
+          topology?: string | { mode?: string }
           contextCount?: number
           bootstrapKit?: boolean
         }>
@@ -203,7 +231,7 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
             id: a.id,
             slug: a.slug ?? '',
             blueprint: a.blueprint ?? '',
-            topology: a.topology ?? '',
+            topology: topologyLabel(a.topology),
             contextCount: a.contextCount ?? 0,
             status: a.status === 'installed' ? 'installed' : 'installing',
             environment: a.environment ?? 'dev',


### PR DESCRIPTION
## What

An app instance created via **Catalog→New-instance** with topology **active-hot-standby** has its Application `spec.placement` written as an **object** `{"mode":"active-hot-standby","regions":[...]}`. The Apps-grid instance-card projection read placement with a raw `unstructured.NestedString(app, "spec","placement")`, which returns `""` for the object form. So the projected `topology` was empty and the grid rendered **no** topology badge (`sov-app-topology-<name>` absent) for object-placement AHS apps — while singleton instances and bootstrap/spine AHS apps (string placement) rendered fine.

Live-verified on hw232: `uatprobe-single` (singleton) showed a badge; `uatprobe-ahs` (New-instance AHS) showed none.

## Root cause

Data-shape mismatch between the create-write path (dual-form: string **or** object `{mode, regions}`) and the grid read path (string-only). The canonical dual-shape helper `readTopology` (which reads `spec.placement.mode` for the object form) is used by the AppDetail Topology tab but **not** by the two Apps-grid projection sites.

## Fix

**Load-bearing (server-side BFF)** — both Apps-grid projection sites now use `readTopology` (object → `placement.mode`, string → as-is):
- `sovereign.go` — `HandleSovereignApps` (sovereign-admin grid)
- `org_applications.go` — `HandleOrgApplications` (customer-Org grid, the New-instance surface)

The Fleet table's identical read (`fleet.go`) is hardened the same way, preserving its existing `single-region` default.

**FE resilience** (as requested) — `AppsPage.topologyLabel()` normalises the projected `topology` whether it arrives as a string or the raw `{ mode }` object, so the grid stays correct if the dual-form placement ever reaches the client.

## Before / after

Object-placement AHS instance (`{mode:"active-hot-standby", regions:[...]}`):
- **before:** projected `topology = ""` → badge absent
- **after:** projected `topology = "active-hot-standby"` → badge renders, identical to string-form spine AHS apps

Singleton and string-form AHS paths are unchanged (regression-guarded in tests).

## Note on scope

The briefing scoped this as a Console FE change, but the FE only ever receives the pre-collapsed `topology` **string** — it never receives the placement object — so an FE-only guard would have been inert against the live defect. The load-bearing fix is therefore the server-side projection (the FE guard is kept as forward-compat resilience per the brief).

## Tests
- `org_applications_test.go`: object-form + string-form + singleton placement all project the correct posture through `HandleOrgApplications`.
- `AppsPage.topology.test.tsx`: `topologyLabel` covers string, object(`.mode`), and missing/invalid shapes.
- Full `internal/handler` Go suite green; UI `typecheck` + `vitest` green.

Refs #4897