### PR TITLE
fix(#5017): route 4 residual raw-external-ref Blueprint images via the Sovereign-local Harbor proxy

### DIFF
--- a/clusters/_template/bootstrap-kit/12-external-dns.yaml
+++ b/clusters/_template/bootstrap-kit/12-external-dns.yaml
@@ -57,12 +57,16 @@ spec:
   chart:
     spec:
       chart: bp-external-dns
+      # 1.1.9: image routed via Sovereign-local Harbor proxy (#5017 —
+      # kyverno harbor-proxy-pull denied the raw registry.k8s.io ref under
+      # cutover step-08 deny-egress; strategy Recreate took DNS sync to
+      # ZERO pods on hw242).
       # 1.1.7: companion CiliumNetworkPolicy with toEntities[kube-apiserver]
       # so external-dns can reach the kube-apiserver on Cilium clusters
       # (default policy-cidr-match-mode=""). Fixes #770 — the vanilla
       # NetworkPolicy 0.0.0.0/0 ipBlock does NOT match apiserver traffic
       # under Cilium's identity model.
-      version: 1.1.8
+      version: 1.1.9
       sourceRef:
         kind: HelmRepository
         name: bp-external-dns

--- a/clusters/_template/bootstrap-kit/19c-opentelemetry-operator.yaml
+++ b/clusters/_template/bootstrap-kit/19c-opentelemetry-operator.yaml
@@ -58,7 +58,10 @@ spec:
   chart:
     spec:
       chart: bp-opentelemetry-operator
-      version: 1.0.4
+      # 1.0.5: manager + kube-rbac-proxy images routed via Sovereign-local
+      # Harbor proxy (#5017 — kyverno harbor-proxy-pull denied the raw
+      # ghcr.io/quay.io refs under cutover step-08 deny-egress).
+      version: 1.0.5
       sourceRef:
         kind: HelmRepository
         name: bp-opentelemetry-operator

--- a/clusters/_template/bootstrap-kit/28-reloader.yaml
+++ b/clusters/_template/bootstrap-kit/28-reloader.yaml
@@ -50,7 +50,10 @@ spec:
   chart:
     spec:
       chart: bp-reloader
-      version: 1.0.0
+      # 1.0.1: image routed via Sovereign-local Harbor proxy + fixes the
+      # inert chart-1.x image key (#5017 — kyverno harbor-proxy-pull denied
+      # the raw ghcr.io ref under cutover step-08 deny-egress).
+      version: 1.0.1
       sourceRef:
         kind: HelmRepository
         name: bp-reloader

--- a/clusters/_template/bootstrap-kit/32-sigstore.yaml
+++ b/clusters/_template/bootstrap-kit/32-sigstore.yaml
@@ -54,7 +54,11 @@ spec:
   chart:
     spec:
       chart: bp-sigstore
-      version: 1.0.0
+      # 1.0.1: webhook image routed via Sovereign-local Harbor proxy +
+      # disable-tuf so the webhook boots without dialing sigstore's public
+      # TUF CDN (#5017 — both denied/impossible under cutover step-08
+      # deny-egress; proven live on hw242).
+      version: 1.0.1
       sourceRef:
         kind: HelmRepository
         name: bp-sigstore

--- a/platform/external-dns/blueprint.yaml
+++ b/platform/external-dns/blueprint.yaml
@@ -14,7 +14,7 @@ spec:
   # PowerDNS auth replica via the webhook provider; no cross-cluster
   # replication primitive — the source of truth is PowerDNS state
   # (replicated by bp-powerdns lua-records + PG-backed pair).
-  version: 1.1.8
+  version: 1.1.9
   card:
     title: ExternalDNS
     family: networking

--- a/platform/external-dns/chart/Chart.yaml
+++ b/platform/external-dns/chart/Chart.yaml
@@ -1,6 +1,10 @@
 apiVersion: v2
 name: bp-external-dns
-version: 1.1.8
+# 1.1.9 (#5017 — route the external-dns image through the Sovereign-local
+# Harbor proxy: kyverno harbor-proxy-pull denies the raw registry.k8s.io ref
+# when cutover step-08's deny-egress roll recreates the pod; with
+# strategy: Recreate this took DNS sync fully down on hw242.)
+version: 1.1.9
 description: |
   Catalyst-curated Blueprint umbrella chart for ExternalDNS. Depends on the
   upstream `external-dns` chart (kubernetes-sigs) as a Helm subchart so

--- a/platform/external-dns/chart/values.yaml
+++ b/platform/external-dns/chart/values.yaml
@@ -31,6 +31,16 @@ catalystBlueprint:
 # `helm dependency build` resolves the upstream as a subchart; values here
 # under the `external-dns:` key flow into that subchart unchanged.
 external-dns:
+  # Route the external-dns image through the Sovereign-local Harbor proxy
+  # (#5017): the kyverno `harbor-proxy-pull` ClusterPolicy only admits pod
+  # images matching `*/proxy-*/*` or `*/openova-io/*`; the upstream default
+  # `registry.k8s.io/external-dns/external-dns` matches neither, so cutover
+  # step-08's deny-egress roll left the Deployment (strategy: Recreate) at
+  # ZERO pods on hw242 — DNS record sync down until live-healed. Tag defaults
+  # to the chart appVersion (v0.15.1) — unchanged.
+  image:
+    repository: harbor.openova.io/proxy-k8s/external-dns/external-dns
+
   # Native PowerDNS provider — talks to the in-cluster bp-powerdns Service
   # (powerdns.openova-system.svc.cluster.local:8081) over the REST API.
   # Per the user-facing brief: PowerDNS webhook adapter or native `pdns`

--- a/platform/opentelemetry-operator/blueprint.yaml
+++ b/platform/opentelemetry-operator/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-2-observability-and-tracing
 spec:
-  version: 1.0.4
+  version: 1.0.5
   card:
     title: OpenTelemetry Operator
     summary: |

--- a/platform/opentelemetry-operator/chart/Chart.yaml
+++ b/platform/opentelemetry-operator/chart/Chart.yaml
@@ -1,6 +1,10 @@
 apiVersion: v2
 name: bp-opentelemetry-operator
-version: 1.0.4
+# 1.0.5 (#5017 — route the operator manager (ghcr.io) + kube-rbac-proxy
+# (quay.io) images through the Sovereign-local Harbor proxy: kyverno
+# harbor-proxy-pull denies the raw refs when cutover step-08's deny-egress
+# roll recreates the pod, blocking cutoverComplete on hw242.)
+version: 1.0.5
 description: |
   Catalyst-curated Blueprint umbrella chart for the OpenTelemetry
   Operator. Wraps the upstream open-telemetry/opentelemetry-helm-charts

--- a/platform/opentelemetry-operator/chart/values.yaml
+++ b/platform/opentelemetry-operator/chart/values.yaml
@@ -37,9 +37,29 @@ defaultInstrumentation:
   dotnet:
     enabled: false
 
+# ─── Catalyst overlay values (consumed by templates/ in this chart) ───
+# webhook-gate hook Job (G38 #2593). The published 1.0.4 OCI artifact
+# predates the hook template — 1.0.5 is the FIRST release that ships it,
+# so its image must be proxy-routed from day one (#5017): the hook runs
+# post-install AND post-upgrade in the `opentelemetry` namespace, which
+# is NOT in the kyverno harbor-proxy-pull exclude list — a raw
+# `bitnamilegacy/kubectl` ref would be denied at admission and fail every
+# install/upgrade of this chart. Same MIRROR-EVERYTHING pattern as
+# platform/flux (Fix #163).
+webhookGate:
+  image: "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7"
+
 # ─── Upstream subchart values (subchart key: opentelemetry-operator) ──
 opentelemetry-operator:
   manager:
+    # Route the operator manager image through the Sovereign-local Harbor
+    # proxy (#5017): the kyverno `harbor-proxy-pull` ClusterPolicy only
+    # admits pod images matching `*/proxy-*/*` or `*/openova-io/*`; the
+    # upstream default raw ghcr.io ref was DENIED when cutover step-08's
+    # deny-egress roll recreated the pod on hw242, blocking cutoverComplete.
+    # Tag defaults to the upstream chart appVersion (0.101.0) — unchanged.
+    image:
+      repository: harbor.openova.io/proxy-ghcr/open-telemetry/opentelemetry-operator/opentelemetry-operator
     # The upstream chart REQUIRES manager.collectorImage.repository to
     # be set (the operator needs to know which collector image to deploy
     # when an OpenTelemetryCollector CR is created without an explicit
@@ -55,6 +75,13 @@ opentelemetry-operator:
     resources:
       requests: { cpu: 50m, memory: 64Mi }
       limits: { memory: 256Mi }
+  # Route the kube-rbac-proxy sidecar image through the Sovereign-local
+  # Harbor proxy (#5017) — same kyverno harbor-proxy-pull denial class as
+  # the manager image above (upstream default is a raw quay.io ref). Tag
+  # stays the upstream chart default (v0.15.0).
+  kubeRBACProxy:
+    image:
+      repository: harbor.openova.io/proxy-quay/brancz/kube-rbac-proxy
   admissionWebhooks:
     certManager:
       enabled: true

--- a/platform/reloader/blueprint.yaml
+++ b/platform/reloader/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.0
+  version: 1.0.1
   card:
     title: Reloader
     family: guardian

--- a/platform/reloader/chart/Chart.yaml
+++ b/platform/reloader/chart/Chart.yaml
@@ -1,5 +1,10 @@
 apiVersion: v2
 name: bp-reloader
+# 1.0.1 (#5017 — route the Reloader image through the Sovereign-local Harbor
+# proxy: kyverno harbor-proxy-pull denies raw ghcr.io refs when cutover
+# step-08's deny-egress roll recreates the pod, blocking cutoverComplete on
+# hw242. Also fixes the previously-INERT image pin: upstream chart 2.2.x
+# reads the top-level `image:` block, not `reloader.deployment.image.name`.)
 description: |
   Catalyst Blueprint umbrella chart for Stakater Reloader. Depends on the
   upstream `reloader` chart (stakater/stakater-charts) as a Helm subchart
@@ -13,7 +18,7 @@ description: |
   rolling restart of the dependent workloads marked with
   `reloader.stakater.com/auto: "true"` (or per-resource annotations).
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "v1.4.16"
 keywords: [catalyst, blueprint, reloader, configmap, secret, rotation, security]
 maintainers:

--- a/platform/reloader/chart/values.yaml
+++ b/platform/reloader/chart/values.yaml
@@ -14,20 +14,32 @@ catalystBlueprint:
 
 # ─── Upstream chart values (subchart key: reloader) ──────────────────────
 reloader:
+  # Pin upstream image — routed through the Sovereign-local Harbor proxy
+  # (#5017): the kyverno `harbor-proxy-pull` ClusterPolicy only admits pod
+  # images matching `*/proxy-*/*` or `*/openova-io/*`, and cutover step-08's
+  # deny-egress roll DENIED the raw `ghcr.io/stakater/reloader` ref on hw242
+  # (RS FailedCreate → rollout never completes → cutoverComplete blocked).
+  # Pre-cutover the containerd mirror rewrite resolves harbor.openova.io to
+  # the local Harbor; step-07's sweep pivots the host to registry.<fqdn> at
+  # cutover — the `*/proxy-*/*` glob matches both.
+  #
+  # NOTE: upstream reloader chart 2.2.x reads this TOP-LEVEL `image:` block
+  # (image.repository/image.tag). The previous pin at
+  # `reloader.deployment.image.name` was INERT (a chart 1.x key) — the
+  # rendered pod silently ran the upstream default ghcr.io image.
+  # DO NOT use floating tags per docs/INVIOLABLE-PRINCIPLES.md.
+  image:
+    repository: harbor.openova.io/proxy-ghcr/stakater/reloader
+    tag: "v1.4.16"
+    pullPolicy: IfNotPresent
+
   # Reloader controller — single replica (the upstream chart uses leader
   # election when scaled, but a single-pod restart only delays a rotation
   # by ≤30s in practice).
   reloader:
     replicaCount: 1
 
-    # Pin upstream image tag — DO NOT use floating tags per
-    # docs/INVIOLABLE-PRINCIPLES.md.
     deployment:
-      image:
-        name: ghcr.io/stakater/reloader
-        tag: "v1.4.16"
-        pullPolicy: IfNotPresent
-
       resources:
         requests:
           cpu: 50m

--- a/platform/sigstore/blueprint.yaml
+++ b/platform/sigstore/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.0
+  version: 1.0.1
   card:
     title: Sigstore Policy Controller
     family: guardian

--- a/platform/sigstore/chart/Chart.yaml
+++ b/platform/sigstore/chart/Chart.yaml
@@ -1,5 +1,12 @@
 apiVersion: v2
 name: bp-sigstore
+# 1.0.1 (#5017 — two cutover step-08 fixes, both proven live on hw242:
+# (1) route the policy-controller webhook image through the Sovereign-local
+# Harbor proxy (kyverno harbor-proxy-pull denies the raw ghcr.io digest ref
+# on pod recreation; digest pin preserved); (2) webhook.extraArgs disable-tuf
+# — the webhook panics at startup fetching its TUF root from
+# tuf-repo-cdn.sigstore.dev, impossible under deny-egress and a Principle #11
+# sovereignty violation.)
 description: |
   Catalyst Blueprint umbrella chart for Sigstore Policy Controller.
   Depends on the upstream `policy-controller` chart (sigstore/helm-charts)
@@ -12,7 +19,7 @@ description: |
   admission time. Pairs with bp-harbor (registry) and the Catalyst
   build-pipeline that publishes signed bp-* OCI artifacts to GHCR.
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "0.13.1"
 keywords: [catalyst, blueprint, sigstore, cosign, supply-chain, admission, security]
 maintainers:

--- a/platform/sigstore/chart/values.yaml
+++ b/platform/sigstore/chart/values.yaml
@@ -28,10 +28,29 @@ policy-controller:
     replicaCount: 1
     # Pin upstream image — DO NOT use floating tags per
     # docs/INVIOLABLE-PRINCIPLES.md.
+    #
+    # Routed through the Sovereign-local Harbor proxy (#5017): the kyverno
+    # `harbor-proxy-pull` ClusterPolicy only admits pod images matching
+    # `*/proxy-*/*` or `*/openova-io/*`; the raw ghcr.io ref was DENIED when
+    # cutover step-08's deny-egress roll recreated the pod on hw242. The
+    # digest pin is preserved (`version` renders as `@sha256:...`).
     image:
-      repository: ghcr.io/sigstore/policy-controller/policy-controller
+      repository: harbor.openova.io/proxy-ghcr/sigstore/policy-controller/policy-controller
       version: "sha256:0bcd60beb93f4427c29cf3a669743caf58490e98ded4380c33c09f092734a6ab"
       pullPolicy: IfNotPresent
+
+    # disable-tuf (#5017, proven live on hw242): the webhook binary panics at
+    # startup fetching its TUF trust root from https://tuf-repo-cdn.sigstore.dev
+    # — impossible under the cutover step-08 deny-egress hold (CrashLoopBackOff
+    # → rollout never completes) and a sovereign-independence violation
+    # (Principle #11): a Sovereign must never phone home to sigstore's public
+    # CDN to boot. With TUF disabled, trust roots come from in-cluster
+    # TrustRoot/ClusterImagePolicy CRs — none are installed by default (see
+    # sigstoreOverlay.defaultClusterImagePolicy below), so the webhook stays
+    # healthy and inert. Per-Sovereign overlays that enable signature
+    # enforcement ship their own TrustRoot CR alongside the policy.
+    extraArgs:
+      disable-tuf: true
     # failurePolicy=Ignore on solo-Sovereign so a single-pod webhook
     # restart doesn't block all admission. Per-Sovereign overlays MAY flip
     # to Fail once 3-replica HA is in place.

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -4032,7 +4032,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.1.8"
+  version: "1.1.9"
   visibility: unlisted
   card:
     title: "ExternalDNS"
@@ -4049,7 +4049,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-external-dns
-    version: "1.1.8"
+    version: "1.1.9"
   topology:
     supported:
       - singleton
@@ -4708,7 +4708,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.0.4"
+  version: "1.0.5"
   visibility: unlisted
   card:
     title: "OpenTelemetry Operator"
@@ -4725,7 +4725,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-opentelemetry-operator
-    version: "1.0.4"
+    version: "1.0.5"
   topology:
     supported:
       - singleton
@@ -4944,7 +4944,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.0.0"
+  version: "1.0.1"
   visibility: unlisted
   card:
     title: "Reloader"
@@ -4961,7 +4961,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-reloader
-    version: "1.0.0"
+    version: "1.0.1"
   topology:
     supported:
       - singleton
@@ -5091,7 +5091,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.0.0"
+  version: "1.0.1"
   visibility: unlisted
   card:
     title: "Sigstore Policy Controller"
@@ -5110,7 +5110,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-sigstore
-    version: "1.0.0"
+    version: "1.0.1"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Problem

Cutover step-08's deny-egress hold force-rolls every external-registry workload; the kyverno `harbor-proxy-pull` ClusterPolicy admits only `*/proxy-*/*` / `*/openova-io/*` pod images. Four Blueprints still shipped raw external refs (running since bootstrap only via `allowExistingViolations: true`), so their recreated pods were **denied at admission** on hw242 (`RS FailedCreate`, rollout never completes) → step-08 cannot pass → `cutoverComplete` blocked.

## Changes (one root cause, four Blueprints, lockstep bumps)

| Blueprint | Version | Image routing change |
|---|---|---|
| bp-reloader | 1.0.0 → 1.0.1 | `ghcr.io/stakater/reloader` → `harbor.openova.io/proxy-ghcr/stakater/reloader` — **also fixes an inert pin**: upstream chart 2.2.x reads the top-level `image:` block; the old `reloader.deployment.image.name` (chart-1.x key) was dead, the pod silently ran the upstream default |
| bp-external-dns | 1.1.8 → 1.1.9 | `registry.k8s.io/external-dns/external-dns` → `harbor.openova.io/proxy-k8s/external-dns/external-dns` — with `strategy: Recreate` the denied roll took DNS sync to **zero pods for ~78 min** on hw242 |
| bp-opentelemetry-operator | 1.0.4 → 1.0.5 | manager → `proxy-ghcr/open-telemetry/opentelemetry-operator/opentelemetry-operator`; kube-rbac-proxy → `proxy-quay/brancz/kube-rbac-proxy`; **plus** the G38 webhook-gate hook image → `proxy-dockerhub/bitnamilegacy/kubectl:1.30.7` (1.0.5 is the first published artifact shipping that hook template; `opentelemetry` ns is not kyverno-excluded, so a raw hook image would fail every install/upgrade) |
| bp-sigstore | 1.0.0 → 1.0.1 | webhook image → `proxy-ghcr/sigstore/policy-controller/policy-controller@sha256:0bcd60...` (digest preserved) **plus** `webhook.extraArgs: {disable-tuf: true}` — the webhook panics at boot fetching its TUF root from `tuf-repo-cdn.sigstore.dev`, impossible under deny-egress and a Principle #11 sovereignty violation. Proven live on hw242: image-only heal left the new pod CrashLoopBackOff on the TUF dial; with `-disable-tuf=true` it reaches 1/1 Ready. Trust roots come from in-cluster TrustRoot/ClusterImagePolicy CRs (none installed by default → webhook healthy and inert) |

**Why `harbor.openova.io/proxy-*` and not `registry.<fqdn>`:** pre-cutover envs resolve `harbor.openova.io` via the containerd mirror rewrite; step-07's sweep pivots the host to `registry.<fqdn>` at cutover — the `*/proxy-*/*` glob matches both pre- and post-pivot.

**Lockstep set per chart** (same as #5010 / #5016): `Chart.yaml` + `blueprint.yaml` + `clusters/_template/bootstrap-kit/<slot>.yaml` pin + catalog-seed `spec.version`/`source.version`.

## Gates

- `helm lint` — 4/4 pass; `helm template` — 4/4 render.
- Every rendered **pod-spec** image is a `harbor.openova.io/proxy-*` path; zero raw `ghcr.io` / `registry.k8s.io` / `quay.io` / `docker.io` pod-spec refs.
- Remaining non-proxy refs are benign, delete/test-time only: upstream `busybox:latest` helm-test Pod (`helm.sh/hook: test`, flux never runs it) and upstream `cgr.dev/chainguard/kubectl` leases-cleanup Job (`helm.sh/hook: post-delete`).

## Live verification (hw242, dep f05b0718dac62fe9)

Every live patch here is twinned by this PR. The four HelmReleases were healed via HR-values commits to the **sovereign-local Gitea** (`clusters/_template/bootstrap-kit/` slot files — kubectl-only HR patches proved to be reverted by the bootstrap-kit Kustomization within minutes):

- reloader → `reloader-reloader-6b7d566578-xjgrx` Running 1/1, image `harbor.openova.io/proxy-ghcr/stakater/reloader:v1.4.16`
- opentelemetry-operator → `opentelemetry-operator-59d9644fd8-ccbs9` Running 2/2, proxy-ghcr manager + proxy-quay rbac-proxy, pulls hit the prewarmed local mirror (2.6s)
- sigstore → `sigstore-policy-controller-webhook-5694d7546f-4lq9v` Running 1/1 with `-disable-tuf=true` (pull from local mirror in 4.8s)
- external-dns → `external-dns-674cd95bcc-m565b` Running 1/1, proxy-k8s image, `"All records are already up to date"` — restored from the 78-min zero-pod outage

## Known residuals (out of #5017's declared scope, called out honestly)

Live on hw242 the step-08 roll is *also* denying workloads beyond the four in #5017: `velero` (`docker.io/velero/velero:v1.18.0`) and `vpa` (`registry.k8s.io/autoscaling/vpa-*:1.5.0` ×3), and `otel/opentelemetry-collector-contrib` (bp-opentelemetry collector) + `quay.io/jetstack/*` (cert-manager, kyverno-excluded ns) + `zachomedia/cert-manager-webhook-pdns` remain raw-but-running. Re-firing the cutover trigger before those are routed will fail step-08 again — they need their own routing pass.

Refs #5017

🤖 Generated with [Claude Code](https://claude.com/claude-code)