### PR TITLE
fix(#4994 #4996): harden cutover step-03 harbor-prewarm + step-07 catalyst-api roll

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -788,7 +788,18 @@ spec:
       # mirrors RUNNING tags but the cutover rolls to DESIRED chart-pinned tags, so
       # an unsettled env 404s step-06/08 under the deny-egress hold (live hw239).
       # Toggle prewarm.settledRollPreflight.enabled (default true). Still 11 steps.
-      version: 0.1.117
+      # 0.1.118 (#4994 + #4996 Refs #3379 #4972 #4885): two hw240 cutover-hardening
+      # fixes. #4994 — step-03 harbor-prewarm gains content-digest idempotency
+      # (skip a copy when local Harbor already serves it; fail-open) + real-time
+      # per-image progress + a heartbeat so it can't silently hang re-pushing ~121
+      # mothership images for 68m. #4996 — step-07 gains pre-roll safety gates:
+      # image-warmed gate (no blind pivot onto an unpullable image), broken-CSI
+      # node cordon + drain, and a deadlock-aware rollout wait that force-detaches
+      # the STALE RWO-EVS VolumeAttachment that Multi-Attach-wedged the Recreate
+      # roll (#4972). Toggles prewarm.skipIfAlreadyPresent + catalystAPI.rollSafety
+      # (both default on). RBAC adds volumeattachments/pvc read + delete + nodes
+      # patch. Still 11 steps / 10 job-mode.
+      version: 0.1.118
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.117
+  version: 0.1.118
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,44 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.118 (#4994 + #4996 Refs #3379 #4972 #4885 — two cutover-hardening defects
+# found live on hw240 (dep 0f1aac5431e6a436) that BLOCK cutoverComplete on
+# kom4dc/Huawei Sovereigns).
+#   #4994 (step-03 harbor-prewarm hangs/looks-hung): the skopeo mirror had (a) NO
+#     idempotency — a re-run (catalyst-api re-fires after a DeadlineExceeded) or an
+#     already-mirrored image re-transferred every multi-hundred-MB blob from the
+#     mothership; and (b) NO real-time progress — per-image copy logs were
+#     file-buffered and only surfaced after the whole `wait`, so a slow-but-working
+#     68m run (re-pushing ~121 proxy-* images) logged ONLY `queue` lines and was
+#     indistinguishable from a hang. FIX (template 03 + values): a content-digest
+#     skip (`skopeo inspect --raw | sha256sum` compares src vs dest manifest — no
+#     blob pull; works for single-arch AND multi-arch LISTS) elides a copy when
+#     local Harbor already serves byte-identical content, fail-OPEN so a
+#     partial/absent dest is still re-pushed (completeness contract preserved); a
+#     real-time per-image `done`/`skip` line + a bounded self-stopping heartbeat
+#     ("N/M settled" every 30s), drained via explicit worker PIDs (a bare `wait`
+#     would block on the never-returning heartbeat). New value
+#     prewarm.skipIfAlreadyPresent (default true). Applies to Phase A (container
+#     images) + Phase A2 (chart OCI). cutover-contract Case 42 locks it.
+#   #4996 (step-07 catalyst-api-env-patch wedges): step-07 pivoted catalyst-api's
+#     imageRegistry then blind `kubectl rollout status --timeout=300s` (Recreate).
+#     It WEDGED (succeeded=0 failed=4) because (a) the pivoted image was momentarily
+#     unpullable from local Harbor during a transient gateway blip →
+#     ImagePullBackOff cascade, and (b) the old Recreate pod's RWO-EVS PVCs didn't
+#     detach — worse on a broken-CSI node with no
+#     topology.evs.csi.huaweicloud.com/zone (#4972 wd2ab90) — so the new pod hit
+#     Multi-Attach and never scheduled. FIX (template 07 + values + rbac): three
+#     pre-roll gates, all toggle-able + FAIL-OPEN — (a) an image-warmed gate that
+#     confirms the local-Harbor catalyst-api manifest is servable BEFORE the pivot
+#     (FATAL pre-pivot on a genuine miss, so the env stays pre-pivot/recoverable);
+#     (c) a broken-CSI node cordon + drain-old-pod-first (no-op off Huawei); (b) a
+#     deadlock-aware rollout wait (roll_and_wait_catalyst_api) that force-detaches
+#     STALE catalyst-api VolumeAttachments (its owning pod is gone) while tolerating
+#     a self-healing ImagePullBackOff, replacing the blind 300s. New
+#     catalystAPI.rollSafety.* values; RBAC adds volumeattachments {get,list,delete}
+#     + persistentvolumeclaims {get,list} + nodes {patch}. cutover-contract Case 43
+#     locks it. NO step-count / job-mode change (still 11 steps / 10 job-mode).
+# Slot-06a pin + blueprint.yaml + catalog-seed source.version + spec.version move
+# to 0.1.118 in lockstep (Inviolable Principle #13; catalog-seed pin must NOT lag).
 # 0.1.117 (#4982 Refs #3379 — two durable robustness fixes found driving hw239 to
 # the step-08 pre-hold completeness gate). Finding A: LOCK the invariant that the
 # offline-mirror resolver (03a) + every per-step script CM (cutover-step-0N-*)
@@ -1798,7 +1837,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.117
+version: 0.1.118
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -170,6 +170,21 @@ data:
           # disable override. The key is always present in values.yaml.
           - name: SETTLED_ROLL_PREFLIGHT
             value: {{ .Values.prewarm.settledRollPreflight.enabled | quote }}
+          # #4994 (Refs #3379) — content-digest idempotency. When true (default)
+          # each skopeo copy first compares the SOURCE vs DEST manifest digest
+          # (`skopeo inspect --raw | sha256sum` — the sha256 of the exact manifest
+          # bytes IS the digest, for single-arch AND multi-arch LISTS, fetched
+          # WITHOUT pulling a single blob) and SKIPS the copy when local Harbor
+          # already serves byte-identical content. A prewarm RE-RUN (catalyst-api
+          # re-fires the step after a DeadlineExceeded) or an already-mirrored
+          # image then costs a cheap manifest HEAD instead of re-transferring
+          # every multi-hundred-MB blob from the mothership (the hw240 #4994
+          # "step-03 Running 0/1 for 68m" symptom). Fail-OPEN: any inspect miss
+          # (source or dest unreachable/absent/partial) FALLS THROUGH to the full
+          # copy, so the fail-closed completeness contract is preserved — a skip
+          # happens ONLY on a positive src==dst match. Set false to force re-copy.
+          - name: PREWARM_SKIP_IF_PRESENT
+            value: {{ .Values.prewarm.skipIfAlreadyPresent | quote }}
         volumeMounts:
           - name: prewarm
             mountPath: /work
@@ -535,6 +550,39 @@ data:
               esac
             }
 
+            # #4994 (Refs #3379) — content-digest idempotency probe. Returns 0
+            # (SKIP the copy) only when the local Harbor DEST already serves
+            # byte-identical manifest content as the SOURCE. `skopeo inspect --raw`
+            # streams the exact manifest (or manifest LIST) bytes the registry
+            # serves; their sha256 IS the manifest digest — correct for single-arch
+            # AND multi-arch, and it pulls NO blob. Comparing the two inspect-raw
+            # shas to each other (not to a precomputed digest) is robust to any
+            # consistent skopeo formatting. Fail-CLOSED to a full copy on ANY miss:
+            # an empty source sha (upstream unreachable) or a mismatched/empty dest
+            # sha (absent / partial / single-arch leftover from the pre-#4975 bug)
+            # both return non-zero → the caller does the real copy. So the
+            # fail-closed completeness contract is untouched; this only elides a
+            # redundant re-transfer.
+            dest_already_current() {
+              # $1 upstream ref  $2 local dest ref  $3 src creds (may be empty)
+              _dc_up="$1"; _dc_lref="$2"; _dc_sc="$3"
+              if [ -n "${_dc_sc}" ]; then
+                _dc_s=$(skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT}" inspect --raw \
+                  --creds="${_dc_sc}" --tls-verify=true "docker://${_dc_up}" 2>/dev/null \
+                  | sha256sum 2>/dev/null | awk '{print $1}')
+              else
+                _dc_s=$(skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT}" inspect --raw \
+                  --tls-verify=true "docker://${_dc_up}" 2>/dev/null \
+                  | sha256sum 2>/dev/null | awk '{print $1}')
+              fi
+              [ -z "${_dc_s}" ] && return 1
+              _dc_d=$(skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT}" inspect --raw \
+                --creds="${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
+                --tls-verify="${PREWARM_DEST_TLS_VERIFY}" "docker://${_dc_lref}" 2>/dev/null \
+                | sha256sum 2>/dev/null | awk '{print $1}')
+              [ -n "${_dc_d}" ] && [ "${_dc_s}" = "${_dc_d}" ]
+            }
+
             # #4975 — copy ONE upstream image to ALL of its local Harbor
             # destination path(s) (usually one; TWO for a ghcr.io/openova-io/*
             # ref — the host-drop openova-io/… convention + proxy-ghcr/openova-io/…).
