### PR TITLE
fix(#4986): bp-postgres emits dr-<instance> Continuum CR → shared-pg Topology DR panel renders (#3375 rows 51/52/56/57/64)

### DIFF
--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -155,7 +155,7 @@ spec:
       # (#4442). Lockstep with 16c/16d.
       # 0.2.10 (#4846): identity-based cross-region DR CiliumNetworkPolicy
       # (crossRegionPeerClusters) replaces the inert ipBlock. Lockstep 16c/16d.
-      version: 0.2.11
+      version: 0.2.12
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
+++ b/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
@@ -93,7 +93,7 @@ spec:
       # moment the mesh peers. Lockstep with 16a/16d.
       # 0.2.10 (#4846): identity-based cross-region DR CiliumNetworkPolicy
       # (crossRegionPeerClusters) replaces the inert ipBlock. Lockstep 16a/16d.
-      version: 0.2.11
+      version: 0.2.12
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
+++ b/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
@@ -81,7 +81,7 @@ spec:
       # openova-flow hosts resolve the moment the mesh peers. Lockstep 16a/16c.
       # 0.2.10 (#4846): identity-based cross-region DR CiliumNetworkPolicy
       # (crossRegionPeerClusters) replaces the inert ipBlock. Lockstep 16a/16c.
-      version: 0.2.11
+      version: 0.2.12
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/platform/postgres/blueprint.yaml
+++ b/platform/postgres/blueprint.yaml
@@ -11,7 +11,7 @@ spec:
   # 0.2.10 (#4846): cross-region DR admission is an identity-based
   # CiliumNetworkPolicy (io.cilium.k8s.policy.cluster) — the 0.2.9 ipBlock was
   # inert for ClusterMesh remote endpoints. values crossRegionPeerClusters.
-  version: 0.2.11
+  version: 0.2.12
   card:
     title: PostgreSQL
     summary: |

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -167,7 +167,7 @@ name: bp-postgres
 #   the singleton render is byte-identical to 0.2.9 (the ipBlock only rendered
 #   under crossRegion, which singletons never set). Lockstep slot pins 16a/16c/
 #   16d → 0.2.10. tests/postgres-render.sh Case 4e/4f added.
-version: 0.2.11
+version: 0.2.12
 appVersion: "0.1.2"
 description: |
   Catalyst-authored data-instance Blueprint for a shareable, reusable

--- a/platform/postgres/chart/templates/continuum.yaml
+++ b/platform/postgres/chart/templates/continuum.yaml
@@ -1,0 +1,106 @@
+{{- /*
+Per-app Continuum DR contract for the active-hot-standby shared Postgres pair
+(#4986 — live root-cause on hw239; #3375 rows 51/52/56/57/64, Refs #3969 #4212).
+
+WHY: bp-postgres in active-hot-standby renders a genuine 2-region CNPG pair —
+cluster.yaml (primary half) + replica-cluster.yaml (follower) — both carrying
+the `catalyst.openova.io/cnpg-pair=<instance>` + `openova.io/region` labels the
+DR read-path keys on. But UNLIKE the spine charts (platform/openbao,
+platform/cnpg-pair, each of which ships a continuum.yaml → that is why
+`dr-spine-gitea/harbor/keycloak/openbao` exist and their per-app Topology DR
+panels render), bp-postgres emitted NO Continuum.dr.openova.io CR. And the
+bootstrap-ADOPTED HelmRelease install path never runs the application-
+controller's per-app Continuum producer (core/controllers/application/
+internal/controller/continuum.go) — that runs only for wizard / Application-CR
+topology fan-outs, not adopted bootstrap HRs. So on a 2-region prov
+`kubectl get continuums.dr.openova.io -A` had `dr-spine-*` + the cnpg-pair CR
+but NO `dr-shared-pg`, and catalyst-api's /continuums/dr-<app>/replication-
+status 404'd → the console TopologyTab.tsx `showDR` gate stayed false → the DR
+panel was hidden even though a healthy region-a primary + region-b standby pair
+was streaming with 0.0s WAL lag.
+
+This template closes that gap the SAME way platform/cnpg-pair/chart/templates/
+continuum.yaml does — it mints the `dr-<instance>` Continuum CR the UI polls,
+keyed entirely off the pair the cluster templates already render (zero
+app-name literal). catalyst-api then discovers the two Cluster halves by the
+`catalyst.openova.io/cnpg-pair` label (continuum_live.go) → returns
+source:"live" → the DR panel renders the primary/standby regions + live WAL lag
++ the armed manual Switchover. Proven live on hw239: hand-applying dr-shared-pg
+(+ dr-shared-pg-b) made the panel render `● LIVE · PRIMARY me-east-215-a
+serves writes · STANDBY me-east-215-b streaming · Replication lag 0.0 s ·
+Switch over…` — this template makes that zero-touch on a fresh prov.
+
+GATING (strict + generic — the SAME preconditions cluster.yaml's mesh aliases
+already use, so the two can never disagree):
+  - .Values.enabled != false (the shared-pg master gate — an empty release
+    renders zero resources, same as cluster.yaml);
+  - continuum.enabled (default true) — operator opt-out;
+  - activeHotStandby (mode active-hot-standby OR crossRegion) — a singleton has
+    no standby, so no DR contract (honest: the panel stays hidden, row 58);
+  - PRIMARY side only (not renderReplicaHalf) — the continuum-controller runs
+    on the primary control-plane (its HR is suspended on secondary CPs), so the
+    CR it reconciles must live there too (mirrors cnpg-pair's isPrimarySide);
+  - the Continuum CRD is registered (dr.openova.io/v1 ships with bp-catalyst-
+    platform slot 13, sequenced before this slot — the capability gate mirrors
+    cluster.yaml's postgresql.cnpg.io/v1 gate so a cold pre-CRD reconcile is a
+    no-op rather than an apply failure);
+  - BOTH topology.primary.region AND topology.replica.region are non-empty — a
+    genuine 2-region prov. A single-region prov leaves replica.region "" so we
+    never mint a CR with an empty/phantom hotStandbyRegions[] (the #3698
+    standby-region integrity precondition).
+
+Status is NEVER seeded here — the running continuum-controller owns status
+(ADR-0001 §2.7). autoFailover defaults false: the panel arms a MANUAL
+switchover with an RPO/health preflight; no unattended promotion.
+*/ -}}
+{{- $ahs := eq (include "bp-postgres.activeHotStandby" .) "true" -}}
+{{- $primaryRegion := dig "primary" "region" "" (.Values.topology | default dict) -}}
+{{- $replicaRegion := dig "replica" "region" "" (.Values.topology | default dict) -}}
+{{- /* $continuum is a nested map (plain map[string]interface{}), so dig works;
+     .Values itself is chartutil.Values which dig rejects. */ -}}
+{{- $continuum := .Values.continuum | default dict -}}
+{{- $continuumOn := ne (toString (dig "enabled" true $continuum)) "false" -}}
+{{- if and
+      (ne (toString .Values.enabled) "false")
+      $continuumOn
+      $ahs
+      (not (include "bp-postgres.renderReplicaHalf" .))
+      (.Capabilities.APIVersions.Has "dr.openova.io/v1")
+      (ne (toString $primaryRegion) "")
+      (ne (toString $replicaRegion) "") }}
+apiVersion: dr.openova.io/v1
+kind: Continuum
+metadata:
+  name: dr-{{ include "bp-postgres.instanceName" . }}
+  namespace: {{ include "bp-postgres.namespace" . }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+    # Back-pointer + pair join-key the DR read-path (catalyst-api
+    # continuum_live.go) + the console rollup key on. The cnpg-pair label ties
+    # this contract to the two Cluster halves cluster.yaml/replica-cluster.yaml
+    # already stamp; scope=application distinguishes the per-app producer from
+    # the cnpg-pair chart's openova.io/scope:platform CR.
+    openova.io/app: {{ include "bp-postgres.instanceName" . | quote }}
+    catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+    openova.io/scope: application
+spec:
+  applicationRef: {{ printf "%s/%s" (include "bp-postgres.namespace" .) (include "bp-postgres.instanceName" .) | quote }}
+  primaryRegion: {{ $primaryRegion | quote }}
+  hotStandbyRegions:
+    - {{ $replicaRegion | quote }}
+  autoFailover: {{ dig "autoFailover" false $continuum }}
+  {{- with dig "rto" "30s" $continuum }}
+  rto: {{ . | quote }}
+  {{- end }}
+  {{- with dig "rpo" "" $continuum }}
+  rpo: {{ . | quote }}
+  {{- end }}
+  switchover:
+    # cnpg-pair promotion (cordon + replica.enabled flip on the two Cluster
+    # halves) — the mechanism bp-postgres's active-hot-standby replication
+    # backend uses (blueprint.yaml topology.active-hot-standby.replication.
+    # backend: cnpg-pair).
+    mechanism: cnpg-pair
+  leaseClient:
+    kind: {{ dig "leaseClient" "kind" "k8s-lease" $continuum | quote }}
+{{- end }}

--- a/platform/postgres/chart/tests/postgres-render.sh
+++ b/platform/postgres/chart/tests/postgres-render.sh
@@ -802,4 +802,59 @@ if grep -qE 'gitea-database-secret-x-' "$TMP/mangled.yaml"; then
   fail "#3878 REGRESSION: a binding WITHOUT reflect.mangledTarget must NOT emit a mangled copy"
 fi
 
-echo "[render] PASS — bp-postgres render gate green (reuse proof: 1 Cluster, 2 Databases, 2 roles, 2 Secrets; master gate OFF → empty; 3-instance shapes locked; #3370 Application-CR self-registration locked; #3375 underscore-owner role-Secret sanitization locked; #3375/#3768 ONE canonical placement vocabulary locked; #3878 reflect.mangledTarget vc-mgmt native DB-secret delivery locked)"
+# ── Case #4986: per-app Continuum DR contract (dr-<instance>) ────
+# active-hot-standby PRIMARY 2-region → the CR the console Topology DR panel
+# polls renders so catalyst-api resolves source:live (it discovers the CNPG
+# pair by the catalyst.openova.io/cnpg-pair label). Proven live on hw239:
+# without dr-shared-pg the panel 404'd/hid; with it the panel rendered
+# ● LIVE primary/standby + WAL lag + armed Switchover.
+echo "[render] Case #4986: AHS primary 2-region → dr-<instance> Continuum CR renders"
+helm template shared-pg . \
+  --set enabled=true --set instance.name=shared-pg --set instance.namespace=shared-data \
+  --set topology.mode=active-hot-standby --set topology.side=primary \
+  --set topology.primary.region=hw-me-east-215-a-rtz-prod \
+  --set topology.replica.region=hw-me-east-215-b-rtz-prod \
+  --api-versions dr.openova.io/v1 \
+  --show-only templates/continuum.yaml > "$TMP/cont.yaml" 2>&1 || { cat "$TMP/cont.yaml" >&2; fail "#4986 continuum render errored"; }
+grep -qE '^kind: Continuum$'                          "$TMP/cont.yaml" || fail "#4986: Continuum CR not rendered on AHS primary"
+grep -qE '^  name: dr-shared-pg$'                     "$TMP/cont.yaml" || fail "#4986: CR must be named dr-<instance> (dr-shared-pg) — the name TopologyTab.tsx polls"
+grep -qE 'catalyst.openova.io/cnpg-pair: "shared-pg"' "$TMP/cont.yaml" || fail "#4986: CR must carry the cnpg-pair label catalyst-api discovers the pair by"
+grep -qE 'applicationRef: "shared-data/shared-pg"'    "$TMP/cont.yaml" || fail "#4986: applicationRef missing/wrong"
+grep -qE 'primaryRegion: "hw-me-east-215-a-rtz-prod"' "$TMP/cont.yaml" || fail "#4986: primaryRegion missing"
+grep -qE '"hw-me-east-215-b-rtz-prod"'                "$TMP/cont.yaml" || fail "#4986: hotStandbyRegions must carry the replica region"
+grep -qE 'mechanism: cnpg-pair'                       "$TMP/cont.yaml" || fail "#4986: switchover.mechanism must be cnpg-pair"
+grep -qE 'kind: "k8s-lease"'                          "$TMP/cont.yaml" || fail "#4986: leaseClient.kind must default k8s-lease (air-gappable, self-sovereign)"
+grep -qE 'openova.io/scope: application'              "$TMP/cont.yaml" || fail "#4986: scope=application distinguishes the per-app producer from the cnpg-pair chart's platform CR"
+
+# ── Case #4986b: the DR contract is HONESTLY ABSENT where there is no live
+# pair — singleton, replica side, single-region (empty replica.region),
+# operator-disabled, and CRD-absent — so we never mint a phantom DR panel
+# against a region that isn't there (row 58).
+echo "[render] Case #4986b: Continuum ABSENT for singleton / replica / single-region / disabled / CRD-absent"
+assert_no_continuum() { # $1=label ; rest=helm --set flags (+ implicit --api-versions dr.openova.io/v1)
+  local label="$1"; shift
+  local out
+  out=$(helm template shared-pg . "$@" --api-versions dr.openova.io/v1 --show-only templates/continuum.yaml 2>&1 || true)
+  if echo "$out" | grep -qE '^kind: Continuum$'; then fail "#4986: Continuum MUST be absent — $label"; fi
+}
+assert_no_continuum "singleton" \
+  --set enabled=true --set instance.name=shared-pg --set topology.mode=singleton
+assert_no_continuum "AHS replica side" \
+  --set enabled=true --set instance.name=shared-pg --set topology.mode=active-hot-standby --set topology.side=replica \
+  --set topology.primary.region=hw-me-east-215-a-rtz-prod --set topology.replica.region=hw-me-east-215-b-rtz-prod
+assert_no_continuum "single-region (empty replica.region)" \
+  --set enabled=true --set instance.name=shared-pg --set topology.mode=active-hot-standby --set topology.side=primary \
+  --set topology.primary.region=hw-me-east-215-a-rtz-prod
+assert_no_continuum "continuum.enabled=false opt-out" \
+  --set enabled=true --set instance.name=shared-pg --set topology.mode=active-hot-standby --set topology.side=primary \
+  --set topology.primary.region=hw-me-east-215-a-rtz-prod --set topology.replica.region=hw-me-east-215-b-rtz-prod \
+  --set continuum.enabled=false
+# CRD-absent: the SAME AHS-primary flags but WITHOUT the dr.openova.io/v1
+# capability → a cold pre-CRD reconcile is a no-op, not an apply failure.
+cont_nocrd=$(helm template shared-pg . \
+  --set enabled=true --set instance.name=shared-pg --set topology.mode=active-hot-standby --set topology.side=primary \
+  --set topology.primary.region=hw-me-east-215-a-rtz-prod --set topology.replica.region=hw-me-east-215-b-rtz-prod \
+  --show-only templates/continuum.yaml 2>&1 || true)
+if echo "$cont_nocrd" | grep -qE '^kind: Continuum$'; then fail "#4986: Continuum MUST be absent when the dr.openova.io/v1 CRD is not registered"; fi
+
+echo "[render] PASS — bp-postgres render gate green (reuse proof: 1 Cluster, 2 Databases, 2 roles, 2 Secrets; master gate OFF → empty; 3-instance shapes locked; #3370 Application-CR self-registration locked; #3375 underscore-owner role-Secret sanitization locked; #3375/#3768 ONE canonical placement vocabulary locked; #3878 reflect.mangledTarget vc-mgmt native DB-secret delivery locked; #4986 per-app Continuum DR contract renders on AHS-primary + absent for singleton/replica/single-region/disabled/CRD-absent)"

--- a/platform/postgres/chart/values.yaml
+++ b/platform/postgres/chart/values.yaml
@@ -224,6 +224,32 @@ topology:
     # CiliumNetworkPolicy (byte-identical single-region default).
     crossRegionPeerClusters: []
 
+# ── Continuum DR contract (#4986, #3375 rows 51/52/56/57/64) ─────────────
+# The per-app Continuum.dr.openova.io CR (`dr-<instance>`) that fronts the
+# active-hot-standby CNPG pair so the console per-app Topology DR panel renders
+# (catalyst-api /continuums/dr-<app>/replication-status discovers the pair by
+# the catalyst.openova.io/cnpg-pair label → source:live). templates/continuum.yaml
+# renders it ONLY on a 2-region active-hot-standby PRIMARY-side install (both
+# topology.primary.region + topology.replica.region non-empty). A singleton
+# emits nothing (byte-identical single-region default).
+continuum:
+  # enabled — opt-out for an operator running a 2-region pair WITHOUT the
+  # continuum-controller (no DR contract to reconcile). Default true: every
+  # active-hot-standby shared-pg gets its DR roster row + Topology DR panel.
+  enabled: true
+  # autoFailover false → the panel arms a MANUAL switchover (RPO/health
+  # preflight before confirm); no unattended promotion. Pillar-3 default.
+  autoFailover: false
+  # Recovery objectives surfaced on the CR (informational; the CRD validates
+  # the `^[0-9]+(s|m|h)$` form). rpo empty → omitted.
+  rto: "30s"
+  rpo: ""
+  # Lease witness backend — k8s-lease (a native coordination.k8s.io/v1 Lease)
+  # is the air-gappable, self-sovereign default (#3829). Enum:
+  # [k8s-lease, cloudflare-kv, dns-quorum].
+  leaseClient:
+    kind: k8s-lease
+
 # ── Bindings (the shareable part) ───────────────────────────────────────
 # Each entry binds ONE consumer to this instance. The chart renders a
 # Database CR + a managed role + (optionally) a reflected connection

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5928,7 +5928,9 @@ spec:
     # 0.2.8 (#4460): -mesh/-mesh-rw global Service aliases decoupled from the
     # cnpg-pair flip (render on the multi-region signal so cross-region consumer
     # DB hosts resolve the moment the mesh peers; region-B NXDOMAIN fix).
-    version: "0.2.11"
+    # 0.2.12 (#4986): active-hot-standby emits the dr-<instance> Continuum CR so
+    # the per-app Topology DR panel renders (shared-pg #3375 rows 51/52/56/57/64).
+    version: "0.2.12"
   # Seeded verbatim from platform/postgres/blueprint.yaml spec.topology.
   # singleton = single-instance Cluster; active-hot-standby = sync
   # replication across regions (ADR-0004 Pillar-3 zero-tx-loss) via the


### PR DESCRIPTION
## Problem

The per-app Topology **DR panel** stays hidden for `shared-pg` / `shared-pg-b` / `shared-pg-c` even though each has a **healthy live 2-region CNPG pair** (region-a primary + region-b `<instance>-replica`, both healthy, WAL lag 0.0s). Blocks UAT #3375 rows **51/52/56/57/64**.

## Root cause (verified live on hw239)

- `bp-postgres` active-hot-standby renders a real cnpg pair (`cluster.yaml` primary + `replica-cluster.yaml` follower, both labeled `catalyst.openova.io/cnpg-pair=<instance>`). ✅ data plane is a real DR pair.
- The console `TopologyTab.tsx` DR panel (`showDR`) resolves off catalyst-api `/continuums/dr-<app>/replication-status`, which discovers the pair **by the `catalyst.openova.io/cnpg-pair` label** (`continuum_live.go`) and returns `source:live` — **but only if a `dr-<app>` Continuum CR exists** (else 404 → panel hidden).
- **`bp-postgres` emitted NO `Continuum.dr.openova.io` CR** — unlike `platform/cnpg-pair` + `platform/openbao` (which ship a `continuum.yaml` → that's why `dr-spine-*` exist and their panels render). And the bootstrap-**adopted** HelmRelease install path never runs the application-controller's per-app Continuum producer.
- `kubectl get continuums.dr.openova.io -A` on hw239: `dr-spine-*` + the cnpg-pair CR, but **no `dr-shared-pg`** → 404 → no DR panel.

## Fix

`platform/postgres/chart/templates/continuum.yaml` (mirrors `platform/cnpg-pair/chart/templates/continuum.yaml`) mints `dr-<instance>` when: `activeHotStandby` ∧ primary side ∧ both `topology.primary.region`+`topology.replica.region` non-empty ∧ `continuum.enabled` (default true) ∧ CRD registered. Keyed off the pair the cluster templates already render — zero app-name literal.

## Live proof

Hand-applying `dr-shared-pg` (+ `dr-shared-pg-b`) on hw239 → continuum-controller reconciled `phase=Healthy` → the shared-pg Topology DR panel **immediately rendered**: `● LIVE · PRIMARY me-east-215-a serves writes · STANDBY me-east-215-b streaming · Replication lag 0.0 s · Switch over… (armed)`. This template makes that **zero-touch on a fresh 2-region prov**.

## Tests

`tests/postgres-render.sh` +9 assertions: renders `dr-shared-pg` on AHS-primary (name, cnpg-pair label, applicationRef, primary/standby regions, mechanism cnpg-pair, k8s-lease, scope=application); **absent** for singleton / replica-side / single-region / `continuum.enabled=false` / CRD-absent. `helm lint` clean. Full gate green.

- chart `0.2.11` → `0.2.12`; blueprint.yaml + slots 16a/16c/16d pins bumped (lockstep).

## Verification pending

Rows 51/52/56/57/64 flip to ✅ **zero-touch on the next fresh 2-region prov** (per merged≠walked). The DR UI + data plane were always correct — this supplies the only missing wiring.

Refs #4986 #3375 #3969 #4212