### PR TITLE
test(#4934): stop leaked phase1-watch + post-handover goroutines racing t.TempDir cleanup

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -801,7 +801,22 @@ func (h *Handler) resumePhase1Watch(dep *Deployment) {
 		"kubeconfigPath", dep.Result.KubeconfigPath,
 	)
 
+	// phase1WatchWG (test-only; nil in production) lets a test await this
+	// resumed watch before returning, exactly as PutKubeconfig does for the
+	// first-launch spawn (#4932). restoreFromStore fires this on a
+	// rehydrated phase1-watching record, and its terminal markPhase1Done →
+	// persistDeployment write into the store dir races Go's testing
+	// RemoveAll cleanup when the store is a t.TempDir() (the #4934 restore
+	// leak, e.g. TestPodRestart_Phase1WatchingResumesWithKubeconfig). Add(1)
+	// runs before `go` (the WaitGroup contract); Done fires when the
+	// goroutine fully unwinds.
+	if h.phase1WatchWG != nil {
+		h.phase1WatchWG.Add(1)
+	}
 	go func() {
+		if h.phase1WatchWG != nil {
+			defer h.phase1WatchWG.Done()
+		}
 		h.runPhase1Watch(dep)
 		// runPhase1Watch -> markPhase1Done flips Status terminal,
 		// but does NOT close the channels (the original

--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -145,6 +145,22 @@ type Handler struct {
 	// empty"). See makePutFixture in kubeconfig_test.go.
 	phase1WatchWG *sync.WaitGroup
 
+	// suppressPostHandoverHooks — test-only gate. markPhase1Done, at its
+	// OutcomeReady/OutcomeTimeout terminal, spawns fire-and-forget day-2
+	// goroutines on context.Background() (runAutoEstablishClusterMesh +
+	// the runPostHandover* hooks). They carry 15-min / 6-hour budgets, so
+	// in a store+kubeconfigsDir fixture backed by t.TempDir() they outlive
+	// the test body and their emitWatchEvent → recordEventAndPersist write
+	// (or a spine-seam read) races Go's testing RemoveAll cleanup
+	// ("TempDir RemoveAll cleanup: directory not empty") / trips -race.
+	// phase1WatchWG only awaits runPhase1Watch's OWN return, not these
+	// descendant goroutines. Nil/false in production (New leaves it zero)
+	// so the hooks always fire on a real Sovereign; the phase1-watch
+	// fixtures set it true so no goroutine outlives the test. The hooks
+	// keep their own dedicated coverage in post_handover_*_test.go /
+	// clustermesh_test.go. See makePutFixture in kubeconfig_test.go.
+	suppressPostHandoverHooks bool
+
 	// phase1ReadySentinel is the component id (bp- prefix stripped) whose
 	// terminal-install gates OutcomeReady (#4746). The PRIMARY watch refuses
 	// to classify a prov "ready" until this component (the console's own

--- a/products/catalyst/bootstrap/api/internal/handler/kubeconfig_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/kubeconfig_test.go
@@ -118,6 +118,20 @@ func makePutFixture(t *testing.T, status string) (*Handler, string, string, stri
 	h.phase1WatchWG = &phase1WG
 	t.Cleanup(phase1WG.Wait)
 
+	// phase1WatchWG above awaits runPhase1Watch's OWN return, but its
+	// OutcomeReady terminal (markPhase1Done) spawns fire-and-forget day-2
+	// goroutines (runAutoEstablishClusterMesh + the runPostHandover* hooks)
+	// on context.Background() carrying 15-min / 6-hour budgets. Those
+	// descendants outlive phase1WG.Wait and — because this fixture wires a
+	// real store + kubeconfigsDir on t.TempDir() — their emitWatchEvent →
+	// recordEventAndPersist write (or a spine-seam read) races Go's testing
+	// RemoveAll cleanup ("TempDir RemoveAll cleanup: directory not empty")
+	// and trips -race, intermittently reddening a clean package run (the
+	// #4934 second flake, sibling of the #4932 phase1-watch leak). Suppress
+	// the hooks here so no goroutine outlives the test; the hooks keep their
+	// own dedicated coverage in post_handover_*_test.go / clustermesh_test.go.
+	h.suppressPostHandoverHooks = true
+
 	id := "putkc-" + status
 	bearer, hash, err := newBearerToken()
 	if err != nil {

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -729,6 +729,20 @@ func (h *Handler) EnableConsoleReachabilityGate() {
 	h.consoleProbe = defaultConsoleReachable
 }
 
+// spawnPostHandoverHook runs fn on a background goroutine — the
+// fire-and-forget day-2 shape every post-handover hook uses — UNLESS the
+// test-only suppressPostHandoverHooks gate is set (see the field doc on
+// Handler). Production always spawns; the phase1-watch fixtures suppress so
+// no goroutine carrying a 15-min / 6-hour budget outlives the test body and
+// races t.TempDir cleanup / trips -race. Behaviour when not suppressed is
+// byte-identical to the previous inline `go h.run…(dep)`.
+func (h *Handler) spawnPostHandoverHook(fn func()) {
+	if h.suppressPostHandoverHooks {
+		return
+	}
+	go fn()
+}
+
 func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string, outcome string) {
 	now := time.Now().UTC()
 
@@ -1053,7 +1067,7 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 		// path (which holds no locks now) doesn't block on the
 		// per-region LB IP wait loops (each up to 5 min).
 		// docs/SOVEREIGN-MULTI-REGION-DOD.md gates D9-D12.
-		go h.runAutoEstablishClusterMesh(dep)
+		h.spawnPostHandoverHook(func() { h.runAutoEstablishClusterMesh(dep) })
 		// C10-003 (2026-05-17 t143): when Phase-1 reaches
 		// OutcomeReady, the PRIMARY's terminate path persists the
 		// final per-Job status from its own helmwatch state map.
@@ -1118,7 +1132,7 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 		// handover (Audit-stuck is non-catastrophic; operators can
 		// manually patch per #2441 fallback). See post_handover_policy_
 		// enforce.go for the full helper.
-		go h.runPostHandoverPolicyEnforceFlip(dep)
+		h.spawnPostHandoverHook(func() { h.runPostHandoverPolicyEnforceFlip(dep) })
 
 		// #4212 (Path B of #4018; un-gates #4002): carry the real-id
 		// Observe-first CloudAdoption claims from the deploy workdir's
@@ -1134,7 +1148,7 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 		// this must NOT block the terminate path. Failures log + emit SSE
 		// warn but never fail the handover (adoption is a day-2
 		// observability surface). See post_handover_adoption_apply.go.
-		go h.runPostHandoverAdoptionApply(dep)
+		h.spawnPostHandoverHook(func() { h.runPostHandoverAdoptionApply(dep) })
 
 		// #4212 Seam 3 (folds #3829): enroll the DR-capable bootstrap spine
 		// (openbao/keycloak/harbor/gitea) into the object model by stamping
@@ -1147,7 +1161,7 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 		// this must NOT block the terminate path. Failures log + emit SSE
 		// warn but never fail the handover (spine enrollment is a day-2
 		// object-model surface). See post_handover_spine_apps.go.
-		go h.runPostHandoverSpineApplications(dep)
+		h.spawnPostHandoverHook(func() { h.runPostHandoverSpineApplications(dep) })
 
 		// #4690 / #4686: on the CCM-less Huawei provider, discover the Sovereign
 		// gateway LoadBalancer Service's live auto-allocated nodePort and
@@ -1159,7 +1173,7 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 		// block the terminate path. No-op on Hetzner (hcloud-ccm programs
 		// node:443 directly). Failures log + emit SSE warn but never fail the
 		// handover. See post_handover_gateway_elb.go.
-		go h.runPostHandoverGatewayELB(dep)
+		h.spawnPostHandoverHook(func() { h.runPostHandoverGatewayELB(dep) })
 	} else if outcome == helmwatch.OutcomeTimeout && len(dep.Request.Regions) >= 2 {
 		// #3285/hw130 (2026-06-12): a Phase-1 TIMEOUT is the
 		// recoverable classification ("components observed, none
@@ -1175,7 +1189,7 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 		// it converges exactly when the env does. Handover, the job
 		// sweep, and the policy flip stay ready-only — this rescues
 		// the TOPOLOGY, not the lifecycle.
-		go h.runAutoEstablishClusterMesh(dep)
+		h.spawnPostHandoverHook(func() { h.runAutoEstablishClusterMesh(dep) })
 		// #3277 (founder, 2026-06-12): the secondary-region job rows
 		// freeze at their last-seen state forever on a timeout record
 		// (witnessed live: 9 "running" rows on hw130 with every

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch_test.go
@@ -751,16 +751,30 @@ func TestPodRestart_Phase1WatchingResumesWithKubeconfig(t *testing.T) {
 			// when the previous Pod died.
 		},
 	}
+
+	// Build the handler against the (still-empty) store first so the
+	// constructor's restoreFromStore finds nothing and spawns no watch yet.
+	// Then wire a WaitGroup the resumed watch joins (+ suppress the day-2
+	// hooks), persist the record, and restore explicitly: restoreFromStore
+	// now fires resumePhase1Watch UNDER the WaitGroup. Its background watch
+	// ends in markPhase1Done → persistDeployment, writing into the store dir
+	// (this test's t.TempDir()); left unbounded it outlives the test body
+	// and its write races Go's testing RemoveAll cleanup ("TempDir RemoveAll
+	// cleanup: directory not empty" — the #4934 restore leak). t.Cleanup is
+	// registered AFTER t.TempDir() so it runs (cleanups are LIFO) BEFORE
+	// RemoveAll. We do NOT assert on the resumed watch here (that is covered
+	// by the runPhase1Watch happy-path tests above); we only assert the
+	// gating decision (shouldResumePhase1=true) and the preserved Status.
+	h := NewWithStore(silentLogger(), &fakePDM{}, st)
+	var phase1WG sync.WaitGroup
+	h.phase1WatchWG = &phase1WG
+	h.suppressPostHandoverHooks = true
+	t.Cleanup(phase1WG.Wait)
+
 	if err := st.Save(rec); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-
-	// Build a handler against the on-disk store. We do NOT exercise
-	// runPhase1Watch end-to-end here (that's covered above); we only
-	// assert the gating decision (shouldResumePhase1=true) and the
-	// preserved Status value, both of which are the load-bearing
-	// pieces of the issue #830 Bug 3 fix.
-	h := NewWithStore(silentLogger(), &fakePDM{}, st)
+	h.restoreFromStore()
 
 	// Confirm the gating decision matches expectation.
 	dep := fromRecord(rec)


### PR DESCRIPTION
## Problem

Under `go test -race ./...` the catalyst-api handler package intermittently red-flags a clean tree. Two seen shapes, both from a background goroutine on the phase1-watch path outliving the test body:

- a DNS/powerdns test blamed for `race detected during execution of test` (a `TestRepublishDNS_*` parallel test just happens to run `checkRaces` when the leaked goroutine fires), or
- `testing.go: TempDir RemoveAll cleanup: ... directory not empty` on `TestPodRestart_Phase1WatchingResumesWithKubeconfig` / `TestPutKubeconfig_LaunchesPhase1Watch`.

A clean re-run passes, so honest PRs look like regressions. This is the second flake in the family; #4932 fixed the first (the `PutKubeconfig` first-launch spawn) but its `phase1WatchWG` does not reach two descendant spawn sites.

## Root cause + fix

**1. restore-resume spawn (`resumePhase1Watch`, deployments.go).** `restoreFromStore` rehydrates a `phase1-watching` record and spawns `go runPhase1Watch` with no join. Its terminal `markPhase1Done → persistDeployment` writes into the store dir; when the store is a `t.TempDir()` the write races Go's testing `RemoveAll`. The resumed watch now joins `phase1WatchWG` (Add before `go`, Done on unwind), mirroring the `PutKubeconfig` spawn. `TestPodRestart_Phase1WatchingResumesWithKubeconfig` builds the handler against the empty store, wires the WaitGroup, then persists + restores so the resume fires bounded, and awaits it in a `t.Cleanup` registered after `t.TempDir()` (LIFO → before RemoveAll). Assertions unchanged.

**2. post-handover hook spawns (`markPhase1Done`, phase1_watch.go).** Its OutcomeReady/OutcomeTimeout terminal spawns five fire-and-forget day-2 goroutines (`runAutoEstablishClusterMesh` + the `runPostHandover*` hooks) on `context.Background()` with 15-min / 6-hour budgets. They outlive `phase1WatchWG.Wait` and, in the store+kubeconfigsDir fixtures, persist / read the spine test-seam package vars long after the test returns. A test-only `Handler` gate (`suppressPostHandoverHooks`, false in production) routed through a `spawnPostHandoverHook` helper; `makePutFixture` sets it so no hook goroutine outlives the test. Production always spawns the hooks; they keep their own coverage in `post_handover_*_test.go` / `clustermesh_test.go`.

Test-lifecycle / determinism only — no assertion weakening, no `t.Skip`, production behaviour byte-identical.

## Verification

- `go test -race -p 1 ./internal/handler/` → green (157s)
- `TestPodRestart_Phase1WatchingResumesWithKubeconfig` -race -count=100 → green (2s)
- `TestPutKubeconfig_LaunchesPhase1Watch` -count=50 → green
- `Spine` -count=400 → green
- `Kubeconfig|PodRestart|Spine|Republish|RunPhase1Watch` -parallel=16 -count=8 ×10 loop → green
- `go build ./...` + `go vet ./...` → pass

Refs #944 #4932 #4934

🤖 Generated with [Claude Code](https://claude.com/claude-code)