### PR TITLE
fix(#4902): cascade-delete fan-out per-region HelmReleases on Application delete

### DIFF
--- a/core/controllers/application/internal/controller/application_controller.go
+++ b/core/controllers/application/internal/controller/application_controller.go
@@ -194,6 +194,17 @@ const (
 // FinalizerName — owned by application-controller.
 const FinalizerName = "application.apps.openova.io/finalizer"
 
+// LabelAppUID is the per-instance back-pointer the topology fan-out
+// stamps on every `<app>-<cluster>` HelmRelease it imperatively upserts
+// (via fanoutOwnerLabels). It carries the owning Application CR's
+// metadata.uid — globally unique per instance, so it disambiguates two
+// same-named Applications in different Orgs/namespaces. handleDeletion()
+// cascades on this label because the fan-out HRs carry NO ownerReferences
+// (they can live in a DIFFERENT namespace than the Application CR — the
+// vCluster pivot lands them in the tier host namespace — and K8s
+// ownerRefs only resolve inside a single namespace; see #4902).
+const LabelAppUID = "catalyst.openova.io/app-uid"
+
 // Gitea is the subset of the gitea.Client surface the reconciler needs.
 // Defining it as an interface here lets tests swap in a fake without a
 // real HTTP server. The production gitea.Client satisfies this
@@ -2065,6 +2076,24 @@ func (r *Reconciler) handleDeletion(ctx context.Context, app *unstructured.Unstr
 		Ready:   "False",
 	})
 
+	// #4902 — cascade-delete the per-region HelmReleases the topology
+	// fan-out imperatively upserted for this Application (the
+	// `<app>-<cluster>` HRs — e.g. `uatprobe-ahs-rtz-a`). They carry NO
+	// ownerReferences (they can live in a different namespace than the
+	// Application CR, which makes same-namespace ownerRefs unsafe — see
+	// the cross-namespace-GC note on ensureHostFluxBootstrap), so K8s GC
+	// never reaps them; and when the fan-out owns the install the legacy
+	// per-region Gitea path below is suppressed, so nothing else removes
+	// them. Without this, an Application created via the New-instance
+	// flow leaks its per-region HR (and its Helm release) on every
+	// delete. Runs BEFORE the spec/env resolution below so orphans are
+	// cleaned even when the spec is unparseable or the parent Environment
+	// is already gone — the cleanup keys off the app-uid back-pointer
+	// label alone.
+	if err := r.cascadeDeleteFanoutHelmReleases(ctx, app); err != nil {
+		return fmt.Errorf("delete per-cluster HelmReleases: %w", err)
+	}
+
 	spec, err := parseSpec(app)
 	if err != nil {
 		// Spec is unparseable — nothing we can do but release the
@@ -2126,6 +2155,78 @@ func (r *Reconciler) handleDeletion(ctx context.Context, app *unstructured.Unstr
 	}
 
 	return r.removeFinalizer(ctx, app)
+}
+
+// cascadeDeleteFanoutHelmReleases removes every per-cluster HelmRelease
+// the topology fan-out imperatively upserted for this Application
+// (#4902). The fan-out reconcile path (§G117.6a) writes each
+// `<app>-<cluster>` HelmRelease straight onto the host k3s via the
+// dynamic client — NOT through Gitea — and when the fan-out owns the
+// install the legacy per-region Gitea render+commit path is suppressed.
+// So handleDeletion's Gitea cleanup removes nothing for a fan-out-owned
+// Application and these HRs would orphan (no deletionTimestamp, only the
+// Flux finalizer) unless we delete them here.
+//
+// We select by the globally-unique app-uid back-pointer label rather
+// than an ownerReference: the fan-out HRs deliberately carry no
+// ownerRefs because they may live in a DIFFERENT namespace than the
+// Application CR (the vCluster pivot lands them in the tier host
+// namespace), and K8s ownerRefs only resolve within a single namespace
+// — a cross-namespace ownerRef would get the HR hard-GC'd the instant
+// it is created (the same trap documented on ensureHostFluxBootstrap).
+//
+// The List is cluster-scoped because the fan-out authors HRs across the
+// Application's own namespace AND per-Tier vCluster host namespaces: the
+// app-uid label pre-filters server-side (efficient on a busy Sovereign)
+// and we re-verify it client-side so nothing outside THIS instance is
+// ever deleted. The controller ClusterRole grants list+delete on
+// helmreleases cluster-wide.
+func (r *Reconciler) cascadeDeleteFanoutHelmReleases(ctx context.Context, app *unstructured.Unstructured) error {
+	uid := string(app.GetUID())
+	name := app.GetName()
+
+	// Prefer the globally-unique app-uid selector; fall back to the
+	// app-name back-pointer only when the CR carries no UID (never in
+	// practice for an API-server-persisted CR, but keeps the cleanup
+	// robust against a hand-crafted / partially-migrated object).
+	selectorKey, selectorVal := LabelAppUID, uid
+	if uid == "" {
+		selectorKey, selectorVal = topo.LabelApp, name
+	}
+
+	list, err := r.Dynamic.Resource(FluxHelmReleaseGVR).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", selectorKey, selectorVal),
+	})
+	if err != nil {
+		return fmt.Errorf("list fan-out HelmReleases: %w", err)
+	}
+
+	for i := range list.Items {
+		hr := &list.Items[i]
+		labels := hr.GetLabels()
+		// Client-side re-verify against the app-uid (or, uid-absent, the
+		// app-name) back-pointer so a List that ignored the server-side
+		// selector can never over-delete another Application's HRs.
+		if uid != "" {
+			if labels[LabelAppUID] != uid {
+				continue
+			}
+		} else if labels[topo.LabelApp] != name {
+			continue
+		}
+		ns, hrName := hr.GetNamespace(), hr.GetName()
+		if derr := r.Dynamic.Resource(FluxHelmReleaseGVR).Namespace(ns).
+			Delete(ctx, hrName, metav1.DeleteOptions{}); derr != nil {
+			if apierrors.IsNotFound(derr) {
+				continue
+			}
+			return fmt.Errorf("delete fan-out HelmRelease %s/%s: %w", ns, hrName, derr)
+		}
+		r.Log.Info("cascade-deleted per-cluster HelmRelease on Application delete (#4902)",
+			"namespace", ns, "name", hrName,
+			"cluster", labels[topo.LabelCluster], "app", name)
+	}
+	return nil
 }
 
 // ensureFinalizer adds the controller's finalizer to the Application
