### PR TITLE
fix(#5007): cutover pins registry.<fqdn> on nodes + pdm reaps stale parent wildcards (hw241 DNS-shadow ImagePullBackOff)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -799,7 +799,12 @@ spec:
       # roll (#4972). Toggles prewarm.skipIfAlreadyPresent + catalystAPI.rollSafety
       # (both default on). RBAC adds volumeattachments/pvc read + delete + nodes
       # patch. Still 11 steps / 10 job-mode.
-      version: 0.1.118
+      # 0.1.119 (#5007 Refs #4682 #3379): step-04 registry-pivot pins registry.<fqdn>
+      # on the NODE /etc/hosts to the gateway VIP (LB-ingress IP / HOST_IP
+      # hostNetwork fallback) so a fresh-node local-registry pull never depends on
+      # the public DNS wildcard-vs-specific race (hw241 dead `*.omantel.biz`
+      # 49.12.16.160 ImagePullBackOff). Still 11 steps / 10 job-mode.
+      version: 0.1.119
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/core/pool-domain-manager/cmd/pdm/main.go
+++ b/core/pool-domain-manager/cmd/pdm/main.go
@@ -32,6 +32,11 @@
 //	                              with an ip address" rejection (issue #1500).
 //	PDM_RESERVATION_TTL        — go duration string, default "10m"
 //	PDM_SWEEPER_INTERVAL       — go duration string, default "30s"
+//	PDM_REAP_STALE_PARENT_WILDCARDS — reap a foreign `*.<pool>` wildcard from each
+//	                              managed parent pool zone at bootstrap (#5007),
+//	                              default true. pdm never writes a parent wildcard,
+//	                              so this only removes stale/foreign leftovers that
+//	                              would shadow delegated child names.
 //	PDM_LOG_LEVEL              — debug | info | warn | error (default info)
 package main
 
@@ -88,8 +93,9 @@ func main() {
 	pdnsClient := pdns.New(cfg.PDNSBaseURL, cfg.PDNSServerID, cfg.PDNSAPIKey)
 
 	alloc := allocator.New(s, pdnsClient, log, allocator.Config{
-		Nameservers:    cfg.Nameservers,
-		ReservationTTL: cfg.ReservationTTL,
+		Nameservers:              cfg.Nameservers,
+		ReservationTTL:           cfg.ReservationTTL,
+		ReapStaleParentWildcards: cfg.ReapStaleParentWildcards,
 	})
 
 	// Bootstrap every managed pool zone before HTTP serves traffic. /reserve
@@ -197,6 +203,9 @@ type config struct {
 	Nameservers     []string
 	ReservationTTL  time.Duration
 	SweeperInterval time.Duration
+	// ReapStaleParentWildcards — reap a foreign `*.<pool>` wildcard from each
+	// managed parent pool zone at bootstrap (#5007). Default true.
+	ReapStaleParentWildcards bool
 }
 
 func loadConfig() (*config, error) {
@@ -244,6 +253,12 @@ func loadConfig() (*config, error) {
 	}
 	c.SweeperInterval = sw
 
+	// #5007 — reap a stale/foreign `*.<pool>` wildcard from each managed parent
+	// pool zone at bootstrap. Default true (pdm never writes a parent wildcard, so
+	// reaping one is always safe in its delegation model). Set false only where a
+	// deployment intentionally serves a flat parent wildcard managed elsewhere.
+	c.ReapStaleParentWildcards = envBool("PDM_REAP_STALE_PARENT_WILDCARDS", true)
+
 	return c, nil
 }
 
@@ -252,6 +267,23 @@ func env(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// envBool reads a boolean env var, returning fallback when unset/blank.
+// Accepts the usual truthy/falsey spellings; an unparseable value falls back.
+func envBool(key string, fallback bool) bool {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return fallback
+	}
+	switch strings.ToLower(v) {
+	case "1", "t", "true", "yes", "y", "on":
+		return true
+	case "0", "f", "false", "no", "n", "off":
+		return false
+	default:
+		return fallback
+	}
 }
 
 func parseNameservers(raw string) []string {

--- a/core/pool-domain-manager/internal/allocator/allocator.go
+++ b/core/pool-domain-manager/internal/allocator/allocator.go
@@ -71,6 +71,10 @@ type DNSWriter interface {
 	AddNSDelegation(ctx context.Context, parentZone, childName string, nameservers []string, ttl int) error
 	// RemoveNSDelegation drops the delegation RRset (idempotent).
 	RemoveNSDelegation(ctx context.Context, parentZone, childName string) error
+	// RemoveWildcardRecords deletes any "*.<zone>" A/AAAA RRset (idempotent) —
+	// used by the parent-zone bootstrap to reap a stale/foreign parent wildcard
+	// that would shadow every delegated child (#5007).
+	RemoveWildcardRecords(ctx context.Context, zone string) error
 	// EnableDNSSEC turns on DNSSEC for the child zone and generates KSK+ZSK.
 	EnableDNSSEC(ctx context.Context, zone string) error
 }
@@ -97,6 +101,15 @@ type Allocator struct {
 	// reservationTTL — how long a /reserve holds the name before the
 	// sweeper reclaims it. Per the issue body this is 10 minutes.
 	reservationTTL time.Duration
+
+	// reapStaleParentWildcards — when true (default), BootstrapParentZones
+	// reaps any foreign `*.<pool>` A/AAAA wildcard from each managed parent
+	// pool zone so a wiped env can never leave a wildcard shadowing sibling
+	// child names (#5007). pdm never writes a parent-level wildcard, so this
+	// is always safe within pdm's delegation model; the flag is an operator
+	// escape hatch for a deployment that intentionally serves a flat parent
+	// wildcard managed by another system.
+	reapStaleParentWildcards bool
 }
 
 // Config bundles the runtime allocator configuration.
@@ -105,17 +118,21 @@ type Config struct {
 	Nameservers []string
 	// ReservationTTL — see Allocator.reservationTTL.
 	ReservationTTL time.Duration
+	// ReapStaleParentWildcards — see Allocator.reapStaleParentWildcards.
+	// Default true (wired from PDM_REAP_STALE_PARENT_WILDCARDS in main).
+	ReapStaleParentWildcards bool
 }
 
 // New constructs an Allocator. cfg.Nameservers must contain at least one
 // NS host; production passes the three openova.io NS FQDNs.
 func New(s *store.Store, d DNSWriter, log *slog.Logger, cfg Config) *Allocator {
 	return &Allocator{
-		store:          s,
-		dns:            d,
-		log:            log,
-		nameservers:    cfg.Nameservers,
-		reservationTTL: cfg.ReservationTTL,
+		store:                    s,
+		dns:                      d,
+		log:                      log,
+		nameservers:              cfg.Nameservers,
+		reservationTTL:           cfg.ReservationTTL,
+		reapStaleParentWildcards: cfg.ReapStaleParentWildcards,
 	}
 }
 
@@ -497,6 +514,24 @@ func (a *Allocator) BootstrapParentZones(ctx context.Context, poolDomains []stri
 			// DNSSEC enabled — EnableDNSSEC is idempotent. Log and continue.
 			a.log.Warn("DNSSEC enable for parent zone returned error (may be harmless if already on)",
 				"parent", parent, "err", err)
+		}
+		// #5007 — assert the pdm-intended parent-zone shape: delegations + apex
+		// only, NEVER a parent-level `*.<pool>` A/AAAA wildcard. pdm never writes
+		// one (the per-Sovereign wildcard lives in the delegated child zone), so a
+		// `*.<pool>` record is a FOREIGN leftover — e.g. the dead `*.omantel.biz A
+		// 49.12.16.160` a wiped Hetzner-era env left, which SHADOWED every child
+		// name on the node resolver and black-holed image pulls (hw241 #5007).
+		// Reap it so a wiped env can never shadow its siblings. Best-effort +
+		// idempotent (DELETE of an absent RRset is a no-op): a reap failure never
+		// blocks bootstrap. Gated (default on) for a deployment that intentionally
+		// serves a flat parent wildcard managed elsewhere.
+		if a.reapStaleParentWildcards {
+			if err := a.dns.RemoveWildcardRecords(ctx, parent); err != nil {
+				a.log.Warn("reap of stale parent-zone wildcard returned error (best-effort; may be harmless if none existed)",
+					"parent", parent, "err", err)
+			} else {
+				a.log.Info("parent pool zone wildcard reaped (asserted delegations-only shape)", "parent", parent)
+			}
 		}
 		a.log.Info("parent pool zone ensured", "parent", parent, "nameservers", a.nameservers)
 	}

--- a/core/pool-domain-manager/internal/allocator/allocator_test.go
+++ b/core/pool-domain-manager/internal/allocator/allocator_test.go
@@ -26,6 +26,7 @@ type fakeDNS struct {
 	callsDelete       []string
 	callsAddNS        []string
 	callsRemoveNS     []string
+	callsRemoveWild   []string
 	callsEnableDNSSEC []string
 	callsPatch        int
 }
@@ -122,6 +123,23 @@ func (f *fakeDNS) RemoveNSDelegation(_ context.Context, parent, child string) er
 	if f.delegations[parent] != nil {
 		delete(f.delegations[parent], child)
 	}
+	return nil
+}
+
+func (f *fakeDNS) RemoveWildcardRecords(_ context.Context, zone string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failOn == "wildcard:"+zone {
+		f.failOn = ""
+		return errors.New("fake remove-wildcard failure")
+	}
+	f.callsRemoveWild = append(f.callsRemoveWild, zone)
+	// Record the DELETE RRsets so a test can assert the *.<zone> A/AAAA shape.
+	wildcard := "*." + zone
+	f.rrsets[zone] = append(f.rrsets[zone],
+		pdns.RRSet{Name: wildcard, Type: "A", ChangeType: "DELETE"},
+		pdns.RRSet{Name: wildcard, Type: "AAAA", ChangeType: "DELETE"},
+	)
 	return nil
 }
 
@@ -259,6 +277,87 @@ func TestBootstrapParentZonesNoNameserversFails(t *testing.T) {
 	err := a.BootstrapParentZones(context.Background(), []string{"omani.works"})
 	if err == nil {
 		t.Fatal("expected error when nameservers empty")
+	}
+}
+
+// #5007 — BootstrapParentZones reaps a foreign `*.<pool>` wildcard from every
+// managed parent pool zone when reapStaleParentWildcards is enabled, so a wiped
+// env can never leave a wildcard (e.g. the dead `*.omantel.biz A 49.12.16.160`)
+// shadowing delegated child names. Assert BOTH the per-pool call AND the DELETE
+// A+AAAA RRset shape.
+func TestBootstrapParentZonesReapsStaleWildcardWhenEnabled(t *testing.T) {
+	dns := newFakeDNS()
+	a := &Allocator{
+		dns:                      dns,
+		log:                      newSilentLogger(),
+		nameservers:              []string{"ns1.openova.io", "ns2.openova.io"},
+		reapStaleParentWildcards: true,
+	}
+	pools := []string{"omantel.biz", "omani.homes"}
+	if err := a.BootstrapParentZones(context.Background(), pools); err != nil {
+		t.Fatal(err)
+	}
+	if len(dns.callsRemoveWild) != len(pools) {
+		t.Fatalf("expected a wildcard reap per pool (%d), got %d: %v", len(pools), len(dns.callsRemoveWild), dns.callsRemoveWild)
+	}
+	for _, p := range pools {
+		var sawA, sawAAAA bool
+		for _, r := range dns.rrsets[p] {
+			if r.Name != "*."+p || r.ChangeType != "DELETE" {
+				continue
+			}
+			switch r.Type {
+			case "A":
+				sawA = true
+			case "AAAA":
+				sawAAAA = true
+			}
+		}
+		if !sawA || !sawAAAA {
+			t.Errorf("pool %s: expected DELETE of *.%s A (%v) and AAAA (%v)", p, p, sawA, sawAAAA)
+		}
+	}
+}
+
+// #5007 — the reap is gated: with reapStaleParentWildcards disabled the parent
+// zone is still ensured + DNSSEC-enabled but NO wildcard DELETE is issued (the
+// operator escape hatch for a deployment serving a flat parent wildcard).
+func TestBootstrapParentZonesSkipsWildcardReapWhenDisabled(t *testing.T) {
+	dns := newFakeDNS()
+	a := &Allocator{
+		dns:                      dns,
+		log:                      newSilentLogger(),
+		nameservers:              []string{"ns1.openova.io"},
+		reapStaleParentWildcards: false,
+	}
+	if err := a.BootstrapParentZones(context.Background(), []string{"omani.works"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := dns.zones["omani.works"]; !ok {
+		t.Error("omani.works parent zone not created")
+	}
+	if len(dns.callsRemoveWild) != 0 {
+		t.Errorf("expected NO wildcard reap when disabled, got %v", dns.callsRemoveWild)
+	}
+}
+
+// #5007 — a wildcard-reap failure is best-effort: it must NOT fail bootstrap (the
+// zone + delegations still resolve; a lingering wildcard is a hygiene issue, not
+// a bootstrap blocker).
+func TestBootstrapParentZonesReapFailureIsBestEffort(t *testing.T) {
+	dns := newFakeDNS()
+	dns.failOn = "wildcard:omani.works"
+	a := &Allocator{
+		dns:                      dns,
+		log:                      newSilentLogger(),
+		nameservers:              []string{"ns1.openova.io"},
+		reapStaleParentWildcards: true,
+	}
+	if err := a.BootstrapParentZones(context.Background(), []string{"omani.works"}); err != nil {
+		t.Fatalf("wildcard reap failure must not fail bootstrap: %v", err)
+	}
+	if _, ok := dns.zones["omani.works"]; !ok {
+		t.Error("omani.works parent zone not created despite best-effort reap failure")
 	}
 }
 

--- a/core/pool-domain-manager/internal/pdns/client.go
+++ b/core/pool-domain-manager/internal/pdns/client.go
@@ -339,6 +339,27 @@ func (c *Client) RemoveNSDelegation(ctx context.Context, parentZone, childName s
 	}})
 }
 
