### PR TITLE
fix(#5026): guarantee mothership-Harbor host pivot + step-08 pre-hold ref-host lint (treadmill-breaker)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -821,7 +821,11 @@ spec:
       # 0.1.122 (#5017 keystone): egressTest.allowProviderCIDRs documented
       # chart default + populated here from PROVIDER_API_CIDRS_YAML;
       # cutover-contract Case 47 asserts the provider-CIDR wiring renders.
-      version: 0.1.122
+      # 0.1.123 (#5026): mothership harbor.openova.io host-swap guaranteed in the
+      # offline-mirror coverage map + NEW step-08 pre-hold ref-host lint that
+      # fails loud on ANY residual tether ref (velero-hcs/cnpg on hw243) —
+      # surfaces the whole un-pivoted set in one prov (treadmill-breaker).
+      version: 0.1.123
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.122
+  version: 0.1.123
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,20 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.123 (#5026 Refs #5010 #4977 #3379 — hw243, the FIRST run to reach step-08:
+# the pre-hold completeness gate correctly FAILED because velero-hcs + cnpg
+# pod-specs still referenced harbor.openova.io/proxy-* (the MOTHERSHIP Harbor, a
+# deny-egress tether) that step-07's sweep had left unpivoted. THREE fixes:
+# (1) the mothership host is now GUARANTEED in the offline-mirror coverage map at
+# the TEMPLATE level (helpers.tpl hostProjectMapInline appends it if a values
+# overlay dropped it) so harbor.openova.io/proxy-* host-swaps to
+# registry.<fqdn>/proxy-* in the step-07 sweep + step-03/04/08 — regression-proof
+# at the single source all steps read; (2) NEW pre-hold REF-HOST LINT in step-08
+# (treadmill-breaker): scans EVERY rolled workload's container+initContainer image
+# hosts and FAILS LOUD listing ALL offenders whose host is not registry.<fqdn>
+# (excluding implicit-docker.io + the offlineMirror excludes) — so a future prov
+# surfaces the whole un-pivoted set in ONE shot instead of one-host-per-prov;
+# (3) cutover-contract Cases 50/51 assert the mothership pivot + the lint's
+# fail-loud/pass behaviour.)
 # 0.1.122 (#5017 keystone Refs #3379 — hw242, 2026-07-12: step-08's deny-egress
 # CCNP omitted the IaaS provider API CIDR because egressTest.allowProviderCIDRs
 # was EMPTY: the #4596 comment claimed "cloud-init populates per region" but the
@@ -1944,7 +1959,7 @@ name: bp-self-sovereign-cutover
 # it back to true. Live 11-step→cutoverComplete=true validation is DEFERRED to a
 # fresh prov whose cutover reaches the 600s egress hold (roll-gated; not run on
 # the permanent env).
-version: 0.1.122
+version: 0.1.123
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
@@ -133,6 +133,9 @@ data:
             value: {{ include "bp-self-sovereign-cutover.localRegistryHost" . | quote }}
           - name: MIRROR_COMPLETENESS_GATE
             value: {{ eq (toString .Values.offlineMirror.enabled) "true" | quote }}
+          # #5026 — pre-hold ref-host lint toggle (treadmill-breaker).
+          - name: PODSPEC_REFHOST_LINT
+            value: {{ eq (toString .Values.egressTest.podspecRefHostLint.enabled) "true" | quote }}
           - name: HARBOR_PUBLIC_URL
             value: {{ .Values.sovereign.harborPublicURL | quote }}
           - name: HARBOR_USERNAME
@@ -389,6 +392,79 @@ data:
             if [ "${MIRROR_COMPLETENESS_GATE}" = "true" ] && [ -n "${HOST_PROJECT_MAP:-}" ]; then
               if ! run_offline_mirror_completeness; then
                 echo "[egress-block-test] offline-mirror completeness FAILED before the hold — sovereignty proof FAILED (cutoverComplete stays false; fix step-03 Phase A3 / offlineMirror.hostProjects)"
+                exit 1
+              fi
+            fi
+
+            # #5026 — PRE-HOLD REF-HOST LINT (treadmill-breaker). Complements the
+            # content-completeness gate above: that proves the IMAGE is in local
+            # Harbor; this proves the pod-spec REF POINTS AT local Harbor. A ref
+            # still on a tether host (harbor.openova.io mothership, ghcr.io, …)
+            # that step-07's sweep missed is a latent deny-egress ImagePullBackOff
+            # AND was historically found one-host-per-prov. This lists EVERY
+            # offender at once and fails BEFORE the hold so the whole un-pivoted
+            # set surfaces in a single prov.
+            run_podspec_refhost_lint() {
+              echo "[egress-block-test] #5026: PRE-HOLD ref-host lint — every rolled workload pod-spec image host must be ${LOCAL_REGISTRY_HOST} (tether refs must be pivoted by step-07)"
+              _lint_off="/work/refhost-offenders.$$"; : > "${_lint_off}"
+              for _lk in deployments daemonsets statefulsets; do
+                kubectl get "${_lk}" -A \
+                  -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' 2>/dev/null \
+                | while IFS=' ' read -r _lns _lname; do
+                    [ -n "${_lns}" ] && [ -n "${_lname}" ] || continue
+                    # roll-set workload exclusions (registry-pivot etc.) — never linted.
+                    _lex=0
+                    for _lw in ${FRESH_PULL_EXCLUDE_WORKLOADS}; do
+                      [ "${_lns}/${_lname}" = "${_lw}" ] && { _lex=1; break; }
+                    done
+                    [ "${_lex}" = "1" ] && continue
+                    kubectl get "${_lk}" "${_lname}" -n "${_lns}" \
+                      -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"="}{.image}{"\n"}{end}{range .spec.template.spec.initContainers[*]}{.name}{"="}{.image}{"\n"}{end}' 2>/dev/null \
+                    | while IFS='=' read -r _lcn _limg; do
+                        [ -n "${_limg}" ] || continue
+                        # Excluded image substrings (rancher/k3s, loft-sh/vcluster) → not an offender.
+                        _sk=0
+                        for _es in ${EXCLUDED_SUBSTRINGS}; do
+                          case "${_limg}" in *"${_es}"*) _sk=1; break ;; esac
+                        done
+                        [ "${_sk}" = "1" ] && continue
+                        # Host classification — mirrors step-08's roll-set + the sweep's
+                        # podspec_pivot_ref EXACTLY: a bare `name[:tag]` or an implicit
+                        # docker.io `ns/name` (first segment has NO dot/:port) is NOT a
+                        # tether (containerd default mirror covers it) → skip.
+                        case "${_limg}" in
+                          */*)
+                            _lh="${_limg%%/*}"
+                            case "${_lh}" in
+                              *.*|*:*|localhost) : ;;
+                              *) continue ;;
+                            esac ;;
+                          *) continue ;;
+                        esac
+                        # Excluded hosts (xpkg.upbound.io — step-11 owns it) → skip.
+                        for _eh in ${EXCLUDED_HOSTS}; do
+                          [ "${_lh}" = "${_eh}" ] && { _sk=1; break; }
+                        done
+                        [ "${_sk}" = "1" ] && continue
+                        # The local registry host is the ONLY acceptable explicit host.
+                        [ "${_lh}" = "${LOCAL_REGISTRY_HOST}" ] && continue
+                        printf '%s/%s [%s] %s (host:%s)\n' "${_lns}" "${_lname}" "${_lcn}" "${_limg}" "${_lh}" >> "${_lint_off}"
+                      done
+                  done
+              done
+              if [ -s "${_lint_off}" ]; then
+                echo "  FAIL — these rolled workload pod-spec image(s) STILL reference a NON-LOCAL registry host after step-07's sweep (each is a deny-egress tether; fix = step-07 sweep coverage / the chart's default image host so it renders registry.<fqdn> or a proxy-* host the sweep pivots):"
+                sort -u "${_lint_off}" | while IFS= read -r _o; do echo "    UNPIVOTED ${_o}"; done
+                rm -f "${_lint_off}"
+                return 1
+              fi
+              rm -f "${_lint_off}"
+              echo "  PASS — every rolled workload pod-spec references the local registry ${LOCAL_REGISTRY_HOST} (or implicit docker.io / excluded) — no residual tether refs (#5026)"
+              return 0
+            }
+            if [ "${PODSPEC_REFHOST_LINT}" = "true" ]; then
+              if ! run_podspec_refhost_lint; then
+                echo "[egress-block-test] ref-host lint FAILED before the hold — sovereignty proof FAILED (cutoverComplete stays false; every offender above must be pivoted to ${LOCAL_REGISTRY_HOST} — fix the step-07 sweep coverage or the workload chart's default image host)"
                 exit 1
               fi
             fi

--- a/platform/self-sovereign-cutover/chart/templates/_helpers.tpl
+++ b/platform/self-sovereign-cutover/chart/templates/_helpers.tpl
@@ -99,8 +99,25 @@ one declaration — this is the retirement of the three hand-maintained lists.
 */}}
 {{- define "bp-self-sovereign-cutover.hostProjectMapInline" -}}
 {{- $pairs := list -}}
