### PR TITLE
fix(#4999): funnel 2nd-Org honors chosen pool-TLD + console /auth/org-handover serves first (rows 93/94/95)

### DIFF
--- a/core/controllers/organization/internal/controller/organization_controller.go
+++ b/core/controllers/organization/internal/controller/organization_controller.go
@@ -509,6 +509,23 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}
 
+	// ── Console-serving FIRST (issue #4999) ─────────────────────────────
+	// The per-Org customer console (console.<slug>.<parentDomain>) is HOW THE
+	// OWNER SIGNS IN — zero-click /auth/org-handover → catalyst_session cookie →
+	// /jobs. Per the tenant_route.go design intent it MUST come up as soon as the
+	// Org has a public hostname, INDEPENDENT of every app-provisioning step below
+	// (Keycloak realm, Gitea, per-Org Flux, Federation, the #4991/#4992
+	// provisioning-RBAC / vcluster-mirror gap) — any of which can `r.fail(...)`.
+	// Before #4999 the DNS + TLS + HTTPRoute trio ran at the END of Reconcile, so
+	// an earlier fatal step aborted BEFORE the console route was ever written and
+	// the customer's /auth/org-handover 503'd (the hw240 2nd-Org walk-stranger-two
+	// symptom: the 1st Org converged fully so its route landed, the 2nd tripped an
+	// earlier step and never got a console route). Running the trio FIRST +
+	// best-effort (log + requeue, never block) guarantees every funnel Org can
+	// sign in even while its purchased app is still converging or has failed.
+	// No-op when spec.tenantPublic.parentDomain is empty.
+	consoleServingDegraded := r.reconcileConsoleServing(ctx, &org)
+
 	// 1. Keycloak group (in the Sovereign realm).
 	kcAttrs := map[string][]string{
 		"org":  {org.Spec.Slug},
@@ -656,53 +673,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return r.fail(ctx, &org, idpCond.Reason, fedErr.Error())
 	}
 
-	// 5a-pre. Per-Org pool-DNS A-record (issue #4236 — the #4179 final layer).
-	// Write `console.<slug>.<parentDomain>` + `*.<slug>.<parentDomain>` to the
-	// CENTRAL PowerDNS so a fresh marketplace-funnel signup's console host
-	// RESOLVES (#4222's pool writer was wired only into the catalyst-api BSS
-	// pipeline, which the marketplace funnel never runs; the org-controller
-	// reconciles EVERY Org CR, so writing the record here covers both doors).
-	// Ordered BEFORE the TLS + HTTPRoute steps so the name resolves the moment
-	// the cert/route land. Failure is TRANSIENT (a PowerDNS hiccup) and must NOT
-	// fail the whole Org reconcile — we log and let the 30s requeue retry, so the
-	// Org still goes Ready while DNS converges. No-op when parentDomain is empty
-	// or the central-pdns writer / console IP is unconfigured (see tenant_dns.go).
-	if _, err := r.reconcileTenantDNS(ctx, &org); err != nil {
-		log.Error(err, "tenant pool-DNS reconcile (transient — requeue)",
-			"organization", org.Name)
-	}
-
-	// 5a-bis. Per-pool console TLS (issue #4075). When the Org picks a
-	// free-subdomain hostname under a pool parent zone, issue the
-	// `*.<parentDomain>` cert-manager Certificate AND append the matching
-	// `*.<parentDomain>` listener to the dedicated console Gateway, so the
-	// Gateway can terminate TLS for `console.<slug>.<parentDomain>`.
-	// Without these, the customer-Org console URL fails with
-	// ERR_CONNECTION_CLOSED (no SNI match → no cert → TLS handshake
-	// closed) even when the HTTPRoute below is present. Both writes are
-	// idempotent + strictly additive (never touch the apex `*.<sovFQDN>`
-	// listener). Failure here is TRANSIENT (DNS-01 issuance latency or a
-	// momentary Gateway-update conflict) and must NOT fail the whole Org
-	// reconcile — we log and let the 30s requeue retry, so the Org still
-	// goes Ready (Keycloak group + Gitea Org + vCluster already landed)
-	// while the cert finishes issuing. No-op when parentDomain is empty.
-	if _, err := r.reconcileTenantConsoleTLS(ctx, &org); err != nil {
-		log.Error(err, "tenant console TLS reconcile (transient — requeue)",
-			"organization", org.Name)
-	}
-
-	// 5b. Per-tenant public-hostname HTTPRoute (issue #1629 follow-up).
-	// When `spec.tenantPublic.parentDomain` is set, render a Gateway-API
-	// HTTPRoute attaching `<subdomain>.<parentDomain>` to the supplied
-	// backend Service on the dedicated console Gateway (#4075). No-op when
-	// the field is empty — Orgs that don't yet have a public hostname keep
-	// working via the Sovereign-wide `*.<sovFQDN>` tenant-wildcard
-	// route. Failure is non-fatal for the Org's other reconciliation
-	// outputs (Keycloak group + Gitea Org + vCluster manifests already
-	// landed) so we requeue instead of marking the whole Org Failed.
-	if _, err := r.reconcileTenantRoute(ctx, &org); err != nil {
-		return r.fail(ctx, &org, "TenantRouteFailed", err.Error())
-	}
+	// 5a/5b. Console-serving trio (pool DNS + console TLS + console HTTPRoute)
+	// moved to the TOP of Reconcile — see reconcileConsoleServing / the
+	// `consoleServingDegraded` call above (issue #4999). Landing it here (after
+	// the vCluster/Gitea/Flux/Federation steps that can `r.fail(...)`) meant a
+	// funnel Org that tripped any earlier step never got a console route → the
+	// owner's /auth/org-handover 503'd. It now runs first + best-effort so the
+	// customer can always sign in; a transient failure is folded into the
+	// end-of-Reconcile requeue via consoleServingDegraded.
 
 	// 5c. Per-Org IaC repo bootstrap (G117.3 / W2.C3 — ADR-0009).
 	// Provisions the canonical `<slug>/iac` repo, the `<slug>-iac-bot`
@@ -818,10 +796,45 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// the Organization watch re-triggers on spec changes; the HR's own
 	// Flux reconcile drives the cluster state. While provisioning we poll
 	// the readback every 30s (matching the fail() cadence).
-	if !vcReady {
+	// Requeue while the vCluster is still coming up OR the console-serving trio
+	// (#4999) reported a transient failure — so the console DNS/TLS/HTTPRoute
+	// retry on the 30s cadence even for an Org that is otherwise Ready (a
+	// host-tier Org goes Ready immediately, so without this a transient console
+	// route write would sit un-retried until the next spec change).
+	if !vcReady || consoleServingDegraded {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 	return ctrl.Result{}, nil
+}
+
+// reconcileConsoleServing brings up the per-Org customer console EDGE — the
+// pool DNS A-record (console.<slug>.<parent> + *.<slug>.<parent>), the console
+// Gateway per-Org TLS listener+cert, and the console HTTPRoute (which wires
+// /auth/org-handover → catalyst-api and / → catalyst-ui) — for an Org that has
+// a public pool hostname (spec.tenantPublic.parentDomain). It is called FIRST in
+// Reconcile (issue #4999) so the owner can SIGN IN regardless of the
+// app-provisioning steps' outcome. All three are best-effort: a failure is
+// logged and returned as degraded=true so the caller requeues, but NEVER aborts
+// the reconcile — the console edge must not gate on, nor be gated by, the
+// vCluster/app pipeline. DNS is ordered first so the name resolves the moment
+// the cert/route land. Every step is a no-op when parentDomain is empty (the Org
+// has no public hostname yet → it is reached via the Sovereign-wide
+// `*.<sovFQDN>` tenant-wildcard route), so degraded stays false.
+func (r *Reconciler) reconcileConsoleServing(ctx context.Context, org *orgapi.Organization) (degraded bool) {
+	log := r.Log.WithValues("organization", org.Name)
+	if _, err := r.reconcileTenantDNS(ctx, org); err != nil {
+		log.Error(err, "tenant pool-DNS reconcile (transient — requeue)")
+		degraded = true
+	}
+	if _, err := r.reconcileTenantConsoleTLS(ctx, org); err != nil {
+		log.Error(err, "tenant console TLS reconcile (transient — requeue)")
+		degraded = true
+	}
+	if _, err := r.reconcileTenantRoute(ctx, org); err != nil {
+		log.Error(err, "tenant console HTTPRoute reconcile (transient — requeue)")
+		degraded = true
+	}
+	return degraded
 }
 
 // readyOrgMessage words the Organization's Ready=True condition message off the

--- a/core/controllers/organization/internal/controller/organization_controller_test.go
+++ b/core/controllers/organization/internal/controller/organization_controller_test.go
@@ -1005,6 +1005,87 @@ func TestReconcile_TenantPublic_RendersHTTPRoute(t *testing.T) {
 	}
 }
 
