### PR TITLE
fix(org-controller): tier-honest Org Ready message — no false "vCluster HelmRelease Ready" for host-tier Orgs (Refs #4813)

### DIFF
--- a/core/controllers/organization/internal/controller/organization_controller.go
+++ b/core/controllers/organization/internal/controller/organization_controller.go
@@ -748,7 +748,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if vcReady {
 		readyCond.Status = "True"
 		readyCond.Reason = "Reconciled"
-		readyCond.Message = "vCluster HelmRelease Ready + Keycloak group + Gitea Org reconciled"
+		// #4813 (status honesty): word the Ready message off the SAME
+		// #4292/#4339 tier gate vclusterReadiness used, so it names the
+		// boundary that ACTUALLY backs the Org. A host-tier (""/s/free) Org
+		// authors NO vCluster HelmRelease — its host `<slug>` namespace IS the
+		// boundary — so asserting "vCluster HelmRelease Ready" for it is a
+		// false green over absent backing (Ready-over-absent-backing
+		// anti-pattern, cf. #3687 / #856). Only the vcluster tier
+		// (m/l/xl/flexi) authors + waits on the HR, so only it may claim it.
+		readyCond.Message = readyOrgMessage(org.Spec.PlanSlug)
 	} else {
 		readyCond.Status = "False"
 		readyCond.Reason = "VClusterProvisioning"
@@ -801,6 +809,26 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 	return ctrl.Result{}, nil
+}
+
+// readyOrgMessage words the Organization's Ready=True condition message off the
+// SAME #4292/#4339 tier gate that decides the boundary primitive
+// (gitops.BoundaryIsVcluster) + that vclusterReadiness keys off. This keeps the
+// human-readable status HONEST about what actually backs the Org (#4813):
+//
+//   - vcluster tier (m/l/xl/flexi): a real vCluster HelmRelease was authored +
+//     is Ready, so the message names it.
+//   - host tier (""/s/free): NO vCluster HR is ever authored — the host `<slug>`
+//     namespace IS the boundary. vclusterReadiness returns Ready as soon as that
+//     namespace is Active (no HR to wait on), so claiming "vCluster HelmRelease
+//     Ready" here would be a false green over absent backing (the
+//     Ready-over-absent-backing anti-pattern flagged in #4813, cf. #3687 / #856).
+//     The message instead names the host namespace boundary that truly exists.
+func readyOrgMessage(planSlug string) string {
+	if gitops.BoundaryIsVcluster(planSlug) {
+		return "vCluster HelmRelease Ready + Keycloak group + Gitea Org reconciled"
+	}
+	return "host namespace Active + Keycloak group + Gitea Org reconciled (namespace-isolated tier — no vCluster authored)"
 }
 
 // vclusterReadiness reads back the vCluster HelmRelease the controller

--- a/core/controllers/organization/internal/controller/vcluster_readiness_test.go
+++ b/core/controllers/organization/internal/controller/vcluster_readiness_test.go
@@ -8,6 +8,7 @@ package controller
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -201,6 +202,37 @@ func TestVClusterReadiness_HostTierDoesNotWaitOnVclusterHR(t *testing.T) {
 	// still waiting on the vcluster HR that has not reconciled yet.
 	if _, ready, _ := r.vclusterReadiness(context.Background(), slug, "m"); ready {
 		t.Errorf("vcluster-tier plan \"m\" must wait on the vcluster HR; got Ready with only the namespace present")
+	}
+}
+
+// TestReadyOrgMessage_TierHonesty locks #4813 (status honesty): the Org's
+// Ready=True message must name the boundary that ACTUALLY backs the Org. A
+// host-tier (""/s/free) Org authors NO vCluster HelmRelease — its host `<slug>`
+// namespace is the boundary — so the message must NOT assert "vCluster
+// HelmRelease Ready" for it (the Ready-over-absent-backing false-green the issue
+// flagged). Only the vcluster tier (m/l/xl/flexi) may claim the HR is Ready. The
+// helper keys off the SAME gitops.BoundaryIsVcluster tier gate vclusterReadiness
+// uses, so the message can never diverge from the boundary it reports.
+func TestReadyOrgMessage_TierHonesty(t *testing.T) {
+	// Host-tier plans: no vCluster HR is ever authored — the message must not
+	// claim one is Ready.
+	for _, plan := range []string{"", "s", "free"} {
+		msg := readyOrgMessage(plan)
+		if strings.Contains(msg, "vCluster HelmRelease") {
+			t.Errorf("host-tier plan %q Ready message must NOT assert a vCluster HelmRelease (false green over absent backing); got %q", plan, msg)
+		}
+		if !strings.Contains(msg, "host namespace") {
+			t.Errorf("host-tier plan %q Ready message should name the host namespace boundary that actually backs the Org; got %q", plan, msg)
+		}
+	}
+
+	// vcluster-tier plans: a real vCluster HR was authored + is Ready — the
+	// message names it.
+	for _, plan := range []string{"m", "l", "xl", "flexi"} {
+		msg := readyOrgMessage(plan)
+		if !strings.Contains(msg, "vCluster HelmRelease Ready") {
+			t.Errorf("vcluster-tier plan %q Ready message should name the vCluster HelmRelease that backs the Org; got %q", plan, msg)
+		}
 	}
 }
 


### PR DESCRIPTION
## What

Makes the Organization `Ready=True` condition message HONEST about the boundary that actually backs the Org.

A namespace-isolated (host-tier: `""`/`s`/`free`) Organization authors **no** vCluster HelmRelease — its host `<slug>` namespace **is** the boundary, and `vclusterReadiness` returns Ready as soon as that namespace is Active (#4339). But the reconcile loop hardcoded the Ready message to:

> `vCluster HelmRelease Ready + Keycloak group + Gitea Org reconciled`

for **every** Ready Org — so a host-tier Org reported a vCluster HelmRelease that never existed. This is the Ready-over-absent-backing false-green flagged in #4813's evidence (cf. #3687 / #856).

## Fix

`readyCond.Message` now comes from a pure `readyOrgMessage(planSlug)` helper that keys off the **same** `gitops.BoundaryIsVcluster` tier gate the boundary render + readiness readback use, so the message can never diverge from the boundary it reports:

- **vcluster tier** (`m`/`l`/`xl`/`flexi`) → `"vCluster HelmRelease Ready + Keycloak group + Gitea Org reconciled"`
- **host tier** (`""`/`s`/`free`) → `"host namespace Active + Keycloak group + Gitea Org reconciled (namespace-isolated tier — no vCluster authored)"`

Adds `TestReadyOrgMessage_TierHonesty` locking that host-tier messages never assert a vCluster HR and vcluster-tier messages do.

## Verification note on the isolation-mode selection (issue ask #1)

The isolation-mode **selection** is already correct and consistent across BOTH provisioning doors: the funnel (`createOrganizationCR`) and the console/BSS door (`createOrgOrganizationCR`→`ensureOrganizationCR`) both mint the same Organization CR carrying `spec.planSlug`, and the org-controller gates isolation via the single `boundaryIsVcluster(planSlug)` tier gate (free/S → namespace, M+ → vcluster — the #4292 WAD policy the founder confirmed on the issue). No remaining code path lands a customer M+ Org namespace-only. This PR therefore only addresses the status-honesty facet (issue ask #2).

## Test

```
go build ./organization/...            # ok
go vet  ./organization/internal/controller/...   # ok
go test ./organization/...             # ok (TestReadyOrgMessage_TierHonesty + full suite green)
```

Refs #4813 #4292 #4339 #3687