### PR TITLE
fix(#4975): complete offline-mirror + per-host containerd rewrite ends step-08 whack-a-mole

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -769,7 +769,11 @@ spec:
       # registry but sits PodInitializing (readyReplicas transiently 0) now PASSES
       # via a #4975 carve-out (the strict ImagePullBackOff FAIL is untouched). No
       # chart behavior change for any other workload.
-      version: 0.1.113
+      # 0.1.114 (#4975 Refs #3379 #3695): the COMPLETE offline-mirror datapath —
+      # step-03 pushes every workload image, step-04 rewrites containerd per-host,
+      # step-08 pre-hold completeness gate + fixed localRegistryHostSubstr (below,
+      # now the FULL registry.${SOVEREIGN_FQDN}). Builds on 0.1.113's carve-out.
+      version: 0.1.114
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover
@@ -885,17 +889,20 @@ spec:
     # a tether the preceding steps 01-07 already pivoted off.
     egressTest:
       enforceCIDRBlock: true
-      # #4563 (Refs #3379): the Sovereign-local registry host is
-      # `registry.${SOVEREIGN_FQDN}` (bp-harbor's HTTPRoute, see
-      # 19-harbor.yaml + harborPublicURL above), NOT `harbor.<fqdn>`.
-      # The step-08 #3695 fresh-pull proof classifies a workload as
-      # "already local" when its image host contains this substring —
-      # with the chart default `harbor.` the post-pivot catalyst-ui /
-      # openova-flow-server images (registry.<fqdn>/openova-io/...) were
-      # mis-classified as external and needlessly bounced. Override to
-      # `registry.` so pivoted workloads are correctly recognised as
-      # local and the proof PASSes on the first scan.
-      localRegistryHostSubstr: "registry."
+      # #4975 (Refs #3379 #3695): the Sovereign-local registry host is the FULL
+      # `registry.${SOVEREIGN_FQDN}` (bp-harbor's HTTPRoute, see 19-harbor.yaml +
+      # harborPublicURL above). The step-08 roll-set classifies a workload as
+      # "already local" when its image host contains this substring.
+      #   • the chart default `harbor.` was doubly wrong: it EXCLUDED the
+      #     harbor.openova.io/proxy-* mothership tether (the DOMINANT tether) from
+      #     the roll-set AND did not match the real local host so pivoted refs
+      #     were needlessly bounced;
+      #   • the former `registry.` (this overlay's prior value) ALSO matched
+      #     registry.k8s.io (an EXTERNAL upstream that MUST be rolled).
+      # The FULL host classifies correctly. Since chart 0.1.113 step-08 DERIVES
+      # this from sovereign.harborPublicURL's host when unset, this override is
+      # made explicit for clarity but agrees with the derive.
+      localRegistryHostSubstr: "registry.${SOVEREIGN_FQDN}"
     # Wave 5.110 (#2462): bastion mirror endpoint for harbor.openova.io,
     # substituted from cloudinit's flux-system/bastion-mirror Secret
     # (Huawei provider only; Hetzner leaves the var empty → chart skips

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.113
+  version: 0.1.114
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,11 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.114 (#4975 Refs #3379 #3695 — generalizes/supersedes #4976 [0.1.113] + the
+# partial #4975): the SYSTEMIC end of the per-prov step-08 whack-a-mole. Layers
+# ON TOP of #4976's Recreate-strategy fresh-pull carve-out (kept intact in
+# roll_and_check_workload) the COMPLETE offline-mirror datapath so no residual
+# image tether can reach step-08 at all. See the 0.1.114-detail block below.
+# ── 0.1.113 (#4976) ──────────────────────────────────────────────────────────
 # 0.1.113 (#4975 Refs #3379 #3695): step-08 fresh-pull classifier no longer
 # MISREADS a Recreate-strategy slow-init workload as a mothership tether. Live
 # hw238 step-08 deny-egress roll FAILED `gitea did not roll out within 240s
@@ -24,6 +30,44 @@ name: bp-self-sovereign-cutover
 # (#4885/#4888) — so no chart change is needed for it. No step-count / job-mode
 # / RBAC change (still 11 steps). Slot-06a pin + blueprint.yaml + catalog-seed
 # source.version move to 0.1.113 in lockstep (Inviolable Principle #13).
+# ── 0.1.114 detail (offline-mirror datapath) ────────────────────────────────
+# 0.1.114 is the
+# SYSTEMIC end of the per-prov step-08 whack-a-mole (each fresh prov surfaced a
+# new residual image tether the deny-egress hold caught mid-window). Root cause:
+# the set of images the cutover makes locally-pullable came from THREE
+# independently hand-maintained lists that each drifted behind the growing chart
+# set — (a) step-03 Phase-A skopeo push was filtered to `^ghcr.io/openova-io/`
+# only, (b) prewarm.images was a hardcoded 11-image HEAD list, (c) step-07
+# imageRegistryPivot.additionalHRs was a hand-listed set — while the LOCAL Harbor
+# proxy-cache projects were COLD/unreachable under deny-egress. THE FIX makes the
+# local Harbor a COMPLETE, dynamically-derived OFFLINE MIRROR + per-host
+# containerd rewrite, retires the hand-lists, and adds a completeness gate + CI
+# guardrail. ALL from ONE coverage map (offlineMirror.hostProjects), the single
+# source of truth that three steps consume so they can never disagree:
+#   • step-03 Phase A3 (03-harbor-prewarm-job.yaml) — DROPS the ghcr.io/openova-io
+#     grep filter and skopeo-PUSHES every enumerated workload image (running Pods
+#     ∪ declared templates) into registry.<fqdn>/<project>/<path> via the shared
+#     resolver, with per-host --src-creds (ghcr PAT / mothership auth / anonymous);
+#   • step-04 (04-registry-pivot-daemonset.yaml) — REPLACES the single
+#     `_default/hosts.toml` dfdaemon catch-all with PER-UPSTREAM-HOST certs.d
+#     entries resolving each host DIRECTLY to the local Harbor project path
+#     (override_path), + a host-swap entry for the mothership; the v2 ack now
+#     gates on the LOCAL Harbor serving /v2/, not dfdaemon;
+#   • step-08 (08-egress-block-test-job.yaml) — a PRE-HOLD completeness gate HEADs
+#     every workload image against local Harbor and FATALs (naming the offender)
+#     if any is absent, turning an opaque mid-hold ImagePullBackOff into a
+#     fail-fast; also FIXES egressTest.localRegistryHostSubstr (was "harbor." →
+#     which excluded the mothership tether AND needlessly rolled local refs; the
+#     06a "registry." also matched registry.k8s.io) to DERIVE the full local host
+#     registry.<fqdn>, and excludes xpkg/rancher-k3s/loft-sh-vcluster from the roll-set.
+# The `proxy-*` local projects become PUBLIC push-mode offline mirrors (step-02
+# harbor.mirrorProjects; only proxy-xpkg stays proxy-cache for step-11). A shared
+# resolver ConfigMap (03a-offline-mirror-resolver.yaml) is the code half of the
+# retirement; the CI guardrail (tests/image-registry-coverage.sh) FAILs if any
+# bootstrap-kit slot introduces an image from an un-mapped registry host. NOT
+# merged with a live walk yet — pillar-5 deny-egress proof is verified on the walk.
+# Slot-06a pin + blueprint.yaml + catalog-seed source.version move to 0.1.114 in
+# lockstep (Inviolable Principle #13; catalog-seed pin must NOT lag the chart).
 # 0.1.112 (#4969 Refs #4967 #3379): REPUBLISH of the 0.1.111 payload — no chart
 # behavior change. 0.1.111's release FAILED at "Run chart integration tests" so
 # it never published to GHCR while slot-06a already pinned it → a fresh prov
@@ -1685,7 +1729,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.113
+version: 0.1.114
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/02-harbor-projects-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/02-harbor-projects-job.yaml
@@ -148,6 +148,30 @@ data:
               esac
             done
             echo "[harbor-projects] all push-mode projects ensured"
+
+            # #4975 (Refs #3379 #3695): PUBLIC push-mode OFFLINE-MIRROR projects.
+            # These hold the complete skopeo-pushed copy of every non-openova
+            # upstream image (step-03 Phase A3) so the node's containerd
+            # (step-04 rewrite) serves them under the step-08 deny-egress hold —
+            # a proxy-cache project cannot (its back-to-source is black-holed).
+            # PUBLIC so an upstream-image pod with NO imagePullSecret pulls
+            # anonymously post-rewrite (the proxy-cache projects these replace
+            # were public:true). Push still requires the harbor admin auth used
+            # here; only anonymous PULL is opened. Names MATCH the mothership
+            # Harbor project names so harbor.openova.io/proxy-<x>/PATH host-swaps
+            # to registry.<fqdn>/proxy-<x>/PATH with the path preserved.
+            for mirror_proj in {{ join " " .Values.harbor.mirrorProjects }}; do
+              echo "[harbor-projects] ensuring public offline-mirror project ${mirror_proj}"
+              proj_payload="{\"project_name\":\"${mirror_proj}\",\"public\":true,\"metadata\":{\"public\":\"true\"}}"
+              code=$(curl -sk -o /tmp/proj.out -w "%{http_code}" -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" -X POST \
+                -H "Content-Type: application/json" \
+                "${base}/projects" --data "${proj_payload}")
+              case "${code}" in
+                201|409) echo "[harbor-projects]   mirror project ${mirror_proj} OK (${code})" ;;
+                *)       echo "[harbor-projects]   mirror project ${mirror_proj} FAILED (${code})"; cat /tmp/proj.out; exit 1 ;;
+              esac
+            done
+            echo "[harbor-projects] all offline-mirror projects ensured"
         resources:
           requests: { cpu: 100m, memory: 128Mi }
           limits:   { memory: 512Mi }

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -143,12 +143,30 @@ data:
           # The SRC (ghcr.io) verification is ALWAYS true (external public host).
           - name: PREWARM_DEST_TLS_VERIFY
             value: {{ .Values.prewarm.destTLSVerify | default false | quote }}
+          # #4975 (Refs #3379 #3695) — the offline-mirror coverage map + the
+          # local/mothership hosts, rendered from .Values.offlineMirror by the
+          # shared helpers. Phase A3 resolves every enumerated image to its
+          # local Harbor push path(s) via /resolver/resolver.sh, which reads
+          # THESE — the SAME env step-08's completeness HEAD reads.
+          - name: HOST_PROJECT_MAP
+            value: {{ include "bp-self-sovereign-cutover.hostProjectMapInline" . | quote }}
+          - name: EXCLUDED_HOSTS
+            value: {{ include "bp-self-sovereign-cutover.excludedHostsInline" . | quote }}
+          - name: EXCLUDED_SUBSTRINGS
+            value: {{ include "bp-self-sovereign-cutover.excludedSubstringsInline" . | quote }}
+          - name: LOCAL_REGISTRY_HOST
+            value: {{ include "bp-self-sovereign-cutover.localRegistryHost" . | quote }}
+          - name: MOTHERSHIP_HOST
+            value: {{ include "bp-self-sovereign-cutover.mothershipHost" . | quote }}
         volumeMounts:
           - name: prewarm
             mountPath: /work
             readOnly: true
           - name: chart-mirror-names
             mountPath: /chart-mirror
+            readOnly: true
+          - name: offline-mirror-resolver
+            mountPath: /resolver
             readOnly: true
           - name: tmp
             mountPath: /tmp
@@ -157,6 +175,13 @@ data:
           - |
             set -eu
             : "${HARBOR_USERNAME:=admin}"
+
+            # #4975 — the offline-mirror image→local-path resolver (shared with
+            # step-08). Defines offlinemirror_normalize_ref + offlinemirror_local_paths
+            # over the HOST_PROJECT_MAP / EXCLUDED_* / LOCAL_REGISTRY_HOST env.
+            . /resolver/resolver.sh
+            echo "[harbor-prewarm] offline-mirror map: ${HOST_PROJECT_MAP}"
+            echo "[harbor-prewarm] local registry host: ${LOCAL_REGISTRY_HOST}; excluded hosts: ${EXCLUDED_HOSTS:-<none>}"
 
             # ─── Phase A: skopeo native push of openova-io images ──────
             echo "[harbor-prewarm] Phase A: install skopeo + jq + enumerate openova-io images"
@@ -256,6 +281,34 @@ data:
             ghcr_pat=$(printf '%s' "${ghcr_auth_b64}" | base64 -d | awk -F: '{print $2}')
             echo "[harbor-prewarm] ghcr.io auth extracted: user=${ghcr_user} pat=${ghcr_pat:0:8}... (len=${#ghcr_pat})"
 
+            # #4975 — OPTIONAL mothership-Harbor source auth. Phase A3 mirrors
+            # `harbor.openova.io/proxy-<x>/...` refs (the dominant bootstrap-kit
+            # image shape) by host-swapping to the local Harbor; the SOURCE pull
+            # from the mothership uses THIS auth when the ghcr-pull dockerconfig
+            # carries it (it usually does — same Secret proxies both). Absent →
+            # anonymous mothership pull (the proxy-<x> projects are public).
+            moth_user=""
+            moth_pat=""
+            moth_auth_b64=$(printf '%s' "${dc_decoded}" | jq -r --arg h "${MOTHERSHIP_HOST}" '.auths[$h].auth // empty' 2>/dev/null || true)
+            if [ -n "${moth_auth_b64}" ]; then
+              moth_user=$(printf '%s' "${moth_auth_b64}" | base64 -d | awk -F: '{print $1}')
+              moth_pat=$(printf '%s' "${moth_auth_b64}" | base64 -d | cut -d: -f2-)
+              echo "[harbor-prewarm] ${MOTHERSHIP_HOST} auth extracted: user=${moth_user} (len=${#moth_pat})"
+            fi
+
+            # #4975 — choose skopeo --src-creds by SOURCE host: ghcr.io → the
+            # ghcr-pull PAT (private openova-io packages); the mothership →
+            # optional mothership auth; every anonymous upstream (docker.io,
+            # quay.io, registry.k8s.io, gcr.io, public.ecr.aws) → NO creds.
+            src_creds_for() {
+              case "$1" in
+                ghcr.io) printf '%s:%s' "${ghcr_user}" "${ghcr_pat}" ;;
+                "${MOTHERSHIP_HOST}")
+                  [ -n "${moth_user}" ] && printf '%s:%s' "${moth_user}" "${moth_pat}" || printf '' ;;
+                *) printf '' ;;
+              esac
+            }
+
             HARBOR_HOST=$(printf '%s' "${HARBOR_PUBLIC_URL}" | sed -e 's,^https\?://,,' -e 's,/$,,')
 
             # Enumerate openova-io images cluster-wide.
