### PR TITLE
fix(catalyst-api): wipe DNS teardown retries the derived tail zone — kill dangling console.<fqdn> (Refs #4764)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_dns_records.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_dns_records.go
@@ -336,6 +336,32 @@ func (h *Handler) upsertSovereignParentZoneRecordsFromResult(ctx context.Context
 	}
 }
 
+// sovereignParentZoneRecordNames returns the fully-qualified, dot-terminated
+// rrset names a Sovereign owns in its parent zone: one per
+// CanonicalSovereignSubdomain (`<sub>.<fqdn>.`) plus the bare apex (`<fqdn>.`).
+//
+// This is the single source of truth for the record-SELECTION contract shared
+// by the write side (upsertSovereignParentZoneRecords) and the wipe teardown
+// (deleteSovereignParentZoneRecords) — keeping them symmetric so a wiped
+// Sovereign can never leave behind a record the upsert created (the #4764
+// dangling-`console.<fqdn>` leak). Pure + allocation-only so the selection can
+// be unit-tested without a PowerDNS client. FQDN is lowercased + trimmed of a
+// trailing dot (DNS names are case-insensitive; PowerDNS canonicalises on
+// write) so a blank/whitespace FQDN yields NO names rather than a bare-dot `.`
+// rrset that could touch the zone apex.
+func sovereignParentZoneRecordNames(sovereignFQDN string) []string {
+	fqdn := strings.TrimSuffix(strings.ToLower(strings.TrimSpace(sovereignFQDN)), ".")
+	if fqdn == "" {
+		return nil
+	}
+	names := make([]string, 0, len(CanonicalSovereignSubdomains)+1)
+	for _, sub := range CanonicalSovereignSubdomains {
+		names = append(names, sub+"."+fqdn+".")
+	}
+	names = append(names, fqdn+".") // apex
+	return names
+}
+
 // deleteSovereignParentZoneRecords is the wipe-side twin of
 // upsertSovereignParentZoneRecords (#4732 item 7). It DELETEs the same
 // rrset names the upsert wrote — every CanonicalSovereignSubdomain plus
