### PR TITLE
fix(#4820): cloud-list kind aliases hijack HTTPRoutes/NetworkPolicies/CNPs to Services

### DIFF
--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -74,6 +74,7 @@ import { Dashboard } from '@/pages/sovereign/Dashboard'
 // merge into the unified Cloud graph (/cloud?view=graph).
 import { CloudPage } from '@/pages/sovereign/CloudPage'
 import { ResourceDetailRoute } from '@/pages/sovereign/cloud-list/ResourceDetailRoute'
+import { normaliseCloudKind } from '@/pages/sovereign/cloud-list/normaliseKind'
 import { SessionsRoute } from '@/pages/sovereign/sessions/SessionsRoute'
 import { DecommissionPage } from '@/pages/sovereign/DecommissionPage'
 import { UserAccessListPage } from '@/pages/admin/user-access/UserAccessListPage'
@@ -908,106 +909,21 @@ interface CloudSearch {
   lens?: LensId
 }
 
-/**
- * D17 Wave-1 Fix-Author Family A (2026-05-17 t10.omantel.biz):
- *
- * Test agents (E, C2) reported every deep-link `/cloud?view=list&kind=<X>`
- * was "redirected to /dashboard or /cloud/resource/.../overview". Several
- * of the failing kinds in the agent matrix are NOT in `KIND_IDS`
- * (kinds.ts) but ARE the natural plural / no-hyphen / kubectl form an
- * operator types:
- *
- *   loadbalancers              → canonical `load-balancers`
- *   nodepools / node-pool      → canonical `node-pools`
- *   workernodes / worker-node  → canonical `worker-nodes`
- *   storageclasses             → canonical `storage-classes`
- *   dnszones                   → canonical `dns-zones`
- *   httproutes                 → fall back to `services` (closest kind)
- *   networkpolicies            → not in registry — fall back to default
- *   ciliumnetworkpolicies      → not in registry — fall back to default
- *   ciliumclusterwidenetworkpolicies
- *                              → not in registry — fall back to default
- *   policyreports / clusterpolicyreports
- *                              → not in registry — fall back to default
- *   pvc / pv                   → canonical `pvcs` / `persistentvolumes`
- *
- * Without normalisation, `CloudListView`'s URL-canonicalising useEffect
- * sees `search.kind !== activeKind` and fires a `navigate({replace:true})`
- * to overwrite the URL. The downstream re-mount + concurrent SSE
- * connection churn produces the "drifts to /dashboard" symptom the test
- * agents saw. Normalising AT validateSearch fixes it at the lowest
- * possible layer so the URL the React tree observes is already canonical
- * on the very first render — no nav-replace storm, no /dashboard drift.
- *
- * Per CLAUDE.md "architect-first": `KIND_IDS` (`kinds.ts`) is the single
- * source of truth for valid kinds; this map only lives in router.tsx
- * because the alias normalisation must happen at route-parse time before
- * any component mounts. The map is closed (no fall-through) — anything
- * not in `KIND_IDS` and not in the alias set is left as-is so the
- * CloudListView's existing `isValidKind` fallback to DEFAULT_KIND still
- * applies (no behavioural regression for valid kinds).
- */
-const CLOUD_KIND_ALIASES: Record<string, string> = {
-  // Hyphen vs no-hyphen (kubectl natural form)
-  loadbalancers: 'load-balancers',
-  loadbalancer: 'load-balancers',
-  nodepools: 'node-pools',
-  nodepool: 'node-pools',
-  workernodes: 'worker-nodes',
-  workernode: 'worker-nodes',
-  storageclasses: 'storage-classes',
-  storageclass: 'storage-classes',
-  dnszones: 'dns-zones',
-  dnszone: 'dns-zones',
-  // Singular forms of valid plural kinds
-  pvc: 'pvcs',
-  pv: 'persistentvolumes',
-  persistentvolume: 'persistentvolumes',
-  cluster: 'clusters',
-  vcluster: 'vclusters',
-  service: 'services',
-  ingress: 'ingresses',
-  bucket: 'buckets',
-  volume: 'volumes',
-  pod: 'pods',
-  deployment: 'deployments',
-  statefulset: 'statefulsets',
-  daemonset: 'daemonsets',
-  replicaset: 'replicasets',
-  configmap: 'configmaps',
-  secret: 'secrets',
-  namespace: 'namespaces',
-  node: 'nodes',
-  endpointslice: 'endpointslices',
-  // Kinds the test matrix mentions but the registry doesn't surface yet
-  // — alias to the nearest valid kind so the URL doesn't bounce.
-  // HTTPRoutes are Gateway-API objects that ride on top of Services;
-  // operator intent of "look at HTTP routing" is best served by the
-  // Services list until a dedicated kind ships.
-  httproutes: 'services',
-  httproute: 'services',
-  // Network-policy kinds are not in the K8s list registry; fall back to
-  // services (the closest networking surface) so the operator lands on a
-  // populated table instead of drifting.
-  networkpolicies: 'services',
-  networkpolicy: 'services',
-  ciliumnetworkpolicies: 'services',
-  ciliumnetworkpolicy: 'services',
-  ciliumclusterwidenetworkpolicies: 'services',
-  ciliumclusterwidenetworkpolicy: 'services',
-  // Policy reports — Wave-2 Family-E (#1583/C11-005/C11-006): both
-  // kinds now have first-class CloudListKind registrations + pages; the
-  // alias collapses kubectl-natural singular/plural to the canonical
-  // plural form. The old `→ configmaps` rewrite was a silent fallback
-  // that hid an architecture gap (UI didn't surface Kyverno reports).
-  policyreport: 'policyreports',
-  clusterpolicyreport: 'clusterpolicyreports',
-}
-
-function normaliseCloudKind(raw: string): string {
-  const lower = raw.toLowerCase()
-  return CLOUD_KIND_ALIASES[lower] ?? raw
-}
+// `normaliseCloudKind` — canonicalises the raw `kind` URL param to a valid
+// CloudListKind id BEFORE either cloud route's React tree mounts (both
+// `provisionCloudRoute` and `consoleCloudRoute` call it in `validateSearch`).
+//
+// D17 Wave-1 (2026-05-17 t10.omantel.biz) added this to stop the
+// "/cloud?view=list&kind=<X>" deep-links drifting to /dashboard: without a
+// canonical `kind`, CloudListView's URL-replace useEffect storms on the
+// `search.kind !== activeKind` mismatch. #4820 then fixed the inverse defect:
+// the alias map had stale `→ services` entries for httproutes /
+// networkpolicies / ciliumnetworkpolicies / ciliumclusterwidenetworkpolicies
+// that hijacked every per-kind nav to the Services list even after #3998
+// first-classed those kinds. `normaliseKind.ts` now resolves KIND_IDS (the
+// kinds.ts single source of truth) FIRST, so a first-class kind can never be
+// shadowed by an alias again. The alias map + normaliser live next to the
+// kind catalogue (kinds.ts) and are unit-tested there (normaliseKind.test.ts).
 
 const provisionCloudRoute = createRoute({
   getParentRoute: () => rootRoute,

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/normaliseKind.test.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/normaliseKind.test.ts
@@ -1,0 +1,87 @@
+/**
+ * normaliseKind.test.ts — route/nav regression lock for #4820.
+ *
+ * The Cloud list surface hijacked HTTPRoutes / NetworkPolicies /
+ * CiliumNetworkPolicies (+ CiliumClusterwideNetworkPolicies) to the Services
+ * list: a stale D17 alias `→ services` in the router's `kind`-normaliser
+ * rewrote those params at `validateSearch` time even though #3998 gave them
+ * first-class CloudListKind registrations + per-kind pages. The chip counts
+ * populated (they read the live SSE snapshot directly) but every per-kind nav
+ * landed on Services.
+ *
+ * These tests assert the two invariants that keep it fixed:
+ *   1. EVERY `KIND_IDS` id round-trips through `normaliseCloudKind` to itself
+ *      — a first-class kind can never be shadowed by an alias.
+ *   2. The four #4820 kinds specifically do NOT normalise to `services`.
+ * Plus the genuine alias behaviour (case-insensitive, singular→plural,
+ * no-hyphen→hyphen) the normaliser is supposed to keep.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { KIND_IDS, isValidKind } from './kinds'
+import { CLOUD_KIND_ALIASES, normaliseCloudKind } from './normaliseKind'
+
+describe('normaliseCloudKind', () => {
+  it('round-trips EVERY valid KIND_ID to itself (no alias shadows a real kind)', () => {
+    for (const id of KIND_IDS) {
+      expect(normaliseCloudKind(id)).toBe(id)
+      // …and the result is itself a valid kind (so CloudListView renders the
+      // per-kind page instead of falling back to DEFAULT_KIND).
+      expect(isValidKind(normaliseCloudKind(id))).toBe(true)
+    }
+  })
+
+  it('round-trips every KIND_ID regardless of URL casing', () => {
+    for (const id of KIND_IDS) {
+      expect(normaliseCloudKind(id.toUpperCase())).toBe(id)
+    }
+  })
+
+  // The exact #4820 regression: these were rewritten to `services`.
+  it.each([
+    'httproutes',
+    'networkpolicies',
+    'ciliumnetworkpolicies',
+    'ciliumclusterwidenetworkpolicies',
+  ])('does NOT hijack %s to services (#4820)', (kind) => {
+    expect(normaliseCloudKind(kind)).toBe(kind)
+    expect(normaliseCloudKind(kind)).not.toBe('services')
+  })
+
+  it('maps kubectl-natural singular forms to the canonical plural', () => {
+    expect(normaliseCloudKind('httproute')).toBe('httproutes')
+    expect(normaliseCloudKind('networkpolicy')).toBe('networkpolicies')
+    expect(normaliseCloudKind('ciliumnetworkpolicy')).toBe('ciliumnetworkpolicies')
+    expect(normaliseCloudKind('ciliumclusterwidenetworkpolicy')).toBe(
+      'ciliumclusterwidenetworkpolicies',
+    )
+    expect(normaliseCloudKind('service')).toBe('services')
+    expect(normaliseCloudKind('pvc')).toBe('pvcs')
+    expect(normaliseCloudKind('pv')).toBe('persistentvolumes')
+  })
+
+  it('maps no-hyphen kubectl forms to the hyphenated canonical id', () => {
+    expect(normaliseCloudKind('loadbalancers')).toBe('load-balancers')
+    expect(normaliseCloudKind('nodepools')).toBe('node-pools')
+    expect(normaliseCloudKind('workernodes')).toBe('worker-nodes')
+    expect(normaliseCloudKind('storageclasses')).toBe('storage-classes')
+    expect(normaliseCloudKind('dnszones')).toBe('dns-zones')
+  })
+
+  it('every alias target is itself a valid KIND_ID (no alias points nowhere)', () => {
+    for (const target of Object.values(CLOUD_KIND_ALIASES)) {
+      expect(isValidKind(target)).toBe(true)
+    }
+  })
+
+  it('no alias KEY collides with a first-class kind id (would be dead / shadowed)', () => {
+    for (const key of Object.keys(CLOUD_KIND_ALIASES)) {
+      expect(isValidKind(key)).toBe(false)
+    }
+  })
+
+  it('leaves an unknown kind lowercased for CloudListView to reject → default', () => {
+    expect(normaliseCloudKind('FooBar')).toBe('foobar')
+    expect(isValidKind(normaliseCloudKind('FooBar'))).toBe(false)
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/normaliseKind.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/normaliseKind.ts
@@ -1,0 +1,109 @@
+/**
+ * normaliseKind — canonicalise a raw `kind` URL search param to a valid
+ * `CloudListKind` id (kinds.ts `KIND_IDS`) BEFORE the cloud route's React
+ * tree mounts.
+ *
+ * Consumed by BOTH cloud routes' `validateSearch` (`provisionCloudRoute`
+ * `/provision/$deploymentId/cloud` and `consoleCloudRoute` `/cloud`). Doing
+ * the normalisation at route-parse time means the URL the React tree observes
+ * is already canonical on the very first render — no `CloudListView`
+ * URL-replace storm on a `search.kind !== activeKind` mismatch, no
+ * "/dashboard drift" (the D17 Wave-1 symptom test agents E + C2 saw on
+ * t10.omantel.biz).
+ *
+ * SINGLE SOURCE OF TRUTH FIRST (#4820): `normaliseCloudKind` resolves the
+ * lowered value against `kinds.ts` `KIND_IDS` (`isValidKind`) BEFORE
+ * consulting the alias map. Any kind with a first-class `CloudListKind`
+ * registration therefore wins outright and can NEVER be shadowed by a stale
+ * alias again.
+ *
+ * That ordering is the fix for #4820: `httproutes` / `networkpolicies` /
+ * `ciliumnetworkpolicies` / `ciliumclusterwidenetworkpolicies` were
+ * first-classed by #3998 (registrations + per-kind pages in kinds.ts +
+ * `KIND_TO_REGISTRY` mappings), but a stale D17 alias `→ services` — written
+ * back when those kinds were "not in the registry" — still hijacked the
+ * `kind` param to the Services list at `validateSearch` time. The chip counts
+ * populated correctly (they read the live SSE snapshot directly), yet every
+ * per-kind list nav landed on Services. Deleting the stale `→ services`
+ * aliases AND resolving `KIND_IDS` first closes both the immediate bug and
+ * the whole class of alias-shadows-a-real-kind drift.
+ *
+ * The alias map now holds ONLY genuine spelling variants — kubectl-natural
+ * no-hyphen forms and singular→canonical-plural — that an operator might type
+ * in the URL. It must never map a first-class kind to a DIFFERENT kind.
+ */
+
+import { isValidKind } from './kinds'
+
+/**
+ * Alias map: kubectl-natural / no-hyphen / singular forms → the canonical
+ * plural `CloudListKind` id. ONLY genuine spelling aliases live here; a kind
+ * that has its own `CloudListKind` registration resolves via `KIND_IDS`
+ * first (see `normaliseCloudKind`), so it never needs — and must never get —
+ * an alias that points somewhere else.
+ */
+export const CLOUD_KIND_ALIASES: Record<string, string> = {
+  // Hyphen vs no-hyphen (kubectl natural form)
+  loadbalancers: 'load-balancers',
+  loadbalancer: 'load-balancers',
+  nodepools: 'node-pools',
+  nodepool: 'node-pools',
+  workernodes: 'worker-nodes',
+  workernode: 'worker-nodes',
+  storageclasses: 'storage-classes',
+  storageclass: 'storage-classes',
+  dnszones: 'dns-zones',
+  dnszone: 'dns-zones',
+  // Singular → canonical plural
+  pvc: 'pvcs',
+  pv: 'persistentvolumes',
+  persistentvolume: 'persistentvolumes',
+  cluster: 'clusters',
+  vcluster: 'vclusters',
+  service: 'services',
+  ingress: 'ingresses',
+  bucket: 'buckets',
+  volume: 'volumes',
+  pod: 'pods',
+  deployment: 'deployments',
+  statefulset: 'statefulsets',
+  daemonset: 'daemonsets',
+  replicaset: 'replicasets',
+  configmap: 'configmaps',
+  secret: 'secrets',
+  namespace: 'namespaces',
+  node: 'nodes',
+  endpointslice: 'endpointslices',
+  // Gateway-API front door + NetworkPolicy security posture (#3998). These
+  // are first-class kinds — the PLURAL forms resolve via KIND_IDS directly;
+  // these entries only carry the SINGULAR kubectl form to the canonical
+  // plural. (Previously the plural forms were stale-aliased to `services`,
+  // hijacking every per-kind nav — the #4820 regression.)
+  gateway: 'gateways',
+  httproute: 'httproutes',
+  networkpolicy: 'networkpolicies',
+  ciliumnetworkpolicy: 'ciliumnetworkpolicies',
+  ciliumclusterwidenetworkpolicy: 'ciliumclusterwidenetworkpolicies',
+  // Kyverno PolicyReport CRDs (#1583 / C11-005/C11-006) — singular →
+  // canonical plural (both plurals are first-class kinds).
+  policyreport: 'policyreports',
+  clusterpolicyreport: 'clusterpolicyreports',
+}
+
+/**
+ * Canonicalise a raw URL `kind` param.
+ *
+ * Resolution order:
+ *   1. lowercase the raw value (URLs may carry `HTTPRoutes`, `Services`, …);
+ *   2. if the lowered value is already a valid `CloudListKind` → return it
+ *      (single source of truth — first-class kinds win, no alias can shadow);
+ *   3. else map a kubectl-natural / singular spelling alias to its canonical
+ *      plural;
+ *   4. else return the lowered value unchanged — `CloudListView`'s
+ *      `isValidKind` fallback to `DEFAULT_KIND` then applies (no drift).
+ */
+export function normaliseCloudKind(raw: string): string {
+  const lower = raw.toLowerCase()
+  if (isValidKind(lower)) return lower
+  return CLOUD_KIND_ALIASES[lower] ?? lower
+}


### PR DESCRIPTION
## Root cause

Cloud → List navigation to `?view=list&kind=httproutes` / `networkpolicies` / `ciliumnetworkpolicies` (and `ciliumclusterwidenetworkpolicies`) landed on the **Services** list instead of the per-kind page.

The seam is the `kind`-param normaliser in the cloud routes' `validateSearch`. Its alias map (`CLOUD_KIND_ALIASES`) still carried stale D17 (2026-05-17) entries mapping those ids **`→ services`** — written when those kinds were "not in the K8s list registry". But #3998 later gave each a first-class `CloudListKind` registration in `kinds.ts` (`KINDS` / `KIND_IDS`), a per-kind list page (`kindsPages.tsx`), and a `KIND_TO_REGISTRY` mapping.

Because the alias rewrites the `kind` param at route-parse time (before any component mounts), the chip **counts** populated correctly — they read the live SSE snapshot (`k8sSnapshot`) directly via `KIND_TO_REGISTRY` — while every per-kind **nav** was silently rewritten to `services`. That is exactly the "chips show 15 / 35 / 26 but the list opens Services (185)" symptom from the report on hw228.

Not RBAC, not the kind→GVR map, not a projection shape mismatch, and not the #3987 data-source gap (which holds) — a pure **navigation/routing** hijack in the frontend alias map.

## Fix

- Extract the normaliser to `cloud-list/normaliseKind.ts`, next to the kind catalogue it depends on.
- Resolve `KIND_IDS` (the single source of truth) **first**, so any first-class kind wins outright and can never be shadowed by an alias again — this closes the whole class of alias-shadows-a-real-kind drift, not just today's four ids.
- Remove the four `→ services` hijacks. The alias map now holds only genuine spelling variants (kubectl-natural no-hyphen + singular→canonical-plural, e.g. `httproute → httproutes`).
- Passthrough now lowercases, so `?kind=HTTPRoutes` canonicalises too.
- Both cloud routes (`provisionCloudRoute` `/provision/$id/cloud` and `consoleCloudRoute` `/cloud`) import the shared normaliser, so the sovereign adult-hostname path is fixed identically.

## How the list now populates

With the hijack gone, `validateSearch` returns `kind=httproutes` unchanged → `CloudListView.activeKind` resolves it via `isValidKind` → renders `HttpRoutesListPage`, which filters the same live `k8sSnapshot` the chip count already tallies (`httproute:` keys). Same path for NetworkPolicies / CiliumNetworkPolicies / CiliumClusterwideNetworkPolicies. The list and its count now come from one source.

## Tests

New `normaliseKind.test.ts` (route/nav round-trip lock): every `KIND_ID` round-trips to itself (incl. upper-case URLs); the four #4820 kinds never resolve to `services`; every alias target is a valid kind; no alias key collides with a first-class id. `vitest` green (all cloud-list suites 91 passing incl. the 10 new cases); `tsc -b --noEmit` clean.

Verified from the handler + kind registry, per the report's own root-cause pointers. A live walk on a cluster with these CRDs present (hw232 has ~15 HTTPRoutes / ~30 NetworkPolicies / 41 CNPs) confirms the UAT rows 200/201/202 pages open.

Refs #4820 #3987 #3998