+// RemoveWildcardRecords deletes any A/AAAA wildcard RRset ("*.<zone>") at the
+// zone apex. Idempotent — a DELETE of an absent RRset is a PowerDNS no-op.
+//
+// #5007 — pdm's model (docs/PLATFORM-POWERDNS.md) is child-zone DELEGATION: the
+// PARENT pool zone (e.g. omantel.biz) holds ONLY NS delegations + apex SOA/NS,
+// and the per-Sovereign wildcard lives INSIDE the child zone (*.<sub>.<pool>).
+// pdm therefore NEVER writes a parent-level `*.<pool>` wildcard — so any
+// `*.<pool> A/AAAA` is a FOREIGN leftover, e.g. the dead `*.omantel.biz A
+// 49.12.16.160` a wiped Hetzner-era env left behind. A stale parent wildcard
+// SHADOWS every child name on a resolver/cache path (the node resolver returns
+// the wildcard instead of the delegated child's specific record) and black-holes
+// image pulls to a dead IP. Reaping it restores the pdm-intended parent-zone
+// shape (delegations only) so a wiped env can never shadow its siblings.
+func (c *Client) RemoveWildcardRecords(ctx context.Context, zone string) error {
+	wildcard := "*." + strings.TrimSuffix(canonicaliseZone(zone), ".")
+	return c.PatchRRSets(ctx, zone, []RRSet{
+		{Name: wildcard, Type: "A", ChangeType: "DELETE"},
+		{Name: wildcard, Type: "AAAA", ChangeType: "DELETE"},
+	})
+}
+
 // EnableDNSSEC turns on DNSSEC for the zone and generates a KSK + ZSK
 // key pair (algorithm 13, ECDSAP256SHA256, per docs/PLATFORM-POWERDNS.md).
 //

