### PR TITLE
fix(#4993): host-native app HTTPRoute for vcluster-tier Orgs (syncer reflects no httproutes)

### DIFF
--- a/core/controllers/organization/internal/controller/organization_controller.go
+++ b/core/controllers/organization/internal/controller/organization_controller.go
@@ -591,7 +591,20 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		// moved to the host-applied `vcluster/host-apps/` tree, whose
 		// kustomization index the controller keeps current since the funnel does
 		// NOT merge into it.)
-		if path == "vcluster/apps/kustomization.yaml" {
+		//
+		// #4993 — `vcluster/host-apps/kustomization.yaml` is now SEED-ONLY for
+		// the SAME reason: the funnel merges the host-native per-app HTTPRoutes
+		// (app-<x>-hostroute.yaml, the durable fix for the vcluster-tier 404,
+		// since loft vcluster 0.33.4 syncs no httproutes) into this index
+		// alongside the CNP + provisioning-rbac baseline. If the controller kept
+		// force-overwriting it with its baseline-only list, Flux's
+		// `kustomize build ./vcluster/host-apps` would drop the app routes and
+		// the customer's app would 404 again on the next reconcile. The baseline
+		// docs (ciliumnetworkpolicy.yaml / provisioning-rbac.yaml) are still
+		// authored + kept current via their own PutFile entries, and the funnel's
+		// MergePerOrgHostAppsKustomization always re-includes them.
+		if path == "vcluster/apps/kustomization.yaml" ||
+			path == "vcluster/host-apps/kustomization.yaml" {
 			if _, gerr := r.GiteaClient.GetFile(ctx, gOrg.Username, repoName, branch, path); gerr == nil {
 				// Already present (seeded earlier, possibly funnel-merged) —
 				// leave it untouched so cart app entries survive.

--- a/core/controllers/organization/internal/controller/perorg_hostapps_kustomization_seed_only_4993_test.go
+++ b/core/controllers/organization/internal/controller/perorg_hostapps_kustomization_seed_only_4993_test.go
@@ -1,0 +1,73 @@
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// #4993 — the org-controller must NOT clobber `vcluster/host-apps/kustomization.yaml`
+// once it exists. The funnel merges the host-native per-app HTTPRoutes
+// (app-<x>-hostroute.yaml — the durable fix for the vcluster-tier 404, since loft
+// vcluster 0.33.4 syncs no httproutes) into that index alongside the CNP +
+// provisioning-rbac baseline. If a subsequent Org reconcile force-overwrote it
+// with its baseline-only list, Flux's `kustomize build ./vcluster/host-apps` would
+// drop the app routes and the customer's app would 404 again. So the controller
+// SEEDS the index once (baseline) and never overwrites it — exactly like the apps
+// kustomization (#4384). The baseline DOCS (ciliumnetworkpolicy.yaml /
+// provisioning-rbac.yaml) are still authored + kept current via their own PutFile.
+func TestReconcile_HostAppsKustomization_SeedOnly_NotClobbered_4993(t *testing.T) {
+	t.Parallel()
+	org := sampleOrg()
+	r, gs, _ := makeReconciler(t, org)
+
+	// First reconcile seeds vcluster/host-apps/kustomization.yaml.
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "acme"},
+	}); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+
+	const kustKey = "acme/catalyst-tenant/vcluster/host-apps/kustomization.yaml"
+	seeded, ok := gs.files[kustKey]
+	if !ok {
+		t.Fatalf("controller did not seed %s", kustKey)
+	}
+	for _, want := range []string{"ciliumnetworkpolicy.yaml", "provisioning-rbac.yaml"} {
+		if !strings.Contains(string(seeded.content), want) {
+			t.Fatalf("seeded host-apps kustomization missing baseline %q:\n%s", want, seeded.content)
+		}
+	}
+
+	// Simulate the funnel cart install merging the customer's host-native app
+	// route into the index (the read-modify-write the provisioning service does).
+	merged := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - app-wordpress-hostroute.yaml
+  - ciliumnetworkpolicy.yaml
+  - provisioning-rbac.yaml
+`
+	gs.files[kustKey] = fileEntry{sha: seeded.sha, content: []byte(merged)}
+
+	// Re-reconcile. The org-controller must leave the funnel-merged index untouched.
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "acme"},
+	}); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+
+	after := string(gs.files[kustKey].content)
+	if !strings.Contains(after, "app-wordpress-hostroute.yaml") {
+		t.Errorf("regression: org-controller CLOBBERED the funnel-merged host-apps kustomization — app route dropped (404 returns):\n%s", after)
+	}
+	for _, want := range []string{"ciliumnetworkpolicy.yaml", "provisioning-rbac.yaml"} {
+		if !strings.Contains(after, want) {
+			t.Errorf("host-apps kustomization lost baseline %q after reconcile:\n%s", want, after)
+		}
+	}
+}

--- a/core/services/provisioning/gitops/gitops.go
+++ b/core/services/provisioning/gitops/gitops.go
@@ -884,9 +884,11 @@ func generateHostIngress(ns, slug string, appSlugs []string) string {
 	//
 	// Observed live on tenant emrah5: ingress paths pointed at
 	// wordpress-x-apps-x-vcluster → 404. Actual service name was
-	// wordpress-x-tenant-emrah5-x-vcluster. Issue #117.
+	// wordpress-x-tenant-emrah5-x-vcluster. Issue #117. Delegates to the ONE
+	// canonical synced-name derivation (hostSyncedServiceName) the #4993
+	// host-native app route also uses, so the two stay in lockstep.
 	syncedName := func(app string) string {
-		return fmt.Sprintf("%s-x-%s-x-vcluster", app, ns)
+		return hostSyncedServiceName(app, ns)
 	}
 
 	var paths string
@@ -2071,6 +2073,77 @@ spec:
 `, appSlug, ns, appSlug, slug,
 		appsGatewayName, appsGatewayNamespace,
 		host, appSlug)
+}
+
+// hostSyncedServiceName is the name the vCluster syncer reflects an in-vcluster
+// Service to on the HOST cluster: `<svc>-x-<host-ns>-x-vcluster`. The host ns is
+// the org-controller-owned `<slug>` boundary (the apps Kustomization's
+// targetNamespace), so a WordPress Service authored inside the vcluster surfaces
+// host-side as `wordpress-x-<slug>-x-vcluster`. Live-confirmed on hw240 acme:
+// `wordpress-x-acme-x-vcluster`. Kept in lockstep with generateHostIngress's
+// inline `syncedName` (issue #117) — the ONE canonical synced-name derivation.
+func hostSyncedServiceName(appSlug, hostNS string) string {
+	return fmt.Sprintf("%s-x-%s-x-vcluster", appSlug, hostNS)
+}
+
+// generateHostNativeAppRoute emits a HOST-NATIVE Gateway-API HTTPRoute (in the
+// host `<slug>` ns) that routes a VCLUSTER-tier app's public host
+// (`<app>.<slug>.<parentDomain>`) to the SYNCED Service the vcluster syncer
+// reflects host-side (`<app>-x-<slug>-x-vcluster:80`).
+//
+// #4993 — the DURABLE FIX for the vcluster-tier 404. generateAppHTTPRoute
+// co-locates the app's HTTPRoute with the Deployment+Service INSIDE the Org
+// vcluster (the apps tree is kubeConfig-targeted into the vcluster for paid M+
+// tiers). That in-vcluster route was expected to reach the host via
+// `sync.toHost.customResources.httproutes`, but loft vcluster 0.33.4 registers
+// NO httproute reflecting controller (only the CRD import + a quota evaluator —
+// proven live on hw240: `vcluster-0 -c syncer` logs "Created service/…/networkpolicy
+// syncer" but never "Created httproute syncer"), so the route never reaches the
+// host Cilium Gateway and the app 404s even with pods Running. This host-native
+// route lives in the ALWAYS-host-applied `vcluster/host-apps/` tree (like the
+// org-controller CNP) and binds the SYNCED Service directly on the host — the
+// SAME host-native model the per-Org console route already uses (tenant_route.go,
+// `catalyst-ui-console-<slug>-…` in catalyst-system), never relying on vcluster
+// sync. Live-proven shape on hw240 acme (`app-wordpress-hostnative-4991proof`:
+// Accepted+ResolvedRefs, serves 200/302 at wordpress.acme.omani.homes).
+//
+// Parents to the dedicated console Gateway (appsGatewayName/appsGatewayNamespace)
+// whose `*.<pool>` wildcard TLS listener terminates TLS — no per-host cert. The
+// gateway→pod reserved-entity hop is admitted namespace-wide by the
+// org-controller's ciliumNetworkPolicyTemplate (endpointSelector:{},
+// fromEntities:[ingress,host,remote-node]) on `<slug>`, so no per-app CNP is
+// needed. Emitted ONLY for the vcluster tier — the host tier (free/S) runs the
+// app + its plain Service in the host `<slug>` ns directly, where the co-located
+// generateAppHTTPRoute already routes and no synced name exists.
+func generateHostNativeAppRoute(hostNS, slug, appSlug, parentDomain string) string {
+	host := fmt.Sprintf("%s.%s.%s", appSlug, slug, parentDomain)
+	synced := hostSyncedServiceName(appSlug, hostNS)
+	return fmt.Sprintf(`apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: app-%s-hostroute
+  namespace: %s
+  labels:
+    app: %s
+    openova.io/tenant: "%s"
+    catalyst.openova.io/component: per-org-app-hostroute
+spec:
+  parentRefs:
+    - name: %s
+      namespace: %s
+  hostnames:
+    - %s
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: %s
+          port: 80
+`, appSlug, hostNS, appSlug, slug,
+		appsGatewayName, appsGatewayNamespace,
+		host, synced)
 }
 
 // generateProvisioningTenantRBAC emits a Role + RoleBinding that gives the

