### PR TITLE
fix(#5017): residual raw-ref images via Harbor proxy + harbor-proxy-pull learns mixed-source pods

### DIFF
--- a/clusters/_template/bootstrap-kit/20-opentelemetry.yaml
+++ b/clusters/_template/bootstrap-kit/20-opentelemetry.yaml
@@ -59,7 +59,10 @@ spec:
   chart:
     spec:
       chart: bp-opentelemetry
-      version: 1.2.1
+      # 1.2.2: Collector image via Sovereign-local Harbor proxy (#5017 —
+      # kyverno harbor-proxy-pull denies the raw docker.io ref on pod
+      # recreation).
+      version: 1.2.2
       sourceRef:
         kind: HelmRepository
         name: bp-opentelemetry

--- a/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
+++ b/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
@@ -150,7 +150,11 @@ spec:
       # that span unbounded org-<uuid> namespaces the excludeNamespaces list can't
       # enumerate; without this the WordPress mysql Deployment was admission-blocked
       # → 0 pods → WordPress had no DB. Refs #4422 #3376.
-      version: 1.0.45
+      # 1.0.46: harbor-proxy-pull third `|`-alternation glob admits
+      # mixed-source pods (proxy-cache sidecars + openova-io plugin) —
+      # un-wedges huawei-evs-csi + its 24-HR dependency cascade (#5017,
+      # #4973 family).
+      version: 1.0.46
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno

--- a/clusters/_template/bootstrap-kit/29-vpa.yaml
+++ b/clusters/_template/bootstrap-kit/29-vpa.yaml
@@ -55,7 +55,10 @@ spec:
       # stall the cilium CNI-bootstrap Pod creates during a cilium roll.
       # 1.0.3 (Refs #3374/#3375): + --webhook-timeout-seconds=2 caps the hang
       # in non-kube-system namespaces (cnpg initdb / keycloak / tenant vclusters).
-      version: 1.0.3
+      # 1.0.4: controller + CRDs-hook images via Sovereign-local Harbor
+      # proxy + hook resources (#5017 — kyverno denied the step-08-rolled
+      # pods on hw242).
+      version: 1.0.4
       sourceRef:
         kind: HelmRepository
         name: bp-vpa

--- a/clusters/_template/bootstrap-kit/34a-bp-velero-hcs.yaml
+++ b/clusters/_template/bootstrap-kit/34a-bp-velero-hcs.yaml
@@ -83,7 +83,10 @@ spec:
       chart: bp-velero-hcs
       # 0.1.1 (#2847): checksumAlgorithm "" — OBS rejects aws-sdk-v2
       # flexible checksums (XAmzContentSHA256Mismatch on every write).
-      version: 0.1.1
+      # 0.1.2: velero + plugin images via Sovereign-local Harbor proxy +
+      # upgrade-crds hook resources (#5017 — kyverno harbor-proxy-pull /
+      # resource-requests denied the step-08-rolled pod + hook on hw242).
+      version: 0.1.2
       sourceRef:
         kind: HelmRepository
         name: bp-velero-hcs

--- a/platform/kyverno-policies/blueprint.yaml
+++ b/platform/kyverno-policies/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.45
+  version: 1.0.46
   card:
     title: Kyverno Policy Library
     family: guardian

--- a/platform/kyverno-policies/chart/Chart.yaml
+++ b/platform/kyverno-policies/chart/Chart.yaml
@@ -1,5 +1,13 @@
 apiVersion: v2
 name: bp-kyverno-policies
+# 1.0.46 (#5017 / #4973 family — harbor-proxy-pull learns mixed-source
+# pods: each anyPattern entry requires EVERY container to match ONE glob,
+# so a pod mixing proxy-cache sidecars with a native-push openova-io
+# plugin (huawei-evs-csi: 4x proxy-k8s sig-storage + 1x openova-io
+# evs-csi-plugin) could NEVER admit — wedging the CSI controller RS +
+# node DS and a 24-HelmRelease dependency cascade on hw242. Adds a third
+# `|`-alternation pattern that admits mixed-source pods while still
+# requiring every image to come from the local Harbor.)
 # 1.0.41 (#4329, proven live omantel.biz/kom4dc 2026-06-25): HARDEN the
 # flux-managed (10) carve-out for the per-Org vCluster CIDR-probe Service. The
 # #3859 exclusion only matched namespaces stamped `openova.io/organization`; the
@@ -302,7 +310,7 @@ type: application
 #   (helm.sh/hook annotation) — hooks get no Flux labels + Helm force-stamps
 #   managed-by:Helm, so a legit hook Job (bp-powerdns zone-bootstrap) was
 #   Enforce-denied on live upgrade, stranding the powerdns anycast NodePort.
-version: 1.0.45
+version: 1.0.46
 appVersion: "1.0.2"
 keywords: [catalyst, blueprint, kyverno, policy, compliance, audit]
 maintainers:

--- a/platform/kyverno-policies/chart/values.yaml
+++ b/platform/kyverno-policies/chart/values.yaml
@@ -249,9 +249,21 @@ compliancePolicies:
     # legacy single-string `allowedImagePattern` is retained for backward
     # compatibility (used as fallback when list is empty).
     allowedImagePattern: "*/proxy-*/*"
+    # #5017 (hw242, 2026-07-12): a THIRD entry with Kyverno `|` alternation.
+    # Each anyPattern entry requires EVERY container in the pod to match
+    # that ONE glob — a pod that legitimately MIXES proxy-cache sidecars
+    # with a native-push openova-io image (e.g. huawei-evs-csi: 4x
+    # proxy-k8s sig-storage sidecars + 1x openova-io evs-csi-plugin,
+    # #4973 family) could NEVER be admitted: the all-proxy pattern fails
+    # on the plugin, the all-openova-io pattern fails on the sidecars.
+    # This wedged the CSI controller RS + node DS on hw242 and, through
+    # bp-huawei-evs-csi, a 24-HelmRelease dependency cascade. The OR entry
+    # admits mixed-source pods while still requiring every image to come
+    # from the local Harbor.
     allowedImagePatterns:
       - "*/proxy-*/*"           # proxy-cache mode (cilium, cert-manager, postgres, etc.)
       - "*/openova-io/*"        # native-push mode (catalyst-api + all openova-io services post-cutover)
+      - "*/proxy-*/* | */openova-io/*"  # mixed-source pods (proxy-cache sidecars + native-push plugin)
     # 2026-06-13: EXCLUDE the `powerdns` namespace from harbor-proxy-pull.
     # bp-powerdns's pdns-auth-50 + dnsdist-19 images pull from raw
     # `docker.io/powerdns/...` (see platform/powerdns/chart/values.yaml).

--- a/platform/opentelemetry/blueprint.yaml
+++ b/platform/opentelemetry/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-observability
 spec:
-  version: 1.2.1
+  version: 1.2.2
   card:
     title: OpenTelemetry Collector
     family: insights

--- a/platform/opentelemetry/chart/Chart.yaml
+++ b/platform/opentelemetry/chart/Chart.yaml
@@ -1,5 +1,9 @@
 apiVersion: v2
 name: bp-opentelemetry
+# 1.2.2 (#5017 — route the Collector image through the Sovereign-local
+# Harbor proxy: kyverno harbor-proxy-pull denies the implicit-registry
+# `otel/...` (docker.io) ref the moment the pod is recreated, e.g. under
+# the cutover step-08 deny-egress roll on hw242.)
 description: |
   Catalyst Blueprint umbrella chart for the OpenTelemetry Collector.
   Depends on the upstream `opentelemetry-collector` chart
@@ -21,7 +25,7 @@ description: |
   moved to bp-opentelemetry-operator's chart (it depends on CRDs that
   ship there). Flux ordering: 19c (Operator+CRDs) → 20 (this chart).
 type: application
