### PR TITLE
fix(console #5000): sign-out menu on the sovereign sidebar user-card

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
@@ -22,7 +22,7 @@
  * Related: GitHub issue #607
  */
 
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Link, useRouterState } from '@tanstack/react-router'
 import { useQuery } from '@tanstack/react-query'
 import { loadTokens, parseJWTClaims } from '@/shared/lib/oidc'
@@ -303,6 +303,33 @@ export function SovereignSidebar({ sovereignFQDN }: SovereignSidebarProps) {
   // tenant label surfaces the FQDN.)
   const [tenantOpen, setTenantOpen] = useState(false)
 
+  // User-menu open state (UAT row 27 / #5000). The footer identity card is
+  // the ONLY place the signed-in owner can sign out of the Sovereign Console.
+  // Clicking (or Enter/Space on) the card toggles a small dropdown that opens
+  // UPWARD (the card is pinned to the bottom of the rail) exposing a
+  // "Signed in as <owner>" label + a Sign out action. Closes on a second
+  // click, Escape, or a click outside the card — mirroring the click-outside/
+  // ESC dismissal pattern already used by the wizard-header ProfileMenu.
+  const [userMenuOpen, setUserMenuOpen] = useState(false)
+  const userMenuRef = useRef<HTMLDivElement | null>(null)
+  useEffect(() => {
+    if (!userMenuOpen) return
+    function onClick(e: MouseEvent) {
+      if (userMenuRef.current && !userMenuRef.current.contains(e.target as Node)) {
+        setUserMenuOpen(false)
+      }
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setUserMenuOpen(false)
+    }
+    document.addEventListener('mousedown', onClick)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onClick)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [userMenuOpen])
+
   // Resolve the FQDN to display. The prop is the canonical source when
   // present; on the chroot Sovereign Console the deploymentId-bound
   // snapshot may not yet be loaded for newly-mounted pages, in which
@@ -493,12 +520,80 @@ export function SovereignSidebar({ sovereignFQDN }: SovereignSidebarProps) {
 
       {/* User card at the bottom — #4187: identity comes from /whoami
           (session.email), not the OIDC id_token, so the cookie/PIN-
-          authenticated owner renders by email instead of `User`. */}
+          authenticated owner renders by email instead of `User`.
+
+          UAT row 27 / #5000: the card is now the account MENU — the only
+          Sign-out affordance in the console. The avatar/name/FQDN layout is
+          unchanged (MUST-PRESERVE); we only wrap it in a menu trigger and add
+          an upward-opening dropdown with a "Signed in as <owner>" label + a
+          Sign out item wired to the shared two-hop `session.signOut()`. */}
       <div
-        className="border-t border-[var(--color-border)] p-3"
+        ref={userMenuRef}
+        className="relative border-t border-[var(--color-border)] p-3"
         data-testid="sov-console-user-card"
       >
-        <div className="flex items-center gap-2">
+        {/* Dropdown opens UPWARD — the card is pinned to the bottom of the
+            rail, so a downward menu would clip below the viewport. */}
+        {userMenuOpen ? (
+          <div
+            role="menu"
+            aria-label="Account"
+            id="sov-console-user-menu"
+            data-testid="sov-console-user-menu"
+            className="absolute bottom-full left-3 right-3 mb-2 overflow-hidden rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] py-1 shadow-lg shadow-black/30"
+          >
+            <div className="px-3 py-2">
+              <p className="text-[10px] uppercase tracking-wide text-[var(--color-text-dimmer)]">
+                Signed in as
+              </p>
+              <p
+                className="mt-0.5 truncate text-xs font-medium text-[var(--color-text)]"
+                data-testid="sov-console-user-menu-owner"
+                title={userName}
+              >
+                {userName}
+              </p>
+            </div>
+            <div className="border-t border-[var(--color-border)]" />
+            <button
+              type="button"
+              role="menuitem"
+              data-testid="sov-console-user-signout"
+              onClick={() => {
+                setUserMenuOpen(false)
+                void session.signOut()
+              }}
+              className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs text-[var(--color-text)] transition-colors hover:bg-[var(--color-surface-hover)] focus-visible:bg-[var(--color-surface-hover)] focus-visible:outline-none"
+            >
+              <svg
+                className="h-4 w-4 shrink-0"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={1.5}
+                aria-hidden
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
+                />
+              </svg>
+              Sign out
+            </button>
+          </div>
+        ) : null}
+
+        <button
+          type="button"
+          aria-haspopup="menu"
+          aria-expanded={userMenuOpen}
+          aria-controls="sov-console-user-menu"
+          onClick={() => setUserMenuOpen((v) => !v)}
+          data-testid="sov-console-user-trigger"
+          title={`${userName} — account menu`}
+          className="flex w-full items-center gap-2 rounded-lg text-left transition-colors hover:bg-[var(--color-surface-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+        >
           <div
             className="flex h-8 w-8 items-center justify-center rounded-full bg-[var(--color-accent)]/20 text-xs font-bold text-[var(--color-accent)]"
             data-testid="sov-console-user-avatar"
@@ -514,7 +609,19 @@ export function SovereignSidebar({ sovereignFQDN }: SovereignSidebarProps) {
             </p>
             <p className="truncate text-[10px] text-[var(--color-text-dimmer)]">{resolvedFQDN}</p>
           </div>
-        </div>
+          <svg
+            className={`h-3 w-3 shrink-0 text-[var(--color-text-dim)] transition-transform ${
+              userMenuOpen ? 'rotate-180' : ''
+            }`}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+            aria-hidden
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
       </div>
     </aside>
   )

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.usermenu.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.usermenu.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * SovereignSidebar.usermenu.test.tsx — UAT row 27 / #5000 account menu.
+ *
+ * The footer identity card is the ONLY Sign-out affordance in the Sovereign
+ * Console. Before #5000 it was a static <div> with no menu and no way to sign
+ * out. This suite pins the interactive contract:
+ *
+ *   1. The card renders a menu TRIGGER (aria-haspopup=menu) and the menu is
+ *      CLOSED by default — no "Sign out" item in the DOM until opened.
+ *   2. Clicking the trigger opens a "Signed in as <owner>" menu exposing a
+ *      Sign out item; a second click / Escape closes it.
+ *   3. Clicking Sign out invokes the shared two-hop `session.signOut()`.
+ *
+ * The identity assertions (avatar initials / owner email) live in the sibling
+ * SovereignSidebar.identity.test.tsx; here we only exercise the new menu.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+
+const signOutMock = vi.fn(async () => {})
+const sessionMock = vi.fn()
+vi.mock('@/shared/lib/useSession', () => ({
+  useSession: () => sessionMock(),
+}))
+vi.mock('@/shared/lib/useConsoleScope', () => ({
+  useConsoleScope: () => ({ orgScoped: false, org: null, loading: false }),
+}))
+vi.mock('@/lib/console-ui.api', () => ({
+  getSidebarEntries: async () => [],
+}))
+vi.mock('@/shared/lib/useResolvedDeploymentId', () => ({
+  useResolvedDeploymentId: () => ({ deploymentId: '' }),
+}))
+vi.mock('@/shared/lib/oidc', () => ({
+  loadTokens: () => null,
+  parseJWTClaims: () => ({}),
+}))
+
+import { SovereignSidebar } from './SovereignSidebar'
+
+function renderSidebar() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const host = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/apps',
+    component: () => <SovereignSidebar sovereignFQDN="console.omantel.biz" />,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([host]),
+    history: createMemoryHistory({ initialEntries: ['/apps'] }),
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router as never} />
+    </QueryClientProvider>,
+  )
+}
+
+describe('SovereignSidebar — UAT row 27 / #5000 account menu', () => {
+  beforeEach(() => {
+    sessionMock.mockReset()
+    signOutMock.mockClear()
+    sessionMock.mockReturnValue({
+      signedIn: true,
+      email: 'uat215@omani.works',
+      sub: 'kc-sub-1',
+      tier: 'owner',
+      roles: ['catalyst-owner'],
+      loading: false,
+      refetch: () => {},
+      signOut: signOutMock,
+    })
+  })
+  afterEach(() => cleanup())
+
+  it('renders a menu trigger and keeps the menu (and Sign out) closed by default', async () => {
+    renderSidebar()
+    const trigger = await screen.findByTestId('sov-console-user-trigger')
+    expect(trigger.getAttribute('aria-haspopup')).toBe('menu')
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+    // No Sign-out affordance in the DOM until the menu is opened.
+    expect(screen.queryByTestId('sov-console-user-signout')).toBeNull()
+    expect(screen.queryByTestId('sov-console-user-menu')).toBeNull()
+  })
+
+  it('opens a "Signed in as <owner>" menu with a Sign out item on click', async () => {
+    renderSidebar()
+    const trigger = await screen.findByTestId('sov-console-user-trigger')
+    fireEvent.click(trigger)
+
+    expect(trigger.getAttribute('aria-expanded')).toBe('true')
+    const menu = screen.getByTestId('sov-console-user-menu')
+    expect(menu.getAttribute('role')).toBe('menu')
+    expect(screen.getByText('Signed in as')).toBeTruthy()
+    expect(screen.getByTestId('sov-console-user-menu-owner').textContent).toBe(
+      'uat215@omani.works',
+    )
+    const signout = screen.getByTestId('sov-console-user-signout')
+    expect(signout.getAttribute('role')).toBe('menuitem')
+    expect(signout.textContent).toContain('Sign out')
+  })
+
+  it('invokes session.signOut() when Sign out is clicked', async () => {
+    renderSidebar()
+    fireEvent.click(await screen.findByTestId('sov-console-user-trigger'))
+    fireEvent.click(screen.getByTestId('sov-console-user-signout'))
+    expect(signOutMock).toHaveBeenCalledTimes(1)
+    // Clicking Sign out also closes the menu.
+    expect(screen.queryByTestId('sov-console-user-menu')).toBeNull()
+  })
+
+  it('closes the menu on Escape', async () => {
+    renderSidebar()
+    fireEvent.click(await screen.findByTestId('sov-console-user-trigger'))
+    expect(screen.getByTestId('sov-console-user-menu')).toBeTruthy()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByTestId('sov-console-user-menu')).toBeNull()
+  })
+})


