### PR TITLE
fix(#4901): surface cnpg-pair Continuum standby-absent condition in DR status

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/continuum.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum.go
@@ -288,6 +288,14 @@ func (h *Handler) HandleContinuumGet(w http.ResponseWriter, r *http.Request) {
 	if statusObj, ok, _ := unstructured.NestedMap(cr.Object, "status"); ok {
 		resp.Status = statusObj
 	}
+	// #4901 — the continuum-controller tracks the witness lease / primary
+	// correctly but derives phase purely from lease-held-ness; it does NOT
+	// reflect a lost REQUIRED synchronous hot-standby into phase/lag. Cross-
+	// check the live cnpg-pair standby and surface a Degraded/standby-absent
+	// condition when the region-b replica is unreachable (writes stalling on
+	// SyncRep, RPO=0 durability at risk). Read-only augmentation of the
+	// projection (NestedMap deep-copies status) — the CR is never mutated.
+	resp.Status = h.augmentContinuumStandbyStatus(r.Context(), client, cr, resp.Status)
 	writeJSON(w, http.StatusOK, resp)
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/continuum_live.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_live.go
@@ -303,6 +303,205 @@ func cnpgClusterLag(cr *unstructured.Unstructured) int {
 	return 0
 }
 
+// cnpgClusterReadyInstances reports status.readyInstances (the count of a
+// CNPG Cluster's Pods currently Ready) and whether the field was present.
+// CNPG drops it to 0 when every instance of a Cluster is down — the
+// region-kill drill (#4901: region-b nodes cordoned, replica Pods deleted →
+// 0 ready). A present-but-zero reading is a standby-absent signal; an absent
+// field means the Cluster status is too old/partial to judge on this axis
+// (the caller then falls back to the Ready condition alone).
+func cnpgClusterReadyInstances(cr *unstructured.Unstructured) (int, bool) {
+	v, found, err := unstructured.NestedFieldNoCopy(cr.Object, "status", "readyInstances")
+	if err != nil || !found {
+		return 0, false
+	}
+	switch n := v.(type) {
+	case int64:
+		return int(n), true
+	case int:
+		return n, true
+	case float64:
+		return int(n), true
+	}
+	return 0, false
+}
+
+// cnpgStandbyAvailable reports whether the replica (standby) half of a cnpg
+// cluster-pair is genuinely serving as a hot-standby: its Cluster reports
+// Ready=True AND (when the field is present) at least one instance is Ready.
+//
+// A Ready-but-LAGGING standby is still AVAILABLE — replication lag is a
+// separate axis (status.replicationLagSeconds) and must NEVER raise a
+// standby-absent alarm (the issue's explicit no-false-alarm rule). Only an
+// unreachable / down standby (not Ready, or zero ready instances) counts as
+// absent.
+func cnpgStandbyAvailable(replica *unstructured.Unstructured) bool {
+	if !cnpgClusterReady(replica) {
+		return false
+	}
+	if inst, found := cnpgClusterReadyInstances(replica); found {
+		return inst >= 1
+	}
+	return true
+}
+
+// cnpgStandbyState is the resolved availability of the REQUIRED synchronous
+// hot-standby a cnpg-pair Continuum CR references via spec.cnpgPair.
+type cnpgStandbyState struct {
+	PairName       string
+	ReplicaCluster string
+	ReplicaRegion  string
+	Available      bool
+}
+
+// cnpgPairStandbyForContinuum resolves the standby (replica) availability of
+// the cnpg cluster-pair a Continuum CR names in spec.cnpgPair. It returns
+// (state, true) ONLY when the CR references a cnpg pair AND that pair's
+// replica-role Cluster half is present on the cluster (so a determination
+// can be made). It returns (_, false) — leave the observed status untouched
+// — when:
+//
+//   - the CR carries no spec.cnpgPair: the dr-spine / openbao-raft continuums
+//     have no synchronous cnpg pair, so the SyncRep standby-absent branch is
+//     not theirs (their own standby posture is surfaced elsewhere), or
+//   - the replica-role Cluster half cannot be listed/found: provisioning in
+//     flight, or the client cannot see the pair — being conservative here
+//     avoids false-alarming a half-provisioned pair.
+//
+// The replica-role Cluster PRESENT-but-not-Ready is the proven region-kill
+// state (#4901) — that is exactly the case this returns Available=false for.
+func (h *Handler) cnpgPairStandbyForContinuum(
+	ctx context.Context,
+	client dynamic.Interface,
+	cr *unstructured.Unstructured,
+) (cnpgStandbyState, bool) {
+	pairName, _, _ := unstructured.NestedString(cr.Object, "spec", "cnpgPair", "name")
+	if strings.TrimSpace(pairName) == "" {
+		return cnpgStandbyState{}, false
+	}
+	pairNS, _, _ := unstructured.NestedString(cr.Object, "spec", "cnpgPair", "namespace")
+	if strings.TrimSpace(pairNS) == "" {
+		pairNS = cr.GetNamespace()
+	}
+	list, err := client.Resource(cnpgClusterGVR).Namespace(pairNS).List(ctx, metav1.ListOptions{
+		LabelSelector: cnpgPairLabel + "=" + pairName,
+	})
+	if err != nil || list == nil {
+		return cnpgStandbyState{}, false
+	}
+	var replica *unstructured.Unstructured
+	for i := range list.Items {
+		if list.Items[i].GetLabels()[cnpgRoleLabel] == cnpgRoleReplica {
+			replica = &list.Items[i]
+			break
+		}
+	}
+	if replica == nil {
+		// No replica-role half resolvable — cannot judge; leave untouched.
+		return cnpgStandbyState{}, false
+	}
+	return cnpgStandbyState{
+		PairName:       pairName,
+		ReplicaCluster: replica.GetName(),
+		ReplicaRegion:  replica.GetLabels()[cnpgRegionLabel],
+		Available:      cnpgStandbyAvailable(replica),
+	}, true
+}
+
+// augmentContinuumStandbyStatus cross-checks the live cnpg-pair standby for a
+// cnpg-pair-backed Continuum CR and reflects a lost REQUIRED synchronous
+// hot-standby into the OBSERVED status the DR panel renders (#4901).
+//
+// THE GAP THIS CLOSES. The continuum-controller owns the CR's stored status
+// (ADR-0001 §2.7) and tracks the witness lease / primary correctly, but it
+// derives phase purely from lease-held-ness (patchStatusFromCR). A lost
+// required-sync standby — region-b replica unreachable, writes stalling on
+// SyncRep — therefore leaves the cnpg-pair Continuum pinned phase=Healthy,
+// replicationLagSeconds=0, switchoverInProgress=false (proven in the G12
+// region-kill drill on hw232). An operator watching the cnpg-pair Continuum
+// would not see that RPO=0 durability is at risk. This augments the READ
+// projection (it does NOT write the CR — no second status writer fighting
+// the controller) so the panel surfaces the standby-absent condition,
+// reusing the same live replica-readiness signal deriveLiveContinuumRecord
+// already computes for the no-CR path.
+//
+// Invariants:
+//   - ONLY cnpg-pair-backed continuums (spec.cnpgPair present) with a
+//     resolvable replica half are touched — dr-spine/raft continuums are
+//     left untouched.
+//   - lease/primary tracking (leaseHolder / currentPrimary /
+//     replicationLagSeconds) is preserved verbatim.
+//   - phase is only nudged Healthy→Degraded — never clobbering a FailedOver /
+//     SwitchingOver / already-Degraded phase.
+//   - a Ready-but-lagging standby is NOT flagged (lag rides its own field).
+func (h *Handler) augmentContinuumStandbyStatus(
+	ctx context.Context,
+	client dynamic.Interface,
+	cr *unstructured.Unstructured,
+	status map[string]interface{},
+) map[string]interface{} {
+	st, ok := h.cnpgPairStandbyForContinuum(ctx, client, cr)
+	if !ok {
+		return status
+	}
+	if status == nil {
+		status = map[string]interface{}{}
+	}
+	now := h.continuumNow().UTC().Format(time.RFC3339)
+	status["standbyAvailable"] = st.Available
+	if st.Available {
+		status["hotStandbyAbsent"] = false
+		setContinuumStatusCondition(status, now, "StandbyAvailable", "True", "StandbyReachable",
+			fmt.Sprintf("required synchronous hot-standby %s (cnpg-pair replica cluster %q) is reachable and following the primary",
+				standbyRegionLabel(st.ReplicaRegion), st.ReplicaCluster))
+		return status
+	}
+	// Standby unreachable — surface the Degraded / standby-absent posture.
+	if phase, _ := status["phase"].(string); phase == "" || phase == "Healthy" {
+		status["phase"] = "Degraded"
+	}
+	status["hotStandbyAbsent"] = true
+	setContinuumStatusCondition(status, now, "StandbyAvailable", "False", "StandbyUnreachable",
+		fmt.Sprintf("required synchronous hot-standby %s (cnpg-pair replica cluster %q) is unreachable; synchronous replication has no standby to acknowledge commits so writes stall and RPO=0 durability is at risk",
+			standbyRegionLabel(st.ReplicaRegion), st.ReplicaCluster))
+	return status
+}
+
+// standbyRegionLabel renders a human region for the condition message,
+// falling back to a generic label when the replica Cluster carries no
+// openova.io/region label (single-node dev pairs).
+func standbyRegionLabel(region string) string {
+	if strings.TrimSpace(region) == "" {
+		return "the standby region"
+	}
+	return region
+}
+
+// setContinuumStatusCondition upserts a K8s-style condition into
+// status.conditions[] (append, or replace the existing entry of the same
+// type). It mutates the OBSERVED status map (a deep copy of the CR's status)
+// — never the CR itself.
+func setContinuumStatusCondition(status map[string]interface{}, now, condType, condStatus, reason, message string) {
+	cond := map[string]interface{}{
+		"type":               condType,
+		"status":             condStatus,
+		"reason":             reason,
+		"message":            message,
+		"lastTransitionTime": now,
+	}
+	conds, _ := status["conditions"].([]interface{})
+	for i := range conds {
+		if m, ok := conds[i].(map[string]interface{}); ok {
+			if t, _ := m["type"].(string); t == condType {
+				conds[i] = cond
+				status["conditions"] = conds
+				return
+			}
+		}
+	}
+	status["conditions"] = append(conds, cond)
+}
+
 // deriveLiveContinuumRecord builds a Continuum DR record from the live
 // cnpg cluster-pair backing the app, in the EXACT continuumGetResponse
 // shape the AppDetail DR panel reads. Returns (record, true) when a real

--- a/products/catalyst/bootstrap/api/internal/handler/continuum_standby_absent_4901_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_standby_absent_4901_test.go
@@ -1,0 +1,257 @@
+// continuum_standby_absent_4901_test.go — #4901 regression coverage.
+//
+// The G12 region-kill drill on hw232 proved the cnpg-pair Continuum CR
+// (`cnpg-pair-bp-cnpg-pair-continuum`) stayed phase=Healthy,
+// replicationLagSeconds=0 for the whole outage even though its REQUIRED
+// synchronous hot-standby (region-b replica) was fully unreachable and
+// writes were stalling on SyncRep. The continuum-controller owns the CR's
+// stored status and tracks the witness lease / primary correctly, but it
+// derives phase purely from lease-held-ness — so a lost required-sync
+// standby is invisible in the CR's phase/lag.
+//
+// HandleContinuumGet now cross-checks the LIVE cnpg-pair standby and
+// reflects a standby-absent posture into the OBSERVED status the DR panel
+// renders (Degraded phase + standbyAvailable=false + a StandbyAvailable
+// condition), WITHOUT writing the CR and WITHOUT breaking the correct
+// lease/primary tracking or false-alarming on mere lag. This file locks
+// that behaviour.
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// newCnpgPairContinuumCR composes a Continuum CR shaped like the real
+// bp-cnpg-pair chart output (platform/cnpg-pair/chart/templates/continuum.yaml):
+// it carries spec.cnpgPair.{name,namespace} referencing the backing pair, and
+// a controller-owned status that (correctly) tracks the lease/primary but is
+// blind to the standby. That blindness is exactly what #4901 augments.
+func newCnpgPairContinuumCR(name, namespace, pairName, primaryRegion, replicaRegion string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("dr.openova.io/v1")
+	u.SetKind("Continuum")
+	u.SetName(name)
+	u.SetNamespace(namespace)
+	_ = unstructured.SetNestedMap(u.Object, map[string]interface{}{
+		"applicationRef":    "catalyst-platform",
+		"primaryRegion":     primaryRegion,
+		"hotStandbyRegions": []interface{}{replicaRegion},
+		"cnpgPair": map[string]interface{}{
+			"name":      pairName,
+			"namespace": namespace,
+		},
+		"leaseClient": map[string]interface{}{"kind": "in-memory"},
+	}, "spec")
+	// Controller-owned status: lease held on region-a, phase Healthy, zero
+	// lag — the exact green-but-blind steady state the drill observed.
+	_ = unstructured.SetNestedMap(u.Object, map[string]interface{}{
+		"phase":                 "Healthy",
+		"primaryRegion":         primaryRegion,
+		"leaseHolder":           primaryRegion,
+		"currentPrimary":        pairName + "-primary-1",
+		"replicationLagSeconds": int64(0),
+		"switchoverInProgress":  false,
+	}, "status")
+	return u
+}
+
+// newCnpgClusterHalf builds one cnpg Cluster half of a pair with the
+// canonical pair/role/region labels and a configurable readiness (Ready
+// condition + readyInstances). A down replica models the region-kill state:
+// Ready=False, readyInstances=0.
+func newCnpgClusterHalf(pairName, role, region string, replicaEnabled, ready bool, readyInstances int) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("postgresql.cnpg.io/v1")
+	u.SetKind("Cluster")
+	u.SetName(pairName + "-" + role)
+	u.SetNamespace("catalyst-system")
+	u.SetLabels(map[string]string{
+		cnpgPairLabel:   pairName,
+		cnpgRoleLabel:   role,
+		cnpgRegionLabel: region,
+	})
+	_ = unstructured.SetNestedMap(u.Object, map[string]interface{}{
+		"instances": int64(2),
+		"replica":   map[string]interface{}{"enabled": replicaEnabled},
+	}, "spec")
+	readyStr := "False"
+	if ready {
+		readyStr = "True"
+	}
+	_ = unstructured.SetNestedMap(u.Object, map[string]interface{}{
+		"currentPrimary": pairName + "-" + role + "-1",
+		"phase":          "Cluster in healthy state",
+		"readyInstances": int64(readyInstances),
+		"conditions": []interface{}{
+			map[string]interface{}{"type": "Ready", "status": readyStr},
+		},
+	}, "status")
+	return u
+}
+
+// getContinuumStatus drives GET /continuums/{name} and returns the decoded
+// status map.
+func getContinuumStatus(t *testing.T, h *Handler, depID, name string) (int, map[string]interface{}) {
+	t.Helper()
+	r := chi.NewRouter()
+	registerContinuumRoutes(r, h)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+depID+"/continuums/"+name+"?namespace=catalyst-system", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp continuumGetResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, rec.Body.String())
+	}
+	return rec.Code, resp.Status
+}
+
+func findCondition(status map[string]interface{}, condType string) (map[string]interface{}, bool) {
+	conds, _, _ := unstructured.NestedSlice(status, "conditions")
+	for _, c := range conds {
+		if m, ok := c.(map[string]interface{}); ok {
+			if t, _, _ := unstructured.NestedString(m, "type"); t == condType {
+				return m, true
+			}
+		}
+	}
+	return nil, false
+}
+
+// #4901 — the required sync standby (region-b replica) is UNREACHABLE:
+// its Cluster is present but Ready=False / readyInstances=0. The Continuum
+// GET must now flip phase Healthy→Degraded, set standbyAvailable=false, and
+// carry a StandbyAvailable=False / StandbyUnreachable condition — while
+// preserving the correct lease/primary tracking.
+func TestHandleContinuumGet_StandbyAbsent_SurfacesDegraded(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newCnpgPairContinuumCR(
+		"cnpg-pair-bp-cnpg-pair-continuum", "catalyst-system",
+		"bp-cnpg-pair", "hz-fsn-rtz-prod", "hz-hel-rtz-prod")
+	primary := newCnpgClusterHalf("bp-cnpg-pair", cnpgRolePrimary, "hz-fsn-rtz-prod", false, true, 2)
+	// Region-b killed: replica half present but NOT Ready, zero ready instances.
+	replica := newCnpgClusterHalf("bp-cnpg-pair", cnpgRoleReplica, "hz-hel-rtz-prod", true, false, 0)
+	factory, _ := fakeContinuumDynamicFactory(cr, primary, replica)
+	h.dynamicFactory = factory
+	fixed := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	h.SetContinuumClock(func() time.Time { return fixed })
+	dep := installUserAccessDeployment(t, h, "dep-4901-absent")
+
+	_, status := getContinuumStatus(t, h, dep.ID, "cnpg-pair-bp-cnpg-pair-continuum")
+
+	if phase, _, _ := unstructured.NestedString(status, "phase"); phase != "Degraded" {
+		t.Errorf("phase: got %q want Degraded (standby unreachable)", phase)
+	}
+	if avail, found, _ := unstructured.NestedBool(status, "standbyAvailable"); !found || avail {
+		t.Errorf("standbyAvailable: got %v (found=%v) want false", avail, found)
+	}
+	if absent, _, _ := unstructured.NestedBool(status, "hotStandbyAbsent"); !absent {
+		t.Errorf("hotStandbyAbsent: got false want true")
+	}
+	cond, ok := findCondition(status, "StandbyAvailable")
+	if !ok {
+		t.Fatalf("missing StandbyAvailable condition; status=%+v", status)
+	}
+	if s, _, _ := unstructured.NestedString(cond, "status"); s != "False" {
+		t.Errorf("condition status: got %q want False", s)
+	}
+	if reason, _, _ := unstructured.NestedString(cond, "reason"); reason != "StandbyUnreachable" {
+		t.Errorf("condition reason: got %q want StandbyUnreachable", reason)
+	}
+	// Lease/primary tracking must be preserved verbatim — the fix must not
+	// break the (correct) autoFailover=false, lease-pinned-region-a behaviour.
+	if lh, _, _ := unstructured.NestedString(status, "leaseHolder"); lh != "hz-fsn-rtz-prod" {
+		t.Errorf("leaseHolder clobbered: got %q want hz-fsn-rtz-prod", lh)
+	}
+	if cp, _, _ := unstructured.NestedString(status, "currentPrimary"); cp != "bp-cnpg-pair-primary-1" {
+		t.Errorf("currentPrimary clobbered: got %q", cp)
+	}
+}
+
+// A healthy, following standby (Ready=True, ready instances present) keeps
+// the Continuum green: phase Healthy, standbyAvailable=true. No false alarm.
+func TestHandleContinuumGet_StandbyPresent_StaysHealthy(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newCnpgPairContinuumCR(
+		"cnpg-pair-bp-cnpg-pair-continuum", "catalyst-system",
+		"bp-cnpg-pair", "hz-fsn-rtz-prod", "hz-hel-rtz-prod")
+	primary := newCnpgClusterHalf("bp-cnpg-pair", cnpgRolePrimary, "hz-fsn-rtz-prod", false, true, 2)
+	replica := newCnpgClusterHalf("bp-cnpg-pair", cnpgRoleReplica, "hz-hel-rtz-prod", true, true, 2)
+	factory, _ := fakeContinuumDynamicFactory(cr, primary, replica)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-4901-present")
+
+	_, status := getContinuumStatus(t, h, dep.ID, "cnpg-pair-bp-cnpg-pair-continuum")
+
+	if phase, _, _ := unstructured.NestedString(status, "phase"); phase != "Healthy" {
+		t.Errorf("phase: got %q want Healthy (standby reachable)", phase)
+	}
+	if avail, found, _ := unstructured.NestedBool(status, "standbyAvailable"); !found || !avail {
+		t.Errorf("standbyAvailable: got %v (found=%v) want true", avail, found)
+	}
+	if absent, _, _ := unstructured.NestedBool(status, "hotStandbyAbsent"); absent {
+		t.Errorf("hotStandbyAbsent: got true want false")
+	}
+}
+
+// A Ready-but-LAGGING standby (Ready=True, ready instances present, high lag)
+// must NOT be flagged standby-absent — lag rides its own field. This guards
+// the explicit no-false-alarm rule.
+func TestHandleContinuumGet_StandbyLagging_NotFlagged(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newCnpgPairContinuumCR(
+		"cnpg-pair-bp-cnpg-pair-continuum", "catalyst-system",
+		"bp-cnpg-pair", "hz-fsn-rtz-prod", "hz-hel-rtz-prod")
+	primary := newCnpgClusterHalf("bp-cnpg-pair", cnpgRolePrimary, "hz-fsn-rtz-prod", false, true, 2)
+	replica := newCnpgClusterHalf("bp-cnpg-pair", cnpgRoleReplica, "hz-hel-rtz-prod", true, true, 2)
+	// Model lag on the replica half — still Ready, so still AVAILABLE.
+	_ = unstructured.SetNestedField(replica.Object, int64(45), "status", "lag")
+	factory, _ := fakeContinuumDynamicFactory(cr, primary, replica)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-4901-lag")
+
+	_, status := getContinuumStatus(t, h, dep.ID, "cnpg-pair-bp-cnpg-pair-continuum")
+
+	if phase, _, _ := unstructured.NestedString(status, "phase"); phase != "Healthy" {
+		t.Errorf("phase: got %q want Healthy (lagging standby is NOT absent)", phase)
+	}
+	if avail, found, _ := unstructured.NestedBool(status, "standbyAvailable"); !found || !avail {
+		t.Errorf("standbyAvailable: got %v (found=%v) want true (lag is not absence)", avail, found)
+	}
+}
+
+// A dr-spine / raft Continuum has no spec.cnpgPair (no synchronous cnpg
+// standby). Its status must pass through UNTOUCHED — the fix is scoped to
+// the cnpg-pair path only.
+func TestHandleContinuumGet_NoCNPGPairRef_Untouched(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	// newContinuumUnstructured sets NO spec.cnpgPair (dr-spine shape).
+	cr := newContinuumUnstructured(
+		"bp-openbao-continuum", "catalyst-system",
+		"spine-openbao", "hz-fsn-rtz-prod", []string{"hz-hel-rtz-prod"})
+	factory, _ := fakeContinuumDynamicFactory(cr)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-4901-spine")
+
+	_, status := getContinuumStatus(t, h, dep.ID, "bp-openbao-continuum")
+
+	if phase, _, _ := unstructured.NestedString(status, "phase"); phase != "Healthy" {
+		t.Errorf("phase: got %q want Healthy (dr-spine untouched)", phase)
+	}
+	if _, found, _ := unstructured.NestedBool(status, "standbyAvailable"); found {
+		t.Errorf("standbyAvailable should be ABSENT for a non-cnpg-pair continuum")
+	}
+	if _, ok := findCondition(status, "StandbyAvailable"); ok {
+		t.Errorf("StandbyAvailable condition should NOT be added for a dr-spine continuum")
+	}
+}


