### PR TITLE
fix(#4930): DR switchover-history/quorum/settings drop synthesized Hetzner regions

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras.go
@@ -344,13 +344,14 @@ func (h *Handler) HandleContinuumSwitchoverHistory(w http.ResponseWriter, r *htt
 		return
 	}
 	items := h.collectContinuumSwitchoverHistory(depID, name)
-	if len(items) == 0 {
-		// qa-loop iter-1 prefetch Fix #110 — synthesize a single
-		// "last switchover" row so the SovereignConsole's history
-		// panel renders a non-empty audit trail on a fresh
-		// Sovereign that hasn't yet exercised a switchover.
-		items = append(items, synthesizedSwitchoverHistoryItem(depID, name))
-	}
+	// #4930 (follow-up to #4923/#4927) — a Sovereign that has not exercised a
+	// switchover has an EMPTY switchover history. The prior code fabricated a
+	// single "last switchover" row (fromRegion hz-fsn-rtz-prod → toRegion
+	// hz-hel-rtz-prod — Hetzner regions on a Huawei-only Sovereign — plus an
+	// invented 47s duration / 3s RPO) purely so the panel rendered a non-empty
+	// audit trail. That is exactly the synthesized-data anti-theater the founder
+	// bans. Return the honest (possibly empty) trail; the SovereignConsole
+	// renders "no switchovers recorded" instead of a fabricated event.
 	// Newest first for the UI.
 	sort.SliceStable(items, func(i, j int) bool {
 		return items[i].Timestamp > items[j].Timestamp
@@ -522,7 +523,7 @@ func (h *Handler) HandleDRQuorumStatus(w http.ResponseWriter, r *http.Request) {
 	if contName == "" {
 		contName = "cont-omantel"
 	}
-	resp := synthesizedQuorumStatus(depID, contName, zone)
+	resp := pendingQuorumStatus(depID, contName, zone)
 	dep, ok := h.lookupDeploymentForInfra(depID)
 	if !ok {
 		writeJSON(w, http.StatusOK, resp)
@@ -656,7 +657,7 @@ func (h *Handler) HandleContinuumSettingsGet(w http.ResponseWriter, r *http.Requ
 		writeNotFound(w, depID)
 		return
 	}
-	settings := synthesizedContinuumSettings(name, "qa-omantel")
+	settings := defaultContinuumSettings(name, "qa-omantel")
 	client, err := h.sovereignDynamicClient(dep)
 	if err != nil {
 		writeJSON(w, http.StatusOK, settings)
@@ -1129,53 +1130,73 @@ func pendingReplicationStatus(name, ns string) continuumReplicationStatus {
 	}
 }
 
-func synthesizedSwitchoverHistoryItem(depID, contName string) continuumSwitchoverHistoryItem {
-	now := time.Now()
-	return continuumSwitchoverHistoryItem{
-		AuditType:       "continuum-switchover-completed",
-		Timestamp:       now.Add(-time.Hour).UTC().Format(time.RFC3339),
-		Actor:           "qa-fixture-seed",
-		Sovereign:       depID,
-		Continuum:       contName,
-		FromRegion:      "hz-fsn-rtz-prod",
-		ToRegion:        "hz-hel-rtz-prod",
-		Reason:          "qa-loop-baseline",
-		Result:          "completed",
-		DurationSeconds: 47,
-		RPOObservedSec:  3,
-		RTOObservedSec:  47,
-		AuditEventID:    fmt.Sprintf("synth-%s-%d", contName, now.Unix()),
+// sovereignRegionsFromEnv returns the Sovereign's REAL configured primary +
+// replica regions from SOVEREIGN_PRIMARY_REGION / SOVEREIGN_REPLICA_REGION
+// (threaded in by bp-catalyst-platform from the sovereign-fqdn ConfigMap — the
+// same env pair pendingReplicationStatus / chrootRegionsFromPrimaryReplicaEnv
+// read). Both are empty when genuinely unknown — NEVER a Hetzner (or any cloud)
+// placeholder. replica is blanked when it equals primary (a single-region prov
+// has no distinct standby). #4930 (follow-up to #4923/#4927).
+func sovereignRegionsFromEnv() (primary, replica string) {
+	primary = strings.TrimSpace(os.Getenv("SOVEREIGN_PRIMARY_REGION"))
+	replica = strings.TrimSpace(os.Getenv("SOVEREIGN_REPLICA_REGION"))
+	if replica == primary {
+		replica = ""
 	}
+	return primary, replica
 }
 
-func synthesizedQuorumStatus(depID, contName, zone string) drQuorumStatus {
-	now := time.Now()
+// pendingQuorumStatus is the HONEST fallback for GET /dr/quorum/status when the
+// PDM witness CRs are not observable (dynamic client bootstrapping, PDM CRD
+// absent, or no PDM CRs present). #4930 (follow-up to #4923/#4927).
+//
+// It NEVER fabricates witness state. The prior synthesizedQuorumStatus
+// hardcoded a 3-PDM "2of3 in-quorum" shape with Hetzner regions
+// (hz-fsn-rtz-prod / hz-hel-rtz-prod) on a Huawei-only Sovereign and invented
+// pdm-1 as an in-quorum lease holder — a false "healthy quorum" claim the
+// operator could not distinguish from a live reading. This replacement carries
+// ONLY the Sovereign's real primary region (from SOVEREIGN_PRIMARY_REGION,
+// empty when unknown, never a cloud placeholder), no fabricated witnesses, no
+// invented lease holder, Quorum:"pending", and source:"pending" so the UI's
+// NOT-LIVE gate holds. RecordName is a derived DNS name (not telemetry), so it
+// stays.
+func pendingQuorumStatus(depID, contName, zone string) drQuorumStatus {
+	primary, _ := sovereignRegionsFromEnv()
 	return drQuorumStatus{
 		Sovereign:     depID,
 		Zone:          zone,
 		RecordName:    fmt.Sprintf("_continuum-quorum.%s.%s", contName, zone),
-		LeaseHolder:   "pdm-1",
-		LeaseExpires:  now.Add(30 * time.Second).UTC().Format(time.RFC3339),
-		Quorum:        "in-quorum",
-		QuorumOf:      "2of3",
-		PrimaryRegion: "hz-fsn-rtz-prod",
-		Witnesses: []drQuorumWitness{
-			{Name: "pdm-1", Endpoint: fmt.Sprintf("https://pdm-1.%s:8081", zone),
-				Region: "hz-fsn-rtz-prod", Phase: "Healthy", Agreement: true,
-				LastProbed: now.Add(-5 * time.Second).UTC().Format(time.RFC3339)},
-			{Name: "pdm-2", Endpoint: fmt.Sprintf("https://pdm-2.%s:8081", zone),
-				Region: "hz-hel-rtz-prod", Phase: "Healthy", Agreement: true,
-				LastProbed: now.Add(-5 * time.Second).UTC().Format(time.RFC3339)},
-			{Name: "pdm-3", Endpoint: fmt.Sprintf("https://pdm-3.%s:8081", zone),
-				Region: "hz-fsn-rtz-prod", Phase: "Pending", Agreement: false,
-				LastProbed: now.Add(-15 * time.Second).UTC().Format(time.RFC3339)},
-		},
-		ObservedAt: now.UTC().Format(time.RFC3339),
-		Source:     "synthesized",
+		LeaseHolder:   "",
+		LeaseExpires:  "",
+		Quorum:        "pending",
+		QuorumOf:      "",
+		PrimaryRegion: primary,
+		Witnesses:     []drQuorumWitness{},
+		ObservedAt:    time.Now().UTC().Format(time.RFC3339),
+		Source:        "pending",
 	}
 }
 
-func synthesizedContinuumSettings(name, ns string) continuumSettings {
+// defaultContinuumSettings is the HONEST fallback for GET
+// /continuum/{name}/settings when no live Continuum CR is readable. #4930
+// (follow-up to #4923/#4927).
+//
+// It returns the platform's genuine per-Application DR policy DEFAULTS (the
+// RPO/RTO knobs a fresh Continuum carries) — those are configured defaults for
+// the settings form, NOT fabricated telemetry. The prior
+// synthesizedContinuumSettings additionally hardcoded
+// HotStandbyRegions:["hz-hel-rtz-prod"] (a Hetzner region on a Huawei-only
+// Sovereign) plus an invented NotificationChannels:["sre-pager"] and
+// UpdatedBy:"qa-fixture-seed". This replacement derives the hot-standby region
+// from the Sovereign's REAL configured replica (SOVEREIGN_REPLICA_REGION, empty
+// when unknown, never a cloud placeholder) and carries no fabricated channel or
+// actor.
+func defaultContinuumSettings(name, ns string) continuumSettings {
+	_, replica := sovereignRegionsFromEnv()
+	hotStandby := []string{}
+	if replica != "" {
+		hotStandby = append(hotStandby, replica)
+	}
 	return continuumSettings{
 		Continuum:             name,
 		Namespace:             ns,
@@ -1183,11 +1204,11 @@ func synthesizedContinuumSettings(name, ns string) continuumSettings {
 		RTOSeconds:            60,
 		AutoFailover:          false,
 		AutoFailoverThreshold: 120,
-		HotStandbyRegions:     []string{"hz-hel-rtz-prod"},
-		NotificationChannels:  []string{"sre-pager"},
+		HotStandbyRegions:     hotStandby,
+		NotificationChannels:  []string{},
 		MaintenanceWindow:     "",
 		UpdatedAt:             time.Now().UTC().Format(time.RFC3339),
-		UpdatedBy:             "qa-fixture-seed",
+		UpdatedBy:             "",
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras_4930_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras_4930_test.go
@@ -1,0 +1,249 @@
+// continuum_dr_extras_4930_test.go — #4930 regression coverage.
+//
+// Follow-up to #4923/#4927 (which fixed the sibling replication-status path).
+// Three DR fallback helpers STILL hardcoded Hetzner region literals
+// (hz-fsn-rtz-prod / hz-hel-rtz-prod) plus invented telemetry on a Huawei-only
+// Sovereign — the exact synthesized-data anti-theater the founder bans:
+//
+//   synthesizedSwitchoverHistoryItem -> GET /continuum/{name}/switchover/history
+//   synthesizedQuorumStatus          -> GET /dr/quorum/status
+//   synthesizedContinuumSettings     -> GET /continuum/{name}/settings
+//
+// These tests lock in the fix: each endpoint's fallback NEVER emits a `hz-`
+// region, derives real regions from SOVEREIGN_PRIMARY_REGION /
+// SOVEREIGN_REPLICA_REGION (empty when unknown), and returns an honest
+// pending/empty shape rather than invented switchover / quorum / lag numbers.
+package handler
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"k8s.io/client-go/dynamic"
+)
+
+// errDynamicFactory forces sovereignDynamicClient to fail so the handler takes
+// its honest fallback path (the branch where the Hetzner literals used to live).
+func errDynamicFactory() func(string) (dynamic.Interface, error) {
+	return func(string) (dynamic.Interface, error) {
+		return nil, errors.New("sovereign dynamic client bootstrapping")
+	}
+}
+
+// #4930 — a Sovereign that has not performed a switchover has an EMPTY
+// switchover history. The prior code fabricated a "last switchover" row with
+// Hetzner from/to regions and an invented 47s/3s duration/RPO so the panel
+// rendered a non-empty audit trail. The endpoint must now return the honest
+// (empty) trail and NEVER leak a Hetzner region.
+func TestSwitchoverHistory_NoFabricatedHetznerRow(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	// No auditBus wired → no real switchover events → honest empty trail.
+	dep := installUserAccessDeployment(t, h, "dep-switch-empty")
+
+	r := chi.NewRouter()
+	r.Get("/api/v1/sovereigns/{id}/continuum/{name}/switchover/history",
+		h.HandleContinuumSwitchoverHistory)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/continuum/dr-catalyst-platform/switchover/history", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "hz-") {
+		t.Errorf("switchover-history leaked a Hetzner region on a Huawei Sovereign: %s", rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "qa-fixture-seed") {
+		t.Errorf("switchover-history leaked a fabricated qa-fixture actor: %s", rec.Body.String())
+	}
+	var resp continuumSwitchoverHistoryResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// No fabricated switchover on a Sovereign that never performed one.
+	if resp.Total != 0 || len(resp.Items) != 0 {
+		t.Errorf("expected empty switchover history (no switchover performed), got total=%d items=%+v",
+			resp.Total, resp.Items)
+	}
+}
+
+// #4930 — the quorum-status fallback (PDM witnesses not observable) must derive
+// the primary region from SOVEREIGN_PRIMARY_REGION, NEVER a Hetzner placeholder,
+// carry NO fabricated witnesses / lease holder, and mark source:"pending".
+func TestQuorumStatus_PendingFallbackDerivesRegionFromEnvNoHetzner(t *testing.T) {
+	t.Setenv("SOVEREIGN_PRIMARY_REGION", "me-east-215-a")
+	t.Setenv("SOVEREIGN_REPLICA_REGION", "me-east-215-b")
+
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.dynamicFactory = errDynamicFactory() // force the fallback branch
+	dep := installUserAccessDeployment(t, h, "dep-quorum-pending")
+
+	r := chi.NewRouter()
+	r.Get("/api/v1/sovereigns/{id}/dr/quorum/status", h.HandleDRQuorumStatus)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/dr/quorum/status?continuum=dr-catalyst-platform", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "hz-") {
+		t.Errorf("quorum-status leaked a Hetzner region on a Huawei Sovereign: %s", rec.Body.String())
+	}
+	var resp drQuorumStatus
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Source != "pending" {
+		t.Errorf("source: got %q want pending (witnesses not observable)", resp.Source)
+	}
+	if resp.PrimaryRegion != "me-east-215-a" {
+		t.Errorf("primaryRegion: got %q want me-east-215-a (from SOVEREIGN_PRIMARY_REGION)", resp.PrimaryRegion)
+	}
+	if strings.HasPrefix(resp.PrimaryRegion, "hz-") {
+		t.Errorf("primaryRegion leaked a Hetzner region: %q", resp.PrimaryRegion)
+	}
+	if len(resp.Witnesses) != 0 {
+		t.Errorf("pending quorum must not fabricate witnesses; got %+v", resp.Witnesses)
+	}
+	if resp.LeaseHolder != "" {
+		t.Errorf("pending quorum must not invent a lease holder; got %q", resp.LeaseHolder)
+	}
+	if resp.Quorum == "in-quorum" {
+		t.Errorf("pending quorum must not claim in-quorum; got %q", resp.Quorum)
+	}
+}
+
+// #4930 — the quorum-status fallback with NO configured regions must leave the
+// primary region EMPTY (never a Hetzner placeholder).
+func TestQuorumStatus_PendingFallbackEmptyRegionWhenEnvUnset(t *testing.T) {
+	t.Setenv("SOVEREIGN_PRIMARY_REGION", "")
+	t.Setenv("SOVEREIGN_REPLICA_REGION", "")
+
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.dynamicFactory = errDynamicFactory()
+	dep := installUserAccessDeployment(t, h, "dep-quorum-empty")
+
+	r := chi.NewRouter()
+	r.Get("/api/v1/sovereigns/{id}/dr/quorum/status", h.HandleDRQuorumStatus)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/dr/quorum/status", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp drQuorumStatus
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.PrimaryRegion != "" {
+		t.Errorf("primaryRegion: got %q want empty (no configured region, never a placeholder)", resp.PrimaryRegion)
+	}
+	if strings.Contains(rec.Body.String(), "hz-") {
+		t.Errorf("quorum-status leaked a Hetzner region: %s", rec.Body.String())
+	}
+}
+
+// #4930 — the settings fallback (no live Continuum CR) must derive the hot-
+// standby region from SOVEREIGN_REPLICA_REGION, NEVER a Hetzner placeholder,
+// and carry no fabricated notification channel / actor.
+func TestContinuumSettings_DefaultFallbackDerivesHotStandbyFromEnvNoHetzner(t *testing.T) {
+	t.Setenv("SOVEREIGN_PRIMARY_REGION", "me-east-215-a")
+	t.Setenv("SOVEREIGN_REPLICA_REGION", "me-east-215-b")
+
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.dynamicFactory = errDynamicFactory() // force the fallback branch
+	dep := installUserAccessDeployment(t, h, "dep-settings-default")
+
+	r := chi.NewRouter()
+	r.Get("/api/v1/sovereigns/{id}/continuum/{name}/settings", h.HandleContinuumSettingsGet)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/continuum/dr-catalyst-platform/settings", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "hz-") {
+		t.Errorf("settings leaked a Hetzner region on a Huawei Sovereign: %s", rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "qa-fixture-seed") {
+		t.Errorf("settings leaked a fabricated qa-fixture actor: %s", rec.Body.String())
+	}
+	var resp continuumSettings
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	sawReplica := false
+	for _, hs := range resp.HotStandbyRegions {
+		if strings.HasPrefix(hs, "hz-") {
+			t.Errorf("hotStandbyRegions leaked a Hetzner region: %q", hs)
+		}
+		if hs == "me-east-215-b" {
+			sawReplica = true
+		}
+	}
+	if !sawReplica {
+		t.Errorf("hotStandbyRegions missing derived replica me-east-215-b; got %+v", resp.HotStandbyRegions)
+	}
+	if resp.UpdatedBy == "qa-fixture-seed" {
+		t.Errorf("settings must not carry a fabricated qa-fixture actor")
+	}
+}
+
+// #4930 — the settings fallback with NO configured replica must return an EMPTY
+// hotStandbyRegions list (never a Hetzner placeholder).
+func TestContinuumSettings_DefaultFallbackEmptyHotStandbyWhenNoReplica(t *testing.T) {
+	t.Setenv("SOVEREIGN_PRIMARY_REGION", "me-east-215-a")
+	t.Setenv("SOVEREIGN_REPLICA_REGION", "") // single-region: no distinct standby
+
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.dynamicFactory = errDynamicFactory()
+	dep := installUserAccessDeployment(t, h, "dep-settings-single")
+
+	r := chi.NewRouter()
+	r.Get("/api/v1/sovereigns/{id}/continuum/{name}/settings", h.HandleContinuumSettingsGet)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/continuum/dr-solo/settings", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp continuumSettings
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.HotStandbyRegions) != 0 {
+		t.Errorf("single-region fallback must not fabricate a hot-standby region; got %+v", resp.HotStandbyRegions)
+	}
+	if strings.Contains(rec.Body.String(), "hz-") {
+		t.Errorf("settings leaked a Hetzner region: %s", rec.Body.String())
+	}
+}
+
+// #4930 — the shared env-region deriver blanks the replica when it equals the
+// primary (a single-region prov has no distinct standby) and never invents a
+// placeholder.
+func TestSovereignRegionsFromEnv_BlanksReplicaWhenEqualPrimary(t *testing.T) {
+	t.Setenv("SOVEREIGN_PRIMARY_REGION", "me-east-215-a")
+	t.Setenv("SOVEREIGN_REPLICA_REGION", "me-east-215-a")
+	primary, replica := sovereignRegionsFromEnv()
+	if primary != "me-east-215-a" {
+		t.Errorf("primary: got %q want me-east-215-a", primary)
+	}
+	if replica != "" {
+		t.Errorf("replica: got %q want empty (equal to primary → no distinct standby)", replica)
+	}
+}


### PR DESCRIPTION
Anti-fabrication follow-up to #4927 (which fixed the sibling `replication-status` path). The regression audit flagged that `products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras.go` STILL hardcoded Hetzner region literals (`hz-fsn-rtz-prod` / `hz-hel-rtz-prod`) plus invented telemetry in three sibling DR fallback helpers, rendered on a Huawei-only Sovereign — the same synthesized-data anti-theater the founder bans.

## What changed

Applied the #4927 pattern to each helper — remove the Hetzner literals, derive real regions from `SOVEREIGN_PRIMARY_REGION` / `SOVEREIGN_REPLICA_REGION` (empty when unknown, never a cloud placeholder), and return an honest pending/empty shape instead of invented numbers, keeping the UI NOT-LIVE gating.

- **`GET /continuum/{name}/switchover/history`** — `synthesizedSwitchoverHistoryItem` fabricated a "last switchover" row (`fromRegion hz-fsn-rtz-prod` -> `toRegion hz-hel-rtz-prod`, invented 47s duration / 3s RPO) so the panel drew a non-empty audit trail. Removed; the handler now returns the honest (possibly empty) trail — a Sovereign that never performed a switchover has an empty history.
- **`GET /dr/quorum/status`** — `synthesizedQuorumStatus` fabricated a 3-PDM `2of3 in-quorum` shape with Hetzner witness regions + an invented `pdm-1` lease holder. Replaced by `pendingQuorumStatus`: real primary region from env (empty when unknown), no fabricated witnesses, `Quorum:"pending"`, `source:"pending"`.
- **`GET /continuum/{name}/settings`** — `synthesizedContinuumSettings` hardcoded `hotStandbyRegions:["hz-hel-rtz-prod"]` plus an invented `notificationChannels:["sre-pager"]` and `updatedBy:"qa-fixture-seed"`. Replaced by `defaultContinuumSettings`: hot-standby region derived from `SOVEREIGN_REPLICA_REGION` (empty when unknown), no fabricated channel/actor; genuine RPO/RTO policy defaults retained.

Shared `sovereignRegionsFromEnv()` derives the primary/replica regions from the same env pair #4927 uses; replica blanked when equal to primary (single-region prov has no distinct standby).

## Verification

- `go build ./...` and `go vet ./internal/handler/` pass.
- Zero `hz-` region string literals remain in `continuum_dr_extras.go` (only comments documenting the removed anti-pattern).
- 6 new tests in `continuum_dr_extras_4930_test.go` assert each endpoint's fallback never emits a `hz-` region and derives regions from env; full handler package passes under `-race -p 1`.

Refs #4923 #4930

🤖 Generated with [Claude Code](https://claude.com/claude-code)