@@ -560,6 +608,16 @@ data:
               last_rc=0
               for dpath in ${dests}; do
                 lref="${HARBOR_HOST}/${dpath}"
+                # #4994 — SKIP the (potentially multi-hundred-MB) copy when the
+                # dest already serves byte-identical content. Streams a real-time
+                # SKIP line to stdout so the operator sees instant forward progress
+                # for pre-warmed / re-run images instead of a silent 68m (hw240).
+                if [ "${PREWARM_SKIP_IF_PRESENT:-true}" = "true" ] \
+                   && dest_already_current "${up}" "${lref}" "${sc}"; then
+                  echo "[harbor-prewarm] skip ${up} -> ${lref} (dest already current)"
+                  echo "  SKIP ${up} -> ${lref} (dest already serves identical manifest; copy skipped)" >>"${cpdir}/${slug}.log"
+                  continue
+                fi
                 # OUTER per-dest retry loop: `--retry-times 5` self-heals a
                 # transient blob fetch inside ONE copy; a Harbor-side reset that
                 # closes the dest connection can still abort the whole copy
@@ -612,8 +670,13 @@ data:
               done
               if [ "${all_ok}" -eq 1 ]; then
                 printf '%s' "${up}" >"${cpdir}/${slug}.ok"
+                # #4994 — real-time per-image completion line to stdout (the worker
+                # runs async; without this the detailed .log is only surfaced after
+                # the whole `wait`, which is what made hw240 look hung for 68m).
+                echo "[harbor-prewarm] done ${up} (ok)"
               else
                 printf '%s exit=%s' "${up}" "${last_rc}" >"${cpdir}/${slug}.fail"
+                echo "[harbor-prewarm] done ${up} (FAIL exit=${last_rc})"
               fi
             }
 
@@ -650,14 +713,38 @@ data:
             count=$(printf '%s\n' ${mirror_work} | grep -c . || true)
             echo "[harbor-prewarm] ${count} mapped image(s) to mirror after resolver filter (parallelism=${PREWARM_PARALLELISM})"
 
