### PR TITLE
fix(#4821): tenant console_host honours Sovereign apps pool, not funnel TLD

### DIFF
--- a/core/services/tenant/handlers/console_host_apps_pool_4821_test.go
+++ b/core/services/tenant/handlers/console_host_apps_pool_4821_test.go
@@ -1,0 +1,131 @@
+package handlers
+
+// console_host_apps_pool_4821_test.go — #4821 Finding-2 contract.
+//
+// The tenant-service returns a SERVER-AUTHORITATIVE `console_host`
+// (`console.<slug>.<parentDomain>`) that the marketplace funnel redirects to
+// after Launch (CheckoutStep.svelte::setActiveOrgConsoleHost). The
+// org-controller — the door that actually WRITES the per-Org DNS A-record +
+// console TLS cert + HTTPRoute — stamps its pool via the identical
+// apps-pool-wins rule (organization_create.go::resolveOrgParentDomain, #4421):
+// the Sovereign's EFFECTIVE apps pool (env TENANT_PARENT_DOMAIN) WINS over the
+// funnel-selected TLD.
+//
+// Finding-2 was the DISAGREEMENT: on hw228 the funnel offered `.omani.rest`
+// but the Sovereign's single apps pool is `omani.homes`. The org-controller
+// provisioned `console.acme.omani.homes`, while this service returned
+// `console.acme.omani.rest` (the raw funnel pick) — an NXDOMAIN host — so the
+// post-Launch redirect 404'd. These tests lock the two doors to the SAME pool.
+
+import (
+	"testing"
+
+	"github.com/openova-io/openova/core/services/tenant/store"
+)
+
+func TestResolveOrgParentDomain_AppsPoolWins(t *testing.T) {
+	cases := []struct {
+		name       string
+		appsPool   string
+		funnelPick string
+		want       string
+	}{
+		{
+			// The exact #4821 Finding-2 shape: funnel offered omani.rest,
+			// Sovereign apps pool is omani.homes → apps pool WINS.
+			name:       "funnel_pick_differs_apps_pool_wins",
+			appsPool:   "omani.homes",
+			funnelPick: "omani.rest",
+			want:       "omani.homes",
+		},
+		{
+			// Funnel pick agrees with the apps pool (the #4176 separate-pool
+			// happy path) → no change, both resolve to the same value.
+			name:       "funnel_pick_matches_apps_pool",
+			appsPool:   "omani.homes",
+			funnelPick: "omani.homes",
+			want:       "omani.homes",
+		},
+		{
+			// Funnel offered nothing but the Sovereign has an apps pool →
+			// apps pool supplies the zone (this is what makes console_host
+			// resolvable even when the funnel omits parent_domain).
+			name:       "empty_funnel_pick_uses_apps_pool",
+			appsPool:   "omani.homes",
+			funnelPick: "",
+			want:       "omani.homes",
+		},
+		{
+			// Degenerate / single-domain Sovereign with NO apps pool wired →
+			// fall back to the funnel pick, matching the org-controller's own
+			// empty-appsPool fallback (resolveOrgParentDomain returns payload).
+			name:       "no_apps_pool_falls_back_to_funnel_pick",
+			appsPool:   "",
+			funnelPick: "omani.rest",
+			want:       "omani.rest",
+		},
+		{
+			// Neither configured → empty (deriveTenantConsoleHost then yields
+			// "" and the client keeps its host-splice fallback).
+			name:       "both_empty",
+			appsPool:   "",
+			funnelPick: "",
+			want:       "",
+		},
+		{
+			// Casing + surrounding whitespace are normalised.
+			name:       "apps_pool_normalised",
+			appsPool:   "  Omani.Homes  ",
+			funnelPick: "omani.rest",
+			want:       "omani.homes",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveOrgParentDomain(tc.appsPool, tc.funnelPick); got != tc.want {
+				t.Fatalf("resolveOrgParentDomain(%q, %q) = %q, want %q",
+					tc.appsPool, tc.funnelPick, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestConsoleHost_MatchesOrgControllerPool is the end-to-end Finding-2 contract:
+// the console_host this service returns MUST be composed from the apps-pool-
+// resolved parent domain, NOT the raw funnel pick — so it equals the host the
+// org-controller provisions. Reproduces the hw228 acme scenario exactly.
+func TestConsoleHost_MatchesOrgControllerPool(t *testing.T) {
+	const (
+		slug       = "acme"
+		appsPool   = "omani.homes" // what the Sovereign actually serves + org-controller writes
+		funnelPick = "omani.rest"  // what the funnel offered (Finding-2)
+	)
+
+	// Mirror CreateOrg: the persisted Tenant.ParentDomain is the RESOLVED pool.
+	resolved := resolveOrgParentDomain(appsPool, funnelPick)
+	tenant := &store.Tenant{Subdomain: slug, ParentDomain: resolved}
+
+	got := deriveTenantConsoleHost(tenant)
+	const want = "console.acme.omani.homes"
+	if got != want {
+		t.Fatalf("console_host = %q, want %q (must match the org-controller's provisioned pool, not the funnel pick)", got, want)
+	}
+
+	// Guard against the regression: the returned host must NOT carry the raw
+	// funnel TLD, which the org-controller never provisions (→ NXDOMAIN → 404).
+	badTenant := &store.Tenant{Subdomain: slug, ParentDomain: funnelPick}
+	if bad := deriveTenantConsoleHost(badTenant); bad == got {
+		t.Fatalf("resolved host collided with the raw funnel-pick host %q — the apps-pool override did not take effect", bad)
+	}
+}
+
+// TestConsoleHost_LegacySingleDomain_UsesFunnelPick asserts back-compat: a
+// Sovereign with NO apps pool wired (AppsParentDomain empty) still honours the
+// funnel pick verbatim, so #4176/#4179 separate-pool Sovereigns are unaffected.
+func TestConsoleHost_LegacySingleDomain_UsesFunnelPick(t *testing.T) {
+	resolved := resolveOrgParentDomain("", "omani.works")
+	tenant := &store.Tenant{Subdomain: "demo", ParentDomain: resolved}
+	if got, want := deriveTenantConsoleHost(tenant), "console.demo.omani.works"; got != want {
+		t.Fatalf("legacy console_host = %q, want %q", got, want)
+	}
+}

--- a/core/services/tenant/handlers/handlers.go
+++ b/core/services/tenant/handlers/handlers.go
@@ -53,6 +53,20 @@ type Handler struct {
 	// when the event bus is unavailable.
 	ProvisioningURL string
 
+	// AppsParentDomain is the Sovereign's EFFECTIVE org-pool apps zone
+	// (env TENANT_PARENT_DOMAIN, e.g. "omani.homes") — the SAME value the
+	// provisioning service + org-controller key off. #4821 Finding-2: when
+	// non-empty it WINS over the funnel-selected `parent_domain`, so the
+	// server-authoritative `console_host` this service returns (and the
+	// `parent_domain` it persists + emits on `tenant.created`) matches the pool
+	// the org-controller actually provisions the per-Org DNS / TLS / HTTPRoute
+	// under. See resolveOrgParentDomain below + the identical #4421 apps-pool-wins
+	// invariant on the provisioning door (core/services/provisioning/handlers/
+	// organization_create.go::resolveOrgParentDomain, which the org-controller CR
+	// then honours). Empty preserves the legacy behaviour: honour the funnel pick
+	// verbatim (single-domain / degenerate Sovereigns with no apps pool wired).
+	AppsParentDomain string
+
 	// DayTwoLocks serializes day-2 install/uninstall on a given tenant so
 	// concurrent callers see consistent tenant.Apps reads. Issue #110.
 	// Callers MUST pre-populate via NewTenantLocks(); nil is not safe.
@@ -182,7 +196,7 @@ func (h *Handler) CreateOrg(w http.ResponseWriter, r *http.Request) {
 		// CreateOrg publishes an extra `tenant.sandbox_requested`
 		// event the sandbox-controller consumes to mint a Sandbox CR
 		// with `spec.agentCatalogue` = these slugs. Tolerated empty.
-		Agents   []string `json:"agents"`
+		Agents []string `json:"agents"`
 		// TBD-V18-D follow-up to PR #2038 — per-app configSchema
 		// values, keyed by app SLUG. Each inner map is `ConfigField.Key`
 		// → field-typed primitive (int / string / bool). Persisted on
@@ -229,7 +243,27 @@ func (h *Handler) CreateOrg(w http.ResponseWriter, r *http.Request) {
 	// #4176/#4179: normalize the chosen org-pool parent apex. Strip any
 	// leading dot the marketplace TLD <select> may carry (".omani.works")
 	// and lowercase so deriveConsoleHost composes a clean RFC-1123 host.
-	parentDomain := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(body.ParentDomain, ".")))
+	funnelParentDomain := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(body.ParentDomain, ".")))
+
+	// #4821 Finding-2: the Sovereign's apps pool WINS over the funnel pick.
+	// The org-controller stamps spec.tenantPublic.parentDomain via the SAME
+	// apps-pool-wins rule (organization_create.go::resolveOrgParentDomain, #4421)
+	// and writes the per-Org DNS / TLS / HTTPRoute under THAT zone. If this
+	// service persisted (and returned as console_host) the raw funnel pick
+	// instead, a Sovereign that serves a single apps pool (`omani.homes`) but
+	// whose funnel offered `omani.rest` would return console.<slug>.omani.rest —
+	// an NXDOMAIN host the org-controller never provisions — so the post-Launch
+	// redirect 404s (the reported #4821 Finding-2). Resolving to the apps pool
+	// here keeps the returned/persisted/emitted host in lockstep with what the
+	// org-controller actually provisions. Empty AppsParentDomain (legacy /
+	// single-domain Sovereign) falls back to the funnel pick, unchanged.
+	parentDomain := resolveOrgParentDomain(h.AppsParentDomain, funnelParentDomain)
+	if funnelParentDomain != "" && parentDomain != funnelParentDomain {
+		slog.Warn("CreateOrg: funnel-selected parent_domain overridden by the Sovereign apps pool to keep console_host aligned with the org-controller's provisioned pool (#4821 Finding-2 / #4421)",
+			"slug", body.Slug,
+			"funnel_parent_domain", funnelParentDomain,
+			"apps_parent_domain", parentDomain)
+	}
 
 	tenant := &store.Tenant{
 		Slug:         body.Slug,
@@ -476,6 +510,27 @@ func (h *Handler) dispatchFunnelCartInstall(ctx context.Context, t *store.Tenant
 		slog.Info("funnel cart-install: dispatched cart app",
 			"tenant_id", t.ID, "slug", t.Subdomain, "app", slug)
 	}
+}
+
+// resolveOrgParentDomain picks the org-pool parent zone the Tenant's
+// ParentDomain (→ console_host + tenant.created payload) is stamped with.
+// #4821 Finding-2: it MIRRORS the provisioning door's resolver of the same name
+// (core/services/provisioning/handlers/organization_create.go) so BOTH doors —
+// and the org-controller CR they mint — agree on the pool.
+//
+// THE INVARIANT (#4421): the pool this service returns as the customer's
+// console_host MUST equal the pool the org-controller writes the per-Org DNS
+// A-record + console TLS cert + HTTPRoute under. appsParentDomain is the
+// Sovereign's EFFECTIVE apps pool (env TENANT_PARENT_DOMAIN); it is non-empty on
+// any real Sovereign, so it WINS. The per-customer funnel pick is honoured only
+// as a last-resort fallback on a degenerate Sovereign with no apps pool wired
+// (which then matches the org-controller's own empty-appsPool fallback).
+// Returns lowercased/trimmed.
+func resolveOrgParentDomain(appsParentDomain, funnelParentDomain string) string {
+	if pd := strings.ToLower(strings.TrimSpace(appsParentDomain)); pd != "" {
+		return pd
+	}
+	return strings.ToLower(strings.TrimSpace(funnelParentDomain))
 }
 
 // deriveTenantConsoleHost composes the per-Org customer console host:

--- a/core/services/tenant/main.go
+++ b/core/services/tenant/main.go
@@ -43,6 +43,14 @@ func main() {
 	corsOrigin := getEnv("CORS_ORIGIN", "*")
 	catalogURL := getEnv("CATALOG_URL", "http://catalog.org-services.svc.cluster.local:8082")
 	provisioningURL := getEnv("PROVISIONING_URL", "http://provisioning.org-services.svc.cluster.local:8084")
+	// TENANT_PARENT_DOMAIN — the Sovereign's EFFECTIVE org-pool apps zone
+	// (e.g. "omani.homes"), the SAME env the provisioning service reads. #4821
+	// Finding-2: CreateOrg resolves the server-authoritative console_host
+	// (`console.<slug>.<parentDomain>`) against THIS value (apps pool wins over
+	// the funnel-selected TLD) so the returned/persisted/emitted host matches the
+	// pool the org-controller actually provisions the per-Org DNS/TLS/HTTPRoute
+	// under. Empty preserves the legacy behaviour (honour the funnel pick).
+	appsParentDomain := getEnv("TENANT_PARENT_DOMAIN", "")
 	port := getEnv("PORT", "8083")
 
 	// Connect to MongoDB (FerretDB).
@@ -103,14 +111,17 @@ func main() {
 	tenantStore := store.New(client, mongoDBName)
 	catalogClient := catalog.New(catalogURL)
 	h := &handlers.Handler{
-		Store:           tenantStore,
-		Producer:        producer,
-		Catalog:         catalogClient,
-		ProvisioningURL: provisioningURL,
-		DayTwoLocks:     handlers.NewTenantLocks(),
+		Store:            tenantStore,
+		Producer:         producer,
+		Catalog:          catalogClient,
+		ProvisioningURL:  provisioningURL,
+		AppsParentDomain: appsParentDomain,
+		DayTwoLocks:      handlers.NewTenantLocks(),
 	}
 	slog.Info("catalog client configured", "url", catalogURL)
 	slog.Info("provisioning URL configured", "url", provisioningURL)
+	slog.Info("apps parent domain configured (console_host pool)",
+		"tenant_parent_domain", appsParentDomain, "enabled", appsParentDomain != "")
 
 	// Provision-events consumer drives the tenant state machine when
 	// provisioning publishes provision.completed / .failed / .app_ready

--- a/products/catalyst/chart/templates/org-services/organization.yaml
+++ b/products/catalyst/chart/templates/org-services/organization.yaml
@@ -73,6 +73,18 @@ spec:
                 configMapKeyRef:
                   name: org-services-config
                   key: PROVISIONING_URL
+            # #4821 Finding-2: the Sovereign's EFFECTIVE org-pool apps zone —
+            # the SAME value wired onto the provisioning Deployment (provisioning.yaml
+            # TENANT_PARENT_DOMAIN). CreateOrg resolves the server-authoritative
+            # console_host (`console.<slug>.<parentDomain>`) against this pool so the
+            # returned/persisted/emitted host matches the pool the org-controller
+            # provisions the per-Org DNS/TLS/HTTPRoute under (apps pool WINS over the
+            # funnel-selected TLD, the #4421 invariant). Sourced from the same
+            # `.Values.orgServices.provisioning.tenantParentDomain` so the tenant +
+            # provisioning services can NEVER drift. Empty preserves the legacy
+            # behaviour (honour the funnel pick verbatim).
+            - name: TENANT_PARENT_DOMAIN
+              value: {{ .Values.orgServices.provisioning.tenantParentDomain | default "" | quote }}
           resources:
             requests:
               cpu: 25m


### PR DESCRIPTION
## What

Closes the remaining **Finding-2** of #4821: a funnel customer-Org's post-Launch redirect 404s because the tenant-service's server-authoritative `console_host` disagreed with the pool the org-controller actually provisions.

On hw228 the funnel offered `.omani.rest` but the Sovereign's single apps pool is `omani.homes`:

| door | pool it used | host |
|---|---|---|
| org-controller (writes DNS + TLS + HTTPRoute) | apps pool (`resolveOrgParentDomain`, #4421) | `console.acme.omani.homes` |
| tenant-service (returned `console_host`) | raw funnel pick | `console.acme.omani.rest` ← **NXDOMAIN** |

So the returning-user redirect target (`.rest`) never resolved.

## Fix

The tenant-service now resolves the effective org-pool zone with the **same apps-pool-wins rule** the provisioning door + org-controller already use (the #4421 invariant: the pool the console host lives under must equal the pool the per-Org DNS/TLS/HTTPRoute is written under).

- `CreateOrg` reads the Sovereign apps pool from env `TENANT_PARENT_DOMAIN` and lets it win over the funnel-selected TLD. The resolved value flows to the returned `console_host`, the persisted `Tenant.ParentDomain`, and the `tenant.created` payload — all three now match what the org-controller provisions.
- Empty `TENANT_PARENT_DOMAIN` preserves the legacy behaviour (honour the funnel pick verbatim), so #4176/#4179 separate-pool Sovereigns are unaffected. When the funnel pick already agrees with the apps pool, this is a no-op.
- The chart wires the **same** `.Values.orgServices.provisioning.tenantParentDomain` onto the tenant Deployment that already feeds the provisioning Deployment, so the two services can never drift.

## Files

- `core/services/tenant/handlers/handlers.go` — `Handler.AppsParentDomain` + `resolveOrgParentDomain` (mirrors the provisioning door); `CreateOrg` resolves the pool + warn-logs on override.
- `core/services/tenant/main.go` — wire `TENANT_PARENT_DOMAIN`.
- `products/catalyst/chart/templates/org-services/organization.yaml` — env wiring (helm-render verified: `TENANT_PARENT_DOMAIN: "omani.homes"`).
- `console_host_apps_pool_4821_test.go` — locks both doors to one pool (incl. the exact hw228 acme reproduction + legacy back-compat).

`go build ./...`, `go vet ./...`, `go test ./...` all green in `core/services/tenant`.

## On the `dns:pending` half of the issue title

Verified already-fixed, no new code needed:
- The stall was root-caused (issue comment) to the per-Org vcluster HelmRelease schema rejection and fixed by **PR #4822** (merged; `manifests.go` now uses `networking.replicateServices.fromHost`).
- The org-controller DNS write path (`tenant_dns.go`) is best-effort + self-healing (env → bridged secret → source secret, #4290/#4475) and requeues on a missing key rather than silently skipping — it cannot hang the reconcile.
- Corroborated by hw234 Wave-D: `console.acme.omani.homes` -> 200.

Refs #4821 #4421 #4176

🤖 Generated with [Claude Code](https://claude.com/claude-code)