+// TestReconcile_ConsoleServing_LandsEvenWhenAppProvisioningStepFails is the
+// #4999 regression guard. The per-Org console HTTPRoute (which wires
+// /auth/org-handover → catalyst-api, the zero-click owner sign-in) MUST land
+// even when a LATER app-provisioning step fatally fails, so the owner can
+// ALWAYS sign in. Before #4999 the console-serving trio ran at the END of
+// Reconcile, so an early `r.fail(...)` — here a per-Org Keycloak realm error,
+// the exact class of failure the hw240 2nd Org (walk-stranger-two) tripped —
+// aborted the reconcile BEFORE the route was ever written, so
+// /auth/org-handover 503'd. The trio now runs FIRST, so the route lands
+// regardless of the downstream app pipeline.
+func TestReconcile_ConsoleServing_LandsEvenWhenAppProvisioningStepFails(t *testing.T) {
+	t.Parallel()
+	org := sampleOrg()
+	org.Spec.TenantPublic = orgapi.OrganizationTenantPublic{
+		ParentDomain: "omani.rest",
+		Subdomain:    "walk-stranger-two",
+	}
+
+	r, _, kc := makeReconciler(t, org)
+	// Enable the per-Org realm and make it FAIL — an EARLY fatal reconcile step
+	// (reconcilePerOrgRealm), well before the OLD console-route position.
+	r.PerOrgRealmEnabled = true
+	kc.realmEnsureErr = fmt.Errorf("keycloak realm create boom (simulated)")
+
+	scheme := r.Scheme()
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{
+		Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute",
+	}, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{
+		Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRouteList",
+	}, &unstructured.UnstructuredList{})
+
+	// A fresh Org first requeues once per finalizer it needs (per-org-realm,
+	// then tenant-networking), then runs the up-path. Loop generously; every
+	// pass returns nil error (finalizer-add + r.fail both requeue without
+	// erroring), and the work pass is idempotent.
+	for i := 0; i < 5; i++ {
+		if _, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: "acme"},
+		}); err != nil {
+			t.Fatalf("reconcile pass %d returned error: %v", i+1, err)
+		}
+	}
+
+	// Prove we actually exercised the early-abort path (the realm step ran +
+	// failed), not a happy-path reconcile.
+	if kc.realmEnsureCalls == 0 {
+		t.Fatal("expected EnsureRealm to be attempted (the early fatal step)")
+	}
+
+	// The console HTTPRoute MUST exist despite the realm failure.
+	hr := unstructured.Unstructured{}
+	hr.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute",
+	})
+	wantName := "catalyst-ui-console-walk-stranger-two-omani-rest"
+	if err := r.Get(context.Background(), client.ObjectKey{Namespace: "catalyst-system", Name: wantName}, &hr); err != nil {
+		t.Fatalf("console HTTPRoute MUST land even when an app-provisioning step fails (#4999): get catalyst-system/%s: %v", wantName, err)
+	}
+	hostnames, _, _ := unstructured.NestedSlice(hr.Object, "spec", "hostnames")
+	if len(hostnames) != 1 || hostnames[0] != "console.walk-stranger-two.omani.rest" {
+		t.Errorf("hostnames: got %v, want [console.walk-stranger-two.omani.rest]", hostnames)
+	}
+	// The route wires /auth/org-handover → catalyst-api (the sign-in path).
+	rules, _, _ := unstructured.NestedSlice(hr.Object, "spec", "rules")
+	if len(rules) != 5 {
+		t.Fatalf("console route rules: got %d, want 5 (health/handover/api/catalyst/catch-all)", len(rules))
+	}
+	handoverMatches, _, _ := unstructured.NestedSlice(rules[1].(map[string]any), "matches")
+	var sawOrgHandover bool
+	for _, m := range handoverMatches {
+		p, _, _ := unstructured.NestedString(m.(map[string]any), "path", "value")
+		if p == "/auth/org-handover" {
+			sawOrgHandover = true
+		}
+	}
+	if !sawOrgHandover {
+		t.Errorf("console route MUST route /auth/org-handover to catalyst-api even when app provisioning fails (#4999), matches=%v", handoverMatches)
+	}
+}
+
 // TestReconcile_TenantPublic_DisabledByDefault covers the no-op path:
 // when spec.tenantPublic.parentDomain is empty (the default for every
 // existing Org CR), NO HTTPRoute MUST be written. Without this guard

--- a/core/services/provisioning/gitops/host_native_app_route_4993_test.go
+++ b/core/services/provisioning/gitops/host_native_app_route_4993_test.go
@@ -55,6 +55,34 @@ func TestGeneratePerOrgHostAppRoutes_VclusterTier_SyncedBackend(t *testing.T) {
 	}
 }
 
+// TestGeneratePerOrgHostAppRoutes_HonorsPerOrgPoolZone is the #4999 apps-side
+// proof: when a 2nd Org's honored pool zone is `omani.rest`, the per-Org app host
+// MUST render under that SAME zone — `<app>.<slug>.omani.rest` — not the
+// Sovereign's primary apps pool. consumer.go achieves this by rendering on a
+// scoped generator clone whose ParentDomain is the honored zone; this test
+// exercises that mechanism directly (a generator pinned to omani.rest), so the
+// app host stays in lockstep with the per-Org console DNS/TLS/route zone (no
+// stale-apex-wildcard dead IP — the #4421 invariant, upheld under the pick).
+func TestGeneratePerOrgHostAppRoutes_HonorsPerOrgPoolZone(t *testing.T) {
+	g := NewManifestGenerator("clusters/sov/org-tenants")
+	// The Sovereign's PRIMARY apps pool is omani.homes, but THIS Org chose
+	// omani.rest — consumer.go clones the generator with ParentDomain=omani.rest.
+	g.ParentDomain = "omani.rest"
+
+	files, _ := g.GeneratePerOrgHostAppRoutes("walk-stranger-two", "m", []string{"wordpress"})
+	doc, ok := files["vcluster/host-apps/app-wordpress-hostroute.yaml"]
+	if !ok {
+		t.Fatalf("host-native route not emitted (keys: %v)", keys(files))
+	}
+	if want := "- wordpress.walk-stranger-two.omani.rest"; !strings.Contains(doc, want) {
+		t.Errorf("app host must render under the honored pool zone %q:\n%s", want, doc)
+	}
+	// Regression guard: it must NOT collapse back to the primary apps pool.
+	if strings.Contains(doc, "wordpress.walk-stranger-two.omani.homes") {
+		t.Errorf("app host regressed to the primary apps pool (omani.homes) instead of the honored omani.rest:\n%s", doc)
+	}
+}
+
 // TestGeneratePerOrgHostAppRoutes_HostTier_NoRoute — free/S host-tier Orgs run the
 // app + its plain Service directly in the host <slug> ns, where the co-located
 // generateAppHTTPRoute already routes and no synced-service name exists. So NO

--- a/core/services/provisioning/handlers/consumer.go
+++ b/core/services/provisioning/handlers/consumer.go
@@ -117,6 +117,12 @@ type appChangeData struct {
 	DeploySlugs    []string          `json:"deploy_slugs"`
 	DepChoices     map[string]string `json:"dep_choices"`
 	Apps           []string          `json:"apps"` // final tenant.Apps IDs after the change
+	// ParentDomain is the Org's chosen (already tenant-service-resolved) pool
+	// zone (#4999). The per-Org apps generator renders app hosts under THIS zone
+	// (via applyTenantChangePerOrg's scoped generator clone) so they match the
+	// per-Org console's zone (console==apps invariant under the honored TLD).
+	// Empty → the apps fall back to the Sovereign's primary apps pool, unchanged.
+	ParentDomain string `json:"parent_domain"`
 }
 
 func (h *Handler) handleAppInstallRequested(ctx context.Context, event *events.Event) error {
@@ -671,7 +677,25 @@ func (h *Handler) applyTenantChangePerOrg(ctx context.Context, data appChangeDat
 			"tenant", slug, "action", action, "repo", slug+"/"+h.perOrgRepoName())
 	}
 
