### PR TITLE
fix(#4902): cascade-delete host-flux GitRepository + Kustomization on Application delete

### DIFF
--- a/core/controllers/application/internal/controller/application_controller.go
+++ b/core/controllers/application/internal/controller/application_controller.go
@@ -205,6 +205,20 @@ const FinalizerName = "application.apps.openova.io/finalizer"
 // ownerRefs only resolve inside a single namespace; see #4902).
 const LabelAppUID = "catalyst.openova.io/app-uid"
 
+// LabelHostFluxApp / LabelHostFluxAppNamespace are the back-pointer labels
+// ensureHostFluxBootstrap stamps on the host-cluster Flux GitRepository +
+// per-region Kustomization CRs it imperatively upserts (those CRs ALSO carry
+// LabelAppUID). handleDeletion() cascades on LabelAppUID for these too — the
+// CRs live in HostFluxNamespace (flux-system), a DIFFERENT namespace than the
+// Application CR, so an ownerReference would be hard-GC'd the instant it is
+// created (same cross-namespace-GC trap as the fan-out HRs; see #4902). The
+// name+namespace pair is the uid-absent fallback selector (disambiguates
+// same-named Applications across Orgs).
+const (
+	LabelHostFluxApp          = "catalyst.openova.io/application"
+	LabelHostFluxAppNamespace = "catalyst.openova.io/app-namespace"
+)
+
 // Gitea is the subset of the gitea.Client surface the reconciler needs.
 // Defining it as an interface here lets tests swap in a fake without a
 // real HTTP server. The production gitea.Client satisfies this
@@ -1903,20 +1917,22 @@ func (r *Reconciler) ensureHostFluxBootstrap(
 	// controller log says "ensured" but `kubectl get` shows nothing.
 	// First version of Fix #42 hit this exact bug live on omantel.
 	//
-	// Cleanup on Application delete is handled by handleDeletion()
-	// which deletes the Gitea-side files; Flux then GCs the workload
-	// via prune=true on the Kustomization. The host-cluster Flux CRs
-	// themselves are removed by an explicit Delete call in
-	// handleDeletion (separate Fix #42 follow-up — TODO).
+	// Cleanup on Application delete is handled by handleDeletion(): it
+	// deletes the Gitea-side files (Flux then GCs the workload via
+	// prune=true on the Kustomization) AND — via
+	// cascadeDeleteHostFluxBootstrap (#4902 follow-on) — issues explicit
+	// Delete calls on these host-cluster GitRepository + Kustomization CRs
+	// themselves, keyed off the app-uid back-pointer label below, so they
+	// no longer orphan on delete.
 	commonLabels := map[string]interface{}{
 		"app.kubernetes.io/managed-by":     "application-controller",
-		"catalyst.openova.io/application":  app.GetName(),
+		LabelHostFluxApp:                   app.GetName(),
 		"catalyst.openova.io/organization": envSpec.OrganizationRef,
 		"catalyst.openova.io/env-type":     envSpec.EnvType,
 		// Reference labels for cascade-delete (replaces ownerRef which
 		// can't span namespaces). handleDeletion() looks these up.
-		"catalyst.openova.io/app-namespace": app.GetNamespace(),
-		"catalyst.openova.io/app-uid":       string(app.GetUID()),
+		LabelHostFluxAppNamespace: app.GetNamespace(),
+		LabelAppUID:               string(app.GetUID()),
 	}
 
 	// --- GitRepository ---
@@ -2105,6 +2121,27 @@ func (r *Reconciler) handleDeletion(ctx context.Context, app *unstructured.Unstr
 		return fmt.Errorf("delete per-cluster HelmReleases: %w", err)
 	}
 
+	// #4902 (follow-on) — cascade-delete the host-cluster Flux
+	// GitRepository + per-region Kustomization CRs that
+	// ensureHostFluxBootstrap imperatively upserted for this Application
+	// (`catalyst-app-<org>-<app>` + `…-<region>`). Like the fan-out HRs
+	// these carry NO ownerReferences (they live in HostFluxNamespace —
+	// flux-system — a DIFFERENT namespace than the Application CR, so a
+	// cross-namespace ownerRef would be hard-GC'd on creation), so K8s GC
+	// never reaps them. The Gitea-file cleanup below only removes the
+	// per-region manifests (Flux then prunes the WORKLOAD via the
+	// Kustomization's prune=true) — it does NOT remove these source/sync
+	// CRs themselves, so without this they orphan on every delete (the
+	// GitRepository keeps polling a now-empty Gitea repo; the Kustomization
+	// keeps reconciling). Closes the explicit TODO on ensureHostFluxBootstrap.
+	// Runs BEFORE the spec/env resolution below so the cleanup happens even
+	// when the spec is unparseable or the parent Environment is already gone
+	// — it keys off the app-uid back-pointer label + the fixed
+	// HostFluxNamespace alone.
+	if err := r.cascadeDeleteHostFluxBootstrap(ctx, app); err != nil {
+		return fmt.Errorf("delete host-flux bootstrap CRs: %w", err)
+	}
+
 	spec, err := parseSpec(app)
 	if err != nil {
 		// Spec is unparseable — nothing we can do but release the
@@ -2236,6 +2273,77 @@ func (r *Reconciler) cascadeDeleteFanoutHelmReleases(ctx context.Context, app *u
 		r.Log.Info("cascade-deleted per-cluster HelmRelease on Application delete (#4902)",
 			"namespace", ns, "name", hrName,
 			"cluster", labels[topo.LabelCluster], "app", name)
+	}
+	return nil
+}
+
+// cascadeDeleteHostFluxBootstrap removes the host-cluster Flux
+// GitRepository + per-region Kustomization CRs that ensureHostFluxBootstrap
+// imperatively upserted for this Application (#4902 follow-on — closes the
+// TODO left on that function). Like the fan-out HelmReleases, these CRs live
+// in HostFluxNamespace (flux-system) — a DIFFERENT namespace than the
+// Application CR — so they deliberately carry NO ownerReferences (a
+// cross-namespace ownerRef would be hard-GC'd the instant it is created) and
+// the K8s garbage collector never reaps them. handleDeletion's Gitea cleanup
+// only removes the per-region manifests (so Flux prunes the workload via the
+// Kustomization's prune=true), NOT these source/sync CRs themselves — so
+// without this they orphan on every Application delete.
+//
+// Selection mirrors cascadeDeleteFanoutHelmReleases: prefer the
+// globally-unique app-uid back-pointer label; fall back to the
+// application-name + app-namespace label pair when the CR carries no UID
+// (disambiguates same-named Applications across Orgs). Scoped to
+// HostFluxNamespace because that is the only namespace ensureHostFluxBootstrap
+// ever writes these CRs into. Kustomizations are deleted before their
+// GitRepository source (delete the sync that references the source first).
+// The controller ClusterRole grants list+delete on gitrepositories +
+// kustomizations.
+func (r *Reconciler) cascadeDeleteHostFluxBootstrap(ctx context.Context, app *unstructured.Unstructured) error {
+	uid := string(app.GetUID())
+	name := app.GetName()
+	appNS := app.GetNamespace()
+	ns := r.Cfg.HostFluxNamespace
+
+	selector := fmt.Sprintf("%s=%s", LabelAppUID, uid)
+	if uid == "" {
+		selector = fmt.Sprintf("%s=%s,%s=%s",
+			LabelHostFluxApp, name, LabelHostFluxAppNamespace, appNS)
+	}
+
+	// Kustomizations first, then the GitRepository they source from.
+	for _, gvr := range []schema.GroupVersionResource{
+		FluxKustomizationGVR,
+		FluxGitRepositoryGVR,
+	} {
+		list, err := r.Dynamic.Resource(gvr).Namespace(ns).List(ctx, metav1.ListOptions{
+			LabelSelector: selector,
+		})
+		if err != nil {
+			return fmt.Errorf("list host-flux %s: %w", gvr.Resource, err)
+		}
+		for i := range list.Items {
+			obj := &list.Items[i]
+			labels := obj.GetLabels()
+			// Client-side re-verify so a List that ignored the server-side
+			// selector can never over-delete another Application's CRs.
+			if uid != "" {
+				if labels[LabelAppUID] != uid {
+					continue
+				}
+			} else if labels[LabelHostFluxApp] != name || labels[LabelHostFluxAppNamespace] != appNS {
+				continue
+			}
+			objName := obj.GetName()
+			if derr := r.Dynamic.Resource(gvr).Namespace(ns).
+				Delete(ctx, objName, metav1.DeleteOptions{}); derr != nil {
+				if apierrors.IsNotFound(derr) {
+					continue
+				}
+				return fmt.Errorf("delete host-flux %s %s/%s: %w", gvr.Resource, ns, objName, derr)
+			}
+			r.Log.Info("cascade-deleted host-flux bootstrap CR on Application delete (#4902)",
+				"kind", obj.GetKind(), "namespace", ns, "name", objName, "app", name)
+		}
 	}
 	return nil
 }

--- a/core/controllers/application/internal/controller/application_controller_hostflux_delete_4902_test.go
+++ b/core/controllers/application/internal/controller/application_controller_hostflux_delete_4902_test.go
@@ -1,0 +1,151 @@
+// application_controller_hostflux_delete_4902_test.go — #4902 follow-on
+// regression coverage for the orphan host-flux-bootstrap cleanup gap.
+//
+// Defect (sibling of the fan-out-HR leak the merged #4902 fix closed):
+// ensureHostFluxBootstrap imperatively upserts a host-cluster Flux
+// GitRepository (`catalyst-app-<org>-<app>`) + one Kustomization per region
+// (`catalyst-app-<org>-<app>-<region>`) into HostFluxNamespace
+// (flux-system). Those CRs carry no ownerReferences (they live in a
+// DIFFERENT namespace than the Application CR, so a same-namespace ownerRef
+// would be hard-GC'd on creation), so K8s GC never reaps them; and
+// handleDeletion's Gitea-file cleanup removes only the per-region manifests,
+// not these source/sync CRs themselves. Before the fix, every Application
+// delete therefore leaked its GitRepository + Kustomization on the host
+// cluster. handleDeletion now cascade-deletes them via the app-uid
+// back-pointer label (cascadeDeleteHostFluxBootstrap).
+package controller
+
+import (
+	"context"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// makeSeedHostFluxCR builds a host-flux GitRepository or Kustomization
+// shaped like one ensureHostFluxBootstrap would upsert (carries the
+// application + app-uid + app-namespace back-pointer labels). Used to seed a
+// DECOY belonging to a different Application so the test proves the cascade
+// is scoped to exactly one instance.
+func makeSeedHostFluxCR(gvr schema.GroupVersionResource, kind, namespace, name, app, appUID, appNS string) *unstructured.Unstructured {
+	o := &unstructured.Unstructured{}
+	o.SetAPIVersion(gvr.Group + "/" + gvr.Version)
+	o.SetKind(kind)
+	o.SetNamespace(namespace)
+	o.SetName(name)
+	o.SetLabels(map[string]string{
+		LabelHostFluxApp:          app,
+		LabelAppUID:               appUID,
+		LabelHostFluxAppNamespace: appNS,
+	})
+	o.Object["spec"] = map[string]interface{}{"interval": "60s"}
+	return o
+}
+
+// TestReconcile_DeletionCascade_HostFluxBootstrap_4902 — the #4902 follow-on
+// acceptance: after a host-placement Application's reconcile upserts its
+// host-cluster Flux GitRepository + per-region Kustomization into
+// flux-system, a delete of the Application MUST remove those CRs (and only
+// those — a sibling Application's host-flux CRs in the same namespace must
+// survive), then release the finalizer.
+func TestReconcile_DeletionCascade_HostFluxBootstrap_4902(t *testing.T) {
+	bp := makeBlueprint("bp-wp", "1.0.0", nil, []string{"single-region"})
+	env := makeEnv("acme-prod", "acme", "prod")
+	org := makeOrg("acme")
+	// Host-placement Application (no vcluster tier) → the legacy per-region
+	// path runs ensureHostFluxBootstrap, which authors the GitRepository +
+	// Kustomization in flux-system — a DIFFERENT namespace than the
+	// Application CR (`acme`), which is exactly why an ownerRef is unsafe and
+	// the finalizer cascade is required.
+	app := makeApp("acme", "site", "acme-prod", "bp-wp", "1.0.0", "single-region",
+		[]string{"hetzner-fsn-rtz-prod"},
+		map[string]interface{}{"replicas": int64(1)})
+
+	// Decoys: a DIFFERENT Application's host-flux CRs in the SAME flux-system
+	// namespace. They carry a different app-uid, so the cascade must NOT
+	// touch them.
+	decoyGR := makeSeedHostFluxCR(FluxGitRepositoryGVR, "GitRepository",
+		"flux-system", "catalyst-app-acme-other", "other", "uid-other", "acme")
+	decoyKS := makeSeedHostFluxCR(FluxKustomizationGVR, "Kustomization",
+		"flux-system", "catalyst-app-acme-other-hetzner-fsn-rtz-prod", "other", "uid-other", "acme")
+
+	fg := newFakeGitea()
+	fg.orgsExist["acme"] = true
+	r := newReconciler(t, fg, app, env, org, bp, decoyGR, decoyKS)
+
+	// First reconcile — upserts the host-flux GitRepository + Kustomization
+	// into flux-system + adds the finalizer.
+	reconcileFromCluster(t, r, "acme", "site")
+
+	grName := "catalyst-app-acme-site"
+	ksName := "catalyst-app-acme-site-hetzner-fsn-rtz-prod"
+
+	gr, err := r.Dynamic.Resource(FluxGitRepositoryGVR).Namespace("flux-system").
+		Get(context.Background(), grName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected host-flux GitRepository %q after first reconcile: %v", grName, err)
+	}
+	// The cascade keys off the app-uid back-pointer — assert it was actually
+	// stamped by ensureHostFluxBootstrap (makeApp sets uid = "uid-site").
+	if got := gr.GetLabels()[LabelAppUID]; got != "uid-site" {
+		t.Errorf("GitRepository %s app-uid label = %q, want uid-site", grName, got)
+	}
+	if _, err := r.Dynamic.Resource(FluxKustomizationGVR).Namespace("flux-system").
+		Get(context.Background(), ksName, metav1.GetOptions{}); err != nil {
+		t.Fatalf("expected host-flux Kustomization %q after first reconcile: %v", ksName, err)
+	}
+
+	got := readApp(t, r, "acme", "site")
+	if !hasFinalizer(got, FinalizerName) {
+		t.Fatal("first pass should add the controller finalizer")
+	}
+
+	// Mark the app for deletion (what `kubectl delete` does — sets
+	// metadata.deletionTimestamp; the finalizer defers GC until removed).
+	now := metav1.Now()
+	got.SetDeletionTimestamp(&now)
+	if _, err := r.Dynamic.Resource(ApplicationGVR).Namespace("acme").
+		Update(context.Background(), got, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("set deletion timestamp: %v", err)
+	}
+
+	// Reconcile again — handleDeletion must cascade-delete the host-flux CRs.
+	reconcileFromCluster(t, r, "acme", "site")
+
+	// The Application's own GitRepository + Kustomization must be gone.
+	if _, err := r.Dynamic.Resource(FluxGitRepositoryGVR).Namespace("flux-system").
+		Get(context.Background(), grName, metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Errorf("host-flux GitRepository %q survived Application delete — orphan leak (#4902); err=%v", grName, err)
+	}
+	if _, err := r.Dynamic.Resource(FluxKustomizationGVR).Namespace("flux-system").
+		Get(context.Background(), ksName, metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Errorf("host-flux Kustomization %q survived Application delete — orphan leak (#4902); err=%v", ksName, err)
+	}
+
+	// The decoys (a DIFFERENT Application) must survive — the cascade is
+	// scoped to exactly one instance by app-uid.
+	if _, err := r.Dynamic.Resource(FluxGitRepositoryGVR).Namespace("flux-system").
+		Get(context.Background(), "catalyst-app-acme-other", metav1.GetOptions{}); err != nil {
+		t.Errorf("decoy GitRepository for a DIFFERENT Application was wrongly deleted — cascade over-reached beyond app-uid scope; err=%v", err)
+	}
+	if _, err := r.Dynamic.Resource(FluxKustomizationGVR).Namespace("flux-system").
+		Get(context.Background(), "catalyst-app-acme-other-hetzner-fsn-rtz-prod", metav1.GetOptions{}); err != nil {
+		t.Errorf("decoy Kustomization for a DIFFERENT Application was wrongly deleted — cascade over-reached beyond app-uid scope; err=%v", err)
+	}
+
+	// Finalizer must be released so the API server can GC the CR.
+	got2, err := r.Dynamic.Resource(ApplicationGVR).Namespace("acme").
+		Get(context.Background(), "site", metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return // already GC'd by the fake — finalizer was released.
+		}
+		t.Fatalf("read app after delete: %v", err)
+	}
+	if hasFinalizer(got2, FinalizerName) {
+		t.Errorf("finalizer should be released after cascade, still present: %v", got2.GetFinalizers())
+	}
+}


### PR DESCRIPTION
## Summary

Follow-on to the merged #4902 fix (PR #4903). That fix cleaned the fan-out per-region **HelmReleases** the topology path imperatively upserts. Verifying the full delete-cascade surface surfaced a **sibling orphan of the same class** that the merged fix did not cover — and that the code itself flagged as an explicit `TODO`.

## The remaining gap

`ensureHostFluxBootstrap` (the legacy per-region path) also imperatively upserts, straight onto the host k3s via the dynamic client:

- one host-cluster Flux **GitRepository** `catalyst-app-<org>-<app>`
- one **Kustomization** per region `catalyst-app-<org>-<app>-<region>`

into `HostFluxNamespace` (flux-system), with **NO `ownerReferences`** (they live in a different namespace than the Application CR, so a cross-namespace ownerRef would be hard-GC'd the instant it is created — the same trap documented for the fan-out HRs).

`handleDeletion`'s Gitea-file cleanup removes only the per-region manifests (Flux then prunes the *workload* via the Kustomization's `prune=true`) — it never removes these source/sync CRs themselves. So **every Application delete leaked its GitRepository + Kustomization** on the host cluster: the GitRepository keeps polling a now-empty Gitea repo and the Kustomization keeps reconciling forever.

Enumerated every imperative host write the application-controller makes: `FluxHelmReleaseGVR` (cleaned by the merged fix), `ContinuumGVR` (cleaned by `deleteContinuumCRIfExists`), and `FluxGitRepositoryGVR` + `FluxKustomizationGVR` (the leak this PR closes).

## Fix

Extend `handleDeletion` with `cascadeDeleteHostFluxBootstrap`: before releasing the finalizer it lists + deletes the host-flux CRs by the globally-unique `catalyst.openova.io/app-uid` back-pointer label (Kustomizations first, then their GitRepository source), scoped to `HostFluxNamespace`, with a client-side re-verify so a sibling Application's CRs can never be over-deleted. Mirrors the proven `cascadeDeleteFanoutHelmReleases` selection logic exactly. Runs before spec/env resolution so cleanup still happens when the spec is unparseable or the parent Environment is already gone. Chart-level ClusterRole already grants list+delete on `gitrepositories` + `kustomizations`.

## Test

`TestReconcile_DeletionCascade_HostFluxBootstrap_4902` — reconcile upserts the host-flux GitRepository + Kustomization, delete cascades them away, a decoy for a different Application (different app-uid) survives, finalizer releases. Full `application/...` suite green; `go build ./...` + `go vet ./...` clean.

Refs #4902

🤖 Generated with [Claude Code](https://claude.com/claude-code)