@@ -285,25 +338,35 @@ data:
             # only WIDEN the prewarm list (every entry is still skopeo-pushed
             # idempotently), never narrow it — a strict superset of the prior
             # behaviour.
-            echo "[harbor-prewarm] enumerating openova-io images across cluster (running pods ∪ declared workload templates)"
+            #
+            # #4975 (Refs #3379 #3695) — GENERALIZED to ALL images, not just
+            # `ghcr.io/openova-io/*`. The `^ghcr.io/openova-io/` grep filter is
+            # DROPPED: the enumeration now unions EVERY container/init/ephemeral
+            # image across running Pods AND declared workload templates, so a
+            # COMPLETE offline mirror of every non-node-cached upstream lands in
+            # local Harbor before the deny-egress hold. copy_one below routes
+            # each image to its local project via the shared resolver
+            # (offlinemirror_local_paths): openova-io → host-drop openova-io/…
+            # (unchanged) + proxy-ghcr/openova-io/…; docker.io/quay.io/registry.
+            # k8s.io/gcr.io/public.ecr.aws → proxy-<host>/…; harbor.openova.io →
+            # host-swap (path preserved); xpkg.upbound.io + rancher/k3s +
+            # loft-sh/vcluster EXCLUDED (offlineMirror.excluded*). This is the
+            # generalization of the former #3944 running-∪-declared union.
+            echo "[harbor-prewarm] enumerating ALL images across cluster (running pods ∪ declared workload templates)"
             running_images=$(kubectl get pods -A -o json | \
-              jq -r '.items[].spec | (.containers // [])[].image, (.initContainers // [])[].image, (.ephemeralContainers // [])[].image' 2>/dev/null | \
-              grep '^ghcr.io/openova-io/' || true)
+              jq -r '.items[].spec | (.containers // [])[].image, (.initContainers // [])[].image, (.ephemeralContainers // [])[].image' 2>/dev/null || true)
             declared_images=$(kubectl get deployments,statefulsets,daemonsets -A -o json 2>/dev/null | \
-              jq -r '.items[].spec.template.spec | (.containers // [])[].image, (.initContainers // [])[].image' 2>/dev/null | \
-              grep '^ghcr.io/openova-io/' || true)
+              jq -r '.items[].spec.template.spec | (.containers // [])[].image, (.initContainers // [])[].image' 2>/dev/null || true)
             cronjob_images=$(kubectl get cronjobs -A -o json 2>/dev/null | \
-              jq -r '.items[].spec.jobTemplate.spec.template.spec | (.containers // [])[].image, (.initContainers // [])[].image' 2>/dev/null | \
-              grep '^ghcr.io/openova-io/' || true)
+              jq -r '.items[].spec.jobTemplate.spec.template.spec | (.containers // [])[].image, (.initContainers // [])[].image' 2>/dev/null || true)
             job_images=$(kubectl get jobs -A -o json 2>/dev/null | \
-              jq -r '.items[].spec.template.spec | (.containers // [])[].image, (.initContainers // [])[].image' 2>/dev/null | \
-              grep '^ghcr.io/openova-io/' || true)
+              jq -r '.items[].spec.template.spec | (.containers // [])[].image, (.initContainers // [])[].image' 2>/dev/null || true)
             openova_images=$(printf '%s\n%s\n%s\n%s\n' \
               "${running_images}" "${declared_images}" "${cronjob_images}" "${job_images}" | \
-              grep '^ghcr.io/openova-io/' | sort -u || true)
+              grep -E '^[^[:space:]]+$' | grep -v '^null$' | sort -u || true)
             run_count=$(printf '%s\n' "${running_images}" | grep -c . || true)
             count=$(printf '%s\n' "${openova_images}" | grep -c . || true)
-            echo "[harbor-prewarm] running-Pod openova-io images=${run_count}; union with declared templates=${count} unique image(s) to native-push"
+            echo "[harbor-prewarm] running-Pod images=${run_count}; union with declared templates=${count} unique image(s) to mirror"
 
             # Native push each via skopeo copy, run in PARALLEL with a
             # bounded fan-out.
@@ -393,70 +456,113 @@ data:
               esac
             }
 
+            # #4975 — copy ONE upstream image to ALL of its local Harbor
+            # destination path(s) (usually one; TWO for a ghcr.io/openova-io/*
+            # ref — the host-drop openova-io/… convention + proxy-ghcr/openova-io/…).
+            # Destinations come from the shared resolver (offlinemirror_local_paths)
+            # so step-03 push and step-08 completeness HEAD agree byte-for-byte.
+            # The per-image record is .ok only if EVERY dest copy succeeded.
             copy_one() {
-              up=$(normalize_ref "$1")
-              # Convert ghcr.io/X/Y:tag → HARBOR_HOST/X/Y:tag
-              # (drop ghcr.io/ prefix, keep rest identical)
-              lref="${HARBOR_HOST}/${up#ghcr.io/}"
-              # Slug for the per-image sentinel/log file names.
+              up=$(offlinemirror_normalize_ref "$1")
               slug=$(printf '%s' "${up}" | tr -c 'A-Za-z0-9._-' '_')
-              # OUTER per-image retry loop: `--retry-times 5` self-heals a
-              # transient blob fetch inside ONE copy, but a Harbor-side reset
-              # that closes the dest connection can abort the whole copy (hw146
-              # large-image FATAL, see comment above). Re-attempt the full
-              # `skopeo copy` up to PREWARM_COPY_ATTEMPTS times before counting a
-              # push_fail. The per-attempt log is APPENDED so the final captured
-              # log shows every try.
-              attempt=1
-              rc=1
               : >"${cpdir}/${slug}.log"
-              while [ "${attempt}" -le "${PREWARM_COPY_ATTEMPTS}" ]; do
-                echo "[harbor-prewarm] copy ${up} attempt ${attempt}/${PREWARM_COPY_ATTEMPTS}" >>"${cpdir}/${slug}.log"
-                # #3944: `--command-timeout` is a skopeo GLOBAL flag (must
-                # precede the `copy` subcommand) — it bounds the whole copy so a
-                # silently-stalled connection can't hang the worker forever.
-                # #4529: --dest-tls-verify is PREWARM_DEST_TLS_VERIFY (default
-                # false) — the dest is the in-cluster Harbor over the pod
-                # network (LE-STAGING/untrusted cert on a fresh prov, no node
-                # trust store in a Job Pod). --src-tls-verify stays true (ghcr.io
-                # is an external public-CA host that MUST be authenticated).
-                if skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT}" copy \
-                  --insecure-policy \
-                  --retry-times 5 \
-                  --src-creds="${ghcr_user}:${ghcr_pat}" \
-                  --dest-creds="${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
-                  --dest-tls-verify="${PREWARM_DEST_TLS_VERIFY}" \
-                  --src-tls-verify=true \
-                  "docker://${up}" "docker://${lref}" >>"${cpdir}/${slug}.log" 2>&1; then
-                  rc=0
-                  break
-                else
-                  # Capture skopeo's REAL exit status INSIDE the else branch —
-                  # `rc=$?` placed AFTER the `fi` would read the if-construct's
-                  # status (0 when the condition is false with no else), the same
-                  # always-0 trap the #3379 hw138 real-exit-status fix called out.
-                  rc=$?
-                fi
-                echo "[harbor-prewarm] copy ${up} attempt ${attempt} failed (exit=${rc}); retrying after backoff" >>"${cpdir}/${slug}.log"
-                attempt=$((attempt+1))
-                # Short backoff lets a Harbor-side reset settle before the
-                # next full copy; skip the sleep after the final attempt.
-                [ "${attempt}" -le "${PREWARM_COPY_ATTEMPTS}" ] && sleep 5
+              dests=$(offlinemirror_local_paths "${up}")
+              if [ -z "${dests}" ]; then
+                # Excluded at copy time (belt to the pre-pass filter).
+                printf '%s (excluded)' "${up}" >"${cpdir}/${slug}.ok"
+                return 0
+              fi
+              # SOURCE host → src-creds selection (bare official image = docker.io).
+              srchost="${up%%/*}"
+              case "${srchost}" in *.*|*:*|localhost) : ;; *) srchost="docker.io" ;; esac
+              sc=$(src_creds_for "${srchost}")
+              if [ -n "${sc}" ]; then set -- --src-creds="${sc}"; else set --; fi
+              all_ok=1
+              last_rc=0
+              for dpath in ${dests}; do
+                lref="${HARBOR_HOST}/${dpath}"
+                # OUTER per-dest retry loop: `--retry-times 5` self-heals a
+                # transient blob fetch inside ONE copy; a Harbor-side reset that
+                # closes the dest connection can still abort the whole copy
+                # (hw146 large-image FATAL), so re-attempt the full copy up to
+                # PREWARM_COPY_ATTEMPTS times. FATAL-on-any-failure preserved:
+                # the image is .fail unless every dest copy eventually succeeds.
+                attempt=1
+                rc=1
+                while [ "${attempt}" -le "${PREWARM_COPY_ATTEMPTS}" ]; do
+                  echo "[harbor-prewarm] copy ${up} -> ${lref} attempt ${attempt}/${PREWARM_COPY_ATTEMPTS}" >>"${cpdir}/${slug}.log"
+                  # #3944 --command-timeout (GLOBAL flag before `copy`) bounds a
+                  # stalled connection. #4529 --dest-tls-verify=PREWARM_DEST_TLS_VERIFY
+                  # (default false: in-cluster LE-staging Harbor). --src-tls-verify
+                  # stays true (external public-CA source). "$@" is the optional
+                  # --src-creds selected by host (empty for anonymous upstreams).
+                  if skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT}" copy \
+                    --insecure-policy \
+                    --retry-times 5 \
+                    "$@" \
+                    --dest-creds="${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
+                    --dest-tls-verify="${PREWARM_DEST_TLS_VERIFY}" \
+                    --src-tls-verify=true \
+                    "docker://${up}" "docker://${lref}" >>"${cpdir}/${slug}.log" 2>&1; then
+                    rc=0
+                    break
+                  else
+                    # Capture skopeo's REAL exit status INSIDE the else branch
+                    # (the #3379 hw138 always-0 trap).
+                    rc=$?
+                  fi
+                  echo "[harbor-prewarm] copy ${up} -> ${lref} attempt ${attempt} failed (exit=${rc}); retrying after backoff" >>"${cpdir}/${slug}.log"
+                  attempt=$((attempt+1))
+                  [ "${attempt}" -le "${PREWARM_COPY_ATTEMPTS}" ] && sleep 5
+                done
+                [ "${rc}" -eq 0 ] || { all_ok=0; last_rc="${rc}"; }
               done
-              if [ "${rc}" -eq 0 ]; then
+              if [ "${all_ok}" -eq 1 ]; then
                 printf '%s' "${up}" >"${cpdir}/${slug}.ok"
               else
-                printf '%s exit=%s' "${up}" "${rc}" >"${cpdir}/${slug}.fail"
+                printf '%s exit=%s' "${up}" "${last_rc}" >"${cpdir}/${slug}.fail"
               fi
             }