--- a/core/services/provisioning/gitops/host_native_app_route_4993_test.go
+++ b/core/services/provisioning/gitops/host_native_app_route_4993_test.go
@@ -1,0 +1,144 @@
+package gitops
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4993 — the vcluster-tier durable fix. The app's own HTTPRoute is co-located
+// INSIDE the Org vcluster (apps tree, kubeConfig-targeted), but loft vcluster
+// 0.33.4 registers NO httproute reflecting controller, so it never reaches the
+// host Cilium Gateway → the app 404s with pods Running. GeneratePerOrgHostAppRoutes
+// emits a HOST-NATIVE HTTPRoute into vcluster/host-apps/ that binds the SYNCED
+// Service (<app>-x-<slug>-x-vcluster) on the host <slug> ns — the same
+// host-native model the per-Org console route already uses.
+
+// TestGeneratePerOrgHostAppRoutes_VclusterTier_SyncedBackend proves the
+// host-native route lands with the synced Service backend, the <app>.<slug>.<pool>
+// host, and the console-Gateway parentRef.
+func TestGeneratePerOrgHostAppRoutes_VclusterTier_SyncedBackend(t *testing.T) {
+	g := NewManifestGenerator("clusters/sov/org-tenants")
+	g.ParentDomain = "omani.homes"
+
+	files, docs := g.GeneratePerOrgHostAppRoutes("walk-stranger-two", "m", []string{"wordpress"})
+
+	const routePath = "vcluster/host-apps/app-wordpress-hostroute.yaml"
+	doc, ok := files[routePath]
+	if !ok {
+		t.Fatalf("host-native route not emitted at %q (keys: %v)", routePath, keys(files))
+	}
+	if len(docs) != 1 || docs[0] != "app-wordpress-hostroute.yaml" {
+		t.Fatalf("hostAppDocs = %v, want [app-wordpress-hostroute.yaml]", docs)
+	}
+
+	checks := map[string]string{
+		"gateway apiVersion":       "apiVersion: gateway.networking.k8s.io/v1",
+		"kind":                     "kind: HTTPRoute",
+		"host <app>.<slug>.<pool>": "- wordpress.walk-stranger-two.omani.homes",
+		"lands in host <slug> ns":  "namespace: walk-stranger-two",
+		"console Gateway parent":   "name: cilium-gateway-console",
+		"kube-system parent ns":    "namespace: kube-system",
+		// The CRUX: backend is the SYNCED service name, NOT the plain <app>. A
+		// plain `wordpress` backend does not exist on the host → ResolvedRefs=False
+		// → 404 (that is exactly what the in-vcluster route would produce if it
+		// ever synced). The synced name is what the syncer actually reflects.
+		"synced backend service": "- name: wordpress-x-walk-stranger-two-x-vcluster",
+	}
+	for label, want := range checks {
+		if !strings.Contains(doc, want) {
+			t.Errorf("host-native route missing %s (%q):\n%s", label, want, doc)
+		}
+	}
+	// Must NOT bind the plain Service name (that is the in-vcluster route's bug).
+	if strings.Contains(doc, "- name: wordpress\n") {
+		t.Errorf("host-native route bound the PLAIN Service name (404 on host) instead of the synced name:\n%s", doc)
+	}
+}
+
+// TestGeneratePerOrgHostAppRoutes_HostTier_NoRoute — free/S host-tier Orgs run the
+// app + its plain Service directly in the host <slug> ns, where the co-located
+// generateAppHTTPRoute already routes and no synced-service name exists. So NO
+// host-native route is emitted (it would reference a non-existent synced Service).
+func TestGeneratePerOrgHostAppRoutes_HostTier_NoRoute(t *testing.T) {
+	g := NewManifestGenerator("clusters/sov/org-tenants")
+	g.ParentDomain = "omani.homes"
+
+	for _, plan := range []string{"s", "free", ""} {
+		files, docs := g.GeneratePerOrgHostAppRoutes("hostorg", plan, []string{"wordpress"})
+		if len(files) != 0 || len(docs) != 0 {
+			t.Errorf("plan=%q (host tier) must emit NO host-native route, got files=%v docs=%v", plan, keys(files), docs)
+		}
+	}
+}
+
+// TestGeneratePerOrgHostAppRoutes_SkipsHelmReleaseAndDB — HelmRelease-shaped apps
+// (openclaw / stalwart-mail) carry their own chart HTTPRoute and sync no
+// <app>-x-…-x-vcluster Service; shareable DB slugs are never externally routed.
+// Both must be skipped so no route points at a non-existent Service.
+func TestGeneratePerOrgHostAppRoutes_SkipsHelmReleaseAndDB(t *testing.T) {
+	g := NewManifestGenerator("clusters/sov/org-tenants")
+	g.ParentDomain = "omani.homes"
+
+	// wordpress (Deployment) + mysql (DB) — mysql must be skipped.
+	files, docs := g.GeneratePerOrgHostAppRoutes("dbmix", "m", []string{"wordpress", "mysql"})
+	if _, bad := files["vcluster/host-apps/app-mysql-hostroute.yaml"]; bad {
+		t.Errorf("DB slug mysql must NOT get a host-native route:\n%v", keys(files))
+	}
+	if len(docs) != 1 || docs[0] != "app-wordpress-hostroute.yaml" {
+		t.Errorf("only wordpress should be routed, got docs=%v", docs)
+	}
+
+	// A cart of ONLY HelmRelease apps (openclaw) yields no host-native routes.
+	if isHelmReleaseApp("openclaw") {
+		hrFiles, hrDocs := g.GeneratePerOrgHostAppRoutes("hrorg", "m", []string{"openclaw"})
+		if len(hrFiles) != 0 || len(hrDocs) != 0 {
+			t.Errorf("HelmRelease-only cart must emit no host-native route, got files=%v docs=%v", keys(hrFiles), hrDocs)
+		}
+	}
+}
+
+// TestMergePerOrgHostAppsKustomization preserves the org-controller host-apps
+// baseline (CNP + provisioning RBAC), is additive across cart installs, drops the
+// removed app on rebuild, and is idempotent + byte-stable.
+func TestMergePerOrgHostAppsKustomization(t *testing.T) {
+	// Fresh seed from the org-controller baseline + one app route.
+	fresh := MergePerOrgHostAppsKustomization("", []string{"app-wordpress-hostroute.yaml"})
+	for _, want := range []string{
+		"ciliumnetworkpolicy.yaml",
+		"provisioning-rbac.yaml",
+		"app-wordpress-hostroute.yaml",
+	} {
+		if !strings.Contains(fresh, want) {
+			t.Errorf("fresh merge missing %q:\n%s", want, fresh)
+		}
+	}
+
+	// A second cart install (nextcloud) is additive; the baseline + prior app survive.
+	second := MergePerOrgHostAppsKustomization(fresh, []string{"app-wordpress-hostroute.yaml", "app-nextcloud-hostroute.yaml"})
+	for _, want := range []string{
+		"ciliumnetworkpolicy.yaml", "provisioning-rbac.yaml",
+		"app-wordpress-hostroute.yaml", "app-nextcloud-hostroute.yaml",
+	} {
+		if !strings.Contains(second, want) {
+			t.Errorf("additive merge lost %q:\n%s", want, second)
+		}
+	}
+
+	// Idempotent + byte-stable.
+	again := MergePerOrgHostAppsKustomization(second, []string{"app-wordpress-hostroute.yaml", "app-nextcloud-hostroute.yaml"})
+	if again != second {
+		t.Errorf("merge not idempotent:\n--- first ---\n%s\n--- second ---\n%s", second, again)
+	}
+
+	// Uninstall rebuild (existing="" + surviving docs only) drops the removed app
+	// but ALWAYS keeps the baseline.
+	rebuilt := MergePerOrgHostAppsKustomization("", []string{"app-nextcloud-hostroute.yaml"})
+	if strings.Contains(rebuilt, "app-wordpress-hostroute.yaml") {
+		t.Errorf("uninstall rebuild kept the removed app route:\n%s", rebuilt)
+	}
+	for _, want := range []string{"ciliumnetworkpolicy.yaml", "provisioning-rbac.yaml", "app-nextcloud-hostroute.yaml"} {
+		if !strings.Contains(rebuilt, want) {
+			t.Errorf("uninstall rebuild dropped %q:\n%s", want, rebuilt)
+		}
+	}
+}

