### PR TITLE
feat(console #4552): arm the per-app Topology Switchover with an RPO/health preflight

### DIFF
--- a/products/catalyst/bootstrap/ui/src/lib/continuum.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/continuum.api.ts
@@ -66,6 +66,31 @@ export interface ContinuumSwitchoverResponse {
   httpStatus?: number
 }
 
+/**
+ * ContinuumSwitchoverPreview — body of
+ * POST /api/v1/sovereigns/{id}/continuum/{name}/switchover/preview
+ * (continuum_extras.go::HandleContinuumSwitchoverPreview).
+ *
+ * The READ-ONLY RPO/health preflight the confirm dialog runs BEFORE it
+ * arms the [ Confirm Switchover ] button. `promotable` is the gate: it is
+ * true only when `blockingChecks` is empty (target is not already primary,
+ * WAL lag is within 4× RTO, and the Continuum is not mid-switchover /
+ * Failed). `currentLagSec` is the live replication lag the operator sees
+ * before committing. Nothing is mutated by this call.
+ */
+export interface ContinuumSwitchoverPreview {
+  continuum: string
+  namespace: string
+  targetRegion: string
+  currentPrimary: string
+  currentLagSec: number
+  estimatedDurationSec: number
+  estimatedDuration: string
+  blockingChecks: string[]
+  promotable: boolean
+  message: string
+}
+
 /** ContinuumFailbackRequest — body of POST .../failback. */
 export interface ContinuumFailbackRequest {
   reason?: string
@@ -274,6 +299,38 @@ export async function requestSwitchover(
   if (!res.ok) {
     const detail = await res.text().catch(() => '')
     throw new Error(`switchover: HTTP ${res.status} ${detail}`)
+  }
+  return res.json()
+}
+
+/**
+ * getSwitchoverPreview — run the read-only RPO/health preflight for a
+ * Continuum CR (POST .../continuum/{name}/switchover/preview). The confirm
+ * dialog calls this before arming its [ Confirm Switchover ] button so the
+ * operator sees the live lag + any blocking checks and can only proceed
+ * when `promotable` is true. Read-only — mutates nothing on the cluster.
+ *
+ * The singular `/continuum/` path is used (the preview endpoint lives only
+ * under the singular alias — see continuum_extras.go).
+ */
+export async function getSwitchoverPreview(
+  sovereignId: string,
+  name: string,
+  body: { targetRegion?: string } = {},
+  opts: { namespace?: string } = {},
+): Promise<ContinuumSwitchoverPreview> {
+  const params = new URLSearchParams()
+  if (opts.namespace) params.set('namespace', opts.namespace)
+  const qs = params.toString()
+  const url = `${continuumSingularBase(sovereignId)}/${encodeURIComponent(name)}/switchover/preview${qs ? '?' + qs : ''}`
+  const res = await authedFetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '')
+    throw new Error(`switchover preview: HTTP ${res.status} ${detail}`)
   }
   return res.json()
 }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.test.tsx
@@ -10,7 +10,7 @@
  * blueprint name.
  */
 import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
-import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 /* ── Mock the API + infra clients so no network is hit ─────────────────── */
@@ -20,6 +20,8 @@ const getCatalogItem = vi.fn()
 const getApplicationPlacement = vi.fn()
 const getHierarchicalInfrastructure = vi.fn()
 const getContinuumReplicationStatus = vi.fn()
