### PR TITLE
fix(#5011): step-01 gitea-mirror pushes explicit refspecs — never prunes sovereign-local branches

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -811,7 +811,14 @@ spec:
       # global.imageRegistry (evs-csi CSI sidecars, continuum init/controller,
       # flow-emitter) no longer wedge step-08's deny-egress roll-set. Still 11
       # steps / 10 job-mode.
-      version: 0.1.120
+      # 0.1.121 (#5011 Refs #3379 #4991): step-01 gitea-mirror pushes EXPLICIT
+      # refspecs (refs/heads/* + refs/tags/*, --force) instead of a mirror-mode
+      # push — mirror mode deleted the sovereign-LOCAL branches catalog-sovereign
+      # (catalyst-api catalog seed) + org-tenants (org-controller per-Org GitOps
+      # tree) from the local Gitea mid-cutover (hw242), breaking both flux
+      # GitRepositories. Explicit refspecs never prune remote-only refs. Still 11
+      # steps / 10 job-mode.
+      version: 0.1.121
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.120
+  version: 0.1.121
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,27 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.121 (#5011 Refs #3379 #4991 — step-01 gitea-mirror's mirror-mode force-push
+# PRUNED sovereign-local Gitea branches; found LIVE on hw242, dep f05b0718dac62fe9,
+# 2026-07-12 — the first-ever post-step-01 GitOps observation: prior cycles walked
+# BEFORE cutover, so this class was structurally hidden). `git push --mirror` makes
+# the remote EXACTLY match the fresh bare clone of GitHub — it DELETES refs absent
+# upstream. The sovereign-LOCAL branches `catalog-sovereign` (catalyst-api catalog
+# seed) and `org-tenants` (org-controller per-Org GitOps tree) live ONLY in the
+# local Gitea openova/openova repo, never on GitHub → both pruned → the flux
+# GitRepositories openova-catalog-sovereign + openova-org-tenants flipped
+# ready=False ("couldn't find remote ref") mid-cutover, killing the per-Org GitOps
+# tree (funnel Launch → app serves, #4991 class) + the sovereign catalog leg while
+# steps 05/06 were about to patch/push those same sources.
+# FIX (template 01): the push now enumerates ONLY the refs the mirror OWNS —
+# `git push --force <local> 'refs/heads/*:refs/heads/*' 'refs/tags/*:refs/tags/*'`
+# — force-updating/creating every GitHub-derived branch + tag (idempotent re-runs,
+# survives upstream history rewrites) while NEVER deleting remote-only refs. No
+# values change, no other template change (the default-off G75-severed
+# mirror-resync CronJob is a pre-existing separate surface). No step-count /
+# job-mode change (still 11 steps). cutover-contract Case 46 locks the explicit
+# refspecs + bans the mirror flag from the rendered step-01 script.
+# Slot-06a pin + blueprint.yaml + catalog-seed source.version + spec.version move
+# to 0.1.121 in lockstep (Inviolable Principle #13; catalog-seed pin must NOT lag).
 # 0.1.120 (#4973 #4975 #4961 Refs #4885 #3379 #3695 — the registry pivot was
 # INCOMPLETE: the step-07 HR global.imageRegistry patch only reaches images a
 # chart renders THROUGH that value, so images pinned by full ref OUTSIDE it stayed
@@ -1903,7 +1925,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.120
+version: 0.1.121
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/01-gitea-mirror-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/01-gitea-mirror-job.yaml
@@ -218,10 +218,19 @@ data:
               echo "[gitea-mirror] empty repo created"
             fi
 
-            # 3. Bare-clone upstream and push to local Gitea. --mirror
-            #    pushes ALL refs (every branch + tag), --force makes
-            #    re-runs idempotent (the upstream may have rewritten
-            #    history; we want local to match exactly).
+            # 3. Bare-clone upstream and push to local Gitea via EXPLICIT
+            #    refspecs — refs/heads/* + refs/tags/* — NEVER mirror mode
+            #    (#5011). Mirror mode makes the remote EXACTLY match the
+            #    clone, DELETING refs absent upstream; on hw242 (2026-07-12,
+            #    dep f05b0718dac62fe9) it pruned the sovereign-LOCAL branches
+            #    `catalog-sovereign` (catalyst-api catalog seed) and
+            #    `org-tenants` (org-controller per-Org GitOps tree) — both
+            #    exist ONLY in the local Gitea, never on GitHub — breaking
+            #    the flux GitRepositories openova-catalog-sovereign +
+            #    openova-org-tenants mid-cutover. The explicit refspecs
+            #    force-update/create every GitHub-derived branch + tag
+            #    (--force keeps re-runs idempotent even after an upstream
+            #    history rewrite) but never touch remote-only refs.
             export HOME=/tmp
             git config --global user.name "self-sovereign-cutover"
             git config --global user.email "cutover@${gitea_host}"
@@ -233,15 +242,15 @@ data:
             echo "[gitea-mirror] cloning ${UPSTREAM_REPO_URL} (bare)"
             git clone --bare "${UPSTREAM_REPO_URL}" upstream.git >/dev/null 2>&1
             cd upstream.git
-            echo "[gitea-mirror] pushing all refs to ${redacted_url}"
-            push_err=$(git push --mirror --force "${local_url}" 2>&1) || {
+            echo "[gitea-mirror] pushing upstream branches + tags (explicit refspecs, never prunes sovereign-local refs) to ${redacted_url}"
+            push_err=$(git push --force "${local_url}" 'refs/heads/*:refs/heads/*' 'refs/tags/*:refs/tags/*' 2>&1) || {
               echo "[gitea-mirror] FATAL: git push to local Gitea failed" >&2
               # Surface git stderr WITHOUT the embedded credential — git
               # redacts URLs in error messages by default but be defensive.
               printf '%s\n' "${push_err}" | sed -E "s,${GITEA_PAT}+,REDACTED,g" >&2
               exit 1
             }
-            echo "[gitea-mirror] pushed all refs successfully"
+            echo "[gitea-mirror] pushed all upstream branches + tags successfully (sovereign-local refs untouched)"
 
             # 4. Verify by reading back the default branch SHA and
             #    confirming non-empty (auto_init=false means a missing
@@ -261,7 +270,7 @@ data:
 
             # G75 #2622 (2026-05-31): SEVER UPSTREAM GIT TETHER (ADR-0002
             # Pillar 5 contract). gitea-mirror-resync CronJob runs every
-            # 5min doing `git push --mirror --force` from upstream → local
+            # 5min doing a mirror-mode force-push from upstream → local
             # Gitea, which CLOBBERS cutover Step 06+07 pushes. G62
             # "Gitea persist" pattern has been a no-op architecturally
             # because of this tether — Step 06+07 pushes survive ~5min

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -1833,4 +1833,47 @@ if ! awk '/^kind: ClusterRole$/,/^---$/' "$TMP/render.yaml" | grep -A3 'resource
 fi
 echo "  PASS (Step-07 Phase 4 comprehensive pod-spec sweep: containers+initContainers, shared resolver, presence-gated, reversible annotation, default enabled; RBAC wired)"
 
+echo "[cutover-contract] Case 46: Step-01 gitea-mirror pushes EXPLICIT refspecs (refs/heads/* + refs/tags/*) — never mirror mode, never prunes sovereign-local branches (#5011, Refs #3379 #4991)"
+# hw242 live (dep f05b0718dac62fe9, 2026-07-12): step-01's mirror-mode force-push
+# made the local Gitea openova/openova EXACTLY match a fresh bare clone of GitHub,
+# DELETING the sovereign-LOCAL branches catalog-sovereign (catalyst-api catalog
+# seed) + org-tenants (org-controller per-Org GitOps tree) — both exist ONLY in
+# the local Gitea — so the flux GitRepositories openova-catalog-sovereign +
+# openova-org-tenants flipped ready=False ("couldn't find remote ref") mid-cutover.
+# The durable contract: the push must enumerate the refs the mirror OWNS
+# (upstream branches + tags, force so re-runs stay idempotent) and must NEVER run
+# in mirror mode, which prunes refs it did not create. Slice step-01's CM (same
+# pattern as Case 45's step-07 slice — from the CM name to the next step's order
+# label).
+awk '/cutover-step-01-gitea-mirror/{c=1} c{print} c&&/cutover-order: "2"/{exit}' "$TMP/render.yaml" > "$TMP/step01_mirror.txt"
+[ -s "$TMP/step01_mirror.txt" ] || cp "$TMP/render.yaml" "$TMP/step01_mirror.txt"
+# (1) the push uses the explicit refspec pair — updates/creates every
+# GitHub-derived branch + tag, deletes nothing.
+if ! grep -qF "git push --force" "$TMP/step01_mirror.txt"; then
+  echo "FAIL: Step-01 missing the explicit-refspec force-push (git push --force) (#5011)" >&2
+  exit 1
+fi
+if ! grep -qF "'refs/heads/*:refs/heads/*'" "$TMP/step01_mirror.txt"; then
+  echo "FAIL: Step-01 push missing the refs/heads/*:refs/heads/* refspec — upstream branches would not sync (#5011)" >&2
+  exit 1
+fi
+if ! grep -qF "'refs/tags/*:refs/tags/*'" "$TMP/step01_mirror.txt"; then
+  echo "FAIL: Step-01 push missing the refs/tags/*:refs/tags/* refspec — upstream tags would not sync (#5011)" >&2
+  exit 1
+fi
+# (2) mirror mode is BANNED in step-01: --mirror makes the remote exactly match
+# the clone and DELETES refs absent upstream (the hw242 prune). Zero occurrences
+# allowed in the step-01 script — flag, comments, anywhere.
+if grep -qF -- '--mirror' "$TMP/step01_mirror.txt"; then
+  echo "FAIL: Step-01 contains '--mirror' — mirror mode prunes sovereign-local branches (catalog-sovereign, org-tenants) (#5011)" >&2
+  exit 1
+fi
+# (3) both refspecs ride the SAME push invocation as --force (idempotent re-runs
+# after an upstream history rewrite) — not a separate non-force push.
+if ! grep -E 'git push --force .*refs/heads/\*:refs/heads/\*.*refs/tags/\*:refs/tags/\*' "$TMP/step01_mirror.txt" >/dev/null; then
+  echo "FAIL: Step-01 explicit refspecs must ride the single 'git push --force' invocation (#5011)" >&2
+  exit 1
+fi
+echo "  PASS (Step-01 pushes refs/heads/* + refs/tags/* explicitly with --force; mirror mode absent — sovereign-local branches survive)"
+
 echo "[cutover-contract] All gates green."

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5041,7 +5041,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.120"
+  version: "0.1.121"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.120"
+    version: "0.1.121"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
Durable fix for #5011 (Refs #5011, not Closes — live cutover proof pends the next cutover walk).

**Defect (proven live on hw242):** step-01 gitea-mirror pushed a fresh bare clone of the GitHub monorepo with `git push --mirror --force`. Mirror mode makes the remote exactly match the clone — deleting refs absent upstream — which pruned the two sovereign-LOCAL branches (`catalog-sovereign`, the per-Org GitOps tree branch) mid-cutover, flipping both flux GitRepositories to Ready=False (`couldn't find remote ref`). Live-heal on hw242 was a ref-restore at the recorded SHAs; this PR removes the defect class.

**Change:** replace mirror-mode push with explicit refspec force-pushes of only the refs the bare clone owns (`refs/heads/*:refs/heads/*` + `refs/tags/*:refs/tags/*`). A bare clone fetches exactly heads+tags from GitHub, so this propagates byte-for-byte everything mirror mode did — minus the deletion of remote-only refs, which is precisely the defect. Logging, PAT handling, idempotent re-run behavior, mirror=false verification and the G75 resync-severed check are untouched.

**Test:** new cutover-contract case asserts the rendered step-01 script uses the explicit refspecs and contains no mirror-mode push.

**Chart version:** 0.1.120 → 0.1.121 in lockstep across Chart.yaml, blueprint.yaml, bootstrap-kit slot 06a pin, and the catalog-seed entry (same set as #5010's bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