+{{- $hosts := list -}}
 {{- range .Values.offlineMirror.hostProjects -}}
 {{- $pairs = append $pairs (printf "%s:%s" .host (.project | default "")) -}}
+{{- $hosts = append $hosts .host -}}
+{{- end -}}
+{{- /*
+   #5026 (Refs #5010 #4977) — REGRESSION-PROOF mothership coverage. The
+   mothership Harbor host (harbor.openova.io) is a sovereignty TETHER: its
+   `harbor.openova.io/proxy-<x>/PATH` pod-spec refs MUST host-swap to
+   `registry.<fqdn>/proxy-<x>/PATH` (path preserved) in the step-07 sweep +
+   step-08 completeness gate, or velero-hcs/cnpg/etc. fail the pre-hold
+   completeness gate (proven live hw243). offlineMirror.hostProjects already
+   carries it, but an operator overlay that rewrites hostProjects could drop
+   it — so GUARANTEE it here (empty project = host-swap) whenever it isn't
+   already present. The map is the single source both step-03/04/07/08 read,
+   so this one guard fixes the whole class at the source. */ -}}
+{{- $mo := (include "bp-self-sovereign-cutover.mothershipHost" .) -}}
+{{- if and $mo (not (has $mo $hosts)) -}}
+{{- $pairs = append $pairs (printf "%s:" $mo) -}}
 {{- end -}}
 {{- join " " $pairs -}}
 {{- end -}}

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -1958,4 +1958,128 @@ if ! grep -q 'for _w in ${FRESH_PULL_EXCLUDE_WORKLOADS}' <<<"$step08_all"; then
 fi
 echo "  PASS (registry-pivot excluded from the roll-set by ns/name; values-overridable)"
 
