### PR TITLE
fix(#4964): grant per-Org provisioning SA tenant-NS secrets write for kubeconfig mirror

### DIFF
--- a/core/services/provisioning/gitops/gitops.go
+++ b/core/services/provisioning/gitops/gitops.go
@@ -2104,8 +2104,22 @@ rules:
     resources: ["kustomizations"]
     verbs: ["get", "list", "watch", "patch", "delete"]
   - apiGroups: [""]
+    # #3376 — the #4785 dual-namespace kubeconfig mirror
+    # (mirrorVClusterKubeconfig, handlers.go) POSTs the
+    # tenant-<slug>-kubeconfig Secret into BOTH flux-system AND this tenant
+    # namespace, because the per-Org application HelmReleases carry a
+    # namespace-less kubeConfig.secretRef that Flux resolves in the HR's OWN
+    # (tenant) namespace. flux-system write is granted by the chart Role
+    # org-provisioning-fluxsystem; the tenant-NS write was missing here, so
+    # 'create secrets -n <slug>' 403'd -> "create mirror secret (<slug>) 403"
+    # -> provisioning failed at the vcluster step and no per-Org app ever
+    # reconciled (WordPress never Ready). create/update/patch are the minimum
+    # for the upsert (POST, then PUT-on-409). NO delete — the mirror never
+    # removes a tenant secret; teardown drops only the flux-system copy
+    # (deleteVClusterKubeconfigMirror) and the tenant-NS copy is GC'd with the
+    # namespace. Least-privilege + namespaced.
     resources: ["secrets"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
   - apiGroups: [""]
     # delete needed so waitForVclusterDNSOrKick can bounce vcluster-0 when
     # the syncer's initial DNS reconciliation doesn't publish the

--- a/core/services/provisioning/gitops/rbac_test.go
+++ b/core/services/provisioning/gitops/rbac_test.go
@@ -37,23 +37,53 @@ func TestGenerateProvisioningTenantRBAC(t *testing.T) {
 		t.Fatalf("expected SA binding to org-services/provisioning, got: %s", got)
 	}
 
-	// Must NOT grant write on secrets in-tenant — only read. Writing tenant
-	// secrets via the provisioning SA was never needed and only expanded
-	// blast radius.
-	if strings.Contains(got, `resources: ["secrets"]`) {
-		// Allowed as long as verbs are read-only.
-		lines := strings.Split(got, "\n")
-		for i, line := range lines {
-			if strings.Contains(line, `resources: ["secrets"]`) && i+1 < len(lines) {
-				verbs := lines[i+1]
-				for _, v := range []string{"create", "update", "patch", "delete"} {
-					if strings.Contains(verbs, `"`+v+`"`) {
-						t.Fatalf("secrets rule must be read-only, got verb %q in: %s", v, verbs)
-					}
+	// #3376: the secrets rule MUST grant create+get+update+patch so the
+	// #4785 dual-namespace kubeconfig mirror (mirrorVClusterKubeconfig) can
+	// upsert tenant-<slug>-kubeconfig INTO this tenant NS (POST, then PUT on
+	// 409). Before this, secrets was read-only here → `create secrets -n
+	// <slug>` 403'd → provisioning failed → no per-Org app ever reconciled.
+	// It must still be least-privilege: NO delete on secrets (the mirror
+	// never removes a tenant secret; teardown deletes only the flux-system
+	// copy, and the tenant-NS copy is GC'd with the namespace).
+	secretsVerbs := verbsForResource(got, `resources: ["secrets"]`)
+	if secretsVerbs == "" {
+		t.Fatalf("expected a secrets rule, got: %s", got)
+	}
+	for _, v := range []string{"create", "get", "update", "patch"} {
+		if !strings.Contains(secretsVerbs, `"`+v+`"`) {
+			t.Fatalf("secrets rule must grant %q for the kubeconfig mirror, got: %s", v, secretsVerbs)
+		}
+	}
+	if strings.Contains(secretsVerbs, `"delete"`) {
+		t.Fatalf("secrets rule must NOT grant delete (least-privilege), got: %s", secretsVerbs)
+	}
+
+	// The vcluster-dns-kick (waitForVclusterDNSOrKick) deletes vcluster-0, so
+	// the pods rule MUST grant delete. Without it `delete pods -n <slug>`
+	// 403s and the DNS kick can't recover a stuck syncer.
+	podsVerbs := verbsForResource(got, `resources: ["pods"]`)
+	if podsVerbs == "" {
+		t.Fatalf("expected a pods rule, got: %s", got)
+	}
+	if !strings.Contains(podsVerbs, `"delete"`) {
+		t.Fatalf("pods rule must grant delete for the vcluster-dns-kick, got: %s", podsVerbs)
+	}
+}
+
+// verbsForResource returns the `verbs:` line that immediately follows the
+// first line matching `resourceLine` in the rendered RBAC, or "" if not found.
+func verbsForResource(rendered, resourceLine string) string {
+	lines := strings.Split(rendered, "\n")
+	for i, line := range lines {
+		if strings.Contains(line, resourceLine) {
+			for j := i + 1; j < len(lines); j++ {
+				if strings.Contains(lines[j], "verbs:") {
+					return lines[j]
 				}
 			}
 		}
 	}
+	return ""
 }
 
 func TestGenerateAllIncludesTenantRBAC(t *testing.T) {


### PR DESCRIPTION
## What

Grant the per-Org provisioning ServiceAccount (`org-services/provisioning`)
`secrets: [get, list, watch, create, update, patch]` in the per-Org tenant
namespace, via the namespaced Role emitted by
`generateProvisioningTenantRBAC` (`core/services/provisioning/gitops/gitops.go`).

## Why (root-caused live on hw236, dep `d412876d4c00c8fb`)

Per-Org customer app provisioning failed — WordPress/customer apps never
reconciled. The provisioning SA was FORBIDDEN from `create secrets` in the
per-Org tenant namespace while it COULD in `flux-system`:

```
kubectl auth can-i create secrets -n acme236     --as=system:serviceaccount:org-services:provisioning → no
kubectl auth can-i create secrets -n flux-system --as=system:serviceaccount:org-services:provisioning → yes
```

Failure chain in the provisioning log:

```
create mirror secret (acme236) 403
→ vcluster dns kick: delete vcluster-0 403
→ kube-dns service still missing → provisioning failed step=2
→ day-2 install: app wordpress not ready after 10m
```

`#4785` made `mirrorVClusterKubeconfig` POST the `tenant-<slug>-kubeconfig`
Secret into BOTH `flux-system` AND the per-Org tenant `<slug>` namespace
(the per-Org app HelmReleases carry a namespace-less `kubeConfig.secretRef`
that Flux resolves in the HR's OWN tenant namespace). The matching write
grant was added only to the flux-system chart Role
(`org-provisioning-fluxsystem` in
`products/catalyst/chart/templates/org-services/provisioning.yaml`), NOT to
the per-Org tenant Role, which stayed `secrets: [get, list, watch]`
read-only → the tenant-NS mirror POST 403s and provisioning fails.

## The fix

- `secrets` verbs in the per-Org tenant Role → `[get, list, watch, create, update, patch]`. Minimum for the mirror upsert (POST, then PUT on 409). **No `delete`** on secrets — the mirror never removes a tenant secret; teardown deletes only the flux-system copy (`deleteVClusterKubeconfigMirror`) and the tenant-NS copy is GC'd with the namespace. Least-privilege preserved.
- The `pods` rule already grants `delete` for the vcluster-dns-kick (`waitForVclusterDNSOrKick` deletes `vcluster-0`).
- Namespaced Role only — no cluster-wide widening. Plane-isolation unchanged.

## Test

`rbac_test.go` `TestGenerateProvisioningTenantRBAC` inverted: it now asserts
the secrets rule grants `create/get/update/patch` and NOT `delete`, and that
the pods rule grants `delete`. `go build ./...`, `go vet ./gitops/`, and
`go test ./gitops/` all pass.

## Validation

Validates on the NEXT per-Org install prov (not hw236, about to be
cutover-degraded): `kubectl auth can-i create secrets -n <slug>
--as=system:serviceaccount:org-services:provisioning` → yes, and the
per-Org WordPress HelmRelease reconciles Ready.

Refs #3376 #4964 #4785
