### PR TITLE
fix(#4975): skopeo --multi-arch all so manifest-list images mirror to local Harbor (cutover step-03)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -773,7 +773,13 @@ spec:
       # step-03 pushes every workload image, step-04 rewrites containerd per-host,
       # step-08 pre-hold completeness gate + fixed localRegistryHostSubstr (below,
       # now the FULL registry.${SOVEREIGN_FQDN}). Builds on 0.1.113's carve-out.
-      version: 0.1.115
+      # 0.1.116 (#4975 Refs #3379): step-03 harbor-prewarm Phase A container-image
+      # skopeo copy gains --multi-arch all so multi-arch manifest-LIST images
+      # (cilium/*, hubble-*, policy-controller, operator-generic) mirror to local
+      # Harbor addressable by their list digest — without it skopeo copies only the
+      # running-arch sub-image and Harbor rejects the list-digest PUT `digest invalid`,
+      # fail-closing step-03 (live hw239). Phase A2 chart-OCI copy left single-manifest.
+      version: 0.1.116
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.115
+  version: 0.1.116
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,25 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.116 (#4975 Refs #3379 — step-03 harbor-prewarm mirrors multi-arch
+# manifest-LIST images by adding --multi-arch all to the Phase A container-image
+# `skopeo copy`. Live hw239 step-03 Phase A pushed 129 single-arch images OK but
+# all 8 multi-arch manifest-LIST images FAILED `digest invalid` (cilium/*,
+# hubble-*, sigstore/policy-controller, cilium/operator-generic): without the flag
+# skopeo defaults to `--multi-arch system` and copies ONLY the running platform's
+# sub-image out of a manifest LIST, while the copy is ADDRESSED by the list digest
+# (`@sha256:205b...`) — Harbor computes the digest of the single-arch manifest it
+# actually stored, which does NOT equal the list digest, so the manifest PUT is
+# rejected `digest invalid`. containerd pulls these pod images BY the list digest,
+# so Harbor must serve the FULL manifest list + every arch sub-manifest + blobs.
+# `--multi-arch all` copies the complete list so the destination is addressable by
+# the exact list digest (digest matches). Phase A2 (helm chart OCI = a single
+# manifest, never a list) is deliberately left alone; the mirror-resync CronJob is
+# a git mirror (no skopeo image copy) and the offline-mirror resolver is a pure
+# path library (no copy), so neither needs the flag. cutover-contract Case 39 locks
+# the flag onto the Phase A copy and asserts exactly one flag line (chart copy
+# stays single-manifest). NO step-count / job-mode / RBAC change (still 11 steps).
+# Slot-06a pin + blueprint.yaml + catalog-seed source.version + spec.version move
+# to 0.1.116 in lockstep (Inviolable Principle #13; catalog-seed pin must NOT lag).
 # 0.1.115 (#4975 Refs #3379 #3695 #4977 — the LAST uncovered offline-mirror host,
 # named by the live hw239 step-03 harbor-prewarm completeness gate): the #4977
 # comprehensive completeness gate FATAL-failed fast on `mirror.gcr.io/aquasec/
@@ -1752,7 +1772,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.115
+version: 0.1.116
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -496,8 +496,22 @@ data:
                   # (default false: in-cluster LE-staging Harbor). --src-tls-verify
                   # stays true (external public-CA source). "$@" is the optional
                   # --src-creds selected by host (empty for anonymous upstreams).
+                  # #4975 --multi-arch all: WITHOUT it skopeo defaults to
+                  # `--multi-arch system`, copying ONLY the running platform's
+                  # sub-image out of a manifest LIST while the copy is ADDRESSED by
+                  # the list's digest (`@sha256:205b...`). Harbor computes the digest
+                  # of the single-arch manifest actually uploaded, which does NOT
+                  # equal the list digest → `digest invalid`, fail-closing step-03
+                  # (live hw239 Phase A: 129 single-arch images pushed OK, all 8
+                  # multi-arch manifest-list images FAILED — cilium/*, hubble-*,
+                  # policy-controller, operator-generic). containerd pulls these pod
+                  # images BY the list digest, so Harbor must serve the FULL manifest
+                  # list + ALL arch sub-manifests + blobs. `--multi-arch all` copies
+                  # the complete list so the dest is addressable by the exact list
+                  # digest (digest matches). Single-arch refs are unaffected.
                   if skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT}" copy \
                     --insecure-policy \
+                    --multi-arch all \
                     --retry-times 5 \
                     "$@" \
                     --dest-creds="${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -1489,4 +1489,32 @@ if ! bash "${COVERAGE}" >/dev/null 2>&1; then
 fi
 echo "  PASS (guardrail negative test green; every scanned bootstrap-kit image host is covered)"
 
+echo "[cutover-contract] Case 39: Step-03 Phase A container-image skopeo copy carries --multi-arch all so manifest-LIST images mirror addressable by their list digest (#4975, Refs #3379)"
+# live hw239: Phase A pushed 129 single-arch images OK but all 8 multi-arch
+# manifest-LIST images (cilium/*, hubble-*, policy-controller, operator-generic)
+# FAILED `digest invalid`. WITHOUT --multi-arch all skopeo defaults to
+# --multi-arch system: it copies ONLY the running platform's sub-image out of a
+# manifest LIST while the copy is ADDRESSED by the list digest, so Harbor computes
+# the single-arch digest != the list digest → `digest invalid` → step-03 fail-closes
+# and the cutover never reaches step-04+. containerd pulls these pod images BY the
+# list digest, so the FULL manifest list + ALL arch sub-manifests + blobs MUST land.
+# Phase A (container images) MUST carry --multi-arch all; Phase A2 (helm chart OCI =
+# a SINGLE manifest, never a list) MUST NOT — leave chart-artifact copies alone.
+awk '/cutover-step-03-harbor-prewarm/{c=1} c{print} c&&/cutover-order: "4"/{exit}' "$TMP/render.yaml" > "$TMP/prewarm_ma_block.txt"
+[ -s "$TMP/prewarm_ma_block.txt" ] || cp "$TMP/render.yaml" "$TMP/prewarm_ma_block.txt"
+# Match the flag LINE (not the explanatory comment that also names the flag).
+if ! grep -Eq '^[[:space:]]*--multi-arch all \\$' "$TMP/prewarm_ma_block.txt"; then
+  echo "FAIL: Step-03 Phase A skopeo copy is missing --multi-arch all — a manifest-list image uploads only a single-arch manifest and Harbor rejects it 'digest invalid', fail-closing step-03 (#4975)" >&2
+  exit 1
+fi
+# EXACTLY ONE copy carries it: the Phase A container-image copy. The Phase A2
+# chart-OCI copy (a single manifest, never a list) is left alone, so the flag-line
+# count is 1 — this also proves the flag did not get sprinkled onto the chart copy.
+ma_lines=$(grep -Ec '^[[:space:]]*--multi-arch all \\$' "$TMP/prewarm_ma_block.txt" || true)
+if [ "${ma_lines}" -ne 1 ]; then
+  echo "FAIL: Step-03 has ${ma_lines} --multi-arch all flag line(s), expected exactly 1 (the container-image copy). The Phase A2 helm-chart-OCI copy must NOT carry it — chart artifacts are single manifests, not lists (#4975)" >&2
+  exit 1
+fi
+echo "  PASS (Step-03 Phase A container-image copy uses --multi-arch all; Phase A2 chart-OCI copy left single-manifest)"
+
 echo "[cutover-contract] All gates green."

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5041,7 +5041,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.115"
+  version: "0.1.116"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.115"
+    version: "0.1.116"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
Refs #4975 #3379

## Finding (live hw239, cutover step-03 harbor-prewarm, Phase A)
Phase A pushed 129 single-arch images OK but **8 multi-arch manifest-LIST images FAILED** `digest invalid`:
`quay.io/cilium/{cilium,cilium-envoy,clustermesh-apiserver,hubble-relay,hubble-ui,hubble-ui-backend,operator-generic}` + `ghcr.io/sigstore/policy-controller/policy-controller`. skopeo fatal: `writing manifest ... digest invalid`. That fail-closed step-03, so the cutover never reached step-04+.

## Root cause
`copy_one()`'s `skopeo copy` (03-harbor-prewarm-job.yaml) carried **no `--multi-arch` flag**, so skopeo defaulted to `--multi-arch system`: it copies ONLY the running platform's sub-image out of a manifest LIST, while the copy is ADDRESSED by the list digest (`@sha256:205b...`). Harbor computes the digest of the single-arch manifest it actually stored, which does NOT equal the list digest, so the manifest PUT is rejected `digest invalid`. Single-arch images (129) push fine; every manifest-list (8) fails. containerd pulls these pod images BY the list digest, so Harbor must serve the FULL manifest list + all arch sub-manifests + blobs.

## Fix
Added `--multi-arch all` to the Phase A container-image `skopeo copy` in `copy_one()`. It copies the complete manifest list + every arch sub-manifest + blobs, so the destination is addressable by the exact list digest (digest matches). Single-arch refs are unaffected.

### skopeo copy change (Phase A, copy_one)
```
   if skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT}" copy \
     --insecure-policy \
+    --multi-arch all \
     --retry-times 5 \
     "$@" \
     --dest-creds="${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
     --dest-tls-verify="${PREWARM_DEST_TLS_VERIFY}" \
     --src-tls-verify=true \
     "docker://${up}" "docker://${lref}" ...
```
(runtime binary is lework/skopeo-binary **v1.15.2**, pinned in the template — `--multi-arch` has been a stable `copy` flag since skopeo 1.5.0)

### Other skopeo calls audited (searched the entire chart)
- **Phase A2 `copy_chart()`** (03-harbor-prewarm-job.yaml) — a Helm chart OCI artifact is a **single manifest, never a manifest list** → left alone (no flag).
- **Phase A3** — not a separate `skopeo copy`; it routes through the same `copy_one()` via the offline-mirror resolver → covered by the one fix.
- **11-mirror-resync-cronjob.yaml** — a `git clone --bare` + `git push --mirror` Gitea mirror; **no skopeo image copy** → nothing to change.
- **03a-offline-mirror-resolver.yaml** — a pure path-resolution shell library; **no copy** → nothing to change.

Only **two** `skopeo ... copy` invocations exist in the whole chart (Phase A + Phase A2); only the container-image one (Phase A) gets the flag.

### step-08 completeness HEAD
Unaffected — it HEADs by the same resolver-derived path + ref with an `Accept:` that already includes `manifest.list.v2` / `image.index.v1`. With `--multi-arch all` the full list is present addressable by its list digest, so the HEAD-by-digest now returns 200 (it strictly improves on the broken single-arch push).

## Version + lockstep
Chart 0.1.115 → **0.1.116**; blueprint.yaml 0.1.116; slot-06a pin 0.1.116; catalog-seed `source.version` + `spec.version` 0.1.116. No step-count / job-mode / RBAC change (still 11 steps).

## Verification (all green)
- `helm template` clean (exit 0).
- `sh -n` on the embedded step-03 + step-08 scripts: OK; rendered ConfigMap contains `--multi-arch all` in the Phase A copy.
- `bash tests/cutover-contract.sh <chart>`: **all 39 gates green** (incl. new **Case 39** asserting the flag on Phase A + exactly one flag line so the chart copy stays single-manifest).
- `bash tests/image-registry-coverage.sh <chart>` + `--self-test`: green.
- `go test ./tests/e2e/bootstrap-kit -run TestCatalogSeed_DeliveryPinsNotBehindComponentCharts`: PASS.
- `check-bootstrap-kit-pin-sync.sh` (bp-self-sovereign-cutover chart=0.1.116 pin=0.1.116) + `check-catalog-seed-lockstep.sh`: PASS.
- No CI-banned words.

🤖 Generated with [Claude Code](https://claude.com/claude-code)