### PR TITLE
fix(#4921): grant catalyst-api RBAC to add per-Org console gateway listener

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1232,7 +1232,12 @@ spec:
       #   stamp spec.parameters.sovereignFqdn so the openova-MCP URL points at
       #   this Sovereign, not the mothership. catalyst-api + application-controller
       #   image fixes (deploy-bot pins on next build). Lockstep w/ Chart.yaml.
-      version: 1.4.1058
+      # 1.4.1059 — #4921: catalyst-api-cutover-driver ClusterRole gains PATCH
+      #   gateways + CREATE certificates/httproutes/organizations so the per-Org
+      #   console-https-<slug> listener actually lands on cilium-gateway-console
+      #   (was 403 -> NoMatchingListenerHostname -> per-Org front doors 000).
+      #   Lockstep w/ Chart.yaml.
+      version: 1.4.1059
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3444,7 +3444,15 @@ name: bp-catalyst-platform
 #   sovereign-fqdn) so GET /catalog/regions returns the Sovereign's REAL
 #   regions instead of [] — the marketplace BCP picker stops falling back to
 #   the hardcoded Hetzner list.
-version: 1.4.1058
+version: 1.4.1059
+# 1.4.1059 — #4921: grant catalyst-api-cutover-driver the four mutating verbs the
+#   per-Org finalisation path needs — PATCH gateways (SSA the per-Org
+#   console-https-<slug> listener onto cilium-gateway-console), CREATE
+#   certificates + httproutes (the per-Org console TLS trio) and CREATE
+#   organizations (the #3687 Organization CR mint). Without the gateway PATCH the
+#   per-Org listener was never added, so every per-Org HTTPRoute failed with
+#   NoMatchingListenerHostname and all per-Org front doors returned 000 (hw233).
+#   Bootstrap-kit slot-13 pin bumped in lockstep (pin-sync-audit gate).
 # 1.4.980 — #4696: SMTP host default mail.openova.io -> stalwart-web.stalwart.svc.cluster.local
 #           (in-cluster svc, matches auth.go code default) — kill flaky-upstream-DNS PIN-delivery 502s.
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/

--- a/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
+++ b/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
@@ -631,3 +631,52 @@ rules:
       - helmrepositories
       - helmcharts
     verbs: ["get", "list", "watch"]
+
+  # ───────────────────────────────────────────────────────────────
+  # Issue #4921 — PER-ORG CONSOLE TLS TRIO + Organization CR mint.
+  # The STSTenantRegistered → STSDone finalisation
+  # (org_tenant_org_cr.go createOrgOrganizationCR + org_console_tls.go
+  # provisionOrgConsoleTLS) mutates four cluster resources via THIS SA
+  # (catalyst-api runs permanently as catalyst-api-cutover-driver —
+  # api-deployment.yaml), but the ClusterRole granted only get/list/watch
+  # on all four kinds. So on every free-subdomain Org create catalyst-api
+  # 403'd (caught live hw233, dep aef1a818):
+  #
+  #   1. ensureOrgConsoleListener SSA-applies the per-Org
+  #      `console-https-<slug>`/`console-http-<slug>` listener pair
+  #      (hostname `*.<slug>.<parent>`) onto cilium-gateway-console
+  #      (kube-system) → needs PATCH on gateways. WITHOUT it the per-Org
+  #      listener is never added, so every per-Org HTTPRoute
+  #      (console/mail/openclaw/keycloak.<slug>.<parent>) fails attachment
+  #      with `NoMatchingListenerHostname` and the front door returns 000.
+  #      THIS is the #4921 root cause. (The console Gateway is pre-created
+  #      by the sovereign-tls Kustomization at Phase-1, so PATCH — the SSA
+  #      merge verb — is sufficient; the path never CREATEs a Gateway.)
+  #   2. ensureOrgConsoleCertificate CREATEs the per-Org wildcard
+  #      Certificate `org-wildcard-tls-<slug>-<parent>` in kube-system →
+  #      needs CREATE on certificates.cert-manager.io.
+  #   3. ensureOrgConsoleHTTPRoute CREATEs the per-Org console HTTPRoute
+  #      `catalyst-ui-<slug>-<parent>` in catalyst-system → needs CREATE
+  #      on httproutes.
+  #   4. createOrgOrganizationCR CREATEs the canonical cluster-scoped
+  #      Organization CR (orgs.openova.io/v1, #3687) → needs CREATE on
+  #      organizations.
+  #
+  # get/list/watch on certificates / gateways+httproutes / organizations
+  # are already granted above (#3978, QA-loop iter-11, Organization page);
+  # RBAC rules merge additively so only the missing mutating verbs are
+  # added here. Per feedback_rbac_create_no_resourcenames.md every `create`
+  # is in its own Rule WITHOUT resourceNames (a POST has no name to match).
+  # ───────────────────────────────────────────────────────────────
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates"]
+    verbs: ["create"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["gateways"]
+    verbs: ["patch"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes"]
+    verbs: ["create"]
+  - apiGroups: ["orgs.openova.io"]
+    resources: ["organizations"]
+    verbs: ["create"]


### PR DESCRIPTION
## Root cause

`kube-system/cilium-gateway-console` `Programmed=False reason=AddressNotAssigned` is a **red herring** — it is the same cosmetic hostNetwork-mode artifact as the owner gateway (both backing Services are `ClusterIP`, LB-IPAM never programs them; the console ELB forwards `:443/:80 → node:8443/:8080`). Proof on hw233: the Sovereign's own `console.hw233.omantel.biz` HTTPRoute is `Accepted=True` on that same Gateway.

The real break is **RBAC**. The catalyst-api Pod runs permanently as ServiceAccount `catalyst-api-cutover-driver` (`api-deployment.yaml`). Its ClusterRole granted only `get/list/watch` on gateways, httproutes, certificates and organizations, so the `STSTenantRegistered → STSDone` finalisation (`org_console_tls.go provisionOrgConsoleTLS` + `org_tenant_org_cr.go createOrgOrganizationCR`) 403'd on every free-subdomain Org create. Live log (hw233, dep `aef1a818`):

```
org-console-tls: Gateway listener apply failed — reconcile will retry
  gateways.gateway.networking.k8s.io "cilium-gateway-console" is forbidden:
  User "...catalyst-api-cutover-driver" cannot patch resource "gateways" in namespace "kube-system"
```

`ensureOrgConsoleListener` server-side-applies the per-Org `console-https-<slug>` listener (hostname `*.<slug>.<parent>`) onto `cilium-gateway-console`. Because the PATCH 403'd, that listener was never added, so every per-Org HTTPRoute (`console/mail/openclaw/keycloak.<slug>.<parent>`) failed attachment with `NoMatchingListenerHostname` → the front door returned **000**. Confirmed live: all three acme routes `Accepted=False / NoMatchingListenerHostname`.

## Fix

Add the four missing mutating verbs to `clusterrole-cutover-driver.yaml`:

| verb | resource | used by |
|---|---|---|
| `patch` | gateways.gateway.networking.k8s.io | SSA per-Org listener (**the 000 cause**) |
| `create` | certificates.cert-manager.io | per-Org wildcard cert |
| `create` | httproutes.gateway.networking.k8s.io | per-Org console route |
| `create` | organizations.orgs.openova.io | #3687 Organization CR mint |

Each `create` is its own Rule without `resourceNames` (`feedback_rbac_create_no_resourcenames.md`). gateways gets only `patch` (least-privilege — the console Gateway is pre-created by the sovereign-tls Kustomization; the path never CREATEs a Gateway). No NodePort involved — gateway serving is unchanged/DIRECT.

## Validation

- `helm template` + `kubectl kustomize` both render the ClusterRole with the new verbs (single file shared by both paths).
- **Live proof (hw233, dep `aef1a818`):** applied the additive grant; `kubectl auth can-i` for all four ops as `system:serviceaccount:catalyst-system:catalyst-api-cutover-driver` flipped `no → yes`.
- Chart version `1.4.1055 → 1.4.1056` (lockstep; bootstrap-kit slot-13 pin bumps in the private repo).

Refs #4921

🤖 Generated with [Claude Code](https://claude.com/claude-code)