### PR TITLE
fix(#5003): per-Org vcluster HelmRelease self-heals cold Harbor pull (remediation retries + timeout)

### DIFF
--- a/core/controllers/organization/internal/gitops/manifests.go
+++ b/core/controllers/organization/internal/gitops/manifests.go
@@ -204,6 +204,37 @@ metadata:
     app.kubernetes.io/managed-by: flux
 spec:
   interval: 10m
+  # #5003 (Refs #3376): a FRESH funnel Org's FIRST vcluster install pulls the
+  # k8s-distro init image (proxy-ghcr/loft-sh/kubernetes:vX) through a COLD
+  # Sovereign-Harbor proxy-ghcr cache — ~3m11s live on hw241 — which blows past
+  # Flux's default 5m Helm-operation timeout as "context deadline exceeded".
+  # WORSE, with install.remediation.retries UNSET (=0) Flux marks the HR
+  # Stalled=True / RetriesExceeded ("terminal error: cannot remediate failed
+  # release") and it NEVER self-heals — even though vcluster-0 actually comes up
+  # 1/1 Running once the pull finally lands. That strands the org-controller
+  # (vcluster_ready:false forever) → the tenant-<slug>-kubeconfig secret is never
+  # minted → the per-Org apps Kustomization fails "unable to read KubeConfig
+  # secret" → WordPress/the customer app never deploys → the app FQDN 404s (the
+  # last terminal blocker for zero-touch marketplace-funnel app-serve).
+  #
+  # Durable fix, two parts:
+  #   (1) timeout: 10m — widen the Helm-operation deadline so the first cold
+  #       proxy-ghcr pull of the vcluster images (k8s-distro + vcluster-oss
+  #       syncer) fits inside a single install attempt.
+  #   (2) install/upgrade.remediation.retries: -1 — retry INDEFINITELY instead of
+  #       terminally stalling, so any residual transient cold-pull timeout
+  #       self-heals on the next reconcile rather than requiring an operator to
+  #       manually kick the wedged HR. Harbor warms after the first pull, so the
+  #       retry converges quickly. (-1 is Flux's "infinite retries" sentinel; the
+  #       vcluster boundary is load-bearing for the whole Org, so we never want it
+  #       to give up — unlike the day-2 app HRs which cap at 3.)
+  timeout: 10m
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    remediation:
+      retries: -1
   chart:
     spec:
       chart: vcluster

--- a/core/controllers/organization/internal/gitops/manifests_test.go
+++ b/core/controllers/organization/internal/gitops/manifests_test.go
@@ -534,6 +534,63 @@ func TestRender_TierGate(t *testing.T) {
 	}
 }
 
