### PR TITLE
fix(#4951): right-size per-Org WordPress footprint so oidc-config hook fits plan-quota

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1245,7 +1245,7 @@ spec:
       # 1.4.1072 — #4952: catalog-seed bp-openclaw pin 0.2.16 -> 0.2.17 so the
       #   per-Org-namespace fix (tenant.namespace default "" -> falls back to
       #   .Release.Namespace) reaches fresh funnel Orgs. Lockstep w/ Chart.yaml.
-      version: 1.4.1072
+      version: 1.4.1073
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/wordpress-tenant/blueprint.yaml
+++ b/platform/wordpress-tenant/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: organization-app
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.4.21
+  version: 0.4.22
   card:
     title: WordPress (per-Organization)
     summary: |

--- a/platform/wordpress-tenant/chart/Chart.yaml
+++ b/platform/wordpress-tenant/chart/Chart.yaml
@@ -280,7 +280,38 @@ name: bp-wordpress-tenant
 #      domain + adminUser.email from the Org owner and injects them before
 #      render). blueprint.yaml + the catalog-seed Blueprint CRs updated in
 #      lockstep.
-version: 0.4.21
+# 0.4.22 (#4951): FIX the per-Org WordPress that runs 1/1 but never serves
+#   externally (wordpress.<org>.<pool> → Envoy 404, valid cert, no route). The
+#   `oidc-config` post-install hook Job stayed Running 0/1 for 13 m+ (never
+#   completed) → Helm post-install `timed out waiting for the condition` → HR
+#   Failed → the org-controller never programmed the external HTTPRoute.
+#   ROOT CAUSE (proven live hw235, Org acme235): the hook's POD WAS NEVER
+#   CREATED. The per-Org namespace carries a `plan-quota` ResourceQuota
+#   (limits.cpu=4 for the WHOLE vcluster-backed namespace) plus a LimitRange
+#   that DEFAULTS every un-capped container to a 500m CPU limit. Steady-state
+#   consumed 3750m (vcluster coredns 1000m + vcluster-0 500m + embedded
+#   postgres 500m + openclaw 250m + WordPress Deployment 1000m + CNPG 500m),
+#   leaving only 250m of `limits.cpu` headroom. The oidc-config Job requested
+#   a 500m CPU LIMIT → the job-controller looped `FailedCreate: exceeded
+#   quota: plan-quota, requested: limits.cpu=500m, used: 3750m, limited: 4` →
+#   no pod → Job 0/1 forever → hook timeout. (NOT a script/keycloak hang — the
+#   container never ran; kyverno did not reject it either, the Deployment runs
+#   with the same securityContext.)
+#   FIX — right-size the bp-wordpress-tenant footprint to fit a 4-CPU per-Org
+#   plan alongside vcluster overhead, with durable headroom for its transient
+#   bootstrap hooks:
+#     1. wordpress.resources.limits.cpu 1 → 500m (a per-Org tenant site is
+#        light; 500m CEILING / 100m request is ample) — frees 500m of durable
+#        quota headroom.
+#     2. oidc-config (weight 10) + admin-user (weight 15) hook Jobs
+#        limits.cpu 500m → 250m (short, self-deleting wp-cli/PHP bootstraps).
+#   Post-fix steady-state 3250m; a running hook peaks at 3500m ≤ 4000m (500m
+#   margin) → the hook pod schedules, the Job completes, the HR reaches Ready,
+#   and the org-controller programs the HTTPRoute → the site serves.
+#   Also hardened the step-0 pg4wp `curl` with `--max-time 120` (mirrors the
+#   step-4 OIDC-plugin vendor) so a black-holed GitHub egress can only FAIL
+#   FAST (→ OnFailure retry) instead of hanging the hook indefinitely.
+version: 0.4.22
 appVersion: "6"
 description: |
   Catalyst Blueprint scratch chart for in-vcluster WordPress, one

--- a/platform/wordpress-tenant/chart/templates/admin-user-job.yaml
+++ b/platform/wordpress-tenant/chart/templates/admin-user-job.yaml
@@ -184,6 +184,12 @@ spec:
               cpu: 50m
               memory: 128Mi
             limits:
-              cpu: 500m
+              # #4951: same per-Org `plan-quota` headroom constraint as the
+              # oidc-config hook (weight 10). This admin-user hook (weight 15)
+              # runs AFTER oidc-config self-deletes; a 500m CPU LIMIT would
+              # equally be rejected `exceeded quota: plan-quota`. It is a
+              # short one-shot PHP seed of the Organization admin's wp_users
+              # row — a 250m ceiling is ample and fits the quota headroom.
+              cpu: 250m
               memory: 256Mi
 {{- end }}

--- a/platform/wordpress-tenant/chart/templates/oidc-config-job.yaml
+++ b/platform/wordpress-tenant/chart/templates/oidc-config-job.yaml
@@ -191,7 +191,11 @@ spec:
                 # omantel.biz region-a). GitHub still extracts the archive to
                 # `postgresql-for-wordpress-3.3.1` (the `v` is stripped from the
                 # top-level directory name), so the cp paths below are unchanged.
-                curl -fsSL -o /tmp/pg4wp.zip \
+                # --max-time bounds the fetch (mirrors the OIDC-plugin
+                # vendor in step 4): a black-holed GitHub egress route can
+                # then only FAIL FAST (→ OnFailure retry within backoffLimit)
+                # instead of hanging the hook indefinitely → Helm timeout.
+                curl -fsSL --max-time 120 -o /tmp/pg4wp.zip \
                   https://github.com/PostgreSQL-For-Wordpress/postgresql-for-wordpress/archive/refs/tags/v3.3.1.zip
                 # wp-cli's bundled PHP can unzip without a system `unzip`.
                 php -r '$z=new ZipArchive();$z->open("/tmp/pg4wp.zip");$z->extractTo("/tmp/");$z->close();'
@@ -410,7 +414,17 @@ spec:
               cpu: 50m
               memory: 128Mi
             limits:
-              cpu: 500m
+              # #4951: the per-Org `plan-quota` (4 CPU limit for the whole
+              # namespace) is nearly exhausted by vcluster overhead + the
+              # running WordPress site + CNPG. A 500m CPU LIMIT here left
+              # this transient post-install hook's pod unschedulable
+              # (`exceeded quota: plan-quota, requested: limits.cpu=500m`)
+              # → the pod was NEVER created → the Job stuck Running 0/1 →
+              # Helm post-install timed out → HR Failed → no HTTPRoute → 404.
+              # This is a short, IO-bound wp-cli bootstrap (self-deletes on
+              # success via hook-delete-policy) — a 250m ceiling is ample and
+              # fits the quota headroom alongside the running Deployment.
+              cpu: 250m
               memory: 256Mi
       volumes:
         # #4220 (Refs #4155): ALWAYS an emptyDir — never the runtime

--- a/platform/wordpress-tenant/chart/values.yaml
+++ b/platform/wordpress-tenant/chart/values.yaml
@@ -110,12 +110,25 @@ wordpress:
     pullSecrets:
       - name: ghcr-pull
   port: 80
+  # #4951: the per-Org namespace carries a `plan-quota` ResourceQuota
+  # (default 4 CPU limit for the WHOLE vcluster-backed namespace) AND a
+  # LimitRange that DEFAULTS every un-capped container to a 500m CPU
+  # limit. vcluster overhead alone (coredns 1000m + vcluster-0 500m +
+  # embedded postgres 500m) plus the CNPG DB (500m) already eats ~2500m.
+  # A 1-core (1000m) runtime LIMIT here left only ~250m of `limits.cpu`
+  # headroom — NOT enough for the post-install oidc-config hook Job to
+  # schedule its pod (its 500m-limit pod was rejected `exceeded quota:
+  # plan-quota` and NEVER created → Helm post-install timed out → HR
+  # Failed → the external HTTPRoute was never programmed → host 404).
+  # A per-Org tenant WordPress site is light; a 500m CPU CEILING (burst)
+  # with a 100m request is ample and frees durable quota headroom so the
+  # transient bootstrap hooks fit alongside the running site.
   resources:
     requests:
       cpu: 100m
       memory: 256Mi
     limits:
-      cpu: 1
+      cpu: 500m
       memory: 512Mi
   # SecurityContext — the official WordPress image runs Apache as
   # `www-data` (UID 33). Keep readOnlyRootFilesystem=false because the

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3453,7 +3453,13 @@ name: bp-catalyst-platform
 #   namespace and Helm install failed `namespaces "org-example" not found` (×2).
 #   0.2.17 defaults it to "" so the helper falls back to .Release.Namespace.
 #   Bootstrap-kit slot-13 pin bumped in lockstep (pin-sync gate).
-version: 1.4.1072
+# 1.4.1072 — #4951: lockstep the catalog-seed bp-wordpress-tenant Blueprint pin
+#   (spec.version + source.version, canonical entry + alias) 0.4.21 → 0.4.22 so
+#   every Sovereign pulls the chart that right-sizes the per-Org WordPress
+#   footprint to fit the 4-CPU `plan-quota` (the 0.4.21 oidc-config post-install
+#   hook requested a 500m CPU limit into a namespace with only 250m of quota
+#   headroom → the hook pod was NEVER created → HR timeout → no HTTPRoute → 404).
+version: 1.4.1073
 # 1.4.1063 — #4841: grant the useraccess-controller ClusterRole `bind` on the 8
 #   canonical Sovereign-IAM ClusterRoles (openova:tier-{viewer,developer,operator,
 #   admin,owner} + openova:application-{admin,editor,viewer}). The controller

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -57,7 +57,12 @@ spec:
   # #4936: →0.4.21 — direct CNPG-secret DB-password bind (kills the reflector
   # race vs Helm --wait) + orgDomain/adminUser made non-required (controller-
   # derived). Lockstep with platform/wordpress-tenant/blueprint.yaml.
-  version: "0.4.21"
+  # #4951: →0.4.22 — right-size the per-Org footprint (runtime CPU limit
+  # 1→500m; oidc-config + admin-user hook Jobs 500m→250m) so the post-install
+  # hook pod fits the 4-CPU `plan-quota` headroom and actually schedules; the
+  # 0.4.21 hook was rejected `exceeded quota: plan-quota` → never created → HR
+  # timeout → no external HTTPRoute → host 404.
+  version: "0.4.22"
   visibility: listed
   card:
     title: "WordPress (per-Organization)"
@@ -86,7 +91,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-wordpress-tenant
-    version: "0.4.21"
+    version: "0.4.22"
   # G117.1+G117.4+G117.5 #2744-followup (2026-06-03): lockstep with
   # platform/wordpress-tenant/blueprint.yaml. Uses {{.AppName}} so
   # multi-instance tenants get distinct hostnames per Application.
@@ -221,7 +226,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-wordpress-tenant
-    version: "0.4.21"
+    version: "0.4.22"
   # Lockstep with the bp-wordpress-tenant entry above + platform/wordpress-tenant/
   # blueprint.yaml. Same chart bytes; this is the bare-slug entrypoint only.
   topology:


### PR DESCRIPTION
## Refs #4951

### Symptom (proven live hw235, Org acme235)
The per-Org WordPress pod runs 1/1 but the HelmRelease is `Failed` (`failed post-install: timed out waiting for the condition`). The org-controller therefore never programs the external HTTPRoute, so `wordpress.<slug>.omani.homes` returns **Envoy 404** (valid cert, no route). The post-install hook Job `wordpress-rtz-a-bp-wordpress-tenant-oidc-config` sat `Running 0/1` for 13 m+.

### Root cause — the hook pod is NEVER created (not a script hang)
Live `kubectl describe job` shows the job-controller looping:
```
Warning FailedCreate ... Error creating: pods "...oidc-config-..." is forbidden:
  exceeded quota: plan-quota, requested: limits.cpu=500m, used: 3750m, limited: 4
```
- The per-Org namespace carries a `plan-quota` ResourceQuota (`limits.cpu=4` for the whole vcluster-backed namespace) **plus** a `LimitRange` that defaults every un-capped container to a **500m** CPU limit.
- Steady-state already consumes **3750m** (vcluster coredns 1000m + vcluster-0 500m + embedded postgres 500m + openclaw 250m + WordPress Deployment 1000m + CNPG 500m), leaving only **250m** of `limits.cpu` headroom.
- The oidc-config Job requested a **500m** CPU LIMIT → rejected by quota admission → **no pod ever created** → Job `0/1` forever → Helm post-install timed out → HR `Failed` → no HTTPRoute → host 404.

It is **not** a keycloak/URL/creds/`until`-loop hang — the container never ran. Kyverno did not reject it either (the Deployment runs 1/1 with the same securityContext).

### Fix — right-size the bp-wordpress-tenant footprint to fit a 4-CPU per-Org plan with durable hook headroom
- `wordpress.resources.limits.cpu` **1 → 500m** — a per-Org tenant WordPress site is light; a 500m CEILING with a 100m request is ample and frees **500m** of durable quota headroom.
- oidc-config (weight 10) + admin-user (weight 15) hook Jobs `limits.cpu` **500m → 250m** — short, self-deleting wp-cli/PHP bootstraps.
- Bounded the step-0 pg4wp `curl` with `--max-time 120` (mirrors the step-4 OIDC-plugin vendor) so a black-holed GitHub egress fails fast instead of hanging the hook.

Post-fix steady-state = **3250m**; a running hook peaks at **3500m ≤ 4000m** (500m margin) → the hook pod schedules, the Job completes, the HR reaches Ready, and the org-controller programs the HTTPRoute → **the site serves** (SSO client registration is unaffected — the hook does its full wp-cli work, just at a lower CPU ceiling).

### Lockstep
Chart `bp-wordpress-tenant` **0.4.21 → 0.4.22**; bumped `platform/wordpress-tenant/blueprint.yaml`, catalog-seed pins (canonical entry + `bp-wordpress` alias, `spec.version` + `source.version`), and the umbrella `products/catalyst` chart **1.4.1071 → 1.4.1072**.

### Validation
- `helm lint` clean.
- `tests/oidc-config.sh` — all 8 cases green.
- `tests/imagepullsecrets-render.sh`, `tests/active-hot-standby-render.sh`, `tests/observability-toggle.sh` — green.
- Render assertion: Deployment `limits.cpu=500m`; both hook Jobs `limits.cpu=250m`; pg4wp + OIDC-plugin curls both `--max-time 120`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)