### PR TITLE
fix(#4872): project-wide OBS-bucket orphan sweep so wiped provs stop hitting the 100-bucket quota

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/janitor.go
+++ b/products/catalyst/bootstrap/api/internal/handler/janitor.go
@@ -307,6 +307,19 @@ func (h *Handler) runJanitorPass(tofuWorkDir string, failedMaxAge, wipedMaxAge t
 	// owned by no live dep are eligible (same protect-by-default guard).
 	stats.OrphanEVS = h.cleanOrphanEVSHuawei(tofuWorkDir, activeIDs)
 
+	// Step 7: #4872 — per-account orphan-OBS-bucket sweep. OBS buckets are
+	// not tagged on HCS (Wave 5.4 disabled tags) so the per-deployment Wipe
+	// (purgeOBSBuckets) reaches only buckets bearing the CURRENT Sovereign's
+	// prefix; a bucket from a PRIOR failed/wiped prov — or one whose wipe
+	// never ran — falls out of reach and piles up against the OBS 100-bucket
+	// account quota, false-failing the next fresh prov's Phase-0 tofu apply
+	// with `Code=TooManyBuckets` (58 May+June orphans back to hw01 observed).
+	// EIPs/keypairs/VPCs/EVS each already had a project-wide reclaim sweep;
+	// object storage did not. Same catalyst- prefix match + 8-char in-flight
+	// protection + log-only gate as its siblings; bastion/non-catalyst
+	// buckets are hard-protected in isReclaimableOrphanOBSBucket itself.
+	stats.OrphanOBSBuckets = h.cleanOrphanOBSBucketsHuawei(tofuWorkDir, activeIDs)
+
 	h.log.Info("[JANITOR] pass complete",
 		"durationMs", int(time.Since(startedAt).Milliseconds()),
 		"destructive", janitorDestructive(),
@@ -318,6 +331,7 @@ func (h *Handler) runJanitorPass(tofuWorkDir string, failedMaxAge, wipedMaxAge t
 		"orphanKeypairsDeleted", stats.OrphanKeypairs,
 		"orphanVPCsDeleted", stats.OrphanVPCs,
 		"orphanEVSDeleted", stats.OrphanEVS,
+		"orphanOBSBucketsDeleted", stats.OrphanOBSBuckets,
 	)
 }
 
@@ -337,6 +351,7 @@ type janitorStats struct {
 	OrphanKeypairs     int
 	OrphanVPCs         int
 	OrphanEVS          int
+	OrphanOBSBuckets   int
 }
 
 // reapDeployment is the cleanup primitive used by the janitor. It
@@ -743,6 +758,42 @@ func (h *Handler) cleanOrphanEVSHuawei(tofuWorkDir string, activeIDs map[string]
 	})
 	if err != nil {
 		h.log.Warn("[JANITOR] orphan-EVS sweep error", "err", err.Error())
+		return deleted
+	}
+	return deleted
+}
+
+// cleanOrphanOBSBucketsHuawei is the object-storage orphan sweep (#4872). OBS
+// buckets are not tagged on HCS so the per-deployment Wipe (purgeOBSBuckets)
+// reaches only buckets bearing the CURRENT Sovereign's prefix; a bucket from a
+// PRIOR failed/wiped prov falls out of reach and accumulates against the OBS
+// 100-bucket account quota until the next fresh prov false-fails Phase-0 with
+// `Code=TooManyBuckets`. EIPs / keypairs / VPCs / EVS each already had a
+// project-wide reclaim sweep; object storage did not. Same protect-by-default
+// guard (buildActivePrefixes) + same log-only gate (janitorDestructive) as its
+// siblings. Only catalyst-prefixed buckets that carry no in-flight
+// deployment-ID prefix are eligible; bastion / non-catalyst buckets are
+// hard-protected.
+func (h *Handler) cleanOrphanOBSBucketsHuawei(tofuWorkDir string, activeIDs map[string]struct{}) int {
+	creds, ok := discoverHuaweiCreds(tofuWorkDir)
+	if !ok {
+		return 0
+	}
+	hp := h.huaweiProvider("orphan-OBS-bucket")
+	if hp == nil {
+		return 0
+	}
+	// Emptying + deleting many buckets (each may hold a full CNPG/openbao
+	// backup set + incomplete multipart parts) is slower than the single-
+	// DELETE sibling sweeps, so give it a wider budget.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	activePrefixes := h.buildActivePrefixes()
+	deleted, err := hp.SweepOrphanOBSBuckets(ctx, creds.AK, creds.SK, creds.ProjectID, creds.Region, activePrefixes, janitorDestructive(), func(msg string) {
+		h.log.Info("[JANITOR] " + msg)
+	})
+	if err != nil {
+		h.log.Warn("[JANITOR] orphan-OBS-bucket sweep error", "err", err.Error())
 		return deleted
 	}
 	return deleted

--- a/products/catalyst/bootstrap/api/internal/providers/huawei/provider.go
+++ b/products/catalyst/bootstrap/api/internal/providers/huawei/provider.go
@@ -2525,15 +2525,7 @@ func purgeOBSBuckets(ctx context.Context, endpoint string, hw hwCreds, region, s
 		if !strings.HasPrefix(b.Name, prefix) {
 			continue
 		}
-		// Empty + delete.
-		objCh := client.ListObjects(ctx, b.Name, minio.ListObjectsOptions{Recursive: true})
-		for o := range objCh {
-			if o.Err != nil {
-				continue
-			}
-			_ = client.RemoveObject(ctx, b.Name, o.Key, minio.RemoveObjectOptions{})
-		}
-		if err := client.RemoveBucket(ctx, b.Name); err != nil {
+		if err := emptyAndRemoveOBSBucket(ctx, client, b.Name); err != nil {
 			progress(fmt.Sprintf("obs: remove bucket %s failed: %s", b.Name, err))
 			continue
 		}
@@ -2541,6 +2533,144 @@ func purgeOBSBuckets(ctx context.Context, endpoint string, hw hwCreds, region, s
 		progress("obs: removed bucket " + b.Name)
 	}
 	return removed, nil
+}
+
+// emptyAndRemoveOBSBucket empties a bucket then deletes it. `tofu destroy`
+// cannot remove a NON-EMPTY OBS bucket (the huaweicloud_obs_bucket resource
+// errors with `BucketNotEmpty` unless force_destroy is set), which is the
+// root cause of #4872: every prov's backup bucket outlives its wipe and the
+// account marches to the 100-bucket OBS quota, false-failing the next fresh
+// prov's Phase-0 `tofu apply` with `Code=TooManyBuckets`.
+//
+// Emptying has TWO parts, both required before DeleteBucket will succeed:
+//  1. every object (recursive), and
+//  2. every incomplete multipart upload — an interrupted tofu apply or CSI
+//     backup can leave dangling parts that keep the bucket non-empty even
+//     after all listable objects are gone, so RemoveBucket still fails with
+//     BucketNotEmpty.
+//
+// Shared by the per-deployment wipe purge (purgeOBSBuckets) and the
+// project-wide janitor reclaim (SweepOrphanOBSBuckets). Idempotent: an
+// already-absent object/upload/bucket is a no-op (the caller only ever passes
+// bucket names ListBuckets just returned, so the terminal RemoveBucket sees a
+// bucket that exists; a re-run simply finds no such bucket in the next list).
+func emptyAndRemoveOBSBucket(ctx context.Context, client *minio.Client, bucket string) error {
+	objCh := client.ListObjects(ctx, bucket, minio.ListObjectsOptions{Recursive: true})
+	for o := range objCh {
+		if o.Err != nil {
+			continue
+		}
+		_ = client.RemoveObject(ctx, bucket, o.Key, minio.RemoveObjectOptions{ForceDelete: true})
+	}
+	for up := range client.ListIncompleteUploads(ctx, bucket, "", true) {
+		if up.Err != nil {
+			continue
+		}
+		_ = client.RemoveIncompleteUpload(ctx, bucket, up.Key)
+	}
+	return client.RemoveBucket(ctx, bucket)
+}
+
+// isReclaimableOrphanOBSBucket is the pure match/protection predicate for the
+// project-wide OBS-bucket orphan sweep (#4872). OBS buckets carry NO usable
+// tags on Kom4DC (Wave 5.4 disabled HCS tags), so — exactly like the EIP /
+// keypair / VPC / EVS sweeps — the reclaim decision is driven purely by the
+// deterministic `catalyst-<sovereign-dashed>-<dep-id-prefix>` naming
+// convention, never by a tag.
+//
+// A bucket is reclaimable when ALL of:
+//   - its name carries the `catalyst-` prefix every per-Sovereign OBS bucket
+//     shares (so operator- / bastion-owned buckets, and any non-catalyst
+//     bucket, are hard-protected — we NEVER reach outside this platform's
+//     own buckets), AND
+//   - its name contains NONE of the in-flight deployment-ID 8-char prefixes
+//     (protect-by-default: a bucket belonging to any live / parked / failed
+//     deployment is never swept — only a genuinely-wiped deployment leaves
+//     its prefix out of the active set and its bucket reclaimable).
+//
+// A `bastion` substring is a defence-in-depth second guard — the catalyst-
+// prefix filter already excludes bastion buckets, but the explicit check
+// costs nothing. Extracted as a free function so the selection logic is
+// unit-testable without an OBS endpoint seam.
+func isReclaimableOrphanOBSBucket(name string, activeDepIDPrefixes map[string]struct{}) bool {
+	if name == "" {
+		return false
+	}
+	if strings.Contains(name, "bastion") || !strings.HasPrefix(name, "catalyst-") {
+		return false
+	}
+	for prefix := range activeDepIDPrefixes {
+		if prefix != "" && strings.Contains(name, prefix) {
+			return false
+		}
+	}
+	return true
+}
+
+// SweepOrphanOBSBuckets lists every OBS bucket in the account and reclaims
+// catalyst-owned buckets that belong to no in-flight deployment (#4872). It
+// is the object-storage sibling of SweepOrphanEIPs / Keypairs / VPCs / EVS:
+// the per-deployment Wipe purges only the buckets matching the CURRENT
+// Sovereign's prefix (purgeOBSBuckets), so a bucket from a PRIOR failed /
+// wiped prov — or one whose wipe never ran / timed out — falls out of reach
+// and piles up against the OBS 100-bucket account quota until a fresh prov
+// fails Phase-0 with `Code=TooManyBuckets` (58 May+June orphans back to hw01
+// observed on the #4872 incident).
+//
+// OBS ListAllMyBuckets is account-wide (not region-scoped), so one pass with
+// any region's endpoint reclaims every stranded bucket. Match + protection
+// live in isReclaimableOrphanOBSBucket (pure, unit-testable). `destructive`
+// gates the real empty+delete (default false → log-only `would-reap`),
+// identical to the sibling sweeps. activeDepIDPrefixes is the protect-by-
+// default set of in-flight deployment-ID 8-char prefixes. `projectID` is
+// unused (S3-compat OBS authenticates by AK/SK) but kept in the signature so
+// the janitor wires this sweep exactly like its siblings. Returns the count
+// reaped (or would-reap, in log-only mode). Idempotent + safe to run during
+// active provisioning.
+func (p *Provider) SweepOrphanOBSBuckets(ctx context.Context, ak, sk, projectID, region string, activeDepIDPrefixes map[string]struct{}, destructive bool, progress func(msg string)) (int, error) {
+	if progress == nil {
+		progress = func(string) {}
+	}
+	if strings.TrimSpace(ak) == "" || strings.TrimSpace(sk) == "" {
+		return 0, errors.New("obs access/secret keys are empty")
+	}
+	if strings.TrimSpace(region) == "" {
+		region = "me-east-215"
+	}
+	endpoint := fmt.Sprintf("obs.%s.kom4dc.nationalcloud.om", region)
+	client, err := minio.New(endpoint, &minio.Options{
+		Creds:  credentials.NewStaticV4(ak, sk, ""),
+		Secure: true,
+		Region: region,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("construct minio client: %w", err)
+	}
+	buckets, err := client.ListBuckets(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("list buckets: %w", err)
+	}
+	reaped := 0
+	for _, b := range buckets {
+		if !isReclaimableOrphanOBSBucket(b.Name, activeDepIDPrefixes) {
+			if strings.HasPrefix(b.Name, "catalyst-") {
+				progress(fmt.Sprintf("sweep orphan OBS bucket %s: skipped (in-flight deployment or protected)", b.Name))
+			}
+			continue
+		}
+		if !destructive {
+			progress(fmt.Sprintf("sweep orphan OBS bucket %s: would-reap (log-only; set CATALYST_JANITOR_DESTRUCTIVE=true to act)", b.Name))
+			reaped++
+			continue
+		}
+		if err := emptyAndRemoveOBSBucket(ctx, client, b.Name); err != nil {
+			progress(fmt.Sprintf("sweep orphan OBS bucket %s: remove failed: %s", b.Name, err))
+			continue
+		}
+		progress("sweep orphan OBS bucket " + b.Name + ": deleted")
+		reaped++
+	}
+	return reaped, nil
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────

--- a/products/catalyst/bootstrap/api/internal/providers/huawei/sweep_orphan_obs_test.go
+++ b/products/catalyst/bootstrap/api/internal/providers/huawei/sweep_orphan_obs_test.go
@@ -1,0 +1,116 @@
+package huawei
+
+import "testing"
+
+// TestIsReclaimableOrphanOBSBucket locks the #4872 OBS-bucket orphan
+// match/protection contract — the pure selection logic the project-wide
+// SweepOrphanOBSBuckets reclaim relies on. OBS buckets carry no usable HCS
+// tag (Wave 5.4 disabled tags) so the decision is driven purely by the
+// deterministic `catalyst-<sovereign-dashed>-<dep-id-prefix>` name:
+//   - only catalyst-prefixed buckets are ever in scope (operator- / bastion-
+//     owned and any non-catalyst bucket are hard-protected),
+//   - protect-by-default: a bucket whose name carries an in-flight
+//     deployment-ID 8-char prefix belongs to a live/parked/failed dep and is
+//     never swept; only a genuinely-wiped dep leaves its bucket reclaimable.
+func TestIsReclaimableOrphanOBSBucket(t *testing.T) {
+	// One in-flight deployment protected by its 8-char ID prefix.
+	active := map[string]struct{}{
+		"5b413990": {},
+	}
+
+	cases := []struct {
+		name   string
+		bucket string
+		want   bool
+	}{
+		// Reclaimable: catalyst bucket from a wiped Sovereign, no active prefix.
+		{
+			name:   "orphan bucket from a wiped prov (hw01-era leak)",
+			bucket: "catalyst-hw01-omani-works-aabbccdd",
+			want:   true,
+		},
+		{
+			name:   "legacy no-suffix catalyst bucket from a wiped prov",
+			bucket: "catalyst-t38-omani-works",
+			want:   true,
+		},
+
+		// Protected: belongs to the in-flight deployment (prefix match).
+		{
+			name:   "live deployment's active bucket",
+			bucket: "catalyst-hw229-omani-works-5b413990",
+			want:   false,
+		},
+
+		// Hard-protected: not a catalyst bucket.
+		{
+			name:   "operator-owned openbao snapshot bucket",
+			bucket: "openbao-snapshots",
+			want:   false,
+		},
+		{
+			name:   "unrelated third-party bucket",
+			bucket: "some-customer-data-lake",
+			want:   false,
+		},
+
+		// Hard-protected: bastion, even if it somehow carried the prefix.
+		{
+			name:   "bastion-named bucket",
+			bucket: "bastion-openova-backups",
+			want:   false,
+		},
+		{
+			name:   "catalyst-prefixed bastion bucket (defence in depth)",
+			bucket: "catalyst-bastion-openova-state",
+			want:   false,
+		},
+
+		{
+			name:   "empty name",
+			bucket: "",
+			want:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isReclaimableOrphanOBSBucket(tc.bucket, active)
+			if got != tc.want {
+				t.Fatalf("isReclaimableOrphanOBSBucket(%q) = %v, want %v", tc.bucket, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsReclaimableOrphanOBSBucket_NoActiveProvs proves the post-wipe sweep
+// (empty active set) reclaims every catalyst-prefixed bucket while still
+// hard-protecting bastion / non-catalyst buckets.
+func TestIsReclaimableOrphanOBSBucket_NoActiveProvs(t *testing.T) {
+	empty := map[string]struct{}{}
+	if !isReclaimableOrphanOBSBucket("catalyst-hw10-omani-works-deadbeef", empty) {
+		t.Fatal("with no in-flight provs every catalyst-prefixed bucket must be reclaimable")
+	}
+	if isReclaimableOrphanOBSBucket("bastion-openova-backups", empty) {
+		t.Fatal("a bastion bucket must stay protected even with an empty active set")
+	}
+	if isReclaimableOrphanOBSBucket("openbao-snapshots", empty) {
+		t.Fatal("a non-catalyst bucket must stay protected even with an empty active set")
+	}
+}
+
+// TestIsReclaimableOrphanOBSBucket_ProtectsEveryActivePrefix proves that when
+// several deployments are in flight, a bucket matching ANY of their prefixes
+// is protected (the sweep never races a concurrent prov's backup bucket).
+func TestIsReclaimableOrphanOBSBucket_ProtectsEveryActivePrefix(t *testing.T) {
+	active := map[string]struct{}{
+		"11112222": {},
+		"33334444": {},
+	}
+	if isReclaimableOrphanOBSBucket("catalyst-hw30-omani-works-33334444", active) {
+		t.Fatal("a bucket carrying a second in-flight dep's prefix must be protected")
+	}
+	if !isReclaimableOrphanOBSBucket("catalyst-hw30-omani-works-99998888", active) {
+		t.Fatal("a bucket carrying no active prefix must be reclaimable")
+	}
+}


### PR DESCRIPTION
## Problem

Fresh prov `hw229` failed `tofu apply` with `Code=TooManyBuckets` — the Huawei OBS account was at its 100-bucket quota, full of orphans from wiped provs back to `hw01` (2026-05-24). `tofu destroy` cannot delete a **non-empty** OBS bucket, and the per-deployment wipe purge (`purgeOBSBuckets`) reaches only buckets bearing the **current** Sovereign's prefix. A backup bucket from a prior failed/wiped prov — or one whose wipe never ran / timed out — falls out of reach and accumulates against the account quota, false-failing the next prov's Phase-0.

OBS was the one Huawei resource **without** a project-wide reclaim sweep: EIPs (`SweepOrphanEIPs`), keypairs (`SweepOrphanKeypairs`), VPCs (`SweepOrphanVPCs`), and EVS (`SweepOrphanEVS`) each already had one wired into the janitor. Object storage did not.

## Root cause

1. No account-wide janitor reclaim for orphan `catalyst-*` buckets — only the per-Sovereign wipe purge existed, so buckets from earlier provs were never reachable again.
2. Emptying was incomplete: an interrupted `tofu apply` / CSI backup can leave incomplete multipart uploads that keep a bucket non-empty, so `DeleteBucket` still fails with `BucketNotEmpty` even after every listable object is gone.

HCS tags are disabled on Kom4DC (Wave 5.4), so — like the sibling sweeps — selection is driven purely by the deterministic `catalyst-<sovereign-dashed>-<dep-id-prefix>` naming convention, never by a tag.

## Fix

- `SweepOrphanOBSBuckets` (huawei provider): account-wide `ListBuckets`, `catalyst-` prefix match, **protect-by-default** via in-flight deployment-ID 8-char prefixes, **log-only** unless `CATALYST_JANITOR_DESTRUCTIVE=true` (identical gate to its siblings), idempotent (re-list each pass; a gone bucket simply doesn't reappear). Bastion / non-catalyst buckets hard-protected.
- `isReclaimableOrphanOBSBucket` — pure selection predicate, unit-tested.
- `emptyAndRemoveOBSBucket` — shared helper for both the wipe purge and the sweep; now also aborts incomplete multipart uploads before `RemoveBucket`, directly fixing the non-empty-bucket delete failure.
- Wired into the janitor as **Step 7** (`cleanOrphanOBSBucketsHuawei`), mirroring the EIP/keypair/VPC/EVS steps + stats/logging.

Never touches buckets outside a wiped deployment, nor any shared/bastion infra.

## Tests

- `go build ./...` + `go vet ./...` pass.
- New `sweep_orphan_obs_test.go` covers the selection logic: orphan reclaim, active-prefix protection (single + multi in-flight), legacy no-suffix names, bastion/non-catalyst hard-protection, empty active set.
- `internal/providers/huawei` + `internal/handler` suites pass.

Refs #4872

🤖 Generated with [Claude Code](https://claude.com/claude-code)