@@ -3333,7 +3434,7 @@ func fanoutOwnerLabels(envSpec envParsedSpec, app *unstructured.Unstructured) ma
 	return map[string]string{
 		"catalyst.openova.io/organization": envSpec.OrganizationRef,
 		"catalyst.openova.io/env-type":     envSpec.EnvType,
-		"catalyst.openova.io/app-uid":      string(app.GetUID()),
+		LabelAppUID:                        string(app.GetUID()),
 	}
 }
 

--- a/core/controllers/application/internal/controller/application_controller_fanout_delete_4902_test.go
+++ b/core/controllers/application/internal/controller/application_controller_fanout_delete_4902_test.go
@@ -1,0 +1,149 @@
+// application_controller_fanout_delete_4902_test.go — #4902 regression
+// coverage for the orphan-HelmRelease cleanup gap proven on hw232.
+//
+// Defect: deleting an Application created via the New-instance flow did
+// NOT cascade-clean the per-region HelmReleases the topology fan-out
+// imperatively upserted (`<app>-<cluster>`). Those HRs carry no
+// ownerReferences (they can live in a DIFFERENT namespace than the
+// Application CR — the vCluster pivot lands them in the tier host
+// namespace — which makes same-namespace ownerRefs unsafe), so K8s GC
+// never reaps them and, because the fan-out suppresses the legacy
+// per-region Gitea path, nothing else did either. handleDeletion now
+// cascade-deletes them via the app-uid back-pointer label.
+package controller
+
+import (
+	"context"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// makeSeedFanoutHR builds a HelmRelease shaped like one the topology
+// fan-out would upsert (carries the app + app-uid + cluster back-pointer
+// labels). Used to seed a DECOY belonging to a different Application so
+// the test proves the cascade is scoped to exactly one instance.
+func makeSeedFanoutHR(namespace, name, app, appUID, cluster string) *unstructured.Unstructured {
+	hr := &unstructured.Unstructured{}
+	hr.SetAPIVersion("helm.toolkit.fluxcd.io/v2")
+	hr.SetKind("HelmRelease")
+	hr.SetNamespace(namespace)
+	hr.SetName(name)
+	hr.SetLabels(map[string]string{
+		"catalyst.openova.io/app":     app,
+		LabelAppUID:                   appUID,
+		"catalyst.openova.io/cluster": cluster,
+	})
+	hr.Object["spec"] = map[string]interface{}{
+		"chart": map[string]interface{}{
+			"spec": map[string]interface{}{"chart": app},
+		},
+	}
+	return hr
+}
+
+// TestReconcile_DeletionCascade_FanoutHelmReleases_4902 — the central
+// #4902 acceptance: after an active-hot-standby Application's fan-out
+// upserts its per-region HelmReleases into the tier host namespace, a
+// delete of the Application MUST remove those HRs (and only those — a
+// sibling Application's HR in the same namespace must survive), then
+// release the finalizer.
+func TestReconcile_DeletionCascade_FanoutHelmReleases_4902(t *testing.T) {
+	bp := makeBlueprintWithActiveHotStandbyTopology(
+		"bp-grafana", "1.0.6", "mgmt",
+		[]string{"mgmt-A", "mgmt-B"},
+	)
+	env := makeMultiRegionEnv("acme-prod", "acme", "prod")
+	org := makeOrg("acme")
+	// The Application CR lives in the Org namespace `acme`; its fan-out
+	// HRs land in the tier host namespace `mgmt` — a DIFFERENT namespace,
+	// which is exactly why an ownerRef would be unsafe and the finalizer
+	// cascade is required.
+	app := makeApp("acme", "obs", "acme-prod", "bp-grafana", "1.0.6",
+		"active-hotstandby",
+		[]string{"hetzner-fsn-rtz-prod", "hetzner-nbg-rtz-prod"},
+		nil,
+	)
+
+	// Decoy: a DIFFERENT Application's fan-out HR in the SAME host ns.
+	// It carries a different app-uid, so the cascade must NOT touch it.
+	decoy := makeSeedFanoutHR("mgmt", "other-mgmt-a", "other", "uid-other", "mgmt-A")
+
+	fg := newFakeGitea()
+	fg.orgsExist["acme"] = true
+	r := newReconciler(t, fg, app, env, org, bp, decoy)
+
+	// First reconcile — fan-out upserts 2 HRs into `mgmt` + adds finalizer.
+	reconcileFromCluster(t, r, "acme", "obs")
+
+	hrList, err := r.Dynamic.Resource(FluxHelmReleaseGVR).
+		Namespace("mgmt").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list HRs in mgmt: %v", err)
+	}
+	ownHRs := 0
+	for _, hr := range hrList.Items {
+		if hr.GetLabels()["catalyst.openova.io/app"] != "obs" {
+			continue
+		}
+		ownHRs++
+		// The cascade keys off the app-uid back-pointer — assert it was
+		// actually stamped by the fan-out (makeApp sets uid = "uid-obs").
+		if got := hr.GetLabels()[LabelAppUID]; got != "uid-obs" {
+			t.Errorf("fan-out HR %s app-uid label = %q, want uid-obs", hr.GetName(), got)
+		}
+	}
+	if ownHRs != 2 {
+		t.Fatalf("want 2 fan-out HRs for obs after first reconcile, got %d", ownHRs)
+	}
+
+	got := readApp(t, r, "acme", "obs")
+	if !hasFinalizer(got, FinalizerName) {
+		t.Fatal("first pass should add the controller finalizer")
+	}
+
+	// Mark the app for deletion (what `kubectl delete` does — sets
+	// metadata.deletionTimestamp; the finalizer defers GC until removed).
+	now := metav1.Now()
+	got.SetDeletionTimestamp(&now)
+	if _, err := r.Dynamic.Resource(ApplicationGVR).Namespace("acme").
+		Update(context.Background(), got, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("set deletion timestamp: %v", err)
+	}
+
+	// Reconcile again — handleDeletion must cascade-delete the 2 fan-out HRs.
+	reconcileFromCluster(t, r, "acme", "obs")
+
+	afterList, err := r.Dynamic.Resource(FluxHelmReleaseGVR).
+		Namespace("mgmt").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list HRs in mgmt after delete: %v", err)
+	}
+	decoySurvived := false
+	for _, hr := range afterList.Items {
+		if hr.GetLabels()[LabelAppUID] == "uid-obs" {
+			t.Errorf("fan-out HR %s survived Application delete — orphan-HR leak (#4902)", hr.GetName())
+		}
+		if hr.GetName() == "other-mgmt-a" {
+			decoySurvived = true
+		}
+	}
+	if !decoySurvived {
+		t.Error("decoy HR for a DIFFERENT Application was wrongly deleted — cascade over-reached beyond app-uid scope")
+	}
+
+	// Finalizer must be released so the API server can GC the CR.
+	got2, err := r.Dynamic.Resource(ApplicationGVR).Namespace("acme").
+		Get(context.Background(), "obs", metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return // already GC'd by the fake — finalizer was released.
+		}
+		t.Fatalf("read app after delete: %v", err)
+	}
+	if hasFinalizer(got2, FinalizerName) {
+		t.Errorf("finalizer should be released after cascade, still present: %v", got2.GetFinalizers())
+	}
+}