-	appFiles, appDocs := h.Generator.GeneratePerOrgAppsTree(slug, planSlug, appSlugs, dbPassword)
+	// #4999: render the per-Org app hosts under the Org's CHOSEN (served) pool
+	// zone — the SAME zone resolveOrgParentDomain stamps on the Org CR's
+	// spec.tenantPublic.parentDomain (which drives the per-Org console DNS / TLS /
+	// route). Without this the apps render under the Sovereign's PRIMARY apps pool
+	// while the console lives on the honored TLD, so `<app>.<slug>.<primary>` has
+	// no per-Org A-record and dead-IPs on a stale apex wildcard (the #4421
+	// failure). Re-resolve the event's parent_domain through the SAME resolver the
+	// Org CR used, then render on a scoped generator clone — ManifestGenerator is
+	// read-only during render, so a shallow copy with an overridden ParentDomain
+	// is safe and confined to this Org. An empty/unserved pick resolves to the
+	// primary apps pool → byte-identical to pre-#4999 output (no regression).
+	gen := h.Generator
+	if zone := resolveOrgParentDomain(h.AppsParentDomain, h.PoolDomains, data.ParentDomain); zone != "" {
+		clone := *h.Generator
+		clone.ParentDomain = zone
+		gen = &clone
+	}
+
+	appFiles, appDocs := gen.GeneratePerOrgAppsTree(slug, planSlug, appSlugs, dbPassword)
 	if len(appFiles) == 0 && action == "install" {
 		// No deployable Application payload on an INSTALL (e.g. the cart held
 		// only HR-overlay apps the generic generator can't emit, or an empty
@@ -718,7 +742,7 @@ func (h *Handler) applyTenantChangePerOrg(ctx context.Context, data appChangeDat
 	// co-located generateAppHTTPRoute (plain Service in the host ns), so
 	// GeneratePerOrgHostAppRoutes returns nothing and this block is a no-op.
 	if gitops.BoundaryIsVcluster(planSlug) {
-		hostRouteFiles, hostAppDocs := h.Generator.GeneratePerOrgHostAppRoutes(slug, planSlug, appSlugs)
+		hostRouteFiles, hostAppDocs := gen.GeneratePerOrgHostAppRoutes(slug, planSlug, appSlugs)
 		for p, c := range hostRouteFiles {
 			appFiles[p] = c
 		}

--- a/core/services/provisioning/handlers/handlers.go
+++ b/core/services/provisioning/handlers/handlers.go
@@ -72,6 +72,15 @@ type Handler struct {
 	// host fell through to a stale apex `*.omani.homes` wildcard → dead IP.
 	AppsParentDomain string
 
+	// PoolDomains is the served org-pool TLD set (#4999) — env
+	// TENANT_POOL_DOMAINS, defaulting to the canonical four .omani.X zones when
+	// empty (see pool_domains.go). resolveOrgParentDomain honors a customer's
+	// funnel pick only when it is in this set (else it falls back to
+	// AppsParentDomain), so a 2nd Org can provision under a DIFFERENT served TLD.
+	// The apps generator follows the SAME resolved zone (applyTenantChangePerOrg
+	// scoped clone), keeping console==apps under the honored TLD.
+	PoolDomains []string
+
 	// PerOrgGitops enables the Sovereign per-Org commit target (#4384). When
 	// true, the day-2 cart install commits the customer's purchased
 	// Applications into the per-Org `<slug>/catalyst-tenant` repo's

--- a/core/services/provisioning/handlers/org_parentdomain_4421_test.go
+++ b/core/services/provisioning/handlers/org_parentdomain_4421_test.go
@@ -7,35 +7,35 @@ import (
 	"github.com/openova-io/openova/core/services/provisioning/gitops"
 )
 
-// TestResolveOrgParentDomain_4421 pins the #4421 invariant: the Organization
-// CR's pool (which the org-controller's DNS writer + console route key off) is
-// the SAME pool the per-Org apps-HTTPRoute renders under (h.AppsParentDomain).
-// A per-customer funnel pick (payload parent_domain) must NEVER override it on
-// a Sovereign that has an apps pool — otherwise the app host falls through to a
-// stale apex wildcard and resolves to a dead IP.
-func TestResolveOrgParentDomain_4421(t *testing.T) {
+// TestResolveOrgParentDomain_4999 pins the #4999 behavior (superseding the #4421
+// band-aid): the Organization CR's pool HONORS the customer's funnel pick when
+// the Sovereign SERVES that pool zone, and only falls back to the apps pool when
+// the pick is empty or not served. The apps-HTTPRoute generator follows the SAME
+// resolved zone (consumer.go scoped clone), so the #4421 invariant (per-Org
+// A-record zone == app-host zone) still holds — both simply move to the honored
+// TLD together instead of collapsing onto the single apps pool.
+func TestResolveOrgParentDomain_4999(t *testing.T) {
 	cases := []struct {
 		name        string
 		appsPool    string
+		poolDomains []string
 		payloadPool string
 		want        string
 	}{
 		{
-			// THE bug: customer picked omani.rest in the funnel but the
-			// Sovereign apps render under omani.homes. The apps pool must win
-			// so the per-Org A-record lands in omani.homes (where the app host
-			// resolves) instead of omani.rest (where it would never be looked
-			// up for the app host).
-			name:        "apps pool wins over a diverging payload pick",
+			// THE #4999 core: customer picked omani.rest (a served pool zone) in
+			// the funnel; apps pool is omani.homes → HONOR the pick. The Org CR,
+			// the console DNS/TLS/route, AND the apps generator all follow it.
+			name:        "served payload pick is honored",
 			appsPool:    "omani.homes",
 			payloadPool: "omani.rest",
-			want:        "omani.homes",
+			want:        "omani.rest",
 		},
 		{
-			name:        "apps pool wins over omani.trade payload pick",
+			name:        "served omani.trade pick is honored",
 			appsPool:    "omani.homes",
 			payloadPool: "omani.trade",
-			want:        "omani.homes",
+			want:        "omani.trade",
 		},
 		{
 			name:        "apps pool used when payload is empty",
@@ -50,8 +50,24 @@ func TestResolveOrgParentDomain_4421(t *testing.T) {
 			want:        "omani.homes",
 		},
 		{
-			// Degenerate Sovereign with no apps pool wired at all — the
-			// payload survives as a last-resort fallback.
+			// The #4421 dead-IP guard: a pick the Sovereign does NOT serve falls
+			// back to the apps pool so we never provision under an unserved zone.
+			name:        "unserved payload pick falls back to apps pool",
+			appsPool:    "omani.homes",
+			payloadPool: "not-a-pool.example",
+			want:        "omani.homes",
+		},
+		{
+			// An explicit served-set that excludes the pick → fall back.
+			name:        "pick outside configured pool set falls back",
+			appsPool:    "omani.homes",
+			poolDomains: []string{"omani.homes"},
+			payloadPool: "omani.rest",
+			want:        "omani.homes",
+		},
+		{
+			// Degenerate Sovereign with no apps pool wired at all — the payload
+			// survives as a last-resort fallback.
 			name:        "payload fallback when apps pool empty",
 			appsPool:    "",
 			payloadPool: "omani.rest",
@@ -64,75 +80,81 @@ func TestResolveOrgParentDomain_4421(t *testing.T) {
 			want:        "",
 		},
 		{
-			name:        "normalizes case + whitespace",
-			appsPool:    "  Omani.Homes  ",
-			payloadPool: "omani.rest",
-			want:        "omani.homes",
+			name:        "normalizes case + whitespace + leading dot (served pick)",
+			appsPool:    "omani.homes",
+			payloadPool: "  .Omani.Rest  ",
+			want:        "omani.rest",
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := resolveOrgParentDomain(tc.appsPool, tc.payloadPool)
+			got := resolveOrgParentDomain(tc.appsPool, tc.poolDomains, tc.payloadPool)
 			if got != tc.want {
-				t.Errorf("resolveOrgParentDomain(%q,%q) = %q; want %q",
-					tc.appsPool, tc.payloadPool, got, tc.want)
+				t.Errorf("resolveOrgParentDomain(%q,%v,%q) = %q; want %q",
+					tc.appsPool, tc.poolDomains, tc.payloadPool, got, tc.want)
 			}
 		})
 	}
 }
 
-// TestResolveParentDomain_SingleSourceOfTruth_4421 proves the handler's apps
-// pool and the gitops apps-HTTPRoute generator pool come from the SAME
-// resolver, so they cannot drift: an unset TENANT_PARENT_DOMAIN defaults to
-// omani.homes on BOTH sides, and a set value flows through verbatim. This is
-// what main.go relies on when it sets
-// Handler.AppsParentDomain = gitops.ResolveParentDomain(tenantParentDomain).
-func TestResolveParentDomain_SingleSourceOfTruth_4421(t *testing.T) {
-	// Empty env: apps generator defaults to omani.homes; the handler, fed the
-	// SAME resolved value, must stamp the SAME pool on the Org CR.
+// TestResolveParentDomain_ConsoleAppsLockstep_4999 proves the two zones stay in
+// lockstep under the honored pick: whatever resolveOrgParentDomain stamps on the
+// Org CR, the apps generator renders under (consumer.go feeds the SAME resolved
+// zone to a scoped generator clone). A served pick moves BOTH; an unset env still
+// defaults both to omani.homes.
+func TestResolveParentDomain_ConsoleAppsLockstep_4999(t *testing.T) {
+	// Empty env: apps generator defaults to omani.homes; an empty pick stamps the
+	// SAME pool on the Org CR.
 	appsPool := gitops.ResolveParentDomain("")
 	if appsPool != "omani.homes" {
 		t.Fatalf("apps generator default pool = %q; want omani.homes", appsPool)
 	}
-	if got := resolveOrgParentDomain(appsPool, "omani.rest"); got != appsPool {
-		t.Errorf("Org CR pool %q diverged from apps pool %q despite shared resolver", got, appsPool)
+	if got := resolveOrgParentDomain(appsPool, nil, ""); got != appsPool {
+		t.Errorf("empty pick: Org CR pool %q diverged from apps pool %q", got, appsPool)
 	}
 
-	// Explicit env: flows through unchanged on both sides.
+	// A served pick is honored — the Org CR zone AND (via the scoped clone) the
+	// app-host zone both become omani.rest, so they stay aligned on the pick.
+	if got := resolveOrgParentDomain(appsPool, nil, "omani.rest"); got != "omani.rest" {
+		t.Errorf("served pick: Org CR pool = %q; want the honored omani.rest", got)
+	}
+
+	// Explicit apps env flows through unchanged when the pick is empty.
 	if got := gitops.ResolveParentDomain("omani.trade"); got != "omani.trade" {
 		t.Errorf("ResolveParentDomain(omani.trade) = %q; want omani.trade", got)
 	}
-	if got := resolveOrgParentDomain("omani.trade", "omani.homes"); got != "omani.trade" {
-		t.Errorf("Org CR pool = %q; want the apps pool omani.trade", got)
+	if got := resolveOrgParentDomain("omani.trade", nil, ""); got != "omani.trade" {
+		t.Errorf("empty pick: Org CR pool = %q; want the apps pool omani.trade", got)
 	}
 }
 
-// TestCreateOrganizationCR_AppsPoolWins_NoFail_4421 drives the full handler
-// path with a diverging payload pick + a configured apps pool: the Org CR must
-// still mint (no provision.org_create_failed), confirming the #4421 override is
-// silent + non-fatal (it only realigns the pool, it does not reject the Org).
-func TestCreateOrganizationCR_AppsPoolWins_NoFail_4421(t *testing.T) {
+// TestCreateOrganizationCR_HonorsServedPick_NoFail_4999 drives the full handler
+// path with a served payload pick + a configured apps pool: the Org CR must
+// still mint (no provision.org_create_failed), confirming honoring the pick is
+// silent + non-fatal.
+func TestCreateOrganizationCR_HonorsServedPick_NoFail_4999(t *testing.T) {
 	clearK8sEnv(t)
 	pub := &recordingPublisher{}
 	h := &Handler{
 		Producer:         pub,
-		AppsParentDomain: "omani.homes", // Sovereign apps render here
+		AppsParentDomain: "omani.homes", // Sovereign primary apps pool
 		SovereignFQDN:    "test.omani.works",
+		// PoolDomains nil → the canonical four .omani.X served zones.
 	}
 	data := tenantCreatedPayload{
 		ID:           "tenant-abc",
 		Slug:         "acme",
 		OwnerEmail:   "owner@example.com",
 		PlanID:       "org-pool-basic",
-		ParentDomain: "omani.rest", // customer's diverging funnel pick
+		ParentDomain: "omani.rest", // customer's served funnel pick — now honored
 	}
-	// k8s env is scrubbed → expect a non-nil "create Organization" error from
-	// the POST, but crucially NOT a validation failure event.
+	// k8s env is scrubbed → expect a non-nil "create Organization" error from the
+	// POST, but crucially NOT a validation failure event.
 	err := h.createOrganizationCR(context.Background(), data)
 	if err == nil {
 		t.Fatalf("expected non-nil error (k8s env scrubbed); got nil")
 	}
 	if pub.byType("provision.org_create_failed") != nil {
-		t.Errorf("diverging payload pool should be silently realigned, not fail-published")
+		t.Errorf("a served payload pick should be silently honored, not fail-published")
 	}
 }

--- a/core/services/provisioning/handlers/organization_create.go
+++ b/core/services/provisioning/handlers/organization_create.go
@@ -106,21 +106,23 @@ func (h *Handler) createOrganizationCR(ctx context.Context, data tenantCreatedPa
 		return h.failOrgCreate(ctx, data.ID, slug,
 			"missing owner_email — cannot mint Organization CR without an owner roster entry")
 	}
-	// Parent domain resolution (#4421) — see resolveOrgParentDomain. The Org
-	// CR's pool MUST equal the pool the per-Org apps-HTTPRoute renders under,
-	// else the app host falls through to a stale apex wildcard → dead IP.
-	parentDomain := resolveOrgParentDomain(h.AppsParentDomain, data.ParentDomain)
+	// Parent domain resolution (#4999) — see resolveOrgParentDomain. The Org CR's
+	// pool == the pool the per-Org apps-HTTPRoute renders under (the apps
+	// generator follows the SAME resolved zone via consumer.go's scoped clone),
+	// so honoring the customer's served pick keeps console==apps under the chosen
+	// TLD instead of collapsing both onto the primary apps pool.
+	parentDomain := resolveOrgParentDomain(h.AppsParentDomain, h.PoolDomains, data.ParentDomain)
 	if parentDomain == "" {
 		slog.Warn("tenant.created consumer: no parent domain configured — Organization will mint without TenantPublic HTTPRoute",
 			"slug", slug)
 	} else if pd := strings.ToLower(strings.TrimSpace(data.ParentDomain)); pd != "" && pd != parentDomain {
-		// The customer's funnel pick disagrees with the Sovereign's apps
-		// pool. We deliberately override it (the apps zone is the one that
-		// must win, else the app host falls through to a stale wildcard) —
-		// log loud so an operator notices the funnel is offering a pool the
-		// Sovereign doesn't actually serve.
-		slog.Warn("tenant.created consumer: payload parent_domain overridden by the Sovereign apps pool to keep the Org DNS pool aligned with the apps-HTTPRoute pool (#4421)",
-			"slug", slug, "payload_parent_domain", pd, "apps_parent_domain", parentDomain)
+		// The customer's funnel pick is NOT a served pool zone → we fell back to
+		// the apps pool (never provision under a zone the Sovereign can't serve,
+		// the #4421 dead-IP guard). Log loud so an operator notices the funnel is
+		// offering a pool the Sovereign doesn't serve (fix the offer or add the
+		// zone to TENANT_POOL_DOMAINS).
+		slog.Warn("tenant.created consumer: payload parent_domain is not a served pool zone — fell back to the Sovereign apps pool (#4999)",
+			"slug", slug, "payload_parent_domain", pd, "resolved_parent_domain", parentDomain)
 	}
 
 	tier := strings.TrimSpace(data.Tier)
@@ -236,30 +238,34 @@ func (h *Handler) createOrganizationCR(ctx context.Context, data tenantCreatedPa
 }
 
 // resolveOrgParentDomain picks the org-pool parent zone the Organization CR's
-// spec.tenantPublic.parentDomain is stamped with (#4421). It returns
-// lowercased/trimmed.
+// spec.tenantPublic.parentDomain is stamped with (#4999, superseding #4421).
+// Returns lowercased/trimmed. It MIRRORS the tenant-service resolver of the same
+// name so both doors + the apps generator agree on ONE zone per Org.
 //
-// THE INVARIANT it enforces: the pool the org-controller's DNS writer
+// THE INVARIANT (#4421) it upholds: the pool the org-controller's DNS writer
 // (tenant_dns.go) + console route (tenant_route.go) key off MUST equal the pool
-// the per-Org apps-HTTPRoute generator renders product hosts under. Otherwise
-// the per-Org A-records land in one zone (the customer's funnel pick) while the
-// app hosts `<app>.<slug>.<otherZone>` have no record and fall through to a
-// stale apex `*.<otherZone>` wildcard → a DEAD IP (the #4421 failure:
-// openclaw.<slug>.omani.homes → 49.12.16.160 when the Org's funnel pick was
-// omani.rest).
+// the per-Org apps-HTTPRoute generator renders product hosts under — else the
+// per-Org A-records land in one zone while `<app>.<slug>.<otherZone>` has no
+// record and dead-IPs on a stale apex wildcard. #4999 keeps that invariant but
+// no longer COLLAPSES both onto the single apps pool: it HONORS the customer's
+// served funnel pick (payloadParentDomain ∈ poolDomains) and the apps generator
+// follows the SAME resolved zone (consumer.go scoped clone), so the two Orgs can
+// live on two different served TLDs.
 //
-// appsParentDomain is the EFFECTIVE pool the apps generator renders under
-// (gitops.ResolveParentDomain(TENANT_PARENT_DOMAIN), defaulting to omani.homes),
-// resolved ONCE in main.go and handed to both the generator and this handler so
-// the two can never drift. It is non-empty on any real Sovereign (the apps
-// ALWAYS render under a zone), so it WINS — the per-customer payloadParentDomain
-// is honored only as a last-resort fallback on a degenerate Sovereign with no
-// apps pool wired at all.
-func resolveOrgParentDomain(appsParentDomain, payloadParentDomain string) string {
-	if pd := strings.ToLower(strings.TrimSpace(appsParentDomain)); pd != "" {
-		return pd
+// A pick outside the served set (or empty) falls back to appsParentDomain (the
+// EFFECTIVE pool, gitops.ResolveParentDomain(TENANT_PARENT_DOMAIN), non-empty on
+// any real Sovereign) so we NEVER provision under a zone the Sovereign can't
+// serve. Only a degenerate Sovereign with no apps pool wired falls through to the
+// raw pick. poolDomains defaults to the canonical four .omani.X zones when unset.
+func resolveOrgParentDomain(appsParentDomain string, poolDomains []string, payloadParentDomain string) string {
+	pick := normalizePoolZone(payloadParentDomain)
+	if pick != "" && isServedPoolDomain(pick, poolDomains) {
+		return pick
 	}
-	return strings.ToLower(strings.TrimSpace(payloadParentDomain))
+	if primary := normalizePoolZone(appsParentDomain); primary != "" {
+		return primary
+	}
+	return pick
 }
 
 // failOrgCreate logs + publishes a `provision.org_create_failed` event

--- a/core/services/provisioning/handlers/pool_domains.go
+++ b/core/services/provisioning/handlers/pool_domains.go
@@ -1,0 +1,63 @@
+// pool_domains.go — the Sovereign's served org-pool TLD set (#4999, Refs #3376).
+//
+// Mirrors core/services/tenant/handlers/pool_domains.go (the two services are
+// separate Go modules, so the tiny served-pool helper is duplicated the same way
+// resolveOrgParentDomain already is). resolveOrgParentDomain uses this to HONOR
+// the customer's funnel-selected pool TLD when the Sovereign serves that zone,
+// instead of the pre-#4999 #4421 band-aid that dropped every non-primary pick.
+package handlers
+
+import (
+	"os"
+	"strings"
+)
+
+// defaultPoolTLDs is the canonical OpenOva-managed org-pool free-subdomain set —
+// matches core/services/domain/store.AllowedTLDs, the marketplace /addons picker,
+// and catalyst-api's CATALYST_ORG_POOL_DOMAINS seed. All four are
+// PowerDNS-delegated + DNS-01-wired on every Sovereign, so provisioning a
+// customer Org under any of them is safe. Used as the served set when
+// TENANT_POOL_DOMAINS is unset, so a fresh Sovereign honors the funnel TLD choice
+// with no extra config.
+var defaultPoolTLDs = []string{"omani.rest", "omani.works", "omani.trade", "omani.homes"}
+
+// PoolDomainsFromEnv reads the operator-overridable served-pool set from
+// TENANT_POOL_DOMAINS (comma-separated FQDNs). Empty → nil (resolveOrgParentDomain
+// falls back to defaultPoolTLDs).
+func PoolDomainsFromEnv() []string {
+	raw := strings.TrimSpace(os.Getenv("TENANT_POOL_DOMAINS"))
+	if raw == "" {
+		return nil
+	}
+	out := []string{}
+	for _, p := range strings.Split(raw, ",") {
+		if z := normalizePoolZone(p); z != "" {
+			out = append(out, z)
+		}
+	}
+	return out
+}
+
+// normalizePoolZone lowercases, trims, and strips any leading dot.
+func normalizePoolZone(z string) string {
+	return strings.ToLower(strings.TrimPrefix(strings.TrimSpace(z), "."))
+}
+
+// isServedPoolDomain reports whether tld is a pool zone this Sovereign serves.
+// An empty configured set falls back to the canonical defaultPoolTLDs.
+func isServedPoolDomain(tld string, configured []string) bool {
+	tld = normalizePoolZone(tld)
+	if tld == "" {
+		return false
+	}
+	set := configured
+	if len(set) == 0 {
+		set = defaultPoolTLDs
+	}
+	for _, z := range set {
+		if normalizePoolZone(z) == tld {
+			return true
+		}
+	}
+	return false
+}

--- a/core/services/provisioning/handlers/tenant_public_patch.go
+++ b/core/services/provisioning/handlers/tenant_public_patch.go
@@ -100,14 +100,23 @@ func (h *Handler) patchOrgTenantPublic(ctx context.Context, tenantSlug, product,
 	}
 	backendService := fmt.Sprintf("%s-x-%s-x-vcluster", product, hostNS)
 
-	// Build the merge-patch body. We patch ONLY spec.tenantPublic
-	// (and stable sub-fields) so any operator-managed field elsewhere
-	// on the CR is untouched.
+	// Build the merge-patch body. We patch ONLY the product-install sub-fields
+	// (backendService / backendPort / product) so any operator-managed field
+	// elsewhere on the CR is untouched.
+	//
+	// #4999: DO NOT patch parentDomain/subdomain here. createOrganizationCR
+	// (tenant.created) is the SOLE owner of the Org's pool zone — it stamps the
+	// HONORED served pick on spec.tenantPublic.parentDomain. This day-2 patch
+	// runs LATER (on product-ready); re-writing parentDomain from the Sovereign's
+	// single primary apps pool (h.TenantParentDomain) would CLOBBER a 2nd Org's
+	// honored `omani.rest` back to `omani.homes` AFTER its console already came up
+	// on omani.rest — reverting the funnel TLD choice. A merge-patch that omits
+	// the field leaves the create-owned zone intact. `parent` above is still
+	// required as the feature-enabled gate (empty → the whole patch is skipped on
+	// a single-domain Sovereign, unchanged).
 	body := map[string]any{
 		"spec": map[string]any{
 			"tenantPublic": map[string]any{
-				"parentDomain":   parent,
-				"subdomain":      slug,
 				"backendService": backendService,
 				"backendPort":    int64(tenantPublicDefaultBackendPort),
 				"product":        product,

--- a/core/services/provisioning/handlers/tenant_public_patch_test.go
+++ b/core/services/provisioning/handlers/tenant_public_patch_test.go
@@ -81,13 +81,16 @@ func TestPatchOrgTenantPublic_EmptyHostNamespaceSkipped(t *testing.T) {
 // the wire bytes — so we construct the same shape ourselves and assert
 // json.Marshal of it round-trips to the expected map.
 func TestPatchOrgTenantPublic_PayloadShape(t *testing.T) {
-	// The fields the patch body MUST carry — exercised here so a
-	// regression that drops or renames one is caught in CI.
+	// #4999: the patch carries ONLY the product-install sub-fields. It MUST NOT
+	// carry parentDomain/subdomain — createOrganizationCR (tenant.created) owns
+	// the Org's pool zone (the honored funnel pick), and re-writing it from the
+	// Sovereign's single primary apps pool here would CLOBBER a 2nd Org's
+	// omani.rest back to omani.homes on product-ready. This mirrors the exact
+	// map literal patchOrgTenantPublic builds, so a regression that re-adds the
+	// clobbering fields is caught in CI.
 	body := map[string]any{
 		"spec": map[string]any{
 			"tenantPublic": map[string]any{
-				"parentDomain":   "omani.homes",
-				"subdomain":      "acme",
 				"backendService": "wordpress-x-tenant-acme-x-vcluster",
 				"backendPort":    int64(80),
 				"product":        "wordpress",
@@ -100,14 +103,18 @@ func TestPatchOrgTenantPublic_PayloadShape(t *testing.T) {
 	}
 	got := string(raw)
 	for _, must := range []string{
-		`"parentDomain":"omani.homes"`,
-		`"subdomain":"acme"`,
 		`"backendService":"wordpress-x-tenant-acme-x-vcluster"`,
 		`"backendPort":80`,
 		`"product":"wordpress"`,
 	} {
 		if !strings.Contains(got, must) {
 			t.Errorf("payload missing %q: %s", must, got)
+		}
+	}
+	// The #4999 no-clobber contract: parentDomain/subdomain must be ABSENT.
+	for _, mustNot := range []string{`"parentDomain"`, `"subdomain"`} {
+		if strings.Contains(got, mustNot) {
+			t.Errorf("patch body must NOT carry %s (createOrganizationCR owns the pool zone, #4999): %s", mustNot, got)
 		}
 	}
 }

--- a/core/services/provisioning/main.go
+++ b/core/services/provisioning/main.go
@@ -290,7 +290,11 @@ func main() {
 		// Resolved here so the Org-CR DNS-writer pool the tenant.created handler
 		// stamps always equals the pool the apps-HTTPRoute renders under.
 		AppsParentDomain: gitops.ResolveParentDomain(tenantParentDomain),
-		PerOrgGitops:     perOrgGitops,
+		// #4999: served org-pool TLD set (env TENANT_POOL_DOMAINS; nil → the
+		// canonical four .omani.X zones) so createOrganizationCR + the apps
+		// generator HONOR the customer's chosen served pool TLD.
+		PoolDomains:    handlers.PoolDomainsFromEnv(),
+		PerOrgGitops:   perOrgGitops,
 		PerOrgRepoName:   perOrgRepoName,
 		PerOrgBranch:     perOrgBranch,
 	}

--- a/core/services/tenant/handlers/apps.go
+++ b/core/services/tenant/handlers/apps.go
@@ -188,6 +188,9 @@ func (h *Handler) InstallApp(w http.ResponseWriter, r *http.Request) {
 		"deploy_slugs":    deploySlugs,
 		"dep_choices":     body.DepChoices,
 		"apps":            tenant.Apps,
+		// #4999: the Org's chosen pool zone so day-2 app installs render under the
+		// same TLD as the per-Org console (console==apps invariant).
+		"parent_domain": tenant.ParentDomain,
 	}
 	if err := h.callProvisioning(r.Context(), "/provisioning/apps/install", payload); err != nil {
 		slog.Error("install: provisioning HTTP call", "error", err, "tenant_id", tenantID)

--- a/core/services/tenant/handlers/console_host_apps_pool_4821_test.go
+++ b/core/services/tenant/handlers/console_host_apps_pool_4821_test.go
@@ -1,21 +1,24 @@
 package handlers
 
-// console_host_apps_pool_4821_test.go — #4821 Finding-2 contract.
+// console_host_apps_pool_4821_test.go — #4821 Finding-2 → #4999 contract.
 //
 // The tenant-service returns a SERVER-AUTHORITATIVE `console_host`
 // (`console.<slug>.<parentDomain>`) that the marketplace funnel redirects to
 // after Launch (CheckoutStep.svelte::setActiveOrgConsoleHost). The
 // org-controller — the door that actually WRITES the per-Org DNS A-record +
-// console TLS cert + HTTPRoute — stamps its pool via the identical
-// apps-pool-wins rule (organization_create.go::resolveOrgParentDomain, #4421):
-// the Sovereign's EFFECTIVE apps pool (env TENANT_PARENT_DOMAIN) WINS over the
-// funnel-selected TLD.
+// console TLS cert + HTTPRoute — stamps its pool via the identical resolver
+// (organization_create.go::resolveOrgParentDomain), so both doors AND the apps
+// generator agree on ONE zone per Org.
 //
-// Finding-2 was the DISAGREEMENT: on hw228 the funnel offered `.omani.rest`
-// but the Sovereign's single apps pool is `omani.homes`. The org-controller
-// provisioned `console.acme.omani.homes`, while this service returned
-// `console.acme.omani.rest` (the raw funnel pick) — an NXDOMAIN host — so the
-// post-Launch redirect 404'd. These tests lock the two doors to the SAME pool.
+// #4821 Finding-2 (the original bug this file guarded) was the DISAGREEMENT
+// where this service returned the raw funnel pick while the org-controller
+// provisioned the apps pool, yielding an NXDOMAIN console_host. The old fix
+// forced the apps pool to WIN (#4421) — which silently DROPPED every non-primary
+// funnel pick, so "two Orgs on two different TLDs" (Pillar-1) could never hold.
+//
+// #4999 supersedes that: the pick is HONORED when the Sovereign serves that pool
+// zone, and BOTH doors + the apps generator follow it — so the two doors stay in
+// lockstep (no NXDOMAIN) AND the customer's chosen TLD is actually provisioned.
 
 import (
 	"testing"
@@ -23,99 +26,114 @@ import (
 	"github.com/openova-io/openova/core/services/tenant/store"
 )
 
-func TestResolveOrgParentDomain_AppsPoolWins(t *testing.T) {
+func TestResolveOrgParentDomain_HonorsServedPick(t *testing.T) {
 	cases := []struct {
-		name       string
-		appsPool   string
-		funnelPick string
-		want       string
+		name        string
+		appsPool    string
+		poolDomains []string
+		funnelPick  string
+		want        string
 	}{
 		{
-			// The exact #4821 Finding-2 shape: funnel offered omani.rest,
-			// Sovereign apps pool is omani.homes → apps pool WINS.
-			name:       "funnel_pick_differs_apps_pool_wins",
+			// The #4999 core: funnel offered omani.rest (a served pool zone),
+			// apps pool is omani.homes → HONOR the pick. (Pre-#4999 this returned
+			// omani.homes and dropped the customer's choice.)
+			name:       "served_pick_is_honored",
 			appsPool:   "omani.homes",
 			funnelPick: "omani.rest",
-			want:       "omani.homes",
+			want:       "omani.rest",
 		},
 		{
-			// Funnel pick agrees with the apps pool (the #4176 separate-pool
-			// happy path) → no change, both resolve to the same value.
-			name:       "funnel_pick_matches_apps_pool",
+			// Funnel pick agrees with the apps pool → no change.
+			name:       "pick_matches_apps_pool",
 			appsPool:   "omani.homes",
 			funnelPick: "omani.homes",
 			want:       "omani.homes",
 		},
 		{
-			// Funnel offered nothing but the Sovereign has an apps pool →
-			// apps pool supplies the zone (this is what makes console_host
-			// resolvable even when the funnel omits parent_domain).
-			name:       "empty_funnel_pick_uses_apps_pool",
+			// Funnel offered nothing → apps pool supplies the zone (keeps
+			// console_host resolvable when the funnel omits parent_domain).
+			name:       "empty_pick_uses_apps_pool",
 			appsPool:   "omani.homes",
 			funnelPick: "",
 			want:       "omani.homes",
 		},
 		{
+			// Pick is NOT a served pool zone (the #4421 dead-IP guard) → fall
+			// back to the apps pool so we never provision under an unserved zone.
+			name:       "unserved_pick_falls_back_to_apps_pool",
+			appsPool:   "omani.homes",
+			funnelPick: "evil.example.com",
+			want:       "omani.homes",
+		},
+		{
+			// An explicit served-set that EXCLUDES the pick → fall back. Proves
+			// the offer is gated on TENANT_POOL_DOMAINS, not blindly trusted.
+			name:        "pick_outside_configured_set_falls_back",
+			appsPool:    "omani.homes",
+			poolDomains: []string{"omani.homes"}, // only homes served here
+			funnelPick:  "omani.rest",
+			want:        "omani.homes",
+		},
+		{
 			// Degenerate / single-domain Sovereign with NO apps pool wired →
-			// fall back to the funnel pick, matching the org-controller's own
-			// empty-appsPool fallback (resolveOrgParentDomain returns payload).
-			name:       "no_apps_pool_falls_back_to_funnel_pick",
+			// fall back to the pick, matching the org-controller's empty-appsPool
+			// fallback.
+			name:       "no_apps_pool_falls_back_to_pick",
 			appsPool:   "",
 			funnelPick: "omani.rest",
 			want:       "omani.rest",
 		},
 		{
-			// Neither configured → empty (deriveTenantConsoleHost then yields
-			// "" and the client keeps its host-splice fallback).
 			name:       "both_empty",
 			appsPool:   "",
 			funnelPick: "",
 			want:       "",
 		},
 		{
-			// Casing + surrounding whitespace are normalised.
-			name:       "apps_pool_normalised",
-			appsPool:   "  Omani.Homes  ",
-			funnelPick: "omani.rest",
-			want:       "omani.homes",
+			// Casing + surrounding whitespace + a leading dot are normalised, and
+			// the (served) pick still wins.
+			name:       "pick_normalised_and_honored",
+			appsPool:   "omani.homes",
+			funnelPick: "  .Omani.Rest  ",
+			want:       "omani.rest",
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := resolveOrgParentDomain(tc.appsPool, tc.funnelPick); got != tc.want {
-				t.Fatalf("resolveOrgParentDomain(%q, %q) = %q, want %q",
-					tc.appsPool, tc.funnelPick, got, tc.want)
+			if got := resolveOrgParentDomain(tc.appsPool, tc.poolDomains, tc.funnelPick); got != tc.want {
+				t.Fatalf("resolveOrgParentDomain(%q, %v, %q) = %q, want %q",
+					tc.appsPool, tc.poolDomains, tc.funnelPick, got, tc.want)
 			}
 		})
 	}
 }
 
-// TestConsoleHost_MatchesOrgControllerPool is the end-to-end Finding-2 contract:
-// the console_host this service returns MUST be composed from the apps-pool-
-// resolved parent domain, NOT the raw funnel pick — so it equals the host the
-// org-controller provisions. Reproduces the hw228 acme scenario exactly.
-func TestConsoleHost_MatchesOrgControllerPool(t *testing.T) {
+// TestConsoleHost_HonorsServedFunnelPick is the end-to-end #4999 contract: the
+// console_host this service returns is composed from the HONORED funnel pick
+// (when served) — so a 2nd Org on `.omani.rest` lands on console.<slug>.omani.rest,
+// which the org-controller (same resolver) provisions. Reproduces the hw240
+// walk-stranger-two scenario that regressed to omani.homes pre-#4999.
+func TestConsoleHost_HonorsServedFunnelPick(t *testing.T) {
 	const (
-		slug       = "acme"
-		appsPool   = "omani.homes" // what the Sovereign actually serves + org-controller writes
-		funnelPick = "omani.rest"  // what the funnel offered (Finding-2)
+		slug       = "walk-stranger-two"
+		appsPool   = "omani.homes" // Sovereign primary apps pool
+		funnelPick = "omani.rest"  // the customer's chosen (served) pool TLD
 	)
 
 	// Mirror CreateOrg: the persisted Tenant.ParentDomain is the RESOLVED pool.
-	resolved := resolveOrgParentDomain(appsPool, funnelPick)
+	resolved := resolveOrgParentDomain(appsPool, nil, funnelPick)
 	tenant := &store.Tenant{Subdomain: slug, ParentDomain: resolved}
 
 	got := deriveTenantConsoleHost(tenant)
-	const want = "console.acme.omani.homes"
+	const want = "console.walk-stranger-two.omani.rest"
 	if got != want {
-		t.Fatalf("console_host = %q, want %q (must match the org-controller's provisioned pool, not the funnel pick)", got, want)
+		t.Fatalf("console_host = %q, want %q (the honored funnel pick, #4999)", got, want)
 	}
 
-	// Guard against the regression: the returned host must NOT carry the raw
-	// funnel TLD, which the org-controller never provisions (→ NXDOMAIN → 404).
-	badTenant := &store.Tenant{Subdomain: slug, ParentDomain: funnelPick}
-	if bad := deriveTenantConsoleHost(badTenant); bad == got {
-		t.Fatalf("resolved host collided with the raw funnel-pick host %q — the apps-pool override did not take effect", bad)
+	// Regression guard: it must NOT collapse back to the primary apps pool.
+	if got == "console.walk-stranger-two.omani.homes" {
+		t.Fatalf("console_host regressed to the primary apps pool — the funnel TLD choice was dropped (pre-#4999 #4421 behavior)")
 	}
 }
 
@@ -123,7 +141,7 @@ func TestConsoleHost_MatchesOrgControllerPool(t *testing.T) {
 // Sovereign with NO apps pool wired (AppsParentDomain empty) still honours the
 // funnel pick verbatim, so #4176/#4179 separate-pool Sovereigns are unaffected.
 func TestConsoleHost_LegacySingleDomain_UsesFunnelPick(t *testing.T) {
-	resolved := resolveOrgParentDomain("", "omani.works")
+	resolved := resolveOrgParentDomain("", nil, "omani.works")
 	tenant := &store.Tenant{Subdomain: "demo", ParentDomain: resolved}
 	if got, want := deriveTenantConsoleHost(tenant), "console.demo.omani.works"; got != want {
 		t.Fatalf("legacy console_host = %q, want %q", got, want)

--- a/core/services/tenant/handlers/handlers.go
+++ b/core/services/tenant/handlers/handlers.go
@@ -67,6 +67,13 @@ type Handler struct {
 	// verbatim (single-domain / degenerate Sovereigns with no apps pool wired).
 	AppsParentDomain string
 
+	// PoolDomains is the served org-pool TLD set (#4999) — env
+	// TENANT_POOL_DOMAINS, defaulting to the canonical four .omani.X zones when
+	// empty (see pool_domains.go). resolveOrgParentDomain honors a funnel pick
+	// only when it is in this set, so a customer can provision a 2nd Org on a
+	// DIFFERENT served TLD instead of being collapsed onto AppsParentDomain.
+	PoolDomains []string
+
 	// DayTwoLocks serializes day-2 install/uninstall on a given tenant so
 	// concurrent callers see consistent tenant.Apps reads. Issue #110.
 	// Callers MUST pre-populate via NewTenantLocks(); nil is not safe.
@@ -262,24 +269,22 @@ func (h *Handler) CreateOrg(w http.ResponseWriter, r *http.Request) {
 	// and lowercase so deriveConsoleHost composes a clean RFC-1123 host.
 	funnelParentDomain := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(body.ParentDomain, ".")))
 
-	// #4821 Finding-2: the Sovereign's apps pool WINS over the funnel pick.
-	// The org-controller stamps spec.tenantPublic.parentDomain via the SAME
-	// apps-pool-wins rule (organization_create.go::resolveOrgParentDomain, #4421)
-	// and writes the per-Org DNS / TLS / HTTPRoute under THAT zone. If this
-	// service persisted (and returned as console_host) the raw funnel pick
-	// instead, a Sovereign that serves a single apps pool (`omani.homes`) but
-	// whose funnel offered `omani.rest` would return console.<slug>.omani.rest —
-	// an NXDOMAIN host the org-controller never provisions — so the post-Launch
-	// redirect 404s (the reported #4821 Finding-2). Resolving to the apps pool
-	// here keeps the returned/persisted/emitted host in lockstep with what the
-	// org-controller actually provisions. Empty AppsParentDomain (legacy /
-	// single-domain Sovereign) falls back to the funnel pick, unchanged.
-	parentDomain := resolveOrgParentDomain(h.AppsParentDomain, funnelParentDomain)
+	// #4999: HONOR the customer's funnel pick when the Sovereign serves that pool
+	// zone; else fall back to the apps pool. resolveOrgParentDomain keeps the
+	// returned/persisted/emitted console_host in lockstep with the zone the
+	// org-controller provisions the per-Org DNS / TLS / HTTPRoute under AND the
+	// zone the apps generator renders app hosts under (both now follow the pick),
+	// so a 2nd Org on `omani.rest` gets console.<slug>.omani.rest — not the
+	// dropped-to-primary omani.homes of the pre-#4999 #4421 band-aid.
+	parentDomain := resolveOrgParentDomain(h.AppsParentDomain, h.PoolDomains, funnelParentDomain)
 	if funnelParentDomain != "" && parentDomain != funnelParentDomain {
-		slog.Warn("CreateOrg: funnel-selected parent_domain overridden by the Sovereign apps pool to keep console_host aligned with the org-controller's provisioned pool (#4821 Finding-2 / #4421)",
+		// The pick was NOT served — we fell back to the apps pool. Log loud so an
+		// operator notices the funnel is offering a pool the Sovereign doesn't
+		// serve (fix the offer or add the zone to TENANT_POOL_DOMAINS).
+		slog.Warn("CreateOrg: funnel-selected parent_domain is not a served pool zone — fell back to the Sovereign apps pool (#4999); offer must match TENANT_POOL_DOMAINS",
 			"slug", body.Slug,
 			"funnel_parent_domain", funnelParentDomain,
-			"apps_parent_domain", parentDomain)
+			"resolved_parent_domain", parentDomain)
 	}
 
 	// Owner email is derived from the caller's JWT claim and persisted on the
@@ -450,6 +455,10 @@ func (h *Handler) dispatchFunnelCartInstall(ctx context.Context, t *store.Tenant
 			"deploy_ids":      []string{},
 			"deploy_slugs":    []string{slug},
 			"apps":            t.Apps,
+			// #4999: carry the Org's chosen (already-resolved) pool zone so the
+			// provisioning apps generator renders app hosts under the SAME zone as
+			// the per-Org console (console==apps invariant under the honored TLD).
+			"parent_domain": t.ParentDomain,
 		}
 		if err := h.callProvisioning(ctx, "/provisioning/apps/install", payload); err != nil {
 			slog.Error("funnel cart-install: provisioning HTTP call failed (event fallback still fires)",
@@ -597,23 +606,34 @@ func (h *Handler) InternalLaunchTenant(w http.ResponseWriter, r *http.Request) {
 
 // resolveOrgParentDomain picks the org-pool parent zone the Tenant's
 // ParentDomain (→ console_host + tenant.created payload) is stamped with.
-// #4821 Finding-2: it MIRRORS the provisioning door's resolver of the same name
+// It MIRRORS the provisioning door's resolver of the same name
 // (core/services/provisioning/handlers/organization_create.go) so BOTH doors —
 // and the org-controller CR they mint — agree on the pool.
 //
-// THE INVARIANT (#4421): the pool this service returns as the customer's
-// console_host MUST equal the pool the org-controller writes the per-Org DNS
-// A-record + console TLS cert + HTTPRoute under. appsParentDomain is the
-// Sovereign's EFFECTIVE apps pool (env TENANT_PARENT_DOMAIN); it is non-empty on
-// any real Sovereign, so it WINS. The per-customer funnel pick is honoured only
-// as a last-resort fallback on a degenerate Sovereign with no apps pool wired
-// (which then matches the org-controller's own empty-appsPool fallback).
-// Returns lowercased/trimmed.
-func resolveOrgParentDomain(appsParentDomain, funnelParentDomain string) string {
-	if pd := strings.ToLower(strings.TrimSpace(appsParentDomain)); pd != "" {
-		return pd
+// #4999 (Refs #3376): HONOR the customer's funnel-selected pool TLD when the
+// Sovereign actually SERVES it (poolDomains, defaulting to the canonical four
+// .omani.X zones). The per-Org console DNS/TLS/route AND the apps generator both
+// render under THAT zone, so "two Orgs on two different TLDs" (Pillar-1) holds
+// without re-breaking the #4421 invariant (console-pool == apps-pool) — both
+// simply move together to the chosen zone instead of being collapsed onto the
+// single apps pool. This SUPERSEDES the #4821 Finding-2 / #4421 "apps-pool-wins"
+// band-aid that silently dropped every non-primary pick.
+//
+// THE INVARIANT (#4421) still holds: we NEVER return a zone the Sovereign does
+// not serve. A pick outside poolDomains (or empty) falls back to appsParentDomain
+// (the Sovereign's EFFECTIVE apps pool, env TENANT_PARENT_DOMAIN — non-empty on
+// any real Sovereign), and only a degenerate Sovereign with no apps pool wired
+// falls through to the raw pick (matching the org-controller's empty-appsPool
+// fallback). Returns lowercased/trimmed.
+func resolveOrgParentDomain(appsParentDomain string, poolDomains []string, funnelParentDomain string) string {
+	pick := normalizePoolZone(funnelParentDomain)
+	if pick != "" && isServedPoolDomain(pick, poolDomains) {
+		return pick
 	}
-	return strings.ToLower(strings.TrimSpace(funnelParentDomain))
+	if primary := normalizePoolZone(appsParentDomain); primary != "" {
+		return primary
+	}
+	return pick
 }
 
 // deriveTenantConsoleHost composes the per-Org customer console host:

--- a/core/services/tenant/handlers/pool_domains.go
+++ b/core/services/tenant/handlers/pool_domains.go
@@ -1,0 +1,69 @@
+// pool_domains.go — the Sovereign's served org-pool TLD set (#4999, Refs #3376).
+//
+// The marketplace funnel offers a pool-TLD choice on /addons
+// (.omani.homes / .omani.rest / .omani.trade / .omani.works). Before #4999 the
+// backend DROPPED that choice — resolveOrgParentDomain forced the single
+// Sovereign-wide apps pool (TENANT_PARENT_DOMAIN) to win (the #4421 band-aid),
+// so "two Orgs on two different TLDs" (Pillar-1) could never hold. This file
+// carries the served-pool set that lets resolveOrgParentDomain HONOR the pick
+// when the Sovereign actually serves that zone.
+package handlers
+
+import (
+	"os"
+	"strings"
+)
+
+// defaultPoolTLDs is the canonical OpenOva-managed org-pool free-subdomain set.
+// It matches core/services/domain/store.AllowedTLDs, the marketplace /addons
+// picker (core/marketplace/src/components/AddonsStep.svelte), and catalyst-api's
+// CATALYST_ORG_POOL_DOMAINS seed (sovereign_parent_domains.go). All four are
+// PowerDNS-delegated + DNS-01-wired on every Sovereign, so provisioning a
+// customer Org under any of them is safe. Used as the served set when
+// TENANT_POOL_DOMAINS is unset, so a fresh Sovereign honors the funnel TLD
+// choice with no extra config.
+var defaultPoolTLDs = []string{"omani.rest", "omani.works", "omani.trade", "omani.homes"}
+
+// PoolDomainsFromEnv reads the operator-overridable served-pool set from
+// TENANT_POOL_DOMAINS (comma-separated FQDNs). Empty → nil (resolveOrgParentDomain
+// falls back to defaultPoolTLDs). Wired onto the Handler in main.go so the set is
+// data-driven (Inviolable Principle #4) yet needs no config on a canonical
+// Sovereign.
+func PoolDomainsFromEnv() []string {
+	raw := strings.TrimSpace(os.Getenv("TENANT_POOL_DOMAINS"))
+	if raw == "" {
+		return nil
+	}
+	out := []string{}
+	for _, p := range strings.Split(raw, ",") {
+		if z := normalizePoolZone(p); z != "" {
+			out = append(out, z)
+		}
+	}
+	return out
+}
+
+// normalizePoolZone lowercases, trims, and strips any leading dot so
+// ".Omani.Rest" and "omani.rest" compare equal.
+func normalizePoolZone(z string) string {
+	return strings.ToLower(strings.TrimPrefix(strings.TrimSpace(z), "."))
+}
+
+// isServedPoolDomain reports whether tld is a pool zone this Sovereign serves.
+// An empty configured set falls back to the canonical defaultPoolTLDs.
+func isServedPoolDomain(tld string, configured []string) bool {
+	tld = normalizePoolZone(tld)
+	if tld == "" {
+		return false
+	}
+	set := configured
+	if len(set) == 0 {
+		set = defaultPoolTLDs
+	}
+	for _, z := range set {
+		if normalizePoolZone(z) == tld {
+			return true
+		}
+	}
+	return false
+}

--- a/core/services/tenant/main.go
+++ b/core/services/tenant/main.go
@@ -116,7 +116,11 @@ func main() {
 		Catalog:          catalogClient,
 		ProvisioningURL:  provisioningURL,
 		AppsParentDomain: appsParentDomain,
-		DayTwoLocks:      handlers.NewTenantLocks(),
+		// #4999: served org-pool TLD set (env TENANT_POOL_DOMAINS; nil → the
+		// canonical four .omani.X zones) so CreateOrg can HONOR the funnel's
+		// chosen pool TLD instead of dropping it to AppsParentDomain.
+		PoolDomains: handlers.PoolDomainsFromEnv(),
+		DayTwoLocks: handlers.NewTenantLocks(),
 	}
 	slog.Info("catalog client configured", "url", catalogURL)
 	slog.Info("provisioning URL configured", "url", provisioningURL)


### PR DESCRIPTION
Fixes the two live hw240 marketplace-funnel defects (UAT rows 93/94/95) that block the "second customer Org on a different TLD, two isolated estates" Pillar-1 walk. Refs #4999 Refs #3376. hw240 is wiped — live-verification is deferred to the hw241 funnel walk.

## Defect B — 2nd-Org /auth/org-handover 503 (row 94) · commit 1

The per-Org console-serving trio (reconcileTenantDNS -> reconcileTenantConsoleTLS -> reconcileTenantRoute, the HTTPRoute that wires /auth/org-handover -> catalyst-api) ran at the END of Reconcile, after nine steps that each r.fail(...) on error (Keycloak group/realm, Gitea org/repo, manifest render, gitops PutFile, per-Org Flux, UserAccess, Federation). When any earlier step trips — the 2nd Org hit the #4991/#4992 provisioning-RBAC / vcluster-mirror gap — the reconcile aborts before the console route lands, so the host 503s on /auth/org-handover. The 1st Org converged fully so its route landed.

**Fix:** run the trio FIRST (reconcileConsoleServing, right after finalizers, before the Keycloak step), best-effort — failures log + set consoleServingDegraded (folded into the end-of-reconcile 30s requeue), never aborting. Every funnel Org can now sign in even while its app is still converging or failed. Regression test injects an early realm failure and asserts the console route still lands with the /auth/org-handover rule.

## Defect A — chosen pool-TLD silently dropped (rows 93/95) · commit 2

resolveOrgParentDomain (tenant-service + provisioning) made the single Sovereign-wide apps pool (TENANT_PARENT_DOMAIN) **unconditionally win** over the funnel pick (the #4421 band-aid), so a 2nd Org that chose .omani.rest provisioned as omani.homes. The band-aid existed only because the apps-HTTPRoute generator rendered every app host under the single global g.parentDomain().

**Direction — provision the choice.** All four .omani.X pool zones are PowerDNS-delegated + DNS-01-wired on every Sovereign; the per-Org console DNS/TLS/route already key off the Org's own parentDomain. Only the backend collapse + the apps generator pinned everything to one pool.

**Fix (safe-by-default — only Orgs picking a NON-primary served TLD change behavior):**
- resolveOrgParentDomain(appsPool, poolDomains, pick) HONORS the pick when it is a served pool zone (poolDomains = env TENANT_POOL_DOMAINS, default = the canonical four, matching domain/store.AllowedTLDs + the marketplace picker + CATALYST_ORG_POOL_DOMAINS); else falls back to the apps pool (the #4421 dead-IP guard). Applied in both doors.
- Threads the per-Org zone into the apps generator so **console-zone == apps-zone under the chosen TLD** (invariant preserved, no longer collapsed): appChangeData gains parent_domain; applyTenantChangePerOrg renders on a scoped ManifestGenerator clone (read-only during render -> shallow copy is safe + Org-confined). Empty/unserved pick -> byte-identical to pre-#4999.
- tenant_public_patch stops writing parentDomain/subdomain — createOrganizationCR owns the zone; the day-2 product-ready patch was clobbering a 2nd Org's honored omani.rest back to omani.homes.

Tests: honor/fall-back matrix (both services), console_host + Org-CR lockstep, app host under the honored zone (row-95 proof), patch no-clobber guard. Frontend offer already matches the served set (no change).

## Verification
go test ./... green across core/services/tenant, core/services/provisioning, core/controllers/organization; go vet clean. Live E2E deferred to the hw241 funnel walk (2nd voucher, slug walk-stranger-two, TLD .omani.rest): expect tenantPublic.parentDomain=omani.rest, console + purchased app serving under .omani.rest, and /auth/org-handover -> 302 + catalyst_session cookie for every funnel Org.

No NodePort — per-Org consoles/apps serve via the host Cilium Gateway / HTTPRoute + shared-EIP. Logic-only changes (no chart touched); org-controller + tenant + provisioning images roll via deploybot on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