### PR DESCRIPTION
## What

Adds a **Sign-out account menu** to the Sovereign Console sidebar user-card.

Found on **hw240, UAT row 27**: the console renders the signed-in owner as a
**static** footer card (`sov-console-user-card`: avatar / owner email /
sovereign FQDN) with **no dropdown and no Sign-out affordance anywhere in the
DOM** — the owner had no way to sign out.

## Root cause

`products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx`
rendered the footer identity as a non-interactive `<div>`. The **backend
session-teardown already exists and works** (`DELETE /api/v1/auth/session` →
`HandleAuthLogout`, `POST /api/v1/auth/session` → `HandleAuthSessionLogout`;
both clear `catalyst_session` + `catalyst_refresh`), and `useSession()` already
exposes a complete two-hop `signOut()` (consumed by the wizard-header
`ProfileMenu`). The sidebar simply never wired a trigger to it.

## Change (frontend-only)

- The avatar/name/FQDN row becomes a **menu trigger** (`aria-haspopup=menu`,
  `aria-expanded`, `focus-visible` accent ring, rotating chevron).
- Clicking / Enter / Space toggles an **upward-opening dropdown** (the card is
  bottom-pinned) with a **"Signed in as \<owner\>"** label + a **Sign out**
  `menuitem`.
- Sign out calls the shared two-hop `session.signOut()` → clears the session
  cookies server-side and hard-navigates to the Keycloak `end_session_endpoint`
  (then back to `/login`).
- Dismisses on second click, **Escape**, or click-outside (mirrors the existing
  `ProfileMenu` dismissal pattern).
- **MUST-PRESERVE honored**: the card look + all existing testids
  (`sov-console-user-card` / `-avatar` / `-name`) are unchanged; this only ADDs
  the trigger + dropdown. No new backend route. No NodePort. Host-gateway-served.

## Tests / gates

- New `SovereignSidebar.usermenu.test.tsx` (4 cases): trigger present + menu
  closed by default; opens "Signed in as \<owner\>" + Sign out on click;
  invokes `session.signOut()`; Escape closes.
- Existing `SovereignSidebar.identity.test.tsx` still green (identity contract
  preserved).
- `npm run build` (`tsc -b && vite build`) green; `eslint` clean on touched files.

## Verification note

Live rendering of the menu + a real sign-out is deferred to **hw241's SSO
walk** (no fresh prov stood up in this session).

Refs #5000
Refs #3374
