### PR TITLE
fix(#4955 Refs #3379): cutover step-03 harbor-prewarm handles tag@digest image refs

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -742,7 +742,11 @@ spec:
       # durably rewrites their clusters/<fqdn>/org-tenants/**.yaml Gitea source — so the
       # step-08 deny-egress PRE-CHECK no longer wedges on tenant HRs still on ghcr.io
       # (proven hw232). No step-count / job-mode / RBAC change.
-      version: 0.1.108
+      # 0.1.109 (#4955 Refs #3379): step-03 harbor-prewarm normalize_ref() strips the
+      # tag from a `name:tag@sha256:…` source ref so skopeo can mirror openova-io
+      # images pinned by BOTH tag and digest (wordpress-tenant-pg) — the FATAL that
+      # wedged the hw235 finale at step-03 (push_ok=31 push_fail=1) before step-04.
+      version: 0.1.109
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.108
+  version: 0.1.109
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,25 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.109 (#4955 Refs #3379, hw235 finale — step-03 harbor-prewarm FATALed on the
+# FIRST openova-io image ever pinned by BOTH a tag AND a digest): the Phase-A
+# skopeo mirror ran `skopeo copy docker://ghcr.io/openova-io/openova/
+# wordpress-tenant-pg:b513b45@sha256:4c80…` verbatim, and skopeo rejects a source
+# reference carrying a tag AND a digest ("Docker references with both a tag and
+# digest are currently not supported"). push_ok=31 push_fail=1 → the step's
+# fail-closed contract (any un-mirrored openova-io image cannot survive the step-08
+# ghcr.io deny-egress) FATALed the whole cutover before step-04, live on hw235
+# (a3818d29c833ab1e). The bp-wordpress-tenant chart pins its Postgres image by
+# tag@digest; no prior openova-io image did, so this reference shape was never
+# exercised. FIX (chart-only, template 03): a new normalize_ref() helper strips the
+# tag from any `name:tag@sha256:…` source ref (the digest is authoritative +
+# immutable and is exactly what containerd pulls by for an image:tag@digest pod
+# ref) → skopeo copies the manifest into local Harbor addressable by digest, the
+# post-pivot pull resolves, and the fail-closed contract is preserved for genuine
+# mirror failures. Tag-only / digest-only refs pass through unchanged; only the
+# final path segment's tag is stripped (host:port refs safe). Phase A2 (helm
+# charts, plain semver) unaffected. NO step-count / job-mode / RBAC change (still
+# 11 steps). Lockstep w/ blueprint.yaml + 06a slot pin + catalog seed. Refs #4955
+# #3379.
 # 0.1.108 (#4885 Refs #3379 #4888, the tenant-HelmRepo cutover-pivot gap — hw232
 # step-08 deny-egress PRE-CHECK wedged on 4 tenant/catalog HRs still on ghcr.io):
 # step-06 (helmrepository-patches) previously pivoted ONLY the curated
@@ -1592,7 +1612,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.108
+version: 0.1.109
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -362,8 +362,39 @@ data:
             rm -rf "${cpdir}"; mkdir -p "${cpdir}"
             echo "[harbor-prewarm] pushing ${count} image(s) with parallelism=${PREWARM_PARALLELISM}"
 
+            # #4955 (Refs #3379): normalize a `name:tag@sha256:...` reference to
+            # digest-only (`name@sha256:...`) before handing it to skopeo.
+            # `skopeo copy docker://name:tag@digest` FATALs with "Docker
+            # references with both a tag and digest are currently not supported",
+            # which fail-closed the WHOLE step on the first openova-io image ever
+            # pinned by BOTH a tag and a digest (`wordpress-tenant-pg` from
+            # bp-wordpress-tenant — live hw235 a3818d29c833ab1e, push_ok=31
+            # push_fail=1 → cutover never reached step-04+). The digest is
+            # authoritative + immutable and is exactly what containerd pulls by
+            # for an `image:tag@digest` pod ref, so dropping the tag preserves the
+            # post-pivot pull (the manifest lands in Harbor addressable by digest).
+            # Tag-only and digest-only refs pass through unchanged. Only the FINAL
+            # path segment's tag is stripped, so a `host:port/...` registry ref is
+            # left intact.
+            normalize_ref() {
+              _nr="$1"
+              case "${_nr}" in
+                *@*)
+                  _nr_digest="${_nr##*@}"   # sha256:...
+                  _nr_name="${_nr%@*}"      # name[:tag]
+                  case "${_nr_name##*/}" in
+                    *:*) _nr_name="${_nr_name%:*}" ;;  # strip tag from last path segment
+                  esac
+                  printf '%s@%s' "${_nr_name}" "${_nr_digest}"
+                  ;;
+                *)
+                  printf '%s' "${_nr}"
+                  ;;
+              esac
+            }
+
             copy_one() {
-              up="$1"
+              up=$(normalize_ref "$1")
               # Convert ghcr.io/X/Y:tag → HARBOR_HOST/X/Y:tag
               # (drop ghcr.io/ prefix, keep rest identical)
               lref="${HARBOR_HOST}/${up#ghcr.io/}"

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5053,7 +5053,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.108"
+    version: "0.1.109"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## What

Fixes the **step-03 harbor-prewarm** wedge that blocked the Pillar-5 sovereignty cutover on the hw235 finale (dep `a3818d29c833ab1e`).

## Root cause (live)

Phase A of harbor-prewarm mirrors openova-io container images into local Harbor via `skopeo copy`. It ran the reference verbatim:

```
skopeo copy docker://ghcr.io/openova-io/openova/wordpress-tenant-pg:b513b45@sha256:4c80995efad754...
level=fatal msg="Invalid source name ...: Docker references with both a tag and digest are currently not supported"
```

`bp-wordpress-tenant` pins its Postgres image with **both a tag and a digest** — a valid Kubernetes ref (containerd pulls by digest), but `skopeo copy` refuses it. Result: `push_ok=31 push_fail=1` on all 4 job retries -> the step's (correct) fail-closed contract FATAL-ed the whole cutover before step-04. No prior openova-io image carried a combined ref, so this shape was never exercised.

## Fix (chart-only, template 03)

New `normalize_ref()` helper strips the tag from any `name:tag@sha256:...` source ref before skopeo copy — the digest is authoritative + immutable and is exactly what the consuming `image:tag@digest` pod pulls by, so the manifest lands in local Harbor addressable by digest and the post-pivot pull resolves. The fail-closed contract is preserved for genuine mirror failures.

- Tag-only and digest-only refs pass through unchanged.
- Only the **final path segment's** tag is stripped -> `host:port/...` refs safe.
- Phase A2 (helm charts, plain semver) unaffected.
- No step-count / job-mode / RBAC change (still 11 steps).

## Validation

- `normalize_ref` unit-tested across 6 cases incl. the failing `wordpress-tenant-pg` ref + host:port edge cases — all pass.
- Rendered step-03 script `dash -n` + `sh -n` clean.
- `cutover-contract.sh` all gates green.
- Bumps `bp-self-sovereign-cutover` 0.1.108 -> 0.1.109 in lockstep (Chart.yaml + blueprint.yaml + 06a slot pin + catalog seed).

## Verification status

Live cutoverComplete=true proof is **roll-gated** — deferred to the next fresh prov whose cutover reaches the 600s deny-egress hold. No live hand-patch was applied to hw235 (disposable finale env) per the never-thrash-live-env discipline.

Refs #4955 #3379.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
