### PR TITLE
test(provisioning): lock the no-duplicate per-Org apps Kustomization contract (Refs #4758)

### DIFF
--- a/core/services/provisioning/gitops/perorg_apps_tree_test.go
+++ b/core/services/provisioning/gitops/perorg_apps_tree_test.go
@@ -58,6 +58,53 @@ func TestGeneratePerOrgAppsTree_WordpressCart(t *testing.T) {
 	}
 }
 
+// TestGeneratePerOrgAppsTree_NoDuplicateAppsSyncKustomization is the #4758
+// regression guard: on a Sovereign (PerOrgGitops) the org-controller's
+// `catalyst-tenant-<slug>-apps` Flux Kustomization is the SINGLE authoritative
+// reconciler of the per-Org apps tree. The legacy contabo-model funnel
+// scaffolding emits a SECOND `tenant-<slug>-apps` Kustomization
+// (generateAppsSyncKustomization → apps-sync.yaml) that, once committed to a
+// Sovereign, becomes a broken DUPLICATE — historically it stuck FALSE on a
+// hardcoded `sourceRef.name: flux-system` (finding #1 on hw223), and even with
+// the sourceRef repointed it double-reconciles the SAME WordPress Deployment as
+// the org-controller's Kustomization (WordPress double-reconcile churn, #4827).
+//
+// GeneratePerOrgAppsTree is the pure-function seam that re-roots ONLY the app
+// payload into `vcluster/apps/` and DROPS the contabo host scaffolding. This
+// test locks that contract by NAME so the duplicate can never be re-minted: the
+// per-Org tree must carry NO apps-sync.yaml, NO `tenant-<slug>-apps`
+// Kustomization, and NO `sourceRef` at all (the org-controller owns the
+// GitRepository + Kustomization wiring).
+func TestGeneratePerOrgAppsTree_NoDuplicateAppsSyncKustomization(t *testing.T) {
+	g := NewManifestGenerator("clusters/sov/org-tenants")
+	g.ParentDomain = "omani.homes"
+
+	for _, plan := range []string{"s", "m"} {
+		t.Run("plan="+plan, func(t *testing.T) {
+			files, _ := g.GeneratePerOrgAppsTree("g6wpwalk", plan, []string{"wordpress"}, "pw123")
+
+			for path, content := range files {
+				// The contabo apps-sync scaffolding must be dropped entirely.
+				if strings.HasSuffix(path, "apps-sync.yaml") {
+					t.Errorf("per-Org tree leaked the legacy apps-sync scaffolding %q — the org-controller's catalyst-tenant-<slug>-apps is authoritative (#4758):\n%s", path, content)
+				}
+				// No rendered doc may BE the broken duplicate Kustomization: a
+				// `kind: Kustomization` named `tenant-<slug>-apps`.
+				if strings.Contains(content, "kind: Kustomization") &&
+					strings.Contains(content, "name: tenant-g6wpwalk-apps") {
+					t.Errorf("per-Org tree emitted the duplicate tenant-<slug>-apps Kustomization at %q (#4758 finding #1):\n%s", path, content)
+				}
+				// The org-controller owns the GitRepository/sourceRef wiring — the
+				// funnel payload must carry no sourceRef (and never the historically
+				// broken flux-system one).
+				if strings.Contains(content, "sourceRef:") {
+					t.Errorf("per-Org tree payload %q carries a sourceRef — the org-controller owns the GitRepository binding, the funnel payload must not (#4758):\n%s", path, content)
+				}
+			}
+		})
+	}
+}
+
 // TestMergePerOrgAppsKustomization preserves the org-controller's NP baseline
 // AND adds the funnel's app docs, deterministically + idempotently — and
 // #4567 force-EXCLUDES ciliumnetworkpolicy.yaml (which lives in host-apps/, not


### PR DESCRIPTION
## Refs #4758

### Verify-then-fix verdict: both root-cause legs already fixed on `main`

#4758 finding #1 observed TWO app-Kustomizations for one Sovereign Org on hw223:
- `catalyst-tenant-<slug>-apps` — the org-controller's authoritative reconciler.
- `tenant-<slug>-apps` — a broken DUPLICATE from `generateAppsSyncKustomization` (`gitops.go`), stuck FALSE on `GitRepository "flux-system" not found`.

Both causes are already remediated in the current tree:

| Leg | Fix | Existing tests |
|-----|-----|----------------|
| `sourceRef.name` hardcoded `flux-system` | threaded from `CATALYST_APPS_SYNC_SOURCE_REPO` (default `openova-org-tenants`) — `#4798` then `#4912` (Refs #4761). `gitops.go` line 831 now renders `name: %s`, no literal. | `TestAppsSync_SourceRepo_DefaultsToHistoricalDefault`, `TestAppsSync_SourceRepo_Configurable` |
| duplicate `tenant-<slug>-apps` emitted on a Sovereign | on a Sovereign (`PerOrgGitops`, default ON when `SOVEREIGN_FQDN` set) the initial funnel workflow authors nothing to git (`consumer.go` line 1412), and the per-Org tree (`GeneratePerOrgAppsTree`) drops the contabo apps-sync scaffolding — `#4828` (Refs #4827). | `TestGeneratePerOrgAppsTree_WordpressCart` (implicit path-prefix), `TestApplyTenantChangePerOrg_CommitsToPerOrgRepo_4384` |

### What this PR adds

The per-Org tree seam carried only an *implicit* guard (paths must be under `vcluster/apps/`). This adds one explicit, named regression test — `TestGeneratePerOrgAppsTree_NoDuplicateAppsSyncKustomization` — asserting `GeneratePerOrgAppsTree` output carries **no** `apps-sync.yaml`, **no** `tenant-<slug>-apps` Kustomization, and **no** `sourceRef` at all, so the duplicate #4758 flagged can never be re-minted at the pure-function level.

Verified non-vacuous: a throwaway probe confirmed the raw `GenerateAllWithAppConfigs` generator DOES emit the `tenant-g6wpwalk-apps` duplicate that the per-Org re-root drops.

### Gate
- `go build ./...` — pass
- `go vet ./...` — clean
- `go test ./...` (whole provisioning module) — pass, including the new guard

No product-code change — a durable regression lock only. The `wordpress`-app-serves headline of #4758 is separately tracked under #4656 (cross-region datapath) / #4936 (chart defect, fixed); this PR closes out only the Kustomization-duplicate root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)