### PR DESCRIPTION
## Problem

The G12 region-kill drill on hw232 proved the cnpg-pair Continuum CR
(`cnpg-pair-bp-cnpg-pair-continuum`) stayed `phase=Healthy`,
`replicationLagSeconds=0`, `switchoverInProgress=false` for the entire outage
even when its **required synchronous hot-standby** (region-b replica) was fully
unreachable and writes were actually stalling on SyncRep.

The continuum-controller owns the CR's stored status and derives phase purely
from witness-lease-held-ness (`patchStatusFromCR`) — which is correct for
lease/primary tracking (lease pinned region-a, no false failover under
`autoFailover=false`), but **blind to a lost required-sync standby**. So an
operator watching the cnpg-pair Continuum would not see that RPO=0 durability
was at risk. The dr-spine continuums do not hit this because they carry no
synchronous cnpg pair; this was the gap for the cnpg-pair path.

## Fix

`HandleContinuumGet` (the plural `/continuums/{name}` surface the DR panel's
`getContinuum` calls) now cross-checks the **live** cnpg-pair standby — reusing
the same replica-readiness signal `deriveLiveContinuumRecord` already computes
for the no-CR path — and reflects a standby-absent posture into the **observed**
status:

- `phase` Healthy → **Degraded**
- `standbyAvailable = false` + `hotStandbyAbsent = true`
- a `StandbyAvailable = False` / reason `StandbyUnreachable` status condition