+            # #4994 — real-time progress heartbeat. A bounded, self-stopping
+            # background loop prints "N/M settled" every 30s while the fan-out
+            # drains, so the step is NEVER a silent black box (hw240: "Running 0/1
+            # for 68m, only queue lines"). Combined with copy_one's per-image
+            # `done`/`skip` lines the operator always sees forward progress — and
+            # a genuine hang is now visibly bounded (settled count stops advancing)
+            # rather than indistinguishable from slow-but-working.
+            progress_heartbeat() {
+              _hb_tot="$1"; _hb_dir="$2"; _hb_label="$3"
+              while [ ! -f "${_hb_dir}/.hb_stop" ]; do
+                _hb_n=$( { ls "${_hb_dir}"/*.ok "${_hb_dir}"/*.fail 2>/dev/null || true; } | grep -c . || true)
+                echo "[harbor-prewarm] ${_hb_label} progress: ${_hb_n}/${_hb_tot} settled (still copying)"
+                _hb_i=0
+                while [ "${_hb_i}" -lt 30 ] && [ ! -f "${_hb_dir}/.hb_stop" ]; do sleep 1; _hb_i=$((_hb_i+1)); done
+              done
+            }
+            rm -f "${cpdir}/.hb_stop"
+            progress_heartbeat "${count}" "${cpdir}" "Phase A" &
+            hb_pid=$!
             # Track live worker PIDs explicitly — POSIX sh's `jobs -p` is
             # unreliable in a non-interactive shell, so we count by polling
-            # `kill -0 <pid>` against the PIDs we launched.
+            # `kill -0 <pid>` against the PIDs we launched. `allpids` accumulates
+            # EVERY worker so the final drain waits on the workers only (a bare
+            # `wait` would also block on the never-returning heartbeat #4994).
             pids=""
+            allpids=""
             for upstream in ${mirror_work}; do
               echo "[harbor-prewarm] queue ${upstream}"
               copy_one "${upstream}" &
-              pids="${pids} $!"
+              _newpid=$!
+              pids="${pids} ${_newpid}"
+              allpids="${allpids} ${_newpid}"
               # Throttle: block launching the next copy while
               # PREWARM_PARALLELISM workers are still alive.
               while : ; do
@@ -674,8 +761,11 @@ data:
                 sleep 2
               done
             done
-            # Drain the final batch.
-            wait
+            # Drain the workers explicitly (NOT a bare `wait` — that would also
+            # block on the heartbeat, which only stops on the sentinel below).
+            for _p in ${allpids}; do wait "${_p}" 2>/dev/null || true; done
+            touch "${cpdir}/.hb_stop"
+            wait "${hb_pid}" 2>/dev/null || true
 
             # Tally + surface each copy's captured log.
             push_ok=0
@@ -871,6 +961,15 @@ data:
               # as the Phase-B PREWARM_COPY_ATTEMPTS image path) turns a
               # transient dest 504 into a bounded retry instead of a cutover-
               # killing FATAL.
+              # #4994 idempotency: skip when local Harbor already serves this exact
+              # chart artifact (re-run / already-mirrored). The chart OCI is a single
+              # manifest; compare src vs dst raw-manifest sha (no blob pull).
+              if [ "${PREWARM_SKIP_IF_PRESENT:-true}" = "true" ] \
+                 && dest_already_current "${up_chart_prefix}/${cchart}:${cver}" "${HARBOR_HOST}/openova-io/${cchart}:${cver}" "${ghcr_user}:${ghcr_pat}"; then
+                echo "[harbor-prewarm] skip chart ${cchart}:${cver} (dest already current)"
+                printf '%s:%s (present)' "${cchart}" "${cver}" >"${chart_cpdir}/${cslug}.ok"
+                return 0
+              fi
               cattempt=0
               cmax="${PREWARM_COPY_ATTEMPTS:-4}"
               while : ; do
@@ -884,11 +983,13 @@ data:
                   --src-tls-verify=true \
                   "${csrc}" "${cdst}" >"${chart_cpdir}/${cslug}.log" 2>&1; then
                   printf '%s:%s' "${cchart}" "${cver}" >"${chart_cpdir}/${cslug}.ok"
+                  echo "[harbor-prewarm] done chart ${cchart}:${cver} (ok)"
                   return 0
                 fi
                 crc=$?
                 if [ "${cattempt}" -ge "${cmax}" ]; then
                   printf '%s:%s exit=%s attempts=%s' "${cchart}" "${cver}" "${crc}" "${cattempt}" >"${chart_cpdir}/${cslug}.fail"
+                  echo "[harbor-prewarm] done chart ${cchart}:${cver} (FAIL exit=${crc})"
                   return 0
                 fi
                 echo "[harbor-prewarm] chart ${cchart}:${cver} copy attempt ${cattempt}/${cmax} failed (rc=${crc}, transient e.g. 504) — retrying in $((cattempt*5))s" >>"${chart_cpdir}/${cslug}.log"
@@ -896,12 +997,20 @@ data:
               done
             }
 
+            # #4994 — Phase A2 gets the same real-time heartbeat + explicit drain
+            # as Phase A (the chart mirror shares the file-buffered-log silence).
+            rm -f "${chart_cpdir}/.hb_stop"
+            progress_heartbeat "${chart_count}" "${chart_cpdir}" "Phase A2" &
+            chart_hb_pid=$!
             chart_pids=""
+            chart_allpids=""
             while IFS="$(printf '\t')" read -r w_chart w_ver; do
               [ -z "${w_chart}" ] && continue
               echo "[harbor-prewarm] queue chart ${up_chart_prefix}/${w_chart}:${w_ver} → ${HARBOR_HOST}/openova-io/${w_chart}:${w_ver}"
               copy_chart "${w_chart}" "${w_ver}" &
-              chart_pids="${chart_pids} $!"
+              _cnp=$!
+              chart_pids="${chart_pids} ${_cnp}"
+              chart_allpids="${chart_allpids} ${_cnp}"
               # Throttle to PREWARM_PARALLELISM live workers (POSIX sh, no wait -n).
               while : ; do
                 clive=0
@@ -917,8 +1026,10 @@ data:
                 sleep 2
               done
             done < "${chart_work}"
-            # Drain.
-            wait
+            # Drain the chart workers explicitly, then stop + reap the heartbeat.
+            for _p in ${chart_allpids}; do wait "${_p}" 2>/dev/null || true; done
+            touch "${chart_cpdir}/.hb_stop"
+            wait "${chart_hb_pid}" 2>/dev/null || true
 
             chart_ok=0
             chart_fail=0

--- a/platform/self-sovereign-cutover/chart/templates/07-catalyst-api-env-patch-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/07-catalyst-api-env-patch-job.yaml
@@ -110,11 +110,238 @@ data:
           # sovereign.harborPublicURL / giteaPublicURL above).
           - name: CONSOLE_PUBLIC_URL
             value: {{ .Values.sovereign.consolePublicURL | quote }}
+          # #4996 (Refs #4972 #4885) — pre-roll safety gate inputs.
+          # Harbor admin creds so the image-warmed gate can HEAD the PRIVATE
+          # openova-io project manifest before pivoting catalyst-api's registry
+          # (same Reflector-mirrored harbor-admin Secret steps 02/03 already use).
+          - name: HARBOR_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.harbor.adminSecretRef.name }}
+                key: {{ .Values.harbor.adminSecretRef.usernameKey }}
+                optional: true
+          - name: HARBOR_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.harbor.adminSecretRef.name }}
+                key: {{ .Values.harbor.adminSecretRef.passwordKey }}
+          - name: ROLL_SAFETY
+            value: {{ .Values.catalystAPI.rollSafety.enabled | quote }}
+          - name: ROLL_BUDGET_SECONDS
+            value: {{ .Values.catalystAPI.rollSafety.rollBudgetSeconds | quote }}
+          - name: IMAGE_WARMED_GATE
+            value: {{ .Values.catalystAPI.rollSafety.imageWarmedGate.enabled | quote }}
+          - name: IMAGE_WARMED_POLL_SECONDS
+            value: {{ .Values.catalystAPI.rollSafety.imageWarmedGate.pollSeconds | quote }}
+          - name: EVS_GATE
+            value: {{ .Values.catalystAPI.rollSafety.evsGate.enabled | quote }}
+          - name: EVS_CSI_ZONE_LABEL
+            value: {{ .Values.catalystAPI.rollSafety.evsGate.zoneLabel | quote }}
         command: ["/bin/sh", "-c"]
         args:
           - |
             set -eu
             echo "[catalyst-api-env-patch] target=${DEPLOYMENT_NAMESPACE}/${DEPLOYMENT_NAME}"
+
+            # ═══ #4996 (Refs #4972 #4885) pre-roll safety gates ═══════════════
+            # Step-07 pivots catalyst-api's imageRegistry → local Harbor then rolls
+            # the Deployment (Recreate). On kom4dc that wedged TWO ways (hw240):
+            #   (a) the pivoted image wasn't cleanly pullable from local Harbor
+            #       during a transient gateway blip → ImagePullBackOff cascade;
+            #   (b) the old Recreate pod's RWO-EVS PVCs didn't detach (worse on a
+            #       broken-CSI node with no topology.evs.csi.huaweicloud.com/zone),
+            #       so the new pod hit Multi-Attach and never scheduled (#4972).
+            # These gates make the roll bounded + self-healing + idempotent. ALL
+            # are toggle-able + FAIL-OPEN: a tooling gap never wedges the cutover
+            # worse than the prior blind roll. They are DEFINED here and CALLED
+            # just before the imageRegistry pivot / around each rollout wait below.
+
+            # Newest live image the catalyst-api Deployment declares (chart-pinned;
+            # the pivot keeps the SAME tag, only the registry host changes).
+            ca_current_image() {
+              kubectl get deploy "${DEPLOYMENT_NAME}" -n "${DEPLOYMENT_NAMESPACE}" \
+                -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true
+            }
+            # HEAD a manifest against local Harbor (authenticated — the openova-io
+            # project is PRIVATE). ANY 200/redirect = present. -k tolerates the
+            # LE-staging wildcard on a fresh prov.
+            harbor_manifest_present() {
+              _hm_ref="$1"; _hm_hp="${_hm_ref#*/}"; _hm_path="${_hm_hp%:*}"; _hm_tag="${_hm_hp##*:}"
+              _hm_code=$(curl -sk -o /dev/null -w '%{http_code}' \
+                -u "${HARBOR_USERNAME:-admin}:${HARBOR_PASSWORD:-}" \
+                -H 'Accept: application/vnd.oci.image.index.v1+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json' \
+                -I "${HARBOR_PUBLIC_URL}/v2/${_hm_path}/manifests/${_hm_tag}" 2>/dev/null || true)
+              case "${_hm_code}" in 200|301|302) return 0 ;; *) return 1 ;; esac
+            }
+            # (a) image-warmed gate: refuse to pivot catalyst-api onto an image the
+            # local Harbor cannot yet serve. Bounded poll (step-03 pushes it, so it
+            # is normally already present); FATAL loudly on a genuine miss so the
+            # cutover stays PRE-PIVOT/recoverable instead of half-pivoted+wedged.
+            image_warmed_gate() {
+              [ "${IMAGE_WARMED_GATE:-true}" = "true" ] || { echo "[catalyst-api-env-patch] #4996 image-warmed gate DISABLED"; return 0; }
+              _iw_img=$(ca_current_image)
+              [ -z "${_iw_img}" ] && { echo "[catalyst-api-env-patch] #4996 image-warmed gate: cannot read catalyst-api image — skipping (fail-open)"; return 0; }
+              # host-drop the registry prefix (the openova-io host-drop convention
+              # step-03 Phase A pushed to + the chart re-renders post-pivot).
+              _iw_rest="${_iw_img}"
+              case "${_iw_img%%/*}" in *.*|*:*|localhost) _iw_rest="${_iw_img#*/}" ;; esac
+              _iw_local="${HARBOR_HOST}/${_iw_rest}"
+              echo "[catalyst-api-env-patch] #4996 image-warmed gate: confirming ${_iw_local} is servable from local Harbor before the imageRegistry pivot"
+              _iw_deadline=$(( $(date +%s) + ${IMAGE_WARMED_POLL_SECONDS:-240} ))
+              while : ; do
+                if harbor_manifest_present "${_iw_local}"; then
+                  echo "[catalyst-api-env-patch] #4996 image-warmed gate OK: ${_iw_local} present in local Harbor"
+                  return 0
+                fi
+                if [ "$(date +%s)" -ge "${_iw_deadline}" ]; then
+                  echo "[catalyst-api-env-patch] #4996 FATAL image-warmed gate: ${_iw_local} NOT servable from local Harbor after ${IMAGE_WARMED_POLL_SECONDS:-240}s — REFUSING to pivot catalyst-api onto an unpullable image (step-03 harbor-prewarm must push it first). Cutover left PRE-PIVOT/intact; re-trigger after harbor-prewarm completes." >&2
+                  return 1
+                fi
+                echo "[catalyst-api-env-patch] #4996 image-warmed gate: ${_iw_local} not yet servable; retry in 10s"
+                sleep 10
+              done
+            }
+
+            # catalyst-api's PVC-backed volumes → the PV names a Recreate roll must
+            # re-attach (the RWO-EVS Multi-Attach surface).
+            ca_pv_names() {
+              for _c in $(kubectl get deploy "${DEPLOYMENT_NAME}" -n "${DEPLOYMENT_NAMESPACE}" \
+                  -o jsonpath='{range .spec.template.spec.volumes[*]}{.persistentVolumeClaim.claimName}{"\n"}{end}' 2>/dev/null); do
+                [ -z "${_c}" ] && continue
+                kubectl get pvc "${_c}" -n "${DEPLOYMENT_NAMESPACE}" -o jsonpath='{.spec.volumeName}' 2>/dev/null
+                echo
+              done | grep -v '^$' | sort -u || true
+            }
+            # (b) EVS detach-gate: force-delete VolumeAttachments that bind
+            # catalyst-api's OWN PVs to a node that NO LONGER runs a catalyst-api
+            # pod. Such an attachment is unambiguously STALE (the pod that needed it
+            # is gone) and is the Multi-Attach deadlock source (#4972). SAFE by
+            # construction — it never touches an attachment on a node with a live
+            # catalyst-api pod, nor any non-catalyst-api PV.
+            evs_detach_gate() {
+              [ "${EVS_GATE:-true}" = "true" ] || return 0
+              _dg_pvs=$(ca_pv_names)
+              [ -z "${_dg_pvs}" ] && { echo "[catalyst-api-env-patch] #4996 detach-gate: catalyst-api has no PVC-backed volumes; nothing to detach"; return 0; }
+              _dg_live=$(kubectl get pods -n "${DEPLOYMENT_NAMESPACE}" \
+                -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.nodeName}{"\n"}{end}' 2>/dev/null \
+                | grep -E "^${DEPLOYMENT_NAME}-" | awk -F'\t' '{print $2}' | grep -v '^$' | sort -u || true)
+              kubectl get volumeattachments \
+                -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.nodeName}{"\t"}{.spec.source.persistentVolumeName}{"\n"}{end}' 2>/dev/null \
+                | while IFS="$(printf '\t')" read -r _va _vanode _vapv; do
+                    [ -z "${_vapv}" ] && continue
+                    printf '%s\n' "${_dg_pvs}" | grep -Fxq "${_vapv}" || continue
+                    if printf '%s\n' "${_dg_live}" | grep -Fxq "${_vanode}"; then continue; fi
+                    echo "[catalyst-api-env-patch] #4996 detach-gate: force-deleting STALE VolumeAttachment ${_va} (pv ${_vapv} on ${_vanode}; no live catalyst-api pod there — the #4972 Multi-Attach source)"
+                    kubectl delete volumeattachment "${_va}" --wait=false >/dev/null 2>&1 \
+                      || echo "[catalyst-api-env-patch] #4996 WARN failed to delete VolumeAttachment ${_va} (best-effort)"
+                  done
+            }
+
+            # (c) broken-CSI node gate: on a Huawei-EVS cluster a node missing the
+            # EVS zone label cannot attach EVS volumes — a Recreate roll landing
+            # catalyst-api there Multi-Attach-deadlocks (#4972 wd2ab90). Cordon
+            # every such node BEFORE the roll so the scheduler places the new pod on
+            # a healthy node, and drain catalyst-api off a broken node first. No-op
+            # off Huawei (no node carries the zone label → Hetzner hcloud-csi path).
+            preroll_node_prep() {
+              [ "${EVS_GATE:-true}" = "true" ] || return 0
+              [ -n "${EVS_CSI_ZONE_LABEL:-}" ] || return 0
+              _np_healthy=$(kubectl get nodes -l "${EVS_CSI_ZONE_LABEL}" \
+                -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null | grep -v '^$' | sort -u || true)
+              if [ -z "${_np_healthy}" ]; then
+                echo "[catalyst-api-env-patch] #4996 EVS gate: no node carries ${EVS_CSI_ZONE_LABEL} — not a Huawei-EVS cluster (or none healthy); skipping broken-CSI cordon"
+                return 0
+              fi
+              _np_all=$(kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null | grep -v '^$' | sort -u || true)
+              _np_broken=""
+              for _n in ${_np_all}; do
+                printf '%s\n' "${_np_healthy}" | grep -Fxq "${_n}" || _np_broken="${_np_broken} ${_n}"
+              done
+              if [ -z "${_np_broken}" ]; then
+                echo "[catalyst-api-env-patch] #4996 EVS gate: every node carries ${EVS_CSI_ZONE_LABEL} — no broken-CSI node to cordon"
+                return 0
+              fi
+              for _n in ${_np_broken}; do
+                echo "[catalyst-api-env-patch] #4996 EVS gate: cordoning broken-CSI node ${_n} (missing ${EVS_CSI_ZONE_LABEL}; RWO-EVS attach would Multi-Attach deadlock the roll — #4972)"
+                kubectl cordon "${_n}" >/dev/null 2>&1 || echo "[catalyst-api-env-patch] #4996 WARN cordon ${_n} failed (best-effort)"
+              done
+              # drain-old-pod-first: if the current catalyst-api pod is on a broken
+              # node, delete it now so its EVS detaches + it reschedules onto a
+              # healthy node BEFORE the Recreate roll (so its stale attachment can't
+              # then linger to Multi-Attach the new pod).
+              kubectl get pods -n "${DEPLOYMENT_NAMESPACE}" \
+                -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.nodeName}{"\n"}{end}' 2>/dev/null \
+                | grep -E "^${DEPLOYMENT_NAME}-" \
+                | while IFS="$(printf '\t')" read -r _op _onode; do
+                    [ -z "${_op}" ] && continue
+                    for _bn in ${_np_broken}; do
+                      if [ "${_onode}" = "${_bn}" ]; then
+                        echo "[catalyst-api-env-patch] #4996 EVS gate: draining catalyst-api pod ${_op} off broken-CSI node ${_onode} before the roll"
+                        kubectl delete pod "${_op}" -n "${DEPLOYMENT_NAMESPACE}" --wait=false >/dev/null 2>&1 \
+                          || echo "[catalyst-api-env-patch] #4996 WARN failed to delete pod ${_op} (best-effort)"
+                      fi
+                    done
+                  done
+              # a freshly-drained pod leaves a stale attachment for a beat — clear it.
+              evs_detach_gate
+            }
+
+            # Deadlock-aware replacement for the blind `kubectl rollout status
+            # --timeout=300s`. Distinguishes ImagePullBackOff (image is confirmed in
+            # local Harbor by the warmed gate → self-heals, keep waiting) from a
+            # volume-attach deadlock (run the safe detach-gate after a grace period).
+            # Bounded by ROLL_BUDGET_SECONDS; a final blocking status check drives
+            # the step's pass/fail so a genuine failure is a clean recoverable exit.
+            roll_and_wait_catalyst_api() {
+              _rw_why="$1"
+              if [ "${ROLL_SAFETY:-true}" != "true" ]; then
+                kubectl rollout status "deploy/${DEPLOYMENT_NAME}" -n "${DEPLOYMENT_NAMESPACE}" --timeout=300s
+                return $?
+              fi
+              echo "[catalyst-api-env-patch] #4996 rollout wait (${_rw_why}): budget=${ROLL_BUDGET_SECONDS:-600}s, EVS-detach + image-pull tolerant"
+              _rw_start=$(date +%s)
+              _rw_deadline=$(( _rw_start + ${ROLL_BUDGET_SECONDS:-600} ))
+              while : ; do
+                if kubectl rollout status "deploy/${DEPLOYMENT_NAME}" -n "${DEPLOYMENT_NAMESPACE}" --timeout=20s >/dev/null 2>&1; then
+                  echo "[catalyst-api-env-patch] #4996 rollout complete (${_rw_why})"
+                  return 0
+                fi
+                # newest catalyst-api pod (ISO8601 creationTimestamp sorts chrono).
+                _rw_pod=$(kubectl get pods -n "${DEPLOYMENT_NAMESPACE}" \
+                  -o jsonpath='{range .items[*]}{.metadata.creationTimestamp}{"\t"}{.metadata.name}{"\n"}{end}' 2>/dev/null \
+                  | grep -E "${DEPLOYMENT_NAME}-" | sort | tail -1 | awk -F'\t' '{print $2}')
+                if [ -n "${_rw_pod}" ]; then
+                  _rw_wait=$(kubectl get pod "${_rw_pod}" -n "${DEPLOYMENT_NAMESPACE}" \
+                    -o jsonpath='{range .status.containerStatuses[*]}{.state.waiting.reason}{" "}{end}{range .status.initContainerStatuses[*]}{.state.waiting.reason}{" "}{end}' 2>/dev/null || true)
+                  case "${_rw_wait}" in
+                    *ImagePullBackOff*|*ErrImagePull*)
+                      echo "[catalyst-api-env-patch] #4996 rollout wait: ${_rw_pod} pulling image (${_rw_wait% }); image confirmed in local Harbor by the warmed gate — pull self-heals, keep waiting" ;;
+                    *)
+                      # Not an image-pull stall. After a grace period (so a HEALTHY
+                      # roll that completes in <grace is never touched), run the
+                      # safe detach-gate — it only deletes provably-stale
+                      # catalyst-api attachments (the #4972 Multi-Attach un-stick).
+                      if [ $(( $(date +%s) - _rw_start )) -gt "${ROLL_DETACH_GRACE:-60}" ]; then
+                        evs_detach_gate
+                      fi ;;
+                  esac
+                fi
+                if [ "$(date +%s)" -ge "${_rw_deadline}" ]; then
+                  echo "[catalyst-api-env-patch] #4996 rollout wait: budget exhausted (${_rw_why}) — final blocking status check" >&2
+                  kubectl rollout status "deploy/${DEPLOYMENT_NAME}" -n "${DEPLOYMENT_NAMESPACE}" --timeout=30s
+                  return $?
+                fi
+                sleep 10
+              done
+            }
+
+            # ─── #4996 gates fire BEFORE the imageRegistry pivot (which rolls
+            # catalyst-api via Flux) so nothing pivots onto an unpullable image or
+            # onto a broken-CSI node. image_warmed_gate FATALs pre-pivot on a
+            # genuine miss; preroll_node_prep is best-effort.
+            HARBOR_HOST=$(echo "${HARBOR_PUBLIC_URL}" | sed -e 's|^https\?://||' -e 's|/.*$||')
+            image_warmed_gate || exit 1
+            preroll_node_prep || true
 
             # G61 Phase 1: patch HR.spec.values.global.imageRegistry
             # so Flux helm-controller upgrades catalyst-api Deployment
