### PR TITLE
fix(#4971): keep catalyst-api off driverless control-plane during Recreate roll

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1245,7 +1245,7 @@ spec:
       # 1.4.1072 — #4952: catalog-seed bp-openclaw pin 0.2.16 -> 0.2.17 so the
       #   per-Org-namespace fix (tenant.namespace default "" -> falls back to
       #   .Release.Namespace) reaches fresh funnel Orgs. Lockstep w/ Chart.yaml.
-      version: 1.4.1082
+      version: 1.4.1083
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform
@@ -1572,6 +1572,18 @@ spec:
     # browser-trusted Sovereign reaches cutoverComplete with ZERO manual steps.
     catalystApi:
       fireCutoverOnHandover: ${FIRE_CUTOVER_ON_HANDOVER:-false}
+      # #4971 — keep catalyst-api OFF the driverless control-plane node on every
+      # fresh Sovereign. catalyst-api mounts two RWO Huawei-EVS PVCs whose CSI
+      # node-plugin (evs.csi.huaweicloud.com) runs ONLY on workers; with
+      # strategy: Recreate a roll (e.g. cutover step-07's catalyst-api-env-patch)
+      # could otherwise place the replacement Pod on the control-plane node,
+      # where the EVS volumes can never attach ("CSINode <cp1> does not contain
+      # driver evs.csi.huaweicloud.com") → ContainerCreating deadlock → step-07
+      # times out → cutover wedges (live on hw237, 2026-07-10). Setting this true
+      # makes the chart emit a hard worker-only nodeAffinity. Sovereign-only:
+      # values.yaml defaults it false so mothership / catalyst-zero on contabo is
+      # unaffected.
+      avoidControlPlane: true
       # #4784 — the etcd port catalyst-api dials for a peer's
       # clustermesh-apiserver (CLUSTERMESH_APISERVER_DIAL_PORT env →
       # clustermesh.go clusterMeshDialPort). Default 2379 (Hetzner hcloud-ccm

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,19 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.1083 — #4971 (Pillar-5 cutover): keep catalyst-api OFF the driverless
+#   control-plane node during a Recreate roll. catalyst-api mounts two RWO
+#   Huawei-EVS PVCs (catalyst-api-deployments, catalyst-api-cache) whose CSI
+#   node-plugin (evs.csi.huaweicloud.com) runs ONLY on workers. On hw237
+#   (2026-07-10) sovereignty-cutover step-07 (catalyst-api-env-patch) rolled the
+#   Pod onto the control-plane node (cp1), where AttachVolume.Attach failed x30
+#   over 45m ("CSINode cp1 does not contain driver evs.csi.huaweicloud.com") →
+#   ContainerCreating deadlock → step-07 rollout wait timed out → cutover wedged.
+#   New gated knob catalystApi.avoidControlPlane (values.yaml default FALSE —
+#   mothership / catalyst-zero on contabo unaffected); when true, api-deployment
+#   .yaml emits a hard worker-only nodeAffinity (node-role.kubernetes.io/
+#   control-plane DoesNotExist). An explicit catalystApi.affinity still wins. The
+#   Sovereign bootstrap-kit slot 13 sets avoidControlPlane: true so every fresh
+#   Sovereign is zero-touch-correct. Lockstep w/ Chart.yaml.
 # 1.4.1058 — #4919 (Refs #4749): the REAL hw233 funnel row-84 fix (Pillar-1) —
 #   deterministically roll org-services/{auth,notification} onto the SMTP relay when
 #   the seed lands. Those Pods read SMTP_* from org-services-secrets via secretKeyRef,
@@ -3459,7 +3473,7 @@ name: bp-catalyst-platform
 #   footprint to fit the 4-CPU `plan-quota` (the 0.4.21 oidc-config post-install
 #   hook requested a 500m CPU limit into a namespace with only 250m of quota
 #   headroom → the hook pod was NEVER created → HR timeout → no HTTPRoute → 404).
-version: 1.4.1082
+version: 1.4.1083
 # 1.4.1063 — #4841: grant the useraccess-controller ClusterRole `bind` on the 8
 #   canonical Sovereign-IAM ClusterRoles (openova:tier-{viewer,developer,operator,
 #   admin,owner} + openova:application-{admin,editor,viewer}). The controller

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -179,9 +179,32 @@ spec:
       {{- with .Values.catalystApi.nodeName }}
       nodeName: {{ . | quote }}
       {{- end }}
-      {{- with .Values.catalystApi.affinity }}
+      {{- if .Values.catalystApi.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .Values.catalystApi.affinity | nindent 8 }}
+      {{- else if .Values.catalystApi.avoidControlPlane }}
+      # ── Keep catalyst-api OFF the driverless control-plane node (#4971) ────
+      # The two RWO Huawei-EVS PVCs mounted above are served by the
+      # evs.csi.huaweicloud.com CSI node-plugin, whose DaemonSet runs ONLY on
+      # workers — the control-plane node has NO CSINode entry for that driver.
+      # With strategy: Recreate, a roll (e.g. cutover step-07's
+      # catalyst-api-env-patch) could otherwise land the replacement Pod on the
+      # control-plane node, where AttachVolume.Attach fails forever ("CSINode
+      # <cp1> does not contain driver evs.csi.huaweicloud.com") → the Pod hangs
+      # ContainerCreating, step-07's rollout wait times out, and the cutover
+      # wedges (live on hw237, 2026-07-10). This hard worker-only nodeAffinity
+      # forces every roll onto a worker that runs the EVS node plugin. Gated by
+      # catalystApi.avoidControlPlane (default false in values.yaml so
+      # mothership / catalyst-zero on contabo is unaffected; the Sovereign
+      # bootstrap-kit turns it on). An explicit catalystApi.affinity wins over
+      # this default — that is the `if` branch above; this is the `else`.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
       {{- end }}
       imagePullSecrets:
         - name: ghcr-pull

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -1284,6 +1284,25 @@ catalystApi:
   # affinity — optional passthrough for operators who prefer a soft/zone
   # nodeAffinity over a hard nodeName pin above. Default empty (no affinity).
   affinity: {}
+  # ── Keep catalyst-api OFF the driverless control-plane node (#4971) ──────
+  # catalyst-api mounts two RWO Huawei-EVS PVCs (catalyst-api-deployments,
+  # catalyst-api-cache) whose CSI node-plugin DaemonSet (evs.csi.huaweicloud.com)
+  # runs ONLY on workers — the control-plane node carries no CSINode entry for
+  # that driver. With strategy: Recreate a roll (e.g. cutover step-07's
+  # catalyst-api-env-patch) can place the replacement Pod on the control-plane
+  # node, where AttachVolume.Attach fails forever ("CSINode <cp1> does not
+  # contain driver evs.csi.huaweicloud.com") → the Pod hangs ContainerCreating,
+  # the step-07 rollout wait times out, and the cutover wedges (live on hw237,
+  # 2026-07-10). When true, the chart emits a hard worker-only nodeAffinity
+  # (node-role.kubernetes.io/control-plane DoesNotExist) so every roll lands on
+  # a worker that runs the EVS node plugin.
+  #
+  # Default false preserves mothership / catalyst-zero (contabo) behaviour,
+  # where there is no such driverless control-plane concern; the Sovereign
+  # bootstrap-kit (clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml)
+  # turns it on so every fresh Sovereign is zero-touch-correct. An explicit
+  # catalystApi.affinity above still wins over this default.
+  avoidControlPlane: false
   # ── Survive a co-tenant disk/memory-pressure storm (#4231) ──────────────
   # catalyst-api is pinned to its EVS node (nodeName above, #4102) so it CANNOT
   # reschedule off a pressured node. With the default priority (0) it competed


### PR DESCRIPTION
## Problem (live: hw237, 2-region Huawei/kom4dc Sovereign, sovereignty-cutover step-07)

Cutover step-07 (`catalyst-api-env-patch`) patches the `catalyst-api` Deployment env and waits for its rollout. `catalyst-api` uses `strategy: Recreate` and mounts two RWO Huawei-EVS PVCs (`catalyst-api-deployments`, `catalyst-api-cache`). With no scheduling constraint, the Recreate rollout placed the replacement pod on the **control-plane node (cp1)**, which does NOT run the `evs.csi.huaweicloud.com` CSI node-plugin DaemonSet (it runs only on workers).

Result — pod `catalyst-api-ddf4fb848-nwpdb` stuck `ContainerCreating`, `FailedAttachVolume` x30 over 45m:

```
AttachVolume.Attach failed for volume ... : CSINode cp1 does not contain driver evs.csi.huaweicloud.com
```

step-07's rollout wait times out and the cutover wedges. Manual unblock was `cordon cp1` + `delete pod` → rescheduled onto a worker → `1/1 Running`.

## Fix (targeted, zero-touch on Sovereigns, mothership unaffected)

Add a gated default worker-only nodeAffinity:

- **`products/catalyst/chart/values.yaml`** — new `catalystApi.avoidControlPlane: false`. Default off preserves mothership / catalyst-zero (contabo) behaviour.
- **`products/catalyst/chart/templates/api-deployment.yaml`** — when `catalystApi.affinity` is set it still wins (unchanged); ELSE when `catalystApi.avoidControlPlane: true`, emit a hard `nodeAffinity` requiring `node-role.kubernetes.io/control-plane` `DoesNotExist`. The `nodeName` pin block is intact and stays ahead of it. The Kustomize variant (`api-deployment-kustomize.yaml`) is **not** touched — contabo/mothership stays default-off.
- **`clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`** — `catalystApi.avoidControlPlane: true` so every fresh Sovereign is zero-touch-correct.
- **`products/catalyst/chart/Chart.yaml`** — `1.4.1082` → `1.4.1083`; slot-13 pin bumped in lockstep.

## Verification

`helm template` renders the affinity **only** when `avoidControlPlane=true`:

| render | rendered `affinity:` key | `operator: DoesNotExist` |
|---|---|---|
| default values.yaml (mothership) | absent | 0 |
| `--set catalystApi.avoidControlPlane=false` | absent | 0 |
| `--set catalystApi.avoidControlPlane=true` (Sovereign bootstrap-kit) | present, worker-only nodeAffinity | 1 |
| `avoidControlPlane=true` + explicit `catalystApi.affinity` | explicit affinity wins (podAntiAffinity), control-plane term | 0 |

- `helm template products/catalyst/chart` — renders clean.
- `scripts/check-bootstrap-kit-pin-sync.sh --changed-only --base <main>` — PASS (chart=pin=1.4.1083).
- `scripts/check-catalog-seed-lockstep.sh` — PASS (checked 69, fail 0; catalog-seed untouched).

Refs #4971 #3379