### PR DESCRIPTION
## What

Deleting an Application created via the New-instance flow now cascade-cleans the per-region HelmReleases the topology fan-out imperatively created. Previously those HRs orphaned on every per-region app delete (leaking their Helm releases). Proven in the write-mutation walk on hw232 (deleting Application `uatprobe-ahs` left HelmRelease `uatprobe-ahs-rtz-a` orphaned — no `deletionTimestamp`, only the Flux finalizer). Also flagged as a secondary finding on #4897.

## Root cause

The topology fan-out (`application-controller` reconcile §G117.6a) renders one `<app>-<cluster>` HelmRelease per placement cluster (`render.FanoutHRs`) and **imperatively upserts each one onto the host k3s via the dynamic client** (`upsertHostResource(FluxHelmReleaseGVR, ...)`).

These HRs carry **no `ownerReferences`** — by design. A fan-out HR may be authored in a **different namespace** than the Application CR: the vCluster pivot lands it in the tier host namespace (e.g. `mgmt`) while the Application CR lives in the Org namespace (e.g. `acme`). Kubernetes ownerReferences only resolve **within a single namespace** (the GC hard-deletes any dependent whose namespaced owner it cannot find there), so a same-namespace ownerRef would get the HR hard-GC'd the instant it is created — the same trap already documented on `ensureHostFluxBootstrap`. The fan-out therefore relies on a `catalyst.openova.io/app` / `catalyst.openova.io/app-uid` back-pointer label.