--- a/core/pool-domain-manager/internal/pdns/client_test.go
+++ b/core/pool-domain-manager/internal/pdns/client_test.go
@@ -287,6 +287,49 @@ func TestRemoveNSDelegation(t *testing.T) {
 	}
 }
 
+// #5007 — RemoveWildcardRecords issues a single PATCH DELETEing the `*.<zone>`
+// A and AAAA RRsets (the reap of a stale/foreign parent-pool wildcard). Assert
+// the wire shape: canonical `*.<zone>.` name, both types, ChangeType DELETE.
+func TestRemoveWildcardRecords(t *testing.T) {
+	var captured struct {
+		RRSets []RRSet `json:"rrsets"`
+	}
+	var gotPath string
+	c, _ := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &captured)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	if err := c.RemoveWildcardRecords(context.Background(), "omantel.biz"); err != nil {
+		t.Fatal(err)
+	}
+	if len(captured.RRSets) != 2 {
+		t.Fatalf("expected 2 RRsets (A + AAAA), got %d", len(captured.RRSets))
+	}
+	sawA, sawAAAA := false, false
+	for _, r := range captured.RRSets {
+		if r.Name != "*.omantel.biz." {
+			t.Errorf("wildcard name = %q, want *.omantel.biz.", r.Name)
+		}
+		if r.ChangeType != "DELETE" {
+			t.Errorf("changetype = %s, want DELETE", r.ChangeType)
+		}
+		switch r.Type {
+		case "A":
+			sawA = true
+		case "AAAA":
+			sawAAAA = true
+		}
+	}
+	if !sawA || !sawAAAA {
+		t.Errorf("expected both A (%v) and AAAA (%v) wildcard DELETEs", sawA, sawAAAA)
+	}
+	if !strings.HasSuffix(gotPath, "/zones/omantel.biz.") {
+		t.Errorf("PATCH path = %q, want a /zones/omantel.biz. target", gotPath)
+	}
+}
+
 func TestEnableDNSSECFullCycle(t *testing.T) {
 	// Track the sequence of API calls to verify the full PUT-flag,
 	// list-keys, create-KSK, create-ZSK, rectify path.

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.118
+  version: 0.1.119
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,36 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.119 (#5007 Refs #4682 #3379 — fresh-node local-registry pull breaks when the
+# public DNS wildcard shadows registry.<fqdn>; found LIVE on the hw241 cutover). After
+# the registry pivot the catalyst-api roll onto a fresh node failed
+#   Failed to pull "registry.hw241.omantel.biz/openova-io/openova/catalyst-api:<tag>":
+#   dial tcp 49.12.16.160:443: connect: connection refused
+# 49.12.16.160 is a DEAD Hetzner IP a wiped Hetzner-era env left on the public
+# `*.omantel.biz` WILDCARD. A specific `registry.<fqdn>` A record (the live gateway VIP)
+# exists and SHOULD win, but the cluster NODES' resolver returns the dead wildcard for
+# registry.<fqdn>, so containerd dials the dead IP → ImagePullBackOff → step-07 wedges.
+# The pod/CoreDNS path is fine (specific-wins); only the NODE/containerd path breaks.
+# FIX (template 04 + values): the step-04 registry-pivot DaemonSet now maintains a NODE
+# `/etc/hosts` pin `<gateway-VIP> registry.<fqdn>` so containerd resolves the local
+# registry DIRECTLY to the Harbor gateway VIP the platform already knows — NEVER via the
+# public wildcard-vs-specific race. The VIP is derived AT RUNTIME (no hardcoded IP,
+# Principle #4): the cilium-gateway `type=LoadBalancer` Service status.loadBalancer.
+# ingress[0].ip (hcloud-ccm ExternalIP on Hetzner / CiliumLoadBalancerIPPool VIP on
+# no-CCM Huawei), falling back to the node's OWN IP (status.hostIP) on the hostNetwork
+# gateway provider (Huawei #4706 — cilium-envoy binds node:443 directly, so there is no
+# LB Service VIP). Host header / SNI stay registry.<fqdn> so the Gateway HTTPRoute still
+# matches — only DNS resolution is pinned. Mounts the node /etc/hosts (hostPath File),
+# rewrites it IN PLACE (truncate, never mv — the single-file bind mount keeps its inode),
+# strips any stale line for the host (incl. a cloud-init r4() boot pin that baked the
+# dead wildcard), idempotent, reconciled every sweep, removed on rollback (v1),
+# FAIL-OPEN. New values.registryPivot.localRegistryHostPin.{enabled,gatewayServiceName,
+# gatewayServiceNamespace}; new DaemonSet envs LOCAL_REGISTRY_PIN_ENABLED /
+# GATEWAY_LB_SVC_NAME / GATEWAY_LB_SVC_NAMESPACE. RBAC already grants services get/list.
+# cutover-contract Case 44 locks it. NO step-count / job-mode change (still 11 steps).
+# Companion: core/pool-domain-manager reaps stale parent-pool wildcards so a wiped env
+# can never leave `*.<pool>` shadowing sibling children (the origin of the dead record).
+# Slot-06a pin + blueprint.yaml + catalog-seed source.version + spec.version move to
+# 0.1.119 in lockstep (Inviolable Principle #13; catalog-seed pin must NOT lag).
 # 0.1.118 (#4994 + #4996 Refs #3379 #4972 #4885 — two cutover-hardening defects
 # found live on hw240 (dep 0f1aac5431e6a436) that BLOCK cutoverComplete on
 # kom4dc/Huawei Sovereigns).
@@ -1837,7 +1868,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.118
+version: 0.1.119
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml
@@ -168,6 +168,21 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            # ── #5007 (Refs #4682 #3379) — NODE /etc/hosts pin for the local
+            # registry. containerd resolves registry.<fqdn> via the NODE resolver,
+            # which on hw241 returned the DEAD `*.omantel.biz` wildcard IP
+            # (49.12.16.160) instead of the live specific record → post-pivot fresh
+            # pulls ImagePullBackOff. The pivot pins registry.<fqdn> DIRECTLY to the
+            # gateway VIP the platform already knows (derived at runtime, no
+            # hardcoded IP), so the local-registry datapath NEVER depends on public
+            # DNS. GATEWAY_LB_SVC_* is the cilium-gateway LoadBalancer Service whose
+            # ingress IP is the VIP (empty → node-own-IP hostNetwork fallback).
+            - name: LOCAL_REGISTRY_PIN_ENABLED
+              value: {{ .Values.registryPivot.localRegistryHostPin.enabled | quote }}
+            - name: GATEWAY_LB_SVC_NAME
+              value: {{ .Values.registryPivot.localRegistryHostPin.gatewayServiceName | quote }}
+            - name: GATEWAY_LB_SVC_NAMESPACE
+              value: {{ .Values.registryPivot.localRegistryHostPin.gatewayServiceNamespace | quote }}
           # readinessProbe: the script touches /tmp/ready after its first
           # successful reconcile pass. catalyst-api's daemonset-wait
           # then sees numberReady=desired and proceeds.
@@ -187,6 +202,13 @@ spec:
               mountPath: /usr/local/bin/pivot.sh
               subPath: pivot.sh
               readOnly: true
+            # #5007 — the node's /etc/hosts (single-file bind mount). The pivot
+            # maintains a managed `<gateway-VIP> registry.<fqdn>` line so
+            # containerd resolves the local registry DIRECTLY to the gateway VIP,
+            # never via the public DNS wildcard-vs-specific race (the hw241 dead
+            # `*.omantel.biz` 49.12.16.160 ImagePullBackOff).
+            - name: node-etc-hosts
+              mountPath: /host/etc/hosts
           command: ["/bin/sh", "/usr/local/bin/pivot.sh"]
           resources:
             requests: { cpu: 25m, memory: 32Mi }
@@ -205,6 +227,14 @@ spec:
           configMap:
             name: registry-pivot-script
             defaultMode: 0755
+        # #5007 — node /etc/hosts (type: File bind mount). The pivot rewrites it
+        # IN PLACE (truncate, never mv — a single-file bind mount keeps the inode)
+        # to pin registry.<fqdn> -> the gateway VIP the platform already knows, so
+        # the local-registry pull never depends on public DNS resolution.
+        - name: node-etc-hosts
+          hostPath:
+            path: /etc/hosts
+            type: File
 ---
 # Step ConfigMap for catalyst-api consumer (mode=daemonset-wait).
 # The handler resolves the DaemonSet name from the `bp.openova.io/cutover-daemonset`
@@ -280,6 +310,11 @@ data:
     certs_d=/host/var/lib/rancher/k3s/agent/etc/containerd/certs.d
     df_proxy="http://127.0.0.1:${DF_PROXY_PORT}"
     last_state=""
+    # #5007 — the node's /etc/hosts (bind-mounted from the host) + the marker that
+    # tags the pin line this pivot owns, so it is idempotently re-writeable and
+    # cleanly removable on rollback.
+    etc_hosts=/host/etc/hosts
+    pin_marker="# managed by bp-self-sovereign-cutover registry-pivot (#5007) — DO NOT EDIT"
 
     # ── helpers ────────────────────────────────────────────────────────────
 
@@ -381,6 +416,87 @@ data:
         rm -f "${certs_d}/${h}/hosts.toml" 2>/dev/null || true
       done
       echo "[registry-pivot]   removed offline-mirror per-host hosts.toml (rollback) on ${NODE_NAME}"
+    }
+
+    # #5007 — resolve the Harbor gateway VIP WITHOUT public DNS. The per-host
+    # certs.d entries above use `server = https://registry.<fqdn>`; containerd
+    # resolves that host via the NODE resolver, which on hw241 returned the DEAD
+    # `*.omantel.biz` wildcard IP → ImagePullBackOff. We instead pin registry.<fqdn>
+    # to the gateway VIP the platform already assigned. Priority (K8s-API only, no
+    # DNS): (1) the cilium-gateway `type=LoadBalancer` Service ingress IP (hcloud-ccm
+    # ExternalIP on Hetzner / CiliumLoadBalancerIPPool VIP on no-CCM Huawei); (2) on
+    # the hostNetwork-gateway provider (Huawei #4706 — cilium-envoy binds node:443
+    # directly, so the Service has NO ingress IP / does not exist) the node's OWN IP,
+    # which serves :443 locally. Echoes the VIP or empty (empty ONLY when the Service
+    # EXISTS but its VIP is still pending, or on a transient API miss → caller defers
+    # + retries; a 404 means hostNetwork → HOST_IP). Word-split $CT is intentional.
+    resolve_gateway_vip() {
+      # No LB Service configured → hostNetwork gateway model: node's own IP serves :443.
+      if [ -z "${GATEWAY_LB_SVC_NAME:-}" ]; then printf '%s' "${HOST_IP:-}"; return; fi
+      svc_url="${api}/api/v1/namespaces/${GATEWAY_LB_SVC_NAMESPACE}/services/${GATEWAY_LB_SVC_NAME}"
+      # -w appends the HTTP status on its own trailing line (NOT -f, so a 404 body is
+      # readable to distinguish "absent → hostNetwork" from "present but VIP pending").
+      resp=$(curl -sS ${CT} --cacert "${cacert}" -H "Authorization: Bearer ${token}" \
+        -w '\n%{http_code}' "${svc_url}" 2>/dev/null || true)
+      code=$(printf '%s' "${resp}" | tail -n1)
+      json=$(printf '%s' "${resp}" | sed '$d')
+      case "${code}" in
+        200)
+          # Service present: use its ingress VIP (or spec.loadBalancerIP). Empty when
+          # the VIP is still pending → caller defers this sweep (do NOT fall back to
+          # HOST_IP here: in the LB model node:443 is NOT served by envoy).
+          printf '%s' "$(printf '%s' "${json}" | jq -r '.status.loadBalancer.ingress[0].ip // .spec.loadBalancerIP // empty' 2>/dev/null || true)"
+          ;;
+        404)
+          # Service absent → hostNetwork gateway model: cilium-envoy binds node:443.
+          printf '%s' "${HOST_IP:-}"
+          ;;
+        *)
+          # Transient (000 / 5xx / 401) → empty so the caller defers + retries.
+          printf '%s' ""
+          ;;
+      esac
+    }
+
+    # #5007 — write/refresh the managed `<VIP> registry.<fqdn>` line in the node's
+    # /etc/hosts, stripping ANY prior line for that host (a cloud-init r4() boot pin
+    # that may have baked the dead wildcard IP, or a stale managed line). In-place
+    # truncate-rewrite (NOT mv) so the single-file bind mount inode is preserved.
+    # Idempotent (grep -qxF no-op once pinned). Fail-OPEN on any error.
+    write_local_registry_pin() {
+      case "${LOCAL_REGISTRY_PIN_ENABLED}" in
+        true|True|TRUE|1|yes) : ;;
+        *) return 0 ;;
+      esac
+      [ -n "${LOCAL_REGISTRY_HOST:-}" ] || return 0
+      [ -f "${etc_hosts}" ] || return 0
+      vip=$(resolve_gateway_vip)
+      if [ -z "${vip}" ]; then
+        echo "[registry-pivot]   WARN could not derive gateway VIP for ${LOCAL_REGISTRY_HOST} (LB VIP pending / API miss); DEFERRING /etc/hosts pin this sweep on ${NODE_NAME}"
+        return 0
+      fi
+      want="${vip} ${LOCAL_REGISTRY_HOST} ${pin_marker}"
+      grep -qxF "${want}" "${etc_hosts}" 2>/dev/null && return 0
+      # Strip EVERY existing line whose host field == LOCAL_REGISTRY_HOST (any IP,
+      # managed or the cloud-init boot pin), then append the authoritative pin.
+      kept=$(awk -v h="${LOCAL_REGISTRY_HOST}" '{
+        drop=0
+        for (i=2; i<=NF; i++) if ($i==h) { drop=1; break }
+        if (!drop) print
+      }' "${etc_hosts}" 2>/dev/null)
+      { [ -n "${kept}" ] && printf '%s\n' "${kept}"; printf '%s\n' "${want}"; } > "${etc_hosts}" 2>/dev/null \
+        && echo "[registry-pivot]   pinned ${LOCAL_REGISTRY_HOST} -> ${vip} in ${etc_hosts} on ${NODE_NAME}" \
+        || echo "[registry-pivot]   WARN failed to write ${etc_hosts} pin on ${NODE_NAME} (will retry next sweep)"
+    }
+
+    # #5007 — rollback: drop the managed pin line so registry.<fqdn> reverts to the
+    # node's pre-pivot DNS resolution. In-place truncate-rewrite; idempotent.
+    remove_local_registry_pin() {
+      [ -f "${etc_hosts}" ] || return 0
+      grep -qF "${pin_marker}" "${etc_hosts}" 2>/dev/null || return 0
+      kept=$(grep -vF "${pin_marker}" "${etc_hosts}" 2>/dev/null)
+      { [ -n "${kept}" ] && printf '%s\n' "${kept}"; } > "${etc_hosts}" 2>/dev/null \
+        && echo "[registry-pivot]   removed ${LOCAL_REGISTRY_HOST} /etc/hosts pin (rollback) on ${NODE_NAME}"
     }
 
     # #4652 (the x509 fix) — materialise the in-cluster Harbor trust anchor in
