### PR TITLE
fix(#4967): cutover step-06 re-asserts gitea admin password before demirror PATCH

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -753,7 +753,12 @@ spec:
       # step-08 deny-egress hold no openova-io image is left on ghcr.io (the #4885
       # residual after #4899 closed org-services). No step-count / job-mode / RBAC
       # change (still 11 steps).
-      version: 0.1.110
+      # 0.1.111 (#4967 Refs #4885 #3379): step-06 RE-ASSERTS the Gitea admin
+      # password (execs `gitea admin user change-password` in the live gitea Pod)
+      # before the demirror PATCH + git push, so a step-04 gitea-image roll that
+      # left the DB password drifted from gitea-admin-secret no longer 401s the
+      # demirror (hw236 wedge). Self-healing, best-effort; no step-count / RBAC change.
+      version: 0.1.111
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.110
+  version: 0.1.111
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,20 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.111 (#4967 Refs #4885 #3379): step-06 now RE-ASSERTS the Gitea admin
+# password before the demirror PATCH + git push. Root cause (hw236 live): the
+# demirror authenticates gitea_admin:<gitea-admin-secret.password>, but step-04
+# registry-pivot rolls the gitea image ~minutes earlier and on that restart the
+# init container's keepUpdated re-sync can race / no-op, leaving the LIVE DB
+# password DRIFTED from the Secret → EVERY admin-API auth 401s `user's password
+# is invalid [uid:1 name:gitea_admin]` (all 62 live-K8s HR URL patches succeeded;
+# only the Gitea-API auth failed). bp-gitea's admin-secret Helm-lookup pin +
+# #4885 reloader roll SHRINK but do not CLOSE the drift window. New Phase-1.4
+# (gated on .Values.gitea.adminPasswordReassert.enabled, default true) resolves
+# the live gitea Pod by label selector and execs `gitea admin user
+# change-password` to force the DB row to match the Secret — self-healing, the
+# CLI writes users directly so it heals even while the API 401s. Best-effort:
+# Pod-not-found logs + falls through to the PATCH (no regression). RBAC already
+# grants pods/exec; NO step-count / job-mode / RBAC change (still 11 steps).
 # 0.1.110 (#4961 Refs #4885 #3379, the LAST step-07 image-pivot residual — two
 # un-pivoted bootstrap-kit DaemonSets wedge the step-08 deny-egress hold): step-07
 # pivoted global.imageRegistry on 7 HRs but left bp-openova-flow-emitter (slot 57,
@@ -1633,7 +1648,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.110
+version: 0.1.111
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
@@ -94,6 +94,22 @@ data:
             value: {{ .Values.gitea.org | quote }}
           - name: GITEA_REPO
             value: {{ .Values.gitea.repo | quote }}
+          # #4967 (Refs #3379 #4885) — self-healing re-assert of the Gitea
+          # admin password before the demirror PATCH + git push. The live DB
+          # password can DRIFT from gitea-admin-secret when step-04 rolls the
+          # gitea image and the init container's keepUpdated re-sync races /
+          # no-ops (hw236 wedge: demirror 401 `user's password is invalid
+          # [uid:1 name:gitea_admin]`). The Phase-1.4 block execs
+          # `gitea admin user change-password` in the live gitea Pod to force
+          # the DB row to match the Secret. See .Values.gitea.adminPasswordReassert.
+          - name: GITEA_ADMIN_PASSWORD_REASSERT
+            value: {{ .Values.gitea.adminPasswordReassert.enabled | default true | quote }}
+          - name: GITEA_NAMESPACE
+            value: {{ .Values.gitea.adminPasswordReassert.namespace | default "gitea" | quote }}
+          - name: GITEA_POD_SELECTOR
+            value: {{ .Values.gitea.adminPasswordReassert.podSelector | default "app.kubernetes.io/name=gitea,app.kubernetes.io/instance=gitea" | quote }}
+          - name: GITEA_CONTAINER
+            value: {{ .Values.gitea.adminPasswordReassert.containerName | default "gitea" | quote }}
           # Phase 0 (#1184) — harbor.<sov-fqdn> auth merge into ghcr-pull.
           # HARBOR_PASSWORD comes from the Reflector-mirrored
           # harbor-admin Secret in this namespace (bp-harbor 1.2.14+
@@ -721,6 +737,67 @@ data:
               if nslookup "${gitea_host}" >/dev/null 2>&1; then break; fi
               sleep 5
             done
+
+            # ---- Phase 1.4 (#4967, Refs #3379 #4885): RE-ASSERT gitea admin ----
+            #                password BEFORE any authenticated Gitea call
+            #
+            # Root cause (hw236 live cutover step-06 demirror 401): the demirror
+            # PATCH and the git clone/push below authenticate to Gitea with
+            # BasicAuth gitea_admin:<gitea-admin-secret.password>. step-04
+            # registry-pivot rolls the gitea image ~minutes earlier; on any gitea
+            # Pod restart the init container is SUPPOSED to re-seed the admin
+            # password from gitea-admin-secret (GITEA_ADMIN_PASSWORD_MODE=
+            # keepUpdated). If that re-sync races / no-ops / is reverted by a CNPG
+            # restore, the LIVE DB password DRIFTS from the Secret and EVERY
+            # admin-API auth 401s `user's password is invalid [uid:1 name:
+            # gitea_admin]` — the exact fault that wedged the hw236 cutover here.
+            # The bp-gitea admin-secret Helm-lookup pin + bp-reloader annotation
+            # (#4885) SHRINK the drift window but do NOT close it (a roll can
+            # complete with the DB row still stale).
+            #
+            # Self-heal: force the DB row to match the Secret by execing
+            # `gitea admin user change-password` in the live gitea Pod. The CLI
+            # writes the users table directly (no admin session needed) so it
+            # works even while the API is 401ing. Idempotent — re-setting to the
+            # same value is harmless. Best-effort: if the gitea Pod cannot be
+            # resolved we log + fall through to the PATCH, which either succeeds
+            # (no drift) or fails with the same clear 401 as before — no
+            # regression. RBAC already grants pods/exec (rbac.yaml #4652 leg).
+            if [ "${GITEA_ADMIN_PASSWORD_REASSERT:-true}" = "true" ]; then
+              echo "[helmrepository-patches] re-asserting gitea admin password (drift-heal, Refs #3379 #4885)"
+              # Upstream gitea 10.5.0 renders a Deployment (pod gitea-<hash>-<id>),
+              # so resolve by label selector, not a StatefulSet index. Take the
+              # first Running+Ready Pod (same idiom as bp-gitea sso-configure #2818).
+              reassert_pod="$(kubectl get pod -n "${GITEA_NAMESPACE}" \
+                -l "${GITEA_POD_SELECTOR}" \
+                -o jsonpath='{range .items[?(@.status.phase=="Running")]}{.metadata.name}{"\t"}{range .status.conditions[?(@.type=="Ready")]}{.status}{end}{"\n"}{end}' \
+                2>/dev/null \
+                | awk -F '\t' '$2=="True" {print $1; exit}' || true)"
+              if [ -n "${reassert_pod}" ]; then
+                # --must-change-password=false so the admin user is NOT forced
+                # into a change-on-next-login flow (this credential is only ever
+                # used non-interactively). The password is passed as an in-Pod CLI
+                # arg and never echoed to this Job's stdout; stderr is redacted.
+                if kubectl exec -n "${GITEA_NAMESPACE}" "${reassert_pod}" -c "${GITEA_CONTAINER}" -- \
+                     gitea admin user change-password \
+                     --username "${GITEA_USERNAME}" \
+                     --password "${GITEA_PASSWORD}" \
+                     --must-change-password=false >/tmp/.reassert.log 2>&1; then
+                  echo "[helmrepository-patches] gitea admin password re-asserted on pod ${reassert_pod}"
+                elif kubectl exec -n "${GITEA_NAMESPACE}" "${reassert_pod}" -c "${GITEA_CONTAINER}" -- \
+                     gitea admin user change-password \
+                     --username "${GITEA_USERNAME}" \
+                     --password "${GITEA_PASSWORD}" >/tmp/.reassert.log 2>&1; then
+                  # Older gitea builds lack --must-change-password on this subcommand.
+                  echo "[helmrepository-patches] gitea admin password re-asserted on pod ${reassert_pod} (legacy flag set)"
+                else
+                  echo "[helmrepository-patches] WARN: gitea admin password re-assert failed; continuing to PATCH (may still 401 if drifted):" >&2
+                  sed -E 's/(--password[ =])[^ ]+/\1***/g' /tmp/.reassert.log >&2 || true
+                fi
+              else
+                echo "[helmrepository-patches] WARN: no Running gitea Pod matched '${GITEA_POD_SELECTOR}' in ns '${GITEA_NAMESPACE}' — skipping re-assert, continuing" >&2
+              fi
+            fi
 
             # URL with embedded basic auth — credential goes to git via
             # URL only, never echoed to stdout.

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -473,6 +473,32 @@ if ! grep -q 'clusters/_template/bootstrap-kit' "$TMP/render.yaml"; then
 fi
 echo "  PASS (Step-06 pushes YAML edit to local Gitea)"
 
+echo "[cutover-contract] Case 16c: Step-06 re-asserts the Gitea admin password before the demirror PATCH (#4967)"
+# hw236 (#4967 live): step-04 registry-pivot rolls the gitea image ~minutes
+# before step-06. If the init container's keepUpdated re-sync races / no-ops, the
+# LIVE DB password drifts from gitea-admin-secret and the demirror PATCH 401s
+# `user's password is invalid [uid:1 name:gitea_admin]` (all live-K8s HR URL
+# patches succeed; only the Gitea-API auth fails). step-06 now execs
+# `gitea admin user change-password` in the live gitea Pod BEFORE the first
+# authenticated Gitea call to force the DB row to match the Secret (self-heal).
+# Lock the re-assert in AND lock its ordering ahead of the demirror.
+STEP06_S=$(awk '/name: cutover-step-06-helmrepository-patches/,/^---$/' "$TMP/render.yaml")
+if ! printf '%s' "$STEP06_S" | grep -q 'gitea admin user change-password'; then
+  echo "FAIL: Step-06 never execs 'gitea admin user change-password' — a drifted gitea DB password 401s the demirror PATCH (#4967)" >&2
+  exit 1
+fi
+if ! printf '%s' "$STEP06_S" | grep -q 'GITEA_ADMIN_PASSWORD_REASSERT'; then
+  echo "FAIL: Step-06 missing the GITEA_ADMIN_PASSWORD_REASSERT gate env — the re-assert is not wired (#4967)" >&2
+  exit 1
+fi
+reassert_ln=$(printf '%s\n' "$STEP06_S" | grep -n 'gitea admin user change-password' | head -1 | cut -d: -f1)
+demirror_ln=$(printf '%s\n' "$STEP06_S" | grep -n 'demirror_code=' | head -1 | cut -d: -f1)
+if [ -z "$reassert_ln" ] || [ -z "$demirror_ln" ] || [ "$reassert_ln" -ge "$demirror_ln" ]; then
+  echo "FAIL: Step-06 password re-assert (line ${reassert_ln:-?}) does not run BEFORE the demirror PATCH (line ${demirror_ln:-?}) — drift would still 401 the PATCH (#4967)" >&2
+  exit 1
+fi
+echo "  PASS (Step-06 re-asserts the gitea admin password before the demirror PATCH)"
+
 echo "[cutover-contract] Case 16b: Step-06 pivots the per-Org TENANT HelmRepositories (#4885)"
 # hw232 (#4885 10:36 residual): step-06 pivoted ONLY the curated
 # .Values.helmRepositories.names set, which NEVER lists the per-Org / marketplace

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -174,6 +174,41 @@ gitea:
     usernameKey: "username"
     passwordKey: "password"
 
+  # #4967 (Refs #3379 #4885) — self-healing re-assert of the Gitea admin
+  # password before step-06's authenticated Gitea-API calls (the demirror
+  # PATCH + the git clone/push).
+  #
+  # ROOT CAUSE (hw236 live cutover step-06 demirror 401). step-06 authenticates
+  # to Gitea with BasicAuth gitea_admin:<gitea-admin-secret.password>. step-04
+  # registry-pivot rolls the gitea image ~minutes earlier; on a gitea Pod
+  # restart the init container re-seeds the admin password from the Secret via
+  # GITEA_ADMIN_PASSWORD_MODE=keepUpdated. If that re-sync races / no-ops / is
+  # reverted by a CNPG restore, the LIVE DB password DRIFTS from the Secret and
+  # EVERY admin-API auth 401s `user's password is invalid [uid:1 name:
+  # gitea_admin]`. bp-gitea's admin-secret Helm-lookup pin + the #4885
+  # bp-reloader roll SHRINK the drift window but do not CLOSE it.
+  #
+  # FIX. Phase-1.4 of 06-helmrepository-patches-job.yaml execs
+  # `gitea admin user change-password` in the live gitea Pod to force the DB row
+  # to match the Secret BEFORE the first authenticated call. The CLI writes the
+  # users table directly (no admin session needed) so it heals even while the
+  # API is 401ing. Best-effort: if the Pod can't be resolved it logs and falls
+  # through to the PATCH (either succeeds — no drift — or fails the same clear
+  # 401 as before; no regression). The cutover runner already has pods/exec.
+  adminPasswordReassert:
+    # Flip false only where the cutover runner is barred from execing the gitea
+    # Pod (then the demirror relies on keepUpdated + reloader having converged).
+    enabled: true
+    # Host namespace where bp-gitea runs. Post-#4325 de-vcluster gitea lives in
+    # the native host `gitea` namespace.
+    namespace: "gitea"
+    # Label selector for the live gitea Pod. Upstream gitea 10.5.0 renders a
+    # Deployment (pod name gitea-<hash>-<id>), so we select by label, not an
+    # index. Release name is `gitea` on Sovereigns (matches sso-configure #2818).
+    podSelector: "app.kubernetes.io/name=gitea,app.kubernetes.io/instance=gitea"
+    # Container inside the gitea Pod that carries the `gitea` CLI.
+    containerName: "gitea"
+
 # #4557 (Refs #3379 #3642 #3811): durable host bridge of `gitea-admin-secret`
 # into THIS chart's release namespace (`catalyst`).
 #

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.110"
+    version: "0.1.111"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Problem

Root-caused live on **hw236** during the sovereignty cutover (a real Pillar-5 blocker). bp-self-sovereign-cutover **step-06 helmrepository-patches** FAILS at the *demirror PATCH* to the Gitea API with:

```
HTTP 401  user's password is invalid [uid:1 name:gitea_admin]
```

All live-K8s HelmRepository URL patches succeed (ok=0 skip=62 fail=0); only the Gitea-API auth fails. Both `gitea/gitea-admin-secret` and `catalyst/gitea-admin-secret` held the **same** 32-char password, yet BOTH 401'd against the running Gitea — the live DB password had **drifted** from the Secret.

**Timeline:** step-04 registry-pivot rolls the gitea image ~minutes earlier; on that restart the init container's `GITEA_ADMIN_PASSWORD_MODE=keepUpdated` re-sync can race / no-op, leaving the DB row stale while the Secret is stable. bp-gitea's admin-secret Helm-`lookup` pin (option a, already shipped) + the #4885 bp-reloader roll SHRINK the drift window but do **not** CLOSE it. Live-fixed this session with `gitea admin user change-password` (→ HTTP 200), then re-fired.

## Fix (self-healing, option b)

step-06 new **Phase-1.4** resolves the live gitea Pod by label selector and execs `gitea admin user change-password` to force the DB row to match the Secret **BEFORE** the demirror PATCH + git push. The CLI writes the `users` table directly (no admin session needed) so it heals even while the API is 401ing.

- Idempotent (re-set to same value = harmless).
- **Best-effort**: if the gitea Pod can't be resolved it logs and falls through to the PATCH (either succeeds — no drift — or fails the same clear 401 as before; **no regression**).
- Gated on `.Values.gitea.adminPasswordReassert.enabled` (default `true`).
- RBAC already grants `pods/exec` (rbac.yaml #4652 leg) — **no step-count / job-mode / RBAC change** (still 11 steps).

## Changes

- `06-helmrepository-patches-job.yaml` — 4 env vars + Phase-1.4 re-assert block before the demirror.
- `values.yaml` — new `gitea.adminPasswordReassert.{enabled,namespace,podSelector,containerName}`.
- Chart `0.1.110 -> 0.1.111`; bootstrap-kit slot 06a pin + `blueprint.yaml` + catalog-seed lockstep bumped.
- `cutover-contract.sh` new **Case 16c** locks the re-assert in and locks its ordering ahead of the demirror.

## Gates

- `helm template` — OK (6718 lines)
- `check-bootstrap-kit-pin-sync.sh --changed-only` — PASS (chart=0.1.111 pin=0.1.111)
- `check-catalog-seed-lockstep.sh` — PASS (69 checked, 0 fail)
- `cutover-contract.sh` — All gates green (incl. new Case 16c)

Validates on the next cutover.

Refs #3379 #4885 #4967

🤖 Generated with [Claude Code](https://claude.com/claude-code)