-version: 1.2.1
+version: 1.2.2
 appVersion: "0.150.1"
 keywords: [catalyst, blueprint, opentelemetry, otlp, observability, telemetry, collector]
 maintainers:

--- a/platform/opentelemetry/chart/values.yaml
+++ b/platform/opentelemetry/chart/values.yaml
@@ -26,8 +26,15 @@ opentelemetry-collector:
   # exporters for Loki / Mimir / Tempo / Prometheus / Kafka are bundled
   # without requiring a custom build. The `command.name` MUST match the
   # binary inside the contrib image (`otelcol-contrib`).
+  #
+  # Routed through the Sovereign-local Harbor proxy (#5017): the kyverno
+  # `harbor-proxy-pull` ClusterPolicy only admits pod images matching
+  # `*/proxy-*/*` or `*/openova-io/*`; the implicit-registry `otel/...` ref
+  # (= docker.io) matches neither and is denied the moment the Collector pod
+  # is recreated on a policy-enforcing Sovereign (hw242 ran it only via
+  # allowExistingViolations).
   image:
-    repository: otel/opentelemetry-collector-contrib
+    repository: harbor.openova.io/proxy-dockerhub/otel/opentelemetry-collector-contrib
     tag: "0.150.1"
     pullPolicy: IfNotPresent
   command:

--- a/platform/velero-hcs/blueprint.yaml
+++ b/platform/velero-hcs/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-observability
 spec:
-  version: 0.1.1
+  version: 0.1.2
   card:
     title: Velero (HCS)
     family: insights

--- a/platform/velero-hcs/chart/Chart.yaml
+++ b/platform/velero-hcs/chart/Chart.yaml
@@ -1,5 +1,13 @@
 apiVersion: v2
 name: bp-velero-hcs
+# 0.1.2 (#5017 — cutover step-08 admissibility, proven live on hw242:
+# (1) velero + velero-plugin-for-aws images routed via the Sovereign-local
+# Harbor proxy (kyverno harbor-proxy-pull denied the raw docker.io refs on
+# pod recreation; strategy=Recreate took Velero to ZERO pods);
+# (2) kubectl hook image routed proxy-k8s; (3) upgradeJobResources set —
+# kyverno resource-requests (Enforce) denies resource-less hook Job pods,
+# and helm's failed-upgrade auto-rollback re-renders the OLD raw hook,
+# wedging the release.)
 description: |
   Catalyst Blueprint umbrella chart for Velero on HCS (Huawei Cloud
   Sovereign) — mirrors platform/velero/chart but pre-targets Huawei
@@ -33,7 +41,7 @@ description: |
   bp-velero on HCS) → closes the resulting backup-engine gap on
   every HCS Sovereign. Refs #2847.
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "1.18.0"
 keywords: [catalyst, blueprint, velero, backup, disaster-recovery, huawei, hcs, obs]
 maintainers:

--- a/platform/velero-hcs/chart/values.yaml
+++ b/platform/velero-hcs/chart/values.yaml
@@ -27,17 +27,41 @@ catalystBlueprint:
 # ─── Upstream chart values (subchart key: velero) ────────────────────────
 velero:
   # Pin upstream Velero image — DO NOT use floating tags.
+  #
+  # Routed through the Sovereign-local Harbor proxy (#5017): the kyverno
+  # `harbor-proxy-pull` ClusterPolicy only admits pod images matching
+  # `*/proxy-*/*` or `*/openova-io/*`; the raw docker.io ref was DENIED when
+  # cutover step-08's deny-egress roll recreated the pod on hw242 — and the
+  # velero Deployment is `strategy: Recreate` (upstream hardcoded), so the
+  # denial took Velero to ZERO pods. The pre-upgrade `upgrade-crds` hook Job
+  # runs this same image, so routing it also keeps the hook admissible.
   image:
-    repository: docker.io/velero/velero
+    repository: harbor.openova.io/proxy-dockerhub/velero/velero
     tag: "v1.18.0"
     pullPolicy: IfNotPresent
 
-  # kubectl image (used by upgradeCRDs Job) — pin to a known-stable
-  # registry.k8s.io/kubectl version. Per-Sovereign overlays MAY pin a
-  # specific tag.
+  # kubectl image (used by the label-namespace hook Job, rendered only when
+  # namespace.labels is set — NOT with Catalyst defaults) — routed through
+  # the Sovereign-local Harbor proxy (#5017) so any per-Sovereign overlay
+  # that enables namespace labelling stays kyverno-admissible. Per-Sovereign
+  # overlays MAY pin a specific tag.
   kubectl:
     image:
-      repository: registry.k8s.io/kubectl
+      repository: harbor.openova.io/proxy-k8s/kubectl
+
+  # upgrade-crds hook Job resources — REQUIRED (#5017): the kyverno
+  # `resource-requests` policy (Enforce) denies Job pods lacking
+  # requests.cpu+memory. Without this the pre-upgrade hook is denied at
+  # admission and — worse — helm's failed-upgrade auto-rollback re-renders
+  # the OLD release's hook (raw image, no resources), which can never pass,
+  # wedging the release (proven live on hw242).
+  upgradeJobResources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
 
   # Plugin init containers — REQUIRED for Velero to talk to ANY backup
   # backend. The AWS plugin (S3-compatible) is the Catalyst standard
@@ -45,9 +69,12 @@ velero:
   # store) exposes an S3 API. Per-Sovereign overlays append additional
   # plugin init containers if a CSI snapshotter / cloud-native plugin is
   # also needed.
+  #
+  # Image routed through the Sovereign-local Harbor proxy (#5017) — kyverno
+  # harbor-proxy-pull validates =(initContainers) images too.
   initContainers:
     - name: velero-plugin-for-aws
-      image: velero/velero-plugin-for-aws:v1.14.0
+      image: harbor.openova.io/proxy-dockerhub/velero/velero-plugin-for-aws:v1.14.0
       imagePullPolicy: IfNotPresent
       volumeMounts:
         - mountPath: /target

--- a/platform/vpa/blueprint.yaml
+++ b/platform/vpa/blueprint.yaml
@@ -9,7 +9,7 @@ spec:
   # cilium CNI-bootstrap Pod creates during a cilium roll.
   # 1.0.3 (Refs #3374/#3375): + --webhook-timeout-seconds=2 caps the same hang
   # in non-kube-system namespaces (cnpg initdb / keycloak / tenant vclusters).
-  version: 1.0.3
+  version: 1.0.4
   card:
     title: Vertical Pod Autoscaler
     family: guardian

--- a/platform/vpa/chart/Chart.yaml
+++ b/platform/vpa/chart/Chart.yaml
@@ -1,5 +1,13 @@
 apiVersion: v2
 name: bp-vpa
+# 1.0.4 (#5017 — cutover step-08 admissibility, proven live on hw242:
+# recommender/updater/admission-controller images routed via the
+# Sovereign-local Harbor proxy (kyverno harbor-proxy-pull denied the raw
+# registry.k8s.io refs on pod recreation); CRDs hook Job image routed
+# proxy-dockerhub + tag pinned to a mirrored tag + resources set (kyverno
+# resource-requests Enforce denies resource-less hook pods). Also replaces
+# the INERT crds.install/keep keys with the cowboysysop chart's real
+# crds.enabled knob.)
 description: |
   Catalyst Blueprint umbrella chart for the Kubernetes Vertical Pod
   Autoscaler. Depends on the upstream `vertical-pod-autoscaler` chart
@@ -26,7 +34,7 @@ type: application
 # defence-in-depth — bounds the same VPA-webhook hang in NON-kube-system
 # namespaces (cnpg initdb, keycloak, tenant vclusters) that the kube-system
 # exemption does not cover.
-version: 1.0.3
+version: 1.0.4
 appVersion: "1.5.0"
 keywords: [catalyst, blueprint, vpa, autoscaling, vertical-pod-autoscaler, right-sizing]
 maintainers:

--- a/platform/vpa/chart/values.yaml
+++ b/platform/vpa/chart/values.yaml
@@ -30,7 +30,14 @@ vertical-pod-autoscaler:
       # be `registry.k8s.io/registry.k8s.io/autoscaling/...` (doubled
       # prefix) and pulls fail with "image not found" (caught live on
       # otech26).