@@ -691,6 +807,7 @@ data:
           ;;
         v1|rollback|*)
           remove_offline_mirror_hosts
+          remove_local_registry_pin
           df_revert_to_ghcr || true
           write_node_ack v1
           ;;
@@ -702,6 +819,12 @@ data:
         | jq -r '.data.registriesYamlActive // "v1"' 2>/dev/null \
         || echo "v1")
       desired=${desired:-v1}
+
+      # #5007 — reconcile the local-registry /etc/hosts pin every sweep while v2 is
+      # desired (idempotent; self-heals a node whose /etc/hosts was rewritten, and
+      # completes the pin once the gateway VIP is assigned after the first v2 sweep
+      # — a fast grep no-op once pinned). On v1/rollback apply_state removes it.
+      [ "${desired}" = "v2" ] && write_local_registry_pin
 
       # #4639 — re-apply v2 if the cluster-wide dfdaemon flip has not yet been
       # confirmed (guard dragonflyUpstream != local). apply_state fires only

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -1707,4 +1707,53 @@ if ! awk '/^kind: ClusterRole$/,/^---$/' "$TMP/render.yaml" | grep -A3 'resource
 fi
 echo "  PASS (Step-07 image-warmed gate pre-pivot + EVS detach-gate + broken-CSI cordon + deadlock-aware rollout wait; RBAC wired)"
 