+
+            # #4975 PRE-PASS — resolve every enumerated image through the shared
+            # coverage map BEFORE the parallel fan-out. Excluded images (xpkg /
+            # rancher-k3s / loft-sh-vcluster) are dropped; an image from a
+            # registry host NOT in offlineMirror.hostProjects is UNMAPPED →
+            # FATAL fail-fast (naming the offender). This is the whack-a-mole
+            # trap closing at step-03: a new chart's un-covered registry host
+            # fails the cutover HERE (egress still open, clear message) instead
+            # of surfacing as an opaque ImagePullBackOff mid deny-egress hold.
+            mirror_work=""
+            unmapped=""
+            for img in ${openova_images}; do
+              [ -z "${img}" ] && continue
+              paths=$(offlinemirror_local_paths "${img}")
+              case "${paths}" in
+                __UNMAPPED__*)
+                  uh=$(printf '%s' "${paths}" | awk '{print $2}')
+                  unmapped="${unmapped} ${uh}(${img})"
+                  ;;
+                "")
+                  : ;;  # excluded — skip
+                *)
+                  mirror_work="${mirror_work} ${img}"
+                  ;;
+              esac
+            done
+            if [ -n "${unmapped}" ]; then
+              echo "[harbor-prewarm] FATAL: image(s) from registry host(s) NOT in the offline-mirror coverage map (offlineMirror.hostProjects). Add the host→project (or exclude it) and re-run:"
+              for u in ${unmapped}; do echo "  UNMAPPED ${u}"; done
+              exit 1
+            fi
+            count=$(printf '%s\n' ${mirror_work} | grep -c . || true)
+            echo "[harbor-prewarm] ${count} mapped image(s) to mirror after resolver filter (parallelism=${PREWARM_PARALLELISM})"
 
             # Track live worker PIDs explicitly — POSIX sh's `jobs -p` is
             # unreliable in a non-interactive shell, so we count by polling
             # `kill -0 <pid>` against the PIDs we launched.
             pids=""
-            for upstream in ${openova_images}; do
-              local_ref="${HARBOR_HOST}/${upstream#ghcr.io/}"
-              echo "[harbor-prewarm] queue ${upstream} → ${local_ref}"
+            for upstream in ${mirror_work}; do
+              echo "[harbor-prewarm] queue ${upstream}"
               copy_one "${upstream}" &
               pids="${pids} $!"
               # Throttle: block launching the next copy while
@@ -803,5 +909,11 @@ data:
           items:
             - key: chart-mirror-names.txt
               path: chart-mirror-names.txt
+      - name: offline-mirror-resolver
+        configMap:
+          name: cutover-offline-mirror-resolver
+          items:
+            - key: resolver.sh
+              path: resolver.sh
       - name: tmp
         emptyDir: {}

