### PR TITLE
fix(#4885): step-06 pivots per-Org tenant HelmRepositories at cutover

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -735,7 +735,14 @@ spec:
       # gains the 6-space `global.imageRegistry: ''` seam so the durable Gitea
       # edit persists. Only org-services (marketplace/auth concrete deploybot-
       # bumped ghcr.io refs) stays excluded — the #4885 residual.
-      version: 0.1.107
+      # 0.1.108 (#4885 Refs #3379 #4888): step-06 now pivots the per-Org / marketplace
+      # TENANT-blueprint HelmRepositories too (bp-agenity / bp-openclaw /
+      # bp-stalwart-tenant / bp-wordpress-tenant + shared bp-keycloak/bp-cnpg/bp-newapi)
+      # — Phase-0.9 unions the curated names with every live upstream HR, and Phase-2b
+      # durably rewrites their clusters/<fqdn>/org-tenants/**.yaml Gitea source — so the
+      # step-08 deny-egress PRE-CHECK no longer wedges on tenant HRs still on ghcr.io
+      # (proven hw232). No step-count / job-mode / RBAC change.
+      version: 0.1.108
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.107
+  version: 0.1.108
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,41 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.108 (#4885 Refs #3379 #4888, the tenant-HelmRepo cutover-pivot gap — hw232
+# step-08 deny-egress PRE-CHECK wedged on 4 tenant/catalog HRs still on ghcr.io):
+# step-06 (helmrepository-patches) previously pivoted ONLY the curated
+# .Values.helmRepositories.names set, which NEVER lists the per-Org / marketplace
+# TENANT-blueprint HelmRepositories the catalyst-api org-tenant pipeline seeds at
+# Org-provisioning time — bp-agenity / bp-openclaw / bp-stalwart-tenant /
+# bp-wordpress-tenant (+ shared bp-keycloak / bp-cnpg / bp-newapi), declared in
+# products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
+# (orgTenantSharedHelmRepositories) + core/services/provisioning/gitops/
+# helmrelease_apps.go (helmRepoBlock), both hardcoded to oci://ghcr.io/openova-io.
+# So those HRs stayed on ghcr.io → step-08's `-A` offender scan (count_offenders)
+# wedged its deny-egress PRE-CHECK on them → the 600s hold never ran →
+# cutoverComplete unreachable (PROVEN hw232, #4885 10:36 residual). The design
+# comment in organization_gitops.go assumed a post-cutover registries.yaml would
+# rewrite these pulls transparently — TRUE for containerd image pulls but FALSE
+# for the Flux source-controller OCI CHART pull, which resolves ghcr.io directly.
+# TWO step-06 changes (chart-only, no step-count / job-mode / RBAC change; still
+# 11 steps):
+#   Phase-0.9 (live pivot, drift-proof) — the Phase-1 patch input is now the
+#     curated names list UNION every live HelmRepository in HELMREPO_NAMESPACE
+#     whose spec.url still points at the upstream OCI prefix (same live∪declared
+#     discipline step-03 Phase-A2 / #4573 F4 uses), so tenant/catalog blueprint
+#     HRs present at cutover time get the URL + certSecretRef pivot.
+#   Phase-2b (durable Gitea edit) — the tenant HRs live in
+#     clusters/<fqdn>/org-tenants/**.yaml in THIS same openova/openova gitops repo,
+#     reconciled by the org-tenants PARENT Kustomization (a DIFFERENT durable source
+#     than the bootstrap-kit slots), so a live patch alone is reverted ~1 reconcile
+#     later. step-06 Phase-2 now ALSO sed-rewrites the upstream url in every
+#     org-tenants YAML (and injects the certSecretRef trust ref into them) so the
+#     pivot is durable and step-08 converges. Repos SEEDED AFTER this step (Orgs
+#     provisioned post-cutover) still get ghcr.io from the org-tenant pipeline
+#     source — the durable-source follow-on (emit local URLs at org-tenant seed
+#     time when post-cutover) is tracked in #4885; this bump covers every tenant HR
+#     present when the cutover runs (the proven wedge). Contract Case 16b locks the
+#     union + the org-tenants durable edit. Lockstep w/ blueprint.yaml + 06a slot
+#     pin + catalog seed. Refs #4885 #3379 #4888.
 # 0.1.107 (#4885 Refs #4888 #4892, wire the four newly-honouring charts into the
 # step-07 image-registry pivot): #4888 introduced
 # .Values.imageRegistryPivot.additionalHRs + the pivot_extra_hr() mechanism
@@ -1556,7 +1592,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.107
+version: 0.1.108
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
@@ -525,6 +525,46 @@ data:
                 ;;
             esac
 
+            # ---- Phase 0.9 (#4885): union curated names with live upstream HRs ----
+            #
+            # The curated .Values.helmRepositories.names list (materialised into
+            # /work/helmrepository-names.txt) is HAND-MAINTAINED and always drifts
+            # behind the per-Org / marketplace TENANT-blueprint HelmRepositories the
+            # catalyst-api org-tenant pipeline seeds at Org-provisioning time —
+            # bp-agenity / bp-openclaw / bp-stalwart-tenant / bp-wordpress-tenant
+            # (+ the shared bp-keycloak / bp-cnpg / bp-newapi), declared in
+            # products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
+            # (orgTenantSharedHelmRepositories) + core/services/provisioning/gitops/
+            # helmrelease_apps.go (helmRepoBlock), both hardcoded to
+            # oci://ghcr.io/openova-io. Those names are NEVER in the curated list, so
+            # step-06 left them on ghcr.io and step-08's `-A` offender scan
+            # (count_offenders) wedged the deny-egress PRE-CHECK on them → the 600s
+            # hold never ran → cutoverComplete unreachable (PROVEN hw232, #4885 10:36
+            # residual).
+            #
+            # FIX: union the curated list with EVERY live HelmRepository in
+            # HELMREPO_NAMESPACE whose spec.url still points at the upstream OCI
+            # prefix, so the Phase-1 pivot is DRIFT-PROOF and covers tenant/catalog
+            # blueprint repos present at cutover time — the SAME live∪declared
+            # discipline step-03 Phase-A2 (#4573 F4) already applies to the chart-
+            # mirror set. (Phase-2b below rewrites their org-tenants Gitea source so
+            # the live patch is durable. Repos SEEDED AFTER this step — Orgs
+            # provisioned post-cutover — additionally need the org-tenant pipeline to
+            # emit local URLs at source; tracked as the #4885 durable-source
+            # follow-on. This covers everything present when the cutover runs, which
+            # is the proven wedge.)
+            combined_names=/tmp/hr-names-combined.txt
+            sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' /work/helmrepository-names.txt \
+              | grep -v '^$' > "${combined_names}" || true
+            kubectl get helmrepositories.source.toolkit.fluxcd.io -n "${HELMREPO_NAMESPACE}" \
+              -o jsonpath='{range .items[*]}{.metadata.name}={.spec.url}{"\n"}{end}' 2>/dev/null \
+              | awk -F= -v p="${UPSTREAM_PREFIX}" 'NF>=2 && index($2,p)==1 {print $1}' \
+              >> "${combined_names}" || true
+            # De-dup (stable sort) so an HR in both the curated list and the live
+            # upstream set is patched exactly once.
+            sort -u "${combined_names}" -o "${combined_names}"
+            echo "[helmrepository-patches] Phase-1 input: $(grep -c . "${combined_names}") HelmRepository name(s) (curated ∪ live-upstream)"
+
             # ---- Phase 1: live K8s patches (immediate) ----
             ok=0
             skip=0
@@ -603,7 +643,7 @@ data:
                 echo "[helmrepository-patches] FAIL ${name}"
                 fail=$((fail+1))
               fi
-            done < /work/helmrepository-names.txt
+            done < "${combined_names}"
 
             echo "[helmrepository-patches] live-K8s ok=${ok} skip=${skip} fail=${fail}"
             [ "${fail}" -eq 0 ] || exit 1
@@ -734,7 +774,32 @@ data:
               edited=$((edited+1))
               echo "[helmrepository-patches] edited ${f}"
             done
-            echo "[helmrepository-patches] sed edited ${edited} files"
+            echo "[helmrepository-patches] sed edited ${edited} bootstrap-kit file(s)"
+
+            # ---- Phase 2b (#4885): pivot the per-Org TENANT shared HelmRepositories ----
+            #
+            # The catalyst-api org-tenant pipeline writes the shared bp-* tenant
+            # HelmRepositories to clusters/<sov-fqdn>/org-tenants/helmrepositories.yaml
+            # (+ per-tenant overlay files under .../org-tenants/<org-id>/), in THIS
+            # same openova/openova gitops repo, reconciled by the org-tenants PARENT
+            # Flux Kustomization — a DIFFERENT durable source than the bootstrap-kit
+            # slots above. So the Phase-1 live patch of these HRs is REVERTED ~1
+            # reconcile later unless their Gitea source is rewritten here too (the
+            # exact #970/#3526 revert-race, one directory over). Rewrite every
+            # org-tenants YAML that still declares the upstream url
+            # (bp-agenity / bp-openclaw / bp-stalwart-tenant / bp-wordpress-tenant /
+            # bp-keycloak / bp-cnpg / bp-newapi) to the local Harbor prefix so
+            # step-08's `-A` offender scan converges durably. Guarded on the tree
+            # existing (a Sovereign with no customer Orgs has no org-tenants dir →
+            # 0 edits, harmless no-op).
+            tenant_edited=0
+            for f in $(grep -rlE "^[[:space:]]*url:[[:space:]]*${UPSTREAM_PREFIX}[[:space:]]*$" clusters 2>/dev/null | grep '/org-tenants/' || true); do
+              sed -i -E "s,^([[:space:]]*url:[[:space:]]*)${UPSTREAM_PREFIX}([[:space:]]*)$,\1${local_prefix}\2," "${f}"
+              tenant_edited=$((tenant_edited+1))
+              edited=$((edited+1))
+              echo "[helmrepository-patches] edited tenant-HR ${f}"
+            done
+            echo "[helmrepository-patches] sed edited ${tenant_edited} org-tenant HelmRepository file(s)"
 
             # Phase-2 trust durability (Refs #3379): inject `certSecretRef:`
             # into every HelmRepository spec whose url was just pivoted to the
@@ -748,7 +813,17 @@ data:
             # Only runs when a trust secret was actually built (Phase-0.5).
             if [ -n "${trust_secret}" ]; then
               trust_edited=0
-              for f in $(grep -lE "^[[:space:]]*url:[[:space:]]*${local_prefix}([[:space:]]*|/.*)$" "${target_dir}"/*.yaml 2>/dev/null || true); do
+              # #4885: union the bootstrap-kit slot files with the org-tenants HR
+              # files (Phase-2b) so the pivoted TENANT HelmRepositories carry the
+              # source-controller trust ref too — else they x509-fail pulling the
+              # LE-staging in-cluster Harbor once the org-tenants Kustomization
+              # reconciles the durable local url. Collect both into a temp file
+              # (avoids an unindented continuation line inside this YAML block scalar).
+              trust_list=/tmp/cutover-trust-targets.txt
+              : > "${trust_list}"
+              grep -lE "^[[:space:]]*url:[[:space:]]*${local_prefix}([[:space:]]*|/.*)$" "${target_dir}"/*.yaml 2>/dev/null >> "${trust_list}" || true
+              grep -rlE "^[[:space:]]*url:[[:space:]]*${local_prefix}([[:space:]]*|/.*)$" clusters 2>/dev/null | grep '/org-tenants/' >> "${trust_list}" || true
+              for f in $(awk 'NF' "${trust_list}" | sort -u); do
                 awk -v ref="${trust_secret}" -v lp="${local_prefix}" '
                   # Match a pivoted `url:` line (local Harbor prefix). Capture
                   # its leading whitespace so the injected block aligns with the

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -473,6 +473,45 @@ if ! grep -q 'clusters/_template/bootstrap-kit' "$TMP/render.yaml"; then
 fi
 echo "  PASS (Step-06 pushes YAML edit to local Gitea)"
 
+echo "[cutover-contract] Case 16b: Step-06 pivots the per-Org TENANT HelmRepositories (#4885)"
+# hw232 (#4885 10:36 residual): step-06 pivoted ONLY the curated
+# .Values.helmRepositories.names set, which NEVER lists the per-Org / marketplace
+# TENANT-blueprint HelmRepositories (bp-agenity / bp-openclaw / bp-stalwart-tenant /
+# bp-wordpress-tenant + shared bp-keycloak/bp-cnpg/bp-newapi) the catalyst-api
+# org-tenant pipeline seeds at Org-provisioning time in
+# clusters/<fqdn>/org-tenants/**.yaml. Those stayed on oci://ghcr.io/openova-io →
+# step-08's `-A` offender scan wedged its deny-egress PRE-CHECK on them →
+# cutoverComplete never set. 0.1.108 fixes this in step-06 with TWO changes; this
+# case locks both so a future edit can't silently drop them.
+#
+# (a) Phase-0.9 LIVE pivot must be DRIFT-PROOF: the Phase-1 patch input unions the
+#     curated names with EVERY live HelmRepository whose spec.url is the upstream
+#     OCI prefix (not just the hand-maintained list).
+if ! grep -q 'curated ∪ live-upstream' "$TMP/render.yaml"; then
+  echo "FAIL: Step-06 Phase-1 does not union the curated names with live upstream HelmRepositories — tenant/catalog HRs stay on ghcr.io (#4885)" >&2
+  exit 1
+fi
+if ! grep -Eq 'index\(\$2,p\)==1' "$TMP/render.yaml"; then
+  echo "FAIL: Step-06 Phase-1 missing the live-HR upstream-prefix enumeration (awk index match) (#4885)" >&2
+  exit 1
+fi
+if ! grep -q 'done < "${combined_names}"' "$TMP/render.yaml"; then
+  echo "FAIL: Step-06 Phase-1 loop no longer iterates the curated∪live combined_names set (#4885)" >&2
+  exit 1
+fi
+# (b) Phase-2b DURABLE edit must rewrite the org-tenants Gitea source (the tenant
+#     HRs' durable source is the org-tenants parent Kustomization, NOT bootstrap-kit,
+#     so a live patch alone is reverted).
+if ! grep -q "grep '/org-tenants/'" "$TMP/render.yaml"; then
+  echo "FAIL: Step-06 Phase-2b does not rewrite the clusters/<fqdn>/org-tenants HelmRepository files — the tenant-HR pivot is non-durable and reverts (#4885)" >&2
+  exit 1
+fi
+if ! grep -q 'org-tenant HelmRepository file(s)' "$TMP/render.yaml"; then
+  echo "FAIL: Step-06 Phase-2b org-tenant durable-edit log line missing (#4885)" >&2
+  exit 1
+fi
+echo "  PASS (Step-06 pivots tenant HelmRepositories live + durably)"
+
 echo "[cutover-contract] Case 18: Step-06 Phase-0 probe is escape-free + has wait-loop (Fix #77, Gap A)"
 # 0.1.24 used kubectl jsonpath `{.data['.dockerconfigjson']}` which
 # silently returns EMPTY because the leading dot inside bracket-form

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5036,7 +5036,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.107"
+    version: "0.1.108"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Problem (proven on hw232)

The cutover egress-block-test (step-08) wedges at its deny-egress **PRE-CHECK** because **4 tenant/marketplace-blueprint HelmRepositories stay on `oci://ghcr.io`** — `bp-agenity`, `bp-openclaw`, `bp-stalwart-tenant`, `bp-wordpress-tenant`. step-06 (`helmrepository-patches`) pivoted **only** the curated `.Values.helmRepositories.names` set, which **never** lists the per-Org tenant-blueprint HRs the catalyst-api org-tenant pipeline seeds at Org-provisioning time:

- `orgTenantSharedHelmRepositories` in `products/catalyst/bootstrap/api/internal/handler/organization_gitops.go` (BSS door)
- `helmRepoBlock` in `core/services/provisioning/gitops/helmrelease_apps.go` (funnel path)

both hardcoded to `oci://ghcr.io/openova-io`. So those HRs stayed on ghcr.io, step-08's `-A` offender scan (`count_offenders`) wedged its pre-check on them, the 600s deny-egress hold never ran, and `cutoverComplete` was unreachable.

**Root of the misconception:** the design comment in `organization_gitops.go` assumed a post-cutover `registries.yaml` would rewrite these pulls transparently. That is true for **containerd image** pulls, but **false** for the **Flux source-controller OCI chart** pull, which resolves `ghcr.io` directly (in-process OCI client, never through containerd).

## Which fix path

Confirmed against the repo: the 4 tenant HRs live in `clusters/<fqdn>/org-tenants/**.yaml` in the **same `openova/openova` gitops repo step-06 clones**, reconciled by the **org-tenants parent Flux Kustomization** — a *different* durable source than the bootstrap-kit slots. So a live `kubectl patch` alone is reverted ~1 reconcile later. The robust, self-contained chart fix is to broaden step-06 (issue fix-direction (a)) in **two** places:

- **Phase-0.9 (drift-proof live pivot):** Phase-1's patch input is now the curated names list **UNION** every live HelmRepository whose `spec.url` still points at the upstream OCI prefix — the same live-union-declared discipline step-03 Phase-A2 (#4573 F4) already uses — so tenant/catalog blueprint HRs present at cutover time get the URL + `certSecretRef` pivot.
- **Phase-2b (durable Gitea edit):** step-06 Phase-2 now also sed-rewrites the upstream url in every `clusters/<fqdn>/org-tenants/**.yaml` and injects the `certSecretRef` trust ref into them, so the pivot is durable and step-08 converges.

No step-count / job-mode / RBAC change (still 11 steps).

## Follow-on (documented, not in this PR)

Repos seeded **after** the cutover has already completed (Orgs provisioned post-cutover) still get `ghcr.io` from the org-tenant pipeline **source**. Making that emit local-registry URLs post-cutover is a coordinated catalyst-api (Go) change — tracked in #4885 as the durable-source follow-on. This PR covers every tenant HR present **when the cutover runs**, which is the proven hw232 wedge.

## Version + proof

- Bumps `bp-self-sovereign-cutover` **0.1.107 -> 0.1.108** across the 4 pins: `chart/Chart.yaml`, `blueprint.yaml`, bootstrap-kit `06a` slot, catalog seed.
- New contract **Case 16b** locks the Phase-1 union + the Phase-2b org-tenants durable edit.
- `helm lint` clean; `helm template` renders; **all 35 `cutover-contract.sh` cases pass**; rendered step-06 shell passes `dash -n` **and** `busybox ash -n` (the container runs `/bin/sh` = busybox ash).

Refs #4885 #3379 #4888

🤖 Generated with [Claude Code](https://claude.com/claude-code)