### PR TITLE
fix(#4923): DR replication-status reads live CNPGPair, not synthesized Hetzner placeholder

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras.go
@@ -35,6 +35,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -237,13 +238,13 @@ func (h *Handler) HandleContinuumReplicationStatus(w http.ResponseWriter, r *htt
 		writeNotFound(w, depID)
 		return
 	}
-	resp := synthesizedReplicationStatus(name, "qa-omantel")
+	ns := strings.TrimSpace(r.URL.Query().Get("namespace"))
+	resp := pendingReplicationStatus(name, ns)
 	client, err := h.sovereignDynamicClient(dep)
 	if err != nil {
 		writeJSON(w, http.StatusOK, resp)
 		return
 	}
-	ns := strings.TrimSpace(r.URL.Query().Get("namespace"))
 	cr, getErr := getContinuumCR(r.Context(), client, name, ns)
 	if getErr != nil {
 		if !apierrors.IsNotFound(getErr) {
@@ -310,6 +311,15 @@ func (h *Handler) HandleContinuumReplicationStatus(w http.ResponseWriter, r *htt
 			}
 		}
 	}
+	// #4923 — the Continuum CR / linked CNPGPair status frequently omit
+	// syncState (and a spine CR carries none), so enrich defaulted it to a
+	// misleading "async". Read the AUTHORITATIVE synchronous posture straight
+	// off the live CNPG cluster-pair backing the app: CNPG renders
+	// `synchronous_standby_names = FIRST N (...)` (sync_state=sync, RPO=0) only
+	// when the primary half declares spec.postgresql.synchronous. No-op when no
+	// 2-region pair resolves (e.g. openbao-raft spine continuums).
+	h.augmentReplicationSyncFromLivePair(
+		r.Context(), client, appNameFromContinuumName(cr.GetName()), cr.GetNamespace(), &resp)
 	resp.Source = "live"
 	resp.ObservedAt = h.continuumNow().UTC().Format(time.RFC3339)
 	writeJSON(w, http.StatusOK, resp)
@@ -596,23 +606,18 @@ func (h *Handler) HandleDRReplicationStatus(w http.ResponseWriter, r *http.Reque
 		Sovereign:  depID,
 		Continuums: []continuumReplicationStatus{},
 		ObservedAt: h.continuumNow().UTC().Format(time.RFC3339),
-		Source:     "synthesized",
+		Source:     "pending",
 	}
 	client, err := h.sovereignDynamicClient(dep)
 	if err != nil {
-		out.Continuums = append(out.Continuums, synthesizedReplicationStatus("cont-omantel", "qa-omantel"))
-		out.ContinuumCount = 1
-		out.ReplicasHealthy = 1
-		out.MaxWALLagSeconds = 2.0
+		// #4923 — honest empty roll-up (source:pending). NEVER a fabricated
+		// 1-healthy / 2s-lag / Hetzner row that misreports the Sovereign's DR
+		// posture when the live status is simply not observable yet.
 		writeJSON(w, http.StatusOK, out)
 		return
 	}
 	list, lerr := client.Resource(ContinuumGVR()).Namespace("").List(r.Context(), metav1.ListOptions{})
 	if lerr != nil || len(list.Items) == 0 {
-		out.Continuums = append(out.Continuums, synthesizedReplicationStatus("cont-omantel", "qa-omantel"))
-		out.ContinuumCount = 1
-		out.ReplicasHealthy = 1
-		out.MaxWALLagSeconds = 2.0
 		writeJSON(w, http.StatusOK, out)
 		return
 	}
@@ -990,7 +995,15 @@ func (h *Handler) liveReplicationStatusFromCNPGPair(
 	healthy, _ := rec.Status["replicationHealthy"].(bool)
 	lag := readNumericNested(map[string]interface{}{"status": rec.Status}, "status", "replicationLagSeconds")
 	streaming := "streaming"
+	// #4923 — real syncState from the live CNPG cluster-pair. deriveLive-
+	// ContinuumRecord stamps status.syncReplication=true when the primary half
+	// declares spec.postgresql.synchronous (CNPG renders
+	// `synchronous_standby_names = FIRST N (...)`, sync_state=sync, RPO=0). The
+	// prior hardcoded "async" mislabelled a synchronous RPO=0 pair as async.
 	syncState := "async"
+	if sr, _ := rec.Status["syncReplication"].(bool); sr {
+		syncState = "sync"
+	}
 	if !healthy {
 		streaming = "catching-up"
 	}
@@ -1020,6 +1033,44 @@ func (h *Handler) liveReplicationStatusFromCNPGPair(
 	return out, true
 }
 
+// augmentReplicationSyncFromLivePair upgrades a replication-status response
+// with the REAL synchronous posture (+ regions when the CR left them blank)
+// read straight off the live CNPG cluster-pair backing the app. #4923.
+//
+// CNPG renders `synchronous_standby_names = FIRST N (...)` — sync_state=sync,
+// replay_lag=0, RPO=0 — ONLY when the primary half declares
+// spec.postgresql.synchronous (the bp-cnpg-pair chart sets it when
+// replication.mode=sync). That is the authoritative sync/async signal; the
+// Continuum CR and the dr.openova.io CNPGPair status often omit syncState, so
+// enrichReplicationStatus otherwise defaults it to a misleading "async" on a
+// genuinely synchronous pair. No-op when no 2-region pair resolves (e.g. the
+// openbao-raft spine continuums carry no cnpg pair) so their observed status
+// is left untouched.
+func (h *Handler) augmentReplicationSyncFromLivePair(
+	ctx context.Context,
+	client dynamic.Interface,
+	appName, ns string,
+	resp *continuumReplicationStatus,
+) {
+	st, err := h.findCNPGPairForApp(ctx, client, appName, ns)
+	if err != nil || st == nil {
+		return
+	}
+	if st.SyncReplication {
+		resp.SyncState = "sync"
+	} else {
+		resp.SyncState = "async"
+	}
+	// Fill regions the CR-derived enrich left blank from the live cluster
+	// placement labels (never a Hetzner placeholder).
+	if resp.PrimaryRegion == "" && st.PrimaryRegion != "" {
+		resp.PrimaryRegion = st.PrimaryRegion
+	}
+	if resp.CurrentPrimary == "" {
+		resp.CurrentPrimary = resp.PrimaryRegion
+	}
+}
+
 // gatePass maps a bool to the health-gate status vocabulary.
 func gatePass(ok bool) string {
 	if ok {
@@ -1028,30 +1079,53 @@ func gatePass(ok bool) string {
 	return "Warn"
 }
 
-func synthesizedReplicationStatus(name, ns string) continuumReplicationStatus {
+// pendingReplicationStatus is the HONEST shape returned when the live
+// cnpg-pair replication status is not yet observable (dynamic client
+// bootstrapping, no Continuum CR, no resolvable 2-region pair). #4923.
+//
+// It NEVER fabricates data. The prior `synthesizedReplicationStatus`
+// hardcoded Hetzner regions (`hz-fsn-rtz-prod` / `hz-hel-rtz-prod`) on a
+// Huawei-only Sovereign, a byte-identical `walLagSeconds:2 / walLagBytes:8192`
+// for EVERY app, and `syncState:async` — flatly contradicting the live truth
+// (`pg_stat_replication`: `sync_state=sync`, `replay_lag=0`,
+// `synchronous_standby_names=FIRST 1`). That misled the operator into reading
+// async / wrong-cloud / 2s-lag when reality was synchronous RPO=0.
+//
+// This replacement carries ONLY facts we actually know at fallback time: the
+// Sovereign's REAL configured regions (from SOVEREIGN_PRIMARY_REGION /
+// SOVEREIGN_REPLICA_REGION, threaded in by bp-catalyst-platform from the
+// sovereign-fqdn ConfigMap — empty when genuinely unknown, NEVER a Hetzner
+// placeholder), zero lag (unknown, not a fake 2s), empty sync/streaming state
+// (unknown), and `source:"pending"` so the UI's "NOT LIVE" gate holds without
+// drawing wrong-cloud regions or invented lag. Region derivation is the same
+// env pair `chrootRegionsFromPrimaryReplicaEnv` reads.
+func pendingReplicationStatus(name, ns string) continuumReplicationStatus {
+	primary := strings.TrimSpace(os.Getenv("SOVEREIGN_PRIMARY_REGION"))
+	replica := strings.TrimSpace(os.Getenv("SOVEREIGN_REPLICA_REGION"))
+	replicas := []continuumReplicaInfo{}
+	if replica != "" && replica != primary {
+		replicas = append(replicas, continuumReplicaInfo{
+			Region: replica,
+			Role:   "replica",
+		})
+	}
 	return continuumReplicationStatus{
 		Continuum:         name,
 		Namespace:         ns,
-		PrimaryRegion:     "hz-fsn-rtz-prod",
-		CurrentPrimary:    "hz-fsn-rtz-prod",
-		WALLagSeconds:     2.0,
-		WALLagBytes:       8192,
-		ReplicaPromotable: true,
-		StreamingState:    "streaming",
-		SyncState:         "async",
-		LastHeartbeat:     time.Now().UTC().Format(time.RFC3339),
-		Replicas: []continuumReplicaInfo{
-			{Region: "hz-hel-rtz-prod", Role: "replica", LagSeconds: 2.0,
-				LastHeartbeat: time.Now().UTC().Format(time.RFC3339)},
-		},
+		PrimaryRegion:     primary,
+		CurrentPrimary:    primary,
+		WALLagSeconds:     0,
+		WALLagBytes:       0,
+		ReplicaPromotable: false,
+		StreamingState:    "",
+		SyncState:         "",
+		Replicas:          replicas,
 		HealthGates: []continuumHealthGate{
-			{Name: "streaming-replication", Status: "Pass", Severity: "info",
-				Message: "synthesized: live cnpgpair status not yet available"},
-			{Name: "wal-lag-under-rpo", Status: "Pass", Severity: "info"},
-			{Name: "lease-witness-quorum", Status: "Pass", Severity: "info"},
+			{Name: "live-status", Status: "Warn", Severity: "info",
+				Message: "live cnpg-pair replication status not yet available; awaiting region-b convergence"},
 		},
 		ObservedAt: time.Now().UTC().Format(time.RFC3339),
-		Source:     "synthesized",
+		Source:     "pending",
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras_4551_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras_4551_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -120,10 +121,13 @@ func TestReplicationStatus_DerivesLiveFromCNPGPairWhenNoCR(t *testing.T) {
 }
 
 // A single-region pair (both halves same region) must NOT be passed off as
-// live cross-region DR — the synthesized fallback stands (honest).
+// live cross-region DR — the HONEST pending fallback stands. #4923: that
+// fallback must NEVER fabricate Hetzner regions or a fake 2s/8192 lag; it
+// carries the Sovereign's real configured regions (empty here — no env set)
+// and zero lag, with source:"pending" so the UI's NOT-LIVE gate holds.
 func TestReplicationStatus_NoLivePairSingleRegionFallsBack(t *testing.T) {
 	h := NewWithPDM(silentLogger(), &fakePDM{})
-	primary, replica := newCNPGPairFixture("shared-pg", "catalyst-system", "hz-fsn-rtz-prod", "hz-fsn-rtz-prod")
+	primary, replica := newCNPGPairFixture("shared-pg", "catalyst-system", "me-east-215-a", "me-east-215-a")
 	factory, _ := fakeContinuumDynamicFactory(primary, replica)
 	h.dynamicFactory = factory
 	dep := installUserAccessDeployment(t, h, "dep-repl-single")
@@ -142,10 +146,163 @@ func TestReplicationStatus_NoLivePairSingleRegionFallsBack(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	// No genuine cross-region pair → synthesized fallback (not a fabricated
-	// "live").
-	if resp.Source != "synthesized" {
-		t.Errorf("source: got %q want synthesized (no real cross-region pair)", resp.Source)
+	// No genuine cross-region pair → honest pending fallback (not a fabricated
+	// "live", and NOT the old "synthesized" Hetzner shape).
+	if resp.Source != "pending" {
+		t.Errorf("source: got %q want pending (no real cross-region pair)", resp.Source)
+	}
+	// The fabricated Hetzner constants must be GONE.
+	for _, banned := range []string{"hz-fsn-rtz-prod", "hz-hel-rtz-prod"} {
+		if resp.PrimaryRegion == banned || resp.CurrentPrimary == banned {
+			t.Errorf("fallback leaked Hetzner region %q on a Huawei Sovereign", banned)
+		}
+		for _, rep := range resp.Replicas {
+			if rep.Region == banned {
+				t.Errorf("fallback replica leaked Hetzner region %q", banned)
+			}
+		}
+	}
+	// The byte-identical fake lag must be GONE.
+	if resp.WALLagSeconds != 0 || resp.WALLagBytes != 0 {
+		t.Errorf("fallback fabricated lag: walLagSeconds=%v walLagBytes=%d (want 0/0)",
+			resp.WALLagSeconds, resp.WALLagBytes)
+	}
+}
+
+// #4923 — when no Continuum CR and no live cnpg-pair resolve, the honest
+// pending fallback still derives the primary/replica regions from the
+// Sovereign's REAL configured regions (SOVEREIGN_PRIMARY_REGION /
+// SOVEREIGN_REPLICA_REGION, threaded in by bp-catalyst-platform), NEVER from
+// a hardcoded Hetzner placeholder.
+func TestReplicationStatus_PendingFallbackDerivesRegionsFromDeployment(t *testing.T) {
+	t.Setenv("SOVEREIGN_PRIMARY_REGION", "me-east-215-a")
+	t.Setenv("SOVEREIGN_REPLICA_REGION", "me-east-215-b")
+
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	// No cnpg-pair, no Continuum CR — forces the pending fallback.
+	factory, _ := fakeContinuumDynamicFactory()
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-repl-pending-regions")
+
+	r := chi.NewRouter()
+	registerReplicationStatusRoute(r, h)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/continuum/dr-catalyst-platform/replication-status", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp continuumReplicationStatus
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Source != "pending" {
+		t.Fatalf("source: got %q want pending", resp.Source)
+	}
+	// Regions derive from the deployment's real (Huawei) regions — NOT Hetzner.
+	if resp.PrimaryRegion != "me-east-215-a" {
+		t.Errorf("primaryRegion: got %q want me-east-215-a (from SOVEREIGN_PRIMARY_REGION)", resp.PrimaryRegion)
+	}
+	var sawReplica bool
+	for _, rep := range resp.Replicas {
+		if rep.Region == "me-east-215-b" {
+			sawReplica = true
+		}
+		if strings.HasPrefix(rep.Region, "hz-") {
+			t.Errorf("replica leaked a Hetzner region %q", rep.Region)
+		}
+	}
+	if !sawReplica {
+		t.Errorf("replicas: missing derived replica region me-east-215-b; got %+v", resp.Replicas)
+	}
+	if resp.WALLagSeconds != 0 || resp.WALLagBytes != 0 {
+		t.Errorf("pending fallback must not fabricate lag; got %v/%d", resp.WALLagSeconds, resp.WALLagBytes)
+	}
+}
+
+// #4923 — the live path must report syncState=sync when the primary CNPG
+// cluster declares synchronous replication (spec.postgresql.synchronous →
+// `synchronous_standby_names = FIRST N (...)`, RPO=0), and it must derive the
+// regions from the live CLUSTER placement labels (me-east-215-a/-b), NOT the
+// old hardcoded Hetzner constants. Fixture: a real 2-region cnpg-pair whose
+// primary half carries the synchronous block, no Continuum CR (derive path).
+func TestReplicationStatus_LiveSyncStateFromSynchronousCNPGPair(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	primary, replica := newCNPGPairFixture("shared-pg", "catalyst-system", "me-east-215-a", "me-east-215-b")
+	// Primary declares synchronous replication — the bp-cnpg-pair sync mode.
+	_ = unstructured.SetNestedMap(primary.Object, map[string]interface{}{
+		"method":         "first",
+		"number":         int64(1),
+		"dataDurability": "required",
+	}, "spec", "postgresql", "synchronous")
+	factory, _ := fakeContinuumDynamicFactory(primary, replica)
+	h.dynamicFactory = factory
+	fixed := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	h.SetContinuumClock(func() time.Time { return fixed })
+	dep := installUserAccessDeployment(t, h, "dep-repl-sync")
+
+	r := chi.NewRouter()
+	registerReplicationStatusRoute(r, h)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/continuum/dr-shared-pg/replication-status?namespace=catalyst-system", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp continuumReplicationStatus
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Source != "live" {
+		t.Errorf("source: got %q want live", resp.Source)
+	}
+	// Regions derived from the CLUSTER placement labels, never Hetzner.
+	if resp.PrimaryRegion != "me-east-215-a" {
+		t.Errorf("primaryRegion: got %q want me-east-215-a (from cluster label)", resp.PrimaryRegion)
+	}
+	if strings.HasPrefix(resp.PrimaryRegion, "hz-") {
+		t.Errorf("primaryRegion leaked Hetzner: %q", resp.PrimaryRegion)
+	}
+	// syncState reflects the synchronous config, NOT a hardcoded async.
+	if resp.SyncState != "sync" {
+		t.Errorf("syncState: got %q want sync (spec.postgresql.synchronous is set → RPO=0)", resp.SyncState)
+	}
+}
+
+// #4923 — the mirror of the sync case: a pair WITHOUT the synchronous block
+// (forensic async mode) reports syncState=async off the same live path, so the
+// signal is genuinely derived, not hardcoded either way.
+func TestReplicationStatus_LiveAsyncStateWhenNoSynchronousBlock(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	primary, replica := newCNPGPairFixture("shared-pg", "catalyst-system", "me-east-215-a", "me-east-215-b")
+	// No spec.postgresql.synchronous on the primary → async.
+	factory, _ := fakeContinuumDynamicFactory(primary, replica)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-repl-async")
+
+	r := chi.NewRouter()
+	registerReplicationStatusRoute(r, h)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/continuum/dr-shared-pg/replication-status?namespace=catalyst-system", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp continuumReplicationStatus
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Source != "live" {
+		t.Errorf("source: got %q want live", resp.Source)
+	}
+	if resp.SyncState != "async" {
+		t.Errorf("syncState: got %q want async (no synchronous block)", resp.SyncState)
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/continuum_live.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_live.go
@@ -137,6 +137,12 @@ type cnpgPairState struct {
 	// PrimaryReady / ReplicaReady — each half's Ready condition.
 	PrimaryReady bool
 	ReplicaReady bool
+
+	// SyncReplication reflects whether the PRIMARY half declares synchronous
+	// replication (spec.postgresql.synchronous present) — the RPO=0 durability
+	// posture that makes CNPG render `synchronous_standby_names = FIRST N (...)`
+	// (sync_state=sync in pg_stat_replication). False for async/lab pairs. #4923.
+	SyncReplication bool
 }
 
 // findCNPGPairForApp discovers the cnpg cluster-pair backing an
@@ -262,6 +268,7 @@ func (h *Handler) findCNPGPairForApp(
 	st.PrimaryReady = cnpgClusterReady(hv.primary)
 	st.ReplicaReady = cnpgClusterReady(hv.replica)
 	st.LagSeconds = cnpgClusterLag(hv.replica)
+	st.SyncReplication = cnpgClusterSynchronous(hv.primary)
 	// Healthy = the standby half is Ready and still in replica mode
 	// (actively following WAL). If replica.enabled flipped to false the
 	// pair is mid/post-switchover — not "healthy steady-state".
@@ -301,6 +308,36 @@ func cnpgClusterLag(cr *unstructured.Unstructured) int {
 		return int(lag)
 	}
 	return 0
+}
+
+// cnpgClusterSynchronous reports whether the PRIMARY half of a cnpg-pair
+// declares synchronous replication. CNPG renders
+// `synchronous_standby_names = FIRST N ("<replica>")` — the RPO=0 durability
+// posture (sync_state=sync in pg_stat_replication) — ONLY when
+// spec.postgresql.synchronous is present. The bp-cnpg-pair chart sets that
+// block (method:first + number:N + standbyNamesPre:[<replica>]) when
+// replication.mode=sync and OMITS it for the forensic "async" mode. Mirrors
+// the chart contract at platform/cnpg-pair/chart/templates/primary-cluster.yaml.
+// #4923.
+func cnpgClusterSynchronous(primary *unstructured.Unstructured) bool {
+	if primary == nil {
+		return false
+	}
+	sync, found, err := unstructured.NestedMap(primary.Object, "spec", "postgresql", "synchronous")
+	if err != nil || !found || len(sync) == 0 {
+		return false
+	}
+	// A synchronous block with a positive `number` forces N synchronous
+	// standbys — the unambiguous sync signal.
+	if n, ok, _ := unstructured.NestedInt64(sync, "number"); ok && n > 0 {
+		return true
+	}
+	// A `method` (first | any) present is likewise sufficient.
+	if m, _, _ := unstructured.NestedString(sync, "method"); strings.TrimSpace(m) != "" {
+		return true
+	}
+	// Any non-empty synchronous block declares synchronous intent.
+	return true
 }
 
 // cnpgClusterReadyInstances reports status.readyInstances (the count of a
@@ -574,7 +611,11 @@ func (h *Handler) deriveLiveContinuumRecord(
 			"replicationLagSeconds": int64(st.LagSeconds),
 			"currentPrimary":        st.CurrentPrimary,
 			"cnpgPair":              st.PairName,
-			"observedAt":            h.continuumNow().UTC().Format(time.RFC3339),
+			// #4923 — the live synchronous posture (RPO=0 when true), read off
+			// the primary half's spec.postgresql.synchronous. Consumed by
+			// liveReplicationStatusFromCNPGPair to report syncState honestly.
+			"syncReplication": st.SyncReplication,
+			"observedAt":      h.continuumNow().UTC().Format(time.RFC3339),
 		},
 	}
 	return rec, true


### PR DESCRIPTION
## Problem (#4923)

`GET /api/v1/sovereigns/{dep}/continuum/dr-<app>/replication-status` returned an **identical fabricated payload for every app**:

- `primaryRegion: hz-fsn-rtz-prod` + replica `hz-hel-rtz-prod` — **Hetzner regions on a Huawei-only Sovereign**
- `walLagSeconds: 2`, `walLagBytes: 8192` — byte-identical across catalyst-platform / continuum / keycloak / powerdns / gitea
- `syncState: async`, `source: "synthesized"`

This flatly contradicted the live truth verified via `pg_stat_replication` on the cnpg-pair primary: `sync_state=sync`, `replay_lag=0`, `synchronous_standby_names=FIRST 1`, `synchronous_commit=remote_apply` — **synchronous RPO=0**, not async. The DR panel drew async / wrong-cloud / 2s-lag when reality was sync / Huawei / 0-lag.

## Where the synthesized payload lived

`products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras.go` — `synthesizedReplicationStatus()` hardcoded the Hetzner regions + `walLagSeconds:2 / walLagBytes:8192 / syncState:async / source:"synthesized"`. It was the fallback in `HandleContinuumReplicationStatus` (and the `HandleDRReplicationStatus` aggregate), reached whenever no Continuum CR by name/applicationRef and no app-labelled live cnpg-pair resolved — which is every platform (spine) continuum on a real Sovereign.

Separately, the live derive path `liveReplicationStatusFromCNPGPair()` **hardcoded `syncState := "async"`**, and `enrichReplicationStatus()` defaulted `syncState` to `"async"` — so even the live path mislabelled a synchronous RPO=0 pair.

## Fix

- **Removed the synthesized Hetzner constants entirely.** Replaced with `pendingReplicationStatus()` — an honest shape that carries only known facts: the Sovereign's **real** configured regions from `SOVEREIGN_PRIMARY_REGION` / `SOVEREIGN_REPLICA_REGION` (empty when unknown, **never Hetzner**), zero lag (not a fake 2s), empty sync/streaming state, `source:"pending"`. The UI's NOT-LIVE gate keys off `source != "live"`, so it still gates — but no longer draws wrong-cloud regions or invented lag.
- **Real `syncState` from the live CNPG cluster-pair.** New `cnpgClusterSynchronous()` reads the primary half's `spec.postgresql.synchronous` (CNPG renders `synchronous_standby_names = FIRST N (...)` only when present — the RPO=0 signal, per `platform/cnpg-pair/chart/templates/primary-cluster.yaml`). Threaded through `cnpgPairState.SyncReplication` -> `deriveLiveContinuumRecord` status -> `liveReplicationStatusFromCNPGPair`.
- **`augmentReplicationSyncFromLivePair()`** upgrades the CR-found path's `syncState` (and blank regions) off the live pair, since spine Continuum CRs / the `dr.openova.io` CNPGPair status frequently omit `syncState`. No-op for openbao-raft spine continuums (no cnpg pair).
- **DR aggregate** roll-up returns an honest empty pending shape instead of a fake `1-healthy / 2s-lag` row.

## Tests

`go build ./... && go vet ./...` clean. New tests (run under `-race -p 1`):

- `TestReplicationStatus_PendingFallbackDerivesRegionsFromDeployment` — regions derive from the deployment env (Huawei `me-east-215-a/-b`), never Hetzner; zero lag; `source:"pending"`.
- `TestReplicationStatus_LiveSyncStateFromSynchronousCNPGPair` — `syncState=sync` when `spec.postgresql.synchronous` is set; regions from cluster labels, not Hetzner.
- `TestReplicationStatus_LiveAsyncStateWhenNoSynchronousBlock` — `syncState=async` when the block is absent (genuinely derived, not hardcoded).
- Updated `TestReplicationStatus_NoLivePairSingleRegionFallsBack` — asserts `source:"pending"`, no leaked Hetzner regions, zero fabricated lag.

Refs #4923 #4905 #3986

🤖 Generated with [Claude Code](https://claude.com/claude-code)