--- a/platform/self-sovereign-cutover/chart/templates/03a-offline-mirror-resolver.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03a-offline-mirror-resolver.yaml
@@ -1,0 +1,117 @@
+{{- /*
+#4975 (Refs #3379 #3695) — the OFFLINE-MIRROR image→local-path resolver.
+
+This ConfigMap carries ONE shell library, sourced by BOTH step-03
+(harbor-prewarm, skopeo push destination) AND step-08 (egress-block-test,
+pre-hold completeness HEAD) so the two consumers derive IDENTICAL local Harbor
+paths from the SAME coverage map (.Values.offlineMirror). It is the code half
+of "retire the three hand-lists": the DATA half is the env the helpers render
+(HOST_PROJECT_MAP / EXCLUDED_HOSTS / EXCLUDED_SUBSTRINGS / LOCAL_REGISTRY_HOST),
+this file is the mapping FUNCTION — neither consumer forks the logic.
+
+NOT a cutover-step ConfigMap: no bp.openova.io/cutover-order label, so it does
+not count toward the 11-step contract (tests/cutover-contract.sh Case 2/4).
+*/ -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cutover-offline-mirror-resolver
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cutover-offline-mirror
+data:
+  resolver.sh: |
+    # POSIX sh. Requires env: HOST_PROJECT_MAP EXCLUDED_HOSTS
+    # EXCLUDED_SUBSTRINGS LOCAL_REGISTRY_HOST. No side effects — pure functions.
+
+    # offlinemirror_normalize_ref REF -> REF with a tag-and-digest collapsed to
+    # digest-only (skopeo rejects `name:tag@digest`; the digest is authoritative
+    # and is exactly what containerd pulls by).
+    offlinemirror_normalize_ref() {
+      _nr="$1"
+      case "${_nr}" in
+        *@*)
+          _nr_digest="${_nr##*@}"
+          _nr_name="${_nr%@*}"
+          case "${_nr_name##*/}" in
+            *:*) _nr_name="${_nr_name%:*}" ;;
+          esac
+          printf '%s@%s' "${_nr_name}" "${_nr_digest}"
+          ;;
+        *) printf '%s' "${_nr}" ;;
+      esac
+    }
+
+    # offlinemirror_local_paths REF -> the local Harbor path(s) this image must
+    # be reachable at (relative to the local registry host), ONE PER LINE:
+    #   excluded host/substring        -> (nothing) SKIP
+    #   already on the local registry  -> the path verbatim
+    #   host in coverage map, proj P   -> "P/<rest>"  (or "<rest>" when P empty = mothership host-swap)
+    #   ghcr.io/openova-io/*           -> ALSO "<rest>" (the host-drop pivoted-ref path)
+    #   host NOT mapped, not excluded  -> "__UNMAPPED__ <host>"  (caller FATALs, naming the offender)
+    offlinemirror_local_paths() {
+      _u=$(offlinemirror_normalize_ref "$1")
+      # Split into host + rest. A registry host exists ONLY when the ref has a
+      # `/` AND the first segment looks like a host (contains `.` or `:port` or
+      # is localhost). A bare `name[:tag]` has NO `/` — the colon is the TAG, NOT
+      # a host:port — so it is a Docker Hub official image (docker.io/library/…).
+      case "${_u}" in
+        */*)
+          _host="${_u%%/*}"
+          case "${_host}" in
+            *.*|*:*|localhost) _rest="${_u#*/}" ;;
+            *) _host="docker.io"; _rest="${_u}" ;;   # docker.io namespaced (e.g. grafana/loki)
+          esac
+          ;;
+        *)
+          _host="docker.io"; _rest="${_u}"           # bare official image
+          ;;
+      esac
+      # Docker Hub official image: bare "name[:tag]" -> "library/name[:tag]".
+      case "${_host}" in
+        docker.io|registry-1.docker.io|index.docker.io)
+          case "${_rest}" in
+            */*) : ;;
+            *) _rest="library/${_rest}" ;;
+          esac
+          ;;
+      esac
+      # Excluded host.
+      for _eh in ${EXCLUDED_HOSTS}; do
+        [ "${_host}" = "${_eh}" ] && return 0
+      done
+      # Excluded image-path substring.
+      for _es in ${EXCLUDED_SUBSTRINGS}; do
+        case "${_u}" in *"${_es}"*) return 0 ;; esac
+      done
+      # Already on the local registry (openova-io host-drop pivoted refs, etc.).
+      if [ "${_host}" = "${LOCAL_REGISTRY_HOST}" ]; then
+        printf '%s\n' "${_rest}"
+        return 0
+      fi
+      # Coverage-map lookup.
+      _proj="__NOMATCH__"
+      for _pair in ${HOST_PROJECT_MAP}; do
+        _ph="${_pair%%:*}"
+        case "${_pair}" in *:*) _pp="${_pair#*:}" ;; *) _pp="" ;; esac
+        if [ "${_ph}" = "${_host}" ]; then _proj="${_pp}"; break; fi
+      done
+      if [ "${_proj}" = "__NOMATCH__" ]; then
+        printf '__UNMAPPED__ %s\n' "${_host}"
+        return 0
+      fi
+      if [ -z "${_proj}" ]; then
+        printf '%s\n' "${_rest}"
+      else
+        printf '%s/%s\n' "${_proj}" "${_rest}"
+      fi
+      # openova-io host-drop DUAL dest: an un-pivoted ghcr.io/openova-io/* ref
+      # resolves to proxy-ghcr/openova-io/<path> (above) AND the step-06/07
+      # pivoted registry.<fqdn>/openova-io/<path> convention — both must exist.
+      if [ "${_host}" = "ghcr.io" ]; then
+        case "${_rest}" in
+          openova-io/*) printf '%s\n' "${_rest}" ;;
+        esac
+      fi
+    }

--- a/platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml
@@ -99,6 +99,15 @@ spec:
           env:
             - name: HARBOR_PUBLIC_URL
               value: {{ .Values.sovereign.harborPublicURL | quote }}
+            # #4975 (Refs #3379 #3695) — the offline-mirror coverage map + the
+            # local registry host. The pivot writes PER-UPSTREAM-HOST containerd
+            # certs.d entries pointing at registry.<fqdn>/<project> (the exact
+            # path step-03 Phase A3 pushed to), replacing the single _default
+            # dfdaemon catch-all. Same map step-03/step-08 read.
+            - name: HOST_PROJECT_MAP
+              value: {{ include "bp-self-sovereign-cutover.hostProjectMapInline" . | quote }}
+            - name: LOCAL_REGISTRY_HOST
+              value: {{ include "bp-self-sovereign-cutover.localRegistryHost" . | quote }}
             - name: STATUS_CONFIGMAP_NAME
               value: {{ .Values.status.configMapName | quote }}
             - name: STATUS_CONFIGMAP_NAMESPACE
@@ -295,53 +304,83 @@ data:
     fqdn_dashed=$(printf '%s' "${SOVEREIGN_FQDN}" | tr '.' '-')
     wildcard_secret="${HARBOR_CA_SRC_NAME_PREFIX}${fqdn_dashed}"
 
-    # Write (v2) or remove (v1) the containerd `_default/hosts.toml` catch-all
-    # that mirrors every registry namespace through the node-local dfdaemon
-    # proxy. `_default` is the containerd wildcard host-config dir — it applies
-    # to ANY registry that has no explicit certs.d/<host> dir, so a single file
-    # routes ghcr.io / docker.io / registry.k8s.io / … all through dfdaemon.
-    # skip_verify is moot (the endpoint is plain-HTTP loopback) but harmless.
-    write_default_mirror() {
-      mkdir -p "${certs_d}/_default"
-      {
-        echo "# managed by bp-self-sovereign-cutover registry-pivot (#4639) — DO NOT EDIT"
-        echo "[host.\"${df_proxy}\"]"
-        echo "  capabilities = [\"pull\", \"resolve\"]"
-        echo "  skip_verify = true"
-      } > "${certs_d}/_default/hosts.toml.new"
-      mv "${certs_d}/_default/hosts.toml.new" "${certs_d}/_default/hosts.toml"
-      echo "[registry-pivot]   wrote _default/hosts.toml -> ${df_proxy} (dfdaemon) on ${NODE_NAME}"
-      # #4637 (live-PROVEN on hw202): containerd's `_default` FALLBACK does NOT
-      # honor the http:// scheme of the [host] key — for an https-origin registry
-      # (registry.<fqdn>, :443) it dials `https://127.0.0.1:4001` and the dfdaemon,
-      # which serves PLAIN HTTP at :4001, EOFs the TLS handshake → step-07
-      # catalyst-api image pull ImagePullBackOff → cutover wedges at 54%. An
-      # EXPLICIT per-host certs.d/<registry-host>/hosts.toml DOES honor the http
-      # scheme, so write one for the pivoted in-cluster Harbor host. Confirmed:
-      # writing this + restarting catalyst-api → image pulled, pod Running.
-      if [ -n "${harbor_host:-}" ]; then
-        mkdir -p "${certs_d}/${harbor_host}"
+    # #4975 (Refs #3379 #3695) — PER-UPSTREAM-HOST containerd certs.d rewrite.
+    #
+    # REPLACES the single `_default/hosts.toml` dfdaemon catch-all. Under the
+    # step-08 deny-egress hold a dfdaemon back-to-source to the flipped upstream
+    # only serves images the dfdaemon already fetched; a workload image that was
+    # never node-cached ImagePullBackOffs. The systemic fix is a COMPLETE local
+    # Harbor mirror (step-03 Phase A3 pushes every image) + per-host containerd
+    # entries that resolve each upstream host DIRECTLY to the exact local path:
+    #   • host with project P → mirror https://<local>/v2/<P> + override_path=true
+    #     so a pull of `<host>/<repo>` resolves to `<local>/v2/<P>/<repo>` (the
+    #     Phase-A3 push dest);
+    #   • MOTHERSHIP host (empty project) → mirror https://<local> WITHOUT
+    #     override_path so the path (which already carries the proxy-<x> segment,
+    #     e.g. proxy-ghcr/cloudnative-pg/postgresql) is PRESERVED — a pure host
+    #     swap harbor.openova.io → registry.<fqdn>.
+    # This OVERRIDES the boot-time per-host `harbor.openova.io` mirror k3s wrote.
+    # Every entry skip_verify=true (the local Harbor serves an LE-staging /
+    # node-untrusted wildcard on a fresh prov — same trust-the-cluster-network
+    # rationale as #4529/#4557). The openova-io host-drop pull path is preserved
+    # by the local-registry self-entry (direct pulls of registry.<fqdn>/openova-io/…).
+    write_offline_mirror_hosts() {
+      # Retire the legacy dfdaemon catch-all (superseded by the per-host entries).
+      rm -f "${certs_d}/_default/hosts.toml" 2>/dev/null || true
+      # Self-entry: trust the local Harbor's cert for DIRECT openova-io host-drop
+      # pulls (registry.<fqdn>/openova-io/…), the pivoted-ref path step-06/07 set.
+      if [ -n "${LOCAL_REGISTRY_HOST:-}" ]; then
+        mkdir -p "${certs_d}/${LOCAL_REGISTRY_HOST}"
         {
-          echo "# managed by bp-self-sovereign-cutover registry-pivot (#4637) — DO NOT EDIT"
-          # The `server` line is LOAD-BEARING: without it containerd's host-dir
-          # falls back to the origin scheme (https) for the dfdaemon hop and
-          # TLS-handshakes the plain-HTTP :4001 proxy → EOF. The proven
-          # harbor.openova.io / 212.72.24.20:5000 certs.d entries on this same node
-          # ALL pair `server = "https://<host>/v2"` with an `[host."http://..."]`
-          # mirror — mirror that exact shape so the http dfdaemon hop is honored.
-          echo "server = \"https://${harbor_host}\""
-          echo "[host.\"${df_proxy}\"]"
+          echo "# managed by bp-self-sovereign-cutover registry-pivot (#4975) — DO NOT EDIT"
+          echo "server = \"https://${LOCAL_REGISTRY_HOST}\""
+          echo "[host.\"https://${LOCAL_REGISTRY_HOST}\"]"
           echo "  capabilities = [\"pull\", \"resolve\"]"
           echo "  skip_verify = true"
-        } > "${certs_d}/${harbor_host}/hosts.toml.new"
-        mv "${certs_d}/${harbor_host}/hosts.toml.new" "${certs_d}/${harbor_host}/hosts.toml"
-        echo "[registry-pivot]   wrote ${harbor_host}/hosts.toml -> ${df_proxy} (explicit http, #4637) on ${NODE_NAME}"
+        } > "${certs_d}/${LOCAL_REGISTRY_HOST}/hosts.toml.new"
+        mv "${certs_d}/${LOCAL_REGISTRY_HOST}/hosts.toml.new" "${certs_d}/${LOCAL_REGISTRY_HOST}/hosts.toml"
+        echo "[registry-pivot]   wrote ${LOCAL_REGISTRY_HOST}/hosts.toml (local self-trust) on ${NODE_NAME}"
       fi
+      # Per-upstream-host mirror → the local Harbor project path.
+      for pair in ${HOST_PROJECT_MAP}; do
+        h="${pair%%:*}"
+        case "${pair}" in *:*) p="${pair#*:}" ;; *) p="" ;; esac
+        [ -z "${h}" ] && continue
+        [ "${h}" = "${LOCAL_REGISTRY_HOST}" ] && continue
+        mkdir -p "${certs_d}/${h}"
+        if [ -z "${p}" ]; then
+          # Mothership host-swap: path preserved (no override_path).
+          {
+            echo "# managed by bp-self-sovereign-cutover registry-pivot (#4975) — DO NOT EDIT"
+            echo "server = \"https://${h}\""
+            echo "[host.\"https://${LOCAL_REGISTRY_HOST}\"]"
+            echo "  capabilities = [\"pull\", \"resolve\"]"
+            echo "  skip_verify = true"
+          } > "${certs_d}/${h}/hosts.toml.new"
+        else
+          # Upstream host → local Harbor project (override_path so containerd
+          # uses the URL path as the API root instead of appending its own /v2).
+          {
+            echo "# managed by bp-self-sovereign-cutover registry-pivot (#4975) — DO NOT EDIT"
+            echo "server = \"https://${h}\""
+            echo "[host.\"https://${LOCAL_REGISTRY_HOST}/v2/${p}\"]"
+            echo "  capabilities = [\"pull\", \"resolve\"]"
+            echo "  override_path = true"
+            echo "  skip_verify = true"
+          } > "${certs_d}/${h}/hosts.toml.new"
+        fi
+        mv "${certs_d}/${h}/hosts.toml.new" "${certs_d}/${h}/hosts.toml"
+        echo "[registry-pivot]   wrote ${h}/hosts.toml -> https://${LOCAL_REGISTRY_HOST}${p:+/v2/${p}} on ${NODE_NAME}"
+      done
     }
-    remove_default_mirror() {
-      rm -f "${certs_d}/_default/hosts.toml" 2>/dev/null || true
-      [ -n "${harbor_host:-}" ] && rm -f "${certs_d}/${harbor_host}/hosts.toml" 2>/dev/null || true
-      echo "[registry-pivot]   removed _default + ${harbor_host} hosts.toml (rollback) on ${NODE_NAME}"
+    remove_offline_mirror_hosts() {
+      [ -n "${LOCAL_REGISTRY_HOST:-}" ] && rm -f "${certs_d}/${LOCAL_REGISTRY_HOST}/hosts.toml" 2>/dev/null || true
+      for pair in ${HOST_PROJECT_MAP}; do
+        h="${pair%%:*}"
+        [ -z "${h}" ] && continue
+        rm -f "${certs_d}/${h}/hosts.toml" 2>/dev/null || true
+      done
+      echo "[registry-pivot]   removed offline-mirror per-host hosts.toml (rollback) on ${NODE_NAME}"
     }
 
     # #4652 (the x509 fix) — materialise the in-cluster Harbor trust anchor in
@@ -596,6 +635,24 @@ data:
       esac
     }
 
+    # #4975 — the step-07 catalyst-api re-pull GATE for the DIRECT path. Post
+    # #4975 containerd resolves each upstream host DIRECTLY to the local Harbor
+    # (registry.<fqdn>), NOT through the node-local dfdaemon, so the ack gate is
+    # "is the LOCAL Harbor serving /v2/" — not "is dfdaemon serving". Probe the
+    # local Harbor external host over :443 (reachable in-cluster via the gateway
+    # LB hairpin, #4682; -k tolerates the LE-staging wildcard). ANY HTTP status
+    # (200 or a 401/403/404 registry challenge) proves the listener is up; a
+    # connection-refused/timeout returns 000 → defer the v2 ack so the
+    # daemonset-wait keeps blocking until the local registry answers.
+    local_registry_serving() {
+      code=$(curl -s -o /dev/null -w '%{http_code}' ${CT} -k \
+        "https://${LOCAL_REGISTRY_HOST}/v2/" 2>/dev/null || true)
+      case "${code}" in
+        [1-5][0-9][0-9]) return 0 ;;
+        *) return 1 ;;
+      esac
+    }
+
     # #3671: per-node ack the daemonset-wait counts (proves EVERY node swapped
     # its containerd to the dfdaemon mirror, not merely that the DS Pods are
     # Ready). Key node.<NODE>.registriesYaml. Best-effort; retried each sweep.
@@ -613,23 +670,27 @@ data:
       desired="$1"
       case "${desired}" in
         v2)
-          # Per-node: point this node's containerd at the local dfdaemon.
-          write_default_mirror
-          # Cluster-wide (guarded): flip the dfdaemon upstream to the local Harbor.
+          # #4975 — per-node: write the PER-UPSTREAM-HOST containerd certs.d
+          # entries that resolve each upstream DIRECTLY to the local Harbor.
+          write_offline_mirror_hosts
+          # Cluster-wide (guarded): flip the dfdaemon upstream to the local
+          # Harbor too — BEST-EFFORT residual cover for any pull that still
+          # transits dfdaemon (e.g. a host bp-dragonfly dfinit mirrored that
+          # our per-host entries did not override). Not on the critical path.
           df_flip_to_local || true
-          # #4637 — ack v2 ONLY once the node-local dfdaemon is actually
-          # serving its registry endpoint. Acking while 127.0.0.1:${DF_PROXY_PORT}
-          # is dead would green the daemonset-wait → step-07 catalyst-api pull
-          # `connection refused`. Defer (no ack) so the wait keeps blocking; the
-          # reconcile loop re-probes every sweep (see the v2-ack retry guard).
-          if dfdaemon_serving; then
+          # #4975 — ack v2 ONLY once the LOCAL Harbor is actually serving /v2/
+          # (the DIRECT path containerd now uses). Acking while registry.<fqdn>
+          # is unreachable would green the daemonset-wait → step-07 catalyst-api
+          # pull fails. Defer (no ack) so the wait keeps blocking; the reconcile
+          # loop re-probes every sweep (see the v2-ack retry guard).
+          if local_registry_serving; then
             write_node_ack v2
           else
-            echo "[registry-pivot]   WARN node-local dfdaemon http://127.0.0.1:${DF_PROXY_PORT}/v2/ not serving yet on ${NODE_NAME}; DEFERRING v2 ack (step-07 must not pull into a dead mirror) — retry next sweep"
+            echo "[registry-pivot]   WARN local Harbor https://${LOCAL_REGISTRY_HOST}/v2/ not serving yet on ${NODE_NAME}; DEFERRING v2 ack (step-07 must not pull into a dead mirror) — retry next sweep"
           fi
           ;;
         v1|rollback|*)
-          remove_default_mirror
+          remove_offline_mirror_hosts
           df_revert_to_ghcr || true
           write_node_ack v1
           ;;

--- a/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
@@ -111,8 +111,42 @@ data:
           # not one hand-picked openova-io Deployment.
           - name: ROLL_ALL_EXTERNAL
             value: {{ eq (toString .Values.egressTest.rollAllExternalRegistryWorkloads) "true" | quote }}
+          # #4975 (Refs #3379 #3695) — the local registry substr that
+          # classifies the roll-set. DERIVED from sovereign.harborPublicURL's
+          # host (registry.<fqdn>) unless the operator overrides
+          # egressTest.localRegistryHostSubstr. The FULL host is used (not
+          # "harbor." nor a bare "registry.") so it excludes ONLY the local
+          # registry — not the mothership harbor.openova.io tether (which MUST
+          # be rolled) and not registry.k8s.io (an external upstream).
           - name: LOCAL_REGISTRY_SUBSTR
-            value: {{ .Values.egressTest.localRegistryHostSubstr | default "harbor." | quote }}
+            value: {{ .Values.egressTest.localRegistryHostSubstr | default (include "bp-self-sovereign-cutover.localRegistryHost" .) | quote }}
+          # #4975 — the offline-mirror coverage map + hosts, for the pre-hold
+          # completeness gate (HEAD every workload image against local Harbor)
+          # and the roll-set exclusions. Same env step-03/step-04 read.
+          - name: HOST_PROJECT_MAP
+            value: {{ include "bp-self-sovereign-cutover.hostProjectMapInline" . | quote }}
+          - name: EXCLUDED_HOSTS
+            value: {{ include "bp-self-sovereign-cutover.excludedHostsInline" . | quote }}
+          - name: EXCLUDED_SUBSTRINGS
+            value: {{ include "bp-self-sovereign-cutover.excludedSubstringsInline" . | quote }}
+          - name: LOCAL_REGISTRY_HOST
+            value: {{ include "bp-self-sovereign-cutover.localRegistryHost" . | quote }}
+          - name: MIRROR_COMPLETENESS_GATE
+            value: {{ eq (toString .Values.offlineMirror.enabled) "true" | quote }}
+          - name: HARBOR_PUBLIC_URL
+            value: {{ .Values.sovereign.harborPublicURL | quote }}
+          - name: HARBOR_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.harbor.adminSecretRef.name }}
+                key: {{ .Values.harbor.adminSecretRef.usernameKey }}
+                optional: true
+          - name: HARBOR_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.harbor.adminSecretRef.name }}
+                key: {{ .Values.harbor.adminSecretRef.passwordKey }}
+                optional: true
           # #3647 — fresh-pull-under-deny-egress proof knobs. See the
           # FRESH-PULL phase in the script below + values.yaml egressTest.
           # freshPullProof for the full rationale.
@@ -138,10 +172,31 @@ data:
           # /work is the one writable path; the manifest is written there.
           - name: work
             mountPath: /work
+          # #4975 — the shared offline-mirror resolver (same file step-03
+          # sources), so the pre-hold completeness gate maps each workload
+          # image to the local Harbor path step-03 pushed it to.
+          - name: offline-mirror-resolver
+            mountPath: /resolver
+            readOnly: true
         command: ["/bin/sh", "-c"]
         args:
           - |
             set -eu
+            : "${HARBOR_USERNAME:=admin}"
+
+            # #4975 — the offline-mirror image→local-path resolver (shared with
+            # step-03). Defines offlinemirror_local_paths over the SAME
+            # HOST_PROJECT_MAP / EXCLUDED_* / LOCAL_REGISTRY_HOST env, so the
+            # pre-hold completeness gate below HEADs the EXACT path step-03
+            # pushed each image to. Guard the source in case the resolver
+            # ConfigMap ever fails to mount (degrade to survival-poll, never
+            # wedge the cutover on a tooling gap).
+            if [ -r /resolver/resolver.sh ]; then
+              . /resolver/resolver.sh
+            else
+              echo "[egress-block-test] WARN /resolver/resolver.sh not mounted — offline-mirror completeness gate DISABLED this run"
+              MIRROR_COMPLETENESS_GATE="false"
+            fi
 
             # Architectural assertion phase — verifies the data-plane
             # pivots from Steps 5/6/7 are actually live BEFORE we begin
@@ -261,6 +316,75 @@ data:
             # skipped so intra-cluster traffic is never blocked. Fail-safe:
             # any resolve/apply error falls back to assertion-only and
             # NEVER wedges the cutover on a tooling failure.
+            # ── #4975 PRE-HOLD OFFLINE-MIRROR COMPLETENESS GATE ───────────
+            # BEFORE the deny-egress hold (egress still OPEN), HEAD every
+            # workload image against the LOCAL Harbor at the exact path the
+            # shared resolver maps it to. A missing manifest = an image that
+            # would ImagePullBackOff the moment its pod is rolled under the
+            # hold. FATAL-fast, NAMING the offender(s) — the systemic end of
+            # the per-prov whack-a-mole (an opaque mid-hold ImagePullBackOff
+            # becomes a clear "step-03 Phase A3 did not mirror <image>").
+            run_offline_mirror_completeness() {
+              echo "[egress-block-test] #4975: PRE-HOLD completeness — HEAD every workload image against local Harbor ${HARBOR_PUBLIC_URL}"
+              _base="${HARBOR_PUBLIC_URL}/v2"
+              _missing=""
+              _checked=0
+              _imgs=$(
+                for _kind in deployments daemonsets statefulsets; do
+                  kubectl get "${_kind}" -A -o jsonpath='{range .items[*]}{range .spec.template.spec.containers[*]}{.image}{"\n"}{end}{range .spec.template.spec.initContainers[*]}{.image}{"\n"}{end}{end}' 2>/dev/null
+                done | sort -u
+              )
+              for _img in ${_imgs}; do
+                [ -z "${_img}" ] && continue
+                _paths=$(offlinemirror_local_paths "${_img}")
+                case "${_paths}" in
+                  __UNMAPPED__*)
+                    _uh=$(printf '%s' "${_paths}" | awk '{print $2}')
+                    _missing="${_missing} UNMAPPED-HOST:${_uh}(${_img})"
+                    continue ;;
+                  "") continue ;;   # excluded by design — not mirrored
+                esac
+                for _lp in ${_paths}; do
+                  # Split "<repo>[:tag|@digest]" into repo + manifest ref.
+                  _repo="${_lp}"; _ref="latest"
+                  case "${_lp}" in
+                    *@*) _ref="${_lp##*@}"; _repo="${_lp%@*}"; case "${_repo##*/}" in *:*) _repo="${_repo%:*}" ;; esac ;;
+                    *) case "${_lp##*/}" in *:*) _ref="${_lp##*:}"; _repo="${_lp%:*}" ;; esac ;;
+                  esac
+                  # 3 attempts to absorb a transient Harbor blip (a genuine
+                  # 404/absent still FATALs — that is the whole point).
+                  _code=000
+                  _try=1
+                  while [ "${_try}" -le 3 ]; do
+                    _code=$(curl -sk -o /dev/null -w '%{http_code}' \
+                      -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
+                      -H "Accept: application/vnd.oci.image.manifest.v1+json,application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json" \
+                      -I "${_base}/${_repo}/manifests/${_ref}" 2>/dev/null || echo 000)
+                    case "${_code}" in 200|301|302) break ;; esac
+                    _try=$((_try+1)); [ "${_try}" -le 3 ] && sleep 3
+                  done
+                  _checked=$((_checked+1))
+                  case "${_code}" in
+                    200|301|302) : ;;
+                    *) _missing="${_missing} ${_img}=>${_repo}/manifests/${_ref}(HTTP:${_code})" ;;
+                  esac
+                done
+              done
+              if [ -n "${_missing}" ]; then
+                echo "  FAIL — offline mirror INCOMPLETE; these workload image(s) are NOT pullable from local Harbor (would ImagePullBackOff under the deny-egress hold):"
+                for _m in ${_missing}; do echo "    MISSING ${_m}"; done
+                return 1
+              fi
+              echo "  PASS — all ${_checked} mapped local path(s) present in local Harbor — offline mirror COMPLETE (#4975)"
+              return 0
+            }
+            if [ "${MIRROR_COMPLETENESS_GATE}" = "true" ] && [ -n "${HOST_PROJECT_MAP:-}" ]; then
+              if ! run_offline_mirror_completeness; then
+                echo "[egress-block-test] offline-mirror completeness FAILED before the hold — sovereignty proof FAILED (cutoverComplete stays false; fix step-03 Phase A3 / offlineMirror.hostProjects)"
+                exit 1
+              fi
+            fi
+
             POLICY_APPLIED=""
             if [ "${ENFORCE_CIDR_BLOCK}" = "true" ]; then
               echo "[egress-block-test] enforce mode ON — resolving upstream hosts to CIDRs"