+echo "[cutover-contract] Case 44: step-04 registry-pivot pins registry.<fqdn> on the NODE /etc/hosts to the gateway VIP so the local-registry pull never depends on public DNS (#5007, Refs #4682 #3379)"
+# hw241 live: post-pivot a fresh catalyst-api pull dialed the DEAD *.omantel.biz
+# wildcard IP (49.12.16.160) because the NODE resolver returned the wildcard for
+# registry.<fqdn>. The pivot now maintains a node /etc/hosts pin
+# `<gateway-VIP> registry.<fqdn>` (VIP derived at runtime from the cilium-gateway
+# LB Service ingress IP, HOST_IP fallback for the hostNetwork model) so containerd
+# resolves the local registry DIRECTLY — no public DNS wildcard-vs-specific race.
+pin_block="$(awk '/name: registry-pivot-script/{c=1} c{print} c&&/^---/{if(seen)exit; seen=1}' "$TMP/render.yaml")"
+# (1) the DaemonSet mounts the node /etc/hosts (hostPath File).
+if ! grep -q 'path: /etc/hosts' "$TMP/render.yaml"; then
+  echo "FAIL: step-04 registry-pivot does not mount the node /etc/hosts — can't pin registry.<fqdn> (#5007)" >&2
+  exit 1
+fi
+# (2) the pivot script derives the gateway VIP from the LB Service ingress IP (DNS-free).
+if ! grep -q 'resolve_gateway_vip()' <<<"$pin_block"; then
+  echo "FAIL: step-04 pivot script missing resolve_gateway_vip() — the DNS-free gateway VIP derivation (#5007)" >&2
+  exit 1
+fi
+if ! grep -qF 'loadBalancer.ingress[0].ip' <<<"$pin_block"; then
+  echo "FAIL: step-04 pivot script does not read the cilium-gateway LB Service ingress IP for the pin (#5007)" >&2
+  exit 1
+fi
+# (3) the pin is written to (and removed from, on rollback) the node /etc/hosts.
+if ! grep -q 'write_local_registry_pin' <<<"$pin_block"; then
+  echo "FAIL: step-04 pivot script missing write_local_registry_pin — the node /etc/hosts pin (#5007)" >&2
+  exit 1
+fi
+if ! grep -q 'remove_local_registry_pin' <<<"$pin_block"; then
+  echo "FAIL: step-04 pivot script does not remove the /etc/hosts pin on rollback (v1) (#5007)" >&2
+  exit 1
+fi
+# (4) the pin must NOT depend on DNS: no getent/nslookup/dig of registry.<fqdn> in
+# the VIP derivation. (The derivation is K8s-API + HOST_IP only.)
+if grep -Eq 'resolve_gateway_vip[^}]*(getent|nslookup|dig )' <<<"$pin_block"; then
+  echo "FAIL: step-04 gateway VIP derivation must be DNS-free (K8s-API + HOST_IP only) (#5007)" >&2
+  exit 1
+fi
+# (5) hostNetwork-gateway fallback to the node's own IP (status.hostIP → HOST_IP).
+if ! grep -q 'name: HOST_IP' "$TMP/render.yaml"; then
+  echo "FAIL: step-04 DaemonSet does not expose HOST_IP (status.hostIP) — the hostNetwork pin fallback (#5007)" >&2
+  exit 1
+fi
+# (6) default enabled (fail-safe robustness posture).
+if ! grep -A1 'name: LOCAL_REGISTRY_PIN_ENABLED' "$TMP/render.yaml" | grep -q 'value: "true"'; then
+  echo "FAIL: LOCAL_REGISTRY_PIN_ENABLED must DEFAULT to enabled (rendered value != \"true\") (#5007)" >&2
+  exit 1
+fi
+echo "  PASS (step-04 pins registry.<fqdn> to the gateway VIP on the node /etc/hosts; LB-ingress VIP with HOST_IP hostNetwork fallback; DNS-free; removed on rollback; default enabled)"
+
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -1043,6 +1043,48 @@ registryPivot:
       certMountPath: "/etc/dragonfly-ca"
       certFileName: "tls.crt"
 
