### PR TITLE
fix(#4746): gate phase-1 ready on the console backend so a slow 2-region prov is not false-failed

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -134,6 +134,19 @@ type Handler struct {
 	phase1MinBootstrapKitHRs int
 	phase1FirstSeenTimeout   time.Duration
 
+	// phase1ReadySentinel is the component id (bp- prefix stripped) whose
+	// terminal-install gates OutcomeReady (#4746). The PRIMARY watch refuses
+	// to classify a prov "ready" until this component (the console's own
+	// backend, catalyst-platform) has been observed — closing the narrow-
+	// census false-"failed" on slow 2-region provs where an early HR reaches
+	// Ready long before the console backend even exists. The zero value ("")
+	// DISABLES the gate: production New() sets it to
+	// helmwatch.DefaultReadySentinelComponent, while unit tests build
+	// &Handler{} inline and leave it empty so a small fake kit (no
+	// catalyst-platform) still exercises the historical terminate path.
+	// Operators override at runtime with CATALYST_PHASE1_READY_SENTINEL.
+	phase1ReadySentinel string
+
 	// consoleProbe is the external console-reachability gate applied before
 	// markPhase1Done flips a converged deployment to "ready" (#4706). NIL =
 	// gate OFF (the pre-#4706 behaviour): production turns it on by calling
@@ -658,6 +671,12 @@ func New(log *slog.Logger) *Handler {
 		dynadotAPISecret: os.Getenv("DYNADOT_API_SECRET"),
 		pdm:              pdm.New(pdmURL),
 		kubeconfigsDir:   kubeconfigsDir,
+		// #4746 — arm the phase-1 ready sentinel so the PRIMARY watch cannot
+		// declare a prov ready before the console's own backend
+		// (catalyst-platform) has converged. Tests build &Handler{} inline
+		// and leave this empty (gate off); the env override still applies in
+		// phase1WatchConfigForDeployment.
+		phase1ReadySentinel: helmwatch.DefaultReadySentinelComponent,
 	}
 
 	// #4614: arm the in-band VPC-quota reclaim (provisioner pre-flight) with

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -66,6 +66,16 @@ const phase1WatchTimeoutEnv = "CATALYST_PHASE1_WATCH_TIMEOUT"
 // catalyst-api Deployment — no code change required.
 const phase1MinBootstrapKitHRsEnv = "CATALYST_PHASE1_MIN_BOOTSTRAP_KIT_HRS"
 
+// phase1ReadySentinelEnv — env var override for the component whose
+// terminal-install gates OutcomeReady (#4746). Default
+// helmwatch.DefaultReadySentinelComponent ("catalyst-platform") — the
+// console's own backend + the terminal node of the bootstrap-kit
+// dependency chain. Setting this empty on the catalyst-api Deployment
+// disables the sentinel gate (reverting to the pre-#4746 narrow census);
+// a future kit that renames the console umbrella only needs this flipped,
+// no code change.
+const phase1ReadySentinelEnv = "CATALYST_PHASE1_READY_SENTINEL"
+
 // phase1FirstSeenTimeoutEnv — env var override for the first-seen
 // gate window. If zero bp-* HelmReleases appear within this window,
 // the watcher emits a single warn event ("bootstrap-kit not
@@ -348,6 +358,17 @@ func (h *Handler) phase1WatchConfigForDeployment(dep *Deployment, kubeconfig str
 		}
 	}
 
+	// #4746 — the component whose terminal-install gates OutcomeReady.
+	// Base value is the Handler field (production New() sets it to
+	// catalyst-platform; tests leave it empty → gate off). An explicitly
+	// set CATALYST_PHASE1_READY_SENTINEL wins — including set-to-empty,
+	// which disables the gate — so os.LookupEnv (not envOrEmpty) is used to
+	// distinguish "unset" from "set empty" (Inviolable Principle #4).
+	readySentinel := h.phase1ReadySentinel
+	if v, ok := os.LookupEnv(phase1ReadySentinelEnv); ok {
+		readySentinel = strings.TrimSpace(v)
+	}
+
 	cfg := helmwatch.Config{
 		KubeconfigYAML:            kubeconfig,
 		WatchTimeout:              timeout,
@@ -356,6 +377,7 @@ func (h *Handler) phase1WatchConfigForDeployment(dep *Deployment, kubeconfig str
 		LatePollTimeout:           latePollTimeout,
 		LatePollInterval:          latePollInterval,
 		ReachabilityOverallBudget: reachabilityBudget,
+		ReadySentinelComponent:    readySentinel,
 		// OnSubstate — issue #923. The watcher fires this on every
 		// Phase-1 substate transition (reconnecting → watching). We
 		// stamp Result.Phase1Substate under dep.mu so a /deployments/
@@ -456,6 +478,15 @@ func (h *Handler) spawnSecondaryRegionWatchers(dep *Deployment) func() {
 			return
 		}
 		cfg := h.phase1WatchConfigForDeployment(dep, string(raw))
+		// #4746 — the ready sentinel (catalyst-platform) is a PRIMARY-region
+		// concept: the console backend runs only in the primary region, so a
+		// secondary-region watcher must NOT wait on catalyst-platform (it
+		// would never observe it and could not self-terminate). Secondary
+		// watchers do not contribute to markPhase1Done's terminal outcome
+		// anyway (see the func doc), so clearing the gate here only lets a
+		// converged secondary self-terminate cleanly instead of idling until
+		// stopSecondaries cancels it.
+		cfg.ReadySentinelComponent = ""
 		watcher, err := helmwatch.NewWatcher(cfg, func(ev provisioner.Event) {
 			// Region-tag the component events so the SSE consumer
 			// can group them per region. Bare bp-* names from

--- a/products/catalyst/bootstrap/api/internal/helmwatch/helmwatch.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/helmwatch.go
@@ -139,6 +139,40 @@ const MinComponentCount = 1
 // exercise the floor.
 const DefaultMinBootstrapKitHRs = 1
 
+// DefaultReadySentinelComponent — the component id (bp- prefix stripped)
+// that MUST have been observed AND reached a terminal state before the
+// terminate-on-all-done gate may fire OutcomeReady. catalyst-platform is
+// the operator-facing console's OWN server and the terminal node of the
+// bootstrap-kit dependency chain (it dependsOn gitea → keycloak → openbao
+// → …), so its arrival-and-terminality is the earliest HONEST signal that
+// the whole platform — the console backend included — has converged.
+//
+// #4746 root cause: the count floor above is 1 (deliberately, to stay
+// drift-proof against kit cardinality — see otech48 in allObservedTerminal).
+// But "≥1 observed AND all-observed-terminal" fires the instant the
+// informer's initial List catches a NARROW early set (e.g. only bp-cilium)
+// all Ready=True — long before bp-catalyst-platform has even been created
+// by Flux. On a slow 2-region prov that premature OutcomeReady then ran the
+// #4706 external console-reachability probe against a console whose backend
+// had not begun installing, so the probe could only fail: a healthy,
+// still-converging Sovereign was stamped status=failed (hw221/hw222). The
+// sentinel closes the census so OutcomeReady cannot precede the console
+// backend, instead of merely widening the downstream probe budget.
+//
+// A terminal-FAILED sentinel does NOT block the gate — an all-terminal
+// snapshot with a failed component classifies OutcomeFailed downstream, so
+// a genuinely broken console still surfaces a failure rather than hanging
+// to WatchTimeout. If the sentinel never appears at all, the watch simply
+// runs to WatchTimeout → OutcomeTimeout (failed) — the correct verdict for
+// a prov whose console backend never installed.
+//
+// Empty string DISABLES the sentinel gate. applyDefaults leaves it empty so
+// existing helmwatch fixtures (which seed kits without catalyst-platform)
+// keep exercising the historical path; the PRODUCTION path wires this
+// constant via the handler's phase1WatchConfigForDeployment, and operators
+// override it with CATALYST_PHASE1_READY_SENTINEL (Inviolable Principle #4).
+const DefaultReadySentinelComponent = "catalyst-platform"
+
 // DefaultFirstSeenTimeout — how long the Watcher waits for the FIRST
 // bp-* HelmRelease to appear in the informer cache after the watch
 // starts. If this elapses with zero HRs observed, the watch emits a
@@ -376,6 +410,19 @@ type Config struct {
 	// satisfy "all observed are terminal" — see helmwatch.go for the
 	// bug-fix narrative.
 	MinBootstrapKitHRs int
+
+	// ReadySentinelComponent — component id (bp- prefix stripped) that
+	// MUST have been observed before the terminate-on-all-done gate may
+	// fire (#4746). When non-empty, allObservedTerminal additionally
+	// requires this id to be present in the observed set; the same
+	// all-terminal loop then guarantees it is in a terminal state. This
+	// closes the narrow-census false-ready on slow multi-region provs
+	// where an early HR reaches Ready before the console's own backend
+	// (catalyst-platform) has even been created. Empty (the applyDefaults
+	// default) disables the requirement so existing fixtures are
+	// unaffected. Production wires DefaultReadySentinelComponent via the
+	// handler; CATALYST_PHASE1_READY_SENTINEL overrides.
+	ReadySentinelComponent string
 
 	// FirstSeenTimeout — duration after watch start during which the
 	// Watcher waits for the FIRST bp-* HelmRelease. If zero HRs are
@@ -917,7 +964,7 @@ func (w *Watcher) Watch(ctx context.Context) (map[string]string, error) {
 	// enter the cache. We park the all-terminal check until here.
 	w.mu.Lock()
 	w.informerSynced = true
-	allTerminalAtSync := allObservedTerminal(w.states, w.observed, w.cfg.MinBootstrapKitHRs, w.firstSeenAt, true)
+	allTerminalAtSync := allObservedTerminal(w.states, w.observed, w.cfg.MinBootstrapKitHRs, w.firstSeenAt, true, w.cfg.ReadySentinelComponent)
 	w.mu.Unlock()
 
 	if allTerminalAtSync {
@@ -1570,7 +1617,7 @@ func (w *Watcher) processEvent(obj any, terminated chan struct{}, closeOnce *syn
 	// The post-WaitForCacheSync block in Watch() owns the first
 	// terminal-check after sync; from then on every transition
 	// re-evaluates here.
-	allTerminal := allObservedTerminal(w.states, w.observed, w.cfg.MinBootstrapKitHRs, w.firstSeenAt, w.informerSynced)
+	allTerminal := allObservedTerminal(w.states, w.observed, w.cfg.MinBootstrapKitHRs, w.firstSeenAt, w.informerSynced, w.cfg.ReadySentinelComponent)
 	w.mu.Unlock()
 
 	// Dispatch on first observation (this watcher has never seen
@@ -1651,6 +1698,10 @@ func (w *Watcher) maybeEmitReadyTransition() {
 //     bootstrap-kit ships ≥ 1 HelmRelease; production sets this to
 //     1 via the chart default to guard the "Phase-0 succeeded but
 //     Flux on the new cluster never started" footgun), AND
+//   - readySentinel (when non-empty) has been OBSERVED — #4746: the
+//     console's own backend (catalyst-platform) must be present before
+//     the platform can be called ready, so a narrow initial List of
+//     early HRs cannot fire OutcomeReady before it even exists, AND
 //   - every observed component is in terminalStates (installed |
 //     failed).
 //
@@ -1671,7 +1722,7 @@ func (w *Watcher) maybeEmitReadyTransition() {
 // alarm bell from this comment when reading: never gate on a count
 // that can drift independently of the kit. The synced gate is
 // drift-proof.
-func allObservedTerminal(states map[string]string, observed map[string]struct{}, minBootstrapKitHRs int, firstSeenAt time.Time, synced bool) bool {
+func allObservedTerminal(states map[string]string, observed map[string]struct{}, minBootstrapKitHRs int, firstSeenAt time.Time, synced bool, readySentinel string) bool {
 	if !synced {
 		return false
 	}
@@ -1680,6 +1731,21 @@ func allObservedTerminal(states map[string]string, observed map[string]struct{},
 	}
 	if len(observed) < minBootstrapKitHRs {
 		return false
+	}
+	// #4746 — the console's own backend sentinel (readySentinel, e.g.
+	// catalyst-platform) must have been OBSERVED before we may declare the
+	// platform done. Without this a narrow initial List that caught only
+	// the alphabetically-early HRs (bp-cilium) all Ready=True would fire
+	// OutcomeReady while catalyst-platform had not even been created — the
+	// slow-2-region false-"failed". The all-observed-terminal loop below
+	// then enforces that the sentinel (and every sibling) is in a terminal
+	// state; a terminal-FAILED sentinel still trips the gate so a genuinely
+	// broken console classifies OutcomeFailed downstream rather than hanging
+	// to WatchTimeout. Empty readySentinel disables the check.
+	if readySentinel != "" {
+		if _, seen := observed[readySentinel]; !seen {
+			return false
+		}
 	}
 	for id := range observed {
 		if !terminalStates[states[id]] {

--- a/products/catalyst/bootstrap/api/internal/helmwatch/ready_sentinel_test.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/ready_sentinel_test.go
@@ -1,0 +1,244 @@
+// Tests for the #4746 ready-sentinel census gate.
+//
+// Root cause the sentinel closes: the terminate-on-all-done gate fires
+// OutcomeReady as soon as the informer's initial List catches a NARROW
+// set of early bp-* HelmReleases (e.g. only bp-cilium) all Ready=True and
+// the MinBootstrapKitHRs floor (1) is met — long before bp-catalyst-platform
+// (the console's own backend) has even been created by Flux. On a slow
+// 2-region prov that premature OutcomeReady then ran the #4706 external
+// console-reachability probe against a console whose backend had not begun
+// installing, so a healthy, still-converging Sovereign was stamped
+// status=failed.
+//
+// The sentinel (Config.ReadySentinelComponent = "catalyst-platform" in
+// production) makes allObservedTerminal refuse OutcomeReady until the
+// console backend has been OBSERVED and reached a terminal state. These
+// tests prove the three behaviours that matter:
+//
+//   1. slow-but-healthy 2-region: an early HR is Ready at sync but the
+//      sentinel appears LATER — the watch must DEFER ready until the
+//      sentinel installs, and then classify OutcomeReady (no false-fail).
+//   2. genuinely-broken (never installs): the sentinel never appears — the
+//      watch must NOT false-ready; it runs to WatchTimeout → OutcomeTimeout
+//      (which the handler maps to status=failed).
+//   3. genuinely-broken (install fails): the sentinel reaches StateFailed —
+//      the watch must classify OutcomeFailed, never OutcomeReady.
+//
+// The companion control assertion in test (1) proves the gate is
+// load-bearing: with an EMPTY sentinel the exact same early-only fixture
+// fires the historical premature OutcomeReady.
+package helmwatch
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// createHR adds a NEW HelmRelease to the fake dynamic client AFTER the
+// informer has started, so a test can model Flux materialising the
+// console backend late in the reconcile. Distinct from updateHR, which
+// patches an object that already exists in the initial List.
+func createHR(t *testing.T, client dynamic.Interface, name string, conds []metav1.Condition) {
+	t.Helper()
+	_, err := client.Resource(HelmReleaseGVR).Namespace(FluxNamespace).Create(
+		t.Context(), makeHelmRelease(name, conds), metav1.CreateOptions{},
+	)
+	if err != nil {
+		t.Fatalf("createHR(%q): %v", name, err)
+	}
+}
+
+// TestWatch_ReadySentinel_SlowConsoleBackend_DefersReadyUntilInstalled is
+// the #4746 slow-but-healthy 2-region case. bp-cilium is Ready=True at
+// informer-sync time, but the console backend (bp-catalyst-platform) is
+// not in the cache yet; it is created Ready a moment later. With the
+// sentinel armed the watch must NOT fire the historical premature ready —
+// it must wait for the sentinel and then classify OutcomeReady, with the
+// final state map carrying BOTH components.
+func TestWatch_ReadySentinel_SlowConsoleBackend_DefersReadyUntilInstalled(t *testing.T) {
+	scheme := newFakeScheme()
+	// Only the early HR exists at watch-start — the console backend has
+	// not been created by Flux yet (the 2-region timing window).
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{HelmReleaseGVR: "HelmReleaseList"},
+		makeReadyHelmRelease("bp-cilium"),
+	)
+
+	rec := &recorder{}
+	cfg := Config{
+		KubeconfigYAML:         "fake",
+		WatchTimeout:           30 * time.Second, // must NOT be hit
+		FirstSeenTimeout:       30 * time.Second,
+		MinBootstrapKitHRs:     1,
+		DynamicFactory:         fakeFactory(client),
+		Resync:                 0,
+		ReadySentinelComponent: "catalyst-platform",
+	}
+	w, err := NewWatcher(cfg, rec.emit)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+
+	// The console backend converges 200ms after start — well after the
+	// informer has synced with only bp-cilium. With the sentinel armed the
+	// watch is BLOCKED in its select loop until this arrives, so there is
+	// no race: it cannot have fired ready on the narrow early set.
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		createHR(t, client, "bp-catalyst-platform", []metav1.Condition{
+			{Type: "Ready", Status: metav1.ConditionTrue, Reason: "ReconciliationSucceeded", Message: "Helm install succeeded"},
+		})
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	final, err := w.Watch(ctx)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+
+	if got, want := w.Outcome(), OutcomeReady; got != want {
+		t.Errorf("Outcome() = %q, want %q (healthy slow-console prov must converge ready, not false-fail)", got, want)
+	}
+	// The load-bearing proof that ready was DEFERRED: the final state map
+	// must contain the sentinel installed. A premature ready on the narrow
+	// early set would have terminated with only bp-cilium (len==1).
+	if got, want := len(final), 2; got != want {
+		t.Fatalf("final states = %d (%v), want %d — ready must have waited for the console backend, not fired on the early set", got, final, want)
+	}
+	if final["catalyst-platform"] != StateInstalled {
+		t.Errorf("final[catalyst-platform] = %q, want %q", final["catalyst-platform"], StateInstalled)
+	}
+
+	// Control: the SAME early-only fixture with an EMPTY sentinel fires the
+	// historical premature ready on bp-cilium alone (len==1). This proves
+	// the sentinel — not some other change — is what defers the gate.
+	t.Run("control_empty_sentinel_fires_early", func(t *testing.T) {
+		cscheme := newFakeScheme()
+		cclient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(cscheme,
+			map[schema.GroupVersionResource]string{HelmReleaseGVR: "HelmReleaseList"},
+			makeReadyHelmRelease("bp-cilium"),
+		)
+		crec := &recorder{}
+		cw, err := NewWatcher(Config{
+			KubeconfigYAML:     "fake",
+			WatchTimeout:       5 * time.Second,
+			FirstSeenTimeout:   5 * time.Second,
+			MinBootstrapKitHRs: 1,
+			DynamicFactory:     fakeFactory(cclient),
+			Resync:             0,
+			// ReadySentinelComponent empty — historical narrow census.
+		}, crec.emit)
+		if err != nil {
+			t.Fatalf("NewWatcher: %v", err)
+		}
+		cctx, ccancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer ccancel()
+		cfinal, err := cw.Watch(cctx)
+		if err != nil {
+			t.Fatalf("Watch: %v", err)
+		}
+		if got, want := cw.Outcome(), OutcomeReady; got != want {
+			t.Errorf("control Outcome() = %q, want %q", got, want)
+		}
+		if got, want := len(cfinal), 1; got != want {
+			t.Errorf("control final states = %d, want %d (premature ready on the early set is the historical behaviour the sentinel closes)", got, want)
+		}
+	})
+}
+
+// TestWatch_ReadySentinel_ConsoleBackendNeverInstalls_TimesOutNotReady is
+// the genuinely-broken case that MUST still fail: bp-cilium is Ready but
+// the console backend never appears. The sentinel must keep the gate shut
+// so the watch runs to WatchTimeout → OutcomeTimeout (handler → failed),
+// never a false OutcomeReady. This is the direct contrapositive of the
+// fix — the sentinel does not mask a real failure.
+func TestWatch_ReadySentinel_ConsoleBackendNeverInstalls_TimesOutNotReady(t *testing.T) {
+	scheme := newFakeScheme()
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{HelmReleaseGVR: "HelmReleaseList"},
+		makeReadyHelmRelease("bp-cilium"),
+	)
+
+	rec := &recorder{}
+	cfg := Config{
+		KubeconfigYAML:         "fake",
+		WatchTimeout:           400 * time.Millisecond, // console backend never comes; time out fast
+		FirstSeenTimeout:       10 * time.Second,
+		MinBootstrapKitHRs:     1,
+		DynamicFactory:         fakeFactory(client),
+		Resync:                 0,
+		ReadySentinelComponent: "catalyst-platform",
+	}
+	w, err := NewWatcher(cfg, rec.emit)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+
+	final, err := w.Watch(context.Background())
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+
+	// firstSeenAt is set (bp-cilium was observed) so this is a TIMEOUT, not
+	// flux-not-reconciling — and crucially NOT ready.
+	if got := w.Outcome(); got == OutcomeReady {
+		t.Fatalf("Outcome() = %q — a prov whose console backend never installs must NEVER be classified ready", got)
+	}
+	if got, want := w.Outcome(), OutcomeTimeout; got != want {
+		t.Errorf("Outcome() = %q, want %q (early HR observed, sentinel absent → timeout, handler maps to failed)", got, want)
+	}
+	if final["cilium"] != StateInstalled {
+		t.Errorf("final[cilium] = %q, want %q (partial state preserved)", final["cilium"], StateInstalled)
+	}
+}
+
+// TestWatch_ReadySentinel_ConsoleBackendFails_ClassifiesFailed proves a
+// sentinel that reaches StateFailed classifies OutcomeFailed — a broken
+// console surfaces a failure rather than hanging to WatchTimeout. The
+// tiny LatePollTimeout exercises the failed classification in
+// milliseconds (production gives Flux a 10-minute recovery window).
+func TestWatch_ReadySentinel_ConsoleBackendFails_ClassifiesFailed(t *testing.T) {
+	scheme := newFakeScheme()
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{HelmReleaseGVR: "HelmReleaseList"},
+		makeReadyHelmRelease("bp-cilium"),
+		makeFailedHelmRelease("bp-catalyst-platform"),
+	)
+
+	rec := &recorder{}
+	cfg := Config{
+		KubeconfigYAML:         "fake",
+		WatchTimeout:           30 * time.Second,
+		FirstSeenTimeout:       30 * time.Second,
+		MinBootstrapKitHRs:     2,
+		DynamicFactory:         fakeFactory(client),
+		Resync:                 0,
+		LatePollTimeout:        200 * time.Millisecond,
+		LatePollInterval:       25 * time.Millisecond,
+		ReadySentinelComponent: "catalyst-platform",
+	}
+	w, err := NewWatcher(cfg, rec.emit)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+
+	final, err := w.Watch(context.Background())
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+
+	if got, want := w.Outcome(), OutcomeFailed; got != want {
+		t.Errorf("Outcome() = %q, want %q (failed console backend must classify failed, not ready)", got, want)
+	}
+	if final["catalyst-platform"] != StateFailed {
+		t.Errorf("final[catalyst-platform] = %q, want %q", final["catalyst-platform"], StateFailed)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/helmwatch/transition_test.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/transition_test.go
@@ -407,30 +407,50 @@ func TestAllObservedTerminal_SyncedGate(t *testing.T) {
 		"cert-manager": {},
 	}
 
+	// #4746 sentinel fixtures: an early-only observed set (cilium terminal,
+	// catalyst-platform not yet in the cache) and a set that additionally
+	// carries the sentinel.
+	earlyOnly := map[string]string{"cilium": StateInstalled}
+	observedEarlyOnly := map[string]struct{}{"cilium": {}}
+	withSentinelInstalled := map[string]string{"cilium": StateInstalled, "catalyst-platform": StateInstalled}
+	observedWithSentinel := map[string]struct{}{"cilium": {}, "catalyst-platform": {}}
+	withSentinelFailed := map[string]string{"cilium": StateInstalled, "catalyst-platform": StateFailed}
+
 	cases := []struct {
-		name             string
-		states           map[string]string
-		observed         map[string]struct{}
-		minHRs           int
-		firstSeenAt      time.Time
-		synced           bool
-		want             bool
+		name          string
+		states        map[string]string
+		observed      map[string]struct{}
+		minHRs        int
+		firstSeenAt   time.Time
+		synced        bool
+		readySentinel string
+		want          bool
 	}{
-		{"synced=false blocks even if all-Ready", allReady, observedAllReady, 1, now, false, false},
-		{"firstSeenAt zero blocks even if synced", allReady, observedAllReady, 1, zero, true, false},
-		{"observed below floor blocks", allReady, observedAllReady, 999, now, true, false},
-		{"one HR not terminal blocks", map[string]string{"cilium": StateInstalled, "cert-manager": StateInstalling}, observedAllReady, 1, now, true, false},
-		{"all-Ready synced cache fires", allReady, observedAllReady, 1, now, true, true},
-		{"all-Ready synced cache with absurd floor still fires when count >= floor", allReady, observedAllReady, 2, now, true, true},
-		{"failed counts as terminal", map[string]string{"cilium": StateInstalled, "cert-manager": StateFailed}, observedAllReady, 1, now, true, true},
+		{"synced=false blocks even if all-Ready", allReady, observedAllReady, 1, now, false, "", false},
+		{"firstSeenAt zero blocks even if synced", allReady, observedAllReady, 1, zero, true, "", false},
+		{"observed below floor blocks", allReady, observedAllReady, 999, now, true, "", false},
+		{"one HR not terminal blocks", map[string]string{"cilium": StateInstalled, "cert-manager": StateInstalling}, observedAllReady, 1, now, true, "", false},
+		{"all-Ready synced cache fires", allReady, observedAllReady, 1, now, true, "", true},
+		{"all-Ready synced cache with absurd floor still fires when count >= floor", allReady, observedAllReady, 2, now, true, "", true},
+		{"failed counts as terminal", map[string]string{"cilium": StateInstalled, "cert-manager": StateFailed}, observedAllReady, 1, now, true, "", true},
+
+		// #4746 — sentinel gate. An early-only terminal set must NOT fire
+		// while the console backend (catalyst-platform) is still absent, but
+		// once the sentinel is observed-and-terminal the gate fires. A
+		// terminal-FAILED sentinel still trips it (classified OutcomeFailed
+		// downstream, never a hang). Empty sentinel = historical behaviour.
+		{"sentinel absent blocks even though early set is terminal", earlyOnly, observedEarlyOnly, 1, now, true, "catalyst-platform", false},
+		{"empty sentinel keeps historical early-fire", earlyOnly, observedEarlyOnly, 1, now, true, "", true},
+		{"sentinel observed+installed fires", withSentinelInstalled, observedWithSentinel, 1, now, true, "catalyst-platform", true},
+		{"sentinel observed+failed still fires (→ OutcomeFailed)", withSentinelFailed, observedWithSentinel, 1, now, true, "catalyst-platform", true},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := allObservedTerminal(tc.states, tc.observed, tc.minHRs, tc.firstSeenAt, tc.synced)
+			got := allObservedTerminal(tc.states, tc.observed, tc.minHRs, tc.firstSeenAt, tc.synced, tc.readySentinel)
 			if got != tc.want {
-				t.Errorf("allObservedTerminal(synced=%t, firstSeenAt-zero=%t, minHRs=%d) = %t, want %t",
-					tc.synced, tc.firstSeenAt.IsZero(), tc.minHRs, got, tc.want)
+				t.Errorf("allObservedTerminal(synced=%t, firstSeenAt-zero=%t, minHRs=%d, sentinel=%q) = %t, want %t",
+					tc.synced, tc.firstSeenAt.IsZero(), tc.minHRs, tc.readySentinel, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Problem

A fresh **2-region** prov reaches `phase1Outcome=ready` but is stamped `status=failed` even though the cluster is still legitimately converging. Live repro: hw221 / hw222.

Root cause (traced in #4746): the phase-1 terminate-on-all-done census fires `OutcomeReady` the instant the informer's initial List catches a **narrow** early set (e.g. only `bp-cilium`) all `Ready=True` and the `MinBootstrapKitHRs` floor (1) is met — long before `bp-catalyst-platform` (the console's own backend) has even been created by Flux. That premature ready then runs the #4706 external console-reachability probe against a console whose backend has not begun installing, so the probe can only fail → a healthy prov is marked failed. hw221 fired `OutcomeReady` at T+24m; the console answered at T+48m.

`#4751` widened the downstream console-probe budget (90s → 35m) to cover the observed gap, but that leaves the census defect in place and is fragile: if `OutcomeReady` fires earlier than the hw221 T+24m sample, 35m may not cover console-up time.

## Fix — repair the gate, not the timeout

Add a **ready-sentinel** to the census. `allObservedTerminal` refuses `OutcomeReady` until the sentinel component (`catalyst-platform` — the terminal node of the bootstrap-kit dependency chain, `dependsOn` gitea → keycloak → openbao → …, and the console's own server) has been **observed** and reached a terminal state.

- This is **not** cardinality-coupled (the otech48 trap the count floor was moved away from): it requires one well-known sentinel, not a count that drifts with the kit.
- Production wires it via `New()` + `phase1WatchConfigForDeployment`; operators override with `CATALYST_PHASE1_READY_SENTINEL` (Inviolable Principle #4). The `Handler` zero-value is empty (gate off) so inline `&Handler{}` unit tests are unaffected.
- **Secondary-region** watchers clear the sentinel — the console backend is primary-only, and secondaries do not contribute to the terminal outcome.

The gate stays honest — a genuinely broken prov still fails:
- sentinel reaches `StateFailed` → `OutcomeFailed`;
- sentinel never installs → runs to `WatchTimeout` → `OutcomeTimeout` (handler → `failed`).

The 35m console-probe budget from #4751 is retained as defense-in-depth for the DNS-01 cert / gateway / LB tail after the backend is up — it is no longer the load-bearing gate.

## Tests

- `allObservedTerminal` sentinel cases (absent-blocks, empty-keeps-historical, observed+installed fires, observed+failed still fires).
- `TestWatch_ReadySentinel_SlowConsoleBackend_DefersReadyUntilInstalled` — the slow-but-healthy 2-region case: early HR ready at sync, console backend appears late → `OutcomeReady` with both components, **plus an empty-sentinel control** proving the same fixture fires the historical premature ready on the early set alone.
- `TestWatch_ReadySentinel_ConsoleBackendNeverInstalls_TimesOutNotReady` — genuinely broken: `OutcomeTimeout`, never ready.
- `TestWatch_ReadySentinel_ConsoleBackendFails_ClassifiesFailed` — genuinely broken: `OutcomeFailed`.

`go build ./...` + `go vet ./...` clean; helmwatch + handler suites green under `-race`.

Refs #4746