@@ -620,6 +744,15 @@ data:
                 | grep -vE "[=, ]${LOCAL_REGISTRY_SUBSTR}" \
                 | { [ -n "${FRESH_PULL_EXCLUDE}" ] && grep -vE " ${FRESH_PULL_EXCLUDE}[^ ]*=" || cat; } \
                 || true)
+              # #4975 — never roll a workload the offline mirror deliberately
+              # does NOT cover: xpkg.upbound.io (step-11 crossplane), rancher/k3s
+              # (per-Org vcluster distro), loft-sh/vcluster (step-10). Rolling
+              # them under deny-egress would ImagePullBackOff on an image the
+              # mirror was never meant to hold and FAIL the proof spuriously.
+              for _x in ${EXCLUDED_HOSTS} ${EXCLUDED_SUBSTRINGS}; do
+                [ -z "${_x}" ] && continue
+                targets=$(printf '%s\n' "${targets}" | grep -vF "${_x}" || true)
+              done
               if [ -z "${targets}" ]; then
                 echo "  no external-registry workloads found — every workload already pulls from the local registry (PASS)"
                 return 0
@@ -905,3 +1038,9 @@ data:
       # dropped: the actual CCNP is generated inline + written here.)
       - name: work
         emptyDir: {}
+      - name: offline-mirror-resolver
+        configMap:
+          name: cutover-offline-mirror-resolver
+          items:
+            - key: resolver.sh
+              path: resolver.sh

