### PR TITLE
fix(#4988): lockstep catalog-seed bp-postgres spec.version 0.2.10→0.2.12

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1245,7 +1245,8 @@ spec:
       # 1.4.1072 — #4952: catalog-seed bp-openclaw pin 0.2.16 -> 0.2.17 so the
       #   per-Org-namespace fix (tenant.namespace default "" -> falls back to
       #   .Release.Namespace) reaches fresh funnel Orgs. Lockstep w/ Chart.yaml.
-      version: 1.4.1090
+      # 1.4.1092 — #4988: catalog-seed bp-postgres spec.version 0.2.10 -> 0.2.12.
+      version: 1.4.1092
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3473,7 +3473,9 @@ name: bp-catalyst-platform
 #   footprint to fit the 4-CPU `plan-quota` (the 0.4.21 oidc-config post-install
 #   hook requested a 500m CPU limit into a namespace with only 250m of quota
 #   headroom → the hook pod was NEVER created → HR timeout → no HTTPRoute → 404).
-version: 1.4.1091
+version: 1.4.1092
+# 1.4.1092 — #4988: bump catalog-seed bp-postgres spec.version display-label 0.2.10→0.2.12
+#   to lockstep with delivery source.version + platform/postgres/blueprint.yaml (#4987 DR).
 # 1.4.1063 — #4841: grant the useraccess-controller ClusterRole `bind` on the 8
 #   canonical Sovereign-IAM ClusterRoles (openova:tier-{viewer,developer,operator,
 #   admin,owner} + openova:application-{admin,editor,viewer}). The controller

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5832,7 +5832,9 @@ metadata:
 spec:
   # 0.2.8 (#4460): -mesh/-mesh-rw global Service aliases decoupled from the
   # cnpg-pair flip (region-B cross-region consumer DB host NXDOMAIN fix).
-  version: "0.2.10"
+  # 0.2.12 (#4987/#4988): continuum.yaml mints dr-<instance> for AHS DR panel;
+  # keep this display-version in lockstep with delivery source.version + blueprint.yaml.
+  version: "0.2.12"
   visibility: listed
   # Shareability + Contexts (#3370) — seeded verbatim from
   # platform/postgres/blueprint.yaml (lockstep-guarded). One instance


### PR DESCRIPTION
## Summary
Completes the #4987 DR lockstep. The seed's `spec.delivery.source.version` (delivered chart) was already `0.2.12`, but the Blueprint `spec.version` **display-label** stayed `0.2.10` → live Blueprint CRs on fresh provs (hw240) showed a stale version despite delivering the DR-fixed chart.

## Change
- `products/catalyst/chart/templates/catalog-seed/blueprints.yaml`: bp-postgres `spec.version` 0.2.10 → 0.2.12 (matches delivery source.version + `platform/postgres/blueprint.yaml`).
- `products/catalyst/chart/Chart.yaml`: 1.4.1091 → 1.4.1092 (republish carries the fix).

## Impact
Cosmetic — no functional change (delivery already pulled 0.2.12 with `continuum.yaml`). Closes UAT robustness row **R21** ('no inert lagging Blueprint CR'). Verified on hw240: delivery pulls 0.2.12, dr-shared-pg Continuum Healthy; only the display-label lagged.

Refs #4986 #4987 #4988