### PR TITLE
fix(#4973): pivot Huawei EVS CSI sidecar images through local Harbor at cutover

### DIFF
--- a/clusters/_template/bootstrap-kit/55b-bp-huawei-evs-csi.yaml
+++ b/clusters/_template/bootstrap-kit/55b-bp-huawei-evs-csi.yaml
@@ -186,7 +186,18 @@ spec:
       # the same `managed-by: flux` label so the kyverno policy admits BOTH the
       # pre- and post- hooks — without it the 1.0.6 upgrade rolled back on the
       # post-upgrade phase and the HR stayed Stalled.
-      version: 1.0.8
+      # 1.0.8 (#4885): the openova-io EVS driver image honours global.imageRegistry
+      # so the step-07 cutover image pivot reaches the controller + node driver
+      # Pods (the imageRegistry:'' seam below is what step-07 patches).
+      # 1.0.9 (#4973 Refs #3379): the six sig-storage CSI sidecar images ALSO
+      # honour global.imageRegistry. 1.0.8 pivoted only the driver; the sidecars
+      # stayed on harbor.openova.io/proxy-k8s/*, the MOTHERSHIP Harbor — a residual
+      # tether the step-08 deny-egress hold blocks, so a controller/node roll under
+      # the hold could not pull them and the EVS attach/provision path broke on any
+      # pod restart (live hw237 step-08). Now all images host-swap through the same
+      # seam. This HR is already in the step-07 imageRegistryPivot.additionalHRs
+      # set, so no cutover-side change is needed.
+      version: 1.0.9
       sourceRef:
         kind: HelmRepository
         name: bp-huawei-evs-csi

--- a/platform/huawei-evs-csi/blueprint.yaml
+++ b/platform/huawei-evs-csi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     catalyst.openova.io/provider: huawei
 spec:
-  version: 1.0.8
+  version: 1.0.9
   card:
     title: Huawei EVS CSI
     summary: |

--- a/platform/huawei-evs-csi/chart/Chart.yaml
+++ b/platform/huawei-evs-csi/chart/Chart.yaml
@@ -96,7 +96,23 @@ name: bp-huawei-evs-csi
 # otherwise). New global.imageRegistry:"" seam. The six CSI sidecar images are
 # public harbor.openova.io proxy-k8s mirrors (3rd-party) and are NOT rewritten.
 # Lockstep: 55b-bp-huawei-evs-csi.yaml pin + blueprint.yaml → 1.0.8. Refs #4885.
-version: 1.0.8
+# 1.0.9 (#4973 Refs #3379): ALSO honour global.imageRegistry for the six
+# sig-storage CSI sidecar images. 1.0.8 pivoted only the openova-io driver; the
+# sidecars stayed on harbor.openova.io/proxy-k8s/*, the MOTHERSHIP Harbor. The
+# self-sovereign-cutover step-08 deny-egress hold blocks harbor.openova.io, so a
+# controller/node roll under the hold could not pull the sidecars → the EVS
+# attach/provision path broke on any pod restart (residual mothership tether,
+# found live on hw237 step-08). New templates/_helpers.tpl sidecarImage helper
+# host-swaps the leading registry host for global.imageRegistry (same logic as
+# driverImage), preserving the proxy-k8s/sig-storage/<name> path + tag verbatim
+# (→ registry.<sovereign-fqdn>/proxy-k8s/sig-storage/*, the LOCAL Harbor's own
+# proxy-k8s cache). Empty default = byte-identical pre-cutover render. Applied to
+# all sidecar refs in controller-deployment.yaml + node-daemonset.yaml.
+# bp-huawei-evs-csi is ALREADY in the cutover imageRegistryPivot.additionalHRs
+# set (#4885/#4892), so the HR's global.imageRegistry is already patched at
+# cutover — this chart-templating change alone completes the fix. Lockstep:
+# 55b-bp-huawei-evs-csi.yaml pin + blueprint.yaml → 1.0.9. Refs #4973 #3379.
+version: 1.0.9
 description: |
   Catalyst-curated Blueprint for the open-source huaweicloud-csi-driver EVS
   block-storage plugin (evs.csi.huaweicloud.com). Provides the durable

--- a/platform/huawei-evs-csi/chart/templates/_helpers.tpl
+++ b/platform/huawei-evs-csi/chart/templates/_helpers.tpl
@@ -25,3 +25,38 @@ Usage: {{ include "bp-huawei-evs-csi.driverImage" . }}
 {{- printf "%s:%s" $repo $tag -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+CSI sidecar image ref with global.imageRegistry rewrite (#4973 Refs #3379).
+
+The six sig-storage CSI sidecars (provisioner / attacher / resizer / snapshotter /
+node-driver-registrar / livenessprobe) ship from harbor.openova.io/proxy-k8s/* —
+the MOTHERSHIP Harbor's proxy-k8s cache. Post-cutover a Sovereign must pull
+EXCLUSIVELY from its OWN local Harbor: the self-sovereign-cutover step-08
+deny-egress hold blocks harbor.openova.io, so a controller/node roll that still
+names harbor.openova.io cannot pull the sidecars → the EVS attach/provision path
+breaks on any pod restart (#4973, found live on hw237 step-08). This mirrors the
+exact host-swap .driverImage already performs for the openova-io driver image.
+
+When .Values.global.imageRegistry is set (the step-07 image pivot patches this
+HR — bp-huawei-evs-csi is already in imageRegistryPivot.additionalHRs), the
+leading registry host of each sidecar repository is swapped for the override,
+preserving the proxy-k8s/sig-storage/<name> path + tag verbatim
+(harbor.openova.io/proxy-k8s/sig-storage/csi-provisioner →
+registry.<sovereign-fqdn>/proxy-k8s/sig-storage/csi-provisioner — the local
+Harbor's OWN proxy-k8s cache). When empty the ref is emitted byte-identical to
+today, so a fresh pre-cutover install renders exactly as before.
+
+Usage:
+  {{ include "bp-huawei-evs-csi.sidecarImage" (dict "repository" $img.sidecars.provisioner.repository "tag" $img.sidecars.provisioner.tag "global" .Values.global) }}
+*/}}
+{{- define "bp-huawei-evs-csi.sidecarImage" -}}
+{{- $repo := .repository -}}
+{{- $tag := .tag -}}
+{{- $globalRegistry := (.global).imageRegistry | default "" -}}
+{{- if ne $globalRegistry "" -}}
+{{- printf "%s/%s:%s" $globalRegistry (join "/" (slice (splitList "/" $repo) 1)) $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end -}}

--- a/platform/huawei-evs-csi/chart/templates/controller-deployment.yaml
+++ b/platform/huawei-evs-csi/chart/templates/controller-deployment.yaml
@@ -67,7 +67,9 @@ spec:
                 topologyKey: kubernetes.io/hostname
       containers:
         - name: csi-provisioner
-          image: "{{ $img.sidecars.provisioner.repository }}:{{ $img.sidecars.provisioner.tag }}"
+          # #4973: honour global.imageRegistry so step-07 cutover pivot reaches
+          # the sidecar too (post-cutover deny-egress blocks harbor.openova.io).
+          image: "{{ include "bp-huawei-evs-csi.sidecarImage" (dict "repository" $img.sidecars.provisioner.repository "tag" $img.sidecars.provisioner.tag "global" .Values.global) }}"
           imagePullPolicy: {{ $img.driver.pullPolicy | default "IfNotPresent" }}
           args:
             - "--csi-address=$(ADDRESS)"
@@ -93,7 +95,8 @@ spec:
             capabilities: { drop: [ALL] }
             seccompProfile: { type: RuntimeDefault }
         - name: csi-attacher
-          image: "{{ $img.sidecars.attacher.repository }}:{{ $img.sidecars.attacher.tag }}"
+          # #4973: honour global.imageRegistry (see csi-provisioner above).
+          image: "{{ include "bp-huawei-evs-csi.sidecarImage" (dict "repository" $img.sidecars.attacher.repository "tag" $img.sidecars.attacher.tag "global" .Values.global) }}"
           imagePullPolicy: {{ $img.driver.pullPolicy | default "IfNotPresent" }}
           args:
             - "--csi-address=$(ADDRESS)"
@@ -116,7 +119,8 @@ spec:
             capabilities: { drop: [ALL] }
             seccompProfile: { type: RuntimeDefault }
         - name: csi-resizer
-          image: "{{ $img.sidecars.resizer.repository }}:{{ $img.sidecars.resizer.tag }}"
+          # #4973: honour global.imageRegistry (see csi-provisioner above).
+          image: "{{ include "bp-huawei-evs-csi.sidecarImage" (dict "repository" $img.sidecars.resizer.repository "tag" $img.sidecars.resizer.tag "global" .Values.global) }}"
           imagePullPolicy: {{ $img.driver.pullPolicy | default "IfNotPresent" }}
           args:
             - "--csi-address=$(ADDRESS)"
@@ -141,7 +145,8 @@ spec:
             seccompProfile: { type: RuntimeDefault }
 {{- if .Values.volumeSnapshotClass.enabled }}
         - name: csi-snapshotter
-          image: "{{ $img.sidecars.snapshotter.repository }}:{{ $img.sidecars.snapshotter.tag }}"
+          # #4973: honour global.imageRegistry (see csi-provisioner above).
+          image: "{{ include "bp-huawei-evs-csi.sidecarImage" (dict "repository" $img.sidecars.snapshotter.repository "tag" $img.sidecars.snapshotter.tag "global" .Values.global) }}"
           imagePullPolicy: {{ $img.driver.pullPolicy | default "IfNotPresent" }}
           args:
             - "--csi-address=$(ADDRESS)"
@@ -166,7 +171,8 @@ spec:
             seccompProfile: { type: RuntimeDefault }
 {{- end }}
         - name: liveness-probe
-          image: "{{ $img.sidecars.livenessProbe.repository }}:{{ $img.sidecars.livenessProbe.tag }}"
+          # #4973: honour global.imageRegistry (see csi-provisioner above).
+          image: "{{ include "bp-huawei-evs-csi.sidecarImage" (dict "repository" $img.sidecars.livenessProbe.repository "tag" $img.sidecars.livenessProbe.tag "global" .Values.global) }}"
           imagePullPolicy: {{ $img.driver.pullPolicy | default "IfNotPresent" }}
           args:
             - "--csi-address=$(ADDRESS)"

--- a/platform/huawei-evs-csi/chart/templates/node-daemonset.yaml
+++ b/platform/huawei-evs-csi/chart/templates/node-daemonset.yaml
@@ -58,7 +58,9 @@ spec:
         - operator: Exists
       containers:
         - name: evs-driver-registrar
-          image: "{{ $img.sidecars.nodeDriverRegistrar.repository }}:{{ $img.sidecars.nodeDriverRegistrar.tag }}"
+          # #4973: honour global.imageRegistry so step-07 cutover pivot reaches
+          # the sidecar too (post-cutover deny-egress blocks harbor.openova.io).
+          image: "{{ include "bp-huawei-evs-csi.sidecarImage" (dict "repository" $img.sidecars.nodeDriverRegistrar.repository "tag" $img.sidecars.nodeDriverRegistrar.tag "global" .Values.global) }}"
           imagePullPolicy: {{ $img.driver.pullPolicy | default "IfNotPresent" }}
           args:
             - "--v=2"
@@ -83,7 +85,8 @@ spec:
             capabilities: { drop: [ALL] }
             seccompProfile: { type: RuntimeDefault }
         - name: liveness-probe
-          image: "{{ $img.sidecars.livenessProbe.repository }}:{{ $img.sidecars.livenessProbe.tag }}"
+          # #4973: honour global.imageRegistry (see evs-driver-registrar above).
+          image: "{{ include "bp-huawei-evs-csi.sidecarImage" (dict "repository" $img.sidecars.livenessProbe.repository "tag" $img.sidecars.livenessProbe.tag "global" .Values.global) }}"
           imagePullPolicy: {{ $img.driver.pullPolicy | default "IfNotPresent" }}
           args:
             - "--csi-address=/csi/csi.sock"

--- a/platform/huawei-evs-csi/chart/values.yaml
+++ b/platform/huawei-evs-csi/chart/values.yaml
@@ -148,15 +148,23 @@ imagePullSecrets:
   - name: ghcr-pull
 
 # ─── Global registry rewrite (matches catalyst / continuum chart pattern) ──
-# When set, the openova-io DRIVER image (image.driver, below) routes through
-# this registry instead of ghcr.io. Per-Sovereign overlays leave this empty;
-# the self-sovereign-cutover step-07 image pivot (#4885) sets it to
-# registry.<sovereign-fqdn> so the driver pulls from the Sovereign's own Harbor
-# post-cutover (the step-08 deny-egress hold blocks ghcr.io). Empty = no rewrite.
-# The six sidecar images (image.sidecars.*) are PUBLIC harbor.openova.io proxy-k8s
-# mirrors — 3rd-party, NOT openova-io — so they carry their own registry and are
-# deliberately NOT rewritten by this seam. The driverImage helper in
-# templates/_helpers.tpl performs the host-swap.
+# When set, EVERY image in this chart (image.driver + all image.sidecars.*)
+# routes through this registry instead of its default host. Per-Sovereign
+# overlays leave this empty; the self-sovereign-cutover step-07 image pivot
+# (#4885/#4973) sets it to registry.<sovereign-fqdn> so BOTH the openova-io
+# driver AND the sig-storage CSI sidecars pull from the Sovereign's OWN Harbor
+# post-cutover. Empty = no rewrite (byte-identical pre-cutover render).
+#
+# #4973: the six sidecar images (image.sidecars.*) default to
+# harbor.openova.io/proxy-k8s/sig-storage/* — the MOTHERSHIP Harbor's proxy-k8s
+# cache. The step-08 deny-egress hold blocks harbor.openova.io, so leaving the
+# sidecars on that host is a residual mothership tether: a controller/node roll
+# under the hold could not pull them → the EVS attach/provision path broke on any
+# pod restart (found live on hw237 step-08). They are now host-swapped by the
+# SAME seam as the driver, preserving the proxy-k8s/sig-storage/<name> path + tag
+# (→ registry.<sovereign-fqdn>/proxy-k8s/sig-storage/*, the LOCAL Harbor's own
+# proxy-k8s cache). The driverImage + sidecarImage helpers in
+# templates/_helpers.tpl perform the host-swap.
 global:
   imageRegistry: ""
 


### PR DESCRIPTION
Refs #4973 #3379

## Defect (found live on hw237 cutover step-08 deny-egress proof)

`deployment/csi-evs-controller` (ns `huawei-evs-csi`) has 5 containers. #4885
pivoted the main `evs-csi-plugin` driver image through `global.imageRegistry`,
but the four CSI **sidecar** images stayed hardcoded to the MOTHERSHIP Harbor
(`harbor.openova.io/proxy-k8s/sig-storage/{csi-provisioner,csi-attacher,csi-resizer,livenessprobe}`).
The node DaemonSet's two sidecars (`csi-node-driver-registrar`, `livenessprobe`)
were the same tether. Post-cutover a Sovereign must pull EXCLUSIVELY from its own
local Harbor; under the step-08 deny-egress hold (blocks `harbor.openova.io`) a
controller/node roll cannot pull them, so the EVS attach/provision path breaks on
any pod restart.

## Fix (chart templating only)

- New `templates/_helpers.tpl` `sidecarImage` helper host-swaps the leading
  registry host for `.Values.global.imageRegistry` — the **same** host-swap logic
  the existing `driverImage` helper (#4885) already uses. Registry prefix
  templated; `proxy-k8s/sig-storage/<name>` path + tag preserved verbatim.
- Applied to every sidecar `image:` ref in `controller-deployment.yaml`
  (provisioner / attacher / resizer / snapshotter / livenessprobe) and
  `node-daemonset.yaml` (node-driver-registrar / livenessprobe).
- Empty default renders **byte-identical** to today, so a fresh pre-cutover
  install does not regress.

**Cutover HR-pivot set already includes this HR.** `bp-huawei-evs-csi` is already
in the step-07 `imageRegistryPivot.additionalHRs` set (#4885/#4892), so the HR's
`global.imageRegistry` is patched to `registry.<sovereign-fqdn>` at cutover. Only
the chart templating was the gap — this change alone completes the fix; no
cutover-side change was needed.

## Verification

`helm template` (with `enabled=true`, snapshotter on):

- **Default** (no override) — image refs byte-identical to today:
  - driver `ghcr.io/openova-io/openova/evs-csi-plugin:v0.1.11-idc.1`
  - sidecars `harbor.openova.io/proxy-k8s/sig-storage/*` (unchanged)
  - `diff` vs the unmodified chart: image refs IDENTICAL (only the intended
    `blueprint-version` label bump + `# #4973` comment lines differ)
- **Override** `--set global.imageRegistry=registry.example.works` — all 7 images
  pivot:
  - `registry.example.works/openova-io/openova/evs-csi-plugin:v0.1.11-idc.1`
  - `registry.example.works/proxy-k8s/sig-storage/{csi-provisioner,csi-attacher,csi-resizer,csi-snapshotter,csi-node-driver-registrar,livenessprobe}:<tag>`

`helm lint` passes. Lockstep bump chart 1.0.8 -> 1.0.9 (Chart.yaml + blueprint.yaml
+ slot 55b pin); `check-bootstrap-kit-pin-sync.sh` and
`check-catalog-seed-lockstep.sh` both PASS.

## Files changed

- `platform/huawei-evs-csi/chart/templates/_helpers.tpl` (new `sidecarImage` helper)
- `platform/huawei-evs-csi/chart/templates/controller-deployment.yaml`
- `platform/huawei-evs-csi/chart/templates/node-daemonset.yaml`
- `platform/huawei-evs-csi/chart/values.yaml` (comment update)
- `platform/huawei-evs-csi/chart/Chart.yaml` (1.0.9)
- `platform/huawei-evs-csi/blueprint.yaml` (1.0.9)
- `clusters/_template/bootstrap-kit/55b-bp-huawei-evs-csi.yaml` (pin 1.0.9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)