### PR TITLE
fix(#4956): gate funnel Org launch on billing settlement + attach ordered apps

### DIFF
--- a/core/marketplace/src/components/CheckoutStep.svelte
+++ b/core/marketplace/src/components/CheckoutStep.svelte
@@ -300,6 +300,16 @@
           // Empty record when no app in the cart exposes a
           // configSchema (Ghost / Nextcloud / Sandbox today).
           app_configs: cart.appConfigs || {},
+          // #4956 — DEFER the Org launch until billing settles. The tenant
+          // service persists the Org shell (so billing can reference its id)
+          // but does NOT mint the Organization CR / dispatch the cart apps
+          // until /billing/checkout succeeds and calls the internal launch
+          // endpoint. This closes the funnel integrity gap where a checkout
+          // that 400'd on a bad voucher still left a provisioned Org with no
+          // purchased apps. The purchased app stack attaches on settlement
+          // (from the persisted cart), so it lands regardless of the re-nav
+          // path that previously skipped createTenant's inline dispatch.
+          defer_launch: true,
         });
         return { id: t.id, slug: t.slug || s, console_host: t.console_host };
       } catch (e: any) {

--- a/core/marketplace/src/lib/api.ts
+++ b/core/marketplace/src/lib/api.ts
@@ -517,6 +517,14 @@ export interface CreateTenantRequest {
   // round-trips on the `tenant.created` event payload — see
   // `tenant_created_wire_test.go`.
   app_configs?: Record<string, Record<string, number | string | boolean>>;
+  // #4956 — when true, the tenant-service persists the Org shell but does NOT
+  // fire the provisioning triggers (Organization CR, cart-install, sandbox).
+  // The Org stays `pending_payment` until billing settlement launches it, so a
+  // checkout that 400s (bad/unseeded voucher, declined card) can never leave a
+  // provisioned Org with no purchased apps behind. The funnel checkout sets
+  // this; omitting it preserves the immediate-launch behaviour for every other
+  // caller.
+  defer_launch?: boolean;
 }
 
 export interface Tenant {

--- a/core/services/billing/handlers/handlers.go
+++ b/core/services/billing/handlers/handlers.go
@@ -1186,6 +1186,52 @@ func (h *Handler) dispatchOrderPlaced(tenantID string, order *store.Order) {
 	if err := h.Producer.Publish(ctx, "org.order.events", evt); err != nil {
 		slog.Warn("dispatch order.placed", "error", err)
 	}
+
+	// #4956 — settlement gate. dispatchOrderPlaced is the SINGLE point both
+	// settlement paths (credit-only checkout AND the Stripe checkout.session
+	// .completed webhook) converge on, so this is where a funnel Org that was
+	// parked at `pending_payment` (defer_launch) is finally launched. Without
+	// this the marketplace funnel would never provision a paid Org, since on a
+	// Sovereign the order.placed event above is only a no-op observer. No-op for
+	// tenants that already launched immediately (non-funnel callers) — the
+	// endpoint is idempotent. This is the ONLY caller that can launch a deferred
+	// Org (the endpoint 401s externally), so a failed/abandoned checkout — which
+	// never reaches this function — leaves the Org un-provisioned.
+	h.launchTenant(tenantID)
+}
+
+// launchTenant asks the tenant service to launch a DEFERRED (pending_payment)
+// Org once its checkout has settled (#4956). Server-to-server POST to the
+// cluster-internal launch endpoint — the same in-cluster tenant URL + path
+// family lookupTenantSubdomain already uses. Best-effort with a short timeout:
+// a transient tenant-service blip logs loud (the paid Org would be left parked)
+// but does not fail the settlement, and the operator can re-drive via the
+// tenant's day-2 surface. Idempotent on the tenant side.
+func (h *Handler) launchTenant(tenantID string) {
+	if h.TenantURL == "" || tenantID == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	url := h.TenantURL + "/tenant/internal/tenants/" + tenantID + "/launch"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	if err != nil {
+		slog.Error("launchTenant: build request", "tenant_id", tenantID, "error", err)
+		return
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		slog.Error("launchTenant: tenant launch call failed — paid Org may be left parked at pending_payment (#4956)",
+			"tenant_id", tenantID, "error", err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		slog.Error("launchTenant: tenant launch non-200 — paid Org may be left parked at pending_payment (#4956)",
+			"tenant_id", tenantID, "status", resp.StatusCode)
+		return
+	}
+	slog.Info("launchTenant: settlement launch dispatched", "tenant_id", tenantID)
 }
 
 // lookupTenantAppConfigs fetches the tenant's per-app configSchema values

--- a/core/services/billing/handlers/settlement_launch_test.go
+++ b/core/services/billing/handlers/settlement_launch_test.go
@@ -1,0 +1,121 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/openova-io/openova/core/services/billing/store"
+	"github.com/openova-io/openova/core/services/shared/events"
+)
+
+// capturingProducer records every published event so a test can assert the
+// order.placed settlement event fired.
+type capturingProducer struct {
+	mu        sync.Mutex
+	published []*events.Event
+}
+
+func (p *capturingProducer) Publish(_ context.Context, _ string, e *events.Event) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.published = append(p.published, e)
+	return nil
+}
+func (p *capturingProducer) Close() {}
+
+func (p *capturingProducer) types() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	var out []string
+	for _, e := range p.published {
+		out = append(out, e.Type)
+	}
+	return out
+}
+
+// TestDispatchOrderPlaced_LaunchesDeferredOrgOnSettlement is the billing half
+// of the #4956 settlement gate. dispatchOrderPlaced is the SINGLE point both
+// settlement paths (credit-only checkout AND the Stripe checkout.session.
+// completed webhook) converge on, so it must POST the tenant-service internal
+// launch endpoint — the ONLY caller that can launch a deferred (pending_payment)
+// funnel Org. If this call were missing, a paid funnel Org would never
+// provision (on a Sovereign the order.placed event alone is a no-op observer).
+//
+// A checkout that 400s never reaches this function, so the Org stays parked —
+// that is the integrity guarantee this test locks in from the billing side.
+func TestDispatchOrderPlaced_LaunchesDeferredOrgOnSettlement(t *testing.T) {
+	const tenantID = "tid-235"
+
+	var (
+		mu         sync.Mutex
+		launchHits int
+		launchPath string
+		launchVerb string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/subdomain"):
+			_, _ = w.Write([]byte(`{"id":"` + tenantID + `","subdomain":"acme235"}`))
+		case strings.HasSuffix(r.URL.Path, "/app-configs"):
+			_, _ = w.Write([]byte(`{"id":"` + tenantID + `","app_configs":{}}`))
+		case strings.HasSuffix(r.URL.Path, "/launch"):
+			mu.Lock()
+			launchHits++
+			launchPath = r.URL.Path
+			launchVerb = r.Method
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"` + tenantID + `","launched":true,"status":"provisioning"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	prod := &capturingProducer{}
+	h := &Handler{Producer: prod, TenantURL: srv.URL}
+
+	order := &store.Order{
+		ID: "order-1", CustomerID: "cust-1", TenantID: tenantID,
+		PlanID: "plan-m", AmountOMR: 0, Status: "completed",
+	}
+
+	h.dispatchOrderPlaced(tenantID, order)
+
+	// The settlement event fired…
+	var sawOrderPlaced bool
+	for _, ty := range prod.types() {
+		if ty == "order.placed" {
+			sawOrderPlaced = true
+		}
+	}
+	if !sawOrderPlaced {
+		t.Errorf("expected an order.placed event to be published on settlement, got %v", prod.types())
+	}
+
+	// …AND the deferred Org was launched via the internal endpoint.
+	mu.Lock()
+	defer mu.Unlock()
+	if launchHits != 1 {
+		t.Fatalf("expected exactly 1 launch POST on settlement, got %d", launchHits)
+	}
+	if launchVerb != http.MethodPost {
+		t.Errorf("launch must be a POST, got %s", launchVerb)
+	}
+	wantPath := "/tenant/internal/tenants/" + tenantID + "/launch"
+	if launchPath != wantPath {
+		t.Errorf("launch path: got %q, want %q", launchPath, wantPath)
+	}
+}
+
+// TestLaunchTenant_NoopWhenTenantURLUnset proves the settlement launch call is
+// inert when the tenant URL isn't wired (Catalyst-Zero / tests) — it must never
+// panic or block, mirroring the existing lookupTenantSubdomain guard.
+func TestLaunchTenant_NoopWhenTenantURLUnset(t *testing.T) {
+	h := &Handler{}
+	h.launchTenant("tid") // TenantURL empty → no-op, must not panic.
+}

--- a/core/services/tenant/handlers/handlers.go
+++ b/core/services/tenant/handlers/handlers.go
@@ -164,6 +164,13 @@ func (h *Handler) callProvisioning(ctx context.Context, path string, payload any
 // Tenant CRUD
 // ---------------------------------------------------------------------------
 
+// statusPendingPayment is the state a DEFERRED-launch funnel Org sits in
+// between CreateOrg (shell persisted) and billing settlement (which calls the
+// internal launch endpoint). No provisioning triggers fire while a tenant is in
+// this state, so a checkout that 400s / is abandoned never leaves a provisioned
+// Org behind (#4956). The launch endpoint transitions it to "provisioning".
+const statusPendingPayment = "pending_payment"
+
 // CreateOrg creates a new organization for the authenticated user.
 func (h *Handler) CreateOrg(w http.ResponseWriter, r *http.Request) {
 	userID := middleware.UserIDFromContext(r.Context())
@@ -207,6 +214,16 @@ func (h *Handler) CreateOrg(w http.ResponseWriter, r *http.Request) {
 		// threads the SHAPE end-to-end so flipping the binding switch
 		// works without a second upstream change. Tolerated empty.
 		AppConfigs map[string]map[string]any `json:"app_configs"`
+		// DeferLaunch (#4956) — when true, CreateOrg persists the Org shell
+		// but does NOT fire the provisioning triggers (tenant.created →
+		// Organization CR, funnel cart-install, sandbox request). The Org
+		// stays `pending_payment` until billing settlement calls the internal
+		// launch endpoint. The marketplace funnel sets this so a checkout that
+		// 400s (bad/unseeded voucher, payment declined) can NEVER leave a
+		// provisioned Org behind — the integrity gap from the hw235 walk. All
+		// other callers (BSS door, direct API) omit it and keep launching
+		// immediately, so this change is inert for every non-funnel path.
+		DeferLaunch bool `json:"defer_launch"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		respond.Error(w, http.StatusBadRequest, "invalid JSON body")
@@ -265,19 +282,37 @@ func (h *Handler) CreateOrg(w http.ResponseWriter, r *http.Request) {
 			"apps_parent_domain", parentDomain)
 	}
 
+	// Owner email is derived from the caller's JWT claim and persisted on the
+	// tenant so the DEFERRED-launch path (#4956) can emit tenant.created with a
+	// non-empty owner_email once billing settles — the launch is triggered
+	// server-to-server by billing, long after these request claims are gone.
+	claims, _ := middleware.ClaimsFromContext(r.Context())
+	ownerEmail, _ := claims["email"].(string)
+
+	// #4956 — a deferred (funnel) Org is parked at `pending_payment`; the
+	// provisioning triggers only fire once billing settlement calls the internal
+	// launch endpoint. Every non-funnel caller keeps the immediate
+	// "provisioning" status + inline launch below.
+	initialStatus := "provisioning"
+	if body.DeferLaunch {
+		initialStatus = statusPendingPayment
+	}
+
 	tenant := &store.Tenant{
 		Slug:         body.Slug,
 		Name:         body.Name,
 		OrgType:      body.OrgType,
 		Industry:     body.Industry,
 		OwnerID:      userID,
+		OwnerEmail:   ownerEmail,
 		PlanID:       body.PlanID,
 		Apps:         body.Apps,
+		Agents:       body.Agents,
 		AddOns:       body.AddOns,
 		AppConfigs:   body.AppConfigs,
 		Subdomain:    body.Slug,
 		ParentDomain: parentDomain,
-		Status:       "provisioning",
+		Status:       initialStatus,
 	}
 
 	if err := h.Store.CreateTenant(r.Context(), tenant); err != nil {
@@ -297,96 +332,17 @@ func (h *Handler) CreateOrg(w http.ResponseWriter, r *http.Request) {
 		// Tenant was created; don't fail the response, but log the error.
 	}
 
-	// Publish tenant.created event (non-blocking — don't let broker outage delay the response).
-	//
-	// Per TBD-C16 (#1722) we enrich the wire payload with the JWT-derived
-	// owner_email so the provisioning consumer can mint an Organization CR
-	// without a second round trip to the user store. The wrapper struct
-	// embeds *store.Tenant so every existing decoder (which decodes a flat
-	// Tenant) keeps working — owner_email is a sibling field, not a
-	// shape-breaking nesting. Empty when the caller's JWT lacks the claim
-	// (the org-create consumer falls back to publishing an error event
-	// rather than minting a half-populated Organization CR).
-	claims, _ := middleware.ClaimsFromContext(r.Context())
-	ownerEmail, _ := claims["email"].(string)
-	// #3687 (fold #3690/#3673): emit the ONE canonical
-	// events.TenantCreatedPayload — the same struct the provisioning
-	// consumer decodes into and the bootstrap-API funnel maps onto —
-	// instead of a per-service anonymous struct embedding *store.Tenant
-	// (which flattened a dozen unused fields onto the wire). Tier /
-	// BillingMode stay empty here (the Organization-pool wizard default);
-	// the consumer applies the canonical defaults (tier→"org",
-	// billing→"real"), so every door defaults identically.
-	//
-	// #4176/#4179: ParentDomain is now carried through — the provisioning
-	// consumer needs the chosen pool apex to create the per-Org
-	// `console.<slug>.<parent_domain>` PowerDNS record + HTTPRoute. Empty
-	// when the caller omitted it (single-domain Sovereign back-compat).
-	tenantCreatedPayload := events.NewTenantCreatedPayload(
-		tenant.ID, tenant.Slug, tenant.Name, tenant.OwnerID, ownerEmail,
-		tenant.PlanID, "", "", tenant.ParentDomain)
-	evt, err := events.NewEvent("tenant.created", "tenant-service", tenant.ID, tenantCreatedPayload)
-	if err == nil {
-		pubCtx, pubCancel := context.WithTimeout(context.Background(), 3*time.Second)
-		defer pubCancel()
-		if pubErr := h.Producer.Publish(pubCtx, "org.tenant.events", evt); pubErr != nil {
-			slog.Error("failed to publish tenant.created event", "tenant_id", tenant.ID, "error", pubErr)
-		}
-	}
-
-	// #4360 funnel cart-placement (Refs #4272 #4307 #4322 #4179): the
-	// marketplace funnel persists the selected cart `Apps` on the Tenant +
-	// emits `tenant.created` (which mints ONLY the Organization CR — the
-	// org-controller renders the boundary ns + vCluster + network policies,
-	// but NO cart Applications). Without an explicit install dispatch the
-	// customer's purchased apps NEVER land in the per-Org gitops tree (the
-	// `vcluster/apps/` tree carried only networkpolicy.yaml) — the exact
-	// BSS-vs-funnel divergence #4179 catalogs, this time for cart placement
-	// (the BSS door's Step-6 renders the cart; the funnel door skipped it).
-	//
-	// Mirror the day-2 InstallApp path: for each deployable cart app, fire
-	// `tenant.app_install_requested` + the HTTP `/provisioning/apps/install`
-	// so the provisioning service renders the Applications into the per-Org
-	// gitops tree (same applyTenantChange → GenerateAllWithPassword path Flux
-	// reconciles once the org-controller boundary is up). Best-effort: a
-	// dispatch failure logs loud but does NOT fail Org creation (the shell is
-	// already minted; the day-2 page can re-install). `sandbox` is excluded
-	// here — it has its own `tenant.sandbox_requested` path below.
-	h.dispatchFunnelCartInstall(r.Context(), tenant)
-
-	// Wave 4 — Sandbox: when the cart contains the sandbox product,
-	// emit a sibling `tenant.sandbox_requested` event so the
-	// sandbox-controller (or its upstream orchestrator) can mint a
-	// Sandbox CR with `spec.agentCatalogue` matching the picks. The
-	// event carries enough to materialize the CR without re-reading
-	// the tenant doc: org slug + owner email + agent list. Subscriber
-	// is responsible for de-dup (sandbox CR name = sanitized email).
-	if containsSlug(body.Apps, "sandbox") {
-		sandboxPayload := map[string]any{
-			"tenant_id": tenant.ID,
-			"org_slug":  tenant.Slug,
-			"owner_id":  userID,
-			"agents":    body.Agents,
-			"sovereign": "", // populated by the consumer from its env / cluster context
-			// plan_id carries the customer-picked Sandbox tier
-			// (sandbox-free | sandbox-pro | sandbox-ent). The
-			// sandbox-orchestrator stamps it onto the Sandbox CR's
-			// openova.io/plan-id annotation so the controller can
-			// derive spec.quota from the catalog plan's
-			// IncludedQuotas. Empty plan_id falls through to the
-			// orchestrator's default quota (Wave 1 baseline) which
-			// matches sandbox-free, the safe-by-default tier.
-			"plan_id":      body.PlanID,
-			"requested_at": time.Now().UTC().Format(time.RFC3339),
-		}
-		sbEvt, sbErr := events.NewEvent("tenant.sandbox_requested", "tenant-service", tenant.ID, sandboxPayload)
-		if sbErr == nil {
-			pubCtx, pubCancel := context.WithTimeout(context.Background(), 3*time.Second)
-			defer pubCancel()
-			if pubErr := h.Producer.Publish(pubCtx, "org.tenant.events", sbEvt); pubErr != nil {
-				slog.Error("failed to publish tenant.sandbox_requested event", "tenant_id", tenant.ID, "error", pubErr)
-			}
-		}
+	// #4956 — fire the provisioning triggers (tenant.created → Organization CR,
+	// funnel cart-install, sandbox request) INLINE only when the caller did NOT
+	// request a deferred launch. The marketplace funnel sets defer_launch=true
+	// so nothing provisions until billing settlement calls the internal launch
+	// endpoint; every non-funnel caller (BSS door, direct API) leaves it false
+	// and launches immediately, exactly as before.
+	if !body.DeferLaunch {
+		h.launchTenant(r.Context(), tenant)
+	} else {
+		slog.Info("CreateOrg: deferred launch — Org parked at pending_payment until billing settles (#4956)",
+			"tenant_id", tenant.ID, "slug", tenant.Slug, "apps", tenant.Apps)
 	}
 
 	// #4176/#4179: return the server-authoritative customer console host so
@@ -510,6 +466,133 @@ func (h *Handler) dispatchFunnelCartInstall(ctx context.Context, t *store.Tenant
 		slog.Info("funnel cart-install: dispatched cart app",
 			"tenant_id", t.ID, "slug", t.Subdomain, "app", slug)
 	}
+}
+
+// launchTenant fires the provisioning triggers for a tenant: the
+// `tenant.created` event (→ provisioning mints the Organization CR → the
+// org-controller renders the boundary ns + vCluster + network policies), the
+// funnel cart-install (→ the customer's purchased Applications land in the
+// per-Org gitops tree), and the Sandbox request (when the cart holds sandbox).
+//
+// #4956 — this is the SINGLE place the funnel Org is provisioned. On the
+// immediate path (defer_launch=false) CreateOrg calls it inline; on the
+// deferred path it is called by InternalLaunchTenant ONLY after billing
+// settlement, so a checkout that 400s / is abandoned can never leave a
+// provisioned Org behind. owner_email + agents are read off the persisted
+// tenant (not the request), so the deferred call — which runs server-to-server
+// with no user context — still emits a complete tenant.created / sandbox
+// request. Best-effort + non-blocking: broker outages log loud but never fail
+// the caller (the Org shell already exists; the day-2 page / redelivery
+// recover).
+func (h *Handler) launchTenant(ctx context.Context, t *store.Tenant) {
+	if t == nil {
+		return
+	}
+	// #3687 (fold #3690/#3673): emit the ONE canonical
+	// events.TenantCreatedPayload — the same struct the provisioning consumer
+	// decodes into and the bootstrap-API funnel maps onto. Tier / BillingMode
+	// stay empty here (the Organization-pool wizard default); the consumer
+	// applies the canonical defaults (tier→"org", billing→"real").
+	//
+	// #4176/#4179: ParentDomain is carried through so the provisioning consumer
+	// can create the per-Org `console.<slug>.<parent_domain>` record + HTTPRoute.
+	tenantCreatedPayload := events.NewTenantCreatedPayload(
+		t.ID, t.Slug, t.Name, t.OwnerID, t.OwnerEmail,
+		t.PlanID, "", "", t.ParentDomain)
+	if evt, err := events.NewEvent("tenant.created", "tenant-service", t.ID, tenantCreatedPayload); err == nil {
+		pubCtx, pubCancel := context.WithTimeout(context.Background(), 3*time.Second)
+		if pubErr := h.Producer.Publish(pubCtx, "org.tenant.events", evt); pubErr != nil {
+			slog.Error("failed to publish tenant.created event", "tenant_id", t.ID, "error", pubErr)
+		}
+		pubCancel()
+	}
+
+	// Funnel cart-placement (#4360): render each deployable cart app into the
+	// per-Org gitops tree. Absent here, the customer's purchased apps never land
+	// (the vcluster/apps tree carried only networkpolicy.yaml).
+	h.dispatchFunnelCartInstall(ctx, t)
+
+	// Wave 4 — Sandbox: when the cart contains the sandbox product, emit
+	// `tenant.sandbox_requested` so the sandbox-orchestrator can mint a Sandbox
+	// CR with `spec.agentCatalogue` matching the persisted picks (t.Agents).
+	if containsSlug(t.Apps, "sandbox") {
+		sandboxPayload := map[string]any{
+			"tenant_id":    t.ID,
+			"org_slug":     t.Slug,
+			"owner_id":     t.OwnerID,
+			"agents":       t.Agents,
+			"sovereign":    "", // populated by the consumer from its env / cluster context
+			"plan_id":      t.PlanID,
+			"requested_at": time.Now().UTC().Format(time.RFC3339),
+		}
+		if sbEvt, sbErr := events.NewEvent("tenant.sandbox_requested", "tenant-service", t.ID, sandboxPayload); sbErr == nil {
+			pubCtx, pubCancel := context.WithTimeout(context.Background(), 3*time.Second)
+			if pubErr := h.Producer.Publish(pubCtx, "org.tenant.events", sbEvt); pubErr != nil {
+				slog.Error("failed to publish tenant.sandbox_requested event", "tenant_id", t.ID, "error", pubErr)
+			}
+			pubCancel()
+		}
+	}
+}
+
+// InternalLaunchTenant transitions a DEFERRED (pending_payment) Org to
+// provisioning and fires its launch — the settlement gate for #4956. It is
+// called SERVER-TO-SERVER by the billing service from dispatchOrderPlaced once a
+// checkout settles (credit-only OR Stripe webhook), so an Org launches iff its
+// order was actually placed.
+//
+// Security: this lives under `/tenant/internal/*`, which both edge gateways 401
+// externally (see main.go's JWT-bypass note) — it is reachable only by
+// in-cluster callers, never the browser. So the customer CANNOT self-launch to
+// skip payment; only billing (post-settlement) can.
+//
+// Idempotent + race-safe: the pending_payment→provisioning transition is a
+// conditional atomic store update, so repeated settlement dispatches (credit +
+// Stripe retry) launch exactly once. A tenant already past pending_payment
+// (immediate-launch caller, or a second settlement) is a benign 200 no-op. The
+// downstream tenant.created (409 AlreadyExists) + cart-install (idempotency-key)
+// dedups are the defence-in-depth backstop.
+func (h *Handler) InternalLaunchTenant(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		respond.Error(w, http.StatusBadRequest, "tenant id is required")
+		return
+	}
+	t, err := h.Store.GetTenant(r.Context(), id)
+	if err != nil {
+		respond.Error(w, http.StatusInternalServerError, "failed to fetch tenant")
+		return
+	}
+	if t == nil {
+		respond.Error(w, http.StatusNotFound, "tenant not found")
+		return
+	}
+
+	// Only a pending_payment Org is launchable here. Win the atomic transition
+	// before firing the triggers so a concurrent settlement dispatch can't
+	// double-launch.
+	won, err := h.Store.TryTransitionTenantStatus(r.Context(), id, statusPendingPayment, "provisioning")
+	if err != nil {
+		respond.Error(w, http.StatusInternalServerError, "failed to transition tenant status")
+		return
+	}
+	if !won {
+		// Already launched (immediate caller or a prior settlement) — benign.
+		slog.Info("internal launch: tenant not in pending_payment — no-op",
+			"tenant_id", id, "status", t.Status)
+		respond.JSON(w, http.StatusOK, map[string]any{
+			"id": id, "launched": false, "status": t.Status,
+		})
+		return
+	}
+
+	t.Status = "provisioning"
+	slog.Info("internal launch: billing settlement — launching deferred Org (#4956)",
+		"tenant_id", id, "slug", t.Slug, "apps", t.Apps)
+	h.launchTenant(r.Context(), t)
+	respond.JSON(w, http.StatusOK, map[string]any{
+		"id": id, "launched": true, "status": "provisioning",
+	})
 }
 
 // resolveOrgParentDomain picks the org-pool parent zone the Tenant's

--- a/core/services/tenant/handlers/launch_gate_test.go
+++ b/core/services/tenant/handlers/launch_gate_test.go
@@ -1,0 +1,124 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/openova-io/openova/core/services/shared/events"
+	"github.com/openova-io/openova/core/services/tenant/store"
+)
+
+// eventsByType returns every recorded event of the given type.
+func eventsByType(evs []*events.Event, typ string) []*events.Event {
+	var out []*events.Event
+	for _, e := range evs {
+		if e.Type == typ {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// TestLaunchTenant_FiresAllProvisioningTriggersFromPersistedFields is the
+// core #4956 guard. It proves that launchTenant — the SINGLE place a funnel Org
+// is provisioned, now invoked ONLY after billing settlement on the deferred
+// path — emits every provisioning trigger using values read off the PERSISTED
+// tenant (owner_email + agents), NOT the original HTTP request. The deferred
+// launch runs server-to-server from billing with no user context, so if these
+// fields weren't persisted the Organization CR would mint without an owner and
+// the sandbox catalogue would be lost. This is what makes "a customer who
+// orders WordPress gets WordPress" hold on the settled path.
+func TestLaunchTenant_FiresAllProvisioningTriggersFromPersistedFields(t *testing.T) {
+	prod := &recordingProducer{}
+	h := &Handler{
+		Producer: prod,
+		// Catalog nil → raw-slug cart dispatch; ProvisioningURL empty → the HTTP
+		// install leg errors (logged, non-fatal) and the event leg still fires.
+	}
+
+	tenant := &store.Tenant{
+		ID:           "tid-235",
+		Slug:         "acme235",
+		Name:         "ACME 235",
+		OwnerID:      "user-abc",
+		OwnerEmail:   "owner@acme235.example",
+		PlanID:       "plan-m",
+		ParentDomain: "omani.homes",
+		Apps:         []string{"wordpress", "sandbox", "umami"},
+		Agents:       []string{"claude-code", "qwen-code"},
+	}
+
+	h.launchTenant(context.Background(), tenant)
+
+	// 1. Exactly one tenant.created, carrying the PERSISTED owner_email + apex.
+	created := eventsByType(prod.published, "tenant.created")
+	if len(created) != 1 {
+		t.Fatalf("expected 1 tenant.created, got %d", len(created))
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(created[0].Data, &payload); err != nil {
+		t.Fatalf("decode tenant.created: %v", err)
+	}
+	if got := payload["owner_email"]; got != "owner@acme235.example" {
+		t.Errorf("tenant.created owner_email: got %v, want the persisted owner email (deferred launch has no request claims)", got)
+	}
+	if got := payload["parent_domain"]; got != "omani.homes" {
+		t.Errorf("tenant.created parent_domain: got %v, want omani.homes", got)
+	}
+
+	// 2. The purchased app stack is attached — one install per deployable cart
+	//    app (sandbox excluded, it has its own dispatch).
+	installs := appSlugsFromInstallEvents(t, prod.published)
+	want := map[string]bool{"wordpress": true, "umami": true}
+	if len(installs) != len(want) {
+		t.Fatalf("expected %d cart installs, got %d (%v)", len(want), len(installs), installs)
+	}
+	for _, s := range installs {
+		if !want[s] {
+			t.Errorf("unexpected cart install %q (sandbox must be excluded)", s)
+		}
+	}
+
+	// 3. Sandbox request fired with the PERSISTED agent catalogue.
+	sb := eventsByType(prod.published, "tenant.sandbox_requested")
+	if len(sb) != 1 {
+		t.Fatalf("expected 1 tenant.sandbox_requested, got %d", len(sb))
+	}
+	var sbData map[string]any
+	if err := json.Unmarshal(sb[0].Data, &sbData); err != nil {
+		t.Fatalf("decode sandbox payload: %v", err)
+	}
+	agents, _ := sbData["agents"].([]any)
+	if len(agents) != 2 {
+		t.Errorf("sandbox agents: got %v, want the 2 persisted picks (agents lost if not persisted for deferred launch)", sbData["agents"])
+	}
+}
+
+// TestLaunchTenant_NilTenantNoPanic guards the defensive nil path.
+func TestLaunchTenant_NilTenantNoPanic(t *testing.T) {
+	prod := &recordingProducer{}
+	h := &Handler{Producer: prod}
+	h.launchTenant(context.Background(), nil)
+	if len(prod.published) != 0 {
+		t.Fatalf("nil tenant must emit nothing, got %d events", len(prod.published))
+	}
+}
+
+// TestLaunchTenant_NoSandboxWhenNotInCart proves the sandbox request is only
+// emitted when the cart holds the sandbox product — a WordPress-only Org must
+// not spuriously request a Sandbox.
+func TestLaunchTenant_NoSandboxWhenNotInCart(t *testing.T) {
+	prod := &recordingProducer{}
+	h := &Handler{Producer: prod}
+	h.launchTenant(context.Background(), &store.Tenant{
+		ID: "tid", Slug: "acme", Subdomain: "acme",
+		OwnerEmail: "o@x.example", Apps: []string{"wordpress"},
+	})
+	if n := len(eventsByType(prod.published, "tenant.sandbox_requested")); n != 0 {
+		t.Fatalf("expected no sandbox request for a sandbox-free cart, got %d", n)
+	}
+	if n := len(eventsByType(prod.published, "tenant.created")); n != 1 {
+		t.Fatalf("expected the Org shell to still launch (1 tenant.created), got %d", n)
+	}
+}

--- a/core/services/tenant/handlers/routes.go
+++ b/core/services/tenant/handlers/routes.go
@@ -76,6 +76,12 @@ func (h *Handler) Routes() http.Handler {
 	// replicas/disk_gb/backups_enabled values were dropped between the
 	// store (PR #2043) and the rendered manifest.
 	mux.HandleFunc("GET /tenant/internal/tenants/{id}/app-configs", h.InternalGetAppConfigs)
+	// #4956 — billing calls this after a checkout settles (credit-only or
+	// Stripe webhook) to launch a DEFERRED (pending_payment) funnel Org. Gated
+	// to in-cluster callers by the gateway 401 on /tenant/internal/* (same
+	// posture as the two GETs above), so the browser can never self-launch to
+	// skip payment. Idempotent.
+	mux.HandleFunc("POST /tenant/internal/tenants/{id}/launch", h.InternalLaunchTenant)
 
 	// Admin — tenant management (superadmin only).
 	mux.HandleFunc("GET /tenant/admin/tenants", h.AdminListTenants)

--- a/core/services/tenant/store/store.go
+++ b/core/services/tenant/store/store.go
@@ -14,18 +14,33 @@ import (
 
 // Tenant represents an organization on the platform.
 type Tenant struct {
-	ID            string    `bson:"_id" json:"id"`
-	Slug          string    `bson:"slug" json:"slug"`
-	Name          string    `bson:"name" json:"name"`
-	OrgType       string    `bson:"org_type" json:"org_type"`
-	Industry      string    `bson:"industry" json:"industry"`
-	OwnerID       string    `bson:"owner_id" json:"owner_id"`
-	PlanID        string    `bson:"plan_id" json:"plan_id"`
-	Apps          []string  `bson:"apps" json:"apps"`
+	ID       string `bson:"_id" json:"id"`
+	Slug     string `bson:"slug" json:"slug"`
+	Name     string `bson:"name" json:"name"`
+	OrgType  string `bson:"org_type" json:"org_type"`
+	Industry string `bson:"industry" json:"industry"`
+	OwnerID  string `bson:"owner_id" json:"owner_id"`
+	// OwnerEmail is the owner's email captured at CreateOrg from the caller's
+	// JWT claim. It is persisted so the DEFERRED-launch path (#4956) can emit
+	// the `tenant.created` event — which the provisioning consumer requires an
+	// owner_email on to mint the Organization CR — long after the original HTTP
+	// request's claims are gone (the launch is triggered server-to-server by
+	// billing on settlement, with no user context). Empty on legacy records /
+	// callers whose JWT lacked the claim (the immediate path still derives it
+	// from claims inline).
+	OwnerEmail string   `bson:"owner_email,omitempty" json:"owner_email,omitempty"`
+	PlanID     string   `bson:"plan_id" json:"plan_id"`
+	Apps       []string `bson:"apps" json:"apps"`
+	// Agents carries the Sandbox coding-agent picks from the marketplace
+	// AppDetail surface. Persisted (#4956) so the deferred-launch path can emit
+	// `tenant.sandbox_requested` with the chosen catalogue on settlement — the
+	// request-body Agents list is otherwise gone by launch time. Only acted on
+	// when Apps contains "sandbox". Tolerated empty.
+	Agents []string `bson:"agents,omitempty" json:"agents,omitempty"`
 	// AppStates tracks per-app lifecycle (keyed by app ID). Values:
 	// "installing" | "uninstalling" | "failed". Absent means the app is in
 	// its steady state (installed when the ID is in Apps; gone otherwise).
-	AppStates     map[string]string `bson:"app_states,omitempty" json:"app_states,omitempty"`
+	AppStates map[string]string `bson:"app_states,omitempty" json:"app_states,omitempty"`
 	// AppConfigs carries per-instance configSchema values chosen by
 	// the customer on the marketplace AppDetail surface, keyed by app
 	// SLUG (e.g. "postgres" or "wordpress"). The inner map keys are
@@ -39,9 +54,9 @@ type Tenant struct {
 	// TBD-V26 (#2040) Path A/B decision; this field threads the
 	// SHAPE end-to-end so the binding lights up without a second
 	// upstream change.
-	AppConfigs    map[string]map[string]any `bson:"app_configs,omitempty" json:"app_configs,omitempty"`
-	AddOns        []string  `bson:"addons" json:"addons"`
-	Subdomain     string    `bson:"subdomain" json:"subdomain"`
+	AppConfigs map[string]map[string]any `bson:"app_configs,omitempty" json:"app_configs,omitempty"`
+	AddOns     []string                  `bson:"addons" json:"addons"`
+	Subdomain  string                    `bson:"subdomain" json:"subdomain"`
 	// ParentDomain — the org-pool parent apex the customer chose at the
 	// /addons step (e.g. "omani.works"). #4176/#4179: the per-Org console
 	// lives at `console.<subdomain>.<parent_domain>`. On a Sovereign whose
@@ -150,6 +165,27 @@ func (s *Store) UpdateTenantStatus(ctx context.Context, id, status string) error
 		return fmt.Errorf("store: tenant %s not found", id)
 	}
 	return nil
+}
+
+// TryTransitionTenantStatus atomically flips a tenant's status from `from` to
+// `to`, but ONLY if it currently equals `from`. It returns true iff the row was
+// matched-and-updated (i.e. this caller won the transition), false if the
+// tenant's status was not `from` (already transitioned by a concurrent caller,
+// or never in that state). This is the idempotency + race guard for the #4956
+// deferred launch: the settlement trigger flips `pending_payment → provisioning`
+// exactly once even if billing dispatches order.placed more than once (credit +
+// Stripe-retry), so the Org CR / cart-install fire a single time.
+func (s *Store) TryTransitionTenantStatus(ctx context.Context, id, from, to string) (bool, error) {
+	update := bson.D{{Key: "$set", Value: bson.D{
+		{Key: "status", Value: to},
+		{Key: "updated_at", Value: time.Now().UTC()},
+	}}}
+	res, err := s.tenants().UpdateOne(ctx,
+		bson.D{{Key: "_id", Value: id}, {Key: "status", Value: from}}, update)
+	if err != nil {
+		return false, fmt.Errorf("store: transition tenant status %s (%s→%s): %w", id, from, to, err)
+	}
+	return res.ModifiedCount > 0, nil
 }
 
 // SetAppState sets AppStates[appID] = state on the given tenant.


### PR DESCRIPTION
## Summary

Closes the funnel integrity gap proven on the hw235 conclusion walk (Org `acme235`): the funnel checkout **launched the Org even when the billing/voucher step returned HTTP 400**, so a customer's ORDERED app stack (e.g. WordPress) was never installed yet the Org still provisioned. An Org could launch with a **failed/skipped payment and no purchased apps**.

## Root cause

`CheckoutStep.svelte::handleCheckout()` provisioned the Org **and** its apps **before** billing settled:

1. **Step 1** `createTenant()` → `CreateOrg` **eagerly** emitted `tenant.created` (→ Organization CR → org-controller vCluster/boundary) **and** ran `dispatchFunnelCartInstall` (→ the app stack).
2. **Step 2** `createCheckout()` → billing `Checkout` ran afterwards and returned **400** on an invalid/unseeded voucher.

Provisioning already fired in Step 1, so the Org launched regardless of the 400. On a Sovereign (`PerOrgGitops`), `order.placed → startProvisioning` is a no-op observer, so **billing never gated anything**. On **re-nav**, `handleCheckout` reused the cached tenant and skipped `createTenant`, so `dispatchFunnelCartInstall` (only inside `CreateOrg`) never re-fired — leaving apps unattached while the vCluster was present.

## Fix — provision only on settlement

| Layer | Change |
|---|---|
| **tenant-service `CreateOrg`** | Opt-in `defer_launch` (default **false** → every non-funnel/BSS/API caller unchanged). When set, the Org shell is persisted at `pending_payment` and the provisioning triggers (`tenant.created`, funnel cart-install, sandbox) are **deferred**. `owner_email` + `agents` are now persisted so the deferred launch (which runs server-to-server with no request claims) still emits a complete `tenant.created` / sandbox request. |
| **tenant-service (new)** | `POST /tenant/internal/tenants/{id}/launch` — idempotently transitions `pending_payment → provisioning` (atomic conditional store update) and fires the launch. `/tenant/internal/*` is **401'd externally** by the gateway (same posture as the sibling internal GETs), so the browser can never self-launch to skip payment. |
| **billing `dispatchOrderPlaced`** | Calls the launch endpoint. This is the **single** settlement point both paths (credit-only checkout AND the Stripe `checkout.session.completed` webhook) converge on, so an Org launches **iff** its order was actually placed. A failed/abandoned checkout never reaches it → the Org stays un-provisioned. |
| **storefront** | Sets `defer_launch: true`; the purchased app stack attaches from the persisted cart **on settlement**, so it lands regardless of the re-nav path that previously skipped the inline dispatch. |

**Free-tier note (honest scope):** a genuinely free order still routes through `/billing/checkout` (`remaining <= 0` → credit-only settle → `order.placed` → launch), so free launches remain valid. The fix targets only the **failed/unsettled** case — an Org can no longer launch with a failed payment and no apps.

## Tests

- `core/services/tenant/handlers/launch_gate_test.go` — `launchTenant` (the sole funnel-provision path) emits `tenant.created` (with the **persisted** `owner_email`/`parent_domain`), one `tenant.app_install_requested` per deployable cart app, and `tenant.sandbox_requested` with the **persisted** agent catalogue; nil-safe; no spurious sandbox for a sandbox-free cart.
- `core/services/billing/handlers/settlement_launch_test.go` — `dispatchOrderPlaced` publishes `order.placed` **and** POSTs `/tenant/internal/tenants/{id}/launch` exactly once on settlement; the call is a no-op when `TenantURL` is unset.

## Builds

`go build ./...` + `go test ./...` green for **tenant** and **billing**; `astro build` green for **marketplace**.

Refs #4956