+echo "[cutover-contract] Case 50: step-07 sweep pivots the MOTHERSHIP Harbor host — harbor.openova.io/proxy-* -> registry.<fqdn>/proxy-* (path preserved) (#5026, hw243)"
+# The mothership Harbor (harbor.openova.io) is a sovereignty TETHER, not a local
+# host: velero-hcs + cnpg pin harbor.openova.io/proxy-* image refs that the
+# deny-egress hold blocks. Run the REAL resolver + podspec_pivot_ref (sliced
+# from the shipped chart) against a harbor.openova.io ref and assert it pivots.
+# awk slicer: dedents a `    <name>() { ... }` shell fn from a rendered template.
+_slice_fn() { awk -v fn="$2" '
+  !st && $0 ~ "^[[:space:]]*"fn"\\(\\) \\{" { match($0,/^[[:space:]]*/); ind=substr($0,1,RLENGTH); st=1 }
+  st { l=$0; sub("^"ind,"",l); print l; if (l=="}") exit }
+' "$1"; }
+helm template smoke . --show-only templates/03a-offline-mirror-resolver.yaml > "$TMP/r03a.yaml"
+helm template smoke . --show-only templates/07-catalyst-api-env-patch-job.yaml > "$TMP/r07.yaml"
+# resolver.sh is a data key body, not a function.
+awk '/resolver.sh: \|/{f=1;next} f{if(/^    /){sub(/^    /,"");print} else if(/^[^ ]/){exit}}' "$TMP/r03a.yaml" > "$TMP/c_resolver.sh"
+_slice_fn "$TMP/r07.yaml" podspec_pivot_ref > "$TMP/c_pivot.sh"
+if ! grep -q 'podspec_pivot_ref() {' "$TMP/c_pivot.sh"; then
+  echo "FAIL: could not slice podspec_pivot_ref from step-07 (#5026)" >&2; exit 1
+fi
+_pivot_out=$(
+  set -u
+  export LOCAL_REGISTRY_HOST="registry.t99.omani.works"
+  # The rendered coverage map MUST carry harbor.openova.io (empty project = host-swap).
+  export HOST_PROJECT_MAP="ghcr.io:proxy-ghcr docker.io:proxy-dockerhub quay.io:proxy-quay registry.k8s.io:proxy-k8s harbor.openova.io:"
+  export EXCLUDED_HOSTS="xpkg.upbound.io"
+  export EXCLUDED_SUBSTRINGS="rancher/k3s loft-sh/vcluster"
+  . "$TMP/c_resolver.sh"; . "$TMP/c_pivot.sh"
+  podspec_pivot_ref "harbor.openova.io/proxy-dockerhub/velero/velero:v1.18.0"
+)
+if [ "$_pivot_out" != "registry.t99.omani.works/proxy-dockerhub/velero/velero:v1.18.0" ]; then
+  echo "FAIL: step-07 sweep did not pivot the mothership ref; got '$_pivot_out' (want registry.t99.omani.works/proxy-dockerhub/velero/velero:v1.18.0) (#5026)" >&2
+  exit 1
+fi
+# The rendered HOST_PROJECT_MAP env in step-08 MUST carry harbor.openova.io so
+# the guarantee (helpers.tpl) is regression-proof against a values-overlay drop.
+if ! grep -A1 'name: HOST_PROJECT_MAP' "$TMP/render.yaml" | grep -q 'harbor.openova.io:'; then
+  echo "FAIL: rendered HOST_PROJECT_MAP does not carry the mothership host harbor.openova.io: (host-swap) (#5026)" >&2
+  exit 1
+fi
+echo "  PASS (mothership harbor.openova.io/proxy-* pivots to registry.<fqdn>/proxy-*; coverage map guarantees the host)"
+
+echo "[cutover-contract] Case 51: step-08 pre-hold ref-host lint FAILS loud on a residual tether ref + PASSES when all-local (#5026 treadmill-breaker)"
+helm template smoke . --show-only templates/08-egress-block-test-job.yaml > "$TMP/r08.yaml"
+_slice_fn "$TMP/r08.yaml" run_podspec_refhost_lint > "$TMP/c_lint.sh"
+if ! grep -q 'run_podspec_refhost_lint() {' "$TMP/c_lint.sh"; then
+  echo "FAIL: could not slice run_podspec_refhost_lint from step-08 (#5026)" >&2; exit 1
+fi
+# The lint must be wired as a HARD gate (exit 1 on failure), not fail-open.
+if ! grep -q 'ref-host lint FAILED before the hold' "$TMP/render.yaml"; then
+  echo "FAIL: run_podspec_refhost_lint is not invoked as a hard pre-hold gate (#5026)" >&2; exit 1
+fi
+# Behavioral test with a mock kubectl. Local work dir so /work redirect is safe.
+_lintdir="$TMP/lint"; mkdir -p "$_lintdir/bin" "$_lintdir/work"
+# FAIL fixture: velero still on harbor.openova.io; reloader local; registry-pivot
+# excluded; nginx implicit-docker.io; rancher/k3s excluded substring.
+cat > "$_lintdir/bin/kubectl" <<'MOCK'
+#!/bin/sh
+kind="$2"
+if [ "$3" = "-A" ]; then
+  case "$kind" in
+    deployments) printf 'velero velero\nreloader reloader-reloader\ncatalyst registry-pivot\norgns myapp\n' ;;
+    daemonsets) printf '' ;; statefulsets) printf '' ;;
+  esac
+else
+  key="$kind/$5/$3"
+  case "$key" in
+    deployments/velero/velero) printf 'velero=harbor.openova.io/proxy-dockerhub/velero/velero:v1.18.0\n' ;;
+    deployments/reloader/reloader-reloader) printf 'r=registry.t99.omani.works/proxy-ghcr/stakater/reloader:v1.4.16\n' ;;
+    deployments/orgns/myapp) printf 'a=nginx:1.27\ns=rancher/k3s:v1\n' ;;
+    deployments/catalyst/registry-pivot) printf 'p=harbor.openova.io/proxy-ghcr/x/y:z\n' ;;
+    *) printf '' ;;
+  esac
+fi
+MOCK
+chmod +x "$_lintdir/bin/kubectl"
+sed 's#/work/#'"$_lintdir"'/work/#g' "$TMP/c_lint.sh" > "$_lintdir/lint.sh"
+_lint_fail_out=$(
+  set +e; set -u
+  export PATH="$_lintdir/bin:$PATH"
+  export LOCAL_REGISTRY_HOST="registry.t99.omani.works"
+  export EXCLUDED_HOSTS="xpkg.upbound.io"; export EXCLUDED_SUBSTRINGS="rancher/k3s loft-sh/vcluster"
+  export FRESH_PULL_EXCLUDE_WORKLOADS="catalyst/registry-pivot"
+  . "$_lintdir/lint.sh"; run_podspec_refhost_lint; echo "RC=$?"
+)
+if ! printf '%s' "$_lint_fail_out" | grep -q 'RC=1'; then
+  echo "FAIL: ref-host lint did not FAIL on a residual harbor.openova.io ref; output:\n$_lint_fail_out" >&2; exit 1
+fi
+if ! printf '%s' "$_lint_fail_out" | grep -q 'UNPIVOTED velero/velero.*host:harbor.openova.io'; then
+  echo "FAIL: ref-host lint did not name the velero offender (#5026); output:\n$_lint_fail_out" >&2; exit 1
+fi
+# The excluded workload (registry-pivot), the implicit-docker.io ref (nginx), the
+# excluded substring (rancher/k3s), and the already-local ref (reloader) must NOT
+# be flagged.
+if printf '%s' "$_lint_fail_out" | grep -qE 'UNPIVOTED (catalyst/registry-pivot|orgns/myapp|reloader/)'; then
+  echo "FAIL: ref-host lint flagged an excluded / implicit-docker.io / already-local ref (false positive) (#5026); output:\n$_lint_fail_out" >&2; exit 1
+fi
+# PASS fixture: velero pivoted to local.
+cat > "$_lintdir/bin/kubectl" <<'MOCK'
+#!/bin/sh
+kind="$2"
+if [ "$3" = "-A" ]; then
+  case "$kind" in deployments) printf 'velero velero\norgns myapp\n' ;; daemonsets) printf '' ;; statefulsets) printf '' ;; esac
+else
+  key="$kind/$5/$3"
+  case "$key" in
+    deployments/velero/velero) printf 'velero=registry.t99.omani.works/proxy-dockerhub/velero/velero:v1.18.0\n' ;;
+    deployments/orgns/myapp) printf 'a=nginx:1.27\n' ;;
+    *) printf '' ;;
+  esac
+fi
+MOCK
+chmod +x "$_lintdir/bin/kubectl"
+_lint_pass_out=$(
+  set +e; set -u
+  export PATH="$_lintdir/bin:$PATH"
+  export LOCAL_REGISTRY_HOST="registry.t99.omani.works"
+  export EXCLUDED_HOSTS="xpkg.upbound.io"; export EXCLUDED_SUBSTRINGS="rancher/k3s loft-sh/vcluster"
+  export FRESH_PULL_EXCLUDE_WORKLOADS="catalyst/registry-pivot"
+  . "$_lintdir/lint.sh"; run_podspec_refhost_lint; echo "RC=$?"
+)
+if ! printf '%s' "$_lint_pass_out" | grep -q 'RC=0'; then
+  echo "FAIL: ref-host lint did not PASS when every ref is local; output:\n$_lint_pass_out" >&2; exit 1
+fi
+echo "  PASS (lint fails loud listing offenders on a tether ref; passes when all-local; skips excluded/implicit-docker.io)"
+
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -1200,6 +1200,20 @@ egressTest:
     # proven by the step-04 daemonset-wait + per-node v2 ACK assertions.
     excludeWorkloads:
       - "catalyst/registry-pivot"
