### PR TITLE
fix(provisioning): thread funnel-door apps Kustomization sourceRef repo from config (Refs #4761)

### DIFF
--- a/core/services/provisioning/gitops/apps_into_vcluster_4297_test.go
+++ b/core/services/provisioning/gitops/apps_into_vcluster_4297_test.go
@@ -85,6 +85,48 @@ func TestAppsSync_HostTier_NoKubeConfig(t *testing.T) {
 	}
 }
 
+// TestAppsSync_SourceRepo_DefaultsToHistoricalDefault — #4761. With no
+// AppsSyncSourceRepo wiring the funnel-door `tenant-<slug>-apps` Kustomization's
+// sourceRef must resolve to the post-#4798 default GitRepository name
+// (openova-org-tenants) so every existing Sovereign renders byte-unchanged.
+func TestAppsSync_SourceRepo_DefaultsToHistoricalDefault(t *testing.T) {
+	for _, plan := range []string{"m", "s", ""} {
+		t.Run("plan="+plan, func(t *testing.T) {
+			body := appsSyncFor(t, "acme", plan)
+			if !strings.Contains(body, "name: "+appsSyncSourceRepoDefault) {
+				t.Errorf("empty AppsSyncSourceRepo must render the historical default sourceRef name %q:\n%s", appsSyncSourceRepoDefault, body)
+			}
+			// The literal default must equal the post-#4798 name (no silent drift).
+			if appsSyncSourceRepoDefault != "openova-org-tenants" {
+				t.Errorf("appsSyncSourceRepoDefault drifted from the post-#4798 funnel-door repo name: got %q", appsSyncSourceRepoDefault)
+			}
+		})
+	}
+}
+
+// TestAppsSync_SourceRepo_Configurable — #4761. A Sovereign whose funnel-door
+// apps GitRepository CR is named differently (per-bootstrap state) can point the
+// sourceRef at it via CATALYST_APPS_SYNC_SOURCE_REPO (ManifestGenerator
+// .AppsSyncSourceRepo) with no code change. Non-default config → non-default
+// output; the historical default must NOT leak through.
+func TestAppsSync_SourceRepo_Configurable(t *testing.T) {
+	for _, plan := range []string{"m", "s"} {
+		t.Run("plan="+plan, func(t *testing.T) {
+			g := NewManifestGenerator(testBasePath)
+			g.AppsSyncSourceRepo = "sovereign-org-tenants"
+			out := g.GenerateAllWithAppConfigs("acme", plan, []string{"wordpress"}, "pw", nil)
+			body := out[testBasePath+"/acme/apps-sync.yaml"]
+			if !strings.Contains(body, "name: sovereign-org-tenants") {
+				t.Errorf("apps-sync sourceRef must honour the overridden AppsSyncSourceRepo:\n%s", body)
+			}
+			// The default must not appear as the live sourceRef name when overridden.
+			if strings.Contains(body, "name: "+appsSyncSourceRepoDefault) {
+				t.Errorf("apps-sync sourceRef must not fall back to the default %q when AppsSyncSourceRepo is set:\n%s", appsSyncSourceRepoDefault, body)
+			}
+		})
+	}
+}
+
 // TestBoundaryIsVcluster_FunnelParity locks the funnel's tier gate in lockstep
 // with the org-controller's authoritative boundaryIsVcluster gate (#4292,
 // core/controllers/organization/internal/gitops/manifests.go). The two are

--- a/core/services/provisioning/gitops/gitops.go
+++ b/core/services/provisioning/gitops/gitops.go
@@ -235,6 +235,29 @@ type ManifestGenerator struct {
 	// `realm: sovereign`; catalyst-api's CATALYST_KC_REALM default). Empty
 	// resolves to sharedRealmNameDefault.
 	SharedRealmName string
+
+	// AppsSyncSourceRepo is the name of the Flux GitRepository CR (in
+	// flux-system) that generateAppsSyncKustomization's `tenant-<slug>-apps`
+	// Kustomization resolves its sourceRef against — the Gitea mono-repo that
+	// holds the funnel-door apps tree (`./<basePath>/<slug>/apps`).
+	//
+	// #4761 LANDMINE: this sourceRef.name was HARDCODED — first to `flux-system`
+	// (#4785: no such GitRepository exists on a Sovereign → the Kustomization
+	// stuck permanently FALSE `GitRepository "flux-system" not found`), then
+	// #4798 swapped the literal to `openova-org-tenants` (the Sovereign's
+	// funnel-door mono-repo GitRepository). But a bare literal is still an
+	// Inviolable-Principle-4 violation: the GitRepository name is
+	// per-Sovereign-bootstrap state (a differently-bootstrapped Sovereign, or a
+	// mothership whose source CR is named `flux-system`, names this repo
+	// differently), so a hardcode renders the `tenant-<slug>-apps` Kustomization
+	// permanently FALSE — the SAME "GitRepository not found" failure #4785 hit,
+	// just re-hardcoded to a different name.
+	//
+	// Populated from CATALYST_APPS_SYNC_SOURCE_REPO in main.go. Empty resolves
+	// to appsSyncSourceRepoDefault ("openova-org-tenants") so the post-#4798
+	// funnel-door behavior is byte-unchanged for every existing Sovereign
+	// (NO-REGRESS).
+	AppsSyncSourceRepo string
 }
 
 // parentDomain resolves the funnel's org-pool parent zone for the