+  # ── #5007 (Refs #4682 #3379) — NODE /etc/hosts pin for the local registry ────
+  #
+  # ROOT CAUSE (hw241 live cutover, step-07 catalyst-api roll onto a fresh node):
+  # post-pivot every image ref is registry.<sov-fqdn>/... A NEW pod that must pull
+  # the image fresh (a roll onto a node that had not cached it) failed
+  #   Failed to pull "registry.hw241.omantel.biz/openova-io/openova/catalyst-api:
+  #   <tag>": dial tcp 49.12.16.160:443: connect: connection refused
+  # 49.12.16.160 is a DEAD Hetzner IP from a wiped Hetzner-era env that the public
+  # `*.omantel.biz` WILDCARD still points at. A specific `registry.<fqdn>` A record
+  # (the live gateway VIP) exists and SHOULD win over the wildcard at the
+  # authoritative NS, but the cluster NODES' resolver returns the dead wildcard IP
+  # for registry.<fqdn>, so containerd dials the dead IP → ImagePullBackOff → the
+  # step-07 roll (and every post-pivot fresh pull) wedges. The pod path is fine
+  # (CoreDNS resolves the specific record); only the NODE/containerd path breaks.
+  #
+  # THE FIX (robustness — eliminate DNS from the local-registry datapath). The
+  # registry-pivot DaemonSet already runs privileged on every node and writes the
+  # containerd certs.d. It now ALSO maintains a NODE `/etc/hosts` pin
+  # `<gateway-VIP> registry.<fqdn>` so containerd resolves the local registry
+  # DIRECTLY to the Harbor gateway VIP the platform already knows — NEVER via the
+  # public wildcard-vs-specific race. The VIP is derived AT RUNTIME (no hardcoded
+  # IP, Principle #4): the cilium-gateway `type=LoadBalancer` Service's
+  # status.loadBalancer.ingress[0].ip (the hcloud-ccm ExternalIP on Hetzner / the
+  # CiliumLoadBalancerIPPool VIP on no-CCM Huawei); on the hostNetwork-gateway
+  # provider (Huawei #4706 — cilium-envoy binds node:443 directly, so there is NO
+  # LB Service VIP) it falls back to the node's OWN IP (status.hostIP), which
+  # serves :443 locally. The Host header / SNI stay registry.<fqdn> so the Gateway
+  # HTTPRoute still matches — only DNS resolution is pinned. Idempotent, reconciled
+  # every sweep, removed on rollback (v1). Fail-OPEN: if NO VIP can be derived the
+  # pin is skipped (never wedges worse than the prior DNS-dependent behaviour).
+  localRegistryHostPin:
+    enabled: true
+    # The cilium-gateway LoadBalancer Service whose ingress VIP serves
+    # registry.<fqdn> (LB-Service gateway model — Hetzner hcloud-ccm / Huawei
+    # CiliumLoadBalancerIPPool). Cilium auto-creates it as
+    # `cilium-gateway-<gateway-name>` in kube-system; the Sovereign Gateway is
+    # named `cilium-gateway`, so the Service is `cilium-gateway-cilium-gateway`.
+    # Empty name disables the Service lookup — the pin then uses the node's own IP
+    # (status.hostIP), correct for the hostNetwork gateway model.
+    gatewayServiceName: "cilium-gateway-cilium-gateway"
+    gatewayServiceNamespace: "kube-system"
+
 # CiliumNetworkPolicy for step 08 (egress-block-test). Operator
 # overrides duration via overlay if 10 min isn't enough.
 egressTest:

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5041,7 +5041,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.118"
+  version: "0.1.119"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.118"
+    version: "0.1.119"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## What & why