This is a **read-only projection augment** (the status map is a deep copy of the
CR's `status`) — it never writes the CR, so it does not fight the controller's
status ownership (ADR-0001 §2.7).

### Status seam

`products/catalyst/bootstrap/api/internal/handler/continuum.go` →
`HandleContinuumGet`, augmented via
`augmentContinuumStandbyStatus` + `cnpgPairStandbyForContinuum` in
`continuum_live.go`.

### Guardrails

- Only cnpg-pair-backed continuums (`spec.cnpgPair` present) with a resolvable
  replica-role Cluster half are touched; dr-spine / openbao-raft continuums pass
  through untouched.
- Lease/primary tracking (`leaseHolder`, `currentPrimary`,
  `replicationLagSeconds`) is preserved verbatim; phase is only nudged
  Healthy → Degraded — never clobbering `FailedOver` / `SwitchingOver`.
- A Ready-but-lagging standby is **not** flagged — standby-absent keys off the
  replica Cluster's Ready condition + `readyInstances`, not lag (no false alarm).

### Note on scope

The catalyst-api intentionally does not import the continuum-controller. The CR's
own stored `.status` (as seen via `kubectl get continuum`) is still owned by
`core/controllers/continuum` and would need the same standby-readiness factor in
its `patchStatusFromCR` to reflect this at the CR level; that durable
controller-side twin is the natural follow-up. This change closes the
operator-facing observability gap at the API/DR-panel layer that the drill
exercised.

## Tests

`continuum_standby_absent_4901_test.go` — standby-absent (Degraded + condition +
lease preserved), standby-present (stays Healthy), lagging-not-flagged, and
dr-spine-untouched. Full handler suite + `go build ./...` + `go vet ./...` green.

Refs #4901

🤖 Generated with [Claude Code](https://claude.com/claude-code)