### PR TITLE
fix(#5022): strategy Recreate for single-replica RWO-backed Deployments (grafana, harbor-jobservice/registry, mimir-minio)

### DIFF
--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -224,7 +224,9 @@ spec:
       #   auto-adds the harbor.-prefixed alias; the wildcard listener (01-cilium.yaml
       #   *.${SOVEREIGN_FQDN}:443) + wildcard TLS already cover it, so no per-Sovereign
       #   DNS/cert change. externalURL + OIDC redirect_uri stay on registry.<fqdn>.
-      version: 1.2.41
+      # 1.2.42: updateStrategy Recreate — single-replica RWO jobservice
+      # deadlocked cutover step-08's forced roll on Multi-Attach (#5022).
+      version: 1.2.42
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/clusters/_template/bootstrap-kit/23-mimir.yaml
+++ b/clusters/_template/bootstrap-kit/23-mimir.yaml
@@ -120,7 +120,9 @@ spec:
       # 1.0.6 — #4343: gateway.resources + MinIO cpu requests so every
       #   container clears the host-ns Kyverno resource-requests Enforce
       #   policy (post-#4325).
-      version: 1.0.8
+      # 1.0.9: Catalyst-owned MinIO Deployment strategy Recreate — RWO
+      # single-replica roll deadlock under cutover step-08 (#5022).
+      version: 1.0.9
       sourceRef:
         kind: HelmRepository
         name: bp-mimir

--- a/clusters/_template/bootstrap-kit/25-grafana.yaml
+++ b/clusters/_template/bootstrap-kit/25-grafana.yaml
@@ -130,7 +130,9 @@ spec:
       # grafana instead of "n/a — bootstrap component, no Application CR".
       # 1.0.17 — #4347: grafana k8s-sidecar exec probes so the Pod clears the
       #   host-ns Kyverno probes-present Enforce policy (post-#4325). Refs #4347 #4325.
-      version: 1.0.17
+      # 1.0.18: deploymentStrategy Recreate — single-replica RWO grafana
+      # deadlocked cutover step-08's forced roll on Multi-Attach (#5022).
+      version: 1.0.18
       sourceRef:
         kind: HelmRepository
         name: bp-grafana

--- a/platform/grafana/blueprint.yaml
+++ b/platform/grafana/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.0.17  # lockstep with chart/Chart.yaml (#4347 grafana sidecar probes for host-ns Kyverno probes-present Enforce)
+  version: 1.0.18  # lockstep with chart/Chart.yaml (#5022 deploymentStrategy Recreate — RWO single-replica roll deadlock)
   card:
     title: Grafana
     family: insights

--- a/platform/grafana/chart/Chart.yaml
+++ b/platform/grafana/chart/Chart.yaml
@@ -1,5 +1,9 @@
 apiVersion: v2
 name: bp-grafana
+# 1.0.18 (#5022 — deploymentStrategy: Recreate. Single-replica Deployment +
+# RWO PVC + RollingUpdate(maxUnavailable rounds to 0) deadlocks every forced
+# roll on Multi-Attach (hw242 cutover step-08 240s roll-timeout FAILed the
+# leg). Recreate detaches the old pod first — same class as bp-gitea #3188.)
 description: |
   Catalyst Blueprint umbrella chart for Grafana. Depends on the upstream
   `grafana` chart (grafana/helm-charts) as a Helm subchart so
@@ -77,7 +81,7 @@ type: application
 #   DEAD (every Grafana datasource health-check failed → empty dashboards).
 #   Now mimir-gateway.mimir.svc:80 / loki.loki.svc:3100 / tempo.tempo.svc:3200
 #   (g115-datasources-dashboards.sh updated to match). Refs #4347 #4325.
-version: 1.0.17
+version: 1.0.18
 appVersion: "12.3.1"
 # 1.0.14 (#3374, 2026-06-14): raise the sidecar memory limit 64Mi → 192Mi
 # (request 32Mi → 64Mi). The 1.0.13 limit was too low for the

--- a/platform/grafana/chart/values.yaml
+++ b/platform/grafana/chart/values.yaml
@@ -28,6 +28,21 @@ grafana:
   # for HA.
   replicas: 1
 
+  # #5022 — grafana is a single-replica Deployment backed by an RWO PVC
+  # (persistence below). The upstream default RollingUpdate (maxUnavailable
+  # rounds to 0 at replicas=1) DEADLOCKS any forced roll: the old pod must
+  # stay Ready until the new pod is Ready, but the new pod can't attach the
+  # RWO volume until the old one detaches -> both ReplicaSets wedge
+  # ContainerCreating on Multi-Attach (proven live on hw242 -- the cutover
+  # step-08 deny-egress roll timed out at 240s and FAILed the leg; also
+  # bites normal Day-2 chart rolls). Recreate terminates + detaches the old
+  # pod FIRST -- the correct strategy for every single-replica RWO-backed
+  # workload (same fix class as bp-gitea #3188 / catalyst-api). Overlays
+  # that scale replicas>1 MUST also move persistence to RWX or per-replica
+  # storage before reverting this to RollingUpdate.
+  deploymentStrategy:
+    type: Recreate
+
   # Pin upstream image tag — DO NOT use floating tags per
   # docs/INVIOLABLE-PRINCIPLES.md.
   # #3375 — proxy-glob ALL grafana images through the Sovereign's local

--- a/platform/harbor/blueprint.yaml
+++ b/platform/harbor/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-5-storage-and-data
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.41  # lockstep with chart/Chart.yaml (#4913 harbor.<fqdn> HTTPRoute alias so the app-named host stops 404ing; UI stays canonical on registry.<fqdn>)
+  version: 1.2.42  # lockstep with chart/Chart.yaml (#5022 updateStrategy Recreate — jobservice RWO single-replica roll deadlock)
   card:
     title: Harbor
     family: foundation

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -1,5 +1,9 @@
 apiVersion: v2
 name: bp-harbor
+# 1.2.42 (#5022 — updateStrategy: Recreate (global; upstream has no
+# per-component knob). harbor-jobservice is a single-replica RWO-backed
+# Deployment; RollingUpdate deadlocks forced rolls on Multi-Attach (hw242
+# step-08). Upstream guidance: Recreate whenever fs persistence is on.)
 description: |
   Catalyst Blueprint umbrella chart for Harbor. Depends on the upstream
   `harbor` chart (goharbor/harbor-helm) as a Helm subchart so
@@ -166,7 +170,7 @@ type: application
 #   sign-in->/c/oidc/login redirect keeps its canonical hostname), so entry via
 #   harbor.<fqdn> lands on the canonical host with no loop. Also adds
 #   gateway.extraHosts (arbitrary aliases) + tests/httproute-render.sh Case 6.
-version: 1.2.41
+version: 1.2.42
 appVersion: "2.14.3"
 # 1.2.23 (G117.5 #2744, 2026-06-02): SSO defense-in-depth via Harbor's
 # `oidc_extra_redirect_parms` config field. The configure-oauth Job now

--- a/platform/harbor/chart/values.yaml
+++ b/platform/harbor/chart/values.yaml
@@ -380,8 +380,21 @@ harbor:
   logLevel: info
 
   # ─── Update strategy ──────────────────────────────────────────────────
+  # #5022 — Recreate, not RollingUpdate. The upstream harbor chart applies
+  # this strategy to its PERSISTENCE-BACKED Deployments (jobservice +
+  # registry — verified in the render; core/portal/nginx keep the k8s
+  # default RollingUpdate) and offers no per-component knob. harbor-
+  # jobservice is a single-replica Deployment backed by an RWO PVC (jobLog
+  # persistence): RollingUpdate (maxUnavailable rounds to 0 at replicas=1)
+  # DEADLOCKS any forced roll -- the new pod can't attach the RWO volume
+  # until the old one detaches, the old one must stay Ready until the new is
+  # Ready -> Multi-Attach wedge (proven live on hw242: cutover step-08 240s
+  # roll-timeout FAILed the leg; jobservice needed a manual scale-bounce).
+  # Upstream's own guidance: use Recreate whenever filesystem (RWO)
+  # persistence is enabled. Overlays running HA replicas + RWX/S3-only
+  # storage MAY flip back to RollingUpdate.
   updateStrategy:
-    type: RollingUpdate
+    type: Recreate
 
 # ─── Harbor admin credentials (issue #935) ────────────────────────────────
 # Catalyst-curated admin Secret that the umbrella chart materialises in

--- a/platform/mimir/blueprint.yaml
+++ b/platform/mimir/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.0.8
+  version: 1.0.9
   card:
     title: Mimir
     family: insights

--- a/platform/mimir/chart/Chart.yaml
+++ b/platform/mimir/chart/Chart.yaml
@@ -1,5 +1,8 @@
 apiVersion: v2
 name: bp-mimir
+# 1.0.9 (#5022 — Catalyst-owned MinIO Deployment strategy: Recreate (was
+# hardcoded RollingUpdate maxSurge:100%/maxUnavailable:0). Single-replica +
+# RWO PVC deadlocks every forced roll on Multi-Attach (hw242 step-08).)
 description: |
   Catalyst Blueprint umbrella chart for Grafana Mimir. Depends on the
   upstream `mimir-distributed` chart (grafana/helm-charts) as a Helm
@@ -31,7 +34,7 @@ type: application
 # every container satisfies the cluster-wide Kyverno `resource-requests`
 # Enforce policy. Post-#4325 this chart installs into the native host namespace
 # (not a vCluster) where the policy applies.
-version: 1.0.8
+version: 1.0.9
 appVersion: "3.0.4"
 keywords: [catalyst, blueprint, mimir, observability, metrics, prometheus]
 maintainers:

--- a/platform/mimir/chart/templates/devcluster-workloads.yaml
+++ b/platform/mimir/chart/templates/devcluster-workloads.yaml
@@ -652,11 +652,17 @@ metadata:
     {{- include "bp-mimir.labels" . | nindent 4 }}
     app.kubernetes.io/component: minio
 spec:
+  # #5022 — single-replica Deployment backed by an RWO PVC (`export` →
+  # PVC <release>-minio, evs-ssd). RollingUpdate with maxUnavailable:0
+  # DEADLOCKS on any forced roll (cutover step-08, Day-2 upgrades): the
+  # old pod must stay Ready until the new pod is Ready, but the new pod
+  # can't attach the RWO volume until the old one detaches → both RS
+  # wedge ContainerCreating on Multi-Attach (proven live on hw242, step-08
+  # 240s roll-timeout FAILed the leg). Recreate terminates + detaches the
+  # old pod FIRST — the correct strategy for every single-replica
+  # RWO-backed workload (same fix class as bp-gitea #3188 / catalyst-api).
   strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 100%
-      maxUnavailable: 0
+    type: Recreate
   replicas: 1
   selector:
     matchLabels:

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -681,7 +681,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.0.17"
+  version: "1.0.18"
   visibility: listed
   card:
     title: "Grafana"
@@ -703,7 +703,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-grafana
-    version: "1.0.17"
+    version: "1.0.18"
   # G117.1+G117.6 #2745-followup (2026-06-03): application-controller
   # fan-out reads spec.topology.perTopology[choice].placement.clusters[]
   # to render per-cluster HelmReleases. Without this block the controller
@@ -2179,7 +2179,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.0.8"
+  version: "1.0.9"
   visibility: listed
   card:
     title: "Mimir"
@@ -2198,7 +2198,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-mimir
-    version: "1.0.8"
+    version: "1.0.9"
   topology:
     supported:
     - active-passive
@@ -3306,7 +3306,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.2.41"
+  version: "1.2.42"
   visibility: unlisted
   card:
     title: "Harbor"
@@ -3330,7 +3330,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-harbor
-    version: "1.2.41"
+    version: "1.2.42"
   topology:
     supported:
     - active-hot-standby


### PR DESCRIPTION
## Problem

Cutover step-08 force-rolls every external-registry workload. For a **single-replica Deployment backed by an RWO PVC** under `RollingUpdate`, `maxUnavailable: 25%` rounds to **0** → the old pod must stay Ready until the new pod is Ready, but the new pod can't attach the RWO volume until the old one detaches → both ReplicaSets wedge `ContainerCreating` on `Multi-Attach`, and step-08's 240s roll-timeout FAILs the leg (proven live on hw242; also bites normal Day-2 chart rolls).

## Changes (lockstep, house set)

| Blueprint | Version | Change |
|---|---|---|
| bp-grafana | 1.0.17 → 1.0.18 | `grafana.deploymentStrategy.type: Recreate` (upstream default RollingUpdate; RWO `grafana` PVC) |
| bp-harbor | 1.2.41 → 1.2.42 | `harbor.updateStrategy.type: Recreate` — upstream applies this to its **persistence-backed** Deployments only (jobservice + registry; core/portal/nginx keep the k8s default RollingUpdate — verified in the render), no per-component knob exists. Upstream guidance: Recreate whenever fs persistence is enabled |
| bp-mimir | 1.0.8 → 1.0.9 | Catalyst-owned MinIO Deployment (`devcluster-workloads.yaml`) hardcoded `RollingUpdate maxSurge:100%/maxUnavailable:0` → `strategy: Recreate` |

## Audit of the rest of the stateful family

Full enumeration of PVC-backed Deployments live on hw242 + repo chart scan:

- **already Recreate in their charts**: gitea (#3188), catalyst-api (#4972 family) — no change needed
- **StatefulSets** (per-pod PVCs, delete-then-create update — no Multi-Attach window): openbao, loki, valkey, seaweedfs master/filer/volume, dragonfly redis/mysql
- **PVC-less Deployments**: powerdns, dnsdist, seaweedfs-s3, openbao sso-*

No other Deployment+RWO+RollingUpdate shape exists in the platform set.

## Gates

`helm lint` 3/3; rendered-strategy verification: grafana `Recreate` (PVC `grafana`), harbor-jobservice + harbor-registry `Recreate`, mimir-minio `Recreate`; stateless harbor components unchanged.

## Live-heal twins (hw242)

grafana + harbor strategy overrides land via sovereign-local Gitea bootstrap-kit slot values (strategy-only change — no pod roll); mimir-minio is chart-only (the pinned bp-mimir\@1.0.8 hardcodes the strategy with no values knob — its next step-08 roll stays in the tolerated rollout-incomplete-but-serving state since the old pod keeps serving under maxUnavailable:0).

Refs #5022

🤖 Generated with [Claude Code](https://claude.com/claude-code)