@@ -306,6 +329,15 @@ const replicaRegionKubeSecretDefault = "sovereign-replica-region-kubeconfig"
 // defaultVClusterRegistryMirror is the bootstrap Harbor proxy host.
 const defaultVClusterRegistryMirror = "harbor.openova.io"
 
+// appsSyncSourceRepoDefault is the Flux GitRepository CR name the funnel-door
+// `tenant-<slug>-apps` Kustomization resolves its sourceRef against when
+// AppsSyncSourceRepo (CATALYST_APPS_SYNC_SOURCE_REPO) is unset. Matches the
+// post-#4798 funnel-door mono-repo GitRepository so an unconfigured Sovereign
+// renders byte-identically (NO-REGRESS). See ManifestGenerator.AppsSyncSourceRepo
+// for why the name must be per-Sovereign-configurable rather than hardcoded
+// (#4761 / Inviolable Principle 4).
+const appsSyncSourceRepoDefault = "openova-org-tenants"
+
 // Block-storage StorageClass names per cloud provider. These are the
 // canonical Catalyst CSI classes installed by the per-provider CSI
 // Blueprints (platform/hcloud-csi → hcloud-volumes,
@@ -346,6 +378,18 @@ func (g *ManifestGenerator) replicaRegionKubeSecret() string {
 		return s
 	}
 	return replicaRegionKubeSecretDefault
