### PR TITLE
fix(marketplace): checkout renders "Organization" not banned term "tenant"

### DIFF
--- a/core/marketplace/playwright/customer-journey.spec.ts
+++ b/core/marketplace/playwright/customer-journey.spec.ts
@@ -480,8 +480,8 @@ test.describe('marketplace customer-journey (17-step regression gate)', () => {
     await page.goto('/checkout')
 
     // Wait for the launch CTA (label is "Purchase · OMR …" when cost > 0,
-    // or "Launch my tenant" when cost == 0). Either text is acceptable.
-    const launch = page.getByRole('button', { name: /Launch my tenant|Purchase/i }).first()
+    // or "Launch my Organization" when cost == 0). Either text is acceptable.
+    const launch = page.getByRole('button', { name: /Launch my Organization|Purchase/i }).first()
     await expect(launch).toBeVisible({ timeout: 10_000 })
 
     // The provisioning panel renders the user's profile + order summary.
@@ -543,7 +543,7 @@ test.describe('marketplace customer-journey (17-step regression gate)', () => {
     await seedCart(page)
     await page.goto('/checkout')
 
-    const launch = page.getByRole('button', { name: /Launch my tenant|Purchase/i }).first()
+    const launch = page.getByRole('button', { name: /Launch my Organization|Purchase/i }).first()
     await expect(launch).toBeVisible({ timeout: 10_000 })
 
     // Click triggers the chain. CheckoutStep.handleCheckout calls them in
@@ -638,7 +638,7 @@ test.describe('marketplace customer-journey (17-step regression gate)', () => {
     })
     await page.goto('/checkout')
 
-    const launch = page.getByRole('button', { name: /Launch my tenant|Purchase/i }).first()
+    const launch = page.getByRole('button', { name: /Launch my Organization|Purchase/i }).first()
     await expect(launch).toBeVisible({ timeout: 10_000 })
     await Promise.all([
       page.waitForURL(/console\.openova\.io|console\..*\.(works|homes|rest|trade)/, { timeout: 15_000 }).catch(() => null),
@@ -781,7 +781,7 @@ test.describe('marketplace customer-journey (17-step regression gate)', () => {
     await seedCart(page)
     await page.goto('/checkout')
 
-    const launch = page.getByRole('button', { name: /Launch my tenant|Purchase/i }).first()
+    const launch = page.getByRole('button', { name: /Launch my Organization|Purchase/i }).first()
     await expect(launch).toBeVisible({ timeout: 10_000 })
 
     const [request] = await Promise.all([

--- a/core/marketplace/src/components/CheckoutStep.svelte
+++ b/core/marketplace/src/components/CheckoutStep.svelte
@@ -319,7 +319,7 @@
         throw e;
       }
     }
-    throw lastErr || new Error('tenant name is taken — please choose a different subdomain');
+    throw lastErr || new Error('Organization name is taken — please choose a different subdomain');
   }
 
   async function handleCheckout() {
@@ -415,7 +415,7 @@
       clearCart();
       redirectToConsole(tenant.slug);
     } catch (e: any) {
-      provisionError = e.message || 'Failed to create tenant';
+      provisionError = e.message || 'Failed to create Organization';
       checkoutLoading = false;
     }
   }
@@ -473,9 +473,9 @@
       {#if !user}
         Sign in to complete your order
       {:else if provision}
-        Setting up your tenant...
+        Setting up your Organization...
       {:else}
-        Review and launch your tenant
+        Review and launch your Organization
       {/if}
     </p>
   </div>
@@ -814,7 +814,7 @@
             <div class="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"></div>
             Processing…
           {:else if totalCost === 0 || creditCovers}
-            Launch my tenant
+            Launch my Organization
             <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6"/>
             </svg>
@@ -826,7 +826,7 @@
           {/if}
         </button>
         <p class="mt-3 text-center text-[11px] text-[var(--color-text-dimmer)]">
-          After payment is confirmed, your tenant will be created automatically.
+          After payment is confirmed, your Organization will be created automatically.
         </p>
       </div>
     {/if}


### PR DESCRIPTION
## Problem
The marketplace **checkout** page (`core/marketplace/src/components/CheckoutStep.svelte`) rendered the GLOSSARY-banned term **"tenant"** in user-facing copy (found on hw236) — a stray regression against the #3383 `sme`/`tenant` → **Organization** eradication. The sibling `/launching` page (`LaunchingStep.svelte`) and the rest of this same component already say "Organization" (L494/L506/L636).

## Fix
Six user-visible strings corrected to **Organization** (matching casing + the `/launching` wording):

| Line | Before | After |
|---|---|---|
| 476 | `Setting up your tenant...` | `Setting up your Organization...` |
| 478 | `Review and launch your tenant` | `Review and launch your Organization` |
| 817 | `Launch my tenant` (button) | `Launch my Organization` |
| 829 | `your tenant will be created automatically.` | `your Organization will be created automatically.` |
| 322 | `tenant name is taken …` (create error) | `Organization name is taken …` |
| 418 | `Failed to create tenant` (provision-error fallback) | `Failed to create Organization` |

The `customer-journey.spec.ts` button-name regex + comment were updated to match the new `Launch my Organization` label.

**Not touched** (legitimately non-Organization): code identifiers (`tenant`, `tenantId`, `createTenantWithRetry`), the `tenant_id` API-contract payload fields, `org-checkout-tenant*` localStorage keys, and source comments. Only user-visible text changed.

## Gates
- **Naming guard proves both directions** — PASS (RED on a new `/api/v1/sme/` route; GREEN on `Tier "sme"` value)
- **Reject persona-named machinery in the working tree** — PASS (`OK: no persona-named machinery introduced`)
- `astro build` — PASS (11 pages) + `check-served-domain-hygiene` postbuild PASS
- Built `dist/_astro/CheckoutStep.*.js` verified: contains "Launch my Organization", zero "Launch my tenant"

## Chart lockstep
`marketplaceTag` is auto-bumped by `.github/workflows/marketplace-build.yaml` + deploy-bot sed on every push to `core/marketplace/**` — a manual pin here would collide with the deploy-bot, so none is included.

Refs #3383
Refs #4963

🤖 Generated with [Claude Code](https://claude.com/claude-code)