-      repository: autoscaling/vpa-recommender
+      #
+      # Routed through the Sovereign-local Harbor proxy (#5017): the kyverno
+      # `harbor-proxy-pull` ClusterPolicy only admits pod images matching
+      # `*/proxy-*/*` or `*/openova-io/*`; the raw registry.k8s.io refs were
+      # DENIED when cutover step-08's deny-egress roll recreated the three
+      # VPA pods on hw242.
+      registry: harbor.openova.io
+      repository: proxy-k8s/autoscaling/vpa-recommender
       tag: "1.5.0"
       pullPolicy: IfNotPresent
     resources:
@@ -59,7 +66,10 @@ vertical-pod-autoscaler:
     enabled: true
     replicaCount: 1
     image:
-      repository: autoscaling/vpa-updater
+      # Routed through the Sovereign-local Harbor proxy (#5017) — see the
+      # recommender image comment above.
+      registry: harbor.openova.io
+      repository: proxy-k8s/autoscaling/vpa-updater
       tag: "1.5.0"
       pullPolicy: IfNotPresent
     resources:
@@ -81,7 +91,10 @@ vertical-pod-autoscaler:
     enabled: true
     replicaCount: 1
     image:
-      repository: autoscaling/vpa-admission-controller
+      # Routed through the Sovereign-local Harbor proxy (#5017) — see the
+      # recommender image comment above.
+      registry: harbor.openova.io
+      repository: proxy-k8s/autoscaling/vpa-admission-controller
       tag: "1.5.0"
       pullPolicy: IfNotPresent
     resources:
@@ -158,9 +171,31 @@ vertical-pod-autoscaler:
   # the chart — Flux will surface CRD upgrade conflicts as
   # InstallFailed/UpgradeFailed events that the operator resolves
   # explicitly (no silent drift).
+  # NOTE (#5017): the previous `install:`/`keep:` keys here were INERT — the
+  # cowboysysop chart's knob is `crds.enabled` and its CRDs apply via a
+  # pre-install/pre-upgrade hook Job, not helm crds/ handling.
   crds:
-    install: true
-    keep: true
+    enabled: true
+    # The CRDs hook Job image + resources (#5017): the raw
+    # docker.io/bitnamilegacy/kubectl default is denied by kyverno
+    # harbor-proxy-pull, and a resource-less hook pod is denied by the
+    # resource-requests policy (Enforce) — either one fails every
+    # install/upgrade of this chart on a policy-enforcing Sovereign.
+    # Tag pinned to 1.30.7 — the tag mirrored on live Sovereigns
+    # (upstream default 1.29.3 is not, and cannot pull through under the
+    # cutover deny-egress hold). Same MIRROR-EVERYTHING pattern as
+    # platform/flux (Fix #163).
+    image:
+      registry: harbor.openova.io
+      repository: proxy-dockerhub/bitnamilegacy/kubectl
+      tag: "1.30.7"
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
 
   # RBAC — chart manages its own ClusterRole + ServiceAccount.
   rbac:

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -2583,7 +2583,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.2.1"
+  version: "1.2.2"
   visibility: listed
   card:
     title: "OpenTelemetry Collector"
@@ -2602,7 +2602,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-opentelemetry
-    version: "1.2.1"
+    version: "1.2.2"
   topology:
     supported:
     - singleton
@@ -3149,7 +3149,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.1"
+  version: "0.1.2"
   visibility: listed
   card:
     title: "Velero (HCS)"
