### PR TITLE
docs(cilium): retire stale clustermesh NodePort-32379 comment in fresh-prov template (Refs #4765)

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -348,11 +348,17 @@ spec:
       # provision time. Mesh registry: docs/CLUSTERMESH-CLUSTER-IDS.md
       # tracks the cluster.id allocation across the OpenOva fleet.
       #
-      # NodePort 32379: clustermesh-apiserver Pod is exposed on every
-      # Cilium node so peers reach it over the Hetzner private network on
-      # `<cp-private-ip>:32379` WITHOUT requiring a Hetzner LoadBalancer
-      # per peer (LB count is project-quota'd). Hetzner firewall must
-      # open 32379/tcp from peer Sovereigns' Hetzner CIDRs.
+      # Cross-region reachability (#4765 — ZERO NodePorts, ever): peers
+      # reach the clustermesh-apiserver etcd (:2379) over the DIRECT
+      # LoadBalancer path — never a NodePort. On no-CCM Huawei the single
+      # `sovereign-vip` LB-IPAM pool (cilium.lbIpam above) hands the
+      # clustermesh-apiserver Service the shared Sovereign EIP via the
+      # `lbipam.cilium.io/sharing-key: sovereign-vip` annotation, and the
+      # #4784 `clustermeshProxy` hostNetwork shim (hostPort :12379) fronts
+      # the etcd where <EIP>:2379 would otherwise collide with the CP
+      # node's own k3s etcd. On Hetzner hcloud-ccm allocates a public-IPv4
+      # LB per peer region. The retired pre-#4765 `node:32379` NodePort
+      # exposure is FORBIDDEN and no longer rendered.
       #
       # A Sovereign that does NOT join a mesh leaves CLUSTER_MESH_NAME
       # empty (Flux envsubst rule: ${VAR:=default} -> "default" when


### PR DESCRIPTION
## Summary

Corrects the last stale forbidden-pattern reference left behind by the #4765 zero-NodePorts work. The canonical fresh-prov template `clusters/_template/bootstrap-kit/01-cilium.yaml` still carried a comment block describing the retired `node:32379` NodePort exposure as the **live** clustermesh-apiserver reachability mechanism — directly contradicting both the founder "zero NodePorts, ever" hard rule and the actual `service.type: LoadBalancer` config 30 lines below it.

## Context — the substantive fix already merged

The actual NodePort elimination for #4765 already landed on `main` across three commits:
- `3ce78f0d7` — single `sovereign-vip` LB-IPAM pool, clustermesh VIP:2379 dial, CI guardrail
- `e0e746eb4` — clustermesh apiserver `authMode=legacy` + kyverno label
- `8e2eb6519` — hook-Job labels spelled out (managed-by=flux)

Result verified in this branch: **zero real nodePort declarations** anywhere under `platform/ products/ clusters/`.
- `powerdns-anycast` Service → `type: LoadBalancer` + `lbipam.cilium.io/sharing-key: sovereign-vip` + `allocateLoadBalancerNodePorts: false`, with a hard `{{ fail }}` guard rejecting `serviceType=NodePort`.
- `clustermesh-apiserver` Service → `type: LoadBalancer` on the shared `sovereign-vip` pool + a postRenderer patch setting `allocateLoadBalancerNodePorts: false`.

## This change

Comment-only. Rewrites the stale block so the next reader is not told a NodePort is part of the design. Cross-region peers reach the clustermesh etcd (:2379) via the DIRECT LoadBalancer path — the `sovereign-vip` LB-IPAM VIP on no-CCM Huawei plus the #4784 `clustermeshProxy` hostNetwork shim (hostPort 12379), or an hcloud-ccm public LB on Hetzner. Never a NodePort.

## Proof — zero nodePorts render

```
$ helm template bp-powerdns platform/powerdns/chart | grep -niE 'nodePort|type: *NodePort'
182:  # 🛑 zero nodePorts, ever (#4765): the VIP is served by Cilium LB-IPAM
184:  allocateLoadBalancerNodePorts: false      # <-- suppression field, not a leak

$ helm template ... --set anycast.serviceType=NodePort
Error: bp-powerdns: anycast.serviceType=NodePort is FORBIDDEN (#4765) — use LoadBalancer (Cilium LB-IPAM shared VIP) or ClusterIP

$ grep -rniE 'type:\s*NodePort|serviceType:\s*NodePort|nodePort:\s*[0-9]' platform/ products/ clusters/
>>> ZERO real nodePort declarations <<<
```

The only rendered `nodePort` token is `allocateLoadBalancerNodePorts: false` (the suppression field) and its explanatory comment.

Refs #4765
Refs #4784

🤖 Generated with [Claude Code](https://claude.com/claude-code)