### PR TITLE
fix(#3374): console silent prompt=none re-auth on session-TTL expiry (no PIN re-prompt)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -370,7 +370,13 @@ async function attemptSilentSovereignSSO(): Promise<boolean> {
     // initiateLogin calls window.location.replace(authEndpoint) — the
     // browser navigates to Keycloak. Control does not return here in
     // practice; we still return true so the caller aborts the route.
-    await initiateLogin(fqdn)
+    //
+    // #3374 row 29 — the attempt MUST be truly silent: `prompt=none` tells
+    // Keycloak to reuse an existing SSO session (→ code, no UI) or return
+    // `error=login_required` WITHOUT rendering the interactive PIN form.
+    // Omitting it lets the realm's catalyst-pin redirector show a PIN wall
+    // during what is supposed to be an invisible re-auth on TTL expiry.
+    await initiateLogin(fqdn, { prompt: 'none' })
     return true
   } catch {
     // OIDC module failed to load / build the request — fall back.

--- a/products/catalyst/bootstrap/ui/src/pages/auth/AuthCallbackPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/auth/AuthCallbackPage.tsx
@@ -62,7 +62,7 @@ function SovereignCallbackPage() {
     async function exchange() {
       try {
         // Lazy-import oidc so Catalyst-Zero builds don't pay for unused code.
-        const { handleCallback } = await import('@/shared/lib/oidc')
+        const { handleCallback, parseSilentAuthError } = await import('@/shared/lib/oidc')
         const { DETECTED_MODE } = await import('@/shared/lib/detectMode')
 
         const sovereignFQDN = DETECTED_MODE.sovereignFQDN
@@ -75,6 +75,28 @@ function SovereignCallbackPage() {
         }
 
         const params = new URLSearchParams(window.location.search)
+
+        // #3374 row 29 — a `prompt=none` silent-SSO attempt (router.tsx
+        // attemptSilentSovereignSSO) that finds no reusable Keycloak
+        // session returns here with ?error=login_required (or
+        // interaction_required / consent_required / account_selection_
+        // required) and NO code. That is the EXPECTED "no live SSO session"
+        // outcome of a SILENT re-auth — not a failure. Fall back cleanly to
+        // the interactive /login PIN form instead of the hard "Sign-in
+        // failed" screen, and clear the one-shot silent-SSO guard so a LATER
+        // genuine session expiry re-arms the silent round-trip (the guard is
+        // otherwise only cleared on a successful exchange). /login is a
+        // public route, so this hard-nav cannot loop back through the gate.
+        if (parseSilentAuthError(params)) {
+          try {
+            sessionStorage.removeItem('catalyst:silent-sso-attempted')
+          } catch {
+            /* private browsing may throw */
+          }
+          window.location.replace(uiBase() + '/login')
+          return
+        }
+
         await handleCallback(sovereignFQDN, params)
         // #3374 Layer-B: clear the silent-SSO one-shot guard now that a
         // real session exists, so a LATER genuine expiry re-arms the

--- a/products/catalyst/bootstrap/ui/src/shared/lib/oidc.test.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/lib/oidc.test.ts
@@ -8,12 +8,15 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import {
   buildOIDCEndpoints,
   buildRedirectURI,
+  buildAuthorizeURL,
+  parseSilentAuthError,
   parseJWTClaims,
   getRequiredActions,
   saveTokens,
   loadTokens,
   clearTokens,
   isTokenExpired,
+  SILENT_AUTH_RECOVERABLE_ERRORS,
   REQUIRED_ACTION_UPDATE_PASSWORD,
   REQUIRED_ACTION_CONFIGURE_PASSKEY,
   REQUIRED_ACTION_CONFIGURE_TOTP,
@@ -55,6 +58,77 @@ describe('buildOIDCEndpoints()', () => {
 describe('buildRedirectURI()', () => {
   it('returns origin + /auth/callback', () => {
     expect(buildRedirectURI()).toBe(`${window.location.origin}/auth/callback`)
+  })
+})
+
+// ── buildAuthorizeURL (#3374 row 29 — silent prompt=none re-auth) ─────────────
+
+describe('buildAuthorizeURL()', () => {
+  const args = {
+    challenge: 'chal-abc',
+    state: 'state-xyz',
+    redirectURI: 'https://console.otech23.omani.works/auth/callback',
+  }
+
+  it('targets the Sovereign Keycloak authorization endpoint with a PKCE code request', () => {
+    const url = new URL(buildAuthorizeURL('otech23.omani.works', args))
+    expect(url.origin + url.pathname).toBe(
+      'https://auth.otech23.omani.works/realms/sovereign/protocol/openid-connect/auth',
+    )
+    expect(url.searchParams.get('response_type')).toBe('code')
+    expect(url.searchParams.get('client_id')).toBe('catalyst-ui')
+    expect(url.searchParams.get('code_challenge')).toBe('chal-abc')
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256')
+    expect(url.searchParams.get('state')).toBe('state-xyz')
+    expect(url.searchParams.get('redirect_uri')).toBe(args.redirectURI)
+  })
+
+  it('OMITS prompt for an ordinary interactive request', () => {
+    const url = new URL(buildAuthorizeURL('otech23.omani.works', args))
+    expect(url.searchParams.has('prompt')).toBe(false)
+  })
+
+  it('adds prompt=none for a silent re-auth request', () => {
+    const url = new URL(
+      buildAuthorizeURL('otech23.omani.works', { ...args, prompt: 'none' }),
+    )
+    expect(url.searchParams.get('prompt')).toBe('none')
+  })
+})
+
+// ── parseSilentAuthError (#3374 row 29) ───────────────────────────────────────
+
+describe('parseSilentAuthError()', () => {
+  it('returns the error code when a silent attempt bounces back with login_required and no code', () => {
+    const params = new URLSearchParams({ error: 'login_required', state: 's' })
+    expect(parseSilentAuthError(params)).toBe('login_required')
+  })
+
+  it.each(SILENT_AUTH_RECOVERABLE_ERRORS)(
+    'recognises the recoverable silent-auth error %s',
+    (code) => {
+      const params = new URLSearchParams({ error: code })
+      expect(parseSilentAuthError(params)).toBe(code)
+    },
+  )
+
+  it('returns null on the happy path (authorization code present)', () => {
+    const params = new URLSearchParams({ code: 'auth-code-123', state: 's' })
+    expect(parseSilentAuthError(params)).toBeNull()
+  })
+
+  it('returns null when a code is present even alongside an error param', () => {
+    const params = new URLSearchParams({ code: 'auth-code-123', error: 'login_required' })
+    expect(parseSilentAuthError(params)).toBeNull()
+  })
+
+  it('returns null for a non-recoverable error so a genuine failure still surfaces', () => {
+    const params = new URLSearchParams({ error: 'invalid_client' })
+    expect(parseSilentAuthError(params)).toBeNull()
+  })
+
+  it('returns null when neither code nor error is present', () => {
+    expect(parseSilentAuthError(new URLSearchParams())).toBeNull()
   })
 })
 

--- a/products/catalyst/bootstrap/ui/src/shared/lib/oidc.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/lib/oidc.ts
@@ -187,15 +187,69 @@ export function parseJWTClaims(jwt: string): JWTClaims {
 
 // ── Authorization code flow (PKCE) ───────────────────────────────────────────
 
+export interface InitiateLoginOptions {
+  /**
+   * OpenID Connect `prompt` parameter (OIDC Core §3.1.2.1).
+   *
+   * Pass `'none'` for a SILENT re-authentication attempt (#3374 row 29):
+   * Keycloak authenticates the visitor against an EXISTING SSO session
+   * without rendering any UI, and — when no reusable session exists —
+   * returns `error=login_required` to the redirect_uri INSTEAD of showing
+   * the interactive catalyst-pin PIN form. Omit for an ordinary
+   * interactive authorization request.
+   */
+  prompt?: 'none'
+}
+
+/**
+ * Build the Keycloak authorization-endpoint URL for the PKCE code flow.
+ *
+ * Pure + exported so the parameter set — including the silent
+ * `prompt=none` variant (#3374 row 29) — is unit-testable without
+ * navigating the browser away.
+ */
+export function buildAuthorizeURL(
+  sovereignFQDN: string,
+  args: {
+    challenge: string
+    state: string
+    redirectURI: string
+    prompt?: 'none'
+  },
+): string {
+  const { authEndpoint } = buildOIDCEndpoints(sovereignFQDN)
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: CLIENT_ID,
+    redirect_uri: args.redirectURI,
+    scope: SCOPE,
+    state: args.state,
+    code_challenge: args.challenge,
+    code_challenge_method: 'S256',
+  })
+  // A silent re-auth request must carry `prompt=none` so Keycloak returns
+  // login_required rather than rendering the interactive PIN form.
+  if (args.prompt === 'none') params.set('prompt', 'none')
+  return `${authEndpoint}?${params.toString()}`
+}
+
 /**
  * Initiate the PKCE authorization code flow.
  *
  * Stores the PKCE verifier + state nonce in sessionStorage, then
  * hard-navigates the browser to the Keycloak authorization endpoint.
  * Returns void — the page will unload.
+ *
+ * Pass `{ prompt: 'none' }` for a silent re-authentication (#3374 row 29):
+ * the request carries `prompt=none`, so Keycloak either issues a code
+ * against a live SSO session (→ /auth/callback?code, no UI) or bounces back
+ * with `?error=login_required` (→ AuthCallbackPage falls back to the PIN
+ * form), never showing an interactive login during the silent attempt.
  */
-export async function initiateLogin(sovereignFQDN: string): Promise<void> {
-  const { authEndpoint } = buildOIDCEndpoints(sovereignFQDN)
+export async function initiateLogin(
+  sovereignFQDN: string,
+  opts: InitiateLoginOptions = {},
+): Promise<void> {
   const verifier = await generateVerifier()
   const challenge = await generateChallenge(verifier)
   const state = generateState()
@@ -204,17 +258,47 @@ export async function initiateLogin(sovereignFQDN: string): Promise<void> {
   sessionStorage.setItem(SESSION_KEY_VERIFIER, verifier)
   sessionStorage.setItem(SESSION_KEY_STATE, state)
 
-  const params = new URLSearchParams({
-    response_type: 'code',
-    client_id: CLIENT_ID,
-    redirect_uri: redirectURI,
-    scope: SCOPE,
-    state,
-    code_challenge: challenge,
-    code_challenge_method: 'S256',
-  })
+  window.location.replace(
+    buildAuthorizeURL(sovereignFQDN, {
+      challenge,
+      state,
+      redirectURI,
+      prompt: opts.prompt,
+    }),
+  )
+}
 
-  window.location.replace(`${authEndpoint}?${params.toString()}`)
+/**
+ * OIDC error codes a `prompt=none` silent-auth attempt returns to the
+ * redirect_uri when it cannot complete without user interaction (OpenID
+ * Connect Core §3.1.2.6). These are EXPECTED "no reusable session"
+ * outcomes — NOT failures: the caller falls back to the interactive PIN
+ * login instead of surfacing an error screen.
+ */
+export const SILENT_AUTH_RECOVERABLE_ERRORS = [
+  'login_required',
+  'interaction_required',
+  'consent_required',
+  'account_selection_required',
+] as const
+
+/**
+ * Inspect an OIDC callback query-string. Returns the recoverable
+ * silent-auth error code (login_required / interaction_required / …) when
+ * the callback carries such an `error` and NO authorization `code`;
+ * otherwise null.
+ *
+ * AuthCallbackPage uses this to distinguish a silent-SSO miss — where the
+ * correct response is a clean fall-back to the PIN form (#3374 row 29) —
+ * from a genuine token-exchange failure (which still surfaces an error).
+ */
+export function parseSilentAuthError(params: URLSearchParams): string | null {
+  if (params.get('code')) return null
+  const err = params.get('error')
+  if (!err) return null
+  return (SILENT_AUTH_RECOVERABLE_ERRORS as readonly string[]).includes(err)
+    ? err
+    : null
 }
 
 /**


### PR DESCRIPTION
## UAT row 29 — silent re-auth after session TTL

**Row 29** (sso): *Re-open the bare console URL after the session TTL → lands signed-in again, no PIN re-prompt.* Currently ❌.

### Root cause (code-traced + reproduced)

The Sovereign console already has a silent front door: on `whoami=401` the route guard (`router.tsx` `rootBeforeLoad`) calls `attemptSilentSovereignSSO()`, which fires an OIDC PKCE request against the Sovereign Keycloak (whose realm browser flow auto-delegates to the `catalyst-pin` IdP redirector).

The gap: `attemptSilentSovereignSSO` called `initiateLogin(fqdn)` **without `prompt=none`** (`oidc.ts:197`). With no `prompt`, when there is no silently-usable session Keycloak's catalyst-pin redirector renders the **interactive 6-digit PIN form** during what is supposed to be an invisible re-auth — instead of returning `login_required`. So a live KC SSO session is not reused silently and the operator is wrongly re-prompted (exactly what the hw228 walk observed). Additionally, `AuthCallbackPage` treated a code-less callback as a hard **"Sign-in failed"** screen, so even a correct `login_required` bounce would dead-end.

### Fix (front-end, scoped to the silent-SSO path)

- **`shared/lib/oidc.ts`** — `initiateLogin` gains an optional `{ prompt?: 'none' }`; a new pure/exported `buildAuthorizeURL()` appends `prompt=none` for the silent variant (unit-tested without navigating). Added `parseSilentAuthError()` + `SILENT_AUTH_RECOVERABLE_ERRORS` to recognise the OIDC "no reusable session" family (`login_required` / `interaction_required` / `consent_required` / `account_selection_required`).
- **`app/router.tsx`** — `attemptSilentSovereignSSO` now calls `initiateLogin(fqdn, { prompt: 'none' })`. Keycloak either issues a code against a live SSO session (→ `/auth/callback?code`, no UI) or returns `error=login_required` **without ever showing a PIN wall**.
- **`pages/auth/AuthCallbackPage.tsx`** — on a `prompt=none` miss (`error=login_required`, no code) it falls back cleanly to the `/login` PIN form instead of "Sign-in failed", and clears the one-shot silent-SSO guard so a later genuine expiry re-arms the silent round-trip. Genuine token-exchange failures still surface.

### Behaviour

| Scenario | Before | After |
|---|---|---|
| TTL expired, **live** KC SSO session | PIN wall shown mid-attempt (KC domain) | Silent code exchange → `/dashboard`, no UI ✅ |
| TTL expired, **no** reusable session | PIN wall shown mid-attempt | KC returns `login_required` → branded console `/login` PIN form ✅ |
| Happy path (valid session) | unchanged | unchanged |

The happy path is unchanged; the only behavioural change is when no reusable session exists.

### Gates
- `tsc -b --noEmit` (typecheck): clean
- `vitest` — oidc + router + auth-callback + sovereign-console-layout suites: **59 passed**; added tests for `buildAuthorizeURL` (prompt=none) and `parseSilentAuthError`. (The 9 unrelated failing suites — PinInput6, SettingsPage, wizard StepComponents, etc. — fail identically on the clean `main` baseline; pre-existing, not touched here.)
- `vite build`: succeeds.

### Runtime verification note
The FE contract is now spec-correct (`prompt=none`). Whether Keycloak reuses the existing sovereign-realm session silently is a realm-config property that can only be confirmed on a fresh-prov walk: PIN-login → let the console session TTL lapse (KC SSO still valid) → re-open the bare console URL → expect land on `/dashboard`, no PIN. If a walk still sees `login_required` **with** a live `KEYCLOAK_SESSION`, that residual is a sovereign-realm cookie-authenticator config item, not a FE bug — the FE now does the right thing either way.

Refs #3374