### PR TITLE
fix(#4975): map mirror.gcr.io (bp-trivy) into cutover offline-mirror + catch split registry: at CI

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -773,7 +773,7 @@ spec:
       # step-03 pushes every workload image, step-04 rewrites containerd per-host,
       # step-08 pre-hold completeness gate + fixed localRegistryHostSubstr (below,
       # now the FULL registry.${SOVEREIGN_FQDN}). Builds on 0.1.113's carve-out.
-      version: 0.1.114
+      version: 0.1.115
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.114
+  version: 0.1.115
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,28 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.115 (#4975 Refs #3379 #3695 #4977 — the LAST uncovered offline-mirror host,
+# named by the live hw239 step-03 harbor-prewarm completeness gate): the #4977
+# comprehensive completeness gate FATAL-failed fast on `mirror.gcr.io/aquasec/
+# trivy-operator:0.30.1` + `mirror.gcr.io/aquasec/trivy:0.70.0` — Google's
+# pull-through Docker Hub / GCR mirror was NOT in offlineMirror.hostProjects.
+# Those trivy images are pinned INSIDE the bp-trivy sub-chart values
+# (platform/trivy/chart/values.yaml, slot 30), as the SPLIT `registry:
+# mirror.gcr.io` + `repository: aquasec/trivy*` shape, which the render-time
+# coverage guardrail (tests/image-registry-coverage.sh) was blind to (it saw only
+# `repository: aquasec/trivy*` and mis-read the host as the covered docker.io) —
+# so the runtime prewarm enumeration is what caught it. TWO fixes: (1) add
+# `host: mirror.gcr.io -> project: proxy-gcr` to offlineMirror.hostProjects
+# (mirror.gcr.io serves gcr.io/docker.io content, so the ref host-swaps to
+# registry.<fqdn>/proxy-gcr/aquasec/trivy with the path preserved; step-02 already
+# creates proxy-gcr, so no new project). All three consumers (step-03 resolver,
+# step-04 per-host containerd rewrite, step-08 completeness HEAD) read
+# hostProjects generically, so the one entry covers every leg. (2) the CI
+# guardrail now parses the split `registry:` + `repository:` sub-chart shape so
+# this whole class is caught at PR time, not runtime — with a positive self-test
+# asserting mirror.gcr.io/aquasec/trivy* is covered + the existing negative
+# self-test kept. NO step-count / job-mode / RBAC change (still 11 steps). Slot-06a
+# pin + blueprint.yaml + catalog-seed source.version move to 0.1.115 in lockstep
+# (Inviolable Principle #13; catalog-seed pin must NOT lag the chart).
 # 0.1.114 (#4975 Refs #3379 #3695 — generalizes/supersedes #4976 [0.1.113] + the
 # partial #4975): the SYSTEMIC end of the per-prov step-08 whack-a-mole. Layers
 # ON TOP of #4976's Recreate-strategy fresh-pull carve-out (kept intact in
@@ -1729,7 +1752,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.114
+version: 0.1.115
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/tests/image-registry-coverage.sh
+++ b/platform/self-sovereign-cutover/chart/tests/image-registry-coverage.sh
@@ -15,9 +15,16 @@
 # It reads the coverage map from the SAME chart values.yaml the runtime steps
 # render from (single source of truth) — nothing to keep in sync.
 #
+# SUB-CHART DESCENT (#4975 Refs #4977). The scan surface includes every
+# platform/<x>/chart/values.yaml + products/<x>/chart/values.yaml (where the
+# bootstrap-kit slots' referenced charts pin their image hosts), and it parses
+# the SPLIT `registry:` + `repository:` shape — so a sub-chart image from an
+# un-mapped host (mirror.gcr.io in platform/trivy) FAILS the build at PR time
+# instead of wedging a live cutover mid deny-egress hold (the hw239 finding).
+#
 # Usage:
 #   tests/image-registry-coverage.sh            # scan the repo's bootstrap-kit slots
-#   tests/image-registry-coverage.sh --self-test # negative test: an un-mapped host FAILS
+#   tests/image-registry-coverage.sh --self-test # negative + positive coverage self-tests
 #
 # Exit: 0 = every scanned host is covered (or excluded); 1 = at least one
 # un-mapped host (named); 2 = tool/input error.
@@ -64,7 +71,8 @@ is_excluded_substr() {
 }
 
 ref_host() {
-  # $1 = image ref. Prints its registry host, or "" to SKIP (templated/local).
+  # $1 = image ref (or a bare `registry:` field value). Prints its registry
+  # host, or "" to SKIP (templated/local).
   _r="$1"
   # Strip an oci:// scheme (chart repos); ghcr.io is mapped anyway.
   _r="${_r#oci://}"
@@ -78,16 +86,37 @@ ref_host() {
         *) printf 'docker.io' ;;    # docker.io namespaced (e.g. grafana/loki)
       esac
       ;;
-    *) printf 'docker.io' ;;        # bare official image
+    *)
+      # No slash. A bare `registry:` field value that LOOKS like a host
+      # (contains a `.`, e.g. mirror.gcr.io / harbor.openova.io) is a REGISTRY
+      # HOST — this is the split `registry:` + `repository:` shape (upstream
+      # Bitnami/trivy-operator idiom) the old scanner was blind to, so a
+      # sub-chart image on an un-mapped host (mirror.gcr.io in platform/trivy)
+      # slipped through as covered `docker.io`. A bare OFFICIAL image
+      # (busybox, nginx:1.25 — the colon is a TAG, not a host:port) has NO dot
+      # → docker.io. A non-host `registry:` value (external-dns `registry: txt`)
+      # has no dot → docker.io (covered, harmless).
+      case "${_r}" in
+        *.*) printf '%s' "${_r}" ;;   # bare registry host (mirror.gcr.io)
+        *)   printf 'docker.io' ;;    # bare official image / non-host token
+      esac
+      ;;
   esac
 }
 
 scan_refs() {
   # Emit candidate image refs (host-bearing) from the given files. Matches
-  # `image:`, `repository:`, `package:`, `spec.package:` values; strips quotes
-  # and inline comments; ignores comment-only lines.
-  grep -rhoE '^[[:space:]]*(image|repository|package):[[:space:]]*["'\'']?[A-Za-z0-9_./:$?{}%-]+' "$@" 2>/dev/null \
-    | sed -E 's/^[[:space:]]*(image|repository|package):[[:space:]]*["'\'']?//' \
+  # `image:`, `repository:`, `registry:`, `package:`, `spec.package:` values;
+  # strips quotes and inline comments; ignores comment-only lines.
+  #
+  # `registry:` is scanned so the SPLIT `registry:` + `repository:` sub-chart
+  # image shape (platform/trivy pins `registry: mirror.gcr.io` +
+  # `repository: aquasec/trivy` in the umbrella values) is caught — the old
+  # scanner only saw `repository: aquasec/trivy` and mis-classified the host as
+  # the covered `docker.io`, so an image from an un-mapped registry host slipped
+  # through (the live hw239 whack-a-mole this guardrail exists to close).
+  grep -rhoE '^[[:space:]]*(image|repository|registry|package):[[:space:]]*["'\'']?[A-Za-z0-9_./:$?{}%-]+' "$@" 2>/dev/null \
+    | sed -E 's/^[[:space:]]*(image|repository|registry|package):[[:space:]]*["'\'']?//' \
     | sed -E 's/["'\''].*$//' \
     | grep -vE '^[[:space:]]*$' \
     | sort -u