@@ -370,9 +597,12 @@ data:
             kubectl set env "deploy/${DEPLOYMENT_NAME}" \
               -n "${DEPLOYMENT_NAMESPACE}" \
               "${ENV_VAR_NAME}=${ENV_VAR_VALUE}"
-            kubectl rollout status "deploy/${DEPLOYMENT_NAME}" \
-              -n "${DEPLOYMENT_NAMESPACE}" \
-              --timeout=300s
+            # #4996: deadlock-aware wait (image-pull tolerant + EVS detach-gate)
+            # replaces the blind 300s rollout status that wedged hw240.
+            if ! roll_and_wait_catalyst_api "gitops-repo-url + image pivot"; then
+              echo "[catalyst-api-env-patch] #4996 FATAL: catalyst-api rollout did not converge (gitops-repo-url + image pivot) — see the EVS/image-pull diagnostics above; step exits for a clean recoverable re-run" >&2
+              exit 1
+            fi
 
             # ---- Phase 3 (#2940, 2026-06-03): pivot the remaining ----
             # catalyst-api mothership env seams. The VERIFIED-PARTIAL
@@ -406,9 +636,11 @@ data:
               -n "${DEPLOYMENT_NAMESPACE}" \
               "CATALYST_PIN_ISSUER=${CONSOLE_PUBLIC_URL}" \
               "CATALYST_HANDOVER_JWT_ISSUER=${CONSOLE_PUBLIC_URL}"
