### PR TITLE
fix(#4913): serve Harbor UI on harbor.<fqdn> alias, not just registry.<fqdn>

### DIFF
--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -215,7 +215,16 @@ spec:
       # 1.2.39 — #4347: harbor-sso-configure liveness/readiness EXEC probes so
       #   it clears the host-ns Kyverno probes-present Enforce policy (post-#4325).
       #   Refs #4347 #4325.
-      version: 1.2.40
+      # 1.2.41 — #4913 (hw233): the HTTPRoute now ALSO answers on the app-named
+      #   harbor.${SOVEREIGN_FQDN}, not just the canonical registry.${SOVEREIGN_FQDN}
+      #   set in gateway.host below. Harbor serves UI+registry+SSO on ONE host
+      #   (registry.<fqdn>); harbor.<fqdn> had NO route → bare-envoy 404 for any
+      #   operator/tool reaching for it (wildcard DNS resolves it to the gateway VIP
+      #   but no route hostname matched). gateway.aliasHarborHost (default true)
+      #   auto-adds the harbor.-prefixed alias; the wildcard listener (01-cilium.yaml
+      #   *.${SOVEREIGN_FQDN}:443) + wildcard TLS already cover it, so no per-Sovereign
+      #   DNS/cert change. externalURL + OIDC redirect_uri stay on registry.<fqdn>.
+      version: 1.2.41
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/platform/harbor/blueprint.yaml
+++ b/platform/harbor/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-5-storage-and-data
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.40  # lockstep with chart/Chart.yaml (#4402 spine topology tier:mgmt → '' host-native, #4325 de-vcluster fallout)
+  version: 1.2.41  # lockstep with chart/Chart.yaml (#4913 harbor.<fqdn> HTTPRoute alias so the app-named host stops 404ing; UI stays canonical on registry.<fqdn>)
   card:
     title: Harbor
     family: foundation
@@ -151,6 +151,12 @@ spec:
       # the Keycloak OIDC client redirect_uri is registry.<sov>/c/oidc/callback.
       # The earlier harbor.<sov> value pointed at a host with NO HTTPRoute → the
       # console launch-url would 404. Keep this aligned with the live externalURL.
+      # registry.<sov> is therefore the CANONICAL launch host and stays the
+      # hostnameTemplate below. #4913 (chart 1.2.41): the HTTPRoute now ALSO
+      # answers on the app-named harbor.<sov> (gateway.aliasHarborHost) so an
+      # operator who reaches for harbor.<sov> by intuition no longer hits a
+      # bare-envoy 404 — but the launch-url / OIDC redirect_uri MUST remain
+      # registry.<sov> (Harbor's externalURL), so do NOT flip this template.
       hostnameTemplate: "registry.{{.SovereignFQDN}}"
       port: 443
       protocol: https

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -152,7 +152,21 @@ type: application
 #   Enforce ClusterPolicy admits it (after #4325 de-vcluster re-homed bp-harbor
 #   into a native host namespace). Adds tests/kyverno-probes-present.sh.
 #   Refs #4347 #4325.
-version: 1.2.40
+# 1.2.41 (#4913, hw233 live walk): the HTTPRoute now ALSO answers on the
+#   app-named harbor.<fqdn>, not just the canonical registry.<fqdn>. Harbor
+#   serves UI + registry-v2 + SSO on ONE host (registry.<fqdn> = gateway.host =
+#   externalURL = OIDC redirect_uri base); the intuitive harbor.<fqdn> had NO
+#   route, so operators/tools reaching for it got a bare-envoy 404 (wildcard DNS
+#   *.<fqdn> resolves it to the gateway VIP but no route hostname matched). NOT a
+#   missing UI route — the UI route lives on registry.<fqdn>. New value
+#   gateway.aliasHarborHost (default true) auto-adds the harbor.-prefixed sibling
+#   as a second hostname on the SAME route when gateway.host is registry.-prefixed;
+#   the Sovereign wildcard listener + wildcard TLS already cover it, so no
+#   DNS/cert change is needed. Auth + self-links stay on registry.<fqdn> (the
+#   sign-in->/c/oidc/login redirect keeps its canonical hostname), so entry via
+#   harbor.<fqdn> lands on the canonical host with no loop. Also adds
+#   gateway.extraHosts (arbitrary aliases) + tests/httproute-render.sh Case 6.
+version: 1.2.41
 appVersion: "2.14.3"
 # 1.2.23 (G117.5 #2744, 2026-06-02): SSO defense-in-depth via Harbor's
 # `oidc_extra_redirect_parms` config field. The configure-oauth Job now

--- a/platform/harbor/chart/templates/httproute.yaml
+++ b/platform/harbor/chart/templates/httproute.yaml
@@ -37,6 +37,30 @@ spec:
       {{- end }}
   hostnames:
     - {{ .Values.gateway.host | quote }}
+{{- /*
+#4913 (hw233 live walk): Harbor's UI + registry-v2 API + SSO are ALL served on
+ONE host — registry.<fqdn> (gateway.host; also harbor.externalURL and the OIDC
+redirect_uri). The app-named harbor.<fqdn> deliberately had NO HTTPRoute, so an
+operator/tool reaching for the intuitive harbor.<fqdn> hit a bare-envoy 404: the
+Sovereign wildcard DNS *.<fqdn> resolves it to the gateway VIP, but no route
+hostname matched (the exact hw233 symptom; NOT a missing UI route — the UI route
+lives on registry.<fqdn>). The wildcard listener (*.${SOVEREIGN_FQDN}:443,
+clusters/_template/bootstrap-kit/01-cilium.yaml) + wildcard TLS already cover
+harbor.<fqdn>, so listing it as a SECOND hostname on the SAME route serves the UI
+there too — no DNS/cert change needed. gateway.host stays canonical: the
+sign-in→/c/oidc/login redirect below and Harbor's externalURL keep auth +
+self-links on registry.<fqdn>, so an entry via harbor.<fqdn> lands on the
+canonical host after login (no redirect loop). Disable via
+gateway.aliasHarborHost=false; add arbitrary aliases via gateway.extraHosts.
+*/}}
+{{- if and .Values.gateway.aliasHarborHost (hasPrefix "registry." .Values.gateway.host) }}
+    - {{ printf "harbor.%s" (trimPrefix "registry." .Values.gateway.host) | quote }}
+{{- end }}
+{{- range $h := .Values.gateway.extraHosts }}
+{{- if and $h (ne $h $.Values.gateway.host) }}
+    - {{ $h | quote }}
+{{- end }}
+{{- end }}
   rules:
 {{- if and .Values.sso .Values.sso.enabled .Values.sso.bareURL .Values.sso.bareURL.enabled }}
 {{- $oidcLoginPath := .Values.sso.bareURL.oidcLoginPath | default "/c/oidc/login" }}

--- a/platform/harbor/chart/tests/httproute-render.sh
+++ b/platform/harbor/chart/tests/httproute-render.sh
@@ -109,4 +109,44 @@ if echo "$appcr" | grep -qE '^  placement: single-region$'; then
 fi
 echo "[bp-harbor] Case 5: PASS"
 
+# ── Case 6: registry.<fqdn> host also serves the app-named harbor.<fqdn> ──
+# #4913 (hw233): Harbor's UI+registry+SSO all live on registry.<fqdn>
+# (gateway.host). The intuitive harbor.<fqdn> deliberately had no route → a
+# bare-envoy 404 for any operator/tool reaching for it. gateway.aliasHarborHost
+# (default true) auto-adds the harbor.-prefixed sibling as a SECOND hostname on
+# the SAME route so both hosts serve the UI (the wildcard listener + wildcard
+# TLS already cover it). The sign-in→/c/oidc/login redirect + externalURL stay
+# on registry.<fqdn>, so entry via harbor.<fqdn> lands on the canonical host.
+echo "[bp-harbor] Case 6: registry.<fqdn> host auto-serves harbor.<fqdn> alias"
+out_alias=$("$helm" template smoke "$chart_dir" \
+        --set gateway.enabled=true \
+        --set gateway.host=registry.smoke.omani.works 2>&1)
+route_block_alias=$(echo "$out_alias" | awk '/^---$/{f=0} /^kind: HTTPRoute$/{f=1} f')
+if ! echo "$route_block_alias" | grep -q "registry.smoke.omani.works"; then
+  echo "FAIL: canonical gateway.host missing from HTTPRoute hostnames"
+  echo "$route_block_alias"
+  exit 1
+fi
+if ! echo "$route_block_alias" | grep -q "harbor.smoke.omani.works"; then
+  echo "FAIL: #4913 REGRESSION — harbor.<fqdn> alias NOT added (bare-envoy 404 returns)"
+  echo "$route_block_alias"
+  exit 1
+fi
+# The sign-in redirect must stay on the canonical registry host (loop-safety).
+if ! echo "$route_block_alias" | grep -q "hostname: \"registry.smoke.omani.works\""; then
+  echo "FAIL: sign-in RequestRedirect hostname must stay canonical registry.<fqdn>"
+  exit 1
+fi
+# Opt-out: aliasHarborHost=false serves ONLY the canonical host.
+out_noalias=$("$helm" template smoke "$chart_dir" \
+        --set gateway.enabled=true \
+        --set gateway.host=registry.smoke.omani.works \
+        --set gateway.aliasHarborHost=false 2>&1)
+route_block_noalias=$(echo "$out_noalias" | awk '/^---$/{f=0} /^kind: HTTPRoute$/{f=1} f')
+if echo "$route_block_noalias" | grep -q "harbor.smoke.omani.works"; then
+  echo "FAIL: gateway.aliasHarborHost=false should NOT emit the harbor.<fqdn> alias"
+  exit 1
+fi
+echo "[bp-harbor] Case 6: PASS"
+
 echo "[bp-harbor] All HTTPRoute render cases PASS"

--- a/platform/harbor/chart/values.yaml
+++ b/platform/harbor/chart/values.yaml
@@ -544,8 +544,24 @@ sso:
 # Gateway shipped by clusters/_template/bootstrap-kit/01-cilium.yaml.
 gateway:
   enabled: true
-  # host: registry.<sovereign-fqdn> — REQUIRED, no default per Inviolable Principle #4
+  # host: registry.<sovereign-fqdn> — REQUIRED, no default per Inviolable Principle #4.
+  # This is the CANONICAL Harbor host: UI (`/`) + registry-v2 (`/v2/`) + SSO all
+  # terminate here, and it MUST equal harbor.externalURL (the OIDC redirect_uri base).
   host: ""
+  # #4913 (hw233): also answer the HTTPRoute on the app-named harbor.<fqdn> so the
+  # intuitive host stops returning a bare-envoy 404 (it deliberately had no route;
+  # the UI lives on registry.<fqdn>). When true AND gateway.host begins with
+  # "registry.", the chart auto-adds the "harbor."-prefixed sibling as a second
+  # hostname on the SAME route. The Sovereign wildcard DNS (*.<fqdn>) + wildcard
+  # TLS already cover it, so no per-Sovereign DNS/cert change is needed. Auth +
+  # self-links stay on gateway.host, so an entry via harbor.<fqdn> lands on the
+  # canonical registry.<fqdn> after login. Set false to serve ONLY gateway.host.
+  aliasHarborHost: true
+  # Additional hostnames the SAME HTTPRoute should answer on (beyond gateway.host
+  # and the auto-derived harbor.<fqdn> alias above). Empty entries and any entry
+  # equal to gateway.host are skipped. Each must be covered by the Gateway
+  # listener's wildcard hostname + TLS cert.
+  extraHosts: []
   path: "/"
   # Backend Service — defaults to <release>-harbor-core (harbor subchart core Service)
   backendService: ""

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -3284,7 +3284,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.2.40"
+  version: "1.2.41"
   visibility: unlisted
   card:
     title: "Harbor"
@@ -3308,7 +3308,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-harbor
-    version: "1.2.40"
+    version: "1.2.41"
   topology:
     supported:
     - active-hot-standby


### PR DESCRIPTION
## What

On the hw233 live walk, `https://harbor.hw233.omantel.biz/` returned a **bare-envoy 404** on every path (`/`, `/account/sign-in`, `/c/oidc/login`, `/api/v2.0/ping`) while `registry.hw233.omantel.biz` (OCI API) returned 200 and `bp-harbor`'s HelmRelease was Reconciled. Harbor UI/SSO appeared unreachable (UAT rows 32/111/181).

## Root cause — host-naming, not a missing route

The route is **not** missing. Harbor serves UI (`/`), registry-v2 (`/v2/`) and SSO all on **one** host: `registry.<fqdn>` — the value the bootstrap-kit slot wires into `gateway.host`, `harbor.externalURL`, and the Keycloak OIDC `redirect_uri` base. The app-named `harbor.<fqdn>` deliberately had **no** HTTPRoute hostname, so anyone reaching for the intuitive host hit envoy with no matching route → 404.

The Sovereign wildcard DNS `*.<fqdn>` resolves `harbor.<fqdn>` to the gateway VIP (hence a bare-envoy 404, not NXDOMAIN), and the wildcard listener (`*.${SOVEREIGN_FQDN}:443`, `clusters/_template/bootstrap-kit/01-cilium.yaml`) + wildcard TLS already cover it. This is the same class as the `bao.` vs `openbao.` and `pdns-admin.` vs `powerdns-admin.` sibling-host corrections. The blueprint already documented that the earlier `harbor.<sov>` endpoint value "pointed at a host with NO HTTPRoute → the console launch-url would 404" — the console launch button correctly opens `registry.<fqdn>`; the walk tripped on the intuitive `harbor.<fqdn>`.

## Fix

New value `gateway.aliasHarborHost` (default `true`) makes the **same** HTTPRoute also answer on the `harbor.`-prefixed sibling when `gateway.host` is `registry.`-prefixed. Both hosts now serve the UI with no per-Sovereign DNS or cert change (wildcard covers `harbor.<fqdn>`). The sign-in → `/c/oidc/login` redirect and `externalURL` stay on `registry.<fqdn>`, so an entry via `harbor.<fqdn>` lands on the canonical host after login — no redirect loop. Also adds `gateway.extraHosts` for arbitrary aliases.

Gateway stays DIRECT — no NodePort.

## Validation

- `helm template` with `gateway.host=registry.hw233.omantel.biz` renders `hostnames: [registry.hw233.omantel.biz, harbor.hw233.omantel.biz]`; the sign-in `RequestRedirect.hostname` stays `registry.<fqdn>`.
- Non-`registry.`-prefixed host → no alias (existing behavior preserved); `aliasHarborHost=false` → canonical host only; `gateway.enabled` unset → no HTTPRoute.
- `tests/httproute-render.sh` — all 6 cases pass (added Case 6 for the alias + opt-out + loop-safe redirect hostname).
- `scripts/check-bootstrap-kit-pin-sync.sh` → `OK bp-harbor: chart=1.2.41 pin=1.2.41`.
- `scripts/check-catalog-seed-lockstep.sh` → PASS.

## Lockstep (chart 1.2.40 → 1.2.41)

- `platform/harbor/chart/Chart.yaml`
- `platform/harbor/blueprint.yaml` (spec.version; endpoints.ui comment kept truthful — canonical launch host stays `registry.<fqdn>`)
- `clusters/_template/bootstrap-kit/19-harbor.yaml` (slot-19 pin)
- `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` (both pins)

Refs #4913

🤖 Generated with [Claude Code](https://claude.com/claude-code)