@@ -146,6 +175,24 @@ YAML
     exit 1
   fi
   echo "  PASS — un-mapped host correctly FAILED the guardrail (negative test green)."
+  # NEGATIVE TEST 2 (#4975): the SPLIT `registry:` + `repository:` sub-chart
+  # shape (platform/trivy idiom) on an UN-MAPPED host MUST fail — proving the
+  # scanner parses `registry:` and no longer mis-reads the host as docker.io.
+  cat > "${TMP}/slot-split.yaml" <<'YAML'
+spec:
+  values:
+    image:
+      registry: unmapped-split.example.net
+      repository: foo/bar
+      tag: "1.0"
+YAML
+  echo "[image-registry-coverage] --self-test: a SPLIT registry:/repository: image from 'unmapped-split.example.net' MUST fail the guardrail"
+  if run_scan "${TMP}" >/dev/null 2>&1; then
+    echo "SELF-TEST FAIL: a split registry:/repository: image on an un-mapped host was NOT caught — the scanner still ignores registry:." >&2
+    exit 1
+  fi
+  echo "  PASS — split-form un-mapped host correctly FAILED the guardrail (negative test 2 green)."
+  rm -f "${TMP}/slot.yaml" "${TMP}/slot-split.yaml"
   # And prove the covered case passes.
   cat > "${TMP}/slot-ok.yaml" <<'YAML'
 spec:
