### PR TITLE
fix(bp-openclaw): per-Org install targets the release namespace, not org-example — chart 0.2.17 (#4952)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1242,7 +1242,10 @@ spec:
       #   creates pass the apiserver escalation-prevention gate (owner + customer-Org
       #   UserAccess CRs were phase=Failed / 0 grants on every fresh prov).
       #   Lockstep w/ Chart.yaml.
-      version: 1.4.1071
+      # 1.4.1072 — #4952: catalog-seed bp-openclaw pin 0.2.16 -> 0.2.17 so the
+      #   per-Org-namespace fix (tenant.namespace default "" -> falls back to
+      #   .Release.Namespace) reaches fresh funnel Orgs. Lockstep w/ Chart.yaml.
+      version: 1.4.1072
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/openclaw/blueprint.yaml
+++ b/platform/openclaw/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-7-agentic-workspace
 spec:
-  version: 0.2.16
+  version: 0.2.17
   card:
     title: OpenClaw
     summary: |

--- a/platform/openclaw/chart/Chart.yaml
+++ b/platform/openclaw/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-openclaw
-version: 0.2.16
+version: 0.2.17
 appVersion: "0.2.0"
 description: |
   Catalyst Blueprint chart for the OpenClaw workspace controller pattern
@@ -31,6 +31,30 @@ description: |
 
   Changelog
   ─────────
+  0.2.17 (2026-07-10, #4952 — per-Org install no longer targets a non-existent
+          `org-example` namespace)
+    - ROOT CAUSE: `tenant.namespace` defaulted to the truthy placeholder
+      "org-example". The `bp-openclaw.tenantNamespace` helper is
+      `default .Release.Namespace .Values.tenant.namespace` — and Helm's
+      `default` returns the SECOND argument when it is truthy, so the
+      placeholder WON over `.Release.Namespace`. Any install path that did not
+      explicitly set `tenant.namespace` (e.g. a day-2 / raw Application-CR
+      install) rendered the controller Role + RoleBinding with
+      `metadata.namespace: org-example`. On a real Sovereign that namespace does
+      not exist, so Helm install failed with `namespaces "org-example" not
+      found` — TWICE (the Role and the RoleBinding), matching the "2 errors
+      occurred" the live hw235 acme235 install reported.
+        • THE FIX: default `tenant.namespace` to "" so the helper falls back to
+          `.Release.Namespace` — the real per-Org namespace the release installs
+          into. Overlays (funnel generator / BSS-door orgTenantBPOpenClaw) still
+          set it explicitly to the Org slug; an unset value is now a CORRECT
+          install, not a placeholder. Removed the obsolete assertNoPlaceholders
+          guard (it checked a stale "sme-example" literal that never matched the
+          real "org-example" default). Render test Case 10 asserts a
+          `--namespace acme235` install with NO tenant.namespace override puts
+          the Role + RoleBinding in `acme235` and emits ZERO `org-example`
+          literals.
+  0.2.16 (2026-07-02, #4863 — controller CPU 500m -> 250m for the S-plan quota)
   0.2.12 (2026-06-26, #4272 #4407 — controller TLS-trust: verify the PUBLIC
           LE cert on the OIDC issuer, the 4th + FINAL openclaw layer)
     - After 0.2.11 opened public-HTTPS egress so the JWKS hairpin REACHED

--- a/platform/openclaw/chart/templates/_helpers.tpl
+++ b/platform/openclaw/chart/templates/_helpers.tpl
@@ -63,9 +63,13 @@ ConfigMap name (per-user pod template).
 {{- end }}
 
 {{/*
-Tenant namespace — falls back to .Release.Namespace if tenant.namespace
-is unset, but we prefer an explicit value so the controller's RBAC scope
-matches the operator's intent.
+Tenant namespace — falls back to .Release.Namespace when tenant.namespace
+is empty (the #4952 default), but an overlay may set it explicitly so the
+controller's RBAC scope matches the operator's intent. NEVER default this
+to a non-empty placeholder: `default` returns the SECOND arg when it is
+truthy, so a placeholder would win over .Release.Namespace and pin the
+Role/RoleBinding at a namespace that does not exist on a real per-Org
+install (the #4952 `namespaces "org-example" not found` failure).
 */}}
 {{- define "bp-openclaw.tenantNamespace" -}}
 {{- default .Release.Namespace .Values.tenant.namespace }}
@@ -192,9 +196,12 @@ HelmRelease.
 {{- if eq (include "bp-openclaw.llm.baseURL" .) "https://newapi.example.local/v1" }}
 {{- fail "llm.baseURL is still the placeholder — overlay must supply the per-tenant NewAPI OpenAI-compatible endpoint" }}
 {{- end }}
-{{- if eq .Values.tenant.namespace "sme-example" }}
-{{- fail "tenant.namespace is still the placeholder — overlay must supply the SME tenant namespace" }}
-{{- end }}
+{{- /* #4952: tenant.namespace has NO placeholder guard. It defaults to ""
+       and `bp-openclaw.tenantNamespace` falls back to .Release.Namespace — the
+       real per-Org namespace of a per-Org install — so an unset value is a
+       CORRECT install, not a placeholder. (The old guard checked a stale
+       "sme-example" literal that never matched the real "org-example" default,
+       which is exactly how the org-example namespace leaked into the RBAC.) */}}
 {{- /* #4272: ingress.host only matters when the traefik Ingress is rendered.
        On a Sovereign the public exposure is httpRoute.hostnames (Cilium Gateway)
        and ingress.enabled is false, so the placeholder host is harmless. */}}

--- a/platform/openclaw/chart/tests/render-toggles.sh
+++ b/platform/openclaw/chart/tests/render-toggles.sh
@@ -292,4 +292,48 @@ if not ok:
 PY
 echo "  PASS"
 
+echo "[render-toggles] Case 10: per-Org install (no tenant.namespace override) targets the release namespace, NOT a placeholder (#4952)"
+# #4952: bp-openclaw 0.2.16 defaulted tenant.namespace to the truthy placeholder
+# "org-example". The bp-openclaw.tenantNamespace helper is
+# `default .Release.Namespace .Values.tenant.namespace` — Helm's `default`
+# returns the SECOND arg when truthy, so the placeholder WON over
+# .Release.Namespace and the controller Role + RoleBinding rendered with
+# `metadata.namespace: org-example`. On a real Sovereign that namespace does not
+# exist → Helm install failed `namespaces "org-example" not found` (×2: Role +
+# RoleBinding). The fix defaults tenant.namespace to "" so the helper falls back
+# to the release namespace. A per-Org install passes `--namespace <org-slug>`;
+# assert the render targets THAT namespace and emits ZERO org-example literals.
+if ! helm template smoke-openclaw . --namespace acme235 > "$TMP/org-ns.yaml" 2> "$TMP/org-ns.err"; then
+  echo "FAIL: per-Org (--namespace acme235) render failed:" >&2
+  cat "$TMP/org-ns.err" >&2
+  exit 1
+fi
+# No placeholder namespace may survive anywhere in the render.
+if grep -q "org-example" "$TMP/org-ns.yaml"; then
+  echo "FAIL: render still contains the 'org-example' placeholder namespace — a per-Org install would fail 'namespaces \"org-example\" not found' (#4952)." >&2
+  grep -n "org-example" "$TMP/org-ns.yaml" >&2
+  exit 1
+fi
+# The controller Role + RoleBinding (the two resources that carry an explicit
+# metadata.namespace = tenantNamespace) MUST land in the release namespace.
+RENDER_OUT="$TMP/org-ns.yaml" python3 - <<'PY'
+import os, sys, yaml
+docs = [d for d in yaml.safe_load_all(open(os.environ["RENDER_OUT"])) if d]
+want = "acme235"
+checked = 0
+for d in docs:
+    if d.get("kind") not in {"Role", "RoleBinding"}:
+        continue
+    ns = d.get("metadata", {}).get("namespace")
+    name = d.get("metadata", {}).get("name", "<unnamed>")
+    checked += 1
+    if ns != want:
+        print(f"FAIL: {d['kind']} {name} metadata.namespace={ns!r}, expected {want!r} (the release namespace) — #4952 fallback broken.", file=sys.stderr)
+        sys.exit(1)
+if checked < 2:
+    print(f"FAIL: expected the controller Role + RoleBinding (2 namespaced resources), found {checked}.", file=sys.stderr)
+    sys.exit(1)
+PY
+echo "  PASS"
+
 echo "[render-toggles] All bp-openclaw render-toggle gates green."

--- a/platform/openclaw/chart/values.yaml
+++ b/platform/openclaw/chart/values.yaml
@@ -208,8 +208,16 @@ newapi:
 #   - per-user pods are created and deleted
 #   - newapi-key-{uuid} Secrets are read by the controller's ServiceAccount
 tenant:
-  # Required at install time. Placeholder default lets smoke render pass.
-  namespace: "org-example"
+  # #4952: leave EMPTY by default. The `bp-openclaw.tenantNamespace` helper
+  # (`default .Release.Namespace .Values.tenant.namespace`) then falls back to
+  # `.Release.Namespace` — the real per-Org namespace a per-Org install targets
+  # (e.g. acme235). A NON-empty placeholder default here (previously
+  # "org-example") WON that `default` call and pinned the controller Role +
+  # RoleBinding at a namespace that does not exist on a real Sovereign → the
+  # install failed with `namespaces "org-example" not found` (×2). Overlays
+  # (funnel generator / BSS-door orgTenantBPOpenClaw) still set this explicitly
+  # to the Org slug; leaving it empty is now a correct install, not a placeholder.
+  namespace: ""
 # ─── Per-user pod template ───────────────────────────────────────────────
 # These values are baked into a ConfigMap; the controller renders the
 # pod-spec at session-start time, substituting NEWAPI_KEY (Secret ref)

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3444,7 +3444,16 @@ name: bp-catalyst-platform
 #   sovereign-fqdn) so GET /catalog/regions returns the Sovereign's REAL
 #   regions instead of [] — the marketplace BCP picker stops falling back to
 #   the hardcoded Hetzner list.
-version: 1.4.1071
+# 1.4.1072 — #4952: catalog-seed bp-openclaw pin 0.2.16 -> 0.2.17 (lockstep w/
+#   platform/openclaw chart + blueprint.yaml) so the per-Org-namespace fix
+#   reaches fresh funnel Orgs. bp-openclaw 0.2.16 defaulted tenant.namespace to
+#   the truthy placeholder "org-example", which WON the helper's
+#   `default .Release.Namespace .Values.tenant.namespace`, so a per-Org install
+#   rendered the controller Role + RoleBinding into the non-existent org-example
+#   namespace and Helm install failed `namespaces "org-example" not found` (×2).
+#   0.2.17 defaults it to "" so the helper falls back to .Release.Namespace.
+#   Bootstrap-kit slot-13 pin bumped in lockstep (pin-sync gate).
+version: 1.4.1072
 # 1.4.1063 — #4841: grant the useraccess-controller ClusterRole `bind` on the 8
 #   canonical Sovereign-IAM ClusterRoles (openova:tier-{viewer,developer,operator,
 #   admin,owner} + openova:application-{admin,editor,viewer}). The controller

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -2412,7 +2412,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.2.16"
+  version: "0.2.17"
   visibility: listed
   card:
     title: "OpenClaw"
@@ -2447,7 +2447,7 @@ hook (ADR-0003). Identity-blind by construction.
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-openclaw
-    version: "0.2.16"
+    version: "0.2.17"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Defect (#4952 — proven live hw235, Org acme235)

The per-Org bp-openclaw HelmRelease failed install:

```
Helm install failed ... chart bp-openclaw@0.2.16:
2 errors occurred:
  * namespaces "org-example" not found
  * namespaces "org-example" not found
```

## Root cause

`platform/openclaw/chart/values.yaml` defaulted `tenant.namespace` to the truthy placeholder `"org-example"`. The `bp-openclaw.tenantNamespace` helper is:

```
{{- default .Release.Namespace .Values.tenant.namespace }}
```

Helm's `default` returns the **second** argument when it is truthy, so the placeholder `"org-example"` WON over `.Release.Namespace`. Any install path that did not explicitly set `tenant.namespace` (day-2 / raw Application-CR) rendered the **two** resources that carry an explicit `metadata.namespace = tenantNamespace` — the controller **Role** and **RoleBinding** in `templates/controller-rbac.yaml` — into the non-existent `org-example` namespace, so the install failed twice (the "2 errors occurred").

## Fix

- `tenant.namespace` now defaults to `""`, so the helper falls back to `.Release.Namespace` — the real per-Org namespace the release installs into. Overlays (funnel generator / BSS-door `orgTenantBPOpenClaw`) still set it explicitly to the Org slug; an unset value is now a correct install, not a placeholder.
- Removed the obsolete `assertNoPlaceholders` guard that checked a stale `"sme-example"` literal (it never matched the real `"org-example"` default — which is precisely how the placeholder leaked into the RBAC).
- Hardened the helper doc so no future edit re-introduces a non-empty default.

## The 2 resources that referenced org-example

Both in `platform/openclaw/chart/templates/controller-rbac.yaml`:
1. `Role` `{{ $fullName }}-controller` — `metadata.namespace: {{ $tenantNs }}`
2. `RoleBinding` `{{ $fullName }}-controller` — `metadata.namespace: {{ $tenantNs }}`

## Delivery (fresh-prov permanence)

- chart `0.2.16 → 0.2.17` + `blueprint.yaml` lockstep
- catalog-seed `bp-openclaw` pins (`spec.version` + `source.version`) `0.2.16 → 0.2.17`
- `bp-catalyst-platform` umbrella `1.4.1071 → 1.4.1072` + bootstrap-kit slot-13 pin, in lockstep, so the fix reaches fresh funnel Orgs

## Proof

```
$ helm template smoke-openclaw . --namespace acme235 | grep -c org-example
0
$ ... Role       metadata.namespace: acme235
$ ... RoleBinding metadata.namespace: acme235
```

- New `render-toggles.sh` **Case 10** asserts a `--namespace acme235` install (no `tenant.namespace` override) puts the Role + RoleBinding in `acme235` and emits ZERO `org-example` literals.
- All 10 render cases + `check-catalog-seed-lockstep.sh` + `check-bootstrap-kit-pin-sync.sh --changed-only` gates are green.

Refs #4952

🤖 Generated with [Claude Code](https://claude.com/claude-code)