`handleDeletion()` only removed the legacy per-region **Gitea** files + the per-app Continuum CR — it never deleted the imperatively-upserted HRs. And when the fan-out owns the install (`fanoutOwnsInstall = true`) the legacy per-region Gitea render+commit path is **suppressed**, so on delete the Gitea cleanup removed nothing and the HRs orphaned.

## Namespace relationship + chosen mechanism

The fan-out HRs can live in a **different namespace** than the Application CR (host/CNPG placement → same namespace; vCluster-tier placement → the tier host namespace). Because ownerReferences are same-namespace-only, an ownerRef is **unsafe** here — so the fix uses the **Application finalizer** (`handleDeletion`) rather than an ownerRef.

## Fix

`handleDeletion` now calls `cascadeDeleteFanoutHelmReleases` before releasing the finalizer:

- Selects HRs by the globally-unique `catalyst.openova.io/app-uid=<uid>` back-pointer (immune to same-name collisions across Orgs/namespaces; falls back to the app-name label only when a CR carries no UID).
- Cluster-scoped List (the fan-out authors HRs across the app namespace AND per-Tier vCluster host namespaces) with a server-side app-uid pre-filter and a **client-side re-verify** so nothing outside the deleted instance is ever removed.
- Runs before the spec/env resolution so orphans are cleaned even when the spec is unparseable or the parent Environment is already gone.
- The controller ClusterRole already grants `list`/`delete` on `helmreleases` cluster-wide.

## Test

Adds `TestReconcile_DeletionCascade_FanoutHelmReleases_4902`: an active-hot-standby Application's fan-out HRs are authored in the `mgmt` tier host namespace while the CR lives in `acme`; on delete the two per-region HRs are removed, a **sibling Application's HR in the same namespace survives** (proves app-uid scoping), and the finalizer is released.

`go build ./...`, `go vet ./...`, and the full `application/...` test package all pass.

Refs #4902