--- a/platform/self-sovereign-cutover/chart/templates/_helpers.tpl
+++ b/platform/self-sovereign-cutover/chart/templates/_helpers.tpl
@@ -65,3 +65,60 @@ the same SA so RBAC is single-source.
 {{- define "bp-self-sovereign-cutover.serviceAccountName" -}}
 {{- printf "%s-runner" (include "bp-self-sovereign-cutover.name" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+── #4975 offline-mirror coverage map (single source of truth) ───────────────
+The bare host of the LOCAL Sovereign Harbor (registry.<fqdn>), derived from
+sovereign.harborPublicURL. Steps 03/04/08 all resolve the local registry from
+THIS one helper so "which host is local" is never hardcoded per-step (the
+"harbor." vs "registry." drift that made step-08 exclude the mothership tether
+and needlessly roll local refs).
+*/}}
+{{- define "bp-self-sovereign-cutover.localRegistryHost" -}}
+{{- .Values.sovereign.harborPublicURL | trimPrefix "https://" | trimPrefix "http://" | trimSuffix "/" -}}
+{{- end -}}
+
+{{/*
+The bare host of the MOTHERSHIP Harbor (harbor.openova.io), derived from
+upstream.mothershipHarborURL. Post-cutover this host is a tether: its
+`harbor.openova.io/proxy-<x>/PATH` refs host-swap to
+`registry.<fqdn>/proxy-<x>/PATH` (path preserved).
+*/}}
+{{- define "bp-self-sovereign-cutover.mothershipHost" -}}
+{{- .Values.upstream.mothershipHarborURL | trimPrefix "https://" | trimPrefix "http://" | trimSuffix "/" -}}
+{{- end -}}
+
+{{/*
+The host→local-Harbor-project coverage map, rendered as a single-line,
+env-safe, space-separated list of `host:project` tokens (empty project =
+host-swap/path-preserve, used for the mothership host whose path already
+carries the proxy-<x> project segment). Consumed VERBATIM by step-03
+(skopeo push dest), step-04 (containerd certs.d rewrite target) and step-08
+(pre-hold completeness HEAD) so all three derive identical local paths from
+one declaration — this is the retirement of the three hand-maintained lists.
+*/}}
+{{- define "bp-self-sovereign-cutover.hostProjectMapInline" -}}
+{{- $pairs := list -}}
+{{- range .Values.offlineMirror.hostProjects -}}
+{{- $pairs = append $pairs (printf "%s:%s" .host (.project | default "")) -}}
+{{- end -}}
+{{- join " " $pairs -}}
+{{- end -}}
+
+{{/*
+Hosts EXCLUDED from the offline mirror (handled elsewhere / un-mirrorable):
+xpkg.upbound.io is pivoted by step-11 (crossplaneProviderPivot) and bypasses
+containerd. Space-separated, env-safe.
+*/}}
+{{- define "bp-self-sovereign-cutover.excludedHostsInline" -}}
+{{- .Values.offlineMirror.excludedHosts | default (list) | join " " -}}
+{{- end -}}
+
+{{/*
+Image-path substrings EXCLUDED from the offline mirror + the step-08 roll-set
+(rancher/k3s = per-Org vcluster distro, un-mirrorable on the host plane;
+loft-sh/vcluster = handled by step-10 vcluster-registry-pivot). Space-separated.
+*/}}
+{{- define "bp-self-sovereign-cutover.excludedSubstringsInline" -}}
+{{- .Values.offlineMirror.excludedImageSubstrings | default (list) | join " " -}}
+{{- end -}}

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -1399,4 +1399,87 @@ if ! grep -Eq 'activeDeadlineSeconds:\s*2100' "$TMP/render-fire.yaml"; then
 fi
 echo "  PASS (auto-trigger POST is wrapped in a bounded while-loop that retries on HTTP 425 until the handover seals — no single give-up exit; activeDeadlineSeconds=2100 covers the wait)"
 
+# ── Case 30 (#4975 Refs #3379 #3695): OFFLINE-MIRROR coverage-map wiring ──────
+# The systemic end of the step-08 whack-a-mole: ONE coverage map
+# (offlineMirror.hostProjects) consumed by step-03 (push), step-04 (containerd
+# rewrite) AND step-08 (pre-hold completeness HEAD), + the shared resolver
+# ConfigMap, + the PUBLIC push-mode mirror projects, + the fail-fast completeness
+# gate. Lock in the wiring so a future edit can't silently drift a consumer back
+# to a hand-list.
+echo "[cutover-contract] Case 37: offline-mirror coverage map wired into steps 03/04/08 + shared resolver"
+# (a) the shared resolver ConfigMap renders and is NOT counted as a step.
+if ! grep -q 'name: cutover-offline-mirror-resolver' "$TMP/render.yaml"; then
+  echo "FAIL: shared offline-mirror resolver ConfigMap (cutover-offline-mirror-resolver) not rendered (#4975)" >&2
+  exit 1
+fi
+if ! grep -q 'offlinemirror_local_paths' "$TMP/render.yaml"; then
+  echo "FAIL: resolver ConfigMap missing the offlinemirror_local_paths function (#4975)" >&2
+  exit 1
+fi
+# (b) the map env is rendered in ALL THREE consuming steps (03/04/08). Count the
+#     HOST_PROJECT_MAP env occurrences — must be >=3 (one per consuming step).
+hpm_count=$(grep -c 'name: HOST_PROJECT_MAP' "$TMP/render.yaml")
+if [ "${hpm_count}" -lt 3 ]; then
+  echo "FAIL: HOST_PROJECT_MAP env present ${hpm_count}x, expected >=3 (steps 03/04/08 must all consume the SAME coverage map) (#4975)" >&2
+  exit 1
+fi
+# (c) the map value carries the mothership host-swap entry (empty project) AND a
+#     real upstream mapping — proving both shapes render.
+if ! grep -q 'harbor.openova.io:' "$TMP/render.yaml"; then
+  echo "FAIL: coverage map missing the mothership host-swap entry harbor.openova.io: (empty project) (#4975)" >&2
+  exit 1
+fi
+if ! grep -q 'ghcr.io:proxy-ghcr' "$TMP/render.yaml"; then
+  echo "FAIL: coverage map missing the ghcr.io:proxy-ghcr mapping (#4975)" >&2
+  exit 1
+fi
+# (d) step-02 creates the PUBLIC push-mode mirror projects (public:true) so
+#     anonymous pull works under the deny-egress hold.
+if ! grep -q 'ensuring public offline-mirror project' "$TMP/render.yaml"; then
+  echo "FAIL: step-02 does not create the public offline-mirror push projects (harbor.mirrorProjects) (#4975)" >&2
+  exit 1
+fi
+# (e) step-04 writes PER-UPSTREAM-HOST certs.d entries (NOT the _default dfdaemon
+#     catch-all) and removes the legacy _default.
+if ! grep -q 'write_offline_mirror_hosts' "$TMP/render.yaml"; then
+  echo "FAIL: step-04 registry-pivot does not write per-upstream-host certs.d entries (write_offline_mirror_hosts) (#4975)" >&2
+  exit 1
+fi
+# (f) step-08 runs the PRE-HOLD completeness gate.
+if ! grep -q 'run_offline_mirror_completeness' "$TMP/render.yaml"; then
+  echo "FAIL: step-08 missing the pre-hold offline-mirror completeness gate (#4975)" >&2
+  exit 1
+fi
+# (g) step-08 LOCAL_REGISTRY_SUBSTR is DERIVED from the local Harbor host, NOT
+#     the old literal "harbor." (which excluded the mothership tether).
+if grep -A1 'name: LOCAL_REGISTRY_SUBSTR' "$TMP/render.yaml" | grep -q 'value: "harbor."'; then
+  echo "FAIL: LOCAL_REGISTRY_SUBSTR still defaults to the buggy \"harbor.\" (excludes the mothership tether from the roll-set) (#4975)" >&2
+  exit 1
+fi
+if ! grep -A1 'name: LOCAL_REGISTRY_SUBSTR' "$TMP/render.yaml" | grep -q 'value: "registry\.'; then
+  echo "FAIL: LOCAL_REGISTRY_SUBSTR is not derived from the local Harbor host (registry.<fqdn>) (#4975)" >&2
+  exit 1
+fi
+echo "  PASS (coverage map + shared resolver wired into steps 03/04/08; public mirror projects; completeness gate; LOCAL_REGISTRY_SUBSTR derived)"
+
+# ── Case 31 (#4975): image-registry coverage GUARDRAIL + negative test ───────
+# Every bootstrap-kit workload image host MUST be in the coverage map (or
+# excluded). The guardrail's --self-test proves an un-mapped host FAILS; the
+# real scan proves the current repo is 100% covered.
+echo "[cutover-contract] Case 38: image-registry coverage guardrail (+ negative test)"
+COVERAGE="$(dirname "$0")/image-registry-coverage.sh"
+if [ ! -x "${COVERAGE}" ] && [ ! -f "${COVERAGE}" ]; then
+  echo "FAIL: image-registry-coverage.sh guardrail missing (#4975)" >&2
+  exit 1
+fi
+if ! bash "${COVERAGE}" --self-test >/dev/null 2>&1; then
+  echo "FAIL: coverage guardrail --self-test did not catch an un-mapped registry host (guardrail is inert) (#4975)" >&2
+  exit 1
+fi
+if ! bash "${COVERAGE}" >/dev/null 2>&1; then
+  echo "FAIL: coverage guardrail found a bootstrap-kit image host NOT in the offline-mirror map — run tests/image-registry-coverage.sh for the offender (#4975)" >&2
+  exit 1
+fi
+echo "  PASS (guardrail negative test green; every scanned bootstrap-kit image host is covered)"
+
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/tests/image-registry-coverage.sh
+++ b/platform/self-sovereign-cutover/chart/tests/image-registry-coverage.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# bp-self-sovereign-cutover — offline-mirror IMAGE-REGISTRY COVERAGE guardrail
+# (#4975 Refs #3379 #3695).
+#
+# THE WHACK-A-MOLE TRAP, CLOSED AT AUTHORING TIME. The step-08 deny-egress proof
+# converges only if the local Harbor is a COMPLETE offline mirror of every
+# workload image. step-03 mirrors + step-04 rewrites strictly what the coverage
+# map (chart values.yaml `offlineMirror.hostProjects` + `.excludedHosts`) covers.
+# So the ONE thing that can silently re-open the whack-a-mole is a chart adding
+# an image from a registry host the map does not cover. This guardrail scans
+# every bootstrap-kit slot's container-image refs and FAILS the build the moment
+# a ref's registry host is neither mapped nor explicitly excluded — BEFORE it can
+# wedge a live cutover mid deny-egress hold.
+#
+# It reads the coverage map from the SAME chart values.yaml the runtime steps
+# render from (single source of truth) — nothing to keep in sync.
+#
+# Usage:
+#   tests/image-registry-coverage.sh            # scan the repo's bootstrap-kit slots
+#   tests/image-registry-coverage.sh --self-test # negative test: an un-mapped host FAILS
+#
+# Exit: 0 = every scanned host is covered (or excluded); 1 = at least one
+# un-mapped host (named); 2 = tool/input error.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CHART_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+VALUES="${CHART_DIR}/values.yaml"
+
+# Repo root — the chart lives at platform/self-sovereign-cutover/chart, so the
+# repo root is four levels up. Allow override for CI layouts.
+REPO_ROOT="${REPO_ROOT:-$(cd "${CHART_DIR}/../../.." && pwd)}"
+SLOT_DIR="${SLOT_DIR:-${REPO_ROOT}/clusters/_template/bootstrap-kit}"
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo "ERROR: yq not installed" >&2; exit 2
+fi
+if [ ! -f "${VALUES}" ]; then
+  echo "ERROR: chart values.yaml not found at ${VALUES}" >&2; exit 2
+fi
+
+# ── Coverage sets from the chart values (single source of truth) ─────────────
+MAPPED_HOSTS="$(yq -r '.offlineMirror.hostProjects[].host' "${VALUES}" | sort -u)"
+EXCLUDED_HOSTS="$(yq -r '.offlineMirror.excludedHosts[]' "${VALUES}" 2>/dev/null | sort -u || true)"
+EXCLUDED_SUBSTR="$(yq -r '.offlineMirror.excludedImageSubstrings[]' "${VALUES}" 2>/dev/null || true)"
+
+host_covered() {
+  # $1 = registry host. Covered if mapped OR excluded OR docker.io (bare images).
+  _h="$1"
+  [ "${_h}" = "docker.io" ] && return 0
+  for _m in ${MAPPED_HOSTS}; do [ "${_h}" = "${_m}" ] && return 0; done
+  for _e in ${EXCLUDED_HOSTS}; do [ "${_h}" = "${_e}" ] && return 0; done
+  return 1
+}
+
+is_excluded_substr() {
+  # $1 = full image ref. True if it contains an excluded substring.
+  _r="$1"
+  for _s in ${EXCLUDED_SUBSTR}; do
+    case "${_r}" in *"${_s}"*) return 0 ;; esac
+  done
+  return 1
+}
+
+ref_host() {
+  # $1 = image ref. Prints its registry host, or "" to SKIP (templated/local).
+  _r="$1"
+  # Strip an oci:// scheme (chart repos); ghcr.io is mapped anyway.
+  _r="${_r#oci://}"
+  # Templated (registry.${SOVEREIGN_FQDN}, ${VAR}/...) → local/dynamic → skip.
+  case "${_r}" in *'${'*|*'}'*) printf ''; return 0 ;; esac
+  case "${_r}" in
+    */*)
+      _h="${_r%%/*}"
+      case "${_h}" in
+        *.*|*:*|localhost) printf '%s' "${_h}" ;;
+        *) printf 'docker.io' ;;    # docker.io namespaced (e.g. grafana/loki)
+      esac
+      ;;
+    *) printf 'docker.io' ;;        # bare official image
+  esac
+}
+
+scan_refs() {
+  # Emit candidate image refs (host-bearing) from the given files. Matches
+  # `image:`, `repository:`, `package:`, `spec.package:` values; strips quotes
+  # and inline comments; ignores comment-only lines.
+  grep -rhoE '^[[:space:]]*(image|repository|package):[[:space:]]*["'\'']?[A-Za-z0-9_./:$?{}%-]+' "$@" 2>/dev/null \
+    | sed -E 's/^[[:space:]]*(image|repository|package):[[:space:]]*["'\'']?//' \
+    | sed -E 's/["'\''].*$//' \
+    | grep -vE '^[[:space:]]*$' \
+    | sort -u
+}
+
+run_scan() {
+  echo "[image-registry-coverage] coverage map (hosts): $(echo "${MAPPED_HOSTS}" | tr '\n' ' ')"
+  echo "[image-registry-coverage] excluded hosts: $(echo "${EXCLUDED_HOSTS}" | tr '\n' ' ')"
+  echo "[image-registry-coverage] scanning $# file(s)"
+  local refs uncovered n_refs n_hosts
+  refs="$(scan_refs "$@")"
+  uncovered=""
+  n_refs=0
+  seen_hosts=""
+  while IFS= read -r ref; do
+    [ -z "${ref}" ] && continue
+    is_excluded_substr "${ref}" && continue
+    h="$(ref_host "${ref}")"
+    [ -z "${h}" ] && continue     # templated/local → skip
+    n_refs=$((n_refs+1))
+    case " ${seen_hosts} " in *" ${h} "*) : ;; *) seen_hosts="${seen_hosts} ${h}" ;; esac
+    if ! host_covered "${h}"; then
+      uncovered="${uncovered}\n  UNMAPPED host '${h}'  (ref: ${ref})"
+    fi
+  done <<EOF
+${refs}
+EOF
+  n_hosts="$(echo "${seen_hosts}" | wc -w | tr -d ' ')"
+  echo "[image-registry-coverage] checked ${n_refs} host-bearing image ref(s) across ${n_hosts} distinct host(s)"
+  if [ -n "${uncovered}" ]; then
+    echo "FAIL: image ref(s) from registry host(s) NOT in the offline-mirror coverage map (offlineMirror.hostProjects) and NOT excluded:" >&2
+    printf '%b\n' "${uncovered}" >&2
+    echo "" >&2
+    echo "FIX: add the host→project to platform/self-sovereign-cutover/chart/values.yaml offlineMirror.hostProjects (and harbor.mirrorProjects), or add it to offlineMirror.excludedHosts if it is handled outside the containerd mirror." >&2
+    return 1
+  fi
+  echo "  PASS — every scanned image host is covered by the offline-mirror map (or excluded)."
+  return 0
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+  # NEGATIVE TEST: prove an un-mapped registry host FAILS the guardrail.
+  TMP="$(mktemp -d)"; trap 'rm -rf "${TMP}"' EXIT
+  cat > "${TMP}/slot.yaml" <<'YAML'
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+spec:
+  values:
+    image:
+      repository: totally-unmapped.example.net/foo/bar
+      tag: "1.0"
+YAML
+  echo "[image-registry-coverage] --self-test: an image from 'totally-unmapped.example.net' MUST fail the guardrail"
+  if run_scan "${TMP}" >/dev/null 2>&1; then
+    echo "SELF-TEST FAIL: an un-mapped registry host was NOT caught — the guardrail is inert." >&2
+    exit 1
+  fi
+  echo "  PASS — un-mapped host correctly FAILED the guardrail (negative test green)."
+  # And prove the covered case passes.
+  cat > "${TMP}/slot-ok.yaml" <<'YAML'
+spec:
+  values:
+    image:
+      repository: harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql
+YAML
+  rm -f "${TMP}/slot.yaml"
+  if ! run_scan "${TMP}" >/dev/null 2>&1; then
+    echo "SELF-TEST FAIL: a mapped host (harbor.openova.io) was wrongly rejected." >&2
+    exit 1
+  fi
+  echo "  PASS — mapped host correctly ACCEPTED (positive control green)."
+  exit 0
+fi
+
+if [ ! -d "${SLOT_DIR}" ]; then
+  echo "WARN: bootstrap-kit slot dir not found at ${SLOT_DIR} — set SLOT_DIR or REPO_ROOT. Skipping repo scan." >&2
+  exit 0
+fi
+# Scan surface = every place a bootstrap-kit workload image host is statically
+# pinned in this repo: the slot overrides AND every platform/products chart
+# values.yaml (where bp-* charts pin image.repository hosts). The actual image
+# TAGS live in the OCI charts, but the HOST — the only thing this guardrail
+# checks — is pinned here. Templated refs (registry.${SOVEREIGN_FQDN},
+# ${REGISTRY_MIRROR:=…}) are skipped (dynamic/local).
+SCAN_FILES="$(
+  find "${SLOT_DIR}" -maxdepth 1 -name '*.yaml' 2>/dev/null
+  find "${REPO_ROOT}/platform" -path '*/chart/values.yaml' 2>/dev/null
+  find "${REPO_ROOT}/products" -path '*/chart/values.yaml' 2>/dev/null
+)"
+# shellcheck disable=SC2086
+run_scan ${SCAN_FILES}

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -407,51 +407,110 @@ harbor:
   # The `openova-io` project name matches the path segment in
   # ghcr.io/openova-io/openova/<svc>:<tag> — Phase A copies to
   # registry.<sov>/openova-io/openova/<svc>:<tag>, dropping only
