### PR TITLE
fix(#4990): prefix-tolerant catalog Get — seed-only Blueprints resolve by bare name

### DIFF
--- a/core/services/catalyst-catalog/internal/source/org_private.go
+++ b/core/services/catalyst-catalog/internal/source/org_private.go
@@ -81,13 +81,27 @@ func (s *OrgPrivate) fetch(ctx context.Context, name string) (*Blueprint, error)
 			return bp, err
 		}
 	}
-	relPath := path.Join(name, "blueprint.yaml")
-	data, err := readBlueprintYAML(ctx, s.GC, s.Org, s.RepoName, relPath)
+	// #4990 — prefix-tolerant per-Blueprint directory lookup: a bare-name
+	// request resolves against a `bp-<x>` directory and vice-versa (the
+	// per-Org repo is fixed, so the "bp-" toggle applies to the directory
+	// segment, not the repo name).
+	resolved := name
+	data, err := readBlueprintYAML(ctx, s.GC, s.Org, s.RepoName, path.Join(name, "blueprint.yaml"))
+	if err != nil && IsNotFound(err) {
+		if alt := altBPName(name); alt != "" && alt != name {
+			d2, e2 := readBlueprintYAML(ctx, s.GC, s.Org, s.RepoName, path.Join(alt, "blueprint.yaml"))
+			if e2 == nil {
+				data, err, resolved = d2, nil, alt
+			} else if !IsNotFound(e2) {
+				return nil, e2
+			}
+		}
+	}
 	if err != nil {
 		return nil, err
 	}
 	if s.Cache != nil {
 		s.Cache.Put(key, data)
 	}
-	return ParseBlueprint(data, s.Origin(), s.Org, name)
+	return ParseBlueprint(data, s.Origin(), s.Org, resolved)
 }

--- a/core/services/catalyst-catalog/internal/source/public.go
+++ b/core/services/catalyst-catalog/internal/source/public.go
@@ -71,12 +71,16 @@ func (s *Public) fetch(ctx context.Context, name string) (*Blueprint, error) {
 			return ParseBlueprint(cached, s.Origin(), "", name)
 		}
 	}
-	data, err := readBlueprintYAML(ctx, s.GC, s.Org, name, "blueprint.yaml")
+	// #4990 — resolve prefix-tolerantly: a bare-name request (the
+	// frontend strips "^bp-") must still find a catalog-seed-only repo
+	// that carries the raw "bp-<x>" name, and vice-versa. `repo` is the
+	// name the blueprint actually resolved under.
+	data, repo, err := fetchBlueprintYAML(ctx, s.GC, s.Org, name, "blueprint.yaml")
 	if err != nil {
 		return nil, err
 	}
 	if s.Cache != nil {
 		s.Cache.Put(key, data)
 	}
-	return ParseBlueprint(data, s.Origin(), "", name)
+	return ParseBlueprint(data, s.Origin(), "", repo)
 }

--- a/core/services/catalyst-catalog/internal/source/source.go
+++ b/core/services/catalyst-catalog/internal/source/source.go
@@ -336,3 +336,55 @@ func IsNotFound(err error) bool {
 func trimBPPrefix(s string) string {
 	return strings.TrimPrefix(s, "bp-")
 }
+
+// altBPName returns the alternate "bp-" form of a Blueprint repo name:
+// the bare name when the input carries the "bp-" prefix, otherwise the
+// "bp-"prefixed form. Returns "" when there is no meaningful alternate
+// (empty input). #4990.
+//
+// The catalog frontend strips a leading "bp-" before requesting the
+// detail endpoint (CatalogDetail.tsx), so `GET /api/v1/catalog/{name}`
+// always arrives bare. Deployed Blueprints live in bare-named Gitea
+// repos (`agenity`) and resolve directly; catalog-SEED-ONLY entries that
+// were never deployed as a live Blueprint CR keep the raw `bp-<x>` repo
+// name (`bp-alloy`), so the bare-name lookup misses. Toggling the prefix
+// on a NotFound lets the bare request resolve against the seed repo (and
+// a `bp-`prefixed request resolve against a bare repo), with no effect on
+// the already-resolving deployed entries.
+func altBPName(name string) string {
+	if name == "" {
+		return ""
+	}
+	if strings.HasPrefix(name, "bp-") {
+		return strings.TrimPrefix(name, "bp-")
+	}
+	return "bp-" + name
+}
+
+// fetchBlueprintYAML reads a Blueprint's blueprint.yaml from a
+// conventional one-repo-per-Blueprint Org (public / sovereign), tolerating
+// the "bp-" prefix mismatch described on altBPName (#4990). It tries the
+// requested repo name first and, only on a typed NotFound, retries the
+// alternate "bp-" form. Returns the decoded bytes plus the repo name that
+// actually resolved (so the caller parses/keys under the real name). On a
+// double-miss the ORIGINAL NotFound is returned so callers' IsNotFound
+// branches still fire; genuine transport/parse errors are never masked.
+func fetchBlueprintYAML(ctx context.Context, gc *gitea.Client, org, name, path string) ([]byte, string, error) {
+	data, err := readBlueprintYAML(ctx, gc, org, name, path)
+	if err == nil {
+		return data, name, nil
+	}
+	if !IsNotFound(err) {
+		return nil, "", err
+	}
+	if alt := altBPName(name); alt != "" && alt != name {
+		d2, e2 := readBlueprintYAML(ctx, gc, org, alt, path)
+		if e2 == nil {
+			return d2, alt, nil
+		}
+		if !IsNotFound(e2) {
+			return nil, "", e2
+		}
+	}
+	return nil, "", err // preserve the original NotFound sentinel
+}

--- a/core/services/catalyst-catalog/internal/source/source_test.go
+++ b/core/services/catalyst-catalog/internal/source/source_test.go
@@ -281,6 +281,88 @@ func TestPublic_ListAndGet(t *testing.T) {
 	}
 }
 
