### PR TITLE
feat(#3988): openova-mcp HTTP/SSE serve mode (unblocks bp-openova-mcp networked Blueprint)

### DIFF
--- a/products/openova-mcp/README.md
+++ b/products/openova-mcp/README.md
@@ -12,8 +12,10 @@ system.
 This module is the **first concrete, live-testable slice** of the EPIC. It
 ships:
 
-1. **The MCP server core** (`cmd/openova-mcp`) — JSON-RPC 2.0 over stdio,
-   the same proven transport the sandbox MCP uses.
+1. **The MCP server core** (`cmd/openova-mcp`) — JSON-RPC 2.0 over one of two
+   transports that share the SAME dispatch + auth core: **stdio** (default,
+   the same proven transport the sandbox MCP uses) and an opt-in **HTTP/SSE**
+   (Streamable-HTTP) transport (see [Transports](#transports) below).
 2. **Per-relevant-Keycloak identity resolution** (`internal/identity`) —
    parses the bearer into `auth.Claims`, derives the realm **context**
    (Organization vs Sovereign), the **tier** (viewer<developer<operator<
@@ -62,6 +64,41 @@ ships:
   caller's Org namespace (`<org>` / `<org>-<env_type>`), so a cross-Org
   leak cannot pass through even if the endpoint widened.
 
+## Transports
+
+The server speaks JSON-RPC 2.0 over one of two transports selected at startup.
+Both run the **identical** resolve → two-layer-RBAC → thin-facade flow
+(`core.handle` in `cmd/openova-mcp`) — the transport only owns the wire, never
+the auth or dispatch logic.
+
+- **stdio (default)** — NDJSON- or Content-Length-framed on stdin/stdout. This
+  is the path `agenity` bakes and forks per session. The bearer is supplied per
+  `tools/call`/`tools/list` via the `_auth.token` argument or `OPENOVA_MCP_BEARER`.
+  Runs whenever no HTTP address is configured — **byte-for-byte unaffected** by
+  the HTTP addition.
+- **HTTP/SSE (opt-in, #3988 §5 / #899)** — the MCP **Streamable-HTTP** transport,
+  enabled by setting `OPENOVA_MCP_HTTP_ADDR` (e.g. `:8080`) or passing
+  `--http :8080`. Endpoints:
+
+  | Method + path | Purpose |
+  |---|---|
+  | `POST /mcp` | a JSON-RPC request → JSON-RPC response (`application/json`); a notification → `202` |
+  | `GET /mcp` | server→client SSE stream (`text/event-stream`); keep-alive today (no server-initiated messages in this slice) |
+  | `GET /healthz`, `GET /readyz` | liveness/readiness for the chart probes |
+  | `GET /` | JSON descriptor of the surface |
+
+  **Auth:** every `/mcp` request MUST carry `Authorization: Bearer <jwt>`,
+  validated through the SAME resolver the stdio path uses. An absent/invalid
+  bearer is rejected at the transport with **HTTP 401** (+ `WWW-Authenticate`)
+  before any dispatch. Application-tier RBAC is unchanged: a `tools/list` scope
+  filter and a `tools/call` Org-scope re-auth (cross-Org `create`/`get` →
+  **MCP 403**, the JSON-RPC error `-32003` with `data.status: 403`, inside a
+  `200`) hold exactly as on stdio. The listener is a plain in-Pod address; the
+  front door is the Cilium Gateway HTTPRoute — **never a NodePort**.
+
+  This is the server the `bp-openova-mcp` chart's `httpTransport.enabled` path
+  (PR #4981) is built to serve: container port `8080`, probes on `/healthz`.
+
 ## Env contract (`cmd/openova-mcp`)
 
 | Env var | Purpose |
@@ -71,7 +108,8 @@ ships:
 | `OPENOVA_MCP_VERIFY` | `rs256` (default) \| `hs256` \| `insecure` — bearer verification mode |
 | `OPENOVA_MCP_RS256_PUBKEY_PEM` | PEM of the RS256 public key (Sovereign handover-jwt pubkey) when verify=rs256 |
 | `OPENOVA_MCP_HS256_SECRET` | HS256 shared secret when verify=hs256 |
-| `OPENOVA_MCP_BEARER` | fallback bearer when a `tools/call` omits the `_auth.token` argument |
+| `OPENOVA_MCP_BEARER` | fallback bearer when a `tools/call` omits the `_auth.token` argument (stdio); on HTTP, a server-token fallback when a request omits the `Authorization` header |
+| `OPENOVA_MCP_HTTP_ADDR` | when set (e.g. `:8080`), serve the HTTP/SSE transport on this address instead of stdio (equivalent to `--http <addr>`) |
 
 ## Live-acceptance (hw173)
 
@@ -82,7 +120,7 @@ server **inside hw173's catalyst-api pod** pointed at the real
 - A sovereign-admin `list_applications` returns the **real** Application CRs
   unfiltered.
 - An Org token (`org_id=acme`) sees **only** that Org's Applications.
-- An out-of-scope `get_application` for another Org returns **forbidden**.
+- A cross-Org `get_application` for another Org returns **forbidden**.
 
 See the walk evidence on issue #3988.
 
@@ -93,8 +131,10 @@ follow-ups:
 
 - **Agenity integration** — the `bp-openova-mcp dependsOn bp-agenity`
   Blueprint chart, the `openovaMCP.*` repoint, the `.mcp.json` injection.
-- **HTTP/SSE transport** — this slice uses stdio; the long-lived
-  per-Org/per-Sovereign Service needs streamable-HTTP/SSE + stable DNS.
+- **Bootstrap-kit / catalog-seed wiring** — the HTTP/SSE transport itself now
+  exists (see [Transports](#transports)), but flipping `httpTransport.enabled`
+  on a real Sovereign (the ConfigMap that sets `OPENOVA_MCP_HTTP_ADDR`, the
+  stable per-Org/per-Sovereign DNS + HTTPRoute host) is a post-SME follow-up.
 - **Per-realm JWKS validation** — this slice verifies against a single
   RS256/HS256 key; the full per-realm JWKS cache (Org realm vs Sovereign
   realm) is the production identity path.

--- a/products/openova-mcp/cmd/openova-mcp/http.go
+++ b/products/openova-mcp/cmd/openova-mcp/http.go
@@ -1,0 +1,278 @@
+// http.go — the opt-in HTTP/SSE transport for openova-mcp (#3988 §5 / #899).
+//
+// This is the MCP Streamable-HTTP transport: a single MCP endpoint (/mcp)
+// that accepts a JSON-RPC request over POST and offers a server→client SSE
+// stream over GET, plus a /healthz probe endpoint the bp-openova-mcp chart's
+// readiness/liveness probes target. It REUSES the SAME dispatch + auth core
+// the stdio transport uses (core.handle) — it forks NONE of the resolve /
+// two-layer-RBAC / thin-facade logic; the only thing this file adds is the
+// wire (HTTP framing + the transport-level bearer gate).
+//
+// Auth: every request to /mcp MUST carry `Authorization: Bearer <jwt>`. The
+// bearer is validated through the SAME identity.Resolver the stdio path uses;
+// an absent/invalid bearer is rejected at the transport with HTTP 401 (plus a
+// `WWW-Authenticate: Bearer` challenge, the OAuth/MCP idiom) BEFORE any
+// dispatch. Application-tier RBAC (the tools/list scope filter and the
+// tools/call Org-scope re-auth, including the cross-Org ErrForbidden → MCP 403)
+// is enforced inside core.handle exactly as on stdio — an app-tier denial is a
+// JSON-RPC error (code -32003, data.status 403) inside a 200 HTTP response, NOT
+// an HTTP 403, so MCP clients see identical semantics on both wires.
+//
+// 🛑 NodePorts are ABSOLUTELY FORBIDDEN. This transport binds a plain in-Pod
+// listen address (":8080"); the front door is the Cilium Gateway HTTPRoute the
+// chart renders — never a nodePort.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const (
+	// mcpEndpoint is the single MCP Streamable-HTTP endpoint: POST for a
+	// JSON-RPC request, GET for the server→client SSE stream.
+	mcpEndpoint = "/mcp"
+
+	// maxRequestBytes bounds a single JSON-RPC POST body (the tool arguments
+	// are small; a create_application body is a few KiB). Mirrors the
+	// catalyst-api client's 8MiB read cap order-of-magnitude, kept smaller
+	// here since MCP requests are tiny.
+	maxRequestBytes = 4 << 20 // 4 MiB
+
+	// sseHeartbeat keeps the GET stream alive through idle proxies.
+	sseHeartbeat = 15 * time.Second
+
+	// httpReadHeaderTimeout bounds slow-loris header reads (mirrors the
+	// openova-flow server convention).
+	httpReadHeaderTimeout = 10 * time.Second
+
+	// shutdownGrace bounds the graceful-drain window on SIGTERM/SIGINT.
+	shutdownGrace = 5 * time.Second
+)
+
+// resolveHTTPAddr decides the HTTP listen address (empty = run stdio). A
+// `--http <addr>` flag wins; otherwise OPENOVA_MCP_HTTP_ADDR. Parsing uses a
+// private FlagSet with ContinueOnError and discarded output, and IGNORES parse
+// errors, so a stray/unknown arg on the stdio invocation can NEVER break the
+// default stdio path (the byte-for-byte-unaffected guarantee).
+func resolveHTTPAddr(args []string) string {
+	fs := flag.NewFlagSet("openova-mcp", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	httpAddr := fs.String("http", "", "listen address for the HTTP/SSE transport (e.g. :8080); empty = stdio")
+	_ = fs.Parse(args) // ignore errors: unknown args must not break stdio
+	if strings.TrimSpace(*httpAddr) != "" {
+		return strings.TrimSpace(*httpAddr)
+	}
+	return strings.TrimSpace(os.Getenv("OPENOVA_MCP_HTTP_ADDR"))
+}
+
+// httpTransport serves the MCP Streamable-HTTP/SSE transport over the shared
+// core. It holds no auth/dispatch logic of its own.
+type httpTransport struct {
+	core *core
+	log  *slog.Logger
+}
+
+// serveHTTP runs the HTTP/SSE transport on addr until SIGTERM/SIGINT, then
+// drains gracefully. It blocks; returns a non-nil error only on a listen
+// failure (mirrors the openova-flow server lifecycle).
+func serveHTTP(addr string, c *core) error {
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	t := &httpTransport{core: c, log: logger}
+
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           t.router(),
+		ReadHeaderTimeout: httpReadHeaderTimeout,
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
+	errCh := make(chan error, 1)
+	go func() {
+		logger.Info("openova-mcp HTTP/SSE transport listening",
+			"addr", addr, "endpoint", mcpEndpoint, "healthz", "/healthz")
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+		}
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		logger.Info("shutting down HTTP/SSE transport")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownGrace)
+		defer cancel()
+		return srv.Shutdown(shutdownCtx)
+	}
+}
+
+// router wires the transport surface. Split out so tests can drive the handler
+// with httptest without binding a socket.
+//
+//	POST /mcp       JSON-RPC request  → JSON-RPC response (application/json)
+//	GET  /mcp       server→client SSE stream (text/event-stream)
+//	GET  /healthz   liveness  (chart probe target)
+//	GET  /readyz    readiness (chart probe target)
+//	GET  /          JSON descriptor of the surface
+func (t *httpTransport) router() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST "+mcpEndpoint, t.handlePost)
+	mux.HandleFunc("GET "+mcpEndpoint, t.handleGetSSE)
+	mux.HandleFunc("GET /healthz", t.handleHealth)
+	mux.HandleFunc("GET /readyz", t.handleHealth)
+	mux.HandleFunc("GET /{$}", t.handleRoot)
+	return mux
+}
+
+// handlePost dispatches one JSON-RPC request. The transport-level bearer gate
+// runs first (401 on invalid/absent); then core.handle runs the identical
+// resolve→RBAC→dispatch flow the stdio path uses.
+func (t *httpTransport) handlePost(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxRequestBytes))
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "read request body: "+err.Error())
+		return
+	}
+
+	bearer, ok := t.authOr401(w, r)
+	if !ok {
+		return
+	}
+
+	resp := t.core.handle(r.Context(), bearer, body)
+	if resp == nil {
+		// A notification (no id) takes no reply — ack at the transport.
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+	out, err := json.Marshal(resp)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "marshal response")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(out)
+}
+
+// handleGetSSE opens the server→client SSE stream. This slice's tool set has
+// no server-initiated messages (capabilities.tools.listChanged=false), so the
+// stream is a spec-compliant keep-alive channel: an open comment + periodic
+// heartbeats until the client disconnects. Auth is enforced identically to the
+// POST path.
+func (t *httpTransport) handleGetSSE(w http.ResponseWriter, r *http.Request) {
+	if _, ok := t.authOr401(w, r); !ok {
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeJSONError(w, http.StatusInternalServerError, "streaming unsupported")
+		return
+	}
+
+	h := w.Header()
+	h.Set("Content-Type", "text/event-stream")
+	h.Set("Cache-Control", "no-cache, no-transform")
+	h.Set("Connection", "keep-alive")
+	h.Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+
+	// SSE comment line: signals the stream is open without emitting a
+	// JSON-RPC message (there are none to push in this slice).
+	_, _ = fmt.Fprint(w, ": openova-mcp stream open\n\n")
+	flusher.Flush()
+
+	ticker := time.NewTicker(sseHeartbeat)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-ticker.C:
+			if _, err := fmt.Fprint(w, "event: heartbeat\ndata: {}\n\n"); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}
+
+func (t *httpTransport) handleHealth(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok\n"))
+}
+
+func (t *httpTransport) handleRoot(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(rootDescriptor))
+}
+
+// authOr401 validates the Authorization: Bearer header (falling back to the
+// OPENOVA_MCP_BEARER server bearer when no header is present) through the SAME
+// resolver the stdio path uses. On success it returns the raw bearer (which
+// core.handle re-resolves for the RBAC decision) and true. On failure it writes
+// an HTTP 401 with a WWW-Authenticate challenge and returns ("", false).
+func (t *httpTransport) authOr401(w http.ResponseWriter, r *http.Request) (string, bool) {
+	bearer := bearerFromHeader(r)
+	if bearer == "" {
+		bearer = strings.TrimSpace(t.core.fallbackBearer)
+	}
+	if _, err := t.core.resolveBearer(bearer); err != nil {
+		w.Header().Set("WWW-Authenticate", `Bearer realm="openova-mcp"`)
+		writeJSONError(w, http.StatusUnauthorized, "unauthorized: "+err.Error())
+		return "", false
+	}
+	return bearer, true
+}
+
+// bearerFromHeader extracts the compact JWT from `Authorization: Bearer …`,
+// returning "" when the header is absent. Case-insensitive on the scheme.
+func bearerFromHeader(r *http.Request) string {
+	h := strings.TrimSpace(r.Header.Get("Authorization"))
+	if h == "" {
+		return ""
+	}
+	if len(h) >= 7 && strings.EqualFold(h[:7], "Bearer ") {
+		return strings.TrimSpace(h[7:])
+	}
+	return h
+}
+
+// writeJSONError writes a minimal JSON error body with an HTTP status. Used for
+// TRANSPORT-level failures (bad body, 401); application-tier errors travel as
+// JSON-RPC error objects inside a 200 response (see core.toolError).
+func writeJSONError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}
+
+// rootDescriptor is the JSON body for GET / — a machine-readable description of
+// the surface so an operator (or smoke test) hitting the bare host gets a 200
+// instead of a 404.
+const rootDescriptor = `{` +
+	`"service":"openova-mcp",` +
+	`"description":"OpenOva MCP server — RBAC-scoped-per-user thin facade over the catalyst-api. HTTP/SSE (Streamable-HTTP) transport.",` +
+	`"transport":"streamable-http",` +
+	`"endpoints":{` +
+	`"mcp":"POST /mcp (JSON-RPC) | GET /mcp (SSE)",` +
+	`"healthz":"GET /healthz",` +
+	`"readyz":"GET /readyz"` +
+	`},` +
+	`"auth":"Authorization: Bearer <jwt> required on every /mcp request"` +
+	`}` + "\n"

