### PR TITLE
test(#4932): await phase1-watch goroutine so it stops writing into t.TempDir during cleanup

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -134,6 +134,17 @@ type Handler struct {
 	phase1MinBootstrapKitHRs int
 	phase1FirstSeenTimeout   time.Duration
 
+	// phase1WatchWG — test-only WaitGroup that the background
+	// phase1-watch goroutine launched by PutKubeconfig joins (Add on
+	// the request goroutine before `go`, Done when the goroutine fully
+	// unwinds). Nil in production (New leaves it zero) so the goroutine
+	// stays fire-and-forget. Tests set it to a &sync.WaitGroup{} and
+	// Wait on it in a t.Cleanup so the goroutine's async
+	// markPhase1Done → persistDeployment write can never race the
+	// testing package's t.TempDir() RemoveAll cleanup ("directory not
+	// empty"). See makePutFixture in kubeconfig_test.go.
+	phase1WatchWG *sync.WaitGroup
+
 	// phase1ReadySentinel is the component id (bp- prefix stripped) whose
 	// terminal-install gates OutcomeReady (#4746). The PRIMARY watch refuses
 	// to classify a prov "ready" until this component (the console's own

--- a/products/catalyst/bootstrap/api/internal/handler/kubeconfig.go
+++ b/products/catalyst/bootstrap/api/internal/handler/kubeconfig.go
@@ -699,7 +699,20 @@ func (h *Handler) PutKubeconfig(w http.ResponseWriter, r *http.Request) {
 		h.emitSovereignSMTPSeedEvent(dep, seedOutcome)
 
 		// Launch the helmwatch goroutine in the background.
+		//
+		// phase1WatchWG (test-only; nil in production) lets a test
+		// deterministically await this goroutine before it returns, so
+		// its terminal markPhase1Done → persistDeployment write can
+		// never race t.TempDir()'s RemoveAll cleanup. Add(1) runs on the
+		// request goroutine BEFORE `go` (the WaitGroup contract); Done
+		// fires when the goroutine fully unwinds.
+		if h.phase1WatchWG != nil {
+			h.phase1WatchWG.Add(1)
+		}
 		go func() {
+			if h.phase1WatchWG != nil {
+				defer h.phase1WatchWG.Done()
+			}
 			h.runPhase1Watch(dep)
 			if relaunchAfterTerminalKubeconfigMissing {
 				dep.mu.Lock()

--- a/products/catalyst/bootstrap/api/internal/handler/kubeconfig_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/kubeconfig_test.go
@@ -35,6 +35,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -90,6 +91,32 @@ func makePutFixture(t *testing.T, status string) (*Handler, string, string, stri
 	}
 
 	h := NewWithStoreAndKubeconfigsDir(silentLogger(), &fakePDM{}, st, kubeconfigsDir)
+
+	// A successful PUT launches a background phase1-watch goroutine that
+	// ends in markPhase1Done → persistDeployment, writing into
+	// deploymentsDir (this test's t.TempDir()). Left unbounded it
+	// outlives the test body and its write races Go's testing RemoveAll
+	// cleanup → "TempDir RemoveAll cleanup: directory not empty" (a real
+	// CI flake, e.g. TestGetKubeconfig_ReadsFromPathPointer). Bound and
+	// await it deterministically:
+	//   - inject a fake dynamic factory so the watch runs against an
+	//     in-memory cluster — this also flips helmwatch to
+	//     noopReachability (helmwatch.go:781), so the goroutine never
+	//     dials the real network — and a tiny watch timeout so it
+	//     terminates in milliseconds (a single ready HR + the default
+	//     MinBootstrapKitHRs=1 with no ready-sentinel gate reaches
+	//     all-done almost immediately);
+	//   - hand the handler a WaitGroup the goroutine joins, then Wait on
+	//     it in a t.Cleanup registered AFTER both t.TempDir() calls so it
+	//     runs (cleanups are LIFO) BEFORE either RemoveAll.
+	// Tests that need their own watch wiring (e.g. LaunchesPhase1Watch)
+	// overwrite dynamicFactory/phase1WatchTimeout after this returns; the
+	// WaitGroup still awaits their goroutine.
+	h.dynamicFactory = fakeDynamicFactoryFromObjects(makeReadyHR("bp-cilium"))
+	h.phase1WatchTimeout = 500 * time.Millisecond
+	var phase1WG sync.WaitGroup
+	h.phase1WatchWG = &phase1WG
+	t.Cleanup(phase1WG.Wait)
 
 	id := "putkc-" + status
 	bearer, hash, err := newBearerToken()


### PR DESCRIPTION
## What

`TestGetKubeconfig_ReadsFromPathPointer` in `products/catalyst/bootstrap/api/internal/handler/kubeconfig_test.go` intermittently failed CI under `go test -race -count=1 ./...` with:

```
testing.go: TempDir RemoveAll cleanup: unlinkat /tmp/.../001: directory not empty
```

This made clean PRs look like regressions — a genuine source of CI noise.

## Root cause (test-lifecycle race, not a logic bug)

`PutKubeconfig` launches a background phase1-watch goroutine (`go func(){ h.runPhase1Watch(dep) }()`). That goroutine ends in `markPhase1Done` → `persistDeployment`, which writes the deployment JSON record into the store dir — which the shared `makePutFixture` helper backs with the test's `t.TempDir()` (`/001`). The goroutine outlived the test body, so its write landed while Go's `testing` package ran `RemoveAll` on the temp dir → "directory not empty". The code under test is correct; the same latent race lived in every `makePutFixture` test that drives a successful PUT (`_AlreadySet…`, `_FirstSuccess…`, `_OnDiskJSON…`, `_ReadsFromPathPointer`).

## Fix (test-lifecycle only — no assertion weakened, nothing skipped)

- Added a test-only `*sync.WaitGroup` field `phase1WatchWG` on `Handler`. Nil in production (`New` leaves it zero) so the goroutine stays fire-and-forget. `PutKubeconfig` `Add(1)`s on the request goroutine before `go` (the WaitGroup contract) and `Done()`s when the goroutine fully unwinds.
- `makePutFixture` now:
  - injects a fake dynamic factory — which also flips helmwatch to `noopReachability` (`helmwatch.go:781`), so the goroutine never dials the real network — plus a 500ms watch timeout, so the watch terminates in milliseconds (a single ready HR + the default `MinBootstrapKitHRs=1` with no ready-sentinel gate reaches all-done almost immediately);
  - hands the handler a `WaitGroup` the goroutine joins and `Wait`s on it in a `t.Cleanup` registered **after** both `t.TempDir()` calls, so it runs (cleanups are LIFO) **before** either `RemoveAll`. This prefers awaiting the real goroutine over sleeping.

## Verification

- `go test -race -count=20 -run TestGetKubeconfig_ReadsFromPathPointer ./internal/handler/` — 20/20 green.
- Full `go test -race -p 1 ./internal/handler/` — green (`ok … 166s`).
- `go build ./...` and `go vet ./internal/handler/` — pass.

Refs #944