### PR TITLE
fix(#4919): signup PIN never sends — org-services SMTP auto-roll + marketplace-api relay

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1232,7 +1232,7 @@ spec:
       #   stamp spec.parameters.sovereignFqdn so the openova-MCP URL points at
       #   this Sovereign, not the mothership. catalyst-api + application-controller
       #   image fixes (deploy-bot pins on next build). Lockstep w/ Chart.yaml.
-      version: 1.4.1057
+      version: 1.4.1058
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,17 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.1058 — #4919 (Refs #4749): the REAL hw233 funnel row-84 fix (Pillar-1) —
+#   deterministically roll org-services/{auth,notification} onto the SMTP relay when
+#   the seed lands. Those Pods read SMTP_* from org-services-secrets via secretKeyRef,
+#   which the kubelet freezes at Pod start; sovereign_smtp_seed.go seeds the relay
+#   (mail.openova.io) ASYNC, so on a fresh prov a Pod can start before it and keep
+#   stale-EMPTY SMTP env even after org-services-secrets is baked correct on the next
+#   reconcile (#934) — POST /auth/magic-link then silently no-sends the anonymous
+#   signup PIN until an unrelated reconcile happens to roll the Pod. New helper
+#   catalyst.orgSmtpChecksum (_smtp-helpers.tpl) hashes the seed and is stamped as a
+#   checksum/smtp-config Pod annotation on auth + notification so Flux rolls them the
+#   moment the seed appears. Gated by tests/org-services-smtp-autoroll-contract.sh.
+#   (1.4.1055 shipped the sibling marketplace-api SMTP repoint.)
 # 1.4.1055 — #4919 (Refs #4749): marketplace-api SMTP env now sources the durable
 #   catalyst-system/sovereign-smtp-credentials seed (#4748/#4749 → mail.openova.io:587)
 #   via secretKeyRef (smtp-host/-port/-from/-user/-pass, all optional:true) instead of
@@ -3432,7 +3444,7 @@ name: bp-catalyst-platform
 #   sovereign-fqdn) so GET /catalog/regions returns the Sovereign's REAL
 #   regions instead of [] — the marketplace BCP picker stops falling back to
 #   the hardcoded Hetzner list.
-version: 1.4.1057
+version: 1.4.1058
 # 1.4.980 — #4696: SMTP host default mail.openova.io -> stalwart-web.stalwart.svc.cluster.local
 #           (in-cluster svc, matches auth.go code default) — kill flaky-upstream-DNS PIN-delivery 502s.
 # 1.4.880 — #4212/#4018: catalog-seed bp-crossplane pin 1.1.5 -> 1.1.6 (lockstep w/

--- a/products/catalyst/chart/templates/org-services/_smtp-helpers.tpl
+++ b/products/catalyst/chart/templates/org-services/_smtp-helpers.tpl
@@ -1,0 +1,46 @@
+{{/*
+catalyst.orgSmtpChecksum — deterministic hash of the Sovereign SMTP source
+Secret (catalyst-system/sovereign-smtp-credentials) so the org-service Pods
+that consume SMTP_* from org-services-secrets can stamp it as a pod-template
+annotation and AUTO-ROLL the moment the seed flips empty→populated (#4919).
+
+Why this exists (root cause of the hw233 funnel row-84 ❌):
+  org-services/{auth,notification} read SMTP_HOST/PORT/FROM/USER/PASS via
+  secretKeyRef, which the kubelet resolves ONCE, at Pod start.
+  products/catalyst/bootstrap/api/.../sovereign_smtp_seed.go seeds the relay
+  (mail.openova.io:587) ASYNCHRONOUSLY from the mothership at provision time;
+  on a fresh Sovereign it can land AFTER these Pods have already started.
+  org-services-secrets.yaml's #934 source-wins lookup then bakes the correct
+  bytes on the NEXT reconcile, but the already-running Pod keeps its stale
+  EMPTY SMTP_* env — so POST /auth/magic-link (the anonymous signup PIN) and
+  every notification email silently no-send until an unrelated reconcile
+  happens to roll the Pod. That accidental roll is exactly what masked the bug
+  on hw233 region-a (org-services-secrets correct since 15:54, auth Pod
+  incidentally rolled 17:17), leaving the funnel dead for the whole window in
+  between.
+
+  Stamping this hash on the consumer Pod templates makes the roll DETERMINISTIC:
+  when the seed appears the hash changes → Flux rolls auth + notification → the
+  new Pods resolve the now-populated env → the PIN sends.
+
+Mirrors the source key read in org-services-secrets.yaml (#934): canonical
+smtp-host/-port/-from/-user/-pass with legacy host/port/from/user/password
+fallback. During `helm template` (no cluster lookup) or pre-seed it hashes the
+empty sentinel; a change away from that sentinel IS the empty→populated
+transition we want to roll on. Uses only the seed bytes (not org-services-
+secrets' persistent-random JWT/ADMIN fields) so the hash never flaps on the
+first-install randAlphaNum path.
+*/}}
+{{- define "catalyst.orgSmtpChecksum" -}}
+{{- $ns := .Values.orgSecrets.smtp.sovereignNamespace | default "catalyst-system" -}}
+{{- $name := .Values.orgSecrets.smtp.sovereignSecretName | default "sovereign-smtp-credentials" -}}
+{{- $sec := lookup "v1" "Secret" $ns $name -}}
+{{- $d := dict -}}
+{{- if and $sec $sec.data -}}{{- $d = $sec.data -}}{{- end -}}
+{{- $host := (index $d "smtp-host" | default (index $d "host" | default "")) -}}
+{{- $port := (index $d "smtp-port" | default (index $d "port" | default "")) -}}
+{{- $from := (index $d "smtp-from" | default (index $d "from" | default "")) -}}
+{{- $user := (index $d "smtp-user" | default (index $d "user" | default "")) -}}
+{{- $pass := (index $d "smtp-pass" | default (index $d "password" | default "")) -}}
+{{- printf "%s|%s|%s|%s|%s" $host $port $from $user $pass | sha256sum -}}
+{{- end -}}

--- a/products/catalyst/chart/templates/org-services/auth.yaml
+++ b/products/catalyst/chart/templates/org-services/auth.yaml
@@ -11,6 +11,16 @@ spec:
       app: org-auth
   template:
     metadata:
+      annotations:
+        # Auto-roll when the Sovereign SMTP seed flips empty→populated (#4919).
+        # SMTP_* below are secretKeyRef env, frozen by the kubelet at Pod start.
+        # sovereign_smtp_seed.go seeds the relay (mail.openova.io) asynchronously,
+        # so on a fresh prov this Pod can start BEFORE the seed lands →
+        # org-services-secrets is baked correct on the next reconcile but this Pod
+        # keeps stale-empty SMTP env → POST /auth/magic-link silently no-sends the
+        # anonymous signup PIN. This checksum changes when the seed appears,
+        # forcing Flux to roll auth onto the populated env. See _smtp-helpers.tpl.
+        checksum/smtp-config: {{ include "catalyst.orgSmtpChecksum" . | quote }}
       labels:
         policy.cilium.io/enforced: "true"  # Wave 5.121 #2466
         app: org-auth

--- a/products/catalyst/chart/templates/org-services/notification.yaml
+++ b/products/catalyst/chart/templates/org-services/notification.yaml
@@ -11,6 +11,15 @@ spec:
       app: org-notification
   template:
     metadata:
+      annotations:
+        # Auto-roll when the Sovereign SMTP seed flips empty→populated (#4919).
+        # SMTP_* below are secretKeyRef env, frozen by the kubelet at Pod start;
+        # sovereign_smtp_seed.go seeds the relay asynchronously, so on a fresh
+        # prov this Pod can start with stale-empty SMTP env and keep it (every
+        # notification email then 503s / no-sends) until an unrelated reconcile
+        # rolls it. This checksum changes when the seed appears, forcing the
+        # roll onto the populated env. See _smtp-helpers.tpl.
+        checksum/smtp-config: {{ include "catalyst.orgSmtpChecksum" . | quote }}
       labels:
         policy.cilium.io/enforced: "true"  # Wave 5.121 #2466
         app: org-notification

--- a/products/catalyst/chart/tests/org-services-smtp-autoroll-contract.sh
+++ b/products/catalyst/chart/tests/org-services-smtp-autoroll-contract.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# bp-catalyst-platform — org-services SMTP auto-roll + marketplace-api relay render contract (#4919).
+#
+# WHY THIS GATE EXISTS (#4919, live hw233 walk, funnel row 84 — Pillar-1):
+#
+# The anonymous signup PIN (POST /api/auth/magic-link → org-services/gateway →
+# org-services/auth `sendCodeEmail`) never sent on hw233. Root cause: the auth +
+# notification Pods read SMTP_HOST/PORT/FROM/USER/PASS from org-services-secrets
+# via secretKeyRef, which the kubelet resolves ONCE at Pod start. The
+# sovereign-smtp-credentials seed (sovereign_smtp_seed.go → mail.openova.io:587)
+# lands ASYNC from the mothership, so on a fresh prov these Pods can start before
+# it. org-services-secrets.yaml's #934 source-wins lookup then bakes the correct
+# bytes on the next reconcile, but the running Pod keeps its stale-EMPTY SMTP env
+# until an unrelated reconcile happens to roll it — a non-deterministic window in
+# which the funnel PIN silently no-sends.
+#
+# Fix: the catalyst.orgSmtpChecksum helper (_smtp-helpers.tpl) hashes the seed and
+# is stamped as a `checksum/smtp-config` pod annotation on auth + notification, so
+# Flux DETERMINISTICALLY rolls them onto the populated env the moment the seed
+# appears. Separately, marketplace-api's own SMTP env is repointed off the dead
+# in-cluster Stalwart host onto the same durable seed.
+#
+# This gate asserts both so a future revert (annotation dropped, or the stalwart
+# hardcode reintroduced) fails Blueprint Release publish BEFORE the OCI artifact
+# reaches a Sovereign.
+#
+# Test framework: pure `helm template` + grep on rendered YAML, matching the
+# established tests/nats-url-host-ns-contract.sh pattern. Picked up automatically
+# by .github/workflows/blueprint-release.yaml ("Run chart integration tests").
+#
+# Usage: bash tests/org-services-smtp-autoroll-contract.sh [CHART_DIR]
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+
+DEAD_SMTP="stalwart-mail.stalwart.svc.cluster.local"
+SEED_SECRET="sovereign-smtp-credentials"
+
+render() { # $1=template  -> $TMP/out.yaml
+  helm template smoke . \
+    --set global.sovereignFQDN=omantel.biz \
+    --set ingress.marketplace.enabled=true \
+    --set 'ingress.hosts.marketplace.host=marketplace.omantel.biz' \
+    --show-only "$1"
+}
+
+echo "[smtp-autoroll] Case 1: org-services/auth pod template carries a non-empty checksum/smtp-config annotation (#4919)"
+render "templates/org-services/auth.yaml" > "$TMP/auth.yaml"
+if ! grep -qE '^[[:space:]]*checksum/smtp-config:[[:space:]]*"[0-9a-f]{64}"' "$TMP/auth.yaml"; then
+  echo "FAIL: auth Deployment is missing the checksum/smtp-config auto-roll annotation — a Pod that starts before the SMTP seed lands keeps stale-empty env and the signup PIN silently no-sends (#4919)" >&2
+  grep -nE 'checksum/smtp-config|annotations:' "$TMP/auth.yaml" >&2 || true
+  exit 1
+fi
+echo "  PASS (auth carries checksum/smtp-config)"
+
+echo "[smtp-autoroll] Case 2: org-services/notification pod template carries the same auto-roll annotation (#4919)"
+render "templates/org-services/notification.yaml" > "$TMP/notification.yaml"
+if ! grep -qE '^[[:space:]]*checksum/smtp-config:[[:space:]]*"[0-9a-f]{64}"' "$TMP/notification.yaml"; then
+  echo "FAIL: notification Deployment is missing the checksum/smtp-config auto-roll annotation — its SMTP env can freeze stale-empty exactly like auth (#4919)" >&2
+  grep -nE 'checksum/smtp-config|annotations:' "$TMP/notification.yaml" >&2 || true
+  exit 1
+fi
+echo "  PASS (notification carries checksum/smtp-config)"
+
+echo "[smtp-autoroll] Case 3: marketplace-api SMTP_HOST sources the durable ${SEED_SECRET} seed, not the dead in-cluster Stalwart host (#4919)"
+render "templates/marketplace-api/deployment.yaml" > "$TMP/mp.yaml"
+# SMTP_HOST must be a secretKeyRef on the seed Secret, immediately followed by key: smtp-host.
+if ! grep -Pzoq "name:\s*SMTP_HOST\s*\n\s*valueFrom:\s*\n\s*secretKeyRef:\s*\n\s*name:\s*${SEED_SECRET}\s*\n\s*key:\s*smtp-host" "$TMP/mp.yaml"; then
+  echo "FAIL: marketplace-api SMTP_HOST is not a secretKeyRef on ${SEED_SECRET}/smtp-host (#4919)" >&2
+  grep -nA4 'name: SMTP_HOST' "$TMP/mp.yaml" >&2 || true
+  exit 1
+fi
+# Scope to value lines — comments documenting the removed host are allowed (they
+# explain why this gate exists), matching Case 4 + the nats-url test philosophy.
+if grep -qE '(value|host|SMTP_HOST):.*'"${DEAD_SMTP}" "$TMP/mp.yaml"; then
+  echo "FAIL: marketplace-api Deployment still sets the dead in-cluster Stalwart SMTP host '${DEAD_SMTP}' as a value — no Stalwart runs on a fresh Sovereign, so the signup PIN black-holes (#4919)" >&2
+  grep -nE '(value|host|SMTP_HOST):.*'"${DEAD_SMTP}" "$TMP/mp.yaml" >&2 || true
+  exit 1
+fi
+echo "  PASS (marketplace-api SMTP_HOST → ${SEED_SECRET}/smtp-host; no stalwart hardcode)"
+
+echo "[smtp-autoroll] Case 4: no live chart template hardcodes the dead Stalwart SMTP host as a value (belt-and-braces)"
+# Comments documenting the history of the dead host are allowed (they explain why
+# this gate exists), so scope the scan to value lines (value:/host:/SMTP_HOST:).
+if grep -rnE '(value|host|SMTP_HOST):.*'"${DEAD_SMTP}" templates/ values.yaml >/dev/null 2>&1; then
+  echo "FAIL: a live chart value still points at the dead in-cluster Stalwart SMTP host '${DEAD_SMTP}' (#4919)" >&2
+  grep -rnE '(value|host|SMTP_HOST):.*'"${DEAD_SMTP}" templates/ values.yaml >&2 || true
+  exit 1
+fi
+echo "  PASS (no live template value hardcodes ${DEAD_SMTP})"
+
+echo "[smtp-autoroll] ALL CASES PASS — SMTP consumers auto-roll on seed arrival; marketplace-api + org-services source the durable ${SEED_SECRET} relay."


### PR DESCRIPTION
## Root cause (live hw233 region-a evidence)

The anonymous customer signup PIN never arrives on the hw233 walk (funnel row 84 — **blocks Pillar-1**). The real funnel path is `marketplace.<sov>/api/auth/magic-link` → `org-services/gateway` → `org-services/auth` `sendCodeEmail`.

Live region-a kubectl proved the #934 SMTP wiring is **not** broken: `catalyst-system/sovereign-smtp-credentials` exists (`smtp-host=mail.openova.io`) and `org-services/org-services-secrets` already carries the correct non-empty `SMTP_*` bytes. The failure is a **pod-start ordering race**:

- `auth`/`notification` read `SMTP_*` from `org-services-secrets` via `secretKeyRef`, which the kubelet resolves **once, at pod start**.
- `sovereign_smtp_seed.go` seeds the relay **asynchronously** from the mothership; on a fresh prov the pods can start *before* it. `org-services-secrets` is baked correct on the next reconcile, but the running pod keeps its **stale-empty** SMTP env → `POST /auth/magic-link` silently no-sends until an unrelated reconcile happens to roll the pod.
- Evidence: on hw233 region-a the secret was correct at 15:54 but the auth pod only picked it up when it *incidentally* rolled at 17:17 — a dead window in between. Region-B is the standby (empty org-services, no seed — expected).

## Fix

New helper `catalyst.orgSmtpChecksum` (`_smtp-helpers.tpl`) hashes the seed Secret and is stamped as a `checksum/smtp-config` pod annotation on `auth` + `notification`, so Flux **deterministically** rolls them onto the populated env the moment the seed appears (the established `checksum/…` auto-roll pattern already used by the controllers in this chart).

## Changes (rebased on current `main`)

- `products/catalyst/chart/templates/org-services/_smtp-helpers.tpl` — new `catalyst.orgSmtpChecksum` helper.
- `products/catalyst/chart/templates/org-services/auth.yaml` + `notification.yaml` — `checksum/smtp-config` auto-roll annotation.
- `products/catalyst/chart/tests/org-services-smtp-autoroll-contract.sh` — new chart contract gate (auto-run by `blueprint-release.yaml`).
- `products/catalyst/chart/Chart.yaml` + bootstrap-kit slot-13 pin — `1.4.1057` → `1.4.1058` (lockstep; pin-sync-audit PASS).

The sibling **marketplace-api** SMTP repoint (deployment `secretKeyRef` on `sovereign-smtp-credentials` + `core/marketplace-api` safe empty default + tests) already landed on `main` in `1.4.1055` (was PR #4924), so it is not re-included in this diff.

## Validation

- `go build ./...` + `go test ./...` green.
- `tests/org-services-smtp-autoroll-contract.sh` — all 4 cases pass; existing `nats-url-host-ns-contract.sh` still passes; full-chart `helm template` renders clean.
- `scripts/check-bootstrap-kit-pin-sync.sh` — `bp-catalyst-platform chart=1.4.1058 pin=1.4.1058` PASS.

## DoD note

The durable proof is a fresh 2-region prov on the fixed chart, walked through row 84. This PR makes the SMTP-consumer roll deterministic so the funnel PIN sends without depending on an accidental pod restart. Per the anti-thrash principle, the live hw233 env is not hand-patched.

Refs #4919 #4749

🤖 Generated with [Claude Code](https://claude.com/claude-code)