+  # #5026 — PRE-HOLD ref-host lint (treadmill-breaker). The completeness gate
+  # above proves image CONTENT is in local Harbor; this lint proves every
+  # rolled workload's pod-spec image REF HOST is the local registry
+  # (registry.<fqdn>). A ref still pointing at a tether host (harbor.openova.io
+  # mothership, ghcr.io, quay.io, …) that step-07's sweep failed to pivot is a
+  # latent deny-egress ImagePullBackOff — and, worse, discovered ONE HOST PER
+  # PROV (the serialized-discovery treadmill #5010/#5017/#5020-25 walked, 3
+  # provs tonight). This lint fails LOUD listing EVERY offender at once so the
+  # NEXT prov surfaces the whole un-pivoted set in one shot. Implicit-docker.io
+  # refs (bare name / ns/name with no dotted first segment) and the
+  # offlineMirror excluded hosts/substrings are NOT offenders (the sweep skips
+  # them by design). Default ON — the class-breaker for #5026.
+  podspecRefHostLint:
+    enabled: true
   # #3678 — TRUE deny-egress shape. defaultDenyEgress flips the Step-08
   # CCNP from a SUBTRACTIVE 4-CIDR block (default-allow, deny only the
   # listed hosts — which left console.openova.io + every un-enumerated

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5041,7 +5041,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.122"
+  version: "0.1.123"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5058,7 +5058,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.122"
+    version: "0.1.123"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Problem (hw243 — the first cutover to REACH step-08)