--- a/core/services/provisioning/gitops/perorg_apps_tree.go
+++ b/core/services/provisioning/gitops/perorg_apps_tree.go
@@ -16,6 +16,18 @@ import (
 // repo, which no per-Org Kustomization watches on a Sovereign.
 const PerOrgAppsDir = "vcluster/apps"
 
+// PerOrgHostAppsDir is the ALWAYS-host-applied tree in the per-Org
+// `<slug>/catalyst-tenant` repo that the org-controller's per-Org host-apps Flux
+// Kustomization (`catalyst-tenant-<slug>-host-apps`, path `./vcluster/host-apps`,
+// NO kubeConfig) reconciles straight onto the host `<slug>` namespace. The
+// org-controller authors the reserved-entity CiliumNetworkPolicy + provisioning
+// RBAC here; the funnel (#4993) adds the host-native per-app HTTPRoutes here so a
+// vcluster-tier app's route reaches the host Cilium Gateway WITHOUT relying on
+// the vcluster syncer (which registers no httproute reflecting controller in
+// vcluster 0.33.4). This is the SAME host-native model the per-Org console route
+// uses — never an in-vcluster route that has to sync out.
+const PerOrgHostAppsDir = "vcluster/host-apps"
+
 // perOrgAppsBaselineDocs are the boundary files the org-controller authored
 // into `vcluster/apps/` on Org create (#4292 boundary set). The funnel MUST
 // preserve them in the apps kustomization (they enforce intra-Org isolation),
@@ -36,6 +48,20 @@ const PerOrgAppsDir = "vcluster/apps"
 // tree by the funnel.
 var perOrgAppsBaselineDocs = []string{
 	"networkpolicy.yaml",
+}
+
+// perOrgHostAppsBaselineDocs are the boundary files the org-controller authored
+// into `vcluster/host-apps/` on Org create (#4475 §1 CNP + #4991 provisioning
+// RBAC). The funnel MUST preserve them when it merges its host-native app-route
+// docs into the host-apps kustomization (#4993) — the CNP admits the Cilium
+// Gateway `ingress` entity for the whole `<slug>` ns (without it every app 503s
+// behind its route) and the RBAC unblocks the kubeconfig mirror. Force-included
+// by MergePerOrgHostAppsKustomization exactly as networkpolicy.yaml is by the
+// apps merge, so a controller reconcile that seeded the index (or a funnel merge
+// that ran first) never drops them.
+var perOrgHostAppsBaselineDocs = []string{
+	"ciliumnetworkpolicy.yaml",
+	"provisioning-rbac.yaml",
 }
 
 // GeneratePerOrgAppsTree renders the customer's purchased Applications for a
@@ -101,6 +127,103 @@ func (g *ManifestGenerator) GeneratePerOrgAppsTree(slug, planSlug string, appSlu
 	}
 	sort.Strings(appDocs)
 	return out, appDocs
+}
+
+// GeneratePerOrgHostAppRoutes renders the HOST-NATIVE per-app HTTPRoutes for a
+// VCLUSTER-tier Org (#4993) into the per-Org repo's `vcluster/host-apps/` tree.
+// Each Deployment-shaped purchased app gets one route (`app-<x>-hostroute.yaml`)
+// that binds the SYNCED Service (`<app>-x-<slug>-x-vcluster:80`) on the host
+// `<slug>` ns to the app's public host (`<app>.<slug>.<parentDomain>`), parented
+// to the dedicated console Cilium Gateway — so the route reaches the host gateway
+// deterministically instead of via the (non-existent) vcluster httproute syncer.
+//
+// Emitted ONLY for the vcluster tier: the host tier (free/S) runs the app + its
+// plain Service directly in the host `<slug>` ns, where the co-located
+// generateAppHTTPRoute already routes (no synced-service name exists there), so
+// this returns (nil, nil) for host-tier plans. HelmRelease-shaped apps (openclaw,
+// stalwart-mail) carry their OWN chart-emitted HTTPRoute parented to the same
+// gateway and sync no `<app>-x-…-x-vcluster` Service, so they are skipped — a
+// second route to a non-existent Service would 404. Shareable DB slugs
+// (mysql/postgres/redis) are never externally routed and are skipped too.
+//
+// Returns the file map (paths relative to the per-Org repo root) and the sorted
+// list of route doc basenames the caller merges into
+// `vcluster/host-apps/kustomization.yaml` (via MergePerOrgHostAppsKustomization).
+func (g *ManifestGenerator) GeneratePerOrgHostAppRoutes(slug, planSlug string, appSlugs []string) (files map[string]string, hostAppDocs []string) {
+	if !BoundaryIsVcluster(planSlug) {
+		return nil, nil
+	}
+	hostNS := slug // the org-controller-owned boundary ns (apps targetNamespace)
+	out := map[string]string{}
+	docs := []string{}
+	for _, a := range appSlugs {
+		switch a {
+		case "mysql", "postgres", "redis":
+			continue // shareable DB backends — never externally routed
+		}
+		if isHelmReleaseApp(a) {
+			continue // carries its own chart-emitted HTTPRoute; syncs no Service
+		}
+		name := fmt.Sprintf("app-%s-hostroute.yaml", a)
+		out[PerOrgHostAppsDir+"/"+name] = generateHostNativeAppRoute(hostNS, slug, a, g.parentDomain())
+		docs = append(docs, name)
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	sort.Strings(docs)
+	return out, docs
+}
+
+// MergePerOrgHostAppsKustomization rebuilds `vcluster/host-apps/kustomization.yaml`
+// so it enumerates the org-controller host-apps baseline
+// (ciliumnetworkpolicy.yaml + provisioning-rbac.yaml) AND the funnel's
+// host-native app-route docs (#4993). Symmetric with MergePerOrgAppsKustomization:
+// any resource already listed in `existing` is preserved (a second cart install
+// is additive), the baseline is force-included, and the new hostAppDocs are
+// unioned in. The result is deterministic (sorted) so a re-render is byte-stable
+// and the commit short-circuits when nothing changed.
+//
+// The org-controller SEEDS this index once (create-if-absent, #4993) and never
+// clobbers it thereafter — exactly like the apps kustomization — so the funnel's
+// route entries survive every subsequent Org reconcile.
+func MergePerOrgHostAppsKustomization(existing string, hostAppDocs []string) string {
+	resources := map[string]struct{}{}
+	for _, d := range perOrgHostAppsBaselineDocs {
+		resources[d] = struct{}{}
+	}
+	for _, line := range strings.Split(existing, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "- ") {
+			continue
+		}
+		name := strings.TrimSpace(strings.TrimPrefix(line, "- "))
+		if name == "" || name == "kustomization.yaml" {
+			continue
+		}
+		resources[name] = struct{}{}
+	}
+	for _, d := range hostAppDocs {
+		if d == "kustomization.yaml" {
+			continue
+		}
+		resources[d] = struct{}{}
+	}
+
+	names := make([]string, 0, len(resources))
+	for n := range resources {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	var b strings.Builder
+	b.WriteString("apiVersion: kustomize.config.k8s.io/v1beta1\n")
+	b.WriteString("kind: Kustomization\n")
+	b.WriteString("resources:\n")
+	for _, n := range names {
+		fmt.Fprintf(&b, "  - %s\n", n)
+	}
+	return b.String()
 }
 
 // isHostHelmReleaseAppFile reports whether `path` is a host-scoped

--- a/core/services/provisioning/handlers/consumer.go
+++ b/core/services/provisioning/handlers/consumer.go
@@ -705,16 +705,51 @@ func (h *Handler) applyTenantChangePerOrg(ctx context.Context, data appChangeDat
 		appFiles[kustPath] = gitops.MergePerOrgAppsKustomization(existingKust, appDocs)
 	}
 
+	// #4993 — for the VCLUSTER tier, also emit the HOST-NATIVE per-app HTTPRoutes
+	// into vcluster/host-apps/. The app's own HTTPRoute is co-located INSIDE the
+	// vcluster (apps tree, kubeConfig-targeted) but loft vcluster 0.33.4 registers
+	// no httproute reflecting controller, so it never reaches the host Cilium
+	// Gateway → 404 with pods Running. The host-native route binds the SYNCED
+	// Service (<app>-x-<slug>-x-vcluster) on the host `<slug>` ns directly — the
+	// same host-native model the per-Org console route uses. The org-controller
+	// SEEDS vcluster/host-apps/kustomization.yaml once and never clobbers it, so
+	// merge our route docs in (preserving the CNP + provisioning-rbac baseline),
+	// exactly as the apps kustomization above. Host-tier Orgs route via the
+	// co-located generateAppHTTPRoute (plain Service in the host ns), so
+	// GeneratePerOrgHostAppRoutes returns nothing and this block is a no-op.
+	if gitops.BoundaryIsVcluster(planSlug) {
+		hostRouteFiles, hostAppDocs := h.Generator.GeneratePerOrgHostAppRoutes(slug, planSlug, appSlugs)
+		for p, c := range hostRouteFiles {
+			appFiles[p] = c
+		}
+		hostKustPath := gitops.PerOrgHostAppsDir + "/kustomization.yaml"
+		existingHostKust := ""
+		if content, err := repoClient.ReadFile(ctx, branch, hostKustPath); err == nil {
+			existingHostKust = content
+		}
+		if action == "uninstall" {
+			// Rebuild from baseline + SURVIVING route docs only (drops the
+			// removed app's route from the index).
+			appFiles[hostKustPath] = gitops.MergePerOrgHostAppsKustomization("", hostAppDocs)
+		} else {
+			appFiles[hostKustPath] = gitops.MergePerOrgHostAppsKustomization(existingHostKust, hostAppDocs)
+		}
+	}
+
 	// Prune scope: ONLY the funnel-owned app docs (so uninstalled apps are
 	// removed), never the whole vcluster/apps tree — pruning the org-controller
 	// baseline (networkpolicy.yaml / ciliumnetworkpolicy.yaml) would tear down
 	// intra-Org isolation. CommitFilesWithPrune deletes blobs under a prune
 	// prefix that are NOT in the committed file set; we re-commit every funnel
 	// app doc each render, so a removed app's stale file is the only thing
-	// pruned. Scope the prefix to app-/db- files under the apps dir.
+	// pruned. Scope the prefix to app-/db- files under the apps dir + the
+	// host-native app-route files under host-apps (#4993) — the org-controller
+	// baseline there (ciliumnetworkpolicy.yaml / provisioning-rbac.yaml) does NOT
+	// start with `app-`, so it is never pruned.
 	prunePrefixes := []string{
 		gitops.PerOrgAppsDir + "/app-",
 		gitops.PerOrgAppsDir + "/db-",
+		gitops.PerOrgHostAppsDir + "/app-",
 	}
 
 	commitMsg := fmt.Sprintf("day-2: %s %s on Org %s (apps: %d) → vcluster/apps",


### PR DESCRIPTION
## Problem (#4993)

A marketplace-funnel **vcluster-tier** Org's purchased app gets pods Running + RBAC correct (after #4992) but still **404s**. Root cause, proven live on hw240 (`vcluster-0 -c syncer` logs): the syncer's `resources/register.go` creates syncers for **service, configmap, secret, endpoints, endpointslice, pod, event, pvc, ingressclass, networkpolicy** — and **no httproute syncer**. `httproutes.gateway.networking.k8s.io` appears ONLY as a quota-monitor/admission evaluator (the #4785 CRD import), never as a reflecting controller. So the app's HTTPRoute — co-located INSIDE the Org vcluster (the apps tree is kubeConfig-targeted for paid M+ tiers) — never reaches the host Cilium Gateway → 404 with pods Running.

Baseline reproduced on hw240: `curl https://wordpress.walk-stranger-two.omani.homes/` → **404** (pods would be Running, no host route).

## Fix direction

Mirror the **proven host-native per-Org console route** pattern (`tenant_route.go` — host-native in `catalyst-system`, never vcluster-synced). The funnel now emits a **host-native HTTPRoute per Deployment-shaped app** into the ALWAYS-host-applied `vcluster/host-apps/` tree, binding the **synced Service** (`<app>-x-<slug>-x-vcluster:80`) on the host `<slug>` ns, host `<app>.<slug>.<parentDomain>`, parented to the dedicated console **Cilium Gateway** (🛑 **NO NodePort**). This is the exact shape of the live-proven `app-wordpress-hostnative-4991proof` route on acme (Accepted+ResolvedRefs, serves 200/302).

- **vcluster tier** → host-native route in `vcluster/host-apps/` (synced backend).
- **host tier (free/S)** → unchanged: the co-located `generateAppHTTPRoute` routes the plain Service in the host `<slug>` ns (no synced name exists).

The org-controller now **SEEDs** `vcluster/host-apps/kustomization.yaml` (create-if-absent) exactly like the apps index, so the funnel's `MergePerOrgHostAppsKustomization` adds route docs (preserving the CNP + provisioning-rbac baseline) without the controller clobbering them.

## Changes

| File | Change |
|---|---|
| `gitops.go` | `generateHostNativeAppRoute` + `hostSyncedServiceName` (one canonical synced-name derivation; `generateHostIngress` delegates to it) |
| `perorg_apps_tree.go` | `GeneratePerOrgHostAppRoutes` + `MergePerOrgHostAppsKustomization` + `PerOrgHostAppsDir`/baseline |
| `consumer.go` | `applyTenantChangePerOrg` commits host routes + merges host-apps kustomization + prunes stale `vcluster/host-apps/app-` |
| `organization_controller.go` | host-apps kustomization seed-only |
| tests | host-native route (synced backend / host-tier no-route / HR+DB skip / merge additive+idempotent) + org-controller host-apps seed-only not-clobbered |

## Tests
`go test ./...` green for `core/services/provisioning/...` and `core/controllers/organization/...`; `gofmt` + `go vet` clean.

## Live verification
See issue #4993 for the hw240 walk on **walk-stranger-two** (2nd Org): 404 → 200/302 via the durable host-native route. Full zero-touch (fresh-prov, no hand-apply) lands on the next org-controller + provisioning image roll.

Refs #4993

🤖 Generated with [Claude Code](https://claude.com/claude-code)