+// TestRender_VclusterHRSelfHealsColdPull_5003 locks in the #5003 durable fix:
+// the per-Org vcluster HelmRelease MUST carry install/upgrade remediation
+// retries of -1 (retry indefinitely — never terminally Stalled) and a widened
+// spec.timeout so the FIRST cold Harbor proxy-ghcr pull of the vcluster init
+// images (~3m11s live on hw241) fits inside a single Helm-operation deadline.
+// Without both, a transient cold-pull "context deadline exceeded" marks the HR
+// Stalled=True/RetriesExceeded, the tenant-<slug>-kubeconfig secret is never
+// minted, and the customer funnel app 404s forever (the last zero-touch blocker).
+func TestRender_VclusterHRSelfHealsColdPull_5003(t *testing.T) {
+	t.Parallel()
+	out, err := Render(Inputs{
+		Slug: "acme", DisplayName: "Acme", Tier: "org", PlanSlug: "m",
+		SovereignFQDN: "x.example", HostCluster: "hz", VClusterChartVersion: "0.33.*",
+	})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	vcl := string(out["vcluster/vcluster.yaml"])
+
+	// (1) String surface — the fields are present in the rendered YAML.
+	for _, want := range []string{"timeout: 10m", "install:", "upgrade:", "remediation:", "retries: -1"} {
+		if !strings.Contains(vcl, want) {
+			t.Errorf("#5003: vcluster.yaml missing %q\nfull contents:\n%s", want, vcl)
+		}
+	}
+
+	// (2) Structural surface — parse the HR and assert the exact spec shape so a
+	// stray indentation/typo can't pass the string check while breaking Flux.
+	var hr struct {
+		Spec struct {
+			Timeout string `json:"timeout"`
+			Install struct {
+				Remediation struct {
+					Retries int `json:"retries"`
+				} `json:"remediation"`
+			} `json:"install"`
+			Upgrade struct {
+				Remediation struct {
+					Retries int `json:"retries"`
+				} `json:"remediation"`
+			} `json:"upgrade"`
+		} `json:"spec"`
+	}
+	if err := yaml.Unmarshal([]byte(vcl), &hr); err != nil {
+		t.Fatalf("#5003: vcluster.yaml is not valid HelmRelease YAML: %v\n%s", err, vcl)
+	}
+	if hr.Spec.Timeout != "10m" {
+		t.Errorf("#5003: spec.timeout = %q, want \"10m\" (cold proxy-ghcr pull ~3m11s must fit)", hr.Spec.Timeout)
+	}
+	if hr.Spec.Install.Remediation.Retries != -1 {
+		t.Errorf("#5003: spec.install.remediation.retries = %d, want -1 (retry forever, never terminally Stalled)", hr.Spec.Install.Remediation.Retries)
+	}
+	if hr.Spec.Upgrade.Remediation.Retries != -1 {
+		t.Errorf("#5003: spec.upgrade.remediation.retries = %d, want -1 (retry forever, never terminally Stalled)", hr.Spec.Upgrade.Remediation.Retries)
+	}
+}
+
 // TestBoundaryIsVcluster_FlippableGate documents the one-line Sovereign switch.
 func TestBoundaryIsVcluster_FlippableGate(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Problem

Last terminal obstacle to zero-touch marketplace-funnel app-serve (found live on **hw241**).

On a fresh funnel Org, the per-Org **vcluster HelmRelease** (`<slug>/vcluster`, chart `vcluster@0.33.4`) terminally stalls:

1. **First install → "context deadline exceeded"** — the init image `proxy-ghcr/loft-sh/kubernetes:v1.35.0` takes ~3m11s on a **COLD** Sovereign-Harbor proxy-ghcr pull, exceeding Flux's default 5m Helm-operation timeout.
2. The HR has **no `spec.install.remediation.retries`** (unset = 0) → Flux marks it `Stalled=True / RetriesExceeded` (*"terminal error: cannot remediate failed release"*) and it **never self-heals** — even though the vcluster pod actually comes up `1/1 Running`.
3. org-controller gates on the HR (`vcluster_ready:false` forever) → `tenant-<slug>-kubeconfig` secret never minted → apps Kustomization fails *"unable to read KubeConfig secret"* → WordPress never deploys → app FQDN 404s.

## Root cause / generation site

The per-Org vcluster HR is rendered by the **org-controller** GitOps renderer — the sole producer of the `<slug>` namespace + `vcluster` HelmRelease:

`core/controllers/organization/internal/gitops/manifests.go` → `vclusterTemplate` (~L193).

The rendered HR had `spec.interval` + `spec.chart` but **no `spec.timeout` and no `install`/`upgrade` remediation**.

## Fix (durable, on the generation site)

- `spec.timeout: 10m` — widen the Helm-operation deadline so the first cold proxy-ghcr pull of the vcluster images (k8s-distro + vcluster-oss syncer) fits inside a single install attempt.
- `spec.install.remediation.retries: -1` + `spec.upgrade.remediation.retries: -1` — retry **indefinitely** instead of terminally stalling; any residual transient cold-pull timeout self-heals on the next reconcile. Harbor warms after the first pull so the retry converges quickly. The vcluster boundary is load-bearing for the whole Org, so `-1` (never give up) vs the day-2 app HRs' cap of 3.

No NodePort. No chart/pin bump — the vcluster chart version is env-config-driven and unchanged; this is a pure renderer-template change.

## Test

Adds `TestRender_VclusterHRSelfHealsColdPull_5003` — asserts the rendered HR carries `timeout: 10m` + `install`/`upgrade` `remediation.retries: -1`, via both string-surface and structural-YAML checks. Full `organization/...` suite green locally (`go test`, `go vet`, `go build`).

Live-verification (funnel app serves zero-touch) deferred to the next fresh prov.

Refs #5003 #3376