+const getSwitchoverPreview = vi.fn()
+const requestSwitchover = vi.fn()
 
 vi.mock('@/lib/catalog.api', () => ({
   getApplicationStatus: (...a: unknown[]) => getApplicationStatus(...a),
@@ -35,6 +37,10 @@ vi.mock('@/lib/continuum.api', async (importOriginal) => {
   return {
     ...actual,
     getContinuumReplicationStatus: (...a: unknown[]) => getContinuumReplicationStatus(...a),
+    // #4552 — the armed SwitchoverDialog runs a preflight + confirm. Mock both
+    // so opening the dialog from the DR panel doesn't hit the network.
+    getSwitchoverPreview: (...a: unknown[]) => getSwitchoverPreview(...a),
+    requestSwitchover: (...a: unknown[]) => requestSwitchover(...a),
   }
 })
 
@@ -64,6 +70,31 @@ beforeEach(() => {
   // the DR section renders the calm "no cross-region replica" note unless a
   // case overrides it. Mirrors the endpoint's real not-found behaviour.
   getContinuumReplicationStatus.mockRejectedValue(new Error('continuum replication-status: HTTP 404'))
+  // #4552 — the switchover preflight defaults to a promotable result so the
+  // armed dialog can be exercised; cases override per-scenario.
+  getSwitchoverPreview.mockResolvedValue({
+    continuum: 'dr-shared-pg',
+    namespace: 'shared-data',
+    targetRegion: 'me-east-215-b',
+    currentPrimary: 'me-east-215-a',
+    currentLagSec: 0,
+    estimatedDurationSec: 60,
+    estimatedDuration: '60s',
+    blockingChecks: [],
+    promotable: true,
+    message: 'preview only',
+  })
+  requestSwitchover.mockResolvedValue({
+    name: 'dr-shared-pg',
+    namespace: 'shared-data',
+    targetRegion: 'me-east-215-b',
+    fromRegion: 'me-east-215-a',
+    toRegion: 'me-east-215-b',
+    requestedAt: new Date().toISOString(),
+    message: 'switchover completed',
+    applied: true,
+    completed: true,
+  })
 })
 
 afterEach(() => {
@@ -358,7 +389,7 @@ describe('TopologyTab — DR / replication surface (#3375 rows 51/52/56/57)', ()
     expect(screen.getByTestId('topology-tab-dr-source').textContent).toContain('live')
   })
 
-  it('Switchover affordance is present but DISABLED (deferred, row 57)', async () => {
+  it('Switchover affordance is ARMED — opens the confirm dialog (row 57, #4552)', async () => {
     getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
     getApplicationPlacement.mockResolvedValue(standbyPlacement)
     getContinuumReplicationStatus.mockResolvedValue({
@@ -374,11 +405,56 @@ describe('TopologyTab — DR / replication surface (#3375 rows 51/52/56/57)', ()
     render(withProviders(<TopologyTab sovereignId="dep-z" applicationName="shared-pg" namespace="shared-data" />))
 
     await waitFor(() => {
-      expect(screen.getByTestId('topology-tab-dr-switchover')).toBeTruthy()
+      expect(screen.getByTestId('topology-tab-dr-switchover-open')).toBeTruthy()
     })
-    const btn = screen.getByTestId('topology-tab-dr-switchover').querySelector('button')
-    expect(btn).toBeTruthy()
-    expect(btn?.disabled).toBe(true)
+    const btn = screen.getByTestId('topology-tab-dr-switchover-open') as HTMLButtonElement
+    // Armed (not the old deferred disabled affordance).
+    expect(btn.disabled).toBe(false)
+    // No dialog until the operator clicks.
+    expect(screen.queryByTestId('continuum-switchover-dialog')).toBeNull()
+    fireEvent.click(btn)
+    // The confirm dialog opens with the from→to diff (the standby is the target).
+    await waitFor(() => {
+      expect(screen.getByTestId('continuum-switchover-dialog')).toBeTruthy()
+    })
+    expect(screen.getByTestId('continuum-switchover-dialog-diff').textContent).toContain('me-east-215-b')
+  })
+
+  it('#4552: a paired CNPG whose placement projects a false singleton STILL renders the pair + switchover (no stale singleton)', async () => {
+    getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
+    getApplicationStatus.mockResolvedValue({ name: 'shared-pg', namespace: 'shared-data', spec: {}, status: {} })
+    // The placement projection reports ONLY the primary (the CNPG replica half
+    // isn't surfaced as a Standby target) → hasStandby is false → the tab used
+    // to render a stale singleton with no DR. But the LIVE continuum status
+    // confirms a real cross-region pair, so the DR panel + switchover must
+    // render off it.
+    getApplicationPlacement.mockResolvedValue({
+      targets: [{ region: 'me-east-215-a', cluster: 'c', vcluster: 'host', role: 'Primary' }],
+      derivedFromRuntime: true,
+    })
+    getContinuumReplicationStatus.mockResolvedValue({
+      continuum: 'dr-shared-pg',
+      namespace: 'shared-data',
+      primaryRegion: 'me-east-215-a',
+      currentPrimary: 'me-east-215-a',
+      walLagSeconds: 0,
+      replicas: [{ region: 'me-east-215-b', role: 'replica', lagSeconds: 0 }],
+      streamingState: 'streaming',
+      syncState: 'sync',
+      source: 'live',
+    })
+
+    render(withProviders(<TopologyTab sovereignId="dep-z" applicationName="shared-pg" namespace="shared-data" />))
+
+    // DR panel renders off the live pair even though placement said singleton.
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-dr-panel')).toBeTruthy()
+    })
+    expect(screen.getByTestId('topology-tab-dr-primary').textContent).toContain('me-east-215-a')
+    expect(screen.getByTestId('topology-tab-dr-standby').textContent).toContain('me-east-215-b')
+    // And the switchover control is armed for it.
+    const btn = screen.getByTestId('topology-tab-dr-switchover-open') as HTMLButtonElement
+    expect(btn.disabled).toBe(false)
   })
 
   it('a SINGLETON app shows NO DR panel + NO Switchover (honestly hidden, row 58)', async () => {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
@@ -36,6 +36,7 @@ import {
 } from '@/lib/continuum.api'
 import { getHierarchicalInfrastructure } from '@/lib/infrastructure.types'
 import { PlacementEditor, type OwnedDependencyInfo } from '@/widgets/topology/PlacementEditor'
+import { SwitchoverDialog } from '@/widgets/continuum/SwitchoverDialog'
 import {
   type Capability,
   type PlacementTarget,
@@ -102,6 +103,9 @@ export function TopologyTab({
   const qc = useQueryClient()
   const [editing, setEditing] = useState(false)
   const [refreshTick, setRefreshTick] = useState(0)
+  // #4552 — the armed manual-switchover confirm dialog (opened from the DR
+  // panel's "Switch over…" button). Closed by default.
+  const [showSwitchover, setShowSwitchover] = useState(false)
 
   // #3656 — bootstrap-kit HelmReleases have no Application CR; the status
   // endpoint 404s forever, so don't poll it for them.
@@ -226,17 +230,24 @@ export function TopologyTab({
   )
   const continuumName = useMemo(() => `dr-${applicationName}`, [applicationName])
 
-  // Poll the DR endpoint for genuinely multi-region apps. Two entry points:
+  // Poll the DR endpoint for every networked app and gate rendering on a
+  // genuine live cross-region result. Three cases the poll covers:
   //   • App-CR apps with a Standby placement target (hasStandby, the #3375 path).
   //   • #4886 — Continuum-backed BOOTSTRAP-HR apps (spine-keycloak/gitea/harbor/
   //     openbao, cnpg-pair). These have NO Application CR and their Pods run
   //     active-active across both regions, so the placement projection can't
   //     advertise a Standby target → hasStandby is false even though the live
   //     `continuums.dr.openova.io` CR carries the real active/standby + lag.
-  //     We poll for them too and gate rendering on a live cross-region result
-  //     (source:"live" + a distinct standby region) so a singleton bootstrap
-  //     component never fabricates DR off the synthesized fallback.
-  // A 404 (no Continuum CR) does NOT retry and leaves drStatus undefined.
+  //   • #4552 — an app whose placement projection reports a FALSE singleton
+  //     (e.g. shared-pg, whose CNPG replica half the projection doesn't surface
+  //     as a Standby target). hasStandby is false and it is not a bootstrap
+  //     component, yet a live 2-region cnpg-pair genuinely backs it. Polling
+  //     unconditionally lets the DR panel render it as a pair with the
+  //     switchover control instead of a stale singleton.
+  // Rendering is ALWAYS gated on a live cross-region result (source:"live" + a
+  // distinct standby region), so a genuine singleton — which 404s or returns a
+  // synthesized/pending shape — never fabricates a DR panel. A 404 (no
+  // Continuum CR / no live pair) does NOT retry and leaves drStatus undefined.
   // Bootstrap components query with an EMPTY namespace so the cluster-wide
   // lookup finds the CR in its own namespace (the HR lives in flux-system, the
   // Continuum in the spine's namespace) — mirrors the #4000 placement rule.
@@ -244,7 +255,7 @@ export function TopologyTab({
   const drQ = useQuery({
     queryKey: ['continuum-replication-status', sovereignId, continuumName, drNamespace, refreshTick],
     queryFn: () => getContinuumReplicationStatus(sovereignId, continuumName, { namespace: drNamespace }),
-    enabled: !disableNetwork && (hasStandby || isBootstrap) && !!sovereignId && !!applicationName,
+    enabled: !disableNetwork && !!sovereignId && !!applicationName,
     refetchInterval: 30_000,
     retry: false,
   })
@@ -282,12 +293,14 @@ export function TopologyTab({
   )
   const lagColor: LagBucket = useMemo(() => lagBucket(lagSeconds), [lagSeconds])
 
-  // #4886 — the DR section renders for App-CR apps with a Standby placement
-  // target (the existing #3375 hasStandby path) AND for bootstrap-HR apps whose
+  // #4886 / #4552 — the DR section renders for App-CR apps with a Standby
+  // placement target (the existing #3375 hasStandby path) AND for ANY app whose
   // LIVE continuum status confirms a genuine cross-region pair: source:"live"
-  // plus a standby region distinct from the active/lease-holder region. A
-  // singleton bootstrap component (no live continuum → synthesized fallback, or
-  // a same-region echo) never renders DR, so we never arm a phantom region.
+  // plus a standby region distinct from the active/lease-holder region. This
+  // covers bootstrap-HR spine apps (#4886) and App-CR apps whose placement
+  // projection reported a false singleton (#4552 — shared-pg). An app with no
+  // live pair (404 → synthesized/pending shape, or a same-region echo) never
+  // renders DR, so we never arm a phantom region.
   const liveStandbyRegion = useMemo(
     () =>
       drStatus?.replicas?.find(
@@ -295,8 +308,15 @@ export function TopologyTab({
       )?.region || '',
     [drStatus, drPrimaryRegion],
   )
-  const bootstrapHasLiveDR = isBootstrap && drStatus?.source === 'live' && !!liveStandbyRegion
-  const showDR = hasStandby || bootstrapHasLiveDR
+  const hasLiveDR = drStatus?.source === 'live' && !!liveStandbyRegion
+  const showDR = hasStandby || hasLiveDR
+
+  // The switchover target — the standby region we would promote. Prefer the
+  // placement Standby target, fall back to the live continuum standby region.
+  const switchoverTarget = useMemo(
+    () => drStandbyRegions[0] || liveStandbyRegion || '',
+    [drStandbyRegions, liveStandbyRegion],
+  )
 
   // Owned dependencies that cascade — read from spec.placement.ownedDependencies
   // when present (override state); the names also come from the blueprint's
@@ -612,24 +632,50 @@ export function TopologyTab({
                 ) : null}
               </div>
 
-              {/* Destructive Switchover is DEFERRED (#4552 — needs careful
-                  safety UX: confirm + RPO/health preflight). Surfaced as a
-                  disabled affordance so the surface is discoverable without
-                  arming a one-click region flip. */}
+              {/* Armed manual Switchover (#4552). The button opens a confirm
+                  dialog that runs a read-only RPO/health preflight and only
+                  arms [ Confirm Switchover ] when the standby is caught up and
+                  promotable. The confirm wires to the operator-gated
+                  POST .../switchover endpoint (the K-Cont-2 reconciler runs the
+                  7-step cordon-before-promote sequence). Hidden when we can't
+                  resolve a standby region to promote to. */}
               <div className="mt-4 flex items-center gap-2" data-testid="topology-tab-dr-switchover">
                 <button
                   type="button"
-                  className="cursor-not-allowed rounded-md border border-[var(--color-border)] px-3 py-1.5 text-xs text-[var(--color-text-dim)] opacity-60"
-                  disabled
-                  aria-disabled="true"
-                  title="Manual switchover ships next — it needs a confirm + preflight safety flow (Refs #4552)."
+                  className="rounded-md border border-[var(--color-border)] px-3 py-1.5 text-xs hover:border-[var(--color-accent)] disabled:cursor-not-allowed disabled:opacity-50"
+                  onClick={() => setShowSwitchover(true)}
+                  disabled={!switchoverTarget}
+                  data-testid="topology-tab-dr-switchover-open"
                 >
                   Switch over…
                 </button>
                 <span className="text-[10px] text-[var(--color-text-dim)]">
-                  manual switchover ships next (Refs #4552)
+                  {switchoverTarget
+                    ? `promote standby ${switchoverTarget} — runs an RPO/health preflight before you confirm`
+                    : 'resolving standby region…'}
                 </span>
               </div>
+
+              {showSwitchover && switchoverTarget ? (
+                <SwitchoverDialog
+                  sovereignId={sovereignId}
+                  continuumName={continuumName}
+                  namespace={drNamespace}
+                  fromRegion={drPrimaryRegion}
+                  toRegion={switchoverTarget}
+                  applicationName={applicationName}
+                  lagSeconds={lagSeconds}
+                  syncState={drStatus?.syncState}
+                  disableNetwork={disableNetwork}
+                  onClose={() => setShowSwitchover(false)}
+                  onConfirmed={() => {
+                    setShowSwitchover(false)
+                    // Re-poll the DR status so the panel reflects the promoted
+                    // primary + fresh lag right after the sequence kicks off.
+                    setRefreshTick((t) => t + 1)
+                  }}
+                />
+              ) : null}
             </>
           )}
         </section>

--- a/products/catalyst/bootstrap/ui/src/widgets/continuum/SwitchoverDialog.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/continuum/SwitchoverDialog.test.tsx
@@ -1,15 +1,33 @@
 /**
  * SwitchoverDialog.test.tsx — Vitest unit tests for the EPIC-6 Slice
- * U-DR-1 (#1101) confirm dialog. Uses disableNetwork seam so no fetch
- * is required.
+ * U-DR-1 (#1101) confirm dialog + the armed RPO/health preflight (#4552).
+ *
+ * The original suite uses the disableNetwork seam so no fetch is required.
+ * The preflight suite drives the real (mocked) preview + switchover calls to
+ * lock the arm-gate: Confirm is enabled ONLY when the preflight is promotable.
  */
-import { describe, it, expect, afterEach, vi } from 'vitest'
-import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+
+const getSwitchoverPreview = vi.fn()
+const requestSwitchover = vi.fn()
+
+vi.mock('@/lib/continuum.api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/continuum.api')>()
+  return {
+    ...actual,
+    getSwitchoverPreview: (...a: unknown[]) => getSwitchoverPreview(...a),
+    requestSwitchover: (...a: unknown[]) => requestSwitchover(...a),
+  }
+})
 
 import { SwitchoverDialog } from './SwitchoverDialog'
 import { SWITCHOVER_STEPS } from '@/lib/continuum.api'
 
-afterEach(() => cleanup())
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
 
 describe('SwitchoverDialog', () => {
   it('renders the diff with from-region → to-region', () => {
@@ -101,5 +119,177 @@ describe('SwitchoverDialog', () => {
     const est = screen.getByTestId('continuum-switchover-dialog-estimates')
     expect(est.textContent).toContain('60s')
     expect(est.textContent).toContain('5s')
+  })
+})
+
+describe('SwitchoverDialog — RPO/health preflight arm-gate (#4552)', () => {
+  beforeEach(() => {
+    getSwitchoverPreview.mockReset()
+    requestSwitchover.mockReset()
+  })
+
+  function renderNetworked(overrides: Record<string, unknown> = {}) {
+    return render(
+      <SwitchoverDialog
+        sovereignId="dep-z"
+        continuumName="dr-shared-pg"
+        namespace="shared-data"
+        applicationName="shared-pg"
+        fromRegion="me-east-215-a"
+        toRegion="me-east-215-b"
+        onClose={vi.fn()}
+        onConfirmed={vi.fn()}
+        {...overrides}
+      />,
+    )
+  }
+
+  it('runs the preflight on open and arms Confirm only after a promotable result', async () => {
+    getSwitchoverPreview.mockResolvedValue({
+      continuum: 'dr-shared-pg',
+      namespace: 'shared-data',
+      targetRegion: 'me-east-215-b',
+      currentPrimary: 'me-east-215-a',
+      currentLagSec: 0,
+      estimatedDurationSec: 60,
+      estimatedDuration: '60s',
+      blockingChecks: [],
+      promotable: true,
+      message: 'preview only',
+    })
+    renderNetworked()
+
+    // The preflight fires against the switchover-preview endpoint.
+    await waitFor(() => {
+      expect(getSwitchoverPreview).toHaveBeenCalledWith(
+        'dep-z',
+        'dr-shared-pg',
+        { targetRegion: 'me-east-215-b' },
+        { namespace: 'shared-data' },
+      )
+    })
+    // Confirm is armed once the preflight clears.
+    await waitFor(() => {
+      const confirm = screen.getByTestId('continuum-switchover-dialog-confirm') as HTMLButtonElement
+      expect(confirm.disabled).toBe(false)
+    })
+    expect(screen.getByTestId('continuum-switchover-dialog-preflight-status').textContent).toContain('ready')
+    // Live lag reading is surfaced (not a hardcoded dash).
+    expect(screen.getByTestId('continuum-switchover-dialog-preflight-lag').textContent).toContain('0.0 s')
+  })
+
+  it('keeps Confirm DISABLED when the preflight has blocking checks', async () => {
+    getSwitchoverPreview.mockResolvedValue({
+      continuum: 'dr-shared-pg',
+      namespace: 'shared-data',
+      targetRegion: 'me-east-215-b',
+      currentPrimary: 'me-east-215-a',
+      currentLagSec: 320,
+      estimatedDurationSec: 320,
+      estimatedDuration: '320s',
+      blockingChecks: ['WAL lag 320.0s exceeds 4× RTO (60s) — replica not promotable'],
+      promotable: false,
+      message: 'preview only',
+    })
+    renderNetworked()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('continuum-switchover-dialog-preflight-checks')).toBeTruthy()
+    })
+    const confirm = screen.getByTestId('continuum-switchover-dialog-confirm') as HTMLButtonElement
+    expect(confirm.disabled).toBe(true)
+    expect(screen.getByTestId('continuum-switchover-dialog-preflight-check-0').textContent).toContain(
+      'not promotable',
+    )
+    // Clicking the disabled Confirm does not fire the switchover mutation.
+    fireEvent.click(confirm)
+    expect(requestSwitchover).not.toHaveBeenCalled()
+  })
+
+  it('on a passing preflight + Confirm, fires the switchover and reports the applied outcome', async () => {
+    getSwitchoverPreview.mockResolvedValue({
+      continuum: 'dr-shared-pg',
+      namespace: 'shared-data',
+      targetRegion: 'me-east-215-b',
+      currentPrimary: 'me-east-215-a',
+      currentLagSec: 0,
+      estimatedDurationSec: 60,
+      estimatedDuration: '60s',
+      blockingChecks: [],
+      promotable: true,
+      message: 'preview only',
+    })
+    requestSwitchover.mockResolvedValue({
+      name: 'dr-shared-pg',
+      namespace: 'shared-data',
+      targetRegion: 'me-east-215-b',
+      fromRegion: 'me-east-215-a',
+      toRegion: 'me-east-215-b',
+      requestedAt: new Date().toISOString(),
+      message: 'switchover completed',
+      applied: true,
+      completed: true,
+    })
+    const onConfirmed = vi.fn()
+    const onClose = vi.fn()
+    renderNetworked({ onConfirmed, onClose })
+
+    await waitFor(() => {
+      const confirm = screen.getByTestId('continuum-switchover-dialog-confirm') as HTMLButtonElement
+      expect(confirm.disabled).toBe(false)
+    })
+    fireEvent.click(screen.getByTestId('continuum-switchover-dialog-confirm'))
+
+    await waitFor(() => {
+      expect(requestSwitchover).toHaveBeenCalledWith(
+        'dep-z',
+        'dr-shared-pg',
+        { targetRegion: 'me-east-215-b', reason: undefined },
+        { namespace: 'shared-data' },
+      )
+    })
+    await waitFor(() => {
+      expect(onConfirmed).toHaveBeenCalled()
+    })
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('a 200-with-error switchover (no-live-dr-pair) keeps the dialog open and surfaces the reason', async () => {
+    getSwitchoverPreview.mockResolvedValue({
+      continuum: 'dr-shared-pg',
+      namespace: 'shared-data',
+      targetRegion: 'me-east-215-b',
+      currentPrimary: 'me-east-215-a',
+      currentLagSec: 0,
+      estimatedDurationSec: 60,
+      estimatedDuration: '60s',
+      blockingChecks: [],
+      promotable: true,
+      message: 'preview only',
+    })
+    requestSwitchover.mockResolvedValue({
+      name: 'dr-shared-pg',
+      namespace: 'shared-data',
+      targetRegion: 'me-east-215-b',
+      requestedAt: new Date().toISOString(),
+      message: 'no live 2-region cnpg-pair backing shared-pg',
+      applied: false,
+      error: 'no-live-dr-pair',
+    })
+    const onConfirmed = vi.fn()
+    const onClose = vi.fn()
+    renderNetworked({ onConfirmed, onClose })
+
+    await waitFor(() => {
+      const confirm = screen.getByTestId('continuum-switchover-dialog-confirm') as HTMLButtonElement
+      expect(confirm.disabled).toBe(false)
+    })
+    fireEvent.click(screen.getByTestId('continuum-switchover-dialog-confirm'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('continuum-switchover-dialog-error').textContent).toContain('no live 2-region')
+    })
+    expect(onConfirmed).not.toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
   })
 })

--- a/products/catalyst/bootstrap/ui/src/widgets/continuum/SwitchoverDialog.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/continuum/SwitchoverDialog.tsx
@@ -1,34 +1,47 @@
 /**
- * SwitchoverDialog — EPIC-6 Slice U-DR-1 (#1101).
+ * SwitchoverDialog — EPIC-6 Slice U-DR-1 (#1101) + armed preflight (#4552).
  *
  * Confirm dialog the operator clicks through before the catalyst-api
  * patches the Continuum CR's `spec.switchover.requested = true`. Shows:
  *
  *   - The diff: "Primary will move from <fromRegion> → <toRegion>"
+ *   - A read-only RPO/health PREFLIGHT (#4552): the live WAL replication
+ *     lag + every blocking check the switchover would hit. The
+ *     [ Confirm Switchover ] button is armed ONLY when the preflight is
+ *     promotable (no blocking checks) — a lagging / mid-switchover /
+ *     already-primary target keeps Confirm disabled with the reason shown.
  *   - The 7-step list from K-Cont-2's Sequencer (SWITCHOVER_STEPS)
  *   - Estimated duration <60s, write disruption <5s
  *   - Cancel / Confirm buttons
  *
  * On Confirm → POST /api/v1/sovereigns/{id}/continuums/{name}/switchover
- * (via continuum.api.requestSwitchover). Returns 202 Accepted; the
- * K-Cont-2 reconciler picks up the patch on its next loop iteration
- * and emits the 7-step audit events on NATS.
+ * (via continuum.api.requestSwitchover). The K-Cont-2 reconciler picks up
+ * the patch on its next reconcile pass and runs the 7-step
+ * cordon-before-promote sequence (or, when no Continuum CR backs the app,
+ * catalyst-api drives the proven live cnpg-pair `spec.replica.enabled`
+ * flip directly). The handler returns HTTP 200 even on a no-op / failure —
+ * the body's `applied` / `error` carry the truth, so the dialog only
+ * closes on a real apply and surfaces the reason otherwise.
  *
  * Per docs/INVIOLABLE-PRINCIPLES.md #5 the underlying handler enforces
- * owner tier on the Application server-side. The widget renders
- * regardless of tier; the parent (DRSection) hides the entry-point
- * button when the caller lacks owner. On a 403 from the API the dialog
- * surfaces the error inline.
+ * owner/operator tier on the Application server-side. The widget renders
+ * regardless of tier; the parent hides the entry-point button when the
+ * caller lacks owner. On a 403 from the API the dialog surfaces the error
+ * inline.
  *
- * Disable-network seam mirrors TopologyEditor — tests render the
- * dialog without a real fetch.
+ * Disable-network seam mirrors TopologyEditor — tests render the dialog
+ * without a real fetch (preflight is skipped and Confirm is armed so the
+ * seam stays a pure UI harness).
  */
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import {
+  getSwitchoverPreview,
   requestSwitchover,
   SWITCHOVER_STEPS,
+  lagBucket,
+  type ContinuumSwitchoverPreview,
   type ContinuumSwitchoverResponse,
 } from '@/lib/continuum.api'
 
@@ -45,11 +58,20 @@ export interface SwitchoverDialogProps {
   toRegion: string
   /** Application name surfaced in the dialog header for context. */
   applicationName: string
+  /**
+   * Live WAL replication lag in seconds (from the Topology tab's
+   * replication-status poll). Displayed in the preflight header while the
+   * authoritative preview resolves; the preview's `currentLagSec` wins once
+   * it lands. Optional.
+   */
+  lagSeconds?: number | null
+  /** Live sync/streaming state (e.g. "sync" / "async") — display only. */
+  syncState?: string
   /** Fired when the operator dismisses the dialog (cancel or after success). */
   onClose: () => void
   /** Fired on a successful POST. */
   onConfirmed?: (resp: ContinuumSwitchoverResponse) => void
-  /** Test seam — bypass the network call. */
+  /** Test seam — bypass the network calls (preflight + confirm). */
   disableNetwork?: boolean
 }
 
@@ -60,6 +82,8 @@ export function SwitchoverDialog({
   fromRegion,
   toRegion,
   applicationName,
+  lagSeconds,
+  syncState,
   onClose,
   onConfirmed,
   disableNetwork = false,
@@ -67,6 +91,58 @@ export function SwitchoverDialog({
   const [reason, setReason] = useState<string>('')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  // ── RPO/health preflight (#4552) ──────────────────────────────────
+  // A read-only dry-run against the live Continuum + CNPGPair status. The
+  // Confirm button is armed ONLY when `preflight.promotable` is true.
+  const [preflight, setPreflight] = useState<ContinuumSwitchoverPreview | null>(null)
+  const [preflightLoading, setPreflightLoading] = useState(!disableNetwork)
+  const [preflightError, setPreflightError] = useState<string | null>(null)
+  // Bump to re-run the preflight after a transient network error.
+  const [preflightTick, setPreflightTick] = useState(0)
+
+  // Kick off the preflight on open (and on each retry). State updates happen
+  // ONLY in the async callbacks — the effect body itself calls no setState
+  // (the "loading" reset lives in the retry click handler / the initial
+  // useState), so this stays clear of cascading synchronous renders.
+  useEffect(() => {
+    if (disableNetwork) return
+    let cancelled = false
+    getSwitchoverPreview(
+      sovereignId,
+      continuumName,
+      { targetRegion: toRegion || undefined },
+      { namespace },
+    )
+      .then((rep) => {
+        if (cancelled) return
+        setPreflight(rep)
+        setPreflightError(null)
+      })
+      .catch((e) => {
+        if (cancelled) return
+        setPreflightError((e as Error).message)
+      })
+      .finally(() => {
+        if (cancelled) return
+        setPreflightLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [disableNetwork, sovereignId, continuumName, toRegion, namespace, preflightTick])
+
+  // The live lag: prefer the authoritative preview reading, fall back to the
+  // parent-supplied replication-status lag while the preview is in flight.
+  const shownLag: number | null =
+    preflight != null ? preflight.currentLagSec : lagSeconds ?? null
+  const shownLagColor = lagBucket(shownLag)
+
+  // Confirm is armed only when the preflight passed. Under disableNetwork the
+  // gate is skipped so the seam stays a pure UI harness.
+  const preflightPassed = disableNetwork || (preflight != null && preflight.promotable)
+  const confirmDisabled =
+    busy || (!disableNetwork && (preflightLoading || !preflightPassed))
 
   const onConfirm = async () => {
     setError(null)
@@ -82,6 +158,12 @@ export function SwitchoverDialog({
       }
       onConfirmed?.(stub)
       onClose()
+      return
+    }
+    // Belt-and-braces: never fire the mutation when the preflight has not
+    // cleared (the button is already disabled, but guard the handler too).
+    if (!preflightPassed) {
+      setError('preflight has not passed — resolve the blocking checks first')
       return
     }
     setBusy(true)
@@ -154,6 +236,125 @@ export function SwitchoverDialog({
           ) : null}
         </div>
 
+        {/* ── RPO/health preflight (#4552) ─────────────────────────────── */}
+        {!disableNetwork ? (
+          <div
+            className="mb-4 rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] p-3"
+            data-testid="continuum-switchover-dialog-preflight"
+          >
+            <div className="mb-2 flex items-baseline justify-between">
+              <h4 className="text-xs font-semibold uppercase tracking-wide text-[var(--color-text-dim)]">
+                RPO / health preflight
+              </h4>
+              {preflightLoading ? (
+                <span
+                  className="text-[10px] text-[var(--color-text-dim)]"
+                  data-testid="continuum-switchover-dialog-preflight-loading"
+                >
+                  checking…
+                </span>
+              ) : preflightError ? (
+                <span
+                  className="rounded bg-red-500/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-red-400"
+                  data-testid="continuum-switchover-dialog-preflight-status"
+                >
+                  ○ check failed
+                </span>
+              ) : preflight?.promotable ? (
+                <span
+                  className="rounded bg-green-500/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-green-400"
+                  data-testid="continuum-switchover-dialog-preflight-status"
+                >
+                  ● ready to promote
+                </span>
+              ) : (
+                <span
+                  className="rounded bg-yellow-500/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-yellow-400"
+                  data-testid="continuum-switchover-dialog-preflight-status"
+                >
+                  ○ not promotable
+                </span>
+              )}
+            </div>
+
+            {/* Live replication lag (the RPO reading). */}
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">
+              <span className="flex items-center gap-1.5">
+                <span className="text-[var(--color-text-dim)]">Replication lag</span>
+                <span
+                  className={`inline-flex items-center rounded-md px-2 py-0.5 font-semibold tabular-nums ${
+                    shownLagColor === 'green'
+                      ? 'bg-green-500/10 text-green-400'
+                      : shownLagColor === 'yellow'
+                        ? 'bg-yellow-500/10 text-yellow-400'
+                        : shownLagColor === 'red'
+                          ? 'bg-red-500/10 text-red-400'
+                          : 'bg-[var(--color-bg)] text-[var(--color-text-dim)]'
+                  }`}
+                  data-testid="continuum-switchover-dialog-preflight-lag"
+                >
+                  {shownLag == null ? '—' : `${shownLag.toFixed(1)} s`}
+                </span>
+              </span>
+              {syncState ? (
+                <span className="text-[var(--color-text-dim)]">
+                  replication: <span className="text-[var(--color-text)]">{syncState}</span>
+                </span>
+              ) : null}
+              {preflight?.estimatedDuration ? (
+                <span className="text-[var(--color-text-dim)]">
+                  est. failover:{' '}
+                  <span className="text-[var(--color-text)]">{preflight.estimatedDuration}</span>
+                </span>
+              ) : null}
+            </div>
+
+            {/* Blocking checks — Confirm stays disabled while any is present. */}
+            {preflightError ? (
+              <div
+                className="mt-2 flex items-center justify-between gap-2 text-xs text-red-400"
+                data-testid="continuum-switchover-dialog-preflight-error"
+              >
+                <span>Preflight could not run: {preflightError}</span>
+                <button
+                  type="button"
+                  className="rounded-md border border-[var(--color-border)] px-2 py-0.5 text-[10px] hover:border-[var(--color-accent)]"
+                  onClick={() => {
+                    setPreflight(null)
+                    setPreflightError(null)
+                    setPreflightLoading(true)
+                    setPreflightTick((t) => t + 1)
+                  }}
+                  data-testid="continuum-switchover-dialog-preflight-retry"
+                >
+                  Re-run
+                </button>
+              </div>
+            ) : preflight && preflight.blockingChecks.length > 0 ? (
+              <ul
+                className="mt-2 space-y-1 text-xs text-yellow-300"
+                data-testid="continuum-switchover-dialog-preflight-checks"
+              >
+                {preflight.blockingChecks.map((c, i) => (
+                  <li
+                    key={i}
+                    data-testid={`continuum-switchover-dialog-preflight-check-${i}`}
+                    className="flex items-start gap-1.5"
+                  >
+                    <span aria-hidden>⚠</span>
+                    <span>{c}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : preflight ? (
+              <p className="mt-2 text-xs text-green-400">
+                All preflight checks passed — the standby is caught up and
+                promotable.
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+
         <div className="mb-4">
           <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[var(--color-text-dim)]">
             What happens (7 steps)
@@ -224,9 +425,14 @@ export function SwitchoverDialog({
           <button
             type="button"
             data-testid="continuum-switchover-dialog-confirm"
-            className="rounded-md bg-[var(--color-accent)] px-3 py-1.5 text-xs text-[var(--color-bg)] hover:opacity-90 disabled:opacity-40"
+            className="rounded-md bg-[var(--color-accent)] px-3 py-1.5 text-xs text-[var(--color-bg)] hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
             onClick={onConfirm}
-            disabled={busy}
+            disabled={confirmDisabled}
+            title={
+              confirmDisabled && !busy
+                ? 'The RPO/health preflight must pass before switchover can be confirmed.'
+                : undefined
+            }
           >
             {busy ? 'Confirming…' : 'Confirm Switchover'}
           </button>


### PR DESCRIPTION
## What

Arms the deferred manual **Switchover** on the per-app **Topology / Disaster-recovery** tab (`AppDetail → Topology`). The button was a disabled affordance; it now opens a confirm dialog that runs a real **RPO / health preflight** and only lets the operator promote the standby when the preflight passes.

Refs #4552 #3375

## Why it is not a hollow shell

The switchover backend already exists and is wired — this PR is the frontend arm-flow onto it:

- **Execute**: `POST /api/v1/sovereigns/{id}/continuum(s)/{name}/switchover` (owner/operator-gated) patches `spec.switchover.requested=true`; the continuum-controller runs the 7-step **cordon-before-promote** sequence (split-brain guard baked in). When no Continuum CR backs the app, catalyst-api drives the proven live cnpg-pair `spec.replica.enabled` flip directly (the region-kill mechanism).
- **Preflight**: `POST /api/v1/sovereigns/{id}/continuum/{name}/switchover/preview` (read-only) returns `currentLagSec`, `blockingChecks[]`, `promotable`.

An operator can now click Switch over, see the live replication lag + each failing check, confirm only when the standby is caught up and promotable, and the standby actually promotes. A 200-with-`error` outcome (e.g. `no-live-dr-pair`) keeps the dialog open and surfaces the reason — no fabricated success.

## Changes

- `lib/continuum.api.ts` — add `getSwitchoverPreview()` + its response type.
- `widgets/continuum/SwitchoverDialog.tsx` — run the preflight on open; arm **Confirm Switchover** only when `promotable`; render the live lag + each check; wire confirm to the existing switchover endpoint and report the true applied/error outcome.
- `pages/sovereign/AppDetail/TopologyTab.tsx` — replace the disabled affordance with the armed button + dialog; generalize the live-DR gate so a paired CNPG whose placement projects a false singleton (e.g. `shared-pg`) renders as a pair with the switchover control instead of a stale singleton. The panel still renders only on a genuine `source:"live"` cross-region result, so a real singleton never fabricates DR.

## No-regress

Only-add. The #4887 DR region labels + WAL replication-lag render and the #4900 instance badge are untouched. No NodePorts. No backend change — the Go switchover + preview handlers already shipped.

## Verification

- `vitest` — `SwitchoverDialog.test.tsx` + `TopologyTab.test.tsx` green (25 tests): preflight arms/disables Confirm, blocking checks keep Confirm disabled, confirm fires the switchover, a 200-with-error keeps the dialog open, and the paired-CNPG false-singleton now renders the pair + armed control.
- `eslint .` on the touched files — clean.
- `tsc -b` — no new type errors (the only failure is a pre-existing missing `@types/js-yaml` in an unrelated test file).

The catalyst-api console image build + bootstrap-kit pin bump is handled by the deploy pipeline on merge (no chart-version bump in this PR, to avoid a version collision with the deploy treadmill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
