### PR TITLE
fix(#4746): self-heal a converged prov false-failed by a lagging console probe

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -628,6 +628,24 @@ func (h *Handler) restoreFromStore() {
 			go h.runConvergedLateRescue(dep)
 		}
 
+		// #4746 — console-unreachable self-heal, the OutcomeReady sibling
+		// of the converged-late rescue above. A record stamped `failed`
+		// ONLY because the #4706 external console probe expired (Flux fully
+		// converged, Phase1Outcome==OutcomeReady) is otherwise a PERMANENT
+		// false-negative: the watch already terminated, so nothing re-probes
+		// when the console DOES come up (issue #4746 root-cause point #4).
+		// The converged-late rescue misses it (that gates on OutcomeTimeout,
+		// not OutcomeReady). This re-probes the SAME hard console gate on the
+		// next catalyst-api roll and heals the record zero-touch the moment
+		// the console answers — only ever flipping failed→ready on a POSITIVE
+		// external observation, so the hw217/hw218 false-green stays killed.
+		// Independent hook (not an else-arm): a converged-late record and a
+		// console-unreachable record are disjoint by Phase1Outcome, and each
+		// downstream step is idempotent.
+		if h.shouldConsoleUnreachableRescue(dep) {
+			go h.runConsoleUnreachableRescue(dep)
+		}
+
 		// #4212 — level-triggered spine Application-CR enrollment on startup.
 		// The spine producer (runPostHandoverSpineApplications) is otherwise
 		// one-shot (Phase-1 OutcomeReady + converged-late only), so a

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_console_rescue.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_console_rescue.go
@@ -1,0 +1,127 @@
+package handler
+
+import (
+	"time"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
+)
+
+// Console-unreachable self-heal (#4746 residual) — the OutcomeReady sibling of
+// the #3319 converged-late rescue in phase1_converged_late.go.
+//
+// #4746 fixed the ORIGINAL false-'failed' on a slow 2-region prov two ways:
+// the ready-sentinel (helmwatch.DefaultReadySentinelComponent) stops
+// OutcomeReady firing before bp-catalyst-platform — the console's OWN backend —
+// is even observed, and the #4706 external console-reachability gate now waits
+// consoleProbeBudget (35m, up from the 90s that false-failed hw221/hw222) for
+// the public console front door to answer. But BOTH of those only bound the
+// FIRST probe; neither re-probes after it. The issue's own root-cause point #4
+// named the residual harm exactly: once markPhase1Done stamps `failed` for
+// OutcomeReady + console-unreachable, "the watch already terminated — nothing
+// re-probes when the console DOES come up. Permanent false-negative." A
+// converged Sovereign whose gateway/DNS crosses the public boundary a few
+// minutes past the 35m budget (or that was transiently unreachable at the exact
+// tick the budget expired) is then latched `failed` FOREVER — inviting the
+// wrong wipe of a perfectly healthy, converged env.
+//
+// The converged-late rescue does NOT cover this: it gates on
+// outcome==OutcomeTimeout, whereas the console-unreachable failure carries
+// outcome==OutcomeReady (Flux fully converged — strictly MORE done than a
+// timeout, yet strictly LESS recoverable). This hook closes that asymmetry, so
+// a catalyst-api roll re-probes the converged record and heals it zero-touch
+// the moment the console answers.
+//
+// Safety mirrors the converged-late rescue exactly: it re-runs the SAME hard
+// console probe (h.consoleProbe → defaultConsoleReachable, the < 400 front-door
+// gate), so it can ONLY EVER upgrade failed→ready on a POSITIVE, externally-
+// observed console answer — the hw217/hw218 false-GREEN this probe exists to
+// kill stays killed. A probe error leaves the record `failed` untouched (it
+// never invents readiness). Every downstream step (fireHandover + the
+// post-handover producer chain) is idempotent and self-guarding, identical to
+// the converged-late chain.
+
+// shouldConsoleUnreachableRescue gates the startup re-probe hook. Read-only.
+// Qualifies iff the record is `failed` with Phase1Outcome==OutcomeReady (Flux
+// converged; ONLY the external console probe failed), the handover has not
+// already fired, Phase-1 has terminated, and the production console gate is
+// wired (h.consoleProbe != nil — unit tests without a stub never touch the
+// network). A failed+timeout / failed+hard-failure / already-ready / already-
+// handed-over record never qualifies.
+func (h *Handler) shouldConsoleUnreachableRescue(dep *Deployment) bool {
+	dep.mu.Lock()
+	defer dep.mu.Unlock()
+	if dep.Status != "failed" || dep.Result == nil {
+		return false
+	}
+	// Only the console-unreachable failure carries OutcomeReady. A
+	// timeout / hard-failure / flux-not-reconciling record is NOT a
+	// console-unreachable false-negative — leave those to their own paths
+	// (the converged-late rescue owns OutcomeTimeout).
+	if dep.Result.Phase1Outcome != helmwatch.OutcomeReady {
+		return false
+	}
+	if dep.Result.HandoverFiredAt != nil {
+		return false
+	}
+	if dep.Result.Phase1FinishedAt == nil {
+		return false
+	}
+	// The production console gate must be wired to re-probe; a Handler with
+	// no consoleProbe (unit tests, or a build with the #4706 gate off) has
+	// nothing to re-evaluate against and must not flip blind.
+	return h.consoleProbe != nil
+}
+
+// runConsoleUnreachableRescue re-probes the public console for a converged
+// record that was stamped `failed` only because the console had not crossed the
+// public boundary within the first probe's budget. On a POSITIVE answer it
+// flips the record ready (clearing the stale #4706 Error) and fires the full,
+// idempotent handover chain; on a negative answer it leaves the record `failed`
+// untouched. Run on a goroutine from the restore loop.
+func (h *Handler) runConsoleUnreachableRescue(dep *Deployment) {
+	if h.consoleProbe == nil {
+		return
+	}
+	if err := h.consoleProbe(dep.Request.SovereignFQDN); err != nil {
+		h.log.Info("console-unreachable rescue: console still not externally reachable; record stays failed",
+			"id", dep.ID, "err", err)
+		return
+	}
+
+	now := time.Now().UTC()
+	dep.mu.Lock()
+	// Re-check under lock — a concurrent resume/flip (or a second rescue
+	// goroutine) loses. ONLY a still-`failed`, still-OutcomeReady,
+	// still-unfired record may be upgraded, so a record that another path
+	// already advanced is never double-processed.
+	if dep.Status != "failed" || dep.Result == nil ||
+		dep.Result.Phase1Outcome != helmwatch.OutcomeReady ||
+		dep.Result.HandoverFiredAt != nil {
+		dep.mu.Unlock()
+		return
+	}
+	dep.Status = "ready"
+	// Clear the stale #4706 "console NOT externally reachable" Error — a
+	// ready deployment must not carry a failure message the wizard's
+	// FailureCard would render as a hard failure (see markPhase1Done).
+	dep.Error = ""
+	if dep.Result.Phase1FinishedAt == nil {
+		dep.Result.Phase1FinishedAt = &now
+	}
+	dep.mu.Unlock()
+	h.persistDeployment(dep)
+	h.log.Info("console-unreachable RESCUE: converged record re-probed and the console now answers — flipped to ready, firing full handover chain (#4746)",
+		"id", dep.ID)
+
+	// The full OutcomeReady chain, each step idempotent/self-guarding —
+	// identical to the converged-late rescue (phase1_converged_late.go).
+	// fireHandover + the sweep run inline (both no-op when their deps are
+	// unwired); the three producers ride spawnPostHandoverHook so the
+	// fire-and-forget shape stays test-suppressible.
+	h.fireHandover(dep)
+	h.runHandoverJobSweep(dep)
+	h.spawnPostHandoverHook(func() { h.runPostHandoverPolicyEnforceFlip(dep) })
+	h.spawnPostHandoverHook(func() { h.runPostHandoverAdoptionApply(dep) })
+	h.spawnPostHandoverHook(func() { h.runPostHandoverSpineApplications(dep) })
+	h.spawnPostHandoverHook(func() { h.runPostHandoverGatewayELB(dep) })
+}

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_console_rescue_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_console_rescue_test.go
@@ -1,0 +1,125 @@
+package handler
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// mkConsoleRescueDep builds a Deployment in the console-unreachable-failed
+// shape: status=failed, Phase1Outcome=OutcomeReady (Flux converged, only the
+// #4706 external console probe failed), Phase1FinishedAt set, handover unfired.
+// Callers override individual fields to exercise the negative gate branches.
+func mkConsoleRescueDep(status, outcome string, finished, fired bool) *Deployment {
+	r := &provisioner.Result{Phase1Outcome: outcome}
+	if finished {
+		now := time.Now().UTC()
+		r.Phase1FinishedAt = &now
+	}
+	if fired {
+		now := time.Now().UTC()
+		r.HandoverFiredAt = &now
+	}
+	return &Deployment{
+		ID:      "hw221consoleunreach",
+		Status:  status,
+		Request: provisioner.Request{SovereignFQDN: "hw221.omani.works"},
+		Result:  r,
+		Error:   "Phase 1 converged (all HelmReleases installed) but the console is NOT externally reachable",
+	}
+}
+
+// TestShouldConsoleUnreachableRescue locks the #4746 residual-rescue gate:
+// ONLY a failed + OutcomeReady + finished + unfired record with the production
+// console gate wired qualifies. A timeout/hard-failure record (the converged-
+// late rescue's job), an already-ready or already-handed-over record, an
+// in-flight record, and a Handler with no console gate all fail the gate.
+func TestShouldConsoleUnreachableRescue(t *testing.T) {
+	probe := func(string) error { return nil }
+	hWired := &Handler{log: silentLogger(), consoleProbe: probe}
+	hNoGate := &Handler{log: silentLogger()} // consoleProbe == nil
+
+	if !hWired.shouldConsoleUnreachableRescue(mkConsoleRescueDep("failed", helmwatch.OutcomeReady, true, false)) {
+		t.Errorf("failed+OutcomeReady+finished+unfired with a wired console gate must qualify (the hw221 shape)")
+	}
+	if hWired.shouldConsoleUnreachableRescue(mkConsoleRescueDep("failed", helmwatch.OutcomeTimeout, true, false)) {
+		t.Errorf("failed+timeout is the converged-late rescue's job, not this one")
+	}
+	if hWired.shouldConsoleUnreachableRescue(mkConsoleRescueDep("failed", helmwatch.OutcomeFailed, true, false)) {
+		t.Errorf("hard failure must never console-rescue")
+	}
+	if hWired.shouldConsoleUnreachableRescue(mkConsoleRescueDep("failed", helmwatch.OutcomeReady, true, true)) {
+		t.Errorf("already-fired handover must not re-rescue")
+	}
+	if hWired.shouldConsoleUnreachableRescue(mkConsoleRescueDep("ready", helmwatch.OutcomeReady, true, false)) {
+		t.Errorf("already-ready records are not rescue candidates")
+	}
+	if hWired.shouldConsoleUnreachableRescue(mkConsoleRescueDep("failed", helmwatch.OutcomeReady, false, false)) {
+		t.Errorf("Phase-1 not terminated (Phase1FinishedAt nil) must not rescue")
+	}
+	if hNoGate.shouldConsoleUnreachableRescue(mkConsoleRescueDep("failed", helmwatch.OutcomeReady, true, false)) {
+		t.Errorf("a Handler with no wired console gate must never flip blind")
+	}
+	// Defensive: a nil Result must not panic and must not qualify.
+	if hWired.shouldConsoleUnreachableRescue(&Deployment{ID: "x", Status: "failed"}) {
+		t.Errorf("nil Result must not qualify")
+	}
+}
+
+// TestRunConsoleUnreachableRescue_ProbeStillDown_LeavesFailed proves the
+// conservative half: when the re-probe still fails, the record is left `failed`
+// with its Error intact — the rescue never invents readiness.
+func TestRunConsoleUnreachableRescue_ProbeStillDown_LeavesFailed(t *testing.T) {
+	h := &Handler{
+		log:          silentLogger(),
+		consoleProbe: func(string) error { return fmt.Errorf("connection refused") },
+	}
+	dep := mkConsoleRescueDep("failed", helmwatch.OutcomeReady, true, false)
+	wantErr := dep.Error
+
+	h.runConsoleUnreachableRescue(dep)
+
+	dep.mu.Lock()
+	defer dep.mu.Unlock()
+	if dep.Status != "failed" {
+		t.Errorf("status must stay failed when the console is still unreachable; got %q", dep.Status)
+	}
+	if dep.Error != wantErr {
+		t.Errorf("Error must be preserved on a still-down re-probe; got %q", dep.Error)
+	}
+	if dep.Result.HandoverFiredAt != nil {
+		t.Errorf("handover must NOT fire when the console is still unreachable")
+	}
+}
+
+// TestRunConsoleUnreachableRescue_ProbeUp_FlipsReady proves the heal: a positive
+// re-probe flips the converged record ready, clears the stale #4706 Error, and
+// stamps Phase1FinishedAt. Post-handover hooks are suppressed and the handover
+// signer / store / jobs are unwired so the flip is asserted deterministically
+// without standing up the real handover machinery.
+func TestRunConsoleUnreachableRescue_ProbeUp_FlipsReady(t *testing.T) {
+	h := &Handler{
+		log:                       silentLogger(),
+		consoleProbe:              func(string) error { return nil }, // console now answers
+		suppressPostHandoverHooks: true,                             // no producer goroutines
+		// store, handoverSigner, jobs all nil → fireHandover + sweep + persist no-op
+	}
+	dep := mkConsoleRescueDep("failed", helmwatch.OutcomeReady, false, false)
+
+	h.runConsoleUnreachableRescue(dep)
+
+	dep.mu.Lock()
+	defer dep.mu.Unlock()
+	if dep.Status != "ready" {
+		t.Fatalf("status must flip to ready when the console now answers; got %q", dep.Status)
+	}
+	if dep.Error != "" {
+		t.Errorf("stale #4706 Error must be cleared on the ready flip; got %q", dep.Error)
+	}
+	if dep.Result.Phase1FinishedAt == nil {
+		t.Errorf("Phase1FinishedAt must be stamped on the ready flip")
+	}
+}


### PR DESCRIPTION
## What / why (Refs #4746)

**Verify-then-fix.** The original #4746 false-`failed` on a slow 2-region prov is **already fixed on main**:
- **Ready-sentinel** (`helmwatch.DefaultReadySentinelComponent = "catalyst-platform"`, PR #4910) — `OutcomeReady` cannot fire before the console's own backend is even observed.
- **Console-reachability budget** raised 90s → **35m** (`consoleProbeBudget`, PR #4751) — the #4706 gate now waits through the real keycloak→gitea→catalyst-platform console-up chain.

Both are merged with tests (`ready_sentinel_test.go`, `phase1_console_gate_test.go`). This PR closes the **one residual false-negative** the issue's own root-cause point #4 named:

> because the watch already terminated — nothing re-probes when the console DOES come up. Permanent false-negative.

The 35m budget only bounds the **first** probe. A converged Sovereign whose gateway/DNS crosses the public boundary a few minutes past 35m (or that was transiently unreachable at the exact tick the budget expired) is latched `failed` **forever** — inviting the wrong wipe of a healthy env. The converged-late rescue (#3319) does not catch it: that gates on `OutcomeTimeout`, whereas a console-unreachable failure carries `OutcomeReady` (Flux fully converged — strictly *more* done than a timeout, yet strictly *less* recoverable).

## Change

New `phase1_console_rescue.go`, wired as an independent hook in the startup-restore loop next to the converged-late rescue:
- `shouldConsoleUnreachableRescue` — qualifies a `failed` + `OutcomeReady` + finished + unfired record when the production console gate is wired.
- `runConsoleUnreachableRescue` — re-runs the **same hard** `h.consoleProbe` (the `< 400` front-door gate). On a positive external answer it flips ready (clearing the stale #4706 Error) and fires the idempotent handover chain; a still-down re-probe leaves the record `failed` untouched.

**Safety:** it only ever upgrades failed → ready on a **positive external observation**, so the hw217/hw218 false-green the probe exists to kill stays killed. Downstream steps are the same idempotent, self-guarding chain the converged-late rescue uses.

## Tests
`phase1_console_rescue_test.go` — gate branches (timeout / hard-fail / already-ready / already-fired / in-flight / no-gate / nil-Result all correctly rejected), the still-down path (stays failed, Error preserved), and the console-up path (flips ready, stale Error cleared, `Phase1FinishedAt` stamped). `go build ./...` + `go vet` green; full handler package green.

## Explains hw235
hw235 (dep b6ba0f7930c5e77d) sat at `phase1-watching` with events reading "all 65 components reached installed" — that is the **35m console probe running** at the top of `markPhase1Done` (status stays `phase1-watching` while probing). Expected post-fix behavior, not a regression. If the console answered within 35m it flipped ready; if not it flipped `failed` — and this PR is what then re-probes and heals it on the next catalyst-api roll instead of leaving it permanently false-failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)