hw243 (dep `144723e5e1567e48`) got steps 1-7 all `success` on the fully-hardened train (#5008/5010/5020-5025). Its pre-hold **offline-mirror completeness gate correctly FAILED**: `velero`, `velero-plugin-for-aws`, and the `cloudnative-pg` operator still carried `harbor.openova.io/proxy-*` pod-spec refs. **harbor.openova.io is the MOTHERSHIP Harbor** — a sovereignty tether the deny-egress hold blocks — not a local host.

## What I found (verified empirically, not assumed)

The resolver's host-swap for `harbor.openova.io/proxy-<x>/PATH` → `registry.<fqdn>/proxy-<x>/PATH` **already landed in #4977/#5010** (`offlineMirror.hostProjects` carries the host, empty project = host-swap), and both the step-07 sweep and step-08 completeness gate read it. I sliced the **shipped** resolver + `podspec_pivot_ref` and ran them: `harbor.openova.io/proxy-dockerhub/velero/velero:v1.18.0` → `registry.hw243.omantel.biz/proxy-dockerhub/velero/velero:v1.18.0` ✓. hw243 was provisioned on an in-between build; the durable fix is to make the class **un-regressable** and to **break the serialized-discovery treadmill**.

## Three fixes

1. **Regression-proof mothership coverage** — `hostProjectMapInline` (the single map all of step-03/04/07/08 read) now APPENDS the `mothershipHost` (from `upstream.mothershipHarborURL`) to the coverage map whenever a values overlay dropped it. The class can never regress via a values edit.

2. **NEW pre-hold REF-HOST LINT in step-08 (the treadmill-breaker)** — the completeness gate proves image CONTENT is in local Harbor; this lint proves each rolled workload's pod-spec **REF HOST** is `registry.<fqdn>`. It scans every Deployment/DaemonSet/StatefulSet container+initContainer, skips implicit-docker.io refs + `offlineMirror` excluded hosts/substrings + roll-set-excluded workloads (registry-pivot), then **FAILS LOUD listing EVERY residual-tether ref at once** and exits before the hold. Ends the one-host-per-prov discovery that cost 3 provs tonight. Default ON (`egressTest.podspecRefHostLint.enabled`), hard gate.

3. **cutover-contract Cases 50/51** — Case 50 slices the **shipped** resolver + `podspec_pivot_ref` and asserts the mothership pivot + that the rendered `HOST_PROJECT_MAP` carries the host; Case 51 slices the **shipped** lint and runs it under a mock kubectl: FAILS + names the offender on a residual `harbor.openova.io` ref, no false-positive on excluded/implicit-docker.io/already-local refs, PASSES when all-local.

## Lockstep + gates

bp-self-sovereign-cutover 0.1.122 → 0.1.123 (Chart.yaml + blueprint.yaml + 06a slot pin + catalog-seed ×2). `helm lint` pass; `cutover-contract.sh` **51/51 green**; all step templates render; `go build` + cutover Go tests pass.

## Base

Originally stacked on #5024; now that #5024 is **merged**, this branch was rebased onto `main` (dropping the duplicate #5024 commits) and retargeted to `main`. The diff is **#5026-only** (8 files) and builds on #5024's now-merged step-08 work (the `0.1.122`→`0.1.123` version lineage + the `FRESH_PULL_EXCLUDE_WORKLOADS` env the lint reuses).

Refs #5026 #5010

🤖 Generated with [Claude Code](https://claude.com/claude-code)
