### PR TITLE
fix(#4841): grant useraccess-controller `bind` on the 8 canonical IAM ClusterRoles

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1237,7 +1237,12 @@ spec:
       #   console-https-<slug> listener actually lands on cilium-gateway-console
       #   (was 403 -> NoMatchingListenerHostname -> per-Org front doors 000).
       #   Lockstep w/ Chart.yaml.
-      version: 1.4.1062
+      # 1.4.1063 — #4841: useraccess-controller ClusterRole gains `bind` on the 8
+      #   canonical tier + application ClusterRoles so RoleBinding/ClusterRoleBinding
+      #   creates pass the apiserver escalation-prevention gate (owner + customer-Org
+      #   UserAccess CRs were phase=Failed / 0 grants on every fresh prov).
+      #   Lockstep w/ Chart.yaml.
+      version: 1.4.1063
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/core/controllers/useraccess/deploy/rbac.yaml
+++ b/core/controllers/useraccess/deploy/rbac.yaml
@@ -52,6 +52,25 @@ rules:
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["clusterroles"]
     verbs: ["get"]
+  # #4841 — escalation-prevention `bind`. Emitting a RoleBinding /
+  # ClusterRoleBinding whose roleRef targets a ClusterRole whose permissions
+  # this controller does NOT itself hold is rejected by the apiserver
+  # ("attempting to grant RBAC permissions not currently held") unless the
+  # controller holds `bind` on that named ClusterRole. Scoped to the fixed
+  # canonical Sovereign-IAM roles the controller binds to — tier + application.
+  # `bind` operates on a named role so resourceNames is valid (unlike create).
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles"]
+    verbs: ["bind"]
+    resourceNames:
+      - "openova:tier-viewer"
+      - "openova:tier-developer"
+      - "openova:tier-operator"
+      - "openova:tier-admin"
+      - "openova:tier-owner"
+      - "openova:application-admin"
+      - "openova:application-editor"
+      - "openova:application-viewer"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/core/controllers/useraccess/internal/controller/reconciler.go
+++ b/core/controllers/useraccess/internal/controller/reconciler.go
@@ -115,6 +115,7 @@ const (
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=bind,resourceNames=openova:tier-viewer;openova:tier-developer;openova:tier-operator;openova:tier-admin;openova:tier-owner;openova:application-admin;openova:application-editor;openova:application-viewer
 //
 // Reconcile is the controller-runtime entrypoint. Exposed so the
 // controller can be wired both from the leader-elected manager (cmd/

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3444,7 +3444,16 @@ name: bp-catalyst-platform
 #   sovereign-fqdn) so GET /catalog/regions returns the Sovereign's REAL
 #   regions instead of [] — the marketplace BCP picker stops falling back to
 #   the hardcoded Hetzner list.
-version: 1.4.1062
+version: 1.4.1063
+# 1.4.1063 — #4841: grant the useraccess-controller ClusterRole `bind` on the 8
+#   canonical Sovereign-IAM ClusterRoles (openova:tier-{viewer,developer,operator,
+#   admin,owner} + openova:application-{admin,editor,viewer}). The controller
+#   already held create/get/list/watch/update/patch/delete on rolebindings, but
+#   the apiserver's RBAC escalation-prevention gate ALSO requires `bind` on the
+#   ClusterRole a binding's roleRef targets when the requester does not itself
+#   hold that role's permissions. Without it every owner + customer-Org
+#   UserAccess CR reconciled to phase=Failed / 0 grants on EVERY fresh prov.
+#   Lockstep w/ bootstrap-kit slot 13 pin.
 # 1.4.1059 — #4921: grant catalyst-api-cutover-driver the four mutating verbs the
 #   per-Org finalisation path needs — PATCH gateways (SSA the per-Org
 #   console-https-<slug> listener onto cilium-gateway-console), CREATE

--- a/products/catalyst/chart/templates/controllers/useraccess-controller-clusterrole.yaml
+++ b/products/catalyst/chart/templates/controllers/useraccess-controller-clusterrole.yaml
@@ -14,12 +14,37 @@ Least-privilege grants (CC3 audit, #1095):
   clusterroles:get                                             yes    ownerRef sanity (the openova:application-*
                                                                        ClusterRoles must exist before a binding to
                                                                        them is emitted) — get-only, never modified
+  clusterroles:bind (resourceNames = 8 canonical roles)        ADD    #4841 escalation-prevention. Creating a
+                                                                       RoleBinding/ClusterRoleBinding whose roleRef
+                                                                       targets a ClusterRole the controller does NOT
+                                                                       itself hold the permissions of is REJECTED by the
+                                                                       apiserver admission check ("attempting to grant
+                                                                       RBAC permissions not currently held") UNLESS the
+                                                                       requester holds the `bind` verb on that
+                                                                       ClusterRole. See kubernetes.io/docs/reference/
+                                                                       access-authn/authz/rbac/#restrictions-on-role-
+                                                                       binding-creation. Without this every owner +
+                                                                       customer-Org UserAccess CR failed phase=Failed /
+                                                                       0 grants on EVERY fresh prov. The controller binds
+                                                                       ONLY to the fixed canonical set: openova:tier-
+                                                                       {viewer,developer,operator,admin,owner} (tier
+                                                                       path, spec.tierRoleRef) + openova:application-
+                                                                       {admin,editor,viewer} (legacy path,
+                                                                       clusterRoleForRole) — so `bind` is resourceNames-
+                                                                       scoped to exactly those 8. `bind` acts on a NAMED
+                                                                       role, so resourceNames is valid here (unlike
+                                                                       `create`, which must stay unnamed — see
+                                                                       feedback_rbac_create_no_resourcenames).
   leases:get/list/watch/create/update/patch/delete             yes    leader election
   events:create/patch                                          ADD    controller-runtime emits Events on every error;
                                                                        missing in agent's original RBAC.
 
 Net delta vs the agent's original ClusterRole:
   - ADDED events:create/patch (was missing — controller-runtime requires it).
+  - ADDED clusterroles:bind on the 8 canonical tier + application roles
+    (#4841 — the create verb alone is insufficient; the RBAC escalation-
+    prevention admission gate additionally requires `bind` on the target
+    ClusterRole the binding's roleRef points at).
 */ -}}
 {{- if .Values.controllers.useraccess.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -44,6 +69,27 @@ rules:
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["clusterroles"]
     verbs: ["get"]
+  # #4841 — escalation-prevention `bind`. The controller emits
+  # RoleBindings/ClusterRoleBindings whose roleRef points at the canonical
+  # Sovereign-IAM ClusterRoles (tier + application). Because the controller
+  # does NOT itself hold the permissions those roles grant, the apiserver
+  # admission check denies the create unless the controller holds `bind` on
+  # the referenced ClusterRole. `bind` targets a NAMED role, so resourceNames
+  # is valid (unlike `create` — see feedback_rbac_create_no_resourcenames).
+  # Scoped to exactly the fixed canonical set so the grant cannot be abused
+  # to bind subjects to an arbitrary (e.g. cluster-admin) ClusterRole.
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles"]
+    verbs: ["bind"]
+    resourceNames:
+      - "openova:tier-viewer"
+      - "openova:tier-developer"
+      - "openova:tier-operator"
+      - "openova:tier-admin"
+      - "openova:tier-owner"
+      - "openova:application-admin"
+      - "openova:application-editor"
+      - "openova:application-viewer"
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]


### PR DESCRIPTION
## Root cause (pinned LIVE on fresh hw234 dep d71e9c7e)

Owner + customer-Org `UserAccess` CRs reconcile to `status.phase=Failed`, 0 grants, on **every** fresh prov. The condition message:

```
rolebinding <ns>/useraccess-...--xlz8d7 create: rolebindings.rbac.authorization.k8s.io
"useraccess-..." is forbidden: user
"system:serviceaccount:catalyst-system:catalyst-useraccess-controller"
(groups=[system:serviceaccounts...]) cannot create rolebindings
```

The `"<name>" is forbidden: user "..." (groups=[...])` shape is the apiserver's **RBAC escalation-prevention** admission check (`ConfirmNoEscalation`), *not* a plain authorizer verb denial. The controller ClusterRole has held `create/get/list/watch/update/patch/delete` on `rolebindings`+`clusterrolebindings` since chart wiring in May — so the create is authorized. But Kubernetes **additionally** forbids creating a RoleBinding/ClusterRoleBinding whose `roleRef` targets a ClusterRole whose permissions the requester does not itself hold, *unless* the requester holds the `bind` verb on that ClusterRole ([docs](https://kubernetes.io/docs/reference/access-authn/authz/rbac/#restrictions-on-role-binding-creation)).

The controller binds subjects to `openova:tier-owner` (owner seed CR) and `openova:tier-*` / `openova:application-*` (assign path) — roles that grant secrets, apps, and RBAC that the controller deliberately does **not** hold. So every binding create was rejected with *"attempting to grant RBAC permissions not currently held"*. SSO login still works (keycloak-seeded separately), which masked this — but the UserAccess grant surface was fully broken. Same RBAC-gap class as #4925 (gateway).

## Fix

Add a `bind` rule on `rbac.authorization.k8s.io/clusterroles`, `resourceNames`-scoped to exactly the fixed canonical set the controller emits:

- `openova:tier-{viewer,developer,operator,admin,owner}` — `spec.tierRoleRef` path (matches the tier enum in `rbac_assign` allowed-tiers)
- `openova:application-{admin,editor,viewer}` — legacy `applications[]` path (matches the role enum validated in `spec.go`)

These 8 are a 1:1, complete match for every `roleRef` the controller can emit against an existing ClusterRole (verified against `desired.go`/`tier_bindings.go` + the spec/tier validators). `bind` acts on a named role, so `resourceNames` is valid here — unlike `create`, which must stay unnamed (per the k8s "create ignores resourceNames" rule). Scoping to the canonical set prevents the grant from being abused to bind subjects to an arbitrary (e.g. `cluster-admin`) ClusterRole.

## Changes

- `products/catalyst/chart/templates/controllers/useraccess-controller-clusterrole.yaml` — the LIVE chart path (renders `catalyst-useraccess-controller` in `catalyst-system`); added the `bind` rule.
- `core/controllers/useraccess/deploy/rbac.yaml` — durable twin; same rule.
- `core/controllers/useraccess/internal/controller/reconciler.go` — kubebuilder `+kubebuilder:rbac` marker updated to match.
- Chart `1.4.1062 -> 1.4.1063` + bootstrap-kit slot 13 pin bumped in lockstep (pin-sync audit green).

## Validation

- `helm template` renders the ClusterRole with `verbs: ["bind"]` + the 8 `resourceNames`.
- `go build ./...` + `go vet` + `go test ./internal/controller/` all green.
- `scripts/check-bootstrap-kit-pin-sync.sh --changed-only --base origin/main` → PASS (chart=1.4.1063 pin=1.4.1063).

Refs #4841 #4925