### PR TITLE
fix(#5017 #5022 #5014): provider-CIDR population + step-08 DS budgets, registry-pivot exclusion, driver CCNP reap backstop

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -818,7 +818,10 @@ spec:
       # tree) from the local Gitea mid-cutover (hw242), breaking both flux
       # GitRepositories. Explicit refspecs never prune remote-only refs. Still 11
       # steps / 10 job-mode.
-      version: 0.1.121
+      # 0.1.122 (#5017 keystone): egressTest.allowProviderCIDRs documented
+      # chart default + populated here from PROVIDER_API_CIDRS_YAML;
+      # cutover-contract Case 47 asserts the provider-CIDR wiring renders.
+      version: 0.1.122
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover
@@ -934,6 +937,20 @@ spec:
     # a tether the preceding steps 01-07 already pivoted off.
     egressTest:
       enforceCIDRBlock: true
+      # #5017 keystone (hw242, 2026-07-12): the deny-egress hold must ALLOW
+      # the IaaS provider control-plane API so the CSI driver can attach
+      # volumes for pods that (re)schedule DURING the hold — step-08's own
+      # force-roll guarantees such pods. This was EMPTY on hw242 (the #4596
+      # chart comment claimed "cloud-init populates per region" but the
+      # population site never existed) → the CCNP omitted the kom4dc API /24
+      # (212.72.2.0/24 — ecs/evs/obs/iam/vpc/elb.me-east-215.kom4dc.
+      # nationalcloud.om all resolve there) → every EVS attach froze for the
+      # whole hold. PROVIDER_API_CIDRS_YAML is an inline-YAML array threaded
+      # from infra/providers/<cloud>/variables.tf provider_api_cidrs (Huawei
+      # default ["212.72.2.0/24"], Hetzner default []) via the cloud-init
+      # postBuild substitute map. Provider API ranges ONLY — the mothership
+      # + bastion live in different ranges and stay denied.
+      allowProviderCIDRs: ${PROVIDER_API_CIDRS_YAML:=[]}
       # #4975 (Refs #3379 #3695): the Sovereign-local registry host is the FULL
       # `registry.${SOVEREIGN_FQDN}` (bp-harbor's HTTPRoute, see 19-harbor.yaml +
       # harborPublicURL above). The step-08 roll-set classifies a workload as

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -510,6 +510,14 @@ write_files:
             SOVEREIGN_FQDN: ${sovereign_fqdn}
             SOVEREIGN_FQDN_DASHED: ${sovereign_fqdn_slug}
             PROVIDER: ${provider}
+            # #5017 keystone (hw242) -- IaaS provider control-plane API CIDRs the
+            # cutover step-08 deny-egress hold must ALLOW so the CSI driver can
+            # still attach volumes mid-hold (Huawei kom4dc: the API /24 where
+            # ecs/evs/obs/iam/vpc/elb resolve). Inline-YAML array computed by
+            # each provider's main.tf from var.provider_api_cidrs (Huawei
+            # default ["212.72.2.0/24"], Hetzner default []). Threads into the
+            # 06a slot's egressTest.allowProviderCIDRs.
+            PROVIDER_API_CIDRS_YAML: '${provider_api_cidrs_yaml}'
             SOVEREIGN_DEPLOYMENT_ID: ${deployment_id}
             # #4236 console-ELB IPv4 → slot-13 sovereignConsoleLBIP (see that file).
             SOVEREIGN_CONSOLE_LB_IP: ${console_load_balancer_ipv4}

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -510,14 +510,10 @@ write_files:
             SOVEREIGN_FQDN: ${sovereign_fqdn}
             SOVEREIGN_FQDN_DASHED: ${sovereign_fqdn_slug}
             PROVIDER: ${provider}
-            # #5017 keystone (hw242) -- IaaS provider control-plane API CIDRs the
-            # cutover step-08 deny-egress hold must ALLOW so the CSI driver can
-            # still attach volumes mid-hold (Huawei kom4dc: the API /24 where
-            # ecs/evs/obs/iam/vpc/elb resolve). Inline-YAML array computed by
-            # each provider's main.tf from var.provider_api_cidrs (Huawei
-            # default ["212.72.2.0/24"], Hetzner default []). Threads into the
-            # 06a slot's egressTest.allowProviderCIDRs.
+%{ if provider_api_cidrs_yaml != "[]" ~}
+            # #5017 step-08 deny-egress provider-API allow (docs: infra vars).
             PROVIDER_API_CIDRS_YAML: '${provider_api_cidrs_yaml}'
+%{ endif ~}
             SOVEREIGN_DEPLOYMENT_ID: ${deployment_id}
             # #4236 console-ELB IPv4 → slot-13 sovereignConsoleLBIP (see that file).
             SOVEREIGN_CONSOLE_LB_IP: ${console_load_balancer_ipv4}

--- a/infra/providers/_shared/tests/render.tf
+++ b/infra/providers/_shared/tests/render.tf
@@ -72,6 +72,9 @@ locals {
     node_external_ip_cmd              = "echo 203.0.113.10"
     node_external_ip_value            = "203.0.113.10"
     clustermesh_proxy_port            = 12379
+    # #5017 keystone — provider API CIDRs (inline-YAML array) for the step-08
+    # deny-egress allow-list; every real templatefile() map supplies it.
+    provider_api_cidrs_yaml           = "[]"
     k3s_extra_args                    = ""
     registry_mirror_yaml              = "mirrors: {}"
     catalyst_api_url                  = "https://console.example.test"

--- a/infra/providers/hetzner/main.tf
+++ b/infra/providers/hetzner/main.tf
@@ -971,10 +971,13 @@ locals {
     # EXCEPT sovereign_region_role: it now feeds the SHARED
     # SOVEREIGN_REGION_ROLE substitute (bp-cnpg-pair split-side, slot 16b
     # `cnpgPair.side`), so the per-CP value is live on Hetzner too.
-    pdns_api_host          = ""
-    sovereign_region_role  = "primary"
-    node_external_ip_value = ""
-    clustermesh_proxy_port = 12379 # #4784 — inert on Hetzner (clustermesh-proxy off; hcloud-ccm LB IP has no k3s-etcd :2379 host collision)
+    pdns_api_host = ""
+    # #5017 keystone — provider API CIDRs for the step-08 deny-egress
+    # allow-list (empty on Hetzner; see variables.tf provider_api_cidrs).
+    provider_api_cidrs_yaml = jsonencode(var.provider_api_cidrs)
+    sovereign_region_role   = "primary"
+    node_external_ip_value  = ""
+    clustermesh_proxy_port  = 12379 # #4784 — inert on Hetzner (clustermesh-proxy off; hcloud-ccm LB IP has no k3s-etcd :2379 host collision)
 
     # ── Provider-injected strings (the §5 hard-dependency exceptions) ──
     registry_mirror_yaml          = local.registry_mirror_yaml_hetzner
@@ -1515,10 +1518,13 @@ locals {
       # Huawei-branch substitute vars — inert on Hetzner (see primary call),
       # EXCEPT sovereign_region_role: live via the shared
       # SOVEREIGN_REGION_ROLE substitute (bp-cnpg-pair split-side).
-      pdns_api_host          = ""
-      sovereign_region_role  = "secondary"
-      node_external_ip_value = ""
-      clustermesh_proxy_port = 12379 # #4784 — inert on Hetzner (clustermesh-proxy off)
+      pdns_api_host = ""
+      # #5017 keystone — provider API CIDRs for the step-08 deny-egress
+      # allow-list (empty on Hetzner; see variables.tf provider_api_cidrs).
+      provider_api_cidrs_yaml = jsonencode(var.provider_api_cidrs)
+      sovereign_region_role   = "secondary"
+      node_external_ip_value  = ""
+      clustermesh_proxy_port  = 12379 # #4784 — inert on Hetzner (clustermesh-proxy off)
 
       # ── Provider-injected strings (the §5 hard-dependency exceptions) ──
       registry_mirror_yaml     = local.registry_mirror_yaml_hetzner

--- a/infra/providers/hetzner/variables.tf
+++ b/infra/providers/hetzner/variables.tf
@@ -1051,3 +1051,23 @@ variable "handover_jwt_public_key" {
   sensitive   = true
   default     = ""
 }
+
+variable "provider_api_cidrs" {
+  description = <<-EOT
+    #5017 keystone — IaaS provider control-plane API CIDR allow-list for
+    the cutover step-08 deny-egress hold (see the Huawei twin for the
+    full rationale). Default EMPTY on Hetzner: api.hetzner.cloud sits on
+    changing public IPs that cannot be CIDR-pinned, and the hcloud CSI
+    tolerated the hold historically; operators MAY pin a range via
+    tfvars if Hetzner ever publishes stable API CIDRs. Threads through
+    cloudinit-control-plane.tftpl postBuild substitute
+    PROVIDER_API_CIDRS_YAML into the 06a bootstrap-kit slot
+    (egressTest.allowProviderCIDRs).
+  EOT
+  type        = list(string)
+  default     = []
+  validation {
+    condition     = alltrue([for c in var.provider_api_cidrs : can(cidrhost(c, 0))])
+    error_message = "provider_api_cidrs entries must be valid CIDR blocks."
+  }
+}

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -1128,9 +1128,12 @@ locals {
       primary_region_canonical_label = "hw-${var.regions[0].code}-rtz-prod"
       replica_region_canonical_label = length(var.regions) > 1 ? "hw-${var.regions[1].code}-rtz-prod" : ""
       # #2940: per-Sovereign PDNS endpoint override (bootstrap-kit substitute).
-      pdns_api_host   = var.pdns_api_host
-      gitops_repo_url = var.gitops_repo_url
-      gitops_branch   = var.gitops_branch
+      pdns_api_host = var.pdns_api_host
+      # #5017 keystone — kom4dc provider API /24 for the step-08 deny-egress
+      # allow-list (egressTest.allowProviderCIDRs via PROVIDER_API_CIDRS_YAML).
+      provider_api_cidrs_yaml = jsonencode(var.provider_api_cidrs)
+      gitops_repo_url         = var.gitops_repo_url
+      gitops_branch           = var.gitops_branch
       parent_domains_yaml = coalesce(
         var.parent_domains_yaml,
         format("[{name: \"%s\", role: \"primary\"}]", var.sovereign_fqdn)

--- a/infra/providers/huawei/variables.tf
+++ b/infra/providers/huawei/variables.tf
@@ -656,3 +656,26 @@ variable "clustermesh_proxy_port" {
     error_message = "clustermesh_proxy_port must be a host port below the k8s NodePort range (30000-32767; §854) and NOT 2379/2380 (k3s embedded etcd on the CP-node host)."
   }
 }
+
+variable "provider_api_cidrs" {
+  description = <<-EOT
+    #5017 keystone (hw242, 2026-07-12) — IaaS provider control-plane API
+    CIDR allow-list for the cutover step-08 deny-egress hold. The hold
+    black-holes the mothership but must NOT deny the cloud the Sovereign
+    runs ON: the EVS CSI driver dials the provider API to attach volumes
+    for any pod that (re)schedules during the hold. On kom4dc every
+    provider API endpoint (ecs/evs/obs/iam/vpc/elb
+    .me-east-215.kom4dc.nationalcloud.om) resolves into 212.72.2.0/24 —
+    the API /24 ONLY: it excludes the bastion (.24.x) and the
+    GitHub/mothership ranges, which stay denied. Threads through
+    cloudinit-control-plane.tftpl postBuild substitute
+    PROVIDER_API_CIDRS_YAML into the 06a bootstrap-kit slot
+    (egressTest.allowProviderCIDRs).
+  EOT
+  type        = list(string)
+  default     = ["212.72.2.0/24"]
+  validation {
+    condition     = alltrue([for c in var.provider_api_cidrs : can(cidrhost(c, 0))])
+    error_message = "provider_api_cidrs entries must be valid CIDR blocks."
+  }
+}

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.121
+  version: 0.1.122
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,14 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.122 (#5017 keystone Refs #3379 — hw242, 2026-07-12: step-08's deny-egress
+# CCNP omitted the IaaS provider API CIDR because egressTest.allowProviderCIDRs
+# was EMPTY: the #4596 comment claimed "cloud-init populates per region" but the
+# population site never existed. The kom4dc API /24 (212.72.2.0/24) was denied →
+# every EVS attach froze for the whole hold → the step-08 force-rolls could
+# never complete. Now populated end-to-end: infra provider_api_cidrs var →
+# cloudinit PROVIDER_API_CIDRS_YAML substitute → 06a slot
+# egressTest.allowProviderCIDRs; chart values document the [] default; contract
+# Case 47 asserts the env wiring + the CCNP writer's provider-CIDR loop.)
 # 0.1.121 (#5011 Refs #3379 #4991 — step-01 gitea-mirror's mirror-mode force-push
 # PRUNED sovereign-local Gitea branches; found LIVE on hw242, dep f05b0718dac62fe9,
 # 2026-07-12 — the first-ever post-step-01 GitOps observation: prior cycles walked
@@ -1925,7 +1934,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.121
+version: 0.1.122
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -8,7 +8,17 @@ name: bp-self-sovereign-cutover
 # never complete. Now populated end-to-end: infra provider_api_cidrs var →
 # cloudinit PROVIDER_API_CIDRS_YAML substitute → 06a slot
 # egressTest.allowProviderCIDRs; chart values document the [] default; contract
-# Case 47 asserts the env wiring + the CCNP writer's provider-CIDR loop.)
+# Case 47 asserts the env wiring + the CCNP writer's provider-CIDR loop.
+# ALSO in 0.1.122 (#5022 / #5014, hw242 run 3): (a) freshPullProof
+# timeoutSeconds 240 -> 600 + per-node DaemonSet budget (dsPerNodeSeconds,
+# 6-node DS sequential pulls blew the flat budget — Case 48); (b) the
+# registry-pivot DS is excluded from the step-08 roll-set by name
+# (freshPullProof.excludeWorkloads — rolling the pivot mechanism mid-hold is
+# recursive — Case 49); (c) driver-side backstop: catalyst-api's
+# runCutoverStep now reaps the cutover-egress-block CCNP on ANY
+# egress-block-test exit (success/fail/watch-loss/deadline — the Job's traps
+# can't run on SIGKILL; the leaked policy froze CSI 3x) with a
+# resourceNames-scoped delete added to clusterrole-cutover-driver.)
 # 0.1.121 (#5011 Refs #3379 #4991 — step-01 gitea-mirror's mirror-mode force-push
 # PRUNED sovereign-local Gitea branches; found LIVE on hw242, dep f05b0718dac62fe9,
 # 2026-07-12 — the first-ever post-step-01 GitOps observation: prior cycles walked

--- a/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
@@ -160,6 +160,14 @@ data:
             value: {{ .Values.egressTest.freshPullProof.excludeDeploymentSubstring | quote }}
           - name: FRESH_PULL_TIMEOUT
             value: {{ .Values.egressTest.freshPullProof.timeoutSeconds | quote }}
+          # #5022 — DaemonSet rollouts are per-node sequential under
+          # RollingUpdate(maxUnavailable:1); budget scales with node count.
+          - name: FRESH_PULL_DS_PER_NODE
+            value: {{ .Values.egressTest.freshPullProof.dsPerNodeSeconds | default 120 | quote }}
+          # #5022 — "<ns>/<name>" pairs never rolled by the sweep (the
+          # registry-pivot DS is the pivot mechanism itself — recursive).
+          - name: FRESH_PULL_EXCLUDE_WORKLOADS
+            value: {{ .Values.egressTest.freshPullProof.excludeWorkloads | default (list "catalyst/registry-pivot") | join " " | quote }}
         volumeMounts:
           # #3379 (hw139, 2026-06-15): WRITABLE emptyDir at /work. The
           # container runs readOnlyRootFilesystem:true (securityContext
@@ -644,10 +652,20 @@ data:
             # errors (rollout status alone would just time out on a BackOff).
             roll_and_check_workload() {
               kind="$1"; ns="$2"; name="$3"
-              echo "  rolling ${kind}/${name} -n ${ns} (forces fresh pull from local registry)"
+              # #5022 — a multi-node DaemonSet rolls per-node SEQUENTIALLY
+              # under RollingUpdate(maxUnavailable:1): scale the budget with
+              # the node count (hw242 run 3: 6-node registry-pivot + falco
+              # blew the flat budget spuriously).
+              roll_timeout="${FRESH_PULL_TIMEOUT}"
+              if [ "${kind}" = "daemonset" ]; then
+                ds_nodes=$(kubectl get daemonset "${name}" -n "${ns}" -o jsonpath='{.status.desiredNumberScheduled}' 2>/dev/null || echo 1)
+                ds_budget=$(( ${ds_nodes:-1} * ${FRESH_PULL_DS_PER_NODE:-120} ))
+                [ "${ds_budget}" -gt "${roll_timeout}" ] && roll_timeout="${ds_budget}"
+              fi
+              echo "  rolling ${kind}/${name} -n ${ns} (forces fresh pull from local registry; budget ${roll_timeout}s)"
               kubectl rollout restart "${kind}/${name}" -n "${ns}" >/dev/null 2>&1 || true
               # Bounded wait; rollout status returns non-zero on timeout.
-              if kubectl rollout status "${kind}/${name}" -n "${ns}" --timeout="${FRESH_PULL_TIMEOUT}s" >/dev/null 2>&1; then
+              if kubectl rollout status "${kind}/${name}" -n "${ns}" --timeout="${roll_timeout}s" >/dev/null 2>&1; then
                 echo "    PASS — ${kind}/${name} rolled out (images pulled from local registry under deny-egress)"
                 return 0
               fi
@@ -716,7 +734,7 @@ data:
                 echo "    PASS — ${kind}/${name} pulled a fresh image from the local registry under deny-egress (new-revision Pod started a container; rollout status incomplete = slow init/DB-migration on a Recreate single-replica stateful workload, e.g. bp-gitea #3188 — readiness lag is judged by the survival-window HR poll, not a mothership tether) (#4975)"
                 return 0
               fi
-              echo "    FAIL — ${kind}/${name} did not roll out within ${FRESH_PULL_TIMEOUT}s under deny-egress (reasons:${reasons:-<none>})"
+              echo "    FAIL — ${kind}/${name} did not roll out within ${roll_timeout}s under deny-egress (reasons:${reasons:-<none>})"
               return 1
             }
 
@@ -752,6 +770,16 @@ data:
               for _x in ${EXCLUDED_HOSTS} ${EXCLUDED_SUBSTRINGS}; do
                 [ -z "${_x}" ] && continue
                 targets=$(printf '%s\n' "${targets}" | grep -vF "${_x}" || true)
+              done
+              # #5022 — name-scoped exclusions ("<ns>/<name>"): the registry-
+              # pivot DS is the certs.d/hosts pivot mechanism every OTHER
+              # fresh pull depends on; rolling it mid-hold is recursive and
+              # its health is already asserted by the step-04 daemonset-wait
+              # + per-node v2 ACKs. Rows are "kind ns name=imgs".
+              for _w in ${FRESH_PULL_EXCLUDE_WORKLOADS}; do
+                [ -z "${_w}" ] && continue
+                _wns="${_w%%/*}"; _wname="${_w##*/}"
+                targets=$(printf '%s\n' "${targets}" | grep -vE "^[a-z]+ ${_wns} ${_wname}=" || true)
               done
               if [ -z "${targets}" ]; then
                 echo "  no external-registry workloads found — every workload already pulls from the local registry (PASS)"

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -1916,4 +1916,46 @@ if [ -z "$a_ln" ] || [ -z "$p_ln" ] || [ -z "$e_ln" ] || [ "$a_ln" -ge "$p_ln" ]
 fi
 echo "  PASS (allowProviderCIDRs → Job env → CCNP toCIDR allow-list; default empty)"
 
+echo "[cutover-contract] Case 48: Step-08 fresh-pull budget — 600s default + per-node DaemonSet scaling (#5022, hw242 run 3)"
+# A 6-node DaemonSet rolls per-node SEQUENTIALLY under RollingUpdate
+# (maxUnavailable:1); the flat 240s budget FAILed registry-pivot + falco
+# spuriously. Locks: (1) values default timeoutSeconds=600 reaches the Job
+# env; (2) the DS per-node budget env renders (default 120); (3) the script
+# computes a daemonset-scaled roll_timeout from desiredNumberScheduled and
+# uses it for `kubectl rollout status`.
+if ! grep -A1 'name: FRESH_PULL_TIMEOUT' "$TMP/render.yaml" | grep -q 'value: "600"'; then
+  echo "FAIL: freshPullProof.timeoutSeconds default must be 600 (multi-node DS sequential pulls blew 240s live) (#5022)" >&2
+  exit 1
+fi
+if ! grep -A1 'name: FRESH_PULL_DS_PER_NODE' "$TMP/render.yaml" | grep -q 'value: "120"'; then
+  echo "FAIL: FRESH_PULL_DS_PER_NODE env missing or default != 120 (#5022)" >&2
+  exit 1
+fi
+step08_all="$(awk '/cutover-order: "8"/{c=1} c{print}' "$TMP/render.yaml")"
+if ! grep -q 'desiredNumberScheduled' <<<"$step08_all"; then
+  echo "FAIL: roll_and_check_workload does not scale the DaemonSet budget from desiredNumberScheduled (#5022)" >&2
+  exit 1
+fi
+if ! grep -q -- '--timeout="${roll_timeout}s"' <<<"$step08_all"; then
+  echo "FAIL: rollout status must use the computed \${roll_timeout} budget, not the flat FRESH_PULL_TIMEOUT (#5022)" >&2
+  exit 1
+fi
+echo "  PASS (600s default; DS budget = max(default, nodes x 120s); rollout status uses the computed budget)"
+
+echo "[cutover-contract] Case 49: Step-08 roll-set NEVER includes the registry-pivot DaemonSet — the pivot mechanism itself is excluded by name (#5022, hw242 run 3)"
+# Rolling catalyst/registry-pivot mid-hold is recursive: a mid-roll node
+# briefly loses the certs.d/hosts pivot exactly while other workloads'
+# fresh pulls are being proven on that node, and its readiness gate
+# (first-reconcile-pass) was already asserted by the step-04
+# daemonset-wait + per-node v2 ACKs.
+if ! grep -A1 'name: FRESH_PULL_EXCLUDE_WORKLOADS' "$TMP/render.yaml" | grep -q 'value: "catalyst/registry-pivot"'; then
+  echo "FAIL: FRESH_PULL_EXCLUDE_WORKLOADS default must carry catalyst/registry-pivot (#5022)" >&2
+  exit 1
+fi
+if ! grep -q 'for _w in ${FRESH_PULL_EXCLUDE_WORKLOADS}' <<<"$step08_all"; then
+  echo "FAIL: run_fresh_pull_all has no name-scoped workload-exclusion loop (#5022)" >&2
+  exit 1
+fi
+echo "  PASS (registry-pivot excluded from the roll-set by ns/name; values-overridable)"
+
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -1876,4 +1876,44 @@ if ! grep -E 'git push --force .*refs/heads/\*:refs/heads/\*.*refs/tags/\*:refs/
 fi
 echo "  PASS (Step-01 pushes refs/heads/* + refs/tags/* explicitly with --force; mirror mode absent — sovereign-local branches survive)"
 
+echo "[cutover-contract] Case 47: Step-08 deny-egress CCNP allows the IaaS provider API CIDRs — egressTest.allowProviderCIDRs threads into PROVIDER_API_CIDRS + the CCNP writer's toCIDR loop (#5017 keystone, Refs #4596 #3379)"
+# hw242 live (2026-07-12): the deny-egress hold omitted the Huawei kom4dc API
+# /24 (212.72.2.0/24) because egressTest.allowProviderCIDRs was EMPTY — the
+# #4596 comment claimed "cloud-init populates per region" but the population
+# site never existed. Every EVS attach froze for the whole hold, so the
+# step-08 force-rolls could never complete. This case locks the CHART half of
+# the population chain (infra provider_api_cidrs → cloudinit
+# PROVIDER_API_CIDRS_YAML → 06a slot → these values): the value must reach the
+# Job env AND the CCNP writer must emit each entry under the allow toCIDR.
+helm template smoke-providercidr . --set 'egressTest.allowProviderCIDRs={212.72.2.0/24}' > "$TMP/render-providercidr.yaml"
+# (1) the Job env carries the provider CIDR (space-joined list).
+if ! grep -A1 'name: PROVIDER_API_CIDRS' "$TMP/render-providercidr.yaml" | grep -q 'value: "212.72.2.0/24"'; then
+  echo "FAIL: egressTest.allowProviderCIDRs does not reach the Step-08 Job env PROVIDER_API_CIDRS (#5017)" >&2
+  exit 1
+fi
+# (2) default render → env EMPTY (providers without a pinnable API range are a
+# no-op; the allow-list never silently widens).
+if ! grep -A1 'name: PROVIDER_API_CIDRS' "$TMP/render.yaml" | grep -q 'value: ""'; then
+  echo "FAIL: PROVIDER_API_CIDRS must default to empty (chart default allowProviderCIDRs: []) (#5017)" >&2
+  exit 1
+fi
+# (3) the step-08 script writes each PROVIDER_API_CIDRS entry into the CCNP —
+# the writer loop must sit INSIDE the default-deny allow-list (toCIDR) section,
+# i.e. after the ALLOW_CIDRS loop and before the toEntities block.
+step08_block="$(awk '/name: cutover-egress-block-test-script|cutover-order: "8"/{c=1} c{print}' "$TMP/render-providercidr.yaml")"
+if ! grep -q 'for cidr in ${PROVIDER_API_CIDRS}' <<<"$step08_block"; then
+  echo "FAIL: Step-08 CCNP writer has no PROVIDER_API_CIDRS loop — provider API CIDRs never reach the deny-egress allow-list (#5017)" >&2
+  exit 1
+fi
+# Line-order anchors: the PROVIDER loop must sit after the ALLOW_CIDRS loop
+# and before the EMITTED toEntities line (not a comment mention of it).
+a_ln="$(grep -n 'for cidr in ${ALLOW_CIDRS}' <<<"$step08_block" | head -1 | cut -d: -f1)"
+p_ln="$(grep -n 'for cidr in ${PROVIDER_API_CIDRS}' <<<"$step08_block" | head -1 | cut -d: -f1)"
+e_ln="$(grep -n 'echo "    - toEntities:"' <<<"$step08_block" | head -1 | cut -d: -f1)"
+if [ -z "$a_ln" ] || [ -z "$p_ln" ] || [ -z "$e_ln" ] || [ "$a_ln" -ge "$p_ln" ] || [ "$p_ln" -ge "$e_ln" ]; then
+  echo "FAIL: PROVIDER_API_CIDRS loop must emit inside the CCNP toCIDR allow-list (after ALLOW_CIDRS at line ${a_ln:-?}, before the toEntities emit at line ${e_ln:-?}; got PROVIDER at line ${p_ln:-?}) (#5017)" >&2
+  exit 1
+fi
+echo "  PASS (allowProviderCIDRs → Job env → CCNP toCIDR allow-list; default empty)"
+
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -1208,6 +1208,24 @@ egressTest:
     - "10.42.0.0/16"   # k3s pod CIDR (Cilium cluster-pool default)
     - "10.43.0.0/16"   # k3s service CIDR
     - "10.96.0.0/12"   # k8s default service CIDR (apiserver 10.96.0.1, CoreDNS)
+  # #4596 / #5017 keystone (hw242, 2026-07-12) — IaaS PROVIDER control-plane
+  # API CIDR allow-list for the deny-egress hold. The hold must black-hole
+  # the MOTHERSHIP, NOT the cloud the Sovereign runs ON: the CSI driver
+  # needs the provider API (Huawei ECS/EVS, …) to attach volumes for any
+  # pod that (re)schedules DURING the hold — step-08's own force-roll
+  # guarantees such pods. On hw242 this list was EMPTY (the #4596 comment
+  # claimed "cloud-init populates per region" but the population site was
+  # never built) → the CCNP omitted the kom4dc API /24 (212.72.2.0/24,
+  # where ecs/evs/obs/iam/vpc/elb.me-east-215.kom4dc.nationalcloud.om all
+  # resolve) → every EVS attach froze for the whole hold. NOW POPULATED
+  # end-to-end: infra/providers/<cloud>/variables.tf `provider_api_cidrs`
+  # (Huawei default ["212.72.2.0/24"], Hetzner default []) → templatefile →
+  # cloud-init postBuild substitute PROVIDER_API_CIDRS_YAML → 06a slot
+  # `egressTest.allowProviderCIDRs`. Empty default here = no-op on
+  # providers whose CSI/control-plane rides the cluster/host paths. These
+  # are the provider API ranges ONLY — the mothership + bastion live in
+  # different ranges and stay denied.
+  allowProviderCIDRs: []
   # #3678 — active call-home assertion. During the hold, the Step-08 Job
   # curls each of these hosts FROM a pod under the policy; if ANY connects,
   # the deny-egress is leaky and the proof FAILS (cutoverComplete stays

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -1177,12 +1177,29 @@ egressTest:
     # Deployment name substring NEVER selected by auto-discovery (the
     # cutover runs inside catalyst-api; bouncing it mid-hold is unsafe).
     excludeDeploymentSubstring: "catalyst-api"
-    # How long to wait for the freshly-rolled Pod to reach Running with its
-    # image pulled. 240s is generous: the image is in local Harbor (Step-03
-    # prewarm / Step-04 mirror) so the pull is typically seconds; the extra
-    # headroom covers scheduler + container-create. A Pod still not Running
-    # at the deadline — or any ImagePull error observed — FAILS the proof.
-    timeoutSeconds: 240
+    # How long to wait for the freshly-rolled workload's rollout to settle.
+    # 240 → 600 (#5022, hw242 run 3): a Deployment's pull is seconds (local
+    # mirror), but `kubectl rollout status` on a MULTI-NODE DaemonSet under
+    # RollingUpdate(maxUnavailable:1) is SEQUENTIAL — 6 nodes x (pull +
+    # start + ready) blew the 240s budget and FAILed registry-pivot + falco
+    # spuriously. 600s covers a 6-node Sovereign; DaemonSets additionally
+    # get a per-node budget below. Any ImagePull error observed still FAILS
+    # immediately regardless of the budget.
+    timeoutSeconds: 600
+    # Per-node rollout budget for DaemonSets (#5022): the effective per-DS
+    # timeout is max(timeoutSeconds, desiredNumberScheduled x
+    # dsPerNodeSeconds), so a wide cluster scales its budget with node
+    # count instead of failing on a constant.
+    dsPerNodeSeconds: 120
+    # Workloads NEVER rolled by step-08's fresh-pull sweep, as "<ns>/<name>"
+    # pairs (#5022, hw242 run 3). catalyst/registry-pivot IS the pivot
+    # mechanism itself — the certs.d/hosts mirror every OTHER fresh pull
+    # depends on. Rolling it mid-hold is recursive: a mid-roll node briefly
+    # loses its registry pivot exactly while the proof pulls images on that
+    # node, and its readiness (first-reconcile-pass gate) was already
+    # proven by the step-04 daemonset-wait + per-node v2 ACK assertions.
+    excludeWorkloads:
+      - "catalyst/registry-pivot"
   # #3678 — TRUE deny-egress shape. defaultDenyEgress flips the Step-08
   # CCNP from a SUBTRACTIVE 4-CIDR block (default-allow, deny only the
   # listed hosts — which left console.openova.io + every un-enumerated

--- a/products/catalyst/bootstrap/api/internal/handler/cutover.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover.go
@@ -168,6 +168,13 @@ const (
 	// registry-pivot DaemonSet-wait then asserts per-node v2 acks.
 	cutoverStepHarborPrewarm = "harbor-prewarm"
 	cutoverStepRegistryPivot = "registry-pivot"
+	// #5014: the step whose Job applies the 10-min deny-egress hold. The
+	// driver reaps its CiliumClusterwideNetworkPolicy on ANY step exit —
+	// the Job's own TERM/EXIT traps cover clean paths, but a SIGKILLed pod
+	// (activeDeadlineSeconds hard-kill after the grace window), a watch
+	// loss, or an engine error LEAKED the policy 3x on hw242 (2026-07-12),
+	// freezing every CSI volume attach until hand-healed.
+	cutoverStepEgressBlockTest = "egress-block-test"
 
 	// SSE phase names.
 	cutoverPhaseStepStarted  = "cutover-step-started"
@@ -1010,6 +1017,33 @@ func watchJobToCompletion(ctx context.Context, deps *cutoverDeps, jobName string
 
 // terminalJobCondition returns (Complete|Failed, true) if the Job has
 // a terminal condition with status=True; otherwise (_, false).
+// cutoverEgressBlockPolicyAbsPath is the REST path of the step-08 deny-egress
+// CiliumClusterwideNetworkPolicy (cluster-scoped CRD object; cutoverDeps only
+// carries a typed clientset, so the delete goes through the discovery
+// RESTClient rather than adding a dynamic-client dependency to every test).
+const cutoverEgressBlockPolicyAbsPath = "/apis/cilium.io/v2/ciliumclusterwidenetworkpolicies/cutover-egress-block"
+
+// reapCutoverEgressPolicy deletes the step-08 deny-egress hold policy.
+// #5014: called via defer on EVERY exit of the egress-block-test step —
+// success, Job-Failed, watch loss, deadline, engine error — so a leaked
+// cutover-egress-block CCNP can never outlive the step and freeze CSI
+// attaches cluster-wide (leaked 3x on hw242, 2026-07-12: the Job's own
+// TERM/EXIT trap does not run when the pod is SIGKILLed after the
+// termination grace window, and a driver watch-loss abandons the Job
+// entirely). NotFound is success (the Job's trap usually got there first).
+// Overridable seam for unit tests (fake clientsets expose no REST client).
+var reapCutoverEgressPolicy = func(ctx context.Context, deps *cutoverDeps) error {
+	rc := deps.core.Discovery().RESTClient()
+	if rc == nil {
+		// Fake clientsets (unit tests) have no discovery REST client.
+		return nil
+	}
+	if err := rc.Delete().AbsPath(cutoverEgressBlockPolicyAbsPath).Do(ctx).Error(); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}
+
 func terminalJobCondition(job *batchv1.Job) (batchv1.JobConditionType, bool) {
 	for _, c := range job.Status.Conditions {
 		if c.Status != corev1.ConditionTrue {
@@ -1488,6 +1522,40 @@ func (h *Handler) runCutover(ctx context.Context, deps *cutoverDeps, steps []cut
 
 func (h *Handler) runCutoverStep(ctx context.Context, deps *cutoverDeps, step cutoverStep, runEpoch int64, operatorRetry bool) error {
 	bus := h.cutoverBusFor()
+
+	// ── #5014: deny-egress hold backstop ────────────────────────────────
+	// Whatever way the egress-block-test step exits — success, Job Failed,
+	// watch loss, step deadline, status-patch error — the cluster-wide
+	// cutover-egress-block CCNP MUST NOT outlive it: a leaked hold policy
+	// black-holes the IaaS provider API and freezes every CSI volume
+	// attach on the Sovereign (leaked 3x live on hw242, 2026-07-12). The
+	// Job's own TERM/EXIT traps cover the clean paths; this defer covers
+	// the SIGKILL/watch-loss/error paths the traps cannot. A fresh context
+	// is used deliberately: on watch-loss the step ctx is already dead —
+	// exactly the leak path this closes.
+	if step.stepName == cutoverStepEgressBlockTest {
+		defer func() {
+			rctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			if err := reapCutoverEgressPolicy(rctx, deps); err != nil {
+				h.publishCutoverEvent(bus, cutoverEvent{
+					Time:    time.Now().UTC().Format(time.RFC3339),
+					Phase:   cutoverPhaseStepFinished,
+					Level:   "warn",
+					Step:    step.stepName,
+					Message: fmt.Sprintf("deny-egress policy backstop reap FAILED (manual `kubectl delete ccnp cutover-egress-block` required or CSI attaches stay frozen): %v", err),
+				})
+				return
+			}
+			h.publishCutoverEvent(bus, cutoverEvent{
+				Time:    time.Now().UTC().Format(time.RFC3339),
+				Phase:   cutoverPhaseStepFinished,
+				Level:   "info",
+				Step:    step.stepName,
+				Message: "deny-egress hold policy reaped on step exit (#5014 backstop; NotFound = Job trap already cleaned)",
+			})
+		}()
+	}
 
 	// ── Idempotency check (TBD-V56 / #2132) ─────────────────────────────
 	//

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_egress_reap_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_egress_reap_test.go
@@ -1,0 +1,137 @@
+package handler
+
+// #5014 — driver-side deny-egress backstop tests.
+//
+// The step-08 Job applies a cluster-wide cutover-egress-block
+// CiliumClusterwideNetworkPolicy for the 10-minute hold and tears it down
+// via TERM/EXIT traps. Those traps CANNOT run when the pod is SIGKILLed
+// after the termination grace window (activeDeadlineSeconds hard-kill) and
+// are never reached on a driver watch-loss — the policy leaked 3x live on
+// hw242 (2026-07-12), freezing every CSI volume attach until hand-healed.
+//
+// runCutoverStep therefore defers reapCutoverEgressPolicy on EVERY exit of
+// the egress-block-test step. These tests pin that contract on both the
+// success path and the failure path, via the same resume-harness the
+// TBD-V56 idempotency tests use (a prior terminal Job short-circuits the
+// step, exercising runCutoverStep's early-return paths — precisely the
+// exits a naive success-only cleanup would miss).
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+)
+
+// installEgressReapCounter swaps the reap seam for a counter and restores
+// it on test cleanup.
+func installEgressReapCounter(t *testing.T) *int64 {
+	t.Helper()
+	var n int64
+	prior := reapCutoverEgressPolicy
+	reapCutoverEgressPolicy = func(ctx context.Context, deps *cutoverDeps) error {
+		atomic.AddInt64(&n, 1)
+		return nil
+	}
+	t.Cleanup(func() { reapCutoverEgressPolicy = prior })
+	return &n
+}
+
+// waitEngineDone blocks until the cutover broadcaster reports the run
+// ended (mirrors the existing resume tests' wait loop).
+func waitEngineDone(t *testing.T, h *Handler) {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		bus := h.cutoverBusFor()
+		bus.mu.Lock()
+		running := bus.running
+		bus.mu.Unlock()
+		if !running {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("cutover engine still running after 15s")
+}
+
+func egressReapPreStatus() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cutoverStatusConfigMapName(),
+			Namespace: cutoverTestNS,
+		},
+		Data: map[string]string{
+			"cutoverComplete":                  "false",
+			"cutoverStartedAt":                 "2026-07-12T01:00:00Z",
+			"totalSteps":                       "1",
+			"step.egress-block-test.result":    "running",
+			"step.egress-block-test.startedAt": "2026-07-12T01:00:05Z",
+			"step.egress-block-test.jobName":   "cutover-egress-block-test-1783805411",
+		},
+	}
+}
+
+// TestRunCutoverStep_ReapsEgressPolicyOnSuccessExit: the step settles as
+// success (prior Complete=True Job, resume path) — the backstop MUST still
+// fire so a policy the Job's trap failed to remove never outlives the step.
+func TestRunCutoverStep_ReapsEgressPolicyOnSuccessExit(t *testing.T) {
+	reaps := installEgressReapCounter(t)
+
+	objs := []k8sruntime.Object{
+		makeCutoverStepCM("cutover-step-08-egress-block-test", "egress-block-test", 8, cutoverModeJob, minimalPodSpecYAML, ""),
+		egressReapPreStatus(),
+		makeCompletedJobForStep("egress-block-test", 13*time.Minute),
+	}
+	h, client := fakeHandlerWithCutover(t, objs...)
+
+	h.ResumeInterruptedCutover(context.Background())
+	waitEngineDone(t, h)
+
+	cm, err := client.CoreV1().ConfigMaps(cutoverTestNS).Get(context.Background(),
+		cutoverStatusConfigMapName(), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get status ConfigMap: %v", err)
+	}
+	if got := cm.Data["step.egress-block-test.result"]; got != "success" {
+		t.Fatalf("step result = %q, want success (harness precondition)", got)
+	}
+	if atomic.LoadInt64(reaps) < 1 {
+		t.Errorf("reapCutoverEgressPolicy calls = %d, want >= 1 on the SUCCESS exit (#5014 backstop)", *reaps)
+	}
+}
+
+// TestRunCutoverStep_ReapsEgressPolicyOnFailureExit: the step surfaces a
+// terminal failure (prior Failed Job, non-transient BackoffLimitExceeded,
+// auto-resume source) — runCutoverStep returns an error, and the backstop
+// MUST fire on that exit too. This is the hw242 leak shape: the failed
+// hold Job left its CCNP behind and nothing removed it.
+func TestRunCutoverStep_ReapsEgressPolicyOnFailureExit(t *testing.T) {
+	reaps := installEgressReapCounter(t)
+
+	objs := []k8sruntime.Object{
+		makeCutoverStepCM("cutover-step-08-egress-block-test", "egress-block-test", 8, cutoverModeJob, minimalPodSpecYAML, ""),
+		egressReapPreStatus(),
+		makeFailedJobForStep("egress-block-test"),
+	}
+	h, client := fakeHandlerWithCutover(t, objs...)
+
+	h.ResumeInterruptedCutover(context.Background())
+	waitEngineDone(t, h)
+
+	cm, err := client.CoreV1().ConfigMaps(cutoverTestNS).Get(context.Background(),
+		cutoverStatusConfigMapName(), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get status ConfigMap: %v", err)
+	}
+	if got := cm.Data["cutoverComplete"]; got == "true" {
+		t.Fatalf("cutoverComplete = true with a Failed egress Job (harness precondition broken)")
+	}
+	if atomic.LoadInt64(reaps) < 1 {
+		t.Errorf("reapCutoverEgressPolicy calls = %d, want >= 1 on the FAILURE exit (#5014 backstop — the hw242 leak shape)", *reaps)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_registry_pivot_mirror_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_registry_pivot_mirror_test.go
@@ -122,52 +122,81 @@ func sliceShellFn(t *testing.T, chartScript, name string) string {
 	return rest[:loc[1]] + "\n"
 }
 
-func TestRegistryPivotV2MirrorUsesNodeReachableClusterIP(t *testing.T) {
+// TestRegistryPivotOfflineMirrorPerHostRewrite asserts the CURRENT #4975/
+// #4977 offline-mirror contract: write_offline_mirror_hosts RETIRES the
+// legacy dfdaemon `_default/hosts.toml` catch-all and writes PER-UPSTREAM-
+// HOST certs.d entries — a project host (ghcr.io:proxy-ghcr) resolves to
+// the local Harbor project path with override_path, the mothership host
+// (empty project) is a pure host swap with the path preserved, and the
+// local registry gets a self-trust entry. The old contract this replaces
+// (write_default_mirror + node-local dfdaemon `_default` catch-all) died
+// in #4977: under the deny-egress hold a dfdaemon back-to-source only
+// serves node-cached images, so the catch-all was superseded by the
+// complete-local-mirror per-host rewrite — the pre-#4977 test sliced a
+// function that no longer exists and left main CI red (same shape as the
+// #4684 note on the flip test below).
+func TestRegistryPivotOfflineMirrorPerHostRewrite(t *testing.T) {
 	chart := pivotChartScript(t)
 
-	// The REAL containerd-pivot function from the chart. It writes the
-	// `_default/hosts.toml` catch-all that routes the node's containerd pulls
-	// (the step-07 catalyst-api image pin pull included) through the mirror.
-	writeDefaultMirror := sliceShellFn(t, chart, "write_default_mirror")
+	writeHosts := sliceShellFn(t, chart, "write_offline_mirror_hosts")
 
-	const proxyPort = "4001" // matches registryPivot.dragonfly.proxyPort in values.yaml
-	// The public host the node resolver pins to the un-hairpinnable PUBLIC
-	// gateway EIP — the endpoint the #4637 wedge dialed. It must NEVER appear in
-	// the generated containerd mirror.
-	const publicHost = "registry.omantel.biz"
-	nodeLocalProxy := "http://127.0.0.1:" + proxyPort
-
+	const localHost = "registry.t99.omani.works"
 	certsD := t.TempDir()
 
-	// Harness: set the env the function reads (certs_d, df_proxy, NODE_NAME),
-	// source the extracted chart function, then drive it exactly as apply_state
-	// does on the v2 path.
+	// Seed a legacy dfdaemon catch-all — the function MUST retire it.
+	if err := os.MkdirAll(filepath.Join(certsD, "_default"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(certsD, "_default", "hosts.toml"),
+		[]byte("# legacy dfdaemon catch-all\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Harness: env the function reads (certs_d, LOCAL_REGISTRY_HOST,
+	// HOST_PROJECT_MAP, NODE_NAME), source the sliced chart function, run it.
 	script := `set -u
 certs_d="` + certsD + `"
-DF_PROXY_PORT="` + proxyPort + `"
+LOCAL_REGISTRY_HOST="` + localHost + `"
+HOST_PROJECT_MAP="ghcr.io:proxy-ghcr harbor.openova.io"
 NODE_NAME=test-node
-df_proxy="http://127.0.0.1:${DF_PROXY_PORT}"
-` + writeDefaultMirror + `
-write_default_mirror
+` + writeHosts + `
+write_offline_mirror_hosts
 `
 	runShell(t, script)
 
-	// The `_default` catch-all hosts.toml is what containerd consults for ANY
-	// registry namespace with no explicit certs.d/<host> dir — so it governs the
-	// step-07 `registry.<fqdn>/...openova/catalyst-api` pull. Its `[host]` block
-	// MUST point at the node-LOCAL dfdaemon loopback proxy, never the public EIP.
-	defaultToml := readToml(t, filepath.Join(certsD, "_default", "hosts.toml"))
-	if !strings.Contains(defaultToml, "[host.\""+nodeLocalProxy+"\"]") {
-		t.Errorf("containerd _default/hosts.toml [host] must point at the node-local dfdaemon proxy %s; got:\n%s", nodeLocalProxy, defaultToml)
+	// (1) The legacy `_default` catch-all is retired.
+	if _, err := os.Stat(filepath.Join(certsD, "_default", "hosts.toml")); !os.IsNotExist(err) {
+		t.Errorf("_default/hosts.toml still present — the legacy dfdaemon catch-all must be retired (#4975)")
 	}
-	// #4637 regression guard: the public hairpin host must appear NOWHERE in the
-	// generated mirror (no https://registry.<fqdn> endpoint the kubelet would
-	// then dial via the un-hairpinnable public EIP).
-	if strings.Contains(defaultToml, publicHost) {
-		t.Errorf("containerd _default/hosts.toml references the PUBLIC host %s (the un-hairpinnable EIP) — #4637 regression:\n%s", publicHost, defaultToml)
+	// (2) Self-trust entry for direct openova-io host-drop pulls.
+	selfToml := readToml(t, filepath.Join(certsD, localHost, "hosts.toml"))
+	if !strings.Contains(selfToml, `server = "https://`+localHost+`"`) ||
+		!strings.Contains(selfToml, "skip_verify = true") {
+		t.Errorf("local self-trust hosts.toml wrong; got:\n%s", selfToml)
 	}
-	if strings.Contains(defaultToml, "https://") {
-		t.Errorf("containerd _default/hosts.toml routes via an https:// endpoint (must be the plain-HTTP loopback dfdaemon proxy):\n%s", defaultToml)
+	// (3) Project host: resolves to the local Harbor PROJECT path with
+	// override_path (a pull of ghcr.io/<repo> lands on /v2/proxy-ghcr/<repo>).
+	ghcrToml := readToml(t, filepath.Join(certsD, "ghcr.io", "hosts.toml"))
+	if !strings.Contains(ghcrToml, `[host."https://`+localHost+`/v2/proxy-ghcr"]`) {
+		t.Errorf("ghcr.io hosts.toml must mirror to the local Harbor project path; got:\n%s", ghcrToml)
+	}
+	if !strings.Contains(ghcrToml, "override_path = true") {
+		t.Errorf("ghcr.io hosts.toml missing override_path = true (containerd would append its own /v2); got:\n%s", ghcrToml)
+	}
+	// (4) Mothership host: pure host swap, path PRESERVED (no override_path —
+	// the pulled path already carries the proxy-<x> project segment).
+	moToml := readToml(t, filepath.Join(certsD, "harbor.openova.io", "hosts.toml"))
+	if !strings.Contains(moToml, `[host."https://`+localHost+`"]`) {
+		t.Errorf("harbor.openova.io hosts.toml must host-swap to the local registry; got:\n%s", moToml)
+	}
+	if strings.Contains(moToml, "override_path") {
+		t.Errorf("harbor.openova.io hosts.toml must NOT set override_path (path carries the proxy-<x> segment); got:\n%s", moToml)
+	}
+	// (5) §854 guard: no NodePort-range port anywhere in the generated mirrors.
+	for _, toml := range []string{selfToml, ghcrToml, moToml} {
+		if regexp.MustCompile(`:3[0-2][0-9]{3}`).MatchString(toml) {
+			t.Errorf("generated hosts.toml carries a NodePort-range port — forbidden (§854):\n%s", toml)
+		}
 	}
 }
 

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5041,7 +5041,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.121"
+  version: "0.1.122"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.121"
+    version: "0.1.122"
   topology:
     supported:
       - singleton

--- a/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
+++ b/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
@@ -498,6 +498,16 @@ rules:
       - "ciliumidentities"
       - "ciliumexternalworkloads"
     verbs: ["get", "list", "watch"]
+  # #5014 — driver-side deny-egress backstop: runCutoverStep reaps the
+  # step-08 hold policy on ANY step exit (success/fail/watch-loss/deadline)
+  # because the Job's TERM/EXIT trap cannot run on a SIGKILLed pod and a
+  # watch-loss abandons the Job — the leaked CCNP froze CSI attaches 3x on
+  # hw242 (2026-07-12). delete is resourceNames-scoped to the ONE hold
+  # policy object; the read-only posture above is otherwise unchanged.
+  - apiGroups: ["cilium.io"]
+    resources: ["ciliumclusterwidenetworkpolicies"]
+    resourceNames: ["cutover-egress-block"]
+    verbs: ["delete"]
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["gatewayclasses"]
     verbs: ["get", "list", "watch"]

--- a/scripts/cloudinit-size-check.sh
+++ b/scripts/cloudinit-size-check.sh
@@ -155,6 +155,9 @@ fixture_cp_common() {
     # (primary + secondary-region); keep the size-check fixture in lockstep
     # or tofu errors "vars map does not contain key clustermesh_proxy_port".
     clustermesh_proxy_port            = 12379
+    # #5017 keystone — provider API CIDRs (inline-YAML array) for the step-08
+    # deny-egress allow-list; every real templatefile() map supplies it.
+    provider_api_cidrs_yaml           = "[]"
 HCL
 }
 

--- a/scripts/lint-cloudinit.sh
+++ b/scripts/lint-cloudinit.sh
@@ -139,6 +139,9 @@ fixture_common() {
     # supply this; keep the lint fixture in lockstep or tofu errors
     # "vars map does not contain key clustermesh_proxy_port".
     clustermesh_proxy_port            = 12379
+    # #5017 keystone — provider API CIDRs (inline-YAML array) for the step-08
+    # deny-egress allow-list; every real templatefile() map supplies it.
+    provider_api_cidrs_yaml           = "[]"
 HCL
 }
 


### PR DESCRIPTION
## Problem (the #5017 keystone)

The step-08 deny-egress CCNP on hw242 omitted the Huawei provider API CIDR → the EVS CSI driver couldn't reach the ECS/EVS API during the hold → **every volume attach froze** — the amplifier that turned each rolled RWO workload into a hard failure.

**Root cause:** the #4596 mechanism (Job env `PROVIDER_API_CIDRS` → CCNP `toCIDR` allow-list) exists in the chart, but its **population site never did** — `egressTest.allowProviderCIDRs` appeared ONLY in the job template; the "cloud-init sets it per region" comment was aspirational. hw242's 06a HR values carried only `enforceCIDRBlock`+`localRegistryHostSubstr`, so the allow-list was empty and the kom4dc API /24 (`212.72.2.0/24`, where `ecs/evs/obs/iam/vpc/elb.me-east-215.kom4dc.nationalcloud.om` all resolve) was denied.

## Population chain (built end-to-end)

| Site | Change |
|---|---|
| `infra/providers/huawei/variables.tf` | new `provider_api_cidrs` (default `["212.72.2.0/24"]`, CIDR-validated) — the kom4dc **API /24 only**; bastion `.24.x` + mothership ranges stay denied |
| `infra/providers/hetzner/variables.tf` | same var, default `[]` (api.hetzner.cloud has no pinnable CIDR; operator-overridable) |
| both `main.tf` templatefile calls (huawei ×1, hetzner ×2) | `provider_api_cidrs_yaml = jsonencode(var.provider_api_cidrs)` |
| `cloudinit-control-plane.tftpl` | common postBuild substitute `PROVIDER_API_CIDRS_YAML` (inline-YAML array) |
| 06a bootstrap-kit slot | `egressTest.allowProviderCIDRs: ${PROVIDER_API_CIDRS_YAML:=[]}` |
| chart `values.yaml` | `egressTest.allowProviderCIDRs: []` documented default (key was undocumented) |

## Contract lock

New **Case 47**: (1) `allowProviderCIDRs` reaches the Step-08 Job env; (2) the default render keeps the env **empty** — the allow-list never silently widens; (3) the CCNP writer's `PROVIDER_API_CIDRS` loop emits **inside** the `toCIDR` allow-list (after the `ALLOW_CIDRS` loop, before the `toEntities` emit — line-order anchored on the emit, not comments).

## Lockstep + gates

bp-self-sovereign-cutover 0.1.121 → 0.1.122 (Chart.yaml + blueprint.yaml + 06a slot pin + catalog-seed ×2). `helm lint` pass; `cutover-contract.sh` **47/47 green**; `tofu validate` **Success** on both `infra/providers/huawei` and `infra/providers/hetzner` (real validate after init).

## Live state on hw242

The running hold's CCNP already carries the /24 (coordinator's live patch, verified: 4th egress entry `toCIDR: ["212.72.2.0/24"]`). The sovereign-gitea 06a values commit — so the NEXT step-08 run **generates** a correct CCNP — is already in place (verified live: gitea 06a line 937 `allowProviderCIDRs: ["212.72.2.0/24"]`, HR values carry it, and the rendered step-08 ConfigMap podSpec shows `PROVIDER_API_CIDRS value: "212.72.2.0/24"`).

Refs #5017

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Second commit set — step-08 hardening (#5022 / #5014, hw242 run 3: 84 PASS / 2 FAIL tail)

| Item | Fix |
|---|---|
| **DS roll budget** | `freshPullProof.timeoutSeconds` 240 → 600 + new `dsPerNodeSeconds` (120): a multi-node DaemonSet rolls per-node **sequentially** under `RollingUpdate(maxUnavailable:1)` — 6 nodes blew the flat 240s and FAILed registry-pivot + falco spuriously. `roll_and_check_workload` now computes `roll_timeout = max(timeoutSeconds, desiredNumberScheduled × dsPerNodeSeconds)` for daemonsets. **Contract Case 48** |
| **registry-pivot excluded from the roll-set** | new `freshPullProof.excludeWorkloads` (default `["catalyst/registry-pivot"]`), name-scoped `<ns>/<name>` filter in `run_fresh_pull_all`: the pivot DS is the certs.d/hosts mechanism every OTHER fresh pull depends on — rolling it mid-hold is recursive, and its readiness (first-reconcile-pass gate) is already asserted by the step-04 daemonset-wait + per-node v2 ACKs. **Contract Case 49** |
| **#5014 driver-side CCNP reap backstop** | the Job's TERM/EXIT traps cannot run on a SIGKILLed pod and are never reached on a driver watch-loss — the `cutover-egress-block` CCNP **leaked 3× on hw242**, freezing every CSI attach. `runCutoverStep` now **defers** `reapCutoverEgressPolicy` on EVERY exit of the egress-block-test step (success / Job-Failed / watch-loss / deadline / status-patch error) on a fresh context (the step ctx is already dead on watch-loss — exactly the leak path). NotFound = the Job's trap got there first. `clusterrole-cutover-driver` gains a `resourceNames`-scoped `delete` on the one policy object. **Unit tests** pin the reap on BOTH success and failure exits (`cutover_egress_reap_test.go`, via the TBD-V56 resume harness) |

Gates (second set): `cutover-contract.sh` **49/49 green**; helm lint pass; `go build` + new tests pass; full handler package green except the **pre-existing** `TestRegistryPivotV2MirrorUsesNodeReachableClusterIP` failure (red on origin/main too — the 04 template no longer defines `write_default_mirror`; unrelated, untouched).