-  # the `ghcr.io/` host prefix.
+  # the `ghcr.io/` host prefix. Kept private (public:false) — the
+  # Sovereign HTTPRoute + Kyverno glob gate anonymous pull of this
+  # project, per CLAUDE.md §pushProjects.
   pushProjects:
     - "openova-io"
-  # Seven proxy-cache projects + their upstream registry endpoints.
-  # Names are stable because step 06 (helmrepository-patches) +
-  # registries.yaml v2 (registry-pivot) rewrite paths against these
-  # literal project names.
+  # #4975 (Refs #3379 #3695) — the OFFLINE-MIRROR push projects. These
+  # REPLACE the former proxy-cache projects for every upstream host containerd
+  # can reach (docker.io / ghcr.io / quay.io / registry.k8s.io / gcr.io /
+  # public.ecr.aws). A proxy-cache project CANNOT survive the step-08
+  # deny-egress hold (its back-to-source to the upstream OR the mothership is
+  # black-holed), so a workload image that was never node-cached
+  # ImagePullBackOffs the moment its pod is rolled. Step-03 Phase A3 skopeo-
+  # PUSHES a COMPLETE copy of every workload image into these projects; step-04
+  # rewrites containerd to serve them from the local Harbor. That is a real
+  # offline mirror, not a warm cache subject to eviction.
+  #
+  # PUBLIC (public:true) so an upstream-image pod that carries NO
+  # imagePullSecret (the common case — it pulled anonymously from docker.io
+  # pre-cutover) still pulls anonymously post-rewrite; the proxy-cache projects
+  # these replace were public:true, so this preserves the proven anon-pull
+  # behaviour. Step 02 ensures these exist (harbor.mirrorProjects loop).
+  #
+  # Names MATCH the MOTHERSHIP Harbor project names (proxy-dockerhub, not
+  # proxy-docker) so a `harbor.openova.io/proxy-<x>/PATH` ref host-swaps to
+  # `registry.<fqdn>/proxy-<x>/PATH` with the path segment preserved — the
+  # dominant bootstrap-kit image shape (cnpg, kubectl, csi, …).
+  mirrorProjects:
+    - "proxy-ghcr"
+    - "proxy-dockerhub"
+    - "proxy-quay"
+    - "proxy-k8s"
+    - "proxy-gcr"
+    - "proxy-ecr"
+  # Proxy-cache project(s) that REMAIN pull-through. Only `proxy-xpkg`:
+  # Crossplane's xpkg fetcher (internal/xpkg/fetch.go remote.Image) bypasses
+  # the node containerd mirror, so step-11 (crossplaneProviderPivot) — NOT the
+  # step-04 containerd rewrite — owns the xpkg tether. xpkg is EXCLUDED from
+  # the offline mirror (offlineMirror.excludedHosts) so the step-08
+  # completeness gate + roll-set never flag it. Names are stable because
+  # step 11 rewrites Provider spec.package against this literal project name.
   proxyProjects:
-    - name: "proxy-ghcr"
-      upstreamURL: "https://ghcr.io"
-      # Harbor adapter "github-ghcr" (the canonical GHCR proxy-cache
-      # adapter), with `docker-registry` fallback for older Harbor
-      # versions. Caught live on otech103 2026-05-04 (was "github" →
-      # "adapter factory for github not found"). Per Harbor 2.x docs.
-      registryType: "github-ghcr"
-      authMode: "credential"      # uses harbor.ghcrSecretRef
-    - name: "proxy-docker"
-      upstreamURL: "https://registry-1.docker.io"
-      registryType: "docker-hub"
-      authMode: "anonymous"
-    - name: "proxy-k8s"
-      upstreamURL: "https://registry.k8s.io"
-      registryType: "docker-registry"
-      authMode: "anonymous"
-    - name: "proxy-gcr"
-      upstreamURL: "https://gcr.io"
-      registryType: "docker-registry"
-      authMode: "anonymous"
-    - name: "proxy-quay"
-      upstreamURL: "https://quay.io"
-      # docker-registry adapter — Harbor's "quay" type is internal/legacy
-      # and rejects project metadata.proxy_cache=true with HTTP 400
-      # "unsupported registry type quay". Quay speaks plain v2 so the
-      # generic docker-registry adapter is the right shape. Caught live
-      # on otech103 2026-05-04.
-      registryType: "docker-registry"
-      authMode: "anonymous"
     - name: "proxy-xpkg"
       upstreamURL: "https://xpkg.upbound.io"
       registryType: "docker-registry"
       authMode: "anonymous"
-    - name: "proxy-ecr"
-      upstreamURL: "https://public.ecr.aws"
-      registryType: "docker-registry"
-      authMode: "anonymous"
+
+# #4975 (Refs #3379 #3695) — the OFFLINE-MIRROR coverage map: the SINGLE
+# source of truth that retires the three hand-maintained lists (step-03
+# ghcr-only push filter, prewarm.images, imageRegistryPivot.additionalHRs)
+# whose drift caused the per-prov whack-a-mole (each fresh prov surfaced a new
+# residual image tether the deny-egress hold caught mid-window).
+#
+# HOW IT ENDS THE WHACK-A-MOLE. Three cutover steps all consume THIS map, so
+# they can never disagree about where an image lives locally:
+#   • step-03 Phase A3 skopeo-PUSHES every enumerated workload image into
+#     registry.<fqdn>/<project>/<path> (host-drop for openova-io; host-swap for
+#     the mothership; <project>/<path> for a direct upstream host);
+#   • step-04 rewrites the node's containerd certs.d so a pull of that upstream
+#     host resolves to EXACTLY that local path;
+#   • step-08 HEADs registry.<fqdn>/v2/<local-path>/manifests/<tag> BEFORE the
+#     deny-egress hold and FATALs (naming the offender) if any is absent —
+#     turning an opaque mid-hold ImagePullBackOff into a fail-fast.
+# A chart that introduces an image from an un-mapped host FAILS the CI
+# guardrail (tests/image-registry-coverage.sh) at authoring time.
+offlineMirror:
+  enabled: true
+  # host → local Harbor project. project "" = host-swap, path preserved (the
+  # mothership host, whose path already carries the proxy-<x> segment).
+  hostProjects:
+    - host: "ghcr.io"
+      project: "proxy-ghcr"
+    - host: "docker.io"
+      project: "proxy-dockerhub"
+    - host: "registry-1.docker.io"
+      project: "proxy-dockerhub"
+    - host: "index.docker.io"
+      project: "proxy-dockerhub"
+    - host: "quay.io"
+      project: "proxy-quay"
+    - host: "registry.k8s.io"
+      project: "proxy-k8s"
+    - host: "gcr.io"
+      project: "proxy-gcr"
+    - host: "k8s.gcr.io"
+      project: "proxy-gcr"
+    - host: "public.ecr.aws"
+      project: "proxy-ecr"
+    # MOTHERSHIP — host-swap, path preserved. Must equal the host of
+    # upstream.mothershipHarborURL. Empty project because the path already
+    # carries the proxy-<x> project (e.g. proxy-ghcr/cloudnative-pg/postgresql).
+    - host: "harbor.openova.io"
+      project: ""
+  # Hosts whose images are NOT mirrored (handled elsewhere / un-mirrorable).
+  excludedHosts:
+    # Crossplane package host — step-11 crossplaneProviderPivot owns it; the
+    # xpkg fetcher bypasses containerd, so a containerd mirror is inert for it.
+    - "xpkg.upbound.io"
+  # Image-path substrings NEVER mirrored NOR rolled under deny-egress.
+  excludedImageSubstrings:
+    # per-Org vcluster distro image — un-mirrorable on the host plane (it runs
+    # inside each Org's vcluster, not a host workload).
+    - "rancher/k3s"
+    # vcluster control-plane image — step-10 vcluster-registry-pivot owns it.
+    - "loft-sh/vcluster"
 
 # Pre-warm list — images to HEAD-pull through Harbor proxy-cache before
 # the cluster reconciles against local Harbor, so first-reconcile pulls
