### PR TITLE
fix(#4922): bound per-Org bp-agenity chart pin so the squatting 0.9.7 image can't be resolved

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
@@ -79,8 +79,14 @@ type OrganizationChartVersions struct {
 	Stalwart  string
 	NewAPI    string
 	// Agenity — the per-Org agentic dashboard (bp-agenity, #4180). Read
-	// from CATALYST_ORG_BP_AGENITY_VER; "*" when empty so Flux pulls the
-	// latest published chart (currently 0.5.4 / appVersion 0.9.6).
+	// from CATALYST_ORG_BP_AGENITY_VER; when empty it falls back to the
+	// BOUNDED range agenityChartConstraint (NOT "*"). Unlike every other
+	// per-Org chart, the bp-agenity OCI repo was historically polluted by
+	// the dashboard IMAGE (tag == appVersion 0.9.x) squatting the CHART
+	// repo before #4706 moved the image to ghcr.io/openova-io/agenity — an
+	// unbounded "*" resolves the HIGHEST semver tag and wrongly picks that
+	// 1-descriptor image over the real chart (#4922). See
+	// agenityChartConstraint.
 	Agenity string
 }
 
@@ -671,10 +677,36 @@ func renderOrganizationOverlay(rec store.OrganizationProvisionRecord, versions O
 	return out, nil
 }
 
+// agenityChartConstraint bounds the per-Org bp-agenity chart resolution to
+// the chart's current 0.5.x minor line instead of an unbounded "*". The
+// bp-agenity OCI repo was historically polluted: the dashboard IMAGE (tag ==
+// appVersion, e.g. 0.9.7) was pushed to the CHART repo before #4706-family
+// moved the image to ghcr.io/openova-io/agenity. A "*" pin resolves the
+// HIGHEST semver tag, so a lingering 0.9.7 image manifest (a 1-descriptor
+// Docker image) out-ranks the real 0.5.20 chart (a 2-descriptor Helm artifact)
+// and Flux dies with `manifest does not contain minimum number of descriptors
+// (2), found: 1` — bp-agenity never installs (#4922, UAT rows 218/219; the
+// same failure the #4706 Chart.yaml note describes). Bounding to <0.6.0 makes
+// the resolution DETERMINISTIC — a stray high-semver image tag can never be
+// picked, even before the squatting tags are pruned from ghcr.
+// Lockstep: bump this upper bound when the bp-agenity chart crosses a minor
+// (0.6.0), alongside products/agenity/blueprint.yaml spec.version + the
+// catalog-seed source.version.
+const agenityChartConstraint = ">=0.5.0 <0.6.0"
+
 func withVersionDefaults(v OrganizationChartVersions) OrganizationChartVersions {
 	star := func(s string) string {
 		if strings.TrimSpace(s) == "" {
 			return "*"
+		}
+		return s
+	}
+	// bounded falls back to a SemVer RANGE (not "*") for charts whose OCI
+	// repo can carry a higher-semver NON-chart tag that "*" would wrongly
+	// resolve. An explicit env-provided version still wins verbatim.
+	bounded := func(s, fallback string) string {
+		if strings.TrimSpace(s) == "" {
+			return fallback
 		}
 		return s
 	}
@@ -685,7 +717,7 @@ func withVersionDefaults(v OrganizationChartVersions) OrganizationChartVersions 
 		OpenClaw:  star(v.OpenClaw),
 		Stalwart:  star(v.Stalwart),
 		NewAPI:    star(v.NewAPI),
-		Agenity:   star(v.Agenity),
+		Agenity:   bounded(v.Agenity, agenityChartConstraint),
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
@@ -432,6 +432,54 @@ func TestDeleteOrganization_RemovesFromRegistry(t *testing.T) {
 	}
 }
 
+// TestRenderOrganizationOverlay_AgenityChartVersionBounded is the #4922 guard.
+// The bp-agenity per-Org HelmRelease MUST pin a BOUNDED SemVer range
+// (>=0.5.0 <0.6.0), never the unbounded "*". The bp-agenity CHART OCI repo was
+// historically squatted by the dashboard IMAGE (tag == appVersion 0.9.7, a
+// 1-descriptor Docker manifest) before #4706 moved the image to
+// ghcr.io/openova-io/agenity. A "*" pin resolves the HIGHEST semver tag, so
+// that lingering image (0.9.7 > 0.5.20 chart) out-ranks the real chart and
+// Flux dies with "manifest does not contain minimum number of descriptors (2),
+// found: 1" — bp-agenity never installs (rows 218/219). The bound makes the
+// resolution deterministic even before the squatting tags are pruned. An
+// explicit CATALYST_ORG_BP_AGENITY_VER still wins verbatim.
+func TestRenderOrganizationOverlay_AgenityChartVersionBounded(t *testing.T) {
+	rec := store.OrganizationProvisionRecord{
+		OrganizationID:  "t-acme",
+		Subdomain:       "acme",
+		DomainMode:      store.OrganizationDomainFreeSubdomain,
+		AdminEmail:      "admin@acme.test",
+		OTECHFQDN:       "otech.example",
+		ParentDomain:    "omani.homes",
+		TenantNamespace: "org-t-acme",
+	}
+
+	// Unconfigured version → the bounded range, NOT "*".
+	files, err := renderOrganizationOverlay(rec, OrganizationChartVersions{})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body, ok := files["bp-agenity.yaml"]
+	if !ok {
+		t.Fatalf("bp-agenity.yaml missing")
+	}
+	if !strings.Contains(body, `version: ">=0.5.0 <0.6.0"`) {
+		t.Errorf("bp-agenity.yaml must pin the bounded chart range, got:\n%s", body)
+	}
+	if strings.Contains(body, `version: "*"`) {
+		t.Errorf("bp-agenity.yaml must NOT pin the unbounded \"*\" (would resolve the squatting 0.9.7 image, #4922):\n%s", body)
+	}
+
+	// An explicit env-provided version still wins verbatim.
+	filesPinned, err := renderOrganizationOverlay(rec, OrganizationChartVersions{Agenity: "0.5.20"})
+	if err != nil {
+		t.Fatalf("render pinned: %v", err)
+	}
+	if !strings.Contains(filesPinned["bp-agenity.yaml"], `version: "0.5.20"`) {
+		t.Errorf("explicit Agenity version should render verbatim, got:\n%s", filesPinned["bp-agenity.yaml"])
+	}
+}
+
 // TestRenderOrganizationOverlay_AgenityMCPBearerWiring is the #4276 hop 7/7b
 // emitter guard. The bp-agenity overlay MUST set openovaMCP.bearerSecret +
 // rs256PubkeySecret + enable the per-Org mcpBearer ExternalSecret pointed at

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5972,9 +5972,14 @@ spec:
 # Fresh provs seed THIS pin,
 # so the chart-version here gates which image a new Sovereign installs — bump
 # in lockstep with the chart on every agenity release. (The per-Org install
-# in organization_gitops.go pins `*` and so auto-resolves the newest published
-# chart; this seed pin is the catalog-card version a fresh prov shows +
-# installs.)
+# in organization_gitops.go pins the BOUNDED range `>=0.5.0 <0.6.0`
+# (agenityChartConstraint), NOT `*`: the bp-agenity CHART repo was historically
+# squatted by the dashboard IMAGE tag (appVersion 0.9.7) before #4706 moved the
+# image to ghcr.io/openova-io/agenity, and an unbounded `*` wrongly resolved
+# that 1-descriptor image over the chart → "manifest does not contain minimum
+# number of descriptors (2), found: 1" (#4922). The bound resolves to the
+# newest 0.5.x chart deterministically. This seed pin is the catalog-card
+# version a fresh prov shows + installs.)
 apiVersion: catalyst.openova.io/v1
 kind: Blueprint
 metadata:


### PR DESCRIPTION
## Problem

`bp-agenity:0.9.7` OCI pull fails with `manifest does not contain minimum number of descriptors (2), found: 1`, so bp-agenity never installs (hw233 walk, UAT rows 218/219).

## Root cause — NOT a chart-packaging bug, NOT a current CI bug

- `bp-agenity:0.9.7` is the dashboard **IMAGE** manifest (config `vnd.docker.container.image.v1+json`, 13 rootfs layers) that **squatted the `bp-agenity` CHART OCI repo** before the #4706-family move relocated the image to `ghcr.io/openova-io/agenity`.
- `bp-agenity:0.5.20` — the real chart — is a **valid 2-descriptor** Helm artifact (verified via `skopeo inspect --raw`: config `vnd.cncf.helm.config.v1+json` + one `helm.chart.content` layer). The `blueprint-release` chart-publish workflow uses `helm package` + `helm push` + a `helm pull` verify-back — it is correct.
- The current `agenity-build.yaml` already pushes the image to `ghcr.io/openova-io/agenity` (`IMAGE:` env), so **no new squat can occur**.
- The residual defect: the per-Org install in `organization_gitops.go` rendered `version: "*"`, which Flux resolves to the **highest semver tag** on the repo. Because `0.9.7` (image) > `0.5.20` (chart), `*` picked the 1-descriptor image and the pull failed. The #4706 note promised the squatting `0.9.7`/`latest` tags would be pruned, but they were never deleted — they are still present on the package.

## Fix

The per-Org `bp-agenity` chart default falls back to the **bounded range `>=0.5.0 <0.6.0`** (`agenityChartConstraint`) instead of `*`. Resolution is now deterministic: the `0.9.x` image tag is excluded and the newest `0.5.x` chart (`0.5.20`) is chosen — **even while the squatting tags remain in ghcr**. This is more robust than deleting the tag (a future mis-push can't undo an in-repo pin). An explicit `CATALYST_ORG_BP_AGENITY_VER` still wins verbatim.

- `organization_gitops.go` — `withVersionDefaults` bounds the Agenity fallback; new `agenityChartConstraint` const with rationale + lockstep note.
- `organization_provisioning_test.go` — `TestRenderOrganizationOverlay_AgenityChartVersionBounded` asserts the overlay pins the bounded range, never `*`, and that an explicit version is honored verbatim.
- catalog-seed `blueprints.yaml` — comment updated (the seed `source.version`/`spec.version` stay `0.5.20`, unchanged).

## Verification

- `go build ./...` clean; `go vet ./internal/handler/` clean.
- Full `internal/handler` test package passes (exit 0); new guard test passes.

## Optional follow-up (operational, not in this PR)

Prune the historical squatting versions from the `bp-agenity` package (`0.9.7`/`latest`/`270e535`, package-version id `982418152`) to honor the #4706 promise. Not required for this fix — the bounded pin already excludes them. Left out to avoid a shared-registry mutation with blast radius on live envs still on pre-0.5.20 charts (whose StatefulSets reference `ghcr.io/openova-io/bp-agenity:0.9.7` as their image).

Refs #4922

🤖 Generated with [Claude Code](https://claude.com/claude-code)