### PR TITLE
fix(#4973 #4975 #4961): comprehensive pod-spec image sweep in cutover step-07

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -804,7 +804,14 @@ spec:
       # hostNetwork fallback) so a fresh-node local-registry pull never depends on
       # the public DNS wildcard-vs-specific race (hw241 dead `*.omantel.biz`
       # 49.12.16.160 ImagePullBackOff). Still 11 steps / 10 job-mode.
-      version: 0.1.119
+      # 0.1.120 (#4973 #4975 #4961 Refs #4885): step-07 Phase 4 comprehensive
+      # pod-spec image sweep — rewrites the registry host of EVERY container +
+      # initContainer of every external-registry workload to registry.<fqdn> (via
+      # the shared offline-mirror resolver) so images pinned by full ref OUTSIDE
+      # global.imageRegistry (evs-csi CSI sidecars, continuum init/controller,
+      # flow-emitter) no longer wedge step-08's deny-egress roll-set. Still 11
+      # steps / 10 job-mode.
+      version: 0.1.120
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.119
+  version: 0.1.120
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,40 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.120 (#4973 #4975 #4961 Refs #4885 #3379 #3695 — the registry pivot was
+# INCOMPLETE: the step-07 HR global.imageRegistry patch only reaches images a
+# chart renders THROUGH that value, so images pinned by full ref OUTSIDE it stayed
+# tethered to a non-local host and wedged step-08's deny-egress roll-set →
+# ImagePullBackOff → cutoverComplete never set. Three open classes, one root:
+#   #4973 — evs-csi CSI SIDECARS (csi-provisioner/attacher/resizer/snapshotter/
+#           livenessprobe/node-driver-registrar) — confirmed live on hw241: a
+#           worker node's evs-csi-node driver couldn't pull post-pivot, so a fresh
+#           catalyst-api roll couldn't attach its RWO-EVS volume;
+#   #4975 — continuum's prerequisite-check INITCONTAINER (hardcoded
+#           harbor.openova.io/proxy-dockerhub/alpine/k8s ref set OUTSIDE
+#           global.imageRegistry) + the continuum-controller ghcr tether;
+#   #4961 — bp-openova-flow-emitter (+ possible siblings) under the step-08
+#           generalized fresh-pull.
+# FIX (template 07 Phase 4 + values): rather than chase each chart-helper (the
+# shallow per-workload allowlist that keeps missing the NEXT un-pivoted image),
+# step-07 now runs a COMPREHENSIVE pod-spec image sweep AFTER the HR pivots. It
+# discovers every external-registry workload (Deployment/DaemonSet/StatefulSet,
+# any ns) EXACTLY as step-08's roll-set does, and rewrites the registry host of
+# EVERY container + initContainer to registry.<fqdn> via the SAME offline-mirror
+# resolver step-03 (push) / step-04 (containerd) / step-08 (completeness gate)
+# share — so the sweep target is byte-identical to where the image lives locally.
+# Idempotent (skips already-local), presence-gated (never pivots onto an image the
+# local Harbor cannot serve — that stays for step-08 to name), fail-open (a tooling
+# gap never wedges the cutover; step-04's containerd rewrite is the durable
+# steady-state net), and reversible (records pre-sweep images in the
+# bp.openova.io/cutover-podspec-preimage pod-template annotation). New
+# values.imageRegistryPivot.podSpecSweep.{enabled,excludeWorkloadSubstring,
+# presenceGate}; new step-07 envs PODSPEC_SWEEP / PODSPEC_SWEEP_EXCLUDE /
+# PODSPEC_SWEEP_PRESENCE_GATE + the shared HOST_PROJECT_MAP / EXCLUDED_* /
+# LOCAL_REGISTRY_HOST + the cutover-offline-mirror-resolver mount. RBAC already
+# grants deployments/daemonsets/statefulsets patch (step-08 uses it). No
+# step-count / job-mode change (still 11 steps). cutover-contract Case 45 locks it.
+# Slot-06a pin + blueprint.yaml + catalog-seed source.version + spec.version move
+# to 0.1.120 in lockstep (Inviolable Principle #13; catalog-seed pin must NOT lag).
 # 0.1.119 (#5007 Refs #4682 #3379 — fresh-node local-registry pull breaks when the
 # public DNS wildcard shadows registry.<fqdn>; found LIVE on the hw241 cutover). After
 # the registry pivot the catalyst-api roll onto a fresh node failed
@@ -1868,7 +1903,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.119
+version: 0.1.120
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/07-catalyst-api-env-patch-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/07-catalyst-api-env-patch-job.yaml
@@ -33,6 +33,18 @@ pattern. Charts that do NOT honour global.imageRegistry (bp-guacamole,
 bp-huawei-evs-csi, bp-newapi, bp-sandbox, org-services marketplace/auth)
 need a separate per-chart templating fix and are excluded (#4885 residual).
 
+#4973 #4975 #4961 (Phase 4, comprehensive pod-spec sweep): the HR
+global.imageRegistry patches above only reach images a chart renders
+THROUGH global.imageRegistry. Images pinned by full ref OUTSIDE that
+value stay tethered to a non-local host and wedge step-08's deny-egress
+roll-set — evs-csi CSI sidecars (#4973), continuum's prerequisite-check
+initContainer (#4975), flow-emitter (#4961). Phase 4 sweeps EVERY
+container + initContainer of every external-registry workload and
+rewrites its registry host to registry.<fqdn> using the SAME
+offline-mirror resolver step-03/04/08 share — no per-chart-helper /
+per-image allowlist to drift. Idempotent, presence-gated, fail-open,
+reversible (records pre-sweep images in a pod-template annotation).
+
 Phase 2 (pre-G61): kubectl set env CATALYST_GITOPS_REPO_URL pointing
 catalyst-api at the local Gitea mirror. Triggers another rolling
 restart (likely already in-flight from Phase 1's HR upgrade, but
@@ -137,11 +149,204 @@ data:
             value: {{ .Values.catalystAPI.rollSafety.evsGate.enabled | quote }}
           - name: EVS_CSI_ZONE_LABEL
             value: {{ .Values.catalystAPI.rollSafety.evsGate.zoneLabel | quote }}
+          # #4973 #4975 #4961 — pod-spec image sweep (COMPREHENSIVE registry pivot).
+          # The G61/#4563/#4885 HR patches above only reach images a chart routes
+          # THROUGH global.imageRegistry. Sidecar images pinned by full ref
+          # (evs-csi CSI sidecars #4973), controller/init images set OUTSIDE
+          # global.imageRegistry (continuum's prerequisite-check initContainer
+          # #4975), and emitter images (#4961) keep a NON-local pod-spec ref, which
+          # step-08's roll-set then rolls under deny-egress → ImagePullBackOff →
+          # cutoverComplete never sets. This sweep is the SUSPENDERS to the HR-pivot
+          # BELT: after the HR pivots, rewrite the registry host of EVERY container +
+          # initContainer of every external-registry workload to registry.<fqdn>
+          # using the SAME offline-mirror resolver step-03/04/08 share (no per-image
+          # / per-workload allowlist to drift). Same env the resolver needs.
+          - name: PODSPEC_SWEEP
+            value: {{ eq (toString .Values.imageRegistryPivot.podSpecSweep.enabled) "true" | quote }}
+          - name: PODSPEC_SWEEP_EXCLUDE
+            value: {{ .Values.imageRegistryPivot.podSpecSweep.excludeWorkloadSubstring | default "catalyst-api" | quote }}
+          - name: PODSPEC_SWEEP_PRESENCE_GATE
+            value: {{ eq (toString .Values.imageRegistryPivot.podSpecSweep.presenceGate) "true" | quote }}
+          - name: LOCAL_REGISTRY_HOST
+            value: {{ include "bp-self-sovereign-cutover.localRegistryHost" . | quote }}
+          - name: HOST_PROJECT_MAP
+            value: {{ include "bp-self-sovereign-cutover.hostProjectMapInline" . | quote }}
+          - name: EXCLUDED_HOSTS
+            value: {{ include "bp-self-sovereign-cutover.excludedHostsInline" . | quote }}
+          - name: EXCLUDED_SUBSTRINGS
+            value: {{ include "bp-self-sovereign-cutover.excludedSubstringsInline" . | quote }}
         command: ["/bin/sh", "-c"]
         args:
           - |
             set -eu
             echo "[catalyst-api-env-patch] target=${DEPLOYMENT_NAMESPACE}/${DEPLOYMENT_NAME}"
+
+            # #4973 #4975 #4961 — the offline-mirror image→local-path resolver
+            # (shared with step-03/step-08). Defines offlinemirror_local_paths over
+            # the SAME HOST_PROJECT_MAP / EXCLUDED_* / LOCAL_REGISTRY_HOST env, so the
+            # pod-spec sweep (Phase 4 below) rewrites each container image to the EXACT
+            # local Harbor path step-03 pushed it to. Guard the source so a missing
+            # mount degrades to "sweep disabled" (fail-open), never a wedged step.
+            if [ -r /resolver/resolver.sh ]; then
+              . /resolver/resolver.sh
+            else
+              echo "[catalyst-api-env-patch] WARN /resolver/resolver.sh not mounted — pod-spec image sweep DISABLED this run"
+              PODSPEC_SWEEP="false"
+            fi
+
+            # ═══ #4973 #4975 #4961 pod-spec image sweep helpers ═══════════════
+            # The COMPREHENSIVE registry pivot. The HR global.imageRegistry patches
+            # below only reach images a chart routes through that value; these
+            # helpers rewrite the registry host of EVERY container + initContainer
+            # of every external-registry workload directly in its live pod-spec, so
+            # the fix does not depend on each chart helper being registry-aware
+            # (the recurring whack-a-mole: evs-csi CSI sidecars #4973, continuum's
+            # prerequisite-check initContainer #4975, flow-emitter #4961). Defined
+            # here; CALLED as Phase 4 after the HR pivots below.
+
+            # podspec_pivot_ref IMAGE -> the local-Harbor ref this image pivots to,
+            # or EMPTY to leave it alone (already local / excluded / unmapped). Reuses
+            # offlinemirror_local_paths so the target path is byte-identical to what
+            # step-03 pushed + step-08's completeness gate HEADs. For an openova-io
+            # ghcr ref the resolver returns BOTH the proxy-ghcr path AND the host-drop
+            # openova-io/<path>; we prefer the host-drop convention (what step-06/07
+            # produce, registry.<fqdn>/openova-io/…), else the single mapped path.
+            podspec_pivot_ref() {
+              _pi_img="$1"
+              [ -n "${_pi_img}" ] || { printf ''; return 0; }
+              # Already on the local registry → nothing to do (idempotent).
+              case "${_pi_img}" in
+                "${LOCAL_REGISTRY_HOST}"/*) printf ''; return 0 ;;
+              esac
+              # Only pivot images with an EXPLICIT external registry host (dotted /
+              # :port / localhost) — mirrors step-08's roll-set exactly. A bare
+              # `name[:tag]` or an implicit-docker.io `ns/name` (first segment has no
+              # dot) is NOT in step-08's roll-set and is already handled by the
+              # containerd mirror, so pivoting it would add needless rollout churn.
+              case "${_pi_img}" in
+                */*)
+                  _pi_host="${_pi_img%%/*}"
+                  case "${_pi_host}" in
+                    *.*|*:*|localhost) : ;;         # explicit registry host → eligible
+                    *) printf ''; return 0 ;;       # implicit docker.io (ns/name) → skip
+                  esac ;;
+                *) printf ''; return 0 ;;           # bare name[:tag] → implicit docker.io → skip
+              esac
+              _pi_paths=$(offlinemirror_local_paths "${_pi_img}" 2>/dev/null || true)
+              case "${_pi_paths}" in
+                __UNMAPPED__*) printf ''; return 0 ;;   # host not covered → leave; step-08 names it
+                "") printf ''; return 0 ;;               # excluded by design → skip
+              esac
+              _pi_chosen=""
+              for _pi_lp in ${_pi_paths}; do
+                case "${_pi_lp}" in
+                  openova-io/*) _pi_chosen="${_pi_lp}"; break ;;
+                esac
+                [ -z "${_pi_chosen}" ] && _pi_chosen="${_pi_lp}"
+              done
+              [ -n "${_pi_chosen}" ] || { printf ''; return 0; }
+              printf '%s/%s' "${LOCAL_REGISTRY_HOST}" "${_pi_chosen}"
+            }
+
+            # podspec_local_present LOCAL_REF -> 0 iff the local Harbor already serves
+            # this manifest. Never pivot a pod-spec onto an image the mirror cannot
+            # serve — leave it for step-08's completeness gate to name as the real
+            # offender rather than introducing a sweep-induced ImagePullBackOff.
+            # Handles both :tag and @digest refs (same split step-08 uses).
+            podspec_local_present() {
+              _pl_hp="${1#*/}"                       # drop the local host
+              case "${_pl_hp}" in
+                *@*) _pl_ref="${_pl_hp##*@}"; _pl_repo="${_pl_hp%@*}"; case "${_pl_repo##*/}" in *:*) _pl_repo="${_pl_repo%:*}" ;; esac ;;
+                *)   case "${_pl_hp##*/}" in *:*) _pl_ref="${_pl_hp##*:}"; _pl_repo="${_pl_hp%:*}" ;; *) _pl_ref="latest"; _pl_repo="${_pl_hp}" ;; esac ;;
+              esac
+              _pl_code=$(curl -sk -o /dev/null -w '%{http_code}' \
+                -u "${HARBOR_USERNAME:-admin}:${HARBOR_PASSWORD:-}" \
+                -H 'Accept: application/vnd.oci.image.index.v1+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json' \
+                -I "${HARBOR_PUBLIC_URL}/v2/${_pl_repo}/manifests/${_pl_ref}" 2>/dev/null || true)
+              case "${_pl_code}" in 200|301|302) return 0 ;; *) return 1 ;; esac
+            }
+
+            # sweep_one_workload KIND NS NAME — rewrite every container + initContainer
+            # image of ONE workload to its local-Harbor ref via a strategic-merge patch
+            # (merge key = container name → only .image changes). Records the pre-sweep
+            # images in the bp.openova.io/cutover-podspec-preimage annotation so the
+            # pivot is auditable + reversible on rollback. Best-effort/idempotent.
+            sweep_one_workload() {
+              _sw_kind="$1"; _sw_ns="$2"; _sw_name="$3"
+              _sw_json=$(kubectl get "${_sw_kind}" "${_sw_name}" -n "${_sw_ns}" -o json 2>/dev/null || true)
+              [ -n "${_sw_json}" ] || return 0
+              _sw_changes="/tmp/podspec-sweep-${_sw_kind}-${_sw_ns}-${_sw_name}.$$"
+              : > "${_sw_changes}"
+              # Rows: "<containers|initContainers>\t<name>\t<image>"
+              printf '%s' "${_sw_json}" | jq -r '
+                (.spec.template.spec.containers // [])[]     | "containers\t\(.name)\t\(.image)",
+                (.spec.template.spec.initContainers // [])[] | "initContainers\t\(.name)\t\(.image)"
+              ' 2>/dev/null | while IFS="$(printf '\t')" read -r _sw_ctype _sw_cname _sw_cimg; do
+                [ -n "${_sw_cname}" ] || continue
+                _sw_new=$(podspec_pivot_ref "${_sw_cimg}")
+                [ -n "${_sw_new}" ] || continue          # excluded/unmapped/already-local
+                [ "${_sw_new}" = "${_sw_cimg}" ] && continue
+                if [ "${PODSPEC_SWEEP_PRESENCE_GATE:-true}" = "true" ] && ! podspec_local_present "${_sw_new}"; then
+                  echo "[catalyst-api-env-patch]     SKIP ${_sw_kind}/${_sw_name} [${_sw_ctype}/${_sw_cname}] ${_sw_cimg} -> ${_sw_new} (not yet in local Harbor; step-08 completeness gate will name it if it is a real gap)"
+                  continue
+                fi
+                printf '%s\t%s\t%s\t%s\n' "${_sw_ctype}" "${_sw_cname}" "${_sw_cimg}" "${_sw_new}" >> "${_sw_changes}"
+              done
+              if [ ! -s "${_sw_changes}" ]; then rm -f "${_sw_changes}"; return 0; fi
+              # Build the strategic-merge patch + pre-image annotation from the changes.
+              _sw_patch=$(jq -Rn '
+                [inputs | split("\t") | {ctype: .[0], name: .[1], old: .[2], new: .[3]}]
+                | {
+                    spec: { template: {
+                      metadata: { annotations: {
+                        "bp.openova.io/cutover-podspec-preimage": ( map({(.name): .old}) | add | tojson )
+                      } },
+                      spec: (
+                        reduce (group_by(.ctype)[]) as $g ({};
+                          .[$g[0].ctype] = [ $g[] | {name: .name, image: .new} ])
+                      )
+                    } }
+                  }' "${_sw_changes}" 2>/dev/null || true)
+              if [ -z "${_sw_patch}" ]; then
+                echo "[catalyst-api-env-patch]     WARN could not build sweep patch for ${_sw_kind}/${_sw_name} (skipping)"
+                rm -f "${_sw_changes}"; return 0
+              fi
+              if kubectl patch "${_sw_kind}" "${_sw_name}" -n "${_sw_ns}" --type=strategic -p "${_sw_patch}" >/dev/null 2>&1; then
+                echo "[catalyst-api-env-patch]     PIVOTED ${_sw_kind}/${_sw_name} -n ${_sw_ns}:"
+                awk -F"$(printf '\t')" '{print "[catalyst-api-env-patch]       "$2": "$3" -> "$4}' "${_sw_changes}"
+              else
+                echo "[catalyst-api-env-patch]     WARN failed to patch ${_sw_kind}/${_sw_name} pod-spec images (best-effort; step-04 containerd rewrite still covers the pull)"
+              fi
+              rm -f "${_sw_changes}"
+            }
+
+            # sweep_workload_podspec_images — discover every external-registry workload
+            # (Deployment/DaemonSet/StatefulSet, any ns) EXACTLY as step-08's roll-set
+            # does, and pivot each one's pod-spec images to local. After this, step-08
+            # finds no external-registry workload left to roll (or every remaining one
+            # is a real un-mirrored offender its completeness gate already named). Not
+            # an allowlist — the discovery is generic; the exclusions mirror step-08's.
+            sweep_workload_podspec_images() {
+              [ "${PODSPEC_SWEEP:-true}" = "true" ] || { echo "[catalyst-api-env-patch] #4973/#4975/#4961 pod-spec image sweep DISABLED (PODSPEC_SWEEP=${PODSPEC_SWEEP:-})"; return 0; }
+              command -v offlinemirror_local_paths >/dev/null 2>&1 || { echo "[catalyst-api-env-patch] WARN resolver not sourced — pod-spec sweep skipped"; return 0; }
+              command -v jq >/dev/null 2>&1 || { echo "[catalyst-api-env-patch] WARN jq unavailable — pod-spec sweep skipped"; return 0; }
+              [ -n "${HOST_PROJECT_MAP:-}" ] || { echo "[catalyst-api-env-patch] WARN empty HOST_PROJECT_MAP (offline mirror off?) — pod-spec sweep skipped"; return 0; }
+              echo "[catalyst-api-env-patch] #4973/#4975/#4961 pod-spec image sweep: pivoting every container+initContainer of every external-registry workload to ${LOCAL_REGISTRY_HOST}"
+              for _sw_k in deployments daemonsets statefulsets; do
+                kubectl get "${_sw_k}" -A \
+                  -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' 2>/dev/null \
+                | while IFS=' ' read -r _sw_ns _sw_name; do
+                    [ -n "${_sw_ns}" ] && [ -n "${_sw_name}" ] || continue
+                    # Never sweep the cutover engine's own catalyst-api (pivoted via
+                    # the bp-catalyst-platform HR + env roll below).
+                    if [ -n "${PODSPEC_SWEEP_EXCLUDE:-}" ]; then
+                      case "${_sw_name}" in *"${PODSPEC_SWEEP_EXCLUDE}"*) continue ;; esac
+                    fi
+                    sweep_one_workload "${_sw_k}" "${_sw_ns}" "${_sw_name}" || true
+                  done
+              done
+              echo "[catalyst-api-env-patch] #4973/#4975/#4961 pod-spec image sweep complete"
+            }
 
             # ═══ #4996 (Refs #4972 #4885) pre-roll safety gates ═══════════════
             # Step-07 pivots catalyst-api's imageRegistry → local Harbor then rolls
@@ -665,7 +870,21 @@ data:
               esac
               echo "[catalyst-api-env-patch] Phase 3 OK: ${VAR}=${LIVE}"
             done
-            echo "[catalyst-api-env-patch] done (Phases 1-3 complete)"
+
+            # ---- Phase 4 (#4973 #4975 #4961): comprehensive pod-spec image sweep ----
+            # The HR global.imageRegistry pivots above (Phases 1-2 + the additionalHRs
+            # loop) only reach images a chart renders THROUGH global.imageRegistry.
+            # Images pinned by full ref OUTSIDE that value stay tethered to a non-local
+            # host and would wedge step-08's roll-set: evs-csi CSI sidecars (#4973),
+            # continuum's prerequisite-check initContainer (#4975), flow-emitter (#4961).
+            # This sweep normalises EVERY container + initContainer of every
+            # external-registry workload to registry.<fqdn> so no pod-spec carries a
+            # non-local ref into the deny-egress hold. Fail-open (a tooling gap never
+            # wedges the cutover worse than the pre-sweep state; step-04's containerd
+            # rewrite is the durable steady-state safety net).
+            sweep_workload_podspec_images || echo "[catalyst-api-env-patch] #4973/#4975/#4961 WARN pod-spec image sweep incomplete (best-effort; step-04 containerd rewrite still covers pulls)"
+
+            echo "[catalyst-api-env-patch] done (Phases 1-4 complete)"
         resources:
           requests: { cpu: 50m, memory: 64Mi }
           limits:   { memory: 256Mi }
@@ -685,6 +904,19 @@ data:
         volumeMounts:
           - name: tmp
             mountPath: /tmp
+          # #4973 #4975 #4961 — the shared offline-mirror resolver (same file
+          # step-03/step-08 source), so the pod-spec sweep maps each image to the
+          # EXACT local Harbor path step-03 Phase A3 pushed it to (never a forked
+          # mapping that could target a path the mirror never held).
+          - name: offline-mirror-resolver
+            mountPath: /resolver
+            readOnly: true
     volumes:
       - name: tmp
         emptyDir: {}
+      - name: offline-mirror-resolver
+        configMap:
+          name: cutover-offline-mirror-resolver
+          items:
+            - key: resolver.sh
+              path: resolver.sh

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -1756,4 +1756,81 @@ if ! grep -A1 'name: LOCAL_REGISTRY_PIN_ENABLED' "$TMP/render.yaml" | grep -q 'v
 fi
 echo "  PASS (step-04 pins registry.<fqdn> to the gateway VIP on the node /etc/hosts; LB-ingress VIP with HOST_IP hostNetwork fallback; DNS-free; removed on rollback; default enabled)"
 
+echo "[cutover-contract] Case 45: Step-07 runs a COMPREHENSIVE pod-spec image sweep — every container + initContainer of every external-registry workload pivots to registry.<fqdn>, not just images honouring global.imageRegistry (#4973 #4975 #4961, Refs #4885 #3379)"
+# The HR global.imageRegistry patch only reaches images a chart renders THROUGH
+# that value; images pinned by full ref OUTSIDE it (evs-csi CSI sidecars #4973,
+# continuum's prerequisite-check initContainer #4975, flow-emitter #4961) stayed
+# tethered to a non-local host and wedged step-08's deny-egress roll-set. 0.1.120
+# adds a Phase-4 sweep that discovers external-registry workloads like step-08
+# does and rewrites EVERY container+initContainer image to the local Harbor path
+# via the SAME offline-mirror resolver. Slice step-07's CM.
+awk '/cutover-step-07-catalyst-api-env-patch/{c=1} c{print} c&&/cutover-order: "8"/{exit}' "$TMP/render.yaml" > "$TMP/step07_sweep.txt"
+[ -s "$TMP/step07_sweep.txt" ] || cp "$TMP/render.yaml" "$TMP/step07_sweep.txt"
+# (1) the sweep function + its call are present.
+if ! grep -q 'sweep_workload_podspec_images()' "$TMP/step07_sweep.txt"; then
+  echo "FAIL: Step-07 missing sweep_workload_podspec_images() — the comprehensive pod-spec pivot (#4973 #4975 #4961)" >&2
+  exit 1
+fi
+if ! grep -q 'sweep_workload_podspec_images ||' "$TMP/step07_sweep.txt"; then
+  echo "FAIL: Step-07 never CALLS sweep_workload_podspec_images (fail-open) — the sweep would be dead code (#4973 #4975 #4961)" >&2
+  exit 1
+fi
+# (2) the sweep must run AFTER the HR imageRegistry pivot (it is the suspenders to
+# the HR-pivot belt) — Phase 4 after Phase 1's G61 HR patch.
+sweep_ln=$(awk 'index($0,"sweep_workload_podspec_images ||"){print NR; exit}' "$TMP/step07_sweep.txt")
+hrpivot_ln=$(awk 'index($0,"G61 HR patch"){print NR; exit}' "$TMP/step07_sweep.txt")
+if [ -z "$sweep_ln" ] || [ -z "$hrpivot_ln" ] || [ "$sweep_ln" -le "$hrpivot_ln" ]; then
+  echo "FAIL: Step-07 pod-spec sweep (line ${sweep_ln:-?}) must run AFTER the HR imageRegistry pivot (line ${hrpivot_ln:-?}) (#4973 #4975 #4961)" >&2
+  exit 1
+fi
+# (3) it sweeps BOTH containers AND initContainers (continuum #4975 is an initContainer).
+if ! grep -q 'initContainers' "$TMP/step07_sweep.txt"; then
+  echo "FAIL: Step-07 sweep does not cover initContainers — misses continuum's prerequisite-check init image (#4975)" >&2
+  exit 1
+fi
+# (4) it reuses the SHARED offline-mirror resolver (no forked mapping) — the CM is
+# mounted and offlinemirror_local_paths is used.
+if ! grep -q 'offlinemirror_local_paths' "$TMP/step07_sweep.txt"; then
+  echo "FAIL: Step-07 sweep does not use the shared offlinemirror_local_paths resolver — a forked mapping could target a path the mirror never held (#4975)" >&2
+  exit 1
+fi
+if ! grep -q 'name: cutover-offline-mirror-resolver' "$TMP/step07_sweep.txt"; then
+  echo "FAIL: Step-07 does not mount the shared cutover-offline-mirror-resolver ConfigMap — offlinemirror_local_paths would be undefined at runtime (#4973 #4975 #4961)" >&2
+  exit 1
+fi
+# (5) presence-gated (never pivots onto an image the local Harbor cannot serve).
+if ! grep -q 'podspec_local_present' "$TMP/step07_sweep.txt"; then
+  echo "FAIL: Step-07 sweep missing the presence gate (podspec_local_present) — could induce an ImagePullBackOff by pivoting onto an unmirrored ref (#4975)" >&2
+  exit 1
+fi
+# (6) reversible — records the pre-sweep images in a pod-template annotation.
+if ! grep -q 'bp.openova.io/cutover-podspec-preimage' "$TMP/step07_sweep.txt"; then
+  echo "FAIL: Step-07 sweep does not record pre-sweep images (bp.openova.io/cutover-podspec-preimage) — not reversible (#4973 #4975 #4961)" >&2
+  exit 1
+fi
+# (7) default enabled (fail-safe robustness posture — the deny-egress proof cannot
+# go green while any pod-spec still carries a non-local ref).
+if ! grep -A1 'name: PODSPEC_SWEEP$' "$TMP/step07_sweep.txt" | grep -q 'value: "true"'; then
+  echo "FAIL: PODSPEC_SWEEP must DEFAULT to enabled (rendered value != \"true\") (#4973 #4975 #4961)" >&2
+  exit 1
+fi
+# (8) the resolver env the sweep needs is wired on step-07.
+for _e in HOST_PROJECT_MAP LOCAL_REGISTRY_HOST EXCLUDED_HOSTS EXCLUDED_SUBSTRINGS; do
+  if ! grep -q "name: ${_e}$" "$TMP/step07_sweep.txt"; then
+    echo "FAIL: Step-07 missing ${_e} env — the shared resolver needs it (#4973 #4975 #4961)" >&2
+    exit 1
+  fi
+done
+# (9) RBAC: the runner must patch deployments + daemonsets + statefulsets (the sweep
+# strategic-merges the pod-spec image). Already granted (step-08 rolls them).
+if ! awk '/^kind: ClusterRole$/,/^---$/' "$TMP/render.yaml" | grep -A3 '"daemonsets", "statefulsets"' | grep -q '"patch"'; then
+  echo "FAIL: ClusterRole missing apps/daemonsets+statefulsets patch — the pod-spec sweep will 403 (#4973 #4975 #4961)" >&2
+  exit 1
+fi
+if ! awk '/^kind: ClusterRole$/,/^---$/' "$TMP/render.yaml" | grep -A3 'resources: \["deployments"\]' | grep -q '"patch"'; then
+  echo "FAIL: ClusterRole missing apps/deployments patch — the pod-spec sweep will 403 (#4973 #4975 #4961)" >&2
+  exit 1
+fi
+echo "  PASS (Step-07 Phase 4 comprehensive pod-spec sweep: containers+initContainers, shared resolver, presence-gated, reversible annotation, default enabled; RBAC wired)"
+
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -929,6 +929,41 @@ imageRegistryPivot:
       namespace: flux-system
       slotFile: clusters/_template/bootstrap-kit/51-bp-k8s-ws-proxy.yaml
 
+  # #4973 #4975 #4961 — COMPREHENSIVE pod-spec image sweep (step-07 Phase 4).
+  #
+  # THE WHACK-A-MOLE, ROOTED. additionalHRs above pivots an HR's
+  # spec.values.global.imageRegistry — which only reaches images the chart
+  # renders THROUGH that value. Three classes slip through and keep a NON-local
+  # pod-spec ref, which step-08's roll-set then rolls under the deny-egress hold
+  # → ImagePullBackOff → cutoverComplete never sets:
+  #   • #4973 — evs-csi CSI SIDECARS (csi-provisioner/attacher/resizer/
+  #     snapshotter/livenessprobe/node-driver-registrar) pinned by full ref;
+  #   • #4975 — continuum's prerequisite-check INITCONTAINER, whose image is a
+  #     hardcoded harbor.openova.io/proxy-dockerhub/alpine/k8s ref set OUTSIDE
+  #     global.imageRegistry, AND the continuum-controller ghcr tether;
+  #   • #4961 — bp-openova-flow-emitter (+ siblings) whose helper ignores the
+  #     value on some paths.
+  # Rather than chase each chart-helper (the shallow per-workload allowlist that
+  # keeps missing the NEXT un-pivoted image), step-07 Phase 4 sweeps EVERY
+  # container + initContainer of every external-registry workload and rewrites
+  # its registry host to registry.<fqdn> using the SAME offline-mirror resolver
+  # step-03 (push) / step-04 (containerd) / step-08 (completeness gate) share —
+  # so the sweep target is byte-identical to where the image actually lives
+  # locally. This is the SUSPENDERS to the HR-pivot BELT and the step-04
+  # containerd-rewrite (which remains the durable steady-state safety net after a
+  # Flux reconcile reverts a non-honouring chart's pod-spec ref).
+  podSpecSweep:
+    # Default ON — the deny-egress proof cannot go green while any pod-spec still
+    # carries a non-local ref; disabling this re-opens the whack-a-mole.
+    enabled: true
+    # Never sweep the cutover engine's own catalyst-api (step-07 pivots it via the
+    # bp-catalyst-platform HR + env roll above). Substring match on workload name.
+    excludeWorkloadSubstring: "catalyst-api"
+    # Refuse to pivot a pod-spec image onto a ref the local Harbor does not yet
+    # serve — leave it as-is so step-08's completeness gate names the REAL offender
+    # instead of a sweep-induced ImagePullBackOff. Keep ON.
+    presenceGate: true
+
 # Step container images. The first three steps (01..03) + the
 # registry-pivot DaemonSet use upstream-public images because they run
 # BEFORE registries.yaml v2 takes effect on the node containerd.

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5041,7 +5041,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.119"
+  version: "0.1.120"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.119"
+    version: "0.1.120"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Problem

The self-sovereignty cutover's **registry pivot is incomplete**. Step-07's per-HR `spec.values.global.imageRegistry` patch only reaches images a chart renders **through** that value. Images pinned by full ref **outside** it stay tethered to a non-local host and wedge step-08's deny-egress roll-set → `ImagePullBackOff` → `cutoverComplete` never sets. Three open in-progress issues, one root cause:

- **#4973** — `huawei-evs-csi` CSI **sidecars** (csi-provisioner/attacher/resizer/snapshotter/livenessprobe/node-driver-registrar). Confirmed live on hw241: a worker node's evs-csi-node driver couldn't pull post-pivot, so a fresh catalyst-api roll couldn't attach its RWO-EVS volume. Load-bearing.
- **#4975** — `continuum`'s prerequisite-check **initContainer** (hardcoded `harbor.openova.io/proxy-dockerhub/alpine/k8s` ref set outside `global.imageRegistry`) + the continuum-controller ghcr tether.
- **#4961** — cutover step-08 wedges on un-pivoted `bp-openova-flow-emitter` (+ possible siblings).

Chasing each chart helper is the shallow per-workload allowlist that keeps missing the *next* un-pivoted image.

## Fix — comprehensive pod-spec sweep (step-07 Phase 4)

Rather than an allowlist, step-07 now runs a **comprehensive pod-spec image sweep** *after* the HR pivots:

- Discovers **every external-registry workload** (Deployment/DaemonSet/StatefulSet, any ns) **exactly as step-08's roll-set does** (explicit-host refs only; skips implicit-docker.io + excluded hosts/substrings).
- Rewrites the registry host of **every container + initContainer** to `registry.<fqdn>` via the **same `offlinemirror_local_paths` resolver** step-03 (push) / step-04 (containerd) / step-08 (completeness gate) share — so the sweep target is byte-identical to where the image actually lives locally (host-drop for `openova-io/*`, proxy-project for third-party, host-swap for the mothership).
- **Idempotent** (skips already-local), **presence-gated** (never pivots onto a ref the local Harbor cannot yet serve — that stays for step-08's completeness gate to name), **fail-open** (a tooling gap never wedges the cutover; step-04's containerd rewrite is the durable steady-state net), **reversible** (records pre-sweep images in the `bp.openova.io/cutover-podspec-preimage` pod-template annotation).

Each of the 3 named workloads is covered by construction — verified by unit-testing the resolver-driven mapping:

| workload | example image | pivots to |
|---|---|---|
| #4973 evs-csi sidecar | `harbor.openova.io/proxy-k8s/sig-storage/csi-provisioner:v3.0.0` | `registry.<fqdn>/proxy-k8s/sig-storage/csi-provisioner:v3.0.0` |
| #4973 evs-csi driver | `ghcr.io/openova-io/openova/evs-csi-plugin:…` | `registry.<fqdn>/openova-io/openova/evs-csi-plugin:…` |
| #4975 continuum init | `harbor.openova.io/proxy-dockerhub/alpine/k8s:1.30.0` | `registry.<fqdn>/proxy-dockerhub/alpine/k8s:1.30.0` |
| #4975 continuum-controller | `ghcr.io/openova-io/openova/continuum-controller:…` | `registry.<fqdn>/openova-io/openova/continuum-controller:…` |
| #4961 flow-emitter | `ghcr.io/openova-io/openova/openova-flow-adapter-flux:…` | `registry.<fqdn>/openova-io/openova/openova-flow-adapter-flux:…` |

## Changes

- `templates/07-catalyst-api-env-patch-job.yaml`: source the shared resolver, add the sweep helpers (`podspec_pivot_ref` / `podspec_local_present` / `sweep_one_workload` / `sweep_workload_podspec_images`) + Phase-4 call; new `PODSPEC_SWEEP*` + `HOST_PROJECT_MAP` / `EXCLUDED_*` / `LOCAL_REGISTRY_HOST` env; mount `cutover-offline-mirror-resolver`.
- `values.yaml`: `imageRegistryPivot.podSpecSweep.{enabled,excludeWorkloadSubstring,presenceGate}` (default-safe).
- `tests/cutover-contract.sh`: **Case 45** locks the sweep (containers+initContainers, shared resolver, presence gate, reversible annotation, default enabled, RBAC). Still 11 steps.
- Chart **0.1.119 → 0.1.120** in lockstep: `Chart.yaml` + `blueprint.yaml` + `06a` bootstrap-kit slot pin + catalog-seed `source.version` + `spec.version`.
- RBAC unchanged — step-08 already patches deployments/daemonsets/statefulsets.

## Verification (offline; live cutover proof deferred to next prov's cutover walk)

- `helm lint` ✅, `helm template` ✅
- `sh -n` on the rendered step-07 script ✅
- resolver-driven pivot mapping unit-tested for all 3 workloads + idempotency/exclusions ✅
- jq strategic-merge patch builder produces a valid by-name container patch + reversibility annotation ✅
- `tests/cutover-contract.sh` — **all 45 cases green** (incl. new Case 45) ✅
- `tests/image-registry-coverage.sh --self-test` + repo scan ✅

Refs #4973 #4975 #4961

🤖 Generated with [Claude Code](https://claude.com/claude-code)