+// TestPublic_SeedOnlyEntryResolvesByBareName is the regression guard for
+// #4990. The catalog frontend strips a leading "bp-" and requests the
+// detail endpoint by BARE name. Deployed Blueprints live in bare-named
+// repos (`agenity`) and already resolve; catalog-SEED-ONLY entries that
+// were never deployed as a live Blueprint CR keep the raw `bp-<x>` repo
+// name (`bp-alloy`). Before the fix, `Get(ctx, "alloy", "")` 404'd. The
+// prefix-tolerant repo lookup must resolve the bare request against the
+// seed repo WITHOUT regressing bare-named deployed repos.
+func TestPublic_SeedOnlyEntryResolvesByBareName(t *testing.T) {
+	t.Parallel()
+	fake := newFakeGitea()
+	// Seed-only entry: repo carries the raw "bp-" prefix, no bare twin.
+	fake.AddFile("catalog", "bp-alloy", "blueprint.yaml", blueprintYAML("bp-alloy", "1.0.0", "Alloy"))
+	// Deployed entry: bare-named repo (as a live-CR-projected Blueprint).
+	fake.AddFile("catalog", "agenity", "blueprint.yaml", blueprintYAML("agenity", "2.0.0", "Agenity"))
+	gc := newGiteaClient(t, fake)
+	src := NewPublic(gc, "catalog", cache.New(64, 30*time.Second))
+
+	// Bare-name request must resolve the seed-only "bp-alloy" repo.
+	bp, err := src.Get(context.Background(), "alloy", "")
+	if err != nil || bp == nil {
+		t.Fatalf("Get(alloy) = (%v, %v), want the bp-alloy seed entry", bp, err)
+	}
+	if bp.Card.Title != "Alloy" {
+		t.Errorf("Get(alloy).Card.Title = %q, want Alloy", bp.Card.Title)
+	}
+
+	// The `bp-`prefixed form must still resolve (back-compat).
+	bp, err = src.Get(context.Background(), "bp-alloy", "")
+	if err != nil || bp == nil {
+		t.Fatalf("Get(bp-alloy) = (%v, %v)", bp, err)
+	}
+	if bp.Card.Title != "Alloy" {
+		t.Errorf("Get(bp-alloy).Card.Title = %q, want Alloy", bp.Card.Title)
+	}
+
+	// Deployed bare-named repo must still resolve directly (no regression).
+	bp, err = src.Get(context.Background(), "agenity", "")
+	if err != nil || bp == nil {
+		t.Fatalf("Get(agenity) = (%v, %v)", bp, err)
+	}
+	if bp.Card.Title != "Agenity" {
+		t.Errorf("Get(agenity).Card.Title = %q, want Agenity", bp.Card.Title)
+	}
+
+	// A genuinely-absent Blueprint must still miss (nil, nil) — the
+	// prefix toggle must not conjure a match, and the original NotFound
+	// sentinel must survive the double-miss.
+	bp, err = src.Get(context.Background(), "nonexistent", "")
+	if err != nil {
+		t.Fatalf("Get(nonexistent) err = %v, want nil", err)
+	}
+	if bp != nil {
+		t.Errorf("Get(nonexistent) = %+v, want nil", bp)
+	}
+}
+
+// TestResolver_SeedOnlyEntryResolvesByBareName exercises the same #4990
+// path end-to-end through the Resolver (the shape the HTTP handler uses),
+// proving a bare-name detail request no longer 404s for seed-only cards.
+func TestResolver_SeedOnlyEntryResolvesByBareName(t *testing.T) {
+	t.Parallel()
+	fake := newFakeGitea()
+	fake.AddFile("catalog", "bp-alloy", "blueprint.yaml", blueprintYAML("bp-alloy", "1.0.0", "Alloy"))
+	gc := newGiteaClient(t, fake)
+	r := NewResolver(gc, "catalog", "catalog-sovereign", "shared-blueprints", cache.New(64, 30*time.Second))
+
+	// Anonymous caller (no visible Orgs), bare name — as the frontend sends.
+	bp, err := r.Get(context.Background(), "alloy", "", nil)
+	if err != nil || bp == nil {
+		t.Fatalf("Resolver.Get(alloy) = (%v, %v), want the seed entry", bp, err)
+	}
+	if bp.Card.Title != "Alloy" {
+		t.Errorf("Resolver.Get(alloy).Card.Title = %q, want Alloy", bp.Card.Title)
+	}
+
+	// Unknown bare name still surfaces ErrBlueprintNotFound.
+	if _, err := r.Get(context.Background(), "ghost", "", nil); !errors.Is(err, ErrBlueprintNotFound) {
+		t.Errorf("Resolver.Get(ghost) err = %v, want ErrBlueprintNotFound", err)
+	}
+}
+
 func TestPublic_OrgNotProvisioned_ReturnsEmpty(t *testing.T) {
 	fake := newFakeGitea()
 	gc := newGiteaClient(t, fake)

--- a/core/services/catalyst-catalog/internal/source/sovereign.go
+++ b/core/services/catalyst-catalog/internal/source/sovereign.go
@@ -72,7 +72,10 @@ func (s *Sovereign) fetch(ctx context.Context, name string) (*Blueprint, error) 
 			return ParseBlueprint(cached, s.Origin(), "", name)
 		}
 	}
