### PR TITLE
fix(#4950): keep placement.targets[] through decode so console Edit-Apply derives mode

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications.go
@@ -138,6 +138,20 @@ type applicationPlacement struct {
 	// keys primaryRegion off regions[0]). Legacy {mode,regions} callers are
 	// unaffected. Refs #3969 #3375.
 	Targets []bpv1.PlacementTarget `json:"targets,omitempty"`
+
+	// OwnedDependencies — the #3969 per-owned-dependency cascade overrides
+	// the console PlacementEditor sends ALONGSIDE targets[] on every Apply
+	// (PlacementEditor.tsx: `ownedDependencies: owned.map(...)`). This field
+	// MUST exist on the wire struct even though the update handler does not
+	// yet project it: `decodeApplicationUpdateBody` decodes the canonical
+	// shape with `DisallowUnknownFields`, so an absent field made the strict
+	// decode REJECT the real console body and fall back to the lenient
+	// simplified decoder — which drops targets[] entirely, leaving Mode empty
+	// and 400'ing "placement.mode is required" (#4950). Mirroring the
+	// bpv1.Placement.OwnedDependencies wire contract lets the canonical
+	// decode accept the body so the targets[]→mode fold fires. Refs #4950
+	// #4840 #3969.
+	OwnedDependencies []bpv1.OwnedDependencyOverride `json:"ownedDependencies,omitempty"`
 }
 
 // validVClusterTier — accepted spec.placement.vcluster values

--- a/products/catalyst/bootstrap/api/internal/handler/applications_update_4950_owndeps_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_update_4950_owndeps_test.go
@@ -1,0 +1,115 @@
+// applications_update_4950_owndeps_test.go — reproduction + regression for
+// #4950: console Topology→Edit-placement→Apply 400'd
+// "placement.mode is required when placement is set" even though the #4840
+// targets[]→mode fold was in the deployed image.
+//
+// Root cause (empirically proven here): the REAL console PUT body
+// (PlacementEditor.tsx apply()) carries `placement.ownedDependencies`
+// ALONGSIDE `placement.targets[]`. `ownedDependencies` was absent from the Go
+// `applicationPlacement` wire struct, so `decodeApplicationUpdateBody`'s
+// canonical Path-A decode (which runs `DisallowUnknownFields`) REJECTED the
+// body and fell back to the lenient simplified decoder — whose
+// `decodePlacementValue` returned only mode+regions and silently dropped
+// targets[]. With targets gone, the fold's `len(Targets)>0` guard was false,
+// Mode stayed empty, and validateApplicationUpdateRequest 400'd.
+//
+// Fix: (1) add OwnedDependencies to applicationPlacement so the canonical
+// decode accepts the real body; (2) make decodePlacementValue carry targets[]
+// through the fallback so the targets are never dropped regardless of path.
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// realConsolePlacementPUT is the EXACT body shape the Sovereign console
+// PlacementEditor sends on Apply (region × cluster × vCluster × role, with a
+// Standby standbyType, PLUS the ownedDependencies cascade list). Roles are
+// the LOCKED capitalised vocabulary ("Primary"/"Standby"), matching
+// core/controllers/pkg/apis/blueprint/v1alpha1/placement_target.go and the FE
+// placement.ts DataRole type.
+const realConsolePlacementPUT = `{"placement":{` +
+	`"targets":[` +
+	`{"region":"me-east-215-a","cluster":"mgmt-A","vcluster":"mgmt","role":"Primary"},` +
+	`{"region":"me-east-215-b","cluster":"mgmt-B","vcluster":"mgmt","role":"Standby","standbyType":"Hot"}` +
+	`],` +
+	`"ownedDependencies":[{"name":"shared-pg-pg","follow":true}]` +
+	`}}`
+
+// TestDecodeApplicationUpdateBody_4950_OwnedDependenciesKeepsTargets is the
+// decode-level regression: the real console body (targets[] + ownedDependencies)
+// must decode with targets[] preserved and mode derived to active-hot-standby —
+// NOT dropped-to-empty-mode which 400'd. This guards BOTH fix arms (the struct
+// field so Path-A succeeds, and the fallback carrying targets).
+func TestDecodeApplicationUpdateBody_4950_OwnedDependenciesKeepsTargets(t *testing.T) {
+	body, err := decodeApplicationUpdateBody([]byte(realConsolePlacementPUT))
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if body.Placement == nil {
+		t.Fatalf("placement dropped entirely")
+	}
+	if len(body.Placement.Targets) != 2 {
+		t.Fatalf("targets[] dropped by decode: got %d, want 2 (the #4950 root cause)", len(body.Placement.Targets))
+	}
+	// The targets[]→mode fold must have derived the pattern (1 Primary + 1 Hot
+	// Standby ⇒ active-hot-standby) and the Primary-first regions.
+	if body.Placement.Mode != "active-hot-standby" {
+		t.Errorf("mode = %q, want active-hot-standby (fold did not fire)", body.Placement.Mode)
+	}
+	if !reflect.DeepEqual(body.Placement.Regions, []string{"me-east-215-a", "me-east-215-b"}) {
+		t.Errorf("regions = %v, want [me-east-215-a me-east-215-b]", body.Placement.Regions)
+	}
+	// The whole point: validation must PASS (previously 400'd
+	// "placement.mode is required when placement is set").
+	if msg, ok := validateApplicationUpdateRequest(body); !ok {
+		t.Errorf("validation STILL 400s after fix: %s", msg)
+	}
+}
+
+// TestHandleApplicationUpdate_4950_ConsolePlacementApply_Returns200 drives the
+// FULL PUT handler with the exact console body (via json.RawMessage so the
+// unknown-to-old-struct `ownedDependencies` key is sent verbatim, exactly as
+// the browser sends it) and asserts a 200 with the CR patched to the derived
+// active-hot-standby pattern across both regions — the operator-visible
+// Edit-placement→Apply outcome from the hw235 walk (app `shared-pg`).
+func TestHandleApplicationUpdate_4950_ConsolePlacementApply_Returns200(t *testing.T) {
+	// Seed the app as a singleton in region-a so the Apply is a non-destructive
+	// scale-up (singleton → active-hot-standby, +1 region) that needs no ?force.
+	cr := makeAppCR("acme", "shared-pg", "1.2.3", "singleton", []string{"me-east-215-a"})
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	factory, client := fakeApplicationDynamicFactory(cr)
+	h.dynamicFactory = factory
+	h.SetCatalogClient(newFakeCatalog(sampleWordpressBlueprint()))
+	dep := installUserAccessDeployment(t, h, "dep-app-4950-placement")
+
+	rec := callUserAccess(t, h, http.MethodPut,
+		"/api/v1/sovereigns/"+dep.ID+"/applications/shared-pg?namespace=acme",
+		json.RawMessage(realConsolePlacementPUT), registerApplicationUpdateRoutes)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("console placement Apply 400'd (the #4950 defect): got %d want 200; body=%s",
+			rec.Code, rec.Body.String())
+	}
+
+	got, err := client.Resource(ApplicationGVR()).Namespace("acme").Get(
+		context.Background(), "shared-pg", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get patched CR: %v", err)
+	}
+	mode, _, _ := unstructured.NestedString(got.Object, "spec", "placement")
+	if mode != "active-hot-standby" {
+		t.Fatalf("spec.placement = %q, want active-hot-standby (derived from targets[])", mode)
+	}
+	regionsRaw, _, _ := unstructured.NestedSlice(got.Object, "spec", "regions")
+	regions := stringsFromAnySlice(regionsRaw)
+	if !reflect.DeepEqual(regions, []string{"me-east-215-a", "me-east-215-b"}) {
+		t.Fatalf("spec.regions = %v, want [me-east-215-a me-east-215-b] (Primary-first)", regions)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/applications_wire_compat.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_wire_compat.go
@@ -62,6 +62,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	bpv1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
 )
 
 // osGetenv is a tiny indirection so tests can stub the env lookup.
@@ -175,13 +177,16 @@ func (s applicationSimplifiedInstall) promoteToCanonicalInstall() (applicationIn
 	// Promote placement — accept either the simplified string-form OR
 	// the canonical object-form OR neither (default single-region).
 	if len(s.PlacementRaw) > 0 {
-		mode, regions, err := decodePlacementValue(s.PlacementRaw)
+		mode, regions, targets, err := decodePlacementValue(s.PlacementRaw)
 		if err != nil {
 			return out, fmt.Errorf("placement: %w", err)
 		}
 		out.Placement.Mode = mode
 		if len(regions) > 0 {
 			out.Placement.Regions = regions
+		}
+		if len(targets) > 0 {
+			out.Placement.Targets = targets
 		}
 	}
 	if len(out.Placement.Regions) == 0 && len(s.Regions) > 0 {
@@ -232,11 +237,11 @@ func (s applicationSimplifiedInstall) promoteToCanonicalUpdate() (applicationUpd
 	}
 
 	if len(s.PlacementRaw) > 0 {
-		mode, regions, err := decodePlacementValue(s.PlacementRaw)
+		mode, regions, targets, err := decodePlacementValue(s.PlacementRaw)
 		if err != nil {
 			return out, fmt.Errorf("placement: %w", err)
 		}
-		out.Placement = &applicationPlacement{Mode: mode, Regions: regions}
+		out.Placement = &applicationPlacement{Mode: mode, Regions: regions, Targets: targets}
 	}
 	if out.Placement != nil && len(s.Regions) > 0 && len(out.Placement.Regions) == 0 {
 		out.Placement.Regions = append(out.Placement.Regions, s.Regions...)
@@ -252,27 +257,34 @@ func (s applicationSimplifiedInstall) promoteToCanonicalUpdate() (applicationUpd
 
 // decodePlacementValue handles BOTH the simplified string-form
 // (`"placement": "single-region"`) AND the canonical object-form
-// (`"placement": {"mode":"single-region","regions":[...]}`).
-func decodePlacementValue(raw json.RawMessage) (mode string, regions []string, err error) {
+// (`"placement": {"mode":"single-region","regions":[...],"targets":[...]}`).
+//
+// #4950 — the object form now carries `targets` back to the caller. The
+// console PlacementEditor PUTs the #3969 per-region targets[] model with no
+// mode/regions; when this lenient fallback decoder is reached (the strict
+// canonical decode rejected the body for any reason) it MUST preserve
+// targets[] so the update handler's targets[]→mode fold can still fire.
+// Dropping targets here was the silent-decode arm of the #4950 400.
+func decodePlacementValue(raw json.RawMessage) (mode string, regions []string, targets []bpv1.PlacementTarget, err error) {
 	trimmed := bytes.TrimSpace(raw)
 	if len(trimmed) == 0 {
-		return "", nil, nil
+		return "", nil, nil, nil
 	}
 	if trimmed[0] == '"' {
 		var s string
 		if err := json.Unmarshal(trimmed, &s); err != nil {
-			return "", nil, fmt.Errorf("placement: %w", err)
+			return "", nil, nil, fmt.Errorf("placement: %w", err)
 		}
-		return strings.TrimSpace(s), nil, nil
+		return strings.TrimSpace(s), nil, nil, nil
 	}
 	if trimmed[0] == '{' {
 		var p applicationPlacement
 		if err := json.Unmarshal(trimmed, &p); err != nil {
-			return "", nil, fmt.Errorf("placement: %w", err)
+			return "", nil, nil, fmt.Errorf("placement: %w", err)
 		}
-		return strings.TrimSpace(p.Mode), p.Regions, nil
+		return strings.TrimSpace(p.Mode), p.Regions, p.Targets, nil
 	}
-	return "", nil, fmt.Errorf("placement: must be a string mode or {mode,regions} object")
+	return "", nil, nil, fmt.Errorf("placement: must be a string mode or {mode,regions,targets} object")
 }
 
 // mergeMaps copies entries from a, then overlays b. Used to merge the
@@ -406,11 +418,11 @@ func decodeApplicationChangePreviewBody(raw []byte) (applicationChangePreviewReq
 		out.Parameters = merged
 	}
 	if len(simple.PlacementRaw) > 0 {
-		mode, regions, err := decodePlacementValue(simple.PlacementRaw)
+		mode, regions, targets, err := decodePlacementValue(simple.PlacementRaw)
 		if err != nil {
 			return out, fmt.Errorf("placement: %w", err)
 		}
-		out.Placement = &applicationPlacement{Mode: mode, Regions: regions}
+		out.Placement = &applicationPlacement{Mode: mode, Regions: regions, Targets: targets}
 	}
 	if out.Placement != nil && len(simple.Regions) > 0 && len(out.Placement.Regions) == 0 {
 		out.Placement.Regions = append(out.Placement.Regions, simple.Regions...)

--- a/products/catalyst/bootstrap/api/internal/handler/applications_wire_compat_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_wire_compat_test.go
@@ -128,20 +128,30 @@ func TestDecodeApplicationUpdateBody_ValuesAlias(t *testing.T) {
 func TestDecodePlacementValue_BothShapes(t *testing.T) {
 	t.Parallel()
 	// String form
-	mode, regions, err := decodePlacementValue([]byte(`"active-active"`))
+	mode, regions, targets, err := decodePlacementValue([]byte(`"active-active"`))
 	if err != nil {
 		t.Fatalf("string-form failed: %v", err)
 	}
-	if mode != "active-active" || len(regions) != 0 {
-		t.Errorf("string-form wrong: mode=%q regions=%+v", mode, regions)
+	if mode != "active-active" || len(regions) != 0 || len(targets) != 0 {
+		t.Errorf("string-form wrong: mode=%q regions=%+v targets=%+v", mode, regions, targets)
 	}
-	// Object form
-	mode, regions, err = decodePlacementValue([]byte(`{"mode":"single-region","regions":["fsn1"]}`))
+	// Object form (mode+regions)
+	mode, regions, targets, err = decodePlacementValue([]byte(`{"mode":"single-region","regions":["fsn1"]}`))
 	if err != nil {
 		t.Fatalf("object-form failed: %v", err)
 	}
-	if mode != "single-region" || !reflect.DeepEqual(regions, []string{"fsn1"}) {
-		t.Errorf("object-form wrong: mode=%q regions=%+v", mode, regions)
+	if mode != "single-region" || !reflect.DeepEqual(regions, []string{"fsn1"}) || len(targets) != 0 {
+		t.Errorf("object-form wrong: mode=%q regions=%+v targets=%+v", mode, regions, targets)
+	}
+	// #4950 — object form with the #3969 targets[] model MUST carry targets
+	// back so the lenient fallback decoder never drops them (the silent-decode
+	// arm of the "placement.mode is required" 400).
+	mode, regions, targets, err = decodePlacementValue([]byte(`{"targets":[{"region":"me-east-215-a","role":"Primary"}]}`))
+	if err != nil {
+		t.Fatalf("targets-form failed: %v", err)
+	}
+	if mode != "" || len(regions) != 0 || len(targets) != 1 || targets[0].Region != "me-east-215-a" {
+		t.Errorf("targets-form wrong: mode=%q regions=%+v targets=%+v", mode, regions, targets)
 	}
 }
 


### PR DESCRIPTION
## Problem

hw235 conclusion walk: console **Topology → Edit-placement → Apply** →
`PUT /api/v1/sovereigns/.../applications/shared-pg` → **HTTP 400
`placement.mode is required when placement is set`** — even though the #4840
`targets[]→mode` fold (`applications_update.go:135`) was already in the deployed
image (2d41a36 ⊃ e937cda9d).

## Root cause (empirically proven, hypothesis (c))

The **real** console Apply body (`PlacementEditor.tsx` `apply()`) is:

```json
{"placement":{
  "targets":[
    {"region":"me-east-215-a","cluster":"mgmt-A","vcluster":"mgmt","role":"Primary"},
    {"region":"me-east-215-b","cluster":"mgmt-B","vcluster":"mgmt","role":"Standby","standbyType":"Hot"}
  ],
  "ownedDependencies":[{"name":"shared-pg-pg","follow":true}]
}}
```

`placement.ownedDependencies` is a field the console **always** sends alongside
`targets[]`, but it was **absent from the Go `applicationPlacement` wire struct**.
`decodeApplicationUpdateBody` Path A runs `json.Decoder.DisallowUnknownFields()`,
so the unknown key made the strict canonical decode **reject** the body and fall
back to Path B (`decodePlacementValue`) — which returned only `mode`+`regions`
and **silently dropped `targets[]`**. With targets gone, the fold's
`len(b.Placement.Targets) > 0` guard was false, `Mode` stayed empty, and
`validateApplicationUpdateRequest` (`:891`) 400'd.

The ticket's shorthand payload (lowercase roles, no `ownedDependencies`) does
**not** reproduce the 400 — it decodes via Path A and derives a (wrong, but
non-400) `singleton`. Only the real body with `ownedDependencies` triggers the
Path A→B fallback that drops targets. Verified before/after on the identical
payload.

## Fix (two arms)

1. **Add `OwnedDependencies` to `applicationPlacement`** (mirroring the
   `bpv1.Placement.OwnedDependencies` wire contract the UI + CR already use), so
   the canonical strict decode accepts the real console body → `targets[]`
   survive Path A → the fold derives `active-hot-standby`.
2. **Make `decodePlacementValue` carry `targets[]` through the lenient
   fallback**, so any future unknown field can never again silently drop them.

The handler still projects to the canonical `spec.placement` string +
`spec.regions` (Primary-first) it stored before — no CR-shape change.

## Tests

- `TestDecodeApplicationUpdateBody_4950_OwnedDependenciesKeepsTargets` — decode-level regression.
- `TestHandleApplicationUpdate_4950_ConsolePlacementApply_Returns200` — drives the **full** `HandleApplicationUpdate` with the exact console body (`json.RawMessage`, `ownedDependencies` verbatim) and asserts **200** + CR patched to `active-hot-standby` across both regions.

Both **fail on pre-fix code** with the exact issue 400
(`placement.mode is required when placement is set`) and pass after. Full
`internal/handler` package green; `go build ./...` + `go vet ./...` clean.

## Chart / pin

`images.catalystApi.tag` is a CI-built git SHA (per the values.yaml comment
"bump these via CI when building new images"). Matching #4840's pattern, this is
a code-only PR; deploybot bumps the chart pin + `bp-catalyst-platform` version
post-merge once the image publishes.

Refs #4950 #4840 #3969

🤖 Generated with [Claude Code](https://claude.com/claude-code)