--- a/products/openova-mcp/cmd/openova-mcp/http_test.go
+++ b/products/openova-mcp/cmd/openova-mcp/http_test.go
@@ -1,0 +1,377 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	sharedauth "github.com/openova-io/openova/core/services/shared/auth"
+	"github.com/openova-io/openova/products/openova-mcp/internal/catalystapi"
+	"github.com/openova-io/openova/products/openova-mcp/internal/identity"
+	"github.com/openova-io/openova/products/openova-mcp/internal/tools"
+)
+
+// ── test fixtures (reuse the identity/tools test idioms) ─────────────────
+
+// roundTripFunc stands in for the live catalyst-api (mirrors tools_test).
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func jsonResp(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+}
+
+// mintToken signs an alg=none JWT carrying claims — the same insecure-resolver
+// path identity_test uses. The HTTP transport verifies it through the SAME
+// resolver the stdio path uses.
+func mintToken(t *testing.T, claims *sharedauth.Claims) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodNone, claims)
+	signed, err := tok.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	if err != nil {
+		t.Fatalf("mint token: %v", err)
+	}
+	return signed
+}
+
+func orgAdminToken(t *testing.T) string {
+	return mintToken(t, &sharedauth.Claims{Email: "a@acme.test", OrgID: "acme", Role: "admin", DeploymentID: "dep1"})
+}
+
+func orgViewerToken(t *testing.T) string {
+	return mintToken(t, &sharedauth.Claims{Email: "v@acme.test", OrgID: "acme", Role: "viewer", DeploymentID: "dep1"})
+}
+
+// newTestTransport builds an httpTransport over the insecure resolver (so
+// alg=none test tokens resolve) wired to the supplied backend client (nil for
+// tests that never reach the backend).
+func newTestTransport(api *catalystapi.Client) *httpTransport {
+	c := &core{
+		reg:            tools.NewRegistry(api),
+		resolver:       identity.NewInsecureResolver(""),
+		fallbackBearer: "",
+	}
+	return &httpTransport{core: c, log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+}
+
+func postMCP(t *testing.T, h http.Handler, bearer, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, mcpEndpoint, strings.NewReader(body))
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+// toolNames pulls the tool names out of a tools/list JSON-RPC response.
+func toolNames(t *testing.T, raw []byte) []string {
+	t.Helper()
+	var resp struct {
+		Result struct {
+			Tools []struct {
+				Name string `json:"name"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("decode tools/list: %v (body=%s)", err, raw)
+	}
+	out := make([]string, 0, len(resp.Result.Tools))
+	for _, tt := range resp.Result.Tools {
+		out = append(out, tt.Name)
+	}
+	return out
+}
+
+func hasName(names []string, want string) bool {
+	for _, n := range names {
+		if n == want {
+			return true
+		}
+	}
+	return false
+}
+
+// ── tests ────────────────────────────────────────────────────────────────
+
+// TestHTTPValidBearerDispatches — a valid-bearer tools/list POST dispatches
+// through the shared core and returns the JSON-RPC result over HTTP.
+func TestHTTPValidBearerDispatches(t *testing.T) {
+	tr := newTestTransport(nil)
+	rec := postMCP(t, tr.router(), orgAdminToken(t),
+		`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Errorf("want application/json, got %q", ct)
+	}
+	names := toolNames(t, rec.Body.Bytes())
+	for _, want := range []string{"whoami", "list_applications", "get_application"} {
+		if !hasName(names, want) {
+			t.Errorf("tools/list missing %q (got %v)", want, names)
+		}
+	}
+}
+
+// TestHTTPAbsentAndInvalidBearer401 — a request with no Authorization header,
+// and one with a non-JWT bearer, are both rejected at the transport with 401 +
+// a WWW-Authenticate challenge, before any dispatch.
+func TestHTTPAbsentAndInvalidBearer401(t *testing.T) {
+	tr := newTestTransport(nil)
+
+	// Absent bearer.
+	rec := postMCP(t, tr.router(), "", `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("absent bearer: want 401, got %d", rec.Code)
+	}
+	if ch := rec.Header().Get("WWW-Authenticate"); !strings.Contains(ch, "Bearer") {
+		t.Errorf("absent bearer: missing WWW-Authenticate challenge, got %q", ch)
+	}
+
+	// Invalid (non-JWT) bearer.
+	rec = postMCP(t, tr.router(), "not-a-jwt", `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("invalid bearer: want 401, got %d", rec.Code)
+	}
+}
+
+// TestHTTPToolsListFiltersByScope — layer-1 RBAC over HTTP: a viewer does NOT
+// see the admin-gated create_application; an admin does. Identical filtering to
+// the stdio path (same core, same registry).
+func TestHTTPToolsListFiltersByScope(t *testing.T) {
+	tr := newTestTransport(nil)
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`
+
+	viewer := toolNames(t, postMCP(t, tr.router(), orgViewerToken(t), body).Body.Bytes())
+	if hasName(viewer, "create_application") {
+		t.Error("viewer must NOT see create_application over HTTP (admin-gated)")
+	}
+	if !hasName(viewer, "list_applications") {
+		t.Error("viewer should still see the read tools")
+	}
+
+	admin := toolNames(t, postMCP(t, tr.router(), orgAdminToken(t), body).Body.Bytes())
+	if !hasName(admin, "create_application") {
+		t.Error("admin should see create_application over HTTP")
+	}
+}
+
+// TestHTTPCrossOrgToolsCallForbidden — layer-2 RBAC over HTTP: an acme-scoped
+// caller creating in globex is denied with the MCP 403 (JSON-RPC error -32003,
+// data.status 403) inside a 200 HTTP response, and the backend is NEVER hit.
+// Exact parity with the stdio cross-Org denial.
+func TestHTTPCrossOrgToolsCallForbidden(t *testing.T) {
+	called := false
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		called = true
+		return jsonResp(201, `{"kind":"Application"}`), nil
+	})
+	api := catalystapi.New("https://console.test").WithHTTPClient(&http.Client{Transport: rt})
+	tr := newTestTransport(api)
+
+	body := `{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"create_application","arguments":{"blueprint":"bp-gitea","version":"1.0.0","name":"leak","organization":"globex"}}}`
+	rec := postMCP(t, tr.router(), orgAdminToken(t), body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("app-tier denial travels as JSON-RPC error inside a 200, got HTTP %d", rec.Code)
+	}
+	var resp struct {
+		Error *struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+			Data    struct {
+				Status int `json:"status"`
+			} `json:"data"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, rec.Body.String())
+	}
+	if resp.Error == nil {
+		t.Fatalf("cross-org create should return a JSON-RPC error, got %s", rec.Body.String())
+	}
+	if resp.Error.Code != -32003 || resp.Error.Data.Status != 403 {
+		t.Fatalf("want MCP 403 (code -32003, status 403), got code=%d status=%d",
+			resp.Error.Code, resp.Error.Data.Status)
+	}
+	if called {
+		t.Fatal("cross-org create must NOT reach the backend (denied at the facade)")
+	}
+}
+
+// TestHTTPOwnOrgToolsCallDispatches — a valid own-org create dispatches through
+// the shared core, forwards the caller's bearer to the backend, and returns the
+// install envelope over HTTP.
+func TestHTTPOwnOrgToolsCallDispatches(t *testing.T) {
+	var sawAuth, sawPath string
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		sawAuth = r.Header.Get("Authorization")
+		sawPath = r.URL.Path
+		return jsonResp(201, `{"kind":"Application","name":"shop","namespace":"acme","applied":true}`), nil
+	})
+	api := catalystapi.New("https://console.acme.omani.homes").
+		WithTenantHost("console.acme.omani.homes").
+		WithHTTPClient(&http.Client{Transport: rt})
+	tr := newTestTransport(api)
+	token := orgAdminToken(t)
+
+	body := `{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"create_application","arguments":{"blueprint":"bp-wordpress","version":"1.2.3","name":"shop"}}}`
+	rec := postMCP(t, tr.router(), token, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+
+	// The caller's bearer is forwarded verbatim to the catalyst-api (thin
+	// facade) and the org-context create uses the dedicated own-org route.
+	if sawAuth != "Bearer "+token {
+		t.Errorf("bearer not forwarded to backend: %q", sawAuth)
+	}
+	if sawPath != "/api/v1/org/applications" {
+		t.Errorf("org context must use the own-org route, got %q", sawPath)
+	}
+
+	var resp struct {
+		Result struct {
+			Content []struct {
+				Text string `json:"text"`
+			} `json:"content"`
+			IsError bool `json:"isError"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Result.IsError || len(resp.Result.Content) == 0 {
+		t.Fatalf("unexpected result envelope: %s", rec.Body.String())
+	}
+	if !strings.Contains(resp.Result.Content[0].Text, `"applied":true`) {
+		t.Errorf("install envelope not surfaced: %s", resp.Result.Content[0].Text)
+	}
+}
+
+// TestHTTPNotificationAccepted — a JSON-RPC notification (no id) takes no reply
+// and is acked at the transport with 202.
+func TestHTTPNotificationAccepted(t *testing.T) {
+	tr := newTestTransport(nil)
+	rec := postMCP(t, tr.router(), orgAdminToken(t),
+		`{"jsonrpc":"2.0","method":"notifications/initialized"}`)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("notification: want 202, got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("notification: want empty body, got %q", rec.Body.String())
+	}
+}
+
+// TestHTTPHealthz — the chart probe target returns 200.
+func TestHTTPHealthz(t *testing.T) {
+	tr := newTestTransport(nil)
+	for _, path := range []string{"/healthz", "/readyz"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rec := httptest.NewRecorder()
+		tr.router().ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s: want 200, got %d", path, rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), "ok") {
+			t.Errorf("%s: want ok body, got %q", path, rec.Body.String())
+		}
+	}
+}
+
+// TestHTTPGetSSEUnauthorized — the SSE stream enforces the same 401 gate.
+func TestHTTPGetSSEUnauthorized(t *testing.T) {
+	tr := newTestTransport(nil)
+	req := httptest.NewRequest(http.MethodGet, mcpEndpoint, nil)
+	rec := httptest.NewRecorder()
+	tr.router().ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated SSE: want 401, got %d", rec.Code)
+	}
+}
+
+// TestHTTPGetSSEOpensStream — an authenticated GET /mcp opens a
+// text/event-stream and emits the open frame. Driven through a real server so
+// the blocking stream handler can be canceled via the request context.
+func TestHTTPGetSSEOpensStream(t *testing.T) {
+	tr := newTestTransport(nil)
+	srv := httptest.NewServer(tr.router())
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+mcpEndpoint, nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+orgAdminToken(t))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("SSE open: want 200, got %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Fatalf("want text/event-stream, got %q", ct)
+	}
+	// The handler flushes an open comment immediately; read it, then cancel.
+	buf := make([]byte, 64)
+	n, err := resp.Body.Read(buf)
+	if err != nil && n == 0 {
+		t.Fatalf("read SSE open frame: %v", err)
+	}
+	if !strings.Contains(string(buf[:n]), "openova-mcp stream open") {
+		t.Errorf("SSE open frame not seen, got %q", string(buf[:n]))
+	}
+	cancel()
+}
+
+// TestResolveHTTPAddr — the flag wins over the env; the env is the fallback; an
+// unknown arg never breaks the (stdio) default.
+func TestResolveHTTPAddr(t *testing.T) {
+	t.Run("flag", func(t *testing.T) {
+		if got := resolveHTTPAddr([]string{"--http", ":9090"}); got != ":9090" {
+			t.Errorf("--http :9090 → %q", got)
+		}
+		if got := resolveHTTPAddr([]string{"--http=:7000"}); got != ":7000" {
+			t.Errorf("--http=:7000 → %q", got)
+		}
+	})
+	t.Run("env fallback", func(t *testing.T) {
+		t.Setenv("OPENOVA_MCP_HTTP_ADDR", ":8080")
+		if got := resolveHTTPAddr(nil); got != ":8080" {
+			t.Errorf("env → %q", got)
+		}
+	})
+	t.Run("flag wins over env", func(t *testing.T) {
+		t.Setenv("OPENOVA_MCP_HTTP_ADDR", ":8080")
+		if got := resolveHTTPAddr([]string{"--http", ":9090"}); got != ":9090" {
+			t.Errorf("flag should win over env, got %q", got)
+		}
+	})
+	t.Run("unknown arg is stdio (empty)", func(t *testing.T) {
+		t.Setenv("OPENOVA_MCP_HTTP_ADDR", "")
+		if got := resolveHTTPAddr([]string{"--unknown", "foo"}); got != "" {
+			t.Errorf("unknown arg must not break stdio, got %q", got)
+		}
+	})
+}

--- a/products/openova-mcp/cmd/openova-mcp/main.go
+++ b/products/openova-mcp/cmd/openova-mcp/main.go
@@ -6,13 +6,23 @@
 // UI. It is a THIN facade: every data tool forwards the caller's bearer to
 // the LIVE catalyst-api, so the endpoint's own authz is the final word.
 //
-// Wire model (this slice): JSON-RPC 2.0 over stdio (Content-Length-framed),
-// the same proven transport the sandbox MCP uses. The bearer is supplied
-// per `tools/call` (and `tools/list`) via the `_auth.token` argument OR the
-// OPENOVA_MCP_BEARER env fallback, validated into the shared
-// auth.Claims, and resolved into the (context, tier, scope) identity that
-// drives both RBAC layers. The streamable-HTTP/SSE transport + chepherd
-// injection are DEFERRED to follow-ups (#3988 §4.3, §5).
+// Wire model: JSON-RPC 2.0 over one of two transports that share the SAME
+// dispatch + auth core (see core.handle):
+//
+//   - stdio (DEFAULT): NDJSON- or Content-Length-framed on os.Stdin/os.Stdout,
+//     the same proven transport the sandbox MCP uses. The bearer is supplied
+//     per `tools/call` (and `tools/list`) via the `_auth.token` argument OR
+//     the OPENOVA_MCP_BEARER env fallback.
+//   - HTTP/SSE (opt-in, #3988 §5 / #899): the MCP Streamable-HTTP transport —
+//     a POST /mcp JSON-RPC endpoint + a GET /mcp server→client SSE stream,
+//     with the bearer in the `Authorization: Bearer` header, plus /healthz for
+//     the chart's probes. Selected by OPENOVA_MCP_HTTP_ADDR (or --http <addr>);
+//     when unset the binary runs stdio, byte-for-byte unaffected. This is what
+//     the bp-openova-mcp chart's httpTransport.enabled path serves.
+//
+// Either way the bearer is validated into the shared auth.Claims and resolved
+// into the (context, tier, scope) identity that drives both RBAC layers.
+// chepherd injection stays DEFERRED to a follow-up (#3988 §4.3).
 //
 // Env contract:
 //
@@ -29,6 +39,10 @@
 //	                              verify=rs256.
 //	OPENOVA_MCP_HS256_SECRET      HS256 shared secret when verify=hs256.
 //	OPENOVA_MCP_BEARER            fallback bearer when a call omits _auth.
+//	OPENOVA_MCP_HTTP_ADDR         when set (e.g. ":8080"), serve the HTTP/SSE
+//	                              transport on this address instead of stdio.
+//	                              Equivalent to the --http <addr> flag. Unset =
+//	                              stdio (default).
 package main
 
 import (
@@ -121,7 +135,7 @@ func main() {
 		}
 	}
 	reg := tools.NewRegistry(api)
-	srv := &server{reg: reg, resolver: resolver, fallbackBearer: os.Getenv("OPENOVA_MCP_BEARER"), out: os.Stdout}
+	c := &core{reg: reg, resolver: resolver, fallbackBearer: os.Getenv("OPENOVA_MCP_BEARER")}
 	tenantHostLog := ""
 	if api != nil {
 		tenantHostLog = api.TenantHost()
@@ -129,6 +143,28 @@ func main() {
 	log.Printf("env: catalyst_api=%q context_pin=%q verify=%q bearer_fallback=%v tenant_host=%q",
 		apiURL, os.Getenv("OPENOVA_MCP_CONTEXT"), verifyMode(), os.Getenv("OPENOVA_MCP_BEARER") != "", tenantHostLog)
 
+	// Transport selection: HTTP/SSE when an address is configured (env or
+	// --http), else stdio (the DEFAULT — byte-for-byte unchanged from the
+	// forked-child path agenity bakes). Keeping stdio the default makes the
+	// HTTP transport strictly ADDITIVE and matches the chart's
+	// httpTransport.enabled opt-in gate.
+	if addr := resolveHTTPAddr(os.Args[1:]); addr != "" {
+		log.Printf("transport: HTTP/SSE on %s", addr)
+		if err := serveHTTP(addr, c); err != nil {
+			log.Fatalf("http transport: %v", err)
+		}
+		return
+	}
+
+	log.Printf("transport: stdio")
+	serveStdio(c)
+}
+
+// serveStdio runs the JSON-RPC-over-stdio loop (the default transport). It is
+// the original main loop, unchanged: read a frame, dispatch through the shared
+// core, reply in the same framing the peer used (#4111).
+func serveStdio(c *core) {
+	srv := &server{core: c, out: os.Stdout}
 	in := bufio.NewReader(os.Stdin)
 	for {
 		msg, lineMode, err := readFrame(in)
@@ -152,12 +188,14 @@ func main() {
 	}
 }
 
-// server handles a single MCP peer over stdio.
+// server adapts the shared core to the stdio transport: it owns only the
+// framing (the writer + the latched framing mode) and delegates every message
+// to core.handle. The auth/dispatch/RBAC logic lives in core so the HTTP
+// transport reuses it verbatim.
 type server struct {
-	reg            *tools.Registry
-	resolver       *identity.Resolver
-	fallbackBearer string
-	out            io.Writer
+	core *core
+
+	out io.Writer
 
 	// lineDelimited records the framing the most-recent inbound message
 	// used: true = newline-delimited JSON (the MCP stdio spec default),
@@ -167,100 +205,142 @@ type server struct {
 }
 
 func (s *server) dispatch(raw []byte) error {
+	// stdio supplies no out-of-band bearer, so core.handle falls back to the
+	// per-call _auth.token / OPENOVA_MCP_BEARER path exactly as before.
+	resp := s.core.handle(context.Background(), "", raw)
+	if resp == nil {
+		return nil // notification — no reply
+	}
+	return s.writeFrame(*resp)
+}
+
+// ── transport-agnostic dispatch + auth core ──────────────────────────────
+
+// core is the transport-agnostic MCP dispatch + auth engine. Both the stdio
+// transport (server) and the HTTP/SSE transport (httpTransport) call
+// core.handle, so the resolve→two-layer-RBAC→dispatch flow is IDENTICAL on
+// every wire (#3988). It holds no writer and no framing state.
+type core struct {
+	reg            *tools.Registry
+	resolver       *identity.Resolver
+	fallbackBearer string
+}
+
+// handle dispatches one raw JSON-RPC message and returns the response to send,
+// or nil for a notification (which takes no reply). headerBearer is an
+// out-of-band bearer (the HTTP Authorization header); it is "" for stdio, in
+// which case the bearer is taken from the per-call _auth.token argument or the
+// OPENOVA_MCP_BEARER fallback — preserving the stdio behaviour byte-for-byte.
+func (c *core) handle(ctx context.Context, headerBearer string, raw []byte) *rpcResponse {
 	var req rpcRequest
 	if err := json.Unmarshal(raw, &req); err != nil {
-		return s.writeError(nil, -32700, "parse error", err.Error())
+		return errorResp(nil, -32700, "parse error", err.Error())
 	}
 	switch req.Method {
 	case "initialize":
-		return s.handleInitialize(req)
+		return c.handleInitialize(req)
 	case "tools/list":
-		return s.handleToolsList(req)
+		return c.handleToolsList(headerBearer, req)
 	case "tools/call":
-		return s.handleToolsCall(req)
+		return c.handleToolsCall(ctx, headerBearer, req)
 	case "ping":
-		return s.writeResult(req.ID, map[string]any{"pong": true})
+		return resultResp(req.ID, map[string]any{"pong": true})
 	case "notifications/initialized", "notifications/cancelled":
 		return nil
 	default:
-		return s.writeError(req.ID, -32601, "method not found", req.Method)
+		return errorResp(req.ID, -32601, "method not found", req.Method)
 	}
 }
 
-func (s *server) handleInitialize(req rpcRequest) error {
-	return s.writeResult(req.ID, map[string]any{
+func (c *core) handleInitialize(req rpcRequest) *rpcResponse {
+	return resultResp(req.ID, map[string]any{
 		"protocolVersion": protocolVersion,
 		"serverInfo":      map[string]any{"name": serverName, "version": serverVersion},
 		"capabilities":    map[string]any{"tools": map[string]any{"listChanged": false}},
 	})
 }
 
-// handleToolsList resolves the caller and returns ONLY the tools visible
-// to their (context, tier) — layer-1 RBAC. The bearer is read from the
-// `_meta._auth.token` param OR the env fallback. An unauthenticated
-// tools/list returns an empty surface (a caller with no identity sees
-// nothing).
-func (s *server) handleToolsList(req rpcRequest) error {
-	id, _ := s.resolveFromParams(req.Params)
-	return s.writeResult(req.ID, map[string]any{"tools": s.reg.List(id)})
+// handleToolsList resolves the caller and returns ONLY the tools visible to
+// their (context, tier) — layer-1 RBAC. The bearer is read from the out-of-band
+// header (HTTP), the `_auth.token` param (stdio), or the env fallback. An
+// unauthenticated tools/list returns an empty surface (no identity → no tools).
+func (c *core) handleToolsList(headerBearer string, req rpcRequest) *rpcResponse {
+	id, _ := c.resolveBearer(effectiveBearer(headerBearer, c.fallbackBearer, req.Params))
+	return resultResp(req.ID, map[string]any{"tools": c.reg.List(id)})
 }
 
-func (s *server) handleToolsCall(req rpcRequest) error {
+func (c *core) handleToolsCall(ctx context.Context, headerBearer string, req rpcRequest) *rpcResponse {
 	var params struct {
 		Name      string          `json:"name"`
 		Arguments json.RawMessage `json:"arguments"`
 	}
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		return s.writeError(req.ID, -32602, "invalid params", err.Error())
+		return errorResp(req.ID, -32602, "invalid params", err.Error())
 	}
 
-	id, err := s.resolveBearer(extractBearer(s.fallbackBearer, params.Arguments))
+	id, err := c.resolveBearer(effectiveBearer(headerBearer, c.fallbackBearer, params.Arguments))
 	if err != nil {
-		return s.writeError(req.ID, -32001, "unauthenticated", err.Error())
+		return errorResp(req.ID, -32001, "unauthenticated", err.Error())
 	}
 	args := stripAuthEnvelope(params.Arguments)
 
-	result, callErr := s.reg.Call(context.Background(), id, params.Name, args)
+	result, callErr := c.reg.Call(ctx, id, params.Name, args)
 	if callErr != nil {
-		return s.toolError(req.ID, callErr)
+		return c.toolError(req.ID, callErr)
 	}
 	body, _ := json.Marshal(result)
-	return s.writeResult(req.ID, map[string]any{
+	return resultResp(req.ID, map[string]any{
 		"content": []map[string]any{{"type": "text", "text": string(body)}},
 		"isError": false,
 	})
 }
 
 // toolError maps a Call error to the right MCP error code so the parity
-// semantics hold: a forbidden tool returns a distinct code carrying the
-// 403-equivalent, an upstream catalyst-api status is surfaced verbatim.
-func (s *server) toolError(id json.RawMessage, err error) error {
+// semantics hold on every transport: a forbidden tool returns a distinct code
+// carrying the 403-equivalent, an upstream catalyst-api status is surfaced
+// verbatim.
+func (c *core) toolError(id json.RawMessage, err error) *rpcResponse {
 	switch {
 	case errors.Is(err, tools.ErrForbidden):
-		return s.writeError(id, -32003, "forbidden", map[string]any{"status": 403, "detail": err.Error()})
+		return errorResp(id, -32003, "forbidden", map[string]any{"status": 403, "detail": err.Error()})
 	case errors.Is(err, tools.ErrUnknownTool):
-		return s.writeError(id, -32601, "unknown tool", err.Error())
+		return errorResp(id, -32601, "unknown tool", err.Error())
 	default:
 		var apiErr *catalystapi.APIError
 		if errors.As(err, &apiErr) {
-			return s.writeError(id, -32010, "upstream error",
+			return errorResp(id, -32010, "upstream error",
 				map[string]any{"status": apiErr.Status, "body": apiErr.Body})
 		}
-		return s.writeError(id, -32000, "tool error", err.Error())
+		return errorResp(id, -32000, "tool error", err.Error())
 	}
 }
 
-// resolveFromParams pulls a bearer out of a generic params blob (the
-// `_meta._auth.token` or `_auth.token` side-channel) for tools/list.
-func (s *server) resolveFromParams(params json.RawMessage) (*identity.Identity, error) {
-	return s.resolveBearer(extractBearer(s.fallbackBearer, params))
-}
-
-func (s *server) resolveBearer(bearer string) (*identity.Identity, error) {
+func (c *core) resolveBearer(bearer string) (*identity.Identity, error) {
 	if bearer == "" {
-		return nil, errors.New("no bearer (set _auth.token in arguments or OPENOVA_MCP_BEARER)")
+		return nil, errors.New("no bearer (set Authorization: Bearer, _auth.token in arguments, or OPENOVA_MCP_BEARER)")
 	}
-	return s.resolver.Resolve(bearer)
+	return c.resolver.Resolve(bearer)
+}
+
+// effectiveBearer selects the bearer for a call. An out-of-band headerBearer
+// (the HTTP Authorization header) wins; otherwise the per-call `_auth.token`
+// side-channel or the OPENOVA_MCP_BEARER fallback is used (the stdio path).
+// With headerBearer=="" this is identical to the original stdio extraction.
+func effectiveBearer(headerBearer, fallback string, raw json.RawMessage) string {
+	if h := strings.TrimSpace(strings.TrimPrefix(headerBearer, "Bearer ")); h != "" {
+		return h
+	}
+	return extractBearer(fallback, raw)
+}
+
+// resultResp / errorResp build the JSON-RPC response envelopes both transports
+// send. Split out so core.handle returns a value the caller frames for its wire.
+func resultResp(id json.RawMessage, result any) *rpcResponse {
+	return &rpcResponse{JSONRPC: "2.0", ID: id, Result: result}
+}
+
+func errorResp(id json.RawMessage, code int, msg string, data any) *rpcResponse {
+	return &rpcResponse{JSONRPC: "2.0", ID: id, Error: &rpcError{Code: code, Message: msg, Data: data}}
 }
 
 // ── bearer plumbing (mirrors the sandbox MCP _auth envelope) ─────────────


### PR DESCRIPTION
## What

Adds the MCP **Streamable-HTTP / SSE** transport to `openova-mcp`, which was
**stdio-only** (JSON-RPC over `os.Stdin`/`os.Stdout`, no `net.Listen`). Because
the binary bound no port, it could not be a live networked Blueprint — which is
exactly why PR #4981's packaging chart gates every serving resource behind
`httpTransport.enabled` (default off) and UAT rows 211/212/213/221/222/223 are ❌.

This gives that gated chart path a **real server to hit**: container port
`8080`, probes on `/healthz`, per-connection bearer auth.

This is the **design-now (parallel)** half of #899. It implements the transport
+ tests only; it does **not** wire anything into bootstrap-kit / catalog-seed
(that is the post-SME step).

## Transport design

| Method + path | Purpose |
|---|---|
| `POST /mcp` | one JSON-RPC request → JSON-RPC response (`application/json`); a notification → `202` |
| `GET /mcp` | server→client SSE stream (`text/event-stream`); keep-alive today (no server-initiated messages in this slice) |
| `GET /healthz`, `GET /readyz` | liveness/readiness for the chart probes |
| `GET /` | JSON descriptor of the surface |

- **Selection:** `OPENOVA_MCP_HTTP_ADDR` (e.g. `:8080`) or `--http :8080`.
  **stdio stays the default** — the HTTP transport is strictly additive and
  matches the chart's `httpTransport.enabled` opt-in gate.
- **Auth (reuses `internal/identity`):** every `/mcp` request must carry
  `Authorization: Bearer <jwt>`, validated through the **same** resolver the
  stdio path uses. Absent/invalid → **HTTP 401** (+ `WWW-Authenticate`) before
  any dispatch.
- **App-tier RBAC (reuses `internal/tools`) preserved verbatim:** `tools/list`
  filters by `(context, tier)`; `tools/call` re-auths by Org scope; a cross-Org
  `get`/`create` still returns the **MCP 403** (`ErrForbidden` → JSON-RPC
  `-32003`, `data.status: 403`) inside a `200`, exactly as on stdio.
- Graceful shutdown on SIGTERM/SIGINT; structured `slog` logging; **ClusterIP-only**
  listener — **no NodePorts**.

## Refactor (noted, minimal)

Extracted a transport-agnostic core `core.handle(ctx, headerBearer, raw) *rpcResponse`
from the old stdio `server`. Both transports call it, so the
resolve → two-layer-RBAC → dispatch flow is **identical** on every wire. The
stdio framing (`readFrame`/`writeFrame`, #4111) is untouched → the
forked-per-session stdio path agenity bakes is **byte-for-byte unaffected** when
HTTP mode is off (verified by driving the real binary + unchanged stdio tests).

## Files

- `cmd/openova-mcp/main.go` — extract `core`; stdio `server` becomes a framing
  wrapper; add transport selection (`resolveHTTPAddr`).
- `cmd/openova-mcp/http.go` — **new** — the HTTP/SSE transport.
- `cmd/openova-mcp/http_test.go` — **new** — transport tests.
- `README.md` — document the transport + `OPENOVA_MCP_HTTP_ADDR`.

## Verify

- `go build ./...`, `go test ./...` (incl. `-race`), `go vet ./...` — all clean.
  New tests: valid-bearer dispatch; absent/invalid bearer → 401; `tools/list`
  scope filter; cross-Org `tools/call` → MCP 403 with no backend hit; own-org
  create dispatches + forwards the bearer; notification → 202; `/healthz`; SSE
  401 + authenticated open; `resolveHTTPAddr` flag/env. Existing stdio + framing
  tests pass unchanged.
- Drove the compiled binary end-to-end: stdio mode returns identical NDJSON;
  HTTP mode serves `/healthz`→200, no-bearer `POST /mcp`→401, `tools/list` with
  bearer→200 (all 6 tools), `initialize`→200, `GET /mcp`→200 `text/event-stream`,
  graceful shutdown on signal.

## Does this unblock `bp-openova-mcp`?

Yes — the binary now has an HTTP/SSE serve mode, so the #4981 chart's
`httpTransport.enabled` path has a real server: it sets `containerPort: 8080`
and probes `/healthz:8080`, both of which this transport provides. The one
remaining wiring step (owned by the chart / post-SME follow-up, **not** this PR):
the chart must also pass `OPENOVA_MCP_HTTP_ADDR=:8080` (ConfigMap env) or
`--http :8080` (args) to flip the binary into HTTP mode — the ConfigMap
currently sets no such value, and the binary defaults to stdio without it (by
design, to keep the agenity forked-stdio path byte-for-byte unaffected).

Refs #3988 #899
