### PR TITLE
fix(#4920): drop per-Org bp-cnpg operator; platform operator reconciles Org Postgres

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/organization_cnpg_rbac_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_cnpg_rbac_test.go
@@ -1,25 +1,36 @@
 package handler
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
-	"sigs.k8s.io/yaml"
 )
 
-// TestPerOrgBPCNPGWebhookHijackRBACOff is the generator-side guard for the
-// G65 (#4322 #4143 #4201) webhook-HIJACK fix.
+// TestPerOrgBPCNPGOperatorNotEmitted is the generator-side guard for the #4920
+// fix (issue Option B): the Organization tenant overlay must NOT deploy a
+// per-Org bp-cnpg operator anymore.
 //
-// The per-Org bp-cnpg operator must be STRUCTURALLY INCAPABLE of patching the
-// cluster-singleton cnpg webhook configs. The upstream cloudnative-pg subchart
-// grants get,patch on *webhookconfigurations in the operator ClusterRole
-// UNCONDITIONALLY (even when clusterWide=false), so the per-Org install MUST
-// turn the subchart RBAC off (cloudnative-pg.rbac.create=false) — the bp-cnpg
-// umbrella then renders minimal replacement RBAC with NO webhookconfigurations
-// (asserted by platform/cnpg/chart/tests/per-org-operator-rbac.sh). This test
-// locks the generator half: the emitted HelmRelease values carry rbac.create
-// false alongside the existing webhook-less + namespace-scoped settings.
-func TestPerOrgBPCNPGWebhookHijackRBACOff(t *testing.T) {
+// History: the per-Org operator ran webhook-LESS + namespace-scoped and, since
+// G65 (#4322), with its cluster-scoped webhookconfigurations RBAC stripped so
+// it could not hijack the shared cnpg webhook singletons. But at the pinned
+// operator image (CNPG 1.29.0) the mandatory startup `ensurePKI` UNCONDITIONALLY
+// get+patches those singletons — the `MANAGE_WEBHOOK_CONFIGURATIONS=false`
+// opt-out does not exist until a later CNPG release, so it is a silent no-op on
+// 1.29.0. Without the RBAC the operator CrashLoopBackOff'd on ensurePKI → the
+// bp-cnpg HelmRelease never went Ready → the Flux `dependsOn: bp-cnpg` gate
+// blocked bp-wordpress-tenant / bp-newapi from installing (hw233 walk, #4920).
+// Re-granting the RBAC would fix the crash but re-introduce the exact #4322
+// cluster-wide caBundle hijack.
+//
+// FIX: drop the per-Org operator entirely. The platform cnpg-system operator is
+// cluster-wide (upstream subchart default `config.clusterWide: true`, no
+// WATCH_NAMESPACE) and already reconciles postgresql.cnpg.io/v1.Cluster CRs in
+// EVERY namespace — including the host org-tenant namespace the per-Org apps
+// install into — AND owns the singleton webhook that admits them. So no per-Org
+// operator is needed. This test locks that in: no bp-cnpg.yaml overlay file, and
+// no per-Org app HelmRelease `dependsOn: bp-cnpg`.
+func TestPerOrgBPCNPGOperatorNotEmitted(t *testing.T) {
 	rec := store.OrganizationProvisionRecord{
 		OrganizationID:  "t-acme",
 		Subdomain:       "acme",
@@ -35,51 +46,24 @@ func TestPerOrgBPCNPGWebhookHijackRBACOff(t *testing.T) {
 	if err != nil {
 		t.Fatalf("render: %v", err)
 	}
-	body, ok := files["bp-cnpg.yaml"]
-	if !ok {
-		t.Fatalf("bp-cnpg.yaml missing from render output")
+
+	// 1. No per-Org bp-cnpg operator HelmRelease overlay file.
+	if _, ok := files["bp-cnpg.yaml"]; ok {
+		t.Errorf("#4920 regression: bp-cnpg.yaml must NOT be emitted — the per-Org operator crashloops on ensurePKI (no webhookconfigurations RBAC) and re-granting it re-introduces the #4322 hijack; the cluster-wide platform operator reconciles the Org's Cluster CRs")
 	}
 
-	var hr helmReleaseYAML
-	if err := yaml.Unmarshal([]byte(body), &hr); err != nil {
-		t.Fatalf("bp-cnpg.yaml does not parse as YAML: %v\n--- body ---\n%s", err, body)
+	// 2. It must not appear in the kustomization resource list either.
+	if k := files["kustomization.yaml"]; strings.Contains(k, "bp-cnpg.yaml") {
+		t.Errorf("#4920 regression: kustomization.yaml still lists bp-cnpg.yaml:\n%s", k)
 	}
 
-	cnpg, ok := hr.Spec.Values["cloudnative-pg"].(map[string]interface{})
-	if !ok {
-		t.Fatalf("values.cloudnative-pg missing or not a map; values=%#v", hr.Spec.Values)
-	}
-
-	// rbac.create MUST be explicitly false — this is the keystone of the
-	// hijack-vector removal.
-	rbac, ok := cnpg["rbac"].(map[string]interface{})
-	if !ok {
-		t.Fatalf("values.cloudnative-pg.rbac missing — the subchart RBAC (with the cluster webhookconfigurations grant) would still render")
-	}
-	if create, _ := rbac["create"].(bool); create {
-		t.Errorf("cloudnative-pg.rbac.create must be false (got true) — per-Org operator would retain cluster-scoped webhookconfigurations patch (#4322)")
-	}
-
-	// The pre-existing webhook-less + namespace-scoped invariants must remain.
-	webhook, ok := cnpg["webhook"].(map[string]interface{})
-	if !ok {
-		t.Fatalf("values.cloudnative-pg.webhook missing — per-Org operator must be webhook-less")
-	}
-	for _, side := range []string{"mutating", "validating"} {
-		w, ok := webhook[side].(map[string]interface{})
-		if !ok {
-			t.Fatalf("values.cloudnative-pg.webhook.%s missing", side)
+	// 3. No per-Org app HelmRelease may `dependsOn` a per-Org bp-cnpg — the HR
+	//    no longer exists, so any such reference wedges the app on
+	//    `dependency bp-cnpg not found`. Postgres readiness is owned by the
+	//    always-present platform cnpg-system operator (bootstrap-kit slot 16).
+	for name, body := range files {
+		if strings.Contains(body, "name: bp-cnpg") {
+			t.Errorf("#4920 regression: %s still references a per-Org bp-cnpg HelmRelease (dependsOn/sourceRef):\n%s", name, body)
 		}
-		if create, _ := w["create"].(bool); create {
-			t.Errorf("cloudnative-pg.webhook.%s.create must be false (got true) — per-Org operator must not own the cluster webhook singleton", side)
-		}
-	}
-
-	cfg, ok := cnpg["config"].(map[string]interface{})
-	if !ok {
-		t.Fatalf("values.cloudnative-pg.config missing")
-	}
-	if clusterWide, _ := cfg["clusterWide"].(bool); clusterWide {
-		t.Errorf("cloudnative-pg.config.clusterWide must be false (got true) — per-Org operator must be namespace-scoped")
 	}
 }

--- a/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
@@ -16,7 +16,6 @@
 //
 //   - Namespace          org-<org_tenant_id>
 //   - HelmRelease       bp-keycloak (per-organization, fresh realm)
-//   - HelmRelease       bp-cnpg (in tenant ns)
 //   - HelmRelease       bp-wordpress-tenant
 //   - HelmRelease       bp-openclaw
 //   - HelmRelease       bp-stalwart-tenant
@@ -239,7 +238,7 @@ func writeParentTenantsIndex(parentDir string) error {
 		}
 	}
 	// Also emit the shared HelmRepositories file (#893) — the Organization
-	// charts (bp-keycloak / bp-cnpg / bp-wordpress-tenant / bp-openclaw /
+	// charts (bp-keycloak / bp-wordpress-tenant / bp-openclaw /
 	// bp-stalwart-tenant + vcluster's loft repo) are NOT shipped by the
 	// bootstrap-kit on a Sovereign by default. The orchestrator emits them
 	// here at the parent level so every per-tenant HR has a valid
@@ -310,18 +309,6 @@ apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
 metadata:
   name: bp-keycloak
-  namespace: flux-system
-spec:
-  type: oci
-  interval: 15m
-  url: oci://ghcr.io/openova-io
-  secretRef:
-    name: ghcr-pull
----
-apiVersion: source.toolkit.fluxcd.io/v1beta2
-kind: HelmRepository
-metadata:
-  name: bp-cnpg
   namespace: flux-system
 spec:
   type: oci
@@ -748,7 +735,6 @@ var orgTenantTemplates = map[string]string{
 	"kustomization.yaml":       orgTenantKustomization,
 	"namespace.yaml":           orgTenantNamespace,
 	"bp-keycloak.yaml":         orgTenantBPKeycloak,
-	"bp-cnpg.yaml":             orgTenantBPCNPG,
 	"bp-newapi.yaml":           orgTenantBPNewAPI,
 	"bp-wordpress-tenant.yaml": orgTenantBPWordPress,
 	"bp-openclaw.yaml":         orgTenantBPOpenClaw,
@@ -775,7 +761,6 @@ resources:
   # the old one.
   - namespace.yaml
   - bp-keycloak.yaml
-  - bp-cnpg.yaml
   - bp-newapi.yaml
   - bp-wordpress-tenant.yaml
   - bp-openclaw.yaml
@@ -1036,125 +1021,39 @@ spec:
         parentDomain: {{.ParentDomain}}
 `
 
-const orgTenantBPCNPG = `# bp-cnpg in the Organization tenant namespace — Postgres for WordPress
-# + (in future tenants) other apps that need a relational store.
-#
-# Values contract (issue #910 / B3): bp-cnpg is a pure umbrella subchart
-# of cloudnative-pg; per-Sovereign overrides flow through the
-# ` + "`cloudnative-pg.*`" + ` namespace (see platform/cnpg/chart/values.yaml).
-# Earlier orchestrator versions emitted ` + "`namespace`" + ` and ` + "`operator.enabled`" + `
-# at the top level — the chart silently ignored them. Fixed to the
-# canonical subchart-keyed shape.
-#
-# 🛑 NAMESPACE-SCOPED, WEBHOOK-LESS per-Org operator (#4143). The
-# cloudnative-pg "single operator per cluster" guidance: the
-# Mutating/ValidatingWebhookConfiguration objects it registers
-# (cnpg-mutating-webhook-configuration / cnpg-validating-webhook-
-# configuration) are CLUSTER-SCOPED SINGLETONS with FIXED names AND the
-# webhook serving Service name (cnpg-webhook-service) is hardcoded
-# upstream ("DO NOT CHANGE THE SERVICE NAME"). When a per-Org operator
-# also creates these, it and the platform cnpg-system operator both
-# reconcile the SAME singletons — whichever writes last repoints the
-# webhook clientConfig.service at ITS namespace's cnpg-webhook-service
-# with a caBundle the other operator's served cert does not match, so
-# admission fails "x509: certificate signed by unknown authority" and
-# every NEW Cluster CR (e.g. wordpress-db) is blocked. Live outage on
-# omantel.biz kom4dc (dep 4635277cae4ffed9): the singleton webhook ended
-# up owned by an Org-namespace release, breaking the platform operator.
-#
-# Fix: the per-Org operator runs WEBHOOK-LESS and NAMESPACE-SCOPED.
-#   - webhook.{mutating,validating}.create=false → it never touches the
-#     cluster-singleton webhook configs; the single platform cnpg-system
-#     operator owns them and admits Cluster CRs in EVERY namespace
-#     (including this Org's) via its cluster-wide webhook.
-#   - config.clusterWide=false + WATCH_NAMESPACE pinned to this Org ns →
-#     the per-Org operator reconciles ONLY its own namespace and can
-#     never contend cluster-scoped resources owned by the platform
-#     operator. (The per-Org operator still manages this Org's own
-#     Cluster/Backup CRs; it just stops fighting over the singletons.)
-apiVersion: helm.toolkit.fluxcd.io/v2
-kind: HelmRelease
-metadata:
-  name: bp-cnpg
-  namespace: {{.Namespace}}
-spec:
-  interval: 10m
-  chart:
-    spec:
-      chart: bp-cnpg
-      version: "{{.ChartVersions.CNPG}}"
-      sourceRef:
-        kind: HelmRepository
-        name: bp-cnpg
-        namespace: flux-system
-  values:
-    cloudnative-pg:
-      # Single replica per tenant — operator-leader-elected, additional
-      # replicas are passive standbys; Organization footprint trade-off per
-      # docs/INVIOLABLE-PRINCIPLES.md #4 (overridable via per-cluster
-      # overlay).
-      replicaCount: 1
-      crds:
-        # CRDs ship with the bootstrap-kit's mothership bp-cnpg already;
-        # the per-tenant install must NOT re-create them or apiserver
-        # rejects the manifest with "already exists, owned by ...".
-        create: false
-      # #4143: do NOT register the cluster-scoped webhook configs — they
-      # are singletons owned by the platform cnpg-system operator. A
-      # per-Org copy fights over them and breaks admission cluster-wide.
-      webhook:
-        mutating:
-          create: false
-        validating:
-          create: false
-      # #4322 (G65): KILL the webhook-HIJACK RBAC vector at its root. The
-      # upstream cloudnative-pg subchart includes its clusterwideRules
-      # (which grant get,patch on mutating/validatingwebhookconfigurations)
-      # in the ClusterRole bp-cnpg-cloudnative-pg UNCONDITIONALLY — even when
-      # clusterWide=false. So a per-Org operator, despite being namespace-
-      # scoped + webhook-less, was STILL granted cluster-scoped patch on the
-      # webhook singleton and on each restart over-wrote the shared caBundle
-      # with its own org-ns leaf cert (CA:FALSE) → apiserver x509-fail → every
-      # CNPG Cluster create/patch rejected cluster-wide (live omantel.biz
-      # org-7283eb4a, #4322). Turning OFF the subchart RBAC (rbac.create=false)
-      # stops that ClusterRole rendering; the bp-cnpg umbrella's
-      # templates/per-org-operator-rbac.yaml then renders REPLACEMENT RBAC —
-      # a namespace Role with the operator's in-ns permissions + a minimal
-      # ClusterRole (nodes + clusterimagecatalogs reads ONLY, NO
-      # webhookconfigurations) — so the per-Org operator is STRUCTURALLY
-      # INCAPABLE of patching the cluster singleton. (serviceAccount.create
-      # stays at its true default so the operator SA still exists.)
-      rbac:
-        create: false
-      # #4143: namespace-scoped watch — the per-Org operator reconciles
-      # ONLY its own Org namespace, never cluster-scoped singletons. The
-      # platform cnpg-system operator stays cluster-wide and admits this
-      # Org's Cluster CRs via the cluster-singleton webhook.
-      config:
-        clusterWide: false
-        data:
-          WATCH_NAMESPACE: {{.Namespace}}
-      monitoring:
-        # Default OFF per docs/BLUEPRINT-AUTHORING.md §11.2.
-        podMonitorEnabled: false
-      # #4739 W-2: the Org namespace's plan-limits LimitRange enforces
-      # maxLimitRequestRatio {cpu:1, memory:1} (Guaranteed-only QoS — the
-      # #4389/#4292 platform contract every per-Org chart must satisfy).
-      # The chart's platform defaults (requests 100m/1Gi, limit 2Gi) render
-      # ratio 2.5/2.0 → every operator pod is FORBIDDEN and the whole
-      # funnel-app chain wedges (live on hw220 nstar: bp-keycloak Stalled →
-      # newapi/openclaw/stalwart/wordpress DependencyNotReady 12h+).
-      # requests==limits here; 1Gi is sufficient because THIS operator is
-      # namespace-scoped (WATCH_NAMESPACE above) — the G17b 2Gi headroom
-      # was sized for the cluster-wide platform operator.
-      resources:
-        requests:
-          cpu: 200m
-          memory: 1Gi
-        limits:
-          cpu: 200m
-          memory: 1Gi
-`
+// orgTenantBPCNPG was REMOVED (#4920). The per-Org bp-cnpg operator is no
+// longer emitted into the Organization tenant overlay.
+//
+// WHY (root cause, verified against upstream CNPG v1.29.0 source):
+//   The per-Org operator ran WEBHOOK-LESS + NAMESPACE-SCOPED and, since G65
+//   (#4322), with its cluster-scoped webhookconfigurations RBAC stripped so it
+//   could not hijack the shared cnpg-{mutating,validating}-webhook-configuration
+//   singletons. But at the pinned operator image (1.29.0) the operator's
+//   mandatory startup `ensurePKI` UNCONDITIONALLY get+patches those singletons
+//   (internal/cmd/manager/controller/controller.go → pkg/certs/k8s.go
+//   injectPublicKeyInto{Mutating,Validating}Webhook). The
+//   `MANAGE_WEBHOOK_CONFIGURATIONS=false` opt-out that the bp-cnpg chart already
+//   sets does NOT exist until a later CNPG release, so on 1.29.0 it is a silent
+//   no-op. Result: without the RBAC the per-Org operator CrashLoopBackOff'd on
+//   ensurePKI → the bp-cnpg HelmRelease never went Ready → the Flux
+//   `dependsOn: bp-cnpg` gate blocked bp-wordpress-tenant / bp-newapi from ever
+//   installing (hw233 walk 2026-07-09, #4920). Re-granting the RBAC would fix
+//   the crash but re-introduce the exact #4322 cluster-wide caBundle hijack
+//   (the per-Org operator injects its own org-ns leaf into the shared caBundle).
+//
+// FIX (#4920, issue Option B): don't deploy a per-Org operator at all. The
+//   platform cnpg-system operator is cluster-wide (upstream subchart default
+//   `config.clusterWide: true`, no WATCH_NAMESPACE) and already reconciles
+//   postgresql.cnpg.io/v1.Cluster CRs in EVERY namespace — including the host
+//   org-tenant namespace the per-Org apps install into. It also owns the
+//   cluster-singleton webhook that admits Org Cluster CRs. So the per-Org
+//   operator was redundant for reconciliation AND the sole source of the
+//   webhook-hijack / crashloop class. Removing it (this const + the
+//   bp-cnpg.yaml overlay file + the bp-cnpg HelmRepository + the
+//   `dependsOn: bp-cnpg` on bp-newapi/bp-wordpress-tenant) lets the platform
+//   operator own the Org's Postgres end-to-end. The per-Org apps still OWN
+//   their Postgres via their own chart `cnpg.enabled=true` Cluster CRs; only
+//   the redundant per-namespace operator is gone.
 
 // orgTenantBPNewAPI emits the per-tenant bp-newapi HelmRelease (#945).
 //
@@ -1203,9 +1102,11 @@ spec:
 //     auto-seeded at install time (canonical
 //     first-otech default per #915 C4 PR #919).
 //
-// dependsOn: bp-keycloak (OIDC for admin UI) + bp-cnpg (Postgres
-// backend). Ordering matters — without it the chart's channel-seed
-// post-install Job races the readiness of the dependencies and Flux
+// dependsOn: bp-keycloak (OIDC for admin UI). Postgres is provided by the
+// cluster-wide platform cnpg-system operator (#4920 removed the redundant
+// per-Org bp-cnpg operator; the chart still OWNS its own CNPG Cluster via
+// cnpg.enabled=true). Ordering matters — without the keycloak gate the
+// chart's channel-seed post-install Job races the readiness of the dependency and Flux
 // retries cost minutes.
 const orgTenantBPNewAPI = `# bp-newapi per-tenant (#915, #945) — alice's own NewAPI gateway.
 #
@@ -1243,7 +1144,8 @@ spec:
   # context deadline, and the post-install DSN-sync hook never fires: a hard
   # deadlock (verified on the omantel.biz demo Org 2026-06-24). disableWait lets
   # the release reach hook execution, the DSN syncs, and the Pod converges.
-  # CNPG/Keycloak readiness is still gated by dependsOn below.
+  # Keycloak readiness is still gated by dependsOn below; the CNPG Cluster is
+  # reconciled by the cluster-wide platform cnpg-system operator (#4920).
   install:
     timeout: 15m
     disableWait: true
@@ -1253,8 +1155,6 @@ spec:
     disableWait: true
   dependsOn:
     - name: bp-keycloak
-      namespace: {{.Namespace}}
-    - name: bp-cnpg
       namespace: {{.Namespace}}
   values:
     # Per-tenant identity zone — drives the OpenBao path convention for
@@ -1441,8 +1341,6 @@ spec:
         namespace: flux-system
   dependsOn:
     - name: bp-keycloak
-      namespace: {{.Namespace}}
-    - name: bp-cnpg
       namespace: {{.Namespace}}
   values:
     # MIRROR-EVERYTHING (#3785, Refs #3376 #3761): route BOTH WordPress

--- a/products/catalyst/bootstrap/api/internal/handler/organization_keycloak_values_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_keycloak_values_test.go
@@ -276,43 +276,11 @@ func TestBPKeycloakValuesContract_NoLegacyKeys(t *testing.T) {
 	}
 }
 
-// TestBPCNPGSubchartKey — the bp-cnpg chart is a pure umbrella subchart
-// of cloudnative-pg; per-Sovereign overrides MUST flow through the
-// `cloudnative-pg.*` values namespace. Earlier orchestrator versions
-// emitted top-level `namespace` and `operator.enabled` — silently
-// ignored by Helm.
-func TestBPCNPGSubchartKey(t *testing.T) {
-	files := mustRenderTenantOverlay(t)
-	body, ok := files["bp-cnpg.yaml"]
-	if !ok {
-		t.Fatalf("bp-cnpg.yaml missing from render output")
-	}
-	var hr helmReleaseYAML
-	if err := yaml.Unmarshal([]byte(body), &hr); err != nil {
-		t.Fatalf("bp-cnpg.yaml does not parse: %v", err)
-	}
-	v := hr.Spec.Values
-	cnpg, ok := v["cloudnative-pg"].(map[string]interface{})
-	if !ok {
-		t.Fatalf("cloudnative-pg subchart block missing or wrong shape: %#v", v["cloudnative-pg"])
-	}
-	if _, ok := cnpg["replicaCount"]; !ok {
-		t.Errorf("cloudnative-pg.replicaCount missing")
-	}
-	crds, ok := cnpg["crds"].(map[string]interface{})
-	if !ok {
-		t.Fatalf("cloudnative-pg.crds missing or wrong shape")
-	}
-	if got, _ := crds["create"].(bool); got {
-		t.Errorf("cloudnative-pg.crds.create: want false (mothership owns CRDs) got true")
-	}
-	// Banned legacy keys at top level — silent-ignore traps.
-	for _, banned := range []string{"namespace", "operator"} {
-		if _, present := v[banned]; present {
-			t.Errorf("legacy key %q still emitted at bp-cnpg values root", banned)
-		}
-	}
-}
+// TestBPCNPGSubchartKey was REMOVED with #4920. The per-Org bp-cnpg operator
+// overlay (bp-cnpg.yaml) is no longer emitted — the cluster-wide platform
+// cnpg-system operator reconciles the Org's Cluster CRs. The invariant that the
+// operator is NOT deployed per-Org is guarded by
+// TestPerOrgBPCNPGOperatorNotEmitted in organization_cnpg_rbac_test.go.
 
 // TestBPKeycloakValuesFromSMTPSecret — the orchestrator wires the
 // tenant SMTP user/password via valuesFrom referring to an OPTIONAL

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
@@ -585,7 +585,6 @@ func TestRenderOrganizationOverlay_FreeSubdomain_AllChartsPresent(t *testing.T) 
 		// vcluster.yaml deliberately absent (#4188): the per-Org vCluster
 		// is owned by the CRD org-controller, not this overlay.
 		"bp-keycloak.yaml",
-		"bp-cnpg.yaml",
 		"bp-newapi.yaml",
 		"bp-wordpress-tenant.yaml",
 		"bp-openclaw.yaml",
@@ -715,7 +714,6 @@ func TestOrgTenantSharedHelmRepositories_DeclaresAgenity(t *testing.T) {
 	//    rendered HR fails `HelmRepository <name> not found` on a fresh Org.
 	for _, want := range []string{
 		"name: bp-keycloak",
-		"name: bp-cnpg",
 		"name: bp-newapi",
 		"name: bp-wordpress-tenant",
 		"name: bp-openclaw",
@@ -725,6 +723,11 @@ func TestOrgTenantSharedHelmRepositories_DeclaresAgenity(t *testing.T) {
 		if !strings.Contains(orgTenantSharedHelmRepositories, want) {
 			t.Errorf("shared HelmRepositories missing %q", want)
 		}
+	}
+	// #4920 — the per-Org bp-cnpg operator was removed; its HelmRepository
+	// must no longer be declared in the shared block.
+	if strings.Contains(orgTenantSharedHelmRepositories, "name: bp-cnpg") {
+		t.Errorf("#4920 regression: shared HelmRepositories still declares bp-cnpg (the per-Org operator was removed)")
 	}
 
 	// 3. Shape parity with the siblings: the bp-agenity block must carry
@@ -829,8 +832,10 @@ func TestRenderOrganizationOverlay_VersionsApplied(t *testing.T) {
 	if !strings.Contains(files["bp-keycloak.yaml"], `version: "1.2.3"`) {
 		t.Errorf("keycloak version missing: %s", files["bp-keycloak.yaml"])
 	}
-	if !strings.Contains(files["bp-cnpg.yaml"], `version: "0.5.0"`) {
-		t.Errorf("cnpg version missing")
+	// #4920 — the per-Org bp-cnpg operator overlay was removed; no bp-cnpg.yaml
+	// is rendered (the cluster-wide platform operator reconciles Org Clusters).
+	if _, ok := files["bp-cnpg.yaml"]; ok {
+		t.Errorf("#4920 regression: bp-cnpg.yaml must not be rendered")
 	}
 }
 
@@ -925,7 +930,9 @@ func TestRenderOrganizationOverlay_OpenClawOIDCAndLLMBlocks(t *testing.T) {
 // NXDOMAIN on every chat request.
 //
 // The chart values must:
-//   - dependsOn bp-keycloak (admin-UI OIDC) AND bp-cnpg (Postgres backend).
+//   - dependsOn bp-keycloak (admin-UI OIDC). Postgres is reconciled by the
+//     cluster-wide platform cnpg-system operator (#4920 removed the per-Org
+//     bp-cnpg operator); the chart still OWNS its CNPG Cluster via cnpg.enabled.
 //   - Emit ingress.host = api.<sub>.<parent> + ingress.adminHost =
 //     admin.<sub>.<parent> so OpenClaw's llm.baseURL resolves.
 //   - Wire auth.adminUI to the per-tenant Keycloak realm
@@ -973,18 +980,21 @@ func TestRenderOrganizationOverlay_NewAPIEmitted(t *testing.T) {
 		}
 	}
 
-	// dependsOn: bp-keycloak + bp-cnpg (BOTH required).
+	// dependsOn: bp-keycloak only. #4920 removed the per-Org bp-cnpg operator;
+	// Postgres is reconciled by the cluster-wide platform cnpg-system operator,
+	// so bp-newapi must NOT dependsOn a (non-existent) per-Org bp-cnpg HR.
 	wantDependsOn := []string{
 		"  dependsOn:",
 		"    - name: bp-keycloak",
-		"      namespace: org-t-alice",
-		"    - name: bp-cnpg",
 		"      namespace: org-t-alice",
 	}
 	for _, line := range wantDependsOn {
 		if !strings.Contains(body, line) {
 			t.Errorf("bp-newapi.yaml dependsOn missing line %q\n--- rendered ---\n%s", line, body)
 		}
+	}
+	if strings.Contains(body, "name: bp-cnpg") {
+		t.Errorf("#4920 regression: bp-newapi.yaml must not dependsOn a per-Org bp-cnpg HR\n--- rendered ---\n%s", body)
 	}
 
 	// #4246 — install.disableWait + upgrade.disableWait MUST be set. The Pod

--- a/products/catalyst/bootstrap/api/internal/store/organization_provisioning.go
+++ b/products/catalyst/bootstrap/api/internal/store/organization_provisioning.go
@@ -58,8 +58,10 @@ const (
 	// pushed to the GitOps repo. Flux reconciles within ~1 min.
 	STSVClusterCreated OrganizationProvisionState = "vcluster_created"
 	// STSBPChartsInstalled — the same overlay also installs the bp-*
-	// charts (bp-keycloak, bp-cnpg, bp-wordpress-tenant, bp-openclaw,
-	// bp-stalwart-tenant) inside the Organization vcluster. The orchestrator
+	// charts (bp-keycloak, bp-wordpress-tenant, bp-openclaw,
+	// bp-stalwart-tenant) inside the Organization vcluster. (Postgres is
+	// reconciled by the cluster-wide platform cnpg-system operator; the per-Org
+	// bp-cnpg operator was removed in #4920.) The orchestrator
 	// advances to this state once the parent overlay's Kustomization
 	// is Ready=True.
 	STSBPChartsInstalled OrganizationProvisionState = "bp_charts_installed"


### PR DESCRIPTION
## Problem (hw233 walk, 2026-07-09)

Per-Org apps (WordPress, newapi) never install on customer Orgs. The per-Org
`bp-cnpg` operator CrashLoopBackOffs → `bp-cnpg@1.0.14` HelmRelease never goes
Ready → the Flux `dependsOn: bp-cnpg` gate blocks `bp-wordpress-tenant` /
`bp-newapi` forever.

## Root cause (verified against upstream CNPG source)

The per-Org operator runs the pinned image **cloudnative-pg 1.29.0**
(`platform/cnpg/chart/values.yaml`). At 1.29.0 the mandatory startup `ensurePKI`
**unconditionally** Get+Patches the cluster-singleton
`cnpg-{mutating,validating}-webhook-configuration`
(`internal/cmd/manager/controller/controller.go` →
`pkg/certs/k8s.go injectPublicKeyInto{Mutating,Validating}Webhook`).

The `MANAGE_WEBHOOK_CONFIGURATIONS=false` opt-out that the chart already sets
**does not exist until a later CNPG release** — confirmed absent in `v1.29.0`
and `v1.29.2` (`internal/configuration/configuration.go` has only
`WEBHOOK_CERT_DIR`; `MANAGE_WEBHOOK_CONFIGURATIONS` is on `main` only). So on
1.29.0 the flag is a **silent no-op**.

Since G65 (#4322) stripped the per-Org operator's `webhookconfigurations` RBAC
(to stop it hijacking the shared caBundle), the operator now hard-fails
`ensurePKI` → CrashLoopBackOff.

### Why NOT re-add the RBAC (issue Option A)

Re-granting `get/patch` makes `ensurePKI` succeed **but re-introduces the exact
#4322 P0**: the injection code sets `config.Webhooks[].ClientConfig.CABundle =
tls.crt` (the operator's own serving leaf) and Patches whenever it differs — so a
per-Org operator in `org-<id>` overwrites the shared singleton caBundle with its
org-namespace leaf → apiserver x509-fails → **every** `postgresql.cnpg.io`
Cluster admission is rejected cluster-wide. Read-only RBAC still crashes (the
Patch is Forbidden). The per-Org-operator design is fundamentally incompatible
with CNPG 1.29.0 in webhook-less mode.

## Fix (issue Option B)

Stop deploying a per-Org `bp-cnpg` operator. The **platform `cnpg-system`
operator is cluster-wide** (upstream subchart default `config.clusterWide: true`,
no `WATCH_NAMESPACE`) and already reconciles Cluster CRs in every namespace —
including the **host org-tenant namespace** the per-Org apps install into — and
owns the singleton webhook that admits them. The per-Org apps still OWN their
Postgres via their own chart `cnpg.enabled=true` Cluster CRs; only the redundant
per-namespace operator (and the whole webhook-hijack / crashloop class) is gone.

### Changes (org-tenant overlay generator)
- Remove the `orgTenantBPCNPG` HelmRelease const + its `bp-cnpg.yaml`
  file-map / kustomization entry.
- Remove the `bp-cnpg` shared `HelmRepository` block.
- Remove `dependsOn: bp-cnpg` from `bp-newapi` and `bp-wordpress-tenant`
  (the CRD + operator + webhook are provided by the always-present platform
  `bp-cnpg`, bootstrap-kit slot 16).
- Tests updated to guard the new invariant (`TestPerOrgBPCNPGOperatorNotEmitted`).

The platform `bp-cnpg` chart is **unchanged** — no chart version bump. The
now-inert `platform/cnpg/chart/templates/per-org-operator-rbac.yaml` (renders
only in the webhook-less per-Org mode that no longer exists) is left in place;
its removal is follow-up.

## Verification
- `go build ./...` + full `go test ./...` (bootstrap-api) green.
- Needs a **live walk** on a fresh prov (customer-Org funnel → WordPress/newapi
  install) before closing — big stateful-plane change.

Refs #4920

🤖 Generated with [Claude Code](https://claude.com/claude-code)