-            kubectl rollout status "deploy/${DEPLOYMENT_NAME}" \
-              -n "${DEPLOYMENT_NAMESPACE}" \
-              --timeout=300s
+            # #4996: deadlock-aware wait for the issuer-env roll too.
+            if ! roll_and_wait_catalyst_api "issuer envs"; then
+              echo "[catalyst-api-env-patch] #4996 FATAL: catalyst-api rollout did not converge (issuer envs) — see the EVS/image-pull diagnostics above; step exits for a clean recoverable re-run" >&2
+              exit 1
+            fi
 
             # 3c. Read-back asserts — live values, not intentions.
             for KEY in sovereign-console-url sovereign-api-public-url; do

--- a/platform/self-sovereign-cutover/chart/templates/rbac.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/rbac.yaml
@@ -30,7 +30,10 @@ The cutover runner needs cluster-scope reach because:
     insecureSkipVerify — certSecretRef is the only trust mechanism). Both
     the cross-namespace Secret read and the Secret create/patch are already
     covered by the cluster-scoped secrets get/create/patch rules below.
-  - Step 07 patches Deployment in `catalyst-platform` namespace.
+  - Step 07 patches the catalyst-api Deployment in `catalyst-system` and
+    (#4996) runs pre-roll safety gates: reads node EVS zone labels + PVCs +
+    VolumeAttachments, cordons a broken-CSI node, and force-deletes the stale
+    RWO-EVS VolumeAttachment that Multi-Attach-deadlocks a Recreate roll (#4972).
   - Step 08 creates+deletes a CiliumNetworkPolicy cluster-wide, queries
     HelmRelease/Kustomization status across all namespaces, AND (#3526)
     force-reconciles the GitRepository + bootstrap-kit Kustomization so
@@ -124,8 +127,14 @@ rules:
     resources: ["ciliumnetworkpolicies"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
-    resources: ["nodes"]   # registry-pivot DaemonSet reports node status into the status ConfigMap
+    resources: ["nodes"]   # registry-pivot DaemonSet reports node status into the status ConfigMap; step 07 (#4996) reads node EVS zone labels to spot a broken-CSI node
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]   # step 07 (#4996) maps catalyst-api's PVCs -> PV names to scope the EVS detach-gate to catalyst-api's OWN volumes
+    verbs: ["get", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]   # step 07 (#4996) enumerates VolumeAttachments to find + clear the STALE RWO-EVS attachment that Multi-Attach-deadlocks a Recreate roll (#4972)
+    verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["services"]   # #4639 (Refs #4637): registry-pivot DaemonSet resolves the cilium-gateway Service ClusterIP (node-routable, serves registry.<fqdn> wildcard TLS + token realm) for the dfdaemon hostAlias instead of the un-hairpinnable public gateway EIP
     verbs: ["get", "list", "watch"]
@@ -150,7 +159,13 @@ rules:
     verbs: ["update", "patch"]   # step 06 phase-0 merges harbor.<sov-fqdn> auth into ghcr-pull (#1184)
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["delete"]   # step 08 (#3647) force-deletes ONE openova-io-imaged Pod under deny-egress to prove a fresh image pull resolves through local Harbor (the ReplicaSet recreates it; only a single Pod is bounced)
+    verbs: ["delete"]   # step 08 (#3647) force-deletes ONE openova-io-imaged Pod under deny-egress; step 07 (#4996) drains the catalyst-api pod off a broken-CSI node before the roll (drain-old-pod-first, #4972)
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["patch"]   # step 07 (#4996) cordons a broken-CSI node (missing the EVS zone label) so the Recreate roll can't place catalyst-api where RWO-EVS attach would Multi-Attach deadlock (#4972)
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["delete"]   # step 07 (#4996) force-detaches the STALE catalyst-api RWO-EVS attachment (its owning pod is gone) that deadlocks the new Recreate pod on Multi-Attach (#4972)
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["delete"]   # #4652 (Refs #4641): registry-pivot rollback (v1) deletes the dragonfly-namespace dragonfly-harbor-ca Secret it created for the dfdaemon registryMirror.cert trust anchor (best-effort, paired with the addr/cert revert)

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -1604,4 +1604,107 @@ if ! grep -A1 'name: SETTLED_ROLL_PREFLIGHT' "$TMP/prewarm_a0_block.txt" | grep 
 fi
 echo "  PASS (Step-03 Phase A0 settled-roll pre-flight fail-closes on a mid-roll env before the mirror is built; default enabled)"
 
+echo "[cutover-contract] Case 42: Step-03 harbor-prewarm is idempotent (skip-if-already-present) + streams real-time progress so it can't silently hang (#4994, Refs #3379)"
+# hw240 (#4994): step-03 sat Running 0/1 for 68m re-pushing ~121 proxy-* images
+# from the mothership, logging ONLY `queue` lines — the per-image copy logs were
+# file-buffered and only surfaced after the whole `wait`, so a slow-but-working
+# run was indistinguishable from a hang. 0.1.118 adds (1) a content-digest skip:
+# `skopeo inspect --raw | sha256sum` compares src vs dest manifest — a copy is
+# elided when local Harbor already serves byte-identical content (re-run /
+# pre-warmed), fail-OPEN so a partial/absent dest is still re-pushed; (2) a
+# real-time per-image `done`/`skip` line + a bounded background heartbeat that
+# prints "N/M settled" every 30s, drained via explicit worker PIDs (a bare `wait`
+# would block on the never-returning heartbeat). Slice step-03's CM.
+awk '/cutover-step-03-harbor-prewarm/{c=1} c{print} c&&/cutover-order: "4"/{exit}' "$TMP/render.yaml" > "$TMP/prewarm_4994.txt"
+[ -s "$TMP/prewarm_4994.txt" ] || cp "$TMP/render.yaml" "$TMP/prewarm_4994.txt"
+if ! grep -q 'name: PREWARM_SKIP_IF_PRESENT' "$TMP/prewarm_4994.txt"; then
+  echo "FAIL: Step-03 missing the PREWARM_SKIP_IF_PRESENT toggle env — content-digest idempotency not wired (#4994)" >&2
+  exit 1
+fi
+if ! grep -q 'dest_already_current()' "$TMP/prewarm_4994.txt"; then
+  echo "FAIL: Step-03 missing dest_already_current() — the skip-if-already-present digest compare (#4994)" >&2
+  exit 1
+fi
+if ! grep -q 'inspect --raw' "$TMP/prewarm_4994.txt"; then
+  echo "FAIL: Step-03 idempotency does not use 'skopeo inspect --raw' (the no-blob-pull manifest-digest compare) (#4994)" >&2
+  exit 1
+fi
+if ! grep -q 'progress_heartbeat' "$TMP/prewarm_4994.txt"; then
+  echo "FAIL: Step-03 missing the progress_heartbeat — the step can still silently hang (#4994)" >&2
+  exit 1
+fi
+if ! grep -Eq '\[harbor-prewarm\] done ' "$TMP/prewarm_4994.txt"; then
+  echo "FAIL: Step-03 missing the real-time per-image 'done' progress line (#4994)" >&2
+  exit 1
+fi
+# The heartbeat must be drained via explicit worker PIDs, NOT a bare `wait` (which
+# would block on the heartbeat forever). Assert the sentinel-stop pattern.
+if ! grep -q 'touch "${cpdir}/.hb_stop"' "$TMP/prewarm_4994.txt"; then
+  echo "FAIL: Step-03 does not stop the heartbeat via the .hb_stop sentinel — a bare wait would deadlock on it (#4994)" >&2
+  exit 1
+fi
+if ! grep -A1 'name: PREWARM_SKIP_IF_PRESENT' "$TMP/prewarm_4994.txt" | grep -q 'value: "true"'; then
+  echo "FAIL: PREWARM_SKIP_IF_PRESENT must DEFAULT to enabled (rendered value != \"true\") (#4994)" >&2
+  exit 1
+fi
+echo "  PASS (Step-03 skips already-present copies + streams real-time progress; heartbeat drained via sentinel; default enabled)"
+
+echo "[cutover-contract] Case 43: Step-07 has pre-roll safety gates — image-warmed gate + EVS detach-gate + broken-CSI cordon + deadlock-aware rollout wait (#4996, Refs #4972 #4885)"
+# hw240 (#4996): step-07 pivoted catalyst-api's imageRegistry then blind
+# `kubectl rollout status --timeout=300s` (Recreate). It WEDGED because (a) the
+# pivoted image was momentarily unpullable from local Harbor and (b) the old
+# pod's RWO-EVS PVCs didn't detach on a broken-CSI node → Multi-Attach. 0.1.118
+# adds: an image-warmed gate BEFORE the pivot (FATAL pre-pivot on a genuine
+# miss), a broken-CSI node cordon + drain-old-pod-first, and a deadlock-aware
+# rollout wait that force-detaches STALE catalyst-api VolumeAttachments while
+# tolerating a self-healing ImagePullBackOff. Slice step-07's CM.
+awk '/cutover-step-07-catalyst-api-env-patch/{c=1} c{print} c&&/cutover-order: "8"/{exit}' "$TMP/render.yaml" > "$TMP/step07_4996.txt"
+[ -s "$TMP/step07_4996.txt" ] || cp "$TMP/render.yaml" "$TMP/step07_4996.txt"
+if ! grep -q 'image_warmed_gate()' "$TMP/step07_4996.txt"; then
+  echo "FAIL: Step-07 missing image_warmed_gate() — catalyst-api can still be blind-pivoted onto an unpullable image (#4996)" >&2
+  exit 1
+fi
+# The image-warmed gate MUST run BEFORE the imageRegistry HR pivot (leaving the
+# env PRE-PIVOT on a genuine miss).
+gate_ln=$(awk 'index($0,"image_warmed_gate || exit 1"){print NR; exit}' "$TMP/step07_4996.txt")
+pivot_ln=$(awk 'index($0,"G61 HR patch"){print NR; exit}' "$TMP/step07_4996.txt")
+if [ -z "$gate_ln" ] || [ -z "$pivot_ln" ] || [ "$gate_ln" -ge "$pivot_ln" ]; then
+  echo "FAIL: Step-07 image-warmed gate (line ${gate_ln:-?}) must run BEFORE the imageRegistry pivot (line ${pivot_ln:-?}) so a miss leaves the env pre-pivot (#4996)" >&2
+  exit 1
+fi
+if ! grep -q 'roll_and_wait_catalyst_api' "$TMP/step07_4996.txt"; then
+  echo "FAIL: Step-07 still uses the blind rollout wait — missing roll_and_wait_catalyst_api (#4996)" >&2
+  exit 1
+fi
+if ! grep -q 'evs_detach_gate()' "$TMP/step07_4996.txt"; then
+  echo "FAIL: Step-07 missing evs_detach_gate() — the RWO-EVS Multi-Attach un-stick (#4972)" >&2
+  exit 1
+fi
+if ! grep -q 'preroll_node_prep()' "$TMP/step07_4996.txt"; then
+  echo "FAIL: Step-07 missing preroll_node_prep() — the broken-CSI node cordon/drain (#4996)" >&2
+  exit 1
+fi
+if ! grep -q 'kubectl cordon' "$TMP/step07_4996.txt"; then
+  echo "FAIL: Step-07 broken-CSI gate does not cordon the node (#4996)" >&2
+  exit 1
+fi
+if ! grep -q 'kubectl delete volumeattachment' "$TMP/step07_4996.txt"; then
+  echo "FAIL: Step-07 detach-gate does not force-delete the stale VolumeAttachment (#4996 / #4972)" >&2
+  exit 1
+fi
+if ! grep -q 'name: EVS_CSI_ZONE_LABEL' "$TMP/step07_4996.txt"; then
+  echo "FAIL: Step-07 missing EVS_CSI_ZONE_LABEL env — the broken-CSI node signal (#4996)" >&2
+  exit 1
+fi
+# RBAC: the runner must be able to delete VolumeAttachments + patch nodes (cordon).
+if ! awk '/^kind: ClusterRole$/,/^---$/' "$TMP/render.yaml" | grep -A3 '"volumeattachments"' | grep -q '"delete"'; then
+  echo "FAIL: ClusterRole missing storage.k8s.io/volumeattachments delete — the detach-gate will 403 (#4996)" >&2
+  exit 1
+fi
+if ! awk '/^kind: ClusterRole$/,/^---$/' "$TMP/render.yaml" | grep -A3 'resources: \["nodes"\]' | grep -q '"patch"'; then
+  echo "FAIL: ClusterRole missing nodes patch — kubectl cordon will 403 (#4996)" >&2
+  exit 1
+fi
+echo "  PASS (Step-07 image-warmed gate pre-pivot + EVS detach-gate + broken-CSI cordon + deadlock-aware rollout wait; RBAC wired)"
+
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -595,6 +595,21 @@ prewarm:
   # settled.
   settledRollPreflight:
     enabled: true
+  # #4994 (Refs #3379) — content-digest idempotency for the step-03 skopeo
+  # mirror. When true (default) each container-image copy (Phase A) + chart-OCI
+  # copy (Phase A2) first compares the SOURCE vs local-Harbor DEST manifest
+  # digest (`skopeo inspect --raw | sha256sum`, no blob pull) and SKIPS the copy
+  # when the dest already serves byte-identical content. This makes a prewarm
+  # re-run (catalyst-api re-fires step-03 after a DeadlineExceeded) or an
+  # already-mirrored image cost a cheap manifest HEAD instead of re-transferring
+  # every multi-hundred-MB blob from the mothership — the hw240 #4994 symptom
+  # (step-03 Running 0/1 for 68m re-pushing ~121 images across the proxy-*
+  # projects). Fail-OPEN: any inspect miss (source unreachable, dest absent /
+  # partial / single-arch leftover) FALLS THROUGH to the full copy, so the
+  # fail-closed completeness contract (every workload image must land locally
+  # before the deny-egress hold) is preserved — a skip happens ONLY on a
+  # positive src==dst digest match. Set false to force an unconditional re-copy.
+  skipIfAlreadyPresent: true
   # #4975 (Refs #3379 #3695) — RETIRED. This hand-maintained 11-image HEAD list
   # (the old Phase B "warm the proxy-cache" pass) was one of the three drifting
   # lists that caused the per-prov whack-a-mole: any upstream image a chart added
@@ -777,6 +792,44 @@ catalystAPI:
   namespace: "catalyst-system"
   # The env var that catalyst-api reads for its GitOps source URL.
   envVar: "CATALYST_GITOPS_REPO_URL"
+
+  # #4996 (Refs #4972 #4885) — pre-roll safety gates. Step-07 pivots
+  # catalyst-api's imageRegistry to the local Harbor then rolls the Deployment
+  # (Recreate). On kom4dc that WEDGED the cutover two ways (hw240 dep
+  # 0f1aac5431e6a436): (a) the pivoted image was momentarily unpullable from the
+  # local Harbor during a transient gateway blip → ImagePullBackOff cascade; (b)
+  # the old Recreate pod's RWO-EVS PVCs did not detach — worse on a broken-CSI
+  # node with no topology.evs.csi.huaweicloud.com/zone (#4972 wd2ab90) — so the
+  # new pod hit Multi-Attach and never scheduled (succeeded=0 failed=4). These
+  # gates make the roll bounded + self-healing + idempotent, and never leave the
+  # Sovereign half-pivoted. All FAIL-OPEN (a tooling gap never wedges worse than
+  # the prior blind `kubectl rollout status --timeout=300s`).
+  rollSafety:
+    # Master switch. false = revert to the blind `rollout status --timeout=300s`.
+    enabled: true
+    # Total budget (seconds) for the deadlock-aware rollout wait, replacing the
+    # blind 300s. Covers image pull + EVS attach/detach on a slow Huawei prov.
+    rollBudgetSeconds: 600
+    # (a) image-warmed gate — before pivoting catalyst-api's imageRegistry,
+    # confirm the local-Harbor catalyst-api manifest is present + servable
+    # (authenticated HEAD, bounded poll). A genuine miss FATALs the step PRE-PIVOT
+    # (recoverable re-run) instead of a blind pivot onto an unpullable image.
+    imageWarmedGate:
+      enabled: true
+      pollSeconds: 240
+    # (b/c) EVS detach + broken-CSI node gate. On a Recreate roll of an RWO-EVS-
+    # backed catalyst-api, a stale VolumeAttachment / broken-CSI node deadlocks
+    # the new pod on Multi-Attach (#4972). The gate cordons every node MISSING the
+    # EVS zone label (broken CSI can't attach EVS) before the roll, drains
+    # catalyst-api off such a node, and force-deletes VolumeAttachments that bind
+    # catalyst-api's OWN PVs to a node with no live catalyst-api pod (provably
+    # stale). NO-OP off Huawei (no node carries zoneLabel → Hetzner hcloud-csi).
+    evsGate:
+      enabled: true
+      # The node label a correctly-registered Huawei EVS CSI publishes. A Ready
+      # node LACKING it (while others carry it) is broken-CSI and is cordoned.
+      # Empty disables the broken-CSI cordon (the detach-gate still runs).
+      zoneLabel: "topology.evs.csi.huaweicloud.com/zone"
 
 # #4885 (Refs #3379 #4563): step-07 image-registry pivot — the CURATED set of
 # ADDITIONAL openova-io HelmReleases whose chart HONOURS global.imageRegistry

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5041,7 +5041,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.117"
+  version: "0.1.118"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.117"
+    version: "0.1.118"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## What

Two hw240 (dep `0f1aac5431e6a436`, 2026-07-11) cutover-hardening defects that block `cutoverComplete` on kom4dc/Huawei Sovereigns. Both are chart-only fixes in `bp-self-sovereign-cutover` (0.1.117 → **0.1.118**).

### #4994 — step-03 harbor-prewarm hangs / looks-hung
The skopeo mirror had **no idempotency** (a re-run after a `DeadlineExceeded`, or an already-mirrored image, re-transferred every multi-hundred-MB blob from the mothership) and **no real-time progress** (per-image copy logs were file-buffered and only surfaced after the whole `wait`). So a slow-but-working 68m run re-pushing ~121 `proxy-*` images logged ONLY `queue` lines and was indistinguishable from a hang.

- **Content-digest skip**: `skopeo inspect --raw | sha256sum` compares SOURCE vs local-Harbor DEST manifest (no blob pull; correct for single-arch AND multi-arch LISTS). A copy is elided only on a positive `src==dst` match — **fail-OPEN**, so a partial/absent/single-arch-leftover dest is always re-pushed (the fail-closed completeness contract is preserved).
- **Real-time progress**: per-image `done`/`skip` line + a bounded self-stopping heartbeat (`N/M settled` every 30s), drained via explicit worker PIDs (a bare `wait` would block on the never-returning heartbeat).
- New value `prewarm.skipIfAlreadyPresent` (default `true`). Applies to Phase A (container images) + Phase A2 (chart OCI).

### #4996 — step-07 catalyst-api-env-patch wedges (RWO-EVS deadlock + registry-pivot ImagePullBackOff)
Step-07 pivoted catalyst-api's `imageRegistry` then blind `kubectl rollout status --timeout=300s` (Recreate). It wedged (`succeeded=0 failed=4`) because (a) the pivoted image was momentarily unpullable from local Harbor during a gateway blip → ImagePullBackOff cascade, and (b) the old Recreate pod's RWO-EVS PVCs didn't detach on a **broken-CSI node** (no `topology.evs.csi.huaweicloud.com/zone`, #4972 `wd2ab90`) → Multi-Attach.

Three pre-roll gates (all toggle-able + **fail-open**):
- **(a) image-warmed gate** — confirm the local-Harbor catalyst-api manifest is servable BEFORE the pivot; a genuine miss FATALs the step **pre-pivot** (env stays intact/recoverable) instead of a blind pivot onto an unpullable image.
- **(c) broken-CSI node gate** — cordon every node missing the EVS zone label + drain catalyst-api off it before the roll (no-op off Huawei).
- **(b) deadlock-aware rollout wait** — `roll_and_wait_catalyst_api` force-detaches STALE catalyst-api VolumeAttachments (owning pod gone) while tolerating a self-healing ImagePullBackOff, replacing the blind 300s.
- New `catalystAPI.rollSafety.*` values; RBAC adds `volumeattachments {get,list,delete}` + `persistentvolumeclaims {get,list}` + `nodes {patch}`.

## Constraints honoured
- 🛑 **No NodePort** — registry/gateway stay DIRECT (external host on :443); the fix only reads/HEADs local Harbor + detaches EVS volumes.
- Chart **0.1.117 → 0.1.118** lockstep across `blueprint.yaml` + `06a` slot pin + catalog-seed `source.version` + `spec.version`.

## Validation
- `helm template` renders clean; rendered step-03 + step-07 scripts pass `sh -n` + `shellcheck -S error`.
- `tests/cutover-contract.sh`: **45/45 gates green** (new Cases 42 + 43 lock both fixes).
- `check-bootstrap-kit-pin-sync.sh` + `check-catalog-seed-lockstep.sh` PASS.
- Functional unit-tests of the digest-compare (skip/copy/fail-open), host-drop derivation, newest-pod selection, and heartbeat/drain termination.

Live verification of the two runtime paths (68m→bounded prewarm; step-07 non-wedge) is **deferred to hw241's cutover** (needs a converged env; hw241 is converging now).

Refs #4994 #4996 #4972 #4885 #3379

🤖 Generated with [Claude Code](https://claude.com/claude-code)