### PR TITLE
fix(#4937): authorize a customer's own-Org session for app list + self-install

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
@@ -767,20 +767,43 @@ func (h *Handler) HandleCreateInstance(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if claims := auth.ClaimsFromContext(r.Context()); claims != nil {
-		if !applicationInstallCallerAuthorized(claims) {
-			writeJSON(w, http.StatusForbidden, map[string]string{
-				"code":    "forbidden",
-				"message": "instance create requires tier-admin or higher",
-			})
-			return
-		}
-		// G117.3a #2757 — must be a member of the target Org.
-		if !h.callerInOrg(r.Context(), claims, body.Org) {
-			writeJSON(w, http.StatusForbidden, map[string]string{
-				"code":    "forbidden-cross-org",
-				"message": fmt.Sprintf("caller is not a member of Organization %q", body.Org),
-			})
-			return
+		// #4937 — an Org-scoped customer session (marketplace→console
+		// handover, tier=org-admin) is the authority over its OWN Org: this
+		// is the RBAC parity of what the Org console UI offers. Reaching this
+		// OrgScopeGuard-allowlisted route on a tenant_kind=org console host
+		// already proves a session confined to its own Org (host-anchored via
+		// X-Forwarded-Host, which the browser cannot forge) — the same own-Org
+		// binding HandleOrgApplicationInstall relies on. So for that path we
+		// FORCE the target to the caller's OWN Org namespace (a customer can
+		// never create outside it, regardless of the body's `org`) and the
+		// Sovereign-tier gate + cross-Org membership check are
+		// satisfied-by-construction and skipped.
+		//
+		// A non-Org-scoped session (operator on the Sovereign console) keeps
+		// the existing tier-admin-or-higher + own-Org checks unchanged — ZERO
+		// behaviour change for the operator console.
+		if ownOrg, scoped := h.orgScopeForRequest(r); scoped && ownOrg != "" {
+			if ns := h.orgNamespaceForRequest(r); ns != "" {
+				body.Org = ns
+			} else {
+				body.Org = ownOrg
+			}
+		} else {
+			if !applicationInstallCallerAuthorized(claims) {
+				writeJSON(w, http.StatusForbidden, map[string]string{
+					"code":    "forbidden",
+					"message": "instance create requires tier-admin or higher",
+				})
+				return
+			}
+			// G117.3a #2757 — must be a member of the target Org.
+			if !h.callerInOrg(r.Context(), claims, body.Org) {
+				writeJSON(w, http.StatusForbidden, map[string]string{
+					"code":    "forbidden-cross-org",
+					"message": fmt.Sprintf("caller is not a member of Organization %q", body.Org),
+				})
+				return
+			}
 		}
 	}
 
@@ -1186,6 +1209,39 @@ func (h *Handler) HandleListBlueprintInstances(w http.ResponseWriter, r *http.Re
 	bp := strings.TrimPrefix(chi.URLParam(r, "blueprint"), "bp-")
 	orgFilter := strings.TrimSpace(r.URL.Query().Get("org"))
 
+	// #4937 — an Org-scoped customer session (marketplace→console handover,
+	// tier=org-admin) is confined to its OWN Organization. It gets a 200
+	// listing of ONLY its own instances; a Sovereign-admin / operator session
+	// is unaffected (scoped=false) and keeps its cluster-wide reach — ZERO
+	// behaviour change for the operator console.
+	//
+	// Confinement is Kubernetes-authoritative: when the request host resolves
+	// to the caller's Org namespace we list ONLY that namespace (listNS),
+	// which is robust to the `catalyst.openova.io/organization` label differing
+	// across install paths (slug vs. real `org-<uuid>`). When the namespace
+	// can't be resolved (claims-only scope, no registry) we fall back to the
+	// slug label filter, which still never leaks another Org.
+	ownOrg, scoped := h.orgScopeForRequest(r)
+	listNS := ""
+	if scoped {
+		if ownOrg == "" {
+			writeJSON(w, http.StatusForbidden, map[string]string{
+				"code":    "org-scope-unresolved",
+				"message": "could not resolve the Organization for this Org-scoped session",
+			})
+			return
+		}
+		if orgFilter != "" && !strings.EqualFold(orgFilter, ownOrg) {
+			writeJSON(w, http.StatusForbidden, map[string]string{
+				"code":    "forbidden-cross-org",
+				"message": fmt.Sprintf("this Organization session cannot list instances for Organization %q", orgFilter),
+			})
+			return
+		}
+		orgFilter = ownOrg
+		listNS = h.orgNamespaceForRequest(r)
+	}
+
 	client, err := h.dynamicClientOrFallback()
 	if err != nil {
 		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
@@ -1195,7 +1251,7 @@ func (h *Handler) HandleListBlueprintInstances(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	list, err := client.Resource(ApplicationGVR()).Namespace("").List(r.Context(), metav1.ListOptions{})
+	list, err := client.Resource(ApplicationGVR()).Namespace(listNS).List(r.Context(), metav1.ListOptions{})
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{
 			"code":    "list-failed",
@@ -1217,7 +1273,12 @@ func (h *Handler) HandleListBlueprintInstances(w http.ResponseWriter, r *http.Re
 			continue
 		}
 		org := extractOrgFromApp(item)
-		if orgFilter != "" && !strings.EqualFold(org, orgFilter) {
+		// When the listing is already namespace-confined (listNS != "", the
+		// #4937 Org-scoped path) the org-label filter is skipped: the label
+		// may legitimately be the real `org-<uuid>` namespace rather than the
+		// slug, and the namespace scope is the authoritative boundary. The
+		// unconfined operator listing (listNS == "") still honours ?org=.
+		if listNS == "" && orgFilter != "" && !strings.EqualFold(org, orgFilter) {
 			continue
 		}
 		params, _, _ := unstructured.NestedMap(item.Object, "spec", "parameters")

--- a/products/catalyst/bootstrap/api/internal/handler/endpoint_instances_org_scope_4937_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/endpoint_instances_org_scope_4937_test.go
@@ -1,0 +1,227 @@
+// endpoint_instances_org_scope_4937_test.go — #4937 authz coverage for the
+// customer self-service app-instance seam.
+//
+// The bug (live on hw234, Org acme): a customer signed into their OWN Org
+// console (console.acme.omani.homes, marketplace→console handover, an Org-
+// scoped RS256 session tier=org-admin) got `getApplicationInstances HTTP 403`
+// and could not self-install. Root cause: the app-instance endpoints
+// (GET /catalyst/v1/catalog/{bp}/instances, POST /catalyst/v1/apps/instances)
+// were NOT on the OrgScopeGuard org-safe allowlist, and the create path's
+// tier gate (applicationInstallCallerAuthorized) rejected tier=org-admin.
+//
+// These tests pin the authz DECISION at the handler level:
+//   - own-Org session  → 200 on the instances list, confined to its own Org.
+//   - cross-Org query   → 403 forbidden-cross-org.
+//   - own-Org session  → 201 on install, forced into its own Org namespace,
+//     Sovereign-tier gate skipped (RBAC parity with the Org console UI).
+//   - a cross-Org install body is FORCED to the caller's own Org (never leaks).
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+// orgConsoleHost is the customer's own Org console host (tenant_kind=org).
+const orgConsoleHost4937 = "console.acme.omani.homes"
+
+// seedAppWithOrgLabel builds an Application in namespace `ns` whose
+// `catalyst.openova.io/organization` label is `orgLabel` — used to simulate
+// the /org/applications install path, which labels CRs with the real
+// `org-<uuid>` namespace rather than the slug. #4937's namespace-anchored
+// confinement must still return it for the owning Org.
+func seedAppWithOrgLabel(uid, name, ns, orgLabel, blueprint string) *unstructured.Unstructured {
+	app := seedApp(uid, name, ns, blueprint)
+	labels := app.GetLabels()
+	labels["catalyst.openova.io/organization"] = orgLabel
+	app.SetLabels(labels)
+	return app
+}
+
+// withOrgConsole wires an Org-scoped customer session onto a request: the
+// host anchor (X-Forwarded-Host, the gateway-set real browser host that an
+// Org-console browser cannot forge) PLUS the org-admin session claims the
+// marketplace→console handover mints.
+func withOrgConsole(req *http.Request, host, org string) *http.Request {
+	req.Header.Set("X-Forwarded-Host", host)
+	return withTestClaims(req, &testClaimsSpec{
+		Email: "member@" + org + ".example",
+		Tier:  orgScopedTier, // "org-admin"
+		Org:   org,
+	})
+}
+
+// orgRegistry returns a tenant registry with `host` registered as a
+// tenant_kind=org console whose Kubernetes namespace is `ns`.
+func orgRegistry(t *testing.T, host, ns string) *store.TenantRegistry {
+	t.Helper()
+	reg, err := store.NewTenantRegistry(t.TempDir())
+	if err != nil {
+		t.Fatalf("new registry: %v", err)
+	}
+	if err := reg.Put(store.TenantRegistration{
+		Host:                  host,
+		TenantID:              "tenant-org-acme",
+		TenantKind:            store.TenantKindOrg,
+		OrganizationNamespace: ns,
+	}); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	return reg
+}
+
+// TestListBlueprintInstances_OrgScoped_ConfinedToOwnOrg — the reproduced
+// 403 becomes a 200 scoped to the caller's own Org. The listing is namespace-
+// anchored, so it includes an instance labelled with the real `org-<uuid>`
+// (the /org/applications install convention) and EXCLUDES another Org's
+// instance in a different namespace.
+func TestListBlueprintInstances_OrgScoped_ConfinedToOwnOrg(t *testing.T) {
+	own := seedApp("uid-4937-1", "wp-own", "acme", "wordpress")
+	// Same Org, different label convention (real org-<uuid> namespace).
+	ownAltLabel := seedAppWithOrgLabel("uid-4937-2", "wp-own-2", "acme", "org-abc123", "wordpress")
+	other := seedApp("uid-4937-3", "wp-other", "bigcorp", "wordpress")
+	h, _, _ := newTestHandlerWithEndpoint(t, own, ownAltLabel, other)
+	h.tenantRegistry = orgRegistry(t, orgConsoleHost4937, "acme")
+	h.SetCatalogClient(newFakeCatalog())
+	r := newTestRouter(h)
+
+	req := httptest.NewRequest("GET", "/catalyst/v1/catalog/wordpress/instances", nil)
+	req = withOrgConsole(req, orgConsoleHost4937, "acme")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("own-Org session must get 200 (not the #4937 403), got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp listInstancesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Items) != 2 {
+		t.Fatalf("expected 2 own-Org instances (namespace-confined), got %d: %+v", len(resp.Items), resp.Items)
+	}
+	for _, it := range resp.Items {
+		if it.Name == "wp-other" {
+			t.Fatalf("cross-Org instance wp-other leaked into the own-Org listing: %+v", resp.Items)
+		}
+	}
+}
+
+// TestListBlueprintInstances_OrgScoped_CrossOrgQuery403 — an Org-scoped
+// session that explicitly asks for another Org is 403'd.
+func TestListBlueprintInstances_OrgScoped_CrossOrgQuery403(t *testing.T) {
+	own := seedApp("uid-4937-10", "wp-own", "acme", "wordpress")
+	other := seedApp("uid-4937-11", "wp-other", "bigcorp", "wordpress")
+	h, _, _ := newTestHandlerWithEndpoint(t, own, other)
+	h.tenantRegistry = orgRegistry(t, orgConsoleHost4937, "acme")
+	h.SetCatalogClient(newFakeCatalog())
+	r := newTestRouter(h)
+
+	req := httptest.NewRequest("GET", "/catalyst/v1/catalog/wordpress/instances?org=bigcorp", nil)
+	req = withOrgConsole(req, orgConsoleHost4937, "acme")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("cross-Org query must be 403, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !bytes.Contains(rec.Body.Bytes(), []byte("forbidden-cross-org")) {
+		t.Fatalf("expected forbidden-cross-org, got body=%s", rec.Body.String())
+	}
+}
+
+// TestListBlueprintInstances_Operator_Unchanged — a Sovereign operator (no
+// Org scope: not on an Org host, no org-admin claims) keeps the cluster-wide
+// listing. Guards against a regression that would confine the operator.
+func TestListBlueprintInstances_Operator_Unchanged(t *testing.T) {
+	a := seedApp("uid-4937-20", "wp-a", "acme", "wordpress")
+	b := seedApp("uid-4937-21", "wp-b", "bigcorp", "wordpress")
+	h, _, _ := newTestHandlerWithEndpoint(t, a, b)
+	h.tenantRegistry = orgRegistry(t, orgConsoleHost4937, "acme")
+	h.SetCatalogClient(newFakeCatalog())
+	r := newTestRouter(h)
+
+	// Operator on the Sovereign console host (not a tenant_kind=org host),
+	// carrying an owner-tier session — must see BOTH Orgs' instances.
+	req := httptest.NewRequest("GET", "/catalyst/v1/catalog/wordpress/instances", nil)
+	req.Header.Set("X-Forwarded-Host", "console.t01.omani.works")
+	req = withTestClaims(req, &testClaimsSpec{Email: "op@openova.io", Tier: "owner"})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("operator must get 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp listInstancesResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if len(resp.Items) != 2 {
+		t.Fatalf("operator must see both Orgs' instances (cluster-wide), got %d", len(resp.Items))
+	}
+}
+
+// TestCreateInstance_OrgScoped_AllowsOwnOrgSkipsTierGate — the customer can
+// self-install into their OWN Org. The org-admin tier (which the Sovereign
+// gate rejects) is accepted here because the OrgScopeGuard-allowlisted,
+// host-anchored own-Org binding IS the authz boundary, and the target is
+// FORCED to the caller's own Org namespace regardless of the body's `org`.
+func TestCreateInstance_OrgScoped_AllowsOwnOrgSkipsTierGate(t *testing.T) {
+	h, _, dyn := newTestHandlerWithEndpoint(t)
+	h.tenantRegistry = orgRegistry(t, orgConsoleHost4937, "acme")
+	h.SetCatalogClient(fakeBlueprintInCatalog("wordpress",
+		[]map[string]interface{}{}, true, []string{"singleton", "active-hot-standby"}))
+	r := newTestRouter(h)
+
+	// The body claims a DIFFERENT Org (an attacker hint) — it must be ignored
+	// and the CR forced into the caller's own Org namespace ("acme").
+	body := []byte(`{"blueprint":"wordpress","org":"bigcorp","name":"wp-self","topology":"singleton"}`)
+	req := httptest.NewRequest("POST", "/catalyst/v1/apps/instances", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withOrgConsole(req, orgConsoleHost4937, "acme")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("own-Org install must be 201 (tier gate skipped), got %d body=%s", rec.Code, rec.Body.String())
+	}
+	// CR landed in the caller's own Org namespace, NOT the body's "bigcorp".
+	if _, err := dyn.Resource(ApplicationGVR()).Namespace("acme").Get(context.Background(), "wp-self", metav1.GetOptions{}); err != nil {
+		t.Fatalf("CR must land in own-Org namespace acme; got %v", err)
+	}
+	if _, err := dyn.Resource(ApplicationGVR()).Namespace("bigcorp").Get(context.Background(), "wp-self", metav1.GetOptions{}); err == nil {
+		t.Fatal("CR must NOT land in the body-specified cross-Org namespace bigcorp")
+	}
+}
+
+// TestCreateInstance_Operator_TierGateUnchanged — a non-Org-scoped caller
+// with an unprivileged tier is still rejected by the Sovereign-tier gate.
+// Proves #4937 only relaxes the gate for the confined own-Org path.
+func TestCreateInstance_Operator_TierGateUnchanged(t *testing.T) {
+	h, _, _ := newTestHandlerWithEndpoint(t)
+	// No Org host in the registry for this request's host → not Org-scoped.
+	h.tenantRegistry = orgRegistry(t, orgConsoleHost4937, "acme")
+	h.SetCatalogClient(fakeBlueprintInCatalog("wordpress",
+		[]map[string]interface{}{}, true, []string{"singleton"}))
+	r := newTestRouter(h)
+
+	body := []byte(`{"blueprint":"wordpress","org":"acme","name":"wp-x","topology":"singleton"}`)
+	req := httptest.NewRequest("POST", "/catalyst/v1/apps/instances", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Forwarded-Host", "console.t01.omani.works") // Sovereign host, not Org-scoped
+	// Unprivileged tier, not org-admin → the Sovereign gate must reject.
+	req = withTestClaims(req, &testClaimsSpec{Email: "nobody@example.com", Tier: "viewer"})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("unprivileged non-Org-scoped caller must be 403, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/org_scope.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_scope.go
@@ -76,6 +76,12 @@ type orgScope struct {
 	Org string
 	// TenantID is the opaque tenant id from the registry.
 	TenantID string
+	// Namespace is the Org's Kubernetes namespace from the registry
+	// (TenantRegistration.OrganizationNamespace, the real `org-<uuid>` for a
+	// free-subdomain Org). Empty when the registry row carries none; callers
+	// then fall back to slugging the Org slug (#4937 uses it to confine the
+	// per-Blueprint instances listing to the caller's own namespace).
+	Namespace string
 	// Host is the resolved (lowercased, port-stripped) request host.
 	Host string
 }
@@ -111,7 +117,12 @@ func (h *Handler) resolveOrgScope(r *http.Request) (orgScope, bool) {
 	if slug == "" {
 		slug = t.TenantID
 	}
-	return orgScope{Org: slug, TenantID: t.TenantID, Host: host}, true
+	return orgScope{
+		Org:       slug,
+		TenantID:  t.TenantID,
+		Namespace: strings.TrimSpace(t.OrganizationNamespace),
+		Host:      host,
+	}, true
 }
 
 // orgSlugFromHost extracts the Org slug from a console host. For
@@ -147,6 +158,66 @@ func claimsAreOrgScoped(claims *auth.Claims) bool {
 	return strings.EqualFold(strings.TrimSpace(claims.Tier), orgScopedTier)
 }
 
+// orgScopeForRequest returns the Organization slug a request is confined
+// to, and whether the request is Org-scoped at all. It mirrors
+// OrgScopeGuard's trust model exactly:
+//
+//  1. The REQUEST HOST is the primary anchor (resolveOrgScope). A request
+//     that arrived on a registered tenant_kind=org console host is confined
+//     to that Org even if it carries a stale / replayed sovereign-admin
+//     cookie — the gateway sets X-Forwarded-Host to the real browser host,
+//     which an Org-console browser can never forge.
+//  2. The session's org-scoped claims (tier=org-admin) are the fallback for
+//     the window before the host is a registered tenant, or in tests /
+//     chroots without a registry.
+//
+// A non-Org-scoped (Sovereign-admin / operator) request returns ("", false)
+// — those keep their existing cross-Org reach with ZERO behaviour change.
+// The slug is lower-cased + trimmed so it compares cleanly against the
+// Application `catalyst.openova.io/organization` label and the JWT `org`
+// claim.
+//
+// This is the single seam the self-service app-instance handlers
+// (HandleListBlueprintInstances / HandleCreateInstance) consult to confine a
+// customer to its OWN Org (#4937).
+func (h *Handler) orgScopeForRequest(r *http.Request) (string, bool) {
+	if sc, ok := h.resolveOrgScope(r); ok {
+		return strings.ToLower(strings.TrimSpace(sc.Org)), true
+	}
+	claims := auth.ClaimsFromContext(r.Context())
+	if claimsAreOrgScoped(claims) {
+		return strings.ToLower(strings.TrimSpace(claims.Org)), true
+	}
+	return "", false
+}
+
+// orgNamespaceForRequest resolves the caller's OWN Organization Kubernetes
+// namespace (the `org-<uuid>` a free-subdomain Org lives in, or the slugged
+// Org slug for a namespace-named Org) from the request HOST via the tenant
+// registry. It returns "" when the request is not Org-scoped by host, or
+// when no namespace can be resolved — the caller then falls back to a
+// slug-label filter rather than widening the query.
+//
+// This is what lets HandleListBlueprintInstances confine an Org-scoped
+// customer to its own namespace (Kubernetes-authoritative), which is robust
+// to the `catalyst.openova.io/organization` label convention differing
+// across install paths (slug on the sovereign/create-instance path vs. the
+// real `org-<uuid>` on the /org/applications install path). Mirrors the
+// namespace resolution HandleOrgApplications already uses (#4113/#4937).
+func (h *Handler) orgNamespaceForRequest(r *http.Request) string {
+	sc, ok := h.resolveOrgScope(r)
+	if !ok {
+		return ""
+	}
+	if ns := strings.TrimSpace(sc.Namespace); ns != "" {
+		return orgNamespace(ns)
+	}
+	if slug := strings.TrimSpace(sc.Org); slug != "" {
+		return orgNamespace(slug)
+	}
+	return ""
+}
+
 // orgSafePathPrefixes is the DENY-BY-DEFAULT allowlist: the ONLY API path
 // prefixes an Org-scoped customer session may reach. Everything else under
 // the RequireSession group (deployments + deployment-stream, the whole-
@@ -179,6 +250,21 @@ func claimsAreOrgScoped(claims *auth.Claims) bool {
 //                                 incl. the agenity Open link. A true per-Org
 //                                 apps PROJECTION (filtering to the Org's own
 //                                 namespaces + vClusters) is the #4113 follow-up.
+//   - /catalyst/v1/catalog/     — the per-Blueprint instances drill-down feed
+//                                 (getApplicationInstances). The customer
+//                                 console's AppDetail / Instances section lists a
+//                                 Blueprint's installed instances here. The
+//                                 handler (HandleListBlueprintInstances) FORCES
+//                                 the org filter to the caller's OWN Org for an
+//                                 Org-scoped session and 403s an explicit
+//                                 cross-Org query, so the allowlist entry never
+//                                 leaks another Org's estate (#4937).
+//   - /catalyst/v1/apps/instances — the self-service install seam
+//                                 (createApplicationInstance). HandleCreateInstance
+//                                 FORCES the target Org to the caller's OWN Org for
+//                                 an Org-scoped session (a customer can never
+//                                 create outside its own Org) and drops the
+//                                 Sovereign-tier gate for that confined case (#4937).
 //
 // NOTE: BSS / billing / commerce / consumption / organizations-directory /
 // the deployments API / the whole-cluster /sovereigns/{id}/k8s estate /
@@ -199,6 +285,11 @@ var orgSafePathPrefixes = []string{
 	"/api/v1/sandbox",
 	"/api/v1/sovereign/self",
 	"/api/v1/sovereign/apps",
+	// #4937 — self-service app list + install for a customer's OWN Org.
+	// Both handlers below server-side-confine an Org-scoped session to its
+	// own Org, so these entries can never span Orgs (see handler comments).
+	"/catalyst/v1/catalog/",
+	"/catalyst/v1/apps/instances",
 }
 
 // pathIsOrgSafe reports whether the request path is on the Org-scoped

--- a/products/catalyst/bootstrap/api/internal/handler/org_scope_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_scope_test.go
@@ -59,6 +59,10 @@ func TestPathIsOrgSafe(t *testing.T) {
 		"/api/v1/sandbox/sessions",
 		"/api/v1/sovereign/apps",
 		"/api/v1/sovereign/self",
+		// #4937 — self-service app list + install (server-side confined to
+		// the caller's own Org inside the handlers).
+		"/catalyst/v1/catalog/wordpress/instances",
+		"/catalyst/v1/apps/instances",
 	}
 	for _, p := range safe {
 		if !pathIsOrgSafe(p) {
@@ -75,6 +79,10 @@ func TestPathIsOrgSafe(t *testing.T) {
 		"/api/v1/organizations",
 		"/api/v1/parent-domains",
 		"/api/v1/org/commerce/plans",
+		// #4937 stays NARROW: the sibling catalyst/v1 app surfaces (endpoint
+		// mutation, launch-url) are NOT opened to Org sessions by this change.
+		"/catalyst/v1/apps/uid-1/endpoints",
+		"/catalyst/v1/apps/uid-1/launch-url",
 	}
 	for _, p := range unsafe {
 		if pathIsOrgSafe(p) {


### PR DESCRIPTION
## Problem (Pillar 1 self-service — live on hw234, Org acme)

A customer signed into their **OWN** Org console (`console.<slug>.<pool>`, an Org-scoped RS256 session minted by the marketplace→console HS256→RS256 handover, `tier=org-admin`) hit `getApplicationInstances HTTP 403` and could not self-install apps into their own Org — installs required the sovereign-admin owner console.

## Root cause (which of a/b/c)

**(a) — the app-instance endpoints were never on the OrgScopeGuard org-safe allowlist.** `GET /catalyst/v1/catalog/{bp}/instances` (getApplicationInstances) and `POST /catalyst/v1/apps/instances` (createApplicationInstance) sit inside the RequireSession+OrgScopeGuard group but were not in `orgSafePathPrefixes`, so an Org-scoped session was denied `org-scoped-forbidden` **before** the handler ran. The catalog list (`/api/v1/catalog`) IS allowlisted — which is exactly why "the catalog loads but the app-instance API returns 403".

Compounding **(b)**: even past the guard, `HandleCreateInstance`'s tier gate (`applicationInstallCallerAuthorized`) rejects `tier=org-admin`.

It is **not** by-design: the customer console already routes its Apps grid through the org-confined `/api/v1/org/applications`; only the per-Blueprint instances drill-down + the create-instance seam were left on the sovereign path.

## Fix (narrow — own-Org only; cross-Org stays 403)

- **OrgScopeGuard allowlist** gains `/catalyst/v1/catalog/` and `/catalyst/v1/apps/instances`. Sibling `catalyst/v1` app surfaces (endpoint mutation, launch-url) stay denied — scope is pinned by a test.
- **`orgScopeForRequest` / `orgNamespaceForRequest`** (new) mirror OrgScopeGuard's trust model: the un-forgeable `X-Forwarded-Host` is the primary anchor, org-admin claims the fallback.
- **`HandleListBlueprintInstances`** confines an Org-scoped session to its OWN Org via **Kubernetes-authoritative namespace scoping** (robust to the `catalyst.openova.io/organization` label differing across install paths — slug vs. real `org-<uuid>`), and 403s an explicit cross-Org `?org=` query. Operator listing is unchanged (cluster-wide).
- **`HandleCreateInstance`** treats the host-anchored own-Org binding as the authz boundary (same reasoning as `HandleOrgApplicationInstall`): forces the target to the caller's own Org namespace and skips the Sovereign-tier gate for that confined path. Operator create keeps the tier + own-Org checks unchanged.

## Tests (authz decision)

`internal/handler/endpoint_instances_org_scope_4937_test.go`:
- own-Org member → **200** scoped listing (incl. an `org-<uuid>`-labelled instance) with the other Org **excluded**;
- cross-Org query → **403 forbidden-cross-org**;
- operator listing → cluster-wide, unchanged;
- own-Org install → **201** into own namespace, a cross-Org body **ignored**;
- unprivileged non-Org-scoped caller → **403** (tier gate intact).

Plus `TestPathIsOrgSafe` pins the new allowlist entries and the narrow scope.

## Gates

`go build ./...` ✅ · `go vet ./...` ✅ · `go test ./internal/handler/` ✅ (full package, 152s).

## Not in scope (noted)

Silent-SSO `/catalyst/v1/apps/{uid}/launch-url` is still denied for Org sessions (the FE falls back to the direct `externalURL`). If the customer "Open" button needs the silent-SSO hop, that is a small follow-up on the same allowlist seam — deliberately left out to keep this change minimal.

Refs #4937

🤖 Generated with [Claude Code](https://claude.com/claude-code)