@@ -153,12 +200,35 @@ spec:
     image:
       repository: harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql
 YAML
-  rm -f "${TMP}/slot.yaml"
   if ! run_scan "${TMP}" >/dev/null 2>&1; then
     echo "SELF-TEST FAIL: a mapped host (harbor.openova.io) was wrongly rejected." >&2
     exit 1
   fi
   echo "  PASS — mapped host correctly ACCEPTED (positive control green)."
+  # POSITIVE TEST 2 (#4975): the platform/trivy SPLIT-form image
+  # `registry: mirror.gcr.io` + `repository: aquasec/trivy*` MUST now be COVERED
+  # (proves Fix 1's coverage-map entry + Fix 2's registry: parsing land together
+  # — the exact hw239 offender is caught AND resolved).
+  cat > "${TMP}/slot-trivy.yaml" <<'YAML'
+spec:
+  values:
+    trivy-operator:
+      image:
+        registry: mirror.gcr.io
+        repository: aquasec/trivy-operator
+        tag: "0.30.1"
+      trivy:
+        image:
+          registry: mirror.gcr.io
+          repository: aquasec/trivy
+          tag: "0.70.0"
+YAML
+  echo "[image-registry-coverage] --self-test: mirror.gcr.io/aquasec/trivy* (platform/trivy split form) MUST be covered"
+  if ! run_scan "${TMP}" >/dev/null 2>&1; then
+    echo "SELF-TEST FAIL: mirror.gcr.io/aquasec/trivy* is NOT covered — add host: mirror.gcr.io -> project: proxy-gcr to offlineMirror.hostProjects." >&2
+    exit 1
+  fi
+  echo "  PASS — mirror.gcr.io/aquasec/trivy* correctly ACCEPTED (positive test 2 green)."
   exit 0
 fi
 
@@ -168,10 +238,13 @@ if [ ! -d "${SLOT_DIR}" ]; then
 fi
 # Scan surface = every place a bootstrap-kit workload image host is statically
 # pinned in this repo: the slot overrides AND every platform/products chart
-# values.yaml (where bp-* charts pin image.repository hosts). The actual image
-# TAGS live in the OCI charts, but the HOST — the only thing this guardrail
-# checks — is pinned here. Templated refs (registry.${SOVEREIGN_FQDN},
-# ${REGISTRY_MIRROR:=…}) are skipped (dynamic/local).
+# values.yaml (where bp-* charts — including the bootstrap-kit slots' referenced
+# SUB-CHARTS, e.g. platform/trivy — pin image.repository / image.registry
+# hosts). The actual image TAGS live in the OCI charts, but the HOST — the only
+# thing this guardrail checks — is pinned here, whether as a single
+# `repository: host/path` or the split `registry: host` + `repository: path`
+# shape. Templated refs (registry.${SOVEREIGN_FQDN}, ${REGISTRY_MIRROR:=…}) are
+# skipped (dynamic/local).
 SCAN_FILES="$(
   find "${SLOT_DIR}" -maxdepth 1 -name '*.yaml' 2>/dev/null
   find "${REPO_ROOT}/platform" -path '*/chart/values.yaml' 2>/dev/null

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -492,6 +492,17 @@ offlineMirror:
       project: "proxy-gcr"
     - host: "k8s.gcr.io"
       project: "proxy-gcr"
+    # #4975 (Refs #3379 #3695 #4977) — Google's pull-through mirror of Docker
+    # Hub / GCR. bp-trivy (slot 30) pins the trivy-operator + trivy scanner
+    # images at mirror.gcr.io/aquasec/trivy-operator + mirror.gcr.io/aquasec/
+    # trivy INSIDE the sub-chart values (platform/trivy/chart/values.yaml), so
+    # the runtime step-03 prewarm enumeration surfaced it as the last uncovered
+    # host on live hw239. Reuse proxy-gcr — mirror.gcr.io serves gcr.io/docker.io
+    # content, so `mirror.gcr.io/aquasec/trivy` host-swaps to
+    # registry.<fqdn>/proxy-gcr/aquasec/trivy with the path preserved. step-02
+    # already creates proxy-gcr (harbor.mirrorProjects), so no new project.
+    - host: "mirror.gcr.io"
+      project: "proxy-gcr"
     - host: "public.ecr.aws"
       project: "proxy-ecr"
     # MOTHERSHIP — host-swap, path preserved. Must equal the host of

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5041,7 +5041,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.114"
+  version: "0.1.115"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.114"
+    version: "0.1.115"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## The finding (live hw239, cutover step-03 harbor-prewarm)