Durable fix for the **P1** defect proven **LIVE on the hw241 sovereignty-cutover**: after the registry pivot, a fresh-node `catalyst-api` roll failed

```
Failed to pull "registry.hw241.omantel.biz/openova-io/openova/catalyst-api:25d26e3":
  dial tcp 49.12.16.160:443: connect: connection refused
```

`49.12.16.160` is a **dead Hetzner IP** a wiped Hetzner-era env left on the public `*.omantel.biz` **wildcard**. A correct specific record `registry.hw241.omantel.biz A 212.72.24.28` (the live Harbor gateway VIP) exists and should win, but the cluster **nodes' resolver** returns the dead wildcard for `registry.<fqdn>`, so containerd dials the dead IP → ImagePullBackOff → the cutover's step-07 roll (and every post-pivot fresh pull) wedges. The pod/CoreDNS path resolves the specific record fine — only the node/containerd path breaks.

Refs #5007 #4682 #3379 #4706

## Part A (PRIMARY, robustness) — cutover pins the local registry on the nodes, eliminating DNS dependence

`platform/self-sovereign-cutover` step-04 registry-pivot DaemonSet now maintains a **node `/etc/hosts` pin** `<gateway-VIP> registry.<fqdn>` when it flips to `v2`, so containerd resolves the local registry **directly** to the Harbor gateway VIP — never via the public wildcard-vs-specific race.

