### PR TITLE
fix(#4969): cutover-contract Case 16c SIGPIPE false-FAIL; republish cutover 0.1.112

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -758,7 +758,12 @@ spec:
       # before the demirror PATCH + git push, so a step-04 gitea-image roll that
       # left the DB password drifted from gitea-admin-secret no longer 401s the
       # demirror (hw236 wedge). Self-healing, best-effort; no step-count / RBAC change.
-      version: 0.1.111
+      # 0.1.112 (#4969 Refs #4967 #3379): REPUBLISH of the identical 0.1.111 payload —
+      # 0.1.111 never published to GHCR (its release FAILED on a TEST-HARNESS SIGPIPE
+      # in tests/cutover-contract.sh Case 16c, not a chart defect), so this pin would
+      # have wedged slot-06a at HelmChart artifact-not-found. Case 16c now asserts the
+      # self-heal against a file (no printf|grep SIGPIPE). No chart behavior change.
+      version: 0.1.112
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.111
+  version: 0.1.112
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,18 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.112 (#4969 Refs #4967 #3379): REPUBLISH of the 0.1.111 payload — no chart
+# behavior change. 0.1.111's release FAILED at "Run chart integration tests" so
+# it never published to GHCR while slot-06a already pinned it → a fresh prov
+# would wedge at slot-06a (HelmChart artifact-not-found). Root cause was a
+# TEST-HARNESS SIGPIPE, not a chart defect: tests/cutover-contract.sh Case 16c
+# asserted the #4967 self-heal via `printf "$STEP06" | grep -q` under
+# `set -o pipefail` — grep -q closed the pipe on first match, printf took EPIPE
+# ("printf: write error: Broken pipe"), the pipeline exited non-zero, and the
+# `if !` fired a spurious FAIL. Case 16c now reads Step-06 into a file and
+# asserts against the file (file-fed grep + `awk '…{print NR;exit}'`, no
+# printf|grep / head pipe to SIGPIPE). This version bump republishes the intact
+# gitea self-heal with a self-consistent slot-06a pin. No step-count / job-mode
+# / RBAC change (still 11 steps).
 # 0.1.111 (#4967 Refs #4885 #3379): step-06 now RE-ASSERTS the Gitea admin
 # password before the demirror PATCH + git push. Root cause (hw236 live): the
 # demirror authenticates gitea_admin:<gitea-admin-secret.password>, but step-04
@@ -1648,7 +1661,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.111
+version: 0.1.112
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -482,17 +482,28 @@ echo "[cutover-contract] Case 16c: Step-06 re-asserts the Gitea admin password b
 # `gitea admin user change-password` in the live gitea Pod BEFORE the first
 # authenticated Gitea call to force the DB row to match the Secret (self-heal).
 # Lock the re-assert in AND lock its ordering ahead of the demirror.
-STEP06_S=$(awk '/name: cutover-step-06-helmrepository-patches/,/^---$/' "$TMP/render.yaml")
-if ! printf '%s' "$STEP06_S" | grep -q 'gitea admin user change-password'; then
+#
+# NOTE (#4969): read the Step-06 ConfigMap into a FILE and assert against the
+# file — never `printf "$STEP06" | grep -q` / `grep -n | head`. Under
+# `set -o pipefail`, `grep -q` (and `head -1`) closes the pipe on its first
+# match, the upstream `printf`/`grep` takes EPIPE ("printf: write error:
+# Broken pipe"), and the whole pipeline exits non-zero → the `if !` fires a
+# spurious FAIL even though the re-assert renders correctly (this is exactly
+# what false-FAILed the 0.1.111 release "Run chart integration tests" step).
+# File-fed `grep` has no upstream writer to SIGPIPE, and `awk '…{print NR;exit}'`
+# yields the first matching line number with no downstream reader to close early.
+STEP06_F="$TMP/step06.yaml"
+awk '/name: cutover-step-06-helmrepository-patches/,/^---$/' "$TMP/render.yaml" > "$STEP06_F"
+if ! grep -q 'gitea admin user change-password' "$STEP06_F"; then
   echo "FAIL: Step-06 never execs 'gitea admin user change-password' — a drifted gitea DB password 401s the demirror PATCH (#4967)" >&2
   exit 1
 fi
-if ! printf '%s' "$STEP06_S" | grep -q 'GITEA_ADMIN_PASSWORD_REASSERT'; then
+if ! grep -q 'GITEA_ADMIN_PASSWORD_REASSERT' "$STEP06_F"; then
   echo "FAIL: Step-06 missing the GITEA_ADMIN_PASSWORD_REASSERT gate env — the re-assert is not wired (#4967)" >&2
   exit 1
 fi
-reassert_ln=$(printf '%s\n' "$STEP06_S" | grep -n 'gitea admin user change-password' | head -1 | cut -d: -f1)
-demirror_ln=$(printf '%s\n' "$STEP06_S" | grep -n 'demirror_code=' | head -1 | cut -d: -f1)
+reassert_ln=$(awk 'index($0,"gitea admin user change-password"){print NR; exit}' "$STEP06_F")
+demirror_ln=$(awk 'index($0,"demirror_code="){print NR; exit}' "$STEP06_F")
 if [ -z "$reassert_ln" ] || [ -z "$demirror_ln" ] || [ "$reassert_ln" -ge "$demirror_ln" ]; then
   echo "FAIL: Step-06 password re-assert (line ${reassert_ln:-?}) does not run BEFORE the demirror PATCH (line ${demirror_ln:-?}) — drift would still 401 the PATCH (#4967)" >&2
   exit 1

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.111"
+    version: "0.1.112"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Why

The `bp-self-sovereign-cutover` **0.1.111** release (from merged PR #4968, the #4967 gitea-admin-password self-heal) FAILED at **"Run chart integration tests"**, so **0.1.111 never published to GHCR** — yet bootstrap-kit **slot-06a already pins 0.1.111**. A fresh prov would wedge at slot-06a with a HelmChart *artifact-not-found*, blocking the clean-prov train.

## Root cause — TEST-HARNESS SIGPIPE, not a chart defect

`platform/self-sovereign-cutover/chart/tests/cutover-contract.sh` **Case 16c** asserted the #4967 self-heal with `printf '%s' "$STEP06_S" | grep -q ...` (and `grep -n | head`) under `set -o pipefail`:

```
line 486: printf: write error: Broken pipe
FAIL: Step-06 never execs 'gitea admin user change-password' ... (#4967)
```

`grep -q` closes the pipe on its first match → the upstream `printf` takes EPIPE (`printf: write error: Broken pipe`) → the pipeline exits non-zero → the `if !` fires a **spurious FAIL**. The actual self-heal is intact: `helm template` shows `gitea admin user change-password` (Phase-1.4, gated on `GITEA_ADMIN_PASSWORD_REASSERT`) rendering BEFORE the demirror PATCH.

## Change

**Before** (Case 16c):
```bash
STEP06_S=$(awk '/name: cutover-step-06-helmrepository-patches/,/^---$/' "$TMP/render.yaml")
if ! printf '%s' "$STEP06_S" | grep -q 'gitea admin user change-password'; then ...
reassert_ln=$(printf '%s\n' "$STEP06_S" | grep -n '...' | head -1 | cut -d: -f1)
```

**After** — render Step-06 into a file, assert against the file (no pipe to SIGPIPE):
```bash
STEP06_F="$TMP/step06.yaml"
awk '/name: cutover-step-06-helmrepository-patches/,/^---$/' "$TMP/render.yaml" > "$STEP06_F"
if ! grep -q 'gitea admin user change-password' "$STEP06_F"; then ...
reassert_ln=$(awk 'index($0,"gitea admin user change-password"){print NR; exit}' "$STEP06_F")
```

The gate still asserts: the `change-password` re-assert is present, the `GITEA_ADMIN_PASSWORD_REASSERT` gate env is wired, and the re-assert is ordered **before** the demirror PATCH.

**Version bump 0.1.111 → 0.1.112**, lockstepped so the intact self-heal republishes with a self-consistent pin:
- `platform/self-sovereign-cutover/chart/Chart.yaml`
- `platform/self-sovereign-cutover/blueprint.yaml`
- `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` (`source.version`)
- `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml` (slot-06a pin)

## Local verification

- `bash tests/cutover-contract.sh <chart>` → **all 37 gates green**, Case 16c PASS.
- **20/20** stress-loop PASS (no flaky SIGPIPE).
- `helm template` renders; `change-password` (self-heal) ordered before demirror.
- `check-bootstrap-kit-pin-sync.sh` → PASS (`chart=0.1.112 pin=0.1.112`).
- `check-catalog-seed-lockstep.sh` → PASS (69 checked, 0 fail).

This unblocks the clean-prov fire: 0.1.112 publishes with the gitea self-heal and a self-consistent slot-06a pin.

Refs #4967 #3379

🤖 Generated with [Claude Code](https://claude.com/claude-code)