The #4977 comprehensive offline-mirror completeness gate worked as designed — it FATAL-failed fast and named the last uncovered host:

```
FATAL: image(s) from registry host(s) NOT in the offline-mirror coverage map (offlineMirror.hostProjects):
  UNMAPPED mirror.gcr.io/aquasec/trivy-operator:0.30.1
  UNMAPPED mirror.gcr.io/aquasec/trivy:0.70.0
```

`mirror.gcr.io` (Google's pull-through Docker Hub / GCR mirror) was NOT in `offlineMirror.hostProjects`. The trivy images are pinned INSIDE the bp-trivy sub-chart values (`platform/trivy/chart/values.yaml`, slot 30) as the SPLIT `registry: mirror.gcr.io` + `repository: aquasec/trivy*` shape, which the render-time coverage guardrail was blind to (it saw only `repository: aquasec/trivy*` and mis-read the host as the covered `docker.io`) — so the runtime prewarm enumeration is what caught it.

## Fix 1 — coverage map

`platform/self-sovereign-cutover/chart/values.yaml` → `offlineMirror.hostProjects`: added `host: mirror.gcr.io` → `project: proxy-gcr`. mirror.gcr.io serves gcr.io/docker.io content, so `mirror.gcr.io/aquasec/trivy` host-swaps to `registry.<fqdn>/proxy-gcr/aquasec/trivy` with the path preserved. All three consumers (step-03 resolver, step-04 per-host containerd `certs.d` rewrite, step-08 completeness HEAD) read `hostProjects` generically via the rendered `HOST_PROJECT_MAP` (`_helpers.tpl` ranges the list) — no per-host hardcoding — so the one entry covers every leg. step-02 already creates `proxy-gcr` (`harbor.mirrorProjects`), so no new project.

## Fix 2 — CI guardrail catches sub-chart images at PR time

`platform/self-sovereign-cutover/chart/tests/image-registry-coverage.sh` now parses the split `registry:` + `repository:` sub-chart shape: `registry` is added to the scan alternation, and a bare dotted `registry:` value (e.g. `mirror.gcr.io`) is classified as a registry host instead of falling through to `docker.io`. A non-host `registry:` value (external-dns `registry: txt`) has no dot → docker.io (harmless). The scan surface already includes every `platform/*/chart/values.yaml` + `products/*/chart/values.yaml`, so with this parse the sub-chart image on an un-mapped host now FAILS the build. Self-tests: **positive** `mirror.gcr.io/aquasec/trivy*` is covered; **negative** a split-form image on an un-mapped host fails; the existing single-`repository:` negative test is kept.

## Fix 3 — version + lockstep

`Chart.yaml` 0.1.114 → **0.1.115** (+ changelog); `blueprint.yaml`, slot-06a pin (`clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml`), and catalog-seed `spec.version` + `source.version` for bp-self-sovereign-cutover → 0.1.115. No step-count / job-mode / RBAC change (still 11 steps).

## Verify (all pass)

- `helm template platform/self-sovereign-cutover/chart` — clean (7186 lines); rendered `HOST_PROJECT_MAP` carries `mirror.gcr.io:proxy-gcr`.
- `sh -n` both test scripts — OK.
- `image-registry-coverage.sh` (relative path + `REPO_ROOT`) — full scan now 7 distinct hosts (was 6), mirror.gcr.io covered, PASS; `--self-test` green (2 negatives + 2 positives, incl. the mirror.gcr.io positive).
- `cutover-contract.sh` (relative path) — **All gates green** (Case 38 coverage guardrail included).
- `go test ./tests/e2e/bootstrap-kit/...` `TestCatalogSeed_DeliveryPinsNotBehindComponentCharts` — **PASS** (75 pins compared, none behind).
- `check-bootstrap-kit-pin-sync.sh` — `bp-self-sovereign-cutover: chart=0.1.115 pin=0.1.115 OK`, PASS.
- `check-catalog-seed-lockstep.sh` — PASS (0 fail).
- No CI-banned words.

Refs #4975 #3379

🤖 Generated with [Claude Code](https://claude.com/claude-code)