### PR TITLE
fix(#5017): bp-falco routes falco + falcoctl images via the Sovereign-local Harbor proxy

### DIFF
--- a/clusters/_template/bootstrap-kit/31-falco.yaml
+++ b/clusters/_template/bootstrap-kit/31-falco.yaml
@@ -51,7 +51,10 @@ spec:
   chart:
     spec:
       chart: bp-falco
-      version: 1.0.1
+      # 1.0.2: falco + falcoctl images via Sovereign-local Harbor proxy
+      # (#5017-class — kyverno denied the raw docker.io refs on DS roll,
+      # freezing step-08's forced roll on hw242).
+      version: 1.0.2
       sourceRef:
         kind: HelmRepository
         name: bp-falco

--- a/platform/falco/blueprint.yaml
+++ b/platform/falco/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.1
+  version: 1.0.2
   card:
     title: Falco
     family: guardian

--- a/platform/falco/chart/Chart.yaml
+++ b/platform/falco/chart/Chart.yaml
@@ -1,5 +1,12 @@
 apiVersion: v2
 name: bp-falco
+# 1.0.2 (#5017-class — route the falco + falcoctl (initContainer AND sidecar)
+# images through the Sovereign-local Harbor proxy: kyverno harbor-proxy-pull
+# denies the raw docker.io refs on any DaemonSet roll; one denied node pod
+# freezes the whole RollingUpdate(maxUnavailable:1) roll — caught live on
+# hw242 cutover step-08 run 3, DS wedged at 0 updated. The DS updateStrategy
+# itself was verified correct (RollingUpdate/maxUnavailable:1) — the denial,
+# not the strategy, froze the roll.)
 description: |
   Catalyst Blueprint umbrella chart for Falco. Depends on the upstream
   `falco` chart (falcosecurity/charts) as a Helm subchart so
@@ -12,7 +19,7 @@ description: |
   (static scanning) and feeds the SIEM pipeline via Falcosidekick into
   bp-opensearch.
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: "0.43.1"
 keywords: [catalyst, blueprint, falco, security, runtime, ebpf, threat-detection]
 maintainers:

--- a/platform/falco/chart/values.yaml
+++ b/platform/falco/chart/values.yaml
@@ -16,11 +16,27 @@ catalystBlueprint:
 falco:
   # Pin upstream image tag — DO NOT use floating tags per
   # docs/INVIOLABLE-PRINCIPLES.md.
+  #
+  # Routed through the Sovereign-local Harbor proxy (#5017-class, caught live
+  # on hw242 step-08 run 3): the kyverno `harbor-proxy-pull` ClusterPolicy
+  # only admits pod images matching `*/proxy-*/*` or `*/openova-io/*`; the
+  # raw docker.io refs are DENIED the moment the DaemonSet rolls — and one
+  # denied node pod freezes the whole RollingUpdate(maxUnavailable:1) roll,
+  # wedging step-08's forced roll (DS stuck at 0 updated).
   image:
-    registry: docker.io
-    repository: falcosecurity/falco
+    registry: harbor.openova.io
+    repository: proxy-dockerhub/falcosecurity/falco
     tag: "0.43.1"
     pullPolicy: IfNotPresent
+
+  # falcoctl — the artifact-install initContainer + artifact-follow sidecar
+  # run in EVERY falco pod; kyverno validates =(initContainers) too, so the
+  # raw docker.io/falcosecurity/falcoctl default is routed the same way
+  # (#5017-class). Tag stays the upstream chart default.
+  falcoctl:
+    image:
+      registry: harbor.openova.io
+      repository: proxy-dockerhub/falcosecurity/falcoctl
 
   # eBPF driver — modern-bpf is the default since Falco 0.35; runs in
   # kernel-space without compiling kernel modules. Per-Sovereign overlays

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -4180,7 +4180,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.0.1"
+  version: "1.0.2"
   visibility: unlisted
   card:
     title: "Falco"
@@ -4197,7 +4197,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-falco
-    version: "1.0.1"
+    version: "1.0.2"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Problem

Caught live on hw242 cutover step-08 **run 3**: bp-falco ships raw `docker.io/falcosecurity/{falco:0.43.1, falcoctl:0.12.2}` refs (main container + artifact-install initContainer + artifact-follow sidecar). kyverno `harbor-proxy-pull` denies them the moment the DaemonSet rolls, and **one denied node pod freezes the whole `RollingUpdate(maxUnavailable:1)` roll** — the DS sat at 0 updated / 5-of-6 scheduled, so step-08's forced roll could never complete.

This also closes the "falco roll never starts (updated=0)" diagnosis: the DS `updateStrategy` was verified **correct** (`RollingUpdate`/`maxUnavailable:1`, generation observed) — the admission denial, not the strategy, froze the roll (the missing node pod consumed the unavailability budget).

## Change

bp-falco 1.0.1 → 1.0.2: `falco.image.{registry,repository}` + `falco.falcoctl.image.{registry,repository}` → `harbor.openova.io/proxy-dockerhub/falcosecurity/*` (tags unchanged). Lockstep: Chart.yaml + blueprint.yaml + `31-falco.yaml` slot pin + catalog-seed ×2.

## Gates

`helm lint` pass; render shows exactly two images, both `harbor.openova.io/proxy-dockerhub/falcosecurity/*`, zero raw refs.

## Live verification (hw242)

Gitea live-heal twin `9b8129651` (bootstrap-kit slot values): DS template now carries the proxy refs (`bp-falco` HR upgrade v2 succeeded); both images presence-checked in the local mirror (HTTP 200) before patching. The frozen roll is draining as the DS controller's create-backoff expires on the missing-pod node.

Refs #5017 #5022

🤖 Generated with [Claude Code](https://claude.com/claude-code)