@@ -3176,7 +3176,7 @@ backup-engine gap (#2847).
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-velero-hcs
-    version: "0.1.1"
+    version: "0.1.2"
   topology:
     supported:
     - singleton
@@ -4591,7 +4591,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.0.45"
+  version: "1.0.46"
   visibility: unlisted
   card:
     title: "Kyverno Policy Library"
@@ -4608,7 +4608,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-kyverno-policies
-    version: "1.0.45"
+    version: "1.0.46"
   topology:
     supported:
       - singleton
@@ -5301,7 +5301,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.0.3"
+  version: "1.0.4"
   visibility: unlisted
   card:
     title: "Vertical Pod Autoscaler"
@@ -5318,7 +5318,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-vpa
-    version: "1.0.3"
+    version: "1.0.4"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Problem

Extension of #5020 (merged). The cutover step-08 deny-egress roll on hw242 was still denying three more workload sets, and the `huawei-evs-csi` wedge (#4973 family) turned out to be a **distinct sub-class of the same policy** — not an image-routing defect.

## Changes (lockstep bumps, house pattern of #5010/#5016/#5020)

| Blueprint | Version | Change |
|---|---|---|
| bp-velero-hcs | 0.1.1 → 0.1.2 | `velero` → `harbor.openova.io/proxy-dockerhub/velero/velero`; `velero-plugin-for-aws` initContainer → `proxy-dockerhub/...` (kyverno validates `=(initContainers)` too); `kubectl` hook image → `proxy-k8s/kubectl`; **`upgradeJobResources` set** — the `resource-requests` policy (Enforce) denies resource-less hook Job pods, and helm's failed-upgrade **auto-rollback re-renders the OLD raw hook, which can never pass**, wedging the release (proven live). Upstream deployment is `strategy: Recreate` — the step-08 denial had Velero at **zero pods** |
| bp-vpa | 1.0.3 → 1.0.4 | recommender/updater/admission-controller → `proxy-k8s/autoscaling/vpa-*` (registry+repository split per the cowboysysop image helper); CRDs pre-upgrade hook image → `proxy-dockerhub/bitnamilegacy/kubectl` **pinned to the mirrored `1.30.7` tag** (upstream default 1.29.3 is not mirrored and cannot pull-through under deny-egress) + hook resources. Also replaces the **inert** `crds.install/keep` keys with the chart's real `crds.enabled` knob |
| bp-opentelemetry | 1.2.1 → 1.2.2 | Collector → `proxy-dockerhub/otel/opentelemetry-collector-contrib` (implicit-registry `otel/...` = docker.io, denied on any pod recreation) |
| bp-kyverno-policies | 1.0.45 → 1.0.46 | `harbor-proxy-pull` gains a third `allowedImagePatterns` entry `"*/proxy-*/* \| */openova-io/*"` (Kyverno `\|` alternation). Each `anyPattern` entry requires EVERY container to match ONE glob — a pod that legitimately mixes proxy-cache sidecars with a native-push openova-io plugin (`huawei-evs-csi`: 4× proxy-k8s sig-storage sidecars + 1× openova-io evs-csi-plugin) could **never** be admitted: pattern[0] fails on the plugin, pattern[1] fails on the sidecars. This wedged the CSI controller RS + node DS and, through `bp-huawei-evs-csi` Ready=False, a **24-HelmRelease dependency cascade**. The OR entry admits mixed-source pods while still requiring every image to come from the local Harbor |

## Gates

- `helm lint` + `helm template` — 4/4 pass; every pod-spec image renders a `harbor.openova.io/proxy-*` path.
- `harbor-proxy-pull` renders 3 `anyPattern` entries (verified in the template output).
- Only benign non-proxy ref remaining: the vpa chart's upstream pytest pod (`helm.sh/hook: test`, never run by flux).

## Live verification (hw242, dep f05b0718dac62fe9)

Every change twinned by sovereign-local Gitea bootstrap-kit commits and verified live:

- velero → `velero-b5946777f-dw99c` Running 1/1, `proxy-dockerhub/velero/velero:v1.18.0` + `proxy-dockerhub/velero/velero-plugin-for-aws:v1.14.0` (recovered from 0 pods)
- vpa ×3 → all 1/1 on `proxy-k8s/autoscaling/vpa-{recommender,updater,admission-controller}:1.5.0`
- otel collector → 1/1 on `proxy-dockerhub/otel/opentelemetry-collector-contrib:0.150.1`
- evs-csi → controller RS `csi-evs-controller-6c5b6b5787` 2/2 + node DS rolled on all 5 nodes under the new mixed-source pattern (first admission ~16 min after the policy landed — replicaset-controller backoff)

All target images presence-checked in the local Harbor mirror (HTTP 200) before patching, per the sweep discipline.

Refs #5017

🤖 Generated with [Claude Code](https://claude.com/claude-code)