### PR TITLE
fix(#4982): cutover step-CMs re-render on upgrade + settled-roll pre-flight for harbor-prewarm

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -779,7 +779,16 @@ spec:
       # Harbor addressable by their list digest — without it skopeo copies only the
       # running-arch sub-image and Harbor rejects the list-digest PUT `digest invalid`,
       # fail-closing step-03 (live hw239). Phase A2 chart-OCI copy left single-manifest.
-      version: 0.1.116
+      # 0.1.117 (#4982 Refs #3379): two durable robustness fixes. (A) cutover-contract
+      # Case 40 LOCKS that the resolver (03a) + every per-step CM re-render on a helm
+      # upgrade (no resource-policy: keep — else a chart-version fix is inert
+      # mid-cutover, #4417 class); only the status CM keeps. (B) step-03 gains a
+      # Phase A0 settled-roll pre-flight that fail-closes before building the mirror
+      # if any host HelmRelease/Deployment/StatefulSet is mid-roll — harbor-prewarm
+      # mirrors RUNNING tags but the cutover rolls to DESIRED chart-pinned tags, so
+      # an unsettled env 404s step-06/08 under the deny-egress hold (live hw239).
+      # Toggle prewarm.settledRollPreflight.enabled (default true). Still 11 steps.
+      version: 0.1.117
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.116
+  version: 0.1.117
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,31 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.117 (#4982 Refs #3379 — two durable robustness fixes found driving hw239 to
+# the step-08 pre-hold completeness gate). Finding A: LOCK the invariant that the
+# offline-mirror resolver (03a) + every per-step script CM (cutover-step-0N-*)
+# re-render on a helm upgrade — they carry NO helm.sh/resource-policy: keep, so a
+# chart-version fix is NOT inert for a cutover in flight (the #4417 /
+# catalog_blueprint_resource_policy_keep_makes_bumps_inert class: keep EXCLUDES a
+# resource from the helm-upgrade UPDATE set). Only the status CM
+# self-sovereign-cutover-status keeps (preserve mid-cutover progress). These CMs
+# were ALREADY keep-free (git history: they never carried keep — the live hw239
+# 0.1.114 stickiness was the unsettled-env symptom, see Finding B); this bump adds
+# cutover-contract Case 40 as the regression guard so a future edit cannot
+# re-introduce keep on a step/resolver CM. Finding B: step-03 harbor-prewarm gains a
+# Phase A0 "settled-roll pre-flight" — it FAIL-CLOSES (exit 1) before building the
+# mirror if any host-cluster HelmRelease or Deployment/StatefulSet is mid-roll,
+# because harbor-prewarm mirrors RUNNING tags but the cutover then rolls workloads
+# to DESIRED chart-pinned tags (registry-pivot step-04 / env-patch step-07); on an
+# unsettled env running != desired and the un-mirrored desired tag 404s step-06/08
+# under the deny-egress hold (live hw239: umbrella 1.4.1086 vs pin 1.4.1088;
+# catalyst-api/ui :3412183 vs desired :00b6cfe). The gate names every offender and
+# leaves the env PRE-PIVOT/intact (steps 01/02 are idempotent). Toggle
+# prewarm.settledRollPreflight.enabled (default true). Mirror-the-desired-tags is
+# the documented #4982 follow-up. cutover-contract Case 41 locks the pre-flight.
+# NO step-count / job-mode / RBAC change (still 11 steps; Phase A0 reuses the
+# HelmRelease + Deployment/StatefulSet get/list RBAC the enumeration already has).
+# Slot-06a pin + blueprint.yaml + catalog-seed source.version + spec.version move to
+# 0.1.117 in lockstep (Inviolable Principle #13; catalog-seed pin must NOT lag).
 # 0.1.116 (#4975 Refs #3379 — step-03 harbor-prewarm mirrors multi-arch
 # manifest-LIST images by adding --multi-arch all to the Phase A container-image
 # `skopeo copy`. Live hw239 step-03 Phase A pushed 129 single-arch images OK but
@@ -1772,7 +1798,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.116
+version: 0.1.117
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -158,6 +158,18 @@ data:
             value: {{ include "bp-self-sovereign-cutover.localRegistryHost" . | quote }}
           - name: MOTHERSHIP_HOST
             value: {{ include "bp-self-sovereign-cutover.mothershipHost" . | quote }}
+          # #4982 (Refs #3379) — settled-roll pre-flight toggle. When true
+          # (default) Phase A0 REFUSES to build the mirror while any HelmRelease
+          # or Deployment/StatefulSet on the host cluster is mid-roll, so the
+          # mirror can never capture running tags the cutover then rolls away
+          # from (running != desired → step-06/step-08 404 under the deny-egress
+          # hold). Set false only as an emergency override on a manually
+          # confirmed-settled env.
+          # NB: no `| default true` — Sprig `default` treats bool false as empty
+          # (`false | default true` → true), which would silently break the
+          # disable override. The key is always present in values.yaml.
+          - name: SETTLED_ROLL_PREFLIGHT
+            value: {{ .Values.prewarm.settledRollPreflight.enabled | quote }}
         volumeMounts:
           - name: prewarm
             mountPath: /work
@@ -206,6 +218,73 @@ data:
               echo "[harbor-prewarm] FATAL: kubectl missing from image"
               exit 1
             fi
+
+            # ─── Phase A0: settled-roll pre-flight (#4982, Refs #3379) ─────────
+            # harbor-prewarm mirrors the RUNNING / declared-template image tags
+            # (Phase A below). If any HelmRelease or Deployment/StatefulSet on the
+            # HOST cluster is MID-ROLL — a bootstrap-kit pin bumped but not yet
+            # reconciled, or an in-flight helm upgrade — then running != desired:
+            # the cutover would later roll those workloads (registry-pivot step-04
+            # / catalyst-api env-patch step-07) to the DESIRED chart-pinned tags
+            # that were NEVER mirrored here, and step-06's readiness sample +
+            # step-08's pre-hold completeness HEAD 404 on the un-mirrored desired
+            # tag (live hw239, dep f5fa3f08d8c3234f: umbrella HR bp-catalyst-platform
+            # running 1.4.1086 but pin 1.4.1088; catalyst-api/ui running :3412183
+            # but desired :00b6cfe — harbor-prewarm mirrored the running side of
+            # the drift). Once step-05 pivots Flux to the local Gitea the
+            # GitRepository freezes at the cutover-start sha, so the workloads can
+            # NEVER roll to the desired tag during the cutover — a running !=
+            # mirrored deadlock the deny-egress hold then trips on. REFUSE to build
+            # the mirror on an unsettled env (still PRE-PIVOT: steps 01/02 only
+            # mirrored git + created Harbor projects, both idempotent — nothing
+            # destructive has run), naming every offender so the operator waits for
+            # the roll to settle and re-triggers. The "settled-roll pre-flight"
+            # STONE principle. The complementary durable fix — mirror the DESIRED
+            # chart-pinned tags, not just running — is the #4982 follow-up (needs
+            # rendering the desired chart version off each HelmRelease spec); this
+            # gate prevents the whole class today with no render dependency. Runs
+            # BEFORE the ~5-min skopeo static-binary download so it fails fast.
+            if [ "${SETTLED_ROLL_PREFLIGHT:-true}" = "true" ]; then
+              echo "[harbor-prewarm] Phase A0: settled-roll pre-flight — no HelmRelease/workload may be mid-roll before the mirror is built"
+              # HelmReleases: a SUSPENDED HR is intentionally frozen (it will NOT
+              # roll during the cutover, so its running IS its desired) → skip it.
+              # Otherwise flag when the spec out-ran the controller
+              # (observedGeneration < generation — the pin-bump case) OR Ready !=
+              # True (mid-reconcile / failed upgrade).
+              hr_pending=$(kubectl get helmreleases -A -o json 2>/dev/null | jq -r '
+                .items[]
+                | select((.spec.suspend // false) | not)
+                | select(
+                    ((.status.observedGeneration // -1) < (.metadata.generation // 0))
+                    or (((.status.conditions // []) | map(select(.type=="Ready")) | (.[0].status // "Unknown")) != "True")
+                  )
+                | "HelmRelease/\(.metadata.namespace)/\(.metadata.name)"' 2>/dev/null || true)
+              # Deployments + StatefulSets: a pending rollout — observedGeneration
+              # behind the spec, or updated/ready replicas short of desired. Skip
+              # intentionally scaled-to-zero (spec.replicas == 0). DaemonSets are
+              # deliberately NOT gated: cordoned / control-plane-tainted nodes skew
+              # desired-vs-ready legitimately and would false-positive the gate.
+              wl_pending=$(kubectl get deployments,statefulsets -A -o json 2>/dev/null | jq -r '
+                .items[]
+                | select((.spec.replicas // 1) > 0)
+                | select(
+                    ((.status.observedGeneration // -1) < (.metadata.generation // 0))
+                    or ((.status.updatedReplicas // 0) < (.spec.replicas // 1))
+                    or ((.status.readyReplicas // 0) < (.spec.replicas // 1))
+                  )
+                | "\(.kind // "Workload")/\(.metadata.namespace)/\(.metadata.name)"' 2>/dev/null || true)
+              unsettled=$(printf '%s\n%s\n' "${hr_pending}" "${wl_pending}" | grep -c . || true)
+              if [ "${unsettled}" -gt 0 ]; then
+                echo "[harbor-prewarm] FATAL: env NOT settled — ${unsettled} release(s)/workload(s) are mid-roll; harbor-prewarm would mirror running tags the cutover then rolls away from (running != desired). Wait for these to settle (HelmRelease Ready=True + observedGeneration==generation; workloads updated==ready==desired replicas), then re-trigger the cutover:"
+                printf '%s\n%s\n' "${hr_pending}" "${wl_pending}" | grep . | sed 's/^/  mid-roll: /'
+                echo "[harbor-prewarm] (settled-roll pre-flight #4982; emergency override for a manually confirmed-settled env: prewarm.settledRollPreflight.enabled=false)"
+                exit 1
+              fi
+              echo "[harbor-prewarm] Phase A0: env settled — no HelmRelease/Deployment/StatefulSet mid-roll; building the mirror from running == desired tags"
+            else
+              echo "[harbor-prewarm] Phase A0: settled-roll pre-flight DISABLED (prewarm.settledRollPreflight.enabled=false) — mirroring running tags without a settle check"
+            fi
+
             if ! command -v skopeo >/dev/null 2>&1; then
               echo "[harbor-prewarm] skopeo not on PATH; downloading static binary"
               # skopeo static binaries published by lework on GitHub releases

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -1517,4 +1517,91 @@ if [ "${ma_lines}" -ne 1 ]; then
 fi
 echo "  PASS (Step-03 Phase A container-image copy uses --multi-arch all; Phase A2 chart-OCI copy left single-manifest)"
 
+echo "[cutover-contract] Case 40: cutover step + resolver ConfigMaps re-render on helm upgrade (NO resource-policy: keep); only the status ConfigMap keeps (#4982 Finding A, Refs #3379)"
+# #4982 Finding A: a cutover-step / resolver ConfigMap that carries
+# helm.sh/resource-policy: keep is EXCLUDED from the helm-upgrade UPDATE set
+# (catalog_blueprint_resource_policy_keep_makes_bumps_inert / #4417) — so a cutover
+# that STARTED on an older chart keeps its STALE step-CMs even after the HelmRelease
+# upgrades, making mid-cutover chart fixes (mirror.gcr.io mapping, --multi-arch)
+# INERT (live hw239: cutover-step-08-egress-block-test label stuck at 0.1.114; the
+# resolver had no mirror.gcr.io mapping despite the newer chart adding it). The
+# resolver + every per-step script CM are PURE chart-derived config and MUST
+# re-render on upgrade → they must NOT carry keep. ONLY the status CM
+# (self-sovereign-cutover-status) keeps, to preserve mid-cutover progress across a
+# chart uninstall (Case 6). This gate locks that invariant so a future edit cannot
+# re-introduce the inert-mid-cutover bug (the #3668/#3710 shape that seeded #4417).
+for cm in cutover-offline-mirror-resolver \
+          cutover-step-01-gitea-mirror cutover-step-02-harbor-projects \
+          cutover-step-03-harbor-prewarm cutover-step-04-registry-pivot \
+          cutover-step-05-flux-gitrepository-patch cutover-step-06-helmrepository-patches \
+          cutover-step-07-catalyst-api-env-patch cutover-step-08-egress-block-test \
+          cutover-step-09-gitea-token-mint cutover-step-10-vcluster-registry-pivot \
+          cutover-step-11-crossplane-provider-pivot; do
+  # The metadata name renders at exactly 2-space indent (`  name: <cm>`); the
+  # deep-indented volume/configMap refs inside podSpec do NOT match, so the awk
+  # range spans exactly this one ConfigMap document (name → next `---`).
+  if ! grep -q "^  name: ${cm}$" "$TMP/render.yaml"; then
+    echo "FAIL: expected ConfigMap ${cm} not found in render (Case 40 list drifted from the chart)" >&2
+    exit 1
+  fi
+  if awk "/^  name: ${cm}\$/,/^---\$/" "$TMP/render.yaml" | grep -q 'helm.sh/resource-policy: keep'; then
+    echo "FAIL: ConfigMap ${cm} carries helm.sh/resource-policy: keep — it will NOT re-render on a helm upgrade, so a mid-cutover chart fix is INERT (#4982 Finding A). Drop keep from step/resolver CMs; only self-sovereign-cutover-status keeps." >&2
+    exit 1
+  fi
+done
+# Positive half of the invariant: the status CM MUST keep (mirror of Case 6, kept
+# here so Case 40 fully specifies the keep policy across ALL cutover ConfigMaps).
+if ! awk '/^  name: self-sovereign-cutover-status$/,/^---$/' "$TMP/render.yaml" | grep -q 'helm.sh/resource-policy: keep'; then
+  echo "FAIL: self-sovereign-cutover-status ConfigMap must carry helm.sh/resource-policy: keep to preserve mid-cutover progress (#4982 Finding A / Case 6)" >&2
+  exit 1
+fi
+echo "  PASS (resolver + 11 step CMs re-render on upgrade; only the status CM keeps)"
+
+echo "[cutover-contract] Case 41: Step-03 harbor-prewarm has a settled-roll pre-flight (Phase A0) that fail-closes on a mid-roll env BEFORE building the mirror (#4982 Finding B, Refs #3379)"
+# #4982 Finding B: harbor-prewarm mirrors the RUNNING / declared-template image
+# tags; if a HelmRelease or Deployment/StatefulSet is mid-roll (a bootstrap-kit pin
+# bumped but not yet reconciled) the cutover later rolls those workloads to the
+# DESIRED chart-pinned tags that were NEVER mirrored → step-06 readiness sample +
+# step-08 pre-hold completeness HEAD 404 (live hw239: umbrella running 1.4.1086 vs
+# pin 1.4.1088; catalyst-api/ui running :3412183 vs desired :00b6cfe). Phase A0
+# REFUSES to build the mirror while the host cluster is unsettled, naming every
+# offender (env still PRE-PIVOT / intact). Slice step-03's CM (up to step-04's
+# cutover-order:"4") the same way Case 39 does.
+awk '/cutover-step-03-harbor-prewarm/{c=1} c{print} c&&/cutover-order: "4"/{exit}' "$TMP/render.yaml" > "$TMP/prewarm_a0_block.txt"
+[ -s "$TMP/prewarm_a0_block.txt" ] || cp "$TMP/render.yaml" "$TMP/prewarm_a0_block.txt"
+if ! grep -q 'Phase A0: settled-roll pre-flight' "$TMP/prewarm_a0_block.txt"; then
+  echo "FAIL: Step-03 is missing the Phase A0 settled-roll pre-flight — harbor-prewarm would mirror running tags the cutover then rolls away from (#4982 Finding B)" >&2
+  exit 1
+fi
+# The gate MUST enumerate pending HelmReleases (the pin-bump drift source).
+if ! grep -q 'kubectl get helmreleases -A -o json' "$TMP/prewarm_a0_block.txt"; then
+  echo "FAIL: Phase A0 does not inspect HelmReleases for a pending roll (observedGeneration/Ready) — the pin-bump drift (running != desired) would slip through (#4982)" >&2
+  exit 1
+fi
+# ...AND pending Deployments/StatefulSets.
+if ! grep -q 'kubectl get deployments,statefulsets -A -o json' "$TMP/prewarm_a0_block.txt"; then
+  echo "FAIL: Phase A0 does not inspect Deployments/StatefulSets for a pending rollout (#4982)" >&2
+  exit 1
+fi
+# It MUST fail-CLOSED (exit 1) on an unsettled env, gated behind the
+# SETTLED_ROLL_PREFLIGHT toggle so an operator can override on a confirmed env.
+if ! grep -q 'name: SETTLED_ROLL_PREFLIGHT' "$TMP/prewarm_a0_block.txt"; then
+  echo "FAIL: Phase A0 is not gated behind the SETTLED_ROLL_PREFLIGHT toggle env (#4982)" >&2
+  exit 1
+fi
+# The pre-flight MUST run BEFORE the Phase A image enumeration so a fail leaves the
+# env pre-pivot (nothing mirrored/pivoted yet).
+a0_line=$(grep -n 'Phase A0: settled-roll pre-flight' "$TMP/prewarm_a0_block.txt" | head -1 | cut -d: -f1)
+enum_line=$(grep -n 'enumerating ALL images across cluster' "$TMP/prewarm_a0_block.txt" | head -1 | cut -d: -f1)
+if [ -z "${a0_line}" ] || [ -z "${enum_line}" ] || [ "${a0_line}" -ge "${enum_line}" ]; then
+  echo "FAIL: Phase A0 settled-roll pre-flight must run BEFORE Phase A image enumeration (fail-closed while still pre-pivot) (#4982)" >&2
+  exit 1
+fi
+# Default posture is ENABLED (fail-closed): the rendered toggle env is "true".
+if ! grep -A1 'name: SETTLED_ROLL_PREFLIGHT' "$TMP/prewarm_a0_block.txt" | grep -q 'value: "true"'; then
+  echo "FAIL: settled-roll pre-flight must DEFAULT to enabled (SETTLED_ROLL_PREFLIGHT rendered value != \"true\") (#4982)" >&2
+  exit 1
+fi
+echo "  PASS (Step-03 Phase A0 settled-roll pre-flight fail-closes on a mid-roll env before the mirror is built; default enabled)"
+
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -575,6 +575,26 @@ prewarm:
   # trust store may set this true via overlay; default false is the correct
   # fresh-prov behaviour.
   destTLSVerify: false
+  # #4982 (Refs #3379) — settled-roll pre-flight. step-03 harbor-prewarm mirrors
+  # the RUNNING / declared-template image tags. If any HelmRelease or
+  # Deployment/StatefulSet is MID-ROLL when the mirror is built (a bootstrap-kit
+  # pin bumped but not yet reconciled, or an in-flight helm upgrade), running !=
+  # desired: the cutover then rolls those workloads (registry-pivot step-04 /
+  # catalyst-api env-patch step-07) to the DESIRED chart-pinned tags that were
+  # never mirrored → step-06 readiness sample + step-08 pre-hold completeness HEAD
+  # 404 on the un-mirrored desired tag (live hw239: umbrella bp-catalyst-platform
+  # running 1.4.1086 but pin 1.4.1088; catalyst-api/ui running :3412183 but desired
+  # :00b6cfe). Once step-05 pivots Flux to the local Gitea the GitRepository
+  # freezes at the cutover-start sha, so the workloads can never roll to the
+  # desired tag during the cutover — a running != mirrored deadlock the deny-egress
+  # hold then trips on. This gate (Phase A0) REFUSES to build the mirror on an
+  # unsettled host cluster — still PRE-PIVOT, nothing destructive has run — and
+  # names every offender so the operator waits for the roll to settle and
+  # re-triggers. The "settled-roll pre-flight" STONE principle. Default true; set
+  # false ONLY as an emergency override on an env you have manually confirmed
+  # settled.
+  settledRollPreflight:
+    enabled: true
   # #4975 (Refs #3379 #3695) — RETIRED. This hand-maintained 11-image HEAD list
   # (the old Phase B "warm the proxy-cache" pass) was one of the three drifting
   # lists that caused the per-prov whack-a-mole: any upstream image a chart added

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5041,7 +5041,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.116"
+  version: "0.1.117"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.116"
+    version: "0.1.117"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
Two durable sovereignty-cutover robustness defects from #4982, found driving hw239 to the step-08 pre-hold completeness gate. Chart `0.1.116 -> 0.1.117` (slot-06a pin + blueprint.yaml + catalog-seed source.version + spec.version moved in lockstep).

## Finding A — cutover step/resolver CMs must re-render on a helm upgrade
A cutover step / resolver ConfigMap carrying `helm.sh/resource-policy: keep` is excluded from the helm-upgrade UPDATE set (the #4417 / `catalog_blueprint_resource_policy_keep_makes_bumps_inert` class), so a cutover that STARTED on an older chart keeps STALE step-CMs even after the HelmRelease upgrades — making mid-cutover chart fixes (mirror.gcr.io mapping, `--multi-arch`) inert.

**Which CMs I changed / left `keep`:** I un-kept **none** — the offline-mirror resolver (`03a`, `cutover-offline-mirror-resolver`) and every per-step script CM (`cutover-step-0N-*`) are **already keep-free** (git `-S 'resource-policy: keep'` history confirms they never carried it; the render at 0.1.116 shows all 11 step CMs + resolver + `registry-pivot-script` keep-free). The live hw239 `0.1.114`-labelled step-08 CM was the **unsettled-env symptom of Finding B** (the 0.1.116 HR upgrade itself had not reconciled), not a chart `keep`. Only `self-sovereign-cutover-status` carries `keep` (correct — it preserves mid-cutover progress across a chart uninstall) and I **left that untouched**. The `00-gitea-admin-secret-bridge` Secret keeps too but is re-emitted verbatim every reconcile (source-wins) and is not a step-definition CM.

**Durable guard:** new **cutover-contract Case 40** asserts the resolver + all 11 step CMs carry NO `resource-policy: keep` (so a future edit cannot re-introduce the inert-mid-cutover bug — the #3668/#3710 shape that seeded #4417) while asserting the status CM DOES keep.

## Finding B — settled-roll pre-flight (implemented) vs mirror-desired-tags (follow-up)
harbor-prewarm mirrors the RUNNING/declared image tags, but the cutover then rolls workloads (registry-pivot step-04 / env-patch step-07) to the DESIRED chart-pinned tags. On an unsettled env `running != desired` and the un-mirrored desired tag 404s step-06/step-08 under the deny-egress hold (live hw239: umbrella running `1.4.1086` vs pin `1.4.1088`; `catalyst-api`/`catalyst-ui` running `:3412183` vs desired `:00b6cfe`). Once step-05 pivots Flux to local Gitea the GitRepository freezes at the cutover-start sha, so the workloads can never roll to the desired tag during the cutover — a running-vs-mirrored deadlock.

**Chose (2) the settled-roll pre-flight** (the cleaner whole-class fix). step-03 gains a **Phase A0** that FAIL-CLOSES (`exit 1`) before building the mirror if any host-cluster **HelmRelease** (`observedGeneration<generation` — the pin-bump case — or `Ready!=True`; suspended HRs skipped since they will not roll) or **Deployment/StatefulSet** (pending rollout; scaled-to-zero skipped; DaemonSets deliberately not gated to avoid cordoned-node false positives) is mid-roll, **naming every offender**. The env stays PRE-PIVOT/intact on a fail (steps 01/02 are idempotent). Toggle `prewarm.settledRollPreflight.enabled` (default `true`). No step-count / job-mode / RBAC change (Phase A0 reuses the HelmRelease + Deployment/StatefulSet get/list RBAC the existing enumeration already has — still 11 steps). New **cutover-contract Case 41** locks the pre-flight in place + default-enabled.

**Why not (1) mirror-desired-tags in this PR:** the desired tags only materialize once the HelmRelease reconciles (the un-rolled Deployment spec still carries the OLD tag), so mirroring them requires rendering the desired chart version in-shell — too involved/fragile for one PR. Documented as the #4982 follow-up; the pre-flight prevents the whole class today with no render dependency.

## Verify (all green)
- `helm template` clean (7279 lines; 0.1.117 label on every resource)
- `sh -n` + `bash -n` on the rendered step-03 script: OK; jq pending-detection validated against fixtures (flags pin-bump + Ready=False + mid-roll replicas; skips settled/suspended/scaled-to-zero)
- `cutover-contract.sh <chart>`: **all 41 gates green** incl. new Case 40 + Case 41 (both negative-controlled — a poisoned `keep` and a missing Phase A0 are correctly detected)
- `image-registry-coverage.sh <chart>` + `--self-test`: PASS
- `go test -run TestCatalogSeed_DeliveryPinsNotBehindComponentCharts`: ok
- `check-bootstrap-kit-pin-sync.sh`: `bp-self-sovereign-cutover chart=0.1.117 pin=0.1.117` PASS
- `check-catalog-seed-lockstep.sh`: PASS (fail: 0)
- No CI-banned words; no NodePorts.

Refs #4982 #3379