+}
+
+// appsSyncSourceRepo resolves the Flux GitRepository CR name the funnel-door
+// `tenant-<slug>-apps` Kustomization points its sourceRef at (#4761). Empty
+// falls back to appsSyncSourceRepoDefault ("openova-org-tenants") so the
+// post-#4798 behavior is byte-unchanged on any Sovereign that does not wire
+// CATALYST_APPS_SYNC_SOURCE_REPO.
+func (g *ManifestGenerator) appsSyncSourceRepo() string {
+	if s := strings.TrimSpace(g.AppsSyncSourceRepo); s != "" {
+		return s
+	}
+	return appsSyncSourceRepoDefault
 }
 
 func NewManifestGenerator(basePath string) *ManifestGenerator {
@@ -488,7 +532,7 @@ func (g *ManifestGenerator) GenerateAllWithAppConfigs(slug, planSlug string, app
 	// never inside the vcluster-redirected apps/ tree).
 	hostFiles := map[string]string{
 		"ingress.yaml":           generateHostIngress(hostNS, slug, appSlugs),
-		"apps-sync.yaml":         generateAppsSyncKustomization(hostNS, slug, g.BasePath, isVcluster),
+		"apps-sync.yaml":         generateAppsSyncKustomization(hostNS, slug, g.BasePath, isVcluster, g.appsSyncSourceRepo()),
 		"provisioning-rbac.yaml": generateProvisioningTenantRBAC(hostNS),
 	}
 
@@ -776,7 +820,15 @@ func (g *ManifestGenerator) GenerateAllWithAppConfigs(slug, planSlug string, app
 // exists this Kustomization simply StateErrors-then-retries (retryInterval 1m)
 // — the intended self-healing for the vcluster tier. The host tier has no
 // secret dependency at all, so it reconciles immediately.
-func generateAppsSyncKustomization(ns, slug, basePath string, isVcluster bool) string {
+//
+// #4761 — sourceRef.name is threaded from ManifestGenerator.appsSyncSourceRepo()
+// (CATALYST_APPS_SYNC_SOURCE_REPO, default "openova-org-tenants"), NOT a bare
+// literal. The Flux GitRepository CR that backs the funnel-door apps tree is
+// per-Sovereign-bootstrap state — hardcoding its name (first `flux-system`
+// #4785, then `openova-org-tenants` #4798) leaves the `tenant-<slug>-apps`
+// Kustomization permanently FALSE (`GitRepository "<name>" not found`) on any
+// Sovereign that names the repo differently (Inviolable Principle 4).
+func generateAppsSyncKustomization(ns, slug, basePath string, isVcluster bool, sourceRepo string) string {
 	kubeConfig := ""
 	if isVcluster {
 		kubeConfig = fmt.Sprintf(`
@@ -799,10 +851,10 @@ spec:
   targetNamespace: %s
   sourceRef:
     kind: GitRepository
-    name: openova-org-tenants
+    name: %s
     namespace: flux-system
   path: ./%s/%s/apps%s
-`, slug, ns, basePath, slug, kubeConfig)
+`, slug, ns, sourceRepo, basePath, slug, kubeConfig)
 }
 
 func generateHostIngress(ns, slug string, appSlugs []string) string {

--- a/core/services/provisioning/main.go
+++ b/core/services/provisioning/main.go
@@ -228,6 +228,15 @@ func main() {
 	generator.SovereignFQDN = sovereignFQDN
 	generator.SharedRealmName = getEnv("CATALYST_KC_REALM", "sovereign")
 
+	// #4761: the Flux GitRepository CR name the funnel-door `tenant-<slug>-apps`
+	// Kustomization resolves its sourceRef against — the Gitea mono-repo that
+	// holds the apps tree. Previously hardcoded (flux-system #4785 → then
+	// openova-org-tenants #4798), which left the Kustomization permanently FALSE
+	// (`GitRepository "<name>" not found`) on any Sovereign that names the repo
+	// differently. Now wired from env; empty falls back to the post-#4798 default
+	// (openova-org-tenants) inside the generator so existing provs are unchanged.
+	generator.AppsSyncSourceRepo = getEnv("CATALYST_APPS_SYNC_SOURCE_REPO", "")
+
 	// ── Git host coordinates (issue #940) ────────────────────────────
 	// On Sovereigns the canonical Git target is the local Gitea (the
 	// cutover step flipped the Sovereign's GitRepository CR to point


### PR DESCRIPTION
## What

`generateAppsSyncKustomization` (core/services/provisioning/gitops/gitops.go) emits the per-Org `tenant-<slug>-apps` Flux Kustomization. Its `sourceRef.name` — the Flux GitRepository CR backing the funnel-door apps tree — was a **bare hardcoded literal**.

History of the hardcode:
- Originally `flux-system` → on a Sovereign no such GitRepository exists, so the Kustomization stuck permanently FALSE: `GitRepository "flux-system" not found` (live on hw224 ns uatwp4758, the #4758 walk).
- #4798 swapped the literal to `openova-org-tenants` (the Sovereign funnel-door mono-repo).

A literal is still an **Inviolable-Principle-4 violation**: the GitRepository name is per-Sovereign-bootstrap state. Any Sovereign (or a mothership whose source CR is named `flux-system`) that names this repo differently hits the *same* "GitRepository not found" wedge #4785 hit — just re-pinned to a different name.

## Fix

Thread the value through `ManifestGenerator.appsSyncSourceRepo()`, wired from `CATALYST_APPS_SYNC_SOURCE_REPO` in `main.go` — the identical struct-field + resolver-with-default + env-wiring pattern the other environment-dependent fields already use (`RegistryMirror`, `CloudProvider`, `ReplicaRegionKubeSecret`, `ParentDomain`, `SovereignFQDN`).

Empty config resolves to `appsSyncSourceRepoDefault` (`openova-org-tenants`), so **every existing prov renders byte-identically** — the post-#4798 value remains the effective default (NO-REGRESS).

## Tests (gitops pkg, `go test -race`)

- `TestAppsSync_SourceRepo_DefaultsToHistoricalDefault` — empty config → sourceRef `name: openova-org-tenants` (across plans m/s/""), plus a drift-guard on the default constant.
- `TestAppsSync_SourceRepo_Configurable` — override → non-default sourceRef name; the historical default must not leak through.

`go build ./...`, `go vet ./...`, and the full `gitops` package suite pass under `-race`.

Refs #4761 #4758 #4798 #4785