@@ -347,6 +373,13 @@ func (h *Handler) upsertSovereignParentZoneRecordsFromResult(ctx context.Context
 // Idempotent: PowerDNS changetype=DELETE on an absent rrset is a 2xx
 // no-op. Best-effort by design — the caller logs and continues so a DNS
 // hiccup never blocks the wipe's cloud purge or record cleanup.
+//
+// NOTE: this targets exactly the `parentZone` it is given. When the wipe is
+// handed a `parentZone` equal to the FQDN itself (the BYO back-compat synthesis
+// that stamps ParentDomains[0].Name = SovereignFQDN), that sub-FQDN is NOT an
+// authoritative PowerDNS zone and the PATCH 404s — the records actually live in
+// the FQDN's tail zone. deleteSovereignParentZoneRecordsWithFallback mirrors the
+// write-side 404 retry so callers get the tail-zone cleanup for free (#4764).
 func (h *Handler) deleteSovereignParentZoneRecords(ctx context.Context, sovereignFQDN, parentZone string) error {
 	if h.powerdnsZoneClient == nil {
 		h.log.Info("sovereign-dns-records: delete skipped (no powerdns client wired)",
@@ -365,20 +398,15 @@ func (h *Handler) deleteSovereignParentZoneRecords(ctx context.Context, sovereig
 			parentZone = sovereignFQDN
 		}
 	}
-	subdomains := CanonicalSovereignSubdomains
-	rrsets := make([]powerdns.RRSet, 0, len(subdomains)+1)
-	for _, sub := range subdomains {
+	names := sovereignParentZoneRecordNames(sovereignFQDN)
+	rrsets := make([]powerdns.RRSet, 0, len(names))
+	for _, name := range names {
 		rrsets = append(rrsets, powerdns.RRSet{
-			Name:       sub + "." + sovereignFQDN + ".",
+			Name:       name,
 			Type:       "A",
 			ChangeType: "DELETE",
 		})
 	}
-	rrsets = append(rrsets, powerdns.RRSet{
-		Name:       sovereignFQDN + ".",
-		Type:       "A",
-		ChangeType: "DELETE",
-	})
 	if err := h.powerdnsZoneClient.PatchRRSets(ctx, parentZone, rrsets); err != nil {
 		return fmt.Errorf("sovereign-dns-records: delete from parent zone %q: %w", parentZone, err)
 	}
@@ -388,4 +416,49 @@ func (h *Handler) deleteSovereignParentZoneRecords(ctx context.Context, sovereig
 		"recordCount", len(rrsets),
 	)
 	return nil
+}
+
+// deleteSovereignParentZoneRecordsWithFallback is the wipe entry point. It
+// deletes the Sovereign's parent-zone records and — crucially — mirrors the
+// write-side 404 retry in upsertSovereignParentZoneRecordsFromResult so the
+// teardown is symmetric with the write.
+//
+// Root cause of #4764: Request.Validate() synthesises ParentDomains[0].Name =
+// SovereignFQDN for BYO Sovereigns (no SovereignPoolDomain). The wipe hands that
+// verbatim value as `parentZone`, but for a sub-FQDN like `t126.omani.works` the
+// authoritative PowerDNS zone is the tail `omani.works` — the write side already
+// learned this (the sub-FQDN PATCH 404s) and retried against the derived tail,
+// so the A records — including `console.<fqdn>` → the console EIP — landed in
+// `omani.works`. The wipe did NOT retry, so it PATCH-DELETEd the non-existent
+// sub-FQDN zone (404), and every record it should have removed survived. A wiped
+// env's `console.<fqdn>` then kept resolving a released EIP.
+//
+// The fallback fires ONLY when the first attempt 404s AND the parent equals the
+// FQDN itself — the exact condition the write side uses. The retry target is
+// strictly the FQDN's own tail label (this deployment's registered parent
+// domain), so it never touches a sibling Sovereign's records or a shared /
+// mothership zone. Idempotent: DELETE on absent rrsets is a PowerDNS no-op.
+func (h *Handler) deleteSovereignParentZoneRecordsWithFallback(ctx context.Context, sovereignFQDN, parentZone string) error {
+	err := h.deleteSovereignParentZoneRecords(ctx, sovereignFQDN, parentZone)
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(err.Error(), "status 404") && parentZone == sovereignFQDN {
+		if i := strings.IndexByte(sovereignFQDN, '.'); i > 0 {
+			derivedParent := sovereignFQDN[i+1:]
+			if derivedParent != parentZone {
+				h.log.Info("sovereign-dns-records: parent zone 404 on delete — retrying with derived tail parent",
+					"sovereignFQDN", sovereignFQDN,
+					"originalParent", parentZone,
+					"derivedParent", derivedParent,
+				)
+				if err2 := h.deleteSovereignParentZoneRecords(ctx, sovereignFQDN, derivedParent); err2 == nil {
+					return nil
+				} else {
+					return fmt.Errorf("original=%w, derived-fallback=%v", err, err2)
+				}
+			}
+		}
+	}
+	return err
 }

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_dns_records_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_dns_records_test.go
@@ -2,8 +2,10 @@ package handler
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/powerdns"
@@ -156,10 +158,14 @@ func TestConsoleGatewaySubdomainSetOverride(t *testing.T) {
 }
 
 // stubZoneClient records PatchRRSets calls for the delete-side test.
+// failZone, when set, makes PatchRRSets return a PowerDNS-shaped 404 for that
+// exact zone (the record of the attempt is still captured) so the 404 →
+// derived-parent fallback can be exercised deterministically.
 type stubZoneClient struct {
-	zones  []string
-	rrsets [][]powerdns.RRSet
-	err    error
+	zones    []string
+	rrsets   [][]powerdns.RRSet
+	err      error
+	failZone string
 }
 
 func (s *stubZoneClient) CreateZone(_ context.Context, _ powerdns.ZoneSpec) error { return nil }
@@ -167,7 +173,111 @@ func (s *stubZoneClient) ZoneExists(_ context.Context, _ string) (bool, error)  
 func (s *stubZoneClient) PatchRRSets(_ context.Context, zone string, rrsets []powerdns.RRSet) error {
 	s.zones = append(s.zones, zone)
 	s.rrsets = append(s.rrsets, rrsets)
+	if s.failZone != "" && zone == s.failZone {
+		// Mirrors *powerdns.Client.PatchRRSets on a missing zone; the
+		// "status 404" token is what the fallback keys off.
+		return fmt.Errorf("powerdns: patch zone %q status 404: Not Found", zone)
+	}
 	return s.err
+}
+
+// TestSovereignParentZoneRecordNames locks the record-SELECTION contract that
+// both the write side and the wipe teardown share: every canonical subdomain
+// plus the apex, each dot-terminated, and NO record at all for a blank FQDN
+// (so a wipe with a missing FQDN can never emit a bare-dot "." apex rrset).
+func TestSovereignParentZoneRecordNames(t *testing.T) {
+	names := sovereignParentZoneRecordNames("hw220.omani.works")
+	if want := len(CanonicalSovereignSubdomains) + 1; len(names) != want {
+		t.Fatalf("name count = %d, want %d (canonical subdomains + apex)", len(names), want)
+	}
+	set := map[string]bool{}
+	for _, n := range names {
+		if !strings.HasSuffix(n, ".") {
+			t.Errorf("record name %q must be dot-terminated (PowerDNS canonical rrset name)", n)
+		}
+		set[n] = true
+	}
+	for _, must := range []string{
+		"console.hw220.omani.works.",
+		"api.hw220.omani.works.",
+		"marketplace.hw220.omani.works.",
+		"hw220.omani.works.", // apex
+	} {
+		if !set[must] {
+			t.Errorf("record-selection missing %q — the wiped-record leak class #4764 guards", must)
+		}
+	}
+	// Case-insensitive + trailing-dot tolerant, and blank → nothing.
+	if got := sovereignParentZoneRecordNames("HW220.omani.works."); !hasName(got, "console.hw220.omani.works.") {
+		t.Errorf("uppercase/trailing-dot FQDN should normalise to lowercase names, got %v", got)
+	}
+	if got := sovereignParentZoneRecordNames("   "); got != nil {
+		t.Errorf("blank FQDN must yield no record names (no bare-dot apex), got %v", got)
+	}
+}
+
+func hasName(names []string, want string) bool {
+	for _, n := range names {
+		if n == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDeleteSovereignParentZoneRecordsWithFallback_404RetriesDerivedParent is
+// the heart of #4764. BYO back-compat stamps ParentDomains[0].Name =
+// SovereignFQDN, so the wipe is handed parent == the sub-FQDN. That sub-FQDN is
+// not an authoritative PowerDNS zone (the tail `omani.works` is), so the first
+// DELETE 404s; the fallback MUST retry against the derived tail where the
+// records — including console.<fqdn> → the released console EIP — actually live.
+func TestDeleteSovereignParentZoneRecordsWithFallback_404RetriesDerivedParent(t *testing.T) {
+	stub := &stubZoneClient{failZone: "hw220.omani.works"}
+	h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil)), powerdnsZoneClient: stub}
+
+	if err := h.deleteSovereignParentZoneRecordsWithFallback(context.Background(), "hw220.omani.works", "hw220.omani.works"); err != nil {
+		t.Fatalf("expected fallback to succeed against derived tail parent, got %v", err)
+	}
+	if len(stub.zones) != 2 || stub.zones[0] != "hw220.omani.works" || stub.zones[1] != "omani.works" {
+		t.Fatalf("zones attempted = %v, want [hw220.omani.works omani.works] (404 then derived-parent retry)", stub.zones)
+	}
+	// The derived-parent DELETE must still carry the console record so the
+	// released console EIP stops resolving after the wipe.
+	sawConsole := false
+	for _, rr := range stub.rrsets[1] {
+		if rr.Name == "console.hw220.omani.works." && rr.ChangeType == "DELETE" {
+			sawConsole = true
+		}
+	}
+	if !sawConsole {
+		t.Errorf("derived-parent DELETE missing console.hw220.omani.works. — the dangling-record leak #4764 fixes")
+	}
+}
+
+// TestDeleteSovereignParentZoneRecordsWithFallback_NoRetryWhenParentIsRealZone
+// guards the blast-radius invariant: for a pool / explicit-multi-domain wipe the
+// parent is the real registered zone (omani.works), the single DELETE succeeds,
+// and the fallback must NOT fire — we never touch a second (sibling) zone.
+func TestDeleteSovereignParentZoneRecordsWithFallback_NoRetryWhenParentIsRealZone(t *testing.T) {
+	stub := &stubZoneClient{}
+	h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil)), powerdnsZoneClient: stub}
+
+	if err := h.deleteSovereignParentZoneRecordsWithFallback(context.Background(), "hw220.omani.works", "omani.works"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(stub.zones) != 1 || stub.zones[0] != "omani.works" {
+		t.Fatalf("zones attempted = %v, want exactly [omani.works] (no fallback, no sibling-zone touch)", stub.zones)
+	}
+}
+
+// TestDeleteSovereignParentZoneRecordsWithFallback_NilClientNoop keeps the
+// best-effort contract: no PowerDNS client wired (pool-mode Sovereigns whose
+// DNS is entirely PDM's child zone) → nil error, no fallback, no panic.
+func TestDeleteSovereignParentZoneRecordsWithFallback_NilClientNoop(t *testing.T) {
+	h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	if err := h.deleteSovereignParentZoneRecordsWithFallback(context.Background(), "hw220.omani.works", "hw220.omani.works"); err != nil {
+		t.Fatalf("expected nil error with no client, got %v", err)
+	}
 }
 
 // TestDeleteSovereignParentZoneRecords locks #4732 item 7: the wipe-side

