### PR TITLE
fix(#4975): cutover step-08 stops misreading a Recreate slow-init workload (gitea) as a mothership tether

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -763,7 +763,13 @@ spec:
       # in tests/cutover-contract.sh Case 16c, not a chart defect), so this pin would
       # have wedged slot-06a at HelmChart artifact-not-found. Case 16c now asserts the
       # self-heal against a file (no printf|grep SIGPIPE). No chart behavior change.
-      version: 0.1.112
+      # 0.1.113 (#4975 Refs #3379 #3695): step-08 fresh-pull classifier stops
+      # MISREADING a Recreate-strategy slow-init workload (bp-gitea, #3188) as a
+      # mothership tether — a new-revision Pod that pulled its image from the local
+      # registry but sits PodInitializing (readyReplicas transiently 0) now PASSES
+      # via a #4975 carve-out (the strict ImagePullBackOff FAIL is untouched). No
+      # chart behavior change for any other workload.
+      version: 0.1.113
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.112
+  version: 0.1.113
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,29 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.113 (#4975 Refs #3379 #3695): step-08 fresh-pull classifier no longer
+# MISREADS a Recreate-strategy slow-init workload as a mothership tether. Live
+# hw238 step-08 deny-egress roll FAILED `gitea did not roll out within 240s
+# (PodInitializing x4)` even though gitea pulled its image from the LOCAL
+# registry fine — bp-gitea sets strategy.type=Recreate (#3188, RWO-PVC/LevelDB
+# lock safety), so its roll tears the OLD Pod down FIRST → readyReplicas is
+# transiently 0 (the #4674 serving-check can't fire, no old Pod serving) → the
+# new Pod sits PodInitializing running its embedded init/DB-migration. The
+# #4674 carve-out only covered RollingUpdate leader-election singletons
+# (readyReplicas>=1); a Recreate single-replica stateful workload fell through
+# to the strict FAIL. roll_and_check_workload now adds a #4975 carve-out: after
+# the (untouched) strict ImagePullBackOff/ErrImagePull check, if a new-revision
+# Pod (updatedReplicas>=1) has POSITIVELY started a container (init/main in
+# running/terminated state → image PROVEN pulled from local registry under
+# deny-egress), the fresh-pull proof PASSES; a slow readiness is judged by the
+# survival-window HR poll, not this roll. Security-preserving: a real image-pull
+# tether still shows ImagePullBackOff → strict FAIL, and a Pod stuck Pending
+# with no started container has no evidence → strict FAIL. The continuum-
+# controller residual of #4975 was ALREADY closed on main — bp-continuum's
+# templates/_helpers.tpl `continuum.image` honours global.imageRegistry (since
+# #1101) and bp-continuum is already in imageRegistryPivot.additionalHRs
+# (#4885/#4888) — so no chart change is needed for it. No step-count / job-mode
+# / RBAC change (still 11 steps). Slot-06a pin + blueprint.yaml + catalog-seed
+# source.version move to 0.1.113 in lockstep (Inviolable Principle #13).
 # 0.1.112 (#4969 Refs #4967 #3379): REPUBLISH of the 0.1.111 payload — no chart
 # behavior change. 0.1.111's release FAILED at "Run chart integration tests" so
 # it never published to GHCR while slot-06a already pinned it → a fresh prov
@@ -1661,7 +1685,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.112
+version: 0.1.113
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
@@ -560,6 +560,38 @@ data:
                 echo "    PASS — ${kind}/${name} pulled a fresh image from the local registry under deny-egress (rollout status incomplete = leader-election readiness artifact under maxUnavailable=0; workload still serving) (#4674)"
                 return 0
               fi
+              # #4975 (Refs #3379 #3695) — a Recreate-strategy single-replica
+              # stateful workload (bp-gitea sets strategy.type=Recreate for
+              # RWO-PVC/LevelDB-lock safety, #3188) tears its OLD Pod down FIRST,
+              # so during a roll readyReplicas is transiently 0 — the #4674
+              # serving-check above CANNOT fire (no old Pod is left serving) — and
+              # the new Pod sits PodInitializing while its embedded init /
+              # DB-migration runs (live hw238: `gitea did not roll out within 240s
+              # (PodInitializing x4)`). That is NOT a mothership tether: the image
+              # ALREADY pulled from the local registry — any pull failure would
+              # have surfaced as ImagePullBackOff/ErrImagePull and been caught by
+              # the strict-FAIL image-pull check ABOVE (untouched, still the hard
+              # security gate). The fresh-pull proof's job is narrowly "did this
+              # workload pull its image from the LOCAL registry under deny-egress";
+              # a slow readiness (init/migration) is judged by the survival-window
+              # HR-readiness poll below, not this roll. So when a NEW-revision Pod
+              # (updatedReplicas>=1) has POSITIVELY pulled + STARTED at least one
+              # container (an init or main container in running/terminated state),
+              # the local-registry pull is PROVEN and the proof PASSES. A Pod that
+              # is stuck Pending / never started a container (nothing pulled) has
+              # NO started-container evidence and still falls through to the strict
+              # FAIL below. DaemonSets expose numberReady/updatedNumberScheduled
+              # (not updatedReplicas) so `updated` is empty → this carve-out never
+              # fires for them; they keep the strict FAIL, unchanged.
+              started_evidence=""
+              if [ -n "${sel}" ]; then
+                started_evidence=$(kubectl get pods -n "${ns}" -l "${sel}" \
+                  -o jsonpath='{range .items[*]}{range .status.initContainerStatuses[*]}{.state.running.startedAt}{.state.terminated.startedAt}{end}{range .status.containerStatuses[*]}{.state.running.startedAt}{.state.terminated.startedAt}{end}{end}' 2>/dev/null || echo "")
+              fi
+              if [ "${updated:-0}" -ge 1 ] && [ -n "${started_evidence}" ]; then
+                echo "    PASS — ${kind}/${name} pulled a fresh image from the local registry under deny-egress (new-revision Pod started a container; rollout status incomplete = slow init/DB-migration on a Recreate single-replica stateful workload, e.g. bp-gitea #3188 — readiness lag is judged by the survival-window HR poll, not a mothership tether) (#4975)"
+                return 0
+              fi
               echo "    FAIL — ${kind}/${name} did not roll out within ${FRESH_PULL_TIMEOUT}s under deny-egress (reasons:${reasons:-<none>})"
               return 1
             }

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.112"
+    version: "0.1.113"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## What / why

Live **hw238** sovereignty-cutover (#3379) **step-08 deny-egress roll** FAILED with:

```
FAIL — deployment/gitea  did not roll out within 240s ( PodInitializing x4 )
```

…even though gitea pulled its image from the **local** registry fine.

**Root cause (false-fail — NOT a tether):** `bp-gitea` sets `strategy.type: Recreate` (#3188, for RWO-PVC/LevelDB-lock safety). A rollout tears the **old** Pod down first → `readyReplicas` is transiently `0` while the new Pod sits **PodInitializing** running its embedded init / DB-migration. `roll_and_check_workload`'s existing `#4674` carve-out only PASSes a timed-out rollout when `readyReplicas>=1` (a RollingUpdate leader-election singleton whose old Pod is still serving), so a **Recreate single-replica stateful** workload fell through to the strict FAIL and was misclassified as a residual external-registry tether. `PodInitializing` ≠ `ImagePullBackOff` → the image already pulled locally.

## The fix (minimal, security-preserving)

In `08-egress-block-test-job.yaml` `roll_and_check_workload`, **after** the untouched strict `ImagePullBackOff`/`ErrImagePull` check (still the hard security gate), add a `#4975` carve-out: when a **new-revision Pod (`updatedReplicas>=1`) has positively started a container** (init or main in `running`/`terminated` state → image **proven** pulled from the local registry under deny-egress), the fresh-pull proof PASSES. Slow readiness (init/migration) is judged by the survival-window HR poll, not this roll.

- A real image-pull tether still shows `ImagePullBackOff` → **strict FAIL** (unchanged).
- A Pod stuck `Pending` with no started container → no evidence → **strict FAIL** (unchanged).
- DaemonSets (no `updatedReplicas`) → carve-out never fires → **strict FAIL** (unchanged).

## continuum-controller residual — already closed on main (no change here)

The other #4975 residual (continuum-controller raw `ghcr.io` ref) is **already fixed on `main`**: `products/continuum/chart/templates/_helpers.tpl` `continuum.image` honours `global.imageRegistry` (since #1101) **and** `bp-continuum` is already in the cutover `imageRegistryPivot.additionalHRs` with its slot-62 6-space seam (#4885/#4888). `helm template` verified:

- default → `ghcr.io/openova-io/openova/continuum-controller:0c717f6` (byte-identical)
- `--set global.imageRegistry=registry.example.works` → `registry.example.works/openova-io/openova/continuum-controller:0c717f6`

## Lockstep + verification

- Cutover chart **0.1.112 → 0.1.113** across `Chart.yaml`, `blueprint.yaml`, catalog-seed `source.version`, slot-06a pin (Inviolable Principle #13). No step-count / job-mode / RBAC change (still 11 steps).
- `helm template platform/self-sovereign-cutover/chart` renders (bp-continuum present in the step-07 pivot); rendered step-08 script passes POSIX `sh -n`.
- `check-bootstrap-kit-pin-sync.sh` PASS; `check-catalog-seed-lockstep.sh` PASS.

Refs #4975 #3379 #3695