### PR TITLE
fix(#4872): version-aware batched OBS bucket empty+delete so wipes stop leaking to the 100-bucket quota

### DIFF
--- a/products/catalyst/bootstrap/api/internal/providers/huawei/obs_bucket_purge_test.go
+++ b/products/catalyst/bootstrap/api/internal/providers/huawei/obs_bucket_purge_test.go
@@ -1,0 +1,410 @@
+// obs_bucket_purge_test.go — regression tests for #4872's OBS bucket-cleanup
+// path (emptyAndRemoveOBSBucket).
+//
+// The #4909 fix shipped a per-Sovereign OBS purge + a project-wide janitor
+// sweep, but both share emptyAndRemoveOBSBucket, which originally used a serial
+// per-object RemoveObject WITHOUT version awareness AND swallowed the delete
+// error. That leaked buckets three ways (documented on the function): (1) a
+// populated Harbor/Velero backup bucket could not be drained within the wipe
+// budget by serial deletes → RemoveBucket 409'd BucketNotEmpty; (2) versioned
+// objects + delete markers survived a non-versioned list; (3) a swallowed
+// per-object error reported phantom success. This file pins the converged,
+// Hetzner-equivalent behaviour so those leak modes cannot silently return.
+//
+// Strategy mirrors internal/hetzner/buckets_test.go: rather than run a real
+// minio binary, stub the subset of S3 endpoints minio-go calls during a purge
+// and drive the real emptyAndRemoveOBSBucket() code path against it.
+
+package huawei
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+)
+
+// obsFakeS3 is a minimal single-tenant S3-compatible stub for the OBS
+// bucket-purge tests. It implements only what minio-go calls during an
+// emptyAndRemoveOBSBucket run:
+//
+//   - HEAD /<bucket>                       — BucketExists
+//   - GET  /<bucket>?versions              — ListObjectVersions (paginated)
+//   - POST /<bucket>?delete                — DeleteObjects (multi-object)
+//   - GET  /<bucket>?uploads               — ListMultipartUploads
+//   - DELETE /<bucket>/<key>?uploadId=...  — AbortMultipartUpload
+//   - DELETE /<bucket>                     — DeleteBucket
+type obsFakeS3 struct {
+	mu sync.Mutex
+
+	bucket   string
+	exists   bool
+	versions []obsFakeVersion
+	uploads  []obsFakeUpload
+	// failDeleteKey, when non-empty, makes the multi-object delete report a
+	// per-object Error for that key (never deletes it) — used to prove the
+	// error is surfaced, not swallowed, and DeleteBucket is NOT attempted.
+	failDeleteKey string
+
+	deletedKeys []obsFakeDeleted
+	abortedUps  []obsFakeUpload
+	bucketDel   atomic.Bool
+	versionsCnt atomic.Int32
+}
+
+type obsFakeVersion struct {
+	Key       string
+	VersionID string
+	IsDelete  bool
+}
+
+type obsFakeUpload struct {
+	Key      string
+	UploadID string
+}
+
+type obsFakeDeleted struct {
+	Key       string
+	VersionID string
+}
+
+// ── AWS S3 XML wire types minio-go expects ────────────────────────────────
+
+type obsListVersionsResult struct {
+	XMLName             xml.Name           `xml:"ListVersionsResult"`
+	Name                string             `xml:"Name"`
+	MaxKeys             int                `xml:"MaxKeys"`
+	IsTruncated         bool               `xml:"IsTruncated"`
+	KeyMarker           string             `xml:"KeyMarker"`
+	NextKeyMarker       string             `xml:"NextKeyMarker"`
+	NextVersionIDMarker string             `xml:"NextVersionIdMarker"`
+	Versions            []obsListVersion   `xml:"Version"`
+	DeleteMarkers       []obsListDelMarker `xml:"DeleteMarker"`
+}
+
+type obsListVersion struct {
+	Key       string `xml:"Key"`
+	VersionID string `xml:"VersionId"`
+}
+
+type obsListDelMarker struct {
+	Key       string `xml:"Key"`
+	VersionID string `xml:"VersionId"`
+}
+
+type obsListMultipartUploadsResult struct {
+	XMLName xml.Name          `xml:"ListMultipartUploadsResult"`
+	Bucket  string            `xml:"Bucket"`
+	Uploads []obsMultipartItem `xml:"Upload"`
+}
+
+type obsMultipartItem struct {
+	Key      string `xml:"Key"`
+	UploadID string `xml:"UploadId"`
+}
+
+type obsDeleteRequest struct {
+	XMLName xml.Name         `xml:"Delete"`
+	Objects []obsDeleteEntry `xml:"Object"`
+}
+
+type obsDeleteEntry struct {
+	Key       string `xml:"Key"`
+	VersionID string `xml:"VersionId"`
+}
+
+type obsDeleteResult struct {
+	XMLName xml.Name            `xml:"DeleteResult"`
+	Deleted []obsDeletedEntry   `xml:"Deleted"`
+	Errors  []obsDeleteErrEntry `xml:"Error"`
+}
+
+type obsDeletedEntry struct {
+	Key       string `xml:"Key"`
+	VersionID string `xml:"VersionId,omitempty"`
+}
+
+type obsDeleteErrEntry struct {
+	Key     string `xml:"Key"`
+	Code    string `xml:"Code"`
+	Message string `xml:"Message"`
+}
+
+func (f *obsFakeS3) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := strings.TrimPrefix(r.URL.Path, "/")
+		if p == "" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		var bucket, key string
+		if i := strings.IndexByte(p, '/'); i >= 0 {
+			bucket, key = p[:i], p[i+1:]
+		} else {
+			bucket = p
+		}
+		if bucket != f.bucket {
+			w.WriteHeader(http.StatusNotFound)
+			_ = obsXMLError(w, "NoSuchBucket", "bucket does not exist")
+			return
+		}
+
+		f.mu.Lock()
+		defer f.mu.Unlock()
+
+		switch {
+		case r.Method == http.MethodHead && key == "":
+			if f.exists {
+				w.WriteHeader(http.StatusOK)
+			} else {
+				w.WriteHeader(http.StatusNotFound)
+			}
+		case r.Method == http.MethodGet && key == "" && r.URL.Query().Has("versions"):
+			f.versionsCnt.Add(1)
+			f.serveListVersions(w, r)
+		case r.Method == http.MethodGet && key == "" && r.URL.Query().Has("uploads"):
+			f.serveListMultipart(w)
+		case r.Method == http.MethodPost && key == "" && r.URL.Query().Has("delete"):
+			f.serveMultiDelete(w, r)
+		case r.Method == http.MethodDelete && key != "" && r.URL.Query().Has("uploadId"):
+			f.abortedUps = append(f.abortedUps, obsFakeUpload{Key: key, UploadID: r.URL.Query().Get("uploadId")})
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodDelete && key == "":
+			f.exists = false
+			f.bucketDel.Store(true)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			if r.Method == http.MethodGet {
+				w.Header().Set("Content-Type", "application/xml")
+				_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><ok/>`))
+				return
+			}
+			http.Error(w, "unexpected fake-s3 call: "+r.Method+" "+r.URL.String(), http.StatusMethodNotAllowed)
+		}
+	})
+}
+
+func (f *obsFakeS3) serveListVersions(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	keyMarker := q.Get("key-marker")
+	verMarker := q.Get("version-id-marker")
+
+	start := 0
+	if keyMarker != "" || verMarker != "" {
+		for i, v := range f.versions {
+			if v.Key == keyMarker && v.VersionID == verMarker {
+				start = i + 1
+				break
+			}
+		}
+	}
+	const pageSize = 1000
+	end := start + pageSize
+	if end > len(f.versions) {
+		end = len(f.versions)
+	}
+	page := f.versions[start:end]
+	resp := obsListVersionsResult{
+		Name:        f.bucket,
+		MaxKeys:     pageSize,
+		KeyMarker:   keyMarker,
+		IsTruncated: end < len(f.versions),
+	}
+	if resp.IsTruncated && end > start {
+		last := page[len(page)-1]
+		resp.NextKeyMarker = last.Key
+		resp.NextVersionIDMarker = last.VersionID
+	}
+	for _, v := range page {
+		if v.IsDelete {
+			resp.DeleteMarkers = append(resp.DeleteMarkers, obsListDelMarker{Key: v.Key, VersionID: v.VersionID})
+		} else {
+			resp.Versions = append(resp.Versions, obsListVersion{Key: v.Key, VersionID: v.VersionID})
+		}
+	}
+	w.Header().Set("Content-Type", "application/xml")
+	_ = xml.NewEncoder(w).Encode(resp)
+}
+
+func (f *obsFakeS3) serveListMultipart(w http.ResponseWriter) {
+	resp := obsListMultipartUploadsResult{Bucket: f.bucket}
+	for _, u := range f.uploads {
+		resp.Uploads = append(resp.Uploads, obsMultipartItem{Key: u.Key, UploadID: u.UploadID})
+	}
+	w.Header().Set("Content-Type", "application/xml")
+	_ = xml.NewEncoder(w).Encode(resp)
+}
+
+func (f *obsFakeS3) serveMultiDelete(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	var dr obsDeleteRequest
+	if err := xml.Unmarshal(body, &dr); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	resp := obsDeleteResult{}
+	for _, o := range dr.Objects {
+		if f.failDeleteKey != "" && o.Key == f.failDeleteKey {
+			resp.Errors = append(resp.Errors, obsDeleteErrEntry{
+				Key: o.Key, Code: "AccessDenied", Message: "object is locked",
+			})
+			continue
+		}
+		f.deletedKeys = append(f.deletedKeys, obsFakeDeleted{Key: o.Key, VersionID: o.VersionID})
+		newVersions := f.versions[:0]
+		for _, v := range f.versions {
+			if v.Key == o.Key && v.VersionID == o.VersionID {
+				continue
+			}
+			newVersions = append(newVersions, v)
+		}
+		f.versions = newVersions
+		resp.Deleted = append(resp.Deleted, obsDeletedEntry{Key: o.Key, VersionID: o.VersionID})
+	}
+	w.Header().Set("Content-Type", "application/xml")
+	_ = xml.NewEncoder(w).Encode(resp)
+}
+
+func obsXMLError(w http.ResponseWriter, code, msg string) error {
+	w.Header().Set("Content-Type", "application/xml")
+	_, err := fmt.Fprintf(w, `<?xml version="1.0" encoding="UTF-8"?><Error><Code>%s</Code><Message>%s</Message></Error>`, code, msg)
+	return err
+}
+
+func obsTestMinio(t *testing.T, srv *httptest.Server) *minio.Client {
+	t.Helper()
+	endpoint := strings.TrimPrefix(strings.TrimPrefix(srv.URL, "http://"), "https://")
+	client, err := minio.New(endpoint, &minio.Options{
+		Creds:        credentials.NewStaticV4("test-access", "test-secret", ""),
+		Secure:       false,
+		Region:       "me-east-215",
+		BucketLookup: minio.BucketLookupPath,
+	})
+	if err != nil {
+		t.Fatalf("minio.New: %v", err)
+	}
+	return client
+}
+
+// TestEmptyAndRemoveOBSBucket_NotFound — an already-gone bucket is idempotent
+// success (nil error, no DeleteBucket attempted). This is the tolerant-of-
+// not-found contract the janitor + a re-run wipe depend on.
+func TestEmptyAndRemoveOBSBucket_NotFound(t *testing.T) {
+	fake := &obsFakeS3{bucket: "catalyst-hw01-omani-works-deadbeef", exists: false}
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	if err := emptyAndRemoveOBSBucket(context.Background(), obsTestMinio(t, srv), fake.bucket); err != nil {
+		t.Fatalf("emptyAndRemoveOBSBucket on absent bucket: %v (want nil)", err)
+	}
+	if fake.bucketDel.Load() {
+		t.Errorf("DeleteBucket was called against a non-existent bucket")
+	}
+}
+
+// TestEmptyAndRemoveOBSBucket_Empty — an existing empty bucket is deleted.
+func TestEmptyAndRemoveOBSBucket_Empty(t *testing.T) {
+	fake := &obsFakeS3{bucket: "catalyst-hw02-omani-works-cafef00d", exists: true}
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	if err := emptyAndRemoveOBSBucket(context.Background(), obsTestMinio(t, srv), fake.bucket); err != nil {
+		t.Fatalf("emptyAndRemoveOBSBucket on empty bucket: %v", err)
+	}
+	if !fake.bucketDel.Load() {
+		t.Errorf("DeleteBucket was not called on empty bucket")
+	}
+}
+
+// TestEmptyAndRemoveOBSBucket_VersionsBatched is the core #4872 regression:
+// a populated, VERSIONED backup bucket (1500 versions across 3 keys) must be
+// fully drained via batched, version-aware multi-object delete and THEN the
+// bucket deleted. The old serial+non-versioned code left versions behind and
+// 409'd BucketNotEmpty, leaking the bucket to the 100-bucket OBS quota.
+func TestEmptyAndRemoveOBSBucket_VersionsBatched(t *testing.T) {
+	fake := &obsFakeS3{bucket: "catalyst-hw229-omani-works-abcd1234", exists: true}
+	for i := 0; i < 1500; i++ {
+		fake.versions = append(fake.versions, obsFakeVersion{
+			Key:       "harbor/blob-" + strconv.Itoa(i%3),
+			VersionID: "v-" + strconv.Itoa(i),
+			IsDelete:  i%7 == 0, // sprinkle delete markers (non-current versions)
+		})
+	}
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	if err := emptyAndRemoveOBSBucket(context.Background(), obsTestMinio(t, srv), fake.bucket); err != nil {
+		t.Fatalf("emptyAndRemoveOBSBucket on versioned bucket: %v", err)
+	}
+	if got := len(fake.deletedKeys); got != 1500 {
+		t.Errorf("deleted versions = %d, want 1500 (every version + delete marker must be removed)", got)
+	}
+	if fake.versionsCnt.Load() < 2 {
+		t.Errorf("ListObjectVersions called %d time(s), want ≥2 (pagination proves the batch loop iterated)", fake.versionsCnt.Load())
+	}
+	if !fake.bucketDel.Load() {
+		t.Errorf("DeleteBucket was not called after the versioned empty completed")
+	}
+}
+
+// TestEmptyAndRemoveOBSBucket_MultipartAbortedBeforeDelete — a dangling
+// multipart upload keeps a bucket non-empty; the purge must abort it before
+// DeleteBucket, or RemoveBucket 409s and the bucket leaks.
+func TestEmptyAndRemoveOBSBucket_MultipartAbortedBeforeDelete(t *testing.T) {
+	fake := &obsFakeS3{
+		bucket:  "catalyst-hw77-omani-works-99887766",
+		exists:  true,
+		uploads: []obsFakeUpload{{Key: "velero/backup.tar", UploadID: "up-42"}},
+	}
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	if err := emptyAndRemoveOBSBucket(context.Background(), obsTestMinio(t, srv), fake.bucket); err != nil {
+		t.Fatalf("emptyAndRemoveOBSBucket with in-progress multipart: %v", err)
+	}
+	if len(fake.abortedUps) != 1 || fake.abortedUps[0].Key != "velero/backup.tar" {
+		t.Errorf("abortedUps = %+v, want one abort of velero/backup.tar before delete", fake.abortedUps)
+	}
+	if !fake.bucketDel.Load() {
+		t.Errorf("DeleteBucket was not called after multipart abort")
+	}
+}
+
+// TestEmptyAndRemoveOBSBucket_SurfacesDeleteError proves the anti-pattern is
+// gone: a per-object delete failure must be RETURNED (not swallowed), and the
+// bucket must NOT be deleted (a still-non-empty bucket would only 409). The
+// old `_ = RemoveObject(...)` hid this and reported phantom success.
+func TestEmptyAndRemoveOBSBucket_SurfacesDeleteError(t *testing.T) {
+	fake := &obsFakeS3{
+		bucket:        "catalyst-hw180-omani-works-0badf00d",
+		exists:        true,
+		failDeleteKey: "locked/object",
+		versions: []obsFakeVersion{
+			{Key: "ok/object", VersionID: "v1"},
+			{Key: "locked/object", VersionID: "v2"},
+		},
+	}
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	err := emptyAndRemoveOBSBucket(context.Background(), obsTestMinio(t, srv), fake.bucket)
+	if err == nil {
+		t.Fatalf("emptyAndRemoveOBSBucket returned nil, want a surfaced delete error")
+	}
+	if !strings.Contains(err.Error(), "locked/object") {
+		t.Errorf("error %q does not name the stuck object — the diagnostic was lost", err.Error())
+	}
+	if fake.bucketDel.Load() {
+		t.Errorf("DeleteBucket was called despite a failed object delete — would 409 BucketNotEmpty and mask the leak")
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/providers/huawei/provider.go
+++ b/products/catalyst/bootstrap/api/internal/providers/huawei/provider.go
@@ -2542,33 +2542,127 @@ func purgeOBSBuckets(ctx context.Context, endpoint string, hw hwCreds, region, s
 // account marches to the 100-bucket OBS quota, false-failing the next fresh
 // prov's Phase-0 `tofu apply` with `Code=TooManyBuckets`.
 //
-// Emptying has TWO parts, both required before DeleteBucket will succeed:
-//  1. every object (recursive), and
-//  2. every incomplete multipart upload — an interrupted tofu apply or CSI
-//     backup can leave dangling parts that keep the bucket non-empty even
-//     after all listable objects are gone, so RemoveBucket still fails with
-//     BucketNotEmpty.
+// This mirrors the battle-tested Hetzner purge (internal/hetzner/buckets.go
+// purgeBucket) exactly, because the earlier per-object serial implementation
+// kept leaking buckets in three ways the #4872 incident hit repeatedly:
+//
+//  1. Serial RemoveObject (one HTTP round-trip per key) could not drain a
+//     populated Harbor / Velero / CNPG backup bucket (thousands of blobs)
+//     inside the 5-minute wipe budget — the loop timed out half-empty and the
+//     terminal RemoveBucket 409'd BucketNotEmpty, so the bucket survived every
+//     wipe. Fix: stream every key into RemoveObjects, which batch-deletes
+//     1000 per request (~1000× fewer round-trips).
+//  2. ListObjects WITHOUT WithVersions enumerates only current versions, so on
+//     a versioned bucket the non-current versions + delete markers survived
+//     the empty and RemoveBucket failed with BucketNotEmpty. Fix:
+//     WithVersions:true + version-aware batch delete (RemoveObjects consumes
+//     ObjectInfo.VersionID).
+//  3. The per-object delete error was swallowed (`_ = RemoveObject(...)`), so
+//     a single stuck object silently left the bucket non-empty with no
+//     diagnostic AND the caller was told the delete succeeded. Fix: collect +
+//     return the delete errors so the caller logs them and does NOT skip on to
+//     RemoveBucket (which would only 409) or report a phantom success.
+//
+// Emptying still has TWO parts, both required before DeleteBucket succeeds:
+// every object version, and every incomplete multipart upload — an interrupted
+// tofu apply or CSI backup can leave dangling parts that keep the bucket
+// non-empty even after all listable objects are gone.
 //
 // Shared by the per-deployment wipe purge (purgeOBSBuckets) and the
 // project-wide janitor reclaim (SweepOrphanOBSBuckets). Idempotent: an
-// already-absent object/upload/bucket is a no-op (the caller only ever passes
-// bucket names ListBuckets just returned, so the terminal RemoveBucket sees a
-// bucket that exists; a re-run simply finds no such bucket in the next list).
+// already-absent bucket (fast 404 path) is a no-op nil, so a re-run after a
+// prior partial purge simply finds the bucket already gone.
 func emptyAndRemoveOBSBucket(ctx context.Context, client *minio.Client, bucket string) error {
-	objCh := client.ListObjects(ctx, bucket, minio.ListObjectsOptions{Recursive: true})
-	for o := range objCh {
-		if o.Err != nil {
-			continue
+	// Fast idempotent 404 path — an already-absent bucket is success.
+	exists, err := client.BucketExists(ctx, bucket)
+	if err != nil {
+		if isNoSuchBucket(err) {
+			return nil
 		}
-		_ = client.RemoveObject(ctx, bucket, o.Key, minio.RemoveObjectOptions{ForceDelete: true})
+		return fmt.Errorf("bucket-exists %s: %w", bucket, err)
 	}
+	if !exists {
+		return nil
+	}
+
+	// Step 1 — list every object version + delete marker and stream them
+	// into RemoveObjects (version-aware, batched at 1000 per request).
+	objectsCh := make(chan minio.ObjectInfo)
+	listCtx, listCancel := context.WithCancel(ctx)
+	defer listCancel()
+	listErrCh := make(chan error, 1)
+	go func() {
+		defer close(objectsCh)
+		for obj := range client.ListObjects(listCtx, bucket, minio.ListObjectsOptions{
+			WithVersions: true,
+			Recursive:    true,
+		}) {
+			if obj.Err != nil {
+				listErrCh <- obj.Err
+				return
+			}
+			select {
+			case objectsCh <- obj:
+			case <-listCtx.Done():
+				return
+			}
+		}
+		listErrCh <- nil
+	}()
+
+	var removeErrs []string
+	for re := range client.RemoveObjects(ctx, bucket, objectsCh, minio.RemoveObjectsOptions{}) {
+		if re.Err != nil {
+			removeErrs = append(removeErrs, fmt.Sprintf("%s@%s: %v", re.ObjectName, re.VersionID, re.Err))
+		}
+	}
+	if listErr := <-listErrCh; listErr != nil {
+		return fmt.Errorf("list versions in %s: %w", bucket, listErr)
+	}
+	if len(removeErrs) > 0 {
+		// Surface a bounded summary; the full list would flood the SSE log.
+		const maxHead = 5
+		head := removeErrs
+		suffix := ""
+		if len(head) > maxHead {
+			head = head[:maxHead]
+			suffix = fmt.Sprintf("; …and %d more", len(removeErrs)-maxHead)
+		}
+		return fmt.Errorf("delete %d object(s) in %s failed: %s%s",
+			len(removeErrs), bucket, strings.Join(head, "; "), suffix)
+	}
+
+	// Step 2 — abort every in-progress multipart upload; a dangling part
+	// keeps the bucket non-empty even after all objects are gone.
 	for up := range client.ListIncompleteUploads(ctx, bucket, "", true) {
 		if up.Err != nil {
-			continue
+			return fmt.Errorf("list incomplete uploads in %s: %w", bucket, up.Err)
 		}
-		_ = client.RemoveIncompleteUpload(ctx, bucket, up.Key)
+		if err := client.RemoveIncompleteUpload(ctx, bucket, up.Key); err != nil {
+			return fmt.Errorf("abort multipart %s in %s: %w", up.Key, bucket, err)
+		}
 	}
-	return client.RemoveBucket(ctx, bucket)
+
+	// Step 3 — delete the now-empty bucket; a 404 is idempotent success.
+	if err := client.RemoveBucket(ctx, bucket); err != nil {
+		if isNoSuchBucket(err) {
+			return nil
+		}
+		return fmt.Errorf("delete bucket %s: %w", bucket, err)
+	}
+	return nil
+}
+
+// isNoSuchBucket reports whether err is the canonical S3 "bucket does not
+// exist" signal (NoSuchBucket code or HTTP 404), so the empty+delete path can
+// treat an already-gone bucket as idempotent success. Mirrors the same guard
+// internal/hetzner/buckets.go uses.
+func isNoSuchBucket(err error) bool {
+	var errResp minio.ErrorResponse
+	if errors.As(err, &errResp) {
+		return errResp.Code == "NoSuchBucket" || errResp.StatusCode == http.StatusNotFound
+	}
+	return false
 }
 
 // isReclaimableOrphanOBSBucket is the pure match/protection predicate for the


### PR DESCRIPTION
## Problem — Refs #4872

Fresh prov `hw229` failed `tofu apply` with `Code=TooManyBuckets`: the OBS
account sat at its 100-bucket quota, full of orphans from wiped provs back to
`hw01`. Every prov's per-Sovereign OBS bucket outlived its wipe.

## Root cause (which of a/b/c) — **(a), refined**

`#4909` already shipped the per-Sovereign OBS purge (`purgeOBSBuckets`, wired
into `Provider.Wipe`) **and** the project-wide janitor sweep
(`SweepOrphanOBSBuckets`). Both share one helper — `emptyAndRemoveOBSBucket`
— which did empty-before-delete, but with a **serial, non-versioned,
error-swallowing** loop. That still leaked buckets three ways the incident
kept hitting:

1. **Serial `RemoveObject`** (one HTTP round-trip per key) could not drain a
   populated Harbor / Velero / CNPG backup bucket (thousands of blobs) within
   the 5-minute wipe budget → the loop timed out half-empty → the terminal
   `RemoveBucket` 409'd `BucketNotEmpty` → the bucket survived every wipe.
2. **No `WithVersions`** → on a versioned bucket the non-current versions +
   delete markers survived the empty → `RemoveBucket` failed `BucketNotEmpty`.
3. **Swallowed per-object error** (`_ = RemoveObject(...)`) → a single stuck
   object silently left the bucket non-empty **and** the caller was told the
   delete succeeded (phantom success). This is exactly the "delete without a
   complete empty / swallow the error" anti-pattern.

The canonical Hetzner purge (`internal/hetzner/buckets.go` `purgeBucket`)
already solved all three; the Huawei duplicate had drifted weaker.

## Fix — `internal/providers/huawei/provider.go:2557` (`emptyAndRemoveOBSBucket`)

Converged onto the battle-tested Hetzner semantics, signature unchanged so
**both** callers (`purgeOBSBuckets` per-deployment wipe + `SweepOrphanOBSBuckets`
janitor) inherit the fix:

- Fast `BucketExists` **404 idempotency** path (already-gone bucket → `nil`).
- `ListObjects{WithVersions:true, Recursive:true}` streamed into
  **`RemoveObjects`** → **version-aware, batched 1000/request** (~1000× fewer
  round-trips; drains large buckets well inside the timeout).
- **Abort every incomplete multipart upload** before delete.
- `RemoveBucket` with **404 tolerance**.
- **Surface** (never swallow) per-object delete errors — bounded summary,
  and on any failure it does **not** proceed to `RemoveBucket` (which would
  only 409 and mask the leak).

Idempotent + tolerant of already-gone buckets throughout.

## Test — `internal/providers/huawei/obs_bucket_purge_test.go` (new)

Fake-S3 (same harness shape as `hetzner/buckets_test.go`) driving the real
`emptyAndRemoveOBSBucket`:

- not-found bucket → idempotent success, no `DeleteBucket`;
- empty bucket → deleted;
- **1500 versions across 3 keys (with delete markers)** → all removed via
  paginated batched delete, then bucket deleted;
- in-progress multipart upload → **aborted before** `DeleteBucket`;
- per-object delete failure → **error surfaced** (names the stuck object) and
  bucket **NOT** deleted (no phantom success).

## Gates

- `go build ./...` ✅  `go vet ./internal/providers/huawei ./internal/handler` ✅
- `go test ./internal/providers/huawei ./internal/hetzner` ✅ (incl. 5 new tests)
- Full `api` module: only pre-existing unrelated failure
  `TestRegistryPivotV2MirrorUsesNodeReachableClusterIP` (cutover chart-pivot
  script; fails identically on pristine `origin/main`, different package,
  another agent's domain).

No NodePorts. No live infra touched. No IaC/tofu templates changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