-	data, err := readBlueprintYAML(ctx, s.GC, s.Org, name, "blueprint.yaml")
+	// #4990 — prefix-tolerant per-Blueprint lookup (see fetchBlueprintYAML):
+	// a bare-name request resolves against a catalog-seed-only `bp-<x>`
+	// repo and vice-versa. `repo` is the resolved repo name.
+	data, repo, err := fetchBlueprintYAML(ctx, s.GC, s.Org, name, "blueprint.yaml")
 	if err != nil && IsNotFound(err) {
 		// #2879 (2026-06-03) — monorepo-layout fallback. The
 		// bp-self-sovereign-cutover gitea-mirror Job actually mirrors
@@ -93,6 +96,7 @@ func (s *Sovereign) fetch(ctx context.Context, name string) (*Blueprint, error) 
 			if e2 == nil {
 				data = d2
 				err = nil
+				repo = bare
 				break
 			}
 			if !IsNotFound(e2) {
@@ -107,5 +111,5 @@ func (s *Sovereign) fetch(ctx context.Context, name string) (*Blueprint, error) 
 	if s.Cache != nil {
 		s.Cache.Put(key, data)
 	}
-	return ParseBlueprint(data, s.Origin(), "", name)
+	return ParseBlueprint(data, s.Origin(), "", repo)
 }


### PR DESCRIPTION
## Problem
The catalog **detail page 404s for catalog-seed-only Blueprints** — those seeded into the catalog but never deployed as a live Blueprint CR (e.g. `alloy`). Confirmed live on hw240 (#3668 UAT rows 125-152, stamped ⚠️).

## Root cause (confirmed)
- The frontend strips a leading `^bp-` and requests the **bare** name: `core/.../CatalogDetail.tsx:129` → `GET /api/v1/catalog/{name}`.
- The resolver's `Get` does a **direct Gitea repo lookup by that bare name** (`Public.fetch`/`Sovereign.fetch` → `readBlueprintYAML(gc, org, name, ...)`).
- **Deployed** Blueprints live in bare-named repos (`agenity`) → bare-name Get hits → 200.
- **Seed-only** entries keep the raw `bp-<x>` repo name (`bp-alloy`) → bare-name Get misses → **404** (`GET /catalog/bp-alloy` → 200, `GET /catalog/alloy` → 404).

## Fix
Make the source-layer repo lookup **`bp-`prefix-tolerant**: try the requested name, and on a typed `NotFound` retry the alternate `bp-` form. A bare request now resolves against the seed `bp-<x>` repo (and a `bp-`prefixed request against a bare repo), with **zero effect** on the already-resolving bare-named deployed entries. The original `NotFound` sentinel survives a double-miss, so callers' `IsNotFound` branches (`nil,nil` / `ErrBlueprintNotFound`) are unchanged.

Applied across all three sources:
- `Public` + `Sovereign` — per-repo lookup (the #2879 monorepo fallback in Sovereign is preserved).
- `OrgPrivate` — per-directory lookup (repo fixed; toggle applies to the directory segment).

Shared helpers `altBPName` + `fetchBlueprintYAML` added to `source.go`.

## Tests
- `TestPublic_SeedOnlyEntryResolvesByBareName` — seed-only `bp-alloy` resolves by bare `alloy`; `bp-alloy` still resolves; deployed bare `agenity` still resolves; absent name still misses `(nil,nil)`.
- `TestResolver_SeedOnlyEntryResolvesByBareName` — same, end-to-end through `Resolver.Get` (the shape the HTTP handler uses); unknown name still surfaces `ErrBlueprintNotFound`.

Verified as a **genuine regression guard**: both new tests FAIL on the pre-fix impl with the exact #4990 symptom (`Get(alloy) = (nil, nil)` / `blueprint not found`) and PASS with the fix. `go test ./...` green across the whole `catalyst-catalog` module; `go vet` clean. No chart touched → no lockstep bump.

Refs #4990

🤖 Generated with [Claude Code](https://claude.com/claude-code)