### PR TITLE
fix(#4860): map apiserver Forbidden to 403 in Blueprint Edit-IaC dry-run/apply

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/k8s_resource_actions.go
+++ b/products/catalyst/bootstrap/api/internal/handler/k8s_resource_actions.go
@@ -361,6 +361,22 @@ func (h *Handler) handleApplyOrDryRun(w http.ResponseWriter, r *http.Request, dr
 				})
 				return
 			}
+			// #4860 — an RBAC denial on the resourceVersion pre-fetch is a
+			// CLIENT/permission error, not a server fault; surface 403 like
+			// the sibling read path (k8s_resource_get.go) does. Before this
+			// case a Forbidden fell through to the 500 below, which is the
+			// exact "Validate(dry-run) → HTTP 500" symptom seen on hw228
+			// when catalyst-api's SA lacked blueprints get/update (later
+			// granted by #4862, but the handler must still classify the
+			// error correctly for any cluster where the grant is absent).
+			if apierrors.IsForbidden(getErr) {
+				writeJSON(w, http.StatusForbidden, map[string]string{
+					"error":  "apiserver-forbidden",
+					"code":   "403",
+					"detail": getErr.Error(),
+				})
+				return
+			}
 			writeJSON(w, http.StatusInternalServerError, map[string]string{
 				"error":  "resource-get-failed",
 				"detail": getErr.Error(),
@@ -379,10 +395,25 @@ func (h *Handler) handleApplyOrDryRun(w http.ResponseWriter, r *http.Request, dr
 	}
 	if updErr != nil {
 		// Validation errors and conflicts surface via apierrors; surface
-		// 400 for invalid + 409 for conflict + 500 otherwise.
+		// 400 for invalid + 403 for forbidden + 409 for conflict + 404 for
+		// not-found + 500 otherwise.
 		if apierrors.IsInvalid(updErr) || apierrors.IsBadRequest(updErr) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{
 				"error":  "invalid-resource",
+				"detail": updErr.Error(),
+			})
+			return
+		}
+		// #4860 — an apiserver RBAC denial on the dry-run/apply Update is a
+		// permission (4xx) error, not a server fault. This case was the one
+		// missing from the switch below, so a Forbidden bubbled to the 500
+		// default and the console saw "Validate(dry-run)/Commit → HTTP 500"
+		// (caught live on hw228, bp-wordpress). Match the sibling PUT path
+		// (writeK8sUpdateError) + scale/restart/delete (writeResourceMutationError).
+		if apierrors.IsForbidden(updErr) {
+			writeJSON(w, http.StatusForbidden, map[string]string{
+				"error":  "apiserver-forbidden",
+				"code":   "403",
 				"detail": updErr.Error(),
 			})
 			return

--- a/products/catalyst/bootstrap/api/internal/handler/k8s_resource_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/k8s_resource_test.go
@@ -53,6 +53,22 @@ type k8sResourceTestRig struct {
 }
 
 func newResourceRig(t *testing.T, objs ...runtime.Object) *k8sResourceTestRig {
+	return newResourceRigWithPrep(t, nil, objs...)
+}
+
+// newResourceRigWithPrep is newResourceRig plus a hook that runs against
+// the fake dynamic client BEFORE the k8scache informer factory starts.
+//
+// This ordering is load-bearing for tests that install a PrependReactor:
+// client-go's fake `PrependReactor` mutates `Fake.ReactionChain` WITHOUT
+// taking the fake's mutex (testing/fake.go), whereas the background
+// informer's reflector reads that same chain under the lock via
+// `Fake.Invokes` on every List/Watch. Installing the reactor after
+// `factory.Start` therefore data-races the reflector goroutine. Running
+// the prep here — before any reflector goroutine exists — means the
+// reaction chain is fully built by the time concurrent Invokes begin, and
+// every subsequent access is serialized under `Fake.Lock`.
+func newResourceRigWithPrep(t *testing.T, prep func(*dynamicfake.FakeDynamicClient), objs ...runtime.Object) *k8sResourceTestRig {
 	t.Helper()
 	scheme := runtime.NewScheme()
 	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Version: "v1", Kind: "PodList"}, &unstructured.UnstructuredList{})
@@ -76,6 +92,11 @@ func newResourceRig(t *testing.T, objs ...runtime.Object) *k8sResourceTestRig {
 		{Group: "catalyst.openova.io", Version: "v1", Resource: "blueprints"}: "BlueprintList",
 	}
 	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, objs...)