- **VIP derived at runtime, no hardcoded IP** (Principle #4): the `cilium-gateway` `type=LoadBalancer` Service `status.loadBalancer.ingress[0].ip` (hcloud-ccm ExternalIP on Hetzner / CiliumLoadBalancerIPPool VIP on no-CCM Huawei), falling back to the node's OWN IP (`status.hostIP`) on the **hostNetwork** gateway provider (Huawei #4706 — cilium-envoy binds `node:443` directly, so there is no LB Service VIP). Distinguishes "Service absent → hostNetwork → HOST_IP" (404) from "Service present but VIP pending → defer" (200/empty) so it never pins a wrong IP.
- **Host header / SNI stay `registry.<fqdn>`** so the Gateway HTTPRoute still routes to Harbor — only the A-record resolution is pinned.
- Mounts the node `/etc/hosts` (hostPath `File`), rewrites it **in place** (truncate, never `mv` — the single-file bind mount keeps its inode), **strips any stale line for the host** (incl. a cloud-init `r4()` boot pin that baked the dead wildcard), **idempotent**, reconciled every sweep, **removed on rollback (v1)**, **fail-open**.
- **No NodePort**, no ClusterIP hairpin, no CoreDNS rewrite — consistent with #4682/§854.

New `values.registryPivot.localRegistryHostPin.{enabled,gatewayServiceName,gatewayServiceNamespace}`; new DaemonSet envs `LOCAL_REGISTRY_PIN_ENABLED` / `GATEWAY_LB_SVC_NAME` / `GATEWAY_LB_SVC_NAMESPACE`. RBAC already grants `services get/list`. Chart **0.1.118 → 0.1.119** in lockstep (blueprint.yaml + 06a slot pin + catalog-seed `source.version` + `spec.version`). `cutover-contract` **Case 44** locks it. Still 11 steps / 10 job-mode.

## Part B (hygiene) — pool-domain-manager can't leave a stale parent wildcard

`core/pool-domain-manager` owns the `omantel.biz` / `*.omani.*` pool zones. Its model is **child-zone delegation** — the parent pool zone holds only NS delegations + apex, and the per-Sovereign wildcard lives in the delegated child zone (`*.<sub>.<pool>`). pdm **never** writes a parent-level `*.<pool>` wildcard, so the `*.omantel.biz A <dead-IP>` was a foreign leftover nothing reaped.

`BootstrapParentZones` now asserts the pdm-intended parent-zone shape and **reaps any `*.<pool>` A/AAAA wildcard** (new `pdns.Client.RemoveWildcardRecords`, an idempotent DELETE), so a wiped env can never leave a wildcard shadowing sibling child names. Gated by `PDM_REAP_STALE_PARENT_WILDCARDS` (default true; escape hatch for a deployment intentionally serving a flat parent wildcard managed elsewhere). Best-effort — a reap failure never blocks bootstrap.

## Verification (local)

- `platform/self-sovereign-cutover/chart/tests/cutover-contract.sh` — **all 44 gates green** (incl. new Case 44 + unchanged Case 31, the #4682 regression guard).
- `helm lint` + `helm template` clean; rendered pivot.sh passes `sh -n` + `dash -n`.
- `core/pool-domain-manager`: `go build ./...`, `go vet ./...`, `go test ./...` — **all green**. New regression tests: allocator reap enabled/disabled/best-effort + pdns client DELETE `A`+`AAAA` wire shape.

## Deferred to a fresh-prov walk (per repo DoD)

The end-to-end proof — a fresh Sovereign cutover whose step-07 catalyst-api roll onto a fresh node pulls the local-registry image with the wildcard still present in public DNS — is a live cutover walk, tracked on #5007. PR merge ≠ pillar shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