@@ -505,18 +564,16 @@ prewarm:
   # trust store may set this true via overlay; default false is the correct
   # fresh-prov behaviour.
   destTLSVerify: false
-  images:
-    - "proxy-docker/library/redis:7"
-    - "proxy-docker/library/postgres:16"
-    - "proxy-quay/cilium/cilium:v1.16.5"
-    - "proxy-quay/jetstack/cert-manager-controller:v1.16.1"
-    - "proxy-quay/kyverno/kyverno:v1.13.4"
-    - "proxy-docker/grafana/loki:3.3.2"
-    - "proxy-docker/grafana/grafana:11.4.0"
-    - "proxy-docker/grafana/alloy:v1.5.1"
-    - "proxy-docker/falcosecurity/falco:0.39.2"
-    - "proxy-ghcr/fluxcd/source-controller:v1.4.1"
-    - "proxy-ghcr/fluxcd/helm-controller:v1.1.0"
+  # #4975 (Refs #3379 #3695) — RETIRED. This hand-maintained 11-image HEAD list
+  # (the old Phase B "warm the proxy-cache" pass) was one of the three drifting
+  # lists that caused the per-prov whack-a-mole: any upstream image a chart added
+  # but this list omitted was never warmed, so under the deny-egress hold its
+  # roll ImagePullBackOff'd. Coverage now comes from step-03 Phase A3's LIVE
+  # enumeration (every running Pod ∪ declared workload template image), pushed
+  # into the offlineMirror push projects — nothing to keep in sync. Left as an
+  # empty list (Phase B is a no-op) for back-compat with overlays that still set
+  # it; an operator MAY still HEAD-warm a proxy-cache project via overlay.
+  images: []
 
 # GitOps source — Flux GitRepository in flux-system namespace that step
 # 05 (flux-gitrepository-patch) patches to point at local Gitea.
@@ -740,6 +797,17 @@ catalystAPI:
 # registry-aware AND lists their HRs in additionalHRs below, so step-07 pivots
 # them with the identical live-HR-patch + durable-Gitea-edit pattern. With that,
 # NO openova-io-image HR is left un-pivoted — there is no remaining residual.
+# #4975 (Refs #3379 #3695 #4885): DEMOTED to an OPTIONAL fallback. step-07's
+# global.imageRegistry pivot (this list) is now a BELT to the step-04 offline
+# mirror's SUSPENDERS: even an openova-io-image HR whose chart does NOT honour
+# global.imageRegistry — so step-07 leaves it on a literal ghcr.io/openova-io ref
+# — survives the step-08 deny-egress hold, because step-03 Phase A3 pushed that
+# image into registry.<fqdn>/proxy-ghcr/openova-io/<path> and step-04 rewrites
+# ghcr.io → that local path. So a chart missing from this list no longer FATALs
+# the cutover (the old whack-a-mole). The list is KEPT because pivoting the HR to
+# global.imageRegistry is still the CLEANER end-state (the pod ref reads
+# registry.<fqdn> directly, no containerd rewrite dependency) — but it is no
+# longer the sole thing standing between a new chart and a wedged cutover.
 imageRegistryPivot:
   additionalHRs:
     - name: bp-continuum
@@ -1021,7 +1089,23 @@ egressTest:
   # demands. localRegistryHostSubstr identifies the local registry so a
   # Sovereign on a non-harbor.<fqdn> registry name overrides via 06a.
   rollAllExternalRegistryWorkloads: true
-  localRegistryHostSubstr: "harbor."
+  # #4975 (Refs #3379 #3695) — the substring that identifies the LOCAL Sovereign
+  # registry so the roll-set EXCLUDES local refs and INCLUDES the mothership
+  # tether. DEFAULT "" → step-08 DERIVES it at runtime from the host of
+  # sovereign.harborPublicURL (registry.<fqdn>) via the
+  # bp-self-sovereign-cutover.localRegistryHost helper.
+  #
+  # WHY the old value was doubly wrong. The chart default was "harbor." and the
+  # 06a overlay set "registry." — BOTH misclassify:
+  #   • "harbor." EXCLUDED harbor.openova.io/proxy-* workloads (the #4975 gitea
+  #     leg — the DOMINANT mothership tether) from the roll-set, so the tether
+  #     was never proven severed, AND it did NOT match the real local host
+  #     registry.<fqdn> so genuine local refs WERE needlessly rolled;
+  #   • "registry." matched registry.k8s.io (an EXTERNAL upstream that MUST be
+  #     rolled) as if it were local, so k8s-registry workloads were skipped.
+  # The FULL host registry.<fqdn> classifies correctly in every case. An
+  # operator on a non-registry.<fqdn> local registry name overrides here.
+  localRegistryHostSubstr: ""
   blockedDomains:
     - "github.com"
     - "ghcr.io"

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5041,7 +5041,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.93"
+  version: "0.1.114"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.113"
+    version: "0.1.114"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## What & why

The self-sovereign cutover (issue #3379) **step-08 deny-egress proof** previously converged only per-chart-set: each fresh prov surfaced a **new residual image tether** the 600s deny-egress hold caught mid-window. Root cause (verified by ticket-history analysis): the set of images the cutover makes locally-pullable came from **THREE independently hand-maintained lists** that each drifted behind the growing chart set, while the LOCAL Harbor proxy-cache projects were cold/unreachable under deny-egress:

- (a) step-03 Phase-A skopeo push was filtered to `^ghcr.io/openova-io/` only — no non-openova upstream reached local Harbor;
- (b) `prewarm.images` was a hardcoded 11-image HEAD list;
- (c) step-07 `imageRegistryPivot.additionalHRs` was a hand-listed set.

Plus a secondary classifier bug: `egressTest.localRegistryHostSubstr` defaulted to `"harbor."` (excludes the real `harbor.openova.io/proxy-*` mothership tether from the roll-set **and** needlessly rolls local `registry.<fqdn>/*` refs); the 06a overlay's `"registry."` also wrongly matched `registry.k8s.io`.

## The systemic fix

Make the local Harbor a **COMPLETE, dynamically-derived offline mirror + per-host containerd rewrite**, retire the hand-lists, add a completeness gate + CI guardrail — all from **ONE coverage map** (`offlineMirror.hostProjects`) that three steps consume so they can never disagree.

| Step | Change |
|---|---|
| **03** (`03-harbor-prewarm-job.yaml`) | Phase A3: DROP the `ghcr.io/openova-io` grep filter; skopeo-PUSH **every** enumerated workload image (running Pods ∪ declared templates) into `registry.<fqdn>/<project>/<path>` via the shared resolver, per-host `--src-creds` (ghcr PAT / mothership / anonymous). Pre-pass FATAL fail-fast on an un-mapped host. FATAL-on-any-failure preserved; Phase A2 chart-mirror unchanged. |
| **04** (`04-registry-pivot-daemonset.yaml`) | REPLACE the single `_default` dfdaemon catch-all with PER-UPSTREAM-HOST `certs.d/<host>/hosts.toml` entries resolving each host DIRECTLY to the local Harbor project (`override_path`), + a host-swap entry for the mothership (path preserved). v2 ack gates on the LOCAL Harbor serving `/v2/`, not dfdaemon. |
| **08** (`08-egress-block-test-job.yaml`) | PRE-HOLD completeness gate: HEAD every workload image against local Harbor, FATAL (naming the offender) if absent. FIX `localRegistryHostSubstr` to DERIVE the full local host `registry.<fqdn>`. Exclude xpkg / rancher-k3s / loft-sh-vcluster from the roll-set. Strict ImagePullBackOff FAIL branch intact. |

Local `proxy-*` projects become **PUBLIC push-mode offline mirrors** (`step-02` + `harbor.mirrorProjects`); only `proxy-xpkg` stays proxy-cache (step-11 crossplane bypasses containerd). Shared resolver ConfigMap (`03a-offline-mirror-resolver.yaml`) is the code half of the retirement; `imageRegistryPivot.additionalHRs` demoted to fallback.

### Host to local-Harbor-project coverage map
| upstream host | local project | rewrite |
|---|---|---|
| `ghcr.io` | `proxy-ghcr` (+ host-drop `openova-io/` for `openova-io/*`) | override_path |
| `docker.io` / `registry-1.docker.io` / `index.docker.io` | `proxy-dockerhub` | override_path |
| `quay.io` | `proxy-quay` | override_path |
| `registry.k8s.io` | `proxy-k8s` | override_path |
| `gcr.io` / `k8s.gcr.io` | `proxy-gcr` | override_path |
| `public.ecr.aws` | `proxy-ecr` | override_path |
| `harbor.openova.io` (mothership) | `""` — path preserved | host-swap |
| `registry.<fqdn>` (local) | served directly (openova-io host-drop) | self-trust |
| `xpkg.upbound.io` | EXCLUDED — step-11 crossplaneProviderPivot | — |
| `rancher/k3s`, `loft-sh/vcluster` | EXCLUDED — per-Org vcluster / step-10 | — |

## Verification (all green)
- `helm lint` + `helm template` (default + fireCutover) render clean; `sh -n` on all 12 embedded scripts + `bash -n` on both test scripts pass.
- `tests/cutover-contract.sh`: **40 PASS**, incl. new Cases 37 (coverage-map wiring in steps 03/04/08 + resolver + public mirror projects + completeness gate + derived `LOCAL_REGISTRY_SUBSTR`) and 38 (guardrail negative + real scan).
- **Render-time coverage: 100%** — `tests/image-registry-coverage.sh` scans all bootstrap-kit slots + platform/products chart values (151 host-bearing refs across 6 distinct hosts: `harbor.openova.io`, `ghcr.io`, `docker.io`, `registry.k8s.io`, `gcr.io`, `quay.io`) — every host mapped.
- **Negative CI test**: an image from an un-mapped host (`totally-unmapped.example.net`) FAILS the guardrail; positive control passes.
- Resolver unit-tested across openova-io dual-dest / mothership host-swap / docker library / bare names / digest+tag / excluded / unmapped.
- `check-bootstrap-kit-pin-sync.sh` + `check-catalog-seed-lockstep.sh` green. Chart 0.1.112 → 0.1.113; blueprint + slot-06a pin bumped in lockstep.
- No CI-banned words in the diff or this body.

**Excluded images** (by design, noted in the map): `xpkg.upbound.io/*` (step-11 handles it, bypasses containerd); `rancher/k3s` (per-Org vcluster distro, un-mirrorable on the host plane); `loft-sh/vcluster` (step-10).

Not merged — the pillar-5 deny-egress proof is verified on a live cutover walk.

Refs #4975 #3379 #3695

🤖 Generated with [Claude Code](https://claude.com/claude-code)