--- a/products/catalyst/bootstrap/api/internal/handler/wipe.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe.go
@@ -623,9 +623,15 @@ func (h *Handler) WipeDeployment(w http.ResponseWriter, r *http.Request) {
 		}
 		dnsCtx, dnsCancel := context.WithTimeout(context.Background(), 60*time.Second)
 		for _, parent := range parents {
-			if err := h.deleteSovereignParentZoneRecords(dnsCtx, fqdn, parent); err != nil {
+			// WithFallback mirrors the write-side 404 retry: a BYO Sovereign's
+			// ParentDomains[0].Name is the FQDN itself, whose authoritative zone
+			// is the tail label — so a DELETE against the sub-FQDN 404s and the
+			// records (incl. console.<fqdn>) survive unless we retry the tail
+			// (#4764). Surfaced at ERROR (not warn) so a genuinely leaked record
+			// is a visible wipe error, not a silently-swallowed line.
+			if err := h.deleteSovereignParentZoneRecordsWithFallback(dnsCtx, fqdn, parent); err != nil {
 				report.Errors = append(report.Errors, "sovereign dns teardown ("+parent+"): "+err.Error())
-				emit("wipe", "warn", "sovereign DNS teardown failed for zone "+parent+" — stale records may linger: "+err.Error())
+				emit("wipe", "error", "sovereign DNS teardown FAILED for zone "+parent+" — stale records may linger and resolve a released EIP; re-run the wipe (idempotent) or delete them by hand: "+err.Error())
 			} else {
 				emit("wipe", "info", "sovereign DNS records deleted from parent zone "+parent)
 			}


### PR DESCRIPTION
## Problem

The canonical wipe (`POST /sovereign/api/v1/deployments/{id}/wipe`) left `console.<fqdn>` (and the sibling per-Sovereign A records) still resolving a **released EIP** after `tofu destroy`. Verified live in #4764: `console.hw220.omani.works` kept resolving `212.72.24.33` — a now-unbound console EIP — with mothership registry showing 0 hw220 deployments. A stale record pointing at a reclaimable EIP can mis-route if that EIP is later reassigned.

## Root cause

`Request.Validate()` synthesises `ParentDomains[0].Name = SovereignFQDN` for BYO Sovereigns (no `SovereignPoolDomain`). The wipe's DNS teardown (Step 2b) handed that verbatim value as the parent zone.

For a sub-FQDN like `t126.omani.works`, the authoritative PowerDNS zone is the **tail** `omani.works`, not the sub-FQDN. The **write** side already learned this: `upsertSovereignParentZoneRecordsFromResult` PATCHes the sub-FQDN zone, gets a 404, and **retries against the derived tail** — so `console.<fqdn>` → console EIP actually landed in `omani.works`.

The **wipe** did NOT mirror that retry. It PATCH-DELETEd the non-existent sub-FQDN zone, got a 404, hit the best-effort warn-path, and **every record it should have removed survived** — the exact dangling-`console.<fqdn>` leak in the issue.

## Fix

- `deleteSovereignParentZoneRecordsWithFallback` mirrors the write-side 404 → derived-tail retry, so the wipe deletes the records from the zone they actually live in. The retry target is strictly the FQDN's own tail label (this deployment's registered parent domain), so it never touches a sibling Sovereign's records or a shared / mothership zone. Idempotent — `changetype=DELETE` on an absent rrset is a PowerDNS no-op.
- Surface a genuine teardown failure at **error** severity (was `warn`) so a leaked record is a visible wipe error, not a silently-swallowed line.
- Extract `sovereignParentZoneRecordNames` as the shared record-selection contract (every canonical subdomain + apex, dot-terminated; a blank/whitespace FQDN yields no names, never a bare-dot `.` apex) and unit-test it plus the fallback zone-selection.

Pool-mode Sovereigns are unaffected: their records live in a PDM-owned **child zone** dropped by the existing PDM release (wipe Step 3); the parent-zone delete is a no-op there.

## Tests

`go build ./... && go vet ./...` pass. New unit tests in `sovereign_dns_records_test.go`:
- `TestSovereignParentZoneRecordNames` — record-selection contract (canonical subdomains + apex, dot-terminated, blank FQDN → no bare-dot apex, case/trailing-dot normalisation).
- `TestDeleteSovereignParentZoneRecordsWithFallback_404RetriesDerivedParent` — 404 on the sub-FQDN zone → retry on the derived tail, and the console record is in the retried DELETE.
- `TestDeleteSovereignParentZoneRecordsWithFallback_NoRetryWhenParentIsRealZone` — a real parent zone deletes once, no sibling-zone touch.
- `TestDeleteSovereignParentZoneRecordsWithFallback_NilClientNoop` — best-effort no-op with no PowerDNS client.

Full `internal/handler` package: `ok` (150s).

Refs #4764

🤖 Generated with [Claude Code](https://claude.com/claude-code)