+	// Install any reactors BEFORE the informer factory starts — see the
+	// doc comment on newResourceRigWithPrep for why the ordering matters.
+	if prep != nil {
+		prep(dyn)
+	}
 	core := kfake.NewSimpleClientset()
 
 	r := k8scache.NewRegistry()
@@ -608,15 +629,18 @@ var blueprintsGR = schema.GroupResource{Group: "catalyst.openova.io", Resource: 
 // fixed alongside so the cluster-scoped Update routes correctly.
 func TestHandleK8sResourceDryRun_ForbiddenUpdateMapsTo403(t *testing.T) {
 	bp := newBlueprintObj("bp-alloy")
-	rig := newResourceRig(t, bp)
-	defer rig.stop()
 	// Let the RV-block Get succeed (object is seeded) but deny the Update,
-	// exactly as an under-privileged SA would experience it.
-	rig.dyn.PrependReactor("update", "blueprints", func(action clienttesting.Action) (bool, runtime.Object, error) {
-		return true, nil, apierrors.NewForbidden(blueprintsGR, "bp-alloy",
-			errors.New(`blueprints.catalyst.openova.io "bp-alloy" is forbidden: `+
-				`User "system:serviceaccount:catalyst:catalyst-api" cannot update resource "blueprints"`))
-	})
+	// exactly as an under-privileged SA would experience it. The reactor is
+	// installed pre-start (via the prep hook) so it does not race the
+	// informer's reflector — see newResourceRigWithPrep.
+	rig := newResourceRigWithPrep(t, func(dyn *dynamicfake.FakeDynamicClient) {
+		dyn.PrependReactor("update", "blueprints", func(action clienttesting.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewForbidden(blueprintsGR, "bp-alloy",
+				errors.New(`blueprints.catalyst.openova.io "bp-alloy" is forbidden: `+
+					`User "system:serviceaccount:catalyst:catalyst-api" cannot update resource "blueprints"`))
+		})
+	}, bp)
+	defer rig.stop()
 
 	yamlBody := `apiVersion: catalyst.openova.io/v1
 kind: Blueprint
@@ -645,13 +669,16 @@ spec:
 // resource-get-failed 500; it must now surface 403.
 func TestHandleK8sResourceApply_ForbiddenGetMapsTo403(t *testing.T) {
 	bp := newBlueprintObj("bp-alloy")
-	rig := newResourceRig(t, bp)
+	// Reactor installed pre-start so it does not race the informer's
+	// reflector List/Watch — see newResourceRigWithPrep.
+	rig := newResourceRigWithPrep(t, func(dyn *dynamicfake.FakeDynamicClient) {
+		dyn.PrependReactor("get", "blueprints", func(action clienttesting.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewForbidden(blueprintsGR, "bp-alloy",
+				errors.New(`blueprints.catalyst.openova.io "bp-alloy" is forbidden: `+
+					`User "system:serviceaccount:catalyst:catalyst-api" cannot get resource "blueprints"`))
+		})
+	}, bp)
 	defer rig.stop()
-	rig.dyn.PrependReactor("get", "blueprints", func(action clienttesting.Action) (bool, runtime.Object, error) {
-		return true, nil, apierrors.NewForbidden(blueprintsGR, "bp-alloy",
-			errors.New(`blueprints.catalyst.openova.io "bp-alloy" is forbidden: `+
-				`User "system:serviceaccount:catalyst:catalyst-api" cannot get resource "blueprints"`))
-	})
 
 	// YAML deliberately omits resourceVersion → the handler runs the
 	// RV-block Get, which the reactor denies.

--- a/products/catalyst/bootstrap/api/internal/handler/k8s_resource_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/k8s_resource_test.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -20,6 +21,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -84,7 +86,9 @@ func newResourceRig(t *testing.T, objs ...runtime.Object) *k8sResourceTestRig {
 		{Name: "replicaset", GVR: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "replicasets"}, Namespaced: true},
 		// Mirrors products/catalyst/bootstrap/api/internal/k8scache/kinds.go
 		// so the #4896 Edit-IaC dry-run routes resolve the Blueprint kind.
-		{Name: "blueprint", GVR: schema.GroupVersionResource{Group: "catalyst.openova.io", Version: "v1", Resource: "blueprints"}, Namespaced: true},
+		// Cluster-scoped (Namespaced:false) to match the served CRD
+		// (blueprint.yaml scope: Cluster) — see #4860.
+		{Name: "blueprint", GVR: schema.GroupVersionResource{Group: "catalyst.openova.io", Version: "v1", Resource: "blueprints"}, Namespaced: false},
 	} {
 		_ = r.Add(k)
 	}
@@ -584,6 +588,90 @@ spec:
 	}
 	if !strings.Contains(rec.Body.String(), "name-mismatch") {
 		t.Fatalf("expected name-mismatch error, got %s", rec.Body.String())
+	}
+}
+
+// blueprintsGR is the GroupResource the fake apiserver reactors below
+// stamp onto the synthetic Forbidden errors, mirroring what a real
+// kube-apiserver returns when catalyst-api's ServiceAccount lacks the
+// verb on catalyst.openova.io/blueprints.
+var blueprintsGR = schema.GroupResource{Group: "catalyst.openova.io", Resource: "blueprints"}
+
+// TestHandleK8sResourceDryRun_ForbiddenUpdateMapsTo403 is the #4860
+// regression: an apiserver RBAC denial on the dry-run Update MUST surface
+// as 403 (a clear client/permission error), never as 500. This is the
+// exact "Validate(dry-run) → HTTP 500" symptom seen live on hw228 before
+// #4862 granted catalyst-api update/patch on blueprints — the handler's
+// error switch was missing the IsForbidden case, so a Forbidden fell
+// through to the resource-update-failed 500 default. The scope-mismatch
+// (Blueprint registered Namespaced while the CRD is cluster-scoped) is
+// fixed alongside so the cluster-scoped Update routes correctly.
+func TestHandleK8sResourceDryRun_ForbiddenUpdateMapsTo403(t *testing.T) {
+	bp := newBlueprintObj("bp-alloy")
+	rig := newResourceRig(t, bp)
+	defer rig.stop()
+	// Let the RV-block Get succeed (object is seeded) but deny the Update,
+	// exactly as an under-privileged SA would experience it.
+	rig.dyn.PrependReactor("update", "blueprints", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(blueprintsGR, "bp-alloy",
+			errors.New(`blueprints.catalyst.openova.io "bp-alloy" is forbidden: `+
+				`User "system:serviceaccount:catalyst:catalyst-api" cannot update resource "blueprints"`))
+	})
+
+	yamlBody := `apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-alloy
+spec:
+  version: 1.0.3
+`
+	body, _ := json.Marshal(map[string]string{"yaml": yamlBody})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sovereigns/alpha/k8s/Blueprint/_/bp-alloy/dry-run", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	rig.router().ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("forbidden Update: got %d want 403; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "apiserver-forbidden") {
+		t.Fatalf("expected apiserver-forbidden envelope, got %s", rec.Body.String())
+	}
+}
+
+// TestHandleK8sResourceApply_ForbiddenGetMapsTo403 covers the sibling
+// error site: the resourceVersion pre-fetch Get (run when the submitted
+// YAML omits metadata.resourceVersion, as the Edit-IaC editor always
+// does) hitting an RBAC denial. Before #4860 this returned
+// resource-get-failed 500; it must now surface 403.
+func TestHandleK8sResourceApply_ForbiddenGetMapsTo403(t *testing.T) {
+	bp := newBlueprintObj("bp-alloy")
+	rig := newResourceRig(t, bp)
+	defer rig.stop()
+	rig.dyn.PrependReactor("get", "blueprints", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(blueprintsGR, "bp-alloy",
+			errors.New(`blueprints.catalyst.openova.io "bp-alloy" is forbidden: `+
+				`User "system:serviceaccount:catalyst:catalyst-api" cannot get resource "blueprints"`))
+	})
+
+	// YAML deliberately omits resourceVersion → the handler runs the
+	// RV-block Get, which the reactor denies.
+	yamlBody := `apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-alloy
+spec:
+  version: 1.0.3
+`
+	body, _ := json.Marshal(map[string]string{"yaml": yamlBody})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sovereigns/alpha/k8s/Blueprint/_/bp-alloy/apply", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	rig.router().ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("forbidden Get: got %d want 403; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "apiserver-forbidden") {
+		t.Fatalf("expected apiserver-forbidden envelope, got %s", rec.Body.String())
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/k8scache/kinds.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/kinds.go
@@ -214,7 +214,16 @@ var DefaultKinds = []Kind{
 	// v1alpha1 (deprecated, storage:false) and v1 (storage:true); pin
 	// the watcher to the storage version so events are not silently
 	// missed. Refs #1946.
-	{Name: "blueprint", GVR: schema.GroupVersionResource{Group: "catalyst.openova.io", Version: "v1", Resource: "blueprints"}, Namespaced: true},
+	//
+	// CLUSTER-scoped (Refs #4860): the served CRD at
+	// products/catalyst/chart/crds/blueprint.yaml declares `scope: Cluster`,
+	// so the Blueprint CR carries no namespace. Registering it Namespaced
+	// drove the generic /k8s/{kind} read + the Edit-IaC dry-run/apply write
+	// down the namespaced dynamic-client branch (`.Namespace(ns)`) and the
+	// GET/tree handlers' `Namespaced && ns==""` guard rejected the "_" ns
+	// with a spurious 400; align the registry with the CRD scope so every
+	// path resolves the cluster-scoped Blueprint correctly.
+	{Name: "blueprint", GVR: schema.GroupVersionResource{Group: "catalyst.openova.io", Version: "v1", Resource: "blueprints"}, Namespaced: false},
 	// orgs.openova.io/v1 Organization — top-level tenancy CRD
 	// surfaced on the /organizations page. CRD ships v1 only. Refs #1946.
 	{Name: "organization", GVR: schema.GroupVersionResource{Group: "orgs.openova.io", Version: "v1", Resource: "organizations"}, Namespaced: false},


### PR DESCRIPTION
## What

The console **Edit IaC** editor's **Validate (dry-run)** / **Commit** endpoints for a catalog Blueprint returned **HTTP 500** on an apiserver RBAC denial. `handleApplyOrDryRun` (POST `/k8s/{kind}/{ns}/{name}/dry-run` + `/apply`) was the **only** k8s mutation handler whose error switch omitted the `apierrors.IsForbidden` case, so a Forbidden on:

- the resourceVersion pre-fetch **Get** → `resource-get-failed` **500**, or
- the dry-run/apply **Update** → `resource-update-failed` **500**

fell through to the 500 default. Every sibling path already classifies Forbidden as **403**: the read path (`k8s_resource_get.go`), the PUT path (`writeK8sUpdateError`), and scale/restart/delete (`writeResourceMutationError`). This PR brings dry-run/apply in line so a permission error surfaces as a clear **4xx**, never a **5xx**.

This is the exact `POST .../Blueprint/_/bp-wordpress/dry-run → HTTP 500` symptom observed on hw228 before #4862 granted catalyst-api `update`/`patch` on `blueprints`. The handler-level misclassification is still a real defect for any cluster where the grant is absent.

## Distinct from #4898

#4898 (`reconcileBlueprintBareName`) fixed the bare-name **400** mismatch on the Edit-IaC path. It never touched the k8s-client error classification, so the **5xx** path was untouched and the issue stayed open. Verified against current `main` (which already carries #4898 and #4862): the happy-path dry-run returns 200, but a Forbidden still returned 500 until this change.

## Scope-mismatch correction

The `blueprint` kind was registered `Namespaced: true` while the served CRD (`products/catalyst/chart/crds/blueprint.yaml`) declares `scope: Cluster`. That drove the cluster-scoped CR down the namespaced dynamic-client branch and made the generic GET/tree handlers' `Namespaced && ns==""` guard reject the `_` placeholder with a spurious 400. The registry now matches the CRD scope so every path resolves the cluster-scoped Blueprint correctly. Only the per-request handlers branch on this flag (the informer lists cluster-wide either way), so the change is behaviour-preserving for the cache.

## Tests

Two handler tests added; both reproduce the **500** without the fix (verified by reverting the handler change → `got 500 want 403`) and assert **403** with it:

- `TestHandleK8sResourceDryRun_ForbiddenUpdateMapsTo403` — reactor denies the Update.
- `TestHandleK8sResourceApply_ForbiddenGetMapsTo403` — reactor denies the RV-prefetch Get.

`go build ./...` + `go vet ./...` pass; full `internal/handler` + `internal/k8scache/...